### PR TITLE
feat(visual-flows): platform-aware ai_extract_platform operation

### DIFF
--- a/apps/backend/src/modules/visual_flows/operations/ai-extract-platform.ts
+++ b/apps/backend/src/modules/visual_flows/operations/ai-extract-platform.ts
@@ -1,0 +1,192 @@
+import { z } from "@medusajs/framework/zod"
+import { generateText } from "ai"
+import { OperationDefinition, OperationContext, OperationResult } from "./types"
+import { interpolateString } from "./utils"
+import {
+  getAiPlatformForRole,
+  buildChatModel,
+} from "../../../mastra/services/ai-platforms"
+
+interface SchemaField {
+  name: string
+  type: "string" | "number" | "boolean" | "enum" | "array" | "object"
+  description?: string
+  enumValues?: string[]
+  required?: boolean
+}
+
+function buildSchemaHint(fields: SchemaField[]): string {
+  if (!fields.length) return ""
+  const lines = fields.map((f) => {
+    const typeStr =
+      f.type === "enum" ? `enum(${(f.enumValues || []).join(" | ")})` : f.type
+    const req = f.required ? " [required]" : " [optional]"
+    const desc = f.description ? ` // ${f.description}` : ""
+    return `  "${f.name}": ${typeStr}${req}${desc}`
+  })
+  return `\n\nReturn ONLY a valid JSON object — no markdown, no explanation, no code fences:\n{\n${lines.join(",\n")}\n}`
+}
+
+function extractJson(raw: string): Record<string, any> {
+  const stripped = raw
+    .replace(/^```(?:json)?\s*/im, "")
+    .replace(/```\s*$/m, "")
+    .trim()
+  try {
+    return JSON.parse(stripped)
+  } catch {}
+  const match = stripped.match(/\{[\s\S]*\}/)
+  if (match) return JSON.parse(match[0])
+  throw new Error(
+    `Model did not return valid JSON. Raw response (first 400 chars): ${raw.slice(0, 400)}`
+  )
+}
+
+/**
+ * Platform-aware structured extraction.
+ *
+ * Unlike `ai_extract` which hardcodes OpenRouter + a fixed model id, this
+ * operation resolves provider + api_key + base_url + default_model from
+ * the admin-configured External Platform with `category="ai"` and the
+ * given `metadata.role`. Switching providers (DashScope ↔ OpenRouter ↔
+ * Cloudflare) or rotating an API key becomes a UI action — no flow edit,
+ * no redeploy.
+ *
+ * Why a separate op (instead of extending ai_extract)
+ *   - Backwards-compat with existing flows that hardcode `model`.
+ *   - Clear discoverability — the flow author sees "AI Extract (Platform)"
+ *     in the picker and knows the model is admin-configured, not stamped
+ *     into the flow definition.
+ *   - Future divergence: vision / multimodal / tool use are easier to
+ *     add here without bloating the legacy op's options schema.
+ */
+export const aiExtractPlatformOperation: OperationDefinition = {
+  type: "ai_extract_platform",
+  name: "AI Extract (Platform)",
+  description:
+    "Extract structured JSON using the admin-configured AI platform for the " +
+    "given role. Provider, API key, base URL, and default model are read from " +
+    "Settings → External Platforms (category=ai).",
+  icon: "sparkles",
+  category: "integration",
+
+  optionsSchema: z.object({
+    role: z
+      .string()
+      .default("ai_search_chat")
+      .describe(
+        "AI role to resolve the platform for. Matches metadata.role on the " +
+          "external platform row (e.g. ai_search_chat, ai_product_description)."
+      ),
+    input: z
+      .string()
+      .describe("Input text sent to the model (supports {{ variable }} interpolation)"),
+    system_prompt: z
+      .string()
+      .optional()
+      .describe("Instructions for the model — what to extract and how"),
+    schema_fields: z
+      .array(
+        z.object({
+          name: z.string(),
+          type: z.enum(["string", "number", "boolean", "enum", "array", "object"]),
+          description: z.string().optional(),
+          enumValues: z.array(z.string()).optional(),
+          required: z.boolean().optional(),
+        })
+      )
+      .default([])
+      .describe("Describe the JSON fields you want extracted (appended to system prompt)"),
+    model_override: z
+      .string()
+      .optional()
+      .describe(
+        "Override the platform's default_model for this one extraction. " +
+          "Leave empty to use whatever the admin configured on the platform."
+      ),
+    fallback_on_error: z
+      .boolean()
+      .default(false)
+      .describe("Return empty object instead of failing the flow on error"),
+    mock_response: z
+      .record(z.string(), z.any())
+      .optional()
+      .describe("If set, skip the AI call and return this object directly (useful for testing)"),
+  }),
+
+  defaultOptions: {
+    role: "ai_search_chat",
+    input: "",
+    system_prompt: "",
+    schema_fields: [],
+    fallback_on_error: false,
+  },
+
+  execute: async (options, context: OperationContext): Promise<OperationResult> => {
+    if (options.mock_response) {
+      return { success: true, data: options.mock_response }
+    }
+
+    try {
+      const role = options.role || "ai_search_chat"
+      const fields: SchemaField[] = options.schema_fields || []
+      const input = interpolateString(options.input, context.dataChain)
+
+      const config = await getAiPlatformForRole(context.container as any, role)
+      if (!config) {
+        const msg = `No active AI platform configured for role "${role}". Configure one in Settings → External Platforms (category=ai, metadata.role=${role}).`
+        if (options.fallback_on_error) {
+          console.warn(`[ai_extract_platform] ${msg} (fallback_on_error → returning {})`)
+          return { success: true, data: {} }
+        }
+        return { success: false, error: msg }
+      }
+
+      const systemPrompt = [
+        options.system_prompt || "",
+        buildSchemaHint(fields),
+      ]
+        .join("")
+        .trim()
+
+      const model = buildChatModel(config, options.model_override || undefined)
+      const resolvedModelId =
+        options.model_override || config.defaultModel || "(provider hint)"
+
+      console.log("[ai_extract_platform] Calling model:", {
+        platformId: config.platformId,
+        provider: config.providerType,
+        role,
+        model: resolvedModelId,
+        inputLength: input.length,
+        inputPreview: input.slice(0, 150) + (input.length > 150 ? `… [${input.length} chars]` : ""),
+        fields: fields.map((f) => f.name),
+      })
+
+      const result = await generateText({
+        model: model as any,
+        messages: [{ role: "user", content: input }],
+        ...(systemPrompt ? { system: systemPrompt } : {}),
+      })
+
+      const object = extractJson(result.text)
+
+      console.log("[ai_extract_platform] Extraction complete:", {
+        model: resolvedModelId,
+        usage: result.usage,
+        keys: Object.keys(object),
+      })
+
+      return { success: true, data: object }
+    } catch (error: any) {
+      const message =
+        error?.responseBody ?? error?.cause?.message ?? error?.message ?? String(error)
+      console.error("[ai_extract_platform] Error:", message)
+
+      if (options.fallback_on_error) {
+        return { success: true, data: {} }
+      }
+      return { success: false, error: message, errorStack: error?.stack }
+    }
+  },
+}

--- a/apps/backend/src/modules/visual_flows/operations/index.ts
+++ b/apps/backend/src/modules/visual_flows/operations/index.ts
@@ -27,6 +27,7 @@ export { bulkCreateDataOperation } from "./bulk-create-data"
 export { bulkHttpRequestOperation } from "./bulk-http-request"
 export { bulkTriggerWorkflowOperation } from "./bulk-trigger-workflow"
 export { aiExtractOperation } from "./ai-extract"
+export { aiExtractPlatformOperation } from "./ai-extract-platform"
 export { generatePartnerDeeplinkOperation } from "./generate-partner-deeplink"
 
 // Import all operations and register them
@@ -55,6 +56,7 @@ import { bulkCreateDataOperation } from "./bulk-create-data"
 import { bulkHttpRequestOperation } from "./bulk-http-request"
 import { bulkTriggerWorkflowOperation } from "./bulk-trigger-workflow"
 import { aiExtractOperation } from "./ai-extract"
+import { aiExtractPlatformOperation } from "./ai-extract-platform"
 import { generatePartnerDeeplinkOperation } from "./generate-partner-deeplink"
 
 // Register all built-in operations
@@ -82,6 +84,7 @@ export function registerBuiltInOperations(): void {
   operationRegistry.register(triggerWorkflowOperation)
   operationRegistry.register(triggerFlowOperation)
   operationRegistry.register(aiExtractOperation)
+  operationRegistry.register(aiExtractPlatformOperation)
   
   // Utility operations
   operationRegistry.register(transformOperation)

--- a/apps/backend/src/scripts/seed-partner-product-create-flow.ts
+++ b/apps/backend/src/scripts/seed-partner-product-create-flow.ts
@@ -103,7 +103,7 @@ const FLOW_DEF = {
         id: "extract_attrs",
         type: "operation",
         position: { x: X_LEFT, y: Y_EXTRACT },
-        data: { label: "Extract Attributes from Caption", operationKey: "extract_attrs", operationType: "ai_extract" },
+        data: { label: "Extract Attributes from Caption", operationKey: "extract_attrs", operationType: "ai_extract_platform" },
       },
       {
         id: "create_draft",
@@ -166,15 +166,20 @@ const FLOW_DEF = {
     // Caption-only for v1. Output keys map 1:1 to W2's `extracted` input.
     // Title is required — if the model can't infer one, W2 throws and the
     // flow logs the failure with the partner's caption attached.
+    //
+    // Uses `ai_extract_platform` so provider / api_key / model are read from
+    // the admin-configured External Platform (Settings → External Platforms,
+    // category=ai, metadata.role=ai_search_chat). Rotating to a different
+    // provider or model is a UI action — no flow edit, no redeploy.
     {
       operation_key: "extract_attrs",
-      operation_type: "ai_extract",
+      operation_type: "ai_extract_platform",
       name: "Extract Attributes from Caption",
       sort_order: 1,
       position_x: X_LEFT,
       position_y: Y_EXTRACT,
       options: {
-        model: "google/gemini-2.5-flash-preview",
+        role: "ai_search_chat",
         input: "{{ $trigger.caption }}",
         system_prompt:
           "Extract product attributes from this textile product caption from a partner artisan. " +


### PR DESCRIPTION
## Summary

New flow operation that resolves provider + api_key + base_url + default_model from admin-configured External Platforms instead of hardcoding them in flow definitions. Unblocks W4 — the first prod test failed because the hardcoded \`google/gemini-2.5-flash-preview\` model id is no longer valid on OpenRouter.

## Problem

\`ai_extract\` hardcodes a model id in flow definitions. Two consequences:

1. **Stale model ids silently break flows.** OpenRouter retired \`google/gemini-2.5-flash-preview\` and W4's first prod run failed with \`google/gemini-2.5-flash-preview is not a valid model ID\`. The default in \`ai_extract.ts:70\` is also stale.
2. **Provider rotation requires a redeploy.** Switching from OpenRouter to DashScope or rotating an API key means editing every flow definition + a backend deploy. Should be a UI action — the admin already has \`Settings → External Platforms\` configured with 6 AI providers tagged by role.

## Solution

New \`ai_extract_platform\` operation that calls the existing \`getAiPlatformForRole(role)\` + \`buildChatModel(config)\` helpers from \`mastra/services/ai-platforms.ts\`. The flow author picks a role; the admin picks the provider + model.

| Option | Purpose |
|---|---|
| \`role\` | AI role to resolve (default \`ai_search_chat\`). Matches \`metadata.role\` on the External Platform row. |
| \`input\` | Same as ai_extract (interpolated). |
| \`system_prompt\` | Same. |
| \`schema_fields\` | Same. |
| \`model_override\` | Optional one-off override of the platform's \`default_model\`. |
| \`fallback_on_error\` | Same. |
| \`mock_response\` | Same. |

## Why a new op (not extending \`ai_extract\`)

- Backwards-compat: existing flows that hardcode \`model\` keep working.
- Discoverability: flow author sees "AI Extract (Platform)" in the picker and knows the model is admin-configured.
- Future-proofing: vision / multimodal / tool use will land on this op without bloating the legacy schema.

## Changes

- \`apps/backend/src/modules/visual_flows/operations/ai-extract-platform.ts\` — new operation (~190 LOC).
- \`apps/backend/src/modules/visual_flows/operations/index.ts\` — export + register.
- \`apps/backend/src/scripts/seed-partner-product-create-flow.ts\` — W4 flow now uses \`ai_extract_platform\` with \`role: "ai_search_chat"\` (the role that maps to the user's DashScope qwen-plus default in prod).

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [ ] Deploy reaches prod
- [ ] Delete the existing W4 flow, re-seed via \`./deploy/aws/scripts/run-backfill.sh seed-partner-product-create-flow\`
- [ ] Partner sends photo + caption to the JYT WhatsApp number
- [ ] Confirm extraction runs against DashScope (not OpenRouter), DRAFT product is created
- [ ] In admin: rotate the default \`ai_search_chat\` platform to a different provider, send another test message, confirm extraction routes to the new provider without redeploying