### PR TITLE
#569 S2 — session entry/exit pages backend (analytics dashboard v2)

### DIFF
--- a/apps/backend/integration-tests/http/analytics/website-session-pages.spec.ts
+++ b/apps/backend/integration-tests/http/analytics/website-session-pages.spec.ts
@@ -1,0 +1,130 @@
+import { setupSharedTestSuite } from "../shared-test-setup";
+import { createAdminUser, getAuthHeaders } from "../../helpers/create-admin-user";
+
+jest.setTimeout(100000);
+
+setupSharedTestSuite(({ api, getContainer }) => {
+  describe("GET /admin/websites/:id/analytics/pages — entry/exit pages (#569 S2)", () => {
+    let websiteId: string;
+    let adminHeaders: { headers: Record<string, string> };
+
+    beforeAll(async () => {
+      const container = await getContainer();
+      await createAdminUser(container);
+      adminHeaders = await getAuthHeaders(api);
+    });
+
+    beforeEach(async () => {
+      const container = await getContainer();
+      const websiteService = container.resolve("websites");
+      const website = await websiteService.createWebsites({
+        domain: `pages-${Date.now()}.example.com`,
+        name: "Session Pages Site",
+        status: "Active",
+        primary_language: "en",
+      });
+      websiteId = website.id;
+
+      const analyticsService = container.resolve("custom_analytics");
+      const now = new Date();
+
+      await analyticsService.createAnalyticsSessions([
+        {
+          website_id: websiteId,
+          session_id: "s1",
+          visitor_id: "v1",
+          entry_page: "/",
+          exit_page: "/checkout",
+          started_at: now,
+          last_activity_at: now,
+        },
+        {
+          website_id: websiteId,
+          session_id: "s2",
+          visitor_id: "v2",
+          entry_page: "/",
+          exit_page: "/checkout",
+          started_at: now,
+          last_activity_at: now,
+        },
+        {
+          website_id: websiteId,
+          session_id: "s3",
+          visitor_id: "v3",
+          entry_page: "/pricing",
+          exit_page: null,
+          started_at: now,
+          last_activity_at: now,
+        },
+      ]);
+    });
+
+    it("returns ranked entry and exit page breakdowns by default", async () => {
+      const res = await api.get(
+        `/admin/websites/${websiteId}/analytics/pages`,
+        adminHeaders
+      );
+      expect(res.status).toBe(200);
+      expect(res.data.website_id).toBe(websiteId);
+
+      const entry = res.data.pages.entry_page;
+      expect(entry.dimension).toBe("entry_page");
+      expect(entry.total_sessions).toBe(3);
+      expect(entry.results[0]).toMatchObject({
+        value: "/",
+        count: 2,
+        unique_visitors: 2,
+        percentage: 67,
+      });
+      expect(entry.results[1]).toMatchObject({ value: "/pricing", count: 1 });
+
+      const exit = res.data.pages.exit_page;
+      expect(exit.dimension).toBe("exit_page");
+      expect(exit.total_sessions).toBe(3);
+      expect(exit.results.find((r: any) => r.value === "/checkout").count).toBe(2);
+      // null exit folds into (none)
+      expect(exit.results.find((r: any) => r.value === "(none)").count).toBe(1);
+    });
+
+    it("scopes to a single dimension when ?dimension= is passed", async () => {
+      const res = await api.get(
+        `/admin/websites/${websiteId}/analytics/pages?dimension=entry_page`,
+        adminHeaders
+      );
+      expect(res.status).toBe(200);
+      expect(res.data.pages.entry_page).toBeDefined();
+      expect(res.data.pages.exit_page).toBeUndefined();
+    });
+
+    it("400s on an unknown dimension", async () => {
+      const res = await api
+        .get(
+          `/admin/websites/${websiteId}/analytics/pages?dimension=bogus`,
+          adminHeaders
+        )
+        .catch((e: any) => e.response);
+      expect(res.status).toBe(400);
+      expect(res.data.supported_dimensions).toEqual(["entry_page", "exit_page"]);
+    });
+
+    it("returns zeroed breakdowns for a website with no sessions", async () => {
+      const container = await getContainer();
+      const websiteService = container.resolve("websites");
+      const empty = await websiteService.createWebsites({
+        domain: `pages-empty-${Date.now()}.example.com`,
+        name: "Empty Pages Site",
+        status: "Active",
+        primary_language: "en",
+      });
+
+      const res = await api.get(
+        `/admin/websites/${empty.id}/analytics/pages`,
+        adminHeaders
+      );
+      expect(res.status).toBe(200);
+      expect(res.data.pages.entry_page.total_sessions).toBe(0);
+      expect(res.data.pages.entry_page.results).toEqual([]);
+      expect(res.data.pages.exit_page.total_sessions).toBe(0);
+    });
+  });
+});

--- a/apps/backend/src/api/admin/websites/[id]/analytics/pages/route.ts
+++ b/apps/backend/src/api/admin/websites/[id]/analytics/pages/route.ts
@@ -1,0 +1,85 @@
+/**
+ * GET /admin/websites/:id/analytics/pages
+ *
+ * Ranked breakdown of a website's analytics sessions by their entry (landing)
+ * and/or exit page (#569 S2). Sessions are scoped by website + an optional date
+ * range. The response mirrors the events breakdown envelope but counts
+ * sessions.
+ *
+ * Query parameters
+ * - dimension (string, optional): one of `entry_page` | `exit_page`. When
+ *   omitted, BOTH breakdowns are returned. 400 if present but unknown.
+ * - days (number, optional): rolling window; takes precedence over
+ *   start_date/end_date when present.
+ * - start_date / end_date (ISO string, optional): explicit window.
+ * - limit (number, optional): max buckets per breakdown (default 20, capped 100).
+ *
+ * Response (200)
+ * {
+ *   website_id,
+ *   period: { start_date?, end_date?, days? },
+ *   pages: {
+ *     entry_page?: { dimension, total_sessions, total_unique_visitors, results: [...] },
+ *     exit_page?:  { dimension, total_sessions, total_unique_visitors, results: [...] }
+ *   }
+ * }
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework";
+import { getSessionPagesWorkflow } from "../../../../../../workflows/analytics/reports/get-session-pages";
+import {
+  isSessionPageDimension,
+  SESSION_PAGE_DIMENSIONS,
+  type SessionPageDimension,
+} from "../../../../../../workflows/analytics/reports/session-pages-lib";
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params;
+  const { dimension, start_date, end_date, days, limit } = req.query;
+
+  let dimensions: SessionPageDimension[] = SESSION_PAGE_DIMENSIONS;
+  if (dimension !== undefined && dimension !== "") {
+    if (!isSessionPageDimension(dimension)) {
+      return res.status(400).json({
+        error: "dimension must be one of the supported session page dimensions",
+        supported_dimensions: SESSION_PAGE_DIMENSIONS,
+      });
+    }
+    dimensions = [dimension];
+  }
+
+  // Resolve date window.
+  let startDate: Date | undefined;
+  let endDate: Date | undefined;
+  if (days) {
+    const daysNum = parseInt(days as string, 10);
+    if (!Number.isNaN(daysNum)) {
+      startDate = new Date(Date.now() - daysNum * 24 * 60 * 60 * 1000);
+      endDate = new Date();
+    }
+  } else {
+    if (start_date) startDate = new Date(start_date as string);
+    if (end_date) endDate = new Date(end_date as string);
+  }
+
+  const parsedLimit = limit ? parseInt(limit as string, 10) : undefined;
+
+  const { result } = await getSessionPagesWorkflow(req.scope).run({
+    input: {
+      website_id: id,
+      dimensions,
+      start_date: startDate,
+      end_date: endDate,
+      limit: Number.isNaN(parsedLimit as number) ? undefined : parsedLimit,
+    },
+  });
+
+  res.json({
+    website_id: id,
+    period: {
+      start_date: startDate?.toISOString(),
+      end_date: endDate?.toISOString(),
+      days: days ? parseInt(days as string, 10) : undefined,
+    },
+    pages: result,
+  });
+};

--- a/apps/backend/src/workflows/analytics/reports/__tests__/session-pages-lib.unit.spec.ts
+++ b/apps/backend/src/workflows/analytics/reports/__tests__/session-pages-lib.unit.spec.ts
@@ -1,0 +1,138 @@
+import {
+  computeSessionPageBreakdown,
+  isSessionPageDimension,
+  normalizePageValue,
+  SESSION_PAGE_DIMENSIONS,
+  DEFAULT_SESSION_PAGE_LIMIT,
+  MAX_SESSION_PAGE_LIMIT,
+  type SessionPageRow,
+} from "../session-pages-lib";
+
+describe("session-pages-lib (#569 S2)", () => {
+  describe("isSessionPageDimension", () => {
+    it("accepts the two supported dimensions", () => {
+      expect(isSessionPageDimension("entry_page")).toBe(true);
+      expect(isSessionPageDimension("exit_page")).toBe(true);
+      expect(SESSION_PAGE_DIMENSIONS).toEqual(["entry_page", "exit_page"]);
+    });
+
+    it("rejects anything else", () => {
+      expect(isSessionPageDimension("pathname")).toBe(false);
+      expect(isSessionPageDimension("")).toBe(false);
+      expect(isSessionPageDimension(undefined)).toBe(false);
+      expect(isSessionPageDimension(null)).toBe(false);
+      expect(isSessionPageDimension(42)).toBe(false);
+    });
+  });
+
+  describe("normalizePageValue", () => {
+    it("maps null/undefined/empty to the (none) label", () => {
+      expect(normalizePageValue(null)).toBe("(none)");
+      expect(normalizePageValue(undefined)).toBe("(none)");
+      expect(normalizePageValue("")).toBe("(none)");
+    });
+
+    it("stringifies real values verbatim", () => {
+      expect(normalizePageValue("/")).toBe("/");
+      expect(normalizePageValue("/pricing")).toBe("/pricing");
+    });
+  });
+
+  describe("computeSessionPageBreakdown", () => {
+    it("returns a zeroed envelope for empty / nullish input", () => {
+      const expected = {
+        dimension: "entry_page",
+        total_sessions: 0,
+        total_unique_visitors: 0,
+        results: [],
+      };
+      expect(computeSessionPageBreakdown([], "entry_page")).toEqual(expected);
+      expect(computeSessionPageBreakdown(null, "entry_page")).toEqual(expected);
+      expect(computeSessionPageBreakdown(undefined, "entry_page")).toEqual(expected);
+    });
+
+    it("groups sessions by entry_page with counts + percentages", () => {
+      const sessions: SessionPageRow[] = [
+        { entry_page: "/", visitor_id: "v1" },
+        { entry_page: "/", visitor_id: "v2" },
+        { entry_page: "/pricing", visitor_id: "v3" },
+        { entry_page: "/", visitor_id: "v1" }, // repeat visitor in same bucket
+      ];
+      const result = computeSessionPageBreakdown(sessions, "entry_page");
+
+      expect(result.dimension).toBe("entry_page");
+      expect(result.total_sessions).toBe(4);
+      expect(result.total_unique_visitors).toBe(3); // v1, v2, v3
+
+      expect(result.results[0]).toEqual({
+        value: "/",
+        count: 3,
+        unique_visitors: 2, // v1, v2
+        percentage: 75, // 3/4
+      });
+      expect(result.results[1]).toEqual({
+        value: "/pricing",
+        count: 1,
+        unique_visitors: 1,
+        percentage: 25,
+      });
+    });
+
+    it("groups by exit_page and folds null exits into (none)", () => {
+      const sessions: SessionPageRow[] = [
+        { exit_page: "/checkout", visitor_id: "v1" },
+        { exit_page: null, visitor_id: "v2" },
+        { exit_page: "", visitor_id: "v3" },
+      ];
+      const result = computeSessionPageBreakdown(sessions, "exit_page");
+
+      expect(result.dimension).toBe("exit_page");
+      expect(result.total_sessions).toBe(3);
+      // two null/empty exits collapse into one (none) bucket
+      const none = result.results.find((r) => r.value === "(none)");
+      expect(none?.count).toBe(2);
+      const checkout = result.results.find((r) => r.value === "/checkout");
+      expect(checkout?.count).toBe(1);
+    });
+
+    it("sorts by count desc then value asc", () => {
+      const sessions: SessionPageRow[] = [
+        { entry_page: "/b" },
+        { entry_page: "/a" },
+        { entry_page: "/a" },
+        { entry_page: "/c" },
+        { entry_page: "/c" },
+      ];
+      const result = computeSessionPageBreakdown(sessions, "entry_page");
+      // /a and /c both have count 2 -> /a first (value asc); /b count 1 last
+      expect(result.results.map((r) => r.value)).toEqual(["/a", "/c", "/b"]);
+    });
+
+    it("caps the number of buckets to the (clamped) limit", () => {
+      const sessions: SessionPageRow[] = Array.from({ length: 30 }, (_, i) => ({
+        entry_page: `/p${i}`,
+      }));
+      expect(computeSessionPageBreakdown(sessions, "entry_page", 5).results).toHaveLength(5);
+      // 0 / NaN fall back to default
+      expect(
+        computeSessionPageBreakdown(sessions, "entry_page", 0).results
+      ).toHaveLength(Math.min(30, DEFAULT_SESSION_PAGE_LIMIT));
+      // over-max clamps to MAX (more than we have here -> all 30)
+      expect(
+        computeSessionPageBreakdown(sessions, "entry_page", 9999).results.length
+      ).toBeLessThanOrEqual(MAX_SESSION_PAGE_LIMIT);
+    });
+
+    it("counts sessions without a visitor_id but excludes them from unique_visitors", () => {
+      const sessions: SessionPageRow[] = [
+        { entry_page: "/", visitor_id: undefined },
+        { entry_page: "/", visitor_id: null },
+      ];
+      const result = computeSessionPageBreakdown(sessions, "entry_page");
+      expect(result.total_sessions).toBe(2);
+      expect(result.total_unique_visitors).toBe(0);
+      expect(result.results[0].count).toBe(2);
+      expect(result.results[0].unique_visitors).toBe(0);
+    });
+  });
+});

--- a/apps/backend/src/workflows/analytics/reports/get-session-pages.ts
+++ b/apps/backend/src/workflows/analytics/reports/get-session-pages.ts
@@ -1,0 +1,85 @@
+import { createStep, createWorkflow, StepResponse, WorkflowResponse } from "@medusajs/framework/workflows-sdk";
+import { ANALYTICS_MODULE } from "../../../modules/analytics";
+import {
+  computeSessionPageBreakdown,
+  DEFAULT_SESSION_PAGE_LIMIT,
+  SESSION_PAGE_DIMENSIONS,
+  type SessionPageBreakdownResult,
+  type SessionPageDimension,
+  type SessionPageRow,
+} from "./session-pages-lib";
+
+/**
+ * Get Session Pages Breakdown (#569 S2)
+ *
+ * Ranked aggregation of a website's analytics sessions by their entry and/or
+ * exit page, over an optional date range. Complements the events breakdown
+ * (getAnalyticsBreakdownWorkflow) which groups raw events; here we group
+ * sessions so the admin can see "top landing pages" and "top exit pages".
+ *
+ * There is NO website→analytics_session module link, so sessions are resolved
+ * directly off the custom_analytics service (mirrors get-website-analytics-
+ * overview's S1 session fetch). The fetch is best-effort: a missing
+ * service/method or query error degrades to empty (zeroed) breakdowns rather
+ * than throwing.
+ */
+export type GetSessionPagesInput = {
+  website_id: string;
+  start_date?: Date;
+  end_date?: Date;
+  /** Which page dimensions to compute. Defaults to both entry + exit. */
+  dimensions?: SessionPageDimension[];
+  limit?: number;
+};
+
+export type GetSessionPagesResult = {
+  /** Present only for requested dimensions. */
+  entry_page?: SessionPageBreakdownResult;
+  exit_page?: SessionPageBreakdownResult;
+};
+
+export const getSessionPagesStep = createStep(
+  "get-session-pages-step",
+  async (input: GetSessionPagesInput, { container }) => {
+    const dimensions =
+      input.dimensions && input.dimensions.length > 0
+        ? input.dimensions
+        : SESSION_PAGE_DIMENSIONS;
+    const limit = input.limit ?? DEFAULT_SESSION_PAGE_LIMIT;
+
+    let sessions: SessionPageRow[] = [];
+    try {
+      const analyticsService: any = container.resolve(ANALYTICS_MODULE);
+      if (analyticsService?.listAnalyticsSessions) {
+        const filters: any = { website_id: input.website_id };
+        if (input.start_date || input.end_date) {
+          filters.started_at = {};
+          if (input.start_date) filters.started_at.$gte = input.start_date;
+          if (input.end_date) filters.started_at.$lte = input.end_date;
+        }
+        sessions = await analyticsService.listAnalyticsSessions(filters, {
+          select: ["visitor_id", "entry_page", "exit_page"],
+          take: 100000,
+        });
+      }
+    } catch (e) {
+      // keep empty -> zeroed breakdowns
+      sessions = [];
+    }
+
+    const result: GetSessionPagesResult = {};
+    for (const dimension of dimensions) {
+      result[dimension] = computeSessionPageBreakdown(sessions, dimension, limit);
+    }
+
+    return new StepResponse(result);
+  }
+);
+
+export const getSessionPagesWorkflow = createWorkflow(
+  "get-session-pages",
+  (input: GetSessionPagesInput) => {
+    const result = getSessionPagesStep(input);
+    return new WorkflowResponse(result);
+  }
+);

--- a/apps/backend/src/workflows/analytics/reports/session-pages-lib.ts
+++ b/apps/backend/src/workflows/analytics/reports/session-pages-lib.ts
@@ -1,0 +1,125 @@
+/**
+ * Pure aggregation helpers for session entry/exit page breakdown reports
+ * (#569 S2).
+ *
+ * Like `breakdown-lib.ts` (which aggregates raw analytics *events*), these
+ * helpers aggregate analytics *sessions* by their landing (`entry_page`) and
+ * leaving (`exit_page`) pages. They are deliberately framework-free so they can
+ * be unit-tested in isolation (`TEST_TYPE=unit`); the workflow/route layer
+ * fetches the raw sessions (scoped by website + date range) and delegates the
+ * grouping here.
+ *
+ * The result shape mirrors the events breakdown envelope (`BreakdownResult`)
+ * but counts sessions rather than events, so the admin UI can render entry/exit
+ * page panels with the same ranked-bar component.
+ */
+
+/** A page dimension a session can be broken down by. */
+export type SessionPageDimension = "entry_page" | "exit_page";
+
+/** All session page dimensions a report can group by. */
+export const SESSION_PAGE_DIMENSIONS: SessionPageDimension[] = [
+  "entry_page",
+  "exit_page",
+];
+
+/** Minimal shape of an analytics session row this module needs. */
+export type SessionPageRow = {
+  visitor_id?: string | null;
+  entry_page?: string | null;
+  exit_page?: string | null;
+};
+
+export type SessionPageBucket = {
+  /** The page path (never null — see NULL_LABEL). */
+  value: string;
+  /** Number of sessions in this bucket. */
+  count: number;
+  /** Distinct visitor_id count in this bucket. */
+  unique_visitors: number;
+  /** count / total_sessions as an integer percentage (0–100). */
+  percentage: number;
+};
+
+export type SessionPageBreakdownResult = {
+  dimension: SessionPageDimension;
+  total_sessions: number;
+  total_unique_visitors: number;
+  /** Buckets sorted by count desc, then value asc, sliced to `limit`. */
+  results: SessionPageBucket[];
+};
+
+/** Default bucket cap, mirroring the events breakdown default. */
+export const DEFAULT_SESSION_PAGE_LIMIT = 20;
+export const MAX_SESSION_PAGE_LIMIT = 100;
+
+/** Label used when a page value is null/empty (exit_page is nullable). */
+const NULL_LABEL = "(none)";
+
+export function isSessionPageDimension(
+  value: unknown
+): value is SessionPageDimension {
+  return (
+    typeof value === "string" &&
+    (SESSION_PAGE_DIMENSIONS as string[]).includes(value)
+  );
+}
+
+/** Coerce a raw page value to its canonical string form for grouping. */
+export function normalizePageValue(raw: unknown): string {
+  if (raw === null || raw === undefined || raw === "") {
+    return NULL_LABEL;
+  }
+  return String(raw);
+}
+
+/**
+ * Group `sessions` by the chosen page `dimension` and compute count /
+ * unique_visitors / percentage per bucket. Buckets are sorted by count desc
+ * (ties broken by value asc) and capped to `limit` (clamped to
+ * [1, MAX_SESSION_PAGE_LIMIT]).
+ */
+export function computeSessionPageBreakdown(
+  sessions: SessionPageRow[] | null | undefined,
+  dimension: SessionPageDimension,
+  limit: number = DEFAULT_SESSION_PAGE_LIMIT
+): SessionPageBreakdownResult {
+  const rows = Array.isArray(sessions) ? sessions : [];
+  const cappedLimit = Math.max(
+    1,
+    Math.min(MAX_SESSION_PAGE_LIMIT, Math.floor(limit) || DEFAULT_SESSION_PAGE_LIMIT)
+  );
+
+  const buckets = new Map<string, { count: number; visitors: Set<string> }>();
+  const allVisitors = new Set<string>();
+
+  for (const session of rows) {
+    const value = normalizePageValue((session as any)[dimension]);
+    const bucket = buckets.get(value) || { count: 0, visitors: new Set<string>() };
+    bucket.count++;
+    if (session.visitor_id) {
+      bucket.visitors.add(session.visitor_id);
+      allVisitors.add(session.visitor_id);
+    }
+    buckets.set(value, bucket);
+  }
+
+  const total = rows.length;
+
+  const results: SessionPageBucket[] = Array.from(buckets.entries())
+    .map(([value, data]) => ({
+      value,
+      count: data.count,
+      unique_visitors: data.visitors.size,
+      percentage: total > 0 ? Math.round((data.count / total) * 100) : 0,
+    }))
+    .sort((a, b) => b.count - a.count || a.value.localeCompare(b.value))
+    .slice(0, cappedLimit);
+
+  return {
+    dimension,
+    total_sessions: total,
+    total_unique_visitors: allVisitors.size,
+    results,
+  };
+}


### PR DESCRIPTION
## #569 S2 — Session entry/exit page breakdown backend

Second backend slice of **#569 (Analytics dashboard v2, OpenPanel parity)**, follow-up to #559. Off `origin/main`, **independent** (does not touch the S1 file / PR #570).

### What
New `GET /admin/websites/:id/analytics/pages` — ranked aggregation of a website's `analytics_session` rows by **entry page** (landing) and/or **exit page**, over an optional date range. Response mirrors the events-breakdown envelope but counts sessions, so the admin UI can reuse the same ranked-bar component for S2b's entry/exit panels.

```
{
  website_id,
  period: { start_date?, end_date?, days? },
  pages: {
    entry_page?: { dimension, total_sessions, total_unique_visitors, results:[{value,count,unique_visitors,percentage}] },
    exit_page?:  { dimension, total_sessions, total_unique_visitors, results:[...] }
  }
}
```

Query params: `dimension` (`entry_page`|`exit_page`, omit → both, 400 on unknown), `days` (wins over) `start_date`/`end_date`, `limit` (default 20, capped 100).

### How
- **Pure** `src/workflows/analytics/reports/session-pages-lib.ts` — `computeSessionPageBreakdown(sessions, dimension, limit)`: groups, computes count / unique_visitors / percentage, folds null/empty pages into `(none)`, sorts count-desc then value-asc, clamps limit. Mirrors `breakdown-lib.ts`'s shape.
- `get-session-pages.ts` workflow resolves `custom_analytics` + `listAnalyticsSessions` (there is **no** website→analytics_session module link — same approach as the S1 overview fetch); best-effort try/catch → empty/zeroed, never throws.
- Route under `src/api/admin/websites/[id]/analytics/pages/route.ts`.

### Tests
- **10 unit** — `src/workflows/analytics/reports/__tests__/session-pages-lib.unit.spec.ts` (`TEST_TYPE=unit`).
- **4 integration** — `integration-tests/http/analytics/website-session-pages.spec.ts` (per-file shared DB).

### Verify
```
cd apps/backend
TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules npx jest --testPathPattern=session-pages-lib.unit
pnpm test:integration:http:shared -- integration-tests/http/analytics/website-session-pages.spec.ts
```

### Notes
- No migration (additive read endpoint over existing model columns).
- No auto-merge. Independent of #570 (S1). UI render slices (S2b etc.) stack after #566.

🤖 Generated with [Claude Code](https://claude.com/claude-code)