### PR TITLE
fix(production-runs): complete parent run even without lifecycle txn + repair stuck runs

### DIFF
--- a/apps/backend/src/scripts/repair-stuck-parent-production-runs.ts
+++ b/apps/backend/src/scripts/repair-stuck-parent-production-runs.ts
@@ -1,0 +1,175 @@
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { PRODUCTION_RUNS_MODULE } from "../modules/production_runs"
+import type ProductionRunService from "../modules/production_runs/service"
+
+/**
+ * Repair — complete parent production runs left STUCK after all their
+ * child runs completed.
+ *
+ * Why: child runs completed by the partner without ever being dispatched
+ * carry no `lifecycle_transaction_id`. The complete-production-run
+ * workflow signalled the lifecycle's `await-run-complete` gate to fire
+ * `cascadeCompletionStep` (which marks the parent completed) — but
+ * `signalLifecycleStepStep` silently no-ops on a null transaction id, so
+ * the cascade never ran and the parent stayed `in_progress` forever.
+ * The inline `cascadeParentCompletionStep` added to
+ * complete-production-run.ts fixes this going forward; this script
+ * repairs the runs already stuck.
+ *
+ * What it does: for every parent run whose children are ALL completed,
+ * if the parent is in a stuck (non-terminal) status, marks it completed
+ * and reconciles its totals from the children (fixes parent/child
+ * quantity mismatch). completed_at = latest child completed_at.
+ *
+ * By default it does NOT touch parents that are already `cancelled`
+ * (those may have been cancelled intentionally). Pass specific ids via
+ * `--force-run-ids=` / `FORCE_RUN_IDS=` to also complete cancelled
+ * parents (e.g. ones an operator cancelled as a workaround).
+ *
+ * Run:
+ *   npx medusa exec ./src/scripts/repair-stuck-parent-production-runs.ts
+ *
+ * Dry run:
+ *   DRY_RUN=1 npx medusa exec ./src/scripts/repair-stuck-parent-production-runs.ts
+ *
+ * Force-complete specific (incl. cancelled) parents:
+ *   FORCE_RUN_IDS=prod_run_a,prod_run_b npx medusa exec ./src/scripts/...
+ */
+
+const STUCK_STATUSES = [
+  "draft",
+  "pending_review",
+  "approved",
+  "sent_to_partner",
+  "in_progress",
+]
+
+export default async function repairStuckParentProductionRuns({
+  container,
+  args,
+}: ExecArgs) {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  const service: ProductionRunService = container.resolve(PRODUCTION_RUNS_MODULE)
+
+  const argList = args ?? []
+  const dryRun = argList.includes("--dry-run") || process.env.DRY_RUN === "1"
+  const parseList = (flag: string, envVar: string): Set<string> => {
+    const fromArg = argList
+      .map((a) => (a.startsWith(`${flag}=`) ? a.slice(flag.length + 1) : null))
+      .find((v): v is string => v !== null)
+    const raw = fromArg ?? process.env[envVar] ?? ""
+    return new Set(
+      raw.split(",").map((s) => s.trim()).filter(Boolean)
+    )
+  }
+  const forceIds = parseList("--force-run-ids", "FORCE_RUN_IDS")
+
+  if (dryRun) logger.info("DRY RUN — no runs will be updated.")
+  if (forceIds.size) logger.info(`Force-complete ids: ${[...forceIds].join(", ")}`)
+
+  // 1. Every child run (parent_run_id set) + its parent + status.
+  const { data: children } = await query.graph({
+    entity: "production_runs",
+    filters: { parent_run_id: { $ne: null } } as any,
+    fields: [
+      "id",
+      "status",
+      "quantity",
+      "produced_quantity",
+      "completed_at",
+      "parent_run_id",
+    ],
+    pagination: { skip: 0, take: 5000 },
+  })
+
+  // 2. Group children by parent.
+  const byParent = new Map<string, any[]>()
+  for (const c of (children ?? []) as any[]) {
+    const p = c.parent_run_id
+    if (!p) continue
+    if (!byParent.has(p)) byParent.set(p, [])
+    byParent.get(p)!.push(c)
+  }
+
+  let completed = 0
+  let skippedNotAllDone = 0
+  let skippedTerminal = 0
+  const errors: Array<{ parent_id: string; error: string }> = []
+
+  for (const [parentId, kids] of byParent) {
+    const allCompleted = kids.every((c) => String(c.status) === "completed")
+    if (!allCompleted) {
+      skippedNotAllDone++
+      continue
+    }
+
+    const parent = (await service
+      .retrieveProductionRun(parentId)
+      .catch(() => null)) as any
+    if (!parent) continue
+
+    const status = String(parent.status)
+    if (status === "completed") {
+      continue // already correct
+    }
+
+    const isStuck = STUCK_STATUSES.includes(status)
+    const isForced = forceIds.has(parentId)
+    if (!isStuck && !isForced) {
+      // e.g. cancelled and not explicitly forced.
+      skippedTerminal++
+      continue
+    }
+
+    // Reconcile totals from children.
+    const sum = (key: string, fallback?: string) =>
+      kids.reduce((acc, c) => {
+        const v = c?.[key] ?? (fallback ? c?.[fallback] : undefined)
+        return acc + (Number.isFinite(Number(v)) ? Number(v) : 0)
+      }, 0)
+    const quantityTotal = sum("quantity")
+    const producedTotal = sum("produced_quantity", "quantity")
+    const latestMs = kids
+      .map((c) => c?.completed_at)
+      .filter(Boolean)
+      .map((d) => new Date(d).getTime())
+      .reduce((a, b) => Math.max(a, b), 0)
+
+    const tag = `parent ${parentId} (${status} → completed, qty ${parent.quantity}→${quantityTotal}, produced→${producedTotal})${isForced ? " [forced]" : ""}`
+
+    if (dryRun) {
+      logger.info(`WOULD complete ${tag}`)
+      completed++
+      continue
+    }
+
+    try {
+      await service.updateProductionRuns({
+        id: parentId,
+        status: "completed" as any,
+        completed_at: latestMs ? new Date(latestMs) : new Date(),
+        cancelled_at: null,
+        ...(quantityTotal > 0 ? { quantity: quantityTotal } : {}),
+        ...(producedTotal > 0 ? { produced_quantity: producedTotal } : {}),
+      } as any)
+      logger.info(`Completed ${tag}`)
+      completed++
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      logger.error(`Failed ${tag}: ${message}`)
+      errors.push({ parent_id: parentId, error: message })
+    }
+  }
+
+  logger.info("")
+  logger.info("─── Repair summary ───")
+  logger.info(`parents_scanned        = ${byParent.size}`)
+  logger.info(`completed              = ${completed}${dryRun ? " (DRY RUN)" : ""}`)
+  logger.info(`skipped_children_open  = ${skippedNotAllDone}`)
+  logger.info(`skipped_terminal       = ${skippedTerminal} (cancelled/other, not forced)`)
+  logger.info(`errors                 = ${errors.length}`)
+
+  if (errors.length) process.exitCode = 1
+}

--- a/apps/backend/src/workflows/production-runs/complete-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/complete-production-run.ts
@@ -233,6 +233,80 @@ const updateDesignOnCompleteStep = createStep(
 // Workflow
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Step: Cascade parent completion (inline, lifecycle-independent)
+// ---------------------------------------------------------------------------
+//
+// The lifecycle workflow's `cascadeCompletionStep` only fires if the
+// child run was dispatched and carries a `lifecycle_transaction_id` —
+// `signalLifecycleStepStep` silently no-ops on a null id. Child runs
+// completed by the partner without ever being dispatched (null
+// transaction id) therefore left the PARENT stuck in `in_progress`
+// forever. This step does the same cascade INLINE so it always runs
+// when a child completes, regardless of lifecycle transaction state.
+// Idempotent + locked; a parent already completed/cancelled is left
+// untouched (the repair script handles intentionally-cancelled parents
+// separately).
+const cascadeParentCompletionStep = createStep(
+  "cascade-parent-completion-inline",
+  async (input: { production_run_id: string }, { container }) => {
+    const service: ProductionRunService = container.resolve(PRODUCTION_RUNS_MODULE)
+    const lockingService = container.resolve(Modules.LOCKING) as any
+
+    const run = (await service
+      .retrieveProductionRun(input.production_run_id)
+      .catch(() => null)) as any
+    const parentRunId = run?.parent_run_id
+    if (!parentRunId) {
+      return new StepResponse(null)
+    }
+
+    const lockKey = `production-run-complete:${String(parentRunId)}`
+    await lockingService.execute(lockKey, async () => {
+      const children = (await service.listProductionRuns({
+        parent_run_id: parentRunId,
+      } as any)) as any[]
+      if (!children?.length) return
+
+      const allCompleted = children.every(
+        (c) => String(c?.status || "") === "completed"
+      )
+      if (!allCompleted) return
+
+      const parent = (await service
+        .retrieveProductionRun(parentRunId)
+        .catch(() => null)) as any
+      if (!parent) return
+      if (["completed", "cancelled"].includes(String(parent.status))) return
+
+      // Reconcile parent totals from the children so the rollup matches
+      // what was actually produced (fixes the parent/child qty mismatch).
+      const sum = (key: string, fallback?: string) =>
+        children.reduce((acc, c) => {
+          const v = c?.[key] ?? (fallback ? c?.[fallback] : undefined)
+          return acc + (Number.isFinite(Number(v)) ? Number(v) : 0)
+        }, 0)
+      const producedTotal = sum("produced_quantity", "quantity")
+      const quantityTotal = sum("quantity")
+      const latestCompletedAt = children
+        .map((c) => c?.completed_at)
+        .filter(Boolean)
+        .map((d) => new Date(d).getTime())
+        .reduce((a, b) => Math.max(a, b), 0)
+
+      await service.updateProductionRuns({
+        id: parentRunId,
+        status: "completed" as any,
+        completed_at: latestCompletedAt ? new Date(latestCompletedAt) : new Date(),
+        ...(quantityTotal > 0 ? { quantity: quantityTotal } : {}),
+        ...(producedTotal > 0 ? { produced_quantity: producedTotal } : {}),
+      })
+    })
+
+    return new StepResponse(null)
+  }
+)
+
 export const completeProductionRunWorkflow = createWorkflow(
   "complete-production-run",
   function (input: CompleteProductionRunInput) {
@@ -329,6 +403,11 @@ export const completeProductionRunWorkflow = createWorkflow(
     }))
 
     signalLifecycleStepStep(lifecycleInput)
+
+    // Inline parent cascade — guarantees the parent completes even when
+    // the child had no lifecycle transaction to signal (root cause of
+    // stuck-parent runs). Idempotent with the lifecycle/subscriber paths.
+    cascadeParentCompletionStep({ production_run_id: input.production_run_id })
 
     // Emit event
     const eventInput = transform({ run, input }, (data) => {


### PR DESCRIPTION
## Problem

Parent production runs get stuck `in_progress` forever even after the partner finishes + the child run completes. Observed on designs `01KMDCWAKKXQAQGCT3XQGY8MB8` (also a parent/child qty mismatch, 5 vs 9) and `01KP4ZT760J5XHBHJ713S6G9MN`, and reported on others.

## Root cause

A child run completed by the partner **without ever being dispatched** carries no `lifecycle_transaction_id`. `complete-production-run` signals the lifecycle's `await-run-complete` gate to fire `cascadeCompletionStep` (which marks the parent completed) — but `signalLifecycleStepStep` **silently no-ops on a null transaction id**:

```ts
if (!input.lifecycle_transaction_id) return new StepResponse({ signaled: false })
```

So the cascade never runs and the parent stays `in_progress`. The `production-run-task-updated` subscriber backstop also misses these (the child has no dispatched tasks).

## Fix

- **`complete-production-run`** gains an inline `cascadeParentCompletionStep` that marks the parent completed **directly** (locked, idempotent) when all siblings are completed — independent of any lifecycle transaction. It also reconciles the parent's `quantity` / `produced_quantity` from the children, fixing the rollup mismatch.
- **`repair-stuck-parent-production-runs.ts`** — one-off that completes every already-stuck parent whose children are all completed (qty reconciled, `completed_at` = latest child). Dry-run aware. Cancelled parents are skipped unless passed via `FORCE_RUN_IDS=` (for parents an operator cancelled as a workaround — e.g. design 1's parent).

## Rollout
- [x] `tsc --noEmit` clean
- [ ] After deploy: `DRY_RUN=1 run-backfill.sh repair-stuck-parent-production-runs` → review → real run (with `FORCE_RUN_IDS=prod_run_01KMQ7SEG7HPMYXAYVT8P3AZDR` to also complete design 1's cancelled parent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)