### PR TITLE
fix(validators): stop .partial() update schemas injecting field defaults (#341 follow-up)

### DIFF
--- a/apps/backend/src/api/admin/email-templates/__tests__/validators.unit.spec.ts
+++ b/apps/backend/src/api/admin/email-templates/__tests__/validators.unit.spec.ts
@@ -1,0 +1,42 @@
+import {
+  CreateEmailTemplateSchema,
+  UpdateEmailTemplateSchema,
+} from "../validators"
+
+describe("email-template validators", () => {
+  describe("UpdateEmailTemplateSchema — is_active default must not survive .partial()", () => {
+    it("does NOT inject is_active on a subject-only update", () => {
+      // Regression: a `.default(true)` survives `.partial()` in Zod v4, so an
+      // omitted is_active used to inject `true` and silently re-activate a
+      // deactivated template (the route spreads ...validatedBody into update).
+      const parsed = UpdateEmailTemplateSchema.parse({ subject: "New subject" })
+      expect(parsed.is_active).toBeUndefined()
+      expect("is_active" in parsed).toBe(false)
+      expect(parsed.subject).toBe("New subject")
+    })
+
+    it("preserves an explicit is_active=false", () => {
+      const parsed = UpdateEmailTemplateSchema.parse({ is_active: false })
+      expect(parsed.is_active).toBe(false)
+    })
+
+    it("preserves an explicit is_active=true", () => {
+      const parsed = UpdateEmailTemplateSchema.parse({ is_active: true })
+      expect(parsed.is_active).toBe(true)
+    })
+  })
+
+  describe("CreateEmailTemplateSchema — default stays intact on create", () => {
+    it("still defaults is_active to true when omitted on create", () => {
+      const parsed = CreateEmailTemplateSchema.parse({
+        name: "T",
+        from: "a@b.com",
+        template_key: "k",
+        subject: "S",
+        html_content: "<p/>",
+        template_type: "marketing",
+      })
+      expect(parsed.is_active).toBe(true)
+    })
+  })
+})

--- a/apps/backend/src/api/admin/email-templates/validators.ts
+++ b/apps/backend/src/api/admin/email-templates/validators.ts
@@ -30,6 +30,12 @@ export type CreateEmailTemplate = z.infer<typeof CreateEmailTemplateSchema>;
 export const UpdateEmailTemplateSchema = EmailTemplateSchema.omit({
 }).partial().extend({
   id: z.string().optional(),
+  // `is_active` carries `.default(true)` on the base schema. A `.default()`
+  // survives `.partial()` in Zod v4, so an omitted `is_active` on a partial
+  // update would silently inject `true` and re-activate a deactivated template
+  // (the route spreads `...req.validatedBody` straight into the update workflow).
+  // Re-declare as plain optional (no default) so omission stays omitted.
+  is_active: z.boolean().optional(),
 }).strict();
 
 export type UpdateEmailTemplate = z.infer<typeof UpdateEmailTemplateSchema>;

--- a/apps/backend/src/api/admin/inventory-items/[id]/rawmaterials/__tests__/validators.unit.spec.ts
+++ b/apps/backend/src/api/admin/inventory-items/[id]/rawmaterials/__tests__/validators.unit.spec.ts
@@ -1,0 +1,40 @@
+import {
+  rawMaterialSchema,
+  UpdateRawMaterialSchema,
+} from "../validators"
+
+describe("raw-material validators", () => {
+  describe("UpdateRawMaterialSchema — unit_of_measure/status defaults must not survive .partial()", () => {
+    it("does NOT inject unit_of_measure or status on a partial update", () => {
+      // Regression: `.optional().default(...)` survives `.partial()` in Zod v4,
+      // so omitting these used to inject "Other"/"Active" and clobber a
+      // material's real unit/status (the route persists rawMaterialData to update).
+      const parsed = UpdateRawMaterialSchema.parse({
+        rawMaterialData: { unit_cost: 5 },
+      })
+      expect(parsed.rawMaterialData.unit_of_measure).toBeUndefined()
+      expect(parsed.rawMaterialData.status).toBeUndefined()
+      expect("unit_of_measure" in parsed.rawMaterialData).toBe(false)
+      expect("status" in parsed.rawMaterialData).toBe(false)
+      expect(parsed.rawMaterialData.unit_cost).toBe(5)
+    })
+
+    it("preserves explicitly provided unit_of_measure and status", () => {
+      const parsed = UpdateRawMaterialSchema.parse({
+        rawMaterialData: { unit_of_measure: "Meter", status: "Discontinued" },
+      })
+      expect(parsed.rawMaterialData.unit_of_measure).toBe("Meter")
+      expect(parsed.rawMaterialData.status).toBe("Discontinued")
+    })
+  })
+
+  describe("rawMaterialSchema — defaults stay intact on create", () => {
+    it("still defaults unit_of_measure='Other' and status='Active' on create", () => {
+      const parsed = rawMaterialSchema.parse({
+        rawMaterialData: { name: "Cotton", composition: "100% cotton" },
+      })
+      expect(parsed.rawMaterialData.unit_of_measure).toBe("Other")
+      expect(parsed.rawMaterialData.status).toBe("Active")
+    })
+  })
+})

--- a/apps/backend/src/api/admin/inventory-items/[id]/rawmaterials/validators.ts
+++ b/apps/backend/src/api/admin/inventory-items/[id]/rawmaterials/validators.ts
@@ -17,20 +17,31 @@ const materialTypeSchema = z.object({
   metadata: z.record(z.string(), z.any()).optional()
 });
 
+// Enum value lists kept as shared consts so the create (default-bearing) and
+// update (default-free) schemas stay in sync without duplicating the literals.
+const unitOfMeasureValues = [
+  "Meter",
+  "Yard",
+  "Kilogram",
+  "Gram",
+  "Piece",
+  "Roll",
+  "Other",
+] as const;
+
+const rawMaterialStatusValues = [
+  "Active",
+  "Discontinued",
+  "Under_Review",
+  "Development",
+] as const;
+
 const rawMaterialDataSchema = z.object({
   name: z.string().min(1, "Name is required"),
   description: z.string().min(1, "Description is required").optional(),
   composition: z.string().min(1, "Composition is required"),
   specifications: z.record(z.string(), z.any()).optional(),
-  unit_of_measure: z.enum([
-    "Meter",
-    "Yard",
-    "Kilogram",
-    "Gram",
-    "Piece",
-    "Roll",
-    "Other"
-  ]).optional().default("Other"),
+  unit_of_measure: z.enum(unitOfMeasureValues).optional().default("Other"),
   unit_cost: z.number().positive().optional(),
   cost_currency: z.string().optional(),
   minimum_order_quantity: z.number().positive().optional(),
@@ -42,12 +53,7 @@ const rawMaterialDataSchema = z.object({
   certification: z.record(z.string(), z.any()).optional(),
   usage_guidelines: z.string().optional(),
   storage_requirements: z.string().optional(),
-  status: z.enum([
-    "Active",
-    "Discontinued",
-    "Under_Review",
-    "Development"
-  ]).optional().default("Active"),
+  status: z.enum(rawMaterialStatusValues).optional().default("Active"),
   metadata: z.record(z.string(), z.any()).optional(),
   material_type: z.string().optional(),
   material_type_id: z.string().optional(),
@@ -61,7 +67,15 @@ export const rawMaterialSchema = z.object({
 export type RawMaterial = z.infer<typeof rawMaterialSchema>;
 export type UpdateRawMaterial = Partial<RawMaterial>;
 
+// `unit_of_measure` and `status` carry `.optional().default(...)` on the base
+// schema. A `.default()` survives `.partial()` in Zod v4, so omitting them on a
+// partial update would silently inject "Other"/"Active" and clobber a material's
+// real unit/status (the route persists `rawMaterialData` straight to the update
+// workflow). Re-declare as plain optional (no default) so omission stays omitted.
 export const UpdateRawMaterialSchema = z.object({
-  rawMaterialData: rawMaterialDataSchema.partial(),
+  rawMaterialData: rawMaterialDataSchema.partial().extend({
+    unit_of_measure: z.enum(unitOfMeasureValues).optional(),
+    status: z.enum(rawMaterialStatusValues).optional(),
+  }),
 });
 

--- a/apps/backend/src/api/admin/inventory-orders/__tests__/validators.unit.spec.ts
+++ b/apps/backend/src/api/admin/inventory-orders/__tests__/validators.unit.spec.ts
@@ -1,0 +1,46 @@
+import {
+  createInventoryOrdersSchema,
+  updateInventoryOrdersSchema,
+} from "../validators"
+
+describe("inventory-order validators", () => {
+  describe("updateInventoryOrdersSchema — is_sample default must not survive .partial()", () => {
+    it("does NOT inject is_sample on a status-only update", () => {
+      // Regression: `.optional().default(false)` survives `.partial()` in Zod v4,
+      // so an omitted is_sample used to inject `false` and silently flip a sample
+      // order to a non-sample one (the route spreads ...validatedBody into update).
+      const parsed = updateInventoryOrdersSchema.parse({ status: "Shipped" })
+      expect(parsed.is_sample).toBeUndefined()
+      expect("is_sample" in parsed).toBe(false)
+      expect(parsed.status).toBe("Shipped")
+    })
+
+    it("preserves an explicit is_sample=true", () => {
+      const parsed = updateInventoryOrdersSchema.parse({ is_sample: true })
+      expect(parsed.is_sample).toBe(true)
+    })
+
+    it("preserves an explicit is_sample=false", () => {
+      const parsed = updateInventoryOrdersSchema.parse({ is_sample: false })
+      expect(parsed.is_sample).toBe(false)
+    })
+  })
+
+  describe("createInventoryOrdersSchema — default stays intact on create", () => {
+    it("still defaults is_sample to false when omitted on create", () => {
+      const parsed = createInventoryOrdersSchema.parse({
+        order_lines: [
+          { inventory_item_id: "ii_1", quantity: 1, price: 1 },
+        ],
+        quantity: 1,
+        total_price: 1,
+        status: "Pending",
+        expected_delivery_date: "2026-06-20T00:00:00.000Z",
+        order_date: "2026-06-18T00:00:00.000Z",
+        shipping_address: {},
+        stock_location_id: "sloc_1",
+      })
+      expect(parsed.is_sample).toBe(false)
+    })
+  })
+})

--- a/apps/backend/src/api/admin/inventory-orders/validators.ts
+++ b/apps/backend/src/api/admin/inventory-orders/validators.ts
@@ -70,8 +70,15 @@ export const ReadSingleInventoryOrderQuerySchema = z.object({
   fields: z.string().optional(),
 })
 
-// Input schema for updating inventory orders
-export const updateInventoryOrdersSchema = inventoryOrdersBaseSchema.partial();
+// Input schema for updating inventory orders.
+// `is_sample` carries `.optional().default(false)` on the base schema. A
+// `.default()` survives `.partial()` in Zod v4, so an omitted `is_sample` on a
+// partial update would silently inject `false` and flip a sample order to a
+// non-sample one (the route spreads `...validatedBody` into the update input).
+// Re-declare as plain optional (no default) so omission stays omitted.
+export const updateInventoryOrdersSchema = inventoryOrdersBaseSchema
+  .partial()
+  .extend({ is_sample: z.boolean().optional() });
 
 // Type definitions for inventory orders
 export type UpdateInventoryOrder = z.infer<typeof updateInventoryOrdersSchema>;


### PR DESCRIPTION
## Summary

Audit follow-up to #473 / #341. A `.default()` **survives `.partial()`** in Zod v4 (verified empirically — both plain `.default()` and `.optional().default()` inject). So any update schema built as `base.partial()` silently injects a field's default when the caller omits it. On routes that spread `...validatedBody` straight into an update workflow, this **clobbers stored state** on partial PUTs.

#473 fixed the stats-panel instance. This sweeps the rest of `apps/backend/src/api/admin` for the same pattern and fixes the three confirmed **state-clobbering** cases.

## Confirmed bugs fixed

| Route | Field | Bad behavior on partial update |
|-------|-------|--------------------------------|
| `PUT /admin/email-templates/:id` | `is_active` (`.default(true)`) | omitting it injected `true` → **re-activated a deactivated template** |
| `PUT /admin/inventory-orders/:id` | `is_sample` (`.optional().default(false)`) | omitting it injected `false` → **flipped a sample order to non-sample** |
| `PUT /admin/inventory-items/:id/rawmaterials/:rmId` | `unit_of_measure` / `status` (`.optional().default(...)`) | omitting them injected `"Other"` / `"Active"` → **clobbered a material's real unit/status** |

All three routes spread the validated body directly into their update workflow, so the injected default persisted.

## Fix

Mirrors #473: re-declare the defaulted fields as plain `.optional()` (no default) on the **update** schema only. Create/preview schemas keep their defaults (verified by tests). Route logic unchanged. **No migration.**

## Not changed (deliberately)
- `pages.genMetaDataLLM` — a transient *action trigger* (default `false` is the safe/no-op value); injecting it doesn't corrupt stored state.
- nested per-item defaults (e.g. `designs.media_files[].isThumbnail`) — `.partial()` doesn't recurse, so these are intended per-item defaults, not partial-injection.

## Tests
11 unit specs added (3 files) asserting: omitted field stays omitted on update, explicit values preserved, and the default still fires on create.

```
Tests: 11 passed
tsc: 0 new errors (69 = baseline)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)