### PR TITLE
feat(visual-flows): gate runtime npm install behind env flag [#459]

### DIFF
--- a/apps/backend/src/modules/visual_flows/operations/__tests__/package-loader.unit.spec.ts
+++ b/apps/backend/src/modules/visual_flows/operations/__tests__/package-loader.unit.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit tests for the visual-flows package-loader runtime-npm-install gate.
+ *
+ * Shell-installing an attacker-supplied package name at flow-execution time is
+ * an RCE vector. The gate (env flag `VFLOW_ALLOW_RUNTIME_NPM_INSTALL`) must:
+ *   - be DISABLED by default,
+ *   - be force-disabled in production even when the flag is set,
+ *   - still load packages that already exist in `node_modules`,
+ *   - throw a clear error (and NOT shell out to `npm install`) for a missing
+ *     package while disabled.
+ *
+ * `child_process` is mocked so we can assert no shell install ever happens.
+ */
+
+jest.mock("child_process", () => ({ execSync: jest.fn() }))
+
+import { execSync } from "child_process"
+import {
+  loadPackage,
+  isRuntimeNpmInstallEnabled,
+  clearPackageCache,
+} from "../package-loader"
+
+const mockExecSync = execSync as unknown as jest.Mock
+
+const FLAG = "VFLOW_ALLOW_RUNTIME_NPM_INSTALL"
+const ORIG_FLAG = process.env[FLAG]
+const ORIG_NODE_ENV = process.env.NODE_ENV
+
+beforeEach(() => {
+  clearPackageCache()
+  mockExecSync.mockReset()
+  delete process.env[FLAG]
+  process.env.NODE_ENV = "test"
+})
+
+afterAll(() => {
+  if (ORIG_FLAG === undefined) {
+    delete process.env[FLAG]
+  } else {
+    process.env[FLAG] = ORIG_FLAG
+  }
+  process.env.NODE_ENV = ORIG_NODE_ENV
+})
+
+describe("isRuntimeNpmInstallEnabled", () => {
+  it("is disabled by default", () => {
+    expect(isRuntimeNpmInstallEnabled()).toBe(false)
+  })
+
+  it.each(["true", "1", "yes", "on", "TRUE", " On "])(
+    "is enabled when flag is %p in a non-production env",
+    (val) => {
+      process.env[FLAG] = val
+      expect(isRuntimeNpmInstallEnabled()).toBe(true)
+    }
+  )
+
+  it("treats arbitrary/false-y values as disabled", () => {
+    for (const val of ["", "false", "0", "no", "maybe"]) {
+      process.env[FLAG] = val
+      expect(isRuntimeNpmInstallEnabled()).toBe(false)
+    }
+  })
+
+  it("is force-disabled in production even when the flag is set", () => {
+    process.env[FLAG] = "true"
+    process.env.NODE_ENV = "production"
+    expect(isRuntimeNpmInstallEnabled()).toBe(false)
+  })
+})
+
+describe("loadPackage gate", () => {
+  it("loads a package already present in node_modules without shelling out", async () => {
+    const lodash = await loadPackage("lodash")
+    expect(typeof lodash.chunk).toBe("function")
+    expect(mockExecSync).not.toHaveBeenCalled()
+  })
+
+  it("throws a clear error for a missing package while disabled (no npm install)", async () => {
+    await expect(
+      loadPackage("definitely-not-a-real-package-xyz-0000")
+    ).rejects.toThrow(/runtime package installation is disabled/i)
+    expect(mockExecSync).not.toHaveBeenCalled()
+  })
+
+  it("error message points operators at the opt-in flag", async () => {
+    await expect(
+      loadPackage("definitely-not-a-real-package-xyz-0001")
+    ).rejects.toThrow(/VFLOW_ALLOW_RUNTIME_NPM_INSTALL/)
+    expect(mockExecSync).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/modules/visual_flows/operations/package-loader.ts
+++ b/apps/backend/src/modules/visual_flows/operations/package-loader.ts
@@ -8,6 +8,34 @@ import * as fs from "fs"
 const packageCache: Map<string, any> = new Map()
 
 /**
+ * Env flag gating runtime `npm install` of arbitrary packages.
+ *
+ * Shell-installing an attacker-supplied package name at flow-execution time is
+ * a remote-code-execution vector (the #1 prod risk flagged in the visual-flows
+ * engine analysis). It is therefore DISABLED by default and force-disabled in
+ * production regardless of the flag. Set
+ * `VFLOW_ALLOW_RUNTIME_NPM_INSTALL=true` only in a trusted, non-production
+ * environment to opt back in.
+ *
+ * When disabled, {@link loadPackage} still loads packages already present in
+ * `node_modules` (or a previously-populated temp dir) — only the on-demand
+ * shell install is blocked.
+ */
+export function isRuntimeNpmInstallEnabled(): boolean {
+  const raw = (process.env.VFLOW_ALLOW_RUNTIME_NPM_INSTALL || "").trim().toLowerCase()
+  const enabled = raw === "true" || raw === "1" || raw === "yes" || raw === "on"
+
+  if (enabled && process.env.NODE_ENV === "production") {
+    console.warn(
+      "[package-loader] VFLOW_ALLOW_RUNTIME_NPM_INSTALL is set but runtime npm install is force-disabled in production for security."
+    )
+    return false
+  }
+
+  return enabled
+}
+
+/**
  * Track packages that are being installed to prevent duplicate installs
  */
 const installingPackages: Set<string> = new Set()
@@ -106,6 +134,15 @@ export async function loadPackage(packageName: string): Promise<any> {
   
   // Check if installed in temp directory
   if (!isPackageInstalled(packageName)) {
+    // Not present anywhere. Only shell-install when explicitly allowed —
+    // installing an arbitrary package name at execution time is an RCE vector.
+    if (!isRuntimeNpmInstallEnabled()) {
+      throw new Error(
+        `Package '${packageName}' is not available and runtime package installation is disabled. ` +
+          `Pre-bundled packages (lodash, dayjs, validator, uuid, crypto, fetch) work out of the box. ` +
+          `To install other packages on demand, set VFLOW_ALLOW_RUNTIME_NPM_INSTALL=true in a non-production environment.`
+      )
+    }
     // Install it
     await installPackage(packageName)
   }


### PR DESCRIPTION
## What

P0 safety slice of the #459 visual-flows engine rework. Gates the on-demand `npm install` in `package-loader.ts` behind `VFLOW_ALLOW_RUNTIME_NPM_INSTALL`.

Shell-installing an attacker-supplied package name at flow-execution time is an RCE vector — the #1 prod risk flagged in the engine analysis (`apps/docs/notes/VISUAL_FLOWS_PLUGIN_ANALYSIS.md`).

## Behavior

- **Disabled by default.** Runtime npm install only happens when `VFLOW_ALLOW_RUNTIME_NPM_INSTALL` is explicitly truthy (`true`/`1`/`yes`/`on`).
- **Force-disabled in production** even when the flag is set (logs a warning).
- When disabled, `loadPackage` still resolves packages already in `node_modules` (so the pre-bundled allowlist — lodash/dayjs/validator/uuid/crypto/fetch — keeps working) and any previously-populated temp dir. Only the on-demand shell install is blocked, with a clear error pointing operators at the opt-in flag.

## Scope / safety

- Live `execute-visual-flow` executor untouched.
- **No migration.**
- Self-contained: one new exported helper + one guard in `loadPackage`.

## Tests

New focused unit spec — `package-loader.unit.spec.ts`, 12 cases:
- flag parsing (truthy variants, false-y/garbage, whitespace),
- production force-disable,
- `node_modules` load path (no shell-out),
- missing-package error path (asserts `execSync` is never called).

```
TEST_TYPE=unit npx jest --testPathPattern="package-loader.unit"
# 12 passed
```

`tsc --noEmit` clean for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)