### PR TITLE
feat(storefront): /gallery page rendering the open-archive paintings

### DIFF
--- a/apps/storefront/src/app/[countryCode]/(main)/gallery/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/gallery/page.tsx
@@ -1,0 +1,83 @@
+import { Heading, Text } from "@medusajs/ui"
+import { Metadata } from "next"
+import Image from "next/image"
+
+import { buildPublicMediaUrl, listPublicMedia } from "@lib/data/media"
+import { GALLERY_ALBUM_ID } from "@lib/util/gallery"
+import imageLoader from "@lib/util/image-loader"
+
+export const metadata: Metadata = {
+  title: "Gallery — The Open Archive",
+  description:
+    "The open-archive paintings behind Cici Label's homepage — the full curated collection.",
+}
+
+/**
+ * The full open-archive collection the homepage hero draws from — every
+ * painting, not just one random pick per visit. Server-rendered; a CSS
+ * column layout keeps each painting's native aspect ratio (no crops).
+ */
+export default async function GalleryPage() {
+  const { medias } = await listPublicMedia({
+    limit: 100,
+    type: "image",
+    random: false,
+    albumId: GALLERY_ALBUM_ID,
+  }).catch(() => ({ medias: [] as any[] }))
+
+  const paintings = (medias || [])
+    .map((m) => ({
+      id: m.id,
+      url: buildPublicMediaUrl(m.file_path),
+      alt: m.alt_text || m.title || "Open archive painting",
+      title: m.title || null,
+      credit: m.caption || m.description || null,
+      width: m.width || 1200,
+      height: m.height || 900,
+    }))
+    .filter((p) => !!p.url)
+
+  return (
+    <div className="content-container py-12">
+      <div className="mb-10 max-w-xl">
+        <Heading level="h1" className="mb-3">
+          The Open Archive
+        </Heading>
+        <Text className="text-ui-fg-subtle">
+          The paintings behind our homepage — a small, rotating collection
+          drawn from open archives. One greets you at random on every
+          visit; this is all of them.
+        </Text>
+      </div>
+
+      {paintings.length === 0 ? (
+        <Text className="text-ui-fg-subtle">
+          The archive is being rehung — check back soon.
+        </Text>
+      ) : (
+        <div className="columns-1 small:columns-2 medium:columns-3 gap-6 [&>figure]:break-inside-avoid">
+          {paintings.map((p) => (
+            <figure key={p.id} className="mb-6">
+              <Image
+                loader={imageLoader}
+                src={p.url!}
+                alt={p.alt}
+                width={p.width}
+                height={p.height}
+                sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                className="w-full h-auto rounded-md shadow-elevation-card-rest"
+              />
+              {(p.title || p.credit) && (
+                <figcaption className="mt-2 text-ui-fg-subtle txt-small">
+                  {p.title}
+                  {p.title && p.credit ? " — " : ""}
+                  {p.credit}
+                </figcaption>
+              )}
+            </figure>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/storefront/src/lib/util/gallery.ts
+++ b/apps/storefront/src/lib/util/gallery.ts
@@ -1,0 +1,9 @@
+/**
+ * The curated "open archive" paintings collection. Resolved by the
+ * backend's /web/media?album_id=… — the id works as an Album OR a public
+ * media folder (the current prod set lives in the `media_art_hero`
+ * folder). Shared by the homepage hero (one random draw) and the
+ * /gallery page (the full set). Swappable without a redeploy via env.
+ */
+export const GALLERY_ALBUM_ID =
+  process.env.NEXT_PUBLIC_HERO_ALBUM_ID ?? "01KS74M4JABCFKHB4WTF90KQYS"

--- a/apps/storefront/src/modules/home/components/hero/index.tsx
+++ b/apps/storefront/src/modules/home/components/hero/index.tsx
@@ -1,4 +1,5 @@
 import { buildPublicMediaUrl, listPublicMedia } from "@lib/data/media"
+import { GALLERY_ALBUM_ID } from "@lib/util/gallery"
 import HeroVisual from "./hero-visual"
 
 /**
@@ -16,8 +17,7 @@ import HeroVisual from "./hero-visual"
  * front. Editors can rotate the curated set by adding / removing media
  * from the album in admin.
  */
-const HERO_ALBUM_ID =
-  process.env.NEXT_PUBLIC_HERO_ALBUM_ID ?? "01KS74M4JABCFKHB4WTF90KQYS"
+const HERO_ALBUM_ID = GALLERY_ALBUM_ID
 
 const Hero = async () => {
   const isDev = process.env.NODE_ENV === "development"

--- a/apps/storefront/src/modules/layout/templates/footer/index.tsx
+++ b/apps/storefront/src/modules/layout/templates/footer/index.tsx
@@ -166,6 +166,11 @@ export default async function Footer() {
                   </LocalizedClientLink>
                 </li>
                 <li>
+                  <LocalizedClientLink className="hover:text-ui-fg-base" href="/gallery">
+                    Gallery
+                  </LocalizedClientLink>
+                </li>
+                <li>
                   <LocalizedClientLink className="hover:text-ui-fg-base" href="/pages/privacy-policy">
                     Privacy Policy
                   </LocalizedClientLink>


### PR DESCRIPTION
## What

Companion to #369 (issue #334). The curated open-archive paintings are now a browsable storefront page, not just a single random hero draw.

- `/[countryCode]/gallery` — server-rendered, CSS-column masonry preserving each painting's native aspect ratio; captions from media title/caption; images served through the shared Cloudflare-aware `imageLoader`
- `GALLERY_ALBUM_ID` extracted to `@lib/util/gallery` — single source shared by the homepage hero and the gallery, still swappable via `NEXT_PUBLIC_HERO_ALBUM_ID`
- Footer "Info & Other" gains a **Gallery** link
- Empty collection renders a friendly "being rehung" note (matches the hero's graceful-fallback philosophy)

Requires the #369 backend deploy (in flight) for the folder-backed collection to return the paintings in prod.

`tsc` error count unchanged vs main (332 pre-existing React-types errors; none in the new files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)