### PR TITLE
feat(stats): pagination + column include/exclude on panels

### DIFF
--- a/apps/backend/src/admin/components/stats/panel-renderer.tsx
+++ b/apps/backend/src/admin/components/stats/panel-renderer.tsx
@@ -1,4 +1,14 @@
-import { Text, Heading, Badge } from "@medusajs/ui"
+import { useMemo, useState } from "react"
+import {
+  Text,
+  Heading,
+  Badge,
+  IconButton,
+  DataTable,
+  useDataTable,
+  type DataTablePaginationState,
+  type DataTableFilteringState,
+} from "@medusajs/ui"
 import { Skeleton, HeadingSkeleton, TextSkeleton } from "../table/skeleton"
 import {
   ResponsiveContainer,
@@ -107,6 +117,82 @@ function pickField(item: Record<string, any>, candidates: string[]): string | un
   return undefined
 }
 
+// Page size defaults — used when `display.page_size` isn't set. Honours the
+// legacy `display.limit` field for back-compat (was a hard cap, now treated
+// as page size since pagination took over the role of capping the view).
+function resolvePageSize(display: Record<string, any> | undefined, fallback: number): number {
+  const explicit = Number(display?.page_size ?? display?.limit)
+  return Number.isFinite(explicit) && explicit > 0 ? Math.floor(explicit) : fallback
+}
+
+// Filter a column list down to what the panel should actually render.
+// - `columns` (allowlist) preserved if provided
+// - `exclude_columns` (denylist) always wins
+// - Either can include nested-link prefixes like "inventory_item" — those
+//   match top-level column names that came back from query.graph as joined
+//   objects (e.g. `inventory_item.id` JSON-encoded under the `inventory_item`
+//   key). Public-facing embeds (blog usage) typically want to drop these.
+function resolveColumns(
+  allColumns: string[],
+  display: Record<string, any> | undefined
+): string[] {
+  const allow = Array.isArray(display?.columns) ? (display!.columns as string[]) : null
+  const deny = new Set<string>(
+    Array.isArray(display?.exclude_columns) ? (display!.exclude_columns as string[]) : []
+  )
+  const base = allow ?? allColumns
+  return base.filter((c) => !deny.has(c))
+}
+
+// Inline prev/next pager used by list + table. Hidden when only one page.
+function Pager({
+  page,
+  pageCount,
+  pageSize,
+  total,
+  onChange,
+}: {
+  page: number
+  pageCount: number
+  pageSize: number
+  total: number
+  onChange: (next: number) => void
+}) {
+  if (pageCount <= 1) return null
+  const from = total === 0 ? 0 : page * pageSize + 1
+  const to = Math.min((page + 1) * pageSize, total)
+  return (
+    <div className="flex items-center justify-between px-4 py-2 border-t border-ui-border-base bg-ui-bg-subtle">
+      <Text size="xsmall" className="text-ui-fg-muted">
+        {from}–{to} of {total}
+      </Text>
+      <div className="flex items-center gap-x-2">
+        <IconButton
+          size="small"
+          variant="transparent"
+          disabled={page === 0}
+          onClick={() => onChange(Math.max(0, page - 1))}
+          aria-label="Previous page"
+        >
+          ‹
+        </IconButton>
+        <Text size="xsmall" className="text-ui-fg-subtle">
+          {page + 1} / {pageCount}
+        </Text>
+        <IconButton
+          size="small"
+          variant="transparent"
+          disabled={page >= pageCount - 1}
+          onClick={() => onChange(Math.min(pageCount - 1, page + 1))}
+          aria-label="Next page"
+        >
+          ›
+        </IconButton>
+      </div>
+    </div>
+  )
+}
+
 function ListPanel({
   result,
   display,
@@ -146,28 +232,51 @@ function ListPanel({
 
   const first = items[0] ?? {}
   const isGrouped = first?.keys !== undefined || first?.key !== undefined
+
+  // Auto-pick label/value fields. Respects `exclude_columns` so e.g. when
+  // a panel joins `inventory_item.*` for context but doesn't want it
+  // surfaced as the label, those keys are skipped by the fallback search.
+  const excluded = new Set<string>(
+    Array.isArray(display?.exclude_columns) ? (display!.exclude_columns as string[]) : []
+  )
+  const allowedFallback = (cands: string[]) => cands.filter((c) => !excluded.has(c))
   const labelField =
     display?.labelField ??
-    (isGrouped ? "key" : pickField(first, RECORD_LABEL_FALLBACK) ?? "id")
+    (isGrouped ? "key" : pickField(first, allowedFallback(RECORD_LABEL_FALLBACK)) ?? "id")
   const valueField =
     display?.valueField ??
-    (isGrouped ? "value" : pickField(first, RECORD_VALUE_FALLBACK) ?? "value")
+    (isGrouped ? "value" : pickField(first, allowedFallback(RECORD_VALUE_FALLBACK)) ?? "value")
+
+  const [page, setPage] = useState(0)
+  const pageSize = resolvePageSize(display, 20)
+  const pageCount = Math.max(1, Math.ceil(items.length / pageSize))
+  const safePage = Math.min(page, pageCount - 1)
+  const pageItems = items.slice(safePage * pageSize, (safePage + 1) * pageSize)
 
   return (
-    <div className="divide-y">
-      {items.slice(0, display?.limit ?? 20).map((item, idx) => {
-        const label =
-          item?.keys?.[labelField] ?? item?.[labelField] ?? item?.key
-        const value = item?.[valueField]
-        return (
-          <div key={idx} className="flex justify-between items-center px-4 py-2">
-            <Text size="small" className="truncate">
-              {label !== undefined && label !== null ? String(label) : "—"}
-            </Text>
-            <Badge size="xsmall">{formatValue(value, display)}</Badge>
-          </div>
-        )
-      })}
+    <div className="flex flex-col h-full">
+      <div className="divide-y flex-1 overflow-y-auto">
+        {pageItems.map((item, idx) => {
+          const label =
+            item?.keys?.[labelField] ?? item?.[labelField] ?? item?.key
+          const value = item?.[valueField]
+          return (
+            <div key={idx} className="flex justify-between items-center px-4 py-2">
+              <Text size="small" className="truncate">
+                {label !== undefined && label !== null ? String(label) : "—"}
+              </Text>
+              <Badge size="xsmall">{formatValue(value, display)}</Badge>
+            </div>
+          )
+        })}
+      </div>
+      <Pager
+        page={safePage}
+        pageCount={pageCount}
+        pageSize={pageSize}
+        total={items.length}
+        onChange={setPage}
+      />
     </div>
   )
 }
@@ -194,43 +303,86 @@ function TablePanel({
     )
   }
 
-  if (!rows.length) {
-    return (
-      <div className="p-4">
-        <Text size="small" className="text-ui-fg-muted">
-          No results
-        </Text>
-      </div>
+  // Render shell even on empty so DataTable's empty state shows + pagination
+  // doesn't disappear mid-flight while a refetch is in progress.
+  const allColumns = rows.length ? Object.keys(rows[0]) : (display?.columns ?? [])
+  const columnKeys = useMemo(
+    () => resolveColumns(allColumns, display),
+    [allColumns, display]
+  )
+
+  const pageSize = resolvePageSize(display, 10)
+  const [pagination, setPagination] = useState<DataTablePaginationState>({
+    pageIndex: 0,
+    pageSize,
+  })
+  const [search, setSearch] = useState("")
+  const [filtering, setFiltering] = useState<DataTableFilteringState>({})
+
+  // Client-side search across rendered columns. Server-side search would
+  // need the operation to accept `q` — out of scope for the renderer.
+  const filteredRows = useMemo(() => {
+    if (!search.trim()) return rows
+    const needle = search.trim().toLowerCase()
+    return rows.filter((row) =>
+      columnKeys.some((c) => {
+        const v = row?.keys?.[c] ?? row?.[c]
+        if (v === null || v === undefined) return false
+        const s = typeof v === "object" ? JSON.stringify(v) : String(v)
+        return s.toLowerCase().includes(needle)
+      })
     )
-  }
-  const columns: string[] = display?.columns ?? Object.keys(rows[0])
+  }, [rows, columnKeys, search])
+
+  const pagedRows = useMemo(() => {
+    const start = pagination.pageIndex * pagination.pageSize
+    return filteredRows.slice(start, start + pagination.pageSize)
+  }, [filteredRows, pagination])
+
+  const columns = useMemo(
+    () =>
+      columnKeys.map((key) => ({
+        id: key,
+        header: key,
+        accessorKey: key,
+        cell: ({ row }: any) => {
+          const v = row.original?.keys?.[key] ?? row.original?.[key]
+          if (v === null || v === undefined) return "—"
+          if (typeof v === "object") return JSON.stringify(v)
+          return String(v)
+        },
+        enableSorting: false,
+      })),
+    [columnKeys]
+  )
+
+  const table = useDataTable({
+    columns,
+    data: pagedRows,
+    getRowId: (row, idx) =>
+      row?.id ?? row?.keys?.id ?? `${pagination.pageIndex}-${idx}`,
+    rowCount: filteredRows.length,
+    pagination: { state: pagination, onPaginationChange: setPagination },
+    search: { state: search, onSearchChange: (v: string) => {
+      setSearch(v)
+      setPagination((prev) => ({ ...prev, pageIndex: 0 }))
+    } },
+    filtering: { state: filtering, onFilteringChange: setFiltering },
+    filters: [],
+    isLoading: false,
+  })
+
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full text-left text-sm">
-        <thead className="bg-ui-bg-subtle">
-          <tr>
-            {columns.map((c) => (
-              <th key={c} className="px-3 py-2 font-medium text-ui-fg-subtle">
-                {c}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody className="divide-y">
-          {rows.slice(0, display?.limit ?? 50).map((row, idx) => (
-            <tr key={idx}>
-              {columns.map((c) => {
-                const v = row?.keys?.[c] ?? row?.[c]
-                return (
-                  <td key={c} className="px-3 py-2 truncate max-w-[200px]">
-                    {typeof v === "object" && v !== null ? JSON.stringify(v) : String(v ?? "—")}
-                  </td>
-                )
-              })}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <div className="flex flex-col h-full">
+      <DataTable instance={table}>
+        {display?.search !== false && (
+          <DataTable.Toolbar className="px-2 py-2 border-b border-ui-border-base">
+            <DataTable.Search placeholder="Search…" />
+          </DataTable.Toolbar>
+        )}
+        <DataTable.Table />
+        <DataTable.Pagination />
+      </DataTable>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Both list + table stats panels gain real pagination instead of the hard `slice(0, 20|50)` cap
- New `display.exclude_columns` denylist + `display.columns` allowlist work for both panel types
- TablePanel rewritten on top of Medusa UI's `DataTable` (same primitive used in `link-people-form.tsx`) — built-in pagination, search, filtering for free
- ListPanel uses a small inline `<Pager />`; the label/value auto-pick now skips excluded keys

## Why
Panels like \`dash_01KSKE3ADB32YKSRG7CF78N0FE\`'s \"Raw materials available\" return 97 rows but the renderer was capping at 20 (list) or 50 (table). Also, the panel joins \`inventory_item.*\` for context — fine for internal admin but it shouldn't leak when the panel is embedded into a public blog (the next PR in this track).

## Config surface

```jsonc
{
  "display": {
    "page_size": 25,                  // default 20 (list) / 10 (table)
    "limit": 25,                      // legacy — still respected as page_size
    "columns": ["name", "composition"],   // allowlist (table)
    "exclude_columns": ["inventory_item"],// denylist (both)
    "search": false                   // hide toolbar/search on table
  }
}
```

For the raw_materials panel you've been wrestling with:
\`\`\`json
{
  "display": {
    "page_size": 25,
    "exclude_columns": ["inventory_item"]
  }
}
\`\`\`

## Back-compat
- Existing panels with \`display.limit: N\` still work — \`resolvePageSize\` falls back to \`limit\` when \`page_size\` is absent, just now treated as page size instead of hard cap
- Panels without any limit get sensible defaults (20 list, 10 table)
- No DB migration

## Test plan
- [ ] Open \`dash_01KSKE3ADB32YKSRG7CF78N0FE\` Raw materials panel as list — pagination shows when >20 rows
- [ ] Same panel as table — DataTable's pagination + search render; search filters client-side across visible columns
- [ ] PATCH the panel with \`{display: {exclude_columns: [\"inventory_item\"]}}\` — joined column disappears from header + rows
- [ ] No regressions on existing seeded dashboards (JYT Overview metrics still render)

🤖 Generated with [Claude Code](https://claude.com/claude-code)