### PR TITLE
fix(partner): cancelled-assignment desync + cancel cancels runs + v1 removal plan

### DIFF
--- a/apps/backend/integration-tests/helpers/seed-email-templates.ts
+++ b/apps/backend/integration-tests/helpers/seed-email-templates.ts
@@ -1,0 +1,71 @@
+import { AxiosInstance } from "axios"
+
+/**
+ * Common email templates that production subscribers/workflows expect to
+ * exist. Many subscribers (order.placed, partner provisioning, design
+ * production lifecycle, partner order lifecycle) throw if their template
+ * is missing — which surfaces as unrelated failures in integration tests
+ * that merely trigger those flows as a side effect.
+ *
+ * Instead of every spec re-seeding its own subset, call
+ * `seedCommonEmailTemplates(api, adminHeaders)` once in `beforeAll`.
+ * Seeding is idempotent: POSTs that collide with an existing key are
+ * ignored, so it's safe to call from multiple suites in the shared runner.
+ *
+ * Keys mirror the `templateKey` values used in
+ * `src/workflows/email/workflows/*`.
+ */
+const COMMON_EMAIL_TEMPLATES = [
+  {
+    name: "Admin Partner Created",
+    template_key: "partner-created-from-admin",
+    subject: "You're invited to set up your partner account at {{partner_name}}",
+    html_content: "<div>Partner {{partner_name}} created. Temp password: {{temp_password}}</div>",
+    from: "partners@jaalyantra.com",
+  },
+  {
+    name: "Design Production Started",
+    template_key: "design-production-started",
+    subject: "Production started for {{design_name}}",
+    html_content: "<div>Production for {{design_name}} has started.</div>",
+    from: "designs@jaalyantra.com",
+  },
+  {
+    name: "Design Production Completed",
+    template_key: "design-production-completed",
+    subject: "Production completed for {{design_name}}",
+    html_content: "<div>Production for {{design_name}} is complete.</div>",
+    from: "designs@jaalyantra.com",
+  },
+  { name: "Order Placed", template_key: "order-placed", subject: "Your order is confirmed", html_content: "<div>Thanks for your order.</div>", from: "orders@jaalyantra.com" },
+  { name: "Order Shipment Created", template_key: "order-shipment-created", subject: "Your order has shipped", html_content: "<div>Shipped.</div>", from: "orders@jaalyantra.com" },
+  { name: "Order Shipment Delivered", template_key: "order-shipment-delivered", subject: "Your order was delivered", html_content: "<div>Delivered.</div>", from: "orders@jaalyantra.com" },
+  { name: "Customer Created", template_key: "customer-created", subject: "Welcome", html_content: "<div>Welcome.</div>", from: "orders@jaalyantra.com" },
+  { name: "Password Reset", template_key: "password-reset", subject: "Reset your password", html_content: "<div>Reset.</div>", from: "orders@jaalyantra.com" },
+  { name: "Design Assigned", template_key: "design-assigned", subject: "A design was assigned", html_content: "<div>Assigned.</div>", from: "designs@jaalyantra.com" },
+  { name: "Partner Order Placed", template_key: "partner-order-placed", subject: "New order", html_content: "<div>New order.</div>", from: "orders@jaalyantra.com" },
+  { name: "Partner Order Fulfilled", template_key: "partner-order-fulfilled", subject: "Order fulfilled", html_content: "<div>Fulfilled.</div>", from: "orders@jaalyantra.com" },
+  { name: "Partner Order Cancelled", template_key: "partner-order-cancelled", subject: "Order cancelled", html_content: "<div>Cancelled.</div>", from: "orders@jaalyantra.com" },
+]
+
+/**
+ * Idempotently seed the common email templates.
+ * @param api      the shared test AxiosInstance
+ * @param adminHeaders `{ headers: { Authorization, ... } }` from getAuthHeaders
+ */
+export async function seedCommonEmailTemplates(
+  api: AxiosInstance,
+  adminHeaders: { headers: Record<string, string> }
+): Promise<void> {
+  for (const tpl of COMMON_EMAIL_TEMPLATES) {
+    try {
+      await api.post(
+        "/admin/email-templates",
+        { ...tpl, variables: {}, template_type: "email" },
+        adminHeaders
+      )
+    } catch {
+      // Already exists (duplicate key) or non-fatal — ignore.
+    }
+  }
+}

--- a/apps/backend/integration-tests/http/order-placed-production-runs.spec.ts
+++ b/apps/backend/integration-tests/http/order-placed-production-runs.spec.ts
@@ -3,6 +3,7 @@ import type { IOrderModuleService } from "@medusajs/types"
 
 import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
 import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { seedCommonEmailTemplates } from "../helpers/seed-email-templates"
 import orderPlacedHandler from "../../src/subscribers/order-placed"
 
 jest.setTimeout(60 * 1000)
@@ -16,46 +17,10 @@ setupSharedTestSuite(() => {
       await createAdminUser(getContainer())
       adminHeaders = await getAuthHeaders(api)
 
-      // Create email templates used by workflows (ignore if already exists)
-      const emailTemplates = [
-        {
-          name: "Admin Partner Created",
-          template_key: "partner-created-from-admin",
-          subject: "You're invited to set up your partner account at {{partner_name}}",
-          html_content: `<div>Partner {{partner_name}} created. Temp password: {{temp_password}}</div>`,
-          from: "partners@jaalyantra.com",
-          variables: {
-            partner_name: "Partner display name",
-            temp_password: "Temporary password issued to the partner admin",
-          },
-          template_type: "email",
-        },
-        {
-          name: "Design Production Started",
-          template_key: "design-production-started",
-          subject: "Production started for {{design_name}}",
-          html_content: "<div>Production for {{design_name}} has started.</div>",
-          from: "designs@jaalyantra.com",
-          variables: { design_name: "name" },
-          template_type: "email",
-        },
-        {
-          name: "Design Production Completed",
-          template_key: "design-production-completed",
-          subject: "Production completed for {{design_name}}",
-          html_content: "<div>Production for {{design_name}} is complete.</div>",
-          from: "designs@jaalyantra.com",
-          variables: { design_name: "name" },
-          template_type: "email",
-        },
-      ]
-      for (const tpl of emailTemplates) {
-        try {
-          await api.post("/admin/email-templates", tpl, adminHeaders)
-        } catch (e: any) {
-          // ok
-        }
-      }
+      // Seed the common email templates production subscribers expect
+      // (order.placed, partner provisioning, design lifecycle, …) so flows
+      // triggered as a side effect don't throw on a missing template.
+      await seedCommonEmailTemplates(api, adminHeaders)
     })
 
     it("should create ProductionRuns per order line item with linked product→design and be idempotent", async () => {

--- a/apps/backend/integration-tests/http/partner-cancel-reassign-desync.spec.ts
+++ b/apps/backend/integration-tests/http/partner-cancel-reassign-desync.spec.ts
@@ -77,6 +77,7 @@ setupSharedTestSuite(() => {
         adminHeaders
       )
       expect(run1.status).toBe(201)
+      const run1ChildId = run1.data.children?.[0]?.id
 
       // Cancel the partner assignment → sets partner_assignment_cancelled_at
       const cancelRes = await api.post(
@@ -85,6 +86,13 @@ setupSharedTestSuite(() => {
         adminHeaders
       )
       expect(cancelRes.status).toBeLessThan(300)
+
+      // Cancelling the assignment must also cancel the partner's active run
+      // (so no non-terminal run lingers for the partner to keep working).
+      if (run1ChildId) {
+        const runDoc = await api.get(`/admin/production-runs/${run1ChildId}`, adminHeaders)
+        expect(runDoc.data.production_run?.status).toBe("cancelled")
+      }
 
       // Run #1 predates the cancel, so it must NOT supersede it — design
       // reports cancelled for the partner.

--- a/apps/backend/integration-tests/http/partner-cancel-reassign-desync.spec.ts
+++ b/apps/backend/integration-tests/http/partner-cancel-reassign-desync.spec.ts
@@ -1,0 +1,113 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+
+jest.setTimeout(60 * 1000)
+
+// Regression: a cancelled partner assignment followed by a NEW production
+// run for the same partner must not leave the design stuck at
+// partner_status="cancelled". Two safeguards are exercised:
+//  1. approveProductionRunWorkflow clears the stale
+//     design.metadata.partner_assignment_cancelled_at marker on re-assign.
+//  2. the /partners/designs[/:id] derivation treats the cancel marker as
+//     superseded by a run created after the cancellation (read-time heal).
+setupSharedTestSuite(() => {
+  describe("Partner cancel → re-assign desync", () => {
+    const { api, getContainer } = getSharedTestEnv()
+    let adminHeaders: { headers: Record<string, string> }
+
+    async function createPartner(unique: number) {
+      const email = `cancel-desync-${unique}@jyt.test`
+      const password = "supersecret"
+      await api.post("/auth/partner/emailpass/register", { email, password })
+      let login = await api.post("/auth/partner/emailpass", { email, password })
+      let headers = { Authorization: `Bearer ${login.data.token}` }
+      const res = await api.post(
+        "/partners",
+        {
+          name: `Cancel Desync ${unique}`,
+          handle: `cancel-desync-${unique}`,
+          admin: { email, first_name: "Test", last_name: "Partner" },
+        },
+        { headers }
+      )
+      expect(res.status).toBe(200)
+      login = await api.post("/auth/partner/emailpass", { email, password })
+      return {
+        partnerId: res.data.partner.id,
+        partnerHeaders: { Authorization: `Bearer ${login.data.token}` },
+      }
+    }
+
+    beforeAll(async () => {
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+      // template used by the partner-created subscriber (ignore failures)
+      try {
+        await api.post(
+          "/admin/email-templates",
+          {
+            name: "Admin Partner Created",
+            template_key: "partner-created-from-admin",
+            subject: "s",
+            html_content: "<div>ok</div>",
+            from: "t@t.com",
+            variables: {},
+            template_type: "email",
+          },
+          adminHeaders
+        )
+      } catch {}
+    })
+
+    it("clears the cancel marker and restores partner_status on re-assignment", async () => {
+      const unique = Date.now()
+      const { partnerId, partnerHeaders } = await createPartner(unique)
+
+      const designRes = await api.post(
+        "/admin/designs",
+        { name: `Cancel Desync Design ${unique}`, description: "x", design_type: "Original", status: "Conceptual", priority: "Medium" },
+        adminHeaders
+      )
+      const designId = designRes.data.design.id
+
+      // Run #1 assigned to the partner — auto-links (design,partner) (#27)
+      const run1 = await api.post(
+        `/admin/designs/${designId}/production-runs`,
+        { run_type: "production", quantity: 2, assignments: [{ partner_id: partnerId, quantity: 2 }] },
+        adminHeaders
+      )
+      expect(run1.status).toBe(201)
+
+      // Cancel the partner assignment → sets partner_assignment_cancelled_at
+      const cancelRes = await api.post(
+        `/admin/designs/${designId}/cancel-partner-assignment`,
+        { partner_id: partnerId },
+        adminHeaders
+      )
+      expect(cancelRes.status).toBeLessThan(300)
+
+      // Run #1 predates the cancel, so it must NOT supersede it — design
+      // reports cancelled for the partner.
+      const afterCancel = await api.get(`/partners/designs/${designId}`, { headers: partnerHeaders })
+      expect(afterCancel.data.design?.partner_info?.partner_status).toBe("cancelled")
+
+      // Re-assign via a NEW production run (created after the cancel)
+      const run2 = await api.post(
+        `/admin/designs/${designId}/production-runs`,
+        { run_type: "production", quantity: 3, assignments: [{ partner_id: partnerId, quantity: 3 }] },
+        adminHeaders
+      )
+      expect(run2.status).toBe(201)
+
+      // partner_status must no longer be "cancelled" (marker cleared on
+      // approve + superseded by the newer run at read time)
+      const afterReassign = await api.get(`/partners/designs/${designId}`, { headers: partnerHeaders })
+      expect(afterReassign.data.design?.partner_info?.partner_status).not.toBe("cancelled")
+
+      // and the stale marker is gone from metadata
+      const designDoc = await api.get(`/admin/designs/${designId}?fields=id,metadata`, adminHeaders)
+      const meta = designDoc.data.design?.metadata || {}
+      expect(meta.partner_assignment_cancelled_at == null).toBe(true)
+    })
+  })
+})

--- a/apps/backend/src/api/admin/designs/[id]/cancel-partner-assignment/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/cancel-partner-assignment/route.ts
@@ -3,6 +3,7 @@ import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/util
 import { DESIGN_MODULE } from "../../../../../modules/designs"
 import { PARTNER_MODULE } from "../../../../../modules/partner"
 import { TASKS_MODULE } from "../../../../../modules/tasks"
+import { PRODUCTION_RUNS_MODULE } from "../../../../../modules/production_runs"
 import { cancelWorkflowTransactionWorkflow } from "../../../../../workflows/designs/design-steps"
 
 const V1_TASK_TITLES = [
@@ -117,6 +118,61 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     }
   }
 
+  // Step 2.5: Cancel the partner's active production runs for this design.
+  // Cancelling the assignment must also cancel the work — otherwise a
+  // non-terminal run lingers that the partner can still drive to
+  // completion via the v2 /partners/production-runs endpoints (which only
+  // guard on the run's own status). Terminal runs (completed/cancelled)
+  // are left as-is.
+  const cancelledRunIds: string[] = []
+  try {
+    const productionRunService = req.scope.resolve(
+      PRODUCTION_RUNS_MODULE
+    ) as any
+    const taskService = req.scope.resolve(TASKS_MODULE) as any
+    const { data: runs } = await query.graph({
+      entity: "production_runs",
+      filters: {
+        design_id: designId,
+        partner_id,
+        status: { $nin: ["completed", "cancelled"] },
+      },
+      fields: ["id", "status"],
+    })
+    for (const run of runs || []) {
+      await productionRunService.updateProductionRuns({
+        id: run.id,
+        status: "cancelled",
+        cancelled_at: new Date(),
+        cancelled_reason: "partner_assignment_cancelled",
+      })
+      cancelledRunIds.push(run.id)
+      // Cancel the run's non-terminal tasks too
+      try {
+        const { data: runData } = await query.graph({
+          entity: "production_runs",
+          fields: ["tasks.id", "tasks.status"],
+          filters: { id: run.id },
+        })
+        for (const task of runData?.[0]?.tasks || []) {
+          if (task.status !== "completed" && task.status !== "cancelled") {
+            await taskService.updateTasks({ id: task.id, status: "cancelled" })
+          }
+        }
+      } catch (e: any) {
+        console.error(
+          `[cancel-partner-assignment] Failed to cancel tasks for run ${run.id}:`,
+          e.message
+        )
+      }
+    }
+  } catch (e: any) {
+    console.error(
+      "[cancel-partner-assignment] Failed to cancel production runs:",
+      e.message
+    )
+  }
+
   // Step 3: Reset design metadata via service directly (workflow merge preserves old keys)
   try {
     const designService = req.scope.resolve(DESIGN_MODULE) as any
@@ -154,7 +210,8 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     partner_id,
     transaction_id: transactionId,
     cancelled_tasks: cancelledTaskIds.length,
+    cancelled_runs: cancelledRunIds.length,
     unlinked: unlink,
-    message: `Partner assignment cancelled.${transactionId ? ` Workflow transaction ${transactionId} cancelled.` : ""} ${cancelledTaskIds.length} task(s) cancelled.${unlink ? " Partner unlinked." : " Partner still linked — ready for production run."}`,
+    message: `Partner assignment cancelled.${transactionId ? ` Workflow transaction ${transactionId} cancelled.` : ""} ${cancelledTaskIds.length} task(s) cancelled.${cancelledRunIds.length ? ` ${cancelledRunIds.length} run(s) cancelled.` : ""}${unlink ? " Partner unlinked." : " Partner still linked — ready for production run."}`,
   })
 }

--- a/apps/backend/src/api/partners/designs/[designId]/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/route.ts
@@ -169,11 +169,8 @@ export const GET = async (
   })
 
   const designMeta = (workflowDesign as any)?.metadata || (linkData.design as any)?.metadata || {}
-  const wasCancelled = !!designMeta.partner_assignment_cancelled_at
+  const cancelledAt = designMeta.partner_assignment_cancelled_at as string | undefined
 
-  // Primary source: production runs (the single system post-v1 migration)
-  let partner_status: "incoming" | "assigned" | "in_progress" | "awaiting_review" | "finished" | "completed" | "cancelled" =
-    wasCancelled ? "cancelled" : "incoming"
   let partner_phase: "redo" | null = null
   let partner_started_at: string | null = null
   let partner_finished_at: string | null = null
@@ -190,10 +187,28 @@ export const GET = async (
       partner_id: partner.id,
       status: { $nin: ["cancelled"] },
     },
-    fields: ["id", "status", "accepted_at", "started_at", "finished_at", "completed_at"],
+    fields: ["id", "status", "accepted_at", "started_at", "finished_at", "completed_at", "created_at"],
     pagination: { skip: 0, take: 10 },
   })
   const allRuns = (runs || []) as any[]
+
+  // A stale cancellation marker should not pin the status to "cancelled"
+  // once the partner has been re-assigned. If any non-cancelled run was
+  // created after the cancellation timestamp, treat the cancellation as
+  // superseded (the new run is the source of truth). Newly-approved runs
+  // also clear the marker outright in approveProductionRunWorkflow; this
+  // read-time guard self-heals designs cancelled before that fix landed.
+  const supersededByNewerRun =
+    !!cancelledAt &&
+    allRuns.some(
+      (r) => r?.created_at && new Date(r.created_at).getTime() > new Date(cancelledAt).getTime()
+    )
+  const wasCancelled = !!cancelledAt && !supersededByNewerRun
+
+  // Primary source: production runs (the single system post-v1 migration)
+  let partner_status: "incoming" | "assigned" | "in_progress" | "awaiting_review" | "finished" | "completed" | "cancelled" =
+    wasCancelled ? "cancelled" : "incoming"
+
   // Prefer an active run over a completed one
   const activeRun =
     allRuns.find((r) => ["in_progress", "sent_to_partner", "approved", "pending_review"].includes(String(r.status))) ||

--- a/apps/backend/src/api/partners/designs/route.ts
+++ b/apps/backend/src/api/partners/designs/route.ts
@@ -235,7 +235,7 @@ export async function GET(
         partner_id: partner.id,
         status: { $nin: ["cancelled"] },
       },
-      fields: ["id", "design_id", "status", "accepted_at", "started_at", "finished_at", "completed_at"],
+      fields: ["id", "design_id", "status", "accepted_at", "started_at", "finished_at", "completed_at", "created_at"],
       pagination: { skip: 0, take: 200 },
     }, { locale: req.locale })
     partnerRuns = runs || []
@@ -310,7 +310,16 @@ export async function GET(
       .filter((r: any) => r.design_id === design.id)
       .sort((a: any, b: any) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
     const activeRun = runsForDesign.find((r: any) => !["completed", "cancelled"].includes(r.status)) || runsForDesign[0]
-    if (activeRun) {
+    // A run only supersedes a cancellation marker if it was created after
+    // the cancellation (a genuine re-assignment) — mirrors the detail
+    // endpoint. Runs predating the cancel must not resurrect the design.
+    const cancelledAt = design?.metadata?.partner_assignment_cancelled_at as string | undefined
+    const runSupersedesCancel =
+      !wasCancelled ||
+      (!!activeRun?.created_at &&
+        !!cancelledAt &&
+        new Date(activeRun.created_at).getTime() > new Date(cancelledAt).getTime())
+    if (activeRun && runSupersedesCancel) {
       const runStatus = String(activeRun.status)
       if (runStatus === "sent_to_partner") {
         partnerStatus = "assigned"

--- a/apps/backend/src/workflows/production-runs/approve-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/approve-production-run.ts
@@ -265,6 +265,83 @@ const linkDesignToPartnersStep = createStep(
   }
 )
 
+// Re-assigning a partner via a production run supersedes any prior
+// cancellation of that design's partner assignment. The legacy cancel
+// marker (`design.metadata.partner_assignment_cancelled_at`) otherwise
+// pins `partner_status` to "cancelled" forever — even after a new run is
+// created and completed — because the partner_status derivation
+// short-circuits on the flag (see /partners/designs/[designId]/route.ts).
+// Clear it here so the design reflects the new assignment.
+type ClearCancelMarkerComp = {
+  design_id: string
+  prev: {
+    partner_assignment_cancelled_at: string | null
+    partner_assignment_cancelled_partner_id: string | null
+  }
+}
+
+const clearDesignCancelMarkerStep = createStep(
+  "clear-design-cancel-marker",
+  async (
+    input: { design_id: string | null; partner_ids: string[] },
+    { container }
+  ) => {
+    if (!input.design_id || !input.partner_ids.length) {
+      return new StepResponse<{ cleared: boolean }, ClearCancelMarkerComp>({ cleared: false })
+    }
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const designService: any = container.resolve(DESIGN_MODULE)
+
+    const { data } = await query.graph({
+      entity: "design",
+      filters: { id: input.design_id },
+      fields: ["id", "metadata"],
+    })
+    const meta = (data?.[0]?.metadata as Record<string, any>) || {}
+    if (
+      meta.partner_assignment_cancelled_at == null &&
+      meta.partner_assignment_cancelled_partner_id == null
+    ) {
+      // Nothing to clear — skip the write (and the compensation no-ops).
+      return new StepResponse<{ cleared: boolean }, ClearCancelMarkerComp>({ cleared: false })
+    }
+
+    const prev = {
+      partner_assignment_cancelled_at: meta.partner_assignment_cancelled_at ?? null,
+      partner_assignment_cancelled_partner_id:
+        meta.partner_assignment_cancelled_partner_id ?? null,
+    }
+    // Medusa merges metadata on update, so omitting keys won't remove
+    // them — set to null (Medusa's metadata-deletion convention).
+    await designService.updateDesigns({
+      id: input.design_id,
+      metadata: {
+        partner_assignment_cancelled_at: null,
+        partner_assignment_cancelled_partner_id: null,
+      },
+    })
+    return new StepResponse<{ cleared: boolean }, ClearCancelMarkerComp>(
+      { cleared: true },
+      { design_id: input.design_id, prev }
+    )
+  },
+  async (compensation: ClearCancelMarkerComp | undefined, { container }) => {
+    if (!compensation?.design_id) return
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const designService: any = container.resolve(DESIGN_MODULE)
+    const { data } = await query.graph({
+      entity: "design",
+      filters: { id: compensation.design_id },
+      fields: ["id", "metadata"],
+    })
+    const meta = (data?.[0]?.metadata as Record<string, any>) || {}
+    await designService.updateDesigns({
+      id: compensation.design_id,
+      metadata: { ...meta, ...compensation.prev },
+    })
+  }
+)
+
 export const approveProductionRunWorkflow = createWorkflow(
   "approve-production-run",
   (input: ApproveProductionRunInput) => {
@@ -302,6 +379,10 @@ export const approveProductionRunWorkflow = createWorkflow(
         .filter((id): id is string => !!id),
     }))
     linkDesignToPartnersStep(designPartnerLinkInput)
+
+    // Clear any stale partner-assignment cancellation marker — this run
+    // is a fresh (re)assignment for the design's partner(s).
+    clearDesignCancelMarkerStep(designPartnerLinkInput)
 
     return new WorkflowResponse(approved)
   }

--- a/apps/docs/notes/V1_PARTNER_DESIGN_REMOVAL_PLAN.md
+++ b/apps/docs/notes/V1_PARTNER_DESIGN_REMOVAL_PLAN.md
@@ -1,0 +1,153 @@
+# V1 Partner-Design Workflow — Removal Plan & Improvements
+
+> Captured 2026-06-07 while fixing the cancelled-assignment desync bug
+> (design `01KE6E3NY88RB64J6D1CCT0E0C`). Maps the legacy "v1" partner-design
+> task workflow so we can retire it now that "v2" production runs are the
+> system of record. This is a **plan**, not executed work — see the
+> phased order at the bottom.
+
+## TL;DR
+
+There are **two parallel partner-work systems**:
+
+- **v1** — partner work modelled as **tasks** titled `partner-design-start`,
+  `partner-design-redo`, `partner-design-finish`, `partner-design-completed`
+  (+ redo children `…-redo-log/-apply/-verify`), driven by async workflow
+  gates (`await-design-*`). Status lives in `design.metadata.partner_*`.
+- **v2** — the `production_runs` module (`prod_run_*`, statuses
+  `sent_to_partner → accepted → in_progress → finished → completed/cancelled`).
+
+The partner-UI has **already cut over to v2** for the work surface
+(`DesignProductionSection`), but v1 is still wired on the **admin assignment
+path**, in the **status-derivation fallback**, and (critically) the v2
+"send to production" path **still creates the v1 task checklist**. So v1
+can't be deleted wholesale yet — it needs a phased retirement.
+
+## The cancelled-assignment bug this came from (fixed)
+
+`design.metadata.partner_assignment_cancelled_at` is set on cancel and was
+**never cleared on re-assignment**, while the v2 production-run endpoints
+ignore it. A design cancelled in March then got a new run that completed
+in June, but still reported `partner_status: "cancelled"`. Fixed in
+`fix/partner-cancel-desync`:
+- `approveProductionRunWorkflow` clears the marker on (re)assignment.
+- the `/partners/designs[/:id]` derivation treats the marker as superseded
+  by any non-cancelled run created **after** the cancel timestamp.
+This is itself a symptom of the v1/v2 split — removing v1 removes the
+class of bug.
+
+## Code map (what is v1)
+
+### A. v1 task creation (workflows)
+- `src/workflows/designs/send-to-partner.ts` — `sendDesignToPartnerWorkflow`
+  creates the 4 main tasks + redo children + the `await-design-*` gates.
+- `src/workflows/designs/complete-partner-design.ts` — completes/cancels the
+  v1 tasks + signals the gates.
+- `src/workflows/designs/design-steps.ts` — `setDesignStepSuccess/Failed`
+  gate-signalling infra (looks up workflow `transaction_id` from tasks).
+- `src/workflows/designs/create-tasks-from-templates.ts` — generic task
+  creation used by the above.
+
+### B. v1 partner API endpoints (`src/api/partners/designs/[designId]/`)
+- `start/`, `finish/`, `redo/`, `refinish/`, `complete/` — each completes a
+  v1 task, writes `metadata.partner_*`, and signals a gate.
+
+### C. v1 admin endpoint
+- `src/api/admin/designs/[id]/send-to-partner/route.ts` — v1 assignment
+  (still invokes `sendDesignToPartnerWorkflow`).
+- `src/api/admin/designs/[id]/cancel-partner-assignment/route.ts` — cancels
+  v1 tasks/transaction + sets `partner_assignment_cancelled_at`.
+
+### D. Status derivation / fallback (dual-source — the bridge)
+- `src/api/partners/designs/[designId]/route.ts` — v2 runs primary, v1-task
+  fallback (`!resolvedFromRun && !wasCancelled`).
+- `src/api/partners/designs/route.ts` (list) — same dual-source shape.
+
+### E. `design.metadata.partner_*` fields
+`partner_status`, `partner_phase`, `partner_started_at`,
+`partner_finished_at`, `partner_completed_at`,
+`partner_assignment_cancelled_at`, `partner_assignment_cancelled_partner_id`
+— written by B/C, read by D + admin/partner UI.
+
+### F. partner-ui
+- **Dead code (safe to delete):** `design-actions-section.tsx` (the v1
+  start/finish/redo buttons) — **not mounted** anywhere; `design-detail.tsx`
+  uses `DesignProductionSection` (v2).
+- v1 mutation hooks in `hooks/api/partner-designs.tsx`:
+  `useStartPartnerDesign`, `useFinishPartnerDesign`, `useRedoPartnerDesign`,
+  `useRefinishPartnerDesign` (+ the `partner_*` fields on
+  `PartnerDesignPartnerInfo`).
+
+### G. admin-ui bridge
+- `src/admin/components/designs/design-partner-section.tsx` — `hasV1Assignment()`
+  mutual-exclusion logic + the "cancel v1 assignment" affordance.
+
+### H. tests
+- `designs-partner-workflow.spec.ts`, `send-to-partner-complete-workflow.spec.ts`,
+  `cancel-workflows.spec.ts`, `design-consumption-logs.spec.ts` (v1 titles),
+  `production-run-partner-status.spec.ts` (v2→v1 fallback bridge).
+
+## The one thing that blocks a clean delete
+
+`sendDesignToPartnerWorkflow` (v1) **still produces the partner's task
+checklist** that the v2 run lifecycle completes. Confirmed on the prod
+design: the v2 run completing also drove `partner-design-*` tasks to
+`completed`. So before deleting v1 task creation, v2 must own the
+partner-facing task list itself (production-run tasks already exist via
+`production-run-prod_run_*` task templates — the checklist needs to move
+fully onto those).
+
+## Phased removal plan
+
+**Phase 0 — land the desync fix (this PR `fix/partner-cancel-desync`).**
+Stops the immediate bleakage; no v1 removal yet.
+
+**Phase 1 — delete confirmed dead code (low risk).**
+- Remove `partner-ui/.../design-actions-section.tsx` (unmounted).
+- Remove the unused v1 mutation hooks if no remaining importers
+  (`useStart/Finish/Redo/RefinishPartnerDesign`) — grep first.
+- No API/behaviour change.
+
+**Phase 2 — make v2 own the partner checklist.**
+- Ensure the production-run task templates fully cover what partners need
+  (start/work/finish/redo). Stop `sendDesignToPartnerWorkflow` from being
+  the source of the checklist; the v2 send/approve path creates the tasks.
+- Keep the v1 task **titles** only if the partner-ui still reads them;
+  otherwise migrate the UI to read run tasks.
+
+**Phase 3 — collapse the status derivation to v2-only.**
+- Delete the v1-task fallback blocks in both `/partners/designs` routes
+  (keep the production-run logic). `partner_status` derives purely from
+  runs. Drop `metadata.partner_*` reads.
+- Replace the `cancel-partner-assignment` flow with **production-run
+  cancellation** (cancel the run(s)); retire `partner_assignment_cancelled_at`.
+
+**Phase 4 — retire v1 endpoints + workflows.**
+- Delete `partners/designs/[id]/{start,finish,redo,refinish,complete}` once
+  the partner-ui no longer calls them.
+- Delete `send-to-partner.ts`, `complete-partner-design.ts`'s v1 bits,
+  `design-steps.ts` gate infra, and the v1 admin `send-to-partner` route.
+- Simplify `design-partner-section.tsx` (drop `hasV1Assignment`).
+- Delete v1-only specs; keep/expand v2 specs.
+
+**Phase 5 — data cleanup (one-off).**
+- Backfill: strip `metadata.partner_*` from designs; optionally archive
+  the historical `partner-design-*` tasks. Mirror the `run-backfill.sh`
+  recipe (dry-run aware, scoped).
+
+## Suggested improvements (independent of removal)
+
+1. **Single source of truth for partner work status** — `partner_status`
+   should derive only from `production_runs`; never from metadata flags.
+   (Phase 3 delivers this.)
+2. **Run cancellation is the cancel** — there should be no separate
+   "assignment cancelled" marker divorced from run state. Cancelling work =
+   cancelling the run.
+3. **Guard the v2 partner endpoints on run state** — `/partners/production-runs/[id]/{accept,start,finish,complete}` should reject transitions on a
+   cancelled/terminal run with a clear error (defence-in-depth; today they
+   rely on the workflow's status check only).
+4. **One partner-work UI** — finish consolidating onto `DesignProductionSection`;
+   delete the dead v1 action UI.
+5. **Typed run-status state machine** — encode allowed transitions in one
+   place (module/service) instead of re-deriving `can*` flags in each route
+   + UI.

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-production-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-production-section.tsx
@@ -425,10 +425,17 @@ const ProductionRunCard = ({
 
   const isCancelled = status === "cancelled"
   const isCompleted = status === "completed"
-  const canAccept = !isCancelled && status === "sent_to_partner"
-  const canStart = !isCancelled && status === "in_progress" && !run.started_at
-  const canFinish = !isCancelled && status === "in_progress" && !!run.started_at && !run.finished_at
-  const canComplete = !isCancelled && status === "in_progress" && !!run.finished_at
+  // Defence-in-depth: if the partner's assignment for this design is
+  // cancelled, no run actions are permitted even if a non-cancelled run
+  // lingers (cancelling the assignment now also cancels the run, but this
+  // guards runs that predate that fix). The run's own status still gates
+  // the individual transitions below.
+  const assignmentCancelled = design?.partner_info?.partner_status === "cancelled"
+  const actionable = !isCancelled && !assignmentCancelled
+  const canAccept = actionable && status === "sent_to_partner"
+  const canStart = actionable && status === "in_progress" && !run.started_at
+  const canFinish = actionable && status === "in_progress" && !!run.started_at && !run.finished_at
+  const canComplete = actionable && status === "in_progress" && !!run.finished_at
 
   const completedTasks = tasks.filter((t: any) => String(t.status) === "completed").length
   const totalTasks = tasks.length


### PR DESCRIPTION
## The bug (prod design `01KE6E3NY88RB64J6D1CCT0E0C`)
A cancelled partner assignment set `design.metadata.partner_assignment_cancelled_at`, which the `partner_status` derivation treats as terminal — but nothing cleared it on re-assignment, and the v2 `/partners/production-runs` endpoints ignore it. The design was cancelled in March, a new run was created 3 min later and completed in June, yet it still reported `partner_status: "cancelled"` while the partner could drive the new run to completion.

## Fixes
1. **Source** — `approveProductionRunWorkflow` clears the cancel marker on (re)assignment (gated: no-op unless `design_id` + partner assignments + an existing marker; metadata keys nulled since Medusa merges metadata; compensation restores).
2. **Self-heal (read-time)** — `/partners/designs[/:id]` treat the marker as superseded by a non-cancelled run created **after** the cancel timestamp (fixes existing designs, no backfill). List route also gains the missing `created_at` field (latent no-op sort).
3. **Defense-in-depth** — `cancel-partner-assignment` now also cancels the partner's active runs (+ their open tasks), so no actionable run lingers; partner-ui `ProductionRunCard` gates actions on `partner_info.partner_status === "cancelled"`.

## Blast radius
Contained to the cancelled-then-reassigned case. Non-cancelled designs behave identically (verified). The approve step is invoked only from 3 admin write paths and no-ops unless a stale marker exists. The other 12 production-run workflows are untouched.

## Tests
- New `partner-cancel-reassign-desync.spec.ts`: cancel→reassign heals + clears marker, run predating the cancel does **not** supersede, and cancel cancels the active run.
- Full production-run suite re-run in batches: **all directly-affected specs green**; the two failures I hit (`cancel-workflows › block /complete` and `order-placed`) both **pre-exist on main**. Fixed the latter (missing `order-placed` template seed) via a reusable `seedCommonEmailTemplates` helper. (`cancel-workflows › block /complete` is a separate pre-existing 2.15.5 error-envelope shape issue — left as-is.)

## Docs
Adds `apps/docs/notes/V1_PARTNER_DESIGN_REMOVAL_PLAN.md` — maps the legacy v1 task workflow and a phased retirement plan (this bug is a symptom of the v1/v2 split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)