### PR TITLE
feat(tax): audit script + e2e test for partner tax coverage (roadmap #5)

### DIFF
--- a/apps/backend/integration-tests/http/tax-coverage-audit-and-cart.spec.ts
+++ b/apps/backend/integration-tests/http/tax-coverage-audit-and-cart.spec.ts
@@ -1,0 +1,323 @@
+/**
+ * Tax coverage audit + cart tax materialization (roadmap item 5).
+ *
+ * Two angles, one spec:
+ *
+ *   1. `scripts/audit-tax-coverage.ts` correctly surfaces partner
+ *      regions whose covered countries lack a canonical tax_region —
+ *      and stays silent when every country is covered.
+ *
+ *   2. Medusa's TaxModule actually computes the right tax rate for a
+ *      partner cart-shaped scenario once the canonical seed has run.
+ *      This guards the e2e contract: AU shipping address → 10% GST
+ *      line, IN shipping address → 18% GST line. If this stops
+ *      working, every partner under-bills their customers.
+ *
+ * Run:
+ *   pnpm test:integration:http:shared ./integration-tests/http/tax-coverage-audit-and-cart
+ */
+
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import seedCanonicalTaxRegions from "../../src/scripts/seed-canonical-tax-regions"
+import { computeTaxCoverage } from "../../src/scripts/audit-tax-coverage"
+
+const PARTNER_PASSWORD = "supersecret"
+
+jest.setTimeout(180_000)
+
+async function createPartnerWithRegion(
+  api: any,
+  adminHeaders: any,
+  label: string,
+  countries: string[]
+) {
+  const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+  const email = `tax5-${label}-${unique}@jyt.test`
+
+  await api.post("/auth/partner/emailpass/register", {
+    email,
+    password: PARTNER_PASSWORD,
+  })
+  let login = await api.post("/auth/partner/emailpass", {
+    email,
+    password: PARTNER_PASSWORD,
+  })
+  let partnerHeaders: Record<string, string> = {
+    Authorization: `Bearer ${login.data.token}`,
+  }
+
+  const partnerRes = await api.post(
+    "/partners",
+    {
+      name: `Tax5 ${label} ${unique}`,
+      handle: `tax5-${label}-${unique}`,
+      admin: { email, first_name: "Tax", last_name: "Test" },
+    },
+    { headers: partnerHeaders }
+  )
+  expect(partnerRes.status).toBe(200)
+  const partnerId = partnerRes.data.partner.id as string
+
+  // Re-login to refresh actor scope after partner creation.
+  login = await api.post("/auth/partner/emailpass", {
+    email,
+    password: PARTNER_PASSWORD,
+  })
+  partnerHeaders = { Authorization: `Bearer ${login.data.token}` }
+
+  // Use USD across the board — partner-stores route requires the
+  // currency be present in admin's supported list, and USD is the
+  // only one we can rely on in a fresh test DB. The tax test cares
+  // about `country`, not currency, so a region can be USD-denominated
+  // while covering AU or IN without changing what tax_region matches.
+  const currencyCode = "usd"
+
+  const storeRes = await api.post(
+    "/partners/stores",
+    {
+      store: {
+        name: `Tax5 Store ${label} ${unique}`,
+        supported_currencies: [{ currency_code: currencyCode, is_default: true }],
+      },
+      region: {
+        name: `Tax5 ${label} Region`,
+        currency_code: currencyCode,
+        countries,
+      },
+      location: {
+        name: "Warehouse",
+        address: {
+          address_1: "1 Test St",
+          city: "Test",
+          postal_code: "00000",
+          country_code: countries[0].toUpperCase(),
+        },
+      },
+    },
+    { headers: partnerHeaders }
+  )
+  // partner-stores has returned both 200 and 201 historically — the
+  // partner-tax-pricing-api spec doesn't even assert on it. Accept
+  // either to keep this resilient.
+  expect([200, 201]).toContain(storeRes.status)
+  return {
+    partnerId,
+    partnerHeaders,
+    regionId: storeRes.data.region?.id,
+  }
+}
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("audit-tax-coverage (roadmap 5)", () => {
+    let adminHeaders: Record<string, any>
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+      // Partner-created notification template — created by the
+      // partner-creation flow. Pre-seed so failures here don't mask
+      // the real assertions.
+      try {
+        await api.post(
+          "/admin/email-templates",
+          {
+            name: "Admin Partner Created",
+            template_key: "partner-created-from-admin",
+            subject: "s",
+            html_content: "<div>ok</div>",
+            from: "t@t.com",
+            variables: {},
+            template_type: "email",
+          },
+          adminHeaders
+        )
+      } catch {
+        /* ignore — pre-existing */
+      }
+    })
+
+    it("reports zero gaps when every partner-covered country has a tax_region", async () => {
+      const container = getContainer()
+
+      // Partner creates the AU region (Medusa enforces 1 country → 1
+      // region globally, so the partner-side creation occupies AU).
+      const { partnerId } = await createPartnerWithRegion(
+        api,
+        adminHeaders,
+        "no-gap",
+        ["au"]
+      )
+      // Seed walks every region — including partner-created ones —
+      // and creates a tax_region per country. AU = 10% GST.
+      await seedCanonicalTaxRegions({ container, args: [] } as any)
+
+      // Audit, scoped to just this partner so other test fixtures
+      // don't pollute the report shape.
+      const report = await computeTaxCoverage(container, {
+        partnerIdFilter: [partnerId],
+      })
+
+      expect(report.partners_audited).toBe(1)
+      expect(report.partners_with_gaps).toBe(0)
+      expect(report.globally_missing).toEqual([])
+      expect(report.per_partner[0].covered).toContain("au")
+      expect(report.per_partner[0].missing).toEqual([])
+    })
+
+    it("surfaces a partner whose region covers a country with no canonical tax_region", async () => {
+      const container = getContainer()
+
+      // Partner covers AU + AO. AO is intentionally not in
+      // COUNTRY_DEFAULT_TAX_RATES so seed-canonical-tax-regions creates
+      // a row without a default_tax_rate — for the audit it's the same
+      // as "no row" (no rate → no tax computed → audit flags it).
+      // Use distinct partner labels per test so country occupation
+      // from a sibling test doesn't bleed across.
+      const { partnerId } = await createPartnerWithRegion(
+        api,
+        adminHeaders,
+        "with-gap",
+        ["nz", "ao"]
+      )
+      await seedCanonicalTaxRegions({ container, args: [] } as any)
+
+      const report = await computeTaxCoverage(container, {
+        partnerIdFilter: [partnerId],
+      })
+
+      expect(report.partners_audited).toBe(1)
+      // AO has no canonical default_tax_rate, so the audit sees it
+      // as covered-but-untaxed. NZ is 15% GST.
+      expect(report.per_partner[0].covered).toContain("nz")
+      expect(report.per_partner[0].covered).not.toContain("ao")
+      expect(report.per_partner[0].missing).toContain("ao")
+      expect(report.globally_missing).toContain("ao")
+    })
+
+    it("does not flag US as missing — partners handle US state-level tax themselves", async () => {
+      const container = getContainer()
+      const { partnerId } = await createPartnerWithRegion(
+        api,
+        adminHeaders,
+        "us-only",
+        ["us"]
+      )
+
+      const report = await computeTaxCoverage(container, {
+        partnerIdFilter: [partnerId],
+      })
+
+      expect(report.partners_with_gaps).toBe(0)
+      expect(report.per_partner[0].missing).not.toContain("us")
+    })
+  })
+
+  describe("TaxModule cart materialization (roadmap 5)", () => {
+    let adminHeaders: Record<string, any>
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+    })
+
+    it("returns the expected GST rate for a shipping address in AU", async () => {
+      const container = getContainer()
+      await api.post(
+        "/admin/regions",
+        { name: "AU for tax calc", currency_code: "aud", countries: ["au"] },
+        adminHeaders
+      )
+      await seedCanonicalTaxRegions({ container, args: [] } as any)
+
+      const taxService: any = container.resolve(Modules.TAX)
+      const lines = await taxService.getTaxLines(
+        [
+          {
+            id: "li_test_au",
+            product_id: "prod_test",
+            quantity: 1,
+            unit_price: 10000,
+            currency_code: "aud",
+          },
+        ],
+        {
+          address: { country_code: "au" },
+        }
+      )
+
+      expect(Array.isArray(lines)).toBe(true)
+      expect(lines.length).toBeGreaterThan(0)
+      const taxLine = lines.find((l: any) => l.line_item_id === "li_test_au")
+      expect(taxLine).toBeDefined()
+      // Australia GST = 10% per COUNTRY_DEFAULT_TAX_RATES.
+      expect(Number(taxLine.rate)).toBe(10)
+      expect(String(taxLine.code)).toBe("AU-GST")
+    })
+
+    it("returns the expected GST rate for a shipping address in IN", async () => {
+      const container = getContainer()
+      await api.post(
+        "/admin/regions",
+        { name: "IN for tax calc", currency_code: "inr", countries: ["in"] },
+        adminHeaders
+      )
+      await seedCanonicalTaxRegions({ container, args: [] } as any)
+
+      const taxService: any = container.resolve(Modules.TAX)
+      const lines = await taxService.getTaxLines(
+        [
+          {
+            id: "li_test_in",
+            product_id: "prod_test",
+            quantity: 1,
+            unit_price: 10000,
+            currency_code: "inr",
+          },
+        ],
+        {
+          address: { country_code: "in" },
+        }
+      )
+
+      const taxLine = lines.find((l: any) => l.line_item_id === "li_test_in")
+      expect(taxLine).toBeDefined()
+      // India GST = 18% per COUNTRY_DEFAULT_TAX_RATES.
+      expect(Number(taxLine.rate)).toBe(18)
+      expect(String(taxLine.code)).toBe("IN-GST")
+    })
+
+    it("returns no tax lines when the shipping country has no canonical tax_region", async () => {
+      // Sanity: prove that the silent-undercharge bug really would
+      // bite if a partner covers a country we haven't seeded. AO has
+      // no entry in COUNTRY_DEFAULT_TAX_RATES, so even running the
+      // seed leaves it uncovered.
+      const container = getContainer()
+      const taxService: any = container.resolve(Modules.TAX)
+      const lines = await taxService.getTaxLines(
+        [
+          {
+            id: "li_test_ao",
+            product_id: "prod_test",
+            quantity: 1,
+            unit_price: 10000,
+            currency_code: "usd",
+          },
+        ],
+        {
+          address: { country_code: "ao" },
+        }
+      )
+      const taxLine = lines.find((l: any) => l.line_item_id === "li_test_ao")
+      // Either no line at all, or a zero-rate line — both mean the
+      // partner under-bills. The audit script is the alarm.
+      const rate = taxLine ? Number(taxLine.rate) : 0
+      expect(rate).toBe(0)
+    })
+  })
+})

--- a/apps/backend/src/scripts/audit-tax-coverage.ts
+++ b/apps/backend/src/scripts/audit-tax-coverage.ts
@@ -1,0 +1,216 @@
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+export type TaxCoverageGap = {
+  partner_id: string
+  name: string
+  handle: string
+  missing: string[]
+  covered: string[]
+}
+
+export type TaxCoverageReport = {
+  canonical_countries: string[]
+  partners_audited: number
+  partners_with_gaps: number
+  globally_missing: string[]
+  per_partner: TaxCoverageGap[]
+}
+
+/**
+ * Audit script — surface countries that a partner storefront covers
+ * but for which no canonical `tax_region` row exists.
+ *
+ * Why (roadmap item 5): canonical tax_regions are admin-seeded
+ * globally (per the `seed-canonical-tax-regions.ts` script PR #261
+ * landed). Medusa's cart-tax calculation matches the cart's shipping
+ * country against `tax_region.country_code`; if no row exists for that
+ * country, the cart shows `tax_total = 0` and the partner under-bills
+ * the customer. Region propagation (0B) adds the partner_region link
+ * but doesn't touch tax_regions because tax_regions are shared
+ * globally — so a brand-new country added to a partner's region
+ * silently relies on the canonical seed already having that country.
+ *
+ * This script is read-only — it reports gaps. The fix path, if gaps
+ * exist, is re-running `seed-canonical-tax-regions.ts` (idempotent),
+ * which will create the missing rows.
+ *
+ * Run:
+ *   npx medusa exec ./src/scripts/audit-tax-coverage.ts
+ *
+ * Scope:
+ *   --partner-ids=par_a,par_b  (or PARTNER_IDS=…)  — limit to a subset of partners
+ */
+/**
+ * Compute the coverage report without any logging side-effects.
+ * Lives separately so integration tests can call it and inspect the
+ * shape directly instead of scraping logs.
+ */
+export async function computeTaxCoverage(
+  container: any,
+  opts: { partnerIdFilter?: string[] | null } = {}
+): Promise<TaxCoverageReport> {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const partnerIdFilter = opts.partnerIdFilter?.length
+    ? opts.partnerIdFilter
+    : null
+
+  // 1. Pull canonical tax_regions once. Root tax_regions (parent_id
+  //    null) are the country-level ones the cart-tax lookup matches.
+  //    A country counts as "covered" only if it has a tax_region row
+  //    AND that row has at least one default tax_rate — otherwise the
+  //    cart still resolves to 0% and the partner under-bills. Seed
+  //    creates rate-less rows for unknown countries; those are gaps,
+  //    not coverage.
+  const { data: taxRegions } = await query.graph({
+    entity: "tax_regions",
+    fields: [
+      "id",
+      "country_code",
+      "parent_id",
+      "tax_rates.rate",
+      "tax_rates.is_default",
+    ],
+  })
+  const canonicalCountries = new Set<string>(
+    (taxRegions ?? [])
+      .filter((tr: any) => !tr.parent_id)
+      .filter((tr: any) =>
+        (tr.tax_rates ?? []).some(
+          (r: any) => r?.is_default && Number(r?.rate) > 0
+        )
+      )
+      .map((tr: any) =>
+        tr.country_code ? String(tr.country_code).toLowerCase() : ""
+      )
+      .filter(Boolean)
+  )
+
+  // 2. Pull partners (filtered if requested) with their region links +
+  //    each region's covered countries. Single query — cheaper than
+  //    walking the link table per-partner.
+  const { data: partners } = await query.graph({
+    entity: "partner",
+    filters: partnerIdFilter ? { id: partnerIdFilter } : undefined,
+    fields: [
+      "id",
+      "name",
+      "handle",
+      "regions.id",
+      "regions.name",
+      "regions.countries.iso_2",
+    ],
+    pagination: { skip: 0, take: 1000 },
+  })
+
+  // 3. Per-partner coverage. A gap = a country the partner's region
+  //    covers but no canonical tax_region exists for. The cart-tax
+  //    lookup falls back to zero in that case.
+  const perPartner: TaxCoverageGap[] = []
+  const globallyMissing = new Set<string>()
+
+  for (const partner of (partners ?? []) as any[]) {
+    const missing = new Set<string>()
+    const covered = new Set<string>()
+    for (const region of partner.regions ?? []) {
+      for (const c of region.countries ?? []) {
+        const code = c?.iso_2 ? String(c.iso_2).toLowerCase() : ""
+        if (!code) continue
+        // US (and US Minor Outlying Islands) deliberately have no
+        // canonical tax_region — they aren't gaps, they're "partner
+        // handles state-level tax themselves". Skip so the report
+        // doesn't surface them as actionable misses.
+        if (code === "us" || code === "um") continue
+        if (canonicalCountries.has(code)) {
+          covered.add(code)
+        } else {
+          missing.add(code)
+          globallyMissing.add(code)
+        }
+      }
+    }
+    perPartner.push({
+      partner_id: partner.id,
+      name: partner.name ?? partner.id,
+      handle: partner.handle ?? "",
+      missing: [...missing].sort(),
+      covered: [...covered].sort(),
+    })
+  }
+
+  return {
+    canonical_countries: [...canonicalCountries].sort(),
+    partners_audited: perPartner.length,
+    partners_with_gaps: perPartner.filter((p) => p.missing.length).length,
+    globally_missing: [...globallyMissing].sort(),
+    per_partner: perPartner,
+  }
+}
+
+export default async function auditTaxCoverage({ container, args }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+
+  const argList = args ?? []
+  const parseListArg = (flag: string, envVar: string): string[] | null => {
+    const fromArg = argList
+      .map((a) => (a.startsWith(`${flag}=`) ? a.slice(flag.length + 1) : null))
+      .find((v): v is string => v !== null)
+    const raw = fromArg ?? process.env[envVar] ?? ""
+    if (!raw.trim()) return null
+    return raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+  }
+  const partnerIdFilter = parseListArg("--partner-ids", "PARTNER_IDS")
+  if (partnerIdFilter?.length) {
+    logger.info(`Partner scope: ${partnerIdFilter.join(", ")}`)
+  }
+
+  const report = await computeTaxCoverage(container, { partnerIdFilter })
+
+  logger.info(
+    `Canonical tax_regions exist for ${report.canonical_countries.length} countries: ` +
+      `${report.canonical_countries.join(", ") || "(none)"}`
+  )
+
+  if (!report.partners_audited) {
+    logger.info("No partners found in scope. Nothing to audit.")
+    return
+  }
+
+  logger.info("")
+  logger.info("─── Per-partner coverage ───")
+  for (const p of report.per_partner) {
+    const tag = `${p.name} (${p.handle || "(no handle)"}) [${p.partner_id}]`
+    if (!p.missing.length) {
+      logger.info(`✓ ${tag}: all ${p.covered.length} covered countries have tax_regions`)
+      continue
+    }
+    logger.warn(
+      `✗ ${tag}: MISSING ${p.missing.join(", ").toUpperCase()} ` +
+        `(covered: ${p.covered.join(", ").toUpperCase() || "—"})`
+    )
+  }
+
+  logger.info("")
+  logger.info("─── Summary ───")
+  logger.info(`partners_audited     = ${report.partners_audited}`)
+  logger.info(`partners_with_gaps   = ${report.partners_with_gaps}`)
+  logger.info(
+    `globally_missing     = ${report.globally_missing.length}` +
+      (report.globally_missing.length
+        ? ` (${report.globally_missing.join(", ").toUpperCase()})`
+        : "")
+  )
+
+  if (report.globally_missing.length) {
+    logger.info("")
+    logger.info(
+      "Fix: re-run seed-canonical-tax-regions.ts — idempotent, " +
+        "creates the missing rows from the curated rate table."
+    )
+  } else {
+    logger.info("✓ No gaps. Every partner-covered country has a canonical tax_region.")
+  }
+}

--- a/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
+++ b/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
@@ -127,6 +127,39 @@ one who doesn't) at the DB level.
 
 #### 5. Tax config per store working as expected
 
+**Status: AUDIT + E2E TEST SHIPPED 2026-06-04.** Branch
+`feat/5-tax-coverage-audit-and-test`. Each partner shares the global
+canonical tax_regions (PR #261); cart-tax lookup matches the
+shipping address's country against `tax_region.country_code`. If no
+row (or no default rate) exists for that country, the cart shows
+`tax_total = 0` and the partner under-bills — silently.
+
+Shipped:
+- `apps/backend/src/scripts/audit-tax-coverage.ts` — walks every
+  partner via `query.graph({ entity: "partner", ... })`, lists
+  every country covered by their regions, and flags any country
+  that lacks a tax_region row **with a default rate > 0**. Exports
+  `computeTaxCoverage()` returning a typed report so tests + admin
+  surfaces can consume it without log-scraping. Skips US/UM (no
+  federal sales tax — partner handles state-level themselves).
+- `integration-tests/http/tax-coverage-audit-and-cart.spec.ts` — 6
+  tests covering: audit reports zero gaps for fully-covered partner,
+  surfaces partner with AO (no curated rate), skips US correctly,
+  TaxModule.getTaxLines returns AU=10% GST + IN=18% GST, returns
+  zero for an unseeded country (the silent-undercharge scenario).
+
+**Next step (post-deploy):** run
+`./deploy/aws/scripts/run-backfill.sh audit-tax-coverage` on prod to
+surface any partner whose region covers a country without a canonical
+default rate. If gaps surface, follow up by either (a) extending
+`COUNTRY_DEFAULT_TAX_RATES` in `seed-canonical-tax-regions.ts` for
+that country and re-seeding, or (b) admin sets the rate manually via
+the existing tax_regions admin UI.
+
+---
+
+**Original problem statement (for the record):**
+
 Each partner should have tax_regions provisioned for the countries
 their regions cover (PR #261 seeded canonical tax_regions). Verify
 end-to-end: order in AU calculates 10% GST, order in EU calculates


### PR DESCRIPTION
## Summary

Roadmap item 5. Adds a read-only audit + an end-to-end test that proves Medusa's TaxModule produces the right rate for partner-shaped carts.

- **`scripts/audit-tax-coverage.ts`** — walks every partner via `query.graph({ entity: \"partner\", ... })`, lists every country covered by their regions, flags any country lacking a tax_region row **with a default rate > 0**. (A rate-less row is the same outcome as no row at all: cart resolves to 0%.) Skips US/UM. Exports `computeTaxCoverage()` returning a typed report so tests + admin surfaces can consume without log-scraping.
- **6 integration tests** in `tax-coverage-audit-and-cart.spec.ts`:
  - audit reports zero gaps when partner-covered countries are seeded
  - audit surfaces a partner whose region covers AO (no curated default rate)
  - audit does **not** flag US (intentional skip)
  - `TaxModule.getTaxLines` returns AU = 10% AU-GST
  - `TaxModule.getTaxLines` returns IN = 18% IN-GST
  - `TaxModule.getTaxLines` returns 0 for an unseeded country (proves the silent-undercharge mode)

## Test plan

- [x] `pnpm test:integration:http:shared ./integration-tests/http/tax-coverage-audit-and-cart` — 6/6 green
- [ ] After deploy: `./deploy/aws/scripts/run-backfill.sh audit-tax-coverage` on prod, surface any partners with gaps
- [ ] If gaps: extend `COUNTRY_DEFAULT_TAX_RATES` in `seed-canonical-tax-regions.ts` for those countries + re-seed, or set rates manually in admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)