### PR TITLE
fix: subscription upgrade crash + partner notification 404s

### DIFF
--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -1450,7 +1450,7 @@ export default defineMiddlewares({
       ],
     },
     {
-      matcher: "/partners/notifications/unread-count",
+      matcher: "/partners/notifications/unread",
       method: "GET",
       middlewares: [
         createCorsPartnerMiddleware(),
@@ -1458,7 +1458,7 @@ export default defineMiddlewares({
       ],
     },
     {
-      matcher: "/partners/notifications/mark-all-read",
+      matcher: "/partners/notifications/read",
       method: "POST",
       middlewares: [
         createCorsPartnerMiddleware(),

--- a/apps/backend/src/api/partners/notifications/read/route.ts
+++ b/apps/backend/src/api/partners/notifications/read/route.ts
@@ -1,5 +1,5 @@
 /**
- * POST /partners/notifications/mark-all-read
+ * POST /partners/notifications/read
  *
  * Bumps `partner.metadata.notifications_last_seen_at` to now() so all
  * existing notifications become "read" from the bell's perspective.

--- a/apps/backend/src/api/partners/notifications/unread/route.ts
+++ b/apps/backend/src/api/partners/notifications/unread/route.ts
@@ -1,5 +1,5 @@
 /**
- * GET /partners/notifications/unread-count
+ * GET /partners/notifications/unread
  *
  * Single-count endpoint for the bell badge. Counts notifications with
  * `receiver_id = partner.id` and `created_at > partner.metadata.notifications_last_seen_at`.

--- a/apps/backend/src/api/partners/subscription/payu/complete/route.ts
+++ b/apps/backend/src/api/partners/subscription/payu/complete/route.ts
@@ -56,15 +56,23 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
         })
       }
 
-      // Activate subscription
+      // Activate subscription, then link the new subscription_id back
+      // onto the pending payment row so the FK reflects reality.
       if (partnerId && planId) {
-        await createPartnerSubscriptionWorkflow(req.scope).run({
+        const { result } = await createPartnerSubscriptionWorkflow(req.scope).run({
           input: {
             partner_id: partnerId,
             plan_id: planId,
             payment_provider: "payu",
           },
         })
+        const newSubscriptionId = (result as any)?.subscription?.id
+        if (paymentId && newSubscriptionId) {
+          await service.updateSubscriptionPayments({
+            id: paymentId,
+            subscription_id: newSubscriptionId,
+          } as any)
+        }
       }
 
       return res.redirect(302, `${partnerUiUrl}/settings/plan?payment=success`)

--- a/apps/backend/src/modules/partner-plan/migrations/Migration20260430030000.ts
+++ b/apps/backend/src/modules/partner-plan/migrations/Migration20260430030000.ts
@@ -1,0 +1,21 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+export class Migration20260430030000 extends Migration {
+
+  override async up(): Promise<void> {
+    // Make subscription_payment.subscription_id nullable so the
+    // pre-PayU pending row can be created before the subscription
+    // exists. Success callback links it back; failure-only audit
+    // rows stay orphan.
+    this.addSql(
+      `alter table if exists "subscription_payment" alter column "subscription_id" drop not null;`
+    );
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(
+      `alter table if exists "subscription_payment" alter column "subscription_id" set not null;`
+    );
+  }
+
+}

--- a/apps/backend/src/modules/partner-plan/models/subscription-payment.ts
+++ b/apps/backend/src/modules/partner-plan/models/subscription-payment.ts
@@ -18,9 +18,13 @@ const SubscriptionPayment = model.define("subscription_payment", {
   failed_at: model.dateTime().nullable(),
   failure_reason: model.text().nullable(),
   metadata: model.json().nullable(),
+  // Nullable: a payment row is created BEFORE the subscription exists
+  // (PayU pre-payment intent). The PayU success callback then creates
+  // the subscription and links it back. Failure-only audit rows also
+  // stay orphan since no subscription was ever activated.
   subscription: model.belongsTo(() => PartnerSubscription, {
     mappedBy: "payments",
-  }),
+  }).nullable(),
 })
 
 export default SubscriptionPayment

--- a/apps/partner-ui/src/hooks/api/notification.tsx
+++ b/apps/partner-ui/src/hooks/api/notification.tsx
@@ -104,7 +104,7 @@ export const usePartnerNotificationsUnreadCount = (
     queryKey: notificationQueryKeys.list({ unread: true }),
     queryFn: () =>
       sdk.client.fetch<PartnerNotificationsUnreadCountResponse>(
-        "/partners/notifications/unread-count",
+        "/partners/notifications/unread",
         { method: "GET" },
       ),
     ...options,
@@ -121,7 +121,7 @@ export const useMarkAllPartnerNotificationsRead = (
   return useMutation({
     mutationFn: () =>
       sdk.client.fetch<PartnerNotificationsUnreadCountResponse>(
-        "/partners/notifications/mark-all-read",
+        "/partners/notifications/read",
         { method: "POST" },
       ),
     onSuccess: async (data, variables, context) => {


### PR DESCRIPTION
Two unrelated production bugs:

1) Subscription upgrade was crashing with
   ValidationError: SubscriptionPayment.subscription_id is required.

   The pre-PayU pending payment row gets created BEFORE the subscription
   exists (the subscription is only activated on the success callback),
   but subscription_id was NOT NULL on the model + DB. Make it nullable
   so the pending row + failure-only audit rows can exist without a
   parent. The PayU success callback now also writes the new
   subscription_id back onto the pending payment after the subscription
   is activated, so the FK reflects reality.

2) Partner notification bell was 404'ing on /partners/notifications/unread-count
   and /partners/notifications/mark-all-read in production.

   Suspected hyphen-handling in the deployed router. Renamed both to
   single-word path segments — drop hyphens entirely:
     /partners/notifications/unread-count    → /partners/notifications/unread
     /partners/notifications/mark-all-read   → /partners/notifications/read
   Middleware matchers + partner-ui hook URLs updated to match.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
