### PR TITLE
fix(web-media): resolve album_id as a public folder when no album matches (roadmap #22)

### DIFF
--- a/apps/backend/integration-tests/http/web-media-collection.spec.ts
+++ b/apps/backend/integration-tests/http/web-media-collection.spec.ts
@@ -1,0 +1,68 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(60000)
+
+// GET /web/media?album_id=… resolves the id as an Album first, then as a
+// public media FOLDER. The folder fallback is what feeds the storefront
+// hero paintings (folder `media_art_hero`) — roadmap bug #22 was this id
+// silently matching nothing and the hero degrading to the random pool.
+setupSharedTestSuite(() => {
+  describe("GET /web/media collection scoping", () => {
+    const { api, getContainer } = getSharedTestEnv()
+    let adminHeaders: any
+
+    beforeAll(async () => {
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+    })
+
+    it("returns a public folder's public images when album_id is a folder id", async () => {
+      const unique = Date.now()
+
+      const folderRes = await api.post(
+        "/admin/medias/folder",
+        { name: `Hero Paintings ${unique}`, is_public: true },
+        adminHeaders
+      )
+      expect(folderRes.status).toBe(201)
+      const folderId = folderRes.data.folder.id
+
+      const mediaService: any = getContainer().resolve("media")
+      const mk = (n: number, pub: boolean) =>
+        mediaService.createMediaFiles({
+          file_name: `painting-${unique}-${n}.jpg`,
+          original_name: `painting-${unique}-${n}.jpg`,
+          file_path: `https://cdn.example.com/painting-${unique}-${n}.jpg`,
+          file_type: "image",
+          mime_type: "image/jpeg",
+          file_size: 1000,
+          file_hash: `hash-${unique}-${n}`,
+          extension: "jpg",
+          is_public: pub,
+          folder_id: folderId,
+        })
+      await mk(1, true)
+      await mk(2, true)
+      await mk(3, false) // private — must not leak
+
+      const res = await api.get(
+        `/web/media?album_id=${folderId}&type=image&random=false&limit=50`
+      )
+      expect(res.status).toBe(200)
+      const paths = (res.data.medias || []).map((m: any) => m.file_path)
+      expect(paths).toContain(`https://cdn.example.com/painting-${unique}-1.jpg`)
+      expect(paths).toContain(`https://cdn.example.com/painting-${unique}-2.jpg`)
+      expect(paths).not.toContain(`https://cdn.example.com/painting-${unique}-3.jpg`)
+      expect(res.data.medias.length).toBe(2)
+    })
+
+    it("returns empty (not the global pool) for an unknown collection id", async () => {
+      const res = await api.get(
+        `/web/media?album_id=01HUNKNOWNCOLLECTION00000&type=image&random=false&limit=50`
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.medias).toEqual([])
+    })
+  })
+})

--- a/apps/backend/src/api/web/media/route.ts
+++ b/apps/backend/src/api/web/media/route.ts
@@ -2,6 +2,7 @@ import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
 import { MedusaError } from "@medusajs/framework/utils";
 import { listAllMediasWorkflow } from "../../../workflows/media/list-all-medias";
 import { listAlbumMediaWorkflow } from "../../../workflows/media/list-album-media";
+import { listMediaFileWorkflow } from "../../../workflows/media/list-media-file";
 
 /**
  * Public endpoint to list media files
@@ -11,8 +12,14 @@ import { listAlbumMediaWorkflow } from "../../../workflows/media/list-album-medi
  * - limit: number (default: 20, max: 100)
  * - random: boolean (default: true) - randomize the order
  * - type: string - filter by media type (image, video, etc.)
- * - album_id: string - return only public media that belong to this album
- *   (walks AlbumMedia → MediaFile and filters by is_public on the file).
+ * - album_id: string - return only public media that belong to this
+ *   collection. The id is tried as an Album first (AlbumMedia →
+ *   MediaFile); when no album rows match, it's tried as a media FOLDER
+ *   id (public files whose folder_id matches). The folder fallback
+ *   exists because curated hero sets are usually folders in the media
+ *   library (e.g. `media_art_hero`), and prod may have no Album rows at
+ *   all — without it, callers silently fell through to the random
+ *   public pool (roadmap bug #22: the hero paintings disappeared).
  */
 export const GET = async (
   req: MedusaRequest,
@@ -90,6 +97,26 @@ export const GET = async (
         .map((r: any) => r?.media)
         .filter((m: any) => m && (m.is_public !== false))
         .filter((m: any) => !type || m.file_type === type);
+
+      if (!mediaFiles.length) {
+        // No album rows — try the id as a public media FOLDER instead.
+        const { result: folderResult } = await listMediaFileWorkflow(
+          req.scope
+        ).run({
+          input: {
+            filters: {
+              folder_id: albumId,
+              is_public: true,
+              ...(type ? { file_type: type } : {}),
+            },
+            config: {
+              take: random ? Math.min((offset + limit) * 3, 500) : limit,
+              skip: random ? 0 : offset,
+            },
+          },
+        });
+        mediaFiles = ((folderResult as any)?.[0] ?? []) as any[];
+      }
     } else {
       const { result } = await listAllMediasWorkflow(req.scope).run({
         input: {


### PR DESCRIPTION
## Bug (issue #334)

The Cici Label storefront hero pulls its painting from `/web/media?album_id=01KS74M4JABCFKHB4WTF90KQYS`. That id is the **`media_art_hero` folder**, not an Album — and prod has zero Album rows. The album walk returned nothing, so the hero silently fell back to the random public pool: arbitrary WhatsApp/test uploads instead of the 6 curated open-archive paintings (the painting assets themselves are all healthy — verified by HEAD-checking every public media URL).

## Fix

`GET /web/media?album_id=…` now tries the id as an Album first, then as a public media **folder** (public files only, type filter respected). Unknown ids still return empty rather than leaking the global pool, so the storefront's client-side fallback behaviour is unchanged.

No storefront change or env-var change needed — the existing default id starts working as intended.

## Tests

`web-media-collection.spec.ts`: folder-as-collection returns its public images, excludes private files in the same folder, unknown id → empty. `media-upload-api` green; the 4 `website-public-api` failures are pre-existing on main (website/blog/subscribe, unrelated to media — verified by stash-rerun). Build clean.

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)