### PR TITLE
feat(visual-flows): partner-targeted notifications + local test script

### DIFF
--- a/apps/backend/src/modules/visual_flows/operations/notification.ts
+++ b/apps/backend/src/modules/visual_flows/operations/notification.ts
@@ -6,58 +6,143 @@ import { Modules } from "@medusajs/framework/utils"
 export const notificationOperation: OperationDefinition = {
   type: "notification",
   name: "Send Notification",
-  description: "Send a notification to the admin feed",
+  description:
+    "Drop a notification into the admin feed, or — when partner_id is set — into a specific partner's bell.",
   icon: "bell",
   category: "communication",
-  
+
   optionsSchema: z.object({
     title: z.string().describe("Notification title"),
     description: z.string().optional().describe("Notification description"),
-    to: z.string().optional().describe("User ID to send to (optional)"),
+    /**
+     * When set, the notification is scoped to this partner via
+     * `receiver_id`. The partner's bell (GET /partners/notifications)
+     * filters on receiver_id, so the entry shows up there instead of
+     * the admin feed. Templates can interpolate from the data chain
+     * (e.g. "{{trigger.partner_id}}").
+     */
+    partner_id: z
+      .string()
+      .optional()
+      .describe(
+        "Partner UUID to target. Sets receiver_id so the notification lands in that partner's bell.",
+      ),
+    /**
+     * Optional URL the bell entry links to (e.g. /production-runs/<id>).
+     * Persisted under data.url so the bell renderer can pick it up.
+     */
+    url: z
+      .string()
+      .optional()
+      .describe(
+        "Optional URL the bell row links to when clicked.",
+      ),
+    to: z
+      .string()
+      .optional()
+      .describe(
+        "Channel-specific recipient. Defaults to partner_id when partner_id is set, else 'admin'.",
+      ),
     channel: z.string().default("feed").describe("Notification channel"),
+    /**
+     * Useful for filtering in the partner UI (e.g. "product.updated",
+     * "production_run.assigned"). Persisted on notification.trigger_type.
+     */
+    trigger_type: z
+      .string()
+      .optional()
+      .describe("Event/workflow that produced this notification."),
+    resource_type: z
+      .string()
+      .optional()
+      .describe("What the notification is about (e.g. 'product')."),
+    resource_id: z
+      .string()
+      .optional()
+      .describe("ID of the resource the notification is about."),
+    /**
+     * Stable dedup key. Pass a value that uniquely identifies this
+     * (event, recipient) pair so re-runs of the same flow don't
+     * double-notify.
+     */
+    idempotency_key: z
+      .string()
+      .optional()
+      .describe("Stable dedup key for re-runs."),
     data: z.record(z.string(), z.any()).optional().describe("Additional data"),
   }),
-  
+
   defaultOptions: {
     title: "",
     description: "",
     channel: "feed",
   },
-  
+
   execute: async (options, context: OperationContext): Promise<OperationResult> => {
     try {
       const title = interpolateString(options.title, context.dataChain)
-      const description = options.description 
-        ? interpolateString(options.description, context.dataChain) 
+      const description = options.description
+        ? interpolateString(options.description, context.dataChain)
         : undefined
-      const to = options.to 
-        ? interpolateString(options.to, context.dataChain) 
+      const url = options.url
+        ? interpolateString(options.url, context.dataChain)
         : undefined
-      const data = options.data 
-        ? interpolateVariables(options.data, context.dataChain) 
+      const partnerId = options.partner_id
+        ? interpolateString(options.partner_id, context.dataChain)
         : undefined
-      
+      const explicitTo = options.to
+        ? interpolateString(options.to, context.dataChain)
+        : undefined
+      const triggerType = options.trigger_type
+        ? interpolateString(options.trigger_type, context.dataChain)
+        : undefined
+      const resourceType = options.resource_type
+        ? interpolateString(options.resource_type, context.dataChain)
+        : undefined
+      const resourceId = options.resource_id
+        ? interpolateString(options.resource_id, context.dataChain)
+        : undefined
+      const idempotencyKey = options.idempotency_key
+        ? interpolateString(options.idempotency_key, context.dataChain)
+        : undefined
+      const extraData = options.data
+        ? interpolateVariables(options.data, context.dataChain)
+        : undefined
+
       const notificationService = context.container.resolve(Modules.NOTIFICATION)
-      
+
+      // When targeting a partner, set receiver_id so the partner bell
+      // (which filters on receiver_id = partner.id) picks it up.
+      // Default `to` to partner_id when not explicitly set — Medusa
+      // requires `to` and the partner_id is the natural routing key.
+      const to = explicitTo ?? partnerId ?? "admin"
+
       const notification = await notificationService.createNotifications({
-        to: to || "admin",
+        to,
         channel: options.channel || "feed",
         template: "visual-flow-notification",
         data: {
           title,
           description,
+          url,
           flow_id: context.flowId,
           execution_id: context.executionId,
-          ...data,
+          ...extraData,
         },
-      })
-      
+        trigger_type: triggerType,
+        resource_type: resourceType,
+        resource_id: resourceId,
+        receiver_id: partnerId,
+        idempotency_key: idempotencyKey,
+      } as any)
+
       return {
         success: true,
         data: {
           notification_id: notification.id,
           title,
           description,
+          partner_id: partnerId,
         },
       }
     } catch (error: any) {

--- a/apps/backend/src/scripts/seed-partner-notification-test.ts
+++ b/apps/backend/src/scripts/seed-partner-notification-test.ts
@@ -1,0 +1,90 @@
+/**
+ * Test seed: drop a fake notification into a partner's bell.
+ *
+ * Use this to verify the partner bell end-to-end without building a
+ * full visual flow first. The script takes a partner uuid (positional
+ * or via --partner-id) and pushes one entry through createPartnerNotification.
+ *
+ * Run:
+ *   npx medusa exec ./src/scripts/seed-partner-notification-test.ts <partner_uuid>
+ *
+ * Or:
+ *   npx medusa exec ./src/scripts/seed-partner-notification-test.ts \
+ *     --partner-id=<uuid> \
+ *     --title="Order placed" \
+ *     --description="Customer Jane bought 3 items" \
+ *     --url=/orders/abc \
+ *     --count=3
+ *
+ * `--count=N` emits N rows so you can see the unread badge increment.
+ */
+
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { createPartnerNotification } from "../lib/notifications/create-partner-notification"
+
+type Args = {
+  partner_id: string
+  title: string
+  description: string
+  url: string | null
+  count: number
+}
+
+function parseArgs(rawArgs: string[]): Args {
+  let partner_id = ""
+  let title = `Test notification ${new Date().toLocaleTimeString()}`
+  let description = "Triggered by seed-partner-notification-test.ts"
+  let url: string | null = null
+  let count = 1
+
+  // First positional that isn't a flag → partner_id (when --partner-id absent)
+  for (const arg of rawArgs) {
+    if (arg.startsWith("--partner-id=")) partner_id = arg.slice("--partner-id=".length)
+    else if (arg.startsWith("--title=")) title = arg.slice("--title=".length)
+    else if (arg.startsWith("--description=")) description = arg.slice("--description=".length)
+    else if (arg.startsWith("--url=")) url = arg.slice("--url=".length)
+    else if (arg.startsWith("--count=")) count = Math.max(1, Number(arg.slice("--count=".length)) || 1)
+    else if (!arg.startsWith("--") && !partner_id) partner_id = arg
+  }
+
+  return { partner_id, title, description, url, count }
+}
+
+export default async function seedPartnerNotificationTest({
+  container,
+  args,
+}: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const parsed = parseArgs(args ?? [])
+
+  if (!parsed.partner_id) {
+    logger.error(
+      "Missing partner_id. Pass it as the first positional arg or via --partner-id=<uuid>.",
+    )
+    return
+  }
+
+  logger.info(
+    `Sending ${parsed.count} test notification(s) to partner=${parsed.partner_id}...`,
+  )
+
+  let success = 0
+  for (let i = 0; i < parsed.count; i++) {
+    const ok = await createPartnerNotification(container, {
+      partner_id: parsed.partner_id,
+      title: parsed.count > 1 ? `${parsed.title} (#${i + 1})` : parsed.title,
+      description: parsed.description,
+      url: parsed.url,
+      trigger_type: "manual.test_seed",
+      // Re-runs intentionally don't dedup — that lets you spam the bell
+      // without changing the script. If you want dedup, append a stable
+      // suffix to title and a matching idempotency_key.
+    })
+    if (ok) success++
+  }
+
+  logger.info(
+    `Done. ${success}/${parsed.count} notification(s) created. Open the partner UI to verify the bell badge.`,
+  )
+}


### PR DESCRIPTION
Extends the visual flow `notification` operation with partner_id +
url + trigger_type / resource_type / resource_id / idempotency_key.
When partner_id is set, the operation stamps it on receiver_id so
the entry lands in the partner's bell (GET /partners/notifications)
instead of the admin feed. Each new field interpolates from the
data chain so flow authors can use {{trigger.partner_id}} etc.

Backwards-compatible: with no partner_id the op behaves as before
(channel=feed, to=admin).

Adds src/scripts/seed-partner-notification-test.ts so you can verify
the bell locally without building a flow:

  npx medusa exec ./src/scripts/seed-partner-notification-test.ts \
    --partner-id=<uuid> --count=3 --url=/orders/abc

Useful for QA'ing the bell after a partner UI change without waiting
for a real product.updated event.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
