### PR TITLE
fix(chat): explicit AI SDK extras (Medusa zodValidator forces .strict)

### DIFF
--- a/apps/backend/src/api/store/ai/chat/validators.ts
+++ b/apps/backend/src/api/store/ai/chat/validators.ts
@@ -58,21 +58,26 @@ const PrefsSchema = z
   })
   .partial()
 
-export const StoreAiChatSchema = z
-  .object({
-    // Capped at 40 turns (20 round-trips) — more than that and the system
-    // prompt + brand corpus would dominate tokens anyway.
-    messages: z.array(UiMessageSchema).min(1).max(40),
-    prefs: PrefsSchema.optional(),
-    visitor_id: z.string().min(1).max(80),
-  })
-  // `.passthrough()` — AI SDK v6 introduced extra top-level fields
-  // (`id` for chat session, `trigger` for "submit" | "regenerate" etc.)
-  // that newer client versions send automatically. Without passthrough
-  // the route 4xxs with `Unrecognized fields: 'id, trigger'`. The
-  // handler only consumes the three required fields above; extras are
-  // ignored.
-  .passthrough()
+export const StoreAiChatSchema = z.object({
+  // Capped at 40 turns (20 round-trips) — more than that and the system
+  // prompt + brand corpus would dominate tokens anyway.
+  messages: z.array(UiMessageSchema).min(1).max(40),
+  prefs: PrefsSchema.optional(),
+  visitor_id: z.string().min(1).max(80),
+
+  // ──────────────────────────────────────────────────────────────────
+  // AI SDK v6 (`useChat`) sends these extra top-level fields on every
+  // request. Medusa's `zodValidator` (in
+  // `@medusajs/framework/dist/zod/zod-helpers.js`) FORCIBLY calls
+  // `.strict()` on any schema with that method, which overrides
+  // `.passthrough()` — so we have to declare known SDK fields
+  // explicitly here. If a future AI SDK version adds more fields,
+  // they'll need to be listed too. The handler ignores them; they're
+  // here purely to satisfy the forced strict check.
+  // ──────────────────────────────────────────────────────────────────
+  id: z.string().optional(),
+  trigger: z.string().optional(),
+})
 
 export type StoreAiChatReq = z.infer<typeof StoreAiChatSchema>
 export type StoreAiChatPrefs = z.infer<typeof PrefsSchema>


### PR DESCRIPTION
## Summary
PR #289's \`.passthrough()\` didn't work in prod. Root cause: Medusa's \`zodValidator\` in \`@medusajs/framework/dist/zod/zod-helpers.js:198-200\` **forcibly wraps every ZodObject in .strict()** before parsing, silently overriding any \`.passthrough()\` the schema author added:

\`\`\`js
if ("strict" in zodSchema) {
  strictSchema = zodSchema.strict();  // ← my .passthrough() got nuked
}
\`\`\`

## Fix
Declare AI SDK v6's known extra top-level fields (\`id\`, \`trigger\`) explicitly as optional. The handler still ignores them; they exist only to satisfy the forced strict check.

Added a comment so the next dev doesn't waste an hour rediscovering the gotcha.

## Test plan
- [ ] After deploy, POST to /store/ai/chat with the useChat shape (\`{id, trigger, messages, prefs, visitor_id}\`) — returns 200 + stream instead of 400
- [ ] cicilabel.com → open concierge chat → send a message → response streams instead of red "Something went wrong" box
- [ ] Existing valid payloads (without id/trigger) still work — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)