### PR TITLE
feat(whatsapp): createDraftProductFromExtractionWorkflow (W2)

### DIFF
--- a/apps/backend/integration-tests/http/whatsapp-create-draft-product.spec.ts
+++ b/apps/backend/integration-tests/http/whatsapp-create-draft-product.spec.ts
@@ -1,0 +1,211 @@
+import { setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { createDraftProductFromExtractionWorkflow } from "../../src/workflows/whatsapp/create-draft-product-from-extraction"
+
+const TEST_PARTNER_PASSWORD = "supersecret"
+
+jest.setTimeout(90 * 1000)
+
+async function bootPartnerWithStore(api: any, adminHeaders: Record<string, any>) {
+  const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+  const email = `wa-prod-${unique}@medusa-test.com`
+
+  await api.post("/auth/partner/emailpass/register", { email, password: TEST_PARTNER_PASSWORD })
+  const login1 = await api.post("/auth/partner/emailpass", { email, password: TEST_PARTNER_PASSWORD })
+  let headers: Record<string, string> = { Authorization: `Bearer ${login1.data.token}` }
+
+  const partnerRes = await api.post(
+    "/partners",
+    {
+      name: `WATest ${unique}`,
+      handle: `watest-${unique}`,
+      admin: { email, first_name: "Admin", last_name: "WA" },
+    },
+    { headers }
+  )
+  const partnerId = partnerRes.data.partner.id
+  const partnerName = partnerRes.data.partner.name
+
+  const login2 = await api.post("/auth/partner/emailpass", { email, password: TEST_PARTNER_PASSWORD })
+  headers = { Authorization: `Bearer ${login2.data.token}` }
+
+  const currenciesRes = await api.get("/admin/currencies", adminHeaders)
+  const currencies = currenciesRes.data.currencies || []
+  const usd = currencies.find((c: any) => c.code?.toLowerCase() === "usd")
+  const currencyCode = String((usd || currencies[0]).code).toLowerCase()
+
+  const storeRes = await api.post(
+    "/partners/stores",
+    {
+      store: {
+        name: `WAStore ${unique}`,
+        supported_currencies: [{ currency_code: currencyCode, is_default: true }],
+      },
+      sales_channel: { name: `WAChannel ${unique}`, description: "Default" },
+      region: { name: "Default Region", currency_code: currencyCode, countries: ["us"] },
+      location: {
+        name: "Warehouse",
+        address: { address_1: "1 Main St", city: "NY", postal_code: "10001", country_code: "US" },
+      },
+    },
+    { headers }
+  )
+
+  return {
+    partnerId,
+    partnerName,
+    storeId: storeRes.data.store.id,
+    salesChannelId: storeRes.data.store.default_sales_channel_id,
+    currencyCode,
+    headers,
+  }
+}
+
+describe("createDraftProductFromExtractionWorkflow", () => {
+  setupSharedTestSuite(({ api, getContainer }) => {
+    let adminHeaders: any
+
+    beforeAll(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+    })
+
+    it("creates a DRAFT product from extracted fields with no media", async () => {
+      const partner = await bootPartnerWithStore(api, adminHeaders)
+      const container = getContainer()
+
+      const { result } = await createDraftProductFromExtractionWorkflow(container).run({
+        input: {
+          partner_id: partner.partnerId,
+          partner_name: partner.partnerName,
+          media_ids: [],
+          extracted: {
+            title: "Handwoven Cotton Kurta",
+            description: "Soft cotton, hand-loom Kashmir.",
+            suggested_price: 4500,
+            fabric_type: "cotton",
+            colors: ["white", "indigo"],
+          },
+          caption: "Saree silk ₹4500",
+        },
+      })
+
+      expect(result).toBeDefined()
+      expect(result.product_id).toMatch(/^prod_/)
+      expect(result.product_title).toBe("Handwoven Cotton Kurta")
+      expect(result.status).toBe("draft")
+      expect(result.admin_url).toBe(`/app/products/${result.product_id}`)
+      expect(result.rehosted_image_urls).toEqual([])
+
+      // Read it back via the partner products route and assert shape.
+      const detail = await api.get(
+        `/partners/stores/${partner.storeId}/products/${result.product_id}`,
+        { headers: partner.headers }
+      )
+      expect(detail.status).toBe(200)
+      const product = detail.data.product
+      expect(product.status).toBe("draft")
+      expect(product.title).toBe("Handwoven Cotton Kurta")
+      expect(product.description).toBe("Soft cotton, hand-loom Kashmir.")
+      expect(product.metadata?.created_via).toBe("whatsapp")
+      expect(product.metadata?.wa_fabric_type).toBe("cotton")
+      expect(product.metadata?.wa_colors).toEqual(["white", "indigo"])
+
+      // Single variant in the store's default currency at the extracted price.
+      expect(product.variants?.length).toBe(1)
+      const price = (product.variants[0].prices || []).find(
+        (p: any) => p.currency_code === partner.currencyCode
+      )
+      expect(price?.amount).toBe(4500)
+    })
+
+    it("defaults missing suggested_price to 0", async () => {
+      const partner = await bootPartnerWithStore(api, adminHeaders)
+      const container = getContainer()
+
+      const { result } = await createDraftProductFromExtractionWorkflow(container).run({
+        input: {
+          partner_id: partner.partnerId,
+          partner_name: partner.partnerName,
+          media_ids: [],
+          extracted: {
+            title: "Untitled Saree",
+            // no suggested_price
+          },
+        },
+      })
+      expect(result.product_id).toMatch(/^prod_/)
+
+      const detail = await api.get(
+        `/partners/stores/${partner.storeId}/products/${result.product_id}`,
+        { headers: partner.headers }
+      )
+      const price = (detail.data.product.variants[0].prices || []).find(
+        (p: any) => p.currency_code === partner.currencyCode
+      )
+      expect(price?.amount).toBe(0)
+    })
+
+    it("fails the workflow when extracted.title is missing", async () => {
+      const partner = await bootPartnerWithStore(api, adminHeaders)
+      const container = getContainer()
+
+      // Medusa workflows don't throw on step errors — failures land in
+      // `errors`. We assert that array contains the expected message
+      // and no product was returned.
+      const { result, errors } = await createDraftProductFromExtractionWorkflow(container).run({
+        input: {
+          partner_id: partner.partnerId,
+          partner_name: partner.partnerName,
+          media_ids: [],
+          extracted: {
+            // no title
+            suggested_price: 1000,
+          },
+        },
+        throwOnError: false,
+      })
+
+      expect(errors?.length).toBeGreaterThan(0)
+      const msgs = (errors || []).map((e: any) => e?.error?.message || String(e)).join(" | ")
+      expect(msgs).toMatch(/title is required/i)
+      expect(result).toBeFalsy()
+    })
+
+    it("fails the workflow when partner has no store", async () => {
+      // Register a partner but don't create a store for them.
+      const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+      const email = `wa-nostore-${unique}@medusa-test.com`
+      await api.post("/auth/partner/emailpass/register", { email, password: TEST_PARTNER_PASSWORD })
+      const login = await api.post("/auth/partner/emailpass", { email, password: TEST_PARTNER_PASSWORD })
+      const headers = { Authorization: `Bearer ${login.data.token}` }
+      const partnerRes = await api.post(
+        "/partners",
+        {
+          name: `NoStorePartner ${unique}`,
+          handle: `nostore-${unique}`,
+          admin: { email, first_name: "A", last_name: "B" },
+        },
+        { headers }
+      )
+      const partnerId = partnerRes.data.partner.id
+
+      const container = getContainer()
+      const { result, errors } = await createDraftProductFromExtractionWorkflow(container).run({
+        input: {
+          partner_id: partnerId,
+          partner_name: "NoStorePartner",
+          media_ids: [],
+          extracted: { title: "x" },
+        },
+        throwOnError: false,
+      })
+
+      expect(errors?.length).toBeGreaterThan(0)
+      const msgs = (errors || []).map((e: any) => e?.error?.message || String(e)).join(" | ")
+      expect(msgs).toMatch(/no store/i)
+      expect(result).toBeFalsy()
+    })
+  })
+})

--- a/apps/backend/src/workflows/whatsapp/create-draft-product-from-extraction.ts
+++ b/apps/backend/src/workflows/whatsapp/create-draft-product-from-extraction.ts
@@ -1,0 +1,313 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  transform,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  ProductStatus,
+} from "@medusajs/framework/utils"
+import { createProductsWorkflow } from "@medusajs/medusa/core-flows"
+import { downloadAndSaveWhatsAppMedia } from "./whatsapp-media-helper"
+
+/**
+ * Build a draft product from WhatsApp message extraction.
+ *
+ * Called from either the WhatsApp visual flow (via the trigger_workflow
+ * operation) or a hardcoded handler. Mirrors the partner quick-create
+ * route at `src/api/partners/stores/[id]/products/quick/route.ts` —
+ * single variant, default option, store-default currency and sales
+ * channel — but always writes `status: DRAFT` so misextracted titles
+ * or stray photos never become a live product on the storefront. The
+ * partner reviews + publishes from admin.
+ *
+ * Why a workflow (vs. POST-ing to the route):
+ *   - Visual flow's `trigger_workflow` operation invokes Medusa
+ *     workflows by name. Wrapping the create logic here makes it
+ *     callable from the flow without standing up a service account
+ *     or HMAC-signing internal HTTP calls.
+ *   - Steps + transform give us per-step audit in the workflow
+ *     execution log, same shape as our other production-run + payment
+ *     workflows.
+ */
+
+export type CreateDraftProductFromExtractionInput = {
+  partner_id: string
+  partner_name: string
+  // WhatsApp media IDs from the inbound message (Meta-presigned URLs are
+  // short-lived; the media helper downloads + re-uploads to S3 and
+  // returns a stable URL). Pass an empty array for caption-only messages.
+  media_ids: string[]
+  // Subset of fields the textile extraction agent returns. We're lenient
+  // on shape because OpenRouter free-tier models occasionally drop
+  // fields; the workflow validates `title` at the build step.
+  extracted: {
+    title?: string | null
+    description?: string | null
+    suggested_price?: number | null
+    fabric_type?: string | null
+    colors?: string[] | null
+  }
+  // Optional caption to stash on the file metadata for future reference.
+  caption?: string | null
+}
+
+export type CreateDraftProductFromExtractionResult = {
+  product_id: string
+  product_title: string
+  admin_url: string
+  rehosted_image_urls: string[]
+  status: "draft"
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Step 1 — resolve the partner's store + currency + sales channel.
+// Same pattern as the partner quick-create route handler. Throws on
+// missing store / sales channel / supported_currencies because there's
+// no sensible default for a partner without a configured storefront.
+// ──────────────────────────────────────────────────────────────────────
+
+type ResolvedStore = {
+  store_id: string
+  currency_code: string
+  default_sales_channel_id: string
+}
+
+const resolvePartnerStoreStep = createStep(
+  "wa-product-create-resolve-store",
+  async (input: { partner_id: string }, { container }) => {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY)
+    const { data } = await query.graph({
+      entity: "partners",
+      fields: [
+        "id",
+        "stores.id",
+        "stores.default_sales_channel_id",
+        "stores.supported_currencies.currency_code",
+        "stores.supported_currencies.is_default",
+      ],
+      filters: { id: input.partner_id },
+    } as any)
+    const partner = (data as any[])?.[0]
+    if (!partner) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Partner ${input.partner_id} not found`
+      )
+    }
+    const store = partner.stores?.[0]
+    if (!store) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Partner ${input.partner_id} has no store configured`
+      )
+    }
+    const supported = (store.supported_currencies || []) as Array<{
+      currency_code: string
+      is_default: boolean
+    }>
+    const currency_code =
+      supported.find((c) => c.is_default)?.currency_code ??
+      supported[0]?.currency_code
+    if (!currency_code) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Store ${store.id} has no supported currencies`
+      )
+    }
+    if (!store.default_sales_channel_id) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Store ${store.id} has no default sales channel`
+      )
+    }
+    return new StepResponse({
+      store_id: store.id as string,
+      currency_code,
+      default_sales_channel_id: store.default_sales_channel_id as string,
+    } as ResolvedStore)
+  }
+)
+
+// ──────────────────────────────────────────────────────────────────────
+// Step 2 — rehost every WhatsApp media into a stable S3 URL via the
+// existing helper. Skipped entries (download failed) drop out of the
+// list rather than fail the workflow — a partner sending one valid
+// photo + one corrupted one should still get a product.
+// ──────────────────────────────────────────────────────────────────────
+
+const rehostMediaStep = createStep(
+  "wa-product-create-rehost-media",
+  async (
+    input: {
+      media_ids: string[]
+      partner_id: string
+      partner_name: string
+      caption?: string | null
+    },
+    { container }
+  ) => {
+    if (!input.media_ids?.length) {
+      return new StepResponse({ image_urls: [] as string[] })
+    }
+    const results: string[] = []
+    for (const mediaId of input.media_ids) {
+      const r = await downloadAndSaveWhatsAppMedia(container, {
+        mediaId,
+        partnerId: input.partner_id,
+        partnerName: input.partner_name,
+        caption: input.caption ?? undefined,
+      })
+      if (r?.fileUrl) results.push(r.fileUrl)
+    }
+    return new StepResponse({ image_urls: results })
+  }
+)
+
+// ──────────────────────────────────────────────────────────────────────
+// Step 3 — build the `createProductsWorkflow` input from the extracted
+// fields + the rehosted URLs + the resolved store defaults.
+//
+// Mirrors the partner quick-create route's payload shape. Single variant,
+// "Default option", prices in the store's default currency, sales
+// channel pre-bound. Status forced to DRAFT regardless of any caller
+// override — a misextracted title must never become a live product.
+// ──────────────────────────────────────────────────────────────────────
+
+const buildProductInputStep = createStep(
+  "wa-product-create-build-input",
+  async (
+    input: {
+      extracted: CreateDraftProductFromExtractionInput["extracted"]
+      image_urls: string[]
+      store: ResolvedStore
+    }
+  ) => {
+    const title = input.extracted.title?.trim()
+    if (!title) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "extracted.title is required to create a product"
+      )
+    }
+    const price =
+      typeof input.extracted.suggested_price === "number" &&
+      input.extracted.suggested_price >= 0
+        ? input.extracted.suggested_price
+        : 0
+    const description = input.extracted.description?.trim() || undefined
+
+    const productInput = {
+      title,
+      description,
+      status: ProductStatus.DRAFT,
+      thumbnail: input.image_urls[0] || undefined,
+      images: input.image_urls.length
+        ? input.image_urls.map((url) => ({ url }))
+        : undefined,
+      sales_channels: [{ id: input.store.default_sales_channel_id }],
+      options: [
+        { title: "Default option", values: ["Default option value"] },
+      ],
+      variants: [
+        {
+          title,
+          options: { "Default option": "Default option value" },
+          manage_inventory: false,
+          prices: [
+            { amount: price, currency_code: input.store.currency_code },
+          ],
+        },
+      ],
+      // Stash the source so admin can filter / audit WhatsApp-created
+      // products later. Keeps the audit trail visible at the product
+      // row level, not just in the flow execution log.
+      metadata: {
+        created_via: "whatsapp",
+        wa_fabric_type: input.extracted.fabric_type || null,
+        wa_colors: input.extracted.colors || null,
+      },
+    }
+    return new StepResponse({ productInput })
+  }
+)
+
+// ──────────────────────────────────────────────────────────────────────
+// Step 4 — invoke the core createProductsWorkflow with the built input.
+// We don't use the workflow composer's `when()` because we always create
+// exactly one product per call.
+// ──────────────────────────────────────────────────────────────────────
+
+const createDraftProductStep = createStep(
+  "wa-product-create-invoke-create",
+  async (input: { productInput: any }, { container }) => {
+    const { result } = await createProductsWorkflow(container).run({
+      input: { products: [input.productInput] },
+    })
+    const product = (result as any)[0]
+    if (!product?.id) {
+      throw new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        "createProductsWorkflow returned no product"
+      )
+    }
+    return new StepResponse({ product_id: product.id, product_title: product.title })
+  }
+)
+
+// ──────────────────────────────────────────────────────────────────────
+// Workflow assembly.
+// ──────────────────────────────────────────────────────────────────────
+
+export const createDraftProductFromExtractionWorkflow = createWorkflow(
+  {
+    name: "create-draft-product-from-extraction",
+    // `store: true` keeps the run + per-step log in the workflow
+    // executions table — same as send-to-partner / accept-production-
+    // run, so the admin UI can show "WhatsApp → product" history.
+    store: true,
+  },
+  (input: CreateDraftProductFromExtractionInput) => {
+    const store = resolvePartnerStoreStep({ partner_id: input.partner_id })
+
+    const media = rehostMediaStep(
+      transform({ input }, ({ input }) => ({
+        media_ids: input.media_ids || [],
+        partner_id: input.partner_id,
+        partner_name: input.partner_name,
+        caption: input.caption ?? null,
+      }))
+    )
+
+    const built = buildProductInputStep(
+      transform(
+        { input, store, media },
+        ({ input, store, media }) => ({
+          extracted: input.extracted,
+          image_urls: media.image_urls,
+          store,
+        })
+      )
+    )
+
+    const created = createDraftProductStep(
+      transform({ built }, ({ built }) => ({ productInput: built.productInput }))
+    )
+
+    return new WorkflowResponse(
+      transform(
+        { created, media },
+        ({ created, media }): CreateDraftProductFromExtractionResult => ({
+          product_id: created.product_id,
+          product_title: created.product_title,
+          admin_url: `/app/products/${created.product_id}`,
+          rehosted_image_urls: media.image_urls,
+          status: "draft",
+        })
+      )
+    )
+  }
+)

--- a/apps/docs/notes/WHATSAPP_PRODUCT_CREATE.md
+++ b/apps/docs/notes/WHATSAPP_PRODUCT_CREATE.md
@@ -1,9 +1,20 @@
 # WhatsApp Product Creation for Partners
 
-> Status: **DESIGN** — not yet built.
-> Date: 2026-05-29
+> Status: **IN PROGRESS** — W1 already shipped; W2 (workflow + tests) landed 2026-05-30.
+> Date: 2026-05-29 (design), 2026-05-30 (W2 update)
 > Owner: Saransh
 > Companion to `WEBHOOK_SETUP_GUIDE.md` (Meta WhatsApp wiring) and `PARTNER_API_PARITY.md` (the quick-create endpoint we reuse).
+
+## Build progress
+
+| PR | Status | Notes |
+|----|--------|-------|
+| W1 — media rehost helper | ✅ **already shipped** | `downloadAndSaveWhatsAppMedia` at `apps/backend/src/workflows/whatsapp/whatsapp-media-helper.ts:239`. Handles Bearer auth on Meta presigned URL + base64 round-trip for file-s3 provider (the second one had bitten us before — well-documented in the source). |
+| W2 — `createDraftProductFromExtractionWorkflow` | ✅ shipped 2026-05-30 | `apps/backend/src/workflows/whatsapp/create-draft-product-from-extraction.ts`. 4 steps: resolve store → rehost media → build product input → invoke `createProductsWorkflow` with `status: DRAFT`. 4 integration tests passing. |
+| W3 — webhook emits `whatsapp.message_received` event + subscriber registration | ⏳ next |
+| W4 — `seed-partner-product-create-flow.ts` for one pilot partner | ⏳ |
+| W5 — Confirm/Edit/Cancel flow + roll-out | ⏳ |
+| W6 — Polish (caption-only, photo-only, dedupe verify) | ⏳ |
 
 ## Goal
 


### PR DESCRIPTION
## Summary

W2 from `apps/docs/notes/WHATSAPP_PRODUCT_CREATE.md`. Workflow that builds a DRAFT product on the partner's storefront from the WhatsApp textile-extraction agent's output. Designed to be invoked from the recommended visual-flow-native path (via the flow's \`trigger_workflow\` operation) or a hardcoded handler.

## What it does

\`createDraftProductFromExtractionWorkflow\`:
1. **resolve-store** — query.graph partner → store + sales channel + currency
2. **rehost-media** — for each inbound \`media_id\`, calls the already-shipped \`downloadAndSaveWhatsAppMedia\` helper to get a stable S3 URL (failed downloads drop, don't fail the workflow)
3. **build-input** — composes the same product input shape as \`POST /partners/stores/:id/products/quick\`, but always with \`status: DRAFT\` and \`metadata.created_via = \"whatsapp\"\`
4. **invoke-create** — runs Medusa's \`createProductsWorkflow\`

Returns \`{ product_id, product_title, admin_url, rehosted_image_urls, status: 'draft' }\` so the next visual-flow node (\`send_whatsapp\`) can echo the admin link back to the partner.

## Discovery (folded into the design doc)

W1 (rehost helper) was already shipped at \`whatsapp-media-helper.ts:239\` from prior production-run media work. The design doc was written without auditing the current state of that helper. W2 reuses it directly — no separate rehost PR needed. Doc updated to mark W1 ✅ done.

## Test plan

4 integration tests, all passing:
- [x] creates DRAFT product from extracted fields, no media — asserts status, title, description, price in store currency, metadata
- [x] defaults missing \`suggested_price\` to 0
- [x] \`workflow.errors\` populated when \`extracted.title\` is missing
- [x] \`workflow.errors\` populated when partner has no store

Total runtime: ~12s.

## Next: W3

Webhook emits \`whatsapp.message_received\` event + register in the visual-flow event subscriber. After W3, the visual flow can be authored from the admin UI to chain: condition (image + caption) → ai_extract → trigger_workflow(this) → send_whatsapp(interactive confirm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)