### PR TITLE
fix(partners): repair POST /partners/customers/:id/customer-groups 500 (#495)

### DIFF
--- a/apps/backend/src/api/partners/customers/[id]/customer-groups/route.ts
+++ b/apps/backend/src/api/partners/customers/[id]/customer-groups/route.ts
@@ -1,7 +1,13 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { Modules } from "@medusajs/framework/utils"
+import { linkCustomerGroupsToCustomerWorkflow } from "@medusajs/medusa/core-flows"
 import { validatePartnerEntityOwnership } from "../../../helpers"
 
+// Mirror admin POST /admin/customers/:id/customer-groups: the
+// customer <-> customer_group relationship is internal to the CUSTOMER module
+// (addCustomerToGroup/removeCustomerFromGroup), NOT a registered module link.
+// The previous remoteLink.create/dismiss between "customer" and "customer_group"
+// 500'd because no such link is defined. Use the core workflow instead (#495).
 export const POST = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
@@ -13,26 +19,20 @@ export const POST = async (
     req.scope
   )
 
-  const body = req.body as any
-  const remoteLink = req.scope.resolve(ContainerRegistrationKeys.LINK) as any
+  const body = req.body as { add?: string[]; remove?: string[] }
 
-  if (body.add?.length) {
-    for (const groupId of body.add) {
-      await remoteLink.create({
-        customer: { customer_id: req.params.id },
-        customer_group: { customer_group_id: groupId },
-      })
-    }
-  }
+  await linkCustomerGroupsToCustomerWorkflow(req.scope).run({
+    input: {
+      id: req.params.id,
+      add: body.add ?? [],
+      remove: body.remove ?? [],
+    },
+  })
 
-  if (body.remove?.length) {
-    for (const groupId of body.remove) {
-      await remoteLink.dismiss({
-        customer: { customer_id: req.params.id },
-        customer_group: { customer_group_id: groupId },
-      })
-    }
-  }
+  const customerService = req.scope.resolve(Modules.CUSTOMER) as any
+  const customer = await customerService.retrieveCustomer(req.params.id, {
+    relations: ["groups"],
+  })
 
-  res.json({ customer: { id: req.params.id } })
+  res.json({ customer })
 }


### PR DESCRIPTION
## Bug
`POST /partners/customers/:id/customer-groups` returned **500** (the lone failing test in `partner-customers-api.spec.ts`, surfaced during #484 search work).

## Root cause
The `customer ↔ customer_group` relationship is **internal to the CUSTOMER module** (`addCustomerToGroup`/`removeCustomerFromGroup` on the customer service) — it is **not** a registered module link. The route was calling `remoteLink.create(...)` / `remoteLink.dismiss(...)` between `"customer"` and `"customer_group"`, which 500s because no such link is defined.

## Fix
Mirror the admin route (`node_modules/@medusajs/medusa/dist/api/admin/customers/[id]/customer-groups/route.js`): run `linkCustomerGroupsToCustomerWorkflow`, then return the refetched customer (with `groups`). Partner ownership validation (`validatePartnerEntityOwnership`) is preserved.

## Verify
```
pnpm test:integration:http:shared -- integration-tests/http/partner-customers-api.spec.ts
```
→ **12/12 green** (was 11/12; the `"links a customer to a group and verifies"` test now passes). tsc: 0 new errors in changed file.

Closes #495.

🤖 Generated with [Claude Code](https://claude.com/claude-code)