### PR TITLE
feat(google-ads): admin UIs for upload defaults, conversion detail, goals + per-goal mapping

### DIFF
--- a/apps/backend/jest.config.js
+++ b/apps/backend/jest.config.js
@@ -1,3 +1,4 @@
+const path = require("path");
 const { loadEnv } = require("@medusajs/utils");
 loadEnv("test", process.cwd());
 
@@ -50,6 +51,21 @@ module.exports = {
     "node_modules/(?!.*tokenx)",
     "\\.pnp\\.[^\\/]+$",
   ],
+  // Jest 29's `Runtime.requireModule` short-circuits with
+  // ERR_REQUIRE_ESM BEFORE the .mjs transform runs whenever the resolved
+  // file is ESM by extension or by `"type": "module"` in package.json.
+  // tokenx ships only as ESM, so the transform-pass-through approach
+  // above is necessary but not sufficient — @mastra/core's CJS chunk
+  // does `require('tokenx')` from a CJS context which Jest rejects
+  // outright. Redirect tokenx to a CJS shim so the require() resolves
+  // to a real CJS file that Jest will load normally. Production isn't
+  // affected (Node's native ESM bridge handles tokenx fine there).
+  // Absolute path via __dirname (not <rootDir>) — `integration-tests/jest-shared.config.js`
+  // spreads this config but uses its own <rootDir>=integration-tests/, which would
+  // resolve "<rootDir>/test-shims/..." into a non-existent path.
+  moduleNameMapper: {
+    "^tokenx$": path.resolve(__dirname, "test-shims/tokenx.cjs"),
+  },
   testEnvironment: "node",
   moduleFileExtensions: ["js", "mjs", "ts", "tsx", "jsx", "json"],
   modulePathIgnorePatterns: ["dist/", "<rootDir>/.medusa/"],

--- a/apps/backend/src/admin/components/ad-planning/goals/goal-form.tsx
+++ b/apps/backend/src/admin/components/ad-planning/goals/goal-form.tsx
@@ -1,0 +1,449 @@
+/**
+ * Conversion Goal Form
+ *
+ * Used by both the create page and the edit drawer. Mirrors the backend
+ * Create/UpdateGoalSchema fields exactly. Conditions are kept structured
+ * (not a JSON blob) since the backend validates against fixed keys.
+ *
+ * Caller passes `onSuccess` so the form doesn't need to know whether it's
+ * embedded in a drawer or rendered as a standalone page.
+ */
+
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
+import {
+  Button,
+  Heading,
+  Input,
+  Label,
+  Select,
+  Switch,
+  Textarea,
+  Text,
+  toast,
+} from "@medusajs/ui"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { sdk } from "../../../lib/config"
+import { KeyboundForm } from "../../utilitites/key-bound-form"
+
+const GOAL_TYPES = [
+  { value: "lead_form", label: "Lead form" },
+  { value: "purchase", label: "Purchase" },
+  { value: "add_to_cart", label: "Add to cart" },
+  { value: "page_view", label: "Page view" },
+  { value: "time_on_page", label: "Time on page" },
+  { value: "scroll_depth", label: "Scroll depth" },
+  { value: "custom_event", label: "Custom event" },
+]
+
+export type GoalFormValues = {
+  name: string
+  description?: string
+  goal_type: string
+  is_active: boolean
+  priority: number
+  default_value?: number | null
+  value_from_event: boolean
+  website_id?: string
+  conditions: {
+    event_name?: string
+    pathname_pattern?: string
+    min_time_seconds?: number
+    min_scroll_percent?: number
+    custom_conditions?: Record<string, any>
+  }
+}
+
+const DEFAULT_VALUES: GoalFormValues = {
+  name: "",
+  description: "",
+  goal_type: "purchase",
+  is_active: true,
+  priority: 0,
+  default_value: null,
+  value_from_event: false,
+  website_id: "",
+  conditions: {},
+}
+
+export const GoalForm = ({
+  initial,
+  goalId,
+  mode,
+  onCancel,
+  onSuccess,
+  bodyClassName,
+  footerClassName,
+}: {
+  initial?: Partial<GoalFormValues>
+  goalId?: string
+  mode: "create" | "edit"
+  onCancel: () => void
+  onSuccess: (goalId: string) => void
+  bodyClassName?: string
+  footerClassName?: string
+}) => {
+  const { t } = useTranslation()
+  const qc = useQueryClient()
+
+  const [values, setValues] = useState<GoalFormValues>({
+    ...DEFAULT_VALUES,
+    ...initial,
+    conditions: { ...DEFAULT_VALUES.conditions, ...(initial?.conditions || {}) },
+  })
+  const [customConditionsText, setCustomConditionsText] = useState(
+    values.conditions.custom_conditions
+      ? JSON.stringify(values.conditions.custom_conditions, null, 2)
+      : ""
+  )
+  const [customConditionsError, setCustomConditionsError] =
+    useState<string | null>(null)
+
+  const mutation = useMutation({
+    mutationFn: async (payload: GoalFormValues) => {
+      // Build the conditions sub-object — drop empty fields rather than
+      // sending undefined keys that the zod schema rejects on strict mode.
+      const conditions: Record<string, any> = {}
+      if (payload.conditions.event_name)
+        conditions.event_name = payload.conditions.event_name
+      if (payload.conditions.pathname_pattern)
+        conditions.pathname_pattern = payload.conditions.pathname_pattern
+      if (
+        payload.conditions.min_time_seconds !== undefined &&
+        payload.conditions.min_time_seconds !== null
+      )
+        conditions.min_time_seconds = payload.conditions.min_time_seconds
+      if (
+        payload.conditions.min_scroll_percent !== undefined &&
+        payload.conditions.min_scroll_percent !== null
+      )
+        conditions.min_scroll_percent = payload.conditions.min_scroll_percent
+      if (
+        payload.conditions.custom_conditions &&
+        Object.keys(payload.conditions.custom_conditions).length > 0
+      )
+        conditions.custom_conditions = payload.conditions.custom_conditions
+
+      const body: Record<string, any> = {
+        name: payload.name,
+        description: payload.description || undefined,
+        goal_type: payload.goal_type,
+        is_active: payload.is_active,
+        priority: payload.priority,
+        default_value:
+          payload.default_value === null || payload.default_value === undefined
+            ? undefined
+            : payload.default_value,
+        value_from_event: payload.value_from_event,
+        website_id: payload.website_id || undefined,
+        conditions,
+      }
+
+      if (mode === "create") {
+        return sdk.client.fetch<{ goal: { id: string } }>(
+          "/admin/ad-planning/goals",
+          { method: "POST", body }
+        )
+      }
+      return sdk.client.fetch<{ goal: { id: string } }>(
+        `/admin/ad-planning/goals/${goalId}`,
+        { method: "PUT", body }
+      )
+    },
+    onSuccess: (result) => {
+      qc.invalidateQueries({ queryKey: ["ad-planning", "goals"] })
+      toast.success(mode === "create" ? "Goal created" : "Goal saved")
+      onSuccess(result.goal.id)
+    },
+    onError: (error: any) => {
+      toast.error(error.message || "Save failed")
+    },
+  })
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!values.name.trim()) {
+      toast.error("Name is required")
+      return
+    }
+
+    let custom: Record<string, any> | undefined = undefined
+    if (customConditionsText.trim().length > 0) {
+      try {
+        const parsed = JSON.parse(customConditionsText)
+        if (
+          typeof parsed !== "object" ||
+          parsed === null ||
+          Array.isArray(parsed)
+        ) {
+          throw new Error("custom_conditions must be a JSON object")
+        }
+        custom = parsed
+        setCustomConditionsError(null)
+      } catch (err: any) {
+        setCustomConditionsError(err.message || "Invalid JSON")
+        return
+      }
+    }
+
+    mutation.mutate({
+      ...values,
+      conditions: { ...values.conditions, custom_conditions: custom },
+    })
+  }
+
+  const set = <K extends keyof GoalFormValues>(k: K, v: GoalFormValues[K]) =>
+    setValues((prev) => ({ ...prev, [k]: v }))
+
+  const setCondition = <
+    K extends keyof GoalFormValues["conditions"],
+  >(
+    k: K,
+    v: GoalFormValues["conditions"][K]
+  ) =>
+    setValues((prev) => ({
+      ...prev,
+      conditions: { ...prev.conditions, [k]: v },
+    }))
+
+  return (
+    <KeyboundForm
+      onSubmit={handleSubmit}
+      className="flex flex-1 flex-col overflow-hidden"
+    >
+      <div
+        className={
+          bodyClassName ||
+          "flex flex-1 flex-col gap-y-5 overflow-y-auto px-6 py-4"
+        }
+      >
+        <FormField label="Name" required>
+          <Input
+            value={values.name}
+            onChange={(e) => set("name", e.target.value)}
+            placeholder="Checkout complete"
+          />
+        </FormField>
+
+        <FormField label="Description">
+          <Textarea
+            value={values.description ?? ""}
+            onChange={(e) => set("description", e.target.value)}
+            placeholder="What this goal tracks"
+            rows={2}
+          />
+        </FormField>
+
+        <FormField label="Goal type" required>
+          <Select
+            value={values.goal_type}
+            onValueChange={(v) => set("goal_type", v)}
+          >
+            <Select.Trigger>
+              <Select.Value />
+            </Select.Trigger>
+            <Select.Content>
+              {GOAL_TYPES.map((opt) => (
+                <Select.Item key={opt.value} value={opt.value}>
+                  {opt.label}
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select>
+        </FormField>
+
+        <div className="grid grid-cols-2 gap-3">
+          <FormField label="Priority">
+            <Input
+              type="number"
+              value={values.priority}
+              onChange={(e) =>
+                set("priority", Number(e.target.value || 0))
+              }
+            />
+          </FormField>
+          <FormField label="Default value">
+            <Input
+              type="number"
+              value={values.default_value ?? ""}
+              onChange={(e) =>
+                set(
+                  "default_value",
+                  e.target.value === "" ? null : Number(e.target.value)
+                )
+              }
+              placeholder="Optional"
+            />
+          </FormField>
+        </div>
+
+        <FormField label="Website ID">
+          <Input
+            value={values.website_id ?? ""}
+            onChange={(e) => set("website_id", e.target.value)}
+            placeholder="Optional — leave blank for all sites"
+          />
+        </FormField>
+
+        <ToggleRow
+          label="Active"
+          description="Inactive goals won't increment their counters or be matched during conversion uploads."
+          checked={values.is_active}
+          onChange={(v) => set("is_active", v)}
+        />
+
+        <ToggleRow
+          label="Value from event"
+          description="When enabled, the conversion's reported value overrides the default value."
+          checked={values.value_from_event}
+          onChange={(v) => set("value_from_event", v)}
+        />
+
+        <div className="flex flex-col gap-y-3">
+          <Heading level="h3">Conditions</Heading>
+          <Text size="xsmall" className="text-ui-fg-subtle">
+            All filled fields are AND-ed during goal matching.
+          </Text>
+
+          <FormField label="Event name">
+            <Input
+              value={values.conditions.event_name ?? ""}
+              onChange={(e) => setCondition("event_name", e.target.value)}
+              placeholder="checkout_complete"
+            />
+          </FormField>
+
+          <FormField label="Pathname pattern">
+            <Input
+              value={values.conditions.pathname_pattern ?? ""}
+              onChange={(e) =>
+                setCondition("pathname_pattern", e.target.value)
+              }
+              placeholder="/checkout/success*"
+            />
+          </FormField>
+
+          <div className="grid grid-cols-2 gap-3">
+            <FormField label="Min time on page (s)">
+              <Input
+                type="number"
+                value={values.conditions.min_time_seconds ?? ""}
+                onChange={(e) =>
+                  setCondition(
+                    "min_time_seconds",
+                    e.target.value === ""
+                      ? undefined
+                      : Number(e.target.value)
+                  )
+                }
+              />
+            </FormField>
+            <FormField label="Min scroll (%)">
+              <Input
+                type="number"
+                value={values.conditions.min_scroll_percent ?? ""}
+                onChange={(e) =>
+                  setCondition(
+                    "min_scroll_percent",
+                    e.target.value === ""
+                      ? undefined
+                      : Number(e.target.value)
+                  )
+                }
+              />
+            </FormField>
+          </div>
+
+          <FormField
+            label="Custom conditions (JSON)"
+            error={customConditionsError}
+          >
+            <Textarea
+              value={customConditionsText}
+              onChange={(e) => {
+                setCustomConditionsText(e.target.value)
+                setCustomConditionsError(null)
+              }}
+              placeholder={`{\n  "key": "value"\n}`}
+              rows={4}
+              className="font-mono text-xs"
+            />
+          </FormField>
+        </div>
+      </div>
+      <div className={footerClassName || "px-6 py-3 border-t"}>
+        <div className="flex items-center justify-end gap-x-2">
+          <Button
+            size="small"
+            variant="secondary"
+            type="button"
+            onClick={onCancel}
+          >
+            {t("actions.cancel")}
+          </Button>
+          <Button
+            size="small"
+            variant="primary"
+            type="submit"
+            isLoading={mutation.isPending}
+          >
+            {mode === "create" ? "Create" : t("actions.save")}
+          </Button>
+        </div>
+      </div>
+    </KeyboundForm>
+  )
+}
+
+function FormField({
+  label,
+  required,
+  error,
+  children,
+}: {
+  label: string
+  required?: boolean
+  error?: string | null
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-col gap-y-1">
+      <Label size="xsmall" className="text-ui-fg-subtle">
+        {label}
+        {required && <span className="text-ui-fg-error ml-1">*</span>}
+      </Label>
+      {children}
+      {error && (
+        <Text size="xsmall" className="text-ui-fg-error">
+          {error}
+        </Text>
+      )}
+    </div>
+  )
+}
+
+function ToggleRow({
+  label,
+  description,
+  checked,
+  onChange,
+}: {
+  label: string
+  description: string
+  checked: boolean
+  onChange: (v: boolean) => void
+}) {
+  return (
+    <div className="flex items-start justify-between rounded-md border px-3 py-3">
+      <div className="flex flex-col">
+        <Text size="small" weight="plus">
+          {label}
+        </Text>
+        <Text size="xsmall" className="text-ui-fg-subtle">
+          {description}
+        </Text>
+      </div>
+      <Switch checked={checked} onCheckedChange={onChange} />
+    </div>
+  )
+}

--- a/apps/backend/src/admin/components/ad-planning/goals/goal-google-ads-mapping-form.tsx
+++ b/apps/backend/src/admin/components/ad-planning/goals/goal-google-ads-mapping-form.tsx
@@ -1,0 +1,363 @@
+/**
+ * Per-goal Google Ads mapping form.
+ *
+ * Saves to goal.metadata.google_ads.{customer_id, conversion_action} —
+ * the keys uploadGoogleAdsConversionStep reads via resolveGoalMapping.
+ *
+ * The form needs three pickers:
+ *   1. Google platform — to scope (2) and (3) for picker queries. NOT stored
+ *      on the goal; the customer_id and conversion_action are unique enough
+ *      since a CID is bound to exactly one platform.
+ *   2. Customer (CID) — from synced GoogleAdsCustomer rows for that platform.
+ *   3. Conversion action — live GAQL fetch for the selected CID.
+ *
+ * Either field can be left blank to fall back to the platform default.
+ */
+
+import { useEffect, useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+import {
+  Badge,
+  Button,
+  Label,
+  Select,
+  Text,
+  toast,
+} from "@medusajs/ui"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { sdk } from "../../../lib/config"
+import { KeyboundForm } from "../../utilitites/key-bound-form"
+import { RouteDrawer } from "../../modal/route-drawer/route-drawer"
+import { useRouteModal } from "../../modal/use-route-modal"
+import {
+  useGoogleAdsConversionActions,
+  useGoogleAdsCustomers,
+} from "../../../hooks/api/google-business"
+import { useSocialPlatforms } from "../../../hooks/api/social-platforms"
+
+type GoalRecord = {
+  id: string
+  metadata: Record<string, any> | null
+}
+
+export const GoalGoogleAdsMappingForm = ({
+  goal,
+}: {
+  goal: GoalRecord
+}) => {
+  const { t } = useTranslation()
+  const { handleSuccess } = useRouteModal()
+  const qc = useQueryClient()
+  const meta = (goal.metadata || {}) as Record<string, any>
+  const existing = (meta.google_ads || {}) as Record<string, any>
+
+  // List google-category platforms. We filter client-side to "connected"
+  // ones that also have a developer token, since a platform without one
+  // can't actually upload.
+  const { social_platforms, isLoading: loadingPlatforms } = useSocialPlatforms({
+    category: "google",
+    limit: 50,
+  }) as any
+  const eligiblePlatforms = useMemo(
+    () =>
+      (social_platforms || []).filter((p: any) => {
+        const cfg = (p.api_config || {}) as Record<string, any>
+        return !!cfg.developer_token_encrypted
+      }),
+    [social_platforms]
+  )
+
+  // Default to the single eligible platform when there's only one (most
+  // ops setups). Otherwise the operator picks.
+  const [platformId, setPlatformId] = useState<string>(() => {
+    if (eligiblePlatforms.length === 1) return eligiblePlatforms[0].id
+    return ""
+  })
+  useEffect(() => {
+    if (!platformId && eligiblePlatforms.length === 1) {
+      setPlatformId(eligiblePlatforms[0].id)
+    }
+  }, [eligiblePlatforms, platformId])
+
+  const [customerId, setCustomerId] = useState<string>(
+    existing.customer_id || ""
+  )
+  const [conversionAction, setConversionAction] = useState<string>(
+    existing.conversion_action || ""
+  )
+
+  const { customers, isLoading: loadingCustomers } = useGoogleAdsCustomers(
+    platformId,
+    !!platformId
+  )
+
+  const {
+    conversionActions,
+    isLoading: loadingActions,
+    isError: actionsError,
+    error: actionsErrorObj,
+  } = useGoogleAdsConversionActions(platformId, customerId || null)
+
+  // Blank a stale conversion_action when the operator switches CID.
+  useEffect(() => {
+    if (!customerId || !conversionAction) return
+    if (
+      conversionActions.length > 0 &&
+      !conversionActions.find((a) => a.resource_name === conversionAction)
+    ) {
+      setConversionAction("")
+    }
+  }, [conversionActions, customerId, conversionAction])
+
+  const dirty =
+    customerId !== (existing.customer_id || "") ||
+    conversionAction !== (existing.conversion_action || "")
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      // Top-level JSON merge replaces metadata.google_ads wholesale, so
+      // spread the existing sub-object to preserve any future fields.
+      const nextGoogleAds: Record<string, any> = {
+        ...existing,
+        customer_id: customerId || undefined,
+        conversion_action: conversionAction || undefined,
+      }
+      // Strip both keys when fully cleared so the goal doesn't sit on a
+      // dead {google_ads: {}} record.
+      const isEmpty = !customerId && !conversionAction
+      const nextMetadata = isEmpty
+        ? { ...meta, google_ads: undefined }
+        : { ...meta, google_ads: nextGoogleAds }
+
+      return sdk.client.fetch<{ goal: any }>(
+        `/admin/ad-planning/goals/${goal.id}`,
+        { method: "PUT", body: { metadata: nextMetadata } }
+      )
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["ad-planning", "goals"] })
+      toast.success("Google Ads mapping saved")
+      handleSuccess()
+    },
+    onError: (error: any) => {
+      toast.error(error.message || "Save failed")
+    },
+  })
+
+  const handleClear = () => {
+    setCustomerId("")
+    setConversionAction("")
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    mutation.mutate()
+  }
+
+  const platformOptions = useMemo(
+    () =>
+      eligiblePlatforms.map((p: any) => ({
+        value: p.id,
+        label: p.name + (p.api_config?.account_email ? ` · ${p.api_config.account_email}` : ""),
+      })),
+    [eligiblePlatforms]
+  )
+
+  const customerOptions = useMemo(
+    () =>
+      customers.map((c) => ({
+        value: c.customer_id,
+        label: c.descriptive_name
+          ? `${c.descriptive_name} (${c.customer_id})`
+          : c.customer_id,
+      })),
+    [customers]
+  )
+
+  const actionOptions = useMemo(
+    () =>
+      conversionActions
+        .filter((a) => a.resource_name && a.name)
+        .map((a) => ({
+          value: a.resource_name,
+          label: `${a.name}${a.status ? ` · ${a.status}` : ""}`,
+        })),
+    [conversionActions]
+  )
+
+  return (
+    <KeyboundForm
+      onSubmit={handleSubmit}
+      className="flex flex-1 flex-col overflow-hidden"
+    >
+      <RouteDrawer.Body className="flex flex-1 flex-col gap-y-5 overflow-y-auto px-6 py-4">
+        <Text size="small" className="text-ui-fg-subtle">
+          When a conversion matches this goal during upload, these values
+          override the platform-level defaults. Leave both blank to fall
+          back to the platform default.
+        </Text>
+
+        <div className="flex flex-col gap-y-2">
+          <Label size="xsmall" className="text-ui-fg-subtle">
+            Google platform
+          </Label>
+          <Select
+            value={platformId}
+            onValueChange={(v) => {
+              setPlatformId(v)
+              setCustomerId("")
+              setConversionAction("")
+            }}
+            disabled={loadingPlatforms || platformOptions.length === 0}
+          >
+            <Select.Trigger>
+              <Select.Value
+                placeholder={
+                  loadingPlatforms
+                    ? "Loading platforms…"
+                    : platformOptions.length === 0
+                      ? "No google platforms with a developer token"
+                      : "Pick a platform"
+                }
+              />
+            </Select.Trigger>
+            <Select.Content>
+              {platformOptions.map((opt: any) => (
+                <Select.Item key={opt.value} value={opt.value}>
+                  {opt.label}
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select>
+        </div>
+
+        <div className="flex flex-col gap-y-2">
+          <div className="flex items-center justify-between">
+            <Label size="xsmall" className="text-ui-fg-subtle">
+              Customer (CID)
+            </Label>
+            {customerId === "" && existing.customer_id && (
+              <Badge size="2xsmall" color="grey">
+                Will fall back to platform default
+              </Badge>
+            )}
+          </div>
+          <Select
+            value={customerId}
+            onValueChange={(v) => setCustomerId(v)}
+            disabled={!platformId || loadingCustomers || customerOptions.length === 0}
+          >
+            <Select.Trigger>
+              <Select.Value
+                placeholder={
+                  !platformId
+                    ? "Pick a platform first"
+                    : loadingCustomers
+                      ? "Loading customers…"
+                      : customerOptions.length === 0
+                        ? "No customers synced — sync from GBM panel first"
+                        : "Optional override"
+                }
+              />
+            </Select.Trigger>
+            <Select.Content>
+              {customerOptions.map((opt) => (
+                <Select.Item key={opt.value} value={opt.value}>
+                  {opt.label}
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select>
+        </div>
+
+        <div className="flex flex-col gap-y-2">
+          <Label size="xsmall" className="text-ui-fg-subtle">
+            Conversion action
+          </Label>
+          <Select
+            value={conversionAction}
+            onValueChange={(v) => setConversionAction(v)}
+            disabled={!customerId || loadingActions || actionOptions.length === 0}
+          >
+            <Select.Trigger>
+              <Select.Value
+                placeholder={
+                  !customerId
+                    ? "Pick a customer first"
+                    : loadingActions
+                      ? "Loading from Google…"
+                      : actionOptions.length === 0
+                        ? "No conversion actions on this CID"
+                        : "Optional override"
+                }
+              />
+            </Select.Trigger>
+            <Select.Content>
+              {actionOptions.map((opt) => (
+                <Select.Item key={opt.value} value={opt.value}>
+                  {opt.label}
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select>
+          {actionsError && (
+            <Text size="xsmall" className="text-ui-fg-error">
+              {(actionsErrorObj as Error)?.message ||
+                "Failed to load conversion actions"}
+            </Text>
+          )}
+          {conversionAction && (
+            <Text
+              size="xsmall"
+              className="text-ui-fg-subtle truncate"
+              title={conversionAction}
+            >
+              {conversionAction}
+            </Text>
+          )}
+        </div>
+
+        {(existing.customer_id || existing.conversion_action) && (
+          <div className="rounded-md border border-ui-border-base bg-ui-bg-subtle px-3 py-2 flex items-center justify-between">
+            <div className="flex flex-col">
+              <Text size="xsmall" weight="plus">
+                Current mapping
+              </Text>
+              <Text size="xsmall" className="text-ui-fg-subtle">
+                {existing.customer_id || "(no CID override)"}
+                {" · "}
+                {existing.conversion_action || "(no action override)"}
+              </Text>
+            </div>
+            <Button
+              size="small"
+              variant="transparent"
+              type="button"
+              onClick={handleClear}
+            >
+              Clear
+            </Button>
+          </div>
+        )}
+      </RouteDrawer.Body>
+      <RouteDrawer.Footer>
+        <div className="flex items-center justify-end gap-x-2">
+          <RouteDrawer.Close asChild>
+            <Button size="small" variant="secondary">
+              {t("actions.cancel")}
+            </Button>
+          </RouteDrawer.Close>
+          <Button
+            size="small"
+            variant="primary"
+            type="submit"
+            isLoading={mutation.isPending}
+            disabled={!dirty}
+          >
+            {t("actions.save")}
+          </Button>
+        </div>
+      </RouteDrawer.Footer>
+    </KeyboundForm>
+  )
+}

--- a/apps/backend/src/admin/components/social-platforms/google-business-panel.tsx
+++ b/apps/backend/src/admin/components/social-platforms/google-business-panel.tsx
@@ -75,7 +75,7 @@ export function GoogleBusinessPanel({
       <CredentialsSection apiConfig={apiConfig} />
       <BindingsSection platformId={platform.id} isConnected={isConnected} />
       {isConnected && hasAdsBinding && (
-        <GoogleAdsDataSection platformId={platform.id} />
+        <GoogleAdsDataSection platformId={platform.id} apiConfig={apiConfig} />
       )}
     </div>
   )
@@ -404,12 +404,24 @@ function ServiceBindingsCard({
   )
 }
 
-function GoogleAdsDataSection({ platformId }: { platformId: string }) {
+function GoogleAdsDataSection({
+  platformId,
+  apiConfig,
+}: {
+  platformId: string
+  apiConfig: Record<string, any>
+}) {
   const { customers, isLoading: loadingCustomers } =
     useGoogleAdsCustomers(platformId)
   const { campaigns, isLoading: loadingCampaigns } =
     useGoogleAdsCampaigns(platformId)
   const sync = useSyncGoogleAds(platformId)
+
+  const googleAds = (apiConfig.google_ads || {}) as Record<string, any>
+  const hasDefaultCustomer = !!googleAds.default_customer_id
+  const hasDefaultAction = !!googleAds.default_conversion_action
+  const defaultsComplete = hasDefaultCustomer && hasDefaultAction
+  const validateOnly = !!googleAds.validate_only
 
   const handleSync = async () => {
     try {
@@ -429,20 +441,42 @@ function GoogleAdsDataSection({ platformId }: { platformId: string }) {
   return (
     <Container className="divide-y p-0">
       <div className="flex items-center justify-between px-6 py-4">
-        <div>
+        <div className="flex flex-col gap-y-1">
           <Heading level="h2">Google Ads data</Heading>
-          <Text className="text-ui-fg-subtle mt-1" size="small">
+          <Text className="text-ui-fg-subtle" size="small">
             Synced campaigns and ad groups, used by ad-planning attribution.
           </Text>
+          <div className="flex flex-wrap items-center gap-2 mt-1">
+            <Badge
+              size="2xsmall"
+              color={defaultsComplete ? "green" : "orange"}
+            >
+              {defaultsComplete
+                ? "Upload defaults configured"
+                : "Upload defaults not set"}
+            </Badge>
+            {validateOnly && (
+              <Badge size="2xsmall" color="orange">
+                Dry run
+              </Badge>
+            )}
+          </div>
         </div>
-        <Button
-          size="small"
-          variant="secondary"
-          onClick={handleSync}
-          isLoading={sync.isPending}
-        >
-          <ArrowPath /> Sync now
-        </Button>
+        <div className="flex items-center gap-x-2">
+          <Button asChild size="small" variant="secondary">
+            <Link to="google-ads-defaults">
+              <Key /> Edit defaults
+            </Link>
+          </Button>
+          <Button
+            size="small"
+            variant="secondary"
+            onClick={handleSync}
+            isLoading={sync.isPending}
+          >
+            <ArrowPath /> Sync now
+          </Button>
+        </div>
       </div>
 
       <div className="px-6 py-4">

--- a/apps/backend/src/admin/components/social-platforms/google/google-ads-defaults-form.tsx
+++ b/apps/backend/src/admin/components/social-platforms/google/google-ads-defaults-form.tsx
@@ -1,0 +1,288 @@
+import { useEffect, useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+import {
+  Badge,
+  Button,
+  Label,
+  Select,
+  Switch,
+  Text,
+  toast,
+} from "@medusajs/ui"
+import { KeyboundForm } from "../../utilitites/key-bound-form"
+import { RouteDrawer } from "../../modal/route-drawer/route-drawer"
+import { useRouteModal } from "../../modal/use-route-modal"
+import {
+  useGoogleAdsConversionActions,
+  useGoogleAdsCustomers,
+} from "../../../hooks/api/google-business"
+import {
+  type AdminSocialPlatform,
+  useUpdateSocialPlatform,
+} from "../../../hooks/api/social-platforms"
+
+type GoogleAdsConfig = {
+  default_customer_id?: string
+  default_conversion_action?: string
+  validate_only?: boolean
+  [k: string]: any
+}
+
+export const GoogleAdsDefaultsForm = ({
+  platform,
+}: {
+  platform: AdminSocialPlatform
+}) => {
+  const { t } = useTranslation()
+  const { handleSuccess } = useRouteModal()
+  const apiConfig = (platform.api_config || {}) as Record<string, any>
+  const existing = (apiConfig.google_ads || {}) as GoogleAdsConfig
+
+  const { customers, isLoading: loadingCustomers } = useGoogleAdsCustomers(
+    platform.id
+  )
+
+  const [customerId, setCustomerId] = useState<string>(
+    existing.default_customer_id || ""
+  )
+  const [conversionAction, setConversionAction] = useState<string>(
+    existing.default_conversion_action || ""
+  )
+  const [validateOnly, setValidateOnly] = useState<boolean>(
+    !!existing.validate_only
+  )
+
+  const update = useUpdateSocialPlatform(platform.id)
+
+  // Refetch conversion actions whenever the operator picks a different CID;
+  // gated by `enabled` so we don't ping Google before there's a selection.
+  const {
+    conversionActions,
+    isLoading: loadingActions,
+    isError: actionsError,
+    error: actionsErrorObj,
+    refetch: refetchActions,
+  } = useGoogleAdsConversionActions(platform.id, customerId || null)
+
+  // If the operator changes the CID and the saved conversion_action no longer
+  // matches the new customer's actions, blank it out so they don't accidentally
+  // save a mismatched mapping.
+  useEffect(() => {
+    if (!customerId) return
+    if (!conversionAction) return
+    const matches = conversionActions.find(
+      (a) => a.resource_name === conversionAction
+    )
+    if (conversionActions.length > 0 && !matches) {
+      setConversionAction("")
+    }
+  }, [conversionActions, customerId, conversionAction])
+
+  const dirty =
+    customerId !== (existing.default_customer_id || "") ||
+    conversionAction !== (existing.default_conversion_action || "") ||
+    validateOnly !== !!existing.validate_only
+
+  const customerOptions = useMemo(
+    () =>
+      customers.map((c) => ({
+        value: c.customer_id,
+        label: c.descriptive_name
+          ? `${c.descriptive_name} (${c.customer_id})`
+          : c.customer_id,
+      })),
+    [customers]
+  )
+
+  const actionOptions = useMemo(
+    () =>
+      conversionActions
+        .filter((a) => a.resource_name && a.name)
+        .map((a) => ({
+          value: a.resource_name,
+          label: `${a.name}${a.status ? ` · ${a.status}` : ""}`,
+        })),
+    [conversionActions]
+  )
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    // Whole `google_ads` sub-object is replaced on save (top-level JSON merge),
+    // so spread `existing` to preserve any future fields we don't surface here.
+    const nextGoogleAds: GoogleAdsConfig = {
+      ...existing,
+      default_customer_id: customerId || undefined,
+      default_conversion_action: conversionAction || undefined,
+      validate_only: validateOnly || undefined,
+    }
+    await update.mutateAsync(
+      { api_config: { google_ads: nextGoogleAds } } as any,
+      {
+        onSuccess: () => {
+          toast.success("Upload defaults saved")
+          handleSuccess()
+        },
+        onError: (error) => toast.error(error.message),
+      }
+    )
+  }
+
+  const noCustomersSynced = !loadingCustomers && customers.length === 0
+
+  return (
+    <KeyboundForm
+      onSubmit={handleSubmit}
+      className="flex flex-1 flex-col overflow-hidden"
+    >
+      <RouteDrawer.Body className="flex flex-1 flex-col gap-y-5 overflow-y-auto px-6 py-4">
+        <div>
+          <Text size="small" className="text-ui-fg-subtle">
+            These defaults drive conversion uploads when a conversion's
+            metadata or matched goal doesn't override them. The conversion
+            upload subscriber skips silently if neither is set.
+          </Text>
+        </div>
+
+        {noCustomersSynced && (
+          <div className="rounded-md border border-ui-border-base bg-ui-bg-subtle px-3 py-2">
+            <Text size="small" className="text-ui-fg-subtle">
+              No Google Ads customers synced yet. Run "Sync now" on the GBM
+              panel first — the picker reads from synced customer rows.
+            </Text>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-y-2">
+          <Label size="xsmall" className="text-ui-fg-subtle">
+            Default Google Ads customer
+          </Label>
+          <Select
+            value={customerId}
+            onValueChange={(v) => setCustomerId(v)}
+            disabled={loadingCustomers || customerOptions.length === 0}
+          >
+            <Select.Trigger>
+              <Select.Value
+                placeholder={
+                  loadingCustomers
+                    ? "Loading customers…"
+                    : customerOptions.length === 0
+                      ? "No customers — sync first"
+                      : "Pick a CID"
+                }
+              />
+            </Select.Trigger>
+            <Select.Content>
+              {customerOptions.map((opt) => (
+                <Select.Item key={opt.value} value={opt.value}>
+                  {opt.label}
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select>
+        </div>
+
+        <div className="flex flex-col gap-y-2">
+          <div className="flex items-center justify-between">
+            <Label size="xsmall" className="text-ui-fg-subtle">
+              Default conversion action
+            </Label>
+            {customerId && (
+              <Button
+                size="small"
+                variant="transparent"
+                onClick={(e) => {
+                  e.preventDefault()
+                  refetchActions()
+                }}
+                disabled={loadingActions}
+              >
+                Refresh
+              </Button>
+            )}
+          </div>
+          <Select
+            value={conversionAction}
+            onValueChange={(v) => setConversionAction(v)}
+            disabled={!customerId || loadingActions || actionOptions.length === 0}
+          >
+            <Select.Trigger>
+              <Select.Value
+                placeholder={
+                  !customerId
+                    ? "Pick a customer first"
+                    : loadingActions
+                      ? "Loading from Google…"
+                      : actionOptions.length === 0
+                        ? "No conversion actions on this CID"
+                        : "Pick a conversion action"
+                }
+              />
+            </Select.Trigger>
+            <Select.Content>
+              {actionOptions.map((opt) => (
+                <Select.Item key={opt.value} value={opt.value}>
+                  {opt.label}
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select>
+          {actionsError && (
+            <Text size="xsmall" className="text-ui-fg-error">
+              {(actionsErrorObj as Error)?.message ||
+                "Failed to load conversion actions"}
+            </Text>
+          )}
+          {conversionAction && (
+            <Text
+              size="xsmall"
+              className="text-ui-fg-subtle truncate"
+              title={conversionAction}
+            >
+              {conversionAction}
+            </Text>
+          )}
+        </div>
+
+        <div className="flex items-start justify-between rounded-md border px-3 py-3">
+          <div className="flex flex-col">
+            <div className="flex items-center gap-x-2">
+              <Text size="small" weight="plus">
+                Validate-only mode
+              </Text>
+              {validateOnly && (
+                <Badge size="2xsmall" color="orange">
+                  Dry run
+                </Badge>
+              )}
+            </div>
+            <Text size="xsmall" className="text-ui-fg-subtle">
+              When on, uploads send <code>validateOnly: true</code> to Google
+              — Google parses the request and reports errors but does not
+              record the conversion. Useful while wiring up a new CID.
+            </Text>
+          </div>
+          <Switch checked={validateOnly} onCheckedChange={setValidateOnly} />
+        </div>
+      </RouteDrawer.Body>
+      <RouteDrawer.Footer>
+        <div className="flex items-center justify-end gap-x-2">
+          <RouteDrawer.Close asChild>
+            <Button size="small" variant="secondary">
+              {t("actions.cancel")}
+            </Button>
+          </RouteDrawer.Close>
+          <Button
+            size="small"
+            variant="primary"
+            type="submit"
+            isLoading={update.isPending}
+            disabled={!dirty}
+          >
+            {t("actions.save")}
+          </Button>
+        </div>
+      </RouteDrawer.Footer>
+    </KeyboundForm>
+  )
+}

--- a/apps/backend/src/admin/hooks/api/google-business.ts
+++ b/apps/backend/src/admin/hooks/api/google-business.ts
@@ -78,6 +78,16 @@ export type GoogleAdsSyncResponse = {
   errors: Array<{ customer_id: string; message: string }>
 }
 
+export type GoogleAdsConversionAction = {
+  resource_name: string
+  conversion_action_id: string
+  name: string
+  type: string | null
+  status: string | null
+  category: string | null
+  include_in_conversions_metric: boolean | null
+}
+
 const KEYS = {
   all: ["google-business"] as const,
   bindings: (platformId: string, service?: GoogleService) =>
@@ -88,6 +98,8 @@ const KEYS = {
     [...KEYS.all, "ads-customers", platformId] as const,
   adsCampaigns: (platformId: string, customerId?: string) =>
     [...KEYS.all, "ads-campaigns", platformId, customerId ?? "all"] as const,
+  adsConversionActions: (platformId: string, customerId: string) =>
+    [...KEYS.all, "ads-conversion-actions", platformId, customerId] as const,
 }
 
 export function useInitiateGoogleConnect(platformId: string) {
@@ -249,4 +261,27 @@ export function useSyncGoogleAds(platformId: string) {
       qc.invalidateQueries({ queryKey: KEYS.all })
     },
   })
+}
+
+export function useGoogleAdsConversionActions(
+  platformId: string,
+  customerId: string | null,
+  enabled = true
+) {
+  const query = useQuery({
+    queryKey: KEYS.adsConversionActions(platformId, customerId || ""),
+    queryFn: () =>
+      sdk.client.fetch<{
+        customer_id: string
+        conversion_actions: GoogleAdsConversionAction[]
+      }>(
+        `/admin/social-platforms/${platformId}/google/ads/conversion-actions`,
+        { method: "GET", query: { customer_id: customerId } }
+      ),
+    enabled: enabled && !!platformId && !!customerId,
+  })
+  return {
+    conversionActions: query.data?.conversion_actions || [],
+    ...query,
+  }
 }

--- a/apps/backend/src/admin/routes/ad-planning/conversions/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/ad-planning/conversions/[id]/page.tsx
@@ -1,0 +1,476 @@
+/**
+ * Conversion Detail Page
+ *
+ * Shows the conversion record plus a Google Ads upload status panel that
+ * reflects the metadata stamped by uploadGoogleAdsConversionStep — and a
+ * Retry Upload action that re-runs the workflow.
+ */
+
+import { useMemo } from "react"
+import {
+  Badge,
+  Button,
+  Container,
+  Heading,
+  StatusBadge,
+  Text,
+  toast,
+} from "@medusajs/ui"
+import { ArrowPath } from "@medusajs/icons"
+import { Link, useParams, UIMatch } from "react-router-dom"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { sdk } from "../../../../lib/config"
+import { useCurrencyFormatter } from "../../../../hooks/api/currency"
+
+type Conversion = {
+  id: string
+  conversion_type: string
+  conversion_name: string | null
+  ad_campaign_id: string | null
+  ad_set_id: string | null
+  ad_id: string | null
+  platform: "meta" | "google" | "generic" | "direct"
+  utm_source: string | null
+  utm_medium: string | null
+  utm_campaign: string | null
+  utm_term: string | null
+  utm_content: string | null
+  attribution_model: string
+  attribution_weight: number
+  conversion_value: number | null
+  currency: string | null
+  order_id: string | null
+  analytics_event_id: string | null
+  analytics_session_id: string | null
+  lead_id: string | null
+  person_id: string | null
+  visitor_id: string
+  session_id: string | null
+  website_id: string | null
+  converted_at: string
+  metadata: Record<string, any> | null
+  created_at: string
+  updated_at: string
+}
+
+type RetryResponse = {
+  conversion_id: string
+  customer_id: string
+  conversion_action: string
+  uploaded: boolean
+  reason?: string
+  partial_failure?: any
+}
+
+const ConversionDetailPage = () => {
+  const { id } = useParams<{ id: string }>()
+  const qc = useQueryClient()
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ["ad-planning", "conversions", id],
+    queryFn: () =>
+      sdk.client.fetch<{ conversion: Conversion }>(
+        `/admin/ad-planning/conversions/${id}`,
+        { method: "GET" }
+      ),
+    enabled: !!id,
+  })
+
+  const retry = useMutation({
+    mutationFn: (input?: { platform_id?: string }) =>
+      sdk.client.fetch<RetryResponse>(
+        `/admin/ad-planning/conversions/${id}/google-upload`,
+        { method: "POST", body: input || {} }
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["ad-planning", "conversions", id] })
+    },
+  })
+
+  if (isLoading) {
+    return (
+      <Container className="p-6">
+        <Text size="small" className="text-ui-fg-subtle">
+          Loading…
+        </Text>
+      </Container>
+    )
+  }
+
+  if (isError || !data?.conversion) {
+    return (
+      <Container className="p-6">
+        <Text size="small" className="text-ui-fg-error">
+          {(error as Error)?.message || "Conversion not found"}
+        </Text>
+      </Container>
+    )
+  }
+
+  const c = data.conversion
+  const meta = (c.metadata || {}) as Record<string, any>
+  const showGoogleAdsSection =
+    c.platform === "google" ||
+    Object.keys(meta).some((k) => k.startsWith("google_ads_"))
+
+  const handleRetry = async () => {
+    try {
+      const result = await retry.mutateAsync(undefined)
+      if (result.uploaded) {
+        toast.success("Conversion uploaded to Google Ads")
+      } else {
+        toast.warning(result.reason || "Upload skipped — see status for details")
+      }
+    } catch (e: any) {
+      toast.error(e.message || "Upload failed")
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-y-3">
+      <ConversionGeneralSection conversion={c} />
+      <AttributionSection conversion={c} />
+      <UtmSection conversion={c} />
+      {showGoogleAdsSection && (
+        <GoogleAdsUploadSection
+          conversion={c}
+          onRetry={handleRetry}
+          isRetrying={retry.isPending}
+        />
+      )}
+      <RawMetadataSection metadata={meta} />
+    </div>
+  )
+}
+
+function ConversionGeneralSection({ conversion }: { conversion: Conversion }) {
+  const { formatCurrency } = useCurrencyFormatter()
+  const value =
+    conversion.conversion_value != null
+      ? formatCurrency(conversion.conversion_value, { convert: false })
+      : "—"
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div>
+          <Heading level="h2">Conversion</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            {conversion.conversion_type.replace(/_/g, " ")} ·{" "}
+            {new Date(conversion.converted_at).toLocaleString()}
+          </Text>
+        </div>
+        <PlatformBadge platform={conversion.platform} />
+      </div>
+      <Field label="Value" value={value} />
+      <Field label="Currency" value={conversion.currency || "—"} />
+      <Field
+        label="Attribution model"
+        value={conversion.attribution_model.replace(/_/g, " ")}
+      />
+      <Field
+        label="Attribution weight"
+        value={String(conversion.attribution_weight ?? "—")}
+      />
+      <Field
+        label="Order"
+        value={conversion.order_id || "—"}
+        link={
+          conversion.order_id ? `/orders/${conversion.order_id}` : undefined
+        }
+      />
+      <Field
+        label="Person"
+        value={conversion.person_id || "—"}
+        link={
+          conversion.person_id ? `/persons/${conversion.person_id}` : undefined
+        }
+      />
+      <Field label="Visitor" value={conversion.visitor_id} />
+      <Field label="Session" value={conversion.session_id || "—"} />
+    </Container>
+  )
+}
+
+function AttributionSection({ conversion }: { conversion: Conversion }) {
+  const hasAttribution =
+    conversion.ad_campaign_id ||
+    conversion.ad_set_id ||
+    conversion.ad_id
+  return (
+    <Container className="divide-y p-0">
+      <div className="px-6 py-4">
+        <Heading level="h2">Attribution</Heading>
+        <Text size="small" className="text-ui-fg-subtle mt-1">
+          Resolved campaign, ad set, and ad references for this conversion.
+        </Text>
+      </div>
+      {!hasAttribution ? (
+        <div className="px-6 py-4">
+          <Text size="small" className="text-ui-fg-subtle">
+            No attribution resolved. Check the UTMs below or wait for the
+            bulk-resolve job to run.
+          </Text>
+        </div>
+      ) : (
+        <>
+          <Field
+            label="Campaign id"
+            value={conversion.ad_campaign_id || "—"}
+            mono
+          />
+          <Field label="Ad set id" value={conversion.ad_set_id || "—"} mono />
+          <Field label="Ad id" value={conversion.ad_id || "—"} mono />
+        </>
+      )}
+    </Container>
+  )
+}
+
+function UtmSection({ conversion }: { conversion: Conversion }) {
+  return (
+    <Container className="divide-y p-0">
+      <div className="px-6 py-4">
+        <Heading level="h2">UTM</Heading>
+      </div>
+      <Field label="Source" value={conversion.utm_source || "—"} />
+      <Field label="Medium" value={conversion.utm_medium || "—"} />
+      <Field label="Campaign" value={conversion.utm_campaign || "—"} />
+      <Field label="Term" value={conversion.utm_term || "—"} />
+      <Field label="Content" value={conversion.utm_content || "—"} />
+    </Container>
+  )
+}
+
+function GoogleAdsUploadSection({
+  conversion,
+  onRetry,
+  isRetrying,
+}: {
+  conversion: Conversion
+  onRetry: () => void
+  isRetrying: boolean
+}) {
+  const meta = (conversion.metadata || {}) as Record<string, any>
+  const uploadedAt = meta.google_ads_uploaded_at as string | null
+  const failedAt = meta.google_ads_upload_failed_at as string | null
+  const skippedAt = meta.google_ads_upload_skipped_at as string | null
+  const skipReason = meta.google_ads_upload_skip_reason as string | null
+  const uploadError = meta.google_ads_upload_error as string | null
+  const partialFailure = meta.google_ads_partial_failure
+  const customerId = meta.google_ads_customer_id as string | null
+  const conversionAction = meta.google_ads_conversion_action as string | null
+  const matchedGoalId = meta.google_ads_matched_goal_id as string | null
+  const platformId = meta.google_ads_platform_id as string | null
+  const clickId = meta.gclid || meta.gbraid || meta.wbraid || null
+
+  const status: "uploaded" | "error" | "skipped" | "pending" = uploadedAt
+    ? "uploaded"
+    : uploadError
+      ? "error"
+      : skipReason
+        ? "skipped"
+        : "pending"
+
+  const statusColor =
+    status === "uploaded"
+      ? "green"
+      : status === "error"
+        ? "red"
+        : status === "skipped"
+          ? "orange"
+          : "grey"
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div>
+          <Heading level="h2">Google Ads upload</Heading>
+          <Text size="small" className="text-ui-fg-subtle mt-1">
+            Status of this conversion's upload via
+            conversionUploads:uploadClickConversions.
+          </Text>
+        </div>
+        <div className="flex items-center gap-x-2">
+          <StatusBadge color={statusColor}>{status}</StatusBadge>
+          <Button
+            size="small"
+            variant="secondary"
+            onClick={onRetry}
+            isLoading={isRetrying}
+          >
+            <ArrowPath /> Retry upload
+          </Button>
+        </div>
+      </div>
+
+      {status === "uploaded" && uploadedAt && (
+        <Field
+          label="Uploaded at"
+          value={new Date(uploadedAt).toLocaleString()}
+        />
+      )}
+      {status === "error" && (
+        <>
+          {failedAt && (
+            <Field
+              label="Failed at"
+              value={new Date(failedAt).toLocaleString()}
+            />
+          )}
+          <FieldBlock label="Error" value={uploadError || "—"} variant="error" />
+        </>
+      )}
+      {status === "skipped" && (
+        <>
+          {skippedAt && (
+            <Field
+              label="Skipped at"
+              value={new Date(skippedAt).toLocaleString()}
+            />
+          )}
+          <FieldBlock
+            label="Reason"
+            value={skipReason || "—"}
+            variant="warning"
+          />
+        </>
+      )}
+
+      <Field label="Click id" value={clickId || "—"} mono />
+      <Field label="Customer id (CID)" value={customerId || "—"} mono />
+      <Field
+        label="Conversion action"
+        value={conversionAction || "—"}
+        mono
+      />
+      <Field
+        label="Matched goal"
+        value={matchedGoalId || "— (used platform default)"}
+      />
+      <Field label="Platform" value={platformId || "—"} />
+      {partialFailure && (
+        <FieldBlock
+          label="Partial failure"
+          value={JSON.stringify(partialFailure, null, 2)}
+          variant="error"
+          mono
+        />
+      )}
+    </Container>
+  )
+}
+
+function RawMetadataSection({ metadata }: { metadata: Record<string, any> }) {
+  const json = useMemo(() => JSON.stringify(metadata, null, 2), [metadata])
+  if (!metadata || Object.keys(metadata).length === 0) return null
+  return (
+    <Container className="divide-y p-0">
+      <div className="px-6 py-4">
+        <Heading level="h2">Raw metadata</Heading>
+      </div>
+      <pre className="bg-ui-bg-subtle text-ui-fg-base px-6 py-4 text-xs overflow-x-auto whitespace-pre-wrap break-all">
+        {json}
+      </pre>
+    </Container>
+  )
+}
+
+function PlatformBadge({
+  platform,
+}: {
+  platform: "meta" | "google" | "generic" | "direct"
+}) {
+  const color =
+    platform === "google"
+      ? "blue"
+      : platform === "meta"
+        ? "purple"
+        : platform === "direct"
+          ? "green"
+          : "grey"
+  return (
+    <Badge color={color} size="2xsmall">
+      {platform}
+    </Badge>
+  )
+}
+
+function Field({
+  label,
+  value,
+  mono,
+  link,
+}: {
+  label: string
+  value: string
+  mono?: boolean
+  link?: string
+}) {
+  return (
+    <div className="text-ui-fg-subtle grid grid-cols-2 items-center px-6 py-4">
+      <Text size="small" leading="compact" weight="plus">
+        {label}
+      </Text>
+      {link ? (
+        <Link
+          to={link}
+          className="text-ui-fg-interactive hover:underline truncate"
+        >
+          <Text
+            size="small"
+            leading="compact"
+            className={mono ? "font-mono" : ""}
+          >
+            {value || "—"}
+          </Text>
+        </Link>
+      ) : (
+        <Text
+          size="small"
+          leading="compact"
+          className={mono ? "font-mono truncate" : "truncate"}
+          title={value}
+        >
+          {value || "—"}
+        </Text>
+      )}
+    </div>
+  )
+}
+
+function FieldBlock({
+  label,
+  value,
+  variant,
+  mono,
+}: {
+  label: string
+  value: string
+  variant?: "error" | "warning"
+  mono?: boolean
+}) {
+  const tone =
+    variant === "error"
+      ? "text-ui-fg-error"
+      : variant === "warning"
+        ? "text-ui-fg-subtle"
+        : "text-ui-fg-base"
+  return (
+    <div className="text-ui-fg-subtle flex flex-col gap-y-1 px-6 py-4">
+      <Text size="small" leading="compact" weight="plus">
+        {label}
+      </Text>
+      <pre
+        className={`${mono ? "font-mono" : ""} ${tone} text-xs whitespace-pre-wrap break-all`}
+      >
+        {value}
+      </pre>
+    </div>
+  )
+}
+
+export default ConversionDetailPage
+
+export const handle = {
+  breadcrumb: (match: UIMatch<{ id: string }>) => match.params.id || "Detail",
+}

--- a/apps/backend/src/admin/routes/ad-planning/conversions/page.tsx
+++ b/apps/backend/src/admin/routes/ad-planning/conversions/page.tsx
@@ -81,7 +81,7 @@ const ConversionsPage = () => {
   const columns = useMemo(() => [
     columnHelper.accessor("conversion_type", {
       header: "Type",
-      cell: ({ getValue }) => {
+      cell: ({ getValue, row }) => {
         const type = getValue()
         const colors: Record<string, "green" | "blue" | "orange" | "purple" | "grey"> = {
           purchase: "green",
@@ -90,9 +90,11 @@ const ConversionsPage = () => {
           begin_checkout: "purple",
         }
         return (
-          <Badge color={colors[type] || "grey"} size="xsmall">
-            {type.replace(/_/g, " ")}
-          </Badge>
+          <Link to={`/ad-planning/conversions/${row.original.id}`}>
+            <Badge color={colors[type] || "grey"} size="xsmall" className="cursor-pointer">
+              {type.replace(/_/g, " ")}
+            </Badge>
+          </Link>
         )
       },
     }),

--- a/apps/backend/src/admin/routes/ad-planning/goals/[id]/@edit/page.tsx
+++ b/apps/backend/src/admin/routes/ad-planning/goals/[id]/@edit/page.tsx
@@ -1,0 +1,53 @@
+import { useParams } from "react-router-dom"
+import { useQuery } from "@tanstack/react-query"
+import { Heading } from "@medusajs/ui"
+import { sdk } from "../../../../../lib/config"
+import { RouteDrawer } from "../../../../../components/modal/route-drawer/route-drawer"
+import { useRouteModal } from "../../../../../components/modal/use-route-modal"
+import {
+  GoalForm,
+  type GoalFormValues,
+} from "../../../../../components/ad-planning/goals/goal-form"
+
+export default function GoalEditDrawerPage() {
+  const { id } = useParams<{ id: string }>()
+  const { handleSuccess } = useRouteModal()
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["ad-planning", "goals", id, "edit"],
+    queryFn: () =>
+      sdk.client.fetch<{ goal: any }>(`/admin/ad-planning/goals/${id}`, {
+        method: "GET",
+      }),
+    enabled: !!id,
+  })
+
+  if (isLoading || !data?.goal) return null
+
+  const initial: Partial<GoalFormValues> = {
+    name: data.goal.name,
+    description: data.goal.description ?? "",
+    goal_type: data.goal.goal_type,
+    is_active: !!data.goal.is_active,
+    priority: data.goal.priority ?? 0,
+    default_value: data.goal.default_value ?? null,
+    value_from_event: !!data.goal.value_from_event,
+    website_id: data.goal.website_id ?? "",
+    conditions: data.goal.conditions ?? {},
+  }
+
+  return (
+    <RouteDrawer>
+      <RouteDrawer.Header>
+        <Heading>Edit goal</Heading>
+      </RouteDrawer.Header>
+      <GoalForm
+        initial={initial}
+        goalId={id}
+        mode="edit"
+        onCancel={() => handleSuccess()}
+        onSuccess={() => handleSuccess()}
+      />
+    </RouteDrawer>
+  )
+}

--- a/apps/backend/src/admin/routes/ad-planning/goals/[id]/@google-ads-mapping/page.tsx
+++ b/apps/backend/src/admin/routes/ad-planning/goals/[id]/@google-ads-mapping/page.tsx
@@ -1,0 +1,30 @@
+import { useParams } from "react-router-dom"
+import { useQuery } from "@tanstack/react-query"
+import { Heading } from "@medusajs/ui"
+import { sdk } from "../../../../../lib/config"
+import { RouteDrawer } from "../../../../../components/modal/route-drawer/route-drawer"
+import { GoalGoogleAdsMappingForm } from "../../../../../components/ad-planning/goals/goal-google-ads-mapping-form"
+
+export default function GoalGoogleAdsMappingDrawerPage() {
+  const { id } = useParams<{ id: string }>()
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["ad-planning", "goals", id, "google-ads-mapping"],
+    queryFn: () =>
+      sdk.client.fetch<{ goal: any }>(`/admin/ad-planning/goals/${id}`, {
+        method: "GET",
+      }),
+    enabled: !!id,
+  })
+
+  if (isLoading || !data?.goal) return null
+
+  return (
+    <RouteDrawer>
+      <RouteDrawer.Header>
+        <Heading>Google Ads mapping</Heading>
+      </RouteDrawer.Header>
+      <GoalGoogleAdsMappingForm goal={data.goal} />
+    </RouteDrawer>
+  )
+}

--- a/apps/backend/src/admin/routes/ad-planning/goals/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/ad-planning/goals/[id]/page.tsx
@@ -1,0 +1,355 @@
+/**
+ * Conversion Goal Detail Page
+ *
+ * Read-only summary of a single goal with edit / mapping / delete actions.
+ * Uses Medusa's Outlet pattern so [id]/@edit and [id]/@google-ads-mapping
+ * sub-routes render as drawers without unmounting the page.
+ */
+
+import {
+  Badge,
+  Button,
+  Container,
+  Heading,
+  StatusBadge,
+  Text,
+  toast,
+  usePrompt,
+} from "@medusajs/ui"
+import { Key, PencilSquare, Trash } from "@medusajs/icons"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  Link,
+  Outlet,
+  useNavigate,
+  useParams,
+  UIMatch,
+} from "react-router-dom"
+import { useMemo } from "react"
+import { sdk } from "../../../../lib/config"
+
+type ConversionGoal = {
+  id: string
+  name: string
+  description: string | null
+  goal_type: string
+  is_active: boolean
+  priority: number
+  default_value: number | null
+  value_from_event: boolean
+  website_id: string | null
+  conditions: Record<string, any> | null
+  metadata: Record<string, any> | null
+  created_at: string
+  updated_at: string
+}
+
+const GOAL_TYPE_COLORS: Record<
+  string,
+  "green" | "blue" | "orange" | "purple" | "grey"
+> = {
+  purchase: "green",
+  lead_form: "blue",
+  add_to_cart: "orange",
+  page_view: "grey",
+  time_on_page: "grey",
+  scroll_depth: "purple",
+  custom_event: "grey",
+}
+
+const ConversionGoalDetailPage = () => {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const prompt = usePrompt()
+  const qc = useQueryClient()
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ["ad-planning", "goals", id],
+    queryFn: () =>
+      sdk.client.fetch<{ goal: ConversionGoal }>(
+        `/admin/ad-planning/goals/${id}`,
+        { method: "GET" }
+      ),
+    enabled: !!id,
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: () =>
+      sdk.client.fetch(`/admin/ad-planning/goals/${id}`, { method: "DELETE" }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["ad-planning", "goals"] })
+      toast.success("Goal deleted")
+      navigate("/ad-planning/goals", { replace: true })
+    },
+  })
+
+  const handleDelete = async () => {
+    const ok = await prompt({
+      title: "Delete goal",
+      description:
+        "This permanently removes the goal. Existing conversions remain untouched.",
+      confirmText: "Delete",
+      cancelText: "Cancel",
+    })
+    if (!ok) return
+    await deleteMutation.mutateAsync()
+  }
+
+  if (isLoading) {
+    return (
+      <Container className="p-6">
+        <Text size="small" className="text-ui-fg-subtle">
+          Loading…
+        </Text>
+      </Container>
+    )
+  }
+
+  if (isError || !data?.goal) {
+    return (
+      <Container className="p-6">
+        <Text size="small" className="text-ui-fg-error">
+          {(error as Error)?.message || "Goal not found"}
+        </Text>
+      </Container>
+    )
+  }
+
+  const g = data.goal
+
+  return (
+    <div className="flex flex-col gap-y-3">
+      <GeneralSection goal={g} onDelete={handleDelete} />
+      <CountersSection goal={g} />
+      <ConditionsSection goal={g} />
+      <GoogleAdsMappingSection goal={g} />
+      <Outlet />
+    </div>
+  )
+}
+
+function GeneralSection({
+  goal,
+  onDelete,
+}: {
+  goal: ConversionGoal
+  onDelete: () => void
+}) {
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex flex-col gap-y-1">
+          <Heading level="h2">{goal.name}</Heading>
+          {goal.description && (
+            <Text size="small" className="text-ui-fg-subtle">
+              {goal.description}
+            </Text>
+          )}
+          <div className="flex items-center gap-x-2 mt-1">
+            <Badge
+              color={GOAL_TYPE_COLORS[goal.goal_type] || "grey"}
+              size="2xsmall"
+            >
+              {goal.goal_type.replace(/_/g, " ")}
+            </Badge>
+            <StatusBadge color={goal.is_active ? "green" : "grey"}>
+              {goal.is_active ? "active" : "inactive"}
+            </StatusBadge>
+            <Badge size="2xsmall" color="grey">
+              priority {goal.priority}
+            </Badge>
+          </div>
+        </div>
+        <div className="flex items-center gap-x-2">
+          <Button asChild size="small" variant="secondary">
+            <Link to="edit">
+              <PencilSquare /> Edit
+            </Link>
+          </Button>
+          <Button
+            size="small"
+            variant="transparent"
+            onClick={onDelete}
+            className="text-ui-fg-error"
+          >
+            <Trash />
+          </Button>
+        </div>
+      </div>
+      <Field label="Default value" value={fmtNumber(goal.default_value)} />
+      <Field
+        label="Value from event"
+        value={goal.value_from_event ? "Yes" : "No"}
+      />
+      <Field label="Website" value={goal.website_id || "All sites"} />
+    </Container>
+  )
+}
+
+function CountersSection({ goal }: { goal: ConversionGoal }) {
+  const meta = (goal.metadata || {}) as Record<string, any>
+  const count = meta.current_count ?? 0
+  const value = meta.current_value ?? 0
+  const last = meta.last_conversion_at as string | undefined
+  return (
+    <Container className="divide-y p-0">
+      <div className="px-6 py-4">
+        <Heading level="h2">Counters</Heading>
+        <Text size="small" className="text-ui-fg-subtle mt-1">
+          Tracked by track-conversion's updateGoalsStep on each matching
+          conversion.
+        </Text>
+      </div>
+      <Field label="Conversions" value={String(count)} />
+      <Field label="Total value" value={fmtNumber(value)} />
+      <Field
+        label="Last conversion"
+        value={last ? new Date(last).toLocaleString() : "—"}
+      />
+    </Container>
+  )
+}
+
+function ConditionsSection({ goal }: { goal: ConversionGoal }) {
+  const c = (goal.conditions || {}) as Record<string, any>
+  const empty = Object.keys(c).every(
+    (k) => c[k] === undefined || c[k] === null || c[k] === ""
+  )
+  return (
+    <Container className="divide-y p-0">
+      <div className="px-6 py-4">
+        <Heading level="h2">Conditions</Heading>
+        <Text size="small" className="text-ui-fg-subtle mt-1">
+          AND-ed during goal matching.
+        </Text>
+      </div>
+      {empty ? (
+        <div className="px-6 py-4">
+          <Text size="small" className="text-ui-fg-subtle">
+            No conditions set — this goal matches by goal_type alone.
+          </Text>
+        </div>
+      ) : (
+        <>
+          <Field label="Event name" value={c.event_name || "—"} />
+          <Field label="Pathname pattern" value={c.pathname_pattern || "—"} />
+          <Field
+            label="Min time on page (s)"
+            value={fmtNumber(c.min_time_seconds)}
+          />
+          <Field
+            label="Min scroll (%)"
+            value={fmtNumber(c.min_scroll_percent)}
+          />
+          {c.custom_conditions && (
+            <FieldBlock
+              label="Custom conditions"
+              value={JSON.stringify(c.custom_conditions, null, 2)}
+              mono
+            />
+          )}
+        </>
+      )}
+    </Container>
+  )
+}
+
+function GoogleAdsMappingSection({ goal }: { goal: ConversionGoal }) {
+  const meta = (goal.metadata || {}) as Record<string, any>
+  const ga = (meta.google_ads || {}) as Record<string, any>
+  const customer = ga.customer_id as string | undefined
+  const action = ga.conversion_action as string | undefined
+  const mapped = !!(customer || action)
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div>
+          <Heading level="h2">Google Ads mapping</Heading>
+          <Text size="small" className="text-ui-fg-subtle mt-1">
+            Per-goal overrides for conversion uploads. Falls back to platform
+            default when blank.
+          </Text>
+        </div>
+        <div className="flex items-center gap-x-2">
+          <StatusBadge color={mapped ? "green" : "grey"}>
+            {mapped ? "mapped" : "not mapped"}
+          </StatusBadge>
+          <Button asChild size="small" variant="secondary">
+            <Link to="google-ads-mapping">
+              <Key /> Edit mapping
+            </Link>
+          </Button>
+        </div>
+      </div>
+      <Field label="Customer (CID)" value={customer || "— platform default"} mono />
+      <Field
+        label="Conversion action"
+        value={action || "— platform default"}
+        mono
+      />
+    </Container>
+  )
+}
+
+function Field({
+  label,
+  value,
+  mono,
+}: {
+  label: string
+  value: string
+  mono?: boolean
+}) {
+  return (
+    <div className="text-ui-fg-subtle grid grid-cols-2 items-center px-6 py-4">
+      <Text size="small" leading="compact" weight="plus">
+        {label}
+      </Text>
+      <Text
+        size="small"
+        leading="compact"
+        className={mono ? "font-mono truncate" : "truncate"}
+        title={value}
+      >
+        {value || "—"}
+      </Text>
+    </div>
+  )
+}
+
+function FieldBlock({
+  label,
+  value,
+  mono,
+}: {
+  label: string
+  value: string
+  mono?: boolean
+}) {
+  return (
+    <div className="text-ui-fg-subtle flex flex-col gap-y-1 px-6 py-4">
+      <Text size="small" leading="compact" weight="plus">
+        {label}
+      </Text>
+      <pre
+        className={`${mono ? "font-mono" : ""} text-xs whitespace-pre-wrap break-all`}
+      >
+        {value}
+      </pre>
+    </div>
+  )
+}
+
+function fmtNumber(v: any): string {
+  if (v == null) return "—"
+  const n = Number(v)
+  return Number.isFinite(n) ? n.toLocaleString() : String(v)
+}
+
+export default ConversionGoalDetailPage
+
+export const handle = {
+  breadcrumb: (match: UIMatch<{ id: string }>) =>
+    match.params.id || "Detail",
+}

--- a/apps/backend/src/admin/routes/ad-planning/goals/create/page.tsx
+++ b/apps/backend/src/admin/routes/ad-planning/goals/create/page.tsx
@@ -1,0 +1,30 @@
+import { Container, Heading, Text } from "@medusajs/ui"
+import { useNavigate, UIMatch } from "react-router-dom"
+import { GoalForm } from "../../../../components/ad-planning/goals/goal-form"
+
+export default function CreateGoalPage() {
+  const navigate = useNavigate()
+
+  return (
+    <Container className="p-0 divide-y">
+      <div className="px-6 py-4">
+        <Heading level="h2">Create goal</Heading>
+        <Text size="small" className="text-ui-fg-subtle mt-1">
+          Define a new conversion goal. After creation you can wire its
+          Google Ads mapping from the detail page.
+        </Text>
+      </div>
+      <GoalForm
+        mode="create"
+        onCancel={() => navigate("/ad-planning/goals")}
+        onSuccess={(goalId) =>
+          navigate(`/ad-planning/goals/${goalId}`, { replace: true })
+        }
+      />
+    </Container>
+  )
+}
+
+export const handle = {
+  breadcrumb: () => "Create",
+}

--- a/apps/backend/src/admin/routes/ad-planning/goals/page.tsx
+++ b/apps/backend/src/admin/routes/ad-planning/goals/page.tsx
@@ -1,0 +1,237 @@
+/**
+ * Conversion Goals List Page
+ *
+ * Lists all goals with filters and a row-level link to detail. The Google
+ * Ads mapping configured per goal lives on goal.metadata.google_ads.* and
+ * is edited from the detail page — not from this list, since the picker
+ * needs context (CID/conversion-action lookups) that's only meaningful one
+ * goal at a time.
+ */
+
+import { defineRouteConfig } from "@medusajs/admin-sdk"
+import {
+  Badge,
+  Button,
+  Container,
+  Heading,
+  Select,
+  StatusBadge,
+  Text,
+  DataTable,
+  createDataTableColumnHelper,
+  useDataTable,
+  type DataTablePaginationState,
+} from "@medusajs/ui"
+import { Plus } from "@medusajs/icons"
+import { useQuery } from "@tanstack/react-query"
+import { useMemo, useState } from "react"
+import { Link } from "react-router-dom"
+import { sdk } from "../../../lib/config"
+
+type ConversionGoal = {
+  id: string
+  name: string
+  description: string | null
+  goal_type: string
+  is_active: boolean
+  priority: number
+  default_value: number | null
+  value_from_event: boolean
+  website_id: string | null
+  conditions: Record<string, any> | null
+  metadata: Record<string, any> | null
+  created_at: string
+  updated_at: string
+}
+
+const GOAL_TYPE_COLORS: Record<
+  string,
+  "green" | "blue" | "orange" | "purple" | "grey" | "red"
+> = {
+  purchase: "green",
+  lead_form: "blue",
+  add_to_cart: "orange",
+  page_view: "grey",
+  time_on_page: "grey",
+  scroll_depth: "purple",
+  custom_event: "grey",
+}
+
+const GOAL_TYPES = [
+  { value: "all", label: "All types" },
+  { value: "purchase", label: "Purchase" },
+  { value: "lead_form", label: "Lead form" },
+  { value: "add_to_cart", label: "Add to cart" },
+  { value: "page_view", label: "Page view" },
+  { value: "time_on_page", label: "Time on page" },
+  { value: "scroll_depth", label: "Scroll depth" },
+  { value: "custom_event", label: "Custom event" },
+]
+
+const columnHelper = createDataTableColumnHelper<ConversionGoal>()
+
+const ConversionGoalsPage = () => {
+  const [pagination, setPagination] = useState<DataTablePaginationState>({
+    pageIndex: 0,
+    pageSize: 20,
+  })
+  const [typeFilter, setTypeFilter] = useState<string>("all")
+
+  const limit = pagination.pageSize
+  const offset = pagination.pageIndex * limit
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["ad-planning", "goals", limit, offset, typeFilter],
+    queryFn: async () => {
+      const params = new URLSearchParams({
+        limit: String(limit),
+        offset: String(offset),
+      })
+      if (typeFilter !== "all") {
+        params.set("goal_type", typeFilter)
+      }
+      return sdk.client.fetch<{ goals: ConversionGoal[]; count: number }>(
+        `/admin/ad-planning/goals?${params}`,
+        { method: "GET" }
+      )
+    },
+  })
+
+  const columns = useMemo(
+    () => [
+      columnHelper.accessor("name", {
+        header: "Name",
+        cell: ({ getValue, row }) => (
+          <Link to={`/ad-planning/goals/${row.original.id}`}>
+            <Text
+              size="small"
+              leading="compact"
+              weight="plus"
+              className="text-ui-fg-interactive hover:underline"
+            >
+              {getValue()}
+            </Text>
+          </Link>
+        ),
+      }),
+      columnHelper.accessor("goal_type", {
+        header: "Type",
+        cell: ({ getValue }) => {
+          const type = getValue()
+          return (
+            <Badge color={GOAL_TYPE_COLORS[type] || "grey"} size="xsmall">
+              {type.replace(/_/g, " ")}
+            </Badge>
+          )
+        },
+      }),
+      columnHelper.accessor("is_active", {
+        header: "Status",
+        cell: ({ getValue }) => (
+          <StatusBadge color={getValue() ? "green" : "grey"}>
+            {getValue() ? "active" : "inactive"}
+          </StatusBadge>
+        ),
+      }),
+      columnHelper.accessor("priority", {
+        header: "Priority",
+        cell: ({ getValue }) => (
+          <Text size="small" leading="compact">
+            {getValue()}
+          </Text>
+        ),
+      }),
+      columnHelper.accessor("metadata", {
+        header: "Conversions (count)",
+        cell: ({ getValue }) => {
+          const m = (getValue() || {}) as Record<string, any>
+          return (
+            <Text size="small" leading="compact" weight="plus">
+              {m.current_count ?? 0}
+            </Text>
+          )
+        },
+      }),
+      columnHelper.accessor("metadata", {
+        header: "Google Ads",
+        id: "google_ads_mapping",
+        cell: ({ getValue }) => {
+          const m = (getValue() || {}) as Record<string, any>
+          const ga = (m.google_ads || {}) as Record<string, any>
+          const mapped = !!(ga.conversion_action || ga.customer_id)
+          return mapped ? (
+            <Badge color="green" size="2xsmall">
+              Mapped
+            </Badge>
+          ) : (
+            <Text size="small" leading="compact" className="text-ui-fg-muted">
+              —
+            </Text>
+          )
+        },
+      }),
+    ],
+    []
+  )
+
+  const table = useDataTable({
+    data: data?.goals || [],
+    columns,
+    getRowId: (g) => g.id,
+    rowCount: data?.count || 0,
+    isLoading,
+    pagination: {
+      state: pagination,
+      onPaginationChange: setPagination,
+    },
+  })
+
+  return (
+    <div className="flex flex-col gap-y-3">
+      <Container className="divide-y p-0">
+        <div className="flex items-center justify-between px-6 py-4">
+          <div>
+            <Heading level="h2">Conversion goals</Heading>
+            <Text size="small" className="text-ui-fg-subtle mt-1">
+              Define what counts as a conversion. Per-goal Google Ads mapping
+              overrides the platform default during upload.
+            </Text>
+          </div>
+          <div className="flex items-center gap-x-2">
+            <Select value={typeFilter} onValueChange={setTypeFilter}>
+              <Select.Trigger className="w-[180px]">
+                <Select.Value placeholder="All types" />
+              </Select.Trigger>
+              <Select.Content>
+                {GOAL_TYPES.map((opt) => (
+                  <Select.Item key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </Select.Item>
+                ))}
+              </Select.Content>
+            </Select>
+            <Button asChild size="small" variant="primary">
+              <Link to="/ad-planning/goals/create">
+                <Plus /> Create goal
+              </Link>
+            </Button>
+          </div>
+        </div>
+        <DataTable instance={table}>
+          <DataTable.Table />
+          <DataTable.Pagination />
+        </DataTable>
+      </Container>
+    </div>
+  )
+}
+
+export const config = defineRouteConfig({
+  label: "Goals",
+})
+
+export const handle = {
+  breadcrumb: () => "Goals",
+}
+
+export default ConversionGoalsPage

--- a/apps/backend/src/admin/routes/settings/external-platforms/[id]/@google-ads-defaults/page.tsx
+++ b/apps/backend/src/admin/routes/settings/external-platforms/[id]/@google-ads-defaults/page.tsx
@@ -1,0 +1,28 @@
+import { useParams, useLoaderData } from "react-router-dom"
+import { Heading } from "@medusajs/ui"
+import { RouteDrawer } from "../../../../../components/modal/route-drawer/route-drawer"
+import { GoogleAdsDefaultsForm } from "../../../../../components/social-platforms/google/google-ads-defaults-form"
+import { useSocialPlatform } from "../../../../../hooks/api/social-platforms"
+import { socialPlatformLoader } from "../loader"
+
+export default function GoogleAdsDefaultsDrawerPage() {
+  const { id } = useParams()
+  const initialData = useLoaderData() as Awaited<
+    ReturnType<typeof socialPlatformLoader>
+  >
+
+  const { socialPlatform, isLoading } = useSocialPlatform(id!, { initialData })
+
+  if (isLoading || !socialPlatform) {
+    return null
+  }
+
+  return (
+    <RouteDrawer>
+      <RouteDrawer.Header>
+        <Heading>Google Ads upload defaults</Heading>
+      </RouteDrawer.Header>
+      <GoogleAdsDefaultsForm platform={socialPlatform} />
+    </RouteDrawer>
+  )
+}

--- a/apps/backend/src/api/admin/ad-planning/conversions/[id]/google-upload/route.ts
+++ b/apps/backend/src/api/admin/ad-planning/conversions/[id]/google-upload/route.ts
@@ -1,0 +1,81 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { AD_PLANNING_MODULE } from "../../../../../../modules/ad-planning"
+import { SOCIALS_MODULE } from "../../../../../../modules/socials"
+import { uploadGoogleAdsConversionWorkflow } from "../../../../../../workflows/google-ads/upload-conversion"
+
+type RetryBody = {
+  /**
+   * Optional override — when omitted we resolve in this order:
+   *   1. conversion.metadata.google_ads_platform_id
+   *   2. The single google-category SocialPlatform with upload defaults set
+   */
+  platform_id?: string
+}
+
+/**
+ * POST /admin/ad-planning/conversions/:id/google-upload
+ *
+ * Manually re-runs the Google Ads conversion upload for this conversion.
+ * Same workflow the conversion-created subscriber dispatches, exposed as
+ * an admin action so operators can retry after fixing config without
+ * waiting for a new conversion.
+ *
+ * Returns the upload result so the UI can render the status without
+ * re-fetching the conversion to pick up the metadata stamps. The metadata
+ * is also written by the workflow itself for the next page load.
+ */
+export const POST = async (
+  req: MedusaRequest<RetryBody>,
+  res: MedusaResponse
+) => {
+  const { id } = req.params
+  const body = (req.body || {}) as RetryBody
+
+  const adPlanning = req.scope.resolve(AD_PLANNING_MODULE) as any
+  const [conversion] = await adPlanning.listConversions({ id })
+  if (!conversion) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Conversion ${id} not found`
+    )
+  }
+
+  const meta = (conversion.metadata || {}) as Record<string, any>
+
+  const platformId =
+    body.platform_id?.trim() ||
+    meta.google_ads_platform_id ||
+    (await resolveSinglePlatform(req.scope))
+
+  if (!platformId) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "Could not resolve a Google platform — pass platform_id, set conversion.metadata.google_ads_platform_id, or configure upload defaults on exactly one google platform"
+    )
+  }
+
+  const { result } = await uploadGoogleAdsConversionWorkflow(req.scope).run({
+    input: {
+      platform_id: platformId,
+      conversion_id: id,
+    },
+  })
+
+  res.status(200).json(result)
+}
+
+async function resolveSinglePlatform(scope: any): Promise<string | null> {
+  const socials = scope.resolve(SOCIALS_MODULE) as any
+  const candidates = await socials.listSocialPlatforms(
+    { category: "google" },
+    { take: 10 }
+  )
+  const eligible = candidates.filter((p: any) => {
+    const cfg = (p.api_config || {}) as Record<string, any>
+    if (!cfg.developer_token_encrypted) return false
+    const ga = (cfg.google_ads || {}) as Record<string, any>
+    return !!(ga.default_customer_id || ga.default_conversion_action)
+  })
+  return eligible.length === 1 ? eligible[0].id : null
+}

--- a/apps/backend/src/api/admin/social-platforms/[id]/google/ads/conversion-actions/route.ts
+++ b/apps/backend/src/api/admin/social-platforms/[id]/google/ads/conversion-actions/route.ts
@@ -1,0 +1,35 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { listGoogleAdsConversionActionsWorkflow } from "../../../../../../../workflows/google-ads/list-conversion-actions"
+
+/**
+ * GET /admin/social-platforms/:id/google/ads/conversion-actions?customer_id=...
+ *
+ * Live GAQL pull of `conversion_action` rows for one CID. Used by the
+ * upload-defaults picker — operators can't be expected to memorize Google
+ * resource names like `customers/1234567890/conversionActions/9876543`.
+ *
+ * `customer_id` is required: conversion actions are scoped per CID, and
+ * iterating across all bound CIDs would be expensive and rarely what the
+ * caller wants.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const customerId = (req.query?.customer_id as string)?.trim()
+  if (!customerId) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "customer_id query param is required"
+    )
+  }
+
+  const { result } = await listGoogleAdsConversionActionsWorkflow(
+    req.scope
+  ).run({
+    input: {
+      platform_id: req.params.id,
+      customer_id: customerId,
+    },
+  })
+
+  res.status(200).json(result)
+}

--- a/apps/backend/src/workflows/google-ads/list-conversion-actions.ts
+++ b/apps/backend/src/workflows/google-ads/list-conversion-actions.ts
@@ -1,0 +1,46 @@
+import {
+  createWorkflow,
+  WorkflowData,
+  WorkflowResponse,
+  transform,
+} from "@medusajs/framework/workflows-sdk"
+import { refreshGoogleTokenStep } from "../google/steps/refresh-google-token"
+import {
+  listConversionActionsStep,
+  type ListConversionActionsOutput,
+} from "./steps/list-conversion-actions-step"
+
+export type ListConversionActionsWorkflowInput = {
+  platform_id: string
+  customer_id: string
+}
+
+export const listGoogleAdsConversionActionsWorkflowId =
+  "list-google-ads-conversion-actions-workflow"
+
+/**
+ * Read-side companion to `syncGoogleAdsWorkflow` — refreshes the access
+ * token (no-op when fresh) and pulls conversion_action rows for one CID.
+ * Used by the platform-defaults picker and (future) per-goal mapping UI.
+ */
+export const listGoogleAdsConversionActionsWorkflow = createWorkflow(
+  listGoogleAdsConversionActionsWorkflowId,
+  function (input: WorkflowData<ListConversionActionsWorkflowInput>) {
+    const refreshed = refreshGoogleTokenStep({
+      platform_id: input.platform_id,
+      force: false,
+    })
+
+    const stepInput = transform(
+      { input, refreshed },
+      ({ input, refreshed }) => ({
+        platform_id: input.platform_id,
+        customer_id: input.customer_id,
+        access_token: refreshed.access_token,
+      })
+    )
+
+    const result = listConversionActionsStep(stepInput)
+    return new WorkflowResponse<ListConversionActionsOutput>(result)
+  }
+)

--- a/apps/backend/src/workflows/google-ads/steps/list-conversion-actions-step.ts
+++ b/apps/backend/src/workflows/google-ads/steps/list-conversion-actions-step.ts
@@ -1,0 +1,160 @@
+import axios from "axios"
+import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+} from "@medusajs/framework/utils"
+import type { Logger } from "@medusajs/types"
+import { SOCIALS_MODULE } from "../../../modules/socials"
+import { ENCRYPTION_MODULE } from "../../../modules/encryption"
+import type EncryptionService from "../../../modules/encryption/service"
+import { withGoogleRetry } from "../../../modules/social-provider/google-retry"
+
+export type ListConversionActionsInput = {
+  platform_id: string
+  customer_id: string
+  /** From the upstream refreshGoogleTokenStep */
+  access_token: string
+}
+
+export type ConversionActionRow = {
+  /** Full Google resource name — what the operator pastes into goal/platform config */
+  resource_name: string
+  /** Numeric ID for picker stable keys */
+  conversion_action_id: string
+  name: string
+  type: string | null
+  status: string | null
+  category: string | null
+  /** Whether the action contributes to "Conversions" metric in Ads UI */
+  include_in_conversions_metric: boolean | null
+}
+
+export type ListConversionActionsOutput = {
+  customer_id: string
+  conversion_actions: ConversionActionRow[]
+}
+
+const ADS_API_BASE = "https://googleads.googleapis.com/v24"
+
+const QUERY = `
+  SELECT
+    conversion_action.id,
+    conversion_action.resource_name,
+    conversion_action.name,
+    conversion_action.type,
+    conversion_action.status,
+    conversion_action.category,
+    conversion_action.include_in_conversions_metric
+  FROM conversion_action
+`.replace(/\s+/g, " ").trim()
+
+/**
+ * Read-only GAQL fetch of `conversion_action` for one CID. Backs the
+ * conversion-action picker on the platform-defaults drawer and the
+ * (future) per-goal mapping drawer in ad-planning.
+ *
+ * Why GAQL instead of a REST list endpoint: Google Ads doesn't expose a
+ * REST `list` for conversion_action — only searchStream/search via GAQL.
+ *
+ * Returns both the resource_name (what callers will store) and the numeric
+ * id (for stable picker keys). Order is whatever Google returns; the UI
+ * sorts as needed.
+ */
+export const listConversionActionsStep = createStep(
+  "list-google-ads-conversion-actions-step",
+  async (input: ListConversionActionsInput, { container }) => {
+    const socials = container.resolve(SOCIALS_MODULE) as any
+    const encryption = container.resolve(ENCRYPTION_MODULE) as EncryptionService
+    const logger = container.resolve(ContainerRegistrationKeys.LOGGER) as Logger
+
+    const developerToken = await readDeveloperToken(
+      input.platform_id,
+      socials,
+      encryption
+    )
+    if (!developerToken) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "Google Ads requires a developer token on the platform row"
+      )
+    }
+
+    try {
+      const response = await withGoogleRetry(
+        () =>
+          axios.post(
+            `${ADS_API_BASE}/customers/${input.customer_id}/googleAds:searchStream`,
+            { query: QUERY },
+            {
+              headers: {
+                Authorization: `Bearer ${input.access_token}`,
+                "developer-token": developerToken,
+                "Content-Type": "application/json",
+              },
+            }
+          ),
+        {
+          label: `ads.conversionActions.list(${input.customer_id})`,
+          logger,
+          maxAttempts: 3,
+        }
+      )
+
+      const rows = extractAllRows(response.data)
+      const out: ConversionActionRow[] = rows.map((r) => {
+        const ca = r.conversionAction || r.conversion_action || {}
+        return {
+          resource_name: ca.resourceName || ca.resource_name || "",
+          conversion_action_id: String(ca.id ?? ""),
+          name: ca.name || "",
+          type: ca.type ?? null,
+          status: ca.status ?? null,
+          category: ca.category ?? null,
+          include_in_conversions_metric:
+            ca.includeInConversionsMetric ??
+            ca.include_in_conversions_metric ??
+            null,
+        }
+      })
+
+      return new StepResponse<ListConversionActionsOutput>({
+        customer_id: input.customer_id,
+        conversion_actions: out,
+      })
+    } catch (e: any) {
+      const msg = e.response?.data?.error?.message || e.message
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Google Ads conversion_action list failed: ${msg}`
+      )
+    }
+  }
+)
+
+function extractAllRows(data: any): any[] {
+  if (!data) return []
+  if (Array.isArray(data)) {
+    return data.flatMap((chunk) => chunk?.results || [])
+  }
+  return data.results || []
+}
+
+async function readDeveloperToken(
+  platform_id: string,
+  socials: any,
+  encryption: EncryptionService
+): Promise<string | null> {
+  const [platform] = await socials.listSocialPlatforms(
+    { id: platform_id },
+    { take: 1 }
+  )
+  if (!platform) return null
+  const apiConfig = (platform.api_config || {}) as Record<string, any>
+  if (!apiConfig.developer_token_encrypted) return null
+  try {
+    return encryption.decrypt(apiConfig.developer_token_encrypted)
+  } catch {
+    return null
+  }
+}

--- a/apps/backend/test-shims/tokenx.cjs
+++ b/apps/backend/test-shims/tokenx.cjs
@@ -1,0 +1,218 @@
+/**
+ * CJS shim for `tokenx` — used in Jest tests only.
+ *
+ * Why this exists:
+ *   tokenx@1.x ships exclusively as ESM (.mjs + "type": "module" in its
+ *   package.json). @mastra/core's CJS bundle does `require('tokenx')`
+ *   from a CJS context, which Node and Jest both reject with
+ *   ERR_REQUIRE_ESM. Jest 29's `unstable_shouldLoadAsEsm` check throws
+ *   BEFORE our @swc/jest .mjs transform gets a chance to run, so the
+ *   transform-based fix from PR #166 / commit 37e763935 doesn't help here.
+ *
+ * Production isn't affected — Node's native ESM bridge handles
+ * tokenx fine when running the actual server.
+ *
+ * This file is a verbatim CJS port of tokenx@1.3.0/dist/index.mjs. If
+ * tokenx upgrades and changes its API, update this shim alongside the
+ * pnpm-lock bump.
+ */
+
+const PATTERNS = {
+  whitespace: /^\s+$/,
+  cjk: /[\u4E00-\u9FFF\u3400-\u4DBF\u3000-\u303F\uFF00-\uFFEF\u30A0-\u30FF\u2E80-\u2EFF\u31C0-\u31EF\u3200-\u32FF\u3300-\u33FF\uAC00-\uD7AF\u1100-\u11FF\u3130-\u318F\uA960-\uA97F\uD7B0-\uD7FF]/,
+  numeric: /^\d+(?:[.,]\d+)*$/,
+  punctuation: /[.,!?;(){}[\]<>:/\\|@#$%^&*+=`~_-]/,
+  alphanumeric: /^[a-zA-Z0-9À-ÖØ-öø-ÿ]+$/,
+}
+const TOKEN_SPLIT_PATTERN = new RegExp(
+  `(\\s+|${PATTERNS.punctuation.source}+)`
+)
+const DEFAULT_CHARS_PER_TOKEN = 6
+const SHORT_TOKEN_THRESHOLD = 3
+const DEFAULT_LANGUAGE_CONFIGS = [
+  { pattern: /[äöüßẞ]/i, averageCharsPerToken: 3 },
+  { pattern: /[éèêëàâîïôûùüÿçœæáíóúñ]/i, averageCharsPerToken: 3 },
+  { pattern: /[ąćęłńóśźżěščřžýůúďťň]/i, averageCharsPerToken: 3.5 },
+]
+
+function isWithinTokenLimit(text, tokenLimit, options) {
+  return estimateTokenCount(text, options) <= tokenLimit
+}
+
+function estimateTokenCount(text, options = {}) {
+  if (!text) return 0
+  const {
+    defaultCharsPerToken = DEFAULT_CHARS_PER_TOKEN,
+    languageConfigs = DEFAULT_LANGUAGE_CONFIGS,
+  } = options
+  const segments = text.split(TOKEN_SPLIT_PATTERN).filter(Boolean)
+  let tokenCount = 0
+  for (const segment of segments)
+    tokenCount += estimateSegmentTokens(
+      segment,
+      languageConfigs,
+      defaultCharsPerToken
+    )
+  return tokenCount
+}
+
+const approximateTokenSize = estimateTokenCount
+
+function sliceByTokens(text, start = 0, end, options = {}) {
+  if (!text) return ""
+  const {
+    defaultCharsPerToken = DEFAULT_CHARS_PER_TOKEN,
+    languageConfigs = DEFAULT_LANGUAGE_CONFIGS,
+  } = options
+  let totalTokens = 0
+  if (start < 0 || (end !== void 0 && end < 0))
+    totalTokens = estimateTokenCount(text, options)
+  const normalizedStart =
+    start < 0 ? Math.max(0, totalTokens + start) : Math.max(0, start)
+  const normalizedEnd =
+    end === void 0
+      ? Infinity
+      : end < 0
+        ? Math.max(0, totalTokens + end)
+        : end
+  if (normalizedStart >= normalizedEnd) return ""
+  const segments = text.split(TOKEN_SPLIT_PATTERN).filter(Boolean)
+  const parts = []
+  let currentTokenPos = 0
+  for (const segment of segments) {
+    if (currentTokenPos >= normalizedEnd) break
+    const tokenCount = estimateSegmentTokens(
+      segment,
+      languageConfigs,
+      defaultCharsPerToken
+    )
+    const extracted = extractSegmentPart(
+      segment,
+      currentTokenPos,
+      tokenCount,
+      normalizedStart,
+      normalizedEnd
+    )
+    if (extracted) parts.push(extracted)
+    currentTokenPos += tokenCount
+  }
+  return parts.join("")
+}
+
+function splitByTokens(text, tokensPerChunk, options = {}) {
+  if (!text || tokensPerChunk <= 0) return []
+  const {
+    defaultCharsPerToken = DEFAULT_CHARS_PER_TOKEN,
+    languageConfigs = DEFAULT_LANGUAGE_CONFIGS,
+    overlap = 0,
+  } = options
+  const segments = text.split(TOKEN_SPLIT_PATTERN).filter(Boolean)
+  const chunks = []
+  let currentChunk = []
+  let currentTokenCount = 0
+  for (const segment of segments) {
+    const tokenCount = estimateSegmentTokens(
+      segment,
+      languageConfigs,
+      defaultCharsPerToken
+    )
+    currentChunk.push(segment)
+    currentTokenCount += tokenCount
+    if (currentTokenCount >= tokensPerChunk) {
+      chunks.push(currentChunk.join(""))
+      if (overlap > 0) {
+        const overlapSegments = []
+        let overlapTokenCount = 0
+        for (
+          let i = currentChunk.length - 1;
+          i >= 0 && overlapTokenCount < overlap;
+          i--
+        ) {
+          const segmentValue = currentChunk[i]
+          const tokCount = estimateSegmentTokens(
+            segmentValue,
+            languageConfigs,
+            defaultCharsPerToken
+          )
+          overlapSegments.unshift(segmentValue)
+          overlapTokenCount += tokCount
+        }
+        currentChunk = overlapSegments
+        currentTokenCount = overlapTokenCount
+      } else {
+        currentChunk = []
+        currentTokenCount = 0
+      }
+    }
+  }
+  if (currentChunk.length > 0) chunks.push(currentChunk.join(""))
+  return chunks
+}
+
+function estimateSegmentTokens(
+  segment,
+  languageConfigs,
+  defaultCharsPerToken
+) {
+  if (PATTERNS.whitespace.test(segment)) return 0
+  if (PATTERNS.cjk.test(segment)) return getCharacterCount(segment)
+  if (PATTERNS.numeric.test(segment)) return 1
+  if (segment.length <= SHORT_TOKEN_THRESHOLD) return 1
+  if (PATTERNS.punctuation.test(segment))
+    return segment.length > 1 ? Math.ceil(segment.length / 2) : 1
+  if (PATTERNS.alphanumeric.test(segment)) {
+    const charsPerToken =
+      getLanguageSpecificCharsPerToken(segment, languageConfigs) ??
+      defaultCharsPerToken
+    return Math.ceil(segment.length / charsPerToken)
+  }
+  const charsPerToken =
+    getLanguageSpecificCharsPerToken(segment, languageConfigs) ??
+    defaultCharsPerToken
+  return Math.ceil(segment.length / charsPerToken)
+}
+
+function getLanguageSpecificCharsPerToken(segment, languageConfigs) {
+  for (const config of languageConfigs)
+    if (config.pattern.test(segment)) return config.averageCharsPerToken
+}
+
+function getCharacterCount(text) {
+  return Array.from(text).length
+}
+
+function extractSegmentPart(
+  segment,
+  segmentTokenStart,
+  segmentTokenCount,
+  targetStart,
+  targetEnd
+) {
+  if (segmentTokenCount === 0)
+    return segmentTokenStart >= targetStart && segmentTokenStart < targetEnd
+      ? segment
+      : ""
+  const segmentTokenEnd = segmentTokenStart + segmentTokenCount
+  if (segmentTokenStart >= targetEnd || segmentTokenEnd <= targetStart) return ""
+  const overlapStart = Math.max(0, targetStart - segmentTokenStart)
+  const overlapEnd = Math.min(
+    segmentTokenCount,
+    targetEnd - segmentTokenStart
+  )
+  if (overlapStart === 0 && overlapEnd === segmentTokenCount) return segment
+  const charStart = Math.floor(
+    (overlapStart / segmentTokenCount) * segment.length
+  )
+  const charEnd = Math.ceil(
+    (overlapEnd / segmentTokenCount) * segment.length
+  )
+  return segment.slice(charStart, charEnd)
+}
+
+module.exports = {
+  approximateTokenSize,
+  estimateTokenCount,
+  isWithinTokenLimit,
+  sliceByTokens,
+  splitByTokens,
+}


### PR DESCRIPTION
## Summary

Follow-up to the merged #203 — three coordinated UI surfaces that make the Google Ads pipeline fully self-serve from the admin (no more curl/DB to configure uploads or debug failures).

| # | Commit | What it does |
|---|---|---|
| 1 | `feat(google-ads)` defaults | Drawer to configure per-platform upload defaults — CID picker (from synced rows), conversion-action picker (live GAQL fetch), validate-only toggle for dry-run |
| 2 | `feat(ad-planning)` conversion detail | Full detail page at `/ad-planning/conversions/:id` with Google Ads upload status (uploaded / error / skipped / pending), error/skip-reason rendering, partial-failure JSON, "Retry upload" action |
| 3 | `feat(ad-planning)` goals | Goals admin from scratch — list + create + detail + edit drawer + Google Ads mapping drawer with platform/CID/conversion-action pickers |

Together these close the loop on PR #203's known gaps: the per-goal `metadata.google_ads.{customer_id, conversion_action}` mapping (read by `uploadGoogleAdsConversionStep`) is now configurable from the UI, and operators can see upload status + retry without DB access.

## New backend surfaces

- `GET /admin/social-platforms/:id/google/ads/conversion-actions?customer_id=X` — GAQL `FROM conversion_action`, used by both the platform-defaults drawer and the per-goal mapping drawer
- `POST /admin/ad-planning/conversions/:id/google-upload` — manual retry endpoint that resolves `platform_id` from body → conversion metadata → single eligible google platform

## New admin routes

- `[platform-id]/google-ads-defaults` — RouteDrawer for platform-level upload defaults
- `/ad-planning/conversions/:id` — conversion detail page (linked from list via Type badge)
- `/ad-planning/goals` — goals list with type filter and "Mapped" badge column
- `/ad-planning/goals/create` — create page using shared GoalForm
- `/ad-planning/goals/:id` — goal detail with general / counters / conditions / Google Ads mapping sections
- `/ad-planning/goals/:id/edit` — full edit drawer
- `/ad-planning/goals/:id/google-ads-mapping` — per-goal Google Ads mapping drawer

## Notable design choices

**Goal mapping doesn't store `platform_id`.** The customer_id and conversion_action resource_name uniquely identify the Google Ads target (a CID is bound to exactly one platform). The drawer needs platform_id only to scope the picker queries; it isn't persisted on the goal.

**Auto-select single eligible platform.** When exactly one google-category platform has a developer token, both the goal-mapping drawer and the conversion-retry endpoint default to it — matching the conversion-created subscriber's existing behavior.

**Top-level JSON merge preservation.** Both forms (platform defaults, per-goal mapping) spread the existing nested object (`api_config.google_ads` / `metadata.google_ads`) before overwriting, so future fields aren't wiped on save.

**`GoalForm` is callback-driven.** Takes `onCancel`/`onSuccess` props instead of using `useRouteModal` directly, so it works equally inside the edit drawer and as a standalone create page (which has no drawer context).

## Test plan

- [ ] Visit a connected Google platform → see the new "Edit defaults" button + status badge in the Google Ads data section
- [ ] Click Edit defaults → pick a CID → conversion-action picker populates from Google → save → status badge flips to green
- [ ] Toggle validate-only → save → "Dry run" badge appears
- [ ] Visit `/ad-planning/conversions` → click a Type badge → detail page renders with platform-aware Google Ads section
- [ ] On a conversion with `metadata.google_ads_uploaded_at` → status badge reads "uploaded"
- [ ] On a conversion with `metadata.google_ads_upload_error` → "Retry upload" succeeds and status flips
- [ ] Visit `/ad-planning/goals` → create a goal → detail page renders → Edit drawer round-trips → delete works
- [ ] On a detail page, open Google Ads mapping → pick CID + conversion-action → save → "mapped" badge on detail page and on list
- [ ] Trigger a conversion that matches the goal → confirm `metadata.google_ads_matched_goal_id` records the goal id
- [ ] `pnpm tsc --noEmit` clean (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)