### PR TITLE
feat(analytics): #344 slice 2 — Cloudflare edge collect worker

### DIFF
--- a/apps/analytics-worker/README.md
+++ b/apps/analytics-worker/README.md
@@ -1,0 +1,57 @@
+# @jyt/analytics-worker — #344 edge analytics collector
+
+Cloudflare Worker that terminates storefront `track` calls at the edge, buffers
+events in **KV**, and every minute drains them as an **HMAC-signed batch** to the
+Medusa ingest endpoint (`POST /web/analytics/ingest-batch`, shipped in #547/#548).
+Downstream (daily rollup → `analytics_daily_stats` → stats panels) is unchanged.
+
+See the design: `apps/docs/notes/525_MODULE_AUDIT_AND_CF_VISITOR_OFFLOAD.md`.
+
+## What it does
+- `POST /track` — same request/response contract as the legacy direct Medusa
+  route (`200 {success:true}`, always). Adds an edge `event_id` (dedupe),
+  `country` (free `request.cf` GeoIP), and receive `timestamp`; buffers to KV.
+- cron (`* * * * *`) — drains the buffer, signs the exact body bytes, POSTs the
+  batch, and deletes keys **only on a 2xx** (failed flush retries next tick;
+  server dedupes on `event_id`, so retries can't double-count).
+
+## Deploy
+
+Prereq: a Cloudflare **API Token** (My Profile → API Tokens → Create Token — *not*
+the Global API Key) with **Account** permissions:
+- **Workers Scripts: Edit**
+- **Workers KV Storage: Edit**
+- **Account Settings: Read** (optional; lets wrangler resolve the account)
+- (only for a custom `collect.<domain>` host: **Zone → Workers Routes: Edit** + **DNS: Edit**)
+
+```bash
+cd apps/analytics-worker
+npm install
+
+export CLOUDFLARE_API_TOKEN=...        # the scoped token above
+export CLOUDFLARE_ACCOUNT_ID=...        # your account id
+
+# 1. create the buffer namespace, paste the printed id into wrangler.jsonc kv_namespaces[0].id
+npx wrangler kv namespace create ANALYTICS_BUFFER
+
+# 2. set the shared secret — MUST equal Medusa's ANALYTICS_INGEST_SECRET (prod SSM)
+npx wrangler secret put ANALYTICS_INGEST_SECRET
+
+# 3. (optional) point MEDUSA_INGEST_URL at a preview before prod, in wrangler.jsonc vars
+# 4. ship
+npx wrangler deploy
+```
+
+## Enabling ingestion (rollout)
+1. Set `ANALYTICS_INGEST_SECRET` in **Medusa prod** (SSM) to the **same** value as
+   the worker secret — until then the endpoint fail-closes (401) and ingestion is inert.
+2. Point the storefront `analytics.js` `track` URL at the worker **behind the
+   `ANALYTICS_EDGE_INGEST` flag with a fallback to the direct Medusa route** (#344
+   slice 4 — reversible; worker downtime degrades to direct ingest).
+
+## Test
+```bash
+npm test        # pure-logic unit tests (normalize / chunk / HMAC parity with Node)
+```
+The HMAC test asserts the worker's signature equals Node's `createHmac` over the
+exact body — i.e. exactly what the Medusa endpoint verifies against its raw bytes.

--- a/apps/analytics-worker/package.json
+++ b/apps/analytics-worker/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@jyt/analytics-worker",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "#344 — Cloudflare edge worker: buffer storefront analytics at the edge, batch-flush (HMAC-signed) to the Medusa ingest endpoint.",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240605.0",
+    "typescript": "^5.4.0",
+    "vitest": "^2.1.9",
+    "wrangler": "^3.60.0"
+  }
+}

--- a/apps/analytics-worker/src/index.ts
+++ b/apps/analytics-worker/src/index.ts
@@ -1,0 +1,144 @@
+/**
+ * #344 slice 2 — Cloudflare analytics edge worker (`collect`).
+ *
+ * Architecture (see apps/docs/notes/525_MODULE_AUDIT_AND_CF_VISITOR_OFFLOAD.md):
+ *   Visitor → POST /track (this worker, at the edge)
+ *     ├─ normalize + buffer the event in KV  (volume sizing chose KV, not Queues)
+ *     └─ respond 200 {success:true} immediately — identical contract to the
+ *        legacy direct Medusa /web/analytics/track, so the client never changes
+ *        behavior on edge hiccups.
+ *   Cron (every minute) → drain the KV buffer → HMAC-sign → POST a batch to
+ *     Medusa  POST {MEDUSA_INGEST_URL}  (the #547 ingest-batch endpoint), then
+ *     delete the drained keys only on a 2xx (so failures retry next tick).
+ *
+ * Downstream (rollup job → analytics_daily_stats → stats panels) is untouched.
+ */
+import { normalizeTrackEvent, chunk, hmacHex, type IngestEvent } from "./lib"
+
+export interface Env {
+  ANALYTICS_BUFFER: KVNamespace
+  /** Full URL of the Medusa ingest endpoint, e.g. https://v3.jaalyantra.com/web/analytics/ingest-batch */
+  MEDUSA_INGEST_URL: string
+  /** Shared secret — MUST equal Medusa's ANALYTICS_INGEST_SECRET. Set via `wrangler secret put`. */
+  ANALYTICS_INGEST_SECRET: string
+  /** Comma-separated allowed origins for CORS, or "*" (default). */
+  ALLOWED_ORIGINS?: string
+  /** Max keys drained per cron tick (<=1000 KV list cap; default 500 = endpoint batch cap). */
+  MAX_DRAIN?: string
+}
+
+const BUFFER_PREFIX = "evt:"
+const BUFFER_TTL_SECONDS = 60 * 60 * 24 // safety net: KV self-expires un-drained events after 24h
+const ENDPOINT_BATCH_CAP = 500
+
+function corsHeaders(env: Env, origin: string | null): Record<string, string> {
+  const allowed = (env.ALLOWED_ORIGINS ?? "*").trim()
+  const allowOrigin =
+    allowed === "*"
+      ? "*"
+      : allowed.split(",").map((o) => o.trim()).includes(origin ?? "")
+      ? (origin as string)
+      : ""
+  const h: Record<string, string> = {
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Access-Control-Max-Age": "86400",
+  }
+  if (allowOrigin) h["Access-Control-Allow-Origin"] = allowOrigin
+  return h
+}
+
+const ok = (env: Env, origin: string | null) =>
+  new Response(JSON.stringify({ success: true }), {
+    status: 200,
+    headers: { "Content-Type": "application/json", ...corsHeaders(env, origin) },
+  })
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const origin = request.headers.get("Origin")
+    const url = new URL(request.url)
+
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: corsHeaders(env, origin) })
+    }
+    if (request.method === "GET") {
+      return new Response("analytics-worker ok", { status: 200 })
+    }
+    if (request.method !== "POST") {
+      return new Response("Method Not Allowed", { status: 405 })
+    }
+
+    // Fire-and-forget contract: ALWAYS 200 so a malformed/over-limit payload or
+    // a transient KV error never changes client behavior. We just drop on error.
+    try {
+      const raw = (await request.json()) as Record<string, unknown>
+      const event = normalizeTrackEvent(raw, {
+        country: (request as any).cf?.country ?? null, // free GeoIP at the edge
+        now: new Date().toISOString(),
+        id: crypto.randomUUID(),
+      })
+      if (event) {
+        const key = `${BUFFER_PREFIX}${Date.now()}:${event.event_id}`
+        await env.ANALYTICS_BUFFER.put(key, JSON.stringify(event), {
+          expirationTtl: BUFFER_TTL_SECONDS,
+        })
+      }
+    } catch {
+      // swallow — never break the page
+    }
+    return ok(env, origin)
+  },
+
+  async scheduled(_event: ScheduledEvent, env: Env, ctx: ExecutionContext): Promise<void> {
+    ctx.waitUntil(drain(env))
+  },
+}
+
+/** Drain the KV buffer → HMAC-signed batched POST → delete drained keys on success. */
+export async function drain(env: Env): Promise<void> {
+  if (!env.ANALYTICS_INGEST_SECRET || !env.MEDUSA_INGEST_URL) return
+  const cap = Math.min(
+    Number(env.MAX_DRAIN) > 0 ? Number(env.MAX_DRAIN) : ENDPOINT_BATCH_CAP,
+    1000
+  )
+
+  const listed = await env.ANALYTICS_BUFFER.list({ prefix: BUFFER_PREFIX, limit: cap })
+  if (!listed.keys.length) return
+
+  // Pull each buffered event (KV list returns names only).
+  const pairs = await Promise.all(
+    listed.keys.map(async (k) => {
+      const v = await env.ANALYTICS_BUFFER.get(k.name)
+      return v ? { key: k.name, event: JSON.parse(v) as IngestEvent } : null
+    })
+  )
+  const live = pairs.filter((p): p is { key: string; event: IngestEvent } => !!p)
+  if (!live.length) return
+
+  // Respect the endpoint's per-request cap; each batch deletes only on 2xx.
+  for (const group of chunk(live, ENDPOINT_BATCH_CAP)) {
+    const body = JSON.stringify({ events: group.map((g) => g.event) })
+    const signature = await hmacHex(env.ANALYTICS_INGEST_SECRET, body)
+    let resOk = false
+    try {
+      const res = await fetch(env.MEDUSA_INGEST_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-analytics-signature": `sha256=${signature}`,
+        },
+        body, // exact bytes we signed (endpoint verifies against raw body, #548)
+      })
+      resOk = res.ok
+    } catch {
+      resOk = false
+    }
+    // Only remove from the buffer once Medusa has durably accepted the batch;
+    // a failed POST leaves the keys so the next cron tick retries (idempotent
+    // server-side via event_id, so retries can't double-count).
+    if (resOk) {
+      await Promise.all(group.map((g) => env.ANALYTICS_BUFFER.delete(g.key)))
+    }
+  }
+}

--- a/apps/analytics-worker/src/lib.ts
+++ b/apps/analytics-worker/src/lib.ts
@@ -1,0 +1,91 @@
+/**
+ * #344 slice 2 — pure helpers for the Cloudflare analytics edge worker.
+ *
+ * Kept free of Worker globals (KV, env, request) so they unit-test in plain
+ * Node. The worker (`index.ts`) wires these to the runtime.
+ */
+
+export type IngestEvent = {
+  event_id: string
+  website_id: string
+  pathname: string
+  referrer: string | null
+  visitor_id: string
+  session_id: string
+  utm_source: string | null
+  utm_medium: string | null
+  utm_campaign: string | null
+  utm_term: string | null
+  utm_content: string | null
+  country: string | null
+  timestamp: string
+}
+
+const str = (v: unknown): string | null =>
+  typeof v === "string" && v.length > 0 ? v : null
+
+/**
+ * Map a raw client `track` payload to the exact shape the Medusa
+ * `/web/analytics/ingest-batch` endpoint accepts, enriching with an
+ * edge-generated `event_id` (for cross-batch dedupe / retry-safety), the
+ * Cloudflare-provided `country` (free GeoIP — saves Medusa a lookup), and a
+ * receive `timestamp`. Returns null when a required field is missing so the
+ * caller can drop it without buffering junk.
+ */
+export function normalizeTrackEvent(
+  raw: Record<string, unknown>,
+  ctx: { country: string | null; now: string; id: string }
+): IngestEvent | null {
+  const website_id = str(raw.website_id)
+  const pathname = str(raw.pathname)
+  const visitor_id = str(raw.visitor_id)
+  const session_id = str(raw.session_id)
+  // The four identity fields are mandatory; without them the row is useless
+  // (mirrors the endpoint's own `invalid` drop rule).
+  if (!website_id || !pathname || !visitor_id || !session_id) return null
+
+  return {
+    event_id: str(raw.event_id) ?? ctx.id,
+    website_id,
+    pathname,
+    referrer: str(raw.referrer),
+    visitor_id,
+    session_id,
+    utm_source: str(raw.utm_source),
+    utm_medium: str(raw.utm_medium),
+    utm_campaign: str(raw.utm_campaign),
+    utm_term: str(raw.utm_term),
+    utm_content: str(raw.utm_content),
+    country: str(raw.country) ?? ctx.country,
+    timestamp: str(raw.timestamp) ?? ctx.now,
+  }
+}
+
+/** Split into fixed-size chunks (the ingest endpoint caps a batch at 500). */
+export function chunk<T>(arr: T[], size: number): T[][] {
+  if (size <= 0) return [arr]
+  const out: T[][] = []
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size))
+  return out
+}
+
+/**
+ * Hex HMAC-SHA256 of `message` under `secret`, via Web Crypto (available in
+ * Workers and Node >=20). MUST be computed over the EXACT body string that is
+ * sent — the Medusa endpoint verifies against its raw request bytes (#548), so
+ * the worker signs and sends the identical string.
+ */
+export async function hmacHex(secret: string, message: string): Promise<string> {
+  const enc = new TextEncoder()
+  const key = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  )
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(message))
+  return [...new Uint8Array(sig)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")
+}

--- a/apps/analytics-worker/test/lib.test.ts
+++ b/apps/analytics-worker/test/lib.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest"
+import { createHmac } from "node:crypto"
+import { normalizeTrackEvent, chunk, hmacHex } from "../src/lib"
+
+describe("normalizeTrackEvent", () => {
+  const ctx = { country: "IN", now: "2026-06-19T10:00:00.000Z", id: "gen-uuid" }
+
+  it("maps a full client payload + enriches event_id/country/timestamp", () => {
+    const e = normalizeTrackEvent(
+      {
+        website_id: "web_1",
+        pathname: "/p/shoes",
+        visitor_id: "vis_1",
+        session_id: "ses_1",
+        referrer: "https://google.com",
+        utm_source: "google",
+      },
+      ctx
+    )
+    expect(e).toMatchObject({
+      website_id: "web_1",
+      pathname: "/p/shoes",
+      visitor_id: "vis_1",
+      session_id: "ses_1",
+      referrer: "https://google.com",
+      utm_source: "google",
+      event_id: "gen-uuid", // edge-generated when client omits it
+      country: "IN", // from request.cf
+      timestamp: "2026-06-19T10:00:00.000Z",
+    })
+  })
+
+  it("prefers a client-supplied event_id/country/timestamp over the edge defaults", () => {
+    const e = normalizeTrackEvent(
+      {
+        website_id: "web_1",
+        pathname: "/",
+        visitor_id: "v",
+        session_id: "s",
+        event_id: "client-id",
+        country: "US",
+        timestamp: "2026-01-01T00:00:00.000Z",
+      },
+      ctx
+    )
+    expect(e?.event_id).toBe("client-id")
+    expect(e?.country).toBe("US")
+    expect(e?.timestamp).toBe("2026-01-01T00:00:00.000Z")
+  })
+
+  it("drops events missing any of the 4 identity fields", () => {
+    expect(normalizeTrackEvent({ website_id: "w", pathname: "/", visitor_id: "v" }, ctx)).toBeNull()
+    expect(normalizeTrackEvent({}, ctx)).toBeNull()
+  })
+})
+
+describe("chunk", () => {
+  it("splits to the cap and keeps order", () => {
+    expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]])
+    expect(chunk([], 500)).toEqual([])
+  })
+})
+
+describe("hmacHex", () => {
+  it("matches Node's HMAC-SHA256 over the exact body string (server parity)", async () => {
+    const secret = "s3cr3t"
+    const body = JSON.stringify({ events: [{ a: 1 }] })
+    const fromWorker = await hmacHex(secret, body)
+    const fromNode = createHmac("sha256", secret).update(body).digest("hex")
+    // This is precisely what the Medusa endpoint computes over its raw body.
+    expect(fromWorker).toBe(fromNode)
+  })
+})

--- a/apps/analytics-worker/tsconfig.json
+++ b/apps/analytics-worker/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "WebWorker"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/apps/analytics-worker/wrangler.jsonc
+++ b/apps/analytics-worker/wrangler.jsonc
@@ -1,0 +1,27 @@
+{
+  // #344 slice 2 — analytics edge worker (`collect`).
+  // Deploy: see README.md. Secrets (ANALYTICS_INGEST_SECRET) are NOT here — set
+  // via `wrangler secret put`. The KV id is filled after `wrangler kv namespace create`.
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "jyt-analytics-collect",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-06-01",
+  "observability": { "enabled": true },
+
+  // Buffer namespace — create with:
+  //   npx wrangler kv namespace create ANALYTICS_BUFFER
+  // then paste the printed id below.
+  "kv_namespaces": [
+    { "binding": "ANALYTICS_BUFFER", "id": "<run: wrangler kv namespace create ANALYTICS_BUFFER>" }
+  ],
+
+  // Drain the buffer every minute (Cloudflare cron min granularity).
+  "triggers": { "crons": ["* * * * *"] },
+
+  // Non-secret config. Point at prod (or a preview) Medusa ingest endpoint.
+  "vars": {
+    "MEDUSA_INGEST_URL": "https://v3.jaalyantra.com/web/analytics/ingest-batch",
+    "ALLOWED_ORIGINS": "*",
+    "MAX_DRAIN": "500"
+  }
+}


### PR DESCRIPTION
#344 slice 2. New **`apps/analytics-worker/`** Cloudflare Worker — terminates storefront `track` at the edge, buffers in KV, drains an HMAC-signed batch every minute to the Medusa `ingest-batch` endpoint (#547/#548).

**Lives outside `apps/backend`** → not in the backend deploy image. **Merging this deploys nothing** — it's inert code until someone runs `wrangler deploy` with a CF token.

## What it does
- `POST /track` → normalize + buffer to KV; always `200 {success:true}` (same client contract); enriches `event_id` (dedupe), `country` (free `request.cf` GeoIP), `timestamp`.
- cron (`* * * * *`) → drain KV → HMAC-sign the exact body → POST `{events}` → delete keys **only on 2xx** (failed flush retries; server dedupes on `event_id`).

## Verified
- **Worker Web-Crypto HMAC == Medusa `node:crypto` HMAC** over the same body (parity check run) → signed batches pass `verifyIngestAuth`.
- Pure `normalizeTrackEvent`/`chunk`/`hmacHex` unit-tested (`test/lib.test.ts`).
- KV over Queues per the #549 volume sizing; live count handled by the #551 DB-poll (no Durable Object needed).

## Deploy (separate, human/CF step)
Scoped CF API token: **Workers Scripts: Edit** + **Workers KV Storage: Edit** (+ Account Settings: Read). Then `wrangler kv namespace create` → set `ANALYTICS_INGEST_SECRET` (must match Medusa prod SSM) → `wrangler deploy`. Full steps in `README.md`. Endpoint stays fail-closed (inert) until that secret is set on both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)