### PR TITLE
infra(#494): Node 22 base image + isolated-vm as a hard dependency

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -7,7 +7,7 @@
 # Built from the repo root context: `docker build -f apps/backend/Dockerfile .`
 # -----------------------------------------------------------------------------
 
-FROM node:20-slim AS builder
+FROM node:22-slim AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       python3 build-essential curl ca-certificates git \
@@ -44,7 +44,7 @@ RUN pnpm run build
 # -----------------------------------------------------------------------------
 # Runtime image — ships only the compiled server and its prod deps.
 # -----------------------------------------------------------------------------
-FROM node:20-slim AS runtime
+FROM node:22-slim AS runtime
 
 ENV NODE_ENV=production
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -132,6 +132,7 @@
     "handlebars": "^4.7.8",
     "html2canvas-pro": "^1.5.8",
     "imapflow": "^1.2.10",
+    "isolated-vm": "^6.1.2",
     "js-yaml": "^4.1.1",
     "json-edit-react": "^1.27.2",
     "jszip": "^3.10.1",
@@ -176,9 +177,6 @@
     "validator": "^13.15.23",
     "zod": "^4.2.0"
   },
-  "optionalDependencies": {
-    "isolated-vm": "^6.1.2"
-  },
   "devDependencies": {
     "@medusajs/test-utils": "2.15.5",
     "@swc/core": "1.7.28",
@@ -210,6 +208,6 @@
     "yalc": "^1.0.0-pre.53"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,6 +348,9 @@ importers:
       imapflow:
         specifier: ^1.2.10
         version: 1.2.10
+      isolated-vm:
+        specifier: ^6.1.2
+        version: 6.1.2
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
@@ -562,10 +565,6 @@ importers:
       yalc:
         specifier: ^1.0.0-pre.53
         version: 1.0.0-pre.53
-    optionalDependencies:
-      isolated-vm:
-        specifier: ^6.1.2
-        version: 6.1.2
 
   apps/docs:
     dependencies:


### PR DESCRIPTION
## What & why

Implements the **approved infra decision** on #494 so the visual-flows `execute_code` **isolated-vm sandbox** can be enabled in production. Until now it was un-enableable because the prod image runs Node 20 (ABI 115) but `isolated-vm@6.1.2` ships prebuilds only for Node 22 (ABI 127) / Node 24 (ABI 137), and `medusa build` strips `optionalDependencies`.

## Changes
- **Dockerfile** — builder + runtime base image `node:20-slim` → `node:22-slim`.
- **package.json** — move `isolated-vm` `optionalDependencies` → `dependencies` (so `medusa build` includes it in `.medusa/server`); `engines.node` `">=20"` → `">=22"`.
- **pnpm-lock.yaml** — mirror the section move (same spec `^6.1.2`, same resolved `6.1.2`).
- `loadIsolatedVm()` is **unchanged** — keeps the indirect string specifier from #493 so the prod `tsc` build does not statically resolve the native addon (TS2307 stays closed).

## Safety
- **Sandbox stays OFF.** `VFLOW_USE_ISOLATED_VM` is unset; runtime behaviour is unchanged by this PR alone.
- v6 is **prebuildify** — install never compiles, so the runtime `pnpm install --ignore-scripts` is fine; no `python3`/`build-essential` needed in the runtime image.

## ⚠️ Human review — do NOT auto-merge
High blast radius: **every native dependency recompiles for the Node 22 ABI** on the next build. Before setting `VFLOW_USE_ISOLATED_VM=true` in SSM:
1. Verify a **full Docker boot** of the new image + **ECS run-task** isolate load (`node:22-slim` loaded + ran an isolate `=42` with zero build tools in earlier verification; `node:20-slim` → `gyp ERR! not ok`).
2. **Audit prod `execute_code` nodes for `options.packages`** — isolated mode rejects external npm packages, so a global flip can't happen if any live flow needs them.

Note: CI (`test-and-release.yml`) still runs Node 20.x — non-blocking here (no `engine-strict`; install never compiles; the module is only `require`d when the flag is on), but worth bumping CI Node in a follow-up.

Refs #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)