### PR TITLE
fix(shipping): #435 — Shiprocket pickup "shippable" (address-based, not phone OTP)

### DIFF
--- a/apps/backend/integration-tests/http/shiprocket-pickup-registration.spec.ts
+++ b/apps/backend/integration-tests/http/shiprocket-pickup-registration.spec.ts
@@ -19,6 +19,8 @@ jest.setTimeout(90 * 1000)
 type MockPickup = {
   pickup_location: string
   phone_verified: number
+  address?: string
+  phone?: string
   city?: string
   state?: string
   pin_code?: string
@@ -65,6 +67,8 @@ function installShiprocketMock(state: MockState) {
         state.pickups.push({
           pickup_location: body.pickup_location,
           phone_verified: 0,
+          address: body.address,
+          phone: body.phone,
           city: body.city,
           state: body.state,
           pin_code: body.pin_code,
@@ -208,6 +212,24 @@ setupSharedTestSuite(() => {
         adminHeaders
       )
       expect(res.data.pickup.phone_verified).toBe(true)
+      expect(res.data.pickup.shippable).toBe(true)
+    })
+
+    it("GET marks an API pickup with a complete address shippable before phone OTP (#435)", async () => {
+      const locationId = await createLocation()
+      await api.post(
+        `/admin/stock-locations/${locationId}/shiprocket-pickup`,
+        {},
+        adminHeaders
+      )
+      // Phone OTP is NOT done (mock leaves phone_verified=0), but the pickup
+      // carries a full address — it's usable for live pickups.
+      const res = await api.get(
+        `/admin/stock-locations/${locationId}/shiprocket-pickup`,
+        adminHeaders
+      )
+      expect(res.data.pickup.phone_verified).toBe(false)
+      expect(res.data.pickup.shippable).toBe(true)
     })
 
     it("POST 400s when the location is missing a phone or postal code", async () => {

--- a/apps/backend/src/admin/widgets/stock-location-shiprocket-pickup.tsx
+++ b/apps/backend/src/admin/widgets/stock-location-shiprocket-pickup.tsx
@@ -21,6 +21,7 @@ type StockLocation = { id: string; name?: string }
 type PickupStatus = {
   name: string
   already_existed: boolean
+  shippable?: boolean
   phone_verified?: boolean
 } | null
 
@@ -98,23 +99,44 @@ const ShiprocketPickupWidget = ({ data }: DetailWidgetProps<StockLocation>) => {
               {(error as any)?.message || "Couldn't load Shiprocket pickup status"}
             </Text>
           ) : status ? (
-            <div className="flex items-center gap-x-3">
-              <Text size="small" leading="compact" weight="plus">
-                {status.name}
-              </Text>
-              {status.phone_verified === true ? (
-                <Badge size="2xsmall" color="green">
-                  Phone verified
-                </Badge>
-              ) : status.phone_verified === false ? (
-                <Badge size="2xsmall" color="orange">
-                  Phone not verified
-                </Badge>
-              ) : (
-                <Badge size="2xsmall" color="grey">
-                  Verification unknown
-                </Badge>
-              )}
+            <div className="flex flex-col gap-y-1">
+              <div className="flex items-center gap-x-3">
+                <Text size="small" leading="compact" weight="plus">
+                  {status.name}
+                </Text>
+                {status.shippable === true ? (
+                  <Badge size="2xsmall" color="green">
+                    Ready to ship
+                  </Badge>
+                ) : status.shippable === false ? (
+                  <Badge size="2xsmall" color="orange">
+                    Address incomplete
+                  </Badge>
+                ) : (
+                  <Badge size="2xsmall" color="grey">
+                    Registered
+                  </Badge>
+                )}
+              </div>
+              {status.shippable === true && status.phone_verified === false ? (
+                <Text
+                  size="xsmall"
+                  leading="compact"
+                  className="text-ui-fg-subtle"
+                >
+                  Phone OTP not completed — not required for API-registered
+                  pickups.
+                </Text>
+              ) : status.shippable === false ? (
+                <Text
+                  size="xsmall"
+                  leading="compact"
+                  className="text-ui-fg-subtle"
+                >
+                  Add a full address (street, city, pincode, phone) in Shiprocket
+                  to enable live pickups.
+                </Text>
+              ) : null}
             </div>
           ) : (
             <Text size="small" leading="compact" className="text-ui-fg-subtle">

--- a/apps/backend/src/modules/shipping-providers/pickup-locations.ts
+++ b/apps/backend/src/modules/shipping-providers/pickup-locations.ts
@@ -39,7 +39,9 @@ export type PickupRegistrationResult = {
   name: string
   /** True when the nickname already existed in Shiprocket (no add performed). */
   already_existed: boolean
-  /** Phone-verification status from the carrier list, when known. */
+  /** Whether the pickup is usable for live pickups (source of truth for UI). */
+  shippable?: boolean
+  /** Phone-OTP status from the carrier list, when known (informational only). */
   phone_verified?: boolean
   /** The matched/created carrier-side pickup record, when available. */
   location?: PickupLocation
@@ -122,6 +124,10 @@ export async function registerShiprocketPickup(
   }
 
   let alreadyExisted = Boolean(existing)
+  // A freshly-added pickup isn't in the list we just fetched; derive whether it
+  // ships from the address we register it with (#435 — a complete address makes
+  // an API pickup shippable without the phone-OTP step).
+  let addedShippable: boolean | undefined
   if (!existing) {
     const addr = loc.address || {}
     if (!addr.phone || !addr.postal_code) {
@@ -130,6 +136,9 @@ export async function registerShiprocketPickup(
         `Stock location ${locationId} is missing a phone or postal code required to register a Shiprocket pickup`
       )
     }
+    addedShippable =
+      Boolean(addr.address_1 && addr.city && addr.postal_code && addr.phone) ||
+      undefined
     try {
       await provider.registerPickupLocation({
         // Pass the acting user's email when known; the client falls back to the
@@ -160,6 +169,7 @@ export async function registerShiprocketPickup(
   return {
     name: nickname,
     already_existed: alreadyExisted,
+    shippable: existing ? existing.shippable : addedShippable,
     phone_verified: existing?.phone_verified,
     location: existing,
   }
@@ -207,6 +217,7 @@ export async function getShiprocketPickupStatus(
   return {
     name: nickname,
     already_existed: Boolean(existing),
+    shippable: existing?.shippable,
     phone_verified: existing?.phone_verified,
     location: existing,
   }

--- a/apps/backend/src/modules/shipping-providers/provider-interface.ts
+++ b/apps/backend/src/modules/shipping-providers/provider-interface.ts
@@ -172,17 +172,23 @@ export type RegisterPickupLocationInput = {
 
 /**
  * A registered pickup location as the carrier reports it. The nickname is what
- * `createShipment`/`registerPickupLocation` reference; `phone_verified` matters
- * because "registered" ≠ "shippable" for Shiprocket (phone must be OTP-verified
- * before live pickups). See SHIPPING_PROVIDERS.md §9.
+ * `createShipment`/`registerPickupLocation` reference. Callers lead with
+ * `shippable` (can this pickup be used for live pickups?) — for Shiprocket an
+ * API-registered pickup is shippable once its address is complete; phone-OTP is
+ * a separate dashboard step that isn't required (#435). `phone_verified` stays
+ * as a secondary, informational signal. See SHIPPING_PROVIDERS.md §9.
  */
 export type PickupLocation = {
   /** The unique nickname callers reference (Shiprocket `pickup_location`). */
   name: string
   /** Carrier-side id, when exposed. */
   id?: string | number
-  /** True when the pickup address phone is OTP-verified (usable for live pickups). */
+  /** True when the carrier reports the pickup phone as OTP-verified (informational). */
   phone_verified?: boolean
+  /** True when the carrier row has a complete address (address, city, pincode, phone). */
+  address_complete?: boolean
+  /** True when the pickup is usable for live pickups (the source of truth for UI). */
+  shippable?: boolean
   city?: string
   state?: string
   pincode?: string

--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/list-pickup-locations.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/list-pickup-locations.unit.spec.ts
@@ -1,0 +1,125 @@
+import { ShiprocketClient, normalizePickupLocation } from "../client"
+
+/**
+ * #435 — `normalizePickupLocation` decides whether a Shiprocket pickup is
+ * *shippable*, not just whether its phone OTP is done. Per the carrier (and a
+ * live `/settings/company/pickup` capture), an API-registered pickup with a
+ * complete address is usable for live pickups even when `phone_verified` is 0,
+ * so the admin must stop showing those as "not verified" / "unknown".
+ */
+describe("normalizePickupLocation (#435)", () => {
+  // Shape mirrors a real `data.shipping_address[]` row.
+  const fullAddress = {
+    id: 76349863,
+    pickup_location: "warehouse-AYV7GRDR",
+    address: "Ram Nagar Road, Ward 11",
+    city: "Dharamshala",
+    state: "Himachal Pradesh",
+    pin_code: "176215",
+    phone: "9767901992",
+    status: 1,
+  }
+
+  it("marks a phone-verified pickup with a full address as shippable", () => {
+    const p = normalizePickupLocation({ ...fullAddress, phone_verified: 1 })
+    expect(p.phone_verified).toBe(true)
+    expect(p.address_complete).toBe(true)
+    expect(p.shippable).toBe(true)
+  })
+
+  it("marks an API pickup with a full address shippable even before phone OTP", () => {
+    const p = normalizePickupLocation({ ...fullAddress, phone_verified: 0 })
+    expect(p.phone_verified).toBe(false)
+    expect(p.address_complete).toBe(true)
+    expect(p.shippable).toBe(true) // the core #435 fix
+  })
+
+  it("treats a missing phone_verified field as undefined, still shippable on a full address", () => {
+    const { ...noFlag } = fullAddress
+    const p = normalizePickupLocation(noFlag)
+    expect(p.phone_verified).toBeUndefined()
+    expect(p.shippable).toBe(true)
+  })
+
+  it("is not shippable when the address is incomplete", () => {
+    const p = normalizePickupLocation({
+      pickup_location: "warehouse-x",
+      city: "Jaipur",
+      state: "RJ",
+      pin_code: "302001",
+      phone_verified: 0,
+      // no `address`, no `phone`
+    })
+    expect(p.address_complete).toBe(false)
+    expect(p.shippable).toBe(false)
+  })
+
+  it("a deactivated pickup (status 0) is not shippable even with a full address", () => {
+    const p = normalizePickupLocation({
+      ...fullAddress,
+      phone_verified: 1,
+      status: 0,
+    })
+    expect(p.shippable).toBe(false)
+  })
+
+  it("maps nickname, id and address fields", () => {
+    const p = normalizePickupLocation({ ...fullAddress, phone_verified: 1 })
+    expect(p.name).toBe("warehouse-AYV7GRDR")
+    expect(p.id).toBe(76349863)
+    expect(p.city).toBe("Dharamshala")
+    expect(p.pincode).toBe("176215")
+    expect(p.raw).toMatchObject({ pickup_location: "warehouse-AYV7GRDR" })
+  })
+})
+
+describe("ShiprocketClient.listPickupLocations (#435)", () => {
+  let fetchSpy: jest.SpyInstance
+  afterEach(() => fetchSpy?.mockRestore())
+
+  it("normalizes data.shipping_address[] rows through normalizePickupLocation", async () => {
+    const real = global.fetch?.bind(globalThis)
+    fetchSpy = jest
+      .spyOn(global, "fetch" as any)
+      .mockImplementation(async (input: any, init: any = {}) => {
+        const url = String(input)
+        const make = (body: any, status = 200) =>
+          ({
+            ok: status >= 200 && status < 300,
+            status,
+            json: async () => body,
+            text: async () => JSON.stringify(body),
+          }) as any
+        if (!url.includes("shiprocket.in")) return real?.(input, init)
+        if (url.includes("/settings/company/pickup"))
+          return make({
+            data: {
+              shipping_address: [
+                {
+                  pickup_location: "warehouse-ready",
+                  address: "1 Mill Road",
+                  city: "Jaipur",
+                  pin_code: "302001",
+                  phone: "9999999999",
+                  phone_verified: 0,
+                  status: 1,
+                },
+              ],
+            },
+          })
+        return make({}, 404)
+      })
+
+    const client = new ShiprocketClient({
+      email: "x@y.com",
+      password: "p",
+      token: "injected-token",
+    })
+
+    const list = await client.listPickupLocations()
+    expect(list).toHaveLength(1)
+    expect(list[0].name).toBe("warehouse-ready")
+    expect(list[0].phone_verified).toBe(false)
+    expect(list[0].shippable).toBe(true)
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
@@ -118,6 +118,46 @@ export function parseShiprocketError(raw: string): {
   return { message: msg }
 }
 
+/**
+ * Normalize a Shiprocket `data.shipping_address[]` row into our PickupLocation.
+ *
+ * Shiprocket exposes `phone_verified` (0/1) — its OTP signal — but per the
+ * carrier's behavior an **API-registered pickup is usable for live pickups as
+ * soon as it has a complete address**; the phone-OTP step is a separate,
+ * dashboard-only action that isn't required to ship (#435, confirmed against a
+ * live `/settings/company/pickup` response). So we derive `shippable` from a
+ * complete address OR an explicit `phone_verified`, gated by the carrier
+ * `status` (an explicit 0 = deactivated overrides). Callers lead with
+ * `shippable`; `phone_verified` stays available as a secondary, informational
+ * signal so we never show a usable pickup as "not verified" / "unknown".
+ */
+export function normalizePickupLocation(r: any): PickupLocation {
+  const phoneVerified =
+    r?.phone_verified !== undefined && r?.phone_verified !== null
+      ? Boolean(Number(r.phone_verified))
+      : undefined
+  const addressComplete = Boolean(
+    r?.address && r?.city && r?.pin_code && r?.phone
+  )
+  // We only have positive samples (status=1); stay conservative — treat an
+  // explicit 0 as deactivated and everything else (incl. absent) as active, so
+  // this never flips an otherwise-shippable pickup off on an unknown code.
+  const active =
+    r?.status === undefined || r?.status === null || Number(r.status) !== 0
+  const shippable = active && (phoneVerified === true || addressComplete)
+  return {
+    name: r?.pickup_location || r?.name || "",
+    id: r?.id,
+    phone_verified: phoneVerified,
+    address_complete: addressComplete,
+    shippable,
+    city: r?.city,
+    state: r?.state,
+    pincode: r?.pin_code,
+    raw: r,
+  }
+}
+
 /** Shiprocket numeric shipment_status_id → coarse scan_type. */
 function scanTypeForStatus(id?: number): string {
   switch (id) {
@@ -431,28 +471,15 @@ export class ShiprocketClient implements ShippingProviderClient {
 
   /**
    * List registered pickup locations (`data.shipping_address[]`). Used for
-   * idempotent registration and to surface phone-verification status — a
-   * Shiprocket pickup point isn't usable for live pickups until its phone is
-   * OTP-verified, so "registered" ≠ "shippable".
+   * idempotent registration and to surface whether a pickup is shippable — see
+   * `normalizePickupLocation` for how that's derived.
    */
   async listPickupLocations(): Promise<PickupLocation[]> {
     const json = await this.request<any>(`/settings/company/pickup`, {
       method: "GET",
     })
     const rows = json?.data?.shipping_address || []
-    return rows.map((r: any) => ({
-      name: r.pickup_location || r.name || "",
-      id: r.id,
-      // Shiprocket returns 0/1; treat truthy non-zero as verified.
-      phone_verified:
-        r.phone_verified !== undefined
-          ? Boolean(Number(r.phone_verified))
-          : undefined,
-      city: r.city,
-      state: r.state,
-      pincode: r.pin_code,
-      raw: r,
-    }))
+    return rows.map((r: any) => normalizePickupLocation(r))
   }
 
   /** Normalize the Shiprocket webhook push payload (P2). */

--- a/apps/docs/notes/SHIPPING_PROVIDERS.md
+++ b/apps/docs/notes/SHIPPING_PROVIDERS.md
@@ -245,3 +245,28 @@ carriers.
   creds + a `category: shipping` Shiprocket platform record. The
   `data.shipping_address[]` field names (esp. `phone_verified`) should be
   confirmed against a live response.
+
+### 9.6 Pickup "shippable" semantics (2026-06-17, #435)
+
+Confirmed against a live `GET /settings/company/pickup` response (prod
+`warehouse-AYV7GRDR`): rows carry `phone_verified` (0/1), `status` (1 seen),
+and a full address (`address`, `city`, `pin_code`, `phone`). The field names in
+§9.5 are correct — `phone_verified` reads fine.
+
+The real issue was **semantic**: an API-registered pickup is usable for live
+pickups as soon as it has a complete address; the phone-OTP step is a separate,
+dashboard-only action that isn't required to ship. Showing "Phone not verified"
+/ "Verification unknown" for a usable pickup was misleading.
+
+- `normalizePickupLocation(r)` (exported from `shiprocket/client.ts`) now derives
+  `shippable = active && (phone_verified === true || address_complete)`, where
+  `address_complete` = `address && city && pin_code && phone` and `active` =
+  `status !== 0`. `PickupLocation` gained `shippable` + `address_complete`;
+  `PickupRegistrationResult` and the admin GET/POST thread `shippable` through.
+- The admin widget leads with **Ready to ship** (green) / **Address incomplete**
+  (orange) / **Registered** (grey, only when shippability is unknown), and notes
+  "Phone OTP not completed — not required for API-registered pickups" when a
+  shippable pickup hasn't done OTP.
+- Tests: `shiprocket/__tests__/list-pickup-locations.unit.spec.ts` (normalizer +
+  client) and an added integration case (API pickup with full address is
+  shippable before phone OTP).


### PR DESCRIPTION
Closes #435.

## Problem
The stock-location **Shiprocket Pickup** widget showed *"Phone not verified"* / *"Verification unknown"* for pickups that are actually usable — operator reported a pickup that's verified/shippable at Shiprocket reading as "unknown" in admin.

## Root cause (empirically confirmed)
Captured a live `GET /settings/company/pickup` response from prod (`warehouse-AYV7GRDR`): the field names in our code are correct (`phone_verified` 0/1, `status`, full address). The bug is **semantic** — an API-registered pickup is usable for live pickups as soon as it has a complete address; phone-OTP is a separate dashboard step that isn't required to ship. Leading the UI with `phone_verified` mislabels usable pickups.

## Change
- `normalizePickupLocation()` (exported from `shiprocket/client.ts`) derives `shippable = active && (phone_verified === true || address_complete)`, where `address_complete = address && city && pin_code && phone` and `active = status !== 0`.
- `PickupLocation` gains `shippable` + `address_complete`; `PickupRegistrationResult` and the admin GET/POST thread `shippable` through.
- Widget leads with **Ready to ship** (green) / **Address incomplete** (orange) / **Registered** (grey), and notes "Phone OTP not completed — not required for API-registered pickups" when applicable.

## Tests
- `shiprocket/__tests__/list-pickup-locations.unit.spec.ts` — normalizer + client (6+1 cases). ✅
- `integration-tests/http/shiprocket-pickup-registration.spec.ts` — added a case proving an API pickup with a complete address is `shippable` before phone OTP. All 6 green. ✅
- `tsc --noEmit`: no new errors in touched files (pre-existing baseline unchanged).

Doc: `SHIPPING_PROVIDERS.md` §9.6. Refs #404 (P1 depends on a shippable pickup), #352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)