### PR TITLE
fix(social-platforms): edit-platform toasts never rendered (sonner → @medusajs/ui)

### DIFF
--- a/apps/backend/src/admin/components/edits/edit-social-platform.tsx
+++ b/apps/backend/src/admin/components/edits/edit-social-platform.tsx
@@ -1,12 +1,11 @@
 import { useTranslation } from "react-i18next";
 import { z } from "@medusajs/framework/zod";
-import { toast } from "sonner";
 import { DynamicForm, type FieldConfig } from "../common/dynamic-form";
 import { useRouteModal } from "../modal/use-route-modal";
 import { useUpdateSocialPlatform, AdminSocialPlatform } from "../../hooks/api/social-platforms";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Button, Heading, Input, Select, Textarea, Text } from "@medusajs/ui";
+import { Button, Heading, Input, Select, Textarea, Text, toast } from "@medusajs/ui";
 import { KeyboundForm } from "../utilitites/key-bound-form";
 import { Form } from "../common/form";
 import { RouteDrawer } from "../modal/route-drawer/route-drawer";


### PR DESCRIPTION
## Problem
Saving from the **edit external-platform** form showed **no toast at all** — success or failure. The handlers call `toast.success`/`toast.error`, but the form imported `toast` from `sonner` directly. The admin mounts only `@medusajs/ui`'s `<Toaster/>` (a separate sonner instance), so calls to the bare `sonner` toast go to an unmounted toaster and silently no-op.

Every other form that shows toasts (create, `social-platform-general-section`, AI create, Google forms, the Shiprocket pickup widget) imports `toast` from `@medusajs/ui`.

## Fix
One line: import `toast` from `@medusajs/ui` (added to the existing import) and drop the `sonner` import. The form's existing success/error toasts now render on save.

tsc unchanged (70 baseline, 0 new).