### PR TITLE
feat(visual-flows): #459 P1 — compile-on-save plan + durable long-running wait

### DIFF
--- a/apps/backend/integration-tests/http/visual-flows/compile-on-save.spec.ts
+++ b/apps/backend/integration-tests/http/visual-flows/compile-on-save.spec.ts
@@ -1,0 +1,141 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "../shared-test-setup"
+import { createVisualFlowWorkflow } from "../../../src/workflows/visual-flows/create-visual-flow"
+import { updateVisualFlowWorkflow } from "../../../src/workflows/visual-flows/update-visual-flow"
+import { VISUAL_FLOWS_MODULE } from "../../../src/modules/visual_flows"
+
+jest.setTimeout(60 * 1000)
+
+// Build a canvas graph + matching DB operations from a compact spec.
+const node = (id: string, type: string, options: Record<string, any> = {}) => ({
+  id: `op_${id}`,
+  type: "operation",
+  position: { x: 0, y: 0 },
+  data: { operationType: type, operationKey: `${type}_${id}`, options },
+})
+const edge = (s: string, t: string, sourceHandle = "default") => ({
+  id: `${s}->${t}`,
+  source: s === "trigger" ? "trigger" : `op_${s}`,
+  target: `op_${t}`,
+  sourceHandle,
+})
+const opRow = (id: string, type: string, sort: number) => ({
+  operation_key: `${type}_${id}`,
+  operation_type: type,
+  name: `${type} ${id}`,
+  options: {},
+  position_x: 0,
+  position_y: 0,
+  sort_order: sort,
+})
+
+setupSharedTestSuite(() => {
+  const { getContainer } = getSharedTestEnv()
+
+  describe("visual-flows/compile-on-save (#459 P1)", () => {
+    let container: any
+    let service: any
+
+    beforeEach(() => {
+      container = getContainer()
+      service = container.resolve(VISUAL_FLOWS_MODULE)
+    })
+
+    it("persists a valid compiled plan when creating an active flow", async () => {
+      const { result } = await createVisualFlowWorkflow(container).run({
+        input: {
+          name: "compile-valid-active",
+          status: "active",
+          trigger_type: "manual",
+          canvas_state: {
+            nodes: [node("a", "log"), node("b", "log")],
+            edges: [edge("trigger", "a"), edge("a", "b")],
+          },
+          operations: [opRow("a", "log", 0), opRow("b", "log", 1)],
+        },
+      })
+
+      const plan = await service.getCompiledPlan(result.id)
+      expect(plan).toBeTruthy()
+      expect(plan.ok).toBe(true)
+      expect(plan.errors).toHaveLength(0)
+      expect(plan.entrypoints).toEqual(["op_a"])
+      expect(plan.levels).toEqual([["op_a"], ["op_b"]])
+      expect(plan.hash).toMatch(/^[0-9a-f]{64}$/)
+
+      const flow = await service.retrieveVisualFlow(result.id)
+      expect(flow.compiled_hash).toBe(plan.hash)
+    })
+
+    it("allows saving a DRAFT with a cyclic graph but records ok:false", async () => {
+      const { result } = await createVisualFlowWorkflow(container).run({
+        input: {
+          name: "compile-cyclic-draft",
+          status: "draft",
+          trigger_type: "manual",
+          canvas_state: {
+            nodes: [node("a", "log"), node("b", "log")],
+            edges: [edge("trigger", "a"), edge("a", "b"), edge("b", "a")],
+          },
+          operations: [opRow("a", "log", 0), opRow("b", "log", 1)],
+        },
+      })
+
+      const plan = await service.getCompiledPlan(result.id)
+      expect(plan.ok).toBe(false)
+      expect(plan.errors.join(" ")).toMatch(/cycle|entrypoint/i)
+    })
+
+    it("blocks activating a flow with an invalid (cyclic) graph", async () => {
+      const { errors } = await createVisualFlowWorkflow(container).run({
+        throwOnError: false,
+        input: {
+          name: "compile-cyclic-active",
+          status: "active",
+          trigger_type: "manual",
+          canvas_state: {
+            nodes: [node("a", "log"), node("b", "log")],
+            edges: [edge("trigger", "a"), edge("a", "b"), edge("b", "a")],
+          },
+          operations: [opRow("a", "log", 0), opRow("b", "log", 1)],
+        },
+      })
+
+      expect(errors).toBeDefined()
+      expect(errors.length).toBeGreaterThan(0)
+      expect(JSON.stringify(errors)).toMatch(/cannot activate flow|cycle/i)
+    })
+
+    it("recompiles on update and blocks activation of an invalid graph", async () => {
+      // Start as a valid draft …
+      const { result: created } = await createVisualFlowWorkflow(container).run({
+        input: {
+          name: "compile-update-activate",
+          status: "draft",
+          trigger_type: "manual",
+          canvas_state: {
+            nodes: [node("a", "log")],
+            edges: [edge("trigger", "a")],
+          },
+          operations: [opRow("a", "log", 0)],
+        },
+      })
+
+      // … then activate with a now-valid two-node graph → compiles + persists.
+      const { result: updated } = await updateVisualFlowWorkflow(container).run({
+        input: {
+          id: created.id,
+          status: "active",
+          canvas_state: {
+            nodes: [node("a", "log"), node("b", "log")],
+            edges: [edge("trigger", "a"), edge("a", "b")],
+          },
+          operations: [opRow("a", "log", 0), opRow("b", "log", 1)],
+        },
+      })
+
+      const plan = await service.getCompiledPlan(updated.id)
+      expect(plan.ok).toBe(true)
+      expect(plan.levels).toEqual([["op_a"], ["op_b"]])
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/visual-flows/flow-wait-long-running.spec.ts
+++ b/apps/backend/integration-tests/http/visual-flows/flow-wait-long-running.spec.ts
@@ -1,0 +1,116 @@
+import { Modules, TransactionHandlerType } from "@medusajs/framework/utils"
+import { StepResponse } from "@medusajs/framework/workflows-sdk"
+import { getSharedTestEnv, setupSharedTestSuite } from "../shared-test-setup"
+import {
+  flowWaitWorkflow,
+  flowWaitWorkflowId,
+  waitForFlowResumeStepId,
+} from "../../../src/workflows/visual-flows/flow-wait"
+import { VISUAL_FLOWS_MODULE } from "../../../src/modules/visual_flows"
+
+// Long-running workflow test. Generous ceiling, but every path RESUMES the
+// workflow explicitly and polls with a bounded loop — it finishes or fails,
+// never hangs. (setup.js also force-fails orphaned async steps as a backstop.)
+jest.setTimeout(90 * 1000)
+
+// Bounded poll: resolve when predicate true, else throw after maxMs. Never hangs.
+async function waitFor<T>(
+  fn: () => Promise<T>,
+  pred: (v: T) => boolean,
+  { maxMs = 15000, stepMs = 250 } = {}
+): Promise<T> {
+  const deadline = Date.now() + maxMs
+  let last: T
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    last = await fn()
+    if (pred(last)) return last
+    if (Date.now() > deadline) {
+      throw new Error(`waitFor timed out after ${maxMs}ms (last=${JSON.stringify(last)?.slice(0, 200)})`)
+    }
+    await new Promise((r) => setTimeout(r, stepMs))
+  }
+}
+
+setupSharedTestSuite(() => {
+  const { getContainer } = getSharedTestEnv()
+
+  describe("visual-flows/flow-wait long-running (#459 P1)", () => {
+    let container: any
+    let service: any
+    let workflowEngine: any
+
+    beforeEach(() => {
+      container = getContainer()
+      service = container.resolve(VISUAL_FLOWS_MODULE)
+      workflowEngine = container.resolve(Modules.WORKFLOW_ENGINE)
+    })
+
+    const makeFlow = async (name: string) =>
+      service.createVisualFlows({ name, trigger_type: "manual", status: "active" })
+
+    // wait_for_event registry/compile coverage lives in the compiler unit test
+    // (no booted app needed); here we focus on the durable suspend/resume.
+
+    it("suspends on the async step, then resumes to completion via setStepSuccess", async () => {
+      const flow = await makeFlow("flow-wait-resume")
+
+      // Start: async step → run() resolves while the workflow is SUSPENDED.
+      const { transaction } = await flowWaitWorkflow(container).run({
+        input: { flowId: flow.id, waitKey: "order-shipped", triggeredBy: "test" },
+      })
+      const transactionId = transaction.transactionId
+      expect(transactionId).toBeTruthy()
+
+      // Step 1 already opened the execution row; it should be `running` (waiting).
+      const [execution] = await service.listVisualFlowExecutions({ flow_id: flow.id } as any)
+      expect(execution).toBeTruthy()
+      expect(execution.status).toBe("running")
+
+      // Resume — exactly what the resume route does (setStepSuccess + payload).
+      await workflowEngine.setStepSuccess({
+        idempotencyKey: {
+          action: TransactionHandlerType.INVOKE,
+          transactionId,
+          stepId: waitForFlowResumeStepId,
+          workflowId: flowWaitWorkflowId,
+        },
+        stepResponse: new StepResponse({ ok: true, awb: "AWB123" }),
+      })
+
+      // Bounded-poll the execution row to completion (never hangs).
+      const done = await waitFor(
+        () => service.retrieveVisualFlowExecution(execution.id),
+        (e: any) => e.status === "completed" || e.status === "failed"
+      )
+      expect(done.status).toBe("completed")
+      expect(done.data_chain?.$wait?.resumed).toBe(true)
+      expect(done.data_chain?.$wait?.payload?.awb).toBe("AWB123")
+    })
+
+    it("can resume immediately (no race when the signal beats the poll)", async () => {
+      const flow = await makeFlow("flow-wait-fast")
+      const { transaction } = await flowWaitWorkflow(container).run({
+        input: { flowId: flow.id, triggeredBy: "test" },
+      })
+
+      await workflowEngine.setStepSuccess({
+        idempotencyKey: {
+          action: TransactionHandlerType.INVOKE,
+          transactionId: transaction.transactionId,
+          stepId: waitForFlowResumeStepId,
+          workflowId: flowWaitWorkflowId,
+        },
+        stepResponse: new StepResponse(true),
+      })
+
+      const [execution] = await service.listVisualFlowExecutions({ flow_id: flow.id } as any)
+      const done = await waitFor(
+        () => service.retrieveVisualFlowExecution(execution.id),
+        (e: any) => e.status === "completed" || e.status === "failed"
+      )
+      expect(done.status).toBe("completed")
+      expect(done.data_chain?.$wait?.resumed).toBe(true)
+    })
+  })
+})

--- a/apps/backend/src/api/admin/visual-flows/waits/[transaction_id]/resume/route.ts
+++ b/apps/backend/src/api/admin/visual-flows/waits/[transaction_id]/resume/route.ts
@@ -1,0 +1,43 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { IWorkflowEngineService } from "@medusajs/types"
+import { Modules, TransactionHandlerType } from "@medusajs/utils"
+import { StepResponse } from "@medusajs/workflows-sdk"
+import {
+  flowWaitWorkflowId,
+  waitForFlowResumeStepId,
+} from "../../../../../../workflows/visual-flows/flow-wait"
+
+/**
+ * #459 P1 — resume a suspended long-running flow wait.
+ *
+ * POST /admin/visual-flows/waits/:transaction_id/resume
+ * body: { step_id?, workflow_id?, payload? }
+ *
+ * Mirrors the persons/geocode-addresses confirm route: resolves the workflow
+ * engine and calls setStepSuccess against the suspended async step, passing an
+ * optional payload that becomes the wait step's output. Defaults target the
+ * flowWaitWorkflow's wait step so callers only need the transaction id.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const workflowEngineService: IWorkflowEngineService = req.scope.resolve(
+    Modules.WORKFLOW_ENGINE
+  )
+  const transactionId = req.params.transaction_id
+  const body = (req.body || {}) as {
+    step_id?: string
+    workflow_id?: string
+    payload?: unknown
+  }
+
+  await workflowEngineService.setStepSuccess({
+    idempotencyKey: {
+      action: TransactionHandlerType.INVOKE,
+      transactionId,
+      stepId: body.step_id || waitForFlowResumeStepId,
+      workflowId: body.workflow_id || flowWaitWorkflowId,
+    },
+    stepResponse: new StepResponse(body.payload ?? true),
+  })
+
+  res.status(200).json({ success: true, transaction_id: transactionId })
+}

--- a/apps/backend/src/modules/visual_flows/__tests__/compiler.unit.spec.ts
+++ b/apps/backend/src/modules/visual_flows/__tests__/compiler.unit.spec.ts
@@ -103,6 +103,18 @@ describe("visual_flows/compiler", () => {
     expect(plan.ok).toBe(true) // template tokens never produce hard errors
   })
 
+  it("recognizes a wait_for_event node (durable wait) as a valid op", () => {
+    const flow = canvas(
+      [opNode("a", "log"), opNode("w", "wait_for_event", { wait_key: "order-shipped" }), opNode("b", "log")],
+      [edge("trigger", "a"), edge("a", "w"), edge("w", "b")]
+    )
+    const plan = compileFlow(flow)
+
+    expect(plan.ok).toBe(true)
+    expect(plan.levels).toEqual([["a"], ["w"], ["b"]])
+    expect(plan.nodes["w"].type).toBe("wait_for_event")
+  })
+
   it("produces a stable hash for the same graph and a different hash when it changes", () => {
     const a = compileFlow(canvas([opNode("a", "log")], [edge("trigger", "a")]))
     const b = compileFlow(canvas([opNode("a", "log")], [edge("trigger", "a")]))

--- a/apps/backend/src/modules/visual_flows/__tests__/compiler.unit.spec.ts
+++ b/apps/backend/src/modules/visual_flows/__tests__/compiler.unit.spec.ts
@@ -1,0 +1,135 @@
+import "../operations" // populate operationRegistry (compiler reads it; app does this at boot)
+import { compileFlow } from "../compiler"
+
+/**
+ * #459 P1 — compiler unit tests. Pure, no container — fast.
+ * `log`, `condition`, `read_data` are real registered operation types.
+ */
+
+const canvas = (nodes: any[], edges: any[]) => ({
+  canvas_state: { nodes, edges },
+})
+
+const opNode = (id: string, type: string, options: Record<string, any> = {}) => ({
+  id,
+  data: { operationType: type, operationKey: `${type}_${id}`, options },
+})
+
+const edge = (source: string, target: string, sourceHandle = "default") => ({
+  id: `${source}->${target}`,
+  source,
+  target,
+  sourceHandle,
+})
+
+describe("visual_flows/compiler", () => {
+  it("compiles a simple linear graph into topological levels", () => {
+    const flow = canvas(
+      [opNode("a", "log"), opNode("b", "log"), opNode("c", "log")],
+      [edge("trigger", "a"), edge("a", "b"), edge("b", "c")]
+    )
+    const plan = compileFlow(flow)
+
+    expect(plan.ok).toBe(true)
+    expect(plan.errors).toHaveLength(0)
+    expect(plan.entrypoints).toEqual(["a"])
+    expect(plan.levels).toEqual([["a"], ["b"], ["c"]])
+    expect(plan.nodes["a"].next.default).toEqual(["b"])
+    expect(plan.hash).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it("places independent branches in the same topological level (parallelizable)", () => {
+    const flow = canvas(
+      [opNode("a", "log"), opNode("b", "log"), opNode("c", "log")],
+      [edge("trigger", "a"), edge("a", "b"), edge("a", "c")]
+    )
+    const plan = compileFlow(flow)
+
+    expect(plan.ok).toBe(true)
+    expect(plan.levels[0]).toEqual(["a"])
+    expect(plan.levels[1].sort()).toEqual(["b", "c"])
+  })
+
+  it("detects a cycle as a hard error", () => {
+    const flow = canvas(
+      [opNode("a", "log"), opNode("b", "log")],
+      [edge("trigger", "a"), edge("a", "b"), edge("b", "a")]
+    )
+    const plan = compileFlow(flow)
+
+    expect(plan.ok).toBe(false)
+    expect(plan.errors.join(" ")).toMatch(/cycle|entrypoint/i)
+  })
+
+  it("flags an unknown operation type as a hard error", () => {
+    const flow = canvas(
+      [opNode("a", "totally_made_up_op")],
+      [edge("trigger", "a")]
+    )
+    const plan = compileFlow(flow)
+
+    expect(plan.ok).toBe(false)
+    expect(plan.errors.join(" ")).toMatch(/unknown operation type/i)
+  })
+
+  it("flags an edge to a missing node as a hard error", () => {
+    const flow = canvas([opNode("a", "log")], [edge("trigger", "a"), edge("a", "ghost")])
+    const plan = compileFlow(flow)
+
+    expect(plan.ok).toBe(false)
+    expect(plan.errors.join(" ")).toMatch(/unknown node 'ghost'/i)
+  })
+
+  it("records condition branch handles (success/failure)", () => {
+    const flow = canvas(
+      [opNode("c", "condition"), opNode("ok", "log"), opNode("no", "log")],
+      [edge("trigger", "c"), edge("c", "ok", "success"), edge("c", "no", "failure")]
+    )
+    const plan = compileFlow(flow)
+
+    expect(plan.ok).toBe(true)
+    expect(plan.nodes["c"].next.success).toEqual(["ok"])
+    expect(plan.nodes["c"].next.failure).toEqual(["no"])
+  })
+
+  it("does NOT hard-fail on option mismatch when the value is a template token", () => {
+    // read_data expects a typed `entity`; a {{ }} token only resolves at runtime.
+    const flow = canvas(
+      [opNode("a", "read_data", { entity: "{{ $trigger.payload.entity }}" })],
+      [edge("trigger", "a")]
+    )
+    const plan = compileFlow(flow)
+
+    expect(plan.ok).toBe(true) // template tokens never produce hard errors
+  })
+
+  it("produces a stable hash for the same graph and a different hash when it changes", () => {
+    const a = compileFlow(canvas([opNode("a", "log")], [edge("trigger", "a")]))
+    const b = compileFlow(canvas([opNode("a", "log")], [edge("trigger", "a")]))
+    const c = compileFlow(
+      canvas([opNode("a", "log"), opNode("b", "log")], [edge("trigger", "a"), edge("a", "b")])
+    )
+
+    expect(a.hash).toBe(b.hash)
+    expect(a.hash).not.toBe(c.hash)
+  })
+
+  it("falls back to DB operations/connections when canvas_state is empty", () => {
+    const flow = {
+      canvas_state: { nodes: [], edges: [] },
+      operations: [
+        { id: "op1", operation_key: "log_1", operation_type: "log", options: {} },
+        { id: "op2", operation_key: "log_2", operation_type: "log", options: {} },
+      ],
+      connections: [
+        { source_id: "trigger", target_id: "op1", source_handle: "default" },
+        { source_id: "op1", target_id: "op2", source_handle: "default" },
+      ],
+    }
+    const plan = compileFlow(flow)
+
+    expect(plan.ok).toBe(true)
+    expect(plan.entrypoints).toEqual(["op1"])
+    expect(plan.levels).toEqual([["op1"], ["op2"]])
+  })
+})

--- a/apps/backend/src/modules/visual_flows/compiler.ts
+++ b/apps/backend/src/modules/visual_flows/compiler.ts
@@ -1,0 +1,259 @@
+import { createHash } from "crypto"
+// Import the registry INSTANCE only (operations/types has no app-level imports),
+// not operations/index — that module pulls in trigger-flow → workflows → steps
+// and would close an import cycle back through service.ts. The registry is
+// populated at app boot when the executor imports operations/index; the compiler
+// just reads whatever handlers are registered by the time a flow is saved.
+import { operationRegistry } from "./operations/types"
+
+/**
+ * #459 P1 — compile-on-save.
+ *
+ * Turns a flow's editor graph (canvas_state, with a DB operations/connections
+ * fallback) into a normalized, validated execution plan computed ONCE at save
+ * time instead of being re-derived from canvas_state on every execution.
+ *
+ * Hard errors (block activation): cycles, unknown operation types, edges that
+ * reference a missing node, and graphs with no entrypoint. Option/Zod
+ * mismatches are recorded as WARNINGS, never hard errors — raw option values
+ * routinely contain `{{ ... }}` template tokens that only resolve at runtime,
+ * so strict static typing of them would falsely reject valid flows.
+ */
+
+export const COMPILED_PLAN_VERSION = 1 as const
+
+export type CompiledNode = {
+  /** graph node id (canvas node id, or DB operation id on the fallback path) */
+  id: string
+  /** operation_key — the data-chain slot this node writes to */
+  key: string
+  /** operation_type — resolves to a handler in operationRegistry */
+  type: string
+  options: Record<string, any>
+  /** outgoing edges grouped by branch handle */
+  next: { default: string[]; success: string[]; failure: string[] }
+}
+
+export type CompiledPlan = {
+  version: typeof COMPILED_PLAN_VERSION
+  ok: boolean
+  errors: string[]
+  warnings: string[]
+  /** node ids reachable from the trigger (entry of the graph) */
+  entrypoints: string[]
+  /** topological levels; nodes within a level have no inter-dependency */
+  levels: string[][]
+  nodes: Record<string, CompiledNode>
+  hash: string
+}
+
+type GraphNode = { id: string; key: string; type: string; options: Record<string, any> }
+type GraphEdge = { source: string; target: string; sourceHandle: string }
+
+const TRIGGER_ID = "trigger"
+
+/**
+ * Extract the execution graph from a flow, mirroring the live executor's
+ * source-of-truth precedence: canvas_state nodes/edges first, falling back to
+ * DB operations/connections (seed scripts store the graph only in the DB).
+ * Canvas node options take precedence; DB operation options fill the gap.
+ */
+export function extractGraph(flow: any): { nodes: GraphNode[]; edges: GraphEdge[] } {
+  const canvas = flow?.canvas_state || {}
+  const canvasNodes: any[] = Array.isArray(canvas.nodes) ? canvas.nodes : []
+  const canvasEdges: any[] = Array.isArray(canvas.edges) ? canvas.edges : []
+
+  const dbOps: any[] = Array.isArray(flow?.operations) ? flow.operations : []
+  const dbOpByKey = new Map<string, any>()
+  for (const op of dbOps) dbOpByKey.set(op.operation_key, op)
+
+  // Prefer the canvas graph (what the executor runs); fall back to DB rows.
+  const usingCanvas = canvasNodes.some((n) => n.id !== TRIGGER_ID)
+
+  if (usingCanvas) {
+    const nodes: GraphNode[] = []
+    for (const node of canvasNodes) {
+      if (node.id === TRIGGER_ID) continue
+      const data = node.data || {}
+      const key = data.operationKey || node.id
+      const dbOp = dbOpByKey.get(key)
+      const hasCanvasOptions = data.options && Object.keys(data.options).length > 0
+      nodes.push({
+        id: node.id,
+        key,
+        type: data.operationType || dbOp?.operation_type || "unknown",
+        options: hasCanvasOptions ? data.options : dbOp?.options || {},
+      })
+    }
+    const edges: GraphEdge[] = canvasEdges.map((e) => ({
+      source: e.source,
+      target: e.target,
+      sourceHandle: e.sourceHandle || "default",
+    }))
+    return { nodes, edges }
+  }
+
+  // DB fallback
+  const nodes: GraphNode[] = dbOps.map((op) => ({
+    id: op.id,
+    key: op.operation_key,
+    type: op.operation_type,
+    options: op.options || {},
+  }))
+  const dbConns: any[] = Array.isArray(flow?.connections) ? flow.connections : []
+  const edges: GraphEdge[] = dbConns.map((c) => ({
+    source: c.source_id,
+    target: c.target_id,
+    sourceHandle: c.source_handle || "default",
+  }))
+  return { nodes, edges }
+}
+
+/** Deep-scan an options object for `{{ ... }}` template tokens. */
+function hasTemplateTokens(value: any): boolean {
+  if (typeof value === "string") return /\{\{\s*[^}]+\s*\}\}/.test(value)
+  if (Array.isArray(value)) return value.some(hasTemplateTokens)
+  if (value && typeof value === "object") return Object.values(value).some(hasTemplateTokens)
+  return false
+}
+
+function stableHash(plan: Omit<CompiledPlan, "hash">): string {
+  // Hash the structural parts only (not ok/errors/warnings — those are derived).
+  const material = JSON.stringify({
+    version: plan.version,
+    entrypoints: plan.entrypoints,
+    levels: plan.levels,
+    nodes: plan.nodes,
+  })
+  return createHash("sha256").update(material).digest("hex")
+}
+
+/**
+ * Compile a flow into a CompiledPlan. Pure — no container, no I/O.
+ */
+export function compileFlow(flow: any): CompiledPlan {
+  const errors: string[] = []
+  const warnings: string[] = []
+
+  const { nodes: graphNodes, edges } = extractGraph(flow)
+
+  const nodeById = new Map<string, GraphNode>()
+  for (const n of graphNodes) nodeById.set(n.id, n)
+
+  // --- Structural validation: edges must reference known nodes (trigger ok) ---
+  const validEdges: GraphEdge[] = []
+  for (const e of edges) {
+    const sourceOk = e.source === TRIGGER_ID || nodeById.has(e.source)
+    const targetOk = nodeById.has(e.target)
+    if (!sourceOk) errors.push(`Edge from unknown node '${e.source}'`)
+    if (!targetOk) errors.push(`Edge to unknown node '${e.target}'`)
+    if (sourceOk && targetOk) validEdges.push(e)
+  }
+
+  // --- Per-node handler + option validation ---
+  const compiledNodes: Record<string, CompiledNode> = {}
+  for (const n of graphNodes) {
+    const def = operationRegistry.get(n.type)
+    if (!def) {
+      errors.push(`Unknown operation type '${n.type}' (node '${n.key}')`)
+    } else {
+      // Option schema mismatches are warnings: raw options may carry {{ }}
+      // tokens that only resolve at runtime.
+      try {
+        const parsed = def.optionsSchema.safeParse(n.options || {})
+        if (!parsed.success && !hasTemplateTokens(n.options)) {
+          const issue = parsed.error.issues?.[0]
+          warnings.push(
+            `Options for '${n.key}' (${n.type}) may be invalid: ${issue?.path?.join(".") || ""} ${issue?.message || ""}`.trim()
+          )
+        }
+      } catch {
+        // safeParse should not throw; ignore defensively.
+      }
+    }
+    compiledNodes[n.id] = {
+      id: n.id,
+      key: n.key,
+      type: n.type,
+      options: n.options || {},
+      next: { default: [], success: [], failure: [] },
+    }
+  }
+
+  // --- Build adjacency over op-nodes (exclude the virtual trigger) ---
+  const adjacency = new Map<string, string[]>()
+  const indegree = new Map<string, number>()
+  for (const id of nodeById.keys()) {
+    adjacency.set(id, [])
+    indegree.set(id, 0)
+  }
+
+  const triggerTargets: string[] = []
+  for (const e of validEdges) {
+    if (e.source === TRIGGER_ID) {
+      triggerTargets.push(e.target)
+      continue
+    }
+    adjacency.get(e.source)!.push(e.target)
+    indegree.set(e.target, (indegree.get(e.target) || 0) + 1)
+
+    // Record the branch handle on the source node.
+    const bucket =
+      e.sourceHandle === "success" || e.sourceHandle === "failure"
+        ? e.sourceHandle
+        : "default"
+    compiledNodes[e.source].next[bucket].push(e.target)
+  }
+
+  // --- Entrypoints: explicit trigger edges, else nodes with no incoming edge
+  // (mirrors the executor's implicit-root synthesis). ---
+  let entrypoints = Array.from(new Set(triggerTargets))
+  if (entrypoints.length === 0) {
+    entrypoints = Array.from(nodeById.keys()).filter((id) => (indegree.get(id) || 0) === 0)
+  }
+  if (graphNodes.length > 0 && entrypoints.length === 0) {
+    errors.push("Graph has no entrypoint (every node has an incoming edge — cycle at the root)")
+  }
+
+  // --- Kahn topological sort → levels; leftover nodes ⇒ cycle ---
+  const workIndegree = new Map(indegree)
+  // Seed the queue with entrypoints + any other zero-indegree nodes.
+  let frontier = Array.from(nodeById.keys()).filter((id) => (workIndegree.get(id) || 0) === 0)
+  const levels: string[][] = []
+  let processed = 0
+  const seen = new Set<string>()
+
+  while (frontier.length > 0) {
+    const level = frontier.filter((id) => !seen.has(id))
+    if (level.length === 0) break
+    levels.push(level)
+    const nextFrontier: string[] = []
+    for (const id of level) {
+      seen.add(id)
+      processed++
+      for (const target of adjacency.get(id) || []) {
+        workIndegree.set(target, (workIndegree.get(target) || 0) - 1)
+        if ((workIndegree.get(target) || 0) === 0) nextFrontier.push(target)
+      }
+    }
+    frontier = nextFrontier
+  }
+
+  if (processed < nodeById.size) {
+    errors.push(
+      `Graph contains a cycle (${nodeById.size - processed} node(s) unreachable in topological order)`
+    )
+  }
+
+  const base: Omit<CompiledPlan, "hash"> = {
+    version: COMPILED_PLAN_VERSION,
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    entrypoints,
+    levels,
+    nodes: compiledNodes,
+  }
+
+  return { ...base, hash: stableHash(base) }
+}

--- a/apps/backend/src/modules/visual_flows/flow-plan-cache.ts
+++ b/apps/backend/src/modules/visual_flows/flow-plan-cache.ts
@@ -1,0 +1,57 @@
+import { Modules } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+import type { CompiledPlan } from "./compiler"
+
+/**
+ * #459 P1 — Redis-backed cache for compiled flow plans.
+ *
+ * The column on `visual_flow` is the source of truth; this is a read-through
+ * accelerator so the executor doesn't re-load + re-derive the plan from
+ * Postgres on every execution. Keyed by `flowId:hash` so a save (which changes
+ * the hash) implicitly invalidates stale entries.
+ *
+ * Everything here is BEST-EFFORT: prod wires the caching module, but dev/test
+ * may not, so we resolve with `allowUnregistered` and swallow all errors — a
+ * missing/broken cache must never break a save or an execution.
+ */
+
+const TTL_SECONDS = 60 * 60 * 24 // 24h; correctness comes from the hash, not TTL
+
+export const planCacheKey = (flowId: string, hash: string): string =>
+  `vflow:plan:${flowId}:${hash}`
+
+function resolveCache(container: MedusaContainer): any | null {
+  try {
+    return container.resolve(Modules.CACHE, { allowUnregistered: true } as any) ?? null
+  } catch {
+    return null
+  }
+}
+
+export async function cacheCompiledPlan(
+  container: MedusaContainer,
+  flowId: string,
+  plan: CompiledPlan
+): Promise<void> {
+  const cache = resolveCache(container)
+  if (!cache) return
+  try {
+    await cache.set(planCacheKey(flowId, plan.hash), plan, TTL_SECONDS)
+  } catch {
+    // best-effort
+  }
+}
+
+export async function getCachedCompiledPlan(
+  container: MedusaContainer,
+  flowId: string,
+  hash: string
+): Promise<CompiledPlan | null> {
+  const cache = resolveCache(container)
+  if (!cache) return null
+  try {
+    return (await cache.get(planCacheKey(flowId, hash))) ?? null
+  } catch {
+    return null
+  }
+}

--- a/apps/backend/src/modules/visual_flows/migrations/Migration20260617000000.ts
+++ b/apps/backend/src/modules/visual_flows/migrations/Migration20260617000000.ts
@@ -1,0 +1,27 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * #459 P1 — compile-on-save. Adds `compiled_plan` (jsonb) + `compiled_hash`
+ * (text) to `visual_flow`. The compiled plan is the normalized, validated
+ * execution artifact derived from the canvas/operations at save time
+ * (topological levels, per-node handler/options, branch handles); the hash
+ * keys the Redis plan cache.
+ *
+ * Hand-written `ADD COLUMN IF NOT EXISTS` rather than editing a
+ * `create table if not exists` migration: the visual_flow table already exists
+ * on every deployed DB, so a create-table edit would never land the new columns
+ * (see reference_medusa_migration_create_if_not_exists_hazard).
+ */
+export class Migration20260617000000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "visual_flow" add column if not exists "compiled_plan" jsonb null;`);
+    this.addSql(`alter table if exists "visual_flow" add column if not exists "compiled_hash" text null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "visual_flow" drop column if exists "compiled_plan";`);
+    this.addSql(`alter table if exists "visual_flow" drop column if exists "compiled_hash";`);
+  }
+
+}

--- a/apps/backend/src/modules/visual_flows/migrations/Migration20260617000001.ts
+++ b/apps/backend/src/modules/visual_flows/migrations/Migration20260617000001.ts
@@ -1,0 +1,25 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * #459 P1 — adds `wait_for_event` to the visual_flow_operation.operation_type
+ * CHECK constraint so a flow can persist a durable-wait node. The wait's
+ * suspend/resume is implemented by the long-running `flowWaitWorkflow`.
+ *
+ * Mirrors Migration20260531000000: drop + re-add the constraint with the full
+ * current type list plus the new value.
+ */
+export class Migration20260617000001 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "visual_flow_operation" drop constraint if exists "visual_flow_operation_operation_type_check";`);
+
+    this.addSql(`alter table if exists "visual_flow_operation" add constraint "visual_flow_operation_operation_type_check" check("operation_type" in ('condition', 'create_data', 'read_data', 'update_data', 'delete_data', 'bulk_update_data', 'bulk_create_data', 'bulk_http_request', 'bulk_trigger_workflow', 'http_request', 'run_script', 'send_email', 'send_whatsapp', 'notification', 'transform', 'trigger_workflow', 'trigger_flow', 'execute_code', 'sleep', 'log', 'ai_extract', 'ai_extract_platform', 'aggregate_product_analytics', 'generate_partner_deeplink', 'wait_for_event'));`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "visual_flow_operation" drop constraint if exists "visual_flow_operation_operation_type_check";`);
+
+    this.addSql(`alter table if exists "visual_flow_operation" add constraint "visual_flow_operation_operation_type_check" check("operation_type" in ('condition', 'create_data', 'read_data', 'update_data', 'delete_data', 'bulk_update_data', 'bulk_create_data', 'bulk_http_request', 'bulk_trigger_workflow', 'http_request', 'run_script', 'send_email', 'send_whatsapp', 'notification', 'transform', 'trigger_workflow', 'trigger_flow', 'execute_code', 'sleep', 'log', 'ai_extract', 'ai_extract_platform', 'aggregate_product_analytics', 'generate_partner_deeplink'));`);
+  }
+
+}

--- a/apps/backend/src/modules/visual_flows/models/visual-flow.ts
+++ b/apps/backend/src/modules/visual_flows/models/visual-flow.ts
@@ -20,7 +20,15 @@ export const VisualFlow = model.define("visual_flow", {
   
   // Canvas state for React Flow (nodes positions, viewport, etc.)
   canvas_state: model.json().default({ nodes: [], edges: [], viewport: { x: 0, y: 0, zoom: 1 } }),
-  
+
+  // Compiled execution plan (#459 P1). Derived from canvas_state/operations at
+  // save time: normalized topological levels + per-node handlers/options +
+  // branch handles. `compiled_plan.ok === false` carries validation errors for
+  // an invalid graph (only blocks save when activating; drafts may be invalid).
+  // `compiled_hash` keys the Redis plan cache.
+  compiled_plan: model.json().nullable(),
+  compiled_hash: model.text().nullable(),
+
   // Additional metadata
   metadata: model.json().default({}),
   

--- a/apps/backend/src/modules/visual_flows/operations/index.ts
+++ b/apps/backend/src/modules/visual_flows/operations/index.ts
@@ -29,6 +29,7 @@ export { bulkTriggerWorkflowOperation } from "./bulk-trigger-workflow"
 export { aiExtractOperation } from "./ai-extract"
 export { aiExtractPlatformOperation } from "./ai-extract-platform"
 export { generatePartnerDeeplinkOperation } from "./generate-partner-deeplink"
+export { waitForEventOperation } from "./wait-for-event"
 
 // Import all operations and register them
 import { operationRegistry } from "./types"
@@ -58,11 +59,13 @@ import { bulkTriggerWorkflowOperation } from "./bulk-trigger-workflow"
 import { aiExtractOperation } from "./ai-extract"
 import { aiExtractPlatformOperation } from "./ai-extract-platform"
 import { generatePartnerDeeplinkOperation } from "./generate-partner-deeplink"
+import { waitForEventOperation } from "./wait-for-event"
 
 // Register all built-in operations
 export function registerBuiltInOperations(): void {
   // Logic operations
   operationRegistry.register(conditionOperation)
+  operationRegistry.register(waitForEventOperation)
   
   // Data operations
   operationRegistry.register(createDataOperation)

--- a/apps/backend/src/modules/visual_flows/operations/wait-for-event.ts
+++ b/apps/backend/src/modules/visual_flows/operations/wait-for-event.ts
@@ -1,0 +1,59 @@
+import { z } from "@medusajs/framework/zod"
+import { OperationDefinition, OperationContext, OperationResult } from "./types"
+
+/**
+ * #459 P1 — Wait For Event (durable wait node).
+ *
+ * Marks a point in a flow where execution should SUSPEND until an external
+ * signal arrives (an event, a webhook, a human approval) or a timeout elapses.
+ *
+ * The actual durable suspend/resume is implemented by the long-running
+ * `flowWaitWorkflow` (src/workflows/visual-flows/flow-wait.ts), which uses a
+ * Medusa async step so the flow holds NO process while waiting and survives a
+ * restart — unlike the old `sleep` op (capped at 5s, lost on restart). This
+ * handler is the graph-node representation: it validates/echoes the wait config
+ * so the node exists in the registry and compiles. Full executor integration
+ * (pausing the running graph on this node) is the next slice.
+ */
+export const waitForEventOperation: OperationDefinition = {
+  type: "wait_for_event",
+  name: "Wait For Event",
+  description:
+    "Suspend the flow until an external event/webhook/approval resumes it (or it times out). Durable — survives restarts.",
+  icon: "clock",
+  category: "logic",
+
+  optionsSchema: z.object({
+    wait_key: z
+      .string()
+      .optional()
+      .describe("Correlation key the resuming signal must reference"),
+    event: z
+      .string()
+      .optional()
+      .describe("Optional event name expected to resume this wait"),
+    timeout_seconds: z
+      .number()
+      .optional()
+      .default(60 * 60 * 24)
+      .describe("Max time to wait before the wait is cancelled (default 24h)"),
+  }),
+
+  defaultOptions: {
+    timeout_seconds: 60 * 60 * 24,
+  },
+
+  execute: async (options, _context: OperationContext): Promise<OperationResult> => {
+    // Marker semantics in the synchronous executor: surface the resolved wait
+    // config so downstream nodes / the future durable driver can act on it.
+    return {
+      success: true,
+      data: {
+        _wait: true,
+        wait_key: options.wait_key ?? null,
+        event: options.event ?? null,
+        timeout_seconds: options.timeout_seconds ?? 60 * 60 * 24,
+      },
+    }
+  },
+}

--- a/apps/backend/src/modules/visual_flows/service.ts
+++ b/apps/backend/src/modules/visual_flows/service.ts
@@ -1,11 +1,12 @@
-import { MedusaService } from "@medusajs/framework/utils"
-import { 
-  VisualFlow, 
-  VisualFlowOperation, 
+import { MedusaService, MedusaError } from "@medusajs/framework/utils"
+import {
+  VisualFlow,
+  VisualFlowOperation,
   VisualFlowConnection,
   VisualFlowExecution,
   VisualFlowExecutionLog,
 } from "./models"
+import { compileFlow, CompiledPlan } from "./compiler"
 
 class VisualFlowService extends MedusaService({
   VisualFlow,
@@ -22,6 +23,48 @@ class VisualFlowService extends MedusaService({
       relations: ["operations", "connections"],
     })
     return flow
+  }
+
+  /**
+   * #459 P1 — compile the flow's graph into a normalized execution plan and
+   * persist it on the flow row (`compiled_plan` + `compiled_hash`). Pure
+   * derivation; safe to recompute anytime.
+   *
+   * `block` makes an invalid graph (cycle / unknown op / dangling edge) throw
+   * instead of persisting silently — used when a flow is saved as `active`, so
+   * drafts may stay invalid while you build them but you can't ACTIVATE a flow
+   * that won't run.
+   */
+  async compileAndPersistPlan(
+    flowId: string,
+    opts: { block?: boolean } = {}
+  ): Promise<CompiledPlan> {
+    const flow = await this.getFlowWithDetails(flowId)
+    const plan = compileFlow(flow)
+
+    if (opts.block && !plan.ok) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        `Cannot activate flow: invalid graph — ${plan.errors.join("; ")}`
+      )
+    }
+
+    await this.updateVisualFlows({
+      id: flowId,
+      compiled_plan: plan,
+      compiled_hash: plan.hash,
+    } as any)
+
+    return plan
+  }
+
+  /**
+   * Read the persisted compiled plan for a flow (column source of truth).
+   * Returns null if the flow has never been compiled.
+   */
+  async getCompiledPlan(flowId: string): Promise<CompiledPlan | null> {
+    const flow = await this.retrieveVisualFlow(flowId)
+    return ((flow as any)?.compiled_plan as CompiledPlan) ?? null
   }
 
   /**

--- a/apps/backend/src/workflows/visual-flows/create-visual-flow.ts
+++ b/apps/backend/src/workflows/visual-flows/create-visual-flow.ts
@@ -7,6 +7,7 @@ import {
   createVisualFlowStep,
   createFlowOperationsStep,
   createFlowConnectionsStep,
+  compileFlowPlanStep,
   getFlowWithDetailsStep,
   CreateVisualFlowInput,
   OperationInput,
@@ -68,7 +69,15 @@ export const createVisualFlowWorkflow = createWorkflow(
     // Step 3: Create connections
     createFlowConnectionsStep(connectionsData)
 
-    // Step 4: Get complete flow with details
+    // Step 4: Compile the execution plan (#459 P1). Block only when saving as
+    // active — drafts may be saved with an incomplete/invalid graph.
+    const compileInput = transform(
+      { flowId: flow.id, status: input.status },
+      (data) => ({ flowId: data.flowId, block: data.status === "active" })
+    )
+    compileFlowPlanStep(compileInput)
+
+    // Step 5: Get complete flow with details
     const completeFlow = getFlowWithDetailsStep({ flowId: flow.id })
 
     return new WorkflowResponse(completeFlow)

--- a/apps/backend/src/workflows/visual-flows/flow-wait.ts
+++ b/apps/backend/src/workflows/visual-flows/flow-wait.ts
@@ -1,0 +1,117 @@
+import {
+  createWorkflow,
+  createStep,
+  StepResponse,
+  WorkflowResponse,
+  transform,
+  WorkflowData,
+} from "@medusajs/framework/workflows-sdk"
+import { VISUAL_FLOWS_MODULE } from "../../modules/visual_flows"
+import VisualFlowService from "../../modules/visual_flows/service"
+
+/**
+ * #459 P1 — durable long-running wait for visual flows.
+ *
+ * Proves the suspend/resume primitive the future executor will use for
+ * `wait_for_event` nodes, WITHOUT touching the live single-step executor. The
+ * middle step is a Medusa async step (returns no StepResponse) so the workflow
+ * SUSPENDS in the workflow engine holding no process — resumed by the resume
+ * route (setStepSuccess) or cancelled on timeout. State is mirrored onto a
+ * visual_flow_execution row (running → completed) so the wait is observable in
+ * the flow's own execution model.
+ *
+ * Docs: https://docs.medusajs.com/learn/fundamentals/workflows/long-running-workflow
+ */
+
+export const flowWaitWorkflowId = "visual-flow-wait"
+export const waitForFlowResumeStepId = "wait-for-flow-resume"
+
+export type FlowWaitInput = {
+  flowId: string
+  waitKey?: string
+  triggeredBy?: string
+}
+
+/** Step 1 (sync): open an execution row in `running` state and log the wait. */
+const recordFlowWaitStartStep = createStep(
+  "record-flow-wait-start",
+  async (input: FlowWaitInput, { container }) => {
+    const service: VisualFlowService = container.resolve(VISUAL_FLOWS_MODULE)
+    const execution = await service.createExecution({
+      flow_id: input.flowId,
+      triggered_by: input.triggeredBy || "wait",
+      metadata: { wait_key: input.waitKey ?? null },
+    })
+    await service.updateExecutionStatus(execution.id, "running", {})
+    await service.addExecutionLog({
+      execution_id: execution.id,
+      operation_key: "$wait",
+      status: "running",
+      input_data: { wait_key: input.waitKey ?? null },
+    })
+    return new StepResponse(execution.id, execution.id)
+  },
+  // Compensation: if a later step fails (or the wait times out), mark cancelled.
+  async (executionId, { container }) => {
+    if (!executionId) return
+    const service: VisualFlowService = container.resolve(VISUAL_FLOWS_MODULE)
+    await service.updateExecutionStatus(executionId, "cancelled", {})
+  }
+)
+
+/**
+ * Step 2 (async / long-running): no StepResponse → the workflow suspends here
+ * until setStepSuccess/Failure is called. `timeout` bounds an orphaned wait.
+ */
+const waitForFlowResumeStep = createStep(
+  {
+    name: waitForFlowResumeStepId,
+    async: true,
+    timeout: 60 * 60 * 24, // 24h ceiling for an un-resumed wait
+  },
+  async () => {
+    // Intentionally returns nothing — see step comment.
+  }
+)
+
+/** Step 3 (sync): record the resume + close the execution row. */
+const recordFlowWaitCompleteStep = createStep(
+  "record-flow-wait-complete",
+  async (input: { executionId: string; resume: any }, { container }) => {
+    const service: VisualFlowService = container.resolve(VISUAL_FLOWS_MODULE)
+    await service.addExecutionLog({
+      execution_id: input.executionId,
+      operation_key: "$wait",
+      status: "success",
+      output_data: { resumed: true, payload: input.resume ?? null },
+    })
+    await service.updateExecutionStatus(input.executionId, "completed", {
+      data_chain: { $wait: { resumed: true, payload: input.resume ?? null } } as any,
+    })
+    return new StepResponse({
+      executionId: input.executionId,
+      resumed: true,
+      payload: input.resume ?? null,
+    })
+  }
+)
+
+export const flowWaitWorkflow = createWorkflow(
+  { name: flowWaitWorkflowId, store: true },
+  (input: WorkflowData<FlowWaitInput>) => {
+    const executionId = recordFlowWaitStartStep(input)
+
+    // Suspends here until resumed; its output is whatever setStepSuccess passes.
+    const resume = waitForFlowResumeStep()
+
+    const completeInput = transform(
+      { executionId, resume },
+      (data) => ({ executionId: data.executionId, resume: data.resume })
+    )
+    const summary = recordFlowWaitCompleteStep(completeInput)
+
+    return new WorkflowResponse(summary)
+  }
+)
+
+export default flowWaitWorkflow

--- a/apps/backend/src/workflows/visual-flows/update-visual-flow.ts
+++ b/apps/backend/src/workflows/visual-flows/update-visual-flow.ts
@@ -3,6 +3,7 @@ import {
   createStep,
   StepResponse,
   WorkflowResponse,
+  transform,
 } from "@medusajs/framework/workflows-sdk"
 import { VISUAL_FLOWS_MODULE } from "../../modules/visual_flows"
 import VisualFlowService from "../../modules/visual_flows/service"
@@ -10,6 +11,7 @@ import {
   UpdateVisualFlowInput,
   OperationInput,
   ConnectionInput,
+  compileFlowPlanStep,
   getFlowWithDetailsStep,
 } from "./visual-flow-steps"
 
@@ -170,7 +172,15 @@ export const updateVisualFlowWorkflow = createWorkflow(
     // Step 1: Update everything atomically
     updateFlowCompleteStep(input)
 
-    // Step 2: Get complete flow with details
+    // Step 2: Recompile the execution plan (#459 P1). Block only on explicit
+    // activation (status === "active"); other saves compile best-effort.
+    const compileInput = transform(
+      { flowId: input.id, status: input.status },
+      (data) => ({ flowId: data.flowId, block: data.status === "active" })
+    )
+    compileFlowPlanStep(compileInput)
+
+    // Step 3: Get complete flow with details
     const completeFlow = getFlowWithDetailsStep({ flowId: input.id })
 
     return new WorkflowResponse(completeFlow)

--- a/apps/backend/src/workflows/visual-flows/visual-flow-steps.ts
+++ b/apps/backend/src/workflows/visual-flows/visual-flow-steps.ts
@@ -4,6 +4,7 @@ import {
 } from "@medusajs/framework/workflows-sdk"
 import { VISUAL_FLOWS_MODULE } from "../../modules/visual_flows"
 import VisualFlowService from "../../modules/visual_flows/service"
+import { cacheCompiledPlan } from "../../modules/visual_flows/flow-plan-cache"
 
 // ============ Types ============
 
@@ -250,6 +251,23 @@ export const createFlowConnectionsStep = createStep(
     for (const id of createdIds) {
       await service.deleteVisualFlowConnections(id)
     }
+  }
+)
+
+/**
+ * #459 P1 — compile the flow graph into a persisted execution plan after a
+ * create/update. `block` (set when saving as `active`) makes an invalid graph
+ * fail the save; otherwise it's best-effort so drafts can stay invalid while
+ * being built. No compensation needed: the plan is a pure derivation that the
+ * next save recomputes.
+ */
+export const compileFlowPlanStep = createStep(
+  "compile-flow-plan-step",
+  async (input: { flowId: string; block?: boolean }, { container }) => {
+    const service: VisualFlowService = container.resolve(VISUAL_FLOWS_MODULE)
+    const plan = await service.compileAndPersistPlan(input.flowId, { block: input.block })
+    await cacheCompiledPlan(container, input.flowId, plan)
+    return new StepResponse({ ok: plan.ok, hash: plan.hash, errors: plan.errors })
   }
 )
 

--- a/apps/docs/notes/VISUAL_FLOWS_P1_ENGINE_DESIGN.md
+++ b/apps/docs/notes/VISUAL_FLOWS_P1_ENGINE_DESIGN.md
@@ -1,0 +1,240 @@
+# Visual Flows — P1 Engine Rework Design (#459)
+
+_Design date: 2026-06-17. Builds on `VISUAL_FLOWS_PLUGIN_ANALYSIS.md`._
+_Scope: P1 only — compile-on-save plan, Redis plan cache, per-operation durability
+(retry / resume / parallel), and durable waits via long-running workflows._
+
+---
+
+## 0. The one hard constraint that shapes everything
+
+Confirmed against the Medusa 2.x docs (workflows-sdk):
+
+> **The `createWorkflow` composition function runs once at application load time
+> and builds a _static_ DAG.** Variables inside it are graph-node proxies, not
+> runtime values. You cannot `if/else` on runtime data (use `when()`), cannot
+> read a step's output (use `transform()`), and **cannot iterate a
+> runtime-length list to emit N steps.**
+
+Therefore the obvious idea — "compile each user node into its own native
+workflow step" — **is not expressible.** A flow's node count, shape, and
+branching are runtime data. We must execute a dynamic graph *inside* steps while
+still getting durability from the workflow engine. The rest of this design is how.
+
+Primitives we _do_ get (all confirmed, prod already runs `workflow-engine-redis`):
+
+| Primitive | API | What it buys us |
+|---|---|---|
+| Step retry | `createStep({ name, maxRetries, retryInterval, autoRetry, timeout }, …)` | Per-step retry w/ backoff. **The whole step fn re-runs** (atomic unit — no mid-step resume). |
+| Nested workflow | `child.runAsStep({ input })` in composition | Compose a static child workflow; participates in parent compensation. |
+| Long-running / async step | step returns **no** `StepResponse`; later `workflowEngine.setStepSuccess/Failure({ idempotencyKey:{ action, transactionId, stepId, workflowId }, stepResponse })` | **Suspend durably in Redis** with no process held; resume on external signal. Also `retryInterval` makes a workflow long-running. |
+| Redis durability | `@medusajs/medusa/workflow-engine-redis` | Completed steps persisted & not re-run after crash; in-flight step may need a manual `retryStep()`. |
+
+---
+
+## 1. Compile-on-save (deterministic plan, built once)
+
+Today the graph is re-derived from `canvas_state` on **every** execution
+(`executeOperationsStep`, ~lines 271–353): node→op mapping, edge→connection
+mapping, topo-root synthesis. Move all of that to **save time**, inside
+`update-visual-flow` / `create-visual-flow`.
+
+**Add a compile step** that produces a normalized, validated `CompiledPlan`:
+
+```ts
+type CompiledPlan = {
+  version: 1
+  entrypoints: string[]                 // node ids reachable from $trigger
+  levels: string[][]                    // topological levels (each level = parallelizable)
+  nodes: Record<string, CompiledNode>   // by node id
+  hash: string                          // content hash for cache keying
+}
+type CompiledNode = {
+  id: string
+  key: string                           // operation_key (data-chain slot)
+  type: string                          // operation_type → registry handler
+  options: Record<string, any>
+  next: { default: string[]; success: string[]; failure: string[] }
+  policy: { maxRetries: number; retryInterval?: number; timeoutMs?: number; continueOnError: boolean }
+}
+```
+
+Compilation does the work that must **fail loud at save, not at 3am**:
+1. Resolve every `operation_type` against `operationRegistry` → unknown type = save error.
+2. Validate each node's `options` against the op's `optionsSchema` (Zod).
+3. **Cycle detection** + topological sort into `levels` (Kahn's algorithm); a
+   cycle = save error (today an accidental cycle would infinite-loop the executor).
+4. Resolve branch handles (`success`/`failure`/`default`) into `next`.
+5. Compute `hash` over the normalized plan.
+
+**Persistence:** add a `compiled_plan` (jsonb) + `compiled_hash` column to
+`visual_flow` (hand-written `ADD COLUMN IF NOT EXISTS` migration — see
+`reference_medusa_migration_create_if_not_exists_hazard`). Keep `canvas_state`
+as the editor's source of truth; `compiled_plan` is the execution artifact.
+
+**Cache:** store the compiled plan in Redis (caching module already configured),
+key `vflow:plan:{flowId}:{compiled_hash}`, invalidated implicitly by the hash
+changing on save. Execution reads cache → falls back to column → (last resort)
+recompiles. Removes the per-execution Postgres load + graph re-derivation.
+
+---
+
+## 2. Durable execution model
+
+Two layers: a **driver** (resumable) and a **per-op unit** (durable + retried).
+
+### 2a. Per-operation unit = a generic nested workflow
+
+One static, generic workflow — `runFlowOperationWorkflow` — that executes
+exactly one node:
+
+```ts
+// input: { executionId, flowId, nodeId } ; reads node + dataChain from the execution row
+const runOperationStep = createStep(
+  { name: "run-flow-operation", maxRetries: 3, retryInterval: 5, timeout: 30 },
+  async ({ executionId, flowId, nodeId }, { container }) => {
+    // load compiled node + current dataChain (checkpointed), resolve handler,
+    // interpolate options, execute handler.execute(opts, ctx), append log row,
+    // persist dataChain[node.key] + $last back to the execution row (checkpoint)
+    return new StepResponse({ outputKey: node.key })
+  }
+)
+export const runFlowOperationWorkflow = createWorkflow("run-flow-operation", (input) => {
+  return new WorkflowResponse(runOperationStep(input))
+})
+```
+
+- **Per-op retry/backoff/timeout** come free from the step config; `policy` from
+  the compiled node overrides defaults (mapped at the driver, since config is
+  static we pick sensible global defaults + honor `continueOnError` in the driver).
+- The op handler signature is unchanged (`execute(options, context) → OperationResult`),
+  so all ~25 existing operations keep working.
+
+### 2b. Driver = resumable orchestrator step
+
+The parent `execute-visual-flow` workflow's heavy step becomes a **resumable
+driver** that walks `compiled_plan.levels` and, for each ready node, invokes the
+per-op unit. Crucially it **checkpoints to the execution row after every node**,
+so on a step retry (the whole step re-runs — that's the Medusa rule) it **skips
+already-completed nodes** and continues:
+
+```
+driver(executionId):
+  plan = loadCompiledPlan(flowId)              # Redis → column
+  state = loadExecutionState(executionId)      # completed set + dataChain (resume)
+  for level in plan.levels:
+    ready = [n in level if n not in state.completed and deps satisfied & branch-active]
+    results = await mapWithConcurrency(ready, CONCURRENCY, n =>
+                 runFlowOperationWorkflow(container).run({ input:{executionId, flowId, nodeId:n} }))
+    for each result:
+      if failed and not node.policy.continueOnError: throw   # aborts → step retry resumes here
+      state.completed.add(n); persist(state)                 # checkpoint
+    pruneInactiveBranches(condition results)                 # success/failure handles
+```
+
+Why this shape:
+- **Each op is its own durable, retried workflow run** (Redis-backed).
+- **Parallel branches**: nodes in the same topo level run concurrently with a
+  bounded `CONCURRENCY` (fixes today's strictly-sequential recursion).
+- **Resume-from-failure**: the driver step is idempotent via the checkpointed
+  `completed` set + `dataChain` — re-running the step doesn't re-send emails or
+  re-write data for completed nodes.
+- **Correctness fix**: level-based execution + a `completed` set removes today's
+  diamond-graph double-execution risk in `executeOperationsRecursive`.
+
+> Trade-off vs the "ideal": the driver is still one step, so a *driver* crash
+> mid-level requires the step to re-run (cheap — it skips completed nodes). We do
+> **not** get the workflow engine scheduling each op as an independent graph node
+> (impossible under the static-composition constraint), but we get the
+> properties that matter: per-op retry, resume, parallelism, durability.
+
+### 2c. The fully-distributed variant (defer to P2/SaaS)
+
+If we later need true per-op distribution / fan-out across workers, switch the
+driver from an in-step loop to **event-driven progression**: each op-complete
+emits `visual_flow.node_completed`; a subscriber computes newly-ready nodes and
+runs their per-op workflows. Same per-op unit, no long-lived driver process.
+More moving parts — only worth it at SaaS scale. Documented, not built in P1.
+
+---
+
+## 3. Durable waits — long-running workflows (the part #459 was reaching for)
+
+Today `sleep` uses `setTimeout(min(ms, 5000))` — capped at 5s and **lost on
+restart**. Real automation needs "wait 3 days, then send", "pause for human
+approval", "wait for this webhook". These are exactly **long-running workflows**.
+
+Model a *waiting* node as an **async step** in the per-op unit (it returns no
+`StepResponse`), so the workflow **suspends in Redis holding no process**:
+
+- `wait_for_duration` (replaces `sleep`): schedule a resume via `retryInterval`
+  / a scheduled job that calls `setStepSuccess` when the deadline passes.
+- `wait_for_event` / `wait_for_webhook`: the inbound event/webhook handler calls
+  `workflowEngine.setStepSuccess({ idempotencyKey:{ action: INVOKE, transactionId,
+  stepId, workflowId }, stepResponse })` to resume the exact suspended execution.
+- `human_approval`: an admin action resolves the step (`setStepSuccess` /
+  `setStepFailure`).
+
+This requires the per-op unit to expose its `transactionId` (returned from
+`.run()`), persisted on the `visual_flow_execution` row so external signals can
+find and resume the right suspended step. Long waits no longer pin a worker and
+survive restarts.
+
+---
+
+## 4. Triggers: enqueue-and-ack
+
+Independent of the engine internals, stop running flows inline on the request
+path:
+- **Event subscriber** & **webhook** (`trigger_config.async`) & **schedule job**:
+  return `202`/ack immediately and let the durable workflow run in the worker
+  (prod already splits server/worker via `MEDUSA_WORKER_MODE`).
+- The every-minute `* * * * *` schedule scanner stays, but only *enqueues* due
+  flows; it must never execute them inline (today it `await`s each).
+
+---
+
+## 5. Migration & safety
+
+- **Backwards compatible:** keep reading `canvas_state`; `compiled_plan` is
+  additive. Old flows without a compiled plan compile lazily on first run + on
+  next save (backfill job optional).
+- **Kill the dead engine** (`execution-engine.ts`) as part of this — there must
+  be exactly one executor (the driver), so the legacy class doesn't re-drift.
+- **Feature-flag** the new executor (`VFLOW_DURABLE_EXECUTOR`) so we can roll
+  back to the current single-step path if needed; run both against the test
+  suite (`operations/__tests__`, integration flows) before flipping prod.
+- Migration column adds via hand-written `ADD COLUMN IF NOT EXISTS`
+  (`reference_medusa_migration_create_if_not_exists_hazard`).
+
+---
+
+## 6. Build order (each shippable)
+
+| # | Slice | Outcome |
+|---|---|---|
+| 1 | Compile step + `compiled_plan`/`compiled_hash` columns + validation/cycle-detect on save | Save-time failures; deterministic plan. No exec change yet. |
+| 2 | Redis plan cache + execution reads plan (not canvas) | Removes per-run DB load + graph re-derivation. |
+| 3 | `runFlowOperationWorkflow` per-op unit + resumable checkpointing driver (behind flag) | Per-op retry + resume + parallel levels; delete dead engine. |
+| 4 | Long-running wait nodes (`wait_for_duration`/`wait_for_event`/`human_approval`) | Durable waits; real delays. |
+| 5 | Enqueue-and-ack triggers (event/webhook/schedule) | No inline blocking. |
+
+P2 (separate): event-driven distributed driver (2c), `isolated-vm`, streaming/
+bulk — per the analysis note.
+
+---
+
+## 7. Open questions
+
+- **Per-op retry config is static** (`createStep` config is fixed at load). The
+  per-node `policy.maxRetries/retryInterval` can't directly parameterize the
+  step config. Resolution: pick conservative global step defaults and implement
+  per-node overrides as an **application-level retry loop inside the per-op
+  step** (bounded), reserving the engine's retry for infra-level failures. Verify
+  this composes cleanly with `continueOnError`.
+- **`setStepSuccess` addressing**: confirm the `transactionId` + `stepId`
+  for a nested per-op workflow is stable & retrievable for the resume signal.
+- **Compensation semantics**: visual-flow ops are mostly external side-effects
+  (emails, HTTP) with no real rollback. Decide explicitly that flow ops are
+  *forward-only* (no compensation) and rely on retry/`continueOnError` + the
+  failure lifecycle event, rather than pretending compensation works.

--- a/apps/docs/notes/VISUAL_FLOWS_PLUGIN_ANALYSIS.md
+++ b/apps/docs/notes/VISUAL_FLOWS_PLUGIN_ANALYSIS.md
@@ -1,0 +1,273 @@
+# Visual Flows — Module Analysis & Plugin Roadmap (#459)
+
+_Analysis date: 2026-06-17. Module: `apps/backend/src/modules/visual_flows` (+ admin UI, API, workflows, subscribers, jobs)._
+
+This note answers the five questions in issue #459:
+
+1. Can we release this as a Medusa plugin?
+2. What can be improved in the execution engine?
+3. How do we run isolated code safely?
+4. How do we handle heavy code / data crunching?
+5. Caching + queue (Redis / workflow-style) like Medusa does it.
+
+---
+
+## 0. What the module actually is today
+
+A visual, node-based automation builder (think n8n / Directus Flows) embedded in
+the Medusa admin. Users drag operation nodes onto an [`@xyflow/react`] canvas,
+wire them up, and the graph runs against the Medusa container.
+
+**Footprint (all under `apps/backend/src`):**
+
+| Layer | Location | ~LOC |
+|---|---|---|
+| Module (models, service, operations, engine) | `modules/visual_flows/` | ~7,300 |
+| Admin UI (canvas, panels, code/json editors) | `admin/components/visual-flows/` | ~5,300 |
+| API routes | `api/admin/visual-flows/`, `api/webhooks/flows/` | ~2,400 |
+| Workflows | `workflows/visual-flows/` | ~1,270 |
+| Subscribers | `subscribers/visual-flow-*.ts` | — |
+| Scheduled job | `jobs/run-scheduled-visual-flows.ts` | — |
+
+**Data model** (`modules/visual_flows/models/`): `visual_flow`,
+`visual_flow_operation`, `visual_flow_connection`, `visual_flow_execution`,
+`visual_flow_execution_log`.
+
+**Triggers** (all converge on the same `executeVisualFlowWorkflow`):
+- **Manual** — `POST /admin/visual-flows/:id/execute` (awaits, returns result).
+- **Event** — `subscribers/visual-flow-event-trigger.ts` subscribes to ~60 events; matches `event_pattern`/`event_types`/`event_type`; runs inline in the subscriber.
+- **Schedule** — `jobs/run-scheduled-visual-flows.ts` runs every minute (`* * * * *`), parses each flow's cron in JS, dedups per-minute via `metadata.schedule.last_run_minute_key`.
+- **Webhook** — `POST /webhooks/flows/:id`; sync by default, fire-and-forget if `trigger_config.async`.
+
+**~25 operations** registered in `operations/index.ts`: data CRUD (`read/create/update/delete_data`), bulk variants, `condition`, `transform`, `http_request`, `bulk_http_request`, `trigger_workflow`, `trigger_flow`, `execute_code`, `send_email`, `send_whatsapp`, `notification`, AI extract, analytics (`aggregate_data`, `time_series`, `aggregate_product_analytics`, `cart_recovery_stats`), `generate_partner_deeplink`, `sleep`, `log`.
+
+---
+
+## 1. Biggest structural finding: two execution paths, one is dead
+
+There are **two** copies of the graph-execution logic:
+
+- `modules/visual_flows/execution-engine.ts` — `FlowExecutionEngine` class.
+  **Dead code.** `grep` for `FlowExecutionEngine` / `createExecutionEngine` /
+  `execution-engine` across the whole backend returns _zero_ references outside
+  the file itself.
+- `workflows/visual-flows/execute-visual-flow.ts` — `executeOperationsStep` +
+  `executeOperationsRecursive`. **This is the live path.** Every trigger calls
+  `executeVisualFlowWorkflow`.
+
+The two implementations have drifted (e.g. the engine reads operations from the
+DB rows; the workflow reads from `canvas_state.nodes` with a DB fallback). Bugs
+get fixed in one and not the other.
+
+> **Action (cheap, do first):** delete `execution-engine.ts`, or — better —
+> invert it: make the workflow step a thin wrapper that calls a single
+> `FlowExecutionEngine.run()`. One graph executor, period. This is also the
+> precondition for everything below (plugin extraction, isolation, queueing all
+> need _one_ engine to modify).
+
+---
+
+## 2. Execution-engine improvements (#2)
+
+Today the entire operation graph runs inside **one** workflow step
+(`executeOperationsStep`) as a synchronous in-process recursion. Consequences:
+
+| Issue | Detail | Impact |
+|---|---|---|
+| **No per-operation durability** | The workflow is `store:true` and prod has `workflow-engine-redis`, so the _flow_ is a durable workflow — but the whole graph is one step. A crash mid-graph re-runs the **entire** flow, not from the failed node. | No resume; re-sends emails, re-writes data. |
+| **No retry/backoff per op** | First failing op throws and aborts the flow. No `http_request` retry, no transient-error handling. | Flaky HTTP / rate limits kill whole flows. |
+| **Sequential only** | `executeOperationsRecursive` walks connections depth-first, `await` each. Two independent branches can't run in parallel. | Slow flows; bulk ops serialize. |
+| **No concurrency/loop primitives** | No native "for-each item → sub-graph", no map/fan-out node. `bulk_*` ops hand-roll loops internally. | Each bulk op reinvents batching; inconsistent. |
+| **Flow def re-loaded every run** | `getFlowWithDetails` hits Postgres on every execution; no cache despite Redis being available. | DB load on high-frequency event flows. |
+| **Graph re-derived every run** | Canvas→operations→connections mapping + topo-root synthesis runs at execution time. | CPU per execution; should be compiled once on save. |
+| **Recursion can double-execute** | `executeOperationsRecursive` re-visits nodes reachable by multiple paths (no visited-set on the executed node, only branch filtering). Diamond graphs can run a node twice. | Correctness risk — verify. |
+| **Cancellation is weak** | `visual_flow_execution.cancelled` is emitted on compensation, but a running in-process recursion can't be interrupted. | "Cancel" doesn't stop a running flow. |
+
+**Recommended engine model — compile then execute:**
+
+1. **Compile on save** (in `update-visual-flow`): validate the graph, detect
+   cycles, topologically sort, resolve each node's operation handler + options
+   schema, and persist a normalized "compiled plan" (nodes + adjacency +
+   entrypoints). Execution stops re-deriving the graph from `canvas_state`.
+2. **Execute as a real workflow** where _each operation is its own durable step_
+   (or batched levels of the topo-sort are parallel steps). This gives
+   per-op retry, resume-from-failure, and parallel branches for free from
+   `workflow-engine-redis`. This is the single highest-leverage change.
+3. **Per-op policy**: `retries`, `timeout`, `continue_on_error`, declared on the
+   operation definition + overridable per node.
+4. **Parallel branches**: execute each topo "level" with `Promise.all` (or
+   parallel workflow steps); only join where the graph joins.
+
+---
+
+## 3. Running isolated code (#3) — current state is unsafe
+
+`operations/execute-code.ts` + `operations/package-loader.ts`. Two serious
+problems:
+
+### 3a. The "sandbox" is not a sandbox
+`runInSandbox` uses `new Function(...paramNames, code)` (line ~581). The file's
+own comment admits: _"This is not a true sandbox."_ It is trivially escapable —
+`this.constructor.constructor("return process")()` reaches the real `process`,
+`globalThis`, `require`, the filesystem, env vars, the DB connection, etc. The
+`BLOCKED_PACKAGES` denylist only blocks _named requires_; it does nothing about
+prototype-chain escapes. The `timeout` is a cooperative `Promise.race` — it
+**cannot interrupt** a CPU-bound `while(true){}`; the loop pins the event loop
+and the timer never fires.
+
+### 3b. Runtime `npm install` in the server process
+`package-loader.ts` does `execSync('npm install <pkg> --legacy-peer-deps')` into
+`process.cwd()/.cache/visual-flow-packages` on first use, then `eval('require')`
+loads it. In a production container this is:
+- **Arbitrary code execution** — installing an arbitrary npm package runs its
+  postinstall scripts as the server user, and loads attacker-controlled code
+  into the main process.
+- **Non-reproducible & fragile** — writes to an ephemeral container FS, needs
+  network egress to the npm registry, 60s blocking `execSync` on the request
+  path, and breaks on read-only / multi-replica filesystems.
+
+> This is the **#1 risk in the whole module.** It should be gated behind an env
+> flag and disabled in prod _now_, independent of the bigger rework.
+
+### Recommended isolation strategy (tiered)
+
+| Tier | Mechanism | Use |
+|---|---|---|
+| **Now (stop-gap)** | Hard-disable runtime `npm install` in prod (env flag); pre-bundle the allowlisted libs (`lodash`, `dayjs`, `validator`, `crypto`, `fetch`) that already ship; keep `new Function` only for trusted-admin flows. | Removes RCE-by-install today. |
+| **Real isolation (in-process)** | [`isolated-vm`] — true V8 isolates with a hard memory cap and a real wall-clock/CPU timeout that _interrupts_ execution. No access to host globals unless explicitly injected. | Untrusted/multi-tenant code in the same process. |
+| **Strong isolation (out-of-process)** | Vercel Sandbox / Firecracker microVM / a dedicated worker container per execution. Best for "heavy crunching" (see #4) and true multi-tenant SaaS. | SaaS Dedicated tier; long/heavy jobs. |
+
+For the multi-tenant SaaS direction (`project_medusa_saas_vision`),
+**`isolated-vm` is the pragmatic next step**; out-of-process sandboxing is the
+Dedicated-tier answer. Either way, package access becomes a **curated, pre-built
+allowlist** baked into the image — never runtime-installed.
+
+---
+
+## 4. Heavy code & data crunching (#4)
+
+Everything runs in the API/worker process, in memory, on the event loop:
+- `read_data` / `aggregate_data` load whole result sets into JS arrays — no
+  streaming, no pagination ceiling, no backpressure. A large `read_data` OOMs
+  the worker.
+- `bulk_*` operations loop in-process and serialize; one slow item blocks the rest.
+- A long flow occupies a workflow worker slot for its entire duration; prod runs
+  split server/worker (`MEDUSA_WORKER_MODE`), so heavy flows starve other jobs.
+
+**Recommendations:**
+1. **Offload heavy ops to background jobs / a queue** (see #5) rather than
+   running them inline in the trigger request.
+2. **Stream + paginate** `read_data`/aggregations; cap result size with an
+   explicit, surfaced limit (`feedback_use_skeletons_everywhere` cousin: never
+   silently truncate — log/return what was dropped).
+3. **Batch + bounded concurrency** for `bulk_*` (e.g. p-limit), and ideally
+   model them as fan-out workflow steps rather than internal loops.
+4. **Push CPU-bound `execute_code` off the main loop** — `isolated-vm` with a
+   memory cap, or out-of-process workers for genuinely heavy crunching.
+5. **Aggregations belong in SQL/the DB**, not in JS, wherever the entity model
+   allows `query.graph` + DB-side grouping.
+
+---
+
+## 5. Caching + queue, the Medusa way (#5)
+
+The infra is **already provisioned** in `medusa-config.prod.ts`:
+`@medusajs/medusa/caching` (caching-redis, default), `event-bus-redis`,
+`workflow-engine-redis`, and `locking-redis` — all on the same ElastiCache
+Serverless (Valkey) cluster. The flow module uses **none** of the cache/queue
+capabilities directly.
+
+**Caching:**
+- Cache the **compiled flow plan** (see #2.1) in Redis keyed by
+  `flow_id:updated_at`; invalidate on save. Removes the per-execution DB load +
+  graph re-derivation.
+- Cache the operations/metadata catalog responses
+  (`/admin/visual-flows/operations`, `/metadata`).
+
+**Queue / async execution (the real win):**
+- Medusa's idiomatic queue _is_ the **workflow engine** (`workflow-engine-redis`)
+  — it already gives durable, retryable, distributed step execution. Lean into
+  it (per-op steps, #2.2) instead of running the whole graph inline.
+- For triggers that shouldn't block (events, webhooks, schedules): **enqueue**
+  the execution (return `202`/ack immediately) and let a worker run it. Today
+  the event subscriber and the every-minute schedule job both run flows _inline_
+  — move them to enqueue-and-ack.
+- The `* * * * *` schedule scanner that loads all schedule-flows and parses cron
+  in JS every minute should become either real per-flow scheduled jobs or a
+  durable-timer/queue-delay mechanism.
+
+---
+
+## 6. Releasing as a Medusa plugin (#1)
+
+**Feasible, but it's a refactor, not a `mv`.** The module proper
+(`modules/visual_flows`) is reasonably self-contained, but the _feature_ is
+spread across `admin/`, `api/`, `workflows/`, `subscribers/`, `jobs/`, and the
+operations have **JYT-specific couplings** that a generic plugin can't ship:
+
+- `generate-partner-deeplink.ts`, `cart-recovery-stats.ts`,
+  `aggregate-product-analytics.ts`, `ai-extract-platform.ts`,
+  `send-whatsapp.ts` — all reference JYT modules / business concepts.
+- The event-trigger subscriber hard-codes ~60 JYT/Medusa event names.
+- `$env` allow-list and credentials are app-specific.
+
+**Recommended shape — split into core + extensions:**
+
+```
+@jyt/visual-flows          ← plugin: engine, models, base operations,
+                              admin UI, API routes, generic triggers
+                              (data CRUD, condition, transform, http,
+                               trigger_workflow, execute_code, log, sleep,
+                               send_email, notification)
+apps/backend (host)        ← registers JYT-specific operations via a public
+                              `registerOperation()` extension point:
+                              partner-deeplink, cart-recovery, whatsapp,
+                              product-analytics, ai-extract-platform
+```
+
+Prerequisites before extraction (do these first regardless of the plugin):
+1. **Collapse to one engine** (#1 above) — can't ship two.
+2. **Make the operation registry an open extension point** so host apps add ops
+   without editing `operations/index.ts`.
+3. **Decouple the trigger event list** from hard-coded names (config-driven
+   subscription).
+4. **Parameterize `$env` allow-list / secrets** via plugin options.
+5. **Settle the isolation story** (#3) — a plugin that ships runtime `npm install`
+   + `new Function` is not something we'd publish.
+
+Package using Medusa 2.x plugin conventions (exports map for `modules`,
+`workflows`, `subscribers`, `jobs`, `admin` extensions). Good external precedent
+exists (Directus Flows, n8n) for the UX, but the Medusa-plugin packaging is the
+new work.
+
+---
+
+## 7. Recommended sequencing
+
+Each step is independently shippable and de-risks the next.
+
+| # | Step | Why first |
+|---|---|---|
+| **P0** | Disable runtime `npm install` in prod (env flag); pre-bundle allowlisted libs. | Closes the live RCE-by-install surface immediately. |
+| **P0** | Delete/converge the dead `execution-engine.ts` → single executor. | Precondition for all engine work; stops drift. |
+| **P1** | Compile-on-save plan + Redis cache of the compiled plan. | Removes per-run DB load + graph re-derivation; foundation for durable steps. |
+| **P1** | Per-operation durable workflow steps (retry, resume, `continue_on_error`). | The core execution-engine upgrade; uses infra we already pay for. |
+| **P2** | Real code isolation (`isolated-vm`, hard mem/CPU limits, curated packages). | Makes `execute_code` safe for untrusted/multi-tenant use. |
+| **P2** | Enqueue-and-ack for event/webhook/schedule triggers; parallel branches; streaming/bounded bulk ops. | Heavy-crunch + throughput; stops inline blocking. |
+| **P3** | Extract to `@jyt/visual-flows` plugin with an open operation-registry extension point; JYT ops stay in the host app. | Reuse / SaaS packaging, once the engine is clean and safe. |
+
+---
+
+## 8. Key file references
+
+- Live executor: `apps/backend/src/workflows/visual-flows/execute-visual-flow.ts` (`executeOperationsStep`, `executeOperationsRecursive`)
+- Dead executor: `apps/backend/src/modules/visual_flows/execution-engine.ts`
+- Code sandbox: `apps/backend/src/modules/visual_flows/operations/execute-code.ts` (`runInSandbox`, `new Function`)
+- Runtime npm install: `apps/backend/src/modules/visual_flows/operations/package-loader.ts` (`installPackage`, `execSync`)
+- Operation registry / types: `apps/backend/src/modules/visual_flows/operations/types.ts`, `operations/index.ts`
+- Triggers: `subscribers/visual-flow-event-trigger.ts`, `jobs/run-scheduled-visual-flows.ts`, `api/webhooks/flows/[id]/route.ts`
+- Infra (Redis cache/event-bus/workflow-engine/locking): `apps/backend/medusa-config.prod.ts` lines ~108–168
+- Admin UI: `apps/backend/src/admin/components/visual-flows/` (`flow-editor.tsx`, `panels/properties-panel.tsx`)
+
+[`@xyflow/react`]: https://reactflow.dev
+[`isolated-vm`]: https://github.com/laverdet/isolated-vm


### PR DESCRIPTION
## #459 P1 — Visual Flows engine foundation

First two slices of the P1 engine rework from the [analysis](apps/docs/notes/VISUAL_FLOWS_PLUGIN_ANALYSIS.md) + [design](apps/docs/notes/VISUAL_FLOWS_P1_ENGINE_DESIGN.md) notes (both included). Pure additions — the **live `execute-visual-flow` executor is untouched**, so prod flows (cart-recovery, etc.) are unaffected.

### 1) Compile-on-save plan + validation + cache
Derive a normalized, validated execution plan at **save** time instead of re-deriving it from `canvas_state` on every run.
- `compiler.ts`: canvas-first (DB-operations fallback) extraction → Kahn **topological levels** + **cycle detection**, branch-handle resolution, op-type resolution, lenient Zod option checks (`{{ }}` template tokens never hard-fail).
- New `compiled_plan` (jsonb) + `compiled_hash` (text) columns via hand-written `ADD COLUMN IF NOT EXISTS` migration.
- `compileAndPersistPlan` wired into create/update workflows; **blocks save only when activating** (`status=active`) an invalid graph — drafts may stay invalid while being built.
- Best-effort Redis plan cache keyed `vflow:plan:{flowId}:{hash}`.

### 2) Durable long-running wait + resume
The suspend/resume primitive the durable executor will use, proven end-to-end.
- `wait_for_event` operation (registered + compiler-recognized; CHECK-constraint migration).
- `flowWaitWorkflow` (`store:true`): sync step opens a `visual_flow_execution` row → **async step suspends in the workflow engine holding no process** → resume closes the row with the payload in `data_chain.$wait`. 24h timeout ceiling. Mirrors the [Medusa long-running docs](https://docs.medusajs.com/learn/fundamentals/workflows/long-running-workflow) + the repo's `backfill-all-geocodes`.
- `POST /admin/visual-flows/waits/:transaction_id/resume` → `setStepSuccess` (mirrors the geocode confirm route).

### Tests
- **10 compiler unit tests** (linear/parallel levels, cycle, unknown-op, dangling edge, branch handles, template-token leniency, stable hash, DB fallback, `wait_for_event` node).
- **4 compile-on-save integration tests** (valid→persisted, draft-cycle→`ok:false`, active-cycle→blocked, update-activate→recompiled).
- **2 long-running integration tests** (suspend→`running`, resume via `setStepSuccess`→`completed` w/ payload). Tests resume explicitly + bounded-poll → **finish or fail, never hang**.

Each spec passes in isolation. Running both visual-flows specs in one shared boot can intermittently hit the **pre-existing `@medusajs/index` `CREATE INDEX CONCURRENTLY` vs `TRUNCATE` boot deadlock** (unrelated to these changes; CI batches per-file).

### Deferred to next slices (handoff on #459)
Per-op durable steps + resumable driver (compiled plan → workflow), executor integration of `wait_for_event`, `isolated-vm` for `execute_code`, disabling runtime `npm install`, plugin extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
