### PR TITLE
fix(storefront): derive base URL from Vercel env instead of localhost

### DIFF
--- a/apps/storefront/src/lib/util/env.ts
+++ b/apps/storefront/src/lib/util/env.ts
@@ -1,3 +1,28 @@
+/**
+ * Resolve the storefront's public base URL.
+ *
+ * Priority:
+ * 1. NEXT_PUBLIC_BASE_URL — explicit override (rarely set per partner)
+ * 2. VERCEL_PROJECT_PRODUCTION_URL — injected by Vercel into every
+ *    deployment; resolves to the project's production domain (the
+ *    partner's custom domain when one is attached). This is what makes
+ *    canonicals / sitemap / robots correct on partner storefronts with
+ *    zero per-project configuration.
+ * 3. VERCEL_URL — the deployment's own *.vercel.app host (previews)
+ * 4. localhost — local dev only
+ *
+ * Without 2–4 every partner store shipped `https://localhost:8000`
+ * canonicals and sitemap entries to Google (roadmap #12).
+ */
 export const getBaseURL = () => {
-  return process.env.NEXT_PUBLIC_BASE_URL || "https://localhost:8000"
+  if (process.env.NEXT_PUBLIC_BASE_URL) {
+    return process.env.NEXT_PUBLIC_BASE_URL
+  }
+  if (process.env.VERCEL_PROJECT_PRODUCTION_URL) {
+    return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+  }
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`
+  }
+  return "https://localhost:8000"
 }


### PR DESCRIPTION
Part of #349 ([#12] SEO). Every partner storefront (and potentially cicilabel) serves `https://localhost:8000` canonicals, sitemap entries and robots Sitemap lines because `NEXT_PUBLIC_BASE_URL` is never set per deployment.

`getBaseURL()` now falls back to **`VERCEL_PROJECT_PRODUCTION_URL`** (injected by Vercel into every deployment; resolves to the project's production custom domain) and `VERCEL_URL` (previews) before localhost — zero per-project configuration needed.

- `apps/storefront` (cicilabel): this PR
- `storefront-starter` (partner template): pushed directly to its main as `4ff61ae` (submodule pointer bumped here); partner storefronts pick it up on redeploy — canary (Sharlho) first, then the fleet

🤖 Generated with [Claude Code](https://claude.com/claude-code)