### PR TITLE
fix(store/ai/search): drop calculated_price fields pending pricing context

### DIFF
--- a/apps/backend/src/api/store/ai/search/route.ts
+++ b/apps/backend/src/api/store/ai/search/route.ts
@@ -37,8 +37,13 @@ const PRODUCT_FIELDS = [
   "status",
   "variants.id",
   "variants.title",
-  "variants.calculated_price.calculated_amount",
-  "variants.calculated_price.currency_code",
+  // NB: omitting `variants.calculated_price.*` deliberately. Medusa
+  // requires a pricing context (currency_code or region_id) to compute
+  // those amounts and throws otherwise; the search route doesn't yet
+  // resolve the visitor's region. The storefront UI already degrades
+  // gracefully when amounts are absent — "no price shown" rather than
+  // a failed request. Plumb a real pricing context in the chat-modal
+  // PR when the frontend can pass region_id alongside the query.
   // Pull sales_channels so attachStorefrontAttribution can decide
   // whether each hit belongs to the main JYT storefront or a partner's
   // — partner products link out to their own domain, main products


### PR DESCRIPTION
Live API call after the backfill returned:

  {"message":"Method calculatePrices requires currency_code in the pricing context"}

Medusa requires currency_code (or region_id) to compute `variants.calculated_price.*` — the search route doesn't yet pass it. Quick fix: omit those fields from the graph query. The storefront UI already renders gracefully when amounts are missing.

Proper fix lands with the chat-modal PR: storefront passes its current region_id alongside the query, route runs `query.graph` with a real pricing context, prices return on the dropdown.

After this merges + deploys, search will respond with title + thumbnail (no price line) — that's a smaller, working iteration ahead of the chat-modal release.