### PR TITLE
fix(#32): vflow 401 — WhatsApp token shadow + secret redaction + failure alerting

### DIFF
--- a/apps/backend/integration-tests/http/visual-flow-lifecycle-email.spec.ts
+++ b/apps/backend/integration-tests/http/visual-flow-lifecycle-email.spec.ts
@@ -172,9 +172,58 @@ setupSharedTestSuite(() => {
     })
   })
 
+  // NOTE (roadmap 32B): the engine path (FlowExecutionEngine.execute) now
+  // emits `visual_flow_execution.failed` from its catch — but it can't be
+  // exercised end-to-end here. The engine resolves a flow's graph by matching
+  // connection.target_id against operation.id (a generated `vfop_…`), while
+  // canvas-built flows store the canvas node id as `operation_key` and wire
+  // connections by node id. So the engine finds zero starting operations for a
+  // canvas flow and completes empty — a PRE-EXISTING engine graph-resolution
+  // gap (the engine path is currently unused), unrelated to the emit fix.
+  // The emit mirrors the workflow compensation emit covered above; fixing the
+  // engine graph resolver is tracked separately.
+
   describe("visual-flow-lifecycle-email subscriber helpers", () => {
+    const ENV_KEYS = ["VISUAL_FLOW_FAILURE_EMAIL", "MAILJET_FROM_EMAIL"]
+    let savedEnv: Record<string, string | undefined>
+
     beforeEach(() => {
       lifecycleTesting.clearThrottle()
+      savedEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]))
+      for (const k of ENV_KEYS) delete process.env[k]
+    })
+
+    afterEach(() => {
+      for (const k of ENV_KEYS) {
+        if (savedEnv[k] === undefined) delete process.env[k]
+        else process.env[k] = savedEnv[k]
+      }
+    })
+
+    it("resolveRecipient prefers per-flow metadata, then env, then Mailjet fallback (32B)", () => {
+      // 1. per-flow override wins
+      process.env.VISUAL_FLOW_FAILURE_EMAIL = "env@jyt.test"
+      process.env.MAILJET_FROM_EMAIL = "from@jyt.test"
+      expect(
+        lifecycleTesting.resolveRecipient({ flow_metadata: { failure_email: "flow@jyt.test" } })
+      ).toEqual({ email: "flow@jyt.test", source: "flow.metadata.failure_email" })
+
+      // 2. platform env when no per-flow override
+      expect(lifecycleTesting.resolveRecipient({})).toEqual({
+        email: "env@jyt.test",
+        source: "VISUAL_FLOW_FAILURE_EMAIL",
+      })
+
+      // 3. Mailjet from-address as the never-silent floor
+      delete process.env.VISUAL_FLOW_FAILURE_EMAIL
+      expect(lifecycleTesting.resolveRecipient({})).toEqual({
+        email: "from@jyt.test",
+        source: "MAILJET_FROM_EMAIL (fallback)",
+      })
+
+      // 4. truly nothing configured → null (subscriber then WARN-logs)
+      delete process.env.MAILJET_FROM_EMAIL
+      expect(lifecycleTesting.resolveRecipient({})).toBeNull()
     })
 
     it("fingerprint normalises ULID-like ids and truncates", () => {

--- a/apps/backend/src/api/admin/social-platforms/[id]/route.ts
+++ b/apps/backend/src/api/admin/social-platforms/[id]/route.ts
@@ -116,20 +116,49 @@ import { updateSocialPlatformWorkflow } from "../../../../workflows/socials/upda
 import { deleteSocialPlatformWorkflow } from "../../../../workflows/socials/delete-social-platform";
 import { SOCIALS_MODULE } from "../../../../modules/socials";
 import type SocialsService from "../../../../modules/socials/service";
+import { ENCRYPTION_MODULE } from "../../../../modules/encryption";
+import type EncryptionService from "../../../../modules/encryption/service";
 import { encryptSocialPlatformCredentials } from "../../../../subscribers/social-platform-credentials-encryption";
+import {
+  redactSocialPlatform,
+  isSecretRevealAllowed,
+  preserveExistingSecrets,
+} from "../secrets";
 
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const { result } = await listSocialPlatformWorkflow(req.scope).run({
     input: { filters: { id: [req.params.id] } },
   });
-  res.status(200).json({ socialPlatform: result[0][0] });
+  // Secrets are stripped by default; a raw token comes back only for an
+  // MFA-protected caller who explicitly asks (`?reveal_secrets=true`).
+  const reveal = await isSecretRevealAllowed(req);
+  const encryptionService = reveal
+    ? (req.scope.resolve(ENCRYPTION_MODULE) as EncryptionService)
+    : undefined;
+  res.status(200).json({
+    socialPlatform: redactSocialPlatform(result[0][0], { reveal, encryptionService }),
+  });
 };
 
 export const POST = async (req: MedusaRequest<UpdateSocialPlatform>, res: MedusaResponse) => {
+  const body: any = { ...req.validatedBody };
+
+  // Redacted responses no longer carry secrets, so an edit that touches an
+  // unrelated field arrives with credentials missing from `api_config`.
+  // Restore any omitted/blank secret from the existing row server-side so the
+  // save never wipes live credentials (see secrets.ts).
+  if (body.api_config && typeof body.api_config === "object") {
+    const existing = await refetchSocialPlatform(req.params.id, req.scope);
+    body.api_config = preserveExistingSecrets(
+      body.api_config,
+      (existing as any)?.api_config
+    );
+  }
+
   await updateSocialPlatformWorkflow(req.scope).run({
     input: {
       id: req.params.id,
-      ...req.validatedBody,
+      ...body,
     },
   });
 
@@ -152,7 +181,7 @@ export const POST = async (req: MedusaRequest<UpdateSocialPlatform>, res: Medusa
     await socials.clearOtherWhatsAppDefaults((socialPlatform as any).id);
   }
 
-  res.status(200).json({ socialPlatform });
+  res.status(200).json({ socialPlatform: redactSocialPlatform(socialPlatform) });
 };
 
 export const PUT = POST;

--- a/apps/backend/src/api/admin/social-platforms/__tests__/secrets.unit.spec.ts
+++ b/apps/backend/src/api/admin/social-platforms/__tests__/secrets.unit.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit test — social-platforms secret handling (#32A API hardening)
+ *
+ * The admin social-platforms API used to echo back raw credentials in
+ * `api_config`. These cover the three guarantees in secrets.ts:
+ *   - redact: no plaintext OR ciphertext leaves the API by default
+ *   - reveal: a raw secret only comes back for an MFA-enabled caller that asks
+ *   - preserve: a blank-field save restores omitted secrets server-side
+ *
+ * Run:
+ *   TEST_TYPE=unit npx jest --testPathPattern="social-platforms/__tests__/secrets"
+ */
+import { Modules } from "@medusajs/framework/utils"
+import {
+  redactApiConfig,
+  preserveExistingSecrets,
+  isSecretRevealAllowed,
+} from "../secrets"
+
+describe("redactApiConfig (#32A)", () => {
+  const fullConfig = {
+    provider: "whatsapp",
+    phone_number_id: "123",
+    waba_id: "456",
+    access_token: "PLAINTEXT-TOKEN",
+    access_token_encrypted: { enc: "v1:abc" },
+    app_secret: "PLAINTEXT-SECRET",
+    webhook_verify_token: "VERIFY",
+    templates: [{ name: "t1" }],
+  }
+
+  it("strips plaintext AND ciphertext, keeps non-secret config, adds presence flags", () => {
+    const out = redactApiConfig(fullConfig)!
+    // Secrets gone (both shapes)…
+    expect(out.access_token).toBeUndefined()
+    expect(out.access_token_encrypted).toBeUndefined()
+    expect(out.app_secret).toBeUndefined()
+    expect(out.webhook_verify_token).toBeUndefined()
+    // …presence preserved for the UI…
+    expect(out.access_token_present).toBe(true)
+    expect(out.app_secret_present).toBe(true)
+    // …non-secret config untouched.
+    expect(out.phone_number_id).toBe("123")
+    expect(out.waba_id).toBe("456")
+    expect(out.templates).toEqual([{ name: "t1" }])
+  })
+
+  it("does not mutate the input", () => {
+    const copy = JSON.parse(JSON.stringify(fullConfig))
+    redactApiConfig(fullConfig)
+    expect(fullConfig).toEqual(copy)
+  })
+
+  it("reveals the decrypted token (and only then) when reveal=true", () => {
+    const fakeEncryption: any = {
+      decrypt: (d: any) => (d?.enc === "v1:abc" ? "PLAINTEXT-TOKEN" : null),
+    }
+    const out = redactApiConfig(fullConfig, { reveal: true, encryptionService: fakeEncryption })!
+    expect(out.access_token).toBe("PLAINTEXT-TOKEN")
+    // Ciphertext blob is dropped from a revealed response.
+    expect(out.access_token_encrypted).toBeUndefined()
+  })
+
+  it("passes through null/empty config unchanged", () => {
+    expect(redactApiConfig(null)).toBeNull()
+    expect(redactApiConfig(undefined)).toBeUndefined()
+  })
+})
+
+describe("preserveExistingSecrets (#32A)", () => {
+  it("restores omitted/blank secrets from the existing row", () => {
+    const existing = {
+      provider: "whatsapp",
+      access_token_encrypted: { enc: "v1:keep" },
+      app_secret: "KEEP-SECRET",
+    }
+    const incoming = {
+      provider: "whatsapp",
+      phone_number_id: "999",
+      // secrets omitted (redacted response → blank-field save)
+    }
+    const merged = preserveExistingSecrets(incoming, existing)!
+    expect(merged.phone_number_id).toBe("999")
+    expect(merged.access_token_encrypted).toEqual({ enc: "v1:keep" })
+    expect(merged.app_secret).toBe("KEEP-SECRET")
+  })
+
+  it("lets a freshly-submitted secret win over the existing one", () => {
+    const existing = { access_token: "OLD" }
+    const incoming = { access_token: "NEW" }
+    const merged = preserveExistingSecrets(incoming, existing)!
+    expect(merged.access_token).toBe("NEW")
+  })
+
+  it("strips UI-only *_present hints before persisting", () => {
+    const merged = preserveExistingSecrets(
+      { access_token_present: true, phone_number_id: "1" },
+      {}
+    )!
+    expect(merged.access_token_present).toBeUndefined()
+    expect(merged.phone_number_id).toBe("1")
+  })
+})
+
+describe("isSecretRevealAllowed (#32A MFA gate)", () => {
+  function makeReq(opts: {
+    revealQuery?: string
+    authIdentityId?: string
+    factors?: any[]
+    throws?: boolean
+  }): any {
+    return {
+      query: { reveal_secrets: opts.revealQuery },
+      auth_context: opts.authIdentityId ? { auth_identity_id: opts.authIdentityId } : undefined,
+      scope: {
+        resolve: (key: string) => {
+          if (key === Modules.AUTH) {
+            return {
+              listAuthMfa: async () => {
+                if (opts.throws) throw new Error("boom")
+                return opts.factors ?? []
+              },
+            }
+          }
+          throw new Error(`unexpected resolve(${key})`)
+        },
+      },
+    }
+  }
+
+  it("false when reveal not requested", async () => {
+    expect(
+      await isSecretRevealAllowed(makeReq({ authIdentityId: "ai_1", factors: [{ status: "enabled" }] }))
+    ).toBe(false)
+  })
+
+  it("false when requested but identity has no enabled MFA factor", async () => {
+    expect(
+      await isSecretRevealAllowed(makeReq({ revealQuery: "true", authIdentityId: "ai_1", factors: [] }))
+    ).toBe(false)
+  })
+
+  it("true when reveal requested and identity has an enabled MFA factor", async () => {
+    expect(
+      await isSecretRevealAllowed(
+        makeReq({ revealQuery: "true", authIdentityId: "ai_1", factors: [{ status: "enabled" }] })
+      )
+    ).toBe(true)
+  })
+
+  it("fails closed (false) on any error or missing auth context", async () => {
+    expect(await isSecretRevealAllowed(makeReq({ revealQuery: "true" }))).toBe(false)
+    expect(
+      await isSecretRevealAllowed(makeReq({ revealQuery: "true", authIdentityId: "ai_1", throws: true }))
+    ).toBe(false)
+  })
+})

--- a/apps/backend/src/api/admin/social-platforms/route.ts
+++ b/apps/backend/src/api/admin/social-platforms/route.ts
@@ -110,6 +110,7 @@ import { createSocialPlatformWorkflow } from "../../../workflows/socials/create-
 import { listSocialPlatformWorkflow } from "../../../workflows/socials/list-social-platform";
 import { SOCIALS_MODULE } from "../../../modules/socials";
 import type SocialsService from "../../../modules/socials/service";
+import { redactSocialPlatform } from "./secrets";
 
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const filters: Record<string, any> = {}
@@ -157,7 +158,9 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       },
     },
   });
-  res.status(200).json({ socialPlatforms: result[0], count: result[1] });
+  // List never reveals secrets — strip every credential from each row.
+  const socialPlatforms = (result[0] as any[]).map((p) => redactSocialPlatform(p));
+  res.status(200).json({ socialPlatforms, count: result[1] });
 };
 
 export const POST = async (req: MedusaRequest<SocialPlatform>, res: MedusaResponse) => {
@@ -175,5 +178,5 @@ export const POST = async (req: MedusaRequest<SocialPlatform>, res: MedusaRespon
     await socials.clearOtherWhatsAppDefaults((socialPlatform as any).id);
   }
 
-  res.status(201).json({ socialPlatform });
+  res.status(201).json({ socialPlatform: redactSocialPlatform(socialPlatform) });
 };

--- a/apps/backend/src/api/admin/social-platforms/secrets.ts
+++ b/apps/backend/src/api/admin/social-platforms/secrets.ts
@@ -1,0 +1,188 @@
+/**
+ * Secret handling for the admin social-platforms API.
+ *
+ * Three concerns, kept together because they're two halves of one contract:
+ *
+ *  1. `redactApiConfig` — strip every credential (plaintext AND the encrypted
+ *     ciphertext blobs) out of any `api_config` before it leaves the API.
+ *     A `<field>_present` boolean is added so the UI can still show a
+ *     "configured" state. This is the #32A follow-up: the admin API used to
+ *     echo back the raw `access_token` (and app_secret, webhook tokens, …),
+ *     which is exactly the plaintext that the encryption subscriber works to
+ *     keep off disk.
+ *
+ *  2. `isSecretRevealAllowed` — the only way a raw secret comes back is when
+ *     the caller's auth identity has an ENABLED Medusa MFA factor AND they
+ *     explicitly ask (`?reveal_secrets=true`). Medusa refuses to mint a
+ *     session token for an MFA-enabled identity without a completed challenge
+ *     (see `applyMfaRequirement_` in @medusajs/auth), so "MFA enabled for this
+ *     identity" is a sound proxy for "this session passed MFA". Fails closed.
+ *
+ *  3. `preserveExistingSecrets` — because responses no longer carry secrets,
+ *     the admin edit form can't echo them back on a blank-field save. So on
+ *     update we restore any omitted/blank secret from the existing DB row,
+ *     server-side. This makes redaction safe for every platform category
+ *     without the UI ever needing to hold a secret.
+ */
+import type { MedusaRequest } from "@medusajs/framework/http"
+import { Modules } from "@medusajs/framework/utils"
+import { ENCRYPTION_MODULE } from "../../../modules/encryption"
+import type EncryptionService from "../../../modules/encryption/service"
+import type { EncryptedData } from "../../../modules/encryption"
+
+// Plaintext credential keys across every platform category (email, sms,
+// payment, shipping, analytics, storage, crm, auth, communication/WhatsApp).
+// Superset is intentional — redaction must over-strip rather than leak.
+const PLAINTEXT_SECRET_FIELDS = [
+  "access_token",
+  "api_key",
+  "api_secret",
+  "auth_token",
+  "refresh_token",
+  "page_access_token",
+  "user_access_token",
+  "client_secret",
+  "developer_token",
+  "secret_key",
+  "secret_access_key",
+  "webhook_secret",
+  "webhook_signing_secret",
+  "app_secret",
+  "webhook_verify_token",
+  "password",
+] as const
+
+// Nested secret bags (OAuth1). Stripped wholesale by default.
+const NESTED_SECRET_FIELDS = ["oauth1_credentials", "oauth1_app_credentials"] as const
+
+function encKey(field: string): string {
+  return `${field}_encrypted`
+}
+
+/**
+ * Return a copy of `apiConfig` with all credentials stripped. Non-secret
+ * config (host, phone_number_id, waba_id, cached templates, …) is preserved.
+ *
+ * When `reveal` is true, the raw secret is decrypted from its `*_encrypted`
+ * blob (falling back to any stored plaintext) and returned in the plaintext
+ * field; the ciphertext blob is dropped from the revealed copy.
+ */
+export function redactApiConfig(
+  apiConfig: Record<string, any> | null | undefined,
+  opts: { reveal?: boolean; encryptionService?: EncryptionService } = {}
+): Record<string, any> | null | undefined {
+  if (!apiConfig || typeof apiConfig !== "object") return apiConfig
+  const { reveal = false, encryptionService } = opts
+  const out: Record<string, any> = { ...apiConfig }
+
+  for (const field of PLAINTEXT_SECRET_FIELDS) {
+    const ek = encKey(field)
+    const hasValue = Boolean(out[field]) || Boolean(out[ek])
+    if (hasValue) out[`${field}_present`] = true
+
+    if (reveal) {
+      let revealed: string | null = null
+      if (out[ek] && encryptionService) {
+        try {
+          revealed = encryptionService.decrypt(out[ek] as EncryptedData)
+        } catch {
+          revealed = null
+        }
+      }
+      out[field] = revealed ?? (typeof out[field] === "string" ? out[field] : null)
+      delete out[ek] // plaintext is enough for a revealed response
+    } else {
+      delete out[field]
+      delete out[ek]
+    }
+  }
+
+  for (const field of NESTED_SECRET_FIELDS) {
+    const ek = encKey(field)
+    if (out[field] || out[ek]) out[`${field}_present`] = true
+    if (!reveal) {
+      delete out[field]
+      delete out[ek]
+    }
+  }
+
+  return out
+}
+
+/** Redact a full social-platform row's `api_config` in place-ish (returns a copy). */
+export function redactSocialPlatform<T extends Record<string, any>>(
+  platform: T | null | undefined,
+  opts: { reveal?: boolean; encryptionService?: EncryptionService } = {}
+): T | null | undefined {
+  if (!platform) return platform
+  return { ...platform, api_config: redactApiConfig(platform.api_config, opts) }
+}
+
+/**
+ * True only when the request's auth identity has an enabled MFA factor and the
+ * caller explicitly requested a reveal. Fails closed on any error.
+ */
+export async function isSecretRevealAllowed(req: MedusaRequest): Promise<boolean> {
+  const wantsReveal =
+    String((req.query as any)?.reveal_secrets ?? "").toLowerCase() === "true"
+  if (!wantsReveal) return false
+  return mfaEnabledForRequest(req)
+}
+
+async function mfaEnabledForRequest(req: MedusaRequest): Promise<boolean> {
+  try {
+    const authIdentityId = (req as any).auth_context?.auth_identity_id
+    if (!authIdentityId) return false
+    const auth: any = req.scope.resolve(Modules.AUTH)
+    const factors = await auth.listAuthMfa({
+      auth_identity_id: authIdentityId,
+      status: "enabled",
+    })
+    return Array.isArray(factors) && factors.length > 0
+  } catch {
+    return false // fail closed — never reveal when MFA state is unknown
+  }
+}
+
+/**
+ * Merge incoming `api_config` over `existing`, restoring any secret the caller
+ * omitted or left blank from the existing row (both plaintext and ciphertext
+ * variants, plus nested OAuth1 bags). Returns the merged config.
+ *
+ * Why: redacted responses no longer carry secrets, so an admin saving an
+ * unrelated field (e.g. renaming the platform) sends an `api_config` with the
+ * secrets missing. Without this, that save would wipe live credentials.
+ */
+export function preserveExistingSecrets(
+  incoming: Record<string, any> | null | undefined,
+  existing: Record<string, any> | null | undefined
+): Record<string, any> | null | undefined {
+  if (!incoming || typeof incoming !== "object") return incoming
+  const prev = existing && typeof existing === "object" ? existing : {}
+  const merged: Record<string, any> = { ...incoming }
+
+  const restore = (key: string) => {
+    const submitted = merged[key]
+    const isBlank =
+      submitted === undefined ||
+      submitted === null ||
+      (typeof submitted === "string" && submitted.length === 0)
+    if (isBlank && prev[key] !== undefined && prev[key] !== null) {
+      merged[key] = prev[key]
+    }
+  }
+
+  for (const field of PLAINTEXT_SECRET_FIELDS) {
+    restore(field)
+    restore(encKey(field))
+  }
+  for (const field of NESTED_SECRET_FIELDS) {
+    restore(field)
+    restore(encKey(field))
+  }
+  // Never persist the UI-only presence hints.
+  for (const k of Object.keys(merged)) {
+    if (k.endsWith("_present")) delete merged[k]
+  }
+  return merged
+}

--- a/apps/backend/src/api/admin/social-platforms/whatsapp/connect/route.ts
+++ b/apps/backend/src/api/admin/social-platforms/whatsapp/connect/route.ts
@@ -3,6 +3,7 @@ import { MedusaError } from "@medusajs/framework/utils"
 import { SOCIALS_MODULE } from "../../../../../modules/socials"
 import { ENCRYPTION_MODULE } from "../../../../../modules/encryption"
 import type EncryptionService from "../../../../../modules/encryption/service"
+import { encryptSocialPlatformCredentials } from "../../../../../subscribers/social-platform-credentials-encryption"
 
 interface ConnectWhatsAppBody {
   access_token: string
@@ -88,6 +89,12 @@ export const POST = async (
   }
 
   const result = Array.isArray(platform) ? platform[0] : platform
+
+  // Strip the plaintext `access_token` backward-compat field at rest so the
+  // encrypted ciphertext is the single source of truth (the resolver decrypts
+  // it first). This mirrors what the generic edit route does and keeps a
+  // freshly-rotated token from ever being shadowed by a stale value (#32A).
+  await encryptSocialPlatformCredentials(result.id, req.scope)
 
   res.status(200).json({
     socialPlatform: {

--- a/apps/backend/src/modules/visual_flows/execution-engine.ts
+++ b/apps/backend/src/modules/visual_flows/execution-engine.ts
@@ -1,4 +1,5 @@
 import { MedusaContainer } from "@medusajs/framework/types"
+import { Modules } from "@medusajs/framework/utils"
 import { 
   DataChain, 
   OperationContext, 
@@ -144,12 +145,67 @@ export class FlowExecutionEngine {
         completed_at: new Date(),
       })
 
+      // Lifecycle: emit a failure event so engine/manual-run failures alert
+      // too (#32B). Until this hook existed, only the workflow path emitted
+      // `visual_flow_execution.failed` (from its rollback compensation) — a
+      // direct engine run (manual execute / test run) marked the row failed
+      // and emitted nothing, so the failure-email subscriber never fired.
+      await this.emitFailureLifecycleEvent(execution.id, flowId, flow, incomingEventName, options, error)
+
       return {
         executionId: execution.id,
         status: "failed",
         dataChain,
         error: error.message,
       }
+    }
+  }
+
+  /**
+   * Best-effort failure lifecycle emit. Observability is strictly additive —
+   * a missing/misconfigured event bus must never turn a logged failure into a
+   * thrown one, so everything here is wrapped and swallowed. The execution row
+   * + log table still hold the truth even if the email never goes out.
+   */
+  private async emitFailureLifecycleEvent(
+    executionId: string,
+    flowId: string,
+    flow: any,
+    incomingEventName: string | undefined,
+    options: ExecutionOptions,
+    error: any
+  ): Promise<void> {
+    try {
+      // Pull the failing operation key from the most recent failure log row,
+      // mirroring the workflow compensation path so the email is specific.
+      let failingOperationKey: string | null = null
+      try {
+        const logs = await (this.flowService as any).listVisualFlowExecutionLogs(
+          { execution_id: executionId, status: "failure" },
+          { take: 1, order: { created_at: "DESC" } }
+        )
+        failingOperationKey = logs?.[0]?.operation_key ?? null
+      } catch {
+        // Best-effort — fall through to a generic event.
+      }
+
+      const eventBus: any = this.container.resolve(Modules.EVENT_BUS)
+      await eventBus.emit({
+        name: "visual_flow_execution.failed",
+        data: {
+          flow_id: flowId,
+          flow_name: flow?.name,
+          flow_metadata: flow?.metadata ?? null,
+          execution_id: executionId,
+          triggered_by: options.triggeredBy,
+          triggered_by_event: incomingEventName,
+          failing_operation_key: failingOperationKey,
+          error_message: error?.message ?? "Unknown error",
+          failed_at: new Date().toISOString(),
+        },
+      })
+    } catch {
+      // Intentional: see method comment.
     }
   }
 

--- a/apps/backend/src/scripts/seed-partner-run-whatsapp-flow.ts
+++ b/apps/backend/src/scripts/seed-partner-run-whatsapp-flow.ts
@@ -242,6 +242,15 @@ const map = {
     has_header: true,
   },
   // Add more mappings here as templates get approved in Meta.
+  //
+  // #32C decision: production_run.accepted / .started are INTENTIONALLY
+  // unmapped. They're the partner's own acknowledgement actions (they accepted
+  // / started the run), so there's no partner to notify — the wildcard trigger
+  // catches them but `no_template_for_event` skip is the correct, expected
+  // outcome (NOT a failure; the flow reports success on purpose). To start
+  // notifying on one of these, (1) create + get the template APPROVED in all
+  // target WABAs, (2) add it to src/scripts/whatsapp-templates/partner-run-templates.ts,
+  // (3) uncomment the matching line below.
   // "production_run.accepted":  { template: "…", vars: [...], has_header: false },
   // "production_run.started":   { template: "…", vars: [...], has_header: false },
   // "production_run.finished":  { template: "…", vars: [...], has_header: false },
@@ -249,6 +258,9 @@ const map = {
 
 const config = map[eventName]
 if (!config) {
+  // Expected skip for any production_run.* event without an approved template
+  // (e.g. .accepted / .started — see #32C note above). The downstream
+  // `has_template` condition routes this to log_skip and the flow succeeds.
   return { skipped: true, reason: "no_template_for_event", event: eventName }
 }
 

--- a/apps/backend/src/subscribers/__tests__/social-platform-credentials-encryption.unit.spec.ts
+++ b/apps/backend/src/subscribers/__tests__/social-platform-credentials-encryption.unit.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit test — encryptSocialPlatformCredentials (#32A token-shadow fix)
+ *
+ * The vflow-401 incident: a WhatsApp `SocialPlatform.api_config` carries a
+ * plaintext `access_token` (just-rotated) AND a STALE `access_token_encrypted`
+ * from a prior write. The resolver decrypts the ciphertext first, so it kept
+ * using the old/expired token → Meta code 190 / 401 on every send.
+ *
+ * The fix: a plaintext credential present in `api_config` is always the source
+ * of truth — `encryptBearer` must (re)encrypt it over any stale ciphertext and
+ * strip the plaintext, instead of skipping whenever a `*_encrypted` key exists.
+ *
+ * Uses a trivial reversible fake encryptor (not the real EncryptionService,
+ * which is constructed through Medusa's DI) — the helper only needs
+ * encrypt/decrypt symmetry.
+ *
+ * Run:
+ *   TEST_TYPE=unit npx jest --testPathPattern="social-platform-credentials-encryption"
+ */
+import { SOCIALS_MODULE } from "../../modules/socials"
+import { ENCRYPTION_MODULE } from "../../modules/encryption"
+import { encryptSocialPlatformCredentials } from "../social-platform-credentials-encryption"
+
+type FakeCipher = { enc: string }
+
+// Reversible, deterministic stand-in for AES-GCM. `decrypt` throws on a blob
+// it didn't produce, mirroring a ciphertext written under a rotated/old key.
+const fakeEncryption = {
+  encrypt: (s: string): FakeCipher => ({ enc: `v1:${Buffer.from(s).toString("base64")}` }),
+  decrypt: (d: any): string => {
+    if (!d || typeof d.enc !== "string" || !d.enc.startsWith("v1:")) {
+      throw new Error("undecryptable")
+    }
+    return Buffer.from(d.enc.slice(3), "base64").toString("utf8")
+  },
+}
+
+describe("encryptSocialPlatformCredentials (#32A)", () => {
+  // Build a fake container + socials service around a single platform row,
+  // capturing whatever the helper writes back so we can assert on it.
+  function makeHarness(apiConfig: Record<string, any>) {
+    const row = { id: "socplat_1", name: "WhatsApp", api_config: apiConfig }
+    let savedConfig: Record<string, any> | null = null
+    const socials = {
+      listSocialPlatforms: jest.fn(async () => [row]),
+      updateSocialPlatforms: jest.fn(async (updates: any[]) => {
+        savedConfig = updates[0].data.api_config
+        return [{ ...row, api_config: savedConfig }]
+      }),
+    }
+    const logger = { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+    const container: any = {
+      resolve: (key: string) => {
+        if (key === SOCIALS_MODULE) return socials
+        if (key === ENCRYPTION_MODULE) return fakeEncryption
+        if (key === "logger") return logger
+        throw new Error(`unexpected resolve(${key})`)
+      },
+    }
+    return { container, socials, getSaved: () => savedConfig }
+  }
+
+  it("re-encrypts a fresh plaintext token over a STALE ciphertext (the incident)", async () => {
+    // Stale ciphertext = the OLD expired token; plaintext = the rotated one.
+    const stale = fakeEncryption.encrypt("OLD-EXPIRED-TOKEN")
+    const { container, getSaved } = makeHarness({
+      provider: "whatsapp",
+      access_token: "NEW-ROTATED-TOKEN",
+      access_token_encrypted: stale,
+    })
+
+    const result = await encryptSocialPlatformCredentials("socplat_1", container)
+
+    expect(result.encrypted).toBe(true)
+    const saved = getSaved()!
+    // Plaintext stripped at rest…
+    expect(saved.access_token).toBeNull()
+    // …and the ciphertext now decrypts to the ROTATED token, not the stale one.
+    expect(fakeEncryption.decrypt(saved.access_token_encrypted)).toBe("NEW-ROTATED-TOKEN")
+  })
+
+  it("encrypts a plaintext token when no ciphertext exists yet", async () => {
+    const { container, getSaved } = makeHarness({
+      provider: "whatsapp",
+      access_token: "FIRST-TOKEN",
+    })
+
+    const result = await encryptSocialPlatformCredentials("socplat_1", container)
+
+    expect(result.encrypted).toBe(true)
+    const saved = getSaved()!
+    expect(saved.access_token).toBeNull()
+    expect(fakeEncryption.decrypt(saved.access_token_encrypted)).toBe("FIRST-TOKEN")
+  })
+
+  it("re-encrypts when the existing ciphertext is undecryptable (rotated key)", async () => {
+    const { container, getSaved } = makeHarness({
+      provider: "whatsapp",
+      access_token: "NEW-TOKEN",
+      access_token_encrypted: { enc: "garbage-not-ours" },
+    })
+
+    const result = await encryptSocialPlatformCredentials("socplat_1", container)
+
+    expect(result.encrypted).toBe(true)
+    const saved = getSaved()!
+    expect(saved.access_token).toBeNull()
+    expect(fakeEncryption.decrypt(saved.access_token_encrypted)).toBe("NEW-TOKEN")
+  })
+
+  it("strips a redundant plaintext that already matches the ciphertext (connect cleanup)", async () => {
+    // The connect route writes both plaintext + matching ciphertext.
+    const enc = fakeEncryption.encrypt("SAME-TOKEN")
+    const { container, getSaved } = makeHarness({
+      provider: "whatsapp",
+      access_token: "SAME-TOKEN",
+      access_token_encrypted: enc,
+    })
+
+    const result = await encryptSocialPlatformCredentials("socplat_1", container)
+
+    expect(result.encrypted).toBe(true)
+    const saved = getSaved()!
+    expect(saved.access_token).toBeNull()
+    expect(fakeEncryption.decrypt(saved.access_token_encrypted)).toBe("SAME-TOKEN")
+  })
+
+  it("is idempotent — a row with only ciphertext needs no write", async () => {
+    const enc = fakeEncryption.encrypt("TOKEN")
+    const { container, socials } = makeHarness({
+      provider: "whatsapp",
+      access_token: null,
+      access_token_encrypted: enc,
+    })
+
+    const result = await encryptSocialPlatformCredentials("socplat_1", container)
+
+    expect(result.encrypted).toBe(false)
+    expect(socials.updateSocialPlatforms).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/subscribers/social-platform-credentials-encryption.ts
+++ b/apps/backend/src/subscribers/social-platform-credentials-encryption.ts
@@ -2,6 +2,7 @@ import { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
 import { MedusaContainer } from "@medusajs/framework/types"
 import { SOCIALS_MODULE } from "../modules/socials"
 import { ENCRYPTION_MODULE } from "../modules/encryption"
+import type { EncryptedData } from "../modules/encryption"
 import SocialsService from "../modules/socials/service"
 import EncryptionService from "../modules/encryption/service"
 
@@ -35,16 +36,43 @@ export async function encryptSocialPlatformCredentials(
 
     const encryptBearer = (field: string) => {
       const value = apiConfig[field]
+      if (typeof value !== "string" || !value) return // nothing freshly submitted
       const encryptedKey = `${field}_encrypted`
-      if (typeof value === "string" && value && !apiConfig[encryptedKey]) {
-        encryptedConfig[encryptedKey] = encryptionService.encrypt(value)
-        // MikroORM merges JSON columns on update, so `delete` on the local
-        // object never reaches the DB. Null-out the key instead — the merge
-        // wipes the plaintext from storage.
-        encryptedConfig[field] = null
-        needsUpdate = true
-        logger.info(`[Encryption] ✓ Encrypted ${field} for platform ${platform.name}`)
+      const existing = apiConfig[encryptedKey]
+
+      // A plaintext value present in `api_config` always means a credential
+      // was just submitted — the only writers (the WhatsApp connect route and
+      // the generic External-Platforms edit) both set the plaintext field on a
+      // token change. Treat that plaintext as the source of truth and ALWAYS
+      // (re)encrypt it. The old guard (`!apiConfig[encryptedKey]`) skipped
+      // re-encryption whenever ANY `${field}_encrypted` already existed, so a
+      // STALE ciphertext left behind by a prior write kept shadowing the fresh
+      // token — and the resolver decrypts ciphertext first. That shadowing is
+      // the vflow-401 incident (#32A): a rotated WhatsApp token written as
+      // plaintext while the old ciphertext lingered → 190/401 on every send.
+      if (existing) {
+        let currentDecrypted: string | null = null
+        try {
+          currentDecrypted = encryptionService.decrypt(existing as EncryptedData)
+        } catch {
+          currentDecrypted = null // unreadable ciphertext → definitely re-encrypt
+        }
+        if (currentDecrypted === value) {
+          // Already in sync — just strip the redundant plaintext from storage
+          // (MikroORM merges JSON columns, so null-out rather than delete).
+          encryptedConfig[field] = null
+          needsUpdate = true
+          return
+        }
       }
+
+      encryptedConfig[encryptedKey] = encryptionService.encrypt(value)
+      // MikroORM merges JSON columns on update, so `delete` on the local
+      // object never reaches the DB. Null-out the key instead — the merge
+      // wipes the plaintext from storage.
+      encryptedConfig[field] = null
+      needsUpdate = true
+      logger.info(`[Encryption] ✓ (re)encrypted ${field} for platform ${platform.name}`)
     }
 
     // Single-token credentials: any non-OAuth platform (Qwen / OpenAI / Meta

--- a/apps/backend/src/subscribers/visual-flow-lifecycle-email.ts
+++ b/apps/backend/src/subscribers/visual-flow-lifecycle-email.ts
@@ -54,14 +54,26 @@ function shouldThrottle(key: string, now: number): boolean {
   return false
 }
 
-function resolveRecipient(data: any): string | null {
+// Recipient resolution (first non-empty wins):
+//   1. flow.metadata.failure_email  — per-flow override, set in admin UI
+//   2. VISUAL_FLOW_FAILURE_EMAIL     — platform default (set in prod SSM)
+//   3. MAILJET_FROM_EMAIL            — last-resort floor so a failure alert
+//      never silently no-ops. The 401 incident (#32B) paged nobody precisely
+//      because (1) and (2) were both unset and the subscriber bailed at debug
+//      level. The from-address is an inbox the team controls, so it's a
+//      sane catch-all until VISUAL_FLOW_FAILURE_EMAIL is configured.
+function resolveRecipient(data: any): { email: string; source: string } | null {
   const fromMetadata = data?.flow_metadata?.failure_email
   if (typeof fromMetadata === "string" && fromMetadata.includes("@")) {
-    return fromMetadata
+    return { email: fromMetadata, source: "flow.metadata.failure_email" }
   }
   const fromEnv = process.env.VISUAL_FLOW_FAILURE_EMAIL
   if (fromEnv && fromEnv.includes("@")) {
-    return fromEnv
+    return { email: fromEnv, source: "VISUAL_FLOW_FAILURE_EMAIL" }
+  }
+  const fallback = process.env.MAILJET_FROM_EMAIL
+  if (fallback && fallback.includes("@")) {
+    return { email: fallback, source: "MAILJET_FROM_EMAIL (fallback)" }
   }
   return null
 }
@@ -97,14 +109,18 @@ export default async function visualFlowLifecycleEmailHandler({
   const data = event.data || {}
   const eventName = event.name
 
-  const recipient = resolveRecipient(data)
-  if (!recipient) {
-    logger.debug(
-      `[visual-flow-lifecycle-email] ${eventName}: no recipient configured ` +
-        `(flow.metadata.failure_email + VISUAL_FLOW_FAILURE_EMAIL both empty); skipping`
+  const resolved = resolveRecipient(data)
+  if (!resolved) {
+    // WARN, not debug: a no-recipient bail is exactly how the 401 incident
+    // (#32B) paged nobody. Make the silent skip visible in logs/alerting.
+    logger.warn(
+      `[visual-flow-lifecycle-email] ${eventName}: NO RECIPIENT configured ` +
+        `(flow.metadata.failure_email + VISUAL_FLOW_FAILURE_EMAIL + MAILJET_FROM_EMAIL ` +
+        `all empty) — failure alert dropped. Set VISUAL_FLOW_FAILURE_EMAIL in prod.`
     )
     return
   }
+  const recipient = resolved.email
 
   const flowId = data.flow_id || "unknown"
   const flowName = data.flow_name || flowId
@@ -146,12 +162,22 @@ export default async function visualFlowLifecycleEmailHandler({
     return
   }
 
-  if (eventName === "visual_flow_execution.failed") {
+  // Both terminal-failure shapes alert identically (#32B, user-requested
+  // "email on fail AND cancelled"): the workflow rollback ends a run as
+  // `cancelled` while the engine path marks `failed`, and either means the
+  // flow didn't complete. Treat them the same so neither slips through.
+  if (
+    eventName === "visual_flow_execution.failed" ||
+    eventName === "visual_flow_execution.cancelled"
+  ) {
+    const status = eventName === "visual_flow_execution.cancelled" ? "cancelled" : "failed"
     const errMsg = data.error_message || "Unknown error"
-    const fp = `failed:${flowId}:${fingerprint(errMsg)}`
+    // Fingerprint is keyed by status too so a flow that emits both shapes
+    // doesn't suppress the second behind the first.
+    const fp = `${status}:${flowId}:${fingerprint(errMsg)}`
     if (shouldThrottle(fp, now)) {
       logger.debug(
-        `[visual-flow-lifecycle-email] throttled failure email for ${flowId} (fingerprint=${fp})`
+        `[visual-flow-lifecycle-email] throttled ${status} email for ${flowId} (fingerprint=${fp})`
       )
       return
     }
@@ -163,6 +189,7 @@ export default async function visualFlowLifecycleEmailHandler({
           data: {
             flow_name: flowName,
             execution_id: executionId,
+            status,
             failing_operation_key: data.failing_operation_key ?? null,
             error_message: errMsg,
             triggered_by: data.triggered_by ?? null,
@@ -173,19 +200,24 @@ export default async function visualFlowLifecycleEmailHandler({
         },
       })
       logger.info(
-        `[visual-flow-lifecycle-email] sent failure email for flow=${flowId} execution=${executionId}`
+        `[visual-flow-lifecycle-email] sent ${status} email to ${recipient} ` +
+          `(via ${resolved.source}) for flow=${flowId} execution=${executionId}`
       )
     } catch (err) {
       const message = err instanceof Error ? err.message : JSON.stringify(err)
       logger.error(
-        `[visual-flow-lifecycle-email] failed to send failure email: ${message}`
+        `[visual-flow-lifecycle-email] failed to send ${status} email: ${message}`
       )
     }
   }
 }
 
 export const config: SubscriberConfig = {
-  event: ["visual_flow_execution.started", "visual_flow_execution.failed"],
+  event: [
+    "visual_flow_execution.started",
+    "visual_flow_execution.failed",
+    "visual_flow_execution.cancelled",
+  ],
 }
 
 // Exposed for the integration test so it can reset throttle state
@@ -193,4 +225,5 @@ export const config: SubscriberConfig = {
 export const __testing = {
   clearThrottle: () => lastSentAt.clear(),
   fingerprint,
+  resolveRecipient,
 }

--- a/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
+++ b/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
@@ -964,7 +964,9 @@ interface + COD remittance loop before committing.
 
 #### 32. Visual-flow + WhatsApp token reliability (post-incident, vflow 401)
 
-**Status: ANALYSED 2026-06-15 — fix deferred to a dedicated session.**
+**Status: FIXED 2026-06-15 (A + B landed; C decided as intended).** Issues
+#405 (A), #406 (B), #407 (C). Code-only fixes; A also needs the one-time data
+unblock below in prod.
 Incident: the production WhatsApp flow `vflow_01KQ9RSZ1TFMB7MQ0Y64P4E98Y`
 ("Partner WhatsApp — Production Run (all events)") started failing in prod.
 Worker log (2026-06-14 19:46):
@@ -997,17 +999,28 @@ rotated token) tested directly against Meta is `is_valid: true`,
 `{WABA}/message_templates` call returns `ok: true`. So the token is good; the
 platform record just isn't using it.
 
-**Fix (A) — next session:**
-- Unify the token-update path so ANY token write re-encrypts
-  `access_token_encrypted` (or have the generic edit route through the same
-  encrypt step), and/or drop the plain `access_token` backward-compat field
-  entirely so there's one source of truth.
-- Consider making the resolver prefer the more-recently-written field, or
-  clear `access_token_encrypted` whenever a plain `access_token` is set.
-- **Immediate unblock (data-only, no deploy):** re-save the IN (and AU) token
-  through the WhatsApp **connect** route (which re-encrypts), OR null out the
-  stale `access_token_encrypted` so the resolver falls back to the good plain
-  token. Then re-run template sync.
+**Fix (A) — LANDED 2026-06-15.**
+- `encryptBearer` (in `subscribers/social-platform-credentials-encryption.ts`)
+  now treats a freshly-submitted plaintext as the source of truth: it ALWAYS
+  (re)encrypts it over any stale/mismatched ciphertext and strips the plaintext.
+  The old guard skipped re-encryption whenever any `*_encrypted` already
+  existed — the root cause. The WhatsApp **connect** route now routes through
+  the same helper so it no longer leaves a backward-compat plaintext behind.
+  Unit-tested (stale-ciphertext re-encrypt, first-encrypt, undecryptable key,
+  connect cleanup, idempotency).
+- **API hardening (added this session):** the admin social-platforms API no
+  longer echoes raw credentials — `redactApiConfig` strips plaintext AND
+  ciphertext from list/detail/create/update responses (presence booleans
+  only); a raw secret returns only for an MFA-enabled caller asking explicitly
+  (`?reveal_secrets=true`, fails closed); `preserveExistingSecrets` restores
+  omitted secrets server-side so blank-field saves don't wipe credentials.
+- **Still TODO in prod — immediate data unblock (data-only, no deploy):** the
+  fix corrects the NEXT write; the live IN/AU rows still hold the stale
+  ciphertext until re-saved. Re-save the IN (`01KP9N46ZGGM3N32E1N16Z5W4C`) and
+  AU (`01KPJJ4ACPRVW5QA27PVPX304V`) token through the WhatsApp **connect**
+  route (re-encrypts), OR null out the stale `access_token_encrypted`. Then
+  re-run template sync. (See `reference_prod_ecs_run_task_scripts` for running
+  one-off prod scripts via ECS run-task.)
 
 **Gap (B) — failure alerting didn't page anyone.** Roadmap #26 wired
 `visual_flow_execution.failed` → admin email
@@ -1018,28 +1031,39 @@ email. Also: the workflow path emits `failed` from its rollback compensation
 (status ends `cancelled`), but the **module engine path**
 (`modules/visual_flows/execution-engine.ts:140`) marks `failed` and emits **no
 event at all** → manual/test-run failures never email.
-**Fix (B) — next session (user-requested "email on fail AND cancelled"):**
-- Subscriber: handle `visual_flow_execution.cancelled` in addition to
-  `failed` (treat identically); escalate the no-recipient log debug→warn so a
-  silent skip is visible.
-- Engine path: emit a failure lifecycle event from the catch so engine/manual
-  runs also alert.
-- Recipient: set `VISUAL_FLOW_FAILURE_EMAIL` in prod (SSM) and/or a default
-  fallback so it never silently no-ops; document `flow.metadata.failure_email`
-  per-flow override.
+**Fix (B) — LANDED 2026-06-15.**
+- Subscriber now listens for `visual_flow_execution.cancelled` and handles it
+  identically to `failed` (fingerprint keyed by status so a flow emitting both
+  doesn't suppress the second).
+- No-recipient bail escalated debug→**WARN**, and a third recipient fallback
+  (`MAILJET_FROM_EMAIL`) was added so an alert never silently no-ops. Resolution
+  order: `flow.metadata.failure_email` → `VISUAL_FLOW_FAILURE_EMAIL` →
+  `MAILJET_FROM_EMAIL`. **Still recommended:** set `VISUAL_FLOW_FAILURE_EMAIL`
+  in prod SSM so alerts go to a real ops inbox rather than the from-address.
+- Engine path (`modules/visual_flows/execution-engine.ts`) now emits
+  `visual_flow_execution.failed` from its catch. **Caveat discovered:** the
+  engine path is dormant and currently can't run a canvas-built flow at all —
+  it resolves the graph by `operation.id` while canvas flows wire connections
+  by node id (`operation_key`), so it finds zero starting ops. The emit is
+  correct for when an op fails; the engine graph-resolution gap is a separate
+  pre-existing bug (not fixed here).
 
-**Gap (C) — `no_template_for_event` skips (secondary).** After the (still
-stale) token, recent runs log `Skipping WhatsApp for event
-production_run.accepted|started — reason: no_template_for_event` and the flow
-reports success. Decide whether those events SHOULD have templates (then the
-mapping/sync is the gap, dependent on (A)) or the skip is intended — confirm
-once (A) is fixed and templates re-sync.
+**Gap (C) — `no_template_for_event` skips — DECIDED 2026-06-15: intended.**
+The "all events" flow (`seed-partner-run-whatsapp-flow.ts`) lists to
+`production_run.*` and maps each event to a Meta-approved template;
+`production_run.accepted` / `.started` are deliberately unmapped. They're the
+partner's OWN acknowledgement actions (they accepted/started the run), so there
+is no partner to notify — the `no_template_for_event` skip is the correct,
+expected outcome and the flow reports success on purpose. This was never a
+token side-effect; it's a product decision. Documented inline in the seed's
+template map. To start notifying on one of these: create + APPROVE the template
+in all target WABAs, add it to `whatsapp-templates/partner-run-templates.ts`,
+and uncomment the matching map line.
 
-**First step (next session):** fix (A) — the token shadow — verify IN sends +
-template sync recover, then (B) the alerting so the next token expiry pages us
-instead of failing silently.
-**Effort:** ~half a day (A: token-write unification + data unblock; B:
-subscriber + engine-emit + recipient config; C: confirm).
+**Done this session:** A (token re-encryption + API secret redaction) and B
+(cancelled + engine-emit + no-silent-bail) landed with tests; C decided as
+intended. **Remaining:** the one-time prod data unblock for the stale IN/AU
+ciphertext (see Fix A above) + set `VISUAL_FLOW_FAILURE_EMAIL` in prod SSM.
 
 ---
 

--- a/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
+++ b/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
@@ -962,6 +962,85 @@ interface + COD remittance loop before committing.
 > capture-on-delivery (COD remittance) or a pre-auth; and whether this is
 > design-orders-only or all work-orders.
 
+#### 32. Visual-flow + WhatsApp token reliability (post-incident, vflow 401)
+
+**Status: ANALYSED 2026-06-15 — fix deferred to a dedicated session.**
+Incident: the production WhatsApp flow `vflow_01KQ9RSZ1TFMB7MQ0Y64P4E98Y`
+("Partner WhatsApp — Production Run (all events)") started failing in prod.
+Worker log (2026-06-14 19:46):
+`WhatsApp API error: 401 - {"error":{"message":"Authentication Error","code":190,"type":"OAuthException"}}`
+→ `[visual-flow-event-trigger] Failed to execute flow`. Meta **code 190 =
+expired/invalid access token**. (Later runs "succeed" by logging
+`Skipping WhatsApp … reason: no_template_for_event` — a separate, secondary
+gap, see (C).)
+
+**Root cause (A) — stale encrypted token shadows the freshly-set plain one.**
+A WhatsApp `SocialPlatform.api_config` carries BOTH `access_token` (plain,
+"backward compat") AND `access_token_encrypted`. The resolver
+`buildConfigFromPlatform` (`api/admin/social-platforms/whatsapp/helpers.ts`)
+reads `access_token_encrypted` FIRST (decrypt), and only falls back to the
+plain `access_token` if decrypt *throws*. There are two write paths:
+- the WhatsApp **connect** route (`whatsapp/connect/route.ts:40`) correctly
+  re-encrypts on update;
+- the **generic External-Platforms edit** writes only `access_token` (plain)
+  and leaves the OLD `access_token_encrypted` in place (`enc_updated: null`,
+  no `access_token_updated_at`).
+The admin rotated the token via the generic edit → plain updated, encrypted
+**stale** → resolver keeps using the **old expired** token → 190/401 on every
+send + on template sync + on the config WABA/phone validation (verified live:
+`whatsapp/config` returns `waba_info_ok: false`, `phone_info_ok: false` for
+BOTH the IN and AU platforms, which both have the same shadow shape).
+**Proof the new token is fine:** the `.env WHATSAPP_ACCESS_TOKEN` (the same
+rotated token) tested directly against Meta is `is_valid: true`,
+`type: SYSTEM_USER`, `expires_at: 0` (never expires), scopes
+`whatsapp_business_management` + `whatsapp_business_messaging`, and the exact
+`{WABA}/message_templates` call returns `ok: true`. So the token is good; the
+platform record just isn't using it.
+
+**Fix (A) — next session:**
+- Unify the token-update path so ANY token write re-encrypts
+  `access_token_encrypted` (or have the generic edit route through the same
+  encrypt step), and/or drop the plain `access_token` backward-compat field
+  entirely so there's one source of truth.
+- Consider making the resolver prefer the more-recently-written field, or
+  clear `access_token_encrypted` whenever a plain `access_token` is set.
+- **Immediate unblock (data-only, no deploy):** re-save the IN (and AU) token
+  through the WhatsApp **connect** route (which re-encrypts), OR null out the
+  stale `access_token_encrypted` so the resolver falls back to the good plain
+  token. Then re-run template sync.
+
+**Gap (B) — failure alerting didn't page anyone.** Roadmap #26 wired
+`visual_flow_execution.failed` → admin email
+(`subscribers/visual-flow-lifecycle-email.ts`), but it **bails silently** when
+no recipient is configured (`flow.metadata.failure_email` AND
+`VISUAL_FLOW_FAILURE_EMAIL` both empty) — which is why this 401 generated no
+email. Also: the workflow path emits `failed` from its rollback compensation
+(status ends `cancelled`), but the **module engine path**
+(`modules/visual_flows/execution-engine.ts:140`) marks `failed` and emits **no
+event at all** → manual/test-run failures never email.
+**Fix (B) — next session (user-requested "email on fail AND cancelled"):**
+- Subscriber: handle `visual_flow_execution.cancelled` in addition to
+  `failed` (treat identically); escalate the no-recipient log debug→warn so a
+  silent skip is visible.
+- Engine path: emit a failure lifecycle event from the catch so engine/manual
+  runs also alert.
+- Recipient: set `VISUAL_FLOW_FAILURE_EMAIL` in prod (SSM) and/or a default
+  fallback so it never silently no-ops; document `flow.metadata.failure_email`
+  per-flow override.
+
+**Gap (C) — `no_template_for_event` skips (secondary).** After the (still
+stale) token, recent runs log `Skipping WhatsApp for event
+production_run.accepted|started — reason: no_template_for_event` and the flow
+reports success. Decide whether those events SHOULD have templates (then the
+mapping/sync is the gap, dependent on (A)) or the skip is intended — confirm
+once (A) is fixed and templates re-sync.
+
+**First step (next session):** fix (A) — the token shadow — verify IN sends +
+template sync recover, then (B) the alerting so the next token expiry pages us
+instead of failing silently.
+**Effort:** ~half a day (A: token-write unification + data unblock; B:
+subscriber + engine-emit + recipient config; C: confirm).
+
 ---
 
 ## Suggested working order for the week


### PR DESCRIPTION
Resolves the vflow-401 incident (roadmap #32). Closes #405, #406; addresses #407.

## #32A — WhatsApp token shadow (the 401 root cause) — #405
`encryptBearer` only encrypted a token when **no** `*_encrypted` key existed, so a freshly-rotated plaintext `access_token` left the **stale** `access_token_encrypted` in place — and the resolver decrypts ciphertext first → Meta code 190 / 401 on every send + template sync. Now a submitted plaintext is always the source of truth: it's (re)encrypted over any stale/mismatched ciphertext and the plaintext is stripped. The WhatsApp connect route routes through the same helper (single source of truth).

## #32A — API secret hardening (added in-session)
The admin social-platforms API echoed raw credentials in `api_config`. Now:
- `redactApiConfig` strips **plaintext AND ciphertext** from list/detail/create/update responses (presence booleans only).
- `isSecretRevealAllowed` returns a raw secret **only** for an MFA-enabled identity asking explicitly (`?reveal_secrets=true`) — wired to Medusa native MFA (`listAuthMfa`), **fails closed**.
- `preserveExistingSecrets` restores omitted secrets server-side so blank-field saves don't wipe credentials.
- Runtime sends are unaffected (resolver reads the DB, not the API response).

## #32B — failure alerting — #406
- Subscriber now handles `visual_flow_execution.cancelled` identically to `failed`.
- No-recipient bail escalated debug→**WARN**; added `MAILJET_FROM_EMAIL` fallback so an alert never silently no-ops.
- Engine path emits a failure event from its catch. (Caveat: the engine path is dormant — it resolves a flow graph by `operation.id` while canvas flows wire by `operation_key`, a separate pre-existing bug; the emit is correct for when an op fails.)

## #32C — `no_template_for_event` — #407
**Decided: intended.** `production_run.accepted`/`.started` are the partner's own acknowledgement actions — no partner to notify, so the skip is correct (flow succeeds on purpose). Documented inline + in the roadmap.

## Tests
New unit specs for the encryption fix (5) and secret handling (11); `resolveRecipient` fallback covered; lifecycle integration spec green. No regressions (the pre-existing `estimate-design-cost` failure and ~70 tsc errors are unrelated — confirmed via stash).

## ⚠️ Do NOT merge until the prod data unblock is done
Merge → main auto-deploys to prod. This fix corrects the *next* write, but the live IN (`01KP9N46ZGGM3N32E1N16Z5W4C`) and AU (`01KPJJ4ACPRVW5QA27PVPX304V`) rows still hold stale ciphertext. Re-save each token through the connect route (or null the stale `access_token_encrypted`), then re-run template sync. Also set `VISUAL_FLOW_FAILURE_EMAIL` in SSM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)