### PR TITLE
feat(orders): #342 T2 — dual-write unified core order for inventory orders

### DIFF
--- a/apps/backend/integration-tests/http/orders-unification-dual-write.spec.ts
+++ b/apps/backend/integration-tests/http/orders-unification-dual-write.spec.ts
@@ -1,0 +1,296 @@
+/**
+ * #342 T2 — orders unification dual-write shim.
+ *
+ * Creating a legacy inventory order must additionally project a core `order`
+ * (metadata.kind = "inventory") per apps/docs/notes/ORDERS_UNIFICATION_342.md
+ * §3 + §5, without ever failing the legacy create. Also probes the two gaps
+ * the doc left to empirical verification:
+ *   GAP-1 — core order_line_item.quantity accepts decimals (raw-material kg)
+ *   GAP-3 — core order create works customer-less (no customer_id, no email)
+ */
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import partnerOrderLink from "../../src/links/partner-order"
+
+jest.setTimeout(60000)
+
+const TEST_PARTNER_EMAIL = "partner@orders-unification-test.com"
+const TEST_PARTNER_PASSWORD = "supersecret"
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Orders unification dual-write (#342 T2)", () => {
+    let adminHeaders: any
+    let inventoryItemId: string
+    let stockLocationId: string
+    let fromStockLocationId: string
+
+    const createRegion = async () => {
+      const container = getContainer()
+      const regionService: any = container.resolve(Modules.REGION)
+      const region = await regionService.createRegions({
+        name: "India",
+        currency_code: "inr",
+        countries: ["in"],
+      })
+      return region.id
+    }
+
+    const createLegacyOrder = async (overrides: Record<string, any> = {}) => {
+      const payload = {
+        order_lines: [
+          { inventory_item_id: inventoryItemId, quantity: 2.5, price: 100 },
+        ],
+        quantity: 2.5,
+        total_price: 100,
+        status: "Pending",
+        expected_delivery_date: new Date().toISOString(),
+        order_date: new Date().toISOString(),
+        shipping_address: {
+          first_name: "JYT",
+          address_1: "Mill Road 1",
+          city: "Jaipur",
+          country_code: "in",
+          postal_code: "302001",
+          loading_dock: "B",
+        },
+        stock_location_id: stockLocationId,
+        from_stock_location_id: fromStockLocationId,
+        ...overrides,
+      }
+      const res = await api.post("/admin/inventory-orders", payload, adminHeaders)
+      expect(res.status).toBe(201)
+      return res.data.inventoryOrder
+    }
+
+    const fetchUnifiedOrder = async (unifiedOrderId: string) => {
+      const container = getContainer()
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data } = await query.graph({
+        entity: "order",
+        filters: { id: unifiedOrderId },
+        fields: [
+          "id",
+          "status",
+          "currency_code",
+          "email",
+          "customer_id",
+          "region_id",
+          "metadata",
+          "total",
+          "sales_channel.name",
+          "items.*",
+          "shipping_address.*",
+        ],
+      })
+      return data?.[0]
+    }
+
+    const fetchLegacyOrder = async (id: string) => {
+      const container = getContainer()
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data } = await query.graph({
+        entity: "inventory_orders",
+        filters: { id },
+        fields: ["id", "status", "quantity", "total_price", "metadata", "orderlines.*"],
+      })
+      return data?.[0]
+    }
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+
+      const inventoryRes = await api.post(
+        "/admin/inventory-items",
+        { title: "Raw Cotton", sku: "RAW-COTTON-KG" },
+        adminHeaders
+      )
+      expect(inventoryRes.status).toBe(200)
+      inventoryItemId = inventoryRes.data.inventory_item.id
+
+      const toLocation = await api.post(
+        "/admin/stock-locations",
+        { name: "Main Warehouse" },
+        adminHeaders
+      )
+      stockLocationId = toLocation.data.stock_location.id
+      const fromLocation = await api.post(
+        "/admin/stock-locations",
+        { name: "Secondary Warehouse" },
+        adminHeaders
+      )
+      fromStockLocationId = fromLocation.data.stock_location.id
+    })
+
+    it("dual-writes a kind=inventory core order with decimal quantities and no customer", async () => {
+      await createRegion()
+      const legacy = await createLegacyOrder()
+
+      const legacyRow = await fetchLegacyOrder(legacy.id)
+      const unifiedOrderId = legacyRow.metadata?.unified_order_id
+      expect(unifiedOrderId).toBeTruthy()
+
+      const unified = await fetchUnifiedOrder(unifiedOrderId)
+      expect(unified).toBeTruthy()
+
+      // §2/§3 discriminator + projection metadata
+      expect(unified.metadata.kind).toBe("inventory")
+      expect(unified.metadata.legacy_id).toBe(legacy.id)
+      expect(unified.metadata.is_sample).toBe(false)
+      expect(unified.metadata.currency_assumed).toBe(true)
+      expect(unified.metadata.total_quantity).toBe(2.5)
+      expect(unified.metadata.to_stock_location_id).toBe(stockLocationId)
+      expect(unified.metadata.from_stock_location_id).toBe(fromStockLocationId)
+      // non-core address keys preserved
+      expect(unified.metadata.shipping_address_extra).toEqual({ loading_dock: "B" })
+
+      // §5 status map: legacy Pending → core pending
+      expect(unified.status).toBe("pending")
+
+      // GAP-3: truly customer-less — no guest customer was created either
+      expect(unified.customer_id ?? null).toBeNull()
+      expect(unified.email ?? null).toBeNull()
+
+      // GAP-2: currency falls back to the store default, flagged as assumed
+      const container = getContainer()
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data: stores } = await query.graph({
+        entity: "store",
+        fields: ["supported_currencies.*"],
+      })
+      const storeDefaultCurrency =
+        stores?.[0]?.supported_currencies?.find((c: any) => c?.is_default)
+          ?.currency_code ?? "inr"
+      expect(unified.currency_code).toBe(storeDefaultCurrency)
+
+      // Work-orders live on the internal channel, not a storefront channel
+      expect(unified.sales_channel?.name).toBe("Partner Work Orders")
+
+      // GAP-1: decimal quantity survives end-to-end; legacy line price is the
+      // line total, so unit_price = 100 / 2.5 = 40
+      expect(unified.items).toHaveLength(1)
+      expect(Number(unified.items[0].quantity)).toBe(2.5)
+      expect(Number(unified.items[0].unit_price)).toBe(40)
+      expect(unified.items[0].title).toBe("Raw Cotton")
+      expect(unified.items[0].metadata.inventory_item_id).toBe(inventoryItemId)
+
+      // Totals parity: Σ(unit_price × qty) == legacy total_price
+      expect(Number(unified.total)).toBe(Number(legacyRow.total_price))
+
+      // Core address fields mapped onto a real address row
+      expect(unified.shipping_address?.city).toBe("Jaipur")
+      expect(unified.shipping_address?.country_code).toBe("in")
+
+      // Legacy row untouched apart from the metadata backref
+      expect(legacyRow.status).toBe("Pending")
+      expect(Number(legacyRow.quantity)).toBe(2.5)
+      expect(Number(legacyRow.total_price)).toBe(100)
+      expect(legacyRow.orderlines).toHaveLength(1)
+    })
+
+    it("does not fail the legacy create when the dual-write cannot run (no region)", async () => {
+      // No region created — the projection step must skip, not throw
+      const legacy = await createLegacyOrder()
+
+      const legacyRow = await fetchLegacyOrder(legacy.id)
+      expect(legacyRow.status).toBe("Pending")
+      expect(legacyRow.metadata?.unified_order_id ?? null).toBeNull()
+    })
+
+    it("links the partner to the unified order on send-to-partner", async () => {
+      // Surface which call fails instead of a bare AxiosError
+      const post = async (url: string, body: any, cfg?: any) => {
+        try {
+          return await api.post(url, body, cfg)
+        } catch (err: any) {
+          throw new Error(
+            `POST ${url} failed: ${err?.response?.status} ${JSON.stringify(
+              err?.response?.data
+            )}`
+          )
+        }
+      }
+
+      await createRegion()
+
+      // Partner + the task templates the send-to-partner workflow requires
+      await post("/auth/partner/emailpass/register", {
+        email: TEST_PARTNER_EMAIL,
+        password: TEST_PARTNER_PASSWORD,
+      })
+      const partnerLogin = await post("/auth/partner/emailpass", {
+        email: TEST_PARTNER_EMAIL,
+        password: TEST_PARTNER_PASSWORD,
+      })
+      const partnerRes = await post(
+        "/partners",
+        {
+          name: "Unification Test Partner",
+          handle: "orders-unification-partner",
+          admin: {
+            email: TEST_PARTNER_EMAIL,
+            first_name: "Partner",
+            last_name: "Admin",
+          },
+        },
+        { headers: { Authorization: `Bearer ${partnerLogin.data.token}` } }
+      )
+      expect(partnerRes.status).toBe(200)
+      const partnerId = partnerRes.data.partner.id
+
+      for (const name of [
+        "partner-order-sent",
+        "partner-order-received",
+        "partner-order-shipped",
+      ]) {
+        const templateRes = await post(
+          "/admin/task-templates",
+          {
+            name,
+            description: `${name} template`,
+            priority: "medium",
+            estimated_duration: 30,
+            eventable: true,
+            notifiable: true,
+            metadata: { workflow_type: "partner_assignment" },
+          },
+          adminHeaders
+        )
+        expect([200, 201]).toContain(templateRes.status)
+      }
+
+      const legacy = await createLegacyOrder()
+      const legacyRow = await fetchLegacyOrder(legacy.id)
+      const unifiedOrderId = legacyRow.metadata?.unified_order_id
+      expect(unifiedOrderId).toBeTruthy()
+
+      const sendRes = await post(
+        `/admin/inventory-orders/${legacy.id}/send-to-partner`,
+        { partnerId, notes: "unification link test" },
+        adminHeaders
+      )
+      expect(sendRes.status).toBe(200)
+
+      // D3: partner ↔ order link row exists
+      const container = getContainer()
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data: linkRows } = await query.graph({
+        entity: partnerOrderLink.entryPoint,
+        filters: { order_id: unifiedOrderId },
+        fields: ["partner_id", "order_id"],
+      })
+      expect(linkRows).toHaveLength(1)
+      expect(linkRows[0].partner_id).toBe(partnerId)
+
+      // §5: assignment mirrors metadata.partner_status = "assigned"
+      const unified = await fetchUnifiedOrder(unifiedOrderId)
+      expect(unified.metadata.partner_status).toBe("assigned")
+      // kind survives the metadata update
+      expect(unified.metadata.kind).toBe("inventory")
+    })
+  })
+})

--- a/apps/backend/src/links/partner-order.ts
+++ b/apps/backend/src/links/partner-order.ts
@@ -1,0 +1,18 @@
+import { defineLink } from "@medusajs/framework/utils"
+import PartnerModule from "../modules/partner"
+import OrderModule from "@medusajs/medusa/order"
+
+// D3 (#342): partner ↔ core order scoping link for unified work-orders
+// (order.metadata.kind = design | inventory). Retail orders keep using
+// sales-channel scoping; work-orders need an explicit link because a partner
+// can serve another partner's store.
+export default defineLink(
+  {
+    linkable: PartnerModule.linkable.partner,
+    isList: true,
+  },
+  {
+    linkable: OrderModule.linkable.order,
+    isList: true,
+  }
+)

--- a/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
@@ -14,6 +14,7 @@ import InventoryOrder from "../../modules/inventory_orders/models/order";
 import InventoryOrderService from "../../modules/inventory_orders/service";
 import type { Link } from "@medusajs/modules-sdk";
 import type { IInventoryService } from "@medusajs/types";
+import { dualWriteUnifiedOrderStep } from "./dual-write-unified-order";
 export type InventoryOrder = InferTypeOf<typeof InventoryOrder>;
 
 // --- Interfaces for API Input ---
@@ -241,6 +242,15 @@ export const createInventoryOrderWorkflow = createWorkflow(
         order_id: linkInput.order_id,
         from_stock_location_id: input.from_stock_location_id as string,
       });
+    });
+
+    // #342 T2: best-effort projection onto a core order (metadata.kind =
+    // "inventory"). The step swallows its own errors — a dual-write failure
+    // must never fail the legacy create.
+    dualWriteUnifiedOrderStep({
+      order: linkInput.order,
+      orderLines: linkInput.orderLines,
+      input,
     });
 
     // Step 3: Use transform to shape the final response

--- a/apps/backend/src/workflows/inventory_orders/dual-write-unified-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/dual-write-unified-order.ts
@@ -1,0 +1,291 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
+import { createOrderWorkflow } from "@medusajs/medusa/core-flows"
+import type { Link } from "@medusajs/modules-sdk"
+import type { LinkDefinition } from "@medusajs/framework/types"
+import { ORDER_INVENTORY_MODULE } from "../../modules/inventory_orders"
+import { PARTNER_MODULE } from "../../modules/partner"
+import InventoryOrderService from "../../modules/inventory_orders/service"
+
+// #342 T2 — best-effort projection of legacy inventory orders onto the core
+// `order` entity (metadata.kind = "inventory"). See
+// apps/docs/notes/ORDERS_UNIFICATION_342.md §3 + §5. Failure must never fail
+// the legacy create, so each step swallows errors and reports via logger.
+
+export const PARTNER_WORK_ORDERS_CHANNEL = "Partner Work Orders"
+
+// §5 — legacy 6-value enum → core order.status. The work-progress dimension
+// (metadata.partner_status) only exists once a partner is assigned, which
+// never holds at create time.
+const LEGACY_TO_CORE_STATUS: Record<string, string> = {
+  Pending: "pending",
+  Processing: "pending",
+  Shipped: "pending",
+  Partial: "pending",
+  Delivered: "completed",
+  Cancelled: "canceled",
+}
+
+// Core address columns; anything else in the legacy json blob is preserved
+// under order.metadata.shipping_address_extra.
+const CORE_ADDRESS_KEYS = [
+  "first_name",
+  "last_name",
+  "company",
+  "address_1",
+  "address_2",
+  "city",
+  "province",
+  "postal_code",
+  "country_code",
+  "phone",
+]
+
+const splitShippingAddress = (raw: Record<string, unknown> | null | undefined) => {
+  if (!raw || typeof raw !== "object" || !Object.keys(raw).length) {
+    return { address: undefined, extra: undefined }
+  }
+  const address: Record<string, unknown> = {}
+  const extra: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(raw)) {
+    if (CORE_ADDRESS_KEYS.includes(key)) {
+      address[key] = value
+    } else {
+      extra[key] = value
+    }
+  }
+  return {
+    address: Object.keys(address).length ? address : undefined,
+    extra: Object.keys(extra).length ? extra : undefined,
+  }
+}
+
+type DualWriteResult = {
+  unified_order_id: string | null
+  skipped?: string
+  error?: string
+}
+
+type MirrorResult = {
+  linked: boolean
+  unified_order_id?: string
+  skipped?: string
+  error?: string
+}
+
+type DualWriteInput = {
+  order: any
+  orderLines: any[]
+  input: {
+    stock_location_id: string
+    from_stock_location_id?: string
+    order_lines: { inventory_item_id: string; quantity: number; price: number }[]
+  } & Record<string, any>
+}
+
+export const dualWriteUnifiedOrderStep = createStep(
+  "dual-write-unified-order",
+  async ({ order, orderLines, input }: DualWriteInput, { container }) => {
+    const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+    try {
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+      // Region + currency: legacy rows have neither (GAP-2). Use the store's
+      // default region (or any region) and default currency, flagged as
+      // assumed so FX work can re-rate later.
+      const { data: stores } = await query.graph({
+        entity: "store",
+        fields: ["id", "default_region_id", "supported_currencies.*"],
+      })
+      const store = stores?.[0]
+      let regionId: string | undefined = store?.default_region_id ?? undefined
+      if (!regionId) {
+        const { data: regions } = await query.graph({
+          entity: "region",
+          fields: ["id"],
+          pagination: { take: 1 },
+        })
+        regionId = regions?.[0]?.id
+      }
+      if (!regionId) {
+        logger.warn(
+          `[orders-unification] skipped dual-write for ${order.id}: no region exists`
+        )
+        return new StepResponse<DualWriteResult>({
+          unified_order_id: null,
+          skipped: "no_region",
+        })
+      }
+      const currencyCode =
+        store?.supported_currencies?.find((c: any) => c?.is_default)
+          ?.currency_code ?? "inr"
+
+      // Internal sales channel keeps work-orders out of storefront analytics
+      // and retail listings. Lazily ensured (idempotent) instead of a seed
+      // script so fresh environments need no deploy-time coordination.
+      const salesChannelService: any = container.resolve(Modules.SALES_CHANNEL)
+      let [channel] = await salesChannelService.listSalesChannels({
+        name: PARTNER_WORK_ORDERS_CHANNEL,
+      })
+      if (!channel) {
+        channel = await salesChannelService.createSalesChannels({
+          name: PARTNER_WORK_ORDERS_CHANNEL,
+          description:
+            "Internal channel for unified partner work-orders (#342). Not a storefront.",
+        })
+      }
+
+      // Line titles come from the inventory items (raw materials have no
+      // product/variant — items are custom lines with explicit unit_price).
+      const inventoryService: any = container.resolve(Modules.INVENTORY)
+      const inventoryItemIds = input.order_lines.map((l) => l.inventory_item_id)
+      const inventoryItems = await inventoryService.listInventoryItems({
+        id: inventoryItemIds,
+      })
+      const titleByItemId = new Map<string, string>(
+        inventoryItems.map((item: any) => [
+          item.id,
+          item.title || item.sku || item.id,
+        ])
+      )
+
+      // Legacy line `price` is the line-total contribution (the legacy
+      // workflow sums plain prices into total_price); core wants unit price.
+      const items = orderLines.map((line: any, idx: number) => {
+        const legacyLine = input.order_lines[idx]
+        const quantity = Number(line.quantity)
+        const lineTotal = Number(line.price)
+        return {
+          title: titleByItemId.get(legacyLine?.inventory_item_id) ?? "Raw material",
+          quantity,
+          unit_price: quantity > 0 ? lineTotal / quantity : lineTotal,
+          metadata: {
+            inventory_item_id: legacyLine?.inventory_item_id,
+            legacy_orderline_id: line.id,
+            legacy_line_price: lineTotal,
+          },
+        }
+      })
+
+      const { address, extra } = splitShippingAddress(order.shipping_address)
+
+      // Legacy metadata wins on collision except the unification keys (§3).
+      const metadata: Record<string, unknown> = {
+        ...(order.metadata ?? {}),
+        kind: "inventory",
+        legacy_id: order.id,
+        total_quantity: Number(order.quantity),
+        expected_delivery_date: order.expected_delivery_date ?? null,
+        order_date: order.order_date ?? null,
+        is_sample: !!order.is_sample,
+        to_stock_location_id:
+          input.to_stock_location_id || input.stock_location_id,
+        from_stock_location_id: input.from_stock_location_id ?? null,
+        currency_assumed: true,
+        ...(extra ? { shipping_address_extra: extra } : {}),
+      }
+
+      // GAP-3: omit customer_id AND email — findOrCreateCustomerStep then
+      // resolves no customer and the order is created customer-less. Passing
+      // an email would find-or-create a guest customer row, which we don't
+      // want for internal POs.
+      const { result: unified } = await createOrderWorkflow(container).run({
+        input: {
+          region_id: regionId,
+          sales_channel_id: channel.id,
+          currency_code: currencyCode,
+          status: (LEGACY_TO_CORE_STATUS[order.status] ?? "pending") as any,
+          items: items as any,
+          shipping_address: address as any,
+          metadata,
+        },
+      })
+
+      const inventoryOrderService: InventoryOrderService =
+        container.resolve(ORDER_INVENTORY_MODULE)
+      await inventoryOrderService.updateInventoryOrders({
+        id: order.id,
+        metadata: {
+          ...(order.metadata ?? {}),
+          unified_order_id: unified.id,
+        },
+      })
+
+      return new StepResponse<DualWriteResult>({ unified_order_id: unified.id })
+    } catch (e: any) {
+      logger.warn(
+        `[orders-unification] dual-write failed for ${order?.id}: ${e?.message}`
+      )
+      return new StepResponse<DualWriteResult>({
+        unified_order_id: null,
+        error: e?.message,
+      })
+    }
+  }
+)
+
+// Send-to-partner mirror: once the partner is known, scope the unified order
+// to them (D3 link) and stamp metadata.partner_status = "assigned" (§5).
+// Same best-effort contract as the create-side step.
+export const mirrorPartnerLinkOnUnifiedOrderStep = createStep(
+  "mirror-partner-link-on-unified-order",
+  async (
+    input: { inventoryOrderId: string; partnerId: string },
+    { container }
+  ) => {
+    const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+    try {
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data: invOrders } = await query.graph({
+        entity: "inventory_orders",
+        fields: ["id", "metadata"],
+        filters: { id: input.inventoryOrderId },
+      })
+      const unifiedOrderId = invOrders?.[0]?.metadata?.unified_order_id
+      if (!unifiedOrderId) {
+        return new StepResponse<MirrorResult>({
+          linked: false,
+          skipped: "no_unified_order",
+        })
+      }
+
+      const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+      const links: LinkDefinition[] = [
+        {
+          [PARTNER_MODULE]: { partner_id: input.partnerId },
+          [Modules.ORDER]: { order_id: unifiedOrderId },
+          data: {
+            partner_id: input.partnerId,
+            order_id: unifiedOrderId,
+            assigned_at: new Date().toISOString(),
+          },
+        },
+      ]
+      await remoteLink.create(links)
+
+      const orderService: any = container.resolve(Modules.ORDER)
+      const unifiedOrder = await orderService.retrieveOrder(unifiedOrderId, {
+        select: ["id", "metadata"],
+      })
+      await orderService.updateOrders([
+        {
+          id: unifiedOrderId,
+          metadata: {
+            ...(unifiedOrder?.metadata ?? {}),
+            partner_status: "assigned",
+          },
+        },
+      ])
+
+      return new StepResponse<MirrorResult>({
+        linked: true,
+        unified_order_id: unifiedOrderId,
+      })
+    } catch (e: any) {
+      logger.warn(
+        `[orders-unification] partner link mirror failed for ${input.inventoryOrderId}: ${e?.message}`
+      )
+      return new StepResponse<MirrorResult>({ linked: false, error: e?.message })
+    }
+  }
+)

--- a/apps/backend/src/workflows/inventory_orders/send-to-partner.ts
+++ b/apps/backend/src/workflows/inventory_orders/send-to-partner.ts
@@ -19,6 +19,7 @@ import { PARTNER_MODULE } from "../../modules/partner"
 import InventoryOrderService from "../../modules/inventory_orders/service"
 import { LinkDefinition } from "@medusajs/framework/types"
 import { createTasksFromTemplatesWorkflow } from "./create-tasks-from-templates"
+import { mirrorPartnerLinkOnUnifiedOrderStep } from "./dual-write-unified-order"
 import { TASKS_MODULE } from "../../modules/tasks"
 import TaskService from "../../modules/tasks/service"
 
@@ -390,6 +391,14 @@ export const sendInventoryOrderToPartnerWorkflow = createWorkflow(
             partnerId: input.partnerId
         })
         
+        // #342 T2: mirror the assignment onto the unified core order
+        // (partner_order link + metadata.partner_status). Best-effort —
+        // the step swallows its own errors.
+        mirrorPartnerLinkOnUnifiedOrderStep({
+            inventoryOrderId: input.inventoryOrderId,
+            partnerId: input.partnerId
+        })
+
         // Step 4: Update inventory order with admin notes
         const orderWithNotes = updateInventoryOrderStep({
             inventoryOrderId: input.inventoryOrderId,

--- a/apps/docs/notes/ORDERS_UNIFICATION_342.md
+++ b/apps/docs/notes/ORDERS_UNIFICATION_342.md
@@ -138,47 +138,65 @@ T2 the shim only mirrors state, it never drives it.
   order's status/metadata.partner_status per §5. If that bloats the PR, defer
   mirror-on-update to early T3 and dual-write creates only.
 
-## 7. Open questions for T2 (answer empirically in the shim)
+## 7. Open questions for T2 — ANSWERED (T2 shim, 2026-06-12)
 
-1. **GAP-1:** does `order_line_item.quantity` accept decimals end-to-end
-   (create → totals → admin UI render)? Test with 2.5.
-2. **GAP-3:** minimal viable input for creating a core order with no customer —
-   draft-order workflow vs `createOrdersWorkflow` directly; which keeps totals
-   math + currency handling correct?
-3. Does the admin orders list need a filter to HIDE kind!=null orders (so work
-   orders don't pollute retail views)? Likely yes — small middleware/query
-   tweak, do it in the same PR as the shim to avoid confusing ops.
-4. Confirm `/partners/orders` channel-scoping does not accidentally expose
-   kind'd orders to the wrong partner before the partner_order link ships.
+1. **GAP-1 RESOLVED:** `order_line_item.quantity` accepts decimals end-to-end
+   through `createOrderWorkflow` → totals math (2.5 × 40 = 100 verified by
+   integration test). No `quantity_float` fallback needed. Admin UI render
+   still unverified — check in T3.
+2. **GAP-3 RESOLVED:** `createOrderWorkflow` (core-flows) directly, omitting
+   BOTH `customer_id` and `email`. `findOrCreateCustomerStep` then resolves no
+   customer and the order is created customer-less. Do NOT pass an email — it
+   find-or-creates a guest customer row. Totals/currency handling correct
+   (items are custom lines with explicit `unit_price`; no variant_id means
+   inventory confirmation is skipped).
+3. **DEFERRED to T3:** admin retail list still shows kind'd orders. Mitigated
+   meanwhile by the "Partner Work Orders" sales channel (filterable in admin
+   UI). Needs a middleware/query tweak on GET /admin/orders.
+4. **OK:** unified work-orders live on the internal "Partner Work Orders"
+   channel, which no partner store includes — channel-scoped `/partners/orders`
+   cannot leak them.
 
 ---
 
-## Handoff → next task (T2: thin shim PR)
+## Handoff → next task (T3: unified panels + status mirror)
 
-*Updated 2026-06-12 after T1. Next session: read THIS file + `TaskList`; do not
-rely on chat history.*
+*Updated 2026-06-12 after T2 (PR: feat/342-t2-unified-order-dual-write). Next
+session: read THIS file; do not rely on chat history.*
 
-- **State:** mapping + decisions D1–D3 locked above; nothing implemented yet.
-- **T2 deliverable:** one PR —
-  1. `src/links/partner-order.ts` (D3),
-  2. seed for "Partner Work Orders" sales channel,
-  3. dual-write step appended to `createInventoryOrderWorkflow`
-     (`src/workflows/inventory_orders/create-inventory-orders.ts`) creating the
-     kind=inventory core order per §3 + §5, non-fatal on failure,
-  4. integration test (shared suite): create inventory order → assert core
-     order exists, kind, partner link, line items, totals parity, legacy row
-     untouched; plus GAP-1 decimal-quantity probe and GAP-3 resolution,
-  5. admin retail list filter from §7.3 if cheap, else note it here.
-- **Key files discovered in T1** (saves re-exploration):
-  - inventory module: `src/modules/inventory_orders/{models/order.ts, models/orderline.ts, service.ts, constants.ts}`
-  - its workflows: `src/workflows/inventory_orders/*` (create, send-to-partner with await-steps, partner-complete, update)
-  - production runs: `src/modules/production_runs/models/production-run.ts`, workflows under `src/workflows/production-runs/`, policy in `src/modules/production_policy/service.ts`
-  - partner scoping today: `src/links/partner-inventory-order.ts`; partner routes `src/api/partners/inventory-orders/**`, `src/api/partners/production-runs/**`
-  - design↔order link infra from #29: `src/workflows/designs/link-designs-to-order.ts`, `src/links/design-order-link.ts`
-  - partner-ui app: `apps/partner-ui` — orders hooks `src/hooks/api/orders.tsx`, inventory-order hooks `src/hooks/api/partner-inventory-orders.tsx` (T3 material)
-- **Gotchas to carry:** unscoped `workflow.run()` can't resolve "query" (always
-  `(container)` scope); shared test suite truncates per test (create fixtures
-  per-test); migrations adding columns must be hand-written ALTERs; CI may need
-  `:any` on `container.resolve(...)`.
-- **After T2:** update this Handoff section for T3, mark task #26 completed,
-  user can `/clear`.
+- **State after T2:** dual-write shim LIVE for inventory orders.
+  - `apps/backend/src/links/partner-order.ts` — D3 link (partner ↔ core
+    order, isList both sides). Query rows via the link's `entryPoint`.
+  - `apps/backend/src/workflows/inventory_orders/dual-write-unified-order.ts`
+    — `dualWriteUnifiedOrderStep` (appended to `createInventoryOrderWorkflow`)
+    + `mirrorPartnerLinkOnUnifiedOrderStep` (appended to
+    `sendInventoryOrderToPartnerWorkflow`, sets link + `partner_status:
+    "assigned"`). Both best-effort: swallow errors, `logger.warn` with
+    `[orders-unification]` prefix. Legacy row gets
+    `metadata.unified_order_id` backref.
+  - "Partner Work Orders" sales channel is lazily ensured by the step (NOT a
+    seed script — fresh envs need no coordination).
+  - Currency = store default currency (NOT hardcoded inr) +
+    `metadata.currency_assumed: true`.
+  - Test: `integration-tests/http/orders-unification-dual-write.spec.ts`
+    (3 tests: full projection incl. GAP-1/GAP-3, non-fatality without region,
+    partner link on send).
+- **T2 scope notes:** status mirror on UPDATE workflows not done (per §6
+  fallback — creates only). No compensation on the dual-write step: if a later
+  legacy step rolls the create back, an orphan kind'd order may remain
+  (harmless, invisible to retail; T4 backfill dedups on `metadata.legacy_id`).
+- **T3 deliverable(s):**
+  1. status mirror: extend `updateInventoryOrderWorkflow` + partner
+     start/complete paths to PATCH unified order status +
+     `metadata.partner_status` per §5,
+  2. same dual-write for production runs (kind=design, §4) on the run-create
+     path,
+  3. admin retail list filter (§7.3 — still open),
+  4. partner-ui panels keyed on `order.metadata.kind` + `partner_status`
+     (hooks: `apps/partner-ui/src/hooks/api/orders.tsx`),
+  5. legacy routes become shims.
+- **Gotchas to carry:** test store default currency is eur (don't assert inr);
+  task-template create 404s if `category` names a non-existent category;
+  shared test suite truncates per test (create fixtures per-test); CI may need
+  `:any` on `container.resolve(...)`; `createOrderWorkflow` requires a region
+  to exist (step skips with warn if none).


### PR DESCRIPTION
## What

Phase T2 of #342 (orders unification): every legacy inventory-order create now also projects a core `order` with `metadata.kind = "inventory"`, per the field mapping in `apps/docs/notes/ORDERS_UNIFICATION_342.md` §3 + §5.

- **D3 link**: `src/links/partner-order.ts` — `partner ↔ order`, isList both sides. This is the scoping row the T3 unified panels will read.
- **`dualWriteUnifiedOrderStep`** appended to `createInventoryOrderWorkflow`:
  - custom line items (no variant), titles from inventory items, `unit_price` derived from the legacy line-total price
  - customer-less (no `customer_id`, no `email` — passing an email would find-or-create a guest customer)
  - currency = store default + `metadata.currency_assumed: true` (GAP-2)
  - "Partner Work Orders" sales channel lazily ensured (idempotent; replaces the planned seed script)
  - legacy row gets `metadata.unified_order_id` backref
  - **best-effort**: any failure logs `[orders-unification]` and never fails the legacy create
- **`mirrorPartnerLinkOnUnifiedOrderStep`** appended to `sendInventoryOrderToPartnerWorkflow`: creates the `partner_order` link + stamps `metadata.partner_status = "assigned"` (§5 vocabulary). Same best-effort contract.

## Gap resolutions (doc §7 updated)

- **GAP-1 resolved**: `order_line_item.quantity` accepts decimals end-to-end (2.5 kg verified, totals math correct — 2.5 × 40 = 100).
- **GAP-3 resolved**: `createOrderWorkflow` directly, omitting both `customer_id` and `email`, creates a truly customer-less order.
- §7.3 (hide kind'd orders from admin retail list) deferred to T3 — mitigated meanwhile by the dedicated sales channel.

## Scope fence (per doc §6)

No legacy table/route/workflow behavior changed. Status mirror on *update* paths deferred to early T3.

## Tests

New shared-suite spec `integration-tests/http/orders-unification-dual-write.spec.ts` — 3/3 pass:
1. full projection assertions (kind, metadata, status map, address split, totals parity, decimal qty, customer-less, channel)
2. legacy create succeeds when dual-write can't run (no region) — non-fatality proof
3. partner link + `partner_status=assigned` after send-to-partner

Regression: `inventory-orders-api`, `send-to-partner-complete-workflow`, `send-to-partner-error-cases` — 29/32; the 3 failures (`PUT not-Pending → 200`, complete non-existent → 400 not 404, complete unassigned 400) **also fail on main** (verified baseline), unrelated to this change.

Closes nothing yet — #342 continues with T3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)