### PR TITLE
feat(whatsapp): media-header reminder templates + dynamic per-send image

### DIFF
--- a/apps/backend/src/modules/visual_flows/operations/send-whatsapp.ts
+++ b/apps/backend/src/modules/visual_flows/operations/send-whatsapp.ts
@@ -66,6 +66,15 @@ export const sendWhatsAppOperation: OperationDefinition = {
         'Template body placeholder values (strings). Each supports {{ }} interpolation. ' +
           "Order matches {{1}}, {{2}}, ... in the template body."
       ),
+    header_image_url: z
+      .string()
+      .optional()
+      .describe(
+        'Optional public HTTPS image URL passed as the template HEADER parameter. ' +
+          "Required if the template was approved with an IMAGE header AND you want " +
+          "a per-send image instead of the example one. Empty string is treated as " +
+          "\"no parameter\" — Meta uses the template's example_url instead. Supports {{ }} interpolation."
+      ),
 
     // Text-mode field
     body: z
@@ -303,15 +312,40 @@ export const sendWhatsAppOperation: OperationDefinition = {
             )
           : []
 
-        const components =
-          variableValues.length > 0
-            ? [
-                {
-                  type: "body" as const,
-                  parameters: variableValues.map((text) => ({ type: "text", text })),
-                },
-              ]
-            : []
+        // Optional HEADER parameter — only set when the operator passes a
+        // header_image_url AND it resolves to a non-empty value. Templates
+        // approved with an IMAGE header otherwise fall back to the example
+        // URL declared at template-creation time, so omitting this is safe.
+        // Order matters in Meta's API: HEADER must come before BODY.
+        const headerImageUrl = options.header_image_url
+          ? interpolateString(options.header_image_url, dataChain).trim()
+          : ""
+
+        type TemplateComponent = {
+          type: "body" | "button" | "header"
+          parameters: Array<{
+            type: string
+            text?: string
+            image?: { link: string }
+          }>
+          sub_type?: string
+          index?: number
+        }
+        const components: TemplateComponent[] = []
+        if (headerImageUrl) {
+          components.push({
+            type: "header",
+            parameters: [
+              { type: "image", image: { link: headerImageUrl } },
+            ],
+          })
+        }
+        if (variableValues.length > 0) {
+          components.push({
+            type: "body",
+            parameters: variableValues.map((text) => ({ type: "text", text })),
+          })
+        }
 
         // Audit context — picked up by WhatsAppService and written to the
         // Notification Module after Meta accepts the send. trigger_type

--- a/apps/backend/src/scripts/manage-whatsapp-templates.ts
+++ b/apps/backend/src/scripts/manage-whatsapp-templates.ts
@@ -400,6 +400,20 @@ async function fetchTemplateStatus(
 function buildComponents(lang: TemplateLanguageVariant): any[] {
   const components: any[] = []
 
+  // HEADER must come first in Meta's components array. Currently only
+  // IMAGE format is wired through — VIDEO / DOCUMENT slot in here when
+  // we need them. `header_handle` accepts a public URL during template
+  // creation; Meta downloads it to generate the approval-review preview
+  // and uses it as the fallback header when sends don't pass a per-
+  // message header parameter.
+  if (lang.header) {
+    components.push({
+      type: "HEADER",
+      format: lang.header.format,
+      example: { header_handle: [lang.header.example_url] },
+    })
+  }
+
   const body: any = { type: "BODY", text: lang.body }
   if (lang.examples && lang.examples.length > 0) {
     body.example = { body_text: [lang.examples] }

--- a/apps/backend/src/scripts/seed-partner-run-whatsapp-flow.ts
+++ b/apps/backend/src/scripts/seed-partner-run-whatsapp-flow.ts
@@ -440,6 +440,14 @@ const FLOW_DEF = {
         mode: "template",
         template_name: "{{ resolve_template.template_name }}",
         variables: "{{ resolve_template.variables }}",
+        // Pass the design thumbnail as the template HEADER parameter.
+        // Templates with an IMAGE header are exempt from WhatsApp's
+        // 24-hour customer-care window, so reminders to partners who
+        // haven't replied recently will still deliver the image. When
+        // resolve_template.design_image_url is empty, send_whatsapp
+        // silently omits the parameter and Meta uses the template's
+        // example image fallback — never sends a broken header.
+        header_image_url: "{{ resolve_template.design_image_url }}",
         // Honor the partner's saved language preference. Empty string
         // (no preference on file) lets send_whatsapp's own resolver
         // chain (conv metadata → phone heuristic → env → "hi") take over.

--- a/apps/backend/src/scripts/whatsapp-templates/partner-run-templates.ts
+++ b/apps/backend/src/scripts/whatsapp-templates/partner-run-templates.ts
@@ -23,6 +23,30 @@ export type ButtonSpec =
   | { type: "URL"; text: string; url: string }
   | { type: "PHONE_NUMBER"; text: string; phone_number: string }
 
+/**
+ * Optional media header attached to a template. Templates with a media
+ * header are exempt from WhatsApp's 24-hour customer-care window — the
+ * primary reason we use them for reminders that need to reach partners
+ * who haven't replied recently.
+ *
+ * Meta needs an `example_url` (publicly accessible) at approval time so
+ * its reviewers can preview the rendering. At send time the runtime
+ * passes the per-message image as a header parameter; if the runtime
+ * doesn't pass one, recipients see the example image.
+ *
+ * Today only IMAGE is wired through; VIDEO / DOCUMENT extensions slot
+ * in at the same `format` field with their respective example URLs.
+ */
+export type HeaderSpec = {
+  format: "IMAGE"
+  /**
+   * Publicly-reachable URL Meta downloads during template review. Used
+   * as the fallback header when the runtime doesn't provide a per-send
+   * image parameter. Should point at a representative brand asset.
+   */
+  example_url: string
+}
+
 export interface TemplateLanguageVariant {
   /** BCP-47 / Meta locale code, e.g. "en", "hi", "en_US". */
   language: string
@@ -39,6 +63,14 @@ export interface TemplateLanguageVariant {
   buttons?: ButtonSpec[]
   /** Optional short footer line. Meta caps at 60 chars. */
   footer?: string
+  /**
+   * Optional media header. When set, the management script emits a
+   * `HEADER` component during template create — making the template
+   * eligible for sends outside the 24-hour customer-care window.
+   * Same header config typically applies across languages, but it's
+   * declared per-variant so language-specific assets are possible.
+   */
+  header?: HeaderSpec
 }
 
 export interface TemplateSpec {
@@ -46,6 +78,20 @@ export interface TemplateSpec {
   category: "UTILITY" | "MARKETING" | "AUTHENTICATION"
   languages: TemplateLanguageVariant[]
 }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Shared header example
+//
+// The 3 reminder templates share the same example image. Meta downloads this
+// URL during template review to render the preview, and falls back to it at
+// send time when the runtime doesn't pass a per-message header parameter.
+// Override via env so staging can point at a sample asset without editing
+// the spec file.
+// ──────────────────────────────────────────────────────────────────────────────
+
+const REMINDER_HEADER_EXAMPLE_URL =
+  process.env.WHATSAPP_REMINDER_HEADER_EXAMPLE_URL ||
+  "https://cicilabel.com/static/whatsapp/reminder-header.jpg"
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Template definitions
@@ -161,9 +207,11 @@ const TEMPLATE_COMPLETED: TemplateSpec = {
  *   {{3}} run id
  *   {{4}} days since assignment
  *
- * No buttons — keep informational. The send_image follow-up node in the
- * existing wildcard flow attaches the design thumbnail + a no-password
- * portal deep-link as a separate WhatsApp message after the template.
+ * No buttons — keep informational. The IMAGE header carries the design
+ * thumbnail at send time, so this single template fully replaces the
+ * old "template + send_image follow-up" pair (which kept failing for
+ * any partner outside the 24-hour customer-care window — raw media
+ * sends are blocked there, but a media-header template is exempt).
  */
 const TEMPLATE_REMINDER_PENDING: TemplateSpec = {
   name: "jyt_production_run_reminder_pending_v1",
@@ -171,6 +219,10 @@ const TEMPLATE_REMINDER_PENDING: TemplateSpec = {
   languages: [
     {
       language: "en",
+      header: {
+        format: "IMAGE",
+        example_url: REMINDER_HEADER_EXAMPLE_URL,
+      },
       body:
         "Hi {{1}}, a quick reminder — production run {{3}} for design " +
         "{{2}} has been waiting for your response.\n\n" +
@@ -181,6 +233,10 @@ const TEMPLATE_REMINDER_PENDING: TemplateSpec = {
     },
     {
       language: "hi",
+      header: {
+        format: "IMAGE",
+        example_url: REMINDER_HEADER_EXAMPLE_URL,
+      },
       body:
         "नमस्ते {{1}}, याद दिला रहे हैं — डिज़ाइन {{2}} के लिए प्रोडक्शन " +
         "रन {{3}} अभी भी आपके उत्तर की प्रतीक्षा में है।\n\n" +
@@ -206,6 +262,10 @@ const TEMPLATE_REMINDER_NOT_STARTED: TemplateSpec = {
   languages: [
     {
       language: "en",
+      header: {
+        format: "IMAGE",
+        example_url: REMINDER_HEADER_EXAMPLE_URL,
+      },
       body:
         "Hi {{1}}, just checking in — you've accepted production run " +
         "{{3}} for design {{2}}, but we haven't seen it start yet.\n\n" +
@@ -217,6 +277,10 @@ const TEMPLATE_REMINDER_NOT_STARTED: TemplateSpec = {
     },
     {
       language: "hi",
+      header: {
+        format: "IMAGE",
+        example_url: REMINDER_HEADER_EXAMPLE_URL,
+      },
       body:
         "नमस्ते {{1}}, बस संपर्क कर रहे हैं — आपने डिज़ाइन {{2}} के लिए " +
         "प्रोडक्शन रन {{3}} स्वीकार किया है, लेकिन काम अभी शुरू नहीं " +
@@ -246,6 +310,10 @@ const TEMPLATE_REMINDER_IDLE: TemplateSpec = {
   languages: [
     {
       language: "en",
+      header: {
+        format: "IMAGE",
+        example_url: REMINDER_HEADER_EXAMPLE_URL,
+      },
       body:
         "Hi {{1}}, checking in on production run {{3}} for design {{2}} " +
         "— it's been quiet for a few days.\n\n" +
@@ -257,6 +325,10 @@ const TEMPLATE_REMINDER_IDLE: TemplateSpec = {
     },
     {
       language: "hi",
+      header: {
+        format: "IMAGE",
+        example_url: REMINDER_HEADER_EXAMPLE_URL,
+      },
       body:
         "नमस्ते {{1}}, डिज़ाइन {{2}} के लिए प्रोडक्शन रन {{3}} पर अपडेट " +
         "चाहिए — कुछ दिनों से कोई गतिविधि नहीं है।\n\n" +


### PR DESCRIPTION
WhatsApp Cloud API blocks raw media (free-form) sends outside the 24h
customer-care window — the recipient must have replied to one of our
messages within 24h for a non-template send to land. The reminder flow
sends a TEMPLATE (works anytime) followed by a raw send_image
(`mode='image'`) carrying the design photo. For any partner who
hadn't replied recently, the second op silently failed every time —
visible in messaging_message as paired "read template + failed media"
rows on every reminder dispatch.

Templates with an IMAGE header are exempt from the 24h rule, so the
image rides along on the template itself instead of needing a separate
free-form send. Four coordinated changes here, runnable as one
operator workflow once Meta re-approves.

apps/backend/src/scripts/whatsapp-templates/partner-run-templates.ts
- Add HeaderSpec type (IMAGE format with example_url) and an optional
  `header` field on TemplateLanguageVariant.
- Attach an IMAGE header to all 3 reminder templates (pending,
  not_started, idle) on both en + hi variants. Shared
  REMINDER_HEADER_EXAMPLE_URL constant — env-overridable via
  WHATSAPP_REMINDER_HEADER_EXAMPLE_URL — defaults to a placeholder
  cicilabel.com path. Operator should swap to a real brand asset
  before running replace.

apps/backend/src/scripts/manage-whatsapp-templates.ts
- Extend buildComponents() to emit a HEADER component first when
  lang.header is set (Meta requires HEADER before BODY in components
  array). Templates without a header are unaffected.

apps/backend/src/modules/visual_flows/operations/send-whatsapp.ts
- New optional `header_image_url` field on the operation schema.
  When set and non-empty after interpolation, the operation prepends
  a runtime header parameter (`{type:'image', image:{link:...}}`)
  so each reminder carries the actual design photo instead of the
  template's example image. Empty/omitted falls back to the example
  URL declared at template-create time — never sends a broken header.

apps/backend/src/scripts/seed-partner-run-whatsapp-flow.ts
- Pass resolve_template.design_image_url through to send_whatsapp's
  new header_image_url option, so once Meta approves the updated
  IMAGE-header templates, every reminder lands with the design photo
  in the header — regardless of session state.

Operator workflow once this is merged + deployed:
  1. Update WHATSAPP_REMINDER_HEADER_EXAMPLE_URL (or edit the constant)
     to point at a real publicly-reachable JYT brand image.
  2. MODE=replace CONFIRM_REPLACE=1 \
     npx medusa exec ./src/scripts/manage-whatsapp-templates.ts
     This deletes the existing _v1 reminder templates from Meta and
     recreates them with the IMAGE header.
  3. Wait for Meta approval (UTILITY templates usually <30 min).
  4. Re-seed the visual flow:
     - Delete the existing 'Partner Production Run WhatsApp' flow row
       in admin.
     - npx medusa exec ./src/scripts/seed-partner-run-whatsapp-flow.ts
     so the operation options pick up the new header_image_url field.
  5. The existing send_image follow-up op stays in place for now —
     it's redundant for reminders (the image is in the template) but
     still useful for non-reminder events. Removing it cleanly is a
     follow-up.
