### PR TITLE
fix(storefront): render gallery images in a client component

### DIFF
--- a/apps/storefront/src/app/[countryCode]/(main)/gallery/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/gallery/page.tsx
@@ -1,10 +1,9 @@
 import { Heading, Text } from "@medusajs/ui"
 import { Metadata } from "next"
-import Image from "next/image"
 
 import { buildPublicMediaUrl, listPublicMedia } from "@lib/data/media"
 import { GALLERY_ALBUM_ID } from "@lib/util/gallery"
-import imageLoader from "@lib/util/image-loader"
+import GalleryGrid, { GalleryPainting } from "@modules/gallery/gallery-grid"
 
 export const metadata: Metadata = {
   title: "Gallery — The Open Archive",
@@ -25,10 +24,10 @@ export default async function GalleryPage() {
     albumId: GALLERY_ALBUM_ID,
   }).catch(() => ({ medias: [] as any[] }))
 
-  const paintings = (medias || [])
+  const paintings: GalleryPainting[] = (medias || [])
     .map((m) => ({
       id: m.id,
-      url: buildPublicMediaUrl(m.file_path),
+      url: buildPublicMediaUrl(m.file_path) || "",
       alt: m.alt_text || m.title || "Open archive painting",
       title: m.title || null,
       credit: m.caption || m.description || null,
@@ -55,28 +54,7 @@ export default async function GalleryPage() {
           The archive is being rehung — check back soon.
         </Text>
       ) : (
-        <div className="columns-1 small:columns-2 medium:columns-3 gap-6 [&>figure]:break-inside-avoid">
-          {paintings.map((p) => (
-            <figure key={p.id} className="mb-6">
-              <Image
-                loader={imageLoader}
-                src={p.url!}
-                alt={p.alt}
-                width={p.width}
-                height={p.height}
-                sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
-                className="w-full h-auto rounded-md shadow-elevation-card-rest"
-              />
-              {(p.title || p.credit) && (
-                <figcaption className="mt-2 text-ui-fg-subtle txt-small">
-                  {p.title}
-                  {p.title && p.credit ? " — " : ""}
-                  {p.credit}
-                </figcaption>
-              )}
-            </figure>
-          ))}
-        </div>
+        <GalleryGrid paintings={paintings} />
       )}
     </div>
   )

--- a/apps/storefront/src/modules/gallery/gallery-grid.tsx
+++ b/apps/storefront/src/modules/gallery/gallery-grid.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import Image from "next/image"
+import imageLoader from "@lib/util/image-loader"
+
+export type GalleryPainting = {
+  id: string
+  url: string
+  alt: string
+  title: string | null
+  credit: string | null
+  width: number
+  height: number
+}
+
+/**
+ * Client component so next/image can take the custom Cloudflare-aware
+ * loader (function props can't cross the RSC boundary — same reason the
+ * homepage hero renders its painting inside HeroVisual).
+ */
+export default function GalleryGrid({
+  paintings,
+}: {
+  paintings: GalleryPainting[]
+}) {
+  return (
+    <div className="columns-1 small:columns-2 medium:columns-3 gap-6 [&>figure]:break-inside-avoid">
+      {paintings.map((p) => (
+        <figure key={p.id} className="mb-6">
+          <Image
+            loader={imageLoader}
+            src={p.url}
+            alt={p.alt}
+            width={p.width}
+            height={p.height}
+            sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
+            className="w-full h-auto rounded-md shadow-elevation-card-rest"
+          />
+          {(p.title || p.credit) && (
+            <figcaption className="mt-2 text-ui-fg-subtle txt-small">
+              {p.title}
+              {p.title && p.credit ? " — " : ""}
+              {p.credit}
+            </figcaption>
+          )}
+        </figure>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
Follow-up to #370 — `/gallery` 500'd in production because the page (a Server Component) passed the `imageLoader` function to `next/image`; function props can't cross the RSC boundary. The grid now lives in a `'use client'` `GalleryGrid` (mirroring how the hero renders inside `HeroVisual`), and the server page passes plain serializable data.

Verified the failure mode on prod: `/in/zzz-bogus` → 404, `/in/what-is-a-design-score` → 200, `/in/gallery` → 500 (runtime, not routing). Will re-verify after the Vercel deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)