### PR TITLE
fix(visual-flows): #459 — guard live executor against diamond double-exec + cycles

### DIFF
--- a/apps/backend/src/workflows/visual-flows/__tests__/executor-dedup.unit.spec.ts
+++ b/apps/backend/src/workflows/visual-flows/__tests__/executor-dedup.unit.spec.ts
@@ -1,0 +1,153 @@
+import {
+  executeOperationsRecursive,
+  findNextOperations,
+} from "../execute-visual-flow"
+
+/**
+ * #459 P1 — live-executor traversal guard unit tests. Pure, no container — fast.
+ *
+ * Verifies the `visited` set added to `executeOperationsRecursive` so each canvas
+ * node runs at most once per execution: fixes diamond-join double-execution and
+ * cyclic-graph infinite loops, while leaving linear/branch flows unchanged.
+ */
+
+type Op = {
+  id: string
+  operation_key: string
+  operation_type: string
+  position_x: number
+  position_y: number
+}
+
+const op = (id: string, type = "log"): Op => ({
+  id,
+  operation_key: `${type}_${id}`,
+  operation_type: type,
+  position_x: 0,
+  position_y: 0,
+})
+
+const conn = (
+  source_id: string,
+  target_id: string,
+  handle = "default"
+) => ({
+  source_id,
+  target_id,
+  source_handle: handle,
+  connection_type:
+    handle === "success" || handle === "failure" ? handle : "default",
+})
+
+/**
+ * Builds a fake per-op executor that records execution order and returns canned
+ * results. `branches` maps an op id → the `_branch` a condition node resolves to.
+ */
+const makeExecOp = (branches: Record<string, string> = {}) => {
+  const order: string[] = []
+  const execOp = async (operation: any) => {
+    order.push(operation.id)
+    const data: Record<string, any> = {}
+    if (operation.operation_type === "condition") {
+      data._branch = branches[operation.id] ?? "success"
+    }
+    return { success: true, data }
+  }
+  return { order, execOp }
+}
+
+const run = (
+  start: Op[],
+  all: Op[],
+  connections: any[],
+  branches?: Record<string, string>
+) => {
+  const { order, execOp } = makeExecOp(branches)
+  return executeOperationsRecursive(
+    start,
+    all,
+    connections,
+    {} as any,
+    "exec-1",
+    "flow-1",
+    null,
+    null as any,
+    new Set<string>(),
+    execOp as any
+  ).then(() => order)
+}
+
+describe("visual_flows/execute-visual-flow traversal guard", () => {
+  it("runs a diamond join node exactly once", async () => {
+    // a -> b, a -> c, b -> d, c -> d
+    const [a, b, c, d] = [op("a"), op("b"), op("c"), op("d")]
+    const all = [a, b, c, d]
+    const connections = [
+      conn("a", "b"),
+      conn("a", "c"),
+      conn("b", "d"),
+      conn("c", "d"),
+    ]
+
+    const order = await run([a], all, connections)
+
+    expect(order.filter((id) => id === "d")).toHaveLength(1)
+    expect(order.sort()).toEqual(["a", "b", "c", "d"])
+    expect(order).toHaveLength(4)
+  })
+
+  it("terminates on a cyclic graph, running each node once", async () => {
+    // a -> b -> a (cycle)
+    const [a, b] = [op("a"), op("b")]
+    const all = [a, b]
+    const connections = [conn("a", "b"), conn("b", "a")]
+
+    const order = await run([a], all, connections)
+
+    expect(order).toEqual(["a", "b"])
+  })
+
+  it("leaves a linear flow unchanged (each node once, in order)", async () => {
+    const [a, b, c] = [op("a"), op("b"), op("c")]
+    const all = [a, b, c]
+    const connections = [conn("a", "b"), conn("b", "c")]
+
+    const order = await run([a], all, connections)
+
+    expect(order).toEqual(["a", "b", "c"])
+  })
+
+  it("follows only the active branch of a condition node", async () => {
+    // cond --success--> x ; cond --failure--> y
+    const cond = op("cond", "condition")
+    const [x, y] = [op("x"), op("y")]
+    const all = [cond, x, y]
+    const connections = [
+      conn("cond", "x", "success"),
+      conn("cond", "y", "failure"),
+    ]
+
+    const order = await run([cond], all, connections, { cond: "success" })
+
+    expect(order).toEqual(["cond", "x"])
+    expect(order).not.toContain("y")
+  })
+
+  it("findNextOperations filters condition branches by handle", () => {
+    const cond = op("cond", "condition")
+    const [x, y] = [op("x"), op("y")]
+    const connections = [
+      conn("cond", "x", "success"),
+      conn("cond", "y", "failure"),
+    ]
+
+    const next = findNextOperations(
+      cond,
+      { success: true, data: { _branch: "failure" } },
+      [cond, x, y],
+      connections
+    )
+
+    expect(next.map((o: any) => o.id)).toEqual(["y"])
+  })
+})

--- a/apps/backend/src/workflows/visual-flows/execute-visual-flow.ts
+++ b/apps/backend/src/workflows/visual-flows/execute-visual-flow.ts
@@ -413,9 +413,24 @@ const completeExecutionStep = createStep(
 // ============ Helper Functions ============
 
 /**
- * Recursively execute operations following the connection graph
+ * Recursively execute operations following the connection graph.
+ *
+ * A `visited` set (keyed by canvas node id) guards every node so it runs **at
+ * most once per execution**. This fixes two correctness bugs in the prior
+ * un-guarded traversal:
+ *   1. Diamond graphs (A→B→D, A→C→D) double-executed the join node `D` — once
+ *      down each branch — re-sending emails / re-writing data.
+ *   2. An accidental cycle (A→B→A) infinite-looped the executor (and the worker).
+ * Linear and simple-branch flows are unaffected (each node is reached once
+ * anyway). True fan-in *join* semantics (waiting for every parent before running
+ * D) are a separate concern handled by the compiled-plan level driver (#459
+ * slice 3); this guard only removes the double-run / infinite-loop hazards.
+ *
+ * `execOp` is injectable so the traversal can be unit-tested without a container.
+ *
+ * @internal exported for unit testing only.
  */
-async function executeOperationsRecursive(
+export async function executeOperationsRecursive(
   currentOps: any[],
   allOperations: any[],
   connections: any[],
@@ -423,7 +438,9 @@ async function executeOperationsRecursive(
   executionId: string,
   flowId: string,
   container: any,
-  service: VisualFlowService
+  service: VisualFlowService,
+  visited: Set<string> = new Set<string>(),
+  execOp: typeof executeSingleOperation = executeSingleOperation
 ): Promise<void> {
   // Sort by position (top to bottom, left to right)
   const sortedOps = [...currentOps].sort((a, b) => {
@@ -434,10 +451,17 @@ async function executeOperationsRecursive(
   console.log("[execute-visual-flow] Executing operations:", sortedOps.map((o: any) => o.operation_key))
 
   for (const operation of sortedOps) {
+    // Skip nodes already executed in this run (diamond join / cycle guard).
+    if (visited.has(operation.id)) {
+      console.log(`[execute-visual-flow] Skipping already-executed: ${operation.operation_key}`)
+      continue
+    }
+    visited.add(operation.id)
+
     console.log(`[execute-visual-flow] Executing: ${operation.operation_key} (${operation.operation_type})`)
-    
+
     // Execute the operation
-    const result = await executeSingleOperation(
+    const result = await execOp(
       operation,
       dataChain,
       executionId,
@@ -468,7 +492,9 @@ async function executeOperationsRecursive(
         executionId,
         flowId,
         container,
-        service
+        service,
+        visited,
+        execOp
       )
     }
   }
@@ -572,9 +598,10 @@ async function executeSingleOperation(
 }
 
 /**
- * Find next operations based on connections and result
+ * Find next operations based on connections and result.
+ * @internal exported for unit testing only.
  */
-function findNextOperations(
+export function findNextOperations(
   currentOp: any,
   result: any,
   allOperations: any[],


### PR DESCRIPTION
## What

Adds a `visited` set to the live executor's `executeOperationsRecursive` so every canvas node runs **at most once per execution**.

## Why

The recursive executor walked the connection graph with no dedup guard:
- **Diamond joins** (`A→B→D`, `A→C→D`) executed the join node `D` **twice** — once down each inbound branch — re-sending emails / re-writing data.
- An accidental **cycle** (`A→B→A`) **infinite-looped** the executor (and its worker process).

Flagged in `VISUAL_FLOWS_P1_ENGINE_DESIGN.md` §2b ("a `completed` set removes today's diamond-graph double-execution risk").

## Scope / safety

- Linear and simple-branch flows are **unaffected** (each node was reached once anyway).
- True fan-in *join* semantics (wait for **all** parents before running `D`) remain for the compiled-plan level driver (#459 slice 3, not in this PR). This PR only removes the double-run / infinite-loop hazards.
- Live-path change → auto-deploys on merge, but behavior changes only for graphs that currently misbehave.
- No migration. Live executor logic otherwise untouched.

## Tests

`executeOperationsRecursive` + `findNextOperations` exported (internal) and the per-op executor made injectable, enabling a pure, container-free unit test:

```
src/workflows/visual-flows/__tests__/executor-dedup.unit.spec.ts  (5 cases, all green)
```
diamond-join-once · cycle-terminates · linear-unchanged · condition-active-branch-only · branch-filter.

`TEST_TYPE=unit jest --testPathPattern=executor-dedup` → 5 passed. `tsc` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)