### PR TITLE
fix(prod-config): register fx_rates module in medusa-config.prod.ts

### DIFF
--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -416,5 +416,8 @@ module.exports = defineConfig({
   {
     resolve: "./src/modules/ai_usage",
   },
+  {
+    resolve: "./src/modules/fx_rates",
+  },
 ],
 });


### PR DESCRIPTION
## Summary

PR #263 (G1) added the \`fx_rates\` module registration to \`medusa-config.ts\` but missed \`medusa-config.prod.ts\`. The Dockerfile overwrites the former with the latter at build time:

\`\`\`dockerfile
# Use the production Medusa config for the build.
RUN cp apps/backend/medusa-config.prod.ts apps/backend/medusa-config.ts
\`\`\`

So in prod the module is invisible and any seed script (or runtime resolver) that does \`container.resolve(FX_RATES_MODULE)\` crashes immediately.

This is the 3-line fix to register the module in the prod config.

## Discovered when

Tried to run \`seed-initial-fx-rates\` + \`seed-fx-refresh-flow\` via \`run-backfill.sh\` against prod after G1+G2 were merged + deployed. Killed both tasks before they crashed in front of customers. Caught by Saransh asking "are we using medusa-config.prod.ts?".

## Test plan
- [ ] CI passes (the same module registration works in test envs already)
- [ ] After deploy, re-run \`FOLLOW=0 ./deploy/aws/scripts/run-backfill.sh seed-initial-fx-rates\` — task should exit 0, fx_rate table populated
- [ ] Re-run \`FOLLOW=0 ./deploy/aws/scripts/run-backfill.sh seed-fx-refresh-flow\` — visual_flow row created, listed in admin

## Follow-up

Worth consolidating dev/prod configs (or deriving one from the other) so this drift can't happen again. Not in scope here; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)