### PR TITLE
refactor(partner): extract admin whatsapp-connect into a workflow

### DIFF
--- a/apps/backend/src/api/admin/partners/[id]/whatsapp-verify/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/whatsapp-verify/route.ts
@@ -1,24 +1,16 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { MedusaError } from "@medusajs/framework/utils"
 import { PARTNER_MODULE } from "../../../../../modules/partner"
-import { SOCIAL_PROVIDER_MODULE } from "../../../../../modules/social-provider"
-import type SocialProviderService from "../../../../../modules/social-provider/service"
-import { MESSAGING_MODULE } from "../../../../../modules/messaging"
-import { TEMPLATE_NAMES } from "../../../../../scripts/whatsapp-templates/partner-run-templates"
-
-// Welcome template: dedicated to the admin-triggered onboarding flow.
-// Canonical name lives in the templates spec so bumping the version
-// (welcome_v1 → welcome_v2) is a one-file change.
-const DEFAULT_TEMPLATE = TEMPLATE_NAMES.PARTNER_WELCOME
-const DEFAULT_LANG = process.env.WHATSAPP_TEMPLATE_LANG || "hi"
-const BUSINESS_NAME = process.env.WHATSAPP_BUSINESS_NAME || "JYT Textiles"
+import { connectPartnerWhatsappWorkflow } from "../../../../../workflows/partner/connect-partner-whatsapp"
 
 /**
  * POST /admin/partners/:id/whatsapp-verify
  *
  * "Connect on WhatsApp" — sets the partner's WhatsApp number and sends
  * a welcome template to initiate the conversation. The partner goes through
- * consent → language selection → onboarded when they reply.
+ * consent → language selection → onboarded when they reply. Orchestration
+ * (set number → send template → record conversation) lives in
+ * connectPartnerWhatsappWorkflow.
  *
  * Body: { phone: "919876543210" }
  */
@@ -43,102 +35,23 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     )
   }
 
-  // Verify partner exists
+  // Verify partner exists (clean 404 from the route)
   const partnerService = req.scope.resolve(PARTNER_MODULE) as any
   const partner = await partnerService.retrievePartner(partnerId).catch(() => null)
   if (!partner) {
     throw new MedusaError(MedusaError.Types.NOT_FOUND, "Partner not found")
   }
 
-  // Update partner with WhatsApp number (verified = true since admin is setting it)
-  await partnerService.updatePartners({
-    id: partnerId,
-    whatsapp_number: normalized,
-    whatsapp_verified: true,
+  const { result } = await connectPartnerWhatsappWorkflow(req.scope).run({
+    input: { partner_id: partnerId, phone: normalized },
   })
-
-  // Send welcome template to initiate the conversation
-  const socialProvider = req.scope.resolve(SOCIAL_PROVIDER_MODULE) as SocialProviderService
-  const whatsapp = socialProvider.getWhatsApp(req.scope)
-
-  let waMessageId: string | null = null
-  let templateSent = false
-
-  try {
-    // jyt_partner_welcome_v1 body has two placeholders:
-    //   {{1}} partner name, {{2}} business name
-    const waResponse = await whatsapp.sendTemplateMessage(
-      normalized,
-      DEFAULT_TEMPLATE,
-      DEFAULT_LANG,
-      [{
-        type: "body",
-        parameters: [
-          { type: "text", text: partner.name || "Partner" },
-          { type: "text", text: BUSINESS_NAME },
-        ],
-      }]
-    )
-    waMessageId = waResponse?.messages?.[0]?.id || null
-    templateSent = true
-  } catch (e: any) {
-    console.warn(`[admin-whatsapp-connect] Failed to send template to ${normalized}:`, e.message)
-  }
-
-  // Create or find conversation for this partner + phone
-  const messagingService = req.scope.resolve(MESSAGING_MODULE) as any
-  const phoneDigits = normalized.replace(/[^0-9]/g, "")
-
-  const [allConversations] = await messagingService.listAndCountMessagingConversations(
-    { partner_id: partnerId },
-    { take: 50 }
-  )
-
-  const existing = (allConversations || []).find((conv: any) => {
-    const convDigits = (conv.phone_number || "").replace(/[^0-9]/g, "")
-    return convDigits === phoneDigits || convDigits.endsWith(phoneDigits) || phoneDigits.endsWith(convDigits)
-  })
-
-  let conversationId: string
-  if (existing) {
-    conversationId = existing.id
-  } else {
-    const conv = await messagingService.createMessagingConversations({
-      partner_id: partnerId,
-      phone_number: normalized,
-      title: partner.name,
-      status: "active",
-      metadata: {
-        consent_source: "admin_initiated",
-      },
-    })
-    conversationId = conv.id
-  }
-
-  // Persist the outbound template message
-  if (templateSent) {
-    await messagingService.createMessagingMessages({
-      conversation_id: conversationId,
-      direction: "outbound",
-      sender_name: "System",
-      content: `WhatsApp connection initiated for ${partner.name}`,
-      message_type: "template",
-      wa_message_id: waMessageId,
-      status: waMessageId ? "sent" : "failed",
-    })
-
-    await messagingService.updateMessagingConversations({
-      id: conversationId,
-      last_message_at: new Date(),
-    })
-  }
 
   return res.json({
     partner_id: partnerId,
     whatsapp_number: normalized,
     whatsapp_verified: true,
-    template_sent: templateSent,
-    conversation_id: conversationId,
+    template_sent: result.template_sent,
+    conversation_id: result.conversation_id,
   })
 }
 

--- a/apps/backend/src/workflows/partner/connect-partner-whatsapp.ts
+++ b/apps/backend/src/workflows/partner/connect-partner-whatsapp.ts
@@ -1,0 +1,152 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+
+import { PARTNER_MODULE } from "../../modules/partner"
+import { SOCIAL_PROVIDER_MODULE } from "../../modules/social-provider"
+import type SocialProviderService from "../../modules/social-provider/service"
+import { MESSAGING_MODULE } from "../../modules/messaging"
+import { TEMPLATE_NAMES } from "../../scripts/whatsapp-templates/partner-run-templates"
+
+const DEFAULT_TEMPLATE = TEMPLATE_NAMES.PARTNER_WELCOME
+const DEFAULT_LANG = process.env.WHATSAPP_TEMPLATE_LANG || "hi"
+const BUSINESS_NAME = process.env.WHATSAPP_BUSINESS_NAME || "JYT Textiles"
+
+export type ConnectPartnerWhatsappInput = {
+  partner_id: string
+  /** Already-normalized digits-only phone with country code. */
+  phone: string
+}
+
+/** Set the partner's verified WhatsApp number. Compensation restores prior. */
+type SetComp = { partner_id: string; prev_number: string | null; prev_verified: boolean }
+const setPartnerWhatsappStep = createStep(
+  "connect-wa-set-number",
+  async (input: ConnectPartnerWhatsappInput, { container }) => {
+    const partnerService: any = container.resolve(PARTNER_MODULE)
+    const partner = await partnerService.retrievePartner(input.partner_id)
+    await partnerService.updatePartners({
+      id: input.partner_id,
+      whatsapp_number: input.phone,
+      whatsapp_verified: true,
+    })
+    return new StepResponse<{ partner_name: string }, SetComp>(
+      { partner_name: partner.name || "Partner" },
+      {
+        partner_id: input.partner_id,
+        prev_number: partner.whatsapp_number ?? null,
+        prev_verified: !!partner.whatsapp_verified,
+      }
+    )
+  },
+  async (comp: SetComp | undefined, { container }) => {
+    if (!comp) return
+    const partnerService: any = container.resolve(PARTNER_MODULE)
+    await partnerService.updatePartners({
+      id: comp.partner_id,
+      whatsapp_number: comp.prev_number,
+      whatsapp_verified: comp.prev_verified,
+    })
+  }
+)
+
+/** Send the welcome template to initiate the conversation (non-fatal). */
+const sendWelcomeTemplateStep = createStep(
+  "connect-wa-send-welcome",
+  async (input: { phone: string; partner_name: string }, { container }) => {
+    const socialProvider = container.resolve(SOCIAL_PROVIDER_MODULE) as SocialProviderService
+    const whatsapp = socialProvider.getWhatsApp(container as any)
+    let waMessageId: string | null = null
+    let templateSent = false
+    try {
+      const waResponse = await whatsapp.sendTemplateMessage(
+        input.phone,
+        DEFAULT_TEMPLATE,
+        DEFAULT_LANG,
+        [{ type: "body", parameters: [
+          { type: "text", text: input.partner_name },
+          { type: "text", text: BUSINESS_NAME },
+        ] }]
+      )
+      waMessageId = waResponse?.messages?.[0]?.id || null
+      templateSent = true
+    } catch (e: any) {
+      console.warn(`[connect-partner-whatsapp] template send failed to ${input.phone}:`, e.message)
+    }
+    return new StepResponse({ wa_message_id: waMessageId, template_sent: templateSent })
+  }
+)
+
+/** Find/create the partner conversation + persist the outbound template. */
+const recordConversationStep = createStep(
+  "connect-wa-record-conversation",
+  async (
+    input: { partner_id: string; phone: string; partner_name: string; template_sent: boolean; wa_message_id: string | null },
+    { container }
+  ) => {
+    const messagingService: any = container.resolve(MESSAGING_MODULE)
+    const phoneDigits = input.phone.replace(/[^0-9]/g, "")
+
+    const [allConversations] = await messagingService.listAndCountMessagingConversations(
+      { partner_id: input.partner_id },
+      { take: 50 }
+    )
+    const existing = (allConversations || []).find((conv: any) => {
+      const d = (conv.phone_number || "").replace(/[^0-9]/g, "")
+      return d === phoneDigits || d.endsWith(phoneDigits) || phoneDigits.endsWith(d)
+    })
+
+    let conversationId: string
+    if (existing) {
+      conversationId = existing.id
+    } else {
+      const conv = await messagingService.createMessagingConversations({
+        partner_id: input.partner_id,
+        phone_number: input.phone,
+        title: input.partner_name,
+        status: "active",
+        metadata: { consent_source: "admin_initiated" },
+      })
+      conversationId = conv.id
+    }
+
+    if (input.template_sent) {
+      await messagingService.createMessagingMessages({
+        conversation_id: conversationId,
+        direction: "outbound",
+        sender_name: "System",
+        content: `WhatsApp connection initiated for ${input.partner_name}`,
+        message_type: "template",
+        wa_message_id: input.wa_message_id,
+        status: input.wa_message_id ? "sent" : "failed",
+      })
+      await messagingService.updateMessagingConversations({
+        id: conversationId,
+        last_message_at: new Date(),
+      })
+    }
+    return new StepResponse({ conversation_id: conversationId })
+  }
+)
+
+export const connectPartnerWhatsappWorkflow = createWorkflow(
+  "connect-partner-whatsapp",
+  (input: ConnectPartnerWhatsappInput) => {
+    const set = setPartnerWhatsappStep(input)
+    const sent = sendWelcomeTemplateStep({ phone: input.phone, partner_name: set.partner_name })
+    const conv = recordConversationStep({
+      partner_id: input.partner_id,
+      phone: input.phone,
+      partner_name: set.partner_name,
+      template_sent: sent.template_sent,
+      wa_message_id: sent.wa_message_id,
+    })
+    return new WorkflowResponse({
+      template_sent: sent.template_sent,
+      conversation_id: conv.conversation_id,
+    })
+  }
+)


### PR DESCRIPTION
Route→workflow sweep. `POST /admin/partners/:id/whatsapp-verify` mutations move into `connectPartnerWhatsappWorkflow`: set verified `whatsapp_number` (compensation restores), send welcome template (non-fatal), find/create conversation + persist outbound message. Route keeps validation + 404 guard; trivial DELETE stays inline. Logic moved verbatim; build clean. (The 3 whatsapp-partner-flow failures are pre-existing Real-API tests — confirmed on main — and hit different endpoints.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)