### PR TITLE
feat(#336): partner transaction-fee accrual subscriber [Slice 2, stacked on #536]

### DIFF
--- a/apps/backend/integration-tests/http/order-placed-partner-fee.spec.ts
+++ b/apps/backend/integration-tests/http/order-placed-partner-fee.spec.ts
@@ -1,0 +1,143 @@
+import {
+  ContainerRegistrationKeys,
+  Modules,
+} from "@medusajs/framework/utils"
+import type { IOrderModuleService } from "@medusajs/types"
+
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { seedCommonEmailTemplates } from "../helpers/seed-email-templates"
+import orderPlacedAccrueFeeHandler from "../../src/subscribers/order-placed-accrue-fee"
+import { PARTNER_BILLING_MODULE } from "../../src/modules/partner_billing"
+import { PARTNER_MODULE } from "../../src/modules/partner"
+import { computeFee } from "../../src/modules/partner_billing/lib/compute-fee"
+
+jest.setTimeout(60 * 1000)
+
+setupSharedTestSuite(() => {
+  describe("order.placed subscriber → partner fee accrual (#336)", () => {
+    let adminHeaders: { headers: Record<string, string> }
+
+    beforeAll(async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+      await seedCommonEmailTemplates(api, adminHeaders)
+    })
+
+    async function createPartner(unique: number) {
+      const { api } = getSharedTestEnv()
+      const email = `fee-accrual-${unique}@jyt.test`
+      const password = "supersecret"
+      await api.post("/auth/partner/emailpass/register", { email, password })
+      const login = await api.post("/auth/partner/emailpass", {
+        email,
+        password,
+      })
+      const headers = { Authorization: `Bearer ${login.data.token}` }
+      const res = await api.post(
+        "/partners",
+        {
+          name: `Fee Accrual ${unique}`,
+          handle: `fee-accrual-${unique}`,
+          admin: { email, first_name: "Test", last_name: "Partner" },
+        },
+        { headers }
+      )
+      expect(res.status).toBe(200)
+      return res.data.partner.id as string
+    }
+
+    async function createOrder(unique: number, currency = "usd") {
+      const container = getSharedTestEnv().getContainer()
+      const orderService = container.resolve(
+        Modules.ORDER
+      ) as IOrderModuleService
+      const order: any = await orderService.createOrders({
+        currency_code: currency,
+        email: `fee-order-${unique}@jyt.test`,
+        items: [
+          { title: "Line A", quantity: 2, unit_price: 1000 },
+          { title: "Line B", quantity: 1, unit_price: 500 },
+        ],
+      } as any)
+      return order
+    }
+
+    async function linkPartnerOrder(partnerId: string, orderId: string) {
+      const container = getSharedTestEnv().getContainer()
+      const remoteLink: any = container.resolve(
+        ContainerRegistrationKeys.LINK
+      )
+      await remoteLink.create([
+        {
+          [PARTNER_MODULE]: { partner_id: partnerId },
+          [Modules.ORDER]: { order_id: orderId },
+          data: { partner_id: partnerId, order_id: orderId },
+        },
+      ])
+    }
+
+    it("accrues one 2% partner_fee for a partner-linked order, and is idempotent", async () => {
+      const { getContainer } = getSharedTestEnv()
+      const container = getContainer()
+      const unique = Date.now()
+
+      const partnerId = await createPartner(unique)
+      const order = await createOrder(unique)
+      await linkPartnerOrder(partnerId, order.id)
+
+      // Re-read total post-creation (taxes/shipping may adjust it).
+      const orderService = container.resolve(
+        Modules.ORDER
+      ) as IOrderModuleService
+      const placed: any = await orderService.retrieveOrder(order.id, {
+        select: ["id", "total", "currency_code"],
+      })
+      const expectedFee = computeFee(Number(placed.total), "percentage", 200)
+
+      await orderPlacedAccrueFeeHandler({
+        event: { data: { id: order.id } },
+        container,
+      } as any)
+
+      const billing: any = container.resolve(PARTNER_BILLING_MODULE)
+      let fees = await billing.listPartnerFees({ order_id: order.id })
+      expect(fees.length).toBe(1)
+      const fee = fees[0]
+      expect(fee.partner_id).toBe(partnerId)
+      expect(fee.status).toBe("accrued")
+      expect(fee.fee_basis).toBe("percentage")
+      expect(fee.fee_rate).toBe(200)
+      expect(fee.currency_code).toBe("usd")
+      expect(Number(fee.fee_amount)).toBeCloseTo(expectedFee, 2)
+      expect(fee.accrued_at).toBeTruthy()
+
+      // Re-fire → still exactly one (idempotent on order_id).
+      await orderPlacedAccrueFeeHandler({
+        event: { data: { id: order.id } },
+        container,
+      } as any)
+      fees = await billing.listPartnerFees({ order_id: order.id })
+      expect(fees.length).toBe(1)
+    })
+
+    it("does NOT accrue a fee for a retail order with no partner link", async () => {
+      const { getContainer } = getSharedTestEnv()
+      const container = getContainer()
+      const unique = Date.now() + 1
+
+      const order = await createOrder(unique)
+      // No partner↔order link → retail → must be skipped.
+
+      await orderPlacedAccrueFeeHandler({
+        event: { data: { id: order.id } },
+        container,
+      } as any)
+
+      const billing: any = container.resolve(PARTNER_BILLING_MODULE)
+      const fees = await billing.listPartnerFees({ order_id: order.id })
+      expect(fees.length).toBe(0)
+    })
+  })
+})

--- a/apps/backend/src/subscribers/order-placed-accrue-fee.ts
+++ b/apps/backend/src/subscribers/order-placed-accrue-fee.ts
@@ -1,0 +1,105 @@
+import { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { IOrderModuleService, Logger } from "@medusajs/types"
+import partnerOrderLink from "../links/partner-order"
+import { PARTNER_BILLING_MODULE } from "../modules/partner_billing"
+import { computeFee } from "../modules/partner_billing/lib/compute-fee"
+import { resolvePartnerFeeRate } from "../modules/partner_billing/lib/resolve-fee-rate"
+
+/**
+ * #336 Slice 2 — partner transaction-fee accrual.
+ *
+ * Sibling subscriber on `order.placed` (kept separate from `order-placed.ts` so
+ * fee accrual can never break order confirmation / production-run creation, and
+ * vice-versa). For a partner-linked order only, accrues ONE `partner_fee` row:
+ * the platform commission (default 2% — `PLATFORM_TX_FEE_BPS=200`) of the order
+ * total, deducted from the partner's payout (a COMMISSION, not a customer charge
+ * and not a tax).
+ *
+ * GATING — `order.placed` fires for retail orders too. We accrue ONLY when the
+ * D3 partner↔order link (`src/links/partner-order.ts`) resolves a partner; retail
+ * orders have no such link and are skipped (else we'd bill the platform store).
+ *
+ * IDEMPOTENCY — `order.placed` can re-fire; `findFeeForOrder` keys on `order_id`
+ * and we skip if a fee already exists.
+ *
+ * CURRENCY — accrue in the order's own `currency_code` (post-#485: never grab
+ * `stores[0]`).
+ *
+ * Best-effort: any failure is logged and swallowed — accrual must never throw
+ * out of the placement event.
+ */
+export default async function orderPlacedAccrueFeeHandler({
+  event: { data },
+  container,
+}: SubscriberArgs<{ id: string }>) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER) as Logger
+
+  try {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+    const billingService: any = container.resolve(PARTNER_BILLING_MODULE)
+
+    // Gate: resolve the partner via the D3 partner↔order link (source of truth).
+    // No link → retail order → no commission.
+    const { data: linkRows } = await query.graph({
+      entity: partnerOrderLink.entryPoint,
+      fields: ["partner_id"],
+      filters: { order_id: data.id },
+      pagination: { skip: 0, take: 1 },
+    })
+    const partnerId: string | null = (linkRows || [])[0]?.partner_id || null
+    if (!partnerId) {
+      return
+    }
+
+    // Idempotency: one accrued fee per order.
+    const existing = await billingService.findFeeForOrder(data.id)
+    if (existing) {
+      return
+    }
+
+    const orderService = container.resolve(
+      Modules.ORDER
+    ) as IOrderModuleService
+    const order: any = await orderService.retrieveOrder(data.id, {
+      select: ["id", "total", "currency_code"],
+    })
+
+    const orderTotal = Number(order?.total)
+    const currencyCode: string = order?.currency_code || ""
+
+    const { fee_basis, fee_rate } = await resolvePartnerFeeRate(container, {
+      partnerId,
+    })
+    const feeAmount = computeFee(orderTotal, fee_basis, fee_rate)
+
+    await billingService.createPartnerFees([
+      {
+        partner_id: partnerId,
+        order_id: data.id,
+        order_total: Number.isFinite(orderTotal) ? orderTotal : 0,
+        currency_code: currencyCode,
+        fee_basis,
+        fee_rate,
+        fee_amount: feeAmount,
+        status: "accrued",
+        accrued_at: new Date(),
+        metadata: { source: "order.placed" },
+      },
+    ])
+
+    logger.info(
+      `[order.placed] Accrued partner fee ${feeAmount} ${currencyCode} for partner ${partnerId} on order ${data.id}`
+    )
+  } catch (e: any) {
+    logger.warn(
+      `[order.placed] Partner fee accrual failed for order ${data.id}: ${
+        e?.message || e
+      }`
+    )
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: "order.placed",
+}


### PR DESCRIPTION
## #336 Slice 2 — partner transaction-fee accrual

Part of #336 per-order partner transaction-fee billing (6-slice build).
**Stacked on #536 (Slice 1) → merge parent-first** (#535 → #536 → this). Imports `compute-fee.ts` (Slice 0) and `resolve-fee-rate.ts` (Slice 1) which only exist on the parent branches.

### What
New **sibling subscriber** `src/subscribers/order-placed-accrue-fee.ts` on `order.placed`. For a partner-linked order it accrues **one** `partner_fee` row — the platform commission (default **2%**, `PLATFORM_TX_FEE_BPS=200`) of the order total, deducted from the partner's payout (a commission, **not** a customer charge and **not** a tax).

### Locked-decision compliance
- **Gating** — `order.placed` fires for retail too. Accrues **only** when the D3 `partner↔order` link (`src/links/partner-order.ts`) resolves a partner; retail orders have no link → skipped (never bills the platform store).
- **Idempotency** — `findFeeForOrder` keys on `order_id`; re-fire is a no-op.
- **Currency** — accrues in the order's own `currency_code` (post-#485: never `stores[0]`).
- **Best-effort** — any failure is logged + swallowed; accrual never throws out of placement.

Kept separate from `order-placed.ts` so fee accrual and production-run creation can't break each other.

### Tests
`integration-tests/http/order-placed-partner-fee.spec.ts` — **2 passing**:
1. partner-linked order → exactly one 2% accrued fee (right partner/rate/basis/currency/amount), re-fire stays at one.
2. retail order (no link) → no fee row.

`pnpm test:integration:http:shared -- integration-tests/http/order-placed-partner-fee.spec.ts` → 2/2 green. tsc clean on changed files.

### Next (queue)
Slice 3 reversal on `order.canceled` (flip to `reversed`/`waived`) · Slice 4 read API · Slice 5 backfill ops job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)