### PR TITLE
fix(ci): unblock copilot svc deploy (missing needs + .workspace)

### DIFF
--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -176,7 +176,7 @@ jobs:
   deploy-server:
     name: Deploy medusa-server
     runs-on: ubuntu-latest
-    needs: mirror-to-ecr
+    needs: [build-and-push, mirror-to-ecr]
     steps:
       - uses: actions/checkout@v4
 
@@ -202,7 +202,7 @@ jobs:
   deploy-worker:
     name: Deploy medusa-worker
     runs-on: ubuntu-latest
-    needs: mirror-to-ecr
+    needs: [build-and-push, mirror-to-ecr]
     steps:
       - uses: actions/checkout@v4
 

--- a/deploy/aws/.gitignore
+++ b/deploy/aws/.gitignore
@@ -3,7 +3,6 @@ secrets.local.env
 secrets.*.env
 !secrets.example.env
 
-# Copilot generates a workspace marker that contains your app + account binding.
-# It's environment-specific so committing it can confuse multi-developer setups.
-# If you want it committed (most teams do), delete this line.
-copilot/.workspace
+# Copilot's workspace marker (deploy/aws/copilot/.workspace) IS committed
+# so the CI runner can resolve the application name. The file contains only
+# `application: jyt` — no secrets.

--- a/deploy/aws/copilot/.workspace
+++ b/deploy/aws/copilot/.workspace
@@ -1,0 +1,1 @@
+application: jyt


### PR DESCRIPTION
## Summary

Follow-up to PR #238. Two bugs from PR #237's original workflow surfaced when the merge-to-main run failed with:
- `--tag \"\"` (empty)
- `couldn't find an application associated with this workspace`

This PR ships the fix that didn't quite make it into #238 in time.

## Why it broke

| Bug | Root cause | Fix |
|---|---|---|
| `--tag \"\"` | `deploy-server` / `deploy-worker` only declared `needs: mirror-to-ecr`. GHA only exposes outputs of jobs in `needs:`, so `${{ needs.build-and-push.outputs.image_tag }}` resolved to `\"\"`. | Both deploy jobs now `needs: [build-and-push, mirror-to-ecr]`. |
| copilot can't find app | `deploy/aws/copilot/.workspace` was gitignored, so the runner's clone had no `application:` marker. | Force-added the file (content: `application: jyt` — not sensitive) and removed the `.gitignore` rule. The original .gitignore comment already noted most teams commit it. |

## Test plan
- [ ] On merge, the next workflow run shows `--tag sha-<long-hash>` (not empty) and `copilot svc deploy` completes for both server + worker
- [ ] `services.deployed@jaalyantra.com` receives the `[ECS deploy] SERVICE_DEPLOYMENT_*` emails from the EventBridge rule wired in #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)