### PR TITLE
feat: partner design self-serve — BOM, cost, runs, cost-summary (roadmap #6 P2–P5)

### DIFF
--- a/apps/backend/integration-tests/http/partner-design-cost.spec.ts
+++ b/apps/backend/integration-tests/http/partner-design-cost.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * Partner design cost estimation (roadmap #6, Phase 3).
+ *
+ * A partner links inventory (with a unit_cost) to their own design,
+ * triggers a recalculate, and reads the persisted cost back. Ownership
+ * is enforced on both endpoints.
+ *
+ * Run:
+ *   pnpm test:integration:http:shared ./integration-tests/http/partner-design-cost
+ */
+
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+const PARTNER_PASSWORD = "supersecret"
+jest.setTimeout(180_000)
+
+async function createPartner(api: any, label: string) {
+  const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+  const email = `pcost-${label}-${unique}@jyt.test`
+  await api.post("/auth/partner/emailpass/register", {
+    email,
+    password: PARTNER_PASSWORD,
+  })
+  let login = await api.post("/auth/partner/emailpass", {
+    email,
+    password: PARTNER_PASSWORD,
+  })
+  let headers: Record<string, string> = {
+    Authorization: `Bearer ${login.data.token}`,
+  }
+  const partnerRes = await api.post(
+    "/partners",
+    {
+      name: `PCost ${label} ${unique}`,
+      handle: `pcost-${label}-${unique}`,
+      admin: { email, first_name: "Test", last_name: "Partner" },
+    },
+    { headers }
+  )
+  expect(partnerRes.status).toBe(200)
+  login = await api.post("/auth/partner/emailpass", {
+    email,
+    password: PARTNER_PASSWORD,
+  })
+  headers = { Authorization: `Bearer ${login.data.token}` }
+  return { partnerId: partnerRes.data.partner.id as string, partnerHeaders: headers }
+}
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Partner design cost estimation (roadmap 6, Phase 3)", () => {
+    let adminHeaders: Record<string, any>
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+      try {
+        await api.post(
+          "/admin/email-templates",
+          {
+            name: "Admin Partner Created",
+            template_key: "partner-created-from-admin",
+            subject: "s",
+            html_content: "<div>ok</div>",
+            from: "t@t.com",
+            variables: {},
+            template_type: "email",
+          },
+          adminHeaders
+        )
+      } catch {
+        /* pre-existing */
+      }
+    })
+
+    it("recalculates + persists cost from the linked BOM, readable via GET", async () => {
+      const { partnerId, partnerHeaders } = await createPartner(api, "calc")
+      const container = getContainer()
+
+      // Inventory item with a known unit_cost (drives the estimate).
+      const invRes = await api.post(
+        "/admin/inventory-items",
+        { title: "Costed Cotton", description: "unit cost test" },
+        adminHeaders
+      )
+      const invId = invRes.data.inventory_item.id
+      // Set unit_cost directly on the inventory item via the module so
+      // the estimate waterfall has a value to read.
+      const invSvc: any = container.resolve(Modules.INVENTORY)
+      await invSvc.updateInventoryItems({ id: invId, unit_cost: 100 } as any)
+
+      // Partner design + BOM link with planned_quantity = 3.
+      const designRes = await api.post(
+        "/partners/designs",
+        { name: "Costed Design", design_type: "Original" },
+        { headers: partnerHeaders }
+      )
+      const designId = designRes.data.design.id
+      await api.post(
+        `/partners/designs/${designId}/inventory`,
+        { inventoryItems: [{ inventoryId: invId, plannedQuantity: 3 }] },
+        { headers: partnerHeaders }
+      )
+
+      // Recalculate.
+      const recalc = await api.post(
+        `/partners/designs/${designId}/recalculate-cost`,
+        {},
+        { headers: partnerHeaders }
+      )
+      expect(recalc.status).toBe(200)
+      expect(recalc.data.cost_estimate).toBeDefined()
+      expect(typeof recalc.data.cost_estimate.total_estimated).toBe("number")
+      // Material cost reflects qty×unit_cost when the waterfall picks up
+      // the inventory unit_cost; never negative.
+      expect(recalc.data.cost_estimate.material_cost).toBeGreaterThanOrEqual(0)
+
+      // GET cost returns the persisted values.
+      const costRes = await api.get(`/partners/designs/${designId}/cost`, {
+        headers: partnerHeaders,
+      })
+      expect(costRes.status).toBe(200)
+      expect(costRes.data.design_id).toBe(designId)
+      expect(Number(costRes.data.estimated_cost)).toBe(
+        recalc.data.cost_estimate.total_estimated
+      )
+      expect(costRes.data.cost_breakdown).toBeTruthy()
+    })
+
+    it("blocks recalculate + cost read on a design the partner doesn't own", async () => {
+      const { partnerHeaders: owner } = await createPartner(api, "owner")
+      const { partnerHeaders: intruder } = await createPartner(api, "intruder")
+      const designRes = await api.post(
+        "/partners/designs",
+        { name: "Guarded", design_type: "Original" },
+        { headers: owner }
+      )
+      const designId = designRes.data.design.id
+
+      const recalc = await api.post(
+        `/partners/designs/${designId}/recalculate-cost`,
+        {},
+        { headers: intruder, validateStatus: () => true }
+      )
+      expect([400, 401, 403]).toContain(recalc.status)
+
+      const cost = await api.get(`/partners/designs/${designId}/cost`, {
+        headers: intruder,
+        validateStatus: () => true,
+      })
+      expect([400, 401, 403]).toContain(cost.status)
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/partner-design-inventory-bom.spec.ts
+++ b/apps/backend/integration-tests/http/partner-design-inventory-bom.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * Partner design ↔ inventory BOM (roadmap #6, Phase 2).
+ *
+ * A partner links GLOBAL inventory items to their OWN design as a
+ * bill-of-materials (planned_quantity per item), lists it, updates a
+ * line, and delinks. Ownership is enforced — a partner can't touch the
+ * BOM of a design they don't own.
+ *
+ * Run:
+ *   pnpm test:integration:http:shared ./integration-tests/http/partner-design-inventory-bom
+ */
+
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+const PARTNER_PASSWORD = "supersecret"
+
+jest.setTimeout(180_000)
+
+async function createPartner(api: any, label: string) {
+  const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+  const email = `pbom-${label}-${unique}@jyt.test`
+  await api.post("/auth/partner/emailpass/register", {
+    email,
+    password: PARTNER_PASSWORD,
+  })
+  let login = await api.post("/auth/partner/emailpass", {
+    email,
+    password: PARTNER_PASSWORD,
+  })
+  let headers: Record<string, string> = {
+    Authorization: `Bearer ${login.data.token}`,
+  }
+  const partnerRes = await api.post(
+    "/partners",
+    {
+      name: `PBom ${label} ${unique}`,
+      handle: `pbom-${label}-${unique}`,
+      admin: { email, first_name: "Test", last_name: "Partner" },
+    },
+    { headers }
+  )
+  expect(partnerRes.status).toBe(200)
+  login = await api.post("/auth/partner/emailpass", {
+    email,
+    password: PARTNER_PASSWORD,
+  })
+  headers = { Authorization: `Bearer ${login.data.token}` }
+  return { partnerId: partnerRes.data.partner.id as string, partnerHeaders: headers }
+}
+
+async function createInventoryItem(api: any, adminHeaders: any, title: string) {
+  const res = await api.post(
+    "/admin/inventory-items",
+    { title, description: `${title} for BOM test` },
+    adminHeaders
+  )
+  expect(res.status).toBe(200)
+  return res.data.inventory_item.id as string
+}
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Partner design ↔ inventory BOM (roadmap 6, Phase 2)", () => {
+    let adminHeaders: Record<string, any>
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+      try {
+        await api.post(
+          "/admin/email-templates",
+          {
+            name: "Admin Partner Created",
+            template_key: "partner-created-from-admin",
+            subject: "s",
+            html_content: "<div>ok</div>",
+            from: "t@t.com",
+            variables: {},
+            template_type: "email",
+          },
+          adminHeaders
+        )
+      } catch {
+        /* pre-existing */
+      }
+    })
+
+    async function ownDesign(partnerHeaders: any) {
+      const res = await api.post(
+        "/partners/designs",
+        { name: "BOM Design", design_type: "Original" },
+        { headers: partnerHeaders }
+      )
+      expect(res.status).toBe(201)
+      return res.data.design.id as string
+    }
+
+    it("links global inventory to a partner-owned design with planned qty", async () => {
+      const { partnerHeaders } = await createPartner(api, "link")
+      const designId = await ownDesign(partnerHeaders)
+      const invId = await createInventoryItem(api, adminHeaders, "Cotton Twill")
+
+      const linkRes = await api.post(
+        `/partners/designs/${designId}/inventory`,
+        { inventoryItems: [{ inventoryId: invId, plannedQuantity: 12 }] },
+        { headers: partnerHeaders }
+      )
+      expect(linkRes.status).toBe(201)
+      const items = linkRes.data.inventory_items || []
+      const line = items.find((i: any) => i.inventory_item_id === invId)
+      expect(line).toBeDefined()
+      expect(Number(line.planned_quantity)).toBe(12)
+
+      // GET returns the same BOM.
+      const getRes = await api.get(`/partners/designs/${designId}/inventory`, {
+        headers: partnerHeaders,
+      })
+      expect(getRes.status).toBe(200)
+      expect(
+        (getRes.data.inventory_items || []).map((i: any) => i.inventory_item_id)
+      ).toContain(invId)
+    })
+
+    it("updates a BOM line's planned quantity, then delinks it", async () => {
+      const { partnerHeaders } = await createPartner(api, "edit")
+      const designId = await ownDesign(partnerHeaders)
+      const invId = await createInventoryItem(api, adminHeaders, "Silk Charmeuse")
+
+      await api.post(
+        `/partners/designs/${designId}/inventory`,
+        { inventoryItems: [{ inventoryId: invId, plannedQuantity: 5 }] },
+        { headers: partnerHeaders }
+      )
+
+      // PATCH planned qty.
+      const patch = await api.patch(
+        `/partners/designs/${designId}/inventory/${invId}`,
+        { plannedQuantity: 20 },
+        { headers: partnerHeaders }
+      )
+      expect(patch.status).toBe(200)
+      const patched = (patch.data.inventory_items || []).find(
+        (i: any) => i.inventory_item_id === invId
+      )
+      expect(Number(patched.planned_quantity)).toBe(20)
+
+      // DELETE (delink).
+      const del = await api.delete(
+        `/partners/designs/${designId}/inventory/delink`,
+        { headers: partnerHeaders, data: { inventoryIds: [invId] } }
+      )
+      expect(del.status).toBe(200)
+      expect(
+        (del.data.inventory_items || []).map((i: any) => i.inventory_item_id)
+      ).not.toContain(invId)
+    })
+
+    it("blocks a partner from touching another partner's design BOM", async () => {
+      const { partnerHeaders: owner } = await createPartner(api, "owner")
+      const { partnerHeaders: intruder } = await createPartner(api, "intruder")
+      const designId = await ownDesign(owner)
+      const invId = await createInventoryItem(api, adminHeaders, "Wool Blend")
+
+      const res = await api.post(
+        `/partners/designs/${designId}/inventory`,
+        { inventoryItems: [{ inventoryId: invId, plannedQuantity: 3 }] },
+        { headers: intruder, validateStatus: () => true }
+      )
+      // NOT_ALLOWED → 400 (or 401 if auth rejected upstream).
+      expect([400, 401, 403]).toContain(res.status)
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/partner-production-run-create.spec.ts
+++ b/apps/backend/integration-tests/http/partner-production-run-create.spec.ts
@@ -1,0 +1,168 @@
+/**
+ * Partner-originated production runs (roadmap #6, Phase 4).
+ *
+ * A partner creates a SELF-APPROVED production run for their own design,
+ * in_house or outsourced. execution_mode + sub_partner_id are recorded;
+ * outsourced mirrors the design link to the sub-partner.
+ *
+ * Run:
+ *   pnpm test:integration:http:shared ./integration-tests/http/partner-production-run-create
+ */
+
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import designPartnersLink from "../../src/links/design-partners-link"
+
+const PARTNER_PASSWORD = "supersecret"
+jest.setTimeout(180_000)
+
+async function createPartner(api: any, label: string) {
+  const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+  const email = `prun-${label}-${unique}@jyt.test`
+  await api.post("/auth/partner/emailpass/register", {
+    email,
+    password: PARTNER_PASSWORD,
+  })
+  let login = await api.post("/auth/partner/emailpass", {
+    email,
+    password: PARTNER_PASSWORD,
+  })
+  let headers: Record<string, string> = {
+    Authorization: `Bearer ${login.data.token}`,
+  }
+  const partnerRes = await api.post(
+    "/partners",
+    {
+      name: `PRun ${label} ${unique}`,
+      handle: `prun-${label}-${unique}`,
+      admin: { email, first_name: "Test", last_name: "Partner" },
+    },
+    { headers }
+  )
+  expect(partnerRes.status).toBe(200)
+  login = await api.post("/auth/partner/emailpass", {
+    email,
+    password: PARTNER_PASSWORD,
+  })
+  headers = { Authorization: `Bearer ${login.data.token}` }
+  return { partnerId: partnerRes.data.partner.id as string, partnerHeaders: headers }
+}
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Partner-originated production runs (roadmap 6, Phase 4)", () => {
+    let adminHeaders: Record<string, any>
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+      try {
+        await api.post(
+          "/admin/email-templates",
+          {
+            name: "Admin Partner Created",
+            template_key: "partner-created-from-admin",
+            subject: "s",
+            html_content: "<div>ok</div>",
+            from: "t@t.com",
+            variables: {},
+            template_type: "email",
+          },
+          adminHeaders
+        )
+      } catch {
+        /* pre-existing */
+      }
+    })
+
+    async function ownDesign(partnerHeaders: any) {
+      const res = await api.post(
+        "/partners/designs",
+        { name: "Run Design", design_type: "Original" },
+        { headers: partnerHeaders }
+      )
+      expect(res.status).toBe(201)
+      return res.data.design.id as string
+    }
+
+    it("creates a self-approved in_house run owned by the partner", async () => {
+      const { partnerId, partnerHeaders } = await createPartner(api, "inhouse")
+      const designId = await ownDesign(partnerHeaders)
+
+      const res = await api.post(
+        `/partners/designs/${designId}/production-runs`,
+        { quantity: 5, execution_mode: "in_house" },
+        { headers: partnerHeaders }
+      )
+      expect(res.status).toBe(201)
+      const run = res.data.production_run
+      // Self-approved + self-started → in_progress (ready to work).
+      expect(run.status).toBe("in_progress")
+      expect(run.execution_mode).toBe("in_house")
+      expect(run.partner_id).toBe(partnerId)
+      expect(run.sub_partner_id == null).toBe(true)
+      expect(Number(run.quantity)).toBe(5)
+
+      // The run shows up in the partner's own run list.
+      const list = await api.get("/partners/production-runs?limit=100", {
+        headers: partnerHeaders,
+      })
+      expect(
+        (list.data.production_runs || list.data.productionRuns || []).map(
+          (r: any) => r.id
+        )
+      ).toContain(run.id)
+    })
+
+    it("creates an outsourced run + mirrors the design link to the sub-partner", async () => {
+      const { partnerHeaders: owner } = await createPartner(api, "owner")
+      const { partnerId: subId } = await createPartner(api, "vendor")
+      const designId = await ownDesign(owner)
+
+      const res = await api.post(
+        `/partners/designs/${designId}/production-runs`,
+        { quantity: 2, execution_mode: "outsourced", sub_partner_id: subId },
+        { headers: owner }
+      )
+      expect(res.status).toBe(201)
+      const run = res.data.production_run
+      expect(run.execution_mode).toBe("outsourced")
+      expect(run.sub_partner_id).toBe(subId)
+
+      // design → sub-partner link mirrored.
+      const container = getContainer()
+      const query = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data: links } = await query.graph({
+        entity: designPartnersLink.entryPoint,
+        filters: { design_id: designId, partner_id: subId },
+        fields: ["design_id", "partner_id"],
+      })
+      expect((links || []).length).toBe(1)
+    })
+
+    it("rejects outsourced without a sub_partner_id, and blocks non-owners", async () => {
+      const { partnerHeaders: owner } = await createPartner(api, "validate")
+      const { partnerHeaders: intruder } = await createPartner(api, "intruder")
+      const designId = await ownDesign(owner)
+
+      // Missing sub_partner_id on outsourced → 400 validation.
+      const bad = await api.post(
+        `/partners/designs/${designId}/production-runs`,
+        { execution_mode: "outsourced" },
+        { headers: owner, validateStatus: () => true }
+      )
+      expect(bad.status).toBe(400)
+
+      // Non-owner can't create a run on someone else's design.
+      const intruderRes = await api.post(
+        `/partners/designs/${designId}/production-runs`,
+        { execution_mode: "in_house" },
+        { headers: intruder, validateStatus: () => true }
+      )
+      expect([400, 401, 403]).toContain(intruderRes.status)
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/partner-run-cost-summary.spec.ts
+++ b/apps/backend/integration-tests/http/partner-run-cost-summary.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * Partner production-run cost summary (roadmap #6, Phase 5).
+ *
+ * A partner creates a self-approved run, logs a costed consumption, and
+ * reads the cost-summary (admin-parity numbers). Scoped: only the
+ * owning partner can read it.
+ *
+ * Run:
+ *   pnpm test:integration:http:shared ./integration-tests/http/partner-run-cost-summary
+ */
+
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+const PARTNER_PASSWORD = "supersecret"
+jest.setTimeout(180_000)
+
+async function createPartner(api: any, label: string) {
+  const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+  const email = `prcs-${label}-${unique}@jyt.test`
+  await api.post("/auth/partner/emailpass/register", {
+    email,
+    password: PARTNER_PASSWORD,
+  })
+  let login = await api.post("/auth/partner/emailpass", {
+    email,
+    password: PARTNER_PASSWORD,
+  })
+  let headers: Record<string, string> = {
+    Authorization: `Bearer ${login.data.token}`,
+  }
+  const partnerRes = await api.post(
+    "/partners",
+    {
+      name: `PRcs ${label} ${unique}`,
+      handle: `prcs-${label}-${unique}`,
+      admin: { email, first_name: "Test", last_name: "Partner" },
+    },
+    { headers }
+  )
+  expect(partnerRes.status).toBe(200)
+  login = await api.post("/auth/partner/emailpass", {
+    email,
+    password: PARTNER_PASSWORD,
+  })
+  headers = { Authorization: `Bearer ${login.data.token}` }
+  return { partnerId: partnerRes.data.partner.id as string, partnerHeaders: headers }
+}
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Partner run cost-summary (roadmap 6, Phase 5)", () => {
+    let adminHeaders: Record<string, any>
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+      try {
+        await api.post(
+          "/admin/email-templates",
+          {
+            name: "Admin Partner Created",
+            template_key: "partner-created-from-admin",
+            subject: "s",
+            html_content: "<div>ok</div>",
+            from: "t@t.com",
+            variables: {},
+            template_type: "email",
+          },
+          adminHeaders
+        )
+      } catch {
+        /* pre-existing */
+      }
+    })
+
+    async function ownDesignAndRun(partnerHeaders: any) {
+      const dRes = await api.post(
+        "/partners/designs",
+        { name: "CostSum Design", design_type: "Original" },
+        { headers: partnerHeaders }
+      )
+      const designId = dRes.data.design.id
+      const rRes = await api.post(
+        `/partners/designs/${designId}/production-runs`,
+        { quantity: 4, execution_mode: "in_house" },
+        { headers: partnerHeaders }
+      )
+      expect(rRes.status).toBe(201)
+      return { designId, runId: rRes.data.production_run.id as string }
+    }
+
+    it("returns a cost-summary reflecting logged consumption", async () => {
+      const { partnerHeaders } = await createPartner(api, "calc")
+      const { runId } = await ownDesignAndRun(partnerHeaders)
+
+      const invRes = await api.post(
+        "/admin/inventory-items",
+        { title: "CostSum Cotton", description: "cost summary test" },
+        adminHeaders
+      )
+      const invId = invRes.data.inventory_item.id
+
+      // Log a production consumption with a unit cost (2 units × 50).
+      const log = await api.post(
+        `/partners/production-runs/${runId}/consumption-logs`,
+        {
+          inventoryItemId: invId,
+          consumptionType: "production",
+          quantity: 2,
+          unitCost: 50,
+          unitOfMeasure: "Meter",
+        },
+        { headers: partnerHeaders, validateStatus: () => true }
+      )
+      expect([200, 201]).toContain(log.status)
+
+      const res = await api.get(
+        `/partners/production-runs/${runId}/cost-summary`,
+        { headers: partnerHeaders }
+      )
+      expect(res.status).toBe(200)
+      const cs = res.data.cost_summary
+      expect(cs.production_run_id).toBe(runId)
+      expect(cs.material.total).toBe(100) // 2 × 50
+      expect(cs.grand_total).toBe(100)
+      expect(cs.total_consumption_logs).toBeGreaterThanOrEqual(1)
+    })
+
+    it("blocks a partner from reading another partner's run cost-summary", async () => {
+      const { partnerHeaders: owner } = await createPartner(api, "owner")
+      const { partnerHeaders: intruder } = await createPartner(api, "intruder")
+      const { runId } = await ownDesignAndRun(owner)
+
+      const res = await api.get(
+        `/partners/production-runs/${runId}/cost-summary`,
+        { headers: intruder, validateStatus: () => true }
+      )
+      expect([400, 401, 404]).toContain(res.status)
+    })
+  })
+})

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -178,6 +178,7 @@ import { AdminRecreateProductionRunSchema } from "./admin/designs/recreate-produ
 import { listDesignsQuerySchema, PartnerCreateDesignReq, PartnerUpdateDesignReq } from "./partners/designs/validators";
 import { listProductionRunsQuerySchema } from "./partners/production-runs/validators";
 import { PartnerPostDesignInventoryReq, PartnerPatchDesignInventoryLinkReq, PartnerDeleteDesignInventoryReq } from "./partners/designs/[designId]/inventory/validators";
+import { PartnerCreateProductionRunReq } from "./partners/designs/[designId]/production-runs/validators";
 import { PartnerPostConsumptionLogReq } from "./partners/designs/[designId]/consumption-logs/validators";
 import { PartnerPostProductionRunConsumptionLogReq } from "./partners/production-runs/[id]/consumption-logs/validators";
 import { listPartnersQuerySchema, PostPartnerSchema } from "./admin/partners/validators";
@@ -3879,6 +3880,15 @@ export default defineMiddlewares({
       matcher: "/partners/designs/:designId/cost",
       method: "GET",
       middlewares: [authenticate("partner", ["session", "bearer"])],
+    },
+    {
+      // Roadmap #6 Phase 4 — partner-originated (self-approved) runs
+      matcher: "/partners/designs/:designId/production-runs",
+      method: "POST",
+      middlewares: [
+        authenticate("partner", ["session", "bearer"]),
+        validateAndTransformBody(wrapSchema(PartnerCreateProductionRunReq)),
+      ],
     },
     {
       matcher: "/partners/designs/:designId/consumption-logs",

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -177,7 +177,7 @@ import { AdminCreateDesignProductionRunSchema } from "./admin/designs/[id]/produ
 import { AdminRecreateProductionRunSchema } from "./admin/designs/recreate-production-run/validators";
 import { listDesignsQuerySchema, PartnerCreateDesignReq, PartnerUpdateDesignReq } from "./partners/designs/validators";
 import { listProductionRunsQuerySchema } from "./partners/production-runs/validators";
-import { PartnerDesignInventorySchema } from "./partners/designs/[designId]/inventory/validators";
+import { PartnerPostDesignInventoryReq, PartnerPatchDesignInventoryLinkReq, PartnerDeleteDesignInventoryReq } from "./partners/designs/[designId]/inventory/validators";
 import { PartnerPostConsumptionLogReq } from "./partners/designs/[designId]/consumption-logs/validators";
 import { PartnerPostProductionRunConsumptionLogReq } from "./partners/production-runs/[id]/consumption-logs/validators";
 import { listPartnersQuerySchema, PostPartnerSchema } from "./admin/partners/validators";
@@ -3840,11 +3840,33 @@ export default defineMiddlewares({
       ],
     },
     {
+      // Roadmap #6 Phase 2 — design ↔ inventory BOM (partner)
       matcher: "/partners/designs/:designId/inventory",
       method: "POST",
       middlewares: [
         authenticate("partner", ["session", "bearer"]),
-        validateAndTransformBody(wrapSchema(PartnerDesignInventorySchema)),
+        validateAndTransformBody(wrapSchema(PartnerPostDesignInventoryReq)),
+      ],
+    },
+    {
+      matcher: "/partners/designs/:designId/inventory",
+      method: "GET",
+      middlewares: [authenticate("partner", ["session", "bearer"])],
+    },
+    {
+      matcher: "/partners/designs/:designId/inventory/:inventoryLinkId",
+      method: "PATCH",
+      middlewares: [
+        authenticate("partner", ["session", "bearer"]),
+        validateAndTransformBody(wrapSchema(PartnerPatchDesignInventoryLinkReq)),
+      ],
+    },
+    {
+      matcher: "/partners/designs/:designId/inventory/delink",
+      method: "DELETE",
+      middlewares: [
+        authenticate("partner", ["session", "bearer"]),
+        validateAndTransformBody(wrapSchema(PartnerDeleteDesignInventoryReq)),
       ],
     },
     {

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -3870,6 +3870,17 @@ export default defineMiddlewares({
       ],
     },
     {
+      // Roadmap #6 Phase 3 — partner cost estimation
+      matcher: "/partners/designs/:designId/recalculate-cost",
+      method: "POST",
+      middlewares: [authenticate("partner", ["session", "bearer"])],
+    },
+    {
+      matcher: "/partners/designs/:designId/cost",
+      method: "GET",
+      middlewares: [authenticate("partner", ["session", "bearer"])],
+    },
+    {
       matcher: "/partners/designs/:designId/consumption-logs",
       method: "POST",
       middlewares: [

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -2165,6 +2165,15 @@ export default defineMiddlewares({
       ],
     },
     {
+      // Roadmap #6 Phase 5 — partner run cost-summary (admin parity)
+      matcher: "/partners/production-runs/:id/cost-summary",
+      method: "GET",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
+    {
       matcher: "/partners/production-runs/:id/accept",
       method: "POST",
       middlewares: [

--- a/apps/backend/src/api/partners/designs/[designId]/cost/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/cost/route.ts
@@ -1,0 +1,42 @@
+/**
+ * @file Partner design cost read
+ * @description Roadmap #6 Phase 3 — read the persisted cost fields for
+ * a partner-owned design (estimated / material / production cost +
+ * breakdown). Populated by `POST .../recalculate-cost`.
+ * @module API/Partners/Designs/Cost
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { assertPartnerOwnsDesign } from "../../helpers"
+
+export async function GET(
+  req: AuthenticatedMedusaRequest & { params: { designId: string } },
+  res: MedusaResponse
+) {
+  const { designId } = req.params
+  await assertPartnerOwnsDesign(req, designId)
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data } = await query.graph({
+    entity: "design",
+    filters: { id: designId },
+    fields: [
+      "id",
+      "estimated_cost",
+      "material_cost",
+      "production_cost",
+      "cost_breakdown",
+      "cost_currency",
+    ],
+  })
+  const design = (data || [])[0] as any
+
+  res.status(200).json({
+    design_id: designId,
+    estimated_cost: design?.estimated_cost ?? null,
+    material_cost: design?.material_cost ?? null,
+    production_cost: design?.production_cost ?? null,
+    cost_breakdown: design?.cost_breakdown ?? null,
+    cost_currency: design?.cost_currency ?? null,
+  })
+}

--- a/apps/backend/src/api/partners/designs/[designId]/inventory/[inventoryLinkId]/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/inventory/[inventoryLinkId]/route.ts
@@ -1,0 +1,56 @@
+/**
+ * @file Partner design ↔ inventory link update
+ * @description Roadmap #6 Phase 2 — update a single BOM line
+ * (planned quantity / location / metadata) on a partner-owned design.
+ * Mirrors `PATCH /admin/designs/:id/inventory/:inventoryLinkId`.
+ * @module API/Partners/Designs/Inventory
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { MedusaError } from "@medusajs/framework/utils"
+import { updateDesignInventoryLinkWorkflow } from "../../../../../../workflows/designs/inventory/link-inventory"
+import { listDesignInventoryWorkflow } from "../../../../../../workflows/designs/inventory/list-design-inventory"
+import {
+  assertPartnerOwnsDesign,
+  getPartnerPrimaryStore,
+} from "../../../helpers"
+import { PartnerPatchDesignInventoryLinkReq } from "../validators"
+
+export const PATCH = async (
+  req: AuthenticatedMedusaRequest<PartnerPatchDesignInventoryLinkReq> & {
+    params: { designId: string; inventoryLinkId: string }
+  },
+  res: MedusaResponse
+) => {
+  const { designId, inventoryLinkId } = req.params
+  const { partner } = await assertPartnerOwnsDesign(req, designId)
+
+  // If the partner moves the line to a location, it must be theirs.
+  if (req.validatedBody.locationId) {
+    const store = await getPartnerPrimaryStore(req, partner.id)
+    const defaultLocationId = store?.default_location_id
+    if (defaultLocationId && req.validatedBody.locationId !== defaultLocationId) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        `location_id ${req.validatedBody.locationId} is not this partner's warehouse`
+      )
+    }
+  }
+
+  const { errors } = await updateDesignInventoryLinkWorkflow(req.scope).run({
+    input: {
+      design_id: designId,
+      inventory_id: inventoryLinkId,
+      planned_quantity: req.validatedBody.plannedQuantity,
+      location_id: req.validatedBody.locationId,
+      metadata: req.validatedBody.metadata ?? undefined,
+    },
+  })
+  if (errors.length > 0) {
+    throw errors
+  }
+
+  const { result } = await listDesignInventoryWorkflow(req.scope).run({
+    input: { design_id: designId },
+  })
+  res.status(200).json(result)
+}

--- a/apps/backend/src/api/partners/designs/[designId]/inventory/delink/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/inventory/delink/route.ts
@@ -1,0 +1,36 @@
+/**
+ * @file Partner design ↔ inventory delink
+ * @description Roadmap #6 Phase 2 — remove BOM lines from a
+ * partner-owned design. Mirrors `DELETE /admin/designs/:id/inventory/delink`.
+ * @module API/Partners/Designs/Inventory
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { delinkDesignInventoryWorkflow } from "../../../../../../workflows/designs/inventory/link-inventory"
+import { listDesignInventoryWorkflow } from "../../../../../../workflows/designs/inventory/list-design-inventory"
+import { assertPartnerOwnsDesign } from "../../../helpers"
+import { PartnerDeleteDesignInventoryReq } from "../validators"
+
+export const DELETE = async (
+  req: AuthenticatedMedusaRequest<PartnerDeleteDesignInventoryReq> & {
+    params: { designId: string }
+  },
+  res: MedusaResponse
+) => {
+  const { designId } = req.params
+  await assertPartnerOwnsDesign(req, designId)
+
+  const { errors } = await delinkDesignInventoryWorkflow(req.scope).run({
+    input: {
+      design_id: designId,
+      inventory_ids: req.validatedBody.inventoryIds,
+    },
+  })
+  if (errors.length > 0) {
+    throw errors
+  }
+
+  const { result } = await listDesignInventoryWorkflow(req.scope).run({
+    input: { design_id: designId },
+  })
+  res.status(200).json(result)
+}

--- a/apps/backend/src/api/partners/designs/[designId]/inventory/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/inventory/route.ts
@@ -1,45 +1,100 @@
 /**
- * @file Partner API routes for design inventory management
- * @description Provides endpoints for reporting inventory consumption for designs in the JYT Commerce platform
+ * @file Partner design ↔ inventory (bill-of-materials) routes
+ * @description Roadmap #6 Phase 2 — lets a partner link GLOBAL
+ * inventory items to their OWN design as a bill-of-materials, with a
+ * planned quantity per item. Mirrors the admin
+ * `/admin/designs/:id/inventory` contract; scoping (design ownership +
+ * location) is enforced in the handler.
+ *
+ * Supersedes the previously-deprecated (410) consumption-report POST —
+ * consumption reporting now lives on
+ * `POST /partners/designs/:id/complete`.
+ *
  * @module API/Partners/Designs/Inventory
- * @deprecated This endpoint is deprecated. Use POST /partners/designs/:designId/complete instead.
- */
-
-/**
- * @typedef {Object} ErrorResponse
- * @property {string} error - Error message describing the issue
- * @property {string} message - Detailed message with migration instructions
- */
-
-/**
- * Report inventory consumption for a design (DEPRECATED)
- * @route POST /partners/designs/:designId/inventory
- * @group Design - Operations related to design inventory
- * @param {string} designId.path.required - The ID of the design to report inventory for
- * @returns {ErrorResponse} 410 - Deprecation notice with migration instructions
- * @throws {MedusaError} 401 - Unauthorized if not authenticated
- * @throws {MedusaError} 404 - Not found if design doesn't exist
- *
- * @example request
- * POST /partners/designs/design_123456789/inventory
- *
- * @example response 410
- * {
- *   "error": "This endpoint is deprecated",
- *   "message": "Report inventory via POST /partners/designs/:designId/complete with { consumptions: [{ inventory_item_id, quantity, location_id? }] }."
- * }
  */
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { MedusaError } from "@medusajs/framework/utils"
+import { linkDesignInventoryWorkflow } from "../../../../../workflows/designs/inventory/link-inventory"
+import { listDesignInventoryWorkflow } from "../../../../../workflows/designs/inventory/list-design-inventory"
+import { assertPartnerOwnsDesign, getPartnerPrimaryStore } from "../../helpers"
+import { PartnerPostDesignInventoryReq } from "./validators"
 
-// Deprecated endpoint: Inventory reporting is now handled via
-// POST /partners/designs/:designId/complete with an optional `consumptions` payload.
-// See src/api/partners/designs/[designId]/complete/route.ts
+/**
+ * Link global inventory items to a partner-owned design (BOM).
+ * @route POST /partners/designs/:designId/inventory
+ */
 export async function POST(
-  req: AuthenticatedMedusaRequest,
+  req: AuthenticatedMedusaRequest<PartnerPostDesignInventoryReq> & {
+    params: { designId: string }
+  },
   res: MedusaResponse
 ) {
-  return res.status(410).json({
-    error: "This endpoint is deprecated",
-    message: "Report inventory via POST /partners/designs/:designId/complete with { consumptions: [{ inventory_item_id, quantity, location_id? }] }.",
+  const { designId } = req.params
+  const { partner } = await assertPartnerOwnsDesign(req, designId)
+
+  // Scope any location the partner pins to their own warehouse. Default
+  // to the store's default location when omitted. A partner must not be
+  // able to pin a BOM line to a location they don't own.
+  const store = await getPartnerPrimaryStore(req, partner.id)
+  const defaultLocationId: string | undefined =
+    store?.default_location_id ?? undefined
+
+  const body = req.validatedBody
+  const scopeLocation = (locationId?: string): string | undefined => {
+    const loc = locationId ?? defaultLocationId
+    if (loc && defaultLocationId && loc !== defaultLocationId) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        `location_id ${loc} is not this partner's warehouse`
+      )
+    }
+    return loc
+  }
+
+  const inventoryItems = (body.inventoryItems ?? []).map((item) => ({
+    inventory_id: item.inventoryId,
+    planned_quantity: item.plannedQuantity,
+    location_id: scopeLocation(item.locationId),
+    metadata: item.metadata,
+  }))
+
+  // Bare inventoryIds inherit the partner's default location.
+  const inventoryItemsFromIds = (body.inventoryIds ?? []).map((id) => ({
+    inventory_id: id,
+    location_id: defaultLocationId,
+  }))
+
+  const { errors } = await linkDesignInventoryWorkflow(req.scope).run({
+    input: {
+      design_id: designId,
+      inventory_items: [...inventoryItems, ...inventoryItemsFromIds],
+    },
   })
+  if (errors.length > 0) {
+    throw errors
+  }
+
+  const { result } = await listDesignInventoryWorkflow(req.scope).run({
+    input: { design_id: designId },
+  })
+  res.status(201).json(result)
+}
+
+/**
+ * List the design's linked inventory (BOM). Readable by the owning
+ * partner; non-owners who aren't linked are blocked by the ownership
+ * guard (NOT_ALLOWED).
+ * @route GET /partners/designs/:designId/inventory
+ */
+export async function GET(
+  req: AuthenticatedMedusaRequest & { params: { designId: string } },
+  res: MedusaResponse
+) {
+  const { designId } = req.params
+  await assertPartnerOwnsDesign(req, designId)
+
+  const { result } = await listDesignInventoryWorkflow(req.scope).run({
+    input: { design_id: designId },
+  })
+  res.status(200).json(result)
 }

--- a/apps/backend/src/api/partners/designs/[designId]/inventory/validators.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/inventory/validators.ts
@@ -1,5 +1,7 @@
 import { z } from "@medusajs/framework/zod"
 
+// Legacy consumption-report shape (kept for the deprecated path's
+// type; the BOM-link POST below supersedes it).
 export const PartnerDesignInventorySchema = z.object({
   inventory_used: z.preprocess((val) => {
     if (typeof val === "string") {
@@ -11,3 +13,57 @@ export const PartnerDesignInventorySchema = z.object({
 })
 
 export type PartnerDesignInventoryReq = z.infer<typeof PartnerDesignInventorySchema>
+
+// Roadmap #6 Phase 2 — partner links GLOBAL inventory items to their
+// own design (the bill-of-materials). Mirrors the admin
+// `AdminPostDesignInventoryReq` wire shape. Location scoping to the
+// partner's own warehouse is enforced in the handler.
+
+const inventoryLinkItemSchema = z.object({
+  inventoryId: z.string(),
+  plannedQuantity: z.number().int().optional(),
+  locationId: z.string().optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
+})
+
+export const PartnerPostDesignInventoryReq = z
+  .object({
+    inventoryIds: z.array(z.string()).optional(),
+    inventoryItems: z.array(inventoryLinkItemSchema).optional(),
+  })
+  .refine(
+    (body) =>
+      (body.inventoryIds && body.inventoryIds.length > 0) ||
+      (body.inventoryItems && body.inventoryItems.length > 0),
+    { message: "Provide at least one inventory id or inventory item payload." }
+  )
+
+export type PartnerPostDesignInventoryReq = z.infer<
+  typeof PartnerPostDesignInventoryReq
+>
+
+export const PartnerPatchDesignInventoryLinkReq = z
+  .object({
+    plannedQuantity: z.number().int().nullable().optional(),
+    locationId: z.string().nullable().optional(),
+    metadata: z.record(z.string(), z.any()).nullable().optional(),
+  })
+  .refine(
+    (body) =>
+      body.plannedQuantity !== undefined ||
+      body.locationId !== undefined ||
+      body.metadata !== undefined,
+    { message: "Provide at least one field to update." }
+  )
+
+export type PartnerPatchDesignInventoryLinkReq = z.infer<
+  typeof PartnerPatchDesignInventoryLinkReq
+>
+
+export const PartnerDeleteDesignInventoryReq = z.object({
+  inventoryIds: z.array(z.string()).min(1),
+})
+
+export type PartnerDeleteDesignInventoryReq = z.infer<
+  typeof PartnerDeleteDesignInventoryReq
+>

--- a/apps/backend/src/api/partners/designs/[designId]/production-runs/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/production-runs/route.ts
@@ -1,0 +1,85 @@
+/**
+ * @file Partner-originated production runs
+ * @description Roadmap #6 Phase 4 — a partner creates a SELF-APPROVED
+ * production run for their OWN design and runs production themselves
+ * (in_house) or farms it out to a sub-partner (outsourced).
+ *
+ * The creating partner is the run's `partner_id` (originator + lifecycle
+ * driver). `execution_mode` + `sub_partner_id` are recorded structurally
+ * so cost tracking can isolate self-made vs outsourced work. For
+ * outsourced runs we also mirror the design→sub-partner link so the
+ * vendor can see the design. NOTE (Phase 4b follow-up): full vendor-side
+ * execution handoff — the sub-partner accepting/working an outsourced
+ * run via the partner lifecycle endpoints — is not yet wired; today the
+ * originating partner drives the lifecycle.
+ *
+ * @module API/Partners/Designs/ProductionRuns
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { MedusaError } from "@medusajs/framework/utils"
+import { createProductionRunWorkflow } from "../../../../../workflows/production-runs/create-production-run"
+import { linkDesignPartnerWorkflow } from "../../../../../workflows/designs/partner/link-design-to-partner"
+import { assertPartnerOwnsDesign } from "../../helpers"
+import { PartnerCreateProductionRunReq } from "./validators"
+
+export async function POST(
+  req: AuthenticatedMedusaRequest<PartnerCreateProductionRunReq> & {
+    params: { designId: string }
+  },
+  res: MedusaResponse
+) {
+  const { designId } = req.params
+  const { partner } = await assertPartnerOwnsDesign(req, designId)
+
+  const body = req.validatedBody
+
+  const { result: createdRun, errors } = await createProductionRunWorkflow(
+    req.scope
+  ).run({
+    input: {
+      design_id: designId,
+      // Originator + lifecycle driver.
+      partner_id: partner.id,
+      quantity: body.quantity ?? 1,
+      run_type: body.run_type ?? "production",
+      // Self-approved AND self-started: a partner running their own
+      // production owns the decision (no admin gate) and is ready to
+      // work it immediately — so it enters `in_progress`, which also
+      // unlocks consumption logging + completion via the existing
+      // partner lifecycle endpoints. (The dispatch→accept dance only
+      // applies to admin-assigned runs.)
+      status: "in_progress",
+      execution_mode: body.execution_mode,
+      sub_partner_id:
+        body.execution_mode === "outsourced" ? body.sub_partner_id : null,
+      metadata: {
+        ...(body.metadata ?? {}),
+        source: "partner.self_serve",
+      },
+    },
+  })
+
+  if (errors?.length) {
+    throw new MedusaError(
+      MedusaError.Types.UNEXPECTED_STATE,
+      `Failed to create production run: ${errors
+        .map((e: any) => e?.error?.message || String(e))
+        .join(", ")}`
+    )
+  }
+
+  // Outsourced: let the sub-partner see the design (the run carries
+  // sub_partner_id; mirroring the design link surfaces it on their
+  // /partners/designs). Idempotent on the (design, partner) pair.
+  if (body.execution_mode === "outsourced" && body.sub_partner_id) {
+    try {
+      await linkDesignPartnerWorkflow(req.scope).run({
+        input: { design_id: designId, partner_ids: [body.sub_partner_id] },
+      })
+    } catch {
+      // Non-fatal — the run is created; link mirror is best-effort.
+    }
+  }
+
+  res.status(201).json({ production_run: createdRun })
+}

--- a/apps/backend/src/api/partners/designs/[designId]/production-runs/validators.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/production-runs/validators.ts
@@ -1,0 +1,26 @@
+import { z } from "@medusajs/framework/zod"
+
+// Roadmap #6 Phase 4 — a partner creates a self-approved production
+// run for their OWN design. execution_mode records whether the partner
+// makes it themselves (in_house) or farms it out to a sub-partner
+// (outsourced); sub_partner_id is required for the latter.
+export const PartnerCreateProductionRunReq = z
+  .object({
+    quantity: z.number().positive().optional(),
+    run_type: z.enum(["production", "sample"]).optional(),
+    execution_mode: z.enum(["in_house", "outsourced"]).default("in_house"),
+    sub_partner_id: z.string().optional(),
+    metadata: z.record(z.string(), z.any()).optional(),
+  })
+  .refine(
+    (b) => b.execution_mode !== "outsourced" || !!b.sub_partner_id,
+    { message: "sub_partner_id is required when execution_mode is outsourced." }
+  )
+  .refine(
+    (b) => b.execution_mode === "outsourced" || !b.sub_partner_id,
+    { message: "sub_partner_id is only valid when execution_mode is outsourced." }
+  )
+
+export type PartnerCreateProductionRunReq = z.infer<
+  typeof PartnerCreateProductionRunReq
+>

--- a/apps/backend/src/api/partners/designs/[designId]/recalculate-cost/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/recalculate-cost/route.ts
@@ -1,0 +1,56 @@
+/**
+ * @file Partner design cost re-estimation
+ * @description Roadmap #6 Phase 3 — a partner triggers a cost estimate
+ * for their OWN design (material + production cost from the linked
+ * inventory BOM + order history). Mirrors
+ * `POST /admin/designs/:id/recalculate-cost`; persists the richer cost
+ * fields back onto the design so `GET .../cost` can read them.
+ * @module API/Partners/Designs/RecalculateCost
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { estimateDesignCostWorkflow } from "../../../../../workflows/designs/estimate-design-cost"
+import { DESIGN_MODULE } from "../../../../../modules/designs"
+import { assertPartnerOwnsDesign } from "../../helpers"
+
+export async function POST(
+  req: AuthenticatedMedusaRequest & { params: { designId: string } },
+  res: MedusaResponse
+) {
+  const { designId } = req.params
+  await assertPartnerOwnsDesign(req, designId)
+
+  const { result, errors } = await estimateDesignCostWorkflow(req.scope).run({
+    input: { design_id: designId },
+  })
+  if (errors && errors.length > 0) {
+    return res
+      .status(400)
+      .json({ error: "Failed to estimate cost", details: errors })
+  }
+
+  // Persist the estimate so the design carries its latest cost. Mirrors
+  // the admin route but stores the fuller breakdown too.
+  try {
+    const designService = req.scope.resolve(DESIGN_MODULE) as any
+    await designService.updateDesigns({
+      id: designId,
+      estimated_cost: result.total_estimated,
+      material_cost: result.material_cost,
+      production_cost: result.production_cost,
+      cost_breakdown: {
+        items: result.breakdown?.materials ?? [],
+        production_percent: result.breakdown?.production_percent,
+        confidence: result.confidence,
+        calculated_at: new Date().toISOString(),
+        source: "partner_recalculate",
+      },
+    })
+  } catch {
+    // Non-fatal — the estimate was still computed + returned.
+  }
+
+  res.status(200).json({
+    cost_estimate: result,
+    message: `Cost recalculated: ${result.total_estimated} (${result.confidence})`,
+  })
+}

--- a/apps/backend/src/api/partners/designs/[designId]/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/route.ts
@@ -126,49 +126,7 @@ import designPartnersLink from "../../../../links/design-partners-link"
 import { updateDesignWorkflow } from "../../../../workflows/designs/update-design"
 import { deleteDesignWorkflow } from "../../../../workflows/designs/delete-design"
 import { PartnerUpdateDesign } from "../validators"
-
-/**
- * Resolve the design + assert the authenticated partner OWNS it
- * (created it via the self-serve flow). Ownership is stricter than
- * assignment — an admin-assigned design is readable but not editable
- * by the partner. Throws 401/403/404 as appropriate.
- */
-async function assertPartnerOwnsDesign(
-  req: AuthenticatedMedusaRequest,
-  designId: string
-): Promise<{ partner: any; design: any }> {
-  if (!req.auth_context?.actor_id) {
-    throw new MedusaError(
-      MedusaError.Types.UNAUTHORIZED,
-      "Partner authentication required"
-    )
-  }
-  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
-  if (!partner) {
-    throw new MedusaError(
-      MedusaError.Types.UNAUTHORIZED,
-      "Partner authentication required"
-    )
-  }
-  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
-  const { data } = await query.graph({
-    entity: "design",
-    filters: { id: designId },
-    fields: ["id", "owner_partner_id", "name", "status"],
-  })
-  const design = (data || [])[0] as any
-  if (!design) {
-    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Design not found")
-  }
-  if (design.owner_partner_id !== partner.id) {
-    // Partner can read assigned designs but only mutate ones they own.
-    throw new MedusaError(
-      MedusaError.Types.NOT_ALLOWED,
-      "You can only modify designs you created"
-    )
-  }
-  return { partner, design }
-}
+import { assertPartnerOwnsDesign } from "../helpers"
 
 
 export const GET = async (

--- a/apps/backend/src/api/partners/designs/helpers.ts
+++ b/apps/backend/src/api/partners/designs/helpers.ts
@@ -1,0 +1,72 @@
+import { AuthenticatedMedusaRequest } from "@medusajs/framework"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { getPartnerFromAuthContext } from "../helpers"
+
+/**
+ * Resolve the design + assert the authenticated partner OWNS it
+ * (created it via the self-serve flow, `owner_partner_id` === partner).
+ * Ownership is stricter than assignment — an admin-assigned design is
+ * readable but not mutable by the partner. Throws 401/400(NOT_ALLOWED)/404.
+ *
+ * Shared by the partner design detail route (PUT/DELETE) and the
+ * design-inventory (BOM) routes so the guard stays consistent.
+ */
+export async function assertPartnerOwnsDesign(
+  req: AuthenticatedMedusaRequest,
+  designId: string
+): Promise<{ partner: any; design: any }> {
+  if (!req.auth_context?.actor_id) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "Partner authentication required"
+    )
+  }
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
+  if (!partner) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "Partner authentication required"
+    )
+  }
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data } = await query.graph({
+    entity: "design",
+    filters: { id: designId },
+    fields: ["id", "owner_partner_id", "name", "status"],
+  })
+  const design = (data || [])[0] as any
+  if (!design) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Design not found")
+  }
+  if (design.owner_partner_id !== partner.id) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "You can only modify designs you created"
+    )
+  }
+  return { partner, design }
+}
+
+/**
+ * Resolve the partner's primary store + its default location/sales
+ * channel. Used to scope inventory-link locations to the partner's own
+ * warehouse (a partner must not pin a design's BOM line to a location
+ * they don't own).
+ */
+export async function getPartnerPrimaryStore(
+  req: AuthenticatedMedusaRequest,
+  partnerId: string
+): Promise<any | null> {
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data } = await query.graph({
+    entity: "partner",
+    filters: { id: partnerId },
+    fields: [
+      "id",
+      "stores.id",
+      "stores.default_location_id",
+      "stores.default_sales_channel_id",
+    ],
+  })
+  return (data?.[0] as any)?.stores?.[0] ?? null
+}

--- a/apps/backend/src/api/partners/production-runs/[id]/cost-summary/route.ts
+++ b/apps/backend/src/api/partners/production-runs/[id]/cost-summary/route.ts
@@ -1,0 +1,47 @@
+/**
+ * @file Partner production-run cost summary
+ * @description Roadmap #6 Phase 5 — parity with the admin
+ * `/admin/production-runs/:id/cost-summary`, scoped to the partner that
+ * owns the run (or is the outsourced sub-partner on it). Reuses the
+ * shared `computeRunCostSummary` so the numbers match admin exactly.
+ * @module API/Partners/ProductionRuns/CostSummary
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { computeRunCostSummary } from "../../../../../modules/production_runs/cost-summary"
+
+export const GET = async (
+  req: AuthenticatedMedusaRequest & { params: { id: string } },
+  res: MedusaResponse
+) => {
+  const { id } = req.params
+  const partnerId = req.auth_context?.actor_id
+  if (!partnerId) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "Partner authentication required"
+    )
+  }
+
+  // Scope: the run must belong to this partner — either as the
+  // originator (partner_id) or the outsourced executor (sub_partner_id).
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data } = await query.graph({
+    entity: "production_runs",
+    filters: { id },
+    fields: ["id", "partner_id", "sub_partner_id"],
+  })
+  const run = (data || [])[0] as any
+  if (
+    !run ||
+    (run.partner_id !== partnerId && run.sub_partner_id !== partnerId)
+  ) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Production run ${id} not found for this partner`
+    )
+  }
+
+  const cost_summary = await computeRunCostSummary(req.scope, id)
+  res.status(200).json({ cost_summary })
+}

--- a/apps/backend/src/modules/production_runs/cost-summary.ts
+++ b/apps/backend/src/modules/production_runs/cost-summary.ts
@@ -1,0 +1,214 @@
+import { MedusaContainer } from "@medusajs/framework/types"
+import { MedusaError } from "@medusajs/framework/utils"
+import { PRODUCTION_RUNS_MODULE } from "./index"
+import type ProductionRunService from "./service"
+import { CONSUMPTION_LOG_MODULE } from "../consumption_log"
+import type ConsumptionLogService from "../consumption_log/service"
+import { ENERGY_RATES_MODULE } from "../energy_rates"
+import type EnergyRateService from "../energy_rates/service"
+
+/**
+ * Compute a production run's cost summary — material + energy + labor +
+ * partner estimate → grand total + cost per unit. Extracted from the
+ * admin cost-summary route so the partner-side route can reuse the exact
+ * same computation (roadmap #6 Phase 5). Pure aside from the reads it
+ * does; never mutates.
+ */
+export type RunCostSummary = {
+  production_run_id: string
+  design_id: string
+  status: string
+  quantity: number
+  produced_quantity: number | null
+  rejected_quantity: number | null
+  material: { total: number; items: any[] }
+  energy: { total: number; breakdown: any[] }
+  labor: { total: number; total_hours: number; rate_per_hour: number | null }
+  partner: { estimate: number | null; cost_type: string; total: number | null }
+  grand_total: number | null
+  cost_per_unit: number | null
+  total_consumption_logs: number
+}
+
+export async function computeRunCostSummary(
+  container: MedusaContainer,
+  runId: string
+): Promise<RunCostSummary> {
+  const productionRunService: ProductionRunService =
+    container.resolve(PRODUCTION_RUNS_MODULE)
+  const consumptionLogService: ConsumptionLogService =
+    container.resolve(CONSUMPTION_LOG_MODULE)
+  const energyRateService: EnergyRateService =
+    container.resolve(ENERGY_RATES_MODULE)
+
+  const run = await productionRunService
+    .retrieveProductionRun(runId)
+    .catch(() => null)
+  if (!run) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Production run ${runId} not found`
+    )
+  }
+
+  const [logs] = await consumptionLogService.listAndCountConsumptionLogs(
+    { production_run_id: runId },
+    { take: null }
+  )
+
+  const materialTypes = ["sample", "production", "wastage"]
+  const energyTypes = ["energy_electricity", "energy_water", "energy_gas"]
+
+  const materialLogs = logs.filter((l: any) =>
+    materialTypes.includes(l.consumption_type)
+  )
+  const energyLogs = logs.filter((l: any) =>
+    energyTypes.includes(l.consumption_type)
+  )
+  const laborLogs = logs.filter((l: any) => l.consumption_type === "labor")
+
+  const [activeRates] = await energyRateService.listAndCountEnergyRates(
+    { is_active: true },
+    { take: null }
+  )
+  const rateMap = new Map<string, any>()
+  for (const rate of activeRates) {
+    const key = (rate as any).energy_type
+    const existing = rateMap.get(key)
+    if (
+      !existing ||
+      new Date((rate as any).effective_from) > new Date(existing.effective_from)
+    ) {
+      rateMap.set(key, rate)
+    }
+  }
+
+  // Material
+  let materialTotal = 0
+  const materialItems = materialLogs.map((log: any) => {
+    const lineTotal =
+      log.unit_cost != null ? log.quantity * Number(log.unit_cost) : null
+    if (lineTotal != null) materialTotal += lineTotal
+    return {
+      consumption_log_id: log.id,
+      inventory_item_id: log.inventory_item_id,
+      consumption_type: log.consumption_type,
+      quantity: log.quantity,
+      unit_cost: log.unit_cost != null ? Number(log.unit_cost) : null,
+      unit_of_measure: log.unit_of_measure,
+      line_total: lineTotal,
+      notes: log.notes,
+    }
+  })
+
+  // Energy
+  let energyTotal = 0
+  const energySummary: any[] = []
+  const energyByType = new Map<string, any[]>()
+  for (const log of energyLogs) {
+    const type = (log as any).consumption_type
+    if (!energyByType.has(type)) energyByType.set(type, [])
+    energyByType.get(type)!.push(log)
+  }
+  for (const [energyType, typeLogs] of energyByType) {
+    const totalQty = typeLogs.reduce((s: number, l: any) => s + l.quantity, 0)
+    const rate = rateMap.get(energyType)
+    const ratePerUnit = rate ? Number((rate as any).rate_per_unit) : null
+
+    let typeCost: number | null = null
+    const logsWithCost = typeLogs.filter((l: any) => l.unit_cost != null)
+    if (logsWithCost.length > 0) {
+      typeCost = logsWithCost.reduce(
+        (s: number, l: any) => s + l.quantity * Number(l.unit_cost),
+        0
+      )
+      const logsWithoutCost = typeLogs.filter((l: any) => l.unit_cost == null)
+      if (logsWithoutCost.length > 0 && ratePerUnit != null) {
+        typeCost += logsWithoutCost.reduce(
+          (s: number, l: any) => s + l.quantity * ratePerUnit,
+          0
+        )
+      }
+    } else if (ratePerUnit != null) {
+      typeCost = totalQty * ratePerUnit
+    }
+    if (typeCost != null) energyTotal += typeCost
+
+    energySummary.push({
+      energy_type: energyType,
+      total_quantity: totalQty,
+      unit_of_measure: typeLogs[0]?.unit_of_measure || "Other",
+      rate_per_unit: ratePerUnit,
+      total_cost: typeCost,
+    })
+  }
+
+  // Labor
+  let laborTotal = 0
+  const laborRate = rateMap.get("labor")
+  const laborRatePerUnit = laborRate
+    ? Number((laborRate as any).rate_per_unit)
+    : null
+  const totalLaborHours = laborLogs.reduce(
+    (s: number, l: any) => s + l.quantity,
+    0
+  )
+  const laborLogsWithCost = laborLogs.filter((l: any) => l.unit_cost != null)
+  if (laborLogsWithCost.length > 0) {
+    laborTotal = laborLogsWithCost.reduce(
+      (s: number, l: any) => s + l.quantity * Number(l.unit_cost),
+      0
+    )
+    const laborLogsWithoutCost = laborLogs.filter((l: any) => l.unit_cost == null)
+    if (laborLogsWithoutCost.length > 0 && laborRatePerUnit != null) {
+      laborTotal += laborLogsWithoutCost.reduce(
+        (s: number, l: any) => s + l.quantity * laborRatePerUnit,
+        0
+      )
+    }
+  } else if (laborRatePerUnit != null) {
+    laborTotal = totalLaborHours * laborRatePerUnit
+  }
+
+  // Partner estimate
+  const partnerCost = (run as any).partner_cost_estimate
+    ? Number((run as any).partner_cost_estimate)
+    : null
+  const costType = (run as any).cost_type || "total"
+  let partnerTotal: number | null = null
+  if (partnerCost != null) {
+    partnerTotal =
+      costType === "per_unit"
+        ? partnerCost * ((run as any).quantity || 1)
+        : partnerCost
+  }
+
+  const knownCosts = [materialTotal, energyTotal, laborTotal, partnerTotal].filter(
+    (c): c is number => c != null && c > 0
+  )
+  const grandTotal =
+    knownCosts.length > 0 ? knownCosts.reduce((a, b) => a + b, 0) : null
+  const producedQty =
+    (run as any).produced_quantity || (run as any).quantity || 1
+  const costPerUnit = grandTotal != null ? grandTotal / producedQty : null
+
+  return {
+    production_run_id: runId,
+    design_id: (run as any).design_id,
+    status: (run as any).status,
+    quantity: (run as any).quantity,
+    produced_quantity: (run as any).produced_quantity ?? null,
+    rejected_quantity: (run as any).rejected_quantity ?? null,
+    material: { total: materialTotal, items: materialItems },
+    energy: { total: energyTotal, breakdown: energySummary },
+    labor: {
+      total: laborTotal,
+      total_hours: totalLaborHours,
+      rate_per_hour: laborRatePerUnit,
+    },
+    partner: { estimate: partnerCost, cost_type: costType, total: partnerTotal },
+    grand_total: grandTotal,
+    cost_per_unit: costPerUnit,
+    total_consumption_logs: logs.length,
+  }
+}

--- a/apps/backend/src/modules/production_runs/migrations/.snapshot-production-runs.json
+++ b/apps/backend/src/modules/production_runs/migrations/.snapshot-production-runs.json
@@ -461,6 +461,41 @@
           "enumItems": [],
           "mappedType": "text"
         },
+        "execution_mode": {
+          "name": "execution_mode",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "'in_house'",
+          "comment": null,
+          "enumItems": [
+            "in_house",
+            "outsourced"
+          ],
+          "mappedType": "enum"
+        },
+        "sub_partner_id": {
+          "name": "sub_partner_id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
         "product_id": {
           "name": "product_id",
           "type": "text",

--- a/apps/backend/src/modules/production_runs/migrations/Migration20260605150400.ts
+++ b/apps/backend/src/modules/production_runs/migrations/Migration20260605150400.ts
@@ -1,0 +1,34 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Roadmap #6 Phase 4 — partner-originated production runs.
+ *
+ * Adds `execution_mode` (in_house | outsourced) + `sub_partner_id` to
+ * `production_runs` so a partner running production for themselves can
+ * distinguish self-made work from work farmed out to a sub-partner,
+ * and cost tracking can isolate per mode.
+ *
+ * Hand-written incremental ALTER (the generator emits a full
+ * `create table if not exists` snapshot, a no-op on the existing prod
+ * table). `add column if not exists` keeps it idempotent. See memory
+ * `reference_medusa_migration_create_if_not_exists_hazard`.
+ */
+export class Migration20260605150400 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(
+      `alter table if exists "production_runs" add column if not exists "execution_mode" text check ("execution_mode" in ('in_house', 'outsourced')) not null default 'in_house';`
+    );
+    this.addSql(
+      `alter table if exists "production_runs" add column if not exists "sub_partner_id" text null;`
+    );
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(
+      `alter table if exists "production_runs" drop column if exists "execution_mode";`
+    );
+    this.addSql(
+      `alter table if exists "production_runs" drop column if exists "sub_partner_id";`
+    );
+  }
+}

--- a/apps/backend/src/modules/production_runs/models/production-run.ts
+++ b/apps/backend/src/modules/production_runs/models/production-run.ts
@@ -22,6 +22,14 @@ const ProductionRun = model.define("production_runs", {
   design_id: model.text(),
   partner_id: model.text().nullable(),
 
+  // Roadmap #6 Phase 4 — how the run is executed:
+  //   in_house   = the owning partner manufactures it themselves
+  //   outsourced = handed to another partner/vendor (sub_partner_id)
+  // Lets partner cost tracking isolate self-made vs farmed-out work.
+  execution_mode: model.enum(["in_house", "outsourced"]).default("in_house"),
+  // The downstream partner a run is outsourced to (null for in_house).
+  sub_partner_id: model.text().nullable(),
+
   product_id: model.text().nullable(),
   variant_id: model.text().nullable(),
   order_id: model.text().nullable(),

--- a/apps/backend/src/workflows/production-runs/create-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/create-production-run.ts
@@ -46,6 +46,17 @@ export type CreateProductionRunInput = {
   order_line_item_id?: string
   metadata?: Record<string, any>
   task_ids?: string[]
+  // Roadmap #6 Phase 4 — partner self-serve runs.
+  status?:
+    | "draft"
+    | "pending_review"
+    | "approved"
+    | "sent_to_partner"
+    | "in_progress"
+    | "completed"
+    | "cancelled"
+  execution_mode?: "in_house" | "outsourced"
+  sub_partner_id?: string | null
 }
 
 const fetchDesignSnapshotStep = createStep(
@@ -142,7 +153,17 @@ const createProductionRunStep = createStep(
       snapshot: input.snapshot,
       captured_at: input.captured_at,
       metadata: input.payload.metadata,
-    })
+      // Phase 4: only set when explicitly provided so admin/order
+      // paths keep the model defaults (status=pending_review,
+      // execution_mode=in_house).
+      ...(input.payload.status ? { status: input.payload.status } : {}),
+      ...(input.payload.execution_mode
+        ? { execution_mode: input.payload.execution_mode }
+        : {}),
+      ...(input.payload.sub_partner_id !== undefined
+        ? { sub_partner_id: input.payload.sub_partner_id }
+        : {}),
+    } as any)
 
     const run = Array.isArray(created) ? created[0] : created
     return new StepResponse(run, (run as any).id)

--- a/apps/docs/notes/PARTNER_DESIGN_PRODUCTION_SELF_SERVE.md
+++ b/apps/docs/notes/PARTNER_DESIGN_PRODUCTION_SELF_SERVE.md
@@ -176,6 +176,18 @@ ships with HTTP integration tests using the parity recipe
 - **Tests:** in-house run stays with creator; outsourced run surfaces to
   sub-partner via `/partners/production-runs`; cost isolates per mode.
 
+**Phase 4 shipped (2026-06-05).** Decision: partner **self-approves**
+(runs created `status=approved`, no admin gate). Migration added
+`execution_mode` (`in_house`|`outsourced`) + `sub_partner_id` to
+`production_runs`. `POST /partners/designs/:id/production-runs` creates
+the run with `partner_id = self` (originator + lifecycle driver);
+outsourced mirrors the design→sub-partner link. **Phase 4b follow-up
+(deferred):** full vendor-side execution handoff — letting the
+`sub_partner` accept/start/finish/complete an outsourced run via the
+partner lifecycle endpoints (today the originating partner drives the
+lifecycle). Needs the partner run-list + lifecycle guards to also match
+`sub_partner_id`.
+
 ### Phase 5 — Partner production cost-summary + raw-material order placement UI
 
 - `GET /partners/production-runs/[id]/cost-summary` — parity with the

--- a/apps/docs/notes/PARTNER_DESIGN_PRODUCTION_SELF_SERVE.md
+++ b/apps/docs/notes/PARTNER_DESIGN_PRODUCTION_SELF_SERVE.md
@@ -188,6 +188,18 @@ partner lifecycle endpoints (today the originating partner drives the
 lifecycle). Needs the partner run-list + lifecycle guards to also match
 `sub_partner_id`.
 
+**Phase 5 backend shipped (2026-06-05).** `GET
+/partners/production-runs/:id/cost-summary` — admin parity, scoped to
+the run's `partner_id` OR `sub_partner_id`. Computation extracted into
+`src/modules/production_runs/cost-summary.ts` (`computeRunCostSummary`)
+so partner + admin produce identical numbers; admin route can adopt the
+helper later. **Remaining for Phase 5:** the raw-material **order
+placement UI** — the backend `POST /partners/inventory-orders` already
+exists; this is a partner-ui create form (frontend) + optional
+`POST /partners/raw-materials` if partners need to define their own
+materials. Partner-ui work across all phases (forms/panels) is the
+outstanding frontend track.
+
 ### Phase 5 — Partner production cost-summary + raw-material order placement UI
 
 - `GET /partners/production-runs/[id]/cost-summary` — parity with the


### PR DESCRIPTION
## Summary

Phases 2–5 of partner design + production self-serve (roadmap #6). Builds on Phase 1 (#318, merged). Plan + decisions: `apps/docs/notes/PARTNER_DESIGN_PRODUCTION_SELF_SERVE.md`.

Every endpoint is guarded to the **owning** partner via the shared `assertPartnerOwnsDesign` helper; all reuse existing admin workflows/computation — scoped exposure, not new business logic.

### Phase 2 — design ↔ inventory BOM
`POST/GET/PATCH/DELETE /partners/designs/:id/inventory[...]` — link global inventory items to an own design with `planned_quantity`; location scoped to the partner's warehouse. Supersedes the deprecated (410) consumption POST.

### Phase 3 — cost estimation
`POST /partners/designs/:id/recalculate-cost` (runs `estimateDesignCostWorkflow`, persists cost fields) + `GET /partners/designs/:id/cost`.

### Phase 4 — partner-originated runs + `execution_mode`
- Migration: `production_runs` gains `execution_mode` (in_house|outsourced) + `sub_partner_id` (hand-written idempotent ALTER).
- `POST /partners/designs/:id/production-runs` — **self-approved + self-started** run (`status=in_progress`), `partner_id = self`. Outsourced requires `sub_partner_id` + mirrors the design→sub-partner link.
- **Decision:** partner self-approves. **Phase 4b (deferred):** vendor-side execution handoff for outsourced runs.

### Phase 5 — run cost-summary
`GET /partners/production-runs/:id/cost-summary` — admin-parity (material+energy+labor+partner estimate), scoped to `partner_id` OR `sub_partner_id`. Computation extracted into a shared `computeRunCostSummary` helper.
- **Remaining (frontend track):** raw-material order-placement partner-ui form (backend `POST /partners/inventory-orders` already exists).

## Migrations (run on deploy via predeploy:force)
- `design.owner_partner_id` is in Phase 1 (already on prod via #318).
- This PR adds `production_runs.execution_mode` + `sub_partner_id`.

## Test plan
- [x] `partner-design-inventory-bom` 3/3 · `partner-design-cost` 2/2 · `partner-production-run-create` 3/3 · `partner-run-cost-summary` 2/2
- [x] Phase 1 suite (`partner-design-crud`) still green
- [x] `tsc --noEmit` clean on all changed files
- [ ] After deploy: `npx medusa db:migrate` adds the production_runs columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)