### PR TITLE
feat(orders): #404 PR-C — admin Convert-to-Order + Generate-label UI

### DIFF
--- a/apps/backend/src/admin/hooks/api/design-orders.ts
+++ b/apps/backend/src/admin/hooks/api/design-orders.ts
@@ -257,3 +257,39 @@ export const useConvertDesignOrder = (
     ...options,
   });
 };
+
+export type GenerateShiprocketLabelResponse = {
+  shiprocket_label: {
+    awb?: string;
+    tracking_number?: string;
+    label_url?: string;
+    tracking_url?: string;
+    fulfillment_id: string;
+  };
+};
+
+/**
+ * One-click Shiprocket label for a converted order: creates a fulfillment (or
+ * reuses an existing Shiprocket one) and generates the shipment + label. #404
+ * PR-C.
+ */
+export const useGenerateShiprocketLabel = (
+  orderId: string,
+  options?: UseMutationOptions<GenerateShiprocketLabelResponse, FetchError>
+) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async () =>
+      sdk.client.fetch<GenerateShiprocketLabelResponse>(
+        `/admin/orders/${orderId}/shiprocket-label`,
+        { method: "POST", body: {} }
+      ),
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({
+        queryKey: designOrdersQueryKeys.lists(),
+      });
+      options?.onSuccess?.(...args);
+    },
+    ...options,
+  });
+};

--- a/apps/backend/src/admin/routes/design-orders/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/design-orders/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react"
 import { useParams, UIMatch } from "react-router-dom"
 import {
   Container,
@@ -16,6 +17,8 @@ import {
   PencilSquare,
   SquareTwoStack,
   ShoppingBag,
+  CurrencyDollar,
+  HandTruck,
 } from "@medusajs/icons"
 import { ActionMenu } from "../../../components/common/action-menu"
 import { TwoColumnPage } from "../../../components/pages/two-column-pages"
@@ -24,6 +27,8 @@ import {
   useDesignOrder,
   useApproveDesign,
   useCancelDesignOrder,
+  useConvertDesignOrder,
+  useGenerateShiprocketLabel,
 } from "../../../hooks/api/design-orders"
 import {
   PARTNER_STATUS_LABELS,
@@ -248,8 +253,43 @@ const LineItemSection = ({ designOrder }: { designOrder: any }) => {
 
 // ─── Order Section ──────────────────────────────────────────────────────────
 
-const OrderSection = ({ designOrder }: { designOrder: any }) => {
+const OrderSection = ({
+  designOrder,
+  lineItemId,
+}: {
+  designOrder: any
+  lineItemId: string
+}) => {
   const order = designOrder.order
+  const prompt = usePrompt()
+  const { mutateAsync: convert, isPending: isConverting } =
+    useConvertDesignOrder(lineItemId)
+  const { mutateAsync: genLabel, isPending: isLabeling } =
+    useGenerateShiprocketLabel(order?.id ?? "")
+  const [labelUrl, setLabelUrl] = useState<string | null>(null)
+
+  const handleConvert = async (paymentMode: "prepaid" | "cod") => {
+    const confirmed = await prompt({
+      title: paymentMode === "cod" ? "Convert as COD order?" : "Convert to paid order?",
+      description:
+        paymentMode === "cod"
+          ? "Creates a real order marked unpaid (cash on delivery). It can then be shipped."
+          : "Creates a real order and marks it paid. It can then be shipped.",
+      confirmText: "Convert",
+      cancelText: "Cancel",
+    })
+    if (!confirmed) return
+    await convert(
+      { payment_mode: paymentMode },
+      {
+        onSuccess: (res) =>
+          toast.success(
+            `Order #${res.design_order_conversion.display_id ?? ""} created (${paymentMode})`
+          ),
+        onError: (e) => toast.error(e.message),
+      }
+    )
+  }
 
   if (!order) {
     return (
@@ -259,12 +299,48 @@ const OrderSection = ({ designOrder }: { designOrder: any }) => {
         </div>
         <div className="px-6 py-4">
           <Badge size="2xsmall" color="orange">Pending Checkout</Badge>
-          <Text size="small" className="text-ui-fg-subtle mt-2">
-            The customer has not completed checkout yet.
+          <Text size="small" className="text-ui-fg-subtle mt-2 mb-4">
+            The customer hasn't checked out. Convert this design order into a
+            real order to fulfil and ship it.
           </Text>
+          <div className="flex items-center gap-x-2">
+            <Button
+              variant="primary"
+              size="small"
+              isLoading={isConverting}
+              onClick={() => handleConvert("prepaid")}
+            >
+              <CurrencyDollar className="w-4 h-4 mr-1" />
+              Convert to Paid Order
+            </Button>
+            <Button
+              variant="secondary"
+              size="small"
+              disabled={isConverting}
+              onClick={() => handleConvert("cod")}
+            >
+              Convert as COD
+            </Button>
+          </div>
         </div>
       </Container>
     )
+  }
+
+  const isCanceled = !!order.canceled_at
+
+  const handleGenerateLabel = async () => {
+    await genLabel(undefined, {
+      onSuccess: (res) => {
+        setLabelUrl(res.shiprocket_label?.label_url || null)
+        toast.success(
+          res.shiprocket_label?.awb
+            ? `Label generated (AWB ${res.shiprocket_label.awb})`
+            : "Shipment created"
+        )
+      },
+      onError: (e) => toast.error(e.message),
+    })
   }
 
   return (
@@ -273,14 +349,34 @@ const OrderSection = ({ designOrder }: { designOrder: any }) => {
         <Heading level="h2">Order #{order.display_id}</Heading>
         <ActionMenu
           groups={[{
-            actions: [{
-              label: "View Order",
-              icon: <ShoppingBag />,
-              to: `/orders/${order.id}`,
-            }],
+            actions: [
+              {
+                label: "View Order",
+                icon: <ShoppingBag />,
+                to: `/orders/${order.id}`,
+              },
+              ...(!isCanceled
+                ? [{
+                    label: isLabeling ? "Generating…" : "Generate Shipping Label",
+                    icon: <HandTruck />,
+                    onClick: handleGenerateLabel,
+                    disabled: isLabeling,
+                  }]
+                : []),
+            ],
           }]}
         />
       </div>
+      {labelUrl && (
+        <div className="px-6 py-3">
+          <Button variant="secondary" size="small" asChild>
+            <a href={labelUrl} target="_blank" rel="noreferrer">
+              <HandTruck className="w-4 h-4 mr-1" />
+              Open Shipping Label
+            </a>
+          </Button>
+        </div>
+      )}
       <div className="grid grid-cols-2 gap-4 px-6 py-4">
         <div>
           <Text size="xsmall" className="text-ui-fg-subtle mb-1">Status</Text>
@@ -415,7 +511,7 @@ const DesignOrderDetailPage = () => {
       <TwoColumnPage.Main>
         <DesignOrderHeaderSection designOrder={designOrder} />
         <LineItemSection designOrder={designOrder} />
-        <OrderSection designOrder={designOrder} />
+        <OrderSection designOrder={designOrder} lineItemId={id!} />
       </TwoColumnPage.Main>
       <TwoColumnPage.Sidebar>
         <CustomerSection designOrder={designOrder} />

--- a/apps/backend/src/api/admin/orders/[id]/shiprocket-label/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/shiprocket-label/route.ts
@@ -1,0 +1,80 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { createOrderFulfillmentWorkflow } from "@medusajs/medusa/core-flows"
+import { createShiprocketShipmentForFulfillment } from "../../../../../workflows/orders/shiprocket-shipment"
+
+/**
+ * POST /admin/orders/:id/shiprocket-label
+ *
+ * #404 (#31) PR-C convenience endpoint — one click from the Design Orders UI:
+ * create a fulfillment for the whole order (reusing an existing Shiprocket
+ * fulfillment if one's already there) and generate the Shiprocket shipment +
+ * label off it. Returns the AWB + label URL.
+ *
+ * Errors (incl. Shiprocket's ShiprocketApiError, a MedusaError #427) surface
+ * cleanly to the UI toast.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const orderId = req.params.id
+  const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: orders } = await query.graph({
+    entity: "order",
+    fields: [
+      "id",
+      "items.id",
+      "items.quantity",
+      "fulfillments.id",
+      "fulfillments.data",
+      "fulfillments.created_at",
+    ],
+    filters: { id: orderId },
+  })
+  const order = orders?.[0]
+  if (!order) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, `Order ${orderId} not found`)
+  }
+
+  // Reuse an existing Shiprocket fulfillment if present; else create one for
+  // the whole order.
+  let fulfillmentId: string | undefined = (order.fulfillments || []).find(
+    (f: any) => f.data?.carrier === "shiprocket"
+  )?.id
+
+  if (!fulfillmentId) {
+    const items = (order.items || []).map((i: any) => ({
+      id: i.id,
+      quantity: i.quantity,
+    }))
+    await createOrderFulfillmentWorkflow(req.scope).run({
+      input: { order_id: orderId, items },
+    })
+    // The workflow returns the order; resolve the newest fulfillment by re-query.
+    const { data: refetched } = await query.graph({
+      entity: "order",
+      fields: ["fulfillments.id", "fulfillments.created_at"],
+      filters: { id: orderId },
+    })
+    const fs = (refetched?.[0]?.fulfillments || []) as any[]
+    fulfillmentId = fs
+      .slice()
+      .sort(
+        (a, b) =>
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+      )[0]?.id
+  }
+
+  if (!fulfillmentId) {
+    throw new MedusaError(
+      MedusaError.Types.UNEXPECTED_STATE,
+      "Could not resolve a fulfillment to ship for this order"
+    )
+  }
+
+  const shipment = await createShiprocketShipmentForFulfillment(req.scope, {
+    orderId,
+    fulfillmentId,
+  })
+
+  res.status(200).json({ shiprocket_label: shipment })
+}


### PR DESCRIPTION
Final PR for #404 P1 (builds on PR-A #431 + PR-B #433). Completes the UX on the **Design Orders detail** page.

## What
- **Convert to Order** — when the design order has no backing order, the Order section shows **"Convert to Paid Order"** (primary) + **"Convert as COD"** (secondary). Confirm prompt → `useConvertDesignOrder({ payment_mode })` (PR-A) → `@medusajs/ui` toast. On success the query invalidates and the real order renders in place.
- **Generate Shipping Label** — once an order exists, an order-section action creates a fulfillment + Shiprocket shipment in one click and surfaces the label URL (opens in a new tab). New convenience endpoint `POST /admin/orders/:id/shiprocket-label` (reuses an existing Shiprocket fulfillment or creates one for the whole order, then calls PR-B's `createShiprocketShipmentForFulfillment`). New hook `useGenerateShiprocketLabel`.
- Errors (incl. `ShiprocketApiError`, a MedusaError #427) surface via toast — no opaque failures.

## Verification
- `tsc --noEmit` → 70 (baseline), 0 new.
- Convert backend integration-tested (PR-A, green); `createShipment` client unit-tested (PR-B, green); UI is type-checked.
- ⚠️ Local Playwright wasn't available this session, so the rendered Convert/Label actions weren't browser-driven — **please eyeball on the deploy**. Live label needs prod Shiprocket creds + a verified pickup (#427).

## #404 P1 complete (order-only)
Design order → **Convert** (paid/COD) → **Generate label** (fulfillment + Shiprocket AWB/label), all from the Design Orders detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)