### PR TITLE
feat(google-merchant): derive landing URL from partner storefront (#377)

### DIFF
--- a/apps/backend/src/workflows/google_merchant/steps/__tests__/resolve-partner-landing-base.unit.spec.ts
+++ b/apps/backend/src/workflows/google_merchant/steps/__tests__/resolve-partner-landing-base.unit.spec.ts
@@ -1,0 +1,113 @@
+import {
+  normalizeLandingBase,
+  partnerBaseFromRecord,
+  resolvePartnerLandingBase,
+} from "../resolve-partner-landing-base"
+
+/**
+ * #377 — Google Merchant landing URL derived from the owning partner
+ * storefront. Pure precedence + the product→store→partner pivot, exercised
+ * with a stubbed query.graph so no DB is needed.
+ */
+describe("normalizeLandingBase", () => {
+  it("prefixes https:// for bare domains and strips trailing slash", () => {
+    expect(normalizeLandingBase("gof.asia")).toBe("https://gof.asia")
+    expect(normalizeLandingBase("acme.cicilabel.com/")).toBe("https://acme.cicilabel.com")
+  })
+
+  it("keeps an explicit scheme", () => {
+    expect(normalizeLandingBase("http://shop.test")).toBe("http://shop.test")
+    expect(normalizeLandingBase("https://shop.test/")).toBe("https://shop.test")
+  })
+
+  it("returns null for empty/whitespace/nullish", () => {
+    expect(normalizeLandingBase(undefined)).toBeNull()
+    expect(normalizeLandingBase(null)).toBeNull()
+    expect(normalizeLandingBase("")).toBeNull()
+    expect(normalizeLandingBase("   ")).toBeNull()
+  })
+})
+
+describe("partnerBaseFromRecord precedence", () => {
+  it("prefers metadata.custom_domain", () => {
+    expect(
+      partnerBaseFromRecord({
+        storefront_domain: "acme.cicilabel.com",
+        metadata: { custom_domain: "shop.acme.com", website_domain: "alt.acme.com" },
+      })
+    ).toBe("https://shop.acme.com")
+  })
+
+  it("falls back to website_domain then storefront_domain", () => {
+    expect(
+      partnerBaseFromRecord({
+        storefront_domain: "acme.cicilabel.com",
+        metadata: { website_domain: "alt.acme.com" },
+      })
+    ).toBe("https://alt.acme.com")
+    expect(
+      partnerBaseFromRecord({ storefront_domain: "acme.cicilabel.com", metadata: {} })
+    ).toBe("https://acme.cicilabel.com")
+  })
+
+  it("returns null when no domain present", () => {
+    expect(partnerBaseFromRecord({ storefront_domain: null, metadata: {} })).toBeNull()
+    expect(partnerBaseFromRecord(null)).toBeNull()
+  })
+})
+
+describe("resolvePartnerLandingBase pivot", () => {
+  const makeQuery = (responses: Record<string, any[]>) => ({
+    graph: jest.fn(async ({ entity }: any) => ({ data: responses[entity] ?? [] })),
+  })
+
+  it("resolves product → sales_channel → store → partner domain", async () => {
+    const query = makeQuery({
+      product: [{ id: "prod_1", sales_channels: [{ id: "sc_1" }] }],
+      stores: [{ id: "store_1", default_sales_channel_id: "sc_1" }],
+      partners: [
+        { id: "par_x", storefront_domain: "x.cicilabel.com", metadata: {}, stores: [{ id: "store_z" }] },
+        {
+          id: "par_1",
+          storefront_domain: "acme.cicilabel.com",
+          metadata: { custom_domain: "shop.acme.com" },
+          stores: [{ id: "store_1" }],
+        },
+      ],
+    })
+    await expect(resolvePartnerLandingBase(query as any, "prod_1")).resolves.toBe(
+      "https://shop.acme.com"
+    )
+  })
+
+  it("returns null when product has no sales channel", async () => {
+    const query = makeQuery({ product: [{ id: "prod_1", sales_channels: [] }] })
+    await expect(resolvePartnerLandingBase(query as any, "prod_1")).resolves.toBeNull()
+  })
+
+  it("returns null when no store owns the channel", async () => {
+    const query = makeQuery({
+      product: [{ id: "prod_1", sales_channels: [{ id: "sc_1" }] }],
+      stores: [],
+    })
+    await expect(resolvePartnerLandingBase(query as any, "prod_1")).resolves.toBeNull()
+  })
+
+  it("returns null when no partner owns the store", async () => {
+    const query = makeQuery({
+      product: [{ id: "prod_1", sales_channels: [{ id: "sc_1" }] }],
+      stores: [{ id: "store_1", default_sales_channel_id: "sc_1" }],
+      partners: [{ id: "par_x", storefront_domain: "x.cicilabel.com", metadata: {}, stores: [{ id: "store_z" }] }],
+    })
+    await expect(resolvePartnerLandingBase(query as any, "prod_1")).resolves.toBeNull()
+  })
+
+  it("never throws — swallows query errors to null", async () => {
+    const query = {
+      graph: jest.fn(async () => {
+        throw new Error("boom")
+      }),
+    }
+    await expect(resolvePartnerLandingBase(query as any, "prod_1")).resolves.toBeNull()
+  })
+})

--- a/apps/backend/src/workflows/google_merchant/steps/bulk-sync-products-to-google.ts
+++ b/apps/backend/src/workflows/google_merchant/steps/bulk-sync-products-to-google.ts
@@ -5,6 +5,7 @@ import type { Link } from "@medusajs/modules-sdk"
 import { GOOGLE_MERCHANT_MODULE } from "../../../modules/google_merchant"
 import type GoogleMerchantService from "../../../modules/google_merchant/service"
 import { mapProductToGoogleMerchant, validateProductForGoogle } from "./map-product-to-google"
+import { resolvePartnerLandingBase } from "./resolve-partner-landing-base"
 import productGoogleMerchantLink from "../../../links/product-google-merchant-link"
 
 const LINK_ENTRY = productGoogleMerchantLink.entryPoint
@@ -126,9 +127,16 @@ export const bulkSyncProductsToGoogleStep = createStep(
         continue
       }
 
+      // #377 — per-product partner landing base (custom domain → subdomain).
+      // Explicit caller override wins; the batch base is the fallback.
+      const productBase =
+        input.landing_url_base ||
+        (await resolvePartnerLandingBase(query, product.id)) ||
+        landingBase
+
       const payload = mapProductToGoogleMerchant(product, {
         offerId: product.handle || product.id,
-        link: `${landingBase.replace(/\/$/, "")}/products/${product.handle}`,
+        link: `${productBase.replace(/\/$/, "")}/products/${product.handle}`,
         contentLanguage,
         feedLabel,
         currencyCode,

--- a/apps/backend/src/workflows/google_merchant/steps/resolve-partner-landing-base.ts
+++ b/apps/backend/src/workflows/google_merchant/steps/resolve-partner-landing-base.ts
@@ -1,0 +1,107 @@
+import type { RemoteQueryFunction } from "@medusajs/types"
+
+/**
+ * #377 — Google Merchant: derive a product's landing-page base URL from the
+ * partner storefront that owns it, instead of always using a single global
+ * base (`landing_url_base` on the merchant account / `STORE_URL`).
+ *
+ * Resolution order for the base, matching the roadmap issue:
+ *   1. partner.metadata.custom_domain   (attached custom domain — primary)
+ *   2. partner.metadata.website_domain  (legacy alias key)
+ *   3. partner.storefront_domain        (the *.cicilabel.com subdomain)
+ *
+ * Product → partner pivot mirrors the FX fanout work:
+ *   product → sales_channels → store (default_sales_channel_id) → partner
+ *   (partner_stores link). sales_channel ↔ store is NOT a Medusa link
+ *   (store.default_sales_channel_id is a plain column), so it's resolved
+ *   with an explicit second query rather than a dot-path join.
+ *
+ * Domains are stored bare (e.g. "gof.asia", "acme.cicilabel.com"); the
+ * serving convention everywhere else is `https://<host>` (see
+ * set-storefront-base-url.ts), so we normalize to that.
+ */
+
+type Queryable = Pick<Omit<RemoteQueryFunction, symbol>, "graph">
+
+/**
+ * Normalize a bare or schemed domain into a clean `https://<host>` base with
+ * no trailing slash. Returns null for empty / unusable input.
+ */
+export function normalizeLandingBase(value?: string | null): string | null {
+  if (!value) return null
+  let v = String(value).trim()
+  if (!v) return null
+  // Strip any path/trailing slash noise but keep an explicit scheme.
+  if (!/^https?:\/\//i.test(v)) {
+    v = `https://${v}`
+  }
+  // Drop trailing slashes (the caller appends `/products/<handle>`).
+  v = v.replace(/\/+$/, "")
+  return v || null
+}
+
+/**
+ * Pure precedence over a partner-like record's domain fields.
+ * Exported for unit testing without a query layer.
+ */
+export function partnerBaseFromRecord(
+  partner: {
+    storefront_domain?: string | null
+    metadata?: Record<string, any> | null
+  } | null | undefined
+): string | null {
+  if (!partner) return null
+  const meta = partner.metadata || {}
+  return (
+    normalizeLandingBase(meta.custom_domain) ||
+    normalizeLandingBase(meta.website_domain) ||
+    normalizeLandingBase(partner.storefront_domain)
+  )
+}
+
+/**
+ * Resolve the landing base for a single product from its owning partner
+ * storefront. Returns null (never throws) when the product isn't tied to a
+ * partner store or no domain is configured, so callers can fall back to the
+ * account-level / env base.
+ */
+export async function resolvePartnerLandingBase(
+  query: Queryable,
+  product_id: string
+): Promise<string | null> {
+  try {
+    // 1. product → sales_channels
+    const { data: products } = await query.graph({
+      entity: "product",
+      fields: ["id", "sales_channels.id"],
+      filters: { id: product_id },
+    } as any)
+    const channelIds: string[] = (products?.[0]?.sales_channels ?? [])
+      .map((sc: any) => sc?.id)
+      .filter(Boolean)
+    if (!channelIds.length) return null
+
+    // 2. sales_channel → store (default_sales_channel_id is a plain column).
+    const { data: stores } = await query.graph({
+      entity: "stores",
+      fields: ["id", "default_sales_channel_id"],
+      filters: { default_sales_channel_id: channelIds },
+    } as any)
+    const storeIds = new Set((stores ?? []).map((s: any) => s?.id).filter(Boolean))
+    if (!storeIds.size) return null
+
+    // 3. store → partner (partner_stores link). Filters don't auto-join
+    //    dot-paths, so fetch partners with their store ids + domain fields
+    //    and match in JS (mirrors propagate-region-to-partners).
+    const { data: partners } = await query.graph({
+      entity: "partners",
+      fields: ["id", "storefront_domain", "metadata", "stores.id"],
+    } as any)
+    const owner = (partners ?? []).find((p: any) =>
+      (p?.stores ?? []).some((st: any) => storeIds.has(st?.id))
+    )
+    return partnerBaseFromRecord(owner)
+  } catch {
+    return null
+  }
+}

--- a/apps/backend/src/workflows/google_merchant/steps/sync-product-to-google.ts
+++ b/apps/backend/src/workflows/google_merchant/steps/sync-product-to-google.ts
@@ -5,6 +5,7 @@ import type { Link } from "@medusajs/modules-sdk"
 import { GOOGLE_MERCHANT_MODULE } from "../../../modules/google_merchant"
 import type GoogleMerchantService from "../../../modules/google_merchant/service"
 import { mapProductToGoogleMerchant, validateProductForGoogle } from "./map-product-to-google"
+import { resolvePartnerLandingBase } from "./resolve-partner-landing-base"
 import productGoogleMerchantLink from "../../../links/product-google-merchant-link"
 
 const LINK_ENTRY = productGoogleMerchantLink.entryPoint
@@ -78,7 +79,16 @@ export const syncProductToGoogleStep = createStep(
     const contentLanguage = input.content_language || (account.api_config as any)?.content_language || "en"
     const feedLabel = input.feed_label || (account.api_config as any)?.feed_label || "US"
     const currencyCode = input.currency_code || (account.api_config as any)?.currency_code || "USD"
-    const landingBase = input.landing_url_base || (account.api_config as any)?.landing_url_base || process.env.STORE_URL || ""
+    // #377 — for partner-owned products, derive the landing base from the
+    // partner storefront (custom domain → subdomain). An explicit caller
+    // override still wins; the account/env base is the final fallback.
+    const partnerLandingBase = await resolvePartnerLandingBase(query, input.product_id)
+    const landingBase =
+      input.landing_url_base ||
+      partnerLandingBase ||
+      (account.api_config as any)?.landing_url_base ||
+      process.env.STORE_URL ||
+      ""
 
     if (!landingBase) {
       throw new MedusaError(


### PR DESCRIPTION
## What
Roadmap **#377** (`[#28]`) — Google Merchant sync now builds a partner product's landing link from **its own storefront**, instead of always using a single global base.

## Why
`sync-product-to-google` / `bulk-sync` built every product's `link` from one base (`account.api_config.landing_url_base` → `STORE_URL`). Partner products therefore synced under the wrong store URL (or couldn't sync under their own).

## How
New `resolve-partner-landing-base.ts`:
- **Pivot** (mirrors FX fanout): `product → sales_channels → store (default_sales_channel_id) → partner (partner_stores link)`. `sales_channel ↔ store` isn't a Medusa link, so it's resolved with an explicit query; partner match is done in JS (filters don't auto-join dot-paths).
- **Precedence**: `partner.metadata.custom_domain` → `metadata.website_domain` → `partner.storefront_domain`, normalized to `https://<host>` (matches `set-storefront-base-url.ts` convention; domains are stored bare).
- Never throws → returns `null` so callers fall back to the account/env base.

Wired into both **single** and **bulk** sync steps. An explicit caller `landing_url_base` still wins; account/`STORE_URL` remains the final fallback. Bulk resolves **per product** (a batch can span partners).

## Scope / deferred
- URL resolution on the **umbrella** Merchant account (the issue's recommended ~1-day first step). Per-partner Merchant accounts are out of scope.
- No model/migration changes.

## Tests
11 unit tests (`resolve-partner-landing-base.unit.spec.ts`) — pure normalize, precedence, and the stubbed-`query.graph` pivot (incl. null-fallback + never-throws). No DB. `tsc` 0 new errors (69 = baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)