### PR TITLE
fix: lift AI provider config + UI to main (PR #242 + #243 stranded)

### DIFF
--- a/apps/backend/src/admin/components/social-platforms/create-ai-platform-component.tsx
+++ b/apps/backend/src/admin/components/social-platforms/create-ai-platform-component.tsx
@@ -1,0 +1,379 @@
+import { Button, Heading, Input, Select, Switch, Text, toast } from "@medusajs/ui"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "@medusajs/framework/zod"
+import { useCreateSocialPlatform } from "../../hooks/api/social-platforms"
+import { KeyboundForm } from "../utilitites/key-bound-form"
+import { Form } from "../common/form"
+import { RouteFocusModal } from "../modal/route-focus-modal"
+import { useRouteModal } from "../modal/use-route-modal"
+
+/**
+ * Tailored "Create AI provider" form.
+ *
+ * Sits alongside the generic CreateSocialPlatformComponent. We split it
+ * out because the AI shape is small and well-defined (api_key + a few
+ * provider-specific fields), and embedding it as another category branch
+ * inside the already-500-line create-social-platform form would bloat
+ * the validation logic for everyone.
+ *
+ * What this writes:
+ *   - category = "ai"
+ *   - auth_type = "bearer"
+ *   - metadata.provider_type ∈ {openrouter, dashscope, cloudflare, vercel_ai_gateway, custom}
+ *   - metadata.role ∈ {ai_search_chat, ai_search_embed, ai_product_description}
+ *   - metadata.is_default = true/false
+ *   - api_config.api_key (plaintext on the wire — the
+ *     social-platform-credentials-encryption subscriber encrypts in
+ *     place after the create event fires)
+ *   - api_config.default_model
+ *   - api_config.account_id    (cloudflare only)
+ *   - api_config.base_url      (vercel_ai_gateway + custom)
+ *   - base_url (column)        (vercel_ai_gateway + custom, mirrored for searchability)
+ *
+ * Consumed by mastra/services/ai-platforms.ts:getAiPlatformForRole.
+ */
+const ProviderTypeEnum = z.enum([
+  "openrouter",
+  "dashscope",
+  "cloudflare",
+  "vercel_ai_gateway",
+  "custom",
+])
+
+const RoleEnum = z.enum([
+  "ai_search_chat",
+  "ai_search_embed",
+  "ai_product_description",
+])
+
+const Schema = z.object({
+  name: z.string().min(1, "Name is required"),
+  provider_type: ProviderTypeEnum,
+  role: RoleEnum,
+  is_default: z.boolean().optional().default(true),
+  api_key: z.string().min(1, "API key is required"),
+  default_model: z.string().optional(),
+  account_id: z.string().optional(),
+  base_url: z.string().url("Must be a valid URL").optional().or(z.literal("")),
+}).superRefine((data, ctx) => {
+  if (data.provider_type === "cloudflare" && !data.account_id) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["account_id"],
+      message: "Account ID is required for Cloudflare AI",
+    })
+  }
+  if (
+    (data.provider_type === "vercel_ai_gateway" ||
+      data.provider_type === "custom") &&
+    !data.base_url
+  ) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["base_url"],
+      message: "Base URL is required for this provider type",
+    })
+  }
+})
+
+type FormValues = z.infer<typeof Schema>
+
+const PROVIDER_LABELS: Record<z.infer<typeof ProviderTypeEnum>, string> = {
+  openrouter: "OpenRouter",
+  dashscope: "DashScope (Qwen)",
+  cloudflare: "Cloudflare Workers AI",
+  vercel_ai_gateway: "Vercel AI Gateway",
+  custom: "Custom (OpenAI-compatible)",
+}
+
+const ROLE_LABELS: Record<z.infer<typeof RoleEnum>, string> = {
+  ai_search_chat: "Storefront search — chat / extraction",
+  ai_search_embed: "Storefront search — embeddings",
+  ai_product_description: "Product image → description",
+}
+
+const DEFAULT_MODEL_HINTS: Record<z.infer<typeof ProviderTypeEnum>, string> = {
+  openrouter: "meta-llama/llama-3.3-70b-instruct:free",
+  dashscope: "qwen-turbo  (chat) / text-embedding-v3 (embed)",
+  cloudflare: "@cf/meta/llama-3.1-8b-instruct (chat) / @cf/baai/bge-base-en-v1.5 (embed)",
+  vercel_ai_gateway: "openai/gpt-4o-mini",
+  custom: "your-model-id",
+}
+
+export const CreateAiPlatformComponent = () => {
+  const { handleSuccess } = useRouteModal()
+  const { mutateAsync, isPending } = useCreateSocialPlatform()
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(Schema as any),
+    defaultValues: {
+      name: "",
+      provider_type: "openrouter" as const,
+      role: "ai_search_chat" as const,
+      is_default: true,
+      api_key: "",
+      default_model: "",
+      account_id: "",
+      base_url: "",
+    },
+  })
+
+  const providerType = form.watch("provider_type")
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    const apiConfig: Record<string, unknown> = {
+      api_key: values.api_key,
+    }
+    if (values.default_model) apiConfig.default_model = values.default_model
+    if (values.account_id) apiConfig.account_id = values.account_id
+    if (values.base_url) apiConfig.base_url = values.base_url
+
+    try {
+      await mutateAsync({
+        name: values.name,
+        category: "ai",
+        auth_type: "bearer",
+        status: "active",
+        base_url:
+          values.base_url && values.base_url.length > 0
+            ? values.base_url
+            : undefined,
+        api_config: apiConfig,
+        metadata: {
+          provider_type: values.provider_type,
+          role: values.role,
+          is_default: values.is_default ?? true,
+          source: "admin_ui",
+        },
+      })
+      toast.success("AI provider created")
+      handleSuccess("/settings/external-platforms")
+    } catch (e: any) {
+      toast.error(e?.message ?? "Failed to create AI provider")
+    }
+  })
+
+  return (
+    <RouteFocusModal.Form form={form}>
+      <KeyboundForm onSubmit={onSubmit} className="flex h-full flex-col">
+        <RouteFocusModal.Header>
+          <div className="flex items-center justify-end gap-x-2">
+            <RouteFocusModal.Close asChild>
+              <Button size="small" variant="secondary">
+                Cancel
+              </Button>
+            </RouteFocusModal.Close>
+            <Button
+              size="small"
+              variant="primary"
+              type="submit"
+              isLoading={isPending}
+            >
+              Save
+            </Button>
+          </div>
+        </RouteFocusModal.Header>
+        <RouteFocusModal.Body className="flex flex-col items-center overflow-y-auto p-16">
+          <div className="flex w-full max-w-[640px] flex-col gap-y-8">
+            <div>
+              <Heading>Create AI provider</Heading>
+              <Text size="small" className="text-ui-fg-subtle">
+                Configure a chat or embedding provider that storefront
+                search and AI-using workflows will pick up at runtime.
+                The API key is encrypted on save.
+              </Text>
+            </div>
+
+            <Form.Field
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label>Name</Form.Label>
+                  <Form.Control>
+                    <Input
+                      {...field}
+                      placeholder="e.g. OpenRouter free, DashScope qwen, CF Workers AI"
+                    />
+                  </Form.Control>
+                  <Form.ErrorMessage />
+                </Form.Item>
+              )}
+            />
+
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <Form.Field
+                control={form.control}
+                name="provider_type"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label>Provider</Form.Label>
+                    <Form.Control>
+                      <Select
+                        value={field.value}
+                        onValueChange={field.onChange}
+                      >
+                        <Select.Trigger>
+                          <Select.Value placeholder="Select provider" />
+                        </Select.Trigger>
+                        <Select.Content>
+                          {Object.entries(PROVIDER_LABELS).map(([v, label]) => (
+                            <Select.Item key={v} value={v}>
+                              {label}
+                            </Select.Item>
+                          ))}
+                        </Select.Content>
+                      </Select>
+                    </Form.Control>
+                    <Form.ErrorMessage />
+                  </Form.Item>
+                )}
+              />
+
+              <Form.Field
+                control={form.control}
+                name="role"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label>Role</Form.Label>
+                    <Form.Control>
+                      <Select
+                        value={field.value}
+                        onValueChange={field.onChange}
+                      >
+                        <Select.Trigger>
+                          <Select.Value placeholder="Select role" />
+                        </Select.Trigger>
+                        <Select.Content>
+                          {Object.entries(ROLE_LABELS).map(([v, label]) => (
+                            <Select.Item key={v} value={v}>
+                              {label}
+                            </Select.Item>
+                          ))}
+                        </Select.Content>
+                      </Select>
+                    </Form.Control>
+                    <Form.ErrorMessage />
+                  </Form.Item>
+                )}
+              />
+            </div>
+
+            <Form.Field
+              control={form.control}
+              name="api_key"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label>API key</Form.Label>
+                  <Form.Control>
+                    <Input
+                      {...field}
+                      type="password"
+                      placeholder="sk-…"
+                      autoComplete="off"
+                    />
+                  </Form.Control>
+                  <Form.Hint>
+                    Stored encrypted via the encryption subscriber on save.
+                  </Form.Hint>
+                  <Form.ErrorMessage />
+                </Form.Item>
+              )}
+            />
+
+            {providerType === "cloudflare" && (
+              <Form.Field
+                control={form.control}
+                name="account_id"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label>Cloudflare account ID</Form.Label>
+                    <Form.Control>
+                      <Input
+                        {...field}
+                        placeholder="e.g. 9719d38e64dffe8fd6982afb3a7b25f6"
+                      />
+                    </Form.Control>
+                    <Form.Hint>
+                      Used to construct the base URL{" "}
+                      <code>api.cloudflare.com/.../{`<account_id>`}/ai/v1</code>.
+                    </Form.Hint>
+                    <Form.ErrorMessage />
+                  </Form.Item>
+                )}
+              />
+            )}
+
+            {(providerType === "vercel_ai_gateway" ||
+              providerType === "custom") && (
+              <Form.Field
+                control={form.control}
+                name="base_url"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label>Base URL</Form.Label>
+                    <Form.Control>
+                      <Input
+                        {...field}
+                        type="url"
+                        placeholder="https://gateway.example.com/v1"
+                      />
+                    </Form.Control>
+                    <Form.ErrorMessage />
+                  </Form.Item>
+                )}
+              />
+            )}
+
+            <Form.Field
+              control={form.control}
+              name="default_model"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label optional>Default model</Form.Label>
+                  <Form.Control>
+                    <Input
+                      {...field}
+                      placeholder={DEFAULT_MODEL_HINTS[providerType]}
+                    />
+                  </Form.Control>
+                  <Form.Hint>
+                    Optional. If empty, a provider-specific default is used.
+                  </Form.Hint>
+                  <Form.ErrorMessage />
+                </Form.Item>
+              )}
+            />
+
+            <Form.Field
+              control={form.control}
+              name="is_default"
+              render={({ field }) => (
+                <Form.Item>
+                  <div className="flex items-center justify-between gap-4">
+                    <div className="flex flex-col">
+                      <Form.Label>Default for this role</Form.Label>
+                      <Text size="small" className="text-ui-fg-subtle">
+                        Only one platform per role should be default. The
+                        runtime picks the default; other platforms are
+                        available as alternatives.
+                      </Text>
+                    </div>
+                    <Form.Control>
+                      <Switch
+                        checked={field.value === true}
+                        onCheckedChange={(v: boolean) => field.onChange(v)}
+                      />
+                    </Form.Control>
+                  </div>
+                  <Form.ErrorMessage />
+                </Form.Item>
+              )}
+            />
+          </div>
+        </RouteFocusModal.Body>
+      </KeyboundForm>
+    </RouteFocusModal.Form>
+  )
+}

--- a/apps/backend/src/admin/hooks/api/social-platforms.ts
+++ b/apps/backend/src/admin/hooks/api/social-platforms.ts
@@ -26,6 +26,7 @@ export type ApiCategory =
   | "communication"
   | "authentication"
   | "google"
+  | "ai"
   | "other"
 
 export type AuthType = 
@@ -73,6 +74,7 @@ export type AdminCreateSocialPlatformPayload = {
   base_url?: string
   description?: string
   status?: PlatformStatus
+  api_config?: Record<string, any>
   metadata?: Record<string, any>
 }
 

--- a/apps/backend/src/admin/routes/settings/external-platforms/create-ai/page.tsx
+++ b/apps/backend/src/admin/routes/settings/external-platforms/create-ai/page.tsx
@@ -1,0 +1,10 @@
+import { CreateAiPlatformComponent } from "../../../../components/social-platforms/create-ai-platform-component"
+import { RouteFocusModal } from "../../../../components/modal/route-focus-modal"
+
+const CreateAiPlatformPage = () => (
+  <RouteFocusModal>
+    <CreateAiPlatformComponent />
+  </RouteFocusModal>
+)
+
+export default CreateAiPlatformPage

--- a/apps/backend/src/admin/routes/settings/external-platforms/page.tsx
+++ b/apps/backend/src/admin/routes/settings/external-platforms/page.tsx
@@ -188,6 +188,15 @@ const SocialPlatformPage = () => {
               <Button
                 size="small"
                 variant="secondary"
+                onClick={() =>
+                  navigate("/settings/external-platforms/create-ai")
+                }
+              >
+                Create AI provider
+              </Button>
+              <Button
+                size="small"
+                variant="secondary"
                 onClick={() => navigate("/settings/external-platforms/create")}
               >
                 Create

--- a/apps/backend/src/api/admin/social-platforms/validators.ts
+++ b/apps/backend/src/api/admin/social-platforms/validators.ts
@@ -13,6 +13,7 @@ export const ApiCategorySchema = z.enum([
   "communication",
   "authentication",
   "google",
+  "ai", // AI/LLM providers (OpenRouter, DashScope, Cloudflare AI, Vercel AI, custom)
   "other",
 ]);
 

--- a/apps/backend/src/api/store/ai/search/extract.ts
+++ b/apps/backend/src/api/store/ai/search/extract.ts
@@ -1,33 +1,35 @@
 /**
  * LLM extraction layer for /store/ai/search.
  *
- * Tries provider chain in this order, returning the first that succeeds:
+ * Provider resolution order:
  *
- *   1. OpenRouter (free models only). Uses the existing
- *      mastra/providers/dynamic-text-model resolver, which auto-selects
- *      the best currently-available free model from the live OpenRouter
- *      catalogue and evicts models whose free tier has ended.
+ *   1. **DB-configured AI platform** for role `ai_search_chat` (admin
+ *      configured one in Settings → External Platforms). When present,
+ *      this is the ONLY provider we try — admins picked it deliberately,
+ *      so silently switching to env-var providers on a model error
+ *      would mask configuration problems.
  *
- *   2. DashScope (Qwen) via its OpenAI-compatible endpoint. Used when
- *      DASHSCOPE_API_KEY is set — the user has credits there so this is
- *      a reliable paid fallback. Default model qwen-turbo (cheap, fast,
- *      tool-use capable); override with STOREFRONT_SEARCH_DASHSCOPE_MODEL.
+ *   2. **Env-var fallback chain** when no DB platform is configured.
+ *      Tried in this order, first success wins:
+ *        a. OpenRouter free models via the existing
+ *           dynamicFreeTextModel resolver
+ *        b. DashScope (Qwen) when DASHSCOPE_API_KEY is set
+ *        c. Cloudflare Workers AI when CLOUDFLARE_AI_ACCOUNT_ID +
+ *           CLOUDFLARE_AI_TOKEN are set
  *
- *   3. Cloudflare Workers AI via its OpenAI-compatible endpoint at
- *      api.cloudflare.com/client/v4/accounts/<id>/ai/v1. Used when both
- *      CLOUDFLARE_AI_ACCOUNT_ID and CLOUDFLARE_AI_TOKEN are set. Default
- *      model @cf/meta/llama-3.1-8b-instruct (also tool-use capable);
- *      override with STOREFRONT_SEARCH_CLOUDFLARE_MODEL.
- *
- * If all three fail (no providers configured, all rate-limited, schema
- * mismatch from a particular model, etc.) we fall back to treating the
- * raw query as a single keyword so search still works — just without
- * the LLM enrichment.
+ *   3. If everything fails (no providers, all rate-limited, schema
+ *      mismatch) we fall back to treating the raw query as a single
+ *      keyword so search still works — just without the LLM enrichment.
  */
+import type { MedusaContainer } from "@medusajs/framework"
 import { createOpenAI } from "@ai-sdk/openai"
 import { generateObject } from "ai"
 import { z } from "zod"
 import { dynamicFreeTextModel } from "../../../../mastra/providers/dynamic-text-model"
+import {
+  buildChatModel,
+  getAiPlatformForRole,
+} from "../../../../mastra/services/ai-platforms"
 
 const SearchInterpretationSchema = z.object({
   keywords: z
@@ -168,14 +170,54 @@ const buildAttempts = (query: string): Attempt[] => {
 
 /**
  * Convert a natural-language shopper query into a small structured
- * interpretation. Walks the provider chain in order, returning the
- * first successful result. If every provider fails (or none are
- * configured), falls back to treating the raw query as a single
- * keyword so /store/ai/search degrades gracefully to lexical search.
+ * interpretation.
+ *
+ * If the admin has configured a platform for role `ai_search_chat`
+ * we use that exclusively. Otherwise we walk the env-var fallback
+ * chain (OpenRouter free → DashScope → Cloudflare). All-failures
+ * degrade to a single-keyword interpretation so search still works.
  */
 export const extractSearchInterpretation = async (
-  query: string
+  query: string,
+  container?: MedusaContainer
 ): Promise<SearchInterpretation> => {
+  const opts = {
+    schema: SearchInterpretationSchema,
+    system: SYSTEM_PROMPT,
+    prompt: query,
+    temperature: 0.1,
+  }
+
+  // 1. DB-configured platform — wins if present.
+  if (container) {
+    try {
+      const cfg = await getAiPlatformForRole(container, "ai_search_chat")
+      if (cfg) {
+        try {
+          const { object } = await generateObject({
+            ...opts,
+            model: buildChatModel(cfg),
+          })
+          return object
+        } catch (e: any) {
+          console.warn(
+            `[store/ai/search] db-platform ${cfg.platformId} (${cfg.providerType}) failed:`,
+            e?.message ?? e
+          )
+          // Fall through to env chain — better degraded behaviour
+          // than failing the search outright when one DB-configured
+          // provider has a transient issue.
+        }
+      }
+    } catch (e: any) {
+      console.warn(
+        "[store/ai/search] getAiPlatformForRole failed:",
+        e?.message ?? e
+      )
+    }
+  }
+
+  // 2. Env-var chain (legacy / unconfigured deployments).
   const attempts = buildAttempts(query)
   for (const attempt of attempts) {
     try {

--- a/apps/backend/src/api/store/ai/search/route.ts
+++ b/apps/backend/src/api/store/ai/search/route.ts
@@ -85,15 +85,27 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const { query, limit } = (req as any).validatedBody as StoreAiSearchReq
   const queryService = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
-  // 1. Interpret the query.
-  const interpretation = await extractSearchInterpretation(query)
+  // 1. Interpret the query. Passes req.scope so the extractor can
+  // resolve the admin-configured AI platform for role "ai_search_chat";
+  // when none is configured the extractor walks the env-var fallback
+  // chain (OpenRouter free → DashScope → Cloudflare).
+  const interpretation = await extractSearchInterpretation(
+    query,
+    req.scope as any
+  )
 
-  // 2. Try vector search first.
+  // 2. Try vector search first. Pass req.scope so productCatalog can
+  // resolve the admin-configured embedding platform for role
+  // ai_search_embed (env fallback when unconfigured).
   const enriched = buildEnrichedQuery(query, interpretation)
   let productIds: string[] = []
   let mode: "vector" | "lexical" = "vector"
   try {
-    const hits = await searchProducts(enriched, Math.max(limit * 3, 24))
+    const hits = await searchProducts(
+      enriched,
+      Math.max(limit * 3, 24),
+      req.scope as any
+    )
     productIds = hits.map((h) => h.product_id).filter(Boolean)
   } catch {
     productIds = []

--- a/apps/backend/src/mastra/rag/productCatalog.ts
+++ b/apps/backend/src/mastra/rag/productCatalog.ts
@@ -10,12 +10,19 @@
  * the admin RAG (which indexes API endpoints) and the storefront search
  * (which indexes products) can evolve independently.
  *
- * Embedding provider selection (env: PRODUCT_SEARCH_EMBED_PROVIDER):
- *   • hf_local    — Xenova/all-MiniLM-L6-v2, 384 dims, runs in-process (default)
- *   • google      — text-embedding-004, 768 dims, needs GOOGLE_GENERATIVE_AI_API_KEY
- *   • dashscope   — text-embedding-v3, 1024 dims, needs DASHSCOPE_API_KEY
- *   • cloudflare  — @cf/baai/bge-base-en-v1.5, 768 dims, needs
- *                   CLOUDFLARE_AI_ACCOUNT_ID + CLOUDFLARE_AI_TOKEN
+ * Embedding provider resolution order:
+ *
+ *   1. DB-configured platform for role `ai_search_embed` (admin UI:
+ *      Settings → External Platforms with category=ai, metadata.role=
+ *      ai_search_embed, metadata.is_default=true). When set, this takes
+ *      precedence — the admin picked it deliberately.
+ *
+ *   2. PRODUCT_SEARCH_EMBED_PROVIDER env var:
+ *        • hf_local    — Xenova/all-MiniLM-L6-v2, 384 dims (default)
+ *        • google      — text-embedding-004, 768 dims, needs GOOGLE_GENERATIVE_AI_API_KEY
+ *        • dashscope   — text-embedding-v3, 1024 dims, needs DASHSCOPE_API_KEY
+ *        • cloudflare  — @cf/baai/bge-base-en-v1.5, 768 dims, needs
+ *                        CLOUDFLARE_AI_ACCOUNT_ID + CLOUDFLARE_AI_TOKEN
  *
  * IMPORTANT: switching providers changes the vector dimension, which is
  * incompatible with the existing PgVector index. Changing provider means:
@@ -25,11 +32,16 @@
  * The LLM extraction layer (extract.ts) DOES fall back across providers
  * because each call is independent, but embeddings have to commit.
  */
+import type { MedusaContainer } from "@medusajs/framework"
 import { createOpenAI } from "@ai-sdk/openai"
 import { PgVector } from "@mastra/pg"
 import { embedMany } from "ai"
 import { google } from "@ai-sdk/google"
 import crypto from "crypto"
+import {
+  buildEmbeddingModel,
+  getAiPlatformForRole,
+} from "../services/ai-platforms"
 
 const INDEX_NAME = "product_search_v1"
 const HF_DEFAULT_MODEL = "Xenova/all-MiniLM-L6-v2"
@@ -106,8 +118,33 @@ const getCloudflareClient = () => {
   return _cloudflareClient
 }
 
-export const embedTexts = async (values: string[]): Promise<number[][]> => {
+export const embedTexts = async (
+  values: string[],
+  container?: MedusaContainer
+): Promise<number[][]> => {
   if (!values.length) return []
+
+  // 1. DB-configured platform wins when present and successful. We only
+  // try the env fallback if no platform is configured — if the admin
+  // set up a platform that's failing, surfacing the error rather than
+  // silently switching is more honest.
+  if (container) {
+    try {
+      const cfg = await getAiPlatformForRole(container, "ai_search_embed")
+      if (cfg) {
+        const model = buildEmbeddingModel(cfg)
+        const { embeddings } = await embedMany({ model, values })
+        return embeddings as number[][]
+      }
+    } catch (e: any) {
+      console.warn(
+        "[productCatalog] db-configured embed platform failed; falling through to env:",
+        e?.message ?? e
+      )
+    }
+  }
+
+  // 2. Env-var path (existing logic).
   const provider = getEmbeddingProvider()
   if (provider === "hf_local") {
     const extractor = await getHfExtractor()
@@ -247,7 +284,8 @@ export type UpsertResult = {
  * back with the same text_hash, we skip the re-embed.
  */
 export const upsertProducts = async (
-  products: IndexableProduct[]
+  products: IndexableProduct[],
+  container?: MedusaContainer
 ): Promise<UpsertResult> => {
   const result: UpsertResult = { upserted: 0, skipped: 0, errors: 0 }
   if (!products.length) return result
@@ -295,7 +333,7 @@ export const upsertProducts = async (
   for (let i = 0; i < toEmbed.length; i += BATCH) {
     const slice = toEmbed.slice(i, i + BATCH)
     try {
-      const embeddings = await embedTexts(slice.map((c) => c.text))
+      const embeddings = await embedTexts(slice.map((c) => c.text), container)
       vectors.push(...embeddings)
     } catch (e) {
       console.warn("[productCatalog] embed batch failed", (e as any)?.message)
@@ -353,12 +391,13 @@ export type ProductSearchHit = {
  */
 export const searchProducts = async (
   query: string,
-  topK = 12
+  topK = 12,
+  container?: MedusaContainer
 ): Promise<ProductSearchHit[]> => {
   if (!query.trim()) return []
   let queryVector: number[] = []
   try {
-    const [v] = await embedTexts([query])
+    const [v] = await embedTexts([query], container)
     queryVector = Array.isArray(v) ? v : []
   } catch (e) {
     console.warn("[productCatalog] query embed failed", (e as any)?.message)

--- a/apps/backend/src/mastra/services/AI_PLATFORMS_CONFIG.md
+++ b/apps/backend/src/mastra/services/AI_PLATFORMS_CONFIG.md
@@ -1,0 +1,129 @@
+# AI platforms — admin configuration
+
+This is the JSON shape an admin enters in `Settings → External Platforms →
+Create` to register an AI provider that the storefront search (and any
+future AI-using workflow) will pick up at runtime.
+
+Until a tailored "Create AI provider" form lands (follow-up), use the
+generic create flow with these fields:
+
+| Field | Value |
+|---|---|
+| `name` | Human-readable label (e.g. "OpenRouter free models") |
+| `category` | `ai` |
+| `auth_type` | `bearer` (or `api_key`) |
+| `status` | `active` |
+| `base_url` | Provider base URL — optional, defaults are computed per `provider_type` |
+| `api_config` (JSON) | See per-provider examples below |
+| `metadata` (JSON) | `{ "provider_type": "...", "role": "...", "is_default": true }` |
+
+## Roles supported in v1
+
+| `metadata.role` | Used by |
+|---|---|
+| `ai_search_chat` | `/store/ai/search` LLM extraction of structured filters |
+| `ai_search_embed` | `/store/ai/search` vector embedding for product search |
+| `ai_product_description` | `workflows/ai/describe-product-image` (existing) |
+
+Exactly one platform per role should have `metadata.is_default = true`.
+A platform can serve multiple roles by creating multiple platform rows
+(one per role) sharing the same underlying credentials.
+
+## Provider types
+
+### `openrouter`
+
+```json
+api_config: {
+  "api_key_encrypted": "<encrypted via the Access tab>",
+  "default_model": "meta-llama/llama-3.3-70b-instruct:free"
+}
+metadata: { "provider_type": "openrouter", "role": "ai_search_chat", "is_default": true }
+```
+
+`base_url` defaults to `https://openrouter.ai/api/v1`. Use `:free` model
+suffixes to constrain to the free tier.
+
+### `dashscope`
+
+```json
+api_config: {
+  "api_key_encrypted": "<encrypted>",
+  "default_model": "qwen-turbo"
+}
+metadata: { "provider_type": "dashscope", "role": "ai_search_chat", "is_default": true }
+```
+
+`base_url` defaults to
+`https://dashscope-intl.aliyuncs.com/compatible-mode/v1`. For embeddings,
+use `default_model: "text-embedding-v3"` (1024 dims).
+
+### `cloudflare`
+
+```json
+api_config: {
+  "api_key_encrypted": "<encrypted CF API token>",
+  "account_id": "<your CF account id>",
+  "default_model": "@cf/meta/llama-3.1-8b-instruct"
+}
+metadata: { "provider_type": "cloudflare", "role": "ai_search_chat", "is_default": true }
+```
+
+`base_url` is derived from `account_id` —
+`https://api.cloudflare.com/client/v4/accounts/<account_id>/ai/v1`.
+For embeddings, use `default_model: "@cf/baai/bge-base-en-v1.5"` (768 dims).
+
+### `vercel_ai_gateway`
+
+```json
+api_config: {
+  "api_key_encrypted": "<encrypted>",
+  "default_model": "openai/gpt-4o-mini",
+  "base_url": "https://gateway.example.com/v1"
+}
+metadata: { "provider_type": "vercel_ai_gateway", "role": "ai_search_chat", "is_default": true }
+```
+
+`base_url` is required — the gateway URL is account-specific.
+
+### `custom`
+
+Any OpenAI-compatible endpoint not covered above.
+
+```json
+api_config: {
+  "api_key_encrypted": "<encrypted>",
+  "base_url": "https://my-llm-proxy.example.com/v1",
+  "default_model": "my-model"
+}
+metadata: { "provider_type": "custom", "role": "ai_search_chat", "is_default": true }
+```
+
+## Embedding provider dimension lock-in
+
+Switching the platform used for `ai_search_embed` changes the vector
+dimension of new embeddings, which is incompatible with the existing
+PgVector index. When switching:
+
+1. Drop the index: `psql $DATABASE_URL -c "DROP TABLE IF EXISTS product_search_v1 CASCADE;"`
+2. Re-run the backfill: `pnpm --filter @jyt/backend exec medusa exec ./src/scripts/backfill-product-search.ts`
+
+Dimensions per provider:
+
+| Provider | Dims |
+|---|---|
+| HF local Xenova/all-MiniLM-L6-v2 | 384 |
+| Google text-embedding-004 | 768 |
+| Cloudflare @cf/baai/bge-base-en-v1.5 | 768 |
+| DashScope text-embedding-v3 | 1024 |
+
+## Fallback behaviour
+
+When no platform is configured for a role, the system falls back to env
+vars — every existing deployment continues to work unchanged:
+
+| Role | Env fallback |
+|---|---|
+| `ai_search_chat` | OpenRouter free → DashScope (`DASHSCOPE_API_KEY`) → Cloudflare (`CLOUDFLARE_AI_*`) |
+| `ai_search_embed` | `PRODUCT_SEARCH_EMBED_PROVIDER` (default `hf_local`) |
+| `ai_product_description` | Existing `metadata.role = ai_product_description` lookup (predates this PR) |

--- a/apps/backend/src/mastra/services/ai-platforms.ts
+++ b/apps/backend/src/mastra/services/ai-platforms.ts
@@ -1,0 +1,291 @@
+/**
+ * AI platform resolution.
+ *
+ * Looks up an AI provider configured via the admin
+ * "External Platforms" UI (Settings → External Platforms with
+ * category="ai") and returns a normalised config the callers
+ * (`extract.ts`, `productCatalog.ts`, …) can feed into the AI SDK.
+ *
+ * Provider abstraction:
+ *   - `provider_type` (on platform.metadata) selects which AI SDK
+ *     adapter to use. We support five today:
+ *
+ *       openrouter         — uses @openrouter/ai-sdk-provider
+ *       dashscope          — OpenAI-compatible, base
+ *                            dashscope-intl.aliyuncs.com/compatible-mode/v1
+ *       cloudflare         — OpenAI-compatible, base
+ *                            api.cloudflare.com/client/v4/accounts/<id>/ai/v1
+ *       vercel_ai_gateway  — OpenAI-compatible Vercel AI Gateway endpoint
+ *       custom             — any OpenAI-compatible endpoint with
+ *                            api_config.base_url required
+ *
+ * Role assignment:
+ *   - Each "role" (ai_search_chat, ai_search_embed,
+ *     ai_product_description, …) has at most one default platform.
+ *   - Selection: platform with `metadata.role === role` AND
+ *     `metadata.is_default === true` AND `status === "active"`.
+ *   - If multiple platforms match, the most-recently-updated wins
+ *     (defensive — a uniqueness check should land at the write side).
+ *
+ * Fallback strategy:
+ *   - This helper resolves DB-backed config only. If no platform is
+ *     configured for a role, returns null and the caller falls back
+ *     to environment variables. That keeps existing deployments
+ *     working without any UI configuration.
+ */
+import type { MedusaContainer } from "@medusajs/framework"
+import { SOCIALS_MODULE } from "../../modules/socials"
+import type SocialsService from "../../modules/socials/service"
+import { decryptApiKey } from "../../modules/socials/utils/token-helpers"
+
+export type AiProviderType =
+  | "openrouter"
+  | "dashscope"
+  | "cloudflare"
+  | "vercel_ai_gateway"
+  | "custom"
+
+export type AiRole =
+  | "ai_search_chat"
+  | "ai_search_embed"
+  | "ai_product_description"
+  // String escape hatch so callers can use ad-hoc roles without
+  // bumping this union every time.
+  | (string & {})
+
+export type AiPlatformConfig = {
+  platformId: string
+  providerType: AiProviderType
+  apiKey: string
+  baseUrl: string
+  /** Default model id stored on the platform — null if the admin
+   * didn't set one (the caller picks their own default). */
+  defaultModel: string | null
+  /** Only set for provider_type=cloudflare. */
+  accountId?: string
+}
+
+const PROVIDER_DEFAULTS: Record<
+  AiProviderType,
+  { baseUrl?: string; defaultModelHint?: string }
+> = {
+  openrouter: {
+    baseUrl: "https://openrouter.ai/api/v1",
+    defaultModelHint: "meta-llama/llama-3.3-70b-instruct:free",
+  },
+  dashscope: {
+    baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+    defaultModelHint: "qwen-turbo",
+  },
+  cloudflare: {
+    // Filled in dynamically with the account id when read.
+    defaultModelHint: "@cf/meta/llama-3.1-8b-instruct",
+  },
+  vercel_ai_gateway: {
+    baseUrl: "https://gateway.ai.cloudflare.com/v1", // overridable; admin
+    // can set api_config.base_url for the actual endpoint.
+  },
+  custom: {},
+}
+
+const normalizeProviderType = (raw: unknown): AiProviderType | null => {
+  const s = String(raw ?? "").trim().toLowerCase()
+  switch (s) {
+    case "openrouter":
+      return "openrouter"
+    case "dashscope":
+    case "qwen":
+      return "dashscope"
+    case "cloudflare":
+    case "cf":
+    case "workers_ai":
+    case "workers-ai":
+      return "cloudflare"
+    case "vercel":
+    case "vercel_ai":
+    case "vercel_ai_gateway":
+    case "vercel-ai-gateway":
+      return "vercel_ai_gateway"
+    case "custom":
+    case "openai_compatible":
+    case "openai-compatible":
+      return "custom"
+    default:
+      return null
+  }
+}
+
+/**
+ * Resolve an AI platform from the DB for the given role. Returns null
+ * if nothing is configured — caller falls back to env vars.
+ */
+export const getAiPlatformForRole = async (
+  container: MedusaContainer,
+  role: AiRole
+): Promise<AiPlatformConfig | null> => {
+  let socials: SocialsService
+  try {
+    socials = container.resolve(SOCIALS_MODULE) as unknown as SocialsService
+  } catch {
+    return null
+  }
+
+  let platforms: any[] = []
+  try {
+    platforms = await socials.listSocialPlatforms(
+      {
+        category: "ai",
+        status: "active",
+        // Filter narrows on the metadata.role tag the admin set. We
+        // can't easily filter `metadata.is_default` in the DAL, so we
+        // do that JS-side after the fetch.
+        metadata: { role },
+      } as any,
+      { take: 10 }
+    )
+  } catch (e) {
+    console.warn(
+      "[ai-platforms] listSocialPlatforms failed:",
+      (e as any)?.message ?? e
+    )
+    return null
+  }
+
+  // Pick the one explicitly marked as default for this role; if no
+  // explicit default, pick the most recently updated of the candidates.
+  const candidates = (platforms ?? []).filter(
+    (p) => p?.metadata?.is_default === true
+  )
+  const chosen = candidates[0] ?? platforms[0]
+  if (!chosen) return null
+
+  const apiConfig = (chosen.api_config ?? {}) as Record<string, any>
+  const meta = (chosen.metadata ?? {}) as Record<string, any>
+
+  const providerType = normalizeProviderType(
+    meta.provider_type ?? apiConfig.provider_type
+  )
+  if (!providerType) {
+    console.warn(
+      `[ai-platforms] platform ${chosen.id} has no recognised provider_type`
+    )
+    return null
+  }
+
+  const apiKey = decryptApiKey(apiConfig, container)
+  if (!apiKey) {
+    console.warn(
+      `[ai-platforms] platform ${chosen.id} is missing api_key — skipping`
+    )
+    return null
+  }
+
+  // Resolve baseUrl in order of priority:
+  //   1. api_config.base_url (admin override)
+  //   2. platform.base_url (column)
+  //   3. provider default
+  const accountId =
+    apiConfig.account_id ?? meta.account_id ?? undefined
+  let baseUrl: string | undefined =
+    apiConfig.base_url ?? chosen.base_url ?? PROVIDER_DEFAULTS[providerType].baseUrl
+  if (providerType === "cloudflare" && !apiConfig.base_url && !chosen.base_url) {
+    if (!accountId) {
+      console.warn(
+        `[ai-platforms] cloudflare platform ${chosen.id} has no account_id; can't derive base_url`
+      )
+      return null
+    }
+    baseUrl = `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/v1`
+  }
+  if (!baseUrl) {
+    console.warn(
+      `[ai-platforms] platform ${chosen.id} (provider=${providerType}) has no base_url`
+    )
+    return null
+  }
+
+  return {
+    platformId: chosen.id,
+    providerType,
+    apiKey,
+    baseUrl,
+    defaultModel: apiConfig.default_model ?? meta.default_model ?? null,
+    accountId,
+  }
+}
+
+// ── AI SDK adapters ────────────────────────────────────────────────────
+
+import { createOpenAI } from "@ai-sdk/openai"
+import { createOpenRouter } from "@openrouter/ai-sdk-provider"
+
+/**
+ * Build an AI SDK chat/language model from a resolved platform config.
+ * Used with generateObject, generateText, streamText.
+ *
+ * `modelOverride` lets the caller pick a model at the call site,
+ * defaulting to the platform's `default_model`, and falling back to
+ * the provider-specific hint when nothing is configured.
+ */
+export const buildChatModel = (
+  config: AiPlatformConfig,
+  modelOverride?: string
+) => {
+  const id =
+    modelOverride ??
+    config.defaultModel ??
+    PROVIDER_DEFAULTS[config.providerType].defaultModelHint ??
+    ""
+
+  if (config.providerType === "openrouter") {
+    const router = createOpenRouter({ apiKey: config.apiKey })
+    return router.chat(id)
+  }
+  const client = createOpenAI({
+    baseURL: config.baseUrl,
+    apiKey: config.apiKey,
+  })
+  return client(id)
+}
+
+/**
+ * Build an AI SDK embedding model from a resolved platform config. The
+ * caller is responsible for the dimension lock-in (see productCatalog
+ * docstring).
+ */
+export const buildEmbeddingModel = (
+  config: AiPlatformConfig,
+  modelOverride?: string
+) => {
+  const id =
+    modelOverride ??
+    config.defaultModel ??
+    PROVIDER_DEFAULTS[config.providerType].defaultModelHint ??
+    ""
+
+  // OpenRouter doesn't host embedding models — error early.
+  if (config.providerType === "openrouter") {
+    throw new Error(
+      "OpenRouter does not host embedding models — pick dashscope / cloudflare / google / hf_local for the embed role"
+    )
+  }
+  const client = createOpenAI({
+    baseURL: config.baseUrl,
+    apiKey: config.apiKey,
+  })
+  return client.embedding(id)
+}
+
+export const PROVIDER_TYPES: AiProviderType[] = [
+  "openrouter",
+  "dashscope",
+  "cloudflare",
+  "vercel_ai_gateway",
+  "custom",
+]
+
+export const AI_ROLES: AiRole[] = [
+  "ai_search_chat",
+  "ai_search_embed",
+  "ai_product_description",
+]

--- a/apps/backend/src/scripts/backfill-ai-platforms-from-env.ts
+++ b/apps/backend/src/scripts/backfill-ai-platforms-from-env.ts
@@ -1,0 +1,244 @@
+/**
+ * Backfill AI platform rows in the SocialPlatform table from existing
+ * environment variables.
+ *
+ * Reads:
+ *   OPENROUTER_API_KEY
+ *   DASHSCOPE_API_KEY
+ *   STOREFRONT_SEARCH_DASHSCOPE_MODEL      (defaults to qwen-turbo)
+ *   CLOUDFLARE_AI_ACCOUNT_ID
+ *   CLOUDFLARE_AI_TOKEN
+ *   STOREFRONT_SEARCH_CLOUDFLARE_MODEL     (defaults to @cf/meta/llama-3.1-8b-instruct)
+ *   PRODUCT_SEARCH_EMBED_PROVIDER          (decides which platform owns
+ *                                          ai_search_embed if any)
+ *
+ * Creates one platform per (provider, role) pair, with `metadata.role`,
+ * `metadata.provider_type`, and `metadata.is_default` set so the new
+ * lookup (mastra/services/ai-platforms.ts) picks them up. The credentials
+ * subscriber encrypts api_key in place after creation.
+ *
+ * Priority for the `is_default` flag mirrors the env-fallback chain
+ * already in extract.ts: OpenRouter > DashScope > Cloudflare for chat.
+ * Embed picks the explicit PRODUCT_SEARCH_EMBED_PROVIDER (or DashScope
+ * when nothing is set and only DashScope creds are present, etc.).
+ *
+ * Idempotent: looks for an existing platform with the same name first
+ * and skips if found. To force-re-create, delete the row in the admin
+ * UI before re-running.
+ *
+ * Usage:
+ *   pnpm --filter @jyt/backend exec medusa exec \
+ *     ./src/scripts/backfill-ai-platforms-from-env.ts
+ *
+ * Options (env):
+ *   DRY_RUN=1                Print what would be created, don't write
+ */
+import { ExecArgs } from "@medusajs/framework/types"
+import {
+  ContainerRegistrationKeys,
+  Modules,
+} from "@medusajs/framework/utils"
+import { createSocialPlatformWorkflow } from "../workflows/socials/create-social-platform"
+import { SOCIALS_MODULE } from "../modules/socials"
+import type SocialsService from "../modules/socials/service"
+
+type ProviderType =
+  | "openrouter"
+  | "dashscope"
+  | "cloudflare"
+  | "vercel_ai_gateway"
+  | "custom"
+
+type Role = "ai_search_chat" | "ai_search_embed" | "ai_product_description"
+
+type PlatformPlan = {
+  name: string
+  provider_type: ProviderType
+  role: Role
+  is_default: boolean
+  api_key: string
+  base_url?: string
+  account_id?: string
+  default_model?: string
+}
+
+const planFromEnv = (): PlatformPlan[] => {
+  const plans: PlatformPlan[] = []
+
+  // ── Chat role: OpenRouter (default if present) → DashScope → Cloudflare ──
+  let chatDefaultClaimed = false
+  if (process.env.OPENROUTER_API_KEY) {
+    plans.push({
+      name: "OpenRouter (env backfill)",
+      provider_type: "openrouter",
+      role: "ai_search_chat",
+      is_default: true,
+      api_key: process.env.OPENROUTER_API_KEY,
+      default_model:
+        process.env.OPENROUTER_DEFAULT_MODEL ||
+        "meta-llama/llama-3.3-70b-instruct:free",
+    })
+    chatDefaultClaimed = true
+  }
+  if (process.env.DASHSCOPE_API_KEY) {
+    plans.push({
+      name: "DashScope chat (env backfill)",
+      provider_type: "dashscope",
+      role: "ai_search_chat",
+      is_default: !chatDefaultClaimed,
+      api_key: process.env.DASHSCOPE_API_KEY,
+      default_model:
+        process.env.STOREFRONT_SEARCH_DASHSCOPE_MODEL || "qwen-turbo",
+    })
+    chatDefaultClaimed = true
+  }
+  if (process.env.CLOUDFLARE_AI_ACCOUNT_ID && process.env.CLOUDFLARE_AI_TOKEN) {
+    plans.push({
+      name: "Cloudflare AI chat (env backfill)",
+      provider_type: "cloudflare",
+      role: "ai_search_chat",
+      is_default: !chatDefaultClaimed,
+      api_key: process.env.CLOUDFLARE_AI_TOKEN,
+      account_id: process.env.CLOUDFLARE_AI_ACCOUNT_ID,
+      default_model:
+        process.env.STOREFRONT_SEARCH_CLOUDFLARE_MODEL ||
+        "@cf/meta/llama-3.1-8b-instruct",
+    })
+  }
+
+  // ── Embed role: driven by PRODUCT_SEARCH_EMBED_PROVIDER ────────────────
+  // We only create rows for cloud-hosted embed providers (HF local has no
+  // credentials to migrate). The default is set on whichever matches the
+  // env switch.
+  const embedProvider = String(
+    process.env.PRODUCT_SEARCH_EMBED_PROVIDER ||
+      process.env.ADMIN_RAG_EMBED_PROVIDER ||
+      "hf_local"
+  )
+    .trim()
+    .toLowerCase()
+
+  if (process.env.DASHSCOPE_API_KEY) {
+    plans.push({
+      name: "DashScope embed (env backfill)",
+      provider_type: "dashscope",
+      role: "ai_search_embed",
+      is_default: embedProvider === "dashscope" || embedProvider === "qwen",
+      api_key: process.env.DASHSCOPE_API_KEY,
+      default_model:
+        process.env.PRODUCT_SEARCH_DASHSCOPE_MODEL || "text-embedding-v3",
+    })
+  }
+  if (process.env.CLOUDFLARE_AI_ACCOUNT_ID && process.env.CLOUDFLARE_AI_TOKEN) {
+    plans.push({
+      name: "Cloudflare AI embed (env backfill)",
+      provider_type: "cloudflare",
+      role: "ai_search_embed",
+      is_default: embedProvider === "cloudflare" || embedProvider === "cf",
+      api_key: process.env.CLOUDFLARE_AI_TOKEN,
+      account_id: process.env.CLOUDFLARE_AI_ACCOUNT_ID,
+      default_model:
+        process.env.PRODUCT_SEARCH_CLOUDFLARE_MODEL ||
+        "@cf/baai/bge-base-en-v1.5",
+    })
+  }
+
+  return plans
+}
+
+export default async function backfillAiPlatformsFromEnv({
+  container,
+}: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const socials = container.resolve(SOCIALS_MODULE) as unknown as SocialsService
+  const DRY_RUN = process.env.DRY_RUN === "1"
+
+  const plans = planFromEnv()
+  if (!plans.length) {
+    logger.info(
+      "[ai-platforms backfill] no AI provider env vars set — nothing to do. " +
+        "Configure OPENROUTER_API_KEY, DASHSCOPE_API_KEY, or " +
+        "CLOUDFLARE_AI_ACCOUNT_ID + CLOUDFLARE_AI_TOKEN and re-run."
+    )
+    return
+  }
+
+  logger.info(
+    `[ai-platforms backfill] planned ${plans.length} platform(s)${
+      DRY_RUN ? " (DRY_RUN)" : ""
+    }`
+  )
+
+  let created = 0
+  let skipped = 0
+
+  for (const plan of plans) {
+    // Idempotency: skip if a platform with this exact name already exists.
+    // Matching by name keeps the script re-runnable; admins can edit a
+    // backfilled row without losing it on re-run.
+    let existing: any[] = []
+    try {
+      existing = await socials.listSocialPlatforms({ name: plan.name }, {})
+    } catch (e: any) {
+      logger.warn(
+        `[ai-platforms backfill] listSocialPlatforms failed for "${plan.name}": ${e?.message ?? e}`
+      )
+    }
+    if (existing?.length) {
+      skipped++
+      logger.info(
+        `[ai-platforms backfill] ↷ already exists: "${plan.name}" (id=${existing[0].id})`
+      )
+      continue
+    }
+
+    logger.info(
+      `[ai-platforms backfill] + ${plan.name} ` +
+        `[provider=${plan.provider_type}, role=${plan.role}, default=${plan.is_default}]`
+    )
+    if (DRY_RUN) {
+      created++
+      continue
+    }
+
+    try {
+      // api_key is sent plaintext; the social-platform-credentials-encryption
+      // subscriber fires on social_platform.created and encrypts in place.
+      const apiConfig: Record<string, unknown> = {
+        api_key: plan.api_key,
+        ...(plan.default_model ? { default_model: plan.default_model } : {}),
+        ...(plan.account_id ? { account_id: plan.account_id } : {}),
+        ...(plan.base_url ? { base_url: plan.base_url } : {}),
+      }
+      await createSocialPlatformWorkflow(container as any).run({
+        input: {
+          name: plan.name,
+          category: "ai",
+          auth_type: "bearer",
+          status: "active",
+          base_url: plan.base_url,
+          api_config: apiConfig,
+          metadata: {
+            provider_type: plan.provider_type,
+            role: plan.role,
+            is_default: plan.is_default,
+            source: "env_backfill",
+          },
+        },
+      })
+      created++
+    } catch (e: any) {
+      logger.error(
+        `[ai-platforms backfill] ✗ failed to create "${plan.name}": ${e?.message ?? e}`
+      )
+    }
+  }
+
+  logger.info(
+    `[ai-platforms backfill] done. created=${created} skipped=${skipped}`
+  )
+  logger.info(
+    `[ai-platforms backfill] next: visit /admin/settings/external-platforms ` +
+      `to verify and (optionally) clear the corresponding env vars.`
+  )
+}

--- a/apps/backend/src/scripts/backfill-product-search.ts
+++ b/apps/backend/src/scripts/backfill-product-search.ts
@@ -57,7 +57,7 @@ export default async function backfillProductSearch({ container }: ExecArgs) {
     )
 
     if (!DRY_RUN) {
-      const result = await upsertProducts(batch as any)
+      const result = await upsertProducts(batch as any, container)
       totals.upserted += result.upserted
       totals.skipped += result.skipped
       totals.errors += result.errors

--- a/apps/backend/src/subscribers/index-product-for-search.ts
+++ b/apps/backend/src/subscribers/index-product-for-search.ts
@@ -57,7 +57,7 @@ const indexOne = async (
       )
       return
     }
-    const result = await upsertProducts([product as any])
+    const result = await upsertProducts([product as any], container)
     logger?.debug?.(
       `[product-search] indexed product ${productId}: ` +
         `upserted=${result.upserted} skipped=${result.skipped} errors=${result.errors}`


### PR DESCRIPTION
## What happened

PRs #241 → #242 → #243 were stacked. #241 squash-merged into `main` cleanly; #242 and #243 then merged into their stacked bases (\`feat/storefront-hero-search\` and \`feat/ai-platforms-config\` respectively). Because nobody re-targeted #242/#243 to \`main\` after #241 landed, their merge commits live on those stranded branches and \`main\` is missing their content.

Both PRs show "merged" on GitHub but `git show origin/main:apps/backend/src/mastra/services/ai-platforms.ts` errors with "path does not exist".

## What this PR ships

The content from both stranded PRs — re-targeted to main as a single merge so we don't have to relitigate the diffs.

Branch `feat/ai-platforms-config` is two commits ahead of main:
- `bf67d9542` — feat(ai): lookup AI provider config from external-platforms (env fallback) (originally #242)
- (via merge) `469adc1c1` — feat(ai): Create-AI-provider admin UI + env-vars backfill script (originally #243)

No new code — just a re-merge to land what was supposed to be on main already.

## After this merges

The env-vars audit work the user requested can proceed against current main, with the `mastra/services/ai-platforms.ts` helper and the Create-AI-provider form both available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)