### PR TITLE
feat(#337): partner design tasks create (POST) parity [stacked on #531]

### DIFF
--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -183,6 +183,7 @@ import { listProductionRunsQuerySchema } from "./partners/production-runs/valida
 import { PartnerPostDesignInventoryReq, PartnerPatchDesignInventoryLinkReq, PartnerDeleteDesignInventoryReq } from "./partners/designs/[designId]/inventory/validators";
 import { PartnerCreateProductionRunReq } from "./partners/designs/[designId]/production-runs/validators";
 import { PartnerPostConsumptionLogReq } from "./partners/designs/[designId]/consumption-logs/validators";
+import { PartnerPostDesignTasksReq } from "./partners/designs/[designId]/tasks/validators";
 import { PartnerPostProductionRunConsumptionLogReq } from "./partners/production-runs/[id]/consumption-logs/validators";
 import { listPartnersQuerySchema, PostPartnerSchema } from "./admin/partners/validators";
 import { ListIdentitiesQuerySchema } from "./admin/users/identities/validators";
@@ -3886,6 +3887,17 @@ export default defineMiddlewares({
       matcher: "/partners/designs/:designId/tasks",
       method: "GET",
       middlewares: [authenticate("partner", ["session", "bearer"])],
+    },
+    {
+      // Roadmap #6/#337 — partner creates tasks on their OWN design (mirrors
+      // POST /admin/designs/:id/tasks, createTasksFromTemplatesWorkflow).
+      // Ownership-guarded; no assignee/external side-effects in the handler.
+      matcher: "/partners/designs/:designId/tasks",
+      method: "POST",
+      middlewares: [
+        authenticate("partner", ["session", "bearer"]),
+        validateAndTransformBody(wrapSchema(PartnerPostDesignTasksReq)),
+      ],
     },
     {
       // Roadmap #6/#337 — partner image segmentation (mirrors POST

--- a/apps/backend/src/api/partners/designs/[designId]/tasks/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/tasks/route.ts
@@ -8,13 +8,25 @@
  * children of the design, so the design-ownership guard is the security
  * boundary — there is no cross-design relation to leak through here.
  *
- * Read-only (GET) only. Partner-side task creation (the admin POST) is a
- * separate, decision-bearing slice and is intentionally NOT mirrored yet.
+ * GET mirrors `GET /admin/designs/:id/tasks`; POST mirrors
+ * `POST /admin/designs/:id/tasks` (same `createTasksFromTemplatesWorkflow`
+ * call + `{ taskLinks: { list, count }, message }` response). Both are guarded
+ * to the owning partner.
+ *
+ * Why the POST is safe to self-serve (unlike approve/notify-customer/
+ * partner/cancel-assignment): it only attaches tasks — optionally from shared
+ * admin task-templates — to the partner's OWN design. There is no assignee/
+ * partner field in the body, no storefront product created, no customer email,
+ * and no partner-assignment change, so design ownership is the full boundary.
  */
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { createTasksFromTemplatesWorkflow } from "../../../../../workflows/designs/create-tasks-from-templates"
+import { refetchTask } from "../../../../admin/designs/[id]/tasks/helpers"
 import { assertPartnerOwnsDesign } from "../../helpers"
 import { extractDesignTasks, DesignTasksRow } from "./extract-tasks"
+import { PartnerPostDesignTasksReqType } from "./validators"
+import { selectCreatedTaskIds } from "./select-task-ids"
 
 /**
  * List the tasks of a partner-owned design.
@@ -47,4 +59,53 @@ export async function GET(
   const tasks = extractDesignTasks(data as DesignTasksRow[])
 
   res.status(200).json({ tasks })
+}
+
+/**
+ * Create one or more tasks for a partner-owned design (optionally from shared
+ * admin task-templates). Mirrors `POST /admin/designs/:id/tasks`.
+ * @route POST /partners/designs/{designId}/tasks
+ *
+ * @returns {Object} 200 - { taskLinks: { list, count }, message }
+ * @throws {MedusaError} 401 - Partner authentication required
+ * @throws {MedusaError} 403 - Design is not owned by this partner
+ * @throws {MedusaError} 404 - Design not found
+ */
+export async function POST(
+  req: AuthenticatedMedusaRequest<PartnerPostDesignTasksReqType> & {
+    params: { designId: string }
+  },
+  res: MedusaResponse
+) {
+  const { designId } = req.params
+
+  // Ownership guard (401/403/404). Only the owning partner may add tasks to
+  // their own design — an admin-assigned design is not theirs to mutate.
+  await assertPartnerOwnsDesign(req, designId)
+
+  const { result: list } = await createTasksFromTemplatesWorkflow(
+    req.scope
+  ).run({
+    input: {
+      ...(req.validatedBody as any),
+      designId,
+    },
+  })
+
+  const workflowResponse = list[0] as any
+  const taskLinks = (list[1] as any[]) || []
+
+  const taskIds = selectCreatedTaskIds(workflowResponse, taskLinks)
+
+  const tasks = taskIds.length
+    ? await refetchTask(taskIds, req.scope, ["*"])
+    : []
+
+  res.status(200).json({
+    taskLinks: {
+      list: Array.isArray(tasks) ? tasks : [tasks],
+      count: taskLinks.length,
+    },
+    message: `Design ${designId} successfully created ${taskLinks.length} tasks from templates`,
+  })
 }

--- a/apps/backend/src/api/partners/designs/[designId]/tasks/select-task-ids.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/tasks/select-task-ids.ts
@@ -1,0 +1,42 @@
+/**
+ * Pure helper — selects the IDs of the tasks created by
+ * `createTasksFromTemplatesWorkflow`, mirroring the admin route's branching on
+ * the workflow-response flags (`withTemplates` / `withParent` / `withoutTemplates`).
+ *
+ * Extracted so it is unit-testable without booting Medusa (no partner-design
+ * integration harness exists). Unlike the admin route — which indexes
+ * `taskLinks[0].id` directly and would throw on an empty array — this helper is
+ * defensive: it never throws on missing/empty input.
+ */
+
+export type TaskCreationFlags = {
+  withTemplates?: boolean
+  withParent?: boolean
+  withoutTemplates?: boolean
+}
+
+export type CreatedTaskLink = { id?: string | null }
+
+export function selectCreatedTaskIds(
+  flags: TaskCreationFlags | null | undefined,
+  taskLinks: CreatedTaskLink[] | null | undefined
+): string[] {
+  if (!Array.isArray(taskLinks) || taskLinks.length === 0) {
+    return []
+  }
+
+  const ids = (links: CreatedTaskLink[]): string[] =>
+    links.map((t) => t?.id).filter((id): id is string => Boolean(id))
+
+  if (flags?.withTemplates) {
+    return ids(taskLinks)
+  }
+  if (flags?.withParent) {
+    return ids(taskLinks)
+  }
+  if (flags?.withoutTemplates) {
+    return ids(taskLinks.slice(0, 1))
+  }
+
+  return []
+}

--- a/apps/backend/src/api/partners/designs/[designId]/tasks/validators.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/tasks/validators.ts
@@ -1,0 +1,90 @@
+import { z } from "@medusajs/framework/zod"
+import { PriorityLevel, Status } from "../../../../../workflows/tasks/create-task"
+
+/**
+ * Partner-side create-design-tasks body schema. Mirrors the admin schema
+ * (`POST /admin/designs/:id/tasks`, `AdminPostDesignTasksReq`) EXACTLY so the
+ * partner wire contract is identical — only the auth/ownership scope differs
+ * (enforced in the route via `assertPartnerOwnsDesign`).
+ *
+ * Note: there is intentionally NO assignee/partner field — task creation only
+ * attaches tasks (optionally from shared admin task-templates) to the partner's
+ * OWN design, so there is no cross-tenant vector to gate.
+ */
+
+// ============= Constants =============
+const TASK_PRIORITIES = ["low", "medium", "high"] as const
+const DEPENDENCY_TYPES = ["blocking", "non_blocking", "subtask", "related"] as const
+const CHILD_TASK_STATUSES = [
+  "pending",
+  "in_progress",
+  "completed",
+  "cancelled",
+  "accepted",
+] as const
+
+// ============= Utilities =============
+const dateTransformer = (val: unknown): Date | undefined => {
+  if (typeof val === "string") {
+    const date = new Date(val)
+    return isNaN(date.getTime()) ? undefined : date
+  }
+  return val as Date | undefined
+}
+
+// ============= Base Schema =============
+const BaseTaskSchema = z.object({
+  title: z.string().optional(),
+  description: z.string().optional(),
+  priority: z.nativeEnum(PriorityLevel).optional(),
+  status: z.nativeEnum(Status).optional(),
+  due_date: z.preprocess(dateTransformer, z.date()).optional(),
+  start_date: z
+    .preprocess(dateTransformer, z.date())
+    .optional()
+    .default(() => new Date()),
+  metadata: z.record(z.string(), z.any()).optional(),
+})
+
+// ============= Child Task Schema =============
+const ChildTaskSchema = z.object({
+  title: z.string().optional(),
+  description: z.string().optional(),
+  priority: z.enum(TASK_PRIORITIES).optional(),
+  status: z.enum(CHILD_TASK_STATUSES).optional(),
+  dependency_type: z.enum(DEPENDENCY_TYPES),
+})
+
+// ============= Template Based Creation Schema =============
+const TemplateBasedCreation = z.object({
+  template_names: z
+    .array(z.string())
+    .min(1, "At least one template name is required"),
+  child_tasks: z.array(ChildTaskSchema).optional(),
+  metadata: z.record(z.string(), z.any()).optional(),
+  dependency_type: z.enum(DEPENDENCY_TYPES).optional(),
+})
+
+// ============= Parent Task Schema =============
+const ParentTaskSchema = BaseTaskSchema.extend({
+  template_names: z.array(z.string()).optional(),
+  parent_task_id: z.string().optional(),
+  child_tasks: z.array(ChildTaskSchema).optional(),
+  dependency_type: z.enum(DEPENDENCY_TYPES).optional(),
+})
+
+// ============= Multiple Tasks Creation Schema =============
+const MultipleTasksCreation = z.object({
+  tasks: z.array(ParentTaskSchema).min(1, "At least one task is required"),
+})
+
+// Export the schema (discriminated union — identical to admin)
+export const PartnerPostDesignTasksReq = z.discriminatedUnion("type", [
+  TemplateBasedCreation.extend({ type: z.literal("template") }),
+  ParentTaskSchema.extend({ type: z.literal("task") }),
+  MultipleTasksCreation.extend({ type: z.literal("multiple") }),
+])
+
+export type PartnerPostDesignTasksReqType = z.infer<
+  typeof PartnerPostDesignTasksReq
+>

--- a/apps/backend/src/api/partners/designs/__tests__/select-task-ids.unit.spec.ts
+++ b/apps/backend/src/api/partners/designs/__tests__/select-task-ids.unit.spec.ts
@@ -1,0 +1,50 @@
+import { selectCreatedTaskIds } from "../[designId]/tasks/select-task-ids"
+
+describe("selectCreatedTaskIds (#337 partner design tasks POST)", () => {
+  it("returns all task ids when withTemplates is set", () => {
+    const ids = selectCreatedTaskIds({ withTemplates: true }, [
+      { id: "t1" },
+      { id: "t2" },
+      { id: "t3" },
+    ])
+    expect(ids).toEqual(["t1", "t2", "t3"])
+  })
+
+  it("returns all task ids when withParent is set", () => {
+    const ids = selectCreatedTaskIds({ withParent: true }, [
+      { id: "p1" },
+      { id: "c1" },
+    ])
+    expect(ids).toEqual(["p1", "c1"])
+  })
+
+  it("returns only the first task id when withoutTemplates is set", () => {
+    const ids = selectCreatedTaskIds({ withoutTemplates: true }, [
+      { id: "single" },
+      { id: "ignored" },
+    ])
+    expect(ids).toEqual(["single"])
+  })
+
+  it("returns [] when no flag matches", () => {
+    expect(selectCreatedTaskIds({}, [{ id: "t1" }])).toEqual([])
+    expect(selectCreatedTaskIds(null, [{ id: "t1" }])).toEqual([])
+    expect(selectCreatedTaskIds(undefined, [{ id: "t1" }])).toEqual([])
+  })
+
+  it("never throws on empty/missing taskLinks (admin route would crash here)", () => {
+    expect(selectCreatedTaskIds({ withoutTemplates: true }, [])).toEqual([])
+    expect(selectCreatedTaskIds({ withTemplates: true }, null)).toEqual([])
+    expect(selectCreatedTaskIds({ withParent: true }, undefined)).toEqual([])
+  })
+
+  it("filters out null/empty ids defensively", () => {
+    const ids = selectCreatedTaskIds({ withTemplates: true }, [
+      { id: "t1" },
+      { id: null },
+      { id: "" },
+      { id: "t2" },
+    ])
+    expect(ids).toEqual(["t1", "t2"])
+  })
+})


### PR DESCRIPTION
## What

Mirrors `POST /admin/designs/:id/tasks` into partner-ui:
`POST /partners/designs/:designId/tasks` lets a partner create one or more
tasks (inline, parent/child, or from shared admin task-templates) on **their
own** design via `createTasksFromTemplatesWorkflow`. Same `{ taskLinks: { list, count }, message }` wire shape as admin.

## Why this mutating route is safe to self-serve

Unlike the other deferred admin design mutations (`approve` / `notify-customer` / `partner` / `cancel-partner-assignment`), this one raises **no product decision** on inspection:

- **Ownership-guarded** by `assertPartnerOwnsDesign` — only the owning partner can add tasks; an admin-assigned design is not theirs to mutate.
- **No assignee/partner field** in the body (the admin JSDoc mentioning `assigneeId` is stale — the actual `AdminPostDesignTasksReq` schema has none). Nothing to gate cross-tenant.
- **No external side-effects**: the workflow only creates tasks and links them to the design (`createDesignTaskLinksStep`) — no storefront product, no customer email, no partner-assignment change.
- **Templates are shared admin resources**, not tenant data.

This is the same "deferred-as-decision-bearing but actually clean own-design mutation" realization as `revise` (#531).

## Changes
- `tasks/route.ts` — add `POST` handler (GET unchanged).
- `tasks/validators.ts` (new) — `PartnerPostDesignTasksReq`, a duplicate of the admin discriminated union so the wire contract is identical.
- `tasks/select-task-ids.ts` (new) — pure, null-safe `selectCreatedTaskIds` (admin indexes `taskLinks[0].id` directly and would crash on empty).
- `__tests__/select-task-ids.unit.spec.ts` (new) — 6 unit tests.
- `middlewares.ts` — register the POST matcher (`authenticate("partner") + validateAndTransformBody`).

## Verification
- ✅ 6 unit tests green (`jest select-task-ids`).
- ✅ `tsc --noEmit` clean for all changed files.
- No partner-design integration harness exists (unit-only, per prior #337 slices).

## Stacking
**Stacked on #531** (`feat/337-partner-design-revise`) — both append to the same `middlewares.ts` partner-designs matcher block. **Merge the #337 chain parent-first: #528 → #529 → #530 → #531 → this.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)