### PR TITLE
feat(ai): Create-AI-provider admin UI + env→DB backfill script

### DIFF
--- a/apps/backend/src/admin/components/social-platforms/create-ai-platform-component.tsx
+++ b/apps/backend/src/admin/components/social-platforms/create-ai-platform-component.tsx
@@ -1,0 +1,379 @@
+import { Button, Heading, Input, Select, Switch, Text, toast } from "@medusajs/ui"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "@medusajs/framework/zod"
+import { useCreateSocialPlatform } from "../../hooks/api/social-platforms"
+import { KeyboundForm } from "../utilitites/key-bound-form"
+import { Form } from "../common/form"
+import { RouteFocusModal } from "../modal/route-focus-modal"
+import { useRouteModal } from "../modal/use-route-modal"
+
+/**
+ * Tailored "Create AI provider" form.
+ *
+ * Sits alongside the generic CreateSocialPlatformComponent. We split it
+ * out because the AI shape is small and well-defined (api_key + a few
+ * provider-specific fields), and embedding it as another category branch
+ * inside the already-500-line create-social-platform form would bloat
+ * the validation logic for everyone.
+ *
+ * What this writes:
+ *   - category = "ai"
+ *   - auth_type = "bearer"
+ *   - metadata.provider_type ∈ {openrouter, dashscope, cloudflare, vercel_ai_gateway, custom}
+ *   - metadata.role ∈ {ai_search_chat, ai_search_embed, ai_product_description}
+ *   - metadata.is_default = true/false
+ *   - api_config.api_key (plaintext on the wire — the
+ *     social-platform-credentials-encryption subscriber encrypts in
+ *     place after the create event fires)
+ *   - api_config.default_model
+ *   - api_config.account_id    (cloudflare only)
+ *   - api_config.base_url      (vercel_ai_gateway + custom)
+ *   - base_url (column)        (vercel_ai_gateway + custom, mirrored for searchability)
+ *
+ * Consumed by mastra/services/ai-platforms.ts:getAiPlatformForRole.
+ */
+const ProviderTypeEnum = z.enum([
+  "openrouter",
+  "dashscope",
+  "cloudflare",
+  "vercel_ai_gateway",
+  "custom",
+])
+
+const RoleEnum = z.enum([
+  "ai_search_chat",
+  "ai_search_embed",
+  "ai_product_description",
+])
+
+const Schema = z.object({
+  name: z.string().min(1, "Name is required"),
+  provider_type: ProviderTypeEnum,
+  role: RoleEnum,
+  is_default: z.boolean().optional().default(true),
+  api_key: z.string().min(1, "API key is required"),
+  default_model: z.string().optional(),
+  account_id: z.string().optional(),
+  base_url: z.string().url("Must be a valid URL").optional().or(z.literal("")),
+}).superRefine((data, ctx) => {
+  if (data.provider_type === "cloudflare" && !data.account_id) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["account_id"],
+      message: "Account ID is required for Cloudflare AI",
+    })
+  }
+  if (
+    (data.provider_type === "vercel_ai_gateway" ||
+      data.provider_type === "custom") &&
+    !data.base_url
+  ) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["base_url"],
+      message: "Base URL is required for this provider type",
+    })
+  }
+})
+
+type FormValues = z.infer<typeof Schema>
+
+const PROVIDER_LABELS: Record<z.infer<typeof ProviderTypeEnum>, string> = {
+  openrouter: "OpenRouter",
+  dashscope: "DashScope (Qwen)",
+  cloudflare: "Cloudflare Workers AI",
+  vercel_ai_gateway: "Vercel AI Gateway",
+  custom: "Custom (OpenAI-compatible)",
+}
+
+const ROLE_LABELS: Record<z.infer<typeof RoleEnum>, string> = {
+  ai_search_chat: "Storefront search — chat / extraction",
+  ai_search_embed: "Storefront search — embeddings",
+  ai_product_description: "Product image → description",
+}
+
+const DEFAULT_MODEL_HINTS: Record<z.infer<typeof ProviderTypeEnum>, string> = {
+  openrouter: "meta-llama/llama-3.3-70b-instruct:free",
+  dashscope: "qwen-turbo  (chat) / text-embedding-v3 (embed)",
+  cloudflare: "@cf/meta/llama-3.1-8b-instruct (chat) / @cf/baai/bge-base-en-v1.5 (embed)",
+  vercel_ai_gateway: "openai/gpt-4o-mini",
+  custom: "your-model-id",
+}
+
+export const CreateAiPlatformComponent = () => {
+  const { handleSuccess } = useRouteModal()
+  const { mutateAsync, isPending } = useCreateSocialPlatform()
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(Schema as any),
+    defaultValues: {
+      name: "",
+      provider_type: "openrouter" as const,
+      role: "ai_search_chat" as const,
+      is_default: true,
+      api_key: "",
+      default_model: "",
+      account_id: "",
+      base_url: "",
+    },
+  })
+
+  const providerType = form.watch("provider_type")
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    const apiConfig: Record<string, unknown> = {
+      api_key: values.api_key,
+    }
+    if (values.default_model) apiConfig.default_model = values.default_model
+    if (values.account_id) apiConfig.account_id = values.account_id
+    if (values.base_url) apiConfig.base_url = values.base_url
+
+    try {
+      await mutateAsync({
+        name: values.name,
+        category: "ai",
+        auth_type: "bearer",
+        status: "active",
+        base_url:
+          values.base_url && values.base_url.length > 0
+            ? values.base_url
+            : undefined,
+        api_config: apiConfig,
+        metadata: {
+          provider_type: values.provider_type,
+          role: values.role,
+          is_default: values.is_default ?? true,
+          source: "admin_ui",
+        },
+      })
+      toast.success("AI provider created")
+      handleSuccess("/settings/external-platforms")
+    } catch (e: any) {
+      toast.error(e?.message ?? "Failed to create AI provider")
+    }
+  })
+
+  return (
+    <RouteFocusModal.Form form={form}>
+      <KeyboundForm onSubmit={onSubmit} className="flex h-full flex-col">
+        <RouteFocusModal.Header>
+          <div className="flex items-center justify-end gap-x-2">
+            <RouteFocusModal.Close asChild>
+              <Button size="small" variant="secondary">
+                Cancel
+              </Button>
+            </RouteFocusModal.Close>
+            <Button
+              size="small"
+              variant="primary"
+              type="submit"
+              isLoading={isPending}
+            >
+              Save
+            </Button>
+          </div>
+        </RouteFocusModal.Header>
+        <RouteFocusModal.Body className="flex flex-col items-center overflow-y-auto p-16">
+          <div className="flex w-full max-w-[640px] flex-col gap-y-8">
+            <div>
+              <Heading>Create AI provider</Heading>
+              <Text size="small" className="text-ui-fg-subtle">
+                Configure a chat or embedding provider that storefront
+                search and AI-using workflows will pick up at runtime.
+                The API key is encrypted on save.
+              </Text>
+            </div>
+
+            <Form.Field
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label>Name</Form.Label>
+                  <Form.Control>
+                    <Input
+                      {...field}
+                      placeholder="e.g. OpenRouter free, DashScope qwen, CF Workers AI"
+                    />
+                  </Form.Control>
+                  <Form.ErrorMessage />
+                </Form.Item>
+              )}
+            />
+
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <Form.Field
+                control={form.control}
+                name="provider_type"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label>Provider</Form.Label>
+                    <Form.Control>
+                      <Select
+                        value={field.value}
+                        onValueChange={field.onChange}
+                      >
+                        <Select.Trigger>
+                          <Select.Value placeholder="Select provider" />
+                        </Select.Trigger>
+                        <Select.Content>
+                          {Object.entries(PROVIDER_LABELS).map(([v, label]) => (
+                            <Select.Item key={v} value={v}>
+                              {label}
+                            </Select.Item>
+                          ))}
+                        </Select.Content>
+                      </Select>
+                    </Form.Control>
+                    <Form.ErrorMessage />
+                  </Form.Item>
+                )}
+              />
+
+              <Form.Field
+                control={form.control}
+                name="role"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label>Role</Form.Label>
+                    <Form.Control>
+                      <Select
+                        value={field.value}
+                        onValueChange={field.onChange}
+                      >
+                        <Select.Trigger>
+                          <Select.Value placeholder="Select role" />
+                        </Select.Trigger>
+                        <Select.Content>
+                          {Object.entries(ROLE_LABELS).map(([v, label]) => (
+                            <Select.Item key={v} value={v}>
+                              {label}
+                            </Select.Item>
+                          ))}
+                        </Select.Content>
+                      </Select>
+                    </Form.Control>
+                    <Form.ErrorMessage />
+                  </Form.Item>
+                )}
+              />
+            </div>
+
+            <Form.Field
+              control={form.control}
+              name="api_key"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label>API key</Form.Label>
+                  <Form.Control>
+                    <Input
+                      {...field}
+                      type="password"
+                      placeholder="sk-…"
+                      autoComplete="off"
+                    />
+                  </Form.Control>
+                  <Form.Hint>
+                    Stored encrypted via the encryption subscriber on save.
+                  </Form.Hint>
+                  <Form.ErrorMessage />
+                </Form.Item>
+              )}
+            />
+
+            {providerType === "cloudflare" && (
+              <Form.Field
+                control={form.control}
+                name="account_id"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label>Cloudflare account ID</Form.Label>
+                    <Form.Control>
+                      <Input
+                        {...field}
+                        placeholder="e.g. 9719d38e64dffe8fd6982afb3a7b25f6"
+                      />
+                    </Form.Control>
+                    <Form.Hint>
+                      Used to construct the base URL{" "}
+                      <code>api.cloudflare.com/.../{`<account_id>`}/ai/v1</code>.
+                    </Form.Hint>
+                    <Form.ErrorMessage />
+                  </Form.Item>
+                )}
+              />
+            )}
+
+            {(providerType === "vercel_ai_gateway" ||
+              providerType === "custom") && (
+              <Form.Field
+                control={form.control}
+                name="base_url"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label>Base URL</Form.Label>
+                    <Form.Control>
+                      <Input
+                        {...field}
+                        type="url"
+                        placeholder="https://gateway.example.com/v1"
+                      />
+                    </Form.Control>
+                    <Form.ErrorMessage />
+                  </Form.Item>
+                )}
+              />
+            )}
+
+            <Form.Field
+              control={form.control}
+              name="default_model"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label optional>Default model</Form.Label>
+                  <Form.Control>
+                    <Input
+                      {...field}
+                      placeholder={DEFAULT_MODEL_HINTS[providerType]}
+                    />
+                  </Form.Control>
+                  <Form.Hint>
+                    Optional. If empty, a provider-specific default is used.
+                  </Form.Hint>
+                  <Form.ErrorMessage />
+                </Form.Item>
+              )}
+            />
+
+            <Form.Field
+              control={form.control}
+              name="is_default"
+              render={({ field }) => (
+                <Form.Item>
+                  <div className="flex items-center justify-between gap-4">
+                    <div className="flex flex-col">
+                      <Form.Label>Default for this role</Form.Label>
+                      <Text size="small" className="text-ui-fg-subtle">
+                        Only one platform per role should be default. The
+                        runtime picks the default; other platforms are
+                        available as alternatives.
+                      </Text>
+                    </div>
+                    <Form.Control>
+                      <Switch
+                        checked={field.value === true}
+                        onCheckedChange={(v: boolean) => field.onChange(v)}
+                      />
+                    </Form.Control>
+                  </div>
+                  <Form.ErrorMessage />
+                </Form.Item>
+              )}
+            />
+          </div>
+        </RouteFocusModal.Body>
+      </KeyboundForm>
+    </RouteFocusModal.Form>
+  )
+}

--- a/apps/backend/src/admin/hooks/api/social-platforms.ts
+++ b/apps/backend/src/admin/hooks/api/social-platforms.ts
@@ -26,6 +26,7 @@ export type ApiCategory =
   | "communication"
   | "authentication"
   | "google"
+  | "ai"
   | "other"
 
 export type AuthType = 
@@ -73,6 +74,7 @@ export type AdminCreateSocialPlatformPayload = {
   base_url?: string
   description?: string
   status?: PlatformStatus
+  api_config?: Record<string, any>
   metadata?: Record<string, any>
 }
 

--- a/apps/backend/src/admin/routes/settings/external-platforms/create-ai/page.tsx
+++ b/apps/backend/src/admin/routes/settings/external-platforms/create-ai/page.tsx
@@ -1,0 +1,10 @@
+import { CreateAiPlatformComponent } from "../../../../components/social-platforms/create-ai-platform-component"
+import { RouteFocusModal } from "../../../../components/modal/route-focus-modal"
+
+const CreateAiPlatformPage = () => (
+  <RouteFocusModal>
+    <CreateAiPlatformComponent />
+  </RouteFocusModal>
+)
+
+export default CreateAiPlatformPage

--- a/apps/backend/src/admin/routes/settings/external-platforms/page.tsx
+++ b/apps/backend/src/admin/routes/settings/external-platforms/page.tsx
@@ -188,6 +188,15 @@ const SocialPlatformPage = () => {
               <Button
                 size="small"
                 variant="secondary"
+                onClick={() =>
+                  navigate("/settings/external-platforms/create-ai")
+                }
+              >
+                Create AI provider
+              </Button>
+              <Button
+                size="small"
+                variant="secondary"
                 onClick={() => navigate("/settings/external-platforms/create")}
               >
                 Create

--- a/apps/backend/src/api/admin/social-platforms/validators.ts
+++ b/apps/backend/src/api/admin/social-platforms/validators.ts
@@ -13,6 +13,7 @@ export const ApiCategorySchema = z.enum([
   "communication",
   "authentication",
   "google",
+  "ai", // AI/LLM providers (OpenRouter, DashScope, Cloudflare AI, Vercel AI, custom)
   "other",
 ]);
 

--- a/apps/backend/src/scripts/backfill-ai-platforms-from-env.ts
+++ b/apps/backend/src/scripts/backfill-ai-platforms-from-env.ts
@@ -1,0 +1,244 @@
+/**
+ * Backfill AI platform rows in the SocialPlatform table from existing
+ * environment variables.
+ *
+ * Reads:
+ *   OPENROUTER_API_KEY
+ *   DASHSCOPE_API_KEY
+ *   STOREFRONT_SEARCH_DASHSCOPE_MODEL      (defaults to qwen-turbo)
+ *   CLOUDFLARE_AI_ACCOUNT_ID
+ *   CLOUDFLARE_AI_TOKEN
+ *   STOREFRONT_SEARCH_CLOUDFLARE_MODEL     (defaults to @cf/meta/llama-3.1-8b-instruct)
+ *   PRODUCT_SEARCH_EMBED_PROVIDER          (decides which platform owns
+ *                                          ai_search_embed if any)
+ *
+ * Creates one platform per (provider, role) pair, with `metadata.role`,
+ * `metadata.provider_type`, and `metadata.is_default` set so the new
+ * lookup (mastra/services/ai-platforms.ts) picks them up. The credentials
+ * subscriber encrypts api_key in place after creation.
+ *
+ * Priority for the `is_default` flag mirrors the env-fallback chain
+ * already in extract.ts: OpenRouter > DashScope > Cloudflare for chat.
+ * Embed picks the explicit PRODUCT_SEARCH_EMBED_PROVIDER (or DashScope
+ * when nothing is set and only DashScope creds are present, etc.).
+ *
+ * Idempotent: looks for an existing platform with the same name first
+ * and skips if found. To force-re-create, delete the row in the admin
+ * UI before re-running.
+ *
+ * Usage:
+ *   pnpm --filter @jyt/backend exec medusa exec \
+ *     ./src/scripts/backfill-ai-platforms-from-env.ts
+ *
+ * Options (env):
+ *   DRY_RUN=1                Print what would be created, don't write
+ */
+import { ExecArgs } from "@medusajs/framework/types"
+import {
+  ContainerRegistrationKeys,
+  Modules,
+} from "@medusajs/framework/utils"
+import { createSocialPlatformWorkflow } from "../workflows/socials/create-social-platform"
+import { SOCIALS_MODULE } from "../modules/socials"
+import type SocialsService from "../modules/socials/service"
+
+type ProviderType =
+  | "openrouter"
+  | "dashscope"
+  | "cloudflare"
+  | "vercel_ai_gateway"
+  | "custom"
+
+type Role = "ai_search_chat" | "ai_search_embed" | "ai_product_description"
+
+type PlatformPlan = {
+  name: string
+  provider_type: ProviderType
+  role: Role
+  is_default: boolean
+  api_key: string
+  base_url?: string
+  account_id?: string
+  default_model?: string
+}
+
+const planFromEnv = (): PlatformPlan[] => {
+  const plans: PlatformPlan[] = []
+
+  // ── Chat role: OpenRouter (default if present) → DashScope → Cloudflare ──
+  let chatDefaultClaimed = false
+  if (process.env.OPENROUTER_API_KEY) {
+    plans.push({
+      name: "OpenRouter (env backfill)",
+      provider_type: "openrouter",
+      role: "ai_search_chat",
+      is_default: true,
+      api_key: process.env.OPENROUTER_API_KEY,
+      default_model:
+        process.env.OPENROUTER_DEFAULT_MODEL ||
+        "meta-llama/llama-3.3-70b-instruct:free",
+    })
+    chatDefaultClaimed = true
+  }
+  if (process.env.DASHSCOPE_API_KEY) {
+    plans.push({
+      name: "DashScope chat (env backfill)",
+      provider_type: "dashscope",
+      role: "ai_search_chat",
+      is_default: !chatDefaultClaimed,
+      api_key: process.env.DASHSCOPE_API_KEY,
+      default_model:
+        process.env.STOREFRONT_SEARCH_DASHSCOPE_MODEL || "qwen-turbo",
+    })
+    chatDefaultClaimed = true
+  }
+  if (process.env.CLOUDFLARE_AI_ACCOUNT_ID && process.env.CLOUDFLARE_AI_TOKEN) {
+    plans.push({
+      name: "Cloudflare AI chat (env backfill)",
+      provider_type: "cloudflare",
+      role: "ai_search_chat",
+      is_default: !chatDefaultClaimed,
+      api_key: process.env.CLOUDFLARE_AI_TOKEN,
+      account_id: process.env.CLOUDFLARE_AI_ACCOUNT_ID,
+      default_model:
+        process.env.STOREFRONT_SEARCH_CLOUDFLARE_MODEL ||
+        "@cf/meta/llama-3.1-8b-instruct",
+    })
+  }
+
+  // ── Embed role: driven by PRODUCT_SEARCH_EMBED_PROVIDER ────────────────
+  // We only create rows for cloud-hosted embed providers (HF local has no
+  // credentials to migrate). The default is set on whichever matches the
+  // env switch.
+  const embedProvider = String(
+    process.env.PRODUCT_SEARCH_EMBED_PROVIDER ||
+      process.env.ADMIN_RAG_EMBED_PROVIDER ||
+      "hf_local"
+  )
+    .trim()
+    .toLowerCase()
+
+  if (process.env.DASHSCOPE_API_KEY) {
+    plans.push({
+      name: "DashScope embed (env backfill)",
+      provider_type: "dashscope",
+      role: "ai_search_embed",
+      is_default: embedProvider === "dashscope" || embedProvider === "qwen",
+      api_key: process.env.DASHSCOPE_API_KEY,
+      default_model:
+        process.env.PRODUCT_SEARCH_DASHSCOPE_MODEL || "text-embedding-v3",
+    })
+  }
+  if (process.env.CLOUDFLARE_AI_ACCOUNT_ID && process.env.CLOUDFLARE_AI_TOKEN) {
+    plans.push({
+      name: "Cloudflare AI embed (env backfill)",
+      provider_type: "cloudflare",
+      role: "ai_search_embed",
+      is_default: embedProvider === "cloudflare" || embedProvider === "cf",
+      api_key: process.env.CLOUDFLARE_AI_TOKEN,
+      account_id: process.env.CLOUDFLARE_AI_ACCOUNT_ID,
+      default_model:
+        process.env.PRODUCT_SEARCH_CLOUDFLARE_MODEL ||
+        "@cf/baai/bge-base-en-v1.5",
+    })
+  }
+
+  return plans
+}
+
+export default async function backfillAiPlatformsFromEnv({
+  container,
+}: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const socials = container.resolve(SOCIALS_MODULE) as unknown as SocialsService
+  const DRY_RUN = process.env.DRY_RUN === "1"
+
+  const plans = planFromEnv()
+  if (!plans.length) {
+    logger.info(
+      "[ai-platforms backfill] no AI provider env vars set — nothing to do. " +
+        "Configure OPENROUTER_API_KEY, DASHSCOPE_API_KEY, or " +
+        "CLOUDFLARE_AI_ACCOUNT_ID + CLOUDFLARE_AI_TOKEN and re-run."
+    )
+    return
+  }
+
+  logger.info(
+    `[ai-platforms backfill] planned ${plans.length} platform(s)${
+      DRY_RUN ? " (DRY_RUN)" : ""
+    }`
+  )
+
+  let created = 0
+  let skipped = 0
+
+  for (const plan of plans) {
+    // Idempotency: skip if a platform with this exact name already exists.
+    // Matching by name keeps the script re-runnable; admins can edit a
+    // backfilled row without losing it on re-run.
+    let existing: any[] = []
+    try {
+      existing = await socials.listSocialPlatforms({ name: plan.name }, {})
+    } catch (e: any) {
+      logger.warn(
+        `[ai-platforms backfill] listSocialPlatforms failed for "${plan.name}": ${e?.message ?? e}`
+      )
+    }
+    if (existing?.length) {
+      skipped++
+      logger.info(
+        `[ai-platforms backfill] ↷ already exists: "${plan.name}" (id=${existing[0].id})`
+      )
+      continue
+    }
+
+    logger.info(
+      `[ai-platforms backfill] + ${plan.name} ` +
+        `[provider=${plan.provider_type}, role=${plan.role}, default=${plan.is_default}]`
+    )
+    if (DRY_RUN) {
+      created++
+      continue
+    }
+
+    try {
+      // api_key is sent plaintext; the social-platform-credentials-encryption
+      // subscriber fires on social_platform.created and encrypts in place.
+      const apiConfig: Record<string, unknown> = {
+        api_key: plan.api_key,
+        ...(plan.default_model ? { default_model: plan.default_model } : {}),
+        ...(plan.account_id ? { account_id: plan.account_id } : {}),
+        ...(plan.base_url ? { base_url: plan.base_url } : {}),
+      }
+      await createSocialPlatformWorkflow(container as any).run({
+        input: {
+          name: plan.name,
+          category: "ai",
+          auth_type: "bearer",
+          status: "active",
+          base_url: plan.base_url,
+          api_config: apiConfig,
+          metadata: {
+            provider_type: plan.provider_type,
+            role: plan.role,
+            is_default: plan.is_default,
+            source: "env_backfill",
+          },
+        },
+      })
+      created++
+    } catch (e: any) {
+      logger.error(
+        `[ai-platforms backfill] ✗ failed to create "${plan.name}": ${e?.message ?? e}`
+      )
+    }
+  }
+
+  logger.info(
+    `[ai-platforms backfill] done. created=${created} skipped=${skipped}`
+  )
+  logger.info(
+    `[ai-platforms backfill] next: visit /admin/settings/external-platforms ` +
+      `to verify and (optionally) clear the corresponding env vars.`
+  )
+}


### PR DESCRIPTION
Stacked on top of #242 (which adds the runtime lookup helper). Merge order: #241 → #242 → this.

## Summary

The user-facing other half of the AI provider configuration work.

- **Admin UI**: tailored "Create AI provider" route with provider dropdown driving conditional fields, encrypted-on-save API key
- **Backfill script**: one-shot migration from existing env vars to DB-backed platform rows, so an existing deployment can move to the new config without typing into the UI

After this PR plus #242 merges, admins can manage every AI provider (OpenRouter / DashScope / Cloudflare AI / Vercel AI Gateway / custom OpenAI-compatible) and pick which serves each role (chat extraction, embeddings, product-image descriptions) entirely from `/admin/settings/external-platforms`. Env vars stay valid as fallbacks for deployments that haven't run the backfill.

## What it touches

### `scripts/backfill-ai-platforms-from-env.ts` (new)

Idempotent migration script. Reads the existing AI env vars and creates one SocialPlatform per (provider, role) pair:

| Env var | Platform | Role |
|---|---|---|
| `OPENROUTER_API_KEY` | OpenRouter | `ai_search_chat` |
| `DASHSCOPE_API_KEY` | DashScope | `ai_search_chat`, `ai_search_embed` |
| `CLOUDFLARE_AI_*` | Cloudflare AI | `ai_search_chat`, `ai_search_embed` |

`PRODUCT_SEARCH_EMBED_PROVIDER` selects which embed platform gets `metadata.is_default=true`. Chat-role default goes to the first available provider in the order OpenRouter > DashScope > Cloudflare (matches the env-fallback chain in extract.ts).

Idempotent: skips platforms that already exist by name. Plaintext `api_key` is encrypted in place by the existing social-platform-credentials-encryption subscriber after the create event fires.

Run:
```
pnpm --filter @jyt/backend exec medusa exec \\
  ./src/scripts/backfill-ai-platforms-from-env.ts
# DRY_RUN=1 to preview without writing
```

### Admin UI — Create AI provider

- New route: `/admin/settings/external-platforms/create-ai`
- New component: `components/social-platforms/create-ai-platform-component.tsx`
- New button: "Create AI provider" on the external-platforms list page, next to the existing "Create"

Form: name, provider dropdown, role dropdown, API key (encrypted on save), is-default switch, default model (with provider-specific placeholder), conditional account ID (Cloudflare) / base URL (Vercel AI Gateway + custom). Validation: account ID required for Cloudflare, base URL required for Vercel AI Gateway and custom.

Submits to the existing `POST /admin/social-platforms` with the right `category=ai`, `auth_type=bearer`, `api_config`, and `metadata` shape that `mastra/services/ai-platforms.ts:getAiPlatformForRole` consumes (see #242).

### Plumbing

- `"ai"` added to `ApiCategorySchema` (validators.ts) and to the admin SDK's `ApiCategory` union
- `AdminCreateSocialPlatformPayload` now includes `api_config` — the type was missing it even though the API route accepted it

## Test plan

- [ ] `medusa exec ./src/scripts/backfill-ai-platforms-from-env.ts` creates the expected platforms (start with `DRY_RUN=1` to preview)
- [ ] Re-running the script is a no-op (skipped=N, created=0)
- [ ] After backfill, GET `/admin/social-platforms?category=ai` returns the new rows
- [ ] After backfill, `/store/ai/search` uses the DB-configured provider (verifiable in logs)
- [ ] Admin UI: "Create AI provider" → fill form → save → row appears in list with category=ai, api_key encrypted (api_key field is null, api_key_encrypted populated)
- [ ] Provider-specific validation: pick Cloudflare → account_id becomes required; pick Vercel AI Gateway → base_url becomes required
- [ ] Toggle `is_default` off → the platform is created but the env fallback still wins (existing default platform stays in effect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)