### PR TITLE
feat(orders): #342 PR-D — concurrency hardening (locking + Redis provider)

### DIFF
--- a/apps/backend/integration-tests/http/orders-unification-locking.spec.ts
+++ b/apps/backend/integration-tests/http/orders-unification-locking.spec.ts
@@ -1,0 +1,195 @@
+/**
+ * #342 PR-D (Chunk 7 / H1) — concurrency locking on the unified order's
+ * metadata read-modify-write.
+ *
+ * Every #342 mirror does retrieveOrder → spread metadata → updateOrders. Two
+ * near-simultaneous transitions (e.g. a partner `/complete` racing the
+ * `production-run-task-updated` auto-complete) both read the same snapshot, and
+ * the later write clobbers the earlier one (a lost update on `partner_status`).
+ * `withUnifiedOrderMetadataLock` serializes that RMW on the unified order id so
+ * every writer of the same order contends on one lock.
+ *
+ * This proves the primitive directly: fire N concurrent RMW jobs that each
+ * increment a metadata counter (with an await between read and write to force
+ * interleaving). Locked → the counter reaches exactly N. As a control, the same
+ * jobs WITHOUT the lock lose updates (final < N), proving the lock is what makes
+ * the locked case correct (not just a fast machine).
+ */
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { withUnifiedOrderMetadataLock } from "../../src/workflows/inventory_orders/dual-write-unified-order"
+
+jest.setTimeout(60000)
+
+const CONCURRENCY = 8
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Orders unification locking (#342 PR-D / Chunk 7)", () => {
+    let adminHeaders: any
+    let inventoryItemId: string
+    let stockLocationId: string
+    let fromStockLocationId: string
+
+    const createRegion = async () => {
+      const regionService: any = getContainer().resolve(Modules.REGION)
+      const region = await regionService.createRegions({
+        name: "India",
+        currency_code: "inr",
+        countries: ["in"],
+      })
+      return region.id
+    }
+
+    // Reuse the inventory dual-write to mint a real unified order, then read its
+    // id off the order↔inventory_order link (Chunk 6 — the link is the pointer).
+    const createUnifiedOrder = async (): Promise<string> => {
+      const res = await api.post(
+        "/admin/inventory-orders",
+        {
+          order_lines: [
+            { inventory_item_id: inventoryItemId, quantity: 1, price: 100 },
+          ],
+          quantity: 1,
+          total_price: 100,
+          status: "Pending",
+          expected_delivery_date: new Date().toISOString(),
+          order_date: new Date().toISOString(),
+          shipping_address: {
+            first_name: "JYT",
+            address_1: "Mill Road 1",
+            city: "Jaipur",
+            country_code: "in",
+            postal_code: "302001",
+          },
+          stock_location_id: stockLocationId,
+          from_stock_location_id: fromStockLocationId,
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      const legacyId = res.data.inventoryOrder.id
+
+      const query: any = getContainer().resolve(ContainerRegistrationKeys.QUERY)
+      const { data } = await query.graph({
+        entity: "inventory_orders",
+        filters: { id: legacyId },
+        fields: ["id", "order.id"],
+      })
+      const unifiedOrderId = data?.[0]?.order?.id
+      expect(unifiedOrderId).toBeTruthy()
+      return unifiedOrderId
+    }
+
+    const readCounter = async (unifiedOrderId: string): Promise<number> => {
+      const orderService: any = getContainer().resolve(Modules.ORDER)
+      const order = await orderService.retrieveOrder(unifiedOrderId, {
+        select: ["id", "metadata"],
+      })
+      return Number(order?.metadata?.lock_test_counter ?? 0)
+    }
+
+    // One read-modify-write step: read the counter, await (forces interleaving),
+    // then write counter+1 merged with existing metadata — the exact shape the
+    // real mirrors use.
+    const incrementCounter = async (unifiedOrderId: string) => {
+      const orderService: any = getContainer().resolve(Modules.ORDER)
+      const order = await orderService.retrieveOrder(unifiedOrderId, {
+        select: ["id", "metadata"],
+      })
+      const next = Number(order?.metadata?.lock_test_counter ?? 0) + 1
+      await sleep(15)
+      await orderService.updateOrders([
+        {
+          id: unifiedOrderId,
+          metadata: { ...(order?.metadata ?? {}), lock_test_counter: next },
+        },
+      ])
+    }
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+      await createRegion()
+
+      const inventoryRes = await api.post(
+        "/admin/inventory-items",
+        { title: "Raw Cotton", sku: "RAW-COTTON-LOCK" },
+        adminHeaders
+      )
+      expect(inventoryRes.status).toBe(200)
+      inventoryItemId = inventoryRes.data.inventory_item.id
+
+      const location = await api.post(
+        "/admin/stock-locations",
+        { name: "Lock Warehouse" },
+        adminHeaders
+      )
+      stockLocationId = location.data.stock_location.id
+      const fromLocation = await api.post(
+        "/admin/stock-locations",
+        { name: "Lock Warehouse Secondary" },
+        adminHeaders
+      )
+      fromStockLocationId = fromLocation.data.stock_location.id
+    })
+
+    it("serializes concurrent metadata writes — no lost updates under the lock", async () => {
+      const container = getContainer()
+      const unifiedOrderId = await createUnifiedOrder()
+
+      await Promise.all(
+        Array.from({ length: CONCURRENCY }, () =>
+          withUnifiedOrderMetadataLock(container, unifiedOrderId, () =>
+            incrementCounter(unifiedOrderId)
+          )
+        )
+      )
+
+      // Every increment landed: the lock made each RMW atomic.
+      expect(await readCounter(unifiedOrderId)).toBe(CONCURRENCY)
+    })
+
+    it("loses updates WITHOUT the lock (control — proves the lock is load-bearing)", async () => {
+      const unifiedOrderId = await createUnifiedOrder()
+
+      // Same N concurrent RMW jobs, but unlocked: the awaited gap lets them all
+      // read the same snapshot, so writes clobber each other.
+      await Promise.all(
+        Array.from({ length: CONCURRENCY }, () =>
+          incrementCounter(unifiedOrderId)
+        )
+      )
+
+      expect(await readCounter(unifiedOrderId)).toBeLessThan(CONCURRENCY)
+    })
+
+    it("does not leak the lock — sequential writes still all land afterwards", async () => {
+      const container = getContainer()
+      const unifiedOrderId = await createUnifiedOrder()
+
+      // A burst under the lock, then sequential writes: if execute() failed to
+      // release, the next acquire would hang and time out.
+      await Promise.all(
+        Array.from({ length: CONCURRENCY }, () =>
+          withUnifiedOrderMetadataLock(container, unifiedOrderId, () =>
+            incrementCounter(unifiedOrderId)
+          )
+        )
+      )
+      await withUnifiedOrderMetadataLock(container, unifiedOrderId, () =>
+        incrementCounter(unifiedOrderId)
+      )
+      await withUnifiedOrderMetadataLock(container, unifiedOrderId, () =>
+        incrementCounter(unifiedOrderId)
+      )
+
+      expect(await readCounter(unifiedOrderId)).toBe(CONCURRENCY + 2)
+    })
+  })
+})

--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -137,6 +137,34 @@ module.exports = defineConfig({
       },
     },
 
+    // #342 PR-D (Chunk 8 / H2) — Locking Module with the Redis provider.
+    // The Locking Module's default provider is in-memory + single-process. Prod
+    // runs SPLIT server + worker tasks (MEDUSA_WORKER_MODE), so the #342
+    // per-unified-order locks (withUnifiedOrderMetadataLock, Chunk 7) must hold
+    // ACROSS processes — e.g. a partner /complete on the server racing the
+    // production-run-task-updated subscriber on the worker. In-memory would be a
+    // silent no-op for that cross-process race; Redis serializes it. Same
+    // ElastiCache Serverless Valkey cluster as the cache/event-bus/workflow-
+    // engine above. Provider ships inside @medusajs/medusa as
+    // `@medusajs/medusa/locking-redis` (NOT a separate top-level package).
+    // LOCKING_REDIS_URL lets ops isolate locks on their own Redis/db index;
+    // else reuse the existing REDIS_URL.
+    {
+      resolve: "@medusajs/medusa/locking",
+      options: {
+        providers: [
+          {
+            resolve: "@medusajs/medusa/locking-redis",
+            id: "locking-redis",
+            is_default: true,
+            options: {
+              redisUrl: process.env.LOCKING_REDIS_URL || process.env.REDIS_URL,
+            },
+          },
+        ],
+      },
+    },
+
     {
       resolve: "@medusajs/medusa/notification",
       options: {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -149,6 +149,30 @@ module.exports = defineConfig({
     //   },
     // },
 
+    // #342 PR-D (Chunk 8 / H2) — Locking Module with the Redis provider.
+    // ACTIVE in prod via medusa-config.prod.ts (prod runs split server+worker,
+    // so the #342 per-unified-order locks must hold across processes). Here in
+    // the dev/test base config it stays commented — single-process dev/test use
+    // the built-in in-memory locking provider, which needs no config. Kept as a
+    // commented block to mirror the cache/event-bus/workflow-engine-redis blocks
+    // above. The provider ships inside @medusajs/medusa as
+    // `@medusajs/medusa/locking-redis` (NOT a separate top-level package).
+    // {
+    //   resolve: "@medusajs/medusa/locking",
+    //   options: {
+    //     providers: [
+    //       {
+    //         resolve: "@medusajs/medusa/locking-redis",
+    //         id: "locking-redis",
+    //         is_default: true,
+    //         options: {
+    //           redisUrl: process.env.LOCKING_REDIS_URL || process.env.REDIS_URL,
+    //         },
+    //       },
+    //     ],
+    //   },
+    // },
+
     {
       resolve: "@medusajs/medusa/notification",
       options: {

--- a/apps/backend/src/workflows/inventory_orders/dual-write-unified-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/dual-write-unified-order.ts
@@ -104,6 +104,40 @@ type MirrorResult = {
   error?: string
 }
 
+// #342 PR-D (Chunk 7 / H1) — serialize the read-modify-write of a unified
+// order's `metadata` (chiefly `partner_status`). Every mirror does
+// retrieveOrder → spread metadata → updateOrders; two near-simultaneous
+// transitions (e.g. a partner `/complete` and the
+// `production-run-task-updated` auto-complete) otherwise both read the same
+// snapshot and the later write clobbers the earlier one (lost update). The lock
+// key is the unified order id so EVERY writer of that order's metadata contends
+// on the same key — including the non-workflow writers (the task-updated
+// subscriber + the admin cancel route), which call the mirror helpers directly
+// and so inherit the lock for free.
+//
+// Why here and not a workflow-level acquireLockStep (the doc's "preferred"):
+//   1. acquire-as-a-step throws on timeout → it would FAIL the legacy workflow,
+//      violating the best-effort "never fail the legacy path" contract. Wrapped
+//      inside each mirror's existing swallow-and-warn try/catch, a timeout is
+//      caught → the mirror is skipped, the legacy path is untouched.
+//   2. A workflow step can't cover the subscriber / admin route writers; this
+//      shared seam does.
+// `LockingService.execute` acquires, runs the job, and releases (even on throw).
+// In-memory provider today (prod runs one Fargate task); Chunk 8 (H2) wires the
+// Redis provider so the lock holds across instances before we scale out.
+const UNIFIED_ORDER_LOCK_TIMEOUT_SECONDS = 5
+
+export const withUnifiedOrderMetadataLock = <T>(
+  container: MedusaContainer,
+  unifiedOrderId: string,
+  job: () => Promise<T>
+): Promise<T> => {
+  const locking: any = container.resolve(Modules.LOCKING)
+  return locking.execute(`unified-order-metadata:${unifiedOrderId}`, job, {
+    timeout: UNIFIED_ORDER_LOCK_TIMEOUT_SECONDS,
+  })
+}
+
 // D5-3 — resolve a legacy row's unified order id by the order↔<execution>
 // link, forward (`<entity>.order`), which the Chunk 2 directionality finding
 // established as the authoritative join. This replaces reading the
@@ -349,19 +383,24 @@ export const mirrorPartnerLinkOnUnifiedOrderStep = createStep(
       ]
       await remoteLink.create(links)
 
+      // Chunk 7 — serialize the metadata RMW on the unified order id (see
+      // withUnifiedOrderMetadataLock). The remoteLink.create above is not a
+      // metadata RMW, so it stays outside the lock.
       const orderService: any = container.resolve(Modules.ORDER)
-      const unifiedOrder = await orderService.retrieveOrder(unifiedOrderId, {
-        select: ["id", "metadata"],
-      })
-      await orderService.updateOrders([
-        {
-          id: unifiedOrderId,
-          metadata: {
-            ...(unifiedOrder?.metadata ?? {}),
-            partner_status: "assigned",
+      await withUnifiedOrderMetadataLock(container, unifiedOrderId, async () => {
+        const unifiedOrder = await orderService.retrieveOrder(unifiedOrderId, {
+          select: ["id", "metadata"],
+        })
+        await orderService.updateOrders([
+          {
+            id: unifiedOrderId,
+            metadata: {
+              ...(unifiedOrder?.metadata ?? {}),
+              partner_status: "assigned",
+            },
           },
-        },
-      ])
+        ])
+      })
 
       return new StepResponse<MirrorResult>({
         linked: true,
@@ -409,24 +448,29 @@ export const mirrorUnifiedOrderStatusStep = createStep(
       const coreStatus = LEGACY_TO_CORE_STATUS[legacy.status]
       const partnerStatus = LEGACY_TO_PARTNER_STATUS[legacy.status]
 
+      // Chunk 7 — serialize the metadata RMW on the unified order id so a
+      // concurrent transition can't clobber partner_status (see
+      // withUnifiedOrderMetadataLock).
       const orderService: any = container.resolve(Modules.ORDER)
-      const unifiedOrder = await orderService.retrieveOrder(unifiedOrderId, {
-        select: ["id", "metadata"],
+      await withUnifiedOrderMetadataLock(container, unifiedOrderId, async () => {
+        const unifiedOrder = await orderService.retrieveOrder(unifiedOrderId, {
+          select: ["id", "metadata"],
+        })
+        await orderService.updateOrders([
+          {
+            id: unifiedOrderId,
+            ...(coreStatus ? { status: coreStatus } : {}),
+            ...(partnerStatus
+              ? {
+                  metadata: {
+                    ...(unifiedOrder?.metadata ?? {}),
+                    partner_status: partnerStatus,
+                  },
+                }
+              : {}),
+          },
+        ])
       })
-      await orderService.updateOrders([
-        {
-          id: unifiedOrderId,
-          ...(coreStatus ? { status: coreStatus } : {}),
-          ...(partnerStatus
-            ? {
-                metadata: {
-                  ...(unifiedOrder?.metadata ?? {}),
-                  partner_status: partnerStatus,
-                },
-              }
-            : {}),
-        },
-      ])
 
       return new StepResponse<MirrorResult>({
         linked: true,

--- a/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
+++ b/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
@@ -12,6 +12,7 @@ import {
   PARTNER_WORK_ORDERS_CHANNEL,
   resolveUnifiedOrderIdByLink,
   linkUnifiedOrderOrRollback,
+  withUnifiedOrderMetadataLock,
 } from "../inventory_orders/dual-write-unified-order"
 
 // #342 T3.2 — best-effort projection of production runs onto the core `order`
@@ -148,17 +149,30 @@ const patchUnifiedOrder = async (
   patch: { status?: string; metadata?: Record<string, unknown> }
 ) => {
   const orderService: any = container.resolve(Modules.ORDER)
+  // Chunk 7 — when the patch touches metadata, the read-then-merge must run
+  // under the per-order lock so a concurrent mirror can't clobber it (see
+  // withUnifiedOrderMetadataLock). A pure status patch (no metadata) is a
+  // single blind write with nothing to lose, so it skips the lock.
   if (patch.metadata) {
-    const current = await orderService.retrieveOrder(unifiedOrderId, {
-      select: ["id", "metadata"],
+    await withUnifiedOrderMetadataLock(container, unifiedOrderId, async () => {
+      const current = await orderService.retrieveOrder(unifiedOrderId, {
+        select: ["id", "metadata"],
+      })
+      const mergedMetadata = { ...(current?.metadata ?? {}), ...patch.metadata }
+      await orderService.updateOrders([
+        {
+          id: unifiedOrderId,
+          ...(patch.status ? { status: patch.status } : {}),
+          metadata: mergedMetadata,
+        },
+      ])
     })
-    patch.metadata = { ...(current?.metadata ?? {}), ...patch.metadata }
+    return
   }
   await orderService.updateOrders([
     {
       id: unifiedOrderId,
       ...(patch.status ? { status: patch.status } : {}),
-      ...(patch.metadata ? { metadata: patch.metadata } : {}),
     },
   ])
 }
@@ -359,34 +373,48 @@ export const mirrorRunStatusToUnifiedOrder = async (
       return { linked: false, skipped: "no_unified_order" }
     }
 
-    const orderService: any = container.resolve(Modules.ORDER)
-    const unifiedOrder = await orderService.retrieveOrder(unifiedOrderId, {
-      select: ["id", "metadata"],
-    })
-
-    // A parent order superseded by a run split stays canceled forever —
-    // the child orders carry the commercial reality.
-    if (unifiedOrder?.metadata?.superseded_by_run_ids) {
-      return { linked: false, skipped: "superseded" }
-    }
-
+    // coreStatus/partnerStatus derive from `run` (read above, a different
+    // entity), so they're computed outside the unified-order lock.
     const coreStatus = RUN_TO_CORE_STATUS[run.status]
     const partnerStatus = deriveRunPartnerStatus(run, opts)
 
-    await orderService.updateOrders([
-      {
-        id: unifiedOrderId,
-        ...(coreStatus ? { status: coreStatus } : {}),
-        ...(partnerStatus
-          ? {
-              metadata: {
-                ...(unifiedOrder?.metadata ?? {}),
-                partner_status: partnerStatus,
-              },
-            }
-          : {}),
-      },
-    ])
+    // Chunk 7 — the retrieve → superseded-check → update is one read-modify-
+    // write on the unified order's metadata; run it under the per-order lock so
+    // a concurrent transition (e.g. partner /complete racing the task-updated
+    // auto-complete, which calls this same fn) can't clobber partner_status.
+    const orderService: any = container.resolve(Modules.ORDER)
+    let superseded = false
+    await withUnifiedOrderMetadataLock(container, unifiedOrderId, async () => {
+      const unifiedOrder = await orderService.retrieveOrder(unifiedOrderId, {
+        select: ["id", "metadata"],
+      })
+
+      // A parent order superseded by a run split stays canceled forever —
+      // the child orders carry the commercial reality.
+      if (unifiedOrder?.metadata?.superseded_by_run_ids) {
+        superseded = true
+        return
+      }
+
+      await orderService.updateOrders([
+        {
+          id: unifiedOrderId,
+          ...(coreStatus ? { status: coreStatus } : {}),
+          ...(partnerStatus
+            ? {
+                metadata: {
+                  ...(unifiedOrder?.metadata ?? {}),
+                  partner_status: partnerStatus,
+                },
+              }
+            : {}),
+        },
+      ])
+    })
+
+    if (superseded) {
+      return { linked: false, skipped: "superseded" }
+    }
 
     return { linked: true, unified_order_id: unifiedOrderId }
   } catch (e: any) {

--- a/apps/docs/notes/ORDERS_UNIFICATION_342.md
+++ b/apps/docs/notes/ORDERS_UNIFICATION_342.md
@@ -296,6 +296,29 @@ as the discriminator/pointer. Instead:
 - [ ] **Chunk 9 (T4)** — Backfill historicals (idempotent on link), repoint §4
   deviation + ancillary links, legacy routes → shims, quiet retirement. Needs
   its own planning pass. *(blocked by: 3, 6, 7)*
+- [ ] **Chunk 9b (T4) — promote `metadata.partner_status` to a typed column;
+  then RETIRE the Chunk-7 lock.** This is the structural follow-through on PR-D
+  and the direct application of [[feedback_no_critical_data_in_metadata]]:
+  `partner_status` is the ONLY high-frequency-mutated unification key (written on
+  every lifecycle transition); the other metadata keys (`legacy_id`,
+  `source_*`, `superseded_by_run_ids`) are all write-once at projection.
+  - **We will likely have to get rid of `metadata.partner_status` in the end.**
+    PR-D's `withUnifiedOrderMetadataLock` is the correct *interim* hardening — it
+    serializes the read-modify-write so no transition is lost — but the
+    lower-risk, lower-overhead end-state is a typed column where a single-column
+    UPDATE is atomic at the DB level (no RMW, no lost-update, no lock) AND panels
+    can filter/sort natively instead of querying JSON.
+  - **Can't add a column to `order` directly** (Medusa-owned table). Path: a
+    small 1:1 order-linked sidecar model (e.g. `unified_order_status {
+    partner_status, ... }`). Work = model + migration (hand-written
+    `add column if not exists` per [[reference_medusa_migration_create_if_not_exists_hazard]])
+    + repoint the mirror WRITES (the 4 sites PR-D wrapped) + repoint the panel/
+    list READS + backfill historicals (fold into the Chunk-9 backfill pass).
+  - **Once `partner_status` is a column, the remaining metadata writes are all
+    write-once-at-create (no concurrency) → the Chunk-7 lock + the Chunk-8 Redis
+    provider registration can be removed.** Sequence the lock removal AFTER the
+    column read/write repoint + backfill land and are verified, not before.
+  *(blocked by: 7, 8, and the Chunk-9 backfill)*
 
 **Cross-cutting (not a unification chunk — QA + marketing):**
 - [ ] **Playwright stage-by-stage walkthrough + screenshots.** Drive the partner
@@ -615,11 +638,16 @@ chat history.*
          *now*, but wiring Redis is the correct fix and unblocks scaling out.
          This must land before we run >1 backend instance.
     4. **Promote the highest-risk keys to typed columns** (the D2 "revisit if
-       needed" trigger): `kind` (filtered by the admin-list work, item 3 below)
-       and `partner_status` (written on every transition, read by panels) are
+       needed" trigger): `kind` (now retired — link-discriminated since Chunk 6)
+       and `partner_status` (written on every transition, read by panels) were
        the strongest candidates. `legacy_id` + the `unified_order_id` backrefs
        are write-once (lower mutation risk) but are the backfill/idempotency
        anchor — a real indexed column is safer than a JSON key for T4 dedup.
+       **→ `partner_status` promotion is now tracked as Chunk 9b (T4): move it to
+       a 1:1 order-linked sidecar model, repoint reads/writes + backfill, then
+       retire the PR-D Chunk-7 lock. We will likely get rid of
+       `metadata.partner_status` entirely in the end** — PR-D's lock is the
+       interim hardening, the column is the structural fix.
 - **Remaining T3 deliverable(s)** (suggested order):
   1. ~~status mirror per §5~~ — DONE (T3.1),
   2. ~~design-side dual-write for production runs~~ — DONE (T3.2, see above),

--- a/apps/docs/notes/ORDERS_UNIFICATION_342.md
+++ b/apps/docs/notes/ORDERS_UNIFICATION_342.md
@@ -55,7 +55,7 @@ as the discriminator/pointer. Instead:
 | **PR-A** | 1 + 2 + 3 | D5 link adoption: define → write → read (avoid a half-state on main where links exist but are unused) | **MERGED — PR #392** (2026-06-13, merge `c4d03469a`; auto-deploys to prod) |
 | **PR-B** | 4 + 5 | Unified surfacing: admin retail filter + partner panels | **OPEN — PR #393 (draft)** (2026-06-13), `feat/342-pr-b-unified-surfacing`. Chunk 4 + 5 both done, pushed. Both specs green. |
 | **PR-C** | 6 | Metadata-write cleanup (after A + B prove links are the sole path) | **OPEN — PR #394 (draft)** on `feat/342-pr-c-metadata-cleanup`. Stopped writing `metadata.kind` + `unified_order_id`; execution link-create made authoritative w/ order rollback. All 4 unification specs green (20 tests). |
-| **PR-D** | 7 + 8 | Concurrency hardening: locking + Redis provider (parallel track, independent of A–C) | not started |
+| **PR-D** | 7 + 8 | Concurrency hardening: locking + Redis provider (parallel track, independent of A–C) | **DONE (uncommitted→committing)** on `feat/342-pr-d-locking`. Chunk 7 + 8 both done. New spec `orders-unification-locking.spec.ts` 3/3 green; inventory+design dual-write specs 12/12 green (regression). |
 | **PR-E** | 9 | T4 backfill + retirement (own planning pass) | not started |
 
 - [x] **Chunk 1 (D5-1)** — Define `filterable` links + ingest. New
@@ -248,13 +248,51 @@ as the discriminator/pointer. Instead:
   absent from metadata + no backref on the legacy row). All 4 unification specs
   green (12 + 8 = 20). *(blocked by: 3, 4 — both done)* *(NEXT: PR-D locking is
   independent; Chunk 9/T4 still pending.)*
-- [ ] **Chunk 7 (H1)** — Locking on the dual-write/mirror read-modify-write
+- [x] **Chunk 7 (H1)** — Locking on the dual-write/mirror read-modify-write
   (`partner_status` race), key = unified order id, ALL writers share it, inside
-  the swallow-and-warn boundary. Pattern: `complete-production-run.ts`.
+  the swallow-and-warn boundary. **DONE** (PR-D, branch `feat/342-pr-d-locking`).
+  Implemented as one shared helper `withUnifiedOrderMetadataLock(container,
+  unifiedOrderId, job)` in `inventory_orders/dual-write-unified-order.ts` that
+  wraps `Modules.LOCKING.execute("unified-order-metadata:<id>", job, { timeout:
+  5 })`. **Chose the lowest-RMW-layer seam over the doc's "preferred" workflow-
+  level acquireLockStep** because (a) an acquire-as-a-step throws on timeout and
+  would FAIL the legacy workflow — wrapped inside each mirror's existing
+  swallow-and-warn try/catch instead, a timeout just skips the mirror; and (b) a
+  workflow step can't cover the non-workflow writers (the `production-run-task-
+  updated` subscriber + the admin cancel route), which call the mirror helpers
+  directly and so inherit the lock for free. Wrapped sites: inventory
+  `mirrorPartnerLinkOnUnifiedOrderStep` + `mirrorUnifiedOrderStatusStep`;
+  production-run `patchUnifiedOrder` (metadata branch only — pure-status patches
+  skip the lock) + `mirrorRunStatusToUnifiedOrder` (retrieve→superseded-check→
+  update is one locked RMW). Create paths are single-shot (fresh order) → not
+  locked. Spec `orders-unification-locking.spec.ts` proves serialization with a
+  load-bearing control (same N concurrent RMW jobs WITHOUT the lock lose updates).
   *(blocked by: none — parallel to the link work)*
-- [ ] **Chunk 8 (H2)** — Register `@medusajs/locking-redis` in medusa-config
-  (prod env-gated, in-memory fallback for dev). Must precede scaling >1 backend
-  instance. *(blocked by: 7)*
+- [x] **Chunk 8 (H2)** — Register the Redis locking provider in medusa-config
+  (prod env-gated, in-memory fallback for dev). **DONE** (PR-D). **Correction to
+  the original direction:** the provider is NOT a separate `@medusajs/locking-
+  redis` top-level dep — it ships inside `@medusajs/medusa@2.15.5`, resolvable as
+  `@medusajs/medusa/locking-redis` (the locking module is `@medusajs/medusa/
+  locking`). No package.json change needed. **GOTCHA — there are TWO config
+  files: prod runs `medusa-config.prod.ts` (the Dockerfile does `RUN cp
+  medusa-config.prod.ts medusa-config.ts` at build), NOT the base
+  `medusa-config.ts` that dev/test load.** So the ACTIVE locking registration
+  lives in `medusa-config.prod.ts` (added unconditionally next to the existing
+  active `caching-redis`/`event-bus-redis`/`workflow-engine-redis` modules,
+  `redisUrl: LOCKING_REDIS_URL || REDIS_URL`); the base config keeps it as a
+  COMMENTED block (dev/test are single-process → built-in in-memory provider, no
+  config). Prod already wires Redis fully (ElastiCache Serverless Valkey cluster
+  `jyt-spaces-1ufoes`, TLS/`rediss://`, SSM secret `/jyt/prod/REDIS_URL` injected
+  into BOTH the `medusa-server` + `medusa-worker` Fargate tasks). **Why Redis
+  matters here specifically:** prod runs SPLIT server+worker (`MEDUSA_WORKER_MODE`
+  read from env even though the config line was historically commented — Medusa
+  framework reads it: `@medusajs/framework/.../config.js`), so the partner
+  `/complete` (server) vs `production-run-task-updated` subscriber (worker) race
+  spans TWO processes — in-memory locking would be a silent no-op for it. No new
+  SSM secret needed (reuses REDIS_URL; if ops add LOCKING_REDIS_URL it must carry
+  the copilot-application/environment tags per reference_copilot_ssm_tag_requirement).
+  Provider options: `{ redisUrl }` (loader also accepts `redisOptions`,
+  `namespace`; default key prefix `medusa_lock:`). *(blocked by: 7)*
 - [ ] **Chunk 9 (T4)** — Backfill historicals (idempotent on link), repoint §4
   deviation + ancillary links, legacy routes → shims, quiet retirement. Needs
   its own planning pass. *(blocked by: 3, 6, 7)*
@@ -558,7 +596,10 @@ chat history.*
          subscriber) must take the SAME lock — a lock only one writer respects
          is useless.
     3a. **INFRA TASK — enable the Redis locking provider in prod (added
-       2026-06-13).** The default in-memory locking provider is single-process
+       2026-06-13; DONE in PR-D/Chunk 8 — env-gated on
+       `LOCKING_REDIS_URL || REDIS_URL`; package-name correction below: it's
+       `@medusajs/medusa/locking-redis`, bundled in `@medusajs/medusa`, NOT a
+       separate `@medusajs/locking-redis` dep).** The default in-memory locking provider is single-process
        only, so item 3's lock is a no-op across instances. Prod already has a
        working Redis instance, so before (or alongside) shipping the locks:
        register the Redis locking provider in `medusa-config` for prod.

--- a/apps/docs/notes/ORDERS_UNIFICATION_342.md
+++ b/apps/docs/notes/ORDERS_UNIFICATION_342.md
@@ -55,8 +55,11 @@ as the discriminator/pointer. Instead:
 | **PR-A** | 1 + 2 + 3 | D5 link adoption: define → write → read (avoid a half-state on main where links exist but are unused) | **MERGED — PR #392** (2026-06-13, merge `c4d03469a`; auto-deploys to prod) |
 | **PR-B** | 4 + 5 | Unified surfacing: admin retail filter + partner panels | **OPEN — PR #393 (draft)** (2026-06-13), `feat/342-pr-b-unified-surfacing`. Chunk 4 + 5 both done, pushed. Both specs green. |
 | **PR-C** | 6 | Metadata-write cleanup (after A + B prove links are the sole path) | **OPEN — PR #394 (draft)** on `feat/342-pr-c-metadata-cleanup`. Stopped writing `metadata.kind` + `unified_order_id`; execution link-create made authoritative w/ order rollback. All 4 unification specs green (20 tests). |
-| **PR-D** | 7 + 8 | Concurrency hardening: locking + Redis provider (parallel track, independent of A–C) | **DONE (uncommitted→committing)** on `feat/342-pr-d-locking`. Chunk 7 + 8 both done. New spec `orders-unification-locking.spec.ts` 3/3 green; inventory+design dual-write specs 12/12 green (regression). |
-| **PR-E** | 9 | T4 backfill + retirement (own planning pass) | not started |
+| **PR-D** | 7 + 8 | Concurrency hardening: locking + Redis provider (parallel track, independent of A–C) | **OPEN — PR #395 (draft)** on `feat/342-pr-d-locking` (2026-06-13). Chunk 7 + 8 done, pushed. New spec `orders-unification-locking.spec.ts` 3/3 green; inventory+design dual-write specs 12/12 green (regression). **Prereq for PR-E…H (9/9b sequence after it).** |
+| **PR-E** | 9 | T4 backfill (link-only) + retire the 4 `unified_order_id` fallback reads | planned (2026-06-14) — see "T4 plan" below |
+| **PR-F** | 9b-expand | New `unified_order_status` 1:1 sidecar column + dual-write both column & metadata + backfill | planned (2026-06-14) |
+| **PR-G** | 9b-migrate | Repoint the 2 `metadata.partner_status` read sites to the column | planned (2026-06-14) |
+| **PR-H** | 9b-contract | Stop writing `metadata.partner_status`; remove the Chunk-7 lock wrapping (KEEP Redis provider) | planned (2026-06-14) |
 
 - [x] **Chunk 1 (D5-1)** — Define `filterable` links + ingest. New
   `src/links/order-production-run.ts` + `order-inventory-order.ts`, execution
@@ -293,32 +296,62 @@ as the discriminator/pointer. Instead:
   the copilot-application/environment tags per reference_copilot_ssm_tag_requirement).
   Provider options: `{ redisUrl }` (loader also accepts `redisOptions`,
   `namespace`; default key prefix `medusa_lock:`). *(blocked by: 7)*
-- [ ] **Chunk 9 (T4)** — Backfill historicals (idempotent on link), repoint §4
-  deviation + ancillary links, legacy routes → shims, quiet retirement. Needs
-  its own planning pass. *(blocked by: 3, 6, 7)*
-- [ ] **Chunk 9b (T4) — promote `metadata.partner_status` to a typed column;
-  then RETIRE the Chunk-7 lock.** This is the structural follow-through on PR-D
-  and the direct application of [[feedback_no_critical_data_in_metadata]]:
-  `partner_status` is the ONLY high-frequency-mutated unification key (written on
-  every lifecycle transition); the other metadata keys (`legacy_id`,
-  `source_*`, `superseded_by_run_ids`) are all write-once at projection.
-  - **We will likely have to get rid of `metadata.partner_status` in the end.**
-    PR-D's `withUnifiedOrderMetadataLock` is the correct *interim* hardening — it
-    serializes the read-modify-write so no transition is lost — but the
-    lower-risk, lower-overhead end-state is a typed column where a single-column
-    UPDATE is atomic at the DB level (no RMW, no lost-update, no lock) AND panels
-    can filter/sort natively instead of querying JSON.
-  - **Can't add a column to `order` directly** (Medusa-owned table). Path: a
-    small 1:1 order-linked sidecar model (e.g. `unified_order_status {
-    partner_status, ... }`). Work = model + migration (hand-written
-    `add column if not exists` per [[reference_medusa_migration_create_if_not_exists_hazard]])
-    + repoint the mirror WRITES (the 4 sites PR-D wrapped) + repoint the panel/
-    list READS + backfill historicals (fold into the Chunk-9 backfill pass).
-  - **Once `partner_status` is a column, the remaining metadata writes are all
-    write-once-at-create (no concurrency) → the Chunk-7 lock + the Chunk-8 Redis
-    provider registration can be removed.** Sequence the lock removal AFTER the
-    column read/write repoint + backfill land and are verified, not before.
-  *(blocked by: 7, 8, and the Chunk-9 backfill)*
+### T4 plan — Chunks 9 + 9b (planned 2026-06-14, scope confirmed with user)
+
+**Scope decisions (2026-06-14):** (1) backfill is **link-only** — covers rows already
+projected (have `metadata.unified_order_id`); pre-T2 legacy rows never projected stay
+legacy-only (not surfaced as unified). (2) **"legacy routes → shims" + ancillary-link
+repoint (tasks/internal-payments/feedback/inbound-email) are DESCOPED** from #342 —
+the execution rows (`production_run`/`inventory_order`) stay authoritative per D1, so
+those links remain valid; only revisit if we ever delete the legacy execution rows.
+(3) Ships as **4 PRs E/F/G/H** (each merge = a prod deploy → strict expand→migrate→contract).
+
+**Two corrections to the earlier notes (verified in code 2026-06-14):**
+- ❗ The **Chunk-8 Redis locking provider must STAY.** `complete-production-run.ts`
+  (`:134`, `:255`) and the `production-run-task-updated` subscriber (`:95`) resolve
+  `Modules.LOCKING` independently of unification. Only the **Chunk-7
+  `withUnifiedOrderMetadataLock` wrapping** is removed in PR-H, NOT the provider.
+- The `metadata.partner_status` **READ** surface is only **2 sites**, not 5:
+  `api/partners/orders/route.ts` (badge field) + partner-ui
+  `routes/orders/order-list/.../order-list-table.tsx`. The inventory-detail and
+  designs routes already derive partner status from tasks/runs — untouched.
+
+- [ ] **Chunk 9 → PR-E (T4 backfill + fallback retirement).** *(blocked by: PR-D)*
+  - New `medusa exec` script `src/scripts/backfill-unified-order-links.ts`:
+    `--dry-run`, paginated, per-row try/catch. For `inventory_orders` and
+    `production_runs` where `metadata.unified_order_id` is set but the D5
+    `order.id` link is absent → `remoteLink.create` the link (model Pattern C —
+    `backfill-store-customers.ts`). Idempotent (skip if `order.id` already present).
+  - Run dry-run then live in prod; verify `count(unified_order_id set AND no link) == 0`.
+  - Then DELETE the 4 fallback reads (`?? …unified_order_id`): `dual-write-unified-order.ts:162`,
+    `:440`; `dual-write-unified-run-order.ts:213`; `api/admin/orders/route.ts:45`.
+    Each becomes link-only. Update the dual-write specs (drop fallback assertions).
+- [ ] **Chunk 9b → PR-F (expand: column + dual-write + backfill).** *(blocked by: 7, 8, PR-E)*
+  - New 1:1 sidecar module `src/modules/unified_order_status` (model/service/index),
+    model `unified_order_status { id (prefix "uos"), partner_status: enum(assigned,
+    accepted, in_progress, finished, partial, completed, declined), updated_at }`.
+    Link `src/links/order-unified-status.ts` (`isList:false`, `filterable:["id"]`).
+    Create-table migration (generated); future column adds hand-written
+    `add column if not exists` per [[reference_medusa_migration_create_if_not_exists_hazard]].
+  - Atomic upsert helper `setUnifiedOrderPartnerStatus(container, orderId, status)` —
+    find-or-create sidecar row, single-column write (no RMW → no lock needed).
+  - Wire the 4 mirror WRITE sites + the create-path projection to write **BOTH** the
+    column (via helper) AND keep `metadata.partner_status` (still under the existing
+    lock) — belt-and-suspenders during expand.
+  - Backfill script (or extend PR-E's): every order with `metadata.partner_status`
+    → upsert the sidecar row. Idempotent.
+- [ ] **Chunk 9b → PR-G (migrate reads).** *(blocked by: PR-F)*
+  - Repoint the 2 read sites to `unified_order_statuses.partner_status`
+    (keep metadata fallback transitionally): backend `api/partners/orders/route.ts`,
+    partner-ui `order-list-table.tsx`. Verify panels render off the column in prod.
+- [ ] **Chunk 9b → PR-H (contract: retire metadata + lock).** *(blocked by: PR-G verified)*
+  - Stop writing `metadata.partner_status` in the 4 sites + create path (column-only).
+  - Remove the `withUnifiedOrderMetadataLock` wrapping from the 4 sites + delete the
+    helper — remaining metadata writes are write-once-at-create (no RMW), safe unlocked.
+    **KEEP the Chunk-8 Redis provider** (other LOCKING consumers, see correction above).
+  - Remove the metadata fallback reads from PR-G; drop `partner_status` from
+    `PROTECTED_UNIFICATION_METADATA_KEYS` if still present. Optional metadata-cleanup
+    backfill to strip stale `metadata.partner_status`.
 
 **Cross-cutting (not a unification chunk — QA + marketing):**
 - [ ] **Playwright stage-by-stage walkthrough + screenshots.** Drive the partner


### PR DESCRIPTION
## #342 PR-D — Chunks 7 + 8 (concurrency hardening)

Parallel hardening track for orders unification (#342), independent of PR-A/B/C. Addresses the read-modify-write race the metadata-as-critical-data audit flagged.

### Chunk 7 (H1) — lock the unified-order metadata RMW
Every #342 mirror does `retrieveOrder → spread metadata → updateOrders`. Two near-simultaneous transitions (e.g. a partner `/complete` racing the `production-run-task-updated` auto-complete) both read the same snapshot and the later write clobbers `partner_status` (lost update).

New shared helper **`withUnifiedOrderMetadataLock(container, unifiedOrderId, job)`** serializes that RMW via `Modules.LOCKING.execute("unified-order-metadata:<id>", job, { timeout: 5 })`, so every writer of the same order contends on one lock.

**Design choice — lowest RMW layer, not workflow-level `acquireLockStep`:**
1. An acquire-as-a-step throws on timeout → would **fail the legacy workflow**. Wrapped inside each mirror's existing swallow-and-warn `try/catch`, a timeout just skips the mirror — the legacy path is never failed.
2. The non-workflow writers (the task-updated subscriber + the admin cancel route) call the mirror helpers directly, so they **inherit the same lock for free** — a workflow step couldn't cover them.

Wrapped sites:
- inventory: `mirrorPartnerLinkOnUnifiedOrderStep`, `mirrorUnifiedOrderStatusStep`
- production-run: `patchUnifiedOrder` (metadata branch only; pure-status patches skip the lock), `mirrorRunStatusToUnifiedOrder` (retrieve→superseded-check→update as one locked RMW)
- create paths stay unlocked (single-shot, fresh order — nothing to race)

### Chunk 8 (H2) — Redis locking provider, env-gated
The default locking provider is in-memory + single-process, so the Chunk 7 locks only serialize within one backend process. Registers the Redis provider whenever a locking Redis URL is present, so locks hold **across instances before we scale past one Fargate task**. Dev/test fall back to the built-in in-memory provider (no config).

- **Correction to the original direction:** the provider ships inside `@medusajs/medusa@2.15.5` as `@medusajs/medusa/locking-redis` (module `@medusajs/medusa/locking`) — **NOT** a separate `@medusajs/locking-redis` dep. No `package.json` change.
- Gated on `LOCKING_REDIS_URL || REDIS_URL` (dedicated var preferred; else reuse existing `REDIS_URL`).

### Tests
- New `orders-unification-locking.spec.ts` — **3/3 green**. Proves serialization (N concurrent increments all land) with a **load-bearing control** (same jobs without the lock lose updates) + a no-leak check.
- Regression: inventory + design dual-write specs **12/12 green** (both locked mirror paths exercised through real workflows).

### Notes
- Auto-deploys to prod on merge. Lock is a no-op safety win today (single task) and unblocks horizontal scaling.
- Full handoff: `apps/docs/notes/ORDERS_UNIFICATION_342.md` (Chunks 7+8 marked done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)