### PR TITLE
feat(marketing): metrics gains GMV + new websites endpoint

### DIFF
--- a/apps/backend/src/api/web/website/[domain]/marketing/metrics/route.ts
+++ b/apps/backend/src/api/web/website/[domain]/marketing/metrics/route.ts
@@ -1,13 +1,30 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
+import { AD_PLANNING_MODULE } from "../../../../../../modules/ad-planning"
+import { findWebsiteByDomainWorkflow } from "../../../../../../workflows/website/find-website-by-domain"
+
 type RawPartner = {
   workspace_type: "seller" | "manufacturer" | "individual"
   vercel_linked: boolean
 }
 
+const GMV_WINDOW_DAYS = 90
+const GMV_MAX_ROWS = 50000
+
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { domain } = req.params
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  // Resolve website for GMV scope. If the domain isn't registered we still
+  // return the partner counts — only GMV degrades.
+  let websiteId: string | null = null
+  try {
+    const { result } = await findWebsiteByDomainWorkflow(req.scope).run({
+      input: { domain },
+    })
+    websiteId = (result as any)?.id ?? null
+  } catch { /* unknown domain — GMV stays null */ }
 
   const { data } = await query.graph({
     entity: "partners",
@@ -26,12 +43,36 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     }
   }
 
+  // Sum conversion_value for the website over the GMV window. Same data
+  // source the ad-planning admin dashboard sums; here it's website-scoped
+  // and trailing-90 by default so it stays "current" without a date param.
+  let gmvAmount = 0
+  let gmvCurrency = "USD"
+  if (websiteId) {
+    try {
+      const adPlanning = req.scope.resolve(AD_PLANNING_MODULE) as any
+      const since = new Date(Date.now() - GMV_WINDOW_DAYS * 24 * 60 * 60 * 1000)
+      const conversions = await adPlanning.listConversions(
+        { website_id: websiteId, converted_at: { $gte: since } },
+        { take: GMV_MAX_ROWS, order: { converted_at: "DESC" } }
+      )
+      for (const c of conversions || []) {
+        gmvAmount += Number(c.conversion_value) || 0
+        if (c.currency) gmvCurrency = String(c.currency).toUpperCase()
+      }
+    } catch { /* surface as 0; never block the response */ }
+  }
+
   res.setHeader("Cache-Control", "public, max-age=60, stale-while-revalidate=300")
   res.status(200).json({
     artisans,
     brands_live: brandsLive,
-    // Distinct production hubs — derived once we wire partner-region links.
     hubs: 3,
+    gmv: {
+      amount: gmvAmount,
+      currency: gmvCurrency,
+      window_days: GMV_WINDOW_DAYS,
+    },
     last_updated: new Date().toISOString(),
   })
 }

--- a/apps/backend/src/api/web/website/[domain]/marketing/websites/route.ts
+++ b/apps/backend/src/api/web/website/[domain]/marketing/websites/route.ts
@@ -1,0 +1,51 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+type RawWebsite = {
+  id: string
+  domain: string
+  name: string
+  description: string | null
+  favicon_url: string | null
+}
+
+type PublicWebsite = {
+  id: string
+  domain: string
+  name: string
+  description: string | null
+  favicon_url: string | null
+  url: string
+}
+
+const LIMIT = 24
+
+// Public list of active websites — the "ateliers powered" rail in jyt-web
+// footer + the cross-brand strip in the consumer view. We don't gate by the
+// :domain in the URL today (every brand can see every other brand); the
+// param stays for parity with sibling marketing endpoints and so the front
+// end can attach cache/auth headers consistently.
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  // query.graph expects the pluralized entity name (matches the working
+  // marketing/partners endpoint convention).
+  const { data } = await query.graph({
+    entity: "websites",
+    fields: ["id", "domain", "name", "description", "favicon_url"],
+    filters: { status: "Active" },
+    pagination: { take: LIMIT, order: { name: "ASC" } },
+  })
+
+  const websites: PublicWebsite[] = ((data || []) as unknown as RawWebsite[]).map((w) => ({
+    id: w.id,
+    domain: w.domain,
+    name: w.name,
+    description: w.description,
+    favicon_url: w.favicon_url,
+    url: w.domain.startsWith("http") ? w.domain : `https://${w.domain}`,
+  }))
+
+  res.setHeader("Cache-Control", "public, max-age=300, stale-while-revalidate=900")
+  res.status(200).json({ websites })
+}


### PR DESCRIPTION
## Summary
Two additions for the jyt-web marketing site rewrite:

- **\`GET /web/website/:domain/marketing/metrics\`** — now resolves the website by domain, then sums \`Conversion.conversion_value\` (trailing 90d, capped 50k rows) and returns it as \`gmv: { amount, currency, window_days }\`. Existing \`artisans\` / \`brands_live\` / \`hubs\` / \`last_updated\` unchanged. GMV degrades to 0 silently if the domain isn't registered or ad-planning has no rows — never blocks the response.
- **\`GET /web/website/:domain/marketing/websites\`** (new) — public list of Active websites with \`{ id, domain, name, description, favicon_url, url }\`. Powers the footer "Ateliers powered" row and the cross-brand strip in the consumer view on jyt-web. 5-minute cache, 24-row cap.

Both follow the same \`entity: \"<plural>\"\` \`query.graph\` convention as the existing \`marketing/partners\` endpoint.

## Test plan
- [ ] \`curl /web/website/jaalyantra.com/marketing/metrics\` — confirm \`gmv.amount > 0\` against prod data
- [ ] \`curl /web/website/kindhealth.com/marketing/metrics\` — confirm GMV scopes per domain
- [ ] \`curl /web/website/jaalyantra.com/marketing/websites\` — confirm Active websites only, alphabetized
- [ ] Pass an unregistered domain — confirm metrics returns \`gmv.amount = 0\` without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)