### PR TITLE
feat(analytics): #344 slice 1 — POST /web/analytics/ingest-batch (authed bulk ingest)

### DIFF
--- a/apps/backend/src/api/web/analytics/ingest-batch/__tests__/lib.unit.spec.ts
+++ b/apps/backend/src/api/web/analytics/ingest-batch/__tests__/lib.unit.spec.ts
@@ -1,0 +1,184 @@
+import { createHmac } from "crypto";
+import {
+  filterAlreadyPersisted,
+  normalizeAndDedupeBatch,
+  verifyIngestAuth,
+  type RawIngestEvent,
+} from "../lib";
+
+const SECRET = "test-ingest-secret";
+const FALLBACK = new Date("2026-06-19T00:00:00.000Z");
+
+const baseEvent = (over: Partial<RawIngestEvent> = {}): RawIngestEvent => ({
+  website_id: "web_1",
+  pathname: "/",
+  visitor_id: "vis_1",
+  session_id: "ses_1",
+  ...over,
+});
+
+describe("verifyIngestAuth", () => {
+  it("returns false when no secret is configured", () => {
+    expect(
+      verifyIngestAuth({ secret: undefined, sharedSecretHeader: SECRET })
+    ).toBe(false);
+  });
+
+  it("accepts a matching shared secret (timing-safe)", () => {
+    expect(
+      verifyIngestAuth({ secret: SECRET, sharedSecretHeader: SECRET })
+    ).toBe(true);
+  });
+
+  it("rejects a wrong shared secret", () => {
+    expect(
+      verifyIngestAuth({ secret: SECRET, sharedSecretHeader: "nope" })
+    ).toBe(false);
+  });
+
+  it("rejects a shared secret of different length without throwing", () => {
+    expect(
+      verifyIngestAuth({ secret: SECRET, sharedSecretHeader: "x" })
+    ).toBe(false);
+  });
+
+  it("accepts a valid HMAC signature over the raw body (sha256= prefix)", () => {
+    const rawBody = JSON.stringify({ events: [baseEvent()] });
+    const sig = createHmac("sha256", SECRET).update(rawBody).digest("hex");
+    expect(
+      verifyIngestAuth({
+        secret: SECRET,
+        signatureHeader: `sha256=${sig}`,
+        rawBody,
+      })
+    ).toBe(true);
+  });
+
+  it("accepts a valid HMAC signature without the prefix", () => {
+    const rawBody = "payload";
+    const sig = createHmac("sha256", SECRET).update(rawBody).digest("hex");
+    expect(
+      verifyIngestAuth({ secret: SECRET, signatureHeader: sig, rawBody })
+    ).toBe(true);
+  });
+
+  it("rejects a tampered HMAC body", () => {
+    const rawBody = "payload";
+    const sig = createHmac("sha256", SECRET).update(rawBody).digest("hex");
+    expect(
+      verifyIngestAuth({
+        secret: SECRET,
+        signatureHeader: `sha256=${sig}`,
+        rawBody: "payload-tampered",
+      })
+    ).toBe(false);
+  });
+
+  it("rejects when neither scheme is supplied", () => {
+    expect(verifyIngestAuth({ secret: SECRET })).toBe(false);
+  });
+});
+
+describe("normalizeAndDedupeBatch", () => {
+  it("drops events missing required fields and counts them", () => {
+    const { normalized, invalid } = normalizeAndDedupeBatch(
+      [
+        baseEvent(),
+        { pathname: "/x", visitor_id: "v", session_id: "s" }, // no website_id
+        { website_id: "w", visitor_id: "v", session_id: "s" }, // no pathname
+      ],
+      FALLBACK
+    );
+    expect(normalized).toHaveLength(1);
+    expect(invalid).toBe(2);
+  });
+
+  it("dedupes within batch on event_id keeping the first", () => {
+    const { normalized, deduped } = normalizeAndDedupeBatch(
+      [
+        baseEvent({ event_id: "e1", pathname: "/first" }),
+        baseEvent({ event_id: "e1", pathname: "/second" }),
+        baseEvent({ event_id: "e2", pathname: "/third" }),
+      ],
+      FALLBACK
+    );
+    expect(deduped).toBe(1);
+    const ids = normalized.map((e) => e.event_id);
+    expect(ids).toEqual(expect.arrayContaining(["e1", "e2"]));
+    expect(normalized.find((e) => e.event_id === "e1")?.pathname).toBe(
+      "/first"
+    );
+  });
+
+  it("keeps all events without an event_id (cannot dedupe)", () => {
+    const { normalized, deduped } = normalizeAndDedupeBatch(
+      [baseEvent({ pathname: "/a" }), baseEvent({ pathname: "/b" })],
+      FALLBACK
+    );
+    expect(deduped).toBe(0);
+    expect(normalized).toHaveLength(2);
+  });
+
+  it("sorts ascending by timestamp and accepts ts/timestamp/epoch", () => {
+    const { normalized } = normalizeAndDedupeBatch(
+      [
+        baseEvent({ pathname: "/late", timestamp: "2026-06-19T10:00:00Z" }),
+        baseEvent({ pathname: "/early", ts: "2026-06-19T08:00:00Z" }),
+        baseEvent({
+          pathname: "/mid",
+          timestamp: Date.parse("2026-06-19T09:00:00Z"),
+        }),
+      ],
+      FALLBACK
+    );
+    expect(normalized.map((e) => e.pathname)).toEqual([
+      "/early",
+      "/mid",
+      "/late",
+    ]);
+  });
+
+  it("uses the fallback timestamp when none is supplied", () => {
+    const { normalized } = normalizeAndDedupeBatch([baseEvent()], FALLBACK);
+    expect(normalized[0].timestamp.getTime()).toBe(FALLBACK.getTime());
+  });
+
+  it("normalizes defaults (event_type, is_404, nullable text)", () => {
+    const { normalized } = normalizeAndDedupeBatch(
+      [baseEvent({ event_type: "garbage" as any, referrer: "" })],
+      FALLBACK
+    );
+    expect(normalized[0].event_type).toBe("pageview");
+    expect(normalized[0].is_404).toBe(false);
+    expect(normalized[0].referrer).toBeNull();
+  });
+});
+
+describe("filterAlreadyPersisted", () => {
+  it("skips events whose event_id is already persisted", () => {
+    const { normalized } = normalizeAndDedupeBatch(
+      [
+        baseEvent({ event_id: "e1" }),
+        baseEvent({ event_id: "e2" }),
+        baseEvent({ pathname: "/no-id" }),
+      ],
+      FALLBACK
+    );
+    const { fresh, skipped } = filterAlreadyPersisted(normalized, ["e1"]);
+    expect(skipped).toBe(1);
+    expect(fresh.map((e) => e.event_id)).toEqual(
+      expect.arrayContaining(["e2", null])
+    );
+    expect(fresh).toHaveLength(2);
+  });
+
+  it("keeps everything when nothing is persisted", () => {
+    const { normalized } = normalizeAndDedupeBatch(
+      [baseEvent({ event_id: "e1" })],
+      FALLBACK
+    );
+    const { fresh, skipped } = filterAlreadyPersisted(normalized, []);
+    expect(skipped).toBe(0);
+    expect(fresh).toHaveLength(1);
+  });
+});

--- a/apps/backend/src/api/web/analytics/ingest-batch/lib.ts
+++ b/apps/backend/src/api/web/analytics/ingest-batch/lib.ts
@@ -1,0 +1,216 @@
+/**
+ * @file Pure helpers for the analytics batch-ingest endpoint (#344 slice 1).
+ * @description
+ * These are framework-free, side-effect-free functions so they can be unit
+ * tested without booting Medusa. They cover the two non-trivial concerns of
+ * the edge-offload ingest path:
+ *   1. Authenticating the caller (shared-secret OR HMAC-signed body).
+ *   2. Normalizing + deduplicating a batch of events before persistence.
+ *
+ * The actual persistence (workflow runs, session upserts) lives in route.ts.
+ */
+import { createHmac, timingSafeEqual } from "crypto";
+
+export type RawIngestEvent = {
+  event_id?: string | null;
+  website_id?: string | null;
+  event_type?: string | null;
+  event_name?: string | null;
+  pathname?: string | null;
+  referrer?: string | null;
+  visitor_id?: string | null;
+  session_id?: string | null;
+  query_string?: string | null;
+  is_404?: boolean | null;
+  utm_source?: string | null;
+  utm_medium?: string | null;
+  utm_campaign?: string | null;
+  utm_term?: string | null;
+  utm_content?: string | null;
+  country?: string | null;
+  metadata?: Record<string, any> | null;
+  // Accept either `timestamp` or `ts` (epoch ms / ISO string) from the edge worker.
+  timestamp?: string | number | Date | null;
+  ts?: string | number | Date | null;
+};
+
+export type NormalizedIngestEvent = {
+  event_id: string | null;
+  website_id: string;
+  event_type: "pageview" | "custom_event";
+  event_name: string | null;
+  pathname: string;
+  referrer: string | null;
+  visitor_id: string;
+  session_id: string;
+  query_string: string | null;
+  is_404: boolean;
+  utm_source: string | null;
+  utm_medium: string | null;
+  utm_campaign: string | null;
+  utm_term: string | null;
+  utm_content: string | null;
+  country: string | null;
+  metadata: Record<string, any> | null;
+  timestamp: Date;
+};
+
+/**
+ * Constant-time string comparison that never throws on length mismatch
+ * (timingSafeEqual requires equal-length buffers).
+ */
+function safeEqual(a: string, b: string): boolean {
+  const ba = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  if (ba.length !== bb.length) {
+    // Still run a comparison to avoid leaking length via early-return timing.
+    timingSafeEqual(ba, ba);
+    return false;
+  }
+  return timingSafeEqual(ba, bb);
+}
+
+/**
+ * Verify an inbound ingest request. Supports two interchangeable schemes so the
+ * CF Worker (slice 2) can pick whichever is easier in its runtime:
+ *   - Shared secret: header value equals `secret` (timing-safe).
+ *   - HMAC: `signatureHeader` is `sha256=<hex>` of `rawBody` keyed by `secret`.
+ *
+ * Returns false (never throws) when the secret is unset or nothing matches, so
+ * the route can reject cleanly with 401.
+ */
+export function verifyIngestAuth(opts: {
+  secret?: string | null;
+  sharedSecretHeader?: string | null;
+  signatureHeader?: string | null;
+  rawBody?: string | null;
+}): boolean {
+  const { secret, sharedSecretHeader, signatureHeader, rawBody } = opts;
+  if (!secret) return false;
+
+  // 1. Shared-secret scheme.
+  if (sharedSecretHeader && safeEqual(sharedSecretHeader, secret)) {
+    return true;
+  }
+
+  // 2. HMAC scheme.
+  if (signatureHeader && rawBody != null) {
+    const provided = signatureHeader.startsWith("sha256=")
+      ? signatureHeader.slice("sha256=".length)
+      : signatureHeader;
+    const expected = createHmac("sha256", secret).update(rawBody).digest("hex");
+    if (provided.length === expected.length && safeEqual(provided, expected)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function toDate(value: RawIngestEvent["timestamp"]): Date | null {
+  if (value == null) return null;
+  if (value instanceof Date) return isNaN(value.getTime()) ? null : value;
+  const d = new Date(value);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+const nullableText = (v: unknown): string | null =>
+  typeof v === "string" && v.length > 0 ? v : null;
+
+/**
+ * Normalize a raw batch and drop duplicates.
+ *
+ * - Invalid events (missing website_id / pathname / visitor_id / session_id)
+ *   are dropped and counted as `invalid`.
+ * - Events carrying an `event_id` are deduplicated WITHIN the batch (first wins)
+ *   — protects against worker retries that re-send overlapping windows.
+ * - Events without an `event_id` are always kept (cannot be safely deduped).
+ * - Output is sorted ascending by timestamp so session entry/exit/bounce
+ *   computation stays correct under batching.
+ * - `fallbackTimestamp` is used when an event omits both `timestamp` and `ts`.
+ */
+export function normalizeAndDedupeBatch(
+  events: RawIngestEvent[],
+  fallbackTimestamp: Date
+): {
+  normalized: NormalizedIngestEvent[];
+  invalid: number;
+  deduped: number;
+} {
+  const seen = new Set<string>();
+  const out: NormalizedIngestEvent[] = [];
+  let invalid = 0;
+  let deduped = 0;
+
+  for (const e of events || []) {
+    const website_id = nullableText(e?.website_id);
+    const pathname = nullableText(e?.pathname);
+    const visitor_id = nullableText(e?.visitor_id);
+    const session_id = nullableText(e?.session_id);
+
+    if (!website_id || !pathname || !visitor_id || !session_id) {
+      invalid++;
+      continue;
+    }
+
+    const event_id = nullableText(e?.event_id);
+    if (event_id) {
+      if (seen.has(event_id)) {
+        deduped++;
+        continue;
+      }
+      seen.add(event_id);
+    }
+
+    const event_type =
+      e?.event_type === "custom_event" ? "custom_event" : "pageview";
+
+    out.push({
+      event_id,
+      website_id,
+      event_type,
+      event_name: nullableText(e?.event_name),
+      pathname,
+      referrer: nullableText(e?.referrer),
+      visitor_id,
+      session_id,
+      query_string: nullableText(e?.query_string),
+      is_404: e?.is_404 === true,
+      utm_source: nullableText(e?.utm_source),
+      utm_medium: nullableText(e?.utm_medium),
+      utm_campaign: nullableText(e?.utm_campaign),
+      utm_term: nullableText(e?.utm_term),
+      utm_content: nullableText(e?.utm_content),
+      country: nullableText(e?.country),
+      metadata:
+        e?.metadata && typeof e.metadata === "object" ? e.metadata : null,
+      timestamp: toDate(e?.timestamp) ?? toDate(e?.ts) ?? fallbackTimestamp,
+    });
+  }
+
+  out.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+
+  return { normalized: out, invalid, deduped };
+}
+
+/**
+ * Given the candidate event_ids in a batch and the set already persisted,
+ * return the subset of `normalized` events that are new (should be inserted).
+ * Events without an event_id are always kept (can't dedupe cross-batch).
+ */
+export function filterAlreadyPersisted(
+  normalized: NormalizedIngestEvent[],
+  existingEventIds: Iterable<string>
+): { fresh: NormalizedIngestEvent[]; skipped: number } {
+  const existing = new Set(existingEventIds);
+  const fresh: NormalizedIngestEvent[] = [];
+  let skipped = 0;
+  for (const e of normalized) {
+    if (e.event_id && existing.has(e.event_id)) {
+      skipped++;
+      continue;
+    }
+    fresh.push(e);
+  }
+  return { fresh, skipped };
+}

--- a/apps/backend/src/api/web/analytics/ingest-batch/route.ts
+++ b/apps/backend/src/api/web/analytics/ingest-batch/route.ts
@@ -1,0 +1,191 @@
+/**
+ * @file Batch-ingest API route for analytics events (#344 slice 1).
+ * @description
+ * Authed bulk endpoint that the Cloudflare edge worker (slice 2) drains its
+ * buffer into. Accepts a normalized array of events, authenticates via a
+ * shared secret or HMAC signature (`ANALYTICS_INGEST_SECRET`), deduplicates on
+ * a client-supplied `event_id` (within-batch AND cross-batch), then reuses the
+ * existing `track-analytics-event` workflow per event so session/rollup logic
+ * stays identical to the per-request `/web/analytics/track` path.
+ *
+ * Design note: this is useful even before the worker exists and keeps the edge
+ * offload reversible — see apps/docs/notes/525_MODULE_AUDIT_AND_CF_VISITOR_OFFLOAD.md
+ * @module API/Web/Analytics
+ */
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import { z } from "@medusajs/framework/zod";
+import { ANALYTICS_MODULE } from "../../../../modules/analytics";
+import { trackAnalyticsEventWorkflow } from "../../../../workflows/analytics/track-analytics-event";
+import {
+  filterAlreadyPersisted,
+  normalizeAndDedupeBatch,
+  verifyIngestAuth,
+  type RawIngestEvent,
+} from "./lib";
+
+const MAX_BATCH = 500;
+
+const IngestEventSchema = z
+  .object({
+    event_id: z.string().optional(),
+    website_id: z.string(),
+    event_type: z.enum(["pageview", "custom_event"]).optional(),
+    event_name: z.string().optional(),
+    pathname: z.string(),
+    referrer: z.string().optional(),
+    visitor_id: z.string(),
+    session_id: z.string(),
+    query_string: z.string().optional(),
+    is_404: z.boolean().optional(),
+    utm_source: z.string().optional(),
+    utm_medium: z.string().optional(),
+    utm_campaign: z.string().optional(),
+    utm_term: z.string().optional(),
+    utm_content: z.string().optional(),
+    country: z.string().optional(),
+    metadata: z.record(z.string(), z.any()).optional(),
+    timestamp: z.union([z.string(), z.number()]).optional(),
+    ts: z.union([z.string(), z.number()]).optional(),
+  })
+  .passthrough();
+
+const IngestBatchSchema = z.object({
+  events: z.array(IngestEventSchema).max(MAX_BATCH),
+});
+
+/**
+ * @oas [post] /web/analytics/ingest-batch
+ * summary: "Batch-ingest Analytics Events"
+ * description: "Authed bulk ingest used by the edge analytics worker. Requires the ANALYTICS_INGEST_SECRET shared secret (header x-analytics-secret) or an HMAC signature (header x-analytics-signature: sha256=<hex of raw body>). Deduplicates on event_id."
+ * x-authenticated: false
+ * responses:
+ *   "200":
+ *     description: Batch processed
+ *   "401":
+ *     description: Missing or invalid ingest credentials
+ *   "400":
+ *     description: Invalid batch payload
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const secret = process.env.ANALYTICS_INGEST_SECRET;
+
+  const sharedSecretHeader =
+    (req.headers["x-analytics-secret"] as string | undefined) || null;
+  const signatureHeader =
+    (req.headers["x-analytics-signature"] as string | undefined) || null;
+  const rawBody =
+    (req as any).rawBody != null
+      ? (req as any).rawBody.toString()
+      : JSON.stringify(req.body ?? {});
+
+  if (
+    !verifyIngestAuth({
+      secret,
+      sharedSecretHeader,
+      signatureHeader,
+      rawBody,
+    })
+  ) {
+    return res.status(401).json({ success: false, message: "Unauthorized" });
+  }
+
+  let parsed: z.infer<typeof IngestBatchSchema>;
+  try {
+    parsed = IngestBatchSchema.parse(req.body);
+  } catch (e) {
+    return res
+      .status(400)
+      .json({ success: false, message: "Invalid batch payload" });
+  }
+
+  const received = parsed.events.length;
+  const { normalized, invalid, deduped } = normalizeAndDedupeBatch(
+    parsed.events as RawIngestEvent[],
+    new Date()
+  );
+
+  // Cross-batch idempotency: skip any event_id we have already persisted.
+  let skipped = 0;
+  let fresh = normalized;
+  const candidateIds = normalized
+    .map((e) => e.event_id)
+    .filter((id): id is string => !!id);
+
+  if (candidateIds.length > 0) {
+    try {
+      const analyticsService: any = req.scope.resolve(ANALYTICS_MODULE);
+      const existing: Array<{ event_id?: string | null }> =
+        await analyticsService.listAnalyticsEvents(
+          { event_id: candidateIds },
+          { select: ["event_id"], take: candidateIds.length }
+        );
+      const existingIds = existing
+        .map((e) => e.event_id)
+        .filter((id): id is string => !!id);
+      const r = filterAlreadyPersisted(normalized, existingIds);
+      fresh = r.fresh;
+      skipped = r.skipped;
+    } catch (e) {
+      // Non-fatal: if the dedup lookup fails, fall back to inserting all
+      // (within-batch dedup already applied). Better to risk a rare duplicate
+      // than to drop real events.
+      console.error("ingest-batch dedup lookup failed:", e);
+    }
+  }
+
+  const userAgent = (req.headers["user-agent"] as string) || "";
+  const ip =
+    (req.headers["x-forwarded-for"] as string) ||
+    req.socket?.remoteAddress ||
+    "";
+
+  let accepted = 0;
+  let failed = 0;
+  for (const e of fresh) {
+    try {
+      await trackAnalyticsEventWorkflow(req.scope).run({
+        input: {
+          client_event_id: e.event_id || undefined,
+          website_id: e.website_id,
+          event_type: e.event_type,
+          event_name: e.event_name || undefined,
+          pathname: e.pathname,
+          referrer: e.referrer || undefined,
+          visitor_id: e.visitor_id,
+          session_id: e.session_id,
+          query_string: e.query_string || undefined,
+          is_404: e.is_404,
+          utm_source: e.utm_source || undefined,
+          utm_medium: e.utm_medium || undefined,
+          utm_campaign: e.utm_campaign || undefined,
+          utm_term: e.utm_term || undefined,
+          utm_content: e.utm_content || undefined,
+          // Prefer the geo the edge worker resolved (request.cf.country);
+          // the workflow falls back to GeoIP when ip is set and country isn't.
+          country: e.country || undefined,
+          metadata: e.metadata || undefined,
+          user_agent: userAgent,
+          ip_address: ip,
+          timestamp: e.timestamp,
+        },
+      });
+      accepted++;
+    } catch (err) {
+      failed++;
+      console.error("ingest-batch event failed:", err);
+    }
+  }
+
+  return res.status(200).json({
+    success: true,
+    received,
+    accepted,
+    invalid,
+    deduped,
+    skipped,
+    failed,
+  });
+};
+
+// Public endpoint: gated by ANALYTICS_INGEST_SECRET (HMAC / shared secret), not session auth.
+export const AUTHENTICATE = false;

--- a/apps/backend/src/modules/analytics/migrations/Migration20260619000000.ts
+++ b/apps/backend/src/modules/analytics/migrations/Migration20260619000000.ts
@@ -1,0 +1,26 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * #344 — add a client-supplied idempotency key to analytics_event so the
+ * batch-ingest path / edge worker can dedupe retried batches cross-request.
+ *
+ * Hand-written ALTER (add column IF NOT EXISTS) so it lands on EXISTING DBs —
+ * editing the original create-table migration would never re-run on prod.
+ */
+export class Migration20260619000000 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(
+      `alter table if exists "analytics_event" add column if not exists "event_id" text null;`
+    );
+    this.addSql(
+      `CREATE INDEX IF NOT EXISTS "IDX_analytics_event_event_id" ON "analytics_event" ("event_id") WHERE deleted_at IS NULL;`
+    );
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop index if exists "IDX_analytics_event_event_id";`);
+    this.addSql(
+      `alter table if exists "analytics_event" drop column if exists "event_id";`
+    );
+  }
+}

--- a/apps/backend/src/modules/analytics/models/analytics-event.ts
+++ b/apps/backend/src/modules/analytics/models/analytics-event.ts
@@ -2,7 +2,12 @@ import { model } from "@medusajs/framework/utils";
 
 const AnalyticsEvent = model.define("analytics_event", {
   id: model.id().primaryKey(),
-  
+
+  // Client-supplied idempotency key (optional). Set by the batch-ingest path /
+  // edge worker so retried batches dedupe cross-request. Null for the direct
+  // /web/analytics/track path. See #344.
+  event_id: model.text().nullable(),
+
   // Website Reference (stored as text ID, linked via module link)
   website_id: model.text(),
   
@@ -62,6 +67,9 @@ const AnalyticsEvent = model.define("analytics_event", {
   },
   {
     on: ["website_id", "event_type", "timestamp"],
+  },
+  {
+    on: ["event_id"],
   },
 ]);
 

--- a/apps/backend/src/workflows/analytics/track-analytics-event.ts
+++ b/apps/backend/src/workflows/analytics/track-analytics-event.ts
@@ -101,6 +101,12 @@ type TrackAnalyticsEventInput = {
   user_agent: string;
   ip_address: string;
   timestamp: Date;
+  // Optional client-supplied idempotency key (set by the batch-ingest path / edge worker).
+  // Persisted to analytics_event.event_id so retried batches dedupe cross-request.
+  client_event_id?: string;
+  // Optional pre-resolved country (e.g. request.cf.country from the edge worker);
+  // when set, it takes precedence over per-event GeoIP lookup.
+  country?: string;
   query_string?: string;
   is_404?: boolean;
   utm_source?: string;
@@ -124,8 +130,8 @@ const createAnalyticsEventStep = createStep(
     // Extract referrer source
     const referrer_source = extractReferrerSource(input.referrer);
     
-    // Get country from IP address
-    const country = getCountryFromIP(input.ip_address);
+    // Prefer an edge-resolved country (request.cf.country); fall back to GeoIP.
+    const country = input.country || getCountryFromIP(input.ip_address);
 
     // Create the event
     const event = await analyticsService.createAnalyticsEvents({
@@ -142,6 +148,7 @@ const createAnalyticsEventStep = createStep(
       os,
       device_type,
       country,
+      event_id: input.client_event_id || null,
       query_string: input.query_string || null,
       is_404: input.is_404 || false,
       utm_source: input.utm_source || null,


### PR DESCRIPTION
## #344 — Cloudflare visitor-data offload, **slice 1** (backend-only)

First slice of the edge-offload vein unlocked by the #525 design doc (`apps/docs/notes/525_MODULE_AUDIT_AND_CF_VISITOR_OFFLOAD.md`). Buildable + useful standalone; keeps the offload reversible (no panel/rollup changes).

### What
New authed bulk endpoint the CF edge worker (slice 2) will drain its buffer into.

- **Route** `POST /web/analytics/ingest-batch` (`AUTHENTICATE=false`; gated by `ANALYTICS_INGEST_SECRET` — `x-analytics-secret` shared-secret **or** `x-analytics-signature: sha256=<hex>` HMAC over the raw body). Returns `200 {success, received, accepted, invalid, deduped, skipped, failed}`; `401` on bad creds, `400` on bad payload (max 500 events/batch).
- **Pure helpers** (`lib.ts`, fully unit-tested): `verifyIngestAuth` (timing-safe shared-secret + HMAC-SHA256), `normalizeAndDedupeBatch` (within-batch dedupe on client `event_id`, ts-ascending sort so session entry/exit/bounce stay correct, defaults), `filterAlreadyPersisted`.
- **Idempotency**: new nullable **indexed** `analytics_event.event_id` column (hand-written `ALTER … add column if not exists` migration so it lands on existing DBs — per the documented create-table hazard) + cross-batch skip of already-persisted ids (best-effort; falls back to insert-all if the lookup fails, never drops real events).
- **Reuse**: runs `trackAnalyticsEventWorkflow` per event so session/daily-rollup logic is identical to `/web/analytics/track`. Workflow gains optional `client_event_id` (persisted to the new column) + `country` (edge `request.cf.country` takes precedence over per-event GeoIP).

### Tests
- 16 unit tests green: `cd apps/backend && TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules npx jest --testPathPattern="ingest-batch/__tests__/lib.unit"`
- `tsc` clean on changed files.

### Watch-outs
- HMAC verify uses `(req as any).rawBody` when present, else re-serializes `req.body`. Slice 2's worker should prefer the **shared-secret** header for guaranteed correctness, or we add a raw-body-preserving middleware (follow-up) before relying on HMAC over re-serialized JSON.
- Per-event workflow loop (not a single bulk insert) — correct/reversible for slice 1; batched insert is a perf follow-up if volume demands.
- Off `main`, independent. **Do not merge — human review.** Auto-deploys on merge (~18-45m); migration is additive (nullable col + partial index).

🤖 Generated with [Claude Code](https://claude.com/claude-code)