### PR TITLE
feat(ops): bulk recalculate-design-cost maintenance job (#457)

### DIFF
--- a/apps/backend/integration-tests/http/ops-maintenance-jobs.spec.ts
+++ b/apps/backend/integration-tests/http/ops-maintenance-jobs.spec.ts
@@ -72,6 +72,53 @@ setupSharedTestSuite(() => {
       ).rejects.toMatchObject({ response: { status: 404 } })
     })
 
+    it("GET lists the bulk recalculate job alongside the single one", async () => {
+      const res = await api.get("/admin/ops/maintenance-jobs", adminHeaders)
+      expect(res.status).toBe(200)
+      const ids = res.data.jobs.map((j: any) => j.id)
+      expect(ids).toEqual(
+        expect.arrayContaining([
+          "recalculate-design-cost",
+          "recalculate-design-cost-bulk",
+        ])
+      )
+      const bulk = res.data.jobs.find(
+        (j: any) => j.id === "recalculate-design-cost-bulk"
+      )
+      expect(bulk.params).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "design_ids", required: true }),
+        ])
+      )
+    })
+
+    it("POST recalculate-design-cost-bulk without design_ids → 400", async () => {
+      await expect(
+        api.post(
+          "/admin/ops/maintenance-jobs/recalculate-design-cost-bulk/run",
+          { dry_run: true, params: {} },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+
+    it("POST recalculate-design-cost-bulk reports a missing id per-design instead of failing the batch", async () => {
+      const res = await api.post(
+        "/admin/ops/maintenance-jobs/recalculate-design-cost-bulk/run",
+        { dry_run: true, params: { design_ids: ["design_does_not_exist"] } },
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.result.dry_run).toBe(true)
+      expect(res.data.result.applied).toBe(false)
+      expect(res.data.result.changes).toEqual([])
+      expect(res.data.result.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: "design_does_not_exist" }),
+        ])
+      )
+    })
+
     it("requires admin auth (401 without headers)", async () => {
       await expect(
         api.get("/admin/ops/maintenance-jobs")

--- a/apps/backend/integration-tests/http/ops-maintenance-jobs.spec.ts
+++ b/apps/backend/integration-tests/http/ops-maintenance-jobs.spec.ts
@@ -1,0 +1,81 @@
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+
+jest.setTimeout(60 * 1000)
+
+/**
+ * #457 — Admin data-plumbing / ops maintenance jobs (backend API layer).
+ *
+ * Covers the registry discovery endpoint + the run endpoint's guard rails
+ * (unknown job → 404, missing required param → 400, missing design → 404) and
+ * the safe-by-default dry_run behaviour. The full recalc-with-real-data path is
+ * unit-tested via diffCostFields; here we assert the API contract + guards
+ * without heavy BOM/production-run seeding.
+ */
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("admin ops maintenance jobs", () => {
+    let adminHeaders: { headers: Record<string, string> }
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+    })
+
+    it("GET /admin/ops/maintenance-jobs lists the recalculate-design-cost job", async () => {
+      const res = await api.get("/admin/ops/maintenance-jobs", adminHeaders)
+      expect(res.status).toBe(200)
+      expect(res.data.count).toBeGreaterThanOrEqual(1)
+
+      const recalc = res.data.jobs.find(
+        (j: any) => j.id === "recalculate-design-cost"
+      )
+      expect(recalc).toBeDefined()
+      expect(recalc.label).toBeTruthy()
+      expect(recalc.description).toBeTruthy()
+      expect(recalc.params).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "design_id", required: true }),
+        ])
+      )
+    })
+
+    it("POST run with an unknown job id → 404", async () => {
+      await expect(
+        api.post(
+          "/admin/ops/maintenance-jobs/no-such-job/run",
+          { dry_run: true },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 404 } })
+    })
+
+    it("POST recalculate-design-cost without design_id → 400", async () => {
+      await expect(
+        api.post(
+          "/admin/ops/maintenance-jobs/recalculate-design-cost/run",
+          { dry_run: true, params: {} },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+
+    it("POST recalculate-design-cost for a missing design → 404 (before any compute)", async () => {
+      await expect(
+        api.post(
+          "/admin/ops/maintenance-jobs/recalculate-design-cost/run",
+          { dry_run: true, params: { design_id: "design_does_not_exist" } },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 404 } })
+    })
+
+    it("requires admin auth (401 without headers)", async () => {
+      await expect(
+        api.get("/admin/ops/maintenance-jobs")
+      ).rejects.toMatchObject({ response: { status: 401 } })
+    })
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/[id]/run/route.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/[id]/run/route.ts
@@ -1,0 +1,47 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+import { getMaintenanceJob } from "../../registry"
+import { OpsMaintenanceRunBody } from "../../validators"
+
+/**
+ * POST /admin/ops/maintenance-jobs/:id/run
+ *
+ * Runs a guarded maintenance job. Safe by default: dry_run defaults to true, so
+ * a body of {} previews changes without writing. Pass { dry_run: false } to
+ * apply. Every run is logged with the actor + outcome (lightweight audit;
+ * a durable audit-log model is a follow-up slice). (#457)
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const job = getMaintenanceJob(req.params.id)
+  if (!job) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Unknown maintenance job: ${req.params.id}`
+    )
+  }
+
+  const body = (req.validatedBody ?? {}) as OpsMaintenanceRunBody
+  const dry_run = body.dry_run ?? true
+  const params = (body.params ?? {}) as Record<string, unknown>
+
+  const result = await job.run(req.scope, { dry_run, params })
+
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  const actorId = (req as any).auth_context?.actor_id ?? "unknown"
+  logger.info(
+    `[ops/maintenance] actor=${actorId} job=${job.id} dry_run=${result.dry_run} applied=${result.applied} changes=${result.changes.length}`
+  )
+
+  res.json({
+    result,
+    audit: {
+      actor_id: actorId,
+      job_id: job.id,
+      dry_run: result.dry_run,
+      applied: result.applied,
+      change_count: result.changes.length,
+      ran_at: new Date().toISOString(),
+    },
+  })
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/registry.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/registry.unit.spec.ts
@@ -2,6 +2,9 @@ import {
   diffCostFields,
   getMaintenanceJob,
   MAINTENANCE_JOBS,
+  MAX_BULK_DESIGNS,
+  parseDesignIds,
+  summarizeBulkRecalc,
 } from "../registry"
 
 // Pure unit coverage for the maintenance-job registry (#457). No DB / workflow
@@ -21,6 +24,64 @@ describe("ops/maintenance-jobs registry (#457)", () => {
 
     it("exposes at least the recalculate-design-cost job", () => {
       expect(MAINTENANCE_JOBS.map((j) => j.id)).toContain("recalculate-design-cost")
+    })
+
+    it("registers the bulk recalculate job with a required design_ids param", () => {
+      const job = getMaintenanceJob("recalculate-design-cost-bulk")
+      expect(job).toBeDefined()
+      expect(job?.params.some((p) => p.name === "design_ids" && p.required)).toBe(true)
+    })
+  })
+
+  describe("parseDesignIds", () => {
+    it("accepts an array of ids", () => {
+      expect(parseDesignIds(["d_1", "d_2"])).toEqual(["d_1", "d_2"])
+    })
+
+    it("accepts a comma/whitespace/newline-separated string", () => {
+      expect(parseDesignIds("d_1, d_2\nd_3  d_4")).toEqual(["d_1", "d_2", "d_3", "d_4"])
+    })
+
+    it("trims, drops blanks, and de-duplicates while preserving order", () => {
+      expect(parseDesignIds([" d_1 ", "d_2", "", "d_1"])).toEqual(["d_1", "d_2"])
+    })
+
+    it("throws INVALID_DATA when no usable id is present", () => {
+      expect(() => parseDesignIds("  ,  ")).toThrow(/at least one/)
+      expect(() => parseDesignIds([])).toThrow(/at least one/)
+    })
+
+    it("throws INVALID_DATA for a non-string/array input", () => {
+      expect(() => parseDesignIds(undefined)).toThrow(/required/)
+      expect(() => parseDesignIds(42 as any)).toThrow(/required/)
+    })
+
+    it("rejects more ids than the per-request cap", () => {
+      const tooMany = Array.from({ length: MAX_BULK_DESIGNS + 1 }, (_, i) => `d_${i}`)
+      expect(() => parseDesignIds(tooMany)).toThrow(/limit of/)
+    })
+
+    it("allows exactly the cap", () => {
+      const atCap = Array.from({ length: MAX_BULK_DESIGNS }, (_, i) => `d_${i}`)
+      expect(parseDesignIds(atCap)).toHaveLength(MAX_BULK_DESIGNS)
+    })
+  })
+
+  describe("summarizeBulkRecalc", () => {
+    it("reports no changes when nothing drifted", () => {
+      expect(summarizeBulkRecalc(true, 3, 0, 0, 0)).toMatch(/No changes — 3 design/)
+    })
+
+    it("uses 'Would update' for dry-run and counts changed designs", () => {
+      expect(summarizeBulkRecalc(true, 5, 2, 4, 0)).toBe(
+        "Would update 4 field(s) across 2/5 design(s)"
+      )
+    })
+
+    it("uses 'Updated' on apply and appends an error count when present", () => {
+      expect(summarizeBulkRecalc(false, 5, 2, 4, 1)).toBe(
+        "Updated 4 field(s) across 2/5 design(s); 1 error(s)"
+      )
     })
   })
 

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/registry.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/registry.unit.spec.ts
@@ -1,0 +1,82 @@
+import {
+  diffCostFields,
+  getMaintenanceJob,
+  MAINTENANCE_JOBS,
+} from "../registry"
+
+// Pure unit coverage for the maintenance-job registry (#457). No DB / workflow
+// boot — only the dry-run/apply diff logic and registry lookup.
+describe("ops/maintenance-jobs registry (#457)", () => {
+  describe("getMaintenanceJob", () => {
+    it("resolves a registered job by id", () => {
+      const job = getMaintenanceJob("recalculate-design-cost")
+      expect(job).toBeDefined()
+      expect(job?.id).toBe("recalculate-design-cost")
+      expect(job?.params.some((p) => p.name === "design_id" && p.required)).toBe(true)
+    })
+
+    it("returns undefined for an unknown job", () => {
+      expect(getMaintenanceJob("does-not-exist")).toBeUndefined()
+    })
+
+    it("exposes at least the recalculate-design-cost job", () => {
+      expect(MAINTENANCE_JOBS.map((j) => j.id)).toContain("recalculate-design-cost")
+    })
+  })
+
+  describe("diffCostFields", () => {
+    const after = { total_estimated: 100, material_cost: 70, production_cost: 30 }
+
+    it("reports a change for every field when nothing is persisted yet (null → value)", () => {
+      const changes = diffCostFields("design_1", {}, after)
+      expect(changes).toHaveLength(3)
+      expect(changes).toEqual(
+        expect.arrayContaining([
+          { entity: "design", id: "design_1", field: "estimated_cost", before: null, after: 100 },
+          { entity: "design", id: "design_1", field: "material_cost", before: null, after: 70 },
+          { entity: "design", id: "design_1", field: "production_cost", before: null, after: 30 },
+        ])
+      )
+    })
+
+    it("returns no changes when persisted values already match (idempotent apply)", () => {
+      const changes = diffCostFields(
+        "design_1",
+        { estimated_cost: 100, material_cost: 70, production_cost: 30 },
+        after
+      )
+      expect(changes).toEqual([])
+    })
+
+    it("only reports the fields that actually differ", () => {
+      const changes = diffCostFields(
+        "design_1",
+        { estimated_cost: 100, material_cost: 60, production_cost: 30 },
+        after
+      )
+      expect(changes).toEqual([
+        { entity: "design", id: "design_1", field: "material_cost", before: 60, after: 70 },
+      ])
+    })
+
+    it("coerces string-typed persisted decimals before comparing", () => {
+      const changes = diffCostFields(
+        "design_1",
+        { estimated_cost: "100" as any, material_cost: "70" as any, production_cost: "30" as any },
+        after
+      )
+      expect(changes).toEqual([])
+    })
+
+    it("treats null and 0 as distinct (null is unset, 0 is a real value)", () => {
+      const changes = diffCostFields(
+        "design_1",
+        { estimated_cost: 100, material_cost: 70, production_cost: null },
+        after
+      )
+      expect(changes).toEqual([
+        { entity: "design", id: "design_1", field: "production_cost", before: null, after: 30 },
+      ])
+    })
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -1,0 +1,182 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import { estimateDesignCostWorkflow } from "../../../../workflows/designs/estimate-design-cost"
+import { DESIGN_MODULE } from "../../../../modules/designs"
+
+/**
+ * Admin "data-plumbing" maintenance jobs (#457 / roadmap #33).
+ *
+ * Each job is a guarded, API-driven data-correction action that follows the
+ * same safe-by-default contract:
+ *   - dry-run preview (default) → returns the changes it WOULD make, no writes
+ *   - apply (dry_run=false)     → idempotent write, returns the changes made
+ *
+ * Jobs mostly surface + guard-rail existing endpoints/scripts so the recurring
+ * "the code fix prevents recurrence but stored rows still need a targeted, safe
+ * correction" incident no longer requires raw curl / one-off ECS run-task
+ * scripts. This is the backend (API) layer; an admin Ops console can consume it.
+ */
+
+export type MaintenanceChange = {
+  entity: string
+  id: string
+  field?: string
+  before?: unknown
+  after?: unknown
+}
+
+export type MaintenanceJobResult = {
+  job_id: string
+  dry_run: boolean
+  /** true only when dry_run=false AND at least one field actually changed */
+  applied: boolean
+  summary: string
+  changes: MaintenanceChange[]
+}
+
+export type MaintenanceJobParam = {
+  name: string
+  type: "string" | "number" | "boolean"
+  required: boolean
+  description: string
+}
+
+export type MaintenanceJob = {
+  id: string
+  label: string
+  description: string
+  /** Human/consumer-facing param descriptors (for the list endpoint + UI) */
+  params: MaintenanceJobParam[]
+  run: (
+    container: any,
+    opts: { dry_run: boolean; params: Record<string, unknown> }
+  ) => Promise<MaintenanceJobResult>
+}
+
+/**
+ * Pure diff between a design's currently-persisted cost fields and a freshly
+ * computed estimate. Exported for unit testing — keeps the dry-run/apply logic
+ * verifiable without booting the DB or the workflow engine.
+ */
+export function diffCostFields(
+  designId: string,
+  before: {
+    estimated_cost?: number | null
+    material_cost?: number | null
+    production_cost?: number | null
+  },
+  after: { total_estimated: number; material_cost: number; production_cost: number }
+): MaintenanceChange[] {
+  const pairs: Array<[string, number | null | undefined, number]> = [
+    ["estimated_cost", before.estimated_cost, after.total_estimated],
+    ["material_cost", before.material_cost, after.material_cost],
+    ["production_cost", before.production_cost, after.production_cost],
+  ]
+
+  const changes: MaintenanceChange[] = []
+  for (const [field, rawBefore, afterValue] of pairs) {
+    const beforeValue = rawBefore == null ? null : Number(rawBefore)
+    if (beforeValue !== afterValue) {
+      changes.push({ entity: "design", id: designId, field, before: beforeValue, after: afterValue })
+    }
+  }
+  return changes
+}
+
+const recalcParamsSchema = z.object({
+  design_id: z.string().min(1, "design_id is required"),
+})
+
+/**
+ * Recalculate design cost — surfaces the same computation as
+ * POST /admin/designs/:id/recalculate-cost, but with a dry-run preview that
+ * shows the before/after of estimated/material/production cost WITHOUT
+ * persisting. Apply mirrors that route's persist payload exactly.
+ */
+export const recalculateDesignCostJob: MaintenanceJob = {
+  id: "recalculate-design-cost",
+  label: "Recalculate design cost",
+  description:
+    "Re-estimate a design's material + production cost from its BOM and latest completed production run. Dry-run previews the before/after without persisting; apply writes the full breakdown back onto the design (idempotent).",
+  params: [
+    {
+      name: "design_id",
+      type: "string",
+      required: true,
+      description: "ID of the design to recalculate",
+    },
+  ],
+  run: async (container, { dry_run, params }) => {
+    const parsed = recalcParamsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { design_id } = parsed.data
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const { data: designs } = await query.graph({
+      entity: "design",
+      filters: { id: design_id },
+      fields: ["id", "estimated_cost", "material_cost", "production_cost"],
+    })
+
+    if (!designs || designs.length === 0) {
+      throw new MedusaError(MedusaError.Types.NOT_FOUND, `Design not found: ${design_id}`)
+    }
+    const current = designs[0]
+
+    const { result, errors } = await estimateDesignCostWorkflow(container).run({
+      input: { design_id },
+    })
+
+    if (errors && errors.length > 0) {
+      throw new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        `Failed to estimate cost: ${errors
+          .map((e: any) => e?.error?.message ?? String(e))
+          .join("; ")}`
+      )
+    }
+
+    const changes = diffCostFields(design_id, current, result)
+
+    if (!dry_run && changes.length > 0) {
+      const designService: any = container.resolve(DESIGN_MODULE)
+      await designService.updateDesigns({
+        id: design_id,
+        estimated_cost: result.total_estimated,
+        material_cost: result.material_cost,
+        production_cost: result.production_cost,
+        cost_breakdown: {
+          items: result.breakdown?.materials ?? [],
+          production_percent: result.breakdown?.production_percent,
+          confidence: result.confidence,
+          calculated_at: new Date().toISOString(),
+          source: "ops_maintenance_recalculate",
+        },
+      })
+    }
+
+    const summary =
+      changes.length === 0
+        ? `No changes — design ${design_id} cost already up to date (total ${result.total_estimated})`
+        : `${dry_run ? "Would update" : "Updated"} ${changes.length} field(s) on design ${design_id}; new total ${result.total_estimated} (${result.confidence})`
+
+    return {
+      job_id: recalculateDesignCostJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary,
+      changes,
+    }
+  },
+}
+
+export const MAINTENANCE_JOBS: MaintenanceJob[] = [recalculateDesignCostJob]
+
+export const getMaintenanceJob = (id: string): MaintenanceJob | undefined =>
+  MAINTENANCE_JOBS.find((job) => job.id === id)

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -33,6 +33,12 @@ export type MaintenanceJobResult = {
   applied: boolean
   summary: string
   changes: MaintenanceChange[]
+  /**
+   * Per-entity errors for batch jobs — a single bad id (e.g. a deleted design)
+   * is recorded here instead of aborting the whole run. Omitted for
+   * single-entity jobs (which throw a MedusaError → HTTP status instead).
+   */
+  errors?: Array<{ id: string; message: string }>
 }
 
 export type MaintenanceJobParam = {
@@ -84,6 +90,76 @@ export function diffCostFields(
   return changes
 }
 
+type DesignCostEstimate = {
+  total_estimated: number
+  material_cost: number
+  production_cost: number
+  confidence: string
+  breakdown?: { materials?: unknown[]; production_percent?: number }
+}
+
+/**
+ * Shared compute used by both the single- and bulk-recalculate jobs: load the
+ * design's currently-persisted cost fields and run the (read-only) estimate
+ * workflow. Throws NOT_FOUND if the design is gone and UNEXPECTED_STATE if the
+ * workflow itself fails — so callers get the right HTTP status for free.
+ */
+export async function recomputeDesignCost(
+  container: any,
+  designId: string
+): Promise<{
+  current: { estimated_cost?: number | null; material_cost?: number | null; production_cost?: number | null }
+  result: DesignCostEstimate
+}> {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  const { data: designs } = await query.graph({
+    entity: "design",
+    filters: { id: designId },
+    fields: ["id", "estimated_cost", "material_cost", "production_cost"],
+  })
+
+  if (!designs || designs.length === 0) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, `Design not found: ${designId}`)
+  }
+
+  const { result, errors } = await estimateDesignCostWorkflow(container).run({
+    input: { design_id: designId },
+  })
+
+  if (errors && errors.length > 0) {
+    throw new MedusaError(
+      MedusaError.Types.UNEXPECTED_STATE,
+      `Failed to estimate cost: ${errors
+        .map((e: any) => e?.error?.message ?? String(e))
+        .join("; ")}`
+    )
+  }
+
+  return { current: designs[0], result: result as DesignCostEstimate }
+}
+
+/** Persist a freshly-computed estimate back onto a design (idempotent). */
+export async function persistDesignCost(
+  container: any,
+  designId: string,
+  result: DesignCostEstimate
+): Promise<void> {
+  const designService: any = container.resolve(DESIGN_MODULE)
+  await designService.updateDesigns({
+    id: designId,
+    estimated_cost: result.total_estimated,
+    material_cost: result.material_cost,
+    production_cost: result.production_cost,
+    cost_breakdown: {
+      items: result.breakdown?.materials ?? [],
+      production_percent: result.breakdown?.production_percent,
+      confidence: result.confidence,
+      calculated_at: new Date().toISOString(),
+      source: "ops_maintenance_recalculate",
+    },
+  })
+}
+
 const recalcParamsSchema = z.object({
   design_id: z.string().min(1, "design_id is required"),
 })
@@ -117,48 +193,11 @@ export const recalculateDesignCostJob: MaintenanceJob = {
     }
     const { design_id } = parsed.data
 
-    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
-    const { data: designs } = await query.graph({
-      entity: "design",
-      filters: { id: design_id },
-      fields: ["id", "estimated_cost", "material_cost", "production_cost"],
-    })
-
-    if (!designs || designs.length === 0) {
-      throw new MedusaError(MedusaError.Types.NOT_FOUND, `Design not found: ${design_id}`)
-    }
-    const current = designs[0]
-
-    const { result, errors } = await estimateDesignCostWorkflow(container).run({
-      input: { design_id },
-    })
-
-    if (errors && errors.length > 0) {
-      throw new MedusaError(
-        MedusaError.Types.UNEXPECTED_STATE,
-        `Failed to estimate cost: ${errors
-          .map((e: any) => e?.error?.message ?? String(e))
-          .join("; ")}`
-      )
-    }
-
+    const { current, result } = await recomputeDesignCost(container, design_id)
     const changes = diffCostFields(design_id, current, result)
 
     if (!dry_run && changes.length > 0) {
-      const designService: any = container.resolve(DESIGN_MODULE)
-      await designService.updateDesigns({
-        id: design_id,
-        estimated_cost: result.total_estimated,
-        material_cost: result.material_cost,
-        production_cost: result.production_cost,
-        cost_breakdown: {
-          items: result.breakdown?.materials ?? [],
-          production_percent: result.breakdown?.production_percent,
-          confidence: result.confidence,
-          calculated_at: new Date().toISOString(),
-          source: "ops_maintenance_recalculate",
-        },
-      })
+      await persistDesignCost(container, design_id, result)
     }
 
     const summary =
@@ -176,7 +215,140 @@ export const recalculateDesignCostJob: MaintenanceJob = {
   },
 }
 
-export const MAINTENANCE_JOBS: MaintenanceJob[] = [recalculateDesignCostJob]
+/**
+ * Hard cap on the bulk recalculate job: each id runs the estimate workflow
+ * synchronously, so we keep the per-request blast radius operator-bounded and
+ * the endpoint responsive. Larger corrections should be chunked across calls.
+ */
+export const MAX_BULK_DESIGNS = 25
+
+/**
+ * Pure normaliser for the bulk job's `design_ids` param. Accepts either a real
+ * array or a comma/whitespace/newline-separated string (handy for pasting a
+ * column out of a spreadsheet). Trims, drops blanks, de-duplicates while
+ * preserving order, and enforces the 1..MAX_BULK_DESIGNS bound. Exported for
+ * unit testing — no container/DB needed.
+ */
+export function parseDesignIds(input: unknown): string[] {
+  let raw: unknown[]
+  if (Array.isArray(input)) {
+    raw = input
+  } else if (typeof input === "string") {
+    raw = input.split(/[\s,]+/)
+  } else {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "design_ids is required (array or comma-separated string of design ids)"
+    )
+  }
+
+  const seen = new Set<string>()
+  const ids: string[] = []
+  for (const entry of raw) {
+    const id = typeof entry === "string" ? entry.trim() : String(entry ?? "").trim()
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+    ids.push(id)
+  }
+
+  if (ids.length === 0) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "design_ids must contain at least one non-empty id"
+    )
+  }
+  if (ids.length > MAX_BULK_DESIGNS) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `design_ids exceeds the per-request limit of ${MAX_BULK_DESIGNS} (got ${ids.length}); split into smaller batches`
+    )
+  }
+  return ids
+}
+
+/**
+ * Pure summary builder for the bulk job — keeps the human-facing string logic
+ * verifiable without booting the workflow engine.
+ */
+export function summarizeBulkRecalc(
+  dryRun: boolean,
+  idCount: number,
+  changedDesignCount: number,
+  changeCount: number,
+  errorCount: number
+): string {
+  const verb = dryRun ? "Would update" : "Updated"
+  const head =
+    changeCount === 0
+      ? `No changes — ${idCount} design(s) already up to date`
+      : `${verb} ${changeCount} field(s) across ${changedDesignCount}/${idCount} design(s)`
+  return errorCount > 0 ? `${head}; ${errorCount} error(s)` : head
+}
+
+/**
+ * Bulk recalculate design cost — same per-design compute as
+ * `recalculate-design-cost`, but over an explicit, capped list of ids so an
+ * operator can re-correct many drifted designs in one guarded call after a
+ * cost-logic fix. Dry-run (default) previews the full aggregate change set;
+ * one bad/deleted id is reported in `errors` instead of failing the batch.
+ */
+export const recalculateDesignCostBulkJob: MaintenanceJob = {
+  id: "recalculate-design-cost-bulk",
+  label: "Recalculate design cost (bulk)",
+  description:
+    `Re-estimate material + production cost for an explicit list of designs (max ${MAX_BULK_DESIGNS} per call). Dry-run previews the aggregate before/after without persisting; apply writes each design's breakdown back (idempotent). A missing/deleted id is reported per-design and does not abort the batch.`,
+  params: [
+    {
+      name: "design_ids",
+      type: "string",
+      required: true,
+      description: `Design ids to recalculate — array or comma-separated string (max ${MAX_BULK_DESIGNS})`,
+    },
+  ],
+  run: async (container, { dry_run, params }) => {
+    const ids = parseDesignIds((params as any).design_ids)
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    const changedDesigns = new Set<string>()
+
+    for (const designId of ids) {
+      try {
+        const { current, result } = await recomputeDesignCost(container, designId)
+        const designChanges = diffCostFields(designId, current, result)
+        if (designChanges.length > 0) {
+          changedDesigns.add(designId)
+          changes.push(...designChanges)
+          if (!dry_run) {
+            await persistDesignCost(container, designId, result)
+          }
+        }
+      } catch (e: any) {
+        errors.push({ id: designId, message: e?.message ?? String(e) })
+      }
+    }
+
+    return {
+      job_id: recalculateDesignCostBulkJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary: summarizeBulkRecalc(
+        dry_run,
+        ids.length,
+        changedDesigns.size,
+        changes.length,
+        errors.length
+      ),
+      changes,
+      errors,
+    }
+  },
+}
+
+export const MAINTENANCE_JOBS: MaintenanceJob[] = [
+  recalculateDesignCostJob,
+  recalculateDesignCostBulkJob,
+]
 
 export const getMaintenanceJob = (id: string): MaintenanceJob | undefined =>
   MAINTENANCE_JOBS.find((job) => job.id === id)

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/route.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/route.ts
@@ -1,0 +1,21 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+import { MAINTENANCE_JOBS } from "./registry"
+
+/**
+ * GET /admin/ops/maintenance-jobs
+ *
+ * Lists the available data-plumbing maintenance jobs and their parameters so an
+ * admin Ops console (or a script) can discover what's runnable. (#457)
+ */
+export const GET = async (_req: MedusaRequest, res: MedusaResponse) => {
+  res.json({
+    jobs: MAINTENANCE_JOBS.map((job) => ({
+      id: job.id,
+      label: job.label,
+      description: job.description,
+      params: job.params,
+    })),
+    count: MAINTENANCE_JOBS.length,
+  })
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/validators.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/validators.ts
@@ -1,0 +1,17 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * Body for POST /admin/ops/maintenance-jobs/:id/run.
+ * dry_run defaults to true (safe by default) — the route applies the default
+ * since validateAndTransformBody strips unknown keys but won't inject one.
+ */
+export const OpsMaintenanceRunSchema = z.object({
+  dry_run: z.boolean().optional(),
+  // Per-job params are validated inside each job's own schema; here we only
+  // accept an object. NOTE: zod v4 requires the two-arg z.record form
+  // (z.record(z.any()) leaves the value schema undefined → "_zod" crash when
+  // params is non-empty).
+  params: z.record(z.string(), z.any()).optional(),
+})
+
+export type OpsMaintenanceRunBody = z.infer<typeof OpsMaintenanceRunSchema>

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -17,6 +17,7 @@ import { parseCorsOrigins, ContainerRegistrationKeys } from "@medusajs/framework
 import cors from "cors";
 import { z } from "@medusajs/framework/zod";
 import { personSchema, listPersonsQuerySchema, UpdatePersonSchema, ReadPersonQuerySchema } from "./admin/persons/validators";
+import { OpsMaintenanceRunSchema } from "./admin/ops/maintenance-jobs/validators";
 import { getPersonResourceDefinition } from "./admin/persons/resources/registry";
 import { AdminGetOrdersOrderParams } from "@medusajs/medusa/api/admin/orders/validators";
 import { retrieveTransformQueryConfig as retrieveOrderTransformQueryConfig } from "@medusajs/medusa/api/admin/orders/query-config";
@@ -2950,6 +2951,12 @@ export default defineMiddlewares({
       matcher: "/admin/designs",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(designSchema))],
+    },
+    {
+      // #457 admin data-plumbing / ops maintenance jobs
+      matcher: "/admin/ops/maintenance-jobs/:id/run",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(OpsMaintenanceRunSchema))],
     },
     // NOTE: /admin/* routes already get Medusa's default admin auth
     // (session + bearer + api-key). Re-registering authenticate() with only


### PR DESCRIPTION
Reopened from auto-closed #471 (its base branch was deleted on #470 merge, which closed it instead of retargeting). Same reviewed-clean diff: a second registry job `recalculate-design-cost-bulk` (capped 25 ids, per-design error reporting, dry-run default), reusing #470's shared compute/persist helpers. #470 is now on main.

Supersedes #471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)