### PR TITLE
fix(designs): #440 — custom-design variant skips price_set link → admin prices crash

### DIFF
--- a/apps/backend/src/workflows/designs/create-product-from-design.ts
+++ b/apps/backend/src/workflows/designs/create-product-from-design.ts
@@ -5,7 +5,10 @@ import {
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk";
 import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils";
-import { createProductsWorkflow } from "@medusajs/medusa/core-flows";
+import {
+  createProductsWorkflow,
+  createProductVariantsWorkflow,
+} from "@medusajs/medusa/core-flows";
 import { DESIGN_MODULE } from "../../modules/designs";
 import type { Link } from "@medusajs/modules-sdk";
 
@@ -139,26 +142,25 @@ const createProductAndVariantStep = createStep(
         },
       };
 
-      const variant = await productService.createProductVariants(variantData);
-      variant_id = variant.id;
-
-      // Create inventory item for this design variant (0 stock until production completes)
-      const inventoryService = container.resolve(Modules.INVENTORY) as any;
-      const inventoryItem = await inventoryService.createInventoryItems({
-        sku: variantData.sku,
-        title: `Custom - ${design.name}`,
-        requires_shipping: false,
-        metadata: {
-          is_custom_design: true,
-          design_id: design.id,
+      // Use createProductVariantsWorkflow rather than the bare product service.
+      // The workflow creates the variant's price_set and links variant ↔ price_set
+      // (via createVariantPricingLinkStep) AND auto-creates the inventory item +
+      // variant ↔ item link for manage_inventory variants. The bare service skips
+      // the price_set link, leaving `variant.prices` undefined so admin's
+      // `/products/:id/prices` page crashes on `variant.prices.reduce(...)` (#440).
+      // Mirrors the new-product branch below, which already relies on the
+      // workflow auto-creating inventory items.
+      const { result } = await createProductVariantsWorkflow(container).run({
+        input: {
+          product_variants: [variantData] as any,
         },
       });
 
-      // Link inventory item → variant
-      await remoteLink.create({
-        [Modules.PRODUCT]: { product_variant_id: variant_id },
-        [Modules.INVENTORY]: { inventory_item_id: inventoryItem.id },
-      });
+      const createdVariant = result?.[0];
+      if (!createdVariant?.id) {
+        throw new Error("Failed to create variant for custom design");
+      }
+      variant_id = createdVariant.id;
     } else {
       // Need to create a new product
       const storeService = container.resolve(Modules.STORE) as any;


### PR DESCRIPTION
## Issue #440 — `undefined is not an object (evaluating 'l.prices.reduce')`

The core Medusa admin `/products/:id/prices` page maps over variants and calls `variant.prices.reduce(...)`. For variants with **no variant↔price_set link**, the joined `prices` field comes back `undefined` and the page crashes. We can't patch that bundle (it's `@medusajs/dashboard` core) — the fix is to never leave a variant unlinked.

### Root cause (code)
`src/workflows/designs/create-product-from-design.ts` — the **hasLinkedProduct** branch (adding a custom-design variant to an existing product) created the variant via the **bare product service** (`productService.createProductVariants`). That skips `createVariantPricingLinkStep`, so no price_set link is created and the passed `prices` are silently dropped → fresh orphan → admin crash.

The partner variant routes were already migrated to the workflow; this was the remaining orphan-maker.

### Fix
Route through `createProductVariantsWorkflow` (mirrors the partner routes and this file's own new-product branch). The workflow:
- creates the price_set + variant↔price_set link (the bug fix), and
- auto-creates the inventory item + variant↔item link for `manage_inventory` variants,

so the now-redundant manual inventory-creation block is removed.

### Historical data
Platform-wide there were **5 orphan variants** (all on prod product `Traditional Muslin`). Repaired in prod by running `backfill-variant-price-sets.js` via ECS run-task — all 5 now return `prices: []` and the admin page renders. Verified via admin API.

### Verification
- Backend typecheck: no new errors in the changed file (pre-existing errors are confined to unrelated specs / admin social-platform components).
- Prod admin API now returns a `prices` array for every variant on the affected product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)