### PR TITLE
fix(partner-ui): BOM crash on object raw_materials + design UX (state-aware Start production, owned/assigned badge+filter)

### DIFF
--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-inventory-bom-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-inventory-bom-section.tsx
@@ -22,6 +22,16 @@ import {
 
 type Props = { design: PartnerDesign }
 
+/**
+ * `raw_materials` comes back as a single object (1:1 link), an array, or
+ * null depending on the endpoint. Always normalize to an array — iterating
+ * the raw object throws "{} is not iterable".
+ */
+function toArray<T = any>(val: any): T[] {
+  if (!val) return []
+  return Array.isArray(val) ? val : [val]
+}
+
 /** Pull image URLs out of a raw_material.media / inventory media json blob. */
 function extractMedia(line: PartnerDesignInventoryItem): string[] {
   const urls: string[] = []
@@ -30,7 +40,7 @@ function extractMedia(line: PartnerDesignInventoryItem): string[] {
     if (typeof m === "string") urls.push(m)
     else if (typeof m?.url === "string") urls.push(m.url)
   }
-  for (const rm of line.inventory_item?.raw_materials ?? []) {
+  for (const rm of toArray(line.inventory_item?.raw_materials)) {
     const media = (rm as any)?.media
     if (Array.isArray(media)) media.forEach(push)
     else push(media)
@@ -107,7 +117,7 @@ export const DesignInventoryBomSection = ({ design }: Props) => {
       ) : (
         inventory_items.map((line) => {
           const item = line.inventory_item
-          const rawMaterials = item?.raw_materials ?? []
+          const rawMaterials = toArray(item?.raw_materials)
           const media = extractMedia(line)
           return (
             <div

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-owner-actions-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-owner-actions-section.tsx
@@ -1,4 +1,4 @@
-import { PencilSquare, PlaySolid, Trash } from "@medusajs/icons"
+import { PencilSquare, PlaySolid, Plus, Trash } from "@medusajs/icons"
 import { Button, Container, Heading, Text, toast, usePrompt } from "@medusajs/ui"
 import { Link, useNavigate } from "react-router-dom"
 
@@ -7,6 +7,9 @@ import {
   PartnerDesign,
   useDeletePartnerDesign,
 } from "../../../../hooks/api/partner-designs"
+import { usePartnerProductionRuns } from "../../../../hooks/api/partner-production-runs"
+
+const TERMINAL_RUN_STATUSES = ["completed", "cancelled"]
 
 type Props = { design: PartnerDesign }
 
@@ -22,9 +25,19 @@ export const DesignOwnerActionsSection = ({ design }: Props) => {
   const prompt = usePrompt()
   const { mutateAsync } = useDeletePartnerDesign(design.id)
 
+  const isOwner = !!(design as any).owner_partner_id
+  const { production_runs = [] } = usePartnerProductionRuns(
+    { design_id: design.id, limit: 50 },
+    { enabled: isOwner }
+  )
+  const activeRuns = production_runs.filter(
+    (r: any) => !TERMINAL_RUN_STATUSES.includes(String(r.status))
+  )
+  const hasActiveRun = activeRuns.length > 0
+
   // Only the owner can manage. Admin-assigned designs have no
   // owner_partner_id and are read-only here.
-  if (!(design as any).owner_partner_id) {
+  if (!isOwner) {
     return null
   }
 
@@ -51,15 +64,19 @@ export const DesignOwnerActionsSection = ({ design }: Props) => {
       <div>
         <Heading level="h2">{design.name || "Your design"}</Heading>
         <Text size="small" className="text-ui-fg-subtle">
-          You created this design. Start production yourself or hand it to a
-          sub-partner.
+          {hasActiveRun
+            ? `${activeRuns.length} run${activeRuns.length > 1 ? "s" : ""} in progress. Start another or hand one to a sub-partner.`
+            : "You created this design. Start production yourself or hand it to a sub-partner."}
         </Text>
       </div>
       <div className="flex items-center gap-x-2">
         <Link to="production-run-create">
-          <Button size="small" variant="primary">
-            <PlaySolid />
-            Start production
+          <Button
+            size="small"
+            variant={hasActiveRun ? "secondary" : "primary"}
+          >
+            {hasActiveRun ? <Plus /> : <PlaySolid />}
+            {hasActiveRun ? "New run" : "Start production"}
           </Button>
         </Link>
         <ActionMenu

--- a/apps/partner-ui/src/routes/designs/design-list/design-list.tsx
+++ b/apps/partner-ui/src/routes/designs/design-list/design-list.tsx
@@ -99,11 +99,13 @@ function formatTargetDate(dateStr: string | undefined | null): {
 
 export const DesignList = () => {
   const { t } = useTranslation()
-  const raw = useQueryParams(["offset", "q", "status", "partner_status", "order"])
+  const raw = useQueryParams(["offset", "q", "status", "partner_status", "order", "source"])
   const offset = raw.offset ? Number(raw.offset) : 0
   const q = raw.q?.trim() || ""
   const statusFilter = raw.status?.trim() || ""
   const partnerStatusFilter = raw.partner_status?.trim() || ""
+  // "owned" = created by this partner (owner_partner_id set); "assigned" = admin-assigned.
+  const sourceFilter = raw.source?.trim() || ""
   // No client-side default sort — preserve the server order (designs come
   // back newest-assigned/created first). Only sort when the user picks one.
   const order = raw.order?.trim() || ""
@@ -126,6 +128,15 @@ export const DesignList = () => {
       const name = String(row.name || "").toLowerCase()
       const status = String(row.status || "").toLowerCase()
       const partnerStatus = String(row?.partner_info?.partner_status || "").toLowerCase()
+      const isOwned = !!(row as any)?.owner_partner_id
+
+      // Source filter (owned vs assigned)
+      if (sourceFilter === "owned" && !isOwned) {
+        return false
+      }
+      if (sourceFilter === "assigned" && isOwned) {
+        return false
+      }
 
       // Partner status filter
       if (partnerStatusFilter) {
@@ -185,10 +196,19 @@ export const DesignList = () => {
     }
 
     return data
-  }, [designs, order, partnerStatusFilter, q, statusFilter])
+  }, [designs, order, partnerStatusFilter, q, statusFilter, sourceFilter])
 
   const filters = useMemo<Filter[]>(
     () => [
+      {
+        type: "select",
+        key: "source",
+        label: "Source",
+        options: [
+          { label: "Created by you", value: "owned" },
+          { label: "Assigned by admin", value: "assigned" },
+        ],
+      },
       {
         type: "select",
         key: "partner_status",
@@ -211,6 +231,15 @@ export const DesignList = () => {
         header: () => "Name",
         cell: ({ getValue }) => (
           <span className="font-medium">{getValue() || "-"}</span>
+        ),
+      }),
+      columnHelper.accessor((row) => (row as any)?.owner_partner_id, {
+        id: "source",
+        header: () => "Source",
+        cell: ({ getValue }) => (
+          <Badge size="2xsmall" color={getValue() ? "green" : "grey"}>
+            {getValue() ? "Yours" : "Assigned"}
+          </Badge>
         ),
       }),
       columnHelper.accessor((row) => row?.partner_info?.partner_status, {


### PR DESCRIPTION
## Changes

### Bug — "TypeError: {} is not iterable" when adding BOM inventory
The API returns `inventory_item.raw_materials` as a **single object** (1:1 link), e.g.:
```json
"raw_materials": { "id": "...", "name": "Cotton", "composition": "50% Cotton", ... }
```
The BOM section iterated it as an array (`for...of` / `.map`) → crash. Added a `toArray()` normalizer everywhere `raw_materials` is read.

### UX — state-aware Start production
The command-header button now reflects run state: with an active (non-terminal) run it reads **"New run"** (secondary) instead of **"Start production"** (primary), and the subtitle shows "N runs in progress."

### UX — owned vs assigned in the design list
Added a **"Source"** badge column (Yours / Assigned, from `owner_partner_id`) + a matching **Source filter** (Created by you / Assigned by admin), so partners can distinguish their own designs from admin-assigned work.

## Test plan
- [x] partner-ui build + tsc (no new errors)
- [ ] Add a BOM material → no crash, material shows with SKU/media. Open an owned design with a running run → button reads "New run". Design list → Source column + filter work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)