### PR TITLE
feat(admin): global `q` search on /admin/partners + /admin/websites (#525 P1)

### DIFF
--- a/apps/backend/src/api/admin/partners/route.ts
+++ b/apps/backend/src/api/admin/partners/route.ts
@@ -157,6 +157,7 @@ import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { listPartnersWorkflow } from "../../../workflows/partners/list-partners"
 import { MedusaError, Modules } from "@medusajs/framework/utils"
 import { createPartnerAdminWithRegistrationWorkflow } from "../../../workflows/partner/create-partner-admin"
+import { buildQSearchFilter } from "../../../lib/list-search-filters"
 import { PostPartnerWithAdminSchema } from "./validators"
 
 export const GET = async (
@@ -164,6 +165,7 @@ export const GET = async (
     query?: {
       offset?: number
       limit?: number
+      q?: string
       name?: string
       handle?: string
       status?: "active" | "inactive" | "pending"
@@ -202,6 +204,9 @@ export const GET = async (
         handle: req.query?.handle,
         status: req.query?.status,
         is_verified: req.query?.is_verified,
+        // Global free-text search across name/handle (mirrors
+        // admin/persons/partner). DB-level `$or`/`$ilike` keeps count correct.
+        ...buildQSearchFilter(req.query?.q, ["name", "handle"]),
       },
       offset,
       limit,

--- a/apps/backend/src/api/admin/websites/route.ts
+++ b/apps/backend/src/api/admin/websites/route.ts
@@ -118,6 +118,7 @@ import {
   ListWebsiteWorkflowInput,
   listWebsiteWorkflow,
 } from "../../../workflows/website/list-website";
+import { buildQSearchFilter } from "../../../lib/list-search-filters";
 
 export const POST = async (
   req: MedusaRequest<WebsiteSchema>,
@@ -131,7 +132,7 @@ export const POST = async (
 };
 
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
-  const { name, status, domain } = req.query;
+  const { name, status, domain, q } = req.query;
   const offset = parseInt(req.query.offset as string) || 0;
   const limit = parseInt(req.query.limit as string) || 10;
 
@@ -145,6 +146,9 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       name,
       status,
       domain,
+      // Global free-text search across name/domain. DB-level `$or`/`$ilike`
+      // keeps the returned `count` accurate for pagination.
+      ...buildQSearchFilter(q as string | undefined, ["name", "domain"]),
     }
   };
 

--- a/apps/backend/src/lib/__tests__/list-search-filters.unit.spec.ts
+++ b/apps/backend/src/lib/__tests__/list-search-filters.unit.spec.ts
@@ -1,0 +1,65 @@
+import { buildQSearchFilter } from "../list-search-filters"
+
+// Pure unit coverage for the global `q` list-search helper (#525 P1 —
+// /admin/partners + /admin/websites). No DB, no container.
+describe("buildQSearchFilter (#525 admin list search)", () => {
+  it("builds an $or of $ilike clauses across the given fields", () => {
+    expect(buildQSearchFilter("acme", ["name", "handle"])).toEqual({
+      $or: [
+        { name: { $ilike: "%acme%" } },
+        { handle: { $ilike: "%acme%" } },
+      ],
+    })
+  })
+
+  it("supports a single field", () => {
+    expect(buildQSearchFilter("store", ["domain"])).toEqual({
+      $or: [{ domain: { $ilike: "%store%" } }],
+    })
+  })
+
+  it("trims surrounding whitespace before matching", () => {
+    expect(buildQSearchFilter("  acme  ", ["name"])).toEqual({
+      $or: [{ name: { $ilike: "%acme%" } }],
+    })
+  })
+
+  it("returns {} for an undefined term", () => {
+    expect(buildQSearchFilter(undefined, ["name", "handle"])).toEqual({})
+  })
+
+  it("returns {} for a null term", () => {
+    expect(buildQSearchFilter(null, ["name"])).toEqual({})
+  })
+
+  it("returns {} for a blank / whitespace-only term", () => {
+    expect(buildQSearchFilter("", ["name"])).toEqual({})
+    expect(buildQSearchFilter("   ", ["name"])).toEqual({})
+  })
+
+  it("returns {} when no fields are supplied", () => {
+    expect(buildQSearchFilter("acme", [])).toEqual({})
+  })
+
+  it("is spreadable into an existing filters object without clobbering", () => {
+    const filters = {
+      status: "active",
+      ...buildQSearchFilter("foo", ["name", "domain"]),
+    }
+    expect(filters).toEqual({
+      status: "active",
+      $or: [
+        { name: { $ilike: "%foo%" } },
+        { domain: { $ilike: "%foo%" } },
+      ],
+    })
+  })
+
+  it("spreads to nothing when q is absent (leaves base filters intact)", () => {
+    const filters = {
+      status: "active",
+      ...buildQSearchFilter(undefined, ["name"]),
+    }
+    expect(filters).toEqual({ status: "active" })
+  })
+})

--- a/apps/backend/src/lib/list-search-filters.ts
+++ b/apps/backend/src/lib/list-search-filters.ts
@@ -1,0 +1,35 @@
+/**
+ * @file Pure helpers for building free-text (`q`) list filters.
+ * @module lib/list-search-filters
+ *
+ * Mirrors the established admin pattern (e.g. `admin/persons/partner/route.ts`,
+ * `admin/google-merchant/accounts/route.ts`): a global `q` query param expands
+ * into a DB-level `$or` of case-insensitive `$ilike` clauses across the given
+ * fields. Doing the filter at the query layer (not in-app) keeps pagination and
+ * the returned `count` correct.
+ */
+
+/**
+ * Build a `$or` / `$ilike` search clause for a free-text `q` over the given
+ * fields. Returns an empty object when `q` is blank or no fields are supplied,
+ * so the result can be spread directly into an existing `filters` object:
+ *
+ *   const filters = { status, ...buildQSearchFilter(q, ["name", "handle"]) }
+ *
+ * @param q - The raw free-text search term (may be undefined/null/blank).
+ * @param fields - Entity fields to match against (case-insensitive contains).
+ * @returns `{ $or: [...] }` when active, otherwise `{}`.
+ */
+export const buildQSearchFilter = (
+  q: string | undefined | null,
+  fields: string[]
+): Record<string, any> => {
+  const trimmed = typeof q === "string" ? q.trim() : ""
+  if (!trimmed || !Array.isArray(fields) || fields.length === 0) {
+    return {}
+  }
+
+  return {
+    $or: fields.map((field) => ({ [field]: { $ilike: `%${trimmed}%` } })),
+  }
+}


### PR DESCRIPTION
## What

Adds a global free-text `q` query param to the two admin list endpoints flagged as the #525 P1 UX gap:

- `GET /admin/partners?q=…` → matches `name` / `handle`
- `GET /admin/websites?q=…` → matches `name` / `domain`

## How

`q` expands into a **DB-level `$or` of case-insensitive `$ilike` clauses**, mirroring the existing admin precedents (`admin/persons/partner/route.ts`, `admin/google-merchant/accounts/route.ts`) — **not** invented. Filtering at the query layer (vs in-app) keeps pagination and the returned `count` accurate.

- New pure helper `src/lib/list-search-filters.ts` → `buildQSearchFilter(q, fields)` returns `{ $or: [...] }` or `{}` (spreadable into existing `filters`).
- Partners route passes through `listPartnersWorkflow` (query.graph filters); websites through `listAndCountWebsites` (MikroORM filters). Both honor `$or`/`$ilike`.
- Backwards compatible: existing `name`/`handle`/`status`/`domain` filters unchanged; `q` is purely additive.

## Tests

- `src/lib/__tests__/list-search-filters.unit.spec.ts` — 9 unit tests (✅), covering active/blank/null/undefined term, single+multi field, trim, spread composition.
- `tsc --noEmit` clean on changed files.

## Notes

- Resolves the chunk-7 "needs `$or $ilike` vs in-app decision" open question: the codebase already standardizes on DB-level `$or`/`$ilike` for admin `q` search, so this just mirrors it.
- Off `origin/main`, independent (no stacking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)