### PR TITLE
feat(storefront/chat): onboarding focus modal + exit prompt + LLM payload fix

### DIFF
--- a/apps/backend/src/api/store/ai/chat/route.ts
+++ b/apps/backend/src/api/store/ai/chat/route.ts
@@ -51,18 +51,42 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     search_products: createSearchProductsTool(req.scope as any),
   }
 
-  // Normalise the inbound UI messages. The AI-SDK v5 client posts
-  // {role, parts:[{type:"text",text}]}; older clients may post
-  // {role, content:"..."}. Coerce both into the parts shape so
-  // convertToModelMessages produces clean ModelMessages.
+  // Normalise the inbound UI messages.
+  //
+  // The AI-SDK v5 client posts {id, role, parts:[{type:"text",text}, …,
+  // {type:"tool-search_products", state, input, output, toolCallId, …}]}.
+  // Older clients may post {role, content:"..."}.
+  //
+  // Two things to strip before `convertToModelMessages`:
+  //
+  //   1. `id` on each message — UI-only field. Some OpenAI-compatible
+  //      shims (DashScope, Cloudflare) bubble it into the upstream
+  //      payload and reject with "invalid request: unrecognised fields,
+  //      id". The model doesn't need it.
+  //
+  //   2. Tool parts from prior turns. The client serialises them with
+  //      the full SDK shape (state machine, tool-call ids, inputs,
+  //      outputs). When `convertToModelMessages` rebuilds the ModelMessage
+  //      from these it can produce assistant/tool message pairs whose
+  //      tool_call_id format the provider doesn't accept — same
+  //      "unrecognised field" error, different keys. Pruning tool parts
+  //      from history is lossy (the model can't remember it searched
+  //      already and may re-call the tool) but keeps the request shape
+  //      clean. Phase 2 will move thread state server-side and let us
+  //      serialise tool calls in a canonical shape.
   const messages = body.messages.map((m: any) => {
-    if (Array.isArray(m.parts) && m.parts.length) {
-      return { id: m.id, role: m.role, parts: m.parts }
-    }
+    const parts = Array.isArray(m.parts) ? m.parts : null
+    const textParts = parts
+      ? parts
+          .filter((p: any) => p?.type === "text" && typeof p.text === "string" && p.text.length > 0)
+          .map((p: any) => ({ type: "text", text: p.text }))
+      : [{ type: "text", text: String(m.content ?? "") }]
+
     return {
-      id: m.id,
       role: m.role,
-      parts: [{ type: "text", text: String(m.content ?? "") }],
+      parts: textParts.length
+        ? textParts
+        : [{ type: "text", text: "" }],
     }
   })
 

--- a/apps/storefront/src/app/[countryCode]/(main)/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/page.tsx
@@ -1,7 +1,6 @@
 import { Metadata } from "next"
 import { cookies } from "next/headers"
 
-import AiSearchTrigger from "@modules/home/components/ai-search-chat/trigger"
 import FeaturedProducts from "@modules/home/components/featured-products"
 import Hero from "@modules/home/components/hero"
 import HolidaySection from "@modules/home/components/holidays"
@@ -89,12 +88,6 @@ export default async function Home(props: {
         <ScrollStage hero={<Hero />} holiday={holidaySection} />
       )}
       <HeroSeenMarker />
-      <div className="mx-auto mt-8 flex w-full max-w-2xl flex-col items-center gap-2 px-4 sm:mt-10 sm:px-6">
-        <AiSearchTrigger />
-        <p className="text-center text-xs text-neutral-500 sm:text-sm">
-          Natural-language discovery — opens a conversation with AI.
-        </p>
-      </div>
       <div id="shop" className="py-12">
         <ul className="flex flex-col gap-x-6">
           <FeaturedProducts collections={collections} region={region} />

--- a/apps/storefront/src/modules/home/components/ai-search-chat/exit-prompt.tsx
+++ b/apps/storefront/src/modules/home/components/ai-search-chat/exit-prompt.tsx
@@ -1,0 +1,101 @@
+"use client"
+
+import { useEffect } from "react"
+
+/**
+ * Small confirmation dialog used when the user tries to dismiss the
+ * onboarding modal with unsaved selections.
+ *
+ * Modelled on Medusa admin's Prompt usage in route-modal-form.tsx —
+ * Cancel keeps the underlying modal open, Continue discards the changes
+ * and lets the parent close. Pure Tailwind so we don't pull
+ * `@medusajs/ui` into the storefront just for this.
+ *
+ * Lives on top of the underlying modal — uses z-[60] so the backdrop
+ * sits above the chat modal (z-50). Escape on this prompt cancels (NOT
+ * proceed) so a stray keystroke doesn't lose work.
+ */
+type Props = {
+  open: boolean
+  title?: string
+  description?: string
+  cancelLabel?: string
+  confirmLabel?: string
+  onCancel: () => void
+  onConfirm: () => void
+}
+
+export default function ExitPrompt({
+  open,
+  title = "Unsaved selections",
+  description = "You've started telling us what you like. Leave anyway?",
+  cancelLabel = "Cancel",
+  confirmLabel = "Leave",
+  onCancel,
+  onConfirm,
+}: Props) {
+  // Escape on the prompt cancels — never proceed. A user dismissing the
+  // chat modal probably wants to undo, not commit to losing input.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation()
+        onCancel()
+      }
+    }
+    window.addEventListener("keydown", onKey, { capture: true })
+    return () => window.removeEventListener("keydown", onKey, { capture: true })
+  }, [open, onCancel])
+
+  if (!open) return null
+
+  return (
+    <div
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="exit-prompt-title"
+      aria-describedby="exit-prompt-desc"
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 p-4"
+    >
+      <button
+        type="button"
+        aria-label="Dismiss prompt"
+        onClick={onCancel}
+        className="absolute inset-0 cursor-default"
+        tabIndex={-1}
+      />
+      <div className="relative z-10 w-full max-w-sm rounded-2xl bg-white p-5 shadow-2xl sm:p-6">
+        <h3
+          id="exit-prompt-title"
+          className="text-base font-medium text-neutral-900 sm:text-lg"
+        >
+          {title}
+        </h3>
+        <p
+          id="exit-prompt-desc"
+          className="mt-1 text-sm text-neutral-600 sm:text-base"
+        >
+          {description}
+        </p>
+        <div className="mt-5 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-full px-4 py-2 text-sm text-neutral-700 hover:bg-neutral-100 sm:text-base"
+            autoFocus
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="rounded-full bg-neutral-900 px-4 py-2 text-sm font-medium text-white hover:bg-neutral-800 sm:text-base"
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/storefront/src/modules/home/components/ai-search-chat/index.tsx
+++ b/apps/storefront/src/modules/home/components/ai-search-chat/index.tsx
@@ -20,6 +20,7 @@ import {
 } from "@lib/util/ai-chat-preferences"
 import { getOrCreateVisitorId } from "@lib/util/visitor-id"
 import OnboardingForm from "./onboarding"
+import ExitPrompt from "./exit-prompt"
 
 /**
  * Chat-style concierge modal.
@@ -78,6 +79,13 @@ export default function AiSearchChat({ ref }: AiSearchChatProps) {
   const [input, setInput] = useState("")
   const [prefs, setPrefs] = useState<AiChatPreferences>({})
   const [showOnboarding, setShowOnboarding] = useState(false)
+  // Dirty state of the onboarding form. Lives here (not in
+  // OnboardingForm) so the close path can decide whether to confirm.
+  const [onboardingDirty, setOnboardingDirty] = useState(false)
+  // When set, the exit prompt is showing because the user tried to
+  // close with unsaved selections. Confirming the prompt calls into
+  // this callback.
+  const [pendingClose, setPendingClose] = useState<null | (() => void)>(null)
   // Lazily resolved on open — SSR can't touch localStorage.
   const visitorIdRef = useRef<string | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
@@ -122,14 +130,31 @@ export default function AiSearchChat({ ref }: AiSearchChatProps) {
     []
   )
 
+  // Centralised close request. Backdrop click, the X button, and the
+  // Escape key all flow through this so the dirty-prompt is enforced
+  // exactly once and the "Leave" / "Cancel" paths agree. Returning
+  // early when the exit prompt is already on screen prevents the
+  // prompt from blinking when the user hammers Escape.
+  const requestClose = useCallback(() => {
+    if (pendingClose) return
+    if (showOnboarding && onboardingDirty) {
+      setPendingClose(() => () => {
+        setOpen(false)
+        setPendingClose(null)
+      })
+      return
+    }
+    setOpen(false)
+  }, [pendingClose, showOnboarding, onboardingDirty])
+
   useEffect(() => {
     if (!open) return
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false)
+      if (e.key === "Escape") requestClose()
     }
     window.addEventListener("keydown", onKey)
     return () => window.removeEventListener("keydown", onKey)
-  }, [open])
+  }, [open, requestClose])
 
   useEffect(() => {
     if (!open) return
@@ -166,6 +191,7 @@ export default function AiSearchChat({ ref }: AiSearchChatProps) {
   const onOnboardingDone = useCallback((next: AiChatPreferences) => {
     setPrefs(next)
     setShowOnboarding(false)
+    setOnboardingDirty(false)
     window.setTimeout(() => inputRef.current?.focus(), 0)
   }, [])
 
@@ -175,6 +201,7 @@ export default function AiSearchChat({ ref }: AiSearchChatProps) {
     // skip handler already wrote { onboarded: true }.
     setPrefs((p) => ({ ...p, onboarded: true }))
     setShowOnboarding(false)
+    setOnboardingDirty(false)
     window.setTimeout(() => inputRef.current?.focus(), 0)
   }, [])
 
@@ -186,21 +213,41 @@ export default function AiSearchChat({ ref }: AiSearchChatProps) {
 
   if (!open) return null
 
+  // Two layouts share the same backdrop:
+  //   - Onboarding: FocusModal-style. The panel is the full viewport on
+  //     every breakpoint so the form has space to breathe and body
+  //     scroll is fully blocked (the dialog itself is the scroll
+  //     container). No rounded panel, no backdrop padding.
+  //   - Chat: standard centred panel that floats inside a dimmed
+  //     backdrop on sm+.
+  const panelLayout = showOnboarding
+    ? // Full-bleed on every breakpoint.
+      "flex h-full w-full flex-col bg-white"
+    : // Centred panel with a dimmed backdrop on sm+.
+      "flex h-full w-full flex-col bg-white sm:h-[80vh] sm:max-h-[680px] sm:w-full sm:max-w-2xl sm:rounded-2xl sm:shadow-2xl"
+  const wrapperLayout = showOnboarding
+    ? "fixed inset-0 z-50 flex flex-col bg-white"
+    : "fixed inset-0 z-50 flex flex-col bg-white sm:items-center sm:justify-center sm:bg-black/40 sm:p-6"
+
   return (
     <div
       role="dialog"
       aria-modal="true"
-      aria-label="AI concierge"
-      className="fixed inset-0 z-50 flex flex-col bg-white sm:items-center sm:justify-center sm:bg-black/40 sm:p-6"
+      aria-label={showOnboarding ? "Tell us what you like" : "AI concierge"}
+      className={wrapperLayout}
     >
-      <button
-        type="button"
-        aria-label="Close"
-        className="absolute inset-0 hidden cursor-default sm:block"
-        onClick={() => setOpen(false)}
-        tabIndex={-1}
-      />
-      <div className="relative z-10 flex h-full w-full flex-col bg-white sm:h-[80vh] sm:max-h-[680px] sm:w-full sm:max-w-2xl sm:rounded-2xl sm:shadow-2xl">
+      {/* Backdrop click only closes the chat view — onboarding is a
+          focus modal, so backdrop is solid and not clickable. */}
+      {!showOnboarding && (
+        <button
+          type="button"
+          aria-label="Close"
+          className="absolute inset-0 hidden cursor-default sm:block"
+          onClick={requestClose}
+          tabIndex={-1}
+        />
+      )}
+      <div className={`relative z-10 ${panelLayout}`}>
         <header className="flex items-center justify-between border-b border-neutral-200 px-4 py-3 sm:px-6 sm:py-4">
           <div className="flex flex-col">
             <p className="text-sm font-medium text-neutral-900 sm:text-base">
@@ -232,7 +279,7 @@ export default function AiSearchChat({ ref }: AiSearchChatProps) {
             )}
             <button
               type="button"
-              onClick={() => setOpen(false)}
+              onClick={requestClose}
               aria-label="Close"
               className="rounded-full p-1 text-neutral-500 hover:bg-neutral-100 hover:text-neutral-900"
             >
@@ -249,6 +296,7 @@ export default function AiSearchChat({ ref }: AiSearchChatProps) {
             initial={prefs}
             onDone={onOnboardingDone}
             onSkip={onOnboardingSkip}
+            onDirtyChange={setOnboardingDirty}
           />
         ) : (
           <>
@@ -318,6 +366,17 @@ export default function AiSearchChat({ ref }: AiSearchChatProps) {
           </>
         )}
       </div>
+      {/* Unsaved-changes prompt — appears above the modal when the user
+          tries to dismiss the onboarding sheet mid-edit. */}
+      <ExitPrompt
+        open={!!pendingClose}
+        title="Unsaved selections"
+        description="You've started telling us what you like. Leave anyway?"
+        confirmLabel="Leave"
+        cancelLabel="Keep editing"
+        onCancel={() => setPendingClose(null)}
+        onConfirm={() => pendingClose?.()}
+      />
     </div>
   )
 }

--- a/apps/storefront/src/modules/home/components/ai-search-chat/onboarding.tsx
+++ b/apps/storefront/src/modules/home/components/ai-search-chat/onboarding.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import {
   savePreferences,
   type AiChatPreferences,
@@ -37,6 +37,12 @@ type Props = {
   initial?: AiChatPreferences
   onDone: (prefs: AiChatPreferences) => void
   onSkip: () => void
+  /**
+   * Notifies the parent when the form transitions between clean and
+   * dirty. The parent uses this to gate "are you sure you want to
+   * leave?" prompts on close attempts.
+   */
+  onDirtyChange?: (dirty: boolean) => void
 }
 
 const toggleIn = (list: string[] | undefined, value: string): string[] => {
@@ -46,7 +52,12 @@ const toggleIn = (list: string[] | undefined, value: string): string[] => {
     : [...current, value]
 }
 
-export default function OnboardingForm({ initial, onDone, onSkip }: Props) {
+export default function OnboardingForm({
+  initial,
+  onDone,
+  onSkip,
+  onDirtyChange,
+}: Props) {
   const [colors, setColors] = useState<string[]>(initial?.colors ?? [])
   const [styles, setStyles] = useState<string[]>(initial?.styles ?? [])
   const [materials, setMaterials] = useState<string[]>(initial?.materials ?? [])
@@ -55,6 +66,27 @@ export default function OnboardingForm({ initial, onDone, onSkip }: Props) {
   const [maxPrice, setMaxPrice] = useState<number | undefined>(
     initial?.price_range?.max
   )
+
+  // Dirty when any field has been edited away from the initial value.
+  // Shallow set-equality is enough for the chip groups (no duplicates,
+  // unordered semantics, small lists). The parent uses this to decide
+  // whether closing should prompt the user.
+  const sameSet = (a: string[], b: string[] | undefined) => {
+    const other = b ?? []
+    if (a.length !== other.length) return false
+    return a.every((v) => other.includes(v))
+  }
+  const dirty =
+    !sameSet(colors, initial?.colors) ||
+    !sameSet(styles, initial?.styles) ||
+    !sameSet(materials, initial?.materials) ||
+    size !== initial?.body?.size ||
+    fit !== initial?.body?.fit ||
+    maxPrice !== initial?.price_range?.max
+
+  useEffect(() => {
+    onDirtyChange?.(dirty)
+  }, [dirty, onDirtyChange])
 
   const submit = () => {
     const next: AiChatPreferences = {


### PR DESCRIPTION
## Summary

Three threads that share the same on-screen surface:

1. **Onboarding → full-viewport focus modal.** The intro sheet now fills the viewport on every breakpoint when active (no rounded panel, no inset). Body scroll stays locked by the existing modal mount logic, so the form is the only scroll container — no phantom scroll behind the modal on big screens. The chat view keeps the standard centred panel; sizing is gated on \`showOnboarding\`.

2. **Unsaved-changes prompt on dismiss.** \`OnboardingForm\` now reports a \`dirty\` boolean (any field different from initial) via \`onDirtyChange\`. All three close paths — X button, backdrop click, Escape — route through a single \`requestClose()\`. If the onboarding is showing and dirty, close is deferred behind an \`ExitPrompt\` ("Unsaved selections / Leave anyway?"). Modelled on admin's \`RouteModalForm\` \`Prompt\` usage. Pure Tailwind — no \`@medusajs/ui\` pull-in.

3. **Remove duplicate home search bar.** The \`AiSearchTrigger\` block between Hero/Holiday and FeaturedProducts is gone. The hero already centres the chat trigger; the duplicate created three CTAs stacked vertically.

## Backend fix — LLM "unrecognised fields, id"

\`/store/ai/chat\` strips \`id\` from every UI message and prunes non-text parts before \`convertToModelMessages\`. DashScope / Cloudflare OpenAI-compat shims reject tool-call ids and stray UI fields with that exact error.

Keeping only text parts is lossy (the model won't remember it searched in earlier turns and may re-call the tool), but it produces a clean upstream payload every time. Phase 2's server-side \`chat_threads\` module will reintroduce tool history in a canonical shape.

## Test plan
- [ ] First-time visitor opens chat — onboarding fills the viewport (no rounded panel).
- [ ] Touch any chip / size / fit / price — try to close via X / Escape / backdrop. ExitPrompt appears.
- [ ] "Keep editing" dismisses the prompt, modal stays open with selections intact.
- [ ] "Leave" closes the modal entirely.
- [ ] No selections changed → close paths bypass the prompt and exit immediately.
- [ ] Onboarding "Looks good" / "Skip" both close the prompt without showing the exit confirm (dirty flag resets).
- [ ] Open chat after onboarding — second message no longer surfaces "invalid request: unrecognised fields, id" upstream error.
- [ ] Home page no longer shows the standalone AiSearchTrigger between Hero/Holiday and FeaturedProducts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)