### PR TITLE
fix(partner-ui): collection scoping, default variant title, product-type redirect

### DIFF
--- a/apps/backend/src/api/partners/product-collections/route.ts
+++ b/apps/backend/src/api/partners/product-collections/route.ts
@@ -1,7 +1,28 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
 import { createCollectionsWorkflow } from "@medusajs/medusa/core-flows"
 import { getPartnerStore, tryGetPartnerStore } from "../helpers"
+
+const slugify = (value: string) =>
+  value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+
+// Collection handles are globally unique in Medusa. Partners share that
+// namespace, so two partners would otherwise collide on common titles like
+// "Summer 2026". Scope every partner-created handle with a short slug from
+// the store id so each partner gets its own subspace.
+const buildPartnerCollectionHandle = (
+  storeId: string,
+  userHandle: string | undefined,
+  title: string
+) => {
+  const storeSuffix = storeId.slice(-6).toLowerCase()
+  const base = slugify(userHandle?.trim() ? userHandle : title)
+  return `s-${storeSuffix}-${base}`
+}
 
 export const GET = async (
   req: AuthenticatedMedusaRequest,
@@ -48,9 +69,31 @@ export const POST = async (
 ) => {
   const { store } = await getPartnerStore(req.auth_context, req.scope)
 
+  const body = (req.body ?? {}) as {
+    title?: string
+    handle?: string
+    metadata?: Record<string, unknown>
+  }
+
+  if (!body.title || typeof body.title !== "string" || !body.title.trim()) {
+    throw new MedusaError(MedusaError.Types.INVALID_DATA, "title is required")
+  }
+
+  const scopedHandle = buildPartnerCollectionHandle(
+    store.id,
+    body.handle,
+    body.title
+  )
+
   const { result } = await createCollectionsWorkflow(req.scope).run({
     input: {
-      collections: [req.body as any],
+      collections: [
+        {
+          ...body,
+          title: body.title.trim(),
+          handle: scopedHandle,
+        } as any,
+      ],
     },
   })
 

--- a/apps/backend/src/api/partners/stores/[id]/products/quick/route.ts
+++ b/apps/backend/src/api/partners/stores/[id]/products/quick/route.ts
@@ -92,8 +92,9 @@ export const POST = async (
     )
   }
 
+  const productTitle = body.title.trim()
   const productInput: any = {
-    title: body.title.trim(),
+    title: productTitle,
     description: body.description?.trim() || undefined,
     status: body.status ?? ProductStatus.PUBLISHED,
     thumbnail: body.thumbnail || body.images?.[0] || undefined,
@@ -104,7 +105,7 @@ export const POST = async (
     ],
     variants: [
       {
-        title: "Default variant",
+        title: productTitle,
         options: { "Default option": "Default option value" },
         manage_inventory: true,
         prices: [{ amount: body.price, currency_code: currencyCode }],

--- a/apps/partner-ui/src/routes/product-types/product-type-create/components/create-product-type-form/create-product-type-form.tsx
+++ b/apps/partner-ui/src/routes/product-types/product-type-create/components/create-product-type-form/create-product-type-form.tsx
@@ -38,7 +38,7 @@ export const CreateProductTypeForm = () => {
             })
           )
 
-          handleSuccess(`/settings/product-types/${product_type.id}`)
+          handleSuccess(`/product-types/${product_type.id}`)
         },
         onError: (e) => {
           toast.error(e.message)

--- a/apps/partner-ui/src/routes/products/product-create/components/product-create-details-form/components/product-create-details-variant-section/product-create-details-variant-section.tsx
+++ b/apps/partner-ui/src/routes/products/product-create/components/product-create-details-form/components/product-create-details-variant-section/product-create-details-variant-section.tsx
@@ -255,7 +255,7 @@ export const ProductCreateVariantsSection = ({
       "variants",
       decorateVariantsWithDefaultValues([
         {
-          title: "Default variant",
+          title: "",
           should_create: true,
           variant_rank: 0,
           options: {

--- a/apps/partner-ui/src/routes/products/product-create/constants.ts
+++ b/apps/partner-ui/src/routes/products/product-create/constants.ts
@@ -132,7 +132,7 @@ export const PRODUCT_CREATE_FORM_DEFAULTS: Partial<
   ],
   variants: decorateVariantsWithDefaultValues([
     {
-      title: "Default variant",
+      title: "",
       should_create: true,
       variant_rank: 0,
       options: {

--- a/apps/partner-ui/src/routes/products/product-create/utils.ts
+++ b/apps/partner-ui/src/routes/products/product-create/utils.ts
@@ -13,6 +13,8 @@ export const normalizeProductFormValues = (
     ?.filter((media) => !media.isThumbnail)
     .map((media) => ({ url: media.url }))
 
+  const productTitle = values.title.trim()
+
   return {
     status: values.status,
     is_giftcard: false,
@@ -33,7 +35,7 @@ export const normalizeProductFormValues = (
     mid_code: values.mid_code || undefined,
     hs_code: values.hs_code || undefined,
     thumbnail,
-    title: values.title.trim(),
+    title: productTitle,
     subtitle: values.subtitle?.trim(),
     description: values.description?.trim(),
     discountable: values.discountable,
@@ -44,14 +46,16 @@ export const normalizeProductFormValues = (
     options: values.options.filter((o) => o.title), // clean temp. values
     variants: normalizeVariants(
       values.variants.filter((variant) => variant.should_create),
-      values.regionsCurrencyMap
+      values.regionsCurrencyMap,
+      productTitle
     ),
   }
 }
 
 export const normalizeVariants = (
   variants: ProductCreateSchemaType["variants"],
-  regionsCurrencyMap: Record<string, string>
+  regionsCurrencyMap: Record<string, string>,
+  productTitle?: string
 ): HttpTypes.AdminCreateProductVariant[] => {
   return variants.map((variant) => {
     const inventoryItems = (variant.inventory || [])
@@ -77,7 +81,10 @@ export const normalizeVariants = (
       )
 
     return {
-    title: variant.title || Object.values(variant.options || {}).join(" / "),
+    title:
+      variant.title ||
+      productTitle ||
+      Object.values(variant.options || {}).join(" / "),
     options: variant.options,
     sku: variant.sku || undefined,
     manage_inventory: !!variant.manage_inventory,


### PR DESCRIPTION
## Summary

Three independent partner-ui / partner-API bug fixes bundled into one PR. Reviewable commit-by-commit.

### 1. `fix(partners): scope product-collection handle per store`
Collection creation went through Medusa's `createCollectionsWorkflow`, which enforces a globally-unique `handle`. Two partners couldn't both use "Summer 2026" — the second got *"already created"*. The partners API now prefixes every partner-created handle with `s-<last-6-of-store-id>-`, so each store has its own collection-handle subspace. Partner-UI form is unchanged.

> Note: I used 6 chars (not 4 from the question preview) to avoid birthday collisions across ~1000 stores. Easy to change to 4 if you prefer a shorter URL.

### 2. `fix(partners): default variant title falls back to product title`
The auto-generated default variant was titled "Default variant" in both flows:
- **Quick create** (`apps/backend/.../products/quick/route.ts`): backend now uses `body.title` for the variant title.
- **Advanced create** (`apps/partner-ui/.../product-create/*`): the wizard's two hardcoded `"Default variant"` defaults are now empty; `normalizeVariants` falls back to the product title at submit time.

### 3. `fix(partner-ui): redirect to /product-types after creating a type`
`create-product-type-form.tsx` was navigating to `/settings/product-types/:id` (legacy nested route). Now points at the top-level `/product-types/:id` registered in `get-partner-route.map.tsx`.

## Test plan
- [ ] As partner A, create collection "Summer 2026" — succeeds.
- [ ] As partner B, create collection "Summer 2026" — also succeeds (handles differ).
- [ ] Quick-create a product titled "Linen Shirt"; verify variant is titled "Linen Shirt" (not "Default variant").
- [ ] Advanced-create a product titled "Linen Shirt" without enabling custom variants; verify the same.
- [ ] Toggle "enable custom variants" off after adding variants; verify the recreated default variant is titled after the product, not "Default variant".
- [ ] Create a product type; verify the modal closes to `/product-types/:id`, not `/settings/product-types/:id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)