### PR TITLE
fix(partner-subscription): correct PayU hash + gate plan activation on verification

### DIFF
--- a/apps/backend/src/api/partners/subscription/payu/complete/route.ts
+++ b/apps/backend/src/api/partners/subscription/payu/complete/route.ts
@@ -34,13 +34,16 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
 
   const service: PartnerPlanService = req.scope.resolve(PARTNER_PLAN_MODULE)
 
-  // Verify PayU reverse hash
-  const reverseHashString = `${payuSalt}|${status}|||||${udf5}|${udf4}|${partnerId}|${planId}|${paymentId}|${email}|${firstname}|${productinfo}|${amount}|${txnid}|${payuKey}`
+  // PayU reverse hash:
+  //   SALT|status|udf10|udf9|udf8|udf7|udf6|udf5|udf4|udf3|udf2|udf1|email|firstname|productinfo|amount|txnid|key
+  // udf6..udf10 are empty in our flow → 6 pipes (5 empty fields) between status and udf5.
+  const reverseHashString = `${payuSalt}|${status}||||||${udf5}|${udf4}|${partnerId}|${planId}|${paymentId}|${email}|${firstname}|${productinfo}|${amount}|${txnid}|${payuKey}`
   const expectedHash = crypto.createHash("sha512").update(reverseHashString).digest("hex")
 
-  if (status.toLowerCase() === "success") {
-    const isValidHash = receivedHash === expectedHash
+  const isValidHash = !!receivedHash && receivedHash === expectedHash
+  const isSuccess = status.toLowerCase() === "success"
 
+  if (isSuccess && isValidHash) {
     try {
       // Update payment record
       if (paymentId) {
@@ -51,7 +54,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
           paid_at: new Date(),
           provider_data: {
             ...body,
-            hash_verified: isValidHash,
+            hash_verified: true,
           },
         })
       }
@@ -82,19 +85,32 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     }
   }
 
-  // Payment failed
+  // Anything that isn't (success + valid hash) is a failure path.
+  // A "success" status with a hash mismatch is treated as failure: never
+  // activate a subscription without verified payment confirmation.
   try {
     if (paymentId) {
+      const failure_reason = isSuccess && !isValidHash
+        ? "PayU hash verification failed"
+        : (body.error_Message || body.unmappedstatus || status || "Payment failed")
       await service.updateSubscriptionPayments({
         id: paymentId,
         status: SubscriptionPaymentStatus.FAILED,
         failed_at: new Date(),
-        failure_reason: body.error_Message || body.unmappedstatus || status || "Payment failed",
-        provider_data: body,
+        failure_reason,
+        provider_data: { ...body, hash_verified: isValidHash },
       })
     }
   } catch (e) {
     console.error("[PayU Subscription] Error recording failure:", e)
+  }
+
+  if (isSuccess && !isValidHash) {
+    console.warn(`[PayU Subscription] Hash mismatch: txnid=${txnid}`)
+    return res.redirect(
+      302,
+      `${partnerUiUrl}/settings/plan?payment=error&message=${encodeURIComponent("Hash verification failed")}`
+    )
   }
 
   return res.redirect(302, `${partnerUiUrl}/settings/plan?payment=failed`)

--- a/apps/backend/src/api/partners/subscription/route.ts
+++ b/apps/backend/src/api/partners/subscription/route.ts
@@ -96,8 +96,15 @@ export const POST = async (
       period_end: (() => { const d = new Date(); d.setMonth(d.getMonth() + 1); return d })(),
     })
 
-    // Generate PayU hash
-    const hashString = `${payuKey}|${txnid}|${amount}|${productinfo}|${firstname}|${email}|||||||||||${payuSalt}`
+    // Hash must be computed from the SAME udf values that the form posts to PayU,
+    // otherwise PayU rejects the request with an invalid-hash error.
+    const udf1 = (pendingPayment as any).id
+    const udf2 = plan_id
+    const udf3 = partner.id
+    const udf4 = ""
+    const udf5 = ""
+
+    const hashString = `${payuKey}|${txnid}|${amount}|${productinfo}|${firstname}|${email}|${udf1}|${udf2}|${udf3}|${udf4}|${udf5}||||||${payuSalt}`
     const hash = crypto.createHash("sha512").update(hashString).digest("hex")
 
     const partnerUiUrl = process.env.PARTNER_UI_URL || "https://partner.jaalyantra.com"
@@ -122,9 +129,11 @@ export const POST = async (
         hash,
         surl: `${backendUrl}/partners/subscription/payu/complete`,
         furl: `${backendUrl}/partners/subscription/payu/complete`,
-        udf1: (pendingPayment as any).id,
-        udf2: plan_id,
-        udf3: partner.id,
+        udf1,
+        udf2,
+        udf3,
+        udf4,
+        udf5,
       },
     })
     return

--- a/apps/partner-ui/src/routes/settings/plan/plan.tsx
+++ b/apps/partner-ui/src/routes/settings/plan/plan.tsx
@@ -165,8 +165,13 @@ export const SettingsPlan = () => {
     if (!confirmed) return
 
     try {
-      await subscribe({ plan_id: plan.id })
-      toast.success(t("partner.plan.toast.switchedTo", { plan: plan.name }))
+      const result = await subscribe({ plan_id: plan.id })
+      // Only the free-plan path activates synchronously. Paid plans get
+      // redirected to PayU/Stripe; the surl callback comes back with
+      // ?payment=success which the useEffect above turns into a toast.
+      if ((result as any)?.subscription) {
+        toast.success(t("partner.plan.toast.switchedTo", { plan: plan.name }))
+      }
     } catch (e: any) {
       toast.error(t("partner.plan.toast.switchFailed"), {
         description: e?.message || t("partner.plan.toast.somethingWrong"),


### PR DESCRIPTION
## Summary

Four bugs in the partner plan-upgrade flow that together caused:
- **PayU rejecting payment with \"invalid hash\" / E000** when a partner picks a PayU-priced plan, and
- **The partner UI flashing \"Switched to X plan\"** before any payment had actually been captured.

### What was broken

| # | Where | Bug |
|---|-------|-----|
| 1 | `apps/backend/src/api/partners/subscription/route.ts:100` | Forward hash used 11 empty pipes between `email` and `salt`, but the form **posted real `udf1`/`udf2`/`udf3`** (payment id, plan id, partner id). PayU recomputed with the real udfs and got a different digest → invalid hash. |
| 2 | `apps/backend/src/api/partners/subscription/payu/complete/route.ts:38` | Reverse hash had 5 pipes between `status` and `udf5`. PayU's spec needs **6 pipes** (5 empty `udf6..udf10` slots). Hash verification could never succeed. |
| 3 | Same file, body of `POST` | `isValidHash` was computed but only stored as metadata. The success status alone activated the subscription — meaning a forged callback or a future hash drift would have silently created plans without payment. |
| 4 | `apps/partner-ui/src/routes/settings/plan/plan.tsx:168-169` | The success toast fired synchronously right after the POST returned, just before the redirect to PayU. The user saw \"Plan switched\" before PayU had even seen the payment. |

### What this PR changes

- **Forward hash** is now built from the same `udf1..udf5` values that go into the form payload, matching the storefront PayU service (`modules/payu-payment/service.ts:170`).
- **Reverse hash** now matches PayU's `SALT|status|udf10|..|udf6|udf5|udf4|udf3|udf2|udf1|email|firstname|productinfo|amount|txnid|key` layout (added a clarifying comment).
- **Activation is gated** on `isSuccess && isValidHash`. A success status with a mismatched hash is recorded as a `FAILED` payment with `failure_reason: \"PayU hash verification failed\"` and the user is redirected to `?payment=error&message=Hash%20verification%20failed`. No subscription is created.
- **Partner UI** only fires the \"switched\" toast when the response actually contains a `subscription` (i.e. free plan / synchronous activation). Paid plans rely on the existing `?payment=success` handling in the `useEffect` at lines 122-143.

## Test plan

- [ ] As an INR partner, upgrade from Free → Growth. Verify the PayU payment page loads (no E000) and shows the correct amount/transaction id.
- [ ] Pay successfully on PayU. Verify redirect lands on `/settings/plan?payment=success`, the toast says \"Payment successful\", and `GET /partners/subscription` returns the new active subscription.
- [ ] Trigger a deliberate hash mismatch (e.g. tamper with the surl payload in a test) and confirm the user lands on `?payment=error` and the `subscription_payment` row is recorded `FAILED` with reason `PayU hash verification failed`.
- [ ] Fail/cancel at PayU. Verify the redirect lands on `?payment=failed` and no subscription is created.
- [ ] As a non-INR partner, confirm the Stripe path is unaffected.
- [ ] Free-plan upgrade (price = 0): confirm the \"switched\" toast still fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)