### PR TITLE
feat(#336): partner transaction-fee reversal subscriber [Slice 3, stacked on #537]

### DIFF
--- a/apps/backend/integration-tests/http/order-canceled-partner-fee.spec.ts
+++ b/apps/backend/integration-tests/http/order-canceled-partner-fee.spec.ts
@@ -1,0 +1,138 @@
+import {
+  ContainerRegistrationKeys,
+  Modules,
+} from "@medusajs/framework/utils"
+import type { IOrderModuleService } from "@medusajs/types"
+
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { seedCommonEmailTemplates } from "../helpers/seed-email-templates"
+import orderPlacedAccrueFeeHandler from "../../src/subscribers/order-placed-accrue-fee"
+import orderCanceledReverseFeeHandler from "../../src/subscribers/order-canceled-reverse-fee"
+import { PARTNER_BILLING_MODULE } from "../../src/modules/partner_billing"
+import { PARTNER_MODULE } from "../../src/modules/partner"
+
+jest.setTimeout(60 * 1000)
+
+setupSharedTestSuite(() => {
+  describe("order.canceled subscriber → partner fee reversal (#336)", () => {
+    let adminHeaders: { headers: Record<string, string> }
+
+    beforeAll(async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+      await seedCommonEmailTemplates(api, adminHeaders)
+    })
+
+    async function createPartner(unique: number) {
+      const { api } = getSharedTestEnv()
+      const email = `fee-reversal-${unique}@jyt.test`
+      const password = "supersecret"
+      await api.post("/auth/partner/emailpass/register", { email, password })
+      const login = await api.post("/auth/partner/emailpass", {
+        email,
+        password,
+      })
+      const headers = { Authorization: `Bearer ${login.data.token}` }
+      const res = await api.post(
+        "/partners",
+        {
+          name: `Fee Reversal ${unique}`,
+          handle: `fee-reversal-${unique}`,
+          admin: { email, first_name: "Test", last_name: "Partner" },
+        },
+        { headers }
+      )
+      expect(res.status).toBe(200)
+      return res.data.partner.id as string
+    }
+
+    async function createOrder(unique: number, currency = "usd") {
+      const container = getSharedTestEnv().getContainer()
+      const orderService = container.resolve(
+        Modules.ORDER
+      ) as IOrderModuleService
+      const order: any = await orderService.createOrders({
+        currency_code: currency,
+        email: `fee-cancel-${unique}@jyt.test`,
+        items: [
+          { title: "Line A", quantity: 2, unit_price: 1000 },
+          { title: "Line B", quantity: 1, unit_price: 500 },
+        ],
+      } as any)
+      return order
+    }
+
+    async function linkPartnerOrder(partnerId: string, orderId: string) {
+      const container = getSharedTestEnv().getContainer()
+      const remoteLink: any = container.resolve(ContainerRegistrationKeys.LINK)
+      await remoteLink.create([
+        {
+          [PARTNER_MODULE]: { partner_id: partnerId },
+          [Modules.ORDER]: { order_id: orderId },
+          data: { partner_id: partnerId, order_id: orderId },
+        },
+      ])
+    }
+
+    it("reverses an accrued fee on cancel, and is idempotent on double-cancel", async () => {
+      const { getContainer } = getSharedTestEnv()
+      const container = getContainer()
+      const unique = Date.now()
+
+      const partnerId = await createPartner(unique)
+      const order = await createOrder(unique)
+      await linkPartnerOrder(partnerId, order.id)
+
+      // Accrue first (Slice 2), so there is a fee to reverse.
+      await orderPlacedAccrueFeeHandler({
+        event: { data: { id: order.id } },
+        container,
+      } as any)
+
+      const billing: any = container.resolve(PARTNER_BILLING_MODULE)
+      let fees = await billing.listPartnerFees({ order_id: order.id })
+      expect(fees.length).toBe(1)
+      expect(fees[0].status).toBe("accrued")
+
+      // Cancel → fee flips to reversed (still exactly one row).
+      await orderCanceledReverseFeeHandler({
+        event: { data: { id: order.id } },
+        container,
+      } as any)
+      fees = await billing.listPartnerFees({ order_id: order.id })
+      expect(fees.length).toBe(1)
+      expect(fees[0].status).toBe("reversed")
+      expect(fees[0].metadata?.reversed_reason).toBe("order.canceled")
+      expect(fees[0].metadata?.reversed_at).toBeTruthy()
+
+      // Double-cancel → still reversed, single row (idempotent no-op).
+      await orderCanceledReverseFeeHandler({
+        event: { data: { id: order.id } },
+        container,
+      } as any)
+      fees = await billing.listPartnerFees({ order_id: order.id })
+      expect(fees.length).toBe(1)
+      expect(fees[0].status).toBe("reversed")
+    })
+
+    it("is a no-op for a retail order that never accrued a fee", async () => {
+      const { getContainer } = getSharedTestEnv()
+      const container = getContainer()
+      const unique = Date.now() + 1
+
+      const order = await createOrder(unique)
+      // No partner link, no accrual → nothing to reverse.
+
+      await orderCanceledReverseFeeHandler({
+        event: { data: { id: order.id } },
+        container,
+      } as any)
+
+      const billing: any = container.resolve(PARTNER_BILLING_MODULE)
+      const fees = await billing.listPartnerFees({ order_id: order.id })
+      expect(fees.length).toBe(0)
+    })
+  })
+})

--- a/apps/backend/src/modules/partner_billing/service.ts
+++ b/apps/backend/src/modules/partner_billing/service.ts
@@ -19,6 +19,38 @@ class PartnerBillingService extends MedusaService({
     const fees = await this.listPartnerFees({ order_id: orderId })
     return fees?.[0] || null
   }
+
+  /**
+   * Reverse the accrued commission for an order (Slice 3 — compensation on
+   * `order.canceled`). Idempotent and best-effort:
+   *   - no fee for the order (retail / never accrued) → returns null, no-op
+   *   - fee already in a terminal/billed state (reversed | waived | invoiced)
+   *     → returns null, leaves it untouched (don't silently undo a billed fee)
+   *   - fee is `accrued` → flips it to `reversed`, stamps the reason/time in
+   *     metadata, and returns the updated row.
+   * Returning null when nothing changed lets the caller log only real reversals.
+   */
+  async reverseFeeForOrder(orderId: string, reason = "order.canceled") {
+    const fee = await this.findFeeForOrder(orderId)
+    if (!fee) {
+      return null
+    }
+    if (fee.status !== "accrued") {
+      return null
+    }
+    const [updated] = await this.updatePartnerFees([
+      {
+        id: fee.id,
+        status: "reversed",
+        metadata: {
+          ...(fee.metadata || {}),
+          reversed_at: new Date().toISOString(),
+          reversed_reason: reason,
+        },
+      },
+    ])
+    return updated
+  }
 }
 
 export default PartnerBillingService

--- a/apps/backend/src/subscribers/order-canceled-reverse-fee.ts
+++ b/apps/backend/src/subscribers/order-canceled-reverse-fee.ts
@@ -1,0 +1,53 @@
+import { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import type { Logger } from "@medusajs/types"
+import { PARTNER_BILLING_MODULE } from "../modules/partner_billing"
+
+/**
+ * #336 Slice 3 — partner transaction-fee reversal (compensation).
+ *
+ * Sibling subscriber on `order.canceled` (kept separate from `order-canceled.ts`
+ * so fee reversal can never break the partner cancellation notification, and
+ * vice-versa). When a partner-linked order that accrued a commission at
+ * `order.placed` is cancelled, the accrued `partner_fee` is flipped to
+ * `reversed` so the partner is no longer billed for it.
+ *
+ * GATING / IDEMPOTENCY — all of it lives in `reverseFeeForOrder`:
+ *   - retail orders (no accrued fee) → no-op (`findFeeForOrder` returns null);
+ *   - a double-fired `order.canceled` → the second pass sees status `reversed`
+ *     (not `accrued`) and is a no-op;
+ *   - an already `invoiced`/`waived` fee is left untouched (don't silently undo
+ *     a billed fee).
+ *
+ * Best-effort: any failure is logged and swallowed — reversal must never throw
+ * out of the cancellation event.
+ */
+export default async function orderCanceledReverseFeeHandler({
+  event: { data },
+  container,
+}: SubscriberArgs<{ id: string }>) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER) as Logger
+
+  try {
+    const billingService: any = container.resolve(PARTNER_BILLING_MODULE)
+    const reversed = await billingService.reverseFeeForOrder(
+      data.id,
+      "order.canceled"
+    )
+    if (reversed) {
+      logger.info(
+        `[order.canceled] Reversed partner fee ${reversed.fee_amount} ${reversed.currency_code} for partner ${reversed.partner_id} on order ${data.id}`
+      )
+    }
+  } catch (e: any) {
+    logger.warn(
+      `[order.canceled] Partner fee reversal failed for order ${data.id}: ${
+        e?.message || e
+      }`
+    )
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: "order.canceled",
+}


### PR DESCRIPTION
## #336 Slice 3 — fee reversal on `order.canceled` (compensation)

Stacked on **#537** (Slice 2). Merge parent-first: **#535 → #536 → #537 → this**.

When a partner-linked order that accrued a 2% commission at `order.placed` is cancelled, the accrued `partner_fee` is flipped to `reversed` so the partner is no longer billed.

### What
- **`PartnerBillingService.reverseFeeForOrder(orderId, reason)`** — idempotent + best-effort:
  - retail / never-accrued (no fee) → `null` no-op
  - already terminal/billed (`reversed`|`waived`|`invoiced`) → `null`, left untouched (don't silently undo a billed fee)
  - `accrued` → `reversed`, stamping `reversed_at`/`reversed_reason` in metadata
- **`src/subscribers/order-canceled-reverse-fee.ts`** — sibling subscriber on `order.canceled`, kept separate from `order-canceled.ts` so reversal can never break the partner cancellation email (and vice-versa). Logs only real reversals.

### Gating / idempotency
All in `reverseFeeForOrder`: retail orders have no accrued fee → no-op; a re-fired `order.canceled` sees status `reversed` (not `accrued`) → no-op.

### Tests
`integration-tests/http/order-canceled-partner-fee.spec.ts` — accrue→cancel flips to `reversed`, double-cancel is an idempotent no-op, retail order is a no-op. **2/2 green.** tsc clean on changed files.

### Next
Slice 4 — read-only API (`GET /admin/partners/[id]/fees`), then Slice 5 ops backfill job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)