### PR TITLE
feat(analytics): overview session engagement metrics (#569 S1)

### DIFF
--- a/apps/backend/integration-tests/http/analytics/website-overview-metrics.spec.ts
+++ b/apps/backend/integration-tests/http/analytics/website-overview-metrics.spec.ts
@@ -1,0 +1,100 @@
+import { setupSharedTestSuite } from "../shared-test-setup";
+import { createAdminUser, getAuthHeaders } from "../../helpers/create-admin-user";
+
+jest.setTimeout(100000);
+
+setupSharedTestSuite(({ api, getContainer }) => {
+  describe("GET /admin/websites/:id/analytics — session metrics (#569 S1)", () => {
+    let websiteId: string;
+    let adminHeaders: { headers: Record<string, string> };
+
+    beforeAll(async () => {
+      const container = await getContainer();
+      await createAdminUser(container);
+      adminHeaders = await getAuthHeaders(api);
+    });
+
+    beforeEach(async () => {
+      const container = await getContainer();
+      const websiteService = container.resolve("websites");
+      const website = await websiteService.createWebsites({
+        domain: `overview-${Date.now()}.example.com`,
+        name: "Overview Metrics Site",
+        status: "Active",
+        primary_language: "en",
+      });
+      websiteId = website.id;
+
+      const analyticsService = container.resolve("custom_analytics");
+      const now = new Date();
+
+      // Seed pageview events so total_events/pageviews are non-zero.
+      await analyticsService.createAnalyticsEvents([
+        { website_id: websiteId, event_type: "pageview", pathname: "/", visitor_id: "v1", session_id: "s1", timestamp: now },
+        { website_id: websiteId, event_type: "pageview", pathname: "/a", visitor_id: "v1", session_id: "s1", timestamp: now },
+        { website_id: websiteId, event_type: "pageview", pathname: "/", visitor_id: "v2", session_id: "s2", timestamp: now },
+      ]);
+
+      // Seed sessions for the engagement metrics.
+      await analyticsService.createAnalyticsSessions([
+        {
+          website_id: websiteId,
+          session_id: "s1",
+          visitor_id: "v1",
+          entry_page: "/",
+          pageviews: 2,
+          duration_seconds: 120,
+          is_bounce: false,
+          started_at: now,
+          last_activity_at: now,
+        },
+        {
+          website_id: websiteId,
+          session_id: "s2",
+          visitor_id: "v2",
+          entry_page: "/",
+          pageviews: 1,
+          duration_seconds: 0,
+          is_bounce: true,
+          started_at: now,
+          last_activity_at: now,
+        },
+      ]);
+    });
+
+    it("includes session-derived engagement metrics in stats", async () => {
+      const res = await api.get(`/admin/websites/${websiteId}/analytics`, adminHeaders);
+      expect(res.status).toBe(200);
+
+      const stats = res.data.stats;
+      expect(stats.total_sessions).toBe(2);
+      // 1 of 2 sessions bounced
+      expect(stats.bounce_rate).toBe(0.5);
+      // only s1 has duration > 0 -> avg = 120
+      expect(stats.avg_session_duration).toBe(120);
+      // (2 + 1) / 2 sessions = 1.5
+      expect(stats.pages_per_session).toBe(1.5);
+      // total pv 3 / 2 unique visitors = 1.5
+      expect(stats.views_per_visitor).toBe(1.5);
+    });
+
+    it("returns zeroed session metrics for a website with no sessions", async () => {
+      const container = await getContainer();
+      const websiteService = container.resolve("websites");
+      const empty = await websiteService.createWebsites({
+        domain: `overview-empty-${Date.now()}.example.com`,
+        name: "Empty Site",
+        status: "Active",
+        primary_language: "en",
+      });
+
+      const res = await api.get(`/admin/websites/${empty.id}/analytics`, adminHeaders);
+      expect(res.status).toBe(200);
+      expect(res.data.stats.total_sessions).toBe(0);
+      expect(res.data.stats.bounce_rate).toBe(0);
+      expect(res.data.stats.avg_session_duration).toBe(0);
+      expect(res.data.stats.pages_per_session).toBe(0);
+      expect(res.data.stats.views_per_visitor).toBe(0);
+    });
+  });
+});

--- a/apps/backend/src/workflows/analytics/__tests__/session-metrics-lib.unit.spec.ts
+++ b/apps/backend/src/workflows/analytics/__tests__/session-metrics-lib.unit.spec.ts
@@ -1,0 +1,93 @@
+import { computeSessionMetrics } from "../session-metrics-lib";
+
+describe("computeSessionMetrics (#569 S1)", () => {
+  it("returns zeroed metrics for empty / nullish input", () => {
+    const empty = computeSessionMetrics([]);
+    expect(empty).toEqual({
+      total_sessions: 0,
+      bounce_rate: 0,
+      avg_session_duration: 0,
+      pages_per_session: 0,
+      views_per_visitor: 0,
+    });
+    expect(computeSessionMetrics(null)).toEqual(empty);
+    expect(computeSessionMetrics(undefined)).toEqual(empty);
+  });
+
+  it("computes bounce_rate as bounced / total (0..1, 4dp)", () => {
+    const m = computeSessionMetrics([
+      { is_bounce: true },
+      { is_bounce: false },
+      { is_bounce: true },
+    ]);
+    expect(m.total_sessions).toBe(3);
+    expect(m.bounce_rate).toBe(0.6667);
+  });
+
+  it("averages duration only over sessions with duration > 0", () => {
+    const m = computeSessionMetrics([
+      { duration_seconds: 100 },
+      { duration_seconds: 0 }, // excluded
+      { duration_seconds: null }, // excluded
+      { duration_seconds: 200 },
+    ]);
+    // (100 + 200) / 2 = 150
+    expect(m.avg_session_duration).toBe(150);
+  });
+
+  it("returns 0 avg_session_duration when no positive durations", () => {
+    const m = computeSessionMetrics([
+      { duration_seconds: 0 },
+      { duration_seconds: null },
+    ]);
+    expect(m.avg_session_duration).toBe(0);
+  });
+
+  it("computes pages_per_session as mean pageviews across all sessions (2dp)", () => {
+    const m = computeSessionMetrics([
+      { pageviews: 1 },
+      { pageviews: 2 },
+      { pageviews: 4 },
+    ]);
+    // 7 / 3 = 2.3333 -> 2.33
+    expect(m.pages_per_session).toBe(2.33);
+  });
+
+  it("treats missing / non-positive pageviews as 0", () => {
+    const m = computeSessionMetrics([
+      { pageviews: null },
+      { pageviews: 0 },
+      { pageviews: 3 },
+    ]);
+    // 3 / 3 = 1
+    expect(m.pages_per_session).toBe(1);
+  });
+
+  it("computes views_per_visitor as total pageviews / unique visitors (2dp)", () => {
+    const m = computeSessionMetrics([
+      { visitor_id: "v1", pageviews: 2 },
+      { visitor_id: "v1", pageviews: 3 }, // same visitor
+      { visitor_id: "v2", pageviews: 5 },
+    ]);
+    // total pv = 10, unique visitors = 2 -> 5
+    expect(m.views_per_visitor).toBe(5);
+  });
+
+  it("returns 0 views_per_visitor when no visitor ids present", () => {
+    const m = computeSessionMetrics([{ pageviews: 4 }, { pageviews: 6 }]);
+    expect(m.views_per_visitor).toBe(0);
+  });
+
+  it("handles a realistic mixed batch", () => {
+    const m = computeSessionMetrics([
+      { visitor_id: "a", pageviews: 1, duration_seconds: 0, is_bounce: true },
+      { visitor_id: "b", pageviews: 5, duration_seconds: 120, is_bounce: false },
+      { visitor_id: "a", pageviews: 3, duration_seconds: 60, is_bounce: false },
+    ]);
+    expect(m.total_sessions).toBe(3);
+    expect(m.bounce_rate).toBe(0.3333);
+    expect(m.avg_session_duration).toBe(90); // (120+60)/2
+    expect(m.pages_per_session).toBe(3); // (1+5+3)/3
+    expect(m.views_per_visitor).toBe(4.5); // 9 / 2 visitors
+  });
+});

--- a/apps/backend/src/workflows/analytics/get-website-analytics-overview.ts
+++ b/apps/backend/src/workflows/analytics/get-website-analytics-overview.ts
@@ -1,5 +1,7 @@
 import { createStep, createWorkflow, StepResponse, WorkflowResponse } from "@medusajs/framework/workflows-sdk";
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils";
+import { ANALYTICS_MODULE } from "../../modules/analytics";
+import { computeSessionMetrics, SessionMetrics } from "./session-metrics-lib";
 
 /**
  * Get Website Analytics Overview
@@ -34,6 +36,12 @@ export type WebsiteAnalyticsOverview = {
     total_custom_events: number;
     unique_visitors: number;
     unique_sessions: number;
+    // Session-derived engagement metrics (#569 S1)
+    total_sessions: number;
+    bounce_rate: number;
+    avg_session_duration: number;
+    pages_per_session: number;
+    views_per_visitor: number;
   };
   recent_events: Array<{
     id: string;
@@ -104,6 +112,29 @@ export const getWebsiteAnalyticsOverviewStep = createStep(
     const uniqueVisitors = new Set(filteredEvents.map((e: any) => e.visitor_id)).size;
     const uniqueSessions = new Set(filteredEvents.map((e: any) => e.session_id)).size;
 
+    // Session-derived engagement metrics (#569 S1) — computed from
+    // analytics_session rows started within the window. Best-effort: a missing
+    // service/method or query error degrades to zeroed metrics, never throws.
+    let sessionMetrics: SessionMetrics = computeSessionMetrics([]);
+    try {
+      const analyticsService: any = container.resolve(ANALYTICS_MODULE);
+      if (analyticsService?.listAnalyticsSessions) {
+        const sessions = await analyticsService.listAnalyticsSessions(
+          {
+            website_id: input.website_id,
+            started_at: { $gte: startDate, $lte: endDate },
+          },
+          {
+            select: ["visitor_id", "pageviews", "duration_seconds", "is_bounce"],
+            take: 100000,
+          }
+        );
+        sessionMetrics = computeSessionMetrics(sessions);
+      }
+    } catch (e) {
+      // keep zeroed metrics
+    }
+
     // Get most recent events (last 100)
     const latestEvents = filteredEvents
       .sort((a: any, b: any) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
@@ -137,6 +168,11 @@ export const getWebsiteAnalyticsOverviewStep = createStep(
         total_custom_events: customEvents.length,
         unique_visitors: uniqueVisitors,
         unique_sessions: uniqueSessions,
+        total_sessions: sessionMetrics.total_sessions,
+        bounce_rate: sessionMetrics.bounce_rate,
+        avg_session_duration: sessionMetrics.avg_session_duration,
+        pages_per_session: sessionMetrics.pages_per_session,
+        views_per_visitor: sessionMetrics.views_per_visitor,
       },
       recent_events: latestEvents,
     };

--- a/apps/backend/src/workflows/analytics/session-metrics-lib.ts
+++ b/apps/backend/src/workflows/analytics/session-metrics-lib.ts
@@ -1,0 +1,88 @@
+/**
+ * Pure session-derived overview metrics (#569 S1).
+ *
+ * OpenPanel-parity overview adds engagement metrics computed from
+ * `analytics_session` rows: bounce rate, average session duration,
+ * pages per session, and views per visitor.
+ *
+ * Kept framework-free so it can be unit-tested without a container and
+ * reused by the website-analytics overview workflow.
+ */
+
+export type SessionMetricRow = {
+  visitor_id?: string | null;
+  pageviews?: number | null;
+  duration_seconds?: number | null;
+  is_bounce?: boolean | null;
+};
+
+export type SessionMetrics = {
+  /** Number of sessions considered in the window. */
+  total_sessions: number;
+  /** Bounced sessions / total sessions, ratio 0..1 (rounded to 4 dp). */
+  bounce_rate: number;
+  /** Mean duration_seconds across sessions with duration > 0 (rounded seconds). */
+  avg_session_duration: number;
+  /** Mean pageviews across all sessions (rounded to 2 dp). */
+  pages_per_session: number;
+  /** Total session pageviews / unique session visitors (rounded to 2 dp). */
+  views_per_visitor: number;
+};
+
+const round = (value: number, dp: number): number => {
+  if (!Number.isFinite(value)) return 0;
+  const f = Math.pow(10, dp);
+  return Math.round(value * f) / f;
+};
+
+/**
+ * Compute session-based engagement metrics from a list of session rows.
+ * Defensive against null/undefined fields and empty input.
+ */
+export const computeSessionMetrics = (
+  sessions: SessionMetricRow[] | null | undefined
+): SessionMetrics => {
+  const rows = Array.isArray(sessions) ? sessions : [];
+  const total = rows.length;
+
+  if (total === 0) {
+    return {
+      total_sessions: 0,
+      bounce_rate: 0,
+      avg_session_duration: 0,
+      pages_per_session: 0,
+      views_per_visitor: 0,
+    };
+  }
+
+  let bounced = 0;
+  let totalPageviews = 0;
+  let durationSum = 0;
+  let durationCount = 0;
+  const visitors = new Set<string>();
+
+  for (const s of rows) {
+    if (s?.is_bounce === true) bounced += 1;
+
+    const pv = Number(s?.pageviews);
+    totalPageviews += Number.isFinite(pv) && pv > 0 ? pv : 0;
+
+    const dur = Number(s?.duration_seconds);
+    if (Number.isFinite(dur) && dur > 0) {
+      durationSum += dur;
+      durationCount += 1;
+    }
+
+    if (s?.visitor_id) visitors.add(String(s.visitor_id));
+  }
+
+  const uniqueVisitors = visitors.size;
+
+  return {
+    total_sessions: total,
+    bounce_rate: round(bounced / total, 4),
+    avg_session_duration: durationCount > 0 ? Math.round(durationSum / durationCount) : 0,
+    pages_per_session: round(totalPageviews / total, 2),
+    views_per_visitor: uniqueVisitors > 0 ? round(totalPageviews / uniqueVisitors, 2) : 0,
+  };
+};


### PR DESCRIPTION
## #569 S1 — Overview metrics backend

First backend-first slice of **#569 (Analytics dashboard v2, OpenPanel parity)**, off `origin/main` (independent).

Extends `GET /admin/websites/:id/analytics` overview `stats` with session-derived engagement metrics (data already exists on `analytics_session`):

| field | definition |
|---|---|
| `total_sessions` | sessions started in window |
| `bounce_rate` | bounced / total (ratio 0..1, 4dp) |
| `avg_session_duration` | mean `duration_seconds` over sessions with duration > 0 (rounded sec) |
| `pages_per_session` | mean `pageviews` across all sessions (2dp) |
| `views_per_visitor` | total session pageviews / unique session visitors (2dp) |

### How
- **Pure** framework-free `computeSessionMetrics()` (`session-metrics-lib.ts`) — defensive against null fields/empty input, deterministic rounding; unit-tested in isolation.
- Workflow fetches in-window sessions via the analytics module service (`listAnalyticsSessions`, mirrors the ad-planning attribution pattern). **Best-effort**: a missing service/method or query error degrades to zeroed metrics, never throws — keeps the overview resilient.

### Tests
- 9 unit (`session-metrics-lib.unit.spec.ts`, `TEST_TYPE=unit`) — all green.
- 2 integration (`website-overview-metrics.spec.ts`, per-file shared DB) — all green.

### Notes
- Additive response fields only; no schema/migration. No modal/UI conflict (UI render slices stack after #566).
- The UI metric cards (S1b) ship later as a verifiable hook + spec doc per the #564 pattern.

Follows #559. Tracker #352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)