### PR TITLE
feat(admin): #485 Settings → Data Plumbing ops console UI

### DIFF
--- a/apps/backend/src/admin/hooks/api/ops-maintenance.ts
+++ b/apps/backend/src/admin/hooks/api/ops-maintenance.ts
@@ -1,0 +1,155 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { sdk } from "../../lib/config"
+import { queryKeysFactory } from "../../lib/query-key-factory"
+
+/**
+ * Admin Ops "data-plumbing" maintenance-jobs API hooks (#457 / #485).
+ * Thin react-query wrappers over the guarded job registry endpoints so the
+ * Settings → Data Plumbing console can list jobs, dry-run/apply them, and read
+ * the durable run history. Mirrors the existing admin hook style (sdk.client).
+ */
+
+export type MaintenanceJobParam = {
+  name: string
+  type: "string" | "number" | "boolean"
+  required: boolean
+  description: string
+}
+
+export type MaintenanceJobSummary = {
+  id: string
+  label: string
+  description: string
+  params: MaintenanceJobParam[]
+}
+
+export type MaintenanceChange = {
+  entity: string
+  id: string
+  field?: string
+  before?: unknown
+  after?: unknown
+}
+
+export type MaintenanceJobResult = {
+  job_id: string
+  dry_run: boolean
+  applied: boolean
+  summary: string
+  changes: MaintenanceChange[]
+  errors?: Array<{ id: string; message: string }>
+}
+
+export type RunJobResponse = {
+  result: MaintenanceJobResult
+  audit: {
+    actor_id: string
+    job_id: string
+    dry_run: boolean
+    applied: boolean
+    change_count: number
+    ran_at: string
+  }
+}
+
+export type MaintenanceRun = {
+  id: string
+  job_id: string
+  actor_id: string
+  dry_run: boolean
+  applied: boolean
+  change_count: number
+  error_count: number
+  summary: string
+  params: Record<string, unknown>
+  changes: MaintenanceChange[]
+  errors: Array<{ id: string; message: string }>
+  created_at: string
+  updated_at: string
+}
+
+export type ListJobsResponse = {
+  jobs: MaintenanceJobSummary[]
+  count: number
+}
+
+export type ListRunsResponse = {
+  runs: MaintenanceRun[]
+  count: number
+  limit: number
+  offset: number
+}
+
+export type RunsQuery = {
+  limit?: number
+  offset?: number
+  job_id?: string
+  dry_run?: boolean
+  applied?: boolean
+}
+
+const OPS_MAINTENANCE_QUERY_KEY = "ops_maintenance_jobs" as const
+export const opsMaintenanceQueryKeys = queryKeysFactory(
+  OPS_MAINTENANCE_QUERY_KEY
+)
+
+export const useMaintenanceJobs = () => {
+  const { data, ...rest } = useQuery({
+    queryKey: opsMaintenanceQueryKeys.list("jobs"),
+    queryFn: async () =>
+      sdk.client.fetch<ListJobsResponse>("/admin/ops/maintenance-jobs", {
+        method: "GET",
+      }),
+  })
+
+  return { ...rest, jobs: data?.jobs ?? [], count: data?.count ?? 0 }
+}
+
+export const useMaintenanceRuns = (query: RunsQuery = {}) => {
+  const { data, ...rest } = useQuery({
+    queryKey: opsMaintenanceQueryKeys.list(["runs", query]),
+    queryFn: async () =>
+      sdk.client.fetch<ListRunsResponse>("/admin/ops/maintenance-jobs/runs", {
+        method: "GET",
+        query: query as Record<string, unknown>,
+      }),
+  })
+
+  return {
+    ...rest,
+    runs: data?.runs ?? [],
+    count: data?.count ?? 0,
+  }
+}
+
+export const useRunMaintenanceJob = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      id,
+      dry_run,
+      params,
+    }: {
+      id: string
+      dry_run: boolean
+      params?: Record<string, unknown>
+    }) =>
+      sdk.client.fetch<RunJobResponse>(
+        `/admin/ops/maintenance-jobs/${id}/run`,
+        {
+          method: "POST",
+          body: { dry_run, params: params ?? {} },
+        }
+      ),
+    onSuccess: (_res, vars) => {
+      // Only an applied (non-dry) run mutates server state + writes a run row.
+      if (!vars.dry_run) {
+        queryClient.invalidateQueries({
+          queryKey: opsMaintenanceQueryKeys.lists(),
+        })
+      }
+    },
+  })
+}

--- a/apps/backend/src/admin/routes/settings/ops-data-plumbing/page.tsx
+++ b/apps/backend/src/admin/routes/settings/ops-data-plumbing/page.tsx
@@ -1,0 +1,395 @@
+import { defineRouteConfig } from "@medusajs/admin-sdk"
+import {
+  Container,
+  Heading,
+  Text,
+  Button,
+  Input,
+  Label,
+  Select,
+  Switch,
+  Badge,
+  Table,
+  Tabs,
+  toast,
+  usePrompt,
+} from "@medusajs/ui"
+import { Tools } from "@medusajs/icons"
+import { useMemo, useState } from "react"
+
+import {
+  useMaintenanceJobs,
+  useMaintenanceRuns,
+  useRunMaintenanceJob,
+  type MaintenanceJobSummary,
+  type MaintenanceJobResult,
+} from "../../../hooks/api/ops-maintenance"
+
+/**
+ * Settings → Data Plumbing (#457 / #485).
+ *
+ * Operator console over the guarded maintenance-jobs registry: pick a job,
+ * fill its params, PREVIEW (dry-run, no writes) then APPLY (confirmed). Shows
+ * the per-entity change diff and the durable run history. The job list is
+ * driven entirely by the backend, so new registry jobs appear automatically.
+ */
+
+type ParamValues = Record<string, string>
+
+const ChangesTable = ({ result }: { result: MaintenanceJobResult }) => {
+  if (!result.changes.length && !(result.errors?.length)) {
+    return (
+      <Text size="small" className="text-ui-fg-subtle">
+        No changes — data already consistent.
+      </Text>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      {result.changes.length > 0 && (
+        <Table>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>Entity</Table.HeaderCell>
+              <Table.HeaderCell>ID</Table.HeaderCell>
+              <Table.HeaderCell>Field</Table.HeaderCell>
+              <Table.HeaderCell>Before</Table.HeaderCell>
+              <Table.HeaderCell>After</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {result.changes.slice(0, 200).map((c, i) => (
+              <Table.Row key={`${c.entity}-${c.id}-${c.field ?? ""}-${i}`}>
+                <Table.Cell>{c.entity}</Table.Cell>
+                <Table.Cell className="font-mono text-xs">{c.id}</Table.Cell>
+                <Table.Cell>{c.field ?? "—"}</Table.Cell>
+                <Table.Cell className="font-mono text-xs">
+                  {formatValue(c.before)}
+                </Table.Cell>
+                <Table.Cell className="font-mono text-xs">
+                  {formatValue(c.after)}
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      )}
+
+      {result.changes.length > 200 && (
+        <Text size="small" className="text-ui-fg-subtle">
+          Showing first 200 of {result.changes.length} changes.
+        </Text>
+      )}
+
+      {result.errors && result.errors.length > 0 && (
+        <div className="rounded-md border border-ui-border-error bg-ui-bg-subtle p-3">
+          <Text size="small" weight="plus" className="text-ui-fg-error">
+            {result.errors.length} error(s)
+          </Text>
+          <ul className="mt-1 list-disc pl-5">
+            {result.errors.slice(0, 50).map((e, i) => (
+              <li key={`${e.id}-${i}`}>
+                <Text size="small" className="text-ui-fg-subtle">
+                  <span className="font-mono">{e.id}</span>: {e.message}
+                </Text>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}
+
+const formatValue = (v: unknown): string => {
+  if (v === null || v === undefined) return "—"
+  if (typeof v === "object") return JSON.stringify(v)
+  return String(v)
+}
+
+const RunBadge = ({ dry_run, applied }: { dry_run: boolean; applied: boolean }) => {
+  if (dry_run) return <Badge color="grey" size="2xsmall">dry-run</Badge>
+  if (applied) return <Badge color="green" size="2xsmall">applied</Badge>
+  return <Badge color="orange" size="2xsmall">no-op</Badge>
+}
+
+const JobRunner = ({ job }: { job: MaintenanceJobSummary }) => {
+  const prompt = usePrompt()
+  const runJob = useRunMaintenanceJob()
+  const [values, setValues] = useState<ParamValues>({})
+  const [result, setResult] = useState<MaintenanceJobResult | null>(null)
+
+  const buildParams = (): Record<string, unknown> => {
+    const out: Record<string, unknown> = {}
+    for (const p of job.params) {
+      const raw = values[p.name]
+      if (raw === undefined || raw === "") continue
+      if (p.type === "number") out[p.name] = Number(raw)
+      else if (p.type === "boolean") out[p.name] = raw === "true"
+      else out[p.name] = raw
+    }
+    return out
+  }
+
+  const missingRequired = job.params
+    .filter((p) => p.required)
+    .filter((p) => !values[p.name])
+    .map((p) => p.name)
+
+  const run = async (dry_run: boolean) => {
+    if (missingRequired.length) {
+      toast.error(`Missing required param(s): ${missingRequired.join(", ")}`)
+      return
+    }
+
+    if (!dry_run) {
+      const ok = await prompt({
+        title: `Apply ${job.label}?`,
+        description:
+          "This writes changes to the database. Run a dry-run first to preview. Continue?",
+        confirmText: "Apply",
+        cancelText: "Cancel",
+      })
+      if (!ok) return
+    }
+
+    try {
+      const res = await runJob.mutateAsync({
+        id: job.id,
+        dry_run,
+        params: buildParams(),
+      })
+      setResult(res.result)
+      toast.success(
+        dry_run
+          ? `Dry-run: ${res.result.changes.length} change(s) previewed`
+          : `Applied: ${res.result.changes.length} change(s)`
+      )
+    } catch (e: any) {
+      toast.error(e?.message ?? "Job run failed")
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-y-4 px-6 py-4">
+      <div>
+        <Text size="small" className="text-ui-fg-subtle">
+          {job.description}
+        </Text>
+      </div>
+
+      {job.params.length > 0 && (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          {job.params.map((p) => (
+            <div key={p.name} className="flex flex-col gap-y-1">
+              <Label size="small" weight="plus">
+                {p.name}
+                {p.required ? " *" : ""}
+              </Label>
+              {p.type === "boolean" ? (
+                <div className="flex items-center gap-x-2">
+                  <Switch
+                    checked={values[p.name] === "true"}
+                    onCheckedChange={(checked) =>
+                      setValues((v) => ({
+                        ...v,
+                        [p.name]: checked ? "true" : "false",
+                      }))
+                    }
+                  />
+                  <Text size="small" className="text-ui-fg-subtle">
+                    {values[p.name] === "true" ? "true" : "false"}
+                  </Text>
+                </div>
+              ) : (
+                <Input
+                  type={p.type === "number" ? "number" : "text"}
+                  value={values[p.name] ?? ""}
+                  placeholder={p.required ? "required" : "optional"}
+                  onChange={(e) =>
+                    setValues((v) => ({ ...v, [p.name]: e.target.value }))
+                  }
+                />
+              )}
+              <Text size="xsmall" className="text-ui-fg-muted">
+                {p.description}
+              </Text>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="flex items-center gap-x-2">
+        <Button
+          variant="secondary"
+          isLoading={runJob.isPending}
+          onClick={() => run(true)}
+        >
+          Preview (dry-run)
+        </Button>
+        <Button
+          variant="danger"
+          isLoading={runJob.isPending}
+          onClick={() => run(false)}
+        >
+          Apply
+        </Button>
+      </div>
+
+      {result && (
+        <div className="flex flex-col gap-y-2 rounded-md border border-ui-border-base p-4">
+          <div className="flex items-center gap-x-2">
+            <RunBadge dry_run={result.dry_run} applied={result.applied} />
+            <Text size="small" weight="plus">
+              {result.summary}
+            </Text>
+          </div>
+          <ChangesTable result={result} />
+        </div>
+      )}
+    </div>
+  )
+}
+
+const RunHistory = () => {
+  const { runs, isLoading } = useMaintenanceRuns({ limit: 20 })
+
+  if (isLoading) {
+    return (
+      <div className="px-6 py-4">
+        <Text size="small" className="text-ui-fg-subtle">
+          Loading run history…
+        </Text>
+      </div>
+    )
+  }
+
+  if (!runs.length) {
+    return (
+      <div className="px-6 py-4">
+        <Text size="small" className="text-ui-fg-subtle">
+          No applied runs yet. (Dry-runs are not persisted.)
+        </Text>
+      </div>
+    )
+  }
+
+  return (
+    <div className="px-6 py-4">
+      <Table>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>When</Table.HeaderCell>
+            <Table.HeaderCell>Job</Table.HeaderCell>
+            <Table.HeaderCell>State</Table.HeaderCell>
+            <Table.HeaderCell>Changes</Table.HeaderCell>
+            <Table.HeaderCell>Errors</Table.HeaderCell>
+            <Table.HeaderCell>Summary</Table.HeaderCell>
+            <Table.HeaderCell>Actor</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {runs.map((r) => (
+            <Table.Row key={r.id}>
+              <Table.Cell className="whitespace-nowrap">
+                {new Date(r.created_at).toLocaleString()}
+              </Table.Cell>
+              <Table.Cell className="font-mono text-xs">{r.job_id}</Table.Cell>
+              <Table.Cell>
+                <RunBadge dry_run={r.dry_run} applied={r.applied} />
+              </Table.Cell>
+              <Table.Cell>{r.change_count}</Table.Cell>
+              <Table.Cell>{r.error_count}</Table.Cell>
+              <Table.Cell className="max-w-[280px] truncate">
+                {r.summary}
+              </Table.Cell>
+              <Table.Cell className="font-mono text-xs">
+                {r.actor_id}
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+    </div>
+  )
+}
+
+const OpsDataPlumbingPage = () => {
+  const { jobs, isLoading, isError } = useMaintenanceJobs()
+  const [selectedId, setSelectedId] = useState<string | undefined>(undefined)
+
+  const selectedJob = useMemo(
+    () => jobs.find((j) => j.id === selectedId),
+    [jobs, selectedId]
+  )
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="px-6 py-4">
+        <Heading>Data Plumbing</Heading>
+        <Text className="text-ui-fg-subtle" size="small">
+          Run guarded data-correction jobs. Always Preview (dry-run) before you
+          Apply — dry-runs never write and are not logged; applied runs are
+          recorded below.
+        </Text>
+      </div>
+
+      <Tabs defaultValue="run">
+        <div className="px-6 pt-4">
+          <Tabs.List>
+            <Tabs.Trigger value="run">Run a job</Tabs.Trigger>
+            <Tabs.Trigger value="history">Run history</Tabs.Trigger>
+          </Tabs.List>
+        </div>
+
+        <Tabs.Content value="run">
+          <div className="flex flex-col gap-y-2 px-6 py-4">
+            <Label size="small" weight="plus">
+              Job
+            </Label>
+            {isLoading ? (
+              <Text size="small" className="text-ui-fg-subtle">
+                Loading jobs…
+              </Text>
+            ) : isError ? (
+              <Text size="small" className="text-ui-fg-error">
+                Failed to load jobs.
+              </Text>
+            ) : (
+              <Select value={selectedId} onValueChange={setSelectedId}>
+                <Select.Trigger className="max-w-md">
+                  <Select.Value placeholder="Select a maintenance job…" />
+                </Select.Trigger>
+                <Select.Content>
+                  {jobs.map((j) => (
+                    <Select.Item key={j.id} value={j.id}>
+                      {j.label}
+                    </Select.Item>
+                  ))}
+                </Select.Content>
+              </Select>
+            )}
+          </div>
+
+          {selectedJob && <JobRunner key={selectedJob.id} job={selectedJob} />}
+        </Tabs.Content>
+
+        <Tabs.Content value="history">
+          <RunHistory />
+        </Tabs.Content>
+      </Tabs>
+    </Container>
+  )
+}
+
+export default OpsDataPlumbingPage
+
+export const config = defineRouteConfig({
+  label: "Data Plumbing",
+  icon: Tools,
+})
+
+export const handle = {
+  breadcrumb: () => "Data Plumbing",
+}


### PR DESCRIPTION
## What

Adds the **Settings → Data Plumbing** admin console the user requested in #485 — a UI over the guarded `#457` maintenance-jobs registry so operators can run data-correction jobs (incl. the `backfill-partner-order-currency` job from #505) without raw curl / ECS run-task.

Closes the last remaining #485 item. The #485 backend is already done (PRs #505/#506); this is the operator surface.

## Files
- `apps/backend/src/admin/hooks/api/ops-maintenance.ts` — react-query hooks over `GET /admin/ops/maintenance-jobs`, `POST :id/run`, `GET /runs`.
- `apps/backend/src/admin/routes/settings/ops-data-plumbing/page.tsx` — `defineRouteConfig` settings route. Tabs (**Run a job** / **Run history**), backend-driven job `Select`, dynamic param form (string/number/boolean), required-param guard, **Preview (dry-run)** + **Apply** (confirmed via `usePrompt`), per-entity changes diff table, durable run-history table.

## Design notes
- **Backend-driven job list** — new registry jobs appear automatically; the UI invents no contract (mirrors existing settings pages: `production-run-policy`, `stats`).
- **Safe by default** — Preview = dry-run (no writes, not logged); Apply gated behind a confirm prompt. Matches the route's `dry_run` default-true contract.
- **Graceful degradation** — runs-history fetch errors fall back to an empty state (no crash).

## Verification
- `tsc --noEmit` — 0 errors in the new files.
- **Playwright against live `yarn dev` admin** (screenshots captured): route renders under Settings nav; 6 registry jobs listed; selecting *Recalculate design cost* shows its `design_id *` param + helper text; required-param guard fires ("Missing required param(s): design_id"); **Run history** tab renders the empty state.

## Watch-outs
- UI only — **do NOT merge** until human review (daemon convention; every merge auto-deploys ~18-45m).
- The `GET /runs` history endpoint relies on the `ops_audit` migration (#480, already on main); ensure prod migrations are applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)