### PR TITLE
fix(admin): design detail dropped base columns (id + relations only)

### DIFF
--- a/apps/backend/integration-tests/http/designs-api.spec.ts
+++ b/apps/backend/integration-tests/http/designs-api.spec.ts
@@ -179,6 +179,34 @@ setupSharedTestSuite(() => {
           });
         });
 
+        // Regression: the admin detail loader requests a relations-ONLY field
+        // list (no `*`). refetchDesign must still return the design's own
+        // scalar columns — otherwise the detail UI renders with no name/status/
+        // media (the whole record collapses to id + relations). See
+        // src/api/admin/designs/helpers.ts (baseFields injects `*`).
+        it("returns base columns even when fields lists only relations", async () => {
+          const response = await api.get(
+            `/admin/designs/${summerDesignId}`,
+            {
+              headers: headers.headers,
+              params: {
+                fields:
+                  "inventory_items.*, tasks.*, partners.*, colors.*, size_sets.*, customers.*",
+              },
+            }
+          );
+
+          expect(response.status).toBe(200);
+          const design = response.data.design;
+          expect(design.id).toBe(summerDesignId);
+          // The design's OWN columns must be present despite the relations-only ask.
+          expect(design.name).toBe(summerDesign.name);
+          expect(design.status).toBe(summerDesign.status);
+          expect(design.priority).toBe(summerDesign.priority);
+          // The requested relations still come through.
+          expect(Array.isArray(design.inventory_items) || design.inventory_items === undefined).toBe(true);
+        });
+
         it("should return 404 for non-existent design", async () => {
           const response = await api
             .get("/admin/designs/non-existent-id", {

--- a/apps/backend/src/api/admin/designs/helpers.ts
+++ b/apps/backend/src/api/admin/designs/helpers.ts
@@ -23,7 +23,16 @@ export const refetchDesign = async (
 ) => {
   const query = container.resolve("query")
 
+  // Always include the design's OWN columns (`*`) alongside the relations.
+  // Callers (e.g. the admin detail loader's DESIGN_DETAIL_FIELDS) enumerate only
+  // relations, so without `*` query.graph returns just `id` + relations — the
+  // design's name/status/media and the legacy `color_palette`/`custom_sizes`
+  // JSON columns all go missing, leaving the detail UI with nothing to render
+  // and the derivation below falling back to the (often empty) relations. `*`
+  // selects only base scalar columns, so the explicit relation wildcards still
+  // drive what gets populated.
   const baseFields: DesignAllowedFields[] = [
+    "*",
     "colors.*",
     "size_sets.*",
     "inventory_items.*",


### PR DESCRIPTION
## Admin design detail renders empty (no name/status/media)

The admin design-detail loader requests a **relations-only** field list (`DESIGN_DETAIL_FIELDS`: `inventory_items/tasks/partners/colors/size_sets/customers`, no `*`). `refetchDesign` added only relation wildcards to `baseFields`, so `query.graph` returned just `id` + relations — the design's own `name`/`status`/`description`/media and the legacy `color_palette`/`custom_sizes` JSON columns were **all absent**, leaving the detail page with nothing to render.

### Verified on prod (`v3.jaalyantra.com`)
Same design (`01KKBDR2N5GPKSBEEPQZY28061`), two requests:
- relations-only `fields` (what the UI sends) → `name: null`, `status: null` (9 keys)
- default `*` (no `fields`) → `name: "Jaam Dani Modern Touch"`, `status: "Conceptual"` (37 keys)

The data was always there; the field list dropped it. The #397 `customer`→`customers` fix stopped the 500 but this incompleteness was masked by it.

### Fix
Inject `*` into `refetchDesign`'s `baseFields` so the design's own columns always come back alongside the explicit relation wildcards — covers GET + PUT and every caller. `*` selects only base scalar columns, so the relation wildcards still drive what gets populated.

### Tests
Adds a regression test asserting base columns (`name`/`status`/`priority`) survive a relations-only `fields` request. `designs-api.spec.ts` 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)