### PR TITLE
feat(admin): design-detail nested pages — production runs summary + sub-page (#8)

### DIFF
--- a/apps/backend/src/admin/components/designs/design-partner-summary.tsx
+++ b/apps/backend/src/admin/components/designs/design-partner-summary.tsx
@@ -1,0 +1,96 @@
+import { Avatar, Badge, Button, Container, Heading, Text } from "@medusajs/ui"
+import { Plus, TriangleRightMini } from "@medusajs/icons"
+import { Link, useNavigate } from "react-router-dom"
+
+import { AdminDesign } from "../../hooks/api/designs"
+
+interface Props {
+  design: AdminDesign
+}
+
+const PREVIEW_COUNT = 3
+
+/**
+ * Compact partners card for the design detail page (roadmap #8). Shows
+ * the count + a few linked partners and links to the dedicated sub-page
+ * (/designs/:id/partners) for the full list + management.
+ */
+export const DesignPartnerSummary = ({ design }: Props) => {
+  const navigate = useNavigate()
+  const partners = ((design as any)?.partners || []) as any[]
+  const preview = partners.slice(0, PREVIEW_COUNT)
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex items-center gap-x-2">
+          <Heading level="h2">Partners</Heading>
+          <Badge size="2xsmall" color="grey" rounded="full">
+            {partners.length}
+          </Badge>
+        </div>
+        <div className="flex items-center gap-x-2">
+          <Button
+            variant="secondary"
+            size="small"
+            onClick={() => navigate(`/designs/${design.id}/linkPartner`)}
+          >
+            <Plus className="mr-1" />
+            Link Partner
+          </Button>
+          {partners.length > 0 && (
+            <Button asChild variant="transparent" size="small">
+              <Link to="partners">View all</Link>
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2 px-3 py-3">
+        {partners.length === 0 ? (
+          <div className="flex items-center justify-center py-4">
+            <Text size="small" className="text-ui-fg-subtle">
+              No partners linked to this design
+            </Text>
+          </div>
+        ) : (
+          <>
+            {preview.map((partner: any) => (
+              <Link
+                key={partner.id}
+                to="partners"
+                className="outline-none focus-within:shadow-borders-interactive-with-focus rounded-md [&:hover>div]:bg-ui-bg-component-hover"
+              >
+                <div className="shadow-elevation-card-rest bg-ui-bg-component flex items-center gap-3 rounded-md px-4 py-2 transition-colors">
+                  <Avatar
+                    src={partner.logo || undefined}
+                    fallback={partner.name?.charAt(0) || "P"}
+                  />
+                  <div className="flex flex-1 flex-col overflow-hidden">
+                    <Text size="small" leading="compact" weight="plus">
+                      {partner.name || `Partner ${partner.id}`}
+                    </Text>
+                    <Text size="xsmall" className="text-ui-fg-subtle truncate">
+                      {partner.handle || "-"}
+                    </Text>
+                  </div>
+                  <TriangleRightMini className="text-ui-fg-muted" />
+                </div>
+              </Link>
+            ))}
+            {partners.length > PREVIEW_COUNT && (
+              <Link
+                to="partners"
+                className="text-ui-fg-interactive hover:text-ui-fg-interactive-hover px-1 py-1"
+              >
+                <Text size="small" leading="compact">
+                  View all {partners.length} partners →
+                </Text>
+              </Link>
+            )}
+          </>
+        )}
+      </div>
+    </Container>
+  )
+}

--- a/apps/backend/src/admin/components/designs/design-production-runs-summary.tsx
+++ b/apps/backend/src/admin/components/designs/design-production-runs-summary.tsx
@@ -1,0 +1,111 @@
+import { Badge, Button, Container, Heading, Skeleton, Text } from "@medusajs/ui"
+import { Plus, TriangleRightMini } from "@medusajs/icons"
+import { Link } from "react-router-dom"
+
+import { AdminDesign } from "../../hooks/api/designs"
+import { useProductionRuns } from "../../hooks/api/production-runs"
+import { productionRunStatusColor as statusColor } from "../../lib/status-colors"
+
+interface Props {
+  design: AdminDesign
+}
+
+const PREVIEW_COUNT = 2
+
+/**
+ * Compact production-runs card for the design detail page (roadmap #8).
+ * Shows the count + the latest couple of runs and links to the dedicated
+ * sub-page (/designs/:id/production-runs) for the full list. Keeps the
+ * detail page light instead of stacking the whole runs section inline.
+ */
+export const DesignProductionRunsSummary = ({ design }: Props) => {
+  const { production_runs, isLoading } = useProductionRuns({
+    design_id: design.id,
+    limit: 50,
+    offset: 0,
+  })
+
+  const runs = production_runs || []
+  const preview = runs.slice(0, PREVIEW_COUNT)
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex items-center gap-x-2">
+          <Heading level="h2">Production Runs</Heading>
+          {!isLoading && (
+            <Badge size="2xsmall" color="grey" rounded="full">
+              {runs.length}
+            </Badge>
+          )}
+        </div>
+        <div className="flex items-center gap-x-2">
+          <Link to="production-run">
+            <Button variant="secondary" size="small">
+              <Plus className="mr-1" />
+              New Run
+            </Button>
+          </Link>
+          {runs.length > 0 && (
+            <Button asChild variant="transparent" size="small">
+              <Link to="production-runs">View all</Link>
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2 px-3 py-3">
+        {isLoading ? (
+          <>
+            <Skeleton className="h-12 w-full rounded-md" />
+            <Skeleton className="h-12 w-full rounded-md" />
+          </>
+        ) : runs.length === 0 ? (
+          <div className="flex items-center justify-center py-4">
+            <Text size="small" className="text-ui-fg-subtle">
+              No production runs yet
+            </Text>
+          </div>
+        ) : (
+          <>
+            {preview.map((run: any) => (
+              <Link
+                key={run.id}
+                to={`production-runs`}
+                className="outline-none focus-within:shadow-borders-interactive-with-focus rounded-md [&:hover>div]:bg-ui-bg-component-hover"
+              >
+                <div className="shadow-elevation-card-rest bg-ui-bg-component flex items-center justify-between rounded-md px-4 py-2.5 transition-colors">
+                  <div className="flex flex-col">
+                    <Text size="small" leading="compact" weight="plus">
+                      {run.run_type === "sample" ? "Sample" : "Production"} ·{" "}
+                      {run.quantity} pc{run.quantity !== 1 ? "s" : ""}
+                    </Text>
+                    <Text size="xsmall" className="text-ui-fg-subtle">
+                      {run.id}
+                    </Text>
+                  </div>
+                  <div className="flex items-center gap-x-2">
+                    <Badge size="2xsmall" color={statusColor(String(run.status))}>
+                      {String(run.status).replace(/_/g, " ")}
+                    </Badge>
+                    <TriangleRightMini className="text-ui-fg-muted" />
+                  </div>
+                </div>
+              </Link>
+            ))}
+            {runs.length > PREVIEW_COUNT && (
+              <Link
+                to="production-runs"
+                className="text-ui-fg-interactive hover:text-ui-fg-interactive-hover px-1 py-1"
+              >
+                <Text size="small" leading="compact">
+                  View all {runs.length} runs →
+                </Text>
+              </Link>
+            )}
+          </>
+        )}
+      </div>
+    </Container>
+  )
+}

--- a/apps/backend/src/admin/components/designs/design-tasks-summary.tsx
+++ b/apps/backend/src/admin/components/designs/design-tasks-summary.tsx
@@ -1,0 +1,97 @@
+import { Badge, Button, Container, Heading, Text } from "@medusajs/ui"
+import { TriangleRightMini } from "@medusajs/icons"
+import { Link } from "react-router-dom"
+
+import { AdminDesign } from "../../hooks/api/designs"
+
+interface Props {
+  design: AdminDesign
+}
+
+const PREVIEW_COUNT = 3
+
+const taskStatusColor = (status: string): "green" | "orange" | "red" | "grey" => {
+  switch (status) {
+    case "completed":
+      return "green"
+    case "in_progress":
+      return "orange"
+    case "cancelled":
+      return "red"
+    default:
+      return "grey"
+  }
+}
+
+/**
+ * Compact tasks card for the design detail page (roadmap #8). Shows the
+ * count + a few tasks and links to the dedicated sub-page
+ * (/designs/:id/tasks) for the full task list + management.
+ */
+export const DesignTasksSummary = ({ design }: Props) => {
+  const tasks = ((design as any)?.tasks || []) as any[]
+  const preview = tasks.slice(0, PREVIEW_COUNT)
+  const doneCount = tasks.filter((t: any) => String(t.status) === "completed").length
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex items-center gap-x-2">
+          <Heading level="h2">Tasks</Heading>
+          {tasks.length > 0 && (
+            <Badge size="2xsmall" color="grey" rounded="full">
+              {doneCount}/{tasks.length}
+            </Badge>
+          )}
+        </div>
+        {tasks.length > 0 && (
+          <Button asChild variant="transparent" size="small">
+            <Link to="tasks">View all</Link>
+          </Button>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2 px-3 py-3">
+        {tasks.length === 0 ? (
+          <div className="flex items-center justify-center py-4">
+            <Text size="small" className="text-ui-fg-subtle">
+              No tasks for this design yet
+            </Text>
+          </div>
+        ) : (
+          <>
+            {preview.map((task: any) => (
+              <Link
+                key={task.id}
+                to="tasks"
+                className="outline-none focus-within:shadow-borders-interactive-with-focus rounded-md [&:hover>div]:bg-ui-bg-component-hover"
+              >
+                <div className="shadow-elevation-card-rest bg-ui-bg-component flex items-center justify-between gap-3 rounded-md px-4 py-2.5 transition-colors">
+                  <Text size="small" leading="compact" weight="plus" className="truncate">
+                    {task.title || task.id}
+                  </Text>
+                  <div className="flex shrink-0 items-center gap-x-2">
+                    <Badge size="2xsmall" color={taskStatusColor(String(task.status))}>
+                      {String(task.status || "pending").replace(/_/g, " ")}
+                    </Badge>
+                    <TriangleRightMini className="text-ui-fg-muted" />
+                  </div>
+                </div>
+              </Link>
+            ))}
+            {tasks.length > PREVIEW_COUNT && (
+              <Link
+                to="tasks"
+                className="text-ui-fg-interactive hover:text-ui-fg-interactive-hover px-1 py-1"
+              >
+                <Text size="small" leading="compact">
+                  View all {tasks.length} tasks →
+                </Text>
+              </Link>
+            )}
+          </>
+        )}
+      </div>
+    </Container>
+  )
+}

--- a/apps/backend/src/admin/routes/designs/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/designs/[id]/page.tsx
@@ -1,8 +1,8 @@
 import { LoaderFunctionArgs, UIMatch, useLoaderData, useParams } from "react-router-dom";
 import { AdminDesignResponse, useDesign } from "../../../hooks/api/designs";
 import { DesignGeneralSection } from "../../../components/designs/design-general-section";
-import { DesignPartnerSection } from "../../../components/designs/design-partner-section";
-import { DesignTasksSection } from "../../../components/designs/design-tasks-section";
+import { DesignPartnerSummary } from "../../../components/designs/design-partner-summary";
+import { DesignTasksSummary } from "../../../components/designs/design-tasks-summary";
 import { DesignMediaSection } from "../../../components/designs/design-media-section";
 import { DesignMediaFolderSection } from "../../../components/designs/design-media-folder-section";
 import { DesignInventorySection } from "../../../components/designs/design-inventory-section";
@@ -70,8 +70,8 @@ const DesignDetailPage = () => {
         <TwoColumnPage.Main>
           <DesignGeneralSection design={design} />
           <DesignProductionRunsSummary design={design} />
-          <DesignTasksSection design={design} />
-          <DesignPartnerSection design={design} />
+          <DesignTasksSummary design={design} />
+          <DesignPartnerSummary design={design} />
           <DesignInventorySection design={design} />
           <DesignConsumptionLogsSection design={design} />
         </TwoColumnPage.Main>

--- a/apps/backend/src/admin/routes/designs/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/designs/[id]/page.tsx
@@ -8,7 +8,7 @@ import { DesignMediaFolderSection } from "../../../components/designs/design-med
 import { DesignInventorySection } from "../../../components/designs/design-inventory-section";
 import { DesignConsumptionLogsSection } from "../../../components/designs/design-consumption-logs-section";
 import { DesignAttributesSection } from "../../../components/designs/design-attributes-section";
-import { DesignProductionRunsSection } from "../../../components/designs/design-production-runs-section";
+import { DesignProductionRunsSummary } from "../../../components/designs/design-production-runs-summary";
 import { DesignComponentsSection } from "../../../components/designs/design-components-section";
 import { TwoColumnPageSkeleton } from "../../../components/table/skeleton";
 import { TwoColumnPage } from "../../../components/pages/two-column-pages";
@@ -69,7 +69,7 @@ const DesignDetailPage = () => {
       >
         <TwoColumnPage.Main>
           <DesignGeneralSection design={design} />
-          <DesignProductionRunsSection design={design} />
+          <DesignProductionRunsSummary design={design} />
           <DesignTasksSection design={design} />
           <DesignPartnerSection design={design} />
           <DesignInventorySection design={design} />

--- a/apps/backend/src/admin/routes/designs/[id]/partners/page.tsx
+++ b/apps/backend/src/admin/routes/designs/[id]/partners/page.tsx
@@ -1,0 +1,32 @@
+import { useParams } from "react-router-dom"
+
+import { useDesign } from "../../../../hooks/api/designs"
+import { DesignPartnerSection } from "../../../../components/designs/design-partner-section"
+import { SingleColumnPageSkeleton } from "../../../../components/table/skeleton"
+
+/**
+ * Dedicated partners sub-page for a design (roadmap #8). The detail page
+ * shows a compact summary card; "View all" links here for the full list +
+ * management. Reuses the existing DesignPartnerSection. Breadcrumb via the
+ * route handle.
+ */
+export default function DesignPartnersPage() {
+  const { id } = useParams()
+  const { design, isLoading } = useDesign(id!, {
+    fields: ["partners.*"],
+  })
+
+  if (isLoading || !design) {
+    return <SingleColumnPageSkeleton sections={1} />
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-y-3">
+      <DesignPartnerSection design={design} />
+    </div>
+  )
+}
+
+export const handle = {
+  breadcrumb: () => "Partners",
+}

--- a/apps/backend/src/admin/routes/designs/[id]/production-runs/page.tsx
+++ b/apps/backend/src/admin/routes/designs/[id]/production-runs/page.tsx
@@ -1,0 +1,33 @@
+import { useParams } from "react-router-dom"
+
+import { useDesign } from "../../../../hooks/api/designs"
+import { DesignProductionRunsSection } from "../../../../components/designs/design-production-runs-section"
+import { SingleColumnPageSkeleton } from "../../../../components/table/skeleton"
+
+/**
+ * Dedicated production-runs sub-page for a design (roadmap #8). The design
+ * detail page shows a compact summary card; "View all" links here for the
+ * full runs list. Reuses the existing DesignProductionRunsSection. The
+ * breadcrumb comes from the route `handle` below (the admin shell renders
+ * the trail), so no hand-rolled back link is needed.
+ */
+export default function DesignProductionRunsPage() {
+  const { id } = useParams()
+  const { design, isLoading } = useDesign(id!, {
+    fields: ["partners.*"],
+  })
+
+  if (isLoading || !design) {
+    return <SingleColumnPageSkeleton sections={1} />
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-y-3">
+      <DesignProductionRunsSection design={design} />
+    </div>
+  )
+}
+
+export const handle = {
+  breadcrumb: () => "Production Runs",
+}

--- a/apps/backend/src/admin/routes/designs/[id]/tasks/page.tsx
+++ b/apps/backend/src/admin/routes/designs/[id]/tasks/page.tsx
@@ -1,0 +1,38 @@
+import { useParams } from "react-router-dom"
+
+import { useDesign } from "../../../../hooks/api/designs"
+import { DesignTasksSection } from "../../../../components/designs/design-tasks-section"
+import { SingleColumnPageSkeleton } from "../../../../components/table/skeleton"
+
+/**
+ * Dedicated tasks sub-page for a design (roadmap #8). The detail page
+ * shows a compact summary card; "View all" links here for the full task
+ * list + management. Reuses the existing DesignTasksSection. The task
+ * create/edit modals continue to live under the @tasks routes. Breadcrumb
+ * via the route handle.
+ */
+export default function DesignTasksPage() {
+  const { id } = useParams()
+  const { design, isLoading } = useDesign(id!, {
+    fields: [
+      "tasks.*",
+      "tasks.subtasks.*",
+      "tasks.outgoing.*",
+      "tasks.incoming.*",
+    ],
+  })
+
+  if (isLoading || !design) {
+    return <SingleColumnPageSkeleton sections={1} />
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-y-3">
+      <DesignTasksSection design={design} />
+    </div>
+  )
+}
+
+export const handle = {
+  breadcrumb: () => "Tasks",
+}


### PR DESCRIPTION
Roadmap **#8** — cleaner admin design-detail UX via summary cards + nested sub-pages (the approach you chose).

## What
The design detail page stacked the full **Production Runs** section inline (one of 10 stacked sections). Replaced it with:
- **`DesignProductionRunsSummary`** — a compact card on the detail page: count badge + latest 2 runs (type · qty + status) + **New Run** / **View all**.
- **`/designs/:id/production-runs`** — a new nested route that renders the full existing `DesignProductionRunsSection` standalone, with its breadcrumb supplied via the route `handle` (no hand-rolled back link).

## Verified (Playwright, running admin)
- Detail page: compact card (0 Cancel buttons), other sections (Tasks, Partners, …) intact, "View all" present.
- `/designs/:id/production-runs`: renders **standalone** (full list with Cancel/New Run; no other detail sections) + "Production Runs" breadcrumb.

## Next (same recipe, follow-ups)
Tasks and Partners sections → summary card + nested sub-page, following this exact pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)