### PR TITLE
feat(marketing-seed): add 'contact' form handle

### DIFF
--- a/apps/backend/src/scripts/seed-marketing-forms.ts
+++ b/apps/backend/src/scripts/seed-marketing-forms.ts
@@ -60,6 +60,19 @@ const FORMS: FormDef[] = [
       { name: "mode", label: "Mode", type: "text", required: false, order: 1 },
     ],
   },
+  {
+    handle: "contact",
+    title: "Contact us",
+    description: "General contact form used by the /contact page on jyt-web.",
+    success_message: "Thanks — we'll be in touch within one business day.",
+    fields: [
+      { name: "email", label: "Email", type: "email", required: true, order: 0 },
+      { name: "name", label: "Name", type: "text", required: true, order: 1 },
+      { name: "company", label: "Company", type: "text", required: false, order: 2 },
+      { name: "role", label: "Role", type: "text", required: false, order: 3 },
+      { name: "message", label: "Message", type: "textarea", required: true, order: 4 },
+    ],
+  },
 ]
 
 export default async function seedMarketingForms({ container }: ExecArgs) {


### PR DESCRIPTION
## Summary
The jyt-web ContactForm POSTs to \`/web/website/<domain>/forms/contact\` via the \`handleContactFormSubmission\` server action, but the seed script only seeded \`waitlist\` / \`investor-intro\` / \`demo-request\`. Submissions 404 in environments that haven't been backfilled manually.

Adds the \`contact\` handle with the same field shape the form sends: email + name + company + role + message. Idempotent — the \`(handle, website_id)\` uniqueness check already in the script makes re-running safe.

## Test plan
- [ ] Merge + deploy backend
- [ ] Run \`npx medusa exec src/scripts/seed-marketing-forms.ts\` in prod
- [ ] Submit jyt-web /contact form, confirm 200 (not 404)
- [ ] Verify the form submission appears in admin Forms module under jaalyantra.com → contact

🤖 Generated with [Claude Code](https://claude.com/claude-code)