### PR TITLE
feat(backfill): 0A — link all partners to all admin regions + FX fanout

### DIFF
--- a/apps/backend/src/scripts/backfill-all-admin-regions-to-partners.ts
+++ b/apps/backend/src/scripts/backfill-all-admin-regions-to-partners.ts
@@ -1,0 +1,176 @@
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import partnerRegionLink from "../links/partner-region"
+
+/**
+ * Backfill `partner_region` links so every partner is linked to every
+ * admin region.
+ *
+ * Why: Until a `region.created` subscriber lands (roadmap #0B), admin
+ * regions don't propagate to existing partners. Live partner stores
+ * (GOF, Ielo, …) only had `partner_region` rows for their own
+ * `default_region_id`, so visitors from countries served by other
+ * admin regions saw "we don't ship here" on the storefront. This
+ * script unblocks them in one pass by cross-producting partners ×
+ * regions.
+ *
+ * Companion of `backfill-partner-region-links.ts` (default-region
+ * only). Run THIS one first when expanding partner region coverage,
+ * then run `backfill-store-currencies-from-partner-regions.ts` to
+ * extend `store.supported_currencies`, then the FX fanout sweep.
+ *
+ * Idempotent: skips any (partner, region) pair that already has a
+ * link row. Safe to re-run.
+ *
+ * Run:
+ *   npx medusa exec ./src/scripts/backfill-all-admin-regions-to-partners.ts
+ *
+ * Dry run — logs what would happen, creates nothing:
+ *   - Args:    npx medusa exec ./src/scripts/backfill-all-admin-regions-to-partners.ts -- --dry-run
+ *   - Env var: DRY_RUN=1 npx medusa exec ./src/scripts/backfill-all-admin-regions-to-partners.ts
+ *
+ * Scope a subset of regions instead of every region:
+ *   npx medusa exec ./src/scripts/backfill-all-admin-regions-to-partners.ts -- --region-ids=reg_a,reg_b
+ *   REGION_IDS=reg_a,reg_b npx medusa exec ./src/scripts/backfill-all-admin-regions-to-partners.ts
+ *
+ * Scope a subset of partners (defaults to every partner):
+ *   npx medusa exec ./src/scripts/backfill-all-admin-regions-to-partners.ts -- --partner-ids=par_a,par_b
+ *   PARTNER_IDS=par_a,par_b npx medusa exec ./src/scripts/backfill-all-admin-regions-to-partners.ts
+ */
+export default async function backfillAllAdminRegionsToPartners({
+  container,
+  args,
+}: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as any
+
+  const argList = args ?? []
+  const dryRun = argList.includes("--dry-run") || process.env.DRY_RUN === "1"
+
+  const parseListArg = (flag: string, envVar: string): string[] | null => {
+    const fromArg = argList
+      .map((a) => (a.startsWith(`${flag}=`) ? a.slice(flag.length + 1) : null))
+      .find((v): v is string => v !== null)
+    const raw = fromArg ?? process.env[envVar] ?? ""
+    if (!raw.trim()) return null
+    return raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+  }
+
+  const regionIdFilter = parseListArg("--region-ids", "REGION_IDS")
+  const partnerIdFilter = parseListArg("--partner-ids", "PARTNER_IDS")
+
+  if (dryRun) {
+    logger.info("DRY RUN — no links will be created.")
+  }
+  if (regionIdFilter?.length) {
+    logger.info(`Region scope: ${regionIdFilter.join(", ")}`)
+  }
+  if (partnerIdFilter?.length) {
+    logger.info(`Partner scope: ${partnerIdFilter.join(", ")}`)
+  }
+
+  // 1. Target regions — either the scoped list or every admin region.
+  const { data: allRegions } = await query.graph({
+    entity: "region",
+    fields: ["id", "name", "currency_code"],
+  })
+  const targetRegions = (allRegions ?? []).filter(
+    (r: any) => !regionIdFilter || regionIdFilter.includes(r.id)
+  )
+
+  if (!targetRegions.length) {
+    logger.warn(
+      regionIdFilter
+        ? `No regions matched the --region-ids filter: ${regionIdFilter.join(", ")}`
+        : "No admin regions found. Nothing to link."
+    )
+    return
+  }
+
+  logger.info(
+    `Linking against ${targetRegions.length} region(s): ${targetRegions
+      .map((r: any) => `${r.name} (${r.id}, ${r.currency_code})`)
+      .join(", ")}`
+  )
+
+  // 2. Target partners.
+  const { data: allPartners } = await query.graph({
+    entity: "partners",
+    fields: ["id", "name", "handle"],
+  })
+  const targetPartners = (allPartners ?? []).filter(
+    (p: any) => !partnerIdFilter || partnerIdFilter.includes(p.id)
+  )
+
+  if (!targetPartners.length) {
+    logger.warn(
+      partnerIdFilter
+        ? `No partners matched the --partner-ids filter: ${partnerIdFilter.join(", ")}`
+        : "No partners found. Nothing to link."
+    )
+    return
+  }
+
+  // 3. Existing partner_region links — used to skip already-linked pairs.
+  const { data: existingLinks } = await query.graph({
+    entity: partnerRegionLink.entryPoint,
+    fields: ["partner_id", "region_id"],
+  })
+  const linkKey = (pid: string, rid: string) => `${pid}::${rid}`
+  const linked = new Set<string>(
+    (existingLinks ?? []).map((l: any) => linkKey(l.partner_id, l.region_id))
+  )
+
+  let created = 0
+  let alreadyLinked = 0
+  const errors: Array<{ partner: string; region: string; error: string }> = []
+
+  for (const partner of targetPartners as any[]) {
+    for (const region of targetRegions as any[]) {
+      const tag = `partner "${partner.name}" (${partner.id}) → region "${region.name}" (${region.id})`
+
+      if (linked.has(linkKey(partner.id, region.id))) {
+        alreadyLinked++
+        continue
+      }
+
+      if (dryRun) {
+        logger.info(`${tag}: WOULD create link`)
+        created++
+        continue
+      }
+
+      try {
+        await remoteLink.create({
+          partner: { partner_id: partner.id },
+          [Modules.REGION]: { region_id: region.id },
+        })
+        linked.add(linkKey(partner.id, region.id))
+        logger.info(`${tag}: created link`)
+        created++
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        logger.error(`${tag}: failed — ${message}`)
+        errors.push({ partner: partner.id, region: region.id, error: message })
+      }
+    }
+  }
+
+  logger.info(
+    `Backfill complete. created=${created}, already_linked=${alreadyLinked}, partners=${targetPartners.length}, regions=${targetRegions.length}, errors=${errors.length}${
+      dryRun ? " (DRY RUN)" : ""
+    }`
+  )
+
+  if (errors.length) {
+    logger.error("Errors during backfill — review the log above:")
+    for (const e of errors) {
+      logger.error(`  partner=${e.partner} region=${e.region}: ${e.error}`)
+    }
+    process.exitCode = 1
+  }
+}

--- a/apps/backend/src/scripts/fanout-existing-variant-prices.ts
+++ b/apps/backend/src/scripts/fanout-existing-variant-prices.ts
@@ -1,0 +1,247 @@
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import fanoutPricesWorkflow from "../workflows/fx/fanout-prices"
+
+/**
+ * Replay the FX fanout workflow against every existing variant price
+ * on partner stores so they materialize auto-converted rows in the
+ * other currencies of `store.supported_currencies`.
+ *
+ * Why: `fanoutPricesWorkflow` runs synchronously when a partner saves
+ * a variant (see `partners/stores/.../variants/batch`), but there's no
+ * subscriber on `price.created` — so prices created before the FX
+ * fanout shipped (or before the partner's store gained extra
+ * supported_currencies via the link backfill) never got fanned out.
+ * This script kicks the workflow once per existing manual price.
+ *
+ * Order of operations for the 0A unblock:
+ *   1. `backfill-all-admin-regions-to-partners.ts` — link partners to
+ *      every admin region so `partner_region` reflects the intended
+ *      coverage.
+ *   2. `backfill-store-currencies-from-partner-regions.ts` — extend
+ *      `store.supported_currencies` to cover every linked region's
+ *      currency.
+ *   3. THIS script — replay fanout so existing variants gain prices in
+ *      the newly-supported currencies.
+ *
+ * Idempotent: the workflow's `fx_price_meta` recursion guard skips
+ * any price that was itself created by a previous fanout, and its
+ * "already priced" check skips currencies that already exist on the
+ * price_set. Safe to re-run.
+ *
+ * Run:
+ *   npx medusa exec ./src/scripts/fanout-existing-variant-prices.ts
+ *
+ * Dry run — counts targets, runs nothing:
+ *   - Args:    npx medusa exec ./src/scripts/fanout-existing-variant-prices.ts -- --dry-run
+ *   - Env var: DRY_RUN=1 npx medusa exec ./src/scripts/fanout-existing-variant-prices.ts
+ *
+ * Scope a subset of partners:
+ *   npx medusa exec ./src/scripts/fanout-existing-variant-prices.ts -- --partner-ids=par_a,par_b
+ *   PARTNER_IDS=par_a,par_b npx medusa exec ./src/scripts/fanout-existing-variant-prices.ts
+ *
+ * Cap concurrency for big tenants (default 4):
+ *   CONCURRENCY=8 npx medusa exec ./src/scripts/fanout-existing-variant-prices.ts
+ */
+export default async function fanoutExistingVariantPrices({
+  container,
+  args,
+}: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  const argList = args ?? []
+  const dryRun = argList.includes("--dry-run") || process.env.DRY_RUN === "1"
+
+  const parseListArg = (flag: string, envVar: string): string[] | null => {
+    const fromArg = argList
+      .map((a) => (a.startsWith(`${flag}=`) ? a.slice(flag.length + 1) : null))
+      .find((v): v is string => v !== null)
+    const raw = fromArg ?? process.env[envVar] ?? ""
+    if (!raw.trim()) return null
+    return raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+  }
+
+  const partnerIdFilter = parseListArg("--partner-ids", "PARTNER_IDS")
+  const concurrency = Math.max(1, Number(process.env.CONCURRENCY ?? "4"))
+
+  if (dryRun) logger.info("DRY RUN — fanout workflow will not be invoked.")
+  if (partnerIdFilter?.length) {
+    logger.info(`Partner scope: ${partnerIdFilter.join(", ")}`)
+  }
+
+  // 1. Partners → stores → default_sales_channel_id. We walk via the
+  //    store's default channel because that's the channel partner-ui
+  //    creates products against; products outside that channel
+  //    wouldn't be priced through this store anyway.
+  const { data: partners } = await query.graph({
+    entity: "partners",
+    fields: [
+      "id",
+      "name",
+      "stores.id",
+      "stores.name",
+      "stores.default_sales_channel_id",
+    ],
+  })
+
+  const targetPartners = (partners ?? []).filter(
+    (p: any) => !partnerIdFilter || partnerIdFilter.includes(p.id)
+  )
+
+  if (!targetPartners.length) {
+    logger.warn(
+      partnerIdFilter
+        ? `No partners matched the --partner-ids filter: ${partnerIdFilter.join(", ")}`
+        : "No partners found. Nothing to fanout."
+    )
+    return
+  }
+
+  type Target = { partnerId: string; storeId: string; priceId: string }
+  const targets: Target[] = []
+  let partnersWithoutChannel = 0
+  let variantsScanned = 0
+  let pricesScanned = 0
+
+  for (const partner of targetPartners as any[]) {
+    for (const store of partner.stores ?? []) {
+      const channelId = store?.default_sales_channel_id
+      if (!channelId) {
+        partnersWithoutChannel++
+        logger.info(
+          `partner "${partner.name}" (${partner.id}), store "${store?.name}" (${store?.id}): no default_sales_channel_id — skipping`
+        )
+        continue
+      }
+
+      // 2. All variants whose product lives in the store's default
+      //    sales channel. price_set.prices is what we need for fanout
+      //    inputs.
+      const { data: variants } = await query.graph({
+        entity: "product_variants",
+        filters: { "product.sales_channels.id": channelId } as any,
+        fields: [
+          "id",
+          "product.id",
+          "price_set.prices.id",
+        ],
+      })
+
+      let storeVariants = 0
+      let storePrices = 0
+      for (const variant of (variants ?? []) as any[]) {
+        storeVariants++
+        const prices = variant?.price_set?.prices ?? []
+        for (const price of prices) {
+          if (!price?.id) continue
+          storePrices++
+          targets.push({
+            partnerId: partner.id,
+            storeId: store.id,
+            priceId: price.id,
+          })
+        }
+      }
+      variantsScanned += storeVariants
+      pricesScanned += storePrices
+      logger.info(
+        `partner "${partner.name}" (${partner.id}), store "${store.name}" (${store.id}): ${storeVariants} variants, ${storePrices} price rows`
+      )
+    }
+  }
+
+  logger.info(
+    `Scanned ${targetPartners.length} partner(s), ${variantsScanned} variant(s), ${pricesScanned} price row(s). Targeting ${targets.length} fanout invocation(s)${
+      partnersWithoutChannel
+        ? ` (${partnersWithoutChannel} store(s) skipped: no default channel)`
+        : ""
+    }.`
+  )
+
+  if (dryRun || !targets.length) {
+    logger.info(
+      `Done${dryRun ? " (DRY RUN)" : ""}. ${targets.length} fanout invocations would have run.`
+    )
+    return
+  }
+
+  // 3. Run the workflow with bounded concurrency. The workflow itself
+  //    short-circuits on its recursion guard for auto-derived prices,
+  //    so we don't need to filter those out up-front — the count of
+  //    "skipped because auto-derived" is what the workflow returns in
+  //    `skipped_reason`, and the operator gets a useful tally.
+  let created = 0
+  let skippedAuto = 0
+  let skippedOther = 0
+  let errored = 0
+  const errors: Array<{ priceId: string; storeId: string; error: string }> = []
+
+  const queue = [...targets]
+  const runOne = async () => {
+    while (queue.length) {
+      const t = queue.shift()
+      if (!t) break
+      try {
+        const { result } = await fanoutPricesWorkflow(container).run({
+          input: { source_price_id: t.priceId, store_id: t.storeId },
+        })
+        if (result?.skipped_reason) {
+          if (result.skipped_reason.includes("auto-converted")) {
+            skippedAuto++
+          } else {
+            skippedOther++
+            logger.info(
+              `[fanout] price ${t.priceId}: skipped — ${result.skipped_reason}`
+            )
+          }
+        }
+        if (result?.created_count) {
+          created += result.created_count
+          logger.info(
+            `[fanout] price ${t.priceId}: created ${result.created_count} auto-prices`
+          )
+        }
+        if (result?.errors?.length) {
+          for (const e of result.errors) {
+            errored++
+            errors.push({
+              priceId: t.priceId,
+              storeId: t.storeId,
+              error: `${e.currency}: ${e.error}`,
+            })
+          }
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        errored++
+        errors.push({ priceId: t.priceId, storeId: t.storeId, error: message })
+        logger.warn(`[fanout] price ${t.priceId}: workflow failed — ${message}`)
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, targets.length) }, runOne)
+  )
+
+  logger.info(
+    `Fanout complete. created_prices=${created}, skipped_auto=${skippedAuto}, skipped_other=${skippedOther}, errors=${errored}, total_invocations=${targets.length}`
+  )
+
+  if (errors.length) {
+    logger.error("Errors during fanout — review the log above:")
+    for (const e of errors.slice(0, 50)) {
+      logger.error(
+        `  price=${e.priceId} store=${e.storeId}: ${e.error}`
+      )
+    }
+    if (errors.length > 50) {
+      logger.error(`  (… ${errors.length - 50} more)`)
+    }
+    process.exitCode = 1
+  }
+}

--- a/apps/docs/notes/PLATFORM_0A_RUNBOOK.md
+++ b/apps/docs/notes/PLATFORM_0A_RUNBOOK.md
@@ -1,0 +1,206 @@
+# Platform 0A — Region + currency + FX backfill runbook
+
+> Operator runbook for the one-shot unblock described in
+> `PLATFORM_ROADMAP_2026_05.md` item #0A. Goal: every active partner
+> store stops showing "we don't ship to AU/EU/US/ID" to visitors from
+> those regions.
+>
+> This is the manual path. The structural fix (`region.created`
+> subscriber + admin "share to all" button) is roadmap #0B — see the
+> roadmap for sequencing.
+
+---
+
+## What this does
+
+Three additive, idempotent passes:
+
+1. **Link** every partner to every admin region (`partner_region`).
+2. **Extend** each partner store's `supported_currencies` to cover the
+   newly-linked regions' currencies.
+3. **Fan out** existing variant prices through the FX workflow so
+   converted price rows materialize for the new currencies.
+
+Each step is safe to re-run — they all skip rows that already match
+the intended state.
+
+---
+
+## Acceptance check
+
+After running all three, on a live partner storefront (Ielo or GOF are
+the canaries):
+
+- `curl https://<partner-storefront>/api/regions` (or whatever the
+  storefront-starter equivalent is) returns AU/EU/US/ID alongside IN.
+- A product detail page shows a price in the visitor's currency when
+  the visitor is in AU/EU/US/ID. No "we don't ship here" fallback.
+- Admin → Partners → Regions tab shows the partner linked to all 5
+  admin regions.
+
+---
+
+## Local / dev run
+
+Each script supports `--dry-run` (or `DRY_RUN=1`) and prints what
+would happen without writing anything. Always start there.
+
+```bash
+cd apps/backend
+
+# Step 1 — preview the partner × region cross-product
+DRY_RUN=1 npx medusa exec ./src/scripts/backfill-all-admin-regions-to-partners.ts
+
+# Step 2 — preview the currency extension
+DRY_RUN=1 npx medusa exec ./src/scripts/backfill-store-currencies-from-partner-regions.ts
+
+# Step 3 — preview the fanout invocations
+DRY_RUN=1 npx medusa exec ./src/scripts/fanout-existing-variant-prices.ts
+```
+
+If the dry-run counts look right, drop `DRY_RUN=1` and re-run each in
+the same order.
+
+### Scoping flags
+
+Both scripts that touch partners/regions take optional scope:
+
+- `--region-ids=reg_a,reg_b` (or `REGION_IDS=…`) — limit step 1 to a
+  subset of admin regions. Useful if there's a test/sandbox region in
+  the DB you don't want to expose to partners.
+- `--partner-ids=par_a,par_b` (or `PARTNER_IDS=…`) — limit any step to
+  a subset of partners. Useful for a canary on one partner before the
+  full sweep.
+- `CONCURRENCY=N` on step 3 — caps parallel fanout invocations
+  (default 4). Bump for big tenants if the fanout is slow.
+
+---
+
+## Dry-run from this branch (before merging)
+
+The scripts must be inside the medusa-server image for the one-off
+Fargate task to find them. Push to `main` does this automatically,
+but you can also dry-run **before** merging via the build-only
+`workflow_dispatch` path — see
+[`CI_BUILD_ONLY_DISPATCH.md`](./CI_BUILD_ONLY_DISPATCH.md).
+
+Short version:
+
+1. **Actions → Deploy to AWS ECS → Run workflow** on this branch with
+   `deploy_services` **unchecked**.
+2. Grab the `sha-<commit>` tag from the build summary.
+3. Run each step with `IMAGE_TAG=sha-<commit> DRY_RUN=1`:
+
+```bash
+IMAGE_TAG=sha-xxx DRY_RUN=1 FOLLOW=1 \
+  ./deploy/aws/scripts/run-backfill.sh backfill-all-admin-regions-to-partners
+
+IMAGE_TAG=sha-xxx DRY_RUN=1 FOLLOW=1 \
+  ./deploy/aws/scripts/run-backfill.sh backfill-store-currencies-from-partner-regions
+
+IMAGE_TAG=sha-xxx DRY_RUN=1 FOLLOW=1 \
+  ./deploy/aws/scripts/run-backfill.sh fanout-existing-variant-prices
+```
+
+If counts look right, either drop `DRY_RUN=1` and run for real on the
+branch image, or merge first and use the normal prod-run flow below.
+
+---
+
+## Prod run
+
+The helper at `deploy/aws/scripts/run-backfill.sh` launches a one-off
+Fargate task reusing the medusa-server task definition (inherits RDS
+secrets + IAM + VPC). It passes `DRY_RUN`, `REGION_IDS`,
+`PARTNER_IDS`, and `CONCURRENCY` through to the container.
+
+```bash
+# Step 1 — dry-run first
+DRY_RUN=1 FOLLOW=1 ./deploy/aws/scripts/run-backfill.sh \
+  backfill-all-admin-regions-to-partners
+
+# Step 1 — real run (no DRY_RUN)
+FOLLOW=1 ./deploy/aws/scripts/run-backfill.sh \
+  backfill-all-admin-regions-to-partners
+
+# Step 2 — dry-run then real
+DRY_RUN=1 FOLLOW=1 ./deploy/aws/scripts/run-backfill.sh \
+  backfill-store-currencies-from-partner-regions
+FOLLOW=1 ./deploy/aws/scripts/run-backfill.sh \
+  backfill-store-currencies-from-partner-regions
+
+# Step 3 — dry-run then real
+DRY_RUN=1 FOLLOW=1 ./deploy/aws/scripts/run-backfill.sh \
+  fanout-existing-variant-prices
+FOLLOW=1 ./deploy/aws/scripts/run-backfill.sh \
+  fanout-existing-variant-prices
+```
+
+`FOLLOW=1` tails CloudWatch until the task exits — recommended so you
+catch the per-step summary line at the end of each run.
+
+### Canary first
+
+Recommended: run step 1 + 2 + 3 against a single partner before the
+full sweep, to confirm the storefront actually picks up the change.
+
+```bash
+# Pick a low-traffic partner, e.g. internal test partner
+PARTNER_IDS=par_xxx FOLLOW=1 \
+  ./deploy/aws/scripts/run-backfill.sh backfill-all-admin-regions-to-partners
+
+PARTNER_IDS=par_xxx FOLLOW=1 \
+  ./deploy/aws/scripts/run-backfill.sh backfill-store-currencies-from-partner-regions
+
+PARTNER_IDS=par_xxx FOLLOW=1 \
+  ./deploy/aws/scripts/run-backfill.sh fanout-existing-variant-prices
+```
+
+Verify on that partner's storefront, then re-run without `PARTNER_IDS`
+to sweep everyone.
+
+---
+
+## Expected output shape
+
+Each script ends with a summary line. Roughly:
+
+```
+Backfill complete. created=42, already_linked=7, partners=14, regions=5, errors=0
+Backfill complete. stores_updated=14, stores_already_current=0, …
+Fanout complete. created_prices=1200, skipped_auto=300, skipped_other=0, errors=0
+```
+
+`errors > 0` exits with code 1 so the Fargate task surfaces a
+non-success status — review the log above the summary, fix, re-run.
+
+---
+
+## Cleanup / rollback
+
+These are additive. Nothing is deleted. Rollback if needed:
+
+- **Step 1** — delete the link rows you just created. They're in the
+  `partner_region` link table; the script logs every `partner → region`
+  pair it added.
+- **Step 2** — `supported_currencies` is a managed relation on
+  `store`; remove via `updateStoresWorkflow` with the original list.
+- **Step 3** — auto-converted prices are tagged via `fx_price_meta`.
+  Drop them by deleting matching `price` rows + their `fx_price_meta`
+  link rows. The price IDs created are in the CloudWatch log.
+
+In practice, "did too many partners get the new regions" is not the
+failure mode we expect — the failure mode is "didn't propagate at
+all", which is what we're fixing here.
+
+---
+
+## See also
+
+- `PLATFORM_ROADMAP_2026_05.md` — item #0A (the blocker), #0B (the
+  structural fix that supersedes this runbook).
+- `FX_AUTO_CONVERSION.md` — design of the FX workflow that step 3
+  drives.
+- `feedback_focused_regions_fx_conversion.md` — why we run one
+  manually-priced source currency per product and fan out via FX
+  rather than per-currency manual entry.

--- a/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
+++ b/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
@@ -29,13 +29,22 @@ only links each partner's `default_region_id`).
 
 ### 0A — Unblock affected partners (one-off, ~30 min)
 
-For each currently-active partner store:
-1. Insert `partner_region` rows linking the partner to every admin
-   region (India, Europe, America, Indonesia, Australia)
-2. Run `backfill-store-currencies-from-partner-regions.ts` —
-   `supported_currencies` extends with `aud, eur, usd, idr`
-3. Trigger FX fanout sweep across all existing variants on those
-   stores so AUD/EUR/USD/IDR prices materialize from the INR base
+Scripts + runbook landed 2026-06-01 (branch
+`feat/backfill-all-regions-to-partners`). Operator runbook lives at
+`PLATFORM_0A_RUNBOOK.md`. The three passes:
+
+1. `backfill-all-admin-regions-to-partners.ts` — cross-products every
+   partner with every admin region into `partner_region`.
+2. `backfill-store-currencies-from-partner-regions.ts` (existing) —
+   extends `store.supported_currencies` for every linked region.
+3. `fanout-existing-variant-prices.ts` — replays the FX fanout
+   workflow against existing variant prices so AUD/EUR/USD/IDR rows
+   materialize from the INR base.
+
+All three are idempotent + dry-run aware. `deploy/aws/scripts/run-backfill.sh`
+threads `REGION_IDS`/`PARTNER_IDS`/`CONCURRENCY` through to the
+Fargate one-off task. Recommended canary: one partner via
+`PARTNER_IDS=par_x`, verify, then full sweep.
 
 **Acceptance:** GOF + 6+ other live partner storefronts stop showing
 the "we don't ship here" fallback for AU/EU/US/ID visitors.

--- a/deploy/aws/scripts/run-backfill.sh
+++ b/deploy/aws/scripts/run-backfill.sh
@@ -164,6 +164,10 @@ add_env() {
 }
 add_env BATCH                    "${BATCH:-}"
 add_env DRY_RUN                  "${DRY_RUN:-}"
+# 0A region/fanout backfill knobs — see apps/docs/notes/PLATFORM_0A_RUNBOOK.md.
+add_env REGION_IDS               "${REGION_IDS:-}"
+add_env PARTNER_IDS              "${PARTNER_IDS:-}"
+add_env CONCURRENCY              "${CONCURRENCY:-}"
 # Pass-throughs for the AI-platforms backfill: keys live in the local
 # `.env` during development and not yet in prod SSM. Exporting them
 # before calling this script (e.g. via `set -a; source .env; set +a`)


### PR DESCRIPTION
## Summary

Roadmap item [0A from `PLATFORM_ROADMAP_2026_05.md`](../blob/main/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md): unblock live partner storefronts that show "we don't ship to AU/EU/US/ID" to visitors from those regions. Three one-off scripts, all additive + idempotent + dry-run aware:

1. **`backfill-all-admin-regions-to-partners.ts`** — cross-products every partner × every admin region into `partner_region` links. (Existing `backfill-partner-region-links.ts` only linked each partner's `default_region_id`, which is the gap.)
2. **Existing `backfill-store-currencies-from-partner-regions.ts`** — no code change; chains correctly off the new link rows to extend `store.supported_currencies`.
3. **`fanout-existing-variant-prices.ts`** — replays `fanoutPricesWorkflow` against every existing price on every partner's variants so AUD/EUR/USD/IDR rows materialize from the INR base. Workflow's `fx_price_meta` recursion guard makes this safe to re-run.

Bounded concurrency on step 3 (`CONCURRENCY=4` default). All three accept `--partner-ids` / `PARTNER_IDS` and the link step accepts `--region-ids` / `REGION_IDS` for canary runs.

Operator runbook: [`apps/docs/notes/PLATFORM_0A_RUNBOOK.md`](../tree/HEAD/apps/docs/notes/PLATFORM_0A_RUNBOOK.md).

**Not in scope here** — the `region.created` subscriber + admin "share to all" button (roadmap item 0B). This PR is the manual unblock; 0B is the structural fix.

## How dry-run / verification works

Uses the build-only `workflow_dispatch` path from #304 (`CI_BUILD_ONLY_DISPATCH.md`):

1. **Actions → Deploy to AWS ECS → Run workflow** on this branch, `deploy_services` unchecked → builds + mirrors a `sha-<commit>` image without rolling prod services.
2. Grab the sha tag from the build summary.
3. Run dry-runs against the branch image:
   ```bash
   IMAGE_TAG=sha-xxx DRY_RUN=1 FOLLOW=1 ./deploy/aws/scripts/run-backfill.sh backfill-all-admin-regions-to-partners
   IMAGE_TAG=sha-xxx DRY_RUN=1 FOLLOW=1 ./deploy/aws/scripts/run-backfill.sh backfill-store-currencies-from-partner-regions
   IMAGE_TAG=sha-xxx DRY_RUN=1 FOLLOW=1 ./deploy/aws/scripts/run-backfill.sh fanout-existing-variant-prices
   ```
4. Verify counts. Drop `DRY_RUN=1` for the real run, OR merge and run via the normal post-merge path.

## Acceptance check

After all three pass for real, on GOF / Ielo / one more live storefront:
- `/store/regions` returns IN + AU + EU + US + ID.
- A product detail page shows a price in AU currency when visited from AU (no "we don't ship here" fallback).
- Admin → Partners → Regions tab shows the partner linked to all 5 admin regions.

## Test plan

- [ ] CodeQL + Vercel preview pass.
- [ ] Build-only `workflow_dispatch` succeeds on this branch (build summary surfaces the sha tag).
- [ ] `IMAGE_TAG=sha-xxx DRY_RUN=1 ./run-backfill.sh backfill-all-admin-regions-to-partners` — count of `created` links matches `(num_partners * num_regions) - already_linked`.
- [ ] `IMAGE_TAG=sha-xxx DRY_RUN=1 ./run-backfill.sh backfill-store-currencies-from-partner-regions` — `stores_updated` is non-zero for the affected partners.
- [ ] `IMAGE_TAG=sha-xxx DRY_RUN=1 ./run-backfill.sh fanout-existing-variant-prices` — `total_invocations` matches the manually-priced variants on prod (rough sanity, not exact).
- [ ] Counts attached to this PR as a comment before marking ready.
- [ ] After merge: real run, then visit GOF / Ielo from AU/EU/US/ID (or via geo simulator) to confirm AUD/EUR/USD/IDR pricing renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)