### PR TITLE
feat: abandoned-carts filter fix + visitor intent scoring foundation

### DIFF
--- a/apps/backend/src/admin/routes/abandoned-carts/page.tsx
+++ b/apps/backend/src/admin/routes/abandoned-carts/page.tsx
@@ -171,8 +171,14 @@ const AbandonedCartsPage = () => {
   const [filtering, setFiltering] = useState<DataTableFilteringState>({});
   const [search, setSearch] = useState<string>("");
 
+  // Filter clicks are discrete events — don't debounce them. Medusa's
+  // FilterMenu fires onFilteringChange three times per interaction
+  // (pick filter → pick value → close popover); a debounce here lets
+  // the close fire against stale state and the popover's onOpenChange
+  // helpfully calls instance.removeFilter, wiping the value the user
+  // just picked. Debouncing only ever made sense for the search input.
   const handleFilterChange = useCallback(
-    debounce((newFilters: DataTableFilteringState) => setFiltering(newFilters), 300),
+    (newFilters: DataTableFilteringState) => setFiltering(newFilters),
     [],
   );
 

--- a/apps/backend/src/api/web/ad-planning/intent/route.ts
+++ b/apps/backend/src/api/web/ad-planning/intent/route.ts
@@ -1,0 +1,127 @@
+/**
+ * Web Visitor Intent API
+ * Public read-only endpoint that aggregates browsing signals for an
+ * anonymous visitor (scroll depth, time on site, pageviews, engagement)
+ * into a 0-100 intent score plus low/medium/high band.
+ *
+ * Storefront callers use this to decide whether to show a soft
+ * email-capture prompt: high intent → modal, medium → inline field
+ * in the mini-cart, low → nothing (likely a bot or 1-pageview bounce).
+ *
+ * Pure read — no writes. Score is computed live; we don't persist a
+ * VisitorScore row because (a) `customer_score` requires a person_id
+ * we don't have for anonymous traffic and (b) the underlying signals
+ * already live in `analytics_event` and `conversion` so caching adds
+ * staleness without saving meaningful work for a single-visitor query.
+ */
+
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import { z } from "@medusajs/framework/zod";
+import { AD_PLANNING_MODULE } from "../../../../modules/ad-planning";
+import { ANALYTICS_MODULE } from "../../../../modules/analytics";
+
+const QuerySchema = z.object({
+  visitor_id: z.string().min(1),
+  // Default to 24h. Anything larger than 7d is rejected — cart-recovery
+  // signals decay fast and a wider window mostly amortizes noise.
+  window_hours: z
+    .preprocess(
+      (v) => (v == null || v === "" ? undefined : Number(v)),
+      z.number().int().min(1).max(168).default(24),
+    ),
+});
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const parsed = QuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    res.status(400).json({ error: "invalid_query", issues: parsed.error.issues });
+    return;
+  }
+  const { visitor_id, window_hours } = parsed.data;
+  const since = new Date(Date.now() - window_hours * 3600 * 1000);
+
+  const adPlanning = req.scope.resolve(AD_PLANNING_MODULE) as any;
+  const analytics = req.scope.resolve(ANALYTICS_MODULE) as any;
+
+  // Pageviews + engagement flag from analytics_event.
+  // listAnalyticsEvents returns rows in insertion order; we just need
+  // counts and a presence check, so a single fetch (capped) is fine.
+  const events = await analytics.listAnalyticsEvents(
+    { visitor_id, timestamp: { $gte: since } },
+    { take: 1000, order: { timestamp: "DESC" } },
+  );
+
+  let pageviews = 0;
+  let hasEngagement = false;
+  for (const e of events) {
+    if (e.event_type === "pageview") pageviews++;
+    if (e.event_name === "page_engagement") hasEngagement = true;
+  }
+
+  // Scroll depth and time-on-site from conversion rows.
+  // The storefront tracker emits scroll_depth at thresholds (25/50/75/90/100)
+  // and time_on_site at thresholds (30/60/120/...). MAX per page is the
+  // signal we want — summing thresholds would double-count progress.
+  const conversions = await adPlanning.listConversions(
+    { visitor_id, converted_at: { $gte: since } },
+    { take: 1000, order: { converted_at: "DESC" } },
+  );
+
+  // Per-page best signals so we don't sum threshold-cumulative rows.
+  const perPage = new Map<string, { maxScroll: number; maxTime: number }>();
+  for (const c of conversions) {
+    const md = (c.metadata ?? {}) as Record<string, any>;
+    const page = (md.page as string | undefined) ?? "_unknown";
+    const entry = perPage.get(page) ?? { maxScroll: 0, maxTime: 0 };
+    if (c.conversion_type === "scroll_depth") {
+      const d = Number(md.depth ?? 0);
+      if (Number.isFinite(d) && d > entry.maxScroll) entry.maxScroll = d;
+    } else if (c.conversion_type === "time_on_site") {
+      const t = Number(md.seconds ?? 0);
+      if (Number.isFinite(t) && t > entry.maxTime) entry.maxTime = t;
+    } else if (c.conversion_type === "page_engagement") {
+      // Reinforce the engagement flag from analytics_event in case the
+      // two streams diverged.
+      hasEngagement = true;
+    }
+    perPage.set(page, entry);
+  }
+
+  let maxScrollDepth = 0;
+  let totalTimeOnSite = 0;
+  for (const v of perPage.values()) {
+    if (v.maxScroll > maxScrollDepth) maxScrollDepth = v.maxScroll;
+    totalTimeOnSite += v.maxTime;
+  }
+
+  const lastSeenAt = events[0]?.timestamp ?? null;
+
+  const { score, level, breakdown } = adPlanning.computeIntentScore({
+    pageviews,
+    maxScrollDepth,
+    totalTimeOnSite,
+    hasEngagement,
+  });
+
+  res.status(200).json({
+    visitor_id,
+    score,
+    level,
+    breakdown,
+    signals: {
+      pageviews,
+      unique_pages: perPage.size,
+      max_scroll_depth: maxScrollDepth,
+      total_time_on_site_seconds: totalTimeOnSite,
+      has_engagement: hasEngagement,
+      last_seen_at: lastSeenAt,
+    },
+    window_hours,
+    calculated_at: new Date().toISOString(),
+  });
+};
+
+// Public endpoint — visitor_id is a client-controlled cookie, so the
+// caller can only read their own (or anyone else's, which exposes only
+// non-sensitive engagement counts).
+export const AUTHENTICATE = false;

--- a/apps/backend/src/modules/ad-planning/__tests__/compute-intent-score.unit.spec.ts
+++ b/apps/backend/src/modules/ad-planning/__tests__/compute-intent-score.unit.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for AdPlanningService.computeIntentScore — the pure
+ * scoring helper used by GET /web/ad-planning/intent.
+ *
+ * We instantiate the service directly with no models so we can call the
+ * helper without booting Medusa. computeIntentScore touches no models,
+ * so the empty MedusaService base is harmless.
+ */
+
+// MedusaService factory needs the framework utils; we mock the whole
+// `model` DSL with a self-returning Proxy so every `.id()/.text()/
+// .enum()/.json()/.belongsTo()/.hasMany()/.primaryKey()/.unique()/...`
+// chain in the model files works without us listing each method.
+jest.mock("@medusajs/framework/utils", () => {
+  const builder: any = new Proxy(() => builder, {
+    get: (_t, prop) => {
+      if (prop === "then") return undefined; // not a thenable
+      return () => builder;
+    },
+  });
+  return {
+    MedusaService: () =>
+      class {
+        constructor(..._args: any[]) {}
+      },
+    model: new Proxy(
+      {},
+      {
+        get: () => () => builder,
+      },
+    ),
+  };
+});
+
+import AdPlanningService from "../service";
+
+describe("computeIntentScore", () => {
+  const svc = new AdPlanningService();
+
+  it("returns 0/low for an empty signal set", () => {
+    const out = svc.computeIntentScore({});
+    expect(out.score).toBe(0);
+    expect(out.level).toBe("low");
+  });
+
+  it("scores the privacy-policy reader (visitor_kkuevqojk7nmoi88zvm) as high", () => {
+    // 7 pageviews, 100% scroll, 624s on site, has_engagement → real prod row
+    const out = svc.computeIntentScore({
+      pageviews: 7,
+      maxScrollDepth: 100,
+      totalTimeOnSite: 624,
+      hasEngagement: true,
+    });
+    // 20 (pv cap) + 30 (scroll cap) + 40 (time cap) + 10 (engagement) = 100
+    expect(out.score).toBe(100);
+    expect(out.level).toBe("high");
+  });
+
+  it("scores a one-pageview bouncer (likely bot) as low", () => {
+    const out = svc.computeIntentScore({
+      pageviews: 1,
+      maxScrollDepth: 0,
+      totalTimeOnSite: 0,
+      hasEngagement: false,
+    });
+    // 5 + 0 + 0 + 0 = 5
+    expect(out.score).toBe(5);
+    expect(out.level).toBe("low");
+  });
+
+  it("crosses into medium at moderate browsing", () => {
+    // 3 pageviews (15) + 50% scroll (15) → 30
+    const out = svc.computeIntentScore({
+      pageviews: 3,
+      maxScrollDepth: 50,
+      totalTimeOnSite: 0,
+      hasEngagement: false,
+    });
+    expect(out.score).toBe(30);
+    expect(out.level).toBe("medium");
+  });
+
+  it("caps each component at its weight ceiling", () => {
+    // Throw absurd numbers and verify nothing exceeds the cap.
+    const out = svc.computeIntentScore({
+      pageviews: 999,
+      maxScrollDepth: 999, // logically impossible but defensive
+      totalTimeOnSite: 999_999,
+      hasEngagement: true,
+    });
+    expect(out.score).toBe(100);
+    expect(out.breakdown.pageviews).toBeLessThanOrEqual(20);
+    expect(out.breakdown.scroll).toBeLessThanOrEqual(30);
+    expect(out.breakdown.time).toBeLessThanOrEqual(40);
+    expect(out.breakdown.engagement).toBe(10);
+  });
+
+  it("treats engagement as a binary 10-point bump", () => {
+    const without = svc.computeIntentScore({ pageviews: 4, maxScrollDepth: 50 });
+    const withE = svc.computeIntentScore({
+      pageviews: 4,
+      maxScrollDepth: 50,
+      hasEngagement: true,
+    });
+    expect(withE.score - without.score).toBe(10);
+  });
+});

--- a/apps/backend/src/modules/ad-planning/service.ts
+++ b/apps/backend/src/modules/ad-planning/service.ts
@@ -141,6 +141,45 @@ class AdPlanningService extends MedusaService({
   }
 
   /**
+   * Compute a 0-100 intent score for an anonymous visitor from
+   * already-aggregated browsing signals.
+   *
+   * Caller is responsible for the I/O (querying analytics_event /
+   * conversion). This function is pure so it can be unit-tested and
+   * reused from any route or workflow.
+   *
+   * Signal weights tuned against current prod data: a visitor who
+   * scrolled 100% AND spent 400s on a page hits ~70 (high) without
+   * any pageviews counted. Bots that load one page and bounce
+   * deterministically score 5 (low) — exactly the behavior we want.
+   */
+  computeIntentScore(signals: {
+    pageviews?: number;
+    maxScrollDepth?: number; // 0-100
+    totalTimeOnSite?: number; // seconds
+    hasEngagement?: boolean;
+  }): { score: number; level: "low" | "medium" | "high"; breakdown: Record<string, number> } {
+    const pageviewsPts = Math.min(20, (signals.pageviews ?? 0) * 5);
+    const scrollPts = Math.min(30, (signals.maxScrollDepth ?? 0) * 0.3);
+    const timePts = Math.min(40, (signals.totalTimeOnSite ?? 0) / 10);
+    const engagementPts = signals.hasEngagement ? 10 : 0;
+
+    const score = Math.round(pageviewsPts + scrollPts + timePts + engagementPts);
+    const level = score >= 70 ? "high" : score >= 30 ? "medium" : "low";
+
+    return {
+      score,
+      level,
+      breakdown: {
+        pageviews: Math.round(pageviewsPts),
+        scroll: Math.round(scrollPts),
+        time: Math.round(timePts),
+        engagement: engagementPts,
+      },
+    };
+  }
+
+  /**
    * Resolve UTM campaign to AdCampaign ID
    * Tries exact match first, then fuzzy matching
    */

--- a/apps/backend/src/scripts/check-visitor-intent.ts
+++ b/apps/backend/src/scripts/check-visitor-intent.ts
@@ -1,0 +1,253 @@
+/**
+ * Verify the intent-scoring pipeline end-to-end against synthetic data.
+ *
+ * Seeds three fixture visitors (high / medium / low) with realistic
+ * analytics_event + conversion rows, runs the same aggregation
+ * GET /web/ad-planning/intent uses, and prints expected vs actual.
+ *
+ * Idempotent — fixture rows are keyed on stable visitor_ids so re-runs
+ * just delete the previous fixtures before re-seeding.
+ *
+ *   npx medusa exec ./src/scripts/check-visitor-intent.ts
+ */
+
+import { ExecArgs } from "@medusajs/framework/types";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
+import { AD_PLANNING_MODULE } from "../modules/ad-planning";
+import { ANALYTICS_MODULE } from "../modules/analytics";
+
+type Fixture = {
+  visitorId: string;
+  expectedLevel: "low" | "medium" | "high";
+  expectedScoreMin: number;
+  expectedScoreMax: number;
+  pageviews: number;
+  pageEngagements: number;
+  scrollDepths: Array<{ page: string; depth: number }>;
+  timeOnSite: Array<{ page: string; seconds: number }>;
+};
+
+const FIXTURES: Fixture[] = [
+  {
+    visitorId: "visitor_test_high_intent",
+    expectedLevel: "high",
+    expectedScoreMin: 70,
+    expectedScoreMax: 100,
+    pageviews: 7,
+    pageEngagements: 2,
+    scrollDepths: [
+      { page: "/products/winter-coat", depth: 25 },
+      { page: "/products/winter-coat", depth: 50 },
+      { page: "/products/winter-coat", depth: 75 },
+      { page: "/products/winter-coat", depth: 100 },
+    ],
+    timeOnSite: [
+      { page: "/products/winter-coat", seconds: 30 },
+      { page: "/products/winter-coat", seconds: 60 },
+      { page: "/products/winter-coat", seconds: 120 },
+      { page: "/products/winter-coat", seconds: 300 },
+    ],
+  },
+  {
+    visitorId: "visitor_test_medium_intent",
+    expectedLevel: "medium",
+    expectedScoreMin: 30,
+    expectedScoreMax: 69,
+    pageviews: 3,
+    pageEngagements: 0,
+    scrollDepths: [{ page: "/categories/coats", depth: 50 }],
+    timeOnSite: [{ page: "/categories/coats", seconds: 30 }],
+  },
+  {
+    visitorId: "visitor_test_low_intent",
+    expectedLevel: "low",
+    expectedScoreMin: 0,
+    expectedScoreMax: 29,
+    pageviews: 1,
+    pageEngagements: 0,
+    scrollDepths: [],
+    timeOnSite: [],
+  },
+];
+
+const FIXTURE_WEBSITE_ID = "01TESTINTENTFIXTUREWEBSITE";
+
+export default async function checkVisitorIntent({ container }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER);
+  const adPlanning = container.resolve(AD_PLANNING_MODULE) as any;
+  const analytics = container.resolve(ANALYTICS_MODULE) as any;
+
+  logger.info("─".repeat(70));
+  logger.info("Intent-score verification — seeding fixtures and re-running aggregation");
+  logger.info("─".repeat(70));
+
+  for (const fx of FIXTURES) {
+    // Wipe any prior run for this visitor_id so the script is idempotent.
+    const oldEvents = await analytics.listAnalyticsEvents({ visitor_id: fx.visitorId });
+    if (oldEvents.length) {
+      await analytics.deleteAnalyticsEvents(oldEvents.map((e: any) => e.id));
+    }
+    const oldConversions = await adPlanning.listConversions({ visitor_id: fx.visitorId });
+    if (oldConversions.length) {
+      await adPlanning.deleteConversions(oldConversions.map((c: any) => c.id));
+    }
+
+    // Seed pageviews + engagement events.
+    const eventsToCreate: any[] = [];
+    for (let i = 0; i < fx.pageviews; i++) {
+      eventsToCreate.push({
+        website_id: FIXTURE_WEBSITE_ID,
+        visitor_id: fx.visitorId,
+        session_id: `session_test_${fx.visitorId}`,
+        event_type: "pageview",
+        pathname: "/products/winter-coat",
+        timestamp: new Date(Date.now() - i * 1000),
+      });
+    }
+    for (let i = 0; i < fx.pageEngagements; i++) {
+      eventsToCreate.push({
+        website_id: FIXTURE_WEBSITE_ID,
+        visitor_id: fx.visitorId,
+        session_id: `session_test_${fx.visitorId}`,
+        event_type: "custom_event",
+        event_name: "page_engagement",
+        pathname: "/products/winter-coat",
+        metadata: { page: "/products/winter-coat", time_on_page: 300, max_scroll_depth: 100 },
+        timestamp: new Date(),
+      });
+    }
+    if (eventsToCreate.length) {
+      await analytics.createAnalyticsEvents(eventsToCreate);
+    }
+
+    // Seed conversion rows for scroll depth + time on site.
+    const conversionsToCreate: any[] = [];
+    for (const sd of fx.scrollDepths) {
+      conversionsToCreate.push({
+        website_id: FIXTURE_WEBSITE_ID,
+        conversion_type: "scroll_depth",
+        visitor_id: fx.visitorId,
+        session_id: `session_test_${fx.visitorId}`,
+        currency: "INR",
+        attribution_model: "last_click",
+        platform: "direct",
+        converted_at: new Date(),
+        metadata: { page: sd.page, depth: sd.depth },
+      });
+    }
+    for (const t of fx.timeOnSite) {
+      conversionsToCreate.push({
+        website_id: FIXTURE_WEBSITE_ID,
+        conversion_type: "time_on_site",
+        visitor_id: fx.visitorId,
+        session_id: `session_test_${fx.visitorId}`,
+        currency: "INR",
+        attribution_model: "last_click",
+        platform: "direct",
+        converted_at: new Date(),
+        metadata: { page: t.page, seconds: t.seconds },
+      });
+    }
+    if (fx.pageEngagements > 0) {
+      conversionsToCreate.push({
+        website_id: FIXTURE_WEBSITE_ID,
+        conversion_type: "page_engagement",
+        visitor_id: fx.visitorId,
+        session_id: `session_test_${fx.visitorId}`,
+        currency: "INR",
+        attribution_model: "last_click",
+        platform: "direct",
+        converted_at: new Date(),
+        metadata: {},
+      });
+    }
+    if (conversionsToCreate.length) {
+      await adPlanning.createConversions(conversionsToCreate);
+    }
+
+    // Run the same aggregation the route uses.
+    const since = new Date(Date.now() - 24 * 3600 * 1000);
+    const events = await analytics.listAnalyticsEvents(
+      { visitor_id: fx.visitorId, timestamp: { $gte: since } },
+      { take: 1000, order: { timestamp: "DESC" } },
+    );
+    let pageviews = 0;
+    let hasEngagement = false;
+    for (const e of events) {
+      if (e.event_type === "pageview") pageviews++;
+      if (e.event_name === "page_engagement") hasEngagement = true;
+    }
+
+    const conversions = await adPlanning.listConversions(
+      { visitor_id: fx.visitorId, converted_at: { $gte: since } },
+      { take: 1000, order: { converted_at: "DESC" } },
+    );
+    const perPage = new Map<string, { maxScroll: number; maxTime: number }>();
+    for (const c of conversions) {
+      const md = (c.metadata ?? {}) as Record<string, any>;
+      const page = (md.page as string | undefined) ?? "_unknown";
+      const entry = perPage.get(page) ?? { maxScroll: 0, maxTime: 0 };
+      if (c.conversion_type === "scroll_depth") {
+        const d = Number(md.depth ?? 0);
+        if (Number.isFinite(d) && d > entry.maxScroll) entry.maxScroll = d;
+      } else if (c.conversion_type === "time_on_site") {
+        const t = Number(md.seconds ?? 0);
+        if (Number.isFinite(t) && t > entry.maxTime) entry.maxTime = t;
+      } else if (c.conversion_type === "page_engagement") {
+        hasEngagement = true;
+      }
+      perPage.set(page, entry);
+    }
+    let maxScrollDepth = 0;
+    let totalTimeOnSite = 0;
+    for (const v of perPage.values()) {
+      if (v.maxScroll > maxScrollDepth) maxScrollDepth = v.maxScroll;
+      totalTimeOnSite += v.maxTime;
+    }
+
+    const result = adPlanning.computeIntentScore({
+      pageviews,
+      maxScrollDepth,
+      totalTimeOnSite,
+      hasEngagement,
+    });
+
+    const pass =
+      result.level === fx.expectedLevel &&
+      result.score >= fx.expectedScoreMin &&
+      result.score <= fx.expectedScoreMax;
+
+    logger.info("");
+    logger.info(`${pass ? "✅" : "❌"} ${fx.visitorId}`);
+    logger.info(
+      `   signals: pv=${pageviews}  scroll=${maxScrollDepth}  time=${totalTimeOnSite}s  engagement=${hasEngagement}`,
+    );
+    logger.info(
+      `   score=${result.score} level=${result.level} (expected ${fx.expectedLevel}, ${fx.expectedScoreMin}-${fx.expectedScoreMax})`,
+    );
+    logger.info(`   breakdown: ${JSON.stringify(result.breakdown)}`);
+
+    if (!pass) {
+      throw new Error(
+        `Intent score mismatch for ${fx.visitorId}: got ${result.score}/${result.level}, expected ${fx.expectedScoreMin}-${fx.expectedScoreMax}/${fx.expectedLevel}`,
+      );
+    }
+  }
+
+  // Cleanup. Comment this block to inspect rows in the DB after a run.
+  for (const fx of FIXTURES) {
+    const events = await analytics.listAnalyticsEvents({ visitor_id: fx.visitorId });
+    if (events.length) {
+      await analytics.deleteAnalyticsEvents(events.map((e: any) => e.id));
+    }
+    const conversions = await adPlanning.listConversions({ visitor_id: fx.visitorId });
+    if (conversions.length) {
+      await adPlanning.deleteConversions(conversions.map((c: any) => c.id));
+    }
+  }
+
+  logger.info("");
+  logger.info("─".repeat(70));
+  logger.info("All fixtures verified. Cleaned up.");
+  logger.info("─".repeat(70));
+}

--- a/apps/storefront/src/lib/data/cart.ts
+++ b/apps/storefront/src/lib/data/cart.ts
@@ -117,10 +117,15 @@ export async function addToCart({
   variantId,
   quantity,
   countryCode,
+  visitorId,
 }: {
   variantId: string
   quantity: number
   countryCode: string
+  // Read from localStorage("jyt_visitor_id") on the client and passed
+  // through. Lets the backend's intent-scoring endpoint join cart →
+  // analytics_event/conversion rows for cart-recovery prioritization.
+  visitorId?: string
 }) {
   if (!variantId) {
     throw new Error("Missing variant ID when adding to cart")
@@ -134,6 +139,24 @@ export async function addToCart({
 
   const headers = {
     ...(await getAuthHeaders()),
+  }
+
+  // Stamp visitor_id on cart metadata exactly once, before adding the
+  // line item. We only write when the cart doesn't already carry one
+  // so a returning visitor on a different device doesn't clobber the
+  // original signal source. Failure is non-fatal — never block the
+  // add-to-cart on this best-effort enrichment.
+  if (visitorId && !(cart.metadata as Record<string, unknown> | null)?.visitor_id) {
+    try {
+      await sdk.store.cart.update(
+        cart.id,
+        { metadata: { ...(cart.metadata ?? {}), visitor_id: visitorId } },
+        {},
+        headers,
+      )
+    } catch (e) {
+      console.warn("[addToCart] visitor_id stamp failed", e)
+    }
   }
 
   await sdk.store.cart

--- a/apps/storefront/src/modules/products/components/product-actions/index.tsx
+++ b/apps/storefront/src/modules/products/components/product-actions/index.tsx
@@ -128,10 +128,25 @@ export default function ProductActions({
 
     setIsAdding(true)
 
+    // The analytics snippet (analytics.min.js) writes its visitor id to
+    // localStorage["jyt_visitor_id"]. Reading it here and passing it
+    // through is what links this cart back to the visitor's browsing
+    // signals (scroll depth / time-on-page / pageviews) for the
+    // intent-score join used by cart recovery. Best-effort: if the
+    // analytics script hasn't loaded yet or storage is unavailable
+    // (private mode, SSR), we silently send undefined.
+    let visitorId: string | undefined
+    try {
+      visitorId = window.localStorage.getItem("jyt_visitor_id") ?? undefined
+    } catch {
+      visitorId = undefined
+    }
+
     await addToCart({
       variantId: selectedVariant.id,
       quantity: 1,
       countryCode,
+      visitorId,
     })
 
     setIsAdding(false)


### PR DESCRIPTION
## Summary

Three things shipping together because they form one end-to-end thread for cart recovery:

1. **Fix the broken filters in admin → Abandoned Carts.** Tier worked; idle_minutes and has_shipping silently did nothing. Root cause was a 300ms debounce on filter state — Medusa's FilterMenu fires `onFilteringChange` three times per pick (filter → value → close), and the close raced against stale state, calling `instance.removeFilter` and wiping the selection. Backend was correct all along (verified on prod: tier=all→99, has_items→77, recoverable→8; idle_minutes 30→99 vs 1440→88; has_shipping yes→84 + no→15 = 99).

2. **Add the live intent score plumbing.** New public `GET /web/ad-planning/intent?visitor_id=X&window_hours=24` aggregates the existing `analytics_event` (pageviews, page_engagement) and `conversion` (scroll_depth, time_on_site) tables into a 0–100 score plus low/medium/high band. No new model — the existing `customer_score` requires `person_id` we don't have for anonymous traffic, and a single-visitor read is fast enough not to need caching. Pure helper `computeIntentScore` lives on `AdPlanningService` for reuse.

3. **Stamp `cart.metadata.visitor_id` on storefront add-to-cart.** Closes the loop so the admin / cart-recovery flows can join a cart back to its browsing signals. Best-effort; never blocks the line-item add.

## Why this combination

The Klaviyo/Omnisend pattern is "capture once, attribute forever via cookie." The user already collects rich engagement signals (9,990 events / 4,780 conversions in prod) but the storefront never tied a `cart_id` to a `visitor_id` — so 91 of 99 abandoned carts had no contact info and no way to gauge intent. Stamping the visitor_id is the join key. The intent endpoint reads it. Together they give the storefront mini-cart UI enough to branch contextually (high intent → modal, medium → inline field, low → silent, likely a bot).

## Verification

- **6/6 unit tests** for `computeIntentScore` (`src/modules/ad-planning/__tests__/compute-intent-score.unit.spec.ts`).
- **`src/scripts/check-visitor-intent.ts`** — seeds high/medium/low fixture visitors, runs the same aggregation the route uses, asserts level + score band, cleans up. All three pass on local DB:
  - high: pv=7 scroll=100 time=300s engagement → score=90/high
  - medium: pv=3 scroll=50 time=30s → score=33/medium
  - low: pv=1 → score=5/low
- Backend filter fix verified by hitting prod admin API directly (`Authorization: Basic sk_…`) — every filter combo changes the count as expected.

## Score formula (tunable)

```
pageviews_pts    = min(20, pageviews * 5)            // 4+ pageviews caps
scroll_pts       = min(30, max_scroll_depth * 0.3)   // 100% scroll = 30
time_pts         = min(40, total_time_on_site / 10)  // 400s = 40
engagement_pts   = has_engagement ? 10 : 0
score            = sum, capped at 100
level            = score >= 70 high | >= 30 medium | low
```

## Files

| Area | File | Change |
|---|---|---|
| Admin filter fix | `apps/backend/src/admin/routes/abandoned-carts/page.tsx` | Drop debounce on `handleFilterChange` |
| Score helper | `apps/backend/src/modules/ad-planning/service.ts` | `computeIntentScore` |
| New route | `apps/backend/src/api/web/ad-planning/intent/route.ts` | Public `GET` handler |
| Unit test | `apps/backend/src/modules/ad-planning/__tests__/compute-intent-score.unit.spec.ts` | 6 tests |
| Verification script | `apps/backend/src/scripts/check-visitor-intent.ts` | Seed → assert → cleanup |
| Storefront | `apps/storefront/src/lib/data/cart.ts` | `addToCart` accepts `visitorId`, writes `cart.metadata.visitor_id` |
| Storefront | `apps/storefront/src/modules/products/components/product-actions/index.tsx` | Reads `localStorage["jyt_visitor_id"]`, passes through |

## Out of scope (next PR)

- Admin abandoned-carts: `intent_score` column + `min_intent` filter (waiting on this PR to deploy so cart→visitor data populates).
- Storefront mini-cart UI branching by intent level.

## Test plan

- [x] CI green
- [ ] Deploy → admin Abandoned Carts page → confirm idle_minutes filter changes the result count
- [ ] Same page → confirm has_shipping filter changes the result count
- [ ] On the storefront, add to cart on a product page → check Medusa admin: `cart.metadata.visitor_id` is set and matches `localStorage.jyt_visitor_id` in the browser
- [ ] `curl https://v3.jaalyantra.com/web/ad-planning/intent?visitor_id=visitor_kkuevqojk7nmoi88zvm` → returns a real score (this visitor has 7 pageviews + 100% scroll + 624s on /privacy, expect high)
- [ ] Run `npx medusa exec ./src/scripts/check-visitor-intent.ts` on a non-prod DB → all three fixtures pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)