### PR TITLE
fix(partners): wire q search on GET /partners/reservations (#484)

### DIFF
--- a/apps/backend/src/api/partners/reservations/__tests__/list-filters.unit.spec.ts
+++ b/apps/backend/src/api/partners/reservations/__tests__/list-filters.unit.spec.ts
@@ -1,0 +1,75 @@
+import {
+  applyReservationListFilters,
+  PartnerReservationView,
+} from "../list-filters"
+
+const make = (over: Partial<PartnerReservationView> & { id: string }): PartnerReservationView => ({
+  inventory_item_id: null,
+  location_id: null,
+  description: null,
+  ...over,
+})
+
+const SET: PartnerReservationView[] = [
+  make({ id: "res_1", inventory_item_id: "iitem_red", location_id: "sloc_a", description: "Red cotton spool" }),
+  make({ id: "res_2", inventory_item_id: "iitem_blue", location_id: "sloc_b", description: "Blue silk thread" }),
+  make({ id: "res_3", inventory_item_id: "iitem_green", location_id: "sloc_a", description: "Green wool batch" }),
+]
+
+describe("applyReservationListFilters", () => {
+  it("returns the full set (paginated) when q is absent", () => {
+    const { items, count } = applyReservationListFilters(SET, {})
+    expect(count).toBe(3)
+    expect(items).toHaveLength(3)
+  })
+
+  it("matches q on description (case-insensitive)", () => {
+    const { items, count } = applyReservationListFilters(SET, { q: "SILK" })
+    expect(count).toBe(1)
+    expect(items[0].id).toBe("res_2")
+  })
+
+  it("matches q on inventory_item_id", () => {
+    const { items, count } = applyReservationListFilters(SET, { q: "iitem_green" })
+    expect(count).toBe(1)
+    expect(items[0].id).toBe("res_3")
+  })
+
+  it("matches q on id", () => {
+    const { items, count } = applyReservationListFilters(SET, { q: "res_1" })
+    expect(count).toBe(1)
+    expect(items[0].id).toBe("res_1")
+  })
+
+  it("matches q on location_id", () => {
+    const { items, count } = applyReservationListFilters(SET, { q: "sloc_a" })
+    expect(count).toBe(2)
+    expect(items.map((r) => r.id)).toEqual(["res_1", "res_3"])
+  })
+
+  it("returns empty for a non-matching q", () => {
+    const { items, count } = applyReservationListFilters(SET, { q: "nope" })
+    expect(count).toBe(0)
+    expect(items).toHaveLength(0)
+  })
+
+  it("counts the TOTAL matched before pagination (page-vs-set guard)", () => {
+    const { items, count } = applyReservationListFilters(SET, { q: "iitem", limit: 2, offset: 0 })
+    // all three match "iitem" prefix; count is total, page is limited to 2
+    expect(count).toBe(3)
+    expect(items).toHaveLength(2)
+    expect(items.map((r) => r.id)).toEqual(["res_1", "res_2"])
+  })
+
+  it("paginates with offset after filtering", () => {
+    const { items, count } = applyReservationListFilters(SET, { q: "iitem", limit: 2, offset: 2 })
+    expect(count).toBe(3)
+    expect(items.map((r) => r.id)).toEqual(["res_3"])
+  })
+
+  it("trims whitespace-only q to a no-op match-all", () => {
+    const { count } = applyReservationListFilters(SET, { q: "   " })
+    expect(count).toBe(3)
+  })
+}
+)

--- a/apps/backend/src/api/partners/reservations/list-filters.ts
+++ b/apps/backend/src/api/partners/reservations/list-filters.ts
@@ -1,0 +1,57 @@
+/**
+ * @file Pure list helpers for the partner reservations route.
+ * @description Free-text (`q`) filtering and pagination applied in-app, AFTER
+ * the full partner-location-scoped reservation set is fetched from the
+ * inventory module. Kept pure so the search/pagination contract can be
+ * unit-tested without booting Medusa.
+ *
+ * Why in-app: the partner route fetches reservation items directly via
+ * `inventoryService.listAndCountReservationItems(filters)` (location-scoped),
+ * which has no free-text index for `q`. Critically, pagination MUST happen
+ * here too — paginating inside the service (`take`/`skip`) slices BEFORE the
+ * `q` filter, which returns the wrong page and a per-page (not total) count.
+ * See #484 (same page-vs-set defect fixed for inventory-orders/designs).
+ */
+
+export type PartnerReservationView = {
+  id: string
+  inventory_item_id?: string | null
+  location_id?: string | null
+  description?: string | null
+  [key: string]: unknown
+}
+
+export type ReservationListFilters = {
+  q?: string
+  offset?: number
+  limit?: number
+}
+
+/**
+ * Filter the full partner-scoped reservation set by `q` (case-insensitive
+ * substring over id / inventory_item_id / location_id / description), then
+ * paginate. `count` is the total matched BEFORE pagination so the UI pager is
+ * correct.
+ */
+export function applyReservationListFilters<T extends PartnerReservationView>(
+  reservations: T[],
+  { q, offset = 0, limit = 20 }: ReservationListFilters
+): { items: T[]; count: number } {
+  let filtered = reservations
+
+  const needle = q?.trim().toLowerCase()
+  if (needle) {
+    filtered = filtered.filter((r) =>
+      [r.id, r.inventory_item_id, r.location_id, r.description].some(
+        (v) => typeof v === "string" && v.toLowerCase().includes(needle)
+      )
+    )
+  }
+
+  const count = filtered.length
+  const safeOffset = Number.isFinite(offset) && offset > 0 ? Math.floor(offset) : 0
+  const safeLimit = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : 20
+  const items = filtered.slice(safeOffset, safeOffset + safeLimit)
+
+  return { items, count }
+}

--- a/apps/backend/src/api/partners/reservations/route.ts
+++ b/apps/backend/src/api/partners/reservations/route.ts
@@ -1,11 +1,13 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys, Modules, MedusaError } from "@medusajs/framework/utils"
 
+import { applyReservationListFilters } from "./list-filters"
+
 /**
  * GET /partners/reservations
  *
  * List reservation items scoped to the partner's stock locations.
- * Accepts: limit, offset, inventory_item_id[], location_id[]
+ * Accepts: q, limit, offset, inventory_item_id[], location_id[]
  */
 export const GET = async (
   req: AuthenticatedMedusaRequest,
@@ -50,6 +52,7 @@ export const GET = async (
   // Parse query params
   const limit = Number(req.query.limit) || 20
   const offset = Number(req.query.offset) || 0
+  const q = typeof req.query.q === "string" ? req.query.q : undefined
 
   // Build filters — scope to partner's locations
   const filters: Record<string, any> = {
@@ -64,10 +67,16 @@ export const GET = async (
       : [inventoryItemId]
   }
 
+  // Fetch the FULL partner-scoped set, then apply `q` + pagination in-app.
+  // The inventory service exposes no free-text index for `q`; paginating in
+  // the service would slice BEFORE the q filter (wrong page + per-page count).
+  // See #484.
   const inventoryService = req.scope.resolve(Modules.INVENTORY) as any
-  const [reservations, count] = await inventoryService.listAndCountReservationItems(
-    filters,
-    { take: limit, skip: offset }
+  const allReservations = await inventoryService.listReservationItems(filters)
+
+  const { items: reservations, count } = applyReservationListFilters(
+    allReservations || [],
+    { q, offset, limit }
   )
 
   res.json({


### PR DESCRIPTION
## What
Wires the `q` free-text search param into `GET /partners/reservations` — the **last** partner-search surface for #484 (after #487 inventory-items, #488 customers, #489 inventory-orders, #490 designs).

## Root cause
The route never read `req.query.q`, and it paginated inside the inventory service (`take`/`skip`) BEFORE any text filter. So partner-UI search returned nothing, and even with location/inventory_item filters the `count` was per-page (the same page-vs-set defect fixed in #489/#490).

## Fix
- Read `q` from the query.
- Fetch the FULL partner-location-scoped reservation set (`listReservationItems`), then apply `q` + pagination in a pure helper `applyReservationListFilters` with `count` = total matched (before pagination).
- `q` matches `id` / `inventory_item_id` / `location_id` / `description`, case-insensitive.
- POST unchanged.

Pure helper kept unit-testable (a live integration test would need a fully linked reservation: inventory item + stock location + partner sales-channel link — heavy; the search/pagination contract is pure).

## Tests
- `+9` unit tests in `src/api/partners/reservations/__tests__/list-filters.unit.spec.ts` — 9/9 pass via `TEST_TYPE=unit`.
- `tsc` 0 new errors (69 baseline).

## Note / deferred
SKU/title search isn't covered because the partner route doesn't expand the `inventory_item` relation (admin does). Matching reservation-own fields is the focused fix; enriching with inventory_item sku/title would be a follow-up.

Closes the search portion of #484 (currency issue tracked separately in #485).

🤖 Generated with [Claude Code](https://claude.com/claude-code)