### PR TITLE
feat(#336): partner transaction-fee read API [Slice 4, stacked on #538]

### DIFF
--- a/apps/backend/integration-tests/http/partner-fees-read-api.spec.ts
+++ b/apps/backend/integration-tests/http/partner-fees-read-api.spec.ts
@@ -1,0 +1,154 @@
+import {
+  ContainerRegistrationKeys,
+  Modules,
+} from "@medusajs/framework/utils"
+import type { IOrderModuleService } from "@medusajs/types"
+
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { seedCommonEmailTemplates } from "../helpers/seed-email-templates"
+import orderPlacedAccrueFeeHandler from "../../src/subscribers/order-placed-accrue-fee"
+import { PARTNER_MODULE } from "../../src/modules/partner"
+
+jest.setTimeout(60 * 1000)
+
+setupSharedTestSuite(() => {
+  describe("GET /admin/partners/:id/fees → partner fee ledger (#336 Slice 4)", () => {
+    let adminHeaders: { headers: Record<string, string> }
+
+    beforeAll(async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+      await seedCommonEmailTemplates(api, adminHeaders)
+    })
+
+    async function createPartner(unique: number) {
+      const { api } = getSharedTestEnv()
+      const email = `fee-read-${unique}@jyt.test`
+      const password = "supersecret"
+      await api.post("/auth/partner/emailpass/register", { email, password })
+      const login = await api.post("/auth/partner/emailpass", { email, password })
+      const headers = { Authorization: `Bearer ${login.data.token}` }
+      const res = await api.post(
+        "/partners",
+        {
+          name: `Fee Read ${unique}`,
+          handle: `fee-read-${unique}`,
+          admin: { email, first_name: "Test", last_name: "Partner" },
+        },
+        { headers }
+      )
+      expect(res.status).toBe(200)
+      return res.data.partner.id as string
+    }
+
+    async function createOrder(unique: number, currency = "usd") {
+      const container = getSharedTestEnv().getContainer()
+      const orderService = container.resolve(Modules.ORDER) as IOrderModuleService
+      const order: any = await orderService.createOrders({
+        currency_code: currency,
+        email: `fee-read-order-${unique}@jyt.test`,
+        items: [
+          { title: "Line A", quantity: 2, unit_price: 1000 },
+          { title: "Line B", quantity: 1, unit_price: 500 },
+        ],
+      } as any)
+      return order
+    }
+
+    async function linkPartnerOrder(partnerId: string, orderId: string) {
+      const container = getSharedTestEnv().getContainer()
+      const remoteLink: any = container.resolve(ContainerRegistrationKeys.LINK)
+      await remoteLink.create([
+        {
+          [PARTNER_MODULE]: { partner_id: partnerId },
+          [Modules.ORDER]: { order_id: orderId },
+          data: { partner_id: partnerId, order_id: orderId },
+        },
+      ])
+    }
+
+    it("lists accrued fees with a roll-up summary scoped to the partner", async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      const container = getContainer()
+      const unique = Date.now()
+
+      const partnerId = await createPartner(unique)
+      const order = await createOrder(unique)
+      await linkPartnerOrder(partnerId, order.id)
+
+      // Accrue a fee (Slice 2) so there is a row to read.
+      await orderPlacedAccrueFeeHandler({
+        event: { data: { id: order.id } },
+        container,
+      } as any)
+
+      const res = await api.get(
+        `/admin/partners/${partnerId}/fees`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.partner_id).toBe(partnerId)
+      expect(res.data.count).toBe(1)
+      expect(res.data.fees).toHaveLength(1)
+      expect(res.data.fees[0].partner_id).toBe(partnerId)
+      expect(res.data.fees[0].order_id).toBe(order.id)
+      expect(res.data.fees[0].status).toBe("accrued")
+
+      // Summary envelope.
+      expect(res.data.summary.count).toBe(1)
+      expect(res.data.summary.net_fee_amount).toBeGreaterThan(0)
+      expect(res.data.summary.by_status.accrued.count).toBe(1)
+      expect(res.data.summary.by_currency.usd.count).toBe(1)
+    })
+
+    it("returns an empty ledger (zeroed summary) for a partner with no fees", async () => {
+      const { api } = getSharedTestEnv()
+      const unique = Date.now() + 1
+      const partnerId = await createPartner(unique)
+
+      const res = await api.get(
+        `/admin/partners/${partnerId}/fees`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.count).toBe(0)
+      expect(res.data.fees).toEqual([])
+      expect(res.data.summary).toEqual({
+        count: 0,
+        total_fee_amount: 0,
+        net_fee_amount: 0,
+        by_status: {},
+        by_currency: {},
+      })
+    })
+
+    it("filters by status", async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      const container = getContainer()
+      const unique = Date.now() + 2
+
+      const partnerId = await createPartner(unique)
+      const order = await createOrder(unique)
+      await linkPartnerOrder(partnerId, order.id)
+      await orderPlacedAccrueFeeHandler({
+        event: { data: { id: order.id } },
+        container,
+      } as any)
+
+      // accrued filter → the row; reversed filter → empty.
+      const accrued = await api.get(
+        `/admin/partners/${partnerId}/fees?status=accrued`,
+        adminHeaders
+      )
+      expect(accrued.data.count).toBe(1)
+
+      const reversed = await api.get(
+        `/admin/partners/${partnerId}/fees?status=reversed`,
+        adminHeaders
+      )
+      expect(reversed.data.count).toBe(0)
+    })
+  })
+})

--- a/apps/backend/src/api/admin/partners/[id]/fees/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/fees/route.ts
@@ -1,0 +1,50 @@
+/**
+ * @file Admin API route for a partner's transaction-fee (commission) ledger.
+ * @description Read-only listing + roll-up of the platform commission accrued
+ * per order for a partner (#336 Slice 4). Mirrors the money-rollup envelope of
+ * `/admin/payment_reports/by-partner`, scoped to one partner.
+ * @module API/Admin/Partners/Fees
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { PARTNER_BILLING_MODULE } from "../../../../../modules/partner_billing"
+import { summarizePartnerFees } from "../../../../../modules/partner_billing/lib/summarize-fees"
+
+/**
+ * GET /admin/partners/[id]/fees
+ *
+ * Lists the `partner_fee` rows accrued for a partner plus a roll-up summary
+ * (totals, by-status, by-currency). Read-only — fees are accrued/reversed by the
+ * order.placed / order.canceled subscribers, never mutated here.
+ *
+ * Query: `status` (filter to one fee status), `offset`/`limit` (pagination).
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const partnerId = req.params.id
+
+  const offset = Number(req.query.offset ?? 0) || 0
+  const limit = Number(req.query.limit ?? 50) || 50
+  const status = typeof req.query.status === "string" ? req.query.status : undefined
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const billing: any = req.scope.resolve(PARTNER_BILLING_MODULE)
+
+  const filters: Record<string, unknown> = { partner_id: partnerId }
+  if (status) {
+    filters.status = status
+  }
+
+  // Roll-up is over the full filtered set (not the paginated page), so summary
+  // totals stay correct regardless of offset/limit (the page-vs-set bug, #484).
+  const all = (await billing.listPartnerFees(filters)) || []
+  const summary = summarizePartnerFees(all)
+  const fees = all.slice(offset, offset + limit)
+
+  return res.status(200).json({
+    partner_id: partnerId,
+    fees,
+    count: all.length,
+    offset,
+    limit,
+    summary,
+  })
+}

--- a/apps/backend/src/api/partners/[id]/fees/route.ts
+++ b/apps/backend/src/api/partners/[id]/fees/route.ts
@@ -1,0 +1,63 @@
+/**
+ * @file Partner-side API route for a partner's transaction-fee (commission) ledger.
+ * @description Self-serve read-only mirror of `GET /admin/partners/[id]/fees`
+ * (#336 Slice 4). Identical wire contract; the only difference is auth scoping —
+ * a partner may only read its own fees.
+ * @module API/Partners/Fees
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { MedusaError } from "@medusajs/framework/utils"
+import { getPartnerFromAuthContext } from "../../helpers"
+import { PARTNER_BILLING_MODULE } from "../../../../modules/partner_billing"
+import { summarizePartnerFees } from "../../../../modules/partner_billing/lib/summarize-fees"
+
+/**
+ * GET /partners/[id]/fees
+ *
+ * Lists the authenticated partner's accrued commission fees + roll-up summary.
+ * Read-only. Forbidden if the auth context's partner does not match `:id`.
+ */
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const { id: partnerId } = req.params
+
+  // AuthZ: the caller must be the partner they're reading.
+  const actorId = req.auth_context?.actor_id
+  if (!actorId) {
+    throw new MedusaError(MedusaError.Types.UNAUTHORIZED, "Unauthorized")
+  }
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
+  if (!partner || partner.id !== partnerId) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "Forbidden: partner mismatch"
+    )
+  }
+
+  const offset = Number(req.query.offset ?? 0) || 0
+  const limit = Number(req.query.limit ?? 50) || 50
+  const status = typeof req.query.status === "string" ? req.query.status : undefined
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const billing: any = req.scope.resolve(PARTNER_BILLING_MODULE)
+
+  const filters: Record<string, unknown> = { partner_id: partnerId }
+  if (status) {
+    filters.status = status
+  }
+
+  const all = (await billing.listPartnerFees(filters)) || []
+  const summary = summarizePartnerFees(all)
+  const fees = all.slice(offset, offset + limit)
+
+  return res.status(200).json({
+    partner_id: partnerId,
+    fees,
+    count: all.length,
+    offset,
+    limit,
+    summary,
+  })
+}

--- a/apps/backend/src/modules/partner_billing/__tests__/summarize-fees.unit.spec.ts
+++ b/apps/backend/src/modules/partner_billing/__tests__/summarize-fees.unit.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit test — summarizePartnerFees (#336 Slice 4)
+ *
+ * Pure roll-up math for the partner-fee read API. No DI, no DB.
+ *
+ * Run:
+ *   TEST_TYPE=unit npx jest --testPathPattern="summarize-fees"
+ */
+import { summarizePartnerFees } from "../lib/summarize-fees"
+
+describe("summarizePartnerFees", () => {
+  it("returns zeroed totals for an empty / nullish input", () => {
+    for (const input of [[], null, undefined] as const) {
+      expect(summarizePartnerFees(input)).toEqual({
+        count: 0,
+        total_fee_amount: 0,
+        net_fee_amount: 0,
+        by_status: {},
+        by_currency: {},
+      })
+    }
+  })
+
+  it("sums total and net, excluding reversed/waived from net", () => {
+    const s = summarizePartnerFees([
+      { status: "accrued", fee_amount: 200, currency_code: "INR" },
+      { status: "invoiced", fee_amount: 50, currency_code: "INR" },
+      { status: "reversed", fee_amount: 100, currency_code: "INR" },
+      { status: "waived", fee_amount: 25, currency_code: "INR" },
+    ])
+    expect(s.count).toBe(4)
+    expect(s.total_fee_amount).toBe(375) // 200+50+100+25
+    expect(s.net_fee_amount).toBe(250) // accrued + invoiced only
+  })
+
+  it("buckets by status with per-status counts and amounts", () => {
+    const s = summarizePartnerFees([
+      { status: "accrued", fee_amount: 10, currency_code: "INR" },
+      { status: "accrued", fee_amount: 5, currency_code: "INR" },
+      { status: "reversed", fee_amount: 3, currency_code: "INR" },
+    ])
+    expect(s.by_status.accrued).toEqual({ count: 2, fee_amount: 15 })
+    expect(s.by_status.reversed).toEqual({ count: 1, fee_amount: 3 })
+  })
+
+  it("buckets by lower-cased currency with total vs net per currency", () => {
+    const s = summarizePartnerFees([
+      { status: "accrued", fee_amount: 100, currency_code: "INR" },
+      { status: "reversed", fee_amount: 40, currency_code: "inr" },
+      { status: "accrued", fee_amount: 9, currency_code: "EUR" },
+    ])
+    expect(s.by_currency.inr).toEqual({
+      count: 2,
+      total_amount: 140,
+      net_amount: 100,
+    })
+    expect(s.by_currency.eur).toEqual({
+      count: 1,
+      total_amount: 9,
+      net_amount: 9,
+    })
+  })
+
+  it("coerces bigNumber string amounts and tolerates malformed rows", () => {
+    const s = summarizePartnerFees([
+      { status: "accrued", fee_amount: "12.5", currency_code: "INR" },
+      { status: "accrued", fee_amount: null, currency_code: "INR" },
+      { status: "accrued", fee_amount: "not-a-number", currency_code: "INR" },
+      // missing status → defaults to accrued; missing currency → "unknown"
+      { fee_amount: 7.5 },
+    ])
+    expect(s.total_fee_amount).toBe(20) // 12.5 + 0 + 0 + 7.5
+    expect(s.net_fee_amount).toBe(20)
+    expect(s.by_currency.unknown.count).toBe(1)
+    expect(s.by_status.accrued.count).toBe(4)
+  })
+
+  it("rounds accumulated floating amounts to 2 decimals", () => {
+    const s = summarizePartnerFees([
+      { status: "accrued", fee_amount: 0.1, currency_code: "INR" },
+      { status: "accrued", fee_amount: 0.2, currency_code: "INR" },
+    ])
+    expect(s.by_currency.inr.total_amount).toBe(0.3)
+    expect(s.total_fee_amount).toBe(0.3)
+  })
+})

--- a/apps/backend/src/modules/partner_billing/lib/summarize-fees.ts
+++ b/apps/backend/src/modules/partner_billing/lib/summarize-fees.ts
@@ -1,0 +1,102 @@
+/**
+ * Pure roll-up math for the #336 partner-fee read API (Slice 4).
+ *
+ * Kept dependency-free so it is trivially unit-testable and shared by both the
+ * admin route (`GET /admin/partners/[id]/fees`) and the partner-side mirror
+ * (`GET /partners/[id]/fees`). Never throws — a reporting endpoint must not 500
+ * on a malformed row.
+ *
+ * Money fields are Medusa `bigNumber` so they arrive as numbers or numeric
+ * strings; everything is coerced with `Number(...)` and non-finite values count
+ * as 0.
+ *
+ * "net" = the commission the platform actually collects: only `accrued` and
+ * `invoiced` fees count. `reversed` / `waived` fees are excluded from net (they
+ * were undone) but still tracked in `total` and per-status breakdowns.
+ */
+
+export type PartnerFeeStatus = "accrued" | "invoiced" | "waived" | "reversed"
+
+export type PartnerFeeLike = {
+  status?: string | null
+  fee_amount?: number | string | null
+  currency_code?: string | null
+}
+
+export type FeeStatusBucket = { count: number; fee_amount: number }
+export type FeeCurrencyBucket = {
+  count: number
+  total_amount: number
+  net_amount: number
+}
+
+export type PartnerFeeSummary = {
+  count: number
+  /** Sum of every fee_amount regardless of status. */
+  total_fee_amount: number
+  /** Sum of fee_amount for billable (accrued | invoiced) fees only. */
+  net_fee_amount: number
+  by_status: Record<string, FeeStatusBucket>
+  by_currency: Record<string, FeeCurrencyBucket>
+}
+
+const BILLABLE: ReadonlySet<string> = new Set(["accrued", "invoiced"])
+
+function toAmount(v: unknown): number {
+  const n = Number(v ?? 0)
+  return Number.isFinite(n) ? n : 0
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+/**
+ * Roll up a partner's fee rows into a reporting envelope. Order-independent and
+ * idempotent; safe on an empty array (returns zeroed totals).
+ */
+export function summarizePartnerFees(
+  fees: ReadonlyArray<PartnerFeeLike> | null | undefined
+): PartnerFeeSummary {
+  const rows = Array.isArray(fees) ? fees : []
+
+  let total = 0
+  let net = 0
+  const by_status: Record<string, FeeStatusBucket> = {}
+  const by_currency: Record<string, FeeCurrencyBucket> = {}
+
+  for (const row of rows) {
+    const status = (row?.status ?? "accrued") as string
+    const currency = (row?.currency_code ?? "unknown").toLowerCase()
+    const amount = toAmount(row?.fee_amount)
+    const billable = BILLABLE.has(status)
+
+    total += amount
+    if (billable) {
+      net += amount
+    }
+
+    const sb = (by_status[status] ??= { count: 0, fee_amount: 0 })
+    sb.count += 1
+    sb.fee_amount = round2(sb.fee_amount + amount)
+
+    const cb = (by_currency[currency] ??= {
+      count: 0,
+      total_amount: 0,
+      net_amount: 0,
+    })
+    cb.count += 1
+    cb.total_amount = round2(cb.total_amount + amount)
+    if (billable) {
+      cb.net_amount = round2(cb.net_amount + amount)
+    }
+  }
+
+  return {
+    count: rows.length,
+    total_fee_amount: round2(total),
+    net_fee_amount: round2(net),
+    by_status,
+    by_currency,
+  }
+}


### PR DESCRIPTION
## #336 Slice 4 — read-only partner fee (commission) ledger

Exposes the `partner_fee` rows accrued by Slices 2/3 as a read-only API. **Stacked on #538 (merge parent-first: #535→#536→#537→#538→this).**

### What
- `GET /admin/partners/[id]/fees` + partner-side mirror `GET /partners/[id]/fees` (auth-scoped to self via `getPartnerFromAuthContext`; 403 on partner mismatch). Identical wire contract.
- Returns `{ partner_id, fees, count, offset, limit, summary }`, paginated, optional `?status` filter.
- Pure `modules/partner_billing/lib/summarize-fees.ts` (`summarizePartnerFees`): `total_fee_amount` vs `net_fee_amount` (net = `accrued`|`invoiced` only; `reversed`/`waived` excluded), `by_status`, `by_currency`. Coerces bigNumber strings, never throws on malformed rows.

### Why this shape
- Roll-up computed over the **full filtered set**, not the paginated page → summary totals stay correct regardless of offset/limit (avoids the page-vs-set count bug, #484).
- `container.resolve(...)` annotated `:any` (TS18046 prod-build trap).

### Tests
- 6 unit (`summarize-fees.unit.spec.ts`) + 3 integration (`partner-fees-read-api.spec.ts`) green. tsc clean on changed files.

### Next
Slice 5 — ops backfill job (registry append) to accrue historical partner orders predating the subscriber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)