### PR TITLE
fix(stats): stop admin panel PUT clobbering operation_options on partial updates

### DIFF
--- a/apps/backend/src/api/admin/stats/__tests__/validators.unit.spec.ts
+++ b/apps/backend/src/api/admin/stats/__tests__/validators.unit.spec.ts
@@ -1,0 +1,64 @@
+import {
+  createPanelSchema,
+  updatePanelSchema,
+  previewPanelSchema,
+} from "../validators"
+
+describe("stats panel validators", () => {
+  describe("updatePanelSchema — operation_options default must not survive .partial()", () => {
+    it("does NOT inject operation_options on a metadata-only update", () => {
+      // Regression: a metadata-only PUT (e.g. toggling metadata.public from the
+      // share-publicly UI) must leave operation_options undefined so the route
+      // falls back to the stored value instead of clobbering it with {}.
+      const parsed = updatePanelSchema.parse({ metadata: { public: true } })
+      expect(parsed.operation_options).toBeUndefined()
+      expect("operation_options" in parsed).toBe(false)
+      expect(parsed.metadata).toEqual({ public: true })
+    })
+
+    it("does NOT inject operation_options on a position-only update", () => {
+      const parsed = updatePanelSchema.parse({ x: 2, y: 3 })
+      expect(parsed.operation_options).toBeUndefined()
+    })
+
+    it("preserves an explicitly provided operation_options", () => {
+      const parsed = updatePanelSchema.parse({
+        operation_options: { limit: 5 },
+      })
+      expect(parsed.operation_options).toEqual({ limit: 5 })
+    })
+
+    it("keeps operation_type optional on update", () => {
+      expect(() => updatePanelSchema.parse({ name: "Renamed" })).not.toThrow()
+    })
+
+    it("the route's `operation_type || operation_options` guard stays falsy for a metadata-only update", () => {
+      // Mirrors the PUT route guard: with the bug, operation_options was always
+      // {} (truthy) so the guard always ran and re-validated/clobbered options.
+      const data = updatePanelSchema.parse({ metadata: { public: true } })
+      expect(Boolean(data.operation_type || data.operation_options)).toBe(false)
+    })
+  })
+
+  describe("createPanelSchema — default behavior is intentionally retained", () => {
+    it("still defaults operation_options to {} on create", () => {
+      const parsed = createPanelSchema.parse({
+        name: "New panel",
+        operation_type: "count_orders",
+      })
+      expect(parsed.operation_options).toEqual({})
+    })
+
+    it("still requires name and operation_type on create", () => {
+      expect(() => createPanelSchema.parse({ name: "x" })).toThrow()
+      expect(() => createPanelSchema.parse({ operation_type: "y" })).toThrow()
+    })
+  })
+
+  describe("previewPanelSchema — unchanged", () => {
+    it("defaults operation_options to {}", () => {
+      const parsed = previewPanelSchema.parse({ operation_type: "count_orders" })
+      expect(parsed.operation_options).toEqual({})
+    })
+  })
+})

--- a/apps/backend/src/api/admin/stats/validators.ts
+++ b/apps/backend/src/api/admin/stats/validators.ts
@@ -42,7 +42,18 @@ export const panelBaseSchema = z.object({
 
 export const createPanelSchema = panelBaseSchema
 
-export const updatePanelSchema = panelBaseSchema.partial()
+// `panelBaseSchema.partial()` makes every field optional, but a field declared
+// with `.default({})` keeps that default even when wrapped in optional — so a
+// partial parse of a payload that omits `operation_options` still injects `{}`.
+// On the panel PUT route that meant a metadata-only update (e.g. toggling
+// `metadata.public`) would re-validate `{}` against the operation's required
+// options (400 for operations with required params) and clobber the stored
+// options with an empty object. Override the field back to a plain optional so
+// an omitted `operation_options` stays `undefined` and the route falls back to
+// the existing stored value.
+export const updatePanelSchema = panelBaseSchema.partial().extend({
+  operation_options: z.record(z.string(), z.any()).optional(),
+})
 
 export const previewPanelSchema = z.object({
   operation_type: z.string().min(1),


### PR DESCRIPTION
## Problem

`updatePanelSchema = panelBaseSchema.partial()` (in `src/api/admin/stats/validators.ts`) makes every field optional, but `operation_options` is declared with `.default({})` — and a `.default()` survives `.partial()`. So any partial parse that **omits** `operation_options` still injects `{}`.

On `PUT /admin/stats/panels/:id` (`src/api/admin/stats/panels/[id]/route.ts`) the guard is `if (data.operation_type || data.operation_options)`. Because the schema always set `operation_options` to `{}` (a truthy object), the guard **always ran**, even for a metadata-only update. That caused two latent bugs:

1. **Data loss** — `nextOptions = data.operation_options ?? existing.operation_options` resolves to `{}` (not nullish), and line 45 then persists `{}`, **clobbering the panel's stored operation_options** on every metadata- or position-only PUT.
2. **Spurious 400s** — `{}` is re-validated against the operation's `optionsSchema`; any operation with required params returns `400 Invalid operation_options`.

This is exactly the path the #341 share-publicly UI hits (a metadata-only PUT toggling `metadata.public`).

This bug predates the #341/#472 work and exists on `main` independently — fix branches off `main`.

## Fix

Override `operation_options` back to a plain `.optional()` on `updatePanelSchema` only:

```ts
export const updatePanelSchema = panelBaseSchema.partial().extend({
  operation_options: z.record(z.string(), z.any()).optional(),
})
```

Now an omitted `operation_options` stays `undefined`, the route guard is skipped, and the stored value is preserved. `createPanelSchema` / `previewPanelSchema` keep `.default({})` (correct for create/preview).

No route logic change needed — the existing `?? existing.operation_options` fallback becomes correct once the schema stops injecting `{}`. No migration.

## Verification

- Empirically confirmed the `.partial()` + `.default()` interaction (metadata-only parse injected `operation_options:{}` before; `undefined` after).
- New unit spec `src/api/admin/stats/__tests__/validators.unit.spec.ts` — **8 tests pass**: metadata-only / position-only updates don't inject options, explicit options preserved, route guard stays falsy, create/preview defaults retained.
- `tsc --noEmit`: 69 errors = baseline, **0 new**, none in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)