### PR TITLE
feat(visual-flows): #418 — gate flow-start email behind per-flow toggle

### DIFF
--- a/apps/backend/integration-tests/http/visual-flow-lifecycle-email.spec.ts
+++ b/apps/backend/integration-tests/http/visual-flow-lifecycle-email.spec.ts
@@ -144,6 +144,9 @@ setupSharedTestSuite(() => {
         expect(started).toBeDefined()
         expect(started!.data.flow_id).toBe(flowId)
         expect(started!.data.execution_id).toBeDefined()
+        // trigger_type rides the started event so the subscriber can apply
+        // the scheduled-default-off rule (#418); this flow is manual.
+        expect(started!.data.flow_trigger_type).toBe("manual")
 
         expect(failed).toBeDefined()
         expect(failed!.data.flow_id).toBe(flowId)
@@ -224,6 +227,58 @@ setupSharedTestSuite(() => {
       // 4. truly nothing configured → null (subscriber then WARN-logs)
       delete process.env.MAILJET_FROM_EMAIL
       expect(lifecycleTesting.resolveRecipient({})).toBeNull()
+    })
+
+    it("shouldSendStartEmail: explicit metadata toggle wins over the trigger default (#418)", () => {
+      // Explicit boolean — both directions, regardless of trigger type.
+      expect(
+        lifecycleTesting.shouldSendStartEmail({
+          flow_trigger_type: "schedule",
+          flow_metadata: { send_start_email: true },
+        })
+      ).toBe(true)
+      expect(
+        lifecycleTesting.shouldSendStartEmail({
+          flow_trigger_type: "manual",
+          flow_metadata: { send_start_email: false },
+        })
+      ).toBe(false)
+
+      // The key-value metadata editor stores "true"/"false" strings.
+      expect(
+        lifecycleTesting.shouldSendStartEmail({
+          flow_trigger_type: "schedule",
+          flow_metadata: { send_start_email: "true" },
+        })
+      ).toBe(true)
+      expect(
+        lifecycleTesting.shouldSendStartEmail({
+          flow_trigger_type: "manual",
+          flow_metadata: { send_start_email: "false" },
+        })
+      ).toBe(false)
+    })
+
+    it("shouldSendStartEmail: defaults OFF for scheduled flows, ON for everything else (#418)", () => {
+      // The short-interval spammer: scheduled flows are silent by default.
+      expect(
+        lifecycleTesting.shouldSendStartEmail({ flow_trigger_type: "schedule" })
+      ).toBe(false)
+      expect(
+        lifecycleTesting.shouldSendStartEmail({
+          flow_trigger_type: "schedule",
+          flow_metadata: {},
+        })
+      ).toBe(false)
+
+      // Every other trigger type keeps the roadmap-26 kick-off paper trail.
+      for (const t of ["manual", "event", "webhook", "another_flow"]) {
+        expect(
+          lifecycleTesting.shouldSendStartEmail({ flow_trigger_type: t })
+        ).toBe(true)
+      }
+      // Unknown/missing trigger type is treated as non-schedule → ON.
+      expect(lifecycleTesting.shouldSendStartEmail({})).toBe(true)
     })
 
     it("fingerprint normalises ULID-like ids and truncates", () => {

--- a/apps/backend/src/admin/routes/visual-flows/[id]/@edit/page.tsx
+++ b/apps/backend/src/admin/routes/visual-flows/[id]/@edit/page.tsx
@@ -1,7 +1,7 @@
 import { useParams } from "react-router-dom"
 import { RouteDrawer } from "../../../../components/modal/route-drawer/route-drawer"
 import { useVisualFlow, useUpdateVisualFlow } from "../../../../hooks/api/visual-flows"
-import { Button, Heading, Text, Input, Textarea, toast, Select } from "@medusajs/ui"
+import { Button, Heading, Text, Input, Textarea, toast, Select, Switch } from "@medusajs/ui"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { z } from "@medusajs/framework/zod"
@@ -14,6 +14,7 @@ const editFlowSchema = z.object({
   description: z.string().optional(),
   trigger_type: z.enum(["manual", "webhook", "event", "schedule", "another_flow"]),
   status: z.enum(["active", "inactive", "draft"]),
+  send_start_email: z.boolean(),
 })
 
 type EditFlowFormValues = z.infer<typeof editFlowSchema>
@@ -22,12 +23,14 @@ type EditVisualFlowDrawerContentProps = {
   form: ReturnType<typeof useForm<EditFlowFormValues>>
   mutateAsync: ReturnType<typeof useUpdateVisualFlow>["mutateAsync"]
   isPending: boolean
+  existingMetadata: Record<string, any>
 }
 
 const EditVisualFlowDrawerContent = ({
   form,
   mutateAsync,
   isPending,
+  existingMetadata,
 }: EditVisualFlowDrawerContentProps) => {
   const { handleSuccess } = useRouteModal()
 
@@ -39,6 +42,9 @@ const EditVisualFlowDrawerContent = ({
           description: data.description || undefined,
           trigger_type: data.trigger_type,
           status: data.status,
+          // Merge so we don't clobber other metadata keys (e.g. failure_email,
+          // schedule bookkeeping) when toggling the start-email setting (#418).
+          metadata: { ...existingMetadata, send_start_email: data.send_start_email },
         },
         {
           onSuccess: () => {
@@ -152,6 +158,31 @@ const EditVisualFlowDrawerContent = ({
                   </Form.Item>
                 )}
               />
+
+              <Form.Field
+                control={form.control}
+                name="send_start_email"
+                render={({ field }) => (
+                  <Form.Item>
+                    <div className="flex items-start justify-between gap-x-4">
+                      <div className="flex flex-col">
+                        <Form.Label>Send email when flow starts</Form.Label>
+                        <Text size="small" className="text-ui-fg-subtle">
+                          Notify the failure-alert recipient each time this flow
+                          starts. Off by default for scheduled flows to avoid
+                          inbox spam. Failure alerts are always sent regardless.
+                        </Text>
+                      </div>
+                      <Form.Control>
+                        <Switch
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
+                      </Form.Control>
+                    </div>
+                  </Form.Item>
+                )}
+              />
             </div>
           </div>
         </RouteDrawer.Body>
@@ -177,6 +208,16 @@ const EditVisualFlowPage = () => {
   const { data: flow, isLoading } = useVisualFlow(id!)
   const { mutateAsync, isPending } = useUpdateVisualFlow(id!)
 
+  // Mirror the subscriber's default (#418): explicit metadata wins; otherwise
+  // start emails are off for schedule-triggered flows, on for everything else.
+  const resolveSendStartEmail = (f: NonNullable<typeof flow>): boolean => {
+    const explicit = (f.metadata as Record<string, any> | undefined)?.send_start_email
+    if (typeof explicit === "boolean") return explicit
+    if (explicit === "true") return true
+    if (explicit === "false") return false
+    return f.trigger_type !== "schedule"
+  }
+
   const form = useForm<EditFlowFormValues>({
     resolver: zodResolver(editFlowSchema),
     values: flow ? {
@@ -184,6 +225,7 @@ const EditVisualFlowPage = () => {
       description: flow.description || "",
       trigger_type: flow.trigger_type,
       status: flow.status,
+      send_start_email: resolveSendStartEmail(flow),
     } : undefined,
   })
 
@@ -204,6 +246,7 @@ const EditVisualFlowPage = () => {
         form={form}
         mutateAsync={mutateAsync}
         isPending={isPending}
+        existingMetadata={(flow.metadata as Record<string, any>) || {}}
       />
     </RouteDrawer>
   )

--- a/apps/backend/src/subscribers/visual-flow-lifecycle-email.ts
+++ b/apps/backend/src/subscribers/visual-flow-lifecycle-email.ts
@@ -78,6 +78,24 @@ function resolveRecipient(data: any): { email: string; source: string } | null {
   return null
 }
 
+// Whether to send the "flow started" email for this execution (#418).
+// The start email (roadmap 26) gives long-running flows a kick-off signal,
+// but short-interval *scheduled* flows turned it into inbox spam. Decision:
+//   1. flow.metadata.send_start_email — explicit per-flow toggle (admin UI).
+//      Accepts a real boolean or the "true"/"false" strings the key-value
+//      metadata editor produces.
+//   2. default — OFF for schedule-triggered flows, ON for every other
+//      trigger type (event/manual/webhook/another_flow keep the paper trail).
+// Failure/cancelled emails are intentionally NOT gated by this — a flow that
+// silences its start notice still alerts on failure.
+function shouldSendStartEmail(data: any): boolean {
+  const explicit = data?.flow_metadata?.send_start_email
+  if (typeof explicit === "boolean") return explicit
+  if (explicit === "true") return true
+  if (explicit === "false") return false
+  return data?.flow_trigger_type !== "schedule"
+}
+
 function buildExecutionUrl(executionId: string): string | undefined {
   const adminBase =
     process.env.ADMIN_BASE_URL ||
@@ -129,6 +147,14 @@ export default async function visualFlowLifecycleEmailHandler({
   const now = Date.now()
 
   if (eventName === "visual_flow_execution.started") {
+    if (!shouldSendStartEmail(data)) {
+      logger.debug(
+        `[visual-flow-lifecycle-email] start email disabled for flow=${flowId} ` +
+          `(send_start_email=${data?.flow_metadata?.send_start_email ?? "unset"}, ` +
+          `trigger_type=${data?.flow_trigger_type ?? "unknown"})`
+      )
+      return
+    }
     if (shouldThrottle(`started:${flowId}`, now)) {
       logger.debug(
         `[visual-flow-lifecycle-email] throttled start email for ${flowId}`
@@ -226,4 +252,5 @@ export const __testing = {
   clearThrottle: () => lastSentAt.clear(),
   fingerprint,
   resolveRecipient,
+  shouldSendStartEmail,
 }

--- a/apps/backend/src/workflows/visual-flows/execute-visual-flow.ts
+++ b/apps/backend/src/workflows/visual-flows/execute-visual-flow.ts
@@ -157,6 +157,10 @@ const initializeExecutionStep = createStep(
       flow_id: input.flowId,
       flow_name: (input.flow as any)?.name,
       flow_metadata: (input.flow as any)?.metadata ?? null,
+      // trigger_type lets the lifecycle-email subscriber default the
+      // start-email OFF for schedule-triggered flows (#418): short-interval
+      // schedules were spamming the inbox with kick-off notices.
+      flow_trigger_type: (input.flow as any)?.trigger_type ?? null,
       execution_id: execution.id,
       triggered_by: input.triggeredBy,
       triggered_by_event: incomingEventName,


### PR DESCRIPTION
Closes #418.

## Problem
Short-interval **scheduled** visual flows emit `visual_flow_execution.started` on every run, so the lifecycle-email subscriber sent a "flow started" email each time. The 10-minute per-process throttle wasn't enough for every-minute schedules, and admins' failure-alert inboxes filled with kick-off noise.

## Fix
A per-flow `send_start_email` control that gates **only** the start email — failure/cancelled alerts are never affected.

- `execute-visual-flow.ts` now emits `flow_trigger_type` on the `visual_flow_execution.started` event.
- `visual-flow-lifecycle-email.ts` gates the started branch on `shouldSendStartEmail()`:
  - explicit `flow.metadata.send_start_email` (boolean, or the `"true"`/`"false"` strings the metadata editor produces) wins;
  - otherwise **default OFF for `schedule` flows, ON for every other trigger type** (preserves the roadmap-26 kick-off paper trail for event/manual/webhook/another_flow).
- Admin: "Send email when flow starts" `Switch` in the flow **edit drawer** (`[id]/@edit/page.tsx`), initialised from the same default and persisted by merging into `flow.metadata` (no clobber of `failure_email` / schedule bookkeeping).

## Tests
Extended `integration-tests/http/visual-flow-lifecycle-email.spec.ts`: started event carries `flow_trigger_type`; unit cases for explicit toggle (both directions, boolean & string) and scheduled-default-off. All 5 pass.

```
pnpm test:integration:http:shared ./integration-tests/http/visual-flow-lifecycle-email
```

## Watch-out
Existing scheduled flows in prod go quiet on **start** emails after deploy unless they set `metadata.send_start_email = true`. Failure alerts are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
