### PR TITLE
fix(consumption-log): add missing production_run_id column (repair)

### DIFF
--- a/apps/backend/src/modules/consumption_log/migrations/Migration20260605120000.ts
+++ b/apps/backend/src/modules/consumption_log/migrations/Migration20260605120000.ts
@@ -1,0 +1,32 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Repair migration — add `production_run_id` to `consumption_log`.
+ *
+ * Why this is needed: the column was added to the model AND edited into
+ * the `create table` statement of `Migration20260414104644` in place,
+ * but no incremental ALTER was ever shipped. Because that migration
+ * uses `create table IF NOT EXISTS`, any database that created
+ * `consumption_log` before the column was added never received it — and
+ * the guard means re-running the create can't fix it. Result: queries
+ * filtering consumption_log by `production_run_id` (production-run
+ * cost-summary, run consumption logs) fail with
+ * `column "production_run_id" of relation "consumption_log" does not exist`.
+ *
+ * `add column if not exists` makes this safe everywhere: DBs missing the
+ * column get it; DBs that already have it (created fresh from the newer
+ * create statement) skip it.
+ */
+export class Migration20260605120000 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(
+      `alter table if exists "consumption_log" add column if not exists "production_run_id" text null;`
+    );
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(
+      `alter table if exists "consumption_log" drop column if exists "production_run_id";`
+    );
+  }
+}


### PR DESCRIPTION
## Problem

Queries that filter `consumption_log` by `production_run_id` — the production-run **cost-summary** and the run **consumption-logs** endpoints — fail on existing databases with:

```
column "production_run_id" of relation "consumption_log" does not exist
```

## Root cause

`production_run_id` was added to the `ConsumptionLog` model **and edited into the `create table` statement** of `Migration20260414104644` in place, without ever shipping a separate `ALTER` migration. Because that migration uses **`create table IF NOT EXISTS`**, any database that had already created `consumption_log` before the column was added simply skips the create — and the guard means the column is never added.

This is the same migration anti-pattern as the `design.owner_partner_id` case from earlier today.

**Verified:** the local dev DB's `consumption_log` was missing the column entirely (column list had `design_id`, `inventory_item_id`, `raw_material_id` … but no `production_run_id`). Prod is almost certainly in the same state.

## Fix

An idempotent repair migration:

```sql
alter table if exists "consumption_log" add column if not exists "production_run_id" text null;
```

- DBs missing the column get it.
- DBs created fresh from the newer create statement skip it (no-op).

## Test plan
- [x] `npx medusa db:migrate` locally → `production_run_id` now present on `consumption_log`.
- [ ] After deploy: prod server boot runs `predeploy:force` (db:migrate) → column added; cost-summary + consumption-log endpoints stop 500ing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)