### PR TITLE
feat(stats): restore public panel REST endpoint + share-audit (#341)

### DIFF
--- a/apps/backend/integration-tests/http/stats-public-panel.spec.ts
+++ b/apps/backend/integration-tests/http/stats-public-panel.spec.ts
@@ -1,0 +1,137 @@
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { STATS_MODULE } from "../../src/modules/stats"
+
+jest.setTimeout(60 * 1000)
+
+/**
+ * #341 / roadmap #20 — share-publicly UX (backend slice).
+ *
+ * Covers the restored public REST endpoint `GET /web/stats/panels/:id/data`
+ * (opt-in via `metadata.public === true`, private/unknown → identical 404)
+ * and the server-side audit stamping on the admin PUT route
+ * (`public_set_by` / `public_set_at` written on a real toggle).
+ */
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  // A minimal valid panel operation. The admin PUT route re-validates
+  // operation_options on every update (its schema defaults to {}), and the
+  // real panel-editor always saves the whole panel — so PUTs echo these.
+  const OP_TYPE = "aggregate_data"
+  const OP_OPTIONS = { entity: "order", aggregate: { fn: "count" } }
+
+  const seedPanel = async (metadata: Record<string, any>) => {
+    const service: any = getContainer().resolve(STATS_MODULE)
+    const dashboard = await service.createStatsDashboards({ name: "Public test dashboard" })
+    const panel = await service.createStatsPanels({
+      name: "Public test panel",
+      type: "metric",
+      operation_type: OP_TYPE,
+      operation_options: OP_OPTIONS,
+      display: {},
+      dashboard_id: dashboard.id,
+      metadata,
+    })
+    return panel
+  }
+
+  describe("GET /web/stats/panels/:id/data (public)", () => {
+    it("returns 404 for a private panel (default — not opted in)", async () => {
+      const panel = await seedPanel({})
+      await expect(
+        api.get(`/web/stats/panels/${panel.id}/data`)
+      ).rejects.toMatchObject({ response: { status: 404 } })
+    })
+
+    it("returns 404 for an unknown panel id (no existence leak)", async () => {
+      await expect(
+        api.get(`/web/stats/panels/panel_does_not_exist/data`)
+      ).rejects.toMatchObject({ response: { status: 404 } })
+    })
+
+    it("returns 200 with the public shape + cache headers for a shared panel", async () => {
+      const panel = await seedPanel({ public: true })
+      const res = await api.get(`/web/stats/panels/${panel.id}/data`)
+
+      expect(res.status).toBe(200)
+      expect(res.data).toEqual(
+        expect.objectContaining({
+          panel_id: panel.id,
+          type: "metric",
+          name: "Public test panel",
+        })
+      )
+      expect(res.data).toHaveProperty("data")
+      expect(res.data).toHaveProperty("resolved_at")
+      expect(res.headers["cache-control"]).toBe(
+        "public, s-maxage=120, stale-while-revalidate=300"
+      )
+    })
+  })
+
+  describe("PUT /admin/stats/panels/:id audit stamping", () => {
+    let adminHeaders: { headers: Record<string, string> }
+
+    beforeEach(async () => {
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+    })
+
+    it("stamps public_set_by + public_set_at when toggled public, and the panel becomes reachable", async () => {
+      const panel = await seedPanel({})
+
+      const put = await api.put(
+        `/admin/stats/panels/${panel.id}`,
+        { operation_type: OP_TYPE, operation_options: OP_OPTIONS, metadata: { public: true } },
+        adminHeaders
+      )
+      expect(put.status).toBe(200)
+      expect(put.data.panel.metadata.public).toBe(true)
+      expect(put.data.panel.metadata.public_set_by).toBeTruthy()
+      expect(put.data.panel.metadata.public_set_at).toBeTruthy()
+
+      // now publicly reachable
+      const pub = await api.get(`/web/stats/panels/${panel.id}/data`)
+      expect(pub.status).toBe(200)
+    })
+
+    it("preserves the stamps on an unrelated metadata edit while staying public", async () => {
+      const panel = await seedPanel({})
+
+      const first = await api.put(
+        `/admin/stats/panels/${panel.id}`,
+        { operation_type: OP_TYPE, operation_options: OP_OPTIONS, metadata: { public: true } },
+        adminHeaders
+      )
+      const setAt = first.data.panel.metadata.public_set_at
+      const setBy = first.data.panel.metadata.public_set_by
+
+      // client edits metadata but drops the audit keys
+      const second = await api.put(
+        `/admin/stats/panels/${panel.id}`,
+        {
+          operation_type: OP_TYPE,
+          operation_options: OP_OPTIONS,
+          metadata: { public: true, note: "edited" },
+        },
+        adminHeaders
+      )
+      expect(second.data.panel.metadata.note).toBe("edited")
+      expect(second.data.panel.metadata.public_set_at).toBe(setAt)
+      expect(second.data.panel.metadata.public_set_by).toBe(setBy)
+    })
+
+    it("re-gates to 404 when toggled back to private", async () => {
+      const panel = await seedPanel({ public: true })
+      await api.put(
+        `/admin/stats/panels/${panel.id}`,
+        { operation_type: OP_TYPE, operation_options: OP_OPTIONS, metadata: { public: false } },
+        adminHeaders
+      )
+      await expect(
+        api.get(`/web/stats/panels/${panel.id}/data`)
+      ).rejects.toMatchObject({ response: { status: 404 } })
+    })
+  })
+})

--- a/apps/backend/src/api/admin/stats/panels/[id]/route.ts
+++ b/apps/backend/src/api/admin/stats/panels/[id]/route.ts
@@ -4,6 +4,7 @@ import { STATS_MODULE } from "../../../../../modules/stats"
 import StatsService from "../../../../../modules/stats/service"
 import { operationRegistry } from "../../../../../modules/visual_flows/operations/types"
 import { invalidatePanelCache } from "../../../../../modules/stats/resolver"
+import { applyPublicAuditStamp } from "../../../../../modules/stats/public-utils"
 import { updatePanelSchema } from "../../validators"
 
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
@@ -42,6 +43,21 @@ export const PUT = async (req: MedusaRequest, res: MedusaResponse) => {
       // optionsResult.data narrows to `unknown` under Zod v4 generics; the
       // operation registry validates it as a record-shaped schema, so cast.
       data.operation_options = optionsResult.data as Record<string, any>
+    }
+
+    // Share-publicly audit (#341): when this update toggles
+    // `metadata.public`, stamp who/when server-side (never trust the
+    // client). Only loads the existing panel when metadata is in the
+    // payload so unrelated updates stay single-write.
+    if (data.metadata !== undefined) {
+      const existing = await service.retrieveStatsPanel(id)
+      const actorId = (req as any).auth_context?.actor_id as string | undefined
+      data.metadata = applyPublicAuditStamp(
+        existing.metadata as Record<string, any> | undefined,
+        data.metadata,
+        actorId,
+        new Date().toISOString()
+      )
     }
 
     const panel = await service.updateStatsPanels({ id, ...data })

--- a/apps/backend/src/api/web/stats/panels/[id]/data/route.ts
+++ b/apps/backend/src/api/web/stats/panels/[id]/data/route.ts
@@ -1,0 +1,92 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { STATS_MODULE } from "../../../../../../modules/stats"
+import StatsService from "../../../../../../modules/stats/service"
+import { resolvePanel } from "../../../../../../modules/stats/resolver"
+import {
+  isPanelPublic,
+  stripExcludedColumns,
+} from "../../../../../../modules/stats/public-utils"
+
+/**
+ * GET /web/stats/panels/:id/data
+ *
+ * Public read endpoint for stats panels. Designed for marketing-site /
+ * blog embeds: an editor drops `<StatsPanel id="panel_..." />` into a
+ * blog post and the component fetches from here.
+ *
+ * Restored for roadmap #20 / issue #341 (share-publicly UX). Removed in
+ * PR #284 pending the proper opt-in share flow; this is that gate.
+ *
+ * Safety
+ * - Panels are NOT public by default. Only panels with
+ *   `metadata.public === true` resolve; everything else returns 404.
+ *   This is an explicit opt-in per panel — admins decide what's safe
+ *   to expose.
+ * - `display.exclude_columns` is applied **server-side** so the wire
+ *   payload doesn't leak joined entities even if a consumer ignores
+ *   the display config. Same denylist the renderer uses.
+ *
+ * Cache
+ * - `s-maxage=120, swr=300` — blog traffic is read-heavy and panel
+ *   data is rarely fresh-required at sub-minute resolution. Edge
+ *   caches absorb spikes; readers see stale-while-revalidate during
+ *   refresh.
+ * - The panel's own `cache_ttl_seconds` still applies inside
+ *   `resolvePanel` (in-memory cache); this just adds an edge layer.
+ *
+ * Response shape mirrors the admin POST endpoint so the same renderer
+ * can be reused on the marketing-site side:
+ *   { panel_id, type, name, data, display, resolved_at }
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params
+
+  const service: StatsService = req.scope.resolve(STATS_MODULE)
+
+  let panel: any
+  try {
+    panel = await service.retrieveStatsPanel(id)
+  } catch (err: any) {
+    // Don't leak whether the id exists at all — same 404 either way.
+    if (err?.type === "not_found") {
+      throw new MedusaError(MedusaError.Types.NOT_FOUND, "Panel not found")
+    }
+    throw err
+  }
+
+  if (!isPanelPublic(panel)) {
+    // Same 404 shape as "doesn't exist" so we don't reveal which panels
+    // exist privately.
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Panel not found")
+  }
+
+  const result = await resolvePanel(
+    req.scope,
+    {
+      id: panel.id,
+      dashboard_id: (panel as any).dashboard_id,
+      operation_type: panel.operation_type,
+      operation_options: (panel.operation_options ?? {}) as Record<string, any>,
+      display: (panel.display ?? {}) as Record<string, any>,
+      cache_ttl_seconds: panel.cache_ttl_seconds,
+    },
+    { skipCache: false }
+  )
+
+  const display = (panel.display ?? {}) as Record<string, any>
+  const data = stripExcludedColumns(display, result.data)
+
+  res.setHeader(
+    "Cache-Control",
+    "public, s-maxage=120, stale-while-revalidate=300"
+  )
+  res.json({
+    panel_id: panel.id,
+    type: panel.type,
+    name: panel.name,
+    data,
+    display,
+    resolved_at: result.resolved_at,
+  })
+}

--- a/apps/backend/src/modules/stats/__tests__/public-utils.unit.spec.ts
+++ b/apps/backend/src/modules/stats/__tests__/public-utils.unit.spec.ts
@@ -1,0 +1,98 @@
+import {
+  isPanelPublic,
+  applyPublicAuditStamp,
+} from "../public-utils"
+
+describe("stats/public-utils — isPanelPublic", () => {
+  it("returns true only for metadata.public === true", () => {
+    expect(isPanelPublic({ metadata: { public: true } })).toBe(true)
+  })
+
+  it("is private by default (no metadata)", () => {
+    expect(isPanelPublic({})).toBe(false)
+    expect(isPanelPublic({ metadata: undefined })).toBe(false)
+  })
+
+  it("treats truthy-but-not-true values as private (strict opt-in)", () => {
+    expect(isPanelPublic({ metadata: { public: "true" } })).toBe(false)
+    expect(isPanelPublic({ metadata: { public: 1 } })).toBe(false)
+    expect(isPanelPublic({ metadata: { public: false } })).toBe(false)
+  })
+})
+
+describe("stats/public-utils — applyPublicAuditStamp", () => {
+  const NOW = "2026-06-18T00:00:00.000Z"
+
+  it("returns incoming unchanged when no metadata is in the payload", () => {
+    expect(applyPublicAuditStamp({ public: true }, undefined, "usr_1", NOW)).toBeUndefined()
+  })
+
+  it("stamps actor + timestamp when toggled private -> public", () => {
+    const out = applyPublicAuditStamp(undefined, { public: true }, "usr_admin", NOW)
+    expect(out).toEqual({
+      public: true,
+      public_set_by: "usr_admin",
+      public_set_at: NOW,
+    })
+  })
+
+  it("stamps when toggled public -> private (records the un-share)", () => {
+    const out = applyPublicAuditStamp({ public: true }, { public: false }, "usr_admin", NOW)
+    expect(out).toEqual({
+      public: false,
+      public_set_by: "usr_admin",
+      public_set_at: NOW,
+    })
+  })
+
+  it("does NOT re-stamp when public is unchanged and there are no prior stamps", () => {
+    const incoming = { public: true, note: "edited" }
+    const out = applyPublicAuditStamp({ public: true }, incoming, "usr_admin", NOW)
+    expect(out).toBe(incoming) // same ref — no churn
+    expect((out as any).public_set_by).toBeUndefined()
+  })
+
+  it("carries forward prior stamps on an unrelated edit while staying public", () => {
+    const current = { public: true, public_set_by: "usr_first", public_set_at: "2026-01-01T00:00:00.000Z" }
+    const incoming = { public: true, note: "edited" } // client dropped the stamps
+    const out = applyPublicAuditStamp(current, incoming, "usr_admin", NOW)
+    expect(out).toEqual({
+      public: true,
+      note: "edited",
+      public_set_by: "usr_first",
+      public_set_at: "2026-01-01T00:00:00.000Z",
+    })
+  })
+
+  it("does not override stamps the client legitimately echoed back", () => {
+    const current = { public: true, public_set_by: "usr_first", public_set_at: "2026-01-01T00:00:00.000Z" }
+    const incoming = { public: true, public_set_by: "usr_first", public_set_at: "2026-01-01T00:00:00.000Z" }
+    const out = applyPublicAuditStamp(current, incoming, "usr_admin", NOW)
+    expect(out).toBe(incoming) // nothing to carry forward → same ref
+  })
+
+  it("does NOT stamp on an unrelated metadata edit (both private)", () => {
+    const incoming = { note: "edited" }
+    const out = applyPublicAuditStamp({ note: "old" }, incoming, "usr_admin", NOW)
+    expect(out).toBe(incoming)
+  })
+
+  it("overwrites client-supplied audit keys on a real toggle (server is source of truth)", () => {
+    const out = applyPublicAuditStamp(
+      undefined,
+      { public: true, public_set_by: "spoofed", public_set_at: "spoofed" },
+      "usr_admin",
+      NOW
+    )
+    expect(out).toEqual({
+      public: true,
+      public_set_by: "usr_admin",
+      public_set_at: NOW,
+    })
+  })
+
+  it("falls back to null actor when unauthenticated id is absent", () => {
+    const out = applyPublicAuditStamp(undefined, { public: true }, undefined, NOW)
+    expect((out as any).public_set_by).toBeNull()
+  })
+})

--- a/apps/backend/src/modules/stats/public-utils.ts
+++ b/apps/backend/src/modules/stats/public-utils.ts
@@ -1,14 +1,23 @@
 /**
- * Helpers used by `inject-panel-data.ts` when serving a blog page —
- * the only public consumer of panel data right now. (The REST endpoint
- * at `/web/stats/panels/:id/data` was removed pending a proper share-
- * publicly UX from the panel editor — see
- * `apps/docs/notes/PLATFORM_ROADMAP_2026_05.md` item #20.)
+ * Shared helpers for the public (blog + REST) panel paths.
  *
- * If/when that ships, `isPanelPublic` can be re-introduced here as the
- * gate; until then, blog injector is the only public path and admin
- * authoring is the auth (admin embedded the panel in the post = admin
- * approved its surface).
+ * Two places resolve panels for non-admin consumers:
+ *   1. inject-panel-data.ts — pre-injects data into TipTap nodes when
+ *      serving a blog page. Admin authoring is the auth there (the admin
+ *      embedded the panel in the post = approved its surface), so the
+ *      blog injector is intentionally NOT `metadata.public`-gated.
+ *   2. api/web/stats/panels/[id]/data — the direct, opt-in public REST
+ *      read. This path IS `isPanelPublic`-gated: only panels an admin
+ *      explicitly shared resolve; everything else returns the same 404
+ *      as a non-existent id (so private panels can't be enumerated).
+ *
+ * Both apply the same `display.exclude_columns` strip so a panel can't
+ * leak columns via one path that the other hides.
+ *
+ * Restored for roadmap #20 / issue #341 (share-publicly UX). The earlier
+ * removal (PR #284) deferred the gate to this proper share flow; the
+ * blog-injector gate was dropped separately (PR #283) on purpose and is
+ * NOT reinstated here.
  */
 
 /**
@@ -47,4 +56,70 @@ export function stripExcludedColumns(
     records: (data as any).records !== undefined ? stripped : undefined,
     groups: (data as any).groups !== undefined ? stripped : undefined,
   }
+}
+
+/**
+ * Public-gate check shared by the public REST endpoint. A panel is
+ * shared only when an admin explicitly opted in via
+ * `metadata.public === true`. Default (missing / any other value) is
+ * private.
+ */
+export function isPanelPublic(panel: { metadata?: any }): boolean {
+  return ((panel?.metadata as Record<string, any>)?.public) === true
+}
+
+/**
+ * Maintain share-audit fields on a panel-update payload. Pure so the
+ * route stays thin and the logic is unit-testable without a DB.
+ *
+ * The PUT route keeps its existing **full-replace** metadata semantics
+ * (Medusa replaces the whole `metadata` blob), so this helper guards the
+ * two audit keys against being lost or spoofed:
+ *
+ * - **On a real toggle** (`incoming.public` differs from the panel's
+ *   current value) it stamps `public_set_by` (admin actor id) +
+ *   `public_set_at` (ISO ts) from the server — the source of truth, so
+ *   any client-supplied audit keys are overwritten.
+ * - **On a non-toggling edit while the panel stays public** it carries
+ *   forward the existing stamps if the payload dropped them, so an
+ *   unrelated metadata edit doesn't silently erase the audit trail.
+ * - Otherwise (no metadata in the payload, or panel stays private) it
+ *   returns `incoming` unchanged (same ref → no churn).
+ */
+export function applyPublicAuditStamp(
+  current: Record<string, any> | undefined | null,
+  incoming: Record<string, any> | undefined,
+  actorId: string | undefined | null,
+  nowIso: string
+): Record<string, any> | undefined {
+  if (incoming === undefined) return incoming
+
+  const cur = (current ?? undefined) as Record<string, any> | undefined
+  const wasPublic = cur?.public === true
+  const willBePublic = (incoming as Record<string, any>)?.public === true
+
+  if (wasPublic !== willBePublic) {
+    return {
+      ...incoming,
+      public_set_by: actorId ?? null,
+      public_set_at: nowIso,
+    }
+  }
+
+  // No toggle. If it stays public, preserve prior stamps the payload omitted.
+  if (willBePublic) {
+    const out = { ...incoming }
+    let changed = false
+    if (out.public_set_by === undefined && cur?.public_set_by !== undefined) {
+      out.public_set_by = cur.public_set_by
+      changed = true
+    }
+    if (out.public_set_at === undefined && cur?.public_set_at !== undefined) {
+      out.public_set_at = cur.public_set_at
+      changed = true
+    }
+    return changed ? out : incoming
+  }
+
+  return incoming
 }


### PR DESCRIPTION
Backend slice of roadmap #20 / **#341** (share-publicly UX on the stats-panel editor). Re-enables the opt-in public read path that PR #284 removed pending a proper share flow — **without** reinstating the blog-injector gate that #283 deliberately dropped (admin authorship is the auth there).

## What's in this slice (backend only)
- **`isPanelPublic()`** restored in `stats/public-utils.ts` — opt-in via `metadata.public === true`. Private and unknown panels both return an identical **404** so private panels can't be enumerated.
- **`GET /web/stats/panels/:id/data`** restored — public (CORS-only `/web/*` middleware), cache headers `public, s-maxage=120, stale-while-revalidate=300`, server-side `display.exclude_columns` strip. Response shape mirrors the admin POST endpoint so the marketing-site renderer can be reused.
- **Server-side share-audit** (`applyPublicAuditStamp`): the admin `PUT /admin/stats/panels/:id` stamps `public_set_by` (admin actor id) + `public_set_at` (ISO ts) on a **real** `public` toggle — the server is the source of truth, so client-supplied audit keys are overwritten. On an unrelated metadata edit while the panel stays public, prior stamps are **carried forward** so the full-replace `metadata` write doesn't silently erase the trail.

## Tests
- **12 unit** — `stats/__tests__/public-utils.unit.spec.ts` (pure `isPanelPublic` + `applyPublicAuditStamp`, incl. toggle/no-toggle/carry-forward/spoof-overwrite).
- **6 integration** — `integration-tests/http/stats-public-panel.spec.ts` (private→404, unknown→404, public→200 + cache header + shape, toggle stamps + reachable, stamp carry-forward, re-gate to 404). `pnpm test:integration:http:shared` green.
- `tsc` 0 new errors (69 = baseline).

## Deferred (follow-up UI chunk, Playwright-gated)
- Panel-editor **"Share publicly"** checkbox (sets `metadata.public`).
- **Copy-link** affordance to the public REST URL.

## Notes / watch-outs
- No migration — `metadata` JSON column already exists. The `public` flag + audit fields live in `metadata` (pre-existing #281 design; this slice keeps that shape and makes the server authoritative for the audit fields).
- Latent (not touched here): the admin PUT re-validates `operation_options` on every update because its schema defaults to `{}`, so a metadata-only PUT validates `{}` against a panel's required options. Tests follow the real panel-editor flow (full panel saved together). Worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)