### PR TITLE
feat(fx): storefront RegionNotServedFallback + contact endpoint (PR H)

### DIFF
--- a/apps/backend/src/api/store/contact-region-request/route.ts
+++ b/apps/backend/src/api/store/contact-region-request/route.ts
@@ -1,0 +1,128 @@
+import {
+  MedusaStoreRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { MedusaError, Modules } from "@medusajs/framework/utils"
+import type { INotificationModuleService } from "@medusajs/types"
+import { getStoreFromPublishableKey } from "../helpers"
+
+/**
+ * POST /store/contact-region-request
+ *
+ * Storefront-facing endpoint for the "We don't ship here yet" fallback.
+ * A visitor whose country isn't covered by any of the partner's
+ * regions (or whose region exists but has no price in the variant's
+ * currency) sees a contact form on the product page; submitting it
+ * lands here.
+ *
+ * Behavior
+ *   Resolves the partner store via the storefront's publishable key,
+ *   then creates a feed-channel notification so the partner sees the
+ *   request in admin. No partner-email send in v1 — the admin feed is
+ *   the lowest-coupling integration and avoids spamming partners
+ *   before they've opted into per-channel routing.
+ *
+ *   Validation is light: name + email required, message + country
+ *   code + product handle optional. We trust the storefront to send
+ *   sane values; abuse vectors here are typical contact-form spam
+ *   which we'll add rate-limiting / captcha for later if it becomes
+ *   a problem.
+ *
+ * Why a Medusa notification vs. a new table
+ *   Notifications already power the admin "Activity feed" and the
+ *   email-provider integrations the partner has set up. Reusing
+ *   them means a region-request shows up in the same UI as every
+ *   other partner-relevant event — no new admin surface to build.
+ *   When/if we want a structured "leads" view, we can promote this
+ *   into its own model with a one-line migration.
+ */
+export const POST = async (
+  req: MedusaStoreRequest,
+  res: MedusaResponse
+) => {
+  const body = (req.body ?? {}) as Record<string, any>
+  const name = String(body.name ?? "").trim()
+  const email = String(body.email ?? "").trim()
+  const message = body.message ? String(body.message).trim() : ""
+  const countryCode = body.country_code
+    ? String(body.country_code).trim().toLowerCase()
+    : ""
+  const productHandle = body.product_handle
+    ? String(body.product_handle).trim()
+    : ""
+
+  if (!name || !email) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "name and email are required"
+    )
+  }
+  // Cheap email format gate — full RFC check is overkill, this just
+  // catches obvious typos / empty submits.
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "email is not a valid address"
+    )
+  }
+
+  // Best-effort store resolution. If the publishable key isn't bound
+  // to a store we still log the request (admin sees it) but flag
+  // the missing store in the metadata so triage knows it's unrouted.
+  let storeId: string | undefined
+  let storeName: string | undefined
+  try {
+    const store = await getStoreFromPublishableKey(
+      req.publishable_key_context!,
+      req.scope
+    )
+    storeId = store?.id
+    storeName = store?.name
+  } catch {
+    // swallow — we still create the notification
+  }
+
+  const notificationService = req.scope.resolve(
+    Modules.NOTIFICATION
+  ) as INotificationModuleService
+
+  const title = countryCode
+    ? `Region request: customer in ${countryCode.toUpperCase()}`
+    : "Region request: storefront contact"
+
+  const description = [
+    `${name} <${email}> can't shop your storefront from`,
+    countryCode ? `${countryCode.toUpperCase()}.` : "their location.",
+    productHandle ? `Product: ${productHandle}.` : "",
+    message ? `Message: ${message}` : "",
+  ]
+    .filter(Boolean)
+    .join(" ")
+
+  const notification = await notificationService.createNotifications({
+    to: "",
+    channel: "feed",
+    template: "admin-ui",
+    data: {
+      title,
+      description,
+      metadata: {
+        kind: "region_request",
+        store_id: storeId ?? null,
+        store_name: storeName ?? null,
+        country_code: countryCode || null,
+        product_handle: productHandle || null,
+        name,
+        email,
+        message: message || null,
+        received_at: new Date().toISOString(),
+      },
+    },
+  })
+
+  res.json({
+    id: notification?.id,
+    received: true,
+    store_id: storeId ?? null,
+  })
+}


### PR DESCRIPTION
## Summary

Closes the FX rollout. When a partner doesn't ship to a visitor's country (or hasn't yet seeded a price in that region's currency), the product page swaps the commerce block for a friendly contact form instead of an empty/skeleton price.

## Backend

\`POST /store/contact-region-request\` — \`apps/backend/src/api/store/contact-region-request/route.ts\`

\`\`\`
body: { name, email, message?, country_code?, product_handle? }
\`\`\`

- Resolves partner store from storefront's publishable key (best-effort; missing store is logged with metadata, not 4xx)
- Validates name + email (cheap regex), trims fields
- Creates a feed-channel Medusa notification → shows up in partner's admin "Activity feed"
- Returns \`{ id, received: true, store_id }\`

No new tables — reuses existing notification infra. Future iteration can promote this into a structured \"leads\" view without breaking the storefront contract.

## Storefront

Submodule bump in \`apps/storefront-starter\`:

- New component: \`<RegionNotServedFallback product countryCode />\` — friendly heading + 3-field form (name / email / optional message), submits to the backend, shows a \"we'll be in touch\" success state. \`data-testid=\"region-not-served-fallback\"\` for Playwright.
- \`ProductActions\` detects \"no variant has a calculated_price\" via \`hasAnyPrice\` useMemo. When false, swaps the price + add-to-cart UI for the fallback. Gallery, title, description, breadcrumbs stay visible.

## Why feed-only (no email-to-partner in v1)

Per-partner notification channel routing isn't wired yet. Feed is the lowest-coupling integration that guarantees the request lands somewhere visible. Future PR can add email-partner forwarding via the existing notification provider system once partners opt in.

## Test plan

- [ ] CI
- [ ] Manual: visit a product from a country with no region → see fallback form (not the price skeleton)
- [ ] Manual: submit form → success state appears → notification visible in admin Activity feed with country code + product handle + email metadata
- [ ] Manual: visit a product from a covered region → normal price + add-to-cart shown (no regression)

## After merge

Just deploys. No seed or migration needed.

## Closes

This is the last planned PR in the FX rollout:

| | |
|---|---|
| G1 (#263) | FX rates module + seed |
| G2 (#264) | Daily refresh workflow + visual flow |
| G3 (#265) | Fanout subscriber + workflow |
| G4a (#268) | Partner-UI badge |
| G4b (#270) | Strip-on-edit + settings toggle |
| #269 | fx_price_meta link table (the metadata column doesn't exist fix) |
| #271 | E2e bug catch: real fanout invocation + 3 other bugs |
| G5 (#272) | Daily re-rate workflow + visual flow |
| **H (this PR)** | Storefront fallback |

🤖 Generated with [Claude Code](https://claude.com/claude-code)