### PR TITLE
feat(visual-flows): non-blocking enqueue-and-ack schedule scanner [#459]

### DIFF
--- a/apps/backend/integration-tests/http/visual-flows/scheduled-enqueue.spec.ts
+++ b/apps/backend/integration-tests/http/visual-flows/scheduled-enqueue.spec.ts
@@ -1,0 +1,102 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "../shared-test-setup"
+import runScheduledVisualFlows from "../../../src/jobs/run-scheduled-visual-flows"
+import { createVisualFlowWorkflow } from "../../../src/workflows/visual-flows/create-visual-flow"
+import { VISUAL_FLOWS_MODULE } from "../../../src/modules/visual_flows"
+
+jest.setTimeout(60 * 1000)
+
+// Compact canvas/op builders (mirror compile-on-save.spec.ts).
+const node = (id: string, type: string, options: Record<string, any> = {}) => ({
+  id: `op_${id}`,
+  type: "operation",
+  position: { x: 0, y: 0 },
+  data: { operationType: type, operationKey: `${type}_${id}`, options },
+})
+const edge = (s: string, t: string, sourceHandle = "default") => ({
+  id: `${s}->${t}`,
+  source: s === "trigger" ? "trigger" : `op_${s}`,
+  target: `op_${t}`,
+  sourceHandle,
+})
+const opRow = (id: string, type: string, sort: number) => ({
+  operation_key: `${type}_${id}`,
+  operation_type: type,
+  name: `${type} ${id}`,
+  options: {},
+  position_x: 0,
+  position_y: 0,
+  sort_order: sort,
+})
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+async function createScheduledFlow(container: any, name: string) {
+  const { result } = await createVisualFlowWorkflow(container).run({
+    input: {
+      name,
+      status: "active",
+      trigger_type: "schedule",
+      // "* * * * *" always matches the current minute, so the scanner picks it up.
+      trigger_config: { cron: "* * * * *" } as any,
+      canvas_state: {
+        nodes: [node("a", "log")],
+        edges: [edge("trigger", "a")],
+      },
+      operations: [opRow("a", "log", 0)],
+    },
+  })
+  return result.id as string
+}
+
+setupSharedTestSuite(() => {
+  const { getContainer } = getSharedTestEnv()
+
+  describe("visual-flows/scheduled-enqueue (#459 P1 — enqueue-and-ack)", () => {
+    let container: any
+    let service: any
+
+    beforeEach(() => {
+      container = getContainer()
+      service = container.resolve(VISUAL_FLOWS_MODULE)
+    })
+
+    // Kept as ONE test on purpose: the medusa integration runner TRUNCATEs
+    // between tests, and that reset can deadlock against the @medusajs/index
+    // CONCURRENTLY index sync (the documented per-file boot deadlock). One test
+    // = no intermediate reset.
+    it("enqueues a due flow non-blocking, dedups within the minute, then completes", async () => {
+      const flowId = await createScheduledFlow(container, "sched-enqueue-flow")
+
+      // --- Tick 1: the marker must be written before the scanner returns,
+      // proving the scanner does not wait on the (fire-and-forget) workflow. ---
+      await runScheduledVisualFlows(container)
+
+      const after1: any = await service.retrieveVisualFlow(flowId)
+      const sched1 = after1?.metadata?.schedule
+      expect(sched1).toBeTruthy()
+      expect(sched1.last_run_minute_key).toBeTruthy()
+      expect(["enqueued", "completed"]).toContain(sched1.last_status)
+      const enqueuedAt1 = sched1.last_enqueued_at
+      expect(enqueuedAt1).toBeTruthy()
+
+      // --- Tick 2 (same minute): dedup on last_run_minute_key must skip, so
+      // the enqueue-marker timestamp stays unchanged. ---
+      await runScheduledVisualFlows(container)
+      const after2: any = await service.retrieveVisualFlow(flowId)
+      expect(after2?.metadata?.schedule?.last_enqueued_at).toBe(enqueuedAt1)
+
+      // --- The fired workflow eventually completes and records its status.
+      // Polling to completion also drains the background writes before the
+      // suite teardown TRUNCATE runs. ---
+      let final: any
+      for (let i = 0; i < 60; i++) {
+        const f: any = await service.retrieveVisualFlow(flowId)
+        final = f?.metadata?.schedule
+        if (final?.last_status === "completed" || final?.last_status === "failed") break
+        await sleep(250)
+      }
+      expect(final?.last_status).toBe("completed")
+      expect(final?.last_execution_id).toBeTruthy()
+    })
+  })
+})

--- a/apps/backend/src/jobs/run-scheduled-visual-flows.ts
+++ b/apps/backend/src/jobs/run-scheduled-visual-flows.ts
@@ -111,6 +111,32 @@ function minuteKey(date: Date): string {
   return `${y}-${m}-${d}T${hh}:${mm}`
 }
 
+/**
+ * Merge a patch into `metadata.schedule` without clobbering the rest of the
+ * flow's metadata. Re-reads the flow fresh on every write because Medusa
+ * replaces the whole `metadata` blob on update — spreading a stale snapshot
+ * (captured at scan time, minutes/days before a long-running flow finishes)
+ * would drop concurrent writes. We only ever touch the `schedule` sub-object.
+ */
+async function patchScheduleMeta(
+  service: VisualFlowService,
+  flowId: string,
+  patch: Record<string, any>
+): Promise<void> {
+  const current: any = await service.retrieveVisualFlow(flowId)
+  const metadata = (current?.metadata || {}) as any
+  await service.updateVisualFlows({
+    id: flowId,
+    metadata: {
+      ...metadata,
+      schedule: {
+        ...(metadata.schedule || {}),
+        ...patch,
+      },
+    },
+  } as any)
+}
+
 export default async function runScheduledVisualFlows(container: MedusaContainer) {
   const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
   const service: VisualFlowService = container.resolve(VISUAL_FLOWS_MODULE)
@@ -138,8 +164,31 @@ export default async function runScheduledVisualFlows(container: MedusaContainer
       continue
     }
 
+    // Enqueue marker — written BEFORE the flow is fired so the every-minute
+    // scanner never double-enqueues a flow, even when the run is long-lived
+    // (durable waits) or a slow tick overlaps the next one. Dedup is keyed on
+    // this `last_run_minute_key`, so it must land synchronously.
     try {
-      const { result, errors } = await executeVisualFlowWorkflow(container).run({
+      await patchScheduleMeta(service, flow.id, {
+        last_run_minute_key: nowKey,
+        last_run_at: now.toISOString(),
+        last_enqueued_at: now.toISOString(),
+        last_status: "enqueued",
+        last_error: null,
+      })
+    } catch (e: any) {
+      logger.error(
+        `[run-scheduled-visual-flows] flow=${flow.id} failed to mark enqueue: ${e?.message}`
+      )
+      continue
+    }
+
+    // Fire-and-forget: the durable workflow runs in the worker. We deliberately
+    // do NOT await it — one slow or long-running flow must not block the
+    // scanner or the other due flows in this tick (mirrors the webhook async
+    // path). Final status is recorded from the resolved/rejected callbacks.
+    void executeVisualFlowWorkflow(container)
+      .run({
         input: {
           flowId: flow.id,
           triggerData: {
@@ -159,55 +208,27 @@ export default async function runScheduledVisualFlows(container: MedusaContainer
           },
         },
       })
-
-      if (errors?.length) {
-        await service.updateVisualFlows({
-          id: flow.id,
-          metadata: {
-            ...(flow.metadata || {}),
-            schedule: {
-              ...((flow.metadata || {}) as any).schedule,
-              last_run_minute_key: nowKey,
-              last_run_at: now.toISOString(),
-              last_status: "failed",
-              last_error: "Workflow execution returned errors",
-            },
-          },
-        } as any)
-
-        continue
-      }
-
-      await service.updateVisualFlows({
-        id: flow.id,
-        metadata: {
-          ...(flow.metadata || {}),
-          schedule: {
-            ...((flow.metadata || {}) as any).schedule,
-            last_run_minute_key: nowKey,
-            last_run_at: now.toISOString(),
-            last_execution_id: result?.executionId,
-            last_status: "completed",
-          },
-        },
-      } as any)
-    } catch (e: any) {
-      logger.error(`[run-scheduled-visual-flows] flow=${flow.id} error=${e?.message}`)
-
-      await service.updateVisualFlows({
-        id: flow.id,
-        metadata: {
-          ...(flow.metadata || {}),
-          schedule: {
-            ...((flow.metadata || {}) as any).schedule,
-            last_run_minute_key: nowKey,
-            last_run_at: now.toISOString(),
+      .then(({ result, errors }) => {
+        if (errors?.length) {
+          return patchScheduleMeta(service, flow.id, {
             last_status: "failed",
-            last_error: e?.message,
-          },
-        },
-      } as any)
-    }
+            last_error: "Workflow execution returned errors",
+          })
+        }
+        return patchScheduleMeta(service, flow.id, {
+          last_execution_id: result?.executionId,
+          last_status: "completed",
+        })
+      })
+      .catch((e: any) => {
+        logger.error(`[run-scheduled-visual-flows] flow=${flow.id} error=${e?.message}`)
+        return patchScheduleMeta(service, flow.id, {
+          last_status: "failed",
+          last_error: e?.message,
+        }).catch(() => {
+          /* best-effort status write */
+        })
+      })
   }
 }
 


### PR DESCRIPTION
## What

P1 slice 5 (schedule portion) of the #459 visual-flows engine rework: make the every-minute schedule scanner **non-blocking**.

### Problem
`src/jobs/run-scheduled-visual-flows.ts` `await`ed `executeVisualFlowWorkflow().run()` **inline, sequentially**, for each due flow. One slow or long-running flow (e.g. a durable `wait_for_event`/`wait_for_duration`) blocked the scanner and **every other due flow in that minute's tick**. The design note (`VISUAL_FLOWS_P1_ENGINE_DESIGN.md` §4) calls this out: the scanner must only *enqueue*, never execute inline.

### Change
- **Enqueue marker first**: write `last_run_minute_key` / `last_enqueued_at` / `last_status: "enqueued"` synchronously *before* firing, so the minute-key dedup is correct even when a run is long-lived or a slow tick overlaps the next.
- **Fire-and-forget**: the durable workflow runs in the worker (mirrors the existing webhook `async` path). Final `completed`/`failed` status recorded from the resolved/rejected callbacks.
- **`patchScheduleMeta` helper**: re-reads the flow fresh and merges only `metadata.schedule`, so the deferred completion write (seconds–days later) never clobbers concurrent metadata (Medusa replaces the whole `metadata` blob on update).

No schema change, no migration. Live executor untouched.

## Test
`integration-tests/http/visual-flows/scheduled-enqueue.spec.ts` — verifies the marker lands synchronously, same-minute dedup skips a second tick, and the fired workflow eventually completes. Green per-file:

```
PASS integration-tests/http/visual-flows/scheduled-enqueue.spec.ts
  ✓ enqueues a due flow non-blocking, dedups within the minute, then completes
```

> Kept as a single `it()` on purpose — the integration runner TRUNCATEs between tests, which can deadlock against the `@medusajs/index` CONCURRENTLY sync (the documented per-file boot deadlock). One test = no intermediate reset.

## Risk
Low. Pure job-logic change, OFF the request path, no migration. Prior open #459 PRs: #464 (npm-install gate), #465 (isolated-vm). #463 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)