### PR TITLE
feat(orders): #342 PR-F Chunk 9b-expand — unified_order_status sidecar column

### DIFF
--- a/apps/backend/integration-tests/http/orders-unification-status-column.spec.ts
+++ b/apps/backend/integration-tests/http/orders-unification-status-column.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * #342 Chunk 9b (PR-F) — promote `partner_status` onto a typed sidecar column.
+ *
+ * PR-F is the EXPAND step of an expand→migrate→contract column swap: every
+ * status transition now writes BOTH `order.metadata.partner_status` (still the
+ * authoritative read surface until PR-G) AND the new 1:1 `unified_order_status`
+ * sidecar row, linked via order↔unified_order_status. This proves the column
+ * tracks the metadata: after each transition the sidecar's partner_status equals
+ * metadata.partner_status, and repeated transitions UPDATE the one row (the
+ * find-or-create upsert never forks a second sidecar).
+ */
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(60000)
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Orders unification status column (#342 PR-F / Chunk 9b)", () => {
+    let adminHeaders: any
+    let inventoryItemId: string
+    let stockLocationId: string
+    let fromStockLocationId: string
+
+    const createRegion = async () => {
+      const regionService: any = getContainer().resolve(Modules.REGION)
+      const region = await regionService.createRegions({
+        name: "India",
+        currency_code: "inr",
+        countries: ["in"],
+      })
+      return region.id
+    }
+
+    const createLegacyOrder = async () => {
+      const res = await api.post(
+        "/admin/inventory-orders",
+        {
+          order_lines: [
+            { inventory_item_id: inventoryItemId, quantity: 1, price: 100 },
+          ],
+          quantity: 1,
+          total_price: 100,
+          status: "Pending",
+          expected_delivery_date: new Date().toISOString(),
+          order_date: new Date().toISOString(),
+          shipping_address: {
+            first_name: "JYT",
+            address_1: "Mill Road 1",
+            city: "Jaipur",
+            country_code: "in",
+            postal_code: "302001",
+          },
+          stock_location_id: stockLocationId,
+          from_stock_location_id: fromStockLocationId,
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      return res.data.inventoryOrder
+    }
+
+    const resolveUnifiedViaLink = async (
+      legacyId: string
+    ): Promise<string | undefined> => {
+      const query: any = getContainer().resolve(ContainerRegistrationKeys.QUERY)
+      const { data } = await query.graph({
+        entity: "inventory_orders",
+        filters: { id: legacyId },
+        fields: ["id", "order.id"],
+      })
+      return data?.[0]?.order?.id ?? undefined
+    }
+
+    // Read the unified order's metadata + its linked sidecar status in one shot.
+    const readStatuses = async (unifiedOrderId: string) => {
+      const query: any = getContainer().resolve(ContainerRegistrationKeys.QUERY)
+      const { data } = await query.graph({
+        entity: "order",
+        filters: { id: unifiedOrderId },
+        fields: [
+          "id",
+          "metadata",
+          "unified_order_status.id",
+          "unified_order_status.partner_status",
+        ],
+      })
+      return {
+        metaStatus: data?.[0]?.metadata?.partner_status,
+        sidecar: data?.[0]?.unified_order_status,
+      }
+    }
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+
+      const inventoryRes = await api.post(
+        "/admin/inventory-items",
+        { title: "Raw Cotton", sku: "RAW-COTTON-KG" },
+        adminHeaders
+      )
+      expect(inventoryRes.status).toBe(200)
+      inventoryItemId = inventoryRes.data.inventory_item.id
+
+      const toLocation = await api.post(
+        "/admin/stock-locations",
+        { name: "Main Warehouse" },
+        adminHeaders
+      )
+      stockLocationId = toLocation.data.stock_location.id
+      const fromLocation = await api.post(
+        "/admin/stock-locations",
+        { name: "Secondary Warehouse" },
+        adminHeaders
+      )
+      fromStockLocationId = fromLocation.data.stock_location.id
+    })
+
+    it("writes partner_status to BOTH metadata and the sidecar column, updating one row across transitions", async () => {
+      await createRegion()
+      const legacy = await createLegacyOrder()
+      const unifiedOrderId = await resolveUnifiedViaLink(legacy.id)
+      expect(unifiedOrderId).toBeTruthy()
+
+      // Create-time: no partner assigned yet → no partner_status on either
+      // surface (the §5 work dimension only exists once work is tracked).
+      let snap = await readStatuses(unifiedOrderId!)
+      expect(snap.metaStatus).toBeUndefined()
+      expect(snap.sidecar).toBeFalsy()
+
+      // Pending → Processing → §5 partner_status "in_progress" on BOTH surfaces.
+      const res1 = await api.put(
+        `/admin/inventory-orders/${legacy.id}`,
+        { status: "Processing" },
+        adminHeaders
+      )
+      expect(res1.status).toBe(200)
+      snap = await readStatuses(unifiedOrderId!)
+      expect(snap.metaStatus).toBe("in_progress")
+      expect(snap.sidecar?.partner_status).toBe("in_progress")
+      const sidecarId = snap.sidecar?.id
+      expect(sidecarId).toBeTruthy()
+
+      // Processing → Shipped → "finished": the SAME sidecar row is updated
+      // (find-or-create upserts; it never forks a second row).
+      const res2 = await api.put(
+        `/admin/inventory-orders/${legacy.id}`,
+        { status: "Shipped" },
+        adminHeaders
+      )
+      expect(res2.status).toBe(200)
+      snap = await readStatuses(unifiedOrderId!)
+      expect(snap.metaStatus).toBe("finished")
+      expect(snap.sidecar?.partner_status).toBe("finished")
+      expect(snap.sidecar?.id).toBe(sidecarId)
+    })
+  })
+})

--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -447,5 +447,8 @@ module.exports = defineConfig({
   {
     resolve: "./src/modules/fx_rates",
   },
+  {
+    resolve: "./src/modules/unified_order_status",
+  },
 ],
 });

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -126,6 +126,9 @@ module.exports = defineConfig({
     {
       resolve: "./src/modules/ai_usage",
     },
+    {
+      resolve: "./src/modules/unified_order_status",
+    },
 
     // Production-ready modules
     // {

--- a/apps/backend/src/links/order-unified-status.ts
+++ b/apps/backend/src/links/order-unified-status.ts
@@ -1,0 +1,26 @@
+import { defineLink } from "@medusajs/framework/utils"
+import OrderModule from "@medusajs/medusa/order"
+import UnifiedOrderStatusModule from "../modules/unified_order_status"
+
+// #342 Chunk 9b (PR-F): the unified core `order` ↔ its `unified_order_status`
+// sidecar row. 1:1 — an order has zero or one status row (presence means the
+// order has reached a partner-tracked state). Promotes the load-bearing
+// `order.metadata.partner_status` off the metadata blob onto a typed column
+// (see the model for the why + feedback_no_critical_data_in_metadata).
+//
+// Exposed on the order as `unified_order_status` so the partner panels (PR-G)
+// can pull the status in one query.graph call:
+//   fields: ["id", "unified_order_status.partner_status"]
+//
+// `filterable: ["id"]` ingests the sidecar side into the Index Module so a
+// future list filter on link existence stays possible; the transactional
+// upsert (setUnifiedOrderPartnerStatus) resolves the row via query.graph, which
+// is authoritative (the index is eventually consistent).
+export default defineLink(
+  OrderModule.linkable.order,
+  {
+    linkable: UnifiedOrderStatusModule.linkable.unifiedOrderStatus,
+    filterable: ["id"],
+    field: "unified_order_status",
+  }
+)

--- a/apps/backend/src/modules/unified_order_status/index.ts
+++ b/apps/backend/src/modules/unified_order_status/index.ts
@@ -1,0 +1,11 @@
+import { Module } from "@medusajs/framework/utils"
+import UnifiedOrderStatusService from "./service"
+
+export const UNIFIED_ORDER_STATUS_MODULE = "unified_order_status"
+
+const UnifiedOrderStatusModule = Module(UNIFIED_ORDER_STATUS_MODULE, {
+  service: UnifiedOrderStatusService,
+})
+
+export { UnifiedOrderStatusModule }
+export default UnifiedOrderStatusModule

--- a/apps/backend/src/modules/unified_order_status/migrations/.snapshot-unified-order-status.json
+++ b/apps/backend/src/modules/unified_order_status/migrations/.snapshot-unified-order-status.json
@@ -1,0 +1,127 @@
+{
+  "namespaces": [
+    "public"
+  ],
+  "name": "public",
+  "tables": [
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "partner_status": {
+          "name": "partner_status",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [
+            "assigned",
+            "accepted",
+            "in_progress",
+            "finished",
+            "partial",
+            "completed",
+            "declined"
+          ],
+          "mappedType": "enum"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": "now()",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": "now()",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        }
+      },
+      "name": "unified_order_status",
+      "schema": "public",
+      "indexes": [
+        {
+          "keyName": "IDX_unified_order_status_deleted_at",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "CREATE INDEX IF NOT EXISTS \"IDX_unified_order_status_deleted_at\" ON \"unified_order_status\" (\"deleted_at\") WHERE deleted_at IS NULL"
+        },
+        {
+          "keyName": "unified_order_status_pkey",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {},
+      "nativeEnums": {}
+    }
+  ],
+  "nativeEnums": {}
+}

--- a/apps/backend/src/modules/unified_order_status/migrations/Migration20260614184932.ts
+++ b/apps/backend/src/modules/unified_order_status/migrations/Migration20260614184932.ts
@@ -1,0 +1,14 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+export class Migration20260614184932 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table if not exists "unified_order_status" ("id" text not null, "partner_status" text check ("partner_status" in ('assigned', 'accepted', 'in_progress', 'finished', 'partial', 'completed', 'declined')) not null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "unified_order_status_pkey" primary key ("id"));`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_unified_order_status_deleted_at" ON "unified_order_status" ("deleted_at") WHERE deleted_at IS NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "unified_order_status" cascade;`);
+  }
+
+}

--- a/apps/backend/src/modules/unified_order_status/models/unified-order-status.ts
+++ b/apps/backend/src/modules/unified_order_status/models/unified-order-status.ts
@@ -1,0 +1,32 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * #342 Chunk 9b (PR-F) — 1:1 sidecar row holding a unified order's
+ * partner-facing work-progress status, promoted OFF `order.metadata.partner_status`.
+ *
+ * Why a separate table (not the order's metadata)
+ *   `partner_status` is load-bearing, mutated state that the partner panels read.
+ *   Medusa's `updateOrders` REPLACES the whole metadata blob, so two concurrent
+ *   mirrors racing a read-then-merge can lose an update (the very hazard PR-D's
+ *   `withUnifiedOrderMetadataLock` guards). A typed 1:1 column is a single-column
+ *   write — no read-modify-write, so no lock is needed once reads move off
+ *   metadata (PR-G/PR-H). See feedback_no_critical_data_in_metadata.
+ *
+ * Row presence = "this order has reached a partner-tracked state". The order↔
+ * unified_order_status link (src/links/order-unified-status.ts) is the 1:1
+ * pointer; `partner_status` is the shared §5 vocabulary the T3 panels key on.
+ */
+const UnifiedOrderStatus = model.define("unified_order_status", {
+  id: model.id({ prefix: "uos" }).primaryKey(),
+  partner_status: model.enum([
+    "assigned",
+    "accepted",
+    "in_progress",
+    "finished",
+    "partial",
+    "completed",
+    "declined",
+  ]),
+})
+
+export default UnifiedOrderStatus

--- a/apps/backend/src/modules/unified_order_status/service.ts
+++ b/apps/backend/src/modules/unified_order_status/service.ts
@@ -1,0 +1,6 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import UnifiedOrderStatus from "./models/unified-order-status"
+
+class UnifiedOrderStatusService extends MedusaService({ UnifiedOrderStatus }) {}
+
+export default UnifiedOrderStatusService

--- a/apps/backend/src/scripts/backfill-unified-order-status.ts
+++ b/apps/backend/src/scripts/backfill-unified-order-status.ts
@@ -1,0 +1,92 @@
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { setUnifiedOrderPartnerStatus } from "../workflows/inventory_orders/dual-write-unified-order"
+
+/**
+ * #342 Chunk 9b (PR-F / T4) — backfill the `unified_order_status` sidecar column
+ * from the existing `order.metadata.partner_status` on every unified order.
+ *
+ * Background: PR-F promotes `partner_status` off the order's metadata blob onto a
+ * typed 1:1 sidecar row (see src/modules/unified_order_status). New transitions
+ * write BOTH surfaces, but historicals only carry the metadata copy. This script
+ * upserts the sidecar row for each order whose metadata still holds a
+ * `partner_status`, so PR-G can repoint the read sites onto the column.
+ *
+ * Safe to re-run: idempotent. Skips orders with no `metadata.partner_status` and
+ * orders whose sidecar row already matches; only writes when the column is
+ * absent or stale.
+ *
+ * Pass `dry-run` positionally (medusa exec does not forward `--flags`):
+ *   npx medusa exec ./src/scripts/backfill-unified-order-status.ts dry-run
+ *   npx medusa exec ./src/scripts/backfill-unified-order-status.ts
+ */
+
+const PAGE = 200
+
+export default async function backfillUnifiedOrderStatus({ container, args }: ExecArgs) {
+  // `medusa exec <file> <args..>` forwards positional args as a string[] (it does
+  // NOT forward `--flags`). Accept both `dry-run` and `--dry-run`.
+  const a: any = args ?? []
+  const tokens: string[] = (Array.isArray(a) ? a : Object.keys(a)).map(String)
+  const dryRun = tokens.some((t) => t.replace(/^--/, "") === "dry-run")
+
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+
+  logger.info(
+    `[backfill-unified-order-status] starting${dryRun ? " (DRY RUN — no writes)" : ""}`
+  )
+
+  let skip = 0
+  let upserted = 0
+  let alreadySet = 0
+  let noStatus = 0
+  let errors = 0
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { data: rows } = await query.graph({
+      entity: "order",
+      fields: ["id", "metadata", "unified_order_status.partner_status"],
+      pagination: { take: PAGE, skip },
+    })
+
+    if (!rows?.length) break
+
+    for (const row of rows as any[]) {
+      const metaStatus = row?.metadata?.partner_status
+      if (!metaStatus) {
+        // Retail orders + work-orders not yet partner-tracked carry no status.
+        noStatus++
+        continue
+      }
+      if (row?.unified_order_status?.partner_status === metaStatus) {
+        // Already promoted (new write path, or a prior run of this script).
+        alreadySet++
+        continue
+      }
+      if (dryRun) {
+        upserted++
+        logger.info(
+          `[backfill-unified-order-status] DRY would set order ${row.id} → ${metaStatus}`
+        )
+        continue
+      }
+      try {
+        await setUnifiedOrderPartnerStatus(container, row.id, String(metaStatus))
+        upserted++
+      } catch (e: any) {
+        errors++
+        logger.error(
+          `[backfill-unified-order-status] order ${row.id} → ${metaStatus} failed: ${e?.message ?? e}`
+        )
+      }
+    }
+
+    skip += PAGE
+  }
+
+  logger.info(
+    `[backfill-unified-order-status] DONE${dryRun ? " (DRY RUN)" : ""} — upserted=${upserted} alreadySet=${alreadySet} noStatus=${noStatus} errors=${errors}`
+  )
+}

--- a/apps/backend/src/workflows/inventory_orders/dual-write-unified-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/dual-write-unified-order.ts
@@ -5,6 +5,7 @@ import type { Link } from "@medusajs/modules-sdk"
 import type { LinkDefinition, MedusaContainer } from "@medusajs/framework/types"
 import { ORDER_INVENTORY_MODULE } from "../../modules/inventory_orders"
 import { PARTNER_MODULE } from "../../modules/partner"
+import { UNIFIED_ORDER_STATUS_MODULE } from "../../modules/unified_order_status"
 
 // #342 T2 — best-effort projection of legacy inventory orders onto the core
 // `order` entity (kind=inventory = "the order↔inventory_order link exists";
@@ -160,6 +161,50 @@ export const resolveUnifiedOrderIdByLink = async (
   })
   const row = data?.[0]
   return row?.order?.id ?? row?.metadata?.unified_order_id ?? undefined
+}
+
+// #342 Chunk 9b (PR-F) — promote `partner_status` off the order's metadata blob
+// onto the typed 1:1 `unified_order_status` sidecar column. Atomic upsert:
+// find-or-create the sidecar row (via the order↔unified_order_status link) and
+// write the single `partner_status` column. A single-column write has no
+// read-modify-write, so it needs no lock — unlike the metadata RMW it shadows
+// (which stays under withUnifiedOrderMetadataLock through the expand phase).
+//
+// During expand every caller writes BOTH this column AND metadata.partner_status
+// (belt-and-suspenders); PR-G repoints the 2 read sites onto this column and
+// PR-H stops writing the metadata copy + drops the lock. The create race on a
+// brand-new order's first status is a non-issue in practice: the create-path
+// projection (production runs) and the single send-to-partner mirror (inventory)
+// establish the row before any concurrent transition can run.
+export const setUnifiedOrderPartnerStatus = async (
+  container: MedusaContainer,
+  unifiedOrderId: string,
+  status: string
+): Promise<void> => {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  const { data } = await query.graph({
+    entity: "order",
+    fields: ["id", "unified_order_status.id"],
+    filters: { id: unifiedOrderId },
+  })
+  const existingId = data?.[0]?.unified_order_status?.id
+  const service: any = container.resolve(UNIFIED_ORDER_STATUS_MODULE)
+  if (existingId) {
+    await service.updateUnifiedOrderStatuses([
+      { id: existingId, partner_status: status },
+    ])
+    return
+  }
+  const created = await service.createUnifiedOrderStatuses({
+    partner_status: status,
+  })
+  const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+  await remoteLink.create([
+    {
+      [Modules.ORDER]: { order_id: unifiedOrderId },
+      [UNIFIED_ORDER_STATUS_MODULE]: { unified_order_status_id: created.id },
+    },
+  ])
 }
 
 // D5-cleanup (Chunk 6) — create the load-bearing order↔<execution> link
@@ -402,6 +447,16 @@ export const mirrorPartnerLinkOnUnifiedOrderStep = createStep(
         ])
       })
 
+      // Chunk 9b (PR-F) — also write the typed sidecar column (expand: BOTH
+      // surfaces). Best-effort so a sidecar failure never regresses the
+      // still-authoritative metadata write above.
+      await setUnifiedOrderPartnerStatus(container, unifiedOrderId, "assigned").catch(
+        (e: any) =>
+          logger.warn(
+            `[orders-unification] sidecar status write failed for ${unifiedOrderId}: ${e?.message}`
+          )
+      )
+
       return new StepResponse<MirrorResult>({
         linked: true,
         unified_order_id: unifiedOrderId,
@@ -471,6 +526,20 @@ export const mirrorUnifiedOrderStatusStep = createStep(
           },
         ])
       })
+
+      // Chunk 9b (PR-F) — mirror partner_status onto the typed sidecar column
+      // too (expand: BOTH surfaces). Best-effort, same contract as above.
+      if (partnerStatus) {
+        await setUnifiedOrderPartnerStatus(
+          container,
+          unifiedOrderId,
+          partnerStatus
+        ).catch((e: any) =>
+          logger.warn(
+            `[orders-unification] sidecar status write failed for ${unifiedOrderId}: ${e?.message}`
+          )
+        )
+      }
 
       return new StepResponse<MirrorResult>({
         linked: true,

--- a/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
+++ b/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
@@ -13,6 +13,7 @@ import {
   resolveUnifiedOrderIdByLink,
   linkUnifiedOrderOrRollback,
   withUnifiedOrderMetadataLock,
+  setUnifiedOrderPartnerStatus,
 } from "../inventory_orders/dual-write-unified-order"
 
 // #342 T3.2 — best-effort projection of production runs onto the core `order`
@@ -167,6 +168,22 @@ const patchUnifiedOrder = async (
         },
       ])
     })
+    // Chunk 9b (PR-F) — when the patch carries partner_status, mirror it onto
+    // the typed sidecar column too (expand: BOTH surfaces). Best-effort; skips
+    // metadata-only patches like superseded_by_run_ids that carry no status.
+    const patchedStatus = (patch.metadata as any)?.partner_status
+    if (patchedStatus) {
+      await setUnifiedOrderPartnerStatus(
+        container,
+        unifiedOrderId,
+        patchedStatus
+      ).catch((e: any) => {
+        const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+        logger.warn(
+          `[orders-unification] sidecar status write failed for ${unifiedOrderId}: ${e?.message}`
+        )
+      })
+    }
     return
   }
   await orderService.updateOrders([
@@ -330,6 +347,23 @@ export const projectRunToUnifiedOrder = async (
       }
     }
 
+    // Chunk 9b (PR-F) — when the projection derived a partner_status (the run is
+    // born at/past sent_to_partner), also write the typed sidecar column. This
+    // single-shot create path establishes the sidecar row before any concurrent
+    // mirror can run, so the column find-or-create never races. BOTH surfaces
+    // during expand; best-effort so it never regresses the metadata projection.
+    if (partnerStatus) {
+      await setUnifiedOrderPartnerStatus(
+        container,
+        unified.id,
+        partnerStatus
+      ).catch((e: any) =>
+        logger.warn(
+          `[orders-unification] sidecar status write failed for ${unified.id}: ${e?.message}`
+        )
+      )
+    }
+
     return { unified_order_id: unified.id }
   } catch (e: any) {
     logger.warn(
@@ -414,6 +448,21 @@ export const mirrorRunStatusToUnifiedOrder = async (
 
     if (superseded) {
       return { linked: false, skipped: "superseded" }
+    }
+
+    // Chunk 9b (PR-F) — mirror partner_status onto the typed sidecar column too
+    // (expand: BOTH surfaces). Outside the lock — a single-column write has no
+    // RMW to protect. Best-effort, same contract as the metadata write above.
+    if (partnerStatus) {
+      await setUnifiedOrderPartnerStatus(
+        container,
+        unifiedOrderId,
+        partnerStatus
+      ).catch((e: any) =>
+        logger.warn(
+          `[orders-unification] sidecar status write failed for ${unifiedOrderId}: ${e?.message}`
+        )
+      )
     }
 
     return { linked: true, unified_order_id: unifiedOrderId }

--- a/apps/docs/notes/ORDERS_UNIFICATION_342.md
+++ b/apps/docs/notes/ORDERS_UNIFICATION_342.md
@@ -58,7 +58,7 @@ as the discriminator/pointer. Instead:
 | **PR-D** | 7 + 8 | Concurrency hardening: locking + Redis provider (parallel track, independent of A–C) | **MERGED — PR #395** (`1ef954378`, 2026-06-14). `orders-unification-locking.spec.ts` 3/3; dual-write 12/12. |
 | **PR-E** | 9 | T4 backfill SCRIPT (link-only) | **MERGED — PR #396** (`e9c5be099`, 2026-06-14). Script `src/scripts/backfill-unified-order-links.ts` shipped. ⚠️ **OPERATIONAL: still must be RUN in prod** (see "T4 plan"). |
 | **PR-E2** | 9 | Retire the 4 `unified_order_id` fallback reads | **NEXT after the prod backfill is RUN + verified** (`linked=0, danglingBackref=0`). Not started. |
-| **PR-F** | 9b-expand | New `unified_order_status` 1:1 sidecar column + dual-write both column & metadata + backfill | **▶ START HERE next session — UNBLOCKED** (PR-D + PR-E merged). Not started. |
+| **PR-F** | 9b-expand | New `unified_order_status` 1:1 sidecar column + dual-write both column & metadata + backfill | **DONE on branch `feat/342-pr-f-status-column`** (2026-06-14). Module `src/modules/unified_order_status` + link `order-unified-status.ts` + helper `setUnifiedOrderPartnerStatus` (find-or-create upsert); 5 write sites mirror BOTH column & metadata; backfill `src/scripts/backfill-unified-order-status.ts`. New spec `orders-unification-status-column.spec.ts` 1/1; full unification suite 24/24 regression-green. ⚠️ **OPERATIONAL: run the backfill in prod after deploy** (dry-run then live). |
 | **PR-G** | 9b-migrate | Repoint the 2 `metadata.partner_status` read sites to the column | planned. *(blocked by PR-F)* |
 | **PR-H** | 9b-contract | Stop writing `metadata.partner_status`; remove the Chunk-7 lock wrapping (KEEP Redis provider) | planned. *(blocked by PR-G verified)* |
 
@@ -300,8 +300,10 @@ as the discriminator/pointer. Instead:
 ### T4 plan — Chunks 9 + 9b (planned 2026-06-14, scope confirmed with user)
 
 > **▶ HANDOFF / NEXT SESSION (updated 2026-06-14):** PR-A…E are all MERGED to main
-> (auto-deployed). **Start PR-F next** — it is UNBLOCKED (see the PR-F checkbox below
-> for the full build list). Two threads are still open and independent of PR-F:
+> (auto-deployed). **PR-F is DONE on branch `feat/342-pr-f-status-column`** (open the
+> PR + merge → deploy → run the status backfill). **Start PR-G next** (migrate the 2
+> `metadata.partner_status` read sites onto `unified_order_statuses.partner_status`) —
+> UNBLOCKED once PR-F merges. Two threads are still open and independent of PR-F/G:
 > 1. **Run the PR-E backfill in prod** (the deploy shipped the script but does NOT
 >    run it): `npx medusa exec ./src/scripts/backfill-unified-order-links.ts dry-run`
 >    then without `dry-run`; verify a second run reports `linked=0 danglingBackref=0`.
@@ -349,8 +351,29 @@ those links remain valid; only revisit if we ever delete the legacy execution ro
     DELETE the 4 fallback reads (`?? …unified_order_id`): `dual-write-unified-order.ts:162`,
     `:440`; `dual-write-unified-run-order.ts:213`; `api/admin/orders/route.ts:45`.
     Each becomes link-only. Update the dual-write specs (drop fallback assertions).
-- [ ] **▶ Chunk 9b → PR-F (expand: column + dual-write + backfill) — START HERE, UNBLOCKED.** *(blocked by: 7, 8, PR-E — all merged)*
-  - New 1:1 sidecar module `src/modules/unified_order_status` (model/service/index),
+- [x] **Chunk 9b → PR-F (expand: column + dual-write + backfill) — DONE on branch `feat/342-pr-f-status-column`.** *(blocked by: 7, 8, PR-E — all merged)*
+  - **Built:** module `src/modules/unified_order_status` (model `partner_status` enum,
+    prefix `uos`, generated create-table migration `Migration20260614184932.ts`),
+    registered in BOTH `medusa-config.ts` + `medusa-config.prod.ts`. Link
+    `src/links/order-unified-status.ts` (`field:"unified_order_status"`,
+    `filterable:["id"]`). Helper `setUnifiedOrderPartnerStatus(container, orderId,
+    status)` (find-or-create via the link, single-column write) lives in
+    `inventory_orders/dual-write-unified-order.ts` next to the other shared seams.
+  - **5 write sites** mirror BOTH surfaces (column best-effort `.catch(warn)` so it
+    never regresses the still-authoritative metadata write): inventory
+    `mirrorPartnerLinkOnUnifiedOrderStep` ("assigned") + `mirrorUnifiedOrderStatusStep`;
+    production-run `projectRunToUnifiedOrder` (create path) + `patchUnifiedOrder`
+    (centralizes the "assigned" path; skips metadata-only `superseded_by_run_ids`) +
+    `mirrorRunStatusToUnifiedOrder`. Inventory create path writes NO status (none at
+    create — correct). The create race is a non-issue: the single-shot create
+    projection / single send-to-partner establishes the row before any concurrent mirror.
+  - **Backfill** `src/scripts/backfill-unified-order-status.ts` (positional `dry-run`,
+    PAGE=200, idempotent — skips no-status + already-matching rows; reuses the helper).
+  - **Tests:** `orders-unification-status-column.spec.ts` (BOTH-surface + same-row-on-
+    re-transition) 1/1; dual-write/design/locking/admin-filter/partner-filter 24/24 green.
+  - ⚠️ **OPERATIONAL after merge+deploy:** run the backfill in prod
+    (`npx medusa exec ./src/scripts/backfill-unified-order-status.ts dry-run` then live).
+  - *Original plan notes (kept for reference):*
     model `unified_order_status { id (prefix "uos"), partner_status: enum(assigned,
     accepted, in_progress, finished, partial, completed, declined), updated_at }`.
     Link `src/links/order-unified-status.ts` (`isList:false`, `filterable:["id"]`).


### PR DESCRIPTION
## #342 PR-F — expand step of the `partner_status` column swap

Promotes the load-bearing `partner_status` off `order.metadata` onto a typed 1:1 sidecar column (`unified_order_status`). This is the **expand** in expand→migrate→contract: writes go to BOTH surfaces; reads stay on metadata until PR-G; metadata + Chunk-7 lock retire in PR-H.

### What's in here
- **Module** `src/modules/unified_order_status` — `partner_status` enum (prefix `uos`), generated create-table migration, registered in both `medusa-config.ts` + `.prod.ts`.
- **Link** `src/links/order-unified-status.ts` — 1:1, `field: "unified_order_status"`, `filterable: ["id"]`.
- **Helper** `setUnifiedOrderPartnerStatus(container, orderId, status)` — find-or-create upsert (single-column write, no RMW → no lock), in the shared `dual-write-unified-order.ts`.
- **5 write sites** mirror BOTH column & `metadata.partner_status` — the column write is best-effort (`.catch(warn)`) so it never regresses the still-authoritative metadata path. Inventory create path writes no status (correct — none at create). The create race is a non-issue: the single-shot create projection / single send-to-partner establishes the row first.
- **Backfill** `src/scripts/backfill-unified-order-status.ts` — idempotent, `dry-run`, reuses the helper.

### Tests
- New `orders-unification-status-column.spec.ts` (BOTH-surface + same-row-on-re-transition) — 1/1.
- Full unification suite regression-green — 24/24 (dual-write inventory + design, locking, admin filter, partner filter).

### ⚠️ Operational (after merge + deploy)
Run the backfill in prod: `npx medusa exec ./src/scripts/backfill-unified-order-status.ts dry-run` then live.

### Next
PR-G repoints the 2 `metadata.partner_status` read sites onto the column; PR-H drops the metadata copy + Chunk-7 lock wrapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)