### PR TITLE
chore: drop patch-package + silence pnpm peer-dep warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,9 +77,6 @@ apps/backend/src/partner/node_modules/*
 
 debug/
 
-# Local patches (not committed)
-apps/backend/patches/
-
 .claude/
 
 # Generated RAG/contextual index (regenerate with src/scripts/generate-contextual-index.ts)

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -32,8 +32,7 @@
     "generate:plans": "ts-node src/scripts/generate-route-plans.ts",
     "seed:plans": "ts-node src/scripts/seed-plans.ts",
     "specs:store": "medusa exec ./src/scripts/specs/store-specs-in-db.ts",
-    "specs:store:direct": "npx tsx src/scripts/specs/store-specs-in-db.ts",
-    "postinstall": "patch-package"
+    "specs:store:direct": "npx tsx src/scripts/specs/store-specs-in-db.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.1.17",
@@ -191,8 +190,6 @@
     "jest": "^29.7.0",
     "jest-silent-reporter": "^0.6.0",
     "mastra": "latest",
-    "patch-package": "^8.0.1",
-    "postinstall-postinstall": "^2.1.0",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
       "@tanstack/react-query": "^5.90.20",
       "effect": "^3.17.14",
       "clsx": "^2.1.0",
-      "zod": "^4.2.0"
+      "zod": "^4.2.0",
+      "@types/node": "^20.12.11"
     },
     "onlyBuiltDependencies": [
       "@medusajs/telemetry",
@@ -66,11 +67,36 @@
       "core-js",
       "esbuild",
       "msgpackr-extract",
-      "postinstall-postinstall",
       "protobufjs",
       "sharp",
       "utf-8-validate"
     ],
-    "patchedDependencies": {}
+    "patchedDependencies": {},
+    "peerDependencyRules": {
+      "allowedVersions": {
+        "@medusajs/framework": "2.14.0",
+        "@medusajs/cli": "2.14.0",
+        "@medusajs/icons": "2.14.0",
+        "@medusajs/test-utils": "2.14.0",
+        "@medusajs/admin-sdk": "2.14.0",
+        "@medusajs/ui": "4.1.7",
+        "react": "19.0.4",
+        "react-dom": "19.0.4",
+        "@tiptap/core": "3.20.0",
+        "@tiptap/pm": "3.20.0",
+        "date-fns": "4.1.0",
+        "eslint": "8.10.0",
+        "happy-dom": "18.0.1"
+      },
+      "ignoreMissing": [
+        "enzyme",
+        "happy-dom",
+        "monaco-editor",
+        "openapi-types",
+        "vite",
+        "@standard-community/standard-json",
+        "@standard-community/standard-openapi"
+      ]
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   effect: ^3.17.14
   clsx: ^2.1.0
   zod: ^4.2.0
+  '@types/node': ^20.12.11
 
 importers:
 
@@ -512,12 +513,6 @@ importers:
       mastra:
         specifier: latest
         version: 1.6.3(@hono/node-server@1.19.9(hono@4.12.15))(@mastra/core@1.28.0(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.19.19)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.19.19)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(effect@3.19.19)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6))(typescript@5.9.3)(zod@4.3.6)
-      patch-package:
-        specifier: ^8.0.1
-        version: 8.0.1
-      postinstall-postinstall:
-        specifier: ^2.1.0
-        version: 2.1.0
       prop-types:
         specifier: ^15.8.1
         version: 15.8.1
@@ -686,10 +681,10 @@ importers:
     devDependencies:
       '@medusajs/admin-vite-plugin':
         specifier: 2.13.6
-        version: 2.13.6(picomatch@4.0.4)(vite@5.4.21(@types/node@22.19.12)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
+        version: 2.13.6(picomatch@4.0.4)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
       '@medusajs/types':
         specifier: 2.13.6
-        version: 2.13.6(ioredis@5.9.3)(vite@5.4.21(@types/node@22.19.12)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
+        version: 2.13.6(ioredis@5.9.3)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
       '@medusajs/ui-preset':
         specifier: 2.13.6
         version: 2.13.6(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
@@ -704,7 +699,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react':
         specifier: 5.1.2
-        version: 5.1.2(vite@5.4.21(@types/node@22.19.12)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
+        version: 5.1.2(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
       autoprefixer:
         specifier: ^10.4.19
         version: 10.4.27(postcss@8.5.6)
@@ -719,13 +714,13 @@ importers:
         version: 8.5.1(@swc/core@1.7.28(@swc/helpers@0.5.19))(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       vite:
         specifier: ^5.4.11
-        version: 5.4.21(@types/node@22.19.12)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
+        version: 5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
       vite-plugin-inspect:
         specifier: 0.8.7
-        version: 0.8.7(rollup@4.59.0)(vite@5.4.21(@types/node@22.19.12)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
+        version: 0.8.7(rollup@4.59.0)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
       vitest:
         specifier: ^2.1.4
-        version: 2.1.9(@types/node@22.19.12)(happy-dom@18.0.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
+        version: 2.1.9(@types/node@20.19.34)(happy-dom@18.0.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
 
   apps/storefront:
     dependencies:
@@ -833,8 +828,8 @@ importers:
         specifier: ^4.14.195
         version: 4.17.24
       '@types/node':
-        specifier: 17.0.21
-        version: 17.0.21
+        specifier: ^20.12.11
+        version: 20.19.34
       '@types/pg':
         specifier: ^8.11.0
         version: 8.15.6
@@ -876,7 +871,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@17.0.21)(happy-dom@18.0.1)
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.34)(happy-dom@18.0.1)
 
   apps/storefront-starter:
     dependencies:
@@ -937,7 +932,7 @@ importers:
         version: 7.29.0
       '@medusajs/types':
         specifier: latest
-        version: 2.13.4(ioredis@5.9.3)(vite@5.4.21(@types/node@17.0.21)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
+        version: 2.13.4(ioredis@5.9.3)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
       '@medusajs/ui-preset':
         specifier: latest
         version: 2.13.4(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
@@ -945,8 +940,8 @@ importers:
         specifier: ^4.14.195
         version: 4.17.24
       '@types/node':
-        specifier: 17.0.21
-        version: 17.0.21
+        specifier: ^20.12.11
+        version: 20.19.34
       '@types/pg':
         specifier: ^8.11.0
         version: 8.15.6
@@ -2561,7 +2556,7 @@ packages:
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@types/node': '>=18'
+      '@types/node': ^20.12.11
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -6575,7 +6570,7 @@ packages:
   '@rushstack/node-core-library@5.13.0':
     resolution: {integrity: sha512-IGVhy+JgUacAdCGXKUrRhwHMTzqhWwZUI+qEPcdzsb80heOw0QPbhhoVsoiMF7Klp8eYsp7hzpScMXmOa3Uhfg==}
     peerDependencies:
-      '@types/node': '*'
+      '@types/node': ^20.12.11
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -6583,7 +6578,7 @@ packages:
   '@rushstack/terminal@0.15.2':
     resolution: {integrity: sha512-7Hmc0ysK5077R/IkLS9hYu0QuNafm+TbZbtYVzCMbeOdMjaRboLKrhryjwZSRJGJzu+TV1ON7qZHeqf58XfLpA==}
     peerDependencies:
-      '@types/node': '*'
+      '@types/node': ^20.12.11
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -7647,17 +7642,8 @@ packages:
   '@types/node-fetch@2.6.13':
     resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
 
-  '@types/node@17.0.21':
-    resolution: {integrity: sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==}
-
-  '@types/node@18.19.130':
-    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
-
   '@types/node@20.19.34':
     resolution: {integrity: sha512-by3/Z0Qp+L9cAySEsSNNwZ6WWw8ywgGLPQGgbQDhNRSitqYgkgp4pErd23ZSCavbtUA2CN4jQtoB3T8nk4j3Rg==}
-
-  '@types/node@22.19.12':
-    resolution: {integrity: sha512-0QEp0aPJYSyf6RrTjDB7HlKgNMTY+V2C7ESTaVt6G9gQ0rPLzTGz7OF2NXTLR5vcy7HJEtIUsyWLsfX0kTqJBA==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -8154,9 +8140,6 @@ packages:
 
   '@xyflow/system@0.0.75':
     resolution: {integrity: sha512-iXs+AGFLi8w/VlAoc/iSxk+CxfT6o64Uw/k0CKASOPqjqz6E0rb5jFZgJtXGZCpfQI6OQpu5EnumP5fGxQheaQ==}
-
-  '@yarnpkg/lockfile@1.1.0':
-    resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
 
   '@zeit/schemas@2.36.0':
     resolution: {integrity: sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==}
@@ -10345,9 +10328,6 @@ packages:
   find-workspaces@0.3.1:
     resolution: {integrity: sha512-UDkGILGJSA1LN5Aa7McxCid4sqW3/e+UYsVwyxki3dDT0F8+ym0rAfnCkEfkL0rO7M+8/mvkim4t/s3IPHmg+w==}
 
-  find-yarn-workspace-root@2.0.0:
-    resolution: {integrity: sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==}
-
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
@@ -10453,10 +10433,6 @@ packages:
 
   fs-exists-cached@1.0.0:
     resolution: {integrity: sha512-kSxoARUDn4F2RPXX48UXnaFKwVU7Ivd/6qpzZL29MCDmr9sTvybv4gFCp+qaI4fM9m0z9fgz/yJvi56GAz+BZg==}
-
-  fs-extra@10.1.0:
-    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
-    engines: {node: '>=12'}
 
   fs-extra@11.3.3:
     resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
@@ -11335,7 +11311,7 @@ packages:
     resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
-      '@types/node': '*'
+      '@types/node': ^20.12.11
       ts-node: '>=9.0.0'
     peerDependenciesMeta:
       '@types/node':
@@ -11558,10 +11534,6 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
-  json-stable-stringify@1.3.0:
-    resolution: {integrity: sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==}
-    engines: {node: '>= 0.4'}
-
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
@@ -11582,9 +11554,6 @@ packages:
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
-
-  jsonify@0.0.1:
-    resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
 
   jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
@@ -11628,9 +11597,6 @@ packages:
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
-
-  klaw-sync@6.0.0:
-    resolution: {integrity: sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -12864,10 +12830,6 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
-  open@7.4.2:
-    resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
-    engines: {node: '>=8'}
-
   openapi-fetch@0.17.0:
     resolution: {integrity: sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==}
 
@@ -13041,11 +13003,6 @@ packages:
 
   password-prompt@1.1.3:
     resolution: {integrity: sha512-HkrjG2aJlvF0t2BMH0e2LB/EHf3Lcq3fNMzy4GYHcQblAvOl+QQji1Lx7WRBMqpVK8p+KR7bCg7oqAMXtdgqyw==}
-
-  patch-package@8.0.1:
-    resolution: {integrity: sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==}
-    engines: {node: '>=14', npm: '>5'}
-    hasBin: true
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
@@ -13402,9 +13359,6 @@ packages:
     resolution: {integrity: sha512-lz3YJOr0Nmiz0yHASaINEDHqoV+0bC3eD8aZAG+Ky292dAnVYul+ga/dMX8KCBXg8hHfKdxw0SztYD5j6dgUqQ==}
     engines: {node: '>=20'}
 
-  postinstall-postinstall@2.1.0:
-    resolution: {integrity: sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==}
-
   potpack@1.0.2:
     resolution: {integrity: sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==}
 
@@ -13686,7 +13640,7 @@ packages:
     resolution: {integrity: sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==}
     peerDependencies:
       '@types/hoist-non-react-statics': '>= 3.3.1'
-      '@types/node': '>= 12'
+      '@types/node': ^20.12.11
       '@types/react': '>= 16'
       react: '>= 16.14'
     peerDependenciesMeta:
@@ -14578,10 +14532,6 @@ packages:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
     engines: {node: '>=8'}
 
-  slash@2.0.0:
-    resolution: {integrity: sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==}
-    engines: {node: '>=6'}
-
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -14851,7 +14801,7 @@ packages:
     resolution: {integrity: sha512-FjgIiE98dMMTNssfdjMvFdD4eZyEzdWAOwPYqzhPRNZeg9ggFWlPXmX1iJKD5pPIwZBaPlC3SayQQkwsPo6/YQ==}
     engines: {node: '>=16'}
     peerDependencies:
-      '@types/node': '>=16'
+      '@types/node': ^20.12.11
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -15131,10 +15081,6 @@ packages:
     resolution: {integrity: sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==}
     hasBin: true
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
-    engines: {node: '>=14.14'}
-
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
@@ -15210,7 +15156,7 @@ packages:
     peerDependencies:
       '@swc/core': '>=1.2.50'
       '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
+      '@types/node': ^20.12.11
       typescript: '>=2.7'
     peerDependenciesMeta:
       '@swc/core':
@@ -15379,9 +15325,6 @@ packages:
   unc-path-regex@0.1.2:
     resolution: {integrity: sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==}
     engines: {node: '>=0.10.0'}
-
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -15657,7 +15600,7 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
+      '@types/node': ^20.12.11
       less: '*'
       lightningcss: ^1.21.0
       sass: '*'
@@ -15689,7 +15632,7 @@ packages:
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
+      '@types/node': ^20.12.11
       '@vitest/browser': 2.1.9
       '@vitest/ui': 2.1.9
       happy-dom: '*'
@@ -15715,7 +15658,7 @@ packages:
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
-      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@types/node': ^20.12.11
       '@vitest/browser-playwright': 4.1.5
       '@vitest/browser-preview': 4.1.5
       '@vitest/browser-webdriverio': 4.1.5
@@ -17988,7 +17931,7 @@ snapshots:
       '@inquirer/figures': 1.0.15
       '@inquirer/type': 2.0.0
       '@types/mute-stream': 0.0.4
-      '@types/node': 22.19.12
+      '@types/node': 20.19.34
       '@types/wrap-ansi': 3.0.0
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
@@ -18550,7 +18493,7 @@ snapshots:
 
   '@medusajs/admin-shared@2.14.1': {}
 
-  '@medusajs/admin-vite-plugin@2.13.6(picomatch@4.0.4)(vite@5.4.21(@types/node@22.19.12)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))':
+  '@medusajs/admin-vite-plugin@2.13.6(picomatch@4.0.4)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))':
     dependencies:
       '@babel/parser': 7.25.6
       '@babel/traverse': 7.25.6
@@ -18561,7 +18504,7 @@ snapshots:
       magic-string: 0.30.5
       outdent: 0.8.0
       picocolors: 1.1.1
-      vite: 5.4.21(@types/node@22.19.12)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
+      vite: 5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
     transitivePeerDependencies:
       - picomatch
       - supports-color
@@ -19787,19 +19730,19 @@ snapshots:
     dependencies:
       '@medusajs/framework': 2.14.0(@medusajs/cli@2.14.0(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))(zod@4.3.6)
 
-  '@medusajs/types@2.13.4(ioredis@5.9.3)(vite@5.4.21(@types/node@17.0.21)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))':
+  '@medusajs/types@2.13.4(ioredis@5.9.3)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))':
     dependencies:
       bignumber.js: 9.3.1
     optionalDependencies:
       ioredis: 5.9.3
-      vite: 5.4.21(@types/node@17.0.21)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
+      vite: 5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
 
-  '@medusajs/types@2.13.6(ioredis@5.9.3)(vite@5.4.21(@types/node@22.19.12)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))':
+  '@medusajs/types@2.13.6(ioredis@5.9.3)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))':
     dependencies:
       bignumber.js: 9.3.1
     optionalDependencies:
       ioredis: 5.9.3
-      vite: 5.4.21(@types/node@22.19.12)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
+      vite: 5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
 
   '@medusajs/types@2.14.0(ioredis@5.9.3)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))':
     dependencies:
@@ -26752,17 +26695,7 @@ snapshots:
       '@types/node': 20.19.34
       form-data: 4.0.5
 
-  '@types/node@17.0.21': {}
-
-  '@types/node@18.19.130':
-    dependencies:
-      undici-types: 5.26.5
-
   '@types/node@20.19.34':
-    dependencies:
-      undici-types: 6.21.0
-
-  '@types/node@22.19.12':
     dependencies:
       undici-types: 6.21.0
 
@@ -27130,7 +27063,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@5.1.2(vite@5.4.21(@types/node@22.19.12)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))':
+  '@vitejs/plugin-react@5.1.2(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -27138,7 +27071,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.53
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 5.4.21(@types/node@22.19.12)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
+      vite: 5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -27158,13 +27091,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.12)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))':
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.21(@types/node@22.19.12)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
+      vite: 5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
 
   '@vitest/mocker@4.1.5':
     dependencies:
@@ -27343,8 +27276,6 @@ snapshots:
       d3-interpolate: 3.0.1
       d3-selection: 3.0.0
       d3-zoom: 3.0.0
-
-  '@yarnpkg/lockfile@1.1.0': {}
 
   '@zeit/schemas@2.36.0': {}
 
@@ -29976,10 +29907,6 @@ snapshots:
       pkg-types: 1.3.1
       yaml: 2.8.2
 
-  find-yarn-workspace-root@2.0.0:
-    dependencies:
-      micromatch: 4.0.8
-
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
       magic-string: 0.30.21
@@ -30076,12 +30003,6 @@ snapshots:
   fs-constants@1.0.0: {}
 
   fs-exists-cached@1.0.0: {}
-
-  fs-extra@10.1.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.2.0
-      universalify: 2.0.1
 
   fs-extra@11.3.3:
     dependencies:
@@ -31378,14 +31299,6 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
-  json-stable-stringify@1.3.0:
-    dependencies:
-      call-bind: 1.0.8
-      call-bound: 1.0.4
-      isarray: 2.0.5
-      jsonify: 0.0.1
-      object-keys: 1.1.1
-
   json-stringify-safe@5.0.1: {}
 
   json5@1.0.2:
@@ -31405,8 +31318,6 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
-
-  jsonify@0.0.1: {}
 
   jsonparse@1.3.1: {}
 
@@ -31463,10 +31374,6 @@ snapshots:
   khroma@2.1.0: {}
 
   kind-of@6.0.3: {}
-
-  klaw-sync@6.0.0:
-    dependencies:
-      graceful-fs: 4.2.11
 
   kleur@3.0.3: {}
 
@@ -32904,11 +32811,6 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
-  open@7.4.2:
-    dependencies:
-      is-docker: 2.2.1
-      is-wsl: 2.2.0
-
   openapi-fetch@0.17.0:
     dependencies:
       openapi-typescript-helpers: 0.1.0
@@ -33092,23 +32994,6 @@ snapshots:
     dependencies:
       ansi-escapes: 4.3.2
       cross-spawn: 7.0.6
-
-  patch-package@8.0.1:
-    dependencies:
-      '@yarnpkg/lockfile': 1.1.0
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      cross-spawn: 7.0.6
-      find-yarn-workspace-root: 2.0.0
-      fs-extra: 10.1.0
-      json-stable-stringify: 1.3.0
-      klaw-sync: 6.0.0
-      minimist: 1.2.8
-      open: 7.4.2
-      semver: 7.7.4
-      slash: 2.0.0
-      tmp: 0.2.5
-      yaml: 2.8.2
 
   path-browserify@1.0.1: {}
 
@@ -33440,8 +33325,6 @@ snapshots:
   posthog-node@5.17.2:
     dependencies:
       '@posthog/core': 1.7.1
-
-  postinstall-postinstall@2.1.0: {}
 
   potpack@1.0.2: {}
 
@@ -35209,8 +35092,6 @@ snapshots:
     dependencies:
       unicode-emoji-modifier-base: 1.0.0
 
-  slash@2.0.0: {}
-
   slash@3.0.0: {}
 
   slash@5.1.0: {}
@@ -35818,8 +35699,6 @@ snapshots:
 
   tlds@1.261.0: {}
 
-  tmp@0.2.5: {}
-
   tmpl@1.0.5: {}
 
   to-fast-properties@2.0.0: {}
@@ -36095,8 +35974,6 @@ snapshots:
 
   unc-path-regex@0.1.2: {}
 
-  undici-types@5.26.5: {}
-
   undici-types@6.21.0: {}
 
   undici@7.22.0: {}
@@ -36371,13 +36248,13 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-node@2.1.9(@types/node@22.19.12)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0):
+  vite-node@2.1.9(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 1.1.2
-      vite: 5.4.21(@types/node@22.19.12)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
+      vite: 5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -36389,7 +36266,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-inspect@0.8.7(rollup@4.59.0)(vite@5.4.21(@types/node@22.19.12)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)):
+  vite-plugin-inspect@0.8.7(rollup@4.59.0)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
@@ -36400,23 +36277,10 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.1.1
       sirv: 2.0.4
-      vite: 5.4.21(@types/node@22.19.12)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
+      vite: 5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
-
-  vite@5.4.21(@types/node@17.0.21)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.6
-      rollup: 4.59.0
-    optionalDependencies:
-      '@types/node': 17.0.21
-      fsevents: 2.3.3
-      sass: 1.97.3
-      sass-embedded: 1.97.3
-      terser: 5.46.0
-    optional: true
 
   vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0):
     dependencies:
@@ -36430,22 +36294,10 @@ snapshots:
       sass-embedded: 1.97.3
       terser: 5.46.0
 
-  vite@5.4.21(@types/node@22.19.12)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.6
-      rollup: 4.59.0
-    optionalDependencies:
-      '@types/node': 22.19.12
-      fsevents: 2.3.3
-      sass: 1.97.3
-      sass-embedded: 1.97.3
-      terser: 5.46.0
-
-  vitest@2.1.9(@types/node@22.19.12)(happy-dom@18.0.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0):
+  vitest@2.1.9(@types/node@20.19.34)(happy-dom@18.0.1)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.12)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -36461,11 +36313,11 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.1.1
       tinyrainbow: 1.2.0
-      vite: 5.4.21(@types/node@22.19.12)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
-      vite-node: 2.1.9(@types/node@22.19.12)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
+      vite: 5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
+      vite-node: 2.1.9(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.19.12
+      '@types/node': 20.19.34
       happy-dom: 18.0.1
     transitivePeerDependencies:
       - less
@@ -36478,7 +36330,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@17.0.21)(happy-dom@18.0.1):
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.34)(happy-dom@18.0.1):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5
@@ -36501,7 +36353,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 17.0.21
+      '@types/node': 20.19.34
       happy-dom: 18.0.1
     transitivePeerDependencies:
       - msw
@@ -36809,7 +36661,7 @@ snapshots:
 
   zeroentropy@0.1.0-alpha.7:
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 20.19.34
       '@types/node-fetch': 2.6.13
       abort-controller: 3.0.0
       agentkeepalive: 4.6.0


### PR DESCRIPTION
## Summary

Two related cleanups, no runtime/behavior changes.

### 1. Drop `patch-package`

The local `apps/backend/patches/@medusajs+medusa+2.13.1.patch` added `apps/`, `assets/`, `docs/`, `specs/` to medusa develop's chokidar ignore list. The patches directory was gitignored — **the patch never made it to CI or production**, so the postinstall hook was a no-op there. Locally it produced a version-mismatch warning every install (created against 2.13.1, applied to 2.14.0).

Removed:
- `"postinstall": "patch-package"` from `apps/backend/package.json`
- `patch-package` + `postinstall-postinstall` from `apps/backend` devDeps
- `postinstall-postinstall` from root `pnpm.onlyBuiltDependencies`
- the dead `apps/backend/patches/` entry in `.gitignore`

> ⚠️ If `medusa develop` starts reloading on `apps/`, `assets/`, `docs/`, `specs/` again and it becomes annoying, prefer a config-based fix over reintroducing this patch.

### 2. Silence pnpm peer-dependency warnings

A forced/strict `pnpm install` surfaced ~80 unmet-peer notes. Categorized and addressed via `pnpm.peerDependencyRules`:

| Cluster | Why safe | Resolution |
|---|---|---|
| `@medusajs/framework`, `/cli`, `/icons`, `/test-utils`, `/admin-sdk` 2.14.0 vs peers asking 2.14.1 (~60 warnings) | Patch-version skew within Medusa 2.14.x | `allowedVersions: 2.14.0` |
| `@medusajs/ui` 4.1.7 vs 4.1.8 | Patch-version skew | `allowedVersions: 4.1.7` |
| Storefront `react` 19.0.4 / `react-dom` 19.0.4 vs deps asking 19.2.x | Minor diff, stable APIs | `allowedVersions: 19.0.4` |
| `@tiptap/core` + `@tiptap/pm` 3.20.0 vs 3.22.4 | Patch-version skew | `allowedVersions: 3.20.0` |
| `eslint` 8.10.0 in storefront-starter (a submodule) | Out of scope to bump from this repo | `allowedVersions: 8.10.0` |
| `date-fns` 4.x vs deps asking 2 \|\| 3 | Backend uses 4 directly | `allowedVersions: 4.1.0` |
| `happy-dom` 18 vs 20 | Testing only | `allowedVersions: 18.0.1` |
| Truly optional peers: `enzyme`, `monaco-editor`, `openapi-types`, `vite` (for non-vite consumers), `@standard-community/*` | Optional / unused | `ignoreMissing` |
| Transitive `@types/node` 17.0.21 (very old) | Doesn't match `engines.node: ">=20"` | `pnpm.overrides: ^20.12.11` |

The `@medusajs/*` patch-version skew could alternatively be fixed by bumping all packages to `2.14.2` (current latest). I chose `allowedVersions` for this PR to keep the diff conservative — production is just unfreezing from the deploy stall, and a wide dep upgrade in the same window is risky. **Happy to do the proper bump as a follow-up PR if you'd prefer.**

## Test plan

- [x] `pnpm install` → no peer warnings
- [x] `pnpm install --force` → no peer warnings
- [x] `pnpm install --strict-peer-dependencies` → exits clean (would error otherwise)
- [x] `pnpm --filter @jyt/backend build` → all three steps (`medusa build`, `resolve:aliases`, `build:schemas`) green
- [ ] CI: `Test and Release` and `Deploy to Railway` pass on this PR
- [ ] After merge: confirm Railway picks up the deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)