### PR TITLE
feat(orders): #342 T3.2 — dual-write unified core order for production runs

### DIFF
--- a/apps/backend/integration-tests/http/orders-unification-design-dual-write.spec.ts
+++ b/apps/backend/integration-tests/http/orders-unification-design-dual-write.spec.ts
@@ -1,0 +1,395 @@
+/**
+ * #342 T3.2 — design-side dual-write shim.
+ *
+ * Creating/approving/transitioning a production run must additionally project
+ * and maintain a core `order` (metadata.kind = "design") per
+ * apps/docs/notes/ORDERS_UNIFICATION_342.md §4 + §5, without ever failing the
+ * legacy run path. Child runs (the partner-facing unit) get their own orders;
+ * a split parent's order is canceled as superseded.
+ */
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import partnerOrderLink from "../../src/links/partner-order"
+import designOrderLink from "../../src/links/design-order-link"
+
+jest.setTimeout(120000)
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Orders unification design dual-write (#342 T3.2)", () => {
+    let adminHeaders: any
+    let unique: number
+
+    const post = async (url: string, body: any, cfg?: any) => {
+      try {
+        return await api.post(url, body, cfg)
+      } catch (err: any) {
+        throw new Error(
+          `POST ${url} failed: ${err?.response?.status} ${JSON.stringify(
+            err?.response?.data
+          )}`
+        )
+      }
+    }
+
+    const createRegion = async () => {
+      const container = getContainer()
+      const regionService: any = container.resolve(Modules.REGION)
+      const region = await regionService.createRegions({
+        name: "India",
+        currency_code: "inr",
+        countries: ["in"],
+      })
+      return region.id
+    }
+
+    const createPartner = async (label = "p") => {
+      const email = `design-unification-${label}-${unique}@jyt.test`
+      const password = "supersecret"
+      await post("/auth/partner/emailpass/register", { email, password })
+      const firstLogin = await post("/auth/partner/emailpass", { email, password })
+      const res = await post(
+        "/partners",
+        {
+          name: `Design Unification Partner ${label} ${unique}`,
+          handle: `design-unification-${label}-${unique}`,
+          admin: { email, first_name: "Test", last_name: "Partner" },
+        },
+        { headers: { Authorization: `Bearer ${firstLogin.data.token}` } }
+      )
+      expect(res.status).toBe(200)
+      // Fresh token after partner creation (stale token misses the partner)
+      const freshLogin = await post("/auth/partner/emailpass", { email, password })
+      return {
+        partnerId: res.data.partner.id,
+        partnerHeaders: {
+          headers: { Authorization: `Bearer ${freshLogin.data.token}` },
+        },
+      }
+    }
+
+    const createTemplate = async (name: string) => {
+      const res = await post(
+        "/admin/task-templates",
+        {
+          name,
+          description: `${name} template`,
+          priority: "medium",
+          estimated_duration: 60,
+          required_fields: {},
+          eventable: false,
+          notifiable: false,
+          message_template: "",
+          metadata: { workflow_type: "production_run" },
+          category: "Design Unification Test",
+        },
+        adminHeaders
+      )
+      expect([200, 201]).toContain(res.status)
+      return name
+    }
+
+    const createDesign = async () => {
+      const res = await post(
+        "/admin/designs",
+        {
+          name: `Unification Design ${unique}`,
+          description: "Design for #342 dual-write test",
+          design_type: "Original",
+          status: "Approved",
+          priority: "Medium",
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      return res.data.design.id
+    }
+
+    const fetchRun = async (id: string) => {
+      const container = getContainer()
+      const productionRunService: any = container.resolve("production_runs")
+      return productionRunService.retrieveProductionRun(id)
+    }
+
+    const fetchUnifiedOrder = async (unifiedOrderId: string) => {
+      const container = getContainer()
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data } = await query.graph({
+        entity: "order",
+        filters: { id: unifiedOrderId },
+        fields: [
+          "id",
+          "status",
+          "currency_code",
+          "email",
+          "customer_id",
+          "metadata",
+          "total",
+          "sales_channel.name",
+          "items.*",
+        ],
+      })
+      return data?.[0]
+    }
+
+    const unifiedOrderIdOf = async (runId: string) => {
+      const run: any = await fetchRun(runId)
+      return run?.metadata?.unified_order_id ?? null
+    }
+
+    beforeEach(async () => {
+      const container = getContainer()
+      unique = Date.now()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+    })
+
+    it("dual-writes a kind=design core order on run create", async () => {
+      await createRegion()
+      const designId = await createDesign()
+
+      const createRes = await post(
+        `/admin/designs/${designId}/production-runs`,
+        { quantity: 5 },
+        adminHeaders
+      )
+      expect(createRes.status).toBe(201)
+      const runId = createRes.data.production_run.id
+
+      const unifiedOrderId = await unifiedOrderIdOf(runId)
+      expect(unifiedOrderId).toBeTruthy()
+      const unified = await fetchUnifiedOrder(unifiedOrderId)
+
+      // §2/§4 discriminator + projection metadata
+      expect(unified.metadata.kind).toBe("design")
+      expect(unified.metadata.legacy_id).toBe(runId)
+      expect(unified.metadata.production_run_id).toBe(runId)
+      expect(unified.metadata.run_type).toBe("production")
+      expect(unified.metadata.currency_assumed).toBe(true)
+      // legacy run metadata merged in (route stamps this source)
+      expect(unified.metadata.source).toBe("admin.designs.manual")
+
+      // §5: pending_review → core draft, no partner_status yet
+      expect(unified.status).toBe("draft")
+      expect(unified.metadata.partner_status ?? null).toBeNull()
+
+      // GAP-3 recipe: customer-less
+      expect(unified.customer_id ?? null).toBeNull()
+      expect(unified.email ?? null).toBeNull()
+
+      // Internal channel, one line per design (no cost estimate yet → 0)
+      expect(unified.sales_channel?.name).toBe("Partner Work Orders")
+      expect(unified.items).toHaveLength(1)
+      expect(Number(unified.items[0].quantity)).toBe(5)
+      expect(Number(unified.items[0].unit_price)).toBe(0)
+      expect(unified.items[0].metadata.design_id).toBe(designId)
+
+      // §4 — design ↔ order link reused
+      const container = getContainer()
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data: designLinks } = await query.graph({
+        entity: designOrderLink.entryPoint,
+        filters: { order_id: unifiedOrderId },
+        fields: ["design_id", "order_id"],
+      })
+      expect(designLinks).toHaveLength(1)
+      expect(designLinks[0].design_id).toBe(designId)
+
+      // Legacy run untouched apart from the metadata backref; order_id still
+      // means "source retail order" (deviation note in the doc)
+      const run: any = await fetchRun(runId)
+      expect(run.status).toBe("pending_review")
+      expect(run.order_id ?? null).toBeNull()
+    })
+
+    it("projects child runs on approve, supersedes the parent order, links partner on send, and mirrors the partner lifecycle", async () => {
+      await createRegion()
+      const designId = await createDesign()
+      const { partnerId, partnerHeaders } = await createPartner()
+      const templateName = await createTemplate(`design-unification-cutting-${unique}`)
+
+      // create + approve + dispatch in one call
+      const createRes = await post(
+        `/admin/designs/${designId}/production-runs`,
+        {
+          assignments: [
+            {
+              partner_id: partnerId,
+              quantity: 4,
+              role: "manufacturing",
+              template_names: [templateName],
+            },
+          ],
+        },
+        adminHeaders
+      )
+      expect(createRes.status).toBe(201)
+      const parentId = createRes.data.production_run.id
+      const childId = createRes.data.children[0].id
+
+      // Parent order: created at create time, then superseded by the split
+      const parentOrderId = await unifiedOrderIdOf(parentId)
+      expect(parentOrderId).toBeTruthy()
+      const parentOrder = await fetchUnifiedOrder(parentOrderId)
+      expect(parentOrder.status).toBe("canceled")
+      expect(parentOrder.metadata.superseded_by_run_ids).toEqual([childId])
+
+      // Child order: the partner-facing commercial artifact (§4)
+      const childOrderId = await unifiedOrderIdOf(childId)
+      expect(childOrderId).toBeTruthy()
+      expect(childOrderId).not.toBe(parentOrderId)
+      let childOrder = await fetchUnifiedOrder(childOrderId)
+      expect(childOrder.metadata.kind).toBe("design")
+      expect(Number(childOrder.items[0].quantity)).toBe(4)
+      // sent_to_partner → core pending + partner_status assigned
+      expect(childOrder.status).toBe("pending")
+      expect(childOrder.metadata.partner_status).toBe("assigned")
+
+      // D3: partner ↔ order link row exists on the child order
+      const container = getContainer()
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data: linkRows } = await query.graph({
+        entity: partnerOrderLink.entryPoint,
+        filters: { order_id: childOrderId },
+        fields: ["partner_id", "order_id"],
+      })
+      expect(linkRows).toHaveLength(1)
+      expect(linkRows[0].partner_id).toBe(partnerId)
+
+      // ——— partner lifecycle: accept → start → finish → complete ———
+      const accept = await post(
+        `/partners/production-runs/${childId}/accept`,
+        {},
+        partnerHeaders
+      )
+      expect(accept.status).toBe(200)
+      childOrder = await fetchUnifiedOrder(childOrderId)
+      expect(childOrder.status).toBe("pending")
+      expect(childOrder.metadata.partner_status).toBe("accepted")
+
+      const start = await post(
+        `/partners/production-runs/${childId}/start`,
+        {},
+        partnerHeaders
+      )
+      expect(start.status).toBe(200)
+      childOrder = await fetchUnifiedOrder(childOrderId)
+      expect(childOrder.metadata.partner_status).toBe("in_progress")
+
+      const finish = await post(
+        `/partners/production-runs/${childId}/finish`,
+        {},
+        partnerHeaders
+      )
+      expect(finish.status).toBe(200)
+      childOrder = await fetchUnifiedOrder(childOrderId)
+      expect(childOrder.status).toBe("pending")
+      expect(childOrder.metadata.partner_status).toBe("finished")
+
+      const complete = await post(
+        `/partners/production-runs/${childId}/complete`,
+        {},
+        partnerHeaders
+      )
+      expect(complete.status).toBe(200)
+      childOrder = await fetchUnifiedOrder(childOrderId)
+      expect(childOrder.status).toBe("completed")
+      expect(childOrder.metadata.partner_status).toBe("completed")
+
+      // Parent order stays superseded even after the completion cascade
+      const parentAfter = await fetchUnifiedOrder(parentOrderId)
+      expect(parentAfter.status).toBe("canceled")
+    })
+
+    it("mirrors a partner decline as canceled + declined", async () => {
+      await createRegion()
+      const designId = await createDesign()
+      const { partnerId, partnerHeaders } = await createPartner("decline")
+      const templateName = await createTemplate(`design-unification-decline-${unique}`)
+
+      const createRes = await post(
+        `/admin/designs/${designId}/production-runs`,
+        {
+          assignments: [
+            {
+              partner_id: partnerId,
+              quantity: 2,
+              template_names: [templateName],
+            },
+          ],
+        },
+        adminHeaders
+      )
+      expect(createRes.status).toBe(201)
+      const childId = createRes.data.children[0].id
+      const childOrderId = await unifiedOrderIdOf(childId)
+      expect(childOrderId).toBeTruthy()
+
+      const decline = await post(
+        `/partners/production-runs/${childId}/decline`,
+        { reason: "capacity", notes: "unification decline test" },
+        partnerHeaders
+      )
+      expect(decline.status).toBe(200)
+
+      const childOrder = await fetchUnifiedOrder(childOrderId)
+      expect(childOrder.status).toBe("canceled")
+      expect(childOrder.metadata.partner_status).toBe("declined")
+    })
+
+    it("mirrors an admin cancel as canceled without touching partner_status", async () => {
+      await createRegion()
+      const designId = await createDesign()
+
+      const createRes = await post(
+        `/admin/designs/${designId}/production-runs`,
+        { quantity: 3 },
+        adminHeaders
+      )
+      expect(createRes.status).toBe(201)
+      const runId = createRes.data.production_run.id
+      const unifiedOrderId = await unifiedOrderIdOf(runId)
+      expect(unifiedOrderId).toBeTruthy()
+
+      const cancel = await post(
+        `/admin/production-runs/${runId}/cancel`,
+        { reason: "test cancel" },
+        adminHeaders
+      )
+      expect(cancel.status).toBe(200)
+
+      const unified = await fetchUnifiedOrder(unifiedOrderId)
+      expect(unified.status).toBe("canceled")
+      // §5 defines no partner_status for an admin cancel
+      expect(unified.metadata.partner_status ?? null).toBeNull()
+    })
+
+    it("does not fail the legacy run path when the dual-write cannot run (no region)", async () => {
+      // No region created — the projection must skip, not throw
+      const designId = await createDesign()
+
+      const createRes = await post(
+        `/admin/designs/${designId}/production-runs`,
+        { quantity: 2 },
+        adminHeaders
+      )
+      expect(createRes.status).toBe(201)
+      const runId = createRes.data.production_run.id
+
+      const run: any = await fetchRun(runId)
+      expect(run.status).toBe("pending_review")
+      expect(run.metadata?.unified_order_id ?? null).toBeNull()
+
+      // Later transitions stay non-fatal without a unified order
+      const cancel = await post(
+        `/admin/production-runs/${runId}/cancel`,
+        { reason: "no region cancel" },
+        adminHeaders
+      )
+      expect(cancel.status).toBe(200)
+      expect(((await fetchRun(runId)) as any).status).toBe("cancelled")
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/partner-orders-api.spec.ts
+++ b/apps/backend/integration-tests/http/partner-orders-api.spec.ts
@@ -336,6 +336,57 @@ setupSharedTestSuite(() => {
         expect(res.data.order.shipping_address.city).toBe("Los Angeles")
       })
 
+      // #342 metadata-as-critical-data audit — POST /partners/orders/:id must
+      // read-then-merge metadata and never let a partner overwrite the
+      // load-bearing unification keys or mutate non-whitelisted order fields.
+      it("merges metadata and protects unification keys on partner PATCH", async () => {
+        // Admin stamps the order as a unified work-order with a partner-owned
+        // key alongside the protected unification keys.
+        await api.post(
+          `/admin/orders/${orderId}`,
+          {
+            metadata: {
+              kind: "design",
+              legacy_id: "leg_test_342",
+              partner_status: "assigned",
+              partner_note: "keep-me",
+            },
+          },
+          adminHeaders
+        )
+
+        // Partner tries to overwrite protected keys, drop a key by omission,
+        // and sneak in a non-whitelisted field (status).
+        const res = await api.post(
+          `/partners/orders/${orderId}`,
+          {
+            status: "completed",
+            metadata: {
+              kind: "hacked",
+              partner_status: "in_progress",
+              partner_note: "updated",
+              extra: "added",
+            },
+          },
+          { headers: partner.headers }
+        )
+        expect(res.status).toBe(200)
+
+        const after = await api.get(`/partners/orders/${orderId}`, {
+          headers: partner.headers,
+        })
+        const md = after.data.order.metadata
+        // Protected keys survive the partner's attempt to change them.
+        expect(md.kind).toBe("design")
+        expect(md.legacy_id).toBe("leg_test_342")
+        expect(md.partner_status).toBe("assigned")
+        // Partner-owned keys merge (incoming wins, new key added).
+        expect(md.partner_note).toBe("updated")
+        expect(md.extra).toBe("added")
+        // Non-whitelisted field was dropped, not applied.
+        expect(after.data.order.status).not.toBe("completed")
+      })
+
       it("lists shipping options for the order", async () => {
         const res = await api.get(
           `/partners/orders/${orderId}/shipping-options`,

--- a/apps/backend/src/api/admin/production-runs/[id]/cancel/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/cancel/route.ts
@@ -3,6 +3,7 @@ import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/util
 import { PRODUCTION_RUNS_MODULE } from "../../../../../modules/production_runs"
 import type ProductionRunService from "../../../../../modules/production_runs/service"
 import { TASKS_MODULE } from "../../../../../modules/tasks"
+import { mirrorRunStatusToUnifiedOrder } from "../../../../../workflows/production-runs/dual-write-unified-run-order"
 
 /**
  * Cancel a single run: update status, cancel tasks.
@@ -138,6 +139,12 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     } catch (e: any) {
       console.error("[cancel-production-run] Failed to check/cancel parent:", e.message)
     }
+  }
+
+  // #342 — best-effort mirror onto the unified orders (admin cancel carries
+  // no partner_status per §5; superseded parent orders are skipped inside)
+  for (const runId of [id, ...cancelledChildren, run.parent_run_id].filter(Boolean)) {
+    await mirrorRunStatusToUnifiedOrder(req.scope, runId)
   }
 
   // Emit event for notifications

--- a/apps/backend/src/api/partners/orders/[id]/route.ts
+++ b/apps/backend/src/api/partners/orders/[id]/route.ts
@@ -1,7 +1,20 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { getOrderDetailWorkflow } from "@medusajs/medusa/core-flows"
-import { Modules } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { validatePartnerOrderOwnership } from "../../helpers"
+import { PROTECTED_UNIFICATION_METADATA_KEYS } from "../../../../workflows/inventory_orders/dual-write-unified-order"
+
+// Fields a partner is allowed to PATCH on an order — mirrors admin's
+// `AdminUpdateOrder` validator (email, addresses, locale, metadata). Anything
+// else in the body (status, customer_id, sales_channel_id, …) is dropped rather
+// than passed to `updateOrders`, which would otherwise mutate it verbatim.
+const PARTNER_UPDATABLE_ORDER_FIELDS = [
+  "email",
+  "shipping_address",
+  "billing_address",
+  "locale",
+  "metadata",
+] as const
 
 /**
  * GET / POST partner order detail.
@@ -48,8 +61,44 @@ export const POST = async (
 ) => {
   await validatePartnerOrderOwnership(req.auth_context, req.params.id, req.scope)
 
+  const body = (req.body ?? {}) as Record<string, unknown>
+
+  // Whitelist: only the admin-equivalent fields survive. A partner cannot move
+  // an order's status, owner, or channel through this route.
+  const update: Record<string, unknown> = {}
+  for (const field of PARTNER_UPDATABLE_ORDER_FIELDS) {
+    if (field in body) {
+      update[field] = body[field]
+    }
+  }
+
+  // metadata is REPLACED (not merged) by `updateOrders`. Read-then-merge so a
+  // partner PATCH preserves untouched keys, and force-restore the load-bearing
+  // unification keys (#342) so they can never be overwritten or dropped — these
+  // discriminate the order and drive billing/statements/panels.
+  if ("metadata" in update) {
+    const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+    const { data: orders } = await query.graph({
+      entity: "orders",
+      fields: ["id", "metadata"],
+      filters: { id: req.params.id },
+    })
+    const existing = (orders?.[0]?.metadata ?? {}) as Record<string, unknown>
+    const incoming = (update.metadata ?? {}) as Record<string, unknown>
+
+    const merged: Record<string, unknown> = { ...existing, ...incoming }
+    for (const key of PROTECTED_UNIFICATION_METADATA_KEYS) {
+      if (key in existing) {
+        merged[key] = existing[key]
+      } else {
+        delete merged[key]
+      }
+    }
+    update.metadata = merged
+  }
+
   const orderService = req.scope.resolve(Modules.ORDER) as any
-  const order = await orderService.updateOrders(req.params.id, req.body as any)
+  const order = await orderService.updateOrders(req.params.id, update)
 
   res.json({ order })
 }

--- a/apps/backend/src/subscribers/production-run-task-updated.ts
+++ b/apps/backend/src/subscribers/production-run-task-updated.ts
@@ -7,6 +7,7 @@ import type ProductionRunService from "../modules/production_runs/service"
 import {
   sendProductionRunToProductionWorkflow,
 } from "../workflows/production-runs/send-production-run-to-production"
+import { mirrorRunStatusToUnifiedOrder } from "../workflows/production-runs/dual-write-unified-run-order"
 
 export default async function productionRunTaskUpdatedHandler({
   event: { data },
@@ -110,6 +111,9 @@ export default async function productionRunTaskUpdatedHandler({
         completed_at: new Date(),
       })
     })
+
+    // #342 — best-effort mirror onto the unified order
+    await mirrorRunStatusToUnifiedOrder(container, String(productionRunId))
 
     // Emit production_run.completed so downstream subscribers fire
     // (e.g. sample-run-completed for cost calculation)

--- a/apps/backend/src/workflows/inventory_orders/dual-write-unified-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/dual-write-unified-order.ts
@@ -14,6 +14,24 @@ import InventoryOrderService from "../../modules/inventory_orders/service"
 
 export const PARTNER_WORK_ORDERS_CHANNEL = "Partner Work Orders"
 
+// #342 metadata-as-critical-data audit — the load-bearing unification keys on a
+// unified order's `metadata`. Medusa's `update*` REPLACES the whole metadata
+// blob, so any external writer (e.g. a partner PATCH) must read-then-merge AND
+// must never let caller input overwrite these — they discriminate the order
+// (`kind`), anchor backfill/idempotency (`legacy_id`), and drive T3 panels
+// (`partner_status`). See ORDERS_UNIFICATION_342.md "metadata-as-critical-data".
+export const PROTECTED_UNIFICATION_METADATA_KEYS = [
+  "kind",
+  "legacy_id",
+  "partner_status",
+  "source_order_id",
+  "source_line_item_id",
+  "superseded_by_run_ids",
+  "currency_assumed",
+  "to_stock_location_id",
+  "from_stock_location_id",
+] as const
+
 // §5 — legacy 6-value enum → core order.status. The work-progress dimension
 // (metadata.partner_status) only exists once a partner is assigned, which
 // never holds at create time.

--- a/apps/backend/src/workflows/production-runs/accept-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/accept-production-run.ts
@@ -11,6 +11,7 @@ import type ProductionRunService from "../../modules/production_runs/service"
 
 import { PRODUCTION_POLICY_MODULE } from "../../modules/production_policy"
 import type ProductionPolicyService from "../../modules/production_policy/service"
+import { mirrorUnifiedRunOrderStatusStep } from "./dual-write-unified-run-order"
 
 export type AcceptProductionRunInput = {
   production_run_id: string
@@ -159,6 +160,11 @@ export const acceptProductionRunWorkflow = createWorkflow(
     const accepted = acceptProductionRunStep({
       run,
       partner_id: input.partner_id,
+    })
+
+    // #342 — mirror in_progress/accepted onto the unified order (§5)
+    mirrorUnifiedRunOrderStatusStep({
+      production_run_id: input.production_run_id,
     })
 
     return new WorkflowResponse(accepted)

--- a/apps/backend/src/workflows/production-runs/approve-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/approve-production-run.ts
@@ -17,6 +17,7 @@ import type ProductionPolicyService from "../../modules/production_policy/servic
 import { DESIGN_MODULE } from "../../modules/designs"
 import { PARTNER_MODULE } from "../../modules/partner"
 import designPartnersLink from "../../links/design-partners-link"
+import { dualWriteChildRunOrdersStep } from "./dual-write-unified-run-order"
 
 export type ProductionRunAssignment = {
   partner_id: string
@@ -82,6 +83,14 @@ const approveProductionRunStep = createStep(
       )
     }
 
+    // Children must NOT inherit the parent's #342 unified-order backref —
+    // each child is its own commercial unit (§4) and gets its own projected
+    // order. Leaving `unified_order_id` in the copied metadata would make the
+    // projection's idempotency guard reuse the parent's (soon-superseded)
+    // order for every child.
+    const { unified_order_id: _omitParentOrderRef, ...inheritedMetadata } =
+      ((original as any).metadata ?? {}) as Record<string, any>
+
     const childPayloads = assignments.map((a) => {
       const quantity = a.quantity ?? (original as any).quantity ?? 1
 
@@ -112,7 +121,7 @@ const approveProductionRunStep = createStep(
         status: "approved" as any,
         run_type: (original as any).run_type ?? "production",
         dispatch_template_names: a.template_names?.length ? a.template_names : null,
-        metadata: (original as any).metadata ?? null,
+        metadata: Object.keys(inheritedMetadata).length ? inheritedMetadata : null,
       }
     })
 
@@ -302,6 +311,16 @@ export const approveProductionRunWorkflow = createWorkflow(
         .filter((id): id is string => !!id),
     }))
     linkDesignToPartnersStep(designPartnerLinkInput)
+
+    // #342 — child runs are the partner-facing unit (§4): each gets its own
+    // kind=design order; a split parent's order is canceled as superseded.
+    const childOrderInput = transform({ input, approved }, (data) => ({
+      parent_run_id: data.input.production_run_id,
+      child_run_ids: ((data.approved as any)?.children ?? [])
+        .map((c: any) => c?.id)
+        .filter(Boolean),
+    }))
+    dualWriteChildRunOrdersStep(childOrderInput)
 
     return new WorkflowResponse(approved)
   }

--- a/apps/backend/src/workflows/production-runs/complete-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/complete-production-run.ts
@@ -29,6 +29,7 @@ import {
   stockFinishedGoodsStep,
   type PartnerRunInput,
 } from "./partner-run-steps"
+import { mirrorUnifiedRunOrderStatusStep } from "./dual-write-unified-run-order"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -425,6 +426,11 @@ export const completeProductionRunWorkflow = createWorkflow(
     })
 
     emitProductionRunEventStep(eventInput)
+
+    // #342 — mirror completed onto the unified order (§5)
+    mirrorUnifiedRunOrderStatusStep({
+      production_run_id: input.production_run_id,
+    })
 
     return new WorkflowResponse({ run, consumptions: consumptionResult })
   }

--- a/apps/backend/src/workflows/production-runs/create-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/create-production-run.ts
@@ -15,6 +15,7 @@ import type ProductionRunService from "../../modules/production_runs/service"
 
 import { TASKS_MODULE } from "../../modules/tasks"
 import DesignInventoryLink from "../../links/design-inventory-link"
+import { dualWriteUnifiedRunOrderStep } from "./dual-write-unified-run-order"
 
 const sanitizeBigInt = (value: any): any => {
   if (typeof value === "bigint") {
@@ -274,6 +275,9 @@ export const createProductionRunWorkflow = createWorkflow(
         task_ids: input.task_ids || [],
       })
     })
+
+    // #342 — best-effort projection onto a kind=design core order
+    dualWriteUnifiedRunOrderStep({ production_run_id: productionRunId })
 
     return new WorkflowResponse(run)
   }

--- a/apps/backend/src/workflows/production-runs/decline-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/decline-production-run.ts
@@ -9,6 +9,7 @@ import {
 import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
 import type ProductionRunService from "../../modules/production_runs/service"
 import { TASKS_MODULE } from "../../modules/tasks"
+import { mirrorUnifiedRunOrderStatusStep } from "./dual-write-unified-run-order"
 
 export type DeclineProductionRunInput = {
   production_run_id: string
@@ -136,6 +137,14 @@ export const declineProductionRunWorkflow = createWorkflow(
       notes: input.notes,
       composed_reason: input.composed_reason,
     })
+
+    // #342 — partner decline mirrors as canceled + partner_status "declined"
+    // (§5: the only cancel that carries a partner_status)
+    mirrorUnifiedRunOrderStatusStep({
+      production_run_id: input.production_run_id,
+      declined: true,
+    })
+
     return new WorkflowResponse({ ok: true })
   }
 )

--- a/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
+++ b/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
@@ -1,0 +1,489 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
+import { createOrderWorkflow } from "@medusajs/medusa/core-flows"
+import type { Link } from "@medusajs/modules-sdk"
+import type { LinkDefinition } from "@medusajs/framework/types"
+import type { MedusaContainer } from "@medusajs/framework/types"
+import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
+import { PARTNER_MODULE } from "../../modules/partner"
+import { DESIGN_MODULE } from "../../modules/designs"
+import type ProductionRunService from "../../modules/production_runs/service"
+import { PARTNER_WORK_ORDERS_CHANNEL } from "../inventory_orders/dual-write-unified-order"
+
+// #342 T3.2 — best-effort projection of production runs onto the core `order`
+// entity (metadata.kind = "design"). Mirrors the T2 inventory-order recipe;
+// see apps/docs/notes/ORDERS_UNIFICATION_342.md §4 + §5. Failure must never
+// fail the legacy path, so every entry point swallows errors and reports via
+// logger.warn with the [orders-unification] prefix.
+//
+// Deviation from §4's "run gains order_id → unified order": during the shim
+// phase the unified order id lives in run.metadata.unified_order_id, NOT in
+// run.order_id — that column still means "the customer retail order that
+// spawned the run" and is read by stockFinishedGoodsStep (reservations) and
+// run provenance. Repointing it is a T4 concern.
+
+// §5 — run status → core order.status. The work-progress dimension lives in
+// metadata.partner_status (below).
+const RUN_TO_CORE_STATUS: Record<string, string> = {
+  draft: "draft",
+  pending_review: "draft",
+  approved: "pending",
+  sent_to_partner: "pending",
+  in_progress: "pending",
+  completed: "completed",
+  cancelled: "canceled",
+}
+
+// §5 — the shared assigned→accepted→in_progress→finished→completed
+// vocabulary. The legacy run enum collapses accepted/started/finished into
+// one "in_progress" value; the lifecycle timestamps disambiguate. approved/
+// draft/pending_review are absent on purpose (no partner work yet), and
+// cancelled only maps to "declined" when the cancel came from a partner
+// decline — an admin cancel leaves the last value untouched (§5 table
+// defines no value for it).
+const deriveRunPartnerStatus = (
+  run: any,
+  opts: { declined?: boolean } = {}
+): string | undefined => {
+  switch (run.status) {
+    case "sent_to_partner":
+      return "assigned"
+    case "in_progress":
+      if (run.finished_at) return "finished"
+      if (run.started_at) return "in_progress"
+      if (run.accepted_at) return "accepted"
+      // Partner self-serve runs are born in_progress with no lifecycle
+      // timestamps — the partner is already working on it.
+      return "in_progress"
+    case "completed":
+      return "completed"
+    case "cancelled":
+      return opts.declined ? "declined" : undefined
+    default:
+      return undefined
+  }
+}
+
+type ProjectionResult = {
+  unified_order_id: string | null
+  skipped?: string
+  error?: string
+}
+
+type MirrorResult = {
+  linked: boolean
+  unified_order_id?: string
+  skipped?: string
+  error?: string
+}
+
+const resolveRegionAndCurrency = async (container: MedusaContainer) => {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  const { data: stores } = await query.graph({
+    entity: "store",
+    fields: ["id", "default_region_id", "supported_currencies.*"],
+  })
+  const store = stores?.[0]
+  let regionId: string | undefined = store?.default_region_id ?? undefined
+  if (!regionId) {
+    const { data: regions } = await query.graph({
+      entity: "region",
+      fields: ["id"],
+      pagination: { take: 1 },
+    })
+    regionId = regions?.[0]?.id
+  }
+  const currencyCode =
+    store?.supported_currencies?.find((c: any) => c?.is_default)
+      ?.currency_code ?? "inr"
+  return { regionId, currencyCode }
+}
+
+const ensureWorkOrdersChannel = async (container: MedusaContainer) => {
+  const salesChannelService: any = container.resolve(Modules.SALES_CHANNEL)
+  let [channel] = await salesChannelService.listSalesChannels({
+    name: PARTNER_WORK_ORDERS_CHANNEL,
+  })
+  if (!channel) {
+    channel = await salesChannelService.createSalesChannels({
+      name: PARTNER_WORK_ORDERS_CHANNEL,
+      description:
+        "Internal channel for unified partner work-orders (#342). Not a storefront.",
+    })
+  }
+  return channel
+}
+
+const createPartnerOrderLink = async (
+  container: MedusaContainer,
+  partnerId: string,
+  orderId: string,
+  role?: string
+) => {
+  const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+  const links: LinkDefinition[] = [
+    {
+      [PARTNER_MODULE]: { partner_id: partnerId },
+      [Modules.ORDER]: { order_id: orderId },
+      data: {
+        partner_id: partnerId,
+        order_id: orderId,
+        assigned_at: new Date().toISOString(),
+        ...(role ? { role } : {}),
+      },
+    },
+  ]
+  await remoteLink.create(links)
+}
+
+const patchUnifiedOrder = async (
+  container: MedusaContainer,
+  unifiedOrderId: string,
+  patch: { status?: string; metadata?: Record<string, unknown> }
+) => {
+  const orderService: any = container.resolve(Modules.ORDER)
+  if (patch.metadata) {
+    const current = await orderService.retrieveOrder(unifiedOrderId, {
+      select: ["id", "metadata"],
+    })
+    patch.metadata = { ...(current?.metadata ?? {}), ...patch.metadata }
+  }
+  await orderService.updateOrders([
+    {
+      id: unifiedOrderId,
+      ...(patch.status ? { status: patch.status } : {}),
+      ...(patch.metadata ? { metadata: patch.metadata } : {}),
+    },
+  ])
+}
+
+/**
+ * Project ONE run onto a kind=design core order (§4). The order represents
+ * "JYT commissions partner X to produce design Y, qty N, at cost C" — one
+ * line item per design. Idempotent on run.metadata.unified_order_id.
+ *
+ * Exported as a plain function so the create/approve steps, the admin cancel
+ * route and the task subscriber can all share it without composing workflows.
+ */
+export const projectRunToUnifiedOrder = async (
+  container: MedusaContainer,
+  productionRunId: string
+): Promise<ProjectionResult> => {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  try {
+    const productionRunService: ProductionRunService =
+      container.resolve(PRODUCTION_RUNS_MODULE)
+    const run: any = await productionRunService.retrieveProductionRun(
+      productionRunId
+    )
+
+    if (run?.metadata?.unified_order_id) {
+      return {
+        unified_order_id: run.metadata.unified_order_id,
+        skipped: "already_projected",
+      }
+    }
+
+    const { regionId, currencyCode } = await resolveRegionAndCurrency(container)
+    if (!regionId) {
+      logger.warn(
+        `[orders-unification] skipped run dual-write for ${productionRunId}: no region exists`
+      )
+      return { unified_order_id: null, skipped: "no_region" }
+    }
+
+    const channel = await ensureWorkOrdersChannel(container)
+
+    // GAP-4: cost_type "total" → derive unit price; "per_unit" is already a
+    // unit price. No estimate yet (admin sets it later) → 0; the original is
+    // preserved in metadata for parity checks and T4 backfill.
+    const quantity = Number(run.quantity) || 1
+    const estimate = Number(run.partner_cost_estimate) || 0
+    const unitPrice =
+      run.cost_type === "per_unit" ? estimate : quantity > 0 ? estimate / quantity : estimate
+
+    const designTitle =
+      run.snapshot?.design?.name ?? `Design ${run.design_id}`
+
+    // Legacy metadata wins on collision except the unification keys (§3/§4).
+    const metadata: Record<string, unknown> = {
+      ...(run.metadata ?? {}),
+      kind: "design",
+      legacy_id: run.id,
+      production_run_id: run.id,
+      run_type: run.run_type ?? "production",
+      execution_mode: run.execution_mode ?? "in_house",
+      source_order_id: run.order_id ?? null,
+      source_line_item_id: run.order_line_item_id ?? null,
+      currency_assumed: true,
+    }
+
+    const partnerStatus = deriveRunPartnerStatus(run)
+    if (partnerStatus) {
+      metadata.partner_status = partnerStatus
+    }
+
+    // GAP-3 recipe: omit customer_id AND email so the order is created
+    // customer-less (the "customer" of a work-order is JYT itself).
+    const { result: unified } = await createOrderWorkflow(container).run({
+      input: {
+        region_id: regionId,
+        sales_channel_id: channel.id,
+        currency_code: currencyCode,
+        status: (RUN_TO_CORE_STATUS[run.status] ?? "pending") as any,
+        items: [
+          {
+            title: designTitle,
+            quantity,
+            unit_price: unitPrice,
+            metadata: {
+              design_id: run.design_id,
+              cost_type: run.cost_type ?? null,
+              legacy_cost_estimate: run.partner_cost_estimate ?? null,
+              production_run_id: run.id,
+            },
+          },
+        ] as any,
+        metadata,
+      },
+    })
+
+    // §4 — reuse the existing design↔order link infra (#29) so design panels
+    // and linkDesignsToOrder consumers see the work-order too.
+    if (run.design_id) {
+      const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+      await remoteLink
+        .create([
+          {
+            [DESIGN_MODULE]: { design_id: run.design_id },
+            [Modules.ORDER]: { order_id: unified.id },
+          },
+        ])
+        .catch((e: any) =>
+          logger.warn(
+            `[orders-unification] design link failed for ${run.id}: ${e?.message}`
+          )
+        )
+    }
+
+    // Partner scoping: runs born at/past sent_to_partner (child runs are
+    // linked by the send mirror instead; partner self-serve runs are born
+    // in_progress and need the link immediately).
+    if (
+      run.partner_id &&
+      ["sent_to_partner", "in_progress", "completed"].includes(run.status)
+    ) {
+      await createPartnerOrderLink(container, run.partner_id, unified.id)
+      if (run.execution_mode === "outsourced" && run.sub_partner_id) {
+        await createPartnerOrderLink(
+          container,
+          run.sub_partner_id,
+          unified.id,
+          "sub_partner"
+        )
+      }
+    }
+
+    await productionRunService.updateProductionRuns({
+      id: run.id,
+      metadata: {
+        ...(run.metadata ?? {}),
+        unified_order_id: unified.id,
+      },
+    })
+
+    return { unified_order_id: unified.id }
+  } catch (e: any) {
+    logger.warn(
+      `[orders-unification] run dual-write failed for ${productionRunId}: ${e?.message}`
+    )
+    return { unified_order_id: null, error: e?.message }
+  }
+}
+
+/**
+ * Mirror a run's current status onto its unified order per §5. Re-reads the
+ * run from DB (not workflow input) so compensations mirror correctly too.
+ * Safe to call from non-workflow code (routes, subscribers).
+ */
+export const mirrorRunStatusToUnifiedOrder = async (
+  container: MedusaContainer,
+  productionRunId: string,
+  opts: { declined?: boolean } = {}
+): Promise<MirrorResult> => {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  try {
+    const productionRunService: ProductionRunService =
+      container.resolve(PRODUCTION_RUNS_MODULE)
+    const run: any = await productionRunService
+      .retrieveProductionRun(productionRunId)
+      .catch(() => null)
+
+    const unifiedOrderId = run?.metadata?.unified_order_id
+    if (!unifiedOrderId) {
+      return { linked: false, skipped: "no_unified_order" }
+    }
+
+    const orderService: any = container.resolve(Modules.ORDER)
+    const unifiedOrder = await orderService.retrieveOrder(unifiedOrderId, {
+      select: ["id", "metadata"],
+    })
+
+    // A parent order superseded by a run split stays canceled forever —
+    // the child orders carry the commercial reality.
+    if (unifiedOrder?.metadata?.superseded_by_run_ids) {
+      return { linked: false, skipped: "superseded" }
+    }
+
+    const coreStatus = RUN_TO_CORE_STATUS[run.status]
+    const partnerStatus = deriveRunPartnerStatus(run, opts)
+
+    await orderService.updateOrders([
+      {
+        id: unifiedOrderId,
+        ...(coreStatus ? { status: coreStatus } : {}),
+        ...(partnerStatus
+          ? {
+              metadata: {
+                ...(unifiedOrder?.metadata ?? {}),
+                partner_status: partnerStatus,
+              },
+            }
+          : {}),
+      },
+    ])
+
+    return { linked: true, unified_order_id: unifiedOrderId }
+  } catch (e: any) {
+    logger.warn(
+      `[orders-unification] run status mirror failed for ${productionRunId}: ${e?.message}`
+    )
+    return { linked: false, error: e?.message }
+  }
+}
+
+// Create-side step: appended to createProductionRunWorkflow. Covers admin
+// top-level runs and partner self-serve runs (born in_progress).
+export const dualWriteUnifiedRunOrderStep = createStep(
+  "dual-write-unified-run-order",
+  async (input: { production_run_id: string }, { container }) => {
+    const result = await projectRunToUnifiedOrder(
+      container,
+      input.production_run_id
+    )
+    return new StepResponse<ProjectionResult>(result)
+  }
+)
+
+// Approve-side step: §4 says one unified order per CHILD run (the
+// partner-facing unit). When approve splits a parent into child runs, each
+// child gets its own order and the parent's order — projected at create time,
+// before we could know it would become a planning artifact — is canceled and
+// marked superseded so billing never double-counts the work.
+export const dualWriteChildRunOrdersStep = createStep(
+  "dual-write-child-run-orders",
+  async (
+    input: { parent_run_id: string; child_run_ids: string[] },
+    { container }
+  ) => {
+    const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+    try {
+      for (const childId of input.child_run_ids) {
+        await projectRunToUnifiedOrder(container, childId)
+      }
+
+      if (input.child_run_ids.length) {
+        const productionRunService: ProductionRunService =
+          container.resolve(PRODUCTION_RUNS_MODULE)
+        const parent: any = await productionRunService
+          .retrieveProductionRun(input.parent_run_id)
+          .catch(() => null)
+        const parentOrderId = parent?.metadata?.unified_order_id
+        if (parentOrderId) {
+          await patchUnifiedOrder(container, parentOrderId, {
+            status: "canceled",
+            metadata: { superseded_by_run_ids: input.child_run_ids },
+          })
+        }
+      } else {
+        // No split — the run itself stays the partner-facing unit; mirror
+        // its approved status.
+        await mirrorRunStatusToUnifiedOrder(container, input.parent_run_id)
+      }
+
+      return new StepResponse({ projected: input.child_run_ids.length })
+    } catch (e: any) {
+      logger.warn(
+        `[orders-unification] child run dual-write failed for ${input.parent_run_id}: ${e?.message}`
+      )
+      return new StepResponse({ projected: 0, error: e?.message })
+    }
+  }
+)
+
+// Send-side mirror: once the run is dispatched the partner is committed —
+// scope the unified order to them (D3 link) and stamp partner_status
+// "assigned" (§5). Same best-effort contract as the other steps.
+export const mirrorRunPartnerLinkOnUnifiedOrderStep = createStep(
+  "mirror-run-partner-link-on-unified-order",
+  async (input: { production_run_id: string }, { container }) => {
+    const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+    try {
+      const productionRunService: ProductionRunService =
+        container.resolve(PRODUCTION_RUNS_MODULE)
+      const run: any = await productionRunService
+        .retrieveProductionRun(input.production_run_id)
+        .catch(() => null)
+
+      const unifiedOrderId = run?.metadata?.unified_order_id
+      if (!unifiedOrderId || !run?.partner_id) {
+        return new StepResponse<MirrorResult>({
+          linked: false,
+          skipped: !unifiedOrderId ? "no_unified_order" : "no_partner",
+        })
+      }
+
+      await createPartnerOrderLink(container, run.partner_id, unifiedOrderId)
+      if (run.execution_mode === "outsourced" && run.sub_partner_id) {
+        await createPartnerOrderLink(
+          container,
+          run.sub_partner_id,
+          unifiedOrderId,
+          "sub_partner"
+        )
+      }
+
+      await patchUnifiedOrder(container, unifiedOrderId, {
+        metadata: { partner_status: "assigned" },
+      })
+
+      return new StepResponse<MirrorResult>({
+        linked: true,
+        unified_order_id: unifiedOrderId,
+      })
+    } catch (e: any) {
+      logger.warn(
+        `[orders-unification] run partner link mirror failed for ${input.production_run_id}: ${e?.message}`
+      )
+      return new StepResponse<MirrorResult>({ linked: false, error: e?.message })
+    }
+  }
+)
+
+// Status mirror: appended to every run lifecycle workflow (accept, start,
+// finish, complete, decline, send) so partner actions, admin actions and
+// their compensations all converge through one path.
+export const mirrorUnifiedRunOrderStatusStep = createStep(
+  "mirror-unified-run-order-status",
+  async (
+    input: { production_run_id: string; declined?: boolean },
+    { container }
+  ) => {
+    const result = await mirrorRunStatusToUnifiedOrder(
+      container,
+      input.production_run_id,
+      { declined: input.declined }
+    )
+    return new StepResponse<MirrorResult>(result)
+  }
+)

--- a/apps/backend/src/workflows/production-runs/finish-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/finish-production-run.ts
@@ -21,6 +21,7 @@ import {
   emitProductionRunEventStep,
   type PartnerRunInput,
 } from "./partner-run-steps"
+import { mirrorUnifiedRunOrderStatusStep } from "./dual-write-unified-run-order"
 
 // ---------------------------------------------------------------------------
 // Step: Mark run as finished
@@ -117,6 +118,11 @@ export const finishProductionRunWorkflow = createWorkflow(
     }))
 
     emitProductionRunEventStep(eventInput)
+
+    // #342 — mirror in_progress (finished) onto the unified order (§5)
+    mirrorUnifiedRunOrderStatusStep({
+      production_run_id: input.production_run_id,
+    })
 
     return new WorkflowResponse({ run })
   }

--- a/apps/backend/src/workflows/production-runs/send-production-run-to-production.ts
+++ b/apps/backend/src/workflows/production-runs/send-production-run-to-production.ts
@@ -25,6 +25,7 @@ import { PARTNER_MODULE } from "../../modules/partner"
 import {
   runProductionRunLifecycleWorkflow,
 } from "./run-production-run-lifecycle"
+import { mirrorRunPartnerLinkOnUnifiedOrderStep } from "./dual-write-unified-run-order"
 
 export type SendProductionRunToProductionInput = {
   production_run_id: string
@@ -337,6 +338,11 @@ export const sendProductionRunToProductionWorkflow = createWorkflow(
 
     // Start the long-running lifecycle workflow fire-and-forget
     startLifecycleWorkflowStep({
+      production_run_id: input.production_run_id,
+    })
+
+    // #342 — partner is committed now: D3 link + partner_status "assigned"
+    mirrorRunPartnerLinkOnUnifiedOrderStep({
       production_run_id: input.production_run_id,
     })
 

--- a/apps/backend/src/workflows/production-runs/start-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/start-production-run.ts
@@ -21,6 +21,7 @@ import {
   emitProductionRunEventStep,
   type PartnerRunInput,
 } from "./partner-run-steps"
+import { mirrorUnifiedRunOrderStatusStep } from "./dual-write-unified-run-order"
 
 // ---------------------------------------------------------------------------
 // Step: Mark run as started
@@ -105,6 +106,11 @@ export const startProductionRunWorkflow = createWorkflow(
     }))
 
     emitProductionRunEventStep(eventInput)
+
+    // #342 — mirror in_progress (started) onto the unified order (§5)
+    mirrorUnifiedRunOrderStatusStep({
+      production_run_id: input.production_run_id,
+    })
 
     return new WorkflowResponse({ run })
   }

--- a/apps/docs/notes/ORDERS_UNIFICATION_342.md
+++ b/apps/docs/notes/ORDERS_UNIFICATION_342.md
@@ -161,11 +161,84 @@ T2 the shim only mirrors state, it never drives it.
 
 ---
 
-## Handoff → next task (T3 continues: design-side dual-write)
+## Handoff → next task (T3 continues: admin retail list filter + partner panels)
 
-*Updated 2026-06-12 after T3.1 status mirror (PR:
-feat/342-t3-status-mirror-on-update). Next session: read THIS file; do not
-rely on chat history.*
+*Updated 2026-06-13 after T3.2 design-side dual-write (PR:
+feat/342-t3-design-dual-write). Next session: read THIS file; do not rely on
+chat history.*
+
+- **State after T3.2:** dual-write + status mirror LIVE for production runs
+  (kind=design), mirroring the T2 inventory recipe (§4 + §5). Both legacy
+  surfaces (inventory orders, production runs) now project + maintain a unified
+  core order.
+  - `apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts`
+    — the design-side counterpart to `inventory_orders/dual-write-unified-order.ts`.
+    Exports two plain async helpers (`projectRunToUnifiedOrder`,
+    `mirrorRunStatusToUnifiedOrder`) so routes + subscribers can reuse them
+    without composing workflows, plus four workflow steps wrapping them. It
+    reuses T2's `PARTNER_WORK_ORDERS_CHANNEL` constant + region/currency
+    fallback recipe. Same best-effort contract (`[orders-unification]` warn,
+    never fails the legacy path).
+  - **Wiring** (one projection on create, mirror on every transition):
+    - `create-production-run.ts` → `dualWriteUnifiedRunOrderStep` (admin
+      top-level runs + partner self-serve runs, born `in_progress`).
+    - `approve-production-run.ts` → `dualWriteChildRunOrdersStep`: §4 says the
+      CHILD run is the partner-facing unit, so on a split each child gets its
+      own order and the parent's create-time order is **canceled + stamped
+      `metadata.superseded_by_run_ids`**. `mirrorRunStatusToUnifiedOrder` then
+      permanently skips superseded orders. **Gotcha fixed in this PR:**
+      `approveProductionRunStep` copied the parent run's `metadata` onto each
+      child verbatim, including the create-step's `unified_order_id` backref —
+      so the projection's idempotency guard reused the parent's order for every
+      child. Now strips `unified_order_id` from inherited child metadata.
+    - `send-production-run-to-production.ts` →
+      `mirrorRunPartnerLinkOnUnifiedOrderStep` (D3 partner↔order link +
+      `partner_status: "assigned"`; outsourced runs also link `sub_partner_id`
+      with `role: "sub_partner"`).
+    - accept / start / finish / complete / decline workflows →
+      `mirrorUnifiedRunOrderStatusStep`. Decline passes `declined: true` (the
+      ONLY cancel that carries `partner_status: "declined"`; admin cancel
+      leaves it untouched per §5).
+    - Non-workflow mutators also mirror: admin cancel route
+      (`production-runs/[id]/cancel/route.ts`, covers run + children + parent)
+      and the `production-run-task-updated` subscriber's auto-complete.
+  - **§5 run mapping** lives in `RUN_TO_CORE_STATUS` + `deriveRunPartnerStatus`.
+    The legacy enum collapses accepted/started/finished into one `in_progress`
+    value, so `deriveRunPartnerStatus` disambiguates via lifecycle timestamps
+    (`finished_at` → finished, `started_at` → in_progress, `accepted_at` →
+    accepted). `draft`/`pending_review`/`approved` carry no `partner_status`.
+  - **DEVIATION from §4:** the unified order id is stored on
+    `run.metadata.unified_order_id`, NOT `run.order_id`. That column still
+    means "the customer retail order that spawned the run" and is read by
+    `stockFinishedGoodsStep` (reservations) + run provenance — repointing it is
+    a T4 concern. The `order.metadata.source_order_id` carries the retail
+    pointer on the unified side.
+  - Test: `integration-tests/http/orders-unification-design-dual-write.spec.ts`
+    (5 tests: create projection + design link, approve→child-orders +
+    supersede + full partner lifecycle accept→complete, partner decline,
+    admin cancel, non-fatality without region). Regression-checked the
+    lifecycle / multi-partner / cross-ordering / design-status specs.
+- **T3.2 scope notes / still open:**
+  - WhatsApp run handlers (`workflows/whatsapp/*`) mutate run status directly
+    and are NOT mirrored yet (out of scope; low traffic). Same for
+    `recreate-production-run`.
+  - No cost re-sync: the unified order's line `unit_price` is set at create
+    time from `partner_cost_estimate` (0 until an admin sets it). When the
+    partner reports cost at `/complete`, the run's cost updates but the order
+    line is not re-priced — billing (#336) should read cost from the run or we
+    add a price-sync in T4.
+  - No compensation on `dualWriteUnifiedRunOrderStep` (mirrors T2): a rolled-back
+    run-create can leave an orphan kind=design order (harmless, invisible to
+    retail; T4 backfill dedups on `metadata.legacy_id`).
+- **Remaining T3 deliverable(s)** (suggested order):
+  1. ~~status mirror per §5~~ — DONE (T3.1),
+  2. ~~design-side dual-write for production runs~~ — DONE (T3.2, see above),
+  3. admin retail list filter (§7.3 — still open): GET /admin/orders shows
+     kind'd work-orders; needs a middleware/query tweak to exclude
+     `metadata.kind` unless asked,
+  4. partner-ui panels keyed on `order.metadata.kind` + `partner_status`
+     (hooks: `apps/partner-ui/src/hooks/api/orders.tsx`),
+  5. legacy routes become shims.
 
 - **State after T3.1:** status mirror LIVE for inventory orders — every legacy
   status change now PATCHes the unified order per §5.

--- a/apps/docs/notes/ORDERS_UNIFICATION_342.md
+++ b/apps/docs/notes/ORDERS_UNIFICATION_342.md
@@ -248,11 +248,20 @@ chat history.*
        each does read-then-spread, not blind replace. The dual-write steps
        already re-read first (`patchUnifiedOrder` + the mirror steps); the
        legacy-row backref writers also spread `...(row.metadata ?? {})`.
-    2. **KNOWN HIT to fix:** `src/api/partners/orders/[id]/route.ts:52` does
+    2. ~~**KNOWN HIT to fix:** `src/api/partners/orders/[id]/route.ts:52` does
        `updateOrders(req.params.id, req.body)` — a partner PATCH carrying a
        `metadata` field REPLACES the whole blob, wiping `kind`/`legacy_id`/
-       `partner_status` off a unified work-order. Whitelist fields / merge
-       metadata there before partner panels start writing.
+       `partner_status` off a unified work-order.~~ **FIXED (2026-06-13, on PR
+       #391).** The POST handler now (a) whitelists the body to admin's
+       `AdminUpdateOrder` fields (`email`, `shipping_address`, `billing_address`,
+       `locale`, `metadata`) so a partner can't move `status`/`customer_id`/
+       `sales_channel_id`, and (b) read-then-merges `metadata`, then force-restores
+       the new exported `PROTECTED_UNIFICATION_METADATA_KEYS` (in
+       `workflows/inventory_orders/dual-write-unified-order.ts`) from the existing
+       order so partner input can never overwrite or drop them. Those keys are
+       system-owned: they're set once at projection and `partner_status` only
+       moves via the lifecycle mirror steps — never a direct PATCH. Test:
+       `partner-orders-api.spec.ts` "merges metadata and protects unification keys".
     3. **Concurrency hazard:** the mirror steps are read-modify-write; two
        near-simultaneous transitions (e.g. partner `/complete` + the
        `production-run-task-updated` auto-complete) can lose a `partner_status`

--- a/apps/docs/notes/ORDERS_UNIFICATION_342.md
+++ b/apps/docs/notes/ORDERS_UNIFICATION_342.md
@@ -230,6 +230,39 @@ chat history.*
   - No compensation on `dualWriteUnifiedRunOrderStep` (mirrors T2): a rolled-back
     run-create can leave an orphan kind=design order (harmless, invisible to
     retail; T4 backfill dedups on `metadata.legacy_id`).
+- **TRACKED TASK — metadata-as-critical-data audit (added 2026-06-13):**
+  The unification leans on JSON `metadata` for load-bearing, frequently-mutated
+  fields. Medusa's `update*` **replaces the whole metadata blob** — any writer
+  that doesn't read-then-spread silently drops keys, and concurrent transitions
+  race on the blob with no atomic merge. This is a footgun for critical state;
+  audit and harden before T4 retirement.
+  - **Keys a wrong update would corrupt:**
+    - unified `order.metadata`: `kind`, `legacy_id`, `partner_status`,
+      `source_order_id`/`source_line_item_id`, `superseded_by_run_ids`,
+      `currency_assumed`, `to_/from_stock_location_id`.
+    - legacy backrefs: `inventory_orders.metadata.unified_order_id`,
+      `production_runs.metadata.unified_order_id` (the run↔order pointer this
+      whole shim depends on — see the §4 deviation note above).
+  - **Audit steps:**
+    1. Grep every writer of those entities' metadata across `src/` and verify
+       each does read-then-spread, not blind replace. The dual-write steps
+       already re-read first (`patchUnifiedOrder` + the mirror steps); the
+       legacy-row backref writers also spread `...(row.metadata ?? {})`.
+    2. **KNOWN HIT to fix:** `src/api/partners/orders/[id]/route.ts:52` does
+       `updateOrders(req.params.id, req.body)` — a partner PATCH carrying a
+       `metadata` field REPLACES the whole blob, wiping `kind`/`legacy_id`/
+       `partner_status` off a unified work-order. Whitelist fields / merge
+       metadata there before partner panels start writing.
+    3. **Concurrency hazard:** the mirror steps are read-modify-write; two
+       near-simultaneous transitions (e.g. partner `/complete` + the
+       `production-run-task-updated` auto-complete) can lose a `partner_status`
+       write. Decide lock vs typed column.
+    4. **Promote the highest-risk keys to typed columns** (the D2 "revisit if
+       needed" trigger): `kind` (filtered by the admin-list work, item 3 below)
+       and `partner_status` (written on every transition, read by panels) are
+       the strongest candidates. `legacy_id` + the `unified_order_id` backrefs
+       are write-once (lower mutation risk) but are the backfill/idempotency
+       anchor — a real indexed column is safer than a JSON key for T4 dedup.
 - **Remaining T3 deliverable(s)** (suggested order):
   1. ~~status mirror per §5~~ — DONE (T3.1),
   2. ~~design-side dual-write for production runs~~ — DONE (T3.2, see above),


### PR DESCRIPTION
## What

Extends #342 orders unification to the **design work-order** side. Every production run now projects and maintains a core `order` with `metadata.kind = "design"`, mirroring the T2 inventory-order recipe (doc §4 + §5). Both legacy surfaces — inventory orders (T2/T3.1) and production runs (this PR) — now feed one unified order surface for billing (#336), statements, and FX.

## How

New `workflows/production-runs/dual-write-unified-run-order.ts`, the design-side counterpart to `inventory_orders/dual-write-unified-order.ts`:
- `projectRunToUnifiedOrder` / `mirrorRunStatusToUnifiedOrder` — plain async helpers so routes + subscribers reuse them without composing workflows
- four workflow steps wrapping them; reuses T2's `PARTNER_WORK_ORDERS_CHANNEL` + region/currency fallback
- best-effort contract (`[orders-unification]` warn, never fails the legacy run path)

Wiring — one projection on create, mirror on every transition:
| Path | Step |
|---|---|
| create-production-run | `dualWriteUnifiedRunOrderStep` (admin + partner self-serve) |
| approve-production-run | `dualWriteChildRunOrdersStep` — one order per **child** run (§4); split parent's order canceled + `superseded_by_run_ids` |
| send-to-production | `mirrorRunPartnerLinkOnUnifiedOrderStep` — D3 partner↔order link + `partner_status: assigned` |
| accept / start / finish / complete / decline | `mirrorUnifiedRunOrderStatusStep` (decline → `declined`) |
| admin cancel route + task-updated subscriber | `mirrorRunStatusToUnifiedOrder` |

§5 mapping disambiguates the legacy enum's collapsed `in_progress` via lifecycle timestamps (`finished_at`/`started_at`/`accepted_at`).

### Notable
- **Deviation from §4:** unified order id lives on `run.metadata.unified_order_id`, NOT `run.order_id` — that column still means "the source retail order" and is read by reservations/provenance. T4 repoints.
- **Bug fixed:** `approveProductionRunStep` copied the parent run's `metadata` onto each child verbatim, including the create-step's `unified_order_id` backref, so the projection idempotency guard reused the parent's (soon-superseded) order for every child. Now strips it.

## Still open (noted in handoff doc)
- WhatsApp run handlers + `recreate-production-run` not mirrored (low traffic).
- No cost re-sync: order line `unit_price` set at create from `partner_cost_estimate`; partner's reported cost at `/complete` doesn't re-price the line (T4 / billing reads from run).

## Test
`integration-tests/http/orders-unification-design-dual-write.spec.ts` — 5 tests (create projection + design link; approve → child orders + supersede + full partner lifecycle; partner decline; admin cancel; non-fatality without region). All pass. Regression-checked lifecycle / multi-partner / cross-ordering / design-status / inventory dual-write specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)