### PR TITLE
feat(visual-flows): isolated-vm sandbox for execute_code [#459]

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -176,6 +176,9 @@
     "validator": "^13.15.23",
     "zod": "^4.2.0"
   },
+  "optionalDependencies": {
+    "isolated-vm": "^6.1.2"
+  },
   "devDependencies": {
     "@medusajs/test-utils": "2.15.5",
     "@swc/core": "1.7.28",

--- a/apps/backend/src/modules/visual_flows/operations/__tests__/execute-code-isolated.unit.spec.ts
+++ b/apps/backend/src/modules/visual_flows/operations/__tests__/execute-code-isolated.unit.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for the `execute_code` operation's isolated-vm execution backend
+ * (#459 — the code-injection half of the #1 prod RCE risk).
+ *
+ * These force `VFLOW_USE_ISOLATED_VM=true` so user code runs inside a real V8
+ * isolate (no host realm, no `process`/`require`, hard timeout) and assert:
+ *   - the data contract still works ($last/$input/$trigger, $-aliases, {{ }})
+ *   - bridged capabilities work (console, crypto, sleep) and bundled libs
+ *     (lodash/dayjs/validator) are available
+ *   - host-realm escapes are blocked
+ *   - runaway code is killed by the timeout
+ *   - external npm packages are rejected with a clear error in isolated mode
+ *
+ * The operation only reads `context.dataChain`, so we invoke it directly.
+ */
+
+import { isIsolatedVmEnabled } from "../isolated-runner"
+
+const READ_KEY = "read_data_1765961329832"
+
+function makeContext(dataChain: Record<string, any>): any {
+  return {
+    container: {} as any,
+    dataChain: {
+      $trigger: { payload: {}, timestamp: "2026-06-16T00:00:00.000Z" },
+      $last: null,
+      ...dataChain,
+    },
+    flowId: "flow_test",
+    executionId: "exec_test",
+    operationId: "op_test",
+    operationKey: "code_test",
+  }
+}
+
+describe("isIsolatedVmEnabled — flag parsing", () => {
+  const prev = process.env.VFLOW_USE_ISOLATED_VM
+  afterEach(() => {
+    if (prev === undefined) delete process.env.VFLOW_USE_ISOLATED_VM
+    else process.env.VFLOW_USE_ISOLATED_VM = prev
+  })
+
+  it.each(["true", "1", "yes", "on", "TRUE", "  On  "])("treats %p as enabled", (v) => {
+    process.env.VFLOW_USE_ISOLATED_VM = v
+    expect(isIsolatedVmEnabled()).toBe(true)
+  })
+
+  it.each(["false", "0", "no", "off", "", undefined as any])("treats %p as disabled", (v) => {
+    if (v === undefined) delete process.env.VFLOW_USE_ISOLATED_VM
+    else process.env.VFLOW_USE_ISOLATED_VM = v
+    expect(isIsolatedVmEnabled()).toBe(false)
+  })
+})
+
+describe("execute_code — isolated-vm backend", () => {
+  const prev = process.env.VFLOW_USE_ISOLATED_VM
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  let executeCodeOperation: any
+
+  beforeAll(() => {
+    process.env.VFLOW_USE_ISOLATED_VM = "true"
+    // Import after the flag is set (operation reads it at execute time, but be safe).
+    executeCodeOperation = require("../execute-code").executeCodeOperation
+  })
+  afterAll(() => {
+    if (prev === undefined) delete process.env.VFLOW_USE_ISOLATED_VM
+    else process.env.VFLOW_USE_ISOLATED_VM = prev
+  })
+
+  const run = (code: string, dataChain: Record<string, any> = {}, options: any = {}) =>
+    executeCodeOperation.execute({ code, ...options }, makeContext(dataChain))
+
+  it("runs a basic transform reading $last", async () => {
+    const res = await run(
+      `const recs = $last.records || []; return { n: recs.length, ids: recs.map(r => r.id) }`,
+      { $last: { records: [{ id: "a" }, { id: "b" }] } }
+    )
+    expect(res.success).toBe(true)
+    expect(res.data).toEqual({ n: 2, ids: ["a", "b"] })
+  })
+
+  it("exposes $-aliases and {{ }} tokens for named outputs", async () => {
+    const aliasRes = await run(`return $${READ_KEY}.records.length`, {
+      [READ_KEY]: { records: [1, 2, 3] },
+    })
+    expect(aliasRes.success).toBe(true)
+    expect(aliasRes.data).toBe(3)
+
+    const tokenRes = await run(`return JSON.parse({{ $${READ_KEY}.records }})`, {
+      [READ_KEY]: { records: '[{"sku":"A1"},{"sku":"B2"}]' },
+    })
+    expect(tokenRes.success).toBe(true)
+    expect(tokenRes.data).toEqual([{ sku: "A1" }, { sku: "B2" }])
+  })
+
+  it("provides bundled lodash, dayjs and validator inside the isolate", async () => {
+    const res = await run(`return {
+      grouped: _.groupBy([{t:'x'},{t:'y'},{t:'x'}], 't'),
+      year: dayjs('2021-05-05').year(),
+      email: validator.isEmail('a@b.com'),
+    }`)
+    expect(res.success).toBe(true)
+    expect(res.data.year).toBe(2021)
+    expect(res.data.email).toBe(true)
+    expect(Object.keys(res.data.grouped)).toEqual(["x", "y"])
+  })
+
+  it("provides bridged crypto helpers", async () => {
+    const res = await run(`return {
+      sha: crypto.sha256('hello'),
+      isUuid: uuid.validate(crypto.randomUUID()),
+    }`)
+    expect(res.success).toBe(true)
+    // sha256("hello") is a stable, well-known digest
+    expect(res.data.sha).toBe("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")
+    expect(res.data.isUuid).toBe(true)
+  })
+
+  it("supports the bridged async sleep helper", async () => {
+    const res = await run(`await sleep(5); return { done: true }`)
+    expect(res.success).toBe(true)
+    expect(res.data).toEqual({ done: true })
+  })
+
+  it("blocks host-realm escape via constructor chain", async () => {
+    const res = await run(`return this.constructor.constructor('return process')().pid`)
+    expect(res.success).toBe(false)
+    // process must NOT be reachable — either a ReferenceError or undefined access
+    expect(JSON.stringify(res)).not.toContain('"pid"')
+  })
+
+  it("has no process/require in scope", async () => {
+    const res = await run(
+      `return { hasProcess: typeof process, hasRequire: typeof require }`
+    )
+    expect(res.success).toBe(true)
+    expect(res.data).toEqual({ hasProcess: "undefined", hasRequire: "undefined" })
+  })
+
+  it("kills runaway code via the timeout", async () => {
+    const res = await run(`while (true) {}`, {}, { timeout: 300 })
+    expect(res.success).toBe(false)
+    expect(res.error).toMatch(/timed out|time/i)
+  })
+
+  it("rejects external npm packages in isolated mode with a clear error", async () => {
+    const res = await run(`return 1`, {}, { packages: ["axios"] })
+    expect(res.success).toBe(false)
+    expect(res.error).toMatch(/not supported while VFLOW_USE_ISOLATED_VM/i)
+    expect(res.error).toMatch(/axios/)
+  })
+
+  it("still blocks dangerous packages in isolated mode", async () => {
+    const res = await run(`return 1`, {}, { packages: ["child_process"] })
+    expect(res.success).toBe(false)
+    expect(res.error).toMatch(/blocked for security/i)
+  })
+})

--- a/apps/backend/src/modules/visual_flows/operations/execute-code.ts
+++ b/apps/backend/src/modules/visual_flows/operations/execute-code.ts
@@ -2,6 +2,7 @@ import { z } from "@medusajs/framework/zod"
 import { OperationDefinition, OperationContext, OperationResult } from "./types"
 import { getValueByPath } from "./utils"
 import { loadPackage } from "./package-loader"
+import { isIsolatedVmEnabled, runInIsolate } from "./isolated-runner"
 
 // Import npm packages to expose in sandbox
 import lodash from "lodash"
@@ -309,52 +310,95 @@ return {
         validation.warnings.forEach(w => logs.push(`[WARN] ${w}`))
       }
       
-      // Load requested external packages (from node_modules or auto-install)
-      const externalPackages: Record<string, any> = {}
-      const packageErrors: string[] = []
-      
-      for (const pkgName of requestedPackages) {
-        // Security check - block dangerous packages
-        const baseName = pkgName.split("/")[0].replace("@", "")
-        if (BLOCKED_PACKAGES.has(baseName) || BLOCKED_PACKAGES.has(pkgName)) {
-          return {
-            success: false,
-            error: `Package '${pkgName}' is blocked for security reasons.`,
+      // Pick the execution backend. When VFLOW_USE_ISOLATED_VM is enabled, user
+      // code runs inside a real isolated-vm sandbox (no host realm, no process/
+      // require, hard memory + CPU limits) instead of the in-process
+      // `new Function(...)` body — closing the code-injection half of the #1
+      // prod RCE risk. Default is OFF, so production behaviour is unchanged.
+      const isolated = isIsolatedVmEnabled()
+
+      let result: any
+
+      if (isolated) {
+        // Block dangerous packages even in isolated mode (defence in depth)
+        for (const pkgName of requestedPackages) {
+          const baseName = pkgName.split("/")[0].replace("@", "")
+          if (BLOCKED_PACKAGES.has(baseName) || BLOCKED_PACKAGES.has(pkgName)) {
+            return {
+              success: false,
+              error: `Package '${pkgName}' is blocked for security reasons.`,
+            }
           }
         }
-        
-        try {
-          // Load package (auto-installs if not present)
-          const pkg = await loadPackage(pkgName)
-          // Convert package name to valid JS identifier (e.g., "date-fns" -> "date_fns")
-          const varName = pkgName.replace(/[^a-zA-Z0-9]/g, "_").replace(/^_+|_+$/g, "")
-          externalPackages[varName] = pkg
-          logs.push(`[INFO] Loaded package: ${pkgName}`)
-        } catch (err: any) {
-          console.warn(`[execute_code] Failed to load package '${pkgName}': ${err.message}`)
-          packageErrors.push(`${pkgName}: ${err.message}`)
+        // External npm packages can't be bridged as live objects across the
+        // isolate boundary yet. Built-ins (lodash/dayjs/validator/uuid/crypto)
+        // are evaluated inside the isolate and remain available.
+        if (requestedPackages.length > 0) {
+          return {
+            success: false,
+            error:
+              `External npm packages are not supported while VFLOW_USE_ISOLATED_VM is enabled ` +
+              `(requested: ${requestedPackages.join(", ")}). Built-in packages ` +
+              `(lodash, dayjs, validator, uuid, crypto) are available — remove the "packages" ` +
+              `field, or disable isolated mode to load external packages.`,
+          }
         }
-      }
-      
-      // If any packages failed to load, return error
-      if (packageErrors.length > 0) {
-        return {
-          success: false,
-          error: `Failed to load package(s):\n${packageErrors.join("\n")}`,
-          data: { packageErrors },
+
+        console.log("[execute_code] Running in isolated-vm sandbox")
+        result = await runInIsolate(code, {
+          dataChain: context.dataChain,
+          extraBindings,
+          logs,
+          timeout,
+        })
+      } else {
+        // Load requested external packages (from node_modules or auto-install)
+        const externalPackages: Record<string, any> = {}
+        const packageErrors: string[] = []
+
+        for (const pkgName of requestedPackages) {
+          // Security check - block dangerous packages
+          const baseName = pkgName.split("/")[0].replace("@", "")
+          if (BLOCKED_PACKAGES.has(baseName) || BLOCKED_PACKAGES.has(pkgName)) {
+            return {
+              success: false,
+              error: `Package '${pkgName}' is blocked for security reasons.`,
+            }
+          }
+
+          try {
+            // Load package (auto-installs if not present)
+            const pkg = await loadPackage(pkgName)
+            // Convert package name to valid JS identifier (e.g., "date-fns" -> "date_fns")
+            const varName = pkgName.replace(/[^a-zA-Z0-9]/g, "_").replace(/^_+|_+$/g, "")
+            externalPackages[varName] = pkg
+            logs.push(`[INFO] Loaded package: ${pkgName}`)
+          } catch (err: any) {
+            console.warn(`[execute_code] Failed to load package '${pkgName}': ${err.message}`)
+            packageErrors.push(`${pkgName}: ${err.message}`)
+          }
         }
+
+        // If any packages failed to load, return error
+        if (packageErrors.length > 0) {
+          return {
+            success: false,
+            error: `Failed to load package(s):\n${packageErrors.join("\n")}`,
+            data: { packageErrors },
+          }
+        }
+
+        // Create a sandboxed execution environment ($-aliases + token bindings)
+        const sandbox = createSandbox(context.dataChain, logs, externalPackages, extraBindings)
+
+        console.log("[execute_code] Sandbox created with $last:", typeof context.dataChain.$last)
+
+        // Execute with timeout (code is wrapped in async function inside runInSandbox)
+        result = await executeWithTimeout(
+          () => runInSandbox(code, sandbox),
+          timeout
+        )
       }
-      
-      // Create a sandboxed execution environment ($-aliases + token bindings)
-      const sandbox = createSandbox(context.dataChain, logs, externalPackages, extraBindings)
-      
-      console.log("[execute_code] Sandbox created with $last:", typeof context.dataChain.$last)
-      
-      // Execute with timeout (code is wrapped in async function inside runInSandbox)
-      const result = await executeWithTimeout(
-        () => runInSandbox(code, sandbox),
-        timeout
-      )
       
       const duration = Date.now() - startTime
       

--- a/apps/backend/src/modules/visual_flows/operations/isolated-runner.ts
+++ b/apps/backend/src/modules/visual_flows/operations/isolated-runner.ts
@@ -1,0 +1,310 @@
+/**
+ * True-sandbox runner for the visual-flows `execute_code` operation, backed by
+ * `isolated-vm`.
+ *
+ * The default `execute_code` runner uses a `new Function(...)` body, which runs
+ * user code in the host realm — it is explicitly NOT a real sandbox. User code
+ * can escape via prototype tricks (e.g. `this.constructor.constructor("return
+ * process")()`) and reach `process`, `require`, the filesystem, etc. That, plus
+ * runtime npm-install (gated separately in {@link ./package-loader}), is the #1
+ * remote-code-execution risk flagged in the visual-flows engine analysis.
+ *
+ * This module runs the same user code inside a fresh V8 isolate with no host
+ * objects in scope: no `process`, no `require`, no `Function`-realm escape, a
+ * hard memory limit, and a CPU/wall-clock timeout. Capabilities the existing
+ * sandbox exposes are bridged explicitly across the isolate boundary:
+ *
+ *   - data chain (`$input`/`$last`/`$trigger`/`$context`) + `{{ }}` token
+ *     bindings + `$`-aliases — copied in via `ExternalCopy` (structured clone)
+ *   - `console.log/error/warn` — captured to the host `logs` array
+ *   - `crypto` helpers + `uuid` + `btoa`/`atob` — bridged to host functions
+ *   - `sleep(ms)` — bridged to a host timer (capped at 5s)
+ *   - `lodash` (`_`), `dayjs`, `validator` — their UMD bundles are evaluated
+ *     INSIDE the isolate (pure JS, no boundary objects needed)
+ *
+ * NOT supported in isolated mode (yet): `fetch` and on-demand external npm
+ * packages — those require live host objects across the boundary and are left
+ * for a follow-up. The caller surfaces a clear error if a flow requests them.
+ *
+ * Gated behind {@link isIsolatedVmEnabled} (env `VFLOW_USE_ISOLATED_VM`),
+ * DISABLED by default so production behaviour is unchanged until explicitly
+ * opted in. `isolated-vm` is an `optionalDependency` and is imported lazily, so
+ * a host where the native addon is absent or failed to build is unaffected
+ * while the flag is off.
+ */
+
+import * as crypto from "crypto"
+import { createRequire } from "module"
+
+/**
+ * Whether to run `execute_code` inside an `isolated-vm` sandbox instead of the
+ * in-process `new Function(...)` runner.
+ *
+ * DISABLED by default. Set `VFLOW_USE_ISOLATED_VM=true` (or `1`/`yes`/`on`) to
+ * opt in. Unlike the npm-install gate this is a hardening switch, so it is NOT
+ * force-disabled in production — an operator may enable it anywhere.
+ */
+export function isIsolatedVmEnabled(): boolean {
+  const raw = (process.env.VFLOW_USE_ISOLATED_VM || "").trim().toLowerCase()
+  return raw === "true" || raw === "1" || raw === "yes" || raw === "on"
+}
+
+/**
+ * Bootstrap evaluated inside the isolate before user code. Wires `console`,
+ * `crypto`, `uuid`, `btoa`/`atob` and `sleep` onto the isolate global using the
+ * host references injected as `__hostLog` / `__hostCall` / `__hostSleep`.
+ */
+const SANDBOX_BOOTSTRAP = `
+;(function () {
+  function stringify(a) {
+    try { return typeof a === "string" ? a : JSON.stringify(a) }
+    catch (e) { return String(a) }
+  }
+  function joinArgs(args) {
+    return Array.prototype.map.call(args, stringify).join(" ")
+  }
+  global.console = {
+    log: function () { __hostLog.applySync(undefined, ["log", joinArgs(arguments)]) },
+    error: function () { __hostLog.applySync(undefined, ["error", joinArgs(arguments)]) },
+    warn: function () { __hostLog.applySync(undefined, ["warn", joinArgs(arguments)]) },
+    info: function () { __hostLog.applySync(undefined, ["log", joinArgs(arguments)]) },
+    debug: function () { __hostLog.applySync(undefined, ["log", joinArgs(arguments)]) },
+  }
+  function call(kind, args) {
+    return JSON.parse(__hostCall.applySync(undefined, [kind, JSON.stringify(args)]) || "null")
+  }
+  global.crypto = {
+    randomUUID: function () { return call("crypto.randomUUID", []) },
+    hash: function (algorithm, data) { return call("crypto.hash", [algorithm, data]) },
+    md5: function (data) { return call("crypto.md5", [data]) },
+    sha256: function (data) { return call("crypto.sha256", [data]) },
+    hmac: function (algorithm, key, data) { return call("crypto.hmac", [algorithm, key, data]) },
+  }
+  global.uuid = {
+    v4: function () { return call("crypto.randomUUID", []) },
+    validate: function (str) {
+      var re = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      return re.test(str)
+    },
+  }
+  global.btoa = function (str) { return call("util.btoa", [str]) }
+  global.atob = function (str) { return call("util.atob", [str]) }
+  global.sleep = function (ms) {
+    return __hostSleep.apply(undefined, [Math.min(Number(ms) || 0, 5000)], { result: { promise: true } })
+  }
+})();
+`
+
+let cachedLibSources: { lodash: string; dayjs: string; validator: string } | null = null
+
+/**
+ * Read the UMD bundles for the convenience libraries once. They are evaluated
+ * inside the isolate (no host objects cross the boundary). Missing files are
+ * tolerated — the corresponding global just won't be defined.
+ */
+function loadLibSources(): { lodash: string; dayjs: string; validator: string } {
+  if (cachedLibSources) {
+    return cachedLibSources
+  }
+  // Resolve relative to this module so we read the same versions the backend
+  // depends on, regardless of cwd.
+  const req = createRequire(__filename)
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const fs = require("fs") as typeof import("fs")
+  const read = (spec: string): string => {
+    try {
+      return fs.readFileSync(req.resolve(spec), "utf8")
+    } catch {
+      return ""
+    }
+  }
+  cachedLibSources = {
+    lodash: read("lodash/lodash.js"),
+    dayjs: read("dayjs/dayjs.min.js"),
+    validator: read("validator/validator.min.js"),
+  }
+  return cachedLibSources
+}
+
+/**
+ * Host-side dispatcher for the small set of native capabilities exposed to the
+ * sandbox. Receives a JSON payload, returns a JSON string.
+ */
+function hostCall(kind: string, payload: string): string {
+  const args: any[] = JSON.parse(payload || "[]")
+  let result: any = null
+  switch (kind) {
+    case "crypto.randomUUID":
+      result = crypto.randomUUID()
+      break
+    case "crypto.hash":
+      result = crypto.createHash(String(args[0])).update(String(args[1])).digest("hex")
+      break
+    case "crypto.md5":
+      result = crypto.createHash("md5").update(String(args[0])).digest("hex")
+      break
+    case "crypto.sha256":
+      result = crypto.createHash("sha256").update(String(args[0])).digest("hex")
+      break
+    case "crypto.hmac":
+      result = crypto.createHmac(String(args[0]), String(args[1])).update(String(args[2])).digest("hex")
+      break
+    case "util.btoa":
+      result = Buffer.from(String(args[0])).toString("base64")
+      break
+    case "util.atob":
+      result = Buffer.from(String(args[0]), "base64").toString("utf-8")
+      break
+    default:
+      result = null
+  }
+  return JSON.stringify(result === undefined ? null : result)
+}
+
+/**
+ * Lazily import `isolated-vm`. Throws an operator-facing error if the optional
+ * native addon is not installed/built on this host.
+ */
+async function loadIsolatedVm(): Promise<any> {
+  try {
+    const mod: any = await import("isolated-vm")
+    return mod.default || mod
+  } catch (err: any) {
+    throw new Error(
+      `isolated-vm is not available (VFLOW_USE_ISOLATED_VM is enabled but the native module failed to load): ${err?.message || err}`
+    )
+  }
+}
+
+export type IsolatedRunOptions = {
+  /** Full data chain (already containing $last/$trigger/etc.). */
+  dataChain: Record<string, any>
+  /** $-aliases for named outputs + resolved {{ }} token bindings. */
+  extraBindings?: Record<string, any>
+  /** Host log sink — console.* output is appended here. */
+  logs: string[]
+  /** Total wall-clock budget in ms. */
+  timeout: number
+  /** Isolate memory limit in MB. */
+  memoryLimitMb?: number
+}
+
+/**
+ * Best-effort copy of a value across the isolate boundary. Falls back to a JSON
+ * round-trip (which drops functions/undefined) and finally to `undefined` so a
+ * single non-cloneable binding never aborts the whole run.
+ */
+function setBinding(jail: any, ivm: any, name: string, value: any): void {
+  try {
+    jail.setSync(name, new ivm.ExternalCopy(value).copyInto())
+    return
+  } catch {
+    // structured clone failed (e.g. a function) — try a JSON round-trip
+  }
+  try {
+    const safe = value === undefined ? null : JSON.parse(JSON.stringify(value))
+    jail.setSync(name, new ivm.ExternalCopy(safe).copyInto())
+  } catch {
+    jail.setSync(name, new ivm.ExternalCopy(null).copyInto())
+  }
+}
+
+/**
+ * Run `code` inside a fresh isolate and return its value.
+ *
+ * The code is wrapped in an async IIFE so `return` and top-level `await` both
+ * work, mirroring the in-process runner.
+ */
+export async function runInIsolate(code: string, opts: IsolatedRunOptions): Promise<any> {
+  const ivm = await loadIsolatedVm()
+  const { dataChain, extraBindings = {}, logs, timeout } = opts
+  const memoryLimit = opts.memoryLimitMb ?? 128
+
+  const isolate = new ivm.Isolate({ memoryLimit })
+  let disposed = false
+  const dispose = () => {
+    if (!disposed) {
+      disposed = true
+      try {
+        isolate.dispose()
+      } catch {
+        // already disposed / mid-execution termination
+      }
+    }
+  }
+
+  let timer: NodeJS.Timeout | undefined
+  try {
+    const context = await isolate.createContext()
+    const jail = context.global
+    await jail.set("global", jail.derefInto())
+    await jail.set("globalThis", jail.derefInto())
+
+    // ---- host capability references -------------------------------------
+    await jail.set(
+      "__hostLog",
+      new ivm.Reference((level: string, msg: string) => {
+        if (level === "error") logs.push(`[ERROR] ${msg}`)
+        else if (level === "warn") logs.push(`[WARN] ${msg}`)
+        else logs.push(msg)
+      })
+    )
+    await jail.set("__hostCall", new ivm.Reference(hostCall))
+    await jail.set(
+      "__hostSleep",
+      new ivm.Reference((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)))
+    )
+
+    // ---- bootstrap + convenience libraries ------------------------------
+    await context.eval(SANDBOX_BOOTSTRAP)
+    const libs = loadLibSources()
+    if (libs.lodash) {
+      await context.eval(libs.lodash)
+      await context.eval("try { global.lodash = _ } catch (e) {}")
+    }
+    if (libs.dayjs) {
+      await context.eval(libs.dayjs)
+    }
+    if (libs.validator) {
+      await context.eval(libs.validator)
+    }
+
+    // ---- data bindings ---------------------------------------------------
+    setBinding(jail, ivm, "$input", { ...dataChain })
+    setBinding(jail, ivm, "$last", dataChain.$last)
+    setBinding(jail, ivm, "$trigger", dataChain.$trigger)
+    setBinding(jail, ivm, "$context", { timestamp: new Date().toISOString() })
+    for (const [name, value] of Object.entries(extraBindings)) {
+      setBinding(jail, ivm, name, value)
+    }
+
+    // ---- execute ---------------------------------------------------------
+    const wrapped = `(async function () {\n"use strict";\n${code}\n})()`
+
+    const evalPromise = context.eval(wrapped, {
+      timeout,
+      promise: true,
+      copy: true,
+    })
+
+    const result = await Promise.race([
+      evalPromise,
+      new Promise((_resolve, reject) => {
+        // Host-side wall-clock guard: the isolate `timeout` only bounds
+        // synchronous CPU; a pending async chain (e.g. await that never
+        // resolves) needs the isolate forcibly disposed.
+        timer = setTimeout(() => {
+          dispose()
+          reject(new Error(`Execution timed out after ${timeout}ms`))
+        }, timeout + 500)
+      }),
+    ])
+
+    return result
+  } finally {
+    if (timer) {
+      clearTimeout(timer)
+    }
+    dispose()
+  }
+}

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
       "bufferutil",
       "core-js",
       "esbuild",
+      "isolated-vm",
       "msgpackr-extract",
       "protobufjs",
       "sharp",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -562,6 +562,10 @@ importers:
       yalc:
         specifier: ^1.0.0-pre.53
         version: 1.0.0-pre.53
+    optionalDependencies:
+      isolated-vm:
+        specifier: ^6.1.2
+        version: 6.1.2
 
   apps/docs:
     dependencies:
@@ -13017,6 +13021,10 @@ packages:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
 
+  isolated-vm@6.1.2:
+    resolution: {integrity: sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A==}
+    engines: {node: '>=22.0.0'}
+
   issue-parser@6.0.0:
     resolution: {integrity: sha512-zKa/Dxq2lGsBIXQ7CUZWTHfvxPC2ej0KfO7fIPqLlHB9J2hJ7rGhZ5rilhuufylr4RXYPzJUeFjKxz305OsNlA==}
     engines: {node: '>=10.13'}
@@ -14472,6 +14480,10 @@ packages:
 
   node-gyp-build-optional-packages@5.2.2:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
 
   node-html-better-parser@1.5.8:
@@ -36874,6 +36886,11 @@ snapshots:
 
   isobject@3.0.1: {}
 
+  isolated-vm@6.1.2:
+    dependencies:
+      node-gyp-build: 4.8.4
+    optional: true
+
   issue-parser@6.0.0:
     dependencies:
       lodash.capitalize: 4.2.1
@@ -38925,6 +38942,9 @@ snapshots:
   node-gyp-build-optional-packages@5.2.2:
     dependencies:
       detect-libc: 2.1.2
+    optional: true
+
+  node-gyp-build@4.8.4:
     optional: true
 
   node-html-better-parser@1.5.8:


### PR DESCRIPTION
## What

Adds a **true-sandbox execution backend** for the visual-flows `execute_code` operation, backed by [`isolated-vm`](https://github.com/laverdet/isolated-vm) and gated behind env flag **`VFLOW_USE_ISOLATED_VM`** (default **OFF**).

This closes the **code-injection half of the #1 prod RCE risk** flagged in `VISUAL_FLOWS_PLUGIN_ANALYSIS.md`. (The runtime-`npm install` half was gated in #464.)

### The risk
The default runner uses a `new Function(...)` body — explicitly *not* a sandbox. User code can escape to the host realm:
```js
this.constructor.constructor("return process")().mainModule.require("child_process")
```
…reaching `process`, `require`, the filesystem, etc.

### The fix
When `VFLOW_USE_ISOLATED_VM` is on, the same user code runs inside a **fresh V8 isolate** — no host objects in scope (`process`/`require`/`Function`-realm escape all gone), a hard **memory limit**, and a **CPU + wall-clock timeout**.

Capabilities are bridged explicitly across the isolate boundary:
| Capability | How |
|---|---|
| `$input`/`$last`/`$trigger`/`$context`, `{{ }}` tokens, `$`-aliases | `ExternalCopy` (structured clone, JSON fallback) |
| `console.log/error/warn` | captured to host `logs` |
| `crypto` helpers, `uuid`, `btoa`/`atob` | host dispatcher reference |
| `sleep(ms)` | host timer (capped 5s) |
| `lodash` (`_`), `dayjs`, `validator` | their UMD bundles eval'd **inside** the isolate (pure JS, no boundary objects) |

**Not yet supported in isolated mode** (clear error surfaced to the operator): on-demand external npm packages and `fetch` — they need live host objects across the boundary. Left for a follow-up.

## Why it's safe for the auto-deploy pipeline
- `isolated-vm` is an **`optionalDependency`**, imported **lazily** only when the flag is on. With the flag **off (prod default)** the native addon is **never loaded**, so a missing/unbuilt binary can't affect boot.
- `pnpm.onlyBuiltDependencies` updated so the addon builds where allowed. `--frozen-lockfile` verified.
- **No migration.** Live executor and default behaviour unchanged.

> ⚠️ Follow-up to *enable* in prod: the runtime Docker stage installs with `--ignore-scripts`, so the native binary isn't built there yet. Enabling `VFLOW_USE_ISOLATED_VM=true` in prod will need a Docker step to build/prebuild isolated-vm in `.medusa/server`. Until then the flag is dev/opt-in only.

## Verification
Backend-only change — no UI, so no Playwright.

- **22 new unit cases** (`execute-code-isolated.unit.spec.ts`): flag parsing; isolated transform; `$`-alias + `{{ }}` token; lodash/dayjs/validator; crypto + uuid; async sleep; **host-realm escape blocked**; **no process/require in scope**; **runaway loop killed by timeout**; external-package rejection; dangerous-package still blocked.
- Existing `execute-code.unit` (9) + `package-loader.unit` (12) suites still green — **flag-off path untouched**.
- `tsc` clean for changed files. Validated `isolated-vm` v6.1.2 builds + runs on local Node 24 and in the Node 20 builder.

```
TEST_TYPE=unit NODE_OPTIONS="--experimental-vm-modules" npx jest \
  --testPathPattern="execute-code-isolated.unit"   # 22 passed
```

Part of #459 (visual-flows P1 engine rework).

🤖 Generated with [Claude Code](https://claude.com/claude-code)