### PR TITLE
feat(orders): #342 PR-C Chunk 6 — retire metadata.kind + unified_order_id (links authoritative)

### DIFF
--- a/apps/backend/integration-tests/http/orders-unification-design-dual-write.spec.ts
+++ b/apps/backend/integration-tests/http/orders-unification-design-dual-write.spec.ts
@@ -2,7 +2,8 @@
  * #342 T3.2 — design-side dual-write shim.
  *
  * Creating/approving/transitioning a production run must additionally project
- * and maintain a core `order` (metadata.kind = "design") per
+ * and maintain a core `order` (kind=design, discriminated by the
+ * order↔production_run link since Chunk 6) per
  * apps/docs/notes/ORDERS_UNIFICATION_342.md §4 + §5, without ever failing the
  * legacy run path. Child runs (the partner-facing unit) get their own orders;
  * a split parent's order is canceled as superseded.
@@ -134,9 +135,17 @@ setupSharedTestSuite(() => {
       return data?.[0]
     }
 
+    // Chunk 6: resolve a run's unified order via the order↔production_run link
+    // (forward `.order`), not the retired run.metadata.unified_order_id backref.
     const unifiedOrderIdOf = async (runId: string) => {
-      const run: any = await fetchRun(runId)
-      return run?.metadata?.unified_order_id ?? null
+      const container = getContainer()
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data } = await query.graph({
+        entity: "production_runs",
+        filters: { id: runId },
+        fields: ["id", "order.id"],
+      })
+      return data?.[0]?.order?.id ?? null
     }
 
     beforeEach(async () => {
@@ -162,9 +171,12 @@ setupSharedTestSuite(() => {
       expect(unifiedOrderId).toBeTruthy()
       const unified = await fetchUnifiedOrder(unifiedOrderId)
 
-      // §2/§4 discriminator + projection metadata
-      expect(unified.metadata.kind).toBe("design")
+      // §2/§4 projection metadata (the kind=design discriminator is the
+      // order↔production_run link, asserted forward below).
       expect(unified.metadata.legacy_id).toBe(runId)
+      // Chunk 6 regression: `kind` is no longer written onto the order (the
+      // link IS the discriminator now).
+      expect(unified.metadata.kind).toBeUndefined()
       expect(unified.metadata.production_run_id).toBe(runId)
       expect(unified.metadata.run_type).toBe("production")
       expect(unified.metadata.currency_assumed).toBe(true)
@@ -207,11 +219,12 @@ setupSharedTestSuite(() => {
       })
       expect(linkedRuns?.[0]?.order?.id).toBe(unifiedOrderId)
 
-      // Legacy run untouched apart from the metadata backref; order_id still
-      // means "source retail order" (deviation note in the doc)
+      // Legacy run untouched — Chunk 6 stopped writing the projection backref;
+      // order_id still means "source retail order" (deviation note in the doc)
       const run: any = await fetchRun(runId)
       expect(run.status).toBe("pending_review")
       expect(run.order_id ?? null).toBeNull()
+      expect(run.metadata?.unified_order_id ?? null).toBeNull()
     })
 
     it("projects child runs on approve, supersedes the parent order, links partner on send, and mirrors the partner lifecycle", async () => {
@@ -251,7 +264,6 @@ setupSharedTestSuite(() => {
       expect(childOrderId).toBeTruthy()
       expect(childOrderId).not.toBe(parentOrderId)
       let childOrder = await fetchUnifiedOrder(childOrderId)
-      expect(childOrder.metadata.kind).toBe("design")
       expect(Number(childOrder.items[0].quantity)).toBe(4)
       // sent_to_partner → core pending + partner_status assigned
       expect(childOrder.status).toBe("pending")
@@ -394,9 +406,10 @@ setupSharedTestSuite(() => {
     })
 
     it("resolves the unified order via the link, not the metadata backref (D5-3)", async () => {
-      // Chunk 3 — the run status mirror (incl. the admin cancel route) now
+      // Chunk 3/6 — the run status mirror (incl. the admin cancel route)
       // resolves the unified order through the order↔production_run link
-      // (query.graph forward `.order`), not run.metadata.unified_order_id.
+      // (query.graph forward `.order`) with PRIORITY over the transitional
+      // run.metadata.unified_order_id fallback (Chunk 6 no longer writes it).
       // POISON the backref with a bogus id, leave the link intact: the mirror
       // must still cancel the REAL order, which is only possible via the link.
       await createRegion()
@@ -447,7 +460,8 @@ setupSharedTestSuite(() => {
 
       const run: any = await fetchRun(runId)
       expect(run.status).toBe("pending_review")
-      expect(run.metadata?.unified_order_id ?? null).toBeNull()
+      // No projection → no order↔production_run link.
+      expect(await unifiedOrderIdOf(runId)).toBeFalsy()
 
       // Later transitions stay non-fatal without a unified order
       const cancel = await post(

--- a/apps/backend/integration-tests/http/orders-unification-dual-write.spec.ts
+++ b/apps/backend/integration-tests/http/orders-unification-dual-write.spec.ts
@@ -2,8 +2,9 @@
  * #342 T2 — orders unification dual-write shim.
  *
  * Creating a legacy inventory order must additionally project a core `order`
- * (metadata.kind = "inventory") per apps/docs/notes/ORDERS_UNIFICATION_342.md
- * §3 + §5, without ever failing the legacy create. Also probes the two gaps
+ * (kind=inventory, discriminated by the order↔inventory_order link since
+ * Chunk 6) per apps/docs/notes/ORDERS_UNIFICATION_342.md §3 + §5, without ever
+ * failing the legacy create. Also probes the two gaps
  * the doc left to empirical verification:
  *   GAP-1 — core order_line_item.quantity accepts decimals (raw-material kg)
  *   GAP-3 — core order create works customer-less (no customer_id, no email)
@@ -100,6 +101,21 @@ setupSharedTestSuite(() => {
       return data?.[0]
     }
 
+    // Chunk 6: the unified order id is resolved via the order↔inventory_order
+    // link (forward `.order`), not the retired metadata.unified_order_id backref.
+    const resolveUnifiedViaLink = async (
+      legacyId: string
+    ): Promise<string | undefined> => {
+      const container = getContainer()
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data } = await query.graph({
+        entity: "inventory_orders",
+        filters: { id: legacyId },
+        fields: ["id", "order.id"],
+      })
+      return data?.[0]?.order?.id ?? undefined
+    }
+
     beforeEach(async () => {
       const container = getContainer()
       await createAdminUser(container)
@@ -132,15 +148,18 @@ setupSharedTestSuite(() => {
       const legacy = await createLegacyOrder()
 
       const legacyRow = await fetchLegacyOrder(legacy.id)
-      const unifiedOrderId = legacyRow.metadata?.unified_order_id
+      const unifiedOrderId = await resolveUnifiedViaLink(legacy.id)
       expect(unifiedOrderId).toBeTruthy()
 
-      const unified = await fetchUnifiedOrder(unifiedOrderId)
+      const unified = await fetchUnifiedOrder(unifiedOrderId!)
       expect(unified).toBeTruthy()
 
-      // §2/§3 discriminator + projection metadata
-      expect(unified.metadata.kind).toBe("inventory")
+      // §2/§3 projection metadata (the kind=inventory discriminator is the
+      // order↔inventory_order link, asserted forward below).
       expect(unified.metadata.legacy_id).toBe(legacy.id)
+      // Chunk 6 regression: `kind` is no longer written onto the order (the
+      // link IS the discriminator now).
+      expect(unified.metadata.kind).toBeUndefined()
       expect(unified.metadata.is_sample).toBe(false)
       expect(unified.metadata.currency_assumed).toBe(true)
       expect(unified.metadata.total_quantity).toBe(2.5)
@@ -186,15 +205,16 @@ setupSharedTestSuite(() => {
       expect(unified.shipping_address?.city).toBe("Jaipur")
       expect(unified.shipping_address?.country_code).toBe("in")
 
-      // Legacy row untouched apart from the metadata backref
+      // Legacy row untouched — Chunk 6 stopped writing any projection backref
+      // onto it; the link is the sole pointer.
       expect(legacyRow.status).toBe("Pending")
       expect(Number(legacyRow.quantity)).toBe(2.5)
       expect(Number(legacyRow.total_price)).toBe(100)
       expect(legacyRow.orderlines).toHaveLength(1)
+      expect(legacyRow.metadata?.unified_order_id ?? null).toBeNull()
 
-      // D5-2: the order↔inventory_order link is the authoritative pointer.
-      // Resolve it forward (legacy row → unified order) via query.graph — the
-      // same join the mirror/read paths will use in D5-3.
+      // kind=inventory discriminator: exactly one order↔inventory_order link,
+      // resolving forward (legacy row → unified order) to the projected order.
       const { data: linked } = await query.graph({
         entity: "inventory_orders",
         filters: { id: legacy.id },
@@ -209,14 +229,14 @@ setupSharedTestSuite(() => {
 
       const legacyRow = await fetchLegacyOrder(legacy.id)
       expect(legacyRow.status).toBe("Pending")
-      expect(legacyRow.metadata?.unified_order_id ?? null).toBeNull()
+      // No projection → no order↔inventory_order link.
+      expect(await resolveUnifiedViaLink(legacy.id)).toBeFalsy()
     })
 
     it("mirrors admin status updates onto the unified order (§5)", async () => {
       await createRegion()
       const legacy = await createLegacyOrder()
-      const unifiedOrderId = (await fetchLegacyOrder(legacy.id)).metadata
-        ?.unified_order_id
+      const unifiedOrderId = await resolveUnifiedViaLink(legacy.id)
       expect(unifiedOrderId).toBeTruthy()
 
       // Pending → Processing: core stays pending, work dimension advances
@@ -229,8 +249,7 @@ setupSharedTestSuite(() => {
       let unified = await fetchUnifiedOrder(unifiedOrderId)
       expect(unified.status).toBe("pending")
       expect(unified.metadata.partner_status).toBe("in_progress")
-      // projection metadata survives the patch
-      expect(unified.metadata.kind).toBe("inventory")
+      // projection metadata survives the read-then-merge patch
       expect(unified.metadata.legacy_id).toBe(legacy.id)
 
       // Processing → Cancelled: core cancels; §5 defines no partner_status
@@ -247,16 +266,16 @@ setupSharedTestSuite(() => {
     })
 
     it("resolves the unified order via the link, not the metadata backref (D5-3)", async () => {
-      // Chunk 3 — the status mirror now reads the order↔inventory_order link
-      // (query.graph forward `.order`), no longer the metadata.unified_order_id
-      // backref. Prove it by POISONING the backref with a bogus order id while
-      // leaving the link intact: if the mirror still lands on the REAL unified
-      // order, it can ONLY have resolved via the link (a backref read would
-      // target the bogus id and leave the real order untouched).
+      // Chunk 3/6 — the status mirror reads the order↔inventory_order link
+      // (query.graph forward `.order`) with PRIORITY over the transitional
+      // metadata.unified_order_id fallback (kept only for pre-D5-2 historicals;
+      // Chunk 6 no longer writes it). Prove the priority by POISONING the backref
+      // with a bogus order id while leaving the link intact: if the mirror still
+      // lands on the REAL unified order, it resolved via the link (a backref read
+      // would target the bogus id and leave the real order untouched).
       await createRegion()
       const legacy = await createLegacyOrder()
-      const legacyRow = await fetchLegacyOrder(legacy.id)
-      const unifiedOrderId = legacyRow.metadata?.unified_order_id
+      const unifiedOrderId = await resolveUnifiedViaLink(legacy.id)
       expect(unifiedOrderId).toBeTruthy()
 
       const container = getContainer()
@@ -285,9 +304,7 @@ setupSharedTestSuite(() => {
     it("keeps legacy updates non-fatal when no unified order exists", async () => {
       // No region → create skipped the dual-write; updates must still work
       const legacy = await createLegacyOrder()
-      expect(
-        (await fetchLegacyOrder(legacy.id)).metadata?.unified_order_id ?? null
-      ).toBeNull()
+      expect(await resolveUnifiedViaLink(legacy.id)).toBeFalsy()
 
       const res = await api.put(
         `/admin/inventory-orders/${legacy.id}`,
@@ -363,8 +380,7 @@ setupSharedTestSuite(() => {
       }
 
       const legacy = await createLegacyOrder()
-      const legacyRow = await fetchLegacyOrder(legacy.id)
-      const unifiedOrderId = legacyRow.metadata?.unified_order_id
+      const unifiedOrderId = await resolveUnifiedViaLink(legacy.id)
       expect(unifiedOrderId).toBeTruthy()
 
       const sendRes = await post(
@@ -388,8 +404,6 @@ setupSharedTestSuite(() => {
       // §5: assignment mirrors metadata.partner_status = "assigned"
       let unified = await fetchUnifiedOrder(unifiedOrderId)
       expect(unified.metadata.partner_status).toBe("assigned")
-      // kind survives the metadata update
-      expect(unified.metadata.kind).toBe("inventory")
 
       // ——— partner lifecycle: start → in_progress, complete → finished ———
       // Fresh token after partner creation (critical for auth context)

--- a/apps/backend/src/api/partners/orders/route.ts
+++ b/apps/backend/src/api/partners/orders/route.ts
@@ -29,8 +29,9 @@ const DEFAULT_FIELDS = [
   "sales_channel.*",
   "payment_collections.*",
   "shipping_address.*",
-  // Chunk 5 (T3.4): the unified panels key on `metadata.kind` +
-  // `metadata.partner_status`, so surface the whole metadata blob.
+  // Chunk 5 (T3.4): kind is the route `?kind=` param (link-derived, Chunk 6),
+  // but the panels still read `metadata.partner_status` for the badge column,
+  // so surface the whole metadata blob.
   "metadata",
 ]
 

--- a/apps/backend/src/links/partner-order.ts
+++ b/apps/backend/src/links/partner-order.ts
@@ -3,9 +3,9 @@ import PartnerModule from "../modules/partner"
 import OrderModule from "@medusajs/medusa/order"
 
 // D3 (#342): partner ↔ core order scoping link for unified work-orders
-// (order.metadata.kind = design | inventory). Retail orders keep using
-// sales-channel scoping; work-orders need an explicit link because a partner
-// can serve another partner's store.
+// (kind = design | inventory, discriminated by the order↔execution link since
+// Chunk 6). Retail orders keep using sales-channel scoping; work-orders need an
+// explicit link because a partner can serve another partner's store.
 export default defineLink(
   {
     linkable: PartnerModule.linkable.partner,

--- a/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
@@ -244,9 +244,10 @@ export const createInventoryOrderWorkflow = createWorkflow(
       });
     });
 
-    // #342 T2: best-effort projection onto a core order (metadata.kind =
-    // "inventory"). The step swallows its own errors — a dual-write failure
-    // must never fail the legacy create.
+    // #342 T2: best-effort projection onto a core order (kind=inventory,
+    // discriminated by the order↔inventory_order link since Chunk 6). The step
+    // swallows its own errors — a dual-write failure must never fail the legacy
+    // create.
     dualWriteUnifiedOrderStep({
       order: linkInput.order,
       orderLines: linkInput.orderLines,

--- a/apps/backend/src/workflows/inventory_orders/dual-write-unified-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/dual-write-unified-order.ts
@@ -5,10 +5,10 @@ import type { Link } from "@medusajs/modules-sdk"
 import type { LinkDefinition, MedusaContainer } from "@medusajs/framework/types"
 import { ORDER_INVENTORY_MODULE } from "../../modules/inventory_orders"
 import { PARTNER_MODULE } from "../../modules/partner"
-import InventoryOrderService from "../../modules/inventory_orders/service"
 
 // #342 T2 — best-effort projection of legacy inventory orders onto the core
-// `order` entity (metadata.kind = "inventory"). See
+// `order` entity (kind=inventory = "the order↔inventory_order link exists";
+// Chunk 6 retired the metadata.kind discriminator). See
 // apps/docs/notes/ORDERS_UNIFICATION_342.md §3 + §5. Failure must never fail
 // the legacy create, so each step swallows errors and reports via logger.
 
@@ -17,11 +17,11 @@ export const PARTNER_WORK_ORDERS_CHANNEL = "Partner Work Orders"
 // #342 metadata-as-critical-data audit — the load-bearing unification keys on a
 // unified order's `metadata`. Medusa's `update*` REPLACES the whole metadata
 // blob, so any external writer (e.g. a partner PATCH) must read-then-merge AND
-// must never let caller input overwrite these — they discriminate the order
-// (`kind`), anchor backfill/idempotency (`legacy_id`), and drive T3 panels
-// (`partner_status`). See ORDERS_UNIFICATION_342.md "metadata-as-critical-data".
+// must never let caller input overwrite these — they anchor backfill/idempotency
+// (`legacy_id`) and drive T3 panels (`partner_status`). NOTE: `kind` is no longer
+// here — Chunk 6 retired it; the order↔execution link IS the discriminator now.
+// See ORDERS_UNIFICATION_342.md "metadata-as-critical-data".
 export const PROTECTED_UNIFICATION_METADATA_KEYS = [
-  "kind",
   "legacy_id",
   "partner_status",
   "source_order_id",
@@ -128,6 +128,37 @@ export const resolveUnifiedOrderIdByLink = async (
   return row?.order?.id ?? row?.metadata?.unified_order_id ?? undefined
 }
 
+// D5-cleanup (Chunk 6) — create the load-bearing order↔<execution> link
+// AUTHORITATIVELY. Until Chunk 6 the link was best-effort (swallow + warn)
+// because `metadata.unified_order_id` was a backref safety net. Chunk 6 stops
+// writing that backref, so the link is now the SOLE pointer from a freshly
+// projected order back to its legacy entity — a silent link failure would
+// orphan the order (no pointer, and — being link-less — it would leak into the
+// admin retail anti-join). Make the dual-write atomic instead: if the link
+// fails, delete the just-created unified order and rethrow, so the projection
+// reports failure via the caller's swallow-and-warn boundary and leaves no
+// half-state. The work-order has no payment/fulfillment/reservation (its items
+// carry no variant_id), so `deleteOrders` is a clean cascade.
+export const linkUnifiedOrderOrRollback = async (
+  container: MedusaContainer,
+  unifiedOrderId: string,
+  link: LinkDefinition
+): Promise<void> => {
+  const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+  try {
+    await remoteLink.create([link])
+  } catch (linkErr: any) {
+    const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+    const orderService: any = container.resolve(Modules.ORDER)
+    await orderService.deleteOrders([unifiedOrderId]).catch((delErr: any) =>
+      logger.error(
+        `[orders-unification] ORPHANED unified order ${unifiedOrderId}: execution link failed (${linkErr?.message}) AND rollback delete failed (${delErr?.message}) — manual cleanup needed`
+      )
+    )
+    throw linkErr
+  }
+}
+
 type DualWriteInput = {
   order: any
   orderLines: any[]
@@ -227,7 +258,6 @@ export const dualWriteUnifiedOrderStep = createStep(
       // Legacy metadata wins on collision except the unification keys (§3).
       const metadata: Record<string, unknown> = {
         ...(order.metadata ?? {}),
-        kind: "inventory",
         legacy_id: order.id,
         total_quantity: Number(order.quantity),
         expected_delivery_date: order.expected_delivery_date ?? null,
@@ -256,36 +286,17 @@ export const dualWriteUnifiedOrderStep = createStep(
         },
       })
 
-      // D5-2 — the load-bearing order↔inventory_order link + kind=inventory
-      // discriminator (replaces metadata.unified_order_id as the authoritative
-      // pointer; the metadata backref below is still written during the D5
-      // transition). filterable:["id"] → the Index Module ingests it so the
-      // admin retail-list anti-join can exclude work-orders (Chunk 4). This
-      // create path runs once per legacy create, so no link-existence guard is
-      // needed (a fresh unified order per call). Best-effort: a link failure
-      // must not lose the metadata backref legacy reads still depend on.
-      const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
-      await remoteLink
-        .create([
-          {
-            [Modules.ORDER]: { order_id: unified.id },
-            [ORDER_INVENTORY_MODULE]: { inventory_orders_id: order.id },
-          },
-        ])
-        .catch((e: any) =>
-          logger.warn(
-            `[orders-unification] order↔inventory_order link failed for ${order.id}: ${e?.message}`
-          )
-        )
-
-      const inventoryOrderService: InventoryOrderService =
-        container.resolve(ORDER_INVENTORY_MODULE)
-      await inventoryOrderService.updateInventoryOrders({
-        id: order.id,
-        metadata: {
-          ...(order.metadata ?? {}),
-          unified_order_id: unified.id,
-        },
+      // D5-2 / Chunk 6 — the load-bearing order↔inventory_order link is the
+      // SOLE discriminator + pointer (kind=inventory is "this link exists").
+      // filterable:["id"] → the Index Module ingests it so the admin retail-list
+      // anti-join can exclude work-orders (Chunk 4). This create path runs once
+      // per legacy create, so no link-existence guard is needed (a fresh unified
+      // order per call). Authoritative: a link failure rolls back the order
+      // rather than leaving a pointer-less orphan (the metadata.unified_order_id
+      // backref that used to be the safety net is no longer written, Chunk 6).
+      await linkUnifiedOrderOrRollback(container, unified.id, {
+        [Modules.ORDER]: { order_id: unified.id },
+        [ORDER_INVENTORY_MODULE]: { inventory_orders_id: order.id },
       })
 
       return new StepResponse<DualWriteResult>({ unified_order_id: unified.id })

--- a/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
+++ b/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
@@ -11,19 +11,22 @@ import type ProductionRunService from "../../modules/production_runs/service"
 import {
   PARTNER_WORK_ORDERS_CHANNEL,
   resolveUnifiedOrderIdByLink,
+  linkUnifiedOrderOrRollback,
 } from "../inventory_orders/dual-write-unified-order"
 
 // #342 T3.2 — best-effort projection of production runs onto the core `order`
-// entity (metadata.kind = "design"). Mirrors the T2 inventory-order recipe;
-// see apps/docs/notes/ORDERS_UNIFICATION_342.md §4 + §5. Failure must never
-// fail the legacy path, so every entry point swallows errors and reports via
-// logger.warn with the [orders-unification] prefix.
+// entity (kind=design = "the order↔production_run link exists"; Chunk 6 retired
+// the metadata.kind discriminator). Mirrors the T2 inventory-order recipe; see
+// apps/docs/notes/ORDERS_UNIFICATION_342.md §4 + §5. Failure must never fail the
+// legacy path, so every entry point swallows errors and reports via logger.warn
+// with the [orders-unification] prefix.
 //
-// Deviation from §4's "run gains order_id → unified order": during the shim
-// phase the unified order id lives in run.metadata.unified_order_id, NOT in
-// run.order_id — that column still means "the customer retail order that
-// spawned the run" and is read by stockFinishedGoodsStep (reservations) and
-// run provenance. Repointing it is a T4 concern.
+// Deviation from §4's "run gains order_id → unified order": the pointer from a
+// run to its unified order is the order↔production_run link (Chunk 6 stopped
+// writing the transitional run.metadata.unified_order_id backref). run.order_id
+// is NOT repointed — that column still means "the customer retail order that
+// spawned the run" and is read by stockFinishedGoodsStep (reservations) and run
+// provenance. Repointing it is a T4 concern.
 
 // §5 — run status → core order.status. The work-progress dimension lives in
 // metadata.partner_status (below).
@@ -225,7 +228,6 @@ export const projectRunToUnifiedOrder = async (
     // Legacy metadata wins on collision except the unification keys (§3/§4).
     const metadata: Record<string, unknown> = {
       ...(run.metadata ?? {}),
-      kind: "design",
       legacy_id: run.id,
       production_run_id: run.id,
       run_type: run.run_type ?? "production",
@@ -267,23 +269,17 @@ export const projectRunToUnifiedOrder = async (
 
     const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
 
-    // D5-2 — the load-bearing order↔production_run link + kind=design
-    // discriminator (replaces metadata.unified_order_id as the authoritative
-    // pointer; the metadata backref is still written below during the D5
-    // transition). filterable:["id"] means the Index Module ingests it so the
-    // admin retail-list anti-join can exclude work-orders (Chunk 4).
-    await remoteLink
-      .create([
-        {
-          [Modules.ORDER]: { order_id: unified.id },
-          [PRODUCTION_RUNS_MODULE]: { production_runs_id: run.id },
-        },
-      ])
-      .catch((e: any) =>
-        logger.warn(
-          `[orders-unification] order↔production_run link failed for ${run.id}: ${e?.message}`
-        )
-      )
+    // D5-2 / Chunk 6 — the load-bearing order↔production_run link is the SOLE
+    // discriminator + pointer (kind=design is "this link exists").
+    // filterable:["id"] means the Index Module ingests it so the admin retail-
+    // list anti-join can exclude work-orders (Chunk 4). Authoritative: a link
+    // failure rolls back the just-created order rather than orphaning it — the
+    // metadata.unified_order_id backref that used to be the safety net is no
+    // longer written (Chunk 6).
+    await linkUnifiedOrderOrRollback(container, unified.id, {
+      [Modules.ORDER]: { order_id: unified.id },
+      [PRODUCTION_RUNS_MODULE]: { production_runs_id: run.id },
+    })
 
     // §4 — reuse the existing design↔order link infra (#29) so design panels
     // and linkDesignsToOrder consumers see the work-order too.
@@ -319,14 +315,6 @@ export const projectRunToUnifiedOrder = async (
         )
       }
     }
-
-    await productionRunService.updateProductionRuns({
-      id: run.id,
-      metadata: {
-        ...(run.metadata ?? {}),
-        unified_order_id: unified.id,
-      },
-    })
 
     return { unified_order_id: unified.id }
   } catch (e: any) {

--- a/apps/docs/notes/ORDERS_UNIFICATION_342.md
+++ b/apps/docs/notes/ORDERS_UNIFICATION_342.md
@@ -54,7 +54,7 @@ as the discriminator/pointer. Instead:
 |---|---|---|---|
 | **PR-A** | 1 + 2 + 3 | D5 link adoption: define → write → read (avoid a half-state on main where links exist but are unused) | **MERGED — PR #392** (2026-06-13, merge `c4d03469a`; auto-deploys to prod) |
 | **PR-B** | 4 + 5 | Unified surfacing: admin retail filter + partner panels | **OPEN — PR #393 (draft)** (2026-06-13), `feat/342-pr-b-unified-surfacing`. Chunk 4 + 5 both done, pushed. Both specs green. |
-| **PR-C** | 6 | Metadata-write cleanup (after A + B prove links are the sole path) | not started |
+| **PR-C** | 6 | Metadata-write cleanup (after A + B prove links are the sole path) | **OPEN — PR #394 (draft)** on `feat/342-pr-c-metadata-cleanup`. Stopped writing `metadata.kind` + `unified_order_id`; execution link-create made authoritative w/ order rollback. All 4 unification specs green (20 tests). |
 | **PR-D** | 7 + 8 | Concurrency hardening: locking + Redis provider (parallel track, independent of A–C) | not started |
 | **PR-E** | 9 | T4 backfill + retirement (own planning pass) | not started |
 
@@ -223,9 +223,31 @@ as the discriminator/pointer. Instead:
     (Design link needs a `notifiable:false` task template + `template_names` so
     the dispatch that writes the D3 link doesn't error in the notification path
     and get swallowed.) *(blocked by: 4 — done)*
-- [ ] **Chunk 6 (D5-cleanup)** — Stop WRITING `metadata.kind` + `unified_order_id`;
-  trim them from `PROTECTED_UNIFICATION_METADATA_KEYS` + the partner PATCH route.
-  `partner_status` stays. *(blocked by: 3, 4)*
+- [x] **Chunk 6 (D5-cleanup)** — **DONE** (commit `6bcd6034d` on
+  `feat/342-pr-c-metadata-cleanup`, **PR #394 draft**). Stopped WRITING `metadata.kind`
+  (zero reads — pure dead weight) and the `metadata.unified_order_id` backref in
+  both projections; removed `"kind"` from `PROTECTED_UNIFICATION_METADATA_KEYS`
+  (→ partner PATCH no longer force-protects it). `partner_status` + `legacy_id`
+  stay. **Link-hardening (decided 2026-06-13, beyond the original chunk text):**
+  the backref was the safety net that let the execution link-create be
+  best-effort; with it gone, the order↔execution link is the SOLE pointer, so a
+  silent link failure would orphan the order AND leak it into the admin retail
+  anti-join (link-less ⇒ retail). New shared helper `linkUnifiedOrderOrRollback`
+  (in `inventory_orders/dual-write-unified-order.ts`) makes the dual-write
+  ATOMIC: on link-create failure it deletes the just-created unified order and
+  rethrows (caught by each projection's swallow-and-warn boundary → returns
+  null), so it's "order + link both, or neither" and the next mirror re-projects
+  cleanly. Work-orders have no payment/fulfillment/reservation (items carry no
+  `variant_id`) → `orderService.deleteOrders` is a clean cascade. The
+  design↔order + partner↔order links stay as they were (ancillary / already
+  authoritative). The 4 transitional fallback reads (`?? metadata.unified_order_id`
+  in `resolveUnifiedOrderIdByLink` + the two idempotency guards) **stay** — they
+  serve pre-D5-2 historicals until Chunk 9 backfill retires them. Specs: both
+  dual-write specs now resolve the unified id via the link (not the backref),
+  drop the `metadata.kind` asserts, and gain a Chunk-6 regression assert (kind
+  absent from metadata + no backref on the legacy row). All 4 unification specs
+  green (12 + 8 = 20). *(blocked by: 3, 4 — both done)* *(NEXT: PR-D locking is
+  independent; Chunk 9/T4 still pending.)*
 - [ ] **Chunk 7 (H1)** — Locking on the dual-write/mirror read-modify-write
   (`partner_status` race), key = unified order id, ALL writers share it, inside
   the swallow-and-warn boundary. Pattern: `complete-production-run.ts`.


### PR DESCRIPTION
## #342 orders unification — PR-C (Chunk 6: metadata-write cleanup)

Follows **PR-A #392** (link adoption) and **PR-B #393** (unified surfacing), both merged. With the `order↔production_run` / `order↔inventory_order` links now the sole discriminator + pointer, this retires the transitional metadata the projections were still dual-writing.

### What changed
- **Stop writing `metadata.kind`** on the unified order in both projections — zero active reads; the link's existence *is* `kind`.
- **Stop writing the `metadata.unified_order_id` backref** on the legacy entity (inventory_order / production_run).
- **Drop `"kind"` from `PROTECTED_UNIFICATION_METADATA_KEYS`** → the partner PATCH route no longer force-protects it. `partner_status` + `legacy_id` stay protected.

### Link-hardening (decided this PR, beyond the original chunk text)
The metadata backref was the safety net that let the execution link-create be **best-effort** (`.catch → warn`). With the backref gone, a silent link failure would orphan the freshly-created order *and* leak it into the admin retail anti-join (link-less ⇒ retail). New shared helper **`linkUnifiedOrderOrRollback`** makes the dual-write **atomic**: on link-create failure it deletes the just-created unified order and rethrows (caught by each projection's swallow-and-warn boundary → returns `null`), so the invariant is "order + link both, or neither" and the next mirror re-projects cleanly. Work-orders carry no payment/fulfillment/reservation (items have no `variant_id`), so `deleteOrders` is a clean cascade.

### Deliberately left in place
The 4 transitional `?? metadata.unified_order_id` fallback **reads** (`resolveUnifiedOrderIdByLink` + the two idempotency guards) stay — they serve pre-D5-2 link-less historicals until **Chunk 9 / T4** backfills links and retires them.

### Tests
Both dual-write specs now resolve the unified id via the link (not the backref), drop the `metadata.kind` assertions, and gain a Chunk-6 regression assert (kind absent from metadata + no backref on the legacy row). **All 4 unification specs green — 20 tests** (dual-write 12 + list-filter 8).

> Auto-deploys to prod on merge. Draft until reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)