### PR TITLE
feat(ops): #508 slice 4 — repair-partner-region-links maintenance job

### DIFF
--- a/apps/backend/integration-tests/http/ops-maintenance-jobs.spec.ts
+++ b/apps/backend/integration-tests/http/ops-maintenance-jobs.spec.ts
@@ -452,5 +452,51 @@ setupSharedTestSuite(() => {
         )
       ).rejects.toMatchObject({ response: { status: 400 } })
     })
+
+    // #508 slice 4 — repair-partner-region-links (tenant correctness). The
+    // add-missing / remove-orphan decision is unit-tested via
+    // diffPartnerRegionLinks; here we assert the registry discovery + the
+    // safe-by-default dry_run contract without seeding partner/store/region.
+    it("GET lists the repair-partner-region-links job with optional partner_id + limit params", async () => {
+      const res = await api.get("/admin/ops/maintenance-jobs", adminHeaders)
+      expect(res.status).toBe(200)
+      const job = res.data.jobs.find(
+        (j: any) => j.id === "repair-partner-region-links"
+      )
+      expect(job).toBeDefined()
+      expect(job.label).toBeTruthy()
+      expect(job.description).toBeTruthy()
+      expect(job.params).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "partner_id", required: false }),
+          expect.objectContaining({ name: "limit", required: false }),
+        ])
+      )
+    })
+
+    it("POST repair-partner-region-links with no params is safe-by-default dry_run (no partners → no changes)", async () => {
+      const res = await api.post(
+        "/admin/ops/maintenance-jobs/repair-partner-region-links/run",
+        {},
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.result.job_id).toBe("repair-partner-region-links")
+      expect(res.data.result.dry_run).toBe(true)
+      expect(res.data.result.applied).toBe(false)
+      expect(res.data.result.changes).toEqual([])
+      expect(res.data.result.errors).toEqual([])
+      expect(res.data.result.summary).toMatch(/consistent/i)
+    })
+
+    it("POST repair-partner-region-links rejects an invalid limit → 400", async () => {
+      await expect(
+        api.post(
+          "/admin/ops/maintenance-jobs/repair-partner-region-links/run",
+          { dry_run: true, params: { limit: 0 } },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
   })
 })

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/repair-partner-region-links.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/repair-partner-region-links.unit.spec.ts
@@ -1,0 +1,174 @@
+import {
+  diffPartnerRegionLinks,
+  getMaintenanceJob,
+  MAINTENANCE_JOBS,
+  MAX_PARTNER_REGION_SCAN,
+  repairPartnerRegionLinksJob,
+  summarizePartnerRegionRepair,
+} from "../registry"
+
+/**
+ * #508 slice 4 — pure logic for the `repair-partner-region-links` maintenance
+ * job. The container-bound run() (query.graph + remoteLink create/dismiss) is
+ * exercised by the API contract integration test; here we lock down the
+ * add-missing / remove-orphan / keep-existing decision and the summary string
+ * without booting the DB.
+ */
+describe("repair-partner-region-links — diffPartnerRegionLinks", () => {
+  it("adds a missing link when the store default region exists but isn't linked", () => {
+    const changes = diffPartnerRegionLinks(
+      "partner_1",
+      ["reg_1"],
+      [],
+      new Set(["reg_1"])
+    )
+    expect(changes).toEqual([
+      {
+        entity: "partner_region",
+        id: "partner_1:reg_1",
+        field: "add_link",
+        before: null,
+        after: "reg_1",
+      },
+    ])
+  })
+
+  it("is a no-op when the default region is already linked", () => {
+    const changes = diffPartnerRegionLinks(
+      "partner_1",
+      ["reg_1"],
+      ["reg_1"],
+      new Set(["reg_1"])
+    )
+    expect(changes).toEqual([])
+  })
+
+  it("does NOT add a link for a default region that no longer exists (deleted)", () => {
+    const changes = diffPartnerRegionLinks(
+      "partner_1",
+      ["reg_gone"],
+      [],
+      new Set() // region deleted
+    )
+    expect(changes).toEqual([])
+  })
+
+  it("removes an orphan link whose region was deleted", () => {
+    const changes = diffPartnerRegionLinks(
+      "partner_1",
+      [],
+      ["reg_gone"],
+      new Set() // region no longer exists
+    )
+    expect(changes).toEqual([
+      {
+        entity: "partner_region",
+        id: "partner_1:reg_gone",
+        field: "remove_orphan_link",
+        before: "reg_gone",
+        after: null,
+      },
+    ])
+  })
+
+  it("keeps an existing valid link (no change)", () => {
+    const changes = diffPartnerRegionLinks(
+      "partner_1",
+      [],
+      ["reg_1"],
+      new Set(["reg_1"])
+    )
+    expect(changes).toEqual([])
+  })
+
+  it("handles a mixed partner: add the unlinked default, remove the orphan, keep the valid one", () => {
+    const changes = diffPartnerRegionLinks(
+      "partner_1",
+      ["reg_default"], // exists, not linked → add
+      ["reg_orphan", "reg_keep"], // reg_orphan deleted → remove; reg_keep exists → keep
+      new Set(["reg_default", "reg_keep"])
+    )
+    expect(changes).toEqual([
+      {
+        entity: "partner_region",
+        id: "partner_1:reg_default",
+        field: "add_link",
+        before: null,
+        after: "reg_default",
+      },
+      {
+        entity: "partner_region",
+        id: "partner_1:reg_orphan",
+        field: "remove_orphan_link",
+        before: "reg_orphan",
+        after: null,
+      },
+    ])
+  })
+
+  it("de-duplicates repeated default/linked region ids", () => {
+    const addChanges = diffPartnerRegionLinks(
+      "partner_1",
+      ["reg_1", "reg_1"], // two stores default to the same region
+      [],
+      new Set(["reg_1"])
+    )
+    expect(addChanges).toHaveLength(1)
+
+    const orphanChanges = diffPartnerRegionLinks(
+      "partner_1",
+      [],
+      ["reg_x", "reg_x"],
+      new Set()
+    )
+    expect(orphanChanges).toHaveLength(1)
+  })
+
+  it("ignores empty-string region ids", () => {
+    const changes = diffPartnerRegionLinks(
+      "partner_1",
+      [""],
+      [""],
+      new Set([""])
+    )
+    expect(changes).toEqual([])
+  })
+})
+
+describe("repair-partner-region-links — summarizePartnerRegionRepair", () => {
+  it("reports no changes when everything is consistent", () => {
+    expect(summarizePartnerRegionRepair(true, 3, 0, 0, 0)).toBe(
+      "No changes — scanned 3 partner(s), all partner_region links consistent"
+    )
+  })
+
+  it("uses 'Would' for a dry run and lists both add + remove", () => {
+    expect(summarizePartnerRegionRepair(true, 5, 2, 1, 0)).toBe(
+      "Would add 2 missing link(s) and remove 1 orphan link(s) across 5 partner(s)"
+    )
+  })
+
+  it("uses 'Did' for an applied run and appends an error count", () => {
+    expect(summarizePartnerRegionRepair(false, 4, 1, 0, 2)).toBe(
+      "Did add 1 missing link(s) across 4 partner(s); 2 error(s)"
+    )
+  })
+})
+
+describe("repair-partner-region-links — registry wiring", () => {
+  it("is registered and discoverable by id", () => {
+    expect(getMaintenanceJob("repair-partner-region-links")).toBe(
+      repairPartnerRegionLinksJob
+    )
+    expect(MAINTENANCE_JOBS).toContain(repairPartnerRegionLinksJob)
+  })
+
+  it("declares optional partner_id + limit params and a sane cap", () => {
+    expect(MAX_PARTNER_REGION_SCAN).toBeGreaterThan(0)
+    const names = repairPartnerRegionLinksJob.params.map((p) => p.name)
+    expect(names).toEqual(expect.arrayContaining(["partner_id", "limit"]))
+    expect(
+      repairPartnerRegionLinksJob.params.every((p) => p.required === false)
+    ).toBe(true)
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -7,6 +7,7 @@ import { PRODUCTION_RUNS_MODULE } from "../../../../modules/production_runs"
 import { RAW_MATERIAL_MODULE } from "../../../../modules/raw_material"
 import { OPS_AUDIT_MODULE } from "../../../../modules/ops_audit"
 import partnerOrderLink from "../../../../links/partner-order"
+import partnerRegionLink from "../../../../links/partner-region"
 import { resolveStoreCurrency } from "../../../../lib/resolve-store-currency"
 
 /**
@@ -1571,6 +1572,268 @@ export const backfillPartnerOrderCurrencyJob: MaintenanceJob = {
   },
 }
 
+/**
+ * Hard cap on the partner-region link repair scan. Partners are few, but we
+ * still bound the per-request blast radius (each partner reads its stores + the
+ * `partner_region` link rows). Bigger fleets raise `limit` across chunked calls.
+ */
+export const MAX_PARTNER_REGION_SCAN = 5000
+
+const repairPartnerRegionParamsSchema = z.object({
+  /** Restrict the repair to a single partner instead of all partners. */
+  partner_id: z.string().min(1).optional(),
+  /** Max partners to scan in one call (1..MAX_PARTNER_REGION_SCAN). */
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_PARTNER_REGION_SCAN)
+    .optional()
+    .default(1000),
+})
+
+/**
+ * Pure: compute the `partner_region` link repairs for ONE partner.
+ *
+ * The partner↔region link is the tenant source-of-truth — the partner regions
+ * route has NO fallback to `store.default_region_id` ("if it isn't linked, the
+ * partner doesn't own it"), so a missing link silently hides a partner's own
+ * default region. Two safe, well-defined link-table corrections (no entity
+ * writes):
+ *   • ADD a missing link — the store points at an EXISTING `default_region_id`
+ *     R but there's no (partner, R) `partner_region` row.
+ *   • REMOVE an orphan link — a (partner, R) row whose region R no longer
+ *     exists (a deleted region leaves a dangling pivot row).
+ *
+ * Cross-tenant "bleed" (a region linked to a partner that arguably shouldn't own
+ * it) is deliberately NOT auto-repaired: there's no derivable ownership rule for
+ * an arbitrary linked region, and partners legitimately copy/share regions
+ * (feedback_partner_region_extend_not_lockdown), so removing it would risk
+ * dropping a valid link. Only the two unambiguous cases above are corrected.
+ *
+ * Exported for unit testing — container-free.
+ */
+export function diffPartnerRegionLinks(
+  partnerId: string,
+  defaultRegionIds: string[],
+  linkedRegionIds: string[],
+  existingRegionIds: Set<string>
+): MaintenanceChange[] {
+  const linked = new Set(linkedRegionIds)
+  const changes: MaintenanceChange[] = []
+
+  // ADD: a store's default region exists but isn't linked to the partner.
+  const addedSeen = new Set<string>()
+  for (const regionId of defaultRegionIds) {
+    if (!regionId || addedSeen.has(regionId)) continue
+    if (!existingRegionIds.has(regionId)) continue // can't link a deleted region
+    if (linked.has(regionId)) continue // already linked
+    addedSeen.add(regionId)
+    changes.push({
+      entity: "partner_region",
+      id: `${partnerId}:${regionId}`,
+      field: "add_link",
+      before: null,
+      after: regionId,
+    })
+  }
+
+  // REMOVE: a linked region no longer exists (orphan pivot row).
+  const removedSeen = new Set<string>()
+  for (const regionId of linkedRegionIds) {
+    if (!regionId || removedSeen.has(regionId)) continue
+    if (existingRegionIds.has(regionId)) continue // region exists — keep it
+    removedSeen.add(regionId)
+    changes.push({
+      entity: "partner_region",
+      id: `${partnerId}:${regionId}`,
+      field: "remove_orphan_link",
+      before: regionId,
+      after: null,
+    })
+  }
+
+  return changes
+}
+
+/**
+ * Pure summary builder for the partner-region link repair — keeps the
+ * human-facing string verifiable without booting the DB.
+ */
+export function summarizePartnerRegionRepair(
+  dryRun: boolean,
+  partnersScanned: number,
+  addedCount: number,
+  removedCount: number,
+  errorCount: number
+): string {
+  if (addedCount === 0 && removedCount === 0) {
+    return `No changes — scanned ${partnersScanned} partner(s), all partner_region links consistent`
+  }
+  const verb = dryRun ? "Would" : "Did"
+  const parts: string[] = []
+  if (addedCount > 0) parts.push(`add ${addedCount} missing link(s)`)
+  if (removedCount > 0) parts.push(`remove ${removedCount} orphan link(s)`)
+  const head = `${verb} ${parts.join(" and ")} across ${partnersScanned} partner(s)`
+  return errorCount > 0 ? `${head}; ${errorCount} error(s)` : head
+}
+
+/**
+ * Repair partner_region links (#508 Data Plumbing v2 — tenant correctness). The
+ * partner↔region link is the multi-tenant source-of-truth; this job adds the
+ * missing (partner, default-region) link when a store's `default_region_id`
+ * points at an existing region that isn't linked, and removes orphan links whose
+ * region was deleted. Dry-run (default) previews every link it would add/remove
+ * without writing; apply creates/dismisses via the remote link (idempotent —
+ * re-running is a no-op once links are consistent). Pure link-table ops, no
+ * entity writes. Optionally scope to one partner_id; a per-partner failure is
+ * reported in `errors` instead of aborting the sweep.
+ */
+export const repairPartnerRegionLinksJob: MaintenanceJob = {
+  id: "repair-partner-region-links",
+  label: "Repair partner region links",
+  description:
+    `Repair the partner_region link table (tenant source-of-truth). Adds the missing link when a partner's store default_region_id points at an existing region with no link (the partner otherwise can't see its own default region), and removes orphan links whose region was deleted. Dry-run (default) previews every link it would add/remove without persisting; apply creates/dismisses the links (idempotent). Pure link-table ops, no entity writes. Optionally scope to one partner_id. Scans up to 'limit' partners per call (default 1000, max ${MAX_PARTNER_REGION_SCAN}).`,
+  params: [
+    {
+      name: "partner_id",
+      type: "string",
+      required: false,
+      description: "Restrict the repair to a single partner (default: all partners)",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max partners to scan in one call (default 1000, max ${MAX_PARTNER_REGION_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }) => {
+    const parsed = repairPartnerRegionParamsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { partner_id, limit } = parsed.data
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const remoteLink: any = container.resolve(ContainerRegistrationKeys.LINK)
+
+    // Target partners + their stores' default_region_id. Partners are few.
+    const partnerGraphArgs: Record<string, unknown> = {
+      entity: "partners",
+      fields: ["id", "stores.default_region_id"],
+      pagination: { take: limit },
+    }
+    if (partner_id) partnerGraphArgs.filters = { id: partner_id }
+    const { data: partners } = await query.graph(partnerGraphArgs as any)
+    const targetPartners = (partners ?? []).filter((p: any) => p?.id)
+
+    // Existing partner_region links for the target partners.
+    const partnerIds = targetPartners.map((p: any) => p.id)
+    let linkRows: any[] = []
+    if (partnerIds.length) {
+      const { data: links } = await query.graph({
+        entity: partnerRegionLink.entryPoint,
+        fields: ["partner_id", "region_id"],
+        filters: { partner_id: partnerIds },
+      })
+      linkRows = links ?? []
+    }
+
+    // Every region id referenced (default or linked) → which still exist.
+    const referencedRegionIds = new Set<string>()
+    for (const p of targetPartners) {
+      for (const s of p.stores ?? []) {
+        if (s?.default_region_id) referencedRegionIds.add(s.default_region_id)
+      }
+    }
+    for (const l of linkRows) {
+      if (l?.region_id) referencedRegionIds.add(l.region_id)
+    }
+    let existingRegionIds = new Set<string>()
+    if (referencedRegionIds.size) {
+      const { data: regions } = await query.graph({
+        entity: "region",
+        fields: ["id"],
+        filters: { id: Array.from(referencedRegionIds) },
+      })
+      existingRegionIds = new Set((regions ?? []).map((r: any) => r.id))
+    }
+
+    // Index linked region ids by partner.
+    const linkedByPartner = new Map<string, string[]>()
+    for (const l of linkRows) {
+      if (!l?.partner_id || !l?.region_id) continue
+      const arr = linkedByPartner.get(l.partner_id) ?? []
+      arr.push(l.region_id)
+      linkedByPartner.set(l.partner_id, arr)
+    }
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    let added = 0
+    let removed = 0
+
+    for (const partner of targetPartners) {
+      try {
+        const defaultRegionIds = ((partner.stores ?? []) as any[])
+          .map((s) => s?.default_region_id)
+          .filter(Boolean) as string[]
+        const linkedRegionIds = linkedByPartner.get(partner.id) ?? []
+
+        const partnerChanges = diffPartnerRegionLinks(
+          partner.id,
+          defaultRegionIds,
+          linkedRegionIds,
+          existingRegionIds
+        )
+        if (!partnerChanges.length) continue
+
+        for (const change of partnerChanges) {
+          if (change.field === "add_link") {
+            added++
+            if (!dry_run) {
+              await remoteLink.create({
+                partner: { partner_id: partner.id },
+                [Modules.REGION]: { region_id: change.after as string },
+              })
+            }
+          } else if (change.field === "remove_orphan_link") {
+            removed++
+            if (!dry_run) {
+              await remoteLink.dismiss({
+                partner: { partner_id: partner.id },
+                [Modules.REGION]: { region_id: change.before as string },
+              })
+            }
+          }
+        }
+        changes.push(...partnerChanges)
+      } catch (e: any) {
+        errors.push({ id: partner.id, message: e?.message ?? String(e) })
+      }
+    }
+
+    return {
+      job_id: repairPartnerRegionLinksJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary: summarizePartnerRegionRepair(
+        dry_run,
+        targetPartners.length,
+        added,
+        removed,
+        errors.length
+      ),
+      changes,
+      errors,
+    }
+  },
+}
+
 export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   recalculateDesignCostJob,
   recalculateDesignCostBulkJob,
@@ -1579,6 +1842,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   backfillDesignEnergyCostJob,
   pruneOpsAuditRunsJob,
   backfillPartnerOrderCurrencyJob,
+  repairPartnerRegionLinksJob,
 ]
 
 export const getMaintenanceJob = (id: string): MaintenanceJob | undefined =>


### PR DESCRIPTION
## #508 Data Plumbing v2 — slice 4 (first of the 3 approved jobs)

First of the three locked #508 hard-to-reach jobs (ranked #1 — **tenant correctness**). Independent PR off `main` — registry-only, does **not** depend on the batch stack (#510/#511/#512), which never touched `registry.ts`.

### Why
The `partner_region` link is the multi-tenant source-of-truth. The partner regions route has **no fallback** to `store.default_region_id` ("if it isn't linked, the partner doesn't own it"), so a missing link silently hides a partner's own default region. Drift also leaves orphan pivot rows when a region is deleted.

### What — new registry job `repair-partner-region-links`
- **ADD** a missing `(partner, default-region)` link when a store's `default_region_id` points at an **existing** region with no link.
- **REMOVE** an orphan link whose region no longer exists (dangling pivot row).
- Cross-tenant "bleed" (an arbitrary region linked to a partner) is **deliberately NOT** auto-repaired — there's no derivable ownership rule and partners legitimately copy/share regions (`feedback_partner_region_extend_not_lockdown`). Only the two unambiguous cases are corrected.

### Safety contract (unchanged from #457)
- Dry-run (default) previews every link it would add/remove; **no writes**.
- Apply creates/dismisses via `remoteLink` — **idempotent** (re-run = no-op). Pure link-table ops, **no entity writes**.
- Optional `partner_id` scope; `limit` cap (`MAX_PARTNER_REGION_SCAN=5000`); per-partner failures land in `errors[]` (sweep continues).

### Tests
- **13 unit** (`repair-partner-region-links.unit.spec.ts`) — pure `diffPartnerRegionLinks` (add-missing / remove-orphan / keep-existing / dedup / deleted-default) + `summarizePartnerRegionRepair` + registry wiring.
- **3 integration** appended to `ops-maintenance-jobs.spec.ts` — discovery, safe-by-default dry_run (empty DB → consistent, no changes), invalid-limit → 400. **Full suite 33/33 green.**
- `tsc --noEmit` clean on changed files (no new errors).

### Notes for the reviewer
- `container.resolve(...)` annotated `any` per house rule (TS18046).
- Mirrors the existing `backfill-partner-order-currency` job shape (pure helpers + container-bound `run()`).
- Next slices: 5 `resync-product-partner-landing-url`, 6 `backfill-consumption-log-production-run-id`, then UI redesign LAST (Playwright).

🤖 Generated with [Claude Code](https://claude.com/claude-code)