### PR TITLE
fix(google-ads): send login-customer-id so MCC-child CIDs stop 403'ing on sync

### DIFF
--- a/apps/backend/src/api/admin/social-platforms/[id]/google/bindings/[binding_id]/route.ts
+++ b/apps/backend/src/api/admin/social-platforms/[id]/google/bindings/[binding_id]/route.ts
@@ -1,5 +1,13 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { deleteGoogleBindingWorkflow } from "../../../../../../../workflows/google/delete-binding"
+import { updateGoogleBindingWorkflow } from "../../../../../../../workflows/google/update-binding"
+
+type UpdateBody = {
+  resource_label?: string | null
+  settings?: Record<string, any> | null
+  metadata?: Record<string, any> | null
+  status?: "active" | "paused" | "error" | "pending"
+}
 
 export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
   const { result } = await deleteGoogleBindingWorkflow(req.scope).run({
@@ -10,4 +18,21 @@ export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
   })
 
   res.status(200).json(result)
+}
+
+export const POST = async (req: MedusaRequest<UpdateBody>, res: MedusaResponse) => {
+  const body = (req.body || {}) as UpdateBody
+
+  const { result } = await updateGoogleBindingWorkflow(req.scope).run({
+    input: {
+      platform_id: req.params.id,
+      binding_id: req.params.binding_id,
+      resource_label: body.resource_label,
+      settings: body.settings,
+      metadata: body.metadata,
+      status: body.status,
+    },
+  })
+
+  res.status(200).json({ binding: result })
 }

--- a/apps/backend/src/workflows/google-ads/steps/sync-google-ads-step.ts
+++ b/apps/backend/src/workflows/google-ads/steps/sync-google-ads-step.ts
@@ -108,6 +108,10 @@ export const syncGoogleAdsStep = createStep(
       service: "ads",
     })
 
+    const envLoginCid = normalizeCid(
+      process.env.GOOGLE_ADS_LOGIN_CUSTOMER_ID
+    )
+
     const targets = (
       input.customer_id
         ? bindings.filter((b: any) => b.resource_id === input.customer_id)
@@ -116,6 +120,14 @@ export const syncGoogleAdsStep = createStep(
       binding_id: b.id as string,
       customer_id: String(b.resource_id),
       resource_label: (b.resource_label as string) || null,
+      // login-customer-id precedence: per-binding settings > per-binding
+      // metadata (auto-discovered from manager hierarchy) > workspace env.
+      // Standalone accounts can leave all three unset.
+      login_customer_id:
+        normalizeCid(b.settings?.login_customer_id) ||
+        normalizeCid(b.metadata?.login_customer_id) ||
+        envLoginCid ||
+        null,
     }))
 
     if (targets.length === 0) {
@@ -127,7 +139,7 @@ export const syncGoogleAdsStep = createStep(
       )
     }
 
-    const headers = {
+    const baseHeaders = {
       Authorization: `Bearer ${input.access_token}`,
       "developer-token": developerToken,
       "Content-Type": "application/json",
@@ -139,6 +151,10 @@ export const syncGoogleAdsStep = createStep(
     const errors: Array<{ customer_id: string; message: string }> = []
 
     for (const t of targets) {
+      const headers: Record<string, string> = { ...baseHeaders }
+      if (t.login_customer_id) {
+        headers["login-customer-id"] = t.login_customer_id
+      }
       try {
         const { customer, campaigns, adGroups } = await pullCidData(
           t.customer_id,
@@ -173,7 +189,13 @@ export const syncGoogleAdsStep = createStep(
         )
         adGroupsSynced += adGroupCount
       } catch (e: any) {
-        const msg = e.response?.data?.error?.message || e.message
+        let msg = e.response?.data?.error?.message || e.message
+        // Most common 403 on a child CID: missing login-customer-id. Give
+        // the operator a usable next step right in the error row rather
+        // than the bare "status code 403".
+        if (e.response?.status === 403 && !t.login_customer_id) {
+          msg = `${msg} — likely missing login-customer-id (set settings.login_customer_id on the binding to the manager/MCC CID, or GOOGLE_ADS_LOGIN_CUSTOMER_ID env)`
+        }
         logger?.warn?.(
           `[google-ads] sync failed for cid=${t.customer_id}: ${msg}`
         )
@@ -457,6 +479,12 @@ async function upsertAdGroups(
   }
 
   return synced
+}
+
+function normalizeCid(value?: string | null): string | null {
+  if (!value) return null
+  const digits = String(value).replace(/\D/g, "")
+  return digits.length ? digits : null
 }
 
 async function readDeveloperToken(

--- a/apps/backend/src/workflows/google/steps/list-accessible-resources.ts
+++ b/apps/backend/src/workflows/google/steps/list-accessible-resources.ts
@@ -154,6 +154,10 @@ async function listAdsCustomers(
   // Hydrate descriptive names via GAQL — best-effort per CID. A failure here
   // shouldn't drop the whole list; we surface the bare CID with no label
   // so the operator can still bind it.
+  //
+  // First pass: try with no login-customer-id (works for the user's own
+  // accounts + manager accounts). Children of a manager will 403 here —
+  // we fix that in the second pass using the manager → child map.
   const out: AccessibleResource[] = []
   for (const rn of cidResourceNames) {
     const cid = rn.split("/")[1]
@@ -179,7 +183,7 @@ async function listAdsCustomers(
           ),
         { label: `ads.searchStream(${cid})`, logger, maxAttempts: 3 }
       )
-      const row = gaql.data?.[0]?.results?.[0]?.customer || gaql.data?.results?.[0]?.customer
+      const row = extractFirstCustomer(gaql.data)
       if (row) {
         label = row.descriptiveName || cid
         extra = {
@@ -197,7 +201,118 @@ async function listAdsCustomers(
     out.push({ resource_id: cid, resource_label: label, metadata: extra })
   }
 
+  // Second pass: discover manager → child links so we can stash
+  // metadata.login_customer_id on every child. Without this header the
+  // sync step gets a 403 on any account that's nested under an MCC.
+  //
+  // We only query customer_client on rows the first pass tagged as a
+  // manager. customer_client returns ALL descendants under a manager,
+  // including itself — we map children → this manager so the picker
+  // can pass `settings.login_customer_id` straight through on bind.
+  const childToManager = new Map<string, string>()
+  const managers = out.filter((r) => r.metadata?.manager === true)
+  for (const mgr of managers) {
+    try {
+      const response = await withGoogleRetry(
+        () =>
+          axios.post(
+            `${ADS_API_BASE}/customers/${mgr.resource_id}/googleAds:searchStream`,
+            {
+              query:
+                "SELECT customer_client.client_customer, customer_client.id, customer_client.level, customer_client.manager FROM customer_client WHERE customer_client.level <= 5",
+            },
+            {
+              headers: {
+                Authorization: `Bearer ${input.access_token}`,
+                "developer-token": developerToken,
+                "login-customer-id": mgr.resource_id,
+                "Content-Type": "application/json",
+              },
+            }
+          ),
+        { label: `ads.customer_client(${mgr.resource_id})`, logger, maxAttempts: 2 }
+      )
+      const rows = extractAllRows(response.data)
+      for (const r of rows) {
+        const childRn =
+          r.customerClient?.clientCustomer ||
+          r.customer_client?.client_customer ||
+          ""
+        const childCid = childRn.split("/").pop() || ""
+        if (!childCid || childCid === mgr.resource_id) continue
+        // First manager wins (lowest-level link). Don't overwrite if a
+        // higher MCC also lists this child — we want the most specific.
+        if (!childToManager.has(childCid)) {
+          childToManager.set(childCid, mgr.resource_id)
+        }
+      }
+    } catch (e: any) {
+      logger?.warn?.(
+        `[google-ads] customer_client discovery failed for manager=${mgr.resource_id}: ${
+          e.response?.data?.error?.message || e.message
+        }`
+      )
+    }
+  }
+
+  // Attach login_customer_id on children + retry the hydrate for any
+  // child that 403'd in the first pass (label stayed as bare CID).
+  for (const r of out) {
+    const loginCid = childToManager.get(r.resource_id)
+    if (!loginCid) continue
+    r.metadata = { ...(r.metadata || {}), login_customer_id: loginCid }
+    if (r.resource_label === r.resource_id) {
+      try {
+        const gaql = await withGoogleRetry(
+          () =>
+            axios.post(
+              `${ADS_API_BASE}/customers/${r.resource_id}/googleAds:searchStream`,
+              {
+                query:
+                  "SELECT customer.descriptive_name, customer.currency_code, customer.time_zone, customer.manager, customer.test_account FROM customer LIMIT 1",
+              },
+              {
+                headers: {
+                  Authorization: `Bearer ${input.access_token}`,
+                  "developer-token": developerToken,
+                  "login-customer-id": loginCid,
+                  "Content-Type": "application/json",
+                },
+              }
+            ),
+          { label: `ads.searchStream.retry(${r.resource_id})`, logger, maxAttempts: 2 }
+        )
+        const row = extractFirstCustomer(gaql.data)
+        if (row) {
+          r.resource_label = row.descriptiveName || r.resource_id
+          r.metadata = {
+            ...r.metadata,
+            descriptive_name: row.descriptiveName,
+            currency_code: row.currencyCode,
+            time_zone: row.timeZone,
+            manager: row.manager,
+            test_account: row.testAccount,
+          }
+        }
+      } catch {
+        // Still bindable with the login_customer_id we just attached.
+      }
+    }
+  }
+
   return out
+}
+
+function extractAllRows(data: any): any[] {
+  if (!data) return []
+  if (Array.isArray(data)) {
+    return data.flatMap((chunk) => chunk?.results || [])
+  }
+  return data.results || []
+}
+
+function extractFirstCustomer(data: any): any {
+  return extractAllRows(data)[0]?.customer ?? null
 }
 
 async function listSearchConsoleSites(

--- a/apps/backend/src/workflows/google/steps/update-binding.ts
+++ b/apps/backend/src/workflows/google/steps/update-binding.ts
@@ -1,0 +1,68 @@
+import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
+import { MedusaError } from "@medusajs/framework/utils"
+import { SOCIALS_MODULE } from "../../../modules/socials"
+
+export type UpdateBindingInput = {
+  platform_id: string
+  binding_id: string
+  resource_label?: string | null
+  settings?: Record<string, any> | null
+  metadata?: Record<string, any> | null
+  status?: "active" | "paused" | "error" | "pending"
+}
+
+/**
+ * Patches mutable fields on an existing SocialPlatformBinding. Most common
+ * use is setting `settings.login_customer_id` on an Ads binding that was
+ * created before the manager hierarchy was auto-discovered.
+ *
+ * `settings` and `metadata` are merged shallow into the existing JSON so
+ * callers can update one key without clobbering the rest.
+ */
+export const updateBindingStep = createStep(
+  "update-google-binding-step",
+  async (input: UpdateBindingInput, { container }) => {
+    const socials = container.resolve(SOCIALS_MODULE) as any
+
+    const [existing] = await socials.listSocialPlatformBindings(
+      { id: input.binding_id, platform_id: input.platform_id },
+      { take: 1 }
+    )
+    if (!existing) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Binding ${input.binding_id} not found on platform ${input.platform_id}`
+      )
+    }
+
+    const data: Record<string, any> = {}
+    if (input.resource_label !== undefined) {
+      data.resource_label = input.resource_label
+    }
+    if (input.settings !== undefined) {
+      data.settings =
+        input.settings === null
+          ? null
+          : { ...(existing.settings || {}), ...input.settings }
+    }
+    if (input.metadata !== undefined) {
+      data.metadata =
+        input.metadata === null
+          ? null
+          : { ...(existing.metadata || {}), ...input.metadata }
+    }
+    if (input.status !== undefined) {
+      data.status = input.status
+    }
+
+    if (Object.keys(data).length === 0) {
+      return new StepResponse(existing)
+    }
+
+    const updated = await socials.updateSocialPlatformBindings({
+      selector: { id: existing.id },
+      data,
+    })
+    return new StepResponse(Array.isArray(updated) ? updated[0] : updated)
+  }
+)

--- a/apps/backend/src/workflows/google/update-binding.ts
+++ b/apps/backend/src/workflows/google/update-binding.ts
@@ -1,0 +1,16 @@
+import {
+  createWorkflow,
+  WorkflowData,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import { updateBindingStep, type UpdateBindingInput } from "./steps/update-binding"
+
+export const updateGoogleBindingWorkflowId = "update-google-binding-workflow"
+
+export const updateGoogleBindingWorkflow = createWorkflow(
+  updateGoogleBindingWorkflowId,
+  function (input: WorkflowData<UpdateBindingInput>) {
+    const result = updateBindingStep(input)
+    return new WorkflowResponse(result)
+  }
+)


### PR DESCRIPTION
## Summary
- Google Ads sync was firing `googleAds:searchStream` with only `Authorization` + `developer-token`. Google returns **403** whenever the requested CID is a child of a Manager Account (MCC) and `login-customer-id` is missing — which is the common case for real operators.
- Sync now reads `login_customer_id` from `binding.settings` → `binding.metadata` → `GOOGLE_ADS_LOGIN_CUSTOMER_ID` env, normalizes the CID to digits-only, and sends the header per target. 403 errors now include actionable guidance instead of just `"Request failed with status code 403"`.
- `list-accessible-resources` auto-discovers manager → child links via `customer_client` GAQL on every manager CID, stashes the manager into `metadata.login_customer_id` for each child, and retries the descriptive-name hydrate for children that 403'd on the first pass. Future binds get the right header out of the box.
- Adds `POST /admin/social-platforms/:id/google/bindings/:binding_id` so operators can patch `settings.login_customer_id` on existing bindings without rebinding. `settings` / `metadata` shallow-merge.

## Unblocking the existing 403 binding (e.g. `01KRBEWGJ2…`)

After redeploy, pick one:

**A. Patch the existing binding (no rebind needed):**
\`\`\`bash
curl -X POST https://v3.jaalyantra.com/admin/social-platforms/<platform_id>/google/bindings/<binding_id> \\
  -H "Authorization: Bearer <admin-token>" \\
  -H "Content-Type: application/json" \\
  -d '{"settings": {"login_customer_id": "<MCC_CID_DIGITS>"}}'
\`\`\`

**B. Re-list resources + re-bind:** The picker will now include \`metadata.login_customer_id\` for children. POSTing the binding again upserts in place.

**C. Env var fallback:** Set \`GOOGLE_ADS_LOGIN_CUSTOMER_ID=<MCC_CID>\` and redeploy — applies to every ads binding.

## Test plan
- [ ] Bind a CID that is a direct child of an MCC → \`POST .../google/ads/sync\` returns \`customers_synced: 1\` with no \`errors\` (was 403).
- [ ] Bind a standalone (non-MCC-managed) CID → still works without setting any header (env, settings, metadata all unset → header omitted).
- [ ] Hit \`GET .../google/list-accessible-resources?service=ads\` as an MCC user → child resources come back with \`metadata.login_customer_id\` populated and \`resource_label\` hydrated from the descriptive name (was bare CID).
- [ ] Patch \`settings.login_customer_id\` on an existing binding via the new POST → next sync uses the new header without rebinding.
- [ ] Forced 403 on a binding with no \`login_customer_id\` → error row reads \`"… — likely missing login-customer-id (set settings.login_customer_id on the binding to the manager/MCC CID, or GOOGLE_ADS_LOGIN_CUSTOMER_ID env)"\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)