### PR TITLE
feat(ops): backfill-inventory-unit-cost maintenance job (#457)

### DIFF
--- a/apps/backend/integration-tests/http/ops-maintenance-jobs.spec.ts
+++ b/apps/backend/integration-tests/http/ops-maintenance-jobs.spec.ts
@@ -181,6 +181,48 @@ setupSharedTestSuite(() => {
       ).rejects.toMatchObject({ response: { status: 404 } })
     })
 
+    it("GET lists the backfill-inventory-unit-cost job with optional params", async () => {
+      const res = await api.get("/admin/ops/maintenance-jobs", adminHeaders)
+      expect(res.status).toBe(200)
+      const job = res.data.jobs.find(
+        (j: any) => j.id === "backfill-inventory-unit-cost"
+      )
+      expect(job).toBeDefined()
+      expect(job.label).toBeTruthy()
+      expect(job.description).toBeTruthy()
+      expect(job.params).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "force", required: false }),
+          expect.objectContaining({ name: "limit", required: false }),
+        ])
+      )
+    })
+
+    it("POST backfill-inventory-unit-cost with no params is safe-by-default dry_run (empty DB → no changes)", async () => {
+      const res = await api.post(
+        "/admin/ops/maintenance-jobs/backfill-inventory-unit-cost/run",
+        {},
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.result.job_id).toBe("backfill-inventory-unit-cost")
+      expect(res.data.result.dry_run).toBe(true)
+      expect(res.data.result.applied).toBe(false)
+      expect(res.data.result.changes).toEqual([])
+      expect(res.data.result.summary).toMatch(/scanned/i)
+      expect(res.data.audit.job_id).toBe("backfill-inventory-unit-cost")
+    })
+
+    it("POST backfill-inventory-unit-cost rejects an invalid limit → 400", async () => {
+      await expect(
+        api.post(
+          "/admin/ops/maintenance-jobs/backfill-inventory-unit-cost/run",
+          { dry_run: true, params: { limit: -5 } },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+
     it("requires admin auth (401 without headers)", async () => {
       await expect(
         api.get("/admin/ops/maintenance-jobs")

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/registry.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/registry.unit.spec.ts
@@ -1,12 +1,16 @@
 import {
   diffCostFields,
   diffRunCostFields,
+  diffUnitCost,
   getMaintenanceJob,
   interpretRunCost,
   MAINTENANCE_JOBS,
   MAX_BULK_DESIGNS,
+  MAX_INVENTORY_SCAN,
   parseDesignIds,
+  pickLatestOrderLinePrice,
   summarizeBulkRecalc,
+  summarizeUnitCostBackfill,
 } from "../registry"
 
 // Pure unit coverage for the maintenance-job registry (#457). No DB / workflow
@@ -231,6 +235,102 @@ describe("ops/maintenance-jobs registry (#457)", () => {
       expect(changes).toEqual([
         { entity: "design", id: "design_1", field: "production_cost", before: null, after: 30 },
       ])
+    })
+  })
+
+  // ---- backfill-inventory-unit-cost job (#457) ----
+
+  describe("backfill-inventory-unit-cost registration", () => {
+    it("registers the job with optional force + limit params", () => {
+      const job = getMaintenanceJob("backfill-inventory-unit-cost")
+      expect(job).toBeDefined()
+      expect(MAINTENANCE_JOBS.map((j) => j.id)).toContain("backfill-inventory-unit-cost")
+      expect(job?.params.some((p) => p.name === "force" && !p.required)).toBe(true)
+      expect(job?.params.some((p) => p.name === "limit" && !p.required)).toBe(true)
+    })
+  })
+
+  describe("pickLatestOrderLinePrice", () => {
+    const line = (price: any, status: string, order_date: string | null, id = "io_1") => ({
+      inventory_order_line: {
+        id: "iol",
+        price,
+        inventory_orders: { id, order_date, status },
+      },
+    })
+
+    it("returns null for no links / no usable price", () => {
+      expect(pickLatestOrderLinePrice([])).toBeNull()
+      expect(pickLatestOrderLinePrice([{ inventory_order_line: null }])).toBeNull()
+    })
+
+    it("ignores cancelled orders and non-positive prices", () => {
+      expect(
+        pickLatestOrderLinePrice([
+          line(50, "Cancelled", "2026-01-01"),
+          line(0, "Completed", "2026-01-02"),
+          line(-5, "Completed", "2026-01-03"),
+        ])
+      ).toBeNull()
+    })
+
+    it("picks the most recent non-cancelled order line by order_date", () => {
+      const picked = pickLatestOrderLinePrice([
+        line(10, "Completed", "2026-01-01", "io_old"),
+        line(25, "Completed", "2026-03-01", "io_new"),
+        line(99, "Cancelled", "2026-06-01", "io_cxl"),
+      ])
+      expect(picked).toMatchObject({ price: 25, order_id: "io_new" })
+      expect(picked?.order_date).toMatch(/^2026-03-01/)
+    })
+
+    it("coerces string prices and tolerates a missing order_date", () => {
+      const picked = pickLatestOrderLinePrice([line("42.5" as any, "Completed", null)])
+      expect(picked?.price).toBe(42.5)
+      expect(picked?.order_date).toBeNull()
+    })
+  })
+
+  describe("diffUnitCost", () => {
+    it("reports a change when unit_cost is unset (null → value)", () => {
+      expect(diffUnitCost("rm_1", null, 12)).toEqual([
+        { entity: "raw_material", id: "rm_1", field: "unit_cost", before: null, after: 12 },
+      ])
+    })
+
+    it("returns no change when the value already matches (idempotent)", () => {
+      expect(diffUnitCost("rm_1", 12, 12)).toEqual([])
+      expect(diffUnitCost("rm_1", "12" as any, 12)).toEqual([])
+    })
+
+    it("reports the before→after when the price differs", () => {
+      expect(diffUnitCost("rm_1", 8, 12)).toEqual([
+        { entity: "raw_material", id: "rm_1", field: "unit_cost", before: 8, after: 12 },
+      ])
+    })
+  })
+
+  describe("summarizeUnitCostBackfill", () => {
+    it("reports no changes and keeps the scan count", () => {
+      expect(summarizeUnitCostBackfill(true, 7, 0, 0, 0, 0)).toMatch(
+        /No changes — scanned 7 inventory item/
+      )
+    })
+
+    it("uses 'Would set' for dry-run and appends skip breakdown", () => {
+      expect(summarizeUnitCostBackfill(true, 10, 3, 2, 1, 0)).toBe(
+        "Would set unit_cost on 3 raw material(s) (scanned 10 inventory item(s)); 2 unlinked, 1 no order history"
+      )
+    })
+
+    it("uses 'Set' on apply and appends an error count when present", () => {
+      expect(summarizeUnitCostBackfill(false, 10, 3, 0, 0, 1)).toBe(
+        "Set unit_cost on 3 raw material(s) (scanned 10 inventory item(s)); 1 error(s)"
+      )
+    })
+
+    it("exposes a sane scan cap", () => {
+      expect(MAX_INVENTORY_SCAN).toBeGreaterThanOrEqual(1000)
     })
   })
 })

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -1,9 +1,10 @@
-import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
 import { z } from "@medusajs/framework/zod"
 
 import { estimateDesignCostWorkflow } from "../../../../workflows/designs/estimate-design-cost"
 import { DESIGN_MODULE } from "../../../../modules/designs"
 import { PRODUCTION_RUNS_MODULE } from "../../../../modules/production_runs"
+import { RAW_MATERIAL_MODULE } from "../../../../modules/raw_material"
 
 /**
  * Admin "data-plumbing" maintenance jobs (#457 / roadmap #33).
@@ -531,10 +532,245 @@ export const correctProductionRunCostJob: MaintenanceJob = {
   },
 }
 
+/**
+ * Hard cap on the inventory-unit-cost backfill scan. Each item runs two
+ * `query.graph` lookups synchronously, so we bound the per-request blast radius
+ * and keep the endpoint responsive. Bigger sweeps raise the `limit` param
+ * across chunked calls.
+ */
+export const MAX_INVENTORY_SCAN = 5000
+
+const backfillUnitCostParamsSchema = z.object({
+  /** Recompute even when the raw material already has a positive unit_cost. */
+  force: z.boolean().optional().default(false),
+  /** Max inventory items to scan in one call (1..MAX_INVENTORY_SCAN). */
+  limit: z.number().int().positive().max(MAX_INVENTORY_SCAN).optional().default(1000),
+})
+
+/** Shape of one `inventory_order_line_inventory_item` link row, as queried. */
+export type InventoryOrderLineLink = {
+  inventory_order_line?: {
+    id?: string
+    price?: number | string | null
+    inventory_orders?: {
+      id?: string
+      order_date?: string | Date | null
+      status?: string | null
+    } | null
+  } | null
+}
+
+/**
+ * Pure: pick the most recent non-cancelled inventory order line with a positive
+ * price for one inventory item. Mirrors the heuristic of the
+ * `backfill-inventory-unit-cost` script (latest order_date wins) but is
+ * container-free so the dry-run/apply selection is unit-testable. Returns null
+ * when no usable price exists (no history / all cancelled / non-positive).
+ */
+export function pickLatestOrderLinePrice(
+  links: InventoryOrderLineLink[]
+): { price: number; order_id: string | null; order_date: string | null } | null {
+  let best: { price: number; order_id: string | null; date: Date } | null = null
+
+  for (const link of links || []) {
+    const line = link?.inventory_order_line
+    if (!line) continue
+    const order = line.inventory_orders
+    if (!order || order.status === "Cancelled") continue
+
+    const price = Number(line.price) || 0
+    if (price <= 0) continue
+
+    const orderDate = order.order_date ? new Date(order.order_date) : new Date(0)
+    if (!best || orderDate > best.date) {
+      best = { price, order_id: order.id ?? null, date: orderDate }
+    }
+  }
+
+  if (!best) return null
+  return {
+    price: best.price,
+    order_id: best.order_id,
+    order_date: best.date.getTime() === 0 ? null : best.date.toISOString(),
+  }
+}
+
+/**
+ * Pure: diff a raw material's currently-stored unit_cost against a derived
+ * price. Returns a single `unit_cost` change (or none when already equal).
+ * Exported for unit testing.
+ */
+export function diffUnitCost(
+  rawMaterialId: string,
+  before: number | string | null | undefined,
+  after: number
+): MaintenanceChange[] {
+  const beforeValue = before == null ? null : Number(before)
+  if (beforeValue === after) return []
+  return [{ entity: "raw_material", id: rawMaterialId, field: "unit_cost", before: beforeValue, after }]
+}
+
+/**
+ * Pure summary builder for the inventory-unit-cost backfill — keeps the
+ * human-facing string verifiable without booting the DB.
+ */
+export function summarizeUnitCostBackfill(
+  dryRun: boolean,
+  scanned: number,
+  changedCount: number,
+  noRawMaterialCount: number,
+  noHistoryCount: number,
+  errorCount: number
+): string {
+  const verb = dryRun ? "Would set" : "Set"
+  const head =
+    changedCount === 0
+      ? `No changes — scanned ${scanned} inventory item(s), none needed a unit_cost correction`
+      : `${verb} unit_cost on ${changedCount} raw material(s) (scanned ${scanned} inventory item(s))`
+  const skips: string[] = []
+  if (noRawMaterialCount > 0) skips.push(`${noRawMaterialCount} unlinked`)
+  if (noHistoryCount > 0) skips.push(`${noHistoryCount} no order history`)
+  const tail = skips.length ? `; ${skips.join(", ")}` : ""
+  return errorCount > 0 ? `${head}${tail}; ${errorCount} error(s)` : `${head}${tail}`
+}
+
+/**
+ * Backfill raw-material unit_cost from inventory order history — promotes the
+ * one-off `backfill-inventory-unit-cost` script into a guarded, API-driven job
+ * (#457). For each inventory item linked to a raw material with no (or zero)
+ * unit_cost, it derives the cost from the most recent non-cancelled inventory
+ * order line price. Dry-run (default) previews every before→after without
+ * persisting; apply writes `unit_cost` via the raw_materials module (idempotent
+ * — re-running is a no-op once costs match). Items with no raw-material link or
+ * no order history are counted in the summary, not treated as errors; a genuine
+ * per-item failure is reported in `errors` instead of aborting the sweep.
+ */
+export const backfillInventoryUnitCostJob: MaintenanceJob = {
+  id: "backfill-inventory-unit-cost",
+  label: "Backfill inventory unit cost",
+  description:
+    `Derive raw-material unit_cost from the latest non-cancelled inventory order line for each linked inventory item. Dry-run previews the before/after without persisting; apply writes unit_cost back (idempotent). By default only fills missing/zero costs — set force=true to recompute existing ones. Scans up to 'limit' items per call (default 1000, max ${MAX_INVENTORY_SCAN}).`,
+  params: [
+    {
+      name: "force",
+      type: "boolean",
+      required: false,
+      description: "Recompute unit_cost even when a positive value already exists (default false)",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max inventory items to scan in one call (default 1000, max ${MAX_INVENTORY_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }) => {
+    const parsed = backfillUnitCostParamsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { force, limit } = parsed.data
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const inventoryService: any = container.resolve(Modules.INVENTORY)
+    const rawMaterialService: any = container.resolve(RAW_MATERIAL_MODULE)
+
+    const items: any[] = await inventoryService.listInventoryItems({}, { take: limit })
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    const changedRawMaterials = new Set<string>()
+    let noRawMaterial = 0
+    let noHistory = 0
+
+    for (const item of items) {
+      try {
+        let rawMaterial: any = null
+        try {
+          const { data: rmLinks } = await query.graph({
+            entity: "inventory_item_raw_materials",
+            filters: { inventory_item_id: item.id },
+            fields: ["raw_materials.*"],
+          })
+          rawMaterial = rmLinks?.[0]?.raw_materials
+        } catch {
+          // No link table row / not linked — treated as "unlinked" below.
+        }
+
+        if (!rawMaterial) {
+          noRawMaterial++
+          continue
+        }
+
+        const hasExistingCost =
+          rawMaterial.unit_cost != null && Number(rawMaterial.unit_cost) > 0
+        if (hasExistingCost && !force) {
+          continue
+        }
+
+        const { data: orderLineLinks } = await query.graph({
+          entity: "inventory_order_line_inventory_item",
+          filters: { inventory_item_id: item.id },
+          fields: [
+            "inventory_order_line.id",
+            "inventory_order_line.price",
+            "inventory_order_line.inventory_orders.order_date",
+            "inventory_order_line.inventory_orders.status",
+            "inventory_order_line.inventory_orders.id",
+          ],
+        })
+
+        const latest = pickLatestOrderLinePrice(orderLineLinks || [])
+        if (!latest) {
+          noHistory++
+          continue
+        }
+
+        const rmChanges = diffUnitCost(rawMaterial.id, rawMaterial.unit_cost, latest.price)
+        if (rmChanges.length === 0) {
+          continue
+        }
+
+        changedRawMaterials.add(rawMaterial.id)
+        changes.push(...rmChanges)
+
+        if (!dry_run) {
+          await rawMaterialService.updateRawMaterials({
+            id: rawMaterial.id,
+            unit_cost: latest.price,
+          })
+        }
+      } catch (e: any) {
+        errors.push({ id: item.id, message: e?.message ?? String(e) })
+      }
+    }
+
+    return {
+      job_id: backfillInventoryUnitCostJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary: summarizeUnitCostBackfill(
+        dry_run,
+        items.length,
+        changedRawMaterials.size,
+        noRawMaterial,
+        noHistory,
+        errors.length
+      ),
+      changes,
+      errors,
+    }
+  },
+}
+
 export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   recalculateDesignCostJob,
   recalculateDesignCostBulkJob,
   correctProductionRunCostJob,
+  backfillInventoryUnitCostJob,
 ]
 
 export const getMaintenanceJob = (id: string): MaintenanceJob | undefined =>


### PR DESCRIPTION
## What
Promotes the one-off `src/scripts/backfill-inventory-unit-cost.ts` into a **guarded, API-driven ops maintenance job** (#457 / roadmap #33) — the 4th job in the `/admin/ops/maintenance-jobs` registry.

For each inventory item linked to a raw material with **no/zero `unit_cost`**, it derives the cost from the **most recent non-cancelled inventory order line price** and (on apply) writes it back via the `raw_materials` module.

## Safe-by-default contract (mirrors the existing jobs)
- `dry_run` defaults to **true** → previews every `before→after` change without writing.
- `dry_run: false` → idempotent write (re-running is a no-op once costs match).
- **Params:** `force` (recompute existing positive costs, default `false`), `limit` (per-call scan cap, default 1000, max 5000).
- Unlinked items / no-order-history are **counted in the summary**, not treated as errors; a genuine per-item failure is reported in `errors[]` without aborting the sweep.

## Why
Recurring incident pattern: a code fix prevents recurrence, but stored `raw_materials.unit_cost` rows still need a targeted, safe correction. This removes the need for raw `medusa exec` / ECS run-task scripts and gives an auditable dry-run preview first.

## Tests
- **Pure helpers** `pickLatestOrderLinePrice` / `diffUnitCost` / `summarizeUnitCostBackfill` extracted + unit-tested (no DB/workflow boot).
- `registry.unit.spec.ts`: **31 passed** (10 new).
- `integration-tests/http/ops-maintenance-jobs.spec.ts`: **11 passed** (3 new — list, safe-by-default dry-run on empty DB, invalid-limit → 400).
- `tsc`: **0 new** errors (69 baseline).

## Scope / safety
- **Registry-only** — no migration, no config change, no new module.
- Additive: appends one entry to `MAINTENANCE_JOBS`. Conflicts only on that array literal with the unmerged #481 (trivial append resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)