### PR TITLE
feat(#541): admin partner transaction-fee ledger UI

### DIFF
--- a/apps/backend/src/admin/components/partners/partner-transaction-fees-section.tsx
+++ b/apps/backend/src/admin/components/partners/partner-transaction-fees-section.tsx
@@ -1,0 +1,125 @@
+import { Container, Heading, Text, Badge, StatusBadge } from "@medusajs/ui"
+import { usePartnerFees, type AdminPartnerFee } from "../../hooks/api/partners-admin"
+
+// #541 (parent #336): surface the partner transaction-fee (commission) ledger
+// on the admin partner DETAIL page, consuming the Slice-4 read API
+// (`GET /admin/partners/:id/fees`). Read-only — fees are accrued at order.placed
+// and reversed on cancel by subscribers, never mutated here.
+
+type PartnerTransactionFeesSectionProps = {
+  partnerId: string
+}
+
+function formatMoney(amount: number | string | null | undefined, currency: string) {
+  const n = Number(amount ?? 0)
+  const safe = Number.isFinite(n) ? n : 0
+  try {
+    return new Intl.NumberFormat("en-IN", {
+      style: "currency",
+      currency: (currency || "INR").toUpperCase(),
+      maximumFractionDigits: 2,
+    }).format(safe)
+  } catch {
+    // Unknown/invalid currency code → fall back to a plain number + raw code.
+    return `${safe.toFixed(2)} ${(currency || "").toUpperCase()}`
+  }
+}
+
+const STATUS_COLOR: Record<string, "green" | "orange" | "grey" | "red"> = {
+  accrued: "orange",
+  invoiced: "green",
+  waived: "grey",
+  reversed: "red",
+}
+
+export const PartnerTransactionFeesSection = ({
+  partnerId,
+}: PartnerTransactionFeesSectionProps) => {
+  const { fees, summary, count, isPending } = usePartnerFees(partnerId, { limit: 10 })
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div>
+          <Heading level="h2">Transaction fees</Heading>
+          <Text size="small" leading="compact" className="text-ui-fg-subtle">
+            Platform commission accrued per order this partner fulfils.
+          </Text>
+        </div>
+        {summary ? (
+          <Badge size="small" color="grey">
+            {summary.count} {summary.count === 1 ? "fee" : "fees"}
+          </Badge>
+        ) : null}
+      </div>
+
+      {isPending ? (
+        <div className="px-6 py-4">
+          <div className="bg-ui-bg-subtle h-5 w-40 animate-pulse rounded" />
+          <div className="bg-ui-bg-subtle mt-3 h-4 w-full animate-pulse rounded" />
+          <div className="bg-ui-bg-subtle mt-2 h-4 w-2/3 animate-pulse rounded" />
+        </div>
+      ) : !summary || summary.count === 0 ? (
+        <div className="px-6 py-6">
+          <Text size="small" className="text-ui-fg-subtle">
+            No transaction fees accrued yet.
+          </Text>
+        </div>
+      ) : (
+        <>
+          {/* Net-commission roll-up, per currency. */}
+          <div className="px-6 py-4">
+            <Text size="xsmall" weight="plus" className="text-ui-fg-muted mb-2 uppercase">
+              Net commission
+            </Text>
+            <div className="flex flex-col gap-y-1">
+              {Object.entries(summary.by_currency).map(([currency, b]) => (
+                <div key={currency} className="flex items-center justify-between">
+                  <Text size="small" className="text-ui-fg-subtle">
+                    {currency.toUpperCase()}
+                  </Text>
+                  <Text size="small" weight="plus">
+                    {formatMoney(b.net_amount, currency)}
+                  </Text>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Most recent fees. */}
+          <div className="px-6 py-4">
+            <Text size="xsmall" weight="plus" className="text-ui-fg-muted mb-2 uppercase">
+              Recent
+            </Text>
+            <div className="flex flex-col gap-y-2">
+              {(fees ?? []).map((fee: AdminPartnerFee) => (
+                <div key={fee.id} className="flex items-center justify-between gap-x-2">
+                  <Text
+                    size="small"
+                    className="text-ui-fg-subtle truncate font-mono"
+                    title={fee.order_id}
+                  >
+                    {fee.order_id}
+                  </Text>
+                  <div className="flex items-center gap-x-2">
+                    <Text size="small" weight="plus" className="text-nowrap">
+                      {formatMoney(fee.fee_amount, fee.currency_code)}
+                    </Text>
+                    <StatusBadge color={STATUS_COLOR[fee.status] ?? "grey"}>
+                      {fee.status}
+                    </StatusBadge>
+                  </div>
+                </div>
+              ))}
+            </div>
+            {typeof count === "number" && count > (fees?.length ?? 0) ? (
+              <Text size="xsmall" className="text-ui-fg-muted mt-3">
+                Showing {fees?.length ?? 0} of {count}.
+              </Text>
+            ) : null}
+          </div>
+        </>
+      )}
+    </Container>
+  )
+}

--- a/apps/backend/src/admin/hooks/api/partners-admin.ts
+++ b/apps/backend/src/admin/hooks/api/partners-admin.ts
@@ -316,3 +316,63 @@ export const useAdminCancelSubscription = (partnerId: string) => {
     },
   })
 }
+
+// --- #336 / #541: partner transaction-fee (commission) ledger -----------------
+
+export type AdminPartnerFee = {
+  id: string
+  partner_id: string
+  order_id: string
+  order_total: number | string
+  currency_code: string
+  fee_basis: "percentage" | "flat"
+  fee_rate: number
+  fee_amount: number | string
+  status: "accrued" | "invoiced" | "waived" | "reversed"
+  accrued_at?: string | null
+}
+
+export type AdminPartnerFeeSummary = {
+  count: number
+  total_fee_amount: number
+  net_fee_amount: number
+  by_status: Record<string, { count: number; fee_amount: number }>
+  by_currency: Record<
+    string,
+    { count: number; total_amount: number; net_amount: number }
+  >
+}
+
+export interface AdminPartnerFeesResponse {
+  partner_id: string
+  fees: AdminPartnerFee[]
+  count: number
+  offset: number
+  limit: number
+  summary: AdminPartnerFeeSummary
+}
+
+/**
+ * Reads a partner's accrued transaction-fee (commission) ledger from the
+ * Slice-4 read API (`GET /admin/partners/:id/fees`). Read-only — fees are
+ * accrued/reversed by the order.placed / order.canceled subscribers.
+ */
+export const usePartnerFees = (
+  partnerId: string,
+  query?: { status?: string; offset?: number; limit?: number },
+  options?: Omit<
+    UseQueryOptions<AdminPartnerFeesResponse, FetchError, AdminPartnerFeesResponse, QueryKey>,
+    "queryFn" | "queryKey"
+  >,
+) => {
+  const { data, ...rest } = useQuery({
+    queryFn: () =>
+      sdk.client.fetch<AdminPartnerFeesResponse>(`/admin/partners/${partnerId}/fees`, {
+        method: "GET",
+        query,
+      }),
+    queryKey: ["admin_partner_fees", partnerId, query],
+    ...options,
+  })
+  return { ...data, ...rest }
+}

--- a/apps/backend/src/admin/routes/partners/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/partners/[id]/page.tsx
@@ -12,6 +12,7 @@ import { PartnerStorefrontSection } from "../../../components/partners/partner-s
 import { PartnerSubscriptionSection } from "../../../components/partners/partner-subscription-section"
 import { PartnerPeopleSection } from "../../../components/partners/partner-people-section"
 import { PartnerWhatsAppSection } from "../../../components/partners/partner-whatsapp-section"
+import { PartnerTransactionFeesSection } from "../../../components/partners/partner-transaction-fees-section"
 import type { AdminPartner } from "../../../hooks/api/partners-admin"
 import { partnerLoader } from "./loader"
 
@@ -54,6 +55,7 @@ const PartnerDetailPage = () => {
           <PartnerPeopleSection partnerId={partner.id} />
           <PartnerAdminsSection partnerId={partner.id} admins={partner.admins || []} />
           <PartnerPaymentsSection partner={partner} />
+          <PartnerTransactionFeesSection partnerId={partner.id} />
           <PartnerFeedbacksSection partnerId={partner.id} />
         </TwoColumnPage.Sidebar>
       </TwoColumnPage>


### PR DESCRIPTION
Closes part of #541 (parent #336). Admin UI consumer for the Slice-4 partner-fee read API.

## What
Surfaces the per-partner platform-commission ledger on the **admin partner detail page**, consuming the existing read API `GET /admin/partners/:id/fees` (#539). Read-only — fees are accrued/reversed by the `order.placed` / `order.canceled` subscribers, never mutated in the UI.

- **`usePartnerFees`** hook (`src/admin/hooks/api/partners-admin.ts`) — typed `{ fees, count, summary }` envelope.
- **`PartnerTransactionFeesSection`** (`src/admin/components/partners/partner-transaction-fees-section.tsx`):
  - Net-commission roll-up **per currency** (from `summary.by_currency`).
  - **Recent fees** list (order id, amount, color-coded `StatusBadge`: accrued=orange, invoiced=green, waived=grey, reversed=red).
  - Skeleton loading + empty state; Medusa `--ui-*` tokens (dark-mode safe); `Intl.NumberFormat` money with a safe fallback for unknown currency codes.
- Wired into the partner detail page sidebar (`partners/[id]/page.tsx`).

## Tasks coverage (#541)
1. **Admin UI** ✅ — partner-detail fees section consuming the Slice-4 API.
2. **Order-test fee coverage** ✅ already present — `order-placed-partner-fee.spec.ts` (accrual + idempotency + retail-skip), `order-canceled-partner-fee.spec.ts` (reversal), `partner-fees-read-api.spec.ts` (read-API shape + empty ledger + reversal). No gap to fill.
3. **Playwright E2E** ✅ — verified against live `yarn dev` admin: logged in (throwaway admin user), seeded two `partner_fee` rows, confirmed the section renders the net roll-up (₹1,250.00) + both status badges with **0 console errors** (seed rows cleaned up after).

## Screenshot
Transaction-fees card: "2 fees" badge, NET COMMISSION INR ₹1,250.00, recent list with accrued/invoiced badges.

## Notes / watch-outs
- Local dev needed `npx medusa db:migrate` to create the merged `partner_fee` table before the endpoint returned 200 (migrations land on merge in prod).
- tsc clean on changed files; no new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)