### PR TITLE
feat(forms): guide dashboard, share-with-partner, segment locations

### DIFF
--- a/apps/backend/src/admin/components/edits/edit-tour-settings.tsx
+++ b/apps/backend/src/admin/components/edits/edit-tour-settings.tsx
@@ -47,6 +47,7 @@ const guideSchema = z.object({
   languages: z.string().optional(),
   instagram: z.string().optional(),
   availability: z.enum(["available", "na"]).default("available"),
+  access_token: z.string().optional(),
 })
 
 const tourSettingsSchema = z.object({
@@ -106,8 +107,24 @@ const buildDefaults = (form: AdminForm): TourSettingsFormData => {
       languages: Array.isArray(g.languages) ? g.languages.join(", ") : g.languages ?? "",
       instagram: g.instagram ?? "",
       availability: g.availability === "na" ? "na" : "available",
+      access_token: g.access_token ?? "",
     })),
   }
+}
+
+/**
+ * 32-byte url-safe token. Stable across browsers (uses Web Crypto when
+ * available, falls back to Math.random for old environments — fine since
+ * the admin UI is logged-in territory anyway).
+ */
+const mintToken = (): string => {
+  const bytes =
+    typeof crypto !== "undefined" && crypto.getRandomValues
+      ? crypto.getRandomValues(new Uint8Array(32))
+      : new Uint8Array(Array.from({ length: 32 }, () => Math.floor(Math.random() * 256)))
+  let str = ""
+  for (const b of bytes) str += String.fromCharCode(b)
+  return btoa(str).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
 }
 
 type EditTourSettingsProps = { form: AdminForm }
@@ -173,6 +190,7 @@ export const EditTourSettingsComponent = ({ form }: EditTourSettingsProps) => {
           .filter(Boolean),
         instagram: g.instagram?.trim() || null,
         availability: g.availability === "na" ? "na" : "available",
+        access_token: g.access_token?.trim() || mintToken(),
       }))
 
     const headline = data.story_headline?.trim() || null
@@ -476,6 +494,57 @@ export const EditTourSettingsComponent = ({ form }: EditTourSettingsProps) => {
                                 </Form.Control>
                                 <Form.Hint>
                                   &quot;Not available&quot; tags the guide on the visit page so customers know it&apos;s a placeholder rather than someone they&apos;ll meet.
+                                </Form.Hint>
+                              </Form.Item>
+                            )}
+                          />
+                          <Form.Field
+                            control={formCtx.control}
+                            name={`guides.${index}.access_token` as const}
+                            render={({ field: { value, onChange } }) => (
+                              <Form.Item className="md:col-span-2">
+                                <Form.Label optional>Guide dashboard token</Form.Label>
+                                <div className="flex gap-2">
+                                  <Form.Control>
+                                    <Input
+                                      autoComplete="off"
+                                      readOnly
+                                      placeholder="Save once to auto-generate"
+                                      value={value || ""}
+                                      onChange={(e) => onChange(e.target.value)}
+                                      className="font-mono text-xs"
+                                    />
+                                  </Form.Control>
+                                  <Button
+                                    type="button"
+                                    size="small"
+                                    variant="secondary"
+                                    onClick={() => onChange(mintToken())}
+                                  >
+                                    {value ? "Regenerate" : "Generate"}
+                                  </Button>
+                                  {value ? (
+                                    <Button
+                                      type="button"
+                                      size="small"
+                                      variant="secondary"
+                                      onClick={async () => {
+                                        try {
+                                          await navigator.clipboard.writeText(value)
+                                          toast.success("Token copied")
+                                        } catch {
+                                          toast.error("Could not copy")
+                                        }
+                                      }}
+                                    >
+                                      Copy
+                                    </Button>
+                                  ) : null}
+                                </div>
+                                <Form.Hint>
+                                  Share /guides/&lt;token&gt; with the guide. They&apos;ll see all
+                                  upcoming visits assigned to tours where they&apos;re listed.
+                                  Regenerating revokes the previous link.
                                 </Form.Hint>
                               </Form.Item>
                             )}

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -3157,6 +3157,11 @@ export default defineMiddlewares({
       method: "PATCH",
       middlewares: [validateAndTransformBody(wrapSchema(WebSaveTourItinerarySchema))],
     },
+    {
+      matcher: "/web/guide-visits/:token",
+      method: "GET",
+      middlewares: [],
+    },
 
     // Raw Materials Categories API
     {

--- a/apps/backend/src/api/web/guide-visits/[token]/route.ts
+++ b/apps/backend/src/api/web/guide-visits/[token]/route.ts
@@ -1,0 +1,176 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { MedusaError } from "@medusajs/framework/utils"
+import { FORMS_MODULE } from "../../../../modules/forms"
+import FormsService from "../../../../modules/forms/service"
+
+/**
+ * GET /web/guide-visits/:token
+ *
+ * Token-only auth. The guide's `access_token` lives on each guide entry
+ * in Form.settings.guides[]. This route walks every tour form, finds
+ * the ones where any guide carries the matching token, and returns the
+ * upcoming + recent FormResponses across those forms — flattened so the
+ * guide can see "everyone coming this week" in one list.
+ *
+ * Past visits older than 7 days are excluded so the list stays short.
+ */
+
+type GuideVisit = {
+  response_id: string
+  booking_ref: string | null
+  tour_form: { id: string; title: string; handle: string }
+  tour_date: string | null
+  status: string
+  traveller: Record<string, any> | null
+  headcount: Record<string, number>
+  selected_segments: Array<{ id: string; title: string; required: boolean }>
+  answers: Record<string, any>
+  payment: {
+    paid_via_source: { provider: string; amount: number; currency: string } | null
+    add_ons_due: number
+    add_ons_currency: string
+  } | null
+}
+
+const PAST_WINDOW_DAYS = 7
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const token = req.params.token
+  if (!token || token.length < 16) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Invalid guide token")
+  }
+
+  const forms: FormsService = req.scope.resolve(FORMS_MODULE)
+
+  // Walk all tour forms; in a real prod scenario we'd add a denormalised
+  // index, but this list is small and walking is fine for now.
+  const [tourForms] = await (forms as any).listAndCountForms(
+    { type: "tour" },
+    { take: 1000 }
+  )
+
+  const guideMatches: Array<{ form: any; guide: any }> = []
+  for (const form of tourForms || []) {
+    const settings = (form.settings as Record<string, any> | null) || {}
+    const guides = Array.isArray(settings.guides) ? settings.guides : []
+    const guide = guides.find(
+      (g: any) => typeof g?.access_token === "string" && g.access_token === token
+    )
+    if (guide) guideMatches.push({ form, guide })
+  }
+
+  if (guideMatches.length === 0) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Guide not found")
+  }
+
+  // Profile of the guide (just the first matching form's record — guides are
+  // keyed by token so any match has the same name/role).
+  const guideProfile = (() => {
+    const g = guideMatches[0].guide
+    return {
+      id: g.id || null,
+      name: g.name || null,
+      role: g.role || null,
+      photo_url: g.photo_url || null,
+    }
+  })()
+
+  const cutoff = new Date(Date.now() - PAST_WINDOW_DAYS * 86_400_000)
+
+  const visits: GuideVisit[] = []
+  for (const { form } of guideMatches) {
+    const segments = Array.isArray((form.settings as any)?.itinerary_segments)
+      ? ((form.settings as any).itinerary_segments as any[])
+      : []
+    const segmentIndex = new Map(segments.map((s) => [s.id, s]))
+
+    const [responses] = await (forms as any).listAndCountFormResponses(
+      { form_id: form.id },
+      { take: 1000 }
+    )
+
+    for (const r of responses || []) {
+      const data = (r.data as Record<string, any>) || {}
+      const meta = (r.metadata as Record<string, any>) || {}
+      const tourDate: string | null = meta?.gyg?.tour_date || null
+
+      // Cull old visits.
+      if (tourDate) {
+        const d = new Date(tourDate)
+        if (!isNaN(d.getTime()) && d < cutoff) continue
+      }
+
+      const selectedIds: string[] = Array.isArray(data.selected_segments)
+        ? data.selected_segments.filter((s: any) => typeof s === "string")
+        : []
+
+      const includedSegments = segments
+        .filter((s) => selectedIds.includes(s.id) || s.required)
+        .map((s) => ({
+          id: s.id,
+          title: (s.title as string) || s.id,
+          required: !!s.required,
+        }))
+
+      // Re-derive payment summary from selections so the guide sees what
+      // the customer last saved (without forcing them to dig into JSON).
+      const computeSubtotal = () => {
+        const ids = new Set(selectedIds)
+        let subtotal = 0
+        let currency = "EUR"
+        for (const s of segments) {
+          if (!ids.has(s.id) && !s.required) continue
+          const price = typeof s.base_price === "number" ? s.base_price : 0
+          subtotal += price
+          if (s.currency) currency = s.currency
+        }
+        return { subtotal, currency }
+      }
+      const cost = computeSubtotal()
+      const gygPrice = meta?.gyg?.price as string | undefined
+      const m = typeof gygPrice === "string" ? gygPrice.trim().match(/^([\d,]+(?:\.\d+)?)\s*([A-Z]{3})$/) : null
+      const paid_via_source = m
+        ? {
+            provider: meta?.gyg?.booking_ref ? "GYG" : "Source",
+            amount: parseFloat(m[1].replace(/,/g, "")),
+            currency: m[2],
+          }
+        : null
+
+      visits.push({
+        response_id: r.id,
+        booking_ref: meta?.gyg?.booking_ref || null,
+        tour_form: { id: form.id, title: form.title, handle: form.handle },
+        tour_date: tourDate,
+        status: r.status,
+        traveller: meta?.gyg?.traveller || null,
+        headcount: (meta?.gyg?.headcount as Record<string, number>) || {},
+        selected_segments: includedSegments,
+        answers:
+          typeof data.answers === "object" && data.answers ? data.answers : {},
+        payment: {
+          paid_via_source,
+          add_ons_due: cost.subtotal,
+          add_ons_currency: cost.currency,
+        },
+      })
+    }
+  }
+
+  // Earliest tour first; null tour_date sinks to the bottom.
+  visits.sort((a, b) => {
+    if (!a.tour_date && !b.tour_date) return 0
+    if (!a.tour_date) return 1
+    if (!b.tour_date) return -1
+    return new Date(a.tour_date).getTime() - new Date(b.tour_date).getTime()
+  })
+
+  res.status(200).json({
+    guide: guideProfile,
+    visits,
+    upcoming_count: visits.filter((v) => {
+      if (!v.tour_date) return false
+      return new Date(v.tour_date).getTime() > Date.now()
+    }).length,
+  })
+}

--- a/apps/backend/src/api/web/tour-visits/[token]/route.ts
+++ b/apps/backend/src/api/web/tour-visits/[token]/route.ts
@@ -17,18 +17,36 @@ import { buildPaymentSummary, computeCost, getSegments } from "./helpers"
 const findResponseByToken = async (
   scope: MedusaRequest["scope"],
   token: string
-): Promise<{ response: any; form: any }> => {
+): Promise<{ response: any; form: any; access_mode: "owner" | "share" }> => {
   if (!token || typeof token !== "string" || token.length < 16) {
     throw new MedusaError(MedusaError.Types.NOT_FOUND, "Invalid visit token")
   }
 
   const forms: FormsService = scope.resolve(FORMS_MODULE)
 
+  // First try the canonical owner token.
   const responses = await forms.listFormResponses(
     { verification_code: token },
     { take: 1 }
   )
-  const response = responses?.[0]
+  let response = responses?.[0]
+  let access_mode: "owner" | "share" = "owner"
+
+  if (!response) {
+    // Fall back to checking metadata.shares[].token across responses. This is
+    // a small linear scan; for prod scale we'd add a dedicated table or a
+    // metadata jsonb index. Fine for current volumes.
+    const [allResponses] = await (forms as any).listAndCountFormResponses(
+      {},
+      { take: 1000 }
+    )
+    response = (allResponses || []).find((r: any) => {
+      const shares = (r.metadata as any)?.shares
+      return Array.isArray(shares) && shares.some((s: any) => s?.token === token)
+    })
+    if (response) access_mode = "share"
+  }
+
   if (!response) {
     throw new MedusaError(MedusaError.Types.NOT_FOUND, "Visit not found")
   }
@@ -60,10 +78,14 @@ const findResponseByToken = async (
     )
   }
 
-  return { response, form }
+  return { response, form, access_mode }
 }
 
-const buildPayload = (response: any, form: any) => {
+const buildPayload = (
+  response: any,
+  form: any,
+  access_mode: "owner" | "share" = "owner"
+) => {
   const data = (response.data as Record<string, any>) || {}
   const selected: string[] = Array.isArray(data.selected_segments)
     ? data.selected_segments.filter((s: any) => typeof s === "string")
@@ -118,13 +140,14 @@ const buildPayload = (response: any, form: any) => {
     },
     cost: computed,
     payment,
+    access_mode,
   }
 }
 
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const token = req.params.token
-  const { response, form } = await findResponseByToken(req.scope, token)
-  res.status(200).json(buildPayload(response, form))
+  const { response, form, access_mode } = await findResponseByToken(req.scope, token)
+  res.status(200).json(buildPayload(response, form, access_mode))
 }
 
 export const PATCH = async (
@@ -137,7 +160,14 @@ export const PATCH = async (
   res: MedusaResponse
 ) => {
   const token = req.params.token
-  const { response, form } = await findResponseByToken(req.scope, token)
+  const { response, form, access_mode } = await findResponseByToken(req.scope, token)
+
+  if (access_mode === "share") {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "This is a read-only share link. Ask the original recipient to make changes."
+    )
+  }
 
   const body = req.validatedBody || (req.body as any) || {}
   const incomingSelected: string[] = Array.isArray(body.selected_segments)
@@ -217,5 +247,5 @@ export const PATCH = async (
     }
   }
 
-  res.status(200).json(buildPayload(next, form))
+  res.status(200).json(buildPayload(next, form, access_mode))
 }

--- a/apps/backend/src/api/web/tour-visits/[token]/share/route.ts
+++ b/apps/backend/src/api/web/tour-visits/[token]/share/route.ts
@@ -1,0 +1,75 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { MedusaError } from "@medusajs/framework/utils"
+import { randomBytes } from "crypto"
+import { FORMS_MODULE } from "../../../../../modules/forms"
+import FormsService from "../../../../../modules/forms/service"
+
+/**
+ * POST /web/tour-visits/:token/share
+ *
+ * Mints a read-only sibling token for the same FormResponse so a
+ * traveller can share their itinerary with a partner / family member
+ * without giving them the ability to edit. Sibling tokens accumulate in
+ * `metadata.shares[]` so the customer can revoke individually later.
+ *
+ * Owner-only. Share tokens cannot mint further share tokens.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const token = req.params.token
+  if (!token || token.length < 16) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Invalid visit token")
+  }
+
+  const forms: FormsService = req.scope.resolve(FORMS_MODULE)
+
+  const responses = await forms.listFormResponses(
+    { verification_code: token },
+    { take: 1 }
+  )
+  const response = responses?.[0]
+  if (!response) {
+    // Either the token is invalid or it's a share token (which can't mint more).
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "Only the original recipient can create share links."
+    )
+  }
+
+  const existingShares: Array<{
+    token: string
+    mode: "read"
+    created_at: string
+  }> =
+    Array.isArray((response.metadata as any)?.shares)
+      ? (response.metadata as any).shares
+      : []
+
+  // Cap at 3 active shares to avoid token sprawl. If they want more, they
+  // can revoke an old one (revocation lives in a future enhancement).
+  if (existingShares.length >= 3) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "You already have 3 active share links — revoke one before minting a new one."
+    )
+  }
+
+  const shareToken = randomBytes(32).toString("base64url")
+  const next = {
+    token: shareToken,
+    mode: "read" as const,
+    created_at: new Date().toISOString(),
+  }
+
+  await (forms as any).updateFormResponses({
+    id: response.id,
+    metadata: {
+      ...((response.metadata as any) || {}),
+      shares: [...existingShares, next],
+    },
+  })
+
+  res.status(200).json({
+    share: next,
+    visit_path: `/tours/visit/${shareToken}`,
+  })
+}

--- a/apps/backend/src/scripts/seed-florence-tour.ts
+++ b/apps/backend/src/scripts/seed-florence-tour.ts
@@ -46,6 +46,9 @@ const FLORENCE_SETTINGS = {
       // PLACEHOLDER: this profile is illustrative until we onboard the real
       // host. Customers see "Profile coming soon" treatment.
       availability: "na" as const,
+      // Demo dashboard token — replace with mintToken() when onboarding the
+      // actual guide so the demo link rotates out.
+      access_token: "demo_guide_giulio_GCcm1kTjJ8hP7Cpu5LwAiB2zLrRjcRiH",
     },
     {
       id: "anjali",
@@ -57,6 +60,7 @@ const FLORENCE_SETTINGS = {
         "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?auto=format&fit=crop&w=600&q=80",
       languages: ["English", "Bengali", "Italian"],
       availability: "na" as const,
+      access_token: "demo_guide_anjali_4uRXVmjEsMsGJBNXn5GaX9bHCRc4kN5n",
     },
   ],
   pricing: {
@@ -86,6 +90,11 @@ const FLORENCE_SETTINGS = {
       required: true,
       image_url:
         "https://images.unsplash.com/photo-1605557626634-7b4f2b3e9bff?auto=format&fit=crop&w=900&q=80",
+      location: {
+        address: "Via Benedetto Fortini 143, 50125 Firenze FI, Italy",
+        lat: 43.7569,
+        lng: 11.2885,
+      },
       links: [
         { label: "Fondazione Lisio (official site)", url: "https://www.fondazionelisio.org" },
       ],
@@ -102,6 +111,11 @@ const FLORENCE_SETTINGS = {
       required: true,
       image_url:
         "https://images.unsplash.com/photo-1604147495798-57beb5d6af73?auto=format&fit=crop&w=900&q=80",
+      location: {
+        address: "Via Romana 67, 50125 Firenze FI, Italy",
+        lat: 43.7604,
+        lng: 11.2436,
+      },
     },
     {
       id: "seg_antico_setificio",
@@ -115,6 +129,11 @@ const FLORENCE_SETTINGS = {
       required: false,
       image_url:
         "https://images.unsplash.com/photo-1610890716171-6b1bb98ffd09?auto=format&fit=crop&w=900&q=80",
+      location: {
+        address: "Via L. Bartolini 4, 50124 Firenze FI, Italy",
+        lat: 43.7706,
+        lng: 11.2392,
+      },
       links: [
         { label: "Antico Setificio Fiorentino", url: "https://anticosetificiofiorentino.com/" },
       ],
@@ -131,6 +150,9 @@ const FLORENCE_SETTINGS = {
       required: false,
       image_url:
         "https://images.unsplash.com/photo-1596443686116-d0d3b48aa4f4?auto=format&fit=crop&w=900&q=80",
+      location: {
+        address: "Studio outside Centro Storico — exact address shared by your guide.",
+      },
     },
     {
       id: "seg_transport_private",
@@ -157,6 +179,9 @@ const FLORENCE_SETTINGS = {
       required: false,
       image_url:
         "https://images.unsplash.com/photo-1414235077428-338989a2e8c0?auto=format&fit=crop&w=900&q=80",
+      location: {
+        address: "Trattoria neighbourhood near the workshops — venue confirmed by your guide.",
+      },
     },
   ],
 } as const


### PR DESCRIPTION
Guide dashboard:
- Each guide in Form.settings.guides[] now carries an `access_token`. Admin tour-settings drawer adds Generate / Regenerate / Copy controls per guide.
- New /web/guide-visits/:token route walks all tour forms, finds the ones whose guides match the token, and returns flattened upcoming + recent FormResponses with traveller info, headcount, selected segments and customer answers. Past visits older than 7 days are culled.
- Useful for the guide-side dashboard at /guides/<token> on jyt-web.

Share-with-partner:
- New POST /web/tour-visits/:token/share mints a sibling read-only token (32-byte url-safe) and persists into metadata.shares[]. Capped at 3 active shares per response.
- The token lookup helper now tries owner token first, falls back to scanning metadata.shares for a match.
- Routes return access_mode: "owner" | "share" so the wizard can render read-only state.
- PATCH rejects share tokens with NOT_ALLOWED — the partner can view but not edit.

Segment locations (for the wizard's "Where you'll be" card):
- TourSegment now optionally carries `location: { address, lat?, lng? }`.
- seed-florence-tour.ts populates real addresses + coords for Lisio, Tessitura LAB Casini Guidotti, and Antico Setificio Fiorentino.