### PR TITLE
ci: set ENCRYPTION_KEY in integration-test env

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -75,6 +75,11 @@ jobs:
         ADMIN_CORS=http://localhost:7001
         STORE_CORS=http://localhost:8000
         NODE_ENV=test
+        # Test-only AES-256 key for the EncryptionService module. Not real
+        # cryptographic material — CI runs against a throwaway DB, no
+        # production data is encrypted with it. Generate prod keys via
+        # openssl rand -base64 32 and store in your secret manager.
+        ENCRYPTION_KEY=bPH59JuZDRQULLeDD62+NiwqwcChpOLN/j7aqu3A+Hw=
         EOF
 
     - name: Run integration tests


### PR DESCRIPTION
## Summary

Fix the integration-test job that's been failing on every PR since Phase 3 — including #147, #149, #150, and the four Dependabot dep-bump PRs.

The encryption module (\`apps/backend/src/modules/encryption/service.ts\`) reads \`process.env.ENCRYPTION_KEY\` (a 32-byte base64 AES-256 key) at module init and throws if missing. Without it, the module fails to register, so any later \`container.resolve(Modules.WORKFLOW_ENGINE)\` returns null, and tests that touch the workflow engine crash with:

\`\`\`
TypeError: Cannot read properties of null (reading 'resolve')
  at waitWorkflowExecutions (... container.resolve(Modules.WORKFLOW_ENGINE, { allowUnregistered: true }))
\`\`\`

In the failed runs, this surfaces in batch 19 (\`partners-decline-run.spec.ts\`), retries 2x, and then fails the whole job.

The \`.env.test\` heredoc in this workflow has every other test secret (DATABASE_URL, JWT_SECRET, etc.) but never had \`ENCRYPTION_KEY\`. Adding it.

## What's in this PR

- \`.github/workflows/test-and-release.yml\` — add \`ENCRYPTION_KEY=<32-byte-b64>\` to the test \`.env.test\` heredoc.

The value is a freshly-generated random key. Not real cryptographic material — CI runs against a throwaway Postgres each time, no production data encrypted with it. Production keys still come from your secret manager.

## Test plan

- [ ] CI \`test\` job in this PR completes batch 19 (\`partners-decline-run.spec.ts\`) without the null-resolve crash.
- [ ] Full 24-batch run reaches "✅ All batches passed" or fails on something genuinely unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)