### PR TITLE
refactor(api): remoteQueryConfig → queryConfig + zod-validate cancel-partner-assignment

### DIFF
--- a/apps/backend/src/api/admin/designs/[id]/cancel-partner-assignment/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/cancel-partner-assignment/route.ts
@@ -1,6 +1,7 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 import { cancelPartnerAssignmentWorkflow } from "../../../../../workflows/designs/cancel-partner-assignment"
+import type { CancelPartnerAssignmentReq } from "./validators"
 
 /**
  * POST /admin/designs/:id/cancel-partner-assignment
@@ -15,16 +16,13 @@ import { cancelPartnerAssignmentWorkflow } from "../../../../../workflows/design
  * Cancellation is the run's own state — partner_status derives from the
  * cancelled run. Re-assigning via a new production run supersedes it.
  */
-export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+export const POST = async (
+  req: MedusaRequest<CancelPartnerAssignmentReq>,
+  res: MedusaResponse
+) => {
   const designId = req.params.id
-  const { partner_id, unlink = false } = (req.body || {}) as {
-    partner_id?: string
-    unlink?: boolean
-  }
-
-  if (!partner_id) {
-    throw new MedusaError(MedusaError.Types.INVALID_DATA, "partner_id is required")
-  }
+  // Body shape is enforced by validateAndTransformBody in middlewares.ts
+  const { partner_id, unlink } = req.validatedBody
 
   // Validate the design exists and the partner is actually linked.
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY) as any

--- a/apps/backend/src/api/admin/designs/[id]/cancel-partner-assignment/validators.ts
+++ b/apps/backend/src/api/admin/designs/[id]/cancel-partner-assignment/validators.ts
@@ -1,0 +1,10 @@
+import { z } from "zod"
+
+export const CancelPartnerAssignmentSchema = z.object({
+  partner_id: z.string().min(1, "partner_id is required"),
+  unlink: z.boolean().optional().default(false),
+})
+
+export type CancelPartnerAssignmentReq = z.infer<
+  typeof CancelPartnerAssignmentSchema
+>

--- a/apps/backend/src/api/admin/designs/[id]/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/route.ts
@@ -149,7 +149,7 @@ export const GET = async (
 export const PUT = async (
   req: MedusaRequest<UpdateDesign> & {
     params: { id: string };
-    remoteQueryConfig?: {
+    queryConfig?: {
       fields?: DesignAllowedFields[];
     };
   },
@@ -170,7 +170,7 @@ export const PUT = async (
   const design = await refetchDesign(
     req.params.id,
     req.scope,
-    req.remoteQueryConfig?.fields || ["*"],
+    req.queryConfig?.fields || ["*"],
   );
 
   res.status(200).json({ design });

--- a/apps/backend/src/api/admin/designs/route.ts
+++ b/apps/backend/src/api/admin/designs/route.ts
@@ -21,7 +21,7 @@
  *
  * - Refetch:
  *   - After creating a design, POST calls refetchDesign(result.id, req.scope, fields) to reload the created resource before returning it.
- *   - The optional remoteQueryConfig.fields on the request can be used to control which fields are fetched back (defaults to ["*"]).
+ *   - The optional queryConfig.fields on the request can be used to control which fields are fetched back (defaults to ["*"]).
  *
  * POST (Create new design)
  * @remarks
@@ -34,7 +34,7 @@
  *
  * @param req - AuthenticatedMedusaRequest<Design> with:
  *   - req.validatedBody: validated Design input
- *   - optional req.remoteQueryConfig?: { fields?: DesignAllowedFields[] }
+ *   - optional req.queryConfig?: { fields?: DesignAllowedFields[] }
  *   - req.auth_context?.actor_id: admin id (required)
  * @param res - MedusaResponse
  *
@@ -73,7 +73,7 @@
  *     "origin_source": "manual",
  *     "target_completion_date": "2026-04-01",
  *     "created_at": "2026-01-10T12:00:00.000Z",
- *     "...": "other fields as requested via remoteQueryConfig.fields"
+ *     "...": "other fields as requested via queryConfig.fields"
  *   }
  * }
  *
@@ -157,7 +157,7 @@ import designCustomerLink from "../../../links/design-customer-link";
 // Create new design
 export const POST = async (
   req: AuthenticatedMedusaRequest<Design> & {
-    remoteQueryConfig?: {
+    queryConfig?: {
       fields?: DesignAllowedFields[];
     };
   },
@@ -180,7 +180,7 @@ export const POST = async (
   const design = await refetchDesign(
     result.id,
     req.scope,
-    req.remoteQueryConfig?.fields || ["*"],
+    req.queryConfig?.fields || ["*"],
   );
 
   res.status(201).json({ design });

--- a/apps/backend/src/api/admin/inventory-items/[id]/rawmaterials/route.ts
+++ b/apps/backend/src/api/admin/inventory-items/[id]/rawmaterials/route.ts
@@ -12,11 +12,11 @@
  * @remarks
  * - Endpoint path: /admin/inventory-items/:id/rawmaterials
  * - Request scope (req.scope) is passed to the workflow and refetch helper.
- * - The refetch operation uses req.remoteQueryConfig?.fields if provided, otherwise selects all fields ["*"].
+ * - The refetch operation uses req.queryConfig?.fields if provided, otherwise selects all fields ["*"].
  * - The handler expects req.validatedBody.rawMaterialData to contain the raw material payload.
  *
- * @param req - MedusaRequest with generic body RawMaterial and optional remoteQueryConfig:
- *                { remoteQueryConfig?: { fields?: RawMaterialAllowedFields[] } }
+ * @param req - MedusaRequest with generic body RawMaterial and optional queryConfig:
+ *                { queryConfig?: { fields?: RawMaterialAllowedFields[] } }
  *               - req.params.id: inventory item id to which the raw material will be attached
  *               - req.validatedBody.rawMaterialData: payload for the new raw material
  * @param res - MedusaResponse used to send the created raw material with status 201
@@ -63,8 +63,8 @@
  * }
  *
  * @example TypeScript (server-side invocation)
- * // req.remoteQueryConfig can limit returned fields:
- * req.remoteQueryConfig = { fields: ["id", "sku", "name"] };
+ * // req.queryConfig can limit returned fields:
+ * req.queryConfig = { fields: ["id", "sku", "name"] };
  * // call handler as shown in the file's routing layer; final response JSON will include only requested fields.
  *
  * @statuscodes
@@ -81,7 +81,7 @@ import { RawMaterialAllowedFields, refetchRawMaterial } from "./helpers";
 
 export const POST = async (
   req: MedusaRequest<RawMaterial> & {
-    remoteQueryConfig?: {
+    queryConfig?: {
       fields?: RawMaterialAllowedFields[];
     };
   },
@@ -102,7 +102,7 @@ export const POST = async (
   const rawMaterial = await refetchRawMaterial(
     req.params.id,
     req.scope,
-    req.remoteQueryConfig?.fields || ["*"],
+    req.queryConfig?.fields || ["*"],
   );
 
   res.status(201).json( rawMaterial );

--- a/apps/backend/src/api/admin/persons/[id]/addresses/[addressId]/route.ts
+++ b/apps/backend/src/api/admin/persons/[id]/addresses/[addressId]/route.ts
@@ -45,7 +45,7 @@
  * @param {string} id.path.required - The ID of the person
  * @param {string} addressId.path.required - The ID of the address to update
  * @param {AddressInput} request.body.required - Address data to update
- * @param {string[]} [remoteQueryConfig.fields] - Fields to include in the response (e.g., ["id", "first_name"])
+ * @param {string[]} [queryConfig.fields] - Fields to include in the response (e.g., ["id", "first_name"])
  * @returns {Object} 200 - Updated address object
  * @throws {MedusaError} 400 - Invalid input data
  * @throws {MedusaError} 404 - Address not found for the specified person
@@ -109,7 +109,7 @@ import deleteAddressWorkflow from "../../../../../../workflows/persons/delete-ad
 
 export const POST = async (
   req: MedusaRequest & {
-    remoteQueryConfig?: {
+    queryConfig?: {
       fields?: AddressAllowedFields[];
     };
   },
@@ -155,7 +155,7 @@ export const POST = async (
       personId,
       addressId,
       req.scope,
-      req.remoteQueryConfig?.fields || ["*"],
+      req.queryConfig?.fields || ["*"],
     );
 
     res.status(200).json({ address: updatedAddress });

--- a/apps/backend/src/api/admin/persons/[id]/contacts/[contactId]/route.ts
+++ b/apps/backend/src/api/admin/persons/[id]/contacts/[contactId]/route.ts
@@ -115,7 +115,7 @@ import deleteContactWorkflow from "../../../../../../workflows/persons/delete-co
 
 export const POST = async (
   req: MedusaRequest & {
-    remoteQueryConfig?: {
+    queryConfig?: {
       fields?: ContactAllowedFields[];
     };
   },

--- a/apps/backend/src/api/admin/persons/[id]/contacts/route.ts
+++ b/apps/backend/src/api/admin/persons/[id]/contacts/route.ts
@@ -113,7 +113,7 @@ import retrieveContactsWorkflow from "../../../../../workflows/persons/retrieve-
 
 export const POST = async (
   req: MedusaRequest & {
-    remoteQueryConfig?: {
+    queryConfig?: {
       fields?: ContactAllowedFields[];
     };
   },
@@ -149,7 +149,7 @@ export const POST = async (
 
 export const GET = async (
   req: MedusaRequest & {
-    remoteQueryConfig?: {
+    queryConfig?: {
       fields?: ContactAllowedFields[];
     };
   },

--- a/apps/backend/src/api/admin/persons/[id]/route.ts
+++ b/apps/backend/src/api/admin/persons/[id]/route.ts
@@ -67,8 +67,8 @@
  * @group Person - Operations related to persons
  * @param {string} id.path.required - The ID of the person to update
  * @param {AdminUpdatePerson} request.body.required - Person data to update
- * @param {Object} [remoteQueryConfig] - Configuration for remote queries
- * @param {string[]} [remoteQueryConfig.fields] - Fields to include in the response
+ * @param {Object} [queryConfig] - Configuration for remote queries
+ * @param {string[]} [queryConfig.fields] - Fields to include in the response
  * @returns {Object} 201 - The updated person object
  * @returns {PersonResponse} 201.person - The updated person data
  * @throws {MedusaError} 400 - Invalid input data
@@ -147,7 +147,7 @@ export const GET = async (req: MedusaRequest , res: MedusaResponse) => {
 
 export const POST = async (
   req: MedusaRequest<AdminUpdatePerson> & {
-    remoteQueryConfig?: {
+    queryConfig?: {
       fields?: PersonAllowedFields[];
     };
   },
@@ -185,7 +185,7 @@ export const POST = async (
   const person = await refetchPerson(
     result.id, 
     req.scope,
-    req.remoteQueryConfig?.fields || ["*"],
+    req.queryConfig?.fields || ["*"],
   );
   res.status(201).json({ person });
 };

--- a/apps/backend/src/api/admin/persons/[id]/tags/[tagId]/route.ts
+++ b/apps/backend/src/api/admin/persons/[id]/tags/[tagId]/route.ts
@@ -65,7 +65,7 @@ import { DeleteTagForPerson } from "../validators";
 
 export const DELETE = async (
     req: MedusaRequest<DeleteTagForPerson> & {
-      remoteQueryConfig?: {
+      queryConfig?: {
         fields?: TagAllowedFields[];
       };
     },

--- a/apps/backend/src/api/admin/persons/[id]/tags/route.ts
+++ b/apps/backend/src/api/admin/persons/[id]/tags/route.ts
@@ -146,7 +146,7 @@ import updatePersonTagsWorkflow from "../../../../../workflows/persons/update-pe
 
 export const POST = async (
   req: MedusaRequest & {
-    remoteQueryConfig?: {
+    queryConfig?: {
       fields?: TagAllowedFields[];
     };
   },
@@ -172,7 +172,7 @@ export const POST = async (
 
 export const GET = async (
   req: MedusaRequest & {
-    remoteQueryConfig?: {
+    queryConfig?: {
       fields?: TagAllowedFields[];
     };
   },
@@ -200,7 +200,7 @@ export const GET = async (
 
 export const PUT = async (
   req: MedusaRequest<UpdateTagsForPerson> & {
-    remoteQueryConfig?: {
+    queryConfig?: {
       fields?: TagAllowedFields[];
     };
   },

--- a/apps/backend/src/api/admin/persons/route.ts
+++ b/apps/backend/src/api/admin/persons/route.ts
@@ -53,8 +53,8 @@
  * @route POST /admin/persons
  * @group Person - Operations related to persons
  * @param {PersonInput} request.body.required - Person data to create
- * @param {Object} [request.remoteQueryConfig] - Configuration for remote queries
- * @param {string[]} [request.remoteQueryConfig.fields] - Fields to include in the response
+ * @param {Object} [request.queryConfig] - Configuration for remote queries
+ * @param {string[]} [request.queryConfig.fields] - Fields to include in the response
  * @returns {Object} 201 - Created person object
  * @returns {PersonResponse} 201.person - The created person
  * @throws {MedusaError} 400 - Invalid input data
@@ -147,7 +147,7 @@ import { listAndCountPersonsWithFilterWorkflow } from "../../../workflows/person
 
 export const POST = async (
   req: MedusaRequest<Person> & {
-    remoteQueryConfig?: {
+    queryConfig?: {
       fields?: PersonAllowedFields[];
     };
   },
@@ -163,7 +163,7 @@ export const POST = async (
   const person = await refetchPerson(
     result.id,
     req.scope,
-    req.remoteQueryConfig?.fields || ["*"],
+    req.queryConfig?.fields || ["*"],
   );
   res.status(201).json({ person });
 };

--- a/apps/backend/src/api/admin/persontypes/[id]/route.ts
+++ b/apps/backend/src/api/admin/persontypes/[id]/route.ts
@@ -160,7 +160,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
 
 export const POST = async (
   req: AuthenticatedMedusaRequest<UpdatePersonTypeSchema> & {
-    remoteQueryConfig?: {
+    queryConfig?: {
       fields?: PersonTypeAllowedFields[];
     };
   },
@@ -186,7 +186,7 @@ export const POST = async (
   });
 
   const fieldsToFetch: PersonTypeAllowedFields[] =
-    req.remoteQueryConfig?.fields || [];
+    req.queryConfig?.fields || [];
     
   const personType = await refetchPersonType(
     result.id,

--- a/apps/backend/src/api/admin/task-templates/[id]/route.ts
+++ b/apps/backend/src/api/admin/task-templates/[id]/route.ts
@@ -121,7 +121,7 @@ import { listSingleTaskTemplateWorkflow } from "../../../../workflows/task-templ
 export const GET = async (
   req: MedusaRequest & {
     params: { id: string };
-    remoteQueryConfig?: {
+    queryConfig?: {
       fields?: string[] | TaskTemplateAllowedFields[];
     };
   },
@@ -147,7 +147,7 @@ export const GET = async (
 export const PUT = async (
   req: MedusaRequest<UpdateTaskTemplate> & {
     params: { id: string };
-    remoteQueryConfig?: {
+    queryConfig?: {
       fields?: string[] | TaskTemplateAllowedFields[];
     };
   },

--- a/apps/backend/src/api/admin/task-templates/categories/route.ts
+++ b/apps/backend/src/api/admin/task-templates/categories/route.ts
@@ -83,7 +83,7 @@ export const GET = async (
         fields?: string[];
         expand?: string[];
       };
-      remoteQueryConfig?: {
+      queryConfig?: {
         fields?: TaskTemplateCategoriesAllowedFields[];
       };
     },

--- a/apps/backend/src/api/admin/task-templates/route.ts
+++ b/apps/backend/src/api/admin/task-templates/route.ts
@@ -41,7 +41,7 @@
  * @route POST /admin/task-templates
  * @group TaskTemplate - Operations related to task templates
  * @param {TaskTemplateInput} request.body.required - Task template data to create
- * @param {string[]} [request.remoteQueryConfig.fields] - Fields to select in the response
+ * @param {string[]} [request.queryConfig.fields] - Fields to select in the response
  * @returns {Object} 201 - Created task template object
  * @returns {TaskTemplateResponse} 201.task_template - The created task template
  * @throws {MedusaError} 400 - Invalid input data
@@ -161,7 +161,7 @@ import { TaskTemplateAllowedFields, refetchTaskTemplate } from "./helpers";
 // Create new task template
 export const POST = async (
   req: MedusaRequest<TaskTemplate> & {
-    remoteQueryConfig?: {
+    queryConfig?: {
       fields?: string[] | TaskTemplateAllowedFields[];
     };
   },
@@ -198,7 +198,7 @@ export const GET = async (
       fields?: string[];
       expand?: string[];
     };
-    remoteQueryConfig?: {
+    queryConfig?: {
       fields?: string[] | TaskTemplateAllowedFields[];
     };
   },

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -172,6 +172,7 @@ import {
   CreatePaymentMethodForPartnerSchema as PartnerCreatePaymentMethodForPartnerSchema,
 } from "./partners/[id]/payments/validators";
 import { ReviseDesignSchema } from "./admin/designs/[id]/revise/validators";
+import { CancelPartnerAssignmentSchema } from "./admin/designs/[id]/cancel-partner-assignment/validators";
 import { AdminCreateDesignProductionRunSchema } from "./admin/designs/[id]/production-runs/validators";
 import { AdminRecreateProductionRunSchema } from "./admin/designs/recreate-production-run/validators";
 import { listDesignsQuerySchema, PartnerCreateDesignReq, PartnerUpdateDesignReq } from "./partners/designs/validators";
@@ -2954,6 +2955,13 @@ export default defineMiddlewares({
     // (session + bearer + api-key). Re-registering authenticate() with only
     // ["session","bearer"] NARROWS that and silently breaks API-key access —
     // don't add it back. (Removed from 11 admin matchers, 2026-06-12.)
+    {
+      matcher: "/admin/designs/:id/cancel-partner-assignment",
+      method: "POST",
+      middlewares: [
+        validateAndTransformBody(wrapSchema(CancelPartnerAssignmentSchema)),
+      ],
+    },
     {
       matcher: "/admin/designs/:id",
       method: "PUT",


### PR DESCRIPTION
Two follow-ups from today's middleware review:

1. **`remoteQueryConfig` → `queryConfig`** — the framework marks `req.remoteQueryConfig` deprecated and aliases it onto `req.queryConfig` (verified in `@medusajs/framework` 2.15.5 types + `validate-query.js`), so behaviour is identical today but breaks on a future major. Mechanical rename across 14 api route files (designs, persons, persontypes, inventory-items, …), 40 occurrences, including the local request-generic type declarations.

2. **Body validation per the docs** — `POST /admin/designs/:id/cancel-partner-assignment` had hand-rolled `req.body` checks; it now registers a zod schema via `validateAndTransformBody` and reads `req.validatedBody`. (Audited the other routes de-authed in #381: they all read raw `req.body` with their own guards, so #381 broke no body parsing; this one we own end-to-end so it gets the proper treatment.)

**Tests:** cancel-workflows (exercises the new validator path incl. missing-partner_id 400), partner-cancel-reassign-desync, person-types-api — green. designs-api has 6 pre-existing failures (identical on unchanged main — color_palette retrieval + numeric-string drift; not from this change). Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)