### PR TITLE
feat(analytics): in-house Redis queue ingestion (#559 slices 1-2)

### DIFF
--- a/apps/backend/src/api/web/analytics/track/route.ts
+++ b/apps/backend/src/api/web/analytics/track/route.ts
@@ -75,9 +75,16 @@
  *   }
  * }
  */
+import { randomUUID } from "crypto";
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
 import { z } from "@medusajs/framework/zod";
 import { trackAnalyticsEventWorkflow } from "../../../../workflows/analytics/track-analytics-event";
+import {
+  getIngestRedis,
+  isBatchIngestEnabled,
+  isHeartbeatEvent,
+  pushBufferedEvent,
+} from "../../../../modules/analytics/lib/ingest-buffer";
 
 // Validator for tracking request
 export const TrackEventSchema = z.object({
@@ -168,7 +175,50 @@ export const POST = async (
     const userAgent = req.headers["user-agent"] || "";
     const ip = req.headers["x-forwarded-for"] || req.socket.remoteAddress || "";
 
-    // Run tracking workflow
+    // Hybrid batching (#559): when ANALYTICS_BATCH_INGEST is on, the bulk firehose
+    // (pageviews / custom events) is LPUSHed to Redis and persisted by the
+    // drain-analytics-buffer job — the request returns without a synchronous DB
+    // write. Heartbeats ALWAYS write through so the live-visitor count stays
+    // real-time. We capture the visitor's real UA + IP here, so the async path
+    // keeps full device/geo fidelity.
+    if (
+      isBatchIngestEnabled() &&
+      !isHeartbeatEvent(validatedData.event_type, validatedData.event_name)
+    ) {
+      try {
+        await pushBufferedEvent(getIngestRedis(), {
+          event_id: randomUUID(),
+          website_id: validatedData.website_id,
+          event_type: validatedData.event_type,
+          event_name: validatedData.event_name,
+          pathname: validatedData.pathname,
+          referrer: validatedData.referrer,
+          visitor_id: validatedData.visitor_id,
+          session_id: validatedData.session_id,
+          query_string: validatedData.query_string,
+          is_404: validatedData.is_404,
+          utm_source: validatedData.utm_source,
+          utm_medium: validatedData.utm_medium,
+          utm_campaign: validatedData.utm_campaign,
+          utm_term: validatedData.utm_term,
+          utm_content: validatedData.utm_content,
+          metadata: validatedData.metadata,
+          user_agent: userAgent as string,
+          ip_address: ip as string,
+          timestamp: new Date().toISOString(),
+        });
+        return res.status(200).json({ success: true, message: "Event queued" });
+      } catch (bufferErr) {
+        // Buffer unavailable (e.g. Redis down) → fall through to the synchronous
+        // write so we never silently drop an event.
+        console.error(
+          "Analytics buffer push failed, writing through synchronously:",
+          bufferErr
+        );
+      }
+    }
+
+    // Run tracking workflow (synchronous path: flag off, heartbeat, or buffer fallback)
     await trackAnalyticsEventWorkflow(req.scope).run({
       input: {
         ...validatedData,

--- a/apps/backend/src/jobs/drain-analytics-buffer.ts
+++ b/apps/backend/src/jobs/drain-analytics-buffer.ts
@@ -1,0 +1,105 @@
+import { MedusaContainer } from "@medusajs/framework/types";
+import { Modules } from "@medusajs/framework/utils";
+import { trackAnalyticsEventWorkflow } from "../workflows/analytics/track-analytics-event";
+import {
+  drainBuffer,
+  getIngestRedis,
+  isBatchIngestEnabled,
+  orderAndDedupeBuffer,
+} from "../modules/analytics/lib/ingest-buffer";
+
+/**
+ * Drain Analytics Buffer Job (#559 slice 2).
+ *
+ * Consumer half of the in-house ingestion queue. Every minute (Medusa cron's
+ * finest granularity) it RPOPs a batch off the Redis buffer that
+ * `/web/analytics/track` fills (when ANALYTICS_BATCH_INGEST is on) and persists
+ * each event via the existing `trackAnalyticsEventWorkflow` — a SHORT-LIVED
+ * workflow per event, not a long-running one. This decouples the visitor request
+ * from the DB write while keeping session/rollup logic identical to the
+ * synchronous path.
+ *
+ * Heartbeats never reach the buffer (they write through synchronously), so the
+ * live-visitor count stays real-time regardless of this drain cadence.
+ *
+ * locking-redis guards the drain so overlapping ticks / multiple Fargate
+ * instances can't double-process the same keys.
+ */
+const DRAIN_MAX =
+  Number(process.env.ANALYTICS_DRAIN_MAX) > 0
+    ? Number(process.env.ANALYTICS_DRAIN_MAX)
+    : 500;
+const LOCK_KEY = "analytics-buffer-drain";
+
+export default async function drainAnalyticsBuffer(container: MedusaContainer) {
+  // Nothing is buffered when the flag is off — skip without touching Redis.
+  if (!isBatchIngestEnabled()) return;
+
+  const logger = container.resolve("logger");
+  const locking = container.resolve(Modules.LOCKING) as any;
+
+  try {
+    await locking.execute(LOCK_KEY, async () => {
+      const redis = getIngestRedis();
+      const drained = await drainBuffer(redis, DRAIN_MAX);
+      if (!drained.length) return;
+
+      const events = orderAndDedupeBuffer(drained);
+      let persisted = 0;
+      let failed = 0;
+
+      for (const e of events) {
+        try {
+          await trackAnalyticsEventWorkflow(container).run({
+            input: {
+              client_event_id: e.event_id,
+              website_id: e.website_id,
+              event_type: e.event_type,
+              event_name: e.event_name,
+              pathname: e.pathname,
+              referrer: e.referrer,
+              visitor_id: e.visitor_id,
+              session_id: e.session_id,
+              query_string: e.query_string,
+              is_404: e.is_404,
+              utm_source: e.utm_source,
+              utm_medium: e.utm_medium,
+              utm_campaign: e.utm_campaign,
+              utm_term: e.utm_term,
+              utm_content: e.utm_content,
+              metadata: e.metadata,
+              user_agent: e.user_agent,
+              ip_address: e.ip_address,
+              timestamp: new Date(e.timestamp),
+            },
+          });
+          persisted++;
+        } catch (err) {
+          // Per-event failure must not abort the batch.
+          failed++;
+          logger.error(
+            `[analytics-drain] event ${e.event_id} failed: ${
+              (err as Error)?.message
+            }`
+          );
+        }
+      }
+
+      logger.info(
+        `[analytics-drain] persisted=${persisted} failed=${failed} drained=${events.length}`
+      );
+    });
+  } catch (lockErr) {
+    // Lock contention / Redis hiccup — skip this tick; the next one retries.
+    logger.warn(
+      `[analytics-drain] skipped tick: ${(lockErr as Error)?.message}`
+    );
+  }
+}
+
+export const config = {
+  name: "drain-analytics-buffer",
+  // Every minute — Medusa cron's finest granularity. Bulk firehose only;
+  // heartbeats are synchronous so live data is unaffected by this cadence.
+  schedule: "* * * * *",
+};

--- a/apps/backend/src/modules/analytics/lib/__tests__/ingest-buffer.unit.spec.ts
+++ b/apps/backend/src/modules/analytics/lib/__tests__/ingest-buffer.unit.spec.ts
@@ -1,0 +1,94 @@
+import {
+  BufferedAnalyticsEvent,
+  isBatchIngestEnabled,
+  isHeartbeatEvent,
+  orderAndDedupeBuffer,
+  parseBufferedEvent,
+} from "../ingest-buffer";
+
+const ev = (over: Partial<BufferedAnalyticsEvent> = {}): BufferedAnalyticsEvent => ({
+  event_id: "e1",
+  website_id: "web_1",
+  event_type: "pageview",
+  pathname: "/",
+  visitor_id: "v1",
+  session_id: "s1",
+  user_agent: "ua",
+  ip_address: "1.2.3.4",
+  timestamp: "2026-06-20T10:00:00.000Z",
+  ...over,
+});
+
+describe("ingest-buffer pure helpers (#559)", () => {
+  describe("isBatchIngestEnabled", () => {
+    const prev = process.env.ANALYTICS_BATCH_INGEST;
+    afterEach(() => {
+      process.env.ANALYTICS_BATCH_INGEST = prev;
+    });
+
+    it.each(["1", "true", "TRUE", "yes", "on"])("is on for %s", (v) => {
+      process.env.ANALYTICS_BATCH_INGEST = v;
+      expect(isBatchIngestEnabled()).toBe(true);
+    });
+
+    it.each(["0", "false", "", "off", undefined as any])(
+      "is off for %s",
+      (v) => {
+        if (v === undefined) delete process.env.ANALYTICS_BATCH_INGEST;
+        else process.env.ANALYTICS_BATCH_INGEST = v;
+        expect(isBatchIngestEnabled()).toBe(false);
+      }
+    );
+  });
+
+  describe("isHeartbeatEvent", () => {
+    it("true only for custom_event named heartbeat", () => {
+      expect(isHeartbeatEvent("custom_event", "heartbeat")).toBe(true);
+    });
+    it("false for pageviews and other custom events", () => {
+      expect(isHeartbeatEvent("pageview", undefined)).toBe(false);
+      expect(isHeartbeatEvent("custom_event", "add_to_cart")).toBe(false);
+      expect(isHeartbeatEvent("custom_event", undefined)).toBe(false);
+    });
+  });
+
+  describe("orderAndDedupeBuffer", () => {
+    it("sorts ascending by timestamp", () => {
+      const out = orderAndDedupeBuffer([
+        ev({ event_id: "b", timestamp: "2026-06-20T10:00:02.000Z" }),
+        ev({ event_id: "a", timestamp: "2026-06-20T10:00:01.000Z" }),
+        ev({ event_id: "c", timestamp: "2026-06-20T10:00:03.000Z" }),
+      ]);
+      expect(out.map((e) => e.event_id)).toEqual(["a", "b", "c"]);
+    });
+
+    it("drops within-batch event_id duplicates (first wins)", () => {
+      const out = orderAndDedupeBuffer([
+        ev({ event_id: "dup", pathname: "/first", timestamp: "2026-06-20T10:00:01.000Z" }),
+        ev({ event_id: "dup", pathname: "/second", timestamp: "2026-06-20T10:00:02.000Z" }),
+        ev({ event_id: "x", timestamp: "2026-06-20T10:00:03.000Z" }),
+      ]);
+      expect(out).toHaveLength(2);
+      expect(out.find((e) => e.event_id === "dup")?.pathname).toBe("/first");
+    });
+
+    it("handles empty / undefined input", () => {
+      expect(orderAndDedupeBuffer([])).toEqual([]);
+      expect(orderAndDedupeBuffer(undefined as any)).toEqual([]);
+    });
+  });
+
+  describe("parseBufferedEvent", () => {
+    it("parses a valid serialized event", () => {
+      const parsed = parseBufferedEvent(JSON.stringify(ev()));
+      expect(parsed?.website_id).toBe("web_1");
+    });
+    it("returns null for malformed JSON", () => {
+      expect(parseBufferedEvent("{not json")).toBeNull();
+    });
+    it("returns null when required identity fields are missing", () => {
+      const { visitor_id, ...rest } = ev();
+      expect(parseBufferedEvent(JSON.stringify(rest))).toBeNull();
+    });
+  });
+});

--- a/apps/backend/src/modules/analytics/lib/ingest-buffer.ts
+++ b/apps/backend/src/modules/analytics/lib/ingest-buffer.ts
@@ -1,0 +1,151 @@
+/**
+ * In-house analytics ingestion buffer (#559 slice 1/2).
+ *
+ * Producer/consumer queue on Redis — NOT a long-running workflow:
+ *   - `/web/analytics/track` (producer) LPUSHes the event and returns immediately.
+ *   - `drain-analytics-buffer` job (consumer) RPOPs a batch every minute and runs
+ *     the existing `trackAnalyticsEventWorkflow` per event (short-lived).
+ *
+ * Heartbeats are deliberately NOT buffered — they drive the real-time live-visitor
+ * count, so they keep the synchronous write-through path (`isHeartbeatEvent`).
+ *
+ * Unlike the (now-removed) Cloudflare edge worker, the producer runs INSIDE the
+ * Medusa request, so we capture the visitor's real `user_agent` + `ip_address` and
+ * carry them through the buffer — no device/geo fidelity is lost.
+ *
+ * Pure helpers (env flag, heartbeat test, order/dedupe, parse) are framework-free
+ * and unit-tested; the I/O wrappers at the bottom are thin shims over ioredis.
+ */
+import Redis from "ioredis"
+
+export const ANALYTICS_BUFFER_KEY = "analytics:ingest:buffer"
+
+/** Full payload buffered per hit — carries the real UA + IP captured in /track. */
+export type BufferedAnalyticsEvent = {
+  event_id: string
+  website_id: string
+  event_type: "pageview" | "custom_event"
+  event_name?: string
+  pathname: string
+  referrer?: string
+  visitor_id: string
+  session_id: string
+  query_string?: string
+  is_404?: boolean
+  utm_source?: string
+  utm_medium?: string
+  utm_campaign?: string
+  utm_term?: string
+  utm_content?: string
+  metadata?: Record<string, any>
+  user_agent: string
+  ip_address: string
+  /** ISO string — serialized back to a Date in the drain. */
+  timestamp: string
+}
+
+/** Batch ingestion is opt-in via env so rollout/rollback is a single flag flip. */
+export function isBatchIngestEnabled(): boolean {
+  const v = (process.env.ANALYTICS_BATCH_INGEST || "").toLowerCase()
+  return v === "1" || v === "true" || v === "yes" || v === "on"
+}
+
+/**
+ * Heartbeats drive the real-time live-visitor count, so they must bypass the
+ * buffer and always take the synchronous write-through path.
+ */
+export function isHeartbeatEvent(
+  event_type: string | undefined,
+  event_name: string | undefined
+): boolean {
+  return event_type === "custom_event" && event_name === "heartbeat"
+}
+
+/**
+ * Sort ascending by timestamp and drop within-batch `event_id` duplicates
+ * (first wins). Keeps session entry/exit/bounce computation correct when a
+ * batch is drained out of arrival order. Pure — unit tested.
+ */
+export function orderAndDedupeBuffer(
+  events: BufferedAnalyticsEvent[]
+): BufferedAnalyticsEvent[] {
+  const seen = new Set<string>()
+  const deduped: BufferedAnalyticsEvent[] = []
+  for (const e of events || []) {
+    if (e?.event_id) {
+      if (seen.has(e.event_id)) continue
+      seen.add(e.event_id)
+    }
+    deduped.push(e)
+  }
+  deduped.sort(
+    (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+  )
+  return deduped
+}
+
+/** Safe parse — drop malformed/incomplete buffer entries instead of throwing. */
+export function parseBufferedEvent(raw: string): BufferedAnalyticsEvent | null {
+  try {
+    const o = JSON.parse(raw)
+    if (
+      o &&
+      typeof o.website_id === "string" &&
+      typeof o.pathname === "string" &&
+      typeof o.visitor_id === "string" &&
+      typeof o.session_id === "string"
+    ) {
+      return o as BufferedAnalyticsEvent
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+// --------------------------- I/O (ioredis shims) ---------------------------
+
+let _redis: Redis | null = null
+
+/** Singleton ioredis client for the ingest buffer (separate from module conns). */
+export function getIngestRedis(): Redis {
+  if (!_redis) {
+    const url = process.env.REDIS_URL
+    if (!url) {
+      throw new Error("REDIS_URL not set — analytics ingest buffer unavailable")
+    }
+    _redis = new Redis(url, { maxRetriesPerRequest: null })
+  }
+  return _redis
+}
+
+/** Producer: LPUSH onto the head of the buffer list. */
+export async function pushBufferedEvent(
+  redis: Redis,
+  event: BufferedAnalyticsEvent
+): Promise<void> {
+  await redis.lpush(ANALYTICS_BUFFER_KEY, JSON.stringify(event))
+}
+
+/**
+ * Consumer: RPOP up to `max` entries from the tail (FIFO with the LPUSH
+ * producer). Returns parsed events, malformed entries dropped.
+ *
+ * Note: at-most-once on a hard crash between RPOP and persist (RPOP removes the
+ * entries). Acceptable for analytics; upgrade to an LMOVE processing-queue if
+ * stricter delivery is ever needed.
+ */
+export async function drainBuffer(
+  redis: Redis,
+  max: number
+): Promise<BufferedAnalyticsEvent[]> {
+  if (max <= 0) return []
+  // count arg requires Redis >= 6.2; cast through any for the ioredis overload.
+  const raw = (await (redis as any).rpop(ANALYTICS_BUFFER_KEY, max)) as
+    | string[]
+    | null
+  if (!raw || !raw.length) return []
+  return raw
+    .map(parseBufferedEvent)
+    .filter((e): e is BufferedAnalyticsEvent => !!e)
+}


### PR DESCRIPTION
Implements the producer/consumer queue from #559 (design: `apps/docs/notes/ANALYTICS_INHOUSE_BATCHING_AND_UI.md`, landing via #560).

## What
Makes `/web/analytics/track` non-blocking behind the **`ANALYTICS_BATCH_INGEST`** flag (default **OFF** → current behavior preserved).

- **Producer** (`/track`): when the flag is on, bulk events (pageviews/custom events) are `LPUSH`ed to a Redis buffer and the request returns immediately — no synchronous DB write. **Heartbeats always write through synchronously** so the live-visitor count stays real-time (the hybrid decision).
- **Consumer** (`jobs/drain-analytics-buffer.ts`): every minute (cron's finest granularity), `RPOP`s a batch and runs the existing `trackAnalyticsEventWorkflow` per event — **short-lived per tick, NOT a long-running workflow**. `locking-redis`-guarded so multiple Fargate instances can't double-drain; per-event continue-on-error.
- **Fidelity:** the producer runs inside the request, so the visitor's **real UA + IP** are captured and carried through the buffer → full device/geo parity (unlike the removed CF worker, which lost them).
- **Safety:** if Redis is unavailable on push, the route **falls back to a synchronous write** — never silently drops an event.

## Files
- `modules/analytics/lib/ingest-buffer.ts` — pure helpers (flag, heartbeat test, order+dedupe, parse) + thin ioredis I/O.
- `jobs/drain-analytics-buffer.ts` — the drain consumer.
- `api/web/analytics/track/route.ts` — producer + fallback.

## Tests
18 unit tests green (`TEST_TYPE=unit … ingest-buffer.unit`). Touched files typecheck clean.

## Rollout
Flag stays OFF until verified in a dev env (flip `ANALYTICS_BATCH_INGEST=1`, fire `/track`, confirm events land via the drain with `event_id` populated + live count still instant from heartbeats). Tunables: `ANALYTICS_DRAIN_MAX` (default 500).

## Not in scope (later #559 slices)
Granular stats endpoints (3), OpenPanel-style UI (4), browser country capture (6). Storage stays Postgres (ClickHouse / CF Analytics Engine recorded as future options in the design note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)