### PR TITLE
fix(admin): wire abandoned-carts FilterMenu values into the API call

### DIFF
--- a/apps/backend/src/admin/hooks/api/abandoned-carts.ts
+++ b/apps/backend/src/admin/hooks/api/abandoned-carts.ts
@@ -48,6 +48,7 @@ export type AbandonedCartsQuery = {
   region_id?: string;
   customer_id?: string;
   email?: string;
+  has_shipping?: "yes" | "no";
   offset?: number;
   limit?: number;
   order?: string;

--- a/apps/backend/src/admin/routes/abandoned-carts/page.tsx
+++ b/apps/backend/src/admin/routes/abandoned-carts/page.tsx
@@ -15,7 +15,7 @@ import { useNavigate } from "react-router-dom";
 import { keepPreviousData } from "@tanstack/react-query";
 import { defineRouteConfig } from "@medusajs/admin-sdk";
 import { ShoppingCart } from "@medusajs/icons";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { createColumnHelper } from "@tanstack/react-table";
 import debounce from "lodash/debounce";
 import {
@@ -181,21 +181,38 @@ const AbandonedCartsPage = () => {
     [],
   );
 
-  // Filter values come from the FilterMenu's `filtering` state. We coerce
-  // defensively because select filters can land as either a single string
-  // or undefined depending on whether the user has interacted with them.
-  const tierRaw = filtering["tier"];
-  const tier: AbandonedCartTier =
-    typeof tierRaw === "string" ? (tierRaw as AbandonedCartTier) : "has_items";
+  // Filter values come from the FilterMenu's `filtering` state. The
+  // DataTable returns select-filter values as `string | string[]` —
+  // checked elsewhere in the codebase (see saved-reports-tab.tsx).
+  // The previous implementation only handled the bare-string case and
+  // silently fell back to defaults whenever the array shape was
+  // returned, which made the whole FilterMenu look inert.
+  const readFilterValue = (key: string): string | undefined => {
+    const v = filtering[key];
+    if (Array.isArray(v)) return typeof v[0] === "string" ? v[0] : undefined;
+    return typeof v === "string" ? v : undefined;
+  };
 
-  const idleRaw = filtering["idle_minutes"];
-  const idleMinutes = typeof idleRaw === "string" ? idleRaw : "60";
+  const tier: AbandonedCartTier =
+    (readFilterValue("tier") as AbandonedCartTier | undefined) ?? "has_items";
+  const idleMinutes = readFilterValue("idle_minutes") ?? "60";
+  const hasShipping = readFilterValue("has_shipping") as
+    | "yes"
+    | "no"
+    | undefined;
+
+  // Reset pagination when filters or search change — otherwise switching
+  // tier on page 5 leaves you stranded on a non-existent page.
+  useEffect(() => {
+    setPagination((prev) => (prev.pageIndex === 0 ? prev : { ...prev, pageIndex: 0 }));
+  }, [tier, idleMinutes, hasShipping, search]);
 
   const offset = pagination.pageIndex * pagination.pageSize;
 
   const queryParams: AbandonedCartsQuery = {
     tier,
     idle_minutes: Number(idleMinutes),
+    has_shipping: hasShipping,
     limit: pagination.pageSize,
     offset,
     q: search || undefined,

--- a/apps/backend/src/api/admin/abandoned-carts/route.ts
+++ b/apps/backend/src/api/admin/abandoned-carts/route.ts
@@ -87,6 +87,8 @@ export async function GET(
   if (validated.region_id) filters.region_id = validated.region_id
   if (validated.customer_id) filters.customer_id = validated.customer_id
   if (validated.email) filters.email = validated.email
+  if (validated.has_shipping === "yes") filters.shipping_address_id = { $ne: null }
+  if (validated.has_shipping === "no") filters.shipping_address_id = null
 
   const andClauses: Array<Record<string, any>> = []
 

--- a/apps/backend/src/api/admin/abandoned-carts/validators.ts
+++ b/apps/backend/src/api/admin/abandoned-carts/validators.ts
@@ -20,6 +20,10 @@ export const listAbandonedCartsQuerySchema = z.object({
   region_id: z.string().optional(),
   customer_id: z.string().optional(),
   email: z.string().optional(),
+  // Whether the cart already has a shipping address attached. Useful
+  // for narrowing to "checkout-stage" abandoners who got past the
+  // address step. Accepts "yes" / "no" — anything else is ignored.
+  has_shipping: z.enum(["yes", "no"]).optional(),
   offset: z.preprocess(
     (val) => (val !== undefined && val !== null && val !== "" ? Number(val) : undefined),
     z.number().int().min(0).default(0),


### PR DESCRIPTION
The FilterMenu was rendering correctly but every selection silently
fell back to defaults — selections never reached the request.

Root cause: select-filter values from useDataTable land in the
`filtering` state as `string | string[]` (the array shape is what
saved-reports-tab.tsx already handles). The page only checked
`typeof === 'string'`, so the array case slipped through and the
fallback default was used instead.

- page.tsx: readFilterValue() helper handles both shapes; tier,
  idle_minutes and has_shipping all read through it.
- page.tsx: useEffect resets pagination.pageIndex to 0 when filters
  or search change so switching tier on page 5 doesn't strand you on
  an empty page.
- validators.ts / route.ts: 'has_shipping' was a UI-only placeholder
  with no backend hook. Now accepted as 'yes' | 'no' and translated
  to shipping_address_id: { $ne: null } / null at the DB filter.
- hooks/api/abandoned-carts.ts: types the new field on the query.
