### PR TITLE
feat(ops): admin data-plumbing maintenance-jobs API (#457)

### DIFF
--- a/apps/backend/integration-tests/http/ops-maintenance-jobs.spec.ts
+++ b/apps/backend/integration-tests/http/ops-maintenance-jobs.spec.ts
@@ -1,0 +1,81 @@
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+
+jest.setTimeout(60 * 1000)
+
+/**
+ * #457 — Admin data-plumbing / ops maintenance jobs (backend API layer).
+ *
+ * Covers the registry discovery endpoint + the run endpoint's guard rails
+ * (unknown job → 404, missing required param → 400, missing design → 404) and
+ * the safe-by-default dry_run behaviour. The full recalc-with-real-data path is
+ * unit-tested via diffCostFields; here we assert the API contract + guards
+ * without heavy BOM/production-run seeding.
+ */
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("admin ops maintenance jobs", () => {
+    let adminHeaders: { headers: Record<string, string> }
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+    })
+
+    it("GET /admin/ops/maintenance-jobs lists the recalculate-design-cost job", async () => {
+      const res = await api.get("/admin/ops/maintenance-jobs", adminHeaders)
+      expect(res.status).toBe(200)
+      expect(res.data.count).toBeGreaterThanOrEqual(1)
+
+      const recalc = res.data.jobs.find(
+        (j: any) => j.id === "recalculate-design-cost"
+      )
+      expect(recalc).toBeDefined()
+      expect(recalc.label).toBeTruthy()
+      expect(recalc.description).toBeTruthy()
+      expect(recalc.params).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "design_id", required: true }),
+        ])
+      )
+    })
+
+    it("POST run with an unknown job id → 404", async () => {
+      await expect(
+        api.post(
+          "/admin/ops/maintenance-jobs/no-such-job/run",
+          { dry_run: true },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 404 } })
+    })
+
+    it("POST recalculate-design-cost without design_id → 400", async () => {
+      await expect(
+        api.post(
+          "/admin/ops/maintenance-jobs/recalculate-design-cost/run",
+          { dry_run: true, params: {} },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+
+    it("POST recalculate-design-cost for a missing design → 404 (before any compute)", async () => {
+      await expect(
+        api.post(
+          "/admin/ops/maintenance-jobs/recalculate-design-cost/run",
+          { dry_run: true, params: { design_id: "design_does_not_exist" } },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 404 } })
+    })
+
+    it("requires admin auth (401 without headers)", async () => {
+      await expect(
+        api.get("/admin/ops/maintenance-jobs")
+      ).rejects.toMatchObject({ response: { status: 401 } })
+    })
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/[id]/run/route.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/[id]/run/route.ts
@@ -1,0 +1,47 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+import { getMaintenanceJob } from "../../registry"
+import { OpsMaintenanceRunBody } from "../../validators"
+
+/**
+ * POST /admin/ops/maintenance-jobs/:id/run
+ *
+ * Runs a guarded maintenance job. Safe by default: dry_run defaults to true, so
+ * a body of {} previews changes without writing. Pass { dry_run: false } to
+ * apply. Every run is logged with the actor + outcome (lightweight audit;
+ * a durable audit-log model is a follow-up slice). (#457)
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const job = getMaintenanceJob(req.params.id)
+  if (!job) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Unknown maintenance job: ${req.params.id}`
+    )
+  }
+
+  const body = (req.validatedBody ?? {}) as OpsMaintenanceRunBody
+  const dry_run = body.dry_run ?? true
+  const params = (body.params ?? {}) as Record<string, unknown>
+
+  const result = await job.run(req.scope, { dry_run, params })
+
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  const actorId = (req as any).auth_context?.actor_id ?? "unknown"
+  logger.info(
+    `[ops/maintenance] actor=${actorId} job=${job.id} dry_run=${result.dry_run} applied=${result.applied} changes=${result.changes.length}`
+  )
+
+  res.json({
+    result,
+    audit: {
+      actor_id: actorId,
+      job_id: job.id,
+      dry_run: result.dry_run,
+      applied: result.applied,
+      change_count: result.changes.length,
+      ran_at: new Date().toISOString(),
+    },
+  })
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/registry.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/registry.unit.spec.ts
@@ -1,0 +1,82 @@
+import {
+  diffCostFields,
+  getMaintenanceJob,
+  MAINTENANCE_JOBS,
+} from "../registry"
+
+// Pure unit coverage for the maintenance-job registry (#457). No DB / workflow
+// boot — only the dry-run/apply diff logic and registry lookup.
+describe("ops/maintenance-jobs registry (#457)", () => {
+  describe("getMaintenanceJob", () => {
+    it("resolves a registered job by id", () => {
+      const job = getMaintenanceJob("recalculate-design-cost")
+      expect(job).toBeDefined()
+      expect(job?.id).toBe("recalculate-design-cost")
+      expect(job?.params.some((p) => p.name === "design_id" && p.required)).toBe(true)
+    })
+
+    it("returns undefined for an unknown job", () => {
+      expect(getMaintenanceJob("does-not-exist")).toBeUndefined()
+    })
+
+    it("exposes at least the recalculate-design-cost job", () => {
+      expect(MAINTENANCE_JOBS.map((j) => j.id)).toContain("recalculate-design-cost")
+    })
+  })
+
+  describe("diffCostFields", () => {
+    const after = { total_estimated: 100, material_cost: 70, production_cost: 30 }
+
+    it("reports a change for every field when nothing is persisted yet (null → value)", () => {
+      const changes = diffCostFields("design_1", {}, after)
+      expect(changes).toHaveLength(3)
+      expect(changes).toEqual(
+        expect.arrayContaining([
+          { entity: "design", id: "design_1", field: "estimated_cost", before: null, after: 100 },
+          { entity: "design", id: "design_1", field: "material_cost", before: null, after: 70 },
+          { entity: "design", id: "design_1", field: "production_cost", before: null, after: 30 },
+        ])
+      )
+    })
+
+    it("returns no changes when persisted values already match (idempotent apply)", () => {
+      const changes = diffCostFields(
+        "design_1",
+        { estimated_cost: 100, material_cost: 70, production_cost: 30 },
+        after
+      )
+      expect(changes).toEqual([])
+    })
+
+    it("only reports the fields that actually differ", () => {
+      const changes = diffCostFields(
+        "design_1",
+        { estimated_cost: 100, material_cost: 60, production_cost: 30 },
+        after
+      )
+      expect(changes).toEqual([
+        { entity: "design", id: "design_1", field: "material_cost", before: 60, after: 70 },
+      ])
+    })
+
+    it("coerces string-typed persisted decimals before comparing", () => {
+      const changes = diffCostFields(
+        "design_1",
+        { estimated_cost: "100" as any, material_cost: "70" as any, production_cost: "30" as any },
+        after
+      )
+      expect(changes).toEqual([])
+    })
+
+    it("treats null and 0 as distinct (null is unset, 0 is a real value)", () => {
+      const changes = diffCostFields(
+        "design_1",
+        { estimated_cost: 100, material_cost: 70, production_cost: null },
+        after
+      )
+      expect(changes).toEqual([
+        { entity: "design", id: "design_1", field: "production_cost", before: null, after: 30 },
+      ])
+    })
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -1,0 +1,182 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import { estimateDesignCostWorkflow } from "../../../../workflows/designs/estimate-design-cost"
+import { DESIGN_MODULE } from "../../../../modules/designs"
+
+/**
+ * Admin "data-plumbing" maintenance jobs (#457 / roadmap #33).
+ *
+ * Each job is a guarded, API-driven data-correction action that follows the
+ * same safe-by-default contract:
+ *   - dry-run preview (default) → returns the changes it WOULD make, no writes
+ *   - apply (dry_run=false)     → idempotent write, returns the changes made
+ *
+ * Jobs mostly surface + guard-rail existing endpoints/scripts so the recurring
+ * "the code fix prevents recurrence but stored rows still need a targeted, safe
+ * correction" incident no longer requires raw curl / one-off ECS run-task
+ * scripts. This is the backend (API) layer; an admin Ops console can consume it.
+ */
+
+export type MaintenanceChange = {
+  entity: string
+  id: string
+  field?: string
+  before?: unknown
+  after?: unknown
+}
+
+export type MaintenanceJobResult = {
+  job_id: string
+  dry_run: boolean
+  /** true only when dry_run=false AND at least one field actually changed */
+  applied: boolean
+  summary: string
+  changes: MaintenanceChange[]
+}
+
+export type MaintenanceJobParam = {
+  name: string
+  type: "string" | "number" | "boolean"
+  required: boolean
+  description: string
+}
+
+export type MaintenanceJob = {
+  id: string
+  label: string
+  description: string
+  /** Human/consumer-facing param descriptors (for the list endpoint + UI) */
+  params: MaintenanceJobParam[]
+  run: (
+    container: any,
+    opts: { dry_run: boolean; params: Record<string, unknown> }
+  ) => Promise<MaintenanceJobResult>
+}
+
+/**
+ * Pure diff between a design's currently-persisted cost fields and a freshly
+ * computed estimate. Exported for unit testing — keeps the dry-run/apply logic
+ * verifiable without booting the DB or the workflow engine.
+ */
+export function diffCostFields(
+  designId: string,
+  before: {
+    estimated_cost?: number | null
+    material_cost?: number | null
+    production_cost?: number | null
+  },
+  after: { total_estimated: number; material_cost: number; production_cost: number }
+): MaintenanceChange[] {
+  const pairs: Array<[string, number | null | undefined, number]> = [
+    ["estimated_cost", before.estimated_cost, after.total_estimated],
+    ["material_cost", before.material_cost, after.material_cost],
+    ["production_cost", before.production_cost, after.production_cost],
+  ]
+
+  const changes: MaintenanceChange[] = []
+  for (const [field, rawBefore, afterValue] of pairs) {
+    const beforeValue = rawBefore == null ? null : Number(rawBefore)
+    if (beforeValue !== afterValue) {
+      changes.push({ entity: "design", id: designId, field, before: beforeValue, after: afterValue })
+    }
+  }
+  return changes
+}
+
+const recalcParamsSchema = z.object({
+  design_id: z.string().min(1, "design_id is required"),
+})
+
+/**
+ * Recalculate design cost — surfaces the same computation as
+ * POST /admin/designs/:id/recalculate-cost, but with a dry-run preview that
+ * shows the before/after of estimated/material/production cost WITHOUT
+ * persisting. Apply mirrors that route's persist payload exactly.
+ */
+export const recalculateDesignCostJob: MaintenanceJob = {
+  id: "recalculate-design-cost",
+  label: "Recalculate design cost",
+  description:
+    "Re-estimate a design's material + production cost from its BOM and latest completed production run. Dry-run previews the before/after without persisting; apply writes the full breakdown back onto the design (idempotent).",
+  params: [
+    {
+      name: "design_id",
+      type: "string",
+      required: true,
+      description: "ID of the design to recalculate",
+    },
+  ],
+  run: async (container, { dry_run, params }) => {
+    const parsed = recalcParamsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { design_id } = parsed.data
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const { data: designs } = await query.graph({
+      entity: "design",
+      filters: { id: design_id },
+      fields: ["id", "estimated_cost", "material_cost", "production_cost"],
+    })
+
+    if (!designs || designs.length === 0) {
+      throw new MedusaError(MedusaError.Types.NOT_FOUND, `Design not found: ${design_id}`)
+    }
+    const current = designs[0]
+
+    const { result, errors } = await estimateDesignCostWorkflow(container).run({
+      input: { design_id },
+    })
+
+    if (errors && errors.length > 0) {
+      throw new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        `Failed to estimate cost: ${errors
+          .map((e: any) => e?.error?.message ?? String(e))
+          .join("; ")}`
+      )
+    }
+
+    const changes = diffCostFields(design_id, current, result)
+
+    if (!dry_run && changes.length > 0) {
+      const designService: any = container.resolve(DESIGN_MODULE)
+      await designService.updateDesigns({
+        id: design_id,
+        estimated_cost: result.total_estimated,
+        material_cost: result.material_cost,
+        production_cost: result.production_cost,
+        cost_breakdown: {
+          items: result.breakdown?.materials ?? [],
+          production_percent: result.breakdown?.production_percent,
+          confidence: result.confidence,
+          calculated_at: new Date().toISOString(),
+          source: "ops_maintenance_recalculate",
+        },
+      })
+    }
+
+    const summary =
+      changes.length === 0
+        ? `No changes — design ${design_id} cost already up to date (total ${result.total_estimated})`
+        : `${dry_run ? "Would update" : "Updated"} ${changes.length} field(s) on design ${design_id}; new total ${result.total_estimated} (${result.confidence})`
+
+    return {
+      job_id: recalculateDesignCostJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary,
+      changes,
+    }
+  },
+}
+
+export const MAINTENANCE_JOBS: MaintenanceJob[] = [recalculateDesignCostJob]
+
+export const getMaintenanceJob = (id: string): MaintenanceJob | undefined =>
+  MAINTENANCE_JOBS.find((job) => job.id === id)

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/route.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/route.ts
@@ -1,0 +1,21 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+import { MAINTENANCE_JOBS } from "./registry"
+
+/**
+ * GET /admin/ops/maintenance-jobs
+ *
+ * Lists the available data-plumbing maintenance jobs and their parameters so an
+ * admin Ops console (or a script) can discover what's runnable. (#457)
+ */
+export const GET = async (_req: MedusaRequest, res: MedusaResponse) => {
+  res.json({
+    jobs: MAINTENANCE_JOBS.map((job) => ({
+      id: job.id,
+      label: job.label,
+      description: job.description,
+      params: job.params,
+    })),
+    count: MAINTENANCE_JOBS.length,
+  })
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/validators.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/validators.ts
@@ -1,0 +1,17 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * Body for POST /admin/ops/maintenance-jobs/:id/run.
+ * dry_run defaults to true (safe by default) — the route applies the default
+ * since validateAndTransformBody strips unknown keys but won't inject one.
+ */
+export const OpsMaintenanceRunSchema = z.object({
+  dry_run: z.boolean().optional(),
+  // Per-job params are validated inside each job's own schema; here we only
+  // accept an object. NOTE: zod v4 requires the two-arg z.record form
+  // (z.record(z.any()) leaves the value schema undefined → "_zod" crash when
+  // params is non-empty).
+  params: z.record(z.string(), z.any()).optional(),
+})
+
+export type OpsMaintenanceRunBody = z.infer<typeof OpsMaintenanceRunSchema>

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -17,6 +17,7 @@ import { parseCorsOrigins, ContainerRegistrationKeys } from "@medusajs/framework
 import cors from "cors";
 import { z } from "@medusajs/framework/zod";
 import { personSchema, listPersonsQuerySchema, UpdatePersonSchema, ReadPersonQuerySchema } from "./admin/persons/validators";
+import { OpsMaintenanceRunSchema } from "./admin/ops/maintenance-jobs/validators";
 import { getPersonResourceDefinition } from "./admin/persons/resources/registry";
 import { AdminGetOrdersOrderParams } from "@medusajs/medusa/api/admin/orders/validators";
 import { retrieveTransformQueryConfig as retrieveOrderTransformQueryConfig } from "@medusajs/medusa/api/admin/orders/query-config";
@@ -2950,6 +2951,12 @@ export default defineMiddlewares({
       matcher: "/admin/designs",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(designSchema))],
+    },
+    {
+      // #457 admin data-plumbing / ops maintenance jobs
+      matcher: "/admin/ops/maintenance-jobs/:id/run",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(OpsMaintenanceRunSchema))],
     },
     // NOTE: /admin/* routes already get Medusa's default admin auth
     // (session + bearer + api-key). Re-registering authenticate() with only


### PR DESCRIPTION
## What
Backend **API layer** for the admin "data-plumbing / ops tools" feature (#457 / roadmap #33). A registry of guarded, API-driven data-correction jobs with a **safe-by-default** contract: dry-run preview → idempotent apply, lightweight audit log.

This is intentionally backend-first per the issue's principle — *"API-driven: every action is a real admin endpoint (so it's scriptable too), not a UI-only hack."* An admin Ops console can consume these endpoints in a follow-up.

### Endpoints
- `GET /admin/ops/maintenance-jobs` — discover runnable jobs + their params.
- `POST /admin/ops/maintenance-jobs/:id/run` — run a job. Body `{ dry_run?, params? }`; **`dry_run` defaults to `true`** (a body of `{}` previews, never writes). Pass `{ "dry_run": false }` to apply.

### First job: `recalculate-design-cost`
Surfaces the same computation as `POST /admin/designs/:id/recalculate-cost`, but:
- **dry-run** computes the estimate and returns the `estimated/material/production` cost **before→after** diff **without persisting**;
- **apply** persists via the exact same payload the existing route uses.

The compute (`estimateDesignCostWorkflow`) is read-only — the persist lives in the route — so the dry-run is clean by construction. A missing design returns **404 before any compute**.

## Why
Per #457: incident fixes prevent recurrence, but already-stored rows still need targeted, safe corrections, which we keep doing by hand via SSM token + curl / one-off ECS run-task scripts. This gives those corrections a first-class, audited, dry-runnable home.

## Tests
- **8 unit** (`registry.unit.spec.ts`) — `diffCostFields` (null=unset vs 0, string-decimal coercion, idempotency, partial diffs) + registry lookup.
- **5 integration** (`ops-maintenance-jobs.spec.ts`) — discovery shape, unknown-job → 404, missing-param → 400, missing-design → 404, unauth → 401.
- `tsc --noEmit`: 0 new errors (69 total, ≤ baseline).

## Notes / follow-ups
- Audit is lightweight (logger line + `audit` block in the response). A **durable audit-log model** is a deliberate follow-up slice.
- More jobs (correct production-run cost, promote backfill scripts, re-projection) plug into `MAINTENANCE_JOBS` with the same contract.
- ⚠️ zod v4 gotcha fixed: `z.record(z.any())` leaves the value schema undefined → `_zod` crash on non-empty `params`; must use the two-arg `z.record(z.string(), z.any())`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)