### PR TITLE
feat(#337): partner design components (BOM children) parity

### DIFF
--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -3874,6 +3874,12 @@ export default defineMiddlewares({
       middlewares: [authenticate("partner", ["session", "bearer"])],
     },
     {
+      // Roadmap #6 — partner design "components" / BOM children (mirrors GET /admin/designs/:id/components)
+      matcher: "/partners/designs/:designId/components",
+      method: "GET",
+      middlewares: [authenticate("partner", ["session", "bearer"])],
+    },
+    {
       // Roadmap #6 Phase 4 — partner-originated (self-approved) runs
       matcher: "/partners/designs/:designId/production-runs",
       method: "POST",

--- a/apps/backend/src/api/partners/designs/[designId]/components/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/components/route.ts
@@ -1,0 +1,47 @@
+/**
+ * @file Partner API route for a design's components (BOM children).
+ * @module API/Partners/Designs/Components
+ *
+ * Roadmap #6 — promote admin Designs to partner-ui. Mirrors
+ * `GET /admin/designs/:id/components` (same `listDesignComponents` query +
+ * `{ components, count }` response shape), but guarded to the owning
+ * partner and scoped so the partner only sees components that are THEIR
+ * own designs (no cross-tenant leak via the `component_design` relation).
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { DESIGN_MODULE } from "../../../../../modules/designs"
+import type DesignService from "../../../../../modules/designs/service"
+import { assertPartnerOwnsDesign } from "../../helpers"
+import { scopeComponentsToPartner, ComponentEntry } from "./scope-components"
+
+/**
+ * List the partner-owned component designs that make up this bundle.
+ * @route GET /partners/designs/{designId}/components
+ *
+ * @returns {Object} 200 - { components, count }
+ * @throws {MedusaError} 401 - Partner authentication required
+ * @throws {MedusaError} 403 - Design is not owned by this partner
+ * @throws {MedusaError} 404 - Design not found
+ */
+export async function GET(
+  req: AuthenticatedMedusaRequest & { params: { designId: string } },
+  res: MedusaResponse
+) {
+  const { designId } = req.params
+
+  // Ownership guard (401/403/404). Self-serve designs only — an
+  // admin-assigned design is not a partner's to inspect components of.
+  const { partner } = await assertPartnerOwnsDesign(req, designId)
+
+  const designService = req.scope.resolve(DESIGN_MODULE) as DesignService
+
+  const components = (await designService.listDesignComponents(
+    { parent_design_id: designId },
+    { relations: ["component_design"] }
+  )) as ComponentEntry[]
+
+  // Scope strictly to components this partner owns (no cross-tenant leak).
+  const scoped = scopeComponentsToPartner(components, partner.id)
+
+  res.status(200).json({ components: scoped, count: scoped.length })
+}

--- a/apps/backend/src/api/partners/designs/[designId]/components/scope-components.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/components/scope-components.ts
@@ -1,0 +1,46 @@
+/**
+ * @file Pure component-scoping helper for partner design "components".
+ * @module API/Partners/Designs/Components
+ *
+ * Roadmap #6 — promote admin Designs to partner-ui. Mirrors
+ * `GET /admin/designs/:id/components` (the component designs that make up
+ * this bundle), but a partner must only ever see components that are
+ * THEIR OWN designs. A component that resolves to an admin (or another
+ * partner's) design must not leak its details back through the
+ * `component_design` relation, even when the partner legitimately owns
+ * the parent bundle.
+ */
+
+export type ComponentEntry = {
+  id: string
+  component_design?: {
+    id?: string
+    owner_partner_id?: string | null
+    [key: string]: unknown
+  } | null
+  [key: string]: unknown
+}
+
+/**
+ * Restrict the list of bundle components to those whose COMPONENT design
+ * is owned by the authenticated partner.
+ *
+ * Components whose `component_design` is missing, unresolved, or owned by
+ * someone else are dropped — the partner only sees components that are
+ * their own designs.
+ *
+ * @param components The full component list (may reference admin /
+ *                   other-partner designs).
+ * @param partnerId  The authenticated partner's id.
+ */
+export function scopeComponentsToPartner(
+  components: ComponentEntry[],
+  partnerId: string
+): ComponentEntry[] {
+  return (components || []).filter(
+    (c) =>
+      c != null &&
+      c.component_design != null &&
+      c.component_design.owner_partner_id === partnerId
+  )
+}

--- a/apps/backend/src/api/partners/designs/__tests__/components-scope.unit.spec.ts
+++ b/apps/backend/src/api/partners/designs/__tests__/components-scope.unit.spec.ts
@@ -1,0 +1,77 @@
+import {
+  scopeComponentsToPartner,
+  ComponentEntry,
+} from "../[designId]/components/scope-components"
+
+const make = (over: Partial<ComponentEntry> = {}): ComponentEntry => ({
+  id: over.id ?? "dc_1",
+  component_design:
+    over.component_design === undefined
+      ? { id: "comp_1", owner_partner_id: "partner_me" }
+      : over.component_design,
+  ...over,
+})
+
+describe("scopeComponentsToPartner (#337 partner design components)", () => {
+  const ME = "partner_me"
+
+  it("returns only components the partner owns", () => {
+    const components = [
+      make({ id: "dc1", component_design: { id: "c1", owner_partner_id: ME } }),
+      make({ id: "dc2", component_design: { id: "c2", owner_partner_id: ME } }),
+    ]
+    expect(scopeComponentsToPartner(components, ME).map((c) => c.id)).toEqual([
+      "dc1",
+      "dc2",
+    ])
+  })
+
+  it("strips a component that is an admin-owned design — no cross-tenant leak", () => {
+    const components = [
+      make({ id: "mine", component_design: { id: "c1", owner_partner_id: ME } }),
+      make({
+        id: "admin_comp",
+        component_design: { id: "c2", owner_partner_id: null },
+      }),
+    ]
+    expect(scopeComponentsToPartner(components, ME).map((c) => c.id)).toEqual([
+      "mine",
+    ])
+  })
+
+  it("strips a component that belongs to another partner", () => {
+    const components = [
+      make({ id: "mine", component_design: { id: "c1", owner_partner_id: ME } }),
+      make({
+        id: "other",
+        component_design: { id: "c2", owner_partner_id: "partner_other" },
+      }),
+    ]
+    expect(scopeComponentsToPartner(components, ME).map((c) => c.id)).toEqual([
+      "mine",
+    ])
+  })
+
+  it("drops components with a missing / unresolved component_design", () => {
+    const components = [
+      make({ id: "mine", component_design: { id: "c1", owner_partner_id: ME } }),
+      make({ id: "no_comp", component_design: null }),
+    ]
+    expect(scopeComponentsToPartner(components, ME).map((c) => c.id)).toEqual([
+      "mine",
+    ])
+  })
+
+  it("is null/empty safe", () => {
+    expect(scopeComponentsToPartner([], ME)).toEqual([])
+    expect(
+      scopeComponentsToPartner(
+        [
+          null as any,
+          make({ id: "ok", component_design: { owner_partner_id: ME } }),
+        ],
+        ME
+      ).map((c) => c.id)
+    ).toEqual(["ok"])
+  })
+})


### PR DESCRIPTION
## What
New `GET /partners/designs/:designId/components` mirroring admin `GET /admin/designs/:id/components` — lists the component designs (BOM children) that make up this bundle design. Same `listDesignComponents({ parent_design_id }, { relations: ["component_design"] })` query + `{ components, count }` response shape.

## Tenant safety
- Guarded by `assertPartnerOwnsDesign` (401/403/404) — partner must own the bundle.
- Pure `scopeComponentsToPartner()` keeps only components whose `component_design` is partner-owned, so an admin/other-partner design added as a component never leaks its details through the `component_design` relation.
- Per-route partner auth matcher added (`authenticate("partner", ["session", "bearer"])`) — partner auth is per-route.

## Tests
- 5 unit tests for `scopeComponentsToPartner` (ownership, admin-strip, other-partner-strip, missing-relation, null/empty). Green.
- tsc clean on changed files.

Additive, read-only, no model/migration. Next #337 parity slice: partner `tasks` / `segment` reads.

Part of #337 (promote admin Designs → partner-ui). Continues the #520 (revisions) / #524 (used-in) recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)