### PR TITLE
feat(ops): bulk recalculate-design-cost maintenance job (#457)

### DIFF
--- a/apps/backend/integration-tests/http/ops-maintenance-jobs.spec.ts
+++ b/apps/backend/integration-tests/http/ops-maintenance-jobs.spec.ts
@@ -72,6 +72,53 @@ setupSharedTestSuite(() => {
       ).rejects.toMatchObject({ response: { status: 404 } })
     })
 
+    it("GET lists the bulk recalculate job alongside the single one", async () => {
+      const res = await api.get("/admin/ops/maintenance-jobs", adminHeaders)
+      expect(res.status).toBe(200)
+      const ids = res.data.jobs.map((j: any) => j.id)
+      expect(ids).toEqual(
+        expect.arrayContaining([
+          "recalculate-design-cost",
+          "recalculate-design-cost-bulk",
+        ])
+      )
+      const bulk = res.data.jobs.find(
+        (j: any) => j.id === "recalculate-design-cost-bulk"
+      )
+      expect(bulk.params).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "design_ids", required: true }),
+        ])
+      )
+    })
+
+    it("POST recalculate-design-cost-bulk without design_ids → 400", async () => {
+      await expect(
+        api.post(
+          "/admin/ops/maintenance-jobs/recalculate-design-cost-bulk/run",
+          { dry_run: true, params: {} },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+
+    it("POST recalculate-design-cost-bulk reports a missing id per-design instead of failing the batch", async () => {
+      const res = await api.post(
+        "/admin/ops/maintenance-jobs/recalculate-design-cost-bulk/run",
+        { dry_run: true, params: { design_ids: ["design_does_not_exist"] } },
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.result.dry_run).toBe(true)
+      expect(res.data.result.applied).toBe(false)
+      expect(res.data.result.changes).toEqual([])
+      expect(res.data.result.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: "design_does_not_exist" }),
+        ])
+      )
+    })
+
     it("requires admin auth (401 without headers)", async () => {
       await expect(
         api.get("/admin/ops/maintenance-jobs")

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/registry.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/registry.unit.spec.ts
@@ -2,6 +2,9 @@ import {
   diffCostFields,
   getMaintenanceJob,
   MAINTENANCE_JOBS,
+  MAX_BULK_DESIGNS,
+  parseDesignIds,
+  summarizeBulkRecalc,
 } from "../registry"
 
 // Pure unit coverage for the maintenance-job registry (#457). No DB / workflow
@@ -21,6 +24,64 @@ describe("ops/maintenance-jobs registry (#457)", () => {
 
     it("exposes at least the recalculate-design-cost job", () => {
       expect(MAINTENANCE_JOBS.map((j) => j.id)).toContain("recalculate-design-cost")
+    })
+
+    it("registers the bulk recalculate job with a required design_ids param", () => {
+      const job = getMaintenanceJob("recalculate-design-cost-bulk")
+      expect(job).toBeDefined()
+      expect(job?.params.some((p) => p.name === "design_ids" && p.required)).toBe(true)
+    })
+  })
+
+  describe("parseDesignIds", () => {
+    it("accepts an array of ids", () => {
+      expect(parseDesignIds(["d_1", "d_2"])).toEqual(["d_1", "d_2"])
+    })
+
+    it("accepts a comma/whitespace/newline-separated string", () => {
+      expect(parseDesignIds("d_1, d_2\nd_3  d_4")).toEqual(["d_1", "d_2", "d_3", "d_4"])
+    })
+
+    it("trims, drops blanks, and de-duplicates while preserving order", () => {
+      expect(parseDesignIds([" d_1 ", "d_2", "", "d_1"])).toEqual(["d_1", "d_2"])
+    })
+
+    it("throws INVALID_DATA when no usable id is present", () => {
+      expect(() => parseDesignIds("  ,  ")).toThrow(/at least one/)
+      expect(() => parseDesignIds([])).toThrow(/at least one/)
+    })
+
+    it("throws INVALID_DATA for a non-string/array input", () => {
+      expect(() => parseDesignIds(undefined)).toThrow(/required/)
+      expect(() => parseDesignIds(42 as any)).toThrow(/required/)
+    })
+
+    it("rejects more ids than the per-request cap", () => {
+      const tooMany = Array.from({ length: MAX_BULK_DESIGNS + 1 }, (_, i) => `d_${i}`)
+      expect(() => parseDesignIds(tooMany)).toThrow(/limit of/)
+    })
+
+    it("allows exactly the cap", () => {
+      const atCap = Array.from({ length: MAX_BULK_DESIGNS }, (_, i) => `d_${i}`)
+      expect(parseDesignIds(atCap)).toHaveLength(MAX_BULK_DESIGNS)
+    })
+  })
+
+  describe("summarizeBulkRecalc", () => {
+    it("reports no changes when nothing drifted", () => {
+      expect(summarizeBulkRecalc(true, 3, 0, 0, 0)).toMatch(/No changes — 3 design/)
+    })
+
+    it("uses 'Would update' for dry-run and counts changed designs", () => {
+      expect(summarizeBulkRecalc(true, 5, 2, 4, 0)).toBe(
+        "Would update 4 field(s) across 2/5 design(s)"
+      )
+    })
+
+    it("uses 'Updated' on apply and appends an error count when present", () => {
+      expect(summarizeBulkRecalc(false, 5, 2, 4, 1)).toBe(
+        "Updated 4 field(s) across 2/5 design(s); 1 error(s)"
+      )
     })
   })
 

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -33,6 +33,12 @@ export type MaintenanceJobResult = {
   applied: boolean
   summary: string
   changes: MaintenanceChange[]
+  /**
+   * Per-entity errors for batch jobs — a single bad id (e.g. a deleted design)
+   * is recorded here instead of aborting the whole run. Omitted for
+   * single-entity jobs (which throw a MedusaError → HTTP status instead).
+   */
+  errors?: Array<{ id: string; message: string }>
 }
 
 export type MaintenanceJobParam = {
@@ -84,6 +90,76 @@ export function diffCostFields(
   return changes
 }
 
+type DesignCostEstimate = {
+  total_estimated: number
+  material_cost: number
+  production_cost: number
+  confidence: string
+  breakdown?: { materials?: unknown[]; production_percent?: number }
+}
+
+/**
+ * Shared compute used by both the single- and bulk-recalculate jobs: load the
+ * design's currently-persisted cost fields and run the (read-only) estimate
+ * workflow. Throws NOT_FOUND if the design is gone and UNEXPECTED_STATE if the
+ * workflow itself fails — so callers get the right HTTP status for free.
+ */
+export async function recomputeDesignCost(
+  container: any,
+  designId: string
+): Promise<{
+  current: { estimated_cost?: number | null; material_cost?: number | null; production_cost?: number | null }
+  result: DesignCostEstimate
+}> {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  const { data: designs } = await query.graph({
+    entity: "design",
+    filters: { id: designId },
+    fields: ["id", "estimated_cost", "material_cost", "production_cost"],
+  })
+
+  if (!designs || designs.length === 0) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, `Design not found: ${designId}`)
+  }
+
+  const { result, errors } = await estimateDesignCostWorkflow(container).run({
+    input: { design_id: designId },
+  })
+
+  if (errors && errors.length > 0) {
+    throw new MedusaError(
+      MedusaError.Types.UNEXPECTED_STATE,
+      `Failed to estimate cost: ${errors
+        .map((e: any) => e?.error?.message ?? String(e))
+        .join("; ")}`
+    )
+  }
+
+  return { current: designs[0], result: result as DesignCostEstimate }
+}
+
+/** Persist a freshly-computed estimate back onto a design (idempotent). */
+export async function persistDesignCost(
+  container: any,
+  designId: string,
+  result: DesignCostEstimate
+): Promise<void> {
+  const designService: any = container.resolve(DESIGN_MODULE)
+  await designService.updateDesigns({
+    id: designId,
+    estimated_cost: result.total_estimated,
+    material_cost: result.material_cost,
+    production_cost: result.production_cost,
+    cost_breakdown: {
+      items: result.breakdown?.materials ?? [],
+      production_percent: result.breakdown?.production_percent,
+      confidence: result.confidence,
+      calculated_at: new Date().toISOString(),
+      source: "ops_maintenance_recalculate",
+    },
+  })
+}
+
 const recalcParamsSchema = z.object({
   design_id: z.string().min(1, "design_id is required"),
 })
@@ -117,48 +193,11 @@ export const recalculateDesignCostJob: MaintenanceJob = {
     }
     const { design_id } = parsed.data
 
-    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
-    const { data: designs } = await query.graph({
-      entity: "design",
-      filters: { id: design_id },
-      fields: ["id", "estimated_cost", "material_cost", "production_cost"],
-    })
-
-    if (!designs || designs.length === 0) {
-      throw new MedusaError(MedusaError.Types.NOT_FOUND, `Design not found: ${design_id}`)
-    }
-    const current = designs[0]
-
-    const { result, errors } = await estimateDesignCostWorkflow(container).run({
-      input: { design_id },
-    })
-
-    if (errors && errors.length > 0) {
-      throw new MedusaError(
-        MedusaError.Types.UNEXPECTED_STATE,
-        `Failed to estimate cost: ${errors
-          .map((e: any) => e?.error?.message ?? String(e))
-          .join("; ")}`
-      )
-    }
-
+    const { current, result } = await recomputeDesignCost(container, design_id)
     const changes = diffCostFields(design_id, current, result)
 
     if (!dry_run && changes.length > 0) {
-      const designService: any = container.resolve(DESIGN_MODULE)
-      await designService.updateDesigns({
-        id: design_id,
-        estimated_cost: result.total_estimated,
-        material_cost: result.material_cost,
-        production_cost: result.production_cost,
-        cost_breakdown: {
-          items: result.breakdown?.materials ?? [],
-          production_percent: result.breakdown?.production_percent,
-          confidence: result.confidence,
-          calculated_at: new Date().toISOString(),
-          source: "ops_maintenance_recalculate",
-        },
-      })
+      await persistDesignCost(container, design_id, result)
     }
 
     const summary =
@@ -176,7 +215,140 @@ export const recalculateDesignCostJob: MaintenanceJob = {
   },
 }
 
-export const MAINTENANCE_JOBS: MaintenanceJob[] = [recalculateDesignCostJob]
+/**
+ * Hard cap on the bulk recalculate job: each id runs the estimate workflow
+ * synchronously, so we keep the per-request blast radius operator-bounded and
+ * the endpoint responsive. Larger corrections should be chunked across calls.
+ */
+export const MAX_BULK_DESIGNS = 25
+
+/**
+ * Pure normaliser for the bulk job's `design_ids` param. Accepts either a real
+ * array or a comma/whitespace/newline-separated string (handy for pasting a
+ * column out of a spreadsheet). Trims, drops blanks, de-duplicates while
+ * preserving order, and enforces the 1..MAX_BULK_DESIGNS bound. Exported for
+ * unit testing — no container/DB needed.
+ */
+export function parseDesignIds(input: unknown): string[] {
+  let raw: unknown[]
+  if (Array.isArray(input)) {
+    raw = input
+  } else if (typeof input === "string") {
+    raw = input.split(/[\s,]+/)
+  } else {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "design_ids is required (array or comma-separated string of design ids)"
+    )
+  }
+
+  const seen = new Set<string>()
+  const ids: string[] = []
+  for (const entry of raw) {
+    const id = typeof entry === "string" ? entry.trim() : String(entry ?? "").trim()
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+    ids.push(id)
+  }
+
+  if (ids.length === 0) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "design_ids must contain at least one non-empty id"
+    )
+  }
+  if (ids.length > MAX_BULK_DESIGNS) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `design_ids exceeds the per-request limit of ${MAX_BULK_DESIGNS} (got ${ids.length}); split into smaller batches`
+    )
+  }
+  return ids
+}
+
+/**
+ * Pure summary builder for the bulk job — keeps the human-facing string logic
+ * verifiable without booting the workflow engine.
+ */
+export function summarizeBulkRecalc(
+  dryRun: boolean,
+  idCount: number,
+  changedDesignCount: number,
+  changeCount: number,
+  errorCount: number
+): string {
+  const verb = dryRun ? "Would update" : "Updated"
+  const head =
+    changeCount === 0
+      ? `No changes — ${idCount} design(s) already up to date`
+      : `${verb} ${changeCount} field(s) across ${changedDesignCount}/${idCount} design(s)`
+  return errorCount > 0 ? `${head}; ${errorCount} error(s)` : head
+}
+
+/**
+ * Bulk recalculate design cost — same per-design compute as
+ * `recalculate-design-cost`, but over an explicit, capped list of ids so an
+ * operator can re-correct many drifted designs in one guarded call after a
+ * cost-logic fix. Dry-run (default) previews the full aggregate change set;
+ * one bad/deleted id is reported in `errors` instead of failing the batch.
+ */
+export const recalculateDesignCostBulkJob: MaintenanceJob = {
+  id: "recalculate-design-cost-bulk",
+  label: "Recalculate design cost (bulk)",
+  description:
+    `Re-estimate material + production cost for an explicit list of designs (max ${MAX_BULK_DESIGNS} per call). Dry-run previews the aggregate before/after without persisting; apply writes each design's breakdown back (idempotent). A missing/deleted id is reported per-design and does not abort the batch.`,
+  params: [
+    {
+      name: "design_ids",
+      type: "string",
+      required: true,
+      description: `Design ids to recalculate — array or comma-separated string (max ${MAX_BULK_DESIGNS})`,
+    },
+  ],
+  run: async (container, { dry_run, params }) => {
+    const ids = parseDesignIds((params as any).design_ids)
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    const changedDesigns = new Set<string>()
+
+    for (const designId of ids) {
+      try {
+        const { current, result } = await recomputeDesignCost(container, designId)
+        const designChanges = diffCostFields(designId, current, result)
+        if (designChanges.length > 0) {
+          changedDesigns.add(designId)
+          changes.push(...designChanges)
+          if (!dry_run) {
+            await persistDesignCost(container, designId, result)
+          }
+        }
+      } catch (e: any) {
+        errors.push({ id: designId, message: e?.message ?? String(e) })
+      }
+    }
+
+    return {
+      job_id: recalculateDesignCostBulkJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary: summarizeBulkRecalc(
+        dry_run,
+        ids.length,
+        changedDesigns.size,
+        changes.length,
+        errors.length
+      ),
+      changes,
+      errors,
+    }
+  },
+}
+
+export const MAINTENANCE_JOBS: MaintenanceJob[] = [
+  recalculateDesignCostJob,
+  recalculateDesignCostBulkJob,
+]
 
 export const getMaintenanceJob = (id: string): MaintenanceJob | undefined =>
   MAINTENANCE_JOBS.find((job) => job.id === id)


### PR DESCRIPTION
Stacked on #470 (`feat/457-ops-maintenance-jobs`). Adds the **second** job to the #457 data-plumbing maintenance registry.

## What
`recalculate-design-cost-bulk` — recompute + optionally persist design cost for an explicit, capped list of design ids in one guarded call. Lets an operator re-correct many drifted designs after a cost-logic fix instead of N one-off curls / ECS scripts.

- `GET /admin/ops/maintenance-jobs` now lists both jobs (single + bulk).
- `POST /admin/ops/maintenance-jobs/recalculate-design-cost-bulk/run` — body `{ dry_run?, params: { design_ids } }`. `design_ids` accepts an **array or comma/whitespace-separated string** (paste a spreadsheet column). Capped at **25/call** (`MAX_BULK_DESIGNS`).
- **Dry-run defaults true** (aggregate preview, no writes). Apply persists each changed design (idempotent, same payload as the single job).
- A missing/deleted id is reported **per-design in `result.errors`** instead of aborting the batch.

## How (DRY)
Extracted shared `recomputeDesignCost` (load persisted fields + run the read-only estimate workflow; throws NOT_FOUND/UNEXPECTED_STATE) and `persistDesignCost` helpers. The existing single `recalculate-design-cost` job now reuses them — **behavior identical** (covered by the unchanged guard tests). New pure helpers `parseDesignIds` + `summarizeBulkRecalc` are unit-tested. `MaintenanceJobResult` gains an optional `errors[]`.

## No migration
Pure registry + route layer. Additive.

## Verified
- **Unit** (`registry.unit.spec.ts`, `TEST_TYPE=unit`): 19 passed (7 new — parseDesignIds array/string/dedup/blank/non-string/cap/at-cap, summarizeBulkRecalc dry/apply/error).
- **Integration** (`integration-tests/http/ops-maintenance-jobs.spec.ts`, shared DB): 8 passed (3 new — discovery lists both jobs, bulk missing-param → 400, bulk missing-id → 200 with per-design error + applied=false).
- `tsc`: 0 new errors (69 == baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)