### PR TITLE
fix(partner-ui): PlaySolid icon (Play not exported)

### DIFF
--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-start-production-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-start-production-section.tsx
@@ -1,4 +1,4 @@
-import { Play } from "@medusajs/icons"
+import { PlaySolid } from "@medusajs/icons"
 import { Button, Container, Heading, Text } from "@medusajs/ui"
 import { Link } from "react-router-dom"
 
@@ -27,7 +27,7 @@ export const DesignStartProductionSection = ({ design }: Props) => {
       </div>
       <Link to="production-run-create">
         <Button size="small" variant="secondary">
-          <Play />
+          <PlaySolid />
           Start production
         </Button>
       </Link>


### PR DESCRIPTION
Follow-up to #323 (merged before this fix). `Play` isn't exported by `@medusajs/icons@2.14.2` — the partner-ui build fails. Swap to `PlaySolid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)