### PR TITLE
feat(ci): build-only workflow_dispatch + IMAGE_TAG run-backfill override

### DIFF
--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -21,6 +21,20 @@ on:
       - 'deploy/aws/**'
       - '.github/workflows/deploy-to-aws.yml'
   workflow_dispatch:
+    inputs:
+      deploy_services:
+        # When false (the default for dispatch), the workflow builds +
+        # mirrors the image only — copilot svc deploy is skipped. This
+        # is the safe path for branch dispatches: the sha-tagged image
+        # ends up in GHCR + ECR so run-backfill.sh can target it for a
+        # one-off task, but the live medusa-server / medusa-worker
+        # services keep running whatever :latest already pointed at.
+        #
+        # Push-to-main always deploys (the `if` on the deploy jobs
+        # below treats push events as deploy_services=true).
+        description: "Also deploy medusa-server + medusa-worker (push-to-main always does this)"
+        type: boolean
+        default: false
 
 # Serialize deploys on the same branch — but don't cancel a deploy
 # mid-flight; if you push twice in quick succession, the second waits.
@@ -117,6 +131,17 @@ jobs:
             echo "|---|---|"
             echo "| Tags | \`${{ steps.meta.outputs.tags }}\` |"
             echo "| SHA-tag | \`${{ steps.meta.outputs.version }}\` |"
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.deploy_services }}" != "true" ]; then
+              echo ""
+              echo "**Build-only dispatch.** Live services were not redeployed."
+              echo ""
+              echo "To run a backfill against this image:"
+              echo ""
+              echo "\`\`\`bash"
+              echo "IMAGE_TAG=${{ steps.meta.outputs.version }} DRY_RUN=1 FOLLOW=1 \\"
+              echo "  ./deploy/aws/scripts/run-backfill.sh <script-name>"
+              echo "\`\`\`"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
   # ─────────────────────────────────────────────────────────────────────────
@@ -163,9 +188,21 @@ jobs:
 
           docker pull "$SRC"
           docker tag  "$SRC" "$DST_SHA"
-          docker tag  "$SRC" "$DST_LATEST"
           docker push "$DST_SHA"
-          docker push "$DST_LATEST"
+
+          # Only move :latest forward when this build is a push to main.
+          # A branch dispatch must NOT rewrite :latest, because the
+          # medusa-server + medusa-worker task definitions reference
+          # :latest, and ECS would pull the branch image on the next
+          # task replacement (autoscale, host drain, etc.) — silently
+          # deploying unmerged code.
+          if [ "${GITHUB_REF}" = "refs/heads/main" ]; then
+            docker tag  "$SRC" "$DST_LATEST"
+            docker push "$DST_LATEST"
+            echo "Tagged ECR :latest"
+          else
+            echo "Skipping :latest tag (ref=${GITHUB_REF}); only sha-tag was pushed."
+          fi
 
           echo "ecr_image=${DST_SHA}" >> "$GITHUB_OUTPUT"
 
@@ -177,6 +214,11 @@ jobs:
     name: Deploy medusa-server
     runs-on: ubuntu-latest
     needs: [build-and-push, mirror-to-ecr]
+    # Push to main always deploys. Manual dispatch only deploys when
+    # the operator explicitly checked `deploy_services`. Branch
+    # dispatches default to build-only so they don't roll the prod
+    # service.
+    if: github.event_name == 'push' || inputs.deploy_services == true
     steps:
       - uses: actions/checkout@v4
 
@@ -210,6 +252,8 @@ jobs:
     name: Deploy medusa-worker
     runs-on: ubuntu-latest
     needs: [build-and-push, mirror-to-ecr]
+    # See deploy-server above for the rationale.
+    if: github.event_name == 'push' || inputs.deploy_services == true
     steps:
       - uses: actions/checkout@v4
 

--- a/apps/docs/notes/CI_BUILD_ONLY_DISPATCH.md
+++ b/apps/docs/notes/CI_BUILD_ONLY_DISPATCH.md
@@ -1,0 +1,152 @@
+# CI build-only dispatch — dry-run a branch image against prod
+
+> How to run a backfill or one-off `medusa exec` script from a branch
+> against prod RDS **without** deploying the branch to the live
+> medusa-server / medusa-worker services. The path uses
+> `workflow_dispatch` on the deploy workflow and an `IMAGE_TAG`
+> override on `run-backfill.sh`.
+
+---
+
+## When to use this
+
+Whenever you've added a new `src/scripts/foo.ts` and want to verify
+its dry-run output against the real prod database before merging.
+Examples:
+
+- The 0A region/currency/FX backfill (`PLATFORM_0A_RUNBOOK.md`).
+- Any future one-shot migration / data-correction script that lives
+  in `apps/backend/src/scripts/`.
+
+The CI flow exists because the prod medusa-server image only rebuilds
+on push to `main`. Without this dispatch, the only way to dry-run a
+new script in prod is to merge first — which is fine in practice
+(scripts are dry-run aware + idempotent), but this dispatch is the
+"see real counts before merge" path when you want it.
+
+---
+
+## End-to-end flow
+
+### 1. Push your branch with the new script
+
+```bash
+git checkout -b feat/my-backfill
+# … add apps/backend/src/scripts/my-backfill.ts …
+git push -u origin feat/my-backfill
+```
+
+### 2. Manually trigger the deploy workflow (build-only)
+
+GitHub UI: **Actions → Deploy to AWS ECS → Run workflow**.
+
+- **Branch**: pick your feature branch.
+- **`deploy_services`**: leave **unchecked** (default `false`).
+
+This builds the image, mirrors it to ECR as `sha-<commit-hash>`, and
+**skips** `copilot svc deploy` for both medusa-server and
+medusa-worker. The live services keep running whatever they were
+running before.
+
+CLI equivalent:
+
+```bash
+gh workflow run deploy-to-aws.yml --ref feat/my-backfill \
+  -f deploy_services=false
+```
+
+### 3. Grab the sha tag from the build summary
+
+The `build-and-push` job's summary tab includes the sha-tag of the
+image it just produced. On a build-only dispatch it also prints the
+exact `run-backfill.sh` invocation:
+
+```
+**Build-only dispatch.** Live services were not redeployed.
+
+To run a backfill against this image:
+
+IMAGE_TAG=sha-<long-commit-hash> DRY_RUN=1 FOLLOW=1 \
+  ./deploy/aws/scripts/run-backfill.sh <script-name>
+```
+
+### 4. Dry-run against prod RDS using the branch image
+
+```bash
+IMAGE_TAG=sha-<long-commit-hash> DRY_RUN=1 FOLLOW=1 \
+  ./deploy/aws/scripts/run-backfill.sh my-backfill
+```
+
+What this does under the hood:
+
+1. `describe-task-definition` the current `jyt-prod-medusa-server`
+   family.
+2. Filter it down to the fields `register-task-definition` accepts
+   (drops `taskDefinitionArn`, `revision`, `status`,
+   `requiresAttributes`, `compatibilities`, `registeredAt`,
+   `registeredBy`).
+3. Swap the `medusa-server` container's image to your branch's sha
+   tag.
+4. `register-task-definition` to create a new revision in the same
+   family.
+5. `run-task` against the new revision with the usual command
+   overrides (`pnpm exec medusa exec ./src/scripts/<name>.js`) and
+   env overrides (`DRY_RUN`, `BATCH`, `REGION_IDS`, `PARTNER_IDS`,
+   `CONCURRENCY`, …).
+
+The new task def revision is harmless — `copilot svc deploy`
+references the family by name and re-publishes the manifest's
+declared image on the next real deploy, so this side-revision doesn't
+pollute the normal deploy path. ECS retains old revisions for free.
+
+### 5. Verify counts, drop DRY_RUN, run for real
+
+Once the dry-run output looks right:
+
+```bash
+IMAGE_TAG=sha-<long-commit-hash> FOLLOW=1 \
+  ./deploy/aws/scripts/run-backfill.sh my-backfill
+```
+
+### 6. Merge
+
+After verifying, merge the branch normally. The push-to-main deploy
+will re-publish `:latest` with the merged image, and future
+`run-backfill.sh` calls without `IMAGE_TAG` will pick that up.
+
+---
+
+## Why we don't push `:latest` from branches
+
+The `mirror-to-ecr` step in `deploy-to-aws.yml` only tags
+`:latest` when `github.ref == refs/heads/main`. The medusa-server and
+medusa-worker task definitions both reference `:latest`. If a branch
+build moved `:latest` forward, the next ECS task replacement
+(autoscale, host drain, deploy, restart) would silently pull the
+branch image. The `sha-<commit>` tag is immutable + scoped, so
+branch dispatches can only affect what we explicitly point at.
+
+---
+
+## Trade-offs
+
+- **One stale task def revision per dry-run.** Cheap (free), but it
+  accumulates. Worth a quarterly housekeeping pass:
+  `aws ecs list-task-definitions --family-prefix jyt-prod-medusa-server`
+  → deregister the orphans by hand if they pile up.
+- **No automatic cleanup of the registered revision on failure.** If
+  `run-task` fails, the registered revision remains. Same housekeeping.
+- **Not for code changes that need the prod *service* to run them**
+  (route changes, subscriber wiring, etc.). This path is one-off
+  task-only. Service changes go the normal merge-to-main route.
+
+---
+
+## See also
+
+- `.github/workflows/deploy-to-aws.yml` — the dispatch inputs +
+  conditional deploy jobs.
+- `deploy/aws/scripts/run-backfill.sh` — the `IMAGE_TAG` flow lives
+  here.
+- `PLATFORM_0A_RUNBOOK.md` — the first script to use this dispatch
+  path end-to-end.

--- a/deploy/aws/scripts/run-backfill.sh
+++ b/deploy/aws/scripts/run-backfill.sh
@@ -22,6 +22,19 @@
 #   BATCH=50              -> exposed to scripts that batch (e.g. product search)
 #   DRY_RUN=1             -> exposed to scripts that support it
 #   FOLLOW=1              -> tail CloudWatch logs until the task exits
+#   IMAGE_TAG=sha-<hash>  -> run against a specific image tag instead of
+#                            whatever the live task def uses (:latest).
+#                            Used to dry-run scripts that haven't been
+#                            merged to main yet — the deploy workflow
+#                            supports a workflow_dispatch with
+#                            deploy_services=false that builds + mirrors
+#                            an image without rolling the prod service;
+#                            grab its sha tag from the build summary and
+#                            pass it here.
+#   ECR_REGISTRY=...      -> override the ECR account ref. Auto-detected
+#                            from the existing task def when IMAGE_TAG
+#                            is set; only needed if your shell already
+#                            has it cached.
 
 set -euo pipefail
 
@@ -48,14 +61,88 @@ echo "== Container:       $CONTAINER_NAME"
 echo "== Script:          $SCRIPT_NAME"
 echo "== BATCH:           ${BATCH:-(unset, script default)}"
 echo "== DRY_RUN:         ${DRY_RUN:-0}"
+echo "== IMAGE_TAG:       ${IMAGE_TAG:-(unset, use live task def image)}"
 echo
 
-# Resolve the latest active task def revision.
-TASK_DEF_ARN=$(aws ecs describe-task-definition \
-  --task-definition "$TASK_FAMILY" \
-  --region "$AWS_REGION" \
-  --query "taskDefinition.taskDefinitionArn" \
-  --output text)
+# Resolve the task definition to run against.
+#
+# Default path (no IMAGE_TAG): use the current active revision of the
+# medusa-server family. The one-off task pulls whatever image that
+# revision references (:latest in prod today).
+#
+# Branch dry-run path (IMAGE_TAG set): describe the current revision,
+# swap the container image to the supplied sha tag, register a new
+# revision in the family, and target that new revision. The new
+# revision is a one-off — `copilot svc deploy` references the family
+# by name and would still pick whatever the manifest says when the
+# next real deploy runs, so this side-revision doesn't pollute the
+# normal deploy path. ECS keeps old revisions free of charge.
+if [ -n "${IMAGE_TAG:-}" ]; then
+  echo "Registering a one-off task def revision with image tag ${IMAGE_TAG}…"
+  # Write describe-task-definition output to a temp file so python can
+  # read it positionally — `python3 - <<'PY'` heredocs take over stdin,
+  # so we can't pipe JSON in alongside the heredoc.
+  CURRENT_DEF_FILE=$(mktemp -t run-backfill-current-td.XXXXXX.json)
+  aws ecs describe-task-definition \
+    --task-definition "$TASK_FAMILY" \
+    --region "$AWS_REGION" \
+    --output json > "$CURRENT_DEF_FILE"
+
+  # Compose the new image ref. If ECR_REGISTRY isn't passed in, parse
+  # it out of the existing image on the current task def. `-c` reads
+  # code from the arg so stdin is free for the pipe.
+  if [ -z "${ECR_REGISTRY:-}" ]; then
+    CURRENT_IMAGE=$(python3 -c "
+import json, sys
+td = json.load(open(sys.argv[1]))['taskDefinition']
+for c in td['containerDefinitions']:
+    if c['name'] == sys.argv[2]:
+        print(c['image']); break
+" "$CURRENT_DEF_FILE" "$CONTAINER_NAME")
+    # An image looks like 123456789012.dkr.ecr.us-east-1.amazonaws.com/jyt-medusa:latest
+    ECR_REGISTRY="${CURRENT_IMAGE%/*}"
+  fi
+  NEW_IMAGE="${ECR_REGISTRY}/${ECR_REPOSITORY:-jyt-medusa}:${IMAGE_TAG}"
+  echo "  New image: ${NEW_IMAGE}"
+
+  # Filter the current task def down to the fields register-task-definition
+  # accepts and swap the container image. describe-task-definition returns
+  # extra fields (revision, status, registeredAt, taskDefinitionArn,
+  # requiresAttributes, compatibilities, registeredBy) that register-
+  # task-definition rejects.
+  NEW_DEF_FILE=$(mktemp -t run-backfill-taskdef.XXXXXX.json)
+  python3 - "$CURRENT_DEF_FILE" "$CONTAINER_NAME" "$NEW_IMAGE" "$NEW_DEF_FILE" <<'PY'
+import json, sys
+in_path, container_name, new_image, out_path = sys.argv[1:]
+td = json.load(open(in_path))['taskDefinition']
+allowed_keys = {
+  'family', 'taskRoleArn', 'executionRoleArn', 'networkMode',
+  'containerDefinitions', 'volumes', 'placementConstraints',
+  'requiresCompatibilities', 'cpu', 'memory', 'tags',
+  'pidMode', 'ipcMode', 'proxyConfiguration', 'inferenceAccelerators',
+  'ephemeralStorage', 'runtimePlatform',
+}
+filtered = {k: v for k, v in td.items() if k in allowed_keys and v is not None}
+for c in filtered.get('containerDefinitions', []):
+    if c.get('name') == container_name:
+        c['image'] = new_image
+with open(out_path, 'w') as f:
+    json.dump(filtered, f)
+PY
+
+  TASK_DEF_ARN=$(aws ecs register-task-definition \
+    --region "$AWS_REGION" \
+    --cli-input-json "file://${NEW_DEF_FILE}" \
+    --query "taskDefinition.taskDefinitionArn" \
+    --output text)
+  echo "  Registered: ${TASK_DEF_ARN}"
+else
+  TASK_DEF_ARN=$(aws ecs describe-task-definition \
+    --task-definition "$TASK_FAMILY" \
+    --region "$AWS_REGION" \
+    --query "taskDefinition.taskDefinitionArn" \
+    --output text)
+fi
 echo "Using task definition: $TASK_DEF_ARN"
 
 # Compose the command override. WORKDIR inside the runtime image is
@@ -98,7 +185,10 @@ if [ ${#ENV_LIST[@]} -gt 0 ]; then
 fi
 
 OVERRIDES_FILE=$(mktemp -t run-backfill-overrides.XXXXXX.json)
-trap 'rm -f "$OVERRIDES_FILE"' EXIT
+# Single EXIT trap cleans up both temp files — the IMAGE_TAG path
+# above also creates NEW_DEF_FILE, which we want gone whether or not
+# the run-task call succeeded.
+trap 'rm -f "$OVERRIDES_FILE" "${NEW_DEF_FILE:-}" "${CURRENT_DEF_FILE:-}"' EXIT
 
 python3 - "$CONTAINER_NAME" "$OVERRIDES_FILE" "$ENV_JSON" "${CMD_PARTS[@]}" <<'PY'
 import json, sys


### PR DESCRIPTION
## Summary

Enable dry-running a branch's `src/scripts/*.ts` against prod RDS without merging or deploying the branch to the live services. Three pieces:

- **`workflow_dispatch.inputs.deploy_services`** (default `false`) on `deploy-to-aws.yml` — branch dispatches now build + mirror the image without rolling `medusa-server` / `medusa-worker`. Push to `main` keeps deploying as before.
- **Guard the ECR `:latest` push on `main`** in the `mirror-to-ecr` step — branch images only ship as `sha-<commit>`, so a branch can never silently bleed into ECS task replacements that pull `:latest`.
- **`IMAGE_TAG` env on `run-backfill.sh`** — when set, describe the current `jyt-prod-medusa-server` task def, filter to `register-task-definition` shape, swap the `medusa-server` container's image to `<ECR>/jyt-medusa:<IMAGE_TAG>`, register a side revision, and run the one-off task against it. Without `IMAGE_TAG`, behavior unchanged.

Full operator runbook lands in `apps/docs/notes/CI_BUILD_ONLY_DISPATCH.md`.

**First user:** the 0A region/currency/FX backfill (`feat/backfill-all-regions-to-partners`, parked) — once this merges, that branch can dry-run all three scripts against the real partner data before its own merge.

## Test plan

- [ ] On this PR, **Actions → Deploy to AWS ECS → Run workflow → branch=`feat/ci-build-only-dispatch` → `deploy_services` unchecked**. Confirm:
  - `build-and-push` + `mirror-to-ecr` run.
  - `deploy-server`, `deploy-worker`, `health-check` are skipped (UI shows them grey).
  - ECR has a new `jyt-medusa:sha-<this-commit>` tag.
  - ECR `jyt-medusa:latest` is NOT updated.
  - Build summary prints the `IMAGE_TAG=sha-… DRY_RUN=1 ./run-backfill.sh …` command.
- [ ] Re-run with `deploy_services=true` (separate manual dispatch) — confirm the full deploy still works and matches the push-to-main path exactly.
- [ ] **Smoke-test the `IMAGE_TAG` flow** against this branch's image with a benign existing script (e.g. one that supports `--dry-run`):
  - `IMAGE_TAG=sha-<commit> DRY_RUN=1 FOLLOW=1 ./deploy/aws/scripts/run-backfill.sh backfill-partner-region-links`
  - Confirm: new task def revision registers, one-off task starts on the new revision, logs show the script ran, no production data mutated.
- [ ] Verify `aws ecs list-task-definitions --family-prefix jyt-prod-medusa-server` shows the side revision in addition to the live one (will need quarterly cleanup; called out in the runbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)