### PR TITLE
fix(admin): use react-router Link for customer link in abandoned cart detail

### DIFF
--- a/apps/backend/src/admin/routes/abandoned-carts/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/abandoned-carts/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import {
   Container,
   Heading,
@@ -217,9 +217,9 @@ const AbandonedCartDetailPage = () => {
           {cart.customer && (
             <div className="pt-2">
               <Button asChild variant="transparent" size="small">
-                <a href={`/customers/${cart.customer.id}`}>
+                <Link to= {`/customers/${cart.customer.id}`}>
                   View customer →
-                </a>
+                </Link>
               </Button>
             </div>
           )}


### PR DESCRIPTION
Tiny fix — replaces `<a href>` with `<Link to>` so the customer link from the abandoned-cart detail page stays inside the admin SPA instead of triggering a full reload.