### PR TITLE
fix(partners): wire q search + fix page-vs-set on designs list (#484)

### DIFF
--- a/apps/backend/src/api/partners/designs/__tests__/list-filters.unit.spec.ts
+++ b/apps/backend/src/api/partners/designs/__tests__/list-filters.unit.spec.ts
@@ -1,0 +1,86 @@
+import { applyDesignListFilters } from "../list-filters"
+
+const make = (
+  over: Partial<{ id: string; name: string; status: string }> = {}
+) => ({
+  id: over.id ?? "design_1",
+  name: over.name ?? "Untitled",
+  status: over.status ?? "Conceptual",
+  partner_info: { partner_status: "incoming" },
+})
+
+describe("applyDesignListFilters (#484 partner designs search)", () => {
+  const designs = [
+    make({ id: "design_alpha", name: "Summer Kurta", status: "Approved" }),
+    make({ id: "design_beta", name: "Winter Coat", status: "Conceptual" }),
+    make({ id: "design_gamma", name: "Summer Dress", status: "Approved" }),
+  ]
+
+  it("returns all designs when no q/status given", () => {
+    const { items, count } = applyDesignListFilters(designs, {})
+    expect(count).toBe(3)
+    expect(items).toHaveLength(3)
+  })
+
+  it("filters by free-text q on name (case-insensitive)", () => {
+    const { items, count } = applyDesignListFilters(designs, { q: "SUMMER" })
+    expect(count).toBe(2)
+    expect(items.map((d) => d.id)).toEqual(["design_alpha", "design_gamma"])
+  })
+
+  it("filters by q on id", () => {
+    const { items, count } = applyDesignListFilters(designs, { q: "beta" })
+    expect(count).toBe(1)
+    expect(items[0].id).toBe("design_beta")
+  })
+
+  it("filters by q on status text", () => {
+    const { items, count } = applyDesignListFilters(designs, { q: "approved" })
+    expect(count).toBe(2)
+  })
+
+  it("non-matching q yields an empty set (the bug: used to return everything)", () => {
+    const { items, count } = applyDesignListFilters(designs, { q: "no-such-thing" })
+    expect(count).toBe(0)
+    expect(items).toHaveLength(0)
+  })
+
+  it("status filter is exact and combines with q", () => {
+    const { items, count } = applyDesignListFilters(designs, {
+      status: "Approved",
+      q: "summer",
+    })
+    expect(count).toBe(2)
+    expect(items.map((d) => d.id)).toEqual(["design_alpha", "design_gamma"])
+  })
+
+  it("status filter alone returns only exact matches", () => {
+    const { items, count } = applyDesignListFilters(designs, { status: "Conceptual" })
+    expect(count).toBe(1)
+    expect(items[0].id).toBe("design_beta")
+  })
+
+  it("paginates AFTER filtering and reports total matched count (page-vs-set bug)", () => {
+    const many = Array.from({ length: 25 }, (_, i) =>
+      make({ id: `design_${i}`, name: `Kurta ${i}`, status: "Approved" })
+    )
+    const { items, count } = applyDesignListFilters(many, {
+      q: "kurta",
+      offset: 20,
+      limit: 20,
+    })
+    // 25 match, page 2 (offset 20) returns the last 5, count is the full 25.
+    expect(count).toBe(25)
+    expect(items).toHaveLength(5)
+    expect(items[0].id).toBe("design_20")
+  })
+
+  it("falls back to safe defaults for invalid offset/limit", () => {
+    const { items, count } = applyDesignListFilters(designs, {
+      offset: -5 as any,
+      limit: 0 as any,
+    })
+    expect(count).toBe(3)
+    expect(items).toHaveLength(3)
+  })
+})

--- a/apps/backend/src/api/partners/designs/list-filters.ts
+++ b/apps/backend/src/api/partners/designs/list-filters.ts
@@ -1,0 +1,61 @@
+/**
+ * @file Pure list helpers for the partner designs route.
+ * @description Free-text (`q`) + status filtering and pagination applied
+ * in-app, AFTER the full partner-scoped (linked + owned) design set is
+ * fetched and merged. Kept pure so the search/pagination contract can be
+ * unit-tested without booting Medusa.
+ *
+ * Why in-app: `query.graph` cannot filter on linked-module columns
+ * (design.status via the design_partners link) and the partner route has no
+ * free-text index, so `q`/status are matched here. Critically, pagination
+ * MUST happen here too — paginating inside `query.graph` slices BEFORE the
+ * link+owned merge and the filters, which returns the wrong page and a
+ * per-page (not total) count. See #484.
+ */
+
+export type PartnerDesignView = {
+  id: string
+  name?: string | null
+  status?: string | null
+  [key: string]: unknown
+}
+
+export type DesignListFilters = {
+  q?: string
+  status?: string
+  offset?: number
+  limit?: number
+}
+
+/**
+ * Filter the full partner-scoped design set by `status` (exact match on
+ * `design.status`) and `q` (case-insensitive substring over id / name /
+ * status), then paginate. `count` is the total matched BEFORE pagination so
+ * the UI pager is correct.
+ */
+export function applyDesignListFilters<T extends PartnerDesignView>(
+  designs: T[],
+  { q, status, offset = 0, limit = 20 }: DesignListFilters
+): { items: T[]; count: number } {
+  let filtered = designs
+
+  if (status) {
+    filtered = filtered.filter((d) => d.status === status)
+  }
+
+  const needle = q?.trim().toLowerCase()
+  if (needle) {
+    filtered = filtered.filter((d) =>
+      [d.id, d.name, d.status].some(
+        (v) => typeof v === "string" && v.toLowerCase().includes(needle)
+      )
+    )
+  }
+
+  const count = filtered.length
+  const safeOffset = Number.isFinite(offset) && offset > 0 ? Math.floor(offset) : 0
+  const safeLimit = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 20
+  const items = filtered.slice(safeOffset, safeOffset + safeLimit)
+
+  return { items, count }
+}

--- a/apps/backend/src/api/partners/designs/route.ts
+++ b/apps/backend/src/api/partners/designs/route.ts
@@ -107,6 +107,7 @@ import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 import { getPartnerFromAuthContext } from "../helpers"
 import { ListDesignsQuery, PartnerCreateDesign } from "./validators"
+import { applyDesignListFilters } from "./list-filters"
 import designPartnersLink from "../../../links/design-partners-link"
 import { createDesignWorkflow } from "../../../workflows/designs/create-design"
 import { linkDesignPartnerWorkflow } from "../../../workflows/designs/partner/link-design-to-partner"
@@ -115,7 +116,7 @@ export async function GET(
   req: AuthenticatedMedusaRequest<ListDesignsQuery>,
   res: MedusaResponse
 ) {
-  const { limit = 20, offset = 0, status } = req.validatedQuery
+  const { limit = 20, offset = 0, status, q } = req.validatedQuery as ListDesignsQuery
 
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
@@ -139,6 +140,14 @@ export async function GET(
   // and never reach page 1. Wrapped in a fallback so that if a runtime
   // ever rejects `order` on a link entry point, the listing degrades to
   // unordered instead of 500-ing.
+  //
+  // NOTE: pagination is intentionally NOT applied here. `query.graph` cannot
+  // filter on the linked design's columns (design.status) and the partner
+  // route has no free-text index, so status/`q` are matched in-app below.
+  // Paginating here would slice BEFORE the linked+owned merge and those
+  // filters run, returning the wrong page and a per-page (not total) count —
+  // the #484 page-vs-set bug. We fetch the full partner-scoped set (capped)
+  // and paginate in `applyDesignListFilters`.
   const linkFields = ["created_at", "design.*", "design.tasks.*", "partner.*"]
   let results: any[] = []
   try {
@@ -146,7 +155,7 @@ export async function GET(
       entity: designPartnersLink.entryPoint,
       fields: linkFields,
       filters,
-      pagination: { skip: offset, take: limit, order: { created_at: "DESC" } },
+      pagination: { skip: 0, take: 1000, order: { created_at: "DESC" } },
     }, { locale: req.locale })
     results = data
   } catch {
@@ -154,7 +163,7 @@ export async function GET(
       entity: designPartnersLink.entryPoint,
       fields: linkFields,
       filters,
-      pagination: { skip: offset, take: limit },
+      pagination: { skip: 0, take: 1000 },
     }, { locale: req.locale })
     results = data
   }
@@ -177,8 +186,11 @@ export async function GET(
   // the ordered query above already surfaces them — but if link ordering
   // ever misses one, this guarantees a partner still sees what they
   // created. Merged + re-sorted by recency below, never force-pinned.
+  // Always fetched now (no offset gate): pagination happens in-app AFTER
+  // the merge, so gating owned-fetch on offset===0 would drop owned
+  // designs from every page but the first. #484.
   let ownedRows: any[] = []
-  if (offset === 0) {
+  {
     try {
       const { data: owned } = await query.graph(
         {
@@ -220,11 +232,10 @@ export async function GET(
     return bt - at
   })
 
-  // post-filter by design.status if requested
-  let filtered = merged
-  if (status) {
-    filtered = merged.filter((linkData: any) => linkData.design?.status === status)
-  }
+  // status + free-text (`q`) filtering and pagination are applied AFTER the
+  // designs are mapped (so `q` can match the resolved design fields), via
+  // applyDesignListFilters below. Map over the full merged set here.
+  const filtered = merged
 
   // Pre-fetch all production runs for this partner (one query, not per-design)
   let partnerRuns: any[] = []
@@ -243,7 +254,7 @@ export async function GET(
     // Non-fatal
   }
 
-  const designs = filtered.map((linkData: any) => {
+  const mappedDesigns = filtered.map((linkData: any) => {
     const design = linkData.design
 
     const tasks = design.tasks || []
@@ -319,9 +330,19 @@ export async function GET(
     }
   })
 
+  // Apply status + free-text (`q`) filtering, THEN paginate, over the full
+  // partner-scoped set. count = total matched (pre-pagination) so the UI
+  // pager is correct. Pure + unit-tested in ./list-filters.
+  const { items: designs, count } = applyDesignListFilters(mappedDesigns, {
+    q,
+    status,
+    offset,
+    limit,
+  })
+
   res.status(200).json({
     designs,
-    count: designs.length,
+    count,
     limit,
     offset,
   })

--- a/apps/backend/src/api/partners/designs/validators.ts
+++ b/apps/backend/src/api/partners/designs/validators.ts
@@ -4,6 +4,10 @@ export const listDesignsQuerySchema = z.object({
   limit: z.string().transform(Number).optional(),
   offset: z.string().transform(Number).optional(),
   status: z.string().optional(),
+  // Free-text search forwarded by the partner UI (SDK `query` → `q`). The
+  // partner designs list has no DB index for it, so it's matched in-app
+  // over the full partner-scoped set (see ./list-filters). #484.
+  q: z.string().optional(),
 })
 
 export type ListDesignsQuery = z.infer<typeof listDesignsQuerySchema>


### PR DESCRIPTION
## What
4th partner-search surface fix for **#484** (after #487 inventory-items, #488 customers, #489 inventory-orders).

`GET /partners/designs` had the same two defects #489 fixed for inventory-orders:
1. **Dropped the SDK's `q` param** — partner-UI search forwarded `q` but the route never read it, so search looked dead (returned everything).
2. **Page-vs-set bug** — paginated *inside* `query.graph` (`skip: offset, take: limit`) BEFORE the linked+owned merge and status filter ran. The status filter operated on one sliced page, owned designs were only fetched at `offset === 0`, and `count` was per-page instead of total.

## How
- Add `q` to `listDesignsQuerySchema`.
- Fetch the **full** partner-scoped link set (no in-graph pagination, capped at 1000) and **always** merge owned designs (drop the `offset === 0` gate).
- New pure `./list-filters` `applyDesignListFilters`: status (exact on `design.status`) + `q` (case-insensitive over id/name/status), THEN paginate. `count` = total matched pre-pagination so the UI pager is correct.
- Mirrors #489's pure-helper + unit-spec pattern exactly.

## Tests
- 9 unit tests in `__tests__/list-filters.unit.spec.ts` (`TEST_TYPE=unit`), 9/9 pass.
- `tsc` 0 new errors (69 baseline).

## Remaining for #484
`partners/reservations` (no `q` wired) — last ranked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)