### PR TITLE
fix(zod): clean up remaining v4 build errors (213 type errors, 0 runtime changes)

### DIFF
--- a/apps/backend/src/admin/components/creates/create-media-folder.tsx
+++ b/apps/backend/src/admin/components/creates/create-media-folder.tsx
@@ -69,7 +69,7 @@ export const CreateMediaFolderComponent = () => {
       } catch (error) {
         // Handle Zod validation errors
         if (error instanceof z.ZodError) {
-          error.errors.forEach((err) => {
+          error.issues.forEach((err) => {
             const fieldName = err.path.join('.')
             toast.error(`${fieldName}: ${err.message}`)
           })

--- a/apps/backend/src/admin/components/creates/create-page.tsx
+++ b/apps/backend/src/admin/components/creates/create-page.tsx
@@ -35,7 +35,7 @@ const pageSchema = z.object({
     meta_description: z.string().optional(),
     meta_keywords: z.string().optional(),
     published_at: z.string().datetime().optional(),
-    metadata: z.record(z.unknown()).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
     genMetaDataLLM: z.boolean().optional().default(false),
   }))
 });

--- a/apps/backend/src/admin/components/creates/create-person.tsx
+++ b/apps/backend/src/admin/components/creates/create-person.tsx
@@ -71,7 +71,7 @@ export const CreatePersonComponent = () => {
       } catch (error) {
         // Handle Zod validation errors
         if (error instanceof z.ZodError) {
-          error.errors.forEach((err) => {
+          error.issues.forEach((err) => {
             const fieldName = err.path.join('.');
             toast.error(`${fieldName}: ${err.message}`);
           });

--- a/apps/backend/src/admin/components/creates/create-website-blocks.tsx
+++ b/apps/backend/src/admin/components/creates/create-website-blocks.tsx
@@ -29,8 +29,8 @@ const blockSchema = z.object({
       "Testimonial",
       "MainContent"
     ]),
-    content: z.record(z.unknown()).optional(),
-    settings: z.record(z.unknown()).optional(),
+    content: z.record(z.string(), z.unknown()).optional(),
+    settings: z.record(z.string(), z.unknown()).optional(),
     order: z.number().min(0)
   })).min(1, "At least one block is required")
 });

--- a/apps/backend/src/admin/components/creates/create-website.tsx
+++ b/apps/backend/src/admin/components/creates/create-website.tsx
@@ -19,7 +19,7 @@ export const websiteSchema = z.object({
   supported_languages: z.record(z.string(), z.string()).optional(),
   favicon_url: z.string().url().optional(),
   analytics_id: z.string().optional(),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 

--- a/apps/backend/src/admin/components/edits/edit-regular-block.tsx
+++ b/apps/backend/src/admin/components/edits/edit-regular-block.tsx
@@ -36,8 +36,8 @@ const blockSchema = z.object({
     "Section",
     "Custom"
   ]),
-  content: z.record(z.any()).optional(),
-  settings: z.record(z.any()).optional(),
+  content: z.record(z.string(), z.any()).optional(),
+  settings: z.record(z.string(), z.any()).optional(),
   order: z.number()
 });
 

--- a/apps/backend/src/admin/components/forms/raw-material/schema.ts
+++ b/apps/backend/src/admin/components/forms/raw-material/schema.ts
@@ -32,7 +32,7 @@ export const newMaterialTypeSchema = z.object({
     "Accessory",
     "Other"
   ]).default("Other").optional(),
-  properties: z.record(z.any()).optional(),
+  properties: z.record(z.string(), z.any()).optional(),
 });
 
 // Union type for material_type - can be string, existing type object, or new type object
@@ -81,7 +81,7 @@ export const rawMaterialFormSchema = z.object({
   width: z.string().optional(),
   weight: z.string().optional(),
   grade: z.string().optional(),
-  certification: z.record(z.any()).optional(),
+  certification: z.record(z.string(), z.any()).optional(),
   usage_guidelines: z.string().optional(),
   storage_requirements: z.string().optional(),
   material_type_properties: materialTypePropertiesSchema,

--- a/apps/backend/src/api/admin/ad-planning/attribution/route.ts
+++ b/apps/backend/src/api/admin/ad-planning/attribution/route.ts
@@ -78,7 +78,7 @@ const CreateAttributionSchema = z.object({
   entry_page: z.string().optional(),
   session_pageviews: z.number().default(1),
   session_started_at: z.string(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 });
 
 /**

--- a/apps/backend/src/api/admin/ad-planning/conversions/[id]/route.ts
+++ b/apps/backend/src/api/admin/ad-planning/conversions/[id]/route.ts
@@ -38,7 +38,7 @@ const UpdateConversionSchema = z.object({
   conversion_value: z.number().optional().nullable(),
   person_id: z.string().optional().nullable(),
   attribution_model: z.enum(["last_click", "first_click", "linear", "time_decay"]).optional(),
-  metadata: z.record(z.any()).optional().nullable(),
+  metadata: z.record(z.string(), z.any()).optional().nullable(),
 });
 
 /**

--- a/apps/backend/src/api/admin/ad-planning/conversions/route.ts
+++ b/apps/backend/src/api/admin/ad-planning/conversions/route.ts
@@ -95,7 +95,7 @@ const CreateConversionSchema = z.object({
   utm_medium: z.string().optional(),
   utm_campaign: z.string().optional(),
   converted_at: z.string().optional(), // ISO date string
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 });
 
 /**

--- a/apps/backend/src/api/admin/ad-planning/experiments/[id]/route.ts
+++ b/apps/backend/src/api/admin/ad-planning/experiments/[id]/route.ts
@@ -18,7 +18,7 @@ const UpdateExperimentSchema = z.object({
   minimum_detectable_effect: z.number().nullable().optional(),
   primary_metric: z.enum(["conversion_rate", "ctr", "cpc", "roas", "leads", "revenue"]).optional(),
   website_id: z.string().nullable().optional(),
-  metadata: z.record(z.any()).nullable().optional(),
+  metadata: z.record(z.string(), z.any()).nullable().optional(),
 });
 
 /**

--- a/apps/backend/src/api/admin/ad-planning/experiments/route.ts
+++ b/apps/backend/src/api/admin/ad-planning/experiments/route.ts
@@ -26,8 +26,8 @@ const CreateExperimentSchema = z.object({
   // Variants configuration - JSON array
   control_name: z.string().default("Control"),
   treatment_name: z.string().default("Treatment"),
-  control_config: z.record(z.any()).optional(),
-  treatment_config: z.record(z.any()).optional(),
+  control_config: z.record(z.string(), z.any()).optional(),
+  treatment_config: z.record(z.string(), z.any()).optional(),
   traffic_split: z.number().min(0).max(100).default(50),
   // Statistical settings
   target_sample_size: z.number().nullable().optional(),

--- a/apps/backend/src/api/admin/ad-planning/goals/[id]/route.ts
+++ b/apps/backend/src/api/admin/ad-planning/goals/[id]/route.ts
@@ -44,13 +44,13 @@ const UpdateGoalSchema = z.object({
     pathname_pattern: z.string().optional(),
     min_time_seconds: z.number().optional(),
     min_scroll_percent: z.number().optional(),
-    custom_conditions: z.record(z.any()).optional(),
+    custom_conditions: z.record(z.string(), z.any()).optional(),
   }).optional(),
   default_value: z.number().optional().nullable(),
   value_from_event: z.boolean().optional(),
   is_active: z.boolean().optional(),
   priority: z.number().optional(),
-  metadata: z.record(z.any()).optional().nullable(),
+  metadata: z.record(z.string(), z.any()).optional().nullable(),
 });
 
 /**

--- a/apps/backend/src/api/admin/ad-planning/goals/route.ts
+++ b/apps/backend/src/api/admin/ad-planning/goals/route.ts
@@ -63,14 +63,14 @@ const CreateGoalSchema = z.object({
     pathname_pattern: z.string().optional(),
     min_time_seconds: z.number().optional(),
     min_scroll_percent: z.number().optional(),
-    custom_conditions: z.record(z.any()).optional(),
+    custom_conditions: z.record(z.string(), z.any()).optional(),
   }),
   default_value: z.number().optional(),
   value_from_event: z.boolean().default(false),
   is_active: z.boolean().default(true),
   website_id: z.string().optional(),
   priority: z.number().default(0),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 });
 
 /**

--- a/apps/backend/src/api/admin/ad-planning/journeys/route.ts
+++ b/apps/backend/src/api/admin/ad-planning/journeys/route.ts
@@ -36,7 +36,7 @@ const CreateJourneyEventSchema = z.object({
   ]),
   stage: z.enum(["awareness", "interest", "consideration", "intent", "conversion", "retention", "advocacy"]).optional(),
   channel: z.enum(["web", "social", "email", "sms", "phone", "in_person", "ad"]).optional(),
-  event_data: z.record(z.any()).optional(),
+  event_data: z.record(z.string(), z.any()).optional(),
 });
 
 /**

--- a/apps/backend/src/api/admin/ad-planning/segments/[id]/route.ts
+++ b/apps/backend/src/api/admin/ad-planning/segments/[id]/route.ts
@@ -78,7 +78,7 @@ const UpdateSegmentSchema = z.object({
   is_active: z.boolean().optional(),
   auto_update: z.boolean().optional(),
   color: z.string().optional().nullable(),
-  metadata: z.record(z.any()).optional().nullable(),
+  metadata: z.record(z.string(), z.any()).optional().nullable(),
   rebuild: z.boolean().optional(),
 });
 

--- a/apps/backend/src/api/admin/ad-planning/segments/route.ts
+++ b/apps/backend/src/api/admin/ad-planning/segments/route.ts
@@ -74,7 +74,7 @@ const CreateSegmentSchema = z.object({
   is_active: z.boolean().default(true),
   auto_update: z.boolean().default(true),
   color: z.string().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 });
 
 /**

--- a/apps/backend/src/api/admin/ad-planning/sentiment/route.ts
+++ b/apps/backend/src/api/admin/ad-planning/sentiment/route.ts
@@ -25,7 +25,7 @@ const AnalyzeSentimentSchema = z.object({
   source_id: z.string(),
   person_id: z.string().optional(),
   website_id: z.string().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 });
 
 /**

--- a/apps/backend/src/api/admin/agreements/validators.ts
+++ b/apps/backend/src/api/admin/agreements/validators.ts
@@ -10,7 +10,7 @@ export const CreateAgreementSchema = z.object({
   valid_until: z.string().transform((val) => val ? new Date(val) : undefined).optional(),
   from_email: z.string().email().optional(),
   content: z.string().optional(),
-  metadata: z.record(z.any()).default({}),
+  metadata: z.record(z.string(), z.any()).default({}),
 });
 
 // Update Agreement Schema
@@ -23,7 +23,7 @@ export const UpdateAgreementSchema = z.object({
   valid_until: z.string().transform((val) => val ? new Date(val) : undefined).optional(),
   from_email: z.string().email().optional(),
   content: z.string().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 });
 
 // Query Parameters Schema

--- a/apps/backend/src/api/admin/ai/chat/chat/route.ts
+++ b/apps/backend/src/api/admin/ai/chat/chat/route.ts
@@ -75,7 +75,7 @@ export const POST = async (req: MedusaRequest<AdminAiChatReqType>, res: MedusaRe
     )
 
     if (!parsed.success) {
-      const message = parsed.error.errors.map((e) => e.message).join(", ")
+      const message = parsed.error.issues.map((e) => e.message).join(", ")
       throw new MedusaError(MedusaError.Types.INVALID_DATA, message || "Invalid request body")
     }
 

--- a/apps/backend/src/api/admin/ai/image-extraction/route.ts
+++ b/apps/backend/src/api/admin/ai/image-extraction/route.ts
@@ -134,7 +134,7 @@ export const POST = async (
       (req as any).validatedBody || (req.body as AdminImageExtractionReqType)
     );
     if (!parsed.success) {
-      const message = parsed.error.errors.map((e) => e.message).join(", ");
+      const message = parsed.error.issues.map((e) => e.message).join(", ");
       throw new MedusaError(MedusaError.Types.INVALID_DATA, message || "Invalid request body");
     }
     const body = parsed.data;

--- a/apps/backend/src/api/admin/ai/inventory/create-from-levels/route.ts
+++ b/apps/backend/src/api/admin/ai/inventory/create-from-levels/route.ts
@@ -115,7 +115,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   try {
     const parsed = BodySchema.safeParse((req as any).validatedBody || (req.body as BodyType))
     if (!parsed.success) {
-      const msg = parsed.error.errors.map((e) => e.message).join(", ")
+      const msg = parsed.error.issues.map((e) => e.message).join(", ")
       throw new MedusaError(MedusaError.Types.INVALID_DATA, msg || "Invalid request body")
     }
     const body = parsed.data

--- a/apps/backend/src/api/admin/ai/openapi/custom/registry.ts
+++ b/apps/backend/src/api/admin/ai/openapi/custom/registry.ts
@@ -50,7 +50,7 @@ export const buildRegistry = () => {
     target_completion_date: z.string().openapi({ format: "date-time" }).optional(),
     design_files: z.array(z.string()).optional(),
     thumbnail_url: z.string().openapi({ format: "uri" }).optional(),
-    custom_sizes: z.record(z.any()).optional(),
+    custom_sizes: z.record(z.string(), z.any()).optional(),
     color_palette: z.array(ColorPaletteItem).optional(),
     tags: z.array(z.string()).optional(),
     estimated_cost: z.number().optional(),
@@ -65,9 +65,9 @@ export const buildRegistry = () => {
         })
       )
       .optional(),
-    metadata: z.record(z.any()).optional(),
+    metadata: z.record(z.string(), z.any()).optional(),
     media_files: z.array(MediaFile).optional(),
-    moodboard: z.record(z.any()).optional(),
+    moodboard: z.record(z.string(), z.any()).optional(),
   })
 
   const UpdateDesignOpenAPISchema = DesignOpenAPISchema.partial()
@@ -78,11 +78,11 @@ export const buildRegistry = () => {
     last_name: z.string(),
     email: z.string().openapi({ format: "email" }),
     date_of_birth: z.string().openapi({ format: "date-time" }).nullable().optional(),
-    metadata: z.record(z.any()).optional(),
+    metadata: z.record(z.string(), z.any()).optional(),
     addresses: z.array(z.any()).optional(),
     state: z.enum(["Onboarding", "Onboarding Finished", "Stalled", "Conflicted"]).optional(),
     avatar: z.string().optional(),
-    public_metadata: z.record(z.any()).optional(),
+    public_metadata: z.record(z.string(), z.any()).optional(),
   })
 
   const UpdatePersonOpenAPISchema = PersonOpenAPISchema.partial()

--- a/apps/backend/src/api/admin/ai/rag/search/route.ts
+++ b/apps/backend/src/api/admin/ai/rag/search/route.ts
@@ -88,7 +88,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   )
 
   if (!parsed.success) {
-    const message = parsed.error.errors.map((e) => e.message).join(", ")
+    const message = parsed.error.issues.map((e) => e.message).join(", ")
     throw new MedusaError(
       MedusaError.Types.INVALID_DATA,
       message || "Invalid query"

--- a/apps/backend/src/api/admin/ai/visual-flow-codegen/route.ts
+++ b/apps/backend/src/api/admin/ai/visual-flow-codegen/route.ts
@@ -101,7 +101,7 @@ export const POST = async (
     )
 
     if (!parsed.success) {
-      const message = parsed.error.errors.map((e) => e.message).join(", ")
+      const message = parsed.error.issues.map((e) => e.message).join(", ")
       throw new MedusaError(
         MedusaError.Types.INVALID_DATA,
         message || "Invalid request body"

--- a/apps/backend/src/api/admin/ai/visual-flow-codegen/validators.ts
+++ b/apps/backend/src/api/admin/ai/visual-flow-codegen/validators.ts
@@ -2,7 +2,7 @@ import { z } from "@medusajs/framework/zod"
 
 export const AdminVisualFlowCodegenReq = z.object({
   prompt: z.string().min(1, { message: "prompt is required" }),
-  context: z.record(z.any()).optional(),
+  context: z.record(z.string(), z.any()).optional(),
   desiredOutputKeys: z.array(z.string()).optional(),
   allowExternalPackages: z.boolean().optional(),
   // Optional memory routing

--- a/apps/backend/src/api/admin/analytics-events/validators.ts
+++ b/apps/backend/src/api/admin/analytics-events/validators.ts
@@ -15,7 +15,7 @@ export const AnalyticsEventCreateSchema = z.object({
   os: z.string().nullable().optional(),
   device_type: z.enum(["desktop", "mobile", "tablet", "unknown"]).default("unknown"),
   country: z.string().nullable().optional(),
-  metadata: z.record(z.any()).nullable().optional(),
+  metadata: z.record(z.string(), z.any()).nullable().optional(),
   timestamp: z.coerce.date(),
 });
 
@@ -36,7 +36,7 @@ export const AnalyticsEventUpdateSchema = z.object({
   os: z.string().nullable().optional(),
   device_type: z.enum(["desktop", "mobile", "tablet", "unknown"]).optional(),
   country: z.string().nullable().optional(),
-  metadata: z.record(z.any()).nullable().optional(),
+  metadata: z.record(z.string(), z.any()).nullable().optional(),
   timestamp: z.coerce.date().optional(),
 });
 

--- a/apps/backend/src/api/admin/categories/rawmaterials/validators.ts
+++ b/apps/backend/src/api/admin/categories/rawmaterials/validators.ts
@@ -12,7 +12,7 @@ export const ReadRawMaterialCategoriesSchema = z.object({
       }
       return val;
     },
-    z.record(z.unknown()).optional()
+    z.record(z.string(), z.unknown()).optional()
   ),
   filters: z.preprocess(
     (val) => {
@@ -25,7 +25,7 @@ export const ReadRawMaterialCategoriesSchema = z.object({
       }
       return val;
     },
-    z.record(z.unknown()).optional()
+    z.record(z.string(), z.unknown()).optional()
   ),
   page: z.preprocess(
     (val) => {
@@ -63,8 +63,8 @@ export const CreateMaterialTypeSchema = z.object({
     "Accessory",
     "Other"
   ]).optional().default("Other"),
-  properties: z.record(z.any()).optional(),
-  metadata: z.record(z.any()).optional()
+  properties: z.record(z.string(), z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional()
 });
 
 export type CreateMaterialTypeType = z.infer<typeof CreateMaterialTypeSchema>;

--- a/apps/backend/src/api/admin/designs/[id]/consumption-logs/validators.ts
+++ b/apps/backend/src/api/admin/designs/[id]/consumption-logs/validators.ts
@@ -34,7 +34,7 @@ export const AdminPostConsumptionLogReq = z.object({
     .optional(),
   notes: z.string().optional(),
   locationId: z.string().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 export type AdminPostConsumptionLogReq = z.infer<typeof AdminPostConsumptionLogReq>

--- a/apps/backend/src/api/admin/designs/[id]/inventory/validators.ts
+++ b/apps/backend/src/api/admin/designs/[id]/inventory/validators.ts
@@ -4,7 +4,7 @@ const inventoryLinkItemSchema = z.object({
   inventoryId: z.string(),
   plannedQuantity: z.number().int().optional(),
   locationId: z.string().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 export const AdminPostDesignInventoryReq = z
@@ -34,7 +34,7 @@ export const AdminPatchDesignInventoryLinkReq = z
   .object({
     plannedQuantity: z.number().int().nullable().optional(),
     locationId: z.string().nullable().optional(),
-    metadata: z.record(z.any()).nullable().optional(),
+    metadata: z.record(z.string(), z.any()).nullable().optional(),
   })
   .refine(
     (body) =>

--- a/apps/backend/src/api/admin/designs/[id]/link-media-folder/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/link-media-folder/route.ts
@@ -13,7 +13,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
 
   const parsed = LinkMediaFolderBody.safeParse((req as any).validatedBody || req.body)
   if (!parsed.success) {
-    return res.status(400).json({ message: parsed.error.errors[0].message })
+    return res.status(400).json({ message: parsed.error.issues[0].message })
   }
 
   const { folder_id } = parsed.data

--- a/apps/backend/src/api/admin/designs/[id]/tasks/[taskId]/validators.ts
+++ b/apps/backend/src/api/admin/designs/[id]/tasks/[taskId]/validators.ts
@@ -21,7 +21,7 @@ export const AdminPostDesignTaskReq = z.object({
   end_date: z.string().datetime().optional().transform(val => val ? new Date(val) : undefined),
   eventable: z.boolean().optional(),
   notifiable: z.boolean().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 export const AdminPutDesignTaskReq = AdminPostDesignTaskReq.partial()

--- a/apps/backend/src/api/admin/designs/[id]/tasks/validators.ts
+++ b/apps/backend/src/api/admin/designs/[id]/tasks/validators.ts
@@ -22,14 +22,12 @@ const BaseTaskSchema = z.object({
   priority: z.nativeEnum(PriorityLevel).optional(),
   status: z.nativeEnum(Status).optional(),
   due_date: z.preprocess(dateTransformer, z.date()).optional(),
-  start_date: z.preprocess(dateTransformer, z.date()).optional().default((val) => {
-    console.log(val)
-    if (val === undefined) {
-      return new Date()
-    }
-    return val
-  }),
-  metadata: z.record(z.any()).optional(),
+  // .default() runs only when the input is undefined, so () => new Date() is
+  // exactly the "use today if missing" behavior the previous (val)=>... was
+  // approximating. Zod v4 dropped the (val)=>... overload — defaults are now
+  // strictly thunks with no input arg.
+  start_date: z.preprocess(dateTransformer, z.date()).optional().default(() => new Date()),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 // ============= Child Task Schema =============
@@ -46,7 +44,7 @@ const TemplateBasedCreation = z.object({
   template_names: z.array(z.string())
     .min(1, "At least one template name is required"),
   child_tasks: z.array(ChildTaskSchema).optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
   dependency_type: z.enum(DEPENDENCY_TYPES).optional()
 })
 

--- a/apps/backend/src/api/admin/designs/recreate-production-run/validators.ts
+++ b/apps/backend/src/api/admin/designs/recreate-production-run/validators.ts
@@ -11,7 +11,7 @@ export const AdminRecreateProductionRunSchema = z.object({
   partner_id: z.string().min(1),
   run_type: z.enum(["production", "sample"]).optional(),
   notes: z.string().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 export type AdminRecreateProductionRunReq = z.infer<

--- a/apps/backend/src/api/admin/designs/validators.ts
+++ b/apps/backend/src/api/admin/designs/validators.ts
@@ -25,7 +25,7 @@ const designColorSchema = z.object({
 
 const designSizeSetSchema = z.object({
   size_label: z.string(),
-  measurements: z.record(z.number()),
+  measurements: z.record(z.string(), z.number()),
 });
 
 export const designSchema = z.object({
@@ -52,19 +52,19 @@ export const designSchema = z.object({
   }),
   design_files: z.array(z.string()).optional(),
   thumbnail_url: z.string().url().optional(),
-  custom_sizes: z.record(z.any()).optional(),
+  custom_sizes: z.record(z.string(), z.any()).optional(),
   color_palette: colorPaletteSchema.optional(),
   tags: z.array(z.string()).optional(),
   estimated_cost: z.number().optional(),
   designer_notes: z.string().optional(),
   feedback_history: feedbackHistorySchema.optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
   media_files: z.array(z.object({
     id: z.string().optional(),
     url: z.string().url(),
     isThumbnail: z.boolean().optional().default(false)
   })).optional(),
-  moodboard: z.record(z.any()).optional(),
+  moodboard: z.record(z.string(), z.any()).optional(),
   // New structured fields (optional)
   colors: z.array(designColorSchema).optional(),
   size_sets: z.array(designSizeSetSchema).optional(),
@@ -85,7 +85,7 @@ export const ReadDesignsQuerySchema = z.object({
 
 export const CreateDesignLLMSchema = z.object({
   designPrompt: z.string(),
-  existingValues: z.record(z.any()).optional()
+  existingValues: z.record(z.string(), z.any()).optional()
 });
 
 export const LinkDesignPartnerSchema = z.object({

--- a/apps/backend/src/api/admin/email-templates/validators.ts
+++ b/apps/backend/src/api/admin/email-templates/validators.ts
@@ -12,7 +12,7 @@ export const EmailTemplateSchema = z.object({
   template_key: z.string(),
   subject: z.string().min(1, "Subject is required"),
   html_content: z.string(),
-  variables: z.record(z.unknown()).nullable().optional(),
+  variables: z.record(z.string(), z.unknown()).nullable().optional(),
   is_active: z.boolean().default(true),
   template_type: z.string(),
 });

--- a/apps/backend/src/api/admin/energy-rates/validators.ts
+++ b/apps/backend/src/api/admin/energy-rates/validators.ts
@@ -18,7 +18,7 @@ export const AdminCreateEnergyRateReq = z.object({
   region: z.string().optional(),
   isActive: z.boolean().optional(),
   notes: z.string().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 export type AdminCreateEnergyRateReq = z.infer<typeof AdminCreateEnergyRateReq>
@@ -38,7 +38,7 @@ export const AdminUpdateEnergyRateReq = z.object({
   region: z.string().nullable().optional(),
   isActive: z.boolean().optional(),
   notes: z.string().nullable().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 export type AdminUpdateEnergyRateReq = z.infer<typeof AdminUpdateEnergyRateReq>

--- a/apps/backend/src/api/admin/feedbacks/validators.ts
+++ b/apps/backend/src/api/admin/feedbacks/validators.ts
@@ -8,7 +8,7 @@ export const FeedbackSchema = z.object({
   submitted_at: z.coerce.date(),
   reviewed_by: z.string().optional(),
   reviewed_at: z.coerce.date().optional(),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 export type Feedback = z.infer<typeof FeedbackSchema>;
@@ -21,7 +21,7 @@ export const UpdateFeedbackSchema = z.object({
   submitted_at: z.coerce.date().optional(),
   reviewed_by: z.string().optional(),
   reviewed_at: z.coerce.date().optional(),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 export type UpdateFeedback = z.infer<typeof UpdateFeedbackSchema>;

--- a/apps/backend/src/api/admin/forms/validators.ts
+++ b/apps/backend/src/api/admin/forms/validators.ts
@@ -20,10 +20,10 @@ export const AdminCreateFormFieldSchema = z.object({
   required: z.boolean().default(false),
   placeholder: z.string().nullable().optional(),
   help_text: z.string().nullable().optional(),
-  options: z.record(z.any()).nullable().optional(),
-  validation: z.record(z.any()).nullable().optional(),
+  options: z.record(z.string(), z.any()).nullable().optional(),
+  validation: z.record(z.string(), z.any()).nullable().optional(),
   order: z.number().optional(),
-  metadata: z.record(z.any()).nullable().optional(),
+  metadata: z.record(z.string(), z.any()).nullable().optional(),
 })
 
 export const AdminCreateFormSchema = z
@@ -36,8 +36,8 @@ export const AdminCreateFormSchema = z
     status: z.enum(["draft", "published", "archived"]).default("draft"),
     submit_label: z.string().nullable().optional(),
     success_message: z.string().nullable().optional(),
-    settings: z.record(z.any()).nullable().optional(),
-    metadata: z.record(z.any()).nullable().optional(),
+    settings: z.record(z.string(), z.any()).nullable().optional(),
+    metadata: z.record(z.string(), z.any()).nullable().optional(),
     fields: z.array(AdminCreateFormFieldSchema).optional(),
   })
   .refine(
@@ -55,8 +55,8 @@ export const AdminUpdateFormSchema = z
     status: z.enum(["draft", "published", "archived"]).optional(),
     submit_label: z.string().nullable().optional(),
     success_message: z.string().nullable().optional(),
-    settings: z.record(z.any()).nullable().optional(),
-    metadata: z.record(z.any()).nullable().optional(),
+    settings: z.record(z.string(), z.any()).nullable().optional(),
+    metadata: z.record(z.string(), z.any()).nullable().optional(),
   })
   .refine(
     (v) => v.website_id !== undefined || v.domain !== undefined || Object.keys(v).length > 0,

--- a/apps/backend/src/api/admin/inbound-emails/validators.ts
+++ b/apps/backend/src/api/admin/inbound-emails/validators.ts
@@ -25,7 +25,7 @@ export type ExtractInboundEmailBody = z.infer<typeof extractInboundEmailSchema>
 
 export const executeInboundEmailSchema = z.object({
   action_type: z.string().min(1, "action_type is required"),
-  params: z.record(z.unknown()),
+  params: z.record(z.string(), z.unknown()),
 })
 
 export type ExecuteInboundEmailBody = z.infer<typeof executeInboundEmailSchema>

--- a/apps/backend/src/api/admin/inventory-items/[id]/rawmaterials/validators.ts
+++ b/apps/backend/src/api/admin/inventory-items/[id]/rawmaterials/validators.ts
@@ -13,15 +13,15 @@ const materialTypeSchema = z.object({
     "Accessory",
     "Other"
   ]).optional().default("Other"),
-  properties: z.record(z.any()).optional(),
-  metadata: z.record(z.any()).optional()
+  properties: z.record(z.string(), z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional()
 });
 
 const rawMaterialDataSchema = z.object({
   name: z.string().min(1, "Name is required"),
   description: z.string().min(1, "Description is required").optional(),
   composition: z.string().min(1, "Composition is required"),
-  specifications: z.record(z.any()).optional(),
+  specifications: z.record(z.string(), z.any()).optional(),
   unit_of_measure: z.enum([
     "Meter",
     "Yard",
@@ -39,7 +39,7 @@ const rawMaterialDataSchema = z.object({
   width: z.string().optional(),
   weight: z.string().optional(),
   grade: z.string().optional(),
-  certification: z.record(z.any()).optional(),
+  certification: z.record(z.string(), z.any()).optional(),
   usage_guidelines: z.string().optional(),
   storage_requirements: z.string().optional(),
   status: z.enum([
@@ -48,10 +48,10 @@ const rawMaterialDataSchema = z.object({
     "Under_Review",
     "Development"
   ]).optional().default("Active"),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
   material_type: z.string().optional(),
   material_type_id: z.string().optional(),
-  media: z.record(z.any()).optional()
+  media: z.record(z.string(), z.any()).optional()
 });
 
 export const rawMaterialSchema = z.object({

--- a/apps/backend/src/api/admin/inventory-items/raw-materials/validators.ts
+++ b/apps/backend/src/api/admin/inventory-items/raw-materials/validators.ts
@@ -21,7 +21,7 @@ export const ListInventoryItemRawMaterialsQuerySchema = z.object({
       }
       return val
     },
-    z.record(z.unknown()).optional()
+    z.record(z.string(), z.unknown()).optional()
   ),
 })
 

--- a/apps/backend/src/api/admin/inventory-orders/[id]/tasks/validators.ts
+++ b/apps/backend/src/api/admin/inventory-orders/[id]/tasks/validators.ts
@@ -22,13 +22,10 @@ const BaseTaskSchema = z.object({
   priority: z.nativeEnum(PriorityLevel).optional(),
   status: z.nativeEnum(Status).optional(),
   due_date: z.preprocess(dateTransformer, z.date()).optional(),
-  start_date: z.preprocess(dateTransformer, z.date()).optional().default((val) => {
-    if (val === undefined) {
-      return new Date()
-    }
-    return val
-  }),
-  metadata: z.record(z.any()).optional(),
+  // .default() runs only when input is undefined; the function form takes no
+  // arguments in Zod v4 (the v3 (val) => ... overload was removed).
+  start_date: z.preprocess(dateTransformer, z.date()).optional().default(() => new Date()),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 // ============= Child Task Schema =============
@@ -45,7 +42,7 @@ const TemplateBasedCreation = z.object({
   template_names: z.array(z.string())
     .min(1, "At least one template name is required"),
   child_tasks: z.array(ChildTaskSchema).optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
   dependency_type: z.enum(DEPENDENCY_TYPES).optional()
 })
 

--- a/apps/backend/src/api/admin/inventory-orders/validators.ts
+++ b/apps/backend/src/api/admin/inventory-orders/validators.ts
@@ -8,7 +8,7 @@ export const inventoryOrderLineInputSchema = z.object({
   // Allow decimal quantities >= 0 (0 allowed for empty seeded rows)
   quantity: z.number().nonnegative("Quantity must be zero or positive"),
   price: z.number().nonnegative("Price must be zero or positive"),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 // Base ZodObject — kept separately so we can call .partial() on it for the
@@ -23,8 +23,8 @@ const inventoryOrdersBaseSchema = z.object({
   status: z.enum(["Pending", "Processing", "Shipped", "Delivered", "Cancelled"]),
   expected_delivery_date: z.coerce.date(),
   order_date: z.coerce.date(),
-  metadata: z.record(z.unknown()).optional(),
-  shipping_address: z.record(z.unknown()),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  shipping_address: z.record(z.string(), z.unknown()),
   stock_location_id: z.string(),
   from_stock_location_id: z.string().optional(),
   to_stock_location_id: z.string().optional(),
@@ -37,7 +37,8 @@ export const createInventoryOrdersSchema = inventoryOrdersBaseSchema.superRefine
     ctx.addIssue({
       code: z.ZodIssueCode.too_small,
       minimum: 1,
-      type: "number",
+      // Zod v4 renamed the legacy `type` field to `origin` for size-bound issues.
+      origin: "number",
       inclusive: true,
       message: "Order quantity must be a positive number for non-sample orders",
       path: ["quantity"],

--- a/apps/backend/src/api/admin/medias/extract-features/route.ts
+++ b/apps/backend/src/api/admin/medias/extract-features/route.ts
@@ -64,7 +64,7 @@ export const POST = async (
     );
 
     if (!parsed.success) {
-      const message = parsed.error.errors.map((e) => e.message).join(", ");
+      const message = parsed.error.issues.map((e) => e.message).join(", ");
       throw new MedusaError(MedusaError.Types.INVALID_DATA, message || "Invalid request body");
     }
 

--- a/apps/backend/src/api/admin/medias/validator.ts
+++ b/apps/backend/src/api/admin/medias/validator.ts
@@ -69,7 +69,7 @@ export const uploadMediaSchema = z.object({
         }
       }
       return val;
-    }, z.record(z.any()))
+    }, z.record(z.string(), z.any()))
     .optional(),
 });
 

--- a/apps/backend/src/api/admin/partner-plans/validators.ts
+++ b/apps/backend/src/api/admin/partner-plans/validators.ts
@@ -7,10 +7,10 @@ export const createPlanSchema = z.object({
   price: z.number().min(0),
   currency_code: z.string().default("inr"),
   interval: z.enum(["monthly", "yearly"]).default("monthly"),
-  features: z.record(z.unknown()).optional(),
+  features: z.record(z.string(), z.unknown()).optional(),
   is_active: z.boolean().default(true),
   sort_order: z.number().default(0),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 })
 
 export const updatePlanSchema = z.object({
@@ -19,14 +19,14 @@ export const updatePlanSchema = z.object({
   price: z.number().min(0).optional(),
   currency_code: z.string().optional(),
   interval: z.enum(["monthly", "yearly"]).optional(),
-  features: z.record(z.unknown()).optional(),
+  features: z.record(z.string(), z.unknown()).optional(),
   is_active: z.boolean().optional(),
   sort_order: z.number().optional(),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 })
 
 export const createSubscriptionSchema = z.object({
   partner_id: z.string().min(1),
   plan_id: z.string().min(1),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 })

--- a/apps/backend/src/api/admin/partners/[id]/tasks/validators.ts
+++ b/apps/backend/src/api/admin/partners/[id]/tasks/validators.ts
@@ -9,7 +9,7 @@ const childTaskSchema = z.object({
     priority: z.nativeEnum(PriorityLevel).optional(),
     start_date: z.string().or(z.date()).optional(),
     end_date: z.string().or(z.date()).optional(),
-    metadata: z.record(z.any()).optional(),
+    metadata: z.record(z.string(), z.any()).optional(),
 });
 
 /**
@@ -26,7 +26,7 @@ export const AdminCreatePartnerTaskReq = z.object({
     eventable: z.boolean().optional(),
     notifiable: z.boolean().optional(),
     message: z.string().optional(),
-    metadata: z.record(z.any()).optional(),
+    metadata: z.record(z.string(), z.any()).optional(),
     child_tasks: z.array(childTaskSchema).optional(),
     dependency_type: z.enum(["blocking", "related", "subtask"]).optional(),
 });

--- a/apps/backend/src/api/admin/payment-submissions/validators.ts
+++ b/apps/backend/src/api/admin/payment-submissions/validators.ts
@@ -49,7 +49,7 @@ export const CreateAdminPaymentSubmissionSchema = z
         })
       )
       .optional(),
-    metadata: z.record(z.any()).optional(),
+    metadata: z.record(z.string(), z.any()).optional(),
   })
   .refine(
     (data) => (data.design_ids?.length || 0) + (data.task_ids?.length || 0) > 0,

--- a/apps/backend/src/api/admin/payment_reports/reconciliation/validators.ts
+++ b/apps/backend/src/api/admin/payment_reports/reconciliation/validators.ts
@@ -22,7 +22,7 @@ export const CreateReconciliationSchema = z.object({
   actual_amount: z.number().optional(),
   payment_id: z.string().optional(),
   notes: z.string().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 export const UpdateReconciliationSchema = z.object({
@@ -31,7 +31,7 @@ export const UpdateReconciliationSchema = z.object({
     .enum(["Pending", "Matched", "Discrepant", "Settled", "Waived"])
     .optional(),
   notes: z.string().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 export const SettleReconciliationSchema = z.object({

--- a/apps/backend/src/api/admin/payment_reports/validators.ts
+++ b/apps/backend/src/api/admin/payment_reports/validators.ts
@@ -22,7 +22,7 @@ export const CreatePaymentReportSchema = z.object({
   entity_id:    z.string().optional(),   // required when entity_type != "all"
   status:       z.enum(["Pending", "Processing", "Completed", "Failed", "Cancelled"]).optional(),
   payment_type: z.enum(["Bank", "Cash", "Digital_Wallet"]).optional(),
-  metadata:     z.record(z.any()).optional(),
+  metadata:     z.record(z.string(), z.any()).optional(),
 })
 export type CreatePaymentReport = z.infer<typeof CreatePaymentReportSchema>
 
@@ -44,6 +44,6 @@ export type Payment_report = CreatePaymentReport
 
 export const UpdatePaymentReportSchema = z.object({
   name:     z.string().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 export type UpdatePayment_report = z.infer<typeof UpdatePaymentReportSchema>

--- a/apps/backend/src/api/admin/payments/link/validators.ts
+++ b/apps/backend/src/api/admin/payments/link/validators.ts
@@ -9,7 +9,7 @@ export const CreatePaymentAndLinkSchema = z.object({
     status: StatusEnum.optional(),
     payment_type: PaymentTypeEnum,
     payment_date: z.coerce.date(),
-    metadata: z.record(z.any()).nullish(),
+    metadata: z.record(z.string(), z.any()).nullish(),
     paid_to_id: z.string().optional(),
   }),
   personIds: z.array(z.string()).optional(),

--- a/apps/backend/src/api/admin/payments/partners/[id]/methods/validators.ts
+++ b/apps/backend/src/api/admin/payments/partners/[id]/methods/validators.ts
@@ -19,6 +19,6 @@ export const CreatePaymentMethodForPartnerSchema = z.object({
   bank_name: z.string().optional(),
   ifsc_code: z.string().optional(),
   wallet_id: z.string().optional(),
-  metadata: z.record(z.any()).nullish(),
+  metadata: z.record(z.string(), z.any()).nullish(),
 })
 export type CreatePaymentMethodForPartner = z.infer<typeof CreatePaymentMethodForPartnerSchema>

--- a/apps/backend/src/api/admin/payments/persons/[id]/methods/validators.ts
+++ b/apps/backend/src/api/admin/payments/persons/[id]/methods/validators.ts
@@ -19,6 +19,6 @@ export const CreatePaymentMethodForPersonSchema = z.object({
   bank_name: z.string().optional(),
   ifsc_code: z.string().optional(),
   wallet_id: z.string().optional(),
-  metadata: z.record(z.any()).nullish(),
+  metadata: z.record(z.string(), z.any()).nullish(),
 })
 export type CreatePaymentMethodForPerson = z.infer<typeof CreatePaymentMethodForPersonSchema>

--- a/apps/backend/src/api/admin/payments/validators.ts
+++ b/apps/backend/src/api/admin/payments/validators.ts
@@ -9,7 +9,7 @@ export const PaymentSchema = z.object({
   status: StatusEnum.optional(),
   payment_type: PaymentTypeEnum,
   payment_date: z.coerce.date(),
-  metadata: z.record(z.any()).nullish(),
+  metadata: z.record(z.string(), z.any()).nullish(),
   paid_to_id: z.string().optional(),
 });
 
@@ -21,7 +21,7 @@ export const UpdatePaymentSchema = z.object({
   status: StatusEnum.optional(),
   payment_type: PaymentTypeEnum.optional(),
   payment_date: z.coerce.date().optional(),
-  metadata: z.record(z.any()).nullish(),
+  metadata: z.record(z.string(), z.any()).nullish(),
   paid_to_id: z.string().optional(),
 });
 

--- a/apps/backend/src/api/admin/persons/[id]/resources/[resource]/[resourceId]/route.ts
+++ b/apps/backend/src/api/admin/persons/[id]/resources/[resource]/[resourceId]/route.ts
@@ -164,9 +164,12 @@ export const PATCH = async (
     )
   }
 
-  const payload = resource.validators?.update
+  // Zod v4 narrows .parse return types more strictly; the dynamic resource
+  // validators are typed generically so the result lands as `unknown`. The
+  // schema actually returns an object — cast to satisfy the handler's type.
+  const payload = (resource.validators?.update
     ? resource.validators.update.parse(req.body)
-    : req.body
+    : req.body) as Record<string, unknown>;
 
   const updated = await resource.handlers.update({
     scope: req.scope,

--- a/apps/backend/src/api/admin/persons/[id]/resources/[resource]/route.ts
+++ b/apps/backend/src/api/admin/persons/[id]/resources/[resource]/route.ts
@@ -166,9 +166,12 @@ export const POST = async (
     )
   }
 
-  const payload = resource.validators?.create
+  // Zod v4 narrows .parse return types more strictly; the dynamic resource
+  // validators are typed generically so the result lands as `unknown`. The
+  // schema actually returns an object — cast to satisfy the handler's type.
+  const payload = (resource.validators?.create
     ? resource.validators.create.parse(req.body)
-    : req.body
+    : req.body) as Record<string, unknown>;
 
   const created = await resource.handlers.create({
     scope: req.scope,

--- a/apps/backend/src/api/admin/persons/validators.ts
+++ b/apps/backend/src/api/admin/persons/validators.ts
@@ -13,11 +13,11 @@ export const personSchema = z.object({
     z.null(),
     z.undefined()
   ]).optional(), // Optional field that accepts string, null, or undefined
-  metadata: z.record(z.any()).optional(), // Optional field for additional data
+  metadata: z.record(z.string(), z.any()).optional(), // Optional field for additional data
   addresses: z.array(z.any()).optional(),
   state: z.enum(["Onboarding", "Onboarding Finished", "Stalled", "Conflicted"]).optional(),
   avatar: z.string().optional(),
-  public_metadata: z.record(z.any()).optional(),
+  public_metadata: z.record(z.string(), z.any()).optional(),
 });
 
 export const ReadPersonQuerySchema = z.object({

--- a/apps/backend/src/api/admin/persontypes/route.ts
+++ b/apps/backend/src/api/admin/persontypes/route.ts
@@ -123,7 +123,7 @@ export const POST = async (
   if (!parsed.success) {
     throw new MedusaError(
       MedusaError.Types.INVALID_DATA,
-      parsed.error.errors?.[0]?.message || "Invalid person type payload"
+      parsed.error.issues?.[0]?.message || "Invalid person type payload"
     );
   }
 

--- a/apps/backend/src/api/admin/production-run-policy/validators.ts
+++ b/apps/backend/src/api/admin/production-run-policy/validators.ts
@@ -1,7 +1,7 @@
 import { z } from "@medusajs/framework/zod"
 
 export const AdminUpdateProductionRunPolicySchema = z.object({
-  config: z.record(z.any()).nullable(),
+  config: z.record(z.string(), z.any()).nullable(),
 })
 
 export type AdminUpdateProductionRunPolicyReq = z.infer<

--- a/apps/backend/src/api/admin/production-runs/validators.ts
+++ b/apps/backend/src/api/admin/production-runs/validators.ts
@@ -17,7 +17,7 @@ export const AdminCreateProductionRunReq = z.object({
   variant_id: z.string().optional(),
   order_id: z.string().optional(),
   order_line_item_id: z.string().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 export const AdminApproveProductionRunReq = z.object({

--- a/apps/backend/src/api/admin/social-platforms/validators.ts
+++ b/apps/backend/src/api/admin/social-platforms/validators.ts
@@ -40,8 +40,8 @@ export const SocialPlatformSchema = z.object({
   base_url: z.string().url().optional().nullable(),
   description: z.string().optional().nullable(),
   status: PlatformStatusSchema.default("active"),
-  api_config: z.record(z.unknown()).optional().nullable(),
-  metadata: z.record(z.unknown()).optional().nullable(),
+  api_config: z.record(z.string(), z.unknown()).optional().nullable(),
+  metadata: z.record(z.string(), z.unknown()).optional().nullable(),
 });
 
 export type SocialPlatform = z.infer<typeof SocialPlatformSchema>;
@@ -54,8 +54,8 @@ export const UpdateSocialPlatformSchema = z.object({
   base_url: z.string().url().optional().nullable(),
   description: z.string().optional().nullable(),
   status: PlatformStatusSchema.optional(),
-  api_config: z.record(z.unknown()).optional().nullable(),
-  metadata: z.record(z.unknown()).optional().nullable(),
+  api_config: z.record(z.string(), z.unknown()).optional().nullable(),
+  metadata: z.record(z.string(), z.unknown()).optional().nullable(),
 });
 
 export const listSocialPlatformsQuerySchema = z.object({

--- a/apps/backend/src/api/admin/social-posts/validators.ts
+++ b/apps/backend/src/api/admin/social-posts/validators.ts
@@ -13,14 +13,14 @@ export const SocialPostSchema = z.object({
   status: z.enum(["draft","scheduled","posted","failed","archived"]).default("draft").optional(),
   scheduled_at: z.coerce.date().optional(),
   posted_at: z.coerce.date().optional(),
-  insights: z.record(z.unknown()).optional(),
-  media_attachments: z.record(z.unknown()).optional(),
+  insights: z.record(z.string(), z.unknown()).optional(),
+  media_attachments: z.record(z.string(), z.unknown()).optional(),
   notes: z.string().optional(),
   error_message: z.string().optional(),
   related_item_type: z.string().optional(),
   related_item_id: z.string().optional(),
   platform_id: z.string(),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 export type SocialPost = z.infer<typeof SocialPostSchema>;
@@ -32,15 +32,15 @@ export const UpdateSocialPostSchema = z.object({
   status: z.enum(["draft","scheduled","posted","failed","archived"]).optional(),
   scheduled_at: z.coerce.date().optional(),
   posted_at: z.coerce.date().optional(),
-  insights: z.record(z.unknown()).optional(),
-  media_attachments: z.record(z.unknown()).optional(),
+  insights: z.record(z.string(), z.unknown()).optional(),
+  media_attachments: z.record(z.string(), z.unknown()).optional(),
   notes: z.string().optional(),
   error_message: z.string().optional(),
   related_item_type: z.string().optional(),
   related_item_id: z.string().optional(),
   platform_id: z.string().optional(),
   // allow metadata updates too
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 export const listSocialPostsQuerySchema = z.object({

--- a/apps/backend/src/api/admin/socials/publish/route.ts
+++ b/apps/backend/src/api/admin/socials/publish/route.ts
@@ -188,7 +188,7 @@ export const POST = async (
   if (!validation.success) {
     throw new MedusaError(
       MedusaError.Types.INVALID_DATA,
-      validation.error.errors.map((e) => `${e.path.join(".")}: ${e.message}`).join(", ")
+      validation.error.issues.map((e) => `${e.path.join(".")}: ${e.message}`).join(", ")
     )
   }
 

--- a/apps/backend/src/api/admin/stats/dashboards/[id]/panels/route.ts
+++ b/apps/backend/src/api/admin/stats/dashboards/[id]/panels/route.ts
@@ -24,7 +24,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     if (!optionsResult.success) {
       return res.status(400).json({
         error: "Invalid operation_options for this operation_type",
-        details: optionsResult.error.errors,
+        details: optionsResult.error.issues,
       })
     }
 
@@ -37,7 +37,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     res.status(201).json({ panel })
   } catch (error: any) {
     if (error instanceof z.ZodError) {
-      res.status(400).json({ error: "Validation error", details: error.errors })
+      res.status(400).json({ error: "Validation error", details: error.issues })
       return
     }
     res.status(400).json({ error: error.message })

--- a/apps/backend/src/api/admin/stats/dashboards/[id]/route.ts
+++ b/apps/backend/src/api/admin/stats/dashboards/[id]/route.ts
@@ -30,7 +30,7 @@ export const PUT = async (req: MedusaRequest, res: MedusaResponse) => {
     res.json({ dashboard })
   } catch (error: any) {
     if (error instanceof z.ZodError) {
-      res.status(400).json({ error: "Validation error", details: error.errors })
+      res.status(400).json({ error: "Validation error", details: error.issues })
       return
     }
     res.status(400).json({ error: error.message })

--- a/apps/backend/src/api/admin/stats/dashboards/route.ts
+++ b/apps/backend/src/api/admin/stats/dashboards/route.ts
@@ -31,7 +31,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     })
   } catch (error: any) {
     if (error instanceof z.ZodError) {
-      res.status(400).json({ error: "Validation error", details: error.errors })
+      res.status(400).json({ error: "Validation error", details: error.issues })
       return
     }
     res.status(400).json({ error: error.message })
@@ -48,7 +48,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     res.status(201).json({ dashboard })
   } catch (error: any) {
     if (error instanceof z.ZodError) {
-      res.status(400).json({ error: "Validation error", details: error.errors })
+      res.status(400).json({ error: "Validation error", details: error.issues })
       return
     }
     res.status(400).json({ error: error.message })

--- a/apps/backend/src/api/admin/stats/panels/[id]/route.ts
+++ b/apps/backend/src/api/admin/stats/panels/[id]/route.ts
@@ -36,10 +36,12 @@ export const PUT = async (req: MedusaRequest, res: MedusaResponse) => {
       if (!optionsResult.success) {
         return res.status(400).json({
           error: "Invalid operation_options for this operation_type",
-          details: optionsResult.error.errors,
+          details: optionsResult.error.issues,
         })
       }
-      data.operation_options = optionsResult.data
+      // optionsResult.data narrows to `unknown` under Zod v4 generics; the
+      // operation registry validates it as a record-shaped schema, so cast.
+      data.operation_options = optionsResult.data as Record<string, any>
     }
 
     const panel = await service.updateStatsPanels({ id, ...data })
@@ -48,7 +50,7 @@ export const PUT = async (req: MedusaRequest, res: MedusaResponse) => {
     res.json({ panel })
   } catch (error: any) {
     if (error instanceof z.ZodError) {
-      res.status(400).json({ error: "Validation error", details: error.errors })
+      res.status(400).json({ error: "Validation error", details: error.issues })
       return
     }
     res.status(400).json({ error: error.message })

--- a/apps/backend/src/api/admin/stats/panels/preview/route.ts
+++ b/apps/backend/src/api/admin/stats/panels/preview/route.ts
@@ -17,7 +17,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     if (!optionsResult.success) {
       return res.status(400).json({
         error: "Invalid operation_options",
-        details: optionsResult.error.errors,
+        details: optionsResult.error.issues,
       })
     }
 
@@ -26,7 +26,9 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
       {
         id: "preview",
         operation_type: data.operation_type,
-        operation_options: optionsResult.data,
+        // optionsResult.data narrows to `unknown` under Zod v4 generics; the
+        // operation registry validates it as a record-shaped schema.
+        operation_options: optionsResult.data as Record<string, any>,
         display: data.display ?? {},
       },
       { skipCache: true }
@@ -38,7 +40,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     })
   } catch (error: any) {
     if (error instanceof z.ZodError) {
-      res.status(400).json({ error: "Validation error", details: error.errors })
+      res.status(400).json({ error: "Validation error", details: error.issues })
       return
     }
     res.status(400).json({ error: error.message })

--- a/apps/backend/src/api/admin/stats/validators.ts
+++ b/apps/backend/src/api/admin/stats/validators.ts
@@ -15,7 +15,7 @@ export const createDashboardSchema = z.object({
   description: z.string().optional(),
   icon: z.string().optional(),
   color: z.string().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 export const updateDashboardSchema = createDashboardSchema.partial()
@@ -34,10 +34,10 @@ export const panelBaseSchema = z.object({
   width: z.number().int().positive().optional(),
   height: z.number().int().positive().optional(),
   operation_type: z.string().min(1),
-  operation_options: z.record(z.any()).default({}),
-  display: z.record(z.any()).optional(),
+  operation_options: z.record(z.string(), z.any()).default({}),
+  display: z.record(z.string(), z.any()).optional(),
   cache_ttl_seconds: z.number().int().nonnegative().nullable().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 export const createPanelSchema = panelBaseSchema
@@ -46,6 +46,6 @@ export const updatePanelSchema = panelBaseSchema.partial()
 
 export const previewPanelSchema = z.object({
   operation_type: z.string().min(1),
-  operation_options: z.record(z.any()).default({}),
-  display: z.record(z.any()).optional(),
+  operation_options: z.record(z.string(), z.any()).default({}),
+  display: z.record(z.string(), z.any()).optional(),
 })

--- a/apps/backend/src/api/admin/stores/validators.ts
+++ b/apps/backend/src/api/admin/stores/validators.ts
@@ -10,7 +10,7 @@ export const createStoreSchema = z.object({
   default_sales_channel_id: z.string().optional(),
   default_region_id: z.string().optional(),
   default_location_id: z.string().optional(),
-  metadata: z.record(z.any()).optional()
+  metadata: z.record(z.string(), z.any()).optional()
 });
 
 // Schema for updating a store
@@ -23,7 +23,7 @@ export const updateStoreSchema = z.object({
   default_sales_channel_id: z.string().optional(),
   default_region_id: z.string().optional(),
   default_location_id: z.string().optional(),
-  metadata: z.record(z.any()).optional()
+  metadata: z.record(z.string(), z.any()).optional()
 });
 
 // Schema for listing stores with query parameters

--- a/apps/backend/src/api/admin/task-templates/validators.ts
+++ b/apps/backend/src/api/admin/task-templates/validators.ts
@@ -4,7 +4,7 @@ const categorySchema = z.object({
   id: z.string().optional(),
   name: z.string().optional(),
   description: z.string().optional(),
-  metadata: z.record(z.any()).optional()
+  metadata: z.record(z.string(), z.any()).optional()
 });
 
 export const taskTemplateSchema = z.object({
@@ -15,11 +15,11 @@ export const taskTemplateSchema = z.object({
   estimated_cost: z.number().min(0).optional(),
   cost_currency: z.string().optional(),
   priority: z.enum(["low", "medium", "high"]).optional(),
-  required_fields: z.record(z.any()).optional(),
+  required_fields: z.record(z.string(), z.any()).optional(),
   eventable: z.boolean().optional(),
   notifiable: z.boolean().optional(),
   message_template: z.string().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
   category_id: z.string().optional()
 });
 

--- a/apps/backend/src/api/admin/visual-flows/[id]/duplicate/route.ts
+++ b/apps/backend/src/api/admin/visual-flows/[id]/duplicate/route.ts
@@ -58,7 +58,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     res.status(201).json({ flow })
   } catch (error: any) {
     if (error instanceof z.ZodError) {
-      res.status(400).json({ error: "Validation error", details: error.errors })
+      res.status(400).json({ error: "Validation error", details: error.issues })
     } else {
       res.status(400).json({ error: error.message })
     }

--- a/apps/backend/src/api/admin/visual-flows/[id]/execute/route.ts
+++ b/apps/backend/src/api/admin/visual-flows/[id]/execute/route.ts
@@ -62,8 +62,8 @@ import { executeVisualFlowWorkflow } from "../../../../../workflows/visual-flows
 import { VISUAL_FLOWS_MODULE } from "../../../../../modules/visual_flows"
 
 const executeSchema = z.object({
-  trigger_data: z.record(z.any()).optional(),
-  metadata: z.record(z.any()).optional(),
+  trigger_data: z.record(z.string(), z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
   /** When set, copies trigger_data from the referenced execution instead of running fresh. */
   replay_execution_id: z.string().optional(),
 })
@@ -128,7 +128,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     })
   } catch (error: any) {
     if (error instanceof z.ZodError) {
-      res.status(400).json({ error: "Validation error", details: error.errors })
+      res.status(400).json({ error: "Validation error", details: error.issues })
     } else {
       res.status(400).json({ error: error.message })
     }

--- a/apps/backend/src/api/admin/visual-flows/[id]/route.ts
+++ b/apps/backend/src/api/admin/visual-flows/[id]/route.ts
@@ -83,7 +83,7 @@ const operationSchema = z.object({
   operation_key: z.string(),
   operation_type: z.string(),
   name: z.string().optional().nullable(),
-  options: z.record(z.any()).optional(),
+  options: z.record(z.string(), z.any()).optional(),
   position_x: z.number(),
   position_y: z.number(),
   sort_order: z.number(),
@@ -96,9 +96,9 @@ const connectionSchema = z.object({
   target_id: z.string(),
   target_handle: z.string().optional(),
   connection_type: z.enum(["success", "failure", "default"]).optional(),
-  condition: z.record(z.any()).optional().nullable(),
+  condition: z.record(z.string(), z.any()).optional().nullable(),
   label: z.string().optional().nullable(),
-  style: z.record(z.any()).optional().nullable(),
+  style: z.record(z.string(), z.any()).optional().nullable(),
 })
 
 const updateFlowSchema = z.object({
@@ -108,9 +108,9 @@ const updateFlowSchema = z.object({
   icon: z.string().optional().nullable(),
   color: z.string().optional().nullable(),
   trigger_type: z.enum(["event", "schedule", "webhook", "manual", "another_flow"]).optional(),
-  trigger_config: z.record(z.any()).optional(),
-  canvas_state: z.record(z.any()).optional(),
-  metadata: z.record(z.any()).optional(),
+  trigger_config: z.record(z.string(), z.any()).optional(),
+  canvas_state: z.record(z.string(), z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
   operations: z.array(operationSchema).optional(),
   connections: z.array(connectionSchema).optional(),
 })

--- a/apps/backend/src/api/admin/visual-flows/route.ts
+++ b/apps/backend/src/api/admin/visual-flows/route.ts
@@ -99,14 +99,14 @@ const createFlowSchema = z.object({
   icon: z.string().optional(),
   color: z.string().optional(),
   trigger_type: z.enum(["event", "schedule", "webhook", "manual", "another_flow"]),
-  trigger_config: z.record(z.any()).optional(),
-  canvas_state: z.record(z.any()).optional(),
-  metadata: z.record(z.any()).optional(),
+  trigger_config: z.record(z.string(), z.any()).optional(),
+  canvas_state: z.record(z.string(), z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
   operations: z.array(z.object({
     operation_key: z.string(),
     operation_type: z.string(),
     name: z.string().optional(),
-    options: z.record(z.any()).optional(),
+    options: z.record(z.string(), z.any()).optional(),
     position_x: z.number().optional(),
     position_y: z.number().optional(),
     sort_order: z.number().optional(),
@@ -117,7 +117,7 @@ const createFlowSchema = z.object({
     target_id: z.string(),
     target_handle: z.string().optional(),
     connection_type: z.enum(["success", "failure", "default"]).optional(),
-    condition: z.record(z.any()).optional(),
+    condition: z.record(z.string(), z.any()).optional(),
   })).optional(),
 })
 

--- a/apps/backend/src/api/admin/websites/[id]/pages/[pageId]/blocks/validators.ts
+++ b/apps/backend/src/api/admin/websites/[id]/pages/[pageId]/blocks/validators.ts
@@ -15,15 +15,15 @@ const blockBaseSchema = z.object({
     "Section",
     "Custom"
   ]),
-  content: z.record(z.unknown()),
-  settings: z.record(z.unknown()).optional(),
+  content: z.record(z.string(), z.unknown()),
+  settings: z.record(z.string(), z.unknown()).optional(),
   order: z.number().optional(),
   status: z.enum([
     "Active",
     "Inactive",
     "Draft"
   ]).optional(),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 
@@ -40,7 +40,7 @@ export const ReadBlocksQuerySchema = z.object({
       }
       return val;
     },
-    z.record(z.unknown()).optional()
+    z.record(z.string(), z.unknown()).optional()
   ),
   filters: z.preprocess(
     (val) => {
@@ -53,7 +53,7 @@ export const ReadBlocksQuerySchema = z.object({
       }
       return val;
     },
-    z.record(z.unknown()).optional()
+    z.record(z.string(), z.unknown()).optional()
   ),
   page: z.preprocess(
     (val) => {

--- a/apps/backend/src/api/admin/websites/[id]/pages/validators.ts
+++ b/apps/backend/src/api/admin/websites/[id]/pages/validators.ts
@@ -27,9 +27,9 @@ const pageBaseSchema = z.object({
     if (!val) return null;
     return val instanceof Date ? val : new Date(val);
   }),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
   genMetaDataLLM: z.boolean().optional().default(false),
-  public_metadata: z.record(z.unknown()).optional(),
+  public_metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 export const pageSchema = pageBaseSchema;

--- a/apps/backend/src/api/admin/websites/validators.ts
+++ b/apps/backend/src/api/admin/websites/validators.ts
@@ -9,7 +9,7 @@ export const websiteSchema = z.object({
   supported_languages: z.record(z.string(), z.string()).optional(),
   favicon_url: z.string().url().optional(),
   analytics_id: z.string().optional(),
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 export const deleteWebsiteSchema = z.object({
@@ -25,7 +25,7 @@ export const updateWebsiteSchema = z.object({
   supported_languages: z.record(z.string(), z.string()).optional(),
   favicon_url: z.string().url().optional(),
   analytics_id: z.string().optional(),
-  metadata: z.record(z.unknown()).optional().nullish(),
+  metadata: z.record(z.string(), z.unknown()).optional().nullish(),
 });
 
 export type WebsiteSchema = z.infer<typeof websiteSchema>;

--- a/apps/backend/src/api/partners/[id]/payments/validators.ts
+++ b/apps/backend/src/api/partners/[id]/payments/validators.ts
@@ -29,7 +29,7 @@ export const CreatePaymentMethodForPartnerSchema = z.object({
   bank_name: z.string().optional(),
   ifsc_code: z.string().optional(),
   wallet_id: z.string().optional(),
-  metadata: z.record(z.any()).nullish(),
+  metadata: z.record(z.string(), z.any()).nullish(),
 })
 export type CreatePaymentMethodForPartner = z.infer<typeof CreatePaymentMethodForPartnerSchema>
 export const CreatePaymentMethodForPartner = CreatePaymentMethodForPartnerSchema

--- a/apps/backend/src/api/partners/designs/[designId]/consumption-logs/validators.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/consumption-logs/validators.ts
@@ -34,7 +34,7 @@ export const PartnerPostConsumptionLogReq = z.object({
     .optional(),
   notes: z.string().optional(),
   locationId: z.string().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 export type PartnerPostConsumptionLogReq = z.infer<typeof PartnerPostConsumptionLogReq>

--- a/apps/backend/src/api/partners/designs/[designId]/media/attach/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/media/attach/route.ts
@@ -124,7 +124,7 @@ const partnerAttachMediaSchema = z.object({
       })
     )
     .min(1),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 // POST /partners/designs/:designId/media/attach
@@ -164,7 +164,7 @@ export const POST = async (
   // 3) Validate body
   const parse = partnerAttachMediaSchema.safeParse(req.body)
   if (!parse.success) {
-    throw new MedusaError(MedusaError.Types.INVALID_DATA, parse.error.errors.map(e => e.message).join(", "))
+    throw new MedusaError(MedusaError.Types.INVALID_DATA, parse.error.issues.map(e => e.message).join(", "))
   }
   const { media_files, metadata } = parse.data
 

--- a/apps/backend/src/api/partners/inventory-orders/[orderId]/complete/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/[orderId]/complete/route.ts
@@ -136,7 +136,7 @@ export async function POST(
     if (!validation.success) {
         return res.status(400).json({
             error: "Invalid request body",
-            details: validation.error.errors
+            details: validation.error.issues
         });
     }
     

--- a/apps/backend/src/api/partners/inventory-orders/[orderId]/submit-payment/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/[orderId]/submit-payment/route.ts
@@ -21,7 +21,7 @@ export async function POST(
     if (!validation.success) {
         return res.status(400).json({
             error: "Invalid request body",
-            details: validation.error.errors
+            details: validation.error.issues
         });
     }
 

--- a/apps/backend/src/api/partners/payment-config/validators.ts
+++ b/apps/backend/src/api/partners/payment-config/validators.ts
@@ -11,7 +11,7 @@ export const CreatePaymentConfigSchema = z.object({
     api_key: z.string().optional(),
   }),
   is_active: z.boolean().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 export const UpdatePaymentConfigSchema = z.object({
@@ -22,5 +22,5 @@ export const UpdatePaymentConfigSchema = z.object({
     api_key: z.string().optional(),
   }).optional(),
   is_active: z.boolean().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })

--- a/apps/backend/src/api/partners/payment-submissions/validators.ts
+++ b/apps/backend/src/api/partners/payment-submissions/validators.ts
@@ -19,7 +19,7 @@ export const CreatePaymentSubmissionSchema = z
         })
       )
       .optional(),
-    metadata: z.record(z.any()).optional(),
+    metadata: z.record(z.string(), z.any()).optional(),
   })
   .refine(
     (data) => (data.design_ids?.length || 0) + (data.task_ids?.length || 0) > 0,

--- a/apps/backend/src/api/partners/production-runs/[id]/consumption-logs/validators.ts
+++ b/apps/backend/src/api/partners/production-runs/[id]/consumption-logs/validators.ts
@@ -33,7 +33,7 @@ export const PartnerPostProductionRunConsumptionLogReq = z.object({
     .optional(),
   notes: z.string().optional(),
   locationId: z.string().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 export type PartnerPostProductionRunConsumptionLogReq = z.infer<

--- a/apps/backend/src/api/partners/production-runs/[id]/media/attach/route.ts
+++ b/apps/backend/src/api/partners/production-runs/[id]/media/attach/route.ts
@@ -17,7 +17,7 @@ const attachMediaSchema = z.object({
       })
     )
     .min(1),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 export async function POST(
@@ -64,7 +64,7 @@ export async function POST(
   if (!parsed.success) {
     throw new MedusaError(
       MedusaError.Types.INVALID_DATA,
-      parsed.error.errors.map((e) => e.message).join(", ")
+      parsed.error.issues.map((e) => e.message).join(", ")
     )
   }
 

--- a/apps/backend/src/api/partners/products/validators.ts
+++ b/apps/backend/src/api/partners/products/validators.ts
@@ -5,7 +5,7 @@ import { z } from "@medusajs/framework/zod"
 export const PartnerCreateProductReq = z
   .object({
     store_id: z.string().min(1, "store_id is required"),
-    product: z.record(z.any()),
+    product: z.record(z.string(), z.any()),
   })
   .strict()
 

--- a/apps/backend/src/api/partners/stores/[id]/validators.ts
+++ b/apps/backend/src/api/partners/stores/[id]/validators.ts
@@ -6,7 +6,7 @@ export const PartnerCreateRegionReq = z.object({
   countries: z.array(z.string()).optional(),
   payment_providers: z.array(z.string()).optional(),
   automatic_taxes: z.boolean().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 export type PartnerCreateRegionReqType = z.infer<typeof PartnerCreateRegionReq>
@@ -17,7 +17,7 @@ export const PartnerUpdateRegionReq = z.object({
   countries: z.array(z.string()).optional(),
   payment_providers: z.array(z.string()).optional(),
   automatic_taxes: z.boolean().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 export type PartnerUpdateRegionReqType = z.infer<typeof PartnerUpdateRegionReq>
@@ -34,7 +34,7 @@ export const PartnerUpdateLocationReq = z.object({
       country_code: z.string().optional(),
     })
     .optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 export type PartnerUpdateLocationReqType = z.infer<typeof PartnerUpdateLocationReq>
@@ -94,7 +94,7 @@ export const PartnerCreateShippingOptionReq = z.object({
       })
     )
     .optional(),
-  data: z.record(z.any()).optional(),
+  data: z.record(z.string(), z.any()).optional(),
 })
 
 export type PartnerCreateShippingOptionReqType = z.infer<typeof PartnerCreateShippingOptionReq>
@@ -131,7 +131,7 @@ export const PartnerUpdateShippingOptionReq = z.object({
       })
     )
     .optional(),
-  data: z.record(z.any()).optional(),
+  data: z.record(z.string(), z.any()).optional(),
 })
 
 export type PartnerUpdateShippingOptionReqType = z.infer<typeof PartnerUpdateShippingOptionReq>
@@ -157,7 +157,7 @@ export const PartnerUpdateStoreReq = z.object({
   default_sales_channel_id: z.string().nullable().optional(),
   default_region_id: z.string().nullable().optional(),
   default_location_id: z.string().nullable().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 export type PartnerUpdateStoreReqType = z.infer<typeof PartnerUpdateStoreReq>
@@ -167,7 +167,7 @@ export const PartnerCreateSalesChannelReq = z.object({
   name: z.string().min(1),
   description: z.string().nullable().optional(),
   is_disabled: z.boolean().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 export type PartnerCreateSalesChannelReqType = z.infer<typeof PartnerCreateSalesChannelReq>
@@ -176,7 +176,7 @@ export const PartnerUpdateSalesChannelReq = z.object({
   name: z.string().optional(),
   description: z.string().nullable().optional(),
   is_disabled: z.boolean().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 export type PartnerUpdateSalesChannelReqType = z.infer<typeof PartnerUpdateSalesChannelReq>
@@ -193,14 +193,14 @@ export const PartnerCreateTaxRegionReq = z.object({
       name: z.string().optional(),
     })
     .optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 export type PartnerCreateTaxRegionReqType = z.infer<typeof PartnerCreateTaxRegionReq>
 
 export const PartnerUpdateTaxRegionReq = z.object({
   province_code: z.string().nullable().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 })
 
 export type PartnerUpdateTaxRegionReqType = z.infer<typeof PartnerUpdateTaxRegionReq>

--- a/apps/backend/src/api/partners/stores/validators.ts
+++ b/apps/backend/src/api/partners/stores/validators.ts
@@ -17,7 +17,7 @@ export const PartnerCreateStoreReq = z
             })
           )
           .min(1, "At least one supported currency is required"),
-        metadata: z.record(z.any()).optional(),
+        metadata: z.record(z.string(), z.any()).optional(),
       })
       .strict(),
 
@@ -35,7 +35,7 @@ export const PartnerCreateStoreReq = z
         currency_code: z.string().min(1),
         countries: z.array(z.string().min(2)).min(1), // lower-case ISO2, e.g., ["us"]
         payment_providers: z.array(z.string()).optional(),
-        metadata: z.record(z.any()).optional(),
+        metadata: z.record(z.string(), z.any()).optional(),
       })
       .strict(),
 
@@ -52,7 +52,7 @@ export const PartnerCreateStoreReq = z
             country_code: z.string().length(2), // upper-case ISO2 expected by stock locations
           })
           .strict(),
-        metadata: z.record(z.any()).optional(),
+        metadata: z.record(z.string(), z.any()).optional(),
       })
       .strict(),
   })

--- a/apps/backend/src/api/partners/validators.ts
+++ b/apps/backend/src/api/partners/validators.ts
@@ -25,5 +25,5 @@ export const partnerUpdateSchema = z.object({
     is_verified: z.boolean().optional(),
     workspace_type: z.enum(['seller', 'manufacturer', 'individual']).optional(),
     whatsapp_number: z.string().nullable().optional(),
-    metadata: z.record(z.any()).nullable().optional(),
+    metadata: z.record(z.string(), z.any()).nullable().optional(),
 })

--- a/apps/backend/src/api/store/ai/imagegen/validators.ts
+++ b/apps/backend/src/api/store/ai/imagegen/validators.ts
@@ -13,7 +13,7 @@ const canvasSnapshotSchema = z.object({
     z.object({
       id: z.string(),
       type: z.enum(["image", "text", "shape"]).default("image"),
-      data: z.record(z.any()),
+      data: z.record(z.string(), z.any()),
     })
   ),
 })

--- a/apps/backend/src/api/web/ad-planning/track-conversion/route.ts
+++ b/apps/backend/src/api/web/ad-planning/track-conversion/route.ts
@@ -32,7 +32,7 @@ export const TrackConversionSchema = z.object({
   utm_campaign: z.string().optional(),
   utm_term: z.string().optional(),
   utm_content: z.string().optional(),
-  metadata: z.record(z.any()).optional().nullable(),
+  metadata: z.record(z.string(), z.any()).optional().nullable(),
 });
 
 export type TrackConversionRequest = z.infer<typeof TrackConversionSchema>;

--- a/apps/backend/src/api/web/ad-planning/track-journey/route.ts
+++ b/apps/backend/src/api/web/ad-planning/track-journey/route.ts
@@ -24,7 +24,7 @@ export const TrackJourneySchema = z.object({
     "custom"
   ]).default("page_view"),
   event_name: z.string().optional(),
-  event_data: z.record(z.any()).optional().nullable(),
+  event_data: z.record(z.string(), z.any()).optional().nullable(),
   channel: z.enum([
     "web",
     "social",
@@ -51,7 +51,7 @@ export const TrackJourneySchema = z.object({
   ad_campaign_id: z.string().optional().nullable(),
   source_type: z.string().optional().nullable(),
   source_id: z.string().optional().nullable(),
-  metadata: z.record(z.any()).optional().nullable(),
+  metadata: z.record(z.string(), z.any()).optional().nullable(),
 });
 
 export type TrackJourneyRequest = z.infer<typeof TrackJourneySchema>;

--- a/apps/backend/src/api/web/agreement/[id]/respond/route.ts
+++ b/apps/backend/src/api/web/agreement/[id]/respond/route.ts
@@ -115,7 +115,7 @@ export const POST = async (
       return res.status(400).json({
         error: "Validation error",
         message: "Invalid request data",
-        details: error.errors
+        details: error.issues
       });
     }
 

--- a/apps/backend/src/api/web/analytics/track/route.ts
+++ b/apps/backend/src/api/web/analytics/track/route.ts
@@ -95,7 +95,7 @@ export const TrackEventSchema = z.object({
   utm_campaign: z.string().optional(),
   utm_term: z.string().optional(),
   utm_content: z.string().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 });
 
 export type TrackEventRequest = z.infer<typeof TrackEventSchema>;

--- a/apps/backend/src/api/web/website/[domain]/forms/[handle]/validators.ts
+++ b/apps/backend/src/api/web/website/[domain]/forms/[handle]/validators.ts
@@ -2,10 +2,10 @@ import { z } from "@medusajs/framework/zod"
 
 export const webSubmitFormResponseSchema = z.object({
   email: z.string().email().nullable().optional(),
-  data: z.record(z.any()),
+  data: z.record(z.string(), z.any()),
   page_url: z.string().nullable().optional(),
   referrer: z.string().nullable().optional(),
-  metadata: z.record(z.any()).nullable().optional(),
+  metadata: z.record(z.string(), z.any()).nullable().optional(),
 })
 
 export type WebSubmitFormResponse = z.infer<typeof webSubmitFormResponseSchema>

--- a/apps/backend/src/mastra/tools/query-planner.ts
+++ b/apps/backend/src/mastra/tools/query-planner.ts
@@ -85,7 +85,7 @@ const queryPlanSchema = z.object({
       step: z.number(),
       entity: z.string(),
       operation: z.enum(["list", "retrieve", "listAndCount", "count"]),
-      filters: z.record(z.any()),
+      filters: z.record(z.string(), z.any()),
       relations: z.array(z.string()).optional(),
       extract: z.string().optional(),
       linkedFields: z.array(z.string()).optional(), // For Query.graph linked modules
@@ -100,7 +100,7 @@ const queryPlanSchema = z.object({
     type: z.literal("workflow"),
     endpoint: z.string(),
     method: z.enum(["POST", "PUT", "PATCH"]),
-    body: z.record(z.any()).optional(),
+    body: z.record(z.string(), z.any()).optional(),
     workflowName: z.string().optional(),
   }).optional(),
 })

--- a/apps/backend/src/mastra/workflows/aiChat/index.ts
+++ b/apps/backend/src/mastra/workflows/aiChat/index.ts
@@ -70,7 +70,7 @@ const inputSchema = z.object({
   message: z.string(),
   threadId: z.string().optional(),
   resourceId: z.string().optional(),
-  context: z.record(z.any()).optional(),
+  context: z.record(z.string(), z.any()).optional(),
   // Human-in-the-loop: clarification from previous interaction
   clarification: clarificationContextSchema.optional(),
 })

--- a/apps/backend/src/mastra/workflows/designValidator/index.ts
+++ b/apps/backend/src/mastra/workflows/designValidator/index.ts
@@ -8,13 +8,13 @@ const logger = new PinoLogger()
 // Schema definitions for design validation
 const triggerSchema = z.object({
   designPrompt: z.string(),
-  existingValues: z.record(z.any()).optional()
+  existingValues: z.record(z.string(), z.any()).optional()
 });
 
 // EditorJS block types schema
 const editorJsBlockSchema = z.object({
   type: z.string(),
-  data: z.record(z.any())
+  data: z.record(z.string(), z.any())
 });
 
 const editorJsSchema = z.object({
@@ -40,7 +40,7 @@ const designSchema = z.object({
   ]),
   priority: z.enum(["Low", "Medium", "High", "Urgent"]),
   target_completion_date: z.string().optional(),
-  custom_sizes: z.record(z.record(z.number())).optional(),
+  custom_sizes: z.record(z.record(z.string(), z.number())).optional(),
   color_palette: z.array(z.object({
     name: z.string(),
     code: z.string()
@@ -48,7 +48,7 @@ const designSchema = z.object({
   tags: z.array(z.string()),
   estimated_cost: z.number().optional(),
   designer_notes: z.union([z.string(), editorJsSchema]),
-  metadata: z.record(z.any()).optional()
+  metadata: z.record(z.string(), z.any()).optional()
 });
 
 // Design generation step

--- a/apps/backend/src/mastra/workflows/extractionEval/index.ts
+++ b/apps/backend/src/mastra/workflows/extractionEval/index.ts
@@ -56,7 +56,7 @@ export const triggerSchema = z.object({
 
 export const evalResultSchema = z.object({
   /** Best available extraction result (merged original + refined). */
-  extraction: z.record(z.any()),
+  extraction: z.record(z.string(), z.any()),
   /** 0–1 composite quality score. */
   score: z.number().min(0).max(1),
   quality: z.enum(["excellent", "good", "acceptable", "poor"]),
@@ -133,7 +133,7 @@ const extractStep = createStep({
   id: "extract",
   inputSchema: triggerSchema,
   outputSchema: z.object({
-    extraction: z.record(z.any()),
+    extraction: z.record(z.string(), z.any()),
     input: z.string(),
     system_prompt: z.string().optional(),
     schema_fields: z.array(schemaFieldSchema),
@@ -162,7 +162,7 @@ const extractStep = createStep({
 const evalStep = createStep({
   id: "eval",
   inputSchema: z.object({
-    extraction: z.record(z.any()),
+    extraction: z.record(z.string(), z.any()),
     input: z.string(),
     system_prompt: z.string().optional(),
     schema_fields: z.array(schemaFieldSchema),
@@ -170,7 +170,7 @@ const evalStep = createStep({
     built_system_prompt: z.string(),
   }),
   outputSchema: z.object({
-    extraction: z.record(z.any()),
+    extraction: z.record(z.string(), z.any()),
     score: z.number(),
     missing_fields: z.array(z.string()),
     input: z.string(),
@@ -222,7 +222,7 @@ const evalStep = createStep({
 const refineStep = createStep({
   id: "refine",
   inputSchema: z.object({
-    extraction: z.record(z.any()),
+    extraction: z.record(z.string(), z.any()),
     score: z.number(),
     missing_fields: z.array(z.string()),
     input: z.string(),

--- a/apps/backend/src/mastra/workflows/imageExtraction/index.ts
+++ b/apps/backend/src/mastra/workflows/imageExtraction/index.ts
@@ -30,7 +30,7 @@ export const itemSchema = z.object({
   unit: z.string().optional(),
   sku: z.string().optional(),
   confidence: z.number().min(0).max(1).optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
 });
 
 export const extractionResultSchema = z.object({

--- a/apps/backend/src/mastra/workflows/imagegen/index.ts
+++ b/apps/backend/src/mastra/workflows/imagegen/index.ts
@@ -94,7 +94,7 @@ export const triggerSchema = z.object({
         z.object({
           id: z.string(),
           type: z.enum(["image", "text", "shape"]).default("image"),
-          data: z.record(z.any()),
+          data: z.record(z.string(), z.any()),
         })
       ),
     })

--- a/apps/backend/src/mastra/workflows/multiStepApiRequest/index.ts
+++ b/apps/backend/src/mastra/workflows/multiStepApiRequest/index.ts
@@ -19,12 +19,12 @@ import { z } from "@medusajs/framework/zod"
 export const MultiStepApiRequestInput = z.object({
     message: z.string(),
     threadId: z.string().optional(),
-    context: z.record(z.any()).optional(),
+    context: z.record(z.string(), z.any()).optional(),
 })
 
 export const MultiStepApiRequestOutput = z.object({
     result: z.any().optional(),
-    meta: z.record(z.any()).optional(),
+    meta: z.record(z.string(), z.any()).optional(),
     needsDisambiguation: z.boolean(),
     suspended: z.boolean().optional(),
     error: z.string().optional(),
@@ -40,7 +40,7 @@ const detectMultiStepIntent = createStep({
     id: "detect-multi-step",
     inputSchema: z.object({
         message: z.string(),
-        context: z.record(z.any()).optional(),
+        context: z.record(z.string(), z.any()).optional(),
     }),
     outputSchema: z.object({
         needsDisambiguation: z.boolean(),
@@ -51,7 +51,7 @@ const detectMultiStepIntent = createStep({
         targetMethod: z.string().optional(),
         searchField: z.string().optional(),
         linkQueryKey: z.string().optional(),
-        context: z.record(z.any()).optional(),
+        context: z.record(z.string(), z.any()).optional(),
     }),
     execute: async ({ inputData }) => {
         const message = inputData.message
@@ -277,13 +277,13 @@ const queryForMatches = createStep({
         identifier: z.string(),
         searchField: z.string().optional(),
         intent: z.enum(["list", "search", "detail"]).optional(),
-        context: z.record(z.any()).optional(),
+        context: z.record(z.string(), z.any()).optional(),
     }),
     outputSchema: z.object({
         matches: z.array(z.object({
             id: z.string(),
             display: z.string(),
-            metadata: z.record(z.any()),
+            metadata: z.record(z.string(), z.any()),
         })),
         totalCount: z.number().optional(),
     }),
@@ -370,7 +370,7 @@ const confirmSelection = createStep({
         matches: z.array(z.object({
             id: z.string(),
             display: z.string(),
-            metadata: z.record(z.any()),
+            metadata: z.record(z.string(), z.any()),
         })),
         resource: z.string(),
         intent: z.enum(["list", "search", "detail"]).optional(),
@@ -380,16 +380,16 @@ const confirmSelection = createStep({
         selectedId: z.string(),
         action: z.string().optional(), // "view-all" or "select"
         selectedDisplay: z.string().optional(),
-        selectedMetadata: z.record(z.any()).optional(),
-        context: z.record(z.any()).optional(),
+        selectedMetadata: z.record(z.string(), z.any()).optional(),
+        context: z.record(z.string(), z.any()).optional(),
     }),
     resumeSchema: z.object({
         selectedId: z.string(),
         confirmed: z.boolean(),
         action: z.string().optional(),
         selectedDisplay: z.string().optional(),
-        selectedMetadata: z.record(z.any()).optional(),
-        context: z.record(z.any()).optional(),
+        selectedMetadata: z.record(z.string(), z.any()).optional(),
+        context: z.record(z.string(), z.any()).optional(),
     }),
     suspendSchema: z.object({
         reason: z.string(),
@@ -474,14 +474,14 @@ const executeFinalApi = createStep({
         targetMethod: z.string(),
         selectedId: z.string(),
         linkQueryKey: z.string().optional(),
-        context: z.record(z.any()).optional(),
+        context: z.record(z.string(), z.any()).optional(),
         selectedDisplay: z.string().optional(),
-        selectedMetadata: z.record(z.any()).optional(),
+        selectedMetadata: z.record(z.string(), z.any()).optional(),
     }),
     outputSchema: z.object({
         needsDisambiguation: z.boolean().optional(),
         result: z.any().optional(),
-        meta: z.record(z.any()).optional(),
+        meta: z.record(z.string(), z.any()).optional(),
         error: z.string().optional(),
     }),
     execute: async ({ inputData }) => {
@@ -588,7 +588,7 @@ const finalizeOutput = createStep({
     inputSchema: z.object({
         needsDisambiguation: z.boolean(),
         result: z.any().optional(),
-        meta: z.record(z.any()).optional(),
+        meta: z.record(z.string(), z.any()).optional(),
         error: z.string().optional(),
     }),
     outputSchema: MultiStepApiRequestOutput,

--- a/apps/backend/src/mastra/workflows/visualFlowCodegen/index.ts
+++ b/apps/backend/src/mastra/workflows/visualFlowCodegen/index.ts
@@ -6,7 +6,7 @@ import { visualFlowCodegenAgent } from "../../agents"
 const inputSchema = z.object({
   prompt: z.string().min(1, "prompt is required"),
   // Optional: Provide any structured context about the flow/node/available variables
-  context: z.record(z.any()).optional().default({}),
+  context: z.record(z.string(), z.any()).optional().default({}),
   // Optional: force the model to produce certain output keys
   desiredOutputKeys: z.array(z.string()).optional(),
   // Optional: allow the model to declare packages it wants to use

--- a/apps/backend/src/modules/visual_flows/operations/aggregate-data.ts
+++ b/apps/backend/src/modules/visual_flows/operations/aggregate-data.ts
@@ -11,7 +11,7 @@ const aggregateOptionsSchema = z.object({
     .array(z.string())
     .optional()
     .describe("Fields to fetch from query.graph (required for non-count aggregates and groupBy)"),
-  filters: z.record(z.any()).optional().describe("Filter conditions"),
+  filters: z.record(z.string(), z.any()).optional().describe("Filter conditions"),
   aggregate: z
     .object({
       fn: z

--- a/apps/backend/src/modules/visual_flows/operations/ai-extract.ts
+++ b/apps/backend/src/modules/visual_flows/operations/ai-extract.ts
@@ -93,7 +93,7 @@ export const aiExtractOperation: OperationDefinition = {
       .default(false)
       .describe("Return empty object instead of failing the flow on error"),
     mock_response: z
-      .record(z.any())
+      .record(z.string(), z.any())
       .optional()
       .describe("If set, skip the AI call and return this object directly (useful for testing)"),
     use_mastra_eval: z

--- a/apps/backend/src/modules/visual_flows/operations/bulk-create-data.ts
+++ b/apps/backend/src/modules/visual_flows/operations/bulk-create-data.ts
@@ -33,7 +33,7 @@ export const bulkCreateDataOperation: OperationDefinition = {
      * When omitted the item is used as-is.
      */
     item_template: z
-      .record(z.any())
+      .record(z.string(), z.any())
       .optional()
       .describe(
         "Shape of each record to create. Use {{ item.field }} to reference the current item, " +

--- a/apps/backend/src/modules/visual_flows/operations/bulk-http-request.ts
+++ b/apps/backend/src/modules/visual_flows/operations/bulk-http-request.ts
@@ -37,10 +37,10 @@ export const bulkHttpRequestOperation: OperationDefinition = {
      * Body template per item. Supports {{ item.field }} and $index.
      */
     body: z
-      .record(z.any())
+      .record(z.string(), z.any())
       .optional()
       .describe("Body template. Use {{ item.field }} for per-item values."),
-    headers: z.record(z.string()).optional().describe("Extra request headers"),
+    headers: z.record(z.string(), z.string()).optional().describe("Extra request headers"),
     timeout_ms: z.number().optional().default(30000),
     continue_on_error: z.boolean().optional().default(true),
     max_items: z.number().int().min(1).max(500).optional().default(100),

--- a/apps/backend/src/modules/visual_flows/operations/bulk-trigger-workflow.ts
+++ b/apps/backend/src/modules/visual_flows/operations/bulk-trigger-workflow.ts
@@ -36,7 +36,7 @@ export const bulkTriggerWorkflowOperation: OperationDefinition = {
      * All other {{ operation_key.field }} references to the data chain also work.
      */
     input_template: z
-      .record(z.any())
+      .record(z.string(), z.any())
       .optional()
       .describe(
         "Input object passed to each workflow invocation. " +

--- a/apps/backend/src/modules/visual_flows/operations/bulk-update-data.ts
+++ b/apps/backend/src/modules/visual_flows/operations/bulk-update-data.ts
@@ -20,8 +20,8 @@ export const bulkUpdateDataOperation: OperationDefinition = {
     items: z
       .array(
         z.object({
-          selector: z.record(z.any()).optional().describe("Selector to find record (e.g., { id: '...' })"),
-          data: z.record(z.any()).describe("Data to update"),
+          selector: z.record(z.string(), z.any()).optional().describe("Selector to find record (e.g., { id: '...' })"),
+          data: z.record(z.string(), z.any()).describe("Data to update"),
         })
       )
       .describe("Update items"),

--- a/apps/backend/src/modules/visual_flows/operations/condition.ts
+++ b/apps/backend/src/modules/visual_flows/operations/condition.ts
@@ -16,7 +16,7 @@ export const conditionOperation: OperationDefinition = {
   ],
   
   optionsSchema: z.object({
-    filter_rule: z.record(z.any()).describe("Filter rule to evaluate"),
+    filter_rule: z.record(z.string(), z.any()).describe("Filter rule to evaluate"),
     // UI-only fields for the keyword-match builder — ignored at runtime
     condition_mode: z.enum(["expression", "keyword_match"]).optional(),
     expression: z.string().optional(),

--- a/apps/backend/src/modules/visual_flows/operations/create-data.ts
+++ b/apps/backend/src/modules/visual_flows/operations/create-data.ts
@@ -12,7 +12,7 @@ export const createDataOperation: OperationDefinition = {
   optionsSchema: z.object({
     module: z.string().describe("Module identifier (e.g., 'person', 'designs')"),
     collection: z.string().describe("Collection/entity name (e.g., 'People', 'Designs')"),
-    data: z.record(z.any()).describe("Data to create"),
+    data: z.record(z.string(), z.any()).describe("Data to create"),
   }),
   
   defaultOptions: {

--- a/apps/backend/src/modules/visual_flows/operations/http-request.ts
+++ b/apps/backend/src/modules/visual_flows/operations/http-request.ts
@@ -12,7 +12,7 @@ export const httpRequestOperation: OperationDefinition = {
   optionsSchema: z.object({
     method: z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]).default("GET"),
     url: z.string().describe("Request URL"),
-    headers: z.record(z.string()).optional().describe("Request headers"),
+    headers: z.record(z.string(), z.string()).optional().describe("Request headers"),
     body: z.any().optional().describe("Request body (for POST/PUT/PATCH)"),
     timeout_ms: z.number().optional().default(30000).describe("Request timeout in milliseconds"),
   }),

--- a/apps/backend/src/modules/visual_flows/operations/notification.ts
+++ b/apps/backend/src/modules/visual_flows/operations/notification.ts
@@ -15,7 +15,7 @@ export const notificationOperation: OperationDefinition = {
     description: z.string().optional().describe("Notification description"),
     to: z.string().optional().describe("User ID to send to (optional)"),
     channel: z.string().default("feed").describe("Notification channel"),
-    data: z.record(z.any()).optional().describe("Additional data"),
+    data: z.record(z.string(), z.any()).optional().describe("Additional data"),
   }),
   
   defaultOptions: {

--- a/apps/backend/src/modules/visual_flows/operations/read-data.ts
+++ b/apps/backend/src/modules/visual_flows/operations/read-data.ts
@@ -13,7 +13,7 @@ export const readDataOperation: OperationDefinition = {
   optionsSchema: z.object({
     entity: z.string().describe("Entity name to query"),
     fields: z.array(z.string()).describe("Fields to retrieve"),
-    filters: z.record(z.any()).optional().describe("Filter conditions"),
+    filters: z.record(z.string(), z.any()).optional().describe("Filter conditions"),
     limit: z.number().optional().describe("Maximum number of records"),
     offset: z.number().optional().describe("Number of records to skip"),
   }),

--- a/apps/backend/src/modules/visual_flows/operations/send-email.ts
+++ b/apps/backend/src/modules/visual_flows/operations/send-email.ts
@@ -14,7 +14,7 @@ export const sendEmailOperation: OperationDefinition = {
     subject: z.string().describe("Email subject"),
     template: z.string().optional().describe("Email template key"),
     body: z.string().optional().describe("Email body (HTML or plain text)"),
-    data: z.record(z.any()).optional().describe("Template data"),
+    data: z.record(z.string(), z.any()).optional().describe("Template data"),
   }),
   
   defaultOptions: {

--- a/apps/backend/src/modules/visual_flows/operations/time-series.ts
+++ b/apps/backend/src/modules/visual_flows/operations/time-series.ts
@@ -19,7 +19,7 @@ const timeSeriesOptionsSchema = z.object({
   entity: z.string().describe("Entity name to query via query.graph"),
   dateField: z.string().describe("Field on the entity to bucket by"),
   fields: z.array(z.string()).optional(),
-  filters: z.record(z.any()).optional(),
+  filters: z.record(z.string(), z.any()).optional(),
   aggregate: z
     .object({
       fn: z.enum(["count", "sum", "avg", "min", "max"]).default("count"),

--- a/apps/backend/src/modules/visual_flows/operations/transform.ts
+++ b/apps/backend/src/modules/visual_flows/operations/transform.ts
@@ -10,7 +10,7 @@ export const transformOperation: OperationDefinition = {
   category: "utility",
   
   optionsSchema: z.object({
-    json: z.record(z.any()).describe("JSON structure with variable interpolation"),
+    json: z.record(z.string(), z.any()).describe("JSON structure with variable interpolation"),
   }),
   
   defaultOptions: {

--- a/apps/backend/src/modules/visual_flows/operations/trigger-flow.ts
+++ b/apps/backend/src/modules/visual_flows/operations/trigger-flow.ts
@@ -22,7 +22,7 @@ export const triggerFlowOperation: OperationDefinition = {
   optionsSchema: z.object({
     flow_id: z.string().describe("ID of the flow to trigger"),
     flow_name: z.string().optional().describe("Name of the flow (for display)"),
-    input: z.record(z.any()).optional().describe("Input data to pass to the flow"),
+    input: z.record(z.string(), z.any()).optional().describe("Input data to pass to the flow"),
     wait_for_completion: z.boolean().default(true).describe("Wait for the triggered flow to complete"),
   }),
   

--- a/apps/backend/src/modules/visual_flows/operations/trigger-workflow.ts
+++ b/apps/backend/src/modules/visual_flows/operations/trigger-workflow.ts
@@ -13,7 +13,7 @@ export const triggerWorkflowOperation: OperationDefinition = {
   
   optionsSchema: z.object({
     workflow_name: z.string().describe("Name/ID of the workflow to trigger"),
-    input: z.record(z.any()).optional().describe("Input data for the workflow"),
+    input: z.record(z.string(), z.any()).optional().describe("Input data for the workflow"),
     wait_for_completion: z.boolean().default(true).describe("Wait for workflow to complete"),
   }),
   

--- a/apps/backend/src/modules/visual_flows/operations/update-data.ts
+++ b/apps/backend/src/modules/visual_flows/operations/update-data.ts
@@ -12,8 +12,8 @@ export const updateDataOperation: OperationDefinition = {
   optionsSchema: z.object({
     module: z.string().describe("Module identifier"),
     collection: z.string().describe("Collection/entity name"),
-    selector: z.record(z.any()).describe("Selector to find records (e.g., { id: '...' })"),
-    data: z.record(z.any()).describe("Data to update"),
+    selector: z.record(z.string(), z.any()).describe("Selector to find records (e.g., { id: '...' })"),
+    data: z.record(z.string(), z.any()).describe("Data to update"),
   }),
   
   defaultOptions: {

--- a/apps/backend/src/scripts/generate-api-input-validators.ts
+++ b/apps/backend/src/scripts/generate-api-input-validators.ts
@@ -38,7 +38,7 @@ const mapModelTypeToZod = (modelType: string, fieldName: string): string => {
 
   // Handle JSON fields
   if (modelType.startsWith('model.json')) {
-    return 'z.record(z.unknown())';
+    return 'z.record(z.string(), z.unknown())';
   }
 
   // Handle boolean fields

--- a/apps/backend/src/scripts/generate-validators.ts
+++ b/apps/backend/src/scripts/generate-validators.ts
@@ -15,7 +15,7 @@ const toPascalCase = (str: string) =>
 const mapModelTypeToZod = (modelType: string): string => {
   if (modelType.startsWith('model.text')) return 'z.string()';
   if (modelType.startsWith('model.dateTime')) return 'z.coerce.date()';
-  if (modelType.startsWith('model.json')) return 'z.record(z.unknown())';
+  if (modelType.startsWith('model.json')) return 'z.record(z.string(), z.unknown())';
   if (modelType.startsWith('model.enum')) {
     const arrayMatch = modelType.match(/\(\[(.*?)\]\)/);
     if (arrayMatch && arrayMatch[1]) {


### PR DESCRIPTION
## Summary

Follow-up to #152 and #154. Running \`pnpm build\` against Medusa 2.14 + Zod 4 surfaced **213 type errors** that have to be migrated for the build to compile clean. None change runtime behavior — every fix is a syntax shift to match Zod v4's stricter API surface.

\`\`\`
Before: pnpm build → 213 errors across 125 files (TS2554, TS2339, TS2322, TS2769, TS2345)
After:  pnpm build → "Backend build completed successfully (15.05s)" + 230 workflow schemas
\`\`\`

## Migrations applied

| Pattern | Sites | Migration | Why |
|---|---:|---|---|
| \`z.record(VALUE)\` | 180 | → \`z.record(z.string(), VALUE)\` | Key type is required in v4 (was implicit \`string\` in v3) |
| \`parsed.error.errors\` | 24 | → \`parsed.error.issues\` | \`ZodError.errors\` renamed to \`.issues\` |
| \`ctx.addIssue({ type: "number" })\` | 1 | → \`ctx.addIssue({ origin: "number" })\` | Size-bound issue field renamed |
| \`.default((val) => ...)\` | 2 | → \`.default(() => ...)\` | Default-fn arg signature changed (no input arg) |
| \`parse()\` → \`Record<string, unknown>\` | 4 | Cast at dynamic-resource boundaries | v4 generics narrow more strictly to \`unknown\` |

The bulk patterns (z.record, error.errors) were applied via regex; the targeted ones (addIssue origin, .default thunk, payload casts) were edited individually.

## Verified locally

- \`pnpm build\` exits 0
- \`Backend build completed successfully (15.05s)\`
- 230 workflow schemas generated into \`apps/backend/workflow-schemas.json\`
- Zero \`error TS\` / \`ELIFECYCLE\` / \`Failed\` lines in the build log

## Test plan

- [ ] CI \`test\` job passes on this PR (encryption-key + earlier zod fixes are settled).
- [ ] Production Railway deploy completes \`db:migrate --execute-all-links\` and the server boots cleanly. (#152 + #154 + this PR together = full v4 migration.)
- [ ] Smoke a few of the migrated endpoints — particularly anything that round-trips a body through a \`z.record(...)\` schema (most of \`apps/backend/src/api/admin/visual-flows\`, \`stats\`, \`forms\`, \`websites\`, \`partner-plans\`, \`designs\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)