### PR TITLE
fix(whatsapp): single reply for product-create + absolute admin URL

### DIFF
--- a/apps/backend/src/workflows/whatsapp/create-draft-product-from-extraction.ts
+++ b/apps/backend/src/workflows/whatsapp/create-draft-product-from-extraction.ts
@@ -303,7 +303,13 @@ export const createDraftProductFromExtractionWorkflow = createWorkflow(
         ({ created, media }): CreateDraftProductFromExtractionResult => ({
           product_id: created.product_id,
           product_title: created.product_title,
-          admin_url: `/app/products/${created.product_id}`,
+          // Build an absolute admin URL when MEDUSA_BACKEND_URL is set so the
+          // partner can tap the link from the WhatsApp reply directly. Falls
+          // back to the relative path for local dev and tests where no
+          // public hostname is configured.
+          admin_url: process.env.MEDUSA_BACKEND_URL
+            ? `${process.env.MEDUSA_BACKEND_URL.replace(/\/$/, "")}/app/products/${created.product_id}`
+            : `/app/products/${created.product_id}`,
           rehosted_image_urls: media.image_urls,
           status: "draft",
         })

--- a/apps/backend/src/workflows/whatsapp/whatsapp-message-handler.ts
+++ b/apps/backend/src/workflows/whatsapp/whatsapp-message-handler.ts
@@ -480,14 +480,35 @@ export async function handleIncomingMessage(
           // No tap, no single run to auto-match, no shared folder.
           // File is in the per-partner WhatsApp catchall — admin will
           // see it in the inbox and assign appropriately.
-          const hint =
-            autoResolveReason === "multiple"
-              ? "You have several runs in progress — tap *📸 Add Media* on the specific run, then send the photo."
-              : "We've received your file and will sort it shortly. (Tap *📸 Add Media* on a run to attach a photo to a specific run.)"
-          await whatsapp.sendTextMessage(
-            message.from,
-            `📥 Received. ${hint}`
-          )
+          //
+          // Two branches depending on whether the partner gave a caption:
+          //
+          //   With caption  → suppress this reply entirely. That's the W4
+          //                   entry condition; the "Partner WhatsApp —
+          //                   Product Create" visual flow owns the reply
+          //                   and sends "✅ Draft product created — open
+          //                   in admin" via its notify_partner step.
+          //                   Without this guard the partner sees two
+          //                   messages for one inbound.
+          //
+          //   Without caption → nudge toward W4. The legacy "Tap 📸 Add
+          //                   Media on a run" hint is misleading now —
+          //                   it points at the production-run lifecycle,
+          //                   not product create. Tell partners how to
+          //                   turn this into a draft if that's what they
+          //                   wanted; otherwise admin still sees the file
+          //                   in their inbox.
+          const hasCaption = typeof message.text === "string" && message.text.trim().length > 0
+          if (!hasCaption) {
+            const hint =
+              autoResolveReason === "multiple"
+                ? "You have several runs in progress — tap *📸 Add Media* on the specific run, then send the photo."
+                : "Add a caption (e.g. \"Saree silk ₹4500\") and re-send to create a draft product on your storefront. Otherwise admin will sort it from your inbox."
+            await whatsapp.sendTextMessage(
+              message.from,
+              `📥 Received. ${hint}`
+            )
+          }
         }
       } catch (e: any) {
         console.warn("[whatsapp-handler] Failed to save media:", e.message)


### PR DESCRIPTION
## Summary

Two regressions discovered in the first live W4 partner test:

### 1. Two replies for one inbound message

A verified partner sending image + caption got both:

> 📥 Received. We've received your file and will sort it shortly. (Tap *📸 Add Media* on a run to attach a photo to a specific run.)

and:

> ✅ Draft product created: Blouse

The first is from \`handleIncomingMessage\`'s catchall when no production-run context exists. The second is from W4's \`notify_partner\` step. Both fire because the webhook calls the partner handler AND emits \`whatsapp.message_received\` in parallel.

**Fix:** suppress the catchall when the media has a caption (W4 entry condition). Captionless media still falls through to the nudge so partners aren't left wondering whether their photo arrived.

### 2. Relative admin URL in WhatsApp reply

\`admin_url\` was being built as \`/app/products/<id>\` which arrives as a non-clickable string in WhatsApp.

**Fix:** when \`MEDUSA_BACKEND_URL\` is set, stamp the full \`https://v3.jaalyantra.com/app/products/<id>\` so partners can tap to open admin. Falls back to the relative path for local dev / tests.

## Test plan

- [ ] Deploy
- [ ] Partner sends photo + caption — single reply with clickable admin link
- [ ] Partner sends photo WITHOUT caption — still receives the "📥 Received" nudge
- [ ] Partner sends text-only — log_skip fires (no spurious draft, no spurious reply)