### PR TITLE
feat(deploy): SNS deploy alerts + fix CI lowercase/sha-pin bugs

### DIFF
--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -32,7 +32,9 @@ env:
   AWS_REGION: us-east-1
   ECR_REPOSITORY: jyt-medusa
   GHCR_REGISTRY: ghcr.io
-  GHCR_IMAGE: ghcr.io/${{ github.repository }}
+  # GHCR_IMAGE is computed per-job (lowercase) — see the `image-vars` step
+  # in build-and-push. Docker rejects uppercase characters in image refs and
+  # ${{ github.repository }} preserves the org's case (Jaal-Yantra-Textiles).
   # Same Node.js 24 opt-in as the old Railway pipeline used.
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
@@ -51,12 +53,25 @@ jobs:
     name: Build & Push Image
     runs-on: ubuntu-latest
     outputs:
-      image_tag: ${{ steps.meta.outputs.version }}
-      image_ref: ${{ env.GHCR_IMAGE }}:${{ steps.meta.outputs.version }}
+      ghcr_image: ${{ steps.image-vars.outputs.ghcr_image }}
+      image_tag: ${{ steps.image-vars.outputs.image_tag }}
+      image_ref: ${{ steps.image-vars.outputs.ghcr_image }}:${{ steps.image-vars.outputs.image_tag }}
     steps:
       - uses: actions/checkout@v4
 
       - uses: docker/setup-buildx-action@v3
+
+      - name: Compute image vars (lowercase)
+        id: image-vars
+        run: |
+          # GHCR + Docker require lowercase image names; the org is mixed case.
+          REPO_LC=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          # Use the long commit SHA as the immutable tag; we never want :latest
+          # in a task definition because it would change under our feet.
+          {
+            echo "ghcr_image=ghcr.io/${REPO_LC}"
+            echo "image_tag=sha-${{ github.sha }}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -69,9 +84,12 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.GHCR_IMAGE }}
+          images: ${{ steps.image-vars.outputs.ghcr_image }}
+          # Priority forces the sha tag to be the primary one (metadata-action's
+          # default priorities are raw=200 > sha=100, which would otherwise make
+          # outputs.version="latest" on the default branch).
           tags: |
-            type=sha,format=long,prefix=sha-
+            type=sha,format=long,prefix=sha-,priority=1000
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
@@ -132,12 +150,13 @@ jobs:
       - name: Pull from GHCR + push to ECR
         id: mirror
         env:
+          GHCR_IMAGE: ${{ needs.build-and-push.outputs.ghcr_image }}
           GHCR_TAG: ${{ needs.build-and-push.outputs.image_tag }}
           ECR_REGISTRY: ${{ steps.ecr.outputs.registry }}
         run: |
           set -euo pipefail
-          # ECS task definitions reference :latest. We also tag the sha for
-          # auditing — if a regression appears, you can pin to a known-good sha.
+          # ECS task definitions reference the sha tag (immutable). :latest
+          # is kept as a convenience tag for ad-hoc pulls only.
           SRC="${GHCR_IMAGE}:${GHCR_TAG}"
           DST_SHA="${ECR_REGISTRY}/${ECR_REPOSITORY}:${GHCR_TAG}"
           DST_LATEST="${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"

--- a/deploy/aws/scripts/wire-deploy-alerts.sh
+++ b/deploy/aws/scripts/wire-deploy-alerts.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Wire ECS deployment state-change events from the prod cluster into the
+# existing jyt-prod-alerts SNS topic, and subscribe an email endpoint.
+#
+# Idempotent: safe to re-run. Only creates resources that don't exist.
+#
+# Resources touched:
+#   - SNS topic policy on jyt-prod-alerts (allows events.amazonaws.com to publish)
+#   - SNS email subscription for $ALERT_EMAIL (pending until recipient confirms)
+#   - EventBridge rule `jyt-prod-ecs-deploy-state-change` on the default bus
+#   - Rule target → jyt-prod-alerts with an InputTransformer so the email
+#     is human-readable instead of raw JSON
+#
+# Usage:
+#   ./deploy/aws/scripts/wire-deploy-alerts.sh
+#
+# Re-running with a different ALERT_EMAIL adds another subscription; it
+# does NOT remove the old one. Unsubscribe via the SNS console if needed.
+
+set -euo pipefail
+
+: "${AWS_REGION:=us-east-1}"
+: "${SNS_TOPIC_ARN:=arn:aws:sns:us-east-1:369351873445:jyt-prod-alerts}"
+: "${ALERT_EMAIL:=services.deployed@jaalyantra.com}"
+: "${ECS_CLUSTER_ARN:=arn:aws:ecs:us-east-1:369351873445:cluster/jyt-prod-Cluster-JOcsxaMtDKJ3}"
+: "${RULE_NAME:=jyt-prod-ecs-deploy-state-change}"
+
+echo "== Region:          $AWS_REGION"
+echo "== SNS topic:       $SNS_TOPIC_ARN"
+echo "== Alert email:     $ALERT_EMAIL"
+echo "== ECS cluster:     $ECS_CLUSTER_ARN"
+echo "== Rule name:       $RULE_NAME"
+echo
+
+# ---------------------------------------------------------------------------
+# 1. Subscribe email (idempotent: re-subscribing the same address is a no-op
+#    on AWS's side and just returns the existing pending or confirmed ARN).
+# ---------------------------------------------------------------------------
+echo "[1/4] Subscribing $ALERT_EMAIL to SNS topic..."
+SUB_OUT=$(aws sns subscribe \
+  --topic-arn "$SNS_TOPIC_ARN" \
+  --protocol email \
+  --notification-endpoint "$ALERT_EMAIL" \
+  --region "$AWS_REGION" \
+  --output json)
+SUB_ARN=$(echo "$SUB_OUT" | python3 -c "import json,sys;print(json.load(sys.stdin).get('SubscriptionArn','?'))")
+echo "    Subscription ARN: $SUB_ARN"
+if [ "$SUB_ARN" = "pending confirmation" ]; then
+  echo "    ⚠️  Recipient must click the confirmation link in the inbox."
+fi
+echo
+
+# ---------------------------------------------------------------------------
+# 2. Patch SNS topic policy so EventBridge can publish to it. Default policy
+#    only allows same-account publishes; the events.amazonaws.com principal
+#    is treated as a separate party even when the rule is in the same account.
+# ---------------------------------------------------------------------------
+echo "[2/4] Updating SNS topic policy for EventBridge..."
+NEW_POLICY=$(cat <<EOF
+{
+  "Version": "2008-10-17",
+  "Id": "jyt-prod-alerts-policy",
+  "Statement": [
+    {
+      "Sid": "AllowSameAccountServices",
+      "Effect": "Allow",
+      "Principal": {"AWS": "*"},
+      "Action": [
+        "SNS:GetTopicAttributes",
+        "SNS:SetTopicAttributes",
+        "SNS:AddPermission",
+        "SNS:RemovePermission",
+        "SNS:DeleteTopic",
+        "SNS:Subscribe",
+        "SNS:ListSubscriptionsByTopic",
+        "SNS:Publish"
+      ],
+      "Resource": "$SNS_TOPIC_ARN",
+      "Condition": {"StringEquals": {"AWS:SourceOwner": "369351873445"}}
+    },
+    {
+      "Sid": "AllowEventBridgePublish",
+      "Effect": "Allow",
+      "Principal": {"Service": "events.amazonaws.com"},
+      "Action": "SNS:Publish",
+      "Resource": "$SNS_TOPIC_ARN"
+    }
+  ]
+}
+EOF
+)
+aws sns set-topic-attributes \
+  --topic-arn "$SNS_TOPIC_ARN" \
+  --attribute-name Policy \
+  --attribute-value "$NEW_POLICY" \
+  --region "$AWS_REGION"
+echo "    Policy updated."
+echo
+
+# ---------------------------------------------------------------------------
+# 3. Create/update the EventBridge rule. We scope by clusterArn so other
+#    AWS accounts/clusters can't accidentally trigger this rule, and we
+#    match all three lifecycle events for full visibility.
+# ---------------------------------------------------------------------------
+echo "[3/4] Creating EventBridge rule $RULE_NAME..."
+EVENT_PATTERN=$(cat <<EOF
+{
+  "source": ["aws.ecs"],
+  "detail-type": ["ECS Deployment State Change"],
+  "detail": {
+    "clusterArn": ["$ECS_CLUSTER_ARN"]
+  }
+}
+EOF
+)
+aws events put-rule \
+  --name "$RULE_NAME" \
+  --description "Forward ECS deployment lifecycle events from $ECS_CLUSTER_ARN to SNS jyt-prod-alerts" \
+  --event-pattern "$EVENT_PATTERN" \
+  --state ENABLED \
+  --region "$AWS_REGION" >/dev/null
+echo "    Rule put."
+echo
+
+# ---------------------------------------------------------------------------
+# 4. Attach SNS target with an InputTransformer so the email shows a
+#    human-readable summary instead of the raw event JSON.
+#
+#    InputTemplate quoting is tricky: AWS parses the rendered template as
+#    JSON, so a plain-text email needs the template to be a JSON string
+#    literal (i.e., wrapped in escaped quotes). Easiest reliable path is
+#    to build the JSON in Python and write to a temp file.
+# ---------------------------------------------------------------------------
+echo "[4/4] Wiring SNS target with InputTransformer..."
+TARGETS_FILE=$(mktemp -t wire-deploy-alerts-targets.XXXXXX.json)
+trap 'rm -f "$TARGETS_FILE"' EXIT
+
+python3 - "$SNS_TOPIC_ARN" "$TARGETS_FILE" <<'PY'
+import json, sys
+
+sns_arn, out_path = sys.argv[1], sys.argv[2]
+template = (
+    '"[ECS deploy] <eventName>\\n\\n'
+    'Service:    <service>\\n'
+    'Deployment: <deploymentId>\\n'
+    'When:       <when>\\n\\n'
+    'Reason: <reason>"'
+)
+targets = [{
+    "Id": "sns-jyt-prod-alerts",
+    "Arn": sns_arn,
+    "InputTransformer": {
+        "InputPathsMap": {
+            "eventName": "$.detail.eventName",
+            "reason": "$.detail.reason",
+            "deploymentId": "$.detail.deploymentId",
+            "service": "$.resources[0]",
+            "when": "$.time",
+        },
+        "InputTemplate": template,
+    },
+}]
+with open(out_path, "w") as f:
+    json.dump(targets, f)
+PY
+
+aws events put-targets \
+  --rule "$RULE_NAME" \
+  --targets "file://$TARGETS_FILE" \
+  --region "$AWS_REGION" >/dev/null
+echo "    Target wired."
+echo
+
+echo "✅ Done."
+echo
+echo "Next step: $ALERT_EMAIL must confirm the SNS subscription (one-click link)."
+echo "Test by triggering a deploy: copilot svc deploy --name medusa-server --env prod"


### PR DESCRIPTION
## Summary

- **Wire ECS deploy lifecycle events → SNS → email** so `services.deployed@jaalyantra.com` gets paged on each prod deploy. Re-uses the existing `jyt-prod-alerts` topic (which already had 8 CloudWatch alarms wired but zero subscribers).
- **Fix the CI bug** that broke the first auto-deploy after PR #237 merged: GHCR_IMAGE retained the org's case (`Jaal-Yantra-Textiles`) and `outputs.version` was returning `latest` instead of the sha.

## Changes

### `deploy/aws/scripts/wire-deploy-alerts.sh` (new)

Idempotent script that:
1. Subscribes `services.deployed@jaalyantra.com` to the SNS topic.
2. Patches the SNS topic policy with `AllowEventBridgePublish` (default policy only allows same-account IAM principals; `events.amazonaws.com` is treated as a separate party).
3. Creates EventBridge rule `jyt-prod-ecs-deploy-state-change` scoped to the prod cluster's `clusterArn`.
4. Attaches the SNS target with an `InputTransformer` so the email reads as a short human summary (event name, service, deployment ID, time, reason) instead of raw JSON.

Already applied live on 2026-05-20. Subscription confirmed.

### `.github/workflows/deploy-to-aws.yml` (fix)

| Problem | Fix |
|---|---|
| `docker pull` failed: `invalid reference format: repository name (Jaal-Yantra-Textiles/v2) must be lowercase` | New `image-vars` step computes `ghcr_image` and `image_tag` lowercased; jobs pass them through outputs instead of env. |
| `steps.meta.outputs.version` returned `latest` (raw=200 > sha=100 default priority) → ECS task defs pinned to a moving tag | Added `priority=1000` to the sha tag spec; `image_tag` also now derives directly from `${{ github.sha }}` for determinism. |

## Test plan
- [x] Script applied live; `aws events list-targets-by-rule` shows the SNS target with InputTransformer
- [x] Email subscription confirmed (SubscriptionArn is a UUID, not "pending")
- [ ] Merge → next `Deploy to AWS ECS` workflow run produces `SRC=ghcr.io/jaal-yantra-textiles/v2:sha-<hash>` (was `ghcr.io/Jaal-Yantra-Textiles/v2:latest`)
- [ ] Deploy fires `SERVICE_DEPLOYMENT_IN_PROGRESS` → `SERVICE_DEPLOYMENT_COMPLETED` email to `services.deployed@jaalyantra.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)