### PR TITLE
fix(partner-ui): migrate to zod v4 after backend 2.15.2 bump

### DIFF
--- a/apps/partner-ui/package.json
+++ b/apps/partner-ui/package.json
@@ -82,7 +82,7 @@
     "react-jwt": "^1.2.0",
     "react-router-dom": "6.20.1",
     "typescript": "^5.9.3",
-    "zod": "3.25.76"
+    "zod": "^4.2.0"
   },
   "devDependencies": {
     "@medusajs/admin-shared": "2.14.2",

--- a/apps/partner-ui/src/components/onboarding/onboarding-modal.tsx
+++ b/apps/partner-ui/src/components/onboarding/onboarding-modal.tsx
@@ -195,7 +195,7 @@ export const OnboardingModal = ({
     for (const person of filled) {
       const result = personSchema.safeParse(person)
       if (!result.success) {
-        const firstError = result.error.errors[0]
+        const firstError = result.error.issues[0]
         setError(`${firstError.path.join(".")} - ${firstError.message}`)
         return false
       }

--- a/apps/partner-ui/src/dashboard-app/forms/form-extension-zone/utils.ts
+++ b/apps/partner-ui/src/dashboard-app/forms/form-extension-zone/utils.ts
@@ -1,14 +1,4 @@
-import {
-  ZodBoolean,
-  ZodEffects,
-  ZodNull,
-  ZodNullable,
-  ZodNumber,
-  ZodOptional,
-  ZodString,
-  ZodType,
-  ZodUndefined,
-} from "@medusajs/framework/zod"
+import { z } from "@medusajs/framework/zod"
 import { FormFieldType } from "./types"
 
 export function getFieldLabel(name: string, label?: string) {
@@ -22,45 +12,42 @@ export function getFieldLabel(name: string, label?: string) {
     .join(" ")
 }
 
-export function getFieldType(type: ZodType): FormFieldType {
-  if (type instanceof ZodString) {
+export function getFieldType(type: z.ZodType): FormFieldType {
+  if (type instanceof z.ZodString) {
     return "text"
   }
 
-  if (type instanceof ZodNumber) {
+  if (type instanceof z.ZodNumber) {
     return "number"
   }
 
-  if (type instanceof ZodBoolean) {
+  if (type instanceof z.ZodBoolean) {
     return "boolean"
   }
 
-  if (type instanceof ZodNullable) {
-    const innerType = type.unwrap()
-
+  if (type instanceof z.ZodNullable) {
+    const innerType = type.unwrap() as z.ZodType
     return getFieldType(innerType)
   }
 
-  if (type instanceof ZodOptional) {
-    const innerType = type.unwrap()
-
+  if (type instanceof z.ZodOptional) {
+    const innerType = type.unwrap() as z.ZodType
     return getFieldType(innerType)
   }
 
-  if (type instanceof ZodEffects) {
-    const innerType = type.innerType()
-
+  if (type instanceof z.ZodPipe) {
+    const innerType = type.def.in as z.ZodType
     return getFieldType(innerType)
   }
 
   return "unsupported"
 }
 
-export function getIsFieldOptional(type: ZodType) {
+export function getIsFieldOptional(type: z.ZodType) {
   return (
-    type instanceof ZodOptional ||
-    type instanceof ZodNull ||
-    type instanceof ZodUndefined ||
-    type instanceof ZodNullable
+    type instanceof z.ZodOptional ||
+    type instanceof z.ZodNull ||
+    type instanceof z.ZodUndefined ||
+    type instanceof z.ZodNullable
   )
 }

--- a/apps/partner-ui/src/dashboard-app/forms/hooks.tsx
+++ b/apps/partner-ui/src/dashboard-app/forms/hooks.tsx
@@ -1,15 +1,15 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { FieldValues, useForm, UseFormProps } from "react-hook-form"
-import { z, ZodEffects, ZodObject } from "@medusajs/framework/zod"
+import { z, ZodObject } from "@medusajs/framework/zod"
 
 import { ConfigField } from "../types"
 
 interface UseExtendableFormProps<
-  TSchema extends ZodObject<any> | ZodEffects<ZodObject<any>>,
+  TSchema extends ZodObject<any>,
   TContext = any,
   TData = any
 > extends Omit<UseFormProps<z.infer<TSchema>, TContext>, "resolver"> {
-  schema: TSchema
+  schema: TSchema | z.ZodPipe<TSchema, z.ZodType>
   configs: ConfigField[]
   data?: TData
 }
@@ -21,26 +21,40 @@ function createAdditionalDataSchema(configs: ConfigField[]) {
   }, {} as Record<string, z.ZodTypeAny>)
 }
 
-function createExtendedSchema<
-  TSchema extends ZodObject<any> | ZodEffects<ZodObject<any>>
->(baseSchema: TSchema, additionalDataSchema: Record<string, z.ZodTypeAny>) {
+function getSchemaShape(
+  schema: ZodObject<any> | z.ZodPipe<ZodObject<any>, z.ZodType>
+): z.ZodRawShape {
+  if (schema instanceof z.ZodPipe) {
+    const innerSchema = schema.def.in
+    if (innerSchema instanceof ZodObject) {
+      return innerSchema.shape
+    }
+    throw new Error(
+      "Expected ZodPipe to contain a ZodObject. Schema extensions require the base schema to be a ZodObject."
+    )
+  }
+  return schema.shape
+}
+
+function createExtendedSchema(
+  baseSchema: ZodObject<any> | z.ZodPipe<ZodObject<any>, z.ZodType>,
+  additionalDataSchema: Record<string, z.ZodTypeAny>
+) {
+  const baseShape = getSchemaShape(baseSchema)
+
   const extendedObjectSchema = z.object({
-    ...(baseSchema instanceof ZodEffects
-      ? baseSchema.innerType().shape
-      : baseSchema.shape),
+    ...baseShape,
     additional_data: z.object(additionalDataSchema).optional(),
   })
 
-  return baseSchema instanceof ZodEffects
-    ? baseSchema
-        .superRefine((data, ctx) => {
-          const result = extendedObjectSchema.safeParse(data)
-          if (!result.success) {
-            result.error.issues.forEach((issue) => ctx.addIssue(issue))
-          }
-        })
-        .and(extendedObjectSchema)
-    : extendedObjectSchema
+  return baseSchema
+    .superRefine((data, ctx) => {
+      const result = extendedObjectSchema.safeParse(data)
+      if (!result.success) {
+        result.error.issues.forEach((issue) => ctx.addIssue({ ...issue }))
+      }
+    })
+    .and(extendedObjectSchema)
 }
 
 function createExtendedDefaultValues<TData>(
@@ -60,7 +74,7 @@ function createExtendedDefaultValues<TData>(
 }
 
 export const useExtendableForm = <
-  TSchema extends ZodObject<any> | ZodEffects<ZodObject<any>>,
+  TSchema extends ZodObject<any>,
   TContext = any,
   TTransformedValues extends FieldValues | undefined = undefined
 >({

--- a/apps/partner-ui/src/dashboard-app/types.ts
+++ b/apps/partner-ui/src/dashboard-app/types.ts
@@ -8,7 +8,7 @@ import {
 } from "@medusajs/admin-shared"
 import { ComponentType } from "react"
 import { LoaderFunction } from "react-router-dom"
-import { ZodFirstPartySchemaTypes } from "@medusajs/framework/zod"
+import { z } from "@medusajs/framework/zod"
 import { INavItem } from "../components/layout/nav-item"
 
 export type RouteExtension = {
@@ -39,7 +39,7 @@ export type DisplayExtension = {
 }
 
 export type FormFieldExtension = {
-  validation: ZodFirstPartySchemaTypes
+  validation: z.ZodTypeAny
   Component?: ComponentType<any>
   label?: string
   description?: string
@@ -54,7 +54,7 @@ export type FormExtension = {
 
 export type ConfigFieldExtension = {
   defaultValue: ((data: any) => any) | any
-  validation: ZodFirstPartySchemaTypes
+  validation: z.ZodTypeAny
 }
 
 export type ConfigExtension = {

--- a/apps/partner-ui/src/lib/validation.ts
+++ b/apps/partner-ui/src/lib/validation.ts
@@ -87,7 +87,7 @@ export function partialFormValidation<TForm extends FieldValues>(
   const validationResult = schema.safeParse(values)
 
   if (!validationResult.success) {
-    validationResult.error.errors.forEach(({ path, message, code }) => {
+    validationResult.error.issues.forEach(({ path, message, code }) => {
       form.setError(path.join(".") as any, {
         type: code,
         message,

--- a/apps/partner-ui/src/routes/categories/category-create/components/create-category-form/create-category-form.tsx
+++ b/apps/partner-ui/src/routes/categories/category-create/components/create-category-form/create-category-form.tsx
@@ -61,7 +61,7 @@ export const CreateCategoryForm = ({
       })
 
       if (!result.success) {
-        result.error.errors.forEach((error) => {
+        result.error.issues.forEach((error) => {
           form.setError(error.path.join(".") as keyof CreateCategorySchema, {
             type: "manual",
             message: error.message,

--- a/apps/partner-ui/src/routes/home/home-onboarding/home-onboarding.tsx
+++ b/apps/partner-ui/src/routes/home/home-onboarding/home-onboarding.tsx
@@ -209,7 +209,7 @@ const OnboardingForm = () => {
     for (const person of filled) {
       const result = personSchema.safeParse(person)
       if (!result.success) {
-        const firstError = result.error.errors[0]
+        const firstError = result.error.issues[0]
         setError(`${firstError.path.join(".")} - ${firstError.message}`)
         return false
       }

--- a/apps/partner-ui/src/routes/inventory/inventory-stock/schema.ts
+++ b/apps/partner-ui/src/routes/inventory/inventory-stock/schema.ts
@@ -7,14 +7,14 @@ const LocationQuantitySchema = z.object({
   disabledToggle: z.boolean(),
 })
 
-const InventoryLocationsSchema = z.record(LocationQuantitySchema)
+const InventoryLocationsSchema = z.record(z.string(), LocationQuantitySchema)
 
 const InventoryItemSchema = z.object({
   locations: InventoryLocationsSchema,
 })
 
 export const InventoryStockSchema = z.object({
-  inventory_items: z.record(InventoryItemSchema),
+  inventory_items: z.record(z.string(), InventoryItemSchema),
 })
 
 export type InventoryLocationsSchema = z.infer<typeof InventoryLocationsSchema>

--- a/apps/partner-ui/src/routes/locations/location-service-zone-shipping-option-create/components/create-shipping-options-form/create-shipping-options-form.tsx
+++ b/apps/partner-ui/src/routes/locations/location-service-zone-shipping-option-create/components/create-shipping-options-form/create-shipping-options-form.tsx
@@ -199,7 +199,7 @@ export function CreateShippingOptionsForm({
       })
 
       if (!result.success) {
-        const [firstError, ...rest] = result.error.errors
+        const [firstError, ...rest] = result.error.issues
 
         for (const error of rest) {
           const _path = error.path.join(".") as keyof CreateShippingOptionSchema

--- a/apps/partner-ui/src/routes/price-lists/common/schemas.ts
+++ b/apps/partner-ui/src/routes/price-lists/common/schemas.ts
@@ -30,8 +30,14 @@ export type PriceListCreateRegionPriceSchema = z.infer<
 >
 
 const PriceListCreateProductVariantSchema = z.object({
-  currency_prices: z.record(PriceListCreateCurrencyPriceSchema.optional()),
-  region_prices: z.record(PriceListCreateRegionPriceSchema.optional()),
+  currency_prices: z.record(
+    z.string(),
+    PriceListCreateCurrencyPriceSchema.optional()
+  ),
+  region_prices: z.record(
+    z.string(),
+    PriceListCreateRegionPriceSchema.optional()
+  ),
 })
 
 export type PriceListCreateProductVariantSchema = z.infer<
@@ -39,6 +45,7 @@ export type PriceListCreateProductVariantSchema = z.infer<
 >
 
 const PriceListCreateProductVariantsSchema = z.record(
+  z.string(),
   PriceListCreateProductVariantSchema
 )
 
@@ -47,6 +54,7 @@ export type PriceListCreateProductVariantsSchema = z.infer<
 >
 
 export const PriceListCreateProductsSchema = z.record(
+  z.string(),
   z.object({
     variants: PriceListCreateProductVariantsSchema,
   })
@@ -75,9 +83,16 @@ export type PriceListUpdateRegionPrice = z.infer<
 >
 
 export const PriceListUpdateProductVariantsSchema = z.record(
+  z.string(),
   z.object({
-    currency_prices: z.record(PriceListUpdateCurrencyPriceSchema.optional()),
-    region_prices: z.record(PriceListUpdateRegionPriceSchema.optional()),
+    currency_prices: z.record(
+      z.string(),
+      PriceListUpdateCurrencyPriceSchema.optional()
+    ),
+    region_prices: z.record(
+      z.string(),
+      PriceListUpdateRegionPriceSchema.optional()
+    ),
   })
 )
 
@@ -86,6 +101,7 @@ export type PriceListUpdateProductVariantsSchema = z.infer<
 >
 
 export const PriceListUpdateProductsSchema = z.record(
+  z.string(),
   z.object({
     variants: PriceListUpdateProductVariantsSchema,
   })

--- a/apps/partner-ui/src/routes/price-lists/price-list-create/components/price-list-create-form/price-list-create-form.tsx
+++ b/apps/partner-ui/src/routes/price-lists/price-list-create/components/price-list-create-form/price-list-create-form.tsx
@@ -132,7 +132,7 @@ export const PriceListCreateForm = ({
     const validationResult = schema.safeParse(values)
 
     if (!validationResult.success) {
-      validationResult.error.errors.forEach(({ path, message, code }) => {
+      validationResult.error.issues.forEach(({ path, message, code }) => {
         form.setError(path.join(".") as keyof PricingCreateSchemaType, {
           type: code,
           message,

--- a/apps/partner-ui/src/routes/price-lists/price-list-prices-add/components/price-list-prices-add-form/price-list-prices-add-form.tsx
+++ b/apps/partner-ui/src/routes/price-lists/price-list-prices-add/components/price-list-prices-add-form/price-list-prices-add-form.tsx
@@ -102,7 +102,7 @@ export const PriceListPricesAddForm = ({
     const validationResult = schema.safeParse(values)
 
     if (!validationResult.success) {
-      validationResult.error.errors.forEach(({ path, message, code }) => {
+      validationResult.error.issues.forEach(({ path, message, code }) => {
         form.setError(path.join(".") as keyof PriceListPricesAddSchema, {
           type: code,
           message,

--- a/apps/partner-ui/src/routes/product-variants/product-variant-edit/components/product-edit-variant-form/product-edit-variant-form.tsx
+++ b/apps/partner-ui/src/routes/product-variants/product-variant-edit/components/product-edit-variant-form/product-edit-variant-form.tsx
@@ -38,7 +38,7 @@ const ProductEditVariantSchema = z.object({
   mid_code: z.string().optional(),
   hs_code: z.string().optional(),
   origin_country: z.string().optional(),
-  options: z.record(z.string()),
+  options: z.record(z.string(), z.string()),
 })
 
 // TODO: Either pass option ID or make the backend handle options constraints differently to handle the lack of IDs

--- a/apps/partner-ui/src/routes/products/product-create-variant/components/create-product-variant-form/constants.ts
+++ b/apps/partner-ui/src/routes/products/product-create-variant/components/create-product-variant-form/constants.ts
@@ -8,7 +8,7 @@ export const CreateProductVariantSchema = z.object({
   manage_inventory: z.boolean().optional(),
   allow_backorder: z.boolean().optional(),
   inventory_kit: z.boolean().optional(),
-  options: z.record(z.string()),
+  options: z.record(z.string(), z.string()),
   prices: zod
     .record(zod.string(), zod.string().or(zod.number()).optional())
     .optional(),

--- a/apps/partner-ui/src/routes/products/product-stock/schema.ts
+++ b/apps/partner-ui/src/routes/products/product-stock/schema.ts
@@ -7,18 +7,18 @@ const LocationQuantitySchema = z.object({
   disabledToggle: z.boolean(),
 })
 
-const ProductStockLocationsSchema = z.record(LocationQuantitySchema)
+const ProductStockLocationsSchema = z.record(z.string(), LocationQuantitySchema)
 
 const ProductStockInventoryItemSchema = z.object({
   locations: ProductStockLocationsSchema,
 })
 
 const ProductStockVariantSchema = z.object({
-  inventory_items: z.record(ProductStockInventoryItemSchema),
+  inventory_items: z.record(z.string(), ProductStockInventoryItemSchema),
 })
 
 export const ProductStockSchema = z.object({
-  variants: z.record(ProductStockVariantSchema),
+  variants: z.record(z.string(), ProductStockVariantSchema),
 })
 
 export type ProductStockLocationSchema = z.infer<

--- a/apps/partner-ui/src/routes/store/store-add-currencies/components/add-currencies-form/add-currencies-form.tsx
+++ b/apps/partner-ui/src/routes/store/store-add-currencies/components/add-currencies-form/add-currencies-form.tsx
@@ -34,7 +34,7 @@ type AddCurrenciesFormProps = {
 
 const AddCurrenciesSchema = zod.object({
   currencies: zod.array(zod.string()).min(1),
-  pricePreferences: zod.record(zod.boolean()),
+  pricePreferences: zod.record(zod.string(), zod.boolean()),
 })
 
 const PAGE_SIZE = 50


### PR DESCRIPTION
## Summary
- Backend 2.15.2 pulled in `@medusajs/deps@2.15.2`, which switched the transitive zod dep from v3 to v4. `@medusajs/framework/zod` re-exports `require("zod")`, so the whole workspace now resolves to zod v4 — but partner-ui was written for v3.
- Two visible symptoms on production: `Right hand side of instanceof is not an object` on the product edit drawer, and `undefined is not an object (evaluating 'def.valueType._zod')` when changing tabs in the variant create form.
- This PR mirrors the upstream `medusajs/dashboard` migration to bring partner-ui onto v4.

## What changed
- `ZodEffects` (removed in v4) → `z.ZodPipe` with `def.in`. Affected: `dashboard-app/forms/hooks.tsx`, `dashboard-app/forms/form-extension-zone/utils.ts`.
- `ZodFirstPartySchemaTypes` (removed) → `z.ZodTypeAny`. Affected: `dashboard-app/types.ts`.
- `z.record(V)` single-arg form: in v3 it meant "record with V values, string keys"; in v4 the single arg is interpreted as the KEY type and `valueType` is undefined, which is the exact `def.valueType._zod` error path. Converted to `z.record(z.string(), V)` in:
  - `routes/products/product-create-variant/.../constants.ts`
  - `routes/product-variants/product-variant-edit/.../product-edit-variant-form.tsx`
  - `routes/products/product-stock/schema.ts`
  - `routes/inventory/inventory-stock/schema.ts`
  - `routes/price-lists/common/schemas.ts`
  - `routes/store/store-add-currencies/.../add-currencies-form.tsx`
- `ZodError.errors` (removed in v4) → `.issues` in 7 sites: `lib/validation.ts`, `components/onboarding/onboarding-modal.tsx`, `routes/home/home-onboarding/home-onboarding.tsx`, two price-list forms, the shipping-option-create form, the category-create form.
- `apps/partner-ui/package.json`: declared `"zod": "3.25.76"` while node_modules resolved to v4 — corrected to `"^4.2.0"` so the manifest matches reality.

Verified that `.merge()` and `z.string().email()` still work in v4 (deprecated but functional) — left untouched.

## Test plan
- [ ] `/products/:id/edit` drawer opens without `instanceof` error
- [ ] `/products/:id/variants/new` tab navigation works (smoke test the path from the bug report)
- [ ] `/products/:id/variants/:id/edit` saves
- [ ] Price list create + add prices flows
- [ ] Inventory + product stock screens still parse correctly
- [ ] Category create
- [ ] Store add currencies modal
- [ ] Shipping option create on a location

🤖 Generated with [Claude Code](https://claude.com/claude-code)