### PR TITLE
feat(orders): #342 PR-A — D5 link adoption (define → write → read)

### DIFF
--- a/apps/backend/integration-tests/http/orders-unification-design-dual-write.spec.ts
+++ b/apps/backend/integration-tests/http/orders-unification-design-dual-write.spec.ts
@@ -393,6 +393,46 @@ setupSharedTestSuite(() => {
       expect(unified.metadata.partner_status ?? null).toBeNull()
     })
 
+    it("resolves the unified order via the link, not the metadata backref (D5-3)", async () => {
+      // Chunk 3 — the run status mirror (incl. the admin cancel route) now
+      // resolves the unified order through the order↔production_run link
+      // (query.graph forward `.order`), not run.metadata.unified_order_id.
+      // POISON the backref with a bogus id, leave the link intact: the mirror
+      // must still cancel the REAL order, which is only possible via the link.
+      await createRegion()
+      const designId = await createDesign()
+
+      const createRes = await post(
+        `/admin/designs/${designId}/production-runs`,
+        { quantity: 4 },
+        adminHeaders
+      )
+      expect(createRes.status).toBe(201)
+      const runId = createRes.data.production_run.id
+      const unifiedOrderId = await unifiedOrderIdOf(runId)
+      expect(unifiedOrderId).toBeTruthy()
+
+      const container = getContainer()
+      const productionRunService: any = container.resolve("production_runs")
+      await productionRunService.updateProductionRuns({
+        id: runId,
+        metadata: { unified_order_id: "order_bogus_does_not_exist" },
+      })
+      expect((await fetchRun(runId)).metadata?.unified_order_id).toBe(
+        "order_bogus_does_not_exist"
+      )
+
+      const cancel = await post(
+        `/admin/production-runs/${runId}/cancel`,
+        { reason: "link-resolution test" },
+        adminHeaders
+      )
+      expect(cancel.status).toBe(200)
+
+      const unified = await fetchUnifiedOrder(unifiedOrderId)
+      expect(unified.status).toBe("canceled")
+    })
+
     it("does not fail the legacy run path when the dual-write cannot run (no region)", async () => {
       // No region created — the projection must skip, not throw
       const designId = await createDesign()

--- a/apps/backend/integration-tests/http/orders-unification-design-dual-write.spec.ts
+++ b/apps/backend/integration-tests/http/orders-unification-design-dual-write.spec.ts
@@ -197,6 +197,16 @@ setupSharedTestSuite(() => {
       expect(designLinks).toHaveLength(1)
       expect(designLinks[0].design_id).toBe(designId)
 
+      // D5-2: the order↔production_run link is the authoritative pointer +
+      // kind=design discriminator. Resolve it forward (run → unified order)
+      // via query.graph — the same join D5-3 reads switch to.
+      const { data: linkedRuns } = await query.graph({
+        entity: "production_runs",
+        filters: { id: runId },
+        fields: ["id", "order.id"],
+      })
+      expect(linkedRuns?.[0]?.order?.id).toBe(unifiedOrderId)
+
       // Legacy run untouched apart from the metadata backref; order_id still
       // means "source retail order" (deviation note in the doc)
       const run: any = await fetchRun(runId)
@@ -257,6 +267,23 @@ setupSharedTestSuite(() => {
       })
       expect(linkRows).toHaveLength(1)
       expect(linkRows[0].partner_id).toBe(partnerId)
+
+      // D5-2: each child run owns its own order↔production_run link, and the
+      // parent run still points at its (now superseded) order. Confirms the
+      // re-entrant projection links every child distinctly rather than reusing
+      // the parent's order.
+      const { data: childLink } = await query.graph({
+        entity: "production_runs",
+        filters: { id: childId },
+        fields: ["id", "order.id"],
+      })
+      expect(childLink?.[0]?.order?.id).toBe(childOrderId)
+      const { data: parentLink } = await query.graph({
+        entity: "production_runs",
+        filters: { id: parentId },
+        fields: ["id", "order.id"],
+      })
+      expect(parentLink?.[0]?.order?.id).toBe(parentOrderId)
 
       // ——— partner lifecycle: accept → start → finish → complete ———
       const accept = await post(

--- a/apps/backend/integration-tests/http/orders-unification-dual-write.spec.ts
+++ b/apps/backend/integration-tests/http/orders-unification-dual-write.spec.ts
@@ -12,6 +12,7 @@ import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
 import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
 import partnerOrderLink from "../../src/links/partner-order"
+import { ORDER_INVENTORY_MODULE } from "../../src/modules/inventory_orders"
 
 jest.setTimeout(60000)
 
@@ -242,6 +243,42 @@ setupSharedTestSuite(() => {
       expect(res2.status).toBe(200)
       unified = await fetchUnifiedOrder(unifiedOrderId)
       expect(unified.status).toBe("canceled")
+      expect(unified.metadata.partner_status).toBe("in_progress")
+    })
+
+    it("resolves the unified order via the link, not the metadata backref (D5-3)", async () => {
+      // Chunk 3 — the status mirror now reads the order↔inventory_order link
+      // (query.graph forward `.order`), no longer the metadata.unified_order_id
+      // backref. Prove it by POISONING the backref with a bogus order id while
+      // leaving the link intact: if the mirror still lands on the REAL unified
+      // order, it can ONLY have resolved via the link (a backref read would
+      // target the bogus id and leave the real order untouched).
+      await createRegion()
+      const legacy = await createLegacyOrder()
+      const legacyRow = await fetchLegacyOrder(legacy.id)
+      const unifiedOrderId = legacyRow.metadata?.unified_order_id
+      expect(unifiedOrderId).toBeTruthy()
+
+      const container = getContainer()
+      const inventoryOrderService: any =
+        container.resolve(ORDER_INVENTORY_MODULE)
+      await inventoryOrderService.updateInventoryOrders({
+        id: legacy.id,
+        metadata: { unified_order_id: "order_bogus_does_not_exist" },
+      })
+      expect((await fetchLegacyOrder(legacy.id)).metadata?.unified_order_id).toBe(
+        "order_bogus_does_not_exist"
+      )
+
+      const res = await api.put(
+        `/admin/inventory-orders/${legacy.id}`,
+        { status: "Processing" },
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+
+      const unified = await fetchUnifiedOrder(unifiedOrderId)
+      expect(unified.status).toBe("pending")
       expect(unified.metadata.partner_status).toBe("in_progress")
     })
 

--- a/apps/backend/integration-tests/http/orders-unification-dual-write.spec.ts
+++ b/apps/backend/integration-tests/http/orders-unification-dual-write.spec.ts
@@ -190,6 +190,16 @@ setupSharedTestSuite(() => {
       expect(Number(legacyRow.quantity)).toBe(2.5)
       expect(Number(legacyRow.total_price)).toBe(100)
       expect(legacyRow.orderlines).toHaveLength(1)
+
+      // D5-2: the order↔inventory_order link is the authoritative pointer.
+      // Resolve it forward (legacy row → unified order) via query.graph — the
+      // same join the mirror/read paths will use in D5-3.
+      const { data: linked } = await query.graph({
+        entity: "inventory_orders",
+        filters: { id: legacy.id },
+        fields: ["id", "order.id"],
+      })
+      expect(linked?.[0]?.order?.id).toBe(unifiedOrderId)
     })
 
     it("does not fail the legacy create when the dual-write cannot run (no region)", async () => {

--- a/apps/backend/src/links/order-inventory-order.ts
+++ b/apps/backend/src/links/order-inventory-order.ts
@@ -1,0 +1,25 @@
+import { defineLink } from "@medusajs/framework/utils"
+import OrderModule from "@medusajs/medusa/order"
+import InventoryOrderModule from "../modules/inventory_orders"
+
+// D5 (#342): the unified core `order` ↔ its `inventory_orders` execution row.
+//
+// Counterpart to order-production-run.ts. This link is the load-bearing pointer
+// (replacing `inventory_orders.metadata.unified_order_id`) AND the
+// discriminator: an order linked to an inventory_order is a raw-material PO
+// (kind=inventory). Neither execution link → customer retail order.
+//
+// One unified order per inventory order, so 1:1. `filterable: ["id"]` ingests
+// the inventory_orders side into the Index Module so
+// `query.index({ entity: "order", filters: { inventory_order: { id: ... } } })`
+// can filter by link existence. Index for list filtering; query.graph for
+// authoritative transactional reads (see order-production-run.ts).
+export default defineLink(
+  OrderModule.linkable.order,
+  {
+    linkable: InventoryOrderModule.linkable.inventoryOrders,
+    filterable: ["id"],
+    // pin the relation name so the filter key is `inventory_order` (singular).
+    field: "inventory_order",
+  }
+)

--- a/apps/backend/src/links/order-inventory-order.ts
+++ b/apps/backend/src/links/order-inventory-order.ts
@@ -14,12 +14,19 @@ import InventoryOrderModule from "../modules/inventory_orders"
 // `query.index({ entity: "order", filters: { inventory_order: { id: ... } } })`
 // can filter by link existence. Index for list filtering; query.graph for
 // authoritative transactional reads (see order-production-run.ts).
+//
+// Managed link → fully BIDIRECTIONAL in query.graph: forward
+// `inventory_orders.order`, reverse `order.inventory_orders` (auto-derived
+// PLURAL). The `field` below only adds the singular `inventory_order` alias to
+// the Index Module; it does NOT rename query.graph's reverse accessor.
 export default defineLink(
   OrderModule.linkable.order,
   {
     linkable: InventoryOrderModule.linkable.inventoryOrders,
     filterable: ["id"],
-    // pin the relation name so the filter key is `inventory_order` (singular).
+    // adds the singular `inventory_order` alias to the INDEX (query.index) for
+    // the retail anti-join. Does NOT change query.graph's reverse accessor
+    // (that's `order.inventory_orders`).
     field: "inventory_order",
   }
 )

--- a/apps/backend/src/links/order-production-run.ts
+++ b/apps/backend/src/links/order-production-run.ts
@@ -20,13 +20,22 @@ import ProductionRunsModule from "../modules/production_runs"
 // (id: null). Use query.index for list filtering only; resolve the link via
 // query.graph for transactional reads inside workflows (it is authoritative;
 // the index is eventually consistent).
+//
+// This is a MANAGED (pivot-table) link, so it is fully BIDIRECTIONAL in
+// query.graph — verified reading a real linked row both ways:
+//   forward: `production_runs.order`        → the unified order
+//   reverse: `order.production_runs`        → the run (auto-derived PLURAL)
+// The `field` below ONLY affects the Index Module accessor (adds the singular
+// `production_run` alias for query.index); it does NOT rename query.graph's
+// reverse accessor, which stays the plural model name `production_runs`.
 export default defineLink(
   OrderModule.linkable.order,
   {
     linkable: ProductionRunsModule.linkable.productionRuns,
     filterable: ["id"],
-    // pin the relation name so `query.index`/`query.graph` filter key is
-    // `production_run` (not the plural model name `production_runs`).
+    // adds the singular `production_run` alias to the INDEX (query.index) so the
+    // admin retail anti-join can filter `production_run: { id: null }`. Does NOT
+    // change query.graph's reverse accessor (that's `order.production_runs`).
     field: "production_run",
   }
 )

--- a/apps/backend/src/links/order-production-run.ts
+++ b/apps/backend/src/links/order-production-run.ts
@@ -1,0 +1,32 @@
+import { defineLink } from "@medusajs/framework/utils"
+import OrderModule from "@medusajs/medusa/order"
+import ProductionRunsModule from "../modules/production_runs"
+
+// D5 (#342): the unified core `order` ↔ its `production_run` execution row.
+//
+// This link is the load-bearing pointer the orders-unification shim depends on
+// (replacing the old `run.metadata.unified_order_id` backref, which a metadata
+// blob-replace could silently wipe — see feedback_no_critical_data_in_metadata),
+// AND the discriminator: an order linked to a production_run is a design
+// work-order (kind=design). An order with NEITHER this link nor an
+// order↔inventory_order link is a customer retail order. NOTE: do NOT use the
+// `design ↔ order` link to discriminate — that one is shared with retail
+// (order-placed.ts runs linkDesignsToOrder on every purchase).
+//
+// One unified order per (child) run, so 1:1. `filterable: ["id"]` ingests the
+// production_run side into the Index Module (index_engine is enabled) so
+// `query.index({ entity: "order", filters: { production_run: { id: ... } } })`
+// can filter orders by link existence — including the retail anti-join
+// (id: null). Use query.index for list filtering only; resolve the link via
+// query.graph for transactional reads inside workflows (it is authoritative;
+// the index is eventually consistent).
+export default defineLink(
+  OrderModule.linkable.order,
+  {
+    linkable: ProductionRunsModule.linkable.productionRuns,
+    filterable: ["id"],
+    // pin the relation name so `query.index`/`query.graph` filter key is
+    // `production_run` (not the plural model name `production_runs`).
+    field: "production_run",
+  }
+)

--- a/apps/backend/src/workflows/inventory_orders/dual-write-unified-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/dual-write-unified-order.ts
@@ -232,6 +232,28 @@ export const dualWriteUnifiedOrderStep = createStep(
         },
       })
 
+      // D5-2 — the load-bearing order↔inventory_order link + kind=inventory
+      // discriminator (replaces metadata.unified_order_id as the authoritative
+      // pointer; the metadata backref below is still written during the D5
+      // transition). filterable:["id"] → the Index Module ingests it so the
+      // admin retail-list anti-join can exclude work-orders (Chunk 4). This
+      // create path runs once per legacy create, so no link-existence guard is
+      // needed (a fresh unified order per call). Best-effort: a link failure
+      // must not lose the metadata backref legacy reads still depend on.
+      const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+      await remoteLink
+        .create([
+          {
+            [Modules.ORDER]: { order_id: unified.id },
+            [ORDER_INVENTORY_MODULE]: { inventory_orders_id: order.id },
+          },
+        ])
+        .catch((e: any) =>
+          logger.warn(
+            `[orders-unification] order↔inventory_order link failed for ${order.id}: ${e?.message}`
+          )
+        )
+
       const inventoryOrderService: InventoryOrderService =
         container.resolve(ORDER_INVENTORY_MODULE)
       await inventoryOrderService.updateInventoryOrders({

--- a/apps/backend/src/workflows/inventory_orders/dual-write-unified-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/dual-write-unified-order.ts
@@ -2,7 +2,7 @@ import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
 import { createOrderWorkflow } from "@medusajs/medusa/core-flows"
 import type { Link } from "@medusajs/modules-sdk"
-import type { LinkDefinition } from "@medusajs/framework/types"
+import type { LinkDefinition, MedusaContainer } from "@medusajs/framework/types"
 import { ORDER_INVENTORY_MODULE } from "../../modules/inventory_orders"
 import { PARTNER_MODULE } from "../../modules/partner"
 import InventoryOrderService from "../../modules/inventory_orders/service"
@@ -102,6 +102,30 @@ type MirrorResult = {
   unified_order_id?: string
   skipped?: string
   error?: string
+}
+
+// D5-3 — resolve a legacy row's unified order id by the order↔<execution>
+// link, forward (`<entity>.order`), which the Chunk 2 directionality finding
+// established as the authoritative join. This replaces reading the
+// `metadata.unified_order_id` backref as the primary path in every
+// transactional mirror/partner-link reader (inventory + production-run steps,
+// the admin cancel route, the task-updated subscriber). The backref survives
+// only as a transitional fallback for rows projected before D5-2 (link-less);
+// it goes away once T4 (Chunk 9) backfills links onto historicals, after which
+// Chunk 6 stops writing it entirely.
+export const resolveUnifiedOrderIdByLink = async (
+  container: MedusaContainer,
+  entity: "inventory_orders" | "production_runs",
+  legacyId: string
+): Promise<string | undefined> => {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  const { data } = await query.graph({
+    entity,
+    fields: ["id", "order.id", "metadata"],
+    filters: { id: legacyId },
+  })
+  const row = data?.[0]
+  return row?.order?.id ?? row?.metadata?.unified_order_id ?? undefined
 }
 
 type DualWriteInput = {
@@ -288,13 +312,11 @@ export const mirrorPartnerLinkOnUnifiedOrderStep = createStep(
   ) => {
     const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
     try {
-      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
-      const { data: invOrders } = await query.graph({
-        entity: "inventory_orders",
-        fields: ["id", "metadata"],
-        filters: { id: input.inventoryOrderId },
-      })
-      const unifiedOrderId = invOrders?.[0]?.metadata?.unified_order_id
+      const unifiedOrderId = await resolveUnifiedOrderIdByLink(
+        container,
+        "inventory_orders",
+        input.inventoryOrderId
+      )
       if (!unifiedOrderId) {
         return new StepResponse<MirrorResult>({
           linked: false,
@@ -357,11 +379,15 @@ export const mirrorUnifiedOrderStatusStep = createStep(
       const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
       const { data: invOrders } = await query.graph({
         entity: "inventory_orders",
-        fields: ["id", "status", "metadata"],
+        fields: ["id", "status", "order.id", "metadata"],
         filters: { id: input.inventoryOrderId },
       })
       const legacy = invOrders?.[0]
-      const unifiedOrderId = legacy?.metadata?.unified_order_id
+      // D5-3 — resolve the unified order via the order↔inventory_order link
+      // (forward, authoritative); the legacy backref is a transitional fallback
+      // for pre-D5-2 link-less rows. Fetched in the same query as `status`.
+      const unifiedOrderId =
+        legacy?.order?.id ?? legacy?.metadata?.unified_order_id
       if (!unifiedOrderId) {
         return new StepResponse<MirrorResult>({
           linked: false,

--- a/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
+++ b/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
@@ -8,7 +8,10 @@ import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
 import { PARTNER_MODULE } from "../../modules/partner"
 import { DESIGN_MODULE } from "../../modules/designs"
 import type ProductionRunService from "../../modules/production_runs/service"
-import { PARTNER_WORK_ORDERS_CHANNEL } from "../inventory_orders/dual-write-unified-order"
+import {
+  PARTNER_WORK_ORDERS_CHANNEL,
+  resolveUnifiedOrderIdByLink,
+} from "../inventory_orders/dual-write-unified-order"
 
 // #342 T3.2 — best-effort projection of production runs onto the core `order`
 // entity (metadata.kind = "design"). Mirrors the T2 inventory-order recipe;
@@ -351,8 +354,19 @@ export const mirrorRunStatusToUnifiedOrder = async (
     const run: any = await productionRunService
       .retrieveProductionRun(productionRunId)
       .catch(() => null)
+    if (!run) {
+      return { linked: false, skipped: "no_unified_order" }
+    }
 
-    const unifiedOrderId = run?.metadata?.unified_order_id
+    // D5-3 — resolve the unified order via the order↔production_run link
+    // (forward, authoritative); the metadata backref is a transitional fallback
+    // for pre-D5-2 link-less runs. The run itself is still read above for the
+    // §5 status/lifecycle-timestamp mapping.
+    const unifiedOrderId = await resolveUnifiedOrderIdByLink(
+      container,
+      "production_runs",
+      productionRunId
+    )
     if (!unifiedOrderId) {
       return { linked: false, skipped: "no_unified_order" }
     }
@@ -426,12 +440,13 @@ export const dualWriteChildRunOrdersStep = createStep(
       }
 
       if (input.child_run_ids.length) {
-        const productionRunService: ProductionRunService =
-          container.resolve(PRODUCTION_RUNS_MODULE)
-        const parent: any = await productionRunService
-          .retrieveProductionRun(input.parent_run_id)
-          .catch(() => null)
-        const parentOrderId = parent?.metadata?.unified_order_id
+        // D5-3 — the parent's unified order via the link (forward,
+        // authoritative); metadata backref is the pre-D5-2 fallback.
+        const parentOrderId = await resolveUnifiedOrderIdByLink(
+          container,
+          "production_runs",
+          input.parent_run_id
+        )
         if (parentOrderId) {
           await patchUnifiedOrder(container, parentOrderId, {
             status: "canceled",
@@ -468,7 +483,14 @@ export const mirrorRunPartnerLinkOnUnifiedOrderStep = createStep(
         .retrieveProductionRun(input.production_run_id)
         .catch(() => null)
 
-      const unifiedOrderId = run?.metadata?.unified_order_id
+      // D5-3 — resolve the unified order via the link (forward, authoritative);
+      // the run is still read above for partner_id / execution_mode /
+      // sub_partner_id. Metadata backref is the pre-D5-2 fallback.
+      const unifiedOrderId = await resolveUnifiedOrderIdByLink(
+        container,
+        "production_runs",
+        input.production_run_id
+      )
       if (!unifiedOrderId || !run?.partner_id) {
         return new StepResponse<MirrorResult>({
           linked: false,

--- a/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
+++ b/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
@@ -177,9 +177,23 @@ export const projectRunToUnifiedOrder = async (
       productionRunId
     )
 
-    if (run?.metadata?.unified_order_id) {
+    // D5-2 idempotency: the order↔production_run link is the authoritative
+    // "already projected" signal. Resolve it forward (run → order) via
+    // query.graph — that join is synchronous/authoritative; never query.index
+    // here (eventually consistent). Fall back to the legacy
+    // metadata.unified_order_id backref so runs projected before D5-2
+    // (link-less) are not re-projected into a duplicate order.
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const { data: linkedRuns } = await query.graph({
+      entity: "production_runs",
+      fields: ["id", "order.id"],
+      filters: { id: productionRunId },
+    })
+    const alreadyProjectedId =
+      linkedRuns?.[0]?.order?.id ?? run?.metadata?.unified_order_id
+    if (alreadyProjectedId) {
       return {
-        unified_order_id: run.metadata.unified_order_id,
+        unified_order_id: alreadyProjectedId,
         skipped: "already_projected",
       }
     }
@@ -248,10 +262,29 @@ export const projectRunToUnifiedOrder = async (
       },
     })
 
+    const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+
+    // D5-2 — the load-bearing order↔production_run link + kind=design
+    // discriminator (replaces metadata.unified_order_id as the authoritative
+    // pointer; the metadata backref is still written below during the D5
+    // transition). filterable:["id"] means the Index Module ingests it so the
+    // admin retail-list anti-join can exclude work-orders (Chunk 4).
+    await remoteLink
+      .create([
+        {
+          [Modules.ORDER]: { order_id: unified.id },
+          [PRODUCTION_RUNS_MODULE]: { production_runs_id: run.id },
+        },
+      ])
+      .catch((e: any) =>
+        logger.warn(
+          `[orders-unification] order↔production_run link failed for ${run.id}: ${e?.message}`
+        )
+      )
+
     // §4 — reuse the existing design↔order link infra (#29) so design panels
     // and linkDesignsToOrder consumers see the work-order too.
     if (run.design_id) {
-      const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
       await remoteLink
         .create([
           {

--- a/apps/docs/notes/ORDERS_UNIFICATION_342.md
+++ b/apps/docs/notes/ORDERS_UNIFICATION_342.md
@@ -52,7 +52,7 @@ as the discriminator/pointer. Instead:
 **PR grouping (ship relevant chunks together — each chunk = one commit in the PR):**
 | PR | Chunks | Theme | Status |
 |---|---|---|---|
-| **PR-A** | 1 + 2 + 3 | D5 link adoption: define → write → read (avoid a half-state on main where links exist but are unused) | Chunk 1 committed; Chunk 2 committed (ad32afdd1); Chunk 3 done (uncommitted) |
+| **PR-A** | 1 + 2 + 3 | D5 link adoption: define → write → read (avoid a half-state on main where links exist but are unused) | **OPEN — PR #392** (Chunks 1+2+3 all committed) |
 | **PR-B** | 4 + 5 | Unified surfacing: admin retail filter + partner panels | not started |
 | **PR-C** | 6 | Metadata-write cleanup (after A + B prove links are the sole path) | not started |
 | **PR-D** | 7 + 8 | Concurrency hardening: locking + Redis provider (parallel track, independent of A–C) | not started |
@@ -66,7 +66,7 @@ as the discriminator/pointer. Instead:
   tables; a `query.index` probe accepted all three filter shapes
   (`production_run.id $ne null`, `inventory_order.id $ne null`, both-null retail
   anti-join), 0 rows as expected. Relation keys pinned via `field` to
-  `production_run` / `inventory_order`. NOT yet pushed/opened as a PR.
+  `production_run` / `inventory_order`. Shipped in PR #392 (PR-A).
   *(blocked by: none)*
 - [x] **Chunk 2 (D5-2)** — Dual-write creates the links *in addition to* current
   metadata (transitional, nothing removed). Idempotency guard = link existence.

--- a/apps/docs/notes/ORDERS_UNIFICATION_342.md
+++ b/apps/docs/notes/ORDERS_UNIFICATION_342.md
@@ -52,7 +52,7 @@ as the discriminator/pointer. Instead:
 **PR grouping (ship relevant chunks together — each chunk = one commit in the PR):**
 | PR | Chunks | Theme | Status |
 |---|---|---|---|
-| **PR-A** | 1 + 2 + 3 | D5 link adoption: define → write → read (avoid a half-state on main where links exist but are unused) | Chunk 1 committed; 2+3 pending |
+| **PR-A** | 1 + 2 + 3 | D5 link adoption: define → write → read (avoid a half-state on main where links exist but are unused) | Chunk 1 committed; Chunk 2 done (uncommitted); Chunk 3 pending |
 | **PR-B** | 4 + 5 | Unified surfacing: admin retail filter + partner panels | not started |
 | **PR-C** | 6 | Metadata-write cleanup (after A + B prove links are the sole path) | not started |
 | **PR-D** | 7 + 8 | Concurrency hardening: locking + Redis provider (parallel track, independent of A–C) | not started |
@@ -68,13 +68,60 @@ as the discriminator/pointer. Instead:
   anti-join), 0 rows as expected. Relation keys pinned via `field` to
   `production_run` / `inventory_order`. NOT yet pushed/opened as a PR.
   *(blocked by: none)*
-- [ ] **Chunk 2 (D5-2)** — Dual-write creates the links *in addition to* current
+- [x] **Chunk 2 (D5-2)** — Dual-write creates the links *in addition to* current
   metadata (transitional, nothing removed). Idempotency guard = link existence.
-  Update both unification specs to assert the link. *(blocked by: 1)*
+  Update both unification specs to assert the link. **DONE** (uncommitted on
+  branch `feat/342-d5-1-filterable-order-execution-links`, part of PR-A).
+  - Both projections now `remoteLink.create` the execution link right after the
+    unified order is created, best-effort (`.catch` → `[orders-unification]`
+    warn) so a link failure never loses the metadata backref legacy reads still
+    need. Link keys: `{ [Modules.ORDER]: { order_id }, [<MODULE>]: {
+    production_runs_id | inventory_orders_id } }`.
+    - design: `dual-write-unified-run-order.ts` `projectRunToUnifiedOrder`
+      (one `remoteLink` now shared by the execution + design↔order links).
+    - inventory: `dual-write-unified-order.ts` `dualWriteUnifiedOrderStep`.
+  - **Idempotency guard switched to link existence** in `projectRunToUnifiedOrder`
+    (the only re-entrant path — create + per-child approve). Resolves the link
+    FORWARD via `query.graph` (`entity:"production_runs", fields:["id","order.id"]`)
+    and falls back to `metadata.unified_order_id` so pre-D5-2 (link-less) runs
+    aren't re-projected into a duplicate. Inventory create path is single-shot
+    (fresh order per legacy create) → no guard needed.
+  - Specs assert the forward link resolves: inventory create test, design create
+    test, and the approve/child-run test (each child links distinctly, parent
+    still points at its superseded order — proves the guard didn't reuse the
+    parent's order). Both specs green (5 + 5).
+  - **⚠️ LINK NAMING FINDING (empirically nailed down 2026-06-13 — supersedes an
+    earlier wrong "forward only" note):** these are **managed** links (pivot
+    table), so they are **fully bidirectional** in `query.graph`. Verified with a
+    real linked row reading BOTH directions:
+    - **forward** (legacy row → order): `production_runs.order` /
+      `inventory_orders.order` → the unified order. Authoritative.
+    - **reverse** (order → legacy row): `order.production_runs` /
+      `order.inventory_orders` → the run/inventory row. **Note the auto-derived
+      PLURAL accessor** (`production_runs`, not `production_run`).
+    - The `field: "production_run"` pin on the run side ONLY adds the singular
+      alias to the **Index Module** — it does NOT rename `query.graph`'s reverse
+      accessor. So: `query.index` (order side) accepts BOTH `production_run` and
+      `production_runs` for the retail anti-join; `query.graph` reverse needs the
+      PLURAL. (An earlier probe guessed `order.production_run` for query.graph,
+      got "Entity 'Order' does not have property 'production_run'", and wrongly
+      concluded the link was one-way. It is not.)
+    - This is NOT a read-only-link situation: read-only links
+      (`defineLink(..., { readOnly: true })`, e.g. the built-in OrderLineItem→
+      Product) ARE uni-directional and need a separate inverse definition. Ours
+      are stored/managed — bidirectional, no inverse needed.
+    - **Implications:** Chunk 3 reads resolve `.order` **forward** from the legacy
+      row (id already in hand — cleanest). Chunk 4's admin retail LIST filter
+      stays on `query.index` (eventual-consistency-tolerant, and the null
+      anti-join is its job); reverse `query.graph` selection also works if a
+      transactional reverse read is ever needed. `production_runs.order_id` is a
+      plain column (not a relation), so `.order` unambiguously resolves the new
+      link. *(blocked by: none now)*
 - [ ] **Chunk 3 (D5-3)** — Switch transactional reads from
   `metadata.unified_order_id` → `query.graph` link resolution in the mirror
   steps, partner-link steps, admin cancel route, task-updated subscriber. After
-  this, the backref is no longer READ. *(blocked by: 2)*
+  this, the backref is no longer READ. **Use the forward `.order` resolution per
+  the Chunk 2 directionality finding above.** *(blocked by: 2 — now unblocked)*
 - [ ] **Chunk 4 (T3.3)** — Admin retail list filter: `GET /admin/orders` excludes
   work-orders via `query.index` null-link filter; opt-in `?kind=` to surface
   them. *(blocked by: 1)*

--- a/apps/docs/notes/ORDERS_UNIFICATION_342.md
+++ b/apps/docs/notes/ORDERS_UNIFICATION_342.md
@@ -8,9 +8,78 @@
 
 **Phases (task chain):**
 - **T1 (this doc):** field mapping + gap decisions — DONE
-- **T2:** thin shim PR — dual-write a unified `order` alongside one legacy create
-- **T3:** partner-ui panels driven off `order.status` + `metadata.kind`; legacy routes become shims
+- **T2:** thin shim PR — dual-write a unified `order` alongside one legacy create — DONE (#387)
+- **T3:** partner-ui panels driven off `order.status` + kind; legacy routes become shims — IN PROGRESS (T3.1 #389, T3.2 #391 done)
 - **T4:** backfill + quiet retirement
+
+---
+
+## ⚡ Active work breakdown — D5 link refactor + remaining T3/T4 (chunks)
+
+> **HOW TO RECALL AFTER A CONTEXT CLEAR:** read this section. It is the durable
+> copy of the chunk plan (the in-session task tracker does NOT survive `/clear`).
+> Each chunk = one PR with its own test. Update the checkboxes as PRs merge.
+> Last updated 2026-06-13.
+
+**D5 (decided 2026-06-13) — link-based discrimination supersedes `metadata.kind`.**
+Per [[feedback_no_critical_data_in_metadata]], stop using `order.metadata.kind`
+and the `metadata.unified_order_id` backref (load-bearing, blob-replace-prone)
+as the discriminator/pointer. Instead:
+- Two new module links carry the relationship AND discriminate kind:
+  `order ↔ production_run` (kind=design), `order ↔ inventory_order` (kind=inventory).
+  Neither link → retail. (NOT the `design ↔ order` link — that one is shared with
+  retail: `order-placed.ts` runs `linkDesignsToOrder` on every purchase.)
+- The links are declared `filterable: ["id"]` so the **Index Module** (already
+  enabled, `index_engine: true` in medusa-config) ingests them and `query.index`
+  can filter on link existence — including the retail anti-join
+  (`{ production_run: { id: null }, inventory_order: { id: null } }`). This is
+  why **no denormalized `kind` column is needed.**
+- **Split read paths:** `query.index` for list filtering (eventually consistent,
+  fine for UI lists); `query.graph` link-resolution for transactional reads
+  inside workflows (authoritative). Never use `query.index` for mirror-step
+  correctness.
+- **NOT solved by links:** `partner_status` stays in metadata (read-modify-write
+  on every transition) → still needs the locking front (Chunks 7–8). `legacy_id`
+  also survives until T4 decides idempotency-on-link.
+
+**Dependency graph:**
+```
+1 (D5-1 links) ──┬─> 2 (D5-2 write links) ─> 3 (D5-3 read via link) ─┐
+                 └─> 4 (T3.3 admin filter) ─> 5 (T3.4 panels)        ├─> 6 (cleanup) ─┐
+7 (H1 locking) ─> 8 (H2 redis provider) ────────────────────────────┴────────────────┴─> 9 (T4)
+```
+
+- [ ] **Chunk 1 (D5-1)** — Define `filterable` links + ingest. New
+  `src/links/order-production-run.ts` + `order-inventory-order.ts`, execution
+  side `filterable: ["id"]`, order side `isList:false`. Migration + restart,
+  verify `query.index` filters orders by `production_run.id $ne null`. No
+  behavior change. *(blocked by: none)*
+- [ ] **Chunk 2 (D5-2)** — Dual-write creates the links *in addition to* current
+  metadata (transitional, nothing removed). Idempotency guard = link existence.
+  Update both unification specs to assert the link. *(blocked by: 1)*
+- [ ] **Chunk 3 (D5-3)** — Switch transactional reads from
+  `metadata.unified_order_id` → `query.graph` link resolution in the mirror
+  steps, partner-link steps, admin cancel route, task-updated subscriber. After
+  this, the backref is no longer READ. *(blocked by: 2)*
+- [ ] **Chunk 4 (T3.3)** — Admin retail list filter: `GET /admin/orders` excludes
+  work-orders via `query.index` null-link filter; opt-in `?kind=` to surface
+  them. *(blocked by: 1)*
+- [ ] **Chunk 5 (T3.4)** — Partner-ui unified panels keyed on kind (which link is
+  present) + `partner_status`. Hook: `apps/partner-ui/src/hooks/api/orders.tsx`.
+  Skeletons, `--ui-*` tokens, partner API mirrors admin. *(blocked by: 4)*
+- [ ] **Chunk 6 (D5-cleanup)** — Stop WRITING `metadata.kind` + `unified_order_id`;
+  trim them from `PROTECTED_UNIFICATION_METADATA_KEYS` + the partner PATCH route.
+  `partner_status` stays. *(blocked by: 3, 4)*
+- [ ] **Chunk 7 (H1)** — Locking on the dual-write/mirror read-modify-write
+  (`partner_status` race), key = unified order id, ALL writers share it, inside
+  the swallow-and-warn boundary. Pattern: `complete-production-run.ts`.
+  *(blocked by: none — parallel to the link work)*
+- [ ] **Chunk 8 (H2)** — Register `@medusajs/locking-redis` in medusa-config
+  (prod env-gated, in-memory fallback for dev). Must precede scaling >1 backend
+  instance. *(blocked by: 7)*
+- [ ] **Chunk 9 (T4)** — Backfill historicals (idempotent on link), repoint §4
+  deviation + ancillary links, legacy routes → shims, quiet retirement. Needs
+  its own planning pass. *(blocked by: 3, 6, 7)*
 
 ---
 

--- a/apps/docs/notes/ORDERS_UNIFICATION_342.md
+++ b/apps/docs/notes/ORDERS_UNIFICATION_342.md
@@ -52,7 +52,7 @@ as the discriminator/pointer. Instead:
 **PR grouping (ship relevant chunks together — each chunk = one commit in the PR):**
 | PR | Chunks | Theme | Status |
 |---|---|---|---|
-| **PR-A** | 1 + 2 + 3 | D5 link adoption: define → write → read (avoid a half-state on main where links exist but are unused) | Chunk 1 committed; Chunk 2 done (uncommitted); Chunk 3 pending |
+| **PR-A** | 1 + 2 + 3 | D5 link adoption: define → write → read (avoid a half-state on main where links exist but are unused) | Chunk 1 committed; Chunk 2 committed (ad32afdd1); Chunk 3 done (uncommitted) |
 | **PR-B** | 4 + 5 | Unified surfacing: admin retail filter + partner panels | not started |
 | **PR-C** | 6 | Metadata-write cleanup (after A + B prove links are the sole path) | not started |
 | **PR-D** | 7 + 8 | Concurrency hardening: locking + Redis provider (parallel track, independent of A–C) | not started |
@@ -117,11 +117,37 @@ as the discriminator/pointer. Instead:
       transactional reverse read is ever needed. `production_runs.order_id` is a
       plain column (not a relation), so `.order` unambiguously resolves the new
       link. *(blocked by: none now)*
-- [ ] **Chunk 3 (D5-3)** — Switch transactional reads from
+- [x] **Chunk 3 (D5-3)** — Switch transactional reads from
   `metadata.unified_order_id` → `query.graph` link resolution in the mirror
   steps, partner-link steps, admin cancel route, task-updated subscriber. After
-  this, the backref is no longer READ. **Use the forward `.order` resolution per
-  the Chunk 2 directionality finding above.** *(blocked by: 2 — now unblocked)*
+  this, the backref is no longer the PRIMARY read. **DONE** (uncommitted on
+  branch `feat/342-d5-1-filterable-order-execution-links`, part of PR-A).
+  - New shared helper `resolveUnifiedOrderIdByLink(container, entity, legacyId)`
+    in `inventory_orders/dual-write-unified-order.ts`: resolves forward
+    (`<entity>.order` via `query.graph`) → unified order id, falling back to the
+    legacy `metadata.unified_order_id` backref ONLY for pre-D5-2 link-less rows
+    (that fallback retires with T4/Chunk 9 link backfill; Chunk 6 then stops
+    writing the backref). Used by entity `"inventory_orders"` and
+    `"production_runs"` — managed links are bidirectional so forward `.order`
+    works for both (Chunk 2 finding).
+  - **5 read sites switched** (all best-effort, inside the swallow-and-warn
+    boundary): inventory `mirrorPartnerLinkOnUnifiedOrderStep` +
+    `mirrorUnifiedOrderStatusStep` (the latter fetches `status` and `order.id`
+    in one `query.graph`); run `mirrorRunStatusToUnifiedOrder`,
+    `dualWriteChildRunOrdersStep` (parent order id), and
+    `mirrorRunPartnerLinkOnUnifiedOrderStep`. The admin cancel route + the
+    `production-run-task-updated` subscriber inherit the switch via the shared
+    `mirrorRunStatusToUnifiedOrder` helper — no separate edit needed.
+  - The Chunk 2 idempotency guard in `projectRunToUnifiedOrder` was ALREADY
+    link-first (line ~193) — left as-is.
+  - **Still WRITTEN, not yet removed:** both projections still write the
+    `metadata.unified_order_id` backref (Chunk 6 removes the writes once A+B
+    prove links are the sole path).
+  - Tests: each spec gains a "resolves via the link, not the metadata backref"
+    case that POISONS `metadata.unified_order_id` with a bogus order id, leaves
+    the link intact, triggers a mirror (inventory: admin status PUT; run: admin
+    cancel route), and asserts the REAL unified order still mirrors — provable
+    only via the link. Both specs green (6 + 6). *(blocked by: none)*
 - [ ] **Chunk 4 (T3.3)** — Admin retail list filter: `GET /admin/orders` excludes
   work-orders via `query.index` null-link filter; opt-in `?kind=` to surface
   them. *(blocked by: 1)*

--- a/apps/docs/notes/ORDERS_UNIFICATION_342.md
+++ b/apps/docs/notes/ORDERS_UNIFICATION_342.md
@@ -49,11 +49,25 @@ as the discriminator/pointer. Instead:
 7 (H1 locking) ─> 8 (H2 redis provider) ────────────────────────────┴────────────────┴─> 9 (T4)
 ```
 
-- [ ] **Chunk 1 (D5-1)** — Define `filterable` links + ingest. New
+**PR grouping (ship relevant chunks together — each chunk = one commit in the PR):**
+| PR | Chunks | Theme | Status |
+|---|---|---|---|
+| **PR-A** | 1 + 2 + 3 | D5 link adoption: define → write → read (avoid a half-state on main where links exist but are unused) | Chunk 1 committed; 2+3 pending |
+| **PR-B** | 4 + 5 | Unified surfacing: admin retail filter + partner panels | not started |
+| **PR-C** | 6 | Metadata-write cleanup (after A + B prove links are the sole path) | not started |
+| **PR-D** | 7 + 8 | Concurrency hardening: locking + Redis provider (parallel track, independent of A–C) | not started |
+| **PR-E** | 9 | T4 backfill + retirement (own planning pass) | not started |
+
+- [x] **Chunk 1 (D5-1)** — Define `filterable` links + ingest. New
   `src/links/order-production-run.ts` + `order-inventory-order.ts`, execution
-  side `filterable: ["id"]`, order side `isList:false`. Migration + restart,
-  verify `query.index` filters orders by `production_run.id $ne null`. No
-  behavior change. *(blocked by: none)*
+  side `filterable: ["id"]`, order side `isList:false`. **DONE** — committed on
+  branch `feat/342-d5-1-filterable-order-execution-links` (commit 1051daf95),
+  part of PR-A. Verified: `db:migrate --execute-safe-links` created both link
+  tables; a `query.index` probe accepted all three filter shapes
+  (`production_run.id $ne null`, `inventory_order.id $ne null`, both-null retail
+  anti-join), 0 rows as expected. Relation keys pinned via `field` to
+  `production_run` / `inventory_order`. NOT yet pushed/opened as a PR.
+  *(blocked by: none)*
 - [ ] **Chunk 2 (D5-2)** — Dual-write creates the links *in addition to* current
   metadata (transitional, nothing removed). Idempotency guard = link existence.
   Update both unification specs to assert the link. *(blocked by: 1)*


### PR DESCRIPTION
## PR-A — D5 link adoption: define → write → read (#342)

Adopts the **link-based discriminator** for orders unification, replacing
`order.metadata.kind` + the `metadata.unified_order_id` backref as the
load-bearing pointer (per [[feedback_no_critical_data_in_metadata]] — Medusa's
`update*` replaces the whole metadata blob, so a load-bearing JSON key is a
footgun). Shipped as one PR so `main` never has a half-state where the links
exist but nothing reads them.

Two new module links carry the relationship **and** discriminate kind:
`order ↔ production_run` (kind=design) and `order ↔ inventory_order`
(kind=inventory). Neither link → retail. Declared `filterable: ["id"]` so the
Index Module ingests them (enables the Chunk 4 admin retail anti-join later).

### Chunk 1 (D5-1) — define links + ingest
- `src/links/order-production-run.ts` + `order-inventory-order.ts`, execution
  side `filterable: ["id"]`, order side `isList: false`.

### Chunk 2 (D5-2) — dual-write the links
- Both projections `remoteLink.create` the execution link right after the
  unified order is created, best-effort (`.catch` → `[orders-unification]`
  warn) so a link failure never loses the metadata backref legacy still reads.
- Idempotency guard switched to **link existence** (forward `.order` resolution,
  metadata fallback for pre-D5-2 rows).
- **Finding:** these are *managed* links → fully **bidirectional** in
  `query.graph`. Forward `production_runs.order` / `inventory_orders.order` is
  authoritative; the reverse `order.production_runs` accessor is auto-derived
  PLURAL.

### Chunk 3 (D5-3) — read the links, not the backref
- New shared `resolveUnifiedOrderIdByLink(container, entity, legacyId)`: forward
  `<entity>.order` via `query.graph`, metadata backref kept only as a
  transitional fallback for pre-D5-2 link-less rows.
- 5 transactional read sites switched (mirror + partner-link steps, inventory +
  run). The admin cancel route and the `production-run-task-updated` subscriber
  inherit the switch via the shared `mirrorRunStatusToUnifiedOrder` helper.
- The backref is still **written** (Chunk 6 removes the writes); after this it
  is no longer the primary read.

## Scope fence
- Nothing removed: `metadata.kind` + `unified_order_id` are still written
  (Chunk 6), `partner_status` still in metadata (locking front, Chunks 7–8).
- All projections/mirrors remain best-effort — a link/mirror failure never fails
  the legacy create or transition.

## Tests
- `orders-unification-dual-write.spec.ts` (inventory) — **6 green**
- `orders-unification-design-dual-write.spec.ts` (design) — **6 green**
- Each adds a "resolves via the link, not the metadata backref" case: poison
  `metadata.unified_order_id` with a bogus id, leave the link intact, trigger a
  mirror (inventory: admin status PUT; run: admin cancel route), assert the real
  unified order still mirrors — provable only via the link.

Full plan + per-chunk status: `apps/docs/notes/ORDERS_UNIFICATION_342.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
