### PR TITLE
fix(pages): published_at silently overwritten + draft pages stamped + wrong-page PUT response

### DIFF
--- a/apps/backend/src/api/admin/websites/[id]/pages/[pageId]/route.ts
+++ b/apps/backend/src/api/admin/websites/[id]/pages/[pageId]/route.ts
@@ -73,7 +73,7 @@ export const PUT = async (
 ) => {
   
   const { id: websiteId, pageId } = req.params;
-  const { result, errors } = await updatePageWorkflow(req.scope).run({
+  const { errors } = await updatePageWorkflow(req.scope).run({
     input: {
       id: pageId,
       website_id: websiteId,
@@ -85,7 +85,10 @@ export const PUT = async (
     console.warn("Error reported at", errors);
     throw errors;
   }
-  const page = await refetchPage(result.id, websiteId, req.scope, ["*"]);
+  // Refetch by the URL-derived `pageId`, not the workflow result —
+  // even though the workflow now returns a proper object, this stays
+  // defensive: the page id we care about is the one in the URL.
+  const page = await refetchPage(pageId, websiteId, req.scope, ["*"]);
 
   res.status(200).json({ page });
 };

--- a/apps/backend/src/api/admin/websites/[id]/pages/helpers.ts
+++ b/apps/backend/src/api/admin/websites/[id]/pages/helpers.ts
@@ -28,12 +28,23 @@ export const refetchPage = async (
   scope: MedusaContainer,
   fields: PageAllowedFields[] = ["*"],
 ) => {
+  // Hard guard: a falsy `pageId` used to flow into the query as
+  // `filters: { id: undefined }`, which returned an arbitrary first
+  // row — that's how a PUT could 200 with a completely unrelated
+  // page in the body. Throw early so the caller sees the bug instead
+  // of shipping wrong data downstream.
+  if (!pageId || typeof pageId !== "string") {
+    throw new Error(
+      `refetchPage called with invalid pageId: ${JSON.stringify(pageId)}`
+    );
+  }
+
   const remoteQuery = scope.resolve(ContainerRegistrationKeys.QUERY);
 
   const { data: pages } = await remoteQuery.graph({
     entity: "pages",
-    filters: { id: pageId},
-    fields: ['*'],
+    filters: { id: pageId },
+    fields: fields.length ? (fields as string[]) : ["*"],
   });
 
   return pages[0];

--- a/apps/backend/src/api/admin/websites/[id]/pages/validators.ts
+++ b/apps/backend/src/api/admin/websites/[id]/pages/validators.ts
@@ -23,10 +23,22 @@ const pageBaseSchema = z.object({
   meta_title: z.string().optional(),
   meta_description: z.string().optional(),
   meta_keywords: z.string().optional(),
-  published_at: z.union([z.date(), z.string().datetime()]).optional().transform((val) => {
-    if (!val) return null;
-    return val instanceof Date ? val : new Date(val);
-  }),
+  // Three valid client intents:
+  //   undefined → "don't touch" — must stay undefined so the update
+  //               workflow can skip the field (previously coerced to
+  //               null, which nuked published_at on every update)
+  //   null      → "explicitly clear" (e.g. unpublishing back to draft
+  //               with manual clear)
+  //   Date/ISO  → "set to this value"
+  // Auto-stamping on Draft→Published happens in the workflow, not
+  // here — the validator stays a pure pass-through.
+  published_at: z.union([z.date(), z.string().datetime(), z.null()])
+    .optional()
+    .transform((val) => {
+      if (val === undefined) return undefined;
+      if (val === null) return null;
+      return val instanceof Date ? val : new Date(val);
+    }),
   metadata: z.record(z.string(), z.unknown()).optional(),
   genMetaDataLLM: z.boolean().optional().default(false),
   public_metadata: z.record(z.string(), z.unknown()).optional(),

--- a/apps/backend/src/workflows/website/website-page/create-page.ts
+++ b/apps/backend/src/workflows/website/website-page/create-page.ts
@@ -34,11 +34,19 @@ export const createPageStep = createStep(
       // First verify the website exists
       await websiteService.retrieveWebsite(input.website_id);
       
-      // Create the Page entity - database will handle uniqueness
+      // Only stamp `published_at` when the page is created in a
+      // Published state and the client didn't supply one. Previously
+      // we always stamped — which left Draft pages with a publish
+      // date (visible bug example: page 01JQ4HWCE05SD9WKDDNZ9A45KY
+      // had status=Draft + published_at=2025-03-24).
+      const shouldAutoStamp =
+        input.status === "Published" &&
+        (input.published_at === undefined || input.published_at === null);
+
       const page = await websiteService.createPages({
         ...input,
         last_modified: new Date(),
-        published_at: new Date(),
+        ...(shouldAutoStamp ? { published_at: new Date() } : {}),
       })
 
       // Return the created entity and its ID for potential compensation

--- a/apps/backend/src/workflows/website/website-page/update-page.ts
+++ b/apps/backend/src/workflows/website/website-page/update-page.ts
@@ -34,29 +34,51 @@ export const updatePageStep = createStep(
     
     // Get the current state for compensation
     const originalPage = await websiteService.retrievePage(input.id);
-    
-    // Update the Page entity
-    let updatedPage;
-    await websiteService.updatePages(
-      {
-        selector: {
-          id: input.id,
-        },
-        data: {
-          ...input,
-          last_modified: new Date()
-        },
+
+    // Build the update payload from `input`, but strip undefined keys
+    // so we don't blindly overwrite existing columns (e.g. published_at)
+    // when the client didn't send them.
+    const data: Record<string, any> = { last_modified: new Date() };
+    for (const [k, v] of Object.entries(input)) {
+      if (v !== undefined && k !== "id" && k !== "website_id") {
+        data[k] = v;
       }
-    ).catch(error => {
-      if(error.message.includes("already exist")) {
+    }
+
+    // Auto-stamp `published_at` on the Draft→Published transition when
+    // the client didn't supply an explicit value. Republishing an
+    // already-Published page doesn't re-stamp (preserves the original
+    // publish date so feeds + SEO don't churn).
+    if (
+      input.status === "Published" &&
+      originalPage.status !== "Published" &&
+      input.published_at === undefined
+    ) {
+      data.published_at = new Date();
+    }
+
+    // Update the Page entity
+    let updated: any;
+    try {
+      updated = await websiteService.updatePages({
+        selector: { id: input.id },
+        data,
+      });
+    } catch (error: any) {
+      if (error?.message?.includes("already exist")) {
         throw new MedusaError(
           MedusaError.Types.DUPLICATE_ERROR,
           `Page with slug: ${input.slug} already exist`
         );
       }
-    }).then(page => {
-      updatedPage = page;
-    });
+      throw error;
+    }
+
+    // `updatePages` returns an array — unwrap to a single object so
+    // downstream `result.id` works. Previously this was the array,
+    // which made the route's refetchPage(result.id, …) fall through
+    // to `id: undefined` and return an arbitrary first row.
+    const updatedPage = Array.isArray(updated) ? updated[0] : updated;
 
     // Return the updated entity and compensation data
     return new StepResponse(updatedPage, {


### PR DESCRIPTION
## Summary
Four bugs in the page CUD flow, all interlocked. Found while debugging \`inventory-details-with-us\` whose \`published_at\` stayed null after the admin publish UI claimed it had published. Plus example page \`01JQ4HWCE05SD9WKDDNZ9A45KY\`: \`status=Draft\` with \`published_at=2025-03-24\` stamped. Plus the PUT response returning a **completely unrelated** page.

## The bugs

| # | Where | Bug |
|---|---|---|
| 1 | \`pages/validators.ts:26-29\` | \`published_at: z.union([...]).optional().transform((val) => { if (!val) return null; ... })\` — \`.transform()\` runs on \`undefined\` too, coercing absent field to \`null\`. Every update then nuked the column. |
| 2 | \`workflows/website-page/update-page.ts:46\` | Spread \`...input\` verbatim — never auto-stamped on Draft→Published transition. Combined with #1: every update with no explicit \`published_at\` set it to \`null\`. |
| 3 | \`workflows/website-page/create-page.ts:41\` | Always \`published_at: new Date()\` regardless of status. Draft pages got publish dates. |
| 4 | \`api/admin/websites/[id]/pages/[pageId]/route.ts:88\` + \`helpers.ts:33\` | \`updatePages()\` returns an array; workflow stuffed it into \`StepResponse\`, so \`result.id\` was undefined. \`refetchPage(undefined, ...)\` queried \`filters: { id: undefined }\` → returned an arbitrary first row. PUT responses had **wrong page**. |

## Fixes
- **Validator**: pass-through. \`undefined\` stays undefined, \`null\` stays null, Date/ISO normalised. Auto-stamping moved to the workflow.
- **Update workflow**: build payload by skipping undefined keys; auto-stamp \`published_at = now()\` only on Draft→Published when client didn't supply one. Republishing already-Published pages doesn't re-stamp (preserves SEO / feed dates).
- **Update workflow** also unwraps \`updatePages()\` array result so \`StepResponse.id\` is defined.
- **Create workflow**: only stamp \`published_at\` when status is "Published" and no explicit value.
- **PUT route**: refetch by URL-derived \`pageId\` not \`result.id\` — defensive against the workflow result shape changing again.
- **\`refetchPage\` helper**: throws on falsy \`pageId\` so a future regression can't silently return an arbitrary row.

## Test plan
- [ ] Create page with status=Draft → \`published_at\` is null
- [ ] Create page with status=Published → \`published_at\` is \`now()\`
- [ ] Update Draft page setting status=Published (no explicit \`published_at\`) → \`published_at\` stamps to \`now()\`
- [ ] Update Published page (any field) without sending \`published_at\` → existing \`published_at\` preserved
- [ ] Update Published page sending \`published_at: null\` → cleared
- [ ] PUT /admin/websites/X/pages/Y → response body contains page \`Y\`, not some other page
- [ ] PUT with bogus pageId → 4xx (not 200 with wrong data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)