### PR TITLE
fix(storefront): drop node-linker=hoisted (fixes Vercel useContext prerender crash)

### DIFF
--- a/apps/storefront/.npmrc
+++ b/apps/storefront/.npmrc
@@ -1,5 +1,18 @@
+# Settings that originated in the standalone storefront repo. Most are
+# already covered by the root .npmrc, but the explicit `shamefully-hoist`
+# stays because some Next.js/storefront transitives expect phantom imports.
+#
+# `node-linker=hoisted` was REMOVED — the standalone repo could safely
+# use it (no peer conflicts, single React major), but in this monorepo
+# the hoisted linker physically copies every dep into each workspace's
+# node_modules. With three React versions across workspaces, the
+# storefront ends up with two physical copies of React 19 — one at
+# apps/storefront/node_modules/react, one in pnpm's .pnpm store. Two
+# copies = two ReactSharedInternals objects, react-dom sets the
+# dispatcher on one, user code reads useContext from the other and
+# gets null. That surfaces as the prerender crash on /404 and /500.
+# Default isolated linker uses symlinks so React identity is preserved.
 shamefully-hoist=true
 strict-peer-dependencies=false
 auto-install-peers=true
-node-linker=hoisted
 prefer-workspace-packages=true


### PR DESCRIPTION
## Summary

Vercel storefront build was failing at prerender of \`/404\` and \`/500\` with a \`useContext is null\` TypeError. Two earlier attempts (turbo env vars in #170, react isolation patterns in #172) didn't catch the actual root cause — both helped get the build to a state where the *real* error was visible, but didn't fix it.

## How I caught it

\`vercel link\` + \`vercel pull --environment=production\` + \`vercel build\` locally reproduces the Vercel build environment exactly. Got the full stack:

\`\`\`
TypeError: Cannot read properties of null (reading 'useContext')
  at exports.useContext (apps/storefront/node_modules/react/cjs/react.production.js:488)
  at g (.next/server/pages/_error.js:1:3911)
  at renderWithHooks (.../react-dom@19.0.4_react@19.0.4/.../react-dom-server.edge.production.js)
\`\`\`

Looking at React 19's source at line 488:

\`\`\`js
exports.useContext = function (Context) {
  return ReactSharedInternals.H.useContext(Context);  // ← line 488
};
\`\`\`

\`ReactSharedInternals.H\` is the dispatcher react-dom installs on React when it starts rendering. If it's null at \`useContext\` time, the dispatcher was set on a **different React module** than the one user code is reading from.

## Root cause

\`apps/storefront/.npmrc\` had \`node-linker=hoisted\` (carried over from the standalone storefront repo's settings). Unlike the default isolated linker which symlinks dependencies, **hoisted linker physically copies** them into each workspace's \`node_modules\`. Inode comparison after a clean install confirms two distinct files for what should be one module:

\`\`\`
apps/storefront/node_modules/react/index.js     → inode 126425844
.pnpm/react@19.0.4/node_modules/react/index.js  → inode 126299342  (different!)
\`\`\`

Both are React 19.0.4. Same code, different files → Node treats them as separate modules → each gets its own \`ReactSharedInternals\` object. react-dom (loaded from \`.pnpm\` store via Next.js internals) sets \`H\` on inode-B's React. Compiled storefront code at \`apps/storefront/.next/server/pages/_error.js\` resolves \`require("react")\` walking up to \`apps/storefront/node_modules/react\` → inode A, where \`H\` is still null.

## Fix

Remove \`node-linker=hoisted\` from \`apps/storefront/.npmrc\`. Default linker uses symlinks; React identity preserved. After clean install:

\`\`\`
apps/storefront/node_modules/react/index.js     → inode 126935552
.pnpm/react@19.0.4/node_modules/react/index.js  → inode 126935552  (same!)
\`\`\`

\`vercel build\` locally now generates all 1823 static pages cleanly:
\`\`\`
✓ Compiled successfully in 4.0s
✓ Generating static pages (1823/1823)
\`\`\`

## What's preserved

Kept: \`shamefully-hoist=true\` (some Next.js transitives expect phantom imports), \`strict-peer-dependencies=false\`, \`auto-install-peers=true\`, \`prefer-workspace-packages=true\`. None of these trigger the duplication.

## Test plan

- [ ] CI green
- [ ] Vercel preview build for this branch reaches \`Generating static pages (1823/1823)\` and finishes
- [ ] Backend admin (\`apps/backend\`) still installs/builds — its \`node_modules/react\` should now also be a symlink (was previously hoisted-style, but that wasn't causing breakage there)

## Why earlier attempts didn't fix it

- **PR #170** (turbo.json env vars) — was needed to surface env vars to the build, but didn't address the React duplication
- **PR #172** (\`!react\` negation patterns in root \`.npmrc\`) — only affected the root hoist, not the per-workspace hoisted linker setting in \`apps/storefront/.npmrc\` which silently overrode it

🤖 Generated with [Claude Code](https://claude.com/claude-code)