### PR TITLE
feat(admin): unified /admin/ads UI for Meta + Google

### DIFF
--- a/apps/backend/src/admin/hooks/api/ads.ts
+++ b/apps/backend/src/admin/hooks/api/ads.ts
@@ -1,0 +1,320 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { sdk } from "../../lib/config"
+
+// Backend serves the new unified `/admin/ads/*` surface (PR #215). Same hook
+// file backs every tab on `/admin/ads`; the platform discriminator on each
+// response tells the UI which native row shape lives under `.raw` if it
+// wants a network-specific extra.
+
+// ───────────────────────────── Types ─────────────────────────────
+
+export type AdsPlatformKind = "meta" | "google"
+
+export interface AdsAccount {
+  id: string
+  platform: AdsPlatformKind
+  provider_account_id: string
+  name: string
+  currency: string | null
+  status: string
+  last_synced_at: string | null
+  raw: Record<string, any>
+}
+
+export interface AdsCampaign {
+  id: string
+  platform: AdsPlatformKind
+  account_id: string
+  provider_campaign_id: string
+  name: string
+  status: string
+  objective_or_channel_type: string | null
+  start_date: string | null
+  end_date: string | null
+  budget_micros: number
+  impressions: number
+  clicks: number
+  conversions: number
+  cost_micros: number
+  last_synced_at: string | null
+  raw: Record<string, any>
+}
+
+export interface AdsAdGroup {
+  id: string
+  platform: AdsPlatformKind
+  campaign_id: string
+  provider_ad_group_id: string
+  name: string
+  status: string
+  type: string | null
+  impressions: number
+  clicks: number
+  conversions: number
+  cost_micros: number
+  last_synced_at: string | null
+  raw: Record<string, any>
+}
+
+export interface AdsAd {
+  id: string
+  platform: AdsPlatformKind
+  ad_group_id: string
+  provider_ad_id: string
+  name: string | null
+  status: string
+  type: string | null
+  headlines: Array<{ text?: string }> | null
+  descriptions: Array<{ text?: string }> | null
+  final_urls: string[] | null
+  image_url: string | null
+  video_id: string | null
+  display_url: string | null
+  impressions: number
+  clicks: number
+  conversions: number
+  cost_micros: number
+  last_synced_at: string | null
+  raw: Record<string, any>
+}
+
+export type AdsInsightLevel =
+  | "customer"
+  | "account"
+  | "campaign"
+  | "ad_group"
+  | "adset"
+  | "ad"
+
+export interface AdsInsight {
+  id: string
+  platform: AdsPlatformKind
+  level: string
+  date: string | null
+  entity_id: string | null
+  impressions: number
+  clicks: number
+  ctr: number | null
+  cost_micros: number
+  average_cpc_micros: number
+  average_cpm_micros: number
+  conversions: number
+  conversions_value: number | null
+  all_conversions: number | null
+  view_through_conversions: number | null
+  video_views: number
+  video_view_rate: number | null
+  engagements: number
+  engagement_rate: number | null
+  device: string | null
+  network: string | null
+  currency_code: string | null
+  raw: Record<string, any>
+}
+
+export interface SyncResult {
+  platform_id: string
+  customers_synced?: number
+  campaigns_synced?: number
+  ad_groups_synced?: number
+  ads_synced?: number
+  insights_rows_synced?: number
+  errors?: Array<{ customer_id: string; message: string }>
+}
+
+// ───────────────────────────── Query keys ─────────────────────────────
+
+export const adsKeys = {
+  all: ["ads"] as const,
+  platforms: () => [...adsKeys.all, "platforms"] as const,
+  accounts: (params: object) => [...adsKeys.all, "accounts", params] as const,
+  campaigns: (params: object) => [...adsKeys.all, "campaigns", params] as const,
+  adGroups: (params: object) => [...adsKeys.all, "ad-groups", params] as const,
+  adsList: (params: object) => [...adsKeys.all, "ads", params] as const,
+  insights: (params: object) => [...adsKeys.all, "insights", params] as const,
+}
+
+// ───────────────────────────── Platforms (for picker) ─────────────────────────────
+
+export interface PlatformOption {
+  id: string
+  name: string
+  category: string
+  kind: AdsPlatformKind
+}
+
+/**
+ * Lists every SocialPlatform that could plausibly back the ads UI:
+ *   - category === "google"   → Google Ads
+ *   - name contains facebook/instagram/meta → Meta Ads (current convention)
+ *
+ * If/when there's a cleaner discriminator on the row, this is the single
+ * place to update.
+ */
+export const useAdsPlatforms = () => {
+  return useQuery({
+    queryKey: adsKeys.platforms(),
+    queryFn: async () => {
+      const response = await sdk.client.fetch<{
+        socialPlatforms: Array<{ id: string; name: string; category: string }>
+      }>("/admin/social-platforms", { query: { limit: 100 } })
+
+      const options: PlatformOption[] = []
+      for (const p of response.socialPlatforms || []) {
+        const category = (p.category || "").toLowerCase()
+        const name = (p.name || "").toLowerCase()
+        if (category === "google") {
+          options.push({ id: p.id, name: p.name, category, kind: "google" })
+        } else if (
+          name.includes("facebook") ||
+          name.includes("instagram") ||
+          name.includes("meta")
+        ) {
+          options.push({ id: p.id, name: p.name, category, kind: "meta" })
+        }
+      }
+      return options
+    },
+  })
+}
+
+// ───────────────────────────── Resource lists ─────────────────────────────
+
+type ListParams = {
+  platform_id: string
+  limit?: number
+  offset?: number
+}
+
+export const useAdsAccounts = (params: ListParams) => {
+  return useQuery({
+    queryKey: adsKeys.accounts(params),
+    enabled: !!params.platform_id,
+    queryFn: async () => {
+      const query: Record<string, string> = { platform_id: params.platform_id }
+      if (params.limit) query.limit = String(params.limit)
+      if (params.offset !== undefined) query.offset = String(params.offset)
+      return sdk.client.fetch<{
+        platform: AdsPlatformKind
+        accounts: AdsAccount[]
+        count: number
+      }>("/admin/ads/accounts", { query })
+    },
+  })
+}
+
+export const useAdsCampaigns = (
+  params: ListParams & { account_id?: string }
+) => {
+  return useQuery({
+    queryKey: adsKeys.campaigns(params),
+    enabled: !!params.platform_id,
+    queryFn: async () => {
+      const query: Record<string, string> = { platform_id: params.platform_id }
+      if (params.account_id) query.account_id = params.account_id
+      if (params.limit) query.limit = String(params.limit)
+      if (params.offset !== undefined) query.offset = String(params.offset)
+      return sdk.client.fetch<{
+        platform: AdsPlatformKind
+        campaigns: AdsCampaign[]
+        count: number
+      }>("/admin/ads/campaigns", { query })
+    },
+  })
+}
+
+export const useAdsAdGroups = (
+  params: ListParams & { campaign_id?: string }
+) => {
+  return useQuery({
+    queryKey: adsKeys.adGroups(params),
+    enabled: !!params.platform_id,
+    queryFn: async () => {
+      const query: Record<string, string> = { platform_id: params.platform_id }
+      if (params.campaign_id) query.campaign_id = params.campaign_id
+      if (params.limit) query.limit = String(params.limit)
+      if (params.offset !== undefined) query.offset = String(params.offset)
+      return sdk.client.fetch<{
+        platform: AdsPlatformKind
+        ad_groups: AdsAdGroup[]
+        count: number
+      }>("/admin/ads/ad-groups", { query })
+    },
+  })
+}
+
+export const useAdsList = (
+  params: ListParams & { ad_group_id?: string }
+) => {
+  return useQuery({
+    queryKey: adsKeys.adsList(params),
+    enabled: !!params.platform_id,
+    queryFn: async () => {
+      const query: Record<string, string> = { platform_id: params.platform_id }
+      if (params.ad_group_id) query.ad_group_id = params.ad_group_id
+      if (params.limit) query.limit = String(params.limit)
+      if (params.offset !== undefined) query.offset = String(params.offset)
+      return sdk.client.fetch<{
+        platform: AdsPlatformKind
+        ads: AdsAd[]
+        count: number
+      }>("/admin/ads/ads", { query })
+    },
+  })
+}
+
+export const useAdsInsights = (params: {
+  platform_id: string
+  level?: AdsInsightLevel | string
+  entity_id?: string
+  from?: string
+  to?: string
+  breakdown?: "device" | "network"
+  limit?: number
+}) => {
+  return useQuery({
+    queryKey: adsKeys.insights(params),
+    enabled: !!params.platform_id,
+    queryFn: async () => {
+      const query: Record<string, string> = { platform_id: params.platform_id }
+      if (params.level) query.level = String(params.level)
+      if (params.entity_id) query.entity_id = params.entity_id
+      if (params.from) query.from = params.from
+      if (params.to) query.to = params.to
+      if (params.breakdown) query.breakdown = params.breakdown
+      if (params.limit) query.limit = String(params.limit)
+      return sdk.client.fetch<{
+        platform: AdsPlatformKind
+        level: string
+        insights: AdsInsight[]
+        count: number
+      }>("/admin/ads/insights", { query })
+    },
+  })
+}
+
+// ───────────────────────────── Sync mutation ─────────────────────────────
+
+export const useAdsSync = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (body: {
+      platform_id: string
+      account_id?: string
+      include_ads?: boolean
+      include_insights?: boolean
+      include_breakdowns?: boolean
+      window_days?: number
+    }) => {
+      return sdk.client.fetch<{
+        platform: AdsPlatformKind
+        result: SyncResult | null
+        hint?: string
+      }>("/admin/ads/sync", { method: "POST", body })
+    },
+    onSuccess: () => {
+      // Bust every list — the sync wrote new rows across the board.
+      qc.invalidateQueries({ queryKey: adsKeys.all })
+    },
+  })
+}

--- a/apps/backend/src/admin/routes/ads/_components/accounts-tab.tsx
+++ b/apps/backend/src/admin/routes/ads/_components/accounts-tab.tsx
@@ -1,0 +1,130 @@
+import {
+  Container,
+  DataTable,
+  type DataTablePaginationState,
+  Heading,
+  StatusBadge,
+  Text,
+  useDataTable,
+} from "@medusajs/ui"
+import { createColumnHelper } from "@tanstack/react-table"
+import { useCallback } from "react"
+import { useSearchParams } from "react-router-dom"
+import { type AdsAccount, type AdsPlatformKind, useAdsAccounts } from "../../../hooks/api/ads"
+import { formatNumber, shortDate, statusToTone } from "./format"
+
+const PAGE_SIZE = 20
+
+const columnHelper = createColumnHelper<AdsAccount>()
+
+type Props = { platformId: string; kind: AdsPlatformKind | null }
+
+export const AccountsTab = ({ platformId, kind }: Props) => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const pageFromUrl = parseInt(searchParams.get("acc_page") || "1", 10)
+  const limitFromUrl = parseInt(
+    searchParams.get("acc_limit") || String(PAGE_SIZE),
+    10
+  )
+  const pagination: DataTablePaginationState = {
+    pageIndex: Math.max(0, pageFromUrl - 1),
+    pageSize: limitFromUrl,
+  }
+  const offset = pagination.pageIndex * pagination.pageSize
+
+  const { data, isLoading, isError, error } = useAdsAccounts({
+    platform_id: platformId,
+    limit: pagination.pageSize,
+    offset,
+  })
+
+  const handlePaginationChange = useCallback(
+    (newPagination: DataTablePaginationState) => {
+      const params = new URLSearchParams(searchParams)
+      if (newPagination.pageIndex > 0)
+        params.set("acc_page", String(newPagination.pageIndex + 1))
+      else params.delete("acc_page")
+      if (newPagination.pageSize !== PAGE_SIZE)
+        params.set("acc_limit", String(newPagination.pageSize))
+      else params.delete("acc_limit")
+      setSearchParams(params, { replace: true })
+    },
+    [searchParams, setSearchParams]
+  )
+
+  const columns = [
+    columnHelper.accessor("name", {
+      header: "Name",
+      cell: (info) => (
+        <span className="font-medium">{info.getValue() || "—"}</span>
+      ),
+    }),
+    columnHelper.accessor("provider_account_id", {
+      header: kind === "google" ? "Customer ID" : "Account ID",
+      cell: (info) => (
+        <Text size="small" className="font-mono text-ui-fg-subtle">
+          {info.getValue()}
+        </Text>
+      ),
+    }),
+    columnHelper.accessor("currency", {
+      header: "Currency",
+      cell: (info) => info.getValue() || "—",
+    }),
+    columnHelper.accessor("status", {
+      header: "Status",
+      cell: (info) => (
+        <StatusBadge color={statusToTone(info.getValue())}>
+          {info.getValue() || "—"}
+        </StatusBadge>
+      ),
+    }),
+    columnHelper.accessor("raw.amount_spent", {
+      header: "Spent",
+      cell: (info) => {
+        // Meta-only — Google has no flat lifetime spend column at account
+        // level (use insights instead). Cleanly show — for Google rows.
+        const v = info.getValue()
+        if (v === undefined || v === null) return "—"
+        return formatNumber(Number(v) || 0)
+      },
+    }),
+    columnHelper.accessor("last_synced_at", {
+      header: "Last synced",
+      cell: (info) => shortDate(info.getValue()),
+    }),
+  ]
+
+  const table = useDataTable({
+    data: data?.accounts || [],
+    columns,
+    rowCount: data?.count || 0,
+    getRowId: (row) => row.id,
+    isLoading,
+    pagination: {
+      state: pagination,
+      onPaginationChange: handlePaginationChange,
+    },
+  })
+
+  if (isError) throw error
+
+  return (
+    <Container className="divide-y p-0">
+      <DataTable instance={table}>
+        <DataTable.Toolbar className="flex flex-col md:flex-row justify-between gap-y-4 w-full px-6 py-4">
+          <div>
+            <Heading>Accounts</Heading>
+            <Text className="text-ui-fg-subtle" size="small">
+              {kind === "google"
+                ? "Google Ads customers (CIDs) synced from this platform."
+                : "Meta ad accounts synced from this platform."}
+            </Text>
+          </div>
+        </DataTable.Toolbar>
+        <DataTable.Table />
+        <DataTable.Pagination />
+      </DataTable>
+    </Container>
+  )
+}

--- a/apps/backend/src/admin/routes/ads/_components/ad-groups-tab.tsx
+++ b/apps/backend/src/admin/routes/ads/_components/ad-groups-tab.tsx
@@ -1,0 +1,176 @@
+import {
+  Container,
+  DataTable,
+  type DataTablePaginationState,
+  Heading,
+  Select,
+  StatusBadge,
+  Text,
+  useDataTable,
+} from "@medusajs/ui"
+import { createColumnHelper } from "@tanstack/react-table"
+import { useCallback } from "react"
+import { useSearchParams } from "react-router-dom"
+import {
+  type AdsAdGroup,
+  type AdsPlatformKind,
+  useAdsAdGroups,
+  useAdsCampaigns,
+} from "../../../hooks/api/ads"
+import {
+  formatMicros,
+  formatNumber,
+  formatPercent,
+  statusToTone,
+} from "./format"
+
+const PAGE_SIZE = 20
+const columnHelper = createColumnHelper<AdsAdGroup>()
+
+type Props = { platformId: string; kind: AdsPlatformKind | null }
+
+export const AdGroupsTab = ({ platformId, kind }: Props) => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const pageFromUrl = parseInt(searchParams.get("ag_page") || "1", 10)
+  const campaignFilter = searchParams.get("campaign_id") || undefined
+
+  const pagination: DataTablePaginationState = {
+    pageIndex: Math.max(0, pageFromUrl - 1),
+    pageSize: PAGE_SIZE,
+  }
+  const offset = pagination.pageIndex * pagination.pageSize
+
+  const { data: campaignsData } = useAdsCampaigns({
+    platform_id: platformId,
+    limit: 200,
+  })
+
+  const { data, isLoading, isError, error } = useAdsAdGroups({
+    platform_id: platformId,
+    campaign_id: campaignFilter,
+    limit: pagination.pageSize,
+    offset,
+  })
+
+  const handlePaginationChange = useCallback(
+    (newPagination: DataTablePaginationState) => {
+      const params = new URLSearchParams(searchParams)
+      if (newPagination.pageIndex > 0)
+        params.set("ag_page", String(newPagination.pageIndex + 1))
+      else params.delete("ag_page")
+      setSearchParams(params, { replace: true })
+    },
+    [searchParams, setSearchParams]
+  )
+
+  const setCampaignFilter = (next: string) => {
+    const params = new URLSearchParams(searchParams)
+    if (next) params.set("campaign_id", next)
+    else params.delete("campaign_id")
+    params.delete("ag_page")
+    setSearchParams(params, { replace: true })
+  }
+
+  const campaigns = campaignsData?.campaigns || []
+
+  const columns = [
+    columnHelper.accessor("name", {
+      header: "Name",
+      cell: (info) => (
+        <span className="font-medium">{info.getValue() || "—"}</span>
+      ),
+    }),
+    columnHelper.accessor("status", {
+      header: "Status",
+      cell: (info) => (
+        <StatusBadge color={statusToTone(info.getValue())}>
+          {info.getValue()}
+        </StatusBadge>
+      ),
+    }),
+    columnHelper.accessor("type", {
+      header: "Type",
+      cell: (info) => info.getValue() || "—",
+    }),
+    columnHelper.accessor("impressions", {
+      header: "Impressions",
+      cell: (info) => formatNumber(info.getValue()),
+    }),
+    columnHelper.accessor("clicks", {
+      header: "Clicks",
+      cell: (info) => formatNumber(info.getValue()),
+    }),
+    columnHelper.display({
+      id: "ctr",
+      header: "CTR",
+      cell: ({ row }) => {
+        const { impressions, clicks } = row.original
+        if (!impressions) return "—"
+        return formatPercent((clicks / impressions) * 100)
+      },
+    }),
+    columnHelper.accessor("cost_micros", {
+      header: "Spend",
+      cell: (info) => formatMicros(info.getValue()),
+    }),
+    columnHelper.accessor("conversions", {
+      header: "Conversions",
+      cell: (info) => formatNumber(info.getValue()),
+    }),
+  ]
+
+  const table = useDataTable({
+    data: data?.ad_groups || [],
+    columns,
+    rowCount: data?.count || 0,
+    getRowId: (row) => row.id,
+    isLoading,
+    pagination: {
+      state: pagination,
+      onPaginationChange: handlePaginationChange,
+    },
+  })
+
+  if (isError) throw error
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex flex-col sm:flex-row sm:items-center gap-3 px-6 py-4">
+        <Text size="small" className="text-ui-fg-subtle whitespace-nowrap">
+          Filter by campaign:
+        </Text>
+        <Select
+          size="small"
+          value={campaignFilter || "all"}
+          onValueChange={(v) => setCampaignFilter(v === "all" ? "" : v)}
+        >
+          <Select.Trigger className="w-[280px]">
+            <Select.Value placeholder="All campaigns" />
+          </Select.Trigger>
+          <Select.Content>
+            <Select.Item value="all">All campaigns</Select.Item>
+            {campaigns.map((c) => (
+              <Select.Item key={c.id} value={c.id}>
+                {c.name}
+              </Select.Item>
+            ))}
+          </Select.Content>
+        </Select>
+      </div>
+      <DataTable instance={table}>
+        <DataTable.Toolbar className="flex flex-col md:flex-row justify-between gap-y-4 w-full px-6 py-4">
+          <div>
+            <Heading>{kind === "google" ? "Ad groups" : "Ad sets"}</Heading>
+            <Text className="text-ui-fg-subtle" size="small">
+              {kind === "google"
+                ? "Google ad groups under the selected campaign(s)."
+                : "Meta ad sets under the selected campaign(s)."}
+            </Text>
+          </div>
+        </DataTable.Toolbar>
+        <DataTable.Table />
+        <DataTable.Pagination />
+      </DataTable>
+    </Container>
+  )
+}

--- a/apps/backend/src/admin/routes/ads/_components/ads-tab.tsx
+++ b/apps/backend/src/admin/routes/ads/_components/ads-tab.tsx
@@ -1,0 +1,212 @@
+import {
+  Container,
+  DataTable,
+  type DataTablePaginationState,
+  Heading,
+  Select,
+  StatusBadge,
+  Text,
+  useDataTable,
+} from "@medusajs/ui"
+import { createColumnHelper } from "@tanstack/react-table"
+import { useCallback } from "react"
+import { useSearchParams } from "react-router-dom"
+import {
+  type AdsAd,
+  type AdsPlatformKind,
+  useAdsAdGroups,
+  useAdsList,
+} from "../../../hooks/api/ads"
+import {
+  formatMicros,
+  formatNumber,
+  formatPercent,
+  statusToTone,
+} from "./format"
+
+const PAGE_SIZE = 20
+const columnHelper = createColumnHelper<AdsAd>()
+
+type Props = { platformId: string; kind: AdsPlatformKind | null }
+
+export const AdsTab = ({ platformId, kind }: Props) => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const pageFromUrl = parseInt(searchParams.get("a_page") || "1", 10)
+  const adGroupFilter = searchParams.get("ad_group_id") || undefined
+
+  const pagination: DataTablePaginationState = {
+    pageIndex: Math.max(0, pageFromUrl - 1),
+    pageSize: PAGE_SIZE,
+  }
+  const offset = pagination.pageIndex * pagination.pageSize
+
+  const { data: adGroupsData } = useAdsAdGroups({
+    platform_id: platformId,
+    limit: 200,
+  })
+
+  const { data, isLoading, isError, error } = useAdsList({
+    platform_id: platformId,
+    ad_group_id: adGroupFilter,
+    limit: pagination.pageSize,
+    offset,
+  })
+
+  const handlePaginationChange = useCallback(
+    (newPagination: DataTablePaginationState) => {
+      const params = new URLSearchParams(searchParams)
+      if (newPagination.pageIndex > 0)
+        params.set("a_page", String(newPagination.pageIndex + 1))
+      else params.delete("a_page")
+      setSearchParams(params, { replace: true })
+    },
+    [searchParams, setSearchParams]
+  )
+
+  const setAdGroupFilter = (next: string) => {
+    const params = new URLSearchParams(searchParams)
+    if (next) params.set("ad_group_id", next)
+    else params.delete("ad_group_id")
+    params.delete("a_page")
+    setSearchParams(params, { replace: true })
+  }
+
+  const adGroups = adGroupsData?.ad_groups || []
+
+  const columns = [
+    columnHelper.display({
+      id: "preview",
+      header: "Creative",
+      cell: ({ row }) => <AdPreview ad={row.original} />,
+    }),
+    columnHelper.accessor("status", {
+      header: "Status",
+      cell: (info) => (
+        <StatusBadge color={statusToTone(info.getValue())}>
+          {info.getValue()}
+        </StatusBadge>
+      ),
+    }),
+    columnHelper.accessor("type", {
+      header: "Type",
+      cell: (info) => info.getValue() || "—",
+    }),
+    columnHelper.accessor("impressions", {
+      header: "Impressions",
+      cell: (info) => formatNumber(info.getValue()),
+    }),
+    columnHelper.accessor("clicks", {
+      header: "Clicks",
+      cell: (info) => formatNumber(info.getValue()),
+    }),
+    columnHelper.display({
+      id: "ctr",
+      header: "CTR",
+      cell: ({ row }) => {
+        const { impressions, clicks } = row.original
+        if (!impressions) return "—"
+        return formatPercent((clicks / impressions) * 100)
+      },
+    }),
+    columnHelper.accessor("cost_micros", {
+      header: "Spend",
+      cell: (info) => formatMicros(info.getValue()),
+    }),
+    columnHelper.accessor("conversions", {
+      header: "Conversions",
+      cell: (info) => formatNumber(info.getValue()),
+    }),
+  ]
+
+  const table = useDataTable({
+    data: data?.ads || [],
+    columns,
+    rowCount: data?.count || 0,
+    getRowId: (row) => row.id,
+    isLoading,
+    pagination: {
+      state: pagination,
+      onPaginationChange: handlePaginationChange,
+    },
+  })
+
+  if (isError) throw error
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex flex-col sm:flex-row sm:items-center gap-3 px-6 py-4">
+        <Text size="small" className="text-ui-fg-subtle whitespace-nowrap">
+          Filter by {kind === "google" ? "ad group" : "ad set"}:
+        </Text>
+        <Select
+          size="small"
+          value={adGroupFilter || "all"}
+          onValueChange={(v) => setAdGroupFilter(v === "all" ? "" : v)}
+        >
+          <Select.Trigger className="w-[280px]">
+            <Select.Value placeholder={`All ${kind === "google" ? "ad groups" : "ad sets"}`} />
+          </Select.Trigger>
+          <Select.Content>
+            <Select.Item value="all">
+              All {kind === "google" ? "ad groups" : "ad sets"}
+            </Select.Item>
+            {adGroups.map((ag) => (
+              <Select.Item key={ag.id} value={ag.id}>
+                {ag.name}
+              </Select.Item>
+            ))}
+          </Select.Content>
+        </Select>
+      </div>
+      <DataTable instance={table}>
+        <DataTable.Toolbar className="flex flex-col md:flex-row justify-between gap-y-4 w-full px-6 py-4">
+          <div>
+            <Heading>Ads</Heading>
+            <Text className="text-ui-fg-subtle" size="small">
+              Individual creatives. Headlines + final URLs are shown inline;
+              full bodies live under `raw` for now.
+            </Text>
+          </div>
+        </DataTable.Toolbar>
+        <DataTable.Table />
+        <DataTable.Pagination />
+      </DataTable>
+    </Container>
+  )
+}
+
+// Inline preview that picks whichever shape the ad happens to have. Falls
+// back to the bare ad ID so an unrenderable creative still has SOMETHING
+// to click on.
+const AdPreview = ({ ad }: { ad: AdsAd }) => {
+  const firstHeadline = ad.headlines?.[0]?.text
+  const firstUrl = ad.final_urls?.[0]
+  const label = ad.name || firstHeadline || firstUrl || ad.provider_ad_id
+
+  return (
+    <div className="flex items-center gap-3 max-w-[400px]">
+      {ad.image_url ? (
+        <img
+          src={ad.image_url}
+          alt=""
+          className="w-10 h-10 rounded-md object-cover border border-ui-border-base"
+          loading="lazy"
+        />
+      ) : (
+        <div className="w-10 h-10 rounded-md border border-ui-border-base bg-ui-bg-subtle flex items-center justify-center text-[10px] text-ui-fg-muted uppercase">
+          {ad.type?.split("_")[0]?.slice(0, 4) || "ad"}
+        </div>
+      )}
+      <div className="min-w-0 flex-1">
+        <Text size="small" className="font-medium truncate">
+          {label}
+        </Text>
+        {firstUrl && (
+          <Text size="xsmall" className="text-ui-fg-subtle truncate">
+            {firstUrl}
+          </Text>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/backend/src/admin/routes/ads/_components/campaigns-tab.tsx
+++ b/apps/backend/src/admin/routes/ads/_components/campaigns-tab.tsx
@@ -1,0 +1,190 @@
+import {
+  Container,
+  DataTable,
+  type DataTablePaginationState,
+  Heading,
+  Select,
+  StatusBadge,
+  Text,
+  useDataTable,
+} from "@medusajs/ui"
+import { createColumnHelper } from "@tanstack/react-table"
+import { useCallback, useMemo } from "react"
+import { useSearchParams } from "react-router-dom"
+import {
+  type AdsCampaign,
+  type AdsPlatformKind,
+  useAdsAccounts,
+  useAdsCampaigns,
+} from "../../../hooks/api/ads"
+import {
+  formatMicros,
+  formatNumber,
+  formatPercent,
+  shortDate,
+  statusToTone,
+} from "./format"
+
+const PAGE_SIZE = 20
+const columnHelper = createColumnHelper<AdsCampaign>()
+
+type Props = { platformId: string; kind: AdsPlatformKind | null }
+
+export const CampaignsTab = ({ platformId, kind }: Props) => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const pageFromUrl = parseInt(searchParams.get("cmp_page") || "1", 10)
+  const accountFilter = searchParams.get("account_id") || undefined
+
+  const pagination: DataTablePaginationState = {
+    pageIndex: Math.max(0, pageFromUrl - 1),
+    pageSize: PAGE_SIZE,
+  }
+  const offset = pagination.pageIndex * pagination.pageSize
+
+  // Account picker for filtering — uses the same accounts endpoint as the
+  // first tab so the dropdown shows whatever the operator just synced.
+  const { data: accountsData } = useAdsAccounts({
+    platform_id: platformId,
+    limit: 200,
+  })
+
+  const { data, isLoading, isError, error } = useAdsCampaigns({
+    platform_id: platformId,
+    account_id: accountFilter,
+    limit: pagination.pageSize,
+    offset,
+  })
+
+  const handlePaginationChange = useCallback(
+    (newPagination: DataTablePaginationState) => {
+      const params = new URLSearchParams(searchParams)
+      if (newPagination.pageIndex > 0)
+        params.set("cmp_page", String(newPagination.pageIndex + 1))
+      else params.delete("cmp_page")
+      setSearchParams(params, { replace: true })
+    },
+    [searchParams, setSearchParams]
+  )
+
+  const setAccountFilter = (next: string) => {
+    const params = new URLSearchParams(searchParams)
+    if (next) params.set("account_id", next)
+    else params.delete("account_id")
+    params.delete("cmp_page")
+    setSearchParams(params, { replace: true })
+  }
+
+  const accounts = accountsData?.accounts || []
+  const currency = useMemo(() => {
+    if (!accountFilter) return accounts[0]?.currency || "USD"
+    return accounts.find((a) => a.id === accountFilter)?.currency || "USD"
+  }, [accounts, accountFilter])
+
+  const columns = [
+    columnHelper.accessor("name", {
+      header: "Name",
+      cell: (info) => (
+        <span className="font-medium">{info.getValue() || "—"}</span>
+      ),
+    }),
+    columnHelper.accessor("status", {
+      header: "Status",
+      cell: (info) => (
+        <StatusBadge color={statusToTone(info.getValue())}>
+          {info.getValue()}
+        </StatusBadge>
+      ),
+    }),
+    columnHelper.accessor("objective_or_channel_type", {
+      header: kind === "google" ? "Channel" : "Objective",
+      cell: (info) => info.getValue() || "—",
+    }),
+    columnHelper.accessor("impressions", {
+      header: "Impressions",
+      cell: (info) => formatNumber(info.getValue()),
+    }),
+    columnHelper.accessor("clicks", {
+      header: "Clicks",
+      cell: (info) => formatNumber(info.getValue()),
+    }),
+    columnHelper.display({
+      id: "ctr",
+      header: "CTR",
+      cell: ({ row }) => {
+        const { impressions, clicks } = row.original
+        if (!impressions) return "—"
+        return formatPercent((clicks / impressions) * 100)
+      },
+    }),
+    columnHelper.accessor("cost_micros", {
+      header: "Spend",
+      cell: (info) => formatMicros(info.getValue(), currency),
+    }),
+    columnHelper.accessor("conversions", {
+      header: "Conversions",
+      cell: (info) => formatNumber(info.getValue()),
+    }),
+    columnHelper.display({
+      id: "dates",
+      header: "Window",
+      cell: ({ row }) => {
+        const { start_date, end_date } = row.original
+        if (!start_date && !end_date) return "—"
+        return `${shortDate(start_date)} → ${shortDate(end_date)}`
+      },
+    }),
+  ]
+
+  const table = useDataTable({
+    data: data?.campaigns || [],
+    columns,
+    rowCount: data?.count || 0,
+    getRowId: (row) => row.id,
+    isLoading,
+    pagination: {
+      state: pagination,
+      onPaginationChange: handlePaginationChange,
+    },
+  })
+
+  if (isError) throw error
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex flex-col sm:flex-row sm:items-center gap-3 px-6 py-4">
+        <Text size="small" className="text-ui-fg-subtle whitespace-nowrap">
+          Filter by account:
+        </Text>
+        <Select
+          size="small"
+          value={accountFilter || "all"}
+          onValueChange={(v) => setAccountFilter(v === "all" ? "" : v)}
+        >
+          <Select.Trigger className="w-[260px]">
+            <Select.Value placeholder="All accounts" />
+          </Select.Trigger>
+          <Select.Content>
+            <Select.Item value="all">All accounts</Select.Item>
+            {accounts.map((a) => (
+              <Select.Item key={a.id} value={a.id}>
+                {a.name}
+              </Select.Item>
+            ))}
+          </Select.Content>
+        </Select>
+      </div>
+      <DataTable instance={table}>
+        <DataTable.Toolbar className="flex flex-col md:flex-row justify-between gap-y-4 w-full px-6 py-4">
+          <div>
+            <Heading>Campaigns</Heading>
+            <Text className="text-ui-fg-subtle" size="small">
+              Rolled-up window metrics. Use the Insights tab for daily trend.
+            </Text>
+          </div>
+        </DataTable.Toolbar>
+        <DataTable.Table />
+        <DataTable.Pagination />
+      </DataTable>
+    </Container>
+  )
+}

--- a/apps/backend/src/admin/routes/ads/_components/format.ts
+++ b/apps/backend/src/admin/routes/ads/_components/format.ts
@@ -1,0 +1,57 @@
+// Shared formatters used across the unified ads tabs. Currency, integer,
+// and rate formatting all live here so the five DataTables don't drift
+// apart on display rules (especially the micros→units conversion, which
+// is easy to get wrong by 1e6 in one place and not another).
+
+export function formatNumber(value: number | null | undefined): string {
+  if (value === null || value === undefined) return "—"
+  return new Intl.NumberFormat("en-US").format(value)
+}
+
+export function formatPercent(
+  value: number | null | undefined,
+  decimals = 2
+): string {
+  if (value === null || value === undefined) return "—"
+  return `${value.toFixed(decimals)}%`
+}
+
+export function formatMicros(
+  micros: number | null | undefined,
+  currency: string | null | undefined = "USD"
+): string {
+  if (micros === null || micros === undefined || micros === 0) return "—"
+  const value = micros / 1_000_000
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: (currency || "USD").toUpperCase(),
+      minimumFractionDigits: 2,
+    }).format(value)
+  } catch {
+    return `${currency || "USD"} ${value.toFixed(2)}`
+  }
+}
+
+export function statusToTone(
+  status: string | null | undefined
+): "green" | "orange" | "red" | "grey" {
+  const s = (status || "").toUpperCase()
+  if (s === "ENABLED" || s === "ACTIVE" || s === "SYNCED") return "green"
+  if (s === "PAUSED" || s === "PENDING" || s === "SYNCING") return "orange"
+  if (s === "REMOVED" || s === "DELETED" || s === "ERROR") return "red"
+  return "grey"
+}
+
+export function shortDate(value: string | null | undefined): string {
+  if (!value) return "—"
+  try {
+    return new Date(value).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    })
+  } catch {
+    return value
+  }
+}

--- a/apps/backend/src/admin/routes/ads/_components/insights-tab.tsx
+++ b/apps/backend/src/admin/routes/ads/_components/insights-tab.tsx
@@ -1,0 +1,371 @@
+import {
+  Container,
+  DataTable,
+  type DataTablePaginationState,
+  Heading,
+  Input,
+  Select,
+  Text,
+  useDataTable,
+} from "@medusajs/ui"
+import { createColumnHelper } from "@tanstack/react-table"
+import { useCallback, useMemo } from "react"
+import { useSearchParams } from "react-router-dom"
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts"
+import {
+  type AdsInsight,
+  type AdsInsightLevel,
+  type AdsPlatformKind,
+  useAdsAdGroups,
+  useAdsCampaigns,
+  useAdsInsights,
+  useAdsList,
+} from "../../../hooks/api/ads"
+import { formatMicros, formatNumber } from "./format"
+
+const PAGE_SIZE = 50
+const columnHelper = createColumnHelper<AdsInsight>()
+
+type Props = { platformId: string; kind: AdsPlatformKind | null }
+
+const LEVELS_GOOGLE: { value: AdsInsightLevel; label: string }[] = [
+  { value: "campaign", label: "Campaign" },
+  { value: "ad_group", label: "Ad group" },
+  { value: "ad", label: "Ad" },
+  { value: "customer", label: "Account" },
+]
+const LEVELS_META: { value: AdsInsightLevel; label: string }[] = [
+  { value: "campaign", label: "Campaign" },
+  { value: "adset", label: "Ad set" },
+  { value: "ad", label: "Ad" },
+  { value: "account", label: "Account" },
+]
+
+const today = () => new Date().toISOString().slice(0, 10)
+const daysAgo = (n: number) => {
+  const d = new Date()
+  d.setDate(d.getDate() - n)
+  return d.toISOString().slice(0, 10)
+}
+
+export const InsightsTab = ({ platformId, kind }: Props) => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const levels = kind === "meta" ? LEVELS_META : LEVELS_GOOGLE
+
+  const level =
+    (searchParams.get("level") as AdsInsightLevel) || levels[0].value
+  const entityId = searchParams.get("entity_id") || undefined
+  const fromDate = searchParams.get("from") || daysAgo(30)
+  const toDate = searchParams.get("to") || today()
+
+  const pageFromUrl = parseInt(searchParams.get("ins_page") || "1", 10)
+  const pagination: DataTablePaginationState = {
+    pageIndex: Math.max(0, pageFromUrl - 1),
+    pageSize: PAGE_SIZE,
+  }
+
+  // Entity picker dataset depends on level. We load whichever list the
+  // current level needs and let the user pick a specific entity.
+  const { data: campaignsData } = useAdsCampaigns({
+    platform_id: platformId,
+    limit: 200,
+  })
+  const { data: adGroupsData } = useAdsAdGroups({
+    platform_id: platformId,
+    limit: 200,
+  })
+  const { data: adsData } = useAdsList({
+    platform_id: platformId,
+    limit: 200,
+  })
+
+  const entityOptions = useMemo(() => {
+    if (level === "campaign")
+      return (campaignsData?.campaigns || []).map((c) => ({
+        id: c.id,
+        label: c.name,
+      }))
+    if (level === "ad_group" || level === "adset")
+      return (adGroupsData?.ad_groups || []).map((a) => ({
+        id: a.id,
+        label: a.name,
+      }))
+    if (level === "ad")
+      return (adsData?.ads || []).map((a) => ({
+        id: a.id,
+        label: a.name || a.provider_ad_id,
+      }))
+    return []
+  }, [level, campaignsData, adGroupsData, adsData])
+
+  const { data, isLoading, isError, error } = useAdsInsights({
+    platform_id: platformId,
+    level,
+    entity_id: entityId,
+    from: fromDate,
+    to: toDate,
+    limit: 1000,
+  })
+
+  const insights = data?.insights || []
+
+  const updateParam = useCallback(
+    (key: string, value: string | undefined) => {
+      const next = new URLSearchParams(searchParams)
+      if (value) next.set(key, value)
+      else next.delete(key)
+      if (key !== "ins_page") next.delete("ins_page")
+      setSearchParams(next, { replace: true })
+    },
+    [searchParams, setSearchParams]
+  )
+
+  // Time-series chart aggregates daily sums across whatever rows we got.
+  // If the operator picked a specific entity, this is that entity's trend;
+  // otherwise it's the whole level's trend across the date window.
+  const chartData = useMemo(() => {
+    const byDate = new Map<
+      string,
+      { date: string; impressions: number; clicks: number; spend: number }
+    >()
+    for (const row of insights) {
+      if (!row.date) continue
+      const existing = byDate.get(row.date) || {
+        date: row.date,
+        impressions: 0,
+        clicks: 0,
+        spend: 0,
+      }
+      existing.impressions += row.impressions || 0
+      existing.clicks += row.clicks || 0
+      existing.spend += (row.cost_micros || 0) / 1_000_000
+      byDate.set(row.date, existing)
+    }
+    return [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date))
+  }, [insights])
+
+  const currency = insights[0]?.currency_code || "USD"
+
+  const columns = [
+    columnHelper.accessor("date", {
+      header: "Date",
+      cell: (info) => info.getValue() || "—",
+    }),
+    columnHelper.accessor("impressions", {
+      header: "Impressions",
+      cell: (info) => formatNumber(info.getValue()),
+    }),
+    columnHelper.accessor("clicks", {
+      header: "Clicks",
+      cell: (info) => formatNumber(info.getValue()),
+    }),
+    columnHelper.accessor("ctr", {
+      header: "CTR",
+      cell: (info) =>
+        info.getValue() === null
+          ? "—"
+          : `${(info.getValue() as number).toFixed(2)}%`,
+    }),
+    columnHelper.accessor("cost_micros", {
+      header: "Spend",
+      cell: (info) => formatMicros(info.getValue(), currency),
+    }),
+    columnHelper.accessor("average_cpc_micros", {
+      header: "Avg CPC",
+      cell: (info) => formatMicros(info.getValue(), currency),
+    }),
+    columnHelper.accessor("average_cpm_micros", {
+      header: "Avg CPM",
+      cell: (info) => formatMicros(info.getValue(), currency),
+    }),
+    columnHelper.accessor("conversions", {
+      header: "Conversions",
+      cell: (info) => formatNumber(info.getValue()),
+    }),
+    columnHelper.accessor("conversions_value", {
+      header: "Conv. value",
+      cell: (info) =>
+        info.getValue() === null ? "—" : formatNumber(info.getValue()!),
+    }),
+    columnHelper.accessor("video_views", {
+      header: "Video views",
+      cell: (info) => formatNumber(info.getValue()),
+    }),
+    columnHelper.accessor("device", {
+      header: "Device",
+      cell: (info) => info.getValue() || "—",
+    }),
+  ]
+
+  const handlePaginationChange = useCallback(
+    (newPagination: DataTablePaginationState) => {
+      const params = new URLSearchParams(searchParams)
+      if (newPagination.pageIndex > 0)
+        params.set("ins_page", String(newPagination.pageIndex + 1))
+      else params.delete("ins_page")
+      setSearchParams(params, { replace: true })
+    },
+    [searchParams, setSearchParams]
+  )
+
+  const pageStart = pagination.pageIndex * pagination.pageSize
+  const pageRows = insights.slice(pageStart, pageStart + pagination.pageSize)
+
+  const table = useDataTable({
+    data: pageRows,
+    columns,
+    rowCount: insights.length,
+    getRowId: (row) => row.id,
+    isLoading,
+    pagination: {
+      state: pagination,
+      onPaginationChange: handlePaginationChange,
+    },
+  })
+
+  if (isError) throw error
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex flex-wrap items-center gap-3 px-6 py-4">
+        <Text size="small" className="text-ui-fg-subtle whitespace-nowrap">
+          Level:
+        </Text>
+        <Select
+          size="small"
+          value={level}
+          onValueChange={(v) => {
+            updateParam("level", v)
+            updateParam("entity_id", undefined)
+          }}
+        >
+          <Select.Trigger className="w-[150px]">
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Content>
+            {levels.map((l) => (
+              <Select.Item key={l.value} value={l.value}>
+                {l.label}
+              </Select.Item>
+            ))}
+          </Select.Content>
+        </Select>
+
+        <Text size="small" className="text-ui-fg-subtle whitespace-nowrap">
+          Entity:
+        </Text>
+        <Select
+          size="small"
+          value={entityId || "all"}
+          onValueChange={(v) =>
+            updateParam("entity_id", v === "all" ? undefined : v)
+          }
+        >
+          <Select.Trigger className="w-[280px]">
+            <Select.Value placeholder="All" />
+          </Select.Trigger>
+          <Select.Content>
+            <Select.Item value="all">All ({entityOptions.length})</Select.Item>
+            {entityOptions.map((o) => (
+              <Select.Item key={o.id} value={o.id}>
+                {o.label}
+              </Select.Item>
+            ))}
+          </Select.Content>
+        </Select>
+
+        <Text size="small" className="text-ui-fg-subtle whitespace-nowrap">
+          From:
+        </Text>
+        <Input
+          type="date"
+          size="small"
+          value={fromDate}
+          onChange={(e) => updateParam("from", e.target.value)}
+          className="w-[160px]"
+        />
+        <Text size="small" className="text-ui-fg-subtle whitespace-nowrap">
+          To:
+        </Text>
+        <Input
+          type="date"
+          size="small"
+          value={toDate}
+          onChange={(e) => updateParam("to", e.target.value)}
+          className="w-[160px]"
+        />
+      </div>
+
+      <div className="px-6 py-6">
+        <Heading level="h3" className="mb-3">
+          Trend
+        </Heading>
+        {chartData.length === 0 ? (
+          <Text className="text-ui-fg-subtle" size="small">
+            No insights in this window. If you just connected this platform,
+            click <span className="font-medium">Sync now</span> above.
+          </Text>
+        ) : (
+          <ResponsiveContainer width="100%" height={280}>
+            <LineChart data={chartData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="date" tick={{ fontSize: 11 }} />
+              <YAxis yAxisId="left" tick={{ fontSize: 11 }} />
+              <YAxis
+                yAxisId="right"
+                orientation="right"
+                tick={{ fontSize: 11 }}
+              />
+              <Tooltip />
+              <Legend />
+              <Line
+                yAxisId="left"
+                type="monotone"
+                dataKey="impressions"
+                stroke="#8884d8"
+                dot={false}
+              />
+              <Line
+                yAxisId="left"
+                type="monotone"
+                dataKey="clicks"
+                stroke="#82ca9d"
+                dot={false}
+              />
+              <Line
+                yAxisId="right"
+                type="monotone"
+                dataKey="spend"
+                stroke="#ff7300"
+                dot={false}
+                name={`spend (${currency})`}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+
+      <DataTable instance={table}>
+        <DataTable.Toolbar className="flex flex-col md:flex-row justify-between gap-y-4 w-full px-6 py-4">
+          <div>
+            <Heading>Daily rows</Heading>
+            <Text className="text-ui-fg-subtle" size="small">
+              {insights.length} rows in selected window.
+            </Text>
+          </div>
+        </DataTable.Toolbar>
+        <DataTable.Table />
+        <DataTable.Pagination />
+      </DataTable>
+    </Container>
+  )
+}

--- a/apps/backend/src/admin/routes/ads/_components/platform-picker.tsx
+++ b/apps/backend/src/admin/routes/ads/_components/platform-picker.tsx
@@ -1,0 +1,67 @@
+import { Select, Text } from "@medusajs/ui"
+import { type AdsPlatformKind, useAdsPlatforms } from "../../../hooks/api/ads"
+
+type Props = {
+  value: string
+  onChange: (platformId: string, kind: AdsPlatformKind) => void
+}
+
+/**
+ * Top-bar dropdown listing every ads-capable SocialPlatform (Google + Meta).
+ * On change, we fire both the platform_id (for the API) and the resolved
+ * `kind` (so callers can render kind-specific copy without re-fetching).
+ *
+ * Picker is empty-state-aware: zero connected platforms shows guidance
+ * rather than a useless empty dropdown.
+ */
+export const PlatformPicker = ({ value, onChange }: Props) => {
+  const { data: platforms = [], isLoading } = useAdsPlatforms()
+
+  if (!isLoading && platforms.length === 0) {
+    return (
+      <Text size="small" className="text-ui-fg-subtle">
+        No ad platforms connected — connect Google or Meta in Settings → Social
+        Platforms first.
+      </Text>
+    )
+  }
+
+  return (
+    <Select
+      value={value}
+      onValueChange={(v) => {
+        const match = platforms.find((p) => p.id === v)
+        if (match) onChange(match.id, match.kind)
+      }}
+    >
+      <Select.Trigger className="min-w-[220px]">
+        <Select.Value placeholder={isLoading ? "Loading…" : "Select platform"} />
+      </Select.Trigger>
+      <Select.Content>
+        {platforms.map((p) => (
+          <Select.Item key={p.id} value={p.id}>
+            <span className="flex items-center gap-2">
+              <KindBadge kind={p.kind} />
+              {p.name}
+            </span>
+          </Select.Item>
+        ))}
+      </Select.Content>
+    </Select>
+  )
+}
+
+const KindBadge = ({ kind }: { kind: AdsPlatformKind }) => {
+  const label = kind === "google" ? "Google" : "Meta"
+  return (
+    <span
+      className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium ${
+        kind === "google"
+          ? "bg-ui-tag-blue-bg text-ui-tag-blue-text"
+          : "bg-ui-tag-purple-bg text-ui-tag-purple-text"
+      }`}
+    >
+      {label}
+    </span>
+  )
+}

--- a/apps/backend/src/admin/routes/ads/_components/sync-button.tsx
+++ b/apps/backend/src/admin/routes/ads/_components/sync-button.tsx
@@ -1,0 +1,70 @@
+import { Button, toast } from "@medusajs/ui"
+import { ArrowPath } from "@medusajs/icons"
+import { type AdsPlatformKind, useAdsSync } from "../../../hooks/api/ads"
+
+type Props = {
+  platformId: string
+  kind: AdsPlatformKind | null
+}
+
+/**
+ * Single "Sync now" button. Google triggers the unified sync workflow
+ * (campaigns + ad_groups + ads + insights); Meta returns the legacy-routes
+ * hint and we render a friendly toast pointing the operator at the right
+ * page rather than silently no-op'ing.
+ */
+export const SyncButton = ({ platformId, kind }: Props) => {
+  const sync = useAdsSync()
+
+  const onSync = async () => {
+    try {
+      const res = await sync.mutateAsync({
+        platform_id: platformId,
+        include_ads: true,
+        include_insights: true,
+      })
+      if (res.platform === "meta") {
+        toast.info("Meta sync runs through Meta Ads page", {
+          description:
+            res.hint ||
+            "Open /admin/meta-ads and trigger Accounts / Campaigns / Insights sync there.",
+        })
+        return
+      }
+      const r = res.result
+      if (!r) {
+        toast.success("Sync started")
+        return
+      }
+      const parts = [
+        `${r.customers_synced ?? 0} accounts`,
+        `${r.campaigns_synced ?? 0} campaigns`,
+        `${r.ad_groups_synced ?? 0} ad groups`,
+        `${r.ads_synced ?? 0} ads`,
+        `${r.insights_rows_synced ?? 0} insights rows`,
+      ].join(" · ")
+      if (r.errors && r.errors.length) {
+        toast.warning(`Synced with ${r.errors.length} error(s)`, {
+          description: parts + " — " + r.errors[0].message,
+        })
+      } else {
+        toast.success("Sync complete", { description: parts })
+      }
+    } catch (e: any) {
+      toast.error("Sync failed", { description: e?.message || String(e) })
+    }
+  }
+
+  return (
+    <Button
+      size="small"
+      variant="secondary"
+      onClick={onSync}
+      isLoading={sync.isPending}
+      disabled={!platformId || sync.isPending}
+    >
+      {!sync.isPending && <ArrowPath className="mr-1" />}
+      Sync now
+    </Button>
+  )
+}

--- a/apps/backend/src/admin/routes/ads/page.tsx
+++ b/apps/backend/src/admin/routes/ads/page.tsx
@@ -1,0 +1,155 @@
+import { defineRouteConfig } from "@medusajs/admin-sdk"
+import { ChartBar } from "@medusajs/icons"
+import { Heading, Text } from "@medusajs/ui"
+import { Fragment, useEffect } from "react"
+import { useSearchParams } from "react-router-dom"
+import { type AdsPlatformKind, useAdsPlatforms } from "../../hooks/api/ads"
+import { PlatformPicker } from "./_components/platform-picker"
+import { SyncButton } from "./_components/sync-button"
+import { AccountsTab } from "./_components/accounts-tab"
+import { CampaignsTab } from "./_components/campaigns-tab"
+import { AdGroupsTab } from "./_components/ad-groups-tab"
+import { AdsTab } from "./_components/ads-tab"
+import { InsightsTab } from "./_components/insights-tab"
+
+const TAB_PARAM = "tab"
+const DEFAULT_TAB = "accounts"
+const PLATFORM_PARAM = "platform_id"
+const PLATFORM_STORAGE_KEY = "jyt:ads:platform_id"
+
+const TABS = [
+  { value: "accounts", label: "Accounts" },
+  { value: "campaigns", label: "Campaigns" },
+  { value: "ad-groups", label: "Ad groups" },
+  { value: "ads", label: "Ads" },
+  { value: "insights", label: "Insights" },
+]
+
+const AdsPage = () => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const { data: platforms = [], isLoading: platformsLoading } = useAdsPlatforms()
+
+  const activeTab = searchParams.get(TAB_PARAM) || DEFAULT_TAB
+  const platformId =
+    searchParams.get(PLATFORM_PARAM) ||
+    (typeof window !== "undefined"
+      ? window.localStorage.getItem(PLATFORM_STORAGE_KEY) || ""
+      : "")
+
+  // First mount: if no URL platform but localStorage has one, hoist it into
+  // the URL so deep-links from this point onward are stable. If neither
+  // has a value and we just loaded the platforms list, pick the first
+  // available so the page renders something useful out of the box.
+  useEffect(() => {
+    if (searchParams.get(PLATFORM_PARAM)) return
+    const stored =
+      typeof window !== "undefined"
+        ? window.localStorage.getItem(PLATFORM_STORAGE_KEY)
+        : null
+    if (stored && platforms.find((p) => p.id === stored)) {
+      const next = new URLSearchParams(searchParams)
+      next.set(PLATFORM_PARAM, stored)
+      setSearchParams(next, { replace: true })
+      return
+    }
+    if (!platformsLoading && platforms.length > 0) {
+      const next = new URLSearchParams(searchParams)
+      next.set(PLATFORM_PARAM, platforms[0].id)
+      setSearchParams(next, { replace: true })
+    }
+  }, [platforms, platformsLoading, searchParams, setSearchParams])
+
+  const platformKind: AdsPlatformKind | null =
+    platforms.find((p) => p.id === platformId)?.kind || null
+
+  const handleTabChange = (value: string) => {
+    const next = new URLSearchParams(searchParams)
+    next.set(TAB_PARAM, value)
+    setSearchParams(next, { replace: true })
+  }
+
+  const handlePlatformChange = (id: string) => {
+    const next = new URLSearchParams(searchParams)
+    next.set(PLATFORM_PARAM, id)
+    setSearchParams(next, { replace: true })
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(PLATFORM_STORAGE_KEY, id)
+    }
+  }
+
+  return (
+    <div>
+      <div className="flex flex-wrap items-center gap-3 px-6 py-4">
+        <div className="mr-auto">
+          <Heading>Ads</Heading>
+          <Text className="text-ui-fg-subtle" size="small">
+            Unified view of Meta + Google Ads — accounts, campaigns, creatives, and historical performance.
+          </Text>
+        </div>
+        <PlatformPicker value={platformId} onChange={handlePlatformChange} />
+        <SyncButton platformId={platformId} kind={platformKind} />
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 px-6 pb-3">
+        {TABS.map((tab, i) => (
+          <Fragment key={tab.value}>
+            {i > 0 && (
+              <span className="text-ui-fg-muted text-xs select-none">|</span>
+            )}
+            <button
+              type="button"
+              onClick={() => handleTabChange(tab.value)}
+              className={`rounded-full border px-3 py-1 text-xs font-medium transition ${
+                activeTab === tab.value
+                  ? "border-ui-border-strong bg-ui-bg-subtle text-ui-fg-base"
+                  : "border-transparent bg-ui-bg-base text-ui-fg-subtle hover:text-ui-fg-base"
+              }`}
+            >
+              {tab.label}
+            </button>
+          </Fragment>
+        ))}
+      </div>
+
+      <div>
+        {!platformId ? (
+          <div className="px-6 py-12 text-center">
+            <Text className="text-ui-fg-subtle">
+              Pick an ads platform above to begin.
+            </Text>
+          </div>
+        ) : (
+          <>
+            {activeTab === "accounts" && (
+              <AccountsTab platformId={platformId} kind={platformKind} />
+            )}
+            {activeTab === "campaigns" && (
+              <CampaignsTab platformId={platformId} kind={platformKind} />
+            )}
+            {activeTab === "ad-groups" && (
+              <AdGroupsTab platformId={platformId} kind={platformKind} />
+            )}
+            {activeTab === "ads" && (
+              <AdsTab platformId={platformId} kind={platformKind} />
+            )}
+            {activeTab === "insights" && (
+              <InsightsTab platformId={platformId} kind={platformKind} />
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export const config = defineRouteConfig({
+  label: "Ads",
+  nested: "/promotions",
+  icon: ChartBar,
+})
+
+export const handle = {
+  breadcrumb: () => "Ads",
+}
+
+export default AdsPage


### PR DESCRIPTION
Stacked on top of [#215](https://github.com/Jaal-Yantra-Textiles/v2/pull/215). Merge that first.

## Summary
New sidebar entry under **Promotions → Ads** that serves both Meta and Google through the unified `/admin/ads/*` API surface from #215. Meta Ads page stays exactly where it is; nothing is removed. Operator can pick which platform to view via a top-bar dropdown, hit **Sync now**, and read accounts/campaigns/ad-groups/ads/insights in one consistent UI.

## Layout

```
┌───────────────────────────────────────────────────────────┐
│ Ads                                                       │
│ ┌───────────────┐                                         │
│ │ 🟦 Google Ads ▾│  [Sync now]                            │
│ └───────────────┘                                         │
│                                                           │
│ [ Accounts ][ Campaigns ][ Ad groups ][ Ads ][ Insights ] │
│                                                           │
│ (DataTable + filters)                                     │
└───────────────────────────────────────────────────────────┘
```

* `?platform_id=...` is in the URL so deep links work; the picker also mirrors into `localStorage` (`jyt:ads:platform_id`) so the last choice sticks across reloads.
* Tabs persist their own pagination + filter params in the URL (`cmp_page`, `ag_page`, `a_page`, `ins_page`, `account_id`, `campaign_id`, `ad_group_id`, `level`, `entity_id`, `from`, `to`).

## Tab-by-tab

| Tab | Content |
|---|---|
| **Accounts** | Provider account ID, currency, status, last synced. Spent column shown for Meta, dash for Google (no flat lifetime spend at account level). |
| **Campaigns** | Status, objective/channel, impressions, clicks, **derived CTR**, spend (`cost_micros / 1e6` formatted in account currency), conversions, start→end window. Filterable by account. |
| **Ad groups** | Same metric grid as campaigns. Filterable by campaign. Title flips to "Ad sets" for Meta. |
| **Ads** | Creative preview cell (image thumbnail when present, else a type chip), status, type, metrics. Filterable by ad group / ad set. Headlines + first final URL are inline; full bodies live in `raw` for now. |
| **Insights** | Recharts dual-axis line chart (impressions + clicks left axis, spend right axis) plus a daily breakdown table with CTR, avg CPC/CPM, conversions value, video views, and device. Level + entity + from/to date controls in the toolbar. |

## Hooks
- `src/admin/hooks/api/ads.ts` — `adsKeys` namespace, TanStack Query + `sdk.client.fetch` (matches the Meta pattern exactly).
- Platform picker lists every `SocialPlatform` where `category === "google"` or `name` contains facebook/instagram/meta — same heuristic the existing Meta sync controls already use. When a cleaner provider discriminator lands on the row, only this one helper needs to update.

## Sync behavior
- Google → calls `POST /admin/ads/sync` which runs `syncGoogleAdsWorkflow` (campaigns + ad_groups + ads + insights, defaults from #215). Result toast shows `accounts / campaigns / ad_groups / ads / insights_rows`.
- Meta → unified sync route returns a `hint` pointing at `/admin/meta-ads/{accounts,campaigns,insights}/sync`; the button surfaces a friendly toast instead of silently no-op'ing. Meta migration is a follow-up PR.

## Out of scope (deliberately)
- Status mutations (pause/enable) on campaigns / ad groups / ads. The unified API doesn't expose those yet; existing Meta routes still handle this for Meta.
- Detail modals (per-campaign / per-ad drilldowns). Operators can still hit the existing `/admin/meta-ads/campaigns/[id]` pages for Meta deep dives.
- Creative editing.

## Test plan
- [ ] `/admin/ads` shows up under Promotions in the sidebar.
- [ ] First load with no `?platform_id` falls back to localStorage, then to the first ads-capable platform. URL gets rewritten with the chosen `platform_id`.
- [ ] Switching the platform dropdown updates all 5 tabs and persists to localStorage + URL.
- [ ] **Sync now** on a Google platform calls the workflow, toast reports row counts. On a Meta platform, toast prompts to use the legacy routes.
- [ ] **Accounts tab** renders Google customers with provider_account_id + currency.
- [ ] **Campaigns tab** filter dropdown updates the URL and the table; CTR cell renders correctly when impressions > 0.
- [ ] **Ad groups tab** filter dropdown by campaign works for both Google and Meta.
- [ ] **Ads tab** shows image previews for ads with `image_url`; fallback type chip otherwise.
- [ ] **Insights tab** chart renders for a 30-day window; switching level resets entity selection; date range narrows the chart and table consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)