### PR TITLE
fix(scripts): backfills + tax-seed honor DRY_RUN env var

### DIFF
--- a/apps/backend/integration-tests/http/partner-regions/backfill-link.spec.ts
+++ b/apps/backend/integration-tests/http/partner-regions/backfill-link.spec.ts
@@ -185,5 +185,31 @@ setupSharedTestSuite(() => {
       await backfillPartnerRegionLinks({ container, args: ["--dry-run"] } as any)
       expect(await countLinks(container, a.partnerId, a.regionId!)).toBe(0)
     })
+
+    it("DRY_RUN=1 env var also triggers dry-run mode", async () => {
+      // deploy/aws/scripts/run-backfill.sh passes DRY_RUN as an env var
+      // (not as a positional arg). Both paths must lead to the same
+      // dry-run behavior — without this, a "dry-run" deploy step
+      // silently runs the real backfill (which is how the prod
+      // migration ran for real instead of preview on 2026-05-25).
+      const a = await createPartnerWithStore(api, adminHeaders)
+      const container = getContainer()
+      const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as any
+
+      await remoteLink.dismiss({
+        partner: { partner_id: a.partnerId },
+        [Modules.REGION]: { region_id: a.regionId },
+      })
+
+      const before = process.env.DRY_RUN
+      process.env.DRY_RUN = "1"
+      try {
+        await backfillPartnerRegionLinks({ container, args: [] } as any)
+      } finally {
+        if (before === undefined) delete process.env.DRY_RUN
+        else process.env.DRY_RUN = before
+      }
+      expect(await countLinks(container, a.partnerId, a.regionId!)).toBe(0)
+    })
   })
 })

--- a/apps/backend/integration-tests/http/partner-regions/backfill-store-currencies.spec.ts
+++ b/apps/backend/integration-tests/http/partner-regions/backfill-store-currencies.spec.ts
@@ -227,5 +227,45 @@ setupSharedTestSuite(() => {
         before.map((c) => c.currency_code).sort()
       )
     })
+
+    it("DRY_RUN=1 env var also triggers dry-run mode", async () => {
+      // run-backfill.sh sets DRY_RUN as a container env var. Both args
+      // and env-var paths must trigger dry-run. Without this, ECS-spawned
+      // dry-runs silently apply real mutations.
+      const a = await createPartnerWithStore(api, adminHeaders)
+      const container = getContainer()
+      const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as any
+      const storeService = container.resolve(Modules.STORE) as any
+
+      const adminRegionRes = await api.post(
+        "/admin/regions",
+        { name: "Africa", currency_code: "zar", countries: ["za"] },
+        adminHeaders
+      )
+      await remoteLink.create({
+        partner: { partner_id: a.partnerId },
+        [Modules.REGION]: { region_id: adminRegionRes.data.region.id },
+      })
+      await storeService.updateStores({
+        id: a.storeId,
+        supported_currencies: [{ currency_code: a.currencyCode, is_default: true }],
+      })
+
+      const before = await readSupportedCurrencies(container, a.storeId)
+
+      const prev = process.env.DRY_RUN
+      process.env.DRY_RUN = "1"
+      try {
+        await backfillStoreCurrencies({ container, args: [] } as any)
+      } finally {
+        if (prev === undefined) delete process.env.DRY_RUN
+        else process.env.DRY_RUN = prev
+      }
+
+      const after = await readSupportedCurrencies(container, a.storeId)
+      expect(after.map((c) => c.currency_code).sort()).toEqual(
+        before.map((c) => c.currency_code).sort()
+      )
+    })
   })
 })

--- a/apps/backend/integration-tests/http/seed-tax-regions/seed-canonical-tax-regions.spec.ts
+++ b/apps/backend/integration-tests/http/seed-tax-regions/seed-canonical-tax-regions.spec.ts
@@ -120,5 +120,32 @@ setupSharedTestSuite(() => {
       const after = await readTaxRegionsForCountry(container, "us")
       expect(after.length).toBe(0)
     })
+
+    it("DRY_RUN=1 env var also triggers dry-run mode", async () => {
+      // run-backfill.sh sets DRY_RUN as a container env var. Both args
+      // and env-var paths must trigger dry-run so ECS-spawned previews
+      // don't silently create rows.
+      const container = getContainer()
+      await api.post(
+        "/admin/regions",
+        { name: "Test JP", currency_code: "jpy", countries: ["jp"] },
+        adminHeaders
+      )
+
+      const before = await readTaxRegionsForCountry(container, "jp")
+      expect(before.length).toBe(0)
+
+      const prev = process.env.DRY_RUN
+      process.env.DRY_RUN = "1"
+      try {
+        await seedCanonicalTaxRegions({ container, args: [] } as any)
+      } finally {
+        if (prev === undefined) delete process.env.DRY_RUN
+        else process.env.DRY_RUN = prev
+      }
+
+      const after = await readTaxRegionsForCountry(container, "jp")
+      expect(after.length).toBe(0)
+    })
   })
 })

--- a/apps/backend/src/scripts/backfill-partner-region-links.ts
+++ b/apps/backend/src/scripts/backfill-partner-region-links.ts
@@ -19,8 +19,13 @@ import partnerRegionLink from "../links/partner-region"
  * Run:
  *   npx medusa exec ./src/scripts/backfill-partner-region-links.ts
  *
- * Dry run (logs what would happen, creates nothing):
- *   npx medusa exec ./src/scripts/backfill-partner-region-links.ts --dry-run
+ * Dry run — logs what would happen, creates nothing. Two equivalent ways:
+ *   - Args:        npx medusa exec ./src/scripts/backfill-partner-region-links.ts -- --dry-run
+ *   - Env var:     DRY_RUN=1 npx medusa exec ./src/scripts/backfill-partner-region-links.ts
+ *
+ * The env-var form is what deploy/aws/scripts/run-backfill.sh uses when
+ * spawning a one-shot ECS task (the script sets DRY_RUN as a container
+ * env var, not as a positional arg). Both forms are honored here.
  */
 export default async function backfillPartnerRegionLinks({
   container,
@@ -30,7 +35,8 @@ export default async function backfillPartnerRegionLinks({
   const query = container.resolve(ContainerRegistrationKeys.QUERY)
   const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as any
 
-  const dryRun = (args ?? []).includes("--dry-run")
+  const dryRun =
+    (args ?? []).includes("--dry-run") || process.env.DRY_RUN === "1"
   if (dryRun) {
     logger.info("DRY RUN — no links will be created.")
   }

--- a/apps/backend/src/scripts/backfill-store-currencies-from-partner-regions.ts
+++ b/apps/backend/src/scripts/backfill-store-currencies-from-partner-regions.ts
@@ -23,8 +23,12 @@ import partnerRegionLink from "../links/partner-region"
  * Run:
  *   npx medusa exec ./src/scripts/backfill-store-currencies-from-partner-regions.ts
  *
- * Dry run:
- *   npx medusa exec ./src/scripts/backfill-store-currencies-from-partner-regions.ts --dry-run
+ * Dry run — logs what would happen, mutates nothing. Two equivalent ways:
+ *   - Args:    npx medusa exec ./src/scripts/backfill-store-currencies-from-partner-regions.ts -- --dry-run
+ *   - Env var: DRY_RUN=1 npx medusa exec ./src/scripts/backfill-store-currencies-from-partner-regions.ts
+ *
+ * deploy/aws/scripts/run-backfill.sh uses the env-var form when spawning
+ * one-shot ECS tasks.
  */
 export default async function backfillStoreCurrencies({
   container,
@@ -33,7 +37,8 @@ export default async function backfillStoreCurrencies({
   const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
   const query = container.resolve(ContainerRegistrationKeys.QUERY)
 
-  const dryRun = (args ?? []).includes("--dry-run")
+  const dryRun =
+    (args ?? []).includes("--dry-run") || process.env.DRY_RUN === "1"
   if (dryRun) {
     logger.info("DRY RUN — no stores will be updated.")
   }

--- a/apps/backend/src/scripts/seed-canonical-tax-regions.ts
+++ b/apps/backend/src/scripts/seed-canonical-tax-regions.ts
@@ -26,8 +26,12 @@ import { createTaxRegionsWorkflow } from "@medusajs/medusa/core-flows"
  * Run:
  *   npx medusa exec ./src/scripts/seed-canonical-tax-regions.ts
  *
- * Dry run (logs intent, creates nothing):
- *   npx medusa exec ./src/scripts/seed-canonical-tax-regions.ts --dry-run
+ * Dry run — logs intent, creates nothing. Two equivalent ways:
+ *   - Args:    npx medusa exec ./src/scripts/seed-canonical-tax-regions.ts -- --dry-run
+ *   - Env var: DRY_RUN=1 npx medusa exec ./src/scripts/seed-canonical-tax-regions.ts
+ *
+ * deploy/aws/scripts/run-backfill.sh uses the env-var form when spawning
+ * one-shot ECS tasks.
  */
 
 // Statutory standard rates as of 2026-05. Conservative — only
@@ -108,7 +112,8 @@ export default async function seedCanonicalTaxRegions({
   const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
   const query = container.resolve(ContainerRegistrationKeys.QUERY)
 
-  const dryRun = (args ?? []).includes("--dry-run")
+  const dryRun =
+    (args ?? []).includes("--dry-run") || process.env.DRY_RUN === "1"
   if (dryRun) {
     logger.info("DRY RUN — no tax_regions will be created.")
   }


### PR DESCRIPTION
## Summary

Migration scripts (`backfill-partner-region-links`, `backfill-store-currencies-from-partner-regions`, `seed-canonical-tax-regions`) read \`--dry-run\` from positional args only. But `deploy/aws/scripts/run-backfill.sh` sets `DRY_RUN=1` as a container env var when spawning one-shot ECS tasks — that path silently fell through to real execution.

**Discovered when running prod migrations 2026-05-25** — `DRY_RUN=1 ./run-backfill.sh backfill-partner-region-links` created 8 link rows in prod instead of previewing them. No harm done (the links were correct and the script is idempotent + additive), but the dry-run safety net was a fiction.

## Fix

One-line change per script:

\`\`\`ts
// Before
const dryRun = (args ?? []).includes("--dry-run")

// After
const dryRun =
  (args ?? []).includes("--dry-run") || process.env.DRY_RUN === "1"
\`\`\`

Both invocation forms now supported:

\`\`\`bash
# Args form
npx medusa exec ./src/scripts/backfill-partner-region-links.ts -- --dry-run

# Env-var form (used by run-backfill.sh)
DRY_RUN=1 npx medusa exec ./src/scripts/backfill-partner-region-links.ts
\`\`\`

Docstrings updated to document both forms.

## Tests

Added one new spec per script (`DRY_RUN=1 env var also triggers dry-run mode`) that:
1. Sets up legacy state requiring a mutation
2. Sets `process.env.DRY_RUN = "1"`, runs script with `args: []`
3. Asserts no mutation happened
4. Restores prev env value via try/finally

Suite: **15 passing across 3 files in ~51s.**

## Test plan
- [ ] CI passes
- [ ] No behavior change for existing args-form callers (`-- --dry-run`)
- [ ] Future deploys can safely run \`DRY_RUN=1 FOLLOW=1 ./scripts/run-backfill.sh <script>\` and see preview

## Relationship to prior work

Followup to PR #259 + PR #261. Doesn't block anything. The prod migrations have already run; this restores dry-run preview for future deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)