### PR TITLE
fix(admin): use replace navigation after dashboard delete

### DIFF
--- a/apps/backend/src/admin/routes/stats/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/stats/[id]/page.tsx
@@ -52,7 +52,10 @@ const DashboardDetailPage = () => {
     deleteDashboard.mutate(id, {
       onSuccess: () => {
         toast.success("Dashboard deleted")
-        navigate("/stats")
+        // replace: true so the deleted dashboard URL doesn't stay on
+        // the back stack — pressing back from /stats would otherwise
+        // land on the now-404 detail route.
+        navigate("/stats", { replace: true })
       },
       onError: (e) => toast.error(`Failed: ${e.message}`),
     })


### PR DESCRIPTION
Without { replace: true } the deleted /stats/<id> URL stays on the
back stack and pressing back from /stats lands on a 404. Matches the
pattern used in partner/design/visual-flow/folder general sections.
