### PR TITLE
fix(zod): two v4-only crashes uncovered by local boot

### DIFF
--- a/apps/backend/src/api/admin/inventory-orders/validators.ts
+++ b/apps/backend/src/api/admin/inventory-orders/validators.ts
@@ -11,8 +11,11 @@ export const inventoryOrderLineInputSchema = z.object({
   metadata: z.record(z.unknown()).optional(),
 });
 
-// Input schema for creating inventory orders
-export const createInventoryOrdersSchema = z.object({
+// Base ZodObject — kept separately so we can call .partial() on it for the
+// update schema. Going through createInventoryOrdersSchema._def.schema breaks
+// under Zod v4 (the internal _def shape changed; superRefine no longer exposes
+// the inner schema at that path).
+const inventoryOrdersBaseSchema = z.object({
   order_lines: z.array(inventoryOrderLineInputSchema).min(1, "At least one order line is required"),
   // Allow decimal order quantity (sum of line quantities)
   quantity: z.number().nonnegative("Order quantity must be zero or positive"),
@@ -26,7 +29,10 @@ export const createInventoryOrdersSchema = z.object({
   from_stock_location_id: z.string().optional(),
   to_stock_location_id: z.string().optional(),
   is_sample: z.boolean().optional().default(false),
-}).superRefine((data, ctx) => {
+});
+
+// Input schema for creating inventory orders
+export const createInventoryOrdersSchema = inventoryOrdersBaseSchema.superRefine((data, ctx) => {
   if (!data.is_sample && data.quantity <= 0) {
     ctx.addIssue({
       code: z.ZodIssueCode.too_small,
@@ -64,7 +70,7 @@ export const ReadSingleInventoryOrderQuerySchema = z.object({
 })
 
 // Input schema for updating inventory orders
-export const updateInventoryOrdersSchema = createInventoryOrdersSchema._def.schema.partial();
+export const updateInventoryOrdersSchema = inventoryOrdersBaseSchema.partial();
 
 // Type definitions for inventory orders
 export type UpdateInventoryOrder = z.infer<typeof updateInventoryOrdersSchema>;

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -19,10 +19,15 @@ import { z } from "@medusajs/framework/zod";
 import { personSchema, listPersonsQuerySchema, UpdatePersonSchema, ReadPersonQuerySchema } from "./admin/persons/validators";
 import { getPersonResourceDefinition } from "./admin/persons/resources/registry";
 
-// Helper function to wrap Zod schemas for compatibility with validateAndTransformBody
-const wrapSchema = <T extends z.ZodType>(schema: T) => {
-  return z.preprocess((obj) => obj, schema) as any;
-};
+// Helper function to wrap Zod schemas for compatibility with validateAndTransformBody.
+// Historically this wrapped with z.preprocess((obj) => obj, schema) — under Zod v3
+// that returned a ZodEffects that still allowed Medusa's API loader to call
+// .partial() through. Zod v4 returns a ZodPipe instead, which has no .partial(),
+// so the wrap broke route registration ("Cannot read properties of undefined
+// (reading 'partial')"). The preprocess was a no-op anyway — passing the schema
+// through verbatim keeps every call site working and lets Medusa's loader
+// access .partial / .extend / etc. on the underlying ZodObject.
+const wrapSchema = <T extends z.ZodType>(schema: T) => schema as any;
 
 const buildPersonResourceValidator =
   (type: "create" | "update") =>


### PR DESCRIPTION
## Summary

Follow-up to #152. Production deploy still wasn't booting after #152 merged — local \`pnpm dev\` reproduces the same crash and surfaces two more Zod v3-isms that the static grep didn't catch but that crash route registration at boot.

\`\`\`
[ERRO] An error occurred while registering API Routes.
       Error: Cannot read properties of undefined (reading 'partial')
\`\`\`

## Two fixes

### 1. \`apps/backend/src/api/middlewares.ts\` — \`wrapSchema\` passthrough

The helper wrapped 211 schemas with \`z.preprocess((obj) => obj, schema)\`. In Zod v3 that returned a \`ZodEffects\` which still exposed the inner ZodObject's methods (\`.partial\`, \`.extend\`, etc.) for Medusa's API loader to call through. In Zod v4 \`z.preprocess\` returns a \`ZodPipe\` that has none of those — Medusa walks every registered route's body schema and calls \`.partial()\` on it, gets undefined, and crashes route registration.

The preprocess function was \`(obj) => obj\` — a no-op. Reduced \`wrapSchema\` to a passthrough so all 211 sites continue to compile, but Medusa now sees the underlying ZodObject directly with all its methods intact.

### 2. \`apps/backend/src/api/admin/inventory-orders/validators.ts\` — base schema extraction

\`updateInventoryOrdersSchema\` was built as:
\`\`\`ts
createInventoryOrdersSchema._def.schema.partial()
\`\`\`
reaching into the \`ZodEffects\` produced by \`.superRefine()\` to find the inner ZodObject. v3 exposed it at \`_def.schema\`; v4's \`_def\` shape changed and that path is now \`undefined\` → same \`Cannot read properties of undefined\` error.

Extracted the base ZodObject (\`inventoryOrdersBaseSchema\`) and use it for both branches:
- \`createInventoryOrdersSchema\` = base + \`.superRefine(...)\`
- \`updateInventoryOrdersSchema\` = \`base.partial()\`

No reach into \`_def\` needed; works in both v3 and v4.

## Verified locally

- \`rm -rf apps/backend/.medusa && pnpm dev\` boots cleanly
- \`✔ Server is ready on port: 9000 – 6487ms\`
- \`curl /health\` → \`HTTP 200 in 0.02s\`

## Test plan

- [ ] CI \`test\` job passes (uuid+encryption-key story is settled).
- [ ] Production Railway deploy completes \`db:migrate --execute-all-links\` and the server boots without \`Cannot read properties of undefined (reading 'partial')\`.
- [ ] Server responds 200 on \`/health\`.
- [ ] Smoke-test the inventory-orders update endpoint: \`POST /admin/inventory-orders/:id\` with a partial body should validate against the new \`updateInventoryOrdersSchema\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)