### PR TITLE
feat(orders): #404 PR-B — Shiprocket fulfillment label off the order

### DIFF
--- a/apps/backend/src/api/admin/orders/[id]/fulfillments/[fulfillmentId]/label/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/fulfillments/[fulfillmentId]/label/route.ts
@@ -1,0 +1,60 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import {
+  isSupportedCarrier,
+  resolveShippingProvider,
+  shipmentRefFromFulfillment,
+} from "../../../../../../../modules/shipping-providers/resolver"
+
+/**
+ * GET /admin/orders/:id/fulfillments/:fulfillmentId/label
+ *
+ * #404 (#31) PR-B — admin mirror of the partner label route. Fetches the
+ * shipping label for a fulfillment whose `data` carries the carrier refs
+ * (populated by the shiprocket-shipment route). Falls back to the stored label
+ * for manual (no-carrier) fulfillments.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data: orders } = await query.graph({
+    entity: "orders",
+    fields: ["id", "fulfillments.*", "fulfillments.labels.*"],
+    filters: { id: req.params.id },
+  })
+
+  const order = (orders as any)?.[0]
+  const fulfillment = order?.fulfillments?.find(
+    (f: any) => f.id === req.params.fulfillmentId
+  )
+  if (!fulfillment) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Fulfillment not found")
+  }
+
+  const waybill = fulfillment.data?.waybill || fulfillment.data?.tracking_number
+  if (!waybill) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      "No waybill found for this fulfillment"
+    )
+  }
+
+  const carrier = fulfillment.data?.carrier
+  if (!isSupportedCarrier(carrier)) {
+    const label = fulfillment.labels?.[0]
+    res.json({
+      label_url: label?.label_url || "",
+      tracking_number: label?.tracking_number || waybill,
+      packing_slip: null,
+    })
+    return
+  }
+
+  const provider = await resolveShippingProvider(req.scope, carrier)
+  const label = await provider.getLabel(shipmentRefFromFulfillment(fulfillment.data))
+
+  res.json({
+    label_url: label.label_url || "",
+    tracking_number: waybill,
+    packing_slip: label.raw ?? label.data ?? null,
+  })
+}

--- a/apps/backend/src/api/admin/orders/[id]/fulfillments/[fulfillmentId]/shiprocket-shipment/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/fulfillments/[fulfillmentId]/shiprocket-shipment/route.ts
@@ -1,0 +1,43 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import { createShiprocketShipmentForFulfillment } from "../../../../../../../workflows/orders/shiprocket-shipment"
+
+/**
+ * POST /admin/orders/:id/fulfillments/:fulfillmentId/shiprocket-shipment
+ *
+ * #404 (#31) PR-B — create the Shiprocket shipment (forward order → AWB → label)
+ * for a fulfillment of the order, persisting the carrier refs onto
+ * `fulfillment.data`. Returns the AWB + label URL (Shiprocket bundles label
+ * generation into shipment creation). The fulfillment is created first via
+ * Medusa core's `POST /admin/orders/:id/fulfillments`.
+ *
+ * Shiprocket failures throw a ShiprocketApiError (a MedusaError, #427), so the
+ * framework returns a clean error instead of a 500.
+ */
+const Body = z.object({
+  pickup_location_name: z.string().optional(),
+  weight_grams: z.coerce.number().positive().optional(),
+  dimensions_cm: z
+    .object({
+      length: z.coerce.number(),
+      width: z.coerce.number(),
+      height: z.coerce.number(),
+    })
+    .optional(),
+  preferred_courier_id: z.union([z.string(), z.number()]).optional(),
+})
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const body = Body.parse((req.body as Record<string, unknown>) ?? {})
+
+  const result = await createShiprocketShipmentForFulfillment(req.scope, {
+    orderId: req.params.id,
+    fulfillmentId: req.params.fulfillmentId,
+    pickupLocationName: body.pickup_location_name,
+    weightGrams: body.weight_grams,
+    dimensionsCm: body.dimensions_cm,
+    preferredCourierId: body.preferred_courier_id,
+  })
+
+  res.status(200).json({ shipment: result })
+}

--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/create-shipment.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/create-shipment.unit.spec.ts
@@ -1,0 +1,80 @@
+import { ShiprocketClient } from "../client"
+
+/**
+ * #404 PR-B — ShiprocketClient.createShipment sequences create-adhoc-order →
+ * assign-AWB → generate-label and returns a uniform ShipmentResult. The three
+ * Shiprocket endpoints are stubbed via global.fetch (no sandbox API). A token
+ * is injected so no /auth/login round-trip is needed.
+ */
+describe("ShiprocketClient.createShipment (#404 PR-B)", () => {
+  let fetchSpy: jest.SpyInstance
+
+  afterEach(() => fetchSpy?.mockRestore())
+
+  it("returns awb + label_url + provider_refs from the bundled flow", async () => {
+    const real = global.fetch?.bind(globalThis)
+    fetchSpy = jest
+      .spyOn(global, "fetch" as any)
+      .mockImplementation(async (input: any, init: any = {}) => {
+        const url = String(input)
+        const make = (body: any, status = 200) =>
+          ({
+            ok: status >= 200 && status < 300,
+            status,
+            json: async () => body,
+            text: async () => JSON.stringify(body),
+          }) as any
+        if (!url.includes("shiprocket.in")) return real?.(input, init)
+        if (url.endsWith("/orders/create/adhoc"))
+          return make({ shipment_id: 111, order_id: 222 })
+        if (url.endsWith("/courier/assign/awb"))
+          return make({
+            response: {
+              data: {
+                awb_code: "AWB123",
+                courier_company_id: 5,
+                courier_name: "Test Courier",
+              },
+            },
+          })
+        if (url.endsWith("/courier/generate/label"))
+          return make({ label_url: "https://shiprocket/label.pdf" })
+        return make({}, 404)
+      })
+
+    const client = new ShiprocketClient({
+      email: "x@y.com",
+      password: "p",
+      token: "injected-token", // skips /auth/login
+      pickup_location: "warehouse-abc",
+    })
+
+    const result = await client.createShipment({
+      reference_id: "order_1",
+      payment_mode: "prepaid",
+      pickup_location_name: "warehouse-abc",
+      to: {
+        name: "Asha Rao",
+        phone: "+919800000000",
+        address_1: "12 MG Road",
+        city: "Bengaluru",
+        state: "KA",
+        pincode: "560001",
+        country: "IN",
+      },
+      items: [{ name: "Saree", quantity: 1, unit_price: 250 }],
+      weight_grams: 500,
+      sub_total: 250,
+    })
+
+    expect(result.carrier).toBe("shiprocket")
+    expect(result.awb).toBe("AWB123")
+    expect(result.tracking_number).toBe("AWB123")
+    expect(result.label_url).toBe("https://shiprocket/label.pdf")
+    expect(result.provider_refs).toMatchObject({
+      shipment_id: 111,
+      sr_order_id: 222,
+      courier_company_id: 5,
+    })
+  })
+})

--- a/apps/backend/src/workflows/orders/__tests__/build-create-shipment-input.unit.spec.ts
+++ b/apps/backend/src/workflows/orders/__tests__/build-create-shipment-input.unit.spec.ts
@@ -1,0 +1,69 @@
+import {
+  buildCreateShipmentInput,
+  type OrderForShipment,
+} from "../shiprocket-shipment"
+
+const baseOrder: OrderForShipment = {
+  id: "order_1",
+  email: "buyer@example.com",
+  total: 250,
+  subtotal: 250,
+  metadata: {},
+  shipping_address: {
+    first_name: "Asha",
+    last_name: "Rao",
+    phone: "+919800000000",
+    address_1: "12 MG Road",
+    city: "Bengaluru",
+    province: "KA",
+    postal_code: "560001",
+    country_code: "in",
+  },
+  items: [{ title: "Custom Saree", quantity: 2, unit_price: 100, sku: "SAR-1" }],
+}
+
+describe("buildCreateShipmentInput (#404 PR-B)", () => {
+  it("maps a prepaid order (no cod_amount)", () => {
+    const input = buildCreateShipmentInput(baseOrder, {
+      pickupLocationName: "warehouse-abc",
+    })
+    expect(input.reference_id).toBe("order_1")
+    expect(input.payment_mode).toBe("prepaid")
+    expect(input.cod_amount).toBeUndefined()
+    expect(input.pickup_location_name).toBe("warehouse-abc")
+    expect(input.to).toMatchObject({
+      name: "Asha Rao",
+      phone: "+919800000000",
+      email: "buyer@example.com",
+      address_1: "12 MG Road",
+      city: "Bengaluru",
+      state: "KA",
+      pincode: "560001",
+      country: "IN", // upper-cased
+    })
+    expect(input.items).toEqual([
+      { name: "Custom Saree", sku: "SAR-1", quantity: 2, unit_price: 100 },
+    ])
+    expect(input.sub_total).toBe(250)
+    expect(input.weight_grams).toBe(500) // default
+  })
+
+  it("sets cod_amount = order total for a COD order", () => {
+    const input = buildCreateShipmentInput(
+      { ...baseOrder, metadata: { payment_mode: "cod" } },
+      { pickupLocationName: "wh" }
+    )
+    expect(input.payment_mode).toBe("cod")
+    expect(input.cod_amount).toBe(250)
+  })
+
+  it("falls back to empty pickup name (client default) and derives sub_total", () => {
+    const input = buildCreateShipmentInput(
+      { ...baseOrder, subtotal: null },
+      { weightGrams: 1200 }
+    )
+    expect(input.pickup_location_name).toBe("")
+    expect(input.sub_total).toBe(200) // 2 * 100
+    expect(input.weight_grams).toBe(1200)
+  })
+})

--- a/apps/backend/src/workflows/orders/shiprocket-shipment.ts
+++ b/apps/backend/src/workflows/orders/shiprocket-shipment.ts
@@ -1,0 +1,198 @@
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+import { resolveShippingProvider } from "../../modules/shipping-providers/resolver"
+import type {
+  CreateShipmentInput,
+  Dimensions,
+  ShipmentItem,
+  ShipmentResult,
+} from "../../modules/shipping-providers/provider-interface"
+import { SHIPROCKET_PICKUP_METADATA_KEY } from "../../modules/shipping-providers/pickup-locations"
+
+/**
+ * #404 (#31) PR-B — generate a Shiprocket shipment (forward order → AWB → label)
+ * for a fulfillment of a (converted) order, and persist the carrier refs onto
+ * `fulfillment.data` so the existing label/tracking/pickup routes can read them.
+ *
+ * The admin creates the fulfillment first via Medusa core's
+ * `POST /admin/orders/:id/fulfillments`; this drives the carrier off it — the
+ * first consumer of `ShippingProviderClient.createShipment` (the label/tracking
+ * routes only ever fetched against an already-populated `fulfillment.data`).
+ */
+
+const DEFAULT_WEIGHT_GRAMS = 500
+
+export type OrderForShipment = {
+  id: string
+  email?: string | null
+  total?: number | null
+  subtotal?: number | null
+  metadata?: Record<string, any> | null
+  shipping_address?: Record<string, any> | null
+  items?: Array<{
+    title?: string | null
+    quantity?: number | null
+    unit_price?: number | null
+    sku?: string | null
+  }> | null
+}
+
+export type BuildShipmentOpts = {
+  pickupLocationName?: string
+  weightGrams?: number
+  dimensionsCm?: Dimensions
+  preferredCourierId?: string | number
+}
+
+/**
+ * Pure mapping from a core order onto a `CreateShipmentInput`. COD orders
+ * (metadata.payment_mode === "cod") carry a `cod_amount` (the order total in
+ * major units); prepaid orders don't. Exported for unit testing.
+ */
+export function buildCreateShipmentInput(
+  order: OrderForShipment,
+  opts: BuildShipmentOpts
+): CreateShipmentInput {
+  const addr = order.shipping_address || {}
+  const paymentMode: "prepaid" | "cod" =
+    order.metadata?.payment_mode === "cod" ? "cod" : "prepaid"
+
+  const items: ShipmentItem[] = (order.items || []).map((li) => ({
+    name: li.title || "Item",
+    sku: li.sku || undefined,
+    quantity: Number(li.quantity) || 1,
+    unit_price: Number(li.unit_price) || 0,
+  }))
+  const subTotal =
+    order.subtotal != null
+      ? Number(order.subtotal)
+      : items.reduce((s, i) => s + i.unit_price * i.quantity, 0)
+
+  const name =
+    [addr.first_name, addr.last_name].filter(Boolean).join(" ") || "Customer"
+
+  return {
+    reference_id: order.id,
+    payment_mode: paymentMode,
+    cod_amount:
+      paymentMode === "cod" ? Number(order.total) || subTotal : undefined,
+    // "" lets the client fall back to its configured default pickup location.
+    pickup_location_name: opts.pickupLocationName || "",
+    to: {
+      name,
+      phone: addr.phone || "",
+      email: order.email || addr.email || undefined,
+      address_1: addr.address_1 || "",
+      address_2: addr.address_2 || undefined,
+      city: addr.city || "",
+      state: addr.province || "",
+      pincode: addr.postal_code || "",
+      country: addr.country_code ? String(addr.country_code).toUpperCase() : "IN",
+    },
+    items,
+    weight_grams: opts.weightGrams || DEFAULT_WEIGHT_GRAMS,
+    dimensions_cm: opts.dimensionsCm,
+    sub_total: subTotal,
+    preferred_courier_id: opts.preferredCourierId,
+  }
+}
+
+export type CreateShiprocketShipmentInput = {
+  orderId: string
+  fulfillmentId: string
+  pickupLocationName?: string
+  weightGrams?: number
+  dimensionsCm?: Dimensions
+  preferredCourierId?: string | number
+}
+
+export async function createShiprocketShipmentForFulfillment(
+  container: MedusaContainer,
+  input: CreateShiprocketShipmentInput
+): Promise<ShipmentResult & { fulfillment_id: string }> {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  const fulfillmentModule: any = container.resolve(Modules.FULFILLMENT)
+
+  const { data: orders } = await query.graph({
+    entity: "order",
+    fields: [
+      "id",
+      "email",
+      "total",
+      "subtotal",
+      "metadata",
+      "shipping_address.*",
+      "items.title",
+      "items.quantity",
+      "items.unit_price",
+      "fulfillments.id",
+      "fulfillments.location_id",
+      "fulfillments.data",
+    ],
+    filters: { id: input.orderId },
+  })
+  const order = orders?.[0]
+  if (!order) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, `Order ${input.orderId} not found`)
+  }
+  const fulfillment = (order.fulfillments || []).find(
+    (f: any) => f.id === input.fulfillmentId
+  )
+  if (!fulfillment) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Fulfillment ${input.fulfillmentId} not found on order ${input.orderId}`
+    )
+  }
+
+  // Pickup nickname: explicit → the fulfillment's stock-location Shiprocket
+  // nickname → (client default).
+  let pickupLocationName = input.pickupLocationName
+  if (!pickupLocationName && fulfillment.location_id) {
+    const { data: locs } = await query.graph({
+      entity: "stock_location",
+      fields: ["id", "metadata"],
+      filters: { id: fulfillment.location_id },
+    })
+    pickupLocationName = (locs?.[0]?.metadata as any)?.[
+      SHIPROCKET_PICKUP_METADATA_KEY
+    ]
+  }
+
+  const provider = await resolveShippingProvider(container, "shiprocket")
+  if (!provider.createShipment) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "Shiprocket provider does not support shipment creation"
+    )
+  }
+
+  const shipmentInput = buildCreateShipmentInput(order as OrderForShipment, {
+    pickupLocationName,
+    weightGrams: input.weightGrams,
+    dimensionsCm: input.dimensionsCm,
+    preferredCourierId: input.preferredCourierId,
+  })
+  const result = await provider.createShipment(shipmentInput)
+
+  // Persist the carrier refs onto fulfillment.data (what label/tracking read).
+  await fulfillmentModule.updateFulfillment(input.fulfillmentId, {
+    data: {
+      ...(fulfillment.data || {}),
+      carrier: "shiprocket",
+      waybill: result.awb,
+      tracking_number: result.tracking_number,
+      tracking_url: result.tracking_url,
+      label_url: result.label_url,
+      shipment_id: result.provider_refs?.shipment_id,
+      sr_order_id: result.provider_refs?.sr_order_id,
+      provider_refs: result.provider_refs,
+    },
+  })
+
+  return { ...result, fulfillment_id: input.fulfillmentId }
+}


### PR DESCRIPTION
Second of 3 PRs for #404 P1. Builds on PR-A (#431).

## What
Generate a **Shiprocket shipment + label** off a fulfillment of the (converted) order. This wires `ShippingProviderClient.createShipment` for the **first time** — the existing label/tracking/pickup routes only ever *read* an already-populated `fulfillment.data`; nothing created it.

Flow: admin creates the fulfillment via Medusa core's `POST /admin/orders/:id/fulfillments`, then drives the carrier off it.

## Surface
- `src/workflows/orders/shiprocket-shipment.ts`
  - **`buildCreateShipmentInput`** (pure): order → `CreateShipmentInput`. COD orders (`metadata.payment_mode==="cod"`, set by PR-A) carry `cod_amount = order total`; prepaid don't. Address/items/`sub_total` mapped; weight defaults to 500 g.
  - **`createShiprocketShipmentForFulfillment`**: loads order+fulfillment, resolves the pickup nickname from the fulfillment's stock location (`metadata.shiprocket_pickup_location`) or a passed name (else the client default), calls `provider.createShipment`, and persists `carrier`/`waybill`/`label_url`/`provider_refs` onto `fulfillment.data`.
- `POST /admin/orders/:id/fulfillments/:fulfillmentId/shiprocket-shipment` → `{ shipment: { awb, tracking_number, label_url, ... } }`.
- `GET /admin/orders/:id/fulfillments/:fulfillmentId/label` — admin mirror of the partner label route.

Shiprocket failures surface as `ShiprocketApiError` (a MedusaError, #427) — clean error, never a 500.

## Verification
- Unit: `buildCreateShipmentInput` (prepaid / COD / derivation — 3) + a **fetch-stubbed** `ShiprocketClient.createShipment` end-to-end (create-adhoc → assign-AWB → generate-label — 1). Green.
- `tsc --noEmit` → 70 (baseline), 0 new.

Live label needs prod Shiprocket creds + a registered/verified pickup (#427) + a fulfillment — not exercised in CI (the live path was always creds-gated). **PR-C** adds the admin UI: Convert action (PR-A) + Generate-label action (this), Playwright-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)