### PR TITLE
feat(forms): tour wizard polish + email confirmation + guide availabi…

### DIFF
--- a/apps/backend/src/admin/components/edits/edit-tour-settings.tsx
+++ b/apps/backend/src/admin/components/edits/edit-tour-settings.tsx
@@ -46,6 +46,7 @@ const guideSchema = z.object({
   photo_url: z.string().optional(),
   languages: z.string().optional(),
   instagram: z.string().optional(),
+  availability: z.enum(["available", "na"]).default("available"),
 })
 
 const tourSettingsSchema = z.object({
@@ -104,6 +105,7 @@ const buildDefaults = (form: AdminForm): TourSettingsFormData => {
       photo_url: g.photo_url ?? "",
       languages: Array.isArray(g.languages) ? g.languages.join(", ") : g.languages ?? "",
       instagram: g.instagram ?? "",
+      availability: g.availability === "na" ? "na" : "available",
     })),
   }
 }
@@ -170,6 +172,7 @@ export const EditTourSettingsComponent = ({ form }: EditTourSettingsProps) => {
           .map((s) => s.trim())
           .filter(Boolean),
         instagram: g.instagram?.trim() || null,
+        availability: g.availability === "na" ? "na" : "available",
       }))
 
     const headline = data.story_headline?.trim() || null
@@ -452,6 +455,28 @@ export const EditTourSettingsComponent = ({ form }: EditTourSettingsProps) => {
                                 <Form.Control>
                                   <Input autoComplete="off" placeholder="@handle" {...field} />
                                 </Form.Control>
+                              </Form.Item>
+                            )}
+                          />
+                          <Form.Field
+                            control={formCtx.control}
+                            name={`guides.${index}.availability` as const}
+                            render={({ field: { value, onChange } }) => (
+                              <Form.Item className="md:col-span-2">
+                                <Form.Label>Availability</Form.Label>
+                                <Form.Control>
+                                  <select
+                                    value={value || "available"}
+                                    onChange={(e) => onChange(e.target.value)}
+                                    className="bg-ui-bg-base txt-compact-small text-ui-fg-base placeholder:text-ui-fg-muted shadow-borders-base focus-visible:shadow-borders-interactive-with-active hover:bg-ui-bg-base-hover relative w-full appearance-none rounded-md px-2 py-1.5 outline-none"
+                                  >
+                                    <option value="available">Available — guide can be booked</option>
+                                    <option value="na">Not available — placeholder profile</option>
+                                  </select>
+                                </Form.Control>
+                                <Form.Hint>
+                                  &quot;Not available&quot; tags the guide on the visit page so customers know it&apos;s a placeholder rather than someone they&apos;ll meet.
+                                </Form.Hint>
                               </Form.Item>
                             )}
                           />

--- a/apps/backend/src/admin/components/forms/tour-settings-section.tsx
+++ b/apps/backend/src/admin/components/forms/tour-settings-section.tsx
@@ -98,18 +98,39 @@ export const TourSettingsSection = ({ form }: TourSettingsSectionProps) => {
       ) : null}
 
       <div className="px-6 py-4">
-        <Text size="small" weight="plus" className="block">
-          Guides ({guides.length})
-        </Text>
-        {guides.length === 0 ? (
-          <Text size="xsmall" className="text-ui-fg-subtle">
-            None — add guides via &quot;Edit tour settings&quot;.
-          </Text>
-        ) : (
-          <Text size="xsmall" className="text-ui-fg-subtle">
-            {guides.map((g: any) => g.name).filter(Boolean).join(" · ")}
-          </Text>
-        )}
+        {(() => {
+          const availableCount = guides.filter(
+            (g: any) => g?.availability !== "na"
+          ).length
+          const naCount = guides.length - availableCount
+          return (
+            <>
+              <Text size="small" weight="plus" className="block">
+                Guides ({guides.length})
+                {guides.length > 0 ? (
+                  <span className="ml-2 font-normal text-ui-fg-subtle">
+                    {availableCount} available
+                    {naCount > 0 ? `, ${naCount} placeholder` : ""}
+                  </span>
+                ) : null}
+              </Text>
+              {guides.length === 0 ? (
+                <Text size="xsmall" className="text-ui-fg-subtle">
+                  None — add guides via &quot;Edit tour settings&quot;.
+                </Text>
+              ) : (
+                <Text size="xsmall" className="text-ui-fg-subtle">
+                  {guides
+                    .map((g: any) =>
+                      g?.availability === "na" ? `${g.name} (placeholder)` : g.name
+                    )
+                    .filter(Boolean)
+                    .join(" · ")}
+                </Text>
+              )}
+            </>
+          )
+        })()}
       </div>
 
       <div className="px-6 py-4">

--- a/apps/backend/src/api/web/tour-visits/[token]/route.ts
+++ b/apps/backend/src/api/web/tour-visits/[token]/route.ts
@@ -1,10 +1,8 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
-import {
-  ContainerRegistrationKeys,
-  MedusaError,
-} from "@medusajs/framework/utils"
+import { MedusaError } from "@medusajs/framework/utils"
 import { FORMS_MODULE } from "../../../../modules/forms"
 import FormsService from "../../../../modules/forms/service"
+import { sendNotificationEmailWorkflow } from "../../../../workflows/email"
 import { buildPaymentSummary, computeCost, getSegments } from "./helpers"
 
 /**
@@ -42,14 +40,13 @@ const findResponseByToken = async (
     throw new MedusaError(MedusaError.Types.NOT_ALLOWED, "Visit token expired")
   }
 
-  const query: any = scope.resolve(ContainerRegistrationKeys.QUERY)
-  const { data: forms_data } = await query.graph({
-    entity: "form",
-    filters: { id: response.form_id },
-    fields: ["*", "fields.*"],
-    pagination: { take: 1 },
-  })
-  const form = forms_data?.[0]
+  // query.graph treats `fields` as both a projection key and a relation
+  // name — when both collide the relation comes back empty. Resolve the
+  // service directly so we can use `relations: ['fields']` reliably.
+  const form = await (forms as any).retrieveForm(response.form_id, {
+    relations: ["fields"],
+  }).catch(() => null)
+
   if (!form) {
     throw new MedusaError(
       MedusaError.Types.NOT_FOUND,
@@ -105,6 +102,7 @@ const buildPayload = (response: any, form: any) => {
       id: response.id,
       status: response.status,
       submitted_at: response.submitted_at,
+      updated_at: response.updated_at ?? response.submitted_at,
       answers,
       selected_segments: selected,
     },
@@ -133,6 +131,8 @@ export const PATCH = async (
   req: MedusaRequest<{
     selected_segments?: string[]
     answers?: Record<string, any>
+    confirm?: boolean
+    visit_url?: string
   }>,
   res: MedusaResponse
 ) => {
@@ -165,5 +165,57 @@ export const PATCH = async (
   })
 
   const next = Array.isArray(updated) ? updated[0] : updated
+
+  // Final-confirm path: send the customer their itinerary recap. Best-effort —
+  // if the email pipeline is down we still return success so the customer
+  // doesn't see a confused error after their click.
+  if (body.confirm && next.email) {
+    try {
+      const segs = getSegments(form)
+      const selectedSet = new Set(cleanedSelected)
+      const includedSegments = segs
+        .filter((s) => selectedSet.has(s.id) || s.required)
+        .map((s) => ({
+          title: s.title || s.id,
+          duration:
+            typeof s.duration_minutes === "number" && s.duration_minutes > 0
+              ? `${s.duration_minutes} min`
+              : null,
+          required: !!s.required,
+        }))
+
+      const headcount =
+        ((next.metadata as any)?.gyg?.headcount as Record<string, number>) || {}
+      const computed = computeCost(form, cleanedSelected, headcount)
+      const payment = buildPaymentSummary(next.metadata as any, computed)
+      const traveller = (next.metadata as any)?.gyg?.traveller || {}
+
+      await sendNotificationEmailWorkflow(req.scope).run({
+        input: {
+          to: next.email,
+          template: "tour-itinerary-confirmation",
+          data: {
+            first_name: traveller.first_name || "there",
+            tour_title:
+              (next.metadata as any)?.gyg?.product || form.title || "Your visit",
+            tour_date: (next.metadata as any)?.gyg?.tour_date || null,
+            visit_url: typeof body.visit_url === "string" ? body.visit_url : "",
+            segments: includedSegments,
+            has_payment: !!payment.paid_via_source || payment.add_ons_due > 0,
+            paid_provider: payment.paid_via_source?.provider || "",
+            paid_amount: payment.paid_via_source?.amount || 0,
+            paid_currency: payment.paid_via_source?.currency || "",
+            add_ons_amount: payment.add_ons_due,
+            add_ons_currency: payment.add_ons_currency,
+          },
+        },
+      })
+    } catch (err) {
+      // Log only — confirmation UX shouldn't fail because email is misbehaving.
+      // The customer already saw the in-app confirmation.
+      console.error("tour-itinerary-confirmation email failed", err)
+    }
+  }
+
   res.status(200).json(buildPayload(next, form))
 }

--- a/apps/backend/src/api/web/tour-visits/[token]/validators.ts
+++ b/apps/backend/src/api/web/tour-visits/[token]/validators.ts
@@ -3,6 +3,13 @@ import { z } from "@medusajs/framework/zod"
 export const WebSaveTourItinerarySchema = z.object({
   selected_segments: z.array(z.string().min(1)).default([]),
   answers: z.record(z.string(), z.any()).default({}),
+  // When true, the route triggers the tour-itinerary-confirmation email.
+  // The wizard sends this only on the final "Confirm itinerary" click;
+  // intermediate auto-saves leave it false.
+  confirm: z.boolean().default(false),
+  // Public visit URL the customer is on; included in the confirmation
+  // email so they can return to their itinerary.
+  visit_url: z.string().url().optional(),
 })
 
 export type WebSaveTourItinerary = z.infer<typeof WebSaveTourItinerarySchema>

--- a/apps/backend/src/scripts/seed-florence-tour.ts
+++ b/apps/backend/src/scripts/seed-florence-tour.ts
@@ -1,0 +1,209 @@
+/**
+ * Seed the Florence Silk Weaving Workshop tour form with story,
+ * guides, itinerary segments and pricing — the full "tour" settings
+ * payload, so the visit wizard renders something rich without an
+ * operator having to hand-edit JSON.
+ *
+ * Re-runnable: replaces only `settings`, leaves form fields and
+ * responses alone. The form itself must already exist (created via
+ * the admin UI or POST /admin/forms with type=tour).
+ *
+ * Run:
+ *   FORM_ID=form_01KQH52ECNWE1AFV0814VKTMCW \
+ *     npx medusa exec ./src/scripts/seed-florence-tour.ts
+ *
+ * If FORM_ID is omitted the script falls back to the form whose
+ * handle is `florence-silk` on the jaalyantra.com domain.
+ *
+ * Guide entries marked `availability: "na"` are *placeholders* — they
+ * surface a "Profile coming soon" treatment on the wizard so customers
+ * know the real host hasn't been finalised yet. Flip to "available"
+ * once the actual guide is confirmed.
+ */
+
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { FORMS_MODULE } from "../modules/forms"
+import FormsService from "../modules/forms/service"
+
+const FLORENCE_SETTINGS = {
+  story: {
+    headline: "A craft journey through Florence, told at your pace.",
+    body:
+      "Your day is built around two heritage textile institutions — Fondazione Lisio and Tessitura LAB Casini Guidotti — both included in your GetYourGuide booking. From there, you can shape the rest: visit the historic silk factory, meet a contemporary weaver, choose how you'd like to move between sites, and round it off with an artisan lunch. Pick what calls to you. We'll arrange around it.",
+  },
+  guides: [
+    {
+      id: "giulio",
+      name: "Giulio Bruschi",
+      role: "Master weaver, 4th generation",
+      bio:
+        "Forty years at the loom. Speaks with his hands. Knows every defect in every meter of silk that leaves the floor.",
+      photo_url:
+        "https://images.unsplash.com/photo-1542740348-39501cd6e2b4?auto=format&fit=crop&w=600&q=80",
+      languages: ["English", "Italian"],
+      instagram: "giulio.weaves",
+      // PLACEHOLDER: this profile is illustrative until we onboard the real
+      // host. Customers see "Profile coming soon" treatment.
+      availability: "na" as const,
+    },
+    {
+      id: "anjali",
+      name: "Anjali Roy",
+      role: "Studio host & translator",
+      bio:
+        "Anjali grew up between Kolkata and Florence. She bridges the workshops with English, Bengali and Italian, and walks you between the sites.",
+      photo_url:
+        "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?auto=format&fit=crop&w=600&q=80",
+      languages: ["English", "Bengali", "Italian"],
+      availability: "na" as const,
+    },
+  ],
+  pricing: {
+    currency: "EUR",
+    per_category_multiplier: { Adult: 1, Child: 0.5, Senior: 1 },
+  },
+  practical_guidance: {
+    meeting_point:
+      "Fondazione Lisio — Via Benedetto Fortini 143, 50125 Firenze. Look for the wooden sign by the gate; we'll meet you in the courtyard 5 minutes before your start time.",
+    what_to_wear:
+      "Closed-toe shoes (workshop floors are sometimes wet from the dye baths), layers you don't mind getting a little dye-spotted, and comfortable walking shoes if you've added the off-site visits.",
+    what_we_provide:
+      "Aprons, hand-cleansing wipes, drinking water, and a printed itinerary card. If you've added the artisan lunch, food + house wine are included — no extra charge on the day.",
+    what_to_bring:
+      "Camera if you'd like (please respect each weaver's preference). A reusable water bottle. A small notebook is lovely if you take notes — Lisio's pattern books are inspiring.",
+  },
+  itinerary_segments: [
+    {
+      id: "seg_lisio",
+      title: "Fondazione Lisio",
+      description:
+        "The cornerstone visit, included in your GYG booking. Founded in 1906 by Giuseppe Lisio, the foundation safeguards Florence's hand-loom weaving tradition. You'll see Jacquard looms in motion, browse archival pattern books, and meet the apprentice weavers training in the school today.",
+      duration_minutes: 90,
+      time_slot: "Morning",
+      base_price: 0,
+      currency: "EUR",
+      required: true,
+      image_url:
+        "https://images.unsplash.com/photo-1605557626634-7b4f2b3e9bff?auto=format&fit=crop&w=900&q=80",
+      links: [
+        { label: "Fondazione Lisio (official site)", url: "https://www.fondazionelisio.org" },
+      ],
+    },
+    {
+      id: "seg_tessitura_casini",
+      title: "Tessitura LAB Casini Guidotti",
+      description:
+        "Also included in your GYG booking. A working contemporary studio combining traditional looms with modern design — they weave for fashion houses, theatres, and museums. You'll see how a Florentine archive is reinterpreted into cloth that ships worldwide.",
+      duration_minutes: 75,
+      time_slot: "Late morning",
+      base_price: 0,
+      currency: "EUR",
+      required: true,
+      image_url:
+        "https://images.unsplash.com/photo-1604147495798-57beb5d6af73?auto=format&fit=crop&w=900&q=80",
+    },
+    {
+      id: "seg_antico_setificio",
+      title: "Antico Setificio Fiorentino",
+      description:
+        "Optional add-on. Florence's historic silk factory — running 18th-century wooden looms in working condition. Walk the floor, see the warp-winder originally designed by Leonardo da Vinci, and watch craft as it was practiced 250 years ago.",
+      duration_minutes: 60,
+      time_slot: "Afternoon",
+      base_price: 40,
+      currency: "EUR",
+      required: false,
+      image_url:
+        "https://images.unsplash.com/photo-1610890716171-6b1bb98ffd09?auto=format&fit=crop&w=900&q=80",
+      links: [
+        { label: "Antico Setificio Fiorentino", url: "https://anticosetificiofiorentino.com/" },
+      ],
+    },
+    {
+      id: "seg_stefanie_dux",
+      title: "Stefanie Dux — independent weaver",
+      description:
+        "Optional add-on. Stefanie's studio sits in a quiet courtyard outside the Centro. She weaves linen and silk on a single antique loom, taking commissions for fashion designers and collectors. A rare chance to see contemporary independent practice up close.",
+      duration_minutes: 60,
+      time_slot: "Late afternoon",
+      base_price: 60,
+      currency: "EUR",
+      required: false,
+      image_url:
+        "https://images.unsplash.com/photo-1596443686116-d0d3b48aa4f4?auto=format&fit=crop&w=900&q=80",
+    },
+    {
+      id: "seg_transport_private",
+      title: "Private transfer between sites",
+      description:
+        "Optional add-on. A driver moves you between the workshops — comfortable, climate-controlled, no maps to read. Recommended if you've added Antico Setificio or Stefanie Dux, since they're outside the historic centre.",
+      duration_minutes: null,
+      time_slot: null,
+      base_price: 30,
+      currency: "EUR",
+      required: false,
+      image_url:
+        "https://images.unsplash.com/photo-1494976388531-d1058494cdd8?auto=format&fit=crop&w=900&q=80",
+    },
+    {
+      id: "seg_artisan_lunch",
+      title: "Artisan lunch with the weavers",
+      description:
+        "Optional add-on. A long Tuscan lunch — pasta, local wine, conversation that runs as long as the meal. The host weavers join you at the table. Stories you wouldn't get on a tour.",
+      duration_minutes: 75,
+      time_slot: "Midday",
+      base_price: 35,
+      currency: "EUR",
+      required: false,
+      image_url:
+        "https://images.unsplash.com/photo-1414235077428-338989a2e8c0?auto=format&fit=crop&w=900&q=80",
+    },
+  ],
+} as const
+
+export default async function seedFlorenceTour({ container }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const forms: FormsService = container.resolve(FORMS_MODULE)
+
+  const targetId = process.env.FORM_ID
+
+  let form: any | null = null
+  if (targetId) {
+    form = await (forms as any).retrieveForm(targetId).catch(() => null)
+  } else {
+    const [list] = await (forms as any).listAndCountForms(
+      { handle: "florence-silk", domain: "jaalyantra.com" },
+      { take: 1 }
+    )
+    form = list?.[0] ?? null
+  }
+
+  if (!form) {
+    logger.error(
+      `No tour form found. Set FORM_ID or create a tour form with handle 'florence-silk'.`
+    )
+    return
+  }
+
+  if (form.type !== "tour") {
+    logger.warn(
+      `Form ${form.id} has type=${form.type} (not 'tour') — settings will save but the visit wizard won't render until you flip type to 'tour'.`
+    )
+  }
+
+  const next = {
+    ...((form.settings as Record<string, any> | null) || {}),
+    ...FLORENCE_SETTINGS,
+  }
+
+  await (forms as any).updateForms({ id: form.id, settings: next })
+
+  const placeholderGuides = FLORENCE_SETTINGS.guides.filter(
+    (g) => g.availability === "na"
+  ).length
+  const availableGuides = FLORENCE_SETTINGS.guides.length - placeholderGuides
+
+  logger.info(
+    `Seeded ${form.id} (${form.handle}) — ${FLORENCE_SETTINGS.itinerary_segments.length} segments, ${availableGuides} available guide(s), ${placeholderGuides} placeholder guide(s)`
+  )
+}

--- a/apps/backend/src/scripts/seed-tour-email-template.ts
+++ b/apps/backend/src/scripts/seed-tour-email-template.ts
@@ -1,0 +1,116 @@
+/**
+ * Seed (or refresh) the email template used when a tour visitor
+ * confirms their itinerary. Re-runnable.
+ *
+ * Run:
+ *   npx medusa exec ./src/scripts/seed-tour-email-template.ts
+ */
+
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { EMAIL_TEMPLATES_MODULE } from "../modules/email_templates"
+
+const TEMPLATE_KEY = "tour-itinerary-confirmation"
+const TEMPLATE_NAME = "Tour itinerary confirmation"
+
+const SUBJECT = "Your visit is set — {{tour_title}} on {{formatDate tour_date}}"
+
+const HTML = `<!doctype html>
+<html><head><meta charset="utf-8"><title>{{tour_title}}</title></head>
+<body style="margin:0;padding:0;background:#f7f5f0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Inter,sans-serif;color:#2a2620;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#f7f5f0;padding:32px 16px;">
+    <tr><td align="center">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:560px;background:#ffffff;border:1px solid #e5e0d3;border-radius:16px;overflow:hidden;">
+        <tr><td style="padding:32px 32px 8px;">
+          <p style="margin:0;font-style:italic;color:#9a5b3f;font-size:14px;">Confirmed</p>
+          <h1 style="margin:8px 0 0;font-size:24px;line-height:1.25;color:#2a2620;">We've got your day, {{first_name}}.</h1>
+          <p style="margin:12px 0 0;font-size:14px;line-height:1.6;color:#5a534a;">{{tour_title}} on {{formatDate tour_date}}.</p>
+        </td></tr>
+
+        <tr><td style="padding:24px 32px 8px;">
+          <h2 style="margin:0;font-size:14px;text-transform:uppercase;letter-spacing:0.05em;color:#9a8e7c;">Your itinerary</h2>
+          <ul style="margin:12px 0 0;padding:0;list-style:none;">
+            {{#each segments}}
+            <li style="padding:10px 0;border-bottom:1px solid #f0ebe0;font-size:14px;color:#2a2620;">
+              {{title}}{{#if duration}} <span style="color:#9a8e7c;">· {{duration}}</span>{{/if}}{{#if required}} <span style="color:#9a5b3f;">· always included</span>{{/if}}
+            </li>
+            {{/each}}
+          </ul>
+        </td></tr>
+
+        {{#if has_payment}}
+        <tr><td style="padding:24px 32px 8px;">
+          <h2 style="margin:0;font-size:14px;text-transform:uppercase;letter-spacing:0.05em;color:#9a8e7c;">Payment</h2>
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-top:8px;">
+            {{#if paid_amount}}
+            <tr><td style="padding:6px 0;font-size:14px;color:#5a534a;">Paid via {{paid_provider}}</td>
+                <td style="padding:6px 0;text-align:right;font-family:ui-monospace,monospace;color:#2a2620;">{{formatMoney paid_currency paid_amount}}</td></tr>
+            {{/if}}
+            <tr><td style="padding:6px 0;font-size:14px;color:#5a534a;">Add-ons today</td>
+                <td style="padding:6px 0;text-align:right;font-family:ui-monospace,monospace;color:#2a2620;">{{formatMoney add_ons_currency add_ons_amount}}</td></tr>
+          </table>
+          <p style="margin:8px 0 0;font-size:12px;color:#9a8e7c;">Add-ons settle on the day with your guide — cash or card.</p>
+        </td></tr>
+        {{/if}}
+
+        <tr><td style="padding:24px 32px;">
+          <h2 style="margin:0;font-size:14px;text-transform:uppercase;letter-spacing:0.05em;color:#9a8e7c;">What happens next</h2>
+          <ol style="margin:12px 0 0;padding:0 0 0 18px;color:#2a2620;font-size:14px;line-height:1.7;">
+            <li>This email is your receipt — keep it safe.</li>
+            <li>Your guide will reach out about 48 hours before with the meeting point.</li>
+            <li>Show up, we host. Add-ons settle on the day.</li>
+          </ol>
+        </td></tr>
+
+        <tr><td style="padding:0 32px 32px;">
+          <a href="{{visit_url}}" style="display:inline-block;background:#9a5b3f;color:#ffffff;text-decoration:none;font-weight:500;font-size:14px;padding:12px 20px;border-radius:999px;">Open my visit</a>
+          <p style="margin:12px 0 0;font-size:12px;color:#9a8e7c;">You can come back to this link anytime to change your selections.</p>
+        </td></tr>
+      </table>
+      <p style="margin:16px 0 0;font-size:12px;color:#9a8e7c;font-style:italic;">Jaal Yantra Textiles · supporting artisans across the world.</p>
+    </td></tr>
+  </table>
+</body></html>`
+
+export default async function seedTourEmailTemplate({ container }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const templates: any = container.resolve(EMAIL_TEMPLATES_MODULE)
+
+  const [existing] = await templates.listAndCountEmailTemplates(
+    { template_key: TEMPLATE_KEY },
+    { take: 1 }
+  )
+  const current = existing?.[0]
+
+  const fields = {
+    name: TEMPLATE_NAME,
+    description:
+      "Sent to the customer when they confirm their tour itinerary on the visit page.",
+    template_key: TEMPLATE_KEY,
+    subject: SUBJECT,
+    html_content: HTML,
+    is_active: true,
+    template_type: "transactional",
+    variables: {
+      first_name: "string",
+      tour_title: "string",
+      tour_date: "ISO date",
+      visit_url: "string",
+      segments: "Array<{ title, duration?, required? }>",
+      has_payment: "boolean",
+      paid_provider: "string",
+      paid_amount: "number",
+      paid_currency: "ISO 4217",
+      add_ons_amount: "number",
+      add_ons_currency: "ISO 4217",
+    },
+  }
+
+  if (current) {
+    await templates.updateEmailTemplates({ id: current.id, ...fields })
+    logger.info(`Updated email template ${current.id} (${TEMPLATE_KEY})`)
+  } else {
+    const created = await templates.createEmailTemplates(fields)
+    logger.info(`Created email template ${created.id} (${TEMPLATE_KEY})`)
+  }
+}

--- a/apps/backend/src/scripts/seed-tour-form-fields.ts
+++ b/apps/backend/src/scripts/seed-tour-form-fields.ts
@@ -72,6 +72,54 @@ const TOUR_DEFAULT_FIELDS = [
     placeholder: "Hotel name / neighbourhood",
   },
   {
+    name: "meeting_point_transport",
+    label: "Getting to the first meeting point",
+    type: "radio" as const,
+    required: false,
+    options: {
+      choices: [
+        { value: "walking", label: "Walking — send me directions" },
+        { value: "public", label: "Public transport — send me tickets/instructions" },
+        { value: "partner_taxi", label: "Partner taxi (~€15)" },
+        { value: "self", label: "I will arrange my own way" },
+      ],
+    },
+  },
+  {
+    name: "photo_permission",
+    label: "Photos on the day",
+    type: "radio" as const,
+    required: false,
+    options: {
+      choices: [
+        { value: "yes", label: "Yes, photos welcome" },
+        { value: "no_face", label: "Yes, but please not my face" },
+        { value: "no", label: "No photos of me, please" },
+      ],
+    },
+  },
+  {
+    name: "preferred_language",
+    label: "Preferred language for the day",
+    type: "text" as const,
+    required: false,
+    placeholder: "English",
+  },
+  {
+    name: "dietary",
+    label: "Dietary preferences & allergies",
+    type: "textarea" as const,
+    required: false,
+    placeholder: "Vegetarian, gluten-free, nut allergy…",
+  },
+  {
+    name: "access_needs",
+    label: "Access needs & pace",
+    type: "textarea" as const,
+    required: false,
+    placeholder: "Mobility, stairs, sensory considerations, energy level…",
+  },
+  {
     name: "emergency_contact_name",
     label: "Emergency contact name",
     type: "text" as const,
@@ -83,13 +131,6 @@ const TOUR_DEFAULT_FIELDS = [
     type: "phone" as const,
     required: false,
     placeholder: "+1 555 123 4567",
-  },
-  {
-    name: "notes_for_guide",
-    label: "Anything we should know about access, dietary needs, or pace?",
-    type: "textarea" as const,
-    required: false,
-    placeholder: "Mobility, allergies, birthdays, anything at all…",
   },
 ]
 


### PR DESCRIPTION
…lity

Round 1 (UX polish):
- Guide availability flag on Form.settings.guides[] (`available` | `na`). Placeholder guides render desaturated with a "Profile coming soon" pill.
- Public route /web/tour-visits/:token now resolves the form via the service layer with relations:['fields'] — fixes a query.graph bug where the `fields` relation collided with the projection key and came back empty.
- Response payload now exposes updated_at so the wizard can show a persistent "Last saved Xm ago" line that survives reloads.

Round 2 (heavier features):
- New /web/tour-visits/:token PATCH params: confirm + visit_url. When confirm:true, the route fires the new tour-itinerary-confirmation email template (best-effort — email failures don't break the customer's confirm UX).
- Form.settings.practical_guidance shape (meeting_point, what_to_wear, what_we_provide, what_to_bring) renders as an "On the day" block on the wizard's Review step.

Seeds:
- seed-florence-tour.ts: Lisio + Tessitura locked-in (€0, included in GYG), Antico Setificio + Stefanie Dux + transfer + lunch as add-ons, practical guidance, current guides flagged as placeholders.
- seed-tour-email-template.ts: Handlebars template for the confirmation email.
- seed-tour-form-fields.ts: insurance / arrival_mode / arrival_time / accommodation / meeting_point_transport / photo_permission / preferred_language / dietary / access_needs / emergency_contact_*.