### PR TITLE
fix(websites): backfill default pages and surface domain aliases in admin

### DIFF
--- a/apps/backend/src/admin/components/websites/website-general-section.tsx
+++ b/apps/backend/src/admin/components/websites/website-general-section.tsx
@@ -1,5 +1,6 @@
 import { PencilSquare, ChartBar, BoltSolid } from "@medusajs/icons";
 import {
+  Badge,
   Container,
   Heading,
   Text,
@@ -89,20 +90,38 @@ export function WebsiteGeneralSection({ website }: WebsiteGeneralSectionProps) {
           }]} />
         </div>
       </div>
-      <div className="text-ui-fg-subtle grid grid-cols-2 items-center px-6 py-4">
+      <div className="text-ui-fg-subtle grid grid-cols-2 items-start px-6 py-4">
         <Text size="small" leading="compact" weight="plus">
-          Domain
+          Domains
         </Text>
-        <Text size="small" leading="compact">
-          <a
-            href={`https://${website.domain}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-blue-500 hover:underline"
-          >
-            {website.domain}
-          </a>
-        </Text>
+        <div className="flex flex-col gap-y-2">
+          <div className="flex items-center gap-x-2">
+            <a
+              href={`https://${website.domain}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-500 hover:underline text-sm"
+            >
+              {website.domain}
+            </a>
+            <Badge size="2xsmall" color="green">primary</Badge>
+          </div>
+          {(website.domains ?? [])
+            .filter((d) => d.domain !== website.domain && !d.is_primary)
+            .map((d) => (
+              <div key={d.id} className="flex items-center gap-x-2">
+                <a
+                  href={`https://${d.domain}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-500 hover:underline text-sm"
+                >
+                  {d.domain}
+                </a>
+                <Badge size="2xsmall" color="grey">alias</Badge>
+              </div>
+            ))}
+        </div>
       </div>
       <div className="text-ui-fg-subtle grid grid-cols-2 items-center px-6 py-4">
         <Text size="small" leading="compact" weight="plus">

--- a/apps/backend/src/admin/hooks/api/websites.ts
+++ b/apps/backend/src/admin/hooks/api/websites.ts
@@ -33,9 +33,19 @@ type Pages= [ {
   updated_at: Date;
 }]
 
-export type AdminWebsite = WebsiteSchema & { 
+export type WebsiteDomainAlias = {
+  id: string;
+  domain: string;
+  is_primary: boolean;
+  website_id?: string;
+  created_at?: Date;
+  updated_at?: Date;
+};
+
+export type AdminWebsite = WebsiteSchema & {
   id: string;
   pages: Pages
+  domains?: WebsiteDomainAlias[]
   created_at: Date;
   updated_at: Date;
 };

--- a/apps/backend/src/api/admin/websites/[id]/route.ts
+++ b/apps/backend/src/api/admin/websites/[id]/route.ts
@@ -158,9 +158,9 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const { id } = req.params;
 
   try {
-    const website = await websiteService.retrieveWebsite(id, 
+    const website = await websiteService.retrieveWebsite(id,
       {
-        relations:['pages']  
+        relations:['pages', 'domains']
       }
     );
     res.status(200).json({ website });

--- a/apps/backend/src/api/admin/websites/route.ts
+++ b/apps/backend/src/api/admin/websites/route.ts
@@ -137,7 +137,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
 
   const workflowInput: ListWebsiteWorkflowInput = {
     config: {
-      relations: ["pages"],
+      relations: ["pages", "domains"],
       skip: offset,
       take: limit
     },

--- a/apps/backend/src/scripts/backfill-website-default-pages.ts
+++ b/apps/backend/src/scripts/backfill-website-default-pages.ts
@@ -1,0 +1,76 @@
+/**
+ * Backfill: default pages for every existing website.
+ *
+ * Some websites were created before the provisioning workflow seeded
+ * Terms, Privacy, and Contact pages — or were created via paths that
+ * skipped the seed step entirely. This script walks every website and
+ * runs `seedDefaultPagesWorkflow` for each one. The seed workflow is
+ * idempotent (it skips slugs that already exist), so this is safe to
+ * re-run.
+ *
+ * Run:
+ *   npx medusa exec ./src/scripts/backfill-website-default-pages.ts
+ */
+
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { WEBSITE_MODULE } from "../modules/website"
+import WebsiteService from "../modules/website/service"
+import { seedDefaultPagesWorkflow } from "../workflows/website/seed-default-pages"
+
+export default async function backfillWebsiteDefaultPages({ container }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const websiteService: WebsiteService = container.resolve(WEBSITE_MODULE)
+
+  const PAGE_SIZE = 100
+  let offset = 0
+  let totalWebsites = 0
+  let totalCreated = 0
+  let totalSkipped = 0
+  const failures: Array<{ website_id: string; error: string }> = []
+
+  logger.info("Backfilling default pages across all websites...")
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const [websites] = await websiteService.listAndCountWebsites(
+      {},
+      { take: PAGE_SIZE, skip: offset, order: { created_at: "ASC" } },
+    )
+    if (!websites.length) break
+
+    for (const website of websites) {
+      totalWebsites++
+      try {
+        const { result } = await seedDefaultPagesWorkflow(container).run({
+          input: { website_id: website.id },
+        })
+        const created = result?.pages?.length ?? 0
+        const skipped = result?.skipped?.length ?? 0
+        totalCreated += created
+        totalSkipped += skipped
+        if (created > 0) {
+          logger.info(
+            `  ${website.id} (${website.domain}) — created ${created}, skipped ${skipped}`,
+          )
+        }
+      } catch (e: any) {
+        failures.push({ website_id: website.id, error: e.message })
+        logger.error(
+          `  ${website.id} (${website.domain}) — failed: ${e.message}`,
+        )
+      }
+    }
+
+    if (websites.length < PAGE_SIZE) break
+    offset += PAGE_SIZE
+  }
+
+  logger.info(
+    `Done. Walked ${totalWebsites} websites — created ${totalCreated} pages, skipped ${totalSkipped} already-present, ${failures.length} failures.`,
+  )
+
+  if (failures.length > 0) {
+    logger.warn(`Failed websites: ${failures.map((f) => f.website_id).join(", ")}`)
+  }
+}

--- a/apps/backend/src/workflows/stores/provision-storefront.ts
+++ b/apps/backend/src/workflows/stores/provision-storefront.ts
@@ -294,27 +294,24 @@ const createWebsiteRecordStep = createStep(
   }
 )
 
-// Step 8: Seed default pages for the website
+// Step 8: Seed default pages for the website. Always runs — the seed
+// workflow itself is idempotent (it skips slugs that already exist), so
+// re-provisions and previously-created-but-unseeded websites self-heal.
 const seedDefaultWebsitePagesStep = createStep(
   "seed-default-website-pages",
   async (
-    input: { websiteId: string; wasCreated: boolean },
+    input: { websiteId: string },
     { container }
   ) => {
-    // Only seed pages if we just created the website
-    if (!input.wasCreated) {
-      return new StepResponse({ skipped: true })
-    }
-
     try {
       const { result } = await seedDefaultPagesWorkflow(container).run({
         input: { website_id: input.websiteId },
       })
-      return new StepResponse({ skipped: false, pages: result?.pages })
+      return new StepResponse({ pages: result?.pages, skipped_slugs: result?.skipped })
     } catch (e: any) {
       // Non-fatal — provisioning should succeed even if page seeding fails
       console.error("[provision-storefront] Page seeding failed:", e.message)
-      return new StepResponse({ skipped: false, error: e.message })
+      return new StepResponse({ error: e.message })
     }
   }
 )
@@ -334,7 +331,6 @@ export const provisionStorefrontWorkflow = createWorkflow(
     // Step 2: Seed default pages for the website
     seedDefaultWebsitePagesStep({
       websiteId: websiteResult.website.id as unknown as string,
-      wasCreated: websiteResult.created as unknown as boolean,
     })
 
     // Step 3: Create Vercel project (linked directly to the storefront repo)


### PR DESCRIPTION
- Drop the wasCreated gate on seedDefaultWebsitePagesStep so re-provisions
  and previously-created-but-unseeded websites self-heal. The seed
  workflow is already idempotent via slug check.
- Add backfill-website-default-pages.ts to retroactively seed pages on
  every existing website. Safe to re-run.
- Include the website_domain relation in admin website list + detail
  responses so the admin UI can see alias domains alongside the primary
  one without a separate /domains call.
- Render primary + alias domains in the website general section as a
  list with primary/alias badges.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
