### PR TITLE
feat(whatsapp): emit whatsapp.message_received event from webhook (W3)

### DIFF
--- a/apps/backend/integration-tests/http/whatsapp-message-received-event.spec.ts
+++ b/apps/backend/integration-tests/http/whatsapp-message-received-event.spec.ts
@@ -1,0 +1,140 @@
+import crypto from "crypto"
+import { Modules } from "@medusajs/framework/utils"
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser } from "../helpers/create-admin-user"
+
+// W3 — the webhook must emit `whatsapp.message_received` for every parsed
+// inbound message so the visual-flow-event-trigger subscriber can fan out to
+// flows configured against this event (e.g. WhatsApp → product draft).
+//
+// Signed POSTs are accepted when the X-Hub-Signature-256 HMAC matches any
+// known app secret. The simplest known secret in tests is the env-var one,
+// so we set it before the suite boots.
+const TEST_APP_SECRET = "w3_test_app_secret"
+process.env.WHATSAPP_APP_SECRET = TEST_APP_SECRET
+
+const TEST_PHONE = "919876512345"
+
+jest.setTimeout(60 * 1000)
+
+function signBody(rawBody: string, secret: string): string {
+  return "sha256=" + crypto.createHmac("sha256", secret).update(rawBody).digest("hex")
+}
+
+function buildInboundTextPayload(phone: string, messageId: string, text: string) {
+  return {
+    object: "whatsapp_business_account",
+    entry: [
+      {
+        id: "wabai_test",
+        changes: [
+          {
+            field: "messages",
+            value: {
+              messaging_product: "whatsapp",
+              metadata: { display_phone_number: "15555550000", phone_number_id: "phone_test_1" },
+              contacts: [{ profile: { name: "Tester" }, wa_id: phone }],
+              messages: [
+                {
+                  id: messageId,
+                  from: phone,
+                  type: "text",
+                  text: { body: text },
+                  timestamp: String(Math.floor(Date.now() / 1000)),
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  }
+}
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("WhatsApp webhook — emits whatsapp.message_received", () => {
+    beforeAll(async () => {
+      await createAdminUser(getContainer())
+
+      // Register a partner whose admin phone matches the inbound sender, so
+      // the webhook resolves partner_id on the event payload.
+      const unique = Date.now()
+      const email = `wa-event-${unique}@jyt.test`
+
+      await api.post("/auth/partner/emailpass/register", {
+        email,
+        password: "supersecret",
+      })
+      const login = await api.post("/auth/partner/emailpass", {
+        email,
+        password: "supersecret",
+      })
+
+      await api.post(
+        "/partners",
+        {
+          name: `WA Event Partner ${unique}`,
+          handle: `wa-event-${unique}`,
+          admin: { email, first_name: "Event", last_name: "Tester", phone: TEST_PHONE },
+        },
+        { headers: { Authorization: `Bearer ${login.data.token}` } }
+      )
+    })
+
+    it("subscriber config registers whatsapp.message_received", async () => {
+      const mod = await import("../../src/subscribers/visual-flow-event-trigger")
+      const events = mod.config?.event
+      const list = Array.isArray(events) ? events : [events]
+      expect(list).toContain("whatsapp.message_received")
+    })
+
+    it("fires the event when a signed inbound text message arrives", async () => {
+      const eventBus = getContainer().resolve(Modules.EVENT_BUS) as any
+
+      const received = new Promise<any>((resolve) => {
+        const subscriber = async (evt: any) => {
+          eventBus.unsubscribe("whatsapp.message_received", subscriber)
+          resolve(evt)
+        }
+        eventBus.subscribe("whatsapp.message_received", subscriber, {
+          subscriberId: `w3-test-${Date.now()}`,
+        })
+      })
+
+      const messageId = `wamid.test_${Date.now()}`
+      const payload = buildInboundTextPayload(TEST_PHONE, messageId, "hello from W3")
+      const rawBody = JSON.stringify(payload)
+
+      const res = await api.post("/webhooks/social/whatsapp", rawBody, {
+        headers: {
+          "Content-Type": "application/json",
+          "X-Hub-Signature-256": signBody(rawBody, TEST_APP_SECRET),
+        },
+        validateStatus: () => true,
+        transformRequest: [(data: any) => data],
+      })
+
+      expect(res.status).toBe(200)
+      expect(res.data).toBe("EVENT_RECEIVED")
+
+      const evt = await Promise.race([
+        received,
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("timed out waiting for whatsapp.message_received")), 8000)
+        ),
+      ])
+
+      // Subscribers receive Event<T> = { name, data, metadata? }
+      expect(evt.name).toBe("whatsapp.message_received")
+      const data = evt.data
+      expect(data.from).toBe(TEST_PHONE)
+      expect(data.type).toBe("text")
+      expect(data.text).toBe("hello from W3")
+      expect(data.message_id).toBe(messageId)
+      expect(data.media_ids).toEqual([])
+      expect(typeof data.partner_id === "string" || data.partner_id === null).toBe(true)
+    })
+  })
+})

--- a/apps/backend/src/api/webhooks/social/whatsapp/route.ts
+++ b/apps/backend/src/api/webhooks/social/whatsapp/route.ts
@@ -1,9 +1,10 @@
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { Modules } from "@medusajs/framework/utils"
 import crypto from "crypto"
 import { SOCIAL_PROVIDER_MODULE } from "../../../../modules/social-provider"
 import type SocialProviderService from "../../../../modules/social-provider/service"
 import type WhatsAppService from "../../../../modules/social-provider/whatsapp-service"
-import { handleIncomingMessage } from "../../../../workflows/whatsapp/whatsapp-message-handler"
+import { handleIncomingMessage, resolvePartnerByPhone } from "../../../../workflows/whatsapp/whatsapp-message-handler"
 import { resolveAdminByPhone, handleAdminMessage } from "../../../../workflows/whatsapp/whatsapp-admin-handler"
 import  { MESSAGING_MODULE } from "../../../../modules/messaging"
 
@@ -322,6 +323,36 @@ async function processWhatsAppWebhook(
           // Handlers receive the sender-bound wa so replies go out from the
           // same number that received the inbound message.
           const admin = await resolveAdminByPhone(scope, incomingMessage.from)
+          const partner = admin ? null : await resolvePartnerByPhone(scope, incomingMessage.from)
+
+          // Emit a generic event so visual flows can subscribe to inbound
+          // WhatsApp messages without authoring custom subscribers. Partner /
+          // admin handlers below still run unchanged — the event is additive.
+          // Fire-and-forget: an emit failure must not break message handling.
+          try {
+            const eventBus = scope.resolve(Modules.EVENT_BUS) as any
+            await eventBus.emit([{
+              name: "whatsapp.message_received",
+              data: {
+                from: incomingMessage.from,
+                message_id: incomingMessage.messageId,
+                type: incomingMessage.type,
+                text: incomingMessage.text ?? null,
+                caption: incomingMessage.text ?? null,
+                media_ids: incomingMessage.mediaId ? [incomingMessage.mediaId] : [],
+                media_url: incomingMessage.mediaUrl ?? null,
+                media_mime_type: incomingMessage.mediaMimeType ?? null,
+                reply_to_wa_message_id: incomingMessage.replyToWaMessageId ?? null,
+                sender_platform_id: wa.getSenderPlatformId?.() ?? null,
+                partner_id: partner?.partnerId ?? null,
+                partner_name: partner?.adminName ?? null,
+                admin_user_id: admin?.userId ?? null,
+              },
+            }])
+          } catch (e: any) {
+            console.warn("[whatsapp-webhook] Failed to emit whatsapp.message_received:", e.message)
+          }
+
           if (admin) {
             const result = await handleAdminMessage(scope, incomingMessage, admin, wa)
             console.log("[whatsapp-webhook] Admin handled:", result)

--- a/apps/backend/src/subscribers/visual-flow-event-trigger.ts
+++ b/apps/backend/src/subscribers/visual-flow-event-trigger.ts
@@ -255,5 +255,11 @@ export const config: SubscriberConfig = {
     // Inbound Emails
     "inbound_emails.inbound-email.created",
     "inbound_emails.inbound-email.updated",
+
+    // WhatsApp inbound messages — fires for every parsed inbound message
+    // (text, image, video, document, audio, interactive). Used by flows that
+    // need to react to partner replies, e.g. auto-create draft products from
+    // photo+caption messages via createDraftProductFromExtractionWorkflow.
+    "whatsapp.message_received",
   ],
 }

--- a/apps/backend/src/workflows/whatsapp/whatsapp-message-handler.ts
+++ b/apps/backend/src/workflows/whatsapp/whatsapp-message-handler.ts
@@ -55,7 +55,7 @@ interface ResolvedPartner {
   isNewVerification?: boolean // true if this admin's WhatsApp was just auto-verified
 }
 
-async function resolvePartnerByPhone(
+export async function resolvePartnerByPhone(
   scope: any,
   phone: string
 ): Promise<ResolvedPartner | null> {

--- a/apps/docs/docs/implementation/workflows/whatsapp-create-draft-product.md
+++ b/apps/docs/docs/implementation/workflows/whatsapp-create-draft-product.md
@@ -27,7 +27,7 @@ Partner sends 📷 + "Saree silk ₹4500"
 │  - HMAC signature check                        │
 │  - parseWebhookMessage()                       │
 │  - returns 200 OK to Meta immediately          │
-│  - emit("whatsapp.message_received", …)   ⏳W3 │
+│  - emit("whatsapp.message_received", …)    ✅W3 │
 └─────────────────────┬──────────────────────────┘
                       │
                       ▼
@@ -306,8 +306,8 @@ pnpm test:integration:http:shared ./integration-tests/http/whatsapp-create-draft
 |----|--------|-------------|
 | W1 — media rehost helper | ✅ shipped (pre-existing) | `downloadAndSaveWhatsAppMedia` at `whatsapp-media-helper.ts:239` |
 | **W2 — this workflow** | ✅ shipped | `createDraftProductFromExtractionWorkflow` |
-| W3 — webhook emits `whatsapp.message_received` event | ⏳ next | The trigger that lets a visual flow listen for inbound messages |
-| W4 — `seed-partner-product-create-flow.ts` | ⏳ | Seeds the inbound flow for one pilot partner |
+| W3 — webhook emits `whatsapp.message_received` event | ✅ shipped 2026-05-31 | `whatsapp/route.ts` emits after parse + identity resolution; subscriber registers the name |
+| W4 — `seed-partner-product-create-flow.ts` | ⏳ next | Seeds the inbound flow for one pilot partner |
 | W5 — Confirm/Edit/Cancel handling | ⏳ | Button-reply handler flips DRAFT → PUBLISHED, deletes on cancel |
 | W6 — Polish: caption-only edges, photo-only edges, dedup verify | ⏳ | |
 


### PR DESCRIPTION
## Summary

W3 of the WhatsApp product creation series. Adds a generic `whatsapp.message_received` event emission from the inbound webhook so visual flows can subscribe to inbound messages without authoring bespoke subscriber files. The existing partner/admin handler paths still run unchanged — the event is purely additive and fires fire-and-forget after parsing + identity resolution.

This is the trigger that unblocks **W4** (seed a *Partner WhatsApp — Product Create* flow for one pilot partner) which chains:

```
condition (image + caption) -> ai_extract -> trigger_workflow(createDraftProductFromExtractionWorkflow) -> send_whatsapp (Confirm/Edit/Cancel)
```

Until W4 lands, no flow consumes the event yet, so production behavior is unchanged.

## Roadmap status

| PR | Status |
|---|---|
| W1 — `downloadAndSaveWhatsAppMedia` rehost helper | shipped (pre-existing) |
| W2 — `createDraftProductFromExtractionWorkflow` | shipped #292 |
| **W3 — webhook event emission + subscriber registration** | **this PR** |
| W4 — seed visual flow for pilot partner | next |
| W5 — Confirm/Edit/Cancel button handler (DRAFT -> PUBLISHED) | pending |
| W6 — Polish: caption-only, photo-only, dedup verify | pending |

## Changes

- `apps/backend/src/api/webhooks/social/whatsapp/route.ts` — after `parseWebhookMessage()` + admin/partner resolution, emit `whatsapp.message_received` with `{from, message_id, type, text, caption, media_ids, media_url, media_mime_type, reply_to_wa_message_id, sender_platform_id, partner_id, partner_name, admin_user_id}`. Emit failures are caught and logged so they cannot break the existing handler paths.
- `apps/backend/src/subscribers/visual-flow-event-trigger.ts` — register `"whatsapp.message_received"` in the curated event list so the visual-flow engine actually receives it.
- `apps/backend/src/workflows/whatsapp/whatsapp-message-handler.ts` — export `resolvePartnerByPhone` so the webhook can attach `partner_id` to the event without duplicating the lookup logic.
- `apps/docs/docs/implementation/workflows/whatsapp-create-draft-product.md` — flip W3 from pending to shipped in the ASCII diagram and roadmap table.
- New integration test: signed POST asserts the event fires with the expected payload shape and verifies the subscriber config registers the name.

## Event payload shape

```ts
{
  from: string,                          // sender phone (E.164 digits)
  message_id: string,                    // wamid
  type: "text" | "interactive" | "image" | "video" | "document" | "audio",
  text: string | null,
  caption: string | null,                // alias of text for media types
  media_ids: string[],                   // [] for non-media messages
  media_url: string | null,              // Meta presigned URL
  media_mime_type: string | null,
  reply_to_wa_message_id: string | null,
  sender_platform_id: string | null,     // for replies via same WhatsApp number
  partner_id: string | null,             // resolved via resolvePartnerByPhone
  partner_name: string | null,
  admin_user_id: string | null,          // takes precedence over partner_id
}
```

## Test plan

- [x] New: `whatsapp-message-received-event.spec.ts` — 2 tests, ~12s
  - subscriber config registers `whatsapp.message_received`
  - signed inbound text POST fires the event with expected payload shape
- [x] Regression: `whatsapp-routes.spec.ts` — all 9 existing webhook + OTP tests still pass
- [ ] Manual: once W4 lands, send a real inbound message and confirm the flow fires