### PR TITLE
fix(visual-flows): unblock prod build — optional isolated-vm not statically resolved

### DIFF
--- a/apps/backend/src/modules/visual_flows/operations/isolated-runner.ts
+++ b/apps/backend/src/modules/visual_flows/operations/isolated-runner.ts
@@ -167,7 +167,13 @@ function hostCall(kind: string, payload: string): string {
  */
 async function loadIsolatedVm(): Promise<any> {
   try {
-    const mod: any = await import("isolated-vm")
+    // `isolated-vm` is an optional native addon. Reference the specifier
+    // indirectly (typed as `string`, not the literal) so tsc does NOT statically
+    // resolve it at build time — in the prod Docker image the optional dep is
+    // absent, and a literal `import("isolated-vm")` fails compilation (TS2307).
+    // Runtime presence is handled by the catch below.
+    const specifier: string = "isolated-vm"
+    const mod: any = await import(specifier)
     return mod.default || mod
   } catch (err: any) {
     throw new Error(


### PR DESCRIPTION
## Problem
Every `deploy-to-aws` since #465 fails at **Build & Push Image**:
```
src/modules/visual_flows/operations/isolated-runner.ts:170:35
  error TS2307: Cannot find module 'isolated-vm' or its corresponding type declarations.
```
`isolated-vm` is an **optional** native addon (`optionalDependencies`). It's present on dev machines (local `medusa build` passes) but absent in the prod Docker image, where the full `medusa build` (tsc) statically resolves the literal `import("isolated-vm")` and fails. **Result: `main` hasn't deployed to prod since #465 — the #484 partner-search merges (#487–#491) are stuck and not live.**

PR CI didn't catch it because PR runs changed specs, not a full prod build.

## Fix
Reference the import specifier indirectly (typed `string`, not the literal) so tsc does not statically resolve the optional module. Runtime behavior is unchanged — the existing `try/catch` still loads it when the native addon is present and throws the operator-facing error when it isn't.

## Verification
With `node_modules/isolated-vm` hidden (simulating the Docker build):
- **Control** (literal `import("isolated-vm")`) → reproduces `TS2307`.
- **Fix** (indirect specifier) → compiles clean, no `TS2307`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)