### PR TITLE
feat(theme): accept text_color on trust_banner + banner

### DIFF
--- a/apps/backend/src/api/partners/storefront/website/theme/validators.ts
+++ b/apps/backend/src/api/partners/storefront/website/theme/validators.ts
@@ -161,6 +161,9 @@ export const websiteThemeSchema = z.object({
         .object({
           items: z.array(trustBannerItemSchema).optional(),
           background: hexColor,
+          // Optional explicit text colour. Renderer auto-flips text
+          // light/dark based on `background` luminance when omitted.
+          text_color: hexColor,
         })
         .passthrough()
         .optional(),
@@ -188,6 +191,10 @@ export const websiteThemeSchema = z.object({
           description: z.string().optional(),
           background_image_url: z.string().optional(),
           background_color: hexColor,
+          // Optional explicit text colour. Renderer auto-flips text
+          // light/dark based on `background_color` luminance when
+          // omitted.
+          text_color: hexColor,
           cta_text: z.string().optional(),
           cta_link: z.string().optional(),
         })


### PR DESCRIPTION
## Summary
- Adds `home_sections.trust_banner.text_color` and `home_sections.banner.text_color` to the partner theme PUT validators
- Bumps `apps/storefront-starter` submodule to pull in the matching renderer changes (auto-flip text on dark bg + honour `text_color` override)

## Why
Partner sets `trust_banner.background: "#1a1a1a"` → text renders in default `text-ui-fg-base` (dark) → blank stripe. Same shape for `banner` when `background_color` is dark. Renderers now:
1. Auto-flip to white when bg luminance < 0.5 (WCAG threshold)
2. Honour `text_color: "#xxxxxx"` override when partner wants explicit control
3. Same pattern via shared helper `pickTextColor(bg, override?)` in `src/lib/util/theme-color.ts`

Discovered today on www.gof.asia/in — dark trust-banner stripe rendered as a blank bar.

## Test plan
- [ ] PUT a partner theme with `trust_banner: { background: "#1a1a1a", items: [...] }` — text renders in white, readable
- [ ] PUT with `trust_banner: { background: "#1a1a1a", text_color: "#f5f1ea" }` — text renders in the override colour
- [ ] PUT with `trust_banner: { background: "#f5f1ea" }` — text renders in default dark
- [ ] Same matrix for `banner`
- [ ] Existing partners with bg-image banners keep their white text (preserved by treating image bg as "dark" effective)

🤖 Generated with [Claude Code](https://claude.com/claude-code)