### PR TITLE
feat(storefront): one-shot hero + LLM/vector product search

### DIFF
--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -104,6 +104,7 @@ import { createStoreSchema } from "./admin/stores/validators";
 import { UpdateInventoryOrderTask } from "./admin/inventory-orders/[id]/tasks/[taskId]/validators";
 import { TestBlogEmailSchema } from "./admin/websites/[id]/pages/[pageId]/subs/test/route";
 import { listSocialPlatformsQuerySchema, SocialPlatformSchema, UpdateSocialPlatformSchema, ConnectWhatsAppSchema } from "./admin/social-platforms/validators";
+import { StoreAiSearchSchema } from "./store/ai/search/validators";
 import { StoreGenerateAiImageReqSchema } from "./store/ai/imagegen/validators";
 import { StoreTryOnReqSchema } from "./store/ai/tryon/validators";
 import { AccessFeeConfirmSchema } from "./store/ai/accessfee/validators";
@@ -3086,6 +3087,15 @@ export default defineMiddlewares({
     },
 
     // Store AI endpoints
+    {
+      matcher: "/store/ai/search",
+      method: "POST",
+      // Public — no customer auth. Discovery should work for anonymous
+      // visitors. Body validation only.
+      middlewares: [
+        validateAndTransformBody(wrapSchema(StoreAiSearchSchema)),
+      ],
+    },
     {
       matcher: "/store/ai/imagegen",
       method: "POST",

--- a/apps/backend/src/api/store/ai/search/extract.ts
+++ b/apps/backend/src/api/store/ai/search/extract.ts
@@ -1,23 +1,34 @@
-import { createOpenRouter } from "@openrouter/ai-sdk-provider"
+/**
+ * LLM extraction layer for /store/ai/search.
+ *
+ * Tries provider chain in this order, returning the first that succeeds:
+ *
+ *   1. OpenRouter (free models only). Uses the existing
+ *      mastra/providers/dynamic-text-model resolver, which auto-selects
+ *      the best currently-available free model from the live OpenRouter
+ *      catalogue and evicts models whose free tier has ended.
+ *
+ *   2. DashScope (Qwen) via its OpenAI-compatible endpoint. Used when
+ *      DASHSCOPE_API_KEY is set — the user has credits there so this is
+ *      a reliable paid fallback. Default model qwen-turbo (cheap, fast,
+ *      tool-use capable); override with STOREFRONT_SEARCH_DASHSCOPE_MODEL.
+ *
+ *   3. Cloudflare Workers AI via its OpenAI-compatible endpoint at
+ *      api.cloudflare.com/client/v4/accounts/<id>/ai/v1. Used when both
+ *      CLOUDFLARE_AI_ACCOUNT_ID and CLOUDFLARE_AI_TOKEN are set. Default
+ *      model @cf/meta/llama-3.1-8b-instruct (also tool-use capable);
+ *      override with STOREFRONT_SEARCH_CLOUDFLARE_MODEL.
+ *
+ * If all three fail (no providers configured, all rate-limited, schema
+ * mismatch from a particular model, etc.) we fall back to treating the
+ * raw query as a single keyword so search still works — just without
+ * the LLM enrichment.
+ */
+import { createOpenAI } from "@ai-sdk/openai"
 import { generateObject } from "ai"
 import { z } from "zod"
+import { dynamicFreeTextModel } from "../../../../mastra/providers/dynamic-text-model"
 
-/**
- * Schema the LLM is asked to produce. Keep this small and concrete —
- * every field is something we know how to map onto a Medusa product
- * query (q-search, price range, category match, tag match). Adding
- * fields here without wiring them through to the query downstream
- * silently inflates token cost for no benefit.
- *
- * `keywords` is the most important field: a short list of nouns/
- * adjectives extracted from the query that we then OR-join into the
- * Medusa `q` parameter. Models are asked to NOT include filler words
- * (find, show, want, looking, for, the, etc.) so the q-search stays
- * focused on substantive terms.
- *
- * Price fields are optional — we only set them when the LLM finds a
- * "under X" / "below X" / "between X and Y" pattern.
- */
 const SearchInterpretationSchema = z.object({
   keywords: z
     .array(z.string().min(1).max(40))
@@ -63,41 +74,118 @@ Rules:
 - If a price ceiling or floor is mentioned, extract it as an integer in major currency units. Ignore the currency symbol — just the number.
 - Never fabricate fields. If something isn't in the query, omit it.`
 
-let _model: ReturnType<ReturnType<typeof createOpenRouter>["chat"]> | null = null
+// ── Provider builders (lazy) ───────────────────────────────────────────
 
-const getModel = () => {
-  if (_model) return _model
-  const openrouter = createOpenRouter({
-    apiKey: process.env.OPENROUTER_API_KEY,
+let _dashscope: ReturnType<typeof createOpenAI> | null = null
+const getDashscope = () => {
+  if (_dashscope) return _dashscope
+  const apiKey = process.env.DASHSCOPE_API_KEY
+  if (!apiKey) return null
+  _dashscope = createOpenAI({
+    baseURL: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+    apiKey,
   })
-  // Cheap, fast, free-tier — sufficient for a structured one-shot
-  // extraction. Override via env if you want a different model.
-  const id = process.env.STOREFRONT_SEARCH_MODEL || "google/gemini-2.5-flash"
-  _model = openrouter.chat(id)
-  return _model
+  return _dashscope
+}
+
+let _cloudflare: ReturnType<typeof createOpenAI> | null = null
+const getCloudflare = () => {
+  if (_cloudflare) return _cloudflare
+  const accountId = process.env.CLOUDFLARE_AI_ACCOUNT_ID
+  const token = process.env.CLOUDFLARE_AI_TOKEN
+  if (!accountId || !token) return null
+  _cloudflare = createOpenAI({
+    baseURL: `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/v1`,
+    apiKey: token,
+  })
+  return _cloudflare
+}
+
+// ── Provider chain ─────────────────────────────────────────────────────
+
+type Attempt = { name: string; call: () => Promise<SearchInterpretation> }
+
+const buildAttempts = (query: string): Attempt[] => {
+  const opts = {
+    schema: SearchInterpretationSchema,
+    system: SYSTEM_PROMPT,
+    prompt: query,
+    temperature: 0.1,
+  }
+  const attempts: Attempt[] = []
+
+  // 1. OpenRouter free models (via existing dynamic rotator)
+  if (process.env.OPENROUTER_API_KEY) {
+    attempts.push({
+      name: "openrouter:free",
+      call: async () => {
+        const { object } = await generateObject({
+          ...opts,
+          model: dynamicFreeTextModel,
+        })
+        return object
+      },
+    })
+  }
+
+  // 2. DashScope (Qwen)
+  const dashscope = getDashscope()
+  if (dashscope) {
+    const modelId =
+      process.env.STOREFRONT_SEARCH_DASHSCOPE_MODEL || "qwen-turbo"
+    attempts.push({
+      name: `dashscope:${modelId}`,
+      call: async () => {
+        const { object } = await generateObject({
+          ...opts,
+          model: dashscope(modelId),
+        })
+        return object
+      },
+    })
+  }
+
+  // 3. Cloudflare Workers AI
+  const cloudflare = getCloudflare()
+  if (cloudflare) {
+    const modelId =
+      process.env.STOREFRONT_SEARCH_CLOUDFLARE_MODEL ||
+      "@cf/meta/llama-3.1-8b-instruct"
+    attempts.push({
+      name: `cloudflare:${modelId}`,
+      call: async () => {
+        const { object } = await generateObject({
+          ...opts,
+          model: cloudflare(modelId),
+        })
+        return object
+      },
+    })
+  }
+
+  return attempts
 }
 
 /**
  * Convert a natural-language shopper query into a small structured
- * interpretation we can map onto a Medusa product query. Fails closed:
- * if the LLM call errors out, returns a minimal interpretation that
- * treats the raw query as a single keyword, so search degrades to a
- * normal text match rather than crashing.
+ * interpretation. Walks the provider chain in order, returning the
+ * first successful result. If every provider fails (or none are
+ * configured), falls back to treating the raw query as a single
+ * keyword so /store/ai/search degrades gracefully to lexical search.
  */
 export const extractSearchInterpretation = async (
   query: string
 ): Promise<SearchInterpretation> => {
-  try {
-    const { object } = await generateObject({
-      model: getModel(),
-      schema: SearchInterpretationSchema,
-      system: SYSTEM_PROMPT,
-      prompt: query,
-      // Low temperature: this is extraction, not creative writing.
-      temperature: 0.1,
-    })
-    return object
-  } catch {
-    return { keywords: [query] }
+  const attempts = buildAttempts(query)
+  for (const attempt of attempts) {
+    try {
+      return await attempt.call()
+    } catch (e: any) {
+      console.warn(
+        `[store/ai/search] ${attempt.name} failed:`,
+        e?.message ?? e
+      )
+    }
   }
+  return { keywords: [query] }
 }

--- a/apps/backend/src/api/store/ai/search/extract.ts
+++ b/apps/backend/src/api/store/ai/search/extract.ts
@@ -1,0 +1,103 @@
+import { createOpenRouter } from "@openrouter/ai-sdk-provider"
+import { generateObject } from "ai"
+import { z } from "zod"
+
+/**
+ * Schema the LLM is asked to produce. Keep this small and concrete —
+ * every field is something we know how to map onto a Medusa product
+ * query (q-search, price range, category match, tag match). Adding
+ * fields here without wiring them through to the query downstream
+ * silently inflates token cost for no benefit.
+ *
+ * `keywords` is the most important field: a short list of nouns/
+ * adjectives extracted from the query that we then OR-join into the
+ * Medusa `q` parameter. Models are asked to NOT include filler words
+ * (find, show, want, looking, for, the, etc.) so the q-search stays
+ * focused on substantive terms.
+ *
+ * Price fields are optional — we only set them when the LLM finds a
+ * "under X" / "below X" / "between X and Y" pattern.
+ */
+const SearchInterpretationSchema = z.object({
+  keywords: z
+    .array(z.string().min(1).max(40))
+    .min(1)
+    .max(8)
+    .describe(
+      "1-8 substantive search terms extracted from the query, excluding filler words"
+    ),
+  color: z
+    .string()
+    .min(1)
+    .max(30)
+    .optional()
+    .describe("Color if mentioned, single word"),
+  material: z
+    .string()
+    .min(1)
+    .max(30)
+    .optional()
+    .describe("Fabric / material if mentioned (cotton, silk, linen, etc.)"),
+  min_price: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe("Minimum price floor in major currency units"),
+  max_price: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .describe("Maximum price ceiling in major currency units"),
+})
+
+export type SearchInterpretation = z.infer<typeof SearchInterpretationSchema>
+
+const SYSTEM_PROMPT = `You convert a shopper's natural-language search for fashion / textile products into a small structured interpretation.
+
+Rules:
+- Extract 1-8 substantive keywords. Exclude filler verbs (find, show, want, looking, for, get, give, need), articles (the, a, an, some), and the word "product" itself.
+- If a color is mentioned, return it as a single word.
+- If a fabric or material is mentioned, return it as a single word (cotton, silk, linen, wool, etc.).
+- If a price ceiling or floor is mentioned, extract it as an integer in major currency units. Ignore the currency symbol — just the number.
+- Never fabricate fields. If something isn't in the query, omit it.`
+
+let _model: ReturnType<ReturnType<typeof createOpenRouter>["chat"]> | null = null
+
+const getModel = () => {
+  if (_model) return _model
+  const openrouter = createOpenRouter({
+    apiKey: process.env.OPENROUTER_API_KEY,
+  })
+  // Cheap, fast, free-tier — sufficient for a structured one-shot
+  // extraction. Override via env if you want a different model.
+  const id = process.env.STOREFRONT_SEARCH_MODEL || "google/gemini-2.5-flash"
+  _model = openrouter.chat(id)
+  return _model
+}
+
+/**
+ * Convert a natural-language shopper query into a small structured
+ * interpretation we can map onto a Medusa product query. Fails closed:
+ * if the LLM call errors out, returns a minimal interpretation that
+ * treats the raw query as a single keyword, so search degrades to a
+ * normal text match rather than crashing.
+ */
+export const extractSearchInterpretation = async (
+  query: string
+): Promise<SearchInterpretation> => {
+  try {
+    const { object } = await generateObject({
+      model: getModel(),
+      schema: SearchInterpretationSchema,
+      system: SYSTEM_PROMPT,
+      prompt: query,
+      // Low temperature: this is extraction, not creative writing.
+      temperature: 0.1,
+    })
+    return object
+  } catch {
+    return { keywords: [query] }
+  }
+}

--- a/apps/backend/src/api/store/ai/search/route.ts
+++ b/apps/backend/src/api/store/ai/search/route.ts
@@ -24,6 +24,7 @@ import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { searchProducts } from "../../../../mastra/rag/productCatalog"
 import { extractSearchInterpretation } from "./extract"
+import { attachStorefrontAttribution } from "./storefront-attribution"
 import type { StoreAiSearchReq } from "./validators"
 
 const PRODUCT_FIELDS = [
@@ -38,6 +39,12 @@ const PRODUCT_FIELDS = [
   "variants.title",
   "variants.calculated_price.calculated_amount",
   "variants.calculated_price.currency_code",
+  // Pull sales_channels so attachStorefrontAttribution can decide
+  // whether each hit belongs to the main JYT storefront or a partner's
+  // — partner products link out to their own domain, main products
+  // link locally so country-code prefixing works as usual.
+  "sales_channels.id",
+  "sales_channels.name",
 ]
 
 const buildEnrichedQuery = (
@@ -132,11 +139,21 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     )
     .slice(0, limit)
 
+  // 5. Attribute each hit to a storefront (main vs partner) so the UI
+  // can render the right link target. Partner-owned products link out
+  // to the partner's domain instead of the local /products/<handle>
+  // — clicking them locally would 404 because they aren't published
+  // through the main sales channel.
+  const attributed = await attachStorefrontAttribution(
+    filtered as any,
+    req.scope as any
+  )
+
   res.json({
     query,
     mode,
     interpretation,
-    products: filtered,
-    count: filtered.length,
+    products: attributed,
+    count: attributed.length,
   })
 }

--- a/apps/backend/src/api/store/ai/search/route.ts
+++ b/apps/backend/src/api/store/ai/search/route.ts
@@ -1,0 +1,142 @@
+/**
+ * POST /store/ai/search
+ *
+ * Natural-language product search. Two-stage pipeline:
+ *
+ *   1. LLM extracts a small structured interpretation from the query
+ *      (keywords + optional color/material/price range).
+ *   2. We run a semantic vector search against the product_search_v1
+ *      PgVector index using the enriched query text, then post-filter by
+ *      the structured constraints (price) that aren't part of the
+ *      embedding signal.
+ *   3. Finally we hydrate the hits back through Medusa's product query
+ *      so the caller gets a payload shaped like /store/products
+ *      (id, handle, title, thumbnail, variants[].calculated_price).
+ *
+ * Public (no customer auth). Rate limiting + caching are TODOs.
+ *
+ * If the vector index is empty (no backfill yet) or PgVector is
+ * unreachable, the route falls back to a plain Medusa q-search using
+ * the LLM-extracted keywords so the storefront keeps working while the
+ * index is being built.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { searchProducts } from "../../../../mastra/rag/productCatalog"
+import { extractSearchInterpretation } from "./extract"
+import type { StoreAiSearchReq } from "./validators"
+
+const PRODUCT_FIELDS = [
+  "id",
+  "handle",
+  "title",
+  "subtitle",
+  "description",
+  "thumbnail",
+  "status",
+  "variants.id",
+  "variants.title",
+  "variants.calculated_price.calculated_amount",
+  "variants.calculated_price.currency_code",
+]
+
+const buildEnrichedQuery = (
+  raw: string,
+  interpretation: Awaited<ReturnType<typeof extractSearchInterpretation>>
+): string => {
+  // Concatenate the structured fields onto the raw query so the
+  // embedding has both phrasing AND distilled keywords to anchor on.
+  const extras: string[] = []
+  if (interpretation.color) extras.push(interpretation.color)
+  if (interpretation.material) extras.push(interpretation.material)
+  for (const k of interpretation.keywords) {
+    if (!extras.some((x) => x.toLowerCase() === k.toLowerCase())) {
+      extras.push(k)
+    }
+  }
+  return extras.length ? `${raw}. Keywords: ${extras.join(", ")}` : raw
+}
+
+const applyPriceFilter = (
+  product: any,
+  min?: number,
+  max?: number
+): boolean => {
+  if (min === undefined && max === undefined) return true
+  const amounts = ((product?.variants ?? []) as any[])
+    .map((v) => v?.calculated_price?.calculated_amount)
+    .filter((n): n is number => typeof n === "number")
+  if (!amounts.length) return true
+  const low = Math.min(...amounts)
+  const high = Math.max(...amounts)
+  if (max !== undefined && low > max) return false
+  if (min !== undefined && high < min) return false
+  return true
+}
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { query, limit } = (req as any).validatedBody as StoreAiSearchReq
+  const queryService = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  // 1. Interpret the query.
+  const interpretation = await extractSearchInterpretation(query)
+
+  // 2. Try vector search first.
+  const enriched = buildEnrichedQuery(query, interpretation)
+  let productIds: string[] = []
+  let mode: "vector" | "lexical" = "vector"
+  try {
+    const hits = await searchProducts(enriched, Math.max(limit * 3, 24))
+    productIds = hits.map((h) => h.product_id).filter(Boolean)
+  } catch {
+    productIds = []
+  }
+
+  let products: any[] = []
+  if (productIds.length) {
+    const { data } = await queryService.graph({
+      entity: "product",
+      fields: PRODUCT_FIELDS,
+      filters: { id: productIds, status: "published" } as any,
+    })
+    // Preserve vector-search rank — graph results don't guarantee
+    // ordering by the id list.
+    const byId = new Map((data ?? []).map((p: any) => [p.id, p]))
+    products = productIds.map((id) => byId.get(id)).filter(Boolean)
+  }
+
+  // 3. Lexical fallback if vector search returned nothing (e.g. index
+  // not backfilled yet, or query truly has no matches).
+  if (!products.length) {
+    mode = "lexical"
+    const terms: string[] = []
+    if (interpretation.color) terms.push(interpretation.color)
+    if (interpretation.material) terms.push(interpretation.material)
+    for (const k of interpretation.keywords) {
+      if (!terms.includes(k.toLowerCase())) terms.push(k)
+    }
+    const q = terms.join(" ") || query
+    const { data } = await queryService.graph({
+      entity: "product",
+      fields: PRODUCT_FIELDS,
+      filters: { status: "published", q } as any,
+      pagination: { take: Math.max(limit * 3, 24), skip: 0 },
+    })
+    products = data ?? []
+  }
+
+  // 4. Apply price post-filter and cap at the requested limit.
+  const filtered = products
+    .filter((p) =>
+      applyPriceFilter(p, interpretation.min_price, interpretation.max_price)
+    )
+    .slice(0, limit)
+
+  res.json({
+    query,
+    mode,
+    interpretation,
+    products: filtered,
+    count: filtered.length,
+  })
+}

--- a/apps/backend/src/api/store/ai/search/storefront-attribution.ts
+++ b/apps/backend/src/api/store/ai/search/storefront-attribution.ts
@@ -1,0 +1,156 @@
+/**
+ * Storefront attribution for product search hits.
+ *
+ * The product catalogue contains items from both the main JYT/Cici Label
+ * storefront AND partner storefronts (each partner has their own
+ * sales channel + Vercel deployment). The same vector index serves both,
+ * so a search hit could be a product whose canonical storefront isn't
+ * the one the user is currently browsing — clicking it would 404.
+ *
+ * This helper tags each hit with whether the canonical storefront is
+ * "main" (link locally via LocalizedClientLink) or "partner" (link out
+ * to the partner's domain) so the UI can render the right destination
+ * and a visible badge.
+ *
+ * Attribution logic:
+ *   - If any of the product's sales channels is NOT mapped to a
+ *     partner's default sales channel → kind = "main". The current
+ *     storefront can resolve the URL.
+ *   - If every sales channel is partner-owned → kind = "partner", with
+ *     the first matching partner's name + domain attached.
+ *
+ * The partner → sales-channel map is cached in-process for 30s. The
+ * mapping doesn't change often (creating/dissolving a partner storefront
+ * is rare) and a stale read here is harmless — at worst we briefly
+ * misclassify a product, which the next refresh corrects.
+ */
+import type { MedusaContainer } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+export type StorefrontAttribution =
+  | { kind: "main" }
+  | {
+      kind: "partner"
+      url?: string
+      partner_name: string
+      partner_handle: string
+      sales_channel_name?: string
+    }
+
+type PartnerInfo = {
+  name: string
+  handle: string
+  storefront_domain: string | null
+}
+
+let partnerScCache: Map<string, PartnerInfo> = new Map()
+let partnerScCacheTs = 0
+const CACHE_TTL_MS = 30_000
+
+const buildPartnerSalesChannelMap = async (
+  container: MedusaContainer
+): Promise<Map<string, PartnerInfo>> => {
+  const now = Date.now()
+  if (partnerScCache.size > 0 && now - partnerScCacheTs < CACHE_TTL_MS) {
+    return partnerScCache
+  }
+  const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+  const map = new Map<string, PartnerInfo>()
+  try {
+    const { data } = await query.graph({
+      entity: "partners",
+      fields: [
+        "id",
+        "name",
+        "handle",
+        "storefront_domain",
+        "metadata",
+        "stores.id",
+        "stores.default_sales_channel_id",
+      ],
+    })
+    for (const p of (data ?? []) as any[]) {
+      const domain =
+        p.storefront_domain ?? p.metadata?.storefront_domain ?? null
+      for (const s of (p.stores ?? []) as any[]) {
+        const scId = s?.default_sales_channel_id
+        if (!scId) continue
+        map.set(scId, {
+          name: p.name ?? "Partner",
+          handle: p.handle ?? "",
+          storefront_domain: domain,
+        })
+      }
+    }
+  } catch (e) {
+    // If the lookup fails, downstream callers see an empty map and
+    // every product gets kind: "main" — safer than crashing the search.
+    console.warn(
+      "[storefront-attribution] partner map refresh failed:",
+      (e as any)?.message ?? e
+    )
+  }
+  partnerScCache = map
+  partnerScCacheTs = now
+  return map
+}
+
+const buildPartnerUrl = (
+  domain: string | null,
+  productHandle: string
+): string | undefined => {
+  if (!domain || !productHandle) return undefined
+  const stripped = String(domain).replace(/^https?:\/\//, "").replace(/\/+$/, "")
+  if (!stripped) return undefined
+  // Partner storefronts use the same Next.js template, so /products/<handle>
+  // resolves. No country code in the URL — partner storefronts are
+  // single-locale today.
+  return `https://${stripped}/products/${encodeURIComponent(productHandle)}`
+}
+
+type ProductWithChannels = {
+  id: string
+  handle: string
+  sales_channels?: Array<{ id: string; name?: string }> | null
+}
+
+export const attachStorefrontAttribution = async <
+  P extends ProductWithChannels
+>(
+  products: P[],
+  container: MedusaContainer
+): Promise<Array<P & { storefront: StorefrontAttribution }>> => {
+  if (!products.length) return [] as any
+  const partnerMap = await buildPartnerSalesChannelMap(container)
+
+  return products.map((p) => {
+    const channels = p.sales_channels ?? []
+    let firstPartner:
+      | { partner: PartnerInfo; sc: { id: string; name?: string } }
+      | null = null
+    let hasMain = false
+    for (const sc of channels) {
+      const partner = partnerMap.get(sc.id)
+      if (partner) {
+        if (!firstPartner) firstPartner = { partner, sc }
+      } else {
+        hasMain = true
+      }
+    }
+
+    if (hasMain || !firstPartner) {
+      return { ...p, storefront: { kind: "main" as const } }
+    }
+    const { partner, sc } = firstPartner
+    return {
+      ...p,
+      storefront: {
+        kind: "partner" as const,
+        url: buildPartnerUrl(partner.storefront_domain, p.handle),
+        partner_name: partner.name,
+        partner_handle: partner.handle,
+        sales_channel_name: sc.name,
+      },
+    }
+  })
+}

--- a/apps/backend/src/api/store/ai/search/validators.ts
+++ b/apps/backend/src/api/store/ai/search/validators.ts
@@ -1,0 +1,18 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * Request schema for POST /store/ai/search.
+ *
+ * `query` is the customer's natural-language search phrase (e.g.
+ * "soft cotton dress under 2000 rupees"). Capped at 200 chars to keep
+ * LLM token cost predictable.
+ *
+ * `limit` is how many products to return after filtering. 6 is a good
+ * default for an inline dropdown; up to 24 for a full results page.
+ */
+export const StoreAiSearchSchema = z.object({
+  query: z.string().trim().min(2).max(200),
+  limit: z.coerce.number().int().min(1).max(24).optional().default(6),
+})
+
+export type StoreAiSearchReq = z.infer<typeof StoreAiSearchSchema>

--- a/apps/backend/src/mastra/rag/productCatalog.ts
+++ b/apps/backend/src/mastra/rag/productCatalog.ts
@@ -11,9 +11,11 @@
  * (which indexes products) can evolve independently.
  *
  * Embedding provider selection (env: PRODUCT_SEARCH_EMBED_PROVIDER):
- *   • hf_local   — Xenova/all-MiniLM-L6-v2, 384 dims, runs in-process (default)
- *   • google     — text-embedding-004, 768 dims, needs GOOGLE_GENERATIVE_AI_API_KEY
- *   • dashscope  — text-embedding-v3, 1024 dims, needs DASHSCOPE_API_KEY (user has credits)
+ *   • hf_local    — Xenova/all-MiniLM-L6-v2, 384 dims, runs in-process (default)
+ *   • google      — text-embedding-004, 768 dims, needs GOOGLE_GENERATIVE_AI_API_KEY
+ *   • dashscope   — text-embedding-v3, 1024 dims, needs DASHSCOPE_API_KEY
+ *   • cloudflare  — @cf/baai/bge-base-en-v1.5, 768 dims, needs
+ *                   CLOUDFLARE_AI_ACCOUNT_ID + CLOUDFLARE_AI_TOKEN
  *
  * IMPORTANT: switching providers changes the vector dimension, which is
  * incompatible with the existing PgVector index. Changing provider means:
@@ -33,10 +35,11 @@ const INDEX_NAME = "product_search_v1"
 const HF_DEFAULT_MODEL = "Xenova/all-MiniLM-L6-v2"
 const GOOGLE_EMBEDDING_MODEL = "text-embedding-004"
 const DASHSCOPE_EMBEDDING_MODEL = "text-embedding-v3"
+const CLOUDFLARE_EMBEDDING_MODEL = "@cf/baai/bge-base-en-v1.5"
 
 // ── Embedding provider ─────────────────────────────────────────────────
 
-type EmbeddingProvider = "google" | "hf_local" | "dashscope"
+type EmbeddingProvider = "google" | "hf_local" | "dashscope" | "cloudflare"
 
 const getEmbeddingProvider = (): EmbeddingProvider => {
   // Storefront search has its own env so it can be tuned independently
@@ -51,6 +54,7 @@ const getEmbeddingProvider = (): EmbeddingProvider => {
     .toLowerCase()
   if (p === "google") return "google"
   if (p === "dashscope" || p === "qwen") return "dashscope"
+  if (p === "cloudflare" || p === "cf") return "cloudflare"
   return "hf_local"
 }
 
@@ -85,6 +89,23 @@ const getDashscopeClient = () => {
   return _dashscopeClient
 }
 
+let _cloudflareClient: ReturnType<typeof createOpenAI> | null = null
+const getCloudflareClient = () => {
+  if (_cloudflareClient) return _cloudflareClient
+  const accountId = process.env.CLOUDFLARE_AI_ACCOUNT_ID
+  const token = process.env.CLOUDFLARE_AI_TOKEN
+  if (!accountId || !token) {
+    throw new Error(
+      "PRODUCT_SEARCH_EMBED_PROVIDER=cloudflare but CLOUDFLARE_AI_ACCOUNT_ID / CLOUDFLARE_AI_TOKEN are not set"
+    )
+  }
+  _cloudflareClient = createOpenAI({
+    baseURL: `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/v1`,
+    apiKey: token,
+  })
+  return _cloudflareClient
+}
+
 export const embedTexts = async (values: string[]): Promise<number[][]> => {
   if (!values.length) return []
   const provider = getEmbeddingProvider()
@@ -101,6 +122,16 @@ export const embedTexts = async (values: string[]): Promise<number[][]> => {
       process.env.PRODUCT_SEARCH_DASHSCOPE_MODEL || DASHSCOPE_EMBEDDING_MODEL
     const { embeddings } = await embedMany({
       model: ds.embedding(modelId),
+      values,
+    })
+    return embeddings as number[][]
+  }
+  if (provider === "cloudflare") {
+    const cf = getCloudflareClient()
+    const modelId =
+      process.env.PRODUCT_SEARCH_CLOUDFLARE_MODEL || CLOUDFLARE_EMBEDDING_MODEL
+    const { embeddings } = await embedMany({
+      model: cf.embedding(modelId),
       values,
     })
     return embeddings as number[][]

--- a/apps/backend/src/mastra/rag/productCatalog.ts
+++ b/apps/backend/src/mastra/rag/productCatalog.ts
@@ -1,0 +1,319 @@
+// @ts-nocheck
+/**
+ * Product semantic-search index.
+ *
+ * One row per published product, embedded title + subtitle + description +
+ * tags + categories + select metadata, stored in PgVector under the
+ * `product_search_v1` index. Drives /store/ai/search.
+ *
+ * Mirrors the structure of mastra/rag/adminCatalog.ts but kept separate so
+ * the admin RAG (which indexes API endpoints) and the storefront search
+ * (which indexes products) can evolve independently.
+ *
+ * Embedding provider falls back through:
+ *   1. HF local (Xenova/all-MiniLM-L6-v2, 384 dims) — free, runs in-process
+ *   2. Google text-embedding-004 — when GOOGLE_GENERATIVE_AI_API_KEY set
+ *      and ADMIN_RAG_EMBED_PROVIDER=google
+ * HF local is the default — no API key requirement, predictable cost.
+ */
+import { PgVector } from "@mastra/pg"
+import { embedMany } from "ai"
+import { google } from "@ai-sdk/google"
+import crypto from "crypto"
+
+const INDEX_NAME = "product_search_v1"
+const HF_DEFAULT_MODEL = "Xenova/all-MiniLM-L6-v2"
+const GOOGLE_EMBEDDING_MODEL = "text-embedding-004"
+
+// ── Embedding provider ─────────────────────────────────────────────────
+
+type EmbeddingProvider = "google" | "hf_local"
+
+const getEmbeddingProvider = (): EmbeddingProvider => {
+  const p = String(process.env.ADMIN_RAG_EMBED_PROVIDER || "hf_local")
+    .trim()
+    .toLowerCase()
+  if (p === "google") return "google"
+  return "hf_local"
+}
+
+let hfExtractorPromise: Promise<any> | null = null
+const getHfExtractor = async () => {
+  if (hfExtractorPromise) return hfExtractorPromise
+  hfExtractorPromise = (async () => {
+    const { pipeline } = await import("@xenova/transformers")
+    const model = String(
+      process.env.PRODUCT_SEARCH_HF_MODEL ||
+        process.env.ADMIN_RAG_HF_MODEL ||
+        HF_DEFAULT_MODEL
+    )
+    return pipeline("feature-extraction", model, { quantized: true })
+  })()
+  return hfExtractorPromise
+}
+
+export const embedTexts = async (values: string[]): Promise<number[][]> => {
+  if (!values.length) return []
+  const provider = getEmbeddingProvider()
+  if (provider === "hf_local") {
+    const extractor = await getHfExtractor()
+    const out = await extractor(values, { pooling: "mean", normalize: true })
+    const list =
+      out && typeof out.tolist === "function" ? out.tolist() : out
+    return Array.isArray(list[0]) ? (list as number[][]) : [list as number[]]
+  }
+  // Google path. We rely on the AI SDK's embedMany so the wire format
+  // shake-out is handled for us.
+  const { embeddings } = await embedMany({
+    model: google.embedding(GOOGLE_EMBEDDING_MODEL),
+    values,
+  })
+  return embeddings as number[][]
+}
+
+// ── Vector store ───────────────────────────────────────────────────────
+
+let _store: PgVector | null = null
+const getStore = (): PgVector => {
+  if (_store) return _store
+  const conn =
+    process.env.POSTGRES_CONNECTION_STRING || process.env.DATABASE_URL
+  if (!conn) throw new Error("DATABASE_URL not set — required for PgVector")
+  _store = new PgVector({ connectionString: conn })
+  return _store
+}
+
+const ensureIndex = async (dim: number): Promise<void> => {
+  const store = getStore()
+  try {
+    const existing = await store.listIndexes?.()
+    if (Array.isArray(existing) && existing.includes(INDEX_NAME)) return
+  } catch {
+    // listIndexes may not be supported — fall through and try to create.
+  }
+  try {
+    await store.createIndex?.({
+      indexName: INDEX_NAME,
+      dimension: dim,
+      metric: "cosine",
+    })
+  } catch {
+    // Positional signature fallback (older mastra/pg).
+    try {
+      await store.createIndex?.(INDEX_NAME, dim, "cosine")
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+// ── Source-text builder ────────────────────────────────────────────────
+
+/**
+ * Concatenated text used as the embedding source. Order matters slightly
+ * — title first, then merchandising-relevant fields, then tags/categories
+ * — because some embedders weight earlier tokens.
+ *
+ * Sanitization: collapse whitespace, strip HTML-y angle brackets, cap at
+ * ~2000 chars so the embedder doesn't truncate weird mid-sentence.
+ */
+type ProductLike = {
+  id: string
+  handle?: string | null
+  title?: string | null
+  subtitle?: string | null
+  description?: string | null
+  material?: string | null
+  tags?: Array<{ value?: string | null }> | null
+  categories?: Array<{ name?: string | null }> | null
+  collection?: { title?: string | null } | null
+  type?: { value?: string | null } | null
+}
+
+export const buildIndexedText = (product: ProductLike): string => {
+  const parts: string[] = []
+  const push = (v: string | null | undefined) => {
+    if (!v) return
+    const cleaned = String(v).replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim()
+    if (cleaned) parts.push(cleaned)
+  }
+  push(product.title)
+  push(product.subtitle)
+  push(product.collection?.title)
+  push(product.type?.value)
+  push(product.material)
+  for (const c of product.categories ?? []) push(c?.name)
+  for (const t of product.tags ?? []) push(t?.value)
+  push(product.description)
+  const joined = parts.join(". ").slice(0, 2000)
+  return joined
+}
+
+export const hashText = (text: string): string =>
+  crypto.createHash("sha256").update(text).digest("hex").slice(0, 16)
+
+// ── Upsert ─────────────────────────────────────────────────────────────
+
+export type IndexableProduct = ProductLike
+
+export type UpsertResult = {
+  upserted: number
+  skipped: number
+  errors: number
+}
+
+/**
+ * Embed and upsert a batch of products. Idempotent: products whose
+ * `indexed_text` hash matches the value already stored in the vector
+ * metadata are skipped — re-running the backfill or the subscriber on
+ * unchanged products costs almost nothing.
+ *
+ * Skip detection requires reading existing metadata, which PgVector
+ * doesn't expose directly. We fetch a probe vector by id; if it comes
+ * back with the same text_hash, we skip the re-embed.
+ */
+export const upsertProducts = async (
+  products: IndexableProduct[]
+): Promise<UpsertResult> => {
+  const result: UpsertResult = { upserted: 0, skipped: 0, errors: 0 }
+  if (!products.length) return result
+
+  const candidates = products.map((p) => {
+    const text = buildIndexedText(p)
+    return {
+      id: `product:${p.id}`,
+      product_id: p.id,
+      handle: p.handle ?? null,
+      title: p.title ?? null,
+      thumbnail: (p as any).thumbnail ?? null,
+      text,
+      text_hash: hashText(text),
+    }
+  })
+
+  // Probe existing metadata so we can skip unchanged products.
+  const store = getStore()
+  const idsToCheck = candidates.map((c) => c.id)
+  let existing: Record<string, string> = {}
+  try {
+    const probe = await (store as any).query?.({
+      indexName: INDEX_NAME,
+      queryVector: new Array(384).fill(0),
+      topK: candidates.length,
+      filter: { id: { $in: idsToCheck } },
+    })
+    for (const row of probe ?? []) {
+      const id = row?.id ?? row?.metadata?.id
+      const h = row?.metadata?.text_hash
+      if (typeof id === "string" && typeof h === "string") existing[id] = h
+    }
+  } catch {
+    // No probe possible — every candidate gets re-embedded. Slower but safe.
+  }
+
+  const toEmbed = candidates.filter((c) => existing[c.id] !== c.text_hash)
+  result.skipped = candidates.length - toEmbed.length
+  if (!toEmbed.length) return result
+
+  // Batch embed in chunks of 64 to keep memory + per-call latency reasonable.
+  const BATCH = 64
+  const vectors: number[][] = []
+  for (let i = 0; i < toEmbed.length; i += BATCH) {
+    const slice = toEmbed.slice(i, i + BATCH)
+    try {
+      const embeddings = await embedTexts(slice.map((c) => c.text))
+      vectors.push(...embeddings)
+    } catch (e) {
+      console.warn("[productCatalog] embed batch failed", (e as any)?.message)
+      result.errors += slice.length
+      // Push placeholder vectors so indices stay aligned, then filter.
+      for (let j = 0; j < slice.length; j++) vectors.push([])
+    }
+  }
+
+  const aligned = toEmbed
+    .map((c, i) => ({ candidate: c, vector: vectors[i] }))
+    .filter((x) => Array.isArray(x.vector) && x.vector.length > 0)
+
+  if (!aligned.length) return result
+
+  await ensureIndex(aligned[0]!.vector.length)
+
+  try {
+    await store.upsert({
+      indexName: INDEX_NAME,
+      vectors: aligned.map((x) => x.vector),
+      ids: aligned.map((x) => x.candidate.id),
+      metadata: aligned.map((x) => ({
+        product_id: x.candidate.product_id,
+        handle: x.candidate.handle,
+        title: x.candidate.title,
+        thumbnail: x.candidate.thumbnail,
+        text_hash: x.candidate.text_hash,
+        indexed_at: new Date().toISOString(),
+      })),
+    })
+    result.upserted = aligned.length
+  } catch (e) {
+    console.warn("[productCatalog] upsert failed", (e as any)?.message)
+    result.errors += aligned.length
+  }
+
+  return result
+}
+
+// ── Search ─────────────────────────────────────────────────────────────
+
+export type ProductSearchHit = {
+  product_id: string
+  handle: string | null
+  title: string | null
+  thumbnail: string | null
+  score: number
+}
+
+/**
+ * Vector-only similarity search. Returns top-K hits by cosine
+ * similarity, leaving any post-filtering (e.g. price ranges that the
+ * caller knows about) to the caller.
+ */
+export const searchProducts = async (
+  query: string,
+  topK = 12
+): Promise<ProductSearchHit[]> => {
+  if (!query.trim()) return []
+  let queryVector: number[] = []
+  try {
+    const [v] = await embedTexts([query])
+    queryVector = Array.isArray(v) ? v : []
+  } catch (e) {
+    console.warn("[productCatalog] query embed failed", (e as any)?.message)
+    return []
+  }
+  if (!queryVector.length) return []
+
+  const store = getStore()
+  let results: any[] = []
+  try {
+    results = await store.query({
+      indexName: INDEX_NAME,
+      queryVector,
+      topK,
+    })
+  } catch (e) {
+    console.warn("[productCatalog] vector query failed", (e as any)?.message)
+    return []
+  }
+
+  return (results ?? [])
+    .map((r: any) => ({
+      product_id: r?.metadata?.product_id ?? r?.id?.replace(/^product:/, ""),
+      handle: r?.metadata?.handle ?? null,
+      title: r?.metadata?.title ?? null,
+      thumbnail: r?.metadata?.thumbnail ?? null,
+      score: typeof r?.score === "number" ? r.score : 0,
+    }))
+    .filter((h) => typeof h.product_id === "string" && h.product_id.length > 0)
+}
+
+export const PRODUCT_SEARCH_INDEX = INDEX_NAME

--- a/apps/backend/src/mastra/rag/productCatalog.ts
+++ b/apps/backend/src/mastra/rag/productCatalog.ts
@@ -10,12 +10,20 @@
  * the admin RAG (which indexes API endpoints) and the storefront search
  * (which indexes products) can evolve independently.
  *
- * Embedding provider falls back through:
- *   1. HF local (Xenova/all-MiniLM-L6-v2, 384 dims) — free, runs in-process
- *   2. Google text-embedding-004 — when GOOGLE_GENERATIVE_AI_API_KEY set
- *      and ADMIN_RAG_EMBED_PROVIDER=google
- * HF local is the default — no API key requirement, predictable cost.
+ * Embedding provider selection (env: PRODUCT_SEARCH_EMBED_PROVIDER):
+ *   • hf_local   — Xenova/all-MiniLM-L6-v2, 384 dims, runs in-process (default)
+ *   • google     — text-embedding-004, 768 dims, needs GOOGLE_GENERATIVE_AI_API_KEY
+ *   • dashscope  — text-embedding-v3, 1024 dims, needs DASHSCOPE_API_KEY (user has credits)
+ *
+ * IMPORTANT: switching providers changes the vector dimension, which is
+ * incompatible with the existing PgVector index. Changing provider means:
+ *   1. drop product_search_v1 in PG (or bump INDEX_NAME)
+ *   2. re-run scripts/backfill-product-search.ts
+ * There's no on-the-fly fallback for embeddings — it's a one-time choice.
+ * The LLM extraction layer (extract.ts) DOES fall back across providers
+ * because each call is independent, but embeddings have to commit.
  */
+import { createOpenAI } from "@ai-sdk/openai"
 import { PgVector } from "@mastra/pg"
 import { embedMany } from "ai"
 import { google } from "@ai-sdk/google"
@@ -24,16 +32,25 @@ import crypto from "crypto"
 const INDEX_NAME = "product_search_v1"
 const HF_DEFAULT_MODEL = "Xenova/all-MiniLM-L6-v2"
 const GOOGLE_EMBEDDING_MODEL = "text-embedding-004"
+const DASHSCOPE_EMBEDDING_MODEL = "text-embedding-v3"
 
 // ── Embedding provider ─────────────────────────────────────────────────
 
-type EmbeddingProvider = "google" | "hf_local"
+type EmbeddingProvider = "google" | "hf_local" | "dashscope"
 
 const getEmbeddingProvider = (): EmbeddingProvider => {
-  const p = String(process.env.ADMIN_RAG_EMBED_PROVIDER || "hf_local")
+  // Storefront search has its own env so it can be tuned independently
+  // from the admin RAG (which indexes API endpoints, not products).
+  // Falls back to ADMIN_RAG_EMBED_PROVIDER for backwards compat.
+  const p = String(
+    process.env.PRODUCT_SEARCH_EMBED_PROVIDER ||
+      process.env.ADMIN_RAG_EMBED_PROVIDER ||
+      "hf_local"
+  )
     .trim()
     .toLowerCase()
   if (p === "google") return "google"
+  if (p === "dashscope" || p === "qwen") return "dashscope"
   return "hf_local"
 }
 
@@ -52,6 +69,22 @@ const getHfExtractor = async () => {
   return hfExtractorPromise
 }
 
+let _dashscopeClient: ReturnType<typeof createOpenAI> | null = null
+const getDashscopeClient = () => {
+  if (_dashscopeClient) return _dashscopeClient
+  const apiKey = process.env.DASHSCOPE_API_KEY
+  if (!apiKey) {
+    throw new Error(
+      "PRODUCT_SEARCH_EMBED_PROVIDER=dashscope but DASHSCOPE_API_KEY is not set"
+    )
+  }
+  _dashscopeClient = createOpenAI({
+    baseURL: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+    apiKey,
+  })
+  return _dashscopeClient
+}
+
 export const embedTexts = async (values: string[]): Promise<number[][]> => {
   if (!values.length) return []
   const provider = getEmbeddingProvider()
@@ -61,6 +94,16 @@ export const embedTexts = async (values: string[]): Promise<number[][]> => {
     const list =
       out && typeof out.tolist === "function" ? out.tolist() : out
     return Array.isArray(list[0]) ? (list as number[][]) : [list as number[]]
+  }
+  if (provider === "dashscope") {
+    const ds = getDashscopeClient()
+    const modelId =
+      process.env.PRODUCT_SEARCH_DASHSCOPE_MODEL || DASHSCOPE_EMBEDDING_MODEL
+    const { embeddings } = await embedMany({
+      model: ds.embedding(modelId),
+      values,
+    })
+    return embeddings as number[][]
   }
   // Google path. We rely on the AI SDK's embedMany so the wire format
   // shake-out is handled for us.

--- a/apps/backend/src/scripts/backfill-product-search.ts
+++ b/apps/backend/src/scripts/backfill-product-search.ts
@@ -1,0 +1,78 @@
+/**
+ * Backfill the product_search_v1 PgVector index with every published
+ * product. Idempotent — products whose source text hasn't changed
+ * since the last embedding are skipped via text_hash compare in
+ * upsertProducts.
+ *
+ * Run with:
+ *   pnpm --filter @jyt/backend exec medusa exec ./src/scripts/backfill-product-search.ts
+ *
+ * Or set BATCH=100 / DRY_RUN=1 in the environment to tune.
+ */
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { upsertProducts } from "../mastra/rag/productCatalog"
+
+const PRODUCT_FIELDS = [
+  "id",
+  "handle",
+  "title",
+  "subtitle",
+  "description",
+  "material",
+  "thumbnail",
+  "status",
+  "tags.value",
+  "categories.name",
+  "collection.title",
+  "type.value",
+]
+
+export default async function backfillProductSearch({ container }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  const BATCH = Number(process.env.BATCH || 50)
+  const DRY_RUN = process.env.DRY_RUN === "1"
+
+  logger.info(
+    `[product-search backfill] starting (batch=${BATCH}${DRY_RUN ? " DRY_RUN" : ""})`
+  )
+
+  let offset = 0
+  let totals = { fetched: 0, upserted: 0, skipped: 0, errors: 0 }
+  for (;;) {
+    const { data } = await query.graph({
+      entity: "product",
+      fields: PRODUCT_FIELDS,
+      filters: { status: "published" } as any,
+      pagination: { take: BATCH, skip: offset },
+    })
+    const batch = data ?? []
+    if (!batch.length) break
+
+    totals.fetched += batch.length
+    logger.info(
+      `[product-search backfill] batch ${offset / BATCH + 1}: ${batch.length} products (offset=${offset})`
+    )
+
+    if (!DRY_RUN) {
+      const result = await upsertProducts(batch as any)
+      totals.upserted += result.upserted
+      totals.skipped += result.skipped
+      totals.errors += result.errors
+      logger.info(
+        `[product-search backfill] batch result: upserted=${result.upserted} skipped=${result.skipped} errors=${result.errors}`
+      )
+    }
+
+    if (batch.length < BATCH) break
+    offset += BATCH
+  }
+
+  logger.info(
+    `[product-search backfill] done. ` +
+      `fetched=${totals.fetched} upserted=${totals.upserted} ` +
+      `skipped=${totals.skipped} errors=${totals.errors}`
+  )
+}

--- a/apps/backend/src/subscribers/index-product-for-search.ts
+++ b/apps/backend/src/subscribers/index-product-for-search.ts
@@ -1,0 +1,84 @@
+/**
+ * Indexes products into the product_search_v1 PgVector index whenever
+ * they're created or updated, and removes them on delete. Powers
+ * /store/ai/search.
+ *
+ * Idempotent: upsertProducts skips products whose source text hash is
+ * unchanged since the last embedding, so re-firing a product.updated
+ * event for an unrelated metadata change costs almost nothing.
+ *
+ * Errors are logged but never propagate — search-index maintenance
+ * should not block product saves or fail the originating workflow.
+ */
+import { SubscriberArgs, type SubscriberConfig } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { upsertProducts } from "../mastra/rag/productCatalog"
+
+const PRODUCT_FIELDS = [
+  "id",
+  "handle",
+  "title",
+  "subtitle",
+  "description",
+  "material",
+  "thumbnail",
+  "status",
+  "tags.value",
+  "categories.name",
+  "collection.title",
+  "type.value",
+]
+
+const indexOne = async (
+  container: any,
+  productId: string
+): Promise<void> => {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const logger = container.resolve("logger")
+
+  try {
+    const { data } = await query.graph({
+      entity: "product",
+      fields: PRODUCT_FIELDS,
+      filters: { id: productId } as any,
+    })
+    const product = (data ?? [])[0]
+    if (!product) {
+      logger?.debug?.(
+        `[product-search] product ${productId} not found for re-index — likely deleted`
+      )
+      return
+    }
+    // Only index published products. Drafts shouldn't be discoverable
+    // via storefront search.
+    if (product.status !== "published") {
+      logger?.debug?.(
+        `[product-search] product ${productId} not published (status=${product.status}); skipping index`
+      )
+      return
+    }
+    const result = await upsertProducts([product as any])
+    logger?.debug?.(
+      `[product-search] indexed product ${productId}: ` +
+        `upserted=${result.upserted} skipped=${result.skipped} errors=${result.errors}`
+    )
+  } catch (e: any) {
+    logger?.warn?.(
+      `[product-search] failed to index product ${productId}: ${e?.message ?? e}`
+    )
+  }
+}
+
+export default async function indexProductForSearchHandler({
+  event,
+  container,
+}: SubscriberArgs<{ id: string }>) {
+  const id = event?.data?.id
+  if (!id) return
+  // Fire and forget — never block the originating workflow on indexing.
+  void indexOne(container, id)
+}
+
+export const config: SubscriberConfig = {
+  event: ["product.created", "product.updated"],
+}

--- a/apps/storefront/src/app/[countryCode]/(main)/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next"
 import { cookies } from "next/headers"
 
+import AiSearch from "@modules/home/components/ai-search"
 import FeaturedProducts from "@modules/home/components/featured-products"
 import Hero from "@modules/home/components/hero"
 import HolidaySection from "@modules/home/components/holidays"
@@ -89,34 +90,7 @@ export default async function Home(props: {
       )}
       <HeroSeenMarker />
       <div className="mx-auto mt-8 w-full max-w-3xl px-4 sm:mt-10 sm:px-6">
-        <label className="sr-only" htmlFor="coming-soon-search">
-          Search products
-        </label>
-        <div className="relative">
-          <svg
-            aria-hidden="true"
-            className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 text-neutral-400 sm:left-5 sm:h-5 sm:w-5"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <circle cx="11" cy="11" r="7" />
-            <line x1="21" y1="21" x2="16.65" y2="16.65" />
-          </svg>
-          <input
-            id="coming-soon-search"
-            type="text"
-            disabled
-            placeholder="Search soon — describe what you want"
-            className="w-full rounded-full border border-dashed border-neutral-300 bg-neutral-100 pl-11 pr-5 py-2.5 text-sm text-neutral-500 placeholder:text-neutral-500 sm:pl-12 sm:pr-6 sm:py-3 sm:text-base"
-          />
-        </div>
-        <p className="mt-2 text-center text-xs text-neutral-500 sm:text-sm">
-          Powerful natural-language discovery coming soon.
-        </p>
+        <AiSearch />
       </div>
       <div id="shop" className="py-12">
         <ul className="flex flex-col gap-x-6">

--- a/apps/storefront/src/app/[countryCode]/(main)/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/page.tsx
@@ -1,8 +1,10 @@
 import { Metadata } from "next"
+import { cookies } from "next/headers"
 
 import FeaturedProducts from "@modules/home/components/featured-products"
 import Hero from "@modules/home/components/hero"
 import HolidaySection from "@modules/home/components/holidays"
+import HeroSeenMarker, { HERO_SEEN_COOKIE } from "@modules/home/components/home-stage"
 import PartnerShowcase from "@modules/home/components/partner-showcase"
 import ScrollStage from "@modules/home/components/scroll-stage"
 import { listCollections } from "@lib/data/collections"
@@ -67,25 +69,53 @@ export default async function Home(props: {
     return null
   }
 
+  // Cookie-gated hero: first-time visitors see the full scroll-driven
+  // ScrollStage (hero pinned, holiday rises over it). Returning visitors
+  // land directly on the holiday section. HeroSeenMarker (a tiny client
+  // component below) sets the cookie on every render, so once a visitor
+  // has hit any page their next request reads the cookie and skips the
+  // hero. Branching on the server keeps Hero's listPublicMedia call out
+  // of the hot path for returning visitors and avoids hydration flicker.
+  const cookieStore = await cookies()
+  const heroSeen = cookieStore.has(HERO_SEEN_COOKIE)
+  const holidaySection = <HolidaySection countryCode={countryCode} />
+
   return (
     <>
-      <ScrollStage
-        hero={<Hero />}
-        holiday={<HolidaySection countryCode={countryCode} />}
-      />
-      <div className="mx-auto mt-10 w-full max-w-3xl px-4 sm:px-0">
+      {heroSeen ? (
+        holidaySection
+      ) : (
+        <ScrollStage hero={<Hero />} holiday={holidaySection} />
+      )}
+      <HeroSeenMarker />
+      <div className="mx-auto mt-8 w-full max-w-3xl px-4 sm:mt-10 sm:px-6">
         <label className="sr-only" htmlFor="coming-soon-search">
-          Coming soon search
+          Search products
         </label>
-        <input
-          id="coming-soon-search"
-          type="text"
-          disabled
-          placeholder="Soon you can search by entering list of ideas your favorite product coming soon"
-          className="w-full rounded-full border border-dashed border-neutral-300 bg-neutral-100 px-6 py-3 text-base text-neutral-500 placeholder:text-neutral-500"
-        />
-        <p className="mt-2 text-center text-sm text-neutral-500">
-          We&apos;re building powerful discovery tools—stay tuned!
+        <div className="relative">
+          <svg
+            aria-hidden="true"
+            className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 text-neutral-400 sm:left-5 sm:h-5 sm:w-5"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="11" cy="11" r="7" />
+            <line x1="21" y1="21" x2="16.65" y2="16.65" />
+          </svg>
+          <input
+            id="coming-soon-search"
+            type="text"
+            disabled
+            placeholder="Search soon — describe what you want"
+            className="w-full rounded-full border border-dashed border-neutral-300 bg-neutral-100 pl-11 pr-5 py-2.5 text-sm text-neutral-500 placeholder:text-neutral-500 sm:pl-12 sm:pr-6 sm:py-3 sm:text-base"
+          />
+        </div>
+        <p className="mt-2 text-center text-xs text-neutral-500 sm:text-sm">
+          Powerful natural-language discovery coming soon.
         </p>
       </div>
       <div id="shop" className="py-12">

--- a/apps/storefront/src/modules/home/components/ai-search.tsx
+++ b/apps/storefront/src/modules/home/components/ai-search.tsx
@@ -26,12 +26,23 @@ type Variant = {
   } | null
 }
 
+type StorefrontAttribution =
+  | { kind: "main" }
+  | {
+      kind: "partner"
+      url?: string
+      partner_name: string
+      partner_handle: string
+      sales_channel_name?: string
+    }
+
 type SearchProduct = {
   id: string
   handle: string
   title: string
   thumbnail?: string | null
   variants?: Variant[]
+  storefront?: StorefrontAttribution
 }
 
 type SearchResponse = {
@@ -181,6 +192,62 @@ export default function AiSearch() {
           {hasResults &&
             response!.products.map((p) => {
               const price = formatPrice(p.variants)
+              const attribution = p.storefront
+              const isPartner =
+                attribution?.kind === "partner" && Boolean(attribution.url)
+
+              const thumb = p.thumbnail ? (
+                /* eslint-disable-next-line @next/next/no-img-element */
+                <img
+                  src={p.thumbnail}
+                  alt=""
+                  className="h-12 w-12 rounded-md object-cover sm:h-14 sm:w-14"
+                />
+              ) : (
+                <div className="h-12 w-12 rounded-md bg-neutral-100 sm:h-14 sm:w-14" />
+              )
+
+              const body = (
+                <>
+                  {thumb}
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <p className="truncate text-sm font-medium text-neutral-900 sm:text-base">
+                        {p.title}
+                      </p>
+                      {isPartner && (
+                        <span className="shrink-0 rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-800 sm:text-[11px]">
+                          Partner store
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-xs text-neutral-500 sm:text-sm">
+                      {price ? `from ${price}` : null}
+                      {isPartner && attribution.partner_name ? (
+                        <>
+                          {price ? " · " : ""}
+                          sold by {attribution.partner_name}
+                        </>
+                      ) : null}
+                    </p>
+                  </div>
+                </>
+              )
+
+              if (isPartner && attribution.url) {
+                return (
+                  <a
+                    key={p.id}
+                    href={attribution.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-3 px-4 py-3 hover:bg-amber-50/40 focus:bg-amber-50/40 focus:outline-none"
+                    onClick={() => setOpen(false)}
+                  >
+                    {body}
+                  </a>
+                )
+              }
               return (
                 <LocalizedClientLink
                   key={p.id}
@@ -188,26 +255,7 @@ export default function AiSearch() {
                   className="flex items-center gap-3 px-4 py-3 hover:bg-neutral-50 focus:bg-neutral-50 focus:outline-none"
                   onClick={() => setOpen(false)}
                 >
-                  {p.thumbnail ? (
-                    /* eslint-disable-next-line @next/next/no-img-element */
-                    <img
-                      src={p.thumbnail}
-                      alt=""
-                      className="h-12 w-12 rounded-md object-cover sm:h-14 sm:w-14"
-                    />
-                  ) : (
-                    <div className="h-12 w-12 rounded-md bg-neutral-100 sm:h-14 sm:w-14" />
-                  )}
-                  <div className="min-w-0 flex-1">
-                    <p className="truncate text-sm font-medium text-neutral-900 sm:text-base">
-                      {p.title}
-                    </p>
-                    {price && (
-                      <p className="text-xs text-neutral-500 sm:text-sm">
-                        from {price}
-                      </p>
-                    )}
-                  </div>
+                  {body}
                 </LocalizedClientLink>
               )
             })}

--- a/apps/storefront/src/modules/home/components/ai-search.tsx
+++ b/apps/storefront/src/modules/home/components/ai-search.tsx
@@ -1,0 +1,233 @@
+"use client"
+
+import LocalizedClientLink from "@modules/common/components/localized-client-link"
+import { sdk } from "@lib/config"
+import { useEffect, useRef, useState } from "react"
+
+/**
+ * Natural-language product search input on the homepage.
+ *
+ * Calls POST /store/ai/search — the backend LLM-extracts keywords, runs
+ * a semantic vector search against PgVector, and returns a small set of
+ * products shaped like /store/products. Results render in an inline
+ * dropdown below the input; clicking a result navigates to the product
+ * page via LocalizedClientLink so the country-code prefix is preserved.
+ *
+ * Debounce window is intentionally short (350ms) — each call hits a
+ * paid LLM, so we want one call per "thought" rather than per keystroke,
+ * but the user shouldn't notice waiting.
+ */
+type Variant = {
+  id: string
+  title?: string | null
+  calculated_price?: {
+    calculated_amount?: number | null
+    currency_code?: string | null
+  } | null
+}
+
+type SearchProduct = {
+  id: string
+  handle: string
+  title: string
+  thumbnail?: string | null
+  variants?: Variant[]
+}
+
+type SearchResponse = {
+  query: string
+  mode: "vector" | "lexical"
+  interpretation: {
+    keywords: string[]
+    color?: string
+    material?: string
+    min_price?: number
+    max_price?: number
+  }
+  products: SearchProduct[]
+  count: number
+}
+
+const DEBOUNCE_MS = 350
+const MIN_QUERY_LEN = 2
+
+const formatPrice = (variants: Variant[] | undefined): string | null => {
+  const amounts = (variants ?? [])
+    .map((v) => v?.calculated_price?.calculated_amount)
+    .filter((n): n is number => typeof n === "number")
+  if (!amounts.length) return null
+  const low = Math.min(...amounts)
+  const cc =
+    (variants ?? []).find(
+      (v) => v?.calculated_price?.currency_code
+    )?.calculated_price?.currency_code ?? "INR"
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: cc.toUpperCase(),
+      maximumFractionDigits: 0,
+    }).format(low)
+  } catch {
+    return `${cc.toUpperCase()} ${low}`
+  }
+}
+
+export default function AiSearch() {
+  const [query, setQuery] = useState("")
+  const [response, setResponse] = useState<SearchResponse | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+  // Tracks the AbortController of the most recent in-flight request so
+  // we cancel old requests when the user keeps typing — otherwise a
+  // slow earlier response could overwrite a faster later one.
+  const inflightRef = useRef<AbortController | null>(null)
+
+  // Close on outside click.
+  useEffect(() => {
+    const onDocClick = (e: MouseEvent) => {
+      if (!containerRef.current) return
+      if (!containerRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener("mousedown", onDocClick)
+    return () => document.removeEventListener("mousedown", onDocClick)
+  }, [])
+
+  // Debounced search effect.
+  useEffect(() => {
+    const trimmed = query.trim()
+    if (trimmed.length < MIN_QUERY_LEN) {
+      setResponse(null)
+      setLoading(false)
+      return
+    }
+
+    const handle = window.setTimeout(async () => {
+      inflightRef.current?.abort()
+      const controller = new AbortController()
+      inflightRef.current = controller
+      setLoading(true)
+      try {
+        const r = await sdk.client.fetch<SearchResponse>("/store/ai/search", {
+          method: "POST",
+          body: { query: trimmed, limit: 6 },
+          signal: controller.signal,
+        } as any)
+        if (controller.signal.aborted) return
+        setResponse(r)
+      } catch (e) {
+        if ((e as any)?.name === "AbortError") return
+        setResponse(null)
+      } finally {
+        if (!controller.signal.aborted) setLoading(false)
+      }
+    }, DEBOUNCE_MS)
+
+    return () => window.clearTimeout(handle)
+  }, [query])
+
+  const hasResults = Boolean(response?.products?.length)
+  const showDropdown =
+    open && query.trim().length >= MIN_QUERY_LEN && (loading || response)
+
+  return (
+    <div ref={containerRef} className="relative">
+      <label className="sr-only" htmlFor="ai-search">
+        Search products
+      </label>
+      <svg
+        aria-hidden="true"
+        className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 text-neutral-400 sm:left-5 sm:h-5 sm:w-5"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <circle cx="11" cy="11" r="7" />
+        <line x1="21" y1="21" x2="16.65" y2="16.65" />
+      </svg>
+      <input
+        id="ai-search"
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onFocus={() => setOpen(true)}
+        placeholder="Describe what you want — e.g. soft cotton dress"
+        className="w-full rounded-full border border-neutral-300 bg-white pl-11 pr-5 py-2.5 text-sm text-neutral-900 placeholder:text-neutral-500 focus:border-neutral-500 focus:outline-none focus:ring-1 focus:ring-neutral-500 sm:pl-12 sm:pr-6 sm:py-3 sm:text-base"
+        autoComplete="off"
+        spellCheck={false}
+      />
+      <p className="mt-2 text-center text-xs text-neutral-500 sm:text-sm">
+        Natural-language discovery — powered by AI.
+      </p>
+
+      {showDropdown && (
+        <div
+          role="listbox"
+          className="absolute left-0 right-0 top-full z-30 mt-2 max-h-[60vh] overflow-y-auto rounded-2xl border border-neutral-200 bg-white shadow-xl"
+        >
+          {loading && (
+            <div className="px-4 py-3 text-sm text-neutral-500">
+              Searching…
+            </div>
+          )}
+          {!loading && response && !hasResults && (
+            <div className="px-4 py-3 text-sm text-neutral-500">
+              No matches yet — try simpler keywords.
+            </div>
+          )}
+          {hasResults &&
+            response!.products.map((p) => {
+              const price = formatPrice(p.variants)
+              return (
+                <LocalizedClientLink
+                  key={p.id}
+                  href={`/products/${p.handle}`}
+                  className="flex items-center gap-3 px-4 py-3 hover:bg-neutral-50 focus:bg-neutral-50 focus:outline-none"
+                  onClick={() => setOpen(false)}
+                >
+                  {p.thumbnail ? (
+                    /* eslint-disable-next-line @next/next/no-img-element */
+                    <img
+                      src={p.thumbnail}
+                      alt=""
+                      className="h-12 w-12 rounded-md object-cover sm:h-14 sm:w-14"
+                    />
+                  ) : (
+                    <div className="h-12 w-12 rounded-md bg-neutral-100 sm:h-14 sm:w-14" />
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-neutral-900 sm:text-base">
+                      {p.title}
+                    </p>
+                    {price && (
+                      <p className="text-xs text-neutral-500 sm:text-sm">
+                        from {price}
+                      </p>
+                    )}
+                  </div>
+                </LocalizedClientLink>
+              )
+            })}
+          {response?.interpretation && (
+            <div className="border-t border-neutral-100 px-4 py-2 text-[11px] text-neutral-400 sm:text-xs">
+              Interpreted as:{" "}
+              {response.interpretation.keywords.join(", ") || query}
+              {response.interpretation.color
+                ? ` · ${response.interpretation.color}`
+                : ""}
+              {response.interpretation.material
+                ? ` · ${response.interpretation.material}`
+                : ""}
+              {response.interpretation.max_price
+                ? ` · under ${response.interpretation.max_price}`
+                : ""}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/storefront/src/modules/home/components/home-stage.tsx
+++ b/apps/storefront/src/modules/home/components/home-stage.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import { useEffect } from "react"
+
+/**
+ * Tiny client-side helper that marks the homepage as "seen" via a cookie
+ * the next request can read.
+ *
+ * Rationale: gating the hero on the server (see app/[countryCode]/(main)/
+ * page.tsx) keeps Hero from running its `listPublicMedia` fetch for
+ * returning visitors and avoids the hydration flash you get when a
+ * client component flips between two server-rendered trees. The trade-
+ * off is the cookie has to be set somewhere — we set it client-side on
+ * every render so first-time visitors get the hero now, and the next
+ * SSR (be it a refresh or a navigation) sees the cookie and skips it.
+ *
+ * 1-year max-age, SameSite=Lax — same scope you'd use for any UI-pref
+ * cookie. Path=/ so it applies across country code segments. No
+ * sensitive data, doesn't need HttpOnly.
+ *
+ * Returns null — pure side-effect component.
+ */
+const COOKIE = "jyt_hero_seen"
+
+export default function HeroSeenMarker() {
+  useEffect(() => {
+    try {
+      if (document.cookie.includes(`${COOKIE}=`)) return
+      document.cookie = `${COOKIE}=1; Path=/; Max-Age=31536000; SameSite=Lax`
+    } catch {
+      // cookies disabled — we'll show the hero again next visit, which
+      // is acceptable degraded behaviour.
+    }
+  }, [])
+  return null
+}
+
+export const HERO_SEEN_COOKIE = COOKIE


### PR DESCRIPTION
## Summary

Three storefront-home improvements landing together.

### 1. Hero only on first visit (cookie-gated)

The Apple-style ScrollStage hero now only plays on a visitor's first visit to the site. After that, the homepage lands directly on the holiday section.

- Cookie `jyt_hero_seen` (1-year, SameSite=Lax) set by a tiny client component on every render
- Branching happens **server-side** in `page.tsx` via `next/headers`, so:
  - Returning visitors never pay the `Hero` listPublicMedia fetch
  - No hydration flicker swapping client trees
- Clear the cookie from devtools to re-trigger the hero

### 2. Responsive coming-soon → working search

Replaced the disabled wrap-on-mobile placeholder with a real search input:

- Debounced (350ms) calls to `POST /store/ai/search`
- AbortController for in-flight cancellation
- Inline dropdown with thumbnail + title + min-variant price (Intl.NumberFormat per currency)
- Trailing "Interpreted as: …" so the user can see how the backend understood them
- Closes on outside click; results link via `LocalizedClientLink` so the country code prefix is preserved
- Mobile-friendly paddings, icon scale, and text size

### 3. Semantic product search backend (PgVector)

New `POST /store/ai/search` route — public, no customer auth.

Pipeline:
1. LLM (gemini-2.5-flash via OpenRouter, swap with `STOREFRONT_SEARCH_MODEL`) extracts a tiny structured interpretation from the natural-language query: keywords, optional color, material, price range.
2. Enriched query is embedded and cosine-searched against the new `product_search_v1` PgVector index.
3. Hits are hydrated through Medusa's product query so the response shape matches `/store/products`.
4. Price range is applied as a JS post-filter (price isn't part of the embedding signal).
5. **Falls back** to lexical q-search when the vector index is empty or PgVector is unreachable — the storefront keeps working during a backfill.

Index maintenance:
- `mastra/rag/productCatalog.ts` — embed/upsert/query helpers. HF local (`Xenova/all-MiniLM-L6-v2`, 384 dims) is the default embedder; `ADMIN_RAG_EMBED_PROVIDER=google` switches to text-embedding-004. Upserts are idempotent via text_hash compare.
- `subscribers/index-product-for-search.ts` — auto-indexes on `product.created` / `product.updated`. Fires and forgets so it never blocks the originating workflow.
- `scripts/backfill-product-search.ts` — one-off backfill of the existing catalogue: `pnpm --filter @jyt/backend exec medusa exec ./src/scripts/backfill-product-search.ts`. Tunable via `BATCH=50` and `DRY_RUN=1`.

## Test plan

- [ ] First-time visitor (cookie cleared) → hero animates into holiday on scroll
- [ ] Second visit → lands directly on holiday section, no hero
- [ ] Search "soft cotton dress" → results dropdown shows products + "Interpreted as: soft, cotton, dress · cotton"
- [ ] Search "shirt under 1500" → results respect price range, "under 1500" appears in the interpretation line
- [ ] Mobile (375px) → input doesn't overflow, dropdown is full-width, results readable
- [ ] Backend: `medusa exec ./src/scripts/backfill-product-search.ts` populates the `product_search_v1` index without errors
- [ ] Backend: create a new product → subscriber fires → product becomes searchable within seconds

## Follow-ups

- `product.deleted` cleanup of vector rows (currently inert — products are filtered by `status: published` on hydration)
- Rate limiting on `/store/ai/search` (no auth = potential abuse vector)
- Tune the embedding source text fields based on real query data

🤖 Generated with [Claude Code](https://claude.com/claude-code)