### PR TITLE
feat(partners): design tasks read — GET /partners/designs/:designId/tasks (#337)

### DIFF
--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -3880,6 +3880,12 @@ export default defineMiddlewares({
       middlewares: [authenticate("partner", ["session", "bearer"])],
     },
     {
+      // Roadmap #6 — partner design "tasks" read (mirrors GET /admin/designs/:id/tasks)
+      matcher: "/partners/designs/:designId/tasks",
+      method: "GET",
+      middlewares: [authenticate("partner", ["session", "bearer"])],
+    },
+    {
       // Roadmap #6 Phase 4 — partner-originated (self-approved) runs
       matcher: "/partners/designs/:designId/production-runs",
       method: "POST",

--- a/apps/backend/src/api/partners/designs/[designId]/tasks/extract-tasks.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/tasks/extract-tasks.ts
@@ -1,0 +1,37 @@
+/**
+ * @file Pure task-extraction helper for the partner design "tasks" read.
+ * @module API/Partners/Designs/Tasks
+ *
+ * Roadmap #6 — promote admin Designs to partner-ui. Mirrors
+ * `GET /admin/designs/:id/tasks`. Tasks are direct children of the
+ * design, so the security boundary is the design-ownership guard
+ * (`assertPartnerOwnsDesign`) — once a partner owns the design, every
+ * task on it is theirs; there is no cross-design / cross-tenant relation
+ * to leak through here.
+ *
+ * The admin route reads `tasks[0].tasks` directly, which throws when the
+ * `query.graph` result is empty (no row for the id). This pure helper
+ * normalizes that access so the partner route always returns a clean
+ * array, never a runtime crash.
+ */
+
+export type DesignTasksRow = {
+  id?: string
+  tasks?: unknown[] | null
+  [key: string]: unknown
+}
+
+/**
+ * Safely pull the `tasks` array out of a `query.graph({ entity: "design",
+ * fields: ["tasks.*"] })` result.
+ *
+ * @param rows The `data` array returned by query.graph (design rows).
+ * @returns The design's tasks, or an empty array when the design row or
+ *          its tasks are missing/unresolved.
+ */
+export function extractDesignTasks(
+  rows: DesignTasksRow[] | null | undefined
+): unknown[] {
+  const tasks = (rows || [])[0]?.tasks
+  return Array.isArray(tasks) ? tasks : []
+}

--- a/apps/backend/src/api/partners/designs/[designId]/tasks/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/tasks/route.ts
@@ -1,0 +1,50 @@
+/**
+ * @file Partner API route for a design's tasks.
+ * @module API/Partners/Designs/Tasks
+ *
+ * Roadmap #6 — promote admin Designs to partner-ui. Mirrors
+ * `GET /admin/designs/:id/tasks` (same `tasks.*` read + `{ tasks }`
+ * response shape), but guarded to the owning partner. Tasks are direct
+ * children of the design, so the design-ownership guard is the security
+ * boundary — there is no cross-design relation to leak through here.
+ *
+ * Read-only (GET) only. Partner-side task creation (the admin POST) is a
+ * separate, decision-bearing slice and is intentionally NOT mirrored yet.
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { assertPartnerOwnsDesign } from "../../helpers"
+import { extractDesignTasks, DesignTasksRow } from "./extract-tasks"
+
+/**
+ * List the tasks of a partner-owned design.
+ * @route GET /partners/designs/{designId}/tasks
+ *
+ * @returns {Object} 200 - { tasks }
+ * @throws {MedusaError} 401 - Partner authentication required
+ * @throws {MedusaError} 403 - Design is not owned by this partner
+ * @throws {MedusaError} 404 - Design not found
+ */
+export async function GET(
+  req: AuthenticatedMedusaRequest & { params: { designId: string } },
+  res: MedusaResponse
+) {
+  const { designId } = req.params
+
+  // Ownership guard (401/403/404). Self-serve designs only — an
+  // admin-assigned design is not a partner's to inspect tasks of.
+  await assertPartnerOwnsDesign(req, designId)
+
+  const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data } = await query.graph({
+    entity: "design",
+    fields: ["tasks.*"],
+    filters: { id: designId },
+  })
+
+  // Safe extraction — admin reads tasks[0].tasks directly (throws on empty).
+  const tasks = extractDesignTasks(data as DesignTasksRow[])
+
+  res.status(200).json({ tasks })
+}

--- a/apps/backend/src/api/partners/designs/__tests__/tasks-extract.unit.spec.ts
+++ b/apps/backend/src/api/partners/designs/__tests__/tasks-extract.unit.spec.ts
@@ -1,0 +1,38 @@
+import {
+  extractDesignTasks,
+  DesignTasksRow,
+} from "../[designId]/tasks/extract-tasks"
+
+describe("extractDesignTasks (#337 partner design tasks)", () => {
+  it("returns the design's tasks array", () => {
+    const rows: DesignTasksRow[] = [
+      { id: "d1", tasks: [{ id: "t1" }, { id: "t2" }] },
+    ]
+    expect(extractDesignTasks(rows)).toEqual([{ id: "t1" }, { id: "t2" }])
+  })
+
+  it("returns [] when the design has no tasks", () => {
+    expect(extractDesignTasks([{ id: "d1", tasks: [] }])).toEqual([])
+  })
+
+  it("returns [] when tasks is null/undefined (unresolved relation)", () => {
+    expect(extractDesignTasks([{ id: "d1", tasks: null }])).toEqual([])
+    expect(extractDesignTasks([{ id: "d1" }])).toEqual([])
+  })
+
+  it("returns [] when query.graph yielded no design row (no crash)", () => {
+    // Admin reads tasks[0].tasks directly → throws here; helper must not.
+    expect(extractDesignTasks([])).toEqual([])
+  })
+
+  it("is null/undefined-input safe", () => {
+    expect(extractDesignTasks(null)).toEqual([])
+    expect(extractDesignTasks(undefined)).toEqual([])
+  })
+
+  it("ignores a non-array tasks value defensively", () => {
+    expect(
+      extractDesignTasks([{ id: "d1", tasks: "oops" as any }])
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
## What
New `GET /partners/designs/:designId/tasks` mirroring admin `GET /admin/designs/:id/tasks`. Returns `{ tasks }` for a partner-owned design.

Part of **#337** (promote admin Designs → partner-ui). Continues the parity series after revisions (#520), used-in (#524), components (#527) — all now merged to `main`.

## How
- Guarded by `assertPartnerOwnsDesign` (401/403/404). Tasks are **direct children** of the design, so the design-ownership guard is the full security boundary — unlike components/revisions there is no cross-design relation to leak through, so no separate scope-filter is needed.
- Reads `query.graph({ entity: "design", fields: ["tasks.*"] })` (same data admin's workflow returns).
- Pure `extractDesignTasks()` helper safely pulls the tasks array — admin reads `tasks[0].tasks` directly, which throws on an empty result; the partner route returns `[]` instead.
- Per-route partner auth matcher added in `middlewares.ts` (partner auth is per-route).

## Scope
- **Read-only.** Partner-side task creation (admin's POST) is decision-bearing and intentionally deferred.
- Additive, no model/migration.

## Tests
- 6 unit tests (`tasks-extract.unit.spec.ts`) — happy path, empty/null tasks, no-row (no crash), null input, non-array defense. All green.
- `tsc` clean on changed files.
- No partner-design integration harness exists (unit specs only) → live smoke deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)