### PR TITLE
fix(orders): #445 — project legacy-only work-orders (inventory + design) onto the unified surface

### DIFF
--- a/apps/backend/src/scripts/backfill-unified-order-projections.ts
+++ b/apps/backend/src/scripts/backfill-unified-order-projections.ts
@@ -1,32 +1,88 @@
 import { ExecArgs } from "@medusajs/framework/types"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { backfillInventoryOrderProjectionWorkflow } from "../workflows/inventory_orders/backfill-project-inventory-order"
+import { projectRunToUnifiedOrder } from "../workflows/production-runs/dual-write-unified-run-order"
 
 /**
- * #445 / #342 T4 — PROJECTION backfill for legacy-only inventory orders.
+ * #445 / #342 T4 — PROJECTION backfill for legacy-only work-orders (BOTH kinds:
+ * inventory orders AND design orders / production runs).
  *
  * The link-only backfill (`backfill-unified-order-links.ts`) intentionally left
  * pre-T2 rows that were never dual-written as legacy-only — the prod run on
- * 2026-06-14 reported `noBackref=90`. Those orders (e.g. partner GOF's) don't
- * appear under the unified `/orders` surface because they have no core `order`.
- * This script mints the missing projection for each, reusing the create-path
- * dual-write so semantics match exactly, and re-applies the partner D3 link +
- * current status for assigned orders so partners see them in `/orders`.
+ * 2026-06-14 reported a COMBINED `noBackref=90` across inventory_orders +
+ * production_runs. Those rows (e.g. partner GOF's inventory order, and any
+ * pre-T3.2 design run) don't appear under the unified `/orders` surface because
+ * they have no core `order`. This script mints the missing projection for each,
+ * reusing each kind's create-path projector so semantics match exactly:
+ *   - inventory_orders → backfillInventoryOrderProjectionWorkflow
+ *     (gather legacy row + lines/locations/partner → dualWrite → partner mirror
+ *      → status mirror)
+ *   - production_runs  → projectRunToUnifiedOrder (self-contained + idempotent:
+ *     order + order↔run link + design link + partner/sub_partner links +
+ *     status sidecar, derived from the run's current status/lifecycle)
  *
- * Candidate = inventory order with NO order↔inventory_order link AND NO
- * `metadata.unified_order_id` backref. Anything already projected is skipped, so
- * the script is safe to re-run (projected rows gain the link and drop out).
+ * Candidate = row with NO order↔execution link AND NO `metadata.unified_order_id`
+ * backref. Already-projected rows are skipped, so the script is safe to re-run.
  *
  * DRY RUN BY DEFAULT. It only writes when you pass `apply`. medusa exec forwards
  * positional args (not `--flags`); all of these also accept a `--` prefix:
  *   npx medusa exec ./src/scripts/backfill-unified-order-projections.ts
  *   npx medusa exec ./src/scripts/backfill-unified-order-projections.ts apply
  *   npx medusa exec ./src/scripts/backfill-unified-order-projections.ts apply assigned-only
+ *   npx medusa exec ./src/scripts/backfill-unified-order-projections.ts apply entity=inventory
+ *   npx medusa exec ./src/scripts/backfill-unified-order-projections.ts apply entity=design
  *   npx medusa exec ./src/scripts/backfill-unified-order-projections.ts apply partner=part_123
  *   npx medusa exec ./src/scripts/backfill-unified-order-projections.ts apply order=inv_order_123
  */
 
 const PAGE = 200
+
+type ProjectResult = {
+  unified_order_id: string | null
+  skipped?: string
+  error?: string
+}
+
+type Target = {
+  key: "inventory" | "design"
+  entity: "inventory_orders" | "production_runs"
+  label: string
+  // fields used to detect already-projected + assignment
+  fields: string[]
+  // pull the assigned partner id from a candidate row (link vs column)
+  partnerIdOf: (row: any) => string | null
+  // run the kind-specific create-path projection
+  project: (container: any, id: string) => Promise<ProjectResult>
+}
+
+const TARGETS: Target[] = [
+  {
+    key: "inventory",
+    entity: "inventory_orders",
+    label: "inventory order",
+    fields: ["id", "status", "order.id", "metadata", "partner.id"],
+    partnerIdOf: (row) =>
+      Array.isArray(row.partner)
+        ? row.partner?.[0]?.id ?? null
+        : row.partner?.id ?? null,
+    project: async (container, id) => {
+      const { result } = await backfillInventoryOrderProjectionWorkflow(
+        container
+      ).run({ input: { inventoryOrderId: id } })
+      return result as ProjectResult
+    },
+  },
+  {
+    key: "design",
+    entity: "production_runs",
+    label: "design run",
+    // `order.id` = the order↔production_run link (unified pointer); `order_id`
+    // is the legacy retail column and must NOT be used for the projected check.
+    fields: ["id", "status", "order.id", "metadata", "partner_id"],
+    partnerIdOf: (row) => row.partner_id ?? null,
+    project: (container, id) => projectRunToUnifiedOrder(container, id),
+  },
+]
 
 export default async function backfillUnifiedOrderProjections({
   container,
@@ -45,107 +101,117 @@ export default async function backfillUnifiedOrderProjections({
   const assignedOnly = has("assigned-only")
   const onlyPartnerId = valueOf("partner")
   const onlyOrderId = valueOf("order")
+  const entityFilter = valueOf("entity") // inventory | design | (unset = both)
 
   const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
   const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
 
   logger.info(
     `[backfill-projections] starting${apply ? " (APPLY — will create unified orders)" : " (DRY RUN — no writes)"}` +
+      `${entityFilter ? ` entity=${entityFilter}` : " entity=both"}` +
       `${assignedOnly ? " assigned-only" : ""}` +
       `${onlyPartnerId ? ` partner=${onlyPartnerId}` : ""}` +
       `${onlyOrderId ? ` order=${onlyOrderId}` : ""}`
   )
 
-  let scanned = 0
-  let alreadyProjected = 0
-  let candidates = 0
-  let candidatesAssigned = 0
-  let candidatesUnassigned = 0
-  let projected = 0
-  let projectedAssigned = 0
-  let skippedScope = 0
-  let failed = 0
+  const makeCounts = () => ({
+    scanned: 0,
+    alreadyProjected: 0,
+    candidates: 0,
+    candidatesAssigned: 0,
+    candidatesUnassigned: 0,
+    skippedScope: 0,
+    projected: 0,
+    projectedAssigned: 0,
+    failed: 0,
+  })
+  const grand = makeCounts()
 
-  let skip = 0
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const { data: rows } = await query.graph({
-      entity: "inventory_orders",
-      fields: ["id", "status", "order.id", "metadata", "partner.id"],
-      pagination: { take: PAGE, skip },
-      ...(onlyOrderId ? { filters: { id: onlyOrderId } } : {}),
-    })
-    if (!rows?.length) break
+  for (const target of TARGETS) {
+    if (entityFilter && entityFilter !== target.key) continue
 
-    for (const row of rows as any[]) {
-      scanned++
+    const t = makeCounts()
 
-      // Already on the unified surface (link or transitional backref) → skip.
-      if (row?.order?.id || row?.metadata?.unified_order_id) {
-        alreadyProjected++
-        continue
-      }
+    let skip = 0
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const { data: rows } = await query.graph({
+        entity: target.entity,
+        fields: target.fields,
+        pagination: { take: PAGE, skip },
+        ...(onlyOrderId ? { filters: { id: onlyOrderId } } : {}),
+      })
+      if (!rows?.length) break
 
-      const partnerId = Array.isArray(row.partner)
-        ? row.partner?.[0]?.id ?? null
-        : row.partner?.id ?? null
-      const isAssigned = Boolean(partnerId)
+      for (const row of rows as any[]) {
+        t.scanned++
 
-      candidates++
-      if (isAssigned) candidatesAssigned++
-      else candidatesUnassigned++
+        if (row?.order?.id || row?.metadata?.unified_order_id) {
+          t.alreadyProjected++
+          continue
+        }
 
-      // Scope filters
-      if (assignedOnly && !isAssigned) {
-        skippedScope++
-        continue
-      }
-      if (onlyPartnerId && partnerId !== onlyPartnerId) {
-        skippedScope++
-        continue
-      }
+        const partnerId = target.partnerIdOf(row)
+        const isAssigned = Boolean(partnerId)
 
-      if (!apply) {
-        logger.info(
-          `[backfill-projections] DRY would project ${row.id} (status=${row.status}, ${isAssigned ? `partner=${partnerId}` : "unassigned"})`
-        )
-        continue
-      }
+        t.candidates++
+        if (isAssigned) t.candidatesAssigned++
+        else t.candidatesUnassigned++
 
-      try {
-        const { result } = await backfillInventoryOrderProjectionWorkflow(
-          container
-        ).run({ input: { inventoryOrderId: row.id } })
+        if (assignedOnly && !isAssigned) {
+          t.skippedScope++
+          continue
+        }
+        if (onlyPartnerId && partnerId !== onlyPartnerId) {
+          t.skippedScope++
+          continue
+        }
 
-        if (result?.unified_order_id) {
-          projected++
-          if (isAssigned) projectedAssigned++
+        if (!apply) {
           logger.info(
-            `[backfill-projections] projected ${row.id} → order ${result.unified_order_id}` +
-              `${isAssigned ? ` (partner ${partnerId})` : ""}`
+            `[backfill-projections] DRY would project ${target.label} ${row.id} (status=${row.status}, ${isAssigned ? `partner=${partnerId}` : "unassigned"})`
           )
-        } else {
-          failed++
+          continue
+        }
+
+        try {
+          const result = await target.project(container, row.id)
+          if (result?.unified_order_id) {
+            t.projected++
+            if (isAssigned) t.projectedAssigned++
+            logger.info(
+              `[backfill-projections] projected ${target.label} ${row.id} → order ${result.unified_order_id}${isAssigned ? ` (partner ${partnerId})` : ""}`
+            )
+          } else {
+            t.failed++
+            logger.error(
+              `[backfill-projections] ${target.label} ${row.id}: no order (${result?.skipped ?? result?.error ?? "unknown"})`
+            )
+          }
+        } catch (e: any) {
+          t.failed++
           logger.error(
-            `[backfill-projections] ${row.id}: projection returned no order (${result?.skipped ?? result?.error ?? "unknown"})`
+            `[backfill-projections] ${target.label} ${row.id} failed: ${e?.message ?? e}`
           )
         }
-      } catch (e: any) {
-        failed++
-        logger.error(
-          `[backfill-projections] ${row.id} failed: ${e?.message ?? e}`
-        )
       }
+
+      if (onlyOrderId) break
+      skip += PAGE
     }
 
-    if (onlyOrderId) break
-    skip += PAGE
+    logger.info(
+      `[backfill-projections] ${target.entity}: scanned=${t.scanned} alreadyProjected=${t.alreadyProjected} ` +
+        `candidates=${t.candidates} (assigned=${t.candidatesAssigned} unassigned=${t.candidatesUnassigned}) ` +
+        `skippedScope=${t.skippedScope} projected=${t.projected} projectedAssigned=${t.projectedAssigned} failed=${t.failed}`
+    )
+    for (const k of Object.keys(grand) as (keyof typeof grand)[]) grand[k] += t[k]
   }
 
   logger.info(
     `[backfill-projections] DONE${apply ? "" : " (DRY RUN)"} — ` +
-      `scanned=${scanned} alreadyProjected=${alreadyProjected} ` +
-      `candidates=${candidates} (assigned=${candidatesAssigned} unassigned=${candidatesUnassigned}) ` +
-      `skippedScope=${skippedScope} projected=${projected} projectedAssigned=${projectedAssigned} failed=${failed}`
+      `scanned=${grand.scanned} alreadyProjected=${grand.alreadyProjected} ` +
+      `candidates=${grand.candidates} (assigned=${grand.candidatesAssigned} unassigned=${grand.candidatesUnassigned}) ` +
+      `skippedScope=${grand.skippedScope} projected=${grand.projected} projectedAssigned=${grand.projectedAssigned} failed=${grand.failed}`
   )
 }

--- a/apps/backend/src/scripts/backfill-unified-order-projections.ts
+++ b/apps/backend/src/scripts/backfill-unified-order-projections.ts
@@ -1,0 +1,151 @@
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { backfillInventoryOrderProjectionWorkflow } from "../workflows/inventory_orders/backfill-project-inventory-order"
+
+/**
+ * #445 / #342 T4 — PROJECTION backfill for legacy-only inventory orders.
+ *
+ * The link-only backfill (`backfill-unified-order-links.ts`) intentionally left
+ * pre-T2 rows that were never dual-written as legacy-only — the prod run on
+ * 2026-06-14 reported `noBackref=90`. Those orders (e.g. partner GOF's) don't
+ * appear under the unified `/orders` surface because they have no core `order`.
+ * This script mints the missing projection for each, reusing the create-path
+ * dual-write so semantics match exactly, and re-applies the partner D3 link +
+ * current status for assigned orders so partners see them in `/orders`.
+ *
+ * Candidate = inventory order with NO order↔inventory_order link AND NO
+ * `metadata.unified_order_id` backref. Anything already projected is skipped, so
+ * the script is safe to re-run (projected rows gain the link and drop out).
+ *
+ * DRY RUN BY DEFAULT. It only writes when you pass `apply`. medusa exec forwards
+ * positional args (not `--flags`); all of these also accept a `--` prefix:
+ *   npx medusa exec ./src/scripts/backfill-unified-order-projections.ts
+ *   npx medusa exec ./src/scripts/backfill-unified-order-projections.ts apply
+ *   npx medusa exec ./src/scripts/backfill-unified-order-projections.ts apply assigned-only
+ *   npx medusa exec ./src/scripts/backfill-unified-order-projections.ts apply partner=part_123
+ *   npx medusa exec ./src/scripts/backfill-unified-order-projections.ts apply order=inv_order_123
+ */
+
+const PAGE = 200
+
+export default async function backfillUnifiedOrderProjections({
+  container,
+  args,
+}: ExecArgs) {
+  const a: any = args ?? []
+  const tokens: string[] = (Array.isArray(a) ? a : Object.keys(a)).map(String)
+  const norm = tokens.map((t) => t.replace(/^--/, ""))
+  const has = (flag: string) => norm.some((t) => t === flag)
+  const valueOf = (key: string): string | undefined => {
+    const hit = norm.find((t) => t.startsWith(`${key}=`))
+    return hit ? hit.slice(key.length + 1) : undefined
+  }
+
+  const apply = has("apply")
+  const assignedOnly = has("assigned-only")
+  const onlyPartnerId = valueOf("partner")
+  const onlyOrderId = valueOf("order")
+
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+
+  logger.info(
+    `[backfill-projections] starting${apply ? " (APPLY — will create unified orders)" : " (DRY RUN — no writes)"}` +
+      `${assignedOnly ? " assigned-only" : ""}` +
+      `${onlyPartnerId ? ` partner=${onlyPartnerId}` : ""}` +
+      `${onlyOrderId ? ` order=${onlyOrderId}` : ""}`
+  )
+
+  let scanned = 0
+  let alreadyProjected = 0
+  let candidates = 0
+  let candidatesAssigned = 0
+  let candidatesUnassigned = 0
+  let projected = 0
+  let projectedAssigned = 0
+  let skippedScope = 0
+  let failed = 0
+
+  let skip = 0
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { data: rows } = await query.graph({
+      entity: "inventory_orders",
+      fields: ["id", "status", "order.id", "metadata", "partner.id"],
+      pagination: { take: PAGE, skip },
+      ...(onlyOrderId ? { filters: { id: onlyOrderId } } : {}),
+    })
+    if (!rows?.length) break
+
+    for (const row of rows as any[]) {
+      scanned++
+
+      // Already on the unified surface (link or transitional backref) → skip.
+      if (row?.order?.id || row?.metadata?.unified_order_id) {
+        alreadyProjected++
+        continue
+      }
+
+      const partnerId = Array.isArray(row.partner)
+        ? row.partner?.[0]?.id ?? null
+        : row.partner?.id ?? null
+      const isAssigned = Boolean(partnerId)
+
+      candidates++
+      if (isAssigned) candidatesAssigned++
+      else candidatesUnassigned++
+
+      // Scope filters
+      if (assignedOnly && !isAssigned) {
+        skippedScope++
+        continue
+      }
+      if (onlyPartnerId && partnerId !== onlyPartnerId) {
+        skippedScope++
+        continue
+      }
+
+      if (!apply) {
+        logger.info(
+          `[backfill-projections] DRY would project ${row.id} (status=${row.status}, ${isAssigned ? `partner=${partnerId}` : "unassigned"})`
+        )
+        continue
+      }
+
+      try {
+        const { result } = await backfillInventoryOrderProjectionWorkflow(
+          container
+        ).run({ input: { inventoryOrderId: row.id } })
+
+        if (result?.unified_order_id) {
+          projected++
+          if (isAssigned) projectedAssigned++
+          logger.info(
+            `[backfill-projections] projected ${row.id} → order ${result.unified_order_id}` +
+              `${isAssigned ? ` (partner ${partnerId})` : ""}`
+          )
+        } else {
+          failed++
+          logger.error(
+            `[backfill-projections] ${row.id}: projection returned no order (${result?.skipped ?? result?.error ?? "unknown"})`
+          )
+        }
+      } catch (e: any) {
+        failed++
+        logger.error(
+          `[backfill-projections] ${row.id} failed: ${e?.message ?? e}`
+        )
+      }
+    }
+
+    if (onlyOrderId) break
+    skip += PAGE
+  }
+
+  logger.info(
+    `[backfill-projections] DONE${apply ? "" : " (DRY RUN)"} — ` +
+      `scanned=${scanned} alreadyProjected=${alreadyProjected} ` +
+      `candidates=${candidates} (assigned=${candidatesAssigned} unassigned=${candidatesUnassigned}) ` +
+      `skippedScope=${skippedScope} projected=${projected} projectedAssigned=${projectedAssigned} failed=${failed}`
+  )
+}

--- a/apps/backend/src/workflows/inventory_orders/backfill-project-inventory-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/backfill-project-inventory-order.ts
@@ -1,0 +1,146 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+  when,
+} from "@medusajs/framework/workflows-sdk"
+import InventoryOrdersStockLocationsLink from "../../links/inventory-orders-stock-locations"
+import {
+  dualWriteUnifiedOrderStep,
+  mirrorPartnerLinkOnUnifiedOrderStep,
+  mirrorUnifiedOrderStatusStep,
+} from "./dual-write-unified-order"
+
+// #445 / #342 T4 — project a legacy-only inventory order onto the unified core
+// `order` surface AFTER the fact. The create-path projection
+// (`dualWriteUnifiedOrderStep`) only ran for orders created once dual-write
+// existed (T2+). The link-only T4 backfill
+// (`backfill-unified-order-links.ts`) deliberately left pre-T2 rows — the 90
+// `noBackref` rows from the 2026-06-14 prod run — legacy-only, so partners like
+// GOF can't see those orders under `/orders` (the unified surface). This
+// workflow rebuilds the SAME projection the create path would have produced,
+// from current DB state, reusing the exact same steps so semantics never drift.
+//
+// Idempotency is the CALLER's responsibility: only invoke this for orders that
+// have neither the order↔inventory_order link NOR a `metadata.unified_order_id`
+// backref — `dualWriteUnifiedOrderStep` is create-once (no link-existence guard)
+// and would otherwise mint a duplicate unified order. The backfill script
+// (`backfill-unified-order-projections.ts`) enforces that filter.
+
+type GatherResult = {
+  order: any
+  orderLines: any[]
+  input: {
+    stock_location_id: string
+    from_stock_location_id?: string
+    to_stock_location_id?: string
+    order_lines: { inventory_item_id: string; quantity: number; price: number }[]
+  }
+  partnerId: string | null
+}
+
+// Reconstruct the exact `{ order, orderLines, input }` shape the create-path
+// dual-write received, from the persisted legacy row + its module links.
+export const gatherLegacyProjectionInputStep = createStep(
+  "gather-legacy-projection-input",
+  async ({ inventoryOrderId }: { inventoryOrderId: string }, { container }) => {
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+    const { data: orders } = await query.graph({
+      entity: "inventory_orders",
+      fields: [
+        "*",
+        "orderlines.*",
+        "orderlines.inventory_items.*",
+        "partner.*",
+      ],
+      filters: { id: inventoryOrderId },
+    })
+    const order = orders?.[0]
+    if (!order) {
+      throw new Error(`inventory order ${inventoryOrderId} not found`)
+    }
+
+    // to/from stock locations live on the link's extra columns, so read the
+    // link entryPoint directly (same approach as list-single-inventory-order).
+    const { data: locLinks } = await query.graph({
+      entity: (InventoryOrdersStockLocationsLink as any).entryPoint,
+      fields: ["from_location", "to_location", "stock_location_id"],
+      filters: { inventory_orders_id: inventoryOrderId },
+    })
+    let toLocationId: string | undefined
+    let fromLocationId: string | undefined
+    for (const l of (locLinks as any[]) || []) {
+      if (l?.to_location && l?.stock_location_id) toLocationId = l.stock_location_id
+      if (l?.from_location && l?.stock_location_id) fromLocationId = l.stock_location_id
+    }
+
+    const orderLines = Array.isArray(order.orderlines) ? order.orderlines : []
+    // Same index alignment the create path relies on: dual-write maps
+    // orderLines[idx] ↔ input.order_lines[idx].
+    const order_lines = orderLines.map((ol: any) => ({
+      inventory_item_id: ol?.inventory_items?.[0]?.id,
+      quantity: Number(ol?.quantity),
+      price: Number(ol?.price),
+    }))
+
+    // inventory_orders → partner can be a list or a single depending on link
+    // directionality; normalise to a single id (work-orders have one partner).
+    const partnerId = Array.isArray(order.partner)
+      ? order.partner?.[0]?.id ?? null
+      : order.partner?.id ?? null
+
+    const result: GatherResult = {
+      order,
+      orderLines,
+      input: {
+        stock_location_id: (toLocationId ?? fromLocationId ?? "") as string,
+        to_stock_location_id: toLocationId,
+        from_stock_location_id: fromLocationId,
+        order_lines,
+      },
+      partnerId,
+    }
+    return new StepResponse(result)
+  }
+)
+
+export const backfillInventoryOrderProjectionWorkflow = createWorkflow(
+  { name: "backfill-inventory-order-projection", store: true },
+  (input: { inventoryOrderId: string }) => {
+    const prep = gatherLegacyProjectionInputStep(input)
+
+    // Same create-path projection: mint the unified order + the authoritative
+    // order↔inventory_order link (rolls back the order if the link fails).
+    const dw = dualWriteUnifiedOrderStep({
+      order: prep.order,
+      orderLines: prep.orderLines,
+      input: prep.input,
+    })
+
+    // Gating on `dw.unified_order_id` also FORCES ordering — these mirror steps
+    // resolve the unified order via the freshly-created link, so they must run
+    // after the projection, not race it.
+    when({ dw, prep }, ({ dw, prep }) =>
+      Boolean(dw?.unified_order_id) && Boolean(prep?.partnerId)
+    ).then(() => {
+      mirrorPartnerLinkOnUnifiedOrderStep({
+        inventoryOrderId: input.inventoryOrderId,
+        partnerId: prep.partnerId as unknown as string,
+      })
+    })
+
+    // Bring the unified order's status in line with the legacy row's CURRENT
+    // status (the partner mirror only stamps "assigned"). §5 map handles
+    // Processing/Shipped/Partial/Delivered → core status + partner_status.
+    when({ dw }, ({ dw }) => Boolean(dw?.unified_order_id)).then(() => {
+      mirrorUnifiedOrderStatusStep({ inventoryOrderId: input.inventoryOrderId })
+    })
+
+    return new WorkflowResponse(dw)
+  }
+)
+
+export default backfillInventoryOrderProjectionWorkflow


### PR DESCRIPTION
Closes #445.

## Diagnosis

GOF's inventory order doesn't appear under the new unified `/orders` surface because it was **never projected** onto the core `order` entity. Two facts pin it down:

1. The create-path projection (`dualWriteUnifiedOrderStep`) only runs for inventory orders created once dual-write existed (#342 T2+).
2. The T4 link-only backfill (`backfill-unified-order-links.ts`, PR #396) **deliberately** skips never-projected rows — the 2026-06-14 prod run logged `noBackref=90`. GOF's order is one of those 90 legacy-only rows (confirmed shape: old order, `metadata: null`, no `order` link).

The legacy `/partners/inventory-orders` shim still shows it, which is why it's visible there but not under unified `/orders`.

## Fix

A **projection** backfill (vs the existing link-only one) that rebuilds exactly what the create path would have produced, reusing the same steps so semantics can't drift:

- **`backfillInventoryOrderProjectionWorkflow`** — `gatherLegacyProjectionInputStep` reconstructs `{order, orderLines, input}` (lines + `inventory_item_id`, to/from stock locations, assigned partner) from current DB state, then:
  `dualWriteUnifiedOrderStep` → (when assigned) `mirrorPartnerLinkOnUnifiedOrderStep` → `mirrorUnifiedOrderStatusStep`. The `when(dw.unified_order_id)` gates double as ordering barriers so the mirrors resolve the freshly-created link instead of racing it.
- **`backfill-unified-order-projections.ts`** — **dry-run by default**, `apply` to write. Candidate = no order↔inventory_order link **and** no `metadata.unified_order_id` backref → idempotent (re-runs skip projected rows). Scope: `assigned-only`, `partner=<id>`, `order=<id>`.

## Local verification

`apply order=<id>` on one assigned legacy order (`Processing`):
- minted core order + **order↔inventory_order** link
- **partner↔order D3 link** `{partner_id, order_id}` → scopes it into the partner's unified `/orders`
- `unified_order_status.partner_status` = `in_progress`, core `order.status` = `pending` (§5 map)
- re-run → `alreadyProjected=1, projected=0` (idempotent)

## Prod rollout (after merge + deploy)

Script ships in the image, then via ECS run-task:
1. `... backfill-unified-order-projections.ts` (dry-run) → real candidate counts (assigned vs unassigned).
2. `... backfill-unified-order-projections.ts apply assigned-only` (recommended first — only orders a partner is waiting on; avoids resurrecting abandoned drafts as core orders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)