### PR TITLE
feat(messaging): admin "Create payment request from this message"

### DIFF
--- a/apps/backend/src/admin/routes/messaging/[conversationId]/page.tsx
+++ b/apps/backend/src/admin/routes/messaging/[conversationId]/page.tsx
@@ -13,6 +13,7 @@ import { useEffect, useRef, useState, useCallback, useMemo } from "react"
 import { MessageBubble } from "../components/message-bubble"
 import { MessageInput, type SendPayload, type ReplyTo } from "../components/message-input"
 import { SenderPicker } from "../components/sender-picker"
+import { CreatePaymentFromMessageModal } from "../components/create-payment-from-message-modal"
 import type { Message } from "../../../hooks/api/messaging"
 import { type AdminDesign, useDesigns } from "../../../hooks/api/designs"
 
@@ -22,6 +23,10 @@ const ConversationThreadModal = () => {
   const [replyTo, setReplyTo] = useState<ReplyTo | null>(null)
   const [editingTitle, setEditingTitle] = useState(false)
   const [titleDraft, setTitleDraft] = useState("")
+  // Single-modal-per-page pattern: kebab on a bubble sets the message
+  // and opens the payment modal. Keeps only one CreatePaymentModal in
+  // the DOM regardless of message count.
+  const [paymentMessage, setPaymentMessage] = useState<Message | null>(null)
 
   const { conversation, messages = [], isPending } = useConversationMessages(
     conversationId!,
@@ -162,7 +167,12 @@ const ConversationThreadModal = () => {
               ) : (
                 <div className="space-y-1 max-w-3xl mx-auto">
                   {messages.map((msg) => (
-                    <MessageBubble key={msg.id} message={msg} onReply={handleReply} />
+                    <MessageBubble
+                      key={msg.id}
+                      message={msg}
+                      onReply={handleReply}
+                      onCreatePayment={setPaymentMessage}
+                    />
                   ))}
                 </div>
               )}
@@ -181,6 +191,16 @@ const ConversationThreadModal = () => {
           </div>
         )}
       </RouteFocusModal.Body>
+
+      {conversation && (
+        <CreatePaymentFromMessageModal
+          open={!!paymentMessage}
+          onClose={() => setPaymentMessage(null)}
+          message={paymentMessage}
+          partnerId={conversation.partner_id}
+          partnerName={conversation.partner_name}
+        />
+      )}
     </RouteFocusModal>
   )
 }

--- a/apps/backend/src/admin/routes/messaging/components/__tests__/extract-amount.unit.spec.ts
+++ b/apps/backend/src/admin/routes/messaging/components/__tests__/extract-amount.unit.spec.ts
@@ -1,0 +1,59 @@
+import { extractSuggestedAmount } from "../extract-amount"
+
+describe("extractSuggestedAmount", () => {
+  it("returns undefined for empty / null / undefined", () => {
+    expect(extractSuggestedAmount(undefined)).toBeUndefined()
+    expect(extractSuggestedAmount(null)).toBeUndefined()
+    expect(extractSuggestedAmount("")).toBeUndefined()
+    expect(extractSuggestedAmount("   ")).toBeUndefined()
+  })
+
+  it("extracts plain large numbers", () => {
+    expect(extractSuggestedAmount("1500")).toBe(1500)
+    expect(extractSuggestedAmount("can you pay 1500")).toBe(1500)
+    expect(extractSuggestedAmount("payment 12000 done")).toBe(12000)
+  })
+
+  it("handles comma grouping", () => {
+    expect(extractSuggestedAmount("1,500")).toBe(1500)
+    expect(extractSuggestedAmount("payment of 1,25,000 ok?")).toBe(125000)
+    expect(extractSuggestedAmount("12,345.50")).toBe(12345.5)
+  })
+
+  it("recognizes rupee markers", () => {
+    expect(extractSuggestedAmount("₹1500")).toBe(1500)
+    expect(extractSuggestedAmount("₹ 1,500")).toBe(1500)
+    expect(extractSuggestedAmount("INR 1500")).toBe(1500)
+    expect(extractSuggestedAmount("Rs 1500")).toBe(1500)
+    expect(extractSuggestedAmount("Rs. 1,500.50")).toBe(1500.5)
+  })
+
+  it("recognizes trailing currency", () => {
+    expect(extractSuggestedAmount("1500 rupees")).toBe(1500)
+    expect(extractSuggestedAmount("12000 rs for materials")).toBe(12000)
+  })
+
+  it("rejects ambiguous short numbers without a currency marker", () => {
+    // "12 photos" should NOT pre-fill 12 — too noisy.
+    expect(extractSuggestedAmount("ok 12 photos done")).toBeUndefined()
+    expect(extractSuggestedAmount("done 5 of them")).toBeUndefined()
+  })
+
+  it("accepts short numbers when paired with a currency marker", () => {
+    expect(extractSuggestedAmount("Rs 50")).toBe(50)
+    expect(extractSuggestedAmount("₹99")).toBe(99)
+  })
+
+  it("rejects values outside sensible bounds", () => {
+    // 0 and negatives — never sensible
+    expect(extractSuggestedAmount("Rs 0")).toBeUndefined()
+    // > 10M — almost certainly a phone number or order ID, not money
+    expect(extractSuggestedAmount("100000000")).toBeUndefined()
+  })
+
+  it("handles a realistic message with mixed content", () => {
+    expect(
+      extractSuggestedAmount("hi sir, can you transfer ₹3,500 for last week's batch"),
+    ).toBe(3500)
+  })
+})

--- a/apps/backend/src/admin/routes/messaging/components/create-payment-from-message-modal.tsx
+++ b/apps/backend/src/admin/routes/messaging/components/create-payment-from-message-modal.tsx
@@ -1,0 +1,210 @@
+import { useEffect, useMemo, useState } from "react"
+import {
+  FocusModal,
+  Button,
+  Input,
+  Label,
+  Textarea,
+  Text,
+  toast,
+  Tooltip,
+} from "@medusajs/ui"
+import { useCreatePaymentSubmission } from "../../../hooks/api/payment-submissions"
+import type { Message } from "../../../hooks/api/messaging"
+import { extractSuggestedAmount } from "./extract-amount"
+
+type Props = {
+  open: boolean
+  onClose: () => void
+  message: Message | null
+  partnerId: string
+  partnerName: string
+}
+
+export const CreatePaymentFromMessageModal = ({
+  open,
+  onClose,
+  message,
+  partnerId,
+  partnerName,
+}: Props) => {
+  const suggested = useMemo(
+    () => extractSuggestedAmount(message?.content),
+    [message?.id, message?.content],
+  )
+
+  const [amount, setAmount] = useState<string>("")
+  const [notes, setNotes] = useState<string>("")
+
+  // Reset form whenever a new message is loaded into the modal so we don't
+  // leak the previous amount/notes across separate "Create payment" clicks.
+  useEffect(() => {
+    if (!message) return
+    setAmount(suggested ? String(suggested) : "")
+    setNotes(message.content?.trim() ?? "")
+  }, [message?.id, suggested])
+
+  const createMutation = useCreatePaymentSubmission({
+    onSuccess: ({ payment_submission }) => {
+      toast.success(`Draft payment submission ${payment_submission.id} created.`)
+      onClose()
+    },
+    onError: (err: any) => {
+      toast.error(err?.message || "Failed to create payment submission")
+    },
+  })
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!message) return
+
+    const numericAmount = Number(amount.replace(/,/g, ""))
+    if (!Number.isFinite(numericAmount) || numericAmount <= 0) {
+      toast.error("Enter a valid amount")
+      return
+    }
+
+    // Documents from the message: the inbound media if any. Filename falls
+    // back to the URL's last segment so the review UI has something to show.
+    const documents = message.media_url
+      ? [
+          {
+            url: message.media_url,
+            filename: message.media_url.split("/").pop() || "attachment",
+            mimeType: message.media_mime_type ?? undefined,
+          },
+        ]
+      : undefined
+
+    createMutation.mutate({
+      partner_id: partnerId,
+      // No design / task linkage from this surface — admin will associate
+      // those during review. Keeping the create payload minimal lets the
+      // partner WhatsApp text command (`payment 1500`) reuse the same
+      // shape later without divergent code paths.
+      design_ids: [],
+      task_ids: [],
+      notes: notes || undefined,
+      documents,
+      metadata: {
+        // Suggested amount (the one we extracted, if any) is stamped
+        // separately so review UIs can later show "we extracted ₹X,
+        // operator entered ₹Y" if the operator edited the value.
+        suggested_amount: suggested ?? null,
+        entered_amount: numericAmount,
+        from_message_id: message.id,
+        from_conversation_id: message.conversation_id,
+        source: "messaging_inbox_extract",
+      },
+    })
+  }
+
+  const messageHasMedia = !!message?.media_url
+  const isImage = !!(message?.media_mime_type ?? "").startsWith("image/")
+
+  return (
+    <FocusModal open={open} onOpenChange={(o) => !o && onClose()}>
+      <FocusModal.Content>
+        <FocusModal.Header>
+          <Text size="large" weight="plus">
+            Create payment request
+          </Text>
+        </FocusModal.Header>
+        <FocusModal.Body className="overflow-y-auto">
+          <form onSubmit={handleSubmit} className="mx-auto max-w-2xl py-8 px-6">
+            <div className="mb-6">
+              <Text size="small" className="text-ui-fg-subtle">
+                For partner
+              </Text>
+              <Text weight="plus">{partnerName}</Text>
+            </div>
+
+            {message && (
+              <div className="mb-6 rounded-md border border-ui-border-base bg-ui-bg-subtle p-3">
+                <Text size="xsmall" className="text-ui-fg-muted mb-1">
+                  Source message
+                </Text>
+                {messageHasMedia && isImage && (
+                  <a
+                    href={message.media_url!}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block mb-2"
+                  >
+                    <img
+                      src={message.media_url!}
+                      alt="attachment"
+                      className="max-h-40 rounded-md object-cover"
+                    />
+                  </a>
+                )}
+                {messageHasMedia && !isImage && (
+                  <Tooltip content="Open original">
+                    <a
+                      href={message.media_url!}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-ui-fg-interactive text-sm underline"
+                    >
+                      📄 {message.media_url!.split("/").pop()}
+                    </a>
+                  </Tooltip>
+                )}
+                {message.content?.trim() && (
+                  <Text size="small" className="whitespace-pre-wrap break-words">
+                    {message.content}
+                  </Text>
+                )}
+              </div>
+            )}
+
+            <div className="mb-4">
+              <Label htmlFor="payment-amount">
+                Amount (INR){" "}
+                {suggested !== undefined && (
+                  <Text size="xsmall" className="inline text-ui-fg-muted">
+                    — suggested ₹{suggested.toLocaleString("en-IN")} from
+                    message text
+                  </Text>
+                )}
+              </Label>
+              <Input
+                id="payment-amount"
+                type="text"
+                inputMode="decimal"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                placeholder="e.g. 1500"
+                autoFocus
+              />
+            </div>
+
+            <div className="mb-6">
+              <Label htmlFor="payment-notes">Notes</Label>
+              <Textarea
+                id="payment-notes"
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                rows={4}
+                placeholder="Defaults to the message text — edit as needed."
+              />
+            </div>
+
+            <div className="flex justify-end gap-x-3">
+              <Button variant="secondary" onClick={onClose} type="button">
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                isLoading={createMutation.isPending}
+                disabled={createMutation.isPending}
+              >
+                Create draft submission
+              </Button>
+            </div>
+          </form>
+        </FocusModal.Body>
+      </FocusModal.Content>
+    </FocusModal>
+  )
+}

--- a/apps/backend/src/admin/routes/messaging/components/extract-amount.ts
+++ b/apps/backend/src/admin/routes/messaging/components/extract-amount.ts
@@ -1,0 +1,33 @@
+/**
+ * Pull a sensible INR amount suggestion out of free-form WhatsApp text.
+ *
+ * Used by the "Create payment request from message" admin action: when a
+ * partner messages a number ("can you pay 1500 for last week"), we want
+ * to pre-fill the modal so the operator just confirms instead of
+ * retyping. Kept conservative — returns undefined whenever the match is
+ * ambiguous so we don't plant a wrong number in the input.
+ *
+ * Accepts: 1500, 1,500, ₹1500, ₹1,500, 1,500/-, INR 1500, Rs 1500,
+ *          1500 rupees
+ *
+ * Rejects: short standalone numbers (<3 digits) without a currency
+ *          marker — too noisy ("ok 12 photos done").
+ */
+export function extractSuggestedAmount(text?: string | null): number | undefined {
+  if (!text) return undefined
+  // Three branches in priority order:
+  //   1. <currency>NUM     "₹1500", "Rs. 1,500.50", "INR 1500"
+  //   2. NUM<currency>     "1500 rupees", "12000 rs"
+  //   3. bare NUM (3+ digits)  "1500", "12,345.50"
+  // Decimal must be inside the capture group so e.g. "12,345.50" yields
+  // "12,345.50" not "12,345" + dropped ".50".
+  const match = text.match(
+    /(?:₹|inr|rs\.?)\s*([\d,]+(?:\.\d+)?)|([\d,]+(?:\.\d+)?)\s*(?:rs|rupees|inr)\b|(?<![\d.])([\d,]{3,}(?:\.\d+)?)(?![\d])/i,
+  )
+  if (!match) return undefined
+  const raw = match[1] ?? match[2] ?? match[3]
+  if (!raw) return undefined
+  const num = Number(raw.replace(/,/g, ""))
+  if (!Number.isFinite(num) || num <= 0 || num > 10_000_000) return undefined
+  return num
+}

--- a/apps/backend/src/admin/routes/messaging/components/message-bubble.tsx
+++ b/apps/backend/src/admin/routes/messaging/components/message-bubble.tsx
@@ -1,4 +1,4 @@
-import { clx } from "@medusajs/ui"
+import { clx, DropdownMenu } from "@medusajs/ui"
 import type { Message } from "../../../hooks/api/messaging"
 import { ContextCard } from "./context-card"
 
@@ -195,9 +195,14 @@ const ReplyPreview = ({ snapshot, isOutbound }: { snapshot: Message["reply_to_sn
 export const MessageBubble = ({
   message,
   onReply,
+  onCreatePayment,
 }: {
   message: Message
   onReply?: (message: Message) => void
+  // Optional — when provided, inbound messages get a kebab menu with a
+  // "Create payment request" entry. Page-level state owns the modal so
+  // we don't end up with N modals (one per bubble) in the DOM.
+  onCreatePayment?: (message: Message) => void
 }) => {
   const isOutbound = message.direction === "outbound"
 
@@ -264,17 +269,41 @@ export const MessageBubble = ({
         </div>
       </div>
 
-      {/* Reply button (right side for inbound) */}
-      {!isOutbound && onReply && (
-        <button
-          onClick={() => onReply(message)}
-          className="opacity-0 group-hover:opacity-100 transition-opacity mt-2 text-ui-fg-muted hover:text-ui-fg-base"
-          title="Reply"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
-            <path fillRule="evenodd" d="M7.793 2.232a.75.75 0 0 1-.025 1.06L3.622 7.25h10.003a5.375 5.375 0 0 1 0 10.75H10.75a.75.75 0 0 1 0-1.5h2.875a3.875 3.875 0 0 0 0-7.75H3.622l4.146 3.957a.75.75 0 0 1-1.036 1.085l-5.5-5.25a.75.75 0 0 1 0-1.085l5.5-5.25a.75.75 0 0 1 1.06.025Z" clipRule="evenodd" />
-          </svg>
-        </button>
+      {/* Reply + actions (right side for inbound) */}
+      {!isOutbound && (onReply || onCreatePayment) && (
+        <div className="flex flex-col gap-y-1 mt-2 opacity-0 group-hover:opacity-100 transition-opacity">
+          {onReply && (
+            <button
+              onClick={() => onReply(message)}
+              className="text-ui-fg-muted hover:text-ui-fg-base"
+              title="Reply"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
+                <path fillRule="evenodd" d="M7.793 2.232a.75.75 0 0 1-.025 1.06L3.622 7.25h10.003a5.375 5.375 0 0 1 0 10.75H10.75a.75.75 0 0 1 0-1.5h2.875a3.875 3.875 0 0 0 0-7.75H3.622l4.146 3.957a.75.75 0 0 1-1.036 1.085l-5.5-5.25a.75.75 0 0 1 0-1.085l5.5-5.25a.75.75 0 0 1 1.06.025Z" clipRule="evenodd" />
+              </svg>
+            </button>
+          )}
+          {onCreatePayment && (
+            <DropdownMenu>
+              <DropdownMenu.Trigger asChild>
+                <button
+                  className="text-ui-fg-muted hover:text-ui-fg-base"
+                  title="More actions"
+                  aria-label="More actions"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
+                    <path d="M10 4a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3ZM10 11.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3ZM11.5 17.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z" />
+                  </svg>
+                </button>
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Content side="right" align="start">
+                <DropdownMenu.Item onClick={() => onCreatePayment(message)}>
+                  Create payment request from this message
+                </DropdownMenu.Item>
+              </DropdownMenu.Content>
+            </DropdownMenu>
+          )}
+        </div>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary

Phase 2.5 of the partner WhatsApp command channel. Most partners send a bill photo or a free-form "did this and that" message rather than typing \`payment 1500\` — this surfaces a per-message kebab in the admin messaging inbox so an admin can extract a **Draft** \`payment_submission\` from any inbound message in two clicks.

## UX

1. Hover any **inbound** partner message → a kebab appears next to the existing Reply button.
2. Click → DropdownMenu → **"Create payment request from this message"**.
3. Modal opens, pre-filled with:
   - Partner from the conversation
   - Suggested amount extracted from the message text (₹/INR/Rs prefix, rupees/rs suffix, or bare 3+-digit numbers — ambiguous short numbers like "12 photos" are rejected)
   - Notes defaulted to the message content
   - Source media (image/file) attached as the first document
4. Admin confirms / edits amount and notes → Create. Submission lands as \`Draft\` for normal admin review.

## Why no backend changes

The existing \`POST /admin/payment-submissions\` already accepts \`{ partner_id, notes, documents, metadata }\`. We just stamp \`metadata\` with \`from_message_id\`, \`from_conversation_id\`, \`suggested_amount\`, \`entered_amount\`, and \`source: "messaging_inbox_extract"\` so the review UI can later show provenance and divergence between extracted vs entered amount. No design / task linkage from this surface — admin associates those during normal payment review.

This keeps the create payload **shape-identical** to what the upcoming partner WhatsApp \`payment <amount>\` text command (Phase 2) will send, so both surfaces share one server path.

## Files

| File | Change |
|---|---|
| \`create-payment-from-message-modal.tsx\` | new \`FocusModal\` component; read-only message preview, amount + notes inputs, \`useCreatePaymentSubmission\` mutation |
| \`extract-amount.ts\` | pure regex helper (3-branch alt: prefix / suffix / bare); standalone for testability |
| \`__tests__/extract-amount.unit.spec.ts\` | **9 tests** — currency markers, comma grouping, decimals, false-positive rejection, bound checks |
| \`message-bubble.tsx\` | adds optional \`onCreatePayment\` callback; inbound-only kebab via \`DropdownMenu\` next to Reply |
| \`messaging/[conversationId]/page.tsx\` | owns single modal instance via \`paymentMessage\` state, passes the callback + partner_id + partner_name down |

## Test plan

- [x] \`pnpm test:unit extract-amount\` → 9/9 pass
- [ ] After deploy: open a conversation that has an inbound media message, hover, see kebab → "Create payment request from this message"
- [ ] Modal opens with media preview, suggested amount (if message text has one), partner name
- [ ] Submit → toast success → Draft submission visible in /admin/payment-submissions list with metadata.from_message_id matching the original message

## What's next

- **Phase 2** — partner-side \`payment <amount>\` text command in the WhatsApp handler. Tiny scope now that this exists; just calls the same backend endpoint with the partner-side workflow.
- **Phase 3** — admin-side payment-status visual flow seeded like \`seed-partner-run-whatsapp-flow.ts\` (templates need Meta approval first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)