### PR TITLE
fix(visual-flows): add ai_extract_platform to operation_type enum + migration

### DIFF
--- a/apps/backend/src/modules/visual_flows/migrations/Migration20260531000000.ts
+++ b/apps/backend/src/modules/visual_flows/migrations/Migration20260531000000.ts
@@ -1,0 +1,28 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Adds `ai_extract_platform` to the visual_flow_operation.operation_type
+ * CHECK constraint. The new operation is implemented at
+ * `src/modules/visual_flows/operations/ai-extract-platform.ts` and reads
+ * provider / api_key / model from admin-configured External Platforms
+ * (category=ai) instead of hardcoding them in flow definitions.
+ *
+ * Without this migration, inserting a flow operation row with
+ * operation_type='ai_extract_platform' fails the CHECK and rolls back
+ * the seed.
+ */
+export class Migration20260531000000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "visual_flow_operation" drop constraint if exists "visual_flow_operation_operation_type_check";`);
+
+    this.addSql(`alter table if exists "visual_flow_operation" add constraint "visual_flow_operation_operation_type_check" check("operation_type" in ('condition', 'create_data', 'read_data', 'update_data', 'delete_data', 'bulk_update_data', 'bulk_create_data', 'bulk_http_request', 'bulk_trigger_workflow', 'http_request', 'run_script', 'send_email', 'send_whatsapp', 'notification', 'transform', 'trigger_workflow', 'trigger_flow', 'execute_code', 'sleep', 'log', 'ai_extract', 'ai_extract_platform', 'aggregate_product_analytics'));`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "visual_flow_operation" drop constraint if exists "visual_flow_operation_operation_type_check";`);
+
+    this.addSql(`alter table if exists "visual_flow_operation" add constraint "visual_flow_operation_operation_type_check" check("operation_type" in ('condition', 'create_data', 'read_data', 'update_data', 'delete_data', 'bulk_update_data', 'bulk_create_data', 'bulk_http_request', 'bulk_trigger_workflow', 'http_request', 'run_script', 'send_email', 'send_whatsapp', 'notification', 'transform', 'trigger_workflow', 'trigger_flow', 'execute_code', 'sleep', 'log', 'ai_extract', 'aggregate_product_analytics'));`);
+  }
+
+}

--- a/apps/backend/src/modules/visual_flows/models/visual-flow-operation.ts
+++ b/apps/backend/src/modules/visual_flows/models/visual-flow-operation.ts
@@ -11,7 +11,7 @@ export const VisualFlowOperation = model.define("visual_flow_operation", {
   operation_key: model.text(),
   
   // Operation type — keep in sync with the DB CHECK constraint
-  // (see migrations/Migration20260418100000.ts for the latest authoritative list).
+  // (see migrations/Migration20260531000000.ts for the latest authoritative list).
   operation_type: model.enum([
     "condition",
     "create_data",
@@ -34,6 +34,7 @@ export const VisualFlowOperation = model.define("visual_flow_operation", {
     "sleep",
     "log",
     "ai_extract",
+    "ai_extract_platform",
     "aggregate_product_analytics",
   ]),
   


### PR DESCRIPTION
## Summary

#297 added the \`ai_extract_platform\` operation handler + registered it at runtime, but missed the model enum + DB CHECK constraint update. Without this, inserting a flow operation with \`operation_type='ai_extract_platform'\` fails the CHECK and rolls back the seed.

## Changes

- \`models/visual-flow-operation.ts\` — add \`"ai_extract_platform"\` to the enum
- \`migrations/Migration20260531000000.ts\` — drop + recreate the \`visual_flow_operation_operation_type_check\` CHECK constraint with the new value, mirroring the pattern in \`Migration20260418100000.ts\`

## How prod picks this up

\`apps/backend/Dockerfile\` runs \`pnpm predeploy:force\` (\`medusa db:migrate --execute-all-links\`) on container startup, so the next deploy applies the migration before the server boots — no manual step needed.

## Test plan

- [ ] Deploy completes
- [ ] Container startup logs show \`Migration20260531000000\` applied
- [ ] Re-seed W4 flow via Fargate — operation row insert succeeds
- [ ] Send test photo + caption — extraction routes through DashScope