### PR TITLE
feat(partners): in-app notification feed scoped by receiver_id

### DIFF
--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -1440,6 +1440,31 @@ export default defineMiddlewares({
         authenticate("partner", ["session", "bearer"]),
       ],
     },
+    // Partner Notifications (in-app bell)
+    {
+      matcher: "/partners/notifications",
+      method: "GET",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
+    {
+      matcher: "/partners/notifications/unread-count",
+      method: "GET",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
+    {
+      matcher: "/partners/notifications/mark-all-read",
+      method: "POST",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
     // Partner Storefront Pages
     {
       matcher: "/partners/storefront/pages",

--- a/apps/backend/src/api/partners/notifications/helpers.ts
+++ b/apps/backend/src/api/partners/notifications/helpers.ts
@@ -1,0 +1,60 @@
+import { MedusaContainer } from "@medusajs/framework"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { getPartnerFromAuthContext } from "../helpers"
+
+const LAST_SEEN_KEY = "notifications_last_seen_at"
+
+export type ResolvedPartnerForNotifications = {
+  id: string
+  metadata: Record<string, any>
+  /** ISO timestamp; never null — partners with no prior reads get epoch 0. */
+  last_seen_at: string
+}
+
+export const resolvePartnerForNotifications = async (
+  authContext: { actor_id?: string | null } | undefined,
+  container: MedusaContainer,
+): Promise<ResolvedPartnerForNotifications> => {
+  const partner = await getPartnerFromAuthContext(authContext, container)
+  if (!partner) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "No partner associated with this account",
+    )
+  }
+  const metadata = (partner.metadata as Record<string, any>) ?? {}
+  const last_seen_at =
+    typeof metadata[LAST_SEEN_KEY] === "string"
+      ? (metadata[LAST_SEEN_KEY] as string)
+      : new Date(0).toISOString()
+  return { id: partner.id, metadata, last_seen_at }
+}
+
+/**
+ * Bumps `partner.metadata.notifications_last_seen_at` to `at` (default now).
+ * Reads existing metadata first and merges to avoid clobbering other keys.
+ *
+ * Uses query.graph to refetch so we have an authoritative snapshot of
+ * metadata in case the auth-context partner came from a stale cache.
+ */
+export const setPartnerNotificationsLastSeen = async (
+  partnerId: string,
+  container: MedusaContainer,
+  at: Date = new Date(),
+): Promise<string> => {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const { data } = await query.graph({
+    entity: "partners",
+    fields: ["id", "metadata"],
+    filters: { id: partnerId },
+  })
+  const existing = (data?.[0] as any)?.metadata ?? {}
+  const ts = at.toISOString()
+
+  const partnerService: any = container.resolve("partner")
+  await partnerService.updatePartners({
+    id: partnerId,
+    metadata: { ...existing, [LAST_SEEN_KEY]: ts },
+  })
+  return ts
+}

--- a/apps/backend/src/api/partners/notifications/mark-all-read/route.ts
+++ b/apps/backend/src/api/partners/notifications/mark-all-read/route.ts
@@ -1,0 +1,38 @@
+/**
+ * POST /partners/notifications/mark-all-read
+ *
+ * Bumps `partner.metadata.notifications_last_seen_at` to now() so all
+ * existing notifications become "read" from the bell's perspective.
+ *
+ * We track read state via a single per-partner timestamp (channel-level
+ * last-read marker, like Slack/GitHub) instead of per-notification flags.
+ * The standard Medusa notification entity has no `read_at` column and
+ * adding one would mean shipping a migration against framework tables —
+ * this approach gets the same UX without that risk.
+ */
+
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import {
+  resolvePartnerForNotifications,
+  setPartnerNotificationsLastSeen,
+} from "../helpers"
+
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse,
+) => {
+  const partner = await resolvePartnerForNotifications(
+    req.auth_context,
+    req.scope,
+  )
+
+  const ts = await setPartnerNotificationsLastSeen(partner.id, req.scope)
+
+  return res.status(200).json({
+    last_seen_at: ts,
+    unread_count: 0,
+  })
+}

--- a/apps/backend/src/api/partners/notifications/route.ts
+++ b/apps/backend/src/api/partners/notifications/route.ts
@@ -1,0 +1,115 @@
+/**
+ * GET /partners/notifications
+ *
+ * Lists the bell feed for the authenticated partner. Notifications are
+ * scoped via `receiver_id = partner.id`, which is a first-class field
+ * on Medusa's standard notification entity (confirmed in MCP — see PR
+ * #185 thread). No custom model required.
+ *
+ * Each row is annotated with `is_unread` relative to the partner's
+ * `metadata.notifications_last_seen_at` timestamp so the bell can render
+ * unread badges without a separate fetch per row.
+ *
+ * Query params:
+ *   limit, offset       — pagination (default 20 / 0)
+ *   q                   — free-text search (delegated to query.graph)
+ *   channel             — e.g. "feed" / "email" / "whatsapp"
+ *   trigger_type        — filter by producing event
+ *   resource_type       — filter by what the row is about
+ *   only_unread         — "true" returns only unread rows
+ */
+
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { resolvePartnerForNotifications } from "./helpers"
+
+const NOTIFICATION_FIELDS = [
+  "id",
+  "to",
+  "channel",
+  "template",
+  "external_id",
+  "provider_id",
+  "trigger_type",
+  "resource_type",
+  "resource_id",
+  "receiver_id",
+  "data",
+  "created_at",
+] as const
+
+const parseBool = (v: unknown): boolean =>
+  v === "true" || v === "1" || v === true
+
+const parseInteger = (v: unknown, fallback: number): number => {
+  if (v === undefined || v === null || v === "") return fallback
+  const n = Number(v)
+  return Number.isFinite(n) ? Math.max(0, Math.floor(n)) : fallback
+}
+
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse,
+) => {
+  const partner = await resolvePartnerForNotifications(
+    req.auth_context,
+    req.scope,
+  )
+
+  const limit = Math.min(parseInteger(req.query.limit, 20), 100)
+  const offset = parseInteger(req.query.offset, 0)
+  const onlyUnread = parseBool(req.query.only_unread)
+
+  const filters: Record<string, any> = { receiver_id: partner.id }
+  if (typeof req.query.channel === "string" && req.query.channel.trim()) {
+    filters.channel = req.query.channel.trim()
+  }
+  if (
+    typeof req.query.trigger_type === "string" &&
+    req.query.trigger_type.trim()
+  ) {
+    filters.trigger_type = req.query.trigger_type.trim()
+  }
+  if (
+    typeof req.query.resource_type === "string" &&
+    req.query.resource_type.trim()
+  ) {
+    filters.resource_type = req.query.resource_type.trim()
+  }
+  if (typeof req.query.q === "string" && req.query.q.trim()) {
+    filters.q = req.query.q.trim()
+  }
+  if (onlyUnread) {
+    filters.created_at = { $gt: partner.last_seen_at }
+  }
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data, metadata } = await query.graph({
+    entity: "notifications",
+    fields: NOTIFICATION_FIELDS as unknown as string[],
+    filters,
+    pagination: {
+      skip: offset,
+      take: limit,
+      order: { created_at: "DESC" },
+    },
+  })
+
+  const lastSeenMs = new Date(partner.last_seen_at).getTime()
+  const annotated = ((data as any[]) || []).map((n: any) => ({
+    ...n,
+    is_unread: new Date(n.created_at).getTime() > lastSeenMs,
+  }))
+
+  return res.status(200).json({
+    notifications: annotated,
+    count: (metadata as any)?.count ?? annotated.length,
+    offset,
+    limit,
+    last_seen_at: partner.last_seen_at,
+  })
+}

--- a/apps/backend/src/api/partners/notifications/unread-count/route.ts
+++ b/apps/backend/src/api/partners/notifications/unread-count/route.ts
@@ -1,0 +1,44 @@
+/**
+ * GET /partners/notifications/unread-count
+ *
+ * Single-count endpoint for the bell badge. Counts notifications with
+ * `receiver_id = partner.id` and `created_at > partner.metadata.notifications_last_seen_at`.
+ *
+ * Cheap and cacheable — designed to be polled by the bell on an interval
+ * (every 30–60s) without hammering the DB. Returns just the integer +
+ * the last-seen timestamp so the client can short-circuit re-renders.
+ */
+
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { resolvePartnerForNotifications } from "../helpers"
+
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse,
+) => {
+  const partner = await resolvePartnerForNotifications(
+    req.auth_context,
+    req.scope,
+  )
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { metadata } = await query.graph({
+    entity: "notifications",
+    // Minimal field selection — we only need the count from the metadata.
+    fields: ["id"],
+    filters: {
+      receiver_id: partner.id,
+      created_at: { $gt: partner.last_seen_at },
+    },
+    pagination: { skip: 0, take: 1 },
+  })
+
+  return res.status(200).json({
+    unread_count: (metadata as any)?.count ?? 0,
+    last_seen_at: partner.last_seen_at,
+  })
+}

--- a/apps/backend/src/lib/notifications/create-partner-notification.ts
+++ b/apps/backend/src/lib/notifications/create-partner-notification.ts
@@ -1,0 +1,135 @@
+import { Modules, ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import type {
+  INotificationModuleService,
+  Logger,
+} from "@medusajs/framework/types"
+
+/**
+ * Create a feed-channel notification scoped to a partner.
+ *
+ * Produces a row that the partner notification bell (GET /partners/notifications)
+ * picks up via `receiver_id = partner.id`. The standard Medusa notification
+ * entity already has `receiver_id` as a first-class, filterable field — see
+ * MCP confirmation in PR #185 thread — so we don't need a separate model.
+ *
+ * Failures are logged and swallowed. Notifications are observability, not
+ * causal: never block the producing workflow on a failed audit row.
+ *
+ * Mirrors `recordWhatsappNotification` (modules/messaging/lib) — same
+ * tolerance, same shape, just defaulted to channel=feed for in-app display.
+ */
+export type CreatePartnerNotificationInput = {
+  /** Partner uuid. Stored on notification.receiver_id and used as the bell scope. */
+  partner_id: string
+  /**
+   * Title shown in the bell. Goes into `data.title` so the bell renderer
+   * can read it without a join. Required.
+   */
+  title: string
+  /** Body text shown under the title. Goes into `data.description`. */
+  description?: string | null
+  /** Optional URL the bell entry links to (e.g. /production-runs/<id>). */
+  url?: string | null
+  /**
+   * What the notification is about. Useful for filtering in the UI.
+   * Examples: "production_run", "order", "payment_submission".
+   */
+  resource_type?: string | null
+  resource_id?: string | null
+  /**
+   * Event/workflow that produced this notification. Examples:
+   * "production_run.assigned", "order.placed", "payment.approved".
+   */
+  trigger_type?: string | null
+  /**
+   * Stable dedup key. Pass the same value when re-running a workflow that
+   * shouldn't double-notify (e.g. reminder cron jobs).
+   */
+  idempotency_key?: string | null
+  /**
+   * Free-form extra data merged onto notification.data alongside title/
+   * description/url. Use for renderer-specific bits (icon, severity, etc.).
+   */
+  data?: Record<string, unknown>
+  /**
+   * Override the channel. Defaults to "feed" for the in-app bell. Override
+   * to "email" / "whatsapp" / etc. only when you specifically want a
+   * partner-scoped notification on another channel.
+   */
+  channel?: string
+  /**
+   * Recipient identifier for the channel. For feed, default is the
+   * partner_id (acts as a routing key). For email, pass the email address.
+   */
+  to?: string
+  /**
+   * Template id when the channel needs one (email/whatsapp). Feed
+   * notifications don't need a template — leave empty.
+   */
+  template?: string
+}
+
+/**
+ * @returns true if the row was created (or de-duped), false on failure.
+ */
+export async function createPartnerNotification(
+  scope: any,
+  input: CreatePartnerNotificationInput
+): Promise<boolean> {
+  const logger: Logger | null = (() => {
+    try {
+      return scope.resolve(ContainerRegistrationKeys.LOGGER) as Logger
+    } catch {
+      return null
+    }
+  })()
+
+  if (!input.partner_id || !input.title) {
+    logger?.warn(
+      `[partner-notification] missing partner_id or title — refusing to create`
+    )
+    return false
+  }
+
+  let notificationService: INotificationModuleService
+  try {
+    notificationService = scope.resolve(
+      Modules.NOTIFICATION
+    ) as INotificationModuleService
+  } catch (e: any) {
+    logger?.warn(
+      `[partner-notification] notification module not resolvable: ${e?.message}`
+    )
+    return false
+  }
+
+  const channel = input.channel ?? "feed"
+  const to = input.to ?? input.partner_id
+
+  const data: Record<string, unknown> = {
+    ...(input.data ?? {}),
+    title: input.title,
+    description: input.description ?? null,
+    url: input.url ?? null,
+  }
+
+  try {
+    await notificationService.createNotifications({
+      to,
+      channel,
+      template: input.template ?? "",
+      data,
+      trigger_type: input.trigger_type ?? undefined,
+      resource_type: input.resource_type ?? undefined,
+      resource_id: input.resource_id ?? undefined,
+      receiver_id: input.partner_id,
+      idempotency_key: input.idempotency_key ?? undefined,
+    } as any)
+    return true
+  } catch (e: any) {
+    logger?.warn(
+      `[partner-notification] create failed (partner=${input.partner_id} trigger=${input.trigger_type ?? "?"}): ${e?.message}`
+    )
+    return false
+  }
+}


### PR DESCRIPTION
Adds the backend half of the partner notification bell. Three routes,
all scoped by `receiver_id = partner.id` — a first-class field on
Medusa's standard notification entity (confirmed via MCP), so we don't
need a custom model:

  GET  /partners/notifications              — paginated feed; each row
                                              annotated with is_unread
  GET  /partners/notifications/unread-count — single integer for the
                                              bell badge; cheap to poll
  POST /partners/notifications/mark-all-read — bumps the partner's
                                              last-seen timestamp

Read state is tracked via a single per-partner timestamp on
`partner.metadata.notifications_last_seen_at` (channel-level last-read
marker, like Slack/GitHub). Avoids a migration against the framework's
notification table for a per-row read_at column.

Producer helper at src/lib/notifications/create-partner-notification.ts
wraps NotificationModuleService.createNotifications with sane defaults
for the feed channel + partner_id receiver, so future subscribers and
workflows have a one-liner for emitting bell entries:

    await createPartnerNotification(container, {
      partner_id, title, description, url, trigger_type, resource_id,
    })

Wired CORS + partner auth into middlewares.ts. Frontend bell wiring
lands in a follow-up partner-ui PR.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
