### PR TITLE
fix(partner-api): order/return/shipping-option field-shape crashes

### DIFF
--- a/apps/backend/integration-tests/http/partner-stores-api.spec.ts
+++ b/apps/backend/integration-tests/http/partner-stores-api.spec.ts
@@ -234,6 +234,32 @@ setupSharedTestSuite(() => {
         expect(res.data.count).toBeGreaterThanOrEqual(0)
       })
 
+      it("GET /partners/stores/:id/shipping-options includes service_zone.fulfillment_set.location (regression)", async () => {
+        // The partner-ui's order-create-fulfillment form reads
+        // `shippingOption.service_zone.fulfillment_set.location.id` to
+        // default the location selector. The route builds service_zone
+        // and fulfillment_set inline (not joined from the graph), so if
+        // we forget to attach `location`, the form crashes at render
+        // with "undefined is not an object (evaluating
+        // 'shippingOption.service_zone.fulfillment_set.location.id')".
+        const res = await api.get(
+          `/partners/stores/${partner.storeId}/shipping-options`,
+          { headers: partner.headers }
+        )
+        expect(res.status).toBe(200)
+        const opts = res.data.shipping_options as any[]
+        if (!opts.length) {
+          return
+        }
+        const opt = opts[0]
+        expect(opt.service_zone).toBeDefined()
+        expect(opt.service_zone.fulfillment_set).toBeDefined()
+        expect(opt.service_zone.fulfillment_set.location).toBeDefined()
+        expect(opt.service_zone.fulfillment_set.location.id).toBe(
+          partner.locationId
+        )
+      })
+
       it("POST /partners/stores/:id/shipping-options/:optionId persists prices", async () => {
         // Regression test for the bare-service silent-drop bug: the route
         // previously called fulfillmentService.updateShippingOptions(id, body)

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -18,6 +18,8 @@ import cors from "cors";
 import { z } from "@medusajs/framework/zod";
 import { personSchema, listPersonsQuerySchema, UpdatePersonSchema, ReadPersonQuerySchema } from "./admin/persons/validators";
 import { getPersonResourceDefinition } from "./admin/persons/resources/registry";
+import { AdminGetOrdersOrderParams } from "@medusajs/medusa/api/admin/orders/validators";
+import { retrieveTransformQueryConfig as retrieveOrderTransformQueryConfig } from "@medusajs/medusa/api/admin/orders/query-config";
 
 // Helper function to wrap Zod schemas for compatibility with validateAndTransformBody.
 // Historically this wrapped with z.preprocess((obj) => obj, schema) — under Zod v3
@@ -3928,11 +3930,21 @@ export default defineMiddlewares({
       ],
     },
     {
+      // Without `validateAndTransformQuery` here, the route hands raw
+      // field strings (incl. bare relation paths like `region.automatic_taxes`)
+      // straight to MikroORM populate, which trips
+      // "Cannot read properties of undefined (reading 'kind')". Reusing
+      // admin's exact query config keeps partner-ui field requests in
+      // lockstep with what admin already validates.
       matcher: "/partners/orders/:id",
       method: ["GET", "POST"],
       middlewares: [
         createCorsPartnerMiddleware(),
         authenticate("partner", ["session", "bearer"]),
+        validateAndTransformQuery(
+          AdminGetOrdersOrderParams,
+          retrieveOrderTransformQueryConfig
+        ),
       ],
     },
     {

--- a/apps/backend/src/api/partners/orders/[id]/changes/route.ts
+++ b/apps/backend/src/api/partners/orders/[id]/changes/route.ts
@@ -9,10 +9,30 @@ export const GET = async (
   await validatePartnerOrderOwnership(req.auth_context, req.params.id, req.scope)
 
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  // Pass the `change_type` filter through from the partner-ui. The
+  // OrderTimeline narrows changes to edit/claim/exchange/return/transfer
+  // /update_order — without this filter, every order_change row comes back
+  // and the timeline mis-categorises drafts.
+  const reqQuery = (req.query || {}) as Record<string, any>
+  const filters: Record<string, any> = { order_id: req.params.id }
+  if (reqQuery.change_type) {
+    filters.change_type = Array.isArray(reqQuery.change_type)
+      ? reqQuery.change_type
+      : String(reqQuery.change_type).split(",")
+  }
+
   const { data } = await query.graph({
     entity: "order_change",
-    fields: ["*", "*actions"],
-    filters: { order_id: req.params.id },
+    // `actions.*` not `*actions` — the asterisk-prefix form gets passed
+    // to MikroORM as a literal field name on some entities and throws
+    // "undefined is not an object (reading 'kind')" / "does not have
+    // property '*actions'". Suffix form is the universally-safe one.
+    // Without this, the partner-ui's OrderTimeline crashes at
+    // `change.actions.forEach` because each change comes back without
+    // its actions array.
+    fields: ["*", "actions.*"],
+    filters,
   })
 
   res.json({ order_changes: data || [] })

--- a/apps/backend/src/api/partners/orders/[id]/line-items/route.ts
+++ b/apps/backend/src/api/partners/orders/[id]/line-items/route.ts
@@ -11,7 +11,9 @@ export const GET = async (
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
   const { data } = await query.graph({
     entity: "order",
-    fields: ["*items", "*items.variant", "*items.variant.product"],
+    // `relation.*` not `*relation` — the asterisk-prefix form has tripped
+    // MikroORM on several entities. Admin uses the suffix form.
+    fields: ["items.*", "items.variant.*", "items.variant.product.*"],
     filters: { id: req.params.id },
   })
 

--- a/apps/backend/src/api/partners/orders/[id]/preview/route.ts
+++ b/apps/backend/src/api/partners/orders/[id]/preview/route.ts
@@ -11,7 +11,9 @@ export const GET = async (
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
   const { data } = await query.graph({
     entity: "order",
-    fields: ["*", "*items", "*shipping_methods", "+summary"],
+    // `relation.*` not `*relation` — the asterisk-prefix form has tripped
+    // MikroORM on several entities. Admin uses the suffix form.
+    fields: ["*", "items.*", "shipping_methods.*", "+summary"],
     filters: { id: req.params.id },
   })
 

--- a/apps/backend/src/api/partners/orders/[id]/route.ts
+++ b/apps/backend/src/api/partners/orders/[id]/route.ts
@@ -3,30 +3,28 @@ import { getOrderDetailWorkflow } from "@medusajs/medusa/core-flows"
 import { Modules } from "@medusajs/framework/utils"
 import { validatePartnerOrderOwnership } from "../../helpers"
 
-const DEFAULT_FIELDS = [
-  "id", "status", "created_at", "canceled_at", "email",
-  "display_id", "custom_display_id", "currency_code", "metadata",
-  "total", "credit_line_total", "item_subtotal", "item_total",
-  "item_tax_total", "original_item_tax_total", "item_discount_total",
-  "shipping_subtotal", "original_total", "original_tax_total",
-  "subtotal", "discount_total", "discount_subtotal",
-  "shipping_total", "shipping_tax_total", "original_shipping_tax_total",
-  "shipping_discount_total", "tax_total", "refundable_total", "order_change",
-  "*customer", "*items", "*items.variant", "*items.variant.product",
-  "*items.variant.options", "+items.variant.manage_inventory",
-  "*items.variant.inventory_items.inventory",
-  "+items.variant.inventory_items.required_quantity",
-  "+summary", "*shipping_address", "*billing_address",
-  "*sales_channel", "*promotions", "*shipping_methods", "*credit_lines",
-  "*fulfillments",
-  "+fulfillments.shipping_option.service_zone.fulfillment_set.type",
-  "*fulfillments.items", "*fulfillments.labels",
-  "*payment_collections", "*payment_collections.payments",
-  "*payment_collections.payments.refunds",
-  "*payment_collections.payments.refunds.refund_reason",
-  "region.automatic_taxes",
-]
-
+/**
+ * GET / POST partner order detail.
+ *
+ * Field selection is handled by `validateAndTransformQuery` middleware
+ * (registered in `apps/backend/src/api/middlewares.ts`) using Medusa's
+ * own admin order query config. That middleware:
+ *
+ *   1. Validates `?fields=...` from the request
+ *   2. Merges with the admin defaults (`retrieveTransformQueryConfig.defaults`)
+ *   3. Normalises field paths so bare cross-module references
+ *      (e.g. `region.automatic_taxes`) get expanded via remote-link
+ *      instead of being passed to MikroORM as a bare populate
+ *
+ * Without the middleware, bare relation paths trip
+ * "Cannot read properties of undefined (reading 'kind')" inside
+ * MikroORM's `expandDotPaths` because the Order entity has only
+ * `region_id` scalars, not ORM relations for cross-module entities.
+ *
+ * The previous DEFAULT_FIELDS-on-the-route approach bypassed the
+ * middleware and broke whenever the partner-ui added a new field — see
+ * the order detail crash that motivated this refactor.
+ */
 export const GET = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
@@ -35,8 +33,9 @@ export const GET = async (
 
   const { result } = await getOrderDetailWorkflow(req.scope).run({
     input: {
-      fields: DEFAULT_FIELDS,
+      fields: (req as any).queryConfig.fields,
       order_id: req.params.id,
+      version: (req as any).validatedQuery?.version,
     },
   })
 

--- a/apps/backend/src/api/partners/orders/route.ts
+++ b/apps/backend/src/api/partners/orders/route.ts
@@ -7,6 +7,11 @@ const DEFAULT_FIELDS = [
   "custom_display_id", "payment_status", "fulfillment_status",
   "total", "currency_code",
   "*customer", "*sales_channel", "*payment_collections",
+  // shipping_address (carrying country_code) is needed by the partner-ui
+  // orders table — it renders a country-flag icon per row and falls back
+  // to the customer email/name. Without it, the country column stays
+  // blank.
+  "*shipping_address",
 ]
 
 export const GET = async (

--- a/apps/backend/src/api/partners/orders/route.ts
+++ b/apps/backend/src/api/partners/orders/route.ts
@@ -2,16 +2,32 @@ import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/
 import { getOrdersListWorkflow } from "@medusajs/medusa/core-flows"
 import { getPartnerSalesChannelId, tryGetPartnerSalesChannelId } from "../helpers"
 
+// IMPORTANT: use the `relation.*` suffix syntax, not `*relation` prefix.
+//
+// `getOrdersListWorkflow` -> `useRemoteQueryStep` -> `query.graph` only
+// understands `relation.*` (expand all fields of a relation). The
+// `*relation` form is admin's user-facing convention, but the admin
+// middleware (`validateAndTransformQuery` -> `prepareListQuery`) rewrites
+// it to `relation.*` before handing it to the workflow — see
+// node_modules/@medusajs/framework/.../get-query-config.js#prepareListQuery.
+// We don't run that middleware here, so we have to write the canonical
+// form ourselves.
+//
+// Symptom of getting this wrong: `customer`, `sales_channel`, and
+// `shipping_address` all come back as `null` in the response and even
+// their `_id` scalars get dropped — the orders list table renders blank
+// cells for those columns.
 const DEFAULT_FIELDS = [
   "id", "status", "created_at", "email", "display_id",
   "custom_display_id", "payment_status", "fulfillment_status",
   "total", "currency_code",
-  "*customer", "*sales_channel", "*payment_collections",
-  // shipping_address (carrying country_code) is needed by the partner-ui
-  // orders table — it renders a country-flag icon per row and falls back
-  // to the customer email/name. Without it, the country column stays
-  // blank.
-  "*shipping_address",
+  "customer_id",
+  "sales_channel_id",
+  "shipping_address_id",
+  "customer.*",
+  "sales_channel.*",
+  "payment_collections.*",
+  "shipping_address.*",
 ]
 
 export const GET = async (

--- a/apps/backend/src/api/partners/returns/[id]/route.ts
+++ b/apps/backend/src/api/partners/returns/[id]/route.ts
@@ -11,7 +11,8 @@ export const GET = async (
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
   const { data } = await query.graph({
     entity: "return",
-    fields: ["*", "*items", "*items.item", "*shipping_methods"],
+    // `relation.*` not `*relation` — see ../route.ts for the rationale.
+    fields: ["*", "items.*", "items.item.*", "shipping_methods.*"],
     filters: { id: req.params.id },
   })
 

--- a/apps/backend/src/api/partners/returns/route.ts
+++ b/apps/backend/src/api/partners/returns/route.ts
@@ -19,7 +19,13 @@ export const GET = async (
 
   const { data } = await query.graph({
     entity: "return",
-    fields: ["*", "*items", "*items.item"],
+    // query.graph's "expand relation" syntax is `relation.*`, not
+    // `*relation`. The asterisk-prefix form gets passed to MikroORM as a
+    // literal field name on certain entities (Return here) and throws
+    // "Entity 'Return' does not have property '*items'". Admin uses the
+    // suffix form throughout — see @medusajs/medusa/api/admin/returns/
+    // query-config.js defaultAdminDetailsReturnFields.
+    fields: ["*", "items.*", "items.item.*"],
     filters,
   })
 

--- a/apps/backend/src/api/partners/stores/[id]/shipping-options/route.ts
+++ b/apps/backend/src/api/partners/stores/[id]/shipping-options/route.ts
@@ -55,6 +55,13 @@ export const GET = async (
                     id: fs.id,
                     name: fs.name,
                     type: fs.type,
+                    // The partner-ui's order-create-fulfillment form
+                    // reads shippingOption.service_zone.fulfillment_set.location.id
+                    // to default the location selector. Without including
+                    // location here, the form crashes during render with
+                    // "undefined is not an object (evaluating
+                    // 'shippingOption.service_zone.fulfillment_set.location.id')".
+                    location: { id: location.id, name: location.name },
                   },
                 },
               })

--- a/apps/docs/notes/PARTNER_ORDERS_FIELD_SHAPE_FIXES.md
+++ b/apps/docs/notes/PARTNER_ORDERS_FIELD_SHAPE_FIXES.md
@@ -1,0 +1,167 @@
+# Partner orders + table view fixes (PR #258)
+
+Branch: `fix/partner-ui-orders-fields`
+PR: https://github.com/Jaal-Yantra-Textiles/v2/pull/258
+
+This note captures the field-shape gotchas behind a cascade of partner-ui
+crashes after a partner placed an order locally. Read this before
+touching any partner-API route that passes `fields: [...]` to a
+Medusa workflow / `query.graph` / `useRemoteQueryStep`.
+
+## The core gotcha — `*relation` vs `relation.*`
+
+`query.graph` (and `useRemoteQueryStep`, since it wraps query.graph) only
+understands the asterisk-**suffix** form when you want a relation expanded:
+
+```ts
+fields: ["customer.*", "sales_channel.*", "shipping_address.*"]    // ✅
+fields: ["*customer", "*sales_channel", "*shipping_address"]       // ❌ silently dropped
+```
+
+Admin's user-facing convention is the asterisk-**prefix** form. Admin
+gets away with it because its `validateAndTransformQuery` middleware
+rewrites `*relation` → `relation.*` before it reaches the workflow:
+
+```
+node_modules/@medusajs/framework/.../get-query-config.js — prepareListQuery():
+  fields: [
+    ...Array.from(allFields),
+    ...Array.from(starFields).map((f) => `${f}.*`),   // the rewrite
+  ]
+```
+
+Partner routes bypass `validateAndTransformQuery` for most endpoints (no
+queryConfig wired up), so they need to write the canonical `relation.*`
+form themselves.
+
+### Symptoms when you get this wrong
+
+- The relation comes back as `null` in the JSON response.
+- The corresponding `_id` scalar (e.g. `customer_id`) is `null` too —
+  not just missing. **Don't be fooled into thinking the data is
+  genuinely absent** — check the DB.
+- On certain entities (Return, OrderChange), the workflow throws
+  `Entity 'X' does not have property '*foo'` or `Cannot read properties
+  of undefined (reading 'kind')` from MikroORM `expandDotPaths`.
+- Test "rejects unauthenticated" assertions returning 500 instead of
+  401 is usually a sibling failure: the beforeEach (which depends on
+  the broken route) crashes first.
+
+## Routes audited / patched in this PR
+
+| Route | Before | After |
+|---|---|---|
+| `GET /partners/orders` | `*customer, *sales_channel, *payment_collections, *shipping_address` | `customer.*, sales_channel.*, payment_collections.*, shipping_address.*` + scalar `_id`s |
+| `GET /partners/orders/:id` | hand-rolled DEFAULT_FIELDS including bare `region.automatic_taxes` | `validateAndTransformQuery(AdminGetOrdersOrderParams, retrieveTransformQueryConfig)`, route reads `req.queryConfig.fields` |
+| `GET /partners/orders/:id/line-items` | `*items` | `items.*` |
+| `GET /partners/orders/:id/preview` | `*items` | `items.*` |
+| `GET /partners/orders/:id/changes` | `*actions` | `actions.*` (+ `change_type` filter passthrough) |
+| `GET /partners/returns` | `*items, *items.item` | `items.*, items.item.*` |
+| `GET /partners/returns/:id` | same | same |
+
+When you reuse admin's `retrieveTransformQueryConfig`, import like:
+
+```ts
+import {
+  AdminGetOrdersOrderParams,
+  retrieveTransformQueryConfig as retrieveOrderTransformQueryConfig,
+} from "@medusajs/medusa/api/admin/orders/query-config"
+```
+
+The `retrieveTransformQueryConfig as <alias>` rename avoids collisions
+when you import multiple entity configs into `middlewares.ts`.
+
+## Fulfillment-form crash on `service_zone.fulfillment_set.location.id`
+
+`GET /partners/stores/:id/shipping-options` builds the response inline
+from a graph query — it doesn't return the raw graph rows because the
+partner-ui needs the chain in a specific shape. The original inline
+build forgot to include `location` on the `fulfillment_set`:
+
+```ts
+service_zone: {
+  id, name,
+  fulfillment_set: {
+    id, name, type,
+    location: { id: location.id, name: location.name },  // <-- required
+  },
+}
+```
+
+Without `location`, the partner-ui's order-create-fulfillment form
+crashes during render with
+`undefined is not an object (evaluating 'shippingOption.service_zone.fulfillment_set.location.id')`.
+
+There is now a regression assertion in
+`integration-tests/http/partner-stores-api.spec.ts` —
+"GET /partners/stores/:id/shipping-options includes service_zone.fulfillment_set.location".
+
+## `/admin/plugins` 401 from partner-ui
+
+`apps/partner-ui/src/hooks/api/plugins.tsx` previously called
+`sdk.admin.plugin.list()` — that hits `/admin/plugins`, which is
+admin-only and 401s for partner JWTs. The hook now returns
+`{ plugins: [] }` synchronously. Consumers (`order-summary-section`,
+`order-payment-section`, `order-create-refund`) continue to receive
+the `plugins` prop and the loyalty-plugin lookup just resolves to
+nothing. If we want a real loyalty UI for partners, we'll need a
+partner-scoped proxy route or a feature flag.
+
+## Order table view (UI) notes
+
+Old code path (feature flag `view_configurations` off):
+
+- `apps/partner-ui/src/hooks/table/columns/use-order-table-columns.tsx`
+  ends with a `columnHelper.display(...)` that previously had
+  `id: "actions"` but actually rendered the country flag. Renamed to
+  `id: "country"` to fix the duplicate-key React warning and added
+  `CountryHeader`. Backend ships `country_code` only (scalar), so the
+  cell synthesises `{ iso_2, display_name }` for `CountryCell`.
+
+New code path (feature flag on):
+
+- `useEntityColumns` hits `/admin/views/:entity/columns` via the JS SDK
+  — that endpoint is admin-only too, but we haven't wired a partner
+  proxy yet, so partner-ui silently falls back to no API columns.
+- The built-in computed column registry in `@medusajs/settings` already
+  defines a `country` column for Order with `defaultVisible: true`,
+  requiring `shipping_address.country_code`. So once we expose a
+  partner-side columns endpoint, this column will surface automatically.
+
+## What was NOT fixed in this PR
+
+`partner-orders-api.spec.ts` has 8 lifecycle/Delhivery test failures
+(`full lifecycle: create fulfillment → create shipment → mark delivered`,
+`create fulfillment then cancel it`, the label/tracking/pickup endpoint
+tests, plus the 3 unauth-rejection tests in that describe block).
+
+Root cause: `POST /partners/orders/:id/fulfillments` returns 500 with
+no log surface in the test runner output (only non-blocking subscriber
+errors visible — order.placed email template missing, ad-planning DB
+error). None of today's changes touched the fulfillment workflow, auth
+chain, or label/tracking/pickup routes. Treat as pre-existing.
+
+To debug next: either temporarily patch the test to `console.log
+err.response?.data`, or run a custom curl-based repro against a fresh
+test DB to capture the actual server-side stack.
+
+## How to verify after pulling
+
+```bash
+# 1. Restart the backend dev server (Medusa doesn't always hot-reload
+#    .ts changes into the compiled .medusa/server/src/*.js)
+cd apps/backend && yarn dev
+
+# 2. Hit the orders list endpoint as a partner — relations should
+#    be populated:
+TOKEN=$(curl -s -X POST http://localhost:9000/auth/partner/emailpass \
+  -H "Content-Type: application/json" \
+  -d '{"email":"testing@testing.com","password":"1234"}' | jq -r .token)
+curl -s "http://localhost:9000/partners/orders?limit=1" \
+  -H "Authorization: Bearer $TOKEN" | jq '.orders[0] | {customer, sales_channel, shipping_address}'
+# Expect: customer.email, sales_channel.name, shipping_address.country_code all present.
+
+# 3. Run the store regression test:
+pnpm test:integration:http:shared ./integration-tests/http/partner-stores-api
+# Expect: 14/14 pass.
+```

--- a/apps/partner-ui/src/components/table/table-cells/order/country-cell/country-cell.tsx
+++ b/apps/partner-ui/src/components/table/table-cells/order/country-cell/country-cell.tsx
@@ -1,7 +1,18 @@
 import { Tooltip } from "@medusajs/ui"
 import ReactCountryFlag from "react-country-flag"
+import { useTranslation } from "react-i18next"
 import { PlaceholderCell } from "../../common/placeholder-cell"
 import { HttpTypes } from "@medusajs/types"
+
+export const CountryHeader = () => {
+  const { t } = useTranslation()
+
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <span className="truncate">{t("fields.country", "Country")}</span>
+    </div>
+  )
+}
 
 export const CountryCell = ({
   country,

--- a/apps/partner-ui/src/hooks/api/plugins.tsx
+++ b/apps/partner-ui/src/hooks/api/plugins.tsx
@@ -1,14 +1,18 @@
 import { FetchError } from "@medusajs/js-sdk"
 import { HttpTypes } from "@medusajs/types"
 import { QueryKey, UseQueryOptions, useQuery } from "@tanstack/react-query"
-import { sdk } from "../../lib/client"
 import { queryKeysFactory } from "../../lib/query-key-factory"
 
 const PLUGINS_QUERY_KEY = "plugins" as const
 export const pluginsQueryKeys = queryKeysFactory(PLUGINS_QUERY_KEY)
 
+// `/admin/plugins` is not exposed to partner auth, so the SDK call
+// `sdk.admin.plugin.list()` 401s in the partner-ui. Until we either
+// proxy a partner-scoped variant or remove plugin-aware UI bits
+// (loyalty badge on refund + payment summary), the hook returns an
+// empty list so consumers degrade gracefully without firing a request.
 export const usePlugins = (
-  options?: Omit<
+  _options?: Omit<
     UseQueryOptions<
       any,
       FetchError,
@@ -18,10 +22,10 @@ export const usePlugins = (
     "queryKey" | "queryFn"
   >
 ) => {
-  const { data, ...rest } = useQuery({
-    queryFn: () => sdk.admin.plugin.list(),
+  const { data, ...rest } = useQuery<HttpTypes.AdminPluginsListResponse>({
+    queryFn: async () => ({ plugins: [] }),
     queryKey: pluginsQueryKeys.list(),
-    ...options,
+    staleTime: Infinity,
   })
 
   return { ...data, ...rest }

--- a/apps/partner-ui/src/hooks/table/columns/use-configurable-table-columns.tsx
+++ b/apps/partner-ui/src/hooks/table/columns/use-configurable-table-columns.tsx
@@ -23,7 +23,21 @@ export function useConfigurableTableColumns<TData = any>(
       return []
     }
 
-    return apiColumns.map(apiColumn => {
+    // Defensive dedupe. If the entity columns endpoint ever returns two
+    // entries with the same `field` (and it has — observed on `orders`
+    // where the React tree warned about duplicate `actions` keys), the
+    // generated columns would share `id: apiColumn.field` and React
+    // tree-builds it as siblings with identical keys. Keep the first
+    // occurrence per field; later ones get silently dropped.
+    const seen = new Set<string>()
+    const uniqueApiColumns = apiColumns.filter((c) => {
+      if (!c?.field) return false
+      if (seen.has(c.field)) return false
+      seen.add(c.field)
+      return true
+    })
+
+    return uniqueApiColumns.map(apiColumn => {
       let renderType = apiColumn.computed?.type
 
       if (!renderType) {

--- a/apps/partner-ui/src/hooks/table/columns/use-order-table-columns.tsx
+++ b/apps/partner-ui/src/hooks/table/columns/use-order-table-columns.tsx
@@ -9,7 +9,10 @@ import {
   DateCell,
   DateHeader,
 } from "../../../components/table/table-cells/common/date-cell"
-import { CountryCell } from "../../../components/table/table-cells/order/country-cell"
+import {
+  CountryCell,
+  CountryHeader,
+} from "../../../components/table/table-cells/order/country-cell"
 import {
   CustomerCell,
   CustomerHeader,
@@ -119,9 +122,20 @@ export const useOrderTableColumns = (props: UseOrderTableColumnsProps) => {
         },
       }),
       columnHelper.display({
-        id: "actions",
+        id: "country",
+        header: () => <CountryHeader />,
         cell: ({ row }) => {
-          const country = row.original.shipping_address?.country
+          // Backend `shipping_address` ships `country_code` (scalar) but
+          // not the joined `country` relation. CountryCell needs an object
+          // with `iso_2` and `display_name`, so we synthesize one from
+          // the code — that's enough for the flag + tooltip.
+          const code = row.original.shipping_address?.country_code
+          const country = code
+            ? ({
+                iso_2: code,
+                display_name: code.toUpperCase(),
+              } as HttpTypes.AdminRegionCountry)
+            : null
 
           return <CountryCell country={country} />
         },

--- a/apps/partner-ui/src/routes/orders/order-detail/components/order-activity-section/order-timeline.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/components/order-activity-section/order-timeline.tsx
@@ -1103,7 +1103,12 @@ function getMissingLineItemIds(order: AdminOrder, changes: AdminOrderChange[]) {
   const existingItemsMap = new Map(order.items.map((item) => [item.id, true]))
 
   changes.forEach((change) => {
-    change.actions.forEach((action) => {
+    // Defensive `?? []` — the partner /partners/orders/:id/changes
+    // endpoint used to return changes without their actions populated
+    // (broken `*actions` field syntax) and the whole timeline crashed
+    // at this line. The backend is now fixed but the guard prevents
+    // future drift from re-crashing render.
+    ;(change.actions ?? []).forEach((action) => {
       if (!action.details?.reference_id) {
         return
       }

--- a/apps/partner-ui/src/routes/orders/order-list/const.ts
+++ b/apps/partner-ui/src/routes/orders/order-list/const.ts
@@ -11,7 +11,16 @@ export const DEFAULT_PROPERTIES = [
   "currency_code",
 ]
 
-export const DEFAULT_RELATIONS = ["*customer", "*sales_channel", "*payment_collections"]
+// `*shipping_address` carries `country_code` used by the country-flag
+// column in the table AND falls back to address first/last name for
+// guest orders that have `customer_id = null`. Without it the country
+// column renders empty.
+export const DEFAULT_RELATIONS = [
+  "*customer",
+  "*sales_channel",
+  "*payment_collections",
+  "*shipping_address",
+]
 
 export const DEFAULT_FIELDS = `${DEFAULT_PROPERTIES.join(
   ","


### PR DESCRIPTION
## Summary

Three+ classes of partner-ui crashes after a partner places an order locally:

1. **`/partners/orders/:id` 500** — `Cannot read properties of undefined (reading 'kind')` inside MikroORM `expandDotPaths`. Route was using a hand-rolled `DEFAULT_FIELDS` list containing `region.automatic_taxes` (bare cross-module path) and other unknown field names. Now routes through `validateAndTransformQuery` with admin's exact query config, same as `/admin/orders/:id`.

2. **`*items` / `*actions` → `items.*` / `actions.*`** — `useRemoteQueryStep`/`query.graph` only understands the asterisk-SUFFIX form. The prefix form throws `Entity 'Return' does not have property '*items'` on certain entities. Admin's middleware silently rewrites prefix to suffix; we bypass that middleware, so we have to write the canonical form ourselves.

3. **`/partners/orders` list missing relations** — same root cause as #2: passing `*customer, *sales_channel, *shipping_address` to `getOrdersListWorkflow` returned all-nulls. Switched to `customer.*, sales_channel.*, shipping_address.*` + scalar `_id`s. Fixes blank customer/sales-channel/country columns on the orders list.

4. **Fulfillment form crash** — `TypeError: undefined is not an object (evaluating 'shippingOption.service_zone.fulfillment_set.location.id')`. `/partners/stores/:id/shipping-options` was manually rebuilding the service_zone chain without `location`. Added `{ id, name }` from the already-resolved stock_location, plus a regression test in `partner-stores-api.spec.ts`.

5. **OrderTimeline crash on `change.actions.forEach`** — `/partners/orders/:id/changes` used `*actions` and also wasn't passing the `change_type` filter through, so every order_change came back without its `actions` array and mis-categorised. Suffix syntax + filter passthrough + defensive `?? []` guard in the timeline.

6. **`/admin/plugins` 401 from partner-ui** — `usePlugins` was calling `sdk.admin.plugin.list()`, which 401s for partner auth. The hook now returns an empty plugins list synchronously so loyalty-aware refund + payment UI degrades gracefully without firing the request.

7. **Country column** — Renamed `id: "actions"` → `id: "country"` (fixes the duplicate-key React warning), synthesise `{ iso_2, display_name }` from `shipping_address.country_code` for `CountryCell`, add `CountryHeader`.

## Files

### Backend
- `api/middlewares.ts` — register `validateAndTransformQuery` on `/partners/orders/:id` with admin's `retrieveTransformQueryConfig`
- `api/partners/orders/[id]/route.ts` — use `req.queryConfig.fields`
- `api/partners/orders/route.ts` — switch to `relation.*` suffix syntax for `customer, sales_channel, payment_collections, shipping_address`
- `api/partners/orders/[id]/line-items/route.ts`, `.../preview/route.ts` — `*items` → `items.*`
- `api/partners/orders/[id]/changes/route.ts` — `*actions` → `actions.*` + pass `change_type` filter through
- `api/partners/returns/route.ts`, `api/partners/returns/[id]/route.ts` — `*items` → `items.*`
- `api/partners/stores/[id]/shipping-options/route.ts` — include `location` in inline `service_zone.fulfillment_set`
- `integration-tests/http/partner-stores-api.spec.ts` — regression assertion for `location` shape

### Partner UI
- `hooks/api/plugins.tsx` — stub `usePlugins` to empty list, drop `/admin/plugins` request
- `hooks/table/columns/use-order-table-columns.tsx` — rename `actions` → `country`, synthesise country from `country_code`, wire CountryHeader
- `hooks/table/columns/use-configurable-table-columns.tsx` — defensive dedupe by `field` to avoid duplicate React keys
- `components/table/table-cells/order/country-cell/country-cell.tsx` — add `CountryHeader`
- `routes/orders/order-detail/components/order-activity-section/order-timeline.tsx` — `change.actions ?? []` guard
- `routes/orders/order-list/const.ts` — include `*shipping_address` in default relations

## Test plan

- [x] `pnpm test:integration:http:shared ./integration-tests/http/partner-orders-api.spec.ts` — order-detail test passes (was crashing)
- [x] `pnpm test:integration:http:shared ./integration-tests/http/partner-stores-api.spec.ts` — 14/14 (incl. new location regression)
- [x] `curl /partners/orders` against the running dev server: customer, sales_channel, shipping_address now populated
- [ ] Visit orders list in partner-ui: country flag + customer cells render
- [ ] Visit order detail in partner-ui: timeline loads, no more `actions.forEach` crash
- [ ] Order detail → Create fulfillment: form opens without `location.id` crash

## Known unrelated failures

`partner-orders-api.spec.ts` still has 8 lifecycle/Delhivery test failures (full-lifecycle fulfillment workflow returns 500). Pre-existing — none of today's changes touch the fulfillment workflow or label/tracking/pickup routes. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)