### PR TITLE
feat(marketing): hubs from stock_location + lead_time from production_runs

### DIFF
--- a/apps/backend/src/api/web/website/[domain]/marketing/metrics/route.ts
+++ b/apps/backend/src/api/web/website/[domain]/marketing/metrics/route.ts
@@ -12,6 +12,21 @@ type RawWebsite = {
   status: string
 }
 
+type RawStockLocation = {
+  id: string
+  deleted_at: string | null
+}
+
+type RawProductionRun = {
+  id: string
+  status: string
+  started_at: string | null
+  completed_at: string | null
+}
+
+const LEAD_TIME_WINDOW_DAYS = 90
+const LEAD_TIME_MAX_ROWS = 5000
+
 // GMV projection — conservative throughput baseline. Per-brand/per-artisan
 // monthly revenue floor expressed in the website's currency (INR for
 // jaalyantra, USD for kindhealth). Tuned for "defensible run-rate" framing
@@ -36,10 +51,11 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const { domain } = req.params
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
-  // Pull partners + websites in parallel. We use website rows (not partner
-  // flags) for brands_live since storefront sites are seeded there and the
-  // partner-side vercel_linked flag isn't reliably populated yet.
-  const [partnersRes, websitesRes] = await Promise.all([
+  // Pull partners + websites + stock_locations + recent production_runs in
+  // parallel. Each feeds a different stat below; running them concurrently
+  // keeps the endpoint inside its 60s cache window comfortably.
+  const leadWindowFrom = new Date(Date.now() - LEAD_TIME_WINDOW_DAYS * 24 * 60 * 60 * 1000)
+  const [partnersRes, websitesRes, locationsRes, runsRes] = await Promise.all([
     query.graph({
       entity: "partners",
       fields: ["workspace_type", "vercel_linked"],
@@ -52,6 +68,17 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       filters: { status: "Active" },
       pagination: { take: 200 },
     }),
+    query.graph({
+      entity: "stock_location",
+      fields: ["id", "deleted_at"],
+      pagination: { take: 500 },
+    }).catch(() => ({ data: [] })),
+    query.graph({
+      entity: "production_runs",
+      fields: ["id", "status", "started_at", "completed_at"],
+      filters: { status: "completed", completed_at: { $gte: leadWindowFrom } },
+      pagination: { take: LEAD_TIME_MAX_ROWS, order: { completed_at: "DESC" } },
+    }).catch(() => ({ data: [] })),
   ])
 
   let artisans = 0
@@ -74,6 +101,29 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const sites = (websitesRes.data || []) as unknown as RawWebsite[]
   const brandsLive = sites.filter((w) => !platformHosts.has(w.domain.toLowerCase())).length
 
+  // hubs = active production locations. stock_location doesn't have a
+  // status field in Medusa core; soft-delete is via deleted_at, so filter
+  // out tombstoned rows in memory.
+  const locations = (locationsRes.data || []) as unknown as RawStockLocation[]
+  const hubs = locations.filter((l) => !l.deleted_at).length
+
+  // lead_time = avg days between started_at → completed_at for runs that
+  // finished in the trailing window. Skips runs without both timestamps
+  // (incomplete data) and clamps negatives just in case.
+  const runs = (runsRes.data || []) as unknown as RawProductionRun[]
+  let leadSumMs = 0
+  let leadSamples = 0
+  for (const r of runs) {
+    if (!r.started_at || !r.completed_at) continue
+    const ms = new Date(r.completed_at).getTime() - new Date(r.started_at).getTime()
+    if (ms <= 0) continue
+    leadSumMs += ms
+    leadSamples++
+  }
+  const leadAvgDays = leadSamples > 0
+    ? Math.round(leadSumMs / leadSamples / (1000 * 60 * 60 * 24))
+    : null
+
   const currency = DEFAULT_CURRENCY_BY_TLD[domain.toLowerCase()] || "USD"
   const perBrand = PROJECTION_PER_BRAND_MONTHLY[currency] ?? PROJECTION_PER_BRAND_MONTHLY.USD
   const perArtisan = PROJECTION_PER_ARTISAN_MONTHLY[currency] ?? PROJECTION_PER_ARTISAN_MONTHLY.USD
@@ -84,7 +134,12 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   res.status(200).json({
     artisans,
     brands_live: brandsLive,
-    hubs: 3,
+    hubs,
+    lead_time: {
+      avg_days: leadAvgDays,
+      sample_size: leadSamples,
+      window_days: LEAD_TIME_WINDOW_DAYS,
+    },
     gmv: {
       amount: projected,
       currency,


### PR DESCRIPTION
## Summary
Moves two more marketing metrics from hardcoded to real data.

**hubs** (was hardcoded \`3\`)
Now counts active \`stock_location\` rows (Medusa core entity). Soft-deleted rows (\`deleted_at != null\`) are filtered out. Reflects the real production geography we have on file.

**lead_time** (new field)
Avg days between \`started_at\` and \`completed_at\` for \`production_runs\` that completed in the trailing 90 days. Response shape:
\`\`\`json
{
  \"lead_time\": {
    \"avg_days\": 18,
    \"sample_size\": 24,
    \"window_days\": 90
  }
}
\`\`\`
- \`avg_days\` is \`null\` when no completed runs in window — frontend will hide the Hero row rather than render a misleading \"0 days.\"
- Skips runs missing either timestamp.
- Clamps negative deltas (data integrity safety).
- Capped at 5000 rows, ordered by \`completed_at DESC\` so the most recent runs weight the average.

Both queries are wrapped in \`.catch\` so a misconfigured module can't 500 the endpoint — they degrade gracefully to \`hubs: 0\` / \`lead_time.avg_days: null\`.

## Test plan
- [ ] \`curl /web/website/jaalyantra.com/marketing/metrics\` — confirm \`hubs\` reflects actual stock_location count, \`lead_time.sample_size > 0\` if runs have completed
- [ ] Manually mark one production_run \`completed_at\` to a clearly-future date relative to \`started_at\`; verify it shows up in the average
- [ ] Confirm \`avg_days: null\` when there are zero recent completed runs (drop status filter to a status that doesn't exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)