### PR TITLE
feat(partners): GET /partners/designs/:id/used-in parity route (#337)

### DIFF
--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -3868,6 +3868,12 @@ export default defineMiddlewares({
       middlewares: [authenticate("partner", ["session", "bearer"])],
     },
     {
+      // Roadmap #6 — partner design "used-in" (mirrors GET /admin/designs/:id/used-in)
+      matcher: "/partners/designs/:designId/used-in",
+      method: "GET",
+      middlewares: [authenticate("partner", ["session", "bearer"])],
+    },
+    {
       // Roadmap #6 Phase 4 — partner-originated (self-approved) runs
       matcher: "/partners/designs/:designId/production-runs",
       method: "POST",

--- a/apps/backend/src/api/partners/designs/[designId]/used-in/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/used-in/route.ts
@@ -1,0 +1,48 @@
+/**
+ * @file Partner API route for a design's "used-in" (parent bundles).
+ * @module API/Partners/Designs/UsedIn
+ *
+ * Roadmap #6 — promote admin Designs to partner-ui. Mirrors
+ * `GET /admin/designs/:id/used-in` (same `listDesignComponents` query +
+ * `{ used_in, count }` response shape), but guarded to the owning partner
+ * and scoped so the partner only sees the bundle designs THEY own (no
+ * cross-tenant leak via the `parent_design` relation).
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { DESIGN_MODULE } from "../../../../../modules/designs"
+import type DesignService from "../../../../../modules/designs/service"
+import { assertPartnerOwnsDesign } from "../../helpers"
+import { scopeUsagesToPartner, UsageEntry } from "./scope-usages"
+
+/**
+ * List the partner-owned bundle designs that include this design as a
+ * component.
+ * @route GET /partners/designs/{designId}/used-in
+ *
+ * @returns {Object} 200 - { used_in, count }
+ * @throws {MedusaError} 401 - Partner authentication required
+ * @throws {MedusaError} 403 - Design is not owned by this partner
+ * @throws {MedusaError} 404 - Design not found
+ */
+export async function GET(
+  req: AuthenticatedMedusaRequest & { params: { designId: string } },
+  res: MedusaResponse
+) {
+  const { designId } = req.params
+
+  // Ownership guard (401/403/404). Self-serve designs only — an
+  // admin-assigned design is not a partner's to inspect usages of.
+  const { partner } = await assertPartnerOwnsDesign(req, designId)
+
+  const designService = req.scope.resolve(DESIGN_MODULE) as DesignService
+
+  const usages = (await designService.listDesignComponents(
+    { component_design_id: designId },
+    { relations: ["parent_design"] }
+  )) as UsageEntry[]
+
+  // Scope strictly to bundles this partner owns (no cross-tenant leak).
+  const used_in = scopeUsagesToPartner(usages, partner.id)
+
+  res.status(200).json({ used_in, count: used_in.length })
+}

--- a/apps/backend/src/api/partners/designs/[designId]/used-in/scope-usages.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/used-in/scope-usages.ts
@@ -1,0 +1,44 @@
+/**
+ * @file Pure usage-scoping helper for partner design "used-in".
+ * @module API/Partners/Designs/UsedIn
+ *
+ * Roadmap #6 — promote admin Designs to partner-ui. Mirrors
+ * `GET /admin/designs/:id/used-in` (the bundle designs that include this
+ * design as a component), but a partner must only ever see the bundles
+ * THEY own. A bundle owned by admin (or another partner) that happens to
+ * include this partner's component design must not leak back through the
+ * `parent_design` relation.
+ */
+
+export type UsageEntry = {
+  id: string
+  parent_design?: {
+    id?: string
+    owner_partner_id?: string | null
+    [key: string]: unknown
+  } | null
+  [key: string]: unknown
+}
+
+/**
+ * Restrict the list of component-usages to those whose PARENT (bundle)
+ * design is owned by the authenticated partner.
+ *
+ * Usages whose `parent_design` is missing, unresolved, or owned by
+ * someone else are dropped — the partner only sees their own bundles.
+ *
+ * @param usages   The full usage list (may reference admin / other-partner
+ *                 bundles).
+ * @param partnerId The authenticated partner's id.
+ */
+export function scopeUsagesToPartner(
+  usages: UsageEntry[],
+  partnerId: string
+): UsageEntry[] {
+  return (usages || []).filter(
+    (u) =>
+      u != null &&
+      u.parent_design != null &&
+      u.parent_design.owner_partner_id === partnerId
+  )
+}

--- a/apps/backend/src/api/partners/designs/__tests__/used-in-scope.unit.spec.ts
+++ b/apps/backend/src/api/partners/designs/__tests__/used-in-scope.unit.spec.ts
@@ -1,0 +1,65 @@
+import { scopeUsagesToPartner, UsageEntry } from "../[designId]/used-in/scope-usages"
+
+const make = (over: Partial<UsageEntry> = {}): UsageEntry => ({
+  id: over.id ?? "dc_1",
+  parent_design:
+    over.parent_design === undefined
+      ? { id: "bundle_1", owner_partner_id: "partner_me" }
+      : over.parent_design,
+  ...over,
+})
+
+describe("scopeUsagesToPartner (#337 partner design used-in)", () => {
+  const ME = "partner_me"
+
+  it("returns only usages whose parent bundle the partner owns", () => {
+    const usages = [
+      make({ id: "dc1", parent_design: { id: "b1", owner_partner_id: ME } }),
+      make({ id: "dc2", parent_design: { id: "b2", owner_partner_id: ME } }),
+    ]
+    expect(scopeUsagesToPartner(usages, ME).map((u) => u.id)).toEqual([
+      "dc1",
+      "dc2",
+    ])
+  })
+
+  it("strips a usage whose parent bundle is admin-owned — no cross-tenant leak", () => {
+    const usages = [
+      make({ id: "mine", parent_design: { id: "b1", owner_partner_id: ME } }),
+      make({
+        id: "admin_bundle",
+        parent_design: { id: "b2", owner_partner_id: null },
+      }),
+    ]
+    expect(scopeUsagesToPartner(usages, ME).map((u) => u.id)).toEqual(["mine"])
+  })
+
+  it("strips a usage whose parent bundle belongs to another partner", () => {
+    const usages = [
+      make({ id: "mine", parent_design: { id: "b1", owner_partner_id: ME } }),
+      make({
+        id: "other",
+        parent_design: { id: "b2", owner_partner_id: "partner_other" },
+      }),
+    ]
+    expect(scopeUsagesToPartner(usages, ME).map((u) => u.id)).toEqual(["mine"])
+  })
+
+  it("drops usages with a missing / unresolved parent_design", () => {
+    const usages = [
+      make({ id: "mine", parent_design: { id: "b1", owner_partner_id: ME } }),
+      make({ id: "no_parent", parent_design: null }),
+    ]
+    expect(scopeUsagesToPartner(usages, ME).map((u) => u.id)).toEqual(["mine"])
+  })
+
+  it("is null/empty safe", () => {
+    expect(scopeUsagesToPartner([], ME)).toEqual([])
+    expect(
+      scopeUsagesToPartner(
+        [null as any, make({ id: "ok", parent_design: { owner_partner_id: ME } })],
+        ME
+      ).map((u) => u.id)
+    ).toEqual(["ok"])
+  })
+})


### PR DESCRIPTION
## What

Adds `GET /partners/designs/:designId/used-in` — the partner-ui parity mirror of `GET /admin/designs/:id/used-in`. Returns the **bundle designs that include this design as a component**, using the same `listDesignComponents({ component_design_id }, { relations: ["parent_design"] })` query and `{ used_in, count }` response shape as admin.

Next #337 parity slice after revisions (PR #520).

## Scoping / safety

- **Ownership guard** — `assertPartnerOwnsDesign` (401/403/404); self-serve designs only.
- **No cross-tenant leak** — pure `scopeUsagesToPartner()` filters usages to those whose `parent_design` is owned by the authenticated partner, so an admin (or other-partner) bundle that happens to include this component design never surfaces via the `parent_design` relation.
- Partner auth is **per-route** — added a dedicated `authenticate("partner", ["session","bearer"])` matcher in `middlewares.ts`.

## Tests

- 5 unit tests on the pure helper (owns-only, strips admin-owned parent, strips other-partner parent, drops missing parent, null/empty-safe) — all green.
- `tsc --noEmit` clean for changed files.

Additive, read-only, no model/migration. Independent off `main` (only a trivial adjacent-matcher conflict possible vs the revisions PR #520).

🤖 Generated with [Claude Code](https://claude.com/claude-code)