### PR TITLE
feat(ops): #508 — filter GET /maintenance-jobs/runs by batch_id

### DIFF
--- a/apps/backend/integration-tests/http/ops-maintenance-batches-history.spec.ts
+++ b/apps/backend/integration-tests/http/ops-maintenance-batches-history.spec.ts
@@ -128,6 +128,55 @@ setupSharedTestSuite(() => {
       expect(failed.error_count).toBe(1)
     })
 
+    it("GET /runs?batch_id scopes the flat run history to one batch's children", async () => {
+      // Seed a single-job run (batch_id = null) ...
+      const single = await api.post(
+        "/admin/ops/maintenance-jobs/backfill-inventory-unit-cost/run",
+        { dry_run: true },
+        adminHeaders
+      )
+      expect(single.status).toBe(200)
+      // ... and a 2-job batch (children carry the parent batch_id).
+      const batchId = await runBatch({
+        name: "runs filter batch",
+        jobs: [
+          { job_id: "backfill-inventory-unit-cost" },
+          { job_id: "backfill-design-energy-costs" },
+        ],
+      })
+
+      const res = await api.get(
+        `/admin/ops/maintenance-jobs/runs?batch_id=${batchId}&limit=50`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.runs.length).toBe(2)
+      expect(res.data.runs.every((r: any) => r.batch_id === batchId)).toBe(true)
+    })
+
+    it("GET /runs?batch_id=null returns single-job runs only (no batch children)", async () => {
+      const single = await api.post(
+        "/admin/ops/maintenance-jobs/backfill-inventory-unit-cost/run",
+        { dry_run: true },
+        adminHeaders
+      )
+      expect(single.status).toBe(200)
+      const batchId = await runBatch({
+        name: "excluded batch",
+        jobs: [{ job_id: "backfill-inventory-unit-cost" }],
+      })
+
+      const res = await api.get(
+        "/admin/ops/maintenance-jobs/runs?batch_id=null&limit=100",
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.runs.length).toBeGreaterThanOrEqual(1)
+      // Every returned run is a single-job run; no batch child leaks through.
+      expect(res.data.runs.every((r: any) => r.batch_id === null)).toBe(true)
+      expect(res.data.runs.some((r: any) => r.batch_id === batchId)).toBe(false)
+    })
+
     it("GET /batches/:id with an unknown id → 404", async () => {
       await expect(
         api.get(

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/runs/route.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/runs/route.ts
@@ -7,18 +7,28 @@ import { OpsMaintenanceRunsQuery } from "../validators"
  * GET /admin/ops/maintenance-jobs/runs
  *
  * Durable history of maintenance-job runs (#457). Paginated, newest first,
- * filterable by job_id / dry_run / applied. Sibling of `[id]/` so it doesn't
- * collide with the `:id/run` matcher. Mirrors the admin list-route envelope:
- * `{ runs, count, limit, offset }`.
+ * filterable by job_id / dry_run / applied / batch_id. Sibling of `[id]/` so it
+ * doesn't collide with the `:id/run` matcher. Mirrors the admin list-route
+ * envelope: `{ runs, count, limit, offset }`.
+ *
+ * `batch_id` (#508): a parent batch id scopes to that batch's children; the
+ * `"null"`/`"none"` sentinel scopes to single-job runs only (`batch_id IS NULL`)
+ * — what the run-history "All runs" tab reads so batch children aren't shown
+ * twice (once flat, once under their batch).
  */
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
-  const { limit, offset, job_id, dry_run, applied } =
+  const { limit, offset, job_id, dry_run, applied, batch_id } =
     req.validatedQuery as unknown as OpsMaintenanceRunsQuery
 
   const filters: Record<string, unknown> = {}
   if (job_id !== undefined) filters.job_id = job_id
   if (dry_run !== undefined) filters.dry_run = dry_run
   if (applied !== undefined) filters.applied = applied
+  if (batch_id !== undefined) {
+    // "null"/"none" → single-job runs only (IS NULL); else the exact parent id.
+    filters.batch_id =
+      batch_id === "null" || batch_id === "none" ? null : batch_id
+  }
 
   const audit: any = req.scope.resolve(OPS_AUDIT_MODULE)
   const [runs, count] = await audit.listAndCountOpsMaintenanceRuns(filters, {

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/validators.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/validators.ts
@@ -20,6 +20,12 @@ export type OpsMaintenanceRunBody = z.infer<typeof OpsMaintenanceRunSchema>
  * Query for GET /admin/ops/maintenance-jobs/runs (audit-log history). #457.
  * limit/offset are coerced from query strings; dry_run/applied accept the usual
  * "true"/"false" string forms.
+ *
+ * `batch_id` (Data Plumbing v2, #508) scopes the flat run history to a single
+ * batch's children OR — via the `"null"`/`"none"` sentinel — to single-job runs
+ * only (the rows the run-history "All runs" tab shows, so batch children aren't
+ * double-counted alongside their parent batch). Any other value filters to that
+ * exact parent batch id.
  */
 const booleanish = z
   .union([z.boolean(), z.enum(["true", "false"])])
@@ -31,6 +37,7 @@ export const OpsMaintenanceRunsQuerySchema = z.object({
   job_id: z.string().optional(),
   dry_run: booleanish.optional(),
   applied: booleanish.optional(),
+  batch_id: z.string().optional(),
 })
 
 export type OpsMaintenanceRunsQuery = z.infer<typeof OpsMaintenanceRunsQuerySchema>


### PR DESCRIPTION
## What
Adds a `batch_id` filter to `GET /admin/ops/maintenance-jobs/runs` (Data Plumbing v2, #508).

- A **parent batch id** scopes the flat run history to that batch's children.
- The **`"null"`/`"none"` sentinel** scopes to **single-job runs only** (`batch_id IS NULL`).

## Why
The #508 run-history redesign's **"All runs" tab** shows single-job runs over `GET /runs`. Without a `batch_id` filter the endpoint mixes single-job runs *and* batch children, so batch children would appear twice — once flat in "All runs", once under their parent batch. `ops_maintenance_run.batch_id` already distinguishes them (null = single-job, parent id = batch child); this just exposes it as a filter.

This is the **last backend gap before the Playwright-gated render slice** — building it now means the UI session can consume the endpoint directly.

## Scope
- `validators.ts` — `batch_id?: string` on `OpsMaintenanceRunsQuerySchema`.
- `runs/route.ts` — wire the filter; `"null"`/`"none"` → `{ batch_id: null }`, else the exact id. Mirrors the existing `job_id`/`dry_run`/`applied` pattern.
- No model/migration change (additive endpoint-only).

## Verification
- 2 integration tests added to `ops-maintenance-batches-history.spec.ts` (batch-id scoping returns only that batch's children; `batch_id=null` returns single-job runs only, no batch children).
- `pnpm test:integration:http:shared -- integration-tests/http/ops-maintenance-batches-history.spec.ts` → **7/7 green**.
- `tsc` clean on changed files.

## Notes
- Independent off `origin/main` (no stacking). The matching `RunsQuery`/`MaintenanceRun` type additions in the admin hook are deferred to the render-slice PR (which builds on #516, also editing that file) to keep this PR conflict-free.
- Leaves the dry-run→apply guard untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)