### PR TITLE
feat(#336): resolvePartnerFeeRate fee-rate resolution (Slice 1) — stacked on #535

### DIFF
--- a/apps/backend/src/modules/partner_billing/__tests__/resolve-fee-rate.unit.spec.ts
+++ b/apps/backend/src/modules/partner_billing/__tests__/resolve-fee-rate.unit.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit test — pickFeeRate / resolvePartnerFeeRate (#336 Slice 1)
+ *
+ * Pure fee-rate resolution with override > env-default > hard-default precedence.
+ * No DI, no DB.
+ *
+ * Run:
+ *   TEST_TYPE=unit npx jest --testPathPattern="resolve-fee-rate"
+ */
+import {
+  pickFeeRate,
+  resolvePartnerFeeRate,
+  PLATFORM_DEFAULT_FEE_BPS,
+} from "../lib/resolve-fee-rate"
+
+describe("pickFeeRate", () => {
+  it("prefers a valid per-partner override over the default", () => {
+    expect(pickFeeRate(350, 200)).toEqual({
+      fee_basis: "percentage",
+      fee_rate: 350,
+    })
+  })
+
+  it("allows an explicit 0 bps override (fee-waived partner)", () => {
+    expect(pickFeeRate(0, 200)).toEqual({
+      fee_basis: "percentage",
+      fee_rate: 0,
+    })
+  })
+
+  it("truncates a fractional override to an integer", () => {
+    expect(pickFeeRate(250.9, 200).fee_rate).toBe(250)
+  })
+
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["NaN", NaN],
+    ["negative", -10],
+    ["Infinity", Infinity],
+  ])("falls back to the default when override is %s", (_label, override) => {
+    expect(pickFeeRate(override as any, 200)).toEqual({
+      fee_basis: "percentage",
+      fee_rate: 200,
+    })
+  })
+})
+
+describe("resolvePartnerFeeRate", () => {
+  const ORIGINAL = process.env.PLATFORM_TX_FEE_BPS
+
+  afterEach(() => {
+    if (ORIGINAL === undefined) {
+      delete process.env.PLATFORM_TX_FEE_BPS
+    } else {
+      process.env.PLATFORM_TX_FEE_BPS = ORIGINAL
+    }
+  })
+
+  it("resolves the hard-coded 2% default when env is unset", async () => {
+    delete process.env.PLATFORM_TX_FEE_BPS
+    await expect(resolvePartnerFeeRate(null, { partnerId: "p_1" })).resolves.toEqual(
+      { fee_basis: "percentage", fee_rate: PLATFORM_DEFAULT_FEE_BPS }
+    )
+  })
+
+  it("resolves the env-configured platform default", async () => {
+    process.env.PLATFORM_TX_FEE_BPS = "500"
+    await expect(resolvePartnerFeeRate(null)).resolves.toEqual({
+      fee_basis: "percentage",
+      fee_rate: 500,
+    })
+  })
+
+  it("falls back to the default on an invalid env value", async () => {
+    process.env.PLATFORM_TX_FEE_BPS = "garbage"
+    const r = await resolvePartnerFeeRate(null, { partnerId: "p_1" })
+    expect(r.fee_rate).toBe(PLATFORM_DEFAULT_FEE_BPS)
+  })
+
+  it("never throws and ignores partnerId today (overrides deferred)", async () => {
+    process.env.PLATFORM_TX_FEE_BPS = "200"
+    const withPartner = await resolvePartnerFeeRate(null, { partnerId: "p_x" })
+    const without = await resolvePartnerFeeRate(null)
+    expect(withPartner).toEqual(without)
+  })
+})

--- a/apps/backend/src/modules/partner_billing/lib/resolve-fee-rate.ts
+++ b/apps/backend/src/modules/partner_billing/lib/resolve-fee-rate.ts
@@ -1,0 +1,74 @@
+import { parsePlatformFeeBps, type FeeBasis } from "./compute-fee"
+
+/**
+ * #336 Slice 1 — partner commission fee-rate resolution.
+ *
+ * Resolves the commission rate to apply to a partner's order, mirroring the
+ * `resolveStoreCurrency` (#485, `src/lib/resolve-store-currency.ts`)
+ * "resolve-with-fallback" template:
+ *
+ *   per-partner override  →  platform default (env)  →  hard-coded default
+ *
+ * The locked #336 decision is a flat 2% platform commission
+ * (`PLATFORM_TX_FEE_BPS=200`, percentage basis) with **per-partner overrides
+ * deferred** to a later slice. `partnerId` is threaded through now so the
+ * accrual subscriber (Slice 2) and read API (Slice 4) call a stable signature
+ * once overrides land — no call-site churn needed then.
+ *
+ * Never throws — fee resolution is best-effort and must never break order
+ * placement; it always returns a usable rate.
+ */
+
+/** Platform default commission when no env value is configured: 2.00% (#336 locked). */
+export const PLATFORM_DEFAULT_FEE_BPS = 200
+
+export type ResolvedFeeRate = {
+  fee_basis: FeeBasis
+  /** For percentage basis: basis points (200 = 2.00%). */
+  fee_rate: number
+}
+
+/**
+ * Pure precedence: a valid per-partner override (basis points, finite & >= 0)
+ * wins over the platform default; otherwise the default applies. Always returns
+ * a percentage-basis rate. Exported for unit testing — keeps the precedence
+ * verifiable without booting the container.
+ */
+export function pickFeeRate(
+  overrideBps: number | null | undefined,
+  defaultBps: number
+): ResolvedFeeRate {
+  const o = Number(overrideBps)
+  if (overrideBps != null && Number.isFinite(o) && o >= 0) {
+    return { fee_basis: "percentage", fee_rate: Math.trunc(o) }
+  }
+  return { fee_basis: "percentage", fee_rate: defaultBps }
+}
+
+export type ResolvePartnerFeeRateOpts = {
+  /**
+   * The partner the order is being accrued for. Reserved for the future
+   * per-partner override lookup; ignored today (overrides are a later slice).
+   */
+  partnerId?: string | null
+}
+
+/**
+ * Resolve the commission rate for a partner's order.
+ *
+ * Today: the platform default from `PLATFORM_TX_FEE_BPS` (200 = 2%), percentage
+ * basis. Per-partner overrides are deferred (no `partner_fee_config` model yet);
+ * when they land, query the override here and pass it to `pickFeeRate`.
+ */
+export async function resolvePartnerFeeRate(
+  _container: any,
+  _opts: ResolvePartnerFeeRateOpts = {}
+): Promise<ResolvedFeeRate> {
+  const defaultBps = parsePlatformFeeBps(
+    process.env.PLATFORM_TX_FEE_BPS,
+    PLATFORM_DEFAULT_FEE_BPS
+  )
+  // Override resolution intentionally deferred (#336: "per-partner override later").
+  const overrideBps: number | null = null
+  return pickFeeRate(overrideBps, defaultBps)
+}


### PR DESCRIPTION
## #336 Slice 1 — partner commission fee-rate resolution

**Stacked on #535 (Slice 0). Merge parent-first (#535 → this).**

Adds `resolvePartnerFeeRate(container, { partnerId })` — the fee-rate resolver the accrual subscriber (Slice 2) and read API (Slice 4) will call. Mirrors the `resolveStoreCurrency` (#485) resolve-with-fallback template:

```
per-partner override  →  env default (PLATFORM_TX_FEE_BPS)  →  2% hard default
```

### What's in this slice
- `modules/partner_billing/lib/resolve-fee-rate.ts`
  - pure `pickFeeRate(overrideBps, defaultBps)` — override>default precedence, percentage basis, truncates fractional, allows explicit `0` (fee-waived), falls back on null/NaN/negative/Infinity.
  - async `resolvePartnerFeeRate(container, { partnerId })` — reads env via the existing `parsePlatformFeeBps`; never throws.
- 12 unit tests (`__tests__/resolve-fee-rate.unit.spec.ts`).

### Locked-decision compliance
- Flat **2% commission** default (`PLATFORM_TX_FEE_BPS=200`), percentage basis.
- **Per-partner override deferred** ("override later") — `partnerId` is threaded through now so Slice 2 calls a stable signature with no churn when overrides land; the override lookup is a no-op stub with a clear TODO.

### Verification
- `TEST_TYPE=unit npx jest --testPathPattern="resolve-fee-rate"` → 12/12 green.
- `tsc --noEmit` → 0 errors in changed files.
- Additive, zero behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)