### PR TITLE
feat(fx): refresh-fx-rates workflow + daily visual flow seed (PR G2)

### DIFF
--- a/apps/backend/integration-tests/http/fx-rates/refresh-fx-rates-workflow.spec.ts
+++ b/apps/backend/integration-tests/http/fx-rates/refresh-fx-rates-workflow.spec.ts
@@ -1,0 +1,94 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "../shared-test-setup"
+import { FX_RATES_MODULE } from "../../../src/modules/fx_rates"
+import type FxRatesService from "../../../src/modules/fx_rates/service"
+import type { FxProvider } from "../../../src/modules/fx_rates/providers/types"
+import refreshFxRatesWorkflow from "../../../src/workflows/fx/refresh-fx-rates"
+
+jest.setTimeout(60 * 1000)
+
+// Workflow is a thin wrapper around the service; the heavy lifting is
+// already covered in fx-rates-service.spec.ts. This file just verifies:
+//
+//   1. The workflow can be invoked and returns the summary shape the
+//      visual flow's trigger_workflow operation will get.
+//   2. The container resolution works (FX_RATES_MODULE is registered).
+//   3. The injected provider's rates land in the fx_rate table.
+
+setupSharedTestSuite(() => {
+  const { getContainer } = getSharedTestEnv()
+
+  describe("workflows/fx/refresh-fx-rates", () => {
+    let svc: FxRatesService
+    let container: any
+
+    beforeEach(async () => {
+      container = getContainer()
+      svc = container.resolve(FX_RATES_MODULE) as FxRatesService
+      // Test runner truncates between tests; no manual cleanup needed.
+    })
+
+    it("returns the summary shape visual flow operation will receive", async () => {
+      const fake: FxProvider = {
+        fetchRates: async () => ({
+          base_currency: "usd",
+          fetched_at: new Date("2026-05-26T02:00:00Z"),
+          source: "test-fake",
+          rates: { usd: 1, inr: 83.5, eur: 0.93 },
+        }),
+      }
+      svc.setProvider(fake)
+
+      const { result } = await refreshFxRatesWorkflow(container).run({
+        input: {},
+      })
+
+      expect(result).toMatchObject({
+        base_currency: "usd",
+        upserted: 3,
+        source: "test-fake",
+      })
+      expect(typeof result.fetched_at).toBe("string")
+      expect(new Date(result.fetched_at).toISOString()).toBe(
+        "2026-05-26T02:00:00.000Z"
+      )
+
+      // And the rows actually landed.
+      const rows = await svc.listFxRates({})
+      expect(rows.length).toBe(3)
+      const quote_codes = rows.map((r: any) => r.quote_currency).sort()
+      expect(quote_codes).toEqual(["eur", "inr", "usd"])
+    })
+
+    it("is idempotent — running twice doesn't duplicate rows", async () => {
+      const fake: FxProvider = {
+        fetchRates: async () => ({
+          base_currency: "usd",
+          fetched_at: new Date("2026-05-26T02:00:00Z"),
+          source: "test-fake",
+          rates: { usd: 1, inr: 83.5 },
+        }),
+      }
+      svc.setProvider(fake)
+
+      await refreshFxRatesWorkflow(container).run({ input: {} })
+      const firstCount = (await svc.listFxRates({})).length
+
+      // Second run with newer timestamp — same upsert behavior, no dupes.
+      svc.setProvider({
+        fetchRates: async () => ({
+          base_currency: "usd",
+          fetched_at: new Date("2026-05-26T03:00:00Z"),
+          source: "test-fake",
+          rates: { usd: 1, inr: 83.6 },
+        }),
+      })
+
+      await refreshFxRatesWorkflow(container).run({ input: {} })
+      const secondRows = await svc.listFxRates({})
+
+      expect(secondRows.length).toBe(firstCount)
+      const inrRow = secondRows.find((r: any) => r.quote_currency === "inr")
+      expect(Number((inrRow as any).rate)).toBeCloseTo(83.6, 4)
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/fx-rates/seed-fx-refresh-flow.spec.ts
+++ b/apps/backend/integration-tests/http/fx-rates/seed-fx-refresh-flow.spec.ts
@@ -1,0 +1,71 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "../shared-test-setup"
+import { VISUAL_FLOWS_MODULE } from "../../../src/modules/visual_flows"
+import type VisualFlowService from "../../../src/modules/visual_flows/service"
+import seedFxRefreshFlow from "../../../src/scripts/seed-fx-refresh-flow"
+
+jest.setTimeout(60 * 1000)
+
+// Verifies the seed script creates the expected visual flow shape:
+// schedule trigger on cron "0 2 * * *", single trigger_workflow op
+// pointing at "refresh-fx-rates", connections wired correctly,
+// idempotent on re-run.
+
+const FLOW_NAME = "FX Rates — Daily Refresh"
+
+setupSharedTestSuite(() => {
+  const { getContainer } = getSharedTestEnv()
+
+  describe("scripts/seed-fx-refresh-flow", () => {
+    let svc: VisualFlowService
+    let container: any
+
+    beforeEach(async () => {
+      container = getContainer()
+      svc = container.resolve(VISUAL_FLOWS_MODULE) as VisualFlowService
+      // Test runner truncates between tests; no manual cleanup needed.
+    })
+
+    it("creates the daily-refresh flow with schedule trigger and trigger_workflow op", async () => {
+      await seedFxRefreshFlow({ container } as any)
+
+      const [flow] = (await svc.listVisualFlows({ name: FLOW_NAME } as any)) as any[]
+      expect(flow).toBeDefined()
+      expect(flow.status).toBe("draft")
+      expect(flow.trigger_type).toBe("schedule")
+      expect(flow.trigger_config).toMatchObject({ cron: "0 2 * * *" })
+
+      // Pull operations + connections via the service's getter and
+      // verify the single trigger_workflow op is wired right.
+      const operations = await (svc as any).getFlowOperations(flow.id)
+      const connections = await (svc as any).getFlowConnections(flow.id)
+      expect(operations).toHaveLength(1)
+
+      const op = operations[0]
+      expect(op.operation_key).toBe("refresh_rates")
+      expect(op.operation_type).toBe("trigger_workflow")
+      expect(op.options).toMatchObject({
+        workflow_name: "refresh-fx-rates",
+        wait_for_completion: true,
+      })
+
+      // Single connection from trigger to the refresh op.
+      expect(connections).toHaveLength(1)
+      expect(connections[0]).toMatchObject({
+        source_id: "trigger",
+        target_id: "refresh_rates",
+        connection_type: "default",
+      })
+    })
+
+    it("is idempotent — re-running skips if a flow with the same name exists", async () => {
+      await seedFxRefreshFlow({ container } as any)
+      const first = (await svc.listVisualFlows({ name: FLOW_NAME } as any)) as any[]
+      expect(first).toHaveLength(1)
+
+      await seedFxRefreshFlow({ container } as any)
+      const second = (await svc.listVisualFlows({ name: FLOW_NAME } as any)) as any[]
+      expect(second).toHaveLength(1)
+      expect(second[0].id).toBe(first[0].id)
+    })
+  })
+})

--- a/apps/backend/src/scripts/seed-fx-refresh-flow.ts
+++ b/apps/backend/src/scripts/seed-fx-refresh-flow.ts
@@ -1,0 +1,163 @@
+/**
+ * Seed: FX Rates — Daily Refresh
+ *
+ * Single-operation visual flow that fires daily at 02:00 UTC and
+ * triggers the `refresh-fx-rates` workflow. The workflow's only job
+ * is to call `FxRatesService.refreshRatesFromProvider()` — which
+ * fetches the latest rates from the configured provider
+ * (open.er-api.com by default) and upserts the `fx_rate` table.
+ *
+ * Why a visual flow wraps such a thin operation:
+ *   1. The schedule lives in the admin UI, not in code — operators
+ *      can pause / reschedule / toggle from `/app/visual-flows/{id}`
+ *      without a code change.
+ *   2. The execution log (visual_flow_execution rows) gives us a
+ *      built-in audit trail of each refresh.
+ *   3. Future operations can be chained in front of or behind the
+ *      refresh without rewriting the trigger setup.
+ *
+ * Cadence:
+ *   `0 2 * * *` — daily at 02:00 UTC. Refreshing once per day is more
+ *   than enough at our currency mix; FX moves <0.5% daily on the
+ *   major pairs we use (INR/EUR/USD/AUD/GBP).
+ *
+ * Run:
+ *   npx medusa exec ./src/scripts/seed-fx-refresh-flow.ts
+ *
+ * Re-seed:
+ *   Delete the existing flow first (admin UI or by id) and re-run.
+ *   The script is idempotent and refuses to overwrite by name.
+ *
+ * Status on first creation:
+ *   `draft` — flip to `active` from the admin editor after running
+ *   `seed-initial-fx-rates.ts` at least once so there are rates to
+ *   refresh.
+ */
+
+import { VISUAL_FLOWS_MODULE } from "../modules/visual_flows"
+import VisualFlowService from "../modules/visual_flows/service"
+
+const FLOW_NAME = "FX Rates — Daily Refresh"
+
+// Canvas positions — single vertical column, tight spacing.
+const X_CENTER = 500
+const Y_TRIGGER = -20
+const Y_REFRESH = 140
+
+const FLOW_DEF = {
+  name: FLOW_NAME,
+  description:
+    "Daily refresh of FX rates via the refresh-fx-rates workflow. " +
+    "Fetches from the configured provider (open.er-api.com by default) " +
+    "and upserts the fx_rate table. Runs at 02:00 UTC. Idempotent — " +
+    "upsert keyed on (base_currency, quote_currency).",
+  status: "draft" as const,
+  trigger_type: "schedule" as const,
+  trigger_config: {
+    cron: "0 2 * * *", // daily at 02:00 UTC
+  },
+
+  canvas_state: {
+    viewport: { x: 0, y: 0, zoom: 0.8 },
+    nodes: [
+      {
+        id: "trigger",
+        type: "trigger",
+        position: { x: X_CENTER, y: Y_TRIGGER },
+        data: {
+          label: "Schedule — daily 02:00 UTC",
+          triggerType: "schedule",
+          triggerConfig: { cron: "0 2 * * *" },
+        },
+      },
+      {
+        id: "refresh_rates",
+        type: "operation",
+        position: { x: X_CENTER, y: Y_REFRESH },
+        data: {
+          label: "Refresh FX Rates",
+          operationKey: "refresh_rates",
+          operationType: "trigger_workflow",
+        },
+      },
+    ],
+    edges: [
+      {
+        id: "e-0",
+        source: "trigger",
+        sourceHandle: "default",
+        target: "refresh_rates",
+        targetHandle: "default",
+      },
+    ],
+  },
+
+  operations: [
+    {
+      operation_key: "refresh_rates",
+      operation_type: "trigger_workflow",
+      name: "Refresh FX Rates",
+      sort_order: 0,
+      position_x: X_CENTER,
+      position_y: Y_REFRESH,
+      options: {
+        workflow_name: "refresh-fx-rates",
+        wait_for_completion: true,
+        // The workflow takes no meaningful input — the provider is
+        // resolved from the service's configured default. Pass an
+        // empty object so the trigger_workflow operation gets a valid
+        // payload to forward.
+        input: {},
+      },
+    },
+  ],
+
+  connections: [
+    {
+      source_id: "trigger",
+      source_handle: "default",
+      target_id: "refresh_rates",
+      connection_type: "default" as const,
+    },
+  ],
+}
+
+export default async function seedFxRefreshFlow({
+  container,
+}: {
+  container: any
+}) {
+  const service: VisualFlowService = container.resolve(VISUAL_FLOWS_MODULE)
+
+  const [existing] = await service.listVisualFlows({ name: FLOW_NAME } as any)
+  if (existing) {
+    console.log(`Flow "${FLOW_NAME}" already exists (${existing.id}) — skipping.`)
+    console.log(`Delete it in the admin UI (or by id) to re-seed.`)
+    return
+  }
+
+  console.log(`Creating flow "${FLOW_NAME}"...`)
+
+  const flow = await service.createCompleteFlow({
+    flow: {
+      name: FLOW_DEF.name,
+      description: FLOW_DEF.description,
+      status: FLOW_DEF.status,
+      trigger_type: FLOW_DEF.trigger_type,
+      trigger_config: FLOW_DEF.trigger_config,
+      canvas_state: FLOW_DEF.canvas_state,
+    },
+    operations: FLOW_DEF.operations,
+    connections: FLOW_DEF.connections,
+  })
+
+  console.log(`\nFlow created: ${flow.id}`)
+  console.log(`  Open: /app/visual-flows/${flow.id}\n`)
+  console.log(`Before activating:`)
+  console.log(`  1. Run \`npx medusa exec ./src/scripts/seed-initial-fx-rates.ts\` once`)
+  console.log(`     so the fx_rate table has rows to refresh.`)
+  console.log(`  2. Confirm the cron \`0 2 * * *\` (daily 02:00 UTC) matches the`)
+  console.log(`     cadence you want. Adjust trigger_config.cron + the trigger`)
+  console.log(`     node's data.triggerConfig.cron in the editor if needed.`)
+  console.log(`  3. Flip flow status: draft → active in the admin editor.`)
+}

--- a/apps/backend/src/workflows/fx/refresh-fx-rates.ts
+++ b/apps/backend/src/workflows/fx/refresh-fx-rates.ts
@@ -1,0 +1,49 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import { FX_RATES_MODULE } from "../../modules/fx_rates"
+import FxRatesService from "../../modules/fx_rates/service"
+
+/**
+ * Workflow: refresh-fx-rates
+ *
+ * Thin wrapper around FxRatesService.refreshRatesFromProvider() so the
+ * visual flow (`seed-fx-refresh-flow.ts`) can call it via a
+ * trigger_workflow operation. Keeping the logic on the service means
+ * tests don't need the workflow harness — they exercise the service
+ * directly. The workflow exists purely to give the visual flow a
+ * stable name to bind to.
+ *
+ * No compensation step — refresh is non-destructive (upserts, never
+ * deletes). A partial failure on the provider side leaves the cache
+ * in a valid state with whatever rates were written before the throw.
+ */
+
+export type RefreshFxRatesInput = Record<string, unknown> | undefined
+
+export const refreshFxRatesStep = createStep(
+  "refresh-fx-rates-step",
+  async (_input: RefreshFxRatesInput, { container }) => {
+    const fxService: FxRatesService = container.resolve(FX_RATES_MODULE)
+    const summary = await fxService.refreshRatesFromProvider()
+    return new StepResponse({
+      base_currency: summary.base_currency,
+      upserted: summary.upserted,
+      source: summary.source,
+      fetched_at: summary.fetched_at.toISOString(),
+    })
+  }
+)
+
+export const refreshFxRatesWorkflow = createWorkflow(
+  "refresh-fx-rates",
+  (input: RefreshFxRatesInput) => {
+    const summary = refreshFxRatesStep(input)
+    return new WorkflowResponse(summary)
+  }
+)
+
+export default refreshFxRatesWorkflow


### PR DESCRIPTION
## Summary

Second piece of the FX auto-conversion stack (see `apps/docs/notes/FX_AUTO_CONVERSION.md`). Adds the schedule + the thin workflow that wraps PR G1's service. Once PR G1 (#263) merges, this can be re-targeted to `main` via auto-rebase or a manual base change.

**Base branch:** `feat/fx-rates-module` (so this PR builds on G1's module). GitHub will auto-rebase to `main` once G1 merges.

## What lands

### Workflow: `apps/backend/src/workflows/fx/refresh-fx-rates.ts`

Single-step wrapper around `FxRatesService.refreshRatesFromProvider()`. Exists purely to give the visual flow a stable name to bind via `trigger_workflow`. No compensation step — refresh is non-destructive (upserts, never deletes), and a partial failure on the provider leaves the cache in a valid state.

### Seed script: `apps/backend/src/scripts/seed-fx-refresh-flow.ts`

Creates a visual flow named **"FX Rates — Daily Refresh"** with:
- `trigger_type: "schedule"`, `trigger_config: { cron: "0 2 * * *" }` (daily at 02:00 UTC)
- Single operation: `trigger_workflow` → `"refresh-fx-rates"`, `wait_for_completion: true`

Flow is created in `draft` status; admin flips draft → active in `/app/visual-flows/{id}` after running `seed-initial-fx-rates.ts` once. Idempotent — re-running with an existing flow name skips.

```bash
npx medusa exec ./src/scripts/seed-fx-refresh-flow.ts
```

### Integration tests

Under `integration-tests/http/fx-rates/`:

**`refresh-fx-rates-workflow.spec.ts`** (2 tests):
- ✓ returns expected summary shape (`base_currency`, `upserted`, `source`, `fetched_at`)
- ✓ idempotent upsert via the workflow (re-run doesn't duplicate)

**`seed-fx-refresh-flow.spec.ts`** (2 tests):
- ✓ creates flow with right schedule + trigger_workflow op + connections
- ✓ refuses to overwrite an existing flow with same name on re-run

Each spec passes 2/2 when run alone (~10s). Pre-existing TRUNCATE deadlock flake from Medusa's `createPartitions` on first-test-of-a-fresh-test-run is non-fatal (warns to console.error but tests pass on rerun). Affects PR #259's tests too — not a regression.

## Operational notes

- **Default status: `draft`** — prevents accidental cron fires before partners are ready. Admin manually flips draft → active in `/app/visual-flows/{flow.id}`.
- **Schedule cron is editable from admin** — no code change needed to reschedule.
- **No new cron infra** — `run-scheduled-visual-flows.ts` (existing job) polls active scheduled flows; this just adds another row for it to find.

## Test plan
- [ ] CI passes
- [ ] Local: `npx medusa exec ./src/scripts/seed-fx-refresh-flow.ts` creates the flow (visible at /app/visual-flows/)
- [ ] Local: open the flow in admin, verify schedule + single trigger_workflow op
- [ ] Local: flip flow to `active`, wait for next 02:00 UTC tick OR temporarily change cron to fire sooner, verify execution log shows successful refresh and fx_rate rows update fetched_at

## Next in queue (per design doc)

| PR | Scope | Effort |
|---|---|---|
| **G3** | Fanout subscriber + workflow on variant price events | ~1 day |
| G4 | Partner UI badges + settings toggle | ~half day |
| G5 | rerate-auto-converted-prices workflow + daily visual flow seed | ~half day |
| H | Storefront RegionNotServedFallback + endpoint | ~half day, independent |

🤖 Generated with [Claude Code](https://claude.com/claude-code)