### PR TITLE
feat(whatsapp): accept document type in product-create flow + roadmap items

### DIFF
--- a/apps/backend/src/scripts/seed-partner-product-create-flow.ts
+++ b/apps/backend/src/scripts/seed-partner-product-create-flow.ts
@@ -97,7 +97,7 @@ const FLOW_DEF = {
         id: "eligible",
         type: "operation",
         position: { x: X_CENTER, y: Y_ELIGIBLE },
-        data: { label: "Eligible? (verified partner + image + caption)", operationKey: "eligible", operationType: "condition" },
+        data: { label: "Eligible? (verified partner + image|document + caption)", operationKey: "eligible", operationType: "condition" },
       },
       {
         id: "extract_attrs",
@@ -137,25 +137,30 @@ const FLOW_DEF = {
     // ── 1. Eligibility check ──────────────────────────────────────────────
     // All three must hold:
     //   partner_id is set        → sender resolved to a verified partner
-    //   type === "image"         → photo, not text / interactive / status
+    //   type in (image, document) → photo, OR a doc the partner used the
+    //                               file-picker for. WhatsApp clients send
+    //                               iPhone-shot photos as "document" when
+    //                               the user picks them via Files instead of
+    //                               Photos — same product intent, just the
+    //                               picker preserves original quality.
     //   caption non-empty        → partner described the product
-    // Anything else (admin DMs, text messages, status updates, unverified
+    // Everything else (admin DMs, text messages, status updates, unverified
     // numbers, photos without captions) falls through to log_skip.
     {
       operation_key: "eligible",
       operation_type: "condition",
-      name: "Eligible? (verified partner + image + caption)",
+      name: "Eligible? (verified partner + image|document + caption)",
       sort_order: 0,
       position_x: X_CENTER,
       position_y: Y_ELIGIBLE,
       options: {
         condition_mode: "expression",
         expression:
-          "$trigger.partner_id != null && $trigger.type === 'image' && ($trigger.caption || '').length > 0",
+          "$trigger.partner_id != null && ($trigger.type === 'image' || $trigger.type === 'document') && ($trigger.caption || '').length > 0",
         filter_rule: {
           _and: [
             { "$trigger.partner_id": { _null: false } },
-            { "$trigger.type": { _eq: "image" } },
+            { "$trigger.type": { _in: ["image", "document"] } },
             { "$trigger.caption": { _empty: false } },
           ],
         },

--- a/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
+++ b/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
@@ -127,6 +127,27 @@ notification routing per channel.
 through every email touchpoint, log which fire and which don't.
 **Effort:** 2-3 hours testing + fixes as we find gaps.
 
+#### 21. Fix layout issues in pagination-based panels on web-jyt
+
+The marketing site (web-jyt) has layout regressions inside the
+panels that paginate content — cards/tiles overflow or wrap
+awkwardly, controls misalign on certain breakpoints. Add this once
+we have a screenshot or page to repro against.
+**First step:** capture the broken state per breakpoint (mobile /
+tablet / desktop) on the offending panels, then fix in the
+storefront-starter (or web-jyt directly if the panel lives there).
+**Effort:** half a day depending on how many breakpoints regress.
+
+#### 22. Restore the painting from the New York Gallery open archive
+
+A painting tile from the NY Gallery (open archive section on
+jaalyantra.com) is broken — likely a missing image asset or a
+stale URL after a recent archive move.
+**First step:** open the gallery page, identify the broken
+painting, trace the asset source (S3 path / CDN URL / WordPress
+import), restore or re-link.
+**Effort:** 1-2 hours.
+
 ### Partner platform extensions
 
 #### 4. Per-order transaction fee billing per partner
@@ -294,6 +315,32 @@ contact, load into the persons module so they show on the
 **First step:** identify 1-2 source registries, hand-curate a 50-row
 CSV first to validate the schema, then write the importer.
 **Effort:** 1 day for the importer, ongoing for sourcing.
+
+#### 23. Browser extension — design moodboard clipper
+
+A Chrome / Firefox extension that logs into the JYT API (admin or
+partner auth) and lets the user clip images from any web page
+straight into a design's moodboard. Walks the DOM of the active
+tab, extracts `<img>` src + alt + nearby caption text, lets the
+user pick which to keep, and POSTs them to
+`/admin/designs/:id/moodboard` (or the partner equivalent). Same
+flow useful for collecting raw reference data — patterns, fabric
+swatches, gallery images — without the manual "save image →
+upload to admin" loop.
+
+**Why this is high-leverage:** designers already source references
+from Pinterest / Behance / museum archives. Today every reference
+takes a download + admin upload + tagging round trip. Reducing that
+to one click while browsing is a clear ergonomic win and unblocks
+faster moodboard-driven design briefs.
+
+**First step:** scaffold a minimal MV3 extension (manifest +
+popup + content script), wire admin-token storage (settings page
+with paste-the-key UX), implement `<img>` harvest on the active
+tab, then the POST. Pick which design to attach via a search
+combo box backed by `/admin/designs?q=…`.
+**Effort:** 2-3 days for a usable v1; ongoing polish for the
+selection UX, dedup, and HEIC/AVIF support.
 
 ---
 


### PR DESCRIPTION
## Summary

Bundled fix + roadmap captured during the W4 prod test.

### 1. W4 flow now accepts \`document\` type, not just \`image\`

WhatsApp clients send iPhone-shot photos as \`document\` when the user picks them via Files instead of Photos — the file picker preserves original quality, so partners reach for it deliberately. Same product intent, just a different MIME wrapper.

Both paths now flow through \`createDraftProductFromExtractionWorkflow\`, which already handles either via \`downloadAndSaveWhatsAppMedia\` (rehosts whatever Meta returns).

Condition before / after:

\`\`\`diff
- { "$trigger.type": { _eq: "image" } },
+ { "$trigger.type": { _in: ["image", "document"] } },
\`\`\`

### 2. Roadmap captures (PLATFORM_ROADMAP_2026_05.md)

- **#21** — Fix layout issues in pagination-based panels on web-jyt
- **#22** — Restore the painting from the New York Gallery open archive
- **#23** — Browser extension for design moodboard clipping (auth → extract \`<img>\` from active tab → POST to design moodboard)

## Test plan

- [ ] Deploy + auto re-seed
- [ ] Partner sends a photo via WhatsApp's Photos picker — DRAFT product created (image path)
- [ ] Partner sends the same shot via WhatsApp's Files picker — DRAFT product created (document path)
- [ ] Partner sends a text-only message — log_skip fires, no spurious draft

## Note on the underlying "workflow not found" error

The seed referenced \`create-draft-product-from-extraction\` but W2's workflow file lived on an unmerged branch (#292) — only the doc (#293) had landed. #292 was merged just before this PR; this PR rides on top.