### PR TITLE
fix(partner-designs): order list by assignment date (newest first)

### DIFF
--- a/apps/backend/src/api/partners/designs/route.ts
+++ b/apps/backend/src/api/partners/designs/route.ts
@@ -132,16 +132,32 @@ export async function GET(
   // Filters: cannot filter on linked design properties; filter post-query if needed
   const filters: any = { partner_id: partner.id }
 
-  const { data: results } = await query.graph({
-    entity: designPartnersLink.entryPoint,
-    fields: [
-      "design.*",
-      "design.tasks.*",
-      "partner.*",
-    ],
-    filters,
-    pagination: { skip: offset, take: limit },
-  }, { locale: req.locale })
+  // Order newest-assigned first: the link row's `created_at` is when the
+  // design was assigned to (or created by) this partner. Without an
+  // explicit order the link query returns rows in an arbitrary order, so
+  // a freshly assigned/created design could fall past the `take` window
+  // and never reach page 1. Wrapped in a fallback so that if a runtime
+  // ever rejects `order` on a link entry point, the listing degrades to
+  // unordered instead of 500-ing.
+  const linkFields = ["created_at", "design.*", "design.tasks.*", "partner.*"]
+  let results: any[] = []
+  try {
+    const { data } = await query.graph({
+      entity: designPartnersLink.entryPoint,
+      fields: linkFields,
+      filters,
+      pagination: { skip: offset, take: limit, order: { created_at: "DESC" } },
+    }, { locale: req.locale })
+    results = data
+  } catch {
+    const { data } = await query.graph({
+      entity: designPartnersLink.entryPoint,
+      fields: linkFields,
+      filters,
+      pagination: { skip: offset, take: limit },
+    }, { locale: req.locale })
+    results = data
+  }
 
   // Include all linked designs for this partner.
   // We'll compute assignment status based on presence of partner workflow tasks (by known titles).
@@ -149,15 +165,18 @@ export async function GET(
   // a null `design` on the link join (e.g. after DELETE /partners/designs/:id),
   // and the mapping below dereferences `design.*` — drop those so the
   // listing doesn't 500.
-  const allLinked = (results || []).filter((linkData: any) => !!linkData?.design)
+  const allLinked = (results || [])
+    .filter((linkData: any) => !!linkData?.design)
+    .map((l: any) => ({
+      ...l,
+      _recency: l.created_at || l.design?.created_at || null,
+    }))
 
-  // Surface designs this partner OWNS (created via self-serve), newest
-  // first. They ARE in the link table (POST creates the link), but the
-  // link query above is unordered + paginated, so a just-created design
-  // can fall past the `take` window and never reach page 1. Fetching the
-  // owned set directly (ordering on the design entity is reliable) and
-  // merging it in guarantees a partner always sees what they created.
-  // Only on the first page, so it isn't re-injected on every page.
+  // Safety net: also pull designs this partner OWNS (created via
+  // self-serve). They ARE in the link table (POST creates the link), so
+  // the ordered query above already surfaces them — but if link ordering
+  // ever misses one, this guarantees a partner still sees what they
+  // created. Merged + re-sorted by recency below, never force-pinned.
   let ownedRows: any[] = []
   if (offset === 0) {
     try {
@@ -166,23 +185,28 @@ export async function GET(
           entity: "design",
           filters: { owner_partner_id: partner.id } as any,
           fields: ["*", "tasks.*"],
-          pagination: { skip: 0, take: 50, order: { updated_at: "DESC" } },
+          pagination: { skip: 0, take: 50, order: { created_at: "DESC" } },
         },
         { locale: req.locale }
       )
       // Normalize to the {design, partner} shape the mapping below expects.
       ownedRows = (owned || [])
         .filter((d: any) => !!d?.id)
-        .map((d: any) => ({ design: d, partner }))
+        .map((d: any) => ({
+          design: d,
+          partner,
+          _recency: d.created_at || null,
+        }))
     } catch {
       // Non-fatal — owned designs still appear via the linked set.
     }
   }
 
-  // Merge owned (first) + linked, deduped by design id.
+  // Merge linked + owned, deduped by design id, then sort newest-first by
+  // recency so the most recently assigned/created design is always on top.
   const seenDesignIds = new Set<string>()
   const merged: any[] = []
-  for (const item of [...ownedRows, ...allLinked]) {
+  for (const item of [...allLinked, ...ownedRows]) {
     const did = item?.design?.id
     if (!did || seenDesignIds.has(did)) {
       continue
@@ -190,6 +214,11 @@ export async function GET(
     seenDesignIds.add(did)
     merged.push(item)
   }
+  merged.sort((a: any, b: any) => {
+    const at = a._recency ? new Date(a._recency).getTime() : 0
+    const bt = b._recency ? new Date(b._recency).getTime() : 0
+    return bt - at
+  })
 
   // post-filter by design.status if requested
   let filtered = merged

--- a/apps/partner-ui/src/routes/designs/design-list/design-list.tsx
+++ b/apps/partner-ui/src/routes/designs/design-list/design-list.tsx
@@ -104,8 +104,9 @@ export const DesignList = () => {
   const q = raw.q?.trim() || ""
   const statusFilter = raw.status?.trim() || ""
   const partnerStatusFilter = raw.partner_status?.trim() || ""
-  // Default sort: most recently updated first
-  const order = raw.order?.trim() || "-updated_at"
+  // No client-side default sort — preserve the server order (designs come
+  // back newest-assigned/created first). Only sort when the user picks one.
+  const order = raw.order?.trim() || ""
 
   const { designs, count = 0, isPending, isError, error } = usePartnerDesigns(
     {
@@ -159,23 +160,29 @@ export const DesignList = () => {
       )
     })
 
-    // Sort
-    const sortKey = order.startsWith("-") ? order.slice(1) : order
-    const desc = order.startsWith("-")
+    // Sort. Only when the user explicitly picks an order — otherwise
+    // preserve the server order, which already returns designs
+    // newest-assigned/created first (a re-sort by updated_at here would
+    // push a freshly assigned design down, since assignment doesn't bump
+    // the design's updated_at).
+    if (order) {
+      const sortKey = order.startsWith("-") ? order.slice(1) : order
+      const desc = order.startsWith("-")
 
-    data = [...data].sort((a, b) => {
-      const av = (a as any)?.[sortKey]
-      const bv = (b as any)?.[sortKey]
+      data = [...data].sort((a, b) => {
+        const av = (a as any)?.[sortKey]
+        const bv = (b as any)?.[sortKey]
 
-      if (av == null && bv == null) return 0
-      if (av == null) return desc ? 1 : -1
-      if (bv == null) return desc ? -1 : 1
+        if (av == null && bv == null) return 0
+        if (av == null) return desc ? 1 : -1
+        if (bv == null) return desc ? -1 : 1
 
-      const aStr = String(av)
-      const bStr = String(bv)
-      const cmp = aStr.localeCompare(bStr)
-      return desc ? -cmp : cmp
-    })
+        const aStr = String(av)
+        const bStr = String(bv)
+        const cmp = aStr.localeCompare(bStr)
+        return desc ? -cmp : cmp
+      })
+    }
 
     return data
   }, [designs, order, partnerStatusFilter, q, statusFilter])


### PR DESCRIPTION
## Problem

A freshly assigned design doesn't appear on page 1 of the partner designs list. Reproduced via the partner API: **"Dark Desires Dress V2"** (just assigned) was **row 22 of 22** — invisible at `PAGE_SIZE=20`.

Two causes:
1. **Backend**: the `design_partners` link query had **no `order`**, so rows came back arbitrarily and a new assignment fell past the `take=20` window.
2. **Frontend**: it then re-sorted only that page by `updated_at` — and assignment doesn't bump the design's `updated_at`, so even a present row sorted low.

## Fix

- **Backend** — order the link query by the link's `created_at` (= assignment/creation date) **DESC**, and re-sort the merged (linked + owned-safety) set by recency. Wrapped in a fallback so a runtime that rejects `order` on a link entry point degrades to unordered instead of 500-ing. This subsumes the earlier owned-design page-1 merge — owned designs are linked, so they surface naturally newest-first.
- **Frontend** — drop the default client-side re-sort by `updated_at`; preserve the **server order** (newest assigned/created first). Only sort when the user explicitly picks a column.

## Test plan
- [x] backend clean build + partner-ui build pass; tsc no new errors
- [ ] After deploy: `GET /partners/designs` returns "Dark Desires Dress V2" at the top; UI list shows newly assigned designs on page 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)