### PR TITLE
chore(analytics): wire deployed KV id into worker config

### DIFF
--- a/apps/analytics-worker/wrangler.jsonc
+++ b/apps/analytics-worker/wrangler.jsonc
@@ -12,7 +12,7 @@
   //   npx wrangler kv namespace create ANALYTICS_BUFFER
   // then paste the printed id below.
   "kv_namespaces": [
-    { "binding": "ANALYTICS_BUFFER", "id": "<run: wrangler kv namespace create ANALYTICS_BUFFER>" }
+    { "binding": "ANALYTICS_BUFFER", "id": "d8adc4669b8b4f95ae0ab3597137d02f" }
   ],
 
   // Drain the buffer every minute (Cloudflare cron min granularity).


### PR DESCRIPTION
Records the real `ANALYTICS_BUFFER` KV namespace id (`d8adc466…`) created during the #344 worker deploy, so future `wrangler deploy` targets the same namespace. KV ids aren't secret. Worker is live at jyt-analytics-collect.saransh-971.workers.dev (cron + secret set; same secret in SSM for the Medusa side).