### PR TITLE
fix(productCatalog): cap embed batch at 10 (DashScope limit)

### DIFF
--- a/apps/backend/src/mastra/rag/productCatalog.ts
+++ b/apps/backend/src/mastra/rag/productCatalog.ts
@@ -331,8 +331,13 @@ export const upsertProducts = async (
   result.skipped = candidates.length - toEmbed.length
   if (!toEmbed.length) return result
 
-  // Batch embed in chunks of 64 to keep memory + per-call latency reasonable.
-  const BATCH = 64
+  // Batch embed in chunks of 10. DashScope's embedding endpoint caps
+  // `input.contents` at 10 items per request and rejects larger batches
+  // with `InternalError.Algo.InvalidParameter`. The other providers
+  // (HF local, Google, Cloudflare bge) are comfortable at this size too,
+  // so 10 is the safe lowest-common-denominator until we plumb per-
+  // provider batch limits through `mastra/services/ai-platforms.ts`.
+  const BATCH = 10
   const vectors: number[][] = []
   for (let i = 0; i < toEmbed.length; i += BATCH) {
     const slice = toEmbed.slice(i, i + BATCH)


### PR DESCRIPTION
Found while running the prod product-search backfill: DashScope's text-embedding-v3 caps `input.contents` at 10 items per request:

  <400> InternalError.Algo.InvalidParameter: Value error, batch size is invalid, it should not be larger than 10.: input.contents

Backfill landed 10/60 products (the trailing batch was 10) and errored on the larger batches.

One-line fix: drop BATCH from 64 → 10. Safe lowest-common-denominator across all four providers (HF local / Google / Cloudflare bge / DashScope).

Once merged + deployed I'll re-run the product-search backfill — all 60 products should land this time.