### PR TITLE
feat(#337): partner image segmentation route (stacked on #528, merge parent-first)

### DIFF
--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -3886,6 +3886,18 @@ export default defineMiddlewares({
       middlewares: [authenticate("partner", ["session", "bearer"])],
     },
     {
+      // Roadmap #6/#337 — partner image segmentation (mirrors POST
+      // /admin/designs/:id/segment, fal.ai BiRefNet). Ownership-guarded +
+      // quota-metered (image_segment soft-paywall) in the handler.
+      matcher: "/partners/designs/:designId/segment",
+      method: "POST",
+      bodyParser: { sizeLimit: "20mb" },
+      middlewares: [
+        authenticate("partner", ["session", "bearer"]),
+        validateAndTransformBody(wrapSchema(SegmentImageSchema)),
+      ],
+    },
+    {
       // Roadmap #6 Phase 4 — partner-originated (self-approved) runs
       matcher: "/partners/designs/:designId/production-runs",
       method: "POST",

--- a/apps/backend/src/api/partners/designs/[designId]/segment/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/segment/route.ts
@@ -1,0 +1,115 @@
+/**
+ * @file Partner API route for image segmentation on a design.
+ * @module API/Partners/Designs/Segment
+ *
+ * Roadmap #6/#337 — promote admin Designs to partner-ui. Mirrors
+ * `POST /admin/designs/:id/segment` (fal.ai BiRefNet v2 background removal,
+ * same `{ segment: { cutout_url, mask_url } }` response shape), but:
+ *  - guarded to the OWNING partner via `assertPartnerOwnsDesign`, and
+ *  - metered by the same free-tier soft-paywall as `/partners/ai/describe-image`
+ *    (`AI_USAGE_MODULE`, operation `image_segment`) so partner fal cost is
+ *    bounded. Quota is recorded BEFORE the expensive call so it can't be raced.
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { assertPartnerOwnsDesign } from "../../helpers"
+import { resolveFalCredentials } from "../../../../../mastra/services/fal-credentials"
+import { AI_USAGE_MODULE } from "../../../../../modules/ai_usage"
+import type AiUsageService from "../../../../../modules/ai_usage/service"
+import {
+  parseSegmentInput,
+  extractSegmentOutput,
+  SegmentInputBody,
+} from "./segment-image"
+
+/**
+ * Segment an image for a partner-owned design (background removal).
+ * @route POST /partners/designs/{designId}/segment
+ *
+ * @returns {Object} 200 - { segment: { cutout_url, mask_url }, usage }
+ * @returns {Object} 402 - Monthly AI quota exhausted (upgrade required)
+ * @throws {MedusaError} 400 - Missing/invalid image input
+ * @throws {MedusaError} 401 - Partner authentication required
+ * @throws {MedusaError} 403 - Design is not owned by this partner
+ * @throws {MedusaError} 404 - Design not found
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest<SegmentInputBody> & {
+    params: { designId: string }
+  },
+  res: MedusaResponse
+) => {
+  const { designId } = req.params
+
+  // Ownership guard (401/403/404). Self-serve designs only.
+  const { partner } = await assertPartnerOwnsDesign(req, designId)
+
+  // Validate input before touching quota or fal (400 on bad input).
+  const parsed = parseSegmentInput(req.validatedBody)
+  const model = req.validatedBody?.model || "General Use (Light)"
+
+  const aiUsage = req.scope.resolve(
+    AI_USAGE_MODULE
+  ) as unknown as AiUsageService
+
+  // Soft-paywall: bounded free segmentations per calendar month per partner.
+  // Mirrors describe-image — record BEFORE the expensive call so it can't be
+  // raced; a failed fal call still consumes the slot (cheap behaviour until
+  // real subscriptions add metering refunds).
+  const quota = await aiUsage.checkQuota(partner.id, "image_segment")
+  if (!quota.allowed) {
+    res.status(402).json({
+      upgrade_required: true,
+      code: "ai_quota_exhausted",
+      message:
+        "You've used your free AI segmentations this month. Upgrade to keep going.",
+      used: quota.used,
+      limit: quota.limit,
+    })
+    return
+  }
+
+  const falKey = await resolveFalCredentials(req.scope as any)
+  if (!falKey) {
+    throw new MedusaError(
+      MedusaError.Types.UNEXPECTED_STATE,
+      "FAL credentials not configured. Contact support to enable AI image tools."
+    )
+  }
+
+  await aiUsage.recordUsage(partner.id, "image_segment", { designId })
+
+  const { fal } = await import("@fal-ai/client")
+  fal.config({ credentials: falKey })
+
+  // Resolve the input image URL (upload base64 to fal storage first).
+  let resolvedImageUrl: string
+  if (parsed.kind === "url") {
+    resolvedImageUrl = parsed.imageUrl
+  } else {
+    const buffer = Buffer.from(parsed.content, "base64")
+    const blob = new Blob([buffer], { type: parsed.mimeType })
+    const file = new File([blob], `segment-input.${parsed.extension}`, {
+      type: parsed.mimeType,
+    })
+    resolvedImageUrl = await fal.storage.upload(file)
+  }
+
+  const result = await fal.subscribe("fal-ai/birefnet/v2", {
+    input: {
+      image_url: resolvedImageUrl,
+      model,
+      operating_resolution: "1024x1024",
+      output_format: "png",
+      output_mask: true,
+      refine_foreground: true,
+    } as any,
+  })
+
+  const segment = extractSegmentOutput(result)
+
+  res.status(200).json({
+    segment,
+    usage: { used: quota.used + 1, limit: quota.limit },
+  })
+}

--- a/apps/backend/src/api/partners/designs/[designId]/segment/segment-image.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/segment/segment-image.ts
@@ -1,0 +1,77 @@
+/**
+ * @file Pure helpers for partner image segmentation.
+ * @module API/Partners/Designs/Segment
+ *
+ * Roadmap #6/#337 — promote admin Designs to partner-ui. These mirror the
+ * input-validation + fal-result-extraction logic of
+ * `POST /admin/designs/:id/segment` so the partner route can reuse the exact
+ * same behaviour while staying unit-testable without network/fal access.
+ */
+import { MedusaError } from "@medusajs/framework/utils"
+
+export type SegmentInputBody = {
+  image_url?: string
+  image_base64?: string
+  model?: string
+}
+
+export type ParsedSegmentInput =
+  | { kind: "url"; imageUrl: string }
+  | { kind: "base64"; mimeType: string; content: string; extension: string }
+
+/**
+ * Validate the segmentation request body and resolve which input mode was
+ * supplied. Mirrors admin's branch: prefer `image_url`; otherwise parse the
+ * `image_base64` data-URL. Throws `MedusaError` (INVALID_DATA) on a missing or
+ * malformed input — never returns an ambiguous value.
+ */
+export function parseSegmentInput(
+  body: SegmentInputBody | null | undefined
+): ParsedSegmentInput {
+  const image_url = body?.image_url
+  const image_base64 = body?.image_base64
+
+  if (!image_url && !image_base64) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "Either image_url or image_base64 is required"
+    )
+  }
+
+  if (image_url) {
+    return { kind: "url", imageUrl: image_url }
+  }
+
+  const match = (image_base64 as string).match(/^data:([^;]+);base64,(.+)$/)
+  if (!match) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "image_base64 must be a valid base64 data URL"
+    )
+  }
+  const [, mimeType, content] = match
+  const extension = mimeType.split("/")[1] || "png"
+  return { kind: "base64", mimeType, content, extension }
+}
+
+export type SegmentOutput = { cutout_url: string; mask_url: string | null }
+
+/**
+ * Extract the cutout + mask URLs from a fal BiRefNet result. Mirrors admin's
+ * shape read (`data.image.url` / `data.mask_image.url`) and throws
+ * UNEXPECTED_STATE when fal returned no cutout image.
+ */
+export function extractSegmentOutput(result: any): SegmentOutput {
+  const data = result?.data as any
+  const cutoutUrl = data?.image?.url
+  const maskUrl = data?.mask_image?.url
+
+  if (!cutoutUrl) {
+    throw new MedusaError(
+      MedusaError.Types.UNEXPECTED_STATE,
+      "BiRefNet returned no image"
+    )
+  }
+
+  return { cutout_url: cutoutUrl, mask_url: maskUrl || null }
+}

--- a/apps/backend/src/api/partners/designs/__tests__/segment-image.unit.spec.ts
+++ b/apps/backend/src/api/partners/designs/__tests__/segment-image.unit.spec.ts
@@ -1,0 +1,77 @@
+import {
+  parseSegmentInput,
+  extractSegmentOutput,
+} from "../[designId]/segment/segment-image"
+
+describe("parseSegmentInput (#337 partner design segment)", () => {
+  it("returns url mode when image_url is provided", () => {
+    expect(
+      parseSegmentInput({ image_url: "https://cdn/x.png" })
+    ).toEqual({ kind: "url", imageUrl: "https://cdn/x.png" })
+  })
+
+  it("prefers image_url over image_base64", () => {
+    const out = parseSegmentInput({
+      image_url: "https://cdn/x.png",
+      image_base64: "data:image/png;base64,AAA",
+    })
+    expect(out).toEqual({ kind: "url", imageUrl: "https://cdn/x.png" })
+  })
+
+  it("parses a valid base64 data URL into mime/content/extension", () => {
+    expect(
+      parseSegmentInput({ image_base64: "data:image/jpeg;base64,SGVsbG8=" })
+    ).toEqual({
+      kind: "base64",
+      mimeType: "image/jpeg",
+      content: "SGVsbG8=",
+      extension: "jpeg",
+    })
+  })
+
+  it("throws when neither image_url nor image_base64 is provided", () => {
+    expect(() => parseSegmentInput({})).toThrow(/image_url or image_base64/)
+    expect(() => parseSegmentInput(null)).toThrow(/image_url or image_base64/)
+    expect(() => parseSegmentInput(undefined)).toThrow(
+      /image_url or image_base64/
+    )
+  })
+
+  it("throws when image_base64 is not a valid data URL", () => {
+    expect(() =>
+      parseSegmentInput({ image_base64: "not-a-data-url" })
+    ).toThrow(/valid base64 data URL/)
+  })
+})
+
+describe("extractSegmentOutput (#337 partner design segment)", () => {
+  it("returns cutout + mask urls from a fal result", () => {
+    const result = {
+      data: {
+        image: { url: "https://fal/cutout.png" },
+        mask_image: { url: "https://fal/mask.png" },
+      },
+    }
+    expect(extractSegmentOutput(result)).toEqual({
+      cutout_url: "https://fal/cutout.png",
+      mask_url: "https://fal/mask.png",
+    })
+  })
+
+  it("returns mask_url null when fal omits the mask", () => {
+    const result = { data: { image: { url: "https://fal/cutout.png" } } }
+    expect(extractSegmentOutput(result)).toEqual({
+      cutout_url: "https://fal/cutout.png",
+      mask_url: null,
+    })
+  })
+
+  it("throws UNEXPECTED_STATE when fal returned no cutout image", () => {
+    expect(() => extractSegmentOutput({ data: {} })).toThrow(
+      /BiRefNet returned no image/
+    )
+    expect(() => extractSegmentOutput(null)).toThrow(
+      /BiRefNet returned no image/
+    )
+  })
+})

--- a/apps/backend/src/modules/ai_usage/service.ts
+++ b/apps/backend/src/modules/ai_usage/service.ts
@@ -3,6 +3,10 @@ import AiUsageEvent from "./models/ai-usage-event"
 
 export const MONTHLY_QUOTA = {
   image_describe: 10,
+  // Roadmap #6/#337 — partner image segmentation (fal.ai BiRefNet background
+  // removal). Same free-tier soft-paywall policy as image_describe; no
+  // migration needed (operation is a generic string column).
+  image_segment: 10,
 } as const
 
 export type AiOperation = keyof typeof MONTHLY_QUOTA


### PR DESCRIPTION
## What
Adds `POST /partners/designs/:designId/segment` — partner-side mirror of admin `POST /admin/designs/:id/segment` (fal.ai BiRefNet v2 background removal). Roadmap #6/#337 (promote admin Designs → partner-ui).

Same `{ segment: { cutout_url, mask_url } }` response shape as admin, plus a `usage: { used, limit }` field (consistent with `/partners/ai/describe-image`).

## How it stays safe
- **Ownership-guarded** via `assertPartnerOwnsDesign` (401/403/404) — a partner can only segment images for designs they own.
- **Quota-metered** via `AI_USAGE_MODULE` with a new `image_segment` key (10/calendar-month soft-paywall, identical policy to `image_describe`). Usage is recorded **before** the expensive fal call so it can't be raced; exhaustion returns `402 { upgrade_required }`.
- **No migration** — `ai_usage` `operation` is a generic string column; adding a quota key is config-only.

## Pure helpers (unit-tested)
`parseSegmentInput` (validate + resolve url/base64 input) and `extractSegmentOutput` (pull cutout/mask from fal result) are extracted as pure functions → testable without network/fal. **8 unit tests green; tsc clean (no new errors).**

## Stacking
Stacked on **#528** (`feat/337-partner-design-tasks`) because both append to the central `src/api/middlewares.ts` partner-designs matcher block. **Merge #528 first**, then this. Once #528 merges, GitHub will retarget this to `main`.

## Test
```
TEST_TYPE=unit npx jest --testPathPattern="segment-image.unit"  # 8/8
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)