### PR TITLE
feat(ops): Data Plumbing v2 batch-history UI render slice (#508)

### DIFF
--- a/apps/backend/src/admin/hooks/api/ops-maintenance.ts
+++ b/apps/backend/src/admin/hooks/api/ops-maintenance.ts
@@ -65,6 +65,10 @@ export type MaintenanceRun = {
   params: Record<string, unknown>
   changes: MaintenanceChange[]
   errors: Array<{ id: string; message: string }>
+  /** Parent batch id when this run executed as part of a batch (#508); null for single-job runs. */
+  batch_id?: string | null
+  /** Position of this run within its batch, in execution order (#508). */
+  job_index?: number
   created_at: string
   updated_at: string
 }
@@ -87,6 +91,12 @@ export type RunsQuery = {
   job_id?: string
   dry_run?: boolean
   applied?: boolean
+  /**
+   * Scope to a batch's child runs (#508). Pass a batch id for that batch's
+   * children, or `"null"`/`"none"` for single-job runs only (`batch_id IS NULL`)
+   * so the "All runs" tab doesn't double-list runs already shown under a batch.
+   */
+  batch_id?: string
 }
 
 /**

--- a/apps/backend/src/admin/routes/settings/ops-data-plumbing/components.tsx
+++ b/apps/backend/src/admin/routes/settings/ops-data-plumbing/components.tsx
@@ -1,0 +1,291 @@
+import { Badge, Button, Table, Text } from "@medusajs/ui"
+import { useState } from "react"
+
+import type {
+  MaintenanceChange,
+  MaintenanceJobResult,
+  MaintenanceRun,
+} from "../../../hooks/api/ops-maintenance"
+
+/**
+ * Shared presentational helpers for the Settings → Data Plumbing console
+ * (#457 / #485 / #508). Extracted from `page.tsx` so the single-job runner,
+ * the batch-history table, and the batch-detail card/table views all render the
+ * same change diff + run badges without duplicating logic.
+ */
+
+export const formatValue = (v: unknown): string => {
+  if (v === null || v === undefined) return "—"
+  if (typeof v === "object") return JSON.stringify(v)
+  return String(v)
+}
+
+export const RunBadge = ({
+  dry_run,
+  applied,
+}: {
+  dry_run: boolean
+  applied: boolean
+}) => {
+  if (dry_run)
+    return (
+      <Badge color="grey" size="2xsmall">
+        dry-run
+      </Badge>
+    )
+  if (applied)
+    return (
+      <Badge color="green" size="2xsmall">
+        applied
+      </Badge>
+    )
+  return (
+    <Badge color="orange" size="2xsmall">
+      no-op
+    </Badge>
+  )
+}
+
+type ChangeLike = {
+  changes: MaintenanceChange[]
+  errors?: Array<{ id: string; message: string }> | null
+}
+
+/**
+ * Per-entity change diff + error list. Accepts either a fresh job result or a
+ * persisted run row (both expose `changes`/`errors`). Caps rows so a huge diff
+ * can't blow up the DOM, and discloses the cap rather than silently truncating.
+ */
+export const ChangesTable = ({ result }: { result: ChangeLike }) => {
+  const errors = result.errors ?? []
+
+  if (!result.changes.length && !errors.length) {
+    return (
+      <Text size="small" className="text-ui-fg-subtle">
+        No changes — data already consistent.
+      </Text>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      {result.changes.length > 0 && (
+        <Table>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>Entity</Table.HeaderCell>
+              <Table.HeaderCell>ID</Table.HeaderCell>
+              <Table.HeaderCell>Field</Table.HeaderCell>
+              <Table.HeaderCell>Before</Table.HeaderCell>
+              <Table.HeaderCell>After</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {result.changes.slice(0, 200).map((c, i) => (
+              <Table.Row key={`${c.entity}-${c.id}-${c.field ?? ""}-${i}`}>
+                <Table.Cell>{c.entity}</Table.Cell>
+                <Table.Cell className="font-mono text-xs">{c.id}</Table.Cell>
+                <Table.Cell>{c.field ?? "—"}</Table.Cell>
+                <Table.Cell className="font-mono text-xs">
+                  {formatValue(c.before)}
+                </Table.Cell>
+                <Table.Cell className="font-mono text-xs">
+                  {formatValue(c.after)}
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      )}
+
+      {result.changes.length > 200 && (
+        <Text size="small" className="text-ui-fg-subtle">
+          Showing first 200 of {result.changes.length} changes.
+        </Text>
+      )}
+
+      {errors.length > 0 && (
+        <div className="rounded-md border border-ui-border-error bg-ui-bg-subtle p-3">
+          <Text size="small" weight="plus" className="text-ui-fg-error">
+            {errors.length} error(s)
+          </Text>
+          <ul className="mt-1 list-disc pl-5">
+            {errors.slice(0, 50).map((e, i) => (
+              <li key={`${e.id}-${i}`}>
+                <Text size="small" className="text-ui-fg-subtle">
+                  <span className="font-mono">{e.id}</span>: {e.message}
+                </Text>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** One expandable card per child run within a batch (grouped/card view). */
+const BatchJobCard = ({ run }: { run: MaintenanceRun }) => {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="flex flex-col gap-y-2 rounded-md border border-ui-border-base p-4">
+      <div className="flex items-center justify-between gap-x-2">
+        <div className="flex items-center gap-x-2">
+          <Text size="small" className="text-ui-fg-muted">
+            #{(run.job_index ?? 0) + 1}
+          </Text>
+          <Text size="small" weight="plus" className="font-mono">
+            {run.job_id}
+          </Text>
+          <RunBadge dry_run={run.dry_run} applied={run.applied} />
+        </div>
+        <div className="flex items-center gap-x-3">
+          <Text size="small" className="text-ui-fg-subtle">
+            {run.change_count} change(s)
+            {run.error_count > 0 ? ` · ${run.error_count} error(s)` : ""}
+          </Text>
+          <Button
+            variant="transparent"
+            size="small"
+            onClick={() => setOpen((o) => !o)}
+          >
+            {open ? "Hide" : "Details"}
+          </Button>
+        </div>
+      </div>
+      <Text size="small" className="text-ui-fg-subtle">
+        {run.summary}
+      </Text>
+      {open && (
+        <div className="mt-2">
+          <ChangesTable result={run} />
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** Flat table of every change across all child runs (table view). */
+const BatchFlatChanges = ({ jobs }: { jobs: MaintenanceRun[] }) => {
+  const rows = jobs.flatMap((run) =>
+    run.changes.map((c) => ({ job_id: run.job_id, change: c }))
+  )
+  const errorRows = jobs.flatMap((run) =>
+    (run.errors ?? []).map((e) => ({ job_id: run.job_id, error: e }))
+  )
+
+  if (!rows.length && !errorRows.length) {
+    return (
+      <Text size="small" className="text-ui-fg-subtle">
+        No changes — data already consistent.
+      </Text>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      {rows.length > 0 && (
+        <Table>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>Job</Table.HeaderCell>
+              <Table.HeaderCell>Entity</Table.HeaderCell>
+              <Table.HeaderCell>ID</Table.HeaderCell>
+              <Table.HeaderCell>Field</Table.HeaderCell>
+              <Table.HeaderCell>Before</Table.HeaderCell>
+              <Table.HeaderCell>After</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {rows.slice(0, 300).map((r, i) => (
+              <Table.Row key={`${r.job_id}-${r.change.id}-${i}`}>
+                <Table.Cell className="font-mono text-xs">{r.job_id}</Table.Cell>
+                <Table.Cell>{r.change.entity}</Table.Cell>
+                <Table.Cell className="font-mono text-xs">
+                  {r.change.id}
+                </Table.Cell>
+                <Table.Cell>{r.change.field ?? "—"}</Table.Cell>
+                <Table.Cell className="font-mono text-xs">
+                  {formatValue(r.change.before)}
+                </Table.Cell>
+                <Table.Cell className="font-mono text-xs">
+                  {formatValue(r.change.after)}
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      )}
+
+      {rows.length > 300 && (
+        <Text size="small" className="text-ui-fg-subtle">
+          Showing first 300 of {rows.length} changes.
+        </Text>
+      )}
+
+      {errorRows.length > 0 && (
+        <div className="rounded-md border border-ui-border-error bg-ui-bg-subtle p-3">
+          <Text size="small" weight="plus" className="text-ui-fg-error">
+            {errorRows.length} error(s)
+          </Text>
+          <ul className="mt-1 list-disc pl-5">
+            {errorRows.slice(0, 50).map((r, i) => (
+              <li key={`${r.job_id}-${r.error.id}-${i}`}>
+                <Text size="small" className="text-ui-fg-subtle">
+                  <span className="font-mono">{r.job_id}</span> ·{" "}
+                  <span className="font-mono">{r.error.id}</span>:{" "}
+                  {r.error.message}
+                </Text>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Batch-detail body with a card ↔ table view toggle (#508). Card view = one
+ * expandable card per child job; table view = every change flattened across all
+ * jobs. Rendered inside the history drawer.
+ */
+export const BatchDetailView = ({ jobs }: { jobs: MaintenanceRun[] }) => {
+  const [view, setView] = useState<"cards" | "table">("cards")
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      <div className="flex items-center gap-x-2">
+        <Button
+          variant={view === "cards" ? "primary" : "secondary"}
+          size="small"
+          onClick={() => setView("cards")}
+        >
+          Cards
+        </Button>
+        <Button
+          variant={view === "table" ? "primary" : "secondary"}
+          size="small"
+          onClick={() => setView("table")}
+        >
+          Table
+        </Button>
+      </div>
+
+      {!jobs.length ? (
+        <Text size="small" className="text-ui-fg-subtle">
+          This batch has no child runs.
+        </Text>
+      ) : view === "cards" ? (
+        <div className="flex flex-col gap-y-3">
+          {jobs.map((run) => (
+            <BatchJobCard key={run.id} run={run} />
+          ))}
+        </div>
+      ) : (
+        <BatchFlatChanges jobs={jobs} />
+      )}
+    </div>
+  )
+}

--- a/apps/backend/src/admin/routes/settings/ops-data-plumbing/page.tsx
+++ b/apps/backend/src/admin/routes/settings/ops-data-plumbing/page.tsx
@@ -11,108 +11,42 @@ import {
   Badge,
   Table,
   Tabs,
+  DataTable,
+  DataTablePaginationState,
+  useDataTable,
+  Drawer,
+  Skeleton,
   toast,
   usePrompt,
 } from "@medusajs/ui"
 import { Tools } from "@medusajs/icons"
+import { createColumnHelper } from "@tanstack/react-table"
 import { useMemo, useState } from "react"
 
 import {
   useMaintenanceJobs,
   useMaintenanceRuns,
+  useMaintenanceBatches,
+  useMaintenanceBatch,
   useRunMaintenanceJob,
   type MaintenanceJobSummary,
   type MaintenanceJobResult,
+  type MaintenanceBatch,
 } from "../../../hooks/api/ops-maintenance"
+import { ChangesTable, RunBadge, BatchDetailView } from "./components"
 
 /**
- * Settings → Data Plumbing (#457 / #485).
+ * Settings → Data Plumbing (#457 / #485 / #508).
  *
- * Operator console over the guarded maintenance-jobs registry: pick a job,
- * fill its params, PREVIEW (dry-run, no writes) then APPLY (confirmed). Shows
- * the per-entity change diff and the durable run history. The job list is
- * driven entirely by the backend, so new registry jobs appear automatically.
+ * Operator console over the guarded maintenance-jobs registry: pick a job, fill
+ * its params, PREVIEW (dry-run, no writes) then APPLY (confirmed). The history
+ * surface (Data Plumbing v2, #508) is a batch-first DataTable — click a batch to
+ * open its detail drawer with a card ↔ table view toggle — plus an "All runs"
+ * tab for single-job runs. The job list and history are backend-driven, so new
+ * registry jobs and new runs appear automatically.
  */
 
 type ParamValues = Record<string, string>
-
-const ChangesTable = ({ result }: { result: MaintenanceJobResult }) => {
-  if (!result.changes.length && !(result.errors?.length)) {
-    return (
-      <Text size="small" className="text-ui-fg-subtle">
-        No changes — data already consistent.
-      </Text>
-    )
-  }
-
-  return (
-    <div className="flex flex-col gap-y-4">
-      {result.changes.length > 0 && (
-        <Table>
-          <Table.Header>
-            <Table.Row>
-              <Table.HeaderCell>Entity</Table.HeaderCell>
-              <Table.HeaderCell>ID</Table.HeaderCell>
-              <Table.HeaderCell>Field</Table.HeaderCell>
-              <Table.HeaderCell>Before</Table.HeaderCell>
-              <Table.HeaderCell>After</Table.HeaderCell>
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            {result.changes.slice(0, 200).map((c, i) => (
-              <Table.Row key={`${c.entity}-${c.id}-${c.field ?? ""}-${i}`}>
-                <Table.Cell>{c.entity}</Table.Cell>
-                <Table.Cell className="font-mono text-xs">{c.id}</Table.Cell>
-                <Table.Cell>{c.field ?? "—"}</Table.Cell>
-                <Table.Cell className="font-mono text-xs">
-                  {formatValue(c.before)}
-                </Table.Cell>
-                <Table.Cell className="font-mono text-xs">
-                  {formatValue(c.after)}
-                </Table.Cell>
-              </Table.Row>
-            ))}
-          </Table.Body>
-        </Table>
-      )}
-
-      {result.changes.length > 200 && (
-        <Text size="small" className="text-ui-fg-subtle">
-          Showing first 200 of {result.changes.length} changes.
-        </Text>
-      )}
-
-      {result.errors && result.errors.length > 0 && (
-        <div className="rounded-md border border-ui-border-error bg-ui-bg-subtle p-3">
-          <Text size="small" weight="plus" className="text-ui-fg-error">
-            {result.errors.length} error(s)
-          </Text>
-          <ul className="mt-1 list-disc pl-5">
-            {result.errors.slice(0, 50).map((e, i) => (
-              <li key={`${e.id}-${i}`}>
-                <Text size="small" className="text-ui-fg-subtle">
-                  <span className="font-mono">{e.id}</span>: {e.message}
-                </Text>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-    </div>
-  )
-}
-
-const formatValue = (v: unknown): string => {
-  if (v === null || v === undefined) return "—"
-  if (typeof v === "object") return JSON.stringify(v)
-  return String(v)
-}
-
-const RunBadge = ({ dry_run, applied }: { dry_run: boolean; applied: boolean }) => {
-  if (dry_run) return <Badge color="grey" size="2xsmall">dry-run</Badge>
-  if (applied) return <Badge color="green" size="2xsmall">applied</Badge>
-  return <Badge color="orange" size="2xsmall">no-op</Badge>
-}
 
 const JobRunner = ({ job }: { job: MaintenanceJobSummary }) => {
   const prompt = usePrompt()
@@ -252,15 +186,222 @@ const JobRunner = ({ job }: { job: MaintenanceJobSummary }) => {
   )
 }
 
-const RunHistory = () => {
+const PAGE_SIZE = 20
+
+const batchColumnHelper = createColumnHelper<MaintenanceBatch>()
+
+/** CSV export of the currently-loaded batch rows (no built-in export; client-side). */
+const exportBatchesCsv = (batches: MaintenanceBatch[]) => {
+  const header = [
+    "created_at",
+    "name",
+    "actor_id",
+    "dry_run",
+    "job_count",
+    "applied_count",
+    "failed_count",
+    "change_count",
+    "error_count",
+    "summary",
+  ]
+  const escape = (v: unknown) => `"${String(v ?? "").replace(/"/g, '""')}"`
+  const lines = [
+    header.join(","),
+    ...batches.map((b) =>
+      [
+        b.created_at,
+        b.name,
+        b.actor_id,
+        b.dry_run,
+        b.job_count,
+        b.applied_count,
+        b.failed_count,
+        b.change_count,
+        b.error_count,
+        b.summary,
+      ]
+        .map(escape)
+        .join(",")
+    ),
+  ]
+  const blob = new Blob([lines.join("\n")], { type: "text/csv;charset=utf-8" })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement("a")
+  a.href = url
+  a.download = "data-plumbing-batches.csv"
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+const BatchDetailDrawer = ({
+  batchId,
+  onClose,
+}: {
+  batchId: string | undefined
+  onClose: () => void
+}) => {
+  const { batch, jobs, isLoading } = useMaintenanceBatch(batchId)
+
+  return (
+    <Drawer open={!!batchId} onOpenChange={(o) => !o && onClose()}>
+      <Drawer.Content>
+        <Drawer.Header>
+          <Drawer.Title>{batch?.name ?? "Batch detail"}</Drawer.Title>
+        </Drawer.Header>
+        <Drawer.Body className="overflow-y-auto">
+          {isLoading ? (
+            <div className="flex flex-col gap-y-3">
+              <Skeleton className="h-6 w-1/2" />
+              <Skeleton className="h-24 w-full" />
+              <Skeleton className="h-24 w-full" />
+            </div>
+          ) : !batch ? (
+            <Text size="small" className="text-ui-fg-subtle">
+              Batch not found.
+            </Text>
+          ) : (
+            <div className="flex flex-col gap-y-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <RunBadge dry_run={batch.dry_run} applied={!batch.dry_run} />
+                {batch.stop_on_error && (
+                  <Badge color="orange" size="2xsmall">
+                    stop-on-error
+                  </Badge>
+                )}
+                <Text size="small" className="text-ui-fg-subtle">
+                  {batch.job_count} job(s) · {batch.applied_count} applied ·{" "}
+                  {batch.failed_count} failed · {batch.change_count} change(s)
+                </Text>
+              </div>
+              <Text size="small" weight="plus">
+                {batch.summary}
+              </Text>
+              <Text size="xsmall" className="text-ui-fg-muted">
+                {new Date(batch.created_at).toLocaleString()} · {batch.actor_id}
+              </Text>
+              <BatchDetailView jobs={jobs} />
+            </div>
+          )}
+        </Drawer.Body>
+      </Drawer.Content>
+    </Drawer>
+  )
+}
+
+const BatchesHistory = () => {
+  const [pagination, setPagination] = useState<DataTablePaginationState>({
+    pageSize: PAGE_SIZE,
+    pageIndex: 0,
+  })
+  const [selectedBatchId, setSelectedBatchId] = useState<string | undefined>(
+    undefined
+  )
+
+  const offset = pagination.pageIndex * pagination.pageSize
+
+  const { batches, count, isLoading } = useMaintenanceBatches({
+    limit: pagination.pageSize,
+    offset,
+  })
+
+  const columns = useMemo(
+    () => [
+      batchColumnHelper.accessor("created_at", {
+        header: "When",
+        cell: ({ getValue }) => (
+          <span className="whitespace-nowrap">
+            {new Date(getValue()).toLocaleString()}
+          </span>
+        ),
+      }),
+      batchColumnHelper.accessor("name", { header: "Name" }),
+      batchColumnHelper.accessor("job_count", { header: "Jobs" }),
+      batchColumnHelper.accessor("applied_count", { header: "Applied" }),
+      batchColumnHelper.accessor("failed_count", { header: "Failed" }),
+      batchColumnHelper.accessor("change_count", { header: "Changes" }),
+      batchColumnHelper.display({
+        id: "state",
+        header: "State",
+        cell: ({ row }) => (
+          <RunBadge
+            dry_run={row.original.dry_run}
+            applied={!row.original.dry_run}
+          />
+        ),
+      }),
+      batchColumnHelper.accessor("actor_id", {
+        header: "Actor",
+        cell: ({ getValue }) => (
+          <span className="font-mono text-xs">{getValue()}</span>
+        ),
+      }),
+    ],
+    []
+  )
+
+  const table = useDataTable({
+    columns,
+    data: batches,
+    getRowId: (row) => row.id,
+    rowCount: count,
+    isLoading,
+    pagination: { state: pagination, onPaginationChange: setPagination },
+    onRowClick: (_, row) => setSelectedBatchId(row.id),
+  })
+
+  if (!isLoading && !batches.length) {
+    return (
+      <div className="px-6 py-4">
+        <Text size="small" className="text-ui-fg-subtle">
+          No batches yet. Run several jobs as one batch to see them here.
+          (Dry-runs are not persisted.)
+        </Text>
+      </div>
+    )
+  }
+
+  return (
+    <div className="py-2">
+      <DataTable instance={table}>
+        <DataTable.Toolbar className="flex items-center justify-between px-6 py-2">
+          <Text size="small" weight="plus">
+            Batch history
+          </Text>
+          <Button
+            variant="secondary"
+            size="small"
+            disabled={!batches.length}
+            onClick={() => exportBatchesCsv(batches)}
+          >
+            Export CSV
+          </Button>
+        </DataTable.Toolbar>
+        <DataTable.Table />
+        <DataTable.Pagination />
+      </DataTable>
+      <BatchDetailDrawer
+        batchId={selectedBatchId}
+        onClose={() => setSelectedBatchId(undefined)}
+      />
+    </div>
+  )
+}
+
+const AllRunsHistory = () => {
+  // Flat list of every persisted run (single-job + batch children). Once PR
+  // #517's `GET /runs?batch_id=null` filter is merged this can pass
+  // `batch_id: "null"` to drop batch children (which already appear, grouped,
+  // under the Batches tab). Until then the route rejects the unknown param
+  // (400), so we intentionally don't send it — minor double-listing over a
+  // broken tab.
   const { runs, isLoading } = useMaintenanceRuns({ limit: 20 })
 
   if (isLoading) {
     return (
-      <div className="px-6 py-4">
-        <Text size="small" className="text-ui-fg-subtle">
-          Loading run history…
-        </Text>
+      <div className="flex flex-col gap-y-2 px-6 py-4">
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-8 w-full" />
       </div>
     )
   }
@@ -269,7 +410,7 @@ const RunHistory = () => {
     return (
       <div className="px-6 py-4">
         <Text size="small" className="text-ui-fg-subtle">
-          No applied runs yet. (Dry-runs are not persisted.)
+          No single-job runs yet. (Dry-runs are not persisted.)
         </Text>
       </div>
     )
@@ -304,9 +445,7 @@ const RunHistory = () => {
               <Table.Cell className="max-w-[280px] truncate">
                 {r.summary}
               </Table.Cell>
-              <Table.Cell className="font-mono text-xs">
-                {r.actor_id}
-              </Table.Cell>
+              <Table.Cell className="font-mono text-xs">{r.actor_id}</Table.Cell>
             </Table.Row>
           ))}
         </Table.Body>
@@ -331,7 +470,7 @@ const OpsDataPlumbingPage = () => {
         <Text className="text-ui-fg-subtle" size="small">
           Run guarded data-correction jobs. Always Preview (dry-run) before you
           Apply — dry-runs never write and are not logged; applied runs are
-          recorded below.
+          recorded in history below.
         </Text>
       </div>
 
@@ -339,7 +478,8 @@ const OpsDataPlumbingPage = () => {
         <div className="px-6 pt-4">
           <Tabs.List>
             <Tabs.Trigger value="run">Run a job</Tabs.Trigger>
-            <Tabs.Trigger value="history">Run history</Tabs.Trigger>
+            <Tabs.Trigger value="batches">Batches</Tabs.Trigger>
+            <Tabs.Trigger value="runs">All runs</Tabs.Trigger>
           </Tabs.List>
         </div>
 
@@ -349,9 +489,7 @@ const OpsDataPlumbingPage = () => {
               Job
             </Label>
             {isLoading ? (
-              <Text size="small" className="text-ui-fg-subtle">
-                Loading jobs…
-              </Text>
+              <Skeleton className="h-9 w-full max-w-md" />
             ) : isError ? (
               <Text size="small" className="text-ui-fg-error">
                 Failed to load jobs.
@@ -375,8 +513,12 @@ const OpsDataPlumbingPage = () => {
           {selectedJob && <JobRunner key={selectedJob.id} job={selectedJob} />}
         </Tabs.Content>
 
-        <Tabs.Content value="history">
-          <RunHistory />
+        <Tabs.Content value="batches">
+          <BatchesHistory />
+        </Tabs.Content>
+
+        <Tabs.Content value="runs">
+          <AllRunsHistory />
         </Tabs.Content>
       </Tabs>
     </Container>


### PR DESCRIPTION
## #508 Data Plumbing v2 — the LAST slice (history-console render)

Stacked on #516 (batch-history react-query hooks + render spec). Redesigns the
**Settings → Data Plumbing** history surface per `508_DATA_PLUMBING_V2_UI_REDESIGN.md`.

### What this ships
- **Batches tab** — Medusa `DataTable` of batch runs (newest-first): When · Name ·
  Jobs · Applied · Failed · Changes · State badge · Actor. Pagination + a
  client-side **Export CSV** of the loaded rows.
- **Batch-detail Drawer** (row click) — rollup header (summary, counts,
  applied/dry-run badge, stop-on-error) + a **Cards ↔ Table view toggle**:
  - *Cards* — one expandable card per child job (`job_id`, badge, summary,
    change/error counts → its `ChangesTable`).
  - *Table* — every change flattened across all child jobs (Job · Entity · ID ·
    Field · Before · After) + an errors section.
- **All runs tab** — flat run history (single-job + batch children).
- **Reuse** — `ChangesTable`/`RunBadge`/`formatValue` + new `BatchDetailView`
  extracted to `components.tsx`; the single-job runner and the batch detail share
  them. Skeleton loaders replace `Loading…` text.
- **Hooks** — adds forward-compatible `RunsQuery.batch_id` +
  `MaintenanceRun.batch_id/job_index` (deferred from #517).

### Decoupled from #517
The All runs tab does **not** send `batch_id` yet — the `GET /runs` route rejects
the unknown param with a **400** until #517's filter merges. Once #517 is in,
a one-line change passes `batch_id: "null"` to drop batch children from this tab.

### Verification
- `tsc` clean (0 new errors in touched files).
- **Playwright-verified against live `yarn dev` admin** (seeded a no-op applied
  batch): batches `DataTable`, Export CSV button, detail Drawer, and the
  Cards↔Table toggle all render. Screenshots captured locally.

### Notes
- Stacked PR — base is `feat/508-ui-batch-history-hooks` (#516). Merge #516 first.
- UI-only; no model/migration/route changes. After this lands, **#508 closes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)