### PR TITLE
feat(#521): partner-aware abandoned-cart recovery URL + admin partner display

### DIFF
--- a/apps/backend/src/admin/hooks/api/abandoned-carts.ts
+++ b/apps/backend/src/admin/hooks/api/abandoned-carts.ts
@@ -101,6 +101,12 @@ export type AbandonedCartDetail = {
   items_subtotal: number;
   idle_minutes: number;
   recovery_url: string;
+  partner: {
+    id: string;
+    name: string | null;
+    handle: string | null;
+    storefront_base: string | null;
+  } | null;
   is_completed: boolean;
 };
 

--- a/apps/backend/src/admin/routes/abandoned-carts/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/abandoned-carts/[id]/page.tsx
@@ -272,6 +272,21 @@ const AbandonedCartDetailPage = () => {
           <code className="text-xs break-all text-ui-fg-base bg-ui-bg-subtle p-2 rounded block">
             {cart.recovery_url}
           </code>
+          {cart.partner ? (
+            <Text size="xsmall" className="text-ui-fg-subtle">
+              Owning partner:{" "}
+              <span className="text-ui-fg-base">
+                {cart.partner.name || cart.partner.handle || cart.partner.id}
+              </span>
+              {cart.partner.storefront_base
+                ? ` · ${cart.partner.storefront_base.replace(/^https?:\/\//, "")}`
+                : " · no storefront domain configured"}
+            </Text>
+          ) : (
+            <Text size="xsmall" className="text-ui-fg-muted">
+              Not tied to a partner storefront — using the platform base.
+            </Text>
+          )}
           {cart.metadata?.recovery_email_sent_at && (
             <Text size="xsmall" className="text-ui-fg-subtle">
               Recovery email last sent {formatDate(cart.metadata.recovery_email_sent_at)}

--- a/apps/backend/src/api/admin/abandoned-carts/[id]/route.ts
+++ b/apps/backend/src/api/admin/abandoned-carts/[id]/route.ts
@@ -13,6 +13,8 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 
+import { resolvePartnerStorefrontForSalesChannel } from "../../../../workflows/google_merchant/steps/resolve-partner-landing-base"
+
 const DETAIL_FIELDS = [
   "id",
   "email",
@@ -43,8 +45,8 @@ const DETAIL_FIELDS = [
   "sales_channel.name",
 ] as const
 
-const buildRecoveryUrl = (cartId: string) => {
-  const storeUrl = process.env.STORE_URL || "https://cicilabel.com"
+const buildRecoveryUrl = (cartId: string, base?: string | null) => {
+  const storeUrl = base || process.env.STORE_URL || "https://cicilabel.com"
   return `${storeUrl}/checkout/cart/${cartId}`
 }
 
@@ -74,6 +76,13 @@ export async function GET(
     0,
   )
 
+  // #521 — derive the owning partner storefront from the cart's sales channel so
+  // the recovery link points at THAT partner's storefront, not a global base.
+  const partner = await resolvePartnerStorefrontForSalesChannel(
+    query,
+    cart.sales_channel_id,
+  )
+
   res.status(200).json({
     abandoned_cart: {
       ...cart,
@@ -83,7 +92,15 @@ export async function GET(
         0,
         Math.round((Date.now() - new Date(cart.updated_at).getTime()) / 60000),
       ),
-      recovery_url: buildRecoveryUrl(cart.id),
+      recovery_url: buildRecoveryUrl(cart.id, partner?.storefront_base),
+      partner: partner
+        ? {
+            id: partner.id,
+            name: partner.name,
+            handle: partner.handle,
+            storefront_base: partner.storefront_base,
+          }
+        : null,
       is_completed: Boolean(cart.completed_at),
     },
   })

--- a/apps/backend/src/workflows/google_merchant/steps/__tests__/resolve-partner-landing-base.unit.spec.ts
+++ b/apps/backend/src/workflows/google_merchant/steps/__tests__/resolve-partner-landing-base.unit.spec.ts
@@ -2,6 +2,7 @@ import {
   normalizeLandingBase,
   partnerBaseFromRecord,
   resolvePartnerLandingBase,
+  resolvePartnerStorefrontForSalesChannel,
 } from "../resolve-partner-landing-base"
 
 /**
@@ -109,5 +110,84 @@ describe("resolvePartnerLandingBase pivot", () => {
       }),
     }
     await expect(resolvePartnerLandingBase(query as any, "prod_1")).resolves.toBeNull()
+  })
+})
+
+describe("resolvePartnerStorefrontForSalesChannel pivot (#521)", () => {
+  const makeQuery = (responses: Record<string, any[]>) => ({
+    graph: jest.fn(async ({ entity }: any) => ({ data: responses[entity] ?? [] })),
+  })
+
+  it("resolves sales_channel → store → partner identity + base", async () => {
+    const query = makeQuery({
+      stores: [{ id: "store_1", default_sales_channel_id: "sc_1" }],
+      partners: [
+        { id: "par_x", name: "X", handle: "x", storefront_domain: "x.cicilabel.com", metadata: {}, stores: [{ id: "store_z" }] },
+        {
+          id: "par_1",
+          name: "Acme",
+          handle: "acme",
+          storefront_domain: "acme.cicilabel.com",
+          metadata: { custom_domain: "shop.acme.com" },
+          stores: [{ id: "store_1" }],
+        },
+      ],
+    })
+    await expect(
+      resolvePartnerStorefrontForSalesChannel(query as any, "sc_1")
+    ).resolves.toEqual({
+      id: "par_1",
+      name: "Acme",
+      handle: "acme",
+      storefront_base: "https://shop.acme.com",
+    })
+  })
+
+  it("returns null storefront_base when partner has no domain but still returns identity", async () => {
+    const query = makeQuery({
+      stores: [{ id: "store_1", default_sales_channel_id: "sc_1" }],
+      partners: [
+        { id: "par_1", name: "Acme", handle: "acme", storefront_domain: null, metadata: {}, stores: [{ id: "store_1" }] },
+      ],
+    })
+    await expect(
+      resolvePartnerStorefrontForSalesChannel(query as any, "sc_1")
+    ).resolves.toEqual({ id: "par_1", name: "Acme", handle: "acme", storefront_base: null })
+  })
+
+  it("returns null when no sales_channel_id is given", async () => {
+    const query = makeQuery({})
+    await expect(
+      resolvePartnerStorefrontForSalesChannel(query as any, null)
+    ).resolves.toBeNull()
+    expect((query.graph as jest.Mock).mock.calls.length).toBe(0)
+  })
+
+  it("returns null when no store owns the channel", async () => {
+    const query = makeQuery({ stores: [] })
+    await expect(
+      resolvePartnerStorefrontForSalesChannel(query as any, "sc_1")
+    ).resolves.toBeNull()
+  })
+
+  it("returns null when no partner owns the store", async () => {
+    const query = makeQuery({
+      stores: [{ id: "store_1", default_sales_channel_id: "sc_1" }],
+      partners: [{ id: "par_x", name: "X", handle: "x", storefront_domain: "x.cicilabel.com", metadata: {}, stores: [{ id: "store_z" }] }],
+    })
+    await expect(
+      resolvePartnerStorefrontForSalesChannel(query as any, "sc_1")
+    ).resolves.toBeNull()
+  })
+
+  it("never throws — swallows query errors to null", async () => {
+    const query = {
+      graph: jest.fn(async () => {
+        throw new Error("boom")
+      }),
+    }
+    await expect(
+      resolvePartnerStorefrontForSalesChannel(query as any, "sc_1")
+    ).resolves.toBeNull()
   })
 })

--- a/apps/backend/src/workflows/google_merchant/steps/resolve-partner-landing-base.ts
+++ b/apps/backend/src/workflows/google_merchant/steps/resolve-partner-landing-base.ts
@@ -60,6 +60,60 @@ export function partnerBaseFromRecord(
 }
 
 /**
+ * #521 — abandoned-cart recovery link. A cart carries `sales_channel_id`
+ * directly, so we can pivot straight from the channel (skipping the product
+ * step of {@link resolvePartnerLandingBase}):
+ *
+ *   sales_channel → store (default_sales_channel_id) → partner (partner_stores)
+ *
+ * Returns the owning partner's identity + normalized storefront base so the
+ * admin abandoned-cart view can show who owns the cart and build a recovery
+ * link that points at THAT partner's storefront instead of a single global
+ * `STORE_URL`. Never throws — returns null when nothing matches so callers can
+ * fall back to the env base.
+ */
+export async function resolvePartnerStorefrontForSalesChannel(
+  query: Queryable,
+  sales_channel_id?: string | null
+): Promise<{
+  id: string
+  name: string | null
+  handle: string | null
+  storefront_base: string | null
+} | null> {
+  if (!sales_channel_id) return null
+  try {
+    // 1. sales_channel → store (default_sales_channel_id is a plain column).
+    const { data: stores } = await query.graph({
+      entity: "stores",
+      fields: ["id", "default_sales_channel_id"],
+      filters: { default_sales_channel_id: [sales_channel_id] },
+    } as any)
+    const storeIds = new Set((stores ?? []).map((s: any) => s?.id).filter(Boolean))
+    if (!storeIds.size) return null
+
+    // 2. store → partner (partner_stores link). Filters don't auto-join
+    //    dot-paths, so match owner in JS (mirrors resolvePartnerLandingBase).
+    const { data: partners } = await query.graph({
+      entity: "partners",
+      fields: ["id", "name", "handle", "storefront_domain", "metadata", "stores.id"],
+    } as any)
+    const owner = (partners ?? []).find((p: any) =>
+      (p?.stores ?? []).some((st: any) => storeIds.has(st?.id))
+    )
+    if (!owner) return null
+    return {
+      id: owner.id,
+      name: owner.name ?? null,
+      handle: owner.handle ?? null,
+      storefront_base: partnerBaseFromRecord(owner),
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
  * Resolve the landing base for a single product from its owning partner
  * storefront. Returns null (never throws) when the product isn't tied to a
  * partner store or no domain is configured, so callers can fall back to the


### PR DESCRIPTION
## #521 — abandoned-cart recovery link (Part B: backend + admin display)

The admin abandoned-cart detail's recovery link was always built from a single global `STORE_URL`. This makes it **partner-aware**: it derives the owning partner storefront from the cart's `sales_channel` and points the recovery link at that partner's storefront.

### What
- **New pure resolver** `resolvePartnerStorefrontForSalesChannel(query, sales_channel_id)` in the #377 resolver file (`resolve-partner-landing-base.ts`). Pivot: `sales_channel → store (default_sales_channel_id) → partner (partner_stores link)`, reusing #377's `partnerBaseFromRecord` precedence (`custom_domain → website_domain → storefront_domain`). Never throws → null when nothing matches.
- **`GET /admin/abandoned-carts/:id`** now builds `recovery_url` from the partner storefront base (falls back to `STORE_URL`) and returns a `partner` `{id,name,handle,storefront_base}` block (or `null`).
- **Admin detail page** shows the owning partner + storefront under the Recovery section, with an explicit "not tied to a partner — using platform base" fallback.

### Tests / verification
- 6 new unit tests (17 total green) for the pivot + precedence + null/throw paths: `TEST_TYPE=unit npx jest --testPathPattern=resolve-partner-landing-base.unit`
- `tsc --noEmit` clean on changed files
- **Playwright-verified** live against `yarn dev` admin: Recovery section renders the partner line, 0 console errors (fallback path, no partner-owned channel in dev data)

### Scope / follow-up
- **Part A (storefront route port)** — `apps/storefront/.../checkout/cart/[cartId]/route.ts` exists; `apps/storefront-starter` (submodule) lacks it. Deferred: the submodule has unrelated uncommitted changes and pushing to its `main` is a separate-repo op better done deliberately. Backend already builds correct partner-storefront links; the starter route port is the remaining piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)