### PR TITLE
fix(admin/desk): #420 — recover dead routes, native segmented tabs, fix theme tokens

### DIFF
--- a/apps/backend/src/admin/routes/desk/DeskRouteFallback.tsx
+++ b/apps/backend/src/admin/routes/desk/DeskRouteFallback.tsx
@@ -1,0 +1,58 @@
+import { Button, Heading, Text } from "@medusajs/ui"
+import { ArrowUpRightOnBox, ArrowUturnLeft, ExclamationCircle } from "@medusajs/icons"
+import { useLocation, useNavigate } from "react-router-dom"
+
+/**
+ * Catch-all rendered inside an EntityPanel when the tab's MemoryRouter
+ * navigates to a path the panel doesn't register (e.g. a design links out
+ * to an Order or Product, which live outside the Designs route subtree).
+ *
+ * Without this, an unmatched route renders nothing — the panel goes blank
+ * and the only recovery is closing and reopening the tab. Here we keep the
+ * tab alive and offer two ways out: step back inside the tab, or open the
+ * page in the full admin (a normal browser tab outside the workspace).
+ */
+export const DeskRouteFallback = ({
+  entityLabel,
+}: {
+  entityLabel: string
+}) => {
+  const location = useLocation()
+  const navigate = useNavigate()
+
+  const adminUrl = `${window.location.origin}/app${location.pathname}${location.search}`
+
+  return (
+    <div className="flex h-full items-center justify-center p-6">
+      <div className="flex max-w-md flex-col items-center gap-y-3 text-center">
+        <div className="text-ui-fg-muted">
+          <ExclamationCircle />
+        </div>
+        <Heading level="h2">Not available in Desk</Heading>
+        <Text size="small" className="text-ui-fg-subtle">
+          The {entityLabel} tab can&apos;t open{" "}
+          <span className="font-mono text-ui-fg-base">{location.pathname}</span>{" "}
+          inside the workspace. Go back, or open it in the full admin.
+        </Text>
+        <div className="mt-2 flex gap-x-2">
+          <Button
+            variant="secondary"
+            size="small"
+            onClick={() => navigate(-1)}
+          >
+            <ArrowUturnLeft />
+            Go back
+          </Button>
+          <Button
+            variant="primary"
+            size="small"
+            onClick={() => window.open(adminUrl, "_blank", "noopener,noreferrer")}
+          >
+            <ArrowUpRightOnBox />
+            Open in full admin
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/backend/src/admin/routes/desk/EntityPanel.tsx
+++ b/apps/backend/src/admin/routes/desk/EntityPanel.tsx
@@ -10,6 +10,7 @@ import {
   useNavigate,
 } from "react-router-dom"
 import { clearTabState, setTabState } from "./active-tab-store"
+import { DeskRouteFallback } from "./DeskRouteFallback"
 
 /**
  * Resets React Router's location, navigation, and route contexts so a
@@ -107,14 +108,15 @@ export const EntityPanel = ({
 }) => {
   const initial =
     initialPath || config.initialPath || config.routes[0]?.path || "/"
-  // Outer wrapper takes the full FlexLayout panel height and provides the
-  // panel background, so any natural-height inner page (Medusa Containers
-  // sized to their content) renders against a solid colour all the way to
-  // the panel bottom rather than leaving an awkward empty band. The inner
-  // wrapper is min-h-full so a tall page still scrolls naturally.
+
+  // The panel takes the full FlexLayout tab height and scrolls its content.
+  // `bg-ui-bg-subtle` matches the admin's standard page surface so the page's
+  // own white cards stand out instead of floating on raw white. `pt-4 px-3`
+  // gives the content breathing room from the tab strip and pane edges rather
+  // than butting flush against them. `min-h-full` lets a tall page grow.
   return (
-    <div className="h-full overflow-auto bg-ui-bg-base">
-      <div className="min-h-full">
+    <div className="h-full overflow-auto bg-ui-bg-subtle">
+      <div className="min-h-full pt-4 px-3 pb-3">
         <RouterReset>
           <MemoryRouter initialEntries={[initial]}>
             <TabStatePublisher
@@ -122,7 +124,13 @@ export const EntityPanel = ({
               entityKey={entityKey}
               entityLabel={entityLabel}
             />
-            <Routes>{config.routes.map(renderRoute)}</Routes>
+            <Routes>
+              {config.routes.map(renderRoute)}
+              <Route
+                path="*"
+                element={<DeskRouteFallback entityLabel={entityLabel} />}
+              />
+            </Routes>
           </MemoryRouter>
         </RouterReset>
       </div>

--- a/apps/backend/src/admin/routes/desk/desk.css
+++ b/apps/backend/src/admin/routes/desk/desk.css
@@ -10,107 +10,115 @@
 
 /* ── Root + content surfaces ──────────────────────────────────────── */
 .flexlayout__layout {
-  --color-text: var(--ui-fg-base);
-  --color-background: var(--ui-bg-base);
-  --color-base: var(--ui-bg-base);
-  --color-1: var(--ui-bg-base);
-  --color-2: var(--ui-bg-subtle);
-  --color-3: var(--ui-bg-component);
-  --color-4: var(--ui-bg-component-hover);
-  --color-6: var(--ui-bg-base);
-  --color-drag1: var(--ui-fg-interactive);
-  --color-drag2: var(--ui-fg-interactive);
-  --color-drag1-background: var(--ui-bg-component-hover);
-  --color-drag2-background: var(--ui-bg-component-hover);
+  --color-text: var(--fg-base);
+  --color-background: var(--bg-base);
+  --color-base: var(--bg-base);
+  --color-1: var(--bg-base);
+  --color-2: var(--bg-subtle);
+  --color-3: var(--bg-component);
+  --color-4: var(--bg-component-hover);
+  --color-6: var(--bg-base);
+  --color-drag1: var(--fg-interactive);
+  --color-drag2: var(--fg-interactive);
+  --color-drag1-background: var(--bg-component-hover);
+  --color-drag2-background: var(--bg-component-hover);
 
   font-family: inherit;
-  color: var(--ui-fg-base);
-  background-color: var(--ui-bg-base);
+  color: var(--fg-base);
+  background-color: var(--bg-base);
 }
 
 .flexlayout__tab {
-  background-color: var(--ui-bg-base);
-  color: var(--ui-fg-base);
+  background-color: var(--bg-base);
+  color: var(--fg-base);
   overflow: auto;
-  /* Divider between the tab strip and the panel content. Matches the
-     Container's divide-y stroke color (--ui-border-base) so the two
-     seams above and below the tab strip read as the same kind of line. */
-  border-top: 1px solid var(--ui-border-base);
+  /* The strip↔content divider lives on the tab bar's border-bottom (see
+     .flexlayout__tabset_tabbar_outer) so the active macOS-style tab can sit
+     flush against it. No border here, or we'd draw a double line. */
 }
 
 /* Outline every docked pane so the split structure is obvious. */
 .flexlayout__tabset {
-  background-color: var(--ui-bg-base);
+  background-color: var(--bg-base);
 }
 
 /* ── Tab bar ──────────────────────────────────────────────────────── */
 .flexlayout__tabset_tabbar_outer {
-  background-color: var(--ui-bg-subtle);
-  /* No bottom border here — the divider lives on .flexlayout__tab below
-     so it uses the same token and weight as the Container's divide-y
-     above. Having the border on the strip risked it disappearing in
-     dark mode because --ui-border-strong has very low contrast against
-     --ui-bg-subtle there. */
-  min-height: 36px;
-  height: 36px;
+  background-color: var(--bg-subtle);
+  /* Fine dashed divider spanning the full width under the tab rail. The
+     active tab covers its slice of this line (see --selected below) so it
+     reads as "connected" to the pane — the macOS/Safari tab effect. */
+  border-bottom: 1px dashed var(--border-base);
+  min-height: 38px;
+  height: 38px;
 }
 
 .flexlayout__tabset_tabbar_inner {
-  padding-left: 8px;
+  align-items: stretch;
 }
 
-/* ── Tab buttons ──────────────────────────────────────────────────── */
+/* Hairline border framing the whole segmented run of tabs. */
+.flexlayout__tabset_tabbar_inner_tab_container {
+  align-items: stretch;
+}
+
+/* ── Tab buttons — mirror Medusa UI <ProgressTabs.Trigger> ────────── */
 /*
- * Visual hierarchy:
- *  - Inactive tabs blend into the bg-subtle strip (transparent border,
- *    matching background) so they read as "labels on the rail" — no
- *    competing edges
- *  - Hover lifts a tab onto bg-base with a strong border, giving a
- *    discrete, clearly-bounded affordance
- *  - The selected tab raises off the strip onto bg-base with the
- *    dark-mode-aware elevation token, so exactly one pill at any time
- *    reads as "this is what you're looking at"
- *
- * Tabs are separated by a 4px gap (instead of the prior negative-margin
- * connected-cells trick) — each pill is its own discrete object with
- * unambiguous start/end edges.
+ * Styled to match the segmented tab component Medusa UI ships
+ * (ProgressTabs.Trigger): full-height segments on a subtle rail, a single
+ * hairline (border-right) between each, muted text, and the active tab
+ * flipped to the base surface. No elevation shadow — exactly like the
+ * native component, so nothing floats "on top" of the rail.
  */
 .flexlayout__tab_button {
   font-size: 12px;
-  font-weight: 600;
-  height: 28px;
-  margin: 4px 2px 4px 2px;
-  padding: 0 10px;
+  font-weight: 500;
+  height: 38px;
+  margin: 0;
+  /* Slightly tighter on the left (where the × badge sits) + a wider gap so
+     the badge reads as a distinct element set a bit away from the label. */
+  padding: 0 16px 0 12px;
+  /* Cap tab width so a long title ("Production Runs 3") can't balloon and
+     crowd the strip; the label truncates with an ellipsis instead. */
+  max-width: 200px;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  background-color: transparent;
-  color: var(--ui-fg-subtle);
-  border: 1px solid transparent;
-  border-radius: 4px;
+  gap: 10px;
+  background-color: var(--bg-subtle);
+  color: var(--fg-muted);
+  border: 0;
+  border-right: 1px solid var(--border-base);
+  border-radius: 0;
   cursor: pointer;
   user-select: none;
   transition:
     color 120ms ease,
-    background-color 120ms ease,
-    border-color 120ms ease,
-    box-shadow 120ms ease;
+    background-color 120ms ease;
+}
+
+/* Leading hairline so the first segment is bounded on both sides. */
+.flexlayout__tab_button:first-child {
+  border-left: 1px solid var(--border-base);
 }
 
 .flexlayout__tab_button--unselected:hover {
-  color: var(--ui-fg-base);
-  background-color: var(--ui-bg-base);
-  border-color: var(--ui-border-strong);
+  color: var(--fg-base);
+  background-color: var(--bg-subtle-hover);
 }
 
 .flexlayout__tab_button--selected {
-  background-color: var(--ui-bg-base);
-  color: var(--ui-fg-base);
-  border-color: var(--ui-border-strong);
-  box-shadow: var(--elevation-card-rest);
+  background-color: var(--bg-base);
+  color: var(--fg-base);
+  font-weight: 600;
+  /* Cover the rail's dashed divider beneath so the active tab merges into
+     the pane below it (the Safari/Finder connected-tab effect). */
+  margin-bottom: -1px;
+  height: 39px;
 }
 
 .flexlayout__tab_button_content {
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -125,31 +133,63 @@
   min-width: 80px;
   padding: 0 8px;
   border-radius: 6px;
-  border: 1px solid var(--ui-border-base);
-  background-color: var(--ui-bg-field);
-  color: var(--ui-fg-base);
+  border: 1px solid var(--border-base);
+  background-color: var(--bg-field);
+  color: var(--fg-base);
   outline: none;
 }
 
 .flexlayout__tab_button_textbox:focus {
-  border-color: var(--ui-border-interactive);
-  box-shadow: 0 0 0 2px rgb(from var(--ui-border-interactive) r g b / 0.2);
+  border-color: var(--border-interactive);
+  box-shadow: 0 0 0 2px rgb(from var(--border-interactive) r g b / 0.2);
 }
 
-/* close (×) button on each tab */
+/*
+ * close button — a solid Medusa XCircleSolid icon docked on the LEFT of
+ * the label (macOS/Safari placement). `order: -1` moves it ahead of the
+ * tab content; it's always rendered as a fixed slot so hovering never
+ * resizes the tab and shifts the strip. It's a muted badge by default and
+ * brightens on hover.
+ */
 .flexlayout__tab_button_trailing {
-  width: 14px;
-  height: 14px;
-  margin-left: 2px;
-  border-radius: 4px;
-  color: var(--ui-fg-muted);
-  opacity: 0.7;
+  order: -1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  margin: 0;
+  border-radius: 9999px;
+  /* Explicit colour in every state so the solid icon (fill: currentColor)
+     never inherits the tab's hover text-colour and washes out on the
+     white active tab. */
+  color: var(--fg-muted);
+  opacity: 1;
+  /* Always visible — FlexLayout's default hides the close on inactive,
+     un-hovered tabs (so it appeared "only on hover"). We want it as a
+     persistent badge on every tab. */
+  visibility: visible;
+  transition: color 120ms ease, background-color 120ms ease;
+}
+
+.flexlayout__tab_button_trailing svg {
+  width: 18px;
+  height: 18px;
+}
+
+/* Active tab is white — keep the badge a clearly-visible subtle grey. */
+.flexlayout__tab_button--selected .flexlayout__tab_button_trailing {
+  color: var(--fg-subtle);
+}
+
+/* Hovering the badge itself: darkest + a faint halo, never lighter. */
+.flexlayout__tab_button:hover .flexlayout__tab_button_trailing {
+  color: var(--fg-subtle);
 }
 
 .flexlayout__tab_button_trailing:hover {
-  background-color: var(--ui-bg-base-pressed);
-  color: var(--ui-fg-base);
-  opacity: 1;
+  color: var(--fg-base);
+  background-color: var(--bg-base-pressed);
 }
 
 /* ── Toolbar / sticky buttons (the "+" picker lives here) ─────────── */
@@ -164,15 +204,15 @@
 .flexlayout__tab_toolbar_button {
   background: transparent;
   border: 0;
-  color: var(--ui-fg-muted);
+  color: var(--fg-muted);
   border-radius: 4px;
   padding: 2px;
   cursor: pointer;
 }
 
 .flexlayout__tab_toolbar_button:hover {
-  background-color: var(--ui-bg-base-hover);
-  color: var(--ui-fg-base);
+  background-color: var(--bg-base-hover);
+  color: var(--fg-base);
 }
 
 /* ── Splitters between panes ──────────────────────────────────────── */
@@ -184,59 +224,59 @@
  * handle reads at a glance.
  */
 .flexlayout__splitter {
-  background-color: var(--ui-border-strong);
+  background-color: var(--border-strong);
   background-clip: padding-box;
-  border-left: 1px solid var(--ui-border-base);
-  border-right: 1px solid var(--ui-border-base);
+  border-left: 1px solid var(--border-base);
+  border-right: 1px solid var(--border-base);
 }
 
 .flexlayout__splitter_horz {
   border-left: 0;
   border-right: 0;
-  border-top: 1px solid var(--ui-border-base);
-  border-bottom: 1px solid var(--ui-border-base);
+  border-top: 1px solid var(--border-base);
+  border-bottom: 1px solid var(--border-base);
 }
 
 .flexlayout__splitter:hover,
 .flexlayout__splitter_drag {
-  background-color: var(--ui-fg-interactive);
+  background-color: var(--fg-interactive);
 }
 
 /* ── Drag-and-drop overlay rectangles ─────────────────────────────── */
 .flexlayout__outline_rect {
-  border: 2px solid var(--ui-fg-interactive);
-  background-color: rgb(from var(--ui-fg-interactive) r g b / 0.08);
+  border: 2px solid var(--fg-interactive);
+  background-color: rgb(from var(--fg-interactive) r g b / 0.08);
   border-radius: 6px;
 }
 
 .flexlayout__outline_rect_edge {
-  border: 2px dashed var(--ui-fg-interactive);
+  border: 2px dashed var(--fg-interactive);
   border-radius: 6px;
 }
 
 /* ── Overflow menu (when tabs don't fit) ──────────────────────────── */
 .flexlayout__popup_menu_container {
-  background-color: var(--ui-bg-component);
-  border: 1px solid var(--ui-border-base);
+  background-color: var(--bg-component);
+  border: 1px solid var(--border-base);
   border-radius: 6px;
-  box-shadow: var(--shadow-elevation-flyout, 0 4px 12px rgba(0, 0, 0, 0.08));
+  box-shadow: var(--elevation-flyout, 0 4px 12px rgba(0, 0, 0, 0.08));
   font-size: 12px;
-  color: var(--ui-fg-base);
+  color: var(--fg-base);
 }
 
 .flexlayout__popup_menu_item:hover {
-  background-color: var(--ui-bg-base-hover);
+  background-color: var(--bg-base-hover);
 }
 
 /* ── Empty-tabset placeholder text ────────────────────────────────── */
 .flexlayout__tabset-empty {
-  background-color: var(--ui-bg-base);
+  background-color: var(--bg-base);
 }
 
 /* ── Border (sidebars docked to layout edges, if used later) ──────── */
 .flexlayout__border {
-  background-color: var(--ui-bg-subtle);
-  border-color: var(--ui-border-base);
-  color: var(--ui-fg-subtle);
+  background-color: var(--bg-subtle);
+  border-color: var(--border-base);
+  color: var(--fg-subtle);
   font-size: 12px;
 }

--- a/apps/backend/src/admin/routes/desk/page.tsx
+++ b/apps/backend/src/admin/routes/desk/page.tsx
@@ -1,5 +1,5 @@
 import { defineRouteConfig } from "@medusajs/admin-sdk"
-import { GridLayout } from "@medusajs/icons"
+import { GridLayout, XCircleSolid } from "@medusajs/icons"
 import { Container, Heading, Text } from "@medusajs/ui"
 import {
   Action,
@@ -254,37 +254,9 @@ const Desk = () => {
     return () => window.removeEventListener(DESK_ADD_PANEL_EVENT, handler)
   }, [addPanel])
 
-  /**
-   * Keyboard shortcut: Alt+W (Option+W on Mac) closes the active tab.
-   * Cmd+W is hijacked by every browser, so Alt+W is the next-best
-   * muscle memory borrowed from IDE-style tab UX. We ignore the event
-   * when an input/textarea/contenteditable is focused so typing "w"
-   * inside a form doesn't nuke the tab.
-   */
-  useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== "w" && e.key !== "W") return
-      if (!e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return
-      const target = e.target as HTMLElement | null
-      if (target) {
-        const tag = target.tagName
-        if (
-          tag === "INPUT" ||
-          tag === "TEXTAREA" ||
-          tag === "SELECT" ||
-          target.isContentEditable
-        ) {
-          return
-        }
-      }
-      const activeTabId = model.getActiveTabset()?.getSelectedNode()?.getId()
-      if (!activeTabId) return
-      e.preventDefault()
-      model.doAction(Actions.deleteTab(activeTabId))
-    }
-    window.addEventListener("keydown", onKeyDown)
-    return () => window.removeEventListener("keydown", onKeyDown)
-  }, [model])
+  // No global close-tab keyboard shortcut: Alt+W (Option+W) collided with
+  // browser/OS tab handling on macOS Safari and could close the whole
+  // browser tab. The per-tab × close button is the close affordance.
 
   /**
    * On every model action: update hasTabs (derived state), mirror the
@@ -333,11 +305,11 @@ const Desk = () => {
     [addPanel, resetWorkspace]
   )
 
-  // Wrap in the Medusa-canonical Container pattern (see /admin/content +
-  // /admin/medias for prior art): `divide-y p-0` gives an auto-divider
-  // between the heading section and the workspace area below. The tab
-  // strip then naturally appears immediately under the divider, which is
-  // the "post-divider" position the user expected.
+  // Header ⇄ tab-strip swap: the "Desk" heading + description only show
+  // while the workspace is empty. As soon as a tab exists the heading is
+  // dropped and the FlexLayout tab strip rises into that top slot — the
+  // tabs *become* the header row, reclaiming the vertical space (the
+  // admin breadcrumb already says "Desk · {entity} · {path}").
   //
   // Layout must always be mounted so its onModelChange is wired and can
   // flip hasTabs to true when the first tab arrives. EmptyDesk is an
@@ -347,18 +319,21 @@ const Desk = () => {
       className="divide-y p-0 flex flex-col overflow-hidden"
       style={{ height: "calc(100vh - 56px)" }}
     >
-      <div className="px-6 py-4 shrink-0">
-        <Heading>Desk</Heading>
-        <Text size="small" className="text-ui-fg-subtle">
-          Multi-pane workspace. Drag tabs to split panes. Alt+W closes the active tab.
-        </Text>
-      </div>
+      {!hasTabs && (
+        <div className="px-6 py-4 shrink-0">
+          <Heading>Desk</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            Multi-pane workspace. Open entities as tabs and drag them to split panes.
+          </Text>
+        </div>
+      )}
       <div className="flex-1 min-h-0 relative">
         <Layout
           model={model}
           factory={factory}
           onModelChange={onModelChange}
           onRenderTabSet={onRenderTabSet}
+          icons={{ close: <XCircleSolid /> }}
         />
         {!hasTabs && (
           <div className="absolute inset-0 z-10 bg-ui-bg-base">


### PR DESCRIPTION
Closes #420.

## Problems (from #420 + this session)
- **Dead panel on "not sub-routed" links** — clicking a link to a route a panel doesn't register left a blank pane; recovery meant closing & reopening the tab.
- **"Opens new window / on top of the container"** — discussed; we kept Medusa's full-screen route modals as-is (reverted an in-panel-scoping experiment per request).
- **Tab strip polish** — flat pills, an elevated active tab that read as floating "on top", and an overflow dropdown that rendered **transparent** (extra tabs bled over the page).
- **Theme tokens silently dead** — `desk.css` used `var(--ui-*)` which don't exist; the real CSS variables are unprefixed.

## Changes
- **Recovery card** (`DeskRouteFallback`): catch-all `path="*"` in each panel → "Not available in Desk" with **Go back** + **Open in full admin**, instead of a dead pane.
- **macOS / Medusa-native tabs**: restyled to mirror `@medusajs/ui` `ProgressTabs.Trigger` — segmented, hairline separators, fine **dashed full-width divider** under the strip, **integrated active tab** (no elevation float). Solid **`XCircleSolid` close badge** docked left, always visible.
- **Overflow → solid dropdown**: extra tabs collapse into the `▾` menu (no more transparent overlap).
- **Root-cause fix**: renamed every `var(--ui-*)` → real `var(--bg-*/--fg-*/--border-*/--elevation-*)` (defined on `:root`). The `ui-` prefix only belongs on Tailwind classes. This is what made the dropdown transparent and the theme inert.
- **Panel surface** = `--bg-subtle` + content padding so pages read like normal admin pages, with breathing room below the tab strip.
- **Header ⇄ tab-strip swap**: heading shows only when empty; once tabs exist the strip takes the top slot.
- **Removed Alt+W** close shortcut (collided with macOS Safari tab handling).

## Verification
Manually verified with Playwright (Chromium + WebKit/Safari engine): recovery card renders on an unregistered route; overflow dropdown is solid (`--bg-component`); no tab overlap/wrap with 19+ tabs; no layout shift on hover; close badge visible at opacity 1 on active+hover in WebKit; empty vs tabs header-swap both correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)