### PR TITLE
feat(whatsapp): partner silent-upload to shared folders + open / folders commands

### DIFF
--- a/apps/backend/src/scripts/__tests__/whatsapp-partner-helpers.unit.spec.ts
+++ b/apps/backend/src/scripts/__tests__/whatsapp-partner-helpers.unit.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * Unit tests for the partner-side WhatsApp helpers added in Phase 1B.
+ *
+ * The helpers are pure shape-mappers over query.graph. We mock the
+ * container's QUERY service so we can assert on the produced data
+ * without booting Medusa.
+ */
+
+jest.mock("@medusajs/framework/utils", () => ({
+  ContainerRegistrationKeys: { QUERY: "query" },
+  MedusaService: () =>
+    class {
+      constructor(..._args: any[]) {}
+    },
+  model: new Proxy(
+    {},
+    {
+      get: () => () => new Proxy(() => {}, { get: () => () => undefined }),
+    },
+  ),
+}))
+
+// downloadAndSaveWhatsAppMedia and friends pull in workflows that
+// import the workflow SDK at module init. Stub it to a no-op so the
+// helper file's imports don't crash.
+jest.mock("@medusajs/framework/workflows-sdk", () => ({
+  createStep: (_n: string, fn: Function) => fn,
+  createWorkflow: (_n: string, fn: Function) => fn,
+  StepResponse: class {
+    constructor(public data: any) {}
+  },
+  WorkflowResponse: class {
+    constructor(public data: any) {}
+  },
+}))
+
+jest.mock("../../modules/media", () => ({ MEDIA_MODULE: "media" }))
+jest.mock("../../modules/production_runs", () => ({
+  PRODUCTION_RUNS_MODULE: "production_runs",
+}))
+jest.mock("../../modules/social-provider", () => ({
+  SOCIAL_PROVIDER_MODULE: "social_provider",
+}))
+jest.mock("../../workflows/media/upload-and-organize-media", () => ({
+  uploadAndOrganizeMediaWorkflow: () => ({ run: jest.fn() }),
+}))
+jest.mock("../../workflows/designs/list-single-design", () => ({
+  listSingleDesignsWorkflow: () => ({ run: jest.fn() }),
+}))
+jest.mock("../../workflows/designs/update-design", () => ({
+  updateDesignWorkflow: () => ({ run: jest.fn() }),
+}))
+
+import {
+  listPartnerSharedFolders,
+  resolvePartnerDefaultSharedFolder,
+  getPartnerOpenWork,
+} from "../../workflows/whatsapp/whatsapp-media-helper"
+
+function makeScope(graph: jest.Mock) {
+  return {
+    resolve: (_key: string) => ({ graph }),
+  }
+}
+
+describe("listPartnerSharedFolders", () => {
+  it("returns empty when partner has no people", async () => {
+    const graph = jest.fn().mockResolvedValueOnce({ data: [{ people: [] }] })
+    const out = await listPartnerSharedFolders(makeScope(graph), "p1")
+    expect(out).toEqual([])
+  })
+
+  it("dedups folders shared via multiple people and orders by latest activity", async () => {
+    // Person A and Person B both have access to folder F1; only A has F2.
+    // F1 has the more recent file → F1 should come first.
+    const graph = jest
+      .fn()
+      .mockResolvedValueOnce({
+        data: [{ people: [{ id: "person_a" }, { id: "person_b" }] }],
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: "person_a",
+            folders: [
+              {
+                id: "f1",
+                name: "Spring",
+                slug: "spring",
+                media_files: [
+                  { id: "m1", created_at: "2026-04-28T10:00:00Z" },
+                  { id: "m2", created_at: "2026-04-29T12:00:00Z" },
+                ],
+              },
+              {
+                id: "f2",
+                name: "Archive",
+                slug: "archive",
+                media_files: [],
+              },
+            ],
+          },
+          {
+            id: "person_b",
+            folders: [
+              {
+                id: "f1",
+                name: "Spring",
+                slug: "spring",
+                media_files: [{ id: "m1", created_at: "2026-04-28T10:00:00Z" }],
+              },
+            ],
+          },
+        ],
+      })
+
+    const out = await listPartnerSharedFolders(makeScope(graph), "p1")
+    expect(out.map((f) => f.id)).toEqual(["f1", "f2"])
+    expect(out[0].fileCount).toBe(2)
+    expect(out[1].fileCount).toBe(0)
+    expect(out[0].latestFileAt).toBeGreaterThan(out[1].latestFileAt)
+  })
+})
+
+describe("resolvePartnerDefaultSharedFolder", () => {
+  it("returns null when no folders are shared", async () => {
+    const graph = jest.fn().mockResolvedValueOnce({ data: [{ people: [] }] })
+    const out = await resolvePartnerDefaultSharedFolder(makeScope(graph), "p1")
+    expect(out).toBeNull()
+  })
+
+  it("picks the folder with the most recent file", async () => {
+    const graph = jest
+      .fn()
+      .mockResolvedValueOnce({
+        data: [{ people: [{ id: "person_a" }] }],
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: "person_a",
+            folders: [
+              {
+                id: "old",
+                name: "Old",
+                slug: "old",
+                media_files: [{ created_at: "2026-01-01T00:00:00Z" }],
+              },
+              {
+                id: "new",
+                name: "New",
+                slug: "new",
+                media_files: [{ created_at: "2026-04-29T00:00:00Z" }],
+              },
+            ],
+          },
+        ],
+      })
+
+    const out = await resolvePartnerDefaultSharedFolder(makeScope(graph), "p1")
+    expect(out).toEqual({ id: "new", name: "New", slug: "new" })
+  })
+})
+
+describe("getPartnerOpenWork", () => {
+  it("returns empty arrays when nothing pending", async () => {
+    const graph = jest
+      .fn()
+      .mockResolvedValueOnce({ data: [] }) // runs
+      .mockResolvedValueOnce({ data: [] }) // payments
+    const out = await getPartnerOpenWork(makeScope(graph), "p1")
+    expect(out).toEqual({ pendingRuns: [], pendingPayments: [] })
+  })
+
+  it("normalizes runs (accepted flag from accepted_at presence)", async () => {
+    const graph = jest
+      .fn()
+      .mockResolvedValueOnce({
+        data: [
+          { id: "r1", status: "sent_to_partner", accepted_at: null, design: { name: "Spring" } },
+          { id: "r2", status: "in_progress", accepted_at: "2026-04-29T00:00:00Z", design: { name: "Tibetan" } },
+        ],
+      })
+      .mockResolvedValueOnce({ data: [] })
+
+    const out = await getPartnerOpenWork(makeScope(graph), "p1")
+    expect(out.pendingRuns).toEqual([
+      { id: "r1", status: "sent_to_partner", accepted: false, designName: "Spring" },
+      { id: "r2", status: "in_progress", accepted: true, designName: "Tibetan" },
+    ])
+  })
+
+  it("returns an empty result on query failure rather than throwing", async () => {
+    const graph = jest.fn().mockRejectedValue(new Error("db down"))
+    const out = await getPartnerOpenWork(makeScope(graph), "p1")
+    expect(out).toEqual({ pendingRuns: [], pendingPayments: [] })
+  })
+})

--- a/apps/backend/src/workflows/whatsapp/whatsapp-media-helper.ts
+++ b/apps/backend/src/workflows/whatsapp/whatsapp-media-helper.ts
@@ -1,3 +1,4 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { MEDIA_MODULE } from "../../modules/media"
 import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
 import type ProductionRunService from "../../modules/production_runs/service"
@@ -6,6 +7,199 @@ import type SocialProviderService from "../../modules/social-provider/service"
 import { uploadAndOrganizeMediaWorkflow } from "../media/upload-and-organize-media"
 import { listSingleDesignsWorkflow } from "../designs/list-single-design"
 import { updateDesignWorkflow } from "../designs/update-design"
+
+export type PartnerSharedFolder = {
+  id: string
+  name: string
+  slug: string
+  fileCount: number
+  // Epoch ms of the most recent file in this folder; 0 when empty.
+  // Used for ordering ("most-recently-active first").
+  latestFileAt: number
+}
+
+/**
+ * List every folder shared with the partner via their linked people,
+ * with file counts and the latest file timestamp per folder. Sorted
+ * with the most-recently-active folder first; empty folders sink to
+ * the bottom in alphabetical order.
+ *
+ * Centralized so the resolver (silent-upload destination) and the
+ * `folders` WhatsApp command share one query. Adding sharing semantics
+ * later (e.g. ACL filtering) only needs to change this function.
+ */
+export async function listPartnerSharedFolders(
+  scope: any,
+  partnerId: string,
+): Promise<PartnerSharedFolder[]> {
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: partnerData } = await query.graph({
+    entity: "partners",
+    fields: ["people.id"],
+    filters: { id: partnerId },
+  } as any)
+  const personIds: string[] = ((partnerData?.[0] as any)?.people ?? [])
+    .map((p: any) => p?.id)
+    .filter(Boolean)
+  if (!personIds.length) return []
+
+  const { data: personData } = await query.graph({
+    entity: "person",
+    fields: [
+      "id",
+      "folders.id",
+      "folders.name",
+      "folders.slug",
+      "folders.media_files.id",
+      "folders.media_files.created_at",
+    ],
+    filters: { id: personIds },
+  } as any)
+
+  // Dedup folders that show up under multiple people; track best-of stats.
+  const byFolder = new Map<string, PartnerSharedFolder>()
+  for (const person of personData ?? []) {
+    for (const folder of (person as any).folders ?? []) {
+      if (!folder?.id) continue
+      const files = (folder as any).media_files ?? []
+      const fileCount = files.length
+      const latest = files
+        .map((f: any) => (f?.created_at ? Date.parse(f.created_at) : 0))
+        .reduce((a: number, b: number) => (b > a ? b : a), 0)
+      const prev = byFolder.get(folder.id)
+      if (!prev) {
+        byFolder.set(folder.id, {
+          id: folder.id,
+          name: folder.name,
+          slug: folder.slug,
+          fileCount,
+          latestFileAt: latest,
+        })
+      } else if (latest > prev.latestFileAt) {
+        prev.latestFileAt = latest
+        // fileCount may differ between persons if filters ever diverge;
+        // pick the larger so the partner sees what's actually there.
+        if (fileCount > prev.fileCount) prev.fileCount = fileCount
+      }
+    }
+  }
+
+  return [...byFolder.values()].sort((a, b) => {
+    if (b.latestFileAt !== a.latestFileAt) return b.latestFileAt - a.latestFileAt
+    return a.name.localeCompare(b.name)
+  })
+}
+
+/**
+ * Pick the partner's most active shared folder. Used by the WhatsApp
+ * inbound-media path: when a partner sends a photo outside any run
+ * context, we want it to land in their actual working folder rather
+ * than the per-partner WhatsApp catchall, so the admin doesn't have
+ * to move files around. "Most recent" beats "first alphabetical"
+ * because it tracks what the partner is actively collaborating on.
+ */
+export async function resolvePartnerDefaultSharedFolder(
+  scope: any,
+  partnerId: string,
+): Promise<{ id: string; name: string; slug: string } | null> {
+  const folders = await listPartnerSharedFolders(scope, partnerId)
+  if (!folders.length) return null
+  const winner = folders[0]
+  return { id: winner.id, name: winner.name, slug: winner.slug }
+}
+
+export type PartnerOpenWork = {
+  pendingRuns: Array<{
+    id: string
+    status: string
+    accepted: boolean
+    designName?: string
+  }>
+  pendingPayments: Array<{
+    id: string
+    status: string
+    totalAmount?: number | null
+    currency?: string | null
+    submittedAt?: string | null
+  }>
+}
+
+/**
+ * Aggregate everything a partner has open right now. Used by the
+ * WhatsApp `open` command to give partners a single read of their
+ * pending work without having to remember the separate `runs` and
+ * payment commands. Designs are excluded for v1 — the design ↔
+ * partner link is many-to-many with computed status, so the query
+ * is heavier and the production-run row already covers most active
+ * design work in practice.
+ */
+export async function getPartnerOpenWork(
+  scope: any,
+  partnerId: string,
+): Promise<PartnerOpenWork> {
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const runsPromise = query
+    .graph({
+      entity: "production_runs",
+      fields: ["id", "status", "accepted_at", "design.name"],
+      filters: {
+        partner_id: partnerId,
+        status: { $in: ["sent_to_partner", "in_progress"] },
+      },
+      pagination: { skip: 0, take: 25 },
+    } as any)
+    .then(({ data }: any) =>
+      (data ?? []).map((r: any) => ({
+        id: r.id,
+        status: r.status,
+        accepted: !!r.accepted_at,
+        designName: r.design?.name,
+      })),
+    )
+    .catch(() => [])
+
+  // Status casing varies across handler code (see whatsapp-admin-handler
+  // using lowercase "pending"); the model itself defines a TitleCase enum
+  // including Draft / Pending / Under_Review. Match both shapes so the
+  // command works regardless of how submissions were created.
+  const paymentsPromise = query
+    .graph({
+      entity: "payment_submissions",
+      fields: ["id", "status", "total_amount", "currency", "submitted_at"],
+      filters: {
+        partner_id: partnerId,
+        status: {
+          $in: [
+            "Draft",
+            "Pending",
+            "Under_Review",
+            "draft",
+            "pending",
+            "under_review",
+          ],
+        },
+      },
+      pagination: { skip: 0, take: 25 },
+    } as any)
+    .then(({ data }: any) =>
+      (data ?? []).map((s: any) => ({
+        id: s.id,
+        status: s.status,
+        totalAmount: s.total_amount ?? null,
+        currency: s.currency ?? null,
+        submittedAt: s.submitted_at ?? null,
+      })),
+    )
+    .catch(() => [])
+
+  const [pendingRuns, pendingPayments] = await Promise.all([
+    runsPromise,
+    paymentsPromise,
+  ])
+  return { pendingRuns, pendingPayments }
+}
 
 /**
  * Find or create a media folder for a partner's WhatsApp media.
@@ -51,8 +245,12 @@ export async function downloadAndSaveWhatsAppMedia(
     partnerId: string
     partnerName: string
     caption?: string
+    // Override the default per-partner WhatsApp catchall folder. When
+    // set, the file is uploaded directly to this folder — used when the
+    // partner has a real shared working folder we'd rather route to.
+    targetFolderId?: string
   }
-): Promise<{ fileUrl: string; mimeType: string } | null> {
+): Promise<{ fileUrl: string; mimeType: string; folderId: string } | null> {
   const socialProvider = scope.resolve(SOCIAL_PROVIDER_MODULE) as SocialProviderService
   const whatsapp = socialProvider.getWhatsApp(scope)
 
@@ -74,12 +272,15 @@ export async function downloadAndSaveWhatsAppMedia(
 
     mimeType = downloaded.contentType || mimeType
 
-    // Step 3: Get or create the partner's media folder
-    const folderId = await getOrCreatePartnerMediaFolder(
-      scope,
-      options.partnerId,
-      options.partnerName
-    )
+    // Step 3: Resolve target folder. Prefer the caller-supplied override
+    // (a real shared folder); fall back to the per-partner WhatsApp
+    // catchall when nothing is shared with the partner yet.
+    const folderId = options.targetFolderId
+      ?? await getOrCreatePartnerMediaFolder(
+        scope,
+        options.partnerId,
+        options.partnerName
+      )
 
     // Step 4: Generate filename
     const ext = extensionFromMime(mimeType)
@@ -111,7 +312,7 @@ export async function downloadAndSaveWhatsAppMedia(
 
     if (!fileUrl) return null
 
-    return { fileUrl, mimeType }
+    return { fileUrl, mimeType, folderId }
   } catch (e: any) {
     console.error("[whatsapp-media] Failed to download/save media:", e.message)
     return null

--- a/apps/backend/src/workflows/whatsapp/whatsapp-message-handler.ts
+++ b/apps/backend/src/workflows/whatsapp/whatsapp-message-handler.ts
@@ -15,7 +15,13 @@ import { SOCIAL_PROVIDER_MODULE } from "../../modules/social-provider"
 import type SocialProviderService from "../../modules/social-provider/service"
 import { MESSAGING_MODULE } from "../../modules/messaging"
 import type { WhatsAppAuditContext } from "../../modules/social-provider/whatsapp-service"
-import { downloadAndSaveWhatsAppMedia, attachMediaToRunDesign } from "./whatsapp-media-helper"
+import {
+  downloadAndSaveWhatsAppMedia,
+  attachMediaToRunDesign,
+  resolvePartnerDefaultSharedFolder,
+  listPartnerSharedFolders,
+  getPartnerOpenWork,
+} from "./whatsapp-media-helper"
 import { BUTTON_TITLE_ACTIONS } from "../../scripts/whatsapp-templates/partner-run-templates"
 
 interface IncomingMessage {
@@ -331,13 +337,25 @@ export async function handleIncomingMessage(
     action = parsed.action
     runId = parsed.runId
   } else if (message.type === "image" || message.type === "video" || message.type === "document") {
-    // Save media to partner's media folder. If the partner recently tapped
-    // "Add Media" on a started run (button payload `media_<runId>`), we
-    // have a short-lived pointer to the target run on conversation.metadata
-    // — attach the file to that run's design. Outside that window we just
-    // keep the file in the inbox, same as before.
+    // Inbound media. Resolution order:
+    //   1. `active_media_run_id` — partner tapped "📸 Add Media" on a
+    //      started run (10-min TTL). Existing run-attachment behavior.
+    //   2. Single active run — auto-attach to it. Existing auto-route.
+    //   3. Partner has a shared folder — silent, no command needed.
+    //      File lands in the most-recently-active shared folder.
+    //   4. Fall back to per-partner WhatsApp catchall + inbox nudge.
+    //
+    // The destination folder is decided BEFORE we ask Meta for the
+    // download URL: if any folder is shared with the partner we route
+    // the upload there directly; otherwise downloadAndSaveWhatsAppMedia
+    // creates / reuses the catchall.
     if (message.mediaId) {
       try {
+        const sharedFolder = await resolvePartnerDefaultSharedFolder(
+          scope,
+          partner.partnerId,
+        ).catch(() => null)
+
         const saved = await downloadAndSaveWhatsAppMedia(scope, {
           mediaId: message.mediaId,
           mediaUrl: message.mediaUrl,
@@ -345,6 +363,7 @@ export async function handleIncomingMessage(
           partnerId: partner.partnerId,
           partnerName: partner.adminName,
           caption: message.text,
+          targetFolderId: sharedFolder?.id,
         })
 
         // Resolve the attachment target.
@@ -441,23 +460,33 @@ export async function handleIncomingMessage(
           const suffix = contextStillValid
             ? ""
             : " (auto-matched — you only have one run in progress)"
+          const folderSuffix = sharedFolder
+            ? ` Stored in *${sharedFolder.name}*.`
+            : ""
           await whatsapp.sendTextMessage(
             message.from,
-            `📎 Photo attached to run ${attachedRunId}${suffix}.`
+            `📎 Photo attached to run ${attachedRunId}${suffix}.${folderSuffix}`
           )
         } else if (attachError) {
           await whatsapp.sendTextMessage(message.from, attachError)
+        } else if (sharedFolder) {
+          // Silent shared-folder upload — the new default for partners
+          // not in the middle of a run. No command, no choice prompt.
+          await whatsapp.sendTextMessage(
+            message.from,
+            `✅ Thanks for sharing. Uploaded to your shared folder *${sharedFolder.name}*.`,
+          )
         } else if (!pointedRunId) {
-          // No tap, no single run to auto-match. Leave in the inbox and
-          // nudge — the message differs depending on why we couldn't
-          // auto-route so the partner knows what to do.
+          // No tap, no single run to auto-match, no shared folder.
+          // File is in the per-partner WhatsApp catchall — admin will
+          // see it in the inbox and assign appropriately.
           const hint =
             autoResolveReason === "multiple"
               ? "You have several runs in progress — tap *📸 Add Media* on the specific run, then send the photo."
-              : "To attach a photo to a specific run, tap *📸 Add Media* on a started run first, then send the photo."
+              : "We've received your file and will sort it shortly. (Tap *📸 Add Media* on a run to attach a photo to a specific run.)"
           await whatsapp.sendTextMessage(
             message.from,
-            `📥 Received — saved to your inbox. ${hint}`
+            `📥 Received. ${hint}`
           )
         }
       } catch (e: any) {
@@ -524,6 +553,10 @@ export async function handleIncomingMessage(
       case "runs":
       case "list":
         return await handleListRuns(scope, whatsapp, message.from, partner.partnerId)
+      case "folders":
+        return await handleListFolders(scope, whatsapp, message.from, partner.partnerId)
+      case "open":
+        return await handleShowOpenWork(scope, whatsapp, message.from, partner.partnerId)
       case "help":
         await sendHelpMessage(scope, whatsapp, message.from, partner.partnerId, partner.adminName, conversationMeta.language)
         return { handled: true, action: "help" }
@@ -590,6 +623,26 @@ function parseTextCommand(text: string): { action: string; runId: string; extra?
   // Greetings — treated as no specific action (nudge will handle)
   if (lower === "hi" || lower === "hello" || lower === "hey") {
     return { action: "", runId: "" }
+  }
+  // Multi-word matches must come before the single-word "list" → runs
+  // alias, otherwise "list folders" would resolve to action=runs.
+  if (
+    lower === "folders" ||
+    lower === "list folders" ||
+    lower === "my folders" ||
+    lower === "shared folders"
+  ) {
+    return { action: "folders", runId: "" }
+  }
+  if (
+    lower === "open" ||
+    lower === "todo" ||
+    lower === "open work" ||
+    lower === "what's open" ||
+    lower === "what is open" ||
+    lower === "pending"
+  ) {
+    return { action: "open", runId: "" }
   }
   if (lower === "runs" || lower === "list" || lower === "my runs") {
     return { action: "runs", runId: "" }
@@ -1225,6 +1278,99 @@ async function sendWelcomeCommands(
 /**
  * Show help when partner explicitly asks for it (already onboarded).
  */
+async function handleListFolders(
+  scope: any,
+  whatsapp: WhatsAppService,
+  phone: string,
+  partnerId: string,
+): Promise<HandlerResult> {
+  const folders = await listPartnerSharedFolders(scope, partnerId).catch(() => [])
+
+  if (!folders.length) {
+    await whatsapp.sendTextMessage(
+      phone,
+      `📁 No shared folders yet. Send a photo and we'll save it for you, or reach out to the team to get a folder shared with your account.`,
+    )
+    return { handled: true, action: "folders" }
+  }
+
+  const lines = folders.slice(0, 15).map((f, i) => {
+    const fileNote =
+      f.fileCount > 0
+        ? ` (${f.fileCount} ${f.fileCount === 1 ? "file" : "files"})`
+        : " (empty)"
+    return `${i + 1}. *${f.name}*${fileNote}`
+  })
+  const more = folders.length > 15 ? `\n…and ${folders.length - 15} more.` : ""
+  const tail = `\n\n_Send any photo and we'll save it to your most-recent folder._`
+
+  await whatsapp.sendTextMessage(
+    phone,
+    `📁 *Your shared folders (${folders.length}):*\n\n${lines.join("\n")}${more}${tail}`,
+  )
+  return { handled: true, action: "folders" }
+}
+
+async function handleShowOpenWork(
+  scope: any,
+  whatsapp: WhatsAppService,
+  phone: string,
+  partnerId: string,
+): Promise<HandlerResult> {
+  const work = await getPartnerOpenWork(scope, partnerId).catch(
+    () =>
+      ({
+        pendingRuns: [],
+        pendingPayments: [],
+      }) as Awaited<ReturnType<typeof getPartnerOpenWork>>,
+  )
+
+  if (!work.pendingRuns.length && !work.pendingPayments.length) {
+    await whatsapp.sendTextMessage(
+      phone,
+      `✅ All clear. Nothing pending right now.`,
+    )
+    return { handled: true, action: "open" }
+  }
+
+  const lines: string[] = []
+  if (work.pendingRuns.length) {
+    const awaitingAcceptance = work.pendingRuns.filter((r) => !r.accepted).length
+    const inProgress = work.pendingRuns.filter((r) => r.accepted).length
+    lines.push(
+      `*🛠 Production runs:* ${work.pendingRuns.length}` +
+        (awaitingAcceptance ? ` (${awaitingAcceptance} awaiting acceptance)` : "") +
+        (inProgress ? ` (${inProgress} in progress)` : ""),
+    )
+    for (const r of work.pendingRuns.slice(0, 5)) {
+      const tag = r.accepted ? "in progress" : "awaiting accept"
+      const name = r.designName ? ` — ${r.designName}` : ""
+      lines.push(`   • ${r.id}${name} _(${tag})_`)
+    }
+    if (work.pendingRuns.length > 5) {
+      lines.push(`   …and ${work.pendingRuns.length - 5} more — reply *runs*.`)
+    }
+  }
+
+  if (work.pendingPayments.length) {
+    if (lines.length) lines.push("")
+    lines.push(`*💳 Payment requests:* ${work.pendingPayments.length}`)
+    for (const p of work.pendingPayments.slice(0, 5)) {
+      const amt =
+        p.totalAmount != null
+          ? `${p.currency ? p.currency + " " : "₹"}${Number(p.totalAmount).toLocaleString("en-IN")}`
+          : "amount pending"
+      lines.push(`   • ${p.id} — ${amt} _(${p.status})_`)
+    }
+    if (work.pendingPayments.length > 5) {
+      lines.push(`   …and ${work.pendingPayments.length - 5} more.`)
+    }
+  }
+
+  await whatsapp.sendTextMessage(phone, `📋 *Open work:*\n\n${lines.join("\n")}`)
+  return { handled: true, action: "open" }
+}
+
 async function sendHelpMessage(
   scope: any,
   whatsapp: WhatsAppService,
@@ -1250,27 +1396,31 @@ async function sendHelpMessage(
     await whatsapp.sendTextMessage(
       phone,
       `*उपलब्ध कमांड:*\n` +
-      `• *runs* — अपने सक्रिय प्रोडक्शन रन देखें${activeCount > 0 ? ` (${activeCount})` : ""}\n` +
+      `• *open* — आपका लंबित कार्य देखें\n` +
+      `• *runs* — सक्रिय प्रोडक्शन रन${activeCount > 0 ? ` (${activeCount})` : ""}\n` +
+      `• *folders* — साझा फ़ोल्डर देखें\n` +
       `• *accept <run_id>* — असाइन किया गया रन स्वीकार करें\n` +
       `• *start <run_id>* — रन पर काम शुरू करें\n` +
       `• *finish <run_id>* — रन को पूरा हुआ चिह्नित करें\n` +
       `• *complete <run_id> <qty>* — उत्पादित मात्रा के साथ पूरा करें\n` +
       `• *status <run_id>* — रन विवरण देखें\n` +
       `• *help* — यह संदेश दिखाएं\n\n` +
-      `_या बटन दबाकर तुरंत कार्रवाई करें।_`
+      `_कोई भी फोटो भेजें — यह आपके साझा फ़ोल्डर में सेव हो जाएगा।_`
     )
   } else {
     await whatsapp.sendTextMessage(
       phone,
       `*Available Commands:*\n` +
-      `• *runs* — List your active production runs${activeCount > 0 ? ` (${activeCount})` : ""}\n` +
+      `• *open* — See your pending work (runs + payments)\n` +
+      `• *runs* — List active production runs${activeCount > 0 ? ` (${activeCount})` : ""}\n` +
+      `• *folders* — List your shared folders\n` +
       `• *accept <run_id>* — Accept an assigned run\n` +
       `• *start <run_id>* — Start working on a run\n` +
       `• *finish <run_id>* — Mark a run as finished\n` +
       `• *complete <run_id> <qty>* — Complete with produced quantity\n` +
       `• *status <run_id>* — View run details\n` +
       `• *help* — Show this message\n\n` +
-      `_Or tap buttons in messages to take quick actions._`
+      `_Send any photo — it'll be saved to your shared folder automatically._`
     )
   }
 }


### PR DESCRIPTION
## Summary

Phase 1 of the partner WhatsApp command channel. Two user-facing pieces:

1. **Silent media upload** — when a partner sends a photo/document to WhatsApp, it lands in their actual shared working folder (most-recently-active across `partner.people.folders`) instead of the per-partner \`WhatsApp — <name>\` catchall. Reply: \`✅ Thanks for sharing. Uploaded to your shared folder *<name>*.\` Run-attachment behavior (button-tap + single-active-run auto-route) is preserved exactly — the new shared-folder path slots in between auto-route and the inbox fallback.

2. **Two new text commands** — \`folders\` lists the partner's shared folders with file counts; \`open\` aggregates pending production runs + payment submissions into a single summary. \`help\` updated (EN + Hindi) to advertise both, plus the silent-upload behavior.

Zero schema changes. Reuses the existing person↔folder link the admin UI already manages.

## How it works

Resolution order for inbound media:
1. \`active_media_run_id\` on conversation metadata (button-tap, 10-min TTL) — existing
2. Single in-progress run for the partner — existing auto-route
3. **NEW** Most-recently-active shared folder (via \`listPartnerSharedFolders\`)
4. Per-partner \`WhatsApp — <name>\` catchall + inbox nudge — existing fallback

The new \`downloadAndSaveWhatsAppMedia({ targetFolderId })\` override skips the catchall when a real folder is supplied.

## Test plan

- [x] 7/7 unit tests for the pure helpers (\`listPartnerSharedFolders\`, \`resolvePartnerDefaultSharedFolder\`, \`getPartnerOpenWork\`).
- [ ] After deploy: send a photo to the bot from a partner account that has at least one shared folder — confirm reply names the folder + file appears there in admin.
- [ ] Send \`folders\` to bot — confirm numbered list with file counts.
- [ ] Send \`open\` to bot — confirm pending runs + payments summary.
- [ ] Send \`help\` to bot — confirm new commands shown.

## What's next

- **Phase 2** — \`payment <amount>\` text command creates a Draft \`payment_submission\`.
- **Phase 2.5** — Admin messaging inbox: per-message kebab action "Create payment request from this message" (pre-fills from media + content).
- **Phase 3** — Admin-side payment-status WhatsApp visual flow (templates + seed script, modeled on \`seed-partner-run-whatsapp-flow\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)