### PR TITLE
fix(stats): drop public-gate on blog injector (admin authoring is the auth)

### DIFF
--- a/apps/backend/src/modules/stats/inject-panel-data.ts
+++ b/apps/backend/src/modules/stats/inject-panel-data.ts
@@ -2,7 +2,7 @@ import { MedusaContainer } from "@medusajs/framework/types"
 import { STATS_MODULE } from "."
 import StatsService from "./service"
 import { resolvePanel } from "./resolver"
-import { isPanelPublic, stripExcludedColumns } from "./public-utils"
+import { stripExcludedColumns } from "./public-utils"
 
 type TipTapNode = {
   type?: string
@@ -69,20 +69,17 @@ export async function injectStatsPanelData<T extends TipTapNode | TipTapNode[] |
       try {
         const panel = await service.retrieveStatsPanel(panelId)
 
-        // Public gate — without this, anything a blog editor pastes
-        // into TipTap gets resolved and exposed; an internal-KPI panel
-        // embedded in a public blog would leak the data wholesale.
-        // Panels must opt in via metadata.public = true.
-        if (!isPanelPublic(panel)) {
-          panelDataMap.set(panelId, {
-            data: null,
-            display: {},
-            panelType: panel.type,
-            error: "panel_not_public",
-            resolved_at: new Date().toISOString(),
-          })
-          return
-        }
+        // No public-gate here — the admin who authored the blog post
+        // is the authorisation. Adding a `metadata.public` opt-in
+        // (PR #281) broke the editor flow: the admin picks the panel
+        // in the blog editor, but the panel still wouldn't render
+        // unless someone separately PATCHed the panel record. Reverted
+        // (PR #283). The exclude_columns strip below still applies so
+        // joined-entity columns can be hidden per-panel via display
+        // config. The public REST endpoint at
+        // /web/stats/panels/:id/data still keeps the gate — different
+        // threat model (anyone with a panel id vs. admin-authored
+        // blog content).
 
         const result = await resolvePanel(container, {
           id: panel.id,


### PR DESCRIPTION
## Summary
PR #281 added \`metadata.public === true\` to \`injectStatsPanelData\`. Real workflow: an admin picks the panel in the blog editor's TipTap node — that authoring IS the authorisation. The extra opt-in meant every embedded panel rendered as "data not available" until someone separately PATCHed \`metadata.public: true\`. Broke the editor flow.

This reverts the gate **only on the blog injector**. Kept:
- \`stripExcludedColumns\` strip on the injector (joined-entity hiding is useful regardless of who pulled the data)
- The same gate on \`GET /web/stats/panels/:id/data\` (different threat model — anyone with a panel id can hit REST vs blog content which only an admin can author)

## Test plan
- [ ] Open a blog with an embedded statsPanel — renders the panel data immediately (no opt-in required)
- [ ] \`GET /web/stats/panels/<non-public-id>/data\` still returns 404
- [ ] \`GET /web/stats/panels/<public-id>/data\` still returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)