### PR TITLE
feat(stats): Share-publicly toggle + copy-link in panel editor (#341)

### DIFF
--- a/apps/backend/src/admin/components/stats/panel-editor-drawer.tsx
+++ b/apps/backend/src/admin/components/stats/panel-editor-drawer.tsx
@@ -1,14 +1,17 @@
 import {
   Drawer,
   Button,
+  IconButton,
   Input,
   Label,
   Select,
+  Switch,
   Text,
   Textarea,
   toast,
   Heading,
 } from "@medusajs/ui"
+import { SquareTwoStack } from "@medusajs/icons"
 import { useState, useEffect, useMemo } from "react"
 import {
   StatsPanel,
@@ -18,6 +21,7 @@ import {
   useStatsOperations,
   usePreviewPanel,
 } from "../../hooks/api/stats"
+import { API_BASE_URL } from "../../lib/config"
 import { PanelRenderer } from "./panel-renderer"
 
 const PANEL_TYPES: StatsPanelType[] = [
@@ -62,6 +66,7 @@ export function PanelEditorDrawer({ dashboardId, panel, open, onOpenChange }: Pa
   const [cacheTtl, setCacheTtl] = useState<string>("")
   const [width, setWidth] = useState(4)
   const [height, setHeight] = useState(3)
+  const [isPublic, setIsPublic] = useState(false)
   const [previewResult, setPreviewResult] = useState<any>(undefined)
 
   useEffect(() => {
@@ -74,9 +79,23 @@ export function PanelEditorDrawer({ dashboardId, panel, open, onOpenChange }: Pa
       setCacheTtl(panel?.cache_ttl_seconds?.toString() ?? "")
       setWidth(panel?.width ?? 4)
       setHeight(panel?.height ?? 3)
+      setIsPublic((panel?.metadata as Record<string, any> | undefined)?.public === true)
       setPreviewResult(undefined)
     }
   }, [open, panel])
+
+  // Public read-only REST URL for this panel. Only meaningful for an
+  // existing panel (needs its id) that's been shared.
+  const publicUrl = panel ? `${API_BASE_URL}/web/stats/panels/${panel.id}/data` : ""
+
+  const handleCopyPublicUrl = async () => {
+    try {
+      await navigator.clipboard.writeText(publicUrl)
+      toast.success("Public link copied")
+    } catch {
+      toast.error("Could not copy link")
+    }
+  }
 
   const options = useMemo(() => safeParseJSON(optionsText), [optionsText])
   const display = useMemo(() => safeParseJSON(displayText), [displayText])
@@ -128,6 +147,10 @@ export function PanelEditorDrawer({ dashboardId, panel, open, onOpenChange }: Pa
       cache_ttl_seconds: cacheTtl ? parseInt(cacheTtl, 10) : null,
       width,
       height,
+      // Carry forward any existing metadata (incl. server-managed audit
+      // stamps) and only flip the `public` opt-in. The PUT route
+      // re-stamps `public_set_by`/`public_set_at` server-side.
+      metadata: { ...(panel?.metadata ?? {}), public: isPublic },
     }
     try {
       if (isEdit) {
@@ -264,6 +287,46 @@ export function PanelEditorDrawer({ dashboardId, panel, open, onOpenChange }: Pa
             <Text size="xsmall" className="text-ui-fg-muted mt-1">
               Controls how the result renders. E.g. {`{ "label": "Active partners", "prefix": "$" }`}
             </Text>
+          </div>
+
+          <div className="rounded-lg border border-ui-border-base p-4 space-y-3">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <Label size="small">Share publicly</Label>
+                <Text size="xsmall" className="text-ui-fg-muted mt-1">
+                  Expose this panel at a read-only public URL for blog / marketing
+                  embeds. Off by default — only shared panels resolve; everything
+                  else 404s.
+                </Text>
+              </div>
+              <Switch
+                checked={isPublic}
+                onCheckedChange={(v) => setIsPublic(!!v)}
+              />
+            </div>
+            {isEdit && isPublic && (
+              <div className="flex items-center gap-2">
+                <Input
+                  readOnly
+                  value={publicUrl}
+                  className="font-mono text-xs"
+                  onFocus={(e) => e.currentTarget.select()}
+                />
+                <IconButton
+                  type="button"
+                  variant="transparent"
+                  onClick={handleCopyPublicUrl}
+                  aria-label="Copy public link"
+                >
+                  <SquareTwoStack />
+                </IconButton>
+              </div>
+            )}
+            {!isEdit && isPublic && (
+              <Text size="xsmall" className="text-ui-fg-muted">
+                Save the panel to get its shareable link.
+              </Text>
+            )}
           </div>
 
           {previewResult && (


### PR DESCRIPTION
## What & why
Ships the **editor UX tail** for roadmap **#341** (share-publicly UX on the stats-panel editor — parts 1–2). The backend was already merged & tested in #472/#473/#474; this is the admin-UI follow-up that was deferred as Playwright-gated.

The public read endpoint `GET /web/stats/panels/:id/data` resolves a panel **only** when `metadata.public === true` (404 otherwise) and the PUT route stamps `public_set_by`/`public_set_at` server-side. This PR surfaces that opt-in in the panel editor drawer.

## Changes
`apps/backend/src/admin/components/stats/panel-editor-drawer.tsx` only:
- **"Share publicly" `Switch`** (off by default), wired to `metadata.public`. Save payload spreads existing `panel.metadata` so server-managed audit stamps survive the full-replace PUT.
- **Edit path:** read-only public-URL field (`API_BASE_URL + /web/stats/panels/:id/data`) + copy-to-clipboard `IconButton`.
- **Create path:** "Save the panel to get its shareable link" hint (no id yet).
- Medusa-native components/tokens; no new deps, no migration.

## Verification
- `tsc` clean (0 new errors) on the changed admin file.
- **Playwright against live admin** (create + edit drawers):
  - Create drawer renders the section; switch toggles; hint appears.
  - Edit drawer renders read-only URL (`…/web/stats/panels/<id>/data`) + copy button.
  - **End-to-end:** private panel public GET → **404**; after toggling Share-publicly + Update → **200** with `{panel_id,type,name,data,display,resolved_at}`.

## Notes
- Pure additive UI; no backend logic changed (audit-stamp + gate already merged).
- Closes the last open item on #341 (backend parts 3–4 already shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)