### PR TITLE
feat(production-runs): centralize run transitions in ProductionPolicyService

### DIFF
--- a/apps/backend/integration-tests/http/production-run-transition-guards.spec.ts
+++ b/apps/backend/integration-tests/http/production-run-transition-guards.spec.ts
@@ -1,0 +1,219 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(60000)
+
+// Production-run transition rules live in ONE place —
+// ProductionPolicyService (modules/production_policy). These tests pin the
+// partner work-lifecycle ordering + terminal guards end-to-end through the
+// /partners/production-runs endpoints.
+setupSharedTestSuite(() => {
+  describe("Production run transition guards (policy)", () => {
+    const { api, getContainer } = getSharedTestEnv()
+    let adminHeaders: { headers: Record<string, string> }
+
+    async function createPartner(unique: number) {
+      const email = `run-guard-${unique}@jyt.test`
+      const password = "supersecret"
+      await api.post("/auth/partner/emailpass/register", { email, password })
+      let login = await api.post("/auth/partner/emailpass", { email, password })
+      let headers = { Authorization: `Bearer ${login.data.token}` }
+      const res = await api.post(
+        "/partners",
+        {
+          name: `Run Guard ${unique}`,
+          handle: `run-guard-${unique}`,
+          admin: { email, first_name: "Test", last_name: "Partner" },
+        },
+        { headers }
+      )
+      expect(res.status).toBe(200)
+      login = await api.post("/auth/partner/emailpass", { email, password })
+      return {
+        partnerId: res.data.partner.id,
+        partnerHeaders: { Authorization: `Bearer ${login.data.token}` },
+      }
+    }
+
+    async function createDesign(unique: number) {
+      const res = await api.post(
+        "/admin/designs",
+        {
+          name: `Run Guard Design ${unique}`,
+          description: "x",
+          design_type: "Original",
+          status: "Approved",
+          priority: "Medium",
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      return res.data.design.id
+    }
+
+    /** Create a run for the partner and force a specific status directly. */
+    async function createRunWithStatus(
+      designId: string,
+      partnerId: string,
+      status: string,
+      extra: Record<string, any> = {}
+    ) {
+      const res = await api.post(
+        "/admin/production-runs",
+        { design_id: designId, partner_id: partnerId, quantity: 1 },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      const runId = res.data.production_run.id
+      const runService: any = getContainer().resolve("production_runs")
+      await runService.updateProductionRuns({ id: runId, status, ...extra })
+      return runId
+    }
+
+    async function post(path: string, body: any, headers: any) {
+      return api.post(path, body, { headers, validateStatus: () => true })
+    }
+
+    beforeAll(async () => {
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+      try {
+        await api.post(
+          "/admin/email-templates",
+          {
+            name: "Admin Partner Created",
+            template_key: "partner-created-from-admin",
+            subject: "s",
+            html_content: "<div>ok</div>",
+            from: "t@t.com",
+            variables: {},
+            template_type: "email",
+          },
+          adminHeaders
+        )
+      } catch {}
+    })
+
+    it("rejects accept on a cancelled run", async () => {
+      const unique = Date.now()
+      const { partnerId, partnerHeaders } = await createPartner(unique)
+      const designId = await createDesign(unique)
+      const runId = await createRunWithStatus(designId, partnerId, "cancelled", {
+        cancelled_at: new Date(),
+      })
+
+      const res = await post(`/partners/production-runs/${runId}/accept`, {}, partnerHeaders)
+      expect(res.status).toBeGreaterThanOrEqual(400)
+    })
+
+    it("rejects start before accept (sent_to_partner)", async () => {
+      const unique = Date.now() + 1
+      const { partnerId, partnerHeaders } = await createPartner(unique)
+      const designId = await createDesign(unique)
+      const runId = await createRunWithStatus(designId, partnerId, "sent_to_partner")
+
+      const res = await post(`/partners/production-runs/${runId}/start`, {}, partnerHeaders)
+      expect(res.status).toBeGreaterThanOrEqual(400)
+    })
+
+    it("rejects double-start", async () => {
+      const unique = Date.now() + 2
+      const { partnerId, partnerHeaders } = await createPartner(unique)
+      const designId = await createDesign(unique)
+      const runId = await createRunWithStatus(designId, partnerId, "in_progress", {
+        accepted_at: new Date(),
+        started_at: new Date(),
+      })
+
+      const res = await post(`/partners/production-runs/${runId}/start`, {}, partnerHeaders)
+      expect(res.status).toBeGreaterThanOrEqual(400)
+      expect(String(res.data?.message || res.data?.error || "")).toContain("already")
+    })
+
+    it("rejects finish before start", async () => {
+      const unique = Date.now() + 3
+      const { partnerId, partnerHeaders } = await createPartner(unique)
+      const designId = await createDesign(unique)
+      const runId = await createRunWithStatus(designId, partnerId, "in_progress", {
+        accepted_at: new Date(),
+      })
+
+      const res = await post(`/partners/production-runs/${runId}/finish`, {}, partnerHeaders)
+      expect(res.status).toBeGreaterThanOrEqual(400)
+    })
+
+    it("rejects complete before finish", async () => {
+      const unique = Date.now() + 4
+      const { partnerId, partnerHeaders } = await createPartner(unique)
+      const designId = await createDesign(unique)
+      const runId = await createRunWithStatus(designId, partnerId, "in_progress", {
+        accepted_at: new Date(),
+        started_at: new Date(),
+      })
+
+      const res = await post(`/partners/production-runs/${runId}/complete`, {}, partnerHeaders)
+      expect(res.status).toBeGreaterThanOrEqual(400)
+    })
+
+    it("rejects decline once work has started; allows it pre-work", async () => {
+      const unique = Date.now() + 5
+      const { partnerId, partnerHeaders } = await createPartner(unique)
+      const designId = await createDesign(unique)
+
+      // Started run — decline blocked (mid-flight cancel is admin-only)
+      const startedRunId = await createRunWithStatus(designId, partnerId, "in_progress", {
+        accepted_at: new Date(),
+        started_at: new Date(),
+      })
+      const blocked = await post(
+        `/partners/production-runs/${startedRunId}/decline`,
+        { reason: "capacity" },
+        partnerHeaders
+      )
+      expect(blocked.status).toBeGreaterThanOrEqual(400)
+
+      // Pre-work run — decline allowed
+      const freshRunId = await createRunWithStatus(designId, partnerId, "sent_to_partner")
+      const ok = await post(
+        `/partners/production-runs/${freshRunId}/decline`,
+        { reason: "capacity" },
+        partnerHeaders
+      )
+      expect(ok.status).toBe(200)
+      expect(ok.data.production_run.status).toBe("cancelled")
+
+      // Idempotent: declining the already-cancelled run is a 200 no-op
+      const again = await post(
+        `/partners/production-runs/${freshRunId}/decline`,
+        { reason: "capacity" },
+        partnerHeaders
+      )
+      expect(again.status).toBe(200)
+      expect(String(again.data.message || "")).toContain("Already cancelled")
+    })
+
+    it("walks the happy path: accept → start → finish → complete", async () => {
+      const unique = Date.now() + 6
+      const { partnerId, partnerHeaders } = await createPartner(unique)
+      const designId = await createDesign(unique)
+      const runId = await createRunWithStatus(designId, partnerId, "sent_to_partner")
+
+      const accept = await post(`/partners/production-runs/${runId}/accept`, {}, partnerHeaders)
+      expect(accept.status).toBe(200)
+
+      const start = await post(`/partners/production-runs/${runId}/start`, {}, partnerHeaders)
+      expect(start.status).toBe(200)
+
+      const finish = await post(`/partners/production-runs/${runId}/finish`, {}, partnerHeaders)
+      expect(finish.status).toBe(200)
+
+      const complete = await post(
+        `/partners/production-runs/${runId}/complete`,
+        { produced_quantity: 1 },
+        partnerHeaders
+      )
+      expect(complete.status).toBe(200)
+      expect(complete.data.production_run.status).toBe("completed")
+    })
+  })
+})

--- a/apps/backend/src/api/partners/production-runs/[id]/decline/route.ts
+++ b/apps/backend/src/api/partners/production-runs/[id]/decline/route.ts
@@ -2,6 +2,8 @@ import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/
 import { MedusaError } from "@medusajs/framework/utils"
 import { PRODUCTION_RUNS_MODULE } from "../../../../../modules/production_runs"
 import type ProductionRunService from "../../../../../modules/production_runs/service"
+import { PRODUCTION_POLICY_MODULE } from "../../../../../modules/production_policy"
+import type ProductionPolicyService from "../../../../../modules/production_policy/service"
 import { declineProductionRunWorkflow } from "../../../../../workflows/production-runs/decline-production-run"
 
 /**
@@ -79,20 +81,13 @@ export async function POST(
   if (run.status === "cancelled") {
     return res.json({ production_run: run, message: "Already cancelled" })
   }
-  if (run.status === "completed") {
-    throw new MedusaError(
-      MedusaError.Types.NOT_ALLOWED,
-      "Cannot decline a completed production run"
-    )
-  }
-  if (run.started_at) {
-    // Work has begun — partner can't unilaterally back out. Admin cancel
-    // is the right path, and an admin may need to handle partial costs.
-    throw new MedusaError(
-      MedusaError.Types.NOT_ALLOWED,
-      "Work has already started on this run. Contact admin to cancel mid-production."
-    )
-  }
+  // Transition rules live in ProductionPolicyService: completed runs and
+  // runs with started work can't be partner-declined (admin cancel is the
+  // mid-flight path).
+  const productionPolicyService: ProductionPolicyService = req.scope.resolve(
+    PRODUCTION_POLICY_MODULE
+  )
+  await productionPolicyService.assertCanDecline(run)
 
   // Compose a clear attribution string so admin feed / inspection tells
   // the partner vs admin story at a glance.

--- a/apps/backend/src/modules/production_policy/service.ts
+++ b/apps/backend/src/modules/production_policy/service.ts
@@ -13,6 +13,8 @@ type ProductionRunLike = {
   role?: string | null
   depends_on_run_ids?: string[] | null
   dispatch_state?: string | null
+  started_at?: Date | string | null
+  finished_at?: Date | string | null
   metadata?: Record<string, any> | null
 }
 
@@ -24,6 +26,9 @@ type StoredPolicy = {
 }
 
 const DEFAULT_POLICY_KEY = "default"
+
+/** Statuses no transition may leave. */
+export const TERMINAL_RUN_STATUSES = ["completed", "cancelled"] as const
 
 class ProductionPolicyService extends MedusaService({
   ProductionRunPolicy,
@@ -43,7 +48,32 @@ class ProductionPolicyService extends MedusaService({
         dispatch_from: ["approved"],
         send_to_production_from: ["approved"],
         accept_from: ["sent_to_partner"],
+        // Partner work lifecycle. Accepting moves the run to in_progress;
+        // start/finish/complete then stage within it via the lifecycle
+        // timestamps (started_at / finished_at).
+        start_work_from: ["in_progress"],
+        finish_work_from: ["in_progress"],
+        complete_work_from: ["in_progress"],
+        decline_from: ["draft", "pending_review", "approved", "sent_to_partner", "in_progress"],
       },
+    }
+  }
+
+  isTerminal(status: string | null | undefined): boolean {
+    return TERMINAL_RUN_STATUSES.includes(String(status) as any)
+  }
+
+  /**
+   * Defence-in-depth: nothing transitions out of a terminal run. Gives a
+   * clearer error than the per-action allowed-status message.
+   */
+  private assertNotTerminal(run: ProductionRunLike, action: string) {
+    const status = String(run.status)
+    if (this.isTerminal(status)) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        `ProductionRun ${run.id} is ${status} — it cannot be ${action}`
+      )
     }
   }
 
@@ -187,6 +217,120 @@ class ProductionPolicyService extends MedusaService({
       throw new MedusaError(
         MedusaError.Types.NOT_ALLOWED,
         `ProductionRun ${run.id} must be approved before sending. Current status: ${status}`
+      )
+    }
+  }
+
+  // ── Partner work lifecycle ────────────────────────────────────────────
+
+  async assertCanStartWork(run: ProductionRunLike) {
+    if (!run) {
+      throw new MedusaError(MedusaError.Types.NOT_FOUND, "ProductionRun not found")
+    }
+    this.assertNotTerminal(run, "started")
+
+    const config = await this.getPolicyConfig()
+    const allowed = this.allowedStatuses(config, "start_work_from", ["in_progress"])
+    const status = String(run.status)
+    if (!allowed.includes(status)) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        `Production run must be ${allowed.join(" or ")} to start. Current status: ${status}`
+      )
+    }
+
+    if (run.started_at) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        "Production run has already been started"
+      )
+    }
+  }
+
+  async assertCanFinishWork(run: ProductionRunLike) {
+    if (!run) {
+      throw new MedusaError(MedusaError.Types.NOT_FOUND, "ProductionRun not found")
+    }
+    this.assertNotTerminal(run, "finished")
+
+    const config = await this.getPolicyConfig()
+    const allowed = this.allowedStatuses(config, "finish_work_from", ["in_progress"])
+    const status = String(run.status)
+    if (!allowed.includes(status)) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        `Production run must be ${allowed.join(" or ")} to finish. Current status: ${status}`
+      )
+    }
+
+    if (!run.started_at) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        "Production run must be started before it can be finished"
+      )
+    }
+  }
+
+  async assertCanCompleteWork(run: ProductionRunLike) {
+    if (!run) {
+      throw new MedusaError(MedusaError.Types.NOT_FOUND, "ProductionRun not found")
+    }
+    this.assertNotTerminal(run, "completed")
+
+    const config = await this.getPolicyConfig()
+    const allowed = this.allowedStatuses(config, "complete_work_from", ["in_progress"])
+    const status = String(run.status)
+    if (!allowed.includes(status)) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        `Production run must be ${allowed.join(" or ")} to complete. Current status: ${status}`
+      )
+    }
+
+    if (!run.finished_at) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        "Production run must be finished before it can be completed"
+      )
+    }
+  }
+
+  /**
+   * Partner decline — only before real work begins. Mid-flight
+   * cancellation stays admin-only. The idempotent already-cancelled
+   * path is the route's concern (it returns 200, not an error).
+   */
+  async assertCanDecline(run: ProductionRunLike) {
+    if (!run) {
+      throw new MedusaError(MedusaError.Types.NOT_FOUND, "ProductionRun not found")
+    }
+    if (String(run.status) === "completed") {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        "Cannot decline a completed production run"
+      )
+    }
+
+    const config = await this.getPolicyConfig()
+    const allowed = this.allowedStatuses(config, "decline_from", [
+      "draft",
+      "pending_review",
+      "approved",
+      "sent_to_partner",
+      "in_progress",
+    ])
+    const status = String(run.status)
+    if (!allowed.includes(status)) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        `Production run cannot be declined from status ${status}`
+      )
+    }
+
+    if (run.started_at) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        "Work has already started on this run. Contact admin to cancel mid-production."
       )
     }
   }

--- a/apps/backend/src/workflows/production-runs/complete-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/complete-production-run.ts
@@ -314,8 +314,6 @@ export const completeProductionRunWorkflow = createWorkflow(
       production_run_id: input.production_run_id,
       partner_id: input.partner_id,
       opts: {
-        allowedStatuses: ["in_progress"],
-        requireFinished: true,
         action: "complete",
       },
     })

--- a/apps/backend/src/workflows/production-runs/finish-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/finish-production-run.ts
@@ -78,8 +78,6 @@ export const finishProductionRunWorkflow = createWorkflow(
       production_run_id: input.production_run_id,
       partner_id: input.partner_id,
       opts: {
-        allowedStatuses: ["in_progress"],
-        requireStarted: true,
         action: "finish",
       },
     })

--- a/apps/backend/src/workflows/production-runs/partner-run-steps.ts
+++ b/apps/backend/src/workflows/production-runs/partner-run-steps.ts
@@ -9,6 +9,8 @@ import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
 
 import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
 import type ProductionRunService from "../../modules/production_runs/service"
+import { PRODUCTION_POLICY_MODULE } from "../../modules/production_policy"
+import type ProductionPolicyService from "../../modules/production_policy/service"
 import { TASKS_MODULE } from "../../modules/tasks"
 import { lifecycleWorkflowId } from "./run-production-run-lifecycle"
 
@@ -30,14 +32,8 @@ export type ResolvedPartnerLocation = {
 // ---------------------------------------------------------------------------
 
 export type ValidateRunOpts = {
-  /** Which statuses the run must be in */
-  allowedStatuses: string[]
-  /** If true, run.started_at must be set */
-  requireStarted?: boolean
-  /** If true, run.finished_at must be set */
-  requireFinished?: boolean
-  /** Human-readable action name for error messages */
-  action: string
+  /** Which lifecycle action is being attempted — picks the policy guard. */
+  action: "start" | "finish" | "complete"
 }
 
 export const retrieveAndValidatePartnerRunStep = createStep(
@@ -48,6 +44,8 @@ export const retrieveAndValidatePartnerRunStep = createStep(
   ) => {
     const productionRunService: ProductionRunService =
       container.resolve(PRODUCTION_RUNS_MODULE)
+    const productionPolicyService: ProductionPolicyService =
+      container.resolve(PRODUCTION_POLICY_MODULE)
 
     const run = await productionRunService
       .retrieveProductionRun(input.production_run_id)
@@ -60,34 +58,18 @@ export const retrieveAndValidatePartnerRunStep = createStep(
       )
     }
 
-    const status = String((run as any).status)
-    if (!input.opts.allowedStatuses.includes(status)) {
-      throw new MedusaError(
-        MedusaError.Types.NOT_ALLOWED,
-        `Production run must be ${input.opts.allowedStatuses.join(" or ")} to ${input.opts.action}. Current status: ${status}`
-      )
-    }
-
-    if (input.opts.requireStarted && !(run as any).started_at) {
-      throw new MedusaError(
-        MedusaError.Types.NOT_ALLOWED,
-        `Production run must be started before it can be ${input.opts.action}ed`
-      )
-    }
-
-    if (input.opts.requireFinished && !(run as any).finished_at) {
-      throw new MedusaError(
-        MedusaError.Types.NOT_ALLOWED,
-        `Production run must be finished before it can be ${input.opts.action}d`
-      )
-    }
-
-    // Guard against double-start
-    if (input.opts.action === "start" && (run as any).started_at) {
-      throw new MedusaError(
-        MedusaError.Types.NOT_ALLOWED,
-        "Production run has already been started"
-      )
+    // Allowed transitions live in ONE place: ProductionPolicyService
+    // (same authority the admin approve/dispatch/accept path uses).
+    switch (input.opts.action) {
+      case "start":
+        await productionPolicyService.assertCanStartWork(run as any)
+        break
+      case "finish":
+        await productionPolicyService.assertCanFinishWork(run as any)
+        break
+      case "complete":
+        await productionPolicyService.assertCanCompleteWork(run as any)
+        break
     }
 
     return new StepResponse(run)

--- a/apps/backend/src/workflows/production-runs/start-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/start-production-run.ts
@@ -66,7 +66,6 @@ export const startProductionRunWorkflow = createWorkflow(
       production_run_id: input.production_run_id,
       partner_id: input.partner_id,
       opts: {
-        allowedStatuses: ["in_progress"],
         action: "start",
       },
     })

--- a/apps/docs/notes/V1_PARTNER_DESIGN_REMOVAL_PLAN.md
+++ b/apps/docs/notes/V1_PARTNER_DESIGN_REMOVAL_PLAN.md
@@ -184,11 +184,20 @@ Stops the immediate bleakage; no v1 removal yet.
 2. **Run cancellation is the cancel** — there should be no separate
    "assignment cancelled" marker divorced from run state. Cancelling work =
    cancelling the run.
-3. **Guard the v2 partner endpoints on run state** — `/partners/production-runs/[id]/{accept,start,finish,complete}` should reject transitions on a
-   cancelled/terminal run with a clear error (defence-in-depth; today they
-   rely on the workflow's status check only).
-4. **One partner-work UI** — finish consolidating onto `DesignProductionSection`;
-   delete the dead v1 action UI.
-5. **Typed run-status state machine** — encode allowed transitions in one
-   place (module/service) instead of re-deriving `can*` flags in each route
-   + UI.
+3. **Guard the v2 partner endpoints on run state** — ✅ DONE 2026-06-10.
+   `/partners/production-runs/[id]/{accept,start,finish,complete,decline}`
+   all validate through `ProductionPolicyService`, including an explicit
+   terminal-status rejection with a clear error.
+4. **One partner-work UI** — ✅ DONE (Phase 1 deleted the dead v1 action
+   UI; Phase 4 removed the orphaned start/complete routes + hooks).
+5. **Typed run-status state machine** — ✅ DONE 2026-06-10. Rather than a
+   new module, the existing `production_policy` module (which already
+   owned approve/dispatch/send/accept transitions via DB-stored config)
+   was extended with the partner work lifecycle:
+   `assertCanStartWork/FinishWork/CompleteWork/Decline` +
+   `isTerminal`/`TERMINAL_RUN_STATUSES`. The partner workflows'
+   `retrieveAndValidatePartnerRunStep` and the decline route now delegate
+   to it instead of carrying inline `allowedStatuses` lists. Config keys:
+   `start_work_from`, `finish_work_from`, `complete_work_from`,
+   `decline_from`. Pinned by
+   `integration-tests/http/production-run-transition-guards.spec.ts`.


### PR DESCRIPTION
## What

Delivers improvements #3 + #5 from `V1_PARTNER_DESIGN_REMOVAL_PLAN.md`: a single authority for production-run status transitions, plus defence-in-depth guards on the partner endpoints.

## Approach

Rather than inventing a new state-machine module, this extends the **existing `production_policy` module** — it already owned the admin-side transitions (approve/dispatch/send-to-production/accept) with DB-stored, per-key config. It now covers the partner work lifecycle too:

- `assertCanStartWork` / `assertCanFinishWork` / `assertCanCompleteWork` / `assertCanDecline` — config-driven via new keys (`start_work_from`, `finish_work_from`, `complete_work_from`, `decline_from`), each preceded by an explicit terminal-status rejection (`isTerminal` / `TERMINAL_RUN_STATUSES`) with a clear error message
- `retrieveAndValidatePartnerRunStep` now delegates to the policy keyed by action; the start/finish/complete workflows drop their inline `allowedStatuses`/`requireStarted`/`requireFinished` flags
- The partner `decline` route delegates its state guards to `assertCanDecline` (the idempotent already-cancelled → 200 path stays in the route)

Behaviour is parity-preserving — same transitions allowed/blocked as before, but defined once.

## Tests

New `production-run-transition-guards.spec.ts` (7 tests): accept-on-cancelled, start-before-accept, double-start, finish-before-start, complete-before-finish, decline-after-start + pre-work decline + idempotent re-decline, and the full happy path accept→start→finish→complete.

Regression: cancel-workflows, partner-cancel-reassign-desync, production-run-partner-status, partners-decline-run, partners-production-runs, production-run-complete-yield, production-run-consumption-and-guards, production-runs-cross-ordering — all green. `medusa build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)