### PR TITLE
feat(shipping): #31 — Shiprocket pickup-location registration + backfill

### DIFF
--- a/apps/backend/src/api/admin/stock-locations/[id]/shiprocket-pickup/route.ts
+++ b/apps/backend/src/api/admin/stock-locations/[id]/shiprocket-pickup/route.ts
@@ -1,0 +1,25 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import {
+  getShiprocketPickupStatus,
+  registerShiprocketPickup,
+} from "../../../../../modules/shipping-providers/pickup-locations"
+
+/**
+ * Shiprocket pickup-location registration for a stock location (#31, §9).
+ *
+ * On-demand by design (SHIPPING_PROVIDERS.md §9.3): a partner/operator only sees
+ * or touches registration status when they explicitly ask — the inbound case
+ * stays invisible plumbing, the outbound case is a deliberate opt-in.
+ *
+ * GET  → current registration + phone-verification status (null if unregistered)
+ * POST → register (idempotent) and record the nickname on the location
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const status = await getShiprocketPickupStatus(req.scope, req.params.id)
+  res.json({ pickup: status })
+}
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const result = await registerShiprocketPickup(req.scope, req.params.id)
+  res.json({ pickup: result })
+}

--- a/apps/backend/src/modules/shipping-providers/pickup-locations.ts
+++ b/apps/backend/src/modules/shipping-providers/pickup-locations.ts
@@ -1,0 +1,208 @@
+/**
+ * Shiprocket pickup-location registration (#31, SHIPPING_PROVIDERS.md §9).
+ *
+ * Resolver-driven, mirrors how Delhivery warehouses are wired but sources creds
+ * from the external-platform store via `resolveShippingProvider` rather than the
+ * fulfillment-module registry + env vars.
+ *
+ * A Shiprocket pickup point is referenced by a unique nickname string
+ * (`pickup_location`), not by address. We use a deterministic nickname per stock
+ * location (`warehouse-<locationSuffix>`, the same scheme as Delhivery) so the
+ * mapping survives re-runs, then record it on `stock_location.metadata`.
+ *
+ * Registration is idempotent: we list existing pickups first and treat an
+ * already-present nickname as success. Note "registered" ≠ "shippable" —
+ * Shiprocket requires the pickup phone to be OTP-verified before live pickups,
+ * so callers surface `phone_verified` (per §9.3, only on demand).
+ */
+import { MedusaContainer } from "@medusajs/framework/types"
+import { MedusaError, Modules } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { PickupLocation } from "./provider-interface"
+import { resolveShippingProvider } from "./resolver"
+
+/** Metadata key recording the Shiprocket nickname for a stock location. */
+export const SHIPROCKET_PICKUP_METADATA_KEY = "shiprocket_pickup_location"
+
+/**
+ * Deterministic pickup nickname for a stock location. Same scheme as the
+ * Delhivery warehouse name (`warehouse-<last 8 of locationId>`) so a location
+ * that already carries a Delhivery warehouse maps to a matching Shiprocket
+ * nickname.
+ */
+export function pickupNicknameForLocation(locationId: string): string {
+  return `warehouse-${locationId.slice(-8)}`
+}
+
+export type PickupRegistrationResult = {
+  /** The nickname now recorded on the stock location. */
+  name: string
+  /** True when the nickname already existed in Shiprocket (no add performed). */
+  already_existed: boolean
+  /** Phone-verification status from the carrier list, when known. */
+  phone_verified?: boolean
+  /** The matched/created carrier-side pickup record, when available. */
+  location?: PickupLocation
+}
+
+type StockLocationRow = {
+  id: string
+  name?: string
+  metadata?: Record<string, any> | null
+  address?: {
+    phone?: string
+    address_1?: string
+    address_2?: string
+    city?: string
+    province?: string
+    postal_code?: string
+    country_code?: string
+  } | null
+}
+
+async function loadStockLocation(
+  container: MedusaContainer,
+  locationId: string
+): Promise<StockLocationRow> {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const { data } = await query.graph({
+    entity: "stock_location",
+    fields: ["id", "name", "metadata", "address.*"],
+    filters: { id: locationId },
+  })
+  const loc = (data as any)?.[0]
+  if (!loc) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Stock location ${locationId} not found`
+    )
+  }
+  return loc as StockLocationRow
+}
+
+/**
+ * Register (or confirm) a stock location as a Shiprocket pickup point and record
+ * the nickname on `stock_location.metadata`. Idempotent — safe to re-run.
+ *
+ * Used by the admin on-demand action (opt-in / inbound auto-register) and the
+ * backfill script. `email` is optional; Shiprocket accepts an empty contact
+ * email on the pickup address.
+ */
+export async function registerShiprocketPickup(
+  container: MedusaContainer,
+  locationId: string
+): Promise<PickupRegistrationResult> {
+  const loc = await loadStockLocation(container, locationId)
+  const existingNickname = (loc.metadata as any)?.[
+    SHIPROCKET_PICKUP_METADATA_KEY
+  ] as string | undefined
+  const nickname = existingNickname || pickupNicknameForLocation(locationId)
+
+  const provider = await resolveShippingProvider(container, "shiprocket")
+  if (!provider.registerPickupLocation) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "Shiprocket provider does not support pickup-location registration"
+    )
+  }
+
+  // Idempotency: skip the add if the nickname already exists carrier-side.
+  let existing: PickupLocation | undefined
+  if (provider.listPickupLocations) {
+    try {
+      const list = await provider.listPickupLocations()
+      existing = list.find((p) => p.name === nickname)
+    } catch {
+      // List failing shouldn't block a register attempt; addpickup itself
+      // rejects duplicate nicknames, which we treat as success below.
+    }
+  }
+
+  let alreadyExisted = Boolean(existing)
+  if (!existing) {
+    const addr = loc.address || {}
+    if (!addr.phone || !addr.postal_code) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Stock location ${locationId} is missing a phone or postal code required to register a Shiprocket pickup`
+      )
+    }
+    try {
+      await provider.registerPickupLocation({
+        name: nickname,
+        phone: addr.phone,
+        email: undefined,
+        address_1: addr.address_1 || "",
+        address_2: addr.address_2 || "",
+        city: addr.city || "",
+        state: addr.province || "",
+        pincode: addr.postal_code,
+        country: "India",
+      })
+    } catch (e: any) {
+      // Shiprocket rejects a duplicate nickname — treat that as already-present.
+      if (/already|exist|duplicate/i.test(String(e?.message || ""))) {
+        alreadyExisted = true
+      } else {
+        throw e
+      }
+    }
+  }
+
+  // Record the nickname on the stock location (preserve other metadata).
+  await persistNickname(container, loc, nickname)
+
+  return {
+    name: nickname,
+    already_existed: alreadyExisted,
+    phone_verified: existing?.phone_verified,
+    location: existing,
+  }
+}
+
+/** Persist the Shiprocket nickname onto a stock location's metadata. */
+async function persistNickname(
+  container: MedusaContainer,
+  loc: StockLocationRow,
+  nickname: string
+): Promise<void> {
+  if ((loc.metadata as any)?.[SHIPROCKET_PICKUP_METADATA_KEY] === nickname) {
+    return
+  }
+  const stockLocationService = container.resolve(Modules.STOCK_LOCATION) as any
+  await stockLocationService.updateStockLocations(loc.id, {
+    metadata: {
+      ...(loc.metadata || {}),
+      [SHIPROCKET_PICKUP_METADATA_KEY]: nickname,
+    },
+  })
+}
+
+/**
+ * Map an already-recorded nickname for a stock location onto its live carrier
+ * status. Returns null when the location has no nickname recorded. Used by the
+ * admin GET (default-hidden status) — no registration side effects.
+ */
+export async function getShiprocketPickupStatus(
+  container: MedusaContainer,
+  locationId: string
+): Promise<PickupRegistrationResult | null> {
+  const loc = await loadStockLocation(container, locationId)
+  const nickname = (loc.metadata as any)?.[SHIPROCKET_PICKUP_METADATA_KEY] as
+    | string
+    | undefined
+  if (!nickname) return null
+
+  const provider = await resolveShippingProvider(container, "shiprocket")
+  let existing: PickupLocation | undefined
+  if (provider.listPickupLocations) {
+    const list = await provider.listPickupLocations()
+    existing = list.find((p) => p.name === nickname)
+  }
+  return {
+    name: nickname,
+    already_existed: Boolean(existing),
+    phone_verified: existing?.phone_verified,
+    location: existing,
+  }
+}

--- a/apps/backend/src/modules/shipping-providers/provider-interface.ts
+++ b/apps/backend/src/modules/shipping-providers/provider-interface.ts
@@ -170,6 +170,25 @@ export type RegisterPickupLocationInput = {
   gstin?: string
 }
 
+/**
+ * A registered pickup location as the carrier reports it. The nickname is what
+ * `createShipment`/`registerPickupLocation` reference; `phone_verified` matters
+ * because "registered" ≠ "shippable" for Shiprocket (phone must be OTP-verified
+ * before live pickups). See SHIPPING_PROVIDERS.md §9.
+ */
+export type PickupLocation = {
+  /** The unique nickname callers reference (Shiprocket `pickup_location`). */
+  name: string
+  /** Carrier-side id, when exposed. */
+  id?: string | number
+  /** True when the pickup address phone is OTP-verified (usable for live pickups). */
+  phone_verified?: boolean
+  city?: string
+  state?: string
+  pincode?: string
+  raw?: any
+}
+
 export type LabelResult = {
   label_url?: string
   /** Base64-encoded label payload when the provider returns bytes, not a URL. */
@@ -205,6 +224,13 @@ export interface ShippingProviderClient {
   registerPickupLocation?(
     input: RegisterPickupLocationInput
   ): Promise<{ name: string; raw?: any }>
+
+  /**
+   * List the carrier's registered pickup locations. Used for idempotent
+   * registration (skip if the nickname already exists) and to surface
+   * phone-verification status. Optional — not every carrier exposes a list API.
+   */
+  listPickupLocations?(): Promise<PickupLocation[]>
 
   /** Normalize an inbound tracking webhook payload (P2). */
   normalizeWebhook?(payload: any): TrackingResult

--- a/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
@@ -12,6 +12,7 @@
 import {
   CreateShipmentInput,
   LabelResult,
+  PickupLocation,
   RateOption,
   RateQuery,
   RegisterPickupLocationInput,
@@ -334,6 +335,32 @@ export class ShiprocketClient implements ShippingProviderClient {
       }),
     })
     return { name: input.name, raw: json }
+  }
+
+  /**
+   * List registered pickup locations (`data.shipping_address[]`). Used for
+   * idempotent registration and to surface phone-verification status — a
+   * Shiprocket pickup point isn't usable for live pickups until its phone is
+   * OTP-verified, so "registered" ≠ "shippable".
+   */
+  async listPickupLocations(): Promise<PickupLocation[]> {
+    const json = await this.request<any>(`/settings/company/pickup`, {
+      method: "GET",
+    })
+    const rows = json?.data?.shipping_address || []
+    return rows.map((r: any) => ({
+      name: r.pickup_location || r.name || "",
+      id: r.id,
+      // Shiprocket returns 0/1; treat truthy non-zero as verified.
+      phone_verified:
+        r.phone_verified !== undefined
+          ? Boolean(Number(r.phone_verified))
+          : undefined,
+      city: r.city,
+      state: r.state,
+      pincode: r.pin_code,
+      raw: r,
+    }))
   }
 
   /** Normalize the Shiprocket webhook push payload (P2). */

--- a/apps/backend/src/scripts/backfill-shiprocket-pickup-locations.ts
+++ b/apps/backend/src/scripts/backfill-shiprocket-pickup-locations.ts
@@ -1,0 +1,156 @@
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { resolveShippingProvider } from "../modules/shipping-providers/resolver"
+import {
+  pickupNicknameForLocation,
+  SHIPROCKET_PICKUP_METADATA_KEY,
+} from "../modules/shipping-providers/pickup-locations"
+import { PickupLocation } from "../modules/shipping-providers/provider-interface"
+
+/**
+ * Map pre-registered Shiprocket pickup locations onto our stock locations
+ * (#31, SHIPPING_PROVIDERS.md §9).
+ *
+ * Many warehouses already exist in our Shiprocket account (added by hand on the
+ * dashboard before this feature). This backfill records the carrier nickname on
+ * `stock_location.metadata.shiprocket_pickup_location` so existing
+ * partners/stores are wired up WITHOUT re-registering (which would fail on the
+ * unique-nickname constraint anyway).
+ *
+ * Matching (first hit wins, per location):
+ *   1. metadata already set            → skip (idempotent)
+ *   2. exact nickname `warehouse-<sfx>`→ deterministic scheme (same as Delhivery)
+ *   3. unique pincode match            → single Shiprocket pickup on that pin
+ *   4. unique (city + pincode) match   → narrows when a pin has several pickups
+ * Ambiguous (>1 candidate) and unmatched locations are reported, never guessed.
+ *
+ * Run:
+ *   npx medusa exec ./src/scripts/backfill-shiprocket-pickup-locations.ts
+ * Dry run (reports, writes nothing):
+ *   npx medusa exec ./src/scripts/backfill-shiprocket-pickup-locations.ts -- --dry-run
+ *   DRY_RUN=1 npx medusa exec ./src/scripts/backfill-shiprocket-pickup-locations.ts
+ */
+export default async function backfillShiprocketPickupLocations({
+  container,
+  args,
+}: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const stockLocationService = container.resolve(Modules.STOCK_LOCATION) as any
+
+  const dryRun =
+    (args ?? []).includes("--dry-run") || process.env.DRY_RUN === "1"
+  if (dryRun) logger.info("[shiprocket-backfill] DRY RUN — no metadata written.")
+
+  // 1. Pull every registered Shiprocket pickup.
+  let pickups: PickupLocation[] = []
+  try {
+    const provider = await resolveShippingProvider(container, "shiprocket")
+    if (!provider.listPickupLocations) {
+      logger.error("[shiprocket-backfill] provider has no listPickupLocations()")
+      return
+    }
+    pickups = await provider.listPickupLocations()
+  } catch (e: any) {
+    logger.error(
+      `[shiprocket-backfill] could not list Shiprocket pickups: ${e?.message}`
+    )
+    return
+  }
+  logger.info(`[shiprocket-backfill] ${pickups.length} Shiprocket pickup(s) found`)
+  if (!pickups.length) return
+
+  const byNickname = new Map(pickups.map((p) => [p.name, p]))
+  const byPincode = new Map<string, PickupLocation[]>()
+  for (const p of pickups) {
+    if (!p.pincode) continue
+    const list = byPincode.get(p.pincode) || []
+    list.push(p)
+    byPincode.set(p.pincode, list)
+  }
+
+  // 2. Every stock location with its address + metadata.
+  const { data: locations } = await query.graph({
+    entity: "stock_location",
+    fields: ["id", "name", "metadata", "address.*"],
+  })
+
+  let mapped = 0
+  let skipped = 0
+  const ambiguous: string[] = []
+  const unmatched: string[] = []
+
+  for (const loc of (locations || []) as any[]) {
+    const label = `${loc.name || "(unnamed)"} [${loc.id}]`
+    if (loc.metadata?.[SHIPROCKET_PICKUP_METADATA_KEY]) {
+      skipped++
+      continue
+    }
+
+    const addr = loc.address || {}
+    const pin = addr.postal_code as string | undefined
+    const city = (addr.city as string | undefined)?.toLowerCase()
+
+    let match: PickupLocation | undefined
+    let how = ""
+
+    // 2a. deterministic nickname
+    const nickname = pickupNicknameForLocation(loc.id)
+    if (byNickname.has(nickname)) {
+      match = byNickname.get(nickname)
+      how = "nickname"
+    }
+
+    // 2b/2c. pincode (optionally narrowed by city)
+    if (!match && pin) {
+      const candidates = byPincode.get(pin) || []
+      if (candidates.length === 1) {
+        match = candidates[0]
+        how = "pincode"
+      } else if (candidates.length > 1 && city) {
+        const narrowed = candidates.filter(
+          (c) => (c.city || "").toLowerCase() === city
+        )
+        if (narrowed.length === 1) {
+          match = narrowed[0]
+          how = "pincode+city"
+        } else if (narrowed.length > 1) {
+          ambiguous.push(`${label} — ${narrowed.length} pickups on ${pin}/${city}`)
+        }
+      } else if (candidates.length > 1) {
+        ambiguous.push(`${label} — ${candidates.length} pickups on pincode ${pin}`)
+      }
+    }
+
+    if (!match) {
+      unmatched.push(label)
+      continue
+    }
+
+    const verified = match.phone_verified === false ? " (phone UNVERIFIED)" : ""
+    logger.info(
+      `[shiprocket-backfill] ${dryRun ? "would map" : "mapping"} ${label} → "${match.name}" via ${how}${verified}`
+    )
+    if (!dryRun) {
+      await stockLocationService.updateStockLocations(loc.id, {
+        metadata: {
+          ...(loc.metadata || {}),
+          [SHIPROCKET_PICKUP_METADATA_KEY]: match.name,
+        },
+      })
+    }
+    mapped++
+  }
+
+  logger.info(
+    `[shiprocket-backfill] done — ${mapped} mapped, ${skipped} already set, ${ambiguous.length} ambiguous, ${unmatched.length} unmatched`
+  )
+  if (ambiguous.length) {
+    logger.warn(`[shiprocket-backfill] ambiguous (resolve manually):`)
+    ambiguous.forEach((a) => logger.warn(`  - ${a}`))
+  }
+  if (unmatched.length) {
+    logger.info(`[shiprocket-backfill] unmatched (no Shiprocket pickup found):`)
+    unmatched.forEach((u) => logger.info(`  - ${u}`))
+  }
+}

--- a/apps/docs/notes/SHIPPING_PROVIDERS.md
+++ b/apps/docs/notes/SHIPPING_PROVIDERS.md
@@ -167,9 +167,12 @@ Delhivery's equivalent is `registerWarehouse` (a named warehouse), wired today i
 - `ShiprocketFulfillmentService.createFulfillment` already **reads** the nickname
   from `fromLocation.metadata.shiprocket_pickup_location` (→ `fromLocation.name`
   → `"Primary"`) — the deliberate parallel to `delhivery_warehouse_name`.
-- **Gap:** `shiprocket_pickup_location` is only ever read, never written. Nothing
-  registers the location or records the nickname. Also missing: a `list` method
-  (for idempotency) and surfacing of phone-verification status.
+- **Gap (CLOSED 2026-06-15):** `shiprocket_pickup_location` was only ever read,
+  never written. Now wired (branch `feat/31-shiprocket-pickup-registration`):
+  `ShiprocketClient.listPickupLocations()` (idempotency + phone-verification
+  status), a resolver-driven `registerShiprocketPickup()` helper that writes the
+  nickname onto `stock_location.metadata`, an on-demand admin route, and a
+  backfill script for pre-registered warehouses. See §9.5.
 - **Watch-out:** Shiprocket requires the pickup address's **phone to be
   OTP-verified** before it's usable for live pickups. `addpickup` *creates* the
   location; verification is a separate (often manual, dashboard/OTP) step. So
@@ -207,3 +210,28 @@ a deliberate choice.)
 Stays consistent with the spike decision (carriers as external-platform
 providers, resolver-sourced creds) rather than Delhivery's env-var +
 fulfillment-module-registry path.
+
+### 9.5 What was built (2026-06-15, branch `feat/31-shiprocket-pickup-registration`)
+
+| Piece | Location | Notes |
+|-------|----------|-------|
+| `PickupLocation` type + `listPickupLocations?()` | `shipping-providers/provider-interface.ts` | normalized list result incl. `phone_verified` |
+| `ShiprocketClient.listPickupLocations()` | `shiprocket/client.ts` | `GET /settings/company/pickup` → `data.shipping_address[]`; maps `phone_verified` 0/1 → boolean |
+| `registerShiprocketPickup()` / `getShiprocketPickupStatus()` | `shipping-providers/pickup-locations.ts` | resolver-driven, idempotent (lists first, treats duplicate-nickname errors as success), writes `stock_location.metadata.shiprocket_pickup_location`. `SHIPROCKET_PICKUP_METADATA_KEY` + `pickupNicknameForLocation()` exported |
+| Admin route | `admin/stock-locations/[id]/shiprocket-pickup/route.ts` | `GET` status (null if unregistered), `POST` register — on-demand per §9.3 |
+| Backfill | `scripts/backfill-shiprocket-pickup-locations.ts` | maps **pre-registered** Shiprocket pickups onto stock locations by nickname → unique pincode → pincode+city; dry-run (`--dry-run` / `DRY_RUN=1`); reports ambiguous/unmatched, never guesses |
+
+**Nickname scheme:** `warehouse-<last 8 of locationId>` — identical to the
+Delhivery warehouse name, so a location maps to the same nickname on both
+carriers.
+
+**Still open:**
+- **Inbound auto-register** (call `registerShiprocketPickup` from
+  `create-store-with-defaults.ts` alongside the Delhivery branch for `country ===
+  "in"`) — not yet wired; the helper + route exist, the auto-trigger doesn't.
+- **Outbound opt-in UI** — admin/partner surface that calls `POST` (the route is
+  ready; no UI control yet).
+- **Live verification** — untested against the real Shiprocket API; needs test
+  creds + a `category: shipping` Shiprocket platform record. The
+  `data.shipping_address[]` field names (esp. `phone_verified`) should be
+  confirmed against a live response.


### PR DESCRIPTION
Builds the Shiprocket pickup-location registration planned in `SHIPPING_PROVIDERS.md` §9 (issue #404, roadmap #31). Mirrors the Delhivery warehouse pattern but resolver-driven (creds from the external-platform store, not env vars + fulfillment registry).

## What's in it
- **`listPickupLocations()`** on the `ShippingProviderClient` interface + `ShiprocketClient` (`GET /settings/company/pickup`), normalizing `data.shipping_address[]` → `PickupLocation` incl. `phone_verified`. ("registered" ≠ "shippable" — Shiprocket requires OTP-verified phone.)
- **`pickup-locations.ts`** helper: `registerShiprocketPickup()` + `getShiprocketPickupStatus()`. Idempotent (lists first, treats duplicate-nickname errors as success), deterministic nickname `warehouse-<last 8 of locationId>` (same scheme as Delhivery), writes `stock_location.metadata.shiprocket_pickup_location`.
- **Admin route** `/admin/stock-locations/:id/shiprocket-pickup` — `GET` status (null if unregistered), `POST` register. On-demand per §9.3 default-hidden design.
- **Backfill script** `backfill-shiprocket-pickup-locations.ts` — maps **pre-registered** Shiprocket warehouses (added by hand on the dashboard) onto stock locations by nickname → unique pincode → pincode+city. Dry-run aware (`--dry-run` / `DRY_RUN=1`); reports ambiguous/unmatched, never guesses.

## Verify
`cd apps/backend && npx tsc --noEmit -p tsconfig.json` → 70 errors, all pre-existing baseline (react-hook-form resolver generics); **zero in touched files**.

Live path untested — needs test creds + a `category: shipping` Shiprocket platform record. The `data.shipping_address[]` field names (esp. `phone_verified`) should be confirmed against a live response before relying on them.

## Still open (follow-ups, see §9.5)
- Inbound auto-register wiring in `create-store-with-defaults.ts` (helper exists, auto-trigger doesn't).
- Outbound opt-in UI control (route is ready).
- Live verification against the real API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)