### PR TITLE
feat(search-console): per-website GSC view + sync at /admin/websites/[id]/console

### DIFF
--- a/apps/backend/src/admin/hooks/api/search-console.ts
+++ b/apps/backend/src/admin/hooks/api/search-console.ts
@@ -1,0 +1,125 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { sdk } from "../../lib/config"
+
+// Hooks for the per-website Search Console view at
+// /admin/websites/[id]/console. The backend resolves the bound GSC
+// property from the website's domain, so callers only ever pass the
+// website id.
+
+export interface ConsoleStatus {
+  website: { id: string; domain: string; name: string }
+  bound: boolean
+  binding?: {
+    binding_id: string
+    platform_id: string
+    resource_id: string
+    matched_via: "url_prefix" | "url_prefix_www" | "sc_domain" | "sc_domain_parent"
+  }
+  site?: {
+    id: string
+    site_url: string
+    permission_level: string | null
+    last_synced_at: string | null
+    sync_status: string
+    sync_error: string | null
+  } | null
+  candidates: string[]
+}
+
+export type ConsoleDimension =
+  | "date"
+  | "query"
+  | "page"
+  | "country"
+  | "device"
+
+export interface ConsoleInsightRow {
+  date?: string
+  query?: string
+  page?: string
+  country?: string
+  device?: string
+  clicks: number
+  impressions: number
+  ctr: number | null
+  position: number | null
+}
+
+export interface ConsoleInsightsResponse {
+  rows: ConsoleInsightRow[]
+  dimension: ConsoleDimension
+  total: { clicks: number; impressions: number }
+  bound: boolean
+  synced?: boolean
+  window?: { from: string; to: string }
+}
+
+export const consoleKeys = {
+  all: ["search-console"] as const,
+  status: (websiteId: string) =>
+    [...consoleKeys.all, "status", websiteId] as const,
+  insights: (websiteId: string, params: object) =>
+    [...consoleKeys.all, "insights", websiteId, params] as const,
+}
+
+export const useWebsiteConsoleStatus = (websiteId: string) => {
+  return useQuery({
+    queryKey: consoleKeys.status(websiteId),
+    enabled: !!websiteId,
+    queryFn: () =>
+      sdk.client.fetch<ConsoleStatus>(`/admin/websites/${websiteId}/console`),
+  })
+}
+
+export const useWebsiteConsoleInsights = (
+  websiteId: string,
+  params: {
+    dimension?: ConsoleDimension
+    from?: string
+    to?: string
+    limit?: number
+  }
+) => {
+  return useQuery({
+    queryKey: consoleKeys.insights(websiteId, params),
+    enabled: !!websiteId,
+    queryFn: () => {
+      const query: Record<string, string> = {}
+      if (params.dimension) query.dimension = params.dimension
+      if (params.from) query.from = params.from
+      if (params.to) query.to = params.to
+      if (params.limit) query.limit = String(params.limit)
+      return sdk.client.fetch<ConsoleInsightsResponse>(
+        `/admin/websites/${websiteId}/console/insights`,
+        { query }
+      )
+    },
+  })
+}
+
+export const useWebsiteConsoleSync = (websiteId: string) => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (body: {
+      window_days?: number
+      row_limit?: number
+      dimensions?: Array<
+        "date" | "query" | "page" | "country" | "device" | "searchAppearance"
+      >
+    }) =>
+      sdk.client.fetch<{
+        result: {
+          sites_synced: number
+          insights_rows_synced: number
+          errors: Array<{ site_url: string; message: string }>
+        }
+      }>(`/admin/websites/${websiteId}/console/sync`, {
+        method: "POST",
+        body,
+      }),
+    onSuccess: () => {
+      // Bust everything Search Console for this website.
+      qc.invalidateQueries({ queryKey: [...consoleKeys.all] })
+    },
+  })
+}

--- a/apps/backend/src/admin/routes/websites/[id]/console/page.tsx
+++ b/apps/backend/src/admin/routes/websites/[id]/console/page.tsx
@@ -1,0 +1,382 @@
+import {
+  Button,
+  Container,
+  DataTable,
+  type DataTablePaginationState,
+  Heading,
+  Input,
+  Select,
+  StatusBadge,
+  Text,
+  toast,
+  useDataTable,
+} from "@medusajs/ui"
+import { ArrowPath, ArrowLeft } from "@medusajs/icons"
+import { createColumnHelper } from "@tanstack/react-table"
+import { useMemo, useState } from "react"
+import { useNavigate, useParams, useSearchParams } from "react-router-dom"
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts"
+import {
+  type ConsoleDimension,
+  type ConsoleInsightRow,
+  useWebsiteConsoleInsights,
+  useWebsiteConsoleStatus,
+  useWebsiteConsoleSync,
+} from "../../../../hooks/api/search-console"
+
+const today = () => new Date().toISOString().slice(0, 10)
+const daysAgo = (n: number) => {
+  const d = new Date()
+  d.setDate(d.getDate() - n)
+  return d.toISOString().slice(0, 10)
+}
+
+export default function WebsiteConsolePage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const websiteId = id || ""
+  const from = searchParams.get("from") || daysAgo(28)
+  const to = searchParams.get("to") || today()
+
+  const { data: status, isLoading: statusLoading } =
+    useWebsiteConsoleStatus(websiteId)
+
+  const sync = useWebsiteConsoleSync(websiteId)
+
+  // Trend chart pulls "date" dimension; the other two sections pull
+  // "query" and "page". Three queries fired in parallel keep each
+  // tab snappy and cacheable independently.
+  const trend = useWebsiteConsoleInsights(websiteId, {
+    dimension: "date",
+    from,
+    to,
+  })
+  const queries = useWebsiteConsoleInsights(websiteId, {
+    dimension: "query",
+    from,
+    to,
+    limit: 100,
+  })
+  const pages = useWebsiteConsoleInsights(websiteId, {
+    dimension: "page",
+    from,
+    to,
+    limit: 100,
+  })
+
+  const updateParam = (key: string, value: string | undefined) => {
+    const next = new URLSearchParams(searchParams)
+    if (value) next.set(key, value)
+    else next.delete(key)
+    setSearchParams(next, { replace: true })
+  }
+
+  const onSync = async () => {
+    try {
+      const res = await sync.mutateAsync({})
+      const r = res.result
+      if (r.errors && r.errors.length) {
+        toast.warning("Synced with errors", {
+          description: `${r.insights_rows_synced} rows · ${r.errors[0].message}`,
+        })
+      } else {
+        toast.success("Sync complete", {
+          description: `${r.sites_synced} site · ${r.insights_rows_synced} rows`,
+        })
+      }
+    } catch (e: any) {
+      toast.error("Sync failed", {
+        description:
+          e?.response?.data?.message || e?.message || "Unknown error",
+      })
+    }
+  }
+
+  return (
+    <div>
+      <div className="flex flex-wrap items-center gap-3 px-6 py-4">
+        <Button
+          variant="transparent"
+          size="small"
+          onClick={() => navigate(`/websites/${websiteId}`)}
+          className="px-2"
+        >
+          <ArrowLeft />
+        </Button>
+        <div className="mr-auto">
+          <Heading>Search Console</Heading>
+          <Text className="text-ui-fg-subtle" size="small">
+            {statusLoading
+              ? "…"
+              : status?.website
+                ? `Google Search Analytics for ${status.website.domain}`
+                : "Website not found"}
+          </Text>
+        </div>
+        {status?.bound && (
+          <Button
+            size="small"
+            variant="secondary"
+            onClick={onSync}
+            isLoading={sync.isPending}
+            disabled={sync.isPending}
+          >
+            {!sync.isPending && <ArrowPath className="mr-1" />}
+            Sync now
+          </Button>
+        )}
+      </div>
+
+      {/* Bound-state header */}
+      {!statusLoading && status && !status.bound && (
+        <Container className="m-6 p-6">
+          <Heading level="h3">No Search Console property bound</Heading>
+          <Text className="text-ui-fg-subtle" size="small">
+            {status.website
+              ? `${status.website.domain} doesn't have a verified Search Console property bound on any of your Google connections.`
+              : ""}{" "}
+            Connect Google in Settings → External Platforms and bind one of the
+            following resource URLs as a Search Console binding:
+          </Text>
+          <ul className="mt-3 text-xs text-ui-fg-subtle font-mono space-y-1">
+            {status.candidates.map((c) => (
+              <li key={c}>• {c}</li>
+            ))}
+          </ul>
+        </Container>
+      )}
+
+      {status?.bound && (
+        <>
+          <div className="flex flex-wrap items-center gap-3 px-6 pb-3">
+            <Text size="small" className="text-ui-fg-subtle whitespace-nowrap">
+              From:
+            </Text>
+            <Input
+              type="date"
+              size="small"
+              value={from}
+              onChange={(e) => updateParam("from", e.target.value)}
+              className="w-[160px]"
+            />
+            <Text size="small" className="text-ui-fg-subtle whitespace-nowrap">
+              To:
+            </Text>
+            <Input
+              type="date"
+              size="small"
+              value={to}
+              onChange={(e) => updateParam("to", e.target.value)}
+              className="w-[160px]"
+            />
+            <div className="ml-auto flex items-center gap-2">
+              <Text size="small" className="text-ui-fg-subtle whitespace-nowrap">
+                Property:
+              </Text>
+              <Text size="small" className="font-mono">
+                {status.binding?.resource_id}
+              </Text>
+              {status.site?.sync_status && (
+                <StatusBadge color={statusColor(status.site.sync_status)}>
+                  {status.site.sync_status}
+                </StatusBadge>
+              )}
+            </div>
+          </div>
+
+          <Container className="m-6 p-0 divide-y">
+            <div className="px-6 py-6">
+              <Heading level="h3" className="mb-1">
+                Performance trend
+              </Heading>
+              <Text size="small" className="text-ui-fg-subtle mb-4">
+                Daily clicks and impressions (left axis), average position
+                (right axis).
+              </Text>
+              {!status.site ? (
+                <Text size="small" className="text-ui-fg-subtle">
+                  Site bound but never synced yet. Hit{" "}
+                  <span className="font-medium">Sync now</span> above to pull
+                  data.
+                </Text>
+              ) : (trend.data?.rows.length || 0) === 0 ? (
+                <Text size="small" className="text-ui-fg-subtle">
+                  No rows in this window.
+                </Text>
+              ) : (
+                <ResponsiveContainer width="100%" height={280}>
+                  <LineChart data={trend.data?.rows || []}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis dataKey="date" tick={{ fontSize: 11 }} />
+                    <YAxis yAxisId="left" tick={{ fontSize: 11 }} />
+                    <YAxis
+                      yAxisId="right"
+                      orientation="right"
+                      tick={{ fontSize: 11 }}
+                      reversed
+                    />
+                    <Tooltip />
+                    <Legend />
+                    <Line
+                      yAxisId="left"
+                      type="monotone"
+                      dataKey="clicks"
+                      stroke="#82ca9d"
+                      dot={false}
+                    />
+                    <Line
+                      yAxisId="left"
+                      type="monotone"
+                      dataKey="impressions"
+                      stroke="#8884d8"
+                      dot={false}
+                    />
+                    <Line
+                      yAxisId="right"
+                      type="monotone"
+                      dataKey="position"
+                      stroke="#ff7300"
+                      dot={false}
+                      name="position (lower = better)"
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              )}
+            </div>
+          </Container>
+
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 m-6 mt-0">
+            <DimensionTable
+              title="Top queries"
+              dimension="query"
+              rows={queries.data?.rows || []}
+              isLoading={queries.isLoading}
+            />
+            <DimensionTable
+              title="Top pages"
+              dimension="page"
+              rows={pages.data?.rows || []}
+              isLoading={pages.isLoading}
+            />
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+function statusColor(
+  status: string
+): "green" | "orange" | "red" | "grey" {
+  if (status === "synced") return "green"
+  if (status === "syncing" || status === "pending") return "orange"
+  if (status === "error") return "red"
+  return "grey"
+}
+
+const columnHelper = createColumnHelper<ConsoleInsightRow>()
+
+const DimensionTable = ({
+  title,
+  dimension,
+  rows,
+  isLoading,
+}: {
+  title: string
+  dimension: ConsoleDimension
+  rows: ConsoleInsightRow[]
+  isLoading: boolean
+}) => {
+  const [pageIndex, setPageIndex] = useState(0)
+  const pageSize = 20
+
+  const columns = useMemo(
+    () => [
+      columnHelper.accessor((r) => r[dimension] || "—", {
+        id: dimension,
+        header: dimension.charAt(0).toUpperCase() + dimension.slice(1),
+        cell: (info) => (
+          <span className="truncate block max-w-[420px]" title={String(info.getValue())}>
+            {String(info.getValue())}
+          </span>
+        ),
+      }),
+      columnHelper.accessor("clicks", {
+        header: "Clicks",
+        cell: (info) => formatInt(info.getValue()),
+      }),
+      columnHelper.accessor("impressions", {
+        header: "Impressions",
+        cell: (info) => formatInt(info.getValue()),
+      }),
+      columnHelper.accessor("ctr", {
+        header: "CTR",
+        cell: (info) =>
+          info.getValue() === null || info.getValue() === undefined
+            ? "—"
+            : `${((info.getValue() as number) * 100).toFixed(2)}%`,
+      }),
+      columnHelper.accessor("position", {
+        header: "Position",
+        cell: (info) =>
+          info.getValue() === null || info.getValue() === undefined
+            ? "—"
+            : (info.getValue() as number).toFixed(1),
+      }),
+    ],
+    [dimension]
+  )
+
+  const pagination: DataTablePaginationState = {
+    pageIndex,
+    pageSize,
+  }
+  const pageStart = pageIndex * pageSize
+  const pageRows = rows.slice(pageStart, pageStart + pageSize)
+
+  const table = useDataTable({
+    data: pageRows,
+    columns,
+    rowCount: rows.length,
+    getRowId: (row) => String((row as any)[dimension] || Math.random()),
+    isLoading,
+    pagination: {
+      state: pagination,
+      onPaginationChange: (next) => setPageIndex(next.pageIndex),
+    },
+  })
+
+  return (
+    <Container className="divide-y p-0">
+      <DataTable instance={table}>
+        <DataTable.Toolbar className="flex flex-col md:flex-row justify-between gap-y-4 w-full px-6 py-4">
+          <div>
+            <Heading>{title}</Heading>
+            <Text className="text-ui-fg-subtle" size="small">
+              {rows.length} {dimension === "query" ? "queries" : "pages"} ranked
+              by clicks in the selected window.
+            </Text>
+          </div>
+        </DataTable.Toolbar>
+        <DataTable.Table />
+        <DataTable.Pagination />
+      </DataTable>
+    </Container>
+  )
+}
+
+function formatInt(n: number | null | undefined): string {
+  if (n === null || n === undefined) return "—"
+  return new Intl.NumberFormat("en-US").format(n)
+}

--- a/apps/backend/src/api/admin/websites/[id]/console/insights/route.ts
+++ b/apps/backend/src/api/admin/websites/[id]/console/insights/route.ts
@@ -1,0 +1,213 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { SOCIALS_MODULE } from "../../../../../../modules/socials"
+import { resolveSearchConsoleBindingForWebsite } from "../../../../../../lib/search-console-resolver"
+
+/**
+ * GET /admin/websites/:id/console/insights
+ *
+ * Returns daily Search Analytics rows for the website's bound GSC site.
+ *
+ * Query params:
+ *   from        YYYY-MM-DD  (inclusive)        default: 28 days ago
+ *   to          YYYY-MM-DD  (inclusive)        default: today
+ *   dimension   "query" | "page" | "country" | "device" | "date"
+ *                                              default: "date"
+ *                — when set to anything other than "date", the response is
+ *                grouped by that dimension across the date range, sorted
+ *                by clicks DESC. "date" returns one row per day.
+ *   limit       1–500                          default: 100
+ *
+ * Response: `{ rows: [...], dimension, total: { clicks, impressions } }`
+ */
+type Dim = "date" | "query" | "page" | "country" | "device"
+
+const DEFAULT_FROM_DAYS = 28
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const websiteId = req.params.id
+  const dimension = (req.query?.dimension as Dim) || "date"
+  if (!isDim(dimension)) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `dimension must be one of date, query, page, country, device`
+    )
+  }
+  const limit = clamp(parseInt(String(req.query?.limit ?? "100"), 10) || 100, 1, 500)
+
+  const today = new Date()
+  const defaultFrom = new Date(today)
+  defaultFrom.setDate(defaultFrom.getDate() - (DEFAULT_FROM_DAYS - 1))
+  const from = String(req.query?.from || ymd(defaultFrom))
+  const to = String(req.query?.to || ymd(today))
+
+  const { binding } = await resolveSearchConsoleBindingForWebsite(
+    req.scope,
+    websiteId
+  )
+  if (!binding) {
+    return res.status(200).json({
+      rows: [],
+      dimension,
+      total: { clicks: 0, impressions: 0 },
+      bound: false,
+    })
+  }
+
+  const socials = req.scope.resolve(SOCIALS_MODULE) as any
+  const [site] = await socials.listGoogleSearchConsoleSites(
+    { platform_id: binding.platform_id, site_url: binding.resource_id },
+    { take: 1 }
+  )
+  if (!site) {
+    return res.status(200).json({
+      rows: [],
+      dimension,
+      total: { clicks: 0, impressions: 0 },
+      bound: true,
+      synced: false,
+    })
+  }
+
+  // Pull every row in the window once. With 5000/day × 28 days = ~140k
+  // rows worst case, but typically far less. Aggregating in memory is
+  // cheaper than firing a separate group-by query per dimension request.
+  const raw = await socials.listGoogleSearchConsoleInsights(
+    { site_id: site.id },
+    { take: 200_000, order: { date: "ASC" } }
+  )
+  const inWindow = raw.filter(
+    (r: any) => r.date >= from && r.date <= to
+  )
+
+  let total = 0
+  let totalImpressions = 0
+  for (const r of inWindow) {
+    total += toNumber(r.clicks)
+    totalImpressions += toNumber(r.impressions)
+  }
+
+  if (dimension === "date") {
+    // Group by date — one row per day. Average position is weighted by
+    // impressions; CTR derived from totals.
+    const byDate = new Map<
+      string,
+      {
+        date: string
+        clicks: number
+        impressions: number
+        position_num: number
+        position_den: number
+      }
+    >()
+    for (const r of inWindow) {
+      const slot = byDate.get(r.date) || {
+        date: r.date,
+        clicks: 0,
+        impressions: 0,
+        position_num: 0,
+        position_den: 0,
+      }
+      slot.clicks += toNumber(r.clicks)
+      slot.impressions += toNumber(r.impressions)
+      if (r.position !== null && r.position !== undefined) {
+        slot.position_num += (Number(r.position) || 0) * toNumber(r.impressions)
+        slot.position_den += toNumber(r.impressions)
+      }
+      byDate.set(r.date, slot)
+    }
+    const rows = [...byDate.values()]
+      .map((s) => ({
+        date: s.date,
+        clicks: s.clicks,
+        impressions: s.impressions,
+        ctr: s.impressions ? s.clicks / s.impressions : null,
+        position: s.position_den ? s.position_num / s.position_den : null,
+      }))
+      .sort((a, b) => a.date.localeCompare(b.date))
+    return res.status(200).json({
+      rows,
+      dimension,
+      total: { clicks: total, impressions: totalImpressions },
+      bound: true,
+      synced: true,
+      window: { from, to },
+    })
+  }
+
+  // Group by query/page/country/device. Skip rows where the dimension is
+  // null — those are anonymized "no query" buckets we don't want to mix.
+  const byKey = new Map<
+    string,
+    {
+      key: string
+      clicks: number
+      impressions: number
+      position_num: number
+      position_den: number
+    }
+  >()
+  for (const r of inWindow) {
+    const value = r[dimension as keyof typeof r] as string | null | undefined
+    if (!value) continue
+    const slot = byKey.get(value) || {
+      key: value,
+      clicks: 0,
+      impressions: 0,
+      position_num: 0,
+      position_den: 0,
+    }
+    slot.clicks += toNumber(r.clicks)
+    slot.impressions += toNumber(r.impressions)
+    if (r.position !== null && r.position !== undefined) {
+      slot.position_num += (Number(r.position) || 0) * toNumber(r.impressions)
+      slot.position_den += toNumber(r.impressions)
+    }
+    byKey.set(value, slot)
+  }
+  const rows = [...byKey.values()]
+    .map((s) => ({
+      [dimension]: s.key,
+      clicks: s.clicks,
+      impressions: s.impressions,
+      ctr: s.impressions ? s.clicks / s.impressions : null,
+      position: s.position_den ? s.position_num / s.position_den : null,
+    }))
+    .sort((a: any, b: any) => b.clicks - a.clicks)
+    .slice(0, limit)
+
+  res.status(200).json({
+    rows,
+    dimension,
+    total: { clicks: total, impressions: totalImpressions },
+    bound: true,
+    synced: true,
+    window: { from, to },
+  })
+}
+
+function isDim(s: string): s is Dim {
+  return ["date", "query", "page", "country", "device"].includes(s)
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.min(hi, Math.max(lo, n))
+}
+
+function ymd(d: Date): string {
+  const y = d.getUTCFullYear()
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0")
+  const day = String(d.getUTCDate()).padStart(2, "0")
+  return `${y}-${m}-${day}`
+}
+
+function toNumber(v: any): number {
+  if (v === null || v === undefined || v === "") return 0
+  if (typeof v === "number") return Number.isFinite(v) ? v : 0
+  if (typeof v === "string") {
+    const n = Number(v)
+    return Number.isFinite(n) ? n : 0
+  }
+  if (typeof v === "object" && v && "value" in v) return toNumber((v as any).value)
+  return 0
+}

--- a/apps/backend/src/api/admin/websites/[id]/console/route.ts
+++ b/apps/backend/src/api/admin/websites/[id]/console/route.ts
@@ -1,0 +1,58 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { SOCIALS_MODULE } from "../../../../../modules/socials"
+import {
+  resolveSearchConsoleBindingForWebsite,
+} from "../../../../../lib/search-console-resolver"
+
+/**
+ * GET /admin/websites/:id/console
+ *
+ * Returns the Search Console state for a website:
+ *
+ *   { website: {...}, bound: true, site: {...}, last_synced_at: ... }
+ *   { website: {...}, bound: false, candidates: [...] }   // no GSC binding for this domain
+ *   { website: null }                                     // website not found
+ *
+ * Frontend uses this single endpoint to decide whether to render the
+ * data view or the "bind a property" empty state.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const websiteId = req.params.id
+  if (!websiteId) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "website id is required"
+    )
+  }
+
+  const { website, binding, candidates } =
+    await resolveSearchConsoleBindingForWebsite(req.scope, websiteId)
+
+  if (!website) {
+    return res.status(404).json({ website: null })
+  }
+
+  if (!binding) {
+    return res.status(200).json({
+      website,
+      bound: false,
+      candidates,
+    })
+  }
+
+  // We have a binding; look up the synced site row (if any).
+  const socials = req.scope.resolve(SOCIALS_MODULE) as any
+  const [site] = await socials.listGoogleSearchConsoleSites(
+    { platform_id: binding.platform_id, site_url: binding.resource_id },
+    { take: 1 }
+  )
+
+  res.status(200).json({
+    website,
+    bound: true,
+    binding,
+    site: site || null,
+    candidates,
+  })
+}

--- a/apps/backend/src/api/admin/websites/[id]/console/sync/route.ts
+++ b/apps/backend/src/api/admin/websites/[id]/console/sync/route.ts
@@ -1,0 +1,53 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { resolveSearchConsoleBindingForWebsite } from "../../../../../../lib/search-console-resolver"
+import { syncSearchConsoleWorkflow } from "../../../../../../workflows/google-search-console/sync-search-console"
+
+type SyncBody = {
+  window_days?: number
+  row_limit?: number
+  dimensions?: Array<
+    "date" | "query" | "page" | "country" | "device" | "searchAppearance"
+  >
+}
+
+/**
+ * POST /admin/websites/:id/console/sync
+ *
+ * Triggers a Search Console sync scoped to this website's bound property.
+ * Resolves the GSC binding via the same matcher as GET /console — so the
+ * operator never has to remember which platform the property is bound on.
+ */
+export const POST = async (req: MedusaRequest<SyncBody>, res: MedusaResponse) => {
+  const websiteId = req.params.id
+  const body = (req.body || {}) as SyncBody
+
+  const { website, binding } = await resolveSearchConsoleBindingForWebsite(
+    req.scope,
+    websiteId
+  )
+  if (!website) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Website ${websiteId} not found`
+    )
+  }
+  if (!binding) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `No Search Console property is bound for ${website.domain}. Bind one under Settings → External Platforms.`
+    )
+  }
+
+  const { result } = await syncSearchConsoleWorkflow(req.scope).run({
+    input: {
+      platform_id: binding.platform_id,
+      site_url: binding.resource_id,
+      window_days: body.window_days,
+      row_limit: body.row_limit,
+      dimensions: body.dimensions,
+    },
+  })
+
+  res.status(200).json({ website, binding, result })
+}

--- a/apps/backend/src/lib/search-console-resolver.ts
+++ b/apps/backend/src/lib/search-console-resolver.ts
@@ -1,0 +1,135 @@
+import { SOCIALS_MODULE } from "../modules/socials"
+import { WEBSITE_MODULE } from "../modules/website"
+
+/**
+ * Find the Google Search Console binding that covers a given website's
+ * domain. GSC stores `siteUrl` in two flavours and a website's domain
+ * field is a bare hostname, so the matcher has to consider every plausible
+ * form.
+ *
+ * Given a website with `domain = "cicilabel.com"`, this matches against
+ * bindings whose `resource_id` is any of:
+ *   - "https://cicilabel.com/"        (URL-prefix property, https)
+ *   - "http://cicilabel.com/"         (URL-prefix property, http — rare)
+ *   - "https://www.cicilabel.com/"    (URL-prefix with www)
+ *   - "sc-domain:cicilabel.com"       (Domain property — covers all subdomains)
+ *
+ * If a website's domain is itself a subdomain (e.g. "shop.example.com"),
+ * the sc-domain property for the parent ("sc-domain:example.com") is also
+ * considered a valid match — Domain properties cover everything below.
+ *
+ * Returns the first match found, or null if the website has no GSC
+ * property bound on any platform.
+ */
+export type SearchConsoleBinding = {
+  binding_id: string
+  platform_id: string
+  resource_id: string // the site_url as stored on the binding
+  matched_via: "url_prefix" | "url_prefix_www" | "sc_domain" | "sc_domain_parent"
+}
+
+export async function resolveSearchConsoleBindingForWebsite(
+  scope: any,
+  websiteId: string
+): Promise<{
+  website: { id: string; domain: string; name: string } | null
+  binding: SearchConsoleBinding | null
+  candidates: string[]
+}> {
+  const websiteService = scope.resolve(WEBSITE_MODULE) as any
+  const socials = scope.resolve(SOCIALS_MODULE) as any
+
+  const [website] = await websiteService.listWebsites(
+    { id: websiteId },
+    { take: 1 }
+  )
+  if (!website) {
+    return { website: null, binding: null, candidates: [] }
+  }
+
+  const domain = String(website.domain || "").trim().toLowerCase()
+  if (!domain) {
+    return {
+      website: { id: website.id, domain: "", name: website.name || "" },
+      binding: null,
+      candidates: [],
+    }
+  }
+
+  const candidates = buildSearchConsoleCandidates(domain)
+
+  // Single query — any of the candidate site_urls. We don't filter by
+  // platform_id because we don't know which platform the operator bound
+  // the GSC property under; we just want the first match.
+  const bindings = await socials.listSocialPlatformBindings({
+    service: "search-console",
+    resource_id: candidates.map((c) => c.value),
+  })
+
+  if (!bindings?.length) {
+    return {
+      website: { id: website.id, domain, name: website.name || "" },
+      binding: null,
+      candidates: candidates.map((c) => c.value),
+    }
+  }
+
+  // Pick the most specific match. URL-prefix is more specific than
+  // sc-domain (which can cover unrelated subdomains too).
+  const ordered = candidates
+    .map((c) => bindings.find((b: any) => b.resource_id === c.value && c))
+    .filter(Boolean) as any[]
+  const winner = ordered[0] || bindings[0]
+  const matchedCandidate = candidates.find(
+    (c) => c.value === winner.resource_id
+  )
+
+  return {
+    website: { id: website.id, domain, name: website.name || "" },
+    binding: {
+      binding_id: winner.id,
+      platform_id: winner.platform_id,
+      resource_id: winner.resource_id,
+      matched_via: matchedCandidate?.kind || "url_prefix",
+    },
+    candidates: candidates.map((c) => c.value),
+  }
+}
+
+type Candidate = {
+  value: string
+  kind: SearchConsoleBinding["matched_via"]
+}
+
+/**
+ * Generate the plausible Search Console site_url forms for a given bare
+ * domain. Ordered by specificity — exact URL-prefix first, parent-domain
+ * fallback last. The matcher returns the first hit, so this order is
+ * load-bearing.
+ */
+export function buildSearchConsoleCandidates(domain: string): Candidate[] {
+  const d = domain.replace(/^https?:\/\//, "").replace(/\/$/, "")
+  const out: Candidate[] = [
+    { value: `https://${d}/`, kind: "url_prefix" },
+    { value: `http://${d}/`, kind: "url_prefix" },
+  ]
+
+  // Add www. variants only when the input doesn't already include www.
+  if (!d.startsWith("www.")) {
+    out.push({ value: `https://www.${d}/`, kind: "url_prefix_www" })
+    out.push({ value: `http://www.${d}/`, kind: "url_prefix_www" })
+  }
+
+  // sc-domain on the exact hostname
+  out.push({ value: `sc-domain:${d}`, kind: "sc_domain" })
+
+  // sc-domain on the parent — e.g. shop.example.com → sc-domain:example.com.
+  // Stop at the second-level domain to avoid matching on TLDs.
+  const parts = d.split(".")
+  if (parts.length > 2) {
+    const parent = parts.slice(-2).join(".")
+    out.push({ value: `sc-domain:${parent}`, kind: "sc_domain_parent" })
+  }
+
+  return out
+}

--- a/apps/backend/src/modules/socials/migrations/Migration20260512152434.ts
+++ b/apps/backend/src/modules/socials/migrations/Migration20260512152434.ts
@@ -1,0 +1,62 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+export class Migration20260512152434 extends Migration {
+
+  override async up(): Promise<void> {
+    // GoogleSearchConsoleSite — one row per bound GSC property
+    this.addSql(`create table if not exists "google_search_console_site" (
+      "id" text not null,
+      "site_url" text not null,
+      "permission_level" text null,
+      "last_synced_at" timestamptz null,
+      "sync_status" text check ("sync_status" in ('synced', 'syncing', 'error', 'pending')) not null default 'pending',
+      "sync_error" text null,
+      "binding_id" text null,
+      "platform_id" text not null,
+      "created_at" timestamptz not null default now(),
+      "updated_at" timestamptz not null default now(),
+      "deleted_at" timestamptz null,
+      constraint "google_search_console_site_pkey" primary key ("id")
+    );`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_google_search_console_site_platform_id" ON "google_search_console_site" ("platform_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_google_search_console_site_deleted_at" ON "google_search_console_site" ("deleted_at") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "idx_google_search_console_site_url" ON "google_search_console_site" ("site_url") WHERE deleted_at IS NULL;`);
+
+    // GoogleSearchConsoleInsights — daily Search Analytics rows
+    this.addSql(`create table if not exists "google_search_console_insights" (
+      "id" text not null,
+      "date" text not null,
+      "query" text null,
+      "page" text null,
+      "country" text null,
+      "device" text null,
+      "search_appearance" text null,
+      "clicks" numeric not null default 0,
+      "impressions" numeric not null default 0,
+      "ctr" real null,
+      "position" real null,
+      "site_id" text not null,
+      "raw" jsonb null,
+      "synced_at" timestamptz not null,
+      "raw_clicks" jsonb not null default '{"value":"0","precision":20}',
+      "raw_impressions" jsonb not null default '{"value":"0","precision":20}',
+      "created_at" timestamptz not null default now(),
+      "updated_at" timestamptz not null default now(),
+      "deleted_at" timestamptz null,
+      constraint "google_search_console_insights_pkey" primary key ("id")
+    );`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_google_search_console_insights_site_id" ON "google_search_console_insights" ("site_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_google_search_console_insights_deleted_at" ON "google_search_console_insights" ("deleted_at") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "idx_google_search_console_insights_date" ON "google_search_console_insights" ("date") WHERE deleted_at IS NULL;`);
+
+    // FK chain
+    this.addSql(`alter table if exists "google_search_console_site" add constraint "google_search_console_site_platform_id_foreign" foreign key ("platform_id") references "social_platform" ("id") on update cascade;`);
+    this.addSql(`alter table if exists "google_search_console_insights" add constraint "google_search_console_insights_site_id_foreign" foreign key ("site_id") references "google_search_console_site" ("id") on update cascade on delete cascade;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "google_search_console_insights" cascade;`);
+    this.addSql(`drop table if exists "google_search_console_site" cascade;`);
+  }
+
+}

--- a/apps/backend/src/modules/socials/models/GoogleSearchConsoleInsights.ts
+++ b/apps/backend/src/modules/socials/models/GoogleSearchConsoleInsights.ts
@@ -1,0 +1,57 @@
+import { model } from "@medusajs/framework/utils"
+import GoogleSearchConsoleSite from "./GoogleSearchConsoleSite"
+
+/**
+ * GoogleSearchConsoleInsights
+ *
+ * Daily Search Analytics rows from the GSC API. One row per
+ * (site, date, query, page, country, device) tuple — any dimension can be
+ * null when GSC returns an aggregate row (e.g. "no query specified" /
+ * anonymized queries).
+ *
+ * Why a single denormalized table: GSC's Search Analytics endpoint returns
+ * exactly this shape per request; we'd just be re-fanning the same row
+ * into multiple narrower tables and losing the ability to answer cross-
+ * dimension questions ("which page did query X land on for users in DE
+ * on mobile"). 5,000 rows / site / day keeps storage linear and the
+ * indexes small.
+ */
+const GoogleSearchConsoleInsights = model.define(
+  "GoogleSearchConsoleInsights",
+  {
+    id: model.id().primaryKey(),
+
+    // Period — Search Analytics is always per-day for this sync.
+    date: model.text(), // YYYY-MM-DD
+
+    // Dimensions — any subset may be present per row, depending on the
+    // sync's `dimensions` array. Default sync sets all five.
+    query: model.text().searchable().nullable(),
+    page: model.text().searchable().nullable(),
+    country: model.text().nullable(), // ISO 3166-1 alpha-3 (per GSC)
+    device: model.text().nullable(), // DESKTOP | MOBILE | TABLET
+    search_appearance: model.text().nullable(), // AMP_TOP_STORIES, RICH_RESULTS, etc.
+
+    // Metrics
+    clicks: model.bigNumber().default(0),
+    impressions: model.bigNumber().default(0),
+    ctr: model.float().nullable(), // 0..1 (Google's native range — not %)
+    position: model.float().nullable(), // average position
+
+    // Relationships
+    site: model.belongsTo(() => GoogleSearchConsoleSite, {
+      mappedBy: "insights",
+    }),
+
+    // Audit
+    raw: model.json().nullable(),
+    synced_at: model.dateTime(),
+  }
+).indexes([
+  {
+    on: ["date"],
+    name: "idx_google_search_console_insights_date",
+  },
+])
+
+export default GoogleSearchConsoleInsights

--- a/apps/backend/src/modules/socials/models/GoogleSearchConsoleSite.ts
+++ b/apps/backend/src/modules/socials/models/GoogleSearchConsoleSite.ts
@@ -1,0 +1,51 @@
+import { model } from "@medusajs/framework/utils"
+import SocialPlatform from "./SocialPlatform"
+import GoogleSearchConsoleInsights from "./GoogleSearchConsoleInsights"
+
+/**
+ * GoogleSearchConsoleSite
+ *
+ * A verified Google Search Console property bound to a SocialPlatform (the
+ * Google Business Manager connection). One row per (platform, site_url) we
+ * have visibility into via Search Console.
+ *
+ * site_url comes back from Search Console in one of two forms:
+ *   - "https://example.com/"        — URL-prefix property (scheme + host + /)
+ *   - "sc-domain:example.com"       — Domain property (covers all subdomains
+ *                                     and protocols of example.com)
+ *
+ * We store whichever shape Google returned without normalizing — when we
+ * later resolve a website row to a bound property, the resolver matches
+ * across both forms in code.
+ */
+const GoogleSearchConsoleSite = model.define("GoogleSearchConsoleSite", {
+  id: model.id().primaryKey(),
+
+  site_url: model.text().searchable(),
+  permission_level: model.text().nullable(), // siteOwner | siteFullUser | siteRestrictedUser
+
+  // Sync metadata
+  last_synced_at: model.dateTime().nullable(),
+  sync_status: model
+    .enum(["synced", "syncing", "error", "pending"])
+    .default("pending"),
+  sync_error: model.text().nullable(),
+
+  // Source binding — text (not FK) so deleting a binding doesn't cascade
+  // and wipe synced data. Matches the GoogleAdsCustomer pattern.
+  binding_id: model.text().nullable(),
+
+  platform: model.belongsTo(() => SocialPlatform, {
+    mappedBy: "google_search_console_sites",
+  }),
+  insights: model.hasMany(() => GoogleSearchConsoleInsights, {
+    mappedBy: "site",
+  }),
+}).indexes([
+  {
+    on: ["site_url"],
+    name: "idx_google_search_console_site_url",
+  },
+])
+
+export default GoogleSearchConsoleSite

--- a/apps/backend/src/modules/socials/service.ts
+++ b/apps/backend/src/modules/socials/service.ts
@@ -17,6 +17,8 @@ import GoogleAdsCampaign from "./models/GoogleAdsCampaign";
 import GoogleAdsAdGroup from "./models/GoogleAdsAdGroup";
 import GoogleAdsAd from "./models/GoogleAdsAd";
 import GoogleAdsInsights from "./models/GoogleAdsInsights";
+import GoogleSearchConsoleSite from "./models/GoogleSearchConsoleSite";
+import GoogleSearchConsoleInsights from "./models/GoogleSearchConsoleInsights";
 import { MedusaService } from "@medusajs/framework/utils";
 import { extractHashtags, extractMentions } from "./utils/text-extraction";
 import type { WhatsAppPlatformApiConfig } from "./types/whatsapp-platform";
@@ -44,6 +46,9 @@ class SocialsService extends MedusaService({
   GoogleAdsAdGroup,
   GoogleAdsAd,
   GoogleAdsInsights,
+  // Google Search Console models
+  GoogleSearchConsoleSite,
+  GoogleSearchConsoleInsights,
 }) {
   constructor() {
     super(...arguments)

--- a/apps/backend/src/workflows/google-search-console/steps/sync-search-console-step.ts
+++ b/apps/backend/src/workflows/google-search-console/steps/sync-search-console-step.ts
@@ -1,0 +1,371 @@
+import axios from "axios"
+import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+} from "@medusajs/framework/utils"
+import type { Logger } from "@medusajs/types"
+import { SOCIALS_MODULE } from "../../../modules/socials"
+import { withGoogleRetry } from "../../../modules/social-provider/google-retry"
+
+export type SyncSearchConsoleInput = {
+  platform_id: string
+  /** From the upstream refreshGoogleTokenStep */
+  access_token: string
+  /** Optional: scope to a single site_url; defaults to all `search-console` bindings */
+  site_url?: string
+  /** Window in days. Default 28 (GSC's own default). Max 16 months. */
+  window_days?: number
+  /**
+   * Dimensions to request. Default ["date","query","page","country","device"].
+   * Note: more dimensions → more rows → faster cap-out at 5000.
+   */
+  dimensions?: Array<
+    "date" | "query" | "page" | "country" | "device" | "searchAppearance"
+  >
+  /** Row cap per sync call. Default 5000; max 25000 per GSC. */
+  row_limit?: number
+}
+
+export type SyncSearchConsoleOutput = {
+  platform_id: string
+  sites_synced: number
+  insights_rows_synced: number
+  errors: Array<{ site_url: string; message: string }>
+}
+
+const GSC_API_BASE = "https://searchconsole.googleapis.com/webmasters/v3"
+
+const DEFAULT_DIMENSIONS = ["date", "query", "page", "country", "device"]
+
+/**
+ * Pull-and-upsert Search Analytics data for every `search-console` binding
+ * on a platform.
+ *
+ * Flow per site:
+ *   1. POST searchAnalytics/query with the requested dimensions + date range.
+ *   2. Upsert the site row (descriptive metadata + sync status).
+ *   3. Upsert one insights row per returned key tuple. Existing rows for the
+ *      same key are UPDATEd in place rather than appended.
+ *
+ * Best-effort per site: a failure on one site doesn't stop the rest, but the
+ * error is recorded on the site row's `sync_status: "error"`.
+ */
+export const syncSearchConsoleStep = createStep(
+  "sync-search-console-step",
+  async (input: SyncSearchConsoleInput, { container }) => {
+    const socials = container.resolve(SOCIALS_MODULE) as any
+    const logger = container.resolve(ContainerRegistrationKeys.LOGGER) as Logger
+
+    const windowDays = Math.min(Math.max(input.window_days ?? 28, 1), 480)
+    const dimensions =
+      input.dimensions && input.dimensions.length > 0
+        ? input.dimensions
+        : DEFAULT_DIMENSIONS
+    const rowLimit = Math.min(Math.max(input.row_limit ?? 5000, 1), 25000)
+
+    // Resolve target sites from bindings.
+    const bindings = await socials.listSocialPlatformBindings({
+      platform_id: input.platform_id,
+      service: "search-console",
+    })
+
+    const targets = (
+      input.site_url
+        ? bindings.filter((b: any) => b.resource_id === input.site_url)
+        : bindings
+    ).map((b: any) => ({
+      binding_id: b.id as string,
+      site_url: String(b.resource_id),
+      permission_level: (b.metadata?.permissionLevel as string) || null,
+    }))
+
+    if (targets.length === 0) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        input.site_url
+          ? `No Search Console binding for site ${input.site_url}`
+          : "No Search Console bindings on this platform — bind a verified property first"
+      )
+    }
+
+    const headers = {
+      Authorization: `Bearer ${input.access_token}`,
+      "Content-Type": "application/json",
+    }
+
+    const today = new Date()
+    const endDate = formatDate(today)
+    const start = new Date(today)
+    // GSC has a ~2-day data lag; we still ask for "today" and let Google
+    // return whatever's ready. Subtracting (windowDays - 1) makes the
+    // returned window inclusive of today, matching what operators expect.
+    start.setDate(start.getDate() - (windowDays - 1))
+    const startDate = formatDate(start)
+
+    let sitesSynced = 0
+    let insightsRowsSynced = 0
+    const errors: Array<{ site_url: string; message: string }> = []
+
+    for (const t of targets) {
+      try {
+        const rows = await fetchSearchAnalytics({
+          site_url: t.site_url,
+          headers,
+          startDate,
+          endDate,
+          dimensions,
+          rowLimit,
+          logger,
+        })
+
+        const siteRow = await upsertSite(socials, {
+          platform_id: input.platform_id,
+          binding_id: t.binding_id,
+          site_url: t.site_url,
+          permission_level: t.permission_level,
+        })
+        sitesSynced += 1
+
+        const written = await upsertInsights(socials, {
+          site_id: siteRow.id,
+          rows,
+          dimensions,
+        })
+        insightsRowsSynced += written
+      } catch (e: any) {
+        const msg = e.response?.data?.error?.message || e.message
+        logger?.warn?.(
+          `[gsc] sync failed for site=${t.site_url}: ${msg}`
+        )
+        errors.push({ site_url: t.site_url, message: msg })
+
+        try {
+          await markSiteError(socials, input.platform_id, t.site_url, msg)
+        } catch {
+          // ignore — the site row may not exist yet on first failed sync
+        }
+      }
+    }
+
+    return new StepResponse<SyncSearchConsoleOutput>({
+      platform_id: input.platform_id,
+      sites_synced: sitesSynced,
+      insights_rows_synced: insightsRowsSynced,
+      errors,
+    })
+  }
+)
+
+function formatDate(d: Date): string {
+  // YYYY-MM-DD in UTC. GSC expects this exact format.
+  const y = d.getUTCFullYear()
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0")
+  const day = String(d.getUTCDate()).padStart(2, "0")
+  return `${y}-${m}-${day}`
+}
+
+async function fetchSearchAnalytics(args: {
+  site_url: string
+  headers: Record<string, string>
+  startDate: string
+  endDate: string
+  dimensions: string[]
+  rowLimit: number
+  logger?: Logger
+}): Promise<any[]> {
+  // GSC's site_url goes in the path encoded — sc-domain URLs contain ":"
+  // which has to survive encodeURIComponent untouched (it's safe in path
+  // segments, and Google's docs use the encoded form).
+  const encoded = encodeURIComponent(args.site_url)
+  const url = `${GSC_API_BASE}/sites/${encoded}/searchAnalytics/query`
+
+  const body = {
+    startDate: args.startDate,
+    endDate: args.endDate,
+    dimensions: args.dimensions,
+    rowLimit: args.rowLimit,
+    // Google sorts by clicks DESC by default — that's exactly what we
+    // want for the top-N rows we plan to render.
+  }
+
+  const res = await withGoogleRetry(
+    () => axios.post(url, body, { headers: args.headers }),
+    { label: `gsc.searchAnalytics(${args.site_url})`, logger: args.logger, maxAttempts: 3 }
+  )
+
+  return Array.isArray(res.data?.rows) ? res.data.rows : []
+}
+
+async function upsertSite(
+  socials: any,
+  data: {
+    platform_id: string
+    binding_id: string
+    site_url: string
+    permission_level: string | null
+  }
+) {
+  const [existing] = await socials.listGoogleSearchConsoleSites(
+    { platform_id: data.platform_id, site_url: data.site_url },
+    { take: 1 }
+  )
+  const now = new Date()
+  if (existing) {
+    const [updated] = await socials.updateGoogleSearchConsoleSites([
+      {
+        selector: { id: existing.id },
+        data: {
+          ...data,
+          last_synced_at: now,
+          sync_status: "synced",
+          sync_error: null,
+        },
+      },
+    ])
+    return updated
+  }
+  const [created] = await socials.createGoogleSearchConsoleSites([
+    {
+      ...data,
+      last_synced_at: now,
+      sync_status: "synced",
+    },
+  ])
+  return created
+}
+
+async function markSiteError(
+  socials: any,
+  platform_id: string,
+  site_url: string,
+  message: string
+) {
+  const [existing] = await socials.listGoogleSearchConsoleSites(
+    { platform_id, site_url },
+    { take: 1 }
+  )
+  if (!existing) return
+  await socials.updateGoogleSearchConsoleSites([
+    {
+      selector: { id: existing.id },
+      data: { sync_status: "error", sync_error: message.slice(0, 1000) },
+    },
+  ])
+}
+
+async function upsertInsights(
+  socials: any,
+  args: { site_id: string; rows: any[]; dimensions: string[] }
+): Promise<number> {
+  const { site_id, rows, dimensions } = args
+  if (rows.length === 0) return 0
+
+  const now = new Date()
+
+  // Pre-fetch existing rows for this site over the date range so we can
+  // diff in memory rather than firing one SELECT per row. With a 5000-
+  // row cap and ~28 days, this is at most ~140k rows to scan but in
+  // practice much less.
+  const dates = new Set<string>()
+  for (const r of rows) {
+    const idx = dimensions.indexOf("date")
+    if (idx >= 0) dates.add(r.keys?.[idx])
+  }
+  const existing = dates.size
+    ? await socials.listGoogleSearchConsoleInsights({
+        site_id,
+        date: [...dates],
+      })
+    : []
+
+  const buildKey = (
+    date: string,
+    query: string | null,
+    page: string | null,
+    country: string | null,
+    device: string | null,
+    searchAppearance: string | null
+  ) =>
+    [
+      date,
+      query ?? "_",
+      page ?? "_",
+      country ?? "_",
+      device ?? "_",
+      searchAppearance ?? "_",
+    ].join("|")
+
+  const byKey = new Map<string, any>()
+  for (const e of existing) {
+    byKey.set(
+      buildKey(
+        e.date,
+        e.query,
+        e.page,
+        e.country,
+        e.device,
+        e.search_appearance
+      ),
+      e
+    )
+  }
+
+  let written = 0
+  for (const row of rows) {
+    const keys: string[] = Array.isArray(row.keys) ? row.keys : []
+    const valueAt = (dim: string): string | null => {
+      const i = dimensions.indexOf(dim)
+      return i >= 0 ? keys[i] ?? null : null
+    }
+    const date = valueAt("date")
+    if (!date) continue // every row must have a date; skip malformed
+
+    const query = valueAt("query")
+    const page = valueAt("page")
+    const country = valueAt("country")
+    const device = valueAt("device")
+    const searchAppearance = valueAt("searchAppearance")
+
+    const data = {
+      site_id,
+      date,
+      query,
+      page,
+      country,
+      device,
+      search_appearance: searchAppearance,
+      clicks: numericMetric(row.clicks),
+      impressions: numericMetric(row.impressions),
+      ctr: floatMetric(row.ctr),
+      position: floatMetric(row.position),
+      raw: row,
+      synced_at: now,
+    }
+
+    const key = buildKey(date, query, page, country, device, searchAppearance)
+    const found = byKey.get(key)
+    if (found) {
+      await socials.updateGoogleSearchConsoleInsights([
+        { selector: { id: found.id }, data },
+      ])
+    } else {
+      await socials.createGoogleSearchConsoleInsights([data])
+    }
+    written += 1
+  }
+
+  return written
+}
+
+function numericMetric(value: any): number {
+  if (value === null || value === undefined || value === "") return 0
+  const n = typeof value === "number" ? value : Number(value)
+  return Number.isFinite(n) ? n : 0
+}
+
+function floatMetric(value: any): number | null {
+  if (value === null || value === undefined || value === "") return null
+  const n = typeof value === "number" ? value : Number(value)
+  return Number.isFinite(n) ? n : null
+}

--- a/apps/backend/src/workflows/google-search-console/sync-search-console.ts
+++ b/apps/backend/src/workflows/google-search-console/sync-search-console.ts
@@ -1,0 +1,55 @@
+import {
+  createWorkflow,
+  WorkflowData,
+  WorkflowResponse,
+  transform,
+} from "@medusajs/framework/workflows-sdk"
+import { refreshGoogleTokenStep } from "../google/steps/refresh-google-token"
+import {
+  syncSearchConsoleStep,
+  type SyncSearchConsoleOutput,
+} from "./steps/sync-search-console-step"
+
+export type SyncSearchConsoleWorkflowInput = {
+  platform_id: string
+  /** Scope to a single site_url; defaults to all `search-console` bindings on the row. */
+  site_url?: string
+  /** Window in days; default 28 (GSC's default). */
+  window_days?: number
+  dimensions?: Array<
+    "date" | "query" | "page" | "country" | "device" | "searchAppearance"
+  >
+  row_limit?: number
+}
+
+export const syncSearchConsoleWorkflowId = "sync-google-search-console-workflow"
+
+/**
+ * Refresh-first, then pull Search Analytics for every Search Console
+ * binding on this platform. Mirror of `syncGoogleAdsWorkflow` — same
+ * shape, same composition pattern.
+ */
+export const syncSearchConsoleWorkflow = createWorkflow(
+  syncSearchConsoleWorkflowId,
+  function (input: WorkflowData<SyncSearchConsoleWorkflowInput>) {
+    const refreshed = refreshGoogleTokenStep({
+      platform_id: input.platform_id,
+      force: false,
+    })
+
+    const syncInput = transform(
+      { input, refreshed },
+      ({ input, refreshed }) => ({
+        platform_id: input.platform_id,
+        access_token: refreshed.access_token,
+        site_url: input.site_url,
+        window_days: input.window_days,
+        dimensions: input.dimensions,
+        row_limit: input.row_limit,
+      })
+    )
+
+    const result = syncSearchConsoleStep(syncInput)
+    return new WorkflowResponse<SyncSearchConsoleOutput>(result)
+  }
+)


### PR DESCRIPTION
## Summary
Adds Google Search Console as a first-class integration alongside Google Ads (PR #218). The binding picker has been able to bind GSC properties for a while, but until now nothing pulled or displayed the data. This PR wires the full pipeline and places the viewing UI inline on the website's admin page (one of our marketplace sites — cicilabel.com, perennial.to, etc. — gets its own console view scoped to its domain).

## How the domain → property match works
A website row carries a bare hostname like \`cicilabel.com\`. Search Console properties come back from Google in one of two flavors (URL-prefix or Domain), with multiple URL variants per domain. The resolver in \`src/lib/search-console-resolver.ts\` matches across every plausible \`site_url\` form:

\`\`\`
https://cicilabel.com/         (url_prefix)
http://cicilabel.com/          (url_prefix)
https://www.cicilabel.com/     (url_prefix_www)
http://www.cicilabel.com/      (url_prefix_www)
sc-domain:cicilabel.com        (sc_domain)
sc-domain:cicilabel.com        (sc_domain_parent — for subdomain websites)
\`\`\`

First specific match wins. The operator never has to know which platform-row the property is bound under.

## New tables
**\`google_search_console_site\`** — one row per bound property
- \`platform_id\` (FK), \`binding_id\`, \`site_url\`, \`permission_level\`
- \`sync_status\`, \`sync_error\`, \`last_synced_at\`

**\`google_search_console_insights\`** — daily Search Analytics rows
- Dimensions: \`date\`, \`query\`, \`page\`, \`country\`, \`device\`, \`search_appearance\` (any can be null)
- Metrics: \`clicks\`, \`impressions\`, \`ctr\` (0..1), \`position\` (average)
- \`raw\` keeps the full GSC row for debugging
- Upsert key is the full \`(site, date, query, page, country, device, search_appearance)\` tuple so re-sync replaces rows instead of duplicating

Migration: \`Migration20260512152434\`.

## Sync workflow
\`syncGoogleSearchConsoleWorkflow\` — refresh-first, then per-binding GAQL pull. Mirror of \`syncGoogleAdsWorkflow\` from PR #218.

Input flags:
- \`platform_id\` (required)
- \`site_url\` — scope to one property; defaults to all \`search-console\` bindings
- \`window_days\` — default 28 (GSC's own default), clamped 1–480
- \`dimensions\` — default \`["date","query","page","country","device"]\`
- \`row_limit\` — default 5,000, max 25,000 (GSC's per-request cap)

Calls \`POST searchconsole.googleapis.com/webmasters/v3/sites/{siteUrl}/searchAnalytics/query\`. Best-effort per site — a 403 on one binding doesn't stop the rest; the failure is recorded on the site row's \`sync_status\`.

## API surface
All under \`/admin/websites/[id]/console\` — operator only ever passes a website id:

| Endpoint | Returns |
|---|---|
| \`GET /\` | Bound state + last sync + the candidate site_url list (for the empty state) |
| \`GET /insights?dimension=date\|query\|page\|country\|device&from=&to=&limit=\` | Grouped rows. \`date\` returns daily trend; everything else returns top-N by clicks, with weighted-average position. |
| \`POST /sync\` | Resolves the binding and runs the sync workflow scoped to that property. |

## Admin UI
\`/admin/websites/[id]/console\` (regular nested page, not a modal):

- Back button to the website detail page
- Property URL + sync status chip in the header
- **Sync now** button (POSTs to \`/sync\`, toasts the row count or any error)
- Date range picker (defaults to last 28 days)
- **Performance trend** — Recharts dual-axis line chart (clicks + impressions on the left axis, average position on the right axis, reversed so lower-is-better reads correctly)
- **Top queries** + **Top pages** tables side-by-side, each paginated 20/page across the top 100 by clicks
- Empty state when no property is bound surfaces the candidate \`site_url\` list so the operator knows exactly what to bind under Settings → External Platforms

Hooks: \`src/admin/hooks/api/search-console.ts\` with \`consoleKeys\` namespace; matches the \`adsKeys\` pattern from PR #218.

## What's intentionally out of scope
- Sitemap list / submission (deferred)
- URL Inspection API (deferred — has tight quota)
- Top-level \`/admin/search-console\` cross-site overview (we may add later if useful, but the per-website placement is the natural mental model)

## Test plan
- [ ] \`medusa db:migrate\` once after merge → confirm \`google_search_console_site\` + \`google_search_console_insights\` tables exist.
- [ ] On a website that has a bound GSC property (URL-prefix variant) → \`/admin/websites/[id]/console\` renders, **Sync now** populates the tables, chart + top tables render with real data.
- [ ] Same with a \`sc-domain:\` property → resolver picks it up; sync works.
- [ ] On a website with no bound property → empty state lists the right candidate URLs.
- [ ] Subdomain website (e.g. \`sharlho.cicilabel.com\`) → matches the parent \`sc-domain:cicilabel.com\` if no exact prefix property exists.
- [ ] Date range narrows the chart and tables consistently.
- [ ] Sync a second time over the same window → row count stays stable (upsert in place, no duplicates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)