### PR TITLE
fix(partners): #484 honor q search + page-vs-set fix on inventory-orders list

### DIFF
--- a/apps/backend/src/api/partners/inventory-orders/__tests__/list-filters.unit.spec.ts
+++ b/apps/backend/src/api/partners/inventory-orders/__tests__/list-filters.unit.spec.ts
@@ -1,0 +1,77 @@
+import { applyInventoryOrderListFilters } from "../list-filters"
+
+const make = (over: Partial<{ id: string; status: string; stock_location: string }> = {}) => ({
+  id: over.id ?? "invord_1",
+  status: over.status ?? "Pending",
+  stock_location: over.stock_location ?? "Warehouse A",
+  quantity: 1,
+})
+
+describe("applyInventoryOrderListFilters (#484 partner inventory-orders search)", () => {
+  const orders = [
+    make({ id: "invord_alpha", status: "Pending", stock_location: "Warehouse A" }),
+    make({ id: "invord_beta", status: "Shipped", stock_location: "Mumbai Depot" }),
+    make({ id: "invord_gamma", status: "Pending", stock_location: "Mumbai Depot" }),
+  ]
+
+  it("returns all orders when no q/status given", () => {
+    const { items, count } = applyInventoryOrderListFilters(orders, {})
+    expect(count).toBe(3)
+    expect(items).toHaveLength(3)
+  })
+
+  it("filters by free-text q on id (case-insensitive)", () => {
+    const { items, count } = applyInventoryOrderListFilters(orders, { q: "BETA" })
+    expect(count).toBe(1)
+    expect(items[0].id).toBe("invord_beta")
+  })
+
+  it("filters by q on stock location name", () => {
+    const { items, count } = applyInventoryOrderListFilters(orders, { q: "mumbai" })
+    expect(count).toBe(2)
+    expect(items.map((o) => o.id)).toEqual(["invord_beta", "invord_gamma"])
+  })
+
+  it("filters by q on status text", () => {
+    const { items, count } = applyInventoryOrderListFilters(orders, { q: "shipped" })
+    expect(count).toBe(1)
+    expect(items[0].id).toBe("invord_beta")
+  })
+
+  it("non-matching q yields an empty set (the bug: used to return everything)", () => {
+    const { items, count } = applyInventoryOrderListFilters(orders, { q: "no-such-thing" })
+    expect(count).toBe(0)
+    expect(items).toHaveLength(0)
+  })
+
+  it("status filter is exact and combines with q", () => {
+    const { items, count } = applyInventoryOrderListFilters(orders, {
+      status: "Pending",
+      q: "mumbai",
+    })
+    expect(count).toBe(1)
+    expect(items[0].id).toBe("invord_gamma")
+  })
+
+  it("counts the FULL matched set, paginating AFTER the filter (page-vs-set fix)", () => {
+    // q matches 2; first page of size 1 returns 1 item but count stays 2.
+    const { items, count } = applyInventoryOrderListFilters(orders, {
+      q: "mumbai",
+      offset: 0,
+      limit: 1,
+    })
+    expect(count).toBe(2)
+    expect(items).toHaveLength(1)
+    expect(items[0].id).toBe("invord_beta")
+
+    const page2 = applyInventoryOrderListFilters(orders, { q: "mumbai", offset: 1, limit: 1 })
+    expect(page2.count).toBe(2)
+    expect(page2.items).toHaveLength(1)
+    expect(page2.items[0].id).toBe("invord_gamma")
+  })
+
+  it("trims/ignores whitespace-only q", () => {
+    const { count } = applyInventoryOrderListFilters(orders, { q: "   " })
+    expect(count).toBe(3)
+  })
+})

--- a/apps/backend/src/api/partners/inventory-orders/list-filters.ts
+++ b/apps/backend/src/api/partners/inventory-orders/list-filters.ts
@@ -1,0 +1,59 @@
+/**
+ * @file Pure list helpers for the partner inventory-orders route.
+ * @description Free-text (`q`) + status filtering and pagination applied
+ * in-app, AFTER the full partner-scoped set is fetched. Kept pure so the
+ * search/pagination contract can be unit-tested without booting Medusa.
+ *
+ * Why in-app: `query.graph` cannot filter on linked-module columns
+ * (inventory_orders.status) and the partner route has no free-text index, so
+ * `q`/status are matched here. Critically, pagination MUST happen here too —
+ * paginating inside `query.graph` slices BEFORE the filter, which returns the
+ * wrong page and a per-page (not total) count. See #484.
+ */
+
+export type PartnerInventoryOrderView = {
+  id: string
+  status?: string | null
+  stock_location?: string | null
+  [key: string]: unknown
+}
+
+export type InventoryOrderListFilters = {
+  q?: string
+  status?: string
+  offset?: number
+  limit?: number
+}
+
+/**
+ * Filter the full partner-scoped order set by `status` (exact) and `q`
+ * (case-insensitive substring over id / status / stock location name), then
+ * paginate. `count` is the total matched BEFORE pagination so the UI pager is
+ * correct.
+ */
+export function applyInventoryOrderListFilters<T extends PartnerInventoryOrderView>(
+  orders: T[],
+  { q, status, offset = 0, limit = 20 }: InventoryOrderListFilters
+): { items: T[]; count: number } {
+  let filtered = orders
+
+  if (status) {
+    filtered = filtered.filter((o) => o.status === status)
+  }
+
+  const needle = q?.trim().toLowerCase()
+  if (needle) {
+    filtered = filtered.filter((o) =>
+      [o.id, o.status, o.stock_location].some(
+        (v) => typeof v === "string" && v.toLowerCase().includes(needle)
+      )
+    )
+  }
+
+  const count = filtered.length
+  const safeOffset = Number.isFinite(offset) && offset > 0 ? Math.floor(offset) : 0
+  const safeLimit = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 20
+  const items = filtered.slice(safeOffset, safeOffset + safeLimit)
+
+  return { items, count }
+}

--- a/apps/backend/src/api/partners/inventory-orders/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/route.ts
@@ -128,6 +128,7 @@ import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { getPartnerFromAuthContext } from "../helpers";
 import { ListInventoryOrdersQuery } from "./validators";
+import { applyInventoryOrderListFilters } from "./list-filters";
 import InventoryOrderPartnerLink from "../../../links/partner-inventory-order"
 
 
@@ -136,7 +137,8 @@ export async function GET(
     res: MedusaResponse
 ) {
     try {
-        const { limit = 20, offset = 0, status } = req.validatedQuery;
+        const { limit = 20, offset = 0, status, q } =
+            req.validatedQuery as ListInventoryOrdersQuery;
 
         const query = req.scope.resolve(ContainerRegistrationKeys.QUERY);
         
@@ -168,8 +170,13 @@ export async function GET(
         
         // Status filtering will be done after query, not in filters
         
-        // Use query.graph to get orders linked to this partner with associated tasks
-        const { data: orders, metadata } = await query.graph({
+        // Use query.graph to get orders linked to this partner with associated tasks.
+        // NOTE: pagination is intentionally NOT applied here. `query.graph` cannot
+        // filter on linked-module columns (inventory_orders.status) and the partner
+        // route has no free-text index, so status/`q` are matched in-app below.
+        // Paginating here would slice BEFORE those filters run, returning the wrong
+        // page and a per-page (not total) count — the #484 page-vs-set bug.
+        const { data: orders } = await query.graph({
             entity: InventoryOrderPartnerLink.entryPoint,
             fields: [
                 "inventory_orders.*",
@@ -179,24 +186,10 @@ export async function GET(
                 "partner.*",
               ],
             filters,
-            pagination: {
-                skip: offset,
-                take: limit
-            }
         }, { locale: req.locale });
-        
-        // Apply status filtering at application level (cannot be done in query due to MedusaJS limitation)
-        // This is a workaround for now, we shall look into a better solution in the future
-        // @todo fix this
-        let filteredOrders = orders;
-        if (status) {
-            filteredOrders = orders.filter((linkData: any) => 
-                linkData.inventory_orders?.status === status
-            );
-        }
-        
+
         // Format the response for partner view - now using task-based status
-        const partnerOrders = filteredOrders.map((linkData: any) => {
+        const formattedOrders = orders.map((linkData: any) => {
             const order = linkData.inventory_orders;
             
             // Extract partner workflow status from tasks instead of metadata
@@ -254,9 +247,17 @@ export async function GET(
             };
         });
         
+        // Apply status + free-text (`q`) filtering, THEN paginate, over the full
+        // partner-scoped set. count = total matched (pre-pagination) so the UI
+        // pager is correct. Pure + unit-tested in ./list-filters.
+        const { items: partnerOrders, count } = applyInventoryOrderListFilters(
+            formattedOrders,
+            { q, status, offset, limit }
+        );
+
         res.status(200).json({
             inventory_orders: partnerOrders,
-            count: filteredOrders.length,
+            count,
             limit,
             offset
         });

--- a/apps/backend/src/api/partners/inventory-orders/validators.ts
+++ b/apps/backend/src/api/partners/inventory-orders/validators.ts
@@ -3,7 +3,11 @@ import { z } from "@medusajs/framework/zod";
 const querySchema = z.object({
   limit: z.string().transform(Number).optional(),
   offset: z.string().transform(Number).optional(),
-  status: z.string().optional()
+  status: z.string().optional(),
+  // Free-text search forwarded by the partner UI (DataTableSearch -> ?q=).
+  // Validated by the shared admin listInventoryOrdersQuerySchema middleware;
+  // declared here so the route can read it type-safely.
+  q: z.string().optional()
 });
 
 


### PR DESCRIPTION
## #484 — Partner filters/search not working (3rd surface)

Follow-up to #487 (inventory-items) and #488 (customers). Fixes `GET /partners/inventory-orders`.

### Root cause
The route had **two** defects:
1. **`q` dropped** — it never read the free-text search param the partner UI forwards (`DataTableSearch` → `?q=`), so searching returned the full list (looked dead).
2. **Page-vs-set bug** — it paginated *inside* `query.graph` (`pagination: { skip, take }`) and only then applied the `status` filter in-app. So the status filter ran against a single page, and `count` was per-page, not total.

`query.graph` can't filter on linked-module columns (`inventory_orders.status`) and there's no free-text index on this partner route, so filtering must happen in-app — which means pagination must happen in-app too, **after** the filter.

### Fix
- Fetch the full partner-scoped linked set (no `query.graph` pagination).
- Format, then filter by `status` (exact) + `q` (case-insensitive substring over id / status / stock-location name) and paginate via a **pure, unit-tested** helper `applyInventoryOrderListFilters`.
- `count` = total matched **before** pagination → correct UI pager.
- `validators.ts`: declare `q` (already validated by the shared admin `listInventoryOrdersQuerySchema` middleware; declared locally so the route reads it type-safely).

Mirrors the in-app post-filter pattern from #487 / #488. No wire-contract change beyond honoring an already-validated param.

### Tests
`src/api/partners/inventory-orders/__tests__/list-filters.unit.spec.ts` — 8 cases (q on id/status/location, non-match → empty, status+q combine, **count stays full while page is sliced**, whitespace-only q ignored). 8/8 pass.

```
TEST_TYPE=unit pnpm test:unit -- --testPathPattern="inventory-orders/__tests__/list-filters"
```

tsc: 69 baseline, **0 new** errors.

### Notes
- Pure-logic unit spec chosen deliberately: a live list test needs a fully linked inventory order (task templates + stock locations + send-to-partner), which is heavy scaffolding; the search/pagination contract is pure and fully covered here.
- Next #484 surfaces (separate PRs): `partners/designs` (same page-vs-set reorder), then `partners/reservations` (wire q).

🤖 Generated with [Claude Code](https://claude.com/claude-code)