### PR TITLE
fix: open roadmap bug polish — category dropdown (#1), analytics nav (#3), WhatsApp-contact warning (#25d)

### DIFF
--- a/apps/backend/integration-tests/http/partner-has-whatsapp-contact.spec.ts
+++ b/apps/backend/integration-tests/http/partner-has-whatsapp-contact.spec.ts
@@ -1,0 +1,87 @@
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+
+jest.setTimeout(60 * 1000)
+
+// Roadmap bug #25d — the admin partner list surfaces a
+// `has_whatsapp_contact` flag so the production-run assignment UI can
+// warn when a partner has no reachable WhatsApp recipient. The flag
+// mirrors seed-partner-run-whatsapp-flow.ts: a verified whatsapp_number
+// wins, otherwise the first active admin with a phone.
+setupSharedTestSuite(() => {
+  describe("Admin partner list → has_whatsapp_contact flag", () => {
+    let adminHeaders: { headers: Record<string, string> }
+
+    beforeAll(async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+    })
+
+    it("is true when the partner has an active admin with a phone", async () => {
+      const { api } = getSharedTestEnv()
+      const unique = Date.now()
+
+      const res = await api.post(
+        "/admin/partners",
+        {
+          partner: {
+            name: `WA Yes ${unique}`,
+            handle: `wa-yes-${unique}`,
+          },
+          admin: {
+            email: `wa-yes-admin-${unique}@jyt.test`,
+            first_name: "WA",
+            last_name: "Yes",
+            phone: "+919900000000",
+          },
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      const partnerId = res.data.partner.id
+
+      const list = await api.get(
+        `/admin/persons/partner?handle=wa-yes-${unique}&limit=5`,
+        adminHeaders
+      )
+      expect(list.status).toBe(200)
+      const found = list.data.partners.find((p: any) => p.id === partnerId)
+      expect(found).toBeDefined()
+      expect(found.has_whatsapp_contact).toBe(true)
+    })
+
+    it("is false when the partner has no verified number and no admin phone", async () => {
+      const { api } = getSharedTestEnv()
+      const unique = Date.now() + 1
+
+      const res = await api.post(
+        "/admin/partners",
+        {
+          partner: {
+            name: `WA No ${unique}`,
+            handle: `wa-no-${unique}`,
+          },
+          admin: {
+            email: `wa-no-admin-${unique}@jyt.test`,
+            first_name: "WA",
+            last_name: "No",
+            // no phone
+          },
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      const partnerId = res.data.partner.id
+
+      const list = await api.get(
+        `/admin/persons/partner?handle=wa-no-${unique}&limit=5`,
+        adminHeaders
+      )
+      expect(list.status).toBe(200)
+      const found = list.data.partners.find((p: any) => p.id === partnerId)
+      expect(found).toBeDefined()
+      expect(found.has_whatsapp_contact).toBe(false)
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/raw-material-categories-search.spec.ts
+++ b/apps/backend/integration-tests/http/raw-material-categories-search.spec.ts
@@ -1,0 +1,53 @@
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+
+jest.setTimeout(60 * 1000)
+
+// Roadmap bug #1 follow-up — the /admin/categories/rawmaterials list
+// endpoint now supports partial, case-insensitive search via `q`
+// (previously the `name` filter did an exact match, so partial searches
+// returned nothing). `q` is the canonical Medusa search param and maps
+// to an ilike $or across name + description.
+setupSharedTestSuite(() => {
+  describe("Admin raw-material categories — search", () => {
+    let adminHeaders: { headers: Record<string, string> }
+    const tag = `${Date.now()}`
+    const lower = `pwcotton-${tag}`
+    const upper = `PWCotton-${tag}`
+    const other = `pwsilk-${tag}`
+
+    beforeAll(async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+
+      for (const name of [lower, upper, other]) {
+        await api.post("/admin/categories/rawmaterials", { name }, adminHeaders)
+      }
+    })
+
+    it("matches a partial term, case-insensitively, across categories", async () => {
+      const { api } = getSharedTestEnv()
+      // lowercase query must still match the mixed-case "PWCotton" row
+      const res = await api.get(
+        `/admin/categories/rawmaterials?q=pwcotton-${tag}&limit=100`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      const names = res.data.categories.map((c: any) => c.name)
+      expect(names).toEqual(expect.arrayContaining([lower, upper]))
+      // a different category must not leak into a name-specific search
+      expect(names).not.toContain(other)
+    })
+
+    it("returns nothing for a non-matching term", async () => {
+      const { api } = getSharedTestEnv()
+      const res = await api.get(
+        `/admin/categories/rawmaterials?q=zzzznope-${tag}`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.categories.length).toBe(0)
+    })
+  })
+})

--- a/apps/backend/src/admin/components/common/category-search.tsx
+++ b/apps/backend/src/admin/components/common/category-search.tsx
@@ -1,9 +1,7 @@
-import { Input } from "@medusajs/ui";
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
-import { useDebouncedSearch } from "../../hooks/use-debounce";
-import { Form } from "./form";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Form } from "./form";
+import { Combobox } from "../inputs/combobox/combobox";
 
 export type Category = {
   id: string;
@@ -13,192 +11,114 @@ export type Category = {
 
 type CategorySearchProps = {
   defaultValue?: Category | string;
-  onSelect: (category: Category | null) => void;
-  onValueChange: (value: string) => void;
+  onSelect: (category: Category | null) => any;
+  onValueChange: (value: string) => any;
   categories: Category[];
   error?: string;
 };
 
-export const CategorySearch = (props: CategorySearchProps & Record<string, any>) => {
+/**
+ * Category picker for raw materials. Backed by the ariakit Combobox
+ * (ported from partner-ui / Medusa's dashboard) so the dropdown is a
+ * portaled popover that flips and repositions on overflow instead of
+ * being clipped by the scrollable create/edit modal it lives in
+ * (roadmap bug #1). It keeps the original "type to create a new
+ * category" behaviour via the Combobox's onCreateOption affordance.
+ *
+ * Two call sites with different wiring, both supported:
+ *  - the create form passes onSelect/onValueChange that call
+ *    field.onChange themselves and return the value;
+ *  - the edit form (DynamicForm) injects value/onChange and expects
+ *    onSelect/onValueChange to just return the value.
+ * We call the callback AND forward its result to the injected onChange,
+ * which is a no-op in the create case (onChange is undefined there).
+ */
+export const CategorySearch = (
+  props: CategorySearchProps & Record<string, any>
+) => {
   const {
     defaultValue = "",
     onSelect,
     onValueChange,
     categories,
     error,
-    // Extract react-hook-form properties
+    // react-hook-form / DynamicForm injected props
     value: formValue,
     onChange: formOnChange,
-    ...otherProps
   } = props;
   const { t } = useTranslation();
-  const [showCategoryDropdown, setShowCategoryDropdown] = useState(false);
-  const [inputValue, setInputValue] = useState(
-    typeof defaultValue === "string" ? defaultValue : defaultValue?.name || ""
-  );
 
-  // The dropdown is rendered in a portal so it escapes the scrollable /
-  // overflow-hidden ancestors of the modal it usually lives in (otherwise
-  // it gets clipped). We track the anchor input's viewport rect and
-  // position the portal with `fixed` coordinates.
-  const anchorRef = useRef<HTMLDivElement>(null);
-  const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
-
-  const updateAnchorRect = useCallback(() => {
-    if (anchorRef.current) {
-      setAnchorRect(anchorRef.current.getBoundingClientRect());
+  // Resolve the initial selected category name from whatever the caller
+  // seeded (an existing-category object, a plain name string, or RHF's
+  // current value).
+  const initialName = useMemo(() => {
+    if (formValue && typeof formValue === "object" && formValue.name) {
+      return String(formValue.name);
     }
+    if (typeof formValue === "string" && formValue) {
+      return formValue;
+    }
+    if (defaultValue && typeof defaultValue === "object") {
+      return defaultValue.name || "";
+    }
+    if (typeof defaultValue === "string") {
+      return defaultValue;
+    }
+    return "";
+    // initial only — subsequent selection is tracked in `selected`
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const {
-    onSearchValueChange: setCategorySearch,
-    query: debouncedQuery,
-  } = useDebouncedSearch();
-
-  const matchingCategories = categories.filter(
-    (category) => category.name.toLowerCase().includes(inputValue.toLowerCase())
+  const [selected, setSelected] = useState<string>(initialName);
+  // Newly typed (not-yet-persisted) names so they still render as the
+  // selected label and show up as an option.
+  const [createdNames, setCreatedNames] = useState<string[]>(
+    initialName && !categories.some((c) => c.name === initialName)
+      ? [initialName]
+      : []
   );
 
-  const hasExactMatch = categories.some(
-    (category) => category.name.toLowerCase() === inputValue.toLowerCase()
-  );
+  const options = useMemo(() => {
+    const base = categories.map((c) => ({ value: c.name, label: c.name }));
+    const extra = createdNames
+      .filter((n) => !categories.some((c) => c.name === n))
+      .map((n) => ({ value: n, label: n }));
+    return [...base, ...extra];
+  }, [categories, createdNames]);
 
-  const showNewCategoryHint = inputValue && 
-    inputValue.length >= 3 && 
-    !hasExactMatch;
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    setInputValue(value);
-    
-    // When user types, clear any previously selected category
-    // and use the typed value instead
-    const processedValue = onValueChange(value);
-    
-    // Update the form field value directly
-    if (formOnChange) {
-      formOnChange(processedValue);
-    }
-    
-    if (value.length >= 3) {
-      setCategorySearch(value);
-    } else {
-      setCategorySearch("");
-      setShowCategoryDropdown(false);
-    }
-  };
-
-  const handleCategorySelect = (category: Category) => {
-    setInputValue(category.name);
-    const result = onSelect(category);
-    
-    // Update the form field value directly
-    if (formOnChange) {
-      formOnChange(result);
-    }
-    
-    setCategorySearch("");
-    setShowCategoryDropdown(false);
-  };
-
-  // Set initial category if defaultValue is a Category object
-  useEffect(() => {
-    if (typeof defaultValue === "object" && defaultValue !== null) {
-      const result = onSelect(defaultValue);
-      
-      // Update the form field value directly
-      if (formOnChange) {
-        formOnChange(result);
-      }
-    } else if (formValue === undefined && defaultValue) {
-      // If no form value but defaultValue is provided, use it
-      if (formOnChange) {
-        formOnChange(defaultValue);
-      }
-    }
-  }, [defaultValue, onSelect, formOnChange, formValue]);
-
-  // Update dropdown visibility based on matching categories
-  useEffect(() => {
-    if (!debouncedQuery || matchingCategories.length === 0) {
-      setShowCategoryDropdown(false);
-    } else {
-      setShowCategoryDropdown(true);
-    }
-  }, [debouncedQuery, matchingCategories.length]);
-
-  // Keep the portal aligned with the input while it's open — measure on
-  // open and follow scroll/resize so the dropdown tracks the anchor even
-  // when the modal body scrolls.
-  const isOpen = showCategoryDropdown && matchingCategories.length > 0;
-
-  useLayoutEffect(() => {
-    if (!isOpen) {
+  const handleChange = (val?: string) => {
+    if (!val) {
+      setSelected("");
+      formOnChange?.(onValueChange(""));
       return;
     }
-    updateAnchorRect();
-    window.addEventListener("scroll", updateAnchorRect, true);
-    window.addEventListener("resize", updateAnchorRect);
-    return () => {
-      window.removeEventListener("scroll", updateAnchorRect, true);
-      window.removeEventListener("resize", updateAnchorRect);
-    };
-  }, [isOpen, updateAnchorRect]);
+    setSelected(val);
+    const existing = categories.find((c) => c.name === val);
+    if (existing) {
+      formOnChange?.(onSelect(existing));
+    }
+    // A brand-new value is handled by handleCreate, which the Combobox
+    // fires alongside onChange for non-existent options.
+  };
+
+  const handleCreate = (name: string) => {
+    setCreatedNames((prev) => (prev.includes(name) ? prev : [...prev, name]));
+    setSelected(name);
+    formOnChange?.(onValueChange(name));
+  };
 
   return (
     <Form.Item>
-      <div ref={anchorRef} className="relative">
-        <Form.Control>
-          <Input
-            autoComplete="off"
-            value={inputValue}
-            onChange={handleInputChange}
-            placeholder={t("common.searchOrCreateCategory")}
-            onFocus={() => {
-              if (inputValue.length >= 3 && matchingCategories.length > 0) {
-                setShowCategoryDropdown(true);
-              }
-            }}
-            onBlur={() => {
-              setTimeout(() => setShowCategoryDropdown(false), 200);
-            }}
-          />
-        </Form.Control>
-        {isOpen && anchorRect &&
-          createPortal(
-            <div
-              className="z-[100] max-h-48 overflow-y-auto rounded-lg border border-ui-border-base bg-ui-bg-base shadow-elevation-flyout"
-              style={{
-                position: "fixed",
-                top: anchorRect.bottom + 4,
-                left: anchorRect.left,
-                width: anchorRect.width,
-              }}
-            >
-              {matchingCategories.map((category) => (
-                <button
-                  key={category.id}
-                  type="button"
-                  className="w-full px-4 py-2 text-left hover:bg-ui-bg-base-hover"
-                  // onMouseDown fires before the input's onBlur, so the
-                  // selection isn't lost to the blur-close timeout.
-                  onMouseDown={(e) => {
-                    e.preventDefault();
-                    handleCategorySelect(category);
-                  }}
-                >
-                  {category.name}
-                </button>
-              ))}
-            </div>,
-            document.body
-          )}
-        {showNewCategoryHint && (
-          <div className="text-ui-fg-subtle mt-2 text-sm">
-            {t("common.pressEnterToCreateCategory")}
-          </div>
-        )}
-      </div>
+      <Form.Control>
+        <Combobox
+          options={options}
+          value={selected}
+          onChange={handleChange}
+          onCreateOption={handleCreate}
+          allowClear
+          placeholder={t("common.searchOrCreateCategory", "Search or create a category")}
+        />
+      </Form.Control>
       {error && <Form.ErrorMessage>{error}</Form.ErrorMessage>}
     </Form.Item>
   );

--- a/apps/backend/src/admin/components/common/category-search.tsx
+++ b/apps/backend/src/admin/components/common/category-search.tsx
@@ -1,5 +1,6 @@
 import { Input } from "@medusajs/ui";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useDebouncedSearch } from "../../hooks/use-debounce";
 import { Form } from "./form";
 import { useTranslation } from "react-i18next";
@@ -35,6 +36,19 @@ export const CategorySearch = (props: CategorySearchProps & Record<string, any>)
   const [inputValue, setInputValue] = useState(
     typeof defaultValue === "string" ? defaultValue : defaultValue?.name || ""
   );
+
+  // The dropdown is rendered in a portal so it escapes the scrollable /
+  // overflow-hidden ancestors of the modal it usually lives in (otherwise
+  // it gets clipped). We track the anchor input's viewport rect and
+  // position the portal with `fixed` coordinates.
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
+
+  const updateAnchorRect = useCallback(() => {
+    if (anchorRef.current) {
+      setAnchorRect(anchorRef.current.getBoundingClientRect());
+    }
+  }, []);
 
   const {
     onSearchValueChange: setCategorySearch,
@@ -113,12 +127,30 @@ export const CategorySearch = (props: CategorySearchProps & Record<string, any>)
     }
   }, [debouncedQuery, matchingCategories.length]);
 
+  // Keep the portal aligned with the input while it's open — measure on
+  // open and follow scroll/resize so the dropdown tracks the anchor even
+  // when the modal body scrolls.
+  const isOpen = showCategoryDropdown && matchingCategories.length > 0;
+
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    updateAnchorRect();
+    window.addEventListener("scroll", updateAnchorRect, true);
+    window.addEventListener("resize", updateAnchorRect);
+    return () => {
+      window.removeEventListener("scroll", updateAnchorRect, true);
+      window.removeEventListener("resize", updateAnchorRect);
+    };
+  }, [isOpen, updateAnchorRect]);
+
   return (
     <Form.Item>
-      <div className="relative">
+      <div ref={anchorRef} className="relative">
         <Form.Control>
-          <Input 
-            autoComplete="off" 
+          <Input
+            autoComplete="off"
             value={inputValue}
             onChange={handleInputChange}
             placeholder={t("common.searchOrCreateCategory")}
@@ -132,22 +164,35 @@ export const CategorySearch = (props: CategorySearchProps & Record<string, any>)
             }}
           />
         </Form.Control>
-        {showCategoryDropdown && matchingCategories.length > 0 && (
-          <div 
-            className="absolute left-0 right-0 top-full z-50 mt-1 max-h-48 overflow-y-auto rounded-lg border border-ui-border-base bg-ui-bg-base shadow-lg"
-          >
-            {matchingCategories.map((category) => (
-              <button
-                key={category.id}
-                type="button"
-                className="w-full px-4 py-2 text-left hover:bg-ui-bg-base-hover"
-                onClick={() => handleCategorySelect(category)}
-              >
-                {category.name}
-              </button>
-            ))}
-          </div>
-        )}
+        {isOpen && anchorRect &&
+          createPortal(
+            <div
+              className="z-[100] max-h-48 overflow-y-auto rounded-lg border border-ui-border-base bg-ui-bg-base shadow-elevation-flyout"
+              style={{
+                position: "fixed",
+                top: anchorRect.bottom + 4,
+                left: anchorRect.left,
+                width: anchorRect.width,
+              }}
+            >
+              {matchingCategories.map((category) => (
+                <button
+                  key={category.id}
+                  type="button"
+                  className="w-full px-4 py-2 text-left hover:bg-ui-bg-base-hover"
+                  // onMouseDown fires before the input's onBlur, so the
+                  // selection isn't lost to the blur-close timeout.
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    handleCategorySelect(category);
+                  }}
+                >
+                  {category.name}
+                </button>
+              ))}
+            </div>,
+            document.body
+          )}
         {showNewCategoryHint && (
           <div className="text-ui-fg-subtle mt-2 text-sm">
             {t("common.pressEnterToCreateCategory")}

--- a/apps/backend/src/admin/components/edits/edit-raw-material.tsx
+++ b/apps/backend/src/admin/components/edits/edit-raw-material.tsx
@@ -119,10 +119,10 @@ export const EditRawMaterialForm = ({ rawMaterial }: EditRawMaterialFormProps) =
   const { id: inventoryId } = useParams();
   const [searchQuery, setSearchQuery] = useState("");
   
-  // Fetch material type categories when search query is at least 3 characters
-  const { categories = [] } = useRawMaterialCategories(
-    searchQuery.length >= 3 ? { name: searchQuery } : { name: "" }
-  );
+  // Fetch all material-type categories once; the CategorySearch combobox
+  // filters them client-side (the endpoint's `name` filter is unreliable
+  // and the query key is static — see roadmap bug #1).
+  const { categories = [] } = useRawMaterialCategories({ limit: 100 });
 
   const { mutateAsync, isPending } = useUpdateRawMaterial(inventoryId!, rawMaterial.id, {});
 

--- a/apps/backend/src/admin/components/forms/raw-material/raw-material-form.tsx
+++ b/apps/backend/src/admin/components/forms/raw-material/raw-material-form.tsx
@@ -49,10 +49,13 @@ export const RawMaterialForm = () => {
   const [searchQuery, setSearchQuery] = useState("");
   const [mediaUrls, setMediaUrls] = useState<string[]>([]);
   
-  // Fetch material type categories when search query is at least 3 characters
-  const { categories: materialCategories = [] } = useRawMaterialCategories(
-    searchQuery.length >= 3 ? { name: searchQuery } : { name: "" }
-  );
+  // Fetch all material-type categories once; the CategorySearch combobox
+  // filters them client-side. (The endpoint's `name` filter returns
+  // nothing for empty/partial values, and the query key is static, so a
+  // server-side search never populated results — see roadmap bug #1.)
+  const { categories: materialCategories = [] } = useRawMaterialCategories({
+    limit: 100,
+  });
   
   const form = useForm<RawMaterialFormType>({
     resolver: zodResolver(rawMaterialFormSchema),

--- a/apps/backend/src/admin/components/inputs/combobox/combobox.tsx
+++ b/apps/backend/src/admin/components/inputs/combobox/combobox.tsx
@@ -1,0 +1,426 @@
+// Ported from apps/partner-ui (which mirrors Medusa's admin dashboard
+// Combobox) so admin extensions get the same ariakit-based combobox: a
+// portaled popover that flips/repositions on overflow (no clipping
+// inside scrollable modals) and a built-in "create new" affordance.
+import {
+  Combobox as PrimitiveCombobox,
+  ComboboxDisclosure as PrimitiveComboboxDisclosure,
+  ComboboxItem as PrimitiveComboboxItem,
+  ComboboxItemCheck as PrimitiveComboboxItemCheck,
+  ComboboxItemValue as PrimitiveComboboxItemValue,
+  ComboboxPopover as PrimitiveComboboxPopover,
+  ComboboxProvider as PrimitiveComboboxProvider,
+  Separator as PrimitiveSeparator,
+} from "@ariakit/react"
+import {
+  CheckMini,
+  EllipseMiniSolid,
+  PlusMini,
+  TrianglesMini,
+  XMarkMini,
+} from "@medusajs/icons"
+import { clx, Text } from "@medusajs/ui"
+import { matchSorter } from "match-sorter"
+import {
+  ComponentPropsWithoutRef,
+  CSSProperties,
+  ForwardedRef,
+  Fragment,
+  ReactNode,
+  useCallback,
+  useDeferredValue,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from "react"
+import { useTranslation } from "react-i18next"
+
+import { genericForwardRef } from "../../utilities/generic-forward-ref"
+
+type ComboboxOption = {
+  value: string
+  label: string
+  disabled?: boolean
+}
+
+type Value = string[] | string
+
+const TABLUAR_NUM_WIDTH = 8
+const TAG_BASE_WIDTH = 28
+
+interface ComboboxProps<T extends Value = Value>
+  extends Omit<ComponentPropsWithoutRef<"input">, "onChange" | "value"> {
+  value?: T
+  onChange?: (value?: T) => void
+  searchValue?: string
+  onSearchValueChange?: (value: string) => void
+  options: ComboboxOption[]
+  fetchNextPage?: () => void
+  isFetchingNextPage?: boolean
+  onCreateOption?: (value: string) => void
+  noResultsPlaceholder?: ReactNode
+  allowClear?: boolean
+  forceHideInput?: boolean // always hide input -> used for singe value select that don't have query/filter
+}
+
+const ComboboxImpl = <T extends Value = string>(
+  {
+    value: controlledValue,
+    onChange,
+    searchValue: controlledSearchValue,
+    onSearchValueChange,
+    options,
+    className,
+    placeholder,
+    fetchNextPage,
+    isFetchingNextPage,
+    onCreateOption,
+    noResultsPlaceholder,
+    allowClear,
+    forceHideInput,
+    ...inputProps
+  }: ComboboxProps<T>,
+  ref: ForwardedRef<HTMLInputElement>
+) => {
+  const [open, setOpen] = useState(false)
+  const [isPending, startTransition] = useTransition()
+  const { t } = useTranslation()
+
+  const comboboxRef = useRef<HTMLInputElement>(null)
+  const listboxRef = useRef<HTMLDivElement>(null)
+
+  useImperativeHandle(ref, () => comboboxRef.current!)
+
+  const isValueControlled = controlledValue !== undefined
+  const isSearchControlled = controlledSearchValue !== undefined
+
+  const isArrayValue = Array.isArray(controlledValue)
+  const emptyState = (isArrayValue ? [] : "") as T
+
+  const [uncontrolledSearchValue, setUncontrolledSearchValue] = useState(
+    controlledSearchValue || ""
+  )
+  const defferedSearchValue = useDeferredValue(uncontrolledSearchValue)
+
+  const [uncontrolledValue, setUncontrolledValue] = useState<T>(emptyState)
+
+  const searchValue = isSearchControlled
+    ? controlledSearchValue
+    : uncontrolledSearchValue
+  const selectedValues = isValueControlled ? controlledValue : uncontrolledValue
+
+  const handleValueChange = (newValues?: T) => {
+    // check if the value already exists in options
+    const exists = options
+      .filter((o) => !o.disabled)
+      .find((o) => {
+        if (isArrayValue) {
+          return newValues?.includes(o.value)
+        }
+        return o.value === newValues
+      })
+
+    // If the value does not exist in the options, and the component has a handler
+    // for creating new options, call it.
+    if (!exists && onCreateOption && newValues) {
+      onCreateOption(newValues as string)
+    }
+
+    if (!isValueControlled) {
+      setUncontrolledValue(newValues || emptyState)
+    }
+
+    if (onChange) {
+      onChange(newValues)
+    }
+
+    setUncontrolledSearchValue("")
+  }
+
+  const handleSearchChange = (query: string) => {
+    setUncontrolledSearchValue(query)
+
+    if (onSearchValueChange) {
+      onSearchValueChange(query)
+    }
+  }
+
+  /**
+   * Filter and sort the options based on the search value,
+   * and whether the value is already selected.
+   *
+   * This is only used when the search value is uncontrolled.
+   */
+  const matches = useMemo(() => {
+    if (isSearchControlled) {
+      return []
+    }
+
+    // do not use `matcher` if the input is hidden
+    if (forceHideInput) {
+      return options
+    }
+
+    return matchSorter(options, defferedSearchValue, {
+      keys: ["label"],
+    })
+  }, [options, defferedSearchValue, isSearchControlled, forceHideInput])
+
+  const observer = useRef(
+    new IntersectionObserver(
+      (entries) => {
+        const first = entries[0]
+        if (first.isIntersecting) {
+          fetchNextPage?.()
+        }
+      },
+      { threshold: 1 }
+    )
+  )
+
+  const lastOptionRef = useCallback(
+    (node: HTMLDivElement) => {
+      if (isFetchingNextPage) {
+        return
+      }
+      if (observer.current) {
+        observer.current.disconnect()
+      }
+      if (node) {
+        observer.current.observe(node)
+      }
+    },
+    [isFetchingNextPage]
+  )
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      setUncontrolledSearchValue("")
+    }
+
+    setOpen(open)
+  }
+
+  const hasValue = selectedValues?.length > 0
+
+  const showTag = hasValue && isArrayValue
+  const showSelected = showTag && !searchValue && !open
+
+  const hideInput = forceHideInput || (!isArrayValue && hasValue && !open)
+  const selectedLabel = options.find((o) => o.value === selectedValues)?.label
+
+  const hidePlaceholder = showSelected || open
+
+  const tagWidth = useMemo(() => {
+    if (!Array.isArray(selectedValues)) {
+      return TAG_BASE_WIDTH + TABLUAR_NUM_WIDTH // There can only be a single digit
+    }
+
+    const count = selectedValues.length
+    const digits = count.toString().length
+
+    return TAG_BASE_WIDTH + digits * TABLUAR_NUM_WIDTH
+  }, [selectedValues])
+
+  const results = useMemo(() => {
+    return isSearchControlled ? options : matches
+  }, [matches, options, isSearchControlled])
+
+  return (
+    <PrimitiveComboboxProvider
+      open={open}
+      setOpen={handleOpenChange}
+      selectedValue={selectedValues}
+      setSelectedValue={(value) => handleValueChange(value as T)}
+      value={uncontrolledSearchValue}
+      setValue={(query) => {
+        startTransition(() => handleSearchChange(query))
+      }}
+    >
+      <div
+        className={clx(
+          "relative flex cursor-pointer items-center gap-x-2 overflow-hidden",
+          "h-8 w-full rounded-md",
+          "bg-ui-bg-field transition-fg shadow-borders-base",
+          "has-[input:focus]:shadow-borders-interactive-with-active",
+          "has-[:invalid]:shadow-borders-error has-[[aria-invalid=true]]:shadow-borders-error",
+          "has-[:disabled]:bg-ui-bg-disabled has-[:disabled]:text-ui-fg-disabled has-[:disabled]:cursor-not-allowed",
+          className
+        )}
+        style={
+          {
+            "--tag-width": `${tagWidth}px`,
+          } as CSSProperties
+        }
+      >
+        {showTag && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.preventDefault()
+              handleValueChange(isArrayValue ? ([] as unknown as T) : undefined)
+            }}
+            className="bg-ui-bg-base hover:bg-ui-bg-base-hover txt-compact-small-plus text-ui-fg-subtle focus-within:border-ui-fg-interactive transition-fg absolute start-0.5 top-0.5 z-[1] flex h-[28px] items-center rounded-[4px] border py-[3px] pe-1 ps-1.5 outline-none"
+          >
+            <span className="tabular-nums">{selectedValues.length}</span>
+            <XMarkMini className="text-ui-fg-muted" />
+          </button>
+        )}
+        <div className="relative flex size-full items-center">
+          {showSelected && (
+            <div
+              className={clx(
+                "pointer-events-none absolute inset-y-0 flex size-full items-center",
+                {
+                  "start-[calc(var(--tag-width)+8px)]": showTag,
+                  "start-2": !showTag,
+                }
+              )}
+            >
+              <Text size="small" leading="compact">
+                {t("general.selected")}
+              </Text>
+            </div>
+          )}
+          {hideInput && (
+            <div
+              className={clx(
+                "pointer-events-none absolute inset-y-0 flex size-full items-center overflow-hidden",
+                {
+                  "start-[calc(var(--tag-width)+8px)]": showTag,
+                  "start-2": !showTag,
+                }
+              )}
+            >
+              <Text size="small" leading="compact" className="truncate">
+                {selectedLabel}
+              </Text>
+            </div>
+          )}
+          <PrimitiveCombobox
+            autoSelect
+            ref={comboboxRef}
+            onFocus={() => setOpen(true)}
+            className={clx(
+              "txt-compact-small text-ui-fg-base !placeholder:text-ui-fg-muted transition-fg size-full cursor-pointer bg-transparent pe-8 ps-2 outline-none focus:cursor-text",
+              "hover:bg-ui-bg-field-hover",
+              {
+                "opacity-0": hideInput,
+                "ps-2": !showTag,
+                "ps-[calc(var(--tag-width)+8px)]": showTag,
+              }
+            )}
+            placeholder={hidePlaceholder ? undefined : placeholder}
+            {...inputProps}
+          />
+        </div>
+        {allowClear && controlledValue && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.preventDefault()
+              handleValueChange(undefined)
+            }}
+            className="bg-ui-bg-base hover:bg-ui-bg-base-hover txt-compact-small-plus text-ui-fg-subtle focus-within:border-ui-fg-interactive transition-fg absolute end-[28px] top-0.5 z-[1] flex h-[28px] items-center rounded-[4px] border px-1.5 py-[2px] outline-none"
+          >
+            <XMarkMini className="text-ui-fg-muted" />
+          </button>
+        )}
+        <PrimitiveComboboxDisclosure
+          render={(props) => {
+            return (
+              <button
+                {...props}
+                type="button"
+                className="text-ui-fg-muted transition-fg hover:bg-ui-bg-field-hover absolute end-0 flex size-8 items-center justify-center rounded-r outline-none"
+              >
+                <TrianglesMini />
+              </button>
+            )
+          }}
+        />
+      </div>
+      <PrimitiveComboboxPopover
+        gutter={4}
+        sameWidth
+        ref={listboxRef}
+        role="listbox"
+        className={clx(
+          "shadow-elevation-flyout bg-ui-bg-base z-50 rounded-[8px] p-1",
+          "max-h-[200px] overflow-y-auto",
+          "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          "data-[side=bottom]:slide-in-from-top-2 data-[side=start]:slide-in-from-end-2 data-[side=end]:slide-in-from-start-2 data-[side=top]:slide-in-from-bottom-2"
+        )}
+        style={{
+          pointerEvents: open ? "auto" : "none",
+        }}
+        aria-busy={isPending}
+      >
+        {results.map(({ value, label, disabled }) => (
+          <PrimitiveComboboxItem
+            key={value}
+            value={value}
+            focusOnHover
+            setValueOnClick={false}
+            disabled={disabled}
+            className={clx(
+              "transition-fg bg-ui-bg-base data-[active-item=true]:bg-ui-bg-base-hover group flex cursor-pointer items-center gap-x-2 rounded-[4px] px-2 py-1",
+              {
+                "text-ui-fg-disabled": disabled,
+                "bg-ui-bg-component": disabled,
+              }
+            )}
+          >
+            <PrimitiveComboboxItemCheck className="flex !size-5 items-center justify-center">
+              {isArrayValue ? <CheckMini /> : <EllipseMiniSolid />}
+            </PrimitiveComboboxItemCheck>
+            <PrimitiveComboboxItemValue className="txt-compact-small">
+              {label}
+            </PrimitiveComboboxItemValue>
+          </PrimitiveComboboxItem>
+        ))}
+        {!!fetchNextPage && <div ref={lastOptionRef} className="w-px" />}
+        {isFetchingNextPage && (
+          <div className="transition-fg bg-ui-bg-base flex items-center rounded-[4px] px-2 py-1.5">
+            <div className="bg-ui-bg-component size-full h-5 w-full animate-pulse rounded-[4px]" />
+          </div>
+        )}
+        {!results.length &&
+          (noResultsPlaceholder && !searchValue?.length ? (
+            noResultsPlaceholder
+          ) : (
+            <div className="flex items-center gap-x-2 rounded-[4px] px-2 py-1.5">
+              <Text
+                size="small"
+                leading="compact"
+                className="text-ui-fg-subtle"
+              >
+                {t("general.noResultsTitle")}
+              </Text>
+            </div>
+          ))}
+        {!results.length && onCreateOption && searchValue && (
+          <Fragment>
+            <PrimitiveSeparator className="bg-ui-border-base -mx-1" />
+            <PrimitiveComboboxItem
+              value={uncontrolledSearchValue}
+              focusOnHover
+              setValueOnClick={false}
+              className="transition-fg bg-ui-bg-base data-[active-item=true]:bg-ui-bg-base-hover group mt-1 flex cursor-pointer items-center gap-x-2 rounded-[4px] px-2 py-1.5"
+            >
+              <PlusMini className="text-ui-fg-subtle" />
+              <Text size="small" leading="compact">
+                {t("actions.create")} &quot;{searchValue}&quot;
+              </Text>
+            </PrimitiveComboboxItem>
+          </Fragment>
+        )}
+      </PrimitiveComboboxPopover>
+    </PrimitiveComboboxProvider>
+  )
+}
+
+export const Combobox = genericForwardRef(ComboboxImpl)

--- a/apps/backend/src/admin/components/utilities/generic-forward-ref.tsx
+++ b/apps/backend/src/admin/components/utilities/generic-forward-ref.tsx
@@ -1,0 +1,9 @@
+import { ReactNode, Ref, RefAttributes, forwardRef } from "react"
+
+// Mirrors the partner-ui utility so admin components can forward refs to
+// generic (typed) components without losing the type parameters.
+export function genericForwardRef<T, P = {}>(
+  render: (props: P, ref: Ref<T>) => ReactNode
+): (props: P & RefAttributes<T>) => ReactNode {
+  return forwardRef(render) as any
+}

--- a/apps/backend/src/admin/hooks/api/partners.ts
+++ b/apps/backend/src/admin/hooks/api/partners.ts
@@ -16,6 +16,10 @@ export interface AdminPartner {
   status: 'active' | 'inactive' | 'pending';
   is_verified: boolean;
   metadata?: any;
+  // True when the partner has a reachable WhatsApp recipient — a verified
+  // whatsapp_number or at least one active admin with a phone. When false,
+  // production-run notifications can't reach the partner directly.
+  has_whatsapp_contact?: boolean;
   created_at: string;
   updated_at: string;
 }

--- a/apps/backend/src/admin/hooks/api/raw-materials.ts
+++ b/apps/backend/src/admin/hooks/api/raw-materials.ts
@@ -300,7 +300,10 @@ export const useRawMaterialCategories = (
   >,
 ) => {
   const { data, ...rest } = useQuery({
-    queryKey: inventoryItemsRawMaterialQueryKeys.lists(),
+    // Include params in the key — a static key meant changing the search
+    // term never refetched, so server-side category search silently
+    // returned stale results (part of roadmap bug #1).
+    queryKey: [...inventoryItemsRawMaterialQueryKeys.lists(), params],
     queryFn: async () =>
       sdk.client.fetch<RawMaterialCategoriesResponse>(
         `/admin/categories/rawmaterials`,

--- a/apps/backend/src/admin/routes/designs/[id]/@production-run/page.tsx
+++ b/apps/backend/src/admin/routes/designs/[id]/@production-run/page.tsx
@@ -10,6 +10,7 @@ import {
   Text,
   toast,
 } from "@medusajs/ui"
+import { ExclamationCircle } from "@medusajs/icons"
 import { useCallback, useMemo, useState } from "react"
 import { useForm } from "react-hook-form"
 import { useParams } from "react-router-dom"
@@ -168,6 +169,19 @@ const AssignmentsModal = ({
                         ))}
                       </Select.Content>
                     </Select>
+                    {assignment.partner_id &&
+                      partners.find(
+                        (p: any) => String(p.id) === assignment.partner_id
+                      )?.has_whatsapp_contact === false && (
+                        <div className="mt-1 flex items-start gap-x-1 text-ui-tag-orange-text">
+                          <ExclamationCircle className="mt-0.5 shrink-0" />
+                          <Text size="xsmall">
+                            No WhatsApp contact — production updates won't reach
+                            this partner directly. Add a verified WhatsApp number
+                            or an active admin phone on the partner.
+                          </Text>
+                        </div>
+                      )}
                   </div>
 
                   <div>

--- a/apps/backend/src/api/admin/categories/rawmaterials/route.ts
+++ b/apps/backend/src/api/admin/categories/rawmaterials/route.ts
@@ -119,16 +119,27 @@ export const GET = async (
   res: MedusaResponse
 ) => {
   try {
-    // Extract validated query parameters 
-    const { filters = {}, config = {}, page = 1, limit = 10 } = req.validatedQuery;
+    // Extract validated query parameters
+    const { filters = {}, config = {}, page = 1, limit = 10, q, name, offset } =
+      req.validatedQuery;
 
-    // Transform pagination params to match the workflow input format
-    const skip = (page - 1) * limit;
-    
+    // Merge the convenience top-level search params into the filters the
+    // workflow understands (it normalizes name/q into an ilike match).
+    const mergedFilters: Record<string, any> = { ...filters };
+    if (q) {
+      mergedFilters.q = q;
+    }
+    if (name) {
+      mergedFilters.name = name;
+    }
+
+    // Offset-based pagination wins when supplied; otherwise derive from page.
+    const skip = typeof offset === "number" ? offset : (page - 1) * limit;
+
     // Call the workflow with properly formatted input
     const { result, errors } = await listRawMaterialCategoriesWorkflow(req.scope).run({
       input: {
-        filters,
+        filters: mergedFilters,
         config: {
           ...config,
           skip,

--- a/apps/backend/src/api/admin/categories/rawmaterials/validators.ts
+++ b/apps/backend/src/api/admin/categories/rawmaterials/validators.ts
@@ -27,6 +27,11 @@ export const ReadRawMaterialCategoriesSchema = z.object({
     },
     z.record(z.string(), z.unknown()).optional()
   ),
+  // Free-text search across name + description (case-insensitive, partial).
+  q: z.string().optional(),
+  // Convenience partial-match on name (case-insensitive). Both `q` and
+  // `name` map to an ilike filter in the workflow.
+  name: z.string().optional(),
   page: z.preprocess(
     (val) => {
       if (val && typeof val === "string") {
@@ -35,6 +40,17 @@ export const ReadRawMaterialCategoriesSchema = z.object({
       return val;
     },
     z.number().min(1).optional().default(1)
+  ),
+  // Offset-based pagination (admin combobox / SDK send `offset`). When
+  // provided it takes precedence over `page`.
+  offset: z.preprocess(
+    (val) => {
+      if (val && typeof val === "string") {
+        return parseInt(val);
+      }
+      return val;
+    },
+    z.number().min(0).optional()
   ),
   limit: z.preprocess(
     (val) => {

--- a/apps/backend/src/api/admin/persons/partner/route.ts
+++ b/apps/backend/src/api/admin/persons/partner/route.ts
@@ -134,27 +134,64 @@ export const GET = async (
     filters.is_verified = validatedQuery.is_verified === 'true'
   }
 
+  // We always need the WhatsApp-resolution fields so we can surface a
+  // `has_whatsapp_contact` flag (the response shape below is fixed
+  // regardless of caller `fields`, so augmenting the fetch is safe).
+  const baseFields = [
+    "id",
+    "name",
+    "handle",
+    "logo",
+    "status",
+    "is_verified",
+    "metadata",
+    "created_at",
+    "updated_at",
+  ]
+  const whatsappFields = [
+    "whatsapp_number",
+    "whatsapp_verified",
+    "admins.phone",
+    "admins.is_active",
+  ]
+  const fields = Array.from(
+    new Set([...(validatedQuery.fields ?? baseFields), ...whatsappFields])
+  )
+
   const { result } = await listPartnersWorkflow(req.scope).run({
     input: {
       filters,
-      fields: validatedQuery.fields,
+      fields,
       offset: validatedQuery.offset,
       limit: validatedQuery.limit,
     },
   })
 
-  const partners = result.data.map((item: any) => ({
-    id: item.id,
-    partner_id: item.id,
-    name: item.name,
-    handle: item.handle,
-    logo: item.logo,
-    status: item.status,
-    is_verified: item.is_verified,
-    metadata: item.metadata,
-    created_at: item.created_at,
-    updated_at: item.updated_at,
-  }))
+  const partners = result.data.map((item: any) => {
+    // Mirror the WhatsApp recipient resolution in
+    // seed-partner-run-whatsapp-flow.ts: a verified whatsapp_number
+    // wins, otherwise the first active admin with a phone. If neither
+    // resolves, production-run notifications can't reach the partner
+    // directly — the admin UI warns when assigning such a partner.
+    const hasVerifiedNumber = !!(item.whatsapp_number && item.whatsapp_verified)
+    const hasActiveAdminPhone =
+      Array.isArray(item.admins) &&
+      item.admins.some((a: any) => a && a.is_active && a.phone)
+
+    return {
+      id: item.id,
+      partner_id: item.id,
+      name: item.name,
+      handle: item.handle,
+      logo: item.logo,
+      status: item.status,
+      is_verified: item.is_verified,
+      metadata: item.metadata,
+      has_whatsapp_contact: hasVerifiedNumber || hasActiveAdminPhone,
+      created_at: item.created_at,
+      updated_at: item.updated_at,
+    }
+  })
 
   return res.json({
     partners,

--- a/apps/backend/src/workflows/raw-materials/list-raw-material-category.ts
+++ b/apps/backend/src/workflows/raw-materials/list-raw-material-category.ts
@@ -11,6 +11,8 @@ import RawMaterialService from "../../modules/raw_material/service";
   type ListRawMaterialCategories = {
     filters?: {
       id?: string[];
+      /** Free-text search across name + description (partial, case-insensitive) */
+      q?: string;
       name?: string;
       description?: string;
       metadata?: Record<string, any>;
@@ -22,13 +24,30 @@ import RawMaterialService from "../../modules/raw_material/service";
       relations?: string[];
     };
   };
-  
+
   export const listRawMaterialCategoriesStep = createStep(
     "list-raw-materials-categories-step",
     async (input: ListRawMaterialCategories, { container }) => {
       const rawMaterialService: RawMaterialService = container.resolve(RAW_MATERIAL_MODULE);
+
+      // Normalize free-text search to an ilike $or so partial matches
+      // work (the service does exact matching on a bare `name`, and a
+      // top-level `name` filter is intercepted by translatable-field
+      // handling — wrapping it in $or keeps it a raw, reliable filter).
+      // Both `q` and `name` are treated as search-across-name+description.
+      const { q, name, ...restFilters } = input.filters || {};
+      const searchTerm = (q ?? name ?? "").trim();
+      const normalized: Record<string, any> = { ...restFilters };
+      if (searchTerm.length > 0) {
+        const term = `%${searchTerm}%`;
+        normalized.$or = [
+          { name: { $ilike: term } },
+          { description: { $ilike: term } },
+        ];
+      }
+
       const [categories, count] = await rawMaterialService.listAndCountMaterialTypes(
-        input.filters,
+        normalized,
         input.config
       );
       return new StepResponse({ categories, count });

--- a/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
+++ b/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
@@ -322,14 +322,26 @@ change is needed. **Re-seed required in prod** after merge —
 delete the existing flow `vflow_01KQ9RSZ1TFMB7MQ0Y64P4E98Y` and
 re-run `npx medusa exec ./src/scripts/seed-partner-run-whatsapp-flow.ts`.
 
-**25d — Partner profile missing whatsapp_phone_number** (DEFERRED,
-SEPARATE TRACK). Saransh's partner profile has no `phone` /
+**25d — Partner profile missing whatsapp_phone_number** (FIXED
+2026-06-06, GitHub #335). Saransh's partner profile has no `phone` /
 `whatsapp_phone` / `whatsapp_phone_number` on any field — but the
 seed's resolve_template falls back to the first active admin's
 `phone` (which prod payload showed populated), so partner-side
-WhatsApp does have a phone target. Just worth surfacing a clear
-admin warning when assigning a partner without a primary WA contact.
-Out of scope for the bug 25 PR.
+WhatsApp does have a phone target. We now surface a clear admin
+warning when assigning a partner without a reachable WA contact:
+- `GET /admin/persons/partner` computes a `has_whatsapp_contact`
+  boolean per partner, mirroring the seed's resolution priority
+  exactly (verified `whatsapp_number`, else any active admin with a
+  `phone`). The list endpoint now fetches `whatsapp_number`,
+  `whatsapp_verified`, `admins.phone`, `admins.is_active` for the
+  computation (response shape was already fixed, so additive).
+- `AdminPartner` hook type gains the optional `has_whatsapp_contact`.
+- The design production-run assignment modal
+  (`designs/[id]/@production-run/page.tsx`) shows an orange
+  `ExclamationCircle` warning under the partner select when the chosen
+  partner's `has_whatsapp_contact === false`. Non-blocking.
+- Test: `integration-tests/http/partner-has-whatsapp-contact.spec.ts`
+  (2 tests — admin-with-phone → true, no-phone → false), green.
 
 **Effort:** 25a + 25b + 25c shipping in this PR. 25d is a small
 follow-up admin affordance.

--- a/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
+++ b/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
@@ -107,19 +107,31 @@ captured list; ordering inside this doc is just for readability.
 
 #### 1. Category dropdown in "Add Raw Material" UI
 
-**Status: FIXED 2026-06-06.** Root cause confirmed: the category field
-is the custom `CategorySearch` component
-(`apps/backend/src/admin/components/common/category-search.tsx`), not a
-Medusa `Select`/`Combobox`. Its results dropdown was an
-`absolute`-positioned `<div>` (`z-50`) rendered inside the
-`RouteFocusModal` body, which scrolls (`overflow-y-auto`) — so the
-dropdown was clipped by the overflow ancestor. Fix: render the dropdown
-through `createPortal(... , document.body)` with `position: fixed`
-coordinates measured from the input's `getBoundingClientRect`, tracked
-on scroll/resize while open, `z-[100]` + `shadow-elevation-flyout`.
-Selection switched from `onClick` to `onMouseDown`+`preventDefault` so
-it beats the input's blur-close timeout. The edit form
-(`edit-raw-material.tsx`) reuses the same component, so it's fixed too.
+**Status: FIXED 2026-06-07 (Playwright-verified).** Root cause: the
+category field is the custom `CategorySearch` component, not a Medusa
+combobox. Its results dropdown was an `absolute`-positioned `<div>`
+inside the scrollable `RouteFocusModal` body, so it was clipped by the
+overflow ancestor. **A deeper bug surfaced while fixing it:** existing
+categories never loaded at all — the form fetched
+`/admin/categories/rawmaterials` with `{name:""}` (and `{name:q}` while
+typing), but that endpoint's `name` filter returns nothing for
+empty/partial values, and the hook's query key is static so it never
+refetched. The picker only ever worked for *creating* new categories.
+
+Final fix (chose the proper component over a portal band-aid, per
+"mirror Medusa, don't invent"): ported Medusa's ariakit `Combobox`
+(`components/inputs/combobox/combobox.tsx` + a `generic-forward-ref`
+util) from partner-ui into the admin, and rewrote `CategorySearch` to
+use it. The ariakit popover is portaled and flips/repositions on
+overflow (no clipping), and its `onCreateOption` preserves the
+type-to-create-new-category behaviour. Both call sites
+(`raw-material-form.tsx`, `edit-raw-material.tsx`) now fetch **all**
+categories once (`{limit:100}`, no broken `name` filter) and let the
+combobox filter client-side via `matchSorter`. Placeholder also got a
+default so the raw `common.searchOrCreateCategory` i18n key stops
+showing. Verified in the running admin via Playwright: existing
+categories load + filter (`cotton`/`Cotton`), dropdown renders
+unclipped over the modal, select-existing and create-new both work.
 
 The dropdown doesn't render cleanly — likely a portal / overflow /
 z-index issue (same family as the FX badge bug from this morning).

--- a/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
+++ b/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
@@ -1,5 +1,13 @@
 # Platform Roadmap — Open Backlog (captured 2026-05-26)
 
+> **GitHub task list (added 2026-06-06):** the open items below are now
+> mirrored as GitHub issues for day-to-day tracking. Umbrella tracker:
+> [#352 — Platform Backlog](https://github.com/Jaal-Yantra-Textiles/v2/issues/352).
+> Pull the whole set down with `gh issue list --label roadmap --limit 50`.
+> Issue titles carry the `[#N]` roadmap number so the two stay in sync;
+> this doc remains the narrative source-of-truth (the *why* + the
+> closed-out history), GitHub holds the actionable checklist.
+
 > Working order for the next stretch of platform work. Top section is
 > the region-sharing gap discovered while debugging GOF's storefront
 > serving AU customers. Lower section is the open backlog to walk
@@ -99,6 +107,20 @@ captured list; ordering inside this doc is just for readability.
 
 #### 1. Category dropdown in "Add Raw Material" UI
 
+**Status: FIXED 2026-06-06.** Root cause confirmed: the category field
+is the custom `CategorySearch` component
+(`apps/backend/src/admin/components/common/category-search.tsx`), not a
+Medusa `Select`/`Combobox`. Its results dropdown was an
+`absolute`-positioned `<div>` (`z-50`) rendered inside the
+`RouteFocusModal` body, which scrolls (`overflow-y-auto`) — so the
+dropdown was clipped by the overflow ancestor. Fix: render the dropdown
+through `createPortal(... , document.body)` with `position: fixed`
+coordinates measured from the input's `getBoundingClientRect`, tracked
+on scroll/resize while open, `z-[100]` + `shadow-elevation-flyout`.
+Selection switched from `onClick` to `onMouseDown`+`preventDefault` so
+it beats the input's blur-close timeout. The edit form
+(`edit-raw-material.tsx`) reuses the same component, so it's fixed too.
+
 The dropdown doesn't render cleanly — likely a portal / overflow /
 z-index issue (same family as the FX badge bug from this morning).
 **First step:** reproduce in admin, screenshot the broken state, grep
@@ -116,6 +138,19 @@ first, port to drawer.
 **Effort:** ~half day per route once the pattern's in place.
 
 #### 3. Analytics submenu missing for some partners in partner-ui
+
+**Status: FIXED 2026-06-06.** Not a data/backfill issue — the nav was
+gated on `workspace_type` in `useCoreRoutes`
+(`apps/partner-ui/src/components/layout/main-layout/main-layout.tsx`).
+The `seller` branch's Web Store menu listed content + theme +
+**analytics**; the `manufacturer` (default) branch's Web Store menu
+listed only content + theme — analytics was omitted even though both
+partner types get a Web Store and `/webstore/analytics` is registered
+unconditionally in the route map (`get-partner-route.map.tsx:871`).
+Decision (user, 2026-06-06): Analytics is a standard Web Store feature
+→ show it for any Web Store partner. Fix: added the analytics nav item
+to the manufacturer branch's Web Store `items`. Route was already
+reachable, so no 404 risk.
 
 The Analytics submenu appears for some partner accounts and not
 others. Suspect: gated on `partner.workspace_type` or on a feature
@@ -227,6 +262,16 @@ import), restore or re-link.
 **Effort:** 1-2 hours.
 
 #### 25. Partner assignment on design production runs — diagnosed 2026-06-03
+
+**Status: 25a + 25b + 25c SHIPPED & MERGED to main (verified 2026-06-06).**
+Commits: `66c4eea78` (25a, `.nullish()` on both validators), the
+`hasPerAssignmentTemplates` guard in the design production-run drawer
+(25b), and `68d0a8902` → `93ab12772` → `06786c30a` (25c header
+forwarding + a hardened reachable IMAGE-header fallback to dodge Meta
+error 132012). **Re-seed of the prod flow still required** — delete
+`vflow_01KQ9RSZ1TFMB7MQ0Y64P4E98Y` and re-run
+`seed-partner-run-whatsapp-flow.ts` (see 25c below). 25d remains a
+deferred follow-up.
 
 Reported against prod run `01KPET5HBGNH9QXGC0MC8RHR39`. Investigation
 reproduced the validator error on design `01JQ4H4JKX4TMXJZ3GH9TA02MT`

--- a/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
+++ b/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
@@ -133,6 +133,18 @@ showing. Verified in the running admin via Playwright: existing
 categories load + filter (`cotton`/`Cotton`), dropdown renders
 unclipped over the modal, select-existing and create-new both work.
 
+**Server-side follow-up (2026-06-07):** also fixed the underlying
+endpoint so partial search works for any consumer, not just the
+client-side workaround. `GET /admin/categories/rawmaterials` now accepts
+`q` (canonical) and `name` search params and an `offset`; the list
+workflow normalizes the term to an ilike `$or` across name + description
+(mirroring the designs list workflow) instead of the broken exact-match
+`name` filter. The admin hook's React Query key now includes the params
+(it was static, so search terms never refetched). Test:
+`integration-tests/http/raw-material-categories-search.spec.ts` (partial
++ case-insensitive match, non-match → empty), green; live-verified
+`?q=cot`/`?name=cot` → 2, `?q=goog` → 1, no-param → all.
+
 The dropdown doesn't render cleanly — likely a portal / overflow /
 z-index issue (same family as the FX badge bug from this morning).
 **First step:** reproduce in admin, screenshot the broken state, grep

--- a/apps/partner-ui/src/components/layout/main-layout/main-layout.tsx
+++ b/apps/partner-ui/src/components/layout/main-layout/main-layout.tsx
@@ -260,6 +260,7 @@ const useCoreRoutes = (
       items: [
         { label: t("app.nav.main.content"), to: "/content" },
         { label: t("app.nav.main.theme"), to: "/webstore/theme" },
+        { label: t("app.nav.main.analytics"), to: "/webstore/analytics" },
       ],
     },
   ]


### PR DESCRIPTION
Open "Bugs + UX polish" sweep from the platform roadmap, plus doc updates.

Closes #335.
(Roadmap items #1 and #3 were fixed pre-issue-creation, so they have no GitHub issue.)

## Roadmap bug #1 — raw-material category picker (rebuilt on Medusa's Combobox)
The "Material Type" field used a custom `CategorySearch` whose results dropdown was an `absolute` `<div>` inside the scrollable `RouteFocusModal` body — so it was clipped. While fixing it, a deeper bug surfaced: **existing categories never loaded** — the form fetched `/admin/categories/rawmaterials` with `{name:""}`/`{name:q}`, but that endpoint's `name` filter returns nothing for empty/partial values and the hook's query key is static (never refetches). The picker only ever worked for *creating* new categories.

**Fix:** ported Medusa's ariakit `Combobox` (+ a `generic-forward-ref` util) from partner-ui into the admin and rebuilt `CategorySearch` on it — a portaled popover that flips/repositions on overflow (no clipping), with `onCreateOption` preserving type-to-create-new. Both call sites now fetch all categories once (`{limit:100}`) and filter client-side. Placeholder got a default so the raw i18n key stops showing.

**Playwright-verified in the running admin:** existing categories load + filter (`cotton`/`Cotton`), dropdown renders unclipped over the modal, select-existing and create-new both work.

## Roadmap bug #3 — Analytics submenu missing for manufacturers
`useCoreRoutes` gated Analytics on `workspace_type`: the `seller` Web Store menu had analytics, the `manufacturer` (default) branch didn't, though both get a Web Store and `/webstore/analytics` is registered unconditionally. **Fix:** added the nav item to the manufacturer branch (per product decision — it's a standard Web Store feature).

## Roadmap bug #25d — warn when assigning a partner with no WhatsApp contact
`GET /admin/persons/partner` now computes `has_whatsapp_contact` per partner, mirroring `seed-partner-run-whatsapp-flow.ts` resolution (verified `whatsapp_number`, else an active admin with a phone). The design production-run assignment modal shows a non-blocking orange warning under the partner select when the partner has no reachable WA contact. **Test:** `integration-tests/http/partner-has-whatsapp-contact.spec.ts` (2 cases), green.

## Test plan
- [x] Add raw material → category dropdown renders unclipped, existing load/filter, select + create both work (Playwright).
- [ ] Partner-ui as a manufacturer partner: Web Store → Analytics shows and routes correctly.
- [ ] Design → Create Production Run → Manage Assignments → pick a partner with no admin phone / unverified WhatsApp → warning appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)