### PR TITLE
feat(ops): #508 Data Plumbing v2 — batch history data hooks + UI redesign spec

### DIFF
--- a/apps/backend/src/admin/hooks/api/ops-maintenance.ts
+++ b/apps/backend/src/admin/hooks/api/ops-maintenance.ts
@@ -89,6 +89,53 @@ export type RunsQuery = {
   applied?: boolean
 }
 
+/**
+ * A batch parent record — one `POST /admin/ops/maintenance-jobs/batches` call
+ * that ran several jobs sequentially under one named run (Data Plumbing v2,
+ * #508). Mirrors the `ops_maintenance_batch` model columns. The parent stores
+ * its own rollup, so the history list never re-aggregates the child runs.
+ */
+export type MaintenanceBatch = {
+  id: string
+  name: string
+  actor_id: string
+  dry_run: boolean
+  stop_on_error: boolean
+  job_count: number
+  applied_count: number
+  failed_count: number
+  change_count: number
+  error_count: number
+  summary: string
+  created_at: string
+  updated_at: string
+}
+
+export type ListBatchesResponse = {
+  batches: MaintenanceBatch[]
+  count: number
+  limit: number
+  offset: number
+}
+
+export type BatchesQuery = {
+  limit?: number
+  offset?: number
+  dry_run?: boolean
+  actor_id?: string
+}
+
+/**
+ * Per-batch detail: the parent rollup + its child `ops_maintenance_run` rows in
+ * `job_index` order (the order the jobs ran). The children carry their own
+ * per-entity `changes`/`errors`, so the detail view renders the grouped/card ↔
+ * table views without a second call.
+ */
+export type BatchDetailResponse = {
+  batch: MaintenanceBatch
+  jobs: MaintenanceRun[]
+}
+
 const OPS_MAINTENANCE_QUERY_KEY = "ops_maintenance_jobs" as const
 export const opsMaintenanceQueryKeys = queryKeysFactory(
   OPS_MAINTENANCE_QUERY_KEY
@@ -120,6 +167,54 @@ export const useMaintenanceRuns = (query: RunsQuery = {}) => {
     ...rest,
     runs: data?.runs ?? [],
     count: data?.count ?? 0,
+  }
+}
+
+/**
+ * Batch-run history index (Data Plumbing v2, #508). One row per batch, newest
+ * first, filterable by dry_run / actor_id. Mirrors `useMaintenanceRuns`.
+ */
+export const useMaintenanceBatches = (query: BatchesQuery = {}) => {
+  const { data, ...rest } = useQuery({
+    queryKey: opsMaintenanceQueryKeys.list(["batches", query]),
+    queryFn: async () =>
+      sdk.client.fetch<ListBatchesResponse>(
+        "/admin/ops/maintenance-jobs/batches",
+        {
+          method: "GET",
+          query: query as Record<string, unknown>,
+        }
+      ),
+  })
+
+  return {
+    ...rest,
+    batches: data?.batches ?? [],
+    count: data?.count ?? 0,
+  }
+}
+
+/**
+ * Per-batch detail — the parent rollup + its child runs (#508). `enabled` is
+ * gated on `id`, so this is a no-op until a batch is selected in the history.
+ */
+export const useMaintenanceBatch = (id: string | undefined) => {
+  const { data, ...rest } = useQuery({
+    queryKey: opsMaintenanceQueryKeys.detail(id ?? "none"),
+    queryFn: async () =>
+      sdk.client.fetch<BatchDetailResponse>(
+        `/admin/ops/maintenance-jobs/batches/${id}`,
+        {
+          method: "GET",
+        }
+      ),
+    enabled: !!id,
+  })
+
+  return {
+    ...rest,
+    batch: data?.batch,
+    jobs: data?.jobs ?? [],
   }
 }
 

--- a/apps/docs/notes/508_DATA_PLUMBING_V2_UI_REDESIGN.md
+++ b/apps/docs/notes/508_DATA_PLUMBING_V2_UI_REDESIGN.md
@@ -1,0 +1,99 @@
+# #508 Data Plumbing v2 — UI redesign spec (the LAST slice)
+
+> Status: backend 100% done (slices 1–6, PRs #510–#515). This is the only
+> remaining #508 slice. It is **Playwright-gated** — it touches a React surface
+> (`apps/backend/src/admin/...`), so per the daemon rules it MUST be driven with
+> the `playwright-skill`/`webapp-testing` skill against a live `yarn dev` and a
+> screenshot captured. A headless daemon chunk without a bootable Medusa stack
+> (Postgres + Redis + admin build) cannot verify it — hence this spec, so the
+> next UI-capable session executes fast.
+
+## What already exists (do not rebuild)
+
+- **Route:** `apps/backend/src/admin/routes/settings/ops-data-plumbing/page.tsx`
+  — Settings → Data Plumbing console (PR #507). Today it is a single `Container`
+  with a `Tabs` ("Run a job" / "Run history"): a job `Select`, a dynamic param
+  form (`JobRunner`), Preview(dry-run)/Apply buttons, a `ChangesTable` diff, and
+  a flat `RunHistory` table over `GET .../runs`.
+- **Data hooks:** `apps/backend/src/admin/hooks/api/ops-maintenance.ts`.
+  - Existing: `useMaintenanceJobs`, `useMaintenanceRuns({limit,...})`,
+    `useRunMaintenanceJob` (single-job POST mutation).
+  - **Added by the foundation PR (feat/508-ui-batch-history-hooks):**
+    `useMaintenanceBatches(query)` → `GET /admin/ops/maintenance-jobs/batches`
+    (`{batches,count,limit,offset}`, filter `dry_run`/`actor_id`), and
+    `useMaintenanceBatch(id)` → `GET .../batches/:id`
+    (`{batch, jobs: MaintenanceRun[]}`, child runs in `job_index` order;
+    `enabled` gated on id). Types `MaintenanceBatch`, `BatchDetailResponse`,
+    `BatchesQuery`, `ListBatchesResponse` exported.
+
+## Backend contract the UI consumes (all live on `main`)
+
+| Endpoint | Returns | Use |
+|---|---|---|
+| `GET /admin/ops/maintenance-jobs` | `{jobs,count}` | job picker + param schema |
+| `POST /admin/ops/maintenance-jobs/:id/run` | `{result, audit}` | single-job preview/apply |
+| `GET /admin/ops/maintenance-jobs/runs` | `{runs,count,limit,offset}` | flat run history (incl. single-job + batch children) |
+| `POST /admin/ops/maintenance-jobs/batches` | `{batch, results[]}` | run N jobs as one sequential batch (`dry_run` default true, `stop_on_error` opt) |
+| `GET /admin/ops/maintenance-jobs/batches` | `{batches,count,limit,offset}` | **batch** history index, newest-first |
+| `GET /admin/ops/maintenance-jobs/batches/:id` | `{batch, jobs[]}` | batch detail + its child runs |
+
+`MaintenanceBatch` rollup columns: `name, actor_id, dry_run, stop_on_error,
+job_count, applied_count, failed_count, change_count, error_count, summary,
+created_at`. `MaintenanceRun` (child) adds `batch_id, job_index` plus per-entity
+`changes[]`/`errors[]`.
+
+## Target design (per #508 decisions + the handoff)
+
+> "Root = **exportable Data Table of ALL runs** → click a run → **detail with
+> grouped/card ↔ table view toggle**; consumes `GET .../batches` + `/batches/:id`
+> + `GET .../runs`."
+
+Recommended structure (keep "Run a job" + the batch runner as-is; redesign the
+**history** surface):
+
+1. **Root history view** — replace the flat `RunHistory` table with a Medusa
+   `DataTable` (`@medusajs/ui` `DataTable` + `useDataTable`) of **batches**
+   (newest-first), columns: When · Name · Jobs (`job_count`) · Applied · Failed ·
+   Changes · dry-run/applied `Badge` · Actor. Add pagination (`limit`/`offset`
+   via `useMaintenanceBatches`) and an **Export** action (CSV of the visible
+   rows — Medusa has no built-in export; serialize client-side). Single-job runs
+   (`batch_id = null`) are still visible via a secondary "All runs" tab over
+   `useMaintenanceRuns`, OR fold single-job runs into a synthetic 1-job batch row
+   — pick the tab approach (simpler, no backend change).
+2. **Row click → batch detail** (drawer/`FocusModal` or nested route
+   `ops-data-plumbing/batches/[id]`). Uses `useMaintenanceBatch(id)`. Header =
+   the rollup (summary, counts, badges). Body = the child jobs.
+3. **Detail view toggle** — a segmented control (`@medusajs/ui` Button group or
+   Tabs) toggling:
+   - **Grouped/card view** — one card per child job (`job_id`, badge, summary,
+     change/error counts), expandable to its `ChangesTable` (reuse the existing
+     `ChangesTable` component — extract it to a shared file).
+   - **Table view** — flat `DataTable` of every `change` across all child jobs
+     (cols: Job · Entity · ID · Field · Before · After), plus an errors section.
+
+## Implementation notes / gotchas
+
+- **Reuse**: extract `ChangesTable`, `RunBadge`, `formatValue` from `page.tsx`
+  into a sibling (e.g. `ops-data-plumbing/components.tsx`) so both the single-job
+  result and the batch-detail card/table reuse them. Don't duplicate.
+- **Styling**: Medusa-native only (`--ui-*`/`--elevation-*`); use `DataTable`'s
+  built-in skeleton or a `Skeleton` shape while loading — never "Loading…" text
+  (current code violates this — fix it in the redesign).
+- **Export**: build a CSV string from the loaded rows and trigger a Blob
+  download; gate to the current page or refetch with a large `limit` for
+  "export all". Log/disclose any cap (no silent truncation).
+- **Nested route caveat**: admin runs inside a BrowserRouter; if a sub-route is
+  needed prefer a `FocusModal`/drawer over nested routers (see memory:
+  React-Router-nested gotcha). A drawer keyed on the selected batch id is the
+  lowest-risk path.
+- **No batch-run UI yet**: the "Run a job" tab still runs single jobs. A
+  multi-select "Run as batch" composer over `POST .../batches` is a *follow-up*,
+  not part of this slice — the slice is the **history/detail read** redesign.
+
+## Verification (required before merge)
+
+- `yarn dev` (apps/backend) → log into admin → Settings → Data Plumbing.
+- Drive with Playwright: load history, click a batch, toggle card↔table, run an
+  export. Capture screenshots of the root table + the detail toggle.
+- Seed data: run a batch first (`POST .../batches` with 2 jobs, `dry_run:false`)
+  so the history isn't empty. (Dry-runs are NOT persisted to history.)


### PR DESCRIPTION
## #508 Data Plumbing v2 — foundation for the last (UI) slice

Backend slices 1–6 are merged (#510–#515). The only remaining #508 work is the
**history-console redesign**, which is Playwright-gated (it touches a React
surface and must be verified against a live `yarn dev` + screenshot). A headless
daemon chunk can't boot the full Medusa stack, so this PR ships the **verifiable
data layer** + an implementation-ready spec, deferring the render slice.

### What's here
- **`ops-maintenance.ts`** — new admin react-query hooks (pure additive, renders
  nothing, tsc-clean):
  - `useMaintenanceBatches(query)` → `GET /admin/ops/maintenance-jobs/batches`
  - `useMaintenanceBatch(id)` → `GET .../batches/:id` (parent rollup + child runs, `enabled` gated on id)
  - types `MaintenanceBatch` / `ListBatchesResponse` / `BatchesQuery` / `BatchDetailResponse`
- **`apps/docs/notes/508_DATA_PLUMBING_V2_UI_REDESIGN.md`** — grounded spec for
  the render slice: root `DataTable` of batches → detail drawer with card↔table
  view toggle, consuming the live slice-3 endpoints; reuse/styling/export gotchas.

### Verification
- `npx tsc --noEmit` — **zero new errors** in the changed file (69 pre-existing
  baseline errors on `main`, none mine).
- No runtime/UI surface changed → no Playwright needed for *this* PR. The
  rendering slice (next) is the Playwright-gated one.

### Notes
- Hooks mirror the existing `useMaintenanceRuns` pattern exactly.
- Independent off `main` (not stacked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)