### PR TITLE
feat(fx): fx_rates module + open.er-api.com fetcher + seed (PR G1)

### DIFF
--- a/apps/backend/integration-tests/http/fx-rates/fx-rates-service.spec.ts
+++ b/apps/backend/integration-tests/http/fx-rates/fx-rates-service.spec.ts
@@ -1,0 +1,151 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "../shared-test-setup"
+import { FX_RATES_MODULE } from "../../../src/modules/fx_rates"
+import type FxRatesService from "../../../src/modules/fx_rates/service"
+import type { FxProvider, FxProviderResult } from "../../../src/modules/fx_rates/providers/types"
+
+jest.setTimeout(60 * 1000)
+
+// Verifies the fx_rates module's core behaviors. Doesn't hit the real
+// open.er-api.com — uses a fake FxProvider directly via the service's
+// applyProviderResult path.
+//
+// Covers:
+//   1. setRates / getRate roundtrip
+//   2. Cross-rate computation via USD intermediate
+//   3. Same-currency short-circuit (returns 1)
+//   4. Inverse lookup when direct row is missing
+//   5. Idempotent upsert (re-apply doesn't duplicate)
+//   6. getLastFetchedAt reports the most recent fetched_at
+
+setupSharedTestSuite(() => {
+  const { getContainer } = getSharedTestEnv()
+
+  describe("modules/fx_rates", () => {
+    let svc: FxRatesService
+
+    beforeEach(async () => {
+      svc = getContainer().resolve(FX_RATES_MODULE) as FxRatesService
+
+      // Each test gets a fresh world. Wipe any rates created by earlier
+      // tests in this file via the service's listing + delete.
+      const all = await svc.listFxRates({})
+      for (const r of all) {
+        await svc.deleteFxRates(r.id)
+      }
+    })
+
+    const fakeResult = (overrides: Partial<FxProviderResult> = {}): FxProviderResult => ({
+      base_currency: "usd",
+      fetched_at: new Date("2026-05-25T00:00:00Z"),
+      source: "test-fake",
+      rates: {
+        usd: 1,
+        inr: 83.25,
+        eur: 0.92,
+        gbp: 0.79,
+      },
+      ...overrides,
+    })
+
+    it("setRates + getRate roundtrip — direct pair returns stored value", async () => {
+      await svc.applyProviderResult(fakeResult())
+
+      expect(await svc.getRate("usd", "inr")).toBeCloseTo(83.25, 4)
+      expect(await svc.getRate("usd", "eur")).toBeCloseTo(0.92, 4)
+    })
+
+    it("returns 1 when from === to", async () => {
+      await svc.applyProviderResult(fakeResult())
+
+      expect(await svc.getRate("inr", "inr")).toBe(1)
+      expect(await svc.getRate("USD", "usd")).toBe(1) // case-insensitive
+    })
+
+    it("computes cross-rate via USD intermediate when direct pair is missing", async () => {
+      await svc.applyProviderResult(fakeResult())
+
+      // INR→EUR = (USD→EUR) / (USD→INR) = 0.92 / 83.25 ≈ 0.01105
+      const inrToEur = await svc.getRate("inr", "eur")
+      expect(inrToEur).toBeCloseTo(0.92 / 83.25, 6)
+
+      // GBP→INR = (USD→INR) / (USD→GBP) = 83.25 / 0.79 ≈ 105.38
+      const gbpToInr = await svc.getRate("gbp", "inr")
+      expect(gbpToInr).toBeCloseTo(83.25 / 0.79, 4)
+    })
+
+    it("uses inverse when only the opposite direction is cached", async () => {
+      // Only seed USD as base. INR→USD = 1/(USD→INR) = 1/83.25.
+      await svc.applyProviderResult(fakeResult())
+
+      const inrToUsd = await svc.getRate("inr", "usd")
+      expect(inrToUsd).toBeCloseTo(1 / 83.25, 6)
+    })
+
+    it("upsert is idempotent — re-applying the same result doesn't create duplicates", async () => {
+      await svc.applyProviderResult(fakeResult())
+      const first = await svc.listFxRates({})
+
+      await svc.applyProviderResult(fakeResult({ fetched_at: new Date("2026-05-26T00:00:00Z") }))
+      const second = await svc.listFxRates({})
+
+      expect(second.length).toBe(first.length)
+      const usdInr = second.find(
+        (r: any) => r.base_currency === "usd" && r.quote_currency === "inr"
+      )
+      expect(new Date((usdInr as any).fetched_at).toISOString()).toBe(
+        "2026-05-26T00:00:00.000Z"
+      )
+    })
+
+    it("getLastFetchedAt returns the latest fetched_at across the cache", async () => {
+      const noneYet = await svc.getLastFetchedAt()
+      expect(noneYet).toBeNull()
+
+      await svc.applyProviderResult(fakeResult())
+      const after = await svc.getLastFetchedAt()
+      expect(after?.toISOString()).toBe("2026-05-25T00:00:00.000Z")
+
+      // Apply a newer result on top — last_fetched moves forward.
+      await svc.applyProviderResult(
+        fakeResult({ fetched_at: new Date("2026-05-26T12:00:00Z") })
+      )
+      const later = await svc.getLastFetchedAt()
+      expect(later?.toISOString()).toBe("2026-05-26T12:00:00.000Z")
+    })
+
+    it("refreshRatesFromProvider uses the injected provider", async () => {
+      // Replace the service's provider with a fake one. This exercises
+      // the integration between provider + applyProviderResult.
+      const fake: FxProvider = {
+        fetchRates: async () =>
+          fakeResult({ rates: { usd: 1, jpy: 156.4 } }),
+      }
+      ;(svc as any).provider = fake
+
+      const summary = await svc.refreshRatesFromProvider()
+
+      expect(summary.base_currency).toBe("usd")
+      expect(summary.source).toBe("test-fake")
+      expect(summary.upserted).toBe(2)
+      expect(await svc.getRate("usd", "jpy")).toBeCloseTo(156.4, 3)
+    })
+
+    it("getRate throws clearly when no path exists", async () => {
+      // Empty cache.
+      await expect(svc.getRate("usd", "inr")).rejects.toThrow(
+        /no rates cached/i
+      )
+
+      // Cache that has no path between the requested codes.
+      await svc.applyProviderResult({
+        base_currency: "usd",
+        fetched_at: new Date(),
+        source: "isolated-test",
+        rates: { usd: 1, jpy: 156.4 },
+      })
+      await expect(svc.getRate("inr", "eur")).rejects.toThrow(
+        /no path from inr to eur/i
+      )
+    })
+  })
+})

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -115,6 +115,9 @@ module.exports = defineConfig({
       resolve: "./src/modules/partner-payment-config",
     },
     {
+      resolve: "./src/modules/fx_rates",
+    },
+    {
       resolve: "./src/modules/consumption_log",
     },
     {

--- a/apps/backend/src/modules/fx_rates/index.ts
+++ b/apps/backend/src/modules/fx_rates/index.ts
@@ -1,0 +1,8 @@
+import { Module } from "@medusajs/framework/utils"
+import FxRatesService from "./service"
+
+export const FX_RATES_MODULE = "fx_rates"
+
+export default Module(FX_RATES_MODULE, {
+  service: FxRatesService,
+})

--- a/apps/backend/src/modules/fx_rates/migrations/Migration20260525112809.ts
+++ b/apps/backend/src/modules/fx_rates/migrations/Migration20260525112809.ts
@@ -1,0 +1,16 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+export class Migration20260525112809 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "fx_rate" drop constraint if exists "fx_rate_pair_unique";`);
+    this.addSql(`create table if not exists "fx_rate" ("id" text not null, "base_currency" text not null, "quote_currency" text not null, "rate" numeric not null, "fetched_at" timestamptz not null, "source" text not null, "metadata" jsonb null, "raw_rate" jsonb not null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "fx_rate_pkey" primary key ("id"));`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_fx_rate_deleted_at" ON "fx_rate" ("deleted_at") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE UNIQUE INDEX IF NOT EXISTS "IDX_fx_rate_pair_unique" ON "fx_rate" ("base_currency", "quote_currency") WHERE deleted_at IS NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "fx_rate" cascade;`);
+  }
+
+}

--- a/apps/backend/src/modules/fx_rates/models/fx-rate.ts
+++ b/apps/backend/src/modules/fx_rates/models/fx-rate.ts
@@ -1,0 +1,35 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * One row per (base, quote) currency pair.
+ *
+ * Stored unidirectionally — provider returns rates against a single
+ * base (USD for open.er-api.com), and the service computes cross-rates
+ * on demand via the USD intermediate. We could store both directions
+ * to save the divide, but cross-rate math is cheap and storing only
+ * one direction keeps refresh writes minimal.
+ *
+ * `rate` is stored as text-via-bignumber under the hood (Medusa's
+ * `bigNumber` type) to preserve precision — FX rates often have many
+ * decimal places (USD→INR ≈ 83.247291). Avoid float drift.
+ *
+ * Composite key on (base_currency, quote_currency) keeps upserts
+ * straightforward.
+ */
+const FxRate = model.define("fx_rate", {
+  id: model.id().primaryKey(),
+  base_currency: model.text().searchable(),
+  quote_currency: model.text().searchable(),
+  rate: model.bigNumber(),
+  fetched_at: model.dateTime(),
+  source: model.text(),
+  metadata: model.json().nullable(),
+}).indexes([
+  {
+    name: "IDX_fx_rate_pair_unique",
+    on: ["base_currency", "quote_currency"],
+    unique: true,
+  },
+])
+
+export default FxRate

--- a/apps/backend/src/modules/fx_rates/providers/open-er-api-provider.ts
+++ b/apps/backend/src/modules/fx_rates/providers/open-er-api-provider.ts
@@ -1,0 +1,65 @@
+import { FxProvider, FxProviderResult } from "./types"
+
+/**
+ * open.er-api.com — free, no API key, USD-based.
+ *
+ * Sample response:
+ *   {
+ *     "result": "success",
+ *     "provider": "https://www.exchangerate-api.com",
+ *     "base_code": "USD",
+ *     "time_last_update_unix": 1742428801,
+ *     "rates": { "USD": 1, "AED": 3.6725, "AFN": 70.5, ... }
+ *   }
+ *
+ * Limits: 1 request per ~10 min recommended; daily refresh is well
+ * within bounds. No auth.
+ */
+export class OpenErApiProvider implements FxProvider {
+  private readonly endpoint: string
+
+  constructor(opts: { endpoint?: string } = {}) {
+    this.endpoint = opts.endpoint ?? "https://open.er-api.com/v6/latest/USD"
+  }
+
+  async fetchRates(): Promise<FxProviderResult> {
+    const res = await fetch(this.endpoint, {
+      headers: { Accept: "application/json" },
+    })
+    if (!res.ok) {
+      throw new Error(
+        `OpenErApiProvider: HTTP ${res.status} from ${this.endpoint}`
+      )
+    }
+    const body = (await res.json()) as {
+      result?: string
+      base_code?: string
+      time_last_update_unix?: number
+      rates?: Record<string, number>
+      "error-type"?: string
+    }
+
+    if (body.result !== "success" || !body.rates || !body.base_code) {
+      throw new Error(
+        `OpenErApiProvider: unexpected response shape: ${
+          body["error-type"] ?? JSON.stringify(body).slice(0, 200)
+        }`
+      )
+    }
+
+    return {
+      base_currency: body.base_code.toLowerCase(),
+      fetched_at: body.time_last_update_unix
+        ? new Date(body.time_last_update_unix * 1000)
+        : new Date(),
+      source: "open.er-api.com",
+      // Lowercase the keys to match Medusa's currency_code convention.
+      rates: Object.fromEntries(
+        Object.entries(body.rates).map(([code, rate]) => [
+          code.toLowerCase(),
+          rate,
+        ])
+      ),
+    }
+  }
+}

--- a/apps/backend/src/modules/fx_rates/providers/types.ts
+++ b/apps/backend/src/modules/fx_rates/providers/types.ts
@@ -1,0 +1,29 @@
+/**
+ * Provider-agnostic FX fetcher interface.
+ *
+ * `fetchRates()` returns rates against a single base currency (whichever
+ * the provider supplies natively — USD for open.er-api.com, configurable
+ * for paid providers). Cross-rates are derived by the service, not by
+ * the provider.
+ *
+ * Implementations live alongside this file. Swapping providers is a
+ * matter of changing the import in the service or via env-var-based
+ * selection.
+ */
+
+export type FxProviderResult = {
+  base_currency: string
+  fetched_at: Date
+  source: string
+  /** quote_currency → rate (1 base = N quote) */
+  rates: Record<string, number>
+}
+
+export interface FxProvider {
+  /**
+   * Fetch the latest rates from the provider. Throws on network or
+   * parse errors — caller should catch and decide whether to fall back
+   * to cached values.
+   */
+  fetchRates(): Promise<FxProviderResult>
+}

--- a/apps/backend/src/modules/fx_rates/service.ts
+++ b/apps/backend/src/modules/fx_rates/service.ts
@@ -1,0 +1,174 @@
+import { MedusaService, MedusaError } from "@medusajs/framework/utils"
+import FxRate from "./models/fx-rate"
+import { FxProvider, FxProviderResult } from "./providers/types"
+import { OpenErApiProvider } from "./providers/open-er-api-provider"
+
+class FxRatesService extends MedusaService({ FxRate }) {
+  /**
+   * Provider used for `refreshRatesFromProvider()`. Swappable via
+   * `setProvider()` for tests / future paid providers; default is
+   * open.er-api.com.
+   *
+   * Note: we intentionally don't take the provider as a constructor
+   * arg because Medusa's MedusaService factory wires the container
+   * automatically; adding a custom constructor breaks the manager
+   * context binding. A simple setter keeps that wiring intact while
+   * letting tests + future config swap the provider.
+   */
+  protected provider: FxProvider = new OpenErApiProvider()
+
+  setProvider(p: FxProvider): void {
+    this.provider = p
+  }
+
+  /**
+   * Look up the current rate from `from` → `to`.
+   *
+   * Same currency → returns 1.
+   * Direct row present → returns the stored rate.
+   * Otherwise → computes via the cached base currency
+   *   from → base → to  ==  rate(base→to) / rate(base→from)
+   *
+   * Throws if no path exists in cache (caller can handle missing
+   * coverage).
+   */
+  async getRate(from: string, to: string): Promise<number> {
+    const fromCode = from.toLowerCase()
+    const toCode = to.toLowerCase()
+    if (fromCode === toCode) return 1
+
+    const direct = await this.listFxRates({
+      base_currency: fromCode,
+      quote_currency: toCode,
+    })
+    if (direct?.[0]) {
+      return Number(direct[0].rate)
+    }
+
+    // Try via inverse — if we have to→from, return 1/rate.
+    const inverse = await this.listFxRates({
+      base_currency: toCode,
+      quote_currency: fromCode,
+    })
+    if (inverse?.[0]) {
+      const r = Number(inverse[0].rate)
+      if (r > 0) return 1 / r
+    }
+
+    // Compute cross-rate via the most common base currency in the cache.
+    // For open.er-api.com that's USD. We pick whatever base appears
+    // most often so the service stays provider-agnostic.
+    const all = await this.listFxRates({})
+    if (!all.length) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `FxRatesService.getRate: no rates cached. Run seed-initial-fx-rates or refreshRatesFromProvider().`
+      )
+    }
+    const baseCounts = new Map<string, number>()
+    for (const r of all) {
+      baseCounts.set(r.base_currency, (baseCounts.get(r.base_currency) ?? 0) + 1)
+    }
+    const candidateBases = Array.from(baseCounts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .map(([b]) => b)
+
+    for (const intermediate of candidateBases) {
+      if (intermediate === fromCode || intermediate === toCode) continue
+      const baseToFrom = all.find(
+        (r) => r.base_currency === intermediate && r.quote_currency === fromCode
+      )
+      const baseToTo = all.find(
+        (r) => r.base_currency === intermediate && r.quote_currency === toCode
+      )
+      if (baseToFrom && baseToTo) {
+        const a = Number(baseToFrom.rate)
+        const b = Number(baseToTo.rate)
+        if (a > 0) return b / a
+      }
+    }
+
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `FxRatesService.getRate: no path from ${fromCode} to ${toCode}`
+    )
+  }
+
+  /**
+   * Fetch fresh rates from the configured provider and upsert into the
+   * fx_rate table. Returns counts of inserts/updates.
+   */
+  async refreshRatesFromProvider(): Promise<{
+    base_currency: string
+    upserted: number
+    fetched_at: Date
+    source: string
+  }> {
+    const result = await this.provider.fetchRates()
+    return this.applyProviderResult(result)
+  }
+
+  /**
+   * Lower-level: write a provider result into the cache. Useful for
+   * tests (skip the real HTTP fetch) and for scripts that load rates
+   * from a file / fixture.
+   */
+  async applyProviderResult(result: FxProviderResult): Promise<{
+    base_currency: string
+    upserted: number
+    fetched_at: Date
+    source: string
+  }> {
+    const base = result.base_currency.toLowerCase()
+    const rows = Object.entries(result.rates).map(([quote, rate]) => ({
+      base_currency: base,
+      quote_currency: quote.toLowerCase(),
+      rate,
+      fetched_at: result.fetched_at,
+      source: result.source,
+    }))
+
+    let upserted = 0
+    for (const row of rows) {
+      const existing = await this.listFxRates({
+        base_currency: row.base_currency,
+        quote_currency: row.quote_currency,
+      })
+      if (existing?.[0]) {
+        await this.updateFxRates({
+          id: existing[0].id,
+          rate: row.rate,
+          fetched_at: row.fetched_at,
+          source: row.source,
+        })
+      } else {
+        await this.createFxRates(row)
+      }
+      upserted++
+    }
+
+    return {
+      base_currency: base,
+      upserted,
+      fetched_at: result.fetched_at,
+      source: result.source,
+    }
+  }
+
+  /**
+   * Last-refresh timestamp across all rates. Returns null if no rates
+   * are cached. Useful for "is FX cache stale?" checks.
+   */
+  async getLastFetchedAt(): Promise<Date | null> {
+    const all = await this.listFxRates({})
+    if (!all.length) return null
+    let max: Date | null = null
+    for (const r of all) {
+      const d = new Date(r.fetched_at)
+      if (!max || d > max) max = d
+    }
+    return max
+  }
+}
+
+export default FxRatesService

--- a/apps/backend/src/scripts/seed-initial-fx-rates.ts
+++ b/apps/backend/src/scripts/seed-initial-fx-rates.ts
@@ -1,0 +1,44 @@
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { FX_RATES_MODULE } from "../modules/fx_rates"
+import FxRatesService from "../modules/fx_rates/service"
+
+/**
+ * One-shot script that fetches the current FX rates from open.er-api.com
+ * (the default provider) and seeds the `fx_rate` table.
+ *
+ * Idempotent — re-runs upsert by (base, quote) pair, just updating
+ * `rate` + `fetched_at`. Safe to run any time.
+ *
+ * Run:
+ *   npx medusa exec ./src/scripts/seed-initial-fx-rates.ts
+ *
+ * Dry run — fetches and logs what would be written, no DB writes:
+ *   DRY_RUN=1 npx medusa exec ./src/scripts/seed-initial-fx-rates.ts
+ *   npx medusa exec ./src/scripts/seed-initial-fx-rates.ts -- --dry-run
+ */
+export default async function seedInitialFxRates({ container, args }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const fxService = container.resolve(FX_RATES_MODULE) as FxRatesService
+
+  const dryRun =
+    (args ?? []).includes("--dry-run") || process.env.DRY_RUN === "1"
+
+  if (dryRun) {
+    logger.info("DRY RUN — fetching rates, not writing to DB.")
+    // Bypass the service's apply step; just fetch + log.
+    const provider = (fxService as any).provider
+    const result = await provider.fetchRates()
+    const codes = Object.keys(result.rates).sort()
+    logger.info(
+      `Provider: ${result.source}, base: ${result.base_currency}, fetched_at: ${result.fetched_at.toISOString()}, currency_count: ${codes.length}`
+    )
+    logger.info(`Currencies: ${codes.join(", ")}`)
+    return
+  }
+
+  const summary = await fxService.refreshRatesFromProvider()
+  logger.info(
+    `Seeded fx_rates: base=${summary.base_currency}, upserted=${summary.upserted}, source=${summary.source}, fetched_at=${summary.fetched_at.toISOString()}`
+  )
+}

--- a/apps/docs/notes/FX_AUTO_CONVERSION.md
+++ b/apps/docs/notes/FX_AUTO_CONVERSION.md
@@ -1,0 +1,148 @@
+# FX Auto-Conversion + Storefront "We Don't Ship Here" Fixture
+
+> Status: **DRAFT** — design doc before code. Review and mark up.
+> Date: 2026-05-25
+> Owner: Saransh
+> Companion to `SAAS_TIERS.md` and `PARTNER_API_PARITY.md`.
+
+## Goal
+
+Partners set one price per product variant in their native currency (typically INR). The system fans that price out to every other currency the partner's store supports, using current FX rates. Customers in any region see prices in their local currency, no manual partner intervention per region. Daily re-rate keeps prices roughly aligned with current FX. The storefront degrades gracefully when a region or price isn't available.
+
+This unlocks fast partner onboarding (one price, not N), and matches the "Shopify Markets" model partners expect.
+
+## Architecture — visual-flow-trigger + TS-workflow-logic hybrid
+
+Two pieces work together:
+
+1. **TS workflows + new `fx_rates` module** carry the complex logic (FX provider fetch, cross-rate math, price fanout, re-rate). Tested via Jest integration tests like the rest of the partner-region work.
+2. **Visual flow seeds** wrap each workflow with a schedule trigger. Admin sees the flow in the visual editor, can pause/edit/reschedule without code changes. The flow's only operation is `trigger_workflow` → custom TS workflow.
+
+Best of both: the heavy lifting is in code (typed, tested), the schedule + admin visibility comes from the visual flow infra that already exists in this codebase (`apps/backend/src/modules/visual_flows/`, `apps/backend/src/jobs/run-scheduled-visual-flows.ts`).
+
+## Data model — new `fx_rates` module
+
+```
+fx_rates
+  id              ULID
+  base_currency   text  ("usd" — canonical base from provider)
+  quote_currency  text  ("inr", "eur", "gbp", ...)
+  rate            numeric(20, 10)  (1 base = rate quote)
+  fetched_at      timestamptz
+  source          text  ("open.er-api.com" | "manual" | other future providers)
+  metadata        jsonb
+  PRIMARY KEY (base_currency, quote_currency)  — one rate per pair
+```
+
+Service surface:
+- `getRate(from: string, to: string): Promise<number>` — looks up via base, computes cross-rate if needed (e.g., `inr→eur = usd→eur / usd→inr`)
+- `getAllRates(): Promise<FxRate[]>`
+- `setRates(rates: FxRateInput[]): Promise<void>` — upserts
+- `getLastFetchedAt(): Promise<Date | null>` — stale-check helper
+
+Module exposed via `query.graph` for partner UI / admin diagnostic reads. Partner doesn't write to it.
+
+## Daily re-rate, NOT read-time refresh
+
+**Why:** cart consistency. Read-time refresh creates the "customer added at EUR 11.20, checkout charges EUR 11.26" failure. Daily re-rate caps drift at ~24h, which is invisible at our currency mix (INR/EUR/USD/AUD all stable, daily moves <0.5% typical). Stripe/PayU expect a fixed amount; Medusa's cart snapshots line-item prices at add-time — both work cleanly with stable daily prices.
+
+Re-rate flow:
+1. Daily visual flow fires at 02:00 UTC
+2. Triggers `refresh-fx-rates` workflow → fetches from open.er-api.com, writes to `fx_rates` module
+3. Triggers `rerate-auto-converted-prices` workflow → finds all `price.metadata.is_auto_converted = true`, updates `amount` to `base_amount × fresh_rate`
+
+Manual partner overrides (`metadata.is_auto_converted` not set or false) are never touched.
+
+## FX provider: open.er-api.com for v1
+
+| Provider | Why | Why not |
+|---|---|---|
+| **open.er-api.com** ✓ | Free forever, no key, no signup. USD-based. Daily refresh sufficient for our domain. | Slight rounding error on non-USD pairs (computed via USD intermediate). Acceptable. |
+| `exchangerate.host` | Free with signup | Recent plan changes; risk of similar future changes |
+| `openexchangerates.org` | Hourly rates, reliable | $12/mo; overkill until we have FX-sensitive customers |
+
+Service interface keeps provider behind a swap-able adapter — promote to paid provider later without changing the rest of the system.
+
+## Lazy fanout at write time, not aggressive at variant create
+
+Subscriber listens to variant price events. Fanout fires only when a real price is set. Variants without prices stay clean (no zero-priced phantom rows polluting the pricing grid).
+
+Fanout algorithm:
+1. Partner sets price `INR 1000` on variant X
+2. Subscriber fires `fanout-prices-on-variant-price-set` workflow
+3. Workflow reads `variant.product.sales_channels[0].store` → store.supported_currencies
+4. For each currency in supported_currencies that the variant DOESN'T already have a price for:
+   - `convertedAmount = fxRatesService.getRate("inr", targetCurrency) × 1000`
+   - Create a price row with `currency_code: targetCurrency`, `amount: convertedAmount`, `metadata.is_auto_converted: true`, `metadata.base_currency: "inr"`, `metadata.base_amount: 1000`
+5. Existing prices (manual or previously auto-converted) are left alone unless re-rate is running
+
+The `base_currency` + `base_amount` on each auto price lets re-rate recompute from the source (handles the case where partner changes base price → all derived prices update together).
+
+## Partner UI
+
+In the pricing grid (`apps/partner-ui/src/routes/.../*-pricing-form.tsx`):
+
+- Cells where the underlying price has `metadata.is_auto_converted = true` render with a small 🔄 badge + lighter background
+- Hover tooltip: "Auto-converted from INR 1000 at 0.012 USD/INR (refreshed 2 hours ago)"
+- Click on cell value → editable; on save, strips `is_auto_converted` flag (becomes a manual override that never gets re-rated)
+- Store-level setting (settings/store): "Auto-convert prices across regions" toggle. Default ON. OFF means subscriber doesn't fan out for new prices on this store.
+
+No changes to the cart, checkout, or storefront pricing flow — those already use Medusa's calculated_price + line-item snapshot.
+
+## Storefront fixture — "we don't ship here yet"
+
+Two scenarios in `apps/storefront-starter/`:
+
+1. **No region for customer's country** — `getRegion("zw")` returns null because partner has no Zimbabwe region linked
+2. **Region exists but variant has no price in the region's currency** — partner forgot to set up a base price; auto-fanout didn't fire
+
+Both render the same `<RegionNotServedFallback />` component:
+
+- Friendly header: "We don't currently ship to {country}"
+- Sub: "But we'd love to hear from you. Drop us a line and we'll let you know when we expand."
+- Contact form (name, email, optional message) → POSTs to `/store/contact-region-request` → forwards to partner via existing partner notification system
+- Renders inside the product detail layout so product images/description still show; only the price + add-to-cart are replaced
+
+`/store/contact-region-request` is a new partner-scoped storefront endpoint that's hit via the storefront's publishable key → partner lookup.
+
+## Build order (5 PRs, each independently shippable)
+
+| PR | Scope | Effort | Independently useful? |
+|---|---|---|---|
+| **G1** | `fx_rates` module + open.er-api.com fetcher service + one-shot `seed-initial-fx-rates.ts` script | ~half day | Yes — gives partner UI / admin a place to read rates, diagnostic tooling |
+| **G2** | `refresh-fx-rates` workflow + daily visual flow seed | ~half day | Yes — rates stay fresh even before fanout exists |
+| **G3** | `fanout-prices-on-variant-price-set` subscriber + workflow | ~1 day | Yes — once partners set base prices, fanout works automatically |
+| **G4** | Partner UI: pricing-grid badges + manual override + store settings toggle | ~half day | Yes — partners can see + control auto-conversion |
+| **G5** | `rerate-auto-converted-prices` workflow + daily visual flow seed | ~half day | Yes — closes the loop on drift |
+| **H** | Storefront `<RegionNotServedFallback />` + `/store/contact-region-request` endpoint | ~half day | Yes — independent UX improvement, doesn't depend on FX work |
+
+**Total:** ~3.5 days for the full set across 6 PRs. Roughly a week with review cycles.
+
+## Testing strategy per PR
+
+- **G1:** integration test — mock the open.er-api.com fetch, assert rates are written, assert `getRate()` returns expected cross-rate
+- **G2:** integration test — verify the visual flow seed is idempotent, verify the workflow refreshes rates and bumps `fetched_at`
+- **G3:** integration test — set price on variant, assert fanout creates N other prices with `is_auto_converted: true`, assert lazy behavior (no fanout for variants without manual prices)
+- **G4:** Playwright e2e on partner UI — verify badge renders, click promotes to manual, settings toggle disables fanout
+- **G5:** integration test — set manual + auto prices, run re-rate, assert auto prices updated, manual prices untouched
+- **H:** Playwright e2e on storefront-starter — visit storefront with country=zw header, assert fallback component renders, submit contact form, assert POST succeeds
+
+## Out of scope (deferred)
+
+- **Hourly re-rate** — would need an hourly visual flow, fine to add later if 24h drift becomes a complaint
+- **Paid FX provider** — swap-out is a one-line interface change; defer until we have FX-sensitive partners
+- **Per-product base currency override** — every variant uses store's default currency as base; deferred until partners need it
+- **Manual rate override per partner** — partner can't say "treat INR→EUR as 0.013 for my store" yet; deferred until anyone asks
+- **Re-fanout on FX rate change** — if rates move > X%, optionally re-create prices instead of just re-rating. Not v1.
+- **Currency formatting per locale** — already handled by Medusa storefront; verify but don't change
+
+## One open question for you
+
+Where does the `base_currency` for a partner's store live? Options:
+- **A.** `store.supported_currencies.find(c => c.is_default).currency_code` — already on the data model, no schema change
+- **B.** `store.default_region_id` → region.currency_code — uses the partner's "primary" region's currency
+- **C.** New explicit `store.metadata.base_currency` field — explicit, less coupling
+
+I lean toward **A** because it's already there, partner controls it via the store settings UI, and it's the canonical "this is the partner's currency" signal in Medusa. (B) drifts when partner changes default region. (C) duplicates state.
+
+Lock this before I start G3 (the fanout subscriber).

--- a/apps/docs/notes/PR_259_PROD_DEPLOY_RUNBOOK.md
+++ b/apps/docs/notes/PR_259_PROD_DEPLOY_RUNBOOK.md
@@ -1,0 +1,190 @@
+# PR #259 + #261 Production Deploy Runbook
+
+> Status: **READY TO RUN** once the image is built and deployed.
+> Date: 2026-05-25
+> Owner: Saransh
+> Migrations: 2 backfills + 1 seed, all idempotent + dry-run-safe.
+
+## What's about to land in prod
+
+| Commit set | What it does | Compatible with current prod? |
+|---|---|---|
+| Partner region admin-parity + safety (PR #259) | Drops `store.default_region_id` fallback in partner GET, ref-counted DELETE, clone-on-write, auto-expand currencies | **Requires backfill** — see Migration 1 below |
+| Partner-UI hooks fix (PR #259) | Hooks now actually send `query` params to URL | Drop-in, no migration needed |
+| Tax-region admin-mirror (PR #259) | Reuses admin's validators + middleware | No migration |
+| Banner above partner regions list (PR #259) | UI-only, dismissible alert | No migration |
+| Canonical tax-region seed (PR #261) | Fills tax_regions for every admin region's countries | **Requires seed** — see Migration 3 below |
+
+## Pre-flight checks
+
+```bash
+# 1. Confirm main is at the expected commit (PR #259 + #261 merged)
+git fetch origin main
+git log origin/main --oneline | head -5
+#   c803a4963 Merge pull request #261 ... canonical-tax-regions-seed
+#   398aa8d04 Merge pull request #259 ... partner-regions-admin-parity
+
+# 2. Confirm prod state via admin API (read-only sanity check)
+#    Use a fresh API key, not the one shared in a transcript
+PROD=https://v3.jaalyantra.com
+KEY=<your-rotated-admin-api-key>
+BASIC=$(printf "%s:" "$KEY" | base64)
+
+# Region count + names — should match what's seeded today
+curl -sS -H "Authorization: Basic $BASIC" "$PROD/admin/regions?limit=100" \
+  | jq '{count, regions: [.regions[] | {id, name, currency_code, countries: [.countries[].iso_2]}]}'
+
+# Current tax-region count (expect 1 — India only)
+curl -sS -H "Authorization: Basic $BASIC" "$PROD/admin/tax-regions?limit=100" \
+  | jq '{count, by_country: [.tax_regions[] | .country_code]}'
+
+# Partner count (expect 21 as of 2026-05-25)
+curl -sS -H "Authorization: Basic $BASIC" "$PROD/admin/partners?limit=1" | jq '.count'
+```
+
+## Step 1 — Build + deploy the new image to STAGING
+
+CI builds the image automatically on merge to main. Wait for the green check on `398aa8d04` (the PR #259 merge commit).
+
+```bash
+# Deploy to staging via Copilot
+cd deploy/aws
+copilot svc deploy --name medusa-server --env staging
+```
+
+This is a blue/green deploy — the old task keeps serving traffic until the new one passes ALB health checks (240s grace per `reference_aws_ecs_medusa_gotchas`).
+
+## Step 2 — Migration 1: backfill `partner_region` links (STAGING then PROD)
+
+**Why:** PR #259 drops the `store.default_region_id` fallback in partner GET handlers. Pre-PR-A partners whose store has a `default_region_id` but no explicit `partner_region` link row will see an empty region list. This script creates the missing links.
+
+**Idempotent:** re-runs only create what's missing.
+
+```bash
+cd deploy/aws
+
+# STAGING — dry run first
+DRY_RUN=1 FOLLOW=1 \
+  ECS_CLUSTER=jyt-staging-Cluster-XXX \
+  TASK_FAMILY=jyt-staging-medusa-server \
+  LOG_GROUP=/copilot/jyt-staging-medusa-server \
+  ./scripts/run-backfill.sh backfill-partner-region-links
+
+# Eyeball the log output:
+#   ✓ Look for "WOULD link partner ... → region ..." lines
+#   ✓ Confirm count looks reasonable (matches your number of legacy partners)
+#   ✓ Final line: "Backfill complete. created=N, already_linked=M, ... errors=0"
+
+# STAGING — real run (drop DRY_RUN)
+FOLLOW=1 \
+  ECS_CLUSTER=jyt-staging-Cluster-XXX \
+  TASK_FAMILY=jyt-staging-medusa-server \
+  LOG_GROUP=/copilot/jyt-staging-medusa-server \
+  ./scripts/run-backfill.sh backfill-partner-region-links
+
+# STAGING — smoke test
+#   Open partner UI, log in as a test partner, confirm region list is populated
+#   (was empty before the backfill if the partner relied on default_region_id)
+
+# PROD — same sequence
+DRY_RUN=1 FOLLOW=1 ./scripts/run-backfill.sh backfill-partner-region-links
+FOLLOW=1 ./scripts/run-backfill.sh backfill-partner-region-links
+```
+
+The script sets `process.exitCode = 1` on per-link errors. If you see errors, the ECS task exits non-zero — review the log before proceeding.
+
+## Step 3 — Migration 2: backfill `store.supported_currencies` from linked regions
+
+**Why:** PR #259 auto-expands supported_currencies when a partner creates/updates a region. Existing partners whose regions use currencies not in their `supported_currencies` will see disabled pricing columns in the partner UI pricing grid.
+
+**Idempotent.** Uses `updateStoresWorkflow` (direct service call silently no-ops on `supported_currencies` — see commit `10608c6` for the why).
+
+```bash
+# STAGING — dry run
+DRY_RUN=1 FOLLOW=1 \
+  ECS_CLUSTER=jyt-staging-Cluster-XXX \
+  TASK_FAMILY=jyt-staging-medusa-server \
+  LOG_GROUP=/copilot/jyt-staging-medusa-server \
+  ./scripts/run-backfill.sh backfill-store-currencies-from-partner-regions
+
+# Look for: "WOULD add currencies [zar, ...] to supported_currencies" lines
+
+# STAGING — real
+FOLLOW=1 \
+  ECS_CLUSTER=jyt-staging-Cluster-XXX \
+  TASK_FAMILY=jyt-staging-medusa-server \
+  LOG_GROUP=/copilot/jyt-staging-medusa-server \
+  ./scripts/run-backfill.sh backfill-store-currencies-from-partner-regions
+
+# PROD — same sequence
+DRY_RUN=1 FOLLOW=1 ./scripts/run-backfill.sh backfill-store-currencies-from-partner-regions
+FOLLOW=1 ./scripts/run-backfill.sh backfill-store-currencies-from-partner-regions
+```
+
+## Step 4 — Migration 3: seed canonical tax_regions
+
+**Why:** Prod currently has tax_regions only for India. Partners with EU/AU/Indonesia customers can't compute tax at checkout. This script ensures every admin region's countries have a tax_region with the statutory standard rate.
+
+**Idempotent.** Skips countries that already have a root tax_region. US deliberately skipped (no federal sales tax).
+
+```bash
+# STAGING — dry run
+DRY_RUN=1 FOLLOW=1 \
+  ECS_CLUSTER=jyt-staging-Cluster-XXX \
+  TASK_FAMILY=jyt-staging-medusa-server \
+  LOG_GROUP=/copilot/jyt-staging-medusa-server \
+  ./scripts/run-backfill.sh seed-canonical-tax-regions
+
+# Look for: "WOULD create tax_region for AU: 10% (Australia GST)" lines
+
+# STAGING — real
+FOLLOW=1 ./scripts/run-backfill.sh seed-canonical-tax-regions
+
+# STAGING — smoke
+#   Place a test order from an EU IP / region, confirm tax computes at checkout
+
+# PROD — same sequence
+DRY_RUN=1 FOLLOW=1 ./scripts/run-backfill.sh seed-canonical-tax-regions
+FOLLOW=1 ./scripts/run-backfill.sh seed-canonical-tax-regions
+```
+
+## Step 5 — Verify in PROD
+
+```bash
+PROD=https://v3.jaalyantra.com
+KEY=<your-admin-key>
+BASIC=$(printf "%s:" "$KEY" | base64)
+
+# Tax-region count should now be ~36 (every country in the 5 admin regions
+# except US, which we skipped). India should still be 1 (existing), the
+# others new.
+curl -sS -H "Authorization: Basic $BASIC" "$PROD/admin/tax-regions?limit=100" \
+  | jq '{count, by_country: [.tax_regions[] | .country_code] | sort | unique}'
+
+# Pick 2-3 real partners and check their store supported_currencies now
+# covers their linked region currencies (use partner login flow or
+# admin-side query)
+```
+
+## Rollback plan
+
+The migrations are additive — they create new link rows and tax_region rows. **There's no destructive path**. If something goes wrong:
+
+- **Bad data in a backfill:** the rows are easy to identify (recent created_at, our specific tax rate codes, etc.) and can be deleted via admin API
+- **Image regression:** Copilot's blue/green keeps the previous task definition. Re-deploy the prior `copilot svc deploy --resource-tags BuildSHA=<old-sha>`, or roll back the ECS service via console
+
+## Operational gotchas
+
+- **240s ALB grace period** — every new ECS task takes ~3-4 min to be ready after `Server is ready on port: 9000`. Wait for ALB health before declaring "deployed."
+- **One-shot tasks share the same task definition** — the backfill scripts inherit SSM secrets, VPC, IAM role from the medusa-server task. No separate setup.
+- **`pg_stat_activity` is your friend** — if a backfill seems stuck, the long-running query will show up there. RDS is in private subnets; query via the bastion or a one-off Fargate task with psql.
+
+## Total runtime estimate
+
+- Migration 1: ~30-60s (21 partners, 5 regions each — fast)
+- Migration 2: ~30-60s (same scale)
+- Migration 3: ~2-3 min (36 countries × createTaxRegionsWorkflow each)
+- Plus image deploy: ~5 min
+- Plus smoke testing: ~10-15 min
+
+Plan on ~30-45 min wall clock for the full sequence including smoke. Budget an hour to be safe.


### PR DESCRIPTION
## Summary

First PR of the FX auto-conversion stack designed in `apps/docs/notes/FX_AUTO_CONVERSION.md`. Lands the foundation: a new `fx_rates` Medusa module with a provider-agnostic service + default fetcher against the free open.er-api.com endpoint + a one-shot seed script.

Independently useful — gives the admin / partner UI a place to read FX rates, gives the next PR (G2: daily refresh visual flow) something to wire into. Doesn't yet change any pricing behavior.

## What's in this PR

### New module: `apps/backend/src/modules/fx_rates/`

| File | Purpose |
|---|---|
| `models/fx-rate.ts` | DML model — `{base, quote, rate, fetched_at, source}` with unique index on (base, quote) for clean upserts |
| `service.ts` | `getRate(from, to)` with direct → inverse → cross-rate-via-most-common-base fallback. `refreshRatesFromProvider`, `applyProviderResult` (lower-level for tests + fixtures), `getLastFetchedAt` |
| `providers/types.ts` | `FxProvider` interface so paid providers can be dropped in without touching the service |
| `providers/open-er-api-provider.ts` | Default implementation. Hits `https://open.er-api.com/v6/latest/USD`. Returns 166 currencies on each fetch. Lowercases codes to match Medusa's convention. |
| `index.ts` | Module export (`FX_RATES_MODULE = "fx_rates"`) |
| `migrations/Migration20260525112809.ts` | Generated migration for the table |

### Seed script: `apps/backend/src/scripts/seed-initial-fx-rates.ts`

One-shot fetch + upsert. Honors both `--dry-run` arg and `DRY_RUN=1` env var (matches PR #262's convention).

```bash
# Real run
npx medusa exec ./src/scripts/seed-initial-fx-rates.ts

# Dry run (logs what would be written, no DB writes)
DRY_RUN=1 npx medusa exec ./src/scripts/seed-initial-fx-rates.ts
```

### Tests

8 integration scenarios in `integration-tests/http/fx-rates/fx-rates-service.spec.ts` — all passing in ~14s. Uses a fake `FxProvider` so no live HTTP in CI.

- ✓ setRates + getRate roundtrip (direct pair)
- ✓ same-currency returns 1
- ✓ cross-rate via USD intermediate (INR→EUR computed)
- ✓ inverse fallback (only USD→INR cached, INR→USD works)
- ✓ idempotent upsert (re-apply doesn't duplicate)
- ✓ getLastFetchedAt reports latest
- ✓ refreshRatesFromProvider uses injected provider
- ✓ clear error when no path exists

### Docs

- **`apps/docs/notes/FX_AUTO_CONVERSION.md`** — design doc that anchors the rest of the FX work. Captures the hybrid architecture (TS workflows + visual flow schedule triggers), daily re-rate decision (with cart consistency rationale), FX provider choice trade-offs, lazy fanout, 6-PR build order.
- **`apps/docs/notes/PR_259_PROD_DEPLOY_RUNBOOK.md`** — the runbook used for the prod migration of PR #259's partner-region work. Captures the `run-backfill.sh` commands, image-version pre-flight, rollback notes. Reference for future similar migrations.

## Live smoke

Confirmed `seed-initial-fx-rates.ts --dry-run` pulled 166 currencies from open.er-api.com, including all common ones: `usd, inr, eur, gbp, aud, sgd, jpy, aed, zar, cad, idr, ...`

## Test plan
- [ ] CI passes
- [ ] Local: `npx medusa db:migrate` creates `fx_rate` table
- [ ] Local: `DRY_RUN=1 npx medusa exec ./src/scripts/seed-initial-fx-rates.ts` logs the currency list
- [ ] Local: `npx medusa exec ./src/scripts/seed-initial-fx-rates.ts` writes rates to DB
- [ ] Local: query.graph against `fx_rate` returns 166 rows

## Next PRs (per the design doc)

| PR | Scope | Effort |
|---|---|---|
| G2 | `refresh-fx-rates` workflow + daily visual flow seed | ~half day |
| G3 | Fanout subscriber + workflow on variant price events | ~1 day |
| G4 | Partner UI: pricing-grid badges + manual override + settings toggle | ~half day |
| G5 | `rerate-auto-converted-prices` workflow + daily visual flow seed | ~half day |
| H | Storefront `<RegionNotServedFallback />` + `/store/contact-region-request` endpoint | ~half day, independent |

🤖 Generated with [Claude Code](https://claude.com/claude-code)