### PR TITLE
feat(web): public panel data + harden blog injector

### DIFF
--- a/apps/backend/src/api/web/stats/panels/[id]/data/route.ts
+++ b/apps/backend/src/api/web/stats/panels/[id]/data/route.ts
@@ -1,0 +1,113 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { STATS_MODULE } from "../../../../../../modules/stats"
+import StatsService from "../../../../../../modules/stats/service"
+import { resolvePanel } from "../../../../../../modules/stats/resolver"
+
+/**
+ * GET /web/stats/panels/:id/data
+ *
+ * Public read endpoint for stats panels. Designed for marketing-site /
+ * blog embeds: an editor drops `<StatsPanel id="panel_..." />` into a
+ * blog post and the component fetches from here.
+ *
+ * Safety
+ * - Panels are NOT public by default. Only panels with
+ *   `metadata.public === true` resolve; everything else returns 404.
+ *   This is an explicit opt-in per panel — admins decide what's safe
+ *   to expose.
+ * - `display.exclude_columns` is applied **server-side** so the wire
+ *   payload doesn't leak joined entities even if a consumer ignores
+ *   the display config. Same denylist the renderer uses.
+ *
+ * Cache
+ * - `s-maxage=120, swr=300` — blog traffic is read-heavy and panel
+ *   data is rarely fresh-required at sub-minute resolution. Edge
+ *   caches absorb spikes; readers see stale-while-revalidate during
+ *   refresh.
+ * - The panel's own `cache_ttl_seconds` still applies inside
+ *   `resolvePanel` (in-memory cache); this just adds an edge layer.
+ *
+ * Response shape mirrors the admin POST endpoint so the same renderer
+ * can be reused on the marketing-site side:
+ *   { panel_id, type, name, data, display, resolved_at }
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params
+
+  const service: StatsService = req.scope.resolve(STATS_MODULE)
+
+  let panel: any
+  try {
+    panel = await service.retrieveStatsPanel(id)
+  } catch (err: any) {
+    // Don't leak whether the id exists at all — same 404 either way.
+    if (err?.type === "not_found") {
+      throw new MedusaError(MedusaError.Types.NOT_FOUND, "Panel not found")
+    }
+    throw err
+  }
+
+  const isPublic =
+    (panel.metadata && (panel.metadata as Record<string, any>).public) === true
+  if (!isPublic) {
+    // Same 404 shape as "doesn't exist" so we don't reveal which panels
+    // exist privately.
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Panel not found")
+  }
+
+  const result = await resolvePanel(
+    req.scope,
+    {
+      id: panel.id,
+      dashboard_id: (panel as any).dashboard_id,
+      operation_type: panel.operation_type,
+      operation_options: (panel.operation_options ?? {}) as Record<string, any>,
+      display: (panel.display ?? {}) as Record<string, any>,
+      cache_ttl_seconds: panel.cache_ttl_seconds,
+    },
+    { skipCache: false }
+  )
+
+  // Server-side column denylist on the records before they ship over
+  // the wire. Mirrors `resolveColumns` in the admin renderer so the
+  // public payload can never leak a column the editor wanted hidden.
+  const display = (panel.display ?? {}) as Record<string, any>
+  const deny = new Set<string>(
+    Array.isArray(display.exclude_columns)
+      ? (display.exclude_columns as string[])
+      : []
+  )
+  let data = result.data
+  if (deny.size > 0 && data && typeof data === "object") {
+    const records = (data as any).records ?? (data as any).groups
+    if (Array.isArray(records)) {
+      const stripped = records.map((row: any) => {
+        if (!row || typeof row !== "object") return row
+        const out: Record<string, any> = {}
+        for (const [k, v] of Object.entries(row)) {
+          if (!deny.has(k)) out[k] = v
+        }
+        return out
+      })
+      data = {
+        ...(data as Record<string, any>),
+        records: (data as any).records !== undefined ? stripped : undefined,
+        groups: (data as any).groups !== undefined ? stripped : undefined,
+      }
+    }
+  }
+
+  res.setHeader(
+    "Cache-Control",
+    "public, s-maxage=120, stale-while-revalidate=300"
+  )
+  res.json({
+    panel_id: panel.id,
+    type: panel.type,
+    name: panel.name,
+    data,
+    display,
+    resolved_at: result.resolved_at,
+  })
+}

--- a/apps/backend/src/api/web/stats/panels/[id]/data/route.ts
+++ b/apps/backend/src/api/web/stats/panels/[id]/data/route.ts
@@ -3,6 +3,10 @@ import { MedusaError } from "@medusajs/framework/utils"
 import { STATS_MODULE } from "../../../../../../modules/stats"
 import StatsService from "../../../../../../modules/stats/service"
 import { resolvePanel } from "../../../../../../modules/stats/resolver"
+import {
+  isPanelPublic,
+  stripExcludedColumns,
+} from "../../../../../../modules/stats/public-utils"
 
 /**
  * GET /web/stats/panels/:id/data
@@ -48,9 +52,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     throw err
   }
 
-  const isPublic =
-    (panel.metadata && (panel.metadata as Record<string, any>).public) === true
-  if (!isPublic) {
+  if (!isPanelPublic(panel)) {
     // Same 404 shape as "doesn't exist" so we don't reveal which panels
     // exist privately.
     throw new MedusaError(MedusaError.Types.NOT_FOUND, "Panel not found")
@@ -69,34 +71,8 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     { skipCache: false }
   )
 
-  // Server-side column denylist on the records before they ship over
-  // the wire. Mirrors `resolveColumns` in the admin renderer so the
-  // public payload can never leak a column the editor wanted hidden.
   const display = (panel.display ?? {}) as Record<string, any>
-  const deny = new Set<string>(
-    Array.isArray(display.exclude_columns)
-      ? (display.exclude_columns as string[])
-      : []
-  )
-  let data = result.data
-  if (deny.size > 0 && data && typeof data === "object") {
-    const records = (data as any).records ?? (data as any).groups
-    if (Array.isArray(records)) {
-      const stripped = records.map((row: any) => {
-        if (!row || typeof row !== "object") return row
-        const out: Record<string, any> = {}
-        for (const [k, v] of Object.entries(row)) {
-          if (!deny.has(k)) out[k] = v
-        }
-        return out
-      })
-      data = {
-        ...(data as Record<string, any>),
-        records: (data as any).records !== undefined ? stripped : undefined,
-        groups: (data as any).groups !== undefined ? stripped : undefined,
-      }
-    }
-  }
+  const data = stripExcludedColumns(display, result.data)
 
   res.setHeader(
     "Cache-Control",

--- a/apps/backend/src/modules/stats/inject-panel-data.ts
+++ b/apps/backend/src/modules/stats/inject-panel-data.ts
@@ -2,6 +2,7 @@ import { MedusaContainer } from "@medusajs/framework/types"
 import { STATS_MODULE } from "."
 import StatsService from "./service"
 import { resolvePanel } from "./resolver"
+import { isPanelPublic, stripExcludedColumns } from "./public-utils"
 
 type TipTapNode = {
   type?: string
@@ -67,6 +68,22 @@ export async function injectStatsPanelData<T extends TipTapNode | TipTapNode[] |
     Array.from(ids).map(async (panelId) => {
       try {
         const panel = await service.retrieveStatsPanel(panelId)
+
+        // Public gate — without this, anything a blog editor pastes
+        // into TipTap gets resolved and exposed; an internal-KPI panel
+        // embedded in a public blog would leak the data wholesale.
+        // Panels must opt in via metadata.public = true.
+        if (!isPanelPublic(panel)) {
+          panelDataMap.set(panelId, {
+            data: null,
+            display: {},
+            panelType: panel.type,
+            error: "panel_not_public",
+            resolved_at: new Date().toISOString(),
+          })
+          return
+        }
+
         const result = await resolvePanel(container, {
           id: panel.id,
           dashboard_id: (panel as any).dashboard_id,
@@ -75,9 +92,11 @@ export async function injectStatsPanelData<T extends TipTapNode | TipTapNode[] |
           display: (panel.display ?? {}) as Record<string, any>,
           cache_ttl_seconds: panel.cache_ttl_seconds,
         })
+
+        const display = (panel.display ?? {}) as Record<string, any>
         panelDataMap.set(panelId, {
-          data: result.data,
-          display: panel.display ?? {},
+          data: stripExcludedColumns(display, result.data),
+          display,
           panelType: panel.type,
           error: result.error,
           resolved_at: result.resolved_at,

--- a/apps/backend/src/modules/stats/public-utils.ts
+++ b/apps/backend/src/modules/stats/public-utils.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared helpers for the public (blog + REST) panel paths.
+ * Two places resolve panels for non-admin consumers:
+ *   1. inject-panel-data.ts — pre-injects data into TipTap nodes when
+ *      serving a blog page
+ *   2. api/web/stats/panels/[id]/data — direct REST read
+ *
+ * Both must enforce the same `metadata.public` gate AND apply the same
+ * `display.exclude_columns` strip so a panel can't leak via one path
+ * but be hidden by the other.
+ */
+
+/**
+ * Mirrors the renderer's `resolveColumns` semantics on the backend so
+ * public consumers can't ship rows with keys the editor told the
+ * renderer to hide.
+ *
+ * Returns a shallow clone with `records` / `groups` stripped of denied
+ * keys. Falls through unchanged when there's nothing to strip.
+ */
+export function stripExcludedColumns(
+  display: Record<string, any> | undefined,
+  data: any
+): any {
+  const deny = new Set<string>(
+    Array.isArray(display?.exclude_columns)
+      ? (display!.exclude_columns as string[])
+      : []
+  )
+  if (deny.size === 0 || !data || typeof data !== "object") return data
+
+  const records = (data as any).records ?? (data as any).groups
+  if (!Array.isArray(records)) return data
+
+  const stripped = records.map((row: any) => {
+    if (!row || typeof row !== "object") return row
+    const out: Record<string, any> = {}
+    for (const [k, v] of Object.entries(row)) {
+      if (!deny.has(k)) out[k] = v
+    }
+    return out
+  })
+  return {
+    ...(data as Record<string, any>),
+    records: (data as any).records !== undefined ? stripped : undefined,
+    groups: (data as any).groups !== undefined ? stripped : undefined,
+  }
+}
+
+/**
+ * Public-gate check shared by the blog injector and the public REST
+ * endpoint. Opt-in via `panel.metadata.public === true`.
+ */
+export function isPanelPublic(panel: { metadata?: any }): boolean {
+  return ((panel?.metadata as Record<string, any>)?.public) === true
+}


### PR DESCRIPTION
## Summary

Two paths exposed stats panels to non-admin consumers; this PR introduces both AND makes them share the same safety rules:

| | Path | What it does |
|---|---|---|
| **New** | `GET /web/stats/panels/:id/data` | Direct REST read for blog/marketing embeds; cache-friendly |
| **Existing, hardened** | `injectStatsPanelData` (called from `/web/website/[domain]/blogs/[blogId]`) | Pre-resolves TipTap `<statsPanel>` nodes server-side so the storefront renders from `node.attrs.data` with no further fetch |

Both now call shared helpers in `modules/stats/public-utils.ts`:

- `isPanelPublic(panel)` — panels are NOT public by default. Opt-in via `metadata.public === true`. Without this, an editor could embed an internal-KPI panel in a blog post and leak it wholesale (that was the silent gap; this PR closes it).
- `stripExcludedColumns(display, data)` — strips `display.exclude_columns` keys from records/groups before they ship over the wire. Mirrors the renderer's `resolveColumns` from PR #280.

## Why this matters

The existing TipTap `StatsPanelExtension` in jyt-web (`components/stats-panel.tsx`) renders any panel mentioned in TipTap content. `injectStatsPanelData` was happily resolving every referenced panel ID. A compromised or careless blog editor could ship "Quarterly partner revenue" or any other internal panel into a public post.

## Opt a panel in

```
PATCH /admin/stats/panels/<id>
{ "metadata": { "public": true } }
```

Then either:
- Hit `GET https://v3.jaalyantra.com/web/stats/panels/<id>/data` directly, OR
- Embed in a blog via the TipTap node insertion (renders via jyt-web's existing `StatsPanelExtension`)

## Defaults
- Panels without `metadata.public` → 404 from REST + `{ error: "panel_not_public", data: null }` from injector (storefront renders empty state)
- Panels with `display.exclude_columns: ["inventory_item"]` → strip applied identically on both paths
- Cache: `s-maxage=120 swr=300` on the REST endpoint

## Test plan
- [ ] Without `metadata.public` → REST returns 404; blog embed renders empty
- [ ] PATCH `panel_01KSKJGS2Z5H7KGTDAB6FWJVSA` with `{metadata:{public:true},display:{exclude_columns:["inventory_item"]}}`
- [ ] REST returns 200, records have no `inventory_item` key
- [ ] Embed in a blog post via TipTap statsPanel node → blog page payload includes injected `data` with same column strip
- [ ] Bogus panel id → 404 (same shape as private one — no ID leak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)