### PR TITLE
fix(partner-decline): NOT_FOUND on cross-partner; dispatch bRun in spec

### DIFF
--- a/apps/backend/integration-tests/http/partners-decline-run.spec.ts
+++ b/apps/backend/integration-tests/http/partners-decline-run.spec.ts
@@ -65,6 +65,40 @@ setupSharedTestSuite(() => {
       const a = await registerLoginCreatePartner(unique, "A")
       const b = await registerLoginCreatePartner(unique, "B")
 
+      // Templates required by start-dispatch / resume-dispatch so we can
+      // get bRun into "sent_to_partner" — the only status `assertCanAccept`
+      // allows. aRun stays at "approved" (decline doesn't gate on status).
+      const tplA = await api.post(
+        "/admin/task-templates",
+        {
+          name: `decline-step-a-${unique}`,
+          description: "decline spec step A",
+          priority: "medium",
+          estimated_duration: 30,
+          eventable: false,
+          notifiable: false,
+          metadata: { workflow_type: "production_run" },
+          category: "Production",
+        },
+        adminHeaders
+      )
+      expect(tplA.status).toBe(201)
+      const tplB = await api.post(
+        "/admin/task-templates",
+        {
+          name: `decline-step-b-${unique}`,
+          description: "decline spec step B",
+          priority: "medium",
+          estimated_duration: 30,
+          eventable: false,
+          notifiable: false,
+          metadata: { workflow_type: "production_run" },
+          category_id: tplA.data.task_template.category_id,
+        },
+        adminHeaders
+      )
+      expect(tplB.status).toBe(201)
+
       // Create a design and a parent run, then approve with both partners
       // assigned — gives us 2 child runs so we can decline one and keep
       // the other for the cross-partner + started checks.
@@ -161,6 +195,27 @@ setupSharedTestSuite(() => {
       // ── 6. Started run (started_at set) → 403, not allowed ──────────────
       // Accept + start Partner B's run so started_at is populated, then
       // try to decline — the route must refuse because work has begun.
+      // First, dispatch bRun to drive it to "sent_to_partner" so
+      // assertCanAccept passes (mirrors whatsapp-partner-flow.spec.ts).
+      const sd = await api.post(
+        `/admin/production-runs/${bRun.id}/start-dispatch`,
+        {},
+        adminHeaders
+      )
+      expect(sd.status).toBe(202)
+      const rd = await api.post(
+        `/admin/production-runs/${bRun.id}/resume-dispatch`,
+        { transaction_id: sd.data.transaction_id, template_names: [tplA.data.task_template.name, tplB.data.task_template.name] },
+        adminHeaders
+      )
+      expect(rd.status).toBe(200)
+      const dispatchDeadline = Date.now() + 15_000
+      while (Date.now() < dispatchDeadline) {
+        const r = await api.get(`/admin/production-runs/${bRun.id}`, adminHeaders)
+        if (String(r.data.production_run?.status) === "sent_to_partner") break
+        await new Promise((r) => setTimeout(r, 500))
+      }
+
       const accept = await api.post(
         `/partners/production-runs/${bRun.id}/accept`,
         {},

--- a/apps/backend/src/api/partners/production-runs/[id]/decline/route.ts
+++ b/apps/backend/src/api/partners/production-runs/[id]/decline/route.ts
@@ -73,10 +73,9 @@ export async function POST(
   }
 
   if (run.partner_id !== partnerId) {
-    throw new MedusaError(
-      MedusaError.Types.NOT_ALLOWED,
-      "This production run is not assigned to your partner account"
-    )
+    // Surface as NOT_FOUND so we don't leak that the run exists to a
+    // partner it isn't assigned to. Maps to 404 via Medusa's error handler.
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Production run not found")
   }
   if (run.status === "cancelled") {
     return res.json({ production_run: run, message: "Already cancelled" })


### PR DESCRIPTION
## Summary
- **Route**: `POST /partners/production-runs/:id/decline` now throws `MedusaError.Types.NOT_FOUND` (→ 404) instead of `NOT_ALLOWED` (→ 400) when partner B tries to decline a run assigned to partner A. Two reasons: (1) Medusa maps `NOT_ALLOWED` → 400, which both broke the test and violated the test's `[403, 404]` contract; (2) returning 404 doesn't leak the existence of another partner's run to an actor that shouldn't see it.
- **Spec**: `partners-decline-run.spec.ts` now creates task templates and runs `start-dispatch` + `resume-dispatch` for `bRun` before partner B accepts it. `assertCanAccept` only permits accept from `sent_to_partner`; the original test jumped approve → accept which fails the policy. `aRun` doesn't need dispatch since `decline` isn't status-gated. Mirrors the pattern in `whatsapp-partner-flow.spec.ts`.

The original test failed at the cross-partner check at line 138 and never validated anything past it — these two fixes are what was needed for the full assertion sequence to run green.

## Test plan
- [x] `pnpm test:integration:http:shared ./integration-tests/http/partners-decline-run.spec.ts` → PASS (6.7s)
- [ ] Spot-check that no other partner routes rely on the previous 400 behaviour for cross-partner ownership checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)