### PR TITLE
chore(admin): route all toasts through @medusajs/ui (sonner toasts never rendered)

### DIFF
--- a/apps/backend/src/admin/components/creates/create-email-template.tsx
+++ b/apps/backend/src/admin/components/creates/create-email-template.tsx
@@ -1,8 +1,7 @@
-import { Button, Heading, Input, Select, Switch, Text, Textarea } from "@medusajs/ui";
+import { Button, Heading, Input, Select, Switch, Text, Textarea, toast } from "@medusajs/ui";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "@medusajs/framework/zod";
-import { toast } from "sonner";
 import { useNavigate } from "react-router-dom";
 import { RouteFocusModal } from "../modal/route-focus-modal";
 import { KeyboundForm } from "../utilitites/key-bound-form";

--- a/apps/backend/src/admin/components/creates/create-feedback.tsx
+++ b/apps/backend/src/admin/components/creates/create-feedback.tsx
@@ -1,4 +1,4 @@
-import { toast } from "sonner";
+import { toast } from "@medusajs/ui";
 import { z } from "@medusajs/framework/zod";
 import { useMemo } from "react";
 import { DynamicForm, type FieldConfig } from "../common/dynamic-form";

--- a/apps/backend/src/admin/components/creates/create-inventory-order-feedback.tsx
+++ b/apps/backend/src/admin/components/creates/create-inventory-order-feedback.tsx
@@ -1,4 +1,4 @@
-import { toast } from "sonner";
+import { toast } from "@medusajs/ui";
 import { z } from "@medusajs/framework/zod";
 import { useMemo } from "react";
 import { DynamicForm, type FieldConfig } from "../common/dynamic-form";

--- a/apps/backend/src/admin/components/creates/create-partner-feedback.tsx
+++ b/apps/backend/src/admin/components/creates/create-partner-feedback.tsx
@@ -1,4 +1,4 @@
-import { toast } from "sonner";
+import { toast } from "@medusajs/ui";
 import { z } from "@medusajs/framework/zod";
 import { useMemo } from "react";
 import { DynamicForm, type FieldConfig } from "../common/dynamic-form";

--- a/apps/backend/src/admin/components/creates/create-task-feedback.tsx
+++ b/apps/backend/src/admin/components/creates/create-task-feedback.tsx
@@ -1,4 +1,4 @@
-import { toast } from "sonner";
+import { toast } from "@medusajs/ui";
 import { z } from "@medusajs/framework/zod";
 import { useMemo } from "react";
 import { DynamicForm, type FieldConfig } from "../common/dynamic-form";

--- a/apps/backend/src/admin/components/designs/design-task-edit-section.tsx
+++ b/apps/backend/src/admin/components/designs/design-task-edit-section.tsx
@@ -1,10 +1,9 @@
 import { useTranslation } from "react-i18next";
 import { z } from "@medusajs/framework/zod";
-import { toast } from "sonner";
 import { DynamicForm, type FieldConfig } from "../common/dynamic-form";
 import { useRouteModal } from "../modal/use-route-modal";
 import { AdminDesignTask, TaskPriority, TaskStatus, useUpdateDesignTask } from "../../hooks/api/design-tasks";
-import { DatePicker } from "@medusajs/ui";
+import { DatePicker, toast } from "@medusajs/ui";
 
 const taskSchema = z.object({
   description: z.string().optional(),

--- a/apps/backend/src/admin/components/edits/edit-color-palette.tsx
+++ b/apps/backend/src/admin/components/edits/edit-color-palette.tsx
@@ -1,11 +1,11 @@
 import { useState, useRef, useEffect } from "react";
-import { toast } from "sonner";
 import {
   Button,
   Input,
   Text,
   Badge,
   Heading,
+  toast,
 } from "@medusajs/ui";
 import { XMarkMini, Plus } from "@medusajs/icons";
 import { RouteDrawer } from "../modal/route-drawer/route-drawer";

--- a/apps/backend/src/admin/components/edits/edit-design-sizes.tsx
+++ b/apps/backend/src/admin/components/edits/edit-design-sizes.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { z } from "@medusajs/framework/zod";
-import { toast } from "sonner";
-import { Badge, Text, Button, Switch, Input } from "@medusajs/ui";
+import { Badge, Text, Button, Switch, Input, toast } from "@medusajs/ui";
 import { Trash, Plus } from "@medusajs/icons";
 import { useRouteModal } from "../modal/use-route-modal";
 import { useUpdateDesign, AdminDesign, CustomSize } from "../../hooks/api/designs";

--- a/apps/backend/src/admin/components/edits/edit-design.tsx
+++ b/apps/backend/src/admin/components/edits/edit-design.tsx
@@ -1,10 +1,9 @@
 import { useTranslation } from "react-i18next";
 import { z } from "@medusajs/framework/zod";
-import { toast } from "sonner";
 import { DynamicForm, type FieldConfig } from "../common/dynamic-form";
 import { useRouteModal } from "../modal/use-route-modal";
 import { useUpdateDesign, AdminDesign } from "../../hooks/api/designs";
-import { DatePicker } from "@medusajs/ui";
+import { DatePicker, toast } from "@medusajs/ui";
 
 const designSchema = z.object({
   name: z.string().min(1, "Name is required"),

--- a/apps/backend/src/admin/components/edits/edit-email-template.tsx
+++ b/apps/backend/src/admin/components/edits/edit-email-template.tsx
@@ -1,6 +1,6 @@
 import { useUpdateEmailTemplate } from "../../hooks/api/email-templates";
 import { DynamicForm, FieldConfig } from "../common/dynamic-form";
-import { toast } from "sonner";
+import { toast } from "@medusajs/ui";
 import { useTranslation } from "react-i18next";
 import { AdminEmailTemplate } from "../../hooks/api/email-templates";
 import { useRouteModal } from "../../components/modal/use-route-modal";

--- a/apps/backend/src/admin/components/edits/edit-form.tsx
+++ b/apps/backend/src/admin/components/edits/edit-form.tsx
@@ -1,5 +1,5 @@
 import { DynamicForm, FieldConfig } from "../common/dynamic-form"
-import { toast } from "sonner"
+import { toast } from "@medusajs/ui"
 import { useRouteModal } from "../../components/modal/use-route-modal"
 import { AdminForm, useUpdateForm } from "../../hooks/api/forms"
 

--- a/apps/backend/src/admin/components/edits/edit-inventory-order-task.tsx
+++ b/apps/backend/src/admin/components/edits/edit-inventory-order-task.tsx
@@ -1,10 +1,9 @@
 import { useTranslation } from "react-i18next";
 import { z } from "@medusajs/framework/zod";
-import { toast } from "sonner";
 import { DynamicForm, type FieldConfig } from "../common/dynamic-form";
 import { useRouteModal } from "../modal/use-route-modal";
 import { AdminInventoryOrderTask, TaskPriority, TaskStatus, useUpdateInventoryOrderTask } from "../../hooks/api/inventory-order-tasks";
-import { DatePicker } from "@medusajs/ui";
+import { DatePicker, toast } from "@medusajs/ui";
 
 const taskSchema = z.object({
   title: z.string().min(1, "Title is required"),

--- a/apps/backend/src/admin/components/edits/edit-page.tsx
+++ b/apps/backend/src/admin/components/edits/edit-page.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { z } from "@medusajs/framework/zod";
-import { toast } from "sonner";
+import { toast } from "@medusajs/ui";
 import { DynamicForm, type FieldConfig } from "../common/dynamic-form";
 import { useRouteModal } from "../modal/use-route-modal";
 import { useUpdatePage, type AdminPage } from "../../hooks/api/pages";

--- a/apps/backend/src/admin/components/edits/edit-person-general-section.tsx
+++ b/apps/backend/src/admin/components/edits/edit-person-general-section.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { z } from "@medusajs/framework/zod";
-import { toast } from "sonner";
-import { DatePicker } from "@medusajs/ui";
+import { DatePicker, toast } from "@medusajs/ui";
 import { DynamicForm, type FieldConfig } from "../common/dynamic-form";
 import { useRouteModal } from "../modal/use-route-modal";
 import { useUpdatePerson} from "../../hooks/api/persons";

--- a/apps/backend/src/admin/components/edits/edit-raw-material.tsx
+++ b/apps/backend/src/admin/components/edits/edit-raw-material.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { z } from "@medusajs/framework/zod";
-import { toast } from "sonner";
+import { toast } from "@medusajs/ui";
 import { DynamicForm, type FieldConfig } from "../common/dynamic-form";
 import { useRouteModal } from "../modal/use-route-modal";
 import { useUpdateRawMaterial, RawMaterial, useRawMaterialCategories } from "../../hooks/api/raw-materials";

--- a/apps/backend/src/admin/components/edits/edit-task-template.tsx
+++ b/apps/backend/src/admin/components/edits/edit-task-template.tsx
@@ -4,7 +4,7 @@ import { AdminTaskTemplate, useUpdateTaskTemplate } from "../../hooks/api/task-t
 import { useTaskTemplateCategories } from "../../hooks/api/task-template-categories";
 import { CategorySearch } from "../common/category-search";
 import { useState } from "react";
-import { toast } from "sonner";
+import { toast } from "@medusajs/ui";
 import { DynamicForm, type FieldConfig } from "../common/dynamic-form";
 import { useRouteModal } from "../modal/use-route-modal";
 

--- a/apps/backend/src/admin/components/forms/form-general-section.tsx
+++ b/apps/backend/src/admin/components/forms/form-general-section.tsx
@@ -1,10 +1,9 @@
 import { PencilSquare, SquaresPlus, Trash } from "@medusajs/icons"
-import { Container, Heading, Text, usePrompt } from "@medusajs/ui"
+import { Container, Heading, Text, usePrompt, toast } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
 import { ActionMenu } from "../common/action-menu"
 import { AdminForm, useDeleteForm } from "../../hooks/api/forms"
 import { useNavigate } from "react-router-dom"
-import { toast } from "sonner"
 
 type FormGeneralSectionProps = {
   form: AdminForm

--- a/apps/backend/src/admin/components/forms/form-responses-section.tsx
+++ b/apps/backend/src/admin/components/forms/form-responses-section.tsx
@@ -5,12 +5,12 @@ import {
   DataTable,
   useDataTable,
   DataTablePaginationState,
+  toast,
 } from "@medusajs/ui"
 import { keepPreviousData } from "@tanstack/react-query"
 import { useMemo, useState } from "react"
 import { createColumnHelper } from "@tanstack/react-table"
 import { Eye, SquareTwoStack } from "@medusajs/icons"
-import { toast } from "sonner"
 import { EntityActions } from "../persons/personsActions"
 import { AdminFormResponse, useFormResponses } from "../../hooks/api/forms"
 import { useFormResponsesTableColumns } from "../../hooks/columns/useFormResponsesTableColumns"

--- a/apps/backend/src/admin/components/persons/edit-contact-for-person.tsx
+++ b/apps/backend/src/admin/components/persons/edit-contact-for-person.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { z } from "@medusajs/framework/zod";
-import { toast } from "sonner";
-import { Select } from "@medusajs/ui";
+import { Select, toast } from "@medusajs/ui";
 
 import { DynamicForm, type FieldConfig } from "../common/dynamic-form";
 import { useRouteModal } from "../modal/use-route-modal";

--- a/apps/backend/src/admin/components/production-runs/production-run-task-edit-form.tsx
+++ b/apps/backend/src/admin/components/production-runs/production-run-task-edit-form.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next"
 import { z } from "@medusajs/framework/zod"
-import { toast } from "sonner"
-import { DatePicker } from "@medusajs/ui"
+import { DatePicker, toast } from "@medusajs/ui"
 
 import { DynamicForm, type FieldConfig } from "../common/dynamic-form"
 import { useRouteModal } from "../modal/use-route-modal"

--- a/apps/backend/src/admin/components/products/ai-description-chat-modal.tsx
+++ b/apps/backend/src/admin/components/products/ai-description-chat-modal.tsx
@@ -1,7 +1,6 @@
-import { Button, FocusModal, Textarea, Text, Heading, Badge, Switch } from "@medusajs/ui"
+import { Button, FocusModal, Textarea, Text, Heading, Badge, Switch, toast } from "@medusajs/ui"
 import { useState } from "react"
 import { useGenerateProductDescription } from "../../hooks/api/products"
-import { toast } from "sonner"
 import { Spinner } from "../ui/spinner"
 import { Sparkles, ArrowPath, InformationCircle, InformationCircleSolid } from "@medusajs/icons"
 

--- a/apps/backend/src/admin/hooks/api/feedbacks.ts
+++ b/apps/backend/src/admin/hooks/api/feedbacks.ts
@@ -7,7 +7,7 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import { toast } from "sonner";
+import { toast } from "@medusajs/ui";
 import { sdk } from "../../lib/config";
 import { queryKeysFactory } from "../../lib/query-key-factory";
 


### PR DESCRIPTION
Follow-up sweep after #429.

## Problem
22 admin files imported `toast` from `sonner` directly. The admin only mounts `@medusajs/ui`'s `<Toaster/>` (no sonner `<Toaster>` is mounted anywhere, and the tree has multiple sonner instances), so those `toast.success`/`toast.error` calls went to an unmounted observer and **rendered nothing** — saves gave no feedback. Same root cause as the social-platform edit form (#429).

## Fix
Switched all 22 to `import { toast } from "@medusajs/ui"` — merged into the existing @medusajs/ui import where one existed (12), added a new import otherwise (10). Semicolon style preserved per file. Every usage was `.success`/`.error` (incl. `{ description }`), all compatible with @medusajs/ui's toast — **no call sites changed**, no sonner-only APIs (`toast.promise`/`custom`) in play.

## Verification
- `grep 'from "sonner"' apps/backend/src/admin` → no matches.
- No duplicate `@medusajs/ui` imports introduced.
- `npx tsc --noEmit -p tsconfig.json` → 70 (baseline), 0 new.

Files: create/edit feedback + template + design + form + person + raw-material + task forms, production-run task edit, AI description modal, and the feedbacks API hook.