### PR TITLE
refactor(production-runs): extract partner decline route into a workflow

### DIFF
--- a/apps/backend/src/api/partners/production-runs/[id]/decline/route.ts
+++ b/apps/backend/src/api/partners/production-runs/[id]/decline/route.ts
@@ -1,8 +1,8 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
+import { MedusaError } from "@medusajs/framework/utils"
 import { PRODUCTION_RUNS_MODULE } from "../../../../../modules/production_runs"
 import type ProductionRunService from "../../../../../modules/production_runs/service"
-import { TASKS_MODULE } from "../../../../../modules/tasks"
+import { declineProductionRunWorkflow } from "../../../../../workflows/production-runs/decline-production-run"
 
 /**
  * POST /partners/production-runs/:id/decline
@@ -61,10 +61,9 @@ export async function POST(
   const notes = typeof body.notes === "string" ? body.notes.trim().slice(0, 500) : undefined
 
   const productionRunService: ProductionRunService = req.scope.resolve(PRODUCTION_RUNS_MODULE)
-  const taskService = req.scope.resolve(TASKS_MODULE) as any
-  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY) as any
 
-  // Fetch + ownership / state guards
+  // Fetch + ownership / state guards (kept in the route so they surface as
+  // clean HTTP errors; the mutations live in declineProductionRunWorkflow).
   let run: any
   try {
     run = await productionRunService.retrieveProductionRun(id)
@@ -102,61 +101,15 @@ export async function POST(
     ? `Declined by partner (${reasonLabel}): ${notes}`
     : `Declined by partner (${reasonLabel})`
 
-  await productionRunService.updateProductionRuns({
-    id,
-    status: "cancelled",
-    cancelled_at: new Date(),
-    cancelled_reason: composedReason,
+  await declineProductionRunWorkflow(req.scope).run({
+    input: {
+      production_run_id: id,
+      partner_id: partnerId,
+      composed_reason: composedReason,
+      reason,
+      notes,
+    },
   })
-
-  // Cancel linked tasks (mirrors admin cancel flow)
-  try {
-    const { data: runData } = await query.graph({
-      entity: "production_runs",
-      fields: ["tasks.id", "tasks.status"],
-      filters: { id },
-    })
-    const tasks = runData?.[0]?.tasks || []
-    for (const task of tasks) {
-      if (task.status !== "completed" && task.status !== "cancelled") {
-        await taskService.updateTasks({ id: task.id, status: "cancelled" })
-      }
-    }
-  } catch (e: any) {
-    console.error(`[decline-production-run] Failed to cancel tasks for ${id}:`, e.message)
-  }
-
-  // Emit both events:
-  //   - production_run.declined → specific, for future partner-initiated handlers
-  //   - production_run.cancelled → reuses existing subscribers (admin feed +
-  //     WhatsApp "cancelled" template) so the partner gets a receipt today
-  //     without requiring a new subscriber.
-  try {
-    const eventService = req.scope.resolve(Modules.EVENT_BUS) as any
-    await eventService.emit([
-      {
-        name: "production_run.declined",
-        data: {
-          id,
-          production_run_id: id,
-          partner_id: partnerId,
-          action: "declined",
-          reason,
-          notes,
-        },
-      },
-      {
-        name: "production_run.cancelled",
-        data: {
-          id,
-          production_run_id: id,
-          partner_id: partnerId,
-          action: "cancelled",
-          notes: composedReason,
-        },
-      },
-    ])
-  } catch { /* non-fatal */ }
 
   const final = await productionRunService.retrieveProductionRun(id)
   return res.json({

--- a/apps/backend/src/workflows/production-runs/decline-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/decline-production-run.ts
@@ -1,0 +1,141 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+
+import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
+import type ProductionRunService from "../../modules/production_runs/service"
+import { TASKS_MODULE } from "../../modules/tasks"
+
+export type DeclineProductionRunInput = {
+  production_run_id: string
+  partner_id: string
+  /** Pre-composed, attribution-prefixed cancellation reason. */
+  composed_reason: string
+  /** Raw reason code + notes for the emitted events. */
+  reason: string
+  notes?: string
+}
+
+/** Mark the run cancelled (partner decline). Compensation restores prior state. */
+type DeclineComp = {
+  id: string
+  prev_status: string
+  prev_cancelled_at: Date | null
+  prev_cancelled_reason: string | null
+}
+const markRunDeclinedStep = createStep(
+  "decline-mark-run-cancelled",
+  async (input: { production_run_id: string; composed_reason: string }, { container }) => {
+    const service: ProductionRunService = container.resolve(PRODUCTION_RUNS_MODULE)
+    const run = (await service.retrieveProductionRun(input.production_run_id)) as any
+    await service.updateProductionRuns({
+      id: input.production_run_id,
+      status: "cancelled",
+      cancelled_at: new Date(),
+      cancelled_reason: input.composed_reason,
+    })
+    return new StepResponse<{ ok: boolean }, DeclineComp>(
+      { ok: true },
+      {
+        id: input.production_run_id,
+        prev_status: run.status,
+        prev_cancelled_at: run.cancelled_at ?? null,
+        prev_cancelled_reason: run.cancelled_reason ?? null,
+      }
+    )
+  },
+  async (comp: DeclineComp | undefined, { container }) => {
+    if (!comp) return
+    const service: ProductionRunService = container.resolve(PRODUCTION_RUNS_MODULE)
+    await service.updateProductionRuns({
+      id: comp.id,
+      status: comp.prev_status as any,
+      cancelled_at: comp.prev_cancelled_at,
+      cancelled_reason: comp.prev_cancelled_reason,
+    })
+  }
+)
+
+/** Cancel the run's non-terminal tasks (forward-only — mirrors admin cancel). */
+const cancelRunTasksStep = createStep(
+  "decline-cancel-run-tasks",
+  async (input: { production_run_id: string }, { container }) => {
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const taskService: any = container.resolve(TASKS_MODULE)
+    const { data } = await query.graph({
+      entity: "production_runs",
+      fields: ["tasks.id", "tasks.status"],
+      filters: { id: input.production_run_id },
+    })
+    let cancelled = 0
+    for (const t of data?.[0]?.tasks || []) {
+      if (t.status !== "completed" && t.status !== "cancelled") {
+        await taskService.updateTasks({ id: t.id, status: "cancelled" })
+        cancelled++
+      }
+    }
+    return new StepResponse({ cancelled })
+  }
+)
+
+/** Emit declined + cancelled events (non-fatal, fire-and-forget). */
+const emitDeclineEventsStep = createStep(
+  "decline-emit-events",
+  async (
+    input: { production_run_id: string; partner_id: string; reason: string; notes?: string; composed_reason: string },
+    { container }
+  ) => {
+    try {
+      const eventService: any = container.resolve(Modules.EVENT_BUS)
+      await eventService.emit([
+        {
+          name: "production_run.declined",
+          data: {
+            id: input.production_run_id,
+            production_run_id: input.production_run_id,
+            partner_id: input.partner_id,
+            action: "declined",
+            reason: input.reason,
+            notes: input.notes,
+          },
+        },
+        {
+          name: "production_run.cancelled",
+          data: {
+            id: input.production_run_id,
+            production_run_id: input.production_run_id,
+            partner_id: input.partner_id,
+            action: "cancelled",
+            notes: input.composed_reason,
+          },
+        },
+      ])
+    } catch {
+      /* non-fatal */
+    }
+    return new StepResponse({ ok: true })
+  }
+)
+
+export const declineProductionRunWorkflow = createWorkflow(
+  "decline-production-run",
+  (input: DeclineProductionRunInput) => {
+    markRunDeclinedStep({
+      production_run_id: input.production_run_id,
+      composed_reason: input.composed_reason,
+    })
+    cancelRunTasksStep({ production_run_id: input.production_run_id })
+    emitDeclineEventsStep({
+      production_run_id: input.production_run_id,
+      partner_id: input.partner_id,
+      reason: input.reason,
+      notes: input.notes,
+      composed_reason: input.composed_reason,
+    })
+    return new WorkflowResponse({ ok: true })
+  }
+)


### PR DESCRIPTION
Route→workflow sweep (continues the `cancel-partner-assignment` exemplar from #359).

## What
The `/partners/production-runs/:id/decline` route's mutations move into **`declineProductionRunWorkflow`**:
- mark run cancelled with partner attribution (compensation restores prior status/cancelled fields)
- cancel the run's non-terminal tasks
- emit `production_run.declined` + `production_run.cancelled`

The route keeps the request guards (auth, reason validation, ownership, pre-work-state) so they surface as clean HTTP errors.

Behaviour-preserving — `partners-decline-run` spec green. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)