### PR TITLE
feat(orders): #342 PR-B — unified surfacing (admin retail filter + partner panels)

### DIFF
--- a/apps/backend/integration-tests/http/orders-unification-admin-list-filter.spec.ts
+++ b/apps/backend/integration-tests/http/orders-unification-admin-list-filter.spec.ts
@@ -1,0 +1,224 @@
+/**
+ * #342 Chunk 4 (T3.3) — admin retail list filter.
+ *
+ * The unified `order` table now holds three kinds of row, discriminated by which
+ * execution link is present (D5):
+ *   - design     → linked to a production_run
+ *   - inventory  → linked to an inventory_order
+ *   - retail     → NEITHER link (a real customer order)
+ *
+ * GET /admin/orders historically meant "customer orders", so the override route
+ * defaults to retail and hides work-orders; `?kind=` opts them back in and
+ * `?kind=all` restores the pre-D5 (unfiltered) behaviour. These cases assert the
+ * filter by the SPECIFIC ids created here, so they are robust on the shared DB.
+ */
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { createOrderWorkflow } from "@medusajs/core-flows"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { ORDER_INVENTORY_MODULE } from "../../src/modules/inventory_orders"
+
+jest.setTimeout(60000)
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Orders unification admin list filter (#342 Chunk 4)", () => {
+    let adminHeaders: any
+    let unique: number
+    let regionId: string
+    let salesChannelId: string
+    let inventoryItemId: string
+    let stockLocationId: string
+    let fromStockLocationId: string
+
+    const post = async (url: string, body: any, cfg?: any) => {
+      try {
+        return await api.post(url, body, cfg)
+      } catch (err: any) {
+        throw new Error(
+          `POST ${url} failed: ${err?.response?.status} ${JSON.stringify(
+            err?.response?.data
+          )}`
+        )
+      }
+    }
+
+    // GET /admin/orders[?kind=], paged wide, returning the set of order ids.
+    const listOrderIds = async (kind?: string): Promise<Set<string>> => {
+      const q = kind ? `?kind=${kind}&limit=1000` : `?limit=1000`
+      const res = await api.get(`/admin/orders${q}`, adminHeaders)
+      expect(res.status).toBe(200)
+      return new Set<string>(res.data.orders.map((o: any) => o.id))
+    }
+
+    const unifiedIdFromLegacy = async (
+      entity: "inventory_orders" | "production_runs",
+      id: string
+    ): Promise<string> => {
+      const query: any = getContainer().resolve(ContainerRegistrationKeys.QUERY)
+      const { data } = await query.graph({
+        entity,
+        filters: { id },
+        fields: ["id", "order.id", "metadata"],
+      })
+      const row = data?.[0]
+      return row?.order?.id ?? row?.metadata?.unified_order_id
+    }
+
+    const createRetailOrder = async (): Promise<string> => {
+      const { result } = await createOrderWorkflow(getContainer()).run({
+        input: {
+          region_id: regionId,
+          sales_channel_id: salesChannelId,
+          currency_code: "inr",
+          email: `retail-${unique}@jyt.test`,
+          items: [
+            { title: "Retail Tee", quantity: 1, unit_price: 500 } as any,
+          ],
+        } as any,
+      })
+      return (result as any).id
+    }
+
+    const createInventoryWorkOrder = async (): Promise<string> => {
+      const res = await post(
+        "/admin/inventory-orders",
+        {
+          order_lines: [
+            { inventory_item_id: inventoryItemId, quantity: 3, price: 100 },
+          ],
+          quantity: 3,
+          total_price: 100,
+          status: "Pending",
+          expected_delivery_date: new Date().toISOString(),
+          order_date: new Date().toISOString(),
+          shipping_address: {
+            first_name: "JYT",
+            address_1: "Mill Road 1",
+            city: "Jaipur",
+            country_code: "in",
+            postal_code: "302001",
+          },
+          stock_location_id: stockLocationId,
+          from_stock_location_id: fromStockLocationId,
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      return unifiedIdFromLegacy("inventory_orders", res.data.inventoryOrder.id)
+    }
+
+    const createDesignWorkOrder = async (): Promise<string> => {
+      const design = await post(
+        "/admin/designs",
+        {
+          name: `Chunk4 Design ${unique}`,
+          description: "Design for #342 admin-list-filter test",
+          design_type: "Original",
+          status: "Approved",
+          priority: "Medium",
+        },
+        adminHeaders
+      )
+      expect(design.status).toBe(201)
+      const run = await post(
+        `/admin/designs/${design.data.design.id}/production-runs`,
+        {},
+        adminHeaders
+      )
+      expect([200, 201]).toContain(run.status)
+      const runId = run.data.productionRun?.id ?? run.data.production_run?.id
+      return unifiedIdFromLegacy("production_runs", runId)
+    }
+
+    beforeEach(async () => {
+      const container = getContainer()
+      unique = Date.now()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+
+      const region = await (container.resolve(Modules.REGION) as any).createRegions({
+        name: "India",
+        currency_code: "inr",
+        countries: ["in"],
+      })
+      regionId = region.id
+
+      const channel = await (
+        container.resolve(Modules.SALES_CHANNEL) as any
+      ).createSalesChannels({ name: `Chunk4 Channel ${unique}` })
+      salesChannelId = channel.id
+
+      const inv = await api.post(
+        "/admin/inventory-items",
+        { title: "Raw Cotton", sku: `RAW-COTTON-${unique}` },
+        adminHeaders
+      )
+      inventoryItemId = inv.data.inventory_item.id
+
+      const to = await api.post(
+        "/admin/stock-locations",
+        { name: `Main ${unique}` },
+        adminHeaders
+      )
+      stockLocationId = to.data.stock_location.id
+      const from = await api.post(
+        "/admin/stock-locations",
+        { name: `Secondary ${unique}` },
+        adminHeaders
+      )
+      fromStockLocationId = from.data.stock_location.id
+    })
+
+    it("default list shows retail orders and hides work-orders", async () => {
+      const retailId = await createRetailOrder()
+      const inventoryId = await createInventoryWorkOrder()
+      const designId = await createDesignWorkOrder()
+
+      const ids = await listOrderIds()
+      expect(ids.has(retailId)).toBe(true)
+      expect(ids.has(inventoryId)).toBe(false)
+      expect(ids.has(designId)).toBe(false)
+
+      // ?kind=retail is the explicit form of the default.
+      const retailIds = await listOrderIds("retail")
+      expect(retailIds.has(retailId)).toBe(true)
+      expect(retailIds.has(inventoryId)).toBe(false)
+      expect(retailIds.has(designId)).toBe(false)
+    })
+
+    it("?kind=inventory surfaces only raw-material POs", async () => {
+      const retailId = await createRetailOrder()
+      const inventoryId = await createInventoryWorkOrder()
+      const designId = await createDesignWorkOrder()
+
+      const ids = await listOrderIds("inventory")
+      expect(ids.has(inventoryId)).toBe(true)
+      expect(ids.has(designId)).toBe(false)
+      expect(ids.has(retailId)).toBe(false)
+    })
+
+    it("?kind=design surfaces only design work-orders", async () => {
+      const retailId = await createRetailOrder()
+      const inventoryId = await createInventoryWorkOrder()
+      const designId = await createDesignWorkOrder()
+
+      const ids = await listOrderIds("design")
+      expect(ids.has(designId)).toBe(true)
+      expect(ids.has(inventoryId)).toBe(false)
+      expect(ids.has(retailId)).toBe(false)
+    })
+
+    it("?kind=all restores the pre-D5 unfiltered list", async () => {
+      const retailId = await createRetailOrder()
+      const inventoryId = await createInventoryWorkOrder()
+      const designId = await createDesignWorkOrder()
+
+      const ids = await listOrderIds("all")
+      expect(ids.has(retailId)).toBe(true)
+      expect(ids.has(inventoryId)).toBe(true)
+      expect(ids.has(designId)).toBe(true)
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/orders-unification-partner-list-filter.spec.ts
+++ b/apps/backend/integration-tests/http/orders-unification-partner-list-filter.spec.ts
@@ -1,0 +1,359 @@
+/**
+ * #342 Chunk 5 (T3.4) — partner unified panels list filter.
+ *
+ * GET /partners/orders is `?kind=`-aware, mirroring admin's Chunk 4 contract but
+ * scoping work-orders through the D3 `partner ↔ order` link (a partner can serve
+ * another partner's store, so sales-channel scoping is wrong for work):
+ *   - retail (default) → the partner's sales-channel customer orders, work-orders hidden
+ *   - design           → only this partner's design work-orders (→ production_run)
+ *   - inventory        → only this partner's raw-material POs   (→ inventory_order)
+ *   - all              → retail ∪ this partner's work-orders
+ *
+ * Cases assert by the SPECIFIC ids created here. Partner-scoping gives natural
+ * isolation on the shared DB — another partner's work-orders / another channel's
+ * retail orders never appear — but asserting by id keeps it robust regardless.
+ */
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { createOrderWorkflow } from "@medusajs/core-flows"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(60000)
+
+const TEST_PARTNER_PASSWORD = "supersecret"
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Orders unification partner list filter (#342 Chunk 5)", () => {
+    let adminHeaders: any
+    let unique: number
+    let inventoryItemId: string
+    let stockLocationId: string
+    let fromStockLocationId: string
+
+    // The logged-in partner under test.
+    let partnerHeaders: any
+    let partnerId: string
+    let salesChannelId: string
+    let regionId: string
+    let currencyCode: string
+
+    const post = async (url: string, body: any, cfg?: any) => {
+      try {
+        return await api.post(url, body, cfg)
+      } catch (err: any) {
+        throw new Error(
+          `POST ${url} failed: ${err?.response?.status} ${JSON.stringify(
+            err?.response?.data
+          )}`
+        )
+      }
+    }
+
+    // Register a partner admin, create the partner, and stand up a store with a
+    // default sales channel + region + location — the scoping context the route
+    // reads. Returns a fresh-logged-in header set (a stale token misses the
+    // partner context).
+    const createPartnerWithStore = async () => {
+      const email = `partner-list-${unique}@jyt.test`
+      await post("/auth/partner/emailpass/register", {
+        email,
+        password: TEST_PARTNER_PASSWORD,
+      })
+      const login1 = await post("/auth/partner/emailpass", {
+        email,
+        password: TEST_PARTNER_PASSWORD,
+      })
+      const headers1 = { headers: { Authorization: `Bearer ${login1.data.token}` } }
+
+      const partnerRes = await post(
+        "/partners",
+        {
+          name: `List Filter Partner ${unique}`,
+          handle: `list-filter-${unique}`,
+          admin: { email, first_name: "List", last_name: "Filter" },
+        },
+        headers1
+      )
+      const pid = partnerRes.data.partner.id
+
+      const login2 = await post("/auth/partner/emailpass", {
+        email,
+        password: TEST_PARTNER_PASSWORD,
+      })
+      const headers2 = { headers: { Authorization: `Bearer ${login2.data.token}` } }
+
+      const currenciesRes = await api.get("/admin/currencies", adminHeaders)
+      const currencies = currenciesRes.data.currencies || []
+      const inr = currencies.find((c: any) => c.code?.toLowerCase() === "inr")
+      const cc = String((inr || currencies[0]).code).toLowerCase()
+
+      const storeRes = await post(
+        "/partners/stores",
+        {
+          store: {
+            name: `List Filter Store ${unique}`,
+            supported_currencies: [{ currency_code: cc, is_default: true }],
+          },
+          sales_channel: { name: `List Filter Channel ${unique}`, description: "Default" },
+          region: { name: "List Filter Region", currency_code: cc, countries: ["in"] },
+          location: {
+            name: "List Filter Warehouse",
+            address: {
+              address_1: "1 Mill Road",
+              city: "Jaipur",
+              postal_code: "302001",
+              country_code: "IN",
+            },
+          },
+        },
+        headers2
+      )
+
+      partnerHeaders = headers2
+      partnerId = pid
+      currencyCode = cc
+      salesChannelId = storeRes.data.sales_channel?.id
+      regionId = storeRes.data.region?.id
+    }
+
+    // GET /partners/orders[?kind=], paged wide, returning the set of order ids.
+    const listOrderIds = async (kind?: string): Promise<Set<string>> => {
+      const q = kind ? `?kind=${kind}&limit=1000` : `?limit=1000`
+      const res = await api.get(`/partners/orders${q}`, partnerHeaders)
+      expect(res.status).toBe(200)
+      return new Set<string>(res.data.orders.map((o: any) => o.id))
+    }
+
+    const unifiedIdFromLegacy = async (
+      entity: "inventory_orders" | "production_runs",
+      id: string
+    ): Promise<string> => {
+      const query: any = getContainer().resolve(ContainerRegistrationKeys.QUERY)
+      const { data } = await query.graph({
+        entity,
+        filters: { id },
+        fields: ["id", "order.id", "metadata"],
+      })
+      const row = data?.[0]
+      return row?.order?.id ?? row?.metadata?.unified_order_id
+    }
+
+    // A customer retail order in the partner's sales channel.
+    const createRetailOrder = async (): Promise<string> => {
+      const { result } = await createOrderWorkflow(getContainer()).run({
+        input: {
+          region_id: regionId,
+          sales_channel_id: salesChannelId,
+          currency_code: currencyCode,
+          email: `retail-${unique}@jyt.test`,
+          items: [
+            { title: "Retail Tee", quantity: 1, unit_price: 500 } as any,
+          ],
+        } as any,
+      })
+      return (result as any).id
+    }
+
+    // A raw-material PO created by admin and SENT to this partner (the send is
+    // what creates the D3 partner↔order link on the unified order).
+    const createInventoryWorkOrder = async (): Promise<string> => {
+      const res = await post(
+        "/admin/inventory-orders",
+        {
+          order_lines: [
+            { inventory_item_id: inventoryItemId, quantity: 3, price: 100 },
+          ],
+          quantity: 3,
+          total_price: 100,
+          status: "Pending",
+          expected_delivery_date: new Date().toISOString(),
+          order_date: new Date().toISOString(),
+          shipping_address: {
+            first_name: "JYT",
+            address_1: "Mill Road 1",
+            city: "Jaipur",
+            country_code: "in",
+            postal_code: "302001",
+          },
+          stock_location_id: stockLocationId,
+          from_stock_location_id: fromStockLocationId,
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      const invId = res.data.inventoryOrder.id
+
+      const send = await post(
+        `/admin/inventory-orders/${invId}/send-to-partner`,
+        { partnerId, notes: "Chunk 5 partner-list test" },
+        adminHeaders
+      )
+      expect(send.status).toBe(200)
+      return unifiedIdFromLegacy("inventory_orders", invId)
+    }
+
+    // A design work-order assigned to this partner — the per-child run is the
+    // partner-facing unit and carries the D3 link on its unified order.
+    const createDesignWorkOrder = async (): Promise<string> => {
+      const design = await post(
+        "/admin/designs",
+        {
+          name: `Chunk5 Design ${unique}`,
+          description: "Design for #342 partner-list-filter test",
+          design_type: "Original",
+          status: "Approved",
+          priority: "Medium",
+        },
+        adminHeaders
+      )
+      expect(design.status).toBe(201)
+
+      // A non-notifiable task template so the dispatch (which writes the D3
+      // partner↔order link) doesn't error in the notification path and get
+      // swallowed — mirrors orders-unification-design-dual-write.spec.ts.
+      const templateName = `partner-list-design-${unique}`
+      const tpl = await post(
+        "/admin/task-templates",
+        {
+          name: templateName,
+          description: `${templateName} template`,
+          priority: "medium",
+          estimated_duration: 60,
+          required_fields: {},
+          eventable: false,
+          notifiable: false,
+          message_template: "",
+          metadata: { workflow_type: "production_run" },
+          category: "Partner List Filter Test",
+        },
+        adminHeaders
+      )
+      expect([200, 201]).toContain(tpl.status)
+
+      const createRes = await post(
+        `/admin/designs/${design.data.design.id}/production-runs`,
+        {
+          assignments: [
+            {
+              partner_id: partnerId,
+              quantity: 4,
+              role: "manufacturing",
+              template_names: [templateName],
+            },
+          ],
+        },
+        adminHeaders
+      )
+      expect([200, 201]).toContain(createRes.status)
+      const childId =
+        createRes.data.children?.[0]?.id ??
+        createRes.data.result?.children?.[0]?.id
+      expect(childId).toBeTruthy()
+      return unifiedIdFromLegacy("production_runs", childId)
+    }
+
+    beforeEach(async () => {
+      const container = getContainer()
+      unique = Date.now()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+
+      const inv = await api.post(
+        "/admin/inventory-items",
+        { title: "Raw Cotton", sku: `RAW-COTTON-${unique}` },
+        adminHeaders
+      )
+      inventoryItemId = inv.data.inventory_item.id
+
+      const to = await api.post(
+        "/admin/stock-locations",
+        { name: `Main ${unique}` },
+        adminHeaders
+      )
+      stockLocationId = to.data.stock_location.id
+      const from = await api.post(
+        "/admin/stock-locations",
+        { name: `Secondary ${unique}` },
+        adminHeaders
+      )
+      fromStockLocationId = from.data.stock_location.id
+
+      // The inventory send-to-partner workflow creates tasks from these
+      // templates and 400s if they're missing.
+      for (const name of [
+        "partner-order-sent",
+        "partner-order-received",
+        "partner-order-shipped",
+      ]) {
+        const tpl = await api.post(
+          "/admin/task-templates",
+          {
+            name,
+            description: `${name} template`,
+            priority: "medium",
+            estimated_duration: 30,
+            eventable: true,
+            notifiable: true,
+            metadata: { workflow_type: "partner_assignment" },
+          },
+          adminHeaders
+        )
+        expect([200, 201]).toContain(tpl.status)
+      }
+
+      await createPartnerWithStore()
+    })
+
+    it("default list shows the partner's retail orders and hides work-orders", async () => {
+      const retailId = await createRetailOrder()
+      const inventoryId = await createInventoryWorkOrder()
+      const designId = await createDesignWorkOrder()
+
+      const ids = await listOrderIds()
+      expect(ids.has(retailId)).toBe(true)
+      expect(ids.has(inventoryId)).toBe(false)
+      expect(ids.has(designId)).toBe(false)
+
+      // ?kind=retail is the explicit form of the default.
+      const retailIds = await listOrderIds("retail")
+      expect(retailIds.has(retailId)).toBe(true)
+      expect(retailIds.has(inventoryId)).toBe(false)
+      expect(retailIds.has(designId)).toBe(false)
+    })
+
+    it("?kind=inventory surfaces only the partner's raw-material POs", async () => {
+      const retailId = await createRetailOrder()
+      const inventoryId = await createInventoryWorkOrder()
+      const designId = await createDesignWorkOrder()
+
+      const ids = await listOrderIds("inventory")
+      expect(ids.has(inventoryId)).toBe(true)
+      expect(ids.has(designId)).toBe(false)
+      expect(ids.has(retailId)).toBe(false)
+    })
+
+    it("?kind=design surfaces only the partner's design work-orders", async () => {
+      const retailId = await createRetailOrder()
+      const inventoryId = await createInventoryWorkOrder()
+      const designId = await createDesignWorkOrder()
+
+      const ids = await listOrderIds("design")
+      expect(ids.has(designId)).toBe(true)
+      expect(ids.has(inventoryId)).toBe(false)
+      expect(ids.has(retailId)).toBe(false)
+    })
+
+    it("?kind=all shows the partner's retail orders ∪ work-orders", async () => {
+      const retailId = await createRetailOrder()
+      const inventoryId = await createInventoryWorkOrder()
+      const designId = await createDesignWorkOrder()
+
+      const ids = await listOrderIds("all")
+      expect(ids.has(retailId)).toBe(true)
+      expect(ids.has(inventoryId)).toBe(true)
+      expect(ids.has(designId)).toBe(true)
+    })
+  })
+})

--- a/apps/backend/src/api/admin/orders/route.ts
+++ b/apps/backend/src/api/admin/orders/route.ts
@@ -1,0 +1,122 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { getOrdersListWorkflow } from "@medusajs/core-flows"
+import { AdminGetOrdersKindParam, AdminOrderKind } from "./validators"
+
+// Chunk 4 (T3.3, #342): override the built-in admin orders LIST so /admin/orders
+// reads as a *customer retail* list again, hiding the unified work-orders
+// (kind=design / kind=inventory) that now share the `order` table (D5).
+//
+// Mechanism: a project route file at this exact path overrides the core handler
+// (routes-loader: last-registered wins; project src/api is scanned after core).
+// Core's `validateAndTransformQuery` middleware still runs, so `req.queryConfig`
+// + `req.filterableFields` are populated when this handler runs. We translate
+// `?kind=` into an `id` constraint and hand the (otherwise untouched) variables
+// to the SAME built-in workflow — so computed totals, pagination, q-search, and
+// every existing filter keep working exactly as before.
+//
+//   (unset) | retail → exclude both work-order kinds   (id $nin work-orders)
+//   design           → only design work-orders         (id $in design orders)
+//   inventory        → only raw-material POs            (id $in inventory orders)
+//   all              → no link filter (pre-D5 behaviour)
+//
+// Work-order order-ids are resolved by the authoritative forward link
+// (`<entity>.order.id`, the join Chunk 3 standardised on), with the transitional
+// `metadata.unified_order_id` backref as a fallback for pre-D5-2 (link-less)
+// rows — same shape as resolveUnifiedOrderIdByLink. The index `$ne: null`
+// join-null filter is deliberately avoided (only the `id: null` anti-join was
+// verified in D5-1); query.graph is authoritative anyway, which a list tolerates.
+
+const PAGE = 1000
+
+// Collect every unified-order id reachable from a legacy execution table, paged.
+const collectLinkedOrderIds = async (
+  query: any,
+  entity: "production_runs" | "inventory_orders"
+): Promise<string[]> => {
+  const ids: string[] = []
+  for (let skip = 0; ; skip += PAGE) {
+    const { data } = await query.graph({
+      entity,
+      fields: ["id", "order.id", "metadata"],
+      pagination: { skip, take: PAGE },
+    })
+    for (const row of data ?? []) {
+      const orderId = row?.order?.id ?? row?.metadata?.unified_order_id
+      if (orderId) {
+        ids.push(orderId)
+      }
+    }
+    if (!data || data.length < PAGE) {
+      break
+    }
+  }
+  return ids
+}
+
+// Resolve the order-id set the requested kind constrains the list to.
+const resolveKindOrderIds = async (
+  query: any,
+  kind: Exclude<AdminOrderKind, "all">
+): Promise<string[]> => {
+  if (kind === "design") {
+    return collectLinkedOrderIds(query, "production_runs")
+  }
+  if (kind === "inventory") {
+    return collectLinkedOrderIds(query, "inventory_orders")
+  }
+  // retail: union of both work-order kinds, to be excluded.
+  const [runs, invs] = await Promise.all([
+    collectLinkedOrderIds(query, "production_runs"),
+    collectLinkedOrderIds(query, "inventory_orders"),
+  ])
+  return Array.from(new Set([...runs, ...invs]))
+}
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  // `kind` is not a filterable order field — read+validate it off the raw query
+  // and keep it out of the workflow filters.
+  const { kind } = AdminGetOrdersKindParam.parse({
+    kind: (req.query as Record<string, unknown>)?.kind,
+  })
+  const resolved: AdminOrderKind = kind ?? "retail"
+
+  const filters: Record<string, any> = {
+    ...req.filterableFields,
+    is_draft_order: false,
+  }
+
+  if (resolved !== "all") {
+    const ids = await resolveKindOrderIds(query, resolved)
+    const constraint = resolved === "retail" ? { $nin: ids } : { $in: ids }
+
+    if (filters.id !== undefined) {
+      // Preserve a caller-supplied id filter by intersecting via $and.
+      const callerId = filters.id
+      delete filters.id
+      filters.$and = [...(filters.$and ?? []), { id: callerId }, { id: constraint }]
+    } else {
+      filters.id = constraint
+    }
+  }
+
+  const { result } = await getOrdersListWorkflow(req.scope).run({
+    input: {
+      fields: req.queryConfig.fields,
+      variables: {
+        filters,
+        ...req.queryConfig.pagination,
+      },
+    },
+  })
+
+  const { rows, metadata } = result as any
+  res.json({
+    orders: rows,
+    count: metadata.count,
+    offset: metadata.skip,
+    limit: metadata.take,
+  })
+}

--- a/apps/backend/src/api/admin/orders/validators.ts
+++ b/apps/backend/src/api/admin/orders/validators.ts
@@ -1,0 +1,27 @@
+import { z } from "@medusajs/framework/zod"
+
+// Chunk 4 (T3.3, #342): the `?kind=` discriminator for GET /admin/orders.
+//
+// The unified `order` table now holds three kinds of row, told apart by which
+// execution link is present (D5):
+//   - design     → linked to a production_run   (order-production-run.ts)
+//   - inventory  → linked to an inventory_order (order-inventory-order.ts)
+//   - retail     → NEITHER link (a real customer order)
+// (Do NOT use the design↔order link to discriminate — it is shared with retail.)
+//
+// The admin orders list historically meant "customer orders", so it defaults to
+// `retail` and hides work-orders. `?kind=` opts specific kinds back in; `all`
+// restores the pre-D5 behaviour (everything, unfiltered).
+//
+// This is parsed inside the route override rather than wired as its own
+// validateAndTransformQuery middleware: core's middleware already validates
+// /admin/orders, and `kind` is not a filterable order field — it must NOT reach
+// the orders workflow's filters, so we strip it here and translate it into an
+// `id` constraint in the handler.
+export const AdminGetOrdersKindParam = z.object({
+  kind: z.enum(["retail", "design", "inventory", "all"]).optional(),
+})
+
+export type AdminOrderKind = NonNullable<
+  z.infer<typeof AdminGetOrdersKindParam>["kind"]
+>

--- a/apps/backend/src/api/partners/orders/route.ts
+++ b/apps/backend/src/api/partners/orders/route.ts
@@ -1,6 +1,7 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { getOrdersListWorkflow } from "@medusajs/medusa/core-flows"
-import { getPartnerSalesChannelId, tryGetPartnerSalesChannelId } from "../helpers"
+import { tryGetPartnerSalesChannelId } from "../helpers"
+import { PartnerGetOrdersKindParam } from "./validators"
+import { listPartnerOrdersWorkflow } from "../../../workflows/orders/list-partner-orders"
 
 // IMPORTANT: use the `relation.*` suffix syntax, not `*relation` prefix.
 //
@@ -28,43 +29,46 @@ const DEFAULT_FIELDS = [
   "sales_channel.*",
   "payment_collections.*",
   "shipping_address.*",
+  // Chunk 5 (T3.4): the unified panels key on `metadata.kind` +
+  // `metadata.partner_status`, so surface the whole metadata blob.
+  "metadata",
 ]
 
+// Chunk 5 (T3.4, #342): the partner orders list is `?kind=`-aware (retail |
+// design | inventory | all), mirroring admin's Chunk 4 contract. The route is
+// thin — it resolves the partner + their sales channel from auth and delegates
+// all kind discrimination / scoping / listing to listPartnerOrdersWorkflow.
 export const GET = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
 ) => {
-  const { salesChannelId } = await tryGetPartnerSalesChannelId(req.auth_context, req.scope)
-  if (!salesChannelId) {
-    return res.json({ orders: [], count: 0, offset: 0, limit: 20 })
-  }
+  const { kind } = PartnerGetOrdersKindParam.parse({
+    kind: (req.query as Record<string, unknown>)?.kind,
+  })
+
+  const { partner, salesChannelId } = await tryGetPartnerSalesChannelId(
+    req.auth_context,
+    req.scope
+  )
 
   const query = req.query || {}
   const limit = Number(query.limit) || 20
   const offset = Number(query.offset) || 0
 
-  const { result } = await getOrdersListWorkflow(req.scope).run({
+  const { result } = await listPartnerOrdersWorkflow(req.scope).run({
     input: {
+      partnerId: partner?.id ?? null,
+      salesChannelId,
+      kind: kind ?? "retail",
       fields: DEFAULT_FIELDS,
-      variables: {
-        filters: {
-          sales_channel_id: [salesChannelId],
-          ...(query.status ? { status: query.status } : {}),
-          ...(query.q ? { q: query.q } : {}),
-        },
-        skip: offset,
-        take: limit,
+      baseFilters: {
+        ...(query.status ? { status: query.status } : {}),
+        ...(query.q ? { q: query.q } : {}),
       },
+      skip: offset,
+      take: limit,
     },
   })
 
-  const orders = Array.isArray(result) ? result : (result as any)?.rows || []
-  const count = Array.isArray(result) ? result.length : (result as any)?.metadata?.count || orders.length
-
-  res.json({
-    orders,
-    count,
-    offset,
-    limit,
-  })
+  res.json(result)
 }

--- a/apps/backend/src/api/partners/orders/validators.ts
+++ b/apps/backend/src/api/partners/orders/validators.ts
@@ -1,0 +1,28 @@
+import { z } from "@medusajs/framework/zod"
+
+// Chunk 5 (T3.4, #342): the `?kind=` discriminator for GET /partners/orders.
+//
+// Mirrors the admin contract (src/api/admin/orders/validators.ts) so the
+// partner orders surface tells apart the same three kinds of `order` row by
+// which execution link is present (D5):
+//   - design     → linked to a production_run   (order-production-run.ts)
+//   - inventory  → linked to an inventory_order (order-inventory-order.ts)
+//   - retail     → NEITHER link (a real customer order in the partner's channel)
+//
+// Difference from admin: the partner side scopes work-orders through the D3
+// `partner ↔ order` link (a partner can serve another partner's store, so
+// sales-channel scoping is wrong for work). Retail stays sales-channel-scoped.
+//
+// Unset → `retail` (parity with admin's "customer orders" default). `all`
+// surfaces retail ∪ this partner's work-orders.
+//
+// Parsed inside the route (not a validateAndTransformQuery middleware): `kind`
+// is not a filterable order field and must not reach the orders workflow's
+// filters — it is stripped and translated into an `id`/channel constraint.
+export const PartnerGetOrdersKindParam = z.object({
+  kind: z.enum(["retail", "design", "inventory", "all"]).optional(),
+})
+
+export type PartnerOrderKind = NonNullable<
+  z.infer<typeof PartnerGetOrdersKindParam>["kind"]
+>

--- a/apps/backend/src/workflows/orders/list-partner-orders.ts
+++ b/apps/backend/src/workflows/orders/list-partner-orders.ts
@@ -1,0 +1,185 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+  transform,
+  when,
+} from "@medusajs/framework/workflows-sdk"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { getOrdersListWorkflow } from "@medusajs/medusa/core-flows"
+import partnerOrderLink from "../../links/partner-order"
+
+// Chunk 5 (T3.4, #342): the kind-aware partner orders listing, lifted out of the
+// route handler into a workflow so the scoping/discrimination logic is reusable
+// and unit-addressable. The route stays thin: it does auth (resolve the partner
+// + their sales channel from the request) and hands the rest here.
+//
+// The unified `order` table holds three kinds, told apart by which execution
+// link is present (D5): design (→ production_run), inventory (→ inventory_order),
+// retail (neither). The partner side scopes work-orders through the D3
+// `partner ↔ order` link — sales-channel scoping is wrong for work, since a
+// partner can serve another partner's store — while retail stays
+// sales-channel-scoped.
+
+export type PartnerOrderKind = "retail" | "design" | "inventory" | "all"
+
+export type ListPartnerOrdersWorkflowInput = {
+  partnerId?: string | null
+  salesChannelId?: string | null
+  kind: PartnerOrderKind
+  fields: string[]
+  // status / q passthrough — folded into every kind's filter unchanged.
+  baseFilters?: Record<string, any>
+  skip: number
+  take: number
+}
+
+// Resolve THIS partner's work-order order-ids, bucketed by kind, via the D3
+// `partner ↔ order` link + the reverse execution link (D5). Two single-hop
+// `query.graph` reads on confirmed link directions (partner→orders, then
+// order→production_runs/inventory_orders) — never a fragile two-hop selection.
+export const resolvePartnerWorkOrderIdsStep = createStep(
+  "resolve-partner-work-order-ids",
+  async (input: { partnerId?: string | null }, { container }) => {
+    const { partnerId } = input
+    if (!partnerId) {
+      return new StepResponse({ design: [] as string[], inventory: [] as string[] })
+    }
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+    // Read the D3 partner↔order link table directly (by entryPoint) rather than
+    // via a `partner.orders` graph accessor — the link row is the source of
+    // truth and the accessor pluralisation isn't guaranteed.
+    const { data: linkRows } = await query.graph({
+      entity: partnerOrderLink.entryPoint,
+      fields: ["order_id"],
+      filters: { partner_id: partnerId },
+    })
+    const orderIds: string[] = Array.from(
+      new Set(
+        (linkRows ?? []).map((r: any) => r?.order_id).filter(Boolean)
+      )
+    )
+
+    if (!orderIds.length) {
+      return new StepResponse({ design: [] as string[], inventory: [] as string[] })
+    }
+
+    // Reverse, PLURAL accessor — see ORDERS_UNIFICATION_342.md "LINK NAMING FINDING".
+    const { data: orders } = await query.graph({
+      entity: "orders",
+      fields: ["id", "production_runs.id", "inventory_orders.id"],
+      filters: { id: orderIds },
+    })
+
+    // The order→execution links are 1:1, so query.graph resolves the reverse
+    // accessor to a single OBJECT (`{ id }`), not an array — test for a linked
+    // id, tolerating either shape.
+    const linked = (rel: any): boolean =>
+      Array.isArray(rel) ? rel.length > 0 : Boolean(rel?.id)
+
+    const design: string[] = []
+    const inventory: string[] = []
+    for (const o of orders ?? []) {
+      if (linked(o?.production_runs)) {
+        design.push(o.id)
+      } else if (linked(o?.inventory_orders)) {
+        inventory.push(o.id)
+      }
+    }
+    return new StepResponse({ design, inventory })
+  }
+)
+
+export const listPartnerOrdersWorkflow = createWorkflow(
+  "list-partner-orders",
+  (input: ListPartnerOrdersWorkflowInput) => {
+    const workOrderIds = resolvePartnerWorkOrderIdsStep({
+      partnerId: input.partnerId,
+    })
+
+    // Translate kind → the filter handed to the SAME built-in orders workflow.
+    // `shortCircuit` covers the cases that resolve to an empty list without a
+    // query (no partner, retail without a channel, a work-order kind the partner
+    // has none of) — so we never issue an `id: { $in: [] }`.
+    const plan = transform(
+      { input, workOrderIds },
+      ({ input, workOrderIds }) => {
+        const { kind, salesChannelId, partnerId } = input
+        const filters: Record<string, any> = { ...(input.baseFilters ?? {}) }
+        let shortCircuit = false
+
+        if (!partnerId) {
+          shortCircuit = true
+        } else if (kind === "retail") {
+          // Work-orders live in the internal PARTNER_WORK_ORDERS_CHANNEL, so a
+          // sales-channel scope already excludes them — no anti-join needed.
+          if (!salesChannelId) {
+            shortCircuit = true
+          } else {
+            filters.sales_channel_id = [salesChannelId]
+          }
+        } else if (kind === "design" || kind === "inventory") {
+          const ids = workOrderIds[kind]
+          if (!ids.length) {
+            shortCircuit = true
+          } else {
+            filters.id = { $in: ids }
+          }
+        } else {
+          // all: retail (channel) ∪ this partner's work-orders (D3 link).
+          const workIds = [...workOrderIds.design, ...workOrderIds.inventory]
+          const or: Record<string, any>[] = []
+          if (salesChannelId) {
+            or.push({ sales_channel_id: [salesChannelId] })
+          }
+          if (workIds.length) {
+            or.push({ id: { $in: workIds } })
+          }
+          if (!or.length) {
+            shortCircuit = true
+          } else {
+            filters.$or = or
+          }
+        }
+
+        return { filters, shortCircuit }
+      }
+    )
+
+    const listInput = transform({ plan, input }, ({ plan, input }) => ({
+      fields: input.fields,
+      variables: {
+        filters: plan.filters,
+        skip: input.skip,
+        take: input.take,
+      },
+    }))
+
+    const listed = when(
+      "partner-orders-not-empty",
+      plan,
+      (p) => !p.shortCircuit
+    ).then(() => getOrdersListWorkflow.runAsStep({ input: listInput }))
+
+    const output = transform({ listed, input }, ({ listed, input }) => {
+      const result = listed as any
+      const orders = Array.isArray(result)
+        ? result
+        : result?.rows ?? []
+      const count = Array.isArray(result)
+        ? result.length
+        : result?.metadata?.count ?? orders.length
+      return {
+        orders,
+        count,
+        offset: input.skip,
+        limit: input.take,
+      }
+    })
+
+    return new WorkflowResponse(output)
+  }
+)

--- a/apps/docs/notes/ORDERS_UNIFICATION_342.md
+++ b/apps/docs/notes/ORDERS_UNIFICATION_342.md
@@ -53,7 +53,7 @@ as the discriminator/pointer. Instead:
 | PR | Chunks | Theme | Status |
 |---|---|---|---|
 | **PR-A** | 1 + 2 + 3 | D5 link adoption: define → write → read (avoid a half-state on main where links exist but are unused) | **MERGED — PR #392** (2026-06-13, merge `c4d03469a`; auto-deploys to prod) |
-| **PR-B** | 4 + 5 | Unified surfacing: admin retail filter + partner panels | **IN PROGRESS** on `feat/342-pr-b-unified-surfacing` — Chunk 4 done (committed), Chunk 5 next |
+| **PR-B** | 4 + 5 | Unified surfacing: admin retail filter + partner panels | **READY** on `feat/342-pr-b-unified-surfacing` — Chunk 4 + Chunk 5 both done (Chunk 5 uncommitted as of 2026-06-13); push + open PR-B draft. Both specs green. |
 | **PR-C** | 6 | Metadata-write cleanup (after A + B prove links are the sole path) | not started |
 | **PR-D** | 7 + 8 | Concurrency hardening: locking + Redis provider (parallel track, independent of A–C) | not started |
 | **PR-E** | 9 | T4 backfill + retirement (own planning pass) | not started |
@@ -182,9 +182,47 @@ as the discriminator/pointer. Instead:
     a design work-order, asserts by SPECIFIC id (shared-DB-robust) that default
     hides work-orders, each `?kind=` surfaces its own, `?kind=all` shows all.
     4/4 green. *(blocked by: none — PR-A merged)*
-- [ ] **Chunk 5 (T3.4)** — Partner-ui unified panels keyed on kind (which link is
-  present) + `partner_status`. Hook: `apps/partner-ui/src/hooks/api/orders.tsx`.
-  Skeletons, `--ui-*` tokens, partner API mirrors admin. *(blocked by: 4)*
+- [x] **Chunk 5 (T3.4)** — Partner-ui unified panels keyed on kind (which link is
+  present) + `partner_status`. **DONE** (on `feat/342-pr-b-unified-surfacing`,
+  part of PR-B). Decision: **sub-routes, not a local-state tab strip** —
+  `/orders` (retail) · `/orders/design` · `/orders/inventory` · `/orders/all`,
+  registered in BOTH route maps (`get-partner-route.map.tsx` +
+  `get-route.map.tsx`) as static children alongside `:id` (static ranks above
+  `:id`, so an order id never collides). All four back the SAME
+  kind-parameterized `OrderListTable` (kind derived off the path); a `NavLink`
+  strip (`order-kind-tabs.tsx`) is the visual tabs.
+  - **Backend:** `GET /partners/orders?kind=` mirrors admin's Chunk 4 contract,
+    but the route is THIN — logic lives in a workflow
+    `listPartnerOrdersWorkflow` (`src/workflows/orders/list-partner-orders.ts`).
+    The route only resolves the partner + sales channel from auth and delegates.
+    `validators.ts` = partner copy of the kind enum (unset → retail). Scoping
+    diverges from admin: retail stays sales-channel-scoped (work-orders live in
+    the internal `PARTNER_WORK_ORDERS_CHANNEL`, so already excluded — no
+    anti-join); design/inventory scope via the **D3 `partner↔order` link** ∩ the
+    kind's execution link; all = `$or`. `metadata` added to the route's
+    `DEFAULT_FIELDS` (route ignores the client `fields`, always returns metadata)
+    so the UI gets `partner_status`.
+  - **Two link gotchas nailed in this chunk** (both cost a debug cycle): (1) the
+    D3 partner→order set must be read from the link table directly via
+    `partnerOrderLink.entryPoint` filtered by `partner_id` — a `partner.orders`
+    graph accessor was unreliable. (2) The order→execution links are **1:1**, so
+    `query.graph`'s reverse accessor (`order.production_runs` /
+    `order.inventory_orders`) resolves to a **single OBJECT `{id}`, NOT an
+    array** — bucket on `rel?.id`, not `rel?.length`.
+  - **Frontend:** `partner_status` badge column (`getStatusBadgeColor` + §5 label
+    map) shown on every non-retail tab; skeletons via existing `_DataTable`
+    `isLoading`; `--ui-*` tokens throughout. **Caveat:** the experimental
+    `view_configurations` flag path (`ConfigurableOrderListTable`) is NOT
+    kind-wired — when that flag is on, all kinds fall back to the unfiltered
+    configurable table. Wire it if/when that flag ships.
+  - Test: `integration-tests/http/orders-unification-partner-list-filter.spec.ts`
+    — stands up a logged-in partner with a store + sales channel, a retail order
+    in their channel, an inventory PO sent to them, and a design work-order
+    assigned to them; asserts by SPECIFIC id that default hides work-orders, each
+    `?kind=` surfaces the partner's own, `?kind=all` shows the union. 4/4 green.
+    (Design link needs a `notifiable:false` task template + `template_names` so
+    the dispatch that writes the D3 link doesn't error in the notification path
+    and get swallowed.) *(blocked by: 4 — done)*
 - [ ] **Chunk 6 (D5-cleanup)** — Stop WRITING `metadata.kind` + `unified_order_id`;
   trim them from `PROTECTED_UNIFICATION_METADATA_KEYS` + the partner PATCH route.
   `partner_status` stays. *(blocked by: 3, 4)*
@@ -198,6 +236,32 @@ as the discriminator/pointer. Instead:
 - [ ] **Chunk 9 (T4)** — Backfill historicals (idempotent on link), repoint §4
   deviation + ancillary links, legacy routes → shims, quiet retirement. Needs
   its own planning pass. *(blocked by: 3, 6, 7)*
+
+**Cross-cutting (not a unification chunk — QA + marketing):**
+- [ ] **Playwright stage-by-stage walkthrough + screenshots.** Drive the partner
+  + admin UIs through the full unified-orders lifecycle with Playwright and
+  capture a screenshot at each stage — for BOTH automated regression testing AND
+  marketing/demo assets. Stages to cover (the §5 lifecycle the panels surface):
+  retail order in the partner channel; a design work-order assigned (`assigned`)
+  → accepted → in_progress → finished → completed; an inventory PO sent
+  (`assigned`) → Processing (`in_progress`) → Shipped (`finished`) → partial →
+  Delivered (`completed`); plus the four partner kind tabs
+  (`/orders`, `/orders/design`, `/orders/inventory`, `/orders/all`) and the admin
+  `?kind=` retail filter. Each screenshot doubles as a visual-diff baseline and a
+  marketing still. Use the `playwright-skill` / `webapp-testing` toolkit; park
+  artifacts somewhere stable (not `/tmp`). *(blocked by: 5 — the panels exist now)*
+- [ ] **Wire the kind panels into saveable view configurations.** Chunk 5 left
+  the experimental `view_configurations` flag path (`ConfigurableOrderListTable`)
+  NOT kind-aware — when that flag is on, all kind sub-routes fall back to the
+  unfiltered configurable table. The partner-ui already has a save/load view-
+  config system (`useFeatureFlag("view_configurations")`, the
+  `order-table-adapter` + `ConfigurableOrderListTable`). Make `kind` (and the
+  `partner_status` column the work-order tabs add) a **persisted, loadable view
+  configuration** rather than just a route-derived value: a partner should be
+  able to save "Design — in progress" (kind=design + partner_status filter +
+  column layout) as a named view and reload it. Decide whether the sub-route
+  still sets a default kind that the saved view can then refine, or whether saved
+  views supersede the tabs entirely. *(blocked by: 5)*
 
 ---
 

--- a/apps/docs/notes/ORDERS_UNIFICATION_342.md
+++ b/apps/docs/notes/ORDERS_UNIFICATION_342.md
@@ -53,7 +53,7 @@ as the discriminator/pointer. Instead:
 | PR | Chunks | Theme | Status |
 |---|---|---|---|
 | **PR-A** | 1 + 2 + 3 | D5 link adoption: define → write → read (avoid a half-state on main where links exist but are unused) | **MERGED — PR #392** (2026-06-13, merge `c4d03469a`; auto-deploys to prod) |
-| **PR-B** | 4 + 5 | Unified surfacing: admin retail filter + partner panels | **READY** on `feat/342-pr-b-unified-surfacing` — Chunk 4 + Chunk 5 both done (Chunk 5 uncommitted as of 2026-06-13); push + open PR-B draft. Both specs green. |
+| **PR-B** | 4 + 5 | Unified surfacing: admin retail filter + partner panels | **OPEN — PR #393 (draft)** (2026-06-13), `feat/342-pr-b-unified-surfacing`. Chunk 4 + 5 both done, pushed. Both specs green. |
 | **PR-C** | 6 | Metadata-write cleanup (after A + B prove links are the sole path) | not started |
 | **PR-D** | 7 + 8 | Concurrency hardening: locking + Redis provider (parallel track, independent of A–C) | not started |
 | **PR-E** | 9 | T4 backfill + retirement (own planning pass) | not started |

--- a/apps/docs/notes/ORDERS_UNIFICATION_342.md
+++ b/apps/docs/notes/ORDERS_UNIFICATION_342.md
@@ -52,8 +52,8 @@ as the discriminator/pointer. Instead:
 **PR grouping (ship relevant chunks together — each chunk = one commit in the PR):**
 | PR | Chunks | Theme | Status |
 |---|---|---|---|
-| **PR-A** | 1 + 2 + 3 | D5 link adoption: define → write → read (avoid a half-state on main where links exist but are unused) | **OPEN — PR #392** (Chunks 1+2+3 all committed) |
-| **PR-B** | 4 + 5 | Unified surfacing: admin retail filter + partner panels | not started |
+| **PR-A** | 1 + 2 + 3 | D5 link adoption: define → write → read (avoid a half-state on main where links exist but are unused) | **MERGED — PR #392** (2026-06-13, merge `c4d03469a`; auto-deploys to prod) |
+| **PR-B** | 4 + 5 | Unified surfacing: admin retail filter + partner panels | **IN PROGRESS** on `feat/342-pr-b-unified-surfacing` — Chunk 4 done (committed), Chunk 5 next |
 | **PR-C** | 6 | Metadata-write cleanup (after A + B prove links are the sole path) | not started |
 | **PR-D** | 7 + 8 | Concurrency hardening: locking + Redis provider (parallel track, independent of A–C) | not started |
 | **PR-E** | 9 | T4 backfill + retirement (own planning pass) | not started |
@@ -148,9 +148,40 @@ as the discriminator/pointer. Instead:
     the link intact, triggers a mirror (inventory: admin status PUT; run: admin
     cancel route), and asserts the REAL unified order still mirrors — provable
     only via the link. Both specs green (6 + 6). *(blocked by: none)*
-- [ ] **Chunk 4 (T3.3)** — Admin retail list filter: `GET /admin/orders` excludes
-  work-orders via `query.index` null-link filter; opt-in `?kind=` to surface
-  them. *(blocked by: 1)*
+- [x] **Chunk 4 (T3.3)** — Admin retail list filter: `GET /admin/orders` defaults
+  to retail and hides work-orders; opt-in `?kind=` surfaces them. **DONE**
+  (committed on `feat/342-pr-b-unified-surfacing`, part of PR-B).
+  - **Mechanism — route override, not middleware.** New
+    `src/api/admin/orders/route.ts` GET overrides the core list handler
+    (verified: `routes-loader.js` keeps a `[matcher][method]` map, last-registered
+    wins, and project `src/api` is scanned after core — so ours takes precedence).
+    Core's `validateAndTransformQuery` middleware still runs, so `req.queryConfig`
+    + `req.filterableFields` are populated; the handler runs last (ordering-proof).
+    It translates `?kind=` into an `id` constraint and hands otherwise-untouched
+    variables to the SAME `getOrdersListWorkflow` — totals, pagination, q-search,
+    every existing filter intact, zero handler-body drift.
+  - **`?kind=` validator** (`src/api/admin/orders/validators.ts`): zod enum
+    `retail|design|inventory|all`, parsed IN the handler (not a second
+    validate-middleware — core already validates the route, and `kind` is not a
+    filterable order field so it must be stripped before the workflow).
+    Unset → `retail`. `all` → no link filter (pre-D5 behaviour).
+  - **Work-order id set via `query.graph`, NOT the index `$ne: null`.** Only the
+    `id: null` retail anti-join was verified in D5-1; `$ne: null` on a link join
+    is unverified. So we resolve the "has-link" ids by the authoritative forward
+    join (`production_runs.order.id` / `inventory_orders.order.id`, paged 1000s),
+    same shape as `resolveUnifiedOrderIdByLink`, incl. the transitional
+    `metadata.unified_order_id` fallback for pre-D5-2 link-less rows. Then inject
+    `id:{$nin}` (retail) / `id:{$in}` (design|inventory), `$and`-merged with any
+    caller-supplied `id`. query.graph is authoritative (vs the eventually-
+    consistent index), which a list tolerates.
+  - **Known scale limit (accepted, revisit later):** the injected id array is
+    unbounded (all work-orders for retail; all of a kind otherwise) → a large
+    `IN`/`NOT IN` at scale. Fine for an early-stage admin-only list.
+  - Tests: `integration-tests/http/orders-unification-admin-list-filter.spec.ts`
+    — stands up a retail order (`createOrderWorkflow`) + an inventory work-order +
+    a design work-order, asserts by SPECIFIC id (shared-DB-robust) that default
+    hides work-orders, each `?kind=` surfaces its own, `?kind=all` shows all.
+    4/4 green. *(blocked by: none — PR-A merged)*
 - [ ] **Chunk 5 (T3.4)** — Partner-ui unified panels keyed on kind (which link is
   present) + `partner_status`. Hook: `apps/partner-ui/src/hooks/api/orders.tsx`.
   Skeletons, `--ui-*` tokens, partner API mirrors admin. *(blocked by: 4)*

--- a/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
+++ b/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
@@ -582,6 +582,25 @@ export function getPartnerRouteMap(): RouteObject[] {
                   path: "",
                   lazy: () => import("../../routes/orders/order-list"),
                 },
+                // #342 Chunk 5 (T3.4): unified-panel kind sub-routes. Static
+                // segments rank above `:id`, so an order id never collides.
+                // Each renders the SAME kind-parameterized order-list (it reads
+                // the kind off the path).
+                {
+                  path: "design",
+                  lazy: () => import("../../routes/orders/order-list"),
+                  handle: { breadcrumb: () => "Design" },
+                },
+                {
+                  path: "inventory",
+                  lazy: () => import("../../routes/orders/order-list"),
+                  handle: { breadcrumb: () => "Inventory" },
+                },
+                {
+                  path: "all",
+                  lazy: () => import("../../routes/orders/order-list"),
+                  handle: { breadcrumb: () => "All" },
+                },
                 {
                   path: ":id",
                   handle: {

--- a/apps/partner-ui/src/dashboard-app/routes/get-route.map.tsx
+++ b/apps/partner-ui/src/dashboard-app/routes/get-route.map.tsx
@@ -301,6 +301,25 @@ export function getRouteMap({
                   path: "",
                   lazy: () => import("../../routes/orders/order-list"),
                 },
+                // #342 Chunk 5 (T3.4): unified-panel kind sub-routes. Static
+                // segments rank above `:id`, so an order id never collides.
+                // Each renders the SAME kind-parameterized order-list (it reads
+                // the kind off the path).
+                {
+                  path: "design",
+                  lazy: () => import("../../routes/orders/order-list"),
+                  handle: { breadcrumb: () => "Design" },
+                },
+                {
+                  path: "inventory",
+                  lazy: () => import("../../routes/orders/order-list"),
+                  handle: { breadcrumb: () => "Inventory" },
+                },
+                {
+                  path: "all",
+                  lazy: () => import("../../routes/orders/order-list"),
+                  handle: { breadcrumb: () => "All" },
+                },
                 {
                   path: ":id",
                   lazy: async () => {

--- a/apps/partner-ui/src/routes/orders/order-list/components/order-list-table/order-kind-tabs.tsx
+++ b/apps/partner-ui/src/routes/orders/order-list/components/order-list-table/order-kind-tabs.tsx
@@ -1,0 +1,42 @@
+import { clx } from "@medusajs/ui"
+import { NavLink } from "react-router-dom"
+
+// Chunk 5 (T3.4, #342): the unified partner orders surface is split into kind
+// sub-routes (retail | design | inventory | all), each backed by the SAME
+// kind-parameterized table. These NavLinks are the tab strip between them —
+// deep-linkable and breadcrumb-aware, unlike a local-state tab control.
+//
+// `/orders` (index) == retail, so the Retail tab needs `end` to avoid matching
+// the design/inventory/all child paths as a prefix.
+const TABS: { to: string; label: string; end?: boolean }[] = [
+  { to: "/orders/all", label: "All" },
+  { to: "/orders", label: "Retail", end: true },
+  { to: "/orders/design", label: "Design" },
+  { to: "/orders/inventory", label: "Inventory" },
+]
+
+export const OrderKindTabs = () => {
+  return (
+    <nav className="flex items-center gap-1 px-6 pb-3 pt-1">
+      {TABS.map((tab) => (
+        <NavLink
+          key={tab.to}
+          to={tab.to}
+          end={tab.end}
+          className={({ isActive }) =>
+            clx(
+              "txt-compact-small-plus transition-fg rounded-md px-3 py-1.5 outline-none",
+              "text-ui-fg-subtle hover:bg-ui-bg-base-hover hover:text-ui-fg-base",
+              {
+                "bg-ui-bg-base text-ui-fg-base shadow-elevation-card-rest":
+                  isActive,
+              }
+            )
+          }
+        >
+          {tab.label}
+        </NavLink>
+      ))}
+    </nav>
+  )
+}

--- a/apps/partner-ui/src/routes/orders/order-list/components/order-list-table/order-list-table.tsx
+++ b/apps/partner-ui/src/routes/orders/order-list/components/order-list-table/order-list-table.tsx
@@ -1,31 +1,81 @@
-import { Container, Heading } from "@medusajs/ui"
+import { Container, Heading, StatusBadge } from "@medusajs/ui"
 import { keepPreviousData } from "@tanstack/react-query"
+import { createColumnHelper } from "@tanstack/react-table"
+import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
+import { useLocation } from "react-router-dom"
 
 import { _DataTable } from "../../../../../components/table/data-table/data-table"
 import { useOrders } from "../../../../../hooks/api/orders"
 import { usePartnerStores } from "../../../../../hooks/api/partner-stores"
 import { useOrderTableColumns } from "../../../../../hooks/table/columns/use-order-table-columns"
+import { getStatusBadgeColor } from "../../../../../lib/status-badge"
 import { useOrderTableFilters } from "./use-order-table-filters"
 import { useOrderTableQuery } from "../../../../../hooks/table/query/use-order-table-query"
 import { useDataTable } from "../../../../../hooks/use-data-table"
 import { useFeatureFlag } from "../../../../../providers/feature-flag-provider"
 import { ConfigurableOrderListTable } from "./configurable-order-list-table"
+import { OrderKindTabs } from "./order-kind-tabs"
 
 import { DEFAULT_FIELDS } from "../../const"
 
 const PAGE_SIZE = 20
+
+type OrderKind = "retail" | "design" | "inventory" | "all"
+
+// `/orders` (index) == retail; `/orders/{design,inventory,all}` opt into the
+// other unified panels (#342 Chunk 5). The detail route `/orders/:id` renders a
+// different component, so the segment after "orders" here is always a kind.
+const deriveKind = (pathname: string): OrderKind => {
+  const seg = pathname.split("/").filter(Boolean)[1]
+  return seg === "design" || seg === "inventory" || seg === "all"
+    ? (seg as OrderKind)
+    : "retail"
+}
+
+// The §5 work-progress vocabulary stamped on work-order metadata.partner_status.
+const PARTNER_STATUS_LABELS: Record<string, string> = {
+  assigned: "Assigned",
+  accepted: "Accepted",
+  in_progress: "In Progress",
+  partial: "Partial",
+  finished: "Finished",
+  completed: "Completed",
+  declined: "Declined",
+}
+
+// Work-order-only column: the partner-facing lifecycle status. Shown on the
+// design/inventory/all tabs; retail rows have no partner_status and render "—".
+const workColumnHelper = createColumnHelper<any>()
+const partnerStatusColumn = workColumnHelper.display({
+  id: "partner_status",
+  header: () => (
+    <div className="flex h-full w-full items-center px-4 py-2.5">
+      Work status
+    </div>
+  ),
+  cell: ({ row }) => {
+    const status = row.original?.metadata?.partner_status as string | undefined
+    if (!status) {
+      return <span className="text-ui-fg-muted px-4">—</span>
+    }
+    return (
+      <div className="flex items-center px-4">
+        <StatusBadge color={getStatusBadgeColor(status)}>
+          {PARTNER_STATUS_LABELS[status] ?? status}
+        </StatusBadge>
+      </div>
+    )
+  },
+})
 
 export const OrderListTable = () => {
   const { t } = useTranslation()
   const { stores } = usePartnerStores()
   const hasStore = stores?.length > 0
   const isViewConfigEnabled = useFeatureFlag("view_configurations")
-
-  // If feature flag is enabled, use the new configurable table
-  if (isViewConfigEnabled) {
-    return <ConfigurableOrderListTable />
-  }
+  const { pathname } = useLocation()
+  const kind = deriveKind(pathname)
 
   const { searchParams, raw } = useOrderTableQuery({
     pageSize: PAGE_SIZE,
@@ -34,15 +84,21 @@ export const OrderListTable = () => {
   const { orders, count, isError, error, isLoading } = useOrders(
     {
       fields: DEFAULT_FIELDS,
+      kind,
       ...searchParams,
-    },
+    } as any,
     {
       placeholderData: keepPreviousData,
     }
   )
 
   const filters = useOrderTableFilters()
-  const columns = useOrderTableColumns({})
+  const baseColumns = useOrderTableColumns({})
+  const columns = useMemo(
+    () =>
+      kind === "retail" ? baseColumns : [...baseColumns, partnerStatusColumn],
+    [baseColumns, kind]
+  )
 
   const { table } = useDataTable({
     data: orders ?? [],
@@ -56,11 +112,19 @@ export const OrderListTable = () => {
     throw error
   }
 
+  // view_configurations is an experimental flag; the kind sub-routes/tabs are
+  // wired through the standard table only. (When the flag is on, all kinds fall
+  // back to the configurable table unfiltered.)
+  if (isViewConfigEnabled) {
+    return <ConfigurableOrderListTable />
+  }
+
   return (
     <Container className="divide-y p-0">
       <div className="flex items-center justify-between px-6 py-4">
         <Heading>{t("orders.domain")}</Heading>
       </div>
+      <OrderKindTabs />
       <_DataTable
         columns={columns}
         table={table}


### PR DESCRIPTION
**#342 orders unification — PR-B (chunks 4 + 5): unified surfacing.**

Builds on PR-A (#392, D5 link adoption). Now that every work-order has a core `order` spine discriminated by which execution link is present (design → `production_run`, inventory → `inventory_order`, neither → retail), this PR surfaces that distinction in the admin + partner UIs.

## Chunk 4 (T3.3) — admin retail list filter
- `GET /admin/orders` defaults to **retail** and hides work-orders; `?kind=design|inventory|all` opts them back in.
- Route override (`src/api/admin/orders/route.ts`) wins over the core handler; translates `?kind=` into an `id` constraint and hands otherwise-untouched variables to the same `getOrdersListWorkflow` (totals/pagination/q-search intact).
- Work-order ids resolved via the authoritative forward link (`<entity>.order.id`), with the transitional `metadata.unified_order_id` fallback.
- Spec: `orders-unification-admin-list-filter.spec.ts` — 4/4.

## Chunk 5 (T3.4) — partner unified panels
- **Sub-routes**, not a local-state tab strip: `/orders` (retail) · `/orders/design` · `/orders/inventory` · `/orders/all`, registered in **both** route maps as static children alongside `:id` (static ranks above `:id`, so an order id never collides). All four back one kind-parameterized `OrderListTable`; `order-kind-tabs.tsx` is the `NavLink` strip.
- Backend `GET /partners/orders?kind=` mirrors admin's contract but the route is **thin** — logic lives in `listPartnerOrdersWorkflow` (`src/workflows/orders/list-partner-orders.ts`). Scoping diverges where it must: retail = sales-channel (work-orders sit in the internal `PARTNER_WORK_ORDERS_CHANNEL`, already excluded); design/inventory via the **D3 `partner↔order` link** ∩ the kind's execution link; `all` = `$or`.
- `partner_status` badge column (§5 vocabulary) on every non-retail tab; skeletons via existing `_DataTable isLoading`; `--ui-*` tokens.
- Two link gotchas handled: read the D3 set from the link table directly (`partnerOrderLink.entryPoint` by `partner_id`); bucket the 1:1 reverse execution accessor on `rel?.id` (it resolves to a single object, not an array).
- Spec: `orders-unification-partner-list-filter.spec.ts` — 4/4.

## Notes / follow-ups
- The experimental `view_configurations` flag path (`ConfigurableOrderListTable`) is **not** kind-wired yet — falls back to the unfiltered table when on. Logged as a handoff task (saveable/loadable kind view configurations).
- Also logged: a Playwright stage-by-stage walkthrough + screenshots task (QA baselines + marketing stills).
- Full handoff: `apps/docs/notes/ORDERS_UNIFICATION_342.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)