### PR TITLE
fix(website): page-by-domain lookup ignored alias and partner fallbacks

### DIFF
--- a/apps/backend/src/workflows/website/find-website-page-per-domain.ts
+++ b/apps/backend/src/workflows/website/find-website-page-per-domain.ts
@@ -6,6 +6,7 @@ import {
 } from "@medusajs/framework/workflows-sdk";
 import { WEBSITE_MODULE } from "../../modules/website";
 import WebsiteService from "../../modules/website/service";
+import PartnerService from "../../modules/partner/service";
 import { MedusaError } from "@medusajs/framework/utils";
 
 export type FindWebsitePagePerDomainStepInput = {
@@ -14,28 +15,71 @@ export type FindWebsitePagePerDomainStepInput = {
   exclude?: string;
 };
 
+const PAGE_RELATIONS = ["pages", "pages.blocks"] as const;
+
 export const findWebsitePagePerDomainStep = createStep(
   "find-website-page-per-domain-step",
   async (input: FindWebsitePagePerDomainStepInput, { container }) => {
     const websiteService: WebsiteService = container.resolve(WEBSITE_MODULE);
-    
-    // Find website by domain with its pages
-    const websites = await websiteService.listAndCountWebsites(
-      { domain: input.domain },
-      {
-        relations: ["pages", "pages.blocks"],
-        take: 1,
-      }
-    );
 
-    if (!websites[0]?.length) {
+    // The resolution order mirrors findWebsiteByDomainStep so /web/website/:domain
+    // and /web/website/:domain/:page agree on what a "domain" means: primary
+    // domain, alias row, or partner.storefront_domain fallback.
+
+    // 1. Direct domain lookup (primary path, unique index on website.domain).
+    let websiteRow: any | undefined
+    {
+      const [list] = await websiteService.listAndCountWebsites(
+        { domain: input.domain },
+        { relations: [...PAGE_RELATIONS], take: 1 }
+      );
+      websiteRow = list?.[0];
+    }
+
+    // 2. Alias lookup: check website_domain table for additional domains
+    //    (custom domains, marketing aliases) mapped to the same website.
+    if (!websiteRow) {
+      const [aliasRows] = await (websiteService as any).listAndCountWebsiteDomains(
+        { domain: input.domain },
+        { take: 1 }
+      );
+      const websiteId = aliasRows?.[0]?.website_id;
+      if (websiteId) {
+        websiteRow = await websiteService.retrieveWebsite(websiteId, {
+          relations: [...PAGE_RELATIONS],
+        });
+      }
+    }
+
+    // 3. Partner fallback: partner.storefront_domain → partner.website_id.
+    //    Covers the window between provisioning and website row propagation,
+    //    or partners whose website_id was linked via an alternative flow.
+    if (!websiteRow) {
+      try {
+        const partnerService: PartnerService = container.resolve("partner");
+        const [partners] = await partnerService.listAndCountPartners(
+          { storefront_domain: input.domain },
+          { take: 1 }
+        );
+        const websiteId = (partners?.[0] as any)?.website_id;
+        if (websiteId) {
+          websiteRow = await websiteService.retrieveWebsite(websiteId, {
+            relations: [...PAGE_RELATIONS],
+          });
+        }
+      } catch {
+        // partner service may be unavailable in some contexts — fall through
+      }
+    }
+
+    if (!websiteRow) {
       throw new MedusaError(
         MedusaError.Types.NOT_FOUND,
         `Website with domain ${input.domain} not found`
       )
     }
 
-    const website = websites[0][0];
+    const website = websiteRow;
 
     // Return the specific page
     const page = website.pages?.find(


### PR DESCRIPTION
## Summary

`/web/website/:domain` resolves a domain through three layers:
1. direct match on `website.domain`
2. alias rows in the `website_domain` table
3. fallback to `partner.storefront_domain`

`/web/website/:domain/:page` (used by every `/pages/<slug>` lookup on partner storefronts) only did the direct match. That's why `https://v3.jaalyantra.com/web/website/uniquepashmina.com/` returns the site fine, but `https://v3.jaalyantra.com/web/website/uniquepashmina.com/terms-and-conditions` throws `Website with domain uniquepashmina.com not found` — same domain, same DB row, different lookup logic.

This hits every partner whose primary `website.domain` differs from what the storefront sends (alias domains, partners onboarded with `storefront_domain` ahead of the website row, etc.). With the footer's Legal column shipped, this also blew up the three seeded legal slugs.

Fix is in `apps/backend/src/workflows/website/find-website-page-per-domain.ts:findWebsitePagePerDomainStep` — adds the alias and partner fallbacks that `findWebsiteByDomainStep` already had, preserving the `pages.blocks` relation in every branch.

## Test plan
- [ ] `GET /web/website/<alias_domain>/<seeded_slug>` returns the page (was 404).
- [ ] `GET /web/website/<primary_domain>/<seeded_slug>` still returns the page (no regression on the direct-match path).
- [ ] `GET /web/website/<unknown_domain>/<slug>` still returns 404 with "Website with domain X not found".
- [ ] `GET /web/website/<known_domain>/<unknown_slug>` returns 404 with "Page with slug X not found" (the second branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)