### PR TITLE
fix(backend): unblock Railway deploys (3 TS errors on main)

### DIFF
--- a/apps/backend/src/modules/visual_flows/operations/notification.ts
+++ b/apps/backend/src/modules/visual_flows/operations/notification.ts
@@ -117,7 +117,7 @@ export const notificationOperation: OperationDefinition = {
       // requires `to` and the partner_id is the natural routing key.
       const to = explicitTo ?? partnerId ?? "admin"
 
-      const notification = await notificationService.createNotifications({
+      const created = await notificationService.createNotifications({
         to,
         channel: options.channel || "feed",
         template: "visual-flow-notification",
@@ -135,6 +135,9 @@ export const notificationOperation: OperationDefinition = {
         receiver_id: partnerId,
         idempotency_key: idempotencyKey,
       } as any)
+      // Single-input overload returns the row, but the cast widens it to
+      // `NotificationDTO[]`. Normalize to the single row.
+      const notification = (Array.isArray(created) ? created[0] : created) as { id: string }
 
       return {
         success: true,

--- a/apps/backend/src/workflows/stores/provision-storefront.ts
+++ b/apps/backend/src/workflows/stores/provision-storefront.ts
@@ -309,9 +309,14 @@ const seedDefaultWebsitePagesStep = createStep(
       })
       return new StepResponse({ pages: result?.pages, skipped_slugs: result?.skipped })
     } catch (e: any) {
-      // Non-fatal — provisioning should succeed even if page seeding fails
+      // Non-fatal — provisioning should succeed even if page seeding fails.
+      // Return the same shape as the success path so the step's inferred
+      // output type stays unified.
       console.error("[provision-storefront] Page seeding failed:", e.message)
-      return new StepResponse({ error: e.message })
+      return new StepResponse({
+        pages: [] as { id: string; title: string; slug: string; blocks_created: number }[],
+        skipped_slugs: [] as string[],
+      })
     }
   }
 )

--- a/apps/backend/workflow-schemas.json
+++ b/apps/backend/workflow-schemas.json
@@ -6159,6 +6159,24 @@
         "placeholder": "{{ $last.analytics_id }}"
       },
       {
+        "name": "analytics_provider",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.analytics_provider }}"
+      },
+      {
+        "name": "analytics_custom_head",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.analytics_custom_head }}"
+      },
+      {
+        "name": "analytics_custom_body_end",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.analytics_custom_body_end }}"
+      },
+      {
         "name": "metadata",
         "type": "object",
         "required": false,
@@ -6415,6 +6433,24 @@
         "type": "id",
         "required": false,
         "placeholder": "{{ $last.analytics_id }}"
+      },
+      {
+        "name": "analytics_provider",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.analytics_provider }}"
+      },
+      {
+        "name": "analytics_custom_head",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.analytics_custom_head }}"
+      },
+      {
+        "name": "analytics_custom_body_end",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.analytics_custom_body_end }}"
       },
       {
         "name": "theme",


### PR DESCRIPTION
## Summary

- Every `Deploy to Railway` run on `main` since PR #183 has failed in the Docker `pnpm build` step. Production has been frozen for ~26 hours, including PR #192's subscription-crash + partner-notification-404 fix.
- Three TypeScript errors blocking the build (introduced via PRs #184/#190, not caught locally because `medusa build` is stricter than `tsc --noEmit` in dev).

### Errors fixed

**1. `src/modules/visual_flows/operations/notification.ts:142` — TS2339**
`notificationService.createNotifications({...} as any)` made TS resolve to the bulk overload (`Promise<NotificationDTO[]>`), so `.id` errored. Normalize the result to a single row before reading `.id`.

**2. `src/workflows/stores/provision-storefront.ts:302` — TS2345 (and cascading TS2554 at :332)**
The `seed-default-website-pages` step's two return paths emitted different shapes:
- success → `{ pages, skipped_slugs }`
- catch → `{ error }`

TS could not unify them, the inferred `InvokeFn` collapsed, and the workflow call site lost its input parameter ("Expected 0 arguments, but got 1"). Catch now returns the same empty `{ pages: [], skipped_slugs: [] }` shape; failure is already logged via `console.error` and the step is non-fatal.

### Drive-by

`build:schemas` regenerated `workflow-schemas.json` — three new `analytics_*` fields had been added to a workflow input without rerunning the schema build. Committing the regenerated file so the next dev's `git status` is clean.

## Test plan

- [x] `cd apps/backend && pnpm build` → `Backend build completed successfully`, `Frontend build completed successfully`, both downstream `resolve:aliases` and `build:schemas` pass.
- [ ] CI: `Deploy to Railway` and `Test and Release` pass on this PR.
- [ ] Post-merge: confirm Railway picks up the deploy, prod hits the new code, and PR #192's subscription/notification fixes start working in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)