### PR TITLE
feat(visual-flows): #459 P1 slice 5 — event subscriber fire-and-forget dispatch

### DIFF
--- a/apps/backend/integration-tests/http/visual-flows/event-trigger-fire-forget.spec.ts
+++ b/apps/backend/integration-tests/http/visual-flows/event-trigger-fire-forget.spec.ts
@@ -1,0 +1,103 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "../shared-test-setup"
+import visualFlowEventTriggerHandler from "../../../src/subscribers/visual-flow-event-trigger"
+import { createVisualFlowWorkflow } from "../../../src/workflows/visual-flows/create-visual-flow"
+import { VISUAL_FLOWS_MODULE } from "../../../src/modules/visual_flows"
+
+jest.setTimeout(60 * 1000)
+
+// Compact canvas/op builders (mirror scheduled-enqueue.spec.ts).
+const node = (id: string, type: string, options: Record<string, any> = {}) => ({
+  id: `op_${id}`,
+  type: "operation",
+  position: { x: 0, y: 0 },
+  data: { operationType: type, operationKey: `${type}_${id}`, options },
+})
+const edge = (s: string, t: string, sourceHandle = "default") => ({
+  id: `${s}->${t}`,
+  source: s === "trigger" ? "trigger" : `op_${s}`,
+  target: `op_${t}`,
+  sourceHandle,
+})
+const opRow = (id: string, type: string, sort: number) => ({
+  operation_key: `${type}_${id}`,
+  operation_type: type,
+  name: `${type} ${id}`,
+  options: {},
+  position_x: 0,
+  position_y: 0,
+  sort_order: sort,
+})
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+const EVENT_NAME = "test.fire_forget.event"
+
+async function createEventFlow(container: any, name: string) {
+  const { result } = await createVisualFlowWorkflow(container).run({
+    input: {
+      name,
+      status: "active",
+      trigger_type: "event",
+      trigger_config: { event_type: EVENT_NAME } as any,
+      canvas_state: {
+        nodes: [node("a", "log")],
+        edges: [edge("trigger", "a")],
+      },
+      operations: [opRow("a", "log", 0)],
+    },
+  })
+  return result.id as string
+}
+
+async function waitForCompletion(service: any, flowId: string) {
+  for (let i = 0; i < 80; i++) {
+    const execs: any[] = await service.listFlowExecutions(flowId)
+    const done = execs.find(
+      (e) => e.status === "completed" || e.status === "failed"
+    )
+    if (done) return done
+    await sleep(250)
+  }
+  return null
+}
+
+setupSharedTestSuite(() => {
+  const { getContainer } = getSharedTestEnv()
+
+  describe("visual-flows/event-trigger fire-and-forget (#459 P1 — slice 5)", () => {
+    let container: any
+    let service: any
+
+    beforeEach(() => {
+      container = getContainer()
+      service = container.resolve(VISUAL_FLOWS_MODULE)
+    })
+
+    // ONE test on purpose: the medusa integration runner TRUNCATEs between
+    // tests and that reset can deadlock against the @medusajs/index
+    // CONCURRENTLY sync (the documented per-file boot deadlock). One test =
+    // no intermediate reset. Polling to completion also drains the detached
+    // (fire-and-forget) workflow writes before teardown TRUNCATE runs.
+    it("dispatches every matching flow non-blocking and each completes", async () => {
+      const flowA = await createEventFlow(container, "ff-flow-a")
+      const flowB = await createEventFlow(container, "ff-flow-b")
+
+      // The subscriber detaches each flow run (`void ...run()`) and returns
+      // without awaiting — so the bus is never blocked by a slow/long-running
+      // flow. The handler resolving quickly is structurally guaranteed by the
+      // missing `await`; here we assert the behaviour it must preserve: every
+      // matching flow is dispatched and runs to completion independently.
+      await visualFlowEventTriggerHandler({
+        event: { name: EVENT_NAME, data: { ping: "pong" } },
+        container,
+      } as any)
+
+      // Both detached runs eventually complete — proving one flow does not
+      // block the other and matching still dispatches every flow.
+      const doneA = await waitForCompletion(service, flowA)
+      const doneB = await waitForCompletion(service, flowB)
+      expect(doneA?.status).toBe("completed")
+      expect(doneB?.status).toBe("completed")
+    })
+  })
+})

--- a/apps/backend/src/subscribers/visual-flow-event-trigger.ts
+++ b/apps/backend/src/subscribers/visual-flow-event-trigger.ts
@@ -56,28 +56,46 @@ export default async function visualFlowEventTriggerHandler({
     }
     
     logger.info(`[visual-flow-event-trigger] Event "${eventName}" matched ${matchingFlows.length} flow(s)`)
-    
-    // Execute each matching flow
-    for (const flow of matchingFlows) {
-      try {
-        logger.info(`[visual-flow-event-trigger] Executing flow "${flow.name}" (${flow.id})`)
 
-        await executeVisualFlowWorkflow(container).run({
+    // Fire each matching flow WITHOUT awaiting it. The event bus awaits this
+    // subscriber, so awaiting a flow run here would block event delivery — one
+    // slow or long-running flow (durable `wait_for_event` suspends can last
+    // minutes/days) would stall the bus and every other matching flow in this
+    // batch. Detaching mirrors the webhook async path and the schedule scanner
+    // (`run-scheduled-visual-flows.ts`). Each run's own engine persists a flow
+    // execution record, so completion is observable without blocking here.
+    const triggeredAt = new Date().toISOString()
+    for (const flow of matchingFlows) {
+      logger.info(`[visual-flow-event-trigger] Dispatching flow "${flow.name}" (${flow.id})`)
+
+      void executeVisualFlowWorkflow(container)
+        .run({
           input: {
             flowId: flow.id,
             triggerData: eventData,
             triggeredBy: `event:${eventName}`,
             metadata: {
               event_name: eventName,
-              triggered_at: new Date().toISOString(),
+              triggered_at: triggeredAt,
             },
           },
         })
-        
-        logger.info(`[visual-flow-event-trigger] Flow "${flow.name}" executed successfully`)
-      } catch (flowError: any) {
-        logger.error(`[visual-flow-event-trigger] Failed to execute flow "${flow.name}": ${flowError.message}`)
-      }
+        .then(({ errors }) => {
+          if (errors?.length) {
+            logger.error(
+              `[visual-flow-event-trigger] Flow "${flow.name}" (${flow.id}) returned errors`
+            )
+            return
+          }
+          logger.info(
+            `[visual-flow-event-trigger] Flow "${flow.name}" (${flow.id}) executed successfully`
+          )
+        })
+        .catch((flowError: any) => {
+          logger.error(
+            `[visual-flow-event-trigger] Failed to execute flow "${flow.name}" (${flow.id}): ${flowError?.message}`
+          )
+        })
     }
   } catch (error: any) {
     // Don't throw - we don't want to break other subscribers


### PR DESCRIPTION
## What

Part of **#459 (visual-flows P1)** — slice 5, the **event-trigger** half. Makes the `visual-flow-event-trigger` subscriber dispatch matching flows **non-blocking**, completing the same fire-and-forget treatment PR #466 applied to the schedule scanner.

## Why

The subscriber awaited each matching flow run **sequentially** in a `for` loop. The Medusa event bus awaits the subscriber, so:

- A slow or **long-running** flow (durable `wait_for_event` suspends can last minutes/days, landed in #463) would **block event delivery** for the whole bus.
- It would also delay every *other* matching flow in the same batch behind it.

## Change

- Detach each run with `void executeVisualFlowWorkflow(container).run(...)` + `.then/.catch` logging — the handler returns immediately, the durable workflow runs in the worker.
- Mirrors the webhook async path and `run-scheduled-visual-flows.ts` (#466).
- **Live executor untouched. No migration.** Each run persists its own execution record, so completion stays observable (no metadata write-back needed here — unlike the schedule scanner there's no per-minute dedup marker; events are delivered once).

## Test

`integration-tests/http/visual-flows/event-trigger-fire-forget.spec.ts` — green per-file. Two flows on one event both dispatch and run to completion independently. (Single `it()` to avoid the documented @medusajs/index CONCURRENTLY-vs-TRUNCATE per-file boot deadlock; poll-to-completion drains detached writes before teardown.)

```
PASS integration-tests/http/visual-flows/event-trigger-fire-forget.spec.ts
  ✓ dispatches every matching flow non-blocking and each completes
```

tsc clean on changed files. Safe auto-deploy (pure subscriber logic, no schema change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)