### PR TITLE
fix(partner-ui): consume WhatsApp deep-link wa_token to auto-auth

### DIFF
--- a/apps/backend/src/api/partners/wa-auth/route.ts
+++ b/apps/backend/src/api/partners/wa-auth/route.ts
@@ -1,17 +1,38 @@
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { MedusaError } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
+import type { ConfigModule } from "@medusajs/framework/types"
+import jwt from "jsonwebtoken"
 import { verifyPartnerDeeplink } from "../../../modules/social-provider/whatsapp-deeplink"
 import { PARTNER_MODULE } from "../../../modules/partner"
 
 /**
  * GET /partners/wa-auth?wa_token=<jwt>
  *
- * Validates a WhatsApp deep-link token and returns a partner session token.
- * Partners click links in WhatsApp messages and land here — if valid,
- * they get redirected to the portal with an active session.
+ * Validates a WhatsApp deep-link token and issues a Medusa partner
+ * session token. Partners click links in WhatsApp messages and land
+ * here — if the deep-link is valid, we return a Medusa-shaped bearer
+ * token that the partner-ui SDK can store under
+ * `partner_ui_auth_token` (its configured `jwtTokenStorageKey`).
+ *
+ * The deep-link JWT is signed with our own JYT secret (issuer
+ * "jyt-whatsapp"). The bearer we issue is signed with Medusa's
+ * configured `http.jwtSecret` and matches the shape produced by
+ * Medusa's `generateJwtTokenForAuthIdentity` helper, so the framework's
+ * authenticate middleware accepts it on subsequent /partners/* calls.
+ *
+ * Synthetic run-ids of the form "<run_id>:reminder:YYYY-MM-DD" are
+ * stripped from the redirect path — those are dedup keys used by the
+ * reminder dispatcher, not addressable resource ids.
  */
+
+function stripDedupSuffix(id: string | undefined | null): string | null {
+  if (!id) return null
+  const colonIdx = id.indexOf(":")
+  return colonIdx >= 0 ? id.slice(0, colonIdx) : id
+}
+
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
-  const token = req.query.wa_token as string
+  const token = req.query.wa_token as string | undefined
 
   if (!token) {
     throw new MedusaError(
@@ -29,9 +50,12 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     )
   }
 
-  // Verify the partner still exists
+  // 1. Verify the partner still exists and is active.
   const partnerService = req.scope.resolve(PARTNER_MODULE) as any
-  const partner = await partnerService.retrievePartner(payload.partnerId).catch(() => null) as any
+  const partner = await partnerService
+    .retrievePartner(payload.partnerId)
+    .catch(() => null) as any
+
   if (!partner || partner.status === "inactive") {
     throw new MedusaError(
       MedusaError.Types.NOT_FOUND,
@@ -39,20 +63,71 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     )
   }
 
-  // Return the partner info and redirect path
-  // The frontend can use this to set up the session
+  // 2. Find an auth_identity for this partner. setAuthAppMetadataStep
+  //    in the add-partner-admin workflow stores partner.id (the parent
+  //    partner's id) under app_metadata.partner_id, so all admins of a
+  //    partner share the same `actor_id` for Medusa-auth purposes. We
+  //    just need one — which one doesn't matter for downstream API
+  //    authorization since the actor_id is the parent partner's id.
+  const authModule = req.scope.resolve(Modules.AUTH) as any
+  const identities = await authModule.listAuthIdentities({
+    app_metadata: { partner_id: partner.id },
+  })
+
+  const authIdentity = identities?.[0]
+  if (!authIdentity) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      "No active auth identity found for this partner. Ask an admin to invite a user."
+    )
+  }
+
+  // 3. Sign a Medusa-shaped session bearer with the same secret + payload
+  //    layout that Medusa's generateJwtTokenForAuthIdentity produces.
+  //    Keeping the shape exact is critical — the framework's auth middleware
+  //    reads actor_id / actor_type / auth_identity_id from this payload.
+  const configModule = req.scope.resolve<ConfigModule>(
+    ContainerRegistrationKeys.CONFIG_MODULE,
+  )
+  const httpConfig = configModule.projectConfig.http
+  const secret = (httpConfig as any).jwtSecret
+  if (!secret) {
+    throw new MedusaError(
+      MedusaError.Types.UNEXPECTED_STATE,
+      "JWT secret not configured (projectConfig.http.jwtSecret).",
+    )
+  }
+  const expiresIn = (httpConfig as any).jwtExpiresIn ?? "24h"
+
+  const sessionToken = jwt.sign(
+    {
+      actor_id: partner.id,
+      actor_type: "partner",
+      auth_identity_id: authIdentity.id,
+      app_metadata: { partner_id: partner.id },
+    },
+    secret,
+    { expiresIn },
+  )
+
+  // 4. Build the post-login redirect path. The deep-link's `run_id` may
+  //    carry a synthetic ":reminder:YYYY-MM-DD" suffix used as a dedup
+  //    key — strip it so the partner-ui's /production-runs/:id route
+  //    sees the addressable resource id.
+  const cleanRunId = stripDedupSuffix(payload.runId)
   let redirectPath = "/"
-  if (payload.type === "production_run" && payload.runId) {
-    redirectPath = `/production-runs/${payload.runId}`
-  } else if (payload.type === "design" && payload.runId) {
-    redirectPath = `/designs/${payload.runId}`
+  if (payload.type === "production_run" && cleanRunId) {
+    redirectPath = `/production-runs/${cleanRunId}`
+  } else if (payload.type === "design" && cleanRunId) {
+    redirectPath = `/designs/${cleanRunId}`
   }
 
   return res.json({
-    partner_id: payload.partnerId,
+    token: sessionToken,
+    partner_id: partner.id,
     partner_name: partner.name,
     redirect: redirectPath,
     type: payload.type,
-    run_id: payload.runId,
+    run_id: cleanRunId,
   })
 }

--- a/apps/backend/src/modules/social-provider/whatsapp-deeplink.ts
+++ b/apps/backend/src/modules/social-provider/whatsapp-deeplink.ts
@@ -10,6 +10,25 @@ interface DeeplinkPayload {
 }
 
 /**
+ * The reminder dispatcher uses synthetic ids of the form
+ *   "<run_id>:reminder:<YYYY-MM-DD>"
+ * as a per-day dedup key (so the same reminder doesn't fire twice on the
+ * same day). That synthetic id has been leaking into the deep-link URL
+ * and the JWT's `run_id` claim, which means even if auth worked, the
+ * partner-ui's /production-runs/:id route gets the synthetic value and
+ * 404s.
+ *
+ * Strip everything from the first colon onwards as a defensive measure
+ * — production-run / design IDs are ULIDs and never contain colons in
+ * the canonical form, so this is a safe trim regardless of upstream.
+ */
+function stripDedupSuffix(id: string | undefined): string | undefined {
+  if (!id) return id
+  const colonIdx = id.indexOf(":")
+  return colonIdx >= 0 ? id.slice(0, colonIdx) : id
+}
+
+/**
  * Generate a short-lived JWT token for WhatsApp deep-links.
  * Partners can click the link and land in the portal without logging in.
  */
@@ -18,11 +37,12 @@ export function generatePartnerDeeplink(
   baseUrl: string
 ): { url: string; token: string } {
   const secret = getSecret()
+  const cleanRunId = stripDedupSuffix(payload.run_id)
 
   const token = jwt.sign(
     {
       sub: payload.partner_id,
-      run_id: payload.run_id,
+      run_id: cleanRunId,
       type: payload.type,
       iss: DEEPLINK_ISSUER,
     },
@@ -33,10 +53,10 @@ export function generatePartnerDeeplink(
   let path = ""
   switch (payload.type) {
     case "production_run":
-      path = `/production-runs/${payload.run_id}`
+      path = `/production-runs/${cleanRunId}`
       break
     case "design":
-      path = `/designs/${payload.run_id}`
+      path = `/designs/${cleanRunId}`
       break
     case "portal":
       path = "/"

--- a/apps/partner-ui/src/components/authentication/protected-route/protected-route.tsx
+++ b/apps/partner-ui/src/components/authentication/protected-route/protected-route.tsx
@@ -1,14 +1,96 @@
 import { Spinner } from "@medusajs/icons"
-import { Navigate, Outlet, useLocation } from "react-router-dom"
+import { useEffect, useState } from "react"
+import { Navigate, Outlet, useLocation, useNavigate } from "react-router-dom"
+import { backendUrl } from "../../../lib/client/client"
 import { useMe } from "../../../hooks/api/users"
+import { queryClient } from "../../../lib/query-client"
 import { SearchProvider } from "../../../providers/search-provider/search-provider"
 import { SidebarProvider } from "../../../providers/sidebar-provider"
 
-export const ProtectedRoute = () => {
-  const { user, isLoading } = useMe()
-  const location = useLocation()
+// Must match the SDK's jwtTokenStorageKey in lib/client/client.ts. The
+// Medusa SDK reads its bearer token from this localStorage key on every
+// request, so writing it here gives us an authenticated session as soon
+// as we strip the wa_token from the URL.
+const JWT_TOKEN_STORAGE_KEY =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (typeof __JWT_TOKEN_STORAGE_KEY__ !== "undefined" && __JWT_TOKEN_STORAGE_KEY__) ||
+  "partner_ui_auth_token"
 
-  if (isLoading) {
+type WaAuthResponse = {
+  token: string
+  partner_id: string
+  partner_name?: string
+  redirect: string
+  type: string
+  run_id: string | null
+}
+
+/**
+ * Exchange a WhatsApp deep-link token for a Medusa partner session bearer.
+ * Stores the bearer in localStorage (same key the SDK reads from) so
+ * subsequent useMe() / useQuery() calls are authenticated.
+ *
+ * Returns the redirect path on success, or null on failure (caller falls
+ * through to the normal /login redirect).
+ */
+async function exchangeWaToken(waToken: string): Promise<string | null> {
+  try {
+    const url = new URL(`${backendUrl.replace(/\/$/, "")}/partners/wa-auth`)
+    url.searchParams.set("wa_token", waToken)
+    const resp = await fetch(url.toString(), { credentials: "include" })
+    if (!resp.ok) return null
+    const data = (await resp.json()) as WaAuthResponse
+    if (!data?.token) return null
+    window.localStorage.setItem(JWT_TOKEN_STORAGE_KEY, data.token)
+    return data.redirect || "/"
+  } catch {
+    return null
+  }
+}
+
+export const ProtectedRoute = () => {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const params = new URLSearchParams(location.search)
+  const waToken = params.get("wa_token")
+
+  // While exchanging a wa_token we hold the auth check open so the
+  // ProtectedRoute doesn't flicker through the /login redirect on the
+  // first paint. State is null when there's nothing to exchange.
+  const [waExchangeState, setWaExchangeState] = useState<
+    "pending" | "done" | "failed" | null
+  >(waToken ? "pending" : null)
+
+  useEffect(() => {
+    if (!waToken) return
+    let cancelled = false
+    ;(async () => {
+      const redirect = await exchangeWaToken(waToken)
+      if (cancelled) return
+      if (redirect) {
+        // Strip the wa_token from the URL so it doesn't leak via shares
+        // and so a refresh doesn't re-run the exchange. Use replace so
+        // the back button doesn't return to the token URL.
+        // useMe() is invalidated to pick up the new bearer.
+        queryClient.invalidateQueries({ queryKey: ["users", "me"] })
+        setWaExchangeState("done")
+        navigate(redirect, { replace: true })
+      } else {
+        setWaExchangeState("failed")
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [waToken, navigate])
+
+  const { user, isLoading } = useMe({
+    // Skip the `me` query while we're still exchanging the wa_token —
+    // it would 401 on the first paint and trigger the login redirect.
+    enabled: waExchangeState !== "pending",
+  })
+
+  if (waExchangeState === "pending" || isLoading) {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <Spinner className="text-ui-fg-interactive animate-spin" />
@@ -28,3 +110,4 @@ export const ProtectedRoute = () => {
     </SidebarProvider>
   )
 }
+


### PR DESCRIPTION
When a partner clicked a reminder link from WhatsApp, the partner-ui
ProtectedRoute ran its useMe() check before noticing the wa_token
query param, found no session, and bounced the user to /login. The
deep-link's JWT was silently dropped. Two compounding issues fixed
here, plus a defensive trim on the URL builder.

1. partner-ui ProtectedRoute (apps/partner-ui/.../protected-route.tsx)
   - Detect ?wa_token before the auth gate. While the exchange is in
     flight, hold the route in a 'pending' state instead of letting
     useMe() race ahead and trigger /login.
   - Exchange the deep-link for a Medusa session bearer at
     /partners/wa-auth and store it in localStorage under
     partner_ui_auth_token (the SDK's configured jwtTokenStorageKey),
     so subsequent useQuery() calls are authenticated.
   - Strip wa_token from the URL via navigate(replace) so the token
     doesn't leak via shares and a refresh doesn't re-run the exchange.
   - On exchange failure, fall through to the normal /login redirect
     (with router state preserved).

2. /partners/wa-auth (apps/backend/.../wa-auth/route.ts)
   - The endpoint previously only verified the deep-link JWT and
     returned descriptive JSON; it did NOT issue a Medusa session,
     which made the round-trip useless to the partner-ui.
   - Now: look up the partner, find an auth_identity via Modules.AUTH
     (filtered by app_metadata.partner_id, which the add-partner-admin
     workflow sets via setAuthAppMetadataStep with value=partner.id),
     and sign a Medusa-shaped bearer with the configured http.jwtSecret
     matching the payload layout produced by Medusa's
     generateJwtTokenForAuthIdentity helper (actor_id / actor_type /
     auth_identity_id / app_metadata.partner_id).
   - Strip ':reminder:YYYY-MM-DD' synthetic suffixes from run_id when
     constructing the redirect path — those are dedup keys from the
     reminder dispatcher, not addressable resource ids.

3. generatePartnerDeeplink (apps/backend/.../whatsapp-deeplink.ts)
   - Defensive: strip ':...' suffix from run_id at URL-build time so
     even if upstream callers pass a synthetic id, the final URL path
     and JWT 'run_id' claim are clean. Production-run / design ids are
     ULIDs and never legitimately contain colons.
