### PR TITLE
fix(ci): --force copilot deploys so ECS actually rolls tasks

### DIFF
--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -195,8 +195,15 @@ jobs:
 
       - name: Deploy medusa-server
         working-directory: deploy/aws
+        # --force is required because the manifest uses `image.location` (a
+        # static ECR ref :latest), not `image.build`. With image.location,
+        # copilot ignores --tag and the CFN change set has no diff, so ECS
+        # never rolls new tasks even though a new image was just pushed to
+        # ECR :latest. --force makes ECS roll tasks, which pull :latest and
+        # pick up the freshly mirrored image. --tag is kept for parity with
+        # the worker and for any future move to image.build.
         run: |
-          copilot svc deploy --name medusa-server --env prod \
+          copilot svc deploy --name medusa-server --env prod --force \
             --tag "${{ needs.build-and-push.outputs.image_tag }}"
 
   deploy-worker:
@@ -221,8 +228,9 @@ jobs:
 
       - name: Deploy medusa-worker
         working-directory: deploy/aws
+        # See the medusa-server deploy step above for why --force is needed.
         run: |
-          copilot svc deploy --name medusa-worker --env prod \
+          copilot svc deploy --name medusa-worker --env prod --force \
             --tag "${{ needs.build-and-push.outputs.image_tag }}"
 
   # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The pipeline ran end-to-end after #239 — all jobs green — but production didn't actually update. Adding \`--force\` to both \`copilot svc deploy\` commands so ECS rolls new tasks even when CFN sees no manifest diff.

## What was happening

Run 26153585834 (the post-#239 deploy) finished in 12 seconds with this output:

\`\`\`
Note: Set --force to force an update for the service.
deploy service: change set has no changes
\`\`\`

Root cause: the manifests use \`image.location: …jyt-medusa:latest\` (a static ECR reference) rather than \`image.build\`. With \`image.location\`, copilot **ignores \`--tag\`** entirely — there's no Dockerfile context for it to tag. So:

1. We push a fresh image to ECR :latest ✅
2. \`copilot svc deploy --tag sha-XXX\` runs ✅
3. Copilot diffs the CFN stack — nothing changed in the manifest, so no new task definition is registered ❌
4. ECS keeps the old running tasks, still pulling the previously-cached image

\`--force\` is copilot's intended escape hatch (it's literally what the error message suggests): ECS rolls new tasks regardless of the CFN no-op, and those tasks pull \`:latest\` and pick up the new build.

## Why not move to image.build instead?

That's the eventual right answer — it gives immutable task definitions pinned to the commit sha. But it requires:
- Either moving the docker build into the copilot deploy step (slow, duplicates the build we already did in build-and-push), or
- Generating an addon manifest that points at the just-mirrored ECR sha tag.

For now \`--force\` keeps the deploy unblocked. The \`--tag\` arg is kept on the command line so a future switch to \`image.build\` is a one-line change.

## Test plan
- [ ] On merge, the next deploy run takes >2 min (not 12s) and ends with \`SERVICE_DEPLOYMENT_COMPLETED\`
- [ ] \`services.deployed@jaalyantra.com\` receives the \`[ECS deploy] SERVICE_DEPLOYMENT_*\` emails (subscribed in #238)
- [ ] \`describe-services\` shows an updated \`primaryDeployment.updatedAt\` (yesterday's timestamps stop bumping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)