### PR TITLE
feat(analytics): granular breakdown endpoint (#559 slice 3)

### DIFF
--- a/apps/backend/integration-tests/http/analytics/analytics-breakdown.spec.ts
+++ b/apps/backend/integration-tests/http/analytics/analytics-breakdown.spec.ts
@@ -1,0 +1,126 @@
+import { setupSharedTestSuite } from "../shared-test-setup";
+import { createAdminUser, getAuthHeaders } from "../../helpers/create-admin-user";
+
+jest.setTimeout(100000);
+
+setupSharedTestSuite(({ api, getContainer }) => {
+  describe("GET /admin/analytics-events/breakdown (#559 slice 3)", () => {
+    let websiteId: string;
+    let adminHeaders: { headers: Record<string, string> };
+
+    beforeAll(async () => {
+      const container = await getContainer();
+      await createAdminUser(container);
+      adminHeaders = await getAuthHeaders(api);
+    });
+
+    beforeEach(async () => {
+      const container = await getContainer();
+      const websiteService = container.resolve("websites");
+      const website = await websiteService.createWebsites({
+        domain: `breakdown-${Date.now()}.example.com`,
+        name: "Breakdown Test Site",
+        status: "Active",
+        primary_language: "en",
+      });
+      websiteId = website.id;
+
+      // Seed events directly via the analytics service for deterministic data.
+      const analyticsService = container.resolve("custom_analytics");
+      const now = new Date();
+      const rows = [
+        { country: "IN", device_type: "mobile", pathname: "/home", visitor_id: "v1" },
+        { country: "IN", device_type: "desktop", pathname: "/home", visitor_id: "v2" },
+        { country: "US", device_type: "desktop", pathname: "/about", visitor_id: "v3" },
+        { country: "US", device_type: "mobile", pathname: "/home", visitor_id: "v3" },
+        { country: null, device_type: "unknown", pathname: "/404", visitor_id: "v4" },
+      ];
+      await analyticsService.createAnalyticsEvents(
+        rows.map((r, i) => ({
+          website_id: websiteId,
+          event_type: "pageview",
+          pathname: r.pathname,
+          visitor_id: r.visitor_id,
+          session_id: `s${i}`,
+          country: r.country,
+          device_type: r.device_type,
+          timestamp: now,
+        }))
+      );
+    });
+
+    it("400s when website_id is missing", async () => {
+      const res = await api
+        .get("/admin/analytics-events/breakdown?dimension=country", adminHeaders)
+        .catch((e) => e.response);
+      expect(res.status).toBe(400);
+    });
+
+    it("400s when dimension is missing or unknown", async () => {
+      const missing = await api
+        .get(`/admin/analytics-events/breakdown?website_id=${websiteId}`, adminHeaders)
+        .catch((e) => e.response);
+      expect(missing.status).toBe(400);
+
+      const unknown = await api
+        .get(`/admin/analytics-events/breakdown?website_id=${websiteId}&dimension=visitor_id`, adminHeaders)
+        .catch((e) => e.response);
+      expect(unknown.status).toBe(400);
+      expect(unknown.data.supported_dimensions).toContain("country");
+    });
+
+    it("breaks down by country with counts and unique visitors", async () => {
+      const res = await api.get(
+        `/admin/analytics-events/breakdown?website_id=${websiteId}&dimension=country`,
+        adminHeaders
+      );
+      expect(res.status).toBe(200);
+      expect(res.data.dimension).toBe("country");
+      expect(res.data.breakdown.total_events).toBe(5);
+
+      const byValue = Object.fromEntries(
+        res.data.breakdown.results.map((r: any) => [r.value, r])
+      );
+      expect(byValue["IN"].count).toBe(2);
+      expect(byValue["US"].count).toBe(2);
+      // null country bucketed under "unknown"
+      expect(byValue["unknown"].count).toBe(1);
+    });
+
+    it("breaks down by pathname", async () => {
+      const res = await api.get(
+        `/admin/analytics-events/breakdown?website_id=${websiteId}&dimension=pathname`,
+        adminHeaders
+      );
+      expect(res.status).toBe(200);
+      const home = res.data.breakdown.results.find((r: any) => r.value === "/home");
+      expect(home.count).toBe(3);
+    });
+
+    it("applies a composable equality filter", async () => {
+      const res = await api.get(
+        `/admin/analytics-events/breakdown?website_id=${websiteId}&dimension=country&device_type=desktop`,
+        adminHeaders
+      );
+      expect(res.status).toBe(200);
+      expect(res.data.filters.device_type).toBe("desktop");
+      expect(res.data.breakdown.total_events).toBe(2);
+      const byValue = Object.fromEntries(
+        res.data.breakdown.results.map((r: any) => [r.value, r.count])
+      );
+      expect(byValue["IN"]).toBe(1);
+      expect(byValue["US"]).toBe(1);
+    });
+
+    it("respects the limit parameter", async () => {
+      const res = await api.get(
+        `/admin/analytics-events/breakdown?website_id=${websiteId}&dimension=pathname&limit=1`,
+        adminHeaders
+      );
+      expect(res.status).toBe(200);
+      expect(res.data.breakdown.results).toHaveLength(1);
+      // most frequent pathname wins
+      expect(res.data.breakdown.results[0].value).toBe("/home");
+    });
+  });
+});

--- a/apps/backend/src/api/admin/analytics-events/breakdown/route.ts
+++ b/apps/backend/src/api/admin/analytics-events/breakdown/route.ts
@@ -1,0 +1,100 @@
+/**
+ * GET /admin/analytics-events/breakdown
+ *
+ * Single-dimension granular breakdown of a website's analytics events, with
+ * composable equality filters and a date range (#559 slice 3).
+ *
+ * Query parameters
+ * - website_id (string, required): website to report on. 400 if missing.
+ * - dimension (string, required): one of BREAKDOWN_DIMENSIONS (country,
+ *   device_type, browser, os, referrer_source, utm_source, utm_medium,
+ *   utm_campaign, utm_term, utm_content, pathname, is_404, event_type,
+ *   event_name). 400 if missing/unknown.
+ * - days (number, optional): rolling window; takes precedence over
+ *   start_date/end_date when present.
+ * - start_date / end_date (ISO string, optional): explicit window.
+ * - limit (number, optional): max buckets returned (default 20, capped 100).
+ * - <filterable field>=<value> (optional, repeatable): any FILTERABLE_FIELD
+ *   passed as a query key becomes an equality filter, e.g.
+ *   `?dimension=pathname&device_type=mobile&country=IN`. Null rows are matched
+ *   by their canonical label (e.g. `referrer_source=direct`).
+ *
+ * Response (200)
+ * {
+ *   website_id, dimension,
+ *   period: { start_date?, end_date?, days? },
+ *   filters: { ...applied equality filters },
+ *   breakdown: { dimension, total_events, total_unique_visitors, results: [...] }
+ * }
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework";
+import { getAnalyticsBreakdownWorkflow } from "../../../../workflows/analytics/reports/get-analytics-breakdown";
+import {
+  BREAKDOWN_DIMENSIONS,
+  FILTERABLE_FIELDS,
+  isBreakdownDimension,
+  isFilterableField,
+} from "../../../../workflows/analytics/reports/breakdown-lib";
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { website_id, dimension, start_date, end_date, days, limit } = req.query;
+
+  if (!website_id) {
+    return res.status(400).json({ error: "website_id is required" });
+  }
+
+  if (!isBreakdownDimension(dimension)) {
+    return res.status(400).json({
+      error: "dimension is required and must be one of the supported dimensions",
+      supported_dimensions: BREAKDOWN_DIMENSIONS,
+    });
+  }
+
+  // Collect composable equality filters (any filterable field present in query).
+  const filters: Record<string, string> = {};
+  for (const field of FILTERABLE_FIELDS) {
+    const raw = req.query[field];
+    if (isFilterableField(field) && raw !== undefined && raw !== "") {
+      filters[field] = Array.isArray(raw) ? String(raw[0]) : String(raw);
+    }
+  }
+
+  // Resolve date window.
+  let startDate: Date | undefined;
+  let endDate: Date | undefined;
+  if (days) {
+    const daysNum = parseInt(days as string, 10);
+    if (!Number.isNaN(daysNum)) {
+      startDate = new Date(Date.now() - daysNum * 24 * 60 * 60 * 1000);
+      endDate = new Date();
+    }
+  } else {
+    if (start_date) startDate = new Date(start_date as string);
+    if (end_date) endDate = new Date(end_date as string);
+  }
+
+  const parsedLimit = limit ? parseInt(limit as string, 10) : undefined;
+
+  const { result } = await getAnalyticsBreakdownWorkflow(req.scope).run({
+    input: {
+      website_id: website_id as string,
+      dimension,
+      start_date: startDate,
+      end_date: endDate,
+      filters,
+      limit: Number.isNaN(parsedLimit as number) ? undefined : parsedLimit,
+    },
+  });
+
+  res.json({
+    website_id,
+    dimension,
+    period: {
+      start_date: startDate?.toISOString(),
+      end_date: endDate?.toISOString(),
+      days: days ? parseInt(days as string, 10) : undefined,
+    },
+    filters,
+    breakdown: result,
+  });
+};

--- a/apps/backend/src/workflows/analytics/reports/__tests__/breakdown-lib.unit.spec.ts
+++ b/apps/backend/src/workflows/analytics/reports/__tests__/breakdown-lib.unit.spec.ts
@@ -1,0 +1,168 @@
+import {
+  applyEventFilters,
+  computeBreakdown,
+  isBreakdownDimension,
+  isFilterableField,
+  normalizeFieldValue,
+  BREAKDOWN_DIMENSIONS,
+  DEFAULT_BREAKDOWN_LIMIT,
+  MAX_BREAKDOWN_LIMIT,
+  type AnalyticsEventRow,
+} from "../breakdown-lib";
+
+const ev = (over: Partial<AnalyticsEventRow> = {}): AnalyticsEventRow => ({
+  visitor_id: "v1",
+  session_id: "s1",
+  country: "IN",
+  device_type: "desktop",
+  browser: "Chrome",
+  os: "macOS",
+  referrer_source: "google",
+  pathname: "/",
+  is_404: false,
+  event_type: "pageview",
+  ...over,
+});
+
+describe("isBreakdownDimension / isFilterableField", () => {
+  it("accepts every supported dimension", () => {
+    for (const d of BREAKDOWN_DIMENSIONS) {
+      expect(isBreakdownDimension(d)).toBe(true);
+      expect(isFilterableField(d)).toBe(true);
+    }
+  });
+
+  it("rejects unknown / non-string values", () => {
+    expect(isBreakdownDimension("visitor_id")).toBe(false);
+    expect(isBreakdownDimension("")).toBe(false);
+    expect(isBreakdownDimension(undefined)).toBe(false);
+    expect(isBreakdownDimension(42)).toBe(false);
+  });
+});
+
+describe("normalizeFieldValue", () => {
+  it("maps null referrer_source to 'direct'", () => {
+    expect(normalizeFieldValue("referrer_source", null)).toBe("direct");
+  });
+
+  it("maps null/empty country to 'unknown'", () => {
+    expect(normalizeFieldValue("country", null)).toBe("unknown");
+    expect(normalizeFieldValue("country", "")).toBe("unknown");
+  });
+
+  it("maps generic null fields to '(none)'", () => {
+    expect(normalizeFieldValue("utm_campaign", null)).toBe("(none)");
+    expect(normalizeFieldValue("pathname", undefined)).toBe("(none)");
+  });
+
+  it("coerces is_404 to a boolean string from bool or string input", () => {
+    expect(normalizeFieldValue("is_404", true)).toBe("true");
+    expect(normalizeFieldValue("is_404", "true")).toBe("true");
+    expect(normalizeFieldValue("is_404", false)).toBe("false");
+    expect(normalizeFieldValue("is_404", null)).toBe("false");
+  });
+
+  it("stringifies present values", () => {
+    expect(normalizeFieldValue("browser", "Firefox")).toBe("Firefox");
+  });
+});
+
+describe("applyEventFilters", () => {
+  const events = [
+    ev({ country: "IN", device_type: "mobile" }),
+    ev({ country: "US", device_type: "desktop" }),
+    ev({ country: "IN", device_type: "desktop" }),
+    ev({ country: null, referrer_source: null }),
+  ];
+
+  it("returns a copy when no active filters", () => {
+    const out = applyEventFilters(events, {});
+    expect(out).toHaveLength(events.length);
+    expect(out).not.toBe(events);
+  });
+
+  it("filters by a single equality field", () => {
+    expect(applyEventFilters(events, { country: "IN" })).toHaveLength(2);
+  });
+
+  it("composes multiple filters with AND semantics", () => {
+    const out = applyEventFilters(events, { country: "IN", device_type: "desktop" });
+    expect(out).toHaveLength(1);
+  });
+
+  it("matches null rows by their canonical label", () => {
+    expect(applyEventFilters(events, { country: "unknown" })).toHaveLength(1);
+    expect(applyEventFilters(events, { referrer_source: "direct" })).toHaveLength(1);
+  });
+
+  it("ignores unknown / empty filter keys", () => {
+    expect(applyEventFilters(events, { visitor_id: "v1" } as any)).toHaveLength(events.length);
+    expect(applyEventFilters(events, { country: "" })).toHaveLength(events.length);
+  });
+});
+
+describe("computeBreakdown", () => {
+  it("groups by dimension with counts, unique visitors and percentages", () => {
+    const events = [
+      ev({ browser: "Chrome", visitor_id: "a" }),
+      ev({ browser: "Chrome", visitor_id: "a" }),
+      ev({ browser: "Chrome", visitor_id: "b" }),
+      ev({ browser: "Safari", visitor_id: "c" }),
+    ];
+    const out = computeBreakdown(events, "browser");
+    expect(out.dimension).toBe("browser");
+    expect(out.total_events).toBe(4);
+    expect(out.total_unique_visitors).toBe(3);
+
+    const chrome = out.results.find((r) => r.value === "Chrome")!;
+    expect(chrome.count).toBe(3);
+    expect(chrome.unique_visitors).toBe(2);
+    expect(chrome.percentage).toBe(75);
+
+    const safari = out.results.find((r) => r.value === "Safari")!;
+    expect(safari.count).toBe(1);
+    expect(safari.percentage).toBe(25);
+  });
+
+  it("sorts by count desc then value asc", () => {
+    const events = [
+      ev({ country: "B" }),
+      ev({ country: "A" }),
+      ev({ country: "A" }),
+      ev({ country: "C" }),
+    ];
+    const out = computeBreakdown(events, "country");
+    expect(out.results.map((r) => r.value)).toEqual(["A", "B", "C"]);
+  });
+
+  it("buckets null dimension values under their label", () => {
+    const events = [ev({ referrer_source: null }), ev({ referrer_source: "google" })];
+    const out = computeBreakdown(events, "referrer_source");
+    expect(out.results.map((r) => r.value).sort()).toEqual(["direct", "google"]);
+  });
+
+  it("handles is_404 boolean buckets", () => {
+    const events = [ev({ is_404: true }), ev({ is_404: false }), ev({ is_404: false })];
+    const out = computeBreakdown(events, "is_404");
+    const t = out.results.find((r) => r.value === "true")!;
+    const f = out.results.find((r) => r.value === "false")!;
+    expect(t.count).toBe(1);
+    expect(f.count).toBe(2);
+  });
+
+  it("respects the limit and clamps to bounds", () => {
+    const events = Array.from({ length: 5 }, (_, i) => ev({ pathname: `/p${i}` }));
+    expect(computeBreakdown(events, "pathname", 2).results).toHaveLength(2);
+    // limit 0 / NaN falls back to default
+    expect(computeBreakdown(events, "pathname", 0).results.length).toBeLessThanOrEqual(DEFAULT_BREAKDOWN_LIMIT);
+    // over-max is clamped, never throws
+    expect(() => computeBreakdown(events, "pathname", MAX_BREAKDOWN_LIMIT + 50)).not.toThrow();
+  });
+
+  it("returns empty results and zero totals for no events", () => {
+    const out = computeBreakdown([], "device_type");
+    expect(out.total_events).toBe(0);
+    expect(out.total_unique_visitors).toBe(0);
+    expect(out.results).toEqual([]);
+  });
+});

--- a/apps/backend/src/workflows/analytics/reports/breakdown-lib.ts
+++ b/apps/backend/src/workflows/analytics/reports/breakdown-lib.ts
@@ -1,0 +1,201 @@
+/**
+ * Pure aggregation helpers for granular analytics breakdown reports (#559 slice 3).
+ *
+ * These functions are deliberately framework-free so they can be unit-tested in
+ * isolation (`TEST_TYPE=unit`). The workflow/route layer fetches the raw events
+ * (scoped by website + date range) and delegates the slicing + filtering here.
+ */
+
+/** A single dimension an analytics event can be broken down by. */
+export type BreakdownDimension =
+  | "country"
+  | "device_type"
+  | "browser"
+  | "os"
+  | "referrer_source"
+  | "utm_source"
+  | "utm_medium"
+  | "utm_campaign"
+  | "utm_term"
+  | "utm_content"
+  | "pathname"
+  | "is_404"
+  | "event_type"
+  | "event_name";
+
+/** All dimensions a breakdown report can group by. */
+export const BREAKDOWN_DIMENSIONS: BreakdownDimension[] = [
+  "country",
+  "device_type",
+  "browser",
+  "os",
+  "referrer_source",
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+  "pathname",
+  "is_404",
+  "event_type",
+  "event_name",
+];
+
+/**
+ * Fields that may be used as composable equality filters. Same set as the
+ * dimensions — you can both group by and filter on any of them.
+ */
+export const FILTERABLE_FIELDS: BreakdownDimension[] = [...BREAKDOWN_DIMENSIONS];
+
+/** Minimal shape of an analytics event row this module needs. */
+export type AnalyticsEventRow = {
+  visitor_id?: string | null;
+  session_id?: string | null;
+  country?: string | null;
+  device_type?: string | null;
+  browser?: string | null;
+  os?: string | null;
+  referrer_source?: string | null;
+  utm_source?: string | null;
+  utm_medium?: string | null;
+  utm_campaign?: string | null;
+  utm_term?: string | null;
+  utm_content?: string | null;
+  pathname?: string | null;
+  is_404?: boolean | null;
+  event_type?: string | null;
+  event_name?: string | null;
+};
+
+export type BreakdownBucket = {
+  /** The normalized dimension value (never null — see NULL_LABELS). */
+  value: string;
+  /** Number of events in this bucket. */
+  count: number;
+  /** Distinct visitor_id count in this bucket. */
+  unique_visitors: number;
+  /** count / total_events as an integer percentage (0–100). */
+  percentage: number;
+};
+
+export type BreakdownResult = {
+  dimension: BreakdownDimension;
+  total_events: number;
+  total_unique_visitors: number;
+  /** Buckets sorted by count desc, then value asc, sliced to `limit`. */
+  results: BreakdownBucket[];
+};
+
+/** Default bucket cap, mirroring the top-10 cap on the existing stats workflow. */
+export const DEFAULT_BREAKDOWN_LIMIT = 20;
+export const MAX_BREAKDOWN_LIMIT = 100;
+
+/** Labels used when a dimension value is null/empty, per dimension. */
+const NULL_LABELS: Partial<Record<BreakdownDimension, string>> = {
+  referrer_source: "direct",
+  country: "unknown",
+  device_type: "unknown",
+  event_type: "unknown",
+};
+
+const DEFAULT_NULL_LABEL = "(none)";
+
+export function isBreakdownDimension(value: unknown): value is BreakdownDimension {
+  return (
+    typeof value === "string" &&
+    (BREAKDOWN_DIMENSIONS as string[]).includes(value)
+  );
+}
+
+export function isFilterableField(value: unknown): value is BreakdownDimension {
+  return (
+    typeof value === "string" &&
+    (FILTERABLE_FIELDS as string[]).includes(value)
+  );
+}
+
+/** Coerce a raw field value to its canonical string form for grouping/filtering. */
+export function normalizeFieldValue(
+  field: BreakdownDimension,
+  raw: unknown
+): string {
+  if (field === "is_404") {
+    return raw === true || raw === "true" ? "true" : "false";
+  }
+  if (raw === null || raw === undefined || raw === "") {
+    return NULL_LABELS[field] ?? DEFAULT_NULL_LABEL;
+  }
+  return String(raw);
+}
+
+/**
+ * Apply composable equality filters. Each filter value is compared against the
+ * normalized field value, so e.g. `referrer_source: "direct"` matches null rows.
+ * Unknown filter keys are ignored. Returns a new array.
+ */
+export function applyEventFilters(
+  events: AnalyticsEventRow[],
+  filters: Partial<Record<string, string>> = {}
+): AnalyticsEventRow[] {
+  const active = Object.entries(filters).filter(
+    ([key, val]) =>
+      isFilterableField(key) && val !== undefined && val !== null && val !== ""
+  ) as Array<[BreakdownDimension, string]>;
+
+  if (active.length === 0) {
+    return [...events];
+  }
+
+  return events.filter((event) =>
+    active.every(
+      ([field, want]) =>
+        normalizeFieldValue(field, (event as any)[field]) === want
+    )
+  );
+}
+
+/**
+ * Group `events` by `dimension` and compute count / unique_visitors / percentage
+ * per bucket. Buckets are sorted by count desc (ties broken by value asc) and
+ * capped to `limit` (clamped to [1, MAX_BREAKDOWN_LIMIT]).
+ */
+export function computeBreakdown(
+  events: AnalyticsEventRow[],
+  dimension: BreakdownDimension,
+  limit: number = DEFAULT_BREAKDOWN_LIMIT
+): BreakdownResult {
+  const cappedLimit = Math.max(1, Math.min(MAX_BREAKDOWN_LIMIT, Math.floor(limit) || DEFAULT_BREAKDOWN_LIMIT));
+
+  const buckets = new Map<string, { count: number; visitors: Set<string> }>();
+  const allVisitors = new Set<string>();
+
+  for (const event of events) {
+    const value = normalizeFieldValue(dimension, (event as any)[dimension]);
+    const bucket = buckets.get(value) || { count: 0, visitors: new Set<string>() };
+    bucket.count++;
+    if (event.visitor_id) {
+      bucket.visitors.add(event.visitor_id);
+      allVisitors.add(event.visitor_id);
+    }
+    buckets.set(value, bucket);
+  }
+
+  const total = events.length;
+
+  const results: BreakdownBucket[] = Array.from(buckets.entries())
+    .map(([value, data]) => ({
+      value,
+      count: data.count,
+      unique_visitors: data.visitors.size,
+      percentage: total > 0 ? Math.round((data.count / total) * 100) : 0,
+    }))
+    .sort((a, b) => b.count - a.count || a.value.localeCompare(b.value))
+    .slice(0, cappedLimit);
+
+  return {
+    dimension,
+    total_events: total,
+    total_unique_visitors: allVisitors.size,
+    results,
+  };
+}

--- a/apps/backend/src/workflows/analytics/reports/get-analytics-breakdown.ts
+++ b/apps/backend/src/workflows/analytics/reports/get-analytics-breakdown.ts
@@ -1,0 +1,79 @@
+import { createStep, createWorkflow, StepResponse, WorkflowResponse } from "@medusajs/framework/workflows-sdk";
+import { ANALYTICS_MODULE } from "../../../modules/analytics";
+import {
+  applyEventFilters,
+  computeBreakdown,
+  DEFAULT_BREAKDOWN_LIMIT,
+  type BreakdownDimension,
+  type BreakdownResult,
+} from "./breakdown-lib";
+
+/**
+ * Get Analytics Breakdown (#559 slice 3)
+ *
+ * Granular single-dimension breakdown of a website's events, with composable
+ * equality filters and an optional date range. Complements the high-level
+ * getAnalyticsStatsWorkflow which returns a fixed set of aggregates.
+ */
+export type GetAnalyticsBreakdownInput = {
+  website_id: string;
+  dimension: BreakdownDimension;
+  start_date?: Date;
+  end_date?: Date;
+  /** Composable equality filters keyed by filterable field name. */
+  filters?: Record<string, string>;
+  limit?: number;
+};
+
+export const getAnalyticsBreakdownStep = createStep(
+  "get-analytics-breakdown-step",
+  async (input: GetAnalyticsBreakdownInput, { container }) => {
+    const analyticsService = container.resolve(ANALYTICS_MODULE) as any;
+
+    const filters: any = { website_id: input.website_id };
+    if (input.start_date || input.end_date) {
+      filters.timestamp = {};
+      if (input.start_date) filters.timestamp.$gte = input.start_date;
+      if (input.end_date) filters.timestamp.$lte = input.end_date;
+    }
+
+    const [events] = await analyticsService.listAndCountAnalyticsEvents(filters, {
+      select: [
+        "id",
+        "visitor_id",
+        "session_id",
+        "country",
+        "device_type",
+        "browser",
+        "os",
+        "referrer_source",
+        "utm_source",
+        "utm_medium",
+        "utm_campaign",
+        "utm_term",
+        "utm_content",
+        "pathname",
+        "is_404",
+        "event_type",
+        "event_name",
+      ],
+    });
+
+    const filtered = applyEventFilters(events, input.filters);
+    const result: BreakdownResult = computeBreakdown(
+      filtered,
+      input.dimension,
+      input.limit ?? DEFAULT_BREAKDOWN_LIMIT
+    );
+
+    return new StepResponse(result);
+  }
+);
+
+export const getAnalyticsBreakdownWorkflow = createWorkflow(
+  "get-analytics-breakdown",
+  (input: GetAnalyticsBreakdownInput) => {
+    const result = getAnalyticsBreakdownStep(input);
+    return new WorkflowResponse(result);
+  }
+);


### PR DESCRIPTION
## #559 slice 3 — granular stats/breakdown endpoints

Adds `GET /admin/analytics-events/breakdown` for OpenPanel-style granular reporting: a single-dimension breakdown of a website's analytics events with **composable equality filters** and a **date range**.

### Endpoint
`GET /admin/analytics-events/breakdown?website_id=…&dimension=…[&days=N | &start_date&end_date][&limit=N][&<field>=<value>…]`

- **dimension** (required) — one of: `country`, `device_type`, `browser`, `os`, `referrer_source`, `utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content`, `pathname`, `is_404`, `event_type`, `event_name`. 400 on missing/unknown (response lists `supported_dimensions`).
- **filters** — any filterable field passed as a query key becomes an AND equality filter, e.g. `?dimension=pathname&device_type=mobile&country=IN`. Null rows match their canonical label (`referrer_source=direct`, `country=unknown`).
- **window** — `days` (rolling) takes precedence over explicit `start_date`/`end_date`.
- **limit** — buckets returned (default 20, clamped 1–100).

Response: `{ website_id, dimension, period, filters, breakdown: { dimension, total_events, total_unique_visitors, results: [{ value, count, unique_visitors, percentage }] } }`.

### Design
- `breakdown-lib.ts` — pure, framework-free helpers (`normalizeFieldValue`, `applyEventFilters`, `computeBreakdown`) so the slicing/filtering logic is unit-tested in isolation. Mirrors the existing `get-analytics-stats` fetch-then-aggregate pattern.
- `get-analytics-breakdown.ts` — workflow fetches events scoped by website + timestamp range, delegates to the pure helpers.
- Route mirrors the existing `/admin/analytics-events/stats` query conventions.

### Tests
- **18 unit** (`breakdown-lib.unit.spec.ts`, `TEST_TYPE=unit`) — normalization, null-bucketing, AND-composition, sorting, limit clamping, empty input.
- **6 integration** (`analytics-breakdown.spec.ts`, per-file shared DB) — 400s, country/pathname breakdowns, composable filter, limit.

No behavior change to existing endpoints. Additive route only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)