### PR TITLE
feat(fx): partner-ui strip-on-edit + store auto-convert toggle (G4b)

### DIFF
--- a/apps/backend/src/api/partners/stores/[id]/prices/[priceId]/fx-meta/route.ts
+++ b/apps/backend/src/api/partners/stores/[id]/prices/[priceId]/fx-meta/route.ts
@@ -1,0 +1,89 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+import { FX_RATES_MODULE } from "../../../../../../../modules/fx_rates"
+import type FxRatesService from "../../../../../../../modules/fx_rates/service"
+import { validatePartnerStoreAccess } from "../../../../../helpers"
+
+/**
+ * Detach the FX-auto marker from a price.
+ *
+ * Called by the partner UI when the partner edits a previously
+ * auto-converted cell to a new value — the price stops being
+ * "owned" by the fanout system and becomes a manual price (immune
+ * to G5's daily re-rate). Re-running the fanout subscriber on an
+ * unrelated price won't re-create the marker on this price either,
+ * because the source-price logic only creates markers for prices
+ * it itself just added.
+ *
+ * Scoping: walk price_id → price_set → variant → product →
+ * sales_channels → store. If none of those stores match the
+ * partner's store, 404. Same chain the fanout workflow uses (kept
+ * read-only so the chain is cheap).
+ *
+ * Idempotent. If there's no fx_price_meta link, returns
+ * `{ deleted: false }`.
+ */
+export const DELETE = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const { store } = await validatePartnerStoreAccess(
+    req.auth_context,
+    req.params.id,
+    req.scope
+  )
+
+  const priceId = req.params.priceId
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const link = req.scope.resolve(ContainerRegistrationKeys.LINK)
+  const fxService = req.scope.resolve(FX_RATES_MODULE) as FxRatesService
+
+  // Resolve the price → price_set → variant → product → sales_channel → store.
+  // If the chain doesn't terminate at this partner's store, treat as NOT_FOUND.
+  const { data: prices } = await query.graph({
+    entity: "price",
+    filters: { id: priceId },
+    fields: ["id", "price_set_id", "fx_price_meta.id"],
+  })
+  const price = prices?.[0] as any
+  if (!price) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, `price ${priceId} not found`)
+  }
+
+  const { data: variantLinks } = await query.graph({
+    entity: "product_variant_price_set",
+    filters: { price_set_id: price.price_set_id },
+    fields: ["variant.product.sales_channels.store_id"],
+  })
+  const storeIds: string[] = []
+  for (const vl of variantLinks ?? []) {
+    for (const sc of (vl as any).variant?.product?.sales_channels ?? []) {
+      if (sc?.store_id) storeIds.push(sc.store_id)
+    }
+  }
+  if (!storeIds.includes(store.id)) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `price ${priceId} does not belong to this partner's store`
+    )
+  }
+
+  if (!price.fx_price_meta?.id) {
+    return res.json({ id: priceId, deleted: false })
+  }
+
+  const fxMetaId: string = price.fx_price_meta.id
+  await link.dismiss([
+    {
+      [Modules.PRICING]: { price_id: priceId },
+      [FX_RATES_MODULE]: { fx_price_meta_id: fxMetaId },
+    },
+  ])
+  await fxService.deleteFxPriceMetas(fxMetaId)
+
+  res.json({ id: priceId, deleted: true })
+}

--- a/apps/partner-ui/src/routes/products/product-prices/pricing-edit.tsx
+++ b/apps/partner-ui/src/routes/products/product-prices/pricing-edit.tsx
@@ -11,7 +11,9 @@ import { RouteFocusModal, useRouteModal } from "../../../components/modals"
 import { KeyboundForm } from "../../../components/utilities/keybound-form"
 import { useUpdateProductVariantsBatch } from "../../../hooks/api/products"
 import { useRegions } from "../../../hooks/api/regions"
+import { usePartnerStores } from "../../../hooks/api/partner-stores"
 import { castNumber } from "../../../lib/cast-number"
+import { sdk } from "../../../lib/client"
 import {
   FxAutoMetadataMap,
   VariantPricingForm,
@@ -41,6 +43,8 @@ export const PricingEdit = ({
   const { t } = useTranslation()
   const { handleSuccess } = useRouteModal()
   const { mutateAsync, isPending } = useUpdateProductVariantsBatch(product.id)
+  const { stores } = usePartnerStores()
+  const storeId = stores?.[0]?.id
 
   const { regions } = useRegions({ limit: 9999 })
   const regionsCurrencyMap = useMemo(() => {
@@ -81,6 +85,37 @@ export const PricingEdit = ({
     return Object.keys(result).length ? result : undefined
   }, [variants])
 
+  // Snapshot price.id + amount + (optional) fx_price_meta per
+  // (variantIdx, key) so the submit handler can detect which
+  // auto-converted cells the partner actually edited and detach
+  // their fx_price_meta marker.
+  const initialPricesByKey = useMemo(() => {
+    const result: Record<
+      number,
+      Record<
+        string,
+        { id: string; amount: number; hasFxMeta: boolean }
+      >
+    > = {}
+    variants?.forEach((variant: any, idx: number) => {
+      const byKey: Record<
+        string,
+        { id: string; amount: number; hasFxMeta: boolean }
+      > = {}
+      ;(variant.prices ?? []).forEach((price: any) => {
+        const key = price.rules?.region_id ?? price.currency_code
+        if (!key) return
+        byKey[key] = {
+          id: price.id,
+          amount: Number(price.amount),
+          hasFxMeta: !!price.fx_price_meta,
+        }
+      })
+      result[idx] = byKey
+    })
+    return result
+  }, [variants])
+
   const form = useForm<UpdateVariantPricesSchemaType>({
     defaultValues: {
       variants: variants?.map((variant: any) => ({
@@ -100,6 +135,12 @@ export const PricingEdit = ({
   })
 
   const handleSubmit = form.handleSubmit(async (values) => {
+    // Collect price ids whose underlying row was auto-converted AND
+    // whose amount the partner just changed — these need their
+    // fx_price_meta marker detached so daily re-rate leaves them
+    // alone going forward.
+    const fxMetasToDetach: string[] = []
+
     const reqData = values.variants.map((variant, ind) => ({
       id: variants[ind].id,
       prices: Object.entries(variant.prices || {})
@@ -130,6 +171,15 @@ export const PricingEdit = ({
 
           const amount = castNumber(value)
 
+          const initial = initialPricesByKey[ind]?.[currencyCodeOrRegionId]
+          if (
+            initial?.hasFxMeta &&
+            existingId &&
+            initial.amount !== amount
+          ) {
+            fxMetasToDetach.push(existingId)
+          }
+
           return {
             id: existingId,
             currency_code: currencyCode,
@@ -140,7 +190,21 @@ export const PricingEdit = ({
     }))
 
     await mutateAsync(reqData, {
-      onSuccess: () => {
+      onSuccess: async () => {
+        // Fire-and-forget: detach the FX marker from any cell the
+        // partner just took manual control of. We don't block the
+        // success flow on these — if one fails, the cell stays
+        // auto-converted and the next save will retry.
+        if (fxMetasToDetach.length && storeId) {
+          await Promise.allSettled(
+            fxMetasToDetach.map((priceId) =>
+              sdk.client.fetch(
+                `/partners/stores/${storeId}/prices/${priceId}/fx-meta`,
+                { method: "DELETE" }
+              )
+            )
+          )
+        }
         handleSuccess("..")
       },
     })

--- a/apps/partner-ui/src/routes/store/store-detail/components/store-fx-section/index.ts
+++ b/apps/partner-ui/src/routes/store/store-detail/components/store-fx-section/index.ts
@@ -1,0 +1,1 @@
+export * from "./store-fx-section"

--- a/apps/partner-ui/src/routes/store/store-detail/components/store-fx-section/store-fx-section.tsx
+++ b/apps/partner-ui/src/routes/store/store-detail/components/store-fx-section/store-fx-section.tsx
@@ -1,0 +1,89 @@
+import { AdminStore } from "@medusajs/types"
+import { Container, Heading, Switch, Text, toast } from "@medusajs/ui"
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import { useUpdateStore } from "../../../../../hooks/api/store"
+
+// Reads the store's `metadata.fx_auto_convert` flag (default true) and
+// lets the partner flip it. When false, the FX fanout subscriber
+// short-circuits for this store's variant prices — so partner-set
+// prices no longer auto-replicate across the store's other supported
+// currencies. Useful when the partner wants to hand-curate every
+// price per currency.
+//
+// Backend check lives in apps/backend/src/workflows/fx/fanout-prices.ts
+// (the `if (store.metadata?.fx_auto_convert === false)` short-circuit).
+type StoreFxSectionProps = {
+  store: AdminStore
+}
+
+export const StoreFxSection = ({ store }: StoreFxSectionProps) => {
+  const { t } = useTranslation()
+  const metaFlag = (store?.metadata as Record<string, unknown> | undefined)?.[
+    "fx_auto_convert"
+  ]
+  // Default ON when undefined — fanout has always been the default
+  // behavior since PR G3 shipped.
+  const initial = metaFlag !== false
+  const [enabled, setEnabled] = useState(initial)
+  const { mutateAsync, isPending } = useUpdateStore(store.id)
+
+  const handleChange = async (next: boolean) => {
+    const previous = enabled
+    setEnabled(next)
+    try {
+      await mutateAsync({
+        metadata: {
+          ...(store.metadata ?? {}),
+          fx_auto_convert: next,
+        } as Record<string, unknown>,
+      } as any)
+      toast.success(
+        next
+          ? t(
+              "store.fxAutoConvertEnabled",
+              "Auto-conversion enabled. New base prices will fan out to other currencies."
+            )
+          : t(
+              "store.fxAutoConvertDisabled",
+              "Auto-conversion disabled. Partner manages each currency manually."
+            )
+      )
+    } catch (err) {
+      setEnabled(previous)
+      const message = err instanceof Error ? err.message : String(err)
+      toast.error(
+        t(
+          "store.fxAutoConvertError",
+          "Could not update FX auto-conversion: {{message}}",
+          { message }
+        )
+      )
+    }
+  }
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div>
+          <Heading>
+            {t("store.fxAutoConvertTitle", "Auto-convert prices across regions")}
+          </Heading>
+          <Text className="text-ui-fg-subtle" size="small">
+            {t(
+              "store.fxAutoConvertDescription",
+              "When on, prices you set in your base currency are automatically converted to your other supported currencies using daily FX rates. Turn off to manage every currency manually."
+            )}
+          </Text>
+        </div>
+        <Switch
+          checked={enabled}
+          onCheckedChange={handleChange}
+          disabled={isPending}
+          aria-label="fx-auto-convert"
+        />
+      </div>
+    </Container>
+  )
+}

--- a/apps/partner-ui/src/routes/store/store-detail/store-detail.tsx
+++ b/apps/partner-ui/src/routes/store/store-detail/store-detail.tsx
@@ -8,6 +8,7 @@ import { SingleColumnPageSkeleton } from "../../../components/common/skeleton"
 import { SingleColumnPage } from "../../../components/layout/pages"
 import { useExtension } from "../../../providers/extension-provider"
 import { StoreCurrencySection } from "./components/store-currency-section"
+import { StoreFxSection } from "./components/store-fx-section"
 import { StoreLocaleSection } from "./components/store-locale-section"
 import { useFeatureFlag } from "../../../providers/feature-flag-provider"
 
@@ -42,6 +43,7 @@ export const StoreDetail = () => {
     >
       <StoreGeneralSection store={store} />
       <StoreCurrencySection store={store} />
+      <StoreFxSection store={store} />
       {isTranslationsEnabled && <StoreLocaleSection store={store} />}
     </SingleColumnPage>
   )


### PR DESCRIPTION
## Summary

Completes the partner-side FX UX on top of #269's link-table fix.

### 1. Strip-on-edit (per-cell override)

When the partner edits a previously auto-converted cell to a new value, the cell becomes a manual override that's immune to G5's daily re-rate.

**Backend** — new endpoint:
\`\`\`
DELETE /partners/stores/{storeId}/prices/{priceId}/fx-meta
\`\`\`
- Scoped via the price → price_set → variant → product → sales_channel → store chain (same lookup fanout uses); 404 if the price doesn't belong to this partner
- Dismisses the price ↔ fx_price_meta link + deletes the meta row
- Idempotent: \`{ deleted: false }\` when there's no link to remove

**Frontend** — \`pricing-edit.tsx\`:
- Snapshots \`(id, amount, hasFxMeta)\` per cell at load time
- On submit, collects price ids where \`hasFxMeta && amount changed\`, fires \`DELETE\` in parallel via \`Promise.allSettled\` after the variants batch update succeeds
- Fire-and-forget — a failed strip never blocks the form's success path (worst case: next save retries)

### 2. Store-settings toggle

\`"Auto-convert prices across regions"\` switch in the partner store detail page. Default ON.

- Writes to \`store.metadata.fx_auto_convert\` via the existing \`useUpdateStore\` hook
- Optimistic UI with revert on error + toast notifications
- **Backend check already landed in #269**: \`fanout-prices.ts\` short-circuits when \`store.metadata.fx_auto_convert === false\`

## Files

| File | What |
|---|---|
| \`apps/backend/src/api/partners/stores/[id]/prices/[priceId]/fx-meta/route.ts\` | New \`DELETE\` endpoint |
| \`apps/partner-ui/src/routes/products/product-prices/pricing-edit.tsx\` | Snapshot initial state + fire DELETE on changed-auto cells |
| \`apps/partner-ui/src/routes/store/store-detail/components/store-fx-section/store-fx-section.tsx\` | New section with the toggle |
| \`apps/partner-ui/src/routes/store/store-detail/components/store-fx-section/index.ts\` | Re-export |
| \`apps/partner-ui/src/routes/store/store-detail/store-detail.tsx\` | Renders the new section between Currency and Locale |

## Test plan

- [ ] CI passes
- [ ] Manual end-to-end (after merge + dev rebuild):
  1. Set INR price → reload pricing modal → USD/EUR cells show \`FX\` badge
  2. Edit a USD cell to a new value → save → reload → \`FX\` badge gone on USD, still on EUR
  3. Re-rate (manual trigger of the workflow) updates EUR but not USD
  4. Open store settings → toggle "Auto-convert prices" OFF → save → set a new INR price → no USD/EUR rows created
  5. Toggle back ON → set another price → fanout resumes

## Risk

Low. All changes are additive. The \`DELETE\` endpoint is partner-scoped and idempotent; it only removes a marker we created. The toggle defaults to the existing behavior (ON) so silent partners aren't affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)