### PR TITLE
feat(partner): attach custom domains as www+apex pairs (roadmap #17)

### DIFF
--- a/apps/backend/integration-tests/http/storefront-domain-pair.spec.ts
+++ b/apps/backend/integration-tests/http/storefront-domain-pair.spec.ts
@@ -1,0 +1,85 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { deriveDomainPair } from "../../src/workflows/partners/attach-storefront-domain"
+
+jest.setTimeout(60000)
+
+// Roadmap #17 (issue #346): a partner custom domain attaches as a www+apex
+// pair. deriveDomainPair is the single source of the pairing rule; the
+// alias-registration behaviour is pinned through the website module.
+
+// Pure-function tests live OUTSIDE the shared suite — they need no DB,
+// and the suite's per-test TRUNCATE can deadlock against the index
+// engine's boot-time sync.
+describe("deriveDomainPair", () => {
+  it("derives www/apex twins (and none for deeper subdomains)", () => {
+    expect(deriveDomainPair("example.com")).toEqual({
+      primary: "example.com",
+      counterpart: "www.example.com",
+    })
+    expect(deriveDomainPair("www.example.com")).toEqual({
+      primary: "www.example.com",
+      counterpart: "example.com",
+    })
+    expect(deriveDomainPair("shop.example.com")).toEqual({
+      primary: "shop.example.com",
+      counterpart: null,
+    })
+    // www at depth 3+ is itself a subdomain of a subdomain — no twin
+    expect(deriveDomainPair("www.shop.example.com")).toEqual({
+      primary: "www.shop.example.com",
+      counterpart: null,
+    })
+  })
+})
+
+setupSharedTestSuite(() => {
+  describe("storefront domain pairing", () => {
+    const { api, getContainer } = getSharedTestEnv()
+
+    it("registers both pair hosts as website_domain aliases (resolvable via /web/website)", async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      const adminHeaders = await getAuthHeaders(api)
+      const unique = Date.now()
+
+      // Create a website to alias against
+      const siteRes = await api.post(
+        "/admin/websites",
+        {
+          name: `Pair Test ${unique}`,
+          domain: `pair-${unique}.cicilabel.com`,
+          status: "Active",
+        },
+        adminHeaders
+      )
+      expect([200, 201]).toContain(siteRes.status)
+      const websiteId = siteRes.data.website.id
+
+      // Same upsert the workflow's registerWebsiteAliasesStep performs
+      const websiteService: any = container.resolve("websites")
+      for (const host of [`pair-${unique}.com`, `www.pair-${unique}.com`]) {
+        const [existing] = await websiteService.listAndCountWebsiteDomains(
+          { domain: host },
+          { take: 1 }
+        )
+        if (!existing?.length) {
+          await websiteService.createWebsiteDomains({
+            domain: host,
+            is_primary: false,
+            website_id: websiteId,
+          })
+        }
+      }
+
+      // Both forms must resolve through the public host-based lookup
+      for (const host of [`pair-${unique}.com`, `www.pair-${unique}.com`]) {
+        const res = await api.get(`/web/website/${host}`, {
+          validateStatus: () => true,
+        })
+        expect(res.status).toBe(200)
+        expect(res.data.name).toBe(`Pair Test ${unique}`)
+      }
+    })
+  })
+})

--- a/apps/backend/src/api/partners/storefront/domain/route.ts
+++ b/apps/backend/src/api/partners/storefront/domain/route.ts
@@ -10,6 +10,10 @@ import type { VercelDomainConfig } from "../../../../modules/deployment/service"
 import { WEBSITE_MODULE } from "../../../../modules/website"
 import type WebsiteService from "../../../../modules/website/service"
 import updatePartnerWorkflow from "../../../../workflows/partners/update-partner"
+import {
+  attachStorefrontDomainWorkflow,
+  deriveDomainPair,
+} from "../../../../workflows/partners/attach-storefront-domain"
 import { getStorefrontRefs } from "../helpers"
 
 /**
@@ -80,24 +84,35 @@ export const GET = async (
 
   const deployment: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
 
+  const pair = deriveDomainPair(customDomain)
+  const buildPairRecords = (config: VercelDomainConfig | null) => {
+    const records = [...buildDnsRecords(pair.primary, config)]
+    if (pair.counterpart) {
+      records.push(...buildDnsRecords(pair.counterpart, config))
+    }
+    return records
+  }
+
   try {
     const config = await deployment.getDomainConfig(customDomain)
     return res.json({
       configured: true,
       domain: customDomain,
+      redirect_from: pair.counterpart,
       verified: partner.metadata?.custom_domain_verified === true,
       misconfigured: config.misconfigured,
       configured_by: config.configuredBy,
-      dns_records: buildDnsRecords(customDomain, config),
+      dns_records: buildPairRecords(config),
     })
   } catch {
     return res.json({
       configured: true,
       domain: customDomain,
+      redirect_from: pair.counterpart,
       verified: partner.metadata?.custom_domain_verified === true,
       misconfigured: true,
       configured_by: null,
-      dns_records: buildDnsRecords(customDomain, null),
+      dns_records: buildPairRecords(null),
     })
   }
 }
@@ -142,63 +157,45 @@ export const POST = async (
     )
   }
 
-  const deployment: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
+  // Roadmap #17 — the whole attach (Vercel www+apex pair with redirect,
+  // NEXT_PUBLIC_BASE_URL env, partner metadata, website_domain aliases)
+  // lives in the workflow with compensation.
+  const websiteId =
+    ((partner as any).website_id || partner.metadata?.website_id || null) as
+      | string
+      | null
 
-  // Add domain to Vercel project
-  const result = await deployment.addDomain(vercelProjectId, cleaned)
-
-  // Get DNS config so we can show instructions
-  let config: VercelDomainConfig | null = null
-  try {
-    config = await deployment.getDomainConfig(cleaned)
-  } catch {
-    // non-critical
-  }
-
-  // Save to partner metadata
-  await updatePartnerWorkflow(req.scope).run({
+  const { result } = await attachStorefrontDomainWorkflow(req.scope).run({
     input: {
-      id: partner.id,
-      data: {
-        metadata: {
-          ...(partner.metadata || {}),
-          custom_domain: cleaned,
-          custom_domain_verified: result.verified,
-        },
-      },
+      partner_id: partner.id,
+      vercel_project_id: vercelProjectId,
+      website_id: websiteId,
+      domain: cleaned,
+      prev_metadata: (partner.metadata || {}) as Record<string, any>,
     },
   })
 
-  // Register the custom domain as a website alias so backend lookups resolve
-  // this partner's content. Best-effort: don't fail the request if it errors.
-  const websiteId =
-    (partner as any).website_id || partner.metadata?.website_id
-  if (websiteId) {
-    try {
-      const websiteService: WebsiteService = req.scope.resolve(WEBSITE_MODULE)
-      const [existing] = await (websiteService as any).listAndCountWebsiteDomains(
-        { domain: cleaned },
-        { take: 1 }
-      )
-      if (!existing?.length) {
-        await (websiteService as any).createWebsiteDomains({
-          domain: cleaned,
-          is_primary: false,
-          website_id: websiteId,
-        })
-      }
-    } catch (e) {
-      // non-fatal — storefront lookups can fall back through partner.storefront_domain
-    }
+  // DNS instructions for both hosts (best-effort).
+  const deployment: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
+  let config: VercelDomainConfig | null = null
+  try {
+    config = await deployment.getDomainConfig(result.primary)
+  } catch {
+    // non-critical
+  }
+  const dnsRecords = [...buildDnsRecords(result.primary, config)]
+  if (result.counterpart) {
+    dnsRecords.push(...buildDnsRecords(result.counterpart, config))
   }
 
   res.status(201).json({
-    domain: cleaned,
+    domain: result.primary,
+    redirect_from: result.counterpart,
     verified: result.verified,
     verification: result.verification || null,
     misconfigured: config?.misconfigured ?? true,
     configured_by: config?.configuredBy ?? null,
-    dns_records: buildDnsRecords(cleaned, config),
+    dns_records: dnsRecords,
   })
 }
 
@@ -230,10 +227,17 @@ export const DELETE = async (
 
   const deployment: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
 
-  try {
-    await deployment.removeDomain(vercelProjectId, customDomain)
-  } catch {
-    // best-effort removal
+  // Remove BOTH hosts (primary + its www/apex twin — see deriveDomainPair)
+  const pair = deriveDomainPair(customDomain)
+  const hosts = [pair.primary, pair.counterpart].filter(
+    (h): h is string => !!h
+  )
+  for (const host of hosts) {
+    try {
+      await deployment.removeDomain(vercelProjectId, host)
+    } catch {
+      // best-effort removal
+    }
   }
 
   // Clear from metadata
@@ -248,16 +252,18 @@ export const DELETE = async (
     },
   })
 
-  // Soft-delete the alias row so lookups stop resolving the custom domain
+  // Soft-delete the alias rows so lookups stop resolving the custom domain
   try {
     const websiteService: WebsiteService = req.scope.resolve(WEBSITE_MODULE)
-    const [rows] = await (websiteService as any).listAndCountWebsiteDomains(
-      { domain: customDomain },
-      { take: 1 }
-    )
-    const row = rows?.[0]
-    if (row && !row.is_primary) {
-      await (websiteService as any).softDeleteWebsiteDomains(row.id)
+    for (const host of hosts) {
+      const [rows] = await (websiteService as any).listAndCountWebsiteDomains(
+        { domain: host },
+        { take: 1 }
+      )
+      const row = rows?.[0]
+      if (row && !row.is_primary) {
+        await (websiteService as any).softDeleteWebsiteDomains(row.id)
+      }
     }
   } catch {
     // best-effort

--- a/apps/backend/src/modules/deployment/service.ts
+++ b/apps/backend/src/modules/deployment/service.ts
@@ -281,14 +281,23 @@ class DeploymentService extends MedusaService({}) {
     }
   }
 
-  async addDomain(projectId: string, domain: string): Promise<VercelDomain> {
+  async addDomain(
+    projectId: string,
+    domain: string,
+    opts?: { redirect?: string; redirectStatusCode?: 301 | 302 | 307 | 308 }
+  ): Promise<VercelDomain> {
+    const body: Record<string, any> = { name: domain }
+    if (opts?.redirect) {
+      body.redirect = opts.redirect
+      body.redirectStatusCode = opts.redirectStatusCode ?? 308
+    }
     const res = await fetch(
       `${VERCEL_API_BASE}/v10/projects/${projectId}/domains${this.vercelTeamQuery()}`,
-      { method: "POST", headers: this.vercelHeaders(), body: JSON.stringify({ name: domain }) }
+      { method: "POST", headers: this.vercelHeaders(), body: JSON.stringify(body) }
     )
     if (!res.ok) {
-      const body = await res.text()
-      throw new Error(`Vercel addDomain failed (${res.status}): ${body}`)
+      const text = await res.text()
+      throw new Error(`Vercel addDomain failed (${res.status}): ${text}`)
     }
     return res.json()
   }

--- a/apps/backend/src/workflows/partners/attach-storefront-domain.ts
+++ b/apps/backend/src/workflows/partners/attach-storefront-domain.ts
@@ -1,0 +1,275 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  transform,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+
+import { DEPLOYMENT_MODULE } from "../../modules/deployment"
+import type DeploymentService from "../../modules/deployment/service"
+import { WEBSITE_MODULE } from "../../modules/website"
+import type WebsiteService from "../../modules/website/service"
+import { PARTNER_MODULE } from "../../modules/partner"
+
+/**
+ * Roadmap #17 (issue #346) — a partner's custom domain should work in both
+ * its www and apex forms. The submitted host is the canonical one; the
+ * counterpart is attached to the same Vercel project as a permanent
+ * redirect, and BOTH are registered as `website_domain` aliases so the
+ * storefront's host-based website lookup resolves either form (the gap
+ * that left sharlho.com showing the generic "Store" template).
+ */
+
+export type DomainPair = {
+  /** The host the partner asked for — canonical, serves traffic. */
+  primary: string
+  /** The www/apex twin — redirects to primary. Null for deeper subdomains. */
+  counterpart: string | null
+}
+
+/**
+ * apex → www twin; www → apex twin; anything deeper (shop.example.com)
+ * has no twin. Assumes an already-cleaned lowercase host.
+ */
+export function deriveDomainPair(domain: string): DomainPair {
+  const parts = domain.split(".")
+  if (parts[0] === "www" && parts.length === 3) {
+    return { primary: domain, counterpart: parts.slice(1).join(".") }
+  }
+  if (parts.length === 2) {
+    return { primary: domain, counterpart: `www.${domain}` }
+  }
+  return { primary: domain, counterpart: null }
+}
+
+export type AttachStorefrontDomainInput = {
+  partner_id: string
+  vercel_project_id: string
+  website_id: string | null
+  domain: string
+  prev_metadata: Record<string, any>
+}
+
+/** Is this Vercel error just "the domain is already on this project"? */
+const isAlreadyAttached = (message: string) =>
+  /already in use by (one of )?your|domain_already_in_use|already exists/i.test(message)
+
+type VercelPairComp = { project_id: string; created: string[] }
+const addVercelDomainPairStep = createStep(
+  "asd-add-vercel-domain-pair",
+  async (
+    input: { vercel_project_id: string; pair: DomainPair },
+    { container }
+  ) => {
+    const deployment: DeploymentService = container.resolve(DEPLOYMENT_MODULE)
+    const created: string[] = []
+    let verified = false
+    let verification: any = null
+
+    try {
+      const res = await deployment.addDomain(
+        input.vercel_project_id,
+        input.pair.primary
+      )
+      verified = !!res.verified
+      verification = res.verification || null
+      created.push(input.pair.primary)
+    } catch (e: any) {
+      if (!isAlreadyAttached(String(e?.message || ""))) throw e
+      verified = true // already attached to this project — treated as live
+    }
+
+    if (input.pair.counterpart) {
+      try {
+        await deployment.addDomain(
+          input.vercel_project_id,
+          input.pair.counterpart,
+          { redirect: input.pair.primary, redirectStatusCode: 308 }
+        )
+        created.push(input.pair.counterpart)
+      } catch (e: any) {
+        // The twin is best-effort: it may be parked on another project or
+        // owned by someone else — that must not block the primary attach.
+        if (!isAlreadyAttached(String(e?.message || ""))) {
+          console.warn(
+            `[attach-storefront-domain] counterpart ${input.pair.counterpart} not attached:`,
+            e?.message
+          )
+        }
+      }
+    }
+
+    return new StepResponse<
+      { verified: boolean; verification: any; created: string[] },
+      VercelPairComp
+    >(
+      { verified, verification, created },
+      { project_id: input.vercel_project_id, created }
+    )
+  },
+  async (comp: VercelPairComp | undefined, { container }) => {
+    if (!comp?.created?.length) return
+    const deployment: DeploymentService = container.resolve(DEPLOYMENT_MODULE)
+    for (const d of comp.created) {
+      await deployment.removeDomain(comp.project_id, d).catch(() => {})
+    }
+  }
+)
+
+/**
+ * NEXT_PUBLIC_BASE_URL drives canonicals/sitemap/robots on the storefront
+ * (see storefront-starter getBaseURL). Explicitly pinning it to the
+ * partner's canonical host beats relying on VERCEL_PROJECT_PRODUCTION_URL,
+ * which picks the *shortest* attached domain. Build-time var — takes
+ * effect on the next deployment.
+ */
+const setBaseUrlEnvStep = createStep(
+  "asd-set-base-url-env",
+  async (
+    input: { vercel_project_id: string; primary: string },
+    { container }
+  ) => {
+    const deployment: DeploymentService = container.resolve(DEPLOYMENT_MODULE)
+    try {
+      await deployment.setEnvironmentVariables(input.vercel_project_id, [
+        {
+          key: "NEXT_PUBLIC_BASE_URL",
+          value: `https://${input.primary}`,
+          target: ["production"],
+        },
+      ])
+      return new StepResponse({ set: true })
+    } catch (e: any) {
+      // Non-fatal: canonical falls back to VERCEL_PROJECT_PRODUCTION_URL.
+      console.warn("[attach-storefront-domain] env upsert failed:", e?.message)
+      return new StepResponse({ set: false })
+    }
+  }
+)
+
+type MetadataComp = { partner_id: string; prev_metadata: Record<string, any> }
+const updatePartnerDomainMetadataStep = createStep(
+  "asd-update-partner-metadata",
+  async (
+    input: {
+      partner_id: string
+      prev_metadata: Record<string, any>
+      domain: string
+      verified: boolean
+    },
+    { container }
+  ) => {
+    const partnerService: any = container.resolve(PARTNER_MODULE)
+    await partnerService.updatePartners({
+      id: input.partner_id,
+      metadata: {
+        ...(input.prev_metadata || {}),
+        custom_domain: input.domain,
+        custom_domain_verified: input.verified,
+      },
+    })
+    return new StepResponse<{ ok: boolean }, MetadataComp>(
+      { ok: true },
+      { partner_id: input.partner_id, prev_metadata: input.prev_metadata }
+    )
+  },
+  async (comp: MetadataComp | undefined, { container }) => {
+    if (!comp) return
+    const partnerService: any = container.resolve(PARTNER_MODULE)
+    await partnerService.updatePartners({
+      id: comp.partner_id,
+      metadata: comp.prev_metadata,
+    })
+  }
+)
+
+type AliasComp = { created_ids: string[] }
+const registerWebsiteAliasesStep = createStep(
+  "asd-register-website-aliases",
+  async (
+    input: { website_id: string | null; pair: DomainPair },
+    { container }
+  ) => {
+    if (!input.website_id) {
+      return new StepResponse<{ created: number }, AliasComp>(
+        { created: 0 },
+        { created_ids: [] }
+      )
+    }
+    const websiteService: WebsiteService = container.resolve(WEBSITE_MODULE)
+    const hosts = [input.pair.primary, input.pair.counterpart].filter(
+      (h): h is string => !!h
+    )
+    const createdIds: string[] = []
+    for (const host of hosts) {
+      const [existing] = await (websiteService as any).listAndCountWebsiteDomains(
+        { domain: host },
+        { take: 1 }
+      )
+      if (!existing?.length) {
+        const row = await (websiteService as any).createWebsiteDomains({
+          domain: host,
+          is_primary: false,
+          website_id: input.website_id,
+        })
+        if (row?.id) createdIds.push(row.id)
+      }
+    }
+    return new StepResponse<{ created: number }, AliasComp>(
+      { created: createdIds.length },
+      { created_ids: createdIds }
+    )
+  },
+  async (comp: AliasComp | undefined, { container }) => {
+    if (!comp?.created_ids?.length) return
+    const websiteService: WebsiteService = container.resolve(WEBSITE_MODULE)
+    for (const id of comp.created_ids) {
+      await (websiteService as any).softDeleteWebsiteDomains(id).catch(() => {})
+    }
+  }
+)
+
+export const attachStorefrontDomainWorkflow = createWorkflow(
+  "attach-storefront-domain",
+  (input: AttachStorefrontDomainInput) => {
+    const pair = transform({ input }, (d) => deriveDomainPair(d.input.domain))
+
+    const vercelInput = transform({ input, pair }, (d) => ({
+      vercel_project_id: d.input.vercel_project_id,
+      pair: d.pair,
+    }))
+    const vercel = addVercelDomainPairStep(vercelInput)
+
+    const envInput = transform({ input, pair }, (d) => ({
+      vercel_project_id: d.input.vercel_project_id,
+      primary: d.pair.primary,
+    }))
+    setBaseUrlEnvStep(envInput)
+
+    const metaInput = transform({ input, pair, vercel }, (d) => ({
+      partner_id: d.input.partner_id,
+      prev_metadata: d.input.prev_metadata,
+      domain: d.pair.primary,
+      verified: d.vercel.verified,
+    }))
+    updatePartnerDomainMetadataStep(metaInput)
+
+    const aliasInput = transform({ input, pair }, (d) => ({
+      website_id: d.input.website_id,
+      pair: d.pair,
+    }))
+    const aliases = registerWebsiteAliasesStep(aliasInput)
+
+    const result = transform({ pair, vercel, aliases }, (d) => ({
+      primary: d.pair.primary,
+      counterpart: d.pair.counterpart,
+      verified: d.vercel.verified,
+      verification: d.vercel.verification,
+      created_aliases: d.aliases.created,
+    }))
+
+    return new WorkflowResponse(result)
+  }
+)


### PR DESCRIPTION
Closes #346.

A partner custom domain now works in both its forms, automatically:

- **Vercel**: the submitted host attaches normally; its www/apex twin attaches with a 308 redirect to it (deeper subdomains like `shop.example.com` have no twin). `deployment.addDomain` gains the v10 `redirect`/`redirectStatusCode` params.
- **Canonical base URL**: `NEXT_PUBLIC_BASE_URL` is upserted on the project pointing at the canonical host, so storefront canonicals/sitemap/robots resolve to the partner's domain (the GOF nuance from #349) — takes effect on next deployment.
- **Backend aliases**: BOTH hosts get `website_domain` rows, so the host-based website lookup resolves either form — the exact missing data that left sharlho.com serving the generic "Store" template until fixed by hand this week.
- All of it lives in `attachStorefrontDomainWorkflow` with compensation (Vercel domains removed, metadata restored, alias rows soft-deleted). The route keeps guards + DNS instructions (now for both hosts, plus `redirect_from`). DELETE cleans up the pair.

**Tests**: `storefront-domain-pair.spec.ts` — pairing rules (apex↔www, subdomain exemption) + both alias hosts resolving through public `/web/website/:domain`. Note: the pure-function tests sit outside `setupSharedTestSuite` deliberately — the shared suite's first-test TRUNCATE can deadlock against the index engine's boot-time sync (pre-existing flake, also seen on unrelated suites).

**Follow-up (not this PR)**: migrating GOF's existing gof.asia onto its own Vercel project — its DNS currently routes via the cicilabel subdomain and moving a live domain deserves its own change window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)