### PR TITLE
feat(analytics): breakdown react-query hooks + UI spec (#559 slice 4)

### DIFF
--- a/apps/backend/src/admin/hooks/api/__tests__/analytics-breakdown-query.unit.spec.ts
+++ b/apps/backend/src/admin/hooks/api/__tests__/analytics-breakdown-query.unit.spec.ts
@@ -1,0 +1,145 @@
+import {
+  BREAKDOWN_DIMENSIONS,
+  buildBreakdownQuery,
+  isBreakdownDimension,
+} from "../analytics-breakdown-query";
+
+/**
+ * Helper: parse the built query string back into a sorted [key, value] list so
+ * assertions don't depend on URLSearchParams ordering.
+ */
+const parse = (qs: string): Record<string, string> => {
+  const out: Record<string, string> = {};
+  for (const [k, v] of new URLSearchParams(qs).entries()) out[k] = v;
+  return out;
+};
+
+describe("buildBreakdownQuery", () => {
+  it("always includes website_id and dimension", () => {
+    const q = parse(
+      buildBreakdownQuery({ website_id: "web_1", dimension: "country" })
+    );
+    expect(q.website_id).toBe("web_1");
+    expect(q.dimension).toBe("country");
+  });
+
+  it("includes a rolling days window when provided", () => {
+    const q = parse(
+      buildBreakdownQuery({ website_id: "web_1", dimension: "browser", days: 30 })
+    );
+    expect(q.days).toBe("30");
+    expect(q.start_date).toBeUndefined();
+    expect(q.end_date).toBeUndefined();
+  });
+
+  it("includes explicit start/end when no days given", () => {
+    const q = parse(
+      buildBreakdownQuery({
+        website_id: "web_1",
+        dimension: "os",
+        start_date: "2026-06-01T00:00:00.000Z",
+        end_date: "2026-06-20T00:00:00.000Z",
+      })
+    );
+    expect(q.start_date).toBe("2026-06-01T00:00:00.000Z");
+    expect(q.end_date).toBe("2026-06-20T00:00:00.000Z");
+    expect(q.days).toBeUndefined();
+  });
+
+  it("prefers days over explicit start/end (server precedence) and never sends both", () => {
+    const q = parse(
+      buildBreakdownQuery({
+        website_id: "web_1",
+        dimension: "pathname",
+        days: 7,
+        start_date: "2026-06-01T00:00:00.000Z",
+        end_date: "2026-06-20T00:00:00.000Z",
+      })
+    );
+    expect(q.days).toBe("7");
+    expect(q.start_date).toBeUndefined();
+    expect(q.end_date).toBeUndefined();
+  });
+
+  it("includes a numeric limit", () => {
+    const q = parse(
+      buildBreakdownQuery({ website_id: "web_1", dimension: "country", limit: 50 })
+    );
+    expect(q.limit).toBe("50");
+  });
+
+  it("ignores a non-finite limit / days", () => {
+    const q = parse(
+      buildBreakdownQuery({
+        website_id: "web_1",
+        dimension: "country",
+        limit: NaN,
+        days: NaN,
+      })
+    );
+    expect(q.limit).toBeUndefined();
+    expect(q.days).toBeUndefined();
+  });
+
+  it("appends recognized composable equality filters", () => {
+    const q = parse(
+      buildBreakdownQuery({
+        website_id: "web_1",
+        dimension: "pathname",
+        filters: { device_type: "mobile", country: "IN" },
+      })
+    );
+    expect(q.device_type).toBe("mobile");
+    expect(q.country).toBe("IN");
+  });
+
+  it("coerces boolean/number filter values to strings", () => {
+    const q = parse(
+      buildBreakdownQuery({
+        website_id: "web_1",
+        dimension: "pathname",
+        filters: { is_404: true },
+      })
+    );
+    expect(q.is_404).toBe("true");
+  });
+
+  it("drops blank / whitespace-only filter values", () => {
+    const q = parse(
+      buildBreakdownQuery({
+        website_id: "web_1",
+        dimension: "pathname",
+        filters: { country: "", device_type: "   " },
+      })
+    );
+    expect(q.country).toBeUndefined();
+    expect(q.device_type).toBeUndefined();
+  });
+
+  it("ignores unrecognized filter keys", () => {
+    const q = parse(
+      buildBreakdownQuery({
+        website_id: "web_1",
+        dimension: "country",
+        // @ts-expect-error — intentionally passing a non-filterable key
+        filters: { not_a_field: "x" },
+      })
+    );
+    expect(q.not_a_field).toBeUndefined();
+  });
+});
+
+describe("isBreakdownDimension", () => {
+  it("accepts every supported dimension", () => {
+    for (const d of BREAKDOWN_DIMENSIONS) {
+      expect(isBreakdownDimension(d)).toBe(true);
+    }
+  });
+
+  it("rejects unknown values and non-strings", () => {
+    expect(isBreakdownDimension("nonsense")).toBe(false);
+    expect(isBreakdownDimension(undefined)).toBe(false);
+    expect(isBreakdownDimension(42)).toBe(false);
+    expect(isBreakdownDimension(null)).toBe(false);
+  });
+});

--- a/apps/backend/src/admin/hooks/api/analytics-breakdown-query.ts
+++ b/apps/backend/src/admin/hooks/api/analytics-breakdown-query.ts
@@ -1,0 +1,158 @@
+/**
+ * Pure, framework-free helpers for the analytics breakdown hook (#559 slice 4).
+ *
+ * These types + the `buildBreakdownQuery` query-string builder are intentionally
+ * decoupled from React / the Medusa admin SDK so they can be unit-tested without
+ * a render harness (the UI render slice itself is Playwright-gated and deferred).
+ *
+ * The shapes here mirror the server contract of
+ * `GET /admin/analytics-events/breakdown` (#559 slice 3, PR #562):
+ *   workflows/analytics/reports/breakdown-lib.ts (BreakdownResult/BreakdownBucket)
+ *   api/admin/analytics-events/breakdown/route.ts (envelope).
+ * Keep them in sync if the server contract changes.
+ */
+
+/** Dimensions a breakdown report can group by — mirrors BREAKDOWN_DIMENSIONS. */
+export type BreakdownDimension =
+  | "country"
+  | "device_type"
+  | "browser"
+  | "os"
+  | "referrer_source"
+  | "utm_source"
+  | "utm_medium"
+  | "utm_campaign"
+  | "utm_term"
+  | "utm_content"
+  | "pathname"
+  | "is_404"
+  | "event_type"
+  | "event_name";
+
+/** Ordered list of supported dimensions (matches the server's array). */
+export const BREAKDOWN_DIMENSIONS: BreakdownDimension[] = [
+  "country",
+  "device_type",
+  "browser",
+  "os",
+  "referrer_source",
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+  "pathname",
+  "is_404",
+  "event_type",
+  "event_name",
+];
+
+/** Same set as the dimensions — any can be a composable equality filter. */
+export const FILTERABLE_FIELDS: BreakdownDimension[] = [...BREAKDOWN_DIMENSIONS];
+
+/** One row of a breakdown — mirrors server BreakdownBucket. */
+export interface BreakdownBucket {
+  /** Normalized dimension value (never null; null rows get a canonical label). */
+  value: string;
+  /** Number of events in this bucket. */
+  count: number;
+  /** Distinct visitor_id count in this bucket. */
+  unique_visitors: number;
+  /** count / total_events as an integer percentage (0–100). */
+  percentage: number;
+}
+
+/** The `breakdown` object inside the response — mirrors server BreakdownResult. */
+export interface BreakdownResult {
+  dimension: BreakdownDimension;
+  total_events: number;
+  total_unique_visitors: number;
+  /** Buckets sorted by count desc (ties by value asc), sliced to `limit`. */
+  results: BreakdownBucket[];
+}
+
+/** Full response envelope of GET /admin/analytics-events/breakdown. */
+export interface AnalyticsBreakdownResponse {
+  website_id: string;
+  dimension: BreakdownDimension;
+  period: {
+    start_date?: string;
+    end_date?: string;
+    days?: number;
+  };
+  filters: Partial<Record<BreakdownDimension, string>>;
+  breakdown: BreakdownResult;
+}
+
+/**
+ * Input to the breakdown hook / query builder. `website_id` and `dimension`
+ * are required by the endpoint; the date window is either a rolling `days` or an
+ * explicit `start_date`/`end_date` pair; `limit` caps buckets (server clamps
+ * 1–100); `filters` are composable equality filters keyed by any dimension.
+ */
+export interface BreakdownQueryParams {
+  website_id: string;
+  dimension: BreakdownDimension;
+  /** Rolling window in days. Takes precedence over start/end on the server. */
+  days?: number;
+  /** Explicit window start (ISO date string). */
+  start_date?: string;
+  /** Explicit window end (ISO date string). */
+  end_date?: string;
+  /** Max buckets returned (server default 20, clamped 1–100). */
+  limit?: number;
+  /** Composable equality filters; empty/blank values are dropped. */
+  filters?: Partial<Record<BreakdownDimension, string | number | boolean>>;
+}
+
+/**
+ * Build the query string for GET /admin/analytics-events/breakdown from typed
+ * params. Pure + deterministic: omits undefined/empty values, applies only
+ * recognized filterable fields, and never includes both a `days` window and an
+ * explicit start/end (days wins, matching the server's precedence) to avoid
+ * sending contradictory params.
+ *
+ * @returns the query string WITHOUT a leading "?".
+ */
+export function buildBreakdownQuery(params: BreakdownQueryParams): string {
+  const sp = new URLSearchParams();
+
+  sp.set("website_id", params.website_id);
+  sp.set("dimension", params.dimension);
+
+  // Date window: rolling `days` wins over explicit start/end (server precedence).
+  if (params.days != null && Number.isFinite(params.days)) {
+    sp.set("days", String(params.days));
+  } else {
+    if (params.start_date) sp.set("start_date", params.start_date);
+    if (params.end_date) sp.set("end_date", params.end_date);
+  }
+
+  if (params.limit != null && Number.isFinite(params.limit)) {
+    sp.set("limit", String(params.limit));
+  }
+
+  // Composable equality filters — only recognized fields, only non-blank values.
+  if (params.filters) {
+    const allowed = new Set<string>(FILTERABLE_FIELDS);
+    for (const [key, raw] of Object.entries(params.filters)) {
+      if (!allowed.has(key)) continue;
+      if (raw === undefined || raw === null) continue;
+      const value = String(raw).trim();
+      if (value === "") continue;
+      sp.set(key, value);
+    }
+  }
+
+  return sp.toString();
+}
+
+/** Narrowing guard — true if `value` is a supported breakdown dimension. */
+export function isBreakdownDimension(
+  value: unknown
+): value is BreakdownDimension {
+  return (
+    typeof value === "string" &&
+    (BREAKDOWN_DIMENSIONS as string[]).includes(value)
+  );
+}

--- a/apps/backend/src/admin/hooks/api/analytics.ts
+++ b/apps/backend/src/admin/hooks/api/analytics.ts
@@ -1,6 +1,24 @@
 import { useQuery } from "@tanstack/react-query";
 import { sdk } from "../../lib/config";
 import { queryKeysFactory } from "../../lib/query-key-factory";
+import {
+  AnalyticsBreakdownResponse,
+  BreakdownQueryParams,
+  buildBreakdownQuery,
+} from "./analytics-breakdown-query";
+
+export type {
+  AnalyticsBreakdownResponse,
+  BreakdownBucket,
+  BreakdownDimension,
+  BreakdownQueryParams,
+  BreakdownResult,
+} from "./analytics-breakdown-query";
+export {
+  BREAKDOWN_DIMENSIONS,
+  FILTERABLE_FIELDS,
+  isBreakdownDimension,
+} from "./analytics-breakdown-query";
 
 const ANALYTICS_QUERY_KEY = "analytics" as const;
 export const analyticsQueryKeys = queryKeysFactory(ANALYTICS_QUERY_KEY);
@@ -101,6 +119,30 @@ export const useAnalyticsTimeseries = (
       return res.body;
     },
     enabled: !!websiteId,
+  });
+};
+
+// Hook to fetch a single-dimension analytics breakdown (#559 slice 4).
+// Consumes GET /admin/analytics-events/breakdown (slice 3 / PR #562):
+// pass a website + dimension, an optional rolling `days` or explicit
+// start/end window, an optional `limit`, and composable equality `filters`.
+export const useAnalyticsBreakdown = (
+  params: BreakdownQueryParams,
+  options?: { enabled?: boolean }
+) => {
+  const enabled =
+    (options?.enabled ?? true) && !!params.website_id && !!params.dimension;
+
+  return useQuery({
+    queryKey: ["analytics-breakdown", params],
+    queryFn: async () => {
+      const qs = buildBreakdownQuery(params);
+      const res = await sdk.client.fetch<AnalyticsBreakdownResponse>(
+        `/admin/analytics-events/breakdown?${qs}`
+      );
+      return res as AnalyticsBreakdownResponse;
+    },
+    enabled,
   });
 };
 

--- a/apps/docs/notes/559_ANALYTICS_BREAKDOWN_UI_SPEC.md
+++ b/apps/docs/notes/559_ANALYTICS_BREAKDOWN_UI_SPEC.md
@@ -1,0 +1,88 @@
+# #559 Slice 4 — OpenPanel-style Analytics Breakdown UI (spec)
+
+Status: **hooks + spec shipped (this PR); render slice DEFERRED** (Playwright-gated;
+the headless PR daemon cannot boot Medusa admin + Playwright to visually verify a
+React render, so the interactive page is left for an interactive session).
+
+This note is the grounded build plan for the explorable breakdown UI. The
+verifiable, headless-friendly part — typed react-query hooks over the slice-3
+endpoint + a pure, unit-tested query builder — ships now. The render slice that
+mounts these into the admin page is specified here so the next interactive
+session can build + Playwright-verify it directly.
+
+## What shipped in this PR (verifiable, no render)
+
+- `apps/backend/src/admin/hooks/api/analytics-breakdown-query.ts` — **pure,
+  framework-free**: `BreakdownDimension`, `BREAKDOWN_DIMENSIONS`,
+  `FILTERABLE_FIELDS`, `BreakdownBucket`, `BreakdownResult`,
+  `AnalyticsBreakdownResponse`, `BreakdownQueryParams`, `buildBreakdownQuery()`,
+  `isBreakdownDimension()`. Mirrors the server contract in
+  `src/workflows/analytics/reports/breakdown-lib.ts` +
+  `src/api/admin/analytics-events/breakdown/route.ts` (slice 3 / PR #562).
+- `apps/backend/src/admin/hooks/api/analytics.ts` — `useAnalyticsBreakdown(params, opts?)`
+  react-query hook calling `GET /admin/analytics-events/breakdown`; re-exports the
+  types/consts so components import from one place. Disabled until `website_id`
+  and `dimension` are set; query key is `["analytics-breakdown", params]`.
+- `__tests__/analytics-breakdown-query.unit.spec.ts` — 12 unit tests
+  (`TEST_TYPE=unit`) covering query building (days-vs-range precedence, limit,
+  filter coercion/blank-drop/unknown-key rejection) and the dimension guard.
+
+## Server contract recap (slice 3 / PR #562)
+
+`GET /admin/analytics-events/breakdown`
+- Required: `website_id`, `dimension` (one of the 14 `BREAKDOWN_DIMENSIONS`).
+- Window: rolling `days` (wins) OR explicit `start_date`/`end_date` ISO.
+- `limit` (default 20, server clamps 1–100).
+- Any filterable field as a query key = AND equality filter (e.g.
+  `?dimension=pathname&device_type=mobile&country=IN`). Null rows match canonical
+  labels (`referrer_source=direct`, `country/device_type/event_type=unknown`,
+  others `(none)`; `is_404=true|false`).
+- Response: `{ website_id, dimension, period, filters, breakdown: { dimension,
+  total_events, total_unique_visitors, results: BreakdownBucket[] } }` where each
+  bucket = `{ value, count, unique_visitors, percentage }`, sorted count-desc.
+
+## Render slice (DEFERRED — interactive session)
+
+Target surface: `src/admin/routes/websites/[id]/analytics/page.tsx` →
+`components/websites/website-analytics-modal.tsx` (655 lines; recharts +
+`@medusajs/ui` `Container`/`Heading`/`Text`/`Badge`). Add a **"Breakdown / Explore"**
+section below the existing overview cards — do NOT replace the live panel or the
+existing charts.
+
+OpenPanel-style interaction:
+1. **Dimension picker** — a `Select` (or segmented `Tabs`) over `BREAKDOWN_DIMENSIONS`
+   with human labels (Country, Device, Browser, OS, Referrer, UTM Source…, Path,
+   404?, Event Type, Event Name). Drives `params.dimension`.
+2. **Window control** — reuse the page's existing days/from-to filter state; map to
+   `days` or `start_date`/`end_date`.
+3. **Filter chips** — clicking a bucket row adds `{ [currentDimension]: value }` to
+   `params.filters` as a removable chip, then the user can switch dimension to
+   drill down (classic OpenPanel "click to filter, switch dimension" flow). Chips
+   render the active `filters` map; an "x" removes one.
+4. **Breakdown table/bars** — `useAnalyticsBreakdown(params)` → render
+   `breakdown.results` as a ranked list: value label, a proportional bar
+   (`percentage`), `count`, and `unique_visitors`. Show
+   `total_events`/`total_unique_visitors` as the section header. Cap visible rows
+   with `limit` (default 20) + a "Show more" that bumps `limit`.
+
+UX/styling rules (per project conventions in memory):
+- **Medusa-native tokens only** — `--ui-*` / `--elevation-*` CSS vars, no hardcoded
+  colors, so dark mode follows for free.
+- **Skeletons, never "Loading…"** — skeleton the bar rows (`isLoading` from the
+  hook) so layout doesn't jump.
+- Empty state when `results.length === 0` ("No events for this dimension in the
+  selected window").
+
+Verification (interactive only): `yarn dev`, open
+`/app/websites/:id/analytics`, drive the dimension picker + a filter chip with the
+`playwright-skill` / `webapp-testing` skill against the live admin, screenshot the
+breakdown rendering and a drill-down. Unit tests do NOT substitute for UI sign-off.
+
+## Watch-outs
+
+- Keep `analytics-breakdown-query.ts` in sync with `breakdown-lib.ts` if the
+  server dimension/filter set changes (single source on the server; this is a
+  typed mirror for the admin bundle, which is tsconfig-excluded).
+- The endpoint only exists once **PR #562** merges; the hook is decoupled (URL
+  fetch) so this PR is independent off `main`, but the render slice should land
+  after #562 is live.


### PR DESCRIPTION
## #559 slice 4 — OpenPanel-style analytics UI (verifiable part)

Ships the **headless-friendly, verifiable** part of #559 slice 4: typed
react-query hooks over the slice-3 breakdown endpoint (`GET /admin/analytics-events/breakdown`, PR #562) + a pure, unit-tested query builder. The interactive **render slice is Playwright-gated and deferred** — the headless PR daemon can't boot Medusa admin + Playwright to visually verify a React render, so the page wiring is fully specced for an interactive session.

### What's here
- **`src/admin/hooks/api/analytics-breakdown-query.ts`** — pure, framework-free: `BreakdownDimension`/`BREAKDOWN_DIMENSIONS`/`FILTERABLE_FIELDS`, `BreakdownBucket`/`BreakdownResult`/`AnalyticsBreakdownResponse`, `BreakdownQueryParams`, `buildBreakdownQuery()`, `isBreakdownDimension()`. Typed mirror of the server contract (`workflows/analytics/reports/breakdown-lib.ts`).
- **`src/admin/hooks/api/analytics.ts`** — `useAnalyticsBreakdown(params, opts?)` react-query hook (disabled until `website_id`+`dimension` set) + type re-exports.
- **12 unit tests** (`TEST_TYPE=unit`) — query building (days-vs-range precedence, limit, filter coercion/blank-drop/unknown-key rejection) + dimension guard.
- **`apps/docs/notes/559_ANALYTICS_BREAKDOWN_UI_SPEC.md`** — grounded render-slice plan (dimension picker → click-to-filter chips → ranked breakdown bars, Medusa-native tokens, Skeletons, target `routes/websites/[id]/analytics/page.tsx`).

### Notes
- **Independent off `main`** — the hook is a decoupled URL fetch; endpoint goes live when **#562** merges. Land the render slice after #562.
- No behavior change; additive admin-bundle code only (admin is tsconfig-excluded from `medusa build` typecheck).

### Verify
```
cd apps/backend && TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules npx jest --testPathPattern=analytics-breakdown-query.unit
```
(12 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)