### PR TITLE
feat(orders): #403 — kind-aware admin order detail (links + work-status)

### DIFF
--- a/apps/backend/integration-tests/http/orders-unification-admin-detail.spec.ts
+++ b/apps/backend/integration-tests/http/orders-unification-admin-detail.spec.ts
@@ -1,0 +1,362 @@
+/**
+ * #403 — orders unification, ADMIN work-order DETAIL.
+ *
+ * Mirrors the partner detail behaviour (`orders-unification-partner-detail.spec.ts`)
+ * onto the admin surface: `GET /admin/orders/:id` now self-describes its kind +
+ * work-status by attaching the order↔execution reverse links
+ * (`production_runs` / `inventory_orders`) and the `unified_order_status`
+ * sidecar, so the admin UI can discriminate design/inventory/retail.
+ *
+ * Unlike the partner route there is NO ownership scoping — admin reads any order.
+ *
+ * Asserts:
+ *   - admin GET of a design work-order → `production_runs` linked, no inventory
+ *   - admin GET of an inventory work-order → `inventory_orders` linked, no design
+ *   - admin GET of a retail order → neither link present
+ *   - the core order shape (id, items, totals) still comes back (override didn't
+ *     regress the built-in detail)
+ *   - POST /admin/orders/:id (order update) still works (re-exported core POST)
+ */
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { createOrderWorkflow } from "@medusajs/core-flows"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(60000)
+
+const TEST_PARTNER_PASSWORD = "supersecret"
+
+type PartnerCtx = {
+  headers: any
+  partnerId: string
+  salesChannelId: string
+  regionId: string
+  currencyCode: string
+  tag: string
+}
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Orders unification admin work-order detail (#403)", () => {
+    let adminHeaders: any
+    let unique: number
+    let inventoryItemId: string
+    let stockLocationId: string
+    let fromStockLocationId: string
+
+    const post = async (url: string, body: any, cfg?: any) => {
+      try {
+        return await api.post(url, body, cfg)
+      } catch (err: any) {
+        throw new Error(
+          `POST ${url} failed: ${err?.response?.status} ${JSON.stringify(
+            err?.response?.data
+          )}`
+        )
+      }
+    }
+
+    const createPartnerWithStore = async (tag: string): Promise<PartnerCtx> => {
+      const email = `admin-detail-${tag}-${unique}@jyt.test`
+      await post("/auth/partner/emailpass/register", {
+        email,
+        password: TEST_PARTNER_PASSWORD,
+      })
+      const login1 = await post("/auth/partner/emailpass", {
+        email,
+        password: TEST_PARTNER_PASSWORD,
+      })
+      const headers1 = { headers: { Authorization: `Bearer ${login1.data.token}` } }
+
+      const partnerRes = await post(
+        "/partners",
+        {
+          name: `Admin Detail Partner ${tag} ${unique}`,
+          handle: `admin-detail-${tag}-${unique}`,
+          admin: { email, first_name: "Admin", last_name: tag },
+        },
+        headers1
+      )
+      const pid = partnerRes.data.partner.id
+
+      const login2 = await post("/auth/partner/emailpass", {
+        email,
+        password: TEST_PARTNER_PASSWORD,
+      })
+      const headers2 = { headers: { Authorization: `Bearer ${login2.data.token}` } }
+
+      const currenciesRes = await api.get("/admin/currencies", adminHeaders)
+      const currencies = currenciesRes.data.currencies || []
+      const inr = currencies.find((c: any) => c.code?.toLowerCase() === "inr")
+      const cc = String((inr || currencies[0]).code).toLowerCase()
+
+      const storeRes = await post(
+        "/partners/stores",
+        {
+          store: {
+            name: `Admin Detail Store ${tag} ${unique}`,
+            supported_currencies: [{ currency_code: cc, is_default: true }],
+          },
+          sales_channel: { name: `Admin Detail Channel ${tag} ${unique}`, description: "Default" },
+          region: { name: `Admin Detail Region ${tag}`, currency_code: cc, countries: ["in"] },
+          location: {
+            name: `Admin Detail Warehouse ${tag}`,
+            address: {
+              address_1: "1 Mill Road",
+              city: "Jaipur",
+              postal_code: "302001",
+              country_code: "IN",
+            },
+          },
+        },
+        headers2
+      )
+
+      return {
+        headers: headers2,
+        partnerId: pid,
+        currencyCode: cc,
+        salesChannelId: storeRes.data.sales_channel?.id,
+        regionId: storeRes.data.region?.id,
+        tag,
+      }
+    }
+
+    const unifiedIdFromLegacy = async (
+      entity: "inventory_orders" | "production_runs",
+      id: string
+    ): Promise<string> => {
+      const query: any = getContainer().resolve(ContainerRegistrationKeys.QUERY)
+      const { data } = await query.graph({
+        entity,
+        filters: { id },
+        fields: ["id", "order.id", "metadata"],
+      })
+      const row = data?.[0]
+      return row?.order?.id ?? row?.metadata?.unified_order_id
+    }
+
+    const createRetailOrder = async (ctx: PartnerCtx): Promise<string> => {
+      const { result } = await createOrderWorkflow(getContainer()).run({
+        input: {
+          region_id: ctx.regionId,
+          sales_channel_id: ctx.salesChannelId,
+          currency_code: ctx.currencyCode,
+          email: `retail-${ctx.tag}-${unique}@jyt.test`,
+          items: [{ title: "Retail Tee", quantity: 1, unit_price: 500 } as any],
+        } as any,
+      })
+      return (result as any).id
+    }
+
+    const createInventoryWorkOrder = async (
+      ctx: PartnerCtx
+    ): Promise<{ unifiedId: string; legacyId: string }> => {
+      const res = await post(
+        "/admin/inventory-orders",
+        {
+          order_lines: [
+            { inventory_item_id: inventoryItemId, quantity: 3, price: 100 },
+          ],
+          quantity: 3,
+          total_price: 100,
+          status: "Pending",
+          expected_delivery_date: new Date().toISOString(),
+          order_date: new Date().toISOString(),
+          shipping_address: {
+            first_name: "JYT",
+            address_1: "Mill Road 1",
+            city: "Jaipur",
+            country_code: "in",
+            postal_code: "302001",
+          },
+          stock_location_id: stockLocationId,
+          from_stock_location_id: fromStockLocationId,
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(201)
+      const invId = res.data.inventoryOrder.id
+
+      const send = await post(
+        `/admin/inventory-orders/${invId}/send-to-partner`,
+        { partnerId: ctx.partnerId, notes: "Admin detail test" },
+        adminHeaders
+      )
+      expect(send.status).toBe(200)
+      return { unifiedId: await unifiedIdFromLegacy("inventory_orders", invId), legacyId: invId }
+    }
+
+    const createDesignWorkOrder = async (
+      ctx: PartnerCtx
+    ): Promise<{ unifiedId: string; legacyId: string }> => {
+      const design = await post(
+        "/admin/designs",
+        {
+          name: `Admin Detail Design ${ctx.tag} ${unique}`,
+          description: "Design for #403 admin-detail test",
+          design_type: "Original",
+          status: "Approved",
+          priority: "Medium",
+        },
+        adminHeaders
+      )
+      expect(design.status).toBe(201)
+
+      const templateName = `admin-detail-design-${ctx.tag}-${unique}`
+      const tpl = await post(
+        "/admin/task-templates",
+        {
+          name: templateName,
+          description: `${templateName} template`,
+          priority: "medium",
+          estimated_duration: 60,
+          required_fields: {},
+          eventable: false,
+          notifiable: false,
+          message_template: "",
+          metadata: { workflow_type: "production_run" },
+          category: "Admin Detail Test",
+        },
+        adminHeaders
+      )
+      expect([200, 201]).toContain(tpl.status)
+
+      const createRes = await post(
+        `/admin/designs/${design.data.design.id}/production-runs`,
+        {
+          assignments: [
+            {
+              partner_id: ctx.partnerId,
+              quantity: 4,
+              role: "manufacturing",
+              template_names: [templateName],
+            },
+          ],
+        },
+        adminHeaders
+      )
+      expect([200, 201]).toContain(createRes.status)
+      const childId =
+        createRes.data.children?.[0]?.id ??
+        createRes.data.result?.children?.[0]?.id
+      expect(childId).toBeTruthy()
+      return { unifiedId: await unifiedIdFromLegacy("production_runs", childId), legacyId: childId }
+    }
+
+    const getAdminDetail = async (orderId: string) =>
+      api.get(`/admin/orders/${orderId}`, adminHeaders).catch((e: any) => e.response)
+
+    // 1:1 reverse links resolve to a single object or array — match the UI's tolerance.
+    const linked = (rel: any): boolean =>
+      Array.isArray(rel) ? rel.length > 0 : Boolean(rel?.id)
+
+    let partner: PartnerCtx
+
+    beforeEach(async () => {
+      const container = getContainer()
+      unique = Date.now()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+
+      const inv = await api.post(
+        "/admin/inventory-items",
+        { title: "Raw Cotton", sku: `RAW-COTTON-${unique}` },
+        adminHeaders
+      )
+      inventoryItemId = inv.data.inventory_item.id
+
+      const to = await api.post(
+        "/admin/stock-locations",
+        { name: `Main ${unique}` },
+        adminHeaders
+      )
+      stockLocationId = to.data.stock_location.id
+      const from = await api.post(
+        "/admin/stock-locations",
+        { name: `Secondary ${unique}` },
+        adminHeaders
+      )
+      fromStockLocationId = from.data.stock_location.id
+
+      for (const name of [
+        "partner-order-sent",
+        "partner-order-received",
+        "partner-order-shipped",
+      ]) {
+        const tpl = await api.post(
+          "/admin/task-templates",
+          {
+            name,
+            description: `${name} template`,
+            priority: "medium",
+            estimated_duration: 30,
+            eventable: true,
+            notifiable: true,
+            metadata: { workflow_type: "partner_assignment" },
+          },
+          adminHeaders
+        )
+        expect([200, 201]).toContain(tpl.status)
+      }
+
+      partner = await createPartnerWithStore("a")
+    })
+
+    it("admin GET of a design work-order attaches production_runs (kind=design)", async () => {
+      const { unifiedId, legacyId } = await createDesignWorkOrder(partner)
+
+      const res = await getAdminDetail(unifiedId)
+      expect(res.status).toBe(200)
+      const order = res.data.order
+      // core detail shape preserved by the override
+      expect(order.id).toBe(unifiedId)
+      // kind-discriminator fields attached by the route
+      expect(linked(order.production_runs)).toBe(true)
+      expect(linked(order.inventory_orders)).toBe(false)
+      expect(order.metadata?.legacy_id).toBe(legacyId)
+    })
+
+    it("admin GET of an inventory work-order attaches inventory_orders (kind=inventory)", async () => {
+      const { unifiedId, legacyId } = await createInventoryWorkOrder(partner)
+
+      const res = await getAdminDetail(unifiedId)
+      expect(res.status).toBe(200)
+      const order = res.data.order
+      expect(order.id).toBe(unifiedId)
+      expect(linked(order.inventory_orders)).toBe(true)
+      expect(linked(order.production_runs)).toBe(false)
+      expect(order.metadata?.legacy_id).toBe(legacyId)
+    })
+
+    it("admin GET of a retail order attaches neither link (kind=retail)", async () => {
+      const retailId = await createRetailOrder(partner)
+
+      const res = await getAdminDetail(retailId)
+      expect(res.status).toBe(200)
+      const order = res.data.order
+      expect(order.id).toBe(retailId)
+      expect(linked(order.production_runs)).toBe(false)
+      expect(linked(order.inventory_orders)).toBe(false)
+    })
+
+    it("admin POST /admin/orders/:id still updates the order (re-exported core handler)", async () => {
+      const retailId = await createRetailOrder(partner)
+
+      // The core POST returns only `defaultAdminOrderFields` (no `email`) unless
+      // `fields` selects it, so request `email` explicitly to verify the update
+      // actually landed through the re-exported core handler.
+      const res = await api
+        .post(
+          `/admin/orders/${retailId}?fields=id,email`,
+          { email: `updated-${unique}@jyt.test` },
+          adminHeaders
+        )
+        .catch((e: any) => e.response)
+
+      expect(res.status).toBe(200)
+      expect(res.data.order?.email).toBe(`updated-${unique}@jyt.test`)
+    })
+  })
+})

--- a/apps/backend/src/api/admin/orders/[id]/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/route.ts
@@ -1,0 +1,64 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { getOrderDetailWorkflow } from "@medusajs/core-flows"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+// #403 (orders unification → admin): override the built-in admin order DETAIL so
+// /admin/orders/:id self-describes its kind + work-status, mirroring what the
+// partner detail route already does (`/partners/orders/:id`).
+//
+// Mechanism: a project route file at this exact path overrides the core handler
+// (routes-loader: last-registered wins; project src/api is scanned after core).
+// Core's `validateAndTransformQuery` middleware for `/admin/orders/:id` still
+// runs, so `req.queryConfig.fields` is populated when GET runs — and core's
+// `validateAndTransformBody` still runs for POST. Overriding the file replaces
+// BOTH methods, so we re-export core's order-update POST unchanged below; only
+// GET gains the link/work-status attachment.
+//
+// Shim boundary (#342/#403): production_run / inventory_order stay the
+// execution-authoring artifacts. This is a READ-ONLY augmentation — the links
+// are 1:1 reverse accessors resolved best-effort, never written through here.
+
+// Re-export core's order-update handler verbatim — admin order updates must keep
+// working after the override.
+export { POST } from "@medusajs/medusa/api/admin/orders/[id]/route"
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { result } = await getOrderDetailWorkflow(req.scope).run({
+    input: {
+      fields: (req as any).queryConfig.fields,
+      order_id: req.params.id,
+      version: (req as any).validatedQuery?.version,
+    },
+  })
+
+  // The core order query config does not expand our custom order links, so
+  // attach them directly (mirrors `list-partner-orders.ts` discrimination and
+  // the partner detail route). The order↔execution links are 1:1, so each
+  // reverse accessor resolves to a single `{ id }` object; the UI tolerates
+  // object-or-array. `unified_order_status.partner_status` is the PR-F sidecar
+  // column the work-status badge reads. Best-effort: a graph hiccup must not
+  // break the detail route — fall back to plain retail rendering.
+  try {
+    const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+    const { data } = await query.graph({
+      entity: "orders",
+      fields: [
+        "id",
+        "production_runs.id",
+        "inventory_orders.id",
+        "unified_order_status.partner_status",
+      ],
+      filters: { id: req.params.id },
+    })
+    const links = data?.[0]
+    if (links) {
+      ;(result as any).production_runs = links.production_runs
+      ;(result as any).inventory_orders = links.inventory_orders
+      ;(result as any).unified_order_status = links.unified_order_status
+    }
+  } catch {
+    // leave the order as-is; the UI falls back to retail rendering
+  }
+
+  res.json({ order: result })
+}

--- a/apps/docs/notes/AUTONOMOUS_DAEMON.md
+++ b/apps/docs/notes/AUTONOMOUS_DAEMON.md
@@ -1,0 +1,45 @@
+# Autonomous PR Daemon — Runbook
+
+Self-paced loop that picks up roadmap work, builds it, verifies it with sub-agents,
+ships it, and verifies it landed in prod. Designed to survive `/clear`: any fresh
+session resumes by reading this file + the GitHub handoff protocol (#352 → active issue).
+
+Authorized by the user (2026-06-15) to run **full-headless**: it may `git push`,
+`gh pr merge`, and `aws ssm put-parameter` without prompting. The **verification gate**
+(below) is the safety mechanism in place of human approval.
+
+## Per-chunk lifecycle
+
+1. **Resume** — read latest `Session handoff` on #352 → open active issue → read its latest `Handoff` comment.
+2. **Pick** — next task from the queue (serial, one issue at a time — single workspace, no worktrees).
+3. **Build** — feat branch off `main` in `apps/backend` (backend lives under `apps/backend/`, NOT repo-root `src/`).
+4. **Verification gate (BLOCKING — nothing merges unless these pass):**
+   - **API:** integration-test agent → `pnpm test:integration:http:shared <path>` (shared DB).
+   - **UI (only if admin UI changed):** Playwright agent against local `yarn dev` (must keep dev server up).
+5. **Ship** — `gh pr create` → `gh pr merge` to `main` (auto-deploys to prod, ~18 min).
+6. **Pace** — `ScheduleWakeup` ~20 min (the deploy window).
+7. **Prod-verify** — on wake, confirm the deployed change live, using creds from AWS (account `369351873445`) / prod env.
+8. **Handoff** — post `Handoff` comment on the issue, update #352 pointer, then continue to next chunk.
+
+## Work queue (serial)
+
+1. **#403** — extend orders unification to **admin** routes (buildable now; ~3-5 days → multiple chunks/PRs).
+2. **#404 P1** — Design Order → Convert to Order → Shiprocket label. **BLOCKED on 3 product decisions:**
+   Convert-to-Order paid-vs-COD default? · COD-capture = remittance/P4 confirm · per-entity scope (order-only vs +design+inventory).
+   Live-verify also needs a `category: shipping` external-platform record (admin data, not env).
+3. Then auto-pick next buildable roadmap issue (#337, #336, #347/#348/#349/#377, …).
+
+## Creds / prod notes
+
+- Shiprocket creds resolve from the **external-platform store** (`SocialPlatform`, `category: shipping`, encrypted) first;
+  `SHIPROCKET_EMAIL` / `SHIPROCKET_PASSWORD` env are fallback only.
+  ⚠ latent: resolver reads `SHIPROCKET_PASSWORD` but `apps/backend/.env` defines `SHIPROCKET_API_PASSWORD` (fallback dormant, not the primary path).
+- Two Medusa configs: prod runs `medusa-config.prod.ts` (Dockerfile cp-overwrites base) — prod-only wiring goes there.
+- One-off prod scripts: ECS run-task off `jyt-prod-medusa-server` task def (ECS Exec disabled). New SSM params need `copilot-application=jyt` + `copilot-environment=prod` tags.
+- No auto-merge in repo; every merge to `main` auto-deploys. Leave `apps/storefront-starter` submodule untouched.
+
+## Conventions to honor
+
+- Partner API mirrors admin API wire shape exactly; bug fixes mirror admin's pattern (read `node_modules/@medusajs/medusa/dist/api/admin/...` first), never invent JS-level filter workarounds.
+- `query.graph`: `relation.*` suffix (not `*relation` prefix); filters don't auto-join dot-paths.
+- Medusa-native styling (`--ui-*`/`--elevation-*`), Skeleton loaders, no critical data in `metadata`.


### PR DESCRIPTION
## #403 — extend orders unification to the admin routes (slice 1: read-path DETAIL)

First incremental slice of #403. Mirrors the landed partner-ui unification onto the **admin order detail** surface.

### What
`GET /admin/orders/:id` now self-describes its kind + work-status by attaching, best-effort:
- `production_runs` (reverse link → design work-order)
- `inventory_orders` (reverse link → inventory work-order)
- `unified_order_status.partner_status` (the work-status sidecar column)

So admin can discriminate design / inventory / retail the same way partner-ui already does.

### How (low-risk override)
A project route at `src/api/admin/orders/[id]/route.ts` overrides the core handler. Core's `validateAndTransformQuery` middleware still runs, so `req.queryConfig.fields` is populated. Because overriding the file replaces **both** methods, core's order-update **POST is re-exported verbatim** — only GET is augmented, inside a `try/catch` so a graph hiccup falls back to plain retail rendering.

### Shim boundary (#342/#403)
Read-only augmentation. `production_run` / `inventory_order` remain the execution-authoring artifacts; the links are never written through this route.

### Verification
- ✅ 4/4 integration tests green (`orders-unification-admin-detail.spec.ts`): design/inventory/retail GET discrimination + POST-still-updates.
- ✅ `tsc` adds **0** new errors (70 baseline unchanged).
- No admin UI change in this slice (the work-status *badge* is the next slice), so no Playwright run applicable.

### Next slices (follow-ups on #403)
- Inject `unified_order_status.partner_status` into the admin order **LIST** fields.
- Surface work-status **badge** in the admin order UI (→ Playwright-verified).
- Unify admin inventory-orders / production-runs lists to read back the unified order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)