### PR TITLE
feat(fx): daily re-rate auto-converted prices workflow + visual flow (G5)

### DIFF
--- a/apps/backend/integration-tests/http/fx-rates/rerate-auto-converted-prices-workflow.spec.ts
+++ b/apps/backend/integration-tests/http/fx-rates/rerate-auto-converted-prices-workflow.spec.ts
@@ -1,0 +1,123 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { getSharedTestEnv, setupSharedTestSuite } from "../shared-test-setup"
+import { FX_RATES_MODULE } from "../../../src/modules/fx_rates"
+import type FxRatesService from "../../../src/modules/fx_rates/service"
+import rerateAutoConvertedPricesWorkflow from "../../../src/workflows/fx/rerate-auto-converted-prices"
+
+jest.setTimeout(60 * 1000)
+
+// Behavior tests for rerate-auto-converted-prices. We construct a
+// price + fx_price_meta + link manually, then run the workflow with
+// a SECOND set of (different) FX rates and assert the price amount
+// + cached fx_rate get rewritten.
+
+function fakeProviderResult(rates: Record<string, number>) {
+  return {
+    base_currency: "usd",
+    fetched_at: new Date("2026-05-26T00:00:00Z"),
+    source: "test-fake",
+    rates,
+  }
+}
+
+setupSharedTestSuite(() => {
+  const { getContainer } = getSharedTestEnv()
+
+  describe("workflows/fx/rerate-auto-converted-prices", () => {
+    let container: any
+    let fxService: FxRatesService
+
+    beforeEach(async () => {
+      container = getContainer()
+      fxService = container.resolve(FX_RATES_MODULE) as FxRatesService
+
+      // Seed an INITIAL rate cache so the fx_price_meta we set up
+      // looks consistent with what fanout would have done at create time.
+      fxService.setProvider({
+        fetchRates: async () =>
+          fakeProviderResult({
+            usd: 1,
+            inr: 80, // 1 USD = 80 INR (so 1 INR = 0.0125 USD)
+            eur: 0.90,
+          }),
+      })
+      await fxService.refreshRatesFromProvider()
+    })
+
+    it("rewrites price.amount + fx_price_meta.fx_rate using the current cache", async () => {
+      const pricingService = container.resolve(Modules.PRICING) as any
+      const link = container.resolve(ContainerRegistrationKeys.LINK) as any
+
+      // Create a price_set with one USD price (mimics what fanout would
+      // have created from a partner's INR=1000 base price).
+      const [priceSet] = await pricingService.createPriceSets([
+        { prices: [{ amount: 12.5, currency_code: "usd", rules: {} }] },
+      ])
+      const priceId = priceSet.prices[0].id
+
+      // Attach an fx_price_meta marker with the SAME values fanout
+      // would have stamped originally (rate=0.0125, base=inr 1000).
+      const [meta] = await fxService.createFxPriceMetas([
+        {
+          base_currency: "inr",
+          base_amount: 1000,
+          fx_rate: 0.0125,
+          source_price_id: "price_source_synth",
+        },
+      ])
+      await link.create([
+        {
+          [Modules.PRICING]: { price_id: priceId },
+          [FX_RATES_MODULE]: { fx_price_meta_id: meta.id },
+        },
+      ])
+
+      // Now bump the FX cache to a DIFFERENT rate — INR weakens
+      // (1 USD now = 90 INR, so 1 INR = ~0.0111 USD). After re-rate,
+      // 1000 INR should be ~11.11 USD.
+      fxService.setProvider({
+        fetchRates: async () =>
+          fakeProviderResult({
+            usd: 1,
+            inr: 90,
+            eur: 0.92,
+          }),
+      })
+      await fxService.refreshRatesFromProvider()
+
+      const { result } = await rerateAutoConvertedPricesWorkflow(container).run({
+        input: {},
+      })
+
+      expect(result.scanned).toBe(1)
+      expect(result.updated).toBe(1)
+      expect(result.skipped).toBe(0)
+      expect(result.errors).toHaveLength(0)
+
+      // Verify the price's amount actually changed.
+      const updatedSet = await pricingService.retrievePriceSet(priceSet.id, {
+        relations: ["prices"],
+      })
+      const updatedPrice = updatedSet.prices.find((p: any) => p.id === priceId)
+      // 1000 INR → USD at 1/90 ≈ 11.11
+      expect(Number(updatedPrice.amount)).toBeCloseTo(11.11, 1)
+
+      // Verify the meta's cached fx_rate is also fresh.
+      const [updatedMeta] = await fxService.listFxPriceMetas({ id: meta.id })
+      const newRate = Number(updatedMeta.fx_rate)
+      // 1 INR = 1/90 USD ≈ 0.0111
+      expect(newRate).toBeCloseTo(0.0111, 3)
+    })
+
+    it("returns zeros when there are no fx_price_meta rows", async () => {
+      const { result } = await rerateAutoConvertedPricesWorkflow(container).run({
+        input: {},
+      })
+
+      expect(result.scanned).toBe(0)
+      expect(result.updated).toBe(0)
+      expect(result.skipped).toBe(0)
+      expect(result.errors).toHaveLength(0)
+    })
+  })
+})

--- a/apps/backend/src/scripts/seed-fx-rerate-flow.ts
+++ b/apps/backend/src/scripts/seed-fx-rerate-flow.ts
@@ -1,0 +1,146 @@
+/**
+ * Seed: FX Rates — Daily Re-rate Auto-converted Prices
+ *
+ * Two-operation visual flow that fires daily at 02:05 UTC and
+ * triggers the `rerate-auto-converted-prices` workflow. Runs 5
+ * minutes after the refresh-fx-rates flow (02:00 UTC) so the
+ * rate cache is fresh before we walk every auto-converted price
+ * and recompute its amount.
+ *
+ * Why a separate flow (vs. chaining onto refresh):
+ *   Keeping refresh + rerate as independent flows means an operator
+ *   can pause re-rate without losing the daily rate refresh. They
+ *   also fail and surface in the visual_flow_execution log
+ *   independently — a refresh failure (provider 500) doesn't bury
+ *   itself under a downstream rerate failure log.
+ *
+ * Run:
+ *   npx medusa exec ./src/scripts/seed-fx-rerate-flow.ts
+ *
+ * Status on first creation:
+ *   `draft` — flip to `active` only after both:
+ *   1. seed-initial-fx-rates.ts has populated the fx_rate table
+ *   2. The fanout subscriber has created at least one fx_price_meta
+ *      row (otherwise this flow is a no-op).
+ */
+
+import { VISUAL_FLOWS_MODULE } from "../modules/visual_flows"
+import VisualFlowService from "../modules/visual_flows/service"
+
+const FLOW_NAME = "FX Rates — Daily Re-rate Auto-converted Prices"
+const CRON = "5 2 * * *" // daily 02:05 UTC, 5 min after refresh
+
+const X_CENTER = 500
+const Y_TRIGGER = -20
+const Y_RERATE = 140
+
+const FLOW_DEF = {
+  name: FLOW_NAME,
+  description:
+    "Daily walk of every fx_price_meta row → recompute amount = " +
+    "base_amount × today's rate → update the linked Price + cache " +
+    "the new fx_rate. Runs at 02:05 UTC so the rate cache (refreshed " +
+    "at 02:00) is current. Manual overrides are untouched because " +
+    "strip-on-edit deletes the fx_price_meta row.",
+  status: "draft" as const,
+  trigger_type: "schedule" as const,
+  trigger_config: { cron: CRON },
+
+  canvas_state: {
+    viewport: { x: 0, y: 0, zoom: 0.8 },
+    nodes: [
+      {
+        id: "trigger",
+        type: "trigger",
+        position: { x: X_CENTER, y: Y_TRIGGER },
+        data: {
+          label: "Schedule — daily 02:05 UTC",
+          triggerType: "schedule",
+          triggerConfig: { cron: CRON },
+        },
+      },
+      {
+        id: "rerate_prices",
+        type: "operation",
+        position: { x: X_CENTER, y: Y_RERATE },
+        data: {
+          label: "Re-rate auto-converted prices",
+          operationKey: "rerate_prices",
+          operationType: "trigger_workflow",
+        },
+      },
+    ],
+    edges: [
+      {
+        id: "e-0",
+        source: "trigger",
+        sourceHandle: "default",
+        target: "rerate_prices",
+        targetHandle: "default",
+      },
+    ],
+  },
+
+  operations: [
+    {
+      operation_key: "rerate_prices",
+      operation_type: "trigger_workflow",
+      name: "Re-rate auto-converted prices",
+      sort_order: 0,
+      position_x: X_CENTER,
+      position_y: Y_RERATE,
+      options: {
+        workflow_name: "rerate-auto-converted-prices",
+        wait_for_completion: true,
+        input: {},
+      },
+    },
+  ],
+
+  connections: [
+    {
+      source_id: "trigger",
+      source_handle: "default",
+      target_id: "rerate_prices",
+      connection_type: "default" as const,
+    },
+  ],
+}
+
+export default async function seedFxRerateFlow({
+  container,
+}: {
+  container: any
+}) {
+  const service: VisualFlowService = container.resolve(VISUAL_FLOWS_MODULE)
+
+  const [existing] = await service.listVisualFlows({ name: FLOW_NAME } as any)
+  if (existing) {
+    console.log(`Flow "${FLOW_NAME}" already exists (${existing.id}) — skipping.`)
+    console.log(`Delete it in the admin UI (or by id) to re-seed.`)
+    return
+  }
+
+  console.log(`Creating flow "${FLOW_NAME}"...`)
+
+  const flow = await service.createCompleteFlow({
+    flow: {
+      name: FLOW_DEF.name,
+      description: FLOW_DEF.description,
+      status: FLOW_DEF.status,
+      trigger_type: FLOW_DEF.trigger_type,
+      trigger_config: FLOW_DEF.trigger_config,
+      canvas_state: FLOW_DEF.canvas_state,
+    },
+    operations: FLOW_DEF.operations,
+    connections: FLOW_DEF.connections,
+  })
+
+  console.log(`\nFlow created: ${flow.id}`)
+  console.log(`  Open: /app/visual-flows/${flow.id}\n`)
+  console.log(`Before activating:`)
+  console.log(`  1. Confirm refresh-fx-rates flow is active (02:00 UTC).`)
+  console.log(`  2. Confirm at least one fx_price_meta row exists (set a`)
+  console.log(`     partner variant price → fanout writes them).`)
+  console.log(`  3. Flip flow status: draft → active in the admin editor.`)
+}

--- a/apps/backend/src/workflows/fx/rerate-auto-converted-prices.ts
+++ b/apps/backend/src/workflows/fx/rerate-auto-converted-prices.ts
@@ -1,0 +1,205 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { FX_RATES_MODULE } from "../../modules/fx_rates"
+import FxRatesService from "../../modules/fx_rates/service"
+
+/**
+ * Workflow: rerate-auto-converted-prices
+ *
+ * Daily companion to refresh-fx-rates: walks every fx_price_meta row
+ * (which by definition is attached to an auto-converted Price), grabs
+ * the linked Price's currency, computes a fresh converted amount
+ * (base_amount × today's rate), and updates the Price + the meta's
+ * cached fx_rate.
+ *
+ * Why base_amount lives on fx_price_meta:
+ *   We snapshot the partner's source amount at fanout time
+ *   (`base_amount = source.amount`). Re-rate uses this snapshot so
+ *   the daily refresh is one round-trip per price — no need to
+ *   re-resolve the source price every time. If the partner edits the
+ *   source between two re-rate runs the new fanout-from-route flow
+ *   refreshes the snapshot on the next save (it creates a new meta
+ *   row for any newly auto-converted price). Re-rate uses whatever's
+ *   currently in the snapshot.
+ *
+ * Manual overrides are untouched: when a partner edits a previously
+ * auto-converted cell, the strip-on-edit DELETE removes both the
+ * fx_price_meta row and the link, so re-rate's listFxPriceMetas()
+ * query won't see it.
+ *
+ * Per-row failure isolation: a missing FX rate for one currency pair
+ * doesn't abort the whole re-rate.
+ */
+
+export type RerateAutoPricesInput = Record<string, unknown> | undefined
+
+export type RerateAutoPricesOutput = {
+  scanned: number
+  updated: number
+  skipped: number
+  errors: Array<{ fx_price_meta_id: string; error: string }>
+}
+
+const rerateAutoPricesStep = createStep(
+  "rerate-auto-prices-step",
+  async (_input: RerateAutoPricesInput, { container }) => {
+    const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+    const query = container.resolve(ContainerRegistrationKeys.QUERY)
+    const pricingService = container.resolve(Modules.PRICING) as any
+    const fxService = container.resolve(FX_RATES_MODULE) as FxRatesService
+
+    const output: RerateAutoPricesOutput = {
+      scanned: 0,
+      updated: 0,
+      skipped: 0,
+      errors: [],
+    }
+
+    // 1. Pull every fx_price_meta row. The price↔fx_price_meta link
+    //    is 1:1 so we can join to the price in the same query.
+    const { data: metas } = await query.graph({
+      entity: "fx_price_meta",
+      fields: [
+        "id",
+        "base_currency",
+        "base_amount",
+        "fx_rate",
+        "price.id",
+        "price.amount",
+        "price.currency_code",
+        "price.price_set_id",
+      ],
+    })
+
+    output.scanned = (metas ?? []).length
+    if (!output.scanned) {
+      return new StepResponse(output)
+    }
+
+    // 2. Compute fresh amounts. We do this in a first pass so we can
+    //    bail per-row on FX errors without aborting the batch update.
+    type Update = {
+      fx_price_meta_id: string
+      price_id: string
+      price_set_id: string
+      currency_code: string
+      old_amount: number
+      new_amount: number
+      old_rate: number
+      new_rate: number
+    }
+    const updates: Update[] = []
+
+    for (const meta of (metas as any[]) ?? []) {
+      const price = meta?.price
+      if (!price?.id) {
+        // Orphan meta — the underlying price was deleted but the
+        // meta+link weren't cleaned up. Skip; a separate compaction
+        // pass can prune these.
+        output.skipped += 1
+        continue
+      }
+      const base = String(meta.base_currency).toLowerCase()
+      const target = String(price.currency_code).toLowerCase()
+      const baseAmount = Number(meta.base_amount)
+
+      try {
+        const freshRate = await fxService.getRate(base, target)
+        const newAmount = Math.round(baseAmount * freshRate * 100) / 100
+        updates.push({
+          fx_price_meta_id: meta.id,
+          price_id: price.id,
+          price_set_id: price.price_set_id,
+          currency_code: target,
+          old_amount: Number(price.amount),
+          new_amount: newAmount,
+          old_rate: Number(meta.fx_rate),
+          new_rate: freshRate,
+        })
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        output.errors.push({ fx_price_meta_id: meta.id, error: message })
+        logger.warn(
+          `[rerate] fx rate ${base} → ${target} for meta ${meta.id}: ${message}`
+        )
+      }
+    }
+
+    if (!updates.length) {
+      return new StepResponse(output)
+    }
+
+    // 3. Apply price updates one price_set at a time. Medusa's
+    //    `updatePriceSets` takes `{ id: price_set_id, prices: [...] }`
+    //    where each price entry can have an `id` for upsert. Group by
+    //    price_set_id so we issue one call per set.
+    const bySet = new Map<string, Update[]>()
+    for (const u of updates) {
+      const list = bySet.get(u.price_set_id) ?? []
+      list.push(u)
+      bySet.set(u.price_set_id, list)
+    }
+
+    for (const [priceSetId, items] of bySet) {
+      try {
+        await pricingService.updatePriceSets(priceSetId, {
+          prices: items.map((u) => ({
+            id: u.price_id,
+            currency_code: u.currency_code,
+            amount: u.new_amount,
+          })),
+        })
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        for (const u of items) {
+          output.errors.push({ fx_price_meta_id: u.fx_price_meta_id, error: message })
+        }
+        logger.error(
+          `[rerate] price_set ${priceSetId} update failed: ${message}`
+        )
+      }
+    }
+
+    // 4. Write fresh fx_rate values back to fx_price_meta so the next
+    //    audit / tooltip lookup sees the same rate the price was
+    //    computed at.
+    const metaUpdates = updates.map((u) => ({
+      id: u.fx_price_meta_id,
+      fx_rate: u.new_rate,
+    }))
+    if (metaUpdates.length) {
+      try {
+        await fxService.updateFxPriceMetas(metaUpdates as any)
+        output.updated = updates.length
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        logger.error(
+          `[rerate] fx_price_meta bulk update failed: ${message}`
+        )
+        // Don't push individual errors — the price updates succeeded;
+        // only the meta's cached fx_rate is stale. Logged and move on.
+      }
+    }
+
+    logger.info(
+      `[rerate] scanned=${output.scanned} updated=${output.updated} ` +
+        `skipped=${output.skipped} errors=${output.errors.length}`
+    )
+    return new StepResponse(output)
+  }
+)
+
+export const rerateAutoConvertedPricesWorkflow = createWorkflow(
+  "rerate-auto-converted-prices",
+  (input: RerateAutoPricesInput) => {
+    const summary = rerateAutoPricesStep(input)
+    return new WorkflowResponse(summary)
+  }
+)
+
+export default rerateAutoConvertedPricesWorkflow


### PR DESCRIPTION
## Summary

Closes the FX backend loop. Two flows now run daily:

| Time (UTC) | Flow | What |
|---|---|---|
| 02:00 | refresh-fx-rates (G2, already live) | Fetch fresh provider rates, upsert \`fx_rate\` |
| 02:05 | **rerate-auto-converted-prices (this PR)** | Walk every \`fx_price_meta\` row, rewrite the linked Price with today's rate |

## How re-rate works

1. \`query.graph("fx_price_meta", fields: ["base_currency", "base_amount", "fx_rate", "price.*"])\` — joins meta to its linked Price in one query.
2. For each row: \`new_amount = base_amount × fxService.getRate(base_currency, price.currency_code)\`.
3. Group by \`price.price_set_id\`, batch-update via \`pricingService.updatePriceSets({ id, prices: [...] })\`.
4. \`fxService.updateFxPriceMetas([{ id, fx_rate: newRate }])\` so tooltips + audit show today's rate.

## What it leaves alone

- **Manual overrides** — strip-on-edit (G4b) deletes both the \`fx_price_meta\` row and its link, so re-rate's listFxPriceMetas query never sees them.
- **Orphan meta** (price deleted but meta+link not cleaned) — counted as \`skipped\`. A compaction pass for these is deferred.

## Failure isolation

- Missing FX rate for one currency: per-row error logged, others continue.
- price_set update failure: errors attributed to all rows in that set.
- fx_price_meta bulk update failure (rare): logged, prices still successful — only the cached rate is briefly stale until next run.

## Tests

\`\`\`
PASS integration-tests/http/fx-rates/rerate-auto-converted-prices-workflow.spec.ts (14.24 s)
    workflows/fx/rerate-auto-converted-prices
      ✓ rewrites price.amount + fx_price_meta.fx_rate using the current cache (1297 ms)
      ✓ returns zeros when there are no fx_price_meta rows (2565 ms)
\`\`\`

The happy-path test creates a USD price + fx_price_meta marker (base=INR 1000, rate=0.0125), bumps the rate cache to 1 INR = ~0.0111 USD, runs re-rate, and asserts both the Price amount AND the meta's cached rate get rewritten.

## Files

| File | Purpose |
|---|---|
| \`apps/backend/src/workflows/fx/rerate-auto-converted-prices.ts\` | The workflow |
| \`apps/backend/src/scripts/seed-fx-rerate-flow.ts\` | Visual flow seed (cron \`5 2 * * *\`, status \`draft\` until manually activated) |
| \`apps/backend/integration-tests/http/fx-rates/rerate-auto-converted-prices-workflow.spec.ts\` | 2 tests |

## After merge

Run the seed in prod once:
\`\`\`
FOLLOW=0 ./deploy/aws/scripts/run-backfill.sh seed-fx-rerate-flow
\`\`\`

Then in the admin UI, open the new visual flow, verify the cron + workflow binding, flip status → \`active\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)