### PR TITLE
feat(partner-storefront): apply Vercel's recommended DNS via Cloudflare

### DIFF
--- a/apps/backend/src/api/partners/storefront/dns/route.ts
+++ b/apps/backend/src/api/partners/storefront/dns/route.ts
@@ -1,0 +1,73 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { getPartnerFromAuthContext } from "../../helpers"
+import { DEPLOYMENT_MODULE } from "../../../../modules/deployment"
+import type DeploymentService from "../../../../modules/deployment/service"
+import { getStorefrontRefs } from "../helpers"
+
+/**
+ * POST /partners/storefront/dns
+ *
+ * Re-reads Vercel's currently-recommended DNS for a partner-owned domain
+ * and pushes it into Cloudflare. Defaults to the partner's primary
+ * `storefront_domain` (e.g. uniquepashmina.cicilabel.com), or accepts a
+ * `domain` in the body to target a custom domain. Idempotent — safe to
+ * call when a partner sees "Update your DNS" instructions from Vercel
+ * because we shipped a generic CNAME before Vercel had a project-specific
+ * target ready (e.g. dc034fcb6b63fdce.vercel-dns-017.com).
+ *
+ * Skipped/failed apply does not error the response — the body always
+ * carries the apply result so the caller can decide what to surface.
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
+  if (!partner) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "No partner associated with this account"
+    )
+  }
+
+  const refs = getStorefrontRefs(partner)
+  const { domain: bodyDomain } = (req.body || {}) as { domain?: string }
+  const domain = bodyDomain?.trim() || refs.storefrontDomain
+
+  if (!domain) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      "Storefront has not been provisioned and no domain was supplied"
+    )
+  }
+
+  const deployment: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
+  const applied = await deployment.applyRecommendedDns(domain)
+
+  // Best-effort: fetch domain config so the caller can show the recommendation
+  // alongside what was actually applied.
+  let recommendation: Awaited<
+    ReturnType<DeploymentService["getDomainConfig"]>
+  > | null = null
+  try {
+    recommendation = await deployment.getDomainConfig(domain)
+  } catch {
+    // non-critical
+  }
+
+  res.json({
+    domain,
+    applied,
+    recommendation: recommendation
+      ? {
+          misconfigured: recommendation.misconfigured,
+          recommended_cname: recommendation.recommendedCNAME?.[0]?.value ?? null,
+          recommended_ipv4: recommendation.recommendedIPv4?.[0]?.value?.[0] ?? null,
+        }
+      : null,
+  })
+}

--- a/apps/backend/src/api/partners/storefront/domain/verify/route.ts
+++ b/apps/backend/src/api/partners/storefront/domain/verify/route.ts
@@ -30,7 +30,19 @@ function buildDnsRecords(
 
 /**
  * POST /partners/storefront/domain/verify
- * Trigger domain ownership verification on Vercel.
+ *
+ * Re-checks Vercel domain ownership AND — when the domain lives inside
+ * the Cloudflare zone we control — pushes whatever DNS Vercel currently
+ * recommends so the domain self-heals without operator intervention.
+ *
+ * Apply-step behaviour:
+ *   - Always attempts applyRecommendedDns(domain). The deployment service
+ *     skips/fails gracefully when CF isn't configured or the domain isn't
+ *     in our zone, so partner-owned domains (shop.example.com) fall
+ *     through to the existing "return instructions" path unharmed.
+ *   - Re-verifies with Vercel after applying so the response reflects the
+ *     post-apply state (DNS propagation can still cause this to remain
+ *     false for a few minutes).
  */
 export const POST = async (
   req: AuthenticatedMedusaRequest,
@@ -55,6 +67,13 @@ export const POST = async (
   }
 
   const deployment: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
+
+  // Apply Vercel's recommended DNS via Cloudflare. No-op for domains
+  // outside our zone — they'll get the instructions in dns_records below.
+  const applied = await deployment.applyRecommendedDns(customDomain)
+
+  // Verify after applying so a successful CF write can flip verified=true
+  // in the same call (subject to Vercel's propagation window).
   const result = await deployment.verifyDomain(vercelProjectId, customDomain)
 
   if (result.verified) {
@@ -84,6 +103,7 @@ export const POST = async (
     verification: result.verification || null,
     misconfigured: config?.misconfigured ?? true,
     configured_by: config?.configuredBy ?? null,
+    applied,
     dns_records: buildDnsRecords(customDomain, config),
   })
 }

--- a/apps/backend/src/modules/deployment/service.ts
+++ b/apps/backend/src/modules/deployment/service.ts
@@ -65,6 +65,16 @@ export type EnsureCnameResult = {
   reason?: string
 }
 
+export type ApplyRecommendedDnsResult = {
+  action: "created" | "updated" | "exists" | "skipped" | "failed"
+  type?: "CNAME" | "A"
+  name?: string
+  content?: string
+  record?: CloudflareDnsRecord
+  reason?: string
+  error?: string
+}
+
 // ─── Service ─────────────────────────────────────────────────────────────────
 
 const VERCEL_API_BASE = "https://api.vercel.com"
@@ -525,6 +535,89 @@ class DeploymentService {
     })
     this.log("info", `CNAME created successfully`, { id: created.id, name: created.name })
     return { action: "created", record: created }
+  }
+
+  /**
+   * Apply whatever DNS Vercel currently recommends for `domain` into
+   * Cloudflare. Subdomains get a CNAME to recommendedCNAME[0].value (e.g.
+   * `dc034fcb6b63fdce.vercel-dns-017.com` for newer per-project routing);
+   * apex domains get an A record to recommendedIPv4[0].value[0]. Falls
+   * back to the generic cname.vercel-dns.com / 76.76.21.21 if Vercel
+   * returned no recommendation.
+   *
+   * Used in two places that previously had to be kept in sync manually:
+   *   - initial provision (replaces hardcoded ensureVercelCname)
+   *   - the verify/refresh endpoint (which used to only *return* the
+   *     recommended records, leaving DNS apply to the operator)
+   */
+  async applyRecommendedDns(
+    domain: string
+  ): Promise<ApplyRecommendedDnsResult> {
+    if (!this.isCloudflareConfigured()) {
+      return { action: "skipped", reason: "Cloudflare not configured" }
+    }
+
+    let config: VercelDomainConfig | null = null
+    try {
+      config = await this.getDomainConfig(domain)
+    } catch (e: any) {
+      // Non-fatal — we'll still apply a sensible fallback so the storefront
+      // resolves while the operator investigates the Vercel-side error.
+      this.log(
+        "warn",
+        `applyRecommendedDns: getDomainConfig failed for ${domain}, using fallback target`,
+        { error: e.message }
+      )
+    }
+
+    const isApex = domain.split(".").length === 2
+    const recommendedCNAME = config?.recommendedCNAME?.[0]?.value
+    const recommendedIPv4 = config?.recommendedIPv4?.[0]?.value?.[0]
+
+    const type: "CNAME" | "A" = isApex ? "A" : "CNAME"
+    const content = isApex
+      ? recommendedIPv4 || "76.76.21.21"
+      : recommendedCNAME || "cname.vercel-dns.com"
+
+    try {
+      const existing = await this.listDnsRecords({ name: domain, type })
+
+      if (existing.length > 0) {
+        const record = existing[0]
+        if (record.content === content) {
+          this.log("info", `applyRecommendedDns: ${type} already current for ${domain}`)
+          return { action: "exists", type, name: domain, content, record }
+        }
+        const updated = await this.updateDnsRecord(record.id, {
+          name: domain,
+          content,
+          type,
+          proxied: false,
+        })
+        this.log(
+          "info",
+          `applyRecommendedDns: updated ${type} for ${domain} → ${content}`
+        )
+        return { action: "updated", type, name: domain, content, record: updated }
+      }
+
+      const created = await this.createDnsRecord({
+        name: domain,
+        content,
+        type,
+        proxied: false,
+      })
+      this.log(
+        "info",
+        `applyRecommendedDns: created ${type} for ${domain} → ${content}`
+      )
+      return { action: "created", type, name: domain, content, record: created }
+    } catch (e: any) {
+      this.log("error", `applyRecommendedDns failed for ${domain}`, {
+        error: e.message,
+      })
+      return { action: "failed", type, name: domain, content, error: e.message }
+    }
   }
 
   /**

--- a/apps/backend/src/workflows/stores/provision-storefront.ts
+++ b/apps/backend/src/workflows/stores/provision-storefront.ts
@@ -141,13 +141,17 @@ const addVercelDomainStep = createStep(
   }
 )
 
-// Step 4a: Create Cloudflare CNAME record pointing to Vercel
+// Step 4a: Create Cloudflare DNS record using Vercel's recommended target
+// for this specific project. The recommendation is fetched at runtime so
+// per-project CNAMEs (e.g. dc034fcb6b63fdce.vercel-dns-017.com) are applied
+// directly rather than the generic cname.vercel-dns.com fallback.
 const createCloudflareCnameStep = createStep(
   "create-cloudflare-cname",
   async (input: { subdomain: string; rootDomain: string }, { container }) => {
     const deployment: DeploymentService = container.resolve(DEPLOYMENT_MODULE)
+    const fullDomain = `${input.subdomain}.${input.rootDomain}`
     try {
-      const result = await deployment.ensureVercelCname(input.subdomain, input.rootDomain)
+      const result = await deployment.applyRecommendedDns(fullDomain)
       console.log("[provision-storefront] Cloudflare DNS result:", JSON.stringify(result))
       return new StepResponse(result as any)
     } catch (e: any) {


### PR DESCRIPTION
## Summary

Vercel routes newer projects through **per-project CNAME targets** like `dc034fcb6b63fdce.vercel-dns-017.com` instead of the generic `cname.vercel-dns.com`. Partners with a freshly-provisioned subdomain were seeing \"Update your DNS\" instructions in Vercel because we shipped the generic CNAME and never re-read Vercel's recommendation.

This PR centralises the recommendation-aware DNS application and uses it in every place we touch storefront DNS.

## What changed

**New: `DeploymentService.applyRecommendedDns(domain)`**
- Calls Vercel `getDomainConfig(domain)` and applies `recommendedCNAME[0].value` (or `recommendedIPv4[0].value[0]` for apex domains) via Cloudflare `createDnsRecord`/`updateDnsRecord`.
- Falls back to the generic `cname.vercel-dns.com` / `76.76.21.21` if Vercel returned no recommendation.
- Idempotent — safe to re-run; emits `exists` when nothing changed.
- Returns `{ action, type, name, content, record?, error? }` so callers can describe the outcome.

**Provision workflow — `createCloudflareCnameStep`**
- Now calls `applyRecommendedDns(\${subdomain}.\${rootDomain})` instead of `ensureVercelCname`.
- New partners get the project-specific CNAME from day one.

**`POST /partners/storefront/domain/verify`** (custom-domain re-check)
- Applies recommended DNS **before** calling Vercel verify, so when the domain is in our Cloudflare zone the next verify call can flip `verified: true` in the same response.
- Domains outside our zone fail/skip cleanly and fall through to the existing \"return instructions\" path.
- Response gains an `applied: { action, type, content, ... }` field alongside the existing `dns_records`.

**New: `POST /partners/storefront/dns`**
- Focused refresh for the partner's primary `storefront_domain` — lets already-provisioned partners self-heal stale CNAMEs without re-running the whole provision flow.
- Accepts optional `{ domain }` body to target a custom domain instead.
- Response: `{ domain, applied, recommendation: { misconfigured, recommended_cname, recommended_ipv4 } }`.

## Test plan

- [ ] Newly-provisioned partner: confirm CF CNAME content matches Vercel's `recommendedCNAME` (e.g. `dc034fcb6b63fdce.vercel-dns-017.com`), not the generic `cname.vercel-dns.com`.
- [ ] Existing partner with the generic CNAME: `POST /partners/storefront/dns` updates the CF record to the per-project target; second call returns `action: \"exists\"`.
- [ ] Partner with a partner-owned custom domain (outside our zone): `POST /partners/storefront/domain/verify` still returns `dns_records` instructions; the `applied` field shows `failed` or `skipped` reason without breaking the response.
- [ ] Cloudflare unconfigured (no token): `applied` returns `{ action: \"skipped\", reason: \"Cloudflare not configured\" }` and the endpoint still responds 200.
- [ ] Verify endpoint after applying: confirm Vercel's verify call eventually returns `verified: true` (allowing for DNS propagation).

## Follow-ups (not in this PR)
- The legacy `ensureVercelCname` is unused after this change and can be removed in a separate cleanup.
- Custom-domain field `custom_domain` is still metadata-only — separate column work if we want consistency with the primary subdomain pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)