### PR TITLE
feat(#337): partner depth/normal-map route (stacked on #529, merge parent-first)

### DIFF
--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -68,6 +68,7 @@ import { splitInventorySchema } from "./admin/inventory-items/[id]/split/validat
 import { CreateMaterialTypeSchema, ReadRawMaterialCategoriesSchema } from "./admin/categories/rawmaterials/validators";
 import { CreateDesignLLMSchema, designSchema, LinkDesignPartnerSchema, ReadDesignsQuerySchema, UpdateDesignSchema } from "./admin/designs/validators";
 import { SegmentImageSchema } from "./admin/designs/[id]/segment/validators";
+import { DepthImageSchema } from "./partners/designs/[designId]/segment/depth/validators";
 import { taskTemplateSchema, updateTaskTemplateSchema } from "./admin/task-templates/validators";
 import { AdminPostDesignTasksReq } from "./admin/designs/[id]/tasks/validators";
 import { AdminPutDesignTaskReq } from "./admin/designs/[id]/tasks/[taskId]/validators";
@@ -3895,6 +3896,18 @@ export default defineMiddlewares({
       middlewares: [
         authenticate("partner", ["session", "bearer"]),
         validateAndTransformBody(wrapSchema(SegmentImageSchema)),
+      ],
+    },
+    {
+      // Roadmap #6/#337 — partner depth/normal-map estimation (mirrors POST
+      // /admin/designs/:id/segment/depth, fal.ai MiDaS). Ownership-guarded +
+      // quota-metered (image_depth soft-paywall) in the handler.
+      matcher: "/partners/designs/:designId/segment/depth",
+      method: "POST",
+      bodyParser: { sizeLimit: "20mb" },
+      middlewares: [
+        authenticate("partner", ["session", "bearer"]),
+        validateAndTransformBody(wrapSchema(DepthImageSchema)),
       ],
     },
     {

--- a/apps/backend/src/api/partners/designs/[designId]/segment/depth/depth-image.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/segment/depth/depth-image.ts
@@ -1,0 +1,77 @@
+/**
+ * @file Pure helpers for partner image depth/normal estimation.
+ * @module API/Partners/Designs/Segment/Depth
+ *
+ * Roadmap #6/#337 — promote admin Designs to partner-ui. These mirror the
+ * input-validation + fal-result-extraction logic of
+ * `POST /admin/designs/:id/segment/depth` (fal.ai MiDaS preprocessor) so the
+ * partner route can reuse the exact same behaviour while staying
+ * unit-testable without network/fal access.
+ */
+import { MedusaError } from "@medusajs/framework/utils"
+
+export type DepthInputBody = {
+  image_url?: string
+  image_base64?: string
+}
+
+export type ParsedDepthInput =
+  | { kind: "url"; imageUrl: string }
+  | { kind: "base64"; mimeType: string; content: string; extension: string }
+
+/**
+ * Validate the depth request body and resolve which input mode was supplied.
+ * Mirrors admin's branch: prefer `image_url`; otherwise parse the
+ * `image_base64` data-URL. Throws `MedusaError` (INVALID_DATA) on a missing or
+ * malformed input — never returns an ambiguous value.
+ */
+export function parseDepthInput(
+  body: DepthInputBody | null | undefined
+): ParsedDepthInput {
+  const image_url = body?.image_url
+  const image_base64 = body?.image_base64
+
+  if (!image_url && !image_base64) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "Either image_url or image_base64 is required"
+    )
+  }
+
+  if (image_url) {
+    return { kind: "url", imageUrl: image_url }
+  }
+
+  const match = (image_base64 as string).match(/^data:([^;]+);base64,(.+)$/)
+  if (!match) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "image_base64 must be a valid base64 data URL"
+    )
+  }
+  const [, mimeType, content] = match
+  const extension = mimeType.split("/")[1] || "png"
+  return { kind: "base64", mimeType, content, extension }
+}
+
+export type DepthOutput = { depth_url: string; normal_url: string | null }
+
+/**
+ * Extract the depth + normal map URLs from a fal MiDaS result. Mirrors admin's
+ * shape read (`data.depth_map.url` / `data.normal_map.url`) and throws
+ * UNEXPECTED_STATE when MiDaS returned no depth map.
+ */
+export function extractDepthOutput(result: any): DepthOutput {
+  const data = result?.data as any
+  const depthUrl = data?.depth_map?.url
+  const normalUrl = data?.normal_map?.url
+
+  if (!depthUrl) {
+    throw new MedusaError(
+      MedusaError.Types.UNEXPECTED_STATE,
+      "MiDaS returned no depth map"
+    )
+  }
+
+  return { depth_url: depthUrl, normal_url: normalUrl || null }
+}

--- a/apps/backend/src/api/partners/designs/[designId]/segment/depth/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/segment/depth/route.ts
@@ -1,0 +1,112 @@
+/**
+ * @file Partner API route for depth/normal-map estimation on a design.
+ * @module API/Partners/Designs/Segment/Depth
+ *
+ * Roadmap #6/#337 — promote admin Designs to partner-ui. Mirrors
+ * `POST /admin/designs/:id/segment/depth` (fal.ai MiDaS preprocessor — one call
+ * returns a grayscale depth map + an RGB normal map), with the same
+ * `{ depth: { depth_url, normal_url } }` response shape, but:
+ *  - guarded to the OWNING partner via `assertPartnerOwnsDesign`, and
+ *  - metered by the same free-tier soft-paywall as the other partner AI ops
+ *    (`AI_USAGE_MODULE`, operation `image_depth`) so partner fal cost is
+ *    bounded. Quota is recorded BEFORE the expensive call so it can't be raced.
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { assertPartnerOwnsDesign } from "../../../helpers"
+import { resolveFalCredentials } from "../../../../../../mastra/services/fal-credentials"
+import { AI_USAGE_MODULE } from "../../../../../../modules/ai_usage"
+import type AiUsageService from "../../../../../../modules/ai_usage/service"
+import {
+  parseDepthInput,
+  extractDepthOutput,
+  DepthInputBody,
+} from "./depth-image"
+
+/**
+ * Estimate depth + normal maps for a partner-owned design.
+ * @route POST /partners/designs/{designId}/segment/depth
+ *
+ * @returns {Object} 200 - { depth: { depth_url, normal_url }, usage }
+ * @returns {Object} 402 - Monthly AI quota exhausted (upgrade required)
+ * @throws {MedusaError} 400 - Missing/invalid image input
+ * @throws {MedusaError} 401 - Partner authentication required
+ * @throws {MedusaError} 403 - Design is not owned by this partner
+ * @throws {MedusaError} 404 - Design not found
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest<DepthInputBody> & {
+    params: { designId: string }
+  },
+  res: MedusaResponse
+) => {
+  const { designId } = req.params
+
+  // Ownership guard (401/403/404). Self-serve designs only.
+  const { partner } = await assertPartnerOwnsDesign(req, designId)
+
+  // Validate input before touching quota or fal (400 on bad input).
+  const parsed = parseDepthInput(req.validatedBody)
+
+  const aiUsage = req.scope.resolve(
+    AI_USAGE_MODULE
+  ) as unknown as AiUsageService
+
+  // Soft-paywall: bounded free depth estimations per calendar month per
+  // partner. Mirrors describe-image/segment — record BEFORE the expensive call
+  // so it can't be raced; a failed fal call still consumes the slot (cheap
+  // behaviour until real subscriptions add metering refunds).
+  const quota = await aiUsage.checkQuota(partner.id, "image_depth")
+  if (!quota.allowed) {
+    res.status(402).json({
+      upgrade_required: true,
+      code: "ai_quota_exhausted",
+      message:
+        "You've used your free AI depth maps this month. Upgrade to keep going.",
+      used: quota.used,
+      limit: quota.limit,
+    })
+    return
+  }
+
+  const falKey = await resolveFalCredentials(req.scope as any)
+  if (!falKey) {
+    throw new MedusaError(
+      MedusaError.Types.UNEXPECTED_STATE,
+      "FAL credentials not configured. Contact support to enable AI image tools."
+    )
+  }
+
+  await aiUsage.recordUsage(partner.id, "image_depth", { designId })
+
+  const { fal } = await import("@fal-ai/client")
+  fal.config({ credentials: falKey })
+
+  // Resolve the input image URL (upload base64 to fal storage first).
+  let resolvedImageUrl: string
+  if (parsed.kind === "url") {
+    resolvedImageUrl = parsed.imageUrl
+  } else {
+    const buffer = Buffer.from(parsed.content, "base64")
+    const blob = new Blob([buffer], { type: parsed.mimeType })
+    const file = new File([blob], `depth-input.${parsed.extension}`, {
+      type: parsed.mimeType,
+    })
+    resolvedImageUrl = await fal.storage.upload(file)
+  }
+
+  const result = await fal.subscribe("fal-ai/image-preprocessors/midas", {
+    input: {
+      image_url: resolvedImageUrl,
+      a: 6.283185307179586,
+      background_threshold: 0.1,
+    } as any,
+  })
+
+  const depth = extractDepthOutput(result)
+
+  res.status(200).json({
+    depth,
+    usage: { used: quota.used + 1, limit: quota.limit },
+  })
+}

--- a/apps/backend/src/api/partners/designs/[designId]/segment/depth/validators.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/segment/depth/validators.ts
@@ -1,0 +1,13 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * Body validator for partner depth/normal estimation. Mirrors the admin depth
+ * route's accepted input (`image_url` OR `image_base64`); the handler enforces
+ * "at least one is required" via `parseDepthInput`.
+ */
+export const DepthImageSchema = z.object({
+  image_url: z.string().optional(),
+  image_base64: z.string().optional(),
+})
+
+export type DepthImageReq = z.infer<typeof DepthImageSchema>

--- a/apps/backend/src/api/partners/designs/__tests__/depth-image.unit.spec.ts
+++ b/apps/backend/src/api/partners/designs/__tests__/depth-image.unit.spec.ts
@@ -1,0 +1,78 @@
+import {
+  parseDepthInput,
+  extractDepthOutput,
+} from "../[designId]/segment/depth/depth-image"
+
+describe("parseDepthInput (#337 partner design depth)", () => {
+  it("returns url mode when image_url is provided", () => {
+    expect(parseDepthInput({ image_url: "https://cdn/x.png" })).toEqual({
+      kind: "url",
+      imageUrl: "https://cdn/x.png",
+    })
+  })
+
+  it("prefers image_url over image_base64", () => {
+    const out = parseDepthInput({
+      image_url: "https://cdn/x.png",
+      image_base64: "data:image/png;base64,AAA",
+    })
+    expect(out).toEqual({ kind: "url", imageUrl: "https://cdn/x.png" })
+  })
+
+  it("parses a valid base64 data URL into mime/content/extension", () => {
+    expect(
+      parseDepthInput({ image_base64: "data:image/jpeg;base64,SGVsbG8=" })
+    ).toEqual({
+      kind: "base64",
+      mimeType: "image/jpeg",
+      content: "SGVsbG8=",
+      extension: "jpeg",
+    })
+  })
+
+  it("throws when neither image_url nor image_base64 is provided", () => {
+    expect(() => parseDepthInput({})).toThrow(/image_url or image_base64/)
+    expect(() => parseDepthInput(null)).toThrow(/image_url or image_base64/)
+    expect(() => parseDepthInput(undefined)).toThrow(
+      /image_url or image_base64/
+    )
+  })
+
+  it("throws when image_base64 is not a valid data URL", () => {
+    expect(() => parseDepthInput({ image_base64: "not-a-data-url" })).toThrow(
+      /valid base64 data URL/
+    )
+  })
+})
+
+describe("extractDepthOutput (#337 partner design depth)", () => {
+  it("returns depth + normal urls from a fal MiDaS result", () => {
+    const result = {
+      data: {
+        depth_map: { url: "https://fal/depth.png" },
+        normal_map: { url: "https://fal/normal.png" },
+      },
+    }
+    expect(extractDepthOutput(result)).toEqual({
+      depth_url: "https://fal/depth.png",
+      normal_url: "https://fal/normal.png",
+    })
+  })
+
+  it("returns normal_url null when fal omits the normal map", () => {
+    const result = { data: { depth_map: { url: "https://fal/depth.png" } } }
+    expect(extractDepthOutput(result)).toEqual({
+      depth_url: "https://fal/depth.png",
+      normal_url: null,
+    })
+  })
+
+  it("throws UNEXPECTED_STATE when fal returned no depth map", () => {
+    expect(() => extractDepthOutput({ data: {} })).toThrow(
+      /MiDaS returned no depth map/
+    )
+    expect(() => extractDepthOutput(null)).toThrow(
+      /MiDaS returned no depth map/
+    )
+  })
+})

--- a/apps/backend/src/modules/ai_usage/service.ts
+++ b/apps/backend/src/modules/ai_usage/service.ts
@@ -7,6 +7,10 @@ export const MONTHLY_QUOTA = {
   // removal). Same free-tier soft-paywall policy as image_describe; no
   // migration needed (operation is a generic string column).
   image_segment: 10,
+  // Roadmap #6/#337 — partner depth/normal-map estimation (fal.ai MiDaS).
+  // Same free-tier soft-paywall policy as image_segment; no migration needed
+  // (operation is a generic string column).
+  image_depth: 10,
 } as const
 
 export type AiOperation = keyof typeof MONTHLY_QUOTA


### PR DESCRIPTION
## What
New `POST /partners/designs/:designId/segment/depth` — partner mirror of admin `POST /admin/designs/:id/segment/depth` (fal.ai **MiDaS** preprocessor: one call → grayscale **depth map** + RGB **normal map**). Same `{ depth: { depth_url, normal_url }, usage }` response shape.

Continues the #337 partner-design AI-parity work after #529 (segment / BiRefNet background removal). All admin design **GET** subroutes were already mirrored (#520/#524/#527/#528); the two admin AI **POST** ops are `segment` (#529) and `segment/depth` (this PR).

## How (mirrors the #529 segment recipe exactly)
- **Ownership-guarded** via `assertPartnerOwnsDesign` (401/403/404) — self-serve designs only.
- **Quota-metered** by a new `image_depth` key in `MONTHLY_QUOTA` (10/calendar-month soft-paywall, identical policy to `image_segment`). **No migration** — `ai_usage.operation` is a generic string column. 402 `{ upgrade_required }` on exhaustion; usage recorded BEFORE the fal call so it can't be raced.
- Pure `parseDepthInput` / `extractDepthOutput` helpers (`depth-image.ts`) keep fal input-parse + result-extract **unit-testable** without network.
- New per-route partner-auth + body-validation matcher in `middlewares.ts` (`DepthImageSchema`).

## Tests
- **8 unit tests** green (`depth-image.unit.spec.ts`) — input modes (url / base64 / prefer-url), bad-input throws, depth+normal extraction, null-normal, no-depth throws.
- `tsc` clean on changed files.

Additive, read/compute-only, no model/migration.

## ⚠ Stacked on #529 (merge parent-first)
Branched off `feat/337-partner-design-segment` because it appends to the same `middlewares.ts` partner-designs block. Chain: `main ← #528 (tasks) ← #529 (segment) ← this`. Merge **#528 → #529 → this** in order. Once #529 merges, GitHub will retarget this PR's base to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)