### PR TITLE
fix(stats): bound aggregate_data metrics to a date window (#522)

### DIFF
--- a/apps/backend/src/modules/visual_flows/operations/__tests__/aggregate-data.unit.spec.ts
+++ b/apps/backend/src/modules/visual_flows/operations/__tests__/aggregate-data.unit.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * Unit tests for the visual-flows `aggregate_data` operation — specifically the
+ * `range` date-window contract added for #522.
+ *
+ * The regression this guards: a "Unique visitors (30 days)" metric panel used
+ * `aggregate_data` with `{ fn: "sum", field: "unique_visitors" }` but NO date
+ * filter, so it summed all-time daily rollups instead of the trailing 30 days
+ * the panel name promised. `aggregate_data` had no relative-window mechanism
+ * (only `time_series` did via `range.last_days`). This adds `range` + a
+ * `dateField`-bounded filter to the query.graph call.
+ *
+ * The operation only reads `context.container` + `context.dataChain`, so we can
+ * invoke it directly without booting Medusa.
+ */
+
+import { aggregateDataOperation, resolveRangeWindow } from "../aggregate-data"
+
+function makeContext(captured: { options?: any }, rows: any[]): any {
+  return {
+    container: {
+      resolve: () => ({
+        graph: async (opts: any) => {
+          captured.options = opts
+          return { data: rows }
+        },
+      }),
+    } as any,
+    dataChain: {
+      $trigger: { payload: {}, timestamp: "2026-06-19T00:00:00.000Z" },
+      $accountability: {},
+      $env: {},
+      $last: null,
+    },
+    flowId: "flow_test",
+    executionId: "exec_test",
+    operationId: "op_test",
+    operationKey: "panel",
+  }
+}
+
+describe("resolveRangeWindow", () => {
+  it("aligns a rolling last_days window to UTC day boundaries (exclusive end = start of tomorrow)", () => {
+    const now = new Date("2026-06-19T13:45:12.000Z")
+    const { from, to } = resolveRangeWindow({ last_days: 30 }, now)
+    // exclusive end is start of the day AFTER `now`
+    expect(to).toBe("2026-06-20T00:00:00.000Z")
+    // inclusive start is exactly 30 days before the exclusive end
+    expect(from).toBe("2026-05-21T00:00:00.000Z")
+  })
+
+  it("passes through an absolute from/to window normalised to ISO", () => {
+    const { from, to } = resolveRangeWindow(
+      { from: "2026-01-01", to: "2026-02-01" },
+      new Date("2026-06-19T00:00:00.000Z")
+    )
+    expect(from).toBe("2026-01-01T00:00:00.000Z")
+    expect(to).toBe("2026-02-01T00:00:00.000Z")
+  })
+})
+
+describe("aggregate_data operation — range window", () => {
+  it("bounds the query by dateField when range is set", async () => {
+    const captured: { options?: any } = {}
+    const ctx = makeContext(captured, [
+      { unique_visitors: 10 },
+      { unique_visitors: 5 },
+    ])
+
+    const result = await aggregateDataOperation.execute(
+      {
+        entity: "analytics_daily_stats",
+        aggregate: { fn: "sum", field: "unique_visitors" },
+        dateField: "date",
+        range: { last_days: 30 },
+      },
+      ctx
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.data.value).toBe(15)
+    // the date filter reached query.graph
+    expect(captured.options.filters).toBeDefined()
+    expect(captured.options.filters.date).toBeDefined()
+    expect(captured.options.filters.date.$gte).toMatch(/T00:00:00\.000Z$/)
+    expect(captured.options.filters.date.$lt).toMatch(/T00:00:00\.000Z$/)
+    // the resolved window is echoed back on the result
+    expect(result.data.from).toBe(captured.options.filters.date.$gte)
+    expect(result.data.to).toBe(captured.options.filters.date.$lt)
+  })
+
+  it("defaults dateField to created_at when range is set without dateField", async () => {
+    const captured: { options?: any } = {}
+    const ctx = makeContext(captured, [{ id: "1" }, { id: "2" }, { id: "3" }])
+
+    const result = await aggregateDataOperation.execute(
+      {
+        entity: "order",
+        aggregate: { fn: "count" },
+        range: { last_days: 7 },
+      },
+      ctx
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.data.value).toBe(3)
+    expect(captured.options.filters.created_at).toBeDefined()
+  })
+
+  it("does NOT add a date filter when range is omitted (all-time aggregate preserved)", async () => {
+    const captured: { options?: any } = {}
+    const ctx = makeContext(captured, [
+      { unique_visitors: 1 },
+      { unique_visitors: 2 },
+    ])
+
+    const result = await aggregateDataOperation.execute(
+      {
+        entity: "analytics_daily_stats",
+        aggregate: { fn: "sum", field: "unique_visitors" },
+      },
+      ctx
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.data.value).toBe(3)
+    // no range → no filters object forwarded at all
+    expect(captured.options.filters).toBeUndefined()
+    expect(result.data.from).toBeUndefined()
+  })
+
+  it("merges the date window with caller-supplied filters", async () => {
+    const captured: { options?: any } = {}
+    const ctx = makeContext(captured, [{ id: "1" }])
+
+    await aggregateDataOperation.execute(
+      {
+        entity: "analytics_daily_stats",
+        aggregate: { fn: "count" },
+        dateField: "date",
+        range: { last_days: 30 },
+        filters: { website_id: "web_123" },
+      },
+      ctx
+    )
+
+    expect(captured.options.filters.website_id).toBe("web_123")
+    expect(captured.options.filters.date.$gte).toBeDefined()
+  })
+})

--- a/apps/backend/src/modules/visual_flows/operations/aggregate-data.ts
+++ b/apps/backend/src/modules/visual_flows/operations/aggregate-data.ts
@@ -5,6 +5,40 @@ import { interpolateVariables, interpolateString } from "./utils"
 
 type AggregateFn = "count" | "sum" | "avg" | "min" | "max" | "count_distinct"
 
+const rangeSchema = z.union([
+  z.object({
+    from: z.string().describe("ISO date (inclusive)"),
+    to: z.string().describe("ISO date (exclusive)"),
+  }),
+  z.object({
+    last_days: z.number().int().positive().max(3650),
+  }),
+])
+
+/**
+ * Resolve a relative/absolute window to an inclusive-from / exclusive-to pair,
+ * aligned to UTC day boundaries so a `last_days: 30` aggregate covers exactly
+ * the same 30 daily buckets a sibling `time_series` panel shows. Pure +
+ * deterministic given `now`, so it is unit-testable without booting Medusa.
+ */
+export function resolveRangeWindow(
+  range: { from: string; to: string } | { last_days: number },
+  now: Date
+): { from: string; to: string } {
+  if ("last_days" in range) {
+    const to = new Date(now)
+    to.setUTCHours(0, 0, 0, 0)
+    to.setUTCDate(to.getUTCDate() + 1) // exclusive end = start of tomorrow (UTC)
+    const from = new Date(to)
+    from.setUTCDate(from.getUTCDate() - range.last_days)
+    return { from: from.toISOString(), to: to.toISOString() }
+  }
+  return {
+    from: new Date(range.from).toISOString(),
+    to: new Date(range.to).toISOString(),
+  }
+}
+
 const aggregateOptionsSchema = z.object({
   entity: z.string().describe("Entity name to query via query.graph"),
   fields: z
@@ -12,6 +46,15 @@ const aggregateOptionsSchema = z.object({
     .optional()
     .describe("Fields to fetch from query.graph (required for non-count aggregates and groupBy)"),
   filters: z.record(z.string(), z.any()).optional().describe("Filter conditions"),
+  dateField: z
+    .string()
+    .optional()
+    .describe("Date field to bound by when `range` is set. Defaults to created_at."),
+  range: rangeSchema
+    .optional()
+    .describe(
+      "Optional date window. `{ last_days: 30 }` (rolling) or `{ from, to }` (absolute). Bounds the aggregation to rows whose dateField falls inside the window."
+    ),
   aggregate: z
     .object({
       fn: z
@@ -185,6 +228,16 @@ export const aggregateDataOperation: OperationDefinition = {
         }
       }
 
+      // Bound the aggregation to a date window when `range` is set. Without this
+      // a metric like "Unique visitors (30 days)" silently aggregates all-time
+      // rows. Mirrors the time_series window so sibling panels stay consistent.
+      let window: { from: string; to: string } | undefined
+      if (parsed.range) {
+        const dateField = parsed.dateField || "created_at"
+        window = resolveRangeWindow(parsed.range, new Date())
+        filters[dateField] = { $gte: window.from, $lt: window.to }
+      }
+
       const query = context.container.resolve(ContainerRegistrationKeys.QUERY)
 
       const requestedFields = new Set<string>()
@@ -220,6 +273,7 @@ export const aggregateDataOperation: OperationDefinition = {
             value,
             row_count: rows.length,
             truncated: rows.length === parsed.fetchLimit,
+            ...(window ? { from: window.from, to: window.to } : {}),
           },
         }
       }
@@ -265,6 +319,7 @@ export const aggregateDataOperation: OperationDefinition = {
           row_count: rows.length,
           group_count: groups.length,
           truncated: rows.length === parsed.fetchLimit,
+          ...(window ? { from: window.from, to: window.to } : {}),
         },
       }
     } catch (error: any) {

--- a/apps/backend/src/scripts/seed-stats-dashboards.ts
+++ b/apps/backend/src/scripts/seed-stats-dashboards.ts
@@ -194,8 +194,10 @@ const DASHBOARDS: SeedDashboard[] = [
         operation_options: {
           entity: "analytics_daily_stats",
           aggregate: { fn: "sum", field: "unique_visitors" },
+          dateField: "date",
+          range: { last_days: 30 },
         },
-        display: { label: "Unique visitors (all-time rollups)" },
+        display: { label: "Unique visitors (30 days)" },
         width: 4,
       },
       {


### PR DESCRIPTION
## #522 — stats "Unique visitors (30 days)" panel shows all-time, not 30 days

### Root cause
The "Unique visitors (30 days)" metric panel uses the `aggregate_data` operation with `{ fn: "sum", field: "unique_visitors" }` over `analytics_daily_stats` — but with **no date filter**. So it summed *all-time* daily rollups, not the trailing 30 days the name promises (the old label even admitted "all-time rollups"). `aggregate_data` had no relative-window mechanism; only `time_series` did, via `range.last_days`.

### Fix
- **`aggregate_data`**: add optional `range` (`{ last_days }` | `{ from, to }`) + `dateField` (default `created_at`). When set, applies a `dateField >= from / < to` filter to the `query.graph` call, mirroring `time_series`'s UTC-day-aligned window so the metric and the sibling time-series chart cover the exact same 30 buckets. The resolved `from`/`to` are echoed on the result.
- Pure `resolveRangeWindow()` extracted + exported for unit testing.
- **`seed-stats-dashboards`**: fix the Unique-visitors panel to actually carry `dateField: "date"` + `range: { last_days: 30 }` and correct its display label.

### Tests
6 unit tests (`aggregate-data.unit.spec.ts`): window math (rolling + absolute), filter reaches `query.graph`, default `created_at`, all-time preserved when `range` omitted, merge with caller filters. All green. `tsc` clean on changed files.

### ⚠️ Prod follow-up (data, not code)
`seed-stats-dashboards` **skips existing dashboards** (panels untouched). The live "Website Traffic" dashboard's Unique-visitors panel row must have its `operation_options` patched to add `dateField: "date"` + `range: { last_days: 30 }` (via the admin panel editor / PUT), or be re-seeded fresh. The code change enables the window but won't retro-patch existing rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)