### PR TITLE
feat(partner-ui): partner design self-serve UI — P1–P5 (roadmap #6)

### DIFF
--- a/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
+++ b/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
@@ -62,12 +62,22 @@ export function getPartnerRouteMap(): RouteObject[] {
                   lazy: () => import("../../routes/designs/design-list"),
                 },
                 {
+                  // Roadmap #6 Phase 1 — partner creates a design
+                  path: "create",
+                  lazy: () => import("../../routes/designs/design-create"),
+                },
+                {
                   path: ":id",
                   handle: {
                     breadcrumb: (match?: UIMatch) => match?.params?.id || "Design",
                   },
                   lazy: () => import("../../routes/designs/design-detail"),
                   children: [
+                    {
+                      // Phase 1 — edit own design
+                      path: "edit",
+                      lazy: () => import("../../routes/designs/design-edit"),
+                    },
                     {
                       path: "start",
                       lazy: () => import("../../routes/designs/design-start"),

--- a/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
+++ b/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
@@ -79,6 +79,11 @@ export function getPartnerRouteMap(): RouteObject[] {
                       lazy: () => import("../../routes/designs/design-edit"),
                     },
                     {
+                      // Phase 2 — add inventory (BOM) to own design
+                      path: "add-inventory",
+                      lazy: () => import("../../routes/designs/design-add-inventory"),
+                    },
+                    {
                       path: "start",
                       lazy: () => import("../../routes/designs/design-start"),
                     },

--- a/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
+++ b/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
@@ -84,6 +84,12 @@ export function getPartnerRouteMap(): RouteObject[] {
                       lazy: () => import("../../routes/designs/design-add-inventory"),
                     },
                     {
+                      // Phase 4 — partner starts a production run
+                      path: "production-run-create",
+                      lazy: () =>
+                        import("../../routes/designs/design-production-run-create"),
+                    },
+                    {
                       path: "start",
                       lazy: () => import("../../routes/designs/design-start"),
                     },

--- a/apps/partner-ui/src/hooks/api/partner-design-cost.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-design-cost.tsx
@@ -1,0 +1,84 @@
+import { FetchError } from "@medusajs/js-sdk"
+import {
+  QueryKey,
+  UseMutationOptions,
+  UseQueryOptions,
+  useMutation,
+  useQuery,
+} from "@tanstack/react-query"
+
+import { sdk } from "../../lib/client"
+import { queryClient } from "../../lib/query-client"
+
+/**
+ * Roadmap #6 Phase 3 — partner design cost estimation.
+ * GET /partners/designs/:id/cost + POST .../recalculate-cost.
+ */
+
+export type PartnerDesignCost = {
+  design_id: string
+  estimated_cost?: number | null
+  material_cost?: number | null
+  production_cost?: number | null
+  cost_currency?: string | null
+  cost_breakdown?: {
+    items?: Array<Record<string, any>>
+    production_percent?: number
+    confidence?: string
+    calculated_at?: string
+    source?: string
+  } | null
+}
+
+export type PartnerDesignCostEstimate = {
+  cost_estimate: {
+    material_cost: number
+    production_cost: number
+    total_estimated: number
+    confidence: string
+    breakdown?: {
+      materials?: Array<Record<string, any>>
+      production_percent?: number
+    }
+  }
+  message: string
+}
+
+const costKey = (designId: string) => ["partner-design-cost", designId]
+
+export const usePartnerDesignCost = (
+  designId: string,
+  options?: Omit<
+    UseQueryOptions<PartnerDesignCost, FetchError, PartnerDesignCost, QueryKey>,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: costKey(designId),
+    queryFn: async () =>
+      sdk.client.fetch<PartnerDesignCost>(
+        `/partners/designs/${designId}/cost`,
+        { method: "GET" }
+      ),
+    ...options,
+  })
+  return { cost: data, ...rest }
+}
+
+export const useRecalculatePartnerDesignCost = (
+  designId: string,
+  options?: UseMutationOptions<PartnerDesignCostEstimate, FetchError, void>
+) => {
+  return useMutation({
+    mutationFn: async () =>
+      sdk.client.fetch<PartnerDesignCostEstimate>(
+        `/partners/designs/${designId}/recalculate-cost`,
+        { method: "POST", body: {} }
+      ),
+    onSuccess: async (data, variables, context) => {
+      await queryClient.invalidateQueries({ queryKey: costKey(designId) })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}

--- a/apps/partner-ui/src/hooks/api/partner-design-inventory.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-design-inventory.tsx
@@ -1,0 +1,162 @@
+import { FetchError } from "@medusajs/js-sdk"
+import {
+  QueryKey,
+  UseMutationOptions,
+  UseQueryOptions,
+  useMutation,
+  useQuery,
+} from "@tanstack/react-query"
+
+import { sdk } from "../../lib/client"
+import { queryClient } from "../../lib/query-client"
+import { partnerDesignsQueryKeys } from "./partner-designs"
+
+/**
+ * Roadmap #6 Phase 2 — partner design ↔ inventory BOM.
+ * Wires GET/POST/PATCH/DELETE /partners/designs/:id/inventory[...].
+ */
+
+export type PartnerDesignBomMedia = {
+  url?: string
+  isThumbnail?: boolean
+} & Record<string, any>
+
+export type PartnerDesignRawMaterial = Record<string, any> & {
+  id: string
+  name?: string | null
+  composition?: string | null
+  color?: string | null
+  unit_of_measure?: string | null
+  media?: PartnerDesignBomMedia[] | null
+}
+
+export type PartnerDesignInventoryItem = Record<string, any> & {
+  id: string
+  inventory_item_id: string
+  planned_quantity?: number | null
+  consumed_quantity?: number | null
+  location_id?: string | null
+  inventory_item?: Record<string, any> & {
+    id: string
+    sku?: string | null
+    title?: string | null
+    raw_materials?: PartnerDesignRawMaterial[]
+  }
+}
+
+export type PartnerDesignInventoryResponse = {
+  inventory_items: PartnerDesignInventoryItem[]
+}
+
+const inventoryKey = (designId: string) => [
+  "partner-design-inventory",
+  designId,
+]
+
+export const usePartnerDesignInventory = (
+  designId: string,
+  options?: Omit<
+    UseQueryOptions<
+      PartnerDesignInventoryResponse,
+      FetchError,
+      PartnerDesignInventoryResponse,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: inventoryKey(designId),
+    queryFn: async () =>
+      sdk.client.fetch<PartnerDesignInventoryResponse>(
+        `/partners/designs/${designId}/inventory`,
+        { method: "GET" }
+      ),
+    ...options,
+  })
+  return {
+    inventory_items: data?.inventory_items ?? [],
+    ...rest,
+  }
+}
+
+export type LinkInventoryItemPayload = {
+  inventoryItems: Array<{
+    inventoryId: string
+    plannedQuantity?: number
+    locationId?: string
+  }>
+}
+
+export const useLinkPartnerDesignInventory = (
+  designId: string,
+  options?: UseMutationOptions<
+    PartnerDesignInventoryResponse,
+    FetchError,
+    LinkInventoryItemPayload
+  >
+) => {
+  return useMutation({
+    mutationFn: async (payload) =>
+      sdk.client.fetch<PartnerDesignInventoryResponse>(
+        `/partners/designs/${designId}/inventory`,
+        { method: "POST", body: payload }
+      ),
+    onSuccess: async (data, variables, context) => {
+      await queryClient.invalidateQueries({ queryKey: inventoryKey(designId) })
+      await queryClient.invalidateQueries({
+        queryKey: partnerDesignsQueryKeys.detail(designId),
+      })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}
+
+export const useUpdatePartnerDesignInventoryLink = (
+  designId: string,
+  inventoryItemId: string,
+  options?: UseMutationOptions<
+    PartnerDesignInventoryResponse,
+    FetchError,
+    { plannedQuantity?: number | null; locationId?: string | null }
+  >
+) => {
+  return useMutation({
+    mutationFn: async (payload) =>
+      sdk.client.fetch<PartnerDesignInventoryResponse>(
+        `/partners/designs/${designId}/inventory/${inventoryItemId}`,
+        { method: "PATCH", body: payload }
+      ),
+    onSuccess: async (data, variables, context) => {
+      await queryClient.invalidateQueries({ queryKey: inventoryKey(designId) })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}
+
+export const useDelinkPartnerDesignInventory = (
+  designId: string,
+  options?: UseMutationOptions<
+    PartnerDesignInventoryResponse,
+    FetchError,
+    { inventoryIds: string[] }
+  >
+) => {
+  return useMutation({
+    mutationFn: async (payload) =>
+      sdk.client.fetch<PartnerDesignInventoryResponse>(
+        `/partners/designs/${designId}/inventory/delink`,
+        { method: "DELETE", body: payload }
+      ),
+    onSuccess: async (data, variables, context) => {
+      await queryClient.invalidateQueries({ queryKey: inventoryKey(designId) })
+      await queryClient.invalidateQueries({
+        queryKey: partnerDesignsQueryKeys.detail(designId),
+      })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}

--- a/apps/partner-ui/src/hooks/api/partner-designs.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-designs.tsx
@@ -122,6 +122,87 @@ export const usePartnerDesign = (
   }
 }
 
+// Roadmap #6 Phase 1 — partner-owned design CRUD.
+export type CreatePartnerDesignPayload = {
+  name: string
+  description?: string
+  design_type?: "Original" | "Derivative" | "Custom" | "Collaboration"
+  status?: string
+  priority?: "Low" | "Medium" | "High" | "Urgent"
+  tags?: string[]
+  estimated_cost?: number
+  designer_notes?: string
+}
+
+export const useCreatePartnerDesign = (
+  options?: UseMutationOptions<
+    { design: PartnerDesign },
+    FetchError,
+    CreatePartnerDesignPayload
+  >
+) => {
+  return useMutation({
+    mutationFn: async (payload) => {
+      return await sdk.client.fetch<{ design: PartnerDesign }>(
+        `/partners/designs`,
+        { method: "POST", body: payload }
+      )
+    },
+    onSuccess: async (data, variables, context) => {
+      await queryClient.invalidateQueries({ queryKey: partnerDesignsQueryKeys.lists() })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}
+
+export const useUpdatePartnerDesign = (
+  id: string,
+  options?: UseMutationOptions<
+    { design: PartnerDesign },
+    FetchError,
+    Partial<CreatePartnerDesignPayload>
+  >
+) => {
+  return useMutation({
+    mutationFn: async (payload) => {
+      return await sdk.client.fetch<{ design: PartnerDesign }>(
+        `/partners/designs/${id}`,
+        { method: "PUT", body: payload }
+      )
+    },
+    onSuccess: async (data, variables, context) => {
+      await queryClient.invalidateQueries({ queryKey: partnerDesignsQueryKeys.lists() })
+      await queryClient.invalidateQueries({ queryKey: partnerDesignsQueryKeys.detail(id) })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}
+
+export const useDeletePartnerDesign = (
+  id: string,
+  options?: UseMutationOptions<
+    { id: string; deleted: boolean },
+    FetchError,
+    void
+  >
+) => {
+  return useMutation({
+    mutationFn: async () => {
+      return await sdk.client.fetch<{ id: string; deleted: boolean }>(
+        `/partners/designs/${id}`,
+        { method: "DELETE" }
+      )
+    },
+    onSuccess: async (data, variables, context) => {
+      await queryClient.invalidateQueries({ queryKey: partnerDesignsQueryKeys.lists() })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}
+
 export const useStartPartnerDesign = (
   id: string,
   options?: UseMutationOptions<{ message: string; design: PartnerDesign }, FetchError, void>

--- a/apps/partner-ui/src/hooks/api/partner-production-runs.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-production-runs.tsx
@@ -227,3 +227,77 @@ export const useCompletePartnerProductionRun = (
     ...restOptions,
   })
 }
+
+// Roadmap #6 Phase 4 — partner creates a self-approved run on their own design.
+export type CreatePartnerProductionRunPayload = {
+  quantity?: number
+  run_type?: "production" | "sample"
+  execution_mode: "in_house" | "outsourced"
+  sub_partner_id?: string
+}
+
+export const useCreatePartnerProductionRun = (
+  designId: string,
+  options?: UseMutationOptions<
+    { production_run: PartnerProductionRun },
+    FetchError,
+    CreatePartnerProductionRunPayload
+  >
+) => {
+  return useMutation({
+    mutationFn: async (payload) =>
+      sdk.client.fetch<{ production_run: PartnerProductionRun }>(
+        `/partners/designs/${designId}/production-runs`,
+        { method: "POST", body: payload }
+      ),
+    onSuccess: async (data, variables, context) => {
+      await queryClient.invalidateQueries({
+        queryKey: partnerProductionRunsQueryKeys.lists(),
+      })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}
+
+// Roadmap #6 Phase 5 — partner reads a run's cost-summary (admin parity).
+export type PartnerRunCostSummary = {
+  cost_summary: {
+    production_run_id: string
+    design_id: string
+    status: string
+    quantity: number
+    produced_quantity: number | null
+    material: { total: number; items: any[] }
+    energy: { total: number; breakdown: any[] }
+    labor: { total: number; total_hours: number; rate_per_hour: number | null }
+    partner: { estimate: number | null; cost_type: string; total: number | null }
+    grand_total: number | null
+    cost_per_unit: number | null
+    total_consumption_logs: number
+  }
+}
+
+export const usePartnerRunCostSummary = (
+  runId: string,
+  options?: Omit<
+    UseQueryOptions<
+      PartnerRunCostSummary,
+      FetchError,
+      PartnerRunCostSummary,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: ["partner-run-cost-summary", runId],
+    queryFn: async () =>
+      sdk.client.fetch<PartnerRunCostSummary>(
+        `/partners/production-runs/${runId}/cost-summary`,
+        { method: "GET" }
+      ),
+    ...options,
+  })
+  return { cost_summary: data?.cost_summary, ...rest }
+}

--- a/apps/partner-ui/src/routes/designs/design-add-inventory/components/add-inventory-form/add-inventory-form.tsx
+++ b/apps/partner-ui/src/routes/designs/design-add-inventory/components/add-inventory-form/add-inventory-form.tsx
@@ -1,0 +1,137 @@
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "@medusajs/framework/zod"
+import { Button, Heading, Input, Select, Text, toast } from "@medusajs/ui"
+import { useForm } from "react-hook-form"
+
+import { Form } from "../../../../../components/common/form"
+import { RouteFocusModal, useRouteModal } from "../../../../../components/modals"
+import { KeyboundForm } from "../../../../../components/utilities/keybound-form"
+import { useLinkPartnerDesignInventory } from "../../../../../hooks/api/partner-design-inventory"
+import { useInventoryItems } from "../../../../../hooks/api/inventory"
+
+const AddInventorySchema = z.object({
+  inventoryId: z.string().min(1, "Select an inventory item"),
+  plannedQuantity: z.coerce.number().int().positive().optional(),
+})
+type AddInventorySchema = z.infer<typeof AddInventorySchema>
+
+type Props = { designId: string }
+
+export const AddInventoryForm = ({ designId }: Props) => {
+  const { handleSuccess } = useRouteModal()
+  const { inventory_items: available = [], isLoading } = useInventoryItems({
+    limit: 200,
+    // @ts-expect-error partner route accepts fields passthrough
+    fields: "id,title,sku",
+  }) as any
+
+  const form = useForm<AddInventorySchema>({
+    defaultValues: { inventoryId: "", plannedQuantity: undefined },
+    resolver: zodResolver(AddInventorySchema),
+  })
+
+  const { mutateAsync, isPending } = useLinkPartnerDesignInventory(designId)
+
+  const handleSubmit = form.handleSubmit(async (data) => {
+    await mutateAsync(
+      {
+        inventoryItems: [
+          {
+            inventoryId: data.inventoryId,
+            plannedQuantity: data.plannedQuantity,
+          },
+        ],
+      },
+      {
+        onSuccess: () => {
+          toast.success("Material added")
+          handleSuccess()
+        },
+        onError: (e) => toast.error(e.message),
+      }
+    )
+  })
+
+  return (
+    <RouteFocusModal.Form form={form}>
+      <KeyboundForm
+        className="flex h-full flex-col overflow-hidden"
+        onSubmit={handleSubmit}
+      >
+        <RouteFocusModal.Header />
+        <RouteFocusModal.Body className="flex flex-1 flex-col items-center overflow-y-auto">
+          <div className="flex w-full max-w-[640px] flex-col gap-y-8 px-2 py-16">
+            <div className="flex flex-col gap-y-1">
+              <Heading>Add material</Heading>
+              <Text size="small" className="text-ui-fg-subtle">
+                Link an inventory item this design consumes.
+              </Text>
+            </div>
+
+            <Form.Field
+              control={form.control}
+              name="inventoryId"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label>Inventory item</Form.Label>
+                  <Form.Control>
+                    <Select
+                      value={field.value}
+                      onValueChange={field.onChange}
+                      disabled={isLoading}
+                    >
+                      <Select.Trigger>
+                        <Select.Value placeholder="Select an item" />
+                      </Select.Trigger>
+                      <Select.Content>
+                        {available.map((it: any) => (
+                          <Select.Item key={it.id} value={it.id}>
+                            {it.title || it.id}
+                            {it.sku ? ` — ${it.sku}` : ""}
+                          </Select.Item>
+                        ))}
+                      </Select.Content>
+                    </Select>
+                  </Form.Control>
+                  <Form.ErrorMessage />
+                </Form.Item>
+              )}
+            />
+
+            <Form.Field
+              control={form.control}
+              name="plannedQuantity"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label optional>Planned quantity</Form.Label>
+                  <Form.Control>
+                    <Input
+                      type="number"
+                      min={1}
+                      placeholder="e.g. 12"
+                      value={field.value ?? ""}
+                      onChange={field.onChange}
+                    />
+                  </Form.Control>
+                  <Form.ErrorMessage />
+                </Form.Item>
+              )}
+            />
+          </div>
+        </RouteFocusModal.Body>
+        <RouteFocusModal.Footer>
+          <div className="flex items-center justify-end gap-x-2">
+            <RouteFocusModal.Close asChild>
+              <Button variant="secondary" size="small">
+                Cancel
+              </Button>
+            </RouteFocusModal.Close>
+            <Button size="small" type="submit" isLoading={isPending}>
+              Add
+            </Button>
+          </div>
+        </RouteFocusModal.Footer>
+      </KeyboundForm>
+    </RouteFocusModal.Form>
+  )
+}

--- a/apps/partner-ui/src/routes/designs/design-add-inventory/components/add-inventory-form/index.ts
+++ b/apps/partner-ui/src/routes/designs/design-add-inventory/components/add-inventory-form/index.ts
@@ -1,0 +1,1 @@
+export { AddInventoryForm } from "./add-inventory-form"

--- a/apps/partner-ui/src/routes/designs/design-add-inventory/design-add-inventory.tsx
+++ b/apps/partner-ui/src/routes/designs/design-add-inventory/design-add-inventory.tsx
@@ -1,0 +1,12 @@
+import { useParams } from "react-router-dom"
+import { RouteFocusModal } from "../../../components/modals"
+import { AddInventoryForm } from "./components/add-inventory-form"
+
+export const DesignAddInventory = () => {
+  const { id } = useParams()
+  return (
+    <RouteFocusModal>
+      {id && <AddInventoryForm designId={id} />}
+    </RouteFocusModal>
+  )
+}

--- a/apps/partner-ui/src/routes/designs/design-add-inventory/index.ts
+++ b/apps/partner-ui/src/routes/designs/design-add-inventory/index.ts
@@ -1,0 +1,1 @@
+export { DesignAddInventory as Component } from "./design-add-inventory.tsx"

--- a/apps/partner-ui/src/routes/designs/design-create/components/design-create-form/design-create-form.tsx
+++ b/apps/partner-ui/src/routes/designs/design-create/components/design-create-form/design-create-form.tsx
@@ -1,0 +1,191 @@
+import { zodResolver } from "@hookform/resolvers/zod"
+import { Button, Heading, Input, Select, Textarea, toast } from "@medusajs/ui"
+import { useForm } from "react-hook-form"
+
+import { Form } from "../../../../../components/common/form"
+import { RouteFocusModal, useRouteModal } from "../../../../../components/modals"
+import { KeyboundForm } from "../../../../../components/utilities/keybound-form"
+import { useCreatePartnerDesign } from "../../../../../hooks/api/partner-designs"
+import { CreateDesignSchema } from "./schema"
+
+const DESIGN_TYPES = ["Original", "Derivative", "Custom", "Collaboration"] as const
+const PRIORITIES = ["Low", "Medium", "High", "Urgent"] as const
+const STATUSES = [
+  "Conceptual",
+  "In_Development",
+  "Technical_Review",
+  "Sample_Production",
+  "Revision",
+  "Approved",
+  "On_Hold",
+  "Commerce_Ready",
+] as const
+
+export function DesignCreateForm() {
+  const { handleSuccess } = useRouteModal()
+  const form = useForm<CreateDesignSchema>({
+    defaultValues: {
+      name: "",
+      description: "",
+      design_type: "Original",
+      priority: "Medium",
+      status: "Conceptual",
+      designer_notes: "",
+    },
+    resolver: zodResolver(CreateDesignSchema),
+  })
+
+  const { mutateAsync, isPending } = useCreatePartnerDesign()
+
+  const handleSubmit = form.handleSubmit(async (data) => {
+    await mutateAsync(data, {
+      onSuccess: ({ design }) => {
+        toast.success("Design created")
+        handleSuccess(`/designs/${design.id}`)
+      },
+      onError: (e) => toast.error(e.message),
+    })
+  })
+
+  return (
+    <RouteFocusModal.Form form={form}>
+      <KeyboundForm
+        className="flex h-full flex-col overflow-hidden"
+        onSubmit={handleSubmit}
+      >
+        <RouteFocusModal.Header />
+        <RouteFocusModal.Body className="flex flex-1 flex-col items-center overflow-y-auto">
+          <div className="flex w-full max-w-[720px] flex-col gap-y-8 px-2 py-16">
+            <Heading>Create design</Heading>
+
+            <Form.Field
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label>Name</Form.Label>
+                  <Form.Control>
+                    <Input {...field} placeholder="e.g. Spring Jacket" />
+                  </Form.Control>
+                  <Form.ErrorMessage />
+                </Form.Item>
+              )}
+            />
+
+            <Form.Field
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label optional>Description</Form.Label>
+                  <Form.Control>
+                    <Textarea {...field} placeholder="What is this design?" />
+                  </Form.Control>
+                </Form.Item>
+              )}
+            />
+
+            <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+              <Form.Field
+                control={form.control}
+                name="design_type"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label optional>Type</Form.Label>
+                    <Form.Control>
+                      <Select value={field.value} onValueChange={field.onChange}>
+                        <Select.Trigger>
+                          <Select.Value placeholder="Select" />
+                        </Select.Trigger>
+                        <Select.Content>
+                          {DESIGN_TYPES.map((t) => (
+                            <Select.Item key={t} value={t}>
+                              {t}
+                            </Select.Item>
+                          ))}
+                        </Select.Content>
+                      </Select>
+                    </Form.Control>
+                  </Form.Item>
+                )}
+              />
+
+              <Form.Field
+                control={form.control}
+                name="priority"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label optional>Priority</Form.Label>
+                    <Form.Control>
+                      <Select value={field.value} onValueChange={field.onChange}>
+                        <Select.Trigger>
+                          <Select.Value placeholder="Select" />
+                        </Select.Trigger>
+                        <Select.Content>
+                          {PRIORITIES.map((p) => (
+                            <Select.Item key={p} value={p}>
+                              {p}
+                            </Select.Item>
+                          ))}
+                        </Select.Content>
+                      </Select>
+                    </Form.Control>
+                  </Form.Item>
+                )}
+              />
+
+              <Form.Field
+                control={form.control}
+                name="status"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label optional>Status</Form.Label>
+                    <Form.Control>
+                      <Select value={field.value} onValueChange={field.onChange}>
+                        <Select.Trigger>
+                          <Select.Value placeholder="Select" />
+                        </Select.Trigger>
+                        <Select.Content>
+                          {STATUSES.map((s) => (
+                            <Select.Item key={s} value={s}>
+                              {s.replace(/_/g, " ")}
+                            </Select.Item>
+                          ))}
+                        </Select.Content>
+                      </Select>
+                    </Form.Control>
+                  </Form.Item>
+                )}
+              />
+            </div>
+
+            <Form.Field
+              control={form.control}
+              name="designer_notes"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label optional>Designer notes</Form.Label>
+                  <Form.Control>
+                    <Textarea {...field} placeholder="Internal notes" />
+                  </Form.Control>
+                </Form.Item>
+              )}
+            />
+          </div>
+        </RouteFocusModal.Body>
+        <RouteFocusModal.Footer>
+          <div className="flex items-center justify-end gap-x-2">
+            <RouteFocusModal.Close asChild>
+              <Button variant="secondary" size="small">
+                Cancel
+              </Button>
+            </RouteFocusModal.Close>
+            <Button size="small" type="submit" isLoading={isPending}>
+              Create
+            </Button>
+          </div>
+        </RouteFocusModal.Footer>
+      </KeyboundForm>
+    </RouteFocusModal.Form>
+  )
+}

--- a/apps/partner-ui/src/routes/designs/design-create/components/design-create-form/index.ts
+++ b/apps/partner-ui/src/routes/designs/design-create/components/design-create-form/index.ts
@@ -1,0 +1,1 @@
+export { DesignCreateForm } from "./design-create-form"

--- a/apps/partner-ui/src/routes/designs/design-create/components/design-create-form/schema.ts
+++ b/apps/partner-ui/src/routes/designs/design-create/components/design-create-form/schema.ts
@@ -1,0 +1,25 @@
+import { z } from "@medusajs/framework/zod"
+
+export const CreateDesignSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  description: z.string().optional(),
+  design_type: z
+    .enum(["Original", "Derivative", "Custom", "Collaboration"])
+    .optional(),
+  priority: z.enum(["Low", "Medium", "High", "Urgent"]).optional(),
+  status: z
+    .enum([
+      "Conceptual",
+      "In_Development",
+      "Technical_Review",
+      "Sample_Production",
+      "Revision",
+      "Approved",
+      "On_Hold",
+      "Commerce_Ready",
+    ])
+    .optional(),
+  designer_notes: z.string().optional(),
+})
+
+export type CreateDesignSchema = z.infer<typeof CreateDesignSchema>

--- a/apps/partner-ui/src/routes/designs/design-create/design-create.tsx
+++ b/apps/partner-ui/src/routes/designs/design-create/design-create.tsx
@@ -1,0 +1,10 @@
+import { RouteFocusModal } from "../../../components/modals"
+import { DesignCreateForm } from "./components/design-create-form"
+
+export function DesignCreate() {
+  return (
+    <RouteFocusModal>
+      <DesignCreateForm />
+    </RouteFocusModal>
+  )
+}

--- a/apps/partner-ui/src/routes/designs/design-create/index.ts
+++ b/apps/partner-ui/src/routes/designs/design-create/index.ts
@@ -1,0 +1,1 @@
+export { DesignCreate as Component } from "./design-create.tsx"

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-cost-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-cost-section.tsx
@@ -1,0 +1,129 @@
+import { ArrowPath } from "@medusajs/icons"
+import {
+  Badge,
+  Button,
+  Container,
+  Heading,
+  Text,
+  toast,
+} from "@medusajs/ui"
+
+import { SectionRow } from "../../../../components/common/section"
+import { PartnerDesign } from "../../../../hooks/api/partner-designs"
+import {
+  usePartnerDesignCost,
+  useRecalculatePartnerDesignCost,
+} from "../../../../hooks/api/partner-design-cost"
+
+type Props = { design: PartnerDesign }
+
+const fmt = (v?: number | null, currency?: string | null) =>
+  v == null
+    ? "—"
+    : `${currency ? currency.toUpperCase() + " " : ""}${Number(v).toLocaleString(undefined, { maximumFractionDigits: 2 })}`
+
+/**
+ * Roadmap #6 Phase 3 — cost panel. Shows the design's estimated /
+ * material / production cost + breakdown, with a Recalculate action
+ * (owner only) that re-runs the estimate over the linked BOM.
+ */
+export const DesignCostSection = ({ design }: Props) => {
+  const isOwner = !!(design as any).owner_partner_id
+  const { cost, isLoading } = usePartnerDesignCost(design.id)
+  const { mutateAsync: recalc, isPending } = useRecalculatePartnerDesignCost(
+    design.id
+  )
+
+  const handleRecalc = async () => {
+    await recalc(undefined, {
+      onSuccess: (d) =>
+        toast.success(
+          `Cost recalculated: ${fmt(d.cost_estimate.total_estimated)} (${d.cost_estimate.confidence})`
+        ),
+      onError: (e) => toast.error(e.message),
+    })
+  }
+
+  const currency = cost?.cost_currency
+  const confidence = cost?.cost_breakdown?.confidence
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div>
+          <Heading level="h2">Cost estimate</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            Material + production cost from the linked BOM.
+          </Text>
+        </div>
+        {isOwner && (
+          <Button
+            size="small"
+            variant="secondary"
+            isLoading={isPending}
+            onClick={handleRecalc}
+          >
+            <ArrowPath />
+            Recalculate
+          </Button>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="px-6 py-4">
+          <Text size="small" className="text-ui-fg-subtle">
+            Loading…
+          </Text>
+        </div>
+      ) : (
+        <>
+          <SectionRow
+            title="Estimated total"
+            value={
+              <div className="flex items-center gap-x-2">
+                <Text size="small" weight="plus">
+                  {fmt(cost?.estimated_cost, currency)}
+                </Text>
+                {confidence && (
+                  <Badge
+                    size="2xsmall"
+                    color={
+                      confidence === "exact"
+                        ? "green"
+                        : confidence === "estimated"
+                          ? "blue"
+                          : "orange"
+                    }
+                  >
+                    {confidence}
+                  </Badge>
+                )}
+              </div>
+            }
+          />
+          <SectionRow
+            title="Material cost"
+            value={fmt(cost?.material_cost, currency)}
+          />
+          <SectionRow
+            title="Production cost"
+            value={fmt(cost?.production_cost, currency)}
+          />
+          {cost?.cost_breakdown?.calculated_at && (
+            <SectionRow
+              title="Last calculated"
+              value={new Date(cost.cost_breakdown.calculated_at).toLocaleString()}
+            />
+          )}
+          {!cost?.estimated_cost && isOwner && (
+            <div className="px-6 py-4">
+              <Text size="small" className="text-ui-fg-subtle">
+                No estimate yet — add materials to the BOM, then Recalculate.
+              </Text>
+            </div>
+          )}
+        </>
+      )}
+    </Container>
+  )
+}

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-inventory-bom-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-inventory-bom-section.tsx
@@ -1,0 +1,182 @@
+import { Plus, Trash } from "@medusajs/icons"
+import {
+  Badge,
+  Button,
+  Container,
+  Heading,
+  Text,
+  toast,
+  usePrompt,
+} from "@medusajs/ui"
+import { Link } from "react-router-dom"
+
+import { ActionMenu } from "../../../../components/common/action-menu"
+import { PartnerDesign } from "../../../../hooks/api/partner-designs"
+import {
+  PartnerDesignInventoryItem,
+  useDelinkPartnerDesignInventory,
+  usePartnerDesignInventory,
+} from "../../../../hooks/api/partner-design-inventory"
+
+type Props = { design: PartnerDesign }
+
+/** Pull image URLs out of a raw_material.media / inventory media json blob. */
+function extractMedia(line: PartnerDesignInventoryItem): string[] {
+  const urls: string[] = []
+  const push = (m: any) => {
+    if (!m) return
+    if (typeof m === "string") urls.push(m)
+    else if (typeof m?.url === "string") urls.push(m.url)
+  }
+  for (const rm of line.inventory_item?.raw_materials ?? []) {
+    const media = (rm as any)?.media
+    if (Array.isArray(media)) media.forEach(push)
+    else push(media)
+  }
+  // Fall back to the inventory item's own media if the raw material has none.
+  if (!urls.length) {
+    const im = (line.inventory_item as any)?.metadata?.media
+    if (Array.isArray(im)) im.forEach(push)
+  }
+  return urls.slice(0, 4)
+}
+
+export const DesignInventoryBomSection = ({ design }: Props) => {
+  const prompt = usePrompt()
+  const isOwner = !!(design as any).owner_partner_id
+  const { inventory_items, isLoading } = usePartnerDesignInventory(design.id)
+  const { mutateAsync: delink } = useDelinkPartnerDesignInventory(design.id)
+
+  const handleRemove = async (line: PartnerDesignInventoryItem) => {
+    const ok = await prompt({
+      title: "Remove material",
+      description: `Remove "${line.inventory_item?.title ?? line.inventory_item_id}" from this design's bill of materials?`,
+      confirmText: "Remove",
+      cancelText: "Cancel",
+    })
+    if (!ok) return
+    await delink(
+      { inventoryIds: [line.inventory_item_id] },
+      {
+        onSuccess: () => toast.success("Material removed"),
+        onError: (e) => toast.error(e.message),
+      }
+    )
+  }
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div>
+          <Heading level="h2">Materials (BOM)</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            Inventory + raw materials used to make this design.
+          </Text>
+        </div>
+        {isOwner && (
+          <Link to="add-inventory">
+            <Button size="small" variant="secondary">
+              <Plus />
+              Add material
+            </Button>
+          </Link>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="px-6 py-4">
+          <Text size="small" className="text-ui-fg-subtle">
+            Loading…
+          </Text>
+        </div>
+      ) : inventory_items.length === 0 ? (
+        <div className="px-6 py-6">
+          <Text size="small" className="text-ui-fg-subtle">
+            No materials linked yet.
+            {isOwner ? " Add the inventory items this design consumes." : ""}
+          </Text>
+        </div>
+      ) : (
+        inventory_items.map((line) => {
+          const item = line.inventory_item
+          const rawMaterials = item?.raw_materials ?? []
+          const media = extractMedia(line)
+          return (
+            <div
+              key={line.inventory_item_id}
+              className="flex items-start gap-x-4 px-6 py-4"
+            >
+              {/* Media thumbnails — what the material looks like */}
+              <div className="flex shrink-0 gap-x-1">
+                {media.length > 0 ? (
+                  media.map((url, i) => (
+                    <img
+                      key={i}
+                      src={url}
+                      alt={item?.title ?? "material"}
+                      className="bg-ui-bg-subtle size-12 rounded-md object-cover"
+                    />
+                  ))
+                ) : (
+                  <div className="bg-ui-bg-subtle text-ui-fg-muted flex size-12 items-center justify-center rounded-md">
+                    <Text size="xsmall">No img</Text>
+                  </div>
+                )}
+              </div>
+
+              {/* Details — title, SKU, raw material, qty */}
+              <div className="flex min-w-0 flex-1 flex-col gap-y-1">
+                <div className="flex items-center gap-x-2">
+                  <Text size="small" weight="plus" className="truncate">
+                    {item?.title ?? line.inventory_item_id}
+                  </Text>
+                  {item?.sku && (
+                    <Badge size="2xsmall" color="grey">
+                      SKU: {item.sku}
+                    </Badge>
+                  )}
+                </div>
+
+                {rawMaterials.length > 0 && (
+                  <Text size="small" className="text-ui-fg-subtle truncate">
+                    {rawMaterials
+                      .map((rm) =>
+                        [rm.name, rm.composition, rm.color]
+                          .filter(Boolean)
+                          .join(" · ")
+                      )
+                      .filter(Boolean)
+                      .join("  |  ")}
+                  </Text>
+                )}
+
+                <Text size="xsmall" className="text-ui-fg-muted">
+                  Planned: {line.planned_quantity ?? "—"}
+                  {line.consumed_quantity != null
+                    ? `  ·  Consumed: ${line.consumed_quantity}`
+                    : ""}
+                </Text>
+              </div>
+
+              {isOwner && (
+                <ActionMenu
+                  groups={[
+                    {
+                      actions: [
+                        {
+                          label: "Remove",
+                          icon: <Trash />,
+                          onClick: () => handleRemove(line),
+                        },
+                      ],
+                    },
+                  ]}
+                />
+              )}
+            </div>
+          )
+        })
+      )}
+    </Container>
+  )
+}

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-owner-actions-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-owner-actions-section.tsx
@@ -1,0 +1,72 @@
+import { PencilSquare, Trash } from "@medusajs/icons"
+import { Container, Heading, Text, toast, usePrompt } from "@medusajs/ui"
+import { useNavigate } from "react-router-dom"
+
+import { ActionMenu } from "../../../../components/common/action-menu"
+import {
+  PartnerDesign,
+  useDeletePartnerDesign,
+} from "../../../../hooks/api/partner-designs"
+
+type Props = { design: PartnerDesign }
+
+/**
+ * Roadmap #6 Phase 1 — edit/delete actions for a PARTNER-OWNED design.
+ * Only rendered when the design carries `owner_partner_id` (i.e. the
+ * partner created it via self-serve); admin-assigned designs stay
+ * read-only on the partner side.
+ */
+export const DesignOwnerActionsSection = ({ design }: Props) => {
+  const navigate = useNavigate()
+  const prompt = usePrompt()
+  const { mutateAsync } = useDeletePartnerDesign(design.id)
+
+  // Only the owner can manage. Admin-assigned designs have no
+  // owner_partner_id and are read-only here.
+  if (!(design as any).owner_partner_id) {
+    return null
+  }
+
+  const handleDelete = async () => {
+    const ok = await prompt({
+      title: "Delete design",
+      description: `Delete "${design.name ?? design.id}"? This can't be undone.`,
+      confirmText: "Delete",
+      cancelText: "Cancel",
+    })
+    if (!ok) return
+
+    await mutateAsync(undefined, {
+      onSuccess: () => {
+        toast.success("Design deleted")
+        navigate("/designs", { replace: true })
+      },
+      onError: (e) => toast.error(e.message),
+    })
+  }
+
+  return (
+    <Container className="flex items-center justify-between px-6 py-4">
+      <div>
+        <Heading level="h2">Your design</Heading>
+        <Text size="small" className="text-ui-fg-subtle">
+          You created this design — edit or delete it here.
+        </Text>
+      </div>
+      <ActionMenu
+        groups={[
+          {
+            actions: [
+              { label: "Edit", icon: <PencilSquare />, to: "edit" },
+            ],
+          },
+          {
+            actions: [
+              { label: "Delete", icon: <Trash />, onClick: handleDelete },
+            ],
+          },
+        ]}
+      />
+    </Container>
+  )
+}

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-start-production-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-start-production-section.tsx
@@ -1,0 +1,36 @@
+import { Play } from "@medusajs/icons"
+import { Button, Container, Heading, Text } from "@medusajs/ui"
+import { Link } from "react-router-dom"
+
+import { PartnerDesign } from "../../../../hooks/api/partner-designs"
+
+type Props = { design: PartnerDesign }
+
+/**
+ * Roadmap #6 Phase 4 — owner-only "Start production" entry point for a
+ * partner-created design. Opens the run-create modal (in-house /
+ * outsourced). Admin-assigned designs don't show this — those runs are
+ * created by the admin and dispatched to the partner.
+ */
+export const DesignStartProductionSection = ({ design }: Props) => {
+  if (!(design as any).owner_partner_id) {
+    return null
+  }
+
+  return (
+    <Container className="flex items-center justify-between px-6 py-4">
+      <div>
+        <Heading level="h2">Production</Heading>
+        <Text size="small" className="text-ui-fg-subtle">
+          Run production yourself, or hand it to a sub-partner.
+        </Text>
+      </div>
+      <Link to="production-run-create">
+        <Button size="small" variant="secondary">
+          <Play />
+          Start production
+        </Button>
+      </Link>
+    </Container>
+  )
+}

--- a/apps/partner-ui/src/routes/designs/design-detail/design-detail.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/design-detail.tsx
@@ -14,6 +14,7 @@ import { DesignMediaSection } from "./components/design-media-section"
 import { DesignMoodboardSection } from "./components/design-moodboard-section"
 import { DesignConsumptionLogsSection } from "./components/design-consumption-logs-section"
 import { DesignProductionSection } from "./components/design-production-section"
+import { DesignOwnerActionsSection } from "./components/design-owner-actions-section"
 
 type MarkLinkAttrs = { href?: string; target?: string }
 type Mark = {
@@ -278,6 +279,7 @@ export const DesignDetail = () => {
   return (
     <TwoColumnPage widgets={{ before: [], after: [], sideBefore: [], sideAfter: [] }} hasOutlet>
       <TwoColumnPage.Main>
+        {design && <DesignOwnerActionsSection design={design} />}
         <Container className="divide-y p-0">
           <div className="px-6 py-4">
             <Heading level="h2">General</Heading>

--- a/apps/partner-ui/src/routes/designs/design-detail/design-detail.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/design-detail.tsx
@@ -17,6 +17,7 @@ import { DesignProductionSection } from "./components/design-production-section"
 import { DesignOwnerActionsSection } from "./components/design-owner-actions-section"
 import { DesignInventoryBomSection } from "./components/design-inventory-bom-section"
 import { DesignCostSection } from "./components/design-cost-section"
+import { DesignStartProductionSection } from "./components/design-start-production-section"
 
 type MarkLinkAttrs = { href?: string; target?: string }
 type Mark = {
@@ -449,6 +450,7 @@ export const DesignDetail = () => {
 
         {design && <DesignCostSection design={design} />}
 
+        {design && <DesignStartProductionSection design={design} />}
         {design && <DesignProductionSection design={design} />}
 
         {design && <DesignConsumptionLogsSection design={design} />}

--- a/apps/partner-ui/src/routes/designs/design-detail/design-detail.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/design-detail.tsx
@@ -16,6 +16,7 @@ import { DesignConsumptionLogsSection } from "./components/design-consumption-lo
 import { DesignProductionSection } from "./components/design-production-section"
 import { DesignOwnerActionsSection } from "./components/design-owner-actions-section"
 import { DesignInventoryBomSection } from "./components/design-inventory-bom-section"
+import { DesignCostSection } from "./components/design-cost-section"
 
 type MarkLinkAttrs = { href?: string; target?: string }
 type Mark = {
@@ -445,6 +446,8 @@ export const DesignDetail = () => {
 
         {/* Production & Material Usage — highest priority for partners */}
         {design && <DesignInventoryBomSection design={design} />}
+
+        {design && <DesignCostSection design={design} />}
 
         {design && <DesignProductionSection design={design} />}
 

--- a/apps/partner-ui/src/routes/designs/design-detail/design-detail.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/design-detail.tsx
@@ -15,6 +15,7 @@ import { DesignMoodboardSection } from "./components/design-moodboard-section"
 import { DesignConsumptionLogsSection } from "./components/design-consumption-logs-section"
 import { DesignProductionSection } from "./components/design-production-section"
 import { DesignOwnerActionsSection } from "./components/design-owner-actions-section"
+import { DesignInventoryBomSection } from "./components/design-inventory-bom-section"
 
 type MarkLinkAttrs = { href?: string; target?: string }
 type Mark = {
@@ -443,6 +444,8 @@ export const DesignDetail = () => {
         ) : null}
 
         {/* Production & Material Usage — highest priority for partners */}
+        {design && <DesignInventoryBomSection design={design} />}
+
         {design && <DesignProductionSection design={design} />}
 
         {design && <DesignConsumptionLogsSection design={design} />}

--- a/apps/partner-ui/src/routes/designs/design-edit/components/edit-design-form/edit-design-form.tsx
+++ b/apps/partner-ui/src/routes/designs/design-edit/components/edit-design-form/edit-design-form.tsx
@@ -1,0 +1,149 @@
+import { zodResolver } from "@hookform/resolvers/zod"
+import { Button, Input, Select, Textarea, toast } from "@medusajs/ui"
+import { useForm } from "react-hook-form"
+
+import { Form } from "../../../../../components/common/form"
+import { RouteDrawer, useRouteModal } from "../../../../../components/modals"
+import { KeyboundForm } from "../../../../../components/utilities/keybound-form"
+import {
+  PartnerDesign,
+  useUpdatePartnerDesign,
+} from "../../../../../hooks/api/partner-designs"
+import { CreateDesignSchema } from "../../../design-create/components/design-create-form/schema"
+
+const DESIGN_TYPES = ["Original", "Derivative", "Custom", "Collaboration"] as const
+const PRIORITIES = ["Low", "Medium", "High", "Urgent"] as const
+
+type Props = { design: PartnerDesign }
+
+export const EditDesignForm = ({ design }: Props) => {
+  const { handleSuccess } = useRouteModal()
+  const form = useForm<CreateDesignSchema>({
+    defaultValues: {
+      name: design.name ?? "",
+      description: design.description ?? "",
+      design_type: (design.design_type as any) ?? "Original",
+      priority: (design.priority as any) ?? "Medium",
+      designer_notes: design.designer_notes ?? "",
+    },
+    resolver: zodResolver(CreateDesignSchema),
+  })
+
+  const { mutateAsync, isPending } = useUpdatePartnerDesign(design.id)
+
+  const handleSubmit = form.handleSubmit(async (data) => {
+    await mutateAsync(data, {
+      onSuccess: () => {
+        toast.success("Design updated")
+        handleSuccess()
+      },
+      onError: (e) => toast.error(e.message),
+    })
+  })
+
+  return (
+    <RouteDrawer.Form form={form}>
+      <KeyboundForm onSubmit={handleSubmit} className="flex flex-1 flex-col">
+        <RouteDrawer.Body>
+          <div className="flex flex-col gap-y-4">
+            <Form.Field
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label>Name</Form.Label>
+                  <Form.Control>
+                    <Input {...field} />
+                  </Form.Control>
+                  <Form.ErrorMessage />
+                </Form.Item>
+              )}
+            />
+            <Form.Field
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label optional>Description</Form.Label>
+                  <Form.Control>
+                    <Textarea {...field} />
+                  </Form.Control>
+                </Form.Item>
+              )}
+            />
+            <Form.Field
+              control={form.control}
+              name="design_type"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label optional>Type</Form.Label>
+                  <Form.Control>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <Select.Trigger>
+                        <Select.Value placeholder="Select" />
+                      </Select.Trigger>
+                      <Select.Content>
+                        {DESIGN_TYPES.map((t) => (
+                          <Select.Item key={t} value={t}>
+                            {t}
+                          </Select.Item>
+                        ))}
+                      </Select.Content>
+                    </Select>
+                  </Form.Control>
+                </Form.Item>
+              )}
+            />
+            <Form.Field
+              control={form.control}
+              name="priority"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label optional>Priority</Form.Label>
+                  <Form.Control>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <Select.Trigger>
+                        <Select.Value placeholder="Select" />
+                      </Select.Trigger>
+                      <Select.Content>
+                        {PRIORITIES.map((p) => (
+                          <Select.Item key={p} value={p}>
+                            {p}
+                          </Select.Item>
+                        ))}
+                      </Select.Content>
+                    </Select>
+                  </Form.Control>
+                </Form.Item>
+              )}
+            />
+            <Form.Field
+              control={form.control}
+              name="designer_notes"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label optional>Designer notes</Form.Label>
+                  <Form.Control>
+                    <Textarea {...field} />
+                  </Form.Control>
+                </Form.Item>
+              )}
+            />
+          </div>
+        </RouteDrawer.Body>
+        <RouteDrawer.Footer>
+          <div className="flex items-center justify-end gap-x-2">
+            <RouteDrawer.Close asChild>
+              <Button variant="secondary" size="small">
+                Cancel
+              </Button>
+            </RouteDrawer.Close>
+            <Button isLoading={isPending} type="submit" variant="primary" size="small">
+              Save
+            </Button>
+          </div>
+        </RouteDrawer.Footer>
+      </KeyboundForm>
+    </RouteDrawer.Form>
+  )
+}

--- a/apps/partner-ui/src/routes/designs/design-edit/components/edit-design-form/index.ts
+++ b/apps/partner-ui/src/routes/designs/design-edit/components/edit-design-form/index.ts
@@ -1,0 +1,1 @@
+export { EditDesignForm } from "./edit-design-form"

--- a/apps/partner-ui/src/routes/designs/design-edit/design-edit.tsx
+++ b/apps/partner-ui/src/routes/designs/design-edit/design-edit.tsx
@@ -1,0 +1,23 @@
+import { Heading } from "@medusajs/ui"
+import { useParams } from "react-router-dom"
+import { RouteDrawer } from "../../../components/modals"
+import { usePartnerDesign } from "../../../hooks/api/partner-designs"
+import { EditDesignForm } from "./components/edit-design-form"
+
+export const DesignEdit = () => {
+  const { id } = useParams()
+  const { design, isLoading, isError, error } = usePartnerDesign(id!)
+
+  if (isError) {
+    throw error
+  }
+
+  return (
+    <RouteDrawer>
+      <RouteDrawer.Header>
+        <Heading>Edit design</Heading>
+      </RouteDrawer.Header>
+      {!isLoading && design && <EditDesignForm design={design} />}
+    </RouteDrawer>
+  )
+}

--- a/apps/partner-ui/src/routes/designs/design-edit/index.ts
+++ b/apps/partner-ui/src/routes/designs/design-edit/index.ts
@@ -1,0 +1,1 @@
+export { DesignEdit as Component } from "./design-edit.tsx"

--- a/apps/partner-ui/src/routes/designs/design-list/design-list.tsx
+++ b/apps/partner-ui/src/routes/designs/design-list/design-list.tsx
@@ -1,7 +1,8 @@
-import { Badge, Container, Heading, StatusBadge, Text, Tooltip, createDataTableColumnHelper } from "@medusajs/ui"
+import { Badge, Button, Container, Heading, StatusBadge, Text, Tooltip, createDataTableColumnHelper } from "@medusajs/ui"
 import { keepPreviousData } from "@tanstack/react-query"
 import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
+import { Link } from "react-router-dom"
 
 import { SingleColumnPage } from "../../../components/layout/pages"
 import { Filter } from "../../../components/table/data-table"
@@ -343,6 +344,11 @@ export const DesignList = () => {
               }
             </span>
           </div>
+          <Link to="/designs/create">
+            <Button size="small" variant="secondary">
+              Create
+            </Button>
+          </Link>
         </div>
         <_DataTable
           columns={columns}

--- a/apps/partner-ui/src/routes/designs/design-production-run-create/components/run-create-form/index.ts
+++ b/apps/partner-ui/src/routes/designs/design-production-run-create/components/run-create-form/index.ts
@@ -1,0 +1,1 @@
+export { RunCreateForm } from "./run-create-form"

--- a/apps/partner-ui/src/routes/designs/design-production-run-create/components/run-create-form/run-create-form.tsx
+++ b/apps/partner-ui/src/routes/designs/design-production-run-create/components/run-create-form/run-create-form.tsx
@@ -1,0 +1,188 @@
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "@medusajs/framework/zod"
+import { Button, Heading, Input, Select, Text, toast } from "@medusajs/ui"
+import { useForm } from "react-hook-form"
+
+import { Form } from "../../../../../components/common/form"
+import { RouteFocusModal, useRouteModal } from "../../../../../components/modals"
+import { KeyboundForm } from "../../../../../components/utilities/keybound-form"
+import { useCreatePartnerProductionRun } from "../../../../../hooks/api/partner-production-runs"
+
+const RunCreateSchema = z
+  .object({
+    quantity: z.coerce.number().int().positive().optional(),
+    run_type: z.enum(["production", "sample"]).optional(),
+    execution_mode: z.enum(["in_house", "outsourced"]),
+    sub_partner_id: z.string().optional(),
+  })
+  .refine(
+    (b) => b.execution_mode !== "outsourced" || !!b.sub_partner_id,
+    {
+      message: "A sub-partner is required when outsourcing.",
+      path: ["sub_partner_id"],
+    }
+  )
+type RunCreateSchema = z.infer<typeof RunCreateSchema>
+
+type Props = { designId: string }
+
+export const RunCreateForm = ({ designId }: Props) => {
+  const { handleSuccess } = useRouteModal()
+  const form = useForm<RunCreateSchema>({
+    defaultValues: {
+      quantity: 1,
+      run_type: "production",
+      execution_mode: "in_house",
+      sub_partner_id: "",
+    },
+    resolver: zodResolver(RunCreateSchema),
+  })
+
+  const executionMode = form.watch("execution_mode")
+  const { mutateAsync, isPending } = useCreatePartnerProductionRun(designId)
+
+  const handleSubmit = form.handleSubmit(async (data) => {
+    await mutateAsync(
+      {
+        quantity: data.quantity,
+        run_type: data.run_type,
+        execution_mode: data.execution_mode,
+        sub_partner_id:
+          data.execution_mode === "outsourced"
+            ? data.sub_partner_id
+            : undefined,
+      },
+      {
+        onSuccess: () => {
+          toast.success("Production started")
+          handleSuccess()
+        },
+        onError: (e) => toast.error(e.message),
+      }
+    )
+  })
+
+  return (
+    <RouteFocusModal.Form form={form}>
+      <KeyboundForm
+        className="flex h-full flex-col overflow-hidden"
+        onSubmit={handleSubmit}
+      >
+        <RouteFocusModal.Header />
+        <RouteFocusModal.Body className="flex flex-1 flex-col items-center overflow-y-auto">
+          <div className="flex w-full max-w-[640px] flex-col gap-y-8 px-2 py-16">
+            <div className="flex flex-col gap-y-1">
+              <Heading>Start production</Heading>
+              <Text size="small" className="text-ui-fg-subtle">
+                Create a production run for this design. It's approved and
+                ready to work immediately.
+              </Text>
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+              <Form.Field
+                control={form.control}
+                name="quantity"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label>Quantity</Form.Label>
+                    <Form.Control>
+                      <Input
+                        type="number"
+                        min={1}
+                        value={field.value ?? ""}
+                        onChange={field.onChange}
+                      />
+                    </Form.Control>
+                    <Form.ErrorMessage />
+                  </Form.Item>
+                )}
+              />
+
+              <Form.Field
+                control={form.control}
+                name="run_type"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label optional>Run type</Form.Label>
+                    <Form.Control>
+                      <Select value={field.value} onValueChange={field.onChange}>
+                        <Select.Trigger>
+                          <Select.Value placeholder="Select" />
+                        </Select.Trigger>
+                        <Select.Content>
+                          <Select.Item value="production">Production</Select.Item>
+                          <Select.Item value="sample">Sample</Select.Item>
+                        </Select.Content>
+                      </Select>
+                    </Form.Control>
+                  </Form.Item>
+                )}
+              />
+            </div>
+
+            <Form.Field
+              control={form.control}
+              name="execution_mode"
+              render={({ field }) => (
+                <Form.Item>
+                  <Form.Label>How is it made?</Form.Label>
+                  <Form.Control>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <Select.Trigger>
+                        <Select.Value placeholder="Select" />
+                      </Select.Trigger>
+                      <Select.Content>
+                        <Select.Item value="in_house">
+                          In-house (you make it)
+                        </Select.Item>
+                        <Select.Item value="outsourced">
+                          Outsourced (hand to a sub-partner)
+                        </Select.Item>
+                      </Select.Content>
+                    </Select>
+                  </Form.Control>
+                  <Form.Hint>
+                    In-house keeps the work with you; outsourced records the
+                    vendor for cost tracking.
+                  </Form.Hint>
+                </Form.Item>
+              )}
+            />
+
+            {executionMode === "outsourced" && (
+              <Form.Field
+                control={form.control}
+                name="sub_partner_id"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label>Sub-partner ID</Form.Label>
+                    <Form.Control>
+                      <Input {...field} placeholder="partner_…" />
+                    </Form.Control>
+                    <Form.Hint>
+                      The partner you're handing this production to.
+                    </Form.Hint>
+                    <Form.ErrorMessage />
+                  </Form.Item>
+                )}
+              />
+            )}
+          </div>
+        </RouteFocusModal.Body>
+        <RouteFocusModal.Footer>
+          <div className="flex items-center justify-end gap-x-2">
+            <RouteFocusModal.Close asChild>
+              <Button variant="secondary" size="small">
+                Cancel
+              </Button>
+            </RouteFocusModal.Close>
+            <Button size="small" type="submit" isLoading={isPending}>
+              Start production
+            </Button>
+          </div>
+        </RouteFocusModal.Footer>
+      </KeyboundForm>
+    </RouteFocusModal.Form>
+  )
+}

--- a/apps/partner-ui/src/routes/designs/design-production-run-create/design-production-run-create.tsx
+++ b/apps/partner-ui/src/routes/designs/design-production-run-create/design-production-run-create.tsx
@@ -1,0 +1,12 @@
+import { useParams } from "react-router-dom"
+import { RouteFocusModal } from "../../../components/modals"
+import { RunCreateForm } from "./components/run-create-form"
+
+export const DesignProductionRunCreate = () => {
+  const { id } = useParams()
+  return (
+    <RouteFocusModal>
+      {id && <RunCreateForm designId={id} />}
+    </RouteFocusModal>
+  )
+}

--- a/apps/partner-ui/src/routes/designs/design-production-run-create/index.ts
+++ b/apps/partner-ui/src/routes/designs/design-production-run-create/index.ts
@@ -1,0 +1,1 @@
+export { DesignProductionRunCreate as Component } from "./design-production-run-create.tsx"

--- a/apps/partner-ui/src/routes/production-runs/production-run-detail/components/run-cost-summary-section.tsx
+++ b/apps/partner-ui/src/routes/production-runs/production-run-detail/components/run-cost-summary-section.tsx
@@ -1,0 +1,86 @@
+import { Container, Heading, Text } from "@medusajs/ui"
+
+import { SectionRow } from "../../../../components/common/section"
+import { usePartnerRunCostSummary } from "../../../../hooks/api/partner-production-runs"
+
+type Props = { runId: string }
+
+const fmt = (v?: number | null) =>
+  v == null
+    ? "—"
+    : Number(v).toLocaleString(undefined, { maximumFractionDigits: 2 })
+
+/**
+ * Roadmap #6 Phase 5 — production-run cost summary (admin parity):
+ * material + energy + labor + partner estimate → grand total +
+ * cost-per-unit, sourced from the run's consumption logs.
+ */
+export const RunCostSummarySection = ({ runId }: Props) => {
+  const { cost_summary, isLoading, isError } = usePartnerRunCostSummary(runId)
+
+  if (isError) {
+    return null
+  }
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="px-6 py-4">
+        <Heading level="h2">Cost summary</Heading>
+        <Text size="small" className="text-ui-fg-subtle">
+          Material, energy, labor + your estimate for this run.
+        </Text>
+      </div>
+
+      {isLoading ? (
+        <div className="px-6 py-4">
+          <Text size="small" className="text-ui-fg-subtle">
+            Loading…
+          </Text>
+        </div>
+      ) : !cost_summary ? (
+        <div className="px-6 py-4">
+          <Text size="small" className="text-ui-fg-subtle">
+            No cost data yet.
+          </Text>
+        </div>
+      ) : (
+        <>
+          <SectionRow title="Material" value={fmt(cost_summary.material?.total)} />
+          <SectionRow title="Energy" value={fmt(cost_summary.energy?.total)} />
+          <SectionRow
+            title="Labor"
+            value={
+              cost_summary.labor
+                ? `${fmt(cost_summary.labor.total)}${
+                    cost_summary.labor.total_hours
+                      ? `  (${fmt(cost_summary.labor.total_hours)} h)`
+                      : ""
+                  }`
+                : "—"
+            }
+          />
+          <SectionRow
+            title="Your estimate"
+            value={fmt(cost_summary.partner?.total)}
+          />
+          <SectionRow
+            title="Grand total"
+            value={
+              <Text size="small" weight="plus">
+                {fmt(cost_summary.grand_total)}
+              </Text>
+            }
+          />
+          <SectionRow
+            title="Cost / unit"
+            value={fmt(cost_summary.cost_per_unit)}
+          />
+          <SectionRow
+            title="Consumption logs"
+            value={String(cost_summary.total_consumption_logs ?? 0)}
+          />
+        </>
+      )}
+    </Container>
+  )
+}

--- a/apps/partner-ui/src/routes/production-runs/production-run-detail/production-run-detail.tsx
+++ b/apps/partner-ui/src/routes/production-runs/production-run-detail/production-run-detail.tsx
@@ -7,6 +7,7 @@ import {
   ActivityItem,
 } from "../../../components/common/activities-section"
 import { JsonViewSection } from "../../../components/common/json-view-section"
+import { RunCostSummarySection } from "./components/run-cost-summary-section"
 import { SectionRow } from "../../../components/common/section"
 import { TwoColumnPage, SingleColumnPage } from "../../../components/layout/pages"
 import { TwoColumnPageSkeleton } from "../../../components/common/skeleton"
@@ -276,6 +277,8 @@ export const ProductionRunDetail = () => {
             )}
           </div>
         </Container>
+
+        {production_run && <RunCostSummarySection runId={runId} />}
 
         {production_run && (
           <div className="xl:hidden">


### PR DESCRIPTION
## Summary

The full partner-ui frontend for the partner design self-serve feature (roadmap #6, backend live via #318/#321). Mirrors existing partner-ui patterns (RouteFocusModal/RouteDrawer forms, hooks/api, detail-page sections). Every owner action is gated on `owner_partner_id` — admin-assigned designs stay read-only.

### P1 — design create / edit / delete
- `useCreate/Update/DeletePartnerDesign` hooks
- `designs/create` (FocusModal) · `designs/:id/edit` (Drawer) · "Create" button on list
- `DesignOwnerActionsSection` — edit/delete menu on detail (owner-gated, delete confirms via `usePrompt`)

### P2 — inventory BOM, with **SKU + material media**
- `partner-design-inventory` hooks (link/list/update/delink)
- `DesignInventoryBomSection` — per material line shows the **raw-material media thumbnails**, the **inventory SKU badge**, composition/color, and planned/consumed qty, so the partner sees exactly what they're using
- `designs/:id/add-inventory` modal (pick item by title + SKU, set planned qty) · per-line Remove

### P3 — cost panel
- `partner-design-cost` hooks · `DesignCostSection` — estimated/material/production cost + confidence badge + owner-only Recalculate

### P4 — start production (in-house / outsourced)
- `useCreatePartnerProductionRun` · `DesignStartProductionSection` (owner CTA) · `designs/:id/production-run-create` modal with execution_mode toggle (outsourced reveals required sub-partner)

### P5 — run cost-summary
- `usePartnerRunCostSummary` · `RunCostSummarySection` on the run detail — material+energy+labor+estimate → grand total + cost/unit (admin parity)

## Test plan
- [x] `tsc --noEmit` clean (4 pre-existing baseline errors in order-claim/exchange, untouched)
- [x] `npm run build` (tsup) succeeds
- [ ] Manual (manufacturer workspace): create design → add materials (see SKU+media) → Recalculate cost → Start production (in-house + outsourced) → open run → see cost summary. Verify an admin-assigned design shows everything read-only (no owner actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)