### PR TITLE
feat(production-runs): roadmap 27 — auto-link partners to design on assignment

### DIFF
--- a/apps/backend/integration-tests/http/production-run-design-partner-auto-link.spec.ts
+++ b/apps/backend/integration-tests/http/production-run-design-partner-auto-link.spec.ts
@@ -1,0 +1,358 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import designPartnersLink from "../../src/links/design-partners-link"
+import backfillDesignPartnersFromRuns from "../../src/scripts/backfill-design-partners-from-runs"
+import { DESIGN_MODULE } from "../../src/modules/designs"
+import { PARTNER_MODULE } from "../../src/modules/partner"
+
+jest.setTimeout(180_000)
+
+// Verifies roadmap item 27: production-run assignments auto-mirror
+// into design_partners_link so /partners/designs surfaces the design
+// to the partner who got the production run. Sister to
+// production-run-partner-status.spec.ts which exercises the same
+// workflow path end-to-end. The bug this test guards against: a
+// design that was previously linked to one partner (e.g. via the
+// explicit /admin/designs/:id/partners route) but re-assigned via a
+// production run to a different partner used to leave the new
+// partner without a design_partners_link row — they could see the
+// production run but not the design.
+
+const PARTNER_PASSWORD = "supersecret"
+
+async function createPartner(api: any, label: string) {
+  const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+  const email = `dpartner-${label}-${unique}@jyt.test`
+  await api.post("/auth/partner/emailpass/register", {
+    email,
+    password: PARTNER_PASSWORD,
+  })
+  let login = await api.post("/auth/partner/emailpass", {
+    email,
+    password: PARTNER_PASSWORD,
+  })
+  let headers: Record<string, string> = {
+    Authorization: `Bearer ${login.data.token}`,
+  }
+
+  const partnerRes = await api.post(
+    "/partners",
+    {
+      name: `DPartner ${label} ${unique}`,
+      handle: `dpartner-${label}-${unique}`,
+      admin: { email, first_name: "Test", last_name: "Partner" },
+    },
+    { headers }
+  )
+  expect(partnerRes.status).toBe(200)
+
+  login = await api.post("/auth/partner/emailpass", {
+    email,
+    password: PARTNER_PASSWORD,
+  })
+  headers = { Authorization: `Bearer ${login.data.token}` }
+
+  return {
+    partnerId: partnerRes.data.partner.id as string,
+    partnerHeaders: headers,
+  }
+}
+
+async function createDesign(api: any, adminHeaders: any, label: string) {
+  const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+  const res = await api.post(
+    "/admin/designs",
+    {
+      name: `DPartner Design ${label} ${unique}`,
+      description: "design_partners_link auto-link test",
+      design_type: "Original",
+      status: "Approved",
+      priority: "Medium",
+    },
+    adminHeaders
+  )
+  expect(res.status).toBe(201)
+  return res.data.design.id as string
+}
+
+async function countDesignPartnerLinks(
+  container: any,
+  design_id: string,
+  partner_id: string
+) {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const { data } = await query.graph({
+    entity: designPartnersLink.entryPoint,
+    filters: { design_id, partner_id },
+    fields: ["design_id", "partner_id"],
+  })
+  return data?.length ?? 0
+}
+
+async function listDesignPartnerIds(container: any, design_id: string) {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const { data } = await query.graph({
+    entity: designPartnersLink.entryPoint,
+    filters: { design_id },
+    fields: ["partner_id"],
+  })
+  return (data ?? []).map((l: any) => l.partner_id).filter(Boolean)
+}
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("approveProductionRunWorkflow → design_partners_link auto-link (roadmap 27)", () => {
+    let adminHeaders: Record<string, any>
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+      // The partner-created subscriber needs this template; failure
+      // here would mask the real assertions.
+      try {
+        await api.post(
+          "/admin/email-templates",
+          {
+            name: "Admin Partner Created",
+            template_key: "partner-created-from-admin",
+            subject: "s",
+            html_content: "<div>ok</div>",
+            from: "t@t.com",
+            variables: {},
+            template_type: "email",
+          },
+          adminHeaders
+        )
+      } catch {}
+    })
+
+    it("auto-links the design to the assigned partner when no explicit link exists", async () => {
+      const { partnerId } = await createPartner(api, "auto")
+      const designId = await createDesign(api, adminHeaders, "auto")
+      const container = getContainer()
+
+      // Sanity: no existing design ↔ partner link.
+      expect(await countDesignPartnerLinks(container, designId, partnerId)).toBe(0)
+
+      // Assigning a production run with this partner — no explicit
+      // /admin/designs/:id/partners call.
+      const res = await api.post(
+        `/admin/designs/${designId}/production-runs`,
+        {
+          assignments: [{ partner_id: partnerId, quantity: 1 }],
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      expect(res.data.children?.length).toBeGreaterThan(0)
+
+      // Link now exists.
+      expect(await countDesignPartnerLinks(container, designId, partnerId)).toBe(1)
+    })
+
+    it("is idempotent — re-assigning the same partner does not duplicate the link", async () => {
+      const { partnerId } = await createPartner(api, "idem")
+      const designId = await createDesign(api, adminHeaders, "idem")
+      const container = getContainer()
+
+      const first = await api.post(
+        `/admin/designs/${designId}/production-runs`,
+        {
+          assignments: [{ partner_id: partnerId, quantity: 1 }],
+        },
+        adminHeaders
+      )
+      expect(first.status).toBe(201)
+      expect(await countDesignPartnerLinks(container, designId, partnerId)).toBe(1)
+
+      // Second run, same partner.
+      const second = await api.post(
+        `/admin/designs/${designId}/production-runs`,
+        {
+          assignments: [{ partner_id: partnerId, quantity: 2 }],
+        },
+        adminHeaders
+      )
+      expect(second.status).toBe(201)
+
+      // Still exactly one link row.
+      expect(await countDesignPartnerLinks(container, designId, partnerId)).toBe(1)
+    })
+
+    it("is additive — assigning to a new partner keeps the existing link in place", async () => {
+      const { partnerId: partnerA } = await createPartner(api, "addA")
+      const { partnerId: partnerB } = await createPartner(api, "addB")
+      const designId = await createDesign(api, adminHeaders, "add")
+      const container = getContainer()
+
+      // First assignment links A.
+      await api.post(
+        `/admin/designs/${designId}/production-runs`,
+        {
+          assignments: [{ partner_id: partnerA, quantity: 1 }],
+        },
+        adminHeaders
+      )
+      expect(await countDesignPartnerLinks(container, designId, partnerA)).toBe(1)
+      expect(await countDesignPartnerLinks(container, designId, partnerB)).toBe(0)
+
+      // Second assignment to B — A must remain linked.
+      await api.post(
+        `/admin/designs/${designId}/production-runs`,
+        {
+          assignments: [{ partner_id: partnerB, quantity: 1 }],
+        },
+        adminHeaders
+      )
+      const linkedIds = await listDesignPartnerIds(container, designId)
+      expect(linkedIds).toContain(partnerA)
+      expect(linkedIds).toContain(partnerB)
+    })
+
+    it("makes the design appear in the new partner's /partners/designs", async () => {
+      const { partnerId, partnerHeaders } = await createPartner(api, "visible")
+      const designId = await createDesign(api, adminHeaders, "visible")
+
+      // Pre-state: partner sees no designs from this run yet.
+      const before = await api.get("/partners/designs?limit=100", {
+        headers: partnerHeaders,
+      })
+      const beforeIds = (before.data.designs || []).map((d: any) => d.id)
+      expect(beforeIds).not.toContain(designId)
+
+      // Assign the run.
+      await api.post(
+        `/admin/designs/${designId}/production-runs`,
+        {
+          assignments: [{ partner_id: partnerId, quantity: 1 }],
+        },
+        adminHeaders
+      )
+
+      // The partner now sees this design on /partners/designs.
+      const after = await api.get("/partners/designs?limit=100", {
+        headers: partnerHeaders,
+      })
+      const afterIds = (after.data.designs || []).map((d: any) => d.id)
+      expect(afterIds).toContain(designId)
+    })
+  })
+
+  describe("scripts/backfill-design-partners-from-runs (roadmap 27)", () => {
+    let adminHeaders: Record<string, any>
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+      try {
+        await api.post(
+          "/admin/email-templates",
+          {
+            name: "Admin Partner Created",
+            template_key: "partner-created-from-admin",
+            subject: "s",
+            html_content: "<div>ok</div>",
+            from: "t@t.com",
+            variables: {},
+            template_type: "email",
+          },
+          adminHeaders
+        )
+      } catch {}
+    })
+
+    it("recovers legacy runs whose design_partners_link row was dismissed", async () => {
+      const { partnerId } = await createPartner(api, "bf")
+      const designId = await createDesign(api, adminHeaders, "bf")
+      const container = getContainer()
+      const remoteLink = container.resolve(
+        ContainerRegistrationKeys.LINK
+      ) as any
+
+      // Approve via the workflow — link gets auto-created by the
+      // fix this same PR ships. To simulate legacy state (run exists
+      // but link doesn't), dismiss the link after creation.
+      await api.post(
+        `/admin/designs/${designId}/production-runs`,
+        {
+          assignments: [{ partner_id: partnerId, quantity: 1 }],
+        },
+        adminHeaders
+      )
+      expect(await countDesignPartnerLinks(container, designId, partnerId)).toBe(1)
+
+      await remoteLink.dismiss({
+        [DESIGN_MODULE]: { design_id: designId },
+        [PARTNER_MODULE]: { partner_id: partnerId },
+      })
+      expect(await countDesignPartnerLinks(container, designId, partnerId)).toBe(0)
+
+      // Backfill should re-create the link from the still-existing
+      // production_run row.
+      await backfillDesignPartnersFromRuns({ container, args: [] } as any)
+
+      expect(await countDesignPartnerLinks(container, designId, partnerId)).toBe(1)
+    })
+
+    it("is a no-op on a clean DB and is idempotent across re-runs", async () => {
+      const { partnerId } = await createPartner(api, "noop")
+      const designId = await createDesign(api, adminHeaders, "noop")
+      const container = getContainer()
+
+      await api.post(
+        `/admin/designs/${designId}/production-runs`,
+        {
+          assignments: [{ partner_id: partnerId, quantity: 1 }],
+        },
+        adminHeaders
+      )
+
+      // First backfill: link already there from the workflow → no
+      // additional creates.
+      await backfillDesignPartnersFromRuns({ container, args: [] } as any)
+      expect(await countDesignPartnerLinks(container, designId, partnerId)).toBe(1)
+
+      // Second backfill: still exactly one.
+      await backfillDesignPartnersFromRuns({ container, args: [] } as any)
+      expect(await countDesignPartnerLinks(container, designId, partnerId)).toBe(1)
+    })
+
+    it("--dry-run leaves the link table untouched", async () => {
+      const { partnerId } = await createPartner(api, "dry")
+      const designId = await createDesign(api, adminHeaders, "dry")
+      const container = getContainer()
+      const remoteLink = container.resolve(
+        ContainerRegistrationKeys.LINK
+      ) as any
+
+      await api.post(
+        `/admin/designs/${designId}/production-runs`,
+        {
+          assignments: [{ partner_id: partnerId, quantity: 1 }],
+        },
+        adminHeaders
+      )
+
+      // Simulate legacy state.
+      await remoteLink.dismiss({
+        [DESIGN_MODULE]: { design_id: designId },
+        [PARTNER_MODULE]: { partner_id: partnerId },
+      })
+
+      // Dry run — no mutation.
+      await backfillDesignPartnersFromRuns({
+        container,
+        args: ["--dry-run"],
+      } as any)
+      expect(await countDesignPartnerLinks(container, designId, partnerId)).toBe(0)
+
+      // Real run mutates.
+      await backfillDesignPartnersFromRuns({ container, args: [] } as any)
+      expect(await countDesignPartnerLinks(container, designId, partnerId)).toBe(1)
+    })
+  })
+})

--- a/apps/backend/src/scripts/backfill-design-partners-from-runs.ts
+++ b/apps/backend/src/scripts/backfill-design-partners-from-runs.ts
@@ -1,0 +1,172 @@
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import designPartnersLink from "../links/design-partners-link"
+import { DESIGN_MODULE } from "../modules/designs"
+import { PARTNER_MODULE } from "../modules/partner"
+
+/**
+ * Backfill `design_partners_link` rows from existing partner-assigned
+ * production runs.
+ *
+ * Why: roadmap item 27. Before
+ * `apps/backend/src/workflows/production-runs/approve-production-run.ts`
+ * was extended to mirror (design, partner) edges into
+ * `design_partners_link`, assignments only set `run.partner_id` and
+ * created partner-task links. The partner-side `/partners/designs`
+ * surface queries `design_partners_link`, so designs assigned via
+ * production runs never appeared on the partner's design list — they
+ * could see the run but not the design (e.g. design
+ * `01KPET5HBGNH9QXGC0MC8RHR39` was re-assigned to Sharlho via a
+ * production run but the design_partners_link still pointed at the
+ * earlier assignee).
+ *
+ * This script walks every non-cancelled production_run with a
+ * `partner_id` + `design_id` and creates the missing
+ * `design_partners_link` row. Additive — never removes any existing
+ * link, never replaces. Multiple partners stay linked to the same
+ * design.
+ *
+ * Idempotent: skips (design_id, partner_id) pairs that already have a
+ * link row. Safe to re-run.
+ *
+ * Run:
+ *   npx medusa exec ./src/scripts/backfill-design-partners-from-runs.ts
+ *
+ * Dry run — logs what would happen, creates nothing:
+ *   - Args:    npx medusa exec ./src/scripts/backfill-design-partners-from-runs.ts -- --dry-run
+ *   - Env var: DRY_RUN=1 npx medusa exec ./src/scripts/backfill-design-partners-from-runs.ts
+ *
+ * Scope:
+ *   --partner-ids=par_a,par_b   (or PARTNER_IDS=…)  — limit to a subset of partners
+ *   --design-ids=des_a,des_b    (or DESIGN_IDS=…)   — limit to a subset of designs
+ */
+export default async function backfillDesignPartnersFromRuns({
+  container,
+  args,
+}: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const remoteLink = container.resolve(
+    ContainerRegistrationKeys.LINK
+  ) as any
+
+  const argList = args ?? []
+  const dryRun = argList.includes("--dry-run") || process.env.DRY_RUN === "1"
+
+  const parseListArg = (flag: string, envVar: string): string[] | null => {
+    const fromArg = argList
+      .map((a) => (a.startsWith(`${flag}=`) ? a.slice(flag.length + 1) : null))
+      .find((v): v is string => v !== null)
+    const raw = fromArg ?? process.env[envVar] ?? ""
+    if (!raw.trim()) return null
+    return raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+  }
+
+  const partnerIdFilter = parseListArg("--partner-ids", "PARTNER_IDS")
+  const designIdFilter = parseListArg("--design-ids", "DESIGN_IDS")
+
+  if (dryRun) logger.info("DRY RUN — no links will be created.")
+  if (partnerIdFilter?.length) {
+    logger.info(`Partner scope: ${partnerIdFilter.join(", ")}`)
+  }
+  if (designIdFilter?.length) {
+    logger.info(`Design scope: ${designIdFilter.join(", ")}`)
+  }
+
+  // 1. Every non-cancelled run with both a partner and a design.
+  const { data: runs } = await query.graph({
+    entity: "production_runs",
+    filters: { status: { $nin: ["cancelled"] } } as any,
+    fields: ["id", "design_id", "partner_id", "status"],
+    pagination: { skip: 0, take: 5000 },
+  })
+
+  // 2. Distinct (design_id, partner_id) pairs from those runs, with
+  //    the scoping filters applied.
+  const pairKey = (designId: string, partnerId: string) =>
+    `${designId}::${partnerId}`
+  const wantedPairs = new Map<string, { design_id: string; partner_id: string }>()
+  for (const r of (runs ?? []) as any[]) {
+    const designId = r?.design_id
+    const partnerId = r?.partner_id
+    if (!designId || !partnerId) continue
+    if (partnerIdFilter && !partnerIdFilter.includes(partnerId)) continue
+    if (designIdFilter && !designIdFilter.includes(designId)) continue
+    wantedPairs.set(pairKey(designId, partnerId), {
+      design_id: designId,
+      partner_id: partnerId,
+    })
+  }
+
+  if (!wantedPairs.size) {
+    logger.info(
+      `No partner-assigned production runs found${
+        partnerIdFilter || designIdFilter ? " within the given scope" : ""
+      }. Nothing to backfill.`
+    )
+    return
+  }
+
+  // 3. Existing design_partners_link rows for the wanted designs only.
+  //    Filtering server-side keeps the query fast on a busy DB.
+  const designIds = Array.from(
+    new Set(Array.from(wantedPairs.values()).map((p) => p.design_id))
+  )
+  const { data: existingLinks } = await query.graph({
+    entity: designPartnersLink.entryPoint,
+    filters: { design_id: designIds },
+    fields: ["design_id", "partner_id"],
+  })
+  const linkedPairs = new Set<string>(
+    (existingLinks ?? []).map((l: any) => pairKey(l.design_id, l.partner_id))
+  )
+
+  let created = 0
+  let alreadyLinked = 0
+  const errors: Array<{ design_id: string; partner_id: string; error: string }> = []
+
+  for (const { design_id, partner_id } of wantedPairs.values()) {
+    const tag = `design ${design_id} ↔ partner ${partner_id}`
+    if (linkedPairs.has(pairKey(design_id, partner_id))) {
+      alreadyLinked++
+      continue
+    }
+
+    if (dryRun) {
+      logger.info(`${tag}: WOULD create link`)
+      created++
+      continue
+    }
+
+    try {
+      await remoteLink.create({
+        [DESIGN_MODULE]: { design_id },
+        [PARTNER_MODULE]: { partner_id },
+      })
+      linkedPairs.add(pairKey(design_id, partner_id))
+      logger.info(`${tag}: created link`)
+      created++
+    } catch (err) {
+      const message = err instanceof Error ? err.message : JSON.stringify(err)
+      logger.error(`${tag}: failed — ${message}`)
+      errors.push({ design_id, partner_id, error: message })
+    }
+  }
+
+  logger.info(
+    `Backfill complete. created=${created}, already_linked=${alreadyLinked}, pairs=${wantedPairs.size}, errors=${errors.length}${
+      dryRun ? " (DRY RUN)" : ""
+    }`
+  )
+
+  if (errors.length) {
+    logger.error("Errors during backfill — review the log above:")
+    for (const e of errors) {
+      logger.error(`  design=${e.design_id} partner=${e.partner_id}: ${e.error}`)
+    }
+    process.exitCode = 1
+  }
+}

--- a/apps/backend/src/workflows/production-runs/approve-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/approve-production-run.ts
@@ -6,12 +6,17 @@ import {
   WorkflowResponse,
   transform,
 } from "@medusajs/framework/workflows-sdk"
+import type { LinkDefinition } from "@medusajs/framework/types"
 
 import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
 import type ProductionRunService from "../../modules/production_runs/service"
 
 import { PRODUCTION_POLICY_MODULE } from "../../modules/production_policy"
 import type ProductionPolicyService from "../../modules/production_policy/service"
+
+import { DESIGN_MODULE } from "../../modules/designs"
+import { PARTNER_MODULE } from "../../modules/partner"
+import designPartnersLink from "../../links/design-partners-link"
 
 export type ProductionRunAssignment = {
   partner_id: string
@@ -188,6 +193,78 @@ const approveProductionRunStep = createStep(
   }
 )
 
+/**
+ * Roadmap item 27 — when an admin assigns a production run to a
+ * partner, that partner should also appear in the design's
+ * `design_partners_link` so the design surfaces in the partner's
+ * `/partners/designs` listing. The path was previously additive in
+ * intent but only the production-run side got updated, leaving
+ * /partners/designs blind to assignments that came in via this
+ * workflow. Re-using `designPartnersLink.entryPoint` keeps the
+ * idempotency check cheap and avoids duplicate rows.
+ */
+const linkDesignToPartnersStep = createStep(
+  "link-design-to-partners",
+  async (
+    input: { design_id: string | null; partner_ids: string[] },
+    { container }
+  ) => {
+    if (!input.design_id || !input.partner_ids.length) {
+      return new StepResponse({ created: 0, already_linked: 0 }, [])
+    }
+
+    const query = container.resolve(ContainerRegistrationKeys.QUERY)
+    const remoteLink = container.resolve(
+      ContainerRegistrationKeys.LINK
+    ) as any
+
+    // Existing links for this design — used to skip already-linked pairs.
+    // Querying once and filtering in memory is cheaper than N round trips
+    // when an admin assigns to many partners at once.
+    const { data: existing } = await query.graph({
+      entity: designPartnersLink.entryPoint,
+      filters: { design_id: input.design_id },
+      fields: ["partner_id"],
+    })
+    const linkedPartnerIds = new Set<string>(
+      (existing ?? []).map((l: any) => l.partner_id).filter(Boolean)
+    )
+
+    const toCreate: LinkDefinition[] = []
+    let alreadyLinked = 0
+    for (const partnerId of input.partner_ids) {
+      if (!partnerId) continue
+      if (linkedPartnerIds.has(partnerId)) {
+        alreadyLinked++
+        continue
+      }
+      toCreate.push({
+        [DESIGN_MODULE]: { design_id: input.design_id },
+        [PARTNER_MODULE]: { partner_id: partnerId },
+      })
+      // Track in the local set so duplicate partner_ids in the same
+      // assignments array don't push two link entries.
+      linkedPartnerIds.add(partnerId)
+    }
+
+    if (toCreate.length) {
+      await remoteLink.create(toCreate)
+    }
+
+    return new StepResponse(
+      { created: toCreate.length, already_linked: alreadyLinked },
+      toCreate
+    )
+  },
+  async (links: LinkDefinition[] | undefined, { container }) => {
+    if (!links?.length) return
+    const remoteLink = container.resolve(
+      ContainerRegistrationKeys.LINK
+    ) as any
+    await remoteLink.dismiss(links)
+  }
+)
+
 export const approveProductionRunWorkflow = createWorkflow(
   "approve-production-run",
   (input: ApproveProductionRunInput) => {
@@ -212,6 +289,19 @@ export const approveProductionRunWorkflow = createWorkflow(
       production_run_id: input.production_run_id,
       assignments,
     })
+
+    // After child runs land, mirror the (design, partner) edges into
+    // `design_partners_link` so the partners-side `/partners/designs`
+    // surface picks them up. Compensation rolls the link rows we
+    // created (idempotent — already-linked pairs are no-ops on both
+    // create and rollback).
+    const designPartnerLinkInput = transform({ run, assignments }, (data) => ({
+      design_id: ((data.run as any)?.design_id as string | null) ?? null,
+      partner_ids: ((data.assignments as any[]) ?? [])
+        .map((a) => a?.partner_id as string | undefined)
+        .filter((id): id is string => !!id),
+    }))
+    linkDesignToPartnersStep(designPartnerLinkInput)
 
     return new WorkflowResponse(approved)
   }

--- a/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
+++ b/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
@@ -280,8 +280,9 @@ Plus a one-line seed for the email template body.
 
 #### 27. Auto-link partner to design on production-run assignment
 
-Surfaced 2026-06-04 testing partner-side visibility after the bug-25
-fix. Design `01KPET5HBGNH9QXGC0MC8RHR39` ("White Envelope Dress")
+**Status: SHIPPED 2026-06-04.** Branch `feat/27-design-partner-auto-link`.
+Surfaced earlier the same day testing partner-side visibility after
+the bug-25 fix. Design `01KPET5HBGNH9QXGC0MC8RHR39` ("White Envelope Dress")
 was originally linked in `design_partners_link` to Shramdaan. Admin
 then created a production run + assigned it to Sharlho (Tarunsharma).
 Sharlho can see the production run in `/partners/production-runs`
@@ -310,9 +311,29 @@ Fix outline:
   from 0A — dry-run aware, scoped via `--partner-ids` /
   `--design-ids`, surfaced via `run-backfill.sh`.
 
-**Effort:** 1-2 hours for the workflow step + backfill script +
-integration test, plus the run via `run-backfill.sh` afterward to
-fix the existing drift on prod.
+**Shipped:**
+- `linkDesignToPartnersStep` added to
+  `apps/backend/src/workflows/production-runs/approve-production-run.ts`.
+  Runs after the children are created, upserts only the
+  missing `(design_id, partner_id)` pairs, and has a rollback that
+  dismisses just the rows it created.
+- `apps/backend/src/scripts/backfill-design-partners-from-runs.ts`
+  walks every non-cancelled production_run with `partner_id` +
+  `design_id`, creates the missing link rows. Mirrors the 0A recipe:
+  `DRY_RUN=1`, `--partner-ids` / `--design-ids` scoping, error
+  surfacing, exit code 1 on failures.
+- 7 integration tests in
+  `integration-tests/http/production-run-design-partner-auto-link.spec.ts`
+  covering auto-link on first assignment, idempotency, additive
+  behaviour, `/partners/designs` visibility, plus the backfill
+  scenarios (recovery, no-op, dry-run).
+
+**Next step (post-deploy):** run
+`./deploy/aws/scripts/run-backfill.sh backfill-design-partners-from-runs`
+with `DRY_RUN=1` first, then for real, to repair the existing drift
+on prod (e.g. design `01KPET5HBGNH9QXGC0MC8RHR39` re-assigned to
+Sharlho via a production run but linked to Shramdaan in
+`design_partners_link`).
 
 ### Partner platform extensions
 


### PR DESCRIPTION
## Summary

Roadmap item **27** — fixes the design ↔ partner drift between production-run assignments and `design_partners_link`.

**Before:** assigning a production run to a partner set `run.partner_id` and created partner-task links but did **not** update `design_partners_link`. The partner-side `/partners/designs` queries that link table, so designs assigned via the production-run path never appeared on the partner's design list. Real example: design `01KPET5HBGNH9QXGC0MC8RHR39` was re-assigned to Sharlho via a production run, but `design_partners_link` still pointed at the earlier assignee (Shramdaan), so Sharlho saw the run but not the design.

**After:** assignment auto-upserts the link, additively. Design can be linked to many partners; explicit `/admin/designs/:id/partners` route continues to work as a separate path.

## Three pieces

1. **`linkDesignToPartnersStep`** in `approveProductionRunWorkflow` — upserts only the missing pairs after children are created. Idempotent + additive. Compensation dismisses just the rows the step created.

2. **`backfill-design-partners-from-runs.ts`** — walks every non-cancelled run with `partner_id` + `design_id`, creates the missing link rows. Mirrors the 0A recipe: `DRY_RUN=1`, `--partner-ids` / `--design-ids` scoping, error surfacing.

3. **7 integration tests** — auto-link on first assignment, idempotency, additive behaviour, `/partners/designs` visibility, plus the backfill scenarios (legacy recovery, no-op, dry-run). All pass locally in 18s.

## Test plan

- [x] Integration tests pass locally (7/7).
- [ ] CodeQL + Vercel pass on this PR.
- [ ] **After merge + deploy:** run the backfill against prod via:
  ```
  DRY_RUN=1 FOLLOW=1 ./deploy/aws/scripts/run-backfill.sh backfill-design-partners-from-runs
  FOLLOW=1     ./deploy/aws/scripts/run-backfill.sh backfill-design-partners-from-runs
  ```
- [ ] **Verify on prod:** Tarunsharma (Sharlho) logs in via partner API and sees design `01KPET5HBGNH9QXGC0MC8RHR39` in `/partners/designs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)