### PR TITLE
fix(analytics): #344 — preserve raw body for ingest-batch HMAC verification

### DIFF
--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -608,6 +608,17 @@ export default defineMiddlewares({
       matcher: "/web/*",
       middlewares: [createCorsMiddleware()],
     },
+    // Analytics batch-ingest (#344): preserve the raw request body so the HMAC
+    // signature can be verified against the EXACT bytes the edge worker signed.
+    // Without this, the route falls back to JSON.stringify(req.body), whose
+    // key-order/whitespace won't match the worker's serialization → 401s.
+    // CORS still applies via the /web/* entry above (matchers compose).
+    {
+      matcher: "/web/analytics/ingest-batch",
+      method: "POST",
+      middlewares: [],
+      bodyParser: { preserveRawBody: true }, // req.rawBody = Buffer for HMAC, req.body = parsed JSON
+    },
     // Webhooks (no authentication required)
     {
       matcher: "/webhooks/social/facebook",

--- a/apps/backend/src/api/web/analytics/ingest-batch/__tests__/lib.unit.spec.ts
+++ b/apps/backend/src/api/web/analytics/ingest-batch/__tests__/lib.unit.spec.ts
@@ -77,6 +77,39 @@ describe("verifyIngestAuth", () => {
   it("rejects when neither scheme is supplied", () => {
     expect(verifyIngestAuth({ secret: SECRET })).toBe(false);
   });
+
+  // Regression guard for the slice that added `preserveRawBody` middleware to
+  // the ingest route. The worker signs the EXACT bytes it sends; if the route
+  // re-serializes the parsed body (JSON.stringify) the bytes differ (spacing,
+  // key order) and the HMAC fails. This documents why the raw body must be
+  // preserved rather than reconstructed.
+  it("verifies against the exact raw body but NOT a re-serialized one", () => {
+    // Body as the worker would send it on the wire (spaces after ':' and ',').
+    const rawBody = '{"events": [{"website_id": "web_1", "pathname": "/"}]}';
+    const sig = createHmac("sha256", SECRET).update(rawBody).digest("hex");
+
+    // Verifies against the bytes that were actually signed.
+    expect(
+      verifyIngestAuth({
+        secret: SECRET,
+        signatureHeader: `sha256=${sig}`,
+        rawBody,
+      })
+    ).toBe(true);
+
+    // A parse → JSON.stringify round-trip drops the worker's formatting, so the
+    // same signature must NOT verify against the reconstructed body. This is the
+    // failure mode the middleware change eliminates.
+    const reserialized = JSON.stringify(JSON.parse(rawBody));
+    expect(reserialized).not.toBe(rawBody);
+    expect(
+      verifyIngestAuth({
+        secret: SECRET,
+        signatureHeader: `sha256=${sig}`,
+        rawBody: reserialized,
+      })
+    ).toBe(false);
+  });
 });
 
 describe("normalizeAndDedupeBatch", () => {


### PR DESCRIPTION
## What & why
Slice-1 (#547, merged) left a documented watch-out: the `/web/analytics/ingest-batch` HMAC is verified over `req.rawBody` when present, else it falls back to `JSON.stringify(req.body)`. **No middleware preserved the raw body for this route**, so the HMAC path always re-serialized the parsed body — whose key order / whitespace won't match what the edge worker (slice 2) signed → spurious `401`s.

## Change
- Add a `bodyParser: { preserveRawBody: true }` matcher for `POST /web/analytics/ingest-batch` in `src/api/middlewares.ts`, mirroring the existing WhatsApp-webhook pattern. `req.rawBody` now holds the exact signed bytes; `req.body` stays parsed for zod. CORS still applies via the `/web/*` entry (Medusa composes matching matchers).
- Regression unit test: an HMAC verifies against the raw bytes but **not** against a `JSON.parse → JSON.stringify` round-trip — the precise failure mode this eliminates.

## Unblocks
Slice 2 (CF Worker `collect`) can now sign the raw body it POSTs and have it verify deterministically, instead of being forced onto the shared-secret header.

## Verify
```
cd apps/backend && TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules npx jest --testPathPattern="ingest-batch/__tests__/lib.unit"
```
17/17 green; tsc clean on changed files.

Independent off `main` (#547 already merged). Backend-config + test only — no model/migration change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)