### PR TITLE
refactor(partner): production runs as single source of truth for partner_status (incl. cancel-desync fix)

### DIFF
--- a/apps/backend/integration-tests/http/partner-cancel-reassign-desync.spec.ts
+++ b/apps/backend/integration-tests/http/partner-cancel-reassign-desync.spec.ts
@@ -117,5 +117,43 @@ setupSharedTestSuite(() => {
       const meta = designDoc.data.design?.metadata || {}
       expect(meta.partner_assignment_cancelled_at == null).toBe(true)
     })
+
+    it("derives partner_status='cancelled' purely from a cancelled run (no marker)", async () => {
+      const unique = Date.now() + 1
+      const { partnerId, partnerHeaders } = await createPartner(unique)
+
+      const designRes = await api.post(
+        "/admin/designs",
+        { name: `Run Cancel SSOT ${unique}`, description: "x", design_type: "Original", status: "Conceptual", priority: "Medium" },
+        adminHeaders
+      )
+      const designId = designRes.data.design.id
+
+      const run = await api.post(
+        `/admin/designs/${designId}/production-runs`,
+        { run_type: "production", quantity: 1, assignments: [{ partner_id: partnerId, quantity: 1 }] },
+        adminHeaders
+      )
+      expect(run.status).toBe(201)
+      const childId = run.data.children?.[0]?.id
+      expect(childId).toBeTruthy()
+
+      // Cancel the RUN directly (not the assignment) — no metadata marker
+      // is set. Single source of truth: the cancelled run alone must yield
+      // partner_status = "cancelled".
+      const cancelRun = await api.post(
+        `/admin/production-runs/${childId}/cancel`,
+        { reason: "test" },
+        adminHeaders
+      )
+      expect(cancelRun.status).toBeLessThan(300)
+
+      const detail = await api.get(`/partners/designs/${designId}`, { headers: partnerHeaders })
+      expect(detail.data.design?.partner_info?.partner_status).toBe("cancelled")
+
+      // No marker was ever set — proves it's derived from the run, not metadata.
+      const designDoc = await api.get(`/admin/designs/${designId}?fields=id,metadata`, adminHeaders)
+      expect((designDoc.data.design?.metadata || {}).partner_assignment_cancelled_at == null).toBe(true)
+    })
   })
 })

--- a/apps/backend/src/api/partners/designs/[designId]/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/route.ts
@@ -169,7 +169,6 @@ export const GET = async (
   })
 
   const designMeta = (workflowDesign as any)?.metadata || (linkData.design as any)?.metadata || {}
-  const cancelledAt = designMeta.partner_assignment_cancelled_at as string | undefined
 
   let partner_phase: "redo" | null = null
   let partner_started_at: string | null = null
@@ -177,66 +176,69 @@ export const GET = async (
   let partner_completed_at: string | null = null
   let resolvedFromRun = false
 
-  // Fetch all non-cancelled runs for this design+partner, then pick the most
-  // relevant one. Priority: active runs (in_progress, sent_to_partner) over completed.
-  // This handles the case where a second run is created after the first completes.
+  let partner_status: "incoming" | "assigned" | "in_progress" | "awaiting_review" | "finished" | "completed" | "cancelled" =
+    "incoming"
+
+  // ── Single source of truth: production runs ──────────────────────────
+  // For any design that has production runs, status derives PURELY from
+  // those runs — including "cancelled" from a cancelled run. The legacy
+  // `partner_assignment_cancelled_at` marker and v1 task fallback are NOT
+  // consulted here (they only apply to legacy designs that have no runs,
+  // below). Cancelling the assignment cancels the run, so a cancelled
+  // assignment is represented by a cancelled run — no separate flag.
   const { data: runs } = await query.graph({
     entity: "production_runs",
-    filters: {
-      design_id: designId,
-      partner_id: partner.id,
-      status: { $nin: ["cancelled"] },
-    },
+    filters: { design_id: designId, partner_id: partner.id },
     fields: ["id", "status", "accepted_at", "started_at", "finished_at", "completed_at", "created_at"],
-    pagination: { skip: 0, take: 10 },
+    pagination: { skip: 0, take: 50 },
   })
-  const allRuns = (runs || []) as any[]
+  const allRuns = ((runs || []) as any[])
+    .slice()
+    .sort((a, b) => new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime())
 
-  // A stale cancellation marker should not pin the status to "cancelled"
-  // once the partner has been re-assigned. If any non-cancelled run was
-  // created after the cancellation timestamp, treat the cancellation as
-  // superseded (the new run is the source of truth). Newly-approved runs
-  // also clear the marker outright in approveProductionRunWorkflow; this
-  // read-time guard self-heals designs cancelled before that fix landed.
-  const supersededByNewerRun =
-    !!cancelledAt &&
-    allRuns.some(
-      (r) => r?.created_at && new Date(r.created_at).getTime() > new Date(cancelledAt).getTime()
-    )
-  const wasCancelled = !!cancelledAt && !supersededByNewerRun
-
-  // Primary source: production runs (the single system post-v1 migration)
-  let partner_status: "incoming" | "assigned" | "in_progress" | "awaiting_review" | "finished" | "completed" | "cancelled" =
-    wasCancelled ? "cancelled" : "incoming"
-
-  // Prefer an active run over a completed one
-  const activeRun =
-    allRuns.find((r) => ["in_progress", "sent_to_partner", "approved", "pending_review"].includes(String(r.status))) ||
-    allRuns.find((r) => String(r.status) === "completed") ||
-    allRuns[0] || null
-  if (activeRun && !wasCancelled) {
+  if (allRuns.length) {
     resolvedFromRun = true
-    const runStatus = String(activeRun.status)
-    if (runStatus === "completed") {
-      partner_status = "completed"
-      partner_completed_at = activeRun.completed_at ? String(activeRun.completed_at) : null
-    } else if (runStatus === "in_progress") {
-      if (activeRun.finished_at) {
-        partner_status = "awaiting_review"
-      } else if (activeRun.started_at) {
-        partner_status = "in_progress"
+    // An active (non-terminal) run wins over terminal ones; otherwise the
+    // newest run decides (completed vs cancelled).
+    const activeRun = allRuns.find((r) =>
+      ["in_progress", "sent_to_partner", "approved", "pending_review"].includes(String(r.status))
+    )
+    if (activeRun) {
+      const runStatus = String(activeRun.status)
+      if (runStatus === "in_progress") {
+        partner_status = activeRun.finished_at
+          ? "awaiting_review"
+          : activeRun.started_at
+            ? "in_progress"
+            : "assigned"
       } else {
+        // sent_to_partner / approved / pending_review
         partner_status = "assigned"
       }
-    } else if (runStatus === "sent_to_partner") {
-      partner_status = "assigned"
+      if (activeRun.accepted_at) partner_started_at = String(activeRun.accepted_at)
+      if (activeRun.started_at) partner_started_at = String(activeRun.started_at)
+      if (activeRun.finished_at) partner_finished_at = String(activeRun.finished_at)
+    } else {
+      const newest = allRuns[0]
+      const runStatus = String(newest.status)
+      if (runStatus === "completed") {
+        partner_status = "completed"
+        partner_completed_at = newest.completed_at ? String(newest.completed_at) : null
+        if (newest.finished_at) partner_finished_at = String(newest.finished_at)
+      } else if (runStatus === "cancelled") {
+        partner_status = "cancelled"
+      }
     }
-    if (activeRun.accepted_at) partner_started_at = String(activeRun.accepted_at)
-    if (activeRun.started_at) partner_started_at = String(activeRun.started_at)
-    if (activeRun.finished_at) partner_finished_at = String(activeRun.finished_at)
   }
 
-  // Legacy fallback: v1 workflow tasks (only for in-flight v1 designs without a production run)
+  // ── Legacy fallback (designs with NO production runs only) ────────────
+  // Pure-v1 designs predate the production-runs system. Until they're
+  // migrated (see V1_PARTNER_DESIGN_REMOVAL_PLAN.md), honour the cancel
+  // marker, then derive from v1 tasks.
+  const wasCancelled = !resolvedFromRun && !!designMeta.partner_assignment_cancelled_at
+  if (wasCancelled) {
+    partner_status = "cancelled"
+  }
   if (!resolvedFromRun && !wasCancelled) {
     const tasks = (linkData.design?.tasks || []) as Array<{
       title?: string

--- a/apps/backend/src/api/partners/designs/route.ts
+++ b/apps/backend/src/api/partners/designs/route.ts
@@ -231,10 +231,10 @@ export async function GET(
   try {
     const { data: runs } = await query.graph({
       entity: "production_runs",
-      filters: {
-        partner_id: partner.id,
-        status: { $nin: ["cancelled"] },
-      },
+      // Include cancelled runs: production runs are the single source of
+      // truth for partner_status, so a cancelled run is how a cancelled
+      // assignment is represented (no separate metadata marker).
+      filters: { partner_id: partner.id },
       fields: ["id", "design_id", "status", "accepted_at", "started_at", "finished_at", "completed_at", "created_at"],
       pagination: { skip: 0, take: 200 },
     }, { locale: req.locale })
@@ -256,89 +256,92 @@ export async function GET(
       ].includes(t.title)
     const workflowTasks = tasks.filter(isPartnerWorkflowTask)
 
-    // Check if assignment was cancelled
-    const wasCancelled = !!design?.metadata?.partner_assignment_cancelled_at
+    let partnerStatus: "incoming" | "assigned" | "in_progress" | "awaiting_review" | "finished" | "completed" | "cancelled" =
+      "incoming"
+    let partnerPhase: "redo" | null = null
+    let partnerStartedAt: string | null = null
+    let partnerFinishedAt: string | null = null
+    let partnerCompletedAt: string | null = null
 
-    // Derive from metadata first (authoritative), then fall back to task-based inference
-    let partnerStatus: "incoming" | "assigned" | "in_progress" | "finished" | "completed" | "cancelled" =
-      wasCancelled ? "cancelled" : ((design?.metadata?.partner_status as any) || "incoming")
-    let partnerPhase: "redo" | null = (design?.metadata?.partner_phase as any) || null
-    let partnerStartedAt: string | null = (design?.metadata?.partner_started_at as any) || null
-    let partnerFinishedAt: string | null = (design?.metadata?.partner_finished_at as any) || null
-    let partnerCompletedAt: string | null = (design?.metadata?.partner_completed_at as any) || null
-
-    // If redo phase is flagged in metadata, reflect in-progress immediately (deterministic)
-    if (partnerPhase === "redo" && !wasCancelled) {
-      partnerStatus = "in_progress"
-    }
-
-    if (workflowTasks.length > 0) {
-      // start -> redo (optional) -> finish -> completed
-      const startTask = workflowTasks.find((t: any) => t.title === "partner-design-start" && t.status === "completed")
-      const redoTask = workflowTasks.find((t: any) => t.title === "partner-design-redo" && t.status === "completed")
-      const finishTask = workflowTasks.find((t: any) => t.title === "partner-design-finish" && t.status === "completed")
-      const completedTask = workflowTasks.find((t: any) => t.title === "partner-design-completed" && t.status === "completed")
-
-      // If metadata didn't set a terminal state, infer from tasks
-      if (!partnerStatus || partnerStatus === "incoming" || partnerStatus === "assigned") {
-        partnerStatus = "assigned"
-        if (completedTask) {
-          partnerStatus = "completed"
-          partnerCompletedAt = partnerCompletedAt || (completedTask.updated_at ? String(completedTask.updated_at) : null)
-        } else if (redoTask) {
-          // Prefer redo state whenever redo task is completed, regardless of timestamp ordering vs finish
-          partnerStatus = "in_progress"
-          partnerPhase = "redo"
-        } else if (finishTask) {
-          partnerStatus = "finished"
-          partnerFinishedAt = partnerFinishedAt || (finishTask.updated_at ? String(finishTask.updated_at) : null)
-        } else if (startTask) {
-          partnerStatus = "in_progress"
-          partnerStartedAt = partnerStartedAt || (startTask.updated_at ? String(startTask.updated_at) : null)
-        }
-      }
-    }
-
-    // Final safeguard: if phase is redo, ensure status reflects in-progress
-    if (partnerPhase === "redo") {
-      partnerStatus = "in_progress"
-    }
-
-    // Override with production run status if a run exists for this partner + design
-    // Prefer the most recent non-terminal (not completed) run; fall back to most recent overall
+    // ── Single source of truth: production runs (incl. cancelled) ──────
     const runsForDesign = partnerRuns
       .filter((r: any) => r.design_id === design.id)
-      .sort((a: any, b: any) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
-    const activeRun = runsForDesign.find((r: any) => !["completed", "cancelled"].includes(r.status)) || runsForDesign[0]
-    // A run only supersedes a cancellation marker if it was created after
-    // the cancellation (a genuine re-assignment) — mirrors the detail
-    // endpoint. Runs predating the cancel must not resurrect the design.
-    const cancelledAt = design?.metadata?.partner_assignment_cancelled_at as string | undefined
-    const runSupersedesCancel =
-      !wasCancelled ||
-      (!!activeRun?.created_at &&
-        !!cancelledAt &&
-        new Date(activeRun.created_at).getTime() > new Date(cancelledAt).getTime())
-    if (activeRun && runSupersedesCancel) {
-      const runStatus = String(activeRun.status)
-      if (runStatus === "sent_to_partner") {
-        partnerStatus = "assigned"
-      } else if (runStatus === "in_progress") {
-        if (activeRun.finished_at) {
-          // Partner marked finished, waiting for admin to review and complete
-          partnerStatus = "awaiting_review" as any
-          partnerFinishedAt = partnerFinishedAt || String(activeRun.finished_at)
-        } else if (activeRun.started_at) {
-          partnerStatus = "in_progress"
-          partnerStartedAt = partnerStartedAt || String(activeRun.started_at)
+      .sort((a: any, b: any) => new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime())
+    const resolvedFromRun = runsForDesign.length > 0
+    if (resolvedFromRun) {
+      const activeRun = runsForDesign.find(
+        (r: any) => !["completed", "cancelled"].includes(String(r.status))
+      )
+      if (activeRun) {
+        const runStatus = String(activeRun.status)
+        if (runStatus === "in_progress") {
+          partnerStatus = activeRun.finished_at
+            ? "awaiting_review"
+            : activeRun.started_at
+              ? "in_progress"
+              : "assigned"
         } else {
           partnerStatus = "assigned"
         }
-      } else if (runStatus === "completed") {
-        partnerStatus = "completed"
-        partnerCompletedAt = partnerCompletedAt || String(activeRun.completed_at)
+        if (activeRun.started_at) partnerStartedAt = String(activeRun.started_at)
+        if (activeRun.finished_at) partnerFinishedAt = String(activeRun.finished_at)
+      } else {
+        const newest = runsForDesign[0]
+        const runStatus = String(newest.status)
+        if (runStatus === "completed") {
+          partnerStatus = "completed"
+          partnerCompletedAt = newest.completed_at ? String(newest.completed_at) : null
+          if (newest.finished_at) partnerFinishedAt = String(newest.finished_at)
+        } else if (runStatus === "cancelled") {
+          partnerStatus = "cancelled"
+        }
       }
-      if (activeRun.finished_at) partnerFinishedAt = partnerFinishedAt || String(activeRun.finished_at)
+    }
+
+    // ── Legacy fallback (designs with NO production runs only) ─────────
+    if (!resolvedFromRun) {
+      const wasCancelled = !!design?.metadata?.partner_assignment_cancelled_at
+      if (wasCancelled) {
+        partnerStatus = "cancelled"
+      } else {
+        // metadata first, then v1 task inference
+        partnerStatus = (design?.metadata?.partner_status as any) || "incoming"
+        partnerPhase = (design?.metadata?.partner_phase as any) || null
+        partnerStartedAt = (design?.metadata?.partner_started_at as any) || null
+        partnerFinishedAt = (design?.metadata?.partner_finished_at as any) || null
+        partnerCompletedAt = (design?.metadata?.partner_completed_at as any) || null
+
+        if (partnerPhase === "redo") {
+          partnerStatus = "in_progress"
+        }
+
+        if (workflowTasks.length > 0) {
+          const completedTask = workflowTasks.find((t: any) => t.title === "partner-design-completed" && t.status === "completed")
+          const redoTask = workflowTasks.find((t: any) => t.title === "partner-design-redo" && t.status === "completed")
+          const finishTask = workflowTasks.find((t: any) => t.title === "partner-design-finish" && t.status === "completed")
+          const startTask = workflowTasks.find((t: any) => t.title === "partner-design-start" && t.status === "completed")
+
+          if (!partnerStatus || partnerStatus === "incoming" || partnerStatus === "assigned") {
+            partnerStatus = "assigned"
+            if (completedTask) {
+              partnerStatus = "completed"
+              partnerCompletedAt = partnerCompletedAt || (completedTask.updated_at ? String(completedTask.updated_at) : null)
+            } else if (redoTask) {
+              partnerStatus = "in_progress"
+              partnerPhase = "redo"
+            } else if (finishTask) {
+              partnerStatus = "finished"
+              partnerFinishedAt = partnerFinishedAt || (finishTask.updated_at ? String(finishTask.updated_at) : null)
+            } else if (startTask) {
+              partnerStatus = "in_progress"
+              partnerStartedAt = partnerStartedAt || (startTask.updated_at ? String(startTask.updated_at) : null)
+            }
+          }
+        }
+        if (partnerPhase === "redo") {
+          partnerStatus = "in_progress"
+        }
+      }
     }
 
     const partner_info = {


### PR DESCRIPTION
Builds on / **supersedes #357** (contains its commits). Delivers the cancel-desync fix **and** the #1+#2 improvement that prevents the whole bug class.

## The bug (prod design `01KE6E3NY88RB64J6D1CCT0E0C`)
Cancelled in March; a new run created 3 min later completed in June; yet the design still reported `partner_status: "cancelled"` and the partner could still drive the new run. Root cause: a stale `partner_assignment_cancelled_at` marker pinned status while the v2 run endpoints ignored it — a dual-source-of-truth split.

## What this does
**Immediate fix** (from #357):
- `approveProductionRunWorkflow` clears the marker on (re)assignment.
- `cancel-partner-assignment` also cancels the partner's active runs (+ open tasks).
- partner-ui `ProductionRunCard` gates actions on a cancelled assignment.

**#1 + #2 — single source of truth (the structural fix):**
- `partner_status` (detail + list) derives **purely from production_runs** for any run-backed design — including `"cancelled"` from a cancelled run. The `partner_assignment_cancelled_at` marker and v1-task fallback are consulted **only** for legacy designs with **no** production runs (4 such designs remain in prod — tracked for migration in the v1 removal plan).
- Cancellation is represented by a **cancelled run**, not a separate flag.
- The earlier "supersede marker" workaround is removed — newest run naturally wins.

## Data check
Of 5 prod designs carrying the marker, 4 have **zero** production runs (pure-v1) — so the marker/v1 fallback is retained for the no-run case to avoid regressing them; everything run-backed is now run-only.

## Tests
- `partner-cancel-reassign-desync.spec.ts`: cancel→reassign heals; run predating the cancel doesn't supersede; cancel cancels the run; **and** cancelling a run directly (no marker) yields `partner_status="cancelled"` (proves single-source).
- Full production-run suite re-run in batches — all directly-affected specs green. (`order-placed` fixed via a new `seedCommonEmailTemplates` helper; `cancel-workflows › block /complete` is a pre-existing 2.15.5 error-envelope issue, fails on main too.)

## Docs
`apps/docs/notes/V1_PARTNER_DESIGN_REMOVAL_PLAN.md` — phased v1 retirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)