### PR TITLE
hotfix(#32C): unbreak build — backticks in template-literal comment

### DIFF
--- a/apps/backend/src/scripts/seed-partner-run-whatsapp-flow.ts
+++ b/apps/backend/src/scripts/seed-partner-run-whatsapp-flow.ts
@@ -246,7 +246,7 @@ const map = {
   // #32C decision: production_run.accepted / .started are INTENTIONALLY
   // unmapped. They're the partner's own acknowledgement actions (they accepted
   // / started the run), so there's no partner to notify — the wildcard trigger
-  // catches them but `no_template_for_event` skip is the correct, expected
+  // catches them but the no_template_for_event skip is the correct, expected
   // outcome (NOT a failure; the flow reports success on purpose). To start
   // notifying on one of these, (1) create + get the template APPROVED in all
   // target WABAs, (2) add it to src/scripts/whatsapp-templates/partner-run-templates.ts,
@@ -260,7 +260,7 @@ const config = map[eventName]
 if (!config) {
   // Expected skip for any production_run.* event without an approved template
   // (e.g. .accepted / .started — see #32C note above). The downstream
-  // `has_template` condition routes this to log_skip and the flow succeeds.
+  // has_template condition routes this to log_skip and the flow succeeds.
   return { skipped: true, reason: "no_template_for_event", event: eventName }
 }
 


### PR DESCRIPTION
Hotfix for the build break from #408. The #32C comment was added inside the `RESOLVE_TEMPLATE_CODE` template literal and wrapped two terms in backticks, which terminated the literal early → `medusa build` failed (TS1005/TS2304), so the deploy on the #408 merge failed and main is currently broken.

Fix: plain text instead of backticks. Verified locally with `medusa build` → completes successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)