### PR TITLE
fix(visual-flows): #424 — bind execute_code {{...}} tokens as raw values

### DIFF
--- a/apps/backend/integration-tests/http/visual-flow-code-interpolation.spec.ts
+++ b/apps/backend/integration-tests/http/visual-flow-code-interpolation.spec.ts
@@ -1,0 +1,209 @@
+/**
+ * Visual Flow — execute_code interpolation (#424)
+ *
+ * Drives the REAL production path: create a flow whose canvas chains a few
+ * `execute_code` nodes, then run it through `POST /:id/execute`
+ * (→ executeVisualFlowWorkflow). The workflow passes RAW options to each
+ * operation, so this exercises the operation's own `{{...}}` resolution end to
+ * end — the path the autonomous engine unit test can't reach.
+ *
+ * Regression guarded (#424): a `{{ $read_*.records }}` token whose upstream
+ * value is a JSON string used to be JSON-stringified INTO the source text,
+ * producing invalid code and `Expected property name or '}' at position 1`.
+ * Tokens now bind the RAW value into the sandbox, and named outputs are also
+ * reachable as `$<operation_key>` aliases.
+ *
+ * `execute_code` runs in-process (no external services) so this is
+ * deterministic in CI.
+ *
+ * Run:
+ *   pnpm test:integration:http:shared ./integration-tests/http/visual-flow-code-interpolation
+ */
+
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(120_000)
+
+// The named upstream key from the real-world repro.
+const READ_KEY = "read_data_1765961329832"
+
+// A JSON STRING (as a "read" step would return it), with embedded quotes — the
+// exact shape that broke when spliced into source via JSON.stringify.
+const RECORDS_JSON = '[{"sku":"A1"},{"sku":"B2"},{"sku":"C3"}]'
+
+// op_use runs the user's #424 code plus a {{...}} token cross-check:
+//   - $last      → previous node output (no `.records` → fallback fires)
+//   - $read_*    → alias for the earlier read step (JSON.parse its string)
+//   - {{ ... }}  → raw-bound token (must JSON.parse identically, not mangle)
+const USE_CODE = `
+const fromLast = ($last && $last.records)
+const parsed = fromLast || JSON.parse($${READ_KEY}.records)
+const viaToken = JSON.parse({{ $${READ_KEY}.records }})
+return {
+  usedFallback: !fromLast,
+  count: parsed.length,
+  firstSku: parsed[0].sku,
+  tokenCount: viaToken.length,
+  tokenMatchesAlias: viaToken.length === parsed.length,
+}
+`
+
+function buildInterpolationCanvas() {
+  const node = (key: string, code: string, y: number) => ({
+    id: key,
+    type: "operation",
+    position: { x: 400, y },
+    data: {
+      operationKey: key,
+      operationType: "execute_code",
+      label: key,
+      options: { code },
+    },
+  })
+
+  const edge = (source: string, target: string) => ({
+    id: `e_${source}_${target}`,
+    source,
+    target,
+    sourceHandle: "default",
+    targetHandle: "default",
+  })
+
+  return {
+    nodes: [
+      {
+        id: "trigger",
+        type: "trigger",
+        position: { x: 400, y: 0 },
+        data: { label: "Manual Trigger" },
+      },
+      // Read step: returns records as a JSON STRING.
+      node(READ_KEY, `return { records: ${JSON.stringify(RECORDS_JSON)} }`, 150),
+      // Noise step: makes $last (for op_use) lack `.records`, forcing the
+      // JSON.parse fallback branch to run.
+      node("noise", `return { ok: true }`, 300),
+      // Use step: the actual interpolation contract under test.
+      node("use_records", USE_CODE, 450),
+    ],
+    edges: [
+      edge("trigger", READ_KEY),
+      edge(READ_KEY, "noise"),
+      edge("noise", "use_records"),
+    ],
+  }
+}
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("execute_code interpolation end-to-end (#424)", () => {
+    let headers: Record<string, any>
+
+    beforeAll(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      headers = await getAuthHeaders(api)
+    })
+
+    it("resolves $last, $<key> aliases, and {{ }} tokens without mangling JSON", async () => {
+      const createResp = await api.post(
+        "/admin/visual-flows",
+        {
+          name: "VF #424 — code interpolation",
+          status: "active",
+          trigger_type: "manual",
+          canvas_state: buildInterpolationCanvas(),
+        },
+        headers
+      )
+      expect(createResp.status).toBe(201)
+      const flowId = createResp.data.flow.id as string
+
+      const execResp = await api.post(
+        `/admin/visual-flows/${flowId}/execute`,
+        { trigger_data: { source: "interpolation_test" } },
+        { ...headers, validateStatus: () => true }
+      )
+
+      expect(execResp.status).toBe(200)
+      expect(execResp.data.status).toBe("completed")
+      expect(execResp.data.error).toBeFalsy()
+
+      const out = execResp.data.data_chain?.use_records
+      expect(out).toBeDefined()
+      // Fallback branch ran (noise step's $last had no `.records`).
+      expect(out.usedFallback).toBe(true)
+      // $<key> alias + JSON.parse of the raw string worked.
+      expect(out.count).toBe(3)
+      expect(out.firstSku).toBe("A1")
+      // {{ }} token bound the RAW JSON string (no stringify round-trip), so it
+      // JSON.parses to the same array — the core #424 regression.
+      expect(out.tokenCount).toBe(3)
+      expect(out.tokenMatchesAlias).toBe(true)
+    })
+
+    it("a {{ }} token holding an object binds as a real object, not a stringified copy", async () => {
+      // Single read step returns an object; the next node consumes it via a
+      // token and reads a nested field. Pre-fix this became `[object Object]`
+      // or a quoted JSON string spliced into source.
+      const canvas = {
+        nodes: [
+          {
+            id: "trigger",
+            type: "trigger",
+            position: { x: 400, y: 0 },
+            data: { label: "Manual Trigger" },
+          },
+          {
+            id: "make_obj",
+            type: "operation",
+            position: { x: 400, y: 150 },
+            data: {
+              operationKey: "make_obj",
+              operationType: "execute_code",
+              label: "make_obj",
+              options: { code: `return { id: 42, nested: { ok: true } }` },
+            },
+          },
+          {
+            id: "read_obj",
+            type: "operation",
+            position: { x: 400, y: 300 },
+            data: {
+              operationKey: "read_obj",
+              operationType: "execute_code",
+              label: "read_obj",
+              options: {
+                code: `const v = {{ $make_obj }}; return { isObject: typeof v === "object", id: v.id, nestedOk: v.nested.ok }`,
+              },
+            },
+          },
+        ],
+        edges: [
+          { id: "e1", source: "trigger", target: "make_obj", sourceHandle: "default", targetHandle: "default" },
+          { id: "e2", source: "make_obj", target: "read_obj", sourceHandle: "default", targetHandle: "default" },
+        ],
+      }
+
+      const createResp = await api.post(
+        "/admin/visual-flows",
+        { name: "VF #424 — object token", status: "active", trigger_type: "manual", canvas_state: canvas },
+        headers
+      )
+      expect(createResp.status).toBe(201)
+      const flowId = createResp.data.flow.id as string
+
+      const execResp = await api.post(
+        `/admin/visual-flows/${flowId}/execute`,
+        { trigger_data: {} },
+        { ...headers, validateStatus: () => true }
+      )
+
+      expect(execResp.status).toBe(200)
+      expect(execResp.data.status).toBe("completed")
+      const out = execResp.data.data_chain?.read_obj
+      expect(out).toEqual({ isObject: true, id: 42, nestedOk: true })
+    })
+  })
+})

--- a/apps/backend/src/modules/visual_flows/execution-engine.ts
+++ b/apps/backend/src/modules/visual_flows/execution-engine.ts
@@ -292,7 +292,15 @@ export class FlowExecutionEngine {
     }
 
     // Interpolate variables in options
-    const resolvedOptions = interpolateVariables(operation.options || {}, dataChain)
+    let resolvedOptions = interpolateVariables(operation.options || {}, dataChain)
+
+    // The execute_code `code` field must NOT be string-interpolated: splicing a
+    // JSON-stringified value into source text mangles objects/JSON (e.g.
+    // `JSON.parse({{$last}})` produced invalid source). The code operation owns
+    // `{{...}}` resolution and binds each token's RAW value into the sandbox.
+    if (operation.operation_type === "execute_code" && operation.options?.code != null) {
+      resolvedOptions = { ...resolvedOptions, code: operation.options.code }
+    }
 
     // Log operation start
     await this.flowService.addExecutionLog({

--- a/apps/backend/src/modules/visual_flows/operations/__tests__/execute-code.unit.spec.ts
+++ b/apps/backend/src/modules/visual_flows/operations/__tests__/execute-code.unit.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for the visual-flows `execute_code` operation — specifically the
+ * variable/interpolation contract for user code (#424).
+ *
+ * Three ways to reach upstream data from inside code, all exercised here:
+ *   1. Built-in sandbox vars:           `$last`, `$input`, `$trigger`
+ *   2. `$`-aliases for named outputs:    `$read_data_123.records`
+ *   3. `{{ ... }}` template tokens:      `JSON.parse({{ $last.records }})`
+ *
+ * The regression this guards: `{{ ... }}` tokens used to be string-interpolated
+ * by JSON-stringifying the value INTO the source text, which mangled
+ * objects/JSON (`JSON.parse({{$last}})` threw
+ * `Expected property name or '}' at position 1`). Tokens now bind the RAW value
+ * into the sandbox — no stringify→parse round-trip.
+ *
+ * The operation only reads `context.dataChain`, so we can invoke it directly
+ * without booting Medusa.
+ */
+
+import { executeCodeOperation } from "../execute-code"
+
+// The named upstream operation key from the real-world repro.
+const READ_KEY = "read_data_1765961329832"
+
+function makeContext(dataChain: Record<string, any>): any {
+  return {
+    container: {} as any,
+    dataChain: {
+      $trigger: { payload: {}, timestamp: "2026-06-16T00:00:00.000Z" },
+      $accountability: {},
+      $env: {},
+      $last: null,
+      ...dataChain,
+    },
+    flowId: "flow_test",
+    executionId: "exec_test",
+    operationId: "op_test",
+    operationKey: "code_test",
+  }
+}
+
+async function run(code: string, dataChain: Record<string, any>) {
+  return executeCodeOperation.execute({ code }, makeContext(dataChain))
+}
+
+describe("execute_code — interpolation / variable resolution", () => {
+  // The exact user code from #424: prefer $last.records, else parse the JSON
+  // string the read step returned.
+  const USER_CODE = `
+    const records = ($last && $last.records) || JSON.parse($${READ_KEY}.records)
+    return { count: records.length, first: records[0] }
+  `
+
+  it("uses $last.records directly when present (object, no parse)", async () => {
+    const res = await run(USER_CODE, {
+      $last: { records: [{ id: "a" }, { id: "b" }] },
+      [READ_KEY]: { records: '[{"id":"x"}]' }, // present but unused — $last wins
+    })
+
+    expect(res.success).toBe(true)
+    expect(res.data).toEqual({ count: 2, first: { id: "a" } })
+  })
+
+  it("falls back to JSON.parse($read_data_*.records) when $last has no records", async () => {
+    const res = await run(USER_CODE, {
+      $last: { something_else: true }, // truthy but no .records
+      [READ_KEY]: { records: '[{"id":"x"},{"id":"y"},{"id":"z"}]' },
+    })
+
+    expect(res.success).toBe(true)
+    expect(res.data).toEqual({ count: 3, first: { id: "x" } })
+  })
+
+  it("falls back via the $-alias when $last is null", async () => {
+    const res = await run(USER_CODE, {
+      $last: null,
+      [READ_KEY]: { records: '[{"id":"only"}]' },
+    })
+
+    expect(res.success).toBe(true)
+    expect(res.data).toEqual({ count: 1, first: { id: "only" } })
+  })
+
+  it("exposes named outputs via $input too", async () => {
+    const res = await run(
+      `return $input.${READ_KEY}.records.length`,
+      { [READ_KEY]: { records: '[1,2,3,4]'.concat("]") /* keep it a string */ } }
+    )
+    // records is a JSON string here; .length is the string length, proving the
+    // value is passed through verbatim (not auto-parsed).
+    expect(res.success).toBe(true)
+    expect(typeof res.data).toBe("number")
+  })
+})
+
+describe("execute_code — {{ }} template tokens bind RAW values (#424 regression)", () => {
+  it("JSON.parse({{ $read_*.records }}) parses the raw JSON string (no mangling)", async () => {
+    // Pre-fix: the JSON string was JSON-stringified into source, producing
+    // invalid code and the 'Expected property name' error.
+    const res = await run(
+      `return JSON.parse({{ $${READ_KEY}.records }})`,
+      { [READ_KEY]: { records: '[{"sku":"A1"},{"sku":"B2"}]' } }
+    )
+
+    expect(res.success).toBe(true)
+    expect(res.data).toEqual([{ sku: "A1" }, { sku: "B2" }])
+  })
+
+  it("an object token is bound as a real object, not a stringified copy", async () => {
+    const res = await run(
+      `const v = {{ $last }}; return { isObject: typeof v === "object", id: v.id }`,
+      { $last: { id: 42, nested: { ok: true } } }
+    )
+
+    expect(res.success).toBe(true)
+    expect(res.data).toEqual({ isObject: true, id: 42 })
+  })
+
+  it("a JSON-string token round-trips through JSON.parse correctly", async () => {
+    // $last is itself a JSON string. Pre-fix, stringify added an extra layer of
+    // quotes/escapes so JSON.parse saw a quoted string, not an object.
+    const res = await run(
+      `return JSON.parse({{ $last }})`,
+      { $last: '{"hello":"world"}' }
+    )
+
+    expect(res.success).toBe(true)
+    expect(res.data).toEqual({ hello: "world" })
+  })
+
+  it("a primitive token is bound with its type preserved", async () => {
+    const res = await run(
+      `const n = {{ $last }}; return { isNumber: typeof n === "number", doubled: n * 2 }`,
+      { $last: 21 }
+    )
+
+    expect(res.success).toBe(true)
+    expect(res.data).toEqual({ isNumber: true, doubled: 42 })
+  })
+
+  it("a missing token path binds to undefined (does not throw at bind time)", async () => {
+    const res = await run(
+      `return { v: {{ $does_not_exist.foo }} === undefined }`,
+      { $last: null }
+    )
+
+    expect(res.success).toBe(true)
+    expect(res.data).toEqual({ v: true })
+  })
+})

--- a/apps/backend/src/modules/visual_flows/operations/execute-code.ts
+++ b/apps/backend/src/modules/visual_flows/operations/execute-code.ts
@@ -1,6 +1,6 @@
 import { z } from "@medusajs/framework/zod"
 import { OperationDefinition, OperationContext, OperationResult } from "./types"
-import { interpolateVariables } from "./utils"
+import { getValueByPath } from "./utils"
 import { loadPackage } from "./package-loader"
 
 // Import npm packages to expose in sandbox
@@ -99,19 +99,62 @@ function extractPotentialVariables(code: string): string[] {
 }
 
 /**
+ * Resolve `{{ ... }}` template tokens in user code by binding each token's RAW
+ * value into the sandbox under a generated identifier, instead of splicing a
+ * JSON-stringified copy into the source text.
+ *
+ * This preserves the upstream value's type verbatim: `JSON.parse({{$last}})`
+ * and `const x = {{$last}}` both receive the real object/string/number, with no
+ * stringify→parse round-trip (which previously produced invalid source like
+ * `JSON.parse({"a":1})` and threw `Expected property name or '}' at position 1`).
+ */
+function bindTemplateTokens(
+  code: string,
+  dataChain: Record<string, any>
+): { code: string; bindings: Record<string, any> } {
+  const bindings: Record<string, any> = {}
+  let i = 0
+  const boundCode = code.replace(/\{\{\s*([^}]+)\s*\}\}/g, (_match, path) => {
+    const name = `__tpl_${i++}`
+    bindings[name] = getValueByPath(dataChain, String(path).trim())
+    return name
+  })
+  return { code: boundCode, bindings }
+}
+
+/**
+ * Build `$`-prefixed aliases for every named operation output in the data chain,
+ * so user code can reference upstream steps directly — e.g.
+ * `$read_data_123.records` — in addition to `$input.read_data_123` or
+ * `{{ $read_data_123.records }}` tokens. Built-in `$`-keys ($last/$trigger) are
+ * skipped (they're already exposed explicitly).
+ */
+function dollarAliases(dataChain: Record<string, any>): Record<string, any> {
+  const aliases: Record<string, any> = {}
+  for (const [key, value] of Object.entries(dataChain)) {
+    if (!key.startsWith("$")) {
+      aliases[`$${key}`] = value
+    }
+  }
+  return aliases
+}
+
+/**
  * Validate code for potential issues before execution
  */
 function validateCode(
-  code: string, 
-  availablePackages: string[]
+  code: string,
+  availablePackages: string[],
+  extraVars: string[] = []
 ): { valid: boolean; errors: string[]; warnings: string[] } {
   const errors: string[] = []
   const warnings: string[] = []
-  
+
   // Build set of all available variables
   const availableVars = new Set([
     ...BUILTIN_SANDBOX_VARS,
     ...availablePackages.map(p => p.replace(/[^a-zA-Z0-9]/g, "_").replace(/^_+|_+$/g, "")),
+    ...extraVars,
   ])
   
   // Extract variables used in code
@@ -222,22 +265,34 @@ return {
     const logs: string[] = []
     
     try {
-      const code = options.code || ""
+      const rawCode = options.code || ""
       const timeout = options.timeout || 5000
       const requestedPackages = options.packages || []
-      
-      console.log("[execute_code] Starting execution with code length:", code.length)
+
+      console.log("[execute_code] Starting execution with code length:", rawCode.length)
       console.log("[execute_code] Requested packages:", requestedPackages)
-      
-      if (!code.trim()) {
+
+      if (!rawCode.trim()) {
         return {
           success: false,
           error: "No code provided",
         }
       }
-      
-      // Validate code before execution
-      const validation = validateCode(code, requestedPackages)
+
+      // Resolve {{...}} template tokens to RAW sandbox bindings (no JSON
+      // stringify→parse round-trip — preserves the upstream value's type).
+      const { code, bindings: templateBindings } = bindTemplateTokens(
+        rawCode,
+        context.dataChain
+      )
+
+      // Expose each named operation output as a $-prefixed sandbox variable so
+      // user code can reference upstream steps directly ($read_data_123.records).
+      const aliases = dollarAliases(context.dataChain)
+      const extraBindings = { ...aliases, ...templateBindings }
+
+      // Validate code before execution (bindings/aliases are known identifiers)
+      const validation = validateCode(code, requestedPackages, Object.keys(extraBindings))
       if (!validation.valid) {
         return {
           success: false,
@@ -290,8 +345,8 @@ return {
         }
       }
       
-      // Create a sandboxed execution environment
-      const sandbox = createSandbox(context.dataChain, logs, externalPackages)
+      // Create a sandboxed execution environment ($-aliases + token bindings)
+      const sandbox = createSandbox(context.dataChain, logs, externalPackages, extraBindings)
       
       console.log("[execute_code] Sandbox created with $last:", typeof context.dataChain.$last)
       
@@ -374,9 +429,10 @@ export const AVAILABLE_PACKAGES = {
  * Create a sandboxed environment for code execution
  */
 function createSandbox(
-  dataChain: Record<string, any>, 
+  dataChain: Record<string, any>,
   logs: string[],
-  externalPackages: Record<string, any> = {}
+  externalPackages: Record<string, any> = {},
+  extraBindings: Record<string, any> = {}
 ) {
   return {
     // Data chain access
@@ -504,6 +560,11 @@ function createSandbox(
     // ============ EXTERNAL PACKAGES ============
     // Dynamically loaded packages requested by user
     ...externalPackages,
+
+    // ============ DATA BINDINGS ============
+    // $-aliases for named outputs + raw {{...}} token values (type-preserved,
+    // no stringify round-trip).
+    ...extraBindings,
   }
 }
 


### PR DESCRIPTION
## #424 — visual-flow `execute_code` `{{...}}` JSON mangling

### Problem
User code in an `execute_code` node that referenced upstream data via `{{ ... }}` tokens mangled JSON. `JSON.parse({{$last}})` threw `Expected property name or '}' at position 1` because the token's value was `JSON.stringify`'d **into the source text**, producing invalid code.

Two execution paths handled this differently, both broken:
- `execution-engine.ts` interpolated **all** options (incl. `code`) → spliced JSON text into source.
- `execute-visual-flow.ts` (the workflow / prod path) passed **raw** options expecting "operations do their own interpolation" — but `execute_code` never actually resolved its tokens.

### Fix
Token resolution now lives **inside the operation** (single source of truth for both paths):
- `bindTemplateTokens()` — resolve `{{ ... }}` to a generated identifier bound to the **raw** value in the sandbox. No stringify→parse round-trip; type preserved (object/string/number).
- `dollarAliases()` — expose each named output as `$<operation_key>`, so code can reference upstream steps directly (`$read_data_123.records`) alongside `$last`/`$input`/`$trigger`.
- `execution-engine.ts` — exempt the `code` field from string interpolation for `execute_code`.

### Tests
- **Unit** `operations/__tests__/execute-code.unit.spec.ts` — 9 cases: `$last`, `$<key>` aliases, and `{{token}}` for objects / JSON-strings / primitives / missing paths. Includes the reported `($last && $last.records) || JSON.parse($read_data_….records)` across present/fallback/null-`$last`.
- **Integration** `integration-tests/http/visual-flow-code-interpolation.spec.ts` — 2 cases driving the **real** `executeVisualFlowWorkflow` via `POST /:id/execute` with a multi-node canvas.

### Verification
- New tests: 9/9 unit + 2/2 integration green.
- Existing `visual-flow-lifecycle-email` (also `execute_code`): 5/5 green.
- `tsc --noEmit`: 70 errors = exact baseline, **0 new**.

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)