### PR TITLE
feat(#336): partner_billing module + partner_fee model (Slice 0)

### DIFF
--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -438,6 +438,9 @@ module.exports = defineConfig({
       resolve: "./src/modules/partner-payment-config",
     },
     {
+      resolve: "./src/modules/partner_billing",
+    },
+    {
       resolve: "./src/modules/consumption_log",
     },
     {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -115,6 +115,9 @@ module.exports = defineConfig({
       resolve: "./src/modules/partner-payment-config",
     },
     {
+      resolve: "./src/modules/partner_billing",
+    },
+    {
       resolve: "./src/modules/fx_rates",
     },
     {

--- a/apps/backend/src/modules/partner_billing/__tests__/compute-fee.unit.spec.ts
+++ b/apps/backend/src/modules/partner_billing/__tests__/compute-fee.unit.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * Unit test — computeFee / parsePlatformFeeBps (#336 Slice 0)
+ *
+ * Pure fee math for partner transaction-fee billing. No DI, no DB.
+ *
+ * Run:
+ *   TEST_TYPE=unit npx jest --testPathPattern="compute-fee"
+ */
+import { computeFee, parsePlatformFeeBps } from "../lib/compute-fee"
+
+describe("computeFee", () => {
+  describe("percentage basis (rate = basis points)", () => {
+    it("computes 2% (200 bps) of the order total", () => {
+      expect(computeFee(10000, "percentage", 200)).toBe(200)
+    })
+
+    it("computes 2% of a fractional total, rounded to 2 decimals", () => {
+      // 99.99 * 200 / 10000 = 1.9998 → 2.00
+      expect(computeFee(99.99, "percentage", 200)).toBe(2)
+    })
+
+    it("computes a non-round percentage and rounds to 2 decimals", () => {
+      // 1234.56 * 175 / 10000 = 21.6048 → 21.6
+      expect(computeFee(1234.56, "percentage", 175)).toBe(21.6)
+    })
+
+    it("returns 0 when the rate is 0 bps", () => {
+      expect(computeFee(10000, "percentage", 0)).toBe(0)
+    })
+  })
+
+  describe("flat basis (rate = flat amount)", () => {
+    it("returns the flat amount when below the order total", () => {
+      expect(computeFee(10000, "flat", 50)).toBe(50)
+    })
+
+    it("caps the flat amount at the order total", () => {
+      expect(computeFee(30, "flat", 50)).toBe(30)
+    })
+  })
+
+  describe("defensive guards (never throws, returns 0)", () => {
+    it.each([
+      ["zero total", 0, "percentage", 200],
+      ["negative total", -100, "percentage", 200],
+      ["NaN total", NaN, "percentage", 200],
+      ["Infinity total", Infinity, "percentage", 200],
+      ["negative rate", 10000, "percentage", -5],
+      ["NaN rate", 10000, "percentage", NaN],
+    ])("returns 0 for %s", (_label, total, basis, rate) => {
+      expect(computeFee(total as number, basis as any, rate as number)).toBe(0)
+    })
+  })
+})
+
+describe("parsePlatformFeeBps", () => {
+  it("defaults to 200 (2%) when unset", () => {
+    expect(parsePlatformFeeBps(undefined)).toBe(200)
+    expect(parsePlatformFeeBps("")).toBe(200)
+  })
+
+  it("parses a valid bps env value", () => {
+    expect(parsePlatformFeeBps("350")).toBe(350)
+  })
+
+  it("truncates a fractional bps value to an integer", () => {
+    expect(parsePlatformFeeBps("250.9")).toBe(250)
+  })
+
+  it("falls back on invalid / negative input", () => {
+    expect(parsePlatformFeeBps("abc")).toBe(200)
+    expect(parsePlatformFeeBps("-10")).toBe(200)
+    expect(parsePlatformFeeBps("nope", 500)).toBe(500)
+  })
+})

--- a/apps/backend/src/modules/partner_billing/index.ts
+++ b/apps/backend/src/modules/partner_billing/index.ts
@@ -1,0 +1,8 @@
+import { Module } from "@medusajs/framework/utils"
+import PartnerBillingService from "./service"
+
+export const PARTNER_BILLING_MODULE = "partner_billing"
+
+export default Module(PARTNER_BILLING_MODULE, {
+  service: PartnerBillingService,
+})

--- a/apps/backend/src/modules/partner_billing/lib/compute-fee.ts
+++ b/apps/backend/src/modules/partner_billing/lib/compute-fee.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure fee math for #336 partner transaction-fee billing.
+ *
+ * Kept dependency-free so it is trivially unit-testable and reusable by the
+ * accrual subscriber (Slice 2) and the historical backfill job (Slice 5).
+ */
+
+export type FeeBasis = "percentage" | "flat"
+
+/**
+ * Compute the platform commission for an order.
+ *
+ * - `percentage`: `rate` is basis points (bps). 200 bps = 2.00%. fee = total * rate / 10000.
+ * - `flat`: `rate` is a flat amount in the order currency, capped at the order total.
+ *
+ * Returns 0 for any non-positive / non-finite input (never throws — accrual must
+ * never break order placement). Rounded to 2 decimals (the dominant currency
+ * precision: INR/EUR/USD). Zero-decimal currencies (e.g. JPY) are a future concern.
+ */
+export function computeFee(
+  orderTotal: number,
+  basis: FeeBasis,
+  rate: number
+): number {
+  const total = Number(orderTotal)
+  const r = Number(rate)
+
+  if (!Number.isFinite(total) || total <= 0) {
+    return 0
+  }
+  if (!Number.isFinite(r) || r <= 0) {
+    return 0
+  }
+
+  const raw = basis === "flat" ? Math.min(r, total) : (total * r) / 10000
+
+  return Math.round(raw * 100) / 100
+}
+
+/**
+ * Parse the platform-default fee rate (basis points) from an env value.
+ * Falls back to `fallbackBps` (default 200 = 2%) when unset/invalid.
+ */
+export function parsePlatformFeeBps(
+  raw: string | undefined,
+  fallbackBps = 200
+): number {
+  if (raw == null || raw === "") {
+    return fallbackBps
+  }
+  const n = Number(raw)
+  if (!Number.isFinite(n) || n < 0) {
+    return fallbackBps
+  }
+  return Math.trunc(n)
+}

--- a/apps/backend/src/modules/partner_billing/migrations/Migration20260619120000.ts
+++ b/apps/backend/src/modules/partner_billing/migrations/Migration20260619120000.ts
@@ -1,0 +1,16 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+export class Migration20260619120000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table if not exists "partner_fee" ("id" text not null, "partner_id" text not null, "order_id" text not null, "order_total" numeric not null, "raw_order_total" jsonb not null, "currency_code" text not null, "fee_basis" text check ("fee_basis" in ('percentage', 'flat')) not null default 'percentage', "fee_rate" integer not null, "fee_amount" numeric not null, "raw_fee_amount" jsonb not null, "status" text check ("status" in ('accrued', 'invoiced', 'waived', 'reversed')) not null default 'accrued', "accrued_at" timestamptz null, "metadata" jsonb null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "partner_fee_pkey" primary key ("id"));`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_partner_fee_deleted_at" ON "partner_fee" ("deleted_at") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_partner_fee_partner_id" ON "partner_fee" ("partner_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_partner_fee_order_id" ON "partner_fee" ("order_id") WHERE deleted_at IS NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "partner_fee" cascade;`);
+  }
+
+}

--- a/apps/backend/src/modules/partner_billing/models/partner-fee.ts
+++ b/apps/backend/src/modules/partner_billing/models/partner-fee.ts
@@ -1,0 +1,37 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * partner_fee — one accrued platform commission per partner per order (#336).
+ *
+ * The platform's cut (default 2% — `PLATFORM_TX_FEE_BPS=200`) of an order the
+ * partner fulfils. This is a COMMISSION deducted from the partner's payout, NOT
+ * a customer-facing charge and NOT a tax (do not use the Medusa tax module).
+ *
+ * Accrued at `order.placed` for partner-linked orders only; reversed on cancel.
+ * All money fields are `bigNumber` (Medusa money convention) in the order's
+ * currency — never grab `stores[0]` for currency post-#485.
+ */
+const PartnerFee = model.define("partner_fee", {
+  id: model.id().primaryKey(),
+  // The partner who owes the commission (resolved via the partner↔order link).
+  partner_id: model.text(),
+  // The order this fee was accrued for. One accrued fee per order (idempotency key).
+  order_id: model.text(),
+  // Snapshot of the order total the fee was computed from, in `currency_code`.
+  order_total: model.bigNumber(),
+  currency_code: model.text(),
+  // How `fee_rate` is interpreted: percentage (basis points) or a flat amount.
+  fee_basis: model.enum(["percentage", "flat"]).default("percentage"),
+  // For percentage: basis points (200 = 2.00%). For flat: an amount in currency_code.
+  fee_rate: model.number(),
+  // The computed commission amount, in `currency_code`.
+  fee_amount: model.bigNumber(),
+  // Lifecycle: accrued at placement → invoiced when billed → waived/reversed on cancel.
+  status: model
+    .enum(["accrued", "invoiced", "waived", "reversed"])
+    .default("accrued"),
+  accrued_at: model.dateTime().nullable(),
+  metadata: model.json().nullable(),
+})
+
+export default PartnerFee

--- a/apps/backend/src/modules/partner_billing/service.ts
+++ b/apps/backend/src/modules/partner_billing/service.ts
@@ -1,0 +1,24 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import PartnerFee from "./models/partner-fee"
+
+/**
+ * partner_billing — accrues platform commission fees per partner per order (#336).
+ *
+ * MedusaService auto-generates createPartnerFees / listPartnerFees /
+ * listAndCountPartnerFees / retrievePartnerFee / updatePartnerFees /
+ * deletePartnerFees for the PartnerFee model.
+ */
+class PartnerBillingService extends MedusaService({
+  PartnerFee,
+}) {
+  /**
+   * The existing accrued fee for an order, if any. Used for idempotency by the
+   * accrual subscriber (Slice 2) — `order.placed` can re-fire.
+   */
+  async findFeeForOrder(orderId: string) {
+    const fees = await this.listPartnerFees({ order_id: orderId })
+    return fees?.[0] || null
+  }
+}
+
+export default PartnerBillingService


### PR DESCRIPTION
## #336 Slice 0 — partner transaction-fee billing foundation

First of the 6 slices in `apps/docs/notes/336_PARTNER_TRANSACTION_FEE_BILLING.md`. **Additive, zero behaviour change** — just the data model + pure fee math. Nothing accrues yet (that's Slice 2's `order.placed` subscriber).

### What's here
- **`partner_billing` module + `partner_fee` model** — one accrued platform commission per partner per order. Fields: `partner_id`, `order_id` (idempotency key), `order_total`/`fee_amount` (bigNumber, order currency), `currency_code`, `fee_basis` (`percentage`|`flat`), `fee_rate` (bps or flat amount), `status` (`accrued`|`invoiced`|`waived`|`reversed`), `accrued_at`, `metadata`.
- **Hand-written migration** mirroring the bigNumber `raw_*` jsonb + enum `text check` conventions (create-if-not-exists hazard memory: new table, so create-if-not-exists is safe); indexed on `partner_id`/`order_id`/`deleted_at`.
- **Pure helpers** `computeFee(orderTotal, basis, rate)` + `parsePlatformFeeBps` — percentage(bps)/flat, defensive `0` on bad input (never throws), 2-dp rounding.
- **`PartnerBillingService.findFeeForOrder`** — the idempotency lookup Slice 2 will use.
- Registered in `medusa-config.ts` + `medusa-config.prod.ts` (mirrors `partner-payment-config`).

### Locked decision (#336)
Flat **2% commission** (`PLATFORM_TX_FEE_BPS=200`, per-partner override later), deducted from partner payout (NOT customer-facing, NOT a tax), accrue at `order.placed` (partner orders only), waive on cancel, read-only API exposure.

### Tests
- **16 unit tests green** (`compute-fee.unit.spec.ts`): percentage/flat math, rounding, defensive guards, env parsing.
- `tsc` clean on changed files.

### Next slices
1 — `resolvePartnerFeeRate` (override → platform default). 2 — accrual subscriber on `order.placed` (partner-gated, idempotent). 3 — reversal on cancel. 4 — read API. 5 — historical backfill ops job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)