### PR TITLE
fix(ai): product-description uses DashScope platform first, OpenRouter free-vision fallback

### DIFF
--- a/apps/backend/src/api/admin/products/[id]/generateDescription/route.ts
+++ b/apps/backend/src/api/admin/products/[id]/generateDescription/route.ts
@@ -65,9 +65,23 @@
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
 import { GenerateDescriptionValidator } from "./validators"
+import { describeProductImageWorkflow } from "../../../../../workflows/ai/describe-product-image"
 import { generateProductDescriptionWorkflow } from "../../../../../workflows/products/gen-ai-desc"
 import { MedusaError } from "@medusajs/utils"
 
+/**
+ * Generate a product title + description from an image, trying providers in
+ * priority order and falling through on failure:
+ *
+ *   1. Configured AI platform for role `ai_product_description` (e.g. DashScope
+ *      / Qwen-VL set in Settings → External Platforms). The admin's chosen
+ *      default; ~15s and the cheapest reliable path.
+ *   2. OpenRouter FREE vision models (filtered to real vision→text models, so
+ *      the chain no longer wastes time on audio/image-generator models).
+ *
+ * First success wins. If every provider fails, surface one aggregated error
+ * naming what was tried, so the cause is visible instead of a bare 504/500.
+ */
 export const POST = async (
   req: MedusaRequest<GenerateDescriptionValidator>,
   res: MedusaResponse
@@ -83,27 +97,61 @@ export const POST = async (
   }
 
   const hint = body.hint ?? body.notes
+  const attempts: string[] = []
 
-  const { result, errors } = await generateProductDescriptionWorkflow(req.scope).run({
-    input: {
-      imageUrl: body.imageUrl,
-      hint,
-      productData: body.productData || {},
-    },
-  })
-
-  if (errors.length) {
-    // Surface first error for simplicity
-    throw errors[0]
+  // 1) Configured AI platform (DashScope / role=ai_product_description).
+  try {
+    const { result } = await describeProductImageWorkflow(req.scope).run({
+      input: { imageUrl: body.imageUrl, hint },
+    })
+    const r = result as {
+      title: string
+      description: string
+      provider_platform_id: string
+    }
+    res.status(200).json({
+      product_id: id,
+      title: r.title,
+      description: r.description,
+      provider: `platform:${r.provider_platform_id}`,
+    })
+    return
+  } catch (e: any) {
+    attempts.push(`configured-platform: ${e?.message || e}`)
   }
 
-  // result is the workflow response from Mastra validation step
-  // Ensure shape contains title and description
-  const { title, description } = result as { title: string; description: string }
+  // 2) OpenRouter free vision models (skips audio/image-gen models now).
+  if (process.env.OPENROUTER_API_KEY) {
+    try {
+      const { result, errors } = await generateProductDescriptionWorkflow(
+        req.scope
+      ).run({
+        input: {
+          imageUrl: body.imageUrl,
+          hint,
+          productData: body.productData || {},
+        },
+      })
+      if (errors?.length) {
+        throw errors[0]
+      }
+      const r = result as { title: string; description: string }
+      res.status(200).json({
+        product_id: id,
+        title: r.title,
+        description: r.description,
+        provider: "openrouter-free-vision",
+      })
+      return
+    } catch (e: any) {
+      attempts.push(`openrouter-free-vision: ${e?.message || e}`)
+    }
+  } else {
+    attempts.push("openrouter-free-vision: skipped (OPENROUTER_API_KEY not set)")
+  }
 
-  res.status(200).json({
-    product_id: id,
-    title,
-    description,
-  })
+  throw new MedusaError(
+    MedusaError.Types.UNEXPECTED_STATE,
+    `All AI description providers failed. Tried — ${attempts.join(" | ")}`
+  )
 }

--- a/apps/backend/src/mastra/providers/__tests__/openrouter.unit.spec.ts
+++ b/apps/backend/src/mastra/providers/__tests__/openrouter.unit.spec.ts
@@ -1,0 +1,31 @@
+import { outputsText } from "../openrouter"
+import type { OpenRouterModel } from "../openrouter"
+
+const model = (id: string, output?: string[]): OpenRouterModel =>
+  ({
+    id,
+    architecture: {
+      input_modalities: ["text", "image"],
+      ...(output ? { output_modalities: output } : {}),
+    },
+  } as unknown as OpenRouterModel)
+
+describe("openrouter.outputsText", () => {
+  it("keeps vision→text models", () => {
+    expect(outputsText(model("qwen/qwen2.5-vl-72b-instruct:free", ["text"]))).toBe(true)
+  })
+
+  it("rejects audio/image generators that accept image input (the lyria bug)", () => {
+    expect(outputsText(model("google/lyria-3-pro-preview", ["audio"]))).toBe(false)
+    expect(outputsText(model("some/image-gen", ["image"]))).toBe(false)
+  })
+
+  it("keeps multi-output models that include text", () => {
+    expect(outputsText(model("x/multi", ["text", "image"]))).toBe(true)
+  })
+
+  it("keeps models that omit output_modalities (free chat models often do)", () => {
+    expect(outputsText(model("x/no-output-declared"))).toBe(true)
+    expect(outputsText(model("x/empty-output", []))).toBe(true)
+  })
+})

--- a/apps/backend/src/mastra/providers/openrouter.ts
+++ b/apps/backend/src/mastra/providers/openrouter.ts
@@ -100,6 +100,21 @@ export function filterByOutputModality(
   })
 }
 
+/**
+ * True if a model returns text output. Several free "image-input" models are
+ * actually audio/image GENERATORS (e.g. `google/lyria-3-*`) that accept an
+ * image but emit audio/music — never chat text. They produce un-parseable
+ * responses and waste 10-30s each in the vision fallback chain (the cause of
+ * the product-description 504s). We keep models that explicitly output text,
+ * or that omit `output_modalities` entirely (some free chat models don't
+ * declare it but are text models).
+ */
+export function outputsText(m: OpenRouterModel): boolean {
+  const out = m.architecture?.output_modalities
+  if (!out || out.length === 0) return true
+  return out.includes("text")
+}
+
 // Separate cache for vision models
 let cachedFreeVisionModels: OpenRouterModel[] = []
 let visionCacheTimestamp = 0
@@ -117,7 +132,9 @@ export async function getFreeVisionModels(): Promise<OpenRouterModel[]> {
   try {
     const allModels = await fetchAllModels()
     const freeModels = filterFreeModels(allModels)
-    cachedFreeVisionModels = filterByInputModality(freeModels, ["image"])
+    // Must accept image INPUT and return text OUTPUT (see outputsText).
+    const withImageInput = filterByInputModality(freeModels, ["image"])
+    cachedFreeVisionModels = withImageInput.filter(outputsText)
     visionCacheTimestamp = now
 
     // Sort by context length descending


### PR DESCRIPTION
## Problem
`POST /admin/products/:id/generateDescription` (admin product-description button) **504s**. Root-caused via prod CloudWatch logs (`/copilot/jyt-prod-medusa-server`):

- It called the **legacy OpenRouter-only** workflow, which auto-discovers "free vision models" filtering by **input** modality only. OpenRouter recently added audio/image-generator models (`google/lyria-3-*`) that *accept* image input but emit music — selected, returned un-parseable content, ~10–30s each.
- The fallback chain ran **~100s**, past the **60s ALB idle timeout** → 504 (backend often succeeded *after* the client already 504'd).
- It **ignored the admin-configured DashScope** platform (role `ai_product_description`, record `01KPT7…`), the intended default — which already works on the partner route (`/partners/ai/describe-image`, ~15s, verified live on prod).

## Fix
Ordered provider chain in the admin route (first success wins):
1. Configured AI platform via `describeProductImageWorkflow` — DashScope/Qwen-VL, role `ai_product_description` (~15s).
2. **OpenRouter free vision** fallback — now filtered to real vision→text models.

Aggregated error names what was tried if all fail (no bare 504). OpenRouter discovery now requires **text output** (new `outputsText` predicate), excluding audio/image-generator models; keeps models that omit `output_modalities`.

## Verification
- 4 unit tests on `outputsText` (incl. the lyria audio case) — pass.
- `tsc`: 69 baseline, **0 new** errors.
- DashScope path confirmed live on prod (partner endpoint, real product image → valid title/description in ~15s).

## Refs
- `apps/backend/src/api/admin/products/[id]/generateDescription/route.ts`
- `apps/backend/src/mastra/providers/openrouter.ts`
- `apps/backend/src/workflows/ai/describe-product-image.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)