### PR TITLE
fix(pages): TS overload mismatch on createPages (published_at coercion)

### DIFF
--- a/apps/backend/src/workflows/website/website-page/create-page.ts
+++ b/apps/backend/src/workflows/website/website-page/create-page.ts
@@ -21,36 +21,61 @@ export type CreatePageStepInput = {
   meta_title?: string;
   meta_description?: string;
   meta_keywords?: string;
+  // Accept Date | string | null at the input boundary (validator may
+  // hand us either), normalised to Date | null before hitting the
+  // service in the step body.
   published_at?: Date | string | null;
   metadata?: Record<string, unknown>;
   genMetaDataLLM: boolean;
 };
 
+// Coerce input.published_at (Date | string | null | undefined) to the
+// `Date | null | undefined` shape MedusaService.createPages expects.
+function normalisePublishedAt(
+  v: Date | string | null | undefined
+): Date | null | undefined {
+  if (v === undefined) return undefined;
+  if (v === null) return null;
+  return v instanceof Date ? v : new Date(v);
+}
+
 export const createPageStep = createStep(
   "create-page-step",
   async (input: CreatePageStepInput, { container }) => {
     const websiteService: WebsiteService = container.resolve(WEBSITE_MODULE);
-    
-      // First verify the website exists
-      await websiteService.retrieveWebsite(input.website_id);
-      
-      // Only stamp `published_at` when the page is created in a
-      // Published state and the client didn't supply one. Previously
-      // we always stamped — which left Draft pages with a publish
-      // date (visible bug example: page 01JQ4HWCE05SD9WKDDNZ9A45KY
-      // had status=Draft + published_at=2025-03-24).
-      const shouldAutoStamp =
-        input.status === "Published" &&
-        (input.published_at === undefined || input.published_at === null);
 
-      const page = await websiteService.createPages({
-        ...input,
-        last_modified: new Date(),
-        ...(shouldAutoStamp ? { published_at: new Date() } : {}),
-      })
+    // First verify the website exists
+    await websiteService.retrieveWebsite(input.website_id);
 
-      // Return the created entity and its ID for potential compensation
-      return new StepResponse(page, page.id); 
+    const { genMetaDataLLM: _ignored, published_at: incomingPublishedAt, ...rest } = input;
+    const normalisedPublishedAt = normalisePublishedAt(incomingPublishedAt);
+
+    // Only stamp `published_at` when the page is created in a
+    // Published state and the client didn't supply one. Previously
+    // we always stamped — which left Draft pages with a publish
+    // date (visible bug example: page 01JQ4HWCE05SD9WKDDNZ9A45KY
+    // had status=Draft + published_at=2025-03-24).
+    const shouldAutoStamp =
+      input.status === "Published" &&
+      (normalisedPublishedAt === undefined || normalisedPublishedAt === null);
+
+    const created = await websiteService.createPages({
+      ...rest,
+      last_modified: new Date(),
+      ...(shouldAutoStamp
+        ? { published_at: new Date() }
+        : normalisedPublishedAt !== undefined
+        ? { published_at: normalisedPublishedAt }
+        : {}),
+    });
+
+    // `createPages` overload matters: single-object input returns a
+    // single object. Be defensive in case a future Medusa upgrade
+    // changes that to always-array.
+    const page = Array.isArray(created) ? created[0] : created;
+
+    // Return the created entity and its ID for potential compensation
+    return new StepResponse(page, page.id);
   },
   async (id: string , { container }) => {
     const websiteService: WebsiteService = container.resolve(WEBSITE_MODULE);


### PR DESCRIPTION
## Summary
CI build broke on \`create-page.ts\` after PR #285 (published_at fixes) merged:

\`\`\`
src/workflows/website/website-page/create-page.ts:46:41 - error TS2769
  No overload matches this call.
  Type 'string | Date | null | undefined' is not assignable to type
  'Date | null | undefined'.
\`\`\`

Input type accepted \`Date | string | null\` (validator may hand either) but \`createPages\` only accepts \`Date\`. Cascading: when overload 1 failed to match, TS fell back to the array overload (no \`last_modified\`) producing the second error, and \`newPage.id\` lines failed because \`newPage\` got typed as \`{...}[]\` instead of single object.

## Fix
- \`normalisePublishedAt()\` helper coerces string→Date, preserves null + undefined
- Step body destructures \`published_at\` + \`genMetaDataLLM\` out of input before spreading the rest into \`createPages\` — clean payload + explicit normalised date
- Defensive \`Array.isArray(created) ? created[0] : created\` so downstream \`newPage.id\` typing works even if a future Medusa upgrade changes createPages to always-array

Auto-stamp behaviour from #285 unchanged.

## Test plan
- [ ] \`npx tsc --noEmit\` clean in apps/backend
- [ ] Create Draft page → \`published_at\` null
- [ ] Create Published page → \`published_at = now()\`
- [ ] Create with explicit \`published_at\` ISO string → coerced to Date and persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)