### PR TITLE
fix(messaging): add design + task pickers to payment modal (orphaned from #178)

### DIFF
--- a/apps/backend/src/admin/routes/messaging/components/create-payment-from-message-modal.tsx
+++ b/apps/backend/src/admin/routes/messaging/components/create-payment-from-message-modal.tsx
@@ -6,12 +6,123 @@ import {
   Label,
   Textarea,
   Text,
+  Badge,
   toast,
   Tooltip,
+  clx,
 } from "@medusajs/ui"
 import { useCreatePaymentSubmission } from "../../../hooks/api/payment-submissions"
 import type { Message } from "../../../hooks/api/messaging"
+import { useDesigns } from "../../../hooks/api/designs"
+import { usePartnerTasks } from "../../../hooks/api/partner-tasks"
 import { extractSuggestedAmount } from "./extract-amount"
+
+// Small reusable chip-picker: search input → dropdown of suggestions →
+// selected items rendered as removable chips above the input. Used
+// twice in this modal (designs + tasks). Kept inline because the rest
+// of the codebase doesn't have a need for it yet; promote to a shared
+// component when a second consumer shows up.
+type PickerItem = { id: string; label: string; sub?: string }
+const ChipPicker = ({
+  items,
+  selected,
+  onAdd,
+  onRemove,
+  placeholder,
+  loading,
+}: {
+  items: PickerItem[]
+  selected: PickerItem[]
+  onAdd: (id: string) => void
+  onRemove: (id: string) => void
+  placeholder: string
+  loading?: boolean
+}) => {
+  const [search, setSearch] = useState("")
+  const [openDropdown, setOpenDropdown] = useState(false)
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    const selectedIds = new Set(selected.map((s) => s.id))
+    return items
+      .filter((i) => !selectedIds.has(i.id))
+      .filter(
+        (i) =>
+          !q ||
+          i.label.toLowerCase().includes(q) ||
+          i.sub?.toLowerCase().includes(q),
+      )
+      .slice(0, 20)
+  }, [items, selected, search])
+
+  return (
+    <div>
+      {selected.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mb-2">
+          {selected.map((s) => (
+            <Badge
+              key={s.id}
+              size="2xsmall"
+              color="grey"
+              className="cursor-pointer"
+              onClick={() => onRemove(s.id)}
+              title="Remove"
+            >
+              {s.label} ×
+            </Badge>
+          ))}
+        </div>
+      )}
+      <div className="relative">
+        <Input
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value)
+            setOpenDropdown(true)
+          }}
+          onFocus={() => setOpenDropdown(true)}
+          onBlur={() => {
+            // Delay so click on dropdown item lands before blur kills it.
+            setTimeout(() => setOpenDropdown(false), 150)
+          }}
+          placeholder={placeholder}
+          disabled={loading}
+        />
+        {openDropdown && (filtered.length > 0 || (!loading && search)) && (
+          <div className="absolute z-10 mt-1 w-full max-h-56 overflow-y-auto rounded-md border border-ui-border-base bg-ui-bg-base shadow-md">
+            {filtered.length === 0 ? (
+              <div className="px-3 py-2 text-sm text-ui-fg-muted">
+                No matches.
+              </div>
+            ) : (
+              filtered.map((it) => (
+                <button
+                  key={it.id}
+                  type="button"
+                  onMouseDown={(e) => e.preventDefault()} // keep input focus
+                  onClick={() => {
+                    onAdd(it.id)
+                    setSearch("")
+                  }}
+                  className={clx(
+                    "block w-full text-left px-3 py-2 text-sm",
+                    "hover:bg-ui-bg-base-hover",
+                  )}
+                >
+                  <div className="font-medium truncate">{it.label}</div>
+                  {it.sub && (
+                    <div className="text-xs text-ui-fg-muted truncate">
+                      {it.sub}
+                    </div>
+                  )}
+                </button>
+              ))
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
 
 type Props = {
   open: boolean
@@ -35,13 +146,57 @@ export const CreatePaymentFromMessageModal = ({
 
   const [amount, setAmount] = useState<string>("")
   const [notes, setNotes] = useState<string>("")
+  const [selectedDesignIds, setSelectedDesignIds] = useState<string[]>([])
+  const [selectedTaskIds, setSelectedTaskIds] = useState<string[]>([])
+
+  // Designs + tasks for the partner. The workflow requires at least one
+  // design_id (createPaymentSubmissionWorkflow line 91), so we surface a
+  // picker here rather than letting the submit fail with a server error.
+  // Tasks are optional. Both are scoped server-side by partner_id so the
+  // admin only sees this partner's eligible items.
+  const { designs = [], isPending: designsLoading } = useDesigns(
+    { partner_id: partnerId, limit: 200 },
+    { enabled: !!partnerId && open },
+  )
+  const { tasks = [], isPending: tasksLoading } = usePartnerTasks(partnerId, {
+    enabled: !!partnerId && open,
+  })
+
+  const designItems: PickerItem[] = useMemo(
+    () =>
+      (designs as any[]).map((d) => ({
+        id: d.id,
+        label: d.name || d.id,
+        sub: d.status ? d.status.replace(/_/g, " ") : undefined,
+      })),
+    [designs],
+  )
+  const taskItems: PickerItem[] = useMemo(
+    () =>
+      (tasks as any[]).map((t) => ({
+        id: t.id,
+        label: t.title || t.id,
+        sub: t.status ? t.status.replace(/_/g, " ") : undefined,
+      })),
+    [tasks],
+  )
+  const selectedDesigns = useMemo(
+    () => designItems.filter((d) => selectedDesignIds.includes(d.id)),
+    [designItems, selectedDesignIds],
+  )
+  const selectedTasks = useMemo(
+    () => taskItems.filter((t) => selectedTaskIds.includes(t.id)),
+    [taskItems, selectedTaskIds],
+  )
 
   // Reset form whenever a new message is loaded into the modal so we don't
-  // leak the previous amount/notes across separate "Create payment" clicks.
+  // leak the previous amount/notes/selections across separate clicks.
   useEffect(() => {
     if (!message) return
     setAmount(suggested ? String(suggested) : "")
     setNotes(message.content?.trim() ?? "")
+    setSelectedDesignIds([])
+    setSelectedTaskIds([])
   }, [message?.id, suggested])
 
   const createMutation = useCreatePaymentSubmission({
@@ -64,6 +219,13 @@ export const CreatePaymentFromMessageModal = ({
       return
     }
 
+    // The workflow requires ≥1 design — fail fast in the UI rather than
+    // at the server with an opaque MedusaError.
+    if (selectedDesignIds.length === 0) {
+      toast.error("Pick at least one design to associate with this payment")
+      return
+    }
+
     // Documents from the message: the inbound media if any. Filename falls
     // back to the URL's last segment so the review UI has something to show.
     const documents = message.media_url
@@ -78,12 +240,8 @@ export const CreatePaymentFromMessageModal = ({
 
     createMutation.mutate({
       partner_id: partnerId,
-      // No design / task linkage from this surface — admin will associate
-      // those during review. Keeping the create payload minimal lets the
-      // partner WhatsApp text command (`payment 1500`) reuse the same
-      // shape later without divergent code paths.
-      design_ids: [],
-      task_ids: [],
+      design_ids: selectedDesignIds,
+      task_ids: selectedTaskIds,
       notes: notes || undefined,
       documents,
       metadata: {
@@ -176,6 +334,60 @@ export const CreatePaymentFromMessageModal = ({
                 onChange={(e) => setAmount(e.target.value)}
                 placeholder="e.g. 1500"
                 autoFocus
+              />
+            </div>
+
+            <div className="mb-4">
+              <Label>
+                Linked designs{" "}
+                <Text size="xsmall" className="inline text-ui-fg-muted">
+                  — required, pick at least one
+                </Text>
+              </Label>
+              <ChipPicker
+                items={designItems}
+                selected={selectedDesigns}
+                onAdd={(id) =>
+                  setSelectedDesignIds((prev) =>
+                    prev.includes(id) ? prev : [...prev, id],
+                  )
+                }
+                onRemove={(id) =>
+                  setSelectedDesignIds((prev) => prev.filter((x) => x !== id))
+                }
+                placeholder={
+                  designsLoading
+                    ? "Loading designs…"
+                    : `Search this partner's designs (${designItems.length} available)`
+                }
+                loading={designsLoading}
+              />
+            </div>
+
+            <div className="mb-4">
+              <Label>
+                Linked tasks{" "}
+                <Text size="xsmall" className="inline text-ui-fg-muted">
+                  — optional
+                </Text>
+              </Label>
+              <ChipPicker
+                items={taskItems}
+                selected={selectedTasks}
+                onAdd={(id) =>
+                  setSelectedTaskIds((prev) =>
+                    prev.includes(id) ? prev : [...prev, id],
+                  )
+                }
+                onRemove={(id) =>
+                  setSelectedTaskIds((prev) => prev.filter((x) => x !== id))
+                }
+                placeholder={
+                  tasksLoading
+                    ? "Loading tasks…"
+                    : `Search this partner's tasks (${taskItems.length} available)`
+                }
+                loading={tasksLoading}
               />
             </div>
 


### PR DESCRIPTION
## Summary

Hotfix — same pattern as #177. This commit was on the PR #178 branch but didn't make it into the squashed merge to main. Without it, clicking "Create payment request from this message" → fill amount → submit fails with \`INVALID_DATA\` because \`design_ids: []\` and the workflow requires ≥1 design (\`createPaymentSubmissionWorkflow\` line 91).

## What lands

Two stacked chip-pickers in the modal, between Amount and Notes:
- **Linked designs** (required, ≥1) — \`useDesigns({ partner_id })\`
- **Linked tasks** (optional) — \`usePartnerTasks(partnerId)\`

Each: search input → suggestion dropdown → selected items as removable chips above. Submit fails fast in the UI with a useful toast if no design picked, instead of the server error.

## Test plan

- [ ] After deploy, open a partner conversation, hover an inbound message, kebab → "Create payment request"
- [ ] Modal shows two pickers; designs disabled until loaded; once loaded, search works
- [ ] Pick at least one design → submit → Draft submission created with proper \`design_ids\` array
- [ ] Try submit without picking → toast "Pick at least one design"

🤖 Generated with [Claude Code](https://claude.com/claude-code)