### PR TITLE
fix(blocks): PUT response returned wrong block (same shape as #285)

### DIFF
--- a/apps/backend/src/api/admin/websites/[id]/pages/[pageId]/blocks/[blockId]/route.ts
+++ b/apps/backend/src/api/admin/websites/[id]/pages/[pageId]/blocks/[blockId]/route.ts
@@ -32,14 +32,17 @@ export const PUT = async (
     res: MedusaResponse,
   ) => {
     const blockId = req.params.blockId;
-    const { result } = await updateBlockWorkflow(req.scope).run({
+    await updateBlockWorkflow(req.scope).run({
       input: {
         block_id: blockId,
         ...req.validatedBody
       },
     });
-  
-    const block = await refetchBlock(result.id, req.params.pageId, req.scope);
+
+    // Refetch by URL-derived blockId, not workflow result — defensive
+    // against the workflow returning an array or otherwise lacking an
+    // .id (same family of bug as the page PUT fixed in #285).
+    const block = await refetchBlock(blockId, req.params.pageId, req.scope);
     res.json(block);
   };
 

--- a/apps/backend/src/api/admin/websites/[id]/pages/[pageId]/blocks/helpers.ts
+++ b/apps/backend/src/api/admin/websites/[id]/pages/[pageId]/blocks/helpers.ts
@@ -24,13 +24,22 @@ export const refetchBlock = async (
   scope: MedusaContainer,
   fields: BlockAllowedFields[] = ["*"],
 ) => {
+  // Hard guard: a falsy `blockId` used to flow into the query as
+  // `filters: { id: undefined }`, returning an arbitrary first row —
+  // that's how a PUT could 200 with a completely unrelated block in
+  // the response body. Same shape as the `refetchPage` guard added
+  // in #285.
+  if (!blockId || typeof blockId !== "string") {
+    throw new Error(
+      `refetchBlock called with invalid blockId: ${JSON.stringify(blockId)}`
+    );
+  }
+
   const remoteQuery = scope.resolve(ContainerRegistrationKeys.QUERY);
 
   const { data: blocks } = await remoteQuery.graph({
     entity: "blocks",
-    filters: { 
-      id: blockId
-    },
+    filters: { id: blockId },
     fields: fields,
   });
   return blocks[0];

--- a/apps/backend/src/workflows/website/page-blocks/update-block.ts
+++ b/apps/backend/src/workflows/website/page-blocks/update-block.ts
@@ -55,15 +55,20 @@ export const updateBlockStep = createStep(
       }
     }
 
-    // Update the block
-    const updatedBlock = await websiteService.updateBlocks({
+    // Update the block. `updateBlocks` returns an array; unwrap so
+    // downstream `result.id` works in the route handler. Without this
+    // the PUT route's refetchBlock(result.id, ...) fell through to
+    // `{ id: undefined }` and returned an arbitrary first block row
+    // (same shape as the page PUT bug fixed in #285).
+    const updatedRaw = await websiteService.updateBlocks({
       selector: {
         id: input.block_id
       },
       data:{
         ...input,
       }
-    }) as unknown as Block;
+    }) as unknown;
+    const updatedBlock = (Array.isArray(updatedRaw) ? updatedRaw[0] : updatedRaw) as Block;
 
     return new StepResponse(updatedBlock, {
       blockId: input.block_id,


### PR DESCRIPTION
## Summary
PR #285 fixed pages; this fixes the same bug for **blocks**.

Discovered while PUTing the home Testimonial block via curl — response came back with a totally unrelated \`MainContent\` block from page \`01JQ4HWCE05SD9WKDDNZ9A45KY\`. Actual update DID persist correctly (verified via GET on the public endpoint), but the response body was wrong → would mislead any caller relying on it to reflect the just-updated state.

## Cause
\`updateBlocks()\` returns an array; \`updateBlockStep\` stuffed it into \`StepResponse\` so \`result\` was an array and \`result.id\` was undefined. The PUT route called \`refetchBlock(undefined, ...)\` → \`refetchBlock\` queried \`{ id: undefined }\` → returned the first row in the blocks table.

## Fix (mirror of #285)
- \`updateBlockStep\` unwraps the array → single object so \`result.id\` works
- PUT route refetches by URL-derived \`blockId\`, not \`result.id\` — defensive
- \`refetchBlock\` throws on falsy \`blockId\` so a regression can't silently return an arbitrary row

## Test plan
- [ ] PUT /admin/websites/X/pages/Y/blocks/Z → response is block Z, not some other block
- [ ] GET /web/website/jaalyantra.com/home shows the updated block content
- [ ] PUT with invalid blockId → 4xx (not 200 with wrong data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)