### PR TITLE
fix(scripts): seed-partner-page-fixtures uses correct workflow result shape

### DIFF
--- a/apps/backend/src/scripts/seed-partner-page-fixtures.ts
+++ b/apps/backend/src/scripts/seed-partner-page-fixtures.ts
@@ -55,10 +55,10 @@ export default async function seedPartnerPageFixtures({ container }: ExecArgs) {
       },
     },
   })
-  console.log(`   → ${order1.result.id} created`)
+  console.log(`   → ${order1.result.order.id} created`)
 
   await sendInventoryOrderToPartnerWorkflow(container).run({
-    input: { inventoryOrderId: order1.result.id, partnerId: PARTNER_ID, adminNotes: "Sent to weaving partner." } as any,
+    input: { inventoryOrderId: order1.result.order.id, partnerId: PARTNER_ID, adminNotes: "Sent to weaving partner." } as any,
   })
   console.log(`   → linked to partner ${PARTNER_ID}`)
 
@@ -90,10 +90,10 @@ export default async function seedPartnerPageFixtures({ container }: ExecArgs) {
       metadata: { po_reference: "PO-2026-03-PA" },
     },
   })
-  console.log(`   → ${order2.result.id} created`)
+  console.log(`   → ${order2.result.order.id} created`)
 
   await sendInventoryOrderToPartnerWorkflow(container).run({
-    input: { inventoryOrderId: order2.result.id, partnerId: PARTNER_ID, adminNotes: "Dispatched." } as any,
+    input: { inventoryOrderId: order2.result.order.id, partnerId: PARTNER_ID, adminNotes: "Dispatched." } as any,
   })
 
   console.log("\n✓ seeded 2 inventory orders linked to partner", PARTNER_ID)


### PR DESCRIPTION
## Summary

The last 3 AWS deploys (#291, #294, #295) have all failed because the backend Docker build aborts on TS2339 errors in this seed script. That's blocked W3 (event emission) and W4 (seed visual flow) from reaching prod.

\`createInventoryOrderWorkflow\` returns \`{ order, orderLines, links }\` at \`.result\`, not the order directly. Four call sites referenced \`.result.id\` which is undefined. Fixed to \`.result.order.id\`.

## Why local builds didn't catch this

The script lives in \`apps/backend/src/scripts/\` which is excluded from the root tsconfig's strict path coverage. \`pnpm tsc --noEmit\` from the backend dir DOES catch it — I confirmed that just now. The error simply wasn't surfaced in #291's PR review because no one ran \`tsc\` from \`apps/backend/\`.

## Test plan

- [x] \`pnpm tsc --noEmit\` from \`apps/backend\` — clean for both seed-partner-page-fixtures.ts and seed-partner-product-create-flow.ts
- [ ] CI rebuilds image successfully (was the actual failure point)
- [ ] AWS deploy reaches "deploy succeeded" so W3/W4 are live