### PR TITLE
docs: WhatsApp W5 + ai_extract_platform + window guard + language persist

### DIFF
--- a/apps/docs/docs/implementation/workflows/ai-extract-platform-operation.md
+++ b/apps/docs/docs/implementation/workflows/ai-extract-platform-operation.md
@@ -1,0 +1,140 @@
+---
+title: "AI Extract Platform Operation"
+sidebar_label: "AI Extract (Platform)"
+sidebar_position: 13
+---
+
+# AI Extract Platform Operation
+
+`ai_extract_platform` is a visual-flow operation that extracts structured JSON from a text input using an admin-configured AI provider. Unlike the original [`ai_extract`](./ai-extract-operation) operation, which hardcodes the model id in the flow definition, this operation reads the provider, API key, base URL, and default model from the External Platforms registry at runtime.
+
+**Source:** `apps/backend/src/modules/visual_flows/operations/ai-extract-platform.ts`
+**Helpers:** `apps/backend/src/mastra/services/ai-platforms.ts` (`getAiPlatformForRole`, `buildChatModel`)
+
+---
+
+## Why this exists
+
+The first prod test of the WhatsApp product-create flow blew up with:
+
+```
+google/gemini-2.5-flash-preview is not a valid model ID
+```
+
+That model id had been hardcoded as the default in both `ai_extract.ts` and every flow seed that used it. OpenRouter retired the preview; the seed had no way to know. More fundamentally, every flow that called an LLM had to:
+
+- Know its provider's name ahead of time
+- Bake the model id into the flow definition
+- Require a backend redeploy to rotate API keys or switch providers
+
+Rotating any of that should be a UI action. `ai_extract_platform` makes it one.
+
+---
+
+## How it resolves the provider
+
+At execution time:
+
+1. Read the `role` option (defaults to `ai_search_chat`)
+2. Call `getAiPlatformForRole(container, role)` — the helper queries the SocialPlatform module for the row with `category = "ai"`, `status = "active"`, `metadata.role = <role>`, and `metadata.is_default = true`
+3. Decrypt the API key from `api_config.api_key_encrypted` via the encryption module
+4. Resolve `base_url`: `api_config.base_url` → platform column → provider-specific default
+5. Resolve the model: `model_override` (call-site) → `api_config.default_model` → provider-specific hint
+6. Call `buildChatModel(config, modelOverride)` to get an AI SDK chat model bound to the right provider
+7. Run `generateText({ model, system, messages })`, then `JSON.parse` the response
+
+If no platform is configured for the requested role, the operation returns a clean error (or empty object if `fallback_on_error: true`) — no Meta-style 500 leaking through.
+
+### Currently configured AI platforms (prod, 2026-06-01)
+
+| Platform | Role | Provider | Default model | is_default |
+|---|---|---|---|---|
+| DashScope chat | `ai_search_chat` | dashscope | `qwen-plus` | ✅ |
+| Cloudflare AI chat | `ai_search_chat` | cloudflare | `@cf/meta/llama-3.1-8b-instruct` | — |
+| OpenRouter | `ai_search_chat` | openrouter | `meta-llama/llama-3.3-70b-instruct:free` | — |
+| DashScope embed | `ai_search_embed` | dashscope | `text-embedding-v3` | ✅ |
+| Cloudflare AI embed | `ai_search_embed` | cloudflare | `@cf/baai/bge-base-en-v1.5` | — |
+| FAL image gen | `ai_image_gen` | fal | — | ✅ |
+
+W4's `extract_attrs` step uses `role: "ai_search_chat"` → currently DashScope's `qwen-plus`. Switching extraction to OpenRouter is "toggle `is_default` on the OpenRouter row in admin" — no flow edit, no redeploy.
+
+---
+
+## Options
+
+| Option | Required | Default | Notes |
+|---|---|---|---|
+| `role` | ✅ | `ai_search_chat` | AI role to resolve. Matches `metadata.role` on the External Platform row. |
+| `input` | ✅ | — | Text sent to the model. Supports `{{ }}` interpolation. |
+| `system_prompt` | — | — | Instructions appended to the auto-generated schema hint. |
+| `schema_fields` | — | `[]` | Array of `{ name, type, description?, enumValues?, required? }`. Renders as a JSON shape hint at the end of the system prompt. |
+| `model_override` | — | platform default | One-off model id at the call site. Useful for A/B-ing without admin changes. |
+| `fallback_on_error` | — | `false` | When `true`, return `{}` on any failure instead of branching to `failure`. |
+| `mock_response` | — | — | If set, short-circuits the AI call and returns this object. Used in tests. |
+
+### Schema field example
+
+```ts
+schema_fields: [
+  { name: "title",           type: "string", description: "Clean product title (proper case, no price)", required: true },
+  { name: "suggested_price", type: "number", description: "Numeric price in partner's currency (strip ₹/Rs/$)" },
+  { name: "fabric_type",     type: "string", description: "Fabric (silk, cotton, linen, khadi, wool, …) — omit if not mentioned" },
+  { name: "colors",          type: "array",  description: "Array of color names the partner wrote. Empty if none." },
+]
+```
+
+These get appended to the system prompt as:
+
+```
+Return ONLY a valid JSON object — no markdown, no explanation, no code fences:
+{
+  "title": string [required] // Clean product title (proper case, no price),
+  "suggested_price": number [optional] // Numeric price in partner's currency (strip ₹/Rs/$),
+  "fabric_type": string [optional] // Fabric (silk, cotton, linen, khadi, wool, …) — omit if not mentioned,
+  "colors": array [optional] // Array of color names the partner wrote. Empty if none.
+}
+```
+
+---
+
+## When to pick `ai_extract` vs `ai_extract_platform`
+
+| | `ai_extract` (legacy) | `ai_extract_platform` |
+|---|---|---|
+| Model selection | Hardcoded in flow JSON | Admin UI |
+| Provider rotation | Flow edit + redeploy | Toggle `is_default` |
+| Multimodal support | Text-only | Text-only today; multimodal planned for this op |
+| Mastra eval workflow | ✅ via `use_mastra_eval` | Not yet — drop in if needed |
+| Backwards compat | Existing flows | New flows |
+
+**Use `ai_extract_platform` for all new flows.** The legacy `ai_extract` is kept to avoid breaking flows that still hardcode a model — it's not deprecated, just shadowed.
+
+---
+
+## DB enum + migration discipline
+
+`visual_flow_operation.operation_type` is a Postgres `CHECK` constraint, not a plain `text` column. Adding a new operation requires:
+
+1. Add the new value to the `model.enum([...])` in `apps/backend/src/modules/visual_flows/models/visual-flow-operation.ts`
+2. Write a migration that drops + recreates the `CHECK` with the new value **alongside every value the previous migrations added**. Missing a value (e.g. `generate_partner_deeplink` added in `Migration20260420090000`) makes the migration fail validation against existing rows.
+
+The migration for `ai_extract_platform` is `Migration20260531000000.ts` — copy that as a template for the next op.
+
+> **Open follow-up:** the recurring enum+migration friction is what motivated the visual-flow generalisation discussion (Tier A / Tier B in the platform notes). When that lands we can drop the CHECK and skip migrations entirely for new ops.
+
+---
+
+## Test plan
+
+Until a dedicated integration spec lands:
+
+- W4's flow execution log is the easiest end-to-end check: send a WhatsApp photo+caption, open `/app/visual-flows/<id>/executions/<exec_id>`, inspect the `extract_attrs` step's output for the extracted JSON shape
+- For provider rotation: toggle a different `ai_search_chat` platform to `is_default: true` in admin → External Platforms, re-fire the flow, confirm the execution log's `platform_id` matches the new platform
+
+---
+
+## Related
+
+- [AI Extract Operation](./ai-extract-operation) — the legacy hardcoded-model variant
+- [WhatsApp Product Create — Draft Workflow](./whatsapp-create-draft-product) — current consumer of this operation
+- `apps/backend/src/mastra/services/ai-platforms.ts` — provider resolution + AI SDK adapter

--- a/apps/docs/docs/implementation/workflows/whatsapp-create-draft-product.md
+++ b/apps/docs/docs/implementation/workflows/whatsapp-create-draft-product.md
@@ -48,7 +48,8 @@ Partner sends 📷 + "Saree silk ₹4500"
 │     ──────────────────────────────────────╮    │
 │     │ createDraftProductFromExtraction…   │ ← THIS DOC
 │     ──────────────────────────────────────╯    │
-│  5. send_whatsapp: Confirm/Edit/Cancel buttons │
+│  5. send_whatsapp (interactive):               │
+│     ✅ Confirm  /  🗑️ Cancel              ✅W5 │
 └────────────────────────────────────────────────┘
                       │
                       ▼
@@ -307,15 +308,44 @@ pnpm test:integration:http:shared ./integration-tests/http/whatsapp-create-draft
 | W1 — media rehost helper | ✅ shipped (pre-existing) | `downloadAndSaveWhatsAppMedia` at `whatsapp-media-helper.ts:239` |
 | **W2 — this workflow** | ✅ shipped | `createDraftProductFromExtractionWorkflow` |
 | W3 — webhook emits `whatsapp.message_received` event | ✅ shipped 2026-05-31 | `whatsapp/route.ts` emits after parse + identity resolution; subscriber registers the name |
-| W4 — `seed-partner-product-create-flow.ts` | ✅ shipped 2026-05-31 | Single shared flow; fires for any verified-WhatsApp partner. Seed via `run-backfill.sh seed-partner-product-create-flow` |
-| W5 — Confirm/Edit/Cancel handling | ⏳ next | Button-reply handler flips DRAFT → PUBLISHED, deletes on cancel |
-| W6 — Polish: caption-only edges, photo-only edges, dedup verify | ⏳ | |
+| W4 — `seed-partner-product-create-flow.ts` | ✅ shipped 2026-05-31 | Single shared flow; fires for any verified-WhatsApp partner. Seed via `run-backfill.sh seed-partner-product-create-flow`. Now uses `ai_extract_platform` (provider/model from admin-configured platforms, no hardcoded model id) |
+| W5 — Confirm / Cancel interactive buttons | ✅ shipped 2026-06-01 | Flow reply switched from `mode: "text"` to `mode: "interactive"`; tap-Confirm flips DRAFT → PUBLISHED, tap-Cancel deletes. `handleProductCreateButtonReply` dispatches on `wa_pc_confirm:*` / `wa_pc_cancel:*` ids before the production-run parser. Edit deferred to W6. |
+| W6 — Polish | ⏳ next | Edit button (free-text correction with conversation state), caption-only edges, photo-only edges, dedup verify, vision support on `ai_extract_platform` |
+
+---
+
+## W5 — Confirm / Cancel button taps
+
+After the workflow returns a `prod_…`, the flow's `notify_partner` step now sends an `interactive` message with two reply buttons instead of a plain text. The button ids encode the action and the product id:
+
+| Button | id (sent by Meta) | Server action |
+|---|---|---|
+| ✅ Confirm | `wa_pc_confirm:prod_…` | `productService.updateProducts({ id, status: "published" })` + reply with the admin link |
+| 🗑️ Cancel | `wa_pc_cancel:prod_…` | `productService.deleteProducts([id])` + reply confirming removal |
+
+When a tap arrives, the inbound webhook lands in `handleIncomingMessage` (`apps/backend/src/workflows/whatsapp/whatsapp-message-handler.ts`). Before the existing production-run lifecycle parser sees the message, a new prefix check routes anything starting with `wa_pc_` to `handleProductCreateButtonReply`. That handler resolves the product, validates state, and mutates.
+
+### Idempotency rules
+
+- Confirm tap on an **already-published** product → no-op, friendly "Already published" reply
+- Cancel tap on an **already-published** product → refuses to delete (live storefront product); replies with the admin link instead. Partner can still unpublish from admin.
+- Either tap with a missing/deleted product → "no longer available" reply
+
+### Edit (deferred to W6)
+
+Adding a third button (`Edit`) needs a small state machine: stash `pending_product_edit_id` on `messaging_conversation.metadata`, then route the next free-text from that partner into an "update title / price" handler rather than the standard intent dispatcher. Skipped for v1 — partners can resend a new photo + caption today, which creates a fresh draft. Worth the build once we see real usage volume.
+
+### Meta classification
+
+`mode: "interactive"` is **free-form** from Meta's perspective — same 24-hour window restriction as text and image. That's fine here because the flow fires immediately after the partner sent us a photo, which opens the window. The `send_whatsapp` operation's new `skip_if_outside_window` option would block the send if we ever tried to use interactive buttons unprompted — see [WhatsApp Send Modes & 24h Window](./whatsapp-send-modes-and-window-guard).
 
 ---
 
 ## Related
 
-- [AI Extract Operation](./ai-extract-operation) — the prior node that produces the `extracted` payload this workflow consumes
+- [AI Extract Operation](./ai-extract-operation) — the original text-only operation; superseded by `ai_extract_platform` for new flows
+- [AI Extract Platform Operation](./ai-extract-platform-operation) — provider / model resolved from admin-configured External Platforms; what W4's `extract_attrs` node uses today
+- [WhatsApp Send Modes & 24h Window](./whatsapp-send-modes-and-window-guard) — when free-form messages deliver, when they get silently skipped
 - [Partner WhatsApp — Production Run Flow](./whatsapp-partner-run-flow) — the outbound counterpart; same engine, opposite direction
 - `apps/docs/notes/WHATSAPP_PRODUCT_CREATE.md` — the design doc with the full proposed message flow + tradeoff matrix between handler-only and visual-flow paths
 - `apps/backend/src/workflows/whatsapp/whatsapp-media-helper.ts` — the rehost helper this workflow calls

--- a/apps/docs/docs/implementation/workflows/whatsapp-send-modes-and-window-guard.md
+++ b/apps/docs/docs/implementation/workflows/whatsapp-send-modes-and-window-guard.md
@@ -1,0 +1,109 @@
+---
+title: "WhatsApp Send Modes & 24-hour Window Guard"
+sidebar_label: "WhatsApp Send Modes / Window"
+sidebar_position: 14
+---
+
+# WhatsApp Send Modes & 24-hour Window Guard
+
+The `send_whatsapp` visual-flow operation supports four send modes. Three of them are **free-form** in Meta's terms and only deliver inside the recipient's 24-hour "service window". This page explains which mode delivers when, and how the `skip_if_outside_window` option closes the silent-failure gap that bit us on the partner-run flow.
+
+**Source:** `apps/backend/src/modules/visual_flows/operations/send-whatsapp.ts`
+
+---
+
+## Meta's 24-hour conversation window
+
+Whenever a recipient sends *any* WhatsApp message to a business number, a 24-hour "customer service window" opens for that recipient. During the window the business can reply with any free-form content. After 24 hours of recipient silence, Meta blocks free-form sends and only **utility / marketing / authentication templates** are allowed through.
+
+Sending free-form outside the window doesn't queue or retry — Meta returns error code `131047` ("re-engagement required") and the message simply does not arrive.
+
+| Send mode | Wire-level shape | Free-form? | Delivers outside 24h? |
+|---|---|---|---|
+| `template` | `type: "template"` with a Meta-approved `template_name` | No | ✅ Yes — templates are designed to initiate conversations |
+| `text` | `type: "text"` | Yes | ❌ No |
+| `image` | `type: "image"` with caption | Yes | ❌ No |
+| `interactive` | `type: "interactive"` with reply buttons | Yes | ❌ No |
+
+The W5 Confirm / Cancel buttons in the [Product Create flow](./whatsapp-create-draft-product) use `mode: "interactive"`. That's fine for W4 because the flow only fires when the partner just sent us a photo — we're inside the window by definition. Using `interactive` for an *unprompted* nudge (e.g. "tap to view your weekly summary") would fail silently outside the window — for that you'd need a Meta template with quick-reply buttons, which is a separate approval flow.
+
+---
+
+## The bug `skip_if_outside_window` fixes
+
+`seed-partner-run-whatsapp-flow.ts` ships two follow-up messages after every production-run template:
+
+1. `send_image` — design photo with a deep-link caption (image branch)
+2. `send_link_text` — plain text with the deep-link (no-image fallback)
+
+Both are free-form. The template above them always lands because utility templates are window-exempt. But for any partner who hadn't messaged us in the last 24h (most of them on a fresh assignment), the follow-up silently failed. Operators only saw:
+
+- A clean template send in the messaging inbox
+- A `messaging_message` row marked `failed` for the follow-up
+- No partner-visible deep-link
+
+Worse, it ate a Meta API call and wrote a noisy audit row every time.
+
+---
+
+## How the guard works
+
+When the caller sets `skip_if_outside_window: true` on a free-form mode, the operation runs an extra check before any Meta call:
+
+1. Query `messaging_conversation` rows for `(partner_id, phone_number)` (phone is the stable anchor; partner_id narrows when known)
+2. Pick the most-recent matching conversation, then query its `messaging_message` rows with `direction: "inbound"`, ordered by `created_at DESC`, take 1
+3. Compute `Date.now() - lastInbound.created_at`. If under 24h, proceed with the send. Otherwise, exit cleanly via the `failure` branch with:
+
+```json
+{
+  "sent": false,
+  "reason": "outside_24h_window",
+  "last_inbound_at": "2026-05-15T08:12:00Z",
+  "mode": "text",
+  "_branch": "failure"
+}
+```
+
+No Meta API call. No failed `messaging_message` row. The execution log still records the skip with its reason, so an operator querying for "why didn't this send" gets a clear answer.
+
+`template` mode is unaffected — the guard short-circuits when `mode === "template"`.
+
+---
+
+## When to set the option
+
+| Send pattern | `skip_if_outside_window` |
+|---|---|
+| Reply to an inbound message (W4 notify_partner, partner-handler text replies) | `false` (default) — you're inside the window by definition |
+| Unprompted follow-up after a template (partner-run `send_link_text`, `send_image`) | **`true`** — most recipients are outside the window |
+| Daily reminder text follow-up | **`true`** |
+| Admin alert / test send | `false` — admin numbers don't need the guard |
+
+The default is `false` so existing flows that knew they were inside the window keep working without edits.
+
+---
+
+## Operations currently using the guard (prod, 2026-06-01)
+
+| Flow | Operation | Mode |
+|---|---|---|
+| Partner WhatsApp — Production Run (all events) | `send_image` | `image` |
+| Partner WhatsApp — Production Run (all events) | `send_link_text` | `text` |
+
+Both were patched in place via `PUT /admin/visual-flows/<id>` rather than re-seeded — the production-run flow has been tuned in the admin editor and a re-seed would have wiped those tweaks.
+
+---
+
+## Future improvements
+
+- Cache the `last_inbound` lookup per `(partner_id, phone)` for a few seconds within an execution context — currently every guarded send fires its own DB query.
+- Expose a `failure_reason: "outside_24h_window"` distinct branch handle so a flow can route to a template fallback automatically ("we couldn't reach you — tap to reopen the conversation").
+- Optionally write a `messaging_message` row marked `skipped_outside_window: true` for traceability without the noise of `status: "failed"`.
+
+---
+
+## Related
+
+- [Partner WhatsApp — Production Run Flow](./whatsapp-partner-run-flow) — the flow with the guarded follow-up steps
+- [WhatsApp Product Create — Draft Workflow](./whatsapp-create-draft-product) — uses `mode: "interactive"` inside the window
+- `apps/backend/src/modules/visual_flows/operations/send-whatsapp.ts` — the operation itself

--- a/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
+++ b/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
@@ -171,6 +171,44 @@ exist in admin, what needs to be added to partners. Use the
 PARTNER_API_PARITY.md recipe.
 **Effort:** 2-3 days end-to-end, plus tests.
 
+#### 24. Standardise partner-ui orders onto the Medusa `order` entity
+
+Today partner-ui surfaces two parallel order concepts — `design_orders`
+and `inventory_orders` — each with its own modules, APIs, partner
+routes, lifecycle workflows, and UI screens. The underlying intent
+(partner receives work, partner does work, partner gets paid) is the
+same; only the artifact differs (a design vs a raw-material PO). The
+fragmentation costs us in three places: partners learn two mental
+models, status/notification logic duplicates, and every new
+cross-cutting feature (FX, tax, partner statements, audit) ships
+twice.
+
+Consolidate by promoting Medusa's core `order` entity to the single
+home for partner work-orders, distinguishing the two flavours by
+`order.metadata.kind in (design, inventory)` (or a typed extension
+column). Keep the existing route paths as shims that translate to the
+unified order under the hood — no breaking changes for live
+storefronts or the partner SDK — while folding the actions
+(accept / decline / mark shipped / etc.) into a single set of UI
+panels driven off `order.status` + `order.metadata.kind`.
+
+**Why now:** it's pre-condition work for several backlog items —
+per-order transaction fee billing (#4), partner statements, and the
+FX/region propagation work all need a single order surface to act on
+rather than two parallel ones.
+
+**First step:** write a small mapping doc — for each
+`design_order` and `inventory_order` field, where it lives on
+`order` + `order_line_item` + `order.metadata`. Identify the gaps
+(fields that don't fit cleanly) and decide column extension vs.
+metadata. Then a thin shim PR that creates one new
+`order.metadata.kind` order alongside an existing legacy create, to
+validate the model without removing anything yet.
+
+**Effort:** 1 day for the mapping + shim, then 3-5 days to migrate
+the partner-ui panels onto the unified surface and quietly
+back-migrate existing rows.
+
 #### 8. Menu / submenu wizard for partner-ui personalization
 
 Today every partner sees the same sidebar. Wizard lets the partner

--- a/apps/docs/notes/WHATSAPP_LANGUAGE_PERSISTENCE.md
+++ b/apps/docs/notes/WHATSAPP_LANGUAGE_PERSISTENCE.md
@@ -1,0 +1,80 @@
+# WhatsApp Language Preference — Dual Write + Backfill
+
+> Status: **SHIPPED** 2026-06-01.
+> Companion: implementation lives in
+> `apps/backend/src/workflows/whatsapp/whatsapp-message-handler.ts`
+> (handler write) + `apps/backend/src/scripts/backfill-partner-admin-language-from-conversations.ts`
+> (one-off retro fix).
+
+## The bug
+
+Partner taps "हिंदी" / "English" on the onboarding language prompt over WhatsApp. The choice was being written **only** to `messaging_conversation.metadata.language`. The handler itself read from there and worked fine — replies sent inside `handleIncomingMessage` came out in the right language.
+
+But every **outbound visual flow** (production-run assignment, payment-status updates, daily reminders) resolves the template language by reading `partner.admins[*].preferred_language`. That column stayed `NULL` because nothing ever wrote to it. So:
+
+- Sharlho (partner `01K4PJMNMNRGMK0ZXMKBBDZDGD`) tapped Hindi months ago
+- Every subsequent template (assignment, paid, reminder) landed in English
+- No error in any log — the send went through cleanly, just in the wrong language
+
+Discovered when an operator noticed Hindi-confirmed partners still getting English production-run templates. Took a while to find because `conversation.metadata.language` was correctly `"hi"` the whole time — the bug was the missing second write, not the captured preference.
+
+## Fix
+
+Two parts.
+
+### 1. Dual write at selection time
+
+`handleIncomingMessage` already had a branch for `lang_hi` / `lang_en` button taps that wrote `conversation.metadata.language`. Add a call to `persistPartnerAdminLanguage(scope, partnerId, fromPhone, lang)` right after, which:
+
+1. Loads the partner with its admins
+2. Tries to match an admin by phone (admin.phone vs message.from, normalized)
+3. If no phone match (common — admins often don't have phone on file), applies to **all admins** on the partner so we don't silently miss
+4. Calls `partnerService.updatePartnerAdmins({ id, preferred_language: lang })` for each match
+5. Skips admins whose `preferred_language` already equals `lang` (idempotent)
+
+Failures are non-fatal and logged. The conversation.metadata write already gave correct handler-side behaviour; this is purely a hardening pass on the outbound side.
+
+### 2. Backfill script for already-onboarded partners
+
+Code fix only helps partners who go through onboarding *after* deploy. Sharlho and any other historical Hindi/English tappers still had `NULL` admin rows.
+
+`backfill-partner-admin-language-from-conversations.ts` walks every conversation row, applies the same dual-write logic (phone match → fallback to all admins), and skips rows where the language was never set or the admin already has it.
+
+Idempotent. Re-runnable. Honors `DRY_RUN=1`.
+
+### Run on AWS Fargate
+
+```bash
+# Scope first
+DRY_RUN=1 ./deploy/aws/scripts/run-backfill.sh backfill-partner-admin-language-from-conversations
+
+# Apply
+./deploy/aws/scripts/run-backfill.sh backfill-partner-admin-language-from-conversations
+```
+
+## Backfill results — 2026-06-01
+
+| Metric | Count |
+|---|---|
+| Conversations scanned | 9 |
+| Admins updated | **3** |
+| Skipped — already correct | 3 |
+| Skipped — no language saved | 4 |
+| Skipped — no partner | 0 |
+
+Updated:
+
+- Partner `01K4PJMNMNRGMK0ZXMKBBDZDGD` (Sharlho) — 2 admins → `hi` *(the original report)*
+- Partner `01KNY6B5ERNDXJ5118EK72KFTV` — 1 admin → `en`
+
+Both used the "all admins fallback" path (no admin row had a phone matching the conversation phone).
+
+## Why the phone-matching fallback is broad
+
+Most partner admins don't have `phone` set today — onboarding only collects `email` + `first_name` + `last_name`. Until that changes, "match by phone, else apply to every admin on this partner" is the safer default. The downside is multi-admin partners where two humans share one phone get the same language — fine for the current cohort, worth revisiting if a partner adds a second admin with a different language preference.
+
+## Open follow-ups
+
+- Stop showing the language prompt to partners who already have `preferred_language` set on at least one admin (today they get re-prompted on every fresh conversation). Cheap win.
+- Add a `Settings → Language` button to the partner-ui so partners can change later without re-onboarding. Currently the only path is a fresh language-tap on the prompt.
+- Surface the current language on the partner detail page in admin so operators can verify without inspecting JSON.

--- a/apps/docs/notes/WHATSAPP_PRODUCT_CREATE.md
+++ b/apps/docs/notes/WHATSAPP_PRODUCT_CREATE.md
@@ -1,20 +1,27 @@
 # WhatsApp Product Creation for Partners
 
-> Status: **IN PROGRESS** — W1 already shipped; W2 (workflow + tests) landed 2026-05-30.
-> Date: 2026-05-29 (design), 2026-05-30 (W2 update)
+> Status: **W1–W5 SHIPPED (2026-06-01)** — partner-facing end-to-end works in prod. W6 polish next.
+> Date: 2026-05-29 (design), 2026-05-30 (W2), 2026-05-31 (W3+W4), 2026-06-01 (W5)
 > Owner: Saransh
-> Companion to `WEBHOOK_SETUP_GUIDE.md` (Meta WhatsApp wiring) and `PARTNER_API_PARITY.md` (the quick-create endpoint we reuse).
+> Implementation: `apps/docs/docs/implementation/workflows/whatsapp-create-draft-product.md`
+> Companion notes: `WHATSAPP_LANGUAGE_PERSISTENCE.md` (dual-write fix surfaced during W5 prod test), `WEBHOOK_SETUP_GUIDE.md` (Meta wiring), `PARTNER_API_PARITY.md`.
 
 ## Build progress
 
 | PR | Status | Notes |
 |----|--------|-------|
 | W1 — media rehost helper | ✅ **already shipped** | `downloadAndSaveWhatsAppMedia` at `apps/backend/src/workflows/whatsapp/whatsapp-media-helper.ts:239`. Handles Bearer auth on Meta presigned URL + base64 round-trip for file-s3 provider (the second one had bitten us before — well-documented in the source). |
-| W2 — `createDraftProductFromExtractionWorkflow` | ✅ shipped 2026-05-30 | `apps/backend/src/workflows/whatsapp/create-draft-product-from-extraction.ts`. 4 steps: resolve store → rehost media → build product input → invoke `createProductsWorkflow` with `status: DRAFT`. 4 integration tests passing. |
-| W3 — webhook emits `whatsapp.message_received` event + subscriber registration | ⏳ next |
-| W4 — `seed-partner-product-create-flow.ts` for one pilot partner | ⏳ |
-| W5 — Confirm/Edit/Cancel flow + roll-out | ⏳ |
-| W6 — Polish (caption-only, photo-only, dedupe verify) | ⏳ |
+| W2 — `createDraftProductFromExtractionWorkflow` (#292) | ✅ shipped 2026-05-30 | `apps/backend/src/workflows/whatsapp/create-draft-product-from-extraction.ts`. 4 steps: resolve store → rehost media → build product input → invoke `createProductsWorkflow` with `status: DRAFT`. 4 integration tests passing. |
+| W3 — webhook emits `whatsapp.message_received` (#294) | ✅ shipped 2026-05-31 | `whatsapp/route.ts` emits after parse + identity resolution; `visual-flow-event-trigger` subscriber registers the event name. |
+| W4 — `seed-partner-product-create-flow.ts` (#295) | ✅ shipped 2026-05-31 | Single shared flow; fires for any verified-WhatsApp partner. Eligibility now accepts `image` OR `document` (the iPhone-via-Files-picker path). Seeded via `run-backfill.sh seed-partner-product-create-flow`. Live flow id `vflow_01KT1BYKKZA5C0KYTQ4GC27QEM`. |
+| W4.1 — `ai_extract_platform` operation (#297, #298, #299) | ✅ shipped 2026-05-31 | Provider / model resolved from admin-configured External Platforms (no hardcoded model id). W4's `extract_attrs` step uses `role: ai_search_chat` → currently DashScope `qwen-plus`. |
+| W5 — Confirm / Cancel interactive buttons (#302) | ✅ shipped 2026-06-01 | `mode: "interactive"` added to `send_whatsapp`; `handleProductCreateButtonReply` dispatches `wa_pc_confirm:*` / `wa_pc_cancel:*` taps before the production-run parser. Tap Confirm flips DRAFT → PUBLISHED; tap Cancel deletes. Refuses to delete an already-published product. |
+| W6 — Polish | ⏳ next | Edit button (stateful "send a corrected line" flow), vision support on `ai_extract_platform`, photo-only / caption-only edges, dedup verify. |
+
+## Cross-cutting fixes shipped during W5 prod test
+
+- **24h window guard** (#302) — `seed-partner-run-whatsapp-flow.ts`'s text + image deep-link follow-ups were silently failing for partners outside Meta's 24-hour service window. Added `skip_if_outside_window` option to `send_whatsapp`; set `true` on `send_image` and `send_link_text`. Patched live flow in place. See `apps/docs/docs/implementation/workflows/whatsapp-send-modes-and-window-guard.md`.
+- **Language preference dual-write** (#302) — Partner taps "हिंदी" → was saved to `conversation.metadata.language` only, not `partner_admin.preferred_language`. Every outbound template fell back to English. Fixed at write time + ran a backfill across existing conversations. See `WHATSAPP_LANGUAGE_PERSISTENCE.md`.
 
 ## Goal
 


### PR DESCRIPTION
## Summary

Articulates everything shipped across the W3-W5 sprint so future sessions (and humans) can pick up cold.

## Changes

### Implementation docs (`apps/docs/docs/implementation/workflows/`)
- **`whatsapp-create-draft-product.md`** — flips W5 to shipped in the roadmap, adds a new "W5 — Confirm / Cancel button taps" section with the id schema (`wa_pc_confirm:…` / `wa_pc_cancel:…`), idempotency rules, and a Meta-classification note explaining why `mode: "interactive"` is fine for W4 but would fail unprompted.
- **`ai-extract-platform-operation.md`** (new) — full reference for the platform-aware extraction op shipped in #297-#299. Covers why it exists (the `google/gemini-2.5-flash-preview` retirement that bit us), how it resolves the platform, the currently-configured prod platforms (DashScope qwen-plus is the default `ai_search_chat`), options reference, when to pick it over the legacy `ai_extract`, and the DB enum + migration discipline that almost wedged the prod deploy.
- **`whatsapp-send-modes-and-window-guard.md`** (new) — Meta's 24-hour window rules, send-mode table (template / text / image / interactive), the silent-failure bug `skip_if_outside_window` fixes on production-run text follow-ups, where it's enabled in prod today.

### Notes (`apps/docs/notes/`)
- **`WHATSAPP_LANGUAGE_PERSISTENCE.md`** (new) — the dual-write fix surfaced when Sharlho kept getting English templates despite tapping Hindi. Covers the diagnosis (conversation.metadata was correct, partner_admin.preferred_language stayed NULL), the handler-side write + backfill script, and the 2026-06-01 backfill results (3 admins updated).
- **`WHATSAPP_PRODUCT_CREATE.md`** — status table refreshed to current state, cross-cutting fixes called out, links to the three new implementation docs.
- **`PLATFORM_ROADMAP_2026_05.md`** — rolls in the four roadmap items added earlier this session (#21 web-jyt pagination, #22 NY Gallery painting, #23 browser extension moodboard clipper, #24 standardise on Medusa order entity) so the roadmap is current.

## Test plan

- [ ] Docusaurus build succeeds in CI (Vercel preview)
- [ ] Sidebar shows the two new pages under Implementation → Workflows at positions 13 and 14
- [ ] All cross-links resolve (verified by hand: `whatsapp-create-draft-product` → both new docs; `WHATSAPP_PRODUCT_CREATE` notes → all three new docs)