### PR TITLE
chore: exclude react from shamefully-hoist (fixes Vercel useContext crash)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -3,3 +3,15 @@ SHARP_IGNORE_GLOBAL_LIBVIPS=1
 shamefully-hoist=true
 public-hoist-pattern[]=@medusajs/dashboard
 public-hoist-pattern[]=@medusajs/draft-order
+# React must NOT be hoisted: workspaces pin different majors (storefront 19.0.4,
+# storefront-mobile 19.1.0, backend / partner-ui ^18.3.1). Hoisting picks one
+# winner and the others end up loading a React mismatched against their bundle's
+# react-dom. On Vercel that surfaces as "TypeError: Cannot read properties of
+# null (reading 'useContext')" during prerender of /404 — the symptom of two
+# Reacts in one process. The negation patterns below override the
+# shamefully-hoist (which is equivalent to public-hoist-pattern[]=*) so each
+# workspace resolves react/react-dom from its own node_modules.
+public-hoist-pattern[]=!react
+public-hoist-pattern[]=!react-dom
+public-hoist-pattern[]=!@types/react
+public-hoist-pattern[]=!@types/react-dom


### PR DESCRIPTION
## Summary

Vercel storefront build was failing at prerender of `/404`:

```
TypeError: Cannot read properties of null (reading 'useContext')
  at exports.useContext (/vercel/path0/node_modules/next/node_modules/react-dom/...edge.production.js)
```

Root cause is **two Reacts in one bundle**, caused by `shamefully-hoist=true` in `.npmrc` combined with workspaces pinning different React majors:

| Workspace | React |
|---|---|
| `apps/storefront` | `19.0.4` exact |
| `apps/storefront-starter` | `19.0.4` |
| `apps/storefront-mobile` | `19.1.0` |
| `apps/backend` | `^18.3.1` |
| `apps/partner-ui` | `^18.3.1` |

`shamefully-hoist=true` is equivalent to `public-hoist-pattern[]=*` — only one React can win the hoist to root `node_modules`. Others get a mismatched copy via root resolution, hooks fail to find their context, `useContext` returns `null`. Local builds happened to pass because pre-existing `node_modules` had favorable hoisting; Vercel's clean install hit the bad path.

## Fix

Add negation patterns to `.npmrc` so react / react-dom / @types/* are **not** hoisted to root, while everything else stays hoisted (preserving the phantom-import workaround the comment in `.npmrc` describes):

```ini
public-hoist-pattern[]=!react
public-hoist-pattern[]=!react-dom
public-hoist-pattern[]=!@types/react
public-hoist-pattern[]=!@types/react-dom
```

Each workspace then resolves its own pinned react/react-dom from its own `node_modules`, and Node's resolution algorithm finds them before walking up to root.

## Verification

After `pnpm install --force` locally:

```
apps/storefront         react=19.0.4   react-dom=19.0.4
apps/storefront-starter react=19.0.4   react-dom=19.0.4
apps/backend            react=18.3.1   react-dom=18.3.1
apps/partner-ui         react=18.3.1   react-dom=18.3.1
```

`pnpm build` in `apps/storefront` produces all 1823 static pages cleanly. Backend isolation preserved (still on React 18 per its pin).

## Test plan

- [ ] CI green (mostly that the pnpm install / lockfile remains valid).
- [ ] Vercel preview build for this branch reaches `Generating static pages` and finishes — no `useContext` error.
- [ ] Backend admin (`apps/backend`) still builds: `pnpm --filter @jyt/backend build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)