### PR TITLE
fix(storefront-chat): passthrough validator + full-width input + z + focus

### DIFF
--- a/apps/backend/src/api/store/ai/chat/validators.ts
+++ b/apps/backend/src/api/store/ai/chat/validators.ts
@@ -58,13 +58,21 @@ const PrefsSchema = z
   })
   .partial()
 
-export const StoreAiChatSchema = z.object({
-  // Capped at 40 turns (20 round-trips) — more than that and the system
-  // prompt + brand corpus would dominate tokens anyway.
-  messages: z.array(UiMessageSchema).min(1).max(40),
-  prefs: PrefsSchema.optional(),
-  visitor_id: z.string().min(1).max(80),
-})
+export const StoreAiChatSchema = z
+  .object({
+    // Capped at 40 turns (20 round-trips) — more than that and the system
+    // prompt + brand corpus would dominate tokens anyway.
+    messages: z.array(UiMessageSchema).min(1).max(40),
+    prefs: PrefsSchema.optional(),
+    visitor_id: z.string().min(1).max(80),
+  })
+  // `.passthrough()` — AI SDK v6 introduced extra top-level fields
+  // (`id` for chat session, `trigger` for "submit" | "regenerate" etc.)
+  // that newer client versions send automatically. Without passthrough
+  // the route 4xxs with `Unrecognized fields: 'id, trigger'`. The
+  // handler only consumes the three required fields above; extras are
+  // ignored.
+  .passthrough()
 
 export type StoreAiChatReq = z.infer<typeof StoreAiChatSchema>
 export type StoreAiChatPrefs = z.infer<typeof PrefsSchema>

--- a/apps/storefront/src/modules/home/components/ai-search-chat/index.tsx
+++ b/apps/storefront/src/modules/home/components/ai-search-chat/index.tsx
@@ -20,7 +20,7 @@ import {
 // downstream type-check normally.
 const FocusModal = FocusModalBase as any
 const Prompt = PromptBase as any
-import { XMark } from "@medusajs/icons"
+import { ArrowUpMini, StopCircleSolid, XMark } from "@medusajs/icons"
 import {
   type Ref,
   useCallback,
@@ -225,6 +225,21 @@ export default function AiSearchChat({ ref }: AiSearchChatProps) {
   return (
     <FocusModal open={open} onOpenChange={handleOpenChange}>
       <FocusModal.Content
+        // Lift the modal above the sticky nav (z-50 in
+        // layout/templates/nav/nav-scroll-header.tsx) and the cart
+        // dropdown (z-50 too). Without this bump, the top of the
+        // FocusModal sits behind "CICI Label Store" and the visitor
+        // can't reach the close button or first input row.
+        className="z-[100]"
+        // Don't restore focus to whatever opened the modal — there's
+        // no `<Dialog.Trigger>` (we open imperatively from the hero),
+        // so Radix's default restore-focus algorithm walks the page
+        // and lands on the first focusable thing it finds (which has
+        // been our footer Send button → page jumps awkwardly on
+        // close). preventDefault tells Radix to leave focus alone.
+        onCloseAutoFocus={(e: Event) => {
+          e.preventDefault()
+        }}
         // Block dismissal while onboarding has unsaved selections. The
         // Prompt is opened directly here; we never let Radix close the
         // dialog out from under the user.
@@ -351,10 +366,12 @@ export default function AiSearchChat({ ref }: AiSearchChatProps) {
               </Button>
             </div>
           ) : (
-            <form
-              onSubmit={onSubmit}
-              className="flex w-full items-center gap-2"
-            >
+            // Input + send-icon laid out as a single rounded "search-bar"
+            // affordance — input spans full width, icon button sits
+            // absolutely inside it on the right. No separate Send word,
+            // and on small screens the input no longer collapses into a
+            // narrow corner column.
+            <form onSubmit={onSubmit} className="relative w-full">
               <Input
                 ref={inputRef}
                 type="text"
@@ -362,28 +379,34 @@ export default function AiSearchChat({ ref }: AiSearchChatProps) {
                 onChange={(e) => setInput(e.target.value)}
                 placeholder={PLACEHOLDER}
                 disabled={isStreaming}
-                className="flex-1"
+                className="w-full pr-12"
                 maxLength={500}
                 autoComplete="off"
                 spellCheck={false}
               />
-              {isStreaming ? (
-                <Button
-                  type="button"
-                  variant="secondary"
-                  onClick={() => stop()}
-                >
-                  Stop
-                </Button>
-              ) : (
-                <Button
-                  type="submit"
-                  variant="primary"
-                  disabled={input.trim().length < 2}
-                >
-                  Send
-                </Button>
-              )}
+              <div className="absolute right-1.5 top-1/2 -translate-y-1/2">
+                {isStreaming ? (
+                  <IconButton
+                    type="button"
+                    variant="transparent"
+                    size="small"
+                    aria-label="Stop generating"
+                    onClick={() => stop()}
+                  >
+                    <StopCircleSolid />
+                  </IconButton>
+                ) : (
+                  <IconButton
+                    type="submit"
+                    variant="primary"
+                    size="small"
+                    aria-label="Send message"
+                    disabled={input.trim().length < 2}
+                  >
+                    <ArrowUpMini />
+                  </IconButton>
+                )}
+              </div>
             </form>
           )}
         </FocusModal.Footer>


### PR DESCRIPTION
## Summary
Four issues in the cicilabel.com concierge chat, all in the same flow:

| # | Issue | Fix |
|---|---|---|
| 1 | \`"Invalid request: Unrecognized fields: 'id, trigger'"\` from the backend | \`.passthrough()\` on \`StoreAiChatSchema\` — AI SDK v6's \`useChat\` sends \`id\` + \`trigger\` at top level |
| 2 | Input collapsed into a corner with a separate "Send" button | Restyled as a single rounded search-bar — Input full-width with \`pr-12\`, ArrowUpMini IconButton absolutely positioned on the right. StopCircleSolid for streaming. |
| 3 | FocusModal top edge sat behind the sticky nav | \`className="z-[100]"\` on FocusModal.Content. Nav is z-50; country/language selects use z-[900] so 100 stays clear |
| 4 | Closing the modal scrolled the page to the footer | \`onCloseAutoFocus={(e) => e.preventDefault()}\` — we open imperatively (no \`<Dialog.Trigger>\`), so Radix's default restore-focus walked to a footer button. preventDefault keeps focus where it was. |

## Test plan
- [ ] Open chat → type a message → no validator 4xx
- [ ] Input spans full width on mobile + desktop, icon visible on the right
- [ ] Streaming: icon swaps to stop, button stops the stream
- [ ] Modal top edge visible above the sticky nav
- [ ] Close modal → page stays at the original scroll position (no jump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)