### PR TITLE
refactor(admin): use StatusBadge for entity status across routes

### DIFF
--- a/apps/backend/src/admin/routes/designs/@preview/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/designs/@preview/[id]/page.tsx
@@ -99,9 +99,9 @@ const DesignPreviewPage = () => {
             <Heading level="h2">Details</Heading>
             <div className="flex items-center gap-x-2">
               {design.priority && (
-                <Badge color={priorityColor(design.priority)}>
+                <StatusBadge color={priorityColor(design.priority)}>
                   {design.priority}
-                </Badge>
+                </StatusBadge>
               )}
               {design.status && (
                 <StatusBadge color={statusColor(design.status)}>

--- a/apps/backend/src/admin/routes/designs/[id]/@print/page.tsx
+++ b/apps/backend/src/admin/routes/designs/[id]/@print/page.tsx
@@ -339,9 +339,9 @@ const DesignStitchingPrintPage = () => {
             <Heading level="h2">Design Info</Heading>
             <div className="flex items-center gap-x-2">
               {design.priority && (
-                <Badge color={priorityColor(design.priority)}>
+                <StatusBadge color={priorityColor(design.priority)}>
                   {design.priority}
-                </Badge>
+                </StatusBadge>
               )}
               {design.status && (
                 <StatusBadge color={statusColor(design.status)}>
@@ -769,9 +769,9 @@ const DesignStitchingPrintPage = () => {
                     <div className="flex items-center gap-2 mb-2">
                       <Text size="small" weight="plus">{spec.title}</Text>
                       <Badge size="2xsmall" color="blue">{spec.category}</Badge>
-                      <Badge size="2xsmall" color={spec.status === "Approved" ? "green" : "grey"}>
+                      <StatusBadge color={spec.status === "Approved" ? "green" : "grey"}>
                         {spec.status}
-                      </Badge>
+                      </StatusBadge>
                       {spec.version && (
                         <Text size="xsmall" className="text-ui-fg-muted">v{spec.version}</Text>
                       )}

--- a/apps/backend/src/admin/routes/designs/[id]/@revisions/page.tsx
+++ b/apps/backend/src/admin/routes/designs/[id]/@revisions/page.tsx
@@ -1,5 +1,5 @@
 import { useParams, Link } from "react-router-dom";
-import { Badge, Heading, StatusBadge, Text } from "@medusajs/ui";
+import { Heading, StatusBadge, Text } from "@medusajs/ui";
 import { RouteDrawer } from "../../../../components/modal/route-drawer/route-drawer";
 import { useDesignRevisions } from "../../../../hooks/api/designs";
 
@@ -100,9 +100,7 @@ export default function RevisionHistoryPage() {
                             {entry.status?.replace(/_/g, " ")}
                           </StatusBadge>
                           {isCurrent && (
-                            <Badge color="blue" className="text-xs">
-                              Current
-                            </Badge>
+                            <StatusBadge color="blue">Current</StatusBadge>
                           )}
                         </div>
 
@@ -132,9 +130,9 @@ export default function RevisionHistoryPage() {
                         )}
 
                         {isFirst && !entry.revised_from_id && (
-                          <Badge color="green" className="mt-2 text-xs">
-                            Original
-                          </Badge>
+                          <div className="mt-2">
+                            <StatusBadge color="green">Original</StatusBadge>
+                          </div>
                         )}
                       </div>
                     </div>

--- a/apps/backend/src/admin/routes/payment-submissions/_components/reconciliation-tab.tsx
+++ b/apps/backend/src/admin/routes/payment-submissions/_components/reconciliation-tab.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react"
 import { useNavigate } from "react-router-dom"
-import { Container, Badge, DataTable, useDataTable } from "@medusajs/ui"
+import { Container, Badge, DataTable, StatusBadge, useDataTable } from "@medusajs/ui"
 import { createColumnHelper } from "@tanstack/react-table"
 import { keepPreviousData } from "@tanstack/react-query"
 import {
@@ -67,7 +67,7 @@ export const ReconciliationTab = () => {
       columnHelper.accessor("status", {
         header: "Status",
         cell: ({ getValue }) => (
-          <Badge color={statusColor(getValue())}>{getValue()}</Badge>
+          <StatusBadge color={statusColor(getValue())}>{getValue()}</StatusBadge>
         ),
       }),
       columnHelper.accessor("expected_amount", {

--- a/apps/backend/src/admin/routes/payment-submissions/_components/submissions-tab.tsx
+++ b/apps/backend/src/admin/routes/payment-submissions/_components/submissions-tab.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react"
 import { Link, useNavigate } from "react-router-dom"
-import { Button, Container, Badge, DataTable, useDataTable } from "@medusajs/ui"
+import { Button, Container, StatusBadge, DataTable, useDataTable } from "@medusajs/ui"
 import { createColumnHelper } from "@tanstack/react-table"
 import { keepPreviousData } from "@tanstack/react-query"
 import {
@@ -66,7 +66,7 @@ export const SubmissionsTab = () => {
       columnHelper.accessor("status", {
         header: "Status",
         cell: ({ getValue }) => (
-          <Badge color={statusColor(getValue())}>{getValue().replace("_", " ")}</Badge>
+          <StatusBadge color={statusColor(getValue())}>{getValue().replace("_", " ")}</StatusBadge>
         ),
       }),
       columnHelper.accessor("total_amount", {

--- a/apps/backend/src/admin/routes/production-runs/[id]/@dispatch/page.tsx
+++ b/apps/backend/src/admin/routes/production-runs/[id]/@dispatch/page.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   Container,
   Heading,
+  StatusBadge,
   Text,
   toast,
 } from "@medusajs/ui"
@@ -113,7 +114,7 @@ const DispatchProductionRunDrawerForm = () => {
             <Container className="p-4">
               <Text className="text-ui-fg-subtle">
                 Run must be in "approved" status to dispatch. Current status:{" "}
-                <Badge color="grey">{status?.replace(/_/g, " ")}</Badge>
+                <StatusBadge color="grey">{status?.replace(/_/g, " ")}</StatusBadge>
               </Text>
             </Container>
           ) : (

--- a/apps/backend/src/admin/routes/production-runs/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/production-runs/[id]/page.tsx
@@ -5,6 +5,7 @@ import {
   DropdownMenu,
   Heading,
   IconButton,
+  StatusBadge,
   Text,
   toast,
   usePrompt,
@@ -111,9 +112,9 @@ const ProductionRunDetailPage = () => {
                 <Heading level="h1">
                   {run.run_type === "sample" ? "Sample" : "Production"} Run
                 </Heading>
-                <Badge color={statusColor(run.status)}>
+                <StatusBadge color={statusColor(run.status)}>
                   {formatStatus(String(run.status || "-"))}
-                </Badge>
+                </StatusBadge>
                 {isParent && <Badge color="blue">parent</Badge>}
               </div>
               <Text size="small" className="text-ui-fg-subtle">
@@ -412,9 +413,9 @@ const ProductionRunDetailPage = () => {
                                     )}
                                 </Text>
                               )}
-                              <Badge color={statusColor(String(t.status || ""))}>
+                              <StatusBadge color={statusColor(String(t.status || ""))}>
                                 {String(t.status || "-")}
-                              </Badge>
+                              </StatusBadge>
                             </div>
                           </div>
                           {t.description && (

--- a/apps/backend/src/admin/routes/settings/energy-rates/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/settings/energy-rates/[id]/page.tsx
@@ -6,6 +6,7 @@ import {
   Input,
   Label,
   Select,
+  StatusBadge,
   Switch,
   Text,
   Textarea,
@@ -135,9 +136,9 @@ const EnergyRateDetailPage = () => {
           <div>
             <div className="flex items-center gap-x-2">
               <Heading level="h1">{rate.name}</Heading>
-              <Badge color={rate.is_active ? "green" : "grey"}>
+              <StatusBadge color={rate.is_active ? "green" : "grey"}>
                 {rate.is_active ? "Active" : "Inactive"}
-              </Badge>
+              </StatusBadge>
             </div>
             <Text size="small" className="text-ui-fg-subtle">
               {ENERGY_TYPE_LABELS[rate.energy_type] || rate.energy_type} rate

--- a/apps/backend/src/admin/routes/settings/energy-rates/page.tsx
+++ b/apps/backend/src/admin/routes/settings/energy-rates/page.tsx
@@ -8,6 +8,7 @@ import {
   DataTablePaginationState,
   DataTableFilteringState,
   Badge,
+  StatusBadge,
 } from "@medusajs/ui"
 import { keepPreviousData } from "@tanstack/react-query"
 import { defineRouteConfig } from "@medusajs/admin-sdk"
@@ -97,9 +98,9 @@ const useColumns = () => {
       columnHelper.accessor("is_active", {
         header: "Status",
         cell: ({ getValue }) => (
-          <Badge color={getValue() ? "green" : "grey"}>
+          <StatusBadge color={getValue() ? "green" : "grey"}>
             {getValue() ? "Active" : "Inactive"}
-          </Badge>
+          </StatusBadge>
         ),
       }),
     ],

--- a/apps/backend/src/admin/routes/settings/inbound-emails/page.tsx
+++ b/apps/backend/src/admin/routes/settings/inbound-emails/page.tsx
@@ -6,6 +6,7 @@ import {
   DataTableFilteringState,
   DataTablePaginationState,
   Heading,
+  StatusBadge,
   Text,
   Toaster,
   createDataTableFilterHelper,
@@ -100,9 +101,9 @@ const InboundEmailsPage = () => {
         cell: ({ getValue }) => {
           const status = getValue()
           return (
-            <Badge color={STATUS_COLORS[status] || "grey"} size="2xsmall">
+            <StatusBadge color={STATUS_COLORS[status] || "grey"}>
               {STATUS_LABELS[status] ?? status}
-            </Badge>
+            </StatusBadge>
           )
         },
       }),


### PR DESCRIPTION
Status-shaped Badges in admin routes were rendering as plain colored
chips. StatusBadge gives them the canonical Medusa look (color + dot
indicator) that matches the rest of the admin and makes "this is a
status" obvious at a glance.

Converted in:
  designs/[id]/@revisions          Current / Original revision markers
  designs/[id]/@print              priority + spec.status
  designs/@preview/[id]            priority
  production-runs/[id]             run.status + task.status
  production-runs/[id]/@dispatch   current-status callout
  payment-submissions              submissions + reconciliation status
  settings/inbound-emails          email status column
  settings/energy-rates            is_active (list + detail)

Kept Badge for non-status spots: tag/category chips, dependency id
labels, "parent" relationship marker, selection toggles in template
pickers, "Resend" action label. The distinction is intentional —
Badge for arbitrary labels, StatusBadge for "what state is this in".

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
