### PR TITLE
fix(infra): set ANALYTICS_BATCH_INGEST on medusa-worker too (#559)

### DIFF
--- a/deploy/aws/copilot/medusa-worker/manifest.yml
+++ b/deploy/aws/copilot/medusa-worker/manifest.yml
@@ -29,6 +29,10 @@ variables:
 # Worker needs DB + Redis + R2 (for export/report jobs that write files).
 # Does NOT need JWT/COOKIE/CORS (no HTTP surface).
 secrets:
+  # #559 — the drain-analytics-buffer scheduled job runs HERE (worker mode), not on
+  # medusa-server (server mode skips scheduled jobs). The flag MUST be set on the
+  # worker too or the drain early-returns and the Redis buffer never persists.
+  ANALYTICS_BATCH_INGEST: /jyt/prod/ANALYTICS_BATCH_INGEST
   CLOUDFLARE_API_TOKEN: /jyt/prod/CLOUDFLARE_API_TOKEN
   CLOUDFLARE_ZONE_ID: /jyt/prod/CLOUDFLARE_ZONE_ID
   DATABASE_URL: /jyt/prod/DATABASE_URL


### PR DESCRIPTION
**Bug found by prod verification of #565.** The `drain-analytics-buffer` scheduled job runs on **medusa-worker** (worker mode); medusa-server runs `server` mode and skips scheduled jobs. PR #565 set the flag only on medusa-server, so the producer buffered to Redis but the worker drain early-returned (`isBatchIngestEnabled()===false`) → events piled up unpersisted (**not lost** — no TTL; the drain clears the backlog once the worker has the flag).

Verified in prod: synthetic `/track` returned `Event queued` but never landed in `analytics-events` after 2.5 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)