### PR TITLE
fix(backfill): pivot fanout script via sales_channel entity

### DIFF
--- a/apps/backend/src/scripts/fanout-existing-variant-prices.ts
+++ b/apps/backend/src/scripts/fanout-existing-variant-prices.ts
@@ -119,29 +119,45 @@ export default async function fanoutExistingVariantPrices({
       }
 
       // 2. All variants whose product lives in the store's default
-      //    sales channel. Query the `product` entity instead of
-      //    `product_variants` — query.graph filters only auto-join
-      //    a single relation hop, and `product_variants → product →
-      //    sales_channels` is two hops, which produced a postgres
-      //    "missing FROM-clause entry for sales_channels" error
-      //    against prod. Walking products → variants → prices works
-      //    because product → sales_channels is a single direct
-      //    relation. Nested-object filter syntax matches the working
-      //    pattern in apps/backend/src/api/store/products/route.ts.
-      const { data: products } = await query.graph({
-        entity: "product",
-        filters: { sales_channels: { id: channelId } } as any,
+      //    sales channel. Pivot via the `sales_channel` entity and walk
+      //    through the `products_link` join model — this is the path
+      //    that the partner list-store-products workflow uses
+      //    (apps/backend/src/workflows/partner/list-store-products.ts).
+      //
+      //    Other shapes that didn't work, captured here so the next
+      //    person doesn't re-discover:
+      //    - `product_variants` with `"product.sales_channels.id"`
+      //      filter → postgres "missing FROM-clause entry for table
+      //      sales_channels" (two-hop traversal not auto-joined).
+      //    - `product` with `{ sales_channels: { id } }` filter →
+      //      mikro-orm "Trying to query by not existing property
+      //      Product.sales_channels" (the relation lives on the link
+      //      entity, not on Product directly).
+      const { data: scData } = await query.graph({
+        entity: "sales_channel",
+        filters: { id: channelId },
         fields: [
           "id",
-          "variants.id",
-          "variants.price_set.prices.id",
+          "products_link.product.id",
+          "products_link.product.variants.id",
+          "products_link.product.variants.price_set.prices.id",
         ],
       })
 
+      const links = ((scData?.[0] as any)?.products_link ?? []) as Array<{
+        product?: {
+          id?: string
+          variants?: Array<{
+            id?: string
+            price_set?: { prices?: Array<{ id?: string }> }
+          }>
+        }
+      }>
+
       let storeVariants = 0
       let storePrices = 0
-      for (const product of (products ?? []) as any[]) {
-        for (const variant of product?.variants ?? []) {
+      for (const link of links) {
+        for (const variant of link?.product?.variants ?? []) {
           storeVariants++
           const prices = variant?.price_set?.prices ?? []
           for (const price of prices) {


### PR DESCRIPTION
## Summary

Second hotfix to `fanout-existing-variant-prices.ts`. PR #306 switched the variants query to `product` entity with `{ sales_channels: { id } }` filter — but MikroORM rejected that:

```
Trying to query by not existing property Product.sales_channels
```

`Product` doesn't own a `sales_channels` relation; the join lives on the link entity. Re-pivot to query the `sales_channel` entity and walk through `products_link.product.variants.price_set.prices`. Pattern is taken from `apps/backend/src/workflows/partner/list-store-products.ts:51-64`, which is the production code path partner-ui actually uses for store product listing.

Both prior failed shapes are now documented inline in the script as a "what didn't work" comment so the next person doesn't re-discover them.

## Discovery

Task `9855c6da897747e183489da4ea06c0c1` (DRY_RUN=1) → exit 1 with the MikroORM error above. Steps 1 and 2 of the 0A backfill remain unaffected and dry-run-validated.

## Test plan

- [ ] CI green.
- [ ] After merge + deploy, re-run `DRY_RUN=1 ./run-backfill.sh fanout-existing-variant-prices` — expect per-partner / per-store line counts (variants, price rows) and a `Targeting <N> fanout invocations` summary, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)