### PR TITLE
feat(orders): #437 — attach existing Shiprocket AWB + fix title-only fulfillment

### DIFF
--- a/apps/backend/integration-tests/http/shiprocket-attach-awb.spec.ts
+++ b/apps/backend/integration-tests/http/shiprocket-attach-awb.spec.ts
@@ -1,0 +1,201 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { IRegionModuleService } from "@medusajs/types"
+
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import {
+  createTestCustomer,
+  getCustomerAuthHeaders,
+  getTestCustomerCredentials,
+} from "../helpers/create-customer"
+import { setupCheckoutInfrastructure } from "../helpers/setup-checkout-infrastructure"
+import { DESIGN_MODULE } from "../../src/modules/designs"
+import { ensureOrderFulfillment } from "../../src/workflows/orders/fulfillment-context"
+
+jest.setTimeout(120 * 1000)
+
+/**
+ * #437 — fulfillment plumbing for the Shiprocket label / attach-AWB routes.
+ *
+ * The core verification: a CONVERTED design order (title-only line items, NO
+ * shipping method) can have a fulfillment created for it. Before the shared
+ * `ensureOrderFulfillment` fix this 500'd in core's createOrderFulfillmentWorkflow
+ * (null shipping option → null location). Shiprocket itself isn't registered in
+ * the test env, so this asserts the fulfillment-creation half end-to-end.
+ */
+setupSharedTestSuite(() => {
+  describe("ensureOrderFulfillment for converted design orders (#437)", () => {
+    let adminHeaders: { headers: Record<string, string> }
+    let customerHeaders: { headers: Record<string, string> }
+    let designId: string
+    let regionId: string
+
+    const { api, getContainer } = getSharedTestEnv()
+
+    const buildDesignOrder = async (): Promise<string> => {
+      const cartRes = await api.post(
+        "/store/carts",
+        { region_id: regionId },
+        customerHeaders
+      )
+      const cartId = cartRes.data.cart.id
+
+      const checkoutRes = await api.post(
+        `/store/custom/designs/${designId}/checkout`,
+        { cart_id: cartId, currency_code: "usd" },
+        customerHeaders
+      )
+      expect(checkoutRes.status).toBe(200)
+      const lineItemId = checkoutRes.data.line_item_id
+
+      const credentials = getTestCustomerCredentials()
+      await api.post(
+        `/store/carts/${cartId}`,
+        {
+          email: credentials.email,
+          shipping_address: {
+            first_name: "Test",
+            last_name: "Customer",
+            address_1: "123 Main St",
+            city: "New York",
+            postal_code: "10001",
+            country_code: "us",
+          },
+        },
+        customerHeaders
+      )
+      return lineItemId
+    }
+
+    beforeAll(async () => {
+      const container = getContainer()
+
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+
+      const regionsRes = await api.get("/admin/regions", adminHeaders)
+      if (regionsRes.data.regions?.length > 0) {
+        regionId = regionsRes.data.regions[0].id
+      } else {
+        const regionService = container.resolve(
+          Modules.REGION
+        ) as IRegionModuleService
+        const region = await regionService.createRegions({
+          name: "Attach AWB Region",
+          currency_code: "usd",
+          countries: ["us"],
+        })
+        regionId = region.id
+      }
+
+      const designRes = await api.post(
+        "/admin/designs",
+        {
+          name: `Attach AWB Design ${Date.now()}`,
+          description: "attach-awb fulfillment test",
+          design_type: "Original",
+          status: "Commerce_Ready",
+          priority: "Medium",
+          estimated_cost: 250,
+        },
+        adminHeaders
+      )
+      designId = designRes.data.design.id
+      await setupCheckoutInfrastructure(container, regionId)
+
+      const { customer } = await createTestCustomer(container)
+      customerHeaders = await getCustomerAuthHeaders()
+      const remoteLink = container.resolve(
+        ContainerRegistrationKeys.LINK
+      ) as any
+      await remoteLink
+        .create({
+          [DESIGN_MODULE]: { design_id: designId },
+          [Modules.CUSTOMER]: { customer_id: customer.id },
+        })
+        .catch(() => {})
+    })
+
+    it("creates a fulfillment for a converted (title-only) order, and is idempotent", async () => {
+      const container = getContainer()
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+      // Convert a design order → real order with title-only line items.
+      const lineItemId = await buildDesignOrder()
+      const convertRes = await api.post(
+        `/admin/designs/orders/${lineItemId}/convert`,
+        { payment_mode: "prepaid" },
+        adminHeaders
+      )
+      expect(convertRes.status).toBe(200)
+      const orderId = convertRes.data.design_order_conversion.order_id
+      expect(orderId).toEqual(expect.any(String))
+
+      // The order starts with no fulfillment.
+      const { data: before } = await query.graph({
+        entity: "order",
+        fields: ["id", "fulfillments.id"],
+        filters: { id: orderId },
+      })
+      expect((before?.[0]?.fulfillments || []).length).toBe(0)
+
+      // This used to 500 (no shipping method → null shipping option/location).
+      const fulfillmentId = await ensureOrderFulfillment(container, orderId)
+      expect(fulfillmentId).toEqual(expect.any(String))
+
+      const { data: after } = await query.graph({
+        entity: "order",
+        fields: ["id", "fulfillments.id", "fulfillments.items.quantity"],
+        filters: { id: orderId },
+      })
+      const fulfillments = after?.[0]?.fulfillments || []
+      expect(fulfillments.length).toBe(1)
+      expect(fulfillments[0].id).toBe(fulfillmentId)
+      // The title-only line item is on the fulfillment.
+      expect((fulfillments[0].items || []).length).toBeGreaterThan(0)
+
+      // Idempotent: a second call reuses the same fulfillment (no duplicate).
+      const again = await ensureOrderFulfillment(container, orderId)
+      expect(again).toBe(fulfillmentId)
+      const { data: afterAgain } = await query.graph({
+        entity: "order",
+        fields: ["id", "fulfillments.id"],
+        filters: { id: orderId },
+      })
+      expect((afterAgain?.[0]?.fulfillments || []).length).toBe(1)
+
+      // ── attach route over HTTP: clean error, not an opaque 500 ──────────
+      // Shiprocket isn't configured in the test env, so the AWB lookup can't
+      // resolve. The route must still surface a structured MedusaError (with a
+      // message the UI toast can show), having run ensureOrderFulfillment first.
+      const lineItemId2 = await buildDesignOrder()
+      const convert2 = await api.post(
+        `/admin/designs/orders/${lineItemId2}/convert`,
+        { payment_mode: "prepaid" },
+        adminHeaders
+      )
+      const orderId2 = convert2.data.design_order_conversion.order_id
+      const attachErr = await api
+        .post(
+          `/admin/orders/${orderId2}/shiprocket-attach-awb`,
+          { awb: "FAKEAWB123" },
+          adminHeaders
+        )
+        .catch((e: any) => e.response)
+      expect(attachErr).toBeDefined()
+      // structured error body with a real message — never an empty/opaque crash
+      expect(typeof attachErr.data?.message).toBe("string")
+      expect(attachErr.data.message.length).toBeGreaterThan(0)
+
+      // Empty AWB is rejected by validation (clean 400).
+      const blankErr = await api
+        .post(
+          `/admin/orders/${orderId2}/shiprocket-attach-awb`,
+          { awb: "" },
+          adminHeaders
+        )
+        .catch((e: any) => e.response)
+      expect(blankErr.status).toBe(400)
+    })
+  })
+})

--- a/apps/backend/src/admin/hooks/api/design-orders.ts
+++ b/apps/backend/src/admin/hooks/api/design-orders.ts
@@ -293,3 +293,38 @@ export const useGenerateShiprocketLabel = (
     ...options,
   });
 };
+
+export type AttachShiprocketAwbResponse = {
+  shiprocket_awb: {
+    awb: string;
+    current_status?: string;
+    synced_state: "delivered" | "shipped" | "pending";
+    fulfillment_id: string;
+  };
+};
+
+/**
+ * Attach an EXISTING Shiprocket AWB (already shipped/delivered outside this
+ * system) to a converted order. Read-only against Shiprocket — looks the AWB up,
+ * stamps it onto the fulfillment, and auto-syncs the fulfillment status. #437.
+ */
+export const useAttachShiprocketAwb = (
+  orderId: string,
+  options?: UseMutationOptions<AttachShiprocketAwbResponse, FetchError, string>
+) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (awb: string) =>
+      sdk.client.fetch<AttachShiprocketAwbResponse>(
+        `/admin/orders/${orderId}/shiprocket-attach-awb`,
+        { method: "POST", body: { awb } }
+      ),
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({
+        queryKey: designOrdersQueryKeys.lists(),
+      });
+      options?.onSuccess?.(...args);
+    },
+    ...options,
+  });
+};

--- a/apps/backend/src/admin/routes/design-orders/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/design-orders/[id]/page.tsx
@@ -7,6 +7,7 @@ import {
   Badge,
   StatusBadge,
   Button,
+  Input,
   toast,
   usePrompt,
   Skeleton,
@@ -19,6 +20,7 @@ import {
   ShoppingBag,
   CurrencyDollar,
   HandTruck,
+  Link as LinkIcon,
 } from "@medusajs/icons"
 import { ActionMenu } from "../../../components/common/action-menu"
 import { TwoColumnPage } from "../../../components/pages/two-column-pages"
@@ -29,6 +31,7 @@ import {
   useCancelDesignOrder,
   useConvertDesignOrder,
   useGenerateShiprocketLabel,
+  useAttachShiprocketAwb,
 } from "../../../hooks/api/design-orders"
 import {
   PARTNER_STATUS_LABELS,
@@ -87,7 +90,9 @@ const DesignOrderHeaderSection = ({ designOrder }: { designOrder: any }) => {
 
   const isApproved = designOrder.design.status === "Approved"
   const hasOrder = !!designOrder.order
-  const isCanceled = !!designOrder.order?.canceled_at
+  const isCanceled =
+    !!designOrder.order?.canceled_at ||
+    designOrder.order?.status === "canceled"
 
   const handleApprove = async () => {
     const confirmed = await prompt({
@@ -266,7 +271,11 @@ const OrderSection = ({
     useConvertDesignOrder(lineItemId)
   const { mutateAsync: genLabel, isPending: isLabeling } =
     useGenerateShiprocketLabel(order?.id ?? "")
+  const { mutateAsync: attachAwb, isPending: isAttaching } =
+    useAttachShiprocketAwb(order?.id ?? "")
   const [labelUrl, setLabelUrl] = useState<string | null>(null)
+  const [attachOpen, setAttachOpen] = useState(false)
+  const [awbValue, setAwbValue] = useState("")
 
   const handleConvert = async (paymentMode: "prepaid" | "cod") => {
     const confirmed = await prompt({
@@ -327,7 +336,7 @@ const OrderSection = ({
     )
   }
 
-  const isCanceled = !!order.canceled_at
+  const isCanceled = !!order.canceled_at || order.status === "canceled"
 
   const handleGenerateLabel = async () => {
     await genLabel(undefined, {
@@ -338,6 +347,24 @@ const OrderSection = ({
             ? `Label generated (AWB ${res.shiprocket_label.awb})`
             : "Shipment created"
         )
+      },
+      onError: (e) => toast.error(e.message),
+    })
+  }
+
+  const handleAttachAwb = async () => {
+    const awb = awbValue.trim()
+    if (!awb) return
+    await attachAwb(awb, {
+      onSuccess: (res) => {
+        const state = res.shiprocket_awb?.synced_state
+        toast.success(
+          `AWB ${res.shiprocket_awb?.awb} attached${
+            state && state !== "pending" ? ` (${state})` : ""
+          }`
+        )
+        setAttachOpen(false)
+        setAwbValue("")
       },
       onError: (e) => toast.error(e.message),
     })
@@ -356,17 +383,62 @@ const OrderSection = ({
                 to: `/orders/${order.id}`,
               },
               ...(!isCanceled
-                ? [{
-                    label: isLabeling ? "Generating…" : "Generate Shipping Label",
-                    icon: <HandTruck />,
-                    onClick: handleGenerateLabel,
-                    disabled: isLabeling,
-                  }]
+                ? [
+                    {
+                      label: isLabeling ? "Generating…" : "Generate Shipping Label",
+                      icon: <HandTruck />,
+                      onClick: handleGenerateLabel,
+                      disabled: isLabeling,
+                    },
+                    {
+                      label: "Attach existing AWB",
+                      icon: <LinkIcon />,
+                      onClick: () => setAttachOpen(true),
+                      disabled: isAttaching,
+                    },
+                  ]
                 : []),
             ],
           }]}
         />
       </div>
+      {attachOpen && (
+        <div className="px-6 py-4 bg-ui-bg-subtle">
+          <Text size="xsmall" className="text-ui-fg-subtle mb-2">
+            Link an AWB already shipped via Shiprocket. Its status is fetched and
+            the order is synced to match — no new shipment is created.
+          </Text>
+          <div className="flex items-center gap-x-2">
+            <Input
+              placeholder="Shiprocket AWB"
+              value={awbValue}
+              onChange={(e) => setAwbValue(e.target.value)}
+              disabled={isAttaching}
+              autoFocus
+            />
+            <Button
+              variant="primary"
+              size="small"
+              isLoading={isAttaching}
+              disabled={!awbValue.trim()}
+              onClick={handleAttachAwb}
+            >
+              Attach
+            </Button>
+            <Button
+              variant="secondary"
+              size="small"
+              disabled={isAttaching}
+              onClick={() => {
+                setAttachOpen(false)
+                setAwbValue("")
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
       {labelUrl && (
         <div className="px-6 py-3">
           <Button variant="secondary" size="small" asChild>

--- a/apps/backend/src/api/admin/orders/[id]/shiprocket-attach-awb/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/shiprocket-attach-awb/route.ts
@@ -1,0 +1,32 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import { ensureOrderFulfillment } from "../../../../../workflows/orders/fulfillment-context"
+import { attachExistingShiprocketAwb } from "../../../../../workflows/orders/shiprocket-attach-awb"
+
+/**
+ * POST /admin/orders/:id/shiprocket-attach-awb
+ *
+ * #437 — attach an EXISTING Shiprocket AWB to a (converted) order. For parcels
+ * already shipped/delivered outside this system. Reuses or creates a plain
+ * (manual) fulfillment for the order, looks the AWB up on Shiprocket (read-only
+ * — no new shipment is created), stamps the carrier refs onto fulfillment.data,
+ * and auto-syncs the fulfillment status to the AWB's real Shiprocket state.
+ *
+ * A bad/foreign AWB or Shiprocket error surfaces as a clean MedusaError, not a
+ * 500.
+ */
+const Body = z.object({ awb: z.string().trim().min(1, "An AWB is required") })
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const orderId = req.params.id
+  const { awb } = Body.parse((req.body as Record<string, unknown>) ?? {})
+
+  const fulfillmentId = await ensureOrderFulfillment(req.scope, orderId)
+  const result = await attachExistingShiprocketAwb(req.scope, {
+    orderId,
+    fulfillmentId,
+    awb,
+  })
+
+  res.status(200).json({ shiprocket_awb: result })
+}

--- a/apps/backend/src/api/admin/orders/[id]/shiprocket-label/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/shiprocket-label/route.ts
@@ -1,6 +1,5 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
-import { createOrderFulfillmentWorkflow } from "@medusajs/medusa/core-flows"
+import { ensureOrderFulfillment } from "../../../../../workflows/orders/fulfillment-context"
 import { createShiprocketShipmentForFulfillment } from "../../../../../workflows/orders/shiprocket-shipment"
 
 /**
@@ -11,65 +10,18 @@ import { createShiprocketShipmentForFulfillment } from "../../../../../workflows
  * fulfillment if one's already there) and generate the Shiprocket shipment +
  * label off it. Returns the AWB + label URL.
  *
+ * Fulfillment creation for converted (title-only, shipping-method-less) orders
+ * is handled by `ensureOrderFulfillment` — it creates the plain fulfillment
+ * against the MANUAL provider so this route's createShipment is the only thing
+ * that touches Shiprocket (#437).
+ *
  * Errors (incl. Shiprocket's ShiprocketApiError, a MedusaError #427) surface
  * cleanly to the UI toast.
  */
 export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const orderId = req.params.id
-  const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
-  const { data: orders } = await query.graph({
-    entity: "order",
-    fields: [
-      "id",
-      "items.id",
-      "items.quantity",
-      "fulfillments.id",
-      "fulfillments.data",
-      "fulfillments.created_at",
-    ],
-    filters: { id: orderId },
-  })
-  const order = orders?.[0]
-  if (!order) {
-    throw new MedusaError(MedusaError.Types.NOT_FOUND, `Order ${orderId} not found`)
-  }
-
-  // Reuse an existing Shiprocket fulfillment if present; else create one for
-  // the whole order.
-  let fulfillmentId: string | undefined = (order.fulfillments || []).find(
-    (f: any) => f.data?.carrier === "shiprocket"
-  )?.id
-
-  if (!fulfillmentId) {
-    const items = (order.items || []).map((i: any) => ({
-      id: i.id,
-      quantity: i.quantity,
-    }))
-    await createOrderFulfillmentWorkflow(req.scope).run({
-      input: { order_id: orderId, items },
-    })
-    // The workflow returns the order; resolve the newest fulfillment by re-query.
-    const { data: refetched } = await query.graph({
-      entity: "order",
-      fields: ["fulfillments.id", "fulfillments.created_at"],
-      filters: { id: orderId },
-    })
-    const fs = (refetched?.[0]?.fulfillments || []) as any[]
-    fulfillmentId = fs
-      .slice()
-      .sort(
-        (a, b) =>
-          new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-      )[0]?.id
-  }
-
-  if (!fulfillmentId) {
-    throw new MedusaError(
-      MedusaError.Types.UNEXPECTED_STATE,
-      "Could not resolve a fulfillment to ship for this order"
-    )
-  }
+  const fulfillmentId = await ensureOrderFulfillment(req.scope, orderId)
 
   const shipment = await createShiprocketShipmentForFulfillment(req.scope, {
     orderId,

--- a/apps/backend/src/workflows/orders/__tests__/derive-fulfillment-state.unit.spec.ts
+++ b/apps/backend/src/workflows/orders/__tests__/derive-fulfillment-state.unit.spec.ts
@@ -1,0 +1,36 @@
+import { deriveFulfillmentState } from "../shiprocket-attach-awb"
+
+/**
+ * #437 — auto-sync mapping from a Shiprocket tracking status onto a coarse
+ * fulfillment state. Codes mirror the carrier client's scanTypeForStatus.
+ */
+describe("deriveFulfillmentState (#437)", () => {
+  it("maps Shiprocket status codes", () => {
+    expect(deriveFulfillmentState(7)).toBe("delivered")
+    expect(deriveFulfillmentState(6)).toBe("shipped")
+    expect(deriveFulfillmentState(42)).toBe("shipped")
+    // created / not-yet-shipped codes stay pending
+    expect(deriveFulfillmentState(1)).toBe("pending")
+    expect(deriveFulfillmentState(5)).toBe("pending")
+  })
+
+  it("falls back to the status text when no code is present", () => {
+    expect(deriveFulfillmentState(undefined, "Delivered")).toBe("delivered")
+    expect(deriveFulfillmentState(undefined, "In Transit")).toBe("shipped")
+    expect(deriveFulfillmentState(undefined, "Out for Delivery")).toBe("shipped")
+    expect(deriveFulfillmentState(undefined, "Picked Up")).toBe("shipped")
+    // not yet in transit → conservative pending (no status change)
+    expect(deriveFulfillmentState(undefined, "Pickup Scheduled")).toBe("pending")
+  })
+
+  it("defaults to pending for unknown / empty status", () => {
+    expect(deriveFulfillmentState(undefined, undefined)).toBe("pending")
+    expect(deriveFulfillmentState(undefined, "")).toBe("pending")
+    expect(deriveFulfillmentState(999, "Some New Status")).toBe("pending")
+  })
+
+  it("prefers the code over the text", () => {
+    // delivered code wins even if text is stale/ambiguous
+    expect(deriveFulfillmentState(7, "In Transit")).toBe("delivered")
+  })
+})

--- a/apps/backend/src/workflows/orders/fulfillment-context.ts
+++ b/apps/backend/src/workflows/orders/fulfillment-context.ts
@@ -1,0 +1,142 @@
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+} from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+import { createOrderFulfillmentWorkflow } from "@medusajs/medusa/core-flows"
+
+/**
+ * #404 / #437 — shared fulfillment plumbing for admin-converted orders.
+ *
+ * A design order converted via `convert-design-order.ts` is built from
+ * TITLE-ONLY line items and is NEVER given a shipping method (the customer
+ * never checked out). Medusa core's `createOrderFulfillmentWorkflow` resolves
+ * the fulfillment's shipping option as `input.shipping_option_id ??
+ * order.shipping_methods[0]?.shipping_option_id` and then reads
+ * `shippingOption.provider_id` / `service_zone.fulfillment_set.location.id` off
+ * it — so with no shipping method and no explicit option it dereferences a null
+ * option and 500s. We therefore resolve a MANUAL shipping option explicitly.
+ *
+ * Why specifically a MANUAL provider: `createOrderFulfillmentWorkflow` →
+ * `createFulfillmentWorkflow` invokes the shipping option's fulfillment-provider
+ * `createFulfillment`. The Shiprocket provider's `createFulfillment` CREATES A
+ * NEW Shiprocket shipment (service.ts). Creating the plain fulfillment against
+ * the manual provider keeps it side-effect-free; carrier data (a fresh AWB, or
+ * an existing one) is stamped onto `fulfillment.data` out-of-band afterwards.
+ */
+export async function resolvePlainFulfillmentContext(
+  container: MedusaContainer
+): Promise<{ shippingOptionId: string; locationId?: string }> {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  const { data: opts } = await query.graph({
+    entity: "shipping_options",
+    fields: [
+      "id",
+      "provider_id",
+      "service_zone.fulfillment_set.location.id",
+    ],
+  })
+  const isManual = (o: any) =>
+    typeof o?.provider_id === "string" && o.provider_id.startsWith("manual")
+  const withLocation = (opts || []).find(
+    (o: any) => isManual(o) && o.service_zone?.fulfillment_set?.location?.id
+  )
+  const anyManual = (opts || []).find(isManual)
+  const chosen = withLocation ?? anyManual
+  if (!chosen) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "No manual shipping option is configured, so a fulfillment cannot be created for this order. Create a manual shipping option first."
+    )
+  }
+  return {
+    shippingOptionId: chosen.id,
+    locationId: chosen.service_zone?.fulfillment_set?.location?.id,
+  }
+}
+
+/**
+ * Reuse the order's existing Shiprocket fulfillment if it already has one; else
+ * create a plain (manual) fulfillment for the whole order. Returns the
+ * fulfillment id. Used by both the "generate new label" and "attach existing
+ * AWB" routes.
+ */
+export async function ensureOrderFulfillment(
+  container: MedusaContainer,
+  orderId: string
+): Promise<string> {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: orders } = await query.graph({
+    entity: "order",
+    fields: [
+      "id",
+      "items.id",
+      // Order line-item `quantity` is computed from raw_quantity and does NOT
+      // populate when selected by name; read it off the `detail` relation.
+      "items.detail.quantity",
+      "fulfillments.id",
+      "fulfillments.data",
+      "fulfillments.created_at",
+      "fulfillments.canceled_at",
+    ],
+    filters: { id: orderId },
+  })
+  const order = orders?.[0]
+  if (!order) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, `Order ${orderId} not found`)
+  }
+
+  // Reuse an existing fulfillment so a retry (e.g. after a Shiprocket error)
+  // doesn't pile up duplicate fulfillments: prefer one already stamped with the
+  // Shiprocket carrier, else the most recent non-canceled fulfillment.
+  const active = (order.fulfillments || [])
+    .filter((f: any) => !f.canceled_at)
+    .sort(
+      (a: any, b: any) =>
+        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    )
+  const existing: string | undefined =
+    active.find((f: any) => f.data?.carrier === "shiprocket")?.id ?? active[0]?.id
+  if (existing) {
+    return existing
+  }
+
+  const items = (order.items || []).map((i: any) => ({
+    id: i.id,
+    quantity: Number(i.detail?.quantity ?? i.quantity) || 1,
+  }))
+  const { shippingOptionId, locationId } =
+    await resolvePlainFulfillmentContext(container)
+
+  await createOrderFulfillmentWorkflow(container).run({
+    input: {
+      order_id: orderId,
+      items,
+      shipping_option_id: shippingOptionId,
+      location_id: locationId,
+      no_notification: true,
+    } as any,
+  })
+
+  const { data: refetched } = await query.graph({
+    entity: "order",
+    fields: ["fulfillments.id", "fulfillments.created_at"],
+    filters: { id: orderId },
+  })
+  const fs = (refetched?.[0]?.fulfillments || []) as any[]
+  const fulfillmentId = fs
+    .slice()
+    .sort(
+      (a, b) =>
+        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    )[0]?.id
+
+  if (!fulfillmentId) {
+    throw new MedusaError(
+      MedusaError.Types.UNEXPECTED_STATE,
+      "Could not resolve a fulfillment to ship for this order"
+    )
+  }
+  return fulfillmentId
+}

--- a/apps/backend/src/workflows/orders/shiprocket-attach-awb.ts
+++ b/apps/backend/src/workflows/orders/shiprocket-attach-awb.ts
@@ -1,0 +1,204 @@
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+import {
+  createOrderShipmentWorkflow,
+  markOrderFulfillmentAsDeliveredWorkflow,
+} from "@medusajs/medusa/core-flows"
+import { resolveShippingProvider } from "../../modules/shipping-providers/resolver"
+
+/**
+ * #437 — attach an EXISTING Shiprocket AWB to a (converted) order, for parcels
+ * already shipped/delivered directly in the Shiprocket dashboard or before this
+ * system existed. Unlike `createShiprocketShipmentForFulfillment` (which creates
+ * a brand-new Shiprocket order + AWB), this is READ-ONLY against Shiprocket: it
+ * `track`s the AWB to validate + hydrate it, stamps the carrier refs onto
+ * `fulfillment.data` (what the label/tracking routes read), and auto-syncs the
+ * order's fulfillment status to match the AWB's real Shiprocket state.
+ */
+
+export type AttachAwbResult = {
+  awb: string
+  current_status?: string
+  /** What we synced the fulfillment to, derived from the live Shiprocket status. */
+  synced_state: "delivered" | "shipped" | "pending"
+  fulfillment_id: string
+}
+
+/**
+ * Shiprocket `shipment_status_id` (and a status-text fallback) → coarse
+ * fulfillment state for auto-sync. Codes mirror the carrier client's
+ * `scanTypeForStatus`: 7 = delivered, 6/42 = in-transit/out-for-delivery.
+ */
+export function deriveFulfillmentState(
+  code?: number,
+  statusText?: string
+): "delivered" | "shipped" | "pending" {
+  if (code === 7) return "delivered"
+  if (code === 6 || code === 42) return "shipped"
+  const t = (statusText || "").toLowerCase()
+  // "out for delivery" contains "deliver" but is NOT delivered — match the
+  // shipped signals first, then the exact "delivered" signal.
+  if (
+    t.includes("transit") ||
+    t.includes("shipped") ||
+    t.includes("out for delivery") ||
+    t.includes("picked")
+  ) {
+    return "shipped"
+  }
+  if (t.includes("delivered")) return "delivered"
+  return "pending"
+}
+
+export async function attachExistingShiprocketAwb(
+  container: MedusaContainer,
+  input: { orderId: string; fulfillmentId: string; awb: string }
+): Promise<AttachAwbResult> {
+  const awb = (input.awb || "").trim()
+  if (!awb) {
+    throw new MedusaError(MedusaError.Types.INVALID_DATA, "An AWB is required")
+  }
+
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  const fulfillmentModule: any = container.resolve(Modules.FULFILLMENT)
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+
+  const { data: orders } = await query.graph({
+    entity: "order",
+    fields: [
+      "id",
+      "items.id",
+      // `quantity` is computed from raw_quantity — read it off `detail`.
+      "items.detail.quantity",
+      "fulfillments.id",
+      "fulfillments.data",
+    ],
+    filters: { id: input.orderId },
+  })
+  const order = orders?.[0]
+  if (!order) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Order ${input.orderId} not found`
+    )
+  }
+  const fulfillment = (order.fulfillments || []).find(
+    (f: any) => f.id === input.fulfillmentId
+  )
+  if (!fulfillment) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Fulfillment ${input.fulfillmentId} not found on order ${input.orderId}`
+    )
+  }
+
+  const provider = await resolveShippingProvider(container, "shiprocket")
+  if (!provider.track) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "Shiprocket provider does not support tracking lookups"
+    )
+  }
+
+  // Read-only lookup: validates the AWB belongs to this Shiprocket account and
+  // hydrates its real status/courier. A bad/foreign AWB surfaces cleanly.
+  let tracking: any
+  try {
+    tracking = await provider.track({ awb })
+  } catch (e: any) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Could not look up AWB ${awb} on Shiprocket: ${e?.message ?? e}`
+    )
+  }
+  const hasShipment =
+    tracking &&
+    (tracking.awb ||
+      tracking.current_status ||
+      (tracking.events || []).length > 0)
+  if (!hasShipment) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Shiprocket returned no shipment for AWB ${awb}. Check the AWB belongs to this Shiprocket account.`
+    )
+  }
+
+  const refs = tracking.raw?.shipment_track?.[0] || {}
+  const shipmentId = refs.shipment_id ?? refs.id
+  await fulfillmentModule.updateFulfillment(input.fulfillmentId, {
+    data: {
+      ...(fulfillment.data || {}),
+      carrier: "shiprocket",
+      waybill: awb,
+      tracking_number: awb,
+      tracking_url: `https://shiprocket.co/tracking/${awb}`,
+      current_status: tracking.current_status,
+      shipment_id: shipmentId,
+      sr_order_id: refs.sr_order_id,
+      attached_existing: true,
+      provider_refs: {
+        shipment_id: shipmentId,
+        sr_order_id: refs.sr_order_id,
+        courier_name: refs.courier_name,
+      },
+    },
+  })
+
+  const state = deriveFulfillmentState(
+    tracking.current_status_code != null
+      ? Number(tracking.current_status_code)
+      : undefined,
+    tracking.current_status
+  )
+
+  // Auto-sync the order's fulfillment status to reality. createOrderShipment
+  // marks the fulfillment shipped; markDelivered then closes it out. Both are
+  // best-effort — a benign "already in that state" must not fail the attach.
+  if (state === "shipped" || state === "delivered") {
+    const items = (order.items || []).map((i: any) => ({
+      id: i.id,
+      quantity: Number(i.detail?.quantity ?? i.quantity) || 1,
+    }))
+    try {
+      await createOrderShipmentWorkflow(container).run({
+        input: {
+          order_id: input.orderId,
+          fulfillment_id: input.fulfillmentId,
+          items,
+          labels: [],
+          no_notification: true,
+        },
+      })
+    } catch (e: any) {
+      logger.warn(
+        `[attach-awb] mark-shipped skipped for fulfillment ${input.fulfillmentId}: ${e?.message}`
+      )
+    }
+  }
+  if (state === "delivered") {
+    try {
+      await markOrderFulfillmentAsDeliveredWorkflow(container).run({
+        input: {
+          orderId: input.orderId,
+          fulfillmentId: input.fulfillmentId,
+          no_notification: true,
+        } as any,
+      })
+    } catch (e: any) {
+      logger.warn(
+        `[attach-awb] mark-delivered skipped for fulfillment ${input.fulfillmentId}: ${e?.message}`
+      )
+    }
+  }
+
+  return {
+    awb,
+    current_status: tracking.current_status,
+    synced_state: state,
+    fulfillment_id: input.fulfillmentId,
+  }
+}


### PR DESCRIPTION
## What & why

Closes the #437 tail and adds a capability you flagged: **attaching an _existing_ Shiprocket AWB** to a converted design order — for parcels already shipped/delivered (Shiprocket dashboard or pre-system). The existing "Generate Label" creates a *new* shipment; this **read-only** path looks the AWB up, stamps it, and **auto-syncs** the fulfillment status to the AWB's real Shiprocket state.

It also fixes a **latent 500** that the original "Generate Label" path shared: converted design orders are **title-only with no shipping method**, so core's `createOrderFulfillmentWorkflow` dereferenced a null shipping option.

## Changes

- **`workflows/orders/fulfillment-context.ts`** — shared `ensureOrderFulfillment` + `resolvePlainFulfillmentContext`. Creates the fulfillment against the **manual** provider (so it never fires a carrier side-effect — Shiprocket data is stamped out-of-band), and reuses an existing fulfillment to avoid duplicates on retry.
- **`workflows/orders/shiprocket-attach-awb.ts`** — `attachExistingShiprocketAwb`: `track({awb})` → validate → stamp `fulfillment.data` → auto-sync shipped/delivered (`deriveFulfillmentState`).
- **`api/admin/orders/[id]/shiprocket-attach-awb/route.ts`** — `POST {awb}`.
- **`shiprocket-label/route.ts`** — now uses the shared `ensureOrderFulfillment` (fixes its 500 on title-only orders too).
- **Admin UI** — `useAttachShiprocketAwb` hook + inline "Attach existing AWB" panel; action menu now gated on `status === "canceled"` (not just `canceled_at`).

## Verification

- Unit: `deriveFulfillmentState` status mapping (caught a real "Out for Delivery" → delivered bug).
- Integration: `ensureOrderFulfillment` creates a manual fulfillment for a title-only converted order + idempotency; attach route over HTTP returns a **clean structured error, not a 500**; empty AWB → 400.
- Browser (Playwright, local): convert→paid (200), action present on live order, inline panel, attach → clean error toast (no opaque 500). Screenshots captured.
- 0 new TS errors.

## Not covered (needs prod)

A **successful** attach with a real valid AWB needs valid Shiprocket creds + a real AWB → the planned prod test on `cali_01KV5KJM…`. Read-only on Shiprocket; converting that design order creates one real prod order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)