### PR TITLE
feat(forms): tour-type forms with itinerary planner + GYG xlsx import

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -122,6 +122,7 @@
     "dayjs": "^1.11.19",
     "esbuild": "^0.27.1",
     "esbuild-wasm": "^0.27.1",
+    "exceljs": "^4.4.0",
     "file-saver": "^2.0.5",
     "framer-motion": "^12.4.3",
     "fzf": "0.5.2",

--- a/apps/backend/src/admin/components/creates/create-form.tsx
+++ b/apps/backend/src/admin/components/creates/create-form.tsx
@@ -13,6 +13,7 @@ const formSchema = z.object({
   title: z.string().min(1, "Title is required"),
   handle: z.string().min(1, "Handle is required"),
   domain: z.string().min(1, "Domain is required"),
+  type: z.enum(["generic", "tour"]),
   status: z.enum(["draft", "published", "archived"]),
   description: z.string().optional(),
   submit_label: z.string().optional(),
@@ -27,6 +28,7 @@ export const CreateFormComponent = () => {
       title: "",
       handle: "",
       domain: "",
+      type: "generic",
       status: "draft",
       description: "",
       submit_label: "",
@@ -44,6 +46,7 @@ export const CreateFormComponent = () => {
         title: data.title,
         handle: data.handle,
         domain: data.domain,
+        type: data.type,
         status: data.status,
         description: data.description || undefined,
         submit_label: data.submit_label || undefined,
@@ -119,6 +122,27 @@ export const CreateFormComponent = () => {
                     <Form.Label>Domain</Form.Label>
                     <Form.Control>
                       <Input autoComplete="off" {...field} />
+                    </Form.Control>
+                    <Form.ErrorMessage />
+                  </Form.Item>
+                )}
+              />
+              <Form.Field
+                control={form.control}
+                name="type"
+                render={({ field: { value, onChange } }) => (
+                  <Form.Item>
+                    <Form.Label>Type</Form.Label>
+                    <Form.Control>
+                      <Select value={value} onValueChange={onChange}>
+                        <Select.Trigger>
+                          <Select.Value placeholder="Select type" />
+                        </Select.Trigger>
+                        <Select.Content>
+                          <Select.Item value="generic">Generic</Select.Item>
+                          <Select.Item value="tour">Tour</Select.Item>
+                        </Select.Content>
+                      </Select>
                     </Form.Control>
                     <Form.ErrorMessage />
                   </Form.Item>

--- a/apps/backend/src/admin/components/edits/edit-form.tsx
+++ b/apps/backend/src/admin/components/edits/edit-form.tsx
@@ -26,6 +26,16 @@ export const EditFormComponent = ({ form }: EditFormComponentProps) => {
     { name: "handle", type: "text", label: "Handle", required: true },
     { name: "domain", type: "text", label: "Domain", required: false },
     {
+      name: "type",
+      type: "select",
+      label: "Type",
+      required: true,
+      options: [
+        { value: "generic", label: "Generic" },
+        { value: "tour", label: "Tour" },
+      ],
+    },
+    {
       name: "status",
       type: "select",
       label: "Status",
@@ -48,6 +58,7 @@ export const EditFormComponent = ({ form }: EditFormComponentProps) => {
         title: form.title || "",
         handle: form.handle || "",
         domain: form.domain || "",
+        type: form.type || "generic",
         status: form.status || "draft",
         description: form.description || "",
         submit_label: form.submit_label || "",

--- a/apps/backend/src/admin/components/edits/edit-tour-settings.tsx
+++ b/apps/backend/src/admin/components/edits/edit-tour-settings.tsx
@@ -1,0 +1,550 @@
+import { Button, Heading, Input, Text, Textarea, toast } from "@medusajs/ui"
+import { Plus, Trash } from "@medusajs/icons"
+import { FormProvider, useFieldArray, useForm } from "react-hook-form"
+import { z } from "@medusajs/framework/zod"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useRouteModal } from "../modal/use-route-modal"
+import { RouteFocusModal } from "../modal/route-focus-modal"
+import { Form } from "../common/form"
+import { KeyboundForm } from "../utilitites/key-bound-form"
+import { AdminForm, useUpdateForm } from "../../hooks/api/forms"
+import { TourSegmentEditor } from "./tour-segment-editor"
+
+const segmentLinkSchema = z.object({
+  label: z.string().optional(),
+  url: z.string().optional(),
+})
+
+const segmentImageSchema = z.object({
+  url: z.string().optional(),
+})
+
+const segmentSchema = z.object({
+  id: z.string().min(1, "id required"),
+  title: z.string().min(1, "title required"),
+  description: z.string().optional(),
+  image_url: z.string().optional(),
+  duration_minutes: z.number().int().nonnegative().optional(),
+  time_slot: z.string().optional(),
+  base_price: z.number().nonnegative().default(0),
+  currency: z.string().optional(),
+  required: z.boolean().default(false),
+  links: z.array(segmentLinkSchema).default([]),
+  gallery: z.array(segmentImageSchema).default([]),
+})
+
+const multiplierSchema = z.object({
+  category: z.string().min(1),
+  multiplier: z.number().nonnegative().default(1),
+})
+
+const guideSchema = z.object({
+  id: z.string().optional(),
+  name: z.string().min(1, "name required"),
+  role: z.string().optional(),
+  bio: z.string().optional(),
+  photo_url: z.string().optional(),
+  languages: z.string().optional(),
+  instagram: z.string().optional(),
+})
+
+const tourSettingsSchema = z.object({
+  currency: z.string().min(1, "currency required"),
+  story_headline: z.string().optional(),
+  story_body: z.string().optional(),
+  segments: z.array(segmentSchema),
+  multipliers: z.array(multiplierSchema),
+  guides: z.array(guideSchema),
+})
+
+type TourSettingsFormData = z.input<typeof tourSettingsSchema>
+
+const buildDefaults = (form: AdminForm): TourSettingsFormData => {
+  const settings = (form.settings as Record<string, any> | null) || {}
+  const segments = Array.isArray(settings.itinerary_segments)
+    ? (settings.itinerary_segments as any[])
+    : []
+  const pricing = (settings.pricing as Record<string, any>) || {}
+  const multiplierObj = (pricing.per_category_multiplier as Record<string, number>) || {}
+  const story = (settings.story as Record<string, any>) || {}
+  const guides = Array.isArray(settings.guides) ? (settings.guides as any[]) : []
+
+  return {
+    currency: pricing.currency || segments[0]?.currency || "INR",
+    story_headline: story.headline ?? "",
+    story_body: story.body ?? "",
+    segments: segments.map((s) => ({
+      id: s.id ?? "",
+      title: s.title ?? "",
+      description: s.description ?? "",
+      image_url: s.image_url ?? "",
+      duration_minutes: typeof s.duration_minutes === "number" ? s.duration_minutes : undefined,
+      time_slot: s.time_slot ?? "",
+      base_price: typeof s.base_price === "number" ? s.base_price : 0,
+      currency: s.currency ?? "",
+      required: !!s.required,
+      links: Array.isArray(s.links)
+        ? s.links.map((l: any) => ({ label: l?.label ?? "", url: l?.url ?? "" }))
+        : [],
+      gallery: Array.isArray(s.gallery)
+        ? s.gallery
+            .map((g: any) => ({ url: typeof g === "string" ? g : g?.url ?? "" }))
+            .filter((g: any) => g.url)
+        : [],
+    })),
+    multipliers: Object.entries(multiplierObj).map(([category, multiplier]) => ({
+      category,
+      multiplier: typeof multiplier === "number" ? multiplier : 1,
+    })),
+    guides: guides.map((g) => ({
+      id: g.id ?? "",
+      name: g.name ?? "",
+      role: g.role ?? "",
+      bio: g.bio ?? "",
+      photo_url: g.photo_url ?? "",
+      languages: Array.isArray(g.languages) ? g.languages.join(", ") : g.languages ?? "",
+      instagram: g.instagram ?? "",
+    })),
+  }
+}
+
+type EditTourSettingsProps = { form: AdminForm }
+
+export const EditTourSettingsComponent = ({ form }: EditTourSettingsProps) => {
+  const formCtx = useForm<TourSettingsFormData>({
+    defaultValues: buildDefaults(form),
+    resolver: zodResolver(tourSettingsSchema),
+  })
+
+  const segments = useFieldArray({ control: formCtx.control, name: "segments" })
+  const multipliers = useFieldArray({ control: formCtx.control, name: "multipliers" })
+  const guides = useFieldArray({ control: formCtx.control, name: "guides" })
+
+  const { handleSuccess } = useRouteModal()
+  const { mutateAsync, isPending } = useUpdateForm(form.id)
+
+  const handleSubmit = formCtx.handleSubmit(async (data) => {
+    const existingSettings = (form.settings as Record<string, any> | null) || {}
+
+    const cleanedSegments = data.segments.map((s) => ({
+      id: s.id.trim(),
+      title: s.title.trim(),
+      description: s.description?.trim() || null,
+      image_url: s.image_url?.trim() || null,
+      duration_minutes:
+        typeof s.duration_minutes === "number" && s.duration_minutes > 0
+          ? s.duration_minutes
+          : null,
+      time_slot: s.time_slot?.trim() || null,
+      base_price: typeof s.base_price === "number" ? s.base_price : 0,
+      currency: s.currency?.trim() || data.currency,
+      required: !!s.required,
+      links: (s.links || [])
+        .map((l) => ({
+          label: l.label?.trim() || "",
+          url: l.url?.trim() || "",
+        }))
+        .filter((l) => l.url),
+      gallery: (s.gallery || [])
+        .map((g) => g.url?.trim() || "")
+        .filter(Boolean),
+    }))
+
+    const multiplierMap: Record<string, number> = {}
+    for (const m of data.multipliers) {
+      const key = m.category.trim()
+      if (!key) continue
+      multiplierMap[key] = typeof m.multiplier === "number" ? m.multiplier : 1
+    }
+
+    const cleanedGuides = data.guides
+      .filter((g) => g.name?.trim())
+      .map((g, idx) => ({
+        id: g.id?.trim() || `guide_${idx + 1}`,
+        name: g.name.trim(),
+        role: g.role?.trim() || null,
+        bio: g.bio?.trim() || null,
+        photo_url: g.photo_url?.trim() || null,
+        languages: g.languages
+          ?.split(",")
+          .map((s) => s.trim())
+          .filter(Boolean),
+        instagram: g.instagram?.trim() || null,
+      }))
+
+    const headline = data.story_headline?.trim() || null
+    const body = data.story_body?.trim() || null
+    const story = headline || body ? { headline, body } : null
+
+    const nextSettings = {
+      ...existingSettings,
+      story,
+      guides: cleanedGuides,
+      itinerary_segments: cleanedSegments,
+      pricing: {
+        ...(existingSettings.pricing || {}),
+        currency: data.currency,
+        per_category_multiplier: multiplierMap,
+      },
+    }
+
+    try {
+      await mutateAsync({ settings: nextSettings })
+      toast.success("Tour settings saved")
+      handleSuccess()
+    } catch (e: any) {
+      toast.error(e?.message || "Failed to save tour settings")
+    }
+  })
+
+  return (
+    <RouteFocusModal.Form form={formCtx}>
+      <FormProvider {...formCtx}>
+        <KeyboundForm onSubmit={handleSubmit} className="flex flex-col overflow-hidden">
+          <RouteFocusModal.Header>
+            <div className="flex items-center justify-end gap-x-2">
+              <RouteFocusModal.Close asChild>
+                <Button size="small" variant="secondary">Cancel</Button>
+              </RouteFocusModal.Close>
+              <Button size="small" variant="primary" type="submit" isLoading={isPending}>
+                Save
+              </Button>
+            </div>
+          </RouteFocusModal.Header>
+          <RouteFocusModal.Body className="flex flex-col items-center overflow-y-auto p-10">
+            <div className="flex w-full max-w-[920px] flex-col gap-y-10">
+              <div>
+                <Heading>Tour settings</Heading>
+                <Text size="small" className="text-ui-fg-subtle">
+                  Itinerary cards, guides, and pricing rules used by the tour
+                  visit page on the website.
+                </Text>
+              </div>
+
+              {/* Story */}
+              <div className="flex flex-col gap-y-3">
+                <div>
+                  <Text weight="plus">About this tour</Text>
+                  <Text size="small" className="text-ui-fg-subtle">
+                    Shown on the welcome step. Helps the visitor understand why
+                    we&apos;re doing this and the artisans they&apos;re supporting.
+                  </Text>
+                </div>
+                <Form.Field
+                  control={formCtx.control}
+                  name="story_headline"
+                  render={({ field }) => (
+                    <Form.Item>
+                      <Form.Label>Headline</Form.Label>
+                      <Form.Control>
+                        <Input
+                          autoComplete="off"
+                          placeholder="A craft journey, told in your own pace."
+                          {...field}
+                        />
+                      </Form.Control>
+                    </Form.Item>
+                  )}
+                />
+                <Form.Field
+                  control={formCtx.control}
+                  name="story_body"
+                  render={({ field }) => (
+                    <Form.Item>
+                      <Form.Label>Body</Form.Label>
+                      <Form.Control>
+                        <Textarea rows={4} {...field} />
+                      </Form.Control>
+                    </Form.Item>
+                  )}
+                />
+              </div>
+
+              {/* Pricing */}
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+                <Form.Field
+                  control={formCtx.control}
+                  name="currency"
+                  render={({ field }) => (
+                    <Form.Item>
+                      <Form.Label>Default currency</Form.Label>
+                      <Form.Control>
+                        <Input autoComplete="off" placeholder="INR" {...field} />
+                      </Form.Control>
+                      <Form.ErrorMessage />
+                    </Form.Item>
+                  )}
+                />
+              </div>
+
+              {/* Segments */}
+              <div className="flex flex-col gap-y-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <Text weight="plus">Itinerary segments</Text>
+                    <Text size="small" className="text-ui-fg-subtle">
+                      Each segment becomes a clickable card. Add links and
+                      gallery photos for the &quot;more&quot; expand.
+                    </Text>
+                  </div>
+                  <Button
+                    type="button"
+                    size="small"
+                    variant="secondary"
+                    onClick={() =>
+                      segments.append({
+                        id: "",
+                        title: "",
+                        description: "",
+                        image_url: "",
+                        duration_minutes: undefined,
+                        time_slot: "",
+                        base_price: 0,
+                        currency: "",
+                        required: false,
+                        links: [],
+                        gallery: [],
+                      })
+                    }
+                  >
+                    <Plus /> Add segment
+                  </Button>
+                </div>
+
+                {segments.fields.length === 0 ? (
+                  <div className="rounded-md border border-dashed p-6 text-center">
+                    <Text size="small" className="text-ui-fg-subtle">
+                      No segments yet. Add one to get started.
+                    </Text>
+                  </div>
+                ) : (
+                  <div className="flex flex-col gap-y-3">
+                    {segments.fields.map((field, index) => (
+                      <TourSegmentEditor
+                        key={field.id}
+                        index={index}
+                        onRemove={() => segments.remove(index)}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* Guides */}
+              <div className="flex flex-col gap-y-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <Text weight="plus">Guides &amp; artisans</Text>
+                    <Text size="small" className="text-ui-fg-subtle">
+                      The people the visitor will meet — shown on the
+                      &quot;Meet your guides&quot; step.
+                    </Text>
+                  </div>
+                  <Button
+                    type="button"
+                    size="small"
+                    variant="secondary"
+                    onClick={() =>
+                      guides.append({
+                        id: "",
+                        name: "",
+                        role: "",
+                        bio: "",
+                        photo_url: "",
+                        languages: "",
+                        instagram: "",
+                      })
+                    }
+                  >
+                    <Plus /> Add guide
+                  </Button>
+                </div>
+
+                {guides.fields.length === 0 ? (
+                  <div className="rounded-md border border-dashed p-6 text-center">
+                    <Text size="small" className="text-ui-fg-subtle">
+                      No guides yet. Add the artisan(s) leading this tour.
+                    </Text>
+                  </div>
+                ) : (
+                  <div className="flex flex-col gap-y-3">
+                    {guides.fields.map((field, index) => (
+                      <div key={field.id} className="rounded-md border bg-ui-bg-subtle p-4">
+                        <div className="mb-3 flex items-center justify-between">
+                          <Text size="small" weight="plus">Guide {index + 1}</Text>
+                          <Button
+                            type="button"
+                            size="small"
+                            variant="transparent"
+                            onClick={() => guides.remove(index)}
+                          >
+                            <Trash />
+                          </Button>
+                        </div>
+                        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                          <Form.Field
+                            control={formCtx.control}
+                            name={`guides.${index}.name` as const}
+                            render={({ field }) => (
+                              <Form.Item>
+                                <Form.Label>Name</Form.Label>
+                                <Form.Control>
+                                  <Input autoComplete="off" {...field} />
+                                </Form.Control>
+                                <Form.ErrorMessage />
+                              </Form.Item>
+                            )}
+                          />
+                          <Form.Field
+                            control={formCtx.control}
+                            name={`guides.${index}.role` as const}
+                            render={({ field }) => (
+                              <Form.Item>
+                                <Form.Label optional>Role</Form.Label>
+                                <Form.Control>
+                                  <Input autoComplete="off" placeholder="Master weaver" {...field} />
+                                </Form.Control>
+                              </Form.Item>
+                            )}
+                          />
+                          <Form.Field
+                            control={formCtx.control}
+                            name={`guides.${index}.bio` as const}
+                            render={({ field }) => (
+                              <Form.Item className="md:col-span-2">
+                                <Form.Label optional>Bio</Form.Label>
+                                <Form.Control>
+                                  <Textarea rows={3} {...field} />
+                                </Form.Control>
+                              </Form.Item>
+                            )}
+                          />
+                          <Form.Field
+                            control={formCtx.control}
+                            name={`guides.${index}.photo_url` as const}
+                            render={({ field }) => (
+                              <Form.Item className="md:col-span-2">
+                                <Form.Label optional>Photo URL</Form.Label>
+                                <Form.Control>
+                                  <Input autoComplete="off" placeholder="https://…" {...field} />
+                                </Form.Control>
+                              </Form.Item>
+                            )}
+                          />
+                          <Form.Field
+                            control={formCtx.control}
+                            name={`guides.${index}.languages` as const}
+                            render={({ field }) => (
+                              <Form.Item>
+                                <Form.Label optional>Languages</Form.Label>
+                                <Form.Control>
+                                  <Input autoComplete="off" placeholder="English, Hindi, Italian" {...field} />
+                                </Form.Control>
+                              </Form.Item>
+                            )}
+                          />
+                          <Form.Field
+                            control={formCtx.control}
+                            name={`guides.${index}.instagram` as const}
+                            render={({ field }) => (
+                              <Form.Item>
+                                <Form.Label optional>Instagram</Form.Label>
+                                <Form.Control>
+                                  <Input autoComplete="off" placeholder="@handle" {...field} />
+                                </Form.Control>
+                              </Form.Item>
+                            )}
+                          />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* Multipliers */}
+              <div className="flex flex-col gap-y-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <Text weight="plus">Per-category multipliers</Text>
+                    <Text size="small" className="text-ui-fg-subtle">
+                      Optional: scale segment price per traveller category, e.g.
+                      Adult=1, Child=0.5. Categories must match GYG headcount column names.
+                    </Text>
+                  </div>
+                  <Button
+                    type="button"
+                    size="small"
+                    variant="secondary"
+                    onClick={() => multipliers.append({ category: "", multiplier: 1 })}
+                  >
+                    <Plus /> Add row
+                  </Button>
+                </div>
+
+                {multipliers.fields.length === 0 ? (
+                  <div className="rounded-md border border-dashed p-6 text-center">
+                    <Text size="small" className="text-ui-fg-subtle">
+                      No multipliers — every category will count as 1×.
+                    </Text>
+                  </div>
+                ) : (
+                  <div className="flex flex-col gap-y-2">
+                    {multipliers.fields.map((field, index) => (
+                      <div
+                        key={field.id}
+                        className="grid grid-cols-[1fr_180px_auto] items-end gap-3 rounded-md border bg-ui-bg-subtle p-3"
+                      >
+                        <Form.Field
+                          control={formCtx.control}
+                          name={`multipliers.${index}.category` as const}
+                          render={({ field }) => (
+                            <Form.Item>
+                              <Form.Label>Category</Form.Label>
+                              <Form.Control>
+                                <Input autoComplete="off" placeholder="Adult" {...field} />
+                              </Form.Control>
+                              <Form.ErrorMessage />
+                            </Form.Item>
+                          )}
+                        />
+                        <Form.Field
+                          control={formCtx.control}
+                          name={`multipliers.${index}.multiplier` as const}
+                          render={({ field }) => (
+                            <Form.Item>
+                              <Form.Label>Multiplier</Form.Label>
+                              <Form.Control>
+                                <Input
+                                  type="number"
+                                  min={0}
+                                  step="0.01"
+                                  {...field}
+                                  value={field.value ?? 1}
+                                  onChange={(e) => field.onChange(Number(e.target.value))}
+                                />
+                              </Form.Control>
+                              <Form.ErrorMessage />
+                            </Form.Item>
+                          )}
+                        />
+                        <Button
+                          type="button"
+                          size="small"
+                          variant="transparent"
+                          onClick={() => multipliers.remove(index)}
+                        >
+                          <Trash />
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          </RouteFocusModal.Body>
+        </KeyboundForm>
+      </FormProvider>
+    </RouteFocusModal.Form>
+  )
+}

--- a/apps/backend/src/admin/components/edits/import-tour-bookings.tsx
+++ b/apps/backend/src/admin/components/edits/import-tour-bookings.tsx
@@ -1,0 +1,138 @@
+import { useState } from "react"
+import { Button, Heading, Input, Label, Text, toast } from "@medusajs/ui"
+import { useRouteModal } from "../modal/use-route-modal"
+import { RouteFocusModal } from "../modal/route-focus-modal"
+import { KeyboundForm } from "../utilitites/key-bound-form"
+import { useImportTourBookings, type ImportTourBookingsResponse } from "../../hooks/api/forms"
+
+type Props = { formId: string }
+
+export const ImportTourBookingsComponent = ({ formId }: Props) => {
+  const [file, setFile] = useState<File | null>(null)
+  const [tokenTtlDays, setTokenTtlDays] = useState<string>("60")
+  const [result, setResult] = useState<ImportTourBookingsResponse | null>(null)
+  const { handleSuccess } = useRouteModal()
+  const { mutateAsync, isPending } = useImportTourBookings(formId)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!file) {
+      toast.error("Pick an xlsx file first")
+      return
+    }
+    try {
+      const ttl = parseInt(tokenTtlDays, 10)
+      const res = await mutateAsync({
+        file,
+        tokenTtlDays: Number.isFinite(ttl) ? ttl : undefined,
+      })
+      setResult(res)
+      toast.success(
+        `Imported ${res.created_count} booking${res.created_count === 1 ? "" : "s"}` +
+          (res.skipped_count ? `, skipped ${res.skipped_count}` : "")
+      )
+    } catch (err: any) {
+      toast.error(err?.message || "Import failed")
+    }
+  }
+
+  return (
+    <KeyboundForm onSubmit={handleSubmit} className="flex flex-col overflow-hidden">
+      <RouteFocusModal.Header>
+        <div className="flex items-center justify-end gap-x-2">
+          <RouteFocusModal.Close asChild>
+            <Button size="small" variant="secondary">
+              {result ? "Close" : "Cancel"}
+            </Button>
+          </RouteFocusModal.Close>
+          {!result ? (
+            <Button
+              size="small"
+              variant="primary"
+              type="submit"
+              isLoading={isPending}
+              disabled={!file}
+            >
+              Import
+            </Button>
+          ) : (
+            <Button
+              size="small"
+              variant="primary"
+              type="button"
+              onClick={() => handleSuccess()}
+            >
+              Done
+            </Button>
+          )}
+        </div>
+      </RouteFocusModal.Header>
+      <RouteFocusModal.Body className="flex flex-col items-center overflow-y-auto p-10">
+        <div className="flex w-full max-w-[640px] flex-col gap-y-6">
+          <div>
+            <Heading>Import tour bookings</Heading>
+            <Text size="small" className="text-ui-fg-subtle">
+              Upload a GetYourGuide bookings xlsx export. One form response is
+              created per booking with a unique visit token.
+            </Text>
+          </div>
+
+          {!result ? (
+            <>
+              <div className="flex flex-col gap-y-2">
+                <Label htmlFor="tour-bookings-file">XLSX file</Label>
+                <Input
+                  id="tour-bookings-file"
+                  type="file"
+                  accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                  onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+                />
+                {file ? (
+                  <Text size="xsmall" className="text-ui-fg-subtle">
+                    Selected: {file.name} ({Math.round(file.size / 1024)} KB)
+                  </Text>
+                ) : null}
+              </div>
+
+              <div className="flex flex-col gap-y-2">
+                <Label htmlFor="tour-bookings-ttl">Visit token TTL (days from tour date)</Label>
+                <Input
+                  id="tour-bookings-ttl"
+                  type="number"
+                  min={1}
+                  max={3650}
+                  value={tokenTtlDays}
+                  onChange={(e) => setTokenTtlDays(e.target.value)}
+                />
+                <Text size="xsmall" className="text-ui-fg-subtle">
+                  Tokens stay valid until the tour date plus this many days. Default 60.
+                </Text>
+              </div>
+            </>
+          ) : (
+            <div className="flex flex-col gap-y-3 rounded-md border bg-ui-bg-subtle p-4">
+              <div className="grid grid-cols-2 gap-2">
+                <Text size="small" className="text-ui-fg-subtle">Created</Text>
+                <Text size="small" weight="plus">{result.created_count}</Text>
+                <Text size="small" className="text-ui-fg-subtle">Skipped (already imported)</Text>
+                <Text size="small" weight="plus">{result.skipped_count}</Text>
+              </div>
+              {result.skipped_booking_refs.length > 0 ? (
+                <div>
+                  <Text size="xsmall" className="text-ui-fg-subtle">Skipped booking refs:</Text>
+                  <Text size="xsmall" className="break-all font-mono">
+                    {result.skipped_booking_refs.join(", ")}
+                  </Text>
+                </div>
+              ) : null}
+              <Text size="small" className="text-ui-fg-subtle">
+                Visit tokens are now stored as <code>verification_code</code> on the new
+                form responses. Open the responses list below to copy share links.
+              </Text>
+            </div>
+          )}
+        </div>
+      </RouteFocusModal.Body>
+    </KeyboundForm>
+  )
+}

--- a/apps/backend/src/admin/components/edits/tour-segment-editor.tsx
+++ b/apps/backend/src/admin/components/edits/tour-segment-editor.tsx
@@ -1,0 +1,274 @@
+import { Button, Input, Switch, Text, Textarea } from "@medusajs/ui"
+import { Plus, Trash } from "@medusajs/icons"
+import { useFieldArray, useFormContext } from "react-hook-form"
+import { Form } from "../common/form"
+
+type Props = {
+  index: number
+  onRemove: () => void
+}
+
+export const TourSegmentEditor = ({ index, onRemove }: Props) => {
+  const formCtx = useFormContext<any>()
+
+  const links = useFieldArray({
+    control: formCtx.control,
+    name: `segments.${index}.links`,
+  })
+
+  const gallery = useFieldArray({
+    control: formCtx.control,
+    name: `segments.${index}.gallery`,
+  })
+
+  return (
+    <div className="rounded-md border bg-ui-bg-subtle p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <Text size="small" weight="plus">Segment {index + 1}</Text>
+        <Button type="button" size="small" variant="transparent" onClick={onRemove}>
+          <Trash />
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <Form.Field
+          control={formCtx.control}
+          name={`segments.${index}.id` as const}
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label>ID (slug)</Form.Label>
+              <Form.Control>
+                <Input autoComplete="off" placeholder="seg_factory_tour" {...field} />
+              </Form.Control>
+              <Form.ErrorMessage />
+            </Form.Item>
+          )}
+        />
+        <Form.Field
+          control={formCtx.control}
+          name={`segments.${index}.title` as const}
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label>Title</Form.Label>
+              <Form.Control>
+                <Input autoComplete="off" {...field} />
+              </Form.Control>
+              <Form.ErrorMessage />
+            </Form.Item>
+          )}
+        />
+        <Form.Field
+          control={formCtx.control}
+          name={`segments.${index}.description` as const}
+          render={({ field }) => (
+            <Form.Item className="md:col-span-2">
+              <Form.Label optional>Description</Form.Label>
+              <Form.Control>
+                <Textarea rows={2} {...field} />
+              </Form.Control>
+              <Form.ErrorMessage />
+            </Form.Item>
+          )}
+        />
+        <Form.Field
+          control={formCtx.control}
+          name={`segments.${index}.image_url` as const}
+          render={({ field }) => (
+            <Form.Item className="md:col-span-2">
+              <Form.Label optional>Cover image URL</Form.Label>
+              <Form.Control>
+                <Input autoComplete="off" placeholder="https://…" {...field} />
+              </Form.Control>
+              <Form.ErrorMessage />
+            </Form.Item>
+          )}
+        />
+        <Form.Field
+          control={formCtx.control}
+          name={`segments.${index}.duration_minutes` as const}
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label optional>Duration (min)</Form.Label>
+              <Form.Control>
+                <Input
+                  type="number"
+                  min={0}
+                  {...field}
+                  value={field.value ?? ""}
+                  onChange={(e) =>
+                    field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
+                  }
+                />
+              </Form.Control>
+              <Form.ErrorMessage />
+            </Form.Item>
+          )}
+        />
+        <Form.Field
+          control={formCtx.control}
+          name={`segments.${index}.time_slot` as const}
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label optional>Time slot</Form.Label>
+              <Form.Control>
+                <Input autoComplete="off" placeholder="11:00" {...field} />
+              </Form.Control>
+              <Form.ErrorMessage />
+            </Form.Item>
+          )}
+        />
+        <Form.Field
+          control={formCtx.control}
+          name={`segments.${index}.base_price` as const}
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label>Base price (per pax)</Form.Label>
+              <Form.Control>
+                <Input
+                  type="number"
+                  min={0}
+                  step="0.01"
+                  {...field}
+                  value={field.value ?? 0}
+                  onChange={(e) => field.onChange(Number(e.target.value))}
+                />
+              </Form.Control>
+              <Form.ErrorMessage />
+            </Form.Item>
+          )}
+        />
+        <Form.Field
+          control={formCtx.control}
+          name={`segments.${index}.currency` as const}
+          render={({ field }) => (
+            <Form.Item>
+              <Form.Label optional>Currency override</Form.Label>
+              <Form.Control>
+                <Input autoComplete="off" placeholder="(uses default)" {...field} />
+              </Form.Control>
+              <Form.ErrorMessage />
+            </Form.Item>
+          )}
+        />
+        <Form.Field
+          control={formCtx.control}
+          name={`segments.${index}.required` as const}
+          render={({ field: { value, onChange } }) => (
+            <Form.Item className="flex items-center gap-3 pt-6 md:col-span-2">
+              <Form.Control>
+                <Switch checked={!!value} onCheckedChange={onChange} />
+              </Form.Control>
+              <Form.Label className="!mt-0">
+                Required (always included, can&apos;t toggle off)
+              </Form.Label>
+            </Form.Item>
+          )}
+        />
+      </div>
+
+      <div className="mt-4 flex flex-col gap-y-2">
+        <div className="flex items-center justify-between">
+          <Text size="small" weight="plus">Links</Text>
+          <Button
+            type="button"
+            size="small"
+            variant="secondary"
+            onClick={() => links.append({ label: "", url: "" })}
+          >
+            <Plus /> Add link
+          </Button>
+        </div>
+        {links.fields.length === 0 ? (
+          <Text size="xsmall" className="text-ui-fg-subtle">
+            Optional. Shown when the customer expands this segment.
+          </Text>
+        ) : (
+          <div className="flex flex-col gap-y-2">
+            {links.fields.map((row, linkIdx) => (
+              <div key={row.id} className="grid grid-cols-[1fr_2fr_auto] items-end gap-2">
+                <Form.Field
+                  control={formCtx.control}
+                  name={`segments.${index}.links.${linkIdx}.label` as const}
+                  render={({ field }) => (
+                    <Form.Item>
+                      <Form.Label>Label</Form.Label>
+                      <Form.Control>
+                        <Input autoComplete="off" placeholder="Watch the video" {...field} />
+                      </Form.Control>
+                    </Form.Item>
+                  )}
+                />
+                <Form.Field
+                  control={formCtx.control}
+                  name={`segments.${index}.links.${linkIdx}.url` as const}
+                  render={({ field }) => (
+                    <Form.Item>
+                      <Form.Label>URL</Form.Label>
+                      <Form.Control>
+                        <Input autoComplete="off" placeholder="https://…" {...field} />
+                      </Form.Control>
+                    </Form.Item>
+                  )}
+                />
+                <Button
+                  type="button"
+                  size="small"
+                  variant="transparent"
+                  onClick={() => links.remove(linkIdx)}
+                >
+                  <Trash />
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="mt-4 flex flex-col gap-y-2">
+        <div className="flex items-center justify-between">
+          <Text size="small" weight="plus">Gallery</Text>
+          <Button
+            type="button"
+            size="small"
+            variant="secondary"
+            onClick={() => gallery.append({ url: "" })}
+          >
+            <Plus /> Add image
+          </Button>
+        </div>
+        {gallery.fields.length === 0 ? (
+          <Text size="xsmall" className="text-ui-fg-subtle">
+            Optional extra photos shown alongside the cover image.
+          </Text>
+        ) : (
+          <div className="flex flex-col gap-y-2">
+            {gallery.fields.map((row, gIdx) => (
+              <div key={row.id} className="grid grid-cols-[1fr_auto] items-end gap-2">
+                <Form.Field
+                  control={formCtx.control}
+                  name={`segments.${index}.gallery.${gIdx}.url` as const}
+                  render={({ field }) => (
+                    <Form.Item>
+                      <Form.Label>Image URL</Form.Label>
+                      <Form.Control>
+                        <Input autoComplete="off" placeholder="https://…" {...field} />
+                      </Form.Control>
+                    </Form.Item>
+                  )}
+                />
+                <Button
+                  type="button"
+                  size="small"
+                  variant="transparent"
+                  onClick={() => gallery.remove(gIdx)}
+                >
+                  <Trash />
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/backend/src/admin/components/forms/form-general-section.tsx
+++ b/apps/backend/src/admin/components/forms/form-general-section.tsx
@@ -91,6 +91,12 @@ export const FormGeneralSection = ({ form }: FormGeneralSectionProps) => {
         </div>
         <div className="grid grid-cols-2 items-center px-6 py-4">
           <Text size="small" leading="compact" weight="plus">
+            Type
+          </Text>
+          <Text size="small" leading="compact">{form.type || "generic"}</Text>
+        </div>
+        <div className="grid grid-cols-2 items-center px-6 py-4">
+          <Text size="small" leading="compact" weight="plus">
             Status
           </Text>
           <Text size="small" leading="compact">{form.status || "-"}</Text>

--- a/apps/backend/src/admin/components/forms/form-responses-section.tsx
+++ b/apps/backend/src/admin/components/forms/form-responses-section.tsx
@@ -9,10 +9,15 @@ import {
 import { keepPreviousData } from "@tanstack/react-query"
 import { useMemo, useState } from "react"
 import { createColumnHelper } from "@tanstack/react-table"
-import { Eye } from "@medusajs/icons"
+import { Eye, SquareTwoStack } from "@medusajs/icons"
+import { toast } from "sonner"
 import { EntityActions } from "../persons/personsActions"
 import { AdminFormResponse, useFormResponses } from "../../hooks/api/forms"
 import { useFormResponsesTableColumns } from "../../hooks/columns/useFormResponsesTableColumns"
+
+const TOUR_WEBSITE_ORIGIN: string =
+  (process.env.NEXT_PUBLIC_WEBSITE_URL?.replace(/\/$/, "") as string | undefined) ||
+  "https://jaalyantra.com"
 
 type FormResponsesSectionProps = {
   formId: string
@@ -41,19 +46,33 @@ export const FormResponsesSection = ({ formId }: FormResponsesSectionProps) => {
 
   const columnsBase = useFormResponsesTableColumns()
 
-  const responseActionsConfig = useMemo(
-    () => ({
-      actions: [
-        {
-          icon: <Eye />,
-          label: "View",
-          to: (resp: AdminFormResponse) =>
-            `/settings/forms/${formId}/responses/${resp.id}`,
+  const buildActionsConfig = (resp: AdminFormResponse) => {
+    const actions: any[] = [
+      {
+        icon: <Eye />,
+        label: "View",
+        to: (r: AdminFormResponse) =>
+          `/settings/forms/${formId}/responses/${r.id}`,
+      },
+    ]
+    if ((resp as any)?.verification_code) {
+      actions.push({
+        icon: <SquareTwoStack />,
+        label: "Copy visit link",
+        onClick: async (r: AdminFormResponse) => {
+          const code = (r as any)?.verification_code
+          const url = `${TOUR_WEBSITE_ORIGIN}/tours/visit/${code}`
+          try {
+            await navigator.clipboard.writeText(url)
+            toast.success("Visit link copied")
+          } catch {
+            toast.error("Could not copy — check clipboard permissions")
+          }
         },
-      ],
-    }),
-    [formId]
-  )
+      })
+    }
+    return { actions }
+  }
 
   const columns = useMemo(
     () => [
@@ -64,12 +83,13 @@ export const FormResponsesSection = ({ formId }: FormResponsesSectionProps) => {
         cell: ({ row }) => (
           <EntityActions
             entity={row.original}
-            actionsConfig={responseActionsConfig}
+            actionsConfig={buildActionsConfig(row.original)}
           />
         ),
       }),
     ],
-    [columnsBase, responseActionsConfig]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [columnsBase, formId]
   )
 
   const table = useDataTable({

--- a/apps/backend/src/admin/components/forms/tour-settings-section.tsx
+++ b/apps/backend/src/admin/components/forms/tour-settings-section.tsx
@@ -1,0 +1,190 @@
+import { ArrowUpTray, PencilSquare } from "@medusajs/icons"
+import { Badge, Container, Heading, Text } from "@medusajs/ui"
+import { ActionMenu } from "../common/action-menu"
+import { AdminForm } from "../../hooks/api/forms"
+
+type Segment = {
+  id: string
+  title?: string
+  description?: string | null
+  duration_minutes?: number | null
+  time_slot?: string | null
+  base_price?: number
+  currency?: string
+  required?: boolean
+  image_url?: string | null
+}
+
+type Pricing = {
+  currency?: string
+  per_category_multiplier?: Record<string, number>
+}
+
+const formatMoney = (n: number | undefined, currency: string | undefined) => {
+  if (typeof n !== "number") return "-"
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: currency || "INR",
+      maximumFractionDigits: 0,
+    }).format(n)
+  } catch {
+    return `${currency || ""} ${n}`
+  }
+}
+
+type TourSettingsSectionProps = {
+  form: AdminForm
+}
+
+export const TourSettingsSection = ({ form }: TourSettingsSectionProps) => {
+  if (form.type !== "tour") return null
+
+  const settings = (form.settings as Record<string, any> | null) || {}
+  const segments: Segment[] = Array.isArray(settings.itinerary_segments)
+    ? settings.itinerary_segments
+    : []
+  const pricing: Pricing = (settings.pricing as Pricing) || {}
+  const multiplier = pricing.per_category_multiplier || {}
+  const fallbackCurrency = pricing.currency || segments[0]?.currency || "INR"
+  const story = (settings.story as { headline?: string; body?: string } | null) || null
+  const guides = Array.isArray(settings.guides) ? settings.guides : []
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex flex-col">
+          <Heading level="h2">Tour settings</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            Itinerary segments and pricing rules used by the public visit page.
+          </Text>
+        </div>
+        <ActionMenu
+          groups={[
+            {
+              actions: [
+                {
+                  icon: <PencilSquare />,
+                  label: "Edit tour settings",
+                  to: "tour-settings",
+                },
+                {
+                  icon: <ArrowUpTray />,
+                  label: "Import bookings (xlsx)",
+                  to: "import-bookings",
+                },
+              ],
+            },
+          ]}
+        />
+      </div>
+
+      {story?.headline || story?.body ? (
+        <div className="px-6 py-4">
+          <Text size="small" weight="plus" className="block">
+            About this tour
+          </Text>
+          {story.headline ? (
+            <Text size="small" className="mt-1 text-ui-fg-subtle">
+              {story.headline}
+            </Text>
+          ) : null}
+          {story.body ? (
+            <Text size="xsmall" className="mt-1 line-clamp-2 text-ui-fg-subtle">
+              {story.body}
+            </Text>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="px-6 py-4">
+        <Text size="small" weight="plus" className="block">
+          Guides ({guides.length})
+        </Text>
+        {guides.length === 0 ? (
+          <Text size="xsmall" className="text-ui-fg-subtle">
+            None — add guides via &quot;Edit tour settings&quot;.
+          </Text>
+        ) : (
+          <Text size="xsmall" className="text-ui-fg-subtle">
+            {guides.map((g: any) => g.name).filter(Boolean).join(" · ")}
+          </Text>
+        )}
+      </div>
+
+      <div className="px-6 py-4">
+        <div className="mb-3 flex items-center justify-between">
+          <Text size="small" weight="plus">
+            Itinerary segments ({segments.length})
+          </Text>
+          <Text size="xsmall" className="text-ui-fg-subtle">
+            Currency: {fallbackCurrency}
+          </Text>
+        </div>
+        {segments.length === 0 ? (
+          <Text size="small" className="text-ui-fg-subtle">
+            No segments yet — click &quot;Edit tour settings&quot; to add some.
+          </Text>
+        ) : (
+          <ul className="divide-y rounded-md border">
+            {segments.map((s, idx) => (
+              <li
+                key={s.id || idx}
+                className="flex items-start justify-between gap-4 px-4 py-3"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <Text size="small" weight="plus" className="truncate">
+                      {s.title || s.id}
+                    </Text>
+                    {s.required ? (
+                      <Badge size="2xsmall" color="green">Required</Badge>
+                    ) : (
+                      <Badge size="2xsmall" color="grey">Optional</Badge>
+                    )}
+                  </div>
+                  <Text size="xsmall" className="text-ui-fg-subtle truncate">
+                    {s.id}
+                    {s.duration_minutes ? ` · ${s.duration_minutes} min` : ""}
+                    {s.time_slot ? ` · ${s.time_slot}` : ""}
+                  </Text>
+                  {s.description ? (
+                    <Text size="xsmall" className="text-ui-fg-subtle line-clamp-2 mt-1">
+                      {s.description}
+                    </Text>
+                  ) : null}
+                </div>
+                <div className="text-right whitespace-nowrap">
+                  <Text size="small" weight="plus">
+                    {formatMoney(s.base_price, s.currency || fallbackCurrency)}
+                  </Text>
+                  <Text size="xsmall" className="text-ui-fg-subtle">
+                    per pax
+                  </Text>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {Object.keys(multiplier).length > 0 ? (
+        <div className="px-6 py-4">
+          <Text size="small" weight="plus" className="mb-2 block">
+            Per-category multiplier
+          </Text>
+          <div className="grid grid-cols-2 gap-x-6 gap-y-1 sm:grid-cols-3">
+            {Object.entries(multiplier).map(([cat, m]) => (
+              <div key={cat} className="flex items-center justify-between">
+                <Text size="xsmall" className="text-ui-fg-subtle truncate">
+                  {cat}
+                </Text>
+                <Text size="xsmall">{m}×</Text>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </Container>
+  )
+}

--- a/apps/backend/src/admin/hooks/api/forms.ts
+++ b/apps/backend/src/admin/hooks/api/forms.ts
@@ -54,6 +54,7 @@ export type AdminFormField = {
 export type AdminFormsQuery = {
   q?: string
   status?: "draft" | "published" | "archived"
+  type?: "generic" | "tour"
   website_id?: string
   domain?: string
   offset?: number
@@ -76,6 +77,7 @@ export type CreateAdminFormPayload = {
   handle: string
   title: string
   description?: string | null
+  type?: "generic" | "tour"
   status?: "draft" | "published" | "archived"
   submit_label?: string | null
   success_message?: string | null
@@ -298,4 +300,46 @@ export const useFormResponses = (
   })
 
   return { ...data, ...rest }
+}
+
+export type ImportTourBookingsResponse = {
+  created_count: number
+  skipped_count: number
+  skipped_booking_refs: string[]
+}
+
+export const useImportTourBookings = (
+  formId: string,
+  options?: UseMutationOptions<
+    ImportTourBookingsResponse,
+    FetchError,
+    { file: File; tokenTtlDays?: number }
+  >
+) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ file, tokenTtlDays }) => {
+      const formData = new FormData()
+      formData.append("file", file)
+
+      const url =
+        `/admin/forms/${formId}/import-tour-bookings` +
+        (typeof tokenTtlDays === "number"
+          ? `?token_ttl_days=${tokenTtlDays}`
+          : "")
+
+      return sdk.client.fetch<ImportTourBookingsResponse>(url, {
+        method: "POST",
+        body: formData,
+        headers: { "Content-Type": null as any },
+      })
+    },
+    onSuccess: (data, variables, _mutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: formResponsesQueryKeys.list({ formId }) })
+      queryClient.invalidateQueries({ queryKey: formResponsesQueryKeys.lists() })
+      options?.onSuccess?.(data, variables, _mutateResult, context)
+    },
+    ...options,
+  })
 }

--- a/apps/backend/src/admin/routes/settings/forms/[id]/@import-bookings/page.tsx
+++ b/apps/backend/src/admin/routes/settings/forms/[id]/@import-bookings/page.tsx
@@ -1,0 +1,14 @@
+import { useParams } from "react-router-dom"
+import { RouteFocusModal } from "../../../../../components/modal/route-focus-modal"
+import { ImportTourBookingsComponent } from "../../../../../components/edits/import-tour-bookings"
+
+export default function ImportBookingsPage() {
+  const { id } = useParams()
+  if (!id) return null
+
+  return (
+    <RouteFocusModal>
+      <ImportTourBookingsComponent formId={id} />
+    </RouteFocusModal>
+  )
+}

--- a/apps/backend/src/admin/routes/settings/forms/[id]/@tour-settings/page.tsx
+++ b/apps/backend/src/admin/routes/settings/forms/[id]/@tour-settings/page.tsx
@@ -1,0 +1,30 @@
+import { useParams, useLoaderData } from "react-router-dom"
+import { Text } from "@medusajs/ui"
+import { RouteFocusModal } from "../../../../../components/modal/route-focus-modal"
+import { useForm } from "../../../../../hooks/api/forms"
+import { formLoader } from "../loader"
+import { EditTourSettingsComponent } from "../../../../../components/edits/edit-tour-settings"
+
+export default function EditTourSettingsPage() {
+  const { id } = useParams()
+  const initialData = useLoaderData() as Awaited<ReturnType<typeof formLoader>>
+
+  const { form, isLoading } = useForm(id!, { initialData })
+
+  if (isLoading || !form) {
+    return (
+      <RouteFocusModal>
+        <RouteFocusModal.Header />
+        <RouteFocusModal.Body className="flex items-center justify-center">
+          <Text className="text-ui-fg-subtle">Loading tour settings…</Text>
+        </RouteFocusModal.Body>
+      </RouteFocusModal>
+    )
+  }
+
+  return (
+    <RouteFocusModal>
+      <EditTourSettingsComponent form={form} />
+    </RouteFocusModal>
+  )
+}

--- a/apps/backend/src/admin/routes/settings/forms/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/settings/forms/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useForm } from "../../../../hooks/api/forms"
 import { formLoader } from "./loader"
 import { FormGeneralSection } from "../../../../components/forms/form-general-section"
 import { FormResponsesSection } from "../../../../components/forms/form-responses-section"
+import { TourSettingsSection } from "../../../../components/forms/tour-settings-section"
 
 const FormDetailPage = () => {
   const { id } = useParams()
@@ -21,6 +22,7 @@ const FormDetailPage = () => {
   return (
     <SingleColumnPage data={form} hasOutlet showJSON showMetadata>
       <FormGeneralSection form={form} />
+      <TourSettingsSection form={form} />
       <FormResponsesSection formId={form.id} />
     </SingleColumnPage>
   )

--- a/apps/backend/src/api/admin/forms/[id]/import-tour-bookings/route.ts
+++ b/apps/backend/src/api/admin/forms/[id]/import-tour-bookings/route.ts
@@ -1,0 +1,54 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { MedusaError } from "@medusajs/framework/utils"
+import {
+  importTourBookingsWorkflow,
+  parseGygWorkbook,
+} from "../../../../../workflows/forms/import-tour-bookings"
+
+/**
+ * POST /admin/forms/:id/import-tour-bookings
+ *
+ * Multipart upload of a GetYourGuide bookings xlsx export. Each row becomes
+ * a `form_response` pre-filled with traveller info and a visit token. The
+ * customer opens /tours/visit/<token> to plan their itinerary.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const formId = req.params.id
+  const files = (req as any).files as Array<{
+    fieldname: string
+    originalname: string
+    buffer: Buffer
+  }> | undefined
+
+  const file = files?.[0]
+  if (!file?.buffer?.length) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "Upload an xlsx file under the 'file' field"
+    )
+  }
+
+  const ttlRaw = (req.query as any)?.token_ttl_days
+  const ttl =
+    typeof ttlRaw === "string"
+      ? parseInt(ttlRaw, 10)
+      : typeof ttlRaw === "number"
+        ? ttlRaw
+        : undefined
+
+  const bookings = await parseGygWorkbook(file.buffer)
+
+  const { result } = await importTourBookingsWorkflow(req.scope).run({
+    input: {
+      form_id: formId,
+      bookings,
+      token_ttl_days: Number.isFinite(ttl) ? ttl : undefined,
+    },
+  })
+
+  res.status(200).json({
+    created_count: result.created_count,
+    skipped_count: result.skipped_count,
+    skipped_booking_refs: result.skipped_booking_refs,
+  })
+}

--- a/apps/backend/src/api/admin/forms/route.ts
+++ b/apps/backend/src/api/admin/forms/route.ts
@@ -65,6 +65,9 @@ export const GET = async (
   if (queryParams.status) {
     filters.status = queryParams.status
   }
+  if (queryParams.type) {
+    filters.type = queryParams.type
+  }
   if (queryParams.website_id) {
     filters.website_id = queryParams.website_id
   }

--- a/apps/backend/src/api/admin/forms/validators.ts
+++ b/apps/backend/src/api/admin/forms/validators.ts
@@ -33,6 +33,7 @@ export const AdminCreateFormSchema = z
     handle: z.string().min(1),
     title: z.string().min(1),
     description: z.string().nullable().optional(),
+    type: z.enum(["generic", "tour"]).default("generic"),
     status: z.enum(["draft", "published", "archived"]).default("draft"),
     submit_label: z.string().nullable().optional(),
     success_message: z.string().nullable().optional(),
@@ -52,6 +53,7 @@ export const AdminUpdateFormSchema = z
     handle: z.string().min(1).optional(),
     title: z.string().min(1).optional(),
     description: z.string().nullable().optional(),
+    type: z.enum(["generic", "tour"]).optional(),
     status: z.enum(["draft", "published", "archived"]).optional(),
     submit_label: z.string().nullable().optional(),
     success_message: z.string().nullable().optional(),
@@ -70,6 +72,7 @@ export const AdminSetFormFieldsSchema = z.object({
 export const AdminListFormsQuerySchema = z.object({
   q: z.string().optional(),
   status: z.enum(["draft", "published", "archived"]).optional(),
+  type: z.enum(["generic", "tour"]).optional(),
   website_id: z.string().optional(),
   domain: z.string().optional(),
   limit: z.coerce.number().min(1).max(100).default(20),

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -226,6 +226,7 @@ import {
   CreateRemoteAdSchema,
 } from "./admin/meta-ads/validators";
 import { webSubmitFormResponseSchema, webVerifyFormResponseSchema } from "./web/website/[domain]/forms/[handle]/validators";
+import { WebSaveTourItinerarySchema } from "./web/tour-visits/[token]/validators";
 import { LinkDesignsToCustomerSchema } from "./admin/customers/[id]/designs/validators";
 import { CreateDesignOrderSchema } from "./admin/customers/[id]/design-order/validators";
 import { listAbandonedCartsQuerySchema } from "./admin/abandoned-carts/validators";
@@ -3146,6 +3147,16 @@ export default defineMiddlewares({
       method: "GET",
       middlewares: [],
     },
+    {
+      matcher: "/web/tour-visits/:token",
+      method: "GET",
+      middlewares: [],
+    },
+    {
+      matcher: "/web/tour-visits/:token",
+      method: "PATCH",
+      middlewares: [validateAndTransformBody(wrapSchema(WebSaveTourItinerarySchema))],
+    },
 
     // Raw Materials Categories API
     {
@@ -3415,6 +3426,12 @@ export default defineMiddlewares({
       matcher: "/admin/forms/:id/responses/:response_id",
       method: "GET",
       middlewares: [],
+    },
+    {
+      matcher: "/admin/forms/:id/import-tour-bookings",
+      method: "POST",
+      bodyParser: false,
+      middlewares: [maybeMulterArray("file")],
     },
     {
       matcher: "/admin/persons/:id/agreements/send",

--- a/apps/backend/src/api/web/tour-visits/[token]/helpers.ts
+++ b/apps/backend/src/api/web/tour-visits/[token]/helpers.ts
@@ -1,0 +1,158 @@
+type Segment = {
+  id: string
+  title?: string
+  description?: string | null
+  image_url?: string | null
+  duration_minutes?: number | null
+  time_slot?: string | null
+  base_price?: number
+  currency?: string
+  required?: boolean
+  optional?: boolean
+  depends_on?: string[]
+}
+
+type Pricing = {
+  currency?: string
+  per_category_multiplier?: Record<string, number>
+}
+
+export type ComputedCost = {
+  currency: string
+  total_pax: number
+  subtotal: number
+  by_segment: Array<{
+    id: string
+    title?: string
+    base_price: number
+    pax: number
+    line_total: number
+  }>
+}
+
+export type PaymentSummary = {
+  paid_via_source: {
+    provider: string
+    amount: number
+    currency: string
+    raw: string | null
+  } | null
+  add_ons_due: number
+  add_ons_currency: string
+  // Total only when paid + add-ons share a currency. When they differ, the
+  // server can't sum them — the frontend has FX rates and reconciles into
+  // the traveller's local currency.
+  total: number | null
+  total_currency: string | null
+}
+
+/**
+ * GYG exports prices like "20000.00 INR" — split into amount + currency.
+ */
+export function parseGygPrice(raw: unknown): { amount: number; currency: string } | null {
+  if (typeof raw !== "string" || !raw.trim()) return null
+  const m = raw.trim().match(/^([\d,]+(?:\.\d+)?)\s*([A-Z]{3})$/)
+  if (!m) return null
+  const amount = parseFloat(m[1].replace(/,/g, ""))
+  if (!Number.isFinite(amount)) return null
+  return { amount, currency: m[2] }
+}
+
+export function buildPaymentSummary(
+  metadata: Record<string, any> | null | undefined,
+  computed: ComputedCost
+): PaymentSummary {
+  const gyg = (metadata as any)?.gyg
+  const paid = parseGygPrice(gyg?.price)
+
+  const addOnsCurrency = computed.currency
+  const sameCurrency = !!paid && paid.currency === addOnsCurrency
+
+  return {
+    paid_via_source: paid
+      ? {
+          provider: typeof gyg?.booking_ref === "string" ? "GYG" : "Source",
+          amount: paid.amount,
+          currency: paid.currency,
+          raw: typeof gyg?.price === "string" ? gyg.price : null,
+        }
+      : null,
+    add_ons_due: computed.subtotal,
+    add_ons_currency: addOnsCurrency,
+    // Server-side sum only when currencies match. When they differ
+    // (common: GYG paid in INR, add-ons priced in EUR), the frontend
+    // reconciles using live FX rates.
+    total: sameCurrency
+      ? Math.round(((paid?.amount ?? 0) + computed.subtotal) * 100) / 100
+      : null,
+    total_currency: sameCurrency ? addOnsCurrency : null,
+  }
+}
+
+export function getSegments(form: any): Segment[] {
+  const raw = form?.settings?.itinerary_segments
+  if (!Array.isArray(raw)) return []
+  return raw.filter((s) => s && typeof s.id === "string")
+}
+
+export function getPricing(form: any): Pricing {
+  return (form?.settings?.pricing as Pricing) || {}
+}
+
+export function computeHeadcount(
+  headcount: Record<string, number> | undefined,
+  pricing: Pricing
+): { total_pax: number; weighted_pax: number } {
+  const counts = headcount || {}
+  const mult = pricing.per_category_multiplier || {}
+
+  let total_pax = 0
+  let weighted_pax = 0
+  for (const [cat, n] of Object.entries(counts)) {
+    if (typeof n !== "number" || n <= 0) continue
+    total_pax += n
+    const m = typeof mult[cat] === "number" ? mult[cat] : 1
+    weighted_pax += n * m
+  }
+  return { total_pax, weighted_pax }
+}
+
+export function computeCost(
+  form: any,
+  selectedSegmentIds: string[],
+  headcount: Record<string, number> | undefined
+): ComputedCost {
+  const segments = getSegments(form)
+  const pricing = getPricing(form)
+  const currency = pricing.currency || segments[0]?.currency || "INR"
+
+  const selected = new Set(selectedSegmentIds)
+  // Required segments are always included even if not in the user's selection.
+  const effective = segments.filter(
+    (s) => selected.has(s.id) || s.required === true
+  )
+
+  const { total_pax, weighted_pax } = computeHeadcount(headcount, pricing)
+  const pax = weighted_pax || total_pax || 1
+
+  const by_segment = effective.map((s) => {
+    const base = typeof s.base_price === "number" ? s.base_price : 0
+    return {
+      id: s.id,
+      title: s.title,
+      base_price: base,
+      pax,
+      line_total: Math.round(base * pax * 100) / 100,
+    }
+  })
+
+  const subtotal =
+    Math.round(by_segment.reduce((acc, l) => acc + l.line_total, 0) * 100) / 100
+
+  return {
+    currency,
+    total_pax,
+    subtotal,
+    by_segment,
+  }
+}

--- a/apps/backend/src/api/web/tour-visits/[token]/route.ts
+++ b/apps/backend/src/api/web/tour-visits/[token]/route.ts
@@ -1,0 +1,169 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+} from "@medusajs/framework/utils"
+import { FORMS_MODULE } from "../../../../modules/forms"
+import FormsService from "../../../../modules/forms/service"
+import { buildPaymentSummary, computeCost, getSegments } from "./helpers"
+
+/**
+ * GET /web/tour-visits/:token
+ * PATCH /web/tour-visits/:token
+ *
+ * Token-only auth. The token is `verification_code` on `form_response`.
+ * GET returns the tour form, current itinerary draft, and computed cost.
+ * PATCH saves a new itinerary selection and returns the recomputed cost.
+ */
+
+const findResponseByToken = async (
+  scope: MedusaRequest["scope"],
+  token: string
+): Promise<{ response: any; form: any }> => {
+  if (!token || typeof token !== "string" || token.length < 16) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Invalid visit token")
+  }
+
+  const forms: FormsService = scope.resolve(FORMS_MODULE)
+
+  const responses = await forms.listFormResponses(
+    { verification_code: token },
+    { take: 1 }
+  )
+  const response = responses?.[0]
+  if (!response) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Visit not found")
+  }
+
+  if (
+    response.verification_expires_at &&
+    new Date(response.verification_expires_at).getTime() < Date.now()
+  ) {
+    throw new MedusaError(MedusaError.Types.NOT_ALLOWED, "Visit token expired")
+  }
+
+  const query: any = scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data: forms_data } = await query.graph({
+    entity: "form",
+    filters: { id: response.form_id },
+    fields: ["*", "fields.*"],
+    pagination: { take: 1 },
+  })
+  const form = forms_data?.[0]
+  if (!form) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      "Tour form no longer exists"
+    )
+  }
+  if (form.type !== "tour") {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "Linked form is not a tour"
+    )
+  }
+
+  return { response, form }
+}
+
+const buildPayload = (response: any, form: any) => {
+  const data = (response.data as Record<string, any>) || {}
+  const selected: string[] = Array.isArray(data.selected_segments)
+    ? data.selected_segments.filter((s: any) => typeof s === "string")
+    : []
+  const answers: Record<string, any> =
+    typeof data.answers === "object" && data.answers ? data.answers : {}
+
+  const headcount =
+    (response.metadata as any)?.gyg?.headcount || ({} as Record<string, number>)
+
+  const computed = computeCost(form, selected, headcount)
+  const payment = buildPaymentSummary(response.metadata as any, computed)
+
+  const sourceMetadata = (response.metadata as any)?.source
+  const source =
+    typeof sourceMetadata === "string"
+      ? sourceMetadata
+      : (response.metadata as any)?.gyg?.booking_ref
+        ? "gyg"
+        : null
+
+  // Strip nothing from form — fields and settings are public on a published tour.
+  return {
+    form: {
+      id: form.id,
+      handle: form.handle,
+      title: form.title,
+      description: form.description,
+      submit_label: form.submit_label,
+      success_message: form.success_message,
+      settings: form.settings,
+      fields: form.fields || [],
+      itinerary_segments: getSegments(form),
+    },
+    response: {
+      id: response.id,
+      status: response.status,
+      submitted_at: response.submitted_at,
+      answers,
+      selected_segments: selected,
+    },
+    traveller: (response.metadata as any)?.gyg?.traveller || null,
+    headcount,
+    source,
+    booking: {
+      booking_ref: (response.metadata as any)?.gyg?.booking_ref || null,
+      product: (response.metadata as any)?.gyg?.product || null,
+      option: (response.metadata as any)?.gyg?.option || null,
+      tour_date: (response.metadata as any)?.gyg?.tour_date || null,
+      original_price: (response.metadata as any)?.gyg?.price || null,
+    },
+    cost: computed,
+    payment,
+  }
+}
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const token = req.params.token
+  const { response, form } = await findResponseByToken(req.scope, token)
+  res.status(200).json(buildPayload(response, form))
+}
+
+export const PATCH = async (
+  req: MedusaRequest<{
+    selected_segments?: string[]
+    answers?: Record<string, any>
+  }>,
+  res: MedusaResponse
+) => {
+  const token = req.params.token
+  const { response, form } = await findResponseByToken(req.scope, token)
+
+  const body = req.validatedBody || (req.body as any) || {}
+  const incomingSelected: string[] = Array.isArray(body.selected_segments)
+    ? body.selected_segments.filter((s: any) => typeof s === "string")
+    : []
+  const incomingAnswers: Record<string, any> =
+    body.answers && typeof body.answers === "object" ? body.answers : {}
+
+  // Reject unknown segment ids — keep saved data clean.
+  const validIds = new Set(getSegments(form).map((s) => s.id))
+  const cleanedSelected = incomingSelected.filter((id) => validIds.has(id))
+
+  const forms: FormsService = req.scope.resolve(FORMS_MODULE)
+
+  const nextStatus =
+    response.status === "pending_verification" ? "new" : response.status
+
+  const updated = await forms.updateFormResponses({
+    id: response.id,
+    status: nextStatus as any,
+    data: {
+      selected_segments: cleanedSelected,
+      answers: incomingAnswers,
+    },
+  })
+
+  const next = Array.isArray(updated) ? updated[0] : updated
+  res.status(200).json(buildPayload(next, form))
+}

--- a/apps/backend/src/api/web/tour-visits/[token]/validators.ts
+++ b/apps/backend/src/api/web/tour-visits/[token]/validators.ts
@@ -1,0 +1,8 @@
+import { z } from "@medusajs/framework/zod"
+
+export const WebSaveTourItinerarySchema = z.object({
+  selected_segments: z.array(z.string().min(1)).default([]),
+  answers: z.record(z.string(), z.any()).default({}),
+})
+
+export type WebSaveTourItinerary = z.infer<typeof WebSaveTourItinerarySchema>

--- a/apps/backend/src/modules/forms/migrations/Migration20260501155350.ts
+++ b/apps/backend/src/modules/forms/migrations/Migration20260501155350.ts
@@ -1,0 +1,17 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+export class Migration20260501155350 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "form" add column if not exists "type" text not null default 'generic';`);
+    this.addSql(`alter table if exists "form" add constraint "form_type_check" check("type" in ('generic', 'tour'));`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_form_type" ON "form" ("type") WHERE deleted_at IS NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop index if exists "IDX_form_type";`);
+    this.addSql(`alter table if exists "form" drop constraint if exists "form_type_check";`);
+    this.addSql(`alter table if exists "form" drop column if exists "type";`);
+  }
+
+}

--- a/apps/backend/src/modules/forms/models/form.ts
+++ b/apps/backend/src/modules/forms/models/form.ts
@@ -13,6 +13,8 @@ const Form = model
     title: model.text().searchable(),
     description: model.text().nullable(),
 
+    type: model.enum(["generic", "tour"]).default("generic"),
+
     status: model.enum(["draft", "published", "archived"]).default("draft"),
 
     submit_label: model.text().nullable(),

--- a/apps/backend/src/scripts/seed-tour-form-fields.ts
+++ b/apps/backend/src/scripts/seed-tour-form-fields.ts
@@ -1,0 +1,173 @@
+/**
+ * Seed default questions onto every tour-type form (or one specific form).
+ *
+ * The tour visit wizard already shows these questions inline; this seed
+ * also stores them as proper FormFields so admins see them in the form
+ * builder and individual responses keep a tidy schema.
+ *
+ * Run for every tour form:
+ *   npx medusa exec ./src/scripts/seed-tour-form-fields.ts
+ *
+ * Run for one form:
+ *   FORM_ID=form_01ABC… npx medusa exec ./src/scripts/seed-tour-form-fields.ts
+ *
+ * Idempotent: re-running keeps the same field set (set-form-fields replaces
+ * the field list).
+ */
+
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { FORMS_MODULE } from "../modules/forms"
+import FormsService from "../modules/forms/service"
+
+const TOUR_DEFAULT_FIELDS = [
+  {
+    name: "insurance",
+    label: "Travel insurance",
+    type: "radio" as const,
+    required: false,
+    help_text: "Some workshops involve sharp tools and dye baths.",
+    options: {
+      choices: [
+        { value: "yes", label: "Yes — covered" },
+        { value: "no", label: "No insurance" },
+        { value: "unsure", label: "I am not sure" },
+      ],
+    },
+  },
+  {
+    name: "insurance_provider",
+    label: "Insurance provider",
+    type: "text" as const,
+    required: false,
+    placeholder: "Optional",
+  },
+  {
+    name: "arrival_mode",
+    label: "How are you arriving?",
+    type: "radio" as const,
+    required: false,
+    options: {
+      choices: [
+        { value: "train", label: "Train" },
+        { value: "plane", label: "Plane" },
+        { value: "car", label: "Car / private transfer" },
+        { value: "bus", label: "Bus / coach" },
+        { value: "already_in_city", label: "Already in town" },
+      ],
+    },
+  },
+  {
+    name: "arrival_time",
+    label: "Approximate arrival time",
+    type: "text" as const,
+    required: false,
+    placeholder: "14:30 on the 4th",
+  },
+  {
+    name: "accommodation",
+    label: "Where you are staying",
+    type: "text" as const,
+    required: false,
+    placeholder: "Hotel name / neighbourhood",
+  },
+  {
+    name: "emergency_contact_name",
+    label: "Emergency contact name",
+    type: "text" as const,
+    required: false,
+  },
+  {
+    name: "emergency_contact_phone",
+    label: "Emergency contact phone",
+    type: "phone" as const,
+    required: false,
+    placeholder: "+1 555 123 4567",
+  },
+  {
+    name: "notes_for_guide",
+    label: "Anything we should know about access, dietary needs, or pace?",
+    type: "textarea" as const,
+    required: false,
+    placeholder: "Mobility, allergies, birthdays, anything at all…",
+  },
+]
+
+export default async function seedTourFormFields({ container }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const forms: FormsService = container.resolve(FORMS_MODULE)
+
+  const targetId = process.env.FORM_ID
+
+  let tourForms: any[]
+  if (targetId) {
+    const form = await (forms as any).retrieveForm(targetId).catch(() => null)
+    if (!form) {
+      logger.error(`Form ${targetId} not found`)
+      return
+    }
+    if (form.type !== "tour") {
+      logger.warn(`Form ${targetId} has type=${form.type} (not 'tour') — proceeding anyway`)
+    }
+    tourForms = [form]
+  } else {
+    const [list] = await (forms as any).listAndCountForms(
+      { type: "tour" },
+      { take: 1000, order: { created_at: "ASC" } }
+    )
+    tourForms = list || []
+  }
+
+  if (!tourForms.length) {
+    logger.info("No tour forms found.")
+    return
+  }
+
+  logger.info(`Seeding default questions onto ${tourForms.length} tour form(s)…`)
+
+  for (const form of tourForms) {
+    // Pull existing fields, drop ones we own (matched by name) and keep
+    // any custom fields the admin added so we don't trample their work.
+    const [existing] = await (forms as any).listAndCountFormFields(
+      { form_id: form.id },
+      { take: 1000 }
+    )
+    const ownedNames = new Set(TOUR_DEFAULT_FIELDS.map((f) => f.name))
+    const kept = (existing || [])
+      .filter((f: any) => !ownedNames.has(f.name))
+      .map((f: any) => ({
+        name: f.name,
+        label: f.label,
+        type: f.type,
+        required: !!f.required,
+        placeholder: f.placeholder ?? null,
+        help_text: f.help_text ?? null,
+        options: f.options ?? null,
+        validation: f.validation ?? null,
+        order: typeof f.order === "number" ? f.order : 0,
+        metadata: f.metadata ?? null,
+      }))
+
+    const baseOrder = kept.length
+      ? Math.max(...kept.map((f: any) => f.order || 0)) + 1
+      : 0
+
+    const seeded = TOUR_DEFAULT_FIELDS.map((f, idx) => ({
+      ...f,
+      order: baseOrder + idx,
+    }))
+
+    // Replace the form's fields wholesale (keeps any non-default fields
+    // the admin had configured + applies our defaults at the end).
+    if (existing?.length) {
+      await (forms as any).deleteFormFields(existing.map((f: any) => f.id))
+    }
+    await (forms as any).createFormFields(
+      [...kept, ...seeded].map((f: any) => ({ ...f, form_id: form.id }))
+    )
+
+    logger.info(`  ${form.id} (${form.handle}) — seeded ${seeded.length} default question(s), kept ${kept.length} custom`)
+  }
+
+  logger.info("Done.")
+}

--- a/apps/backend/src/scripts/seed-website-from-prod.ts
+++ b/apps/backend/src/scripts/seed-website-from-prod.ts
@@ -1,0 +1,297 @@
+/**
+ * Seed the local website (and its pages + blocks) from a remote backend's
+ * public /web/website API. Useful when running locally and the storefront
+ * is missing block content that lives on prod.
+ *
+ * The script is idempotent: it upserts the website by domain, pages by
+ * (slug, website_id), and blocks by (page_id, type). To wipe and re-seed,
+ * pass --reset.
+ *
+ * Run:
+ *   npx medusa exec ./src/scripts/seed-website-from-prod.ts
+ *
+ * Override the source / domain:
+ *   SOURCE_API=https://v3.jaalyantra.com SEED_DOMAIN=jaalyantra.com \
+ *     npx medusa exec ./src/scripts/seed-website-from-prod.ts -- --reset
+ *
+ * Defaults:
+ *   SOURCE_API   https://v3.jaalyantra.com
+ *   SEED_DOMAIN  jaalyantra.com
+ */
+
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { WEBSITE_MODULE } from "../modules/website"
+import WebsiteService from "../modules/website/service"
+
+type ProdAnalytics = {
+  provider?: "in_house" | "custom" | "off"
+  custom_head?: string | null
+  custom_body_end?: string | null
+}
+
+type ProdWebsiteSummary = {
+  id: string
+  name: string
+  domain: string
+  theme: any
+  favicon_url: string | null
+  analytics?: ProdAnalytics
+  pages: Array<{
+    title: string
+    slug: string
+    content: string
+    status: string
+    page_type: string
+    published_at: string | null
+  }>
+}
+
+type ProdBlock = {
+  id?: string
+  name: string
+  type: string
+  content: any
+  settings?: any
+  order?: number
+  status?: string
+  metadata?: any
+}
+
+type ProdPageDetail = {
+  title: string
+  slug: string
+  content: string
+  status: string
+  page_type: string
+  published_at: string | null
+  blocks?: ProdBlock[]
+  meta_title?: string | null
+  meta_description?: string | null
+  meta_keywords?: string | null
+  metadata?: any
+  public_metadata?: any
+}
+
+const titleCase = (v: string | undefined): string | undefined => {
+  if (!v) return undefined
+  return v.charAt(0).toUpperCase() + v.slice(1).toLowerCase()
+}
+
+const PAGE_TYPES = new Set([
+  "Home",
+  "About",
+  "Contact",
+  "Blog",
+  "Product",
+  "Service",
+  "Portfolio",
+  "Landing",
+  "Custom",
+])
+const PAGE_STATUSES = new Set(["Draft", "Published", "Archived"])
+const BLOCK_TYPES = new Set([
+  "Hero",
+  "Header",
+  "Footer",
+  "MainContent",
+  "ContactForm",
+  "Feature",
+  "Gallery",
+  "Testimonial",
+  "Product",
+  "Section",
+  "Custom",
+])
+const BLOCK_STATUSES = new Set(["Active", "Inactive", "Draft"])
+
+const normalizePageType = (raw: string | undefined): string => {
+  const t = titleCase(raw) || "Custom"
+  return PAGE_TYPES.has(t) ? t : "Custom"
+}
+const normalizePageStatus = (raw: string | undefined): string => {
+  const t = titleCase(raw) || "Draft"
+  return PAGE_STATUSES.has(t) ? t : "Draft"
+}
+const normalizeBlockType = (raw: string | undefined): string => {
+  // Block types are PascalCase already in prod responses.
+  if (!raw) return "Custom"
+  return BLOCK_TYPES.has(raw) ? raw : "Custom"
+}
+const normalizeBlockStatus = (raw: string | undefined): string => {
+  const t = titleCase(raw) || "Active"
+  return BLOCK_STATUSES.has(t) ? t : "Active"
+}
+
+const fetchJson = async <T>(url: string): Promise<T> => {
+  const res = await fetch(url, { headers: { Accept: "application/json" } })
+  if (!res.ok) {
+    throw new Error(
+      `GET ${url} failed: ${res.status} ${res.statusText} — ${await res.text().catch(() => "")}`
+    )
+  }
+  return (await res.json()) as T
+}
+
+export default async function seedWebsiteFromProd({ container }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const websiteService: WebsiteService = container.resolve(WEBSITE_MODULE)
+
+  const sourceApi =
+    (process.env.SOURCE_API || "https://v3.jaalyantra.com").replace(/\/$/, "")
+  const sourceDomain = process.env.SEED_DOMAIN || "jaalyantra.com"
+
+  // medusa exec passes script args after `--`. We only care about --reset.
+  const reset = process.argv.includes("--reset")
+
+  logger.info(
+    `Seeding website "${sourceDomain}" from ${sourceApi}/web/website/${sourceDomain} (reset=${reset})`
+  )
+
+  // 1. Fetch prod summary (website + page list).
+  const summary = await fetchJson<ProdWebsiteSummary>(
+    `${sourceApi}/web/website/${encodeURIComponent(sourceDomain)}`
+  )
+  logger.info(
+    `Prod returned ${summary.pages?.length ?? 0} pages — analytics provider: ${summary.analytics?.provider ?? "n/a"}`
+  )
+
+  // 2. Upsert local website by domain.
+  const [existingByDomain] = await (websiteService as any).listAndCountWebsites(
+    { domain: sourceDomain },
+    { take: 1 }
+  )
+  let website = existingByDomain?.[0]
+
+  if (website && reset) {
+    // cascade-delete pages (cascade also takes blocks).
+    const [pages] = await (websiteService as any).listAndCountPages(
+      { website_id: website.id },
+      { take: 1000 }
+    )
+    if (pages?.length) {
+      await (websiteService as any).deletePages(pages.map((p: any) => p.id))
+      logger.info(`  reset: deleted ${pages.length} existing pages`)
+    }
+  }
+
+  const websiteFields = {
+    domain: summary.domain,
+    name: summary.name,
+    favicon_url: summary.favicon_url ?? null,
+    theme: summary.theme ?? null,
+    analytics_provider: summary.analytics?.provider ?? "in_house",
+    analytics_custom_head: summary.analytics?.custom_head ?? null,
+    analytics_custom_body_end: summary.analytics?.custom_body_end ?? null,
+  }
+
+  if (!website) {
+    website = await (websiteService as any).createWebsites(websiteFields)
+    logger.info(`  created website ${website.id} (${website.domain})`)
+  } else {
+    website = await (websiteService as any).updateWebsites({
+      id: website.id,
+      ...websiteFields,
+    })
+    logger.info(`  updated website ${website.id} (${website.domain})`)
+  }
+
+  // Make sure the primary domain row matches — the storefront lookup uses
+  // the website_domain table.
+  await websiteService.ensurePrimaryWebsiteDomain(website.id, summary.domain)
+
+  // 3. Upsert each page + its blocks.
+  let pagesCreated = 0
+  let pagesUpdated = 0
+  let blocksCreated = 0
+  let blocksUpdated = 0
+  const failures: Array<{ slug: string; error: string }> = []
+
+  for (const summaryPage of summary.pages || []) {
+    try {
+      const detail = await fetchJson<ProdPageDetail>(
+        `${sourceApi}/web/website/${encodeURIComponent(sourceDomain)}/${encodeURIComponent(summaryPage.slug)}`
+      )
+
+      const pageFields = {
+        title: detail.title || summaryPage.title,
+        slug: detail.slug || summaryPage.slug,
+        content: detail.content ?? summaryPage.content ?? "",
+        page_type: normalizePageType(detail.page_type || summaryPage.page_type),
+        status: normalizePageStatus(detail.status || summaryPage.status),
+        meta_title: detail.meta_title ?? null,
+        meta_description: detail.meta_description ?? null,
+        meta_keywords: detail.meta_keywords ?? null,
+        published_at: (detail.published_at || summaryPage.published_at) ?? null,
+        last_modified: new Date(),
+        metadata: detail.metadata ?? null,
+        public_metadata: detail.public_metadata ?? null,
+        website_id: website.id,
+      }
+
+      const [existingPages] = await (websiteService as any).listAndCountPages(
+        { website_id: website.id, slug: pageFields.slug },
+        { take: 1 }
+      )
+      let page = existingPages?.[0]
+
+      if (!page) {
+        page = await (websiteService as any).createPages(pageFields)
+        pagesCreated++
+      } else {
+        page = await (websiteService as any).updatePages({
+          id: page.id,
+          ...pageFields,
+        })
+        pagesUpdated++
+      }
+
+      // Pull existing blocks once, dedupe by type for unique-block enforcement.
+      const [existingBlocks] = await (websiteService as any).listAndCountBlocks(
+        { page_id: page.id },
+        { take: 1000 }
+      )
+      const existingByType = new Map<string, any>()
+      for (const b of existingBlocks || []) {
+        existingByType.set(b.type, b)
+      }
+
+      for (const remoteBlock of detail.blocks || []) {
+        const blockFields = {
+          name: remoteBlock.name,
+          type: normalizeBlockType(remoteBlock.type),
+          content: remoteBlock.content ?? {},
+          settings: remoteBlock.settings ?? null,
+          order: typeof remoteBlock.order === "number" ? remoteBlock.order : 0,
+          status: normalizeBlockStatus(remoteBlock.status),
+          metadata: remoteBlock.metadata ?? null,
+          page_id: page.id,
+        }
+
+        const existing = existingByType.get(blockFields.type)
+        if (existing) {
+          await (websiteService as any).updateBlocks({
+            id: existing.id,
+            ...blockFields,
+          })
+          blocksUpdated++
+        } else {
+          await (websiteService as any).createBlocks(blockFields)
+          blocksCreated++
+        }
+      }
+    } catch (e: any) {
+      failures.push({ slug: summaryPage.slug, error: e.message })
+      logger.error(`  ${summaryPage.slug} — ${e.message}`)
+    }
+  }
+
+  logger.info(
+    `Done. Pages — created ${pagesCreated}, updated ${pagesUpdated}. Blocks — created ${blocksCreated}, updated ${blocksUpdated}. Failures — ${failures.length}.`
+  )
+  if (failures.length) {
+    for (const f of failures) {
+      logger.warn(`  failed page: ${f.slug} (${f.error})`)
+    }
+  }
+}

--- a/apps/backend/src/workflows/forms/create-form.ts
+++ b/apps/backend/src/workflows/forms/create-form.ts
@@ -37,6 +37,7 @@ export type CreateFormStepInput = {
   handle: string
   title: string
   description?: string | null
+  type?: "generic" | "tour"
   status?: "draft" | "published" | "archived"
   submit_label?: string | null
   success_message?: string | null

--- a/apps/backend/src/workflows/forms/import-tour-bookings.ts
+++ b/apps/backend/src/workflows/forms/import-tour-bookings.ts
@@ -1,0 +1,277 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import { MedusaError } from "@medusajs/framework/utils"
+import ExcelJS from "exceljs"
+import { randomBytes } from "crypto"
+import { FORMS_MODULE } from "../../modules/forms"
+import FormsService from "../../modules/forms/service"
+
+export type ImportTourBookingsInput = {
+  form_id: string
+  // Pre-parsed bookings from the GYG xlsx (parsed in the route handler so we
+  // don't have to send a Buffer through the workflow serializer).
+  bookings: GygBooking[]
+  // Days the visit token stays valid past the tour date.
+  token_ttl_days?: number
+}
+
+const HEADCOUNT_KEYS = [
+  "Adult",
+  "Senior",
+  "Student (with ID)",
+  "EU citizens (with ID)",
+  "Student EU citizens (with ID)",
+  "Military (with ID)",
+  "Youth",
+  "Child",
+  "Infant",
+] as const
+
+export type GygBooking = {
+  booking_ref: string
+  supplier_ref: string | null
+  product: string | null
+  option: string | null
+  // ISO 8601 strings so the value survives workflow input serialization.
+  tour_date: string
+  purchase_date: string | null
+  email: string | null
+  phone: string | null
+  first_name: string | null
+  surname: string | null
+  city: string | null
+  country: string | null
+  language: string | null
+  add_ons: string | null
+  group: string | null
+  price: string | null
+  net_price: string | null
+  reseller_information: string | null
+  rnpl: boolean
+  headcount: Record<string, number>
+}
+
+const cellString = (v: ExcelJS.CellValue): string | null => {
+  if (v == null) return null
+  if (typeof v === "string") return v.trim() || null
+  if (typeof v === "number" || typeof v === "boolean") return String(v)
+  if (v instanceof Date) return v.toISOString()
+  if (typeof v === "object" && "text" in (v as any)) {
+    const t = (v as any).text
+    return typeof t === "string" ? t.trim() || null : null
+  }
+  if (typeof v === "object" && "result" in (v as any)) {
+    return cellString((v as any).result)
+  }
+  return null
+}
+
+const cellNumber = (v: ExcelJS.CellValue): number => {
+  if (typeof v === "number") return v
+  if (typeof v === "string") {
+    const n = parseInt(v, 10)
+    return Number.isFinite(n) ? n : 0
+  }
+  return 0
+}
+
+const cellDate = (v: ExcelJS.CellValue): Date | null => {
+  if (v instanceof Date) return v
+  if (typeof v === "string") {
+    const d = new Date(v)
+    return isNaN(d.getTime()) ? null : d
+  }
+  return null
+}
+
+export async function parseGygWorkbook(buffer: Buffer): Promise<GygBooking[]> {
+  const wb = new ExcelJS.Workbook()
+  const arrayBuffer = buffer.buffer.slice(
+    buffer.byteOffset,
+    buffer.byteOffset + buffer.byteLength
+  )
+  await wb.xlsx.load(arrayBuffer as ArrayBuffer)
+
+  const bookings: GygBooking[] = []
+
+  wb.eachSheet((sheet) => {
+    const headerRow = sheet.getRow(1)
+    const header: string[] = []
+    headerRow.eachCell({ includeEmpty: true }, (cell, col) => {
+      header[col] = String(cellString(cell.value) ?? "")
+    })
+
+    const idx = (name: string) => header.findIndex((h) => h === name)
+    const get = (row: ExcelJS.Row, name: string) => {
+      const i = idx(name)
+      return i > 0 ? row.getCell(i).value : null
+    }
+
+    sheet.eachRow({ includeEmpty: false }, (row, rowNumber) => {
+      if (rowNumber === 1) return // header
+      const bookingRef = cellString(get(row, "Booking Ref No."))
+      if (!bookingRef) return // skip empty rows
+
+      const tourDate = cellDate(get(row, "Date"))
+      if (!tourDate) return // tours without a date are noise
+
+      const headcount: Record<string, number> = {}
+      for (const k of HEADCOUNT_KEYS) {
+        const n = cellNumber(get(row, k))
+        if (n) headcount[k] = n
+      }
+      // "Group" column isn't a count category but a flag; preserve as string
+      // alongside.
+
+      const purchaseDate =
+        cellDate(get(row, "Purchase Date (local time)")) ??
+        cellDate(get(row, "Purchase Date (Berlin time)"))
+      bookings.push({
+        booking_ref: bookingRef,
+        supplier_ref: cellString(get(row, "Supplier Ref No.")),
+        product: cellString(get(row, "Product")),
+        option: cellString(get(row, "Option")),
+        tour_date: tourDate.toISOString(),
+        purchase_date: purchaseDate ? purchaseDate.toISOString() : null,
+        email: cellString(get(row, "Email")),
+        phone: cellString(get(row, "Phone")),
+        first_name: cellString(get(row, "Traveller's First Name")),
+        surname: cellString(get(row, "Traveller's Surname")),
+        city: cellString(get(row, "Traveller's City")),
+        country: cellString(get(row, "Traveller's Country")),
+        language: cellString(get(row, "Language")),
+        add_ons: cellString(get(row, "Add-ons")),
+        group: cellString(get(row, "Group")),
+        price: cellString(get(row, "Price")),
+        net_price: cellString(get(row, "Net Price")),
+        reseller_information: cellString(get(row, "Reseller Information")),
+        rnpl:
+          (cellString(get(row, "Reserve Now, Pay Later Booking")) || "").toLowerCase() ===
+          "yes",
+        headcount,
+      })
+    })
+  })
+
+  return bookings
+}
+
+const mintToken = (): string =>
+  randomBytes(32).toString("base64url")
+
+const importTourBookingsStep = createStep(
+  "import-tour-bookings",
+  async (input: ImportTourBookingsInput, { container }) => {
+    const forms: FormsService = container.resolve(FORMS_MODULE)
+
+    const form = await forms.retrieveForm(input.form_id).catch(() => null)
+    if (!form) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Form ${input.form_id} not found`
+      )
+    }
+    if ((form as any).type !== "tour") {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Form ${input.form_id} is not a tour form (type=${(form as any).type})`
+      )
+    }
+
+    const bookings = input.bookings
+
+    // Pull existing responses for this form, dedup by booking_ref to keep
+    // re-imports idempotent.
+    const existing = await forms.listFormResponses(
+      { form_id: input.form_id },
+      { take: 10000 }
+    )
+    const existingByRef = new Map<string, any>()
+    for (const r of existing) {
+      const ref = (r.metadata as any)?.gyg?.booking_ref
+      if (ref) existingByRef.set(ref, r)
+    }
+
+    const ttlDays = input.token_ttl_days ?? 60
+    const created: any[] = []
+    const skipped: string[] = []
+
+    for (const b of bookings) {
+      if (existingByRef.has(b.booking_ref)) {
+        skipped.push(b.booking_ref)
+        continue
+      }
+
+      const tourDate = new Date(b.tour_date)
+      const purchaseDate = b.purchase_date ? new Date(b.purchase_date) : null
+      const expires = new Date(tourDate)
+      expires.setUTCDate(expires.getUTCDate() + ttlDays)
+
+      const response = await forms.createFormResponses({
+        form_id: input.form_id,
+        status: "pending_verification",
+        email: b.email,
+        data: {},
+        submitted_at: purchaseDate ?? new Date(),
+        verification_code: mintToken(),
+        verification_expires_at: expires,
+        metadata: {
+          source: "gyg",
+          gyg: {
+            booking_ref: b.booking_ref,
+            supplier_ref: b.supplier_ref,
+            product: b.product,
+            option: b.option,
+            tour_date: b.tour_date,
+            purchase_date: b.purchase_date,
+            traveller: {
+              first_name: b.first_name,
+              surname: b.surname,
+              email: b.email,
+              phone: b.phone,
+              city: b.city,
+              country: b.country,
+              language: b.language,
+            },
+            headcount: b.headcount,
+            add_ons: b.add_ons,
+            group: b.group,
+            price: b.price,
+            net_price: b.net_price,
+            reseller_information: b.reseller_information,
+            rnpl: b.rnpl,
+          },
+        },
+      })
+
+      created.push(response)
+    }
+
+    return new StepResponse(
+      {
+        created_count: created.length,
+        skipped_count: skipped.length,
+        skipped_booking_refs: skipped,
+        responses: created,
+      },
+      created.map((r) => r.id)
+    )
+  },
+  async (responseIds: string[], { container }) => {
+    if (!responseIds?.length) return
+    const forms: FormsService = container.resolve(FORMS_MODULE)
+    await forms.softDeleteFormResponses(responseIds)
+  }
+)
+
+export const importTourBookingsWorkflow = createWorkflow(
+  "import-tour-bookings",
+  (input: ImportTourBookingsInput) => {
+    const result = importTourBookingsStep(input)
+    return new WorkflowResponse(result)
+  }
+)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,6 +314,9 @@ importers:
       esbuild-wasm:
         specifier: ^0.27.1
         version: 0.27.3
+      exceljs:
+        specifier: ^4.4.0
+        version: 4.4.0
       file-saver:
         specifier: ^2.0.5
         version: 2.0.5
@@ -2198,6 +2201,12 @@ packages:
   '@fal-ai/client@1.9.4':
     resolution: {integrity: sha512-mDjF2QDq+oficSSxzmErNkseQeRXnvUBEhJy39n4PPe7jRPZeSqM2SNb27SW50rDtCtay+stwFU8zRZehlt1Qg==}
     engines: {node: '>=18.0.0'}
+
+  '@fast-csv/format@4.3.5':
+    resolution: {integrity: sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==}
+
+  '@fast-csv/parse@4.3.6':
+    resolution: {integrity: sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==}
 
   '@fastify/otel@0.16.0':
     resolution: {integrity: sha512-2304BdM5Q/kUvQC9qJO1KZq3Zn1WWsw+WWkVmFEaj1UE2hEIiuFqrPeglQOwEtw/ftngisqfQ3v70TWMmwhhHA==}
@@ -7910,9 +7919,21 @@ packages:
   arch@2.2.0:
     resolution: {integrity: sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==}
 
+  archiver-utils@2.1.0:
+    resolution: {integrity: sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==}
+    engines: {node: '>= 6'}
+
+  archiver-utils@3.0.4:
+    resolution: {integrity: sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==}
+    engines: {node: '>= 10'}
+
   archiver-utils@5.0.2:
     resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
     engines: {node: '>= 14'}
+
+  archiver@5.3.2:
+    resolution: {integrity: sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==}
+    engines: {node: '>= 10'}
 
   archiver@7.0.1:
     resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
@@ -8167,6 +8188,10 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  big-integer@1.6.52:
+    resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
+    engines: {node: '>=0.6'}
+
   big.js@5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
 
@@ -8180,8 +8205,14 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  binary@0.3.0:
+    resolution: {integrity: sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  bluebird@3.4.7:
+    resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
 
   body-parser@1.20.4:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
@@ -8246,6 +8277,10 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  buffer-indexof-polyfill@1.0.2:
+    resolution: {integrity: sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==}
+    engines: {node: '>=0.10'}
+
   buffer@5.6.0:
     resolution: {integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==}
 
@@ -8254,6 +8289,10 @@ packages:
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  buffers@0.1.1:
+    resolution: {integrity: sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==}
+    engines: {node: '>=0.2.0'}
 
   bullmq@5.13.0:
     resolution: {integrity: sha512-rE7v3jMZZGsEhfMhLZwADwuHdqJPTTGHBM8C+SpxF9GzyZ+7pvC80EP5bOZJPPRzbmyhvIPJCVd0bchUZiQF+w==}
@@ -8358,6 +8397,9 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  chainsaw@0.1.0:
+    resolution: {integrity: sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==}
 
   chalk-template@0.4.0:
     resolution: {integrity: sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==}
@@ -8646,6 +8688,10 @@ packages:
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
 
+  compress-commons@4.1.2:
+    resolution: {integrity: sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==}
+    engines: {node: '>= 10'}
+
   compress-commons@6.0.2:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
     engines: {node: '>= 14'}
@@ -8788,6 +8834,10 @@ packages:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
     engines: {node: '>=0.8'}
     hasBin: true
+
+  crc32-stream@4.0.3:
+    resolution: {integrity: sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==}
+    engines: {node: '>= 10'}
 
   crc32-stream@6.0.0:
     resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
@@ -9677,6 +9727,10 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
+  exceljs@4.4.0:
+    resolution: {integrity: sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==}
+    engines: {node: '>=8.3.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -9750,6 +9804,10 @@ packages:
 
   fast-copy@4.0.2:
     resolution: {integrity: sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==}
+
+  fast-csv@4.3.6:
+    resolution: {integrity: sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==}
+    engines: {node: '>=10.0.0'}
 
   fast-deep-equal@2.0.1:
     resolution: {integrity: sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==}
@@ -10046,6 +10104,11 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  fstream@1.0.12:
+    resolution: {integrity: sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==}
+    engines: {node: '>=0.6'}
+    deprecated: This package is no longer supported.
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -11310,6 +11373,9 @@ packages:
   linkifyjs@4.3.2:
     resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
 
+  listenercount@1.0.1:
+    resolution: {integrity: sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==}
+
   load-json-file@4.0.0:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
     engines: {node: '>=4'}
@@ -11356,14 +11422,23 @@ packages:
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
 
+  lodash.difference@4.5.0:
+    resolution: {integrity: sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==}
+
   lodash.escape@4.0.1:
     resolution: {integrity: sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==}
 
   lodash.escaperegexp@4.1.2:
     resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
 
+  lodash.flatten@4.4.0:
+    resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
+
   lodash.flattendeep@4.4.0:
     resolution: {integrity: sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==}
+
+  lodash.groupby@4.6.0:
+    resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}
 
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
@@ -11378,8 +11453,14 @@ packages:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
     deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
+  lodash.isfunction@3.0.9:
+    resolution: {integrity: sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==}
+
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnil@4.0.0:
+    resolution: {integrity: sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==}
 
   lodash.isnumber@3.0.3:
     resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
@@ -11389,6 +11470,9 @@ packages:
 
   lodash.isstring@4.0.1:
     resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
+  lodash.isundefined@3.0.1:
+    resolution: {integrity: sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==}
 
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
@@ -11404,6 +11488,12 @@ packages:
 
   lodash.throttle@4.1.1:
     resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
+
+  lodash.union@4.6.0:
+    resolution: {integrity: sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==}
+
+  lodash.uniq@4.5.0:
+    resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
 
   lodash.uniqby@4.7.0:
     resolution: {integrity: sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==}
@@ -13909,6 +13999,10 @@ packages:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
 
+  saxes@5.0.1:
+    resolution: {integrity: sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==}
+    engines: {node: '>=10'}
+
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
@@ -14674,6 +14768,10 @@ packages:
     resolution: {integrity: sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==}
     hasBin: true
 
+  tmp@0.2.5:
+    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+    engines: {node: '>=14.14'}
+
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
@@ -14701,6 +14799,9 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  traverse@0.3.9:
+    resolution: {integrity: sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==}
 
   traverse@0.6.8:
     resolution: {integrity: sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==}
@@ -14991,6 +15092,9 @@ packages:
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
+
+  unzipper@0.10.14:
+    resolution: {integrity: sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -15457,6 +15561,9 @@ packages:
     resolution: {integrity: sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==}
     engines: {node: '>=8'}
 
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -15546,6 +15653,10 @@ packages:
 
   zeroentropy@0.1.0-alpha.7:
     resolution: {integrity: sha512-T17yfhO0pJZ0yj7P9STEn1/b6e+yiPdxRgHuFOjU/vXdivpOv96vmadbfYbKJoBMgoDIo/WmPXxUIcS29/Ui0w==}
+
+  zip-stream@4.1.1:
+    resolution: {integrity: sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==}
+    engines: {node: '>= 10'}
 
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
@@ -17142,6 +17253,25 @@ snapshots:
       '@msgpack/msgpack': 3.1.3
       eventsource-parser: 1.1.2
       robot3: 0.4.1
+
+  '@fast-csv/format@4.3.5':
+    dependencies:
+      '@types/node': 20.19.34
+      lodash.escaperegexp: 4.1.2
+      lodash.isboolean: 3.0.3
+      lodash.isequal: 4.5.0
+      lodash.isfunction: 3.0.9
+      lodash.isnil: 4.0.0
+
+  '@fast-csv/parse@4.3.6':
+    dependencies:
+      '@types/node': 20.19.34
+      lodash.escaperegexp: 4.1.2
+      lodash.groupby: 4.6.0
+      lodash.isfunction: 3.0.9
+      lodash.isnil: 4.0.0
+      lodash.isundefined: 3.0.1
+      lodash.uniq: 4.5.0
 
   '@fastify/otel@0.16.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -26411,6 +26541,32 @@ snapshots:
 
   arch@2.2.0: {}
 
+  archiver-utils@2.1.0:
+    dependencies:
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      lazystream: 1.0.1
+      lodash.defaults: 4.2.0
+      lodash.difference: 4.5.0
+      lodash.flatten: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.union: 4.6.0
+      normalize-path: 3.0.0
+      readable-stream: 2.3.8
+
+  archiver-utils@3.0.4:
+    dependencies:
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      lazystream: 1.0.1
+      lodash.defaults: 4.2.0
+      lodash.difference: 4.5.0
+      lodash.flatten: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.union: 4.6.0
+      normalize-path: 3.0.0
+      readable-stream: 3.6.2
+
   archiver-utils@5.0.2:
     dependencies:
       glob: 10.5.0
@@ -26420,6 +26576,16 @@ snapshots:
       lodash: 4.17.23
       normalize-path: 3.0.0
       readable-stream: 4.7.0
+
+  archiver@5.3.2:
+    dependencies:
+      archiver-utils: 2.1.0
+      async: 3.2.6
+      buffer-crc32: 0.2.13
+      readable-stream: 3.6.2
+      readdir-glob: 1.1.3
+      tar-stream: 2.2.0
+      zip-stream: 4.1.1
 
   archiver@7.0.1:
     dependencies:
@@ -26731,6 +26897,8 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
+  big-integer@1.6.52: {}
+
   big.js@5.2.2: {}
 
   big.js@7.0.1: {}
@@ -26739,11 +26907,18 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  binary@0.3.0:
+    dependencies:
+      buffers: 0.1.1
+      chainsaw: 0.1.0
+
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  bluebird@3.4.7: {}
 
   body-parser@1.20.4:
     dependencies:
@@ -26843,6 +27018,8 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  buffer-indexof-polyfill@1.0.2: {}
+
   buffer@5.6.0:
     dependencies:
       base64-js: 1.5.1
@@ -26857,6 +27034,8 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  buffers@0.1.1: {}
 
   bullmq@5.13.0:
     dependencies:
@@ -26957,6 +27136,10 @@ snapshots:
       pathval: 2.0.1
 
   chai@6.2.2: {}
+
+  chainsaw@0.1.0:
+    dependencies:
+      traverse: 0.3.9
 
   chalk-template@0.4.0:
     dependencies:
@@ -27284,6 +27467,13 @@ snapshots:
       array-ify: 1.0.0
       dot-prop: 5.3.0
 
+  compress-commons@4.1.2:
+    dependencies:
+      buffer-crc32: 0.2.13
+      crc32-stream: 4.0.3
+      normalize-path: 3.0.0
+      readable-stream: 3.6.2
+
   compress-commons@6.0.2:
     dependencies:
       crc-32: 1.2.2
@@ -27435,6 +27625,11 @@ snapshots:
   crc-32@0.3.0: {}
 
   crc-32@1.2.2: {}
+
+  crc32-stream@4.0.3:
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 3.6.2
 
   crc32-stream@6.0.0:
     dependencies:
@@ -28513,6 +28708,18 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.6
 
+  exceljs@4.4.0:
+    dependencies:
+      archiver: 5.3.2
+      dayjs: 1.11.19
+      fast-csv: 4.3.6
+      jszip: 3.10.1
+      readable-stream: 3.6.2
+      saxes: 5.0.1
+      tmp: 0.2.5
+      unzipper: 0.10.14
+      uuid: 8.3.2
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -28672,6 +28879,11 @@ snapshots:
   fast-content-type-parse@2.0.1: {}
 
   fast-copy@4.0.2: {}
+
+  fast-csv@4.3.6:
+    dependencies:
+      '@fast-csv/format': 4.3.5
+      '@fast-csv/parse': 4.3.6
 
   fast-deep-equal@2.0.1: {}
 
@@ -28976,6 +29188,13 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  fstream@1.0.12:
+    dependencies:
+      graceful-fs: 4.2.11
+      inherits: 2.0.4
+      mkdirp: 0.5.6
+      rimraf: 2.7.1
 
   function-bind@1.1.2: {}
 
@@ -30410,6 +30629,8 @@ snapshots:
 
   linkifyjs@4.3.2: {}
 
+  listenercount@1.0.1: {}
+
   load-json-file@4.0.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -30454,11 +30675,17 @@ snapshots:
 
   lodash.defaults@4.2.0: {}
 
+  lodash.difference@4.5.0: {}
+
   lodash.escape@4.0.1: {}
 
   lodash.escaperegexp@4.1.2: {}
 
+  lodash.flatten@4.4.0: {}
+
   lodash.flattendeep@4.4.0: {}
+
+  lodash.groupby@4.6.0: {}
 
   lodash.includes@4.3.0: {}
 
@@ -30468,13 +30695,19 @@ snapshots:
 
   lodash.isequal@4.5.0: {}
 
+  lodash.isfunction@3.0.9: {}
+
   lodash.isinteger@4.0.4: {}
+
+  lodash.isnil@4.0.0: {}
 
   lodash.isnumber@3.0.3: {}
 
   lodash.isplainobject@4.0.6: {}
 
   lodash.isstring@4.0.1: {}
+
+  lodash.isundefined@3.0.1: {}
 
   lodash.memoize@4.1.2: {}
 
@@ -30485,6 +30718,10 @@ snapshots:
   lodash.once@4.1.1: {}
 
   lodash.throttle@4.1.1: {}
+
+  lodash.union@4.6.0: {}
+
+  lodash.uniq@4.5.0: {}
 
   lodash.uniqby@4.7.0: {}
 
@@ -33678,6 +33915,10 @@ snapshots:
 
   sax@1.6.0: {}
 
+  saxes@5.0.1:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
@@ -34649,6 +34890,8 @@ snapshots:
 
   tlds@1.261.0: {}
 
+  tmp@0.2.5: {}
+
   tmpl@1.0.5: {}
 
   to-fast-properties@2.0.0: {}
@@ -34666,6 +34909,8 @@ snapshots:
   totalist@3.0.1: {}
 
   tr46@0.0.3: {}
+
+  traverse@0.3.9: {}
 
   traverse@0.6.8: {}
 
@@ -35018,6 +35263,19 @@ snapshots:
       '@unrs/resolver-binding-win32-arm64-msvc': 1.11.1
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
+
+  unzipper@0.10.14:
+    dependencies:
+      big-integer: 1.6.52
+      binary: 0.3.0
+      bluebird: 3.4.7
+      buffer-indexof-polyfill: 1.0.2
+      duplexer2: 0.1.4
+      fstream: 1.0.12
+      graceful-fs: 4.2.11
+      listenercount: 1.0.1
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
@@ -35510,6 +35768,8 @@ snapshots:
 
   xdg-basedir@4.0.0: {}
 
+  xmlchars@2.2.0: {}
+
   xtend@4.0.2: {}
 
   xxhash-wasm@1.1.0: {}
@@ -35620,6 +35880,12 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+
+  zip-stream@4.1.1:
+    dependencies:
+      archiver-utils: 3.0.4
+      compress-commons: 4.1.2
+      readable-stream: 3.6.2
 
   zip-stream@6.0.1:
     dependencies:


### PR DESCRIPTION
Adds a new `tour` type to the forms module so a Form can host a clickable itinerary planner instead of a generic submission form. Tour-specific config (story, guides, segments, pricing) lives in Form.settings (no new tables).

Backend:
- Form.type enum (`generic`|`tour`) + migration
- /admin/forms/:id/import-tour-bookings — multipart xlsx import that parses GetYourGuide bookings exports into FormResponses, minting a 32-byte url-safe verification_code per booking
- /web/tour-visits/:token — public lookup + PATCH for the customer itinerary planner; returns form, traveller context, computed cost, and a payment summary that handles multi-currency (GYG paid in INR, add-ons in EUR) by exposing each leg with its own currency
- import-tour-bookings workflow with idempotent dedup by booking_ref

Admin UI:
- Form type selector on create + edit
- Tour settings section + drawer (story, guides, itinerary segments with links/gallery, per-category pricing multipliers)
- Import bookings drawer (xlsx upload + result summary)
- Copy-visit-link action on form responses

Scripts:
- seed-website-from-prod.ts — pulls website + pages + blocks from a remote /web API into the local DB so storefront has content
- seed-tour-form-fields.ts — applies default tour questions (insurance, arrival mode, accommodation, emergency contact) to all tour forms