### PR TITLE
fix(backfill): fanout script multi-hop sales_channels filter

### DIFF
--- a/apps/backend/src/scripts/fanout-existing-variant-prices.ts
+++ b/apps/backend/src/scripts/fanout-existing-variant-prices.ts
@@ -119,31 +119,40 @@ export default async function fanoutExistingVariantPrices({
       }
 
       // 2. All variants whose product lives in the store's default
-      //    sales channel. price_set.prices is what we need for fanout
-      //    inputs.
-      const { data: variants } = await query.graph({
-        entity: "product_variants",
-        filters: { "product.sales_channels.id": channelId } as any,
+      //    sales channel. Query the `product` entity instead of
+      //    `product_variants` — query.graph filters only auto-join
+      //    a single relation hop, and `product_variants → product →
+      //    sales_channels` is two hops, which produced a postgres
+      //    "missing FROM-clause entry for sales_channels" error
+      //    against prod. Walking products → variants → prices works
+      //    because product → sales_channels is a single direct
+      //    relation. Nested-object filter syntax matches the working
+      //    pattern in apps/backend/src/api/store/products/route.ts.
+      const { data: products } = await query.graph({
+        entity: "product",
+        filters: { sales_channels: { id: channelId } } as any,
         fields: [
           "id",
-          "product.id",
-          "price_set.prices.id",
+          "variants.id",
+          "variants.price_set.prices.id",
         ],
       })
 
       let storeVariants = 0
       let storePrices = 0
-      for (const variant of (variants ?? []) as any[]) {
-        storeVariants++
-        const prices = variant?.price_set?.prices ?? []
-        for (const price of prices) {
-          if (!price?.id) continue
-          storePrices++
-          targets.push({
-            partnerId: partner.id,
-            storeId: store.id,
-            priceId: price.id,
-          })
+      for (const product of (products ?? []) as any[]) {
+        for (const variant of product?.variants ?? []) {
+          storeVariants++
+          const prices = variant?.price_set?.prices ?? []
+          for (const price of prices) {
+            if (!price?.id) continue
+            storePrices++
+            targets.push({
+              partnerId: partner.id,
+              storeId: store.id,
+              priceId: price.id,
+            })
+          }
         }
       }
       variantsScanned += storeVariants


### PR DESCRIPTION
## Summary

Hotfix for the 0A FX fanout script (`apps/backend/src/scripts/fanout-existing-variant-prices.ts`, landed in #305). The variants query used a two-hop traversal `"product.sales_channels.id"` as a filter, which `query.graph` doesn't auto-join — Postgres returned `missing FROM-clause entry for table "sales_channels"`.

Switched to querying the `product` entity directly with single-hop nested-object filter `{ sales_channels: { id: channelId } }` — the pattern that works in `apps/backend/src/api/store/products/route.ts:66-67`. Walks `products → variants → prices` to populate the fanout targets list.

## Discovery

Caught in the prod dry-run for roadmap item 0A:

```
Task 4bb7411ca6ba4f008918882e1b4f721d (DRY_RUN=1) → exit 1
{"level":"error","message":"… missing FROM-clause entry for table \"sales_channels\" …"}
```

Steps 1 (link backfill) and 2 (currency backfill) dry-runs passed clean (94 links to create, 11 already-linked, 0 errors).

## Test plan

- [ ] CodeQL + Vercel pass on this PR.
- [ ] After merge + deploy, re-run `DRY_RUN=1 ./deploy/aws/scripts/run-backfill.sh fanout-existing-variant-prices` against prod. Expect:
  - Per-store log lines: `partner "X", store "Y": N variants, M price rows`
  - Summary: `Scanned 21 partner(s), <N> variant(s), <M> price row(s). Targeting <T> fanout invocation(s)`
  - Exit code 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)