### PR TITLE
chore: migrate legacy cancelled designs onto production runs (v1 Phase 5)

### DIFF
--- a/apps/backend/integration-tests/http/backfill-cancelled-design-runs.spec.ts
+++ b/apps/backend/integration-tests/http/backfill-cancelled-design-runs.spec.ts
@@ -1,0 +1,87 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { seedCommonEmailTemplates } from "../helpers/seed-email-templates"
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import backfillCancelledDesignRuns from "../../src/scripts/backfill-cancelled-design-runs"
+import { DESIGN_MODULE } from "../../src/modules/designs"
+
+jest.setTimeout(60 * 1000)
+
+// Verifies the legacy-cancelled-design migration: a marker-only design
+// (no runs) gets a terminal cancelled run + the marker cleared, so status
+// derives purely from production runs.
+setupSharedTestSuite(() => {
+  describe("backfill-cancelled-design-runs", () => {
+    let adminHeaders: { headers: Record<string, string> }
+
+    beforeAll(async () => {
+      await createAdminUser(getSharedTestEnv().getContainer())
+      adminHeaders = await getAuthHeaders(getSharedTestEnv().api)
+      await seedCommonEmailTemplates(getSharedTestEnv().api, adminHeaders)
+    })
+
+    it("creates a cancelled run + clears the marker for a marker-only design", async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      const container = getContainer()
+      const unique = Date.now()
+
+      // partner
+      const email = `bf-cancel-${unique}@jyt.test`
+      await api.post("/auth/partner/emailpass/register", { email, password: "supersecret" })
+      let login = await api.post("/auth/partner/emailpass", { email, password: "supersecret" })
+      const pres = await api.post(
+        "/partners",
+        { name: `BF Cancel ${unique}`, handle: `bf-cancel-${unique}`, admin: { email, first_name: "BF", last_name: "C" } },
+        { headers: { Authorization: `Bearer ${login.data.token}` } }
+      )
+      const partnerId = pres.data.partner.id
+
+      // design (no runs) + cancel marker set directly
+      const dres = await api.post(
+        "/admin/designs",
+        { name: `BF Cancel Design ${unique}`, description: "x", design_type: "Original", status: "Conceptual", priority: "Medium" },
+        adminHeaders
+      )
+      const designId = dres.data.design.id
+
+      const designService: any = container.resolve(DESIGN_MODULE)
+      await designService.updateDesigns({
+        id: designId,
+        metadata: {
+          partner_assignment_cancelled_at: new Date().toISOString(),
+          partner_assignment_cancelled_partner_id: partnerId,
+        },
+      })
+
+      // run the migration scoped to this design
+      await backfillCancelledDesignRuns({ container, args: [`--design-ids=${designId}`] } as any)
+
+      // a cancelled run now exists for (design, partner)
+      const query = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data: runs } = await query.graph({
+        entity: "production_runs",
+        filters: { design_id: designId, partner_id: partnerId },
+        fields: ["id", "status"],
+      })
+      expect(runs.length).toBe(1)
+      expect(runs[0].status).toBe("cancelled")
+
+      // marker cleared
+      const { data: designs } = await query.graph({
+        entity: "design",
+        filters: { id: designId },
+        fields: ["id", "metadata"],
+      })
+      expect((designs[0].metadata || {}).partner_assignment_cancelled_at == null).toBe(true)
+
+      // idempotent: a second run creates no duplicate
+      await backfillCancelledDesignRuns({ container, args: [`--design-ids=${designId}`] } as any)
+      const { data: runs2 } = await query.graph({
+        entity: "production_runs",
+        filters: { design_id: designId, partner_id: partnerId },
+        fields: ["id"],
+      })
+      expect(runs2.length).toBe(1)
+    })
+  })
+})

--- a/apps/backend/src/scripts/backfill-cancelled-design-runs.ts
+++ b/apps/backend/src/scripts/backfill-cancelled-design-runs.ts
@@ -1,0 +1,144 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { ExecArgs } from "@medusajs/framework/types"
+import { PRODUCTION_RUNS_MODULE } from "../modules/production_runs"
+import { DESIGN_MODULE } from "../modules/designs"
+
+/**
+ * Backfill: migrate legacy "cancelled partner assignment" designs onto the
+ * single-source-of-truth model (production runs).
+ *
+ * Background: partner_status used to read a metadata marker
+ * (`design.metadata.partner_assignment_cancelled_at`). After the
+ * single-source refactor, run-backed designs derive status purely from
+ * production_runs, but a handful of legacy designs still carry only the
+ * marker. This script makes runs authoritative for ALL marked designs so
+ * the marker + v1-task fallback can be removed later (see
+ * V1_PARTNER_DESIGN_REMOVAL_PLAN.md).
+ *
+ * Per marked design (metadata.partner_assignment_cancelled_at set):
+ *   - If the (design, cancelled-partner) pair has NO production run, create
+ *     a terminal `cancelled` run so the derivation returns "cancelled" from
+ *     the run instead of the marker.
+ *   - Clear the marker (partner_assignment_cancelled_at +
+ *     partner_assignment_cancelled_partner_id → null).
+ *
+ * Idempotent: skips run creation when a cancelled run already exists for
+ * the pair, and skips designs whose marker is already cleared.
+ *
+ * Usage:
+ *   DRY_RUN=1 npx medusa exec ./src/scripts/backfill-cancelled-design-runs.ts
+ *   npx medusa exec ./src/scripts/backfill-cancelled-design-runs.ts
+ *   (scope) --design-ids=des_a,des_b   or DESIGN_IDS=…
+ */
+export default async function backfillCancelledDesignRuns({
+  container,
+  args,
+}: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const runService: any = container.resolve(PRODUCTION_RUNS_MODULE)
+  const designService: any = container.resolve(DESIGN_MODULE)
+
+  const argList = args ?? []
+  const dryRun = argList.includes("--dry-run") || process.env.DRY_RUN === "1"
+  const designFromArg = argList
+    .map((a) => (a.startsWith("--design-ids=") ? a.slice("--design-ids=".length) : null))
+    .find((v): v is string => v !== null)
+  const designIdFilter = (designFromArg ?? process.env.DESIGN_IDS ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+
+  if (dryRun) logger.info("DRY RUN — no runs created, no markers cleared.")
+  if (designIdFilter.length) logger.info(`Design scope: ${designIdFilter.join(", ")}`)
+
+  // Find marked designs (metadata filtering is done in-memory — the design
+  // table is small and metadata isn't a server-side filterable column).
+  const { data: designs } = await query.graph({
+    entity: "design",
+    fields: ["id", "name", "metadata", "partners.id"],
+    pagination: { skip: 0, take: 5000 },
+  })
+
+  const marked = (designs ?? []).filter((d: any) => {
+    if (designIdFilter.length && !designIdFilter.includes(d.id)) return false
+    return !!d?.metadata?.partner_assignment_cancelled_at
+  })
+
+  if (!marked.length) {
+    logger.info("No designs with a cancellation marker. Nothing to migrate.")
+    return
+  }
+  logger.info(`Found ${marked.length} marked design(s).`)
+
+  let runsCreated = 0
+  let markersCleared = 0
+  let skipped = 0
+  const errors: string[] = []
+
+  for (const design of marked as any[]) {
+    const partnerId =
+      design.metadata?.partner_assignment_cancelled_partner_id ||
+      (design.partners || [])[0]?.id ||
+      null
+
+    try {
+      if (!partnerId) {
+        logger.warn(`[${design.id}] no cancelled-partner id and no linked partner — clearing marker only`)
+      } else {
+        // Does the (design, partner) pair already have any run?
+        const { data: runs } = await query.graph({
+          entity: "production_runs",
+          filters: { design_id: design.id, partner_id: partnerId },
+          fields: ["id", "status"],
+        })
+        const hasAnyRun = (runs ?? []).length > 0
+        if (!hasAnyRun) {
+          logger.info(
+            `[${design.id}] "${(design.name || "").slice(0, 30)}" → create cancelled run for partner ${partnerId}`
+          )
+          if (!dryRun) {
+            await runService.createProductionRuns({
+              design_id: design.id,
+              partner_id: partnerId,
+              status: "cancelled",
+              run_type: "production",
+              quantity: 1,
+              snapshot: { backfill: true, reason: "legacy_partner_assignment_cancelled" },
+              captured_at: new Date(),
+              cancelled_at: new Date(),
+              cancelled_reason: "partner_assignment_cancelled (backfill)",
+            })
+          }
+          runsCreated++
+        } else {
+          logger.info(`[${design.id}] already has run(s) — marker is vestigial, clearing only`)
+        }
+      }
+
+      // Clear the (now-vestigial) marker.
+      if (!dryRun) {
+        await designService.updateDesigns({
+          id: design.id,
+          metadata: {
+            partner_assignment_cancelled_at: null,
+            partner_assignment_cancelled_partner_id: null,
+          },
+        })
+      }
+      markersCleared++
+    } catch (e: any) {
+      const msg = `[${design.id}] ${e?.message || e}`
+      errors.push(msg)
+      logger.error(msg)
+    }
+  }
+
+  logger.info(
+    `${dryRun ? "[DRY RUN] " : ""}Done. cancelled runs created: ${runsCreated}, markers cleared: ${markersCleared}, skipped: ${skipped}, errors: ${errors.length}`
+  )
+  if (errors.length) {
+    logger.error(`Failures:\n${errors.join("\n")}`)
+    process.exitCode = 1
+  }
+}

--- a/apps/docs/notes/V1_PARTNER_DESIGN_REMOVAL_PLAN.md
+++ b/apps/docs/notes/V1_PARTNER_DESIGN_REMOVAL_PLAN.md
@@ -131,9 +131,17 @@ Stops the immediate bleakage; no v1 removal yet.
 - Delete v1-only specs; keep/expand v2 specs.
 
 **Phase 5 — data cleanup (one-off).**
-- Backfill: strip `metadata.partner_*` from designs; optionally archive
-  the historical `partner-design-*` tasks. Mirror the `run-backfill.sh`
-  recipe (dry-run aware, scoped).
+- ✅ **Cancelled designs migrated:** `src/scripts/backfill-cancelled-design-runs.ts`
+  — for every design carrying `partner_assignment_cancelled_at`, creates a
+  terminal `cancelled` production run for the cancelled partner when none
+  exists, then clears the marker. After this, status derives purely from
+  runs for all designs (5 marked designs in prod as of 2026-06-08: 4
+  marker-only + 1 run-backed). Run via
+  `DRY_RUN=1 ./deploy/aws/scripts/run-backfill.sh backfill-cancelled-design-runs`
+  then without DRY_RUN. Idempotent. Once run in prod, the marker +
+  v1-task fallback in the `/partners/designs` derivations can be removed.
+- Remaining: optionally strip the other `metadata.partner_*` keys and
+  archive historical `partner-design-*` tasks.
 
 ## Suggested improvements (independent of removal)
 


### PR DESCRIPTION
Migrates the legacy "cancelled partner assignment" designs onto the single-source-of-truth model, so the `partner_assignment_cancelled_at` marker + v1-task fallback become removable.

## Audit (prod, 2026-06-08)
Of 102 designs, **5 carry the marker**: 4 marker-only (no production runs) + 1 run-backed (`01KE6…`, stale marker). The 4 marker-only designs currently rely on the read-time fallback; this migration gives them a real cancelled run.

## Script — `backfill-cancelled-design-runs.ts`
Per marked design:
- if the (design, cancelled-partner) pair has **no** run → create a terminal `cancelled` run (so the derivation returns "cancelled" from the run);
- clear the marker (`partner_assignment_cancelled_at` + `…_partner_id` → null).

DRY_RUN-aware, `--design-ids` scoped, idempotent (skips create when a run exists), non-zero exit on errors. Run:
```
DRY_RUN=1 ./deploy/aws/scripts/run-backfill.sh backfill-cancelled-design-runs   # preview
./deploy/aws/scripts/run-backfill.sh backfill-cancelled-design-runs             # apply
```

## Test
`backfill-cancelled-design-runs.spec.ts` — creates a cancelled run + clears the marker for a marker-only design, and is idempotent on re-run.

After this runs in prod, the marker + v1-task fallback in the `/partners/designs` derivations can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)