### PR TITLE
fix(marketing): classify live brands by storefront, not workspace_type

### DIFF
--- a/apps/backend/src/api/web/website/[domain]/marketing/metrics/route.ts
+++ b/apps/backend/src/api/web/website/[domain]/marketing/metrics/route.ts
@@ -2,8 +2,8 @@ import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
 type RawPartner = {
-  workspace_type: "seller" | "manufacturer" | "individual"
   vercel_linked: boolean
+  storefront_domain: string | null
 }
 
 type RawWebsite = {
@@ -58,7 +58,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const [partnersRes, websitesRes, locationsRes, runsRes] = await Promise.all([
     query.graph({
       entity: "partners",
-      fields: ["workspace_type", "vercel_linked"],
+      fields: ["vercel_linked", "storefront_domain"],
       filters: { status: "active" },
       pagination: { take: 1000 },
     }),
@@ -81,11 +81,13 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     }).catch(() => ({ data: [] })),
   ])
 
+  // Anyone without a provisioned storefront counts as an artisan. Aligned
+  // with the partners route — workspace_type is a sidebar concept, not a
+  // marketing classifier.
   let artisans = 0
   for (const p of (partnersRes.data || []) as unknown as RawPartner[]) {
-    if (p.workspace_type === "individual" || p.workspace_type === "manufacturer") {
-      artisans++
-    }
+    const isLiveBrand = p.vercel_linked === true && !!p.storefront_domain
+    if (!isLiveBrand) artisans++
   }
 
   // brands_live = active brand storefronts. Exclude the platform's own

--- a/apps/backend/src/api/web/website/[domain]/marketing/partners/route.ts
+++ b/apps/backend/src/api/web/website/[domain]/marketing/partners/route.ts
@@ -22,9 +22,17 @@ type PublicPartner = {
   story: string | null
 }
 
+type DomainAlias = {
+  domain: string
+  url: string
+  verified: boolean
+  primary: boolean
+}
+
 type PublicBrand = PublicPartner & {
   storefront_url: string
   is_live: boolean
+  domains: DomainAlias[]
 }
 
 const ARTISAN_LIMIT = 6
@@ -69,18 +77,50 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       story: typeof meta.story === "string" ? meta.story : null,
     }
 
-    if (p.workspace_type === "individual" || p.workspace_type === "manufacturer") {
-      if (artisans.length < ARTISAN_LIMIT) artisans.push(base)
-    } else if (p.workspace_type === "seller" && p.vercel_linked) {
+    // A partner is a "live brand" when they actually have a provisioned
+    // storefront, not based on workspace_type (which is a partner-UI
+    // sidebar concept that's defaulted to "manufacturer" on every row).
+    const isLiveBrand = p.vercel_linked === true && !!p.storefront_domain
+
+    if (isLiveBrand) {
       if (brands.length < BRAND_LIMIT) {
+        // Domain aliases: the cicilabel subdomain is the canonical /
+        // always-available host; custom_domain (e.g. ielocraft.in) is an
+        // optional verified alias. Prefer the verified custom domain as
+        // storefront_url when present so links in marketing UI point at
+        // the partner's branded host.
+        const customDomain =
+          typeof meta.custom_domain === "string" ? meta.custom_domain : null
+        const customVerified = meta.custom_domain_verified === true
+        const primaryHost =
+          customDomain && customVerified ? customDomain : p.storefront_domain!
+
+        const domains: DomainAlias[] = [
+          {
+            domain: p.storefront_domain!,
+            url: `https://${p.storefront_domain}`,
+            verified: true,
+            primary: primaryHost === p.storefront_domain,
+          },
+        ]
+        if (customDomain) {
+          domains.push({
+            domain: customDomain,
+            url: `https://${customDomain}`,
+            verified: customVerified,
+            primary: primaryHost === customDomain,
+          })
+        }
+
         brands.push({
           ...base,
-          storefront_url: p.storefront_domain
-            ? `https://${p.storefront_domain}`
-            : `/storefront/${p.handle}`,
+          storefront_url: `https://${primaryHost}`,
           is_live: true,
+          domains,
         })
       }
+    } else if (artisans.length < ARTISAN_LIMIT) {
+      artisans.push(base)
     }
   }
 


### PR DESCRIPTION
## Summary
- `/web/website/:domain/marketing/partners` was returning an empty `brands` array because it filtered on `workspace_type === "seller"`, but `workspace_type` defaults to `manufacturer` and was never promoted on existing storefront partners
- Discriminator switched to `vercel_linked && storefront_domain` — every live storefront partner now lands in the right bucket
- Brands now expose a `domains[]` array with the cicilabel subdomain + any verified `custom_domain` from metadata; `storefront_url` prefers the verified custom domain
- `/marketing/metrics` artisan count aligned to the same rule (was over-counting live-brand partners as artisans)

## Verified against prod
7 live-brand partners qualify (BRAND_LIMIT = 6 caps to 6): WOVEN FUTURES, Ielo craft, Unique Pashmina, Perennial, GOF, Sharlho, Raja Shawls. 5 of those have verified custom-domain aliases that now surface in `domains[]`.

Note: "Sharlho" with handle `sh-prod` has `vercel_project_id` in metadata but `vercel_linked = false` on the column — provisioned before that column landed and never backfilled. Run `backfill-storefront-deployments.ts` or flip the flag manually if you want it in the list.

## Test plan
- [ ] `GET /web/website/jaalyantra.com/marketing/partners` returns ≥1 brand
- [ ] Each brand row has `domains[]` with `primary: true` on the preferred host
- [ ] `storefront_url` resolves to a real, fetchable URL
- [ ] `GET /web/website/jaalyantra.com/marketing/metrics` artisans count drops by ~6 (was double-counting live-brand partners)

🤖 Generated with [Claude Code](https://claude.com/claude-code)