### PR TITLE
feat(partners): GET /partners/designs/:id/revisions — design revision lineage (#337)

### DIFF
--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -3862,6 +3862,12 @@ export default defineMiddlewares({
       middlewares: [authenticate("partner", ["session", "bearer"])],
     },
     {
+      // Roadmap #6 — partner design revision lineage (mirrors GET /admin/designs/:id/revisions)
+      matcher: "/partners/designs/:designId/revisions",
+      method: "GET",
+      middlewares: [authenticate("partner", ["session", "bearer"])],
+    },
+    {
       // Roadmap #6 Phase 4 — partner-originated (self-approved) runs
       matcher: "/partners/designs/:designId/production-runs",
       method: "POST",

--- a/apps/backend/src/api/partners/designs/[designId]/revisions/lineage.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/revisions/lineage.ts
@@ -1,0 +1,50 @@
+/**
+ * @file Pure lineage-scoping helper for partner design revisions.
+ * @module API/Partners/Designs/Revisions
+ *
+ * Roadmap #6 — promote admin Designs to partner-ui. Mirrors
+ * `GET /admin/designs/:id/revisions`, but a partner must only ever see
+ * the slice of a revision lineage that belongs to them. An
+ * admin-originated (or another partner's) ancestor/descendant must not
+ * leak through the `revised_from_id` chain.
+ */
+
+export type LineageEntry = {
+  id: string
+  owner_partner_id?: string | null
+  revised_from_id?: string | null
+  revision_number?: number | null
+  [key: string]: unknown
+}
+
+export type ScopedLineage = {
+  /** Lineage entries the partner owns, in ancestors→current→descendants order. */
+  lineage: LineageEntry[]
+  /** Topmost partner-owned design id in the visible chain (null if none). */
+  root_design_id: string | null
+}
+
+/**
+ * Restrict a full revision lineage to designs the partner OWNS.
+ *
+ * The input array is expected to already be ordered
+ * ancestors→current→descendants (as produced by the revised_from_id
+ * walk), so the first surviving entry is the root of the partner-visible
+ * chain.
+ *
+ * @param full   The full lineage (may include designs owned by admin or
+ *               other partners).
+ * @param partnerId The authenticated partner's id.
+ */
+export function scopeLineageToPartner(
+  full: LineageEntry[],
+  partnerId: string
+): ScopedLineage {
+  const lineage = (full || []).filter(
+    (d) => d != null && d.owner_partner_id === partnerId
+  )
+  return {
+    lineage,
+    root_design_id: lineage.length ? lineage[0].id : null,
+  }
+}

--- a/apps/backend/src/api/partners/designs/[designId]/revisions/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/revisions/route.ts
@@ -1,0 +1,106 @@
+/**
+ * @file Partner API route for a design's revision lineage.
+ * @module API/Partners/Designs/Revisions
+ *
+ * Roadmap #6 — promote admin Designs to partner-ui. Mirrors
+ * `GET /admin/designs/:id/revisions` (same lineage walk + response
+ * shape), but guarded to the owning partner and scoped so the partner
+ * only sees the slice of the lineage they own (no cross-tenant leak via
+ * the `revised_from_id` chain).
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { assertPartnerOwnsDesign } from "../../helpers"
+import { scopeLineageToPartner, LineageEntry } from "./lineage"
+
+const LINEAGE_FIELDS = [
+  "id",
+  "name",
+  "status",
+  "revision_number",
+  "revision_notes",
+  "revised_from_id",
+  "owner_partner_id",
+  "created_at",
+  "updated_at",
+]
+
+/**
+ * Get the revision lineage of a partner-owned design.
+ * @route GET /partners/designs/{designId}/revisions
+ *
+ * @returns {Object} 200 - { design_id, root_design_id, current_revision, lineage }
+ * @throws {MedusaError} 401 - Partner authentication required
+ * @throws {MedusaError} 403 - Design is not owned by this partner
+ * @throws {MedusaError} 404 - Design not found
+ */
+export async function GET(
+  req: AuthenticatedMedusaRequest & { params: { designId: string } },
+  res: MedusaResponse
+) {
+  const { designId } = req.params
+
+  // Ownership guard (401/403/404). Self-serve designs only — an
+  // admin-assigned design is not a partner's to inspect revisions of.
+  const { partner } = await assertPartnerOwnsDesign(req, designId)
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  // Fetch the current design with the fields needed for the lineage.
+  const {
+    data: [design],
+  } = await query.graph({
+    entity: "design",
+    fields: LINEAGE_FIELDS,
+    filters: { id: designId },
+  })
+
+  // Walk up the chain to find all ancestors (newest-first unshift → oldest-first).
+  let currentReviseFromId = (design as LineageEntry).revised_from_id
+  const ancestors: LineageEntry[] = []
+
+  while (currentReviseFromId) {
+    const {
+      data: [ancestor],
+    } = await query.graph({
+      entity: "design",
+      fields: LINEAGE_FIELDS,
+      filters: { id: currentReviseFromId },
+    })
+
+    if (!ancestor) break
+    ancestors.unshift(ancestor as LineageEntry)
+    currentReviseFromId = (ancestor as LineageEntry).revised_from_id
+  }
+
+  // Walk down from the current design to find all descendants (BFS).
+  const descendants: LineageEntry[] = []
+  const queue = [designId]
+
+  while (queue.length) {
+    const parentId = queue.shift()!
+    const { data: children } = await query.graph({
+      entity: "design",
+      fields: LINEAGE_FIELDS,
+      filters: { revised_from_id: parentId },
+    })
+
+    for (const child of children as LineageEntry[]) {
+      descendants.push(child)
+      queue.push(child.id)
+    }
+  }
+
+  // Full lineage: ancestors → current → descendants.
+  const full = [...ancestors, design as LineageEntry, ...descendants]
+
+  // Scope strictly to designs this partner owns (no cross-tenant leak).
+  const { lineage, root_design_id } = scopeLineageToPartner(full, partner.id)
+
+  res.status(200).json({
+    design_id: designId,
+    root_design_id,
+    current_revision: (design as LineageEntry).revision_number,
+    lineage,
+  })
+}

--- a/apps/backend/src/api/partners/designs/__tests__/revisions-lineage.unit.spec.ts
+++ b/apps/backend/src/api/partners/designs/__tests__/revisions-lineage.unit.spec.ts
@@ -1,0 +1,83 @@
+import { scopeLineageToPartner, LineageEntry } from "../[designId]/revisions/lineage"
+
+const make = (over: Partial<LineageEntry> = {}): LineageEntry => ({
+  id: over.id ?? "design_1",
+  owner_partner_id: over.owner_partner_id ?? "partner_me",
+  revised_from_id: over.revised_from_id ?? null,
+  revision_number: over.revision_number ?? 1,
+  ...over,
+})
+
+describe("scopeLineageToPartner (#337 partner design revisions)", () => {
+  const ME = "partner_me"
+
+  it("returns only entries the partner owns, preserving order", () => {
+    const full = [
+      make({ id: "v1", owner_partner_id: ME, revision_number: 1 }),
+      make({
+        id: "v2",
+        owner_partner_id: ME,
+        revision_number: 2,
+        revised_from_id: "v1",
+      }),
+      make({
+        id: "v3",
+        owner_partner_id: ME,
+        revision_number: 3,
+        revised_from_id: "v2",
+      }),
+    ]
+    const { lineage, root_design_id } = scopeLineageToPartner(full, ME)
+    expect(lineage.map((d) => d.id)).toEqual(["v1", "v2", "v3"])
+    expect(root_design_id).toBe("v1")
+  })
+
+  it("strips an admin-owned (or other-partner) ancestor — no cross-tenant leak", () => {
+    const full = [
+      // admin-originated root the partner must NOT see
+      make({ id: "admin_root", owner_partner_id: null, revision_number: 1 }),
+      make({
+        id: "mine_v2",
+        owner_partner_id: ME,
+        revision_number: 2,
+        revised_from_id: "admin_root",
+      }),
+    ]
+    const { lineage, root_design_id } = scopeLineageToPartner(full, ME)
+    expect(lineage.map((d) => d.id)).toEqual(["mine_v2"])
+    expect(root_design_id).toBe("mine_v2")
+  })
+
+  it("strips a descendant owned by another partner", () => {
+    const full = [
+      make({ id: "mine_v1", owner_partner_id: ME }),
+      make({
+        id: "other_v2",
+        owner_partner_id: "partner_other",
+        revised_from_id: "mine_v1",
+      }),
+    ]
+    const { lineage } = scopeLineageToPartner(full, ME)
+    expect(lineage.map((d) => d.id)).toEqual(["mine_v1"])
+  })
+
+  it("returns empty lineage + null root when the partner owns nothing", () => {
+    const full = [make({ id: "admin_only", owner_partner_id: "admin" })]
+    const { lineage, root_design_id } = scopeLineageToPartner(full, ME)
+    expect(lineage).toEqual([])
+    expect(root_design_id).toBeNull()
+  })
+
+  it("is null/empty safe", () => {
+    expect(scopeLineageToPartner([], ME)).toEqual({
+      lineage: [],
+      root_design_id: null,
+    })
+    // tolerate sparse/nullish entries in the walk result
+    const { lineage } = scopeLineageToPartner(
+      [null as any, make({ id: "ok", owner_partner_id: ME })],
+      ME
+    )
+    expect(lineage.map((d) => d.id)).toEqual(["ok"])
+  })
+})


### PR DESCRIPTION
## What
Promotes the admin **design revision lineage** to partner-ui — roadmap **#337** (mirror admin Designs under `/partners/...` with scoping).

New route: `GET /partners/designs/:designId/revisions`, mirroring `GET /admin/designs/:id/revisions` (same `revised_from_id` ancestor→descendant walk and `{ design_id, root_design_id, current_revision, lineage }` response shape).

## Scoping (cross-tenant safety)
- Guarded by `assertPartnerOwnsDesign` — only the owning partner; an admin-assigned design is **not** a partner's to inspect.
- The lineage is then restricted to designs the partner **owns** via the pure `scopeLineageToPartner()` helper, so an admin-originated (or another partner's) ancestor/descendant **never leaks** through the `revised_from_id` chain. `root_design_id` is recomputed from the partner-visible slice.

## Files
- `src/api/partners/designs/[designId]/revisions/route.ts` — GET handler (mirrors admin walk)
- `src/api/partners/designs/[designId]/revisions/lineage.ts` — pure `scopeLineageToPartner()` helper
- `src/api/partners/designs/__tests__/revisions-lineage.unit.spec.ts` — 5 unit tests
- `src/api/middlewares.ts` — partner `session`/`bearer` auth on the new GET matcher

## Verification
- Unit: `revisions-lineage.unit.spec.ts` — **5/5 green** (order preserved, admin/other-partner ancestor stripped, other-partner descendant stripped, empty→null root, null-safe).
- `tsc`: no new errors in changed files.
- Additive, read-only, no model/migration. Route is a near-verbatim mirror of the admin route; a live partner-auth integration smoke is deferred (no partner-design integration harness exists yet — the security-critical scoping logic is unit-covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)