### PR TITLE
fix(whatsapp): base64-encode inbound media (orphaned from #176)

### DIFF
--- a/apps/backend/src/workflows/whatsapp/whatsapp-media-helper.ts
+++ b/apps/backend/src/workflows/whatsapp/whatsapp-media-helper.ts
@@ -287,13 +287,32 @@ export async function downloadAndSaveWhatsAppMedia(
     const timestamp = Date.now()
     const filename = `wa-${timestamp}${ext}`
 
-    // Step 5: Upload via media workflow
+    // Step 5: Upload via media workflow.
+    //
+    // base64 is required here. The downstream file-s3 provider
+    // (@medusajs/file-s3 services/s3-file.js:68-79) format-detects the
+    // content string by attempting a base64 round-trip — if that
+    // succeeds it decodes as base64; otherwise it falls back to
+    // Buffer.from(content, "utf8"). Passing toString("binary") gives
+    // it a Latin-1 string of raw bytes that fails the round-trip and
+    // takes the utf8 path, which UTF-8-encodes every char >0x7f and
+    // lands the file on S3 with mojibake content (12.5MB instead of
+    // 8.2MB for a real JPEG, magic bytes c3 bf c3 98 instead of
+    // ff d8 ff e0 — file(1) reports "data", browsers fail to render).
+    //
+    // The admin UI sidesteps all of this by using a multi-part
+    // presigned-URL upload (admin/lib/uploads/upload-manager.ts) that
+    // PUTs raw binary directly to S3. The webhook path can't easily do
+    // that because Meta hands us a Buffer in Node, not a browser File,
+    // so we go through the workflow + file-s3 service. base64 is the
+    // only encoding that survives that hop. Memory cost: ~33% over
+    // the buffer (16 MB Meta cap → ~21 MB string, trivial for Node).
     const { result } = await uploadAndOrganizeMediaWorkflow(scope).run({
       input: {
         files: [{
           filename,
           mimeType,
-          content: downloaded.buffer.toString("binary"),
+          content: downloaded.buffer.toString("base64"),
         }],
         existingFolderId: folderId,
         metadata: {


### PR DESCRIPTION
## Summary

Hotfix — this commit was on the PR #176 branch but didn't make it into the squashed merge to main. Without it, every WhatsApp inbound photo lands on S3 with UTF-8 mojibake content (12.5 MB for an 8.2 MB JPEG, magic bytes \`c3 bf c3 98\` instead of \`ff d8 ff e0\`, file(1) reports "data", browsers fail to render).

## Why

\`downloadAndSaveWhatsAppMedia\` calls \`buffer.toString("binary")\`, producing a Latin-1 string. The downstream \`@medusajs/file-s3\` provider format-detects content via a base64 round-trip; the Latin-1 string fails that check and falls through to \`Buffer.from(content, "utf8")\`, which UTF-8-encodes every char >0x7f into a 2-byte sequence.

Empirical confirmation on a real 8.2 MB JPEG:

\`\`\`
toString("binary")  → 12,504,058 bytes, c3 bf c3 98 ...  (broken)
toString("base64")  →  8,238,749 bytes, ff d8 ff e0 ...  (matches original)
\`\`\`

The admin UI sidesteps this by using S3 multi-part presigned uploads (PUT raw binary directly to the bucket, bypasses the workflow + s3 provider entirely). The webhook path can't easily do that because Meta hands us a Buffer in Node, not a browser File. Memory overhead from base64 is ~33% over the original (16 MB Meta cap → ~21 MB string, trivial). Over the workflow's JSON-via-Redis hop, base64 is actually smaller than the broken Latin-1 path because chars >0x7f get JSON-encoded as multi-byte UTF-8.

Past corrupted files (today's test image, the April 21 WhatsApp upload) are unrecoverable — Meta deletes media URLs after 5 minutes.

## Test plan

- [ ] After deploy, send a WhatsApp photo to the bot.
- [ ] \`curl -sS <new url> | head -c 8 | xxd\` should show \`ff d8 ff …\` (valid JPEG), not \`c3 bf c3 98\`.
- [ ] File size on S3 should match what was sent, not be ~50% larger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)