### PR TITLE
feat(ops): #508 Data Plumbing v2 — slice 3: batch-run history endpoints

### DIFF
--- a/apps/backend/integration-tests/http/ops-maintenance-batches-history.spec.ts
+++ b/apps/backend/integration-tests/http/ops-maintenance-batches-history.spec.ts
@@ -1,0 +1,146 @@
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+
+jest.setTimeout(60 * 1000)
+
+/**
+ * #508 — Data Plumbing v2 batch-run HISTORY endpoints (slice 3):
+ *   - GET /admin/ops/maintenance-jobs/batches        → paginated index of
+ *     `ops_maintenance_batch` parents (newest first; dry_run/actor_id filters).
+ *   - GET /admin/ops/maintenance-jobs/batches/:id     → one batch + its child
+ *     `ops_maintenance_run` rows in `job_index` order (404 on unknown id).
+ *
+ * Seeds history by POSTing real batches (the slice-2 run endpoint) with empty-DB
+ * safe jobs, then reads it back. Mirrors the `/runs` reader envelope.
+ */
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("admin ops maintenance-jobs batch history (#508)", () => {
+    let adminHeaders: { headers: Record<string, string> }
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+    })
+
+    const runBatch = async (body: Record<string, unknown>) => {
+      const res = await api.post(
+        "/admin/ops/maintenance-jobs/batches",
+        body,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      return res.data.batch.id as string
+    }
+
+    it("GET /batches lists batch parents newest-first with the list envelope", async () => {
+      const firstId = await runBatch({
+        name: "history batch one",
+        jobs: [{ job_id: "backfill-inventory-unit-cost" }],
+      })
+      const secondId = await runBatch({
+        name: "history batch two",
+        jobs: [
+          { job_id: "backfill-inventory-unit-cost" },
+          { job_id: "backfill-design-energy-costs" },
+        ],
+      })
+
+      const res = await api.get(
+        "/admin/ops/maintenance-jobs/batches?limit=50",
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data).toMatchObject({ limit: 50, offset: 0 })
+      expect(typeof res.data.count).toBe("number")
+      expect(Array.isArray(res.data.batches)).toBe(true)
+
+      const ids = res.data.batches.map((b: any) => b.id)
+      expect(ids).toContain(firstId)
+      expect(ids).toContain(secondId)
+
+      // Newest-first: the later batch sorts ahead of the earlier one.
+      expect(ids.indexOf(secondId)).toBeLessThan(ids.indexOf(firstId))
+
+      const second = res.data.batches.find((b: any) => b.id === secondId)
+      expect(second.name).toBe("history batch two")
+      expect(second.job_count).toBe(2)
+      expect(second.dry_run).toBe(true)
+    })
+
+    it("GET /batches?dry_run=false filters to applied batches only", async () => {
+      const previewId = await runBatch({
+        name: "preview only",
+        dry_run: true,
+        jobs: [{ job_id: "backfill-inventory-unit-cost" }],
+      })
+      const appliedId = await runBatch({
+        name: "applied run",
+        dry_run: false,
+        jobs: [{ job_id: "backfill-inventory-unit-cost" }],
+      })
+
+      const res = await api.get(
+        "/admin/ops/maintenance-jobs/batches?dry_run=false&limit=50",
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      const ids = res.data.batches.map((b: any) => b.id)
+      expect(ids).toContain(appliedId)
+      expect(ids).not.toContain(previewId)
+      expect(res.data.batches.every((b: any) => b.dry_run === false)).toBe(true)
+    })
+
+    it("GET /batches/:id returns the batch + its child runs in job_index order", async () => {
+      const batchId = await runBatch({
+        name: "detail check",
+        jobs: [
+          { job_id: "backfill-inventory-unit-cost" },
+          {
+            job_id: "recalculate-design-cost",
+            params: { design_id: "design_does_not_exist" },
+          },
+          { job_id: "backfill-design-energy-costs" },
+        ],
+      })
+
+      const res = await api.get(
+        `/admin/ops/maintenance-jobs/batches/${batchId}`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.batch.id).toBe(batchId)
+      expect(res.data.batch.name).toBe("detail check")
+      expect(res.data.batch.job_count).toBe(3)
+      expect(res.data.batch.failed_count).toBe(1)
+
+      expect(Array.isArray(res.data.jobs)).toBe(true)
+      expect(res.data.jobs).toHaveLength(3)
+      // Children are ordered by job_index ascending.
+      expect(res.data.jobs.map((j: any) => j.job_index)).toEqual([0, 1, 2])
+      expect(res.data.jobs.every((j: any) => j.batch_id === batchId)).toBe(true)
+
+      const failed = res.data.jobs[1]
+      expect(failed.job_id).toBe("recalculate-design-cost")
+      expect(failed.applied).toBe(false)
+      expect(failed.error_count).toBe(1)
+    })
+
+    it("GET /batches/:id with an unknown id → 404", async () => {
+      await expect(
+        api.get(
+          "/admin/ops/maintenance-jobs/batches/batch_does_not_exist",
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 404 } })
+    })
+
+    it("requires admin auth (401 without headers)", async () => {
+      await expect(
+        api.get("/admin/ops/maintenance-jobs/batches")
+      ).rejects.toMatchObject({ response: { status: 401 } })
+    })
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/batches/[id]/route.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/batches/[id]/route.ts
@@ -1,0 +1,42 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { OPS_AUDIT_MODULE } from "../../../../../../modules/ops_audit"
+
+/**
+ * GET /admin/ops/maintenance-jobs/batches/:id
+ *
+ * Per-batch detail (Data Plumbing v2, #508): one `ops_maintenance_batch` parent
+ * (its persisted rollup) plus its child `ops_maintenance_run` rows, ordered by
+ * `job_index` (the order the jobs ran in the batch). Drills in from the batch
+ * history index (`GET /admin/ops/maintenance-jobs/batches`). 404 if the batch id
+ * is unknown. The children carry their own per-entity `changes`/`errors`, so the
+ * UI can render the grouped/card ↔ table views without a second call.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params
+
+  const audit: any = req.scope.resolve(OPS_AUDIT_MODULE)
+
+  let batch: any
+  try {
+    batch = await audit.retrieveOpsMaintenanceBatch(id)
+  } catch {
+    batch = null
+  }
+  if (!batch) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Maintenance batch '${id}' not found`
+    )
+  }
+
+  // Child runs in batch order. The batch parent stores the rollup, so this is a
+  // straight read of the linked children (no re-aggregation).
+  const jobs = await audit.listOpsMaintenanceRuns(
+    { batch_id: id },
+    { order: { job_index: "ASC" } }
+  )
+
+  res.json({ batch, jobs })
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/batches/route.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/batches/route.ts
@@ -3,6 +3,7 @@ import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/util
 
 import { getMaintenanceJob } from "../registry"
 import { OpsMaintenanceBatchBody } from "../validators"
+import type { OpsMaintenanceBatchesQuery } from "../validators"
 import { runBatch } from "../batch-executor"
 import type { BatchJobSpec } from "../batch-executor"
 import { buildBatchRollup, buildBatchChildRow } from "../batch-audit"
@@ -106,4 +107,35 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
       error: o.error,
     })),
   })
+}
+
+/**
+ * GET /admin/ops/maintenance-jobs/batches
+ *
+ * Batch-run history index (Data Plumbing v2, #508). One row per batch
+ * (`ops_maintenance_batch`), paginated newest-first, filterable by
+ * dry_run / actor_id. The parent stores its own rollup, so this list never
+ * re-aggregates the child runs. Mirrors the `/runs` reader envelope:
+ * `{ batches, count, limit, offset }`. Drill into one batch (with its child
+ * jobs) via `GET /admin/ops/maintenance-jobs/batches/:id`.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { limit, offset, dry_run, actor_id } =
+    req.validatedQuery as unknown as OpsMaintenanceBatchesQuery
+
+  const filters: Record<string, unknown> = {}
+  if (dry_run !== undefined) filters.dry_run = dry_run
+  if (actor_id !== undefined) filters.actor_id = actor_id
+
+  const audit: any = req.scope.resolve(OPS_AUDIT_MODULE)
+  const [batches, count] = await audit.listAndCountOpsMaintenanceBatches(
+    filters,
+    {
+      skip: offset,
+      take: limit,
+      order: { created_at: "DESC" },
+    }
+  )
+
+  res.json({ batches, count, limit, offset })
 }

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/validators.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/validators.ts
@@ -71,3 +71,21 @@ export const OpsMaintenanceBatchSchema = z.object({
 })
 
 export type OpsMaintenanceBatchBody = z.infer<typeof OpsMaintenanceBatchSchema>
+
+/**
+ * Query for GET /admin/ops/maintenance-jobs/batches — batch-run history index
+ * (Data Plumbing v2, #508). Paginated, newest first, filterable by
+ * dry_run / actor_id (the batch parent has no single `applied` boolean — a batch
+ * is an apply when `dry_run=false`). Mirrors the `/runs` reader envelope. Same
+ * coercion shapes as OpsMaintenanceRunsQuerySchema.
+ */
+export const OpsMaintenanceBatchesQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).optional().default(20),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+  dry_run: booleanish.optional(),
+  actor_id: z.string().optional(),
+})
+
+export type OpsMaintenanceBatchesQuery = z.infer<
+  typeof OpsMaintenanceBatchesQuerySchema
+>

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -17,7 +17,7 @@ import { parseCorsOrigins, ContainerRegistrationKeys } from "@medusajs/framework
 import cors from "cors";
 import { z } from "@medusajs/framework/zod";
 import { personSchema, listPersonsQuerySchema, UpdatePersonSchema, ReadPersonQuerySchema } from "./admin/persons/validators";
-import { OpsMaintenanceRunSchema, OpsMaintenanceRunsQuerySchema, OpsMaintenanceBatchSchema } from "./admin/ops/maintenance-jobs/validators";
+import { OpsMaintenanceRunSchema, OpsMaintenanceRunsQuerySchema, OpsMaintenanceBatchSchema, OpsMaintenanceBatchesQuerySchema } from "./admin/ops/maintenance-jobs/validators";
 import { getPersonResourceDefinition } from "./admin/persons/resources/registry";
 import { AdminGetOrdersOrderParams } from "@medusajs/medusa/api/admin/orders/validators";
 import { retrieveTransformQueryConfig as retrieveOrderTransformQueryConfig } from "@medusajs/medusa/api/admin/orders/query-config";
@@ -2969,6 +2969,12 @@ export default defineMiddlewares({
       matcher: "/admin/ops/maintenance-jobs/batches",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(OpsMaintenanceBatchSchema))],
+    },
+    {
+      // #508 ops maintenance-jobs batch-run history index (Data Plumbing v2)
+      matcher: "/admin/ops/maintenance-jobs/batches",
+      method: "GET",
+      middlewares: [validateAndTransformQuery(wrapSchema(OpsMaintenanceBatchesQuerySchema), {})],
     },
     // NOTE: /admin/* routes already get Medusa's default admin auth
     // (session + bearer + api-key). Re-registering authenticate() with only


### PR DESCRIPTION
## #508 Data Plumbing v2 — slice 3 (batch history / read side)

**Stacked on PR #511** (`feat/508-batch-endpoint`, slice 2). Base is **#511, not `main`** — review/merge #510 → #511 → this, bottom-up (squash-stacked gotcha).

Adds the read side of the batch-run audit introduced by slices 1–2.

### Endpoints
- `GET /admin/ops/maintenance-jobs/batches` — paginated **index** of `ops_maintenance_batch` parents, newest-first, filterable by `dry_run` / `actor_id`. Mirrors the `/runs` reader envelope `{ batches, count, limit, offset }`. The parent stores its own rollup, so the list never re-aggregates children.
- `GET /admin/ops/maintenance-jobs/batches/:id` — **detail**: one batch + its child `ops_maintenance_run` rows in `job_index` order. `404` on unknown id. Children carry their own per-entity `changes`/`errors`, so the UI (slice LAST) can render the grouped/card ↔ table views without a second call.

### Changes
- `validators.ts` — `OpsMaintenanceBatchesQuerySchema` (limit/offset/dry_run/actor_id; same coercion shapes as the `/runs` query).
- `batches/route.ts` — added `GET` index handler alongside the existing `POST`.
- `batches/[id]/route.ts` — new detail handler.
- `middlewares.ts` — `GET /admin/ops/maintenance-jobs/batches` matcher with `validateAndTransformQuery` (sibling of the POST matcher).

### Locked-decision notes
- A batch has no single `applied` boolean — a batch is an apply when `dry_run=false`, so the index exposes `dry_run` (+ `actor_id`) filters rather than `applied`.
- Read-only — does not touch the dry-run→apply guard. `container.resolve` annotated `any`.

### Tests
`integration-tests/http/ops-maintenance-batches-history.spec.ts` — **5 per-file integration tests green** (index envelope + newest-first ordering, `dry_run=false` filter, detail + `job_index` ordering, 404, 401). `tsc` clean on changed files.

```
pnpm test:integration:http:shared -- ops-maintenance-batches-history
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)