### PR TITLE
feat(ops): #508 Data Plumbing v2 slice 2 — batch run endpoint

### DIFF
--- a/apps/backend/integration-tests/http/ops-maintenance-batches.spec.ts
+++ b/apps/backend/integration-tests/http/ops-maintenance-batches.spec.ts
@@ -1,0 +1,194 @@
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+
+jest.setTimeout(60 * 1000)
+
+/**
+ * #508 — Data Plumbing v2 batch run endpoint (POST /admin/ops/maintenance-jobs/
+ * batches). Stateless "A2": one call runs + records the whole batch.
+ *
+ * Covers the validator guards (empty jobs / >MAX_BATCH_JOBS / unknown id → 400),
+ * the safe-by-default dry_run, and — the core #508 contract — that a child job
+ * which throws is CAUGHT and recorded (continue-on-error) without aborting the
+ * request, while `stop_on_error` halts the rest. The clean children use the
+ * empty-DB safe jobs (no heavy seeding); the failing child uses a missing
+ * design id, which `recalculate-design-cost` rejects with NOT_FOUND.
+ */
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("admin ops maintenance-jobs batches (#508)", () => {
+    let adminHeaders: { headers: Record<string, string> }
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+    })
+
+    it("POST /batches with an empty jobs array → 400", async () => {
+      await expect(
+        api.post(
+          "/admin/ops/maintenance-jobs/batches",
+          { dry_run: true, jobs: [] },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+
+    it("POST /batches over the per-batch job cap → 400", async () => {
+      const jobs = Array.from({ length: 21 }, () => ({
+        job_id: "backfill-inventory-unit-cost",
+      }))
+      await expect(
+        api.post(
+          "/admin/ops/maintenance-jobs/batches",
+          { dry_run: true, jobs },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+
+    it("POST /batches with an unknown job id → 400 (validated up front)", async () => {
+      await expect(
+        api.post(
+          "/admin/ops/maintenance-jobs/batches",
+          {
+            dry_run: true,
+            jobs: [
+              { job_id: "backfill-inventory-unit-cost" },
+              { job_id: "no-such-job" },
+            ],
+          },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+
+    it("runs a clean 2-job dry-run batch (safe-by-default) and rolls it up", async () => {
+      const res = await api.post(
+        "/admin/ops/maintenance-jobs/batches",
+        {
+          name: "tenant cleanup preview",
+          jobs: [
+            { job_id: "backfill-inventory-unit-cost" },
+            { job_id: "backfill-design-energy-costs" },
+          ],
+        },
+        adminHeaders
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.data.batch.id).toBeTruthy()
+      expect(res.data.batch.name).toBe("tenant cleanup preview")
+      expect(res.data.batch.dry_run).toBe(true)
+      expect(res.data.batch.job_count).toBe(2)
+      expect(res.data.batch.applied_count).toBe(0)
+      expect(res.data.batch.failed_count).toBe(0)
+      expect(res.data.batch.summary).toMatch(/Previewed 2 job\(s\)/)
+
+      expect(res.data.results).toHaveLength(2)
+      expect(res.data.results.every((r: any) => r.ok)).toBe(true)
+      expect(res.data.results.map((r: any) => r.job_index)).toEqual([0, 1])
+      expect(res.data.results[0].result.job_id).toBe("backfill-inventory-unit-cost")
+    })
+
+    it("CATCHES a failing child and continues the batch (continue-on-error default)", async () => {
+      const res = await api.post(
+        "/admin/ops/maintenance-jobs/batches",
+        {
+          jobs: [
+            { job_id: "backfill-inventory-unit-cost" },
+            {
+              job_id: "recalculate-design-cost",
+              params: { design_id: "design_does_not_exist" },
+            },
+            { job_id: "backfill-design-energy-costs" },
+          ],
+        },
+        adminHeaders
+      )
+
+      // The thrown NOT_FOUND child did NOT abort the request.
+      expect(res.status).toBe(200)
+      expect(res.data.results).toHaveLength(3)
+      expect(res.data.results[0].ok).toBe(true)
+      expect(res.data.results[1].ok).toBe(false)
+      expect(res.data.results[1].job_id).toBe("recalculate-design-cost")
+      expect(res.data.results[1].error).toMatch(/not found/i)
+      expect(res.data.results[2].ok).toBe(true)
+
+      expect(res.data.batch.job_count).toBe(3)
+      expect(res.data.batch.failed_count).toBe(1)
+    })
+
+    it("halts the rest of the batch when stop_on_error=true", async () => {
+      const res = await api.post(
+        "/admin/ops/maintenance-jobs/batches",
+        {
+          stop_on_error: true,
+          jobs: [
+            {
+              job_id: "recalculate-design-cost",
+              params: { design_id: "design_does_not_exist" },
+            },
+            { job_id: "backfill-inventory-unit-cost" },
+          ],
+        },
+        adminHeaders
+      )
+
+      expect(res.status).toBe(200)
+      // Second job never ran — only the failing first child is recorded.
+      expect(res.data.results).toHaveLength(1)
+      expect(res.data.results[0].ok).toBe(false)
+      expect(res.data.batch.job_count).toBe(1)
+      expect(res.data.batch.failed_count).toBe(1)
+    })
+
+    it("persists the batch children as ops_maintenance_run rows tied via batch_id", async () => {
+      const runRes = await api.post(
+        "/admin/ops/maintenance-jobs/batches",
+        {
+          name: "audit linkage check",
+          jobs: [
+            { job_id: "backfill-inventory-unit-cost" },
+            {
+              job_id: "recalculate-design-cost",
+              params: { design_id: "design_does_not_exist" },
+            },
+          ],
+        },
+        adminHeaders
+      )
+      expect(runRes.status).toBe(200)
+      const batchId = runRes.data.batch.id
+      expect(batchId).toBeTruthy()
+
+      // The two children surface in the (v1) run-history reader.
+      const runs = await api.get(
+        "/admin/ops/maintenance-jobs/runs?limit=100",
+        adminHeaders
+      )
+      expect(runs.status).toBe(200)
+      const children = runs.data.runs.filter((r: any) => r.batch_id === batchId)
+      expect(children).toHaveLength(2)
+
+      const failed = children.find(
+        (r: any) => r.job_id === "recalculate-design-cost"
+      )
+      expect(failed).toBeDefined()
+      expect(failed.applied).toBe(false)
+      expect(failed.error_count).toBe(1)
+      expect(typeof failed.job_index).toBe("number")
+    })
+
+    it("requires admin auth (401 without headers)", async () => {
+      await expect(
+        api.post("/admin/ops/maintenance-jobs/batches", {
+          jobs: [{ job_id: "backfill-inventory-unit-cost" }],
+        })
+      ).rejects.toMatchObject({ response: { status: 401 } })
+    })
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/batch-executor.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/batch-executor.unit.spec.ts
@@ -1,0 +1,200 @@
+import { runBatch } from "../batch-executor"
+import type { BatchJobSpec, RunSingleJob } from "../batch-executor"
+import { buildBatchChildRow } from "../batch-audit"
+import type { BatchChildOutcome } from "../batch-audit"
+import type { MaintenanceJobResult } from "../registry"
+
+// Pure unit coverage for the #508 batch sequential executor + child-row mapper.
+// The executor's job is the one behaviour that MUST hold: a child that THROWS is
+// caught and recorded, and (by default) the rest of the batch still runs. We
+// inject a fake `runJob` so no container/registry/DB is needed.
+
+const result = (
+  job_id: string,
+  overrides: Partial<MaintenanceJobResult> = {}
+): MaintenanceJobResult => ({
+  job_id,
+  dry_run: true,
+  applied: false,
+  summary: `${job_id} preview`,
+  changes: [],
+  ...overrides,
+})
+
+describe("ops/maintenance-jobs runBatch (#508)", () => {
+  const jobs: BatchJobSpec[] = [
+    { job_id: "job-a", params: {} },
+    { job_id: "job-b", params: { x: 1 } },
+    { job_id: "job-c", params: {} },
+  ]
+
+  it("runs every job sequentially and returns ok outcomes in order", async () => {
+    const seen: string[] = []
+    const runJob: RunSingleJob = async (_c, jobId, opts) => {
+      seen.push(jobId)
+      expect(opts.dry_run).toBe(true)
+      return result(jobId)
+    }
+
+    const outcomes = await runBatch({} as any, {
+      jobs,
+      dry_run: true,
+      stop_on_error: false,
+      runJob,
+    })
+
+    expect(seen).toEqual(["job-a", "job-b", "job-c"])
+    expect(outcomes).toHaveLength(3)
+    expect(outcomes.every((o) => o.ok)).toBe(true)
+    expect(outcomes.map((o) => o.job_id)).toEqual(["job-a", "job-b", "job-c"])
+  })
+
+  it("passes the batch-level dry_run + per-job params through to each job", async () => {
+    const calls: Array<{ jobId: string; opts: any }> = []
+    const runJob: RunSingleJob = async (_c, jobId, opts) => {
+      calls.push({ jobId, opts })
+      return result(jobId, { dry_run: false })
+    }
+
+    await runBatch({} as any, {
+      jobs,
+      dry_run: false,
+      stop_on_error: false,
+      runJob,
+    })
+
+    expect(calls[1]).toEqual({
+      jobId: "job-b",
+      opts: { dry_run: false, params: { x: 1 } },
+    })
+    expect(calls.every((c) => c.opts.dry_run === false)).toBe(true)
+  })
+
+  it("CATCHES a thrown child and continues the batch (continue-on-error default)", async () => {
+    const runJob: RunSingleJob = async (_c, jobId) => {
+      if (jobId === "job-b") {
+        throw new Error("Region not found: reg_x")
+      }
+      return result(jobId)
+    }
+
+    const outcomes = await runBatch({} as any, {
+      jobs,
+      dry_run: true,
+      stop_on_error: false,
+      runJob,
+    })
+
+    // All three attempted — the throw did NOT abort the request.
+    expect(outcomes).toHaveLength(3)
+    expect(outcomes[0]).toMatchObject({ job_id: "job-a", ok: true })
+    expect(outcomes[1]).toEqual({
+      job_id: "job-b",
+      ok: false,
+      error: "Region not found: reg_x",
+    })
+    expect(outcomes[2]).toMatchObject({ job_id: "job-c", ok: true })
+  })
+
+  it("halts after the first failure when stop_on_error=true", async () => {
+    const seen: string[] = []
+    const runJob: RunSingleJob = async (_c, jobId) => {
+      seen.push(jobId)
+      if (jobId === "job-b") {
+        throw new Error("boom")
+      }
+      return result(jobId)
+    }
+
+    const outcomes = await runBatch({} as any, {
+      jobs,
+      dry_run: true,
+      stop_on_error: true,
+      runJob,
+    })
+
+    // job-c never ran — the loop broke after job-b failed.
+    expect(seen).toEqual(["job-a", "job-b"])
+    expect(outcomes).toHaveLength(2)
+    expect(outcomes[1]).toEqual({ job_id: "job-b", ok: false, error: "boom" })
+  })
+
+  it("handles an empty job list as a zero-outcome batch", async () => {
+    const outcomes = await runBatch({} as any, {
+      jobs: [],
+      dry_run: true,
+      stop_on_error: false,
+      runJob: async () => result("never"),
+    })
+    expect(outcomes).toEqual([])
+  })
+})
+
+describe("ops/maintenance-jobs buildBatchChildRow (#508)", () => {
+  it("maps a successful child to a batch-stamped audit row", () => {
+    const outcome: BatchChildOutcome = {
+      job_id: "repair-partner-region-links",
+      ok: true,
+      result: result("repair-partner-region-links", {
+        dry_run: false,
+        applied: true,
+        changes: [
+          { entity: "partner_region", id: "p1", field: "region_id", before: null, after: "reg_1" },
+        ],
+        errors: [{ id: "bad", message: "skip" }],
+      }),
+    }
+
+    const row = buildBatchChildRow(outcome, {
+      actorId: "user_1",
+      params: { partner_id: "p1" },
+      dryRun: false,
+      batchId: "batch_1",
+      jobIndex: 0,
+    })
+
+    expect(row).toMatchObject({
+      job_id: "repair-partner-region-links",
+      actor_id: "user_1",
+      dry_run: false,
+      applied: true,
+      change_count: 1,
+      error_count: 1,
+      params: { partner_id: "p1" },
+      batch_id: "batch_1",
+      job_index: 0,
+    })
+    expect(row.changes).toHaveLength(1)
+  })
+
+  it("maps a thrown child to a not-applied, error-carrying row using the batch dry_run", () => {
+    const outcome: BatchChildOutcome = {
+      job_id: "job-throws",
+      ok: false,
+      error: "Region not found: reg_x",
+    }
+
+    const row = buildBatchChildRow(outcome, {
+      actorId: "user_1",
+      params: { region_id: "reg_x" },
+      dryRun: true,
+      batchId: "batch_2",
+      jobIndex: 3,
+    })
+
+    expect(row).toEqual({
+      job_id: "job-throws",
+      actor_id: "user_1",
+      dry_run: true,
+      applied: false,
+      change_count: 0,
+      error_count: 1,
+      summary: "Job failed: Region not found: reg_x",
+      params: { region_id: "reg_x" },
+      changes: [],
+      errors: [{ id: "job-throws", message: "Region not found: reg_x" }],
+      batch_id: "batch_2",
+      job_index: 3,
+    })
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/batch-audit.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/batch-audit.ts
@@ -1,4 +1,6 @@
 import type { MaintenanceJobResult } from "./registry"
+import { buildAuditRow } from "./audit"
+import type { OpsMaintenanceRunRow } from "./audit"
 
 /**
  * Normalized outcome of one child job within a batch run (Data Plumbing v2,
@@ -83,5 +85,59 @@ export function buildBatchRollup(
     change_count,
     error_count,
     summary,
+  }
+}
+
+/**
+ * A persistable child run row tied to its parent batch (#508). Reuses the v1
+ * `ops_maintenance_run` shape (so the run-history reader is unchanged) plus the
+ * `batch_id`/`job_index` denormalized references added in slice 1.
+ */
+export type OpsMaintenanceBatchChildRow = OpsMaintenanceRunRow & {
+  batch_id: string
+  job_index: number
+}
+
+/**
+ * Pure mapper: one child outcome → a persistable `ops_maintenance_run` row
+ * stamped with its parent `batch_id` + `job_index`. A successful child reuses
+ * the v1 `buildAuditRow` (identical shape to a single-job run). A child that
+ * THREW has no result, so it's recorded as a not-applied, zero-change row whose
+ * `errors` carries the caught message — mirroring how per-entity batch jobs
+ * record a bad id, but at the job level. `dry_run` comes from the batch (a
+ * thrown child never reports its own). Exported for unit testing — no DB.
+ */
+export function buildBatchChildRow(
+  outcome: BatchChildOutcome,
+  meta: {
+    actorId: string
+    params: Record<string, unknown>
+    dryRun: boolean
+    batchId: string
+    jobIndex: number
+  }
+): OpsMaintenanceBatchChildRow {
+  if (outcome.ok && outcome.result) {
+    return {
+      ...buildAuditRow(outcome.result, meta.actorId, meta.params),
+      batch_id: meta.batchId,
+      job_index: meta.jobIndex,
+    }
+  }
+
+  const message = outcome.error ?? "Unknown error"
+  return {
+    job_id: outcome.job_id,
+    actor_id: meta.actorId,
+    dry_run: meta.dryRun,
+    applied: false,
+    change_count: 0,
+    error_count: 1,
+    summary: `Job failed: ${message}`,
+    params: meta.params,
+    changes: [],
+    errors: [{ id: outcome.job_id, message }],
+    batch_id: meta.batchId,
+    job_index: meta.jobIndex,
   }
 }

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/batch-executor.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/batch-executor.ts
@@ -1,0 +1,94 @@
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { getMaintenanceJob } from "./registry"
+import type { MaintenanceJobResult } from "./registry"
+import type { BatchChildOutcome } from "./batch-audit"
+
+/**
+ * One job spec inside a batch run (Data Plumbing v2, #508) — a registry job id
+ * plus its (already object-validated) params. The per-job param shape is
+ * validated by the job's own zod schema when it runs.
+ */
+export type BatchJobSpec = {
+  job_id: string
+  params: Record<string, unknown>
+}
+
+/**
+ * Single-job runner signature. Injected into `runBatch` so the sequential
+ * executor (the part that MUST catch per-job errors) is unit-testable without
+ * booting the container, the registry, or any real job. (#508)
+ */
+export type RunSingleJob = (
+  container: any,
+  jobId: string,
+  opts: { dry_run: boolean; params: Record<string, unknown> }
+) => Promise<MaintenanceJobResult>
+
+/**
+ * Default runner: resolve the job from the registry and run it. A genuinely
+ * unknown id throws NOT_FOUND (the batch route validates ids up front, so this
+ * is a defensive fallback only).
+ */
+export const defaultRunSingleJob: RunSingleJob = async (
+  container,
+  jobId,
+  opts
+) => {
+  const job = getMaintenanceJob(jobId)
+  if (!job) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Unknown maintenance job: ${jobId}`
+    )
+  }
+  return job.run(container, opts)
+}
+
+/**
+ * Run a batch of maintenance jobs SEQUENTIALLY under a single batch-level
+ * `dry_run`. Each child runs in order; a child that throws (e.g. a per-job
+ * `MedusaError` from a bad id or invalid param) is CAUGHT and recorded as a
+ * failed outcome — it does NOT abort the request the way the single-job
+ * `:id/run` route does. This is the core #508 contract: one bad job never sinks
+ * the whole batch.
+ *
+ * With `stop_on_error=true` the loop halts after the first failure (for ordered
+ * / dependent batches); the already-attempted outcomes are still returned. With
+ * the default `stop_on_error=false` every job is attempted regardless.
+ *
+ * Returns the per-child outcomes in execution order; the caller rolls them up
+ * (`buildBatchRollup`) and persists the parent + child audit rows.
+ */
+export async function runBatch(
+  container: any,
+  opts: {
+    jobs: BatchJobSpec[]
+    dry_run: boolean
+    stop_on_error: boolean
+    /** Injectable for unit testing — defaults to the registry-backed runner. */
+    runJob?: RunSingleJob
+  }
+): Promise<BatchChildOutcome[]> {
+  const runJob = opts.runJob ?? defaultRunSingleJob
+  const outcomes: BatchChildOutcome[] = []
+
+  for (const spec of opts.jobs) {
+    try {
+      const result = await runJob(container, spec.job_id, {
+        dry_run: opts.dry_run,
+        params: spec.params,
+      })
+      outcomes.push({ job_id: spec.job_id, ok: true, result })
+    } catch (e: any) {
+      outcomes.push({
+        job_id: spec.job_id,
+        ok: false,
+        error: e?.message ?? String(e),
+      })
+      if (opts.stop_on_error) break
+    }
+  }
+
+  return outcomes
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/batches/route.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/batches/route.ts
@@ -1,0 +1,109 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+
+import { getMaintenanceJob } from "../registry"
+import { OpsMaintenanceBatchBody } from "../validators"
+import { runBatch } from "../batch-executor"
+import type { BatchJobSpec } from "../batch-executor"
+import { buildBatchRollup, buildBatchChildRow } from "../batch-audit"
+import { OPS_AUDIT_MODULE } from "../../../../../modules/ops_audit"
+
+/**
+ * POST /admin/ops/maintenance-jobs/batches
+ *
+ * Run several guarded maintenance jobs as ONE sequential batch (Data Plumbing
+ * v2, #508). Stateless "A2": this single call runs + records the whole batch —
+ * Preview and Apply are two calls with `dry_run` flipped. Safe by default:
+ * `dry_run` defaults to true, so a body with only `jobs` previews without
+ * writing.
+ *
+ * Contract:
+ *   - Jobs run sequentially under one batch-level `dry_run`.
+ *   - A child job that throws is CAUGHT and recorded as a failed child — it does
+ *     NOT abort the request (unlike the single-job `:id/run` route). Pass
+ *     `stop_on_error=true` to halt after the first failure.
+ *   - Persists one `ops_maintenance_batch` parent (rollup) + one
+ *     `ops_maintenance_run` child per attempted job (best-effort: the
+ *     corrections already ran, so an audit-write failure never fails the
+ *     request).
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const body = (req.validatedBody ?? {}) as OpsMaintenanceBatchBody
+
+  const jobs: BatchJobSpec[] = body.jobs.map((j) => ({
+    job_id: j.job_id,
+    params: (j.params ?? {}) as Record<string, unknown>,
+  }))
+  const dry_run = body.dry_run ?? true
+  const stop_on_error = body.stop_on_error ?? false
+  const name = body.name?.trim() || `Batch of ${jobs.length} job(s)`
+
+  // Validate every job id against the registry UP FRONT → 400. A single unknown
+  // id fails the whole batch before any job runs (an unknown id is a caller
+  // mistake, distinct from a job that runs and then throws).
+  const unknown = [
+    ...new Set(jobs.filter((j) => !getMaintenanceJob(j.job_id)).map((j) => j.job_id)),
+  ]
+  if (unknown.length > 0) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Unknown maintenance job(s): ${unknown.join(", ")}`
+    )
+  }
+
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  const actorId = (req as any).auth_context?.actor_id ?? "unknown"
+
+  // Sequential run — per-job errors are caught inside runBatch.
+  const outcomes = await runBatch(req.scope, { jobs, dry_run, stop_on_error })
+
+  const rollup = buildBatchRollup(outcomes, {
+    name,
+    actorId,
+    dryRun: dry_run,
+    stopOnError: stop_on_error,
+  })
+
+  logger.info(
+    `[ops/maintenance] batch actor=${actorId} name="${name}" dry_run=${dry_run} jobs=${rollup.job_count} applied=${rollup.applied_count} failed=${rollup.failed_count} changes=${rollup.change_count}`
+  )
+
+  // Durable audit — best-effort: the corrections already happened, so an
+  // audit-write failure must NOT fail the request. (#508, mirrors #457)
+  let batchId: string | null = null
+  try {
+    const audit: any = req.scope.resolve(OPS_AUDIT_MODULE)
+    const batch = await audit.createOpsMaintenanceBatches(rollup)
+    batchId = batch.id
+
+    const childRows = outcomes.map((outcome, i) =>
+      buildBatchChildRow(outcome, {
+        actorId,
+        params: jobs[i].params,
+        dryRun: dry_run,
+        batchId: batch.id,
+        jobIndex: i,
+      })
+    )
+    if (childRows.length > 0) {
+      await audit.createOpsMaintenanceRuns(childRows)
+    }
+  } catch (e: any) {
+    logger.error(`[ops/maintenance] batch audit persist failed: ${e?.message ?? e}`)
+  }
+
+  res.json({
+    batch: {
+      id: batchId,
+      ...rollup,
+      ran_at: new Date().toISOString(),
+    },
+    results: outcomes.map((o, i) => ({
+      job_id: o.job_id,
+      job_index: i,
+      ok: o.ok,
+      result: o.result,
+      error: o.error,
+    })),
+  })
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/validators.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/validators.ts
@@ -34,3 +34,40 @@ export const OpsMaintenanceRunsQuerySchema = z.object({
 })
 
 export type OpsMaintenanceRunsQuery = z.infer<typeof OpsMaintenanceRunsQuerySchema>
+
+/**
+ * Hard cap on jobs per batch (Data Plumbing v2, #508). Each child job runs
+ * synchronously in sequence, so we bound the per-request blast radius and keep
+ * the endpoint responsive. Bigger corrections are split across batch calls.
+ */
+export const MAX_BATCH_JOBS = 20
+
+/**
+ * Body for POST /admin/ops/maintenance-jobs/batches (#508).
+ *
+ * Stateless "A2": one call runs + records the whole batch. Preview and Apply are
+ * two separate calls with `dry_run` flipped (defaults to true — safe by
+ * default). The batch is sequential with a single batch-level `dry_run`; a child
+ * job that throws is CAUGHT and recorded (continue-on-error) unless
+ * `stop_on_error=true`. Per-job `params` are validated inside each job's own
+ * schema — here we only accept an object (same record() shape as the run route).
+ */
+export const OpsMaintenanceBatchSchema = z.object({
+  name: z.string().min(1).max(200).optional(),
+  dry_run: z.boolean().optional(),
+  stop_on_error: z.boolean().optional(),
+  jobs: z
+    .array(
+      z.object({
+        job_id: z.string().min(1, "job_id is required"),
+        params: z.record(z.string(), z.any()).optional(),
+      })
+    )
+    .min(1, "jobs must contain at least one job")
+    .max(
+      MAX_BATCH_JOBS,
+      `jobs exceeds the per-batch limit of ${MAX_BATCH_JOBS}`
+    ),
+})
+
+export type OpsMaintenanceBatchBody = z.infer<typeof OpsMaintenanceBatchSchema>

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -17,7 +17,7 @@ import { parseCorsOrigins, ContainerRegistrationKeys } from "@medusajs/framework
 import cors from "cors";
 import { z } from "@medusajs/framework/zod";
 import { personSchema, listPersonsQuerySchema, UpdatePersonSchema, ReadPersonQuerySchema } from "./admin/persons/validators";
-import { OpsMaintenanceRunSchema, OpsMaintenanceRunsQuerySchema } from "./admin/ops/maintenance-jobs/validators";
+import { OpsMaintenanceRunSchema, OpsMaintenanceRunsQuerySchema, OpsMaintenanceBatchSchema } from "./admin/ops/maintenance-jobs/validators";
 import { getPersonResourceDefinition } from "./admin/persons/resources/registry";
 import { AdminGetOrdersOrderParams } from "@medusajs/medusa/api/admin/orders/validators";
 import { retrieveTransformQueryConfig as retrieveOrderTransformQueryConfig } from "@medusajs/medusa/api/admin/orders/query-config";
@@ -2963,6 +2963,12 @@ export default defineMiddlewares({
       matcher: "/admin/ops/maintenance-jobs/runs",
       method: "GET",
       middlewares: [validateAndTransformQuery(wrapSchema(OpsMaintenanceRunsQuerySchema), {})],
+    },
+    {
+      // #508 ops maintenance-jobs batch run (Data Plumbing v2)
+      matcher: "/admin/ops/maintenance-jobs/batches",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(OpsMaintenanceBatchSchema))],
     },
     // NOTE: /admin/* routes already get Medusa's default admin auth
     // (session + bearer + api-key). Re-registering authenticate() with only


### PR DESCRIPTION
## #508 Data Plumbing v2 — slice 2 (stacked on PR #510)

> **Base = `feat/508-batch-model` (PR #510).** Review/merge #510 first; this PR's diff is only slice 2. All #508 decisions are locked in the issue.

Adds the stateless **A2** batch run endpoint on top of slice 1's `ops_maintenance_batch` schema.

### Endpoint
`POST /admin/ops/maintenance-jobs/batches` — runs several guarded jobs **sequentially** under one named batch and records the rollup + child rows in a **single call**. Preview & Apply = two calls with `dry_run` flipped (defaults `true`, safe by default). No saved/re-runnable batch lifecycle.

### Locked-decision compliance
- **(2) Stateless A2** — one call runs + records; no draft lifecycle.
- **(3) Sequential, batch-level single `dry_run`.**
- **(4) Continue-on-error default + `stop_on_error` opt-in.** The executor **CATCHES per-job `MedusaError`** so one bad job never aborts the request — the single-job `:id/run` route lets the throw abort; that behaviour deliberately does **not** carry over.
- **(5) `MAX_BATCH_JOBS = 20`** enforced in the zod validator.
- Job ids validated against the registry **up front → 400** (unknown id is a caller mistake, distinct from a job that runs then throws).
- Guard never weakened: `dry_run` defaults true; audit persist is best-effort (a write failure never fails the corrections).

### Files
- `batch-executor.ts` — injectable `runBatch()` (the catch/sequence/stop logic, unit-testable without a container).
- `validators.ts` — `OpsMaintenanceBatchSchema` + `MAX_BATCH_JOBS`.
- `batch-audit.ts` — `buildBatchChildRow` (child outcome → batch-stamped `ops_maintenance_run` row; thrown child = not-applied, error-carrying).
- `batches/route.ts` — endpoint (registry-id 400, rollup via `buildBatchRollup`, persists 1 parent + N children).
- `middlewares.ts` — wire the matcher.

### Tests
- **7 unit** (`batch-executor.unit.spec.ts`): sequencing, dry_run/params passthrough, catch-and-continue, stop-on-error halt, empty batch, child-row mapper (success + thrown).
- **8 per-file integration** (`ops-maintenance-batches.spec.ts`): empty/over-cap/unknown-id → 400, clean 2-job dry-run rollup, continue-on-error, stop-on-error, `batch_id` child linkage via `GET /runs`, 401.
- Full `tsc --noEmit` clean (0 errors).

### Next slice
Slice 3 = batch history endpoints (index list of batches + per-run detail). Then the 3 approved jobs (one PR each), UI last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)