### PR TITLE
feat(analytics): multi-instance-safe live count via DB-poll refresh (#344)

### DIFF
--- a/apps/backend/src/api/admin/analytics/live/__tests__/lib.unit.spec.ts
+++ b/apps/backend/src/api/admin/analytics/live/__tests__/lib.unit.spec.ts
@@ -1,0 +1,122 @@
+import {
+  computeLiveStats,
+  resolveLiveRefreshMs,
+  LIVE_WINDOW_MS,
+  type LiveAnalyticsEvent,
+} from "../lib";
+
+/**
+ * Unit coverage for the live-analytics pure helpers (#344 slice 3 — lightweight,
+ * multi-instance-safe DB-poll refresh). No DI / timers / SSE stream involved.
+ */
+
+const ev = (over: Partial<LiveAnalyticsEvent>): LiveAnalyticsEvent => ({
+  id: over.id ?? "evt",
+  pathname: "/",
+  timestamp: "2026-06-19T12:00:00.000Z",
+  visitor_id: "v1",
+  session_id: "s1",
+  ...over,
+});
+
+describe("computeLiveStats", () => {
+  it("counts distinct sessions and visitors", () => {
+    const stats = computeLiveStats([
+      ev({ id: "a", visitor_id: "v1", session_id: "s1" }),
+      ev({ id: "b", visitor_id: "v1", session_id: "s1" }), // same visitor+session
+      ev({ id: "c", visitor_id: "v2", session_id: "s2" }),
+      ev({ id: "d", visitor_id: "v2", session_id: "s3" }), // same visitor, new session
+    ]);
+    expect(stats.currentVisitors).toBe(3); // s1, s2, s3
+    expect(stats.uniqueVisitors).toBe(2); // v1, v2
+  });
+
+  it("returns an empty snapshot for no events", () => {
+    expect(computeLiveStats([])).toEqual({
+      currentVisitors: 0,
+      uniqueVisitors: 0,
+      recentEvents: [],
+      activePages: [],
+    });
+  });
+
+  it("ignores empty/missing visitor and session ids when counting", () => {
+    const stats = computeLiveStats([
+      ev({ id: "a", visitor_id: "", session_id: "" }),
+      ev({ id: "b", visitor_id: null as any, session_id: undefined as any }),
+      ev({ id: "c", visitor_id: "v1", session_id: "s1" }),
+    ]);
+    expect(stats.currentVisitors).toBe(1);
+    expect(stats.uniqueVisitors).toBe(1);
+  });
+
+  it("attributes each visitor to their LATEST page and ranks pages by count", () => {
+    const stats = computeLiveStats([
+      ev({ id: "1", visitor_id: "v1", pathname: "/a", timestamp: "2026-06-19T12:00:00Z" }),
+      ev({ id: "2", visitor_id: "v1", pathname: "/b", timestamp: "2026-06-19T12:01:00Z" }), // v1 now on /b
+      ev({ id: "3", visitor_id: "v2", pathname: "/b", timestamp: "2026-06-19T12:00:30Z" }),
+      ev({ id: "4", visitor_id: "v3", pathname: "/c", timestamp: "2026-06-19T12:00:10Z" }),
+    ]);
+    // /b has v1 (latest) + v2 = 2; /c has v3 = 1; /a no longer current for anyone
+    expect(stats.activePages).toEqual([
+      { page: "/b", count: 2 },
+      { page: "/c", count: 1 },
+    ]);
+  });
+
+  it("returns recentEvents newest-first, capped at 10", () => {
+    const events: LiveAnalyticsEvent[] = Array.from({ length: 15 }, (_, i) =>
+      ev({
+        id: `e${i}`,
+        visitor_id: `v${i}`,
+        session_id: `s${i}`,
+        timestamp: new Date(Date.UTC(2026, 5, 19, 12, 0, i)).toISOString(),
+      })
+    );
+    const stats = computeLiveStats(events);
+    expect(stats.recentEvents).toHaveLength(10);
+    expect(stats.recentEvents[0].id).toBe("e14"); // newest first
+    expect(stats.recentEvents[9].id).toBe("e5");
+  });
+
+  it("does not mutate the input array", () => {
+    const events = [
+      ev({ id: "old", timestamp: "2026-06-19T12:00:00Z" }),
+      ev({ id: "new", timestamp: "2026-06-19T12:05:00Z" }),
+    ];
+    const snapshot = [...events];
+    computeLiveStats(events);
+    expect(events.map((e) => e.id)).toEqual(snapshot.map((e) => e.id));
+  });
+
+  it("tolerates Date instances and string timestamps interchangeably", () => {
+    const stats = computeLiveStats([
+      ev({ id: "a", visitor_id: "v1", session_id: "s1", timestamp: new Date("2026-06-19T12:00:00Z") }),
+      ev({ id: "b", visitor_id: "v2", session_id: "s2", timestamp: "2026-06-19T12:01:00Z" }),
+    ]);
+    expect(stats.recentEvents[0].id).toBe("b"); // 12:01 newer than 12:00
+    expect(stats.currentVisitors).toBe(2);
+  });
+});
+
+describe("resolveLiveRefreshMs", () => {
+  it("defaults to 15s when unset or invalid", () => {
+    expect(resolveLiveRefreshMs(undefined)).toBe(15000);
+    expect(resolveLiveRefreshMs("")).toBe(15000);
+    expect(resolveLiveRefreshMs("not-a-number")).toBe(15000);
+    expect(resolveLiveRefreshMs("0")).toBe(15000);
+    expect(resolveLiveRefreshMs("-100")).toBe(15000);
+  });
+
+  it("honours a valid override but never polls faster than 5s", () => {
+    expect(resolveLiveRefreshMs("30000")).toBe(30000);
+    expect(resolveLiveRefreshMs("1000")).toBe(5000); // clamped to floor
+    expect(resolveLiveRefreshMs("8000")).toBe(8000);
+  });
+});
+
+describe("LIVE_WINDOW_MS", () => {
+  it("is a 5-minute active window", () => {
+    expect(LIVE_WINDOW_MS).toBe(5 * 60 * 1000);
+  });
+});

--- a/apps/backend/src/api/admin/analytics/live/lib.ts
+++ b/apps/backend/src/api/admin/analytics/live/lib.ts
@@ -1,0 +1,116 @@
+/**
+ * @file Pure helpers for the live-analytics SSE endpoint (#344 slice 3 — lightweight path).
+ * @description
+ * The live dashboard's "active visitors" count must stay correct on a
+ * horizontally-scaled (multi-instance) deployment. The in-memory SSE push pool
+ * (`analyticsConnections`) only broadcasts events processed by the SAME Fargate
+ * instance the client is connected to, so a client on instance A never sees
+ * visits ingested by instance B and the count drifts.
+ *
+ * The reversible, no-new-infra fix the volume-sizing analysis endorsed (KV/poll
+ * over a Durable Object, given ~249 events/day) is to periodically re-derive the
+ * snapshot from the shared DB and re-push it. Each instance computes the SAME
+ * authoritative count from Postgres, so the UI self-heals across instances.
+ *
+ * `computeLiveStats` is the pure aggregation extracted from the route so it is
+ * unit-testable in isolation (no DI, no timers, no res stream).
+ * @module API/Admin/Analytics
+ */
+
+/** Active-visitor window: events newer than this count toward "currently active". */
+export const LIVE_WINDOW_MS = 5 * 60 * 1000;
+
+/**
+ * How often the SSE stream re-derives the snapshot from the DB and re-pushes it.
+ * Override with `ANALYTICS_LIVE_REFRESH_MS` (clamped to a sane floor). Kept well
+ * above the 30s heartbeat so the two never thrash; default 15s.
+ */
+export function resolveLiveRefreshMs(
+  raw: string | undefined = process.env.ANALYTICS_LIVE_REFRESH_MS
+): number {
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return 15000;
+  }
+  // Never poll the DB faster than every 5s, regardless of misconfiguration.
+  return Math.max(5000, Math.floor(parsed));
+}
+
+/** Minimal shape of an analytics event row the live snapshot reads. */
+export type LiveAnalyticsEvent = {
+  id: string;
+  event_type?: string | null;
+  event_name?: string | null;
+  pathname?: string | null;
+  timestamp: Date | string;
+  referrer_source?: string | null;
+  device_type?: string | null;
+  browser?: string | null;
+  visitor_id?: string | null;
+  session_id?: string | null;
+};
+
+export type ActivePage = { page: string; count: number };
+
+export type LiveStats = {
+  currentVisitors: number;
+  uniqueVisitors: number;
+  recentEvents: LiveAnalyticsEvent[];
+  activePages: ActivePage[];
+};
+
+function toMillis(ts: Date | string): number {
+  const t = ts instanceof Date ? ts.getTime() : new Date(ts).getTime();
+  return Number.isFinite(t) ? t : 0;
+}
+
+/**
+ * Aggregate a window of recent events into the live snapshot the UI renders.
+ *
+ * Pure — same input always yields the same output. The caller is responsible for
+ * passing only in-window events (the DB query bounds them by {@link LIVE_WINDOW_MS}).
+ *
+ * - `currentVisitors`  = distinct non-empty `session_id`
+ * - `uniqueVisitors`   = distinct non-empty `visitor_id`
+ * - `recentEvents`     = newest-first, capped at 10
+ * - `activePages`      = visitor's LATEST page → counted → top 5 by count
+ */
+export function computeLiveStats(events: LiveAnalyticsEvent[]): LiveStats {
+  const sorted = [...events].sort(
+    (a, b) => toMillis(b.timestamp) - toMillis(a.timestamp)
+  );
+
+  const uniqueSessionIds = new Set<string>();
+  const uniqueVisitorIds = new Set<string>();
+  // Newest-first walk → first time we see a visitor is their current page.
+  const visitorCurrentPage = new Map<string, string>();
+
+  for (const e of sorted) {
+    if (e.session_id) {
+      uniqueSessionIds.add(e.session_id)
+    }
+    if (e.visitor_id) {
+      uniqueVisitorIds.add(e.visitor_id)
+    }
+    if (e.visitor_id && e.pathname && !visitorCurrentPage.has(e.visitor_id)) {
+      visitorCurrentPage.set(e.visitor_id, e.pathname);
+    }
+  }
+
+  const pageCounts: Record<string, number> = {};
+  for (const pathname of visitorCurrentPage.values()) {
+    pageCounts[pathname] = (pageCounts[pathname] || 0) + 1;
+  }
+
+  const activePages = Object.entries(pageCounts)
+    .map(([page, count]) => ({ page, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 5);
+
+  return {
+    currentVisitors: uniqueSessionIds.size,
+    uniqueVisitors: uniqueVisitorIds.size,
+    recentEvents: sorted.slice(0, 10),
+    activePages,
+  };
+}

--- a/apps/backend/src/api/admin/analytics/live/route.ts
+++ b/apps/backend/src/api/admin/analytics/live/route.ts
@@ -68,6 +68,12 @@ import { MedusaRequest, MedusaResponse } from "@medusajs/framework";
 import { analyticsConnections } from "../../../../subscribers/analytics-realtime";
 import { ANALYTICS_MODULE } from "../../../../modules/analytics";
 import AnalyticsService from "../../../../modules/analytics/service";
+import {
+  computeLiveStats,
+  LIVE_WINDOW_MS,
+  resolveLiveRefreshMs,
+  type LiveAnalyticsEvent,
+} from "./lib";
 
 /**
  * GET /admin/analytics/live
@@ -207,9 +213,27 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     }
   }, 30000);
 
+  // Periodically re-derive the snapshot from the (shared) DB and re-push it.
+  // The in-memory push pool only relays events processed by THIS instance, so on
+  // a multi-instance deployment the count drifts; re-pushing an authoritative
+  // DB-derived snapshot lets every connected client self-heal (the UI already
+  // treats a `connected` message as the source of truth). No new infra needed —
+  // see ./lib.ts and apps/docs/notes/525_MODULE_AUDIT_AND_CF_VISITOR_OFFLOAD.md.
+  const refreshMs = resolveLiveRefreshMs();
+  const refresh = setInterval(async () => {
+    try {
+      const stats = await getCurrentStats(analyticsService, website_id as string);
+      res.write(`data: ${JSON.stringify({ type: 'connected', data: stats })}\n\n`);
+    } catch (error) {
+      // Keep the stream alive on a transient query/write error; the next tick retries.
+      console.error("[Analytics Live] Error refreshing stats:", error);
+    }
+  }, refreshMs);
+
   // Clean up on disconnect
   req.on("close", () => {
     clearInterval(heartbeat);
+    clearInterval(refresh);
     const connections = analyticsConnections.get(website_id as string);
     if (connections) {
       connections.delete(res);
@@ -227,13 +251,13 @@ async function getCurrentStats(
   analyticsService: AnalyticsService,
   websiteId: string
 ) {
-  // Get recent events (last 5 minutes) to determine active visitors
-  const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
+  // Get recent events (within the active-visitor window) to determine who's live
+  const windowStart = new Date(Date.now() - LIVE_WINDOW_MS);
 
   const [recentEvents] = await analyticsService.listAndCountAnalyticsEvents(
     {
       website_id: websiteId,
-      timestamp: { $gte: fiveMinutesAgo },
+      timestamp: { $gte: windowStart },
     },
     {
       select: [
@@ -251,41 +275,6 @@ async function getCurrentStats(
     }
   );
 
-  // Count unique visitors and sessions from recent events
-  const uniqueVisitorIds = new Set(recentEvents.map((e: any) => e.visitor_id));
-  const uniqueSessionIds = new Set(recentEvents.map((e: any) => e.session_id));
-
-  // Get the most recent event per visitor to determine their current page
-  const visitorCurrentPages = new Map<string, string>();
-  
-  // Sort events by timestamp descending
-  const sortedEvents = [...recentEvents].sort(
-    (a: any, b: any) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
-  );
-
-  // Get the latest page for each visitor
-  for (const event of sortedEvents) {
-    if (!visitorCurrentPages.has(event.visitor_id)) {
-      visitorCurrentPages.set(event.visitor_id, event.pathname);
-    }
-  }
-
-  // Count visitors per page
-  const activePages: Record<string, number> = {};
-  for (const pathname of visitorCurrentPages.values()) {
-    activePages[pathname] = (activePages[pathname] || 0) + 1;
-  }
-
-  // Get last 10 events for activity feed
-  const latestEvents = sortedEvents.slice(0, 10);
-
-  return {
-    currentVisitors: uniqueSessionIds.size,
-    uniqueVisitors: uniqueVisitorIds.size,
-    recentEvents: latestEvents,
-    activePages: Object.entries(activePages)
-      .map(([page, count]) => ({ page, count }))
-      .sort((a: any, b: any) => b.count - a.count)
-      .slice(0, 5),
-  };
+  // Pure aggregation (extracted + unit-tested in ./lib.ts).
+  return computeLiveStats(recentEvents as LiveAnalyticsEvent[]);
 }


### PR DESCRIPTION
## #344 slice 3 (lightweight path) — multi-instance-safe live visitor count

### Problem
`GET /admin/analytics/live` (SSE) sends an initial DB-derived snapshot, then only updates counts via the **in-memory** `analyticsConnections` pool, which the realtime subscriber broadcasts into. That pool only contains events processed by the **same Fargate instance** the client connected to — so on a horizontally-scaled deployment a client on instance A never sees visits ingested by instance B, and the "active visitors" count drifts from reality. (Documented in CODEBASE_MAP as "NOT multi-instance-safe".)

### Fix (no new infra, reversible, additive)
Add a periodic **DB-poll refresh** to the SSE loop: every `ANALYTICS_LIVE_REFRESH_MS` (default 15s, 5s floor) re-derive the authoritative snapshot from the shared Postgres 5-minute window and re-push it as a `connected` message. The admin UI (`live-analytics-panel.tsx`) **already** treats `connected` as source-of-truth (`setLiveData(message.data)`), so the count self-heals across instances with **zero UI change**. The in-memory push path stays for immediacy.

This is the lightweight, reversible slice-3 direction the #344 **volume-sizing analysis** endorsed (≈249 events/day → KV/poll, not a Cloudflare Durable Object). See `apps/docs/notes/525_MODULE_AUDIT_AND_CF_VISITOR_OFFLOAD.md`.

### Changes
- **`live/lib.ts`** (new) — pure `computeLiveStats(events)` (distinct sessions/visitors, latest-page-per-visitor → top-5 active pages, newest-first 10 recent events) extracted from the route; `resolveLiveRefreshMs()`; `LIVE_WINDOW_MS`.
- **`live/route.ts`** — `getCurrentStats` now calls `computeLiveStats`; new refresh `setInterval` (cleared on `close` alongside the heartbeat).
- **`live/__tests__/lib.unit.spec.ts`** — 10 unit tests.

### Verification
- `TEST_TYPE=unit npx jest --testPathPattern="admin/analytics/live/__tests__/lib.unit"` → **10/10 green**.
- `tsc --noEmit` → **zero new errors** in changed files.
- Not HTTP-integration-tested: the endpoint is a long-lived SSE stream driven by timers (not exercisable by the shared HTTP runner). The extracted aggregation is covered by units; the interval wiring is mechanical (mirrors the existing heartbeat).
- No React file changed → no Playwright needed (UI already renders `connected`).

No schema change. No auto-merge — leaving for human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)