### PR TITLE
fix(admin): allow limit/offset/q/status on /admin/partners list

### DIFF
--- a/apps/backend/src/api/admin/partners/validators.ts
+++ b/apps/backend/src/api/admin/partners/validators.ts
@@ -39,6 +39,18 @@ export const listPartnersQuerySchema = z.object({
     }
     return undefined
   }, z.string().optional()),
+  // Pagination + filters used by the admin UI's partner list (page.tsx →
+  // usePartners). Without these the validator rejects the request with
+  // "Unrecognized fields: 'limit, offset'" and the table renders empty.
+  // Mirrors the schema for /admin/persons/partner so both list endpoints
+  // accept the same params.
+  offset: z.coerce.number().int().min(0).optional(),
+  limit: z.coerce.number().int().min(1).max(200).optional(),
+  q: z.string().optional(),
+  name: z.string().optional(),
+  handle: z.string().optional(),
+  status: z.enum(["active", "inactive", "pending"]).optional(),
+  is_verified: z.enum(["true", "false"]).optional(),
 })
 
 export type PostPartnerWithAdminSchema = z.infer<typeof PostPartnerSchema>


### PR DESCRIPTION
## Summary

The admin partners list page renders empty (no rows) because the request 400s with:

\`\`\`json
{ "message": "Invalid request: Unrecognized fields: 'limit, offset'" }
\`\`\`

\`listPartnersQuerySchema\` (in \`src/api/admin/partners/validators.ts\`) only declared \`fields\`. Strict Zod \`.object()\` rejects everything else. The admin UI's \`usePartners\` hook (\`hooks/api/partners-admin.ts\`) sends \`limit\`, \`offset\`, \`q\`, \`status\`, \`is_verified\` — all bounced before reaching the route handler.

## Fix

Add those fields to the schema (mirroring \`/admin/persons/partner/validators.ts\` which already accepts the same shape). The route handler at \`route.ts:176-177\` already reads them — it just never received them past the validator.

## Test plan

- [ ] After deploy, open \`/app/partners\` in admin → table populated.
- [ ] Filter by status → results filter correctly.
- [ ] Pagination → next page loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)