### PR TITLE
fix(admin): design detail 500 — customer.* → customers.* (invalid query.graph accessor)

### DIFF
--- a/apps/backend/src/admin/routes/designs/[id]/constants.ts
+++ b/apps/backend/src/admin/routes/designs/[id]/constants.ts
@@ -1,2 +1,7 @@
+// NOTE: the design↔customer link is `isList: true` (a design can be linked to
+// multiple customers via orders), so query.graph's accessor is the PLURAL
+// `customers` — `customer.*` makes query.graph forward an unknown relation to
+// MikroORM populate and 500 ("Entity 'Design' does not have property 'customer'").
+// Newer Medusa (2.15.x) rejects this where it was previously tolerated.
 export const DESIGN_DETAIL_FIELDS =
-  "inventory_items.*, tasks.*, tasks.outgoing.*, tasks.incoming.*, partners.*, colors.*, size_sets.*, customer.*";
+  "inventory_items.*, tasks.*, tasks.outgoing.*, tasks.incoming.*, partners.*, colors.*, size_sets.*, customers.*";


### PR DESCRIPTION
## Symptom
`GET /admin/designs/:id?fields=...,customer.*` returns **HTTP 500**:
```
ValidationError: Entity 'Design' does not have property 'customer'
  at MikroORM preparePopulate ...
```
Surfaces as the admin **design detail page failing to load** (the route loader prefetches the design).

## Root cause
The design detail route loader (`src/admin/routes/designs/[id]/loader.ts`) fetches with `DESIGN_DETAIL_FIELDS`, whose last entry was `customer.*`. The design↔customer link (`src/links/design-customer-link.ts`) is **`isList: true`**, so query.graph's accessor is the **plural `customers`**. Singular `customer` is not a known relation, so query.graph forwards it to the designs module's MikroORM `populate`, which throws → 500.

The field has been there since the file was created — it became **fatal under Medusa 2.15.x**, which rejects unknown relations the older query layer silently tolerated ("it suddenly stopped working"). Not related to the in-flight #342 orders-unification work.

## Fix
`customer.*` → `customers.*` (the correct `isList` accessor) in `DESIGN_DETAIL_FIELDS`.

## Verification (local, admin@jyt.com)
- `GET /admin/designs/:id?fields=...,customer.*` → **500** (reproduced)
- `GET /admin/designs/:id?fields=...,customers.*` → **200** ✅
- list / detail / all other detail subroutes unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)