### PR TITLE
feat(shipping): #31 — Shiprocket in fulfillment providers, inbound auto-register, opt-in UI + test

### DIFF
--- a/apps/backend/integration-tests/http/shiprocket-pickup-registration.spec.ts
+++ b/apps/backend/integration-tests/http/shiprocket-pickup-registration.spec.ts
@@ -1,0 +1,225 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+
+jest.setTimeout(90 * 1000)
+
+/**
+ * Shiprocket pickup-location registration (#31, SHIPPING_PROVIDERS.md §9).
+ *
+ * Exercises the full route → helper → resolver → client chain for
+ * `/admin/stock-locations/:id/shiprocket-pickup` (GET status, POST register)
+ * without touching the live Shiprocket API:
+ *  - creds come from the resolver's env-var fallback (no SocialPlatform record
+ *    needed), and
+ *  - the Shiprocket HTTP calls (`/auth/login`, `/settings/company/pickup`,
+ *    `/settings/company/addpickup`) are stubbed via a stateful `global.fetch`
+ *    mock — Shiprocket has no sandbox endpoint.
+ */
+
+type MockPickup = {
+  pickup_location: string
+  phone_verified: number
+  city?: string
+  state?: string
+  pin_code?: string
+  id?: number
+}
+
+type MockState = { pickups: MockPickup[]; addCalls: number; loginCalls: number }
+
+/**
+ * Install a stateful Shiprocket fetch stub; non-Shiprocket URLs pass through.
+ *
+ * NOTE: `medusaIntegrationTestRunner` runs the server in-process, so this stub
+ * sees the server's OWN fetch calls too. Native (undici) fetch must be invoked
+ * bound to `globalThis` — calling it detached throws — so we bind the real
+ * fetch before spying and route every non-Shiprocket URL straight through it.
+ */
+function installShiprocketMock(state: MockState) {
+  const realFetch = global.fetch.bind(globalThis)
+  return jest
+    .spyOn(global, "fetch" as any)
+    .mockImplementation(async (input: any, init: any = {}) => {
+      const url = String(input)
+      const make = (body: any, status = 200) =>
+        ({
+          ok: status >= 200 && status < 300,
+          status,
+          json: async () => body,
+          text: async () => JSON.stringify(body),
+        } as any)
+
+      if (!url.includes("shiprocket.in")) {
+        return realFetch(input, init)
+      }
+      if (url.endsWith("/auth/login")) {
+        state.loginCalls++
+        return make({ token: "test-token-123" })
+      }
+      if (url.includes("/settings/company/pickup")) {
+        return make({ data: { shipping_address: state.pickups } })
+      }
+      if (url.includes("/settings/company/addpickup")) {
+        state.addCalls++
+        const body = JSON.parse(init.body || "{}")
+        state.pickups.push({
+          pickup_location: body.pickup_location,
+          phone_verified: 0,
+          city: body.city,
+          state: body.state,
+          pin_code: body.pin_code,
+          id: state.pickups.length + 1,
+        })
+        return make({ success: true, address: { pickup_code: body.pickup_location } })
+      }
+      return make({}, 404)
+    })
+}
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Admin API - Shiprocket pickup registration", () => {
+    let adminHeaders: Record<string, any>
+    let mock: ReturnType<typeof installShiprocketMock>
+    let state: MockState
+    let prevEmail: string | undefined
+    let prevPassword: string | undefined
+
+    beforeAll(async () => {
+      // Resolver env-var fallback — avoids seeding a `category: shipping`
+      // SocialPlatform record just to provide creds.
+      prevEmail = process.env.SHIPROCKET_EMAIL
+      prevPassword = process.env.SHIPROCKET_PASSWORD
+      process.env.SHIPROCKET_EMAIL = "test@shiprocket.example"
+      process.env.SHIPROCKET_PASSWORD = "secret"
+
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+    })
+
+    afterAll(() => {
+      if (prevEmail === undefined) delete process.env.SHIPROCKET_EMAIL
+      else process.env.SHIPROCKET_EMAIL = prevEmail
+      if (prevPassword === undefined) delete process.env.SHIPROCKET_PASSWORD
+      else process.env.SHIPROCKET_PASSWORD = prevPassword
+    })
+
+    beforeEach(() => {
+      state = { pickups: [], addCalls: 0, loginCalls: 0 }
+      mock = installShiprocketMock(state)
+    })
+
+    afterEach(() => {
+      mock?.mockRestore()
+    })
+
+    async function createLocation(address?: Record<string, any>) {
+      const res = await api.post(
+        "/admin/stock-locations",
+        {
+          name: `SR Warehouse ${Date.now()}`,
+          address: {
+            address_1: "1 Mill Road",
+            city: "Jaipur",
+            province: "RJ",
+            postal_code: "302001",
+            country_code: "IN",
+            phone: "9999999999",
+            ...address,
+          },
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      return res.data.stock_location.id as string
+    }
+
+    it("GET returns null when the location has no pickup recorded", async () => {
+      const locationId = await createLocation()
+      const res = await api.get(
+        `/admin/stock-locations/${locationId}/shiprocket-pickup`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.pickup).toBeNull()
+    })
+
+    it("POST registers a new pickup and records the nickname on the location", async () => {
+      const locationId = await createLocation()
+      const expectedNickname = `warehouse-${locationId.slice(-8)}`
+
+      const res = await api.post(
+        `/admin/stock-locations/${locationId}/shiprocket-pickup`,
+        {},
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.pickup.name).toBe(expectedNickname)
+      expect(res.data.pickup.already_existed).toBe(false)
+      // One add call against the carrier, with the deterministic nickname.
+      expect(state.addCalls).toBe(1)
+      expect(state.pickups.map((p) => p.pickup_location)).toContain(expectedNickname)
+
+      // Nickname is now persisted → GET surfaces it.
+      const statusRes = await api.get(
+        `/admin/stock-locations/${locationId}/shiprocket-pickup`,
+        adminHeaders
+      )
+      expect(statusRes.data.pickup).not.toBeNull()
+      expect(statusRes.data.pickup.name).toBe(expectedNickname)
+    })
+
+    it("POST is idempotent — a re-register does not add a second carrier pickup", async () => {
+      const locationId = await createLocation()
+      const expectedNickname = `warehouse-${locationId.slice(-8)}`
+
+      await api.post(
+        `/admin/stock-locations/${locationId}/shiprocket-pickup`,
+        {},
+        adminHeaders
+      )
+      expect(state.addCalls).toBe(1)
+
+      const second = await api.post(
+        `/admin/stock-locations/${locationId}/shiprocket-pickup`,
+        {},
+        adminHeaders
+      )
+      expect(second.status).toBe(200)
+      expect(second.data.pickup.name).toBe(expectedNickname)
+      expect(second.data.pickup.already_existed).toBe(true)
+      // No second add — the existing nickname was matched via the list call.
+      expect(state.addCalls).toBe(1)
+    })
+
+    it("GET surfaces phone-verification status from the carrier list", async () => {
+      const locationId = await createLocation()
+      await api.post(
+        `/admin/stock-locations/${locationId}/shiprocket-pickup`,
+        {},
+        adminHeaders
+      )
+      // Carrier OTP-verifies the pickup phone after registration.
+      state.pickups.forEach((p) => (p.phone_verified = 1))
+
+      const res = await api.get(
+        `/admin/stock-locations/${locationId}/shiprocket-pickup`,
+        adminHeaders
+      )
+      expect(res.data.pickup.phone_verified).toBe(true)
+    })
+
+    it("POST 400s when the location is missing a phone or postal code", async () => {
+      const locationId = await createLocation({ phone: "", postal_code: "" })
+      await expect(
+        api.post(
+          `/admin/stock-locations/${locationId}/shiprocket-pickup`,
+          {},
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 400 } })
+      expect(state.addCalls).toBe(0)
+    })
+  })
+})

--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -289,6 +289,23 @@ module.exports = defineConfig({
                 },
               ]
             : []),
+          // Shiprocket (#31). Registers the Medusa fulfillment provider for the
+          // checkout/createFulfillment flow. The resolver-driven label/tracking/
+          // pickup routes source creds from the external-platform store instead;
+          // these env options are the boot-time fallback (no sandbox endpoint).
+          ...(process.env.SHIPROCKET_EMAIL
+            ? [
+                {
+                  resolve: "./src/modules/shipping-providers/shiprocket",
+                  id: "shiprocket",
+                  options: {
+                    email: process.env.SHIPROCKET_EMAIL,
+                    password: process.env.SHIPROCKET_PASSWORD,
+                    pickup_location: process.env.SHIPROCKET_PICKUP_LOCATION,
+                  },
+                },
+              ]
+            : []),
           ...(process.env.DHL_API_KEY
             ? [
                 {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -287,6 +287,19 @@ module.exports = defineConfig({
     //             },
     //           ]
     //         : []),
+    //       ...(process.env.SHIPROCKET_EMAIL
+    //         ? [
+    //             {
+    //               resolve: "./src/modules/shipping-providers/shiprocket",
+    //               id: "shiprocket",
+    //               options: {
+    //                 email: process.env.SHIPROCKET_EMAIL,
+    //                 password: process.env.SHIPROCKET_PASSWORD,
+    //                 pickup_location: process.env.SHIPROCKET_PICKUP_LOCATION,
+    //               },
+    //             },
+    //           ]
+    //         : []),
     //       ...(process.env.DHL_API_KEY
     //         ? [
     //             {

--- a/apps/backend/src/admin/widgets/stock-location-shiprocket-pickup.tsx
+++ b/apps/backend/src/admin/widgets/stock-location-shiprocket-pickup.tsx
@@ -1,0 +1,135 @@
+import { defineWidgetConfig } from "@medusajs/admin-sdk"
+import { DetailWidgetProps } from "@medusajs/framework/types"
+import { Badge, Button, Container, Heading, Skeleton, Text, toast } from "@medusajs/ui"
+import { useState } from "react"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { sdk } from "../lib/config"
+
+/**
+ * Shiprocket pickup-location registration (#31, SHIPPING_PROVIDERS.md §9).
+ *
+ * Outbound opt-in surface for the on-demand admin route
+ * `/admin/stock-locations/:id/shiprocket-pickup` (GET status, POST register).
+ *
+ * Per §9.3 the status/action is "default-hidden — surfaced on demand": the
+ * widget shows only a title + a "Check status" action until the operator asks,
+ * which also avoids a live Shiprocket list call on every stock-location view.
+ */
+
+type StockLocation = { id: string; name?: string }
+
+type PickupStatus = {
+  name: string
+  already_existed: boolean
+  phone_verified?: boolean
+} | null
+
+const ShiprocketPickupWidget = ({ data }: DetailWidgetProps<StockLocation>) => {
+  const [revealed, setRevealed] = useState(false)
+  const queryClient = useQueryClient()
+  const queryKey = ["shiprocket-pickup", data.id]
+
+  const { data: res, isFetching, isError, error } = useQuery({
+    queryKey,
+    queryFn: () =>
+      sdk.client.fetch<{ pickup: PickupStatus }>(
+        `/admin/stock-locations/${data.id}/shiprocket-pickup`
+      ),
+    enabled: revealed,
+  })
+
+  const register = useMutation({
+    mutationFn: () =>
+      sdk.client.fetch<{ pickup: PickupStatus }>(
+        `/admin/stock-locations/${data.id}/shiprocket-pickup`,
+        { method: "POST" }
+      ),
+    onSuccess: (data) => {
+      queryClient.setQueryData(queryKey, data)
+      setRevealed(true)
+      toast.success(
+        data.pickup?.already_existed
+          ? "Pickup already registered with Shiprocket"
+          : "Registered pickup with Shiprocket"
+      )
+    },
+    onError: (e: any) =>
+      toast.error(e?.message || "Failed to register Shiprocket pickup"),
+  })
+
+  const status = res?.pickup ?? null
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div>
+          <Heading level="h2">Shiprocket Pickup</Heading>
+          <Text size="small" leading="compact" className="text-ui-fg-subtle mt-1">
+            Register this location as a pickup point in our Shiprocket account.
+          </Text>
+        </div>
+        {!revealed ? (
+          <Button
+            size="small"
+            variant="secondary"
+            onClick={() => setRevealed(true)}
+          >
+            Check status
+          </Button>
+        ) : (
+          <Button
+            size="small"
+            variant={status ? "secondary" : "primary"}
+            onClick={() => register.mutate()}
+            isLoading={register.isPending}
+            disabled={register.isPending || isFetching}
+          >
+            {status ? "Re-register" : "Register pickup"}
+          </Button>
+        )}
+      </div>
+
+      {revealed && (
+        <div className="px-6 py-4">
+          {isFetching ? (
+            <Skeleton className="h-6 w-64" />
+          ) : isError ? (
+            <Text size="small" leading="compact" className="text-ui-fg-error">
+              {(error as any)?.message || "Couldn't load Shiprocket pickup status"}
+            </Text>
+          ) : status ? (
+            <div className="flex items-center gap-x-3">
+              <Text size="small" leading="compact" weight="plus">
+                {status.name}
+              </Text>
+              {status.phone_verified === true ? (
+                <Badge size="2xsmall" color="green">
+                  Phone verified
+                </Badge>
+              ) : status.phone_verified === false ? (
+                <Badge size="2xsmall" color="orange">
+                  Phone not verified
+                </Badge>
+              ) : (
+                <Badge size="2xsmall" color="grey">
+                  Verification unknown
+                </Badge>
+              )}
+            </div>
+          ) : (
+            <Text size="small" leading="compact" className="text-ui-fg-subtle">
+              Not registered with Shiprocket. Click “Register pickup” to add this
+              location to our Shiprocket pickup set.
+            </Text>
+          )}
+        </div>
+      )}
+    </Container>
+  )
+}
+
+export const config = defineWidgetConfig({
+  zone: "location.details.after",
+})
+
+export default ShiprocketPickupWidget

--- a/apps/backend/src/workflows/stores/create-store-with-defaults.ts
+++ b/apps/backend/src/workflows/stores/create-store-with-defaults.ts
@@ -19,6 +19,7 @@ import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import type { RemoteQueryFunction } from "@medusajs/types"
 import type { Link } from "@medusajs/modules-sdk"
 import { PARTNER_MODULE } from "../../modules/partner"
+import { registerShiprocketPickup } from "../../modules/shipping-providers/pickup-locations"
 
 // Orchestrates creation of a store with its default region, sales channel, and stock location
 // Then updates the store to reference those as defaults
@@ -356,6 +357,29 @@ const autoLinkFulfillmentProvidersStep = createStep(
         }
       } catch (e: any) {
         console.error(`[create-store] Failed to register Delhivery warehouse: ${e.message}`)
+      }
+    }
+
+    // India → Shiprocket (sibling carrier to Delhivery).
+    if (country === "in" && enabledIds.includes("shiprocket_shiprocket")) {
+      toLink.push("shiprocket_shiprocket")
+    }
+
+    // India → Shiprocket inbound pickup auto-register (#31 §9.3). Resolver-driven:
+    // creds come from the external-platform store, so this runs whether or not
+    // Shiprocket is in the fulfillment registry. Best-effort — a missing platform
+    // record / creds (or an unverified phone) must never fail store provisioning.
+    if (country === "in") {
+      try {
+        const result = await registerShiprocketPickup(container, input.locationId)
+        console.log(
+          `[create-store] Registered Shiprocket pickup: ${result.name}` +
+            (result.already_existed ? " (already existed)" : "")
+        )
+      } catch (e: any) {
+        console.warn(
+          `[create-store] Skipped Shiprocket pickup auto-register: ${e.message}`
+        )
       }
     }
 

--- a/apps/docs/notes/SHIPPING_PROVIDERS.md
+++ b/apps/docs/notes/SHIPPING_PROVIDERS.md
@@ -225,12 +225,22 @@ fulfillment-module-registry path.
 Delhivery warehouse name, so a location maps to the same nickname on both
 carriers.
 
+**Done (2026-06-15, branch `feat/31-shiprocket-pickup-registration`):**
+- **Fulfillment provider registration** — Shiprocket added to the
+  `@medusajs/medusa/fulfillment` `providers` list (env-gated on `SHIPROCKET_EMAIL`,
+  mirroring Delhivery; no sandbox). Active in `medusa-config.prod.ts`, kept in
+  parity in the commented base-config block.
+- **Inbound auto-register** — wired into `create-store-with-defaults.ts`: India
+  stores link `shiprocket_shiprocket` (when enabled) and best-effort call
+  `registerShiprocketPickup` (never fails provisioning).
+- **Outbound opt-in UI** — admin widget on the stock-location detail page
+  (`src/admin/widgets/stock-location-shiprocket-pickup.tsx`, zone
+  `location.details.after`). Default-hidden per §9.3: shows a "Check status"
+  action until the operator asks, then GET status / POST register on demand.
+- **Integration test** — `integration-tests/http/shiprocket-pickup-registration.spec.ts`
+  (5 cases) covers the GET/POST route end to end with the Shiprocket HTTP calls stubbed.
+
 **Still open:**
-- **Inbound auto-register** (call `registerShiprocketPickup` from
-  `create-store-with-defaults.ts` alongside the Delhivery branch for `country ===
-  "in"`) — not yet wired; the helper + route exist, the auto-trigger doesn't.
-- **Outbound opt-in UI** — admin/partner surface that calls `POST` (the route is
-  ready; no UI control yet).
 - **Live verification** — untested against the real Shiprocket API; needs test
   creds + a `category: shipping` Shiprocket platform record. The
   `data.shipping_address[]` field names (esp. `phone_verified`) should be


### PR DESCRIPTION
Builds on the merged pickup-registration PR (#416), closing the remaining #31 (#404) gaps.

## What's in it
- **Fulfillment provider registration** — Shiprocket added to the `@medusajs/medusa/fulfillment` `providers` list, env-gated on `SHIPROCKET_EMAIL` (mirrors Delhivery; Shiprocket has no sandbox). Active in `medusa-config.prod.ts`; kept in parity in the commented base-config block.
- **Inbound auto-register** — wired into `create-store-with-defaults.ts`: India stores link `shiprocket_shiprocket` (when enabled) and best-effort call `registerShiprocketPickup` (resolver-driven; a missing platform record / unverified phone never fails store provisioning).
- **Outbound opt-in UI** — admin widget on the stock-location detail page (`src/admin/widgets/stock-location-shiprocket-pickup.tsx`, zone `location.details.after`). Default-hidden per SHIPPING_PROVIDERS.md §9.3: a "Check status" action until the operator asks, then GET status / POST register on demand. Registered → nickname + phone-verified badge; unregistered → "Register pickup".
- **Integration test** — `integration-tests/http/shiprocket-pickup-registration.spec.ts` (5 cases) covers the GET/POST route end to end with the Shiprocket HTTP calls stubbed.
- Doc: `SHIPPING_PROVIDERS.md §9.5` updated (inbound auto-register + opt-in UI now done).

## Verify
- `npx tsc --noEmit -p tsconfig.json` → 70 errors, all pre-existing baseline; **zero in touched files**.
- Integration test: `pnpm test:integration:http:shared ./apps/backend/integration-tests/http/shiprocket-pickup-registration.spec.ts` → **5 passed**.
- Widget verified in the admin via Playwright (initial + post-check states).

## Still open (follow-up)
- **Live verification** against the real Shiprocket API (needs test creds + a `category: shipping` Shiprocket platform record).
- P1 label-first MVP (blocked on 3 product decisions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)