### PR TITLE
Revert PR #220 — restore five routes to root before introducing custom hub

### DIFF
--- a/apps/backend/src/admin/routes/ad-planning/page.tsx
+++ b/apps/backend/src/admin/routes/ad-planning/page.tsx
@@ -239,7 +239,6 @@ const AdPlanningDashboard = () => {
 
 export const config = defineRouteConfig({
   label: "Ad Planning",
-  nested: "/promotions",
   icon: ChartBar,
 })
 

--- a/apps/backend/src/admin/routes/messaging/page.tsx
+++ b/apps/backend/src/admin/routes/messaging/page.tsx
@@ -281,7 +281,6 @@ const MessagingPage = () => {
 
 export const config = defineRouteConfig({
   label: "Messages",
-  nested: "/customers",
   icon: ChatBubbleLeftRight,
 })
 

--- a/apps/backend/src/admin/routes/payment-reports/page.tsx
+++ b/apps/backend/src/admin/routes/payment-reports/page.tsx
@@ -69,7 +69,6 @@ const PaymentReportsPage = () => {
 
 export const config = defineRouteConfig({
   label: "Payment Reports",
-  nested: "/orders",
   icon: CurrencyDollar,
 })
 

--- a/apps/backend/src/admin/routes/payment-submissions/page.tsx
+++ b/apps/backend/src/admin/routes/payment-submissions/page.tsx
@@ -65,7 +65,6 @@ const PaymentSubmissionsPage = () => {
 
 export const config = defineRouteConfig({
   label: "Payment Submissions",
-  nested: "/orders",
   icon: CurrencyDollar,
 })
 

--- a/apps/backend/src/admin/routes/persons/page.tsx
+++ b/apps/backend/src/admin/routes/persons/page.tsx
@@ -258,7 +258,6 @@ export default PersonsPage;
 
 export const config = defineRouteConfig({
   label: "People",
-  nested: "/customers",
   icon: Users,
 });
 


### PR DESCRIPTION
## Why
PR #220 moved five top-level admin routes under SDK-allowed \`nested:\` groups (\`/promotions\`, \`/orders\`, \`/customers\`). Two of those moves turned out to be semantic mismatches:

- **People → /customers**: \`Person\` is multi-role in this codebase (customer, partner, supplier, employee — there's even a \`persontypes\` setting). Filing it under "Customers" narrows the mental model wrong.
- **Messages → /customers**: messages can target partners (not just customers). Same problem.

And while \`Ad Planning → /promotions\` and \`Payment Reports/Submissions → /orders\` were defensible, leaving them in place while reverting just the two semantic mismatches would create a half-baked sidebar.

The plan instead — to be done in a follow-up PR — is to use the **ad-planning hub pattern** (one parent route with \`defineRouteConfig\`, sub-routes that don't declare their own config, navigation through QuickLinkCards on the hub page). That gives us custom group names without fighting the SDK's fixed \`nested:\` enum, and keeps existing URLs intact.

This PR is a clean baseline for that work — it puts all five routes back at root exactly as they were before PR #220.

## Diff
Five \`nested:\` lines removed:

\`\`\`
ad-planning/page.tsx       : -  nested: "/promotions"
payment-reports/page.tsx   : -  nested: "/orders"
payment-submissions/page.tsx: -  nested: "/orders"
persons/page.tsx           : -  nested: "/customers"
messaging/page.tsx         : -  nested: "/customers"
\`\`\`

URLs are unaffected (this PR only touches sidebar grouping).

## Follow-up
Next PR will introduce a custom \`/admin/operations\` (or similar) parent route with sectioned QuickLinkCards linking to the existing routes — same pattern \`ad-planning\` already uses internally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)