### PR TITLE
fix(designs): #456 — persist material cost on admin recalc + stop per-unit cost double-multiply

### DIFF
--- a/apps/backend/integration-tests/http/production-run-complete-yield.spec.ts
+++ b/apps/backend/integration-tests/http/production-run-complete-yield.spec.ts
@@ -144,7 +144,7 @@ setupSharedTestSuite(() => {
 
     // ── Test: Per-unit cost type ────────────────────────────────────
 
-    it("should normalize per_unit cost to total on complete", async () => {
+    it("should store per_unit cost verbatim (raw), not normalized to total", async () => {
       const { adminHeaders, unique } = await setupTestData()
       const { partnerId, partnerHeaders } = await createPartner(unique)
       const { templateName } = await createTemplates(adminHeaders, unique)
@@ -163,7 +163,7 @@ setupSharedTestSuite(() => {
 
       await advanceToFinished(runId, partnerHeaders)
 
-      // Complete with per-unit cost: 500/piece × 7 produced = 3500 total
+      // Complete with per-unit cost: 500/piece (readers multiply by qty)
       const completeRes = await api.post(
         `/partners/production-runs/${runId}/complete`,
         {
@@ -176,8 +176,9 @@ setupSharedTestSuite(() => {
         { headers: partnerHeaders }
       )
       expect(completeRes.status).toBe(200)
-      // API normalizes per_unit to total: 500 × 7 = 3500
-      expect(completeRes.data.production_run.partner_cost_estimate).toBe(3500)
+      // Stored verbatim as the partner entered it (500/unit), paired with
+      // cost_type="per_unit"; readers multiply by quantity themselves. #456
+      expect(completeRes.data.production_run.partner_cost_estimate).toBe(500)
       expect(completeRes.data.production_run.cost_type).toBe("per_unit")
       expect(completeRes.data.production_run.produced_quantity).toBe(7)
     })
@@ -309,8 +310,8 @@ setupSharedTestSuite(() => {
       expect(completeRes.status).toBe(200)
       expect(completeRes.data.consumptions_logged).toBe(1)
       expect(completeRes.data.production_run.produced_quantity).toBe(7)
-      // 600 per unit × 7 produced = 4200 total
-      expect(completeRes.data.production_run.partner_cost_estimate).toBe(4200)
+      // Stored verbatim: 600/unit (cost_type records per_unit). #456
+      expect(completeRes.data.production_run.partner_cost_estimate).toBe(600)
       expect(completeRes.data.message).toContain("1 consumption(s) recorded")
     })
 
@@ -404,8 +405,8 @@ setupSharedTestSuite(() => {
       expect(adminDetail.data.production_run.rejected_quantity).toBe(1)
       expect(adminDetail.data.production_run.rejection_reason).toBe("sizing_error")
       expect(adminDetail.data.production_run.cost_type).toBe("per_unit")
-      // Normalized total: 450 × 9 = 4050
-      expect(adminDetail.data.production_run.partner_cost_estimate).toBe(4050)
+      // Stored verbatim: 450/unit (cost_type records per_unit). #456
+      expect(adminDetail.data.production_run.partner_cost_estimate).toBe(450)
     })
   })
 })

--- a/apps/backend/src/api/admin/designs/[id]/recalculate-cost/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/recalculate-cost/route.ts
@@ -22,12 +22,27 @@ export async function POST(
     return res.status(400).json({ error: "Failed to estimate cost", details: errors })
   }
 
-  // Update design with the new estimate
+  // Persist the full estimate back onto the design so readers of the stored
+  // cost fields (design cost panels, partner `GET .../cost`) surface the
+  // material + production breakdown — not just the total. Mirrors the partner
+  // recalculate route, which already persisted all of these. Previously this
+  // route stored only `estimated_cost`, so `material_cost`/`production_cost`/
+  // `cost_breakdown` stayed null on admin-owned designs and material cost
+  // never showed even when the linked BOM had a price. #456
   try {
     const designService = req.scope.resolve("design") as any
     await designService.updateDesigns({
       id: designId,
       estimated_cost: result.total_estimated,
+      material_cost: result.material_cost,
+      production_cost: result.production_cost,
+      cost_breakdown: {
+        items: result.breakdown?.materials ?? [],
+        production_percent: result.breakdown?.production_percent,
+        confidence: result.confidence,
+        calculated_at: new Date().toISOString(),
+        source: "admin_recalculate",
+      },
     })
   } catch {
     // Non-fatal — estimate was still calculated

--- a/apps/backend/src/workflows/designs/__tests__/estimate-design-cost.unit.spec.ts
+++ b/apps/backend/src/workflows/designs/__tests__/estimate-design-cost.unit.spec.ts
@@ -52,6 +52,18 @@ describe("computeCostBreakdown", () => {
       expect(result.total_estimated).toBe(35)
     })
 
+    it("prefers an actual production cost over the admin-estimate residual (#456)", () => {
+      const result = computeCostBreakdown({
+        ...base,
+        adminEstimate: 35,                 // would derive production = 35 - 25 = 10
+        materials: orderHistoryMaterials,  // material = 25
+        actualProductionCost: 50,          // partner's actual per-unit cost wins
+      })
+      expect(result.material_cost).toBe(25)
+      expect(result.production_cost).toBe(50)        // actual, not the 10 residual
+      expect(result.total_estimated).toBe(75)        // material + actual production
+    })
+
     it("clamps production to 0 when material cost exceeds admin estimate", () => {
       const result = computeCostBreakdown({
         ...base,
@@ -186,12 +198,22 @@ describe("computeCostBreakdown", () => {
       expect(result.confidence).toBe("estimated")
     })
 
-    it("never returns exact since productionIsEstimated is always true", () => {
-      // Even with all order_history materials and hasExactMaterialCosts=true,
-      // production is always estimated so confidence tops out at "estimated"
+    it("returns exact when materials are all exact and a concrete admin estimate sets production", () => {
+      // hasExactMaterialCosts + a concrete admin estimate (which makes
+      // production non-estimated) → confidence is "exact".
       const result = computeCostBreakdown({
         ...base,
         adminEstimate: 35,
+        materials: orderHistoryMaterials,
+        hasExactMaterialCosts: true,
+      })
+      expect(result.confidence).toBe("exact")
+    })
+
+    it("stays estimated when production is derived (no concrete estimate) even with exact materials", () => {
+      const result = computeCostBreakdown({
+        ...base,
+        adminEstimate: null,            // production falls to the 30% default → estimated
         materials: orderHistoryMaterials,
         hasExactMaterialCosts: true,
       })

--- a/apps/backend/src/workflows/designs/estimate-design-cost.ts
+++ b/apps/backend/src/workflows/designs/estimate-design-cost.ts
@@ -94,6 +94,13 @@ export function computeCostBreakdown(input: {
   materials: MaterialCostItem[];
   hasExactMaterialCosts: boolean;
   similarDesigns: Array<{ id: string; name: string; estimated_cost: number }>;
+  /**
+   * Per-unit production cost taken from the latest completed production run
+   * (the partner's actual submitted cost). When present it wins over any
+   * derived figure — an actual cost is more authoritative than an estimate
+   * residual. #456
+   */
+  actualProductionCost?: number | null;
 }): EstimateCostOutput {
   const materialCost = input.materials.reduce((sum, m) => sum + m.cost * m.quantity, 0);
   const { adminEstimate, similarDesigns } = input;
@@ -102,7 +109,12 @@ export function computeCostBreakdown(input: {
   let productionPercent: number;
   let productionIsEstimated = true;
 
-  if (adminEstimate != null && adminEstimate > 0 && materialCost > 0) {
+  if (input.actualProductionCost != null && input.actualProductionCost > 0) {
+    // A real, partner-submitted production cost from a completed run wins.
+    productionCost = input.actualProductionCost;
+    productionPercent = materialCost > 0 ? (productionCost / materialCost) * 100 : 0;
+    productionIsEstimated = false;
+  } else if (adminEstimate != null && adminEstimate > 0 && materialCost > 0) {
     productionCost = Math.max(0, adminEstimate - materialCost);
     productionPercent = (productionCost / materialCost) * 100;
     productionIsEstimated = false; // admin set a concrete estimate
@@ -458,6 +470,39 @@ const findSimilarDesignsStep = createStep(
   }
 );
 
+// ─── Step 3b: Resolve actual production cost from the latest completed run ─────
+// The partner's submitted cost on a completed (non-sample) run is the most
+// authoritative production-cost signal — prefer it over any derived estimate.
+// partner_cost_estimate is stored raw + paired with cost_type, so a "total"
+// is divided back to a per-unit figure (the estimate works per finished unit).
+const getActualProductionCostStep = createStep(
+  "get-actual-production-cost-step",
+  async (input: { design_id: string }, { container }) => {
+    let perUnit: number | null = null;
+    try {
+      // Resolve by registration key (string) to avoid importing the module
+      // entrypoint into this file — its pure functions are unit-tested without
+      // a Medusa runtime, and the module import would pull in model.define().
+      const service = container.resolve("production_runs") as any;
+      const runs = await service.listProductionRuns(
+        { design_id: input.design_id, status: "completed" },
+        { order: { completed_at: "DESC" }, take: 50 }
+      );
+      for (const r of runs || []) {
+        if (r.run_type === "sample") continue;
+        const est = Number(r.partner_cost_estimate);
+        if (!est || est <= 0) continue;
+        const qty = Number(r.produced_quantity) || Number(r.quantity) || 1;
+        perUnit = r.cost_type === "per_unit" ? est : qty > 0 ? est / qty : est;
+        break;
+      }
+    } catch {
+      // Non-fatal — production runs module may be unavailable or none exist.
+    }
+    return new StepResponse({ actualProductionCostPerUnit: perUnit });
+  }
+);
+
 // ─── Step 4: Calculate total cost estimate ────────────────────────────────────
 
 const calculateTotalCostStep = createStep(
@@ -467,6 +512,7 @@ const calculateTotalCostStep = createStep(
     materials: MaterialCostItem[];
     hasExactMaterialCosts: boolean;
     similarDesigns: Array<{ id: string; name: string; estimated_cost: number }>;
+    actualProductionCostPerUnit?: number | null;
   }) => {
     const design = input.design;
 
@@ -508,6 +554,7 @@ const calculateTotalCostStep = createStep(
       materials: input.materials,
       hasExactMaterialCosts: input.hasExactMaterialCosts,
       similarDesigns: input.similarDesigns,
+      actualProductionCost: input.actualProductionCostPerUnit ?? null,
     });
     return new StepResponse(result);
   }
@@ -536,6 +583,10 @@ export const estimateDesignCostWorkflow = createWorkflow(
       design: designResult.design,
     });
 
+    const actualCostResult = getActualProductionCostStep({
+      design_id: input.design_id,
+    });
+
     const result = calculateTotalCostStep({
       design: designResult.design,
       materials: materialsResult.materials as unknown as MaterialCostItem[],
@@ -545,6 +596,8 @@ export const estimateDesignCostWorkflow = createWorkflow(
         name: string;
         estimated_cost: number;
       }>,
+      actualProductionCostPerUnit:
+        actualCostResult.actualProductionCostPerUnit as unknown as number | null,
     });
 
     return new WorkflowResponse(result);

--- a/apps/backend/src/workflows/production-runs/complete-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/complete-production-run.ts
@@ -122,7 +122,7 @@ type CompleteRunData = {
   rejected_quantity?: number
   rejection_reason?: string
   rejection_notes?: string
-  normalized_cost_estimate?: number
+  cost_estimate?: number
   cost_type?: "per_unit" | "total"
   notes?: string
 }
@@ -154,7 +154,7 @@ const completeRunWithLockStep = createStep(
         ...(input.rejected_quantity != null ? { rejected_quantity: input.rejected_quantity } : {}),
         ...(input.rejection_reason ? { rejection_reason: input.rejection_reason } : {}),
         ...(input.rejection_notes ? { rejection_notes: input.rejection_notes } : {}),
-        ...(input.normalized_cost_estimate ? { partner_cost_estimate: input.normalized_cost_estimate } : {}),
+        ...(input.cost_estimate ? { partner_cost_estimate: input.cost_estimate } : {}),
         ...(input.cost_type ? { cost_type: input.cost_type } : {}),
         ...(input.notes ? { completion_notes: input.notes } : {}),
       })
@@ -338,26 +338,25 @@ export const completeProductionRunWorkflow = createWorkflow(
 
     const consumptionResult = logConsumptionsStep(consumptionInput)
 
-    // Normalize cost
-    const completeData = transform({ run, input }, (data) => {
-      const r = data.run as any
-      const runQuantity = r.quantity || 1
-      const effectiveProduced = data.input.produced_quantity ?? runQuantity
-      let normalizedCost = data.input.partner_cost_estimate
-      if (normalizedCost && data.input.cost_type === "per_unit") {
-        normalizedCost = Math.round(normalizedCost * effectiveProduced * 100) / 100
-      }
-      return {
-        production_run_id: data.input.production_run_id,
-        produced_quantity: data.input.produced_quantity,
-        rejected_quantity: data.input.rejected_quantity,
-        rejection_reason: data.input.rejection_reason,
-        rejection_notes: data.input.rejection_notes,
-        normalized_cost_estimate: normalizedCost,
-        cost_type: data.input.cost_type,
-        notes: data.input.notes,
-      }
-    })
+    // Cost is stored verbatim as the partner entered it, paired with
+    // cost_type. Every reader — the cost-summary route, the partner
+    // production-run-card, and the unified-order dual-write — treats
+    // partner_cost_estimate as a raw figure matching cost_type (a "per_unit"
+    // value is per-unit; a "total" value is a total) and multiplies by
+    // quantity itself when needed. Previously this step normalized per_unit
+    // → total while leaving cost_type="per_unit", so every reader re-
+    // multiplied by quantity (e.g. 850/unit → stored 7650 → shown 7650×9 =
+    // 68850 instead of 850×9 = 7650). #456
+    const completeData = transform({ run, input }, (data) => ({
+      production_run_id: data.input.production_run_id,
+      produced_quantity: data.input.produced_quantity,
+      rejected_quantity: data.input.rejected_quantity,
+      rejection_reason: data.input.rejection_reason,
+      rejection_notes: data.input.rejection_notes,
+      cost_estimate: data.input.partner_cost_estimate,
+      cost_type: data.input.cost_type,
+      notes: data.input.notes,
+    }))
 
     completeRunWithLockStep(completeData)
 

--- a/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
+++ b/apps/docs/notes/PLATFORM_ROADMAP_2026_05.md
@@ -701,6 +701,28 @@ helper restore, +0.5 day for the link/affordance UI.
 
 ### Infrastructure / SaaS posture
 
+#### 33. Admin "data-plumbing" tools — safe, API-driven data corrections (GitHub #457)
+
+Recurring pattern: a code fix prevents recurrence, but already-stored
+rows still need a targeted, safe correction — and today that's only
+doable via raw `curl` against prod (SSM admin token) or one-off
+`medusa exec` ECS run-task scripts. Motivated by #456 (design material
+cost not persisted; per-unit production cost displayed double as
+`7650 × 9 = 68850`), whose data tail needed a manual `PATCH` on the run
+plus a design recalculate.
+**What:** an admin Ops/Data-tools console exposing guarded maintenance
+actions — recalculate design cost, correct a run's
+`partner_cost_estimate`/`cost_type` (with a live "per-unit × qty = total"
+preview), trigger the existing backfills
+(`backfill-inventory-unit-cost`, `backfill-design-energy-costs`),
+re-project/repair legacy rows. Each action: dry-run preview → confirm →
+idempotent apply → audit log. API-driven (so it's scriptable too), not
+UI-only.
+**First step:** surface `POST /admin/designs/:id/recalculate-cost` +
+the run cost edit as the first two actions behind a small
+"maintenance jobs" registry, then fold in the ECS backfill scripts.
+**Effort:** 2-3 days for the framework + first 2-3 actions.
+
 #### 10. Dedicated instance per partner (Pro tier)
 
 Already scoped in `project_medusa_saas_vision.md` + `SAAS_TIERS.md`.


### PR DESCRIPTION
Fixes #456. Two bugs on partner-submitted design `01KMDCWAKKXQAQGCT3XQGY8MB8`.

## Bug A — material cost never showed
`POST /admin/designs/:id/recalculate-cost` persisted **only** `estimated_cost`, discarding the `material_cost` / `production_cost` / `cost_breakdown` the estimate workflow computed. Admin-owned designs (`owner_partner_id = null`) recalc through this route, so `design.material_cost` stayed `null` even though the linked raw material ("White Stripes Fabric") carries `unit_cost: 246.4`. The **partner** route already persisted all of these — the admin route now mirrors it.

## Bug B — per-unit cost displayed double (`7650 × 9 = 68850`)
The partner entered **850/unit**. `complete-production-run.ts` normalized per_unit→total (`850 × 9 = 7650`) into `partner_cost_estimate` but kept `cost_type: "per_unit"`. The admin cost-form/PATCH writer **and all three readers** (cost-summary route, partner production-run-card, unified-order dual-write) treat `partner_cost_estimate` as a *raw* figure paired with `cost_type`, so they re-multiplied by quantity. Removed the normalization — the value is stored verbatim as entered, consistent with every reader. Card now shows `850 × 9 = 7650`. No frontend change needed.

## Also
- The estimate now sources production cost from the latest completed (non-sample) run's **actual** submitted cost, so a recalculate preserves the partner's real production cost (850) instead of overwriting it with the admin-estimate residual (≈753.6).
- Corrected a pre-existing stale confidence unit test (`never returns exact…`) that was already red on `main`.

## Tests
- `estimate-design-cost.unit.spec.ts` — 31/31 pass (added actual-cost-override + split confidence cases).
- Updated 3 assertions in `production-run-complete-yield.spec.ts` to expect raw (un-normalized) values.
- Typecheck clean on changed files.

## Data tail (manual, after deploy)
Already-stored rows don't self-correct — handled out of band via the admin API:
- `PATCH /admin/production-runs/prod_run_01KMQ7SFAFV4AV7EJZADNG7D5W` → `partner_cost_estimate: 850`.
- Recalculate design `01KMDCWAKKXQAQGCT3XQGY8MB8` to populate material cost.

## Roadmap
Filed #457 (`[#33]`) for first-class admin **data-plumbing tools** so these corrections stop requiring raw API/ECS scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)