### PR TITLE
feat(visual-flows): emit started + failed lifecycle events + admin email (roadmap #26)

### DIFF
--- a/apps/backend/integration-tests/http/visual-flow-lifecycle-email.spec.ts
+++ b/apps/backend/integration-tests/http/visual-flow-lifecycle-email.spec.ts
@@ -1,0 +1,201 @@
+/**
+ * Visual Flow Lifecycle Email — integration test (roadmap item 26)
+ *
+ * Covers two angles:
+ *
+ *   1. The execute-visual-flow workflow emits
+ *      `visual_flow_execution.started` on entry and
+ *      `visual_flow_execution.failed` on operation failure (via the
+ *      compensation path), with the failing-operation key and the
+ *      real operation error message included on the failed event.
+ *
+ *   2. The subscriber's in-memory throttle + error-fingerprint helper
+ *      collapse repeated failures with the same shape so a broken
+ *      flow that fans out N reminders only sends 1 email per
+ *      throttle window.
+ *
+ * Run:
+ *   pnpm test:integration:http:shared ./integration-tests/http/visual-flow-lifecycle-email
+ */
+
+import { Modules } from "@medusajs/framework/utils"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { __testing as lifecycleTesting } from "../../src/subscribers/visual-flow-lifecycle-email"
+
+jest.setTimeout(120_000)
+
+// Canvas with one `execute_code` operation that throws. Chosen because
+// `execute_code` runs in-process (no Meta / OpenRouter / SMTP) so the
+// test is deterministic in CI and the failure happens inside the
+// per-operation try/catch — exactly the path that writes a "failure"
+// row to the log table, which the compensation reads to surface the
+// real error in the emitted event.
+function buildFailingCanvas() {
+  return {
+    nodes: [
+      {
+        id: "trigger",
+        type: "trigger",
+        position: { x: 400, y: 0 },
+        data: { label: "Manual Trigger" },
+      },
+      {
+        id: "op_throw",
+        type: "operation",
+        position: { x: 400, y: 150 },
+        data: {
+          operationKey: "throw_op",
+          operationType: "execute_code",
+          label: "Throws",
+          options: {
+            code: "throw new Error('intentional test failure')",
+          },
+        },
+      },
+    ],
+    edges: [
+      {
+        id: "e1",
+        source: "trigger",
+        target: "op_throw",
+        sourceHandle: "default",
+        targetHandle: "default",
+      },
+    ],
+  }
+}
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("execute-visual-flow → lifecycle events (roadmap 26)", () => {
+    // `getAuthHeaders` returns `{ headers: { Authorization } }` — the
+    // axios-friendly request-config shape. Carry it through verbatim
+    // so we don't have to unwrap on every call site.
+    let headers: Record<string, any>
+
+    beforeAll(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      headers = await getAuthHeaders(api)
+    })
+
+    it("emits started + failed events with the failing operation key", async () => {
+      const container = getContainer()
+      const eventBus: any = container.resolve(Modules.EVENT_BUS)
+
+      const captured: Array<{ name: string; data: any }> = []
+      const recorder = async (payload: any) => {
+        const evts = Array.isArray(payload) ? payload : [payload]
+        for (const e of evts) {
+          if (
+            e?.name === "visual_flow_execution.started" ||
+            e?.name === "visual_flow_execution.failed"
+          ) {
+            captured.push({ name: e.name, data: e.data })
+          }
+        }
+      }
+      // Subscribe to both names — local-event-bus supports either
+      // direct subscribe (name) or a wildcard. Two explicit subs is
+      // the most portable shape across in-memory + redis impls.
+      eventBus.subscribe("visual_flow_execution.started", recorder)
+      eventBus.subscribe("visual_flow_execution.failed", recorder)
+
+      try {
+        const createResp = await api.post(
+          "/admin/visual-flows",
+          {
+            name: "VF Lifecycle Test — Failing Flow",
+            status: "active",
+            trigger_type: "manual",
+            metadata: {
+              failure_email: "lifecycle-test@jyt.test",
+            },
+            canvas_state: buildFailingCanvas(),
+          },
+          headers
+        )
+        expect(createResp.status).toBe(201)
+        const flowId = createResp.data.flow.id as string
+
+        const execResp = await api.post(
+          `/admin/visual-flows/${flowId}/execute`,
+          { trigger_data: { source: "lifecycle_test" } },
+          { ...headers, validateStatus: () => true }
+        )
+        // The workflow re-throws when the operation throws — admin
+        // route turns that into a non-2xx. Either shape is fine for
+        // this test; the lifecycle events are the contract.
+        expect([200, 400, 500]).toContain(execResp.status)
+
+        // Subscribers run after the workflow emits — small grace
+        // window so the in-memory bus drains before assertions.
+        await new Promise((r) => setTimeout(r, 250))
+
+        const started = captured.find(
+          (e) => e.name === "visual_flow_execution.started"
+        )
+        const failed = captured.find(
+          (e) => e.name === "visual_flow_execution.failed"
+        )
+
+        expect(started).toBeDefined()
+        expect(started!.data.flow_id).toBe(flowId)
+        expect(started!.data.execution_id).toBeDefined()
+
+        expect(failed).toBeDefined()
+        expect(failed!.data.flow_id).toBe(flowId)
+        expect(failed!.data.execution_id).toBe(started!.data.execution_id)
+        expect(failed!.data.failing_operation_key).toBe("throw_op")
+        // The real error survives into the event (vs the generic
+        // "Workflow cancelled during execution" pre-fix message).
+        expect(String(failed!.data.error_message)).toMatch(
+          /intentional test failure/i
+        )
+        // The flow metadata reaches the event payload so the
+        // subscriber can route to flow.metadata.failure_email.
+        expect(failed!.data.flow_metadata).toMatchObject({
+          failure_email: "lifecycle-test@jyt.test",
+        })
+      } finally {
+        // Best-effort unsubscribe — not every event-bus impl exposes
+        // unsubscribe on the public surface, so swallow.
+        try {
+          eventBus.unsubscribe?.("visual_flow_execution.started", recorder)
+          eventBus.unsubscribe?.("visual_flow_execution.failed", recorder)
+        } catch {
+          /* ignore */
+        }
+      }
+    })
+  })
+
+  describe("visual-flow-lifecycle-email subscriber helpers", () => {
+    beforeEach(() => {
+      lifecycleTesting.clearThrottle()
+    })
+
+    it("fingerprint normalises ULID-like ids and truncates", () => {
+      // Real Medusa IDs are Crockford base32 ULIDs (e.g.
+      // `01KPET5HBGNH9QXGC0MC8RHR39`) — alphanumeric, not hex — so
+      // the fingerprint regex must collapse alphanumeric runs, not
+      // just hex.
+      const fp1 = lifecycleTesting.fingerprint(
+        "Meta error: template 01KPET5HBGNH9QXGC0MC8RHR39 has no header component"
+      )
+      const fp2 = lifecycleTesting.fingerprint(
+        "Meta error: template 01KT8ZDV1BPG37K7VTF0D3T4YD has no header component"
+      )
+      // Both errors describe the same problem with different IDs; the
+      // normalised fingerprint should collapse them onto one bucket so
+      // the throttle actually deduplicates.
+      expect(fp1).toEqual(fp2)
+      // Length cap keeps the throttle key bounded regardless of
+      // error-message verbosity.
+      const long = lifecycleTesting.fingerprint("x".repeat(500))
+      expect(long.length).toBeLessThanOrEqual(60)
+    })
+  })
+})

--- a/apps/backend/src/scripts/seed-visual-flow-lifecycle-email-templates.ts
+++ b/apps/backend/src/scripts/seed-visual-flow-lifecycle-email-templates.ts
@@ -1,0 +1,184 @@
+/**
+ * Seed (or refresh) the two email templates used by the visual-flow
+ * lifecycle subscriber:
+ *
+ *   - `visual-flow-started`  → light "flow X started" ack
+ *   - `visual-flow-failure`  → full error report when a flow execution
+ *                              lands as failed
+ *
+ * Re-runnable. Admins can edit the body / subject in the admin UI
+ * without re-deploying because the subscriber renders by template_key.
+ *
+ * Run:
+ *   npx medusa exec ./src/scripts/seed-visual-flow-lifecycle-email-templates.ts
+ */
+
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { EMAIL_TEMPLATES_MODULE } from "../modules/email_templates"
+
+type TemplateSpec = {
+  template_key: string
+  name: string
+  description: string
+  subject: string
+  html_content: string
+  variables: Record<string, string>
+}
+
+const STARTED: TemplateSpec = {
+  template_key: "visual-flow-started",
+  name: "Visual flow — execution started",
+  description:
+    "Sent to the configured admin recipient when a visual flow begins executing. Lets admins notice flows that started but never landed as completed.",
+  subject: "[Flow started] {{flow_name}}",
+  html_content: `<!doctype html>
+<html><head><meta charset="utf-8"><title>{{flow_name}}</title></head>
+<body style="margin:0;padding:0;background:#f7f5f0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Inter,sans-serif;color:#2a2620;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#f7f5f0;padding:32px 16px;">
+    <tr><td align="center">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:560px;background:#ffffff;border:1px solid #e5e0d3;border-radius:16px;overflow:hidden;">
+        <tr><td style="padding:32px 32px 8px;">
+          <p style="margin:0;font-style:italic;color:#5a7a3f;font-size:14px;">Started</p>
+          <h1 style="margin:8px 0 0;font-size:22px;line-height:1.25;color:#2a2620;">{{flow_name}}</h1>
+          <p style="margin:12px 0 0;font-size:14px;line-height:1.6;color:#5a534a;">Execution kicked off at {{started_at}}.</p>
+        </td></tr>
+        <tr><td style="padding:0 32px 24px;">
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="font-size:13px;color:#5a534a;">
+            <tr><td style="padding:6px 0;width:140px;color:#9a8e7c;">Execution ID</td>
+                <td style="padding:6px 0;font-family:ui-monospace,monospace;color:#2a2620;">{{execution_id}}</td></tr>
+            {{#if triggered_by_event}}
+            <tr><td style="padding:6px 0;color:#9a8e7c;">Triggered by event</td>
+                <td style="padding:6px 0;font-family:ui-monospace,monospace;color:#2a2620;">{{triggered_by_event}}</td></tr>
+            {{/if}}
+            {{#if triggered_by}}
+            <tr><td style="padding:6px 0;color:#9a8e7c;">Triggered by</td>
+                <td style="padding:6px 0;font-family:ui-monospace,monospace;color:#2a2620;">{{triggered_by}}</td></tr>
+            {{/if}}
+          </table>
+        </td></tr>
+        {{#if execution_url}}
+        <tr><td style="padding:0 32px 32px;">
+          <a href="{{execution_url}}" style="display:inline-block;background:#2a2620;color:#ffffff;text-decoration:none;font-weight:500;font-size:14px;padding:10px 18px;border-radius:999px;">Open execution</a>
+        </td></tr>
+        {{/if}}
+      </table>
+      <p style="margin:16px 0 0;font-size:12px;color:#9a8e7c;font-style:italic;">JYT visual flows · lifecycle notification.</p>
+    </td></tr>
+  </table>
+</body></html>`,
+  variables: {
+    flow_name: "string",
+    execution_id: "string",
+    triggered_by_event: "string",
+    triggered_by: "string",
+    started_at: "ISO date",
+    execution_url: "string",
+  },
+}
+
+const FAILURE: TemplateSpec = {
+  template_key: "visual-flow-failure",
+  name: "Visual flow — execution failed",
+  description:
+    "Sent to the configured admin recipient when a visual flow execution lands as failed. Includes failing operation key + error message so admins can diagnose without trawling logs.",
+  subject: "[Flow failed] {{flow_name}} — {{failing_operation_key}}",
+  html_content: `<!doctype html>
+<html><head><meta charset="utf-8"><title>{{flow_name}} failed</title></head>
+<body style="margin:0;padding:0;background:#f7f5f0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Inter,sans-serif;color:#2a2620;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#f7f5f0;padding:32px 16px;">
+    <tr><td align="center">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="max-width:560px;background:#ffffff;border:1px solid #e5e0d3;border-radius:16px;overflow:hidden;">
+        <tr><td style="padding:32px 32px 8px;">
+          <p style="margin:0;font-style:italic;color:#9a3f3f;font-size:14px;">Failed</p>
+          <h1 style="margin:8px 0 0;font-size:22px;line-height:1.25;color:#2a2620;">{{flow_name}}</h1>
+          <p style="margin:12px 0 0;font-size:14px;line-height:1.6;color:#5a534a;">Execution failed at {{failed_at}}.</p>
+        </td></tr>
+
+        <tr><td style="padding:24px 32px 8px;">
+          <h2 style="margin:0;font-size:14px;text-transform:uppercase;letter-spacing:0.05em;color:#9a8e7c;">Failure</h2>
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="font-size:13px;color:#5a534a;margin-top:8px;">
+            {{#if failing_operation_key}}
+            <tr><td style="padding:6px 0;width:140px;color:#9a8e7c;">Operation</td>
+                <td style="padding:6px 0;font-family:ui-monospace,monospace;color:#2a2620;">{{failing_operation_key}}</td></tr>
+            {{/if}}
+            <tr><td style="padding:6px 0;color:#9a8e7c;vertical-align:top;">Error</td>
+                <td style="padding:6px 0;font-family:ui-monospace,monospace;color:#9a3f3f;word-break:break-word;">{{error_message}}</td></tr>
+          </table>
+        </td></tr>
+
+        <tr><td style="padding:16px 32px 8px;">
+          <h2 style="margin:0;font-size:14px;text-transform:uppercase;letter-spacing:0.05em;color:#9a8e7c;">Context</h2>
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="font-size:13px;color:#5a534a;margin-top:8px;">
+            <tr><td style="padding:6px 0;width:140px;color:#9a8e7c;">Execution ID</td>
+                <td style="padding:6px 0;font-family:ui-monospace,monospace;color:#2a2620;">{{execution_id}}</td></tr>
+            {{#if triggered_by_event}}
+            <tr><td style="padding:6px 0;color:#9a8e7c;">Triggered by event</td>
+                <td style="padding:6px 0;font-family:ui-monospace,monospace;color:#2a2620;">{{triggered_by_event}}</td></tr>
+            {{/if}}
+            {{#if triggered_by}}
+            <tr><td style="padding:6px 0;color:#9a8e7c;">Triggered by</td>
+                <td style="padding:6px 0;font-family:ui-monospace,monospace;color:#2a2620;">{{triggered_by}}</td></tr>
+            {{/if}}
+          </table>
+        </td></tr>
+
+        {{#if execution_url}}
+        <tr><td style="padding:16px 32px 32px;">
+          <a href="{{execution_url}}" style="display:inline-block;background:#9a3f3f;color:#ffffff;text-decoration:none;font-weight:500;font-size:14px;padding:10px 18px;border-radius:999px;">Open execution</a>
+          <p style="margin:12px 0 0;font-size:12px;color:#9a8e7c;">Repeat failures with the same fingerprint are throttled per flow.</p>
+        </td></tr>
+        {{/if}}
+      </table>
+      <p style="margin:16px 0 0;font-size:12px;color:#9a8e7c;font-style:italic;">JYT visual flows · lifecycle notification.</p>
+    </td></tr>
+  </table>
+</body></html>`,
+  variables: {
+    flow_name: "string",
+    execution_id: "string",
+    failing_operation_key: "string",
+    error_message: "string",
+    triggered_by_event: "string",
+    triggered_by: "string",
+    failed_at: "ISO date",
+    execution_url: "string",
+  },
+}
+
+async function upsert(templates: any, spec: TemplateSpec, logger: any) {
+  const [existing] = await templates.listAndCountEmailTemplates(
+    { template_key: spec.template_key },
+    { take: 1 }
+  )
+  const current = existing?.[0]
+
+  const fields = {
+    name: spec.name,
+    description: spec.description,
+    template_key: spec.template_key,
+    subject: spec.subject,
+    html_content: spec.html_content,
+    is_active: true,
+    template_type: "transactional",
+    variables: spec.variables,
+  }
+
+  if (current) {
+    await templates.updateEmailTemplates({ id: current.id, ...fields })
+    logger.info(`Updated email template ${current.id} (${spec.template_key})`)
+  } else {
+    const created = await templates.createEmailTemplates(fields)
+    logger.info(`Created email template ${created.id} (${spec.template_key})`)
+  }
+}
+
+export default async function seedVisualFlowLifecycleEmailTemplates({
+  container,
+}: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const templates: any = container.resolve(EMAIL_TEMPLATES_MODULE)
+
+  await upsert(templates, STARTED, logger)
+  await upsert(templates, FAILURE, logger)
+}

--- a/apps/backend/src/subscribers/visual-flow-lifecycle-email.ts
+++ b/apps/backend/src/subscribers/visual-flow-lifecycle-email.ts
@@ -1,0 +1,196 @@
+import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { sendNotificationEmailWorkflow } from "../workflows/email"
+
+/**
+ * Subscriber: visual_flow_execution.{started,failed} → admin email
+ *
+ * Why this exists (roadmap item 26): when a visual-flow execution
+ * errored before this PR, it landed as `status=failed` (or `cancelled`
+ * at the wrapping workflow layer) with the generic message
+ * "Workflow cancelled during execution" and silence. The bug-25c
+ * diagnosis took three days because nobody knew the WhatsApp send had
+ * been rejected by Meta. Hooking a notification at start + on failure
+ * gives admins a paper trail and an in-inbox surface for diagnosis.
+ *
+ * Recipient resolution (first non-empty wins):
+ *   1. `flow.metadata.failure_email` (per-flow override, set in admin
+ *      UI without a deploy)
+ *   2. `process.env.VISUAL_FLOW_FAILURE_EMAIL` (platform default)
+ *   3. bail silently (logged) — we never want this subscriber to be
+ *      the reason an execution fails
+ *
+ * Throttle: an in-memory dedup window keyed by
+ *   - started: `started:<flow_id>`
+ *   - failed:  `failed:<flow_id>:<first 60 chars of error message>`
+ * suppresses duplicates within `THROTTLE_MS`. This is per-process; in a
+ * multi-worker deploy each worker will send at most one email per
+ * window, which is acceptable noise (1-2 emails per fanout burst, not
+ * 100). Redis-backed dedup is a follow-up if the per-worker emails
+ * become a real problem.
+ */
+
+const THROTTLE_MS = 10 * 60 * 1000
+
+// Module-scoped so it survives across subscriber invocations within
+// the same node process. Reset on deploy, which is the right TTL floor
+// anyway — a fresh deploy is a legitimate reason to re-page admins.
+const lastSentAt = new Map<string, number>()
+
+function shouldThrottle(key: string, now: number): boolean {
+  const prev = lastSentAt.get(key)
+  if (prev && now - prev < THROTTLE_MS) {
+    return true
+  }
+  lastSentAt.set(key, now)
+  // Opportunistic cleanup so the Map doesn't grow unbounded over the
+  // lifetime of the process. Cheap because we already paid for the
+  // iteration cost on the same hot path.
+  if (lastSentAt.size > 500) {
+    for (const [k, ts] of lastSentAt) {
+      if (now - ts > THROTTLE_MS) lastSentAt.delete(k)
+    }
+  }
+  return false
+}
+
+function resolveRecipient(data: any): string | null {
+  const fromMetadata = data?.flow_metadata?.failure_email
+  if (typeof fromMetadata === "string" && fromMetadata.includes("@")) {
+    return fromMetadata
+  }
+  const fromEnv = process.env.VISUAL_FLOW_FAILURE_EMAIL
+  if (fromEnv && fromEnv.includes("@")) {
+    return fromEnv
+  }
+  return null
+}
+
+function buildExecutionUrl(executionId: string): string | undefined {
+  const adminBase =
+    process.env.ADMIN_BASE_URL ||
+    process.env.MEDUSA_ADMIN_BACKEND_URL ||
+    process.env.BACKEND_URL
+  if (!adminBase) return undefined
+  return `${adminBase.replace(/\/$/, "")}/app/visual-flows/executions/${executionId}`
+}
+
+// Normalize the message so transient identifiers (ULIDs, UUIDs,
+// timestamps, numeric IDs) don't make every fingerprint unique and
+// bypass the throttle. ULIDs are 26-char Crockford base32 — that's
+// alphanumeric, not hex — so a hex-only regex misses every Medusa ID
+// we'd actually want to collapse.
+function fingerprint(message: string): string {
+  return message
+    .toLowerCase()
+    .replace(/[0-9a-z]{12,}/g, "*")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 60)
+}
+
+export default async function visualFlowLifecycleEmailHandler({
+  event,
+  container,
+}: SubscriberArgs<Record<string, any>>) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const data = event.data || {}
+  const eventName = event.name
+
+  const recipient = resolveRecipient(data)
+  if (!recipient) {
+    logger.debug(
+      `[visual-flow-lifecycle-email] ${eventName}: no recipient configured ` +
+        `(flow.metadata.failure_email + VISUAL_FLOW_FAILURE_EMAIL both empty); skipping`
+    )
+    return
+  }
+
+  const flowId = data.flow_id || "unknown"
+  const flowName = data.flow_name || flowId
+  const executionId = data.execution_id || "unknown"
+  const executionUrl = buildExecutionUrl(executionId)
+  const now = Date.now()
+
+  if (eventName === "visual_flow_execution.started") {
+    if (shouldThrottle(`started:${flowId}`, now)) {
+      logger.debug(
+        `[visual-flow-lifecycle-email] throttled start email for ${flowId}`
+      )
+      return
+    }
+    try {
+      await sendNotificationEmailWorkflow(container).run({
+        input: {
+          to: recipient,
+          template: "visual-flow-started",
+          data: {
+            flow_name: flowName,
+            execution_id: executionId,
+            triggered_by: data.triggered_by ?? null,
+            triggered_by_event: data.triggered_by_event ?? null,
+            started_at: data.started_at ?? new Date().toISOString(),
+            execution_url: executionUrl ?? null,
+          },
+        },
+      })
+      logger.info(
+        `[visual-flow-lifecycle-email] sent started email for flow=${flowId} execution=${executionId}`
+      )
+    } catch (err) {
+      const message = err instanceof Error ? err.message : JSON.stringify(err)
+      logger.error(
+        `[visual-flow-lifecycle-email] failed to send started email: ${message}`
+      )
+    }
+    return
+  }
+
+  if (eventName === "visual_flow_execution.failed") {
+    const errMsg = data.error_message || "Unknown error"
+    const fp = `failed:${flowId}:${fingerprint(errMsg)}`
+    if (shouldThrottle(fp, now)) {
+      logger.debug(
+        `[visual-flow-lifecycle-email] throttled failure email for ${flowId} (fingerprint=${fp})`
+      )
+      return
+    }
+    try {
+      await sendNotificationEmailWorkflow(container).run({
+        input: {
+          to: recipient,
+          template: "visual-flow-failure",
+          data: {
+            flow_name: flowName,
+            execution_id: executionId,
+            failing_operation_key: data.failing_operation_key ?? null,
+            error_message: errMsg,
+            triggered_by: data.triggered_by ?? null,
+            triggered_by_event: data.triggered_by_event ?? null,
+            failed_at: data.failed_at ?? new Date().toISOString(),
+            execution_url: executionUrl ?? null,
+          },
+        },
+      })
+      logger.info(
+        `[visual-flow-lifecycle-email] sent failure email for flow=${flowId} execution=${executionId}`
+      )
+    } catch (err) {
+      const message = err instanceof Error ? err.message : JSON.stringify(err)
+      logger.error(
+        `[visual-flow-lifecycle-email] failed to send failure email: ${message}`
+      )
+    }
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: ["visual_flow_execution.started", "visual_flow_execution.failed"],
+}
+
+// Exposed for the integration test so it can reset throttle state
+// between cases. Intentionally not part of the production import path.
+export const __testing = {
+  clearThrottle: () => lastSentAt.clear(),
+  fingerprint,
+}

--- a/apps/backend/src/workflows/visual-flows/execute-visual-flow.ts
+++ b/apps/backend/src/workflows/visual-flows/execute-visual-flow.ts
@@ -4,15 +4,40 @@ import {
   StepResponse,
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
+import type { IEventBusModuleService } from "@medusajs/framework/types"
+import { Modules } from "@medusajs/framework/utils"
 import { VISUAL_FLOWS_MODULE } from "../../modules/visual_flows"
 import VisualFlowService from "../../modules/visual_flows/service"
-import { 
-  operationRegistry, 
-  DataChain, 
+import {
+  operationRegistry,
+  DataChain,
   OperationContext,
   getAllowedEnvVars,
   interpolateVariables,
 } from "../../modules/visual_flows/operations"
+
+/**
+ * Lifecycle event emit helper.
+ *
+ * Why a helper: the execution workflow lives downstream of the event
+ * bus on the boot graph, so we resolve lazily. A missing or
+ * misconfigured event bus must never be the reason a real execution
+ * (or its compensation) fails — observability is strictly additive
+ * here. Errors are swallowed because the execution row + log table
+ * still hold the truth even if the email never goes out.
+ */
+async function emitFlowLifecycleEvent(
+  container: any,
+  name: "visual_flow_execution.started" | "visual_flow_execution.failed",
+  data: Record<string, any>
+) {
+  try {
+    const eventBus = container.resolve(Modules.EVENT_BUS) as IEventBusModuleService
+    await eventBus.emit({ name, data })
+  } catch {
+    // Intentional: see comment above.
+  }
+}
 
 // ============ Types ============
 
@@ -112,7 +137,7 @@ const initializeExecutionStep = createStep(
     await service.updateExecutionStatus(execution.id, "running", {
       data_chain: dataChain,
     })
-    
+
     // Log trigger
     await service.addExecutionLog({
       execution_id: execution.id,
@@ -122,18 +147,101 @@ const initializeExecutionStep = createStep(
       output_data: dataChain.$trigger,
       duration_ms: 0,
     })
-    
+
+    // Lifecycle: emit `visual_flow_execution.started` so admins (or
+    // any other subscriber) can surface an in-progress flow. Until
+    // this hook existed, executions only became visible to admins
+    // when they completed or failed — long flows had no kick-off
+    // signal at all.
+    await emitFlowLifecycleEvent(container, "visual_flow_execution.started", {
+      flow_id: input.flowId,
+      flow_name: (input.flow as any)?.name,
+      flow_metadata: (input.flow as any)?.metadata ?? null,
+      execution_id: execution.id,
+      triggered_by: input.triggeredBy,
+      triggered_by_event: incomingEventName,
+      started_at: new Date().toISOString(),
+    })
+
+    // The compensation needs more than `executionId` so it can emit a
+    // rich `visual_flow_execution.failed` event (flow name + metadata
+    // for recipient resolution; trigger fields for the email body).
+    // The execution log table holds the per-operation failure detail
+    // and is read at compensation time.
     return new StepResponse(
       { executionId: execution.id, dataChain },
-      execution.id // For compensation
+      {
+        executionId: execution.id,
+        flowId: input.flowId,
+        flowName: (input.flow as any)?.name,
+        flowMetadata: (input.flow as any)?.metadata ?? null,
+        triggeredBy: input.triggeredBy,
+        triggeredByEvent: incomingEventName,
+      }
     )
   },
-  // Compensation: mark execution as cancelled
-  async (executionId: string, { container }) => {
+  // Compensation: mark execution as cancelled + emit the failure event
+  // so admins get an email instead of staring at a silent
+  // status=cancelled row. We dig the actual operation-level error out
+  // of the execution log because the workflow-engine error is the
+  // generic "Workflow cancelled during execution" string, which is
+  // exactly the unhelpful surface roadmap item 26 set out to fix.
+  async (
+    rollbackData:
+      | {
+          executionId: string
+          flowId: string
+          flowName?: string
+          flowMetadata?: Record<string, any> | null
+          triggeredBy?: string
+          triggeredByEvent?: string
+        }
+      | undefined,
+    { container }
+  ) => {
+    if (!rollbackData?.executionId) return
     const service: VisualFlowService = container.resolve(VISUAL_FLOWS_MODULE)
-    await service.updateExecutionStatus(executionId, "cancelled", {
-      error: "Workflow cancelled during execution",
+
+    // Pull the most recent failure log row for this execution — the
+    // log table is the only place the per-operation error survives
+    // once the workflow engine rethrows the generic cancel message.
+    let failingOperationKey: string | null = null
+    let operationErrorMessage: string | null = null
+    try {
+      const logs = await (service as any).listVisualFlowExecutionLogs(
+        { execution_id: rollbackData.executionId, status: "failure" },
+        { take: 1, order: { created_at: "DESC" } }
+      )
+      const latest = logs?.[0]
+      if (latest) {
+        failingOperationKey = latest.operation_key ?? null
+        operationErrorMessage = latest.error ?? null
+      }
+    } catch {
+      // Best-effort lookup — fall through to a generic event.
+    }
+
+    const errorMessage =
+      operationErrorMessage ||
+      (failingOperationKey
+        ? `Operation '${failingOperationKey}' failed`
+        : "Workflow cancelled during execution")
+
+    await service.updateExecutionStatus(rollbackData.executionId, "cancelled", {
+      error: errorMessage,
       completed_at: new Date(),
+    })
+
+    await emitFlowLifecycleEvent(container, "visual_flow_execution.failed", {
+      flow_id: rollbackData.flowId,
+      flow_name: rollbackData.flowName,
+      flow_metadata: rollbackData.flowMetadata ?? null,
+      execution_id: rollbackData.executionId,
+      triggered_by: rollbackData.triggeredBy,
+      triggered_by_event: rollbackData.triggeredByEvent,
+      failing_operation_key: failingOperationKey,
+      error_message: errorMessage,
+      failed_at: new Date().toISOString(),
     })
   }
 )

--- a/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
+++ b/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
@@ -244,6 +244,45 @@ follow-up admin affordance.
 
 #### 26. Email notification when a visual flow fails
 
+**Status: SHIPPED 2026-06-04.** Branch `feat/26-visual-flow-failure-email`.
+Expanded from the original spec — covers **start + failure** lifecycle
+hooks, not just failure (user picked the broader shape so admins also
+notice flows that began but never landed). The shipped surface:
+
+- `apps/backend/src/workflows/visual-flows/execute-visual-flow.ts` —
+  emits `visual_flow_execution.started` after the execution row goes
+  to `running`, and emits `visual_flow_execution.failed` from the
+  compensation path. The compensation now reads the latest failure
+  row from `visual_flow_execution_log` so the failed event carries
+  the **real** operation error (not the generic
+  `"Workflow cancelled during execution"`) plus the
+  `failing_operation_key`. The execution row's `error` field gets the
+  same upgrade.
+- `apps/backend/src/subscribers/visual-flow-lifecycle-email.ts` —
+  listens on `["visual_flow_execution.started",
+  "visual_flow_execution.failed"]`. Recipient resolution:
+  `flow.metadata.failure_email` → `VISUAL_FLOW_FAILURE_EMAIL` env →
+  bail silently. In-memory throttle keyed by
+  `started:<flow_id>` or `failed:<flow_id>:<fingerprint>`; ULID-aware
+  fingerprint (`[0-9a-z]{12,}` collapses Crockford base32 ids) keeps
+  identical-shape errors in the same bucket.
+- `apps/backend/src/scripts/seed-visual-flow-lifecycle-email-templates.ts` —
+  upserts both `visual-flow-started` and `visual-flow-failure`
+  templates so admins can edit the body/subject in the admin UI
+  without a redeploy.
+- 2 integration tests in
+  `integration-tests/http/visual-flow-lifecycle-email.spec.ts` —
+  end-to-end lifecycle event capture against a flow with an
+  `execute_code` step that throws, plus a fingerprint unit test on
+  ULID-shaped messages.
+
+**Re-seed required after deploy:**
+`npx medusa exec ./src/scripts/seed-visual-flow-lifecycle-email-templates.ts`.
+
+---
+
+**Original problem statement (for the record):**
+
 Direct follow-up to the 25c diagnosis. Today, when a visual-flow
 execution errors out (a Meta API rejection, a missing
 template, an unreachable image URL, a thrown step) it lands as
@@ -328,12 +367,12 @@ Fix outline:
   behaviour, `/partners/designs` visibility, plus the backfill
   scenarios (recovery, no-op, dry-run).
 
-**Next step (post-deploy):** run
+**Closed out 2026-06-04** — backfill ran on prod via
 `./deploy/aws/scripts/run-backfill.sh backfill-design-partners-from-runs`
-with `DRY_RUN=1` first, then for real, to repair the existing drift
-on prod (e.g. design `01KPET5HBGNH9QXGC0MC8RHR39` re-assigned to
-Sharlho via a production run but linked to Shramdaan in
-`design_partners_link`).
+(dry-run first, then real). 17 (design, partner) pairs walked, 16
+already linked, 1 created: design `01KPET5HBGNH9QXGC0MC8RHR39` ↔
+partner `01K4PJMNMNRGMK0ZXMKBBDZDGD` (Sharlho) — exactly the drift
+reported. Zero errors.
 
 ### Partner platform extensions
 


### PR DESCRIPTION
## Summary

- **Hook the lifecycle.** `execute-visual-flow.ts` now emits `visual_flow_execution.started` after the execution row goes to `running`, and emits `visual_flow_execution.failed` from the compensation path with the **real operation error** (not the generic `"Workflow cancelled during execution"`) and the `failing_operation_key` pulled from the latest log row.
- **Surface the failure.** New subscriber `visual-flow-lifecycle-email.ts` listens on both events, resolves recipient via `flow.metadata.failure_email` → `VISUAL_FLOW_FAILURE_EMAIL` env, and dedupes via an in-memory throttle keyed by `(flow_id, ULID-aware fingerprint)` so a flow that fanouts 100 reminders sends 1 email per window, not 100.
- **Edit-without-deploy.** Two templates (`visual-flow-started`, `visual-flow-failure`) seeded via `seed-visual-flow-lifecycle-email-templates.ts`.

Closes roadmap item 26. Direct follow-up to 25c.

## Test plan

- [x] `pnpm test:integration:http:shared ./integration-tests/http/visual-flow-lifecycle-email` — both tests green
- [ ] After deploy: `npx medusa exec ./src/scripts/seed-visual-flow-lifecycle-email-templates.ts`
- [ ] After deploy: set `VISUAL_FLOW_FAILURE_EMAIL` env (or per-flow `metadata.failure_email`)
- [ ] After deploy: trigger a known-bad flow, confirm failure email lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)