### PR TITLE
feat(ops): add backfill-design-energy-costs maintenance job (#457)

### DIFF
--- a/apps/backend/integration-tests/http/ops-maintenance-jobs.spec.ts
+++ b/apps/backend/integration-tests/http/ops-maintenance-jobs.spec.ts
@@ -223,6 +223,64 @@ setupSharedTestSuite(() => {
       ).rejects.toMatchObject({ response: { status: 400 } })
     })
 
+    it("GET lists the backfill-design-energy-costs job with optional params", async () => {
+      const res = await api.get("/admin/ops/maintenance-jobs", adminHeaders)
+      expect(res.status).toBe(200)
+      const job = res.data.jobs.find(
+        (j: any) => j.id === "backfill-design-energy-costs"
+      )
+      expect(job).toBeDefined()
+      expect(job.label).toBeTruthy()
+      expect(job.description).toBeTruthy()
+      expect(job.params).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "design_id", required: false }),
+          expect.objectContaining({ name: "force", required: false }),
+          expect.objectContaining({ name: "limit", required: false }),
+        ])
+      )
+    })
+
+    it("POST backfill-design-energy-costs with no params is safe-by-default dry_run (empty DB → no changes)", async () => {
+      const res = await api.post(
+        "/admin/ops/maintenance-jobs/backfill-design-energy-costs/run",
+        {},
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.result.job_id).toBe("backfill-design-energy-costs")
+      expect(res.data.result.dry_run).toBe(true)
+      expect(res.data.result.applied).toBe(false)
+      expect(res.data.result.changes).toEqual([])
+      expect(res.data.result.summary).toMatch(/scanned/i)
+    })
+
+    it("POST backfill-design-energy-costs reports a missing design_id per-design instead of failing", async () => {
+      const res = await api.post(
+        "/admin/ops/maintenance-jobs/backfill-design-energy-costs/run",
+        { dry_run: true, params: { design_id: "design_does_not_exist" } },
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.result.dry_run).toBe(true)
+      expect(res.data.result.changes).toEqual([])
+      expect(res.data.result.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: "design_does_not_exist" }),
+        ])
+      )
+    })
+
+    it("POST backfill-design-energy-costs rejects an invalid limit → 400", async () => {
+      await expect(
+        api.post(
+          "/admin/ops/maintenance-jobs/backfill-design-energy-costs/run",
+          { dry_run: true, params: { limit: -5 } },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+
     it("requires admin auth (401 without headers)", async () => {
       await expect(
         api.get("/admin/ops/maintenance-jobs")

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/registry.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/registry.unit.spec.ts
@@ -1,15 +1,22 @@
 import {
+  buildEnergyRateMap,
+  computeEnergyCost,
+  computeLaborCost,
   diffCostFields,
+  diffEnergyCostFields,
   diffRunCostFields,
   diffUnitCost,
   getMaintenanceJob,
   interpretRunCost,
   MAINTENANCE_JOBS,
   MAX_BULK_DESIGNS,
+  MAX_DESIGN_SCAN,
   MAX_INVENTORY_SCAN,
   parseDesignIds,
   pickLatestOrderLinePrice,
+  round2,
   summarizeBulkRecalc,
+  summarizeEnergyBackfill,
   summarizeUnitCostBackfill,
 } from "../registry"
 
@@ -331,6 +338,180 @@ describe("ops/maintenance-jobs registry (#457)", () => {
 
     it("exposes a sane scan cap", () => {
       expect(MAX_INVENTORY_SCAN).toBeGreaterThanOrEqual(1000)
+    })
+  })
+
+  // ---- backfill-design-energy-costs job (#457) ----
+
+  describe("backfill-design-energy-costs registration", () => {
+    it("registers the job with optional design_id + force + limit params", () => {
+      const job = getMaintenanceJob("backfill-design-energy-costs")
+      expect(job).toBeDefined()
+      expect(MAINTENANCE_JOBS.map((j) => j.id)).toContain("backfill-design-energy-costs")
+      expect(job?.params.some((p) => p.name === "design_id" && !p.required)).toBe(true)
+      expect(job?.params.some((p) => p.name === "force" && !p.required)).toBe(true)
+      expect(job?.params.some((p) => p.name === "limit" && !p.required)).toBe(true)
+    })
+
+    it("exposes a sane design-scan cap", () => {
+      expect(MAX_DESIGN_SCAN).toBeGreaterThanOrEqual(1000)
+    })
+  })
+
+  describe("round2", () => {
+    it("rounds to two decimal places", () => {
+      expect(round2(1.005)).toBeCloseTo(1.0) // float quirk: rounds toward 1.00
+      expect(round2(2.345)).toBe(2.35)
+      expect(round2(10)).toBe(10)
+    })
+  })
+
+  describe("buildEnergyRateMap", () => {
+    it("keeps the most-recently effective rate per energy_type", () => {
+      const map = buildEnergyRateMap([
+        { energy_type: "energy_electricity", rate_per_unit: 5, effective_from: "2026-01-01" },
+        { energy_type: "energy_electricity", rate_per_unit: 8, effective_from: "2026-03-01" },
+        { energy_type: "labor", rate_per_unit: 20, effective_from: "2026-01-01" },
+      ])
+      expect(map.get("energy_electricity")?.rate_per_unit).toBe(8)
+      expect(map.get("labor")?.rate_per_unit).toBe(20)
+    })
+
+    it("coerces string rates and ignores rows with no energy_type", () => {
+      const map = buildEnergyRateMap([
+        { energy_type: "energy_water", rate_per_unit: "3.5" as any, effective_from: "2026-01-01" },
+        { rate_per_unit: 99 } as any,
+      ])
+      expect(map.get("energy_water")?.rate_per_unit).toBe(3.5)
+      expect(map.size).toBe(1)
+    })
+  })
+
+  describe("computeEnergyCost", () => {
+    const rates = buildEnergyRateMap([
+      { energy_type: "energy_electricity", rate_per_unit: 10, effective_from: "2026-01-01" },
+    ])
+
+    it("uses the log unit_cost when present (partner_input)", () => {
+      const { total, items } = computeEnergyCost(
+        [{ consumption_type: "energy_electricity", quantity: 2, unit_cost: 7 }],
+        rates
+      )
+      expect(total).toBe(14)
+      expect(items[0].cost_source).toBe("partner_input")
+    })
+
+    it("falls back to the active rate when no unit_cost (energy_rate)", () => {
+      const { total, items } = computeEnergyCost(
+        [{ consumption_type: "energy_electricity", quantity: 3 }],
+        rates
+      )
+      expect(total).toBe(30)
+      expect(items[0].cost_source).toBe("energy_rate")
+    })
+
+    it("marks cost_source none when no rate is available", () => {
+      const { total, items } = computeEnergyCost(
+        [{ consumption_type: "energy_gas", quantity: 5 }],
+        rates
+      )
+      expect(total).toBe(0)
+      expect(items[0].cost_source).toBe("none")
+    })
+  })
+
+  describe("computeLaborCost", () => {
+    const rates = buildEnergyRateMap([
+      { energy_type: "labor", rate_per_unit: 15, effective_from: "2026-01-01" },
+    ])
+
+    it("totals labor hours and prices from the labor rate fallback", () => {
+      const { total, hours } = computeLaborCost(
+        [{ consumption_type: "labor", quantity: 2 }, { consumption_type: "labor", quantity: 3, unit_cost: 20 }],
+        rates
+      )
+      expect(hours).toBe(5)
+      expect(total).toBe(2 * 15 + 3 * 20)
+    })
+
+    it("returns zeroes for no logs", () => {
+      expect(computeLaborCost([], rates)).toEqual({ total: 0, hours: 0 })
+    })
+  })
+
+  describe("diffEnergyCostFields", () => {
+    const after = {
+      estimated_cost: 100,
+      material_cost: 60,
+      production_cost: 20,
+      energy_cost_total: 20,
+    }
+
+    it("reports a change for every field when nothing is persisted (null → value)", () => {
+      const changes = diffEnergyCostFields("d_1", {}, after)
+      expect(changes).toHaveLength(4)
+      expect(changes).toEqual(
+        expect.arrayContaining([
+          { entity: "design", id: "d_1", field: "energy_cost_total", before: null, after: 20 },
+        ])
+      )
+    })
+
+    it("is idempotent when persisted values already match", () => {
+      expect(
+        diffEnergyCostFields(
+          "d_1",
+          { estimated_cost: 100, material_cost: 60, production_cost: 20, energy_cost_total: 20 },
+          after
+        )
+      ).toEqual([])
+    })
+
+    it("coerces string-typed decimals before comparing", () => {
+      expect(
+        diffEnergyCostFields(
+          "d_1",
+          {
+            estimated_cost: "100" as any,
+            material_cost: "60" as any,
+            production_cost: "20" as any,
+            energy_cost_total: "20" as any,
+          },
+          after
+        )
+      ).toEqual([])
+    })
+
+    it("only reports the energy_cost_total when that's the sole drift", () => {
+      expect(
+        diffEnergyCostFields(
+          "d_1",
+          { estimated_cost: 100, material_cost: 60, production_cost: 20, energy_cost_total: 5 },
+          after
+        )
+      ).toEqual([
+        { entity: "design", id: "d_1", field: "energy_cost_total", before: 5, after: 20 },
+      ])
+    })
+  })
+
+  describe("summarizeEnergyBackfill", () => {
+    it("reports no changes and keeps the scan count", () => {
+      expect(summarizeEnergyBackfill(true, 7, 0, 0, 0, 0)).toMatch(
+        /No changes — scanned 7 design/
+      )
+    })
+
+    it("uses 'Would update' for dry-run and appends skip breakdown", () => {
+      expect(summarizeEnergyBackfill(true, 10, 3, 2, 1, 0)).toBe(
+        "Would update cost on 3 design(s) (scanned 10); 2 already had energy costs, 1 no energy/labor logs"
+      )
+    })
+
+    it("uses 'Updated' on apply and appends an error count when present", () => {
+      expect(summarizeEnergyBackfill(false, 10, 3, 0, 0, 1)).toBe(
+        "Updated cost on 3 design(s) (scanned 10); 1 error(s)"
+      )
     })
   })
 })

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -766,11 +766,461 @@ export const backfillInventoryUnitCostJob: MaintenanceJob = {
   },
 }
 
+/**
+ * Hard cap on the energy-cost backfill scan. Without an explicit design_id the
+ * job sweeps every design that has a completed production run, running several
+ * synchronous lookups each, so we bound the per-request blast radius. Bigger
+ * sweeps raise the `limit` param across chunked calls.
+ */
+export const MAX_DESIGN_SCAN = 2000
+
+/** Consumption-log types that contribute to the three cost buckets. */
+export const MATERIAL_CONSUMPTION_TYPES = ["sample", "production", "wastage"]
+export const ENERGY_CONSUMPTION_TYPES = ["energy_electricity", "energy_water", "energy_gas"]
+
+const backfillEnergyParamsSchema = z.object({
+  /** Process a single design instead of sweeping all completed-run designs. */
+  design_id: z.string().min(1).optional(),
+  /** Recompute even when cost_breakdown already has energy_cost_total. */
+  force: z.boolean().optional().default(false),
+  /** Max designs to scan in one sweep when no design_id is given. */
+  limit: z.number().int().positive().max(MAX_DESIGN_SCAN).optional().default(1000),
+})
+
+export const round2 = (n: number): number => Math.round(n * 100) / 100
+
+/** Shape of one energy_rates row, as consumed by the rate map. */
+export type EnergyRateRow = {
+  energy_type?: string | null
+  rate_per_unit?: number | string | null
+  name?: string | null
+  effective_from?: string | Date | null
+}
+
+/**
+ * Pure: collapse the active energy_rates rows into the single most-recently
+ * effective rate per energy_type (latest effective_from wins). Mirrors the
+ * `backfill-design-energy-costs` script's rate selection but is container-free
+ * so the cost math is unit-testable. Exported for testing.
+ */
+export function buildEnergyRateMap(
+  rates: EnergyRateRow[]
+): Map<string, { rate_per_unit: number; name: string }> {
+  const map = new Map<string, { rate_per_unit: number; name: string; effective_from: number }>()
+  for (const rate of rates || []) {
+    const key = rate?.energy_type
+    if (!key) continue
+    const effectiveFrom = rate.effective_from ? new Date(rate.effective_from).getTime() : 0
+    const existing = map.get(key)
+    if (!existing || effectiveFrom > existing.effective_from) {
+      map.set(key, {
+        rate_per_unit: Number(rate.rate_per_unit) || 0,
+        name: rate.name ?? "",
+        effective_from: effectiveFrom,
+      })
+    }
+  }
+  // Strip the internal sort key from the returned shape.
+  const out = new Map<string, { rate_per_unit: number; name: string }>()
+  for (const [k, v] of map) out.set(k, { rate_per_unit: v.rate_per_unit, name: v.name })
+  return out
+}
+
+/** Shape of one consumption_log row used by the energy/labor cost math. */
+export type ConsumptionLogRow = {
+  consumption_type?: string | null
+  quantity?: number | string | null
+  unit_cost?: number | string | null
+  unit_of_measure?: string | null
+}
+
+/**
+ * Pure: total the energy consumption logs, falling back to the active
+ * per-type rate when a log carries no unit_cost. Returns the rounded total plus
+ * a per-line breakdown (with the cost source) for the persisted cost_breakdown.
+ */
+export function computeEnergyCost(
+  energyLogs: ConsumptionLogRow[],
+  rateMap: Map<string, { rate_per_unit: number; name: string }>
+): { total: number; items: Array<Record<string, unknown>> } {
+  let total = 0
+  const items: Array<Record<string, unknown>> = []
+  for (const log of energyLogs || []) {
+    const qty = Number(log.quantity) || 0
+    let unitCost = Number(log.unit_cost) || 0
+    let costSource = "partner_input"
+    if (!unitCost) {
+      const rateInfo = log.consumption_type ? rateMap.get(log.consumption_type) : undefined
+      if (rateInfo && rateInfo.rate_per_unit > 0) {
+        unitCost = rateInfo.rate_per_unit
+        costSource = "energy_rate"
+      } else {
+        costSource = "none"
+      }
+    }
+    const lineTotal = qty * unitCost
+    total += lineTotal
+    items.push({
+      consumption_type: log.consumption_type,
+      quantity: qty,
+      unit_cost: unitCost,
+      unit_of_measure: log.unit_of_measure,
+      line_total: lineTotal,
+      cost_source: costSource,
+    })
+  }
+  return { total: round2(total), items }
+}
+
+/**
+ * Pure: total the labor consumption logs, falling back to the active "labor"
+ * rate when a log carries no unit_cost. Returns the rounded cost plus the total
+ * labor hours.
+ */
+export function computeLaborCost(
+  laborLogs: ConsumptionLogRow[],
+  rateMap: Map<string, { rate_per_unit: number; name: string }>
+): { total: number; hours: number } {
+  let total = 0
+  let hours = 0
+  for (const log of laborLogs || []) {
+    const qty = Number(log.quantity) || 0
+    hours += qty
+    let unitCost = Number(log.unit_cost) || 0
+    if (!unitCost) unitCost = rateMap.get("labor")?.rate_per_unit || 0
+    total += qty * unitCost
+  }
+  return { total: round2(total), hours: round2(hours) }
+}
+
+/**
+ * Pure: diff a design's currently-persisted cost fields against the freshly
+ * computed values. Compares the three top-level cost columns plus the
+ * cost_breakdown's energy_cost_total. Rounded inputs make re-running idempotent.
+ * Exported for unit testing.
+ */
+export function diffEnergyCostFields(
+  designId: string,
+  before: {
+    estimated_cost?: number | null
+    material_cost?: number | null
+    production_cost?: number | null
+    energy_cost_total?: number | null
+  },
+  after: {
+    estimated_cost: number
+    material_cost: number
+    production_cost: number
+    energy_cost_total: number
+  }
+): MaintenanceChange[] {
+  const pairs: Array<[string, number | null | undefined, number]> = [
+    ["estimated_cost", before.estimated_cost, after.estimated_cost],
+    ["material_cost", before.material_cost, after.material_cost],
+    ["production_cost", before.production_cost, after.production_cost],
+    ["energy_cost_total", before.energy_cost_total, after.energy_cost_total],
+  ]
+  const changes: MaintenanceChange[] = []
+  for (const [field, rawBefore, afterValue] of pairs) {
+    const beforeValue = rawBefore == null ? null : Number(rawBefore)
+    if (beforeValue !== afterValue) {
+      changes.push({ entity: "design", id: designId, field, before: beforeValue, after: afterValue })
+    }
+  }
+  return changes
+}
+
+/**
+ * Pure summary builder for the energy-cost backfill — keeps the human-facing
+ * string verifiable without booting the DB.
+ */
+export function summarizeEnergyBackfill(
+  dryRun: boolean,
+  scanned: number,
+  changedCount: number,
+  alreadyHadCount: number,
+  noLogsCount: number,
+  errorCount: number
+): string {
+  const verb = dryRun ? "Would update" : "Updated"
+  const head =
+    changedCount === 0
+      ? `No changes — scanned ${scanned} design(s), none needed an energy/labor cost backfill`
+      : `${verb} cost on ${changedCount} design(s) (scanned ${scanned})`
+  const skips: string[] = []
+  if (alreadyHadCount > 0) skips.push(`${alreadyHadCount} already had energy costs`)
+  if (noLogsCount > 0) skips.push(`${noLogsCount} no energy/labor logs`)
+  const tail = skips.length ? `; ${skips.join(", ")}` : ""
+  return errorCount > 0 ? `${head}${tail}; ${errorCount} error(s)` : `${head}${tail}`
+}
+
+/**
+ * Backfill energy & labor costs into design cost breakdowns — promotes the
+ * one-off `backfill-design-energy-costs` script into a guarded, API-driven job
+ * (#457). For each design with committed energy/labor consumption logs it
+ * recomputes material + energy + labor + production cost (energy/labor priced
+ * from the log's unit_cost, else the latest active energy_rate) and diffs the
+ * result against what's persisted. Dry-run (default) previews every before→after
+ * without writing; apply persists the recomputed cost_breakdown (idempotent —
+ * re-running is a no-op once costs match). By default a design that already has
+ * energy_cost_total is skipped — set force=true to recompute it. Pass a single
+ * design_id to target one design, or sweep up to `limit` designs that have a
+ * completed production run.
+ */
+export const backfillDesignEnergyCostJob: MaintenanceJob = {
+  id: "backfill-design-energy-costs",
+  label: "Backfill design energy & labor costs",
+  description:
+    `Recompute and persist energy + labor costs into a design's cost_breakdown from its committed consumption logs (priced from the log unit_cost, else the latest active energy_rate). Dry-run previews the before/after without persisting; apply writes the recomputed breakdown (idempotent). By default skips designs that already have energy_cost_total — set force=true to recompute. Pass design_id to target one design, or sweep up to 'limit' completed-run designs (default 1000, max ${MAX_DESIGN_SCAN}).`,
+  params: [
+    {
+      name: "design_id",
+      type: "string",
+      required: false,
+      description: "Process a single design instead of sweeping all completed-run designs",
+    },
+    {
+      name: "force",
+      type: "boolean",
+      required: false,
+      description: "Recompute even when cost_breakdown already has energy_cost_total (default false)",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max designs to scan in one sweep when no design_id is given (default 1000, max ${MAX_DESIGN_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }) => {
+    const parsed = backfillEnergyParamsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { design_id, force, limit } = parsed.data
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const inventoryService: any = container.resolve(Modules.INVENTORY)
+    const designService: any = container.resolve(DESIGN_MODULE)
+    const consumptionLogService: any = container.resolve("consumption_log")
+    const productionRunService: any = container.resolve("production_runs")
+    const energyRateService: any = container.resolve("energy_rates")
+
+    // Active energy rates → latest-effective rate per type (pure).
+    const [activeRates] = await energyRateService.listAndCountEnergyRates(
+      { is_active: true },
+      { take: null }
+    )
+    const rateMap = buildEnergyRateMap(activeRates || [])
+
+    // Resolve the design id set: one explicit id, or the completed-run designs.
+    let designIds: string[]
+    if (design_id) {
+      designIds = [design_id]
+    } else {
+      const [completedRuns] = await productionRunService.listAndCountProductionRuns(
+        { status: "completed" },
+        { take: null }
+      )
+      designIds = [...new Set((completedRuns || []).map((r: any) => r.design_id).filter(Boolean))]
+        .slice(0, limit) as string[]
+    }
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    const changedDesigns = new Set<string>()
+    let alreadyHad = 0
+    let noLogs = 0
+
+    for (const designId of designIds) {
+      try {
+        const design: any = await designService.retrieveDesign(designId).catch(() => null)
+        if (!design) {
+          errors.push({ id: designId, message: "Design not found" })
+          continue
+        }
+
+        const existingBreakdown = (design.cost_breakdown as any) || {}
+        if (existingBreakdown.energy_cost_total && !force) {
+          alreadyHad++
+          continue
+        }
+
+        const [allLogs] = await consumptionLogService.listAndCountConsumptionLogs(
+          { design_id: designId, is_committed: true },
+          { take: null }
+        )
+        if (!allLogs || !allLogs.length) {
+          noLogs++
+          continue
+        }
+
+        const materialLogs = allLogs.filter((l: any) =>
+          MATERIAL_CONSUMPTION_TYPES.includes(l.consumption_type)
+        )
+        const energyLogs = allLogs.filter((l: any) =>
+          ENERGY_CONSUMPTION_TYPES.includes(l.consumption_type)
+        )
+        const laborLogs = allLogs.filter((l: any) => l.consumption_type === "labor")
+
+        // Nothing to backfill if there are no energy or labor logs.
+        if (!energyLogs.length && !laborLogs.length) {
+          noLogs++
+          continue
+        }
+
+        // Material cost (impure: per-log inventory + raw-material lookups).
+        let materialCost = 0
+        const materialItems: any[] = []
+        for (const log of materialLogs) {
+          let unitCost = Number(log.unit_cost) || 0
+          let costSource = "partner_input"
+          let title = log.inventory_item_id || "unknown"
+          if (log.inventory_item_id) {
+            try {
+              const item = await inventoryService.retrieveInventoryItem(log.inventory_item_id)
+              title = item.title || item.sku || log.inventory_item_id
+            } catch {
+              /* keep fallback title */
+            }
+            if (!unitCost) {
+              try {
+                const { data: rmLinks } = await query.graph({
+                  entity: "inventory_item_raw_materials",
+                  filters: { inventory_item_id: log.inventory_item_id },
+                  fields: ["raw_materials.unit_cost"],
+                })
+                const rmCost = Number(rmLinks?.[0]?.raw_materials?.unit_cost) || 0
+                if (rmCost > 0) {
+                  unitCost = rmCost
+                  costSource = "raw_material"
+                } else {
+                  costSource = "none"
+                }
+              } catch {
+                costSource = "none"
+              }
+            }
+          }
+          const lineTotal = Number(log.quantity) * unitCost
+          materialCost += lineTotal
+          materialItems.push({
+            inventory_item_id: log.inventory_item_id,
+            title,
+            quantity: Number(log.quantity),
+            unit_cost: unitCost,
+            line_total: lineTotal,
+            cost_source: costSource,
+          })
+        }
+
+        const { total: energyCost, items: energyItems } = computeEnergyCost(energyLogs, rateMap)
+        const { total: laborCost, hours: laborHours } = computeLaborCost(laborLogs, rateMap)
+
+        // Production cost: preserve existing, else partner estimate, else 30%.
+        let productionCost = Number(design.production_cost) || 0
+        let productionSource = existingBreakdown.production_cost_source || "existing"
+        if (!productionCost) {
+          try {
+            const [runs] = await productionRunService.listAndCountProductionRuns(
+              { design_id: designId, status: "completed" },
+              { take: 1, order: { completed_at: "DESC" } }
+            )
+            const partnerEst = Number(runs?.[0]?.partner_cost_estimate) || 0
+            if (partnerEst > 0) {
+              productionCost = partnerEst
+              productionSource = "partner_estimate"
+            }
+          } catch {
+            /* fall through to overhead */
+          }
+          if (!productionCost) {
+            productionCost = materialCost * 0.3
+            productionSource = "overhead_percent"
+          }
+        }
+
+        const roundedMaterial = round2(materialCost)
+        const roundedProduction = round2(productionCost)
+        const totalEstimate = round2(roundedMaterial + roundedProduction + energyCost + laborCost)
+
+        const designChanges = diffEnergyCostFields(
+          designId,
+          {
+            estimated_cost: design.estimated_cost,
+            material_cost: design.material_cost,
+            production_cost: design.production_cost,
+            energy_cost_total: existingBreakdown.energy_cost_total,
+          },
+          {
+            estimated_cost: totalEstimate,
+            material_cost: roundedMaterial,
+            production_cost: roundedProduction,
+            energy_cost_total: energyCost,
+          }
+        )
+
+        if (designChanges.length === 0) continue
+
+        changedDesigns.add(designId)
+        changes.push(...designChanges)
+
+        if (!dry_run) {
+          await designService.updateDesigns({
+            id: designId,
+            estimated_cost: totalEstimate,
+            material_cost: roundedMaterial,
+            production_cost: roundedProduction,
+            cost_breakdown: {
+              items: materialItems.length > 0 ? materialItems : existingBreakdown.items,
+              energy_costs: energyItems.length > 0 ? energyItems : undefined,
+              energy_cost_total: energyCost > 0 ? energyCost : undefined,
+              labor_cost_total: laborCost > 0 ? laborCost : undefined,
+              labor_hours: laborHours > 0 ? laborHours : undefined,
+              service_costs: existingBreakdown.service_costs,
+              service_cost_total: existingBreakdown.service_cost_total,
+              production_cost_source: productionSource,
+              production_overhead_percent:
+                productionSource === "overhead_percent" ? 30 : undefined,
+              partner_cost_estimate: existingBreakdown.partner_cost_estimate,
+              calculated_at: new Date().toISOString(),
+              source: "ops_maintenance_backfill_energy_costs",
+              previous_estimated_cost: design.estimated_cost || undefined,
+            },
+          })
+        }
+      } catch (e: any) {
+        errors.push({ id: designId, message: e?.message ?? String(e) })
+      }
+    }
+
+    return {
+      job_id: backfillDesignEnergyCostJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary: summarizeEnergyBackfill(
+        dry_run,
+        designIds.length,
+        changedDesigns.size,
+        alreadyHad,
+        noLogs,
+        errors.length
+      ),
+      changes,
+      errors,
+    }
+  },
+}
+
 export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   recalculateDesignCostJob,
   recalculateDesignCostBulkJob,
   correctProductionRunCostJob,
   backfillInventoryUnitCostJob,
+  backfillDesignEnergyCostJob,
 ]
 
 export const getMaintenanceJob = (id: string): MaintenanceJob | undefined =>


### PR DESCRIPTION
## What

5th #457 ops data-plumbing maintenance job: **`backfill-design-energy-costs`** — promotes the one-off `src/scripts/backfill-design-energy-costs.ts` into the guarded dry-run/apply registry contract.

For each design with committed energy/labor consumption logs it recomputes material + energy + labor + production cost (energy/labor priced from the log `unit_cost`, else the latest active `energy_rate`) and **diffs** the result against what's persisted:
- **dry-run (default)** previews every before→after (estimated_cost / material_cost / production_cost / energy_cost_total) without writing
- **apply** (`dry_run:false`) persists the recomputed `cost_breakdown` — idempotent (re-run is a no-op once costs match)
- skips designs that already have `energy_cost_total` unless `force=true`
- targets one design via `design_id`, or sweeps up to `limit` completed-run designs (default 1000, max 2000)
- a missing/failed design is reported per-design in `errors[]`, never aborts the sweep

## Why

Mirrors the #482 `backfill-inventory-unit-cost` promotion — turns a manual `medusa exec` script into a safe, operator-bounded, auditable admin endpoint so stored energy/labor cost drift no longer needs raw one-off scripts.

## Scope / conflicts

**Registry-only** — no migration, no config change. Appends one entry to the `MAINTENANCE_JOBS` array (+ `Modules` import). Conflict-free off `main`; the only merge conflict vs sibling #457 PRs (#481/#482) is the trivial `MAINTENANCE_JOBS` array append — keep all entries.

## Tests

- **36 registry unit** (pure: `buildEnergyRateMap` / `computeEnergyCost` / `computeLaborCost` / `diffEnergyCostFields` / `summarizeEnergyBackfill` / `round2`) — green
- **12 ops integration** (list + safe-by-default dry-run + per-design error + invalid-limit 400 + auth) — green
- `tsc` 0 new errors (69 baseline)

## Verify after deploy
`POST /admin/ops/maintenance-jobs/backfill-design-energy-costs/run {}` on v3.jaalyantra.com → dry-run summary `No changes — scanned N design(s)…` (or per-design before/after if drift exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)