### PR TITLE
feat(forms): pre-launch hardening — auth, idempotency, rate limit, ops

### DIFF
--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -231,6 +231,53 @@ import { LinkDesignsToCustomerSchema } from "./admin/customers/[id]/designs/vali
 import { CreateDesignOrderSchema } from "./admin/customers/[id]/design-order/validators";
 import { listAbandonedCartsQuerySchema } from "./admin/abandoned-carts/validators";
 
+/**
+ * In-process per-IP rate limiter for public token-resolution routes.
+ * Lives in node memory — no Redis dep — so it doesn't coordinate across
+ * multiple instances. For prod scale, swap for a Redis-backed limiter
+ * (e.g. rate-limiter-flexible). For our current single-instance Railway
+ * deploy this is enough to stop a runaway client without adding deps.
+ *
+ * Default: 60 req / 60s / IP. Configurable via env if you need to tune.
+ */
+const createRateLimitMiddleware = (
+  options: { windowMs?: number; max?: number; key?: string } = {}
+) => {
+  const windowMs = options.windowMs ?? 60_000
+  const max = options.max ?? 60
+  const buckets = new Map<string, { resetAt: number; count: number }>()
+
+  return (req: MedusaRequest, res: MedusaResponse, next: MedusaNextFunction) => {
+    const ip =
+      ((req.headers["x-forwarded-for"] as string) || "")
+        .split(",")[0]
+        ?.trim() ||
+      req.socket?.remoteAddress ||
+      "unknown"
+    const bucketKey = `${options.key || "default"}:${ip}`
+    const now = Date.now()
+    const bucket = buckets.get(bucketKey)
+
+    if (!bucket || bucket.resetAt < now) {
+      buckets.set(bucketKey, { resetAt: now + windowMs, count: 1 })
+      return next()
+    }
+
+    bucket.count += 1
+    if (bucket.count > max) {
+      res.setHeader(
+        "Retry-After",
+        Math.max(1, Math.ceil((bucket.resetAt - now) / 1000)).toString()
+      )
+      res.status(429).json({
+        message: "Too many requests — please slow down and try again shortly.",
+      })
+      return
+    }
+    next()
+  }
+}
+
 // Utility function to create CORS middleware with configurable options
 const createCorsMiddleware = (corsOptions?: cors.CorsOptions) => {
   return (req: MedusaRequest, res: MedusaResponse, next: MedusaNextFunction) => {
@@ -3150,17 +3197,30 @@ export default defineMiddlewares({
     {
       matcher: "/web/tour-visits/:token",
       method: "GET",
-      middlewares: [],
+      middlewares: [createRateLimitMiddleware({ key: "tour-visit", max: 60 })],
     },
     {
       matcher: "/web/tour-visits/:token",
       method: "PATCH",
-      middlewares: [validateAndTransformBody(wrapSchema(WebSaveTourItinerarySchema))],
+      middlewares: [
+        createRateLimitMiddleware({ key: "tour-visit-write", max: 30 }),
+        validateAndTransformBody(wrapSchema(WebSaveTourItinerarySchema)),
+      ],
     },
     {
       matcher: "/web/guide-visits/:token",
       method: "GET",
-      middlewares: [],
+      middlewares: [createRateLimitMiddleware({ key: "guide-visit", max: 120 })],
+    },
+    {
+      matcher: "/web/tour-visits/:token/share",
+      method: "POST",
+      middlewares: [createRateLimitMiddleware({ key: "share-mint", max: 10 })],
+    },
+    {
+      matcher: "/web/tour-visits/:token/share/:share_token",
+      method: "DELETE",
+      middlewares: [createRateLimitMiddleware({ key: "share-revoke", max: 30 })],
     },
 
     // Raw Materials Categories API

--- a/apps/backend/src/api/web/tour-visits/[token]/route.ts
+++ b/apps/backend/src/api/web/tour-visits/[token]/route.ts
@@ -141,6 +141,20 @@ const buildPayload = (
     cost: computed,
     payment,
     access_mode,
+    // Owner sees the list of share tokens they've minted (so the wizard can
+    // render Revoke buttons). Share-mode viewers see an empty list.
+    shares:
+      access_mode === "owner" && Array.isArray((response.metadata as any)?.shares)
+        ? ((response.metadata as any).shares as Array<{
+            token: string
+            mode: string
+            created_at: string
+          }>).map((s) => ({
+            token: s.token,
+            mode: s.mode,
+            created_at: s.created_at,
+          }))
+        : [],
   }
 }
 
@@ -150,12 +164,23 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   res.status(200).json(buildPayload(response, form, access_mode))
 }
 
+/**
+ * Build the customer-facing visit URL server-side. Defaults to the
+ * production website host so a misconfigured deploy still mails out a
+ * working link instead of a localhost one.
+ */
+const buildVisitUrl = (token: string): string => {
+  const base = (
+    process.env.PUBLIC_TOUR_VISIT_BASE_URL || "https://jaalyantra.com"
+  ).replace(/\/$/, "")
+  return `${base}/tours/visit/${token}`
+}
+
 export const PATCH = async (
   req: MedusaRequest<{
     selected_segments?: string[]
     answers?: Record<string, any>
     confirm?: boolean
-    visit_url?: string
   }>,
   res: MedusaResponse
 ) => {
@@ -196,10 +221,17 @@ export const PATCH = async (
 
   const next = Array.isArray(updated) ? updated[0] : updated
 
-  // Final-confirm path: send the customer their itinerary recap. Best-effort —
-  // if the email pipeline is down we still return success so the customer
-  // doesn't see a confused error after their click.
-  if (body.confirm && next.email) {
+  // Final-confirm path: send the customer their itinerary recap on the
+  // first confirm only. Subsequent PATCHes with confirm:true (e.g. from a
+  // double-click or a returning visitor re-clicking Confirm) skip the
+  // email but still update the response. metadata.confirmed_at acts as
+  // the idempotency marker.
+  const previouslyConfirmedAt =
+    typeof (next.metadata as any)?.confirmed_at === "string"
+      ? (next.metadata as any).confirmed_at
+      : null
+
+  if (body.confirm && next.email && !previouslyConfirmedAt) {
     try {
       const segs = getSegments(form)
       const selectedSet = new Set(cleanedSelected)
@@ -229,7 +261,9 @@ export const PATCH = async (
             tour_title:
               (next.metadata as any)?.gyg?.product || form.title || "Your visit",
             tour_date: (next.metadata as any)?.gyg?.tour_date || null,
-            visit_url: typeof body.visit_url === "string" ? body.visit_url : "",
+            // Visit URL is constructed server-side from
+            // PUBLIC_TOUR_VISIT_BASE_URL — never trust the client.
+            visit_url: buildVisitUrl(token),
             segments: includedSegments,
             has_payment: !!payment.paid_via_source || payment.add_ons_due > 0,
             paid_provider: payment.paid_via_source?.provider || "",
@@ -240,9 +274,20 @@ export const PATCH = async (
           },
         },
       })
+
+      // Mark idempotency. Subsequent confirms by the same customer no
+      // longer trigger a duplicate email but their save still persists.
+      await (forms as any).updateFormResponses({
+        id: next.id,
+        metadata: {
+          ...((next.metadata as any) || {}),
+          confirmed_at: new Date().toISOString(),
+        },
+      })
     } catch (err) {
       // Log only — confirmation UX shouldn't fail because email is misbehaving.
-      // The customer already saw the in-app confirmation.
+      // The customer already saw the in-app confirmation. Note: we do NOT
+      // set confirmed_at here, so the next click will retry the email.
       console.error("tour-itinerary-confirmation email failed", err)
     }
   }

--- a/apps/backend/src/api/web/tour-visits/[token]/share/[share_token]/route.ts
+++ b/apps/backend/src/api/web/tour-visits/[token]/share/[share_token]/route.ts
@@ -1,0 +1,60 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { MedusaError } from "@medusajs/framework/utils"
+import { FORMS_MODULE } from "../../../../../../modules/forms"
+import FormsService from "../../../../../../modules/forms/service"
+
+type Share = { token: string; mode: "read"; created_at: string }
+
+/**
+ * DELETE /web/tour-visits/:token/share/:share_token
+ *
+ * Owner-only. Removes a previously-minted sibling share token from
+ * `metadata.shares[]` so the partner who held that URL loses access.
+ * Idempotent — DELETE-ing an unknown share_token returns 200 with the
+ * current share list (so the wizard's UI can rely on a single shape).
+ */
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const token = req.params.token
+  const shareToken = req.params.share_token
+
+  if (!token || token.length < 16) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Invalid visit token")
+  }
+  if (!shareToken) {
+    throw new MedusaError(MedusaError.Types.INVALID_DATA, "Missing share_token")
+  }
+
+  const forms: FormsService = req.scope.resolve(FORMS_MODULE)
+  const responses = await forms.listFormResponses(
+    { verification_code: token },
+    { take: 1 }
+  )
+  const response = responses?.[0]
+  if (!response) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "Only the original recipient can manage share links."
+    )
+  }
+
+  const existing: Share[] = Array.isArray((response.metadata as any)?.shares)
+    ? (response.metadata as any).shares
+    : []
+  const next = existing.filter((s) => s.token !== shareToken)
+
+  await (forms as any).updateFormResponses({
+    id: response.id,
+    metadata: {
+      ...((response.metadata as any) || {}),
+      shares: next,
+    },
+  })
+
+  res.status(200).json({
+    shares: next.map((s) => ({
+      token: s.token,
+      mode: s.mode,
+      created_at: s.created_at,
+    })),
+  })
+}

--- a/apps/backend/src/api/web/tour-visits/[token]/share/route.ts
+++ b/apps/backend/src/api/web/tour-visits/[token]/share/route.ts
@@ -4,6 +4,30 @@ import { randomBytes } from "crypto"
 import { FORMS_MODULE } from "../../../../../modules/forms"
 import FormsService from "../../../../../modules/forms/service"
 
+type Share = { token: string; mode: "read"; created_at: string }
+
+const requireOwnerResponse = async (
+  scope: MedusaRequest["scope"],
+  token: string
+) => {
+  if (!token || token.length < 16) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Invalid visit token")
+  }
+  const forms: FormsService = scope.resolve(FORMS_MODULE)
+  const responses = await forms.listFormResponses(
+    { verification_code: token },
+    { take: 1 }
+  )
+  const response = responses?.[0]
+  if (!response) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "Only the original recipient can manage share links."
+    )
+  }
+  return { forms, response }
+}
+
 /**
  * POST /web/tour-visits/:token/share
  *
@@ -16,33 +40,11 @@ import FormsService from "../../../../../modules/forms/service"
  */
 export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const token = req.params.token
-  if (!token || token.length < 16) {
-    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Invalid visit token")
-  }
+  const { forms, response } = await requireOwnerResponse(req.scope, token)
 
-  const forms: FormsService = req.scope.resolve(FORMS_MODULE)
-
-  const responses = await forms.listFormResponses(
-    { verification_code: token },
-    { take: 1 }
-  )
-  const response = responses?.[0]
-  if (!response) {
-    // Either the token is invalid or it's a share token (which can't mint more).
-    throw new MedusaError(
-      MedusaError.Types.NOT_ALLOWED,
-      "Only the original recipient can create share links."
-    )
-  }
-
-  const existingShares: Array<{
-    token: string
-    mode: "read"
-    created_at: string
-  }> =
-    Array.isArray((response.metadata as any)?.shares)
-      ? (response.metadata as any).shares
-      : []
+  const existingShares: Share[] = Array.isArray((response.metadata as any)?.shares)
+    ? (response.metadata as any).shares
+    : []
 
   // Cap at 3 active shares to avoid token sprawl. If they want more, they
   // can revoke an old one (revocation lives in a future enhancement).

--- a/apps/backend/src/api/web/tour-visits/[token]/validators.ts
+++ b/apps/backend/src/api/web/tour-visits/[token]/validators.ts
@@ -7,9 +7,9 @@ export const WebSaveTourItinerarySchema = z.object({
   // The wizard sends this only on the final "Confirm itinerary" click;
   // intermediate auto-saves leave it false.
   confirm: z.boolean().default(false),
-  // Public visit URL the customer is on; included in the confirmation
-  // email so they can return to their itinerary.
-  visit_url: z.string().url().optional(),
+  // The visit URL is derived server-side from PUBLIC_TOUR_VISIT_BASE_URL
+  // + the token (never trusted from the client) so a malicious payload
+  // can't redirect the confirmation email to a phishing domain.
 })
 
 export type WebSaveTourItinerary = z.infer<typeof WebSaveTourItinerarySchema>

--- a/apps/backend/src/scripts/seed-florence-tour.ts
+++ b/apps/backend/src/scripts/seed-florence-tour.ts
@@ -8,6 +8,9 @@
  * responses alone. The form itself must already exist (created via
  * the admin UI or POST /admin/forms with type=tour).
  *
+ * Source of truth for the listing copy:
+ * https://www.getyourguide.com/florence-l32/florence-silk-weaving-workshop-and-factory-tour-t1182610/
+ *
  * Run:
  *   FORM_ID=form_01KQH52ECNWE1AFV0814VKTMCW \
  *     npx medusa exec ./src/scripts/seed-florence-tour.ts
@@ -15,52 +18,50 @@
  * If FORM_ID is omitted the script falls back to the form whose
  * handle is `florence-silk` on the jaalyantra.com domain.
  *
- * Guide entries marked `availability: "na"` are *placeholders* — they
- * surface a "Profile coming soon" treatment on the wizard so customers
- * know the real host hasn't been finalised yet. Flip to "available"
- * once the actual guide is confirmed.
+ * To target prod, point DATABASE_URL at the prod URL before running:
+ *   DATABASE_URL=$PROD_DATABASE_URL FORM_ID=… npx medusa exec ./src/scripts/seed-florence-tour.ts
  */
 
 import { ExecArgs } from "@medusajs/framework/types"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { randomBytes } from "crypto"
 import { FORMS_MODULE } from "../modules/forms"
 import FormsService from "../modules/forms/service"
+
+/** 32-byte url-safe token. Compatible with the public route's >= 16 char check. */
+const mintToken = (): string => randomBytes(32).toString("base64url")
 
 const FLORENCE_SETTINGS = {
   story: {
     headline: "A craft journey through Florence, told at your pace.",
     body:
-      "Your day is built around two heritage textile institutions — Fondazione Lisio and Tessitura LAB Casini Guidotti — both included in your GetYourGuide booking. From there, you can shape the rest: visit the historic silk factory, meet a contemporary weaver, choose how you'd like to move between sites, and round it off with an artisan lunch. Pick what calls to you. We'll arrange around it.",
+      "Begin at Fondazione Arte della Seta Lisio — one of the last remaining workshops in the world to use original 18th-century looms — and hear the rhythmic clack of the shuttles alongside the legendary warping machine designed by Leonardo da Vinci. Then move on to Tessitura LAB Casini Guidotti, where you'll witness the technical pinnacle of the craft: hand-woven velvets and brocades made with real gold and silver threads. Both are included in your GetYourGuide booking. If you'd like more, add Antico Setificio Fiorentino — Florence's historic silk factory — to round the day out.",
   },
+  // Guide tokens are minted at seed time when missing — never committed.
+  // Re-running the seed preserves any existing token in DB so guides keep
+  // their existing /guides/<token> URLs.
   guides: [
     {
-      id: "giulio",
-      name: "Giulio Bruschi",
-      role: "Master weaver, 4th generation",
+      id: "alessandra",
+      name: "Alessandra Bianca L'Abate",
+      role: "Textile activist & weaving guide",
       bio:
-        "Forty years at the loom. Speaks with his hands. Knows every defect in every meter of silk that leaves the floor.",
-      photo_url:
-        "https://images.unsplash.com/photo-1542740348-39501cd6e2b4?auto=format&fit=crop&w=600&q=80",
+        "Born in Florence and trained as a weaver in the Florentine tradition, Alessandra is a self-professed \"textile activist\" who has dedicated her life to raising public awareness of the role of textiles in our lives.",
+      photo_url: null,
       languages: ["English", "Italian"],
-      instagram: "giulio.weaves",
-      // PLACEHOLDER: this profile is illustrative until we onboard the real
-      // host. Customers see "Profile coming soon" treatment.
-      availability: "na" as const,
-      // Demo dashboard token — replace with mintToken() when onboarding the
-      // actual guide so the demo link rotates out.
-      access_token: "demo_guide_giulio_GCcm1kTjJ8hP7Cpu5LwAiB2zLrRjcRiH",
+      instagram: null,
+      availability: "available" as const,
     },
     {
-      id: "anjali",
-      name: "Anjali Roy",
-      role: "Studio host & translator",
+      id: "saransh",
+      name: "Saransh Sharma",
+      role: "Organizer & weaver",
       bio:
-        "Anjali grew up between Kolkata and Florence. She bridges the workshops with English, Bengali and Italian, and walks you between the sites.",
-      photo_url:
-        "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?auto=format&fit=crop&w=600&q=80",
-      languages: ["English", "Bengali", "Italian"],
-      availability: "na" as const,
-      access_token: "demo_guide_anjali_4uRXVmjEsMsGJBNXn5GaX9bHCRc4kN5n",
+        "A fluent English speaker and a weaver himself who runs his own fashion business — Saransh bridges the gap between historic craft and modern application. He guides the hands-on portion of the day, drawing the line from the great Florentine setifici to today's artisan-entrepreneurs.",
+      photo_url: null,
+      languages: ["English", "Hindi"],
+      instagram: null,
+      availability: "available" as const,
     },
   ],
   pricing: {
@@ -69,27 +70,57 @@ const FLORENCE_SETTINGS = {
   },
   practical_guidance: {
     meeting_point:
-      "Fondazione Lisio — Via Benedetto Fortini 143, 50125 Firenze. Look for the wooden sign by the gate; we'll meet you in the courtyard 5 minutes before your start time.",
+      "Pickup at Ditta Artigianale (Via dei Neri Specialty Coffee Shop) or near the Uffizi Galleries — your guide will confirm the exact spot 24h before. Drop-off at the same two locations at the end of the 3-hour tour.",
     what_to_wear:
-      "Closed-toe shoes (workshop floors are sometimes wet from the dye baths), layers you don't mind getting a little dye-spotted, and comfortable walking shoes if you've added the off-site visits.",
+      "Comfortable clothes you don't mind getting a little dye-spotted, and shoes you can stand and walk in for extended periods.",
     what_we_provide:
-      "Aprons, hand-cleansing wipes, drinking water, and a printed itinerary card. If you've added the artisan lunch, food + house wine are included — no extra charge on the day.",
+      "Your guide, the workshop visits, and hands-on instruction. Group is capped at 6 so you'll get genuine face-time with the weavers.",
     what_to_bring:
-      "Camera if you'd like (please respect each weaver's preference). A reusable water bottle. A small notebook is lovely if you take notes — Lisio's pattern books are inspiring.",
+      "A reusable water bottle, a camera if you'd like (please respect each weaver's preference), and the cost of foundation entrance tickets — these are paid directly to Lisio + Tessitura LAB on the day, not via GetYourGuide.",
+  },
+  // Customer-facing notes about what's NOT covered. Surfaced separately
+  // from add-ons so people don't confuse "you can pay for this" (add-on)
+  // with "you'll pay for this elsewhere" (excluded).
+  excluded: [
+    "Transportation to and from the activity location",
+    "Meals and drinks during the day",
+    "Foundation entrance tickets for Tessitura LAB Casini Guidotti & Fondazione Arte della Seta Lisio (paid directly on the day)",
+  ],
+  highlights: [
+    "Feel the raw textures of Tuscan wool, organic linen, and cultivated silk",
+    "Learn the difference between the warp and weft threads in weaving",
+    "Sit at a traditional manual frame loom and weave your own fabric",
+    "Visit the Antico Setificio Fiorentino and see 18th-century looms",
+    "See hand-woven velvets and brocades made with real gold and silver threads",
+  ],
+  // High-trust signals lifted from the GYG listing — the wizard surfaces
+  // these as small chips on the welcome step.
+  trust_signals: {
+    duration: "3 hours",
+    group_cap: 6,
+    languages: ["English"],
+    wheelchair_accessible: true,
+    free_cancellation_hours: 24,
+    pay_later: true,
   },
   itinerary_segments: [
+    // NOTE on image URLs: the URLs below are partner-hosted assets sourced
+    // from the official sites of Lisio + Antico Setificio. They render
+    // correctly in production but you should download + re-upload to your
+    // own bucket before broad launch — partner CDNs can change paths
+    // without notice, and self-hosting protects against link-rot.
     {
       id: "seg_lisio",
-      title: "Fondazione Lisio",
+      title: "Fondazione Arte della Seta Lisio",
       description:
-        "The cornerstone visit, included in your GYG booking. Founded in 1906 by Giuseppe Lisio, the foundation safeguards Florence's hand-loom weaving tradition. You'll see Jacquard looms in motion, browse archival pattern books, and meet the apprentice weavers training in the school today.",
+        "One of the last remaining workshops in the world to use original 18th-century looms. Hear the rhythmic 'clack-clack' of the shuttles, see the legendary warping machine designed by Leonardo da Vinci in action, and meet the apprentice weavers training in the school today. Included in your GetYourGuide booking.",
       duration_minutes: 90,
       time_slot: "Morning",
       base_price: 0,
       currency: "EUR",
       required: true,
       image_url:
-        "https://images.unsplash.com/photo-1605557626634-7b4f2b3e9bff?auto=format&fit=crop&w=900&q=80",
+        "https://www.datocms-assets.com/2305/1567424391-fondazione-lisio-photo-stefano-casati-7510.jpg",
       location: {
         address: "Via Benedetto Fortini 143, 50125 Firenze FI, Italy",
         lat: 43.7569,
@@ -103,32 +134,35 @@ const FLORENCE_SETTINGS = {
       id: "seg_tessitura_casini",
       title: "Tessitura LAB Casini Guidotti",
       description:
-        "Also included in your GYG booking. A working contemporary studio combining traditional looms with modern design — they weave for fashion houses, theatres, and museums. You'll see how a Florentine archive is reinterpreted into cloth that ships worldwide.",
-      duration_minutes: 75,
+        "The technical pinnacle of the craft: hand-woven velvets and brocades made with real gold and silver threads — a testament to centuries of opulent artistry. Tessitura LAB combines traditional looms with modern design, weaving for fashion houses, theatres, and museums. Included in your GetYourGuide booking.",
+      duration_minutes: 90,
       time_slot: "Late morning",
       base_price: 0,
       currency: "EUR",
       required: true,
-      image_url:
-        "https://images.unsplash.com/photo-1604147495798-57beb5d6af73?auto=format&fit=crop&w=900&q=80",
+      // Tessitura LAB doesn't have a discoverable public site at the time of
+      // seeding — leaving image_url null falls back to the wizard's gradient
+      // placeholder. Update via admin once their photo is in your S3 bucket.
+      image_url: null,
       location: {
-        address: "Via Romana 67, 50125 Firenze FI, Italy",
-        lat: 43.7604,
-        lng: 11.2436,
+        address:
+          "Atelier di Tessitura Casini Guidotti, Via del Casone 1/R, angolo Viale Petrarca, 50124 Firenze FI, Italy",
+        lat: 43.7677,
+        lng: 11.2398,
       },
     },
     {
       id: "seg_antico_setificio",
       title: "Antico Setificio Fiorentino",
       description:
-        "Optional add-on. Florence's historic silk factory — running 18th-century wooden looms in working condition. Walk the floor, see the warp-winder originally designed by Leonardo da Vinci, and watch craft as it was practiced 250 years ago.",
-      duration_minutes: 60,
+        "Optional add-on. Florence's historic silk factory — running 18th-century wooden looms in working condition. Walk the floor, see the warp-winder originally designed by Leonardo da Vinci, and watch craft as it was practiced 250 years ago. A 40-minute guided visit; ideal if you want to round the day out beyond the two included foundation tours.",
+      duration_minutes: 40,
       time_slot: "Afternoon",
-      base_price: 40,
+      base_price: 120,
       currency: "EUR",
       required: false,
       image_url:
-        "https://images.unsplash.com/photo-1610890716171-6b1bb98ffd09?auto=format&fit=crop&w=900&q=80",
+        "https://anticosetificiofiorentino.com/media/contents/tradizione-arte-seta.jpg",
       location: {
         address: "Via L. Bartolini 4, 50124 Firenze FI, Italy",
         lat: 43.7706,
@@ -142,45 +176,15 @@ const FLORENCE_SETTINGS = {
       id: "seg_stefanie_dux",
       title: "Stefanie Dux — independent weaver",
       description:
-        "Optional add-on. Stefanie's studio sits in a quiet courtyard outside the Centro. She weaves linen and silk on a single antique loom, taking commissions for fashion designers and collectors. A rare chance to see contemporary independent practice up close.",
+        "Optional add-on. A small, intimate textile studio outside the historic centre. Stefanie's practice spans hand weaving, natural dyeing, and manual spinning of Italian wool, hemp, linen, silk, and cotton. You'll see how she turns those fibres into fashion, accessories, and home textiles on a single antique loom — a rare chance to meet a contemporary independent weaver up close.",
       duration_minutes: 60,
       time_slot: "Late afternoon",
       base_price: 60,
       currency: "EUR",
       required: false,
-      image_url:
-        "https://images.unsplash.com/photo-1596443686116-d0d3b48aa4f4?auto=format&fit=crop&w=900&q=80",
+      image_url: null,
       location: {
-        address: "Studio outside Centro Storico — exact address shared by your guide.",
-      },
-    },
-    {
-      id: "seg_transport_private",
-      title: "Private transfer between sites",
-      description:
-        "Optional add-on. A driver moves you between the workshops — comfortable, climate-controlled, no maps to read. Recommended if you've added Antico Setificio or Stefanie Dux, since they're outside the historic centre.",
-      duration_minutes: null,
-      time_slot: null,
-      base_price: 30,
-      currency: "EUR",
-      required: false,
-      image_url:
-        "https://images.unsplash.com/photo-1494976388531-d1058494cdd8?auto=format&fit=crop&w=900&q=80",
-    },
-    {
-      id: "seg_artisan_lunch",
-      title: "Artisan lunch with the weavers",
-      description:
-        "Optional add-on. A long Tuscan lunch — pasta, local wine, conversation that runs as long as the meal. The host weavers join you at the table. Stories you wouldn't get on a tour.",
-      duration_minutes: 75,
-      time_slot: "Midday",
-      base_price: 35,
-      currency: "EUR",
-      required: false,
-      image_url:
-        "https://images.unsplash.com/photo-1414235077428-338989a2e8c0?auto=format&fit=crop&w=900&q=80",
-      location: {
-        address: "Trattoria neighbourhood near the workshops — venue confirmed by your guide.",
+        address: "Studio outside Centro Storico — exact address shared by your guide before the visit.",
       },
     },
   ],
@@ -216,16 +220,44 @@ export default async function seedFlorenceTour({ container }: ExecArgs) {
     )
   }
 
+  // Preserve existing guide tokens so the /guides/<token> URLs stay valid
+  // across re-seeds. Mint a fresh token only when one doesn't already exist.
+  const existingGuides: Array<{ id?: string; access_token?: string }> = Array.isArray(
+    (form.settings as any)?.guides
+  )
+    ? (form.settings as any).guides
+    : []
+  const existingTokenById = new Map<string, string>()
+  for (const g of existingGuides) {
+    if (g?.id && typeof g.access_token === "string" && g.access_token) {
+      existingTokenById.set(g.id, g.access_token)
+    }
+  }
+
+  const guidesWithTokens = FLORENCE_SETTINGS.guides.map((g) => ({
+    ...g,
+    access_token: existingTokenById.get(g.id) || mintToken(),
+  }))
+
   const next = {
     ...((form.settings as Record<string, any> | null) || {}),
     ...FLORENCE_SETTINGS,
+    guides: guidesWithTokens,
   }
 
   await (forms as any).updateForms({ id: form.id, settings: next })
 
-  const placeholderGuides = FLORENCE_SETTINGS.guides.filter(
-    (g) => g.availability === "na"
-  ).length
+  // Surface the tokens once so operators can copy them on first seed; on
+  // re-seeds the same lines just confirm the existing URLs are unchanged.
+  for (const g of guidesWithTokens) {
+    logger.info(
+      `  guide ${g.id} (${g.name}) → /guides/${g.access_token}`
+    )
+  }
+
+  const placeholderGuides = (FLORENCE_SETTINGS.guides as ReadonlyArray<{ availability: string }>)
+    .filter((g) => g.availability === "na")
+    .length
   const availableGuides = FLORENCE_SETTINGS.guides.length - placeholderGuides
 
   logger.info(


### PR DESCRIPTION
Security & correctness:
- Guide access tokens now mint at seed runtime (randomBytes(32)). The seed file no longer ships placeholder strings; existing tokens in DB are preserved across re-seeds so /guides/<token> URLs stay stable.
- /web/tour-visits/:token PATCH no longer trusts a client-sent visit_url. The confirmation email URL is built server-side from PUBLIC_TOUR_VISIT_BASE_URL (defaults to https://jaalyantra.com) + the token, so a malicious payload can't redirect the email link.
- Confirm-email idempotency: PATCH with confirm:true checks metadata.confirmed_at before sending. Subsequent confirms (e.g. a double-click or returning visitor re-clicking Confirm) update the response but skip the email. confirmed_at is only set on successful send, so a transient email failure can be retried.

Share-token revoke (#35 follow-up):
- New DELETE /web/tour-visits/:token/share/:share_token. Owner-only. Idempotent — DELETE-ing an unknown token returns 200 with the current list. The wizard's share card now lists active tokens with Copy + Revoke buttons.
- POST /share + DELETE /share/:share_token now have explicit matcher entries in middlewares.ts.

Rate limiting:
- New in-process per-IP limiter on every public route. No new deps; swap for Redis-backed when we go multi-instance. Limits: tour-visit GET 60/min, PATCH 30/min, share mint 10/min, share revoke 30/min, guide-visit 120/min. Returns 429 + Retry-After.

Real content:
- Tessitura LAB Casini Guidotti address corrected to "Atelier di Tessitura Casini Guidotti, Via del Casone 1/R, angolo Viale Petrarca, 50124 Firenze" with the right coordinates.
- Owner now sees the active share-token list in the visit payload so the wizard can render Revoke per share.