### PR TITLE
infra(shipping): #436 — register Shiprocket fulfillment provider in prod

### DIFF
--- a/deploy/aws/copilot/medusa-server/manifest.yml
+++ b/deploy/aws/copilot/medusa-server/manifest.yml
@@ -112,6 +112,13 @@ secrets:
   S3_REGION: /jyt/prod/S3_REGION
   S3_SECRET_ACCESS_KEY: /jyt/prod/S3_SECRET_ACCESS_KEY
   SENTRY_DSN: /jyt/prod/SENTRY_DSN
+  # Shiprocket fulfillment provider (#436). The env-gated block in
+  # medusa-config.prod.ts registers the provider whenever SHIPROCKET_EMAIL is
+  # set — that alone surfaces it in Fulfillment Providers. The actual Shiprocket
+  # API calls (label/pickup/track) go through resolveShippingProvider, which
+  # reads creds from the `category:shipping` SocialPlatform record, so the
+  # password/pickup are intentionally NOT wired as env here.
+  SHIPROCKET_EMAIL: /jyt/prod/SHIPROCKET_EMAIL
   STOREFRONT_REVALIDATE_SECRET: /jyt/prod/STOREFRONT_REVALIDATE_SECRET
   STORE_CORS: /jyt/prod/STORE_CORS
   STRIPE_API_KEY: /jyt/prod/STRIPE_API_KEY

--- a/deploy/aws/copilot/medusa-worker/manifest.yml
+++ b/deploy/aws/copilot/medusa-worker/manifest.yml
@@ -69,6 +69,10 @@ secrets:
   S3_REGION: /jyt/prod/S3_REGION
   S3_SECRET_ACCESS_KEY: /jyt/prod/S3_SECRET_ACCESS_KEY
   SENTRY_DSN: /jyt/prod/SENTRY_DSN
+  # Shiprocket fulfillment provider (#436) — parity with the server so the
+  # env-gated provider block in medusa-config.prod.ts loads in the worker too.
+  # Email-only: the API path reads creds from the SocialPlatform record.
+  SHIPROCKET_EMAIL: /jyt/prod/SHIPROCKET_EMAIL
   STRIPE_API_KEY: /jyt/prod/STRIPE_API_KEY
   STRIPE_WEBHOOK_SECRET: /jyt/prod/STRIPE_WEBHOOK_SECRET
   VERCEL_STOREFRONT_REPO: /jyt/prod/VERCEL_STOREFRONT_REPO


### PR DESCRIPTION
Closes #436.

## Problem
Admin **Fulfillment Providers** lists only **Delhivery** + **Manual** — Shiprocket is missing. The provider is env-gated in `medusa-config.prod.ts:296` (registers only when `SHIPROCKET_EMAIL` is set), and that env var wasn't wired in prod.

## Change
- Wire `SHIPROCKET_EMAIL` into both `medusa-server` and `medusa-worker` copilot manifests (`secrets:`).
- SSM param **already created**: `/jyt/prod/SHIPROCKET_EMAIL` (SecureString, tagged `copilot-application=jyt` / `copilot-environment=prod`) = `shipping@jaalyantra.com` — verified, so the deploy resolves cleanly (avoids the AccessDenied-on-missing-tag trap).

## Why email-only (not password/pickup)
The env-gated block only needs `SHIPROCKET_EMAIL` present to register + surface the provider. The actual Shiprocket API calls (label / pickup / track) go through `resolveShippingProvider`, which reads credentials from the `category:shipping` **SocialPlatform** record (password stored encrypted there). Wiring the password as a second env var would duplicate the secret and split the source of truth — so it's intentionally omitted.

## Verify after deploy (~18 min)
Admin → Settings → Fulfillment Providers shows **Shiprocket** alongside Delhivery + Manual, so a shipping option can be backed by Shiprocket. (Unblocks the live-label tail in #437.)

Refs #404, #417, #352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)