### PR TITLE
refactor(partner): remove v1 status fallback from /partners/designs (Phase 3)

### DIFF
--- a/apps/backend/src/api/partners/designs/[designId]/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/route.ts
@@ -147,12 +147,11 @@ export const GET = async (
 
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
-  // Verify this design is linked to this partner and fetch tasks via link
+  // Verify this design is linked to this partner.
   const linkResult = await query.graph({
     entity: designPartnersLink.entryPoint,
     fields: [
       "design.*",
-      "design.tasks.*",
       "partner.*",
     ],
     filters: { design_id: designId, partner_id: partner.id },
@@ -168,24 +167,22 @@ export const GET = async (
     input: { id: designId, fields: ["*"] },
   })
 
-  const designMeta = (workflowDesign as any)?.metadata || (linkData.design as any)?.metadata || {}
-
-  let partner_phase: "redo" | null = null
+  const partner_phase: "redo" | null = null
   let partner_started_at: string | null = null
   let partner_finished_at: string | null = null
   let partner_completed_at: string | null = null
-  let resolvedFromRun = false
 
   let partner_status: "incoming" | "assigned" | "in_progress" | "awaiting_review" | "finished" | "completed" | "cancelled" =
     "incoming"
 
   // ── Single source of truth: production runs ──────────────────────────
-  // For any design that has production runs, status derives PURELY from
-  // those runs — including "cancelled" from a cancelled run. The legacy
-  // `partner_assignment_cancelled_at` marker and v1 task fallback are NOT
-  // consulted here (they only apply to legacy designs that have no runs,
-  // below). Cancelling the assignment cancels the run, so a cancelled
-  // assignment is represented by a cancelled run — no separate flag.
+  // partner_status derives entirely from production runs — including
+  // "cancelled" from a cancelled run. Cancelling an assignment cancels the
+  // run, so a cancelled assignment is a cancelled run (no separate flag).
+  // The legacy `partner_assignment_cancelled_at` marker + v1 task fallback
+  // were removed 2026-06-09 after the backfill migrated all marked designs
+  // onto runs (see V1_PARTNER_DESIGN_REMOVAL_PLAN.md). A design with no
+  // runs is simply "incoming".
   const { data: runs } = await query.graph({
     entity: "production_runs",
     filters: { design_id: designId, partner_id: partner.id },
@@ -197,7 +194,6 @@ export const GET = async (
     .sort((a, b) => new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime())
 
   if (allRuns.length) {
-    resolvedFromRun = true
     // An active (non-terminal) run wins over terminal ones; otherwise the
     // newest run decides (completed vs cancelled).
     const activeRun = allRuns.find((r) =>
@@ -227,51 +223,6 @@ export const GET = async (
         if (newest.finished_at) partner_finished_at = String(newest.finished_at)
       } else if (runStatus === "cancelled") {
         partner_status = "cancelled"
-      }
-    }
-  }
-
-  // ── Legacy fallback (designs with NO production runs only) ────────────
-  // Pure-v1 designs predate the production-runs system. Until they're
-  // migrated (see V1_PARTNER_DESIGN_REMOVAL_PLAN.md), honour the cancel
-  // marker, then derive from v1 tasks.
-  const wasCancelled = !resolvedFromRun && !!designMeta.partner_assignment_cancelled_at
-  if (wasCancelled) {
-    partner_status = "cancelled"
-  }
-  if (!resolvedFromRun && !wasCancelled) {
-    const tasks = (linkData.design?.tasks || []) as Array<{
-      title?: string
-      status?: string
-      updated_at?: string | Date | null
-    }>
-    const v1TaskTitles = [
-      "partner-design-start",
-      "partner-design-redo",
-      "partner-design-finish",
-      "partner-design-completed",
-    ]
-    const wfTasks = tasks.filter((t) => !!t && v1TaskTitles.includes(t.title!))
-    if (wfTasks.length > 0) {
-      const findCompleted = (title: string) => wfTasks.find((t) => t.title === title && t.status === "completed")
-      const startTask = findCompleted("partner-design-start")
-      const redoTask = findCompleted("partner-design-redo")
-      const finishTask = findCompleted("partner-design-finish")
-      const completedTask = findCompleted("partner-design-completed")
-
-      partner_status = "assigned"
-      if (completedTask) {
-        partner_status = "completed"
-        partner_completed_at = completedTask.updated_at ? String(completedTask.updated_at) : null
-      } else if (redoTask) {
-        partner_status = "in_progress"
-        partner_phase = "redo"
-      } else if (finishTask) {
-        partner_status = "finished"
-        partner_finished_at = finishTask.updated_at ? String(finishTask.updated_at) : null
-      } else if (startTask) {
-        partner_status = "in_progress"
-        partner_started_at = startTask.updated_at ? String(startTask.updated_at) : null
       }
     }
   }

--- a/apps/backend/src/api/partners/designs/route.ts
+++ b/apps/backend/src/api/partners/designs/route.ts
@@ -298,51 +298,10 @@ export async function GET(
       }
     }
 
-    // ── Legacy fallback (designs with NO production runs only) ─────────
-    if (!resolvedFromRun) {
-      const wasCancelled = !!design?.metadata?.partner_assignment_cancelled_at
-      if (wasCancelled) {
-        partnerStatus = "cancelled"
-      } else {
-        // metadata first, then v1 task inference
-        partnerStatus = (design?.metadata?.partner_status as any) || "incoming"
-        partnerPhase = (design?.metadata?.partner_phase as any) || null
-        partnerStartedAt = (design?.metadata?.partner_started_at as any) || null
-        partnerFinishedAt = (design?.metadata?.partner_finished_at as any) || null
-        partnerCompletedAt = (design?.metadata?.partner_completed_at as any) || null
-
-        if (partnerPhase === "redo") {
-          partnerStatus = "in_progress"
-        }
-
-        if (workflowTasks.length > 0) {
-          const completedTask = workflowTasks.find((t: any) => t.title === "partner-design-completed" && t.status === "completed")
-          const redoTask = workflowTasks.find((t: any) => t.title === "partner-design-redo" && t.status === "completed")
-          const finishTask = workflowTasks.find((t: any) => t.title === "partner-design-finish" && t.status === "completed")
-          const startTask = workflowTasks.find((t: any) => t.title === "partner-design-start" && t.status === "completed")
-
-          if (!partnerStatus || partnerStatus === "incoming" || partnerStatus === "assigned") {
-            partnerStatus = "assigned"
-            if (completedTask) {
-              partnerStatus = "completed"
-              partnerCompletedAt = partnerCompletedAt || (completedTask.updated_at ? String(completedTask.updated_at) : null)
-            } else if (redoTask) {
-              partnerStatus = "in_progress"
-              partnerPhase = "redo"
-            } else if (finishTask) {
-              partnerStatus = "finished"
-              partnerFinishedAt = partnerFinishedAt || (finishTask.updated_at ? String(finishTask.updated_at) : null)
-            } else if (startTask) {
-              partnerStatus = "in_progress"
-              partnerStartedAt = partnerStartedAt || (startTask.updated_at ? String(startTask.updated_at) : null)
-            }
-          }
-        }
-        if (partnerPhase === "redo") {
-          partnerStatus = "in_progress"
-        }
-      }
-    }
+    // The legacy v1 fallback (cancel marker + partner-design-* task status
+    // inference for run-less designs) was removed 2026-06-09 after the
+    // backfill migrated all marked designs onto production runs. A design
+    // with no runs is "incoming". See V1_PARTNER_DESIGN_REMOVAL_PLAN.md.
 
     const partner_info = {
       assigned_partner_id: linkData.partner?.id || partner.id,

--- a/apps/docs/notes/V1_PARTNER_DESIGN_REMOVAL_PLAN.md
+++ b/apps/docs/notes/V1_PARTNER_DESIGN_REMOVAL_PLAN.md
@@ -116,11 +116,19 @@ Stops the immediate bleakage; no v1 removal yet.
   otherwise migrate the UI to read run tasks.
 
 **Phase 3 — collapse the status derivation to v2-only.**
-- Delete the v1-task fallback blocks in both `/partners/designs` routes
-  (keep the production-run logic). `partner_status` derives purely from
-  runs. Drop `metadata.partner_*` reads.
-- Replace the `cancel-partner-assignment` flow with **production-run
-  cancellation** (cancel the run(s)); retire `partner_assignment_cancelled_at`.
+- ✅ **DONE 2026-06-10** (after the Phase 5 backfill ran in prod). Removed
+  the v1-task fallback + cancel-marker reads from both `/partners/designs`
+  routes (`route.ts` list + `[designId]/route.ts` detail). `partner_status`
+  now derives **purely from production runs**; a run-less design is
+  "incoming". Also dropped the now-unused `design.tasks.*` fetch from the
+  detail route's link query. Verified: partner-status specs green
+  (production-run-partner-status, -design-status, -sample-status,
+  partner-cancel-reassign-desync).
+- ✅ `cancel-partner-assignment` already cancels the partner's active
+  run(s) (the cancel = a cancelled run). `partner_assignment_cancelled_at`
+  is no longer read anywhere in the partner derivations; the
+  cancel-partner-assignment workflow still *writes* it (harmless legacy
+  breadcrumb) — can be dropped in Phase 4.
 
 **Phase 4 — retire v1 endpoints + workflows.**
 - Delete `partners/designs/[id]/{start,finish,redo,refinish,complete}` once


### PR DESCRIPTION
Phase 3 of the v1 retirement — the prod backfill (2026-06-09) migrated all marker-carrying designs onto production runs, so the legacy path is now dead.

## Removed from both `/partners/designs` derivations (list + detail)
- the `partner_assignment_cancelled_at` cancel-marker read
- the `partner-design-*` task-based status inference
- the `design.metadata.partner_*` status reads
- (detail) the now-unused `design.tasks.*` link fetch

`partner_status` now derives **purely from production runs**; a run-less design is `incoming`. Cancellation = a cancelled run (already enforced upstream).

## Verified
`production-run-partner-status`, `-design-status`, `-sample-status`, `partner-cancel-reassign-desync` — all green. Build clean.

## Docs
`V1_PARTNER_DESIGN_REMOVAL_PLAN.md` Phase 3 marked done; the `cancel-partner-assignment` workflow still *writes* the marker (harmless legacy breadcrumb) — flagged for Phase 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)