### PR TITLE
feat(admin/desk): #420 follow-up — icons, content-derived names, ⌘⇧K palette, more entities

### DIFF
--- a/apps/backend/src/admin/routes/desk/CommandPalette.tsx
+++ b/apps/backend/src/admin/routes/desk/CommandPalette.tsx
@@ -1,0 +1,182 @@
+import { clx, Input, Text } from "@medusajs/ui"
+import { ArrowUpRightOnBox } from "@medusajs/icons"
+import {
+  ComponentType,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+import {
+  CORE_ENTITIES,
+  ENTITY_REGISTRY,
+  type EntityKey,
+} from "./EntityPicker"
+
+type IconType = ComponentType<{ className?: string }>
+
+type PaletteItem = {
+  id: string
+  label: string
+  hint: string
+  icon: IconType
+  external?: boolean
+  run: () => void
+}
+
+/**
+ * Desk command palette. Medusa's core admin owns Cmd-K (global search) and
+ * doesn't expose a way to register into it, so we bind our OWN palette to
+ * ⌘/Ctrl + Shift + K. It lists Desk entities (open as a tab) and Medusa
+ * core entities (open in the full admin). Mounted on the Desk shell —
+ * outside the per-tab MemoryRouters — so its hooks resolve normally and the
+ * shortcut is only live while the Desk is open.
+ */
+export const DeskCommandPalette = ({
+  onOpenEntity,
+  onOpenCore,
+}: {
+  onOpenEntity: (key: EntityKey) => void
+  onOpenCore: (path: string) => void
+}) => {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState("")
+  const [active, setActive] = useState(0)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (
+        (e.metaKey || e.ctrlKey) &&
+        e.shiftKey &&
+        (e.key === "k" || e.key === "K")
+      ) {
+        e.preventDefault()
+        setOpen((o) => !o)
+      } else if (e.key === "Escape") {
+        setOpen(false)
+      }
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
+    setQuery("")
+    setActive(0)
+    const id = requestAnimationFrame(() => inputRef.current?.focus())
+    return () => cancelAnimationFrame(id)
+  }, [open])
+
+  const items = useMemo<PaletteItem[]>(() => {
+    const tabs = (
+      Object.entries(ENTITY_REGISTRY) as [EntityKey, (typeof ENTITY_REGISTRY)[EntityKey]][]
+    ).map(([key, entity]) => ({
+      id: `tab:${key}`,
+      label: entity.label,
+      hint: "Open tab",
+      icon: entity.icon,
+      run: () => onOpenEntity(key),
+    }))
+    const core = CORE_ENTITIES.map((c) => ({
+      id: `core:${c.path}`,
+      label: c.label,
+      hint: "Open in admin",
+      icon: c.icon,
+      external: true,
+      run: () => onOpenCore(c.path),
+    }))
+    return [...tabs, ...core]
+  }, [onOpenEntity, onOpenCore])
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    return q ? items.filter((i) => i.label.toLowerCase().includes(q)) : items
+  }, [items, query])
+
+  useEffect(() => {
+    setActive((a) => Math.min(a, Math.max(0, filtered.length - 1)))
+  }, [filtered.length])
+
+  if (!open) {
+    return null
+  }
+
+  const select = (item: PaletteItem | undefined) => {
+    if (!item) return
+    item.run()
+    setOpen(false)
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[1000] flex items-start justify-center bg-ui-bg-overlay pt-[12vh] px-4"
+      onMouseDown={() => setOpen(false)}
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        className="w-full max-w-lg overflow-hidden rounded-xl border border-ui-border-base bg-ui-bg-base shadow-elevation-modal"
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <div className="border-b border-ui-border-base p-2">
+          <Input
+            ref={inputRef}
+            placeholder="Search Desk entities…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "ArrowDown") {
+                e.preventDefault()
+                setActive((a) => Math.min(a + 1, filtered.length - 1))
+              } else if (e.key === "ArrowUp") {
+                e.preventDefault()
+                setActive((a) => Math.max(a - 1, 0))
+              } else if (e.key === "Enter") {
+                e.preventDefault()
+                select(filtered[active])
+              }
+            }}
+          />
+        </div>
+        <div className="max-h-[320px] overflow-auto p-1">
+          {filtered.length === 0 ? (
+            <div className="px-3 py-6 text-center">
+              <Text size="small" className="text-ui-fg-muted">
+                No matches
+              </Text>
+            </div>
+          ) : (
+            filtered.map((item, idx) => {
+              const Icon = item.icon
+              return (
+                <button
+                  key={item.id}
+                  type="button"
+                  onMouseEnter={() => setActive(idx)}
+                  onClick={() => select(item)}
+                  className={clx(
+                    "flex w-full items-center gap-x-3 rounded-lg px-3 py-2 text-left outline-none",
+                    idx === active && "bg-ui-bg-base-hover"
+                  )}
+                >
+                  <Icon className="text-ui-fg-subtle" />
+                  <Text size="small" className="flex-1 text-ui-fg-base">
+                    {item.label}
+                  </Text>
+                  {item.external && (
+                    <ArrowUpRightOnBox className="text-ui-fg-muted" />
+                  )}
+                  <Text size="xsmall" className="text-ui-fg-muted">
+                    {item.hint}
+                  </Text>
+                </button>
+              )
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/backend/src/admin/routes/desk/EmptyDesk.tsx
+++ b/apps/backend/src/admin/routes/desk/EmptyDesk.tsx
@@ -8,8 +8,10 @@ import { EntityPickerGrid, type EntityKey } from "./EntityPicker"
  */
 export const EmptyDesk = ({
   onSelect,
+  onOpenCore,
 }: {
   onSelect: (key: EntityKey) => void
+  onOpenCore?: (path: string) => void
 }) => (
   <div className="flex items-center justify-center h-full p-6">
     <Container className="max-w-2xl w-full p-0">
@@ -18,11 +20,11 @@ export const EmptyDesk = ({
         <Text size="small" className="text-ui-fg-subtle">
           Pick what you want to work on. Each tab is its own routing
           context — you can open several side by side and drag them to
-          split.
+          split. Press <kbd>⌘⇧K</kbd> anywhere in the Desk to search.
         </Text>
       </div>
       <div className="px-6 py-4">
-        <EntityPickerGrid onSelect={onSelect} />
+        <EntityPickerGrid onSelect={onSelect} onOpenCore={onOpenCore} />
       </div>
     </Container>
   </div>

--- a/apps/backend/src/admin/routes/desk/EntityPanel.tsx
+++ b/apps/backend/src/admin/routes/desk/EntityPanel.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect } from "react"
+import { ReactNode, useEffect, useRef } from "react"
 import {
   MemoryRouter,
   Route,
@@ -9,7 +9,7 @@ import {
   useLocation,
   useNavigate,
 } from "react-router-dom"
-import { clearTabState, setTabState } from "./active-tab-store"
+import { clearTabState, setTabState, setTabTitle } from "./active-tab-store"
 import { DeskRouteFallback } from "./DeskRouteFallback"
 
 /**
@@ -109,6 +109,37 @@ export const EntityPanel = ({
   const initial =
     initialPath || config.initialPath || config.routes[0]?.path || "/"
 
+  // Derive a content-aware tab title from the panel's primary heading (the
+  // record name on a detail page). A MutationObserver catches the heading
+  // appearing after async data loads; the desk page decides whether it's
+  // specific enough to rename the tab. Route modals portal to <body>, so
+  // their headings are outside this subtree and never picked up.
+  const contentRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    const root = contentRef.current
+    if (!root) return
+    let raf = 0
+    const publish = () => {
+      cancelAnimationFrame(raf)
+      raf = requestAnimationFrame(() => {
+        const heading = root.querySelector("h1, h2, h3")
+        const text = heading?.textContent?.trim() ?? ""
+        setTabTitle(tabId, text ? text.slice(0, 60) : null)
+      })
+    }
+    publish()
+    const observer = new MutationObserver(publish)
+    observer.observe(root, {
+      subtree: true,
+      childList: true,
+      characterData: true,
+    })
+    return () => {
+      cancelAnimationFrame(raf)
+      observer.disconnect()
+    }
+  }, [tabId])
+
   // The panel takes the full FlexLayout tab height and scrolls its content.
   // `bg-ui-bg-subtle` matches the admin's standard page surface so the page's
   // own white cards stand out instead of floating on raw white. `pt-4 px-3`
@@ -116,7 +147,7 @@ export const EntityPanel = ({
   // than butting flush against them. `min-h-full` lets a tall page grow.
   return (
     <div className="h-full overflow-auto bg-ui-bg-subtle">
-      <div className="min-h-full pt-4 px-3 pb-3">
+      <div ref={contentRef} className="min-h-full pt-4 px-3 pb-3">
         <RouterReset>
           <MemoryRouter initialEntries={[initial]}>
             <TabStatePublisher

--- a/apps/backend/src/admin/routes/desk/EntityPicker.tsx
+++ b/apps/backend/src/admin/routes/desk/EntityPicker.tsx
@@ -1,16 +1,44 @@
 import { DropdownMenu, IconButton, Text } from "@medusajs/ui"
-import { Plus, Trash } from "@medusajs/icons"
+import {
+  ArchiveBox,
+  ArrowUpRightOnBox,
+  Buildings,
+  ChatBubbleLeftRight,
+  Globe,
+  Photo,
+  Plus,
+  ShoppingBag,
+  Swatch,
+  Tag,
+  Tools,
+  Trash,
+  Users,
+} from "@medusajs/icons"
+import type { ComponentType } from "react"
 import { designsEntityConfig } from "./entities/designs"
 import { productionRunsEntityConfig } from "./entities/production-runs"
 import { partnersEntityConfig } from "./entities/partners"
 import { mediasEntityConfig } from "./entities/medias"
+import { websitesEntityConfig } from "./entities/websites"
+import { personsEntityConfig } from "./entities/persons"
+import { messagingEntityConfig } from "./entities/messaging"
 import type { EntityPanelConfig } from "./EntityPanel"
 
-export type EntityKey = "designs" | "production-runs" | "partners" | "medias"
+export type EntityKey =
+  | "designs"
+  | "production-runs"
+  | "partners"
+  | "medias"
+  | "websites"
+  | "persons"
+  | "messaging"
+
+type IconType = ComponentType<{ className?: string }>
 
 export type EntityRegistryEntry = {
   label: string
   description: string
+  icon: IconType
   config: EntityPanelConfig
 }
 
@@ -18,22 +46,44 @@ export const ENTITY_REGISTRY: Record<EntityKey, EntityRegistryEntry> = {
   designs: {
     label: "Designs",
     description: "Design library, revisions, tasks, media.",
+    icon: Swatch,
     config: designsEntityConfig,
   },
   "production-runs": {
     label: "Production Runs",
     description: "Run lifecycle, dispatch, cost, approvals.",
+    icon: Tools,
     config: productionRunsEntityConfig,
   },
   partners: {
     label: "Partners",
     description: "Manufacturing and supply partners, payments, feedback.",
+    icon: Buildings,
     config: partnersEntityConfig,
   },
   medias: {
     label: "Medias",
     description: "Media library and uploads.",
+    icon: Photo,
     config: mediasEntityConfig,
+  },
+  websites: {
+    label: "Websites",
+    description: "Sites, pages, blog, analytics.",
+    icon: Globe,
+    config: websitesEntityConfig,
+  },
+  persons: {
+    label: "People",
+    description: "Person directory, contacts, addresses, agreements.",
+    icon: Users,
+    config: personsEntityConfig,
+  },
+  messaging: {
+    label: "Messages",
+    description: "Conversations and messaging.",
+    icon: ChatBubbleLeftRight,
+    config: messagingEntityConfig,
   },
 }
 
@@ -43,6 +93,27 @@ const ENTITY_ENTRIES = Object.entries(ENTITY_REGISTRY) as [
 ][]
 
 /**
+ * Medusa CORE entities. Their pages live in @medusajs/dashboard as
+ * code-split chunks that depend on the core data-router + providers, so
+ * they can't be mounted inside a Desk panel's MemoryRouter. We surface
+ * them as deep-links that open in the full admin instead.
+ */
+export type CoreEntity = {
+  label: string
+  description: string
+  icon: IconType
+  /** Admin path, e.g. "/products" — opened on the shell router. */
+  path: string
+}
+
+export const CORE_ENTITIES: CoreEntity[] = [
+  { label: "Products", description: "Product catalog.", icon: Tag, path: "/products" },
+  { label: "Orders", description: "Customer orders.", icon: ShoppingBag, path: "/orders" },
+  { label: "Inventory", description: "Stock & locations.", icon: ArchiveBox, path: "/inventory" },
+  { label: "Customers", description: "Customer accounts.", icon: Users, path: "/customers" },
+]
+
+/**
  * Compact picker shown inside the FlexLayout tab strip — a "+" IconButton
  * that opens a DropdownMenu listing the four entities. Selecting one
  * fires `onSelect(key)`; the desk page is responsible for opening the
@@ -50,9 +121,12 @@ const ENTITY_ENTRIES = Object.entries(ENTITY_REGISTRY) as [
  */
 export const EntityPickerDropdown = ({
   onSelect,
+  onOpenCore,
   onReset,
 }: {
   onSelect: (key: EntityKey) => void
+  /** Deep-link a Medusa core entity into the full admin. */
+  onOpenCore?: (path: string) => void
   /**
    * Optional. When provided, shows a "Reset workspace" item below the
    * entity list. Used to clear local + server desk state when the layout
@@ -72,11 +146,39 @@ export const EntityPickerDropdown = ({
     </DropdownMenu.Trigger>
     <DropdownMenu.Content>
       <DropdownMenu.Label>New tab</DropdownMenu.Label>
-      {ENTITY_ENTRIES.map(([key, entity]) => (
-        <DropdownMenu.Item key={key} onClick={() => onSelect(key)}>
-          {entity.label}
-        </DropdownMenu.Item>
-      ))}
+      {ENTITY_ENTRIES.map(([key, entity]) => {
+        const Icon = entity.icon
+        return (
+          <DropdownMenu.Item
+            key={key}
+            onClick={() => onSelect(key)}
+            className="gap-x-2"
+          >
+            <Icon className="text-ui-fg-subtle" />
+            {entity.label}
+          </DropdownMenu.Item>
+        )
+      })}
+      {onOpenCore && (
+        <>
+          <DropdownMenu.Separator />
+          <DropdownMenu.Label>Open in admin</DropdownMenu.Label>
+          {CORE_ENTITIES.map((c) => {
+            const Icon = c.icon
+            return (
+              <DropdownMenu.Item
+                key={c.path}
+                onClick={() => onOpenCore(c.path)}
+                className="gap-x-2"
+              >
+                <Icon className="text-ui-fg-subtle" />
+                {c.label}
+                <ArrowUpRightOnBox className="text-ui-fg-muted ml-auto" />
+              </DropdownMenu.Item>
+            )
+          })}
+        </>
+      )}
       {onReset && (
         <>
           <DropdownMenu.Separator />
@@ -100,28 +202,65 @@ export const EntityPickerDropdown = ({
  */
 export const EntityPickerGrid = ({
   onSelect,
+  onOpenCore,
 }: {
   onSelect: (key: EntityKey) => void
+  /** Deep-link a Medusa core entity into the full admin. */
+  onOpenCore?: (path: string) => void
 }) => (
-  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-    {ENTITY_ENTRIES.map(([key, entity]) => (
-      <button
-        key={key}
-        type="button"
-        onClick={() => onSelect(key)}
-        className="text-left shadow-elevation-card-rest bg-ui-bg-component hover:bg-ui-bg-component-hover rounded-lg p-5 transition-colors flex flex-col min-h-[110px] outline-none focus:shadow-borders-interactive-with-focus"
-      >
-        <Text size="base" leading="compact" weight="plus">
-          {entity.label}
+  <div className="flex flex-col gap-y-4">
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      {ENTITY_ENTRIES.map(([key, entity]) => {
+        const Icon = entity.icon
+        return (
+          <button
+            key={key}
+            type="button"
+            onClick={() => onSelect(key)}
+            className="text-left shadow-elevation-card-rest bg-ui-bg-component hover:bg-ui-bg-component-hover rounded-lg p-5 transition-colors flex flex-col min-h-[110px] outline-none focus:shadow-borders-interactive-with-focus"
+          >
+            <div className="flex items-center gap-x-2">
+              <Icon className="text-ui-fg-subtle" />
+              <Text size="base" leading="compact" weight="plus">
+                {entity.label}
+              </Text>
+            </div>
+            <Text
+              size="small"
+              leading="compact"
+              className="text-ui-fg-subtle mt-1 flex-1"
+            >
+              {entity.description}
+            </Text>
+          </button>
+        )
+      })}
+    </div>
+    {onOpenCore && (
+      <div>
+        <Text size="xsmall" leading="compact" className="text-ui-fg-muted mb-2">
+          Open in full admin
         </Text>
-        <Text
-          size="small"
-          leading="compact"
-          className="text-ui-fg-subtle mt-1 flex-1"
-        >
-          {entity.description}
-        </Text>
-      </button>
-    ))}
+        <div className="flex flex-wrap gap-2">
+          {CORE_ENTITIES.map((c) => {
+            const Icon = c.icon
+            return (
+              <button
+                key={c.path}
+                type="button"
+                onClick={() => onOpenCore(c.path)}
+                className="flex items-center gap-x-2 rounded-lg border border-ui-border-base bg-ui-bg-subtle hover:bg-ui-bg-subtle-hover px-3 py-2 text-ui-fg-subtle hover:text-ui-fg-base transition-colors outline-none focus:shadow-borders-interactive-with-focus"
+              >
+                <Icon />
+                <Text size="small" leading="compact">
+                  {c.label}
+                </Text>
+                <ArrowUpRightOnBox className="text-ui-fg-muted" />
+              </button>
+            )
+          })}
+        </div>
+      </div>
+    )}
   </div>
 )

--- a/apps/backend/src/admin/routes/desk/active-tab-store.ts
+++ b/apps/backend/src/admin/routes/desk/active-tab-store.ts
@@ -25,6 +25,12 @@ export type TabState = {
 }
 
 const tabRegistry = new Map<string, TabState>()
+/**
+ * Per-tab display title derived from the panel's primary heading (the
+ * record name on a detail page). The desk page renames the FlexLayout tab
+ * to this when it's more specific than the generic entity label.
+ */
+const tabTitles = new Map<string, string>()
 let focusedTabId: string | null = null
 
 type Listener = () => void
@@ -62,8 +68,34 @@ export const setTabState = (s: TabState): void => {
 
 export const clearTabState = (tabId: string): void => {
   tabRegistry.delete(tabId)
+  tabTitles.delete(tabId)
   if (focusedTabId === tabId) focusedTabId = null
   notify()
+}
+
+/**
+ * Publish (or clear) a tab's content-derived title. Pass null/empty to
+ * clear. No-ops when unchanged so the desk's rename effect doesn't churn.
+ */
+export const setTabTitle = (tabId: string, title: string | null): void => {
+  const current = tabTitles.get(tabId)
+  if (title) {
+    if (current === title) return
+    tabTitles.set(tabId, title)
+  } else {
+    if (!tabTitles.has(tabId)) return
+    tabTitles.delete(tabId)
+  }
+  notify()
+}
+
+/** Snapshot of every tab's derived title keyed by tabId. */
+export const getTabTitles = (): Record<string, string> => {
+  const out: Record<string, string> = {}
+  tabTitles.forEach((title, id) => {
+    out[id] = title
+  })
+  return out
 }
 
 export const setFocusedTab = (tabId: string | null): void => {

--- a/apps/backend/src/admin/routes/desk/entities/messaging.tsx
+++ b/apps/backend/src/admin/routes/desk/entities/messaging.tsx
@@ -1,0 +1,23 @@
+import MessagingPage from "../../messaging/page"
+import MessagingCreate from "../../messaging/create/page"
+import ConversationPage from "../../messaging/[conversationId]/page"
+import type { EntityPanelConfig } from "../EntityPanel"
+
+/**
+ * Messaging entity wiring for the workspace: conversation list + a single
+ * conversation view + the new-conversation route.
+ */
+export const messagingEntityConfig: EntityPanelConfig = {
+  initialPath: "/messaging",
+  routes: [
+    {
+      path: "/messaging",
+      element: <MessagingPage />,
+      children: [{ path: "create", element: <MessagingCreate /> }],
+    },
+    {
+      path: "/messaging/:conversationId",
+      element: <ConversationPage />,
+    },
+  ],
+}

--- a/apps/backend/src/admin/routes/desk/entities/persons.tsx
+++ b/apps/backend/src/admin/routes/desk/entities/persons.tsx
@@ -1,0 +1,60 @@
+import PersonsPage from "../../persons/page"
+import PersonsCreate from "../../persons/create/page"
+import PersonsImport from "../../persons/@import/page"
+import PersonsBackfillGeocodes from "../../persons/@backfill-geocodes/page"
+import PersonsMap from "../../persons/map/page"
+import PersonDetailPage from "../../persons/[id]/page"
+import PersonEdit from "../../persons/[id]/@edit/page"
+import PersonAddAddress from "../../persons/[id]/@add-address/page"
+import PersonAddContact from "../../persons/[id]/@add-contact/page"
+import PersonAddPaymentMethod from "../../persons/[id]/@add-payment-method/page"
+import PersonAddPayment from "../../persons/[id]/@add-payment/page"
+import PersonAddTypes from "../../persons/[id]/@add-types/page"
+import PersonEditAddress from "../../persons/[id]/@edit-address/[addressId]/page"
+import PersonEditContact from "../../persons/[id]/@edit-contact/[contactId]/page"
+import PersonGeocode from "../../persons/[id]/@geocode/page"
+import PersonMetadataEdit from "../../persons/[id]/@metadata/edit/page"
+import PersonSendAgreement from "../../persons/[id]/@sendAgreement/page"
+import PersonShowAgreements from "../../persons/[id]/@showAgreements/page"
+import PersonAddNote from "../../persons/[id]/addnote/page"
+import type { EntityPanelConfig } from "../EntityPanel"
+
+/**
+ * Persons (People) entity wiring. List + map + create + the two list-level
+ * overlays, plus the person detail page and its overlays. Paths mirror
+ * Medusa's @-folder convention without the `@` prefix.
+ */
+export const personsEntityConfig: EntityPanelConfig = {
+  initialPath: "/persons",
+  routes: [
+    {
+      path: "/persons",
+      element: <PersonsPage />,
+      children: [
+        { path: "create", element: <PersonsCreate /> },
+        { path: "import", element: <PersonsImport /> },
+        { path: "backfill-geocodes", element: <PersonsBackfillGeocodes /> },
+      ],
+    },
+    { path: "/persons/map", element: <PersonsMap /> },
+    {
+      path: "/persons/:id",
+      element: <PersonDetailPage />,
+      children: [
+        { path: "edit", element: <PersonEdit /> },
+        { path: "add-address", element: <PersonAddAddress /> },
+        { path: "add-contact", element: <PersonAddContact /> },
+        { path: "add-payment-method", element: <PersonAddPaymentMethod /> },
+        { path: "add-payment", element: <PersonAddPayment /> },
+        { path: "add-types", element: <PersonAddTypes /> },
+        { path: "edit-address/:addressId", element: <PersonEditAddress /> },
+        { path: "edit-contact/:contactId", element: <PersonEditContact /> },
+        { path: "geocode", element: <PersonGeocode /> },
+        { path: "metadata/edit", element: <PersonMetadataEdit /> },
+        { path: "sendAgreement", element: <PersonSendAgreement /> },
+        { path: "showAgreements", element: <PersonShowAgreements /> },
+        { path: "addnote", element: <PersonAddNote /> },
+      ],
+    },
+  ],
+}

--- a/apps/backend/src/admin/routes/desk/entities/websites.tsx
+++ b/apps/backend/src/admin/routes/desk/entities/websites.tsx
@@ -1,0 +1,65 @@
+import WebsitesPage from "../../websites/page"
+import WebsitesCreate from "../../websites/create/page"
+import WebsiteDetailPage from "../../websites/[id]/page"
+import WebsiteEdit from "../../websites/[id]/@edit/page"
+import WebsiteCreatePage from "../../websites/[id]/@create/page"
+import WebsiteBlog from "../../websites/[id]/@blog/page"
+import WebsiteMetadata from "../../websites/[id]/@metadata/page"
+import WebsiteMetadataEdit from "../../websites/[id]/@metadata/edit/page"
+import WebsiteAnalytics from "../../websites/[id]/analytics/page"
+import WebsiteConsole from "../../websites/[id]/console/page"
+import WebsiteLive from "../../websites/[id]/live/page"
+import WebsitePageDetail from "../../websites/[id]/pages/[pageId]/page"
+import WebsitePageEdit from "../../websites/[id]/pages/[pageId]/@edit/page"
+import WebsitePageVisualEditor from "../../websites/[id]/pages/[pageId]/@visual-editor/page"
+import WebsitePageSend from "../../websites/[id]/pages/[pageId]/@send/page"
+import WebsitePageMetadataEdit from "../../websites/[id]/pages/[pageId]/@metadata/edit/page"
+import WebsitePagePublicMetadataEdit from "../../websites/[id]/pages/[pageId]/@public-metadata/edit/page"
+import WebsitePageBlockNew from "../../websites/[id]/pages/[pageId]/@blocks/new/page"
+import WebsitePageBlockEdit from "../../websites/[id]/pages/[pageId]/@blocks/[blockId]/page"
+import type { EntityPanelConfig } from "../EntityPanel"
+
+/**
+ * Websites entity wiring. List + create + website detail with its overlays
+ * and sub-pages (analytics/console/live + the page editor under
+ * pages/:pageId and its overlays). Paths mirror Medusa's @-folder
+ * convention without the `@` prefix; any route not listed here falls back
+ * to the Desk recovery card.
+ */
+export const websitesEntityConfig: EntityPanelConfig = {
+  initialPath: "/websites",
+  routes: [
+    {
+      path: "/websites",
+      element: <WebsitesPage />,
+      children: [{ path: "create", element: <WebsitesCreate /> }],
+    },
+    {
+      path: "/websites/:id",
+      element: <WebsiteDetailPage />,
+      children: [
+        { path: "edit", element: <WebsiteEdit /> },
+        { path: "create", element: <WebsiteCreatePage /> },
+        { path: "blog", element: <WebsiteBlog /> },
+        { path: "metadata", element: <WebsiteMetadata /> },
+        { path: "metadata/edit", element: <WebsiteMetadataEdit /> },
+      ],
+    },
+    { path: "/websites/:id/analytics", element: <WebsiteAnalytics /> },
+    { path: "/websites/:id/console", element: <WebsiteConsole /> },
+    { path: "/websites/:id/live", element: <WebsiteLive /> },
+    {
+      path: "/websites/:id/pages/:pageId",
+      element: <WebsitePageDetail />,
+      children: [
+        { path: "edit", element: <WebsitePageEdit /> },
+        { path: "visual-editor", element: <WebsitePageVisualEditor /> },
+        { path: "send", element: <WebsitePageSend /> },
+        { path: "metadata/edit", element: <WebsitePageMetadataEdit /> },
+        { path: "public-metadata/edit", element: <WebsitePagePublicMetadataEdit /> },
+        { path: "blocks/new", element: <WebsitePageBlockNew /> },
+        { path: "blocks/:blockId", element: <WebsitePageBlockEdit /> },
+      ],
+    },
+  ],
+}

--- a/apps/backend/src/admin/routes/desk/page.tsx
+++ b/apps/backend/src/admin/routes/desk/page.tsx
@@ -16,12 +16,14 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react"
 import {
   getTabPathnames,
+  getTabTitles,
   registerOpenTabHandler,
   setFocusedTab,
   subscribeTabStore,
   useActiveTab,
 } from "./active-tab-store"
 import { EmptyDesk } from "./EmptyDesk"
+import { DeskCommandPalette } from "./CommandPalette"
 import { EntityPanel } from "./EntityPanel"
 import {
   ENTITY_REGISTRY,
@@ -112,6 +114,9 @@ const Desk = () => {
     "production-runs": 0,
     partners: 0,
     medias: 0,
+    websites: 0,
+    persons: 0,
+    messaging: 0,
   })
   /**
    * Frozen at mount and consumed by the factory on each panel mount.
@@ -129,6 +134,17 @@ const Desk = () => {
     save: saveToServer,
     reset: resetServer,
   } = useDeskWorkspace()
+
+  // Deep-link a Medusa core entity into the full admin (a new browser tab,
+  // so the Desk workspace is preserved). Core pages can't be embedded in a
+  // panel — they need the core data-router + providers — so we link out.
+  const openCore = useCallback((path: string) => {
+    window.open(
+      `${window.location.origin}/app${path}`,
+      "_blank",
+      "noopener,noreferrer"
+    )
+  }, [])
 
   const resetWorkspace = useCallback(() => {
     // Drop everything: server, localStorage, in-memory model. Skip the
@@ -203,7 +219,11 @@ const Desk = () => {
       const entity = ENTITY_REGISTRY[entityKey]
       const tabId = `${entityKey}-${n}-${Date.now()}`
 
-      const targetTabsetId = firstTabsetId(model)
+      // Open into the pane the user is currently working in, not always the
+      // first one. Falls back to the first tabset (e.g. the active tabset is
+      // undefined on an empty desk before any pane is focused).
+      const targetTabsetId =
+        model.getActiveTabset()?.getId() ?? firstTabsetId(model)
       if (!targetTabsetId) return
 
       if (initialPath) {
@@ -286,6 +306,24 @@ const Desk = () => {
     return unsub
   }, [model, saveToServer])
 
+  // Rename tabs to their content-derived title (the panel's primary heading,
+  // e.g. a design's name) so tabs read as "Red Linen Dress" rather than
+  // "Designs 3". No-ops when the name already matches; the renameTab action
+  // re-enters via onModelChange but converges since the name then equals the
+  // title. Falls back to the generated "{Entity} N" name when no heading.
+  useEffect(() => {
+    const unsub = subscribeTabStore(() => {
+      const titles = getTabTitles()
+      for (const [id, title] of Object.entries(titles)) {
+        const node = model.getNodeById(id)
+        if (!node || node.getType() !== "tab") continue
+        if ((node as TabNode).getName() === title) continue
+        model.doAction(Actions.renameTab(id, title))
+      }
+    })
+    return unsub
+  }, [model])
+
   // After hydration, point the breadcrumb at whatever tab is selected.
   useEffect(() => {
     const tabset = model.getActiveTabset()
@@ -298,11 +336,12 @@ const Desk = () => {
         <EntityPickerDropdown
           key="add-tab"
           onSelect={addPanel}
+          onOpenCore={openCore}
           onReset={resetWorkspace}
         />
       )
     },
-    [addPanel, resetWorkspace]
+    [addPanel, openCore, resetWorkspace]
   )
 
   // Header ⇄ tab-strip swap: the "Desk" heading + description only show
@@ -333,14 +372,21 @@ const Desk = () => {
           factory={factory}
           onModelChange={onModelChange}
           onRenderTabSet={onRenderTabSet}
+          onRenderTab={(node, renderValues) => {
+            const Icon = ENTITY_REGISTRY[node.getComponent() as EntityKey]?.icon
+            if (Icon) {
+              renderValues.leading = <Icon className="text-ui-fg-subtle" />
+            }
+          }}
           icons={{ close: <XCircleSolid /> }}
         />
         {!hasTabs && (
           <div className="absolute inset-0 z-10 bg-ui-bg-base">
-            <EmptyDesk onSelect={addPanel} />
+            <EmptyDesk onSelect={addPanel} onOpenCore={openCore} />
           </div>
         )}
       </div>
+      <DeskCommandPalette onOpenEntity={addPanel} onOpenCore={openCore} />
     </Container>
   )
 }


### PR DESCRIPTION
Follow-up to #461 (Desk Workspace UI). Re #420.

## What's new
- **Per-tab entity icons** — each tab + picker entry shows its entity icon (Designs/Runs/Partners/Medias/Websites/People/Messages) via `onRenderTab`.
- **Content-derived tab names** — a panel publishes its primary heading; the desk renames the tab via `Actions.renameTab`, so tabs read "WhatsApp Messages" / a record's name instead of "Messages 1". Converges (no rename loop); falls back to the generated name when there's no heading.
- **Add-tab → active tabset** — new tabs open in the pane you're working in (`getActiveTabset`, first-tabset fallback), not always the first.
- **Command palette (⌘/Ctrl+Shift+K)** — Medusa core owns Cmd-K (search) and doesn't expose it, so we bind our own shortcut. Fuzzy-search to open Desk entities as tabs, or core entities in the full admin.
- **New first-party entities as real tabs** — **Websites**, **People** (persons), **Messages** (messaging), with their route subtrees wired (deep/rare routes fall back to the recovery card from #461).
- **Core entities as deep-links** — Products / Orders / Inventory / Customers appear in the picker + palette and open in the full admin. They can't be embedded: their pages ship as content-hashed code-split chunks in `@medusajs/dashboard` that require the core data-router + QueryClient/i18n/Search providers, none of which exist in a panel's isolated MemoryRouter (investigated and confirmed).

## Verification
Playwright (Chromium): empty-state grid lists all 7 entities + 4 core; Websites/People/Messages tabs open and render with no page errors; tabs auto-rename to their page headings; ⌘⇧K palette opens and filters (e.g. "prod" → Production Runs [tab] + Products [admin]); per-tab icons + close badges render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)