### PR TITLE
feat(partners): mirror admin design revise to partner-ui (#337) [stacked on #530]

### DIFF
--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -69,6 +69,7 @@ import { CreateMaterialTypeSchema, ReadRawMaterialCategoriesSchema } from "./adm
 import { CreateDesignLLMSchema, designSchema, LinkDesignPartnerSchema, ReadDesignsQuerySchema, UpdateDesignSchema } from "./admin/designs/validators";
 import { SegmentImageSchema } from "./admin/designs/[id]/segment/validators";
 import { DepthImageSchema } from "./partners/designs/[designId]/segment/depth/validators";
+import { ReviseDesignSchema as PartnerReviseDesignSchema } from "./partners/designs/[designId]/revise/validators";
 import { taskTemplateSchema, updateTaskTemplateSchema } from "./admin/task-templates/validators";
 import { AdminPostDesignTasksReq } from "./admin/designs/[id]/tasks/validators";
 import { AdminPutDesignTaskReq } from "./admin/designs/[id]/tasks/[taskId]/validators";
@@ -3908,6 +3909,18 @@ export default defineMiddlewares({
       middlewares: [
         authenticate("partner", ["session", "bearer"]),
         validateAndTransformBody(wrapSchema(DepthImageSchema)),
+      ],
+    },
+    {
+      // Roadmap #6/#337 — partner revises their OWN design (mirrors POST
+      // /admin/designs/:id/revise). Ownership-guarded + revisable-status
+      // pre-check in the handler; reviseDesignWorkflow re-links the partner
+      // to the new revision so it stays partner-owned & isolated.
+      matcher: "/partners/designs/:designId/revise",
+      method: "POST",
+      middlewares: [
+        authenticate("partner", ["session", "bearer"]),
+        validateAndTransformBody(wrapSchema(PartnerReviseDesignSchema)),
       ],
     },
     {

--- a/apps/backend/src/api/partners/designs/[designId]/revise/revisable.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/revise/revisable.ts
@@ -1,0 +1,36 @@
+/**
+ * @file Pure revisable-status guard for the partner revise route.
+ * @module API/Partners/Designs/Revise
+ *
+ * `reviseDesignWorkflow` only accepts designs in one of these statuses and
+ * otherwise throws a generic workflow error. The partner route pre-checks
+ * the design status with this pure helper so it can return a friendly
+ * `422 NOT_ALLOWED` BEFORE invoking the (expensive, multi-step) workflow.
+ *
+ * Kept as a standalone pure module so it is unit-testable without booting
+ * Medusa (there is no partner-design integration harness).
+ *
+ * Source of truth: `src/workflows/designs/revise-design.ts#REVISABLE_STATUSES`
+ * — keep these in sync.
+ */
+export const REVISABLE_STATUSES = [
+  "Approved",
+  "Commerce_Ready",
+  "In_Development",
+  "Sample_Production",
+  "Technical_Review",
+] as const
+
+export type RevisableStatus = (typeof REVISABLE_STATUSES)[number]
+
+/**
+ * Is a design in a status from which a new revision may be created?
+ * @param status The design's current status (may be null/undefined).
+ * @returns true only when the status is one of REVISABLE_STATUSES.
+ */
+export function isDesignRevisable(status: string | null | undefined): boolean {
+  if (!status) {
+    return false
+  }
+  return (REVISABLE_STATUSES as readonly string[]).includes(status)
+}

--- a/apps/backend/src/api/partners/designs/[designId]/revise/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/revise/route.ts
@@ -1,0 +1,73 @@
+/**
+ * @file Partner API route to revise a partner-owned design.
+ * @module API/Partners/Designs/Revise
+ *
+ * Roadmap #6/#337 — promote admin Designs to partner-ui. Mirrors
+ * `POST /admin/designs/:id/revise` (same `reviseDesignWorkflow` call and
+ * `{ design, message }` response shape), but guarded to the OWNING partner.
+ *
+ * Why this mutating route is safe to self-serve (unlike the other admin
+ * design mutations — approve/notify-customer/partner/cancel-assignment):
+ *   - It operates on the partner's OWN design only (`assertPartnerOwnsDesign`,
+ *     `owner_partner_id === partner.id`).
+ *   - `reviseDesignWorkflow` re-creates the partner ↔ design link on the new
+ *     revision (see its `linkPartnersToNewDesignStep`), so the revision stays
+ *     partner-owned and isolated — no cross-tenant leak.
+ *   - No external side-effects: it does not create a storefront product,
+ *     email a customer, or change partner assignments.
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { MedusaError } from "@medusajs/framework/utils"
+import { reviseDesignWorkflow } from "../../../../../workflows/designs/revise-design"
+import { assertPartnerOwnsDesign } from "../../helpers"
+import { ReviseDesignInput } from "./validators"
+import { isDesignRevisable, REVISABLE_STATUSES } from "./revisable"
+
+/**
+ * Create a new revision of a partner-owned design; the original is superseded.
+ * @route POST /partners/designs/{designId}/revise
+ *
+ * @returns {Object} 200 - { design, message }
+ * @throws {MedusaError} 401 - Partner authentication required
+ * @throws {MedusaError} 404 - Design not found
+ * @throws {MedusaError} 400 (NOT_ALLOWED) - Design not owned by this partner
+ * @throws {MedusaError} 400 (NOT_ALLOWED) - Design status is not revisable
+ */
+export async function POST(
+  req: AuthenticatedMedusaRequest<ReviseDesignInput> & {
+    params: { designId: string }
+  },
+  res: MedusaResponse
+): Promise<void> {
+  const { designId } = req.params
+
+  // Ownership guard (401/404/NOT_ALLOWED). Only the partner that created the
+  // design may revise it — an admin-assigned design is not theirs to fork.
+  const { design } = await assertPartnerOwnsDesign(req, designId)
+
+  // Friendly pre-flight so the partner gets a clear 422 instead of the
+  // generic error the workflow throws for a non-revisable status.
+  if (!isDesignRevisable(design.status)) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `Design cannot be revised from status "${design.status}". Must be one of: ${REVISABLE_STATUSES.join(", ")}`
+    )
+  }
+
+  const { revision_notes, overrides } = req.validatedBody
+
+  const { result } = await reviseDesignWorkflow(req.scope).run({
+    input: {
+      design_id: designId,
+      revision_notes,
+      overrides,
+    },
+    throwOnError: true,
+  })
+
+  res.status(200).json({
+    design: result,
+    message:
+      "Design revised successfully. Original design has been superseded.",
+  })
+}

--- a/apps/backend/src/api/partners/designs/[designId]/revise/validators.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/revise/validators.ts
@@ -1,0 +1,28 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * Partner-side revise-design body schema. Mirrors the admin schema
+ * (`/admin/designs/:id/revise`) exactly so the partner wire contract is
+ * identical — only the auth/ownership scope differs (enforced in the route).
+ */
+export const ReviseDesignSchema = z.object({
+  revision_notes: z.string().min(1, "Revision notes are required"),
+  overrides: z
+    .object({
+      name: z.string().optional(),
+      description: z.string().optional(),
+      priority: z.enum(["Low", "Medium", "High", "Urgent"]).optional(),
+      designer_notes: z.string().optional(),
+      tags: z.array(z.string()).optional(),
+      target_completion_date: z
+        .union([z.date(), z.string().datetime()])
+        .optional()
+        .transform((val) => {
+          if (!val) return undefined
+          return val instanceof Date ? val : new Date(val)
+        }),
+    })
+    .optional(),
+})
+
+export type ReviseDesignInput = z.infer<typeof ReviseDesignSchema>

--- a/apps/backend/src/api/partners/designs/__tests__/revisable.unit.spec.ts
+++ b/apps/backend/src/api/partners/designs/__tests__/revisable.unit.spec.ts
@@ -1,0 +1,43 @@
+import {
+  isDesignRevisable,
+  REVISABLE_STATUSES,
+} from "../[designId]/revise/revisable"
+
+describe("isDesignRevisable (#337 partner design revise)", () => {
+  it("returns true for every revisable status", () => {
+    for (const status of REVISABLE_STATUSES) {
+      expect(isDesignRevisable(status)).toBe(true)
+    }
+  })
+
+  it("returns false for a non-revisable status (e.g. Conceptual/Rejected)", () => {
+    expect(isDesignRevisable("Conceptual")).toBe(false)
+    expect(isDesignRevisable("Rejected")).toBe(false)
+    expect(isDesignRevisable("Superseded")).toBe(false)
+  })
+
+  it("returns false for null/undefined/empty status (no crash)", () => {
+    expect(isDesignRevisable(null)).toBe(false)
+    expect(isDesignRevisable(undefined)).toBe(false)
+    expect(isDesignRevisable("")).toBe(false)
+  })
+
+  it("is case-sensitive (matches the workflow's exact-string check)", () => {
+    expect(isDesignRevisable("approved")).toBe(false)
+    expect(isDesignRevisable("APPROVED")).toBe(false)
+    expect(isDesignRevisable("Approved")).toBe(true)
+  })
+
+  it("mirrors the workflow's REVISABLE_STATUSES set exactly", () => {
+    // Guards against drift from src/workflows/designs/revise-design.ts
+    expect([...REVISABLE_STATUSES].sort()).toEqual(
+      [
+        "Approved",
+        "Commerce_Ready",
+        "In_Development",
+        "Sample_Production",
+        "Technical_Review",
+      ].sort()
+    )
+  })
+})

--- a/apps/docs/notes/337_PARTNER_DESIGN_MUTATION_PARITY.md
+++ b/apps/docs/notes/337_PARTNER_DESIGN_MUTATION_PARITY.md
@@ -1,0 +1,119 @@
+# #337 — Partner-design mutation parity: remaining decision-bearing routes
+
+_Written 2026-06-19 (daemon chunk 4/10). Companion to the merged read/AI-parity
+slices and PR #531 (`revise`)._
+
+## Status of #337 design parity
+
+| Admin subroute | Method | Partner mirror | Notes |
+|---|---|---|---|
+| `revisions` | GET | ✅ #520 | merged |
+| `used-in` | GET | ✅ #524 | merged |
+| `components` | GET | ✅ #527 | merged |
+| `tasks` | GET | ✅ #528 (open) | read-only |
+| `consumption-logs` / `inventory` / `production-runs` / `recalculate-cost` | GET/POST | ✅ earlier phases | self-serve already shipped |
+| `segment` | POST | ✅ #529 (open) | fal BiRefNet, quota-gated |
+| `segment/depth` | POST | ✅ #530 (open) | fal MiDaS, quota-gated |
+| **`revise`** | **POST** | **✅ #531 (open)** | **this chunk — own-design fork, ownership preserved** |
+| `approve` | POST | ❌ decision | see below |
+| `notify-customer` | POST | ❌ decision | see below |
+| `partner` | POST/DELETE | ❌ admin-only | see below |
+| `cancel-partner-assignment` | POST | ❌ decision | see below |
+| `link-media-folder` | POST/DELETE | ❌ near-clean | see below |
+
+**All GET (read), both AI POSTs, and the own-design `revise` POST are now
+mirrored.** What remains are 5 mutating routes that each raise a product
+question. Recommendations below, ranked easiest → hardest.
+
+---
+
+## 1. `link-media-folder` (POST + DELETE) — **near-clean, build next**
+`apps/backend/src/api/admin/designs/[id]/link-media-folder/route.ts`
+
+Links/replaces (one-to-one) a media **folder** to the design via `remoteLink`.
+Partner already has a `media` GET subroute, so managing their own design's
+media folder is natural self-serve.
+
+- **The one gap:** must add a **folder-ownership guard**. Today the admin route
+  trusts any `folder_id`; a partner could otherwise link/steal-display another
+  tenant's (or admin's) folder. Need an `assertPartnerOwnsFolder(req, folder_id)`
+  helper (check folder's owning partner / store) alongside `assertPartnerOwnsDesign`.
+- **Recommendation:** buildable once folder-ownership scoping exists. Confirm how
+  media folders are owned/scoped per partner first (check `modules/media` +
+  any `*_partner` link). If folders are not partner-scoped yet, this is blocked
+  on that model work — escalate.
+
+## 2. `revise` — **DONE this chunk (PR #531).** Reference implementation for "own-design mutation".
+
+## 3. `approve` (POST) — **decision-bearing (heavy)**
+`approve/route.ts`
+
+Transitions design → `Approved`, **creates a real Medusa product/variant**
+(`createProductFromDesignWorkflow`), and emits `design.approved`.
+
+Open decisions before a partner mirror:
+- **Should partners self-approve at all?** Approval publishes a sellable product
+  to a storefront — this is the core "partner self-serve commerce" gate. Aligns
+  with the SaaS vision but is a real authority decision.
+- **Currency:** admin hardcodes `currency_code: "usd"`. A partner mirror MUST use
+  `resolveStoreCurrency(container, {partnerId})` (the #485 helper, PR #505) — this
+  is exactly the EUR-leak class of bug.
+- **Sales channel:** the created product must be scoped to the **partner's** store
+  sales channel, not the platform default (storefront isolation).
+- **Customer link:** admin looks up a design→customer link; partner-owned designs
+  may have no customer. Decide behaviour when absent (already handled as `""`).
+- **Recommendation:** build only after a product call on (a) self-approve gating
+  and (b) wiring currency + sales-channel from the partner store. Ties into #485.
+
+## 4. `notify-customer` (POST) — **decision-bearing (depends on #332)**
+`notify-customer/route.ts`
+
+Sends/re-sends the "design assigned" email to the **customer** linked to the
+design, with a URL hardcoded to `STORE_URL`/`cicilabel.com`.
+
+- **Decisions:** which email template/branding for a partner-originated notice;
+  the storefront URL must derive from the **partner's** storefront (the #377
+  `resolvePartnerStorefrontUrl` pattern), not `cicilabel.com`.
+- **Dependency:** partner email deliverability (#332) should be confirmed first.
+- **Recommendation:** defer until #332 closes; then mirror with partner-storefront
+  URL + partner-branded template.
+
+## 5. `cancel-partner-assignment` (POST) — **reframe, not a direct mirror**
+`cancel-partner-assignment/route.ts`
+
+Admin action **about** a partner: cancels that partner's active production runs +
+tasks and optionally unlinks. Semantically this is "admin pulls work from a partner".
+
+- A partner doing this to **themselves** is conceptually "**decline / withdraw from
+  this assignment**", which is a different UX and may need different side-effects
+  (e.g. notify admin, leave the design assignable). Don't blindly mirror.
+- **Recommendation:** design a partner-facing "decline assignment" route rather
+  than mirroring the admin cancel verbatim. Decision-bearing.
+
+## 6. `partner` (POST link / DELETE unlink) — **keep admin-only**
+`partner/route.ts`
+
+Links/unlinks **partners** to a design — i.e. assignment authority. A partner
+managing design↔partner links (especially adding *other* partners) is a clear
+authority violation; a partner linking *themselves* already happens implicitly at
+design creation.
+
+- **Recommendation:** do **not** mirror to partner-ui. Assignment stays an admin
+  capability. Close this as out-of-scope for partner self-serve.
+
+---
+
+## Suggested build order (once decisions land)
+1. `link-media-folder` — after confirming/adding partner folder ownership.
+2. `approve` — after self-approve + currency/sales-channel decision (with #485 helper).
+3. `notify-customer` — after #332 + partner-storefront URL.
+4. `cancel-partner-assignment` — redesign as "decline assignment".
+5. `partner` — keep admin-only (no mirror).
+
+## Recipe reference
+All partner-design routes follow the parity recipe in
+`scripts/agent-daemon/CODEBASE_MAP.md` (§ Partner API parity): copy the admin
+handler shape, add `assertPartnerOwnsDesign` (ownership = full boundary for
+own-design ops; add a scope-filter only when a cross-design relation can leak),
+register a per-route `authenticate("partner", …)` matcher in `middlewares.ts`,
+extract pure helpers for unit tests (no integration harness exists).


### PR DESCRIPTION
## What
`POST /partners/designs/:designId/revise` — partner-ui mirror of admin `POST /admin/designs/:id/revise`. A partner creates a new revision of **their own** design; the original is superseded.

Same `reviseDesignWorkflow` call + `{ design, message }` response shape as admin — only the auth/ownership scope differs.

## Why this mutating route is safe to self-serve
The other unmirrored admin design mutations (`approve`, `notify-customer`, `partner`, `cancel-partner-assignment`, `link-media-folder`) are **decision-bearing** — they create storefront products, email customers, or change partner assignments. `revise` is not:
- Operates only on the partner's **own** design (`assertPartnerOwnsDesign`, `owner_partner_id === partner.id`).
- `reviseDesignWorkflow` **re-creates the partner ↔ design link** on the new revision (its `linkPartnersToNewDesignStep`), so the revision stays partner-owned & isolated — verified by reading the workflow; no cross-tenant leak.
- No external side-effects (no product creation, customer email, assignment change).

## How
- `revise/validators.ts` — `ReviseDesignSchema` mirrors admin's exactly.
- `revise/revisable.ts` — pure `isDesignRevisable()` + `REVISABLE_STATUSES`; the route pre-checks status for a friendly `422` instead of the workflow's generic error.
- `revise/route.ts` — ownership guard → revisable pre-check → workflow → `{ design, message }`.
- `middlewares.ts` — per-route partner auth + `validateAndTransformBody`.

## Tests
- 5 unit tests (`revisable.unit.spec.ts`) — all green. `tsc` clean on changed files.
- No partner-design integration harness exists (unit-only convention) → live smoke deferred.

## Stacking
Stacked on **#530** (`feat/337-partner-design-depth`) because it appends to the same `middlewares.ts` partner-designs matcher block. **Merge chain: main ← #528 ← #529 ← #530 ← this.**

## Note for reviewers
This completes the *clean* (non-decision-bearing) slices of #337 design parity. The remaining 5 admin design mutations are decision-bearing — analysis + recommendations are in `apps/docs/notes/337_PARTNER_DESIGN_MUTATION_PARITY.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)