### PR TITLE
feat(ops): #508 — repair-inventory-raw-material-links data-plumbing job

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/repair-inventory-raw-material-links.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/repair-inventory-raw-material-links.unit.spec.ts
@@ -1,0 +1,157 @@
+import {
+  diffInventoryRawMaterialLinks,
+  getMaintenanceJob,
+  MAINTENANCE_JOBS,
+  MAX_RAW_MATERIAL_LINK_SCAN,
+  repairInventoryRawMaterialLinksJob,
+  summarizeRawMaterialLinkRepair,
+} from "../registry"
+
+/**
+ * #508 — pure logic for the `repair-inventory-raw-material-links` maintenance
+ * job. The container-bound run() (query.graph enumerate + module existence
+ * checks + remoteLink.dismiss) is exercised by the API contract integration
+ * test; here we lock down the orphan-detection decision and the summary string
+ * without booting the DB.
+ */
+describe("repair-inventory-raw-material-links — diffInventoryRawMaterialLinks", () => {
+  it("keeps a link whose inventory item AND raw material both exist", () => {
+    const changes = diffInventoryRawMaterialLinks(
+      [{ inventory_item_id: "iitem_1", raw_materials_id: "rm_1" }],
+      new Set(["iitem_1"]),
+      new Set(["rm_1"])
+    )
+    expect(changes).toEqual([])
+  })
+
+  it("removes an orphan whose inventory item was deleted", () => {
+    const changes = diffInventoryRawMaterialLinks(
+      [{ inventory_item_id: "iitem_gone", raw_materials_id: "rm_1" }],
+      new Set(), // inventory item no longer exists
+      new Set(["rm_1"])
+    )
+    expect(changes).toEqual([
+      {
+        entity: "inventory_item_raw_materials",
+        id: "iitem_gone:rm_1",
+        field: "remove_orphan_link",
+        before: {
+          inventory_item_id: "iitem_gone",
+          raw_materials_id: "rm_1",
+          missing: "inventory_item",
+        },
+        after: null,
+      },
+    ])
+  })
+
+  it("removes an orphan whose raw material was deleted", () => {
+    const changes = diffInventoryRawMaterialLinks(
+      [{ inventory_item_id: "iitem_1", raw_materials_id: "rm_gone" }],
+      new Set(["iitem_1"]),
+      new Set() // raw material no longer exists
+    )
+    expect(changes).toEqual([
+      {
+        entity: "inventory_item_raw_materials",
+        id: "iitem_1:rm_gone",
+        field: "remove_orphan_link",
+        before: {
+          inventory_item_id: "iitem_1",
+          raw_materials_id: "rm_gone",
+          missing: "raw_material",
+        },
+        after: null,
+      },
+    ])
+  })
+
+  it("tags 'both' when neither side exists", () => {
+    const changes = diffInventoryRawMaterialLinks(
+      [{ inventory_item_id: "iitem_gone", raw_materials_id: "rm_gone" }],
+      new Set(),
+      new Set()
+    )
+    expect(changes).toHaveLength(1)
+    expect((changes[0].before as any).missing).toBe("both")
+  })
+
+  it("skips malformed rows missing either id (can't be dismissed)", () => {
+    const changes = diffInventoryRawMaterialLinks(
+      [
+        { inventory_item_id: "iitem_1", raw_materials_id: null },
+        { inventory_item_id: null, raw_materials_id: "rm_1" },
+        { inventory_item_id: "", raw_materials_id: "" },
+      ],
+      new Set(),
+      new Set()
+    )
+    expect(changes).toEqual([])
+  })
+
+  it("de-duplicates a repeated pivot pair (reports once)", () => {
+    const changes = diffInventoryRawMaterialLinks(
+      [
+        { inventory_item_id: "iitem_gone", raw_materials_id: "rm_1" },
+        { inventory_item_id: "iitem_gone", raw_materials_id: "rm_1" },
+      ],
+      new Set(),
+      new Set(["rm_1"])
+    )
+    expect(changes).toHaveLength(1)
+  })
+
+  it("handles a mixed batch: keep the valid one, remove both orphans", () => {
+    const changes = diffInventoryRawMaterialLinks(
+      [
+        { inventory_item_id: "iitem_keep", raw_materials_id: "rm_keep" }, // both live → keep
+        { inventory_item_id: "iitem_gone", raw_materials_id: "rm_keep" }, // item gone → remove
+        { inventory_item_id: "iitem_keep", raw_materials_id: "rm_gone" }, // rm gone → remove
+      ],
+      new Set(["iitem_keep"]),
+      new Set(["rm_keep"])
+    )
+    expect(changes.map((c) => c.id)).toEqual([
+      "iitem_gone:rm_keep",
+      "iitem_keep:rm_gone",
+    ])
+  })
+})
+
+describe("repair-inventory-raw-material-links — summarizeRawMaterialLinkRepair", () => {
+  it("reports no changes when nothing is orphaned", () => {
+    expect(summarizeRawMaterialLinkRepair(true, 5, 0, 0)).toBe(
+      "No changes — scanned 5 inventory↔raw-material link(s), none orphaned"
+    )
+  })
+
+  it("uses 'Would' for a dry run", () => {
+    expect(summarizeRawMaterialLinkRepair(true, 8, 2, 0)).toBe(
+      "Would remove 2 orphan link(s) whose inventory item or raw material no longer exists (scanned 8)"
+    )
+  })
+
+  it("uses 'Did' for an applied run and appends an error count", () => {
+    expect(summarizeRawMaterialLinkRepair(false, 8, 1, 1)).toBe(
+      "Did remove 1 orphan link(s) whose inventory item or raw material no longer exists (scanned 8); 1 error(s)"
+    )
+  })
+})
+
+describe("repair-inventory-raw-material-links — registry wiring", () => {
+  it("is registered and discoverable by id", () => {
+    expect(getMaintenanceJob("repair-inventory-raw-material-links")).toBe(
+      repairInventoryRawMaterialLinksJob
+    )
+    expect(MAINTENANCE_JOBS).toContain(repairInventoryRawMaterialLinksJob)
+  })
+
+  it("declares an optional limit param and a sane cap", () => {
+    expect(MAX_RAW_MATERIAL_LINK_SCAN).toBeGreaterThan(0)
+    const names = repairInventoryRawMaterialLinksJob.params.map((p) => p.name)
+    expect(names).toEqual(expect.arrayContaining(["limit"]))
+    expect(
+      repairInventoryRawMaterialLinksJob.params.every((p) => p.required === false)
+    ).toBe(true)
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -2332,6 +2332,231 @@ export const backfillConsumptionLogProductionRunIdJob: MaintenanceJob = {
   },
 }
 
+/**
+ * Hard cap on the raw-material link-repair scan. Each call enumerates the
+ * `inventory_item_raw_materials` pivot rows and resolves which inventory items /
+ * raw materials still exist, so we bound the per-request blast radius. Bigger
+ * sweeps raise the `limit` param across chunked calls.
+ */
+export const MAX_RAW_MATERIAL_LINK_SCAN = 10000
+
+const repairRawMaterialLinkParamsSchema = z.object({
+  /** Max pivot rows to scan in one call (1..MAX_RAW_MATERIAL_LINK_SCAN). */
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_RAW_MATERIAL_LINK_SCAN)
+    .optional()
+    .default(2000),
+})
+
+/** Shape of one `inventory_item_raw_materials` pivot row, as queried. */
+export type RawMaterialLinkRow = {
+  inventory_item_id?: string | null
+  raw_materials_id?: string | null
+}
+
+/**
+ * Pure: compute the orphan `inventory_item_raw_materials` link removals.
+ *
+ * The inventory-item ↔ raw-material link is what the cost machinery walks
+ * (`backfill-inventory-unit-cost`, `estimate-design-cost`) to resolve a unit's
+ * raw material — `query.graph(... raw_materials.* )[0]`. When either side of a
+ * pivot row is hard-deleted, the row dangles: the join silently resolves to a
+ * null/missing entity, so `[0]` can land on a dead row and the cost lookup
+ * misbehaves (silently skipped, or worse, the wrong row wins). This is the
+ * inventory analogue of `repair-partner-region-links`.
+ *
+ * The ONLY safe, well-defined correction is removing a pivot row whose
+ * inventory item OR raw material no longer exists. There is no derivable
+ * "should-exist" rule to ADD a missing link (unlike the region job's
+ * store.default_region_id source), so this job is orphan-removal only. Exact
+ * duplicate (inventory_item, raw_material) rows can't exist — the link carries a
+ * composite PK — so duplicate-collapse is a non-case.
+ *
+ * A row is flagged when its inventory_item_id is absent from
+ * `existingInventoryItemIds` OR its raw_materials_id is absent from
+ * `existingRawMaterialIds`. The `before.missing` tag records which side
+ * (inventory_item | raw_material | both) is gone. Malformed rows missing either
+ * id are skipped (can't be safely dismissed). De-duplicated by pivot pair so a
+ * pair is reported once.
+ *
+ * Exported for unit testing — container-free.
+ */
+export function diffInventoryRawMaterialLinks(
+  linkRows: RawMaterialLinkRow[],
+  existingInventoryItemIds: Set<string>,
+  existingRawMaterialIds: Set<string>
+): MaintenanceChange[] {
+  const changes: MaintenanceChange[] = []
+  const seen = new Set<string>()
+
+  for (const row of linkRows) {
+    const invId = row?.inventory_item_id
+    const rmId = row?.raw_materials_id
+    if (!invId || !rmId) continue // malformed pivot row — can't safely dismiss
+
+    const pairKey = `${invId}:${rmId}`
+    if (seen.has(pairKey)) continue
+    seen.add(pairKey)
+
+    const invMissing = !existingInventoryItemIds.has(invId)
+    const rmMissing = !existingRawMaterialIds.has(rmId)
+    if (!invMissing && !rmMissing) continue // both sides live — keep the link
+
+    const missing = invMissing && rmMissing ? "both" : invMissing ? "inventory_item" : "raw_material"
+    changes.push({
+      entity: "inventory_item_raw_materials",
+      id: pairKey,
+      field: "remove_orphan_link",
+      before: { inventory_item_id: invId, raw_materials_id: rmId, missing },
+      after: null,
+    })
+  }
+
+  return changes
+}
+
+/**
+ * Pure summary builder for the raw-material link repair — keeps the human-facing
+ * string verifiable without booting the DB.
+ */
+export function summarizeRawMaterialLinkRepair(
+  dryRun: boolean,
+  rowsScanned: number,
+  removedCount: number,
+  errorCount: number
+): string {
+  const head =
+    removedCount === 0
+      ? `No changes — scanned ${rowsScanned} inventory↔raw-material link(s), none orphaned`
+      : `${dryRun ? "Would" : "Did"} remove ${removedCount} orphan link(s) whose inventory item or raw material no longer exists (scanned ${rowsScanned})`
+  return errorCount > 0 ? `${head}; ${errorCount} error(s)` : head
+}
+
+/**
+ * Repair inventory-item ↔ raw-material links (#508 Data Plumbing v2 — cost-path
+ * integrity). The `inventory_item_raw_materials` pivot is what the unit-cost
+ * backfill and design-cost estimator walk to resolve a unit's raw material; a
+ * pivot row whose inventory item or raw material was hard-deleted dangles and
+ * can corrupt that lookup. This job enumerates the pivot rows, resolves which
+ * inventory items / raw materials still exist, and removes the orphans. Dry-run
+ * (default) previews every link it would remove without writing; apply dismisses
+ * them via the remote link (idempotent — re-running is a no-op once clean). Pure
+ * link-table ops, no entity writes. A per-link dismiss failure is reported in
+ * `errors` instead of aborting the sweep.
+ *
+ * NOTE: existence is checked via the module list (soft-deleted rows are excluded
+ * by default), so a SOFT-deleted inventory item / raw material reads as "gone"
+ * and its links are flagged — mirrors `repair-partner-region-links`. Restore the
+ * entity before running if you intend to keep its links.
+ */
+export const repairInventoryRawMaterialLinksJob: MaintenanceJob = {
+  id: "repair-inventory-raw-material-links",
+  label: "Repair inventory ↔ raw-material links",
+  description:
+    `Remove orphan inventory_item_raw_materials pivot rows whose inventory item or raw material no longer exists — the cost machinery (unit-cost backfill, design-cost estimator) walks this link, and a dangling row corrupts the lookup. Dry-run (default) previews every link it would remove without persisting; apply dismisses them (idempotent). Pure link-table ops, no entity writes. Scans up to 'limit' pivot rows per call (default 2000, max ${MAX_RAW_MATERIAL_LINK_SCAN}).`,
+  params: [
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max pivot rows to scan in one call (default 2000, max ${MAX_RAW_MATERIAL_LINK_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }) => {
+    const parsed = repairRawMaterialLinkParamsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { limit } = parsed.data
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const remoteLink: any = container.resolve(ContainerRegistrationKeys.LINK)
+    const inventoryService: any = container.resolve(Modules.INVENTORY)
+    const rawMaterialService: any = container.resolve(RAW_MATERIAL_MODULE)
+
+    // Enumerate the pivot rows (just the two foreign keys).
+    const { data: rawRows } = await query.graph({
+      entity: "inventory_item_raw_materials",
+      fields: ["inventory_item_id", "raw_materials_id"],
+      pagination: { take: limit },
+    })
+    const linkRows: RawMaterialLinkRow[] = rawRows ?? []
+
+    const invIds = Array.from(
+      new Set(linkRows.map((r) => r.inventory_item_id).filter(Boolean) as string[])
+    )
+    const rmIds = Array.from(
+      new Set(linkRows.map((r) => r.raw_materials_id).filter(Boolean) as string[])
+    )
+
+    // Which referenced inventory items / raw materials still exist.
+    let existingInventoryItemIds = new Set<string>()
+    if (invIds.length) {
+      const items: any[] = await inventoryService.listInventoryItems(
+        { id: invIds },
+        { take: invIds.length, select: ["id"] }
+      )
+      existingInventoryItemIds = new Set(items.map((i) => i.id))
+    }
+    let existingRawMaterialIds = new Set<string>()
+    if (rmIds.length) {
+      const rms: any[] = await rawMaterialService.listRawMaterials(
+        { id: rmIds },
+        { take: rmIds.length, select: ["id"] }
+      )
+      existingRawMaterialIds = new Set(rms.map((r) => r.id))
+    }
+
+    const changes = diffInventoryRawMaterialLinks(
+      linkRows,
+      existingInventoryItemIds,
+      existingRawMaterialIds
+    )
+
+    let removed = 0
+    const errors: Array<{ id: string; message: string }> = []
+    for (const change of changes) {
+      const before = change.before as {
+        inventory_item_id: string
+        raw_materials_id: string
+      }
+      if (dry_run) {
+        removed++
+        continue
+      }
+      try {
+        await remoteLink.dismiss({
+          [Modules.INVENTORY]: { inventory_item_id: before.inventory_item_id },
+          [RAW_MATERIAL_MODULE]: { raw_materials_id: before.raw_materials_id },
+        })
+        removed++
+      } catch (e: any) {
+        errors.push({ id: change.id, message: e?.message ?? String(e) })
+      }
+    }
+
+    return {
+      job_id: repairInventoryRawMaterialLinksJob.id,
+      dry_run,
+      applied: !dry_run && removed > 0,
+      summary: summarizeRawMaterialLinkRepair(
+        dry_run,
+        linkRows.length,
+        removed,
+        errors.length
+      ),
+      changes,
+      errors,
+    }
+  },
+}
+
 export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   recalculateDesignCostJob,
   recalculateDesignCostBulkJob,
@@ -2343,6 +2568,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   repairPartnerRegionLinksJob,
   resyncProductLandingUrlJob,
   backfillConsumptionLogProductionRunIdJob,
+  repairInventoryRawMaterialLinksJob,
 ]
 
 export const getMaintenanceJob = (id: string): MaintenanceJob | undefined =>


### PR DESCRIPTION
## What

11th `#457`/`#508` Data-Plumbing maintenance job — ranked candidate **#5** (`repair-inventory-raw-material-links`) from `DATA_PLUMBING_V2.md §(d)`.

Removes orphan `inventory_item_raw_materials` pivot rows whose **inventory item or raw material no longer exists**. The cost machinery (`backfill-inventory-unit-cost`, `estimate-design-cost`) walks this link via `query.graph(...raw_materials.*)[0]`; a dangling pivot row silently corrupts that lookup (skipped / wrong row wins).

## Why it's a clean, low-risk slice

A faithful mirror of the **already-merged** `repair-partner-region-links` job (PR #514):
1. Enumerate the pivot rows (`inventory_item_id`, `raw_materials_id`).
2. Resolve which inventory items / raw materials still exist (module list).
3. Flag any row whose either side is gone → `remoteLink.dismiss(...)`.

- **Orphan-removal only** — there is no derivable "should-exist" rule to ADD a link (unlike the region job's `store.default_region_id` source).
- **No duplicate-collapse** — the link carries a composite PK, so exact `(inventory_item, raw_material)` duplicates can't exist.
- Safe-by-default: **dry-run previews**, apply dismisses idempotently, per-link failures recorded in `errors[]` instead of aborting, `MAX_RAW_MATERIAL_LINK_SCAN` blast-radius cap.
- **Registry-only** (append to `MAINTENANCE_JOBS`) — no model, no migration.

## Tests
- `diffInventoryRawMaterialLinks` + `summarizeRawMaterialLinkRepair` pure helpers → **12 unit tests** (`repair-inventory-raw-material-links.unit.spec.ts`).
- Registry regression: **81/81** (`registry.unit.spec.ts`).
- `tsc --noEmit` clean on changed files.

## Notes / watch-outs
- Existence is checked via the module list (soft-deleted rows excluded by default), so a **soft-deleted** inventory item / raw material reads as "gone" and its links are flagged — same behaviour as `repair-partner-region-links`. Documented in the job description.
- Branched off `origin/main` (independent — prior ops-job slice #515 already merged; no stacking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)