### PR TITLE
feat(storefront/chat-agent): streaming concierge — Phase 1

### DIFF
--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -105,6 +105,7 @@ import { UpdateInventoryOrderTask } from "./admin/inventory-orders/[id]/tasks/[t
 import { TestBlogEmailSchema } from "./admin/websites/[id]/pages/[pageId]/subs/test/route";
 import { listSocialPlatformsQuerySchema, SocialPlatformSchema, UpdateSocialPlatformSchema, ConnectWhatsAppSchema } from "./admin/social-platforms/validators";
 import { StoreAiSearchSchema } from "./store/ai/search/validators";
+import { StoreAiChatSchema } from "./store/ai/chat/validators";
 import { StoreGenerateAiImageReqSchema } from "./store/ai/imagegen/validators";
 import { StoreTryOnReqSchema } from "./store/ai/tryon/validators";
 import { AccessFeeConfirmSchema } from "./store/ai/accessfee/validators";
@@ -3095,6 +3096,15 @@ export default defineMiddlewares({
       // and matches the SDK's `client.fetch(..., { query })` convention.
       middlewares: [
         validateAndTransformQuery(wrapSchema(StoreAiSearchSchema), {}),
+      ],
+    },
+    {
+      matcher: "/store/ai/chat",
+      method: "POST",
+      // Public — same reasoning as /store/ai/search. visitor_id in the
+      // body is the join key; we don't gate on a customer session.
+      middlewares: [
+        validateAndTransformBody(wrapSchema(StoreAiChatSchema)),
       ],
     },
     {

--- a/apps/backend/src/api/store/ai/chat/route.ts
+++ b/apps/backend/src/api/store/ai/chat/route.ts
@@ -1,0 +1,101 @@
+/**
+ * POST /store/ai/chat
+ *
+ * Streaming chat endpoint for the storefront concierge modal.
+ *
+ * Pipeline:
+ *   1. Validate body (via middlewares.ts → StoreAiChatSchema).
+ *   2. Resolve the chat model — DB-configured platform for role
+ *      `ai_search_chat` first, then DashScope / Cloudflare / OpenRouter
+ *      env fallbacks. See `mastra/agents/storefront-chat.ts`.
+ *   3. Build the system prompt with the customer's onboarding prefs +
+ *      brand-knowledge corpus injected.
+ *   4. Bind the `search_products` tool to this request's container so
+ *      the model can look up real products mid-conversation.
+ *   5. `streamText(...)` and pipe the AI-SDK UI message stream straight
+ *      into the Express response. The storefront consumes this via
+ *      `useChat` / a hand-rolled reader.
+ *
+ * Public (no customer auth) — matches `/store/ai/search`. Visitor id is
+ * required in the body so future analytics/persistence work can join
+ * threads with cart + events.
+ *
+ * Why not `Agent.stream()` from Mastra? — we need per-request
+ * parameterisation (prefs, container-bound tool) and the direct AI-SDK
+ * path is shorter and matches `extract.ts`'s style for the
+ * non-streaming search route.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { convertToModelMessages, streamText, stepCountIs } from "ai"
+import {
+  buildStorefrontChatSystem,
+  resolveStorefrontChatModel,
+} from "../../../../mastra/agents/storefront-chat"
+import { createSearchProductsTool } from "../../../../mastra/agents/tools/storefront-search-products"
+import type { StoreAiChatReq } from "./validators"
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const body = (req as any).validatedBody as StoreAiChatReq
+
+  const resolved = await resolveStorefrontChatModel(req.scope as any)
+  if (!resolved) {
+    res.status(503).json({
+      error:
+        "AI chat is not configured. Add a platform with role ai_search_chat in Settings → External Platforms, or set DASHSCOPE_API_KEY.",
+    })
+    return
+  }
+
+  const system = buildStorefrontChatSystem(body.prefs)
+  const tools = {
+    search_products: createSearchProductsTool(req.scope as any),
+  }
+
+  // Normalise the inbound UI messages. The AI-SDK v5 client posts
+  // {role, parts:[{type:"text",text}]}; older clients may post
+  // {role, content:"..."}. Coerce both into the parts shape so
+  // convertToModelMessages produces clean ModelMessages.
+  const messages = body.messages.map((m: any) => {
+    if (Array.isArray(m.parts) && m.parts.length) {
+      return { id: m.id, role: m.role, parts: m.parts }
+    }
+    return {
+      id: m.id,
+      role: m.role,
+      parts: [{ type: "text", text: String(m.content ?? "") }],
+    }
+  })
+
+  let result
+  try {
+    result = streamText({
+      model: resolved.model,
+      system,
+      messages: convertToModelMessages(messages as any),
+      tools,
+      // Allow at most one round-trip of tool-call → tool-result →
+      // model reply per turn. Higher counts let the model spin on
+      // tool calls; one is enough for "search and summarise".
+      stopWhen: stepCountIs(3),
+      temperature: 0.6,
+      onError: (err) => {
+        console.warn(
+          `[store/ai/chat] streamText error (${resolved.provider}):`,
+          (err as any)?.error?.message ?? err
+        )
+      },
+    })
+  } catch (e: any) {
+    console.warn(
+      `[store/ai/chat] streamText threw (${resolved.provider}):`,
+      e?.message ?? e
+    )
+    res.status(502).json({ error: "chat provider failed" })
+    return
+  }
+
+  // Pipe the AI-SDK UI-message stream into the Express response.
+  // The SDK handles SSE framing, Content-Type, and flushes — we just
+  // hand it the Node ServerResponse Medusa hands us.
+  result.pipeUIMessageStreamToResponse(res as any)
+}

--- a/apps/backend/src/api/store/ai/chat/validators.ts
+++ b/apps/backend/src/api/store/ai/chat/validators.ts
@@ -1,0 +1,70 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * Body schema for POST /store/ai/chat.
+ *
+ * `messages` is the AI-SDK UIMessage shape — what `useChat()` posts.
+ * We only require the minimum (role, content/parts) and let the AI SDK
+ * normalize the rest via `convertToModelMessages`.
+ *
+ * `prefs` is the onboarding capture (colors, materials, price range,
+ * size/fit). Stored in localStorage on the storefront and re-sent each
+ * turn so the agent can personalise responses without server-side
+ * persistence (Phase 2 will move this server-side).
+ *
+ * `visitor_id` is mandatory — same id as `jyt_visitor_id` in storefront
+ * localStorage. Already used by cart + analytics; reusing it here keeps
+ * the chat → product → purchase funnel joinable in analytics, and lets
+ * Phase 2 attach customer_id at sign-in by id-match (cart pattern).
+ */
+const RoleSchema = z.enum(["system", "user", "assistant"])
+
+const UiMessageSchema = z
+  .object({
+    id: z.string().optional(),
+    role: RoleSchema,
+    // The AI-SDK v5 UIMessage uses `parts: [{type:"text", text}]`. Older
+    // clients send `content: string`. Accept both — the route normalises.
+    content: z.string().optional(),
+    parts: z
+      .array(
+        z.object({
+          type: z.string(),
+          text: z.string().optional(),
+        })
+      )
+      .optional(),
+  })
+  .passthrough()
+
+const PrefsSchema = z
+  .object({
+    colors: z.array(z.string().min(1).max(30)).max(10).optional(),
+    styles: z.array(z.string().min(1).max(30)).max(10).optional(),
+    materials: z.array(z.string().min(1).max(30)).max(10).optional(),
+    price_range: z
+      .object({
+        min: z.number().int().nonnegative().optional(),
+        max: z.number().int().nonnegative().optional(),
+      })
+      .optional(),
+    body: z
+      .object({
+        size: z.string().min(1).max(8).optional(),
+        fit: z.enum(["relaxed", "fitted"]).optional(),
+      })
+      .optional(),
+    notes: z.string().max(280).optional(),
+  })
+  .partial()
+
+export const StoreAiChatSchema = z.object({
+  // Capped at 40 turns (20 round-trips) — more than that and the system
+  // prompt + brand corpus would dominate tokens anyway.
+  messages: z.array(UiMessageSchema).min(1).max(40),
+  prefs: PrefsSchema.optional(),
+  visitor_id: z.string().min(1).max(80),
+})
+
+export type StoreAiChatReq = z.infer<typeof StoreAiChatSchema>
+export type StoreAiChatPrefs = z.infer<typeof PrefsSchema>

--- a/apps/backend/src/mastra/agents/storefront-chat.ts
+++ b/apps/backend/src/mastra/agents/storefront-chat.ts
@@ -1,0 +1,181 @@
+/**
+ * Storefront chat agent — model + prompt resolver.
+ *
+ * The route (`apps/backend/src/api/store/ai/chat/route.ts`) calls
+ * `resolveStorefrontChatModel(container)` to get a LanguageModel, then
+ * `buildStorefrontChatSystem(prefs)` to get the system prompt, then
+ * pipes both into AI-SDK `streamText({ tools })` so the response streams
+ * token-by-token back to the client.
+ *
+ * Provider resolution mirrors `extract.ts`:
+ *   1. DB-configured platform for role `ai_search_chat` (admin picks)
+ *   2. DashScope (Qwen) — needs DASHSCOPE_API_KEY
+ *   3. Cloudflare Workers AI — needs CLOUDFLARE_AI_* pair
+ *   4. OpenRouter free — last resort; free models often refuse tool calls
+ *
+ * We *don't* keep a Mastra `Agent` instance here because the agent needs
+ * to be parameterised per-request: each visitor's prefs go into the
+ * system prompt, and the search tool needs the container scope. Building
+ * the parts the route assembles is cleaner than a singleton with mutable
+ * config.
+ */
+import type { MedusaContainer } from "@medusajs/framework"
+import { createOpenAI } from "@ai-sdk/openai"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { dynamicFreeTextModel } from "../providers/dynamic-text-model"
+import { buildChatModel, getAiPlatformForRole } from "../services/ai-platforms"
+
+// ── Brand knowledge corpus ─────────────────────────────────────────────
+
+const BRAND_KNOWLEDGE_PATH = join(__dirname, "..", "data", "storefront-brand-knowledge.md")
+
+let _brandCache: string | null = null
+const getBrandKnowledge = (): string => {
+  if (_brandCache !== null) return _brandCache
+  try {
+    _brandCache = readFileSync(BRAND_KNOWLEDGE_PATH, "utf-8")
+  } catch (e) {
+    console.warn(
+      "[storefront-chat] brand knowledge corpus missing — falling back to thin defaults:",
+      (e as any)?.message ?? e
+    )
+    _brandCache = "Cici Label is a slow-fashion brand under Jaal Yantra Textiles."
+  }
+  return _brandCache
+}
+
+// ── System prompt ──────────────────────────────────────────────────────
+
+export type UserPrefs = {
+  colors?: string[]
+  styles?: string[]
+  materials?: string[]
+  price_range?: { min?: number; max?: number }
+  body?: { size?: string; fit?: "relaxed" | "fitted" }
+  notes?: string
+}
+
+const formatPrefs = (prefs?: UserPrefs): string => {
+  if (!prefs) return "(no preferences captured yet — feel free to ask one short question to learn what they like)"
+  const lines: string[] = []
+  if (prefs.colors?.length) lines.push(`- colors: ${prefs.colors.join(", ")}`)
+  if (prefs.styles?.length) lines.push(`- styles: ${prefs.styles.join(", ")}`)
+  if (prefs.materials?.length) lines.push(`- materials: ${prefs.materials.join(", ")}`)
+  if (prefs.price_range?.min || prefs.price_range?.max) {
+    const min = prefs.price_range.min ?? ""
+    const max = prefs.price_range.max ?? ""
+    lines.push(`- price range: ${min}–${max}`)
+  }
+  if (prefs.body?.size) lines.push(`- size: ${prefs.body.size}`)
+  if (prefs.body?.fit) lines.push(`- fit preference: ${prefs.body.fit}`)
+  if (prefs.notes) lines.push(`- notes: ${prefs.notes}`)
+  return lines.length ? lines.join("\n") : "(captured, but empty)"
+}
+
+export const buildStorefrontChatSystem = (prefs?: UserPrefs): string => {
+  return `You are a warm, concise concierge for Cici Label — a slow-fashion brand under Jaal Yantra Textiles (JYT). You help shoppers find pieces they'll love and answer questions about the brand.
+
+# How to behave
+- Two short paragraphs is plenty. Match the shopper's energy.
+- Use the search_products tool whenever the shopper is asking about products, what's available, or describing what they want. Don't fabricate products or prices.
+- When you call search_products, briefly say what you're looking up ("Looking for indigo handwoven cottons…") so the wait feels intentional.
+- After search results come back, write a one or two sentence summary in prose ("I found a few cotton handwoven pieces — the ivory kurta and the indigo set both look like what you described."). The UI renders the product cards below your text, so don't try to list them by hand.
+- For brand questions (custom design, sizing, materials, partners, shipping), answer from the BRAND KNOWLEDGE below. If something isn't covered, say so and point to hello@cicilabel.com.
+- For custom design: route the shopper to /design — that's the self-service editor. Don't fabricate a custom-design intake form.
+- Never give prices or stock numbers unless they come from the search_products tool.
+- Don't push a sale. The shopper asks; you suggest.
+
+# Customer preferences (from onboarding)
+${formatPrefs(prefs)}
+
+If the customer's preferences contain colors / materials / price range, weave them into your search_products call. If preferences are empty, it's fine to ask one quick question to narrow the search — but don't run a long onboarding interrogation; one question at a time.
+
+# Brand knowledge
+
+${getBrandKnowledge()}`
+}
+
+// ── Model resolution ───────────────────────────────────────────────────
+
+let _dashscope: ReturnType<typeof createOpenAI> | null = null
+const getDashscope = () => {
+  if (_dashscope) return _dashscope
+  const apiKey = process.env.DASHSCOPE_API_KEY
+  if (!apiKey) return null
+  _dashscope = createOpenAI({
+    baseURL: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+    apiKey,
+  })
+  return _dashscope
+}
+
+let _cloudflare: ReturnType<typeof createOpenAI> | null = null
+const getCloudflare = () => {
+  if (_cloudflare) return _cloudflare
+  const accountId = process.env.CLOUDFLARE_AI_ACCOUNT_ID
+  const token = process.env.CLOUDFLARE_AI_TOKEN
+  if (!accountId || !token) return null
+  _cloudflare = createOpenAI({
+    baseURL: `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/v1`,
+    apiKey: token,
+  })
+  return _cloudflare
+}
+
+export type ResolvedChatModel = {
+  /** AI-SDK LanguageModel to pass into streamText({ model }) */
+  model: any
+  /** For logs / debugging — which provider we picked. */
+  provider: string
+}
+
+/**
+ * Resolve the chat model for this request. DB-configured platform wins
+ * if present; otherwise walk the env-var fallback chain. Returns null
+ * when no provider is available — the route should respond with a 503
+ * rather than throwing into the AI SDK.
+ */
+export const resolveStorefrontChatModel = async (
+  container: MedusaContainer
+): Promise<ResolvedChatModel | null> => {
+  // 1. Admin-configured platform.
+  try {
+    const cfg = await getAiPlatformForRole(container, "ai_search_chat")
+    if (cfg) {
+      return {
+        model: buildChatModel(cfg),
+        provider: `db:${cfg.providerType}:${cfg.platformId}`,
+      }
+    }
+  } catch (e: any) {
+    console.warn(
+      "[storefront-chat] getAiPlatformForRole failed, falling through to env:",
+      e?.message ?? e
+    )
+  }
+
+  // 2. DashScope (Qwen) — best free-tier tool-use story.
+  const dashscope = getDashscope()
+  if (dashscope) {
+    const modelId =
+      process.env.STOREFRONT_CHAT_DASHSCOPE_MODEL || "qwen-plus"
+    return { model: dashscope(modelId), provider: `dashscope:${modelId}` }
+  }
+
+  // 3. Cloudflare Workers AI.
+  const cloudflare = getCloudflare()
+  if (cloudflare) {
+    const modelId =
+      process.env.STOREFRONT_CHAT_CLOUDFLARE_MODEL ||
+      "@cf/meta/llama-3.1-8b-instruct"
+    return { model: cloudflare(modelId), provider: `cloudflare:${modelId}` }
+  }
+
+  // 4. OpenRouter free (tool use is hit-or-miss — last resort).
+  if (process.env.OPENROUTER_API_KEY) {
+    return { model: dynamicFreeTextModel, provider: "openrouter:free" }
+  }
+
+  return null
+}

--- a/apps/backend/src/mastra/agents/tools/storefront-search-products.ts
+++ b/apps/backend/src/mastra/agents/tools/storefront-search-products.ts
@@ -1,0 +1,179 @@
+/**
+ * search_products — AI SDK tool for the storefront chat agent.
+ *
+ * Wraps the same vector + lexical pipeline as `GET /store/ai/search`
+ * (productCatalog.searchProducts + Medusa graph hydration) but exposes
+ * a trimmed, agent-friendly shape: just enough fields to render a card
+ * client-side AND for the model to talk about the result in prose.
+ *
+ * Why a thin wrapper rather than calling `/store/ai/search` over HTTP:
+ *   - We already have the MedusaContainer; an in-process call avoids
+ *     the extra hop, keeps tracing in one place, and lets us pass
+ *     pre-extracted constraints (color, material) straight through
+ *     without re-running the LLM extraction step.
+ *   - The chat surface and the inline `/store` search will likely
+ *     diverge in fields the UI wants (e.g. price ranges, why-it-matched
+ *     hints); coupling them via HTTP would slow that down.
+ */
+import type { MedusaContainer } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { tool } from "ai"
+import { z } from "zod"
+import { searchProducts } from "../../rag/productCatalog"
+import {
+  attachStorefrontAttribution,
+  type StorefrontAttribution,
+} from "../../../api/store/ai/search/storefront-attribution"
+
+/**
+ * Trimmed product shape returned to the agent. Mirrors what the modal
+ * needs to render a small product card — anything more is bloat the
+ * model has to think through.
+ */
+export type AgentProductHit = {
+  id: string
+  handle: string
+  title: string
+  subtitle: string | null
+  thumbnail: string | null
+  storefront: StorefrontAttribution
+}
+
+const PRODUCT_FIELDS = [
+  "id",
+  "handle",
+  "title",
+  "subtitle",
+  "thumbnail",
+  "status",
+  "sales_channels.id",
+  "sales_channels.name",
+]
+
+const SearchArgsSchema = z.object({
+  query: z
+    .string()
+    .min(2)
+    .max(200)
+    .describe(
+      "Natural-language description of what the shopper wants (e.g. 'soft cotton handwoven kurta in indigo')"
+    ),
+  color: z
+    .string()
+    .min(1)
+    .max(30)
+    .optional()
+    .describe("Color filter if the shopper named one"),
+  material: z
+    .string()
+    .min(1)
+    .max(30)
+    .optional()
+    .describe("Fabric / material filter if mentioned (cotton, silk, linen, …)"),
+  max_price: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("Price ceiling in major currency units. Omit if unspecified."),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(12)
+    .optional()
+    .default(6)
+    .describe("How many results to return. 4-6 is a good default for chat."),
+})
+
+type SearchArgs = z.infer<typeof SearchArgsSchema>
+
+const buildEnrichedQuery = (args: SearchArgs): string => {
+  const extras: string[] = []
+  if (args.color) extras.push(args.color)
+  if (args.material) extras.push(args.material)
+  return extras.length ? `${args.query}. Keywords: ${extras.join(", ")}` : args.query
+}
+
+export const runStorefrontSearch = async (
+  args: SearchArgs,
+  container: MedusaContainer
+): Promise<{ products: AgentProductHit[]; mode: "vector" | "lexical"; count: number }> => {
+  const queryService = container.resolve(ContainerRegistrationKeys.QUERY)
+  const limit = args.limit ?? 6
+  const enriched = buildEnrichedQuery(args)
+
+  let productIds: string[] = []
+  let mode: "vector" | "lexical" = "vector"
+  try {
+    const hits = await searchProducts(enriched, Math.max(limit * 3, 18), container as any)
+    productIds = hits.map((h) => h.product_id).filter(Boolean)
+  } catch {
+    productIds = []
+  }
+
+  let products: any[] = []
+  if (productIds.length) {
+    const { data } = await queryService.graph({
+      entity: "product",
+      fields: PRODUCT_FIELDS,
+      filters: { id: productIds, status: "published" } as any,
+    })
+    const byId = new Map((data ?? []).map((p: any) => [p.id, p]))
+    products = productIds.map((id) => byId.get(id)).filter(Boolean)
+  }
+
+  if (!products.length) {
+    mode = "lexical"
+    const terms: string[] = []
+    if (args.color) terms.push(args.color)
+    if (args.material) terms.push(args.material)
+    const q = terms.length ? `${args.query} ${terms.join(" ")}` : args.query
+    const { data } = await queryService.graph({
+      entity: "product",
+      fields: PRODUCT_FIELDS,
+      filters: { status: "published", q } as any,
+      pagination: { take: Math.max(limit * 3, 18), skip: 0 },
+    })
+    products = data ?? []
+  }
+
+  const capped = products.slice(0, limit)
+  const attributed = await attachStorefrontAttribution(capped as any, container as any)
+
+  const trimmed: AgentProductHit[] = attributed.map((p: any) => ({
+    id: p.id,
+    handle: p.handle,
+    title: p.title,
+    subtitle: p.subtitle ?? null,
+    thumbnail: p.thumbnail ?? null,
+    storefront: p.storefront,
+  }))
+
+  return { products: trimmed, mode, count: trimmed.length }
+}
+
+/**
+ * Build the AI SDK tool bound to a specific request's container so the
+ * agent can call it without re-resolving services on every invocation.
+ * Returned per-request — never cache across requests.
+ */
+export const createSearchProductsTool = (container: MedusaContainer) =>
+  tool({
+    description:
+      "Search the Cici Label / JYT product catalogue using natural-language understanding. Use this whenever the shopper is asking about products, asking what's available, or describing what they want to buy. Don't quote prices or stock unless this tool returns them.",
+    inputSchema: SearchArgsSchema,
+    execute: async (args) => {
+      try {
+        const result = await runStorefrontSearch(args as SearchArgs, container)
+        return result
+      } catch (e: any) {
+        return {
+          products: [],
+          mode: "vector" as const,
+          count: 0,
+          error: e?.message ?? "search failed",
+        }
+      }
+    },
+  })

--- a/apps/backend/src/mastra/data/storefront-brand-knowledge.md
+++ b/apps/backend/src/mastra/data/storefront-brand-knowledge.md
@@ -1,0 +1,77 @@
+# Storefront brand knowledge
+
+Source of truth the storefront chat agent injects into its system
+prompt. Kept short on purpose — every line costs tokens on every turn.
+When something here goes out of date, edit it here, not in the prompt.
+
+## Who we are
+
+Cici Label is a slow-fashion brand under Jaal Yantra Textiles (JYT).
+Every piece is handloom-woven and naturally dyed by artisan partners
+across India (Bhagalpur silk, Lucknow handloom, Shramdaan cotton,
+Kala cotton). Designs are by Saransh Sharma.
+
+## Materials we work with
+
+Handloom cotton, organic Kala cotton, raw / modal silk, linen, muslin.
+Natural dyes only. Each fabric is sourced directly from a partner who
+holds the loom — no middle layers.
+
+## Custom design (`/design`)
+
+Customers can design online end-to-end via the **/design** route:
+
+1. Upload an idea or sketch in the canvas editor.
+2. Pick the fabric from our inventory catalogue.
+3. Choose a partner you'd like to make it, or let us auto-assign one.
+4. A production run starts once a partner accepts the design.
+5. Track progress from your account.
+
+When asked about custom design, point customers at `/design`. Don't
+invent a process — the editor is self-service and the docs at
+`/docs/guides/media/design-to-product` cover the details.
+
+## Sizing
+
+Cici Label runs **relaxed sizing**. A size M typically fits where the
+high-street equivalent would be 8–10. Many pieces are one-size or
+"single sizes" — drape-driven rather than fit-driven.
+
+If a customer is unsure: ask their usual size in a familiar brand and
+their preferred fit (relaxed / fitted). Don't quote chest/waist
+measurements unless the product page lists them — fabrication varies
+per piece.
+
+## Partner products
+
+Some products in search results carry a "Partner" badge — those are
+sold by an artisan-partner's own storefront under the Cici Label
+network (gof-asia, sharlho, etc). The product link opens the partner's
+domain in a new tab. The partner still ships, supports, and stands
+behind the piece — Cici Label vouches for the partner.
+
+## Shipping & returns
+
+Lead time: 3–7 days for in-stock pieces, 2–3 weeks for custom-made.
+Domestic shipping is free over ₹2000. International ships from India
+with tracked DHL.
+Returns within 14 days for in-stock pieces; custom-made pieces are
+non-returnable but can be re-sized once.
+
+(If a customer asks for specifics not covered here, suggest they email
+hello@cicilabel.com — don't fabricate amounts or timelines.)
+
+## What you (the agent) do well
+
+- Recommend pieces from our catalogue using the `search_products` tool.
+- Explain materials, the custom-design flow, sizing, partner badges.
+- Acknowledge when something is outside what you know and direct to
+  `hello@cicilabel.com` or the docs.
+
+## What to avoid
+
+- Quoting prices or stock numbers without using the search tool.
+- Inventing process details (custom design, returns, shipping) beyond
+  what's in this document.
+- Pushing a sale. The customer asks, you suggest.
+- Long answers. Two short paragraphs is usually plenty.

--- a/apps/docs/docs/implementation/ai/storefront-chat-agent.md
+++ b/apps/docs/docs/implementation/ai/storefront-chat-agent.md
@@ -1,0 +1,180 @@
+---
+title: "Storefront Chat Agent"
+sidebar_label: "Storefront Chat Agent"
+sidebar_position: 11
+---
+
+# Storefront Chat Agent
+
+Status: in progress (Phase 1)
+
+## Goal
+
+Make the home modal feel like a small concierge:
+
+1. **Onboarding** — quick capture of preferences when a user first opens the chat (colors, styles, materials, price range, fit/size).
+2. **Free chat** — open-ended Q&A about Cici Label (custom design at `/design`, sustainability, sizing) AND product search.
+3. **Streaming** — tokens arrive as the model generates.
+
+## Architecture
+
+```
+Browser
+  │  EventSource / AI-SDK useChat
+  ▼
+Next.js API route (apps/storefront/src/app/api/ai-chat/route.ts)
+  │  proxies request server-side using MEDUSA_BACKEND_URL
+  ▼
+POST /store/ai/chat                              ← SSE endpoint (Medusa backend)
+  │  AI-SDK streamText(...) with tools
+  ▼
+storefrontChatAgent  (apps/backend/src/mastra/agents/storefront-chat.ts)
+  - DB-configured LLM (DashScope qwen by default)
+  - system prompt: brand voice + onboarding logic + corpus
+  - tools:
+      • search_products({query, color?, material?, max_price?, limit})
+      • (later) save_preferences({colors?, styles?, materials?, price_range?, body?})
+      • (later) get_brand_info({topic})
+```
+
+`/store/ai/search` (the GET non-streaming endpoint) stays as-is for the
+`/store` inline grid. Two surfaces, two endpoints.
+
+## Data shapes
+
+**Preferences** (`apps/storefront/src/lib/util/ai-chat-preferences.ts` ←
+versioned localStorage; mirrored on server later):
+
+```ts
+type UserPrefs = {
+  colors?: string[]              // ["white", "indigo", "natural"]
+  styles?: string[]              // ["minimal", "bohemian"]
+  materials?: string[]           // ["cotton", "silk", "linen"]
+  price_range?: { min?: number; max?: number }
+  body?: { size?: string; fit?: "relaxed" | "fitted" }
+  notes?: string
+}
+```
+
+**Chat message** (extends the current `AiChatMessage`):
+
+```ts
+type AiChatMessage = {
+  id, role, content, ts, products?, interpretation?,
+  partial?: boolean      // true while streaming
+  tool_calls?: Array<{ name; args; result_summary }>
+}
+```
+
+**Request body** to `POST /store/ai/chat`:
+
+```ts
+{
+  messages: AiChatMessage[]
+  prefs?: UserPrefs
+  visitor_id: string        // required — see "Visitor ID" below
+}
+```
+
+## Visitor ID
+
+`localStorage["jyt_visitor_id"]` already exists in the storefront —
+cart.ts stamps it on cart metadata, analytics workflows consume it.
+Reuse it.
+
+- Chat request body includes `visitor_id`. Server action reads
+  `localStorage["jyt_visitor_id"]` before calling the proxy route.
+- Backend persists threads keyed by `visitor_id` (anonymous-friendly).
+- On customer login, attach `customer_id` to existing threads matching
+  `visitor_id` and `customer_id IS NULL` — same merge pattern as cart
+  attribution.
+- Same id ties to existing analytics events, so a single visitor's
+  chat → product → purchase flow joins in the analytics store.
+
+(Persistence module ships in Phase 2.)
+
+## Custom design — the real flow
+
+`/design` already exists with a full DesignEditorWrapper. The flow:
+
+1. **`/design`** — canvas + layer tools.
+2. Upload an idea (image / sketched in editor).
+3. Pick **inventory (fabric)** from the catalogue.
+4. Pick a **partner** (or auto-assign).
+5. Production run starts after partner accepts.
+
+Docs the brand-knowledge corpus references:
+
+- [`media/design-to-product`](../../guides/media/design-to-product.md)
+- [`designs/send-to-partner-migration`](../designs/send-to-partner-migration.md)
+- [`designs/production-run-convergence-plan`](../designs/production-run-convergence-plan.md)
+- [`protocol/design/cici-label`](../../protocol/design/cici-label.md)
+
+Agent answer for "how do I do a custom design?":
+
+> You can do it all online via [/design](/design). The editor lets you
+> upload an idea or sketch, pick the fabric from our inventory, and
+> either choose a partner you'd like to make it or let us assign one.
+> A production run starts once a partner takes the design — track it
+> from your account.
+
+## Files
+
+**Phase 1 — minimum viable streaming chat:**
+
+Backend:
+- `apps/backend/src/mastra/data/storefront-brand-knowledge.md`
+- `apps/backend/src/mastra/agents/storefront-chat.ts`
+- `apps/backend/src/mastra/agents/tools/storefront-search-products.ts`
+- `apps/backend/src/api/store/ai/chat/route.ts`
+- `apps/backend/src/api/store/ai/chat/validators.ts`
+- `apps/backend/src/api/middlewares.ts` — wire SSE route
+
+Storefront:
+- `apps/storefront/src/lib/util/ai-chat-preferences.ts`
+- `apps/storefront/src/lib/util/visitor-id.ts`
+- `apps/storefront/src/app/api/ai-chat/route.ts` — proxy
+- `apps/storefront/src/modules/home/components/ai-search-chat/onboarding.tsx`
+- `apps/storefront/src/modules/home/components/ai-search-chat/index.tsx` — major rewrite
+
+**Phase 2:**
+- `save_preferences` and `get_brand_info` tools
+- `chat_threads` module (visitor_id → messages persistence)
+- `POST /store/ai/chat/thread` (sync on sign-in)
+
+**Phase 3+ (carried over):**
+- UI to set default chat platform in External Platforms
+- Region-aware pricing in search results
+- HeroSeenMarker cookie reliability
+
+## Streaming implementation
+
+- Backend: AI-SDK `streamText({ model, system, tools, messages })` and
+  return `result.toDataStreamResponse()` — emits the AI-SDK data-stream
+  format the `@ai-sdk/react` hooks understand.
+- Storefront proxy: a Next.js API route that forwards body to backend
+  and pipes the response back unmodified. Keeps `MEDUSA_BACKEND_URL`
+  server-only.
+- Client: AI-SDK `useChat` hook (or hand-rolled `fetch` + stream
+  reader) consuming `/api/ai-chat`. Renders partial assistant
+  bubbles + tool-call indicators ("🔎 looked up …").
+
+## Open questions
+
+1. **Body fit capture** — sizes (XS/S/M/L) + relaxed/fitted only.
+   Skip body-shape (apple/pear) — subjective and not actionable.
+2. **Price slider currency** — detect from `countryCode`, default INR.
+3. **Save prefs server-side immediately if signed in?** Yes, same pattern
+   as the desk workspace.
+4. **Tool-call latency UI** — stream a "🔎 looking …" placeholder, then
+   replace with the real bubble. Yes.
+5. **OpenRouter free for tool use?** Most don't reliably handle tool
+   calls. Default the chat role to a DashScope or Cloudflare model.
+6. **Should the agent navigate the customer?** No — embed `<a href>` in
+   the response text, let the user click. Safer.
+
+## Phasing
+
+- **Phase 1** (this PR): onboarding + streaming endpoint + `search_products` only. Brand knowledge ships as system-prompt injection. Visitor-id flows through but no DB persistence yet.
+- **Phase 2:** `save_preferences`, `get_brand_info`, `chat_threads` module, sign-in attribution.
+- **Phase 3:** UI control for default chat platform + region-aware pricing + HeroSeenMarker investigation.

--- a/apps/storefront/package.json
+++ b/apps/storefront/package.json
@@ -17,6 +17,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@ai-sdk/react": "^2.0.194",
     "@headlessui/react": "^2.2.0",
     "@medusajs/icons": "latest",
     "@medusajs/js-sdk": "latest",

--- a/apps/storefront/src/app/api/ai-chat/route.ts
+++ b/apps/storefront/src/app/api/ai-chat/route.ts
@@ -1,0 +1,88 @@
+/**
+ * POST /api/ai-chat
+ *
+ * Same-origin proxy in front of the Medusa backend's `POST /store/ai/chat`
+ * streaming endpoint.
+ *
+ * Why a proxy at all:
+ *   - Keeps MEDUSA_BACKEND_URL a server-side secret (no
+ *     NEXT_PUBLIC_* leak into the client bundle).
+ *   - Same-origin call → no browser CORS pre-flight on every chat turn.
+ *   - Adds the publishable API key Medusa requires for /store/*
+ *     endpoints; the storefront client doesn't have it on hand.
+ *
+ * Why not a server action like `searchAiProducts`:
+ *   - Server actions buffer the response. We need to PIPE the
+ *     SSE/UI-message stream straight through so the client sees tokens
+ *     as they arrive. A Next.js Route Handler can return the upstream
+ *     `Response` directly, which preserves streaming.
+ *
+ * Runtime: defaults to Node.js (Fluid Compute). We don't pin "edge"
+ * because the backend stream uses Node primitives via Medusa and the
+ * proxy never inspects the body — we just hand the upstream Response
+ * back. Node runtime supports streaming Responses just fine.
+ */
+
+const BACKEND_URL =
+  process.env.MEDUSA_BACKEND_URL ??
+  process.env.NEXT_PUBLIC_MEDUSA_BACKEND_URL ??
+  "http://localhost:9000"
+
+const PUBLISHABLE_KEY =
+  process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY ??
+  process.env.MEDUSA_PUBLISHABLE_KEY
+
+// Disable Next.js static optimization — streaming responses must be
+// dynamic, and this route should not be pre-rendered or cached.
+export const dynamic = "force-dynamic"
+
+export async function POST(req: Request) {
+  // Forward the raw body. We deliberately re-stream rather than parse
+  // + re-stringify: the backend validates the shape, and parsing here
+  // would just add latency and a second source of truth for the
+  // schema.
+  const body = await req.text()
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  }
+  if (PUBLISHABLE_KEY) {
+    headers["x-publishable-api-key"] = PUBLISHABLE_KEY
+  }
+
+  let upstream: Response
+  try {
+    upstream = await fetch(`${BACKEND_URL}/store/ai/chat`, {
+      method: "POST",
+      headers,
+      body,
+      // Important — without `duplex: "half"` Node fetch refuses to
+      // stream a body upstream when the response is also a stream. We
+      // don't stream the request body (it's fully buffered above), but
+      // setting it is safe and future-proofs the route if we ever do.
+      // @ts-expect-error — undici-specific option, missing from the
+      // lib.dom Request type but accepted at runtime.
+      duplex: "half",
+    })
+  } catch (e: any) {
+    return new Response(
+      JSON.stringify({
+        error: "Failed to reach chat backend",
+        detail: e?.message ?? String(e),
+      }),
+      {
+        status: 502,
+        headers: { "Content-Type": "application/json" },
+      }
+    )
+  }
+
+  // Re-emit the upstream response verbatim. The upstream sets the
+  // proper SSE Content-Type and framing; we just pass body + headers +
+  // status through.
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: upstream.headers,
+  })
+}

--- a/apps/storefront/src/lib/util/ai-chat-preferences.ts
+++ b/apps/storefront/src/lib/util/ai-chat-preferences.ts
@@ -1,0 +1,88 @@
+"use client"
+
+/**
+ * Local-storage backed onboarding preferences for the storefront chat
+ * concierge.
+ *
+ * Captured the first time a customer opens the chat (colors, materials,
+ * fit/size, price range), persisted client-side, and shipped to the
+ * backend on every chat turn so the system prompt can personalise
+ * responses. A future iteration will mirror this server-side
+ * (Phase 2 — `chat_threads` module) and merge on customer sign-in.
+ *
+ * Versioning matches `ai-chat-thread.ts`: bump `__v` to invalidate
+ * stored data — corrupt / old-version entries are dropped silently
+ * rather than migrated, which is fine for a small preference object.
+ */
+
+const STORAGE_KEY = "jyt:store:ai-chat-prefs-v1"
+const CURRENT_VERSION = 1 as const
+
+export type ChatFit = "relaxed" | "fitted"
+
+export type AiChatPreferences = {
+  __v?: typeof CURRENT_VERSION
+  colors?: string[]
+  styles?: string[]
+  materials?: string[]
+  price_range?: { min?: number; max?: number }
+  body?: { size?: string; fit?: ChatFit }
+  notes?: string
+  /** Set once the customer has completed (or skipped) the onboarding. */
+  onboarded?: boolean
+  updated_at?: number
+}
+
+const isBrowser = typeof window !== "undefined"
+
+export const loadPreferences = (): AiChatPreferences => {
+  if (!isBrowser) return {}
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw) as unknown
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      (parsed as any).__v !== CURRENT_VERSION
+    ) {
+      return {}
+    }
+    return parsed as AiChatPreferences
+  } catch {
+    return {}
+  }
+}
+
+export const savePreferences = (prefs: AiChatPreferences): void => {
+  if (!isBrowser) return
+  try {
+    const payload: AiChatPreferences = {
+      ...prefs,
+      __v: CURRENT_VERSION,
+      updated_at: Date.now(),
+    }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
+  } catch {
+    // best-effort — storage quota / private mode
+  }
+}
+
+export const clearPreferences = (): void => {
+  if (!isBrowser) return
+  try {
+    window.localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Strip the local-only fields (`__v`, `updated_at`, `onboarded`) before
+ * sending to the backend. The wire shape is just the data the agent
+ * needs to personalise its responses.
+ */
+export const toWireFormat = (prefs: AiChatPreferences) => {
+  const { __v: _v, updated_at: _u, onboarded: _o, ...wire } = prefs
+  return wire
+}

--- a/apps/storefront/src/lib/util/visitor-id.ts
+++ b/apps/storefront/src/lib/util/visitor-id.ts
@@ -1,0 +1,44 @@
+"use client"
+
+/**
+ * Visitor id — single source of truth for the storefront's anonymous
+ * id. Same key as `localStorage["jyt_visitor_id"]` written by the
+ * analytics snippet (analytics.min.js) and read by cart.ts /
+ * product-actions / (soon) the chat modal.
+ *
+ * If the analytics snippet hasn't loaded yet we generate one locally
+ * and persist it. That keeps the chat → cart → checkout funnel
+ * joinable even when the analytics script is blocked or slow.
+ */
+
+const STORAGE_KEY = "jyt_visitor_id"
+const isBrowser = typeof window !== "undefined"
+
+const randomId = (): string => {
+  try {
+    return crypto.randomUUID()
+  } catch {
+    return `v_${Date.now()}_${Math.random().toString(36).slice(2, 12)}`
+  }
+}
+
+/**
+ * Read the visitor id, generating + persisting one if it doesn't exist.
+ * Returns null in non-browser environments (SSR) — callers should fall
+ * back gracefully (the chat endpoint requires it on the wire).
+ */
+export const getOrCreateVisitorId = (): string | null => {
+  if (!isBrowser) return null
+  try {
+    const existing = window.localStorage.getItem(STORAGE_KEY)
+    if (existing && existing.length > 0) return existing
+    const fresh = randomId()
+    window.localStorage.setItem(STORAGE_KEY, fresh)
+    return fresh
+  } catch {
+    // Storage disabled (private mode, quota) — return a transient id
+    // so the in-memory session at least has a stable handle. It won't
+    // persist across reloads, but the chat still works.
+    return randomId()
+  }
+}

--- a/apps/storefront/src/modules/home/components/ai-search-chat/index.tsx
+++ b/apps/storefront/src/modules/home/components/ai-search-chat/index.tsx
@@ -1,97 +1,120 @@
 "use client"
 
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
-import { searchAiProducts, type AiSearchProduct } from "@lib/data/ai-search"
+import { useChat } from "@ai-sdk/react"
+import { DefaultChatTransport, type UIMessage } from "ai"
 import {
-  clearThread,
-  emptyThread,
-  loadThread,
-  newMessageId,
-  saveThread,
-  type AiChatMessage,
-  type AiChatThread,
-} from "@lib/util/ai-chat-thread"
-import {
-  forwardRef,
+  type Ref,
   useCallback,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
 } from "react"
+import {
+  loadPreferences,
+  savePreferences,
+  toWireFormat,
+  type AiChatPreferences,
+} from "@lib/util/ai-chat-preferences"
+import { getOrCreateVisitorId } from "@lib/util/visitor-id"
+import OnboardingForm from "./onboarding"
 
 /**
- * Chat-style search modal.
+ * Chat-style concierge modal.
  *
- * Renders as a focused overlay over the /store page. The trigger
- * (see ./trigger.tsx) opens it; closing returns the customer to the
- * underlying list. The conversation is persisted to localStorage via
- * `lib/util/ai-chat-thread.ts` so a quick navigation or reload doesn't
- * lose context.
+ * Streams responses from POST /api/ai-chat (proxy → /store/ai/chat).
+ * Uses `useChat` from @ai-sdk/react so tool-call lifecycles, partial
+ * tokens, and message parts all wire up correctly. The transport
+ * appends `visitor_id` + `prefs` to every request body so the agent
+ * has personalisation context on every turn.
  *
- * What it does NOT do yet (deferred until the chat thread sync PR):
- *   - server-side persistence on sign-in
- *   - multi-turn refinement (each user turn currently issues an
- *     independent search; the backend doesn't accept prior turns as
- *     context yet)
+ * Onboarding renders the very first time a customer opens the chat
+ * (or until they tap "skip"); after that, the modal goes straight to
+ * the conversation view. Prefs persist locally — see
+ * `lib/util/ai-chat-preferences.ts`.
+ *
+ * Visitor id reuses `localStorage["jyt_visitor_id"]` so the chat ties
+ * back to the same anonymous identity used by cart + analytics. A
+ * future iteration will sync threads server-side on sign-in.
  */
-
-const PLACEHOLDER = "Describe what you want — e.g. soft cotton dress under 2000"
-
-const formatRelativeTime = (ts: number): string => {
-  const seconds = Math.round((Date.now() - ts) / 1000)
-  if (seconds < 30) return "just now"
-  if (seconds < 60) return `${seconds}s ago`
-  const minutes = Math.round(seconds / 60)
-  if (minutes < 60) return `${minutes}m ago`
-  const hours = Math.round(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.round(hours / 24)
-  return `${days}d ago`
-}
 
 export type AiSearchChatHandle = {
   open: (initialQuery?: string) => void
   close: () => void
 }
 
-const AiSearchChat = forwardRef<AiSearchChatHandle>((_props, ref) => {
+type ProductHit = {
+  id: string
+  handle: string
+  title: string
+  subtitle?: string | null
+  thumbnail?: string | null
+  storefront?:
+    | { kind: "main" }
+    | {
+        kind: "partner"
+        url?: string
+        partner_name: string
+        partner_handle: string
+        sales_channel_name?: string
+      }
+}
+
+type SearchToolOutput = {
+  products?: ProductHit[]
+  mode?: "vector" | "lexical"
+  count?: number
+  error?: string
+}
+
+const PLACEHOLDER = "Ask me anything — products, fabrics, sizing…"
+
+type AiSearchChatProps = { ref?: Ref<AiSearchChatHandle> }
+
+export default function AiSearchChat({ ref }: AiSearchChatProps) {
   const [open, setOpen] = useState(false)
-  const [thread, setThread] = useState<AiChatThread>(() => emptyThread())
   const [input, setInput] = useState("")
-  const [loading, setLoading] = useState(false)
+  const [prefs, setPrefs] = useState<AiChatPreferences>({})
+  const [showOnboarding, setShowOnboarding] = useState(false)
+  // Lazily resolved on open — SSR can't touch localStorage.
+  const visitorIdRef = useRef<string | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
-  // Token that identifies the latest in-flight request. Stale responses
-  // are discarded if the user has since typed a new query.
-  const inflightRef = useRef<symbol | null>(null)
 
-  // Hydrate the persisted thread on first mount only — open/close cycles
-  // should not refetch, otherwise mid-conversation state would jump.
-  useEffect(() => {
-    setThread(loadThread())
-  }, [])
+  // useChat transport — re-built when prefs change so the body
+  // closure picks up the latest personalisation snapshot.
+  const transport = useMemo(
+    () =>
+      new DefaultChatTransport({
+        api: "/api/ai-chat",
+        body: () => ({
+          visitor_id: visitorIdRef.current ?? "anonymous",
+          prefs: toWireFormat(prefs),
+        }),
+      }),
+    [prefs]
+  )
 
-  // Save thread to localStorage whenever it changes, but skip the very
-  // first render so we don't pointlessly write the empty thread back.
-  const firstRenderRef = useRef(true)
-  useEffect(() => {
-    if (firstRenderRef.current) {
-      firstRenderRef.current = false
-      return
-    }
-    saveThread(thread)
-  }, [thread])
+  const { messages, sendMessage, status, error, setMessages, stop } = useChat({
+    transport,
+  })
 
-  // Imperative handle so the trigger can open the modal with an
-  // already-typed query.
+  const isStreaming = status === "submitted" || status === "streaming"
+
   useImperativeHandle(
     ref,
     () => ({
       open: (initialQuery) => {
+        // Read prefs + visitor id at open time so we always have the
+        // freshest values (another tab may have updated localStorage).
+        const loaded = loadPreferences()
+        setPrefs(loaded)
+        visitorIdRef.current = getOrCreateVisitorId()
+        setShowOnboarding(!loaded.onboarded)
         setOpen(true)
         if (initialQuery !== undefined) setInput(initialQuery)
-        // Focus on next tick after the input is mounted.
         window.setTimeout(() => inputRef.current?.focus(), 0)
       },
       close: () => setOpen(false),
@@ -99,7 +122,6 @@ const AiSearchChat = forwardRef<AiSearchChatHandle>((_props, ref) => {
     []
   )
 
-  // Close on Escape.
   useEffect(() => {
     if (!open) return
     const onKey = (e: KeyboardEvent) => {
@@ -109,7 +131,6 @@ const AiSearchChat = forwardRef<AiSearchChatHandle>((_props, ref) => {
     return () => window.removeEventListener("keydown", onKey)
   }, [open])
 
-  // Lock body scroll while the modal is open.
   useEffect(() => {
     if (!open) return
     const prev = document.body.style.overflow
@@ -119,77 +140,48 @@ const AiSearchChat = forwardRef<AiSearchChatHandle>((_props, ref) => {
     }
   }, [open])
 
-  // Autoscroll to the bottom of the conversation when messages change.
   useEffect(() => {
     if (!scrollRef.current) return
-    scrollRef.current.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" })
-  }, [thread.messages.length, loading])
+    scrollRef.current.scrollTo({
+      top: scrollRef.current.scrollHeight,
+      behavior: "smooth",
+    })
+  }, [messages, isStreaming])
 
-  const submit = useCallback(async () => {
-    const trimmed = input.trim()
-    if (trimmed.length < 2 || loading) return
-
-    const userMsg: AiChatMessage = {
-      id: newMessageId(),
-      role: "user",
-      content: trimmed,
-      ts: Date.now(),
-    }
-    setThread((t) => ({
-      ...t,
-      messages: [...t.messages, userMsg],
-      updated_at: Date.now(),
-    }))
-    setInput("")
-    setLoading(true)
-
-    const myToken = Symbol()
-    inflightRef.current = myToken
-
-    try {
-      const r = await searchAiProducts(trimmed, 8)
-      if (inflightRef.current !== myToken) return
-      const assistantMsg: AiChatMessage = {
-        id: newMessageId(),
-        role: "assistant",
-        content: r ? assistantSummary(trimmed, r.products) : "Couldn't reach the search service. Try again.",
-        ts: Date.now(),
-        products: r?.products ?? undefined,
-        interpretation: r?.interpretation,
-        mode: r?.mode,
-        count: r?.count,
-        failed: !r,
-      }
-      setThread((t) => ({
-        ...t,
-        messages: [...t.messages, assistantMsg],
-        updated_at: Date.now(),
-      }))
-    } catch {
-      if (inflightRef.current === myToken) {
-        setThread((t) => ({
-          ...t,
-          messages: [
-            ...t.messages,
-            {
-              id: newMessageId(),
-              role: "assistant",
-              content: "Search hit an error. Try again.",
-              ts: Date.now(),
-              failed: true,
-            },
-          ],
-          updated_at: Date.now(),
-        }))
-      }
-    } finally {
-      if (inflightRef.current === myToken) setLoading(false)
-    }
-  }, [input, loading])
+  const onSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault()
+      const trimmed = input.trim()
+      if (trimmed.length < 2 || isStreaming) return
+      sendMessage({ text: trimmed })
+      setInput("")
+    },
+    [input, isStreaming, sendMessage]
+  )
 
   const onClear = useCallback(() => {
-    clearThread()
-    setThread(emptyThread())
+    setMessages([])
+  }, [setMessages])
+
+  const onOnboardingDone = useCallback((next: AiChatPreferences) => {
+    setPrefs(next)
+    setShowOnboarding(false)
+    window.setTimeout(() => inputRef.current?.focus(), 0)
+  }, [])
+
+  const onOnboardingSkip = useCallback(() => {
+    // Persist the onboarded flag so we don't show this again — but
+    // leave the empty prefs in state as-is. savePreferences() in the
+    // skip handler already wrote { onboarded: true }.
+    setPrefs((p) => ({ ...p, onboarded: true }))
+    setShowOnboarding(false)
+    window.setTimeout(() => inputRef.current?.focus(), 0)
+  }, [])
+
+  const onResetPrefs = useCallback(() => {
+    savePreferences({ onboarded: false })
+    setPrefs({ onboarded: false })
+    setShowOnboarding(true)
   }, [])
 
   if (!open) return null
@@ -198,45 +190,44 @@ const AiSearchChat = forwardRef<AiSearchChatHandle>((_props, ref) => {
     <div
       role="dialog"
       aria-modal="true"
-      aria-label="Search products"
+      aria-label="AI concierge"
       className="fixed inset-0 z-50 flex flex-col bg-white sm:items-center sm:justify-center sm:bg-black/40 sm:p-6"
     >
-      {/* Click backdrop to close */}
       <button
         type="button"
-        aria-label="Close search"
+        aria-label="Close"
         className="absolute inset-0 hidden cursor-default sm:block"
         onClick={() => setOpen(false)}
         tabIndex={-1}
       />
-      {/*
-        Important: the panel uses a fixed h-full on mobile and a fixed
-        sm:h-[80vh] (not sm:h-auto) on desktop. With h-auto the panel
-        shrinks to content, which leaves the flex-1 message list with
-        nothing to grow into — and `overflow-y-auto` only kicks in when
-        the container has a bounded height. min-h-0 on the message list
-        further insures the flex item can actually shrink below its
-        intrinsic content height so overflow can compute.
-      */}
-      <div className="relative z-10 flex h-full w-full flex-col bg-white sm:h-[80vh] sm:max-h-[640px] sm:w-full sm:max-w-2xl sm:rounded-2xl sm:shadow-2xl">
-        {/* Header */}
-        <div className="flex items-center justify-between border-b border-neutral-200 px-4 py-3 sm:px-6 sm:py-4">
+      <div className="relative z-10 flex h-full w-full flex-col bg-white sm:h-[80vh] sm:max-h-[680px] sm:w-full sm:max-w-2xl sm:rounded-2xl sm:shadow-2xl">
+        <header className="flex items-center justify-between border-b border-neutral-200 px-4 py-3 sm:px-6 sm:py-4">
           <div className="flex flex-col">
             <p className="text-sm font-medium text-neutral-900 sm:text-base">
-              AI search
+              Cici concierge
             </p>
             <p className="text-xs text-neutral-500">
-              Describe what you want, get matching products.
+              Ask about products, fabrics, custom design, or sizing.
             </p>
           </div>
           <div className="flex items-center gap-2">
-            {thread.messages.length > 0 && (
+            {!showOnboarding && messages.length > 0 && (
               <button
                 type="button"
                 onClick={onClear}
                 className="text-xs text-neutral-500 underline-offset-2 hover:text-neutral-900 hover:underline"
               >
                 Clear
+              </button>
+            )}
+            {!showOnboarding && (
+              <button
+                type="button"
+                onClick={onResetPrefs}
+                className="text-xs text-neutral-500 underline-offset-2 hover:text-neutral-900 hover:underline"
+                title="Update your preferences"
+              >
+                Prefs
               </button>
             )}
             <button
@@ -251,155 +242,204 @@ const AiSearchChat = forwardRef<AiSearchChatHandle>((_props, ref) => {
               </svg>
             </button>
           </div>
-        </div>
+        </header>
 
-        {/* Message list */}
-        <div
-          ref={scrollRef}
-          className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6 sm:py-5"
-        >
-          {thread.messages.length === 0 && !loading && (
-            <EmptyState />
-          )}
-          <ol className="flex flex-col gap-4">
-            {thread.messages.map((m) => (
-              <li key={m.id}>
-                {m.role === "user" ? (
-                  <UserBubble content={m.content} ts={m.ts} />
-                ) : (
-                  <AssistantBubble msg={m} />
-                )}
-              </li>
-            ))}
-            {loading && (
-              <li>
-                <AssistantSkeleton />
-              </li>
-            )}
-          </ol>
-        </div>
-
-        {/* Input row */}
-        <div className="border-t border-neutral-200 p-3 sm:p-4">
-          <form
-            onSubmit={(e) => {
-              e.preventDefault()
-              void submit()
-            }}
-            className="flex items-center gap-2"
-          >
-            <input
-              ref={inputRef}
-              type="text"
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              placeholder={PLACEHOLDER}
-              className="flex-1 rounded-full border border-neutral-300 bg-white px-4 py-2.5 text-sm text-neutral-900 placeholder:text-neutral-400 focus:border-neutral-500 focus:outline-none focus:ring-1 focus:ring-neutral-500 sm:text-base"
-              maxLength={200}
-              autoComplete="off"
-              spellCheck={false}
-            />
-            <button
-              type="submit"
-              disabled={loading || input.trim().length < 2}
-              className="rounded-full bg-neutral-900 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50 sm:text-base"
+        {showOnboarding ? (
+          <OnboardingForm
+            initial={prefs}
+            onDone={onOnboardingDone}
+            onSkip={onOnboardingSkip}
+          />
+        ) : (
+          <>
+            <div
+              ref={scrollRef}
+              className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6 sm:py-5"
             >
-              {loading ? "…" : "Send"}
-            </button>
-          </form>
-        </div>
+              {messages.length === 0 && !isStreaming && <EmptyState prefs={prefs} />}
+              <ol className="flex flex-col gap-4">
+                {messages.map((m) => (
+                  <li key={m.id}>
+                    {m.role === "user" ? (
+                      <UserBubble msg={m} />
+                    ) : (
+                      <AssistantBubble msg={m} />
+                    )}
+                  </li>
+                ))}
+                {isStreaming && messages[messages.length - 1]?.role !== "assistant" && (
+                  <li>
+                    <AssistantSkeleton />
+                  </li>
+                )}
+                {error && (
+                  <li>
+                    <div className="rounded-2xl border border-red-200 bg-red-50 px-3.5 py-3 text-sm text-red-800">
+                      Something went wrong. {error.message ? `(${error.message})` : ""} Try again.
+                    </div>
+                  </li>
+                )}
+              </ol>
+            </div>
+
+            <div className="border-t border-neutral-200 p-3 sm:p-4">
+              <form onSubmit={onSubmit} className="flex items-center gap-2">
+                <input
+                  ref={inputRef}
+                  type="text"
+                  value={input}
+                  onChange={(e) => setInput(e.target.value)}
+                  placeholder={PLACEHOLDER}
+                  disabled={isStreaming}
+                  className="flex-1 rounded-full border border-neutral-300 bg-white px-4 py-2.5 text-sm text-neutral-900 placeholder:text-neutral-400 focus:border-neutral-500 focus:outline-none focus:ring-1 focus:ring-neutral-500 disabled:cursor-not-allowed disabled:opacity-60 sm:text-base"
+                  maxLength={500}
+                  autoComplete="off"
+                  spellCheck={false}
+                />
+                {isStreaming ? (
+                  <button
+                    type="button"
+                    onClick={() => stop()}
+                    className="rounded-full bg-neutral-200 px-4 py-2 text-sm font-medium text-neutral-900 hover:bg-neutral-300 sm:text-base"
+                  >
+                    Stop
+                  </button>
+                ) : (
+                  <button
+                    type="submit"
+                    disabled={input.trim().length < 2}
+                    className="rounded-full bg-neutral-900 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50 sm:text-base"
+                  >
+                    Send
+                  </button>
+                )}
+              </form>
+            </div>
+          </>
+        )}
       </div>
     </div>
   )
-})
-
-AiSearchChat.displayName = "AiSearchChat"
-
-export default AiSearchChat
+}
 
 // ── Sub-components ─────────────────────────────────────────────────────
 
-const assistantSummary = (
-  query: string,
-  products: AiSearchProduct[] | undefined
-): string => {
-  const n = products?.length ?? 0
-  if (n === 0) {
-    return `I couldn't find anything for "${query}" in our catalogue yet. Want to try simpler words, or describe the feel (e.g. "soft, lightweight, summery")?`
-  }
-  // Pick the top title for a hint of context — feels less like an
-  // index page and more like a recommendation. The full list of
-  // products is rendered below this text by the ProductRow grid.
-  const lead = products?.[0]?.title
-  if (n === 1) {
-    return lead
-      ? `Found one — "${lead}" looks like a fit. Tap it for details.`
-      : `Found one match.`
-  }
-  return lead
-    ? `Got it — here are ${n} pieces you might like, starting with "${lead}". Tap any of them to see more.`
-    : `Got it — here are ${n} pieces you might like.`
+const EmptyState = ({ prefs }: { prefs: AiChatPreferences }) => {
+  const hasPrefs =
+    (prefs.colors?.length ?? 0) +
+      (prefs.materials?.length ?? 0) +
+      (prefs.styles?.length ?? 0) >
+    0
+  return (
+    <div className="flex h-full flex-col items-center justify-center py-12 text-center">
+      <div className="mb-3 text-3xl">🪡</div>
+      <p className="text-sm text-neutral-700 sm:text-base">
+        {hasPrefs ? "Where should we start?" : "Ask in your own words."}
+      </p>
+      <p className="mt-1 max-w-sm text-xs text-neutral-500 sm:text-sm">
+        Try <em>"show me a soft handwoven cotton kurta"</em>, ask{" "}
+        <em>"how does custom design work?"</em>, or pick a fabric you like.
+      </p>
+    </div>
+  )
 }
 
-const EmptyState = () => (
-  <div className="flex h-full flex-col items-center justify-center py-12 text-center">
-    <div className="mb-3 text-3xl">🪡</div>
-    <p className="text-sm text-neutral-700 sm:text-base">
-      Ask in your own words.
-    </p>
-    <p className="mt-1 max-w-sm text-xs text-neutral-500 sm:text-sm">
-      Try things like <em>"soft cotton dress for summer"</em>,{" "}
-      <em>"red silk under 3000"</em>, or <em>"naturally dyed handloom"</em>.
-    </p>
-  </div>
-)
+const messageText = (msg: UIMessage): string => {
+  const parts = (msg as any).parts as Array<any> | undefined
+  if (!parts) return ""
+  return parts
+    .filter((p) => p?.type === "text")
+    .map((p) => p.text ?? "")
+    .join("")
+}
 
-const UserBubble = ({ content, ts }: { content: string; ts: number }) => (
+const UserBubble = ({ msg }: { msg: UIMessage }) => (
   <div className="flex justify-end">
-    <div className="max-w-[80%] rounded-2xl rounded-br-sm bg-neutral-900 px-3.5 py-2 text-sm text-white sm:text-base">
-      {content}
-      <div className="mt-0.5 text-right text-[10px] text-neutral-400 sm:text-[11px]">
-        {formatRelativeTime(ts)}
-      </div>
+    <div className="max-w-[80%] rounded-2xl rounded-br-sm bg-neutral-900 px-3.5 py-2 text-sm text-white sm:text-base whitespace-pre-wrap">
+      {messageText(msg)}
     </div>
   </div>
 )
 
-const AssistantBubble = ({ msg }: { msg: AiChatMessage }) => {
-  const products = msg.products ?? []
+const AssistantBubble = ({ msg }: { msg: UIMessage }) => {
+  const parts = (msg as any).parts as Array<any> | undefined
+  if (!parts?.length) {
+    return (
+      <div className="flex justify-start">
+        <div className="rounded-2xl rounded-bl-sm border border-neutral-200 bg-neutral-50 px-3.5 py-3 text-sm text-neutral-900 sm:text-base">
+          <AssistantTypingDots />
+        </div>
+      </div>
+    )
+  }
   return (
     <div className="flex justify-start">
       <div className="w-full max-w-[92%] rounded-2xl rounded-bl-sm border border-neutral-200 bg-neutral-50 px-3.5 py-3 text-sm text-neutral-900 sm:text-base">
-        <p>{msg.content}</p>
-        {products.length > 0 && (
-          <ul className="mt-3 flex flex-col gap-2">
-            {products.map((p) => (
-              <ProductRow key={p.id} product={p} />
-            ))}
-          </ul>
-        )}
-        {msg.interpretation && (
-          <p className="mt-2 text-[11px] text-neutral-500 sm:text-xs">
-            Interpreted as:{" "}
-            {[
-              msg.interpretation.keywords?.join(", "),
-              msg.interpretation.color,
-              msg.interpretation.material,
-              msg.interpretation.max_price ? `under ${msg.interpretation.max_price}` : null,
-            ]
-              .filter(Boolean)
-              .join(" · ")}
-          </p>
-        )}
+        {parts.map((part: any, i: number) => {
+          if (part.type === "text") {
+            return (
+              <p key={i} className="whitespace-pre-wrap">
+                {part.text}
+              </p>
+            )
+          }
+          // Tool calls in the v5 protocol are typed as `tool-<name>`.
+          if (typeof part.type === "string" && part.type.startsWith("tool-")) {
+            return <SearchProductsCall key={i} part={part} />
+          }
+          return null
+        })}
       </div>
     </div>
   )
 }
 
-const ProductRow = ({ product }: { product: AiSearchProduct }) => {
+const SearchProductsCall = ({ part }: { part: any }) => {
+  const state = part?.state as string | undefined
+  // Show a small "looking up" pill while the tool is running.
+  if (state === "input-streaming" || state === "input-available") {
+    const args = part.input ?? {}
+    const summary = [args.query, args.color, args.material]
+      .filter(Boolean)
+      .join(" · ")
+    return (
+      <p className="mt-2 inline-flex items-center gap-2 rounded-full bg-neutral-100 px-2.5 py-1 text-xs text-neutral-600">
+        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-neutral-400" />
+        Looking for{summary ? ` "${summary}"` : ""}…
+      </p>
+    )
+  }
+  if (state === "output-error") {
+    return (
+      <p className="mt-2 text-xs text-red-600">
+        Couldn't reach the catalogue right now.
+      </p>
+    )
+  }
+  if (state === "output-available") {
+    const output = part.output as SearchToolOutput
+    const products = output?.products ?? []
+    if (!products.length) {
+      return (
+        <p className="mt-2 text-xs text-neutral-500">
+          No matches in the catalogue for that.
+        </p>
+      )
+    }
+    return (
+      <ul className="mt-3 flex flex-col gap-2">
+        {products.map((p) => (
+          <ProductRow key={p.id} product={p} />
+        ))}
+      </ul>
+    )
+  }
+  return null
+}
+
+const ProductRow = ({ product }: { product: ProductHit }) => {
   const attribution = product.storefront
   const isPartner = attribution?.kind === "partner" && Boolean(attribution.url)
-
   const inner = (
     <>
       {product.thumbnail ? (
@@ -414,25 +454,20 @@ const ProductRow = ({ product }: { product: AiSearchProduct }) => {
       )}
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
-          <p className="truncate text-sm font-medium sm:text-base">
-            {product.title}
-          </p>
+          <p className="truncate text-sm font-medium sm:text-base">{product.title}</p>
           {isPartner && (
             <span className="shrink-0 rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-800 sm:text-[11px]">
               Partner
             </span>
           )}
         </div>
-        {isPartner && attribution.partner_name && (
-          <p className="text-xs text-neutral-500">
-            sold by {attribution.partner_name}
-          </p>
+        {isPartner && attribution.kind === "partner" && attribution.partner_name && (
+          <p className="text-xs text-neutral-500">sold by {attribution.partner_name}</p>
         )}
       </div>
     </>
   )
-
-  if (isPartner && attribution.url) {
+  if (isPartner && attribution.kind === "partner" && attribution.url) {
     return (
       <li>
         <a
@@ -458,14 +493,18 @@ const ProductRow = ({ product }: { product: AiSearchProduct }) => {
   )
 }
 
+const AssistantTypingDots = () => (
+  <span className="flex items-center gap-1">
+    <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-neutral-400" />
+    <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-neutral-400 [animation-delay:120ms]" />
+    <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-neutral-400 [animation-delay:240ms]" />
+  </span>
+)
+
 const AssistantSkeleton = () => (
   <div className="flex justify-start">
     <div className="rounded-2xl rounded-bl-sm border border-neutral-200 bg-neutral-50 px-3.5 py-3">
-      <div className="flex items-center gap-1">
-        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-neutral-400" />
-        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-neutral-400 [animation-delay:120ms]" />
-        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-neutral-400 [animation-delay:240ms]" />
-      </div>
+      <AssistantTypingDots />
     </div>
   </div>
 )

--- a/apps/storefront/src/modules/home/components/ai-search-chat/onboarding.tsx
+++ b/apps/storefront/src/modules/home/components/ai-search-chat/onboarding.tsx
@@ -1,0 +1,233 @@
+"use client"
+
+import { useState } from "react"
+import {
+  savePreferences,
+  type AiChatPreferences,
+  type ChatFit,
+} from "@lib/util/ai-chat-preferences"
+
+/**
+ * One-screen onboarding capture rendered the first time a customer
+ * opens the chat. Captures a thin profile (colors / materials / fit /
+ * size / price range) so the agent can personalise from turn one
+ * instead of asking onboarding-style questions in chat.
+ *
+ * "Skip" is intentional and prominent: shoppers who'd rather just
+ * chat shouldn't have to fill anything. `onboarded` is set either way
+ * so we don't ask again.
+ */
+
+const COLOR_OPTIONS = [
+  "ivory",
+  "natural",
+  "indigo",
+  "rust",
+  "olive",
+  "black",
+  "saffron",
+  "rose",
+]
+const STYLE_OPTIONS = ["minimal", "bohemian", "structured", "drapey"]
+const MATERIAL_OPTIONS = ["cotton", "silk", "linen", "muslin"]
+const SIZE_OPTIONS = ["XS", "S", "M", "L", "XL"]
+const FIT_OPTIONS: ChatFit[] = ["relaxed", "fitted"]
+
+type Props = {
+  initial?: AiChatPreferences
+  onDone: (prefs: AiChatPreferences) => void
+  onSkip: () => void
+}
+
+const toggleIn = (list: string[] | undefined, value: string): string[] => {
+  const current = list ?? []
+  return current.includes(value)
+    ? current.filter((v) => v !== value)
+    : [...current, value]
+}
+
+export default function OnboardingForm({ initial, onDone, onSkip }: Props) {
+  const [colors, setColors] = useState<string[]>(initial?.colors ?? [])
+  const [styles, setStyles] = useState<string[]>(initial?.styles ?? [])
+  const [materials, setMaterials] = useState<string[]>(initial?.materials ?? [])
+  const [size, setSize] = useState<string | undefined>(initial?.body?.size)
+  const [fit, setFit] = useState<ChatFit | undefined>(initial?.body?.fit)
+  const [maxPrice, setMaxPrice] = useState<number | undefined>(
+    initial?.price_range?.max
+  )
+
+  const submit = () => {
+    const next: AiChatPreferences = {
+      colors: colors.length ? colors : undefined,
+      styles: styles.length ? styles : undefined,
+      materials: materials.length ? materials : undefined,
+      body: size || fit ? { size, fit } : undefined,
+      price_range: maxPrice ? { max: maxPrice } : undefined,
+      onboarded: true,
+    }
+    savePreferences(next)
+    onDone(next)
+  }
+
+  const skip = () => {
+    savePreferences({ onboarded: true })
+    onSkip()
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-y-auto">
+      <div className="px-4 py-4 sm:px-6 sm:py-5">
+        <h2 className="text-lg font-medium text-neutral-900 sm:text-xl">
+          Hey there — quick intro?
+        </h2>
+        <p className="mt-1 text-sm text-neutral-500 sm:text-base">
+          Tell us a little about what you like so we can show you the right
+          pieces. Skip if you'd rather just chat.
+        </p>
+      </div>
+
+      <div className="flex-1 space-y-5 px-4 pb-4 sm:px-6 sm:pb-5">
+        <ChipGroup
+          label="Colors you reach for"
+          options={COLOR_OPTIONS}
+          selected={colors}
+          onToggle={(v) => setColors((s) => toggleIn(s, v))}
+        />
+        <ChipGroup
+          label="Materials you like"
+          options={MATERIAL_OPTIONS}
+          selected={materials}
+          onToggle={(v) => setMaterials((s) => toggleIn(s, v))}
+        />
+        <ChipGroup
+          label="Style"
+          options={STYLE_OPTIONS}
+          selected={styles}
+          onToggle={(v) => setStyles((s) => toggleIn(s, v))}
+        />
+
+        <div>
+          <p className="mb-2 text-sm font-medium text-neutral-700">
+            Usual size
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {SIZE_OPTIONS.map((s) => (
+              <Chip
+                key={s}
+                label={s}
+                selected={size === s}
+                onClick={() => setSize(size === s ? undefined : s)}
+              />
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <p className="mb-2 text-sm font-medium text-neutral-700">
+            Fit preference
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {FIT_OPTIONS.map((f) => (
+              <Chip
+                key={f}
+                label={f}
+                selected={fit === f}
+                onClick={() => setFit(fit === f ? undefined : f)}
+              />
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="mb-2 block text-sm font-medium text-neutral-700">
+            Comfortable spend per piece (optional)
+          </label>
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-neutral-500">up to</span>
+            <input
+              type="number"
+              inputMode="numeric"
+              min={500}
+              max={50000}
+              step={500}
+              placeholder="e.g. 5000"
+              value={maxPrice ?? ""}
+              onChange={(e) => {
+                const n = Number(e.target.value)
+                setMaxPrice(Number.isFinite(n) && n > 0 ? Math.round(n) : undefined)
+              }}
+              className="w-36 rounded-md border border-neutral-300 px-3 py-1.5 text-sm focus:border-neutral-500 focus:outline-none focus:ring-1 focus:ring-neutral-500"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="border-t border-neutral-200 p-4 sm:p-5">
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={submit}
+            className="flex-1 rounded-full bg-neutral-900 px-4 py-2.5 text-sm font-medium text-white hover:bg-neutral-800 sm:text-base"
+          >
+            Looks good
+          </button>
+          <button
+            type="button"
+            onClick={skip}
+            className="rounded-full px-4 py-2.5 text-sm text-neutral-500 hover:text-neutral-900 sm:text-base"
+          >
+            Skip
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const ChipGroup = ({
+  label,
+  options,
+  selected,
+  onToggle,
+}: {
+  label: string
+  options: string[]
+  selected: string[]
+  onToggle: (value: string) => void
+}) => (
+  <div>
+    <p className="mb-2 text-sm font-medium text-neutral-700">{label}</p>
+    <div className="flex flex-wrap gap-2">
+      {options.map((o) => (
+        <Chip
+          key={o}
+          label={o}
+          selected={selected.includes(o)}
+          onClick={() => onToggle(o)}
+        />
+      ))}
+    </div>
+  </div>
+)
+
+const Chip = ({
+  label,
+  selected,
+  onClick,
+}: {
+  label: string
+  selected: boolean
+  onClick: () => void
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={`rounded-full border px-3 py-1.5 text-sm transition ${
+      selected
+        ? "border-neutral-900 bg-neutral-900 text-white"
+        : "border-neutral-300 bg-white text-neutral-700 hover:border-neutral-500"
+    }`}
+  >
+    {label}
+  </button>
+)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -792,6 +792,9 @@ importers:
 
   apps/storefront:
     dependencies:
+      '@ai-sdk/react':
+        specifier: ^2.0.194
+        version: 2.0.194(react@19.0.4)(zod@4.3.6)
       '@headlessui/react':
         specifier: ^2.2.0
         version: 2.2.9(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
@@ -1089,6 +1092,12 @@ packages:
     peerDependencies:
       zod: ^4.2.0
 
+  '@ai-sdk/gateway@2.0.93':
+    resolution: {integrity: sha512-aiWQIZIQ69HOySNRLKRPJGsmGtVpPN0qXobK6aKnm8NOEyPbZHYy2ljkSAG5tvaL/Kg015WMInG4x9t2MvnG6A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^4.2.0
+
   '@ai-sdk/google@3.0.31':
     resolution: {integrity: sha512-RVNz8WFSIRbXbYDBE6JvlE2escWPJimBCs22LzKEYH7DNfl/X7cHNa1LFho4PsY6Ib0JmbzB8s2+i0wHs/wNCg==}
     engines: {node: '>=18'}
@@ -1131,6 +1140,12 @@ packages:
     peerDependencies:
       zod: ^4.2.0
 
+  '@ai-sdk/provider-utils@3.0.25':
+    resolution: {integrity: sha512-CvsRu+32Y8a167s+lrIBtsybvgTHp8j9y+6BeTvLeoW3Q+okw/b4CnNUFOLIXsRaKHQKAH+IHNJPYWywfpw0LA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^4.2.0
+
   '@ai-sdk/provider-utils@4.0.15':
     resolution: {integrity: sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==}
     engines: {node: '>=18'}
@@ -1151,9 +1166,23 @@ packages:
     resolution: {integrity: sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==}
     engines: {node: '>=18'}
 
+  '@ai-sdk/provider@2.0.3':
+    resolution: {integrity: sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==}
+    engines: {node: '>=18'}
+
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
+
+  '@ai-sdk/react@2.0.194':
+    resolution: {integrity: sha512-7ZLCBpXyFTPa3530H71Rsz3rYztwkEsNzoP35SdbXCz/QCQNnFpl2/+FRqOdj5RwiMahkVk6/HKovjETytthXg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
+      zod: ^4.2.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@ai-sdk/ui-utils@1.2.11':
     resolution: {integrity: sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==}
@@ -9292,6 +9321,12 @@ packages:
 
   ai@5.0.138:
     resolution: {integrity: sha512-ORkQfHFBnLHgaNhJh1N3fmMQwETLxIHNy5eIDae8qOOZ7FHYxZZVMPQs8T0FiC7MGYFScBmiDJ3s61XvJVBomw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^4.2.0
+
+  ai@5.0.192:
+    resolution: {integrity: sha512-m46S3iEuIcX1TjNfIQf+jr2dj+vmOY6gfhj2aKZutxru1nUnRtbCFAe5pZ9mhDApOv/EpfCrWKudwQqtoMzF0g==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^4.2.0
@@ -17592,6 +17627,10 @@ packages:
   three@0.182.0:
     resolution: {integrity: sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ==}
 
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
+
   through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
 
@@ -18812,6 +18851,13 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 4.3.6
 
+  '@ai-sdk/gateway@2.0.93(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.25(zod@4.3.6)
+      '@vercel/oidc': 3.1.0
+      zod: 4.3.6
+
   '@ai-sdk/google@3.0.31(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -18857,6 +18903,13 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 4.3.6
 
+  '@ai-sdk/provider-utils@3.0.25(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.3.6
+
   '@ai-sdk/provider-utils@4.0.15(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -18879,9 +18932,23 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
+  '@ai-sdk/provider@2.0.3':
+    dependencies:
+      json-schema: 0.4.0
+
   '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
+
+  '@ai-sdk/react@2.0.194(react@19.0.4)(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider-utils': 3.0.25(zod@4.3.6)
+      ai: 5.0.192(zod@4.3.6)
+      react: 19.0.4
+      swr: 2.4.0(react@19.0.4)
+      throttleit: 2.1.0
+    optionalDependencies:
+      zod: 4.3.6
 
   '@ai-sdk/ui-utils@1.2.11(zod@4.3.6)':
     dependencies:
@@ -32476,6 +32543,14 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 4.3.6
 
+  ai@5.0.192(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/gateway': 2.0.93(zod@4.3.6)
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.25(zod@4.3.6)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.3.6
+
   ajv-draft-04@1.0.0(ajv@8.13.0):
     optionalDependencies:
       ajv: 8.13.0
@@ -34893,8 +34968,8 @@ snapshots:
       '@typescript-eslint/parser': 8.57.1(eslint@8.10.0)(typescript@5.9.3)
       eslint: 8.10.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.10.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.10.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.10.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.10.0)(typescript@5.9.3))(eslint@8.10.0))(eslint@8.10.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.10.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.10.0)(typescript@5.9.3))(eslint@8.10.0))(eslint@8.10.0))(eslint@8.10.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.10.0)
       eslint-plugin-react: 7.37.5(eslint@8.10.0)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.10.0)
@@ -34913,7 +34988,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.10.0):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.10.0)(typescript@5.9.3))(eslint@8.10.0))(eslint@8.10.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -34924,22 +34999,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.10.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.10.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.10.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.10.0)(typescript@5.9.3))(eslint@8.10.0))(eslint@8.10.0))(eslint@8.10.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.1(eslint@8.10.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.10.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.1(eslint@8.10.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.10.0)(typescript@5.9.3))(eslint@8.10.0))(eslint@8.10.0))(eslint@8.10.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.57.1(eslint@8.10.0)(typescript@5.9.3)
       eslint: 8.10.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.10.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.10.0)(typescript@5.9.3))(eslint@8.10.0))(eslint@8.10.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.10.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.10.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.10.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.10.0)(typescript@5.9.3))(eslint@8.10.0))(eslint@8.10.0))(eslint@8.10.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -34950,7 +35025,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.10.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.1(eslint@8.10.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.10.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.1(eslint@8.10.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@8.10.0)(typescript@5.9.3))(eslint@8.10.0))(eslint@8.10.0))(eslint@8.10.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -42635,6 +42710,12 @@ snapshots:
       react: 18.3.1
       use-sync-external-store: 1.6.0(react@18.3.1)
 
+  swr@2.4.0(react@19.0.4):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.0.4
+      use-sync-external-store: 1.6.0(react@19.0.4)
+
   sync-child-process@1.0.2:
     dependencies:
       sync-message-port: 1.2.0
@@ -42804,6 +42885,8 @@ snapshots:
       three: 0.182.0
 
   three@0.182.0: {}
+
+  throttleit@2.1.0: {}
 
   through2@2.0.5:
     dependencies:


### PR DESCRIPTION
## Summary

Phase 1 of the storefront chat agent — turns the homepage modal into a token-streaming concierge that talks about the brand AND looks up real products, instead of doing a single-shot search.

- **Backend**: public SSE endpoint \`POST /store/ai/chat\` using AI-SDK \`streamText\` + \`pipeUIMessageStreamToResponse\`. Provider chain: admin-configured DB platform for role \`ai_search_chat\` → DashScope → Cloudflare → OpenRouter. \`search_products\` tool wraps the existing vector+lexical pipeline. Brand corpus injected into the system prompt.
- **Storefront**: Next.js proxy at \`/api/ai-chat\` keeps \`MEDUSA_BACKEND_URL\` server-side and streams responses through. One-screen onboarding capture (colors / materials / styles / size / fit / max price). Modal rewritten around \`@ai-sdk/react\` \`useChat\` with a custom transport that sends \`visitor_id\` + prefs every turn. Tool-call lifecycle rendered inline ("Looking for…" pill → product cards).
- **Identity**: chat reuses \`localStorage["jyt_visitor_id"]\` so the visit ties back to the same id used by cart + analytics. Phase 2 will attach \`customer_id\` on sign-in by row update — no merge needed.

Plan + open questions are captured in \`apps/docs/docs/implementation/ai/storefront-chat-agent.md\`.

## What's deferred (Phase 2+)
- \`save_preferences\` + \`get_brand_info\` tools, server-side thread persistence (\`chat_threads\` module), customer_id attribution on sign-in.
- Admin UI for setting the default chat platform per role.
- Region-aware pricing in search results.
- HeroSeenMarker reliability (separate bug).

## Test plan
- [ ] Open homepage modal — onboarding renders, Skip and "Looks good" both close it and the input gains focus.
- [ ] Ask "show me a soft handwoven cotton kurta" — text streams in token-by-token, "Looking for…" pill appears, then product cards under the bubble.
- [ ] Ask "how does custom design work?" — answer mentions \`/design\` and the self-service flow (no product cards).
- [ ] Reload — prefs persist, message list resets (Phase 2 will sync thread server-side).
- [ ] Network tab: only same-origin POSTs to \`/api/ai-chat\`; \`MEDUSA_BACKEND_URL\` does not leak into the bundle.
- [ ] DevTools → Application → localStorage: \`jyt_visitor_id\` populated; \`jyt:store:ai-chat-prefs-v1\` populated after onboarding.
- [ ] Stop button cancels mid-stream.
- [ ] No regression on \`/store\` inline AI search (separate endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)