### PR TITLE
chore: add medusa-config dev/prod parity check

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -58,6 +58,9 @@ jobs:
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
 
+    - name: Check medusa-config dev/prod parity
+      run: pnpm --filter @jyt/backend check:prod-config
+
     - name: Setup Database
       run: |
         psql -h localhost -U postgres -d postgres -c "CREATE USER runner SUPERUSER CREATEDB CREATEROLE;"

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -32,7 +32,8 @@
     "generate:plans": "ts-node src/scripts/generate-route-plans.ts",
     "seed:plans": "ts-node src/scripts/seed-plans.ts",
     "specs:store": "medusa exec ./src/scripts/specs/store-specs-in-db.ts",
-    "specs:store:direct": "npx tsx src/scripts/specs/store-specs-in-db.ts"
+    "specs:store:direct": "npx tsx src/scripts/specs/store-specs-in-db.ts",
+    "check:prod-config": "node ./scripts/check-prod-config-parity.mjs"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.1.17",

--- a/apps/backend/scripts/check-prod-config-parity.mjs
+++ b/apps/backend/scripts/check-prod-config-parity.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// Asserts that every custom `./src/modules/<name>` registered in
+// medusa-config.ts is also registered in medusa-config.prod.ts.
+//
+// Why this exists
+//   The Dockerfile overwrites medusa-config.ts with medusa-config.prod.ts
+//   at build time (see apps/backend/Dockerfile, "Use the production
+//   Medusa config for the build"). If you add a new custom module to
+//   medusa-config.ts and forget the prod variant, the module is silently
+//   missing in prod — `container.resolve(MODULE_KEY)` throws at runtime.
+//
+// We deliberately don't compare third-party providers (@medusajs/medusa/*,
+// @medusajs/draft-order, …) because dev and prod legitimately differ
+// (Redis vs in-memory cache/event-bus/workflow-engine, Resend/Mailjet/S3
+// only enabled in prod, etc.).
+//
+// Usage
+//   node apps/backend/scripts/check-prod-config-parity.mjs        # check
+//   node apps/backend/scripts/check-prod-config-parity.mjs --fix  # append missing
+//
+// Exits 1 on drift (no --fix) so CI fails the merge.
+
+import { readFileSync, writeFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import path from "node:path"
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const BACKEND = path.resolve(HERE, "..")
+const DEV = path.join(BACKEND, "medusa-config.ts")
+const PROD = path.join(BACKEND, "medusa-config.prod.ts")
+
+const MODULE_RE = /resolve:\s*"(\.\/src\/modules\/[^"]+)"/g
+
+function extractCustomModules(filePath) {
+  const text = readFileSync(filePath, "utf8")
+  // Strip block comments + line comments before extracting so commented-out
+  // module registrations don't count as "present."
+  const stripped = text
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .split("\n")
+    .map((l) => l.replace(/\/\/.*$/, ""))
+    .join("\n")
+
+  const found = new Set()
+  for (const m of stripped.matchAll(MODULE_RE)) {
+    found.add(m[1])
+  }
+  return found
+}
+
+function appendMissingToProd(missing) {
+  let text = readFileSync(PROD, "utf8")
+  // Find the modules array's closing `]` — the script handles the common
+  // case of `\n],\n});` at the file tail. If the file shape changes, this
+  // throws explicitly rather than corrupting the config.
+  const tailRe = /\n\],\s*\}\);\s*$/
+  if (!tailRe.test(text)) {
+    throw new Error(
+      "Could not locate `\\n],\\n});` at the tail of medusa-config.prod.ts — refusing to auto-edit. Add the missing modules by hand."
+    )
+  }
+  const additions = [...missing]
+    .map((m) => `  {\n    resolve: "${m}",\n  },`)
+    .join("\n")
+  text = text.replace(tailRe, `\n${additions}\n],\n});\n`)
+  writeFileSync(PROD, text)
+}
+
+const dev = extractCustomModules(DEV)
+const prod = extractCustomModules(PROD)
+const missing = [...dev].filter((m) => !prod.has(m)).sort()
+
+if (missing.length === 0) {
+  console.log("✓ medusa-config.prod.ts registers every custom module from medusa-config.ts")
+  process.exit(0)
+}
+
+const fix = process.argv.includes("--fix")
+console.error(
+  `✗ medusa-config.prod.ts is missing ${missing.length} custom module(s) present in medusa-config.ts:`
+)
+for (const m of missing) console.error(`    ${m}`)
+
+if (fix) {
+  appendMissingToProd(missing)
+  console.error(
+    `\n  → Appended to medusa-config.prod.ts. Review the diff and commit.`
+  )
+  process.exit(0)
+}
+
+console.error(
+  `\n  To auto-append: node apps/backend/scripts/check-prod-config-parity.mjs --fix`
+)
+process.exit(1)


### PR DESCRIPTION
## Summary

Catches the drift class that caused PR #266 (3-line hotfix where \`fx_rates\` was registered in \`medusa-config.ts\` but missing from \`medusa-config.prod.ts\`). The Dockerfile overwrites the former with the latter at build time, so this kind of drift = silent missing module in prod = runtime \`AwilixResolutionError\`.

## What's in here

- \`apps/backend/scripts/check-prod-config-parity.mjs\` — node script that grep-extracts all \`resolve: \"./src/modules/X\"\` entries from each config, ignoring comments. Errors out if dev has entries prod doesn't. Skips third-party providers (\`@medusajs/medusa/*\`, plugins) because dev and prod legitimately diverge there (Redis vs in-memory, Stripe/S3/Resend prod-only, etc).
- New pnpm script: \`pnpm --filter @jyt/backend check:prod-config\`
- \`--fix\` flag that appends missing modules to prod config's modules array. Refuses to edit if the file's tail shape is unfamiliar — safer to fail than corrupt the config.

## What's NOT in here (follow-up)

CI step in \`test-and-release.yml\` to fail PRs that introduce drift. The current \`gh\` OAuth token doesn't have \`workflow\` scope and SSH is temporarily timing out, so the workflow file edit can't be pushed yet. Will follow up via a separate commit pushed over SSH once that's back.

## Test plan

- [x] Local: \`pnpm --filter @jyt/backend check:prod-config\` passes against current state (post PR #266 merge)
- [x] Verified \`--fix\` flow against simulated drift in /tmp
- [ ] CI passes once workflow hook lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)