### PR TITLE
fix(admin): #421 — RegionPartnerCoverageWidget was on an invalid zone (never rendered)

### DIFF
--- a/apps/backend/src/admin/widgets/region-partner-coverage.tsx
+++ b/apps/backend/src/admin/widgets/region-partner-coverage.tsx
@@ -104,8 +104,12 @@ const RegionPartnerCoverageWidget = ({ data }: DetailWidgetProps<Region>) => {
   )
 }
 
+// The region detail page is single-column — the core dashboard only renders
+// `region.details.before` / `region.details.after` (there is no `.side.*` zone
+// for regions, unlike products). `region.details.side.after` silently never
+// mounted; `.after` places this supplementary panel below the region details. (#421)
 export const config = defineWidgetConfig({
-  zone: "region.details.side.after",
+  zone: "region.details.after",
 })
 
 export default RegionPartnerCoverageWidget


### PR DESCRIPTION
Closes #421.

`RegionPartnerCoverageWidget` was configured with `zone: "region.details.side.after"`, which isn't a real injection zone. The region detail page is single-column — the core dashboard (`@medusajs/dashboard`) only renders **`region.details.before`** and **`region.details.after`** for regions (the `.side.*` zones exist for the product detail page, which has a side column, not for regions). With an unknown zone the widget silently never mounted.

Fix: move it to **`region.details.after`** so the Partner-coverage panel renders below the region's own details (the conventional spot for a supplementary detail-page widget).

Verified the valid zone set directly against the installed dashboard:
```
$ grep -rohE "region\.details\.[a-z.]+" node_modules/@medusajs/dashboard
region.details.after
region.details.before
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)