### PR TITLE
fix(jest): handle ESM-only tokenx transitive (@mastra/core dep)

### DIFF
--- a/apps/backend/integration-tests/setup.js
+++ b/apps/backend/integration-tests/setup.js
@@ -56,6 +56,11 @@ try {
   ]
 
   wweModule.waitWorkflowExecutions = async function patchedWaitWorkflowExecutions(container) {
+    // Guard against null container — happens during teardown after a
+    // bootstrap failure (e.g. the tokenx ESM error blocks app start,
+    // then the test runner calls this hook with no container and the
+    // .resolve() crashes, masking the real error).
+    if (!container || typeof container.resolve !== "function") return
     const wfe = container.resolve(Modules.WORKFLOW_ENGINE, { allowUnregistered: true })
     if (!wfe) return
 

--- a/apps/backend/jest.config.js
+++ b/apps/backend/jest.config.js
@@ -4,6 +4,7 @@ loadEnv("test", process.cwd());
 module.exports = {
   setupFiles: ["./integration-tests/setup.js"],
   transform: {
+    // TypeScript / JSX / classic JS — same swc preset as before.
     "^.+\\.[jt]sx?$": [
       "@swc/jest",
       {
@@ -13,9 +14,34 @@ module.exports = {
         },
       },
     ],
+    // ESM-only transitive deps (tokenx via @mastra/core) ship `.mjs`
+    // files. The typescript parser above rejects an ESM body so .mjs
+    // needs its own entry. target=es5 forces CJS output so Jest's
+    // CommonJS runtime can require() it without "Must use import to
+    // load ES Module".
+    "^.+\\.mjs$": [
+      "@swc/jest",
+      {
+        jsc: {
+          parser: { syntax: "ecmascript" },
+          target: "es5",
+        },
+      },
+    ],
   },
+  // Default ignore is "/node_modules/" — too broad for ESM transitives.
+  // The pattern below matches `node_modules/` only when the rest of the
+  // path does NOT contain "tokenx", letting tokenx (the @mastra/core
+  // transitive that triggered the original "Must use import to load ES
+  // Module" failure) reach the .mjs transform above. Add other ESM-only
+  // transitives by extending the negative lookahead — keep tight; broad
+  // patterns slow every test run because more files get transformed.
+  transformIgnorePatterns: [
+    "node_modules/(?!.*tokenx)",
+    "\\.pnp\\.[^\\/]+$",
+  ],
   testEnvironment: "node",
-  moduleFileExtensions: ["js", "ts", "tsx", "jsx", "json"],
+  moduleFileExtensions: ["js", "mjs", "ts", "tsx", "jsx", "json"],
   modulePathIgnorePatterns: ["dist/", "<rootDir>/.medusa/"],
   forceExit: true,
 };


### PR DESCRIPTION
Every shared-batch CI run that touched a mastra-importing module path
failed at app bootstrap with:

  Must use import to load ES Module:
    .../node_modules/.pnpm/tokenx@1.3.0/node_modules/tokenx/dist/index.mjs

@mastra/core's CJS bundle does require("tokenx"), but tokenx@1.3.0
ships only as .mjs. Jest's CommonJS runtime can't require() ESM
without the file having been transformed to CJS first — and the
project's swc/jest preset only matches .ts/.tsx/.js/.jsx, AND the
default transformIgnorePatterns ('/node_modules/') skips everything
in node_modules from transformation. Net effect: tokenx's .mjs is
required as-is and the loader throws.

Two-line fix to jest.config.js:

  1. Add a separate transform entry for .mjs that uses swc's
     ecmascript parser (the typescript parser rejects ESM bodies).
     Output target stays es5 so Jest's CJS runtime can require() it.
  2. Replace the default transformIgnorePatterns with a pattern that
     ignores 'node_modules/' EXCEPT paths containing 'tokenx'. Verified
     empirically with a small Node REPL — pnpm puts the file at
     '.pnpm/tokenx@1.3.0/node_modules/tokenx/dist/index.mjs' so the
     pattern catches it whether at the top-level or nested.

Also adds a defensive null-guard to the patched waitWorkflowExecutions
in integration-tests/setup.js. When app bootstrap fails (the original
tokenx error), the test runner calls the teardown hook with no
container and container.resolve(...) crashed, masking the real error
behind 'Cannot read properties of null (reading resolve)'. Now exits
cleanly when the container is absent so the underlying bootstrap
failure surfaces in logs.
