### PR TITLE
fix(designs): link designs to orders on purchase (roadmap #29)

### DIFF
--- a/apps/backend/integration-tests/http/admin-api-key-auth.spec.ts
+++ b/apps/backend/integration-tests/http/admin-api-key-auth.spec.ts
@@ -1,0 +1,71 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(60000)
+
+// PR #381: /admin/* routes get Medusa's default admin auth (session +
+// bearer + api-key). Eleven matchers had re-registered authenticate()
+// with only ["session","bearer"], silently breaking secret-key (sk_*)
+// access. These tests pin api-key access on representatives of those
+// routes so the narrowing can't sneak back in.
+//
+// NOTE: the shared suite truncates the DB around each test, so the
+// api key MUST be created inside each test (a beforeAll key is wiped
+// before later tests run — bearer JWTs survive because they don't
+// need a DB row, which makes the failure mode extra confusing).
+setupSharedTestSuite(() => {
+  describe("admin routes accept secret-key auth", () => {
+    const { api, getContainer } = getSharedTestEnv()
+
+    async function setupKey() {
+      await createAdminUser(getContainer())
+      const adminHeaders = await getAuthHeaders(api)
+      const keyRes = await api.post(
+        "/admin/api-keys",
+        { title: `auth-spec-${Date.now()}`, type: "secret" },
+        adminHeaders
+      )
+      expect(keyRes.status).toBe(200)
+      const token = keyRes.data.api_key.token
+      expect(String(token)).toMatch(/^sk_/)
+      // Secret keys authenticate as HTTP Basic with the key as username.
+      const apiKeyHeaders = {
+        headers: {
+          Authorization: `Basic ${Buffer.from(`${token}:`).toString("base64")}`,
+        },
+      }
+      return { adminHeaders, apiKeyHeaders }
+    }
+
+    it.each([
+      ["/admin/designs/orders", [200]],
+      // 404/4xx for the fake ids is fine — anything but 401 proves auth.
+      ["/admin/orders/order_fake/design", [200, 404, 500]],
+      ["/admin/customers/cus_fake/designs/ordered", [200, 404, 500]],
+    ])("GET %s does not 401 with an sk_ key", async (path, okStatuses) => {
+      const { apiKeyHeaders } = await setupKey()
+      const res = await api.get(path, {
+        ...apiKeyHeaders,
+        validateStatus: () => true,
+      })
+      expect(res.status).not.toBe(401)
+      expect(okStatuses).toContain(res.status)
+    })
+
+    it("still rejects unauthenticated requests", async () => {
+      const res = await api.get("/admin/designs/orders", {
+        validateStatus: () => true,
+      })
+      expect(res.status).toBe(401)
+    })
+
+    it("still accepts bearer auth", async () => {
+      const { adminHeaders } = await setupKey()
+      const res = await api.get("/admin/designs/orders", {
+        ...adminHeaders,
+        validateStatus: () => true,
+      })
+      expect(res.status).toBe(200)
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/design-order-links.spec.ts
+++ b/apps/backend/integration-tests/http/design-order-links.spec.ts
@@ -1,0 +1,128 @@
+import { Modules, ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { linkDesignsToOrder } from "../../src/workflows/designs/link-designs-to-order"
+import designOrderLink from "../../src/links/design-order-link"
+import { DESIGN_MODULE } from "../../src/modules/designs"
+
+jest.setTimeout(60000)
+
+// Roadmap #29 / issue #379: customer purchases never reflected on the
+// admin "Design Orders" view because the order.placed subscriber's
+// design→order linking read `cart_id` off the order model (it's the
+// order_cart LINK) and silently no-oped. linkDesignsToOrder is the
+// fixed shared traversal (subscriber + backfill).
+setupSharedTestSuite(() => {
+  describe("design → order linking on purchase", () => {
+    const { api, getContainer } = getSharedTestEnv()
+    let adminHeaders: any
+
+    beforeAll(async () => {
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+    })
+
+    async function seedPurchase() {
+      const container = getContainer()
+      const unique = Date.now() + Math.floor(Math.random() * 1000)
+
+      const designRes = await api.post(
+        "/admin/designs",
+        {
+          name: `Design Order Link ${unique}`,
+          description: "x",
+          design_type: "Original",
+          status: "Approved",
+          priority: "Medium",
+        },
+        adminHeaders
+      )
+      expect(designRes.status).toBe(201)
+      const designId = designRes.data.design.id
+
+      // Cart with one line item (the design-to-cart flow shape)
+      const cartService: any = container.resolve(Modules.CART)
+      const cart = await cartService.createCarts({ currency_code: "inr" })
+      const [lineItem] = await cartService.addLineItems([
+        {
+          cart_id: cart.id,
+          title: `Design ${unique}`,
+          quantity: 1,
+          unit_price: 1000,
+        },
+      ])
+
+      // design ↔ cart line item (created when the design is added to cart)
+      const remoteLink: any = container.resolve(ContainerRegistrationKeys.LINK)
+      await remoteLink.create({
+        [DESIGN_MODULE]: { design_id: designId },
+        [Modules.CART]: { line_item_id: lineItem.id },
+      })
+
+      // Customer completes the cart → an order exists, linked via order_cart
+      const orderService: any = container.resolve(Modules.ORDER)
+      const order = await orderService.createOrders({
+        currency_code: "inr",
+        items: [{ title: `Design ${unique}`, quantity: 1, unit_price: 1000 }],
+      })
+      await remoteLink.create({
+        [Modules.ORDER]: { order_id: order.id },
+        [Modules.CART]: { cart_id: cart.id },
+      })
+
+      return { container, designId, cartId: cart.id, orderId: order.id }
+    }
+
+    it("links the cart's designs to the order (idempotently)", async () => {
+      const { container, designId, orderId } = await seedPurchase()
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+      const first = await linkDesignsToOrder(container as any, orderId)
+      expect(first.linked).toBe(1)
+      expect(first.design_ids).toEqual([designId])
+
+      const { data: links } = await query.graph({
+        entity: designOrderLink.entryPoint,
+        filters: { order_id: orderId },
+        fields: ["design_id"],
+      })
+      expect((links || []).map((l: any) => l.design_id)).toContain(designId)
+
+      // Idempotent
+      const second = await linkDesignsToOrder(container as any, orderId)
+      expect(second.linked).toBe(0)
+    })
+
+    it("dry-run reports the would-be links without writing", async () => {
+      const { container, designId, orderId } = await seedPurchase()
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+      const dry = await linkDesignsToOrder(container as any, orderId, {
+        dryRun: true,
+      })
+      expect(dry.linked).toBe(1)
+      expect(dry.design_ids).toEqual([designId])
+
+      const { data: links } = await query.graph({
+        entity: designOrderLink.entryPoint,
+        filters: { order_id: orderId },
+        fields: ["design_id"],
+      })
+      expect(links || []).toHaveLength(0)
+    })
+
+    it("admin design-orders view shows the order once linked", async () => {
+      const { container, designId, orderId } = await seedPurchase()
+      await linkDesignsToOrder(container as any, orderId)
+
+      const res = await api.get("/admin/designs/orders?limit=50", adminHeaders)
+      expect(res.status).toBe(200)
+      const group = (res.data.design_orders || []).find((g: any) =>
+        (g.items || []).some((i: any) => i.design?.id === designId)
+      )
+      expect(group).toBeDefined()
+      expect(group.order).toBeTruthy()
+      expect(group.order.id).toBe(orderId)
+    })
+  })
+})

--- a/apps/backend/src/admin/routes/design-orders/page.tsx
+++ b/apps/backend/src/admin/routes/design-orders/page.tsx
@@ -255,7 +255,11 @@ const useColumns = () =>
         header: "Payment",
         cell: ({ getValue }) => {
           const order = getValue();
-          if (!order) return <span className="text-ui-fg-muted">—</span>;
+          // payment_status only ships once the design↔order link exists
+          // (roadmap #29) — guard so a linked order without the computed
+          // field can't crash the whole table.
+          if (!order?.payment_status)
+            return <span className="text-ui-fg-muted">—</span>;
           return (
             <Badge
               color={getPaymentStatusColor(order.payment_status)}

--- a/apps/backend/src/api/admin/designs/orders/route.ts
+++ b/apps/backend/src/api/admin/designs/orders/route.ts
@@ -55,7 +55,7 @@ export async function GET(
       query.graph({
         entity: designOrderLink.entryPoint,
         filters: { design_id: designIds },
-        fields: ["design_id", "order_id", "order.id", "order.display_id", "order.status", "order.total", "order.currency_code", "order.created_at"],
+        fields: ["design_id", "order_id", "order.id", "order.display_id", "order.status", "order.payment_status", "order.fulfillment_status", "order.total", "order.currency_code", "order.created_at"],
       }),
     ]);
 

--- a/apps/backend/src/scripts/backfill-design-order-links.ts
+++ b/apps/backend/src/scripts/backfill-design-order-links.ts
@@ -1,0 +1,76 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { ExecArgs } from "@medusajs/framework/types"
+import { linkDesignsToOrder } from "../workflows/designs/link-designs-to-order"
+
+/**
+ * One-off: create missing design ↔ order links for historical purchases
+ * (roadmap #29 / issue #379).
+ *
+ * The order.placed subscriber's linking block silently no-oped (it read
+ * `cart_id` off the order model, but order↔cart is the `order_cart`
+ * link), so customer purchases never reflected on the admin "Design
+ * Orders" view — they stayed "In Cart"/pending. The subscriber is fixed;
+ * this catches up every existing order via the same shared traversal
+ * (order → cart → line items → design_line_item → design_order upsert).
+ *
+ * Idempotent — already-linked (design, order) pairs are skipped.
+ *
+ * Usage:
+ *   DRY_RUN=1 npx medusa exec ./src/scripts/backfill-design-order-links.ts
+ *   npx medusa exec ./src/scripts/backfill-design-order-links.ts
+ *   (scope) ORDER_IDS=order_a,order_b
+ */
+export default async function backfillDesignOrderLinks({ container }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  const dryRun = process.env.DRY_RUN === "1"
+  const scope = (process.env.ORDER_IDS || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+
+  // Walk every order that came from a cart — the only ones that can
+  // carry design_line_item provenance.
+  const { data: orderCarts } = await query.graph({
+    entity: "order_cart",
+    fields: ["order_id", "cart_id"],
+    ...(scope.length ? { filters: { order_id: scope } } : {}),
+    pagination: { skip: 0, take: 5000 },
+  })
+
+  logger.info(
+    `[backfill-design-order-links] ${orderCarts?.length || 0} cart-backed order(s) to inspect${dryRun ? " (dry run)" : ""}`
+  )
+
+  let ordersLinked = 0
+  let linksCreated = 0
+  let errors = 0
+
+  for (const oc of orderCarts || []) {
+    try {
+      const { linked, design_ids } = await linkDesignsToOrder(
+        container as any,
+        oc.order_id,
+        { dryRun }
+      )
+      if (linked > 0) {
+        ordersLinked++
+        linksCreated += linked
+        logger.info(
+          `[backfill-design-order-links] order ${oc.order_id}: ${dryRun ? "would link" : "linked"} design(s) ${design_ids.join(", ")}`
+        )
+      }
+    } catch (e: any) {
+      errors++
+      logger.error(
+        `[backfill-design-order-links] order ${oc.order_id}: ${e?.message}`
+      )
+    }
+  }
+
+  logger.info(
+    `[backfill-design-order-links] done — orders linked: ${ordersLinked}, links created: ${linksCreated}, errors: ${errors}${dryRun ? " (dry run — no writes)" : ""}`
+  )
+  if (errors > 0) process.exit(1)
+}

--- a/apps/backend/src/subscribers/order-placed.ts
+++ b/apps/backend/src/subscribers/order-placed.ts
@@ -4,8 +4,7 @@ import type { IOrderModuleService, Logger } from "@medusajs/types"
 import { sendOrderConfirmationWorkflow } from "../workflows/email/send-notification-email"
 import { sendPartnerOrderPlacedWorkflow } from "../workflows/email/workflows/send-partner-order-email"
 import { createProductionRunWorkflow } from "../workflows/production-runs/create-production-run"
-import designLineItemLink from "../links/design-line-item-link"
-import { DESIGN_MODULE } from "../modules/designs"
+import { linkDesignsToOrder } from "../workflows/designs/link-designs-to-order"
 
 export default async function orderPlacedHandler({
   event: { data },
@@ -131,41 +130,15 @@ export default async function orderPlacedHandler({
     )
   }
 
-  // Create design → order link by traversing: cart_id → cart_line_items → designLineItemLink
+  // Create design → order links (order → order_cart → cart line items →
+  // design_line_item). Lives in linkDesignsToOrder so the backfill script
+  // shares the exact same traversal.
   try {
-    const orderService = container.resolve(Modules.ORDER) as IOrderModuleService
-    const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
-    const orderId = data.id
-    const orders = await orderService.listOrders(
-      { id: [orderId] } as any,
-      { select: ["id", "cart_id"] as any }
-    )
-    const cartId: string | undefined = (orders as any[])?.[0]?.cart_id
-
-    if (cartId) {
-      const cartService = container.resolve(Modules.CART) as any
-      const cartLineItems = await cartService.listLineItems({ cart_id: [cartId] }, { select: ["id"] })
-      const lineItemIds = (cartLineItems || []).map((li: any) => li.id)
-
-      if (lineItemIds.length > 0) {
-        const { data: designLinks } = await query.graph({
-          entity: designLineItemLink.entryPoint,
-          filters: { line_item_id: lineItemIds },
-          fields: ["design_id"],
-        })
-
-        const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as any
-        for (const dl of designLinks) {
-          if (dl.design_id) {
-            await remoteLink.create({
-              [DESIGN_MODULE]: { design_id: dl.design_id },
-              [Modules.ORDER]: { order_id: orderId },
-            }).catch((err: any) =>
-              logger.warn(`[order-placed] design-order link failed: ${err.message}`)
-            )
-          }
-        }
-      }
+    const { linked } = await linkDesignsToOrder(container, data.id)
+    if (linked > 0) {
+      logger.info(
+        `[order.placed] Linked ${linked} design(s) to order ${data.id}`
+      )
     }
   } catch (e: any) {
     logger.warn(

--- a/apps/backend/src/workflows/designs/link-designs-to-order.ts
+++ b/apps/backend/src/workflows/designs/link-designs-to-order.ts
@@ -1,0 +1,95 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+
+import designLineItemLink from "../../links/design-line-item-link"
+import designOrderLink from "../../links/design-order-link"
+import { DESIGN_MODULE } from "../../modules/designs"
+
+/**
+ * Close the purchase loop for design orders (roadmap #29 / issue #379).
+ *
+ * Designs get linked to CART line items when they're added to a cart
+ * (design_line_item). When the customer completes the cart, an order is
+ * created — but nothing carried the design linkage onto the order, so
+ * the admin "Design Orders" view kept showing those purchases as
+ * "In Cart"/pending forever.
+ *
+ * Resolution path: order → order_cart link → cart line items →
+ * design_line_item links → upsert design_order links.
+ *
+ * NOTE: order.cart_id is NOT a column on the order model — order↔cart
+ * is the `order_cart` link module. The previous subscriber code selected
+ * `cart_id` off the order and silently no-oped (the original #379 bug).
+ *
+ * Idempotent: existing (design, order) pairs are skipped. Shared by the
+ * order.placed subscriber and the backfill script.
+ */
+export async function linkDesignsToOrder(
+  container: MedusaContainer,
+  orderId: string,
+  opts?: { dryRun?: boolean }
+): Promise<{ linked: number; design_ids: string[] }> {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+
+  // order → cart (link module, not a column)
+  const { data: orderCarts } = await query.graph({
+    entity: "order_cart",
+    filters: { order_id: orderId },
+    fields: ["cart_id"],
+  })
+  const cartId: string | undefined = orderCarts?.[0]?.cart_id
+  if (!cartId) {
+    return { linked: 0, design_ids: [] }
+  }
+
+  // cart → line items
+  const cartService = container.resolve(Modules.CART) as any
+  const cartLineItems = await cartService.listLineItems(
+    { cart_id: [cartId] },
+    { select: ["id"] }
+  )
+  const lineItemIds = (cartLineItems || []).map((li: any) => li.id)
+  if (!lineItemIds.length) {
+    return { linked: 0, design_ids: [] }
+  }
+
+  // line items → designs
+  const { data: designLinks } = await query.graph({
+    entity: designLineItemLink.entryPoint,
+    filters: { line_item_id: lineItemIds },
+    fields: ["design_id"],
+  })
+  const designIds = [
+    ...new Set(
+      (designLinks || [])
+        .map((dl: any) => dl.design_id)
+        .filter(Boolean) as string[]
+    ),
+  ]
+  if (!designIds.length) {
+    return { linked: 0, design_ids: [] }
+  }
+
+  // skip pairs that already exist
+  const { data: existing } = await query.graph({
+    entity: designOrderLink.entryPoint,
+    filters: { order_id: orderId, design_id: designIds },
+    fields: ["design_id"],
+  })
+  const already = new Set((existing || []).map((r: any) => r.design_id))
+
+  const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as any
+  const linkedDesigns: string[] = []
+  for (const designId of designIds) {
+    if (already.has(designId)) continue
+    if (!opts?.dryRun) {
+      await remoteLink.create({
+        [DESIGN_MODULE]: { design_id: designId },
+        [Modules.ORDER]: { order_id: orderId },
+      })
+    }
+    linkedDesigns.push(designId)
+  }
+
+  return { linked: linkedDesigns.length, design_ids: linkedDesigns }
+}


### PR DESCRIPTION
Closes #379.

**Bug:** customer purchases never reflected on the admin Design Orders view — groups stayed "In Cart"/pending forever, even after fulfilment.

**Root cause:** the `order.placed` subscriber's design→order linking read `cart_id` off the order model — but order↔cart is the `order_cart` **link**, not a column — so the block silently no-oped on every order.

**Fix:**
- `linkDesignsToOrder` — shared idempotent traversal (order → `order_cart` → cart line items → `design_line_item` → `design_order` upsert), dry-run aware; consumed by the subscriber and the new `backfill-design-order-links` script for historical orders
- `/admin/designs/orders` now selects `payment_status` + `fulfillment_status` on the linked order (UI read them; API never sent them)
- list-page Payment cell guarded (unguarded `.replace()` would crash the table the moment orders linked)

**Tests:** `design-order-links.spec.ts` (link, idempotency, dry-run, admin view shows the order) + `admin-api-key-auth.spec.ts` (pins #381's api-key access; documents the shared-suite truncate-per-test gotcha that silently wipes beforeAll fixtures). 8/8 green, build clean.

**After deploy:** `DRY_RUN=1 ./deploy/aws/scripts/run-backfill.sh backfill-design-order-links` then real, to light up historical purchases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)