### PR TITLE
chore(admin): group five orphan sidebar entries under existing nested keys

### DIFF
--- a/apps/backend/src/admin/routes/ad-planning/page.tsx
+++ b/apps/backend/src/admin/routes/ad-planning/page.tsx
@@ -239,6 +239,7 @@ const AdPlanningDashboard = () => {
 
 export const config = defineRouteConfig({
   label: "Ad Planning",
+  nested: "/promotions",
   icon: ChartBar,
 })
 

--- a/apps/backend/src/admin/routes/messaging/page.tsx
+++ b/apps/backend/src/admin/routes/messaging/page.tsx
@@ -281,6 +281,7 @@ const MessagingPage = () => {
 
 export const config = defineRouteConfig({
   label: "Messages",
+  nested: "/customers",
   icon: ChatBubbleLeftRight,
 })
 

--- a/apps/backend/src/admin/routes/payment-reports/page.tsx
+++ b/apps/backend/src/admin/routes/payment-reports/page.tsx
@@ -69,6 +69,7 @@ const PaymentReportsPage = () => {
 
 export const config = defineRouteConfig({
   label: "Payment Reports",
+  nested: "/orders",
   icon: CurrencyDollar,
 })
 

--- a/apps/backend/src/admin/routes/payment-submissions/page.tsx
+++ b/apps/backend/src/admin/routes/payment-submissions/page.tsx
@@ -65,6 +65,7 @@ const PaymentSubmissionsPage = () => {
 
 export const config = defineRouteConfig({
   label: "Payment Submissions",
+  nested: "/orders",
   icon: CurrencyDollar,
 })
 

--- a/apps/backend/src/admin/routes/persons/page.tsx
+++ b/apps/backend/src/admin/routes/persons/page.tsx
@@ -258,6 +258,7 @@ export default PersonsPage;
 
 export const config = defineRouteConfig({
   label: "People",
+  nested: "/customers",
   icon: Users,
 });
 


### PR DESCRIPTION
## Summary
While planning where new integrations like Google Ads, Search Console, etc. should live in the sidebar, I noticed five existing top-level entries that already fit cleanly under one of Medusa's pre-existing groups.

Medusa Admin SDK's \`nested:\` field is a fixed enum — only \`/products\`, \`/orders\`, \`/inventory\`, \`/customers\`, \`/promotions\`, \`/price-lists\` are accepted by the type system. I originally drafted \`/production\`, \`/content\`, \`/audience\` groups but had to back those out (rejected by tsc). What landed in this PR is the subset that maps cleanly into the SDK-allowed groups.

## Moves

| Route | From | To | Why |
|---|---|---|---|
| \`ad-planning\` | root | \`/promotions\` | Same domain as the existing \`ads\` / \`meta-ads\` / \`publishing-campaigns\` entries; upstream of the Ads UI. |
| \`payment-reports\` | root | \`/orders\` | Money flows from order events. |
| \`payment-submissions\` | root | \`/orders\` | Same. |
| \`persons\` (People) | root | \`/customers\` | Fits Customers as-is. |
| \`messaging\` (Messages) | root | \`/customers\` | Comms targeted at those People. |

Five files, one line added each (the \`nested: \"<group>\"\` field).

## Not touched (deliberately)

Designs, Partners, Websites, Social Posts, Medias — none fit a SDK-allowed group cleanly:
- **Designs / Partners** would have wanted \`/production\` (manufacturing pipeline).
- **Websites / Social Posts / Medias** would have wanted \`/content\`.

Both groups are SDK-rejected, so adding them would require an admin-shell change (likely a UI library bump or a custom sidebar override). Out of scope for this PR — these stay at root.

## Sidebar before / after (root-level entries only)

**Before** (16 root entries): Ad Planning · Designs · Medias · Messaging · Partners · Payment Reports · Payment Submissions · People · Products · Social Posts · Stats · Visual Flows · Websites · (+stubs)

**After** (11 root entries): Designs · Medias · Partners · Products · Social Posts · Stats · Visual Flows · Websites · (+stubs) — plus the five moves visible under their group expansions.

## Test plan
- [ ] tsc clean — no \`Type ... not assignable to ... \"/products\" | \"/orders\" | ...\` errors on the changed files.
- [ ] After deploy: sidebar shows Ad Planning under Promotions, Payment Reports + Payment Submissions under Orders, People + Messages under Customers.
- [ ] Old direct URLs (\`/admin/ad-planning\`, \`/admin/payment-reports\`, etc.) still resolve — only the sidebar grouping moves, not the routes themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)