### PR TITLE
chore(scripts): harden git cm/ph branch-hygiene tooling

### DIFF
--- a/apps/backend/scripts/commit.sh
+++ b/apps/backend/scripts/commit.sh
@@ -357,20 +357,55 @@ fi
 
 if [ "$NEW_BRANCH_MODE" = true ]; then
     # Suggest a default name from the staged paths. The user can always
-    # override; the suggestion is just to save typing.
+    # override; the suggestion is just to save typing. If the default
+    # collides with an existing local branch (typically because today's
+    # name was already used), auto-bump with -2, -3, ... so the prompt
+    # offers something fresh instead of aborting.
     scope_hint=$(suggest_scope)
     default_branch_name="${scope_hint:-feat}/$(date +%Y%m%d)-wip"
-
-    echo -e "\n${BLUE}New branch name (default: ${GREEN}$default_branch_name${BLUE}, press enter to use):${NC}"
-    read new_branch_name
-    new_branch_name="${new_branch_name:-$default_branch_name}"
-
-    # Validate: must not already exist locally.
-    if git show-ref --verify --quiet "refs/heads/$new_branch_name"; then
-        echo -e "${RED}Branch '$new_branch_name' already exists locally. Aborting.${NC}"
-        exit 1
+    if git show-ref --verify --quiet "refs/heads/$default_branch_name"; then
+        suffix=2
+        while git show-ref --verify --quiet "refs/heads/${default_branch_name}-${suffix}"; do
+            suffix=$((suffix + 1))
+            [ "$suffix" -gt 50 ] && break
+        done
+        default_branch_name="${default_branch_name}-${suffix}"
     fi
 
+    # Prompt with up to one retry if the user picks a colliding name.
+    new_branch_name=""
+    for attempt in 1 2; do
+        echo -e "\n${BLUE}New branch name (default: ${GREEN}$default_branch_name${BLUE}, press enter to use):${NC}"
+        read input_name
+        candidate="${input_name:-$default_branch_name}"
+
+        if ! git show-ref --verify --quiet "refs/heads/$candidate"; then
+            new_branch_name="$candidate"
+            break
+        fi
+
+        # Special case: the branch they're trying to create is the one
+        # they're already on. Treat that as "they want to commit here" —
+        # skip the branch dance, fall through to commit on current branch.
+        if [ "$candidate" = "$current_branch" ]; then
+            echo -e "${YELLOW}Already on '$candidate' — skipping branch creation.${NC}"
+            NEW_BRANCH_MODE=false
+            break
+        fi
+
+        if [ "$attempt" = "1" ]; then
+            echo -e "${YELLOW}Branch '$candidate' already exists locally. Pick another name.${NC}"
+        else
+            echo -e "${RED}Branch '$candidate' already exists locally. Aborting.${NC}"
+            exit 1
+        fi
+    done
+fi
+
+# Branch creation runs only if we still need a new branch (the prompt
+# above can flip NEW_BRANCH_MODE off when the candidate equals the
+# current branch).
+if [ "$NEW_BRANCH_MODE" = true ]; then
     echo -e "\n${BLUE}Fetching origin/main...${NC}"
     if ! git fetch origin main 2>&1; then
         echo -e "${RED}Failed to fetch origin/main. Aborting.${NC}"

--- a/apps/backend/scripts/push.sh
+++ b/apps/backend/scripts/push.sh
@@ -67,10 +67,29 @@ fi
 
 # --- Sync + show what will go --------------------------------------------
 if [ "$HAS_UPSTREAM" = true ]; then
-    echo -e "\n${BLUE}Updating local branch with remote changes (rebase)...${NC}"
-    if ! git pull --rebase; then
-        echo -e "${RED}Rebase failed. Resolve conflicts and try again.${NC}"
-        exit 1
+    # Refresh the remote ref so the ahead/behind counts below reflect
+    # what's actually on origin, not a stale tracking branch.
+    echo -e "\n${BLUE}Fetching ${current_branch} from origin...${NC}"
+    if ! git fetch origin "$current_branch" 2>&1; then
+        echo -e "${YELLOW}Fetch failed — proceeding with last-known remote state.${NC}"
+    fi
+
+    # Skip the rebase entirely when there's nothing to rebase onto. This
+    # avoids the common gotcha where the working tree has parked,
+    # unrelated edits and `git pull --rebase` refuses with "You have
+    # unstaged changes" — even though there are zero upstream commits
+    # to integrate. We still rebase when the remote IS ahead, but use
+    # --autostash so the dirty tree is preserved across the operation.
+    behind=$(git rev-list --count HEAD..@{u} 2>/dev/null || echo 0)
+
+    if [ "$behind" -gt 0 ]; then
+        echo -e "${BLUE}Remote is ${behind} commit(s) ahead — rebasing (with autostash)...${NC}"
+        if ! git pull --rebase --autostash; then
+            echo -e "${RED}Rebase failed. Resolve conflicts and try again.${NC}"
+            exit 1
+        fi
+    else
+        echo -e "${GREEN}Already up to date with origin/${current_branch} — skipping rebase.${NC}"
     fi
 
     unpushed_commits=$(git log @{u}..HEAD --oneline 2>/dev/null)
@@ -86,13 +105,27 @@ if [ "$HAS_UPSTREAM" = true ]; then
     echo -e "\n${BLUE}Total commits to push: ${GREEN}$commit_count${NC}"
 else
     echo -e "\n${YELLOW}No upstream tracking branch — first push will set it via --set-upstream.${NC}"
-    unpushed_commits=$(git log --oneline -10 2>/dev/null)
+    # Diff against origin/main (the integration baseline) so we show only
+    # commits unique to this branch. Falls back to a recent-history view
+    # if origin/main isn't available locally.
+    if git rev-parse --verify origin/main >/dev/null 2>&1; then
+        unpushed_commits=$(git log origin/main..HEAD --oneline 2>/dev/null)
+        baseline_label="origin/main"
+    else
+        unpushed_commits=$(git log --oneline -10 2>/dev/null)
+        baseline_label="recent history (origin/main unavailable)"
+    fi
+
+    commit_count=$(printf '%s\n' "$unpushed_commits" | grep -c '^[0-9a-f]')
+
     if [ -z "$unpushed_commits" ]; then
-        echo -e "${RED}No commits to push.${NC}"
+        echo -e "${RED}No commits ahead of $baseline_label — nothing to push.${NC}"
         exit 1
     fi
-    echo -e "\n${BLUE}Recent commits on this branch:${NC}"
+
+    echo -e "\n${BLUE}Commits ahead of ${baseline_label}:${NC}"
     echo -e "${GREEN}$unpushed_commits${NC}"
+    echo -e "\n${BLUE}Total commits to push: ${GREEN}$commit_count${NC}"
 fi
 
 # --- Confirm + push ------------------------------------------------------


### PR DESCRIPTION
Two pain points discovered while dogfooding the new --new-branch flow.

commit.sh — handle name collisions gracefully:
- When the auto-suggested default branch name (`<scope>/YYYYMMDD-wip`)
  already exists locally (typically because today's slot was already
  used), bump the suffix to `-2`, `-3`, ... up to 50 instead of
  refusing to start.
- When the user types a colliding name, prompt 'pick another' once
  before aborting, so a typo doesn't kill the whole composition flow.
- Special case: if the candidate is the branch the user is already
  on, skip the branch-creation dance and continue committing in
  place. Saves a confused 'why is this aborting' when a previous
  attempt already created the branch.

push.sh — stop the rebase from blocking on parked dirty trees:
- The previous behaviour ran `git pull --rebase` unconditionally
  whenever an upstream existed. With unrelated parked edits in the
  working tree (very common during multi-PR sequences), git refused:
  'cannot pull with rebase: You have unstaged changes', killing the
  push even when there were zero upstream commits to rebase onto.
- Now: fetch the remote ref first, count how many commits it's ahead
  of HEAD, and:
    * 0 ahead  → skip the rebase entirely (the typical case after a
      fresh push or when no one else has pushed to the same branch).
    * >0 ahead → run `git pull --rebase --autostash`, which stashes
      unstaged changes around the rebase and re-applies them after.
  Both paths preserve the parked working-tree state instead of
  refusing the operation.
