### PR TITLE
feat(fx): partner-ui FX badge on auto-converted price cells (G4a)

### DIFF
--- a/apps/backend/src/api/partners/stores/[id]/products/[productId]/route.ts
+++ b/apps/backend/src/api/partners/stores/[id]/products/[productId]/route.ts
@@ -45,9 +45,34 @@ export const GET = async (
   }
 
   const product = products[0] as any
-  scopeAndAggregateVariantInventory(product.variants || [], store?.default_location_id)
 
-  res.json({ product: remapProductResponse(product) })
+  // `remapVariantResponse` (used by remapProductResponse) explicitly drops
+  // `price.metadata` when flattening price_set.prices → variant.prices.
+  // The partner UI needs metadata to render FX-auto-converted badges, so
+  // capture it before the remap and re-attach to the flattened prices by
+  // price.id. Empty objects are skipped to keep the response slim.
+  const metadataByPriceId = new Map<string, Record<string, unknown>>()
+  for (const variant of product.variants || []) {
+    for (const price of variant.price_set?.prices || []) {
+      const meta = price.metadata as Record<string, unknown> | null | undefined
+      if (meta && Object.keys(meta).length) {
+        metadataByPriceId.set(price.id, meta)
+      }
+    }
+  }
+
+  scopeAndAggregateVariantInventory(product.variants || [], store?.default_location_id)
+  const remapped: any = remapProductResponse(product)
+  if (metadataByPriceId.size) {
+    for (const variant of remapped.variants || []) {
+      for (const price of variant.prices || []) {
+        const meta = metadataByPriceId.get(price.id)
+        if (meta) price.metadata = meta
+      }
+    }
+  }
+
+  res.json({ product: remapped })
 }
 
 export const POST = async (

--- a/apps/partner-ui/src/components/common/fx-auto-badge/fx-auto-badge.tsx
+++ b/apps/partner-ui/src/components/common/fx-auto-badge/fx-auto-badge.tsx
@@ -1,0 +1,50 @@
+import { Tooltip } from "@medusajs/ui"
+
+export type FxPriceMetadata = {
+  is_auto_converted?: boolean
+  base_currency?: string
+  base_amount?: number
+  fx_rate?: number
+  source_price_id?: string
+}
+
+const formatAmount = (amount?: number, code?: string) => {
+  if (amount == null || !code) return ""
+  const fmt = new Intl.NumberFormat(undefined, { maximumFractionDigits: 4 })
+  return `${fmt.format(amount)} ${code.toUpperCase()}`
+}
+
+const formatRate = (rate?: number, base?: string, quote?: string) => {
+  if (rate == null || !base || !quote) return ""
+  const fmt = new Intl.NumberFormat(undefined, {
+    minimumFractionDigits: 4,
+    maximumFractionDigits: 6,
+  })
+  return `${fmt.format(rate)} ${quote.toUpperCase()}/${base.toUpperCase()}`
+}
+
+export const FxAutoBadge = ({
+  meta,
+  targetCurrency,
+}: {
+  meta: FxPriceMetadata
+  targetCurrency: string
+}) => {
+  const baseDesc = formatAmount(meta.base_amount, meta.base_currency)
+  const rateDesc = formatRate(meta.fx_rate, meta.base_currency, targetCurrency)
+  const tooltipText =
+    baseDesc && rateDesc
+      ? `Auto-converted from ${baseDesc} at ${rateDesc}. Edit to override.`
+      : "Auto-converted price. Edit to override."
+
+  return (
+    <Tooltip content={tooltipText} maxWidth={320}>
+      <span
+        aria-label="auto-converted"
+        className="text-ui-fg-muted bg-ui-bg-subtle pointer-events-auto absolute right-1 top-1 select-none rounded px-1 text-[10px] leading-tight"
+      >
+        FX
+      </span>
+    </Tooltip>
+  )
+}

--- a/apps/partner-ui/src/components/common/fx-auto-badge/fx-auto-badge.tsx
+++ b/apps/partner-ui/src/components/common/fx-auto-badge/fx-auto-badge.tsx
@@ -41,7 +41,7 @@ export const FxAutoBadge = ({
     <Tooltip content={tooltipText} maxWidth={320}>
       <span
         aria-label="auto-converted"
-        className="text-ui-fg-muted bg-ui-bg-subtle pointer-events-auto absolute right-1 top-1 select-none rounded px-1 text-[10px] leading-tight"
+        className="text-ui-fg-muted bg-ui-bg-subtle pointer-events-auto absolute right-1 top-1 z-[3] select-none rounded px-1 text-[10px] leading-tight"
       >
         FX
       </span>

--- a/apps/partner-ui/src/components/data-grid/helpers/create-data-grid-price-columns.tsx
+++ b/apps/partner-ui/src/components/data-grid/helpers/create-data-grid-price-columns.tsx
@@ -1,6 +1,7 @@
 import { HttpTypes } from "@medusajs/types"
 import { ColumnDef } from "@tanstack/react-table"
 import { TFunction } from "i18next"
+import { ReactNode } from "react"
 import { FieldPath, FieldValues } from "react-hook-form"
 import { IncludesTaxTooltip } from "../../common/tax-badge/tax-badge"
 import { DataGridCurrencyCell } from "../components/data-grid-currency-cell"
@@ -20,7 +21,24 @@ type CreateDataGridPriceColumnsProps<
     context: FieldContext<TData>,
     value: string
   ) => FieldPath<TFieldValues> | null
+  // Optional overlay rendered on top of each price cell. Used to mark
+  // FX-auto-converted cells with a small badge.
+  getCellDecorator?: (
+    context: FieldContext<TData>,
+    key: string,
+    kind: "currency" | "region"
+  ) => ReactNode | null
   t: TFunction
+}
+
+const withDecorator = (cell: ReactNode, decorator: ReactNode | null) => {
+  if (!decorator) return cell
+  return (
+    <div className="relative size-full">
+      {cell}
+      {decorator}
+    </div>
+  )
 }
 
 export const createDataGridPriceColumns = <
@@ -32,6 +50,7 @@ export const createDataGridPriceColumns = <
   pricePreferences,
   isReadyOnly,
   getFieldName,
+  getCellDecorator,
   t,
 }: CreateDataGridPriceColumnsProps<TData, TFieldValues>): ColumnDef<
   TData,
@@ -77,7 +96,10 @@ export const createDataGridPriceColumns = <
             return <DataGridReadonlyCell context={context} />
           }
 
-          return <DataGridCurrencyCell code={currency} context={context} />
+          return withDecorator(
+            <DataGridCurrencyCell code={currency} context={context} />,
+            getCellDecorator?.(context, currency, "currency")
+          )
         },
       })
     }) ?? []),
@@ -123,11 +145,12 @@ export const createDataGridPriceColumns = <
             return null
           }
 
-          return (
+          return withDecorator(
             <DataGridCurrencyCell
               code={region.currency_code}
               context={context}
-            />
+            />,
+            getCellDecorator?.(context, region.id, "region")
           )
         },
       })

--- a/apps/partner-ui/src/routes/products/common/variant-pricing-form.tsx
+++ b/apps/partner-ui/src/routes/products/common/variant-pricing-form.tsx
@@ -8,17 +8,28 @@ import {
   createDataGridHelper,
   createDataGridPriceColumns,
 } from "../../../components/data-grid"
+import {
+  FxAutoBadge,
+  FxPriceMetadata,
+} from "../../../components/common/fx-auto-badge/fx-auto-badge"
 import { useRouteModal } from "../../../components/modals/index"
 import { usePricePreferences } from "../../../hooks/api/price-preferences"
 import { useRegions } from "../../../hooks/api/regions.tsx"
 import { useStore } from "../../../hooks/api/store"
 import { ProductCreateSchemaType } from "../product-create/types"
 
+// variantIndex -> currency_code | region_id -> metadata
+export type FxAutoMetadataMap = Record<number, Record<string, FxPriceMetadata>>
+
 type VariantPricingFormProps = {
   form: UseFormReturn<ProductCreateSchemaType>
+  fxAutoMetadata?: FxAutoMetadataMap
 }
 
-export const VariantPricingForm = ({ form }: VariantPricingFormProps) => {
+export const VariantPricingForm = ({
+  form,
+  fxAutoMetadata,
+}: VariantPricingFormProps) => {
   const { store } = useStore()
   const { regions } = useRegions({ limit: 9999 })
   const { price_preferences: pricePreferences } = usePricePreferences({})
@@ -29,6 +40,7 @@ export const VariantPricingForm = ({ form }: VariantPricingFormProps) => {
     currencies: store?.supported_currencies,
     regions,
     pricePreferences,
+    fxAutoMetadata,
   })
 
   const variants = useWatch({
@@ -55,10 +67,12 @@ const useVariantPriceGridColumns = ({
   currencies = [],
   regions = [],
   pricePreferences = [],
+  fxAutoMetadata,
 }: {
   currencies?: HttpTypes.AdminStore["supported_currencies"]
   regions?: HttpTypes.AdminRegion[]
   pricePreferences?: HttpTypes.AdminPricePreference[]
+  fxAutoMetadata?: FxAutoMetadataMap
 }) => {
   const { t } = useTranslation()
 
@@ -92,8 +106,19 @@ const useVariantPriceGridColumns = ({
           }
           return `variants.${context.row.index}.prices.${value}`
         },
+        getCellDecorator: fxAutoMetadata
+          ? (context, key, kind) => {
+              const meta = fxAutoMetadata[context.row.index]?.[key]
+              if (!meta?.is_auto_converted) return null
+              const target =
+                kind === "region"
+                  ? regions.find((r) => r.id === key)?.currency_code ?? key
+                  : key
+              return <FxAutoBadge meta={meta} targetCurrency={target} />
+            }
+          : undefined,
         t,
       }),
     ]
-  }, [t, currencies, regions, pricePreferences])
+  }, [t, currencies, regions, pricePreferences, fxAutoMetadata])
 }

--- a/apps/partner-ui/src/routes/products/product-prices/pricing-edit.tsx
+++ b/apps/partner-ui/src/routes/products/product-prices/pricing-edit.tsx
@@ -6,12 +6,16 @@ import { useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import { z as zod } from "@medusajs/framework/zod"
 
+import { FxPriceMetadata } from "../../../components/common/fx-auto-badge/fx-auto-badge"
 import { RouteFocusModal, useRouteModal } from "../../../components/modals"
 import { KeyboundForm } from "../../../components/utilities/keybound-form"
 import { useUpdateProductVariantsBatch } from "../../../hooks/api/products"
 import { useRegions } from "../../../hooks/api/regions"
 import { castNumber } from "../../../lib/cast-number"
-import { VariantPricingForm } from "../common/variant-pricing-form"
+import {
+  FxAutoMetadataMap,
+  VariantPricingForm,
+} from "../common/variant-pricing-form"
 
 export const UpdateVariantPricesSchema = zod.object({
   variants: zod.array(
@@ -53,6 +57,25 @@ export const PricingEdit = ({
   const variants = variantId
     ? product.variants?.filter((v) => v.id === variantId)
     : product.variants
+
+  // Build variantIndex -> currency|region_id -> FxPriceMetadata so the
+  // pricing grid can render the FX badge on auto-converted cells.
+  const fxAutoMetadata = useMemo<FxAutoMetadataMap | undefined>(() => {
+    if (!variants?.length) return undefined
+    const result: FxAutoMetadataMap = {}
+    variants.forEach((variant: any, idx: number) => {
+      const byKey: Record<string, FxPriceMetadata> = {}
+      ;(variant.prices ?? []).forEach((price: any) => {
+        const meta = price?.metadata as FxPriceMetadata | undefined
+        if (!meta?.is_auto_converted) return
+        const key = price.rules?.region_id ?? price.currency_code
+        if (!key) return
+        byKey[key] = meta
+      })
+      if (Object.keys(byKey).length) result[idx] = byKey
+    })
+    return Object.keys(result).length ? result : undefined
+  }, [variants])
 
   const form = useForm<UpdateVariantPricesSchemaType>({
     defaultValues: {
@@ -124,7 +147,7 @@ export const PricingEdit = ({
       <KeyboundForm onSubmit={handleSubmit} className="flex size-full flex-col">
         <RouteFocusModal.Header />
         <RouteFocusModal.Body className="flex flex-col overflow-hidden">
-          <VariantPricingForm form={form as any} />
+          <VariantPricingForm form={form as any} fxAutoMetadata={fxAutoMetadata} />
         </RouteFocusModal.Body>
         <RouteFocusModal.Footer>
           <div className="flex w-full items-center justify-end gap-x-2">


### PR DESCRIPTION
## Summary

Fourth PR of the FX auto-conversion stack. When a price has \`metadata.is_auto_converted = true\` (set by PR G3's fanout subscriber), the partner-ui pricing grid now shows a small \"FX\" overlay in the top-right of the cell, with a tooltip explaining the conversion.

Read-only display in this PR — partner can still edit the cell, and editing doesn't yet strip the auto-converted flag. That + the store-level toggle land in **G4b**.

## How it looks

\`\`\`
┌─────────────────┬─────────────┬─────────────┬─────────────┐
│ Title           │ INR         │ USD     [FX]│ EUR     [FX]│
├─────────────────┼─────────────┼─────────────┼─────────────┤
│ Variant 1       │ ₹ 1,000.00  │ \$ 12.00    │ € 11.04     │
└─────────────────┴─────────────┴─────────────┴─────────────┘
\`\`\`

Hover the \`FX\` chip:
> Auto-converted from 1,000 INR at 0.012 USD/INR. Edit to override.

## Changes

| File | What |
|---|---|
| \`apps/partner-ui/src/components/common/fx-auto-badge/fx-auto-badge.tsx\` | New badge + tooltip component |
| \`apps/partner-ui/src/components/data-grid/helpers/create-data-grid-price-columns.tsx\` | Generic \`getCellDecorator\` slot — caller can overlay any ReactNode on any price cell. Not FX-specific. |
| \`apps/partner-ui/src/routes/products/common/variant-pricing-form.tsx\` | New \`fxAutoMetadata\` prop, wires the decorator through |
| \`apps/partner-ui/src/routes/products/product-prices/pricing-edit.tsx\` | Builds variantIndex → currency\\|region_id → FxPriceMetadata from loaded \`variant.prices[*].metadata\` |
| \`apps/backend/src/api/partners/stores/[id]/products/[productId]/route.ts\` | Medusa's \`remapVariantResponse\` explicitly drops \`price.metadata\` when flattening price_set.prices → variant.prices. Capture metadata by price.id before remap, re-attach after. |

## Why the backend tweak

Medusa upstream:
\`\`\`js
// node_modules/@medusajs/medusa/dist/api/admin/products/helpers.js
const remapVariantResponse = (variant) => ({
  ...variant,
  prices: variant.price_set?.prices?.map((price) => ({
    id: price.id, amount: price.amount, currency_code: price.currency_code,
    min_quantity, max_quantity, variant_id, created_at, updated_at,
    rules: buildRules(price),
    // ← no metadata
  })),
})
\`\`\`

So even though the query asks for \`variants.price_set.prices.*\`, the metadata gets stripped on the way out. The partner GET route now captures metadata pre-remap and re-attaches it by price.id post-remap.

## Test plan

- [ ] CI passes (no test changes; UI-only feature)
- [ ] Local Playwright smoke (script at \`/tmp/jyt-ui-smoke-g4a/test-fx-badge.js\` — uses route-interception to inject \`is_auto_converted\` metadata so no FX-seed setup needed)
- [ ] Manual end-to-end (once G3 fanout is live in dev):
  - Set INR base price on a variant → save → reopen prices modal → USD/EUR cells show \`FX\` chip
  - Hover chip → tooltip text matches \"Auto-converted from 1000 INR at 0.012 USD/INR\"

## What's NOT here (G4b)

- Edit-strips-metadata semantics (\"if partner edits an auto cell, the new value loses the \`is_auto_converted\` flag\")
- Store-settings \"Auto-convert prices\" toggle
- Subscriber respect for the toggle

Those touch the backend update path + a new settings form, so they're in their own PR for cleaner review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)