### PR TITLE
fix(build): annotate container.resolve() as any to fix CI build (TS18046)

### DIFF
--- a/apps/backend/src/workflows/designs/delete-design.ts
+++ b/apps/backend/src/workflows/designs/delete-design.ts
@@ -42,7 +42,7 @@ export const deleteDesignStep = createStep(
 const resolveDesignPartnerLinksStep = createStep(
   "resolve-design-partner-links",
   async (input: { design_id: string }, { container }) => {
-    const query = container.resolve(ContainerRegistrationKeys.QUERY);
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY);
     const { data } = await query.graph({
       entity: designPartnersLink.entryPoint,
       filters: { design_id: input.design_id },

--- a/apps/backend/src/workflows/fx/fanout-prices.ts
+++ b/apps/backend/src/workflows/fx/fanout-prices.ts
@@ -74,9 +74,9 @@ export type FanoutPricesOutput = {
 const fanoutPricesStep = createStep(
   "fanout-prices-step",
   async (input: FanoutPricesInput, { container }) => {
-    const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
-    const query = container.resolve(ContainerRegistrationKeys.QUERY)
-    const link = container.resolve(ContainerRegistrationKeys.LINK)
+    const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const link: any = container.resolve(ContainerRegistrationKeys.LINK)
     const pricingService = container.resolve(Modules.PRICING) as any
     const fxService = container.resolve(FX_RATES_MODULE) as FxRatesService
 

--- a/apps/backend/src/workflows/fx/rerate-auto-converted-prices.ts
+++ b/apps/backend/src/workflows/fx/rerate-auto-converted-prices.ts
@@ -48,8 +48,8 @@ export type RerateAutoPricesOutput = {
 const rerateAutoPricesStep = createStep(
   "rerate-auto-prices-step",
   async (_input: RerateAutoPricesInput, { container }) => {
-    const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
-    const query = container.resolve(ContainerRegistrationKeys.QUERY)
+    const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
     const pricingService = container.resolve(Modules.PRICING) as any
     const fxService = container.resolve(FX_RATES_MODULE) as FxRatesService
 

--- a/apps/backend/src/workflows/production-runs/approve-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/approve-production-run.ts
@@ -213,8 +213,8 @@ const linkDesignToPartnersStep = createStep(
       return new StepResponse({ created: 0, already_linked: 0 }, [])
     }
 
-    const query = container.resolve(ContainerRegistrationKeys.QUERY)
-    const remoteLink = container.resolve(
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const remoteLink: any = container.resolve(
       ContainerRegistrationKeys.LINK
     ) as any
 
@@ -258,7 +258,7 @@ const linkDesignToPartnersStep = createStep(
   },
   async (links: LinkDefinition[] | undefined, { container }) => {
     if (!links?.length) return
-    const remoteLink = container.resolve(
+    const remoteLink: any = container.resolve(
       ContainerRegistrationKeys.LINK
     ) as any
     await remoteLink.dismiss(links)

--- a/apps/backend/src/workflows/regions/propagate-region-to-partners.ts
+++ b/apps/backend/src/workflows/regions/propagate-region-to-partners.ts
@@ -72,9 +72,9 @@ export type PropagateRegionOutput = {
 const propagateStep = createStep(
   "propagate-region-to-partners-step",
   async (input: PropagateRegionInput, { container }) => {
-    const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
-    const query = container.resolve(ContainerRegistrationKeys.QUERY)
-    const remoteLink = container.resolve(
+    const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const remoteLink: any = container.resolve(
       ContainerRegistrationKeys.LINK
     ) as any
 

--- a/apps/backend/src/workflows/tax/classify-product-tax-class.ts
+++ b/apps/backend/src/workflows/tax/classify-product-tax-class.ts
@@ -72,7 +72,7 @@ async function getMaxInrPrice(
   container: any,
   productId: string
 ): Promise<number | null> {
-  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
   const { data: products } = await query.graph({
     entity: "product",
     filters: { id: productId },
@@ -107,7 +107,7 @@ async function getMaxInrPrice(
 async function resolveManagedTypeIds(
   container: any
 ): Promise<{ overId: string | null }> {
-  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
   const { data: types } = await query.graph({
     entity: "product_type",
     filters: { value: TAX_CLASS_OVER_2500_VALUE },
@@ -120,7 +120,7 @@ async function resolveManagedTypeIds(
 const classifyProductStep = createStep(
   "classify-product-tax-class",
   async (input: ClassifyProductInput, { container }): Promise<StepResponse<ClassifyProductResult>> => {
-    const query = container.resolve(ContainerRegistrationKeys.QUERY)
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
     const productService: any = container.resolve(Modules.PRODUCT)
 
     const { overId } = await resolveManagedTypeIds(container)

--- a/apps/backend/src/workflows/whatsapp/create-draft-product-from-extraction.ts
+++ b/apps/backend/src/workflows/whatsapp/create-draft-product-from-extraction.ts
@@ -79,7 +79,7 @@ type ResolvedStore = {
 const resolvePartnerStoreStep = createStep(
   "wa-product-create-resolve-store",
   async (input: { partner_id: string }, { container }) => {
-    const query = container.resolve(ContainerRegistrationKeys.QUERY)
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
     const { data } = await query.graph({
       entity: "partners",
       fields: [


### PR DESCRIPTION
## Problem

The prod `medusa build` (clean install) started failing after #320/#321 merged — main is currently un-buildable, blocking deploys. **28 `TS18046: 'X' is of type 'unknown'` errors** across 7 workflow files, every one an un-annotated `const query/logger/remoteLink/link = container.resolve(...)`.

Under the CI dependency tree's inference, `container.resolve(ContainerRegistrationKeys.QUERY)` resolves to `unknown`, so downstream `query.graph(...)` / `logger.error(...)` calls error. Local `medusa build` passes (different/stale type tree), which is why it slipped through pre-merge — likely the `production_runs` model change in #321 regenerated the query type registry and flipped inference for the previously-OK un-annotated calls.

## Fix

Annotate the resolves as `:any` — the existing codebase convention (`const query:any = container.resolve(...)` is used throughout). 16 declarations fix all 28 downstream errors. No behavior change.

Files: `regions/propagate-region-to-partners`, `fx/fanout-prices`, `fx/rerate-auto-converted-prices`, `whatsapp/create-draft-product-from-extraction`, `tax/classify-product-tax-class`, `production-runs/approve-production-run`, `designs/delete-design`.

## Verification
- [x] Local `pnpm run build` (medusa build + resolve:aliases + build:schemas) passes
- [ ] CI build check (the real clean-install env that failed) — the oracle for this fix
- All 28 errors are the same class (TS18046); the complete error set was extracted from the failed run before fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)