### PR TITLE
feat(ops): correct-production-run-cost maintenance job (#457)

### DIFF
--- a/apps/backend/integration-tests/http/ops-maintenance-jobs.spec.ts
+++ b/apps/backend/integration-tests/http/ops-maintenance-jobs.spec.ts
@@ -119,6 +119,68 @@ setupSharedTestSuite(() => {
       )
     })
 
+    it("GET lists the correct-production-run-cost job", async () => {
+      const res = await api.get("/admin/ops/maintenance-jobs", adminHeaders)
+      expect(res.status).toBe(200)
+      const job = res.data.jobs.find(
+        (j: any) => j.id === "correct-production-run-cost"
+      )
+      expect(job).toBeDefined()
+      expect(job.params).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "production_run_id", required: true }),
+          expect.objectContaining({ name: "partner_cost_estimate", required: false }),
+          expect.objectContaining({ name: "cost_type", required: false }),
+        ])
+      )
+    })
+
+    it("POST correct-production-run-cost without production_run_id → 400", async () => {
+      await expect(
+        api.post(
+          "/admin/ops/maintenance-jobs/correct-production-run-cost/run",
+          { dry_run: true, params: { cost_type: "per_unit" } },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+
+    it("POST correct-production-run-cost with no cost field to change → 400", async () => {
+      await expect(
+        api.post(
+          "/admin/ops/maintenance-jobs/correct-production-run-cost/run",
+          { dry_run: true, params: { production_run_id: "prod_run_x" } },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+
+    it("POST correct-production-run-cost with an invalid cost_type → 400", async () => {
+      await expect(
+        api.post(
+          "/admin/ops/maintenance-jobs/correct-production-run-cost/run",
+          {
+            dry_run: true,
+            params: { production_run_id: "prod_run_x", cost_type: "bogus" },
+          },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+
+    it("POST correct-production-run-cost for a missing run → 404 (before any write)", async () => {
+      await expect(
+        api.post(
+          "/admin/ops/maintenance-jobs/correct-production-run-cost/run",
+          {
+            dry_run: true,
+            params: { production_run_id: "prod_run_missing", cost_type: "per_unit" },
+          },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 404 } })
+    })
+
     it("requires admin auth (401 without headers)", async () => {
       await expect(
         api.get("/admin/ops/maintenance-jobs")

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/registry.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/registry.unit.spec.ts
@@ -1,6 +1,8 @@
 import {
   diffCostFields,
+  diffRunCostFields,
   getMaintenanceJob,
+  interpretRunCost,
   MAINTENANCE_JOBS,
   MAX_BULK_DESIGNS,
   parseDesignIds,
@@ -30,6 +32,97 @@ describe("ops/maintenance-jobs registry (#457)", () => {
       const job = getMaintenanceJob("recalculate-design-cost-bulk")
       expect(job).toBeDefined()
       expect(job?.params.some((p) => p.name === "design_ids" && p.required)).toBe(true)
+    })
+
+    it("registers the correct-production-run-cost job with a required run id param", () => {
+      const job = getMaintenanceJob("correct-production-run-cost")
+      expect(job).toBeDefined()
+      expect(job?.params.some((p) => p.name === "production_run_id" && p.required)).toBe(true)
+      // cost fields are optional (caller supplies at least one)
+      expect(job?.params.some((p) => p.name === "partner_cost_estimate" && !p.required)).toBe(true)
+      expect(job?.params.some((p) => p.name === "cost_type" && !p.required)).toBe(true)
+    })
+  })
+
+  describe("interpretRunCost (#456 per-unit × qty trap)", () => {
+    it("expands a per_unit estimate to its total over the run quantity", () => {
+      expect(interpretRunCost(7650, "per_unit", 9)).toEqual({ per_unit: 7650, total: 68850 })
+    })
+
+    it("divides a total estimate down to per-unit over the run quantity", () => {
+      expect(interpretRunCost(68850, "total", 9)).toEqual({ per_unit: 7650, total: 68850 })
+    })
+
+    it("defaults to 'total' interpretation when cost_type is null/undefined", () => {
+      expect(interpretRunCost(100, null, 4)).toEqual({ per_unit: 25, total: 100 })
+      expect(interpretRunCost(100, undefined, 4)).toEqual({ per_unit: 25, total: 100 })
+    })
+
+    it("treats a non-positive quantity as 1 (no divide-by-zero)", () => {
+      expect(interpretRunCost(100, "total", 0)).toEqual({ per_unit: 100, total: 100 })
+      expect(interpretRunCost(100, "per_unit", 0)).toEqual({ per_unit: 100, total: 100 })
+    })
+
+    it("returns nulls when no estimate is set", () => {
+      expect(interpretRunCost(null, "total", 9)).toEqual({ per_unit: null, total: null })
+      expect(interpretRunCost(undefined, "per_unit", 9)).toEqual({ per_unit: null, total: null })
+    })
+  })
+
+  describe("diffRunCostFields", () => {
+    it("only considers fields the caller supplied (omitted = untouched)", () => {
+      const changes = diffRunCostFields(
+        "prod_run_1",
+        { partner_cost_estimate: 100, cost_type: "total" },
+        { cost_type: "per_unit" }
+      )
+      expect(changes).toEqual([
+        { entity: "production_run", id: "prod_run_1", field: "cost_type", before: "total", after: "per_unit" },
+      ])
+    })
+
+    it("reports a change for both fields when corrected together", () => {
+      const changes = diffRunCostFields(
+        "prod_run_1",
+        { partner_cost_estimate: 68850, cost_type: "total" },
+        { partner_cost_estimate: 7650, cost_type: "per_unit" }
+      )
+      expect(changes).toEqual(
+        expect.arrayContaining([
+          { entity: "production_run", id: "prod_run_1", field: "partner_cost_estimate", before: 68850, after: 7650 },
+          { entity: "production_run", id: "prod_run_1", field: "cost_type", before: "total", after: "per_unit" },
+        ])
+      )
+      expect(changes).toHaveLength(2)
+    })
+
+    it("returns no changes when the requested values already match (idempotent)", () => {
+      const changes = diffRunCostFields(
+        "prod_run_1",
+        { partner_cost_estimate: 100, cost_type: "total" },
+        { partner_cost_estimate: 100, cost_type: "total" }
+      )
+      expect(changes).toEqual([])
+    })
+
+    it("treats null as a real 'clear the estimate' change, distinct from omitted", () => {
+      const cleared = diffRunCostFields(
+        "prod_run_1",
+        { partner_cost_estimate: 100, cost_type: "total" },
+        { partner_cost_estimate: null }
+      )
+      expect(cleared).toEqual([
+        { entity: "production_run", id: "prod_run_1", field: "partner_cost_estimate", before: 100, after: null },
+      ])
+    })
+
+    it("coerces string-typed persisted decimals before comparing", () => {
+      const changes = diffRunCostFields(
+        "prod_run_1",
+        { partner_cost_estimate: "100" as any, cost_type: "total" },
+        { partner_cost_estimate: 100 }
+      )
+      expect(changes).toEqual([])
     })
   })
 

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -3,6 +3,7 @@ import { z } from "@medusajs/framework/zod"
 
 import { estimateDesignCostWorkflow } from "../../../../workflows/designs/estimate-design-cost"
 import { DESIGN_MODULE } from "../../../../modules/designs"
+import { PRODUCTION_RUNS_MODULE } from "../../../../modules/production_runs"
 
 /**
  * Admin "data-plumbing" maintenance jobs (#457 / roadmap #33).
@@ -345,9 +346,195 @@ export const recalculateDesignCostBulkJob: MaintenanceJob = {
   },
 }
 
+/**
+ * Pure interpretation of a production run's cost estimate as BOTH a per-unit and
+ * a total amount, given its `cost_type` and run quantity. This is the exact
+ * reader-side math that bit #456 (a per-unit estimate stored/read as a total →
+ * `7650 × 9 = 68850` double-multiply). Surfacing it in the dry-run preview makes
+ * a normalisation mistake obvious BEFORE it's applied.
+ *
+ * Exported for unit testing — no container/DB.
+ */
+export function interpretRunCost(
+  estimate: number | null | undefined,
+  costType: "per_unit" | "total" | null | undefined,
+  quantity: number
+): { per_unit: number | null; total: number | null } {
+  if (estimate == null || Number.isNaN(Number(estimate))) {
+    return { per_unit: null, total: null }
+  }
+  const value = Number(estimate)
+  const qty = quantity > 0 ? quantity : 1
+  if (costType === "per_unit") {
+    return { per_unit: value, total: value * qty }
+  }
+  // default / "total"
+  return { per_unit: value / qty, total: value }
+}
+
+export type ProductionRunCostFields = {
+  partner_cost_estimate?: number | null
+  cost_type?: "per_unit" | "total" | null
+}
+
+/**
+ * Pure diff between a production run's persisted cost fields and the operator's
+ * requested correction. Only fields present in `after` (i.e. supplied by the
+ * caller) are considered — an omitted field is left untouched. `null` is a
+ * deliberate "clear the estimate" instruction, distinct from omitted.
+ *
+ * Exported for unit testing — no container/DB.
+ */
+export function diffRunCostFields(
+  runId: string,
+  before: ProductionRunCostFields,
+  after: ProductionRunCostFields
+): MaintenanceChange[] {
+  const changes: MaintenanceChange[] = []
+
+  if (after.partner_cost_estimate !== undefined) {
+    const b = before.partner_cost_estimate == null ? null : Number(before.partner_cost_estimate)
+    const a = after.partner_cost_estimate == null ? null : Number(after.partner_cost_estimate)
+    if (b !== a) {
+      changes.push({ entity: "production_run", id: runId, field: "partner_cost_estimate", before: b, after: a })
+    }
+  }
+
+  if (after.cost_type !== undefined) {
+    const b = before.cost_type ?? null
+    const a = after.cost_type ?? null
+    if (b !== a) {
+      changes.push({ entity: "production_run", id: runId, field: "cost_type", before: b, after: a })
+    }
+  }
+
+  return changes
+}
+
+const correctRunCostParamsSchema = z
+  .object({
+    production_run_id: z.string().min(1, "production_run_id is required"),
+    partner_cost_estimate: z.union([z.number(), z.null()]).optional(),
+    cost_type: z.enum(["per_unit", "total"]).optional(),
+  })
+  .refine(
+    (v) => v.partner_cost_estimate !== undefined || v.cost_type !== undefined,
+    { message: "provide at least one of partner_cost_estimate or cost_type to correct" }
+  )
+
+/**
+ * Correct a production run's cost — surfaces the same edit as
+ * POST /admin/production-runs/:id (partner_cost_estimate / cost_type), but with
+ * a dry-run preview that shows how readers will interpret the corrected value
+ * (per-unit AND total, given run quantity) so a normalisation mistake is obvious
+ * before it's persisted. Mirrors the admin route's guard: a cancelled run is not
+ * editable. Apply writes via updateProductionRuns (idempotent).
+ */
+export const correctProductionRunCostJob: MaintenanceJob = {
+  id: "correct-production-run-cost",
+  label: "Correct a production run's cost",
+  description:
+    "Set a production run's partner_cost_estimate and/or cost_type (per_unit | total). Dry-run previews the before/after AND how the corrected value reads as per-unit × quantity = total (the #456 double-multiply trap) without persisting; apply writes it back. A cancelled run cannot be edited.",
+  params: [
+    {
+      name: "production_run_id",
+      type: "string",
+      required: true,
+      description: "ID of the production run to correct",
+    },
+    {
+      name: "partner_cost_estimate",
+      type: "number",
+      required: false,
+      description: "New cost estimate (null clears it). At least one of this / cost_type is required.",
+    },
+    {
+      name: "cost_type",
+      type: "string",
+      required: false,
+      description: "How the estimate is expressed: 'per_unit' or 'total'. At least one of this / partner_cost_estimate is required.",
+    },
+  ],
+  run: async (container, { dry_run, params }) => {
+    const parsed = correctRunCostParamsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { production_run_id, partner_cost_estimate, cost_type } = parsed.data
+
+    const service: any = container.resolve(PRODUCTION_RUNS_MODULE)
+
+    let run: any
+    try {
+      run = await service.retrieveProductionRun(production_run_id)
+    } catch {
+      run = null
+    }
+    if (!run) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Production run not found: ${production_run_id}`
+      )
+    }
+    if (run.status === "cancelled") {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        "Cannot edit a cancelled production run"
+      )
+    }
+
+    const after: ProductionRunCostFields = {}
+    if (partner_cost_estimate !== undefined) after.partner_cost_estimate = partner_cost_estimate
+    if (cost_type !== undefined) after.cost_type = cost_type
+
+    const before: ProductionRunCostFields = {
+      partner_cost_estimate: run.partner_cost_estimate ?? null,
+      cost_type: run.cost_type ?? null,
+    }
+
+    const changes = diffRunCostFields(production_run_id, before, after)
+
+    if (!dry_run && changes.length > 0) {
+      const update: Record<string, unknown> = { id: production_run_id }
+      if (after.partner_cost_estimate !== undefined) update.partner_cost_estimate = after.partner_cost_estimate
+      if (after.cost_type !== undefined) update.cost_type = after.cost_type
+      await service.updateProductionRuns(update)
+    }
+
+    // Effective (post-correction) values for the reader-side interpretation.
+    const quantity = Number(run.quantity ?? 1)
+    const effEstimate =
+      after.partner_cost_estimate !== undefined ? after.partner_cost_estimate : before.partner_cost_estimate
+    const effCostType = after.cost_type !== undefined ? after.cost_type : before.cost_type
+    const interp = interpretRunCost(effEstimate, effCostType, quantity)
+
+    const reads =
+      interp.total == null
+        ? "no cost set"
+        : `reads as per-unit ${interp.per_unit} × qty ${quantity} = total ${interp.total} (cost_type ${effCostType ?? "total"})`
+
+    const summary =
+      changes.length === 0
+        ? `No changes — production run ${production_run_id} cost already as requested; ${reads}`
+        : `${dry_run ? "Would update" : "Updated"} ${changes.length} field(s) on production run ${production_run_id}; ${reads}`
+
+    return {
+      job_id: correctProductionRunCostJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary,
+      changes,
+    }
+  },
+}
+
 export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   recalculateDesignCostJob,
   recalculateDesignCostBulkJob,
+  correctProductionRunCostJob,
 ]
 
 export const getMaintenanceJob = (id: string): MaintenanceJob | undefined =>


### PR DESCRIPTION
## What

Adds a third guarded **data-plumbing** job — `correct-production-run-cost` — to the ops maintenance-jobs registry (#457 / roadmap #33). Motivated directly by the **#456** incident: a per-unit production cost was read as a total, producing the `7650 × 9 = 68850` double-multiply.

The job surfaces the same edit as `POST /admin/production-runs/:id` (`partner_cost_estimate` / `cost_type`), but with a **dry-run preview** that shows how the corrected value reads **both as per-unit and as total over the run quantity** — so a normalisation mistake is obvious *before* it's persisted.

- Safe-by-default: `dry_run` previews the before/after + the per-unit × qty = total interpretation; apply writes via `updateProductionRuns` (idempotent).
- Mirrors the admin route's guard: a **cancelled** run is not editable; a missing run → 404 before any write.
- Requires at least one of `partner_cost_estimate` / `cost_type`; `null` estimate is a deliberate "clear" distinct from omitted.

## API

`POST /admin/ops/maintenance-jobs/correct-production-run-cost/run`
```jsonc
{ "dry_run": true, "params": { "production_run_id": "prod_run_…", "partner_cost_estimate": 7650, "cost_type": "per_unit" } }
```

## Tests

- **Unit** (no DB/workflow boot): `interpretRunCost` (per-unit ↔ total, default-total, divide-by-zero guard, null) + `diffRunCostFields` (omitted vs supplied, both-fields, idempotent, null-clear, string coercion). 30 registry unit tests green.
- **Integration** (per-file, shared DB): job listed; missing id → 400; no cost field → 400; bad `cost_type` → 400; missing run → 404. All 13 ops specs green on re-run.
- tsc: 0 new errors (69 baseline). Registry-only — **no migration, no config change**, conflict-free with the unmerged audit-log PR #480.

Refs #457, #456. Tracker #352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)