### PR TITLE
fix(partners): honor q search + pagination on customers list (#484)

### DIFF
--- a/apps/backend/integration-tests/http/partner-customers-api.spec.ts
+++ b/apps/backend/integration-tests/http/partner-customers-api.spec.ts
@@ -116,6 +116,67 @@ setupSharedTestSuite(() => {
       })
     })
 
+    // #484 — partner UI search was silently dropped: the list route never
+    // read `q`, so searching returned the full list. These assert the
+    // backend now honors q (by name/email) + offset/limit pagination.
+    describe("GET /partners/customers?q= (search + pagination)", () => {
+      beforeEach(async () => {
+        const unique = Date.now()
+        await api.post(
+          "/partners/customers",
+          { first_name: "Aurora", last_name: "Borealis", email: `aurora-${unique}@example.com` },
+          { headers: partner.headers }
+        )
+        await api.post(
+          "/partners/customers",
+          { first_name: "Zephyr", last_name: "Quill", email: `zephyr-${unique}@example.com` },
+          { headers: partner.headers }
+        )
+      })
+
+      it("filters by name (q)", async () => {
+        const res = await api.get("/partners/customers?q=Aurora", { headers: partner.headers })
+        expect(res.status).toBe(200)
+        expect(res.data.customers.length).toBeGreaterThanOrEqual(1)
+        expect(
+          res.data.customers.every((c: any) =>
+            `${c.first_name} ${c.last_name} ${c.email}`.toLowerCase().includes("aurora")
+          )
+        ).toBe(true)
+        expect(res.data.count).toBe(res.data.customers.length)
+      })
+
+      it("filters by email fragment (q)", async () => {
+        const res = await api.get("/partners/customers?q=zephyr-", { headers: partner.headers })
+        expect(res.status).toBe(200)
+        expect(res.data.customers.length).toBeGreaterThanOrEqual(1)
+        expect(
+          res.data.customers.every((c: any) => c.email.toLowerCase().includes("zephyr-"))
+        ).toBe(true)
+      })
+
+      it("returns empty for a non-matching q (search no longer ignored)", async () => {
+        const res = await api.get("/partners/customers?q=nonexistent-zzz-needle", {
+          headers: partner.headers,
+        })
+        expect(res.status).toBe(200)
+        expect(res.data.customers.length).toBe(0)
+        expect(res.data.count).toBe(0)
+      })
+
+      it("honors limit/offset pagination", async () => {
+        const page = await api.get("/partners/customers?limit=1&offset=0", {
+          headers: partner.headers,
+        })
+        expect(page.status).toBe(200)
+        expect(page.data.customers.length).toBe(1)
+        expect(page.data.limit).toBe(1)
+        expect(page.data.offset).toBe(0)
+        // count reflects the full matched set, not the page size
+        expect(page.data.count).toBeGreaterThanOrEqual(2)
+      })
+    })
+
     describe("Customer Addresses", () => {
       let customerId: string
 

--- a/apps/backend/src/api/partners/customers/route.ts
+++ b/apps/backend/src/api/partners/customers/route.ts
@@ -11,6 +11,11 @@ export const GET = async (
     return res.json({ customers: [], count: 0, offset: 0, limit: 20 })
   }
 
+  const qv = (req.validatedQuery ?? req.query ?? {}) as Record<string, any>
+  const q = typeof qv.q === "string" ? qv.q.trim() : ""
+  const limit = Number.isFinite(Number(qv.limit)) ? Number(qv.limit) : 20
+  const offset = Number.isFinite(Number(qv.offset)) ? Number(qv.offset) : 0
+
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
   const { data } = await query.graph({
     entity: "stores",
@@ -20,11 +25,38 @@ export const GET = async (
 
   const customers = (data?.[0] as any)?.customers || []
 
+  // Apply free-text search (q) against email/name/company/phone. The
+  // store→customers link join above can't filter on these, so we
+  // post-filter in-app (same approach as the inventory-items route).
+  // Without this the partner UI search box silently returns the full
+  // list (#484).
+  const needle = q.toLowerCase()
+  const matched = needle
+    ? customers.filter((c: any) => {
+        const candidates: Array<string | undefined> = [
+          c?.email,
+          c?.first_name,
+          c?.last_name,
+          [c?.first_name, c?.last_name].filter(Boolean).join(" ") || undefined,
+          c?.company_name,
+          c?.phone,
+        ]
+        return candidates.some(
+          (v) => typeof v === "string" && v.toLowerCase().includes(needle)
+        )
+      })
+    : customers
+
+  // Respect offset/limit pagination so the UI's page controls work.
+  const safeOffset = offset > 0 ? offset : 0
+  const safeLimit = limit > 0 ? limit : matched.length
+  const paginated = matched.slice(safeOffset, safeOffset + safeLimit)
+
   res.json({
-    customers,
-    count: customers.length,
-    offset: 0,
-    limit: 20,
+    customers: paginated,
+    count: matched.length,
+    offset: safeOffset,
+    limit: safeLimit,
   })
 }
 


### PR DESCRIPTION
## What & why
`GET /partners/customers` loaded the full store customer set and **never read `req.query`**, so the partner-UI customer search box returned everything regardless of the query. The UI side is already correct — `useCustomerTableQuery` puts `q` in `searchParams` and `useCustomers` forwards it to `/partners/customers`; the backend was the only broken link.

This is the 2nd `/partners/*` route fixed for #484 (after PR #487 inventory-items). Same in-app post-filter pattern.

## Change
- Read `q`/`limit`/`offset` from query.
- Post-filter customers on `email`, `first_name`, `last_name`, full-name (`first last`), `company_name`, `phone`.
- Slice by `offset`/`limit`; `count` = total matched (not page size).
- POST handler unchanged.

## Tests
+4 integration tests in `partner-customers-api.spec.ts`: name match, email fragment, non-matching → empty, limit/offset pagination. **4/4 new pass** per-file (`pnpm test:integration:http:shared -- integration-tests/http/partner-customers-api.spec.ts`). `tsc` 0 new errors (69 baseline).

> Note: one pre-existing failure in that spec — "links a customer to a group" (500 from `POST /partners/customers/:id/customer-groups`, a route this PR does not touch). Unrelated to this change.

## Remaining #484 follow-ups (separate PRs)
`partners/inventory-orders` + `partners/designs` (need pagination-after-filter reorder), `partners/reservations` (reads limit/offset, not q).

🤖 Generated with [Claude Code](https://claude.com/claude-code)