### PR TITLE
feat(whatsapp): W5 Confirm/Cancel + 24h window guard + language persist

### DIFF
--- a/apps/backend/src/modules/visual_flows/operations/send-whatsapp.ts
+++ b/apps/backend/src/modules/visual_flows/operations/send-whatsapp.ts
@@ -45,7 +45,7 @@ export const sendWhatsAppOperation: OperationDefinition = {
         "SocialPlatform row id to send from. Omit to auto-route by country code."
       ),
 
-    mode: z.enum(["template", "text", "image"]).default("template"),
+    mode: z.enum(["template", "text", "image", "interactive"]).default("template"),
 
     // Template-mode fields
     template_name: z
@@ -105,6 +105,45 @@ export const sendWhatsAppOperation: OperationDefinition = {
         'When mode="image" and image_url resolves empty, exit cleanly via the ' +
           '"failure" branch instead of erroring. Lets flows send images only when ' +
           "the source data has one, without an upstream condition node."
+      ),
+
+    // Interactive-mode fields (mode="interactive")
+    // Renders a reply-buttons message: body text + 1-3 tap buttons. The
+    // button id arrives back on the webhook as message.buttonReplyId so a
+    // downstream handler (e.g. whatsapp-message-handler.ts) can dispatch.
+    // Like text + image, this only delivers inside Meta's 24-hour window —
+    // pair with skip_if_outside_window when sending unprompted.
+    interactive_body: z
+      .string()
+      .optional()
+      .describe(
+        'Required when mode="interactive". Body text shown above the buttons. ' +
+          "Supports {{ }} interpolation. Max 1024 chars per Meta."
+      ),
+    interactive_buttons: z
+      .array(
+        z.object({
+          id: z.string().describe("Button id (max 256 chars). Returned on the webhook as buttonReplyId."),
+          title: z.string().describe("Button label shown to recipient (max 20 chars)."),
+        })
+      )
+      .optional()
+      .describe(
+        'Required when mode="interactive". 1-3 reply buttons (Meta caps at 3). ' +
+          "Each id + title supports {{ }} interpolation."
+      ),
+
+    // 24-hour conversation window guard. Applies to text / image / interactive
+    // (all free-form modes Meta blocks outside the window). Templates are
+    // unaffected — they're explicitly designed to initiate conversations.
+    skip_if_outside_window: z
+      .boolean()
+      .default(false)
+      .describe(
+        "When true and mode is text|image|interactive, skip the send if the " +
+          "conversation has no inbound message in the last 24 hours. Prevents " +
+          'silent "outside window" rejections from Meta when the recipient ' +
+          "hasn't talked to us recently — common for unprompted follow-ups."
       ),
 
     // Audit / dedup
@@ -289,6 +328,46 @@ export const sendWhatsAppOperation: OperationDefinition = {
       //   f. On failure, update the preflight to status="failed" with
       //      the error in metadata, then re-throw to the outer catch
       //      which returns success: false.
+      // 2c. 24-hour conversation window guard.
+      //
+      // Templates can initiate conversations. Free-form modes (text /
+      // image / interactive) can ONLY be delivered while the recipient's
+      // 24-hour "service window" is open — i.e. they messaged us within
+      // the last 24 hours. Outside that window Meta rejects with code
+      // 131047 and the call wastes an API hit + writes a noisy failed
+      // row.
+      //
+      // When the caller opts in via skip_if_outside_window, look up the
+      // most recent inbound messaging_message for this recipient and
+      // exit cleanly via the failure branch if none in the last 24h.
+      if (
+        options.skip_if_outside_window &&
+        (mode === "text" || mode === "image" || mode === "interactive")
+      ) {
+        const lastInbound = await findLastInboundForRecipient(
+          messagingService,
+          resolvedPartnerId,
+          to
+        )
+        const windowMs = 24 * 60 * 60 * 1000
+        const insideWindow =
+          lastInbound && lastInbound.created_at
+            ? Date.now() - new Date(lastInbound.created_at).getTime() < windowMs
+            : false
+        if (!insideWindow) {
+          return {
+            success: true,
+            data: {
+              sent: false,
+              reason: "outside_24h_window",
+              last_inbound_at: lastInbound?.created_at ?? null,
+              mode,
+              _branch: "failure",
+            },
+          }
+        }
+      }
+
       let waResponse: any = null
       let messageType: "template" | "text" | "media" = "template"
       let contentPreview = ""
@@ -513,6 +592,74 @@ export const sendWhatsAppOperation: OperationDefinition = {
         })
         messageType = "media"
         contentPreview = `[image] ${caption || imageUrl}`.slice(0, 500)
+      } else if (mode === "interactive") {
+        // Interactive reply-buttons message (1-3 tap buttons).
+        // Button ids returned on the inbound webhook as
+        // message.buttonReplyId; downstream handlers dispatch on the id
+        // prefix (e.g. "wa_pc_confirm:..." for the W4 product-create
+        // confirm flow).
+        const interactiveBody = options.interactive_body
+          ? interpolateString(options.interactive_body, dataChain).slice(0, 1024)
+          : ""
+        if (!interactiveBody.trim()) {
+          return failed('mode="interactive" requires interactive_body')
+        }
+
+        const buttonsRaw: unknown = interpolateVariables(
+          options.interactive_buttons,
+          dataChain
+        )
+        const buttons = Array.isArray(buttonsRaw)
+          ? buttonsRaw
+              .map((b: any) => ({
+                id: typeof b?.id === "string" ? interpolateString(b.id, dataChain).trim() : "",
+                title: typeof b?.title === "string" ? interpolateString(b.title, dataChain).trim() : "",
+              }))
+              .filter((b) => b.id && b.title)
+          : []
+        if (buttons.length === 0) {
+          return failed('mode="interactive" requires at least one interactive_buttons entry')
+        }
+        if (buttons.length > 3) {
+          return failed('mode="interactive" supports at most 3 buttons (Meta cap)')
+        }
+
+        const triggerType =
+          (typeof dataChain?.$trigger?.event === "string"
+            ? dataChain.$trigger.event
+            : null) || `visual_flow:${context.flowId}`
+
+        waResponse = await whatsapp.sendInteractiveMessage(
+          to,
+          {
+            type: "button",
+            body: { text: interactiveBody },
+            action: {
+              buttons: buttons.slice(0, 3).map((b) => ({
+                type: "reply",
+                reply: { id: b.id.slice(0, 256), title: b.title.slice(0, 20) },
+              })),
+            },
+          } as any,
+          {
+            template: null,
+            partner_id: resolvedPartnerId,
+            resource_type: contextType ?? null,
+            resource_id: contextId ?? null,
+            trigger_type: triggerType,
+            idempotency_key: contextType && contextId ? `${contextType}:${contextId}:interactive` : null,
+            data: {
+              mode: "interactive",
+              flow_id: context.flowId,
+              execution_id: context.executionId,
+              operation_key: context.operationKey,
+              platform_id: platform?.id ?? null,
+              button_ids: buttons.map((b) => b.id),
+            },
+          }
+        )
+        messageType = "text"
+        contentPreview = `[buttons] ${interactiveBody} (${buttons.map((b) => b.title).join(" | ")})`.slice(0, 500)
       } else {
         const body = options.body ? interpolateString(options.body, dataChain) : ""
         if (!body.trim()) {
@@ -688,6 +835,41 @@ function stripDedupSuffix(id: string | null | undefined): string | null {
   if (!id) return null
   const idx = id.indexOf(":reminder:")
   return idx >= 0 ? id.slice(0, idx) : id
+}
+
+/**
+ * Find the most recent inbound message for a recipient phone (and partner
+ * if known), used by skip_if_outside_window to compute Meta's 24-hour
+ * service window.
+ *
+ * We query messages tagged with this conversation's partner_id + phone via
+ * the underlying conversation row, falling back to phone-only when no
+ * partner is set. Returns the message row (with created_at) or null.
+ */
+async function findLastInboundForRecipient(
+  messagingService: any,
+  partnerId: string | null,
+  phone: string
+): Promise<{ created_at: Date | string } | null> {
+  try {
+    // Find conversations for this recipient. Phone is the most stable
+    // anchor; partner_id narrows in multi-tenant cases.
+    const convFilter: Record<string, any> = { phone_number: phone }
+    if (partnerId) convFilter.partner_id = partnerId
+    const [convs] = await messagingService.listAndCountMessagingConversations(
+      convFilter,
+      { take: 5, order: { last_message_at: "DESC" } }
+    )
+    if (!convs?.length) return null
+    const conversationIds = convs.map((c: any) => c.id)
+    const [rows] = await messagingService.listAndCountMessagingMessages(
+      { conversation_id: conversationIds, direction: "inbound" },
+      { take: 1, order: { created_at: "DESC" } }
+    )
+    return rows?.[0] ?? null
+  } catch {
+    return null
+  }
 }
 
 async function findRecentOutboundByContext(

--- a/apps/backend/src/scripts/backfill-partner-admin-language-from-conversations.ts
+++ b/apps/backend/src/scripts/backfill-partner-admin-language-from-conversations.ts
@@ -1,0 +1,133 @@
+/**
+ * Backfill: copy conversation.metadata.language onto partner_admin.preferred_language
+ *
+ * Why
+ *   Until #fix/whatsapp-language-persist, the WhatsApp onboarding flow
+ *   stored a partner's tapped language choice ("हिंदी" / "English") only
+ *   in messaging_conversation.metadata.language. Outbound visual flows
+ *   (assignment, payment-status, reminders) read
+ *   partner.admins[*].preferred_language to pick the template language,
+ *   so every Hindi-selected partner kept getting English templates.
+ *
+ *   New onboarding writes both sides going forward. This script
+ *   retro-fixes partners who already onboarded.
+ *
+ * Strategy
+ *   1. List every messaging_conversation with metadata.language set
+ *   2. Resolve the partner + their admins
+ *   3. Match admin by phone vs conversation.phone_number first
+ *   4. If no phone match, apply to every admin on that partner
+ *   5. Skip admins whose preferred_language already matches (idempotent)
+ *
+ * Run locally
+ *   npx medusa exec ./src/scripts/backfill-partner-admin-language-from-conversations.ts
+ *
+ * Run on AWS Fargate
+ *   ./deploy/aws/scripts/run-backfill.sh backfill-partner-admin-language-from-conversations
+ *
+ * Dry run
+ *   DRY_RUN=1 npx medusa exec ./src/scripts/backfill-partner-admin-language-from-conversations.ts
+ */
+
+import { MESSAGING_MODULE } from "../modules/messaging"
+import { PARTNER_MODULE } from "../modules/partner"
+
+export default async function backfillPartnerAdminLanguage({
+  container,
+}: {
+  container: any
+}) {
+  const messagingService = container.resolve(MESSAGING_MODULE) as any
+  const partnerService = container.resolve(PARTNER_MODULE) as any
+  const dryRun = process.env.DRY_RUN === "1"
+
+  console.log(`[backfill] dry_run=${dryRun}`)
+
+  // 1. Pull every active conversation. The DAL doesn't filter by JSON
+  //    metadata keys directly, so we pull and filter in JS. We page in
+  //    batches of 100 to keep memory bounded.
+  const PAGE = 100
+  let offset = 0
+  let scanned = 0
+  let updated = 0
+  let skippedAlreadyMatched = 0
+  let skippedNoLang = 0
+  let skippedNoPartner = 0
+
+  while (true) {
+    const [convs] = await messagingService.listAndCountMessagingConversations(
+      {},
+      { take: PAGE, skip: offset, order: { created_at: "DESC" } }
+    )
+    if (!convs?.length) break
+    scanned += convs.length
+
+    for (const conv of convs) {
+      const lang = (conv?.metadata as any)?.language
+      if (lang !== "hi" && lang !== "en") {
+        skippedNoLang++
+        continue
+      }
+
+      const partnerId = conv.partner_id
+      if (!partnerId) {
+        skippedNoPartner++
+        continue
+      }
+
+      const [partners] = await partnerService.listAndCountPartners(
+        { id: partnerId },
+        { take: 1, relations: ["admins"] }
+      )
+      const partner = partners?.[0]
+      if (!partner) {
+        skippedNoPartner++
+        continue
+      }
+
+      const phone = String(conv.phone_number || "").replace(/[^0-9]/g, "")
+      const admins = Array.isArray(partner.admins) ? partner.admins : []
+
+      const matched = admins.find((a: any) => {
+        if (!a?.phone) return false
+        const norm = String(a.phone).replace(/[^0-9]/g, "")
+        return !!norm && (norm === phone || norm.endsWith(phone) || phone.endsWith(norm))
+      })
+
+      const targets = (matched ? [matched] : admins).filter(
+        (a: any) => a?.id && a.preferred_language !== lang
+      )
+      if (!targets.length) {
+        skippedAlreadyMatched++
+        continue
+      }
+
+      console.log(
+        `[backfill] partner=${partnerId} lang=${lang} phone=${phone} ` +
+          `admins=${targets.map((a: any) => a.id).join(",")} ` +
+          `${matched ? "(phone-matched)" : "(all admins fallback)"}`
+      )
+
+      if (!dryRun) {
+        await Promise.all(
+          targets.map((a: any) =>
+            partnerService.updatePartnerAdmins({ id: a.id, preferred_language: lang })
+          )
+        )
+      }
+      updated += targets.length
+    }
+
+    if (convs.length < PAGE) break
+    offset += PAGE
+  }
+
+  console.log(`[backfill] done`, {
+    dry_run: dryRun,
+    scanned_conversations: scanned,
+    admins_updated: updated,
+    skipped_already_matched: skippedAlreadyMatched,
+    skipped_no_language: skippedNoLang,
+    skipped_no_partner: skippedNoPartner,
+  })
+}

--- a/apps/backend/src/scripts/seed-partner-product-create-flow.ts
+++ b/apps/backend/src/scripts/seed-partner-product-create-flow.ts
@@ -248,11 +248,21 @@ const FLOW_DEF = {
       options: {
         to:         "{{ $trigger.from }}",
         partner_id: "{{ $trigger.partner_id }}",
-        mode:       "text",
-        body:
-          "✅ Draft product created: *{{ create_draft.result.product_title }}*\n\n" +
-          "Open in admin to review price, add description, and publish:\n" +
-          "{{ create_draft.result.admin_url }}",
+        // W5 — interactive Confirm / Cancel buttons. The partner just
+        // sent us a photo so we're inside Meta's 24-hour window; no
+        // skip_if_outside_window needed. Button taps return on the
+        // inbound webhook with buttonReplyId = "wa_pc_confirm:<id>" or
+        // "wa_pc_cancel:<id>", which whatsapp-message-handler dispatches
+        // to handleProductCreateButtonReply.
+        mode:       "interactive",
+        interactive_body:
+          "✅ Draft product created: *{{ create_draft.result.product_title }}*\n" +
+          "Admin: {{ create_draft.result.admin_url }}\n\n" +
+          "Tap *Confirm* to publish, or *Cancel* to remove the draft.",
+        interactive_buttons: [
+          { id: "wa_pc_confirm:{{ create_draft.result.product_id }}", title: "✅ Confirm" },
+          { id: "wa_pc_cancel:{{ create_draft.result.product_id }}",  title: "🗑️ Cancel" },
+        ],
         context_type: "whatsapp_product_create",
         context_id:   "{{ $trigger.message_id }}",
         dedup_window_minutes: 60,

--- a/apps/backend/src/scripts/seed-partner-run-whatsapp-flow.ts
+++ b/apps/backend/src/scripts/seed-partner-run-whatsapp-flow.ts
@@ -529,12 +529,19 @@ const FLOW_DEF = {
         // to swallow it as a duplicate.
         dedup_window_minutes: 0,
         require_partner: true,
+        // Image mode is free-form too — Meta blocks it outside the 24-hour
+        // window for partners who haven't messaged us recently. Skip
+        // silently instead of generating noisy failed sends.
+        skip_if_outside_window: true,
       },
     },
 
     // ── 6f. Send the portal link as plain text (no-image branch) ──────────
-    // The template send opened the 24-hour session window, so a follow-up
-    // text delivers without needing another approved template.
+    // Free-form text only delivers inside Meta's 24-hour conversation
+    // window — i.e. when the partner messaged us within the last day.
+    // skip_if_outside_window guards against silent rejections for partners
+    // we haven't heard from recently. The utility template above always
+    // lands; this follow-up is best-effort.
     {
       operation_key: "send_link_text",
       operation_type: "send_whatsapp",
@@ -553,6 +560,7 @@ const FLOW_DEF = {
         context_id: "{{ resolve_template.context_id }}",
         dedup_window_minutes: 0,
         require_partner: true,
+        skip_if_outside_window: true,
       },
     },
 

--- a/apps/backend/src/workflows/whatsapp/whatsapp-message-handler.ts
+++ b/apps/backend/src/workflows/whatsapp/whatsapp-message-handler.ts
@@ -270,6 +270,16 @@ export async function handleIncomingMessage(
         language: lang,
         onboarded: true,
       })
+      // Also persist onto the partner_admin row(s). The conversation
+      // metadata is the source of truth for the *handler* but outbound
+      // visual flows (seed-partner-run-whatsapp-flow.ts, seed-partner-
+      // payment-status-flow.ts, …) read partner.admins[*].preferred_language
+      // when resolving template language. Without this write, partners
+      // who tap "हिंदी" still get every subsequent template in English.
+      // Match priority: admin whose phone equals message.from first; fall
+      // back to all admins on this partner so we don't miss when the
+      // selecting number isn't yet stored on a specific admin row.
+      await persistPartnerAdminLanguage(scope, partner.partnerId, message.from, lang)
       await sendWelcomeCommands(scope, whatsapp, message.from, partner.partnerId, partner.adminName, lang)
       return { handled: true, action: `language_selected_${lang}` }
     }
@@ -294,6 +304,19 @@ export async function handleIncomingMessage(
   let runId = ""
 
   if (message.type === "interactive" && message.buttonReplyId) {
+    // W5 — product-create Confirm / Cancel taps. Distinct prefix so the
+    // production-run dispatch below doesn't try to parse them. Exit
+    // immediately once handled; the product status mutation IS the
+    // intent — no follow-on action needed.
+    if (message.buttonReplyId.startsWith("wa_pc_")) {
+      return await handleProductCreateButtonReply(
+        scope,
+        whatsapp,
+        message,
+        partner
+      )
+    }
+
     // Precedence:
     //   1. Template quick-reply buttons → arrive as the localized title
     //      (e.g. "✅ Accept" / "✅ स्वीकार करें") with no runId embedded.
@@ -1691,5 +1714,170 @@ async function persistOutboundMessage(
   // Notification Module audit row was already written by WhatsAppService
   // sendRequest() — the wrapper at the top of handleIncomingMessage passes
   // a default audit context to the underlying send.
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Language preference persistence
+//
+// When a partner taps "हिंदी" / "English" on the onboarding language
+// prompt, we used to store the choice only in conversation.metadata.
+// Outbound visual flows (assignment, payment-status, reminders) look at
+// partner.admins[*].preferred_language to pick the template language,
+// and that field stayed NULL — so Hindi-selected partners still got
+// every template in English.
+//
+// Strategy:
+//   1. Find the admin whose phone matches the inbound message.from.
+//   2. If none matches (admins commonly have no phone on file), apply
+//      to every admin on the partner so we don't silently miss.
+//   3. Use updatePartnerAdmins for each match.
+//
+// Failures are non-fatal — the conversation.metadata.language write
+// already gave us the correct handler-side behaviour; this is purely a
+// hardening pass on the outbound side.
+async function persistPartnerAdminLanguage(
+  scope: any,
+  partnerId: string,
+  fromPhone: string,
+  lang: string
+): Promise<void> {
+  try {
+    const partnerService = scope.resolve(PARTNER_MODULE) as any
+    const [partners] = await partnerService.listAndCountPartners(
+      { id: partnerId },
+      { take: 1, relations: ["admins"] }
+    )
+    const partner = partners?.[0]
+    if (!partner) return
+
+    const normalizedFrom = (fromPhone || "").replace(/[^0-9]/g, "")
+    const admins = Array.isArray(partner.admins) ? partner.admins : []
+
+    // Phone-matched admin wins. Fallback: apply to all admins so we
+    // don't depend on phone being set (it commonly isn't).
+    const matched = admins.find((a: any) => {
+      if (!a?.phone) return false
+      const norm = String(a.phone).replace(/[^0-9]/g, "")
+      return !!norm && (norm === normalizedFrom || norm.endsWith(normalizedFrom) || normalizedFrom.endsWith(norm))
+    })
+
+    const targets = matched ? [matched] : admins
+    await Promise.all(
+      targets
+        .filter((a: any) => a && a.id && a.preferred_language !== lang)
+        .map((a: any) =>
+          partnerService.updatePartnerAdmins({ id: a.id, preferred_language: lang })
+        )
+    )
+  } catch (e: any) {
+    console.warn("[whatsapp-handler] Failed to persist partner admin language:", e?.message)
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// W5 — product create Confirm / Cancel button handler
+//
+// W4's notify_partner step sends a buttons message after a DRAFT product
+// is auto-created from the partner's WhatsApp photo + caption. The
+// buttons are wa_pc_confirm:<product_id> / wa_pc_cancel:<product_id>.
+// On tap, we mutate the product directly here — no separate workflow
+// indirection. Edit is deferred to v2 (would need conversation-metadata
+// state tracking for the next text-message intent).
+//
+// Idempotency: if the partner taps Confirm twice the second tap is a
+// no-op with a friendly message. If they tap Cancel after Confirm
+// (product already PUBLISHED), refuse so the live storefront product
+// isn't accidentally deleted.
+async function handleProductCreateButtonReply(
+  scope: any,
+  whatsapp: any,
+  message: IncomingMessage,
+  partner: { partnerId: string; adminName: string }
+): Promise<HandlerResult> {
+  const raw = (message.buttonReplyId || "").replace(/^wa_pc_/, "")
+  const colon = raw.indexOf(":")
+  const action = colon >= 0 ? raw.slice(0, colon) : raw
+  const productId = colon >= 0 ? raw.slice(colon + 1) : ""
+
+  if (!productId) {
+    await whatsapp.sendTextMessage(
+      message.from,
+      "Sorry — I couldn't tell which product this button is for."
+    )
+    return { handled: true, action: "product_create_button_no_id" }
+  }
+
+  const { Modules } = await import("@medusajs/framework/utils")
+  const productService = scope.resolve(Modules.PRODUCT) as any
+
+  let product: any
+  try {
+    product = await productService.retrieveProduct(productId)
+  } catch {
+    await whatsapp.sendTextMessage(
+      message.from,
+      "That product is no longer available."
+    )
+    return { handled: true, action: "product_create_button_not_found" }
+  }
+
+  const adminBase = (process.env.MEDUSA_BACKEND_URL || "").replace(/\/$/, "")
+  const adminLink = adminBase ? `${adminBase}/app/products/${productId}` : `/app/products/${productId}`
+
+  if (action === "confirm") {
+    if (product.status === "published") {
+      await whatsapp.sendTextMessage(
+        message.from,
+        `Already published: *${product.title}*\n${adminLink}`
+      )
+      return { handled: true, action: "product_create_confirm_already_published" }
+    }
+    try {
+      await productService.updateProducts({ id: productId, status: "published" })
+    } catch (e: any) {
+      await whatsapp.sendTextMessage(
+        message.from,
+        `Couldn't publish *${product.title}* — ${e?.message || "unknown error"}. Try again from admin: ${adminLink}`
+      )
+      return { handled: true, action: "product_create_confirm_failed" }
+    }
+    await whatsapp.sendTextMessage(
+      message.from,
+      `✅ Published: *${product.title}*\n${adminLink}`
+    )
+    return { handled: true, action: "product_create_confirmed" }
+  }
+
+  if (action === "cancel") {
+    if (product.status === "published") {
+      // Don't auto-delete live products. Partner can still delete from
+      // admin if they really mean it.
+      await whatsapp.sendTextMessage(
+        message.from,
+        `*${product.title}* is already published. Open admin to unpublish or delete:\n${adminLink}`
+      )
+      return { handled: true, action: "product_create_cancel_after_publish" }
+    }
+    try {
+      await productService.deleteProducts([productId])
+    } catch (e: any) {
+      await whatsapp.sendTextMessage(
+        message.from,
+        `Couldn't remove *${product.title}* — ${e?.message || "unknown error"}.`
+      )
+      return { handled: true, action: "product_create_cancel_failed" }
+    }
+    await whatsapp.sendTextMessage(
+      message.from,
+      `🗑️ Cancelled — *${product.title}* removed.`
+    )
+    return { handled: true, action: "product_create_cancelled" }
+  }
+
+  await whatsapp.sendTextMessage(
+    message.from,
+    "Unrecognised action — open admin to manage this product."
+  )
+  return { handled: true, action: "product_create_button_unknown" }
 }
 


### PR DESCRIPTION
## Summary

Three related fixes bundled (all touch the partner WhatsApp send path):

### 1. W5 — Confirm / Cancel buttons on product create

Replaces W4's text "Draft created" reply with an interactive buttons message. Partner taps:

- **Confirm** → flips product DRAFT → PUBLISHED + reply with admin link
- **Cancel** → deletes the draft + reply confirming removal

Idempotency: refuses to delete an already-published product, refuses to publish twice. Edit deferred to v2 (needs conversation-metadata state machine for the next-text-message intent).

| Layer | Change |
|---|---|
| \`send_whatsapp\` op | New \`mode: "interactive"\` with \`interactive_body\` + \`interactive_buttons[]\` (1-3 buttons, Meta caps at 3) |
| \`whatsapp-message-handler\` | New \`handleProductCreateButtonReply\` dispatched on \`wa_pc_*\` button ids, BEFORE the existing production-run parser |
| \`seed-partner-product-create-flow\` | \`notify_partner\` switches from \`mode: text\` to \`mode: interactive\` with Confirm + Cancel buttons |

### 2. 24-hour window guard for free-form sends

**Bug investigation:** \`seed-partner-run-whatsapp-flow\` ships text + image deep-link follow-ups right after every production-run template. Templates always land (utility templates are window-exempt). Free-form modes can ONLY deliver inside Meta's 24-hour conversation window — when the partner has messaged us recently. For most partners that's never → silent rejection, noisy failed rows.

**Fix:** new \`skip_if_outside_window\` option on \`send_whatsapp\`. When \`true\` on a free-form mode (text / image / interactive), the op queries the most-recent inbound message for the recipient and exits cleanly via the failure branch if none within 24h — no Meta API call, no log spam. Templates are unaffected. Set to \`true\` on \`send_link_text\` and \`send_image\` in the partner-run flow.

### 3. Language preference now persists to \`partner_admin\`

**Bug investigation:** Partner Sharlho (\`01K4PJMNMNRGMK0ZXMKBBDZDGD\`) tapped हिंदी on the onboarding language prompt but kept getting English templates. Both admins had \`preferred_language: None\`. Tracing: the language-selection handler writes the choice ONLY to \`conversation.metadata.language\`. Outbound visual flows look at \`partner.admins[*].preferred_language\` — which stays NULL — so they fall through to the English default.

**Fix:**

- Code path: \`handleIncomingMessage\` now also calls \`partnerService.updatePartnerAdmins\` to set \`preferred_language\` on the matching admin (by phone) or all admins on the partner if no phone match.
- Backfill: \`backfill-partner-admin-language-from-conversations.ts\` walks every \`messaging_conversation.metadata.language\` and forward-copies to admins missing the value. Idempotent. Run with \`DRY_RUN=1\` first if you want to see what it'd touch.

## Test plan

- [ ] Deploy
- [ ] Re-seed W4 flow (notify_partner now uses interactive mode)
- [ ] Partner sends photo + caption → single message with Confirm / Cancel buttons + clickable admin link
- [ ] Tap Confirm → product flips to PUBLISHED, partner gets confirmation
- [ ] Tap Cancel → draft deleted, partner gets confirmation
- [ ] Run backfill (DRY_RUN=1 first to scope, then for real)
  \`\`\`bash
  DRY_RUN=1 ./deploy/aws/scripts/run-backfill.sh backfill-partner-admin-language-from-conversations
  ./deploy/aws/scripts/run-backfill.sh backfill-partner-admin-language-from-conversations
  \`\`\`
- [ ] Verify Sharlho's admins now show \`preferred_language: hi\`
- [ ] Next production-run template to Sharlho lands in Hindi
- [ ] Partner-run text deep-link to a long-silent partner: skipped silently, not a noisy failure