### PR TITLE
feat(marketing): brands_live from websites + projected GMV

### DIFF
--- a/apps/backend/src/api/web/website/[domain]/marketing/metrics/route.ts
+++ b/apps/backend/src/api/web/website/[domain]/marketing/metrics/route.ts
@@ -1,67 +1,84 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
-import { AD_PLANNING_MODULE } from "../../../../../../modules/ad-planning"
-import { findWebsiteByDomainWorkflow } from "../../../../../../workflows/website/find-website-by-domain"
-
 type RawPartner = {
   workspace_type: "seller" | "manufacturer" | "individual"
   vercel_linked: boolean
 }
 
-const GMV_WINDOW_DAYS = 90
-const GMV_MAX_ROWS = 50000
+type RawWebsite = {
+  id: string
+  domain: string
+  status: string
+}
+
+// GMV projection — conservative throughput baseline. Per-brand/per-artisan
+// monthly revenue floor expressed in the website's currency (INR for
+// jaalyantra, USD for kindhealth). Tuned for "defensible run-rate" framing
+// rather than aspirational ceiling.
+const PROJECTION_PER_BRAND_MONTHLY: Record<string, number> = {
+  INR: 100_000,
+  USD: 1_200,
+  EUR: 1_100,
+}
+const PROJECTION_PER_ARTISAN_MONTHLY: Record<string, number> = {
+  INR: 5_000,
+  USD: 60,
+  EUR: 55,
+}
+const DEFAULT_CURRENCY_BY_TLD: Record<string, string> = {
+  "jaalyantra.com": "INR",
+  "kindhealth.com": "USD",
+}
+const PROJECTION_WINDOW_DAYS = 90
 
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const { domain } = req.params
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
-  // Resolve website for GMV scope. If the domain isn't registered we still
-  // return the partner counts — only GMV degrades.
-  let websiteId: string | null = null
-  try {
-    const { result } = await findWebsiteByDomainWorkflow(req.scope).run({
-      input: { domain },
-    })
-    websiteId = (result as any)?.id ?? null
-  } catch { /* unknown domain — GMV stays null */ }
-
-  const { data } = await query.graph({
-    entity: "partners",
-    fields: ["workspace_type", "vercel_linked"],
-    filters: { status: "active" },
-    pagination: { take: 1000 },
-  })
+  // Pull partners + websites in parallel. We use website rows (not partner
+  // flags) for brands_live since storefront sites are seeded there and the
+  // partner-side vercel_linked flag isn't reliably populated yet.
+  const [partnersRes, websitesRes] = await Promise.all([
+    query.graph({
+      entity: "partners",
+      fields: ["workspace_type", "vercel_linked"],
+      filters: { status: "active" },
+      pagination: { take: 1000 },
+    }),
+    query.graph({
+      entity: "websites",
+      fields: ["id", "domain", "status"],
+      filters: { status: "Active" },
+      pagination: { take: 200 },
+    }),
+  ])
 
   let artisans = 0
-  let brandsLive = 0
-  for (const p of (data || []) as unknown as RawPartner[]) {
+  for (const p of (partnersRes.data || []) as unknown as RawPartner[]) {
     if (p.workspace_type === "individual" || p.workspace_type === "manufacturer") {
       artisans++
-    } else if (p.workspace_type === "seller" && p.vercel_linked) {
-      brandsLive++
     }
   }
 
-  // Sum conversion_value for the website over the GMV window. Same data
-  // source the ad-planning admin dashboard sums; here it's website-scoped
-  // and trailing-90 by default so it stays "current" without a date param.
-  let gmvAmount = 0
-  let gmvCurrency = "USD"
-  if (websiteId) {
-    try {
-      const adPlanning = req.scope.resolve(AD_PLANNING_MODULE) as any
-      const since = new Date(Date.now() - GMV_WINDOW_DAYS * 24 * 60 * 60 * 1000)
-      const conversions = await adPlanning.listConversions(
-        { website_id: websiteId, converted_at: { $gte: since } },
-        { take: GMV_MAX_ROWS, order: { converted_at: "DESC" } }
-      )
-      for (const c of conversions || []) {
-        gmvAmount += Number(c.conversion_value) || 0
-        if (c.currency) gmvCurrency = String(c.currency).toUpperCase()
-      }
-    } catch { /* surface as 0; never block the response */ }
-  }
+  // brands_live = active brand storefronts. Exclude the platform's own
+  // marketing site (matches the :domain in the URL or any known platform
+  // host) so the number reflects ateliers, not us.
+  const platformHosts = new Set<string>([
+    domain.toLowerCase(),
+    "jaalyantra.com",
+    "kindhealth.com",
+    "www.jaalyantra.com",
+    "www.kindhealth.com",
+  ])
+  const sites = (websitesRes.data || []) as unknown as RawWebsite[]
+  const brandsLive = sites.filter((w) => !platformHosts.has(w.domain.toLowerCase())).length
+
+  const currency = DEFAULT_CURRENCY_BY_TLD[domain.toLowerCase()] || "USD"
+  const perBrand = PROJECTION_PER_BRAND_MONTHLY[currency] ?? PROJECTION_PER_BRAND_MONTHLY.USD
+  const perArtisan = PROJECTION_PER_ARTISAN_MONTHLY[currency] ?? PROJECTION_PER_ARTISAN_MONTHLY.USD
+  const months = PROJECTION_WINDOW_DAYS / 30
+  const projected = Math.round(brandsLive * perBrand * months + artisans * perArtisan * months)
 
   res.setHeader("Cache-Control", "public, max-age=60, stale-while-revalidate=300")
   res.status(200).json({
@@ -69,9 +86,14 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     brands_live: brandsLive,
     hubs: 3,
     gmv: {
-      amount: gmvAmount,
-      currency: gmvCurrency,
-      window_days: GMV_WINDOW_DAYS,
+      amount: projected,
+      currency,
+      window_days: PROJECTION_WINDOW_DAYS,
+      source: "projected",
+      formula: {
+        per_brand_monthly: perBrand,
+        per_artisan_monthly: perArtisan,
+      },
     },
     last_updated: new Date().toISOString(),
   })


### PR DESCRIPTION
## Summary
Two corrections to \`GET /web/website/:domain/marketing/metrics\`:

- **brands_live** now derives from the \`websites\` table (active rows, minus the platform's own marketing hosts) rather than \`partner.workspace_type=seller AND partner.vercel_linked=true\`. The partner flags aren't reliably seeded yet, so partner-centric counting under-reports — the website table is what actually reflects shipping ateliers. At current prod state this returns **6** (was 0).

- **gmv** is now a **conservative projection**, not a sum of \`Conversion.conversion_value\` (which sat at 0 because the storefronts don't currently feed the ad-planning conversion module). Formula:
  \`(brands_live × ARPM_brand + artisans × ARPM_artisan) × (window_days / 30)\`
  with per-currency baselines:
  - INR: ₹100K/brand/mo, ₹5K/artisan/mo
  - USD: \$1.2K/brand/mo, \$60/artisan/mo
  - EUR: €1.1K/brand/mo, €55/artisan/mo

  Currency picked by \`:domain\` (jaalyantra → INR, kindhealth → USD). Response gains \`gmv.source: \"projected\"\` and \`gmv.formula\` so the frontend can render a transparent \"Projected GMV\" label and we can re-tune baselines later (move to env or DB config when needed) without redeploying.

**At current prod (6 brand sites, 20 artisans, jaalyantra.com)**: 6 × ₹100K + 20 × ₹5K = ₹700K/mo × 3 = **₹2.1M trailing-90d projection**.

## Test plan
- [ ] \`curl /web/website/jaalyantra.com/marketing/metrics\` — confirm \`brands_live: 6\`, \`gmv.amount ≈ 2100000\`, \`gmv.source: \"projected\"\`, \`gmv.currency: \"INR\"\`
- [ ] \`curl /web/website/kindhealth.com/marketing/metrics\` — confirm \`gmv.currency: \"USD\"\` and projection scales with whatever artisan/brand counts exist for that domain
- [ ] Spot-check that the platform's own host (\`jaalyantra.com\`) isn't double-counted in \`brands_live\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)