### PR TITLE
feat(partner-ui): info banner on partner region list

### DIFF
--- a/apps/partner-ui/src/routes/regions/region-list/region-list.tsx
+++ b/apps/partner-ui/src/routes/regions/region-list/region-list.tsx
@@ -1,3 +1,4 @@
+import { Alert } from "@medusajs/ui"
 import { SingleColumnPage } from "../../../components/layout/pages"
 import { useExtension } from "../../../providers/extension-provider"
 import { RequiresStore } from "../../../components/common/requires-store/requires-store"
@@ -14,6 +15,25 @@ export const RegionList = () => {
       }}
     >
       <RequiresStore>
+        {/*
+          Informational banner explaining that JYT-provided regions
+          are read at the storefront automatically — partners get the
+          default tax/payment/currency setup for free. If they want to
+          customize, the path is to create their own region via the
+          existing "Create Region" button rather than editing the
+          shared admin-managed ones (which the backend refuses with a
+          409 anyway when there are assigned countries).
+        */}
+        <Alert
+          variant="info"
+          dismissible
+          className="bg-ui-bg-base mb-4"
+        >
+          Some regions below are provided by JYT — they ship with
+          managed payment providers and tax setup so your storefront
+          works out of the box. To customize for your store, click
+          "Create Region" and set up your own.
+        </Alert>
         <RegionListTable />
       </RequiresStore>
     </SingleColumnPage>


### PR DESCRIPTION
## Summary

Adds a dismissible info Alert above the partner region list that explains:
- Some regions are JYT-provided (admin-managed) and ship with default tax + payment setup
- To customize, partners click the existing "Create Region" button to make their own

One file changed, ~20 lines, UI-only.

## Why

Partners linked to a shared admin region today hit a confusing 409 when they try to edit it — Medusa's `country.region_id` is 1:N, so clone-on-write can't preserve the assigned countries. PR #259 documents the underlying constraint; this PR sets the expectation up front in the UI so the 409 path is rarely hit.

Aligns with the "templates + per-partner copy" framing in `apps/docs/notes/SAAS_TIERS.md` and the partner-architecture memory (`feedback_partner_model_templates_not_shared`): admin maintains canonical defaults, partners benefit from them out of the box, partners create their own when they want customization.

## Test plan
- [ ] Visual check: load `/regions` as a partner — banner appears above the table, dismissible, doesn't interfere with the existing "Create" button
- [ ] Mobile responsive check
- [ ] Refresh after dismiss — banner stays dismissed for the session (default `<Alert dismissible>` behavior)

## Relationship to PR #259

Independent. PR D can land before, alongside, or after PR #259. No conflicts expected — PR #259 doesn't touch this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)