### PR TITLE
feat(ops): #485 resolveStoreCurrency + partner-order currency backfill job

### DIFF
--- a/apps/backend/integration-tests/http/ops-maintenance-jobs.spec.ts
+++ b/apps/backend/integration-tests/http/ops-maintenance-jobs.spec.ts
@@ -409,5 +409,48 @@ setupSharedTestSuite(() => {
       )
       expect(runs.data.count).toBeGreaterThanOrEqual(1)
     })
+
+    // #485 — partner order currency backfill
+    it("GET lists the backfill-partner-order-currency job with optional params", async () => {
+      const res = await api.get("/admin/ops/maintenance-jobs", adminHeaders)
+      expect(res.status).toBe(200)
+      const job = res.data.jobs.find(
+        (j: any) => j.id === "backfill-partner-order-currency"
+      )
+      expect(job).toBeDefined()
+      expect(job.label).toBeTruthy()
+      expect(job.description).toBeTruthy()
+      expect(job.params).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "partner_id", required: false }),
+          expect.objectContaining({ name: "from_currency", required: false }),
+          expect.objectContaining({ name: "limit", required: false }),
+        ])
+      )
+    })
+
+    it("POST backfill-partner-order-currency with no params is safe-by-default dry_run (no partners → no changes)", async () => {
+      const res = await api.post(
+        "/admin/ops/maintenance-jobs/backfill-partner-order-currency/run",
+        {},
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.result.job_id).toBe("backfill-partner-order-currency")
+      expect(res.data.result.dry_run).toBe(true)
+      expect(res.data.result.applied).toBe(false)
+      expect(res.data.result.changes).toEqual([])
+      expect(res.data.result.summary).toMatch(/scanned/i)
+    })
+
+    it("POST backfill-partner-order-currency rejects an invalid limit → 400", async () => {
+      await expect(
+        api.post(
+          "/admin/ops/maintenance-jobs/backfill-partner-order-currency/run",
+          { dry_run: true, params: { limit: -5 } },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
   })
 })

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/registry.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/registry.unit.spec.ts
@@ -5,6 +5,7 @@ import {
   computePruneCutoff,
   diffCostFields,
   diffEnergyCostFields,
+  diffOrderCurrency,
   diffRunCostFields,
   diffUnitCost,
   getMaintenanceJob,
@@ -14,12 +15,14 @@ import {
   MAX_BULK_DESIGNS,
   MAX_DESIGN_SCAN,
   MAX_INVENTORY_SCAN,
+  MAX_ORDER_CURRENCY_SCAN,
   parseDesignIds,
   pickLatestOrderLinePrice,
   round2,
   summarizeAuditPrune,
   summarizeBulkRecalc,
   summarizeEnergyBackfill,
+  summarizeOrderCurrencyBackfill,
   summarizeUnitCostBackfill,
 } from "../registry"
 
@@ -617,6 +620,68 @@ describe("ops/maintenance-jobs registry (#457)", () => {
 
     it("exposes a sane prune cap", () => {
       expect(MAX_AUDIT_PRUNE).toBeGreaterThanOrEqual(1000)
+    })
+  })
+
+  describe("backfill-partner-order-currency registry (#485)", () => {
+    it("registers the job with optional partner_id / from_currency / limit params", () => {
+      const job = getMaintenanceJob("backfill-partner-order-currency")
+      expect(job).toBeDefined()
+      expect(job?.params.some((p) => p.name === "partner_id" && !p.required)).toBe(true)
+      expect(job?.params.some((p) => p.name === "from_currency" && !p.required)).toBe(true)
+      expect(job?.params.some((p) => p.name === "limit" && !p.required)).toBe(true)
+    })
+
+    it("is included in the registry list", () => {
+      expect(MAINTENANCE_JOBS.map((j) => j.id)).toContain("backfill-partner-order-currency")
+    })
+
+    it("exposes a sane scan cap", () => {
+      expect(MAX_ORDER_CURRENCY_SCAN).toBeGreaterThanOrEqual(1000)
+    })
+  })
+
+  describe("diffOrderCurrency", () => {
+    it("returns a single currency_code change when the order is mis-denominated", () => {
+      expect(diffOrderCurrency("order_1", "eur", "inr")).toEqual([
+        { entity: "order", id: "order_1", field: "currency_code", before: "eur", after: "inr" },
+      ])
+    })
+
+    it("returns no change when already in the target currency (case-insensitive)", () => {
+      expect(diffOrderCurrency("order_1", "INR", "inr")).toEqual([])
+    })
+
+    it("normalizes a null before to a real change", () => {
+      expect(diffOrderCurrency("order_1", null, "inr")).toEqual([
+        { entity: "order", id: "order_1", field: "currency_code", before: null, after: "inr" },
+      ])
+    })
+
+    it("lower-cases both sides before comparing and emitting", () => {
+      expect(diffOrderCurrency("order_1", "EUR", "INR")).toEqual([
+        { entity: "order", id: "order_1", field: "currency_code", before: "eur", after: "inr" },
+      ])
+    })
+  })
+
+  describe("summarizeOrderCurrencyBackfill", () => {
+    it("reports no matches with partner + order counts", () => {
+      expect(summarizeOrderCurrencyBackfill(true, 3, 12, 0, "eur", 0)).toBe(
+        "No changes — scanned 12 order(s) across 3 partner(s), none denominated in 'eur' needed correction"
+      )
+    })
+
+    it("uses 'Would re-stamp' for dry-run", () => {
+      expect(summarizeOrderCurrencyBackfill(true, 2, 5, 4, "eur", 0)).toBe(
+        "Would re-stamp currency on 4 order(s) (scanned 5 across 2 partner(s), from 'eur')"
+      )
+    })
+
+    it("uses 'Re-stamped' on apply and appends error count", () => {
+      expect(summarizeOrderCurrencyBackfill(false, 2, 5, 4, "eur", 1)).toBe(
+        "Re-stamped currency on 4 order(s) (scanned 5 across 2 partner(s), from 'eur'); 1 error(s)"
+      )
     })
   })
 })

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -6,6 +6,8 @@ import { DESIGN_MODULE } from "../../../../modules/designs"
 import { PRODUCTION_RUNS_MODULE } from "../../../../modules/production_runs"
 import { RAW_MATERIAL_MODULE } from "../../../../modules/raw_material"
 import { OPS_AUDIT_MODULE } from "../../../../modules/ops_audit"
+import partnerOrderLink from "../../../../links/partner-order"
+import { resolveStoreCurrency } from "../../../../lib/resolve-store-currency"
 
 /**
  * Admin "data-plumbing" maintenance jobs (#457 / roadmap #33).
@@ -1357,6 +1359,218 @@ export const pruneOpsAuditRunsJob: MaintenanceJob = {
   },
 }
 
+/**
+ * Hard cap on the order-currency backfill scan. Bounds the per-request blast
+ * radius (each call reads partner→order links + order rows and may write
+ * order currency_code). Bigger sweeps raise `limit` across chunked calls.
+ */
+export const MAX_ORDER_CURRENCY_SCAN = 5000
+
+const backfillOrderCurrencyParamsSchema = z.object({
+  /** Restrict the sweep to a single partner instead of all partners. */
+  partner_id: z.string().min(1).optional(),
+  /**
+   * Only re-stamp orders currently denominated in this currency. Defaults to
+   * "eur" — the wrong platform-store currency that #485 stamped onto partner
+   * work-orders. Lower-cased before matching.
+   */
+  from_currency: z.string().min(1).optional().default("eur"),
+  /** Max unified orders to change in one call (1..MAX_ORDER_CURRENCY_SCAN). */
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_ORDER_CURRENCY_SCAN)
+    .optional()
+    .default(1000),
+})
+
+/**
+ * Pure: diff one unified order's currently-stored currency_code against the
+ * target (the owning partner's store currency). Returns a single currency_code
+ * change (or none when already equal, case-insensitively). Exported for unit
+ * testing — keeps the dry-run/apply selection verifiable without the DB.
+ */
+export function diffOrderCurrency(
+  orderId: string,
+  before: string | null | undefined,
+  after: string
+): MaintenanceChange[] {
+  const beforeNorm = before == null ? null : String(before).toLowerCase()
+  const afterNorm = after.toLowerCase()
+  if (beforeNorm === afterNorm) return []
+  return [
+    {
+      entity: "order",
+      id: orderId,
+      field: "currency_code",
+      before: beforeNorm,
+      after: afterNorm,
+    },
+  ]
+}
+
+/**
+ * Pure summary builder for the partner-order currency backfill — keeps the
+ * human-facing string verifiable without booting the DB.
+ */
+export function summarizeOrderCurrencyBackfill(
+  dryRun: boolean,
+  partnersScanned: number,
+  ordersScanned: number,
+  changedCount: number,
+  fromCurrency: string,
+  errorCount: number
+): string {
+  const verb = dryRun ? "Would re-stamp" : "Re-stamped"
+  const head =
+    changedCount === 0
+      ? `No changes — scanned ${ordersScanned} order(s) across ${partnersScanned} partner(s), none denominated in '${fromCurrency}' needed correction`
+      : `${verb} currency on ${changedCount} order(s) (scanned ${ordersScanned} across ${partnersScanned} partner(s), from '${fromCurrency}')`
+  return errorCount > 0 ? `${head}; ${errorCount} error(s)` : head
+}
+
+/**
+ * Backfill partner work-order currency (#485). On a multi-store deployment the
+ * historical `stores[0]` pattern stamped the platform store currency (EUR) onto
+ * every partner work-order / design reference instead of the partner's own
+ * store currency (INR). This job, for each partner, resolves the correct store
+ * currency (`resolveStoreCurrency`), reads that partner's unified orders via the
+ * D3 partner↔order link, and re-stamps any order still denominated in
+ * `from_currency` (default "eur") to the partner's store currency.
+ *
+ * This is a RELABEL, not a conversion: the amounts were entered in the partner's
+ * native currency (INR) all along — only the persisted `currency_code` was
+ * wrong (see apps/docs/notes/485_PARTNER_CURRENCY_EUR_ROOT_CAUSE.md). Dry-run
+ * (default) previews every before→after without persisting; apply writes
+ * `currency_code` via the order module (idempotent — re-running is a no-op once
+ * currencies match). A partner whose own store currency equals `from_currency`
+ * is skipped (nothing to correct). Bounded by `limit` changes per call.
+ */
+export const backfillPartnerOrderCurrencyJob: MaintenanceJob = {
+  id: "backfill-partner-order-currency",
+  label: "Backfill partner order currency",
+  description:
+    `Re-stamp partner work-order currency_code from the wrong platform-store currency (#485) to the owning partner's store currency. For each partner, resolves the partner store currency and re-labels their unified orders still denominated in 'from_currency' (default "eur"). This is a relabel, not an FX conversion — amounts were entered in the partner's native currency all along. Dry-run previews before/after without persisting; apply writes currency_code (idempotent). Optionally scope to one partner_id. Changes up to 'limit' orders per call (default 1000, max ${MAX_ORDER_CURRENCY_SCAN}).`,
+  params: [
+    {
+      name: "partner_id",
+      type: "string",
+      required: false,
+      description: "Restrict the sweep to a single partner (default: all partners)",
+    },
+    {
+      name: "from_currency",
+      type: "string",
+      required: false,
+      description: 'Only re-stamp orders currently in this currency (default "eur")',
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max orders to change in one call (default 1000, max ${MAX_ORDER_CURRENCY_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }) => {
+    const parsed = backfillOrderCurrencyParamsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { partner_id, from_currency, limit } = parsed.data
+    const fromCurrency = from_currency.toLowerCase()
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const orderService: any = container.resolve(Modules.ORDER)
+
+    // Target partners: a single id, or all partners (bounded — partners are few).
+    let partnerIds: string[]
+    if (partner_id) {
+      partnerIds = [partner_id]
+    } else {
+      const { data: partners } = await query.graph({
+        entity: "partners",
+        fields: ["id"],
+        pagination: { take: MAX_ORDER_CURRENCY_SCAN },
+      })
+      partnerIds = (partners ?? []).map((p: any) => p?.id).filter(Boolean)
+    }
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    let partnersScanned = 0
+    let ordersScanned = 0
+
+    for (const pid of partnerIds) {
+      if (changes.length >= limit) break
+      partnersScanned++
+      try {
+        const targetCurrency = await resolveStoreCurrency(container, { partnerId: pid })
+        // Partner's own currency equals the (wrong) source — nothing to fix.
+        if (targetCurrency.toLowerCase() === fromCurrency) continue
+
+        // Read the D3 partner↔order link table directly (source of truth) — the
+        // `partner.orders` graph accessor pluralisation isn't guaranteed.
+        const { data: linkRows } = await query.graph({
+          entity: partnerOrderLink.entryPoint,
+          fields: ["order_id"],
+          filters: { partner_id: pid },
+        })
+        const orderIds: string[] = Array.from(
+          new Set((linkRows ?? []).map((r: any) => r?.order_id).filter(Boolean))
+        )
+        if (!orderIds.length) continue
+
+        const { data: orders } = await query.graph({
+          entity: "order",
+          fields: ["id", "currency_code"],
+          filters: { id: orderIds, currency_code: fromCurrency },
+        })
+
+        for (const order of orders ?? []) {
+          if (changes.length >= limit) break
+          ordersScanned++
+          const orderChanges = diffOrderCurrency(
+            order.id,
+            order.currency_code,
+            targetCurrency
+          )
+          if (orderChanges.length === 0) continue
+
+          changes.push(...orderChanges)
+
+          if (!dry_run) {
+            await orderService.updateOrders([
+              { id: order.id, currency_code: targetCurrency },
+            ])
+          }
+        }
+      } catch (e: any) {
+        errors.push({ id: pid, message: e?.message ?? String(e) })
+      }
+    }
+
+    return {
+      job_id: backfillPartnerOrderCurrencyJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary: summarizeOrderCurrencyBackfill(
+        dry_run,
+        partnersScanned,
+        ordersScanned,
+        changes.length,
+        fromCurrency,
+        errors.length
+      ),
+      changes,
+      errors,
+    }
+  },
+}
+
 export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   recalculateDesignCostJob,
   recalculateDesignCostBulkJob,
@@ -1364,6 +1578,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   backfillInventoryUnitCostJob,
   backfillDesignEnergyCostJob,
   pruneOpsAuditRunsJob,
+  backfillPartnerOrderCurrencyJob,
 ]
 
 export const getMaintenanceJob = (id: string): MaintenanceJob | undefined =>

--- a/apps/backend/src/lib/__tests__/resolve-store-currency.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/resolve-store-currency.unit.spec.ts
@@ -1,0 +1,98 @@
+import {
+  pickDefaultCurrency,
+  resolveStoreCurrency,
+} from "../resolve-store-currency"
+
+// Pure / container-mocked unit coverage for the #485 currency resolver. No DB —
+// a fake container whose query.graph returns canned rows per entity.
+describe("resolve-store-currency (#485)", () => {
+  describe("pickDefaultCurrency", () => {
+    it("returns the is_default currency, lower-cased", () => {
+      expect(
+        pickDefaultCurrency({
+          supported_currencies: [
+            { currency_code: "USD", is_default: false },
+            { currency_code: "INR", is_default: true },
+          ],
+        })
+      ).toBe("inr")
+    })
+
+    it("falls back to 'inr' when no default flagged", () => {
+      expect(
+        pickDefaultCurrency({ supported_currencies: [{ currency_code: "usd" }] })
+      ).toBe("inr")
+    })
+
+    it("falls back when store/currencies missing", () => {
+      expect(pickDefaultCurrency(null)).toBe("inr")
+      expect(pickDefaultCurrency({})).toBe("inr")
+      expect(pickDefaultCurrency(undefined, "usd")).toBe("usd")
+    })
+  })
+
+  describe("resolveStoreCurrency", () => {
+    const makeContainer = (graph: (args: any) => any) => ({
+      resolve: () => ({ graph: async (args: any) => graph(args) }),
+    })
+
+    it("resolves the partner store currency when partnerId is given", async () => {
+      const container = makeContainer((args) => {
+        if (args.entity === "partners") {
+          return {
+            data: [
+              {
+                id: "p_1",
+                stores: [
+                  {
+                    supported_currencies: [
+                      { currency_code: "eur", is_default: false },
+                      { currency_code: "inr", is_default: true },
+                    ],
+                  },
+                ],
+              },
+            ],
+          }
+        }
+        // platform store (would be EUR) — must NOT be used here
+        return { data: [{ supported_currencies: [{ currency_code: "eur", is_default: true }] }] }
+      })
+
+      await expect(
+        resolveStoreCurrency(container, { partnerId: "p_1" })
+      ).resolves.toBe("inr")
+    })
+
+    it("falls back to the platform/base store when the partner has no store", async () => {
+      const container = makeContainer((args) => {
+        if (args.entity === "partners") return { data: [{ id: "p_1", stores: [] }] }
+        return { data: [{ supported_currencies: [{ currency_code: "eur", is_default: true }] }] }
+      })
+
+      await expect(
+        resolveStoreCurrency(container, { partnerId: "p_1" })
+      ).resolves.toBe("eur")
+    })
+
+    it("resolves the platform/base store when no partnerId is given", async () => {
+      const container = makeContainer((args) => {
+        if (args.entity === "store") {
+          return { data: [{ supported_currencies: [{ currency_code: "eur", is_default: true }] }] }
+        }
+        return { data: [] }
+      })
+
+      await expect(resolveStoreCurrency(container)).resolves.toBe("eur")
+    })
+
+    it("returns the fallback when nothing resolves", async () => {
+      const container = makeContainer(() => {
+        throw new Error("boom")
+      })
+      await expect(
+        resolveStoreCurrency(container, { fallback: "usd" })
+      ).resolves.toBe("usd")
+    })
+  })
+})

--- a/apps/backend/src/lib/resolve-store-currency.ts
+++ b/apps/backend/src/lib/resolve-store-currency.ts
@@ -1,0 +1,99 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+/**
+ * #485 — multi-store currency resolution.
+ *
+ * The deployment is multi-store (one platform store + one store per partner).
+ * The historical `stores[0]` pattern resolves the platform store (default
+ * currency EUR) for EVERY currency decision, so partner work-orders /
+ * design references get stamped EUR instead of the partner's own currency
+ * (INR). This helper centralises currency resolution so call sites can ask for
+ * "the partner's store currency" when a partner is in context, falling back to
+ * the platform/base store otherwise.
+ *
+ * See apps/docs/notes/485_PARTNER_CURRENCY_EUR_ROOT_CAUSE.md.
+ */
+
+/** Minimal shape of a store as returned by `query.graph` with supported_currencies expanded. */
+export type StoreCurrencyShape = {
+  supported_currencies?: Array<{
+    currency_code?: string | null
+    is_default?: boolean | null
+  } | null> | null
+}
+
+/**
+ * Pure: pick a store's default currency code (the supported currency flagged
+ * `is_default`), lower-cased. Returns `fallback` when the store is missing, has
+ * no supported currencies, or none is flagged default. Exported for unit
+ * testing — keeps the selection verifiable without booting the DB.
+ */
+export function pickDefaultCurrency(
+  store: StoreCurrencyShape | null | undefined,
+  fallback = "inr"
+): string {
+  const code = store?.supported_currencies?.find((c) => c?.is_default)?.currency_code
+  return (code ?? fallback).toLowerCase()
+}
+
+export type ResolveStoreCurrencyOpts = {
+  /**
+   * When provided, resolve the currency of the partner's linked store. Falls
+   * back to the platform/base store currency when the partner has no store or
+   * no default currency.
+   */
+  partnerId?: string | null
+  /** Returned when no store/currency can be resolved at all (default "inr"). */
+  fallback?: string
+}
+
+/**
+ * Resolve the currency code that should denominate work in the given context.
+ *
+ * - With `partnerId`: the partner's linked store default currency (the correct
+ *   denomination for partner work-orders / design references). Falls through to
+ *   the platform/base store when the partner has no usable store currency.
+ * - Without `partnerId`: the platform/base store default currency (the first
+ *   store — preserves the historical behaviour for partner-less contexts such
+ *   as inventory orders created admin-side before a partner is linked).
+ *
+ * Drop-in replacement for the `stores[0].supported_currencies[is_default]`
+ * pattern. Never throws — currency resolution is best-effort and always returns
+ * a usable code.
+ */
+export async function resolveStoreCurrency(
+  container: any,
+  opts: ResolveStoreCurrencyOpts = {}
+): Promise<string> {
+  const { partnerId, fallback = "inr" } = opts
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  if (partnerId) {
+    try {
+      const { data } = await query.graph({
+        entity: "partners",
+        // `stores.supported_currencies.*` MUST be expanded so the default-flag
+        // is present on the returned currencies (see api/partners/helpers.ts).
+        fields: ["id", "stores.supported_currencies.*"],
+        filters: { id: partnerId },
+      })
+      const partnerStore = data?.[0]?.stores?.[0]
+      const code = partnerStore?.supported_currencies?.find(
+        (c: any) => c?.is_default
+      )?.currency_code
+      if (code) return String(code).toLowerCase()
+    } catch {
+      // fall through to the platform/base store
+    }
+  }
+
+  try {
+    const { data: stores } = await query.graph({
+      entity: "store",
+      fields: ["supported_currencies.*"],
+    })
+    return pickDefaultCurrency(stores?.[0], fallback)
+  } catch {
+    return fallback.toLowerCase()
+  }
+}

--- a/apps/docs/notes/485_PARTNER_CURRENCY_EUR_ROOT_CAUSE.md
+++ b/apps/docs/notes/485_PARTNER_CURRENCY_EUR_ROOT_CAUSE.md
@@ -1,7 +1,12 @@
 # #485 — Partner UI shows EUR instead of store-default currency — Root Cause + Proposed Fix
 
-**Status:** ROOT-CAUSED (analysis). Blocked on a product decision before a fix can land.
-**Date:** 2026-06-18 (daemon chunk 1/6)
+**Status:** ROOT-CAUSED → **durable fix PARTIALLY SHIPPED** (daemon chunk 2/6).
+Decision approved (Option B, durable). Shipped: `resolveStoreCurrency` helper +
+`backfill-partner-order-currency` maintenance job (#457 pattern) + how-to doc
+(`OPS_DATA_PLUMBING_HOWTO.md`). **Still TODO:** rewire the 8 `stores[0]` call
+sites to `resolveStoreCurrency` (forward-fix; needs per-workflow integration
+tests) + the Settings-route Ops console UI (Playwright-gated).
+**Date:** 2026-06-18 (daemon chunk 1/6 analysis; chunk 2/6 partial build)
 **Surfaces:** partner-ui inventory-orders money cells; design references / design→order money.
 
 ---

--- a/apps/docs/notes/OPS_DATA_PLUMBING_HOWTO.md
+++ b/apps/docs/notes/OPS_DATA_PLUMBING_HOWTO.md
@@ -1,0 +1,122 @@
+# Ops Data-Plumbing — How-To (admin maintenance jobs)
+
+**Audience:** operators/admins running guarded data corrections.
+**Status:** backend live (#457 registry). Admin Ops-console UI is still pending
+(Playwright-gated — see "UI" below).
+
+---
+
+## What it is
+
+A registry of **guarded, dry-run-by-default** data-correction jobs exposed under
+`/admin/ops/maintenance-jobs`. Each job follows the same safe contract:
+
+- **dry-run (default)** → returns the changes it *would* make, **writes nothing**.
+- **apply** (`dry_run: false`) → idempotent write; returns the changes made.
+- every run is persisted to the durable **audit log** (`GET .../runs`).
+
+Jobs surface + guard-rail one-off scripts so the recurring "the code fix stops
+recurrence but stored rows still need a targeted, safe correction" incident no
+longer needs raw `curl` / ad-hoc ECS run-task scripts.
+
+## API
+
+```
+GET  /admin/ops/maintenance-jobs                 # list jobs + their params
+POST /admin/ops/maintenance-jobs/:id/run         # run a job (dry-run by default)
+GET  /admin/ops/maintenance-jobs/runs            # audit-log history (filter job_id, dry_run, applied)
+```
+
+Auth: admin (same headers as any `/admin/*` route). Prod: see
+`reference_prod_verify_access` (Basic auth, `v3.jaalyantra.com`).
+
+### Run payload
+
+```jsonc
+{
+  "dry_run": true,                 // default true; set false to APPLY
+  "params": { /* job-specific */ } // see GET list for each job's params
+}
+```
+
+### The golden workflow (ALWAYS)
+
+1. **List** → `GET /admin/ops/maintenance-jobs`, read the target job's `params`.
+2. **Dry-run** → `POST :id/run` with `dry_run: true` (or omit — it defaults true).
+   Inspect `result.changes` (every `before → after`) and `result.summary`.
+3. **Apply** → re-`POST` with `dry_run: false` **only after** the dry-run preview
+   looks right. Re-running is idempotent (a no-op once corrected).
+4. **Audit** → `GET .../runs?job_id=<id>` to confirm the persisted record.
+
+> Start narrow: most jobs accept a single-entity id (`design_id`,
+> `production_run_id`, `partner_id`) — correct ONE row, verify, then sweep.
+
+## Registered jobs
+
+| id | what it corrects |
+|---|---|
+| `recalculate-design-cost` / `-bulk` | design cost_breakdown vs fresh estimate |
+| `correct-production-run-cost` | per-unit × qty = total run cost |
+| `backfill-inventory-unit-cost` | raw_material.unit_cost from latest order line |
+| `backfill-design-energy-costs` | design energy/labor cost buckets |
+| `prune-ops-audit-runs` | retention/pruning of the audit log itself |
+| `backfill-partner-order-currency` | partner work-order `currency_code` (#485) |
+
+## Example — fix partner order currency (#485)
+
+On a multi-store deployment the old `stores[0]` pattern stamped the **platform**
+store currency (EUR) onto partner work-orders instead of the partner's own store
+currency (INR). The new code path (`resolveStoreCurrency`) prevents recurrence;
+the backfill job re-labels already-stamped rows.
+
+> This is a **relabel, not an FX conversion** — the amounts were entered in the
+> partner's native currency all along; only the `currency_code` column was wrong.
+
+```bash
+# 1. Dry-run for ONE partner (preview only)
+curl -X POST .../admin/ops/maintenance-jobs/backfill-partner-order-currency/run \
+  -H "$ADMIN_AUTH" -H 'Content-Type: application/json' \
+  -d '{ "dry_run": true, "params": { "partner_id": "partner_123" } }'
+# → result.changes: [{ entity:"order", field:"currency_code", before:"eur", after:"inr" }, ...]
+
+# 2. Apply for that partner
+curl -X POST .../admin/ops/maintenance-jobs/backfill-partner-order-currency/run \
+  -H "$ADMIN_AUTH" -H 'Content-Type: application/json' \
+  -d '{ "dry_run": false, "params": { "partner_id": "partner_123" } }'
+
+# 3. Sweep all partners (bounded by limit; chunk with limit + repeat)
+curl -X POST .../admin/ops/maintenance-jobs/backfill-partner-order-currency/run \
+  -H "$ADMIN_AUTH" -H 'Content-Type: application/json' \
+  -d '{ "dry_run": false, "params": { "limit": 1000 } }'
+```
+
+Params: `partner_id?` (scope to one partner), `from_currency?` (default `"eur"` —
+only re-stamps orders currently in this currency), `limit?` (default 1000, max
+5000 changes/call). A partner whose own store currency equals `from_currency` is
+skipped. Resolution uses `resolveStoreCurrency(container, { partnerId })`
+(`apps/backend/src/lib/resolve-store-currency.ts`).
+
+## Adding a new job (for engineers)
+
+Mirror an existing job in `apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts`:
+
+1. A **pure** diff helper (`diffXxx`) + **pure** summary builder (`summarizeXxx`)
+   — exported so the dry-run/apply selection is unit-testable without the DB.
+2. A zod `params` schema with sane caps (`MAX_*_SCAN`), parsed in `run`; throw
+   `MedusaError.Types.INVALID_DATA` on a bad param (→ 400).
+3. The `MaintenanceJob` object (`id`, `label`, `description`, `params[]`, `run`);
+   append it to `MAINTENANCE_JOBS`.
+4. Tests: pure-helper unit specs in `__tests__/registry.unit.spec.ts`
+   (`TEST_TYPE=unit`); a GET-lists + dry-run-safe + invalid-param-400 trio in
+   `integration-tests/http/ops-maintenance-jobs.spec.ts` (run per-file).
+
+The `:id/run` route persists an audit row best-effort (`buildAuditRow`) — no
+extra wiring needed.
+
+## UI (pending)
+
+A Settings-route admin console to list jobs, run dry-run→apply with a change
+preview, and browse `GET .../runs` history is **not built yet**. It's
+Playwright-gated (must be driven against a live `yarn dev` + screenshot, not
+unit-tested). Until then, drive the jobs via the API above. Mirror the admin
+dashboard patterns in `medusa-dev:building-admin-dashboard-customizations`.


### PR DESCRIPTION
## #485 — partner UI shows EUR instead of store-default currency (durable fix, part 1)

Multi-store deployments stamped the **platform** store currency (EUR) onto
partner work-orders via the legacy `stores[0]` pattern instead of the partner's
own store currency (INR). See `apps/docs/notes/485_PARTNER_CURRENCY_EUR_ROOT_CAUSE.md`.

This PR ships the **durable foundation + the data-correction**:

### 1. `resolveStoreCurrency` helper
`apps/backend/src/lib/resolve-store-currency.ts` — drop-in replacement for the
`stores[0].supported_currencies[is_default]` pattern:
- with `partnerId` → the partner's linked store default currency (correct
  denomination for partner work-orders / design refs); falls through to the
  platform/base store.
- without `partnerId` → platform/base store (preserves historical behaviour).
- never throws. Pure `pickDefaultCurrency` exported for testing.

### 2. `backfill-partner-order-currency` maintenance job (#457 pattern)
Guarded dry-run→apply job: for each partner, resolve the correct store currency
and **re-stamp** unified orders still denominated in `from_currency` (default
`"eur"`) via the D3 partner↔order link. **A relabel, not an FX conversion** —
amounts were entered in the partner's native currency all along. Params:
`partner_id?`, `from_currency?`, `limit?` (default 1000, max 5000). Idempotent.

### 3. How-to doc
`apps/docs/notes/OPS_DATA_PLUMBING_HOWTO.md` — operator guide for the whole
data-plumbing registry + the #485 example, and an "adding a new job" recipe.

## Tests
- Unit (`TEST_TYPE=unit`): `pickDefaultCurrency`, `resolveStoreCurrency` (mocked
  container), `diffOrderCurrency`, `summarizeOrderCurrencyBackfill` — **88 green**.
- Integration (per-file): GET-lists + safe-by-default dry-run + invalid-limit-400
  for the new job — **30 green** (`ops-maintenance-jobs.spec.ts`).
- `tsc`: **0 new errors** in changed files.

## Still TODO (follow-up chunks)
- Rewire the 8 `stores[0]` call sites to `resolveStoreCurrency` (forward-fix;
  needs per-workflow integration tests — see root-cause doc table).
- Settings-route Ops console UI (Playwright-gated; how-to doc has the contract).

Refs #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)