### PR TITLE
fix(visual-flows): bulk_update_data silently dropped template-string `items` (recovery resend loop + product-visit no-write)

### DIFF
--- a/apps/backend/src/modules/visual_flows/operations/__tests__/bulk-update-data.unit.spec.ts
+++ b/apps/backend/src/modules/visual_flows/operations/__tests__/bulk-update-data.unit.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for the visual-flows `bulk_update_data` operation — specifically
+ * the `items` template-resolution contract.
+ *
+ * The regression this guards: `items` is configured as a template string
+ * (e.g. "{{ classify.update_items }}") that must resolve to an array of
+ * { selector, data } records. The operation used to guard on
+ * `Array.isArray(options.items)` BEFORE interpolating, so a string template
+ * was discarded as `[]` and every update became a silent no-op — the cart
+ * recovery flow's `mark_sent` never stamped `recovery_email_sent_at`, so the
+ * resend-gap + send-cap never engaged and carts were re-emailed hourly.
+ *
+ * The operation only reads `context.container` + `context.dataChain`, so we can
+ * invoke it directly without booting Medusa.
+ */
+
+import { bulkUpdateDataOperation } from "../bulk-update-data"
+
+function makeContext(dataChain: Record<string, any>, service: any): any {
+  return {
+    container: {
+      resolve: (name: string) => (name === "cart" ? service : null),
+    } as any,
+    dataChain: {
+      $trigger: { payload: {}, timestamp: "2026-06-17T00:00:00.000Z" },
+      $accountability: {},
+      $env: {},
+      $last: null,
+      ...dataChain,
+    },
+    flowId: "flow_test",
+    executionId: "exec_test",
+    operationId: "op_test",
+    operationKey: "mark_sent",
+  }
+}
+
+describe("bulk_update_data operation — items resolution", () => {
+  const UPDATE_ITEMS = [
+    {
+      selector: { id: "cart_123" },
+      data: { metadata: { recovery_email_sent_at: "2026-06-17T13:00:00.000Z" } },
+    },
+  ]
+
+  it("resolves a template-string `items` into the upstream array and updates each record", async () => {
+    const updateCarts = jest.fn().mockResolvedValue({ id: "cart_123" })
+    const service = { updateCarts }
+
+    const result = await bulkUpdateDataOperation.execute(
+      {
+        module: "cart",
+        collection: "carts",
+        // The real flow passes a template string here, NOT a literal array.
+        items: "{{ classify.update_items }}",
+        continue_on_error: true,
+        max_items: 500,
+      },
+      makeContext({ classify: { update_items: UPDATE_ITEMS } }, service),
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.data?.updated).toBe(1)
+    expect(result.data?.failed).toBe(0)
+    // selector.id present → called positionally with (id, data)
+    expect(updateCarts).toHaveBeenCalledWith("cart_123", {
+      metadata: { recovery_email_sent_at: "2026-06-17T13:00:00.000Z" },
+    })
+  })
+
+  it("still accepts a literal array `items`", async () => {
+    const updateCarts = jest.fn().mockResolvedValue({ id: "cart_123" })
+    const service = { updateCarts }
+
+    const result = await bulkUpdateDataOperation.execute(
+      {
+        module: "cart",
+        collection: "carts",
+        items: UPDATE_ITEMS,
+        continue_on_error: true,
+        max_items: 500,
+      },
+      makeContext({}, service),
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.data?.updated).toBe(1)
+    expect(updateCarts).toHaveBeenCalledTimes(1)
+  })
+
+  it("errors clearly when `items` does not resolve to an array", async () => {
+    const service = { updateCarts: jest.fn() }
+
+    const result = await bulkUpdateDataOperation.execute(
+      {
+        module: "cart",
+        collection: "carts",
+        items: "{{ classify.does_not_exist }}",
+        continue_on_error: true,
+        max_items: 500,
+      },
+      makeContext({ classify: { update_items: UPDATE_ITEMS } }, service),
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/did not resolve to an array/i)
+    expect(service.updateCarts).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/modules/visual_flows/operations/bulk-update-data.ts
+++ b/apps/backend/src/modules/visual_flows/operations/bulk-update-data.ts
@@ -73,11 +73,24 @@ export const bulkUpdateDataOperation: OperationDefinition = {
         }
       }
 
-      const rawItems = Array.isArray(options.items) ? options.items : []
-      const items = interpolateVariables(rawItems, context.dataChain) as Array<{
+      // `items` is typically a template string (e.g. "{{ classify.update_items }}")
+      // that resolves to an array — so interpolate FIRST, then validate. Guarding
+      // on Array.isArray before interpolation silently dropped string templates to
+      // an empty array, making every bulk_update_data a no-op (e.g. the cart
+      // recovery flow's mark_sent never stamped recovery_email_sent_at, so the
+      // dedup gap + send cap never engaged → carts re-emailed hourly). Mirrors the
+      // resolution order in bulk-trigger-workflow.ts.
+      const items = interpolateVariables(options.items, context.dataChain) as Array<{
         selector?: Record<string, any>
         data: Record<string, any>
       }>
+
+      if (!Array.isArray(items)) {
+        return {
+          success: false,
+          error: `'items' did not resolve to an array. Got: ${typeof items}`,
+        }
+      }
 
       if (items.length > maxItems) {
         return {


### PR DESCRIPTION
## Problem

`bulk_update_data` validated `Array.isArray(options.items)` **before** interpolating, so an `items` field configured as a template string — the normal case, e.g. `"{{ classify.update_items }}"` — was discarded as `[]`. Every update became a **silent no-op**: `success: true, updated: 0`, empty `results`.

Confirmed live in prod on two active, schedule-driven flows:

**1. Cart Recovery (`vflow_01KQ4S5CHSHSYYRDPNKK326WAS`)** — `mark_sent` builds `update_items` correctly but writes nothing, so `metadata.recovery_email_sent_at` / `recovery_email_count` are never stamped. The 24h resend gap **and** the 2-email cap both depend on those markers → abandoned carts re-emailed **every hour**. (This is the root cause of the `recovery_email_sent_at: null` finding from #443 — the customer kept getting "You left something beautiful behind".) The 13:00Z execution: `dispatch sent=1`, `mark_sent {updated:0, results:[]}`, `log_summary marked=0`.

**2. Product visits aggregate (`vflow_01KCH0R3FBWV49W2XPGNX3N7YF`)** — the final `bulk_update_data` to write per-product analytics metadata also no-ops. (That flow has a *second*, upstream bug too — the join node reads `$last.records` but a log node now sits between it and the product read, so `products=[]`; fixed in the editor, tracked separately.)

## Fix

Interpolate `options.items` first, then validate it resolved to an array — mirroring `bulk_trigger_workflow` (which is why `dispatch` worked but `mark_sent` didn't). One-line semantics change; literal arrays still pass through unchanged.

## Tests

`bulk-update-data.unit.spec.ts` (direct invocation, no Medusa boot):
- template-string `items` → resolves upstream array, `updated:1`, `updateCarts("cart_123", {metadata})` called ✅ (the regression)
- literal array `items` still works ✅
- non-resolving template → clear `did not resolve to an array` error, no writes ✅

## Deploy note

Executor-code fix — repairs the already-live flows on deploy, no flow re-seed needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)