### PR TITLE
fix(partner-storefront): read columns first, strip legacy metadata on write

### DIFF
--- a/apps/backend/src/api/admin/partners/[id]/storefront/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/storefront/route.ts
@@ -2,6 +2,7 @@ import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 import { DEPLOYMENT_MODULE } from "../../../../../modules/deployment"
 import type DeploymentService from "../../../../../modules/deployment/service"
+import { getStorefrontRefs } from "../../../../partners/storefront/helpers"
 
 export const GET = async (
   req: AuthenticatedMedusaRequest,
@@ -21,9 +22,9 @@ export const GET = async (
   }
 
   const partner = partners[0] as any
-  const vercelProjectId = partner.metadata?.vercel_project_id
+  const refs = getStorefrontRefs(partner)
 
-  if (!vercelProjectId) {
+  if (!refs.vercelProjectId) {
     return res.json({
       provisioned: false,
       message: "Storefront has not been provisioned yet",
@@ -32,7 +33,7 @@ export const GET = async (
 
   try {
     const deployment: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
-    const project = await deployment.getProject(vercelProjectId)
+    const project = await deployment.getProject(refs.vercelProjectId)
     const latestDeployment = project.latestDeployments?.[0]
 
     let deploymentInfo: {
@@ -67,25 +68,25 @@ export const GET = async (
         id: project.id,
         name: project.name,
       },
-      domain: partner.metadata?.storefront_domain || null,
-      storefront_url: partner.metadata?.storefront_domain
-        ? `https://${partner.metadata.storefront_domain}`
+      domain: refs.storefrontDomain,
+      storefront_url: refs.storefrontDomain
+        ? `https://${refs.storefrontDomain}`
         : null,
-      provisioned_at: partner.metadata?.storefront_provisioned_at || null,
+      provisioned_at: refs.storefrontProvisionedAt,
       latest_deployment: deploymentInfo,
     })
   } catch (e: any) {
     res.json({
       provisioned: true,
       project: {
-        id: vercelProjectId,
-        name: partner.metadata?.vercel_project_name || null,
+        id: refs.vercelProjectId,
+        name: refs.vercelProjectName,
       },
-      domain: partner.metadata?.storefront_domain || null,
-      storefront_url: partner.metadata?.storefront_domain
-        ? `https://${partner.metadata.storefront_domain}`
+      domain: refs.storefrontDomain,
+      storefront_url: refs.storefrontDomain
+        ? `https://${refs.storefrontDomain}`
         : null,
-      provisioned_at: partner.metadata?.storefront_provisioned_at || null,
+      provisioned_at: refs.storefrontProvisionedAt,
       latest_deployment: null,
       error: `Could not fetch Vercel status: ${e.message}`,
     })

--- a/apps/backend/src/api/partners/storefront/domain/route.ts
+++ b/apps/backend/src/api/partners/storefront/domain/route.ts
@@ -10,6 +10,7 @@ import type { VercelDomainConfig } from "../../../../modules/deployment/service"
 import { WEBSITE_MODULE } from "../../../../modules/website"
 import type WebsiteService from "../../../../modules/website/service"
 import updatePartnerWorkflow from "../../../../workflows/partners/update-partner"
+import { getStorefrontRefs } from "../helpers"
 
 /**
  * Determines if a domain is an apex (root) domain.
@@ -64,7 +65,7 @@ export const GET = async (
     )
   }
 
-  const vercelProjectId = partner.metadata?.vercel_project_id
+  const vercelProjectId = getStorefrontRefs(partner).vercelProjectId
   if (!vercelProjectId) {
     throw new MedusaError(
       MedusaError.Types.NOT_FOUND,
@@ -117,7 +118,7 @@ export const POST = async (
     )
   }
 
-  const vercelProjectId = partner.metadata?.vercel_project_id
+  const vercelProjectId = getStorefrontRefs(partner).vercelProjectId
   if (!vercelProjectId) {
     throw new MedusaError(
       MedusaError.Types.NOT_FOUND,
@@ -217,7 +218,7 @@ export const DELETE = async (
     )
   }
 
-  const vercelProjectId = partner.metadata?.vercel_project_id
+  const vercelProjectId = getStorefrontRefs(partner).vercelProjectId
   const customDomain = partner.metadata?.custom_domain as string | undefined
 
   if (!vercelProjectId || !customDomain) {

--- a/apps/backend/src/api/partners/storefront/domain/verify/route.ts
+++ b/apps/backend/src/api/partners/storefront/domain/verify/route.ts
@@ -8,6 +8,7 @@ import { DEPLOYMENT_MODULE } from "../../../../../modules/deployment"
 import type DeploymentService from "../../../../../modules/deployment/service"
 import type { VercelDomainConfig } from "../../../../../modules/deployment/service"
 import updatePartnerWorkflow from "../../../../../workflows/partners/update-partner"
+import { getStorefrontRefs } from "../../helpers"
 
 function isApexDomain(domain: string): boolean {
   return domain.split(".").length === 2
@@ -43,7 +44,7 @@ export const POST = async (
     )
   }
 
-  const vercelProjectId = partner.metadata?.vercel_project_id
+  const vercelProjectId = getStorefrontRefs(partner).vercelProjectId
   const customDomain = partner.metadata?.custom_domain as string | undefined
 
   if (!vercelProjectId || !customDomain) {

--- a/apps/backend/src/api/partners/storefront/helpers.ts
+++ b/apps/backend/src/api/partners/storefront/helpers.ts
@@ -5,6 +5,40 @@ import { WEBSITE_MODULE } from "../../../modules/website"
 import WebsiteService from "../../../modules/website/service"
 
 /**
+ * Storefront identifiers live on dedicated partner columns now
+ * (vercel_project_id, vercel_project_name, storefront_domain,
+ * vercel_last_deployment_id). Older records still hold them in
+ * partner.metadata. Always read via this helper so the fallback is
+ * consistent across every route and we can't accidentally miss a
+ * provisioned partner because the read side only checked metadata.
+ */
+export type StorefrontRefs = {
+  vercelProjectId: string | null
+  vercelProjectName: string | null
+  storefrontDomain: string | null
+  vercelLastDeploymentId: string | null
+  storefrontProvisionedAt: string | null
+}
+
+export const getStorefrontRefs = (partner: any): StorefrontRefs => ({
+  vercelProjectId:
+    partner?.vercel_project_id ?? partner?.metadata?.vercel_project_id ?? null,
+  vercelProjectName:
+    partner?.vercel_project_name ??
+    partner?.metadata?.vercel_project_name ??
+    null,
+  storefrontDomain:
+    partner?.storefront_domain ?? partner?.metadata?.storefront_domain ?? null,
+  vercelLastDeploymentId:
+    partner?.vercel_last_deployment_id ??
+    partner?.metadata?.vercel_last_deployment_id ??
+    null,
+  // No column for this one — stays metadata-only.
+  storefrontProvisionedAt:
+    partner?.metadata?.storefront_provisioned_at ?? null,
+})
+
+/**
  * Gets the partner's website.
  * Uses table columns first (website_id, storefront_domain), falls back to metadata.
  */

--- a/apps/backend/src/api/partners/storefront/route.ts
+++ b/apps/backend/src/api/partners/storefront/route.ts
@@ -7,6 +7,7 @@ import { getPartnerFromAuthContext } from "../helpers"
 import { DEPLOYMENT_MODULE } from "../../../modules/deployment"
 import type DeploymentService from "../../../modules/deployment/service"
 import updatePartnerWorkflow from "../../../workflows/partners/update-partner"
+import { getStorefrontRefs } from "./helpers"
 
 const STOREFRONT_META_KEYS = [
   "vercel_project_id",
@@ -39,9 +40,9 @@ export const GET = async (
   }
 
   const deployment: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
-  const vercelProjectId = partner.metadata?.vercel_project_id
+  const refs = getStorefrontRefs(partner)
 
-  if (!vercelProjectId) {
+  if (!refs.vercelProjectId) {
     return res.json({
       provisioned: false,
       message: "Storefront has not been provisioned yet",
@@ -51,7 +52,7 @@ export const GET = async (
   }
 
   try {
-    const project = await deployment.getProject(vercelProjectId)
+    const project = await deployment.getProject(refs.vercelProjectId)
     const latestDeployment = project.latestDeployments?.[0]
 
     let deploymentInfo: {
@@ -86,11 +87,11 @@ export const GET = async (
         id: project.id,
         name: project.name,
       },
-      domain: partner.metadata?.storefront_domain || null,
-      storefront_url: partner.metadata?.storefront_domain
-        ? `https://${partner.metadata.storefront_domain}`
+      domain: refs.storefrontDomain,
+      storefront_url: refs.storefrontDomain
+        ? `https://${refs.storefrontDomain}`
         : null,
-      provisioned_at: partner.metadata?.storefront_provisioned_at || null,
+      provisioned_at: refs.storefrontProvisionedAt,
       latest_deployment: deploymentInfo,
       vercel_configured: deployment.isVercelConfigured(),
       cloudflare_configured: deployment.isCloudflareConfigured(),
@@ -99,12 +100,19 @@ export const GET = async (
     // If Vercel returns 404, the project was deleted — treat as not provisioned
     const is404 = e.message?.includes("(404)") || e.message?.includes("NOT_FOUND")
     if (is404) {
-      // Clean up stale metadata via workflow
+      // Clean up stale references via workflow — clear both columns and legacy metadata.
       try {
         await updatePartnerWorkflow(req.scope).run({
           input: {
             id: partner.id,
-            data: { metadata: stripStorefrontKeys(partner.metadata) },
+            data: {
+              metadata: stripStorefrontKeys(partner.metadata),
+              vercel_project_id: null,
+              vercel_project_name: null,
+              vercel_last_deployment_id: null,
+              vercel_linked: false,
+              storefront_domain: null,
+            },
           },
         })
       } catch {
@@ -122,14 +130,14 @@ export const GET = async (
     res.json({
       provisioned: true,
       project: {
-        id: vercelProjectId,
-        name: partner.metadata?.vercel_project_name || null,
+        id: refs.vercelProjectId,
+        name: refs.vercelProjectName,
       },
-      domain: partner.metadata?.storefront_domain || null,
-      storefront_url: partner.metadata?.storefront_domain
-        ? `https://${partner.metadata.storefront_domain}`
+      domain: refs.storefrontDomain,
+      storefront_url: refs.storefrontDomain
+        ? `https://${refs.storefrontDomain}`
         : null,
-      provisioned_at: partner.metadata?.storefront_provisioned_at || null,
+      provisioned_at: refs.storefrontProvisionedAt,
       latest_deployment: null,
       error: `Could not fetch Vercel status: ${e.message}`,
       vercel_configured: deployment.isVercelConfigured(),
@@ -155,8 +163,9 @@ export const DELETE = async (
   }
 
   const deployment: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
-  const vercelProjectId = partner.metadata?.vercel_project_id
-  const storefrontDomain = partner.metadata?.storefront_domain
+  const refs = getStorefrontRefs(partner)
+  const vercelProjectId = refs.vercelProjectId
+  const storefrontDomain = refs.storefrontDomain
 
   if (!vercelProjectId) {
     throw new MedusaError(

--- a/apps/backend/src/workflows/stores/provision-storefront.ts
+++ b/apps/backend/src/workflows/stores/provision-storefront.ts
@@ -201,7 +201,19 @@ const triggerVercelDeploymentStep = createStep(
   }
 )
 
-// Step 6: Save Vercel metadata to partner
+// Step 6: Save Vercel metadata to partner.
+// Columns are the source of truth. After writing them we strip legacy keys
+// from partner.metadata so we don't keep stale dual state — every read
+// helper falls back to metadata for older partners, and this is the
+// migration step for any partner that gets re-provisioned.
+const LEGACY_STOREFRONT_METADATA_KEYS = [
+  "vercel_project_id",
+  "vercel_project_name",
+  "vercel_last_deployment_id",
+  "storefront_domain",
+  "storefront_provisioned_at",
+] as const
+
 const saveStorefrontMetadataStep = createStep(
   "save-storefront-metadata",
   async (
@@ -220,6 +232,17 @@ const saveStorefrontMetadataStep = createStep(
   ) => {
     const domain = `${input.handle}.${input.rootDomain}`
     const partnerService: PartnerService = container.resolve("partner")
+
+    // Read current metadata so we can strip the legacy keys in the same write.
+    const existing = await partnerService.retrievePartner(input.partnerId)
+    const currentMeta = (existing?.metadata || {}) as Record<string, any>
+    const cleanedMeta: Record<string, any> = {}
+    for (const [k, v] of Object.entries(currentMeta)) {
+      if (!(LEGACY_STOREFRONT_METADATA_KEYS as readonly string[]).includes(k)) {
+        cleanedMeta[k] = v
+      }
+    }
+
     await partnerService.updatePartners({
       id: input.partnerId,
       storefront_domain: domain,
@@ -230,6 +253,7 @@ const saveStorefrontMetadataStep = createStep(
       storefront_repo: input.storefrontRepo,
       storefront_root_dir: input.storefrontRootDir ?? null,
       storefront_branch: input.storefrontBranch ?? "main",
+      metadata: Object.keys(cleanedMeta).length > 0 ? cleanedMeta : null,
     })
 
     return new StepResponse({ success: true })


### PR DESCRIPTION
## Summary

The partner-storefront provision workflow writes Vercel/storefront identifiers to dedicated **columns** on the partner row (`vercel_project_id`, `vercel_project_name`, `storefront_domain`, `vercel_last_deployment_id`, `vercel_linked`). Five read sites still only checked `partner.metadata.*`, so any newly-provisioned partner appeared as **not provisioned** to those endpoints — the symptom you described.

This PR makes the read pattern consistent everywhere and migrates legacy metadata forward on next provision.

## What changed

**New helper** — `api/partners/storefront/helpers.ts::getStorefrontRefs(partner)` returns `vercelProjectId`, `vercelProjectName`, `storefrontDomain`, `vercelLastDeploymentId`, `storefrontProvisionedAt` using **column ?? metadata** fallback. Single place to grep for the read pattern.

**Switched 5 read sites to use the helper:**
- `api/partners/storefront/route.ts` (GET, DELETE)
- `api/partners/storefront/domain/route.ts` (GET, POST, DELETE)
- `api/partners/storefront/domain/verify/route.ts` (POST)
- `api/admin/partners/[id]/storefront/route.ts` (GET)

**GET 404-cleanup path** — when Vercel returns 404 for a stale project, we now clear both the columns *and* the legacy metadata via the update workflow, not just the metadata.

**`saveStorefrontMetadataStep`** — in addition to writing the columns, now strips the legacy keys (`vercel_project_id`, `vercel_project_name`, `vercel_last_deployment_id`, `storefront_domain`, `storefront_provisioned_at`) from `partner.metadata` in the same update. Old partners migrate forward on next provision/re-provision.

`partner.metadata.custom_domain` reads are intentionally unchanged — no column counterpart, separate piece of work.

## What this does **not** do

- Initial provision still hardcodes the CNAME target to `cname.vercel-dns.com` instead of reading Vercel's per-project `recommendedCNAME` (e.g. `dc034fcb6b63fdce.vercel-dns-017.com`) — that's the cause of the \"update your DNS\" message you saw, and is the follow-up PR (tasks #139 + #141).

## Test plan

- [ ] Existing partner with **column only** set: GET `/partners/storefront` returns `provisioned: true` (previously returned `provisioned: false`).
- [ ] Legacy partner with **metadata only** set: GET still works — the helper falls back to metadata.
- [ ] DELETE `/partners/storefront` succeeds for both populations.
- [ ] Re-provisioning a legacy partner (one with both column and metadata set): after the workflow, the metadata fields are removed and the columns hold the values.
- [ ] Admin GET `/admin/partners/{id}/storefront` shows the same data the partner-side endpoint shows.
- [ ] Vercel 404 path: GET returns `provisioned: false` and the partner's columns + legacy metadata are both cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)