### PR TITLE
fix(designs): repair the 6 long-failing designs-api tests

### DIFF
--- a/apps/backend/integration-tests/http/designs-api.spec.ts
+++ b/apps/backend/integration-tests/http/designs-api.spec.ts
@@ -282,6 +282,9 @@ setupSharedTestSuite(() => {
             name: "Updated Summer Collection",
             status: "In_Development",
             priority: "Medium",
+            // Structured `colors` are the source of truth: when both are
+            // sent, colors win and color_palette is DERIVED from them in
+            // the response (legacy palette input is only a fallback).
             color_palette: [
               { name: "Sunset Orange", code: "#FD5E53" }
             ],
@@ -307,10 +310,18 @@ setupSharedTestSuite(() => {
           
 
           expect(response.status).toBe(200);
+          const { color_palette: _legacyPaletteInput, ...expectedFields } =
+            updateData;
           expect(response.data.design).toMatchObject({
-            ...updateData,
+            ...expectedFields,
             id: summerDesignId,
           });
+          // color_palette in the response derives from the structured
+          // colors (source of truth), not the legacy palette input.
+          expect(response.data.design.color_palette).toEqual([
+            { name: "Updated Coral", code: "#FF7F50" },
+            { name: "Updated Sand", code: "#D2B48C" },
+          ]);
           expect(response.data.design.colors).toEqual(
             expect.arrayContaining([
               expect.objectContaining({ name: "Updated Coral", hex_code: "#FF7F50" }),

--- a/apps/backend/src/api/admin/designs/[id]/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/route.ts
@@ -114,11 +114,11 @@ import {
   MedusaRequest,
   MedusaResponse,
 } from "@medusajs/framework/http";
+import { MedusaError } from "@medusajs/framework/utils";
 import { UpdateDesign } from "../validators";
 import updateDesignWorkflow from "../../../../workflows/designs/update-design";
 import deleteDesignWorkflow from "../../../../workflows/designs/delete-design";
 import { DesignAllowedFields, refetchDesign } from "../helpers";
-import listSingleDesignsWorkflow from "../../../../workflows/designs/list-single-design";
 
 
 export const GET = async (
@@ -129,20 +129,24 @@ export const GET = async (
   },
   res: MedusaResponse
 ) => {
-  // Extract fields from validated query and convert to array for the workflow
+  // Extract fields from validated query and convert to array
   const fieldsStr = req.validatedQuery?.fields;
-  const fields = fieldsStr
+  const fields = (fieldsStr
     ? fieldsStr.split(",").map((f) => f.trim()).filter(Boolean)
-    : ["*"];
+    : ["*"]) as DesignAllowedFields[];
 
-  const { result } = await listSingleDesignsWorkflow(req.scope).run({
-    input: {
-      id: req.params.id,
-      fields,
-    },
-  });
+  // refetchDesign (same shaper PUT uses) derives the legacy
+  // color_palette/custom_sizes from the structured colors/size_sets
+  // relations — keeps GET and PUT responses consistent.
+  const design = await refetchDesign(req.params.id, req.scope, fields);
+  if (!design) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Design with id: ${req.params.id} was not found`
+    );
+  }
 
-  res.status(200).json({ design: result });
+  res.status(200).json({ design });
 };
 
 // Update design
@@ -155,11 +159,13 @@ export const PUT = async (
   },
   res: MedusaResponse,
 ) => {
-  const { result, errors } = await updateDesignWorkflow.run({
+  // Scoped run — an unscoped workflow.run() uses a bare container that
+  // can't resolve request-scoped registrations like "query".
+  const { result, errors } = await updateDesignWorkflow(req.scope).run({
     input: {
       id: req.params.id,
       ...req.validatedBody,
-    },
+    } as any,
   });
 
   if (errors.length > 0) {
@@ -183,7 +189,17 @@ export const DELETE = async (
   },
   res: MedusaResponse,
 ) => {
-  const { errors } = await deleteDesignWorkflow.run({
+  // 404 on unknown ids (soft-deleting a missing design 500s deep in the
+  // workflow otherwise).
+  const existing = await refetchDesign(req.params.id, req.scope, ["id"] as any);
+  if (!existing) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Design with id: ${req.params.id} was not found`
+    );
+  }
+
+  const { errors } = await deleteDesignWorkflow(req.scope).run({
     input: {
       id: req.params.id,
     },

--- a/apps/backend/src/workflows/designs/inventory/list-design-inventory.ts
+++ b/apps/backend/src/workflows/designs/inventory/list-design-inventory.ts
@@ -65,8 +65,15 @@ export const listDesignInventoryStep = createStep(
       return {
         id: sanitizedRow.inventory_item?.id ?? sanitizedRow.inventory_item_id,
         inventory_item_id: sanitizedRow.inventory_item_id,
-        planned_quantity: sanitizedRow.planned_quantity,
-        consumed_quantity: sanitizedRow.consumed_quantity,
+        // sanitizeBigInt stringifies numerics — keep quantities numbers on the wire
+        planned_quantity:
+          sanitizedRow.planned_quantity != null
+            ? Number(sanitizedRow.planned_quantity)
+            : null,
+        consumed_quantity:
+          sanitizedRow.consumed_quantity != null
+            ? Number(sanitizedRow.consumed_quantity)
+            : null,
         consumed_at: sanitizedRow.consumed_at,
         location_id: sanitizedRow.location_id,
         metadata: sanitizedRow.metadata || {},


### PR DESCRIPTION
The designs-api suite has had 6 failing tests for a while (identical on main). Turned out to be four real bugs and one stale expectation:

1. **GET /admin/designs/:id dropped legacy fields** — it used `listSingleDesignsWorkflow` while PUT used `refetchDesign` (which derives `color_palette`/`custom_sizes` from the structured `colors`/`size_sets` relations — the legacy json is intentionally nulled on write). GET now uses the same shaper, so GET and PUT agree; unknown ids 404.
2. **DELETE 500'd on every design** — the route ran `deleteDesignWorkflow.run()` *unscoped*; the resolve-partner-links step then failed with `AwilixResolutionError: Could not resolve 'query'`. PUT had the same latent issue. Both run with `req.scope` now; deleting an unknown id 404s instead of 500ing inside soft-delete.
3. **Inventory quantities were strings** — `sanitizeBigInt` stringifies numerics; `planned_quantity`/`consumed_quantity` now coerced to numbers on the wire.
4. **Stale spec expectation** — when both `colors` (structured) and `color_palette` (legacy) are sent, colors are the source of truth and the response palette derives from them; the spec expected the opposite and now documents the real contract.

designs-api 12/12 green (was 6 failing); partner-cancel-reassign-desync + production-run-partner-status green; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)