### PR TITLE
feat(currency): #485 centralise default-currency selection (forward-fix, part 2)

### DIFF
--- a/apps/backend/src/lib/__tests__/resolve-store-currency.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/resolve-store-currency.unit.spec.ts
@@ -29,6 +29,38 @@ describe("resolve-store-currency (#485)", () => {
       expect(pickDefaultCurrency({})).toBe("inr")
       expect(pickDefaultCurrency(undefined, "usd")).toBe("usd")
     })
+
+    // #485 forward-fix: pickDefaultCurrency replaced 3 hand-rolled is_default
+    // scans (create-draft-order-from-designs, dual-write-unified-order,
+    // dual-write-unified-run-order). Prove it reproduces the old inline
+    // expression byte-for-byte across the representative store shapes so the
+    // centralisation is behaviour-preserving.
+    describe("parity with the replaced inline is_default scans", () => {
+      // The exact expression that lived at every call site (mod lower-casing,
+      // which the replaced design site already did and is a no-op for the
+      // canonical lower-case currency codes stored by Medusa).
+      const inline = (store: any, fallback = "inr") =>
+        (store?.supported_currencies?.find((c: any) => c?.is_default)
+          ?.currency_code ?? fallback)
+
+      const shapes = [
+        { supported_currencies: [{ currency_code: "eur", is_default: true }] },
+        { supported_currencies: [
+          { currency_code: "usd", is_default: false },
+          { currency_code: "inr", is_default: true },
+        ] },
+        { supported_currencies: [{ currency_code: "usd", is_default: false }] }, // no default → fallback
+        { supported_currencies: [] },
+        {},
+        null,
+      ]
+
+      it.each(shapes)("matches inline scan for %j", (store) => {
+        expect(pickDefaultCurrency(store, "inr")).toBe(
+          String(inline(store, "inr")).toLowerCase()
+        )
+      })
+    })
   })
 
   describe("resolveStoreCurrency", () => {

--- a/apps/backend/src/workflows/designs/create-draft-order-from-designs.ts
+++ b/apps/backend/src/workflows/designs/create-draft-order-from-designs.ts
@@ -6,6 +6,7 @@ import {
 } from "@medusajs/framework/workflows-sdk"
 import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { DESIGN_MODULE } from "../../modules/designs"
+import { pickDefaultCurrency } from "../../lib/resolve-store-currency"
 import {
   estimateDesignCostWorkflow,
   EstimateCostOutput,
@@ -163,11 +164,10 @@ const convertEstimateCurrencyStep = createStep(
       fields: ["supported_currencies.currency_code", "supported_currencies.is_default"],
     })
 
-    const store = stores?.[0]
-    const defaultCurrency = (
-      store?.supported_currencies?.find((sc: any) => sc.is_default)?.currency_code ||
-      "inr"
-    ).toLowerCase()
+    // #485: single source of truth for default-currency selection (was a
+    // hand-rolled is_default scan). Partner-less context here, so the platform
+    // /base store currency is the correct FX base.
+    const defaultCurrency = pickDefaultCurrency(stores?.[0], "inr")
 
     // Collect unique source currencies we need rates for
     const sourceCurrencies = new Set<string>()

--- a/apps/backend/src/workflows/inventory_orders/dual-write-unified-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/dual-write-unified-order.ts
@@ -6,6 +6,7 @@ import type { LinkDefinition, MedusaContainer } from "@medusajs/framework/types"
 import { ORDER_INVENTORY_MODULE } from "../../modules/inventory_orders"
 import { PARTNER_MODULE } from "../../modules/partner"
 import { UNIFIED_ORDER_STATUS_MODULE } from "../../modules/unified_order_status"
+import { pickDefaultCurrency } from "../../lib/resolve-store-currency"
 
 // #342 T2 — best-effort projection of legacy inventory orders onto the core
 // `order` entity (kind=inventory = "the order↔inventory_order link exists";
@@ -255,9 +256,10 @@ export const dualWriteUnifiedOrderStep = createStep(
           skipped: "no_region",
         })
       }
-      const currencyCode =
-        store?.supported_currencies?.find((c: any) => c?.is_default)
-          ?.currency_code ?? "inr"
+      // #485: centralised default-currency selection. Partner is linked AFTER
+      // creation here, so the platform/base store currency is used at stamping
+      // time; the #457 backfill job re-stamps to the partner currency later.
+      const currencyCode = pickDefaultCurrency(store, "inr")
 
       // Internal sales channel keeps work-orders out of storefront analytics
       // and retail listings. Lazily ensured (idempotent) instead of a seed

--- a/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
+++ b/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
@@ -14,6 +14,7 @@ import {
   linkUnifiedOrderOrRollback,
   setUnifiedOrderPartnerStatus,
 } from "../inventory_orders/dual-write-unified-order"
+import { pickDefaultCurrency } from "../../lib/resolve-store-currency"
 
 // #342 T3.2 — best-effort projection of production runs onto the core `order`
 // entity (kind=design = "the order↔production_run link exists"; Chunk 6 retired
@@ -100,9 +101,10 @@ const resolveRegionAndCurrency = async (container: MedusaContainer) => {
     })
     regionId = regions?.[0]?.id
   }
-  const currencyCode =
-    store?.supported_currencies?.find((c: any) => c?.is_default)
-      ?.currency_code ?? "inr"
+  // #485: centralised default-currency selection (was a hand-rolled is_default
+  // scan). Partner is linked AFTER creation, so the platform/base store
+  // currency is stamped now; the #457 backfill re-stamps to partner currency.
+  const currencyCode = pickDefaultCurrency(store, "inr")
   return { regionId, currencyCode }
 }
 


### PR DESCRIPTION
## #485 forward-fix — part 2 (stacked on #505)

Part 1 (#505) added the `resolveStoreCurrency` / `pickDefaultCurrency` resolver + the backfill job. This part does the **"replacing all `stores[0]`" forward-fix** the user asked for, scoped to where it is **safe and meaningful**.

### What changed
Replaced the three hand-rolled `supported_currencies.find(is_default)?.currency_code ?? "inr"` scans with the shared pure `pickDefaultCurrency()`:
- `workflows/designs/create-draft-order-from-designs.ts` (FX base currency)
- `workflows/inventory_orders/dual-write-unified-order.ts`
- `workflows/production-runs/dual-write-unified-run-order.ts`

### Why only these three
Audited every currency call site:
- **whatsapp/create-draft-product-from-extraction.ts** is *already* partner-aware (queries `partners` → the partner's own store) — left untouched.
- The design **route** takes `currency_code` from the request body (defaults to INR, not EUR) — not a leak.
- The three dual-write/FX sites are **partner-less at stamping time** (partner is linked *after* order creation), so they correctly stamp the platform/base store currency now and are re-stamped to the partner currency by the #457 `backfill-partner-order-currency` job. Centralising them makes each one line away from partner-aware via `resolveStoreCurrency()`.

### Behaviour
Behaviour-preserving. `pickDefaultCurrency` lowercases + falls back to `inr` — a no-op for Medusa's canonical lower-case codes. A parity test block proves it reproduces the old inline expression across all representative store shapes.

### Tests
`resolve-store-currency.unit.spec.ts` — 13 unit (incl. 6 new parity cases) green (`TEST_TYPE=unit`). tsc: 0 new errors in changed files.

### Notes
- **Stacked on #505** (`feat/485-resolve-store-currency-backfill`) — the resolver helper isn't on `main` yet. Merge #505 first; if #505 is squash-merged with `--delete-branch`, GitHub auto-closes this PR — recover by re-pointing the base to `main` (or cherry-pick `a5aac7f51` onto fresh main).
- Do NOT merge — human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)