### PR TITLE
fix(partners): honor q search + pagination on inventory-items list (#484)

### DIFF
--- a/apps/backend/integration-tests/http/partner-inventory-api.spec.ts
+++ b/apps/backend/integration-tests/http/partner-inventory-api.spec.ts
@@ -115,6 +115,56 @@ setupSharedTestSuite(() => {
         const found = listRes.data.inventory_items.some((i: any) => i.id === itemId)
         expect(found).toBe(true)
       })
+
+      it("should filter the list by q (search) on sku/title (#484)", async () => {
+        const unique = Date.now()
+        // Two distinct items at the partner's location.
+        const alphaRes = await api.post(
+          "/partners/inventory-items",
+          { sku: `ALPHA-${unique}`, title: `Cotton Yarn ${unique}` },
+          { headers: partner.headers }
+        )
+        await api.post(
+          "/partners/inventory-items",
+          { sku: `BETA-${unique}`, title: `Silk Thread ${unique}` },
+          { headers: partner.headers }
+        )
+        const alphaId = alphaRes.data.inventory_item.id
+
+        // Search by title fragment unique to the alpha item.
+        const byTitle = await api.get(
+          `/partners/inventory-items?q=Cotton Yarn ${unique}`,
+          { headers: partner.headers }
+        )
+        expect(byTitle.status).toBe(200)
+        expect(byTitle.data.inventory_items.length).toBe(1)
+        expect(byTitle.data.inventory_items[0].id).toBe(alphaId)
+        expect(byTitle.data.count).toBe(1)
+
+        // Search by sku fragment also works.
+        const bySku = await api.get(
+          `/partners/inventory-items?q=ALPHA-${unique}`,
+          { headers: partner.headers }
+        )
+        expect(bySku.status).toBe(200)
+        expect(bySku.data.inventory_items.some((i: any) => i.id === alphaId)).toBe(
+          true
+        )
+        expect(
+          bySku.data.inventory_items.every((i: any) =>
+            String(i.sku).includes(`ALPHA-${unique}`)
+          )
+        ).toBe(true)
+
+        // A non-matching term returns nothing (not the whole list).
+        const none = await api.get(
+          `/partners/inventory-items?q=zzz-no-such-item-${unique}`,
+          { headers: partner.headers }
+        )
+        expect(none.status).toBe(200)
+        expect(none.data.inventory_items.length).toBe(0)
+        expect(none.data.count).toBe(0)
+      })
     })
 
     describe("Inventory Item Details", () => {

--- a/apps/backend/src/api/partners/inventory-items/route.ts
+++ b/apps/backend/src/api/partners/inventory-items/route.ts
@@ -25,6 +25,11 @@ export const GET = async (
     return res.json({ inventory_items: [], count: 0, offset: 0, limit: 20 })
   }
 
+  const qv = (req.validatedQuery ?? req.query ?? {}) as Record<string, any>
+  const q = typeof qv.q === "string" ? qv.q.trim() : ""
+  const limit = Number.isFinite(Number(qv.limit)) ? Number(qv.limit) : 20
+  const offset = Number.isFinite(Number(qv.offset)) ? Number(qv.offset) : 0
+
   const inventoryService = req.scope.resolve(Modules.INVENTORY) as any
 
   // Get inventory levels at the partner's location to find their item IDs
@@ -36,11 +41,11 @@ export const GET = async (
   const itemIds = [...new Set((levels || []).map((l: any) => l.inventory_item_id).filter(Boolean))] as string[]
 
   if (itemIds.length === 0) {
-    return res.json({ inventory_items: [], count: 0, offset: 0, limit: 20 })
+    return res.json({ inventory_items: [], count: 0, offset, limit })
   }
 
   // Fetch full inventory items with their levels (filtered to partner's location)
-  const [items, count] = await inventoryService.listAndCountInventoryItems(
+  const [items] = await inventoryService.listAndCountInventoryItems(
     { id: itemIds },
     { take: itemIds.length, relations: ["location_levels"] }
   )
@@ -65,11 +70,30 @@ export const GET = async (
     }
   })
 
+  // Apply free-text search (q) against sku/title — the inventory service's
+  // location-scoped fetch above can't filter on these, so we post-filter
+  // in-app (same approach as the raw-materials route). Without this the
+  // partner UI search box silently returns the full list (#484).
+  const needle = q.toLowerCase()
+  const matched = needle
+    ? scoped.filter((item: any) => {
+        const candidates: Array<string | undefined> = [item?.sku, item?.title]
+        return candidates.some(
+          (c) => typeof c === "string" && c.toLowerCase().includes(needle)
+        )
+      })
+    : scoped
+
+  // Respect offset/limit pagination so the UI's page controls work.
+  const safeOffset = offset > 0 ? offset : 0
+  const safeLimit = limit > 0 ? limit : matched.length
+  const paginated = matched.slice(safeOffset, safeOffset + safeLimit)
+
   res.json({
-    inventory_items: scoped,
-    count: scoped.length,
-    offset: 0,
-    limit: scoped.length,
+    inventory_items: paginated,
+    count: matched.length,
+    offset: safeOffset,
+    limit: safeLimit,
   })
 }
 


### PR DESCRIPTION
## What & why
Fixes the most central broken surface in **#484** (partner filters/search not working).

`GET /partners/inventory-items` **ignored `req.query` entirely** — it fetched every item at the partner's location (`take: 1000`) and returned the full list with `limit = count`, `offset = 0`. The partner UI search box (and the "send to inventory" item picker) sends `?q=...` through the SDK, so typing in search had **no effect** — the list never filtered.

### Fix
- Read `q` / `limit` / `offset` from the request.
- Post-filter the location-scoped items on `sku` + `title` (case-insensitive contains). The inventory service's id-scoped fetch can't free-text filter these, so we post-filter in-app — same pattern already used by `GET /partners/inventory-items/raw-materials`.
- Slice by `offset`/`limit` and return `count` = total matched, so the UI's page controls work.

### Test
Adds an integration test to `partner-inventory-api.spec.ts`: title match → 1 result, sku match, and a non-matching term → empty list (not the whole list). **9/9 pass** via `pnpm test:integration:http:shared -- integration-tests/http/partner-inventory-api.spec.ts`. `tsc` 0 new errors in changed files.

## Scope note — #484 is broader (root-cause map)
This PR fixes the single most central + cleanly-testable surface. The same "backend silently drops `q`" bug exists on other partner list routes (the UI sends `q` correctly on all of them):

| Surface | Route | Status |
|---|---|---|
| inventory-items list | `partners/inventory-items` | **fixed here** |
| raw-materials ("send to inventory" picker) | `partners/inventory-items/raw-materials` | already works (post-filter) |
| inventory-orders list | `partners/inventory-orders` | drops `q` — **not fixed** (paginates in `query.graph` before post-filtering status; needs a pagination-vs-filter reorder, higher risk) |
| designs list | `partners/designs` | drops `q` — not fixed |
| customers list | `partners/customers` | never reads `req.query` |
| reservations list | `partners/reservations` | reads limit/offset, not `q` |

Follow-ups tracked for #484. These were left out to keep this PR low-risk and focused; the inventory-orders/designs routes need a careful reorder of pagination vs. in-app post-filtering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)