### PR TITLE
feat(analytics): outbound link_out capture + top-outbound-links endpoint (#569 S5a)

### DIFF
--- a/apps/analytics/src/analytics.js
+++ b/apps/analytics/src/analytics.js
@@ -543,9 +543,12 @@
       try {
         const url = new URL(href, window.location.origin);
         if (url.hostname !== window.location.hostname) {
-          trackEvent('outbound_click', {
-            url: href,
-            text: link.textContent?.substring(0, 100),
+          // Track external link clicks as a `link_out` custom event. The full
+          // resolved destination URL is stored under metadata.href so the
+          // backend can aggregate top outbound links (#569 S5a).
+          trackEvent('link_out', {
+            href: url.href,
+            text: link.textContent ? link.textContent.substring(0, 100) : undefined,
             page: window.location.pathname,
           });
         }

--- a/apps/backend/integration-tests/http/analytics/website-outbound-links.spec.ts
+++ b/apps/backend/integration-tests/http/analytics/website-outbound-links.spec.ts
@@ -1,0 +1,113 @@
+import { setupSharedTestSuite } from "../shared-test-setup";
+import { createAdminUser, getAuthHeaders } from "../../helpers/create-admin-user";
+
+jest.setTimeout(100000);
+
+setupSharedTestSuite(({ api, getContainer }) => {
+  describe("GET /admin/websites/:id/analytics/outbound — outbound links (#569 S5a)", () => {
+    let websiteId: string;
+    let adminHeaders: { headers: Record<string, string> };
+
+    beforeAll(async () => {
+      const container = await getContainer();
+      await createAdminUser(container);
+      adminHeaders = await getAuthHeaders(api);
+    });
+
+    beforeEach(async () => {
+      const container = await getContainer();
+      const websiteService = container.resolve("websites");
+      const website = await websiteService.createWebsites({
+        domain: `outbound-${Date.now()}.example.com`,
+        name: "Outbound Links Site",
+        status: "Active",
+        primary_language: "en",
+      });
+      websiteId = website.id;
+
+      const analyticsService = container.resolve("custom_analytics");
+      const now = new Date();
+
+      const mk = (visitor: string, href: string | null) => ({
+        website_id: websiteId,
+        event_type: "custom_event" as const,
+        event_name: "link_out",
+        pathname: "/",
+        visitor_id: visitor,
+        session_id: `sess_${visitor}`,
+        timestamp: now,
+        metadata: href ? { href } : null,
+      });
+
+      await analyticsService.createAnalyticsEvents([
+        mk("v1", "https://partner.example.com/a"),
+        mk("v2", "https://partner.example.com/a"),
+        mk("v1", "https://partner.example.com/a"),
+        mk("v3", "https://other.example.com/b"),
+        // A non-link_out event must be ignored entirely.
+        {
+          website_id: websiteId,
+          event_type: "pageview" as const,
+          pathname: "/",
+          visitor_id: "v9",
+          session_id: "sess_v9",
+          timestamp: now,
+        },
+      ]);
+    });
+
+    it("returns ranked outbound links grouped by href", async () => {
+      const res = await api.get(
+        `/admin/websites/${websiteId}/analytics/outbound`,
+        adminHeaders
+      );
+      expect(res.status).toBe(200);
+      expect(res.data.website_id).toBe(websiteId);
+
+      const ol = res.data.outbound_links;
+      // 4 link_out events; the pageview is excluded
+      expect(ol.total_events).toBe(4);
+      expect(ol.total_unique_visitors).toBe(3); // v1,v2,v3
+
+      expect(ol.results[0]).toMatchObject({
+        value: "https://partner.example.com/a",
+        count: 3,
+        unique_visitors: 2,
+        percentage: 75,
+      });
+      expect(ol.results[1]).toMatchObject({
+        value: "https://other.example.com/b",
+        count: 1,
+      });
+    });
+
+    it("respects the limit query param", async () => {
+      const res = await api.get(
+        `/admin/websites/${websiteId}/analytics/outbound?limit=1`,
+        adminHeaders
+      );
+      expect(res.status).toBe(200);
+      expect(res.data.outbound_links.results).toHaveLength(1);
+      expect(res.data.outbound_links.total_events).toBe(4);
+    });
+
+    it("returns a zeroed result for a website with no outbound events", async () => {
+      const container = await getContainer();
+      const websiteService = container.resolve("websites");
+      const empty = await websiteService.createWebsites({
+        domain: `outbound-empty-${Date.now()}.example.com`,
+        name: "Empty Outbound Site",
+        status: "Active",
+        primary_language: "en",
+      });
+
+      const res = await api.get(
+        `/admin/websites/${empty.id}/analytics/outbound`,
+        adminHeaders
+      );
+      expect(res.status).toBe(200);
+      expect(res.data.outbound_links.total_events).toBe(0);
+      expect(res.data.outbound_links.results).toEqual([]);
+    });
+  });
+});

--- a/apps/backend/src/api/admin/websites/[id]/analytics/outbound/route.ts
+++ b/apps/backend/src/api/admin/websites/[id]/analytics/outbound/route.ts
@@ -1,0 +1,62 @@
+/**
+ * GET /admin/websites/:id/analytics/outbound
+ *
+ * Ranked breakdown of a website's outbound link clicks (#569 S5a). The client
+ * tracks external-host `<a>` clicks as `link_out` custom events carrying the
+ * destination URL under `metadata.href`; this groups them by href.
+ *
+ * Query parameters
+ * - days (number, optional): rolling window; takes precedence over
+ *   start_date/end_date when present.
+ * - start_date / end_date (ISO string, optional): explicit window.
+ * - limit (number, optional): max buckets (default 20, capped 100).
+ *
+ * Response (200)
+ * {
+ *   website_id,
+ *   period: { start_date?, end_date?, days? },
+ *   outbound_links: { total_events, total_unique_visitors, results: [{ value, count, unique_visitors, percentage }] }
+ * }
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework";
+import { getOutboundLinksWorkflow } from "../../../../../../workflows/analytics/reports/get-outbound-links";
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params;
+  const { start_date, end_date, days, limit } = req.query;
+
+  // Resolve date window.
+  let startDate: Date | undefined;
+  let endDate: Date | undefined;
+  if (days) {
+    const daysNum = parseInt(days as string, 10);
+    if (!Number.isNaN(daysNum)) {
+      startDate = new Date(Date.now() - daysNum * 24 * 60 * 60 * 1000);
+      endDate = new Date();
+    }
+  } else {
+    if (start_date) startDate = new Date(start_date as string);
+    if (end_date) endDate = new Date(end_date as string);
+  }
+
+  const parsedLimit = limit ? parseInt(limit as string, 10) : undefined;
+
+  const { result } = await getOutboundLinksWorkflow(req.scope).run({
+    input: {
+      website_id: id,
+      start_date: startDate,
+      end_date: endDate,
+      limit: Number.isNaN(parsedLimit as number) ? undefined : parsedLimit,
+    },
+  });
+
+  res.json({
+    website_id: id,
+    period: {
+      start_date: startDate?.toISOString(),
+      end_date: endDate?.toISOString(),
+      days: days ? parseInt(days as string, 10) : undefined,
+    },
+    outbound_links: result,
+  });
+};

--- a/apps/backend/src/workflows/analytics/reports/__tests__/outbound-links-lib.unit.spec.ts
+++ b/apps/backend/src/workflows/analytics/reports/__tests__/outbound-links-lib.unit.spec.ts
@@ -1,0 +1,133 @@
+import {
+  computeOutboundLinks,
+  extractHref,
+  DEFAULT_OUTBOUND_LINKS_LIMIT,
+  MAX_OUTBOUND_LINKS_LIMIT,
+  type OutboundLinkEventRow,
+} from "../outbound-links-lib";
+
+describe("outbound-links-lib (#569 S5a)", () => {
+  describe("extractHref", () => {
+    it("returns the href string from metadata", () => {
+      expect(extractHref({ href: "https://x.com/" })).toBe("https://x.com/");
+    });
+
+    it("coerces non-string href to string", () => {
+      expect(extractHref({ href: 123 })).toBe("123");
+    });
+
+    it("folds null/undefined/empty metadata into (none)", () => {
+      expect(extractHref(null)).toBe("(none)");
+      expect(extractHref(undefined)).toBe("(none)");
+      expect(extractHref("not-an-object")).toBe("(none)");
+    });
+
+    it("folds missing/null/empty href into (none)", () => {
+      expect(extractHref({})).toBe("(none)");
+      expect(extractHref({ href: null })).toBe("(none)");
+      expect(extractHref({ href: "" })).toBe("(none)");
+    });
+  });
+
+  describe("computeOutboundLinks", () => {
+    const events: OutboundLinkEventRow[] = [
+      { visitor_id: "v1", metadata: { href: "https://a.com/" } },
+      { visitor_id: "v2", metadata: { href: "https://a.com/" } },
+      { visitor_id: "v1", metadata: { href: "https://a.com/" } },
+      { visitor_id: "v3", metadata: { href: "https://b.com/" } },
+      { visitor_id: "v4", metadata: null },
+    ];
+
+    it("groups by href with counts, unique visitors, and percentage", () => {
+      const res = computeOutboundLinks(events);
+      expect(res.total_events).toBe(5);
+      // v1,v2,v3,v4 distinct => 4 (v1 appears twice)
+      expect(res.total_unique_visitors).toBe(4);
+
+      const top = res.results[0];
+      expect(top.value).toBe("https://a.com/");
+      expect(top.count).toBe(3);
+      expect(top.unique_visitors).toBe(2); // v1 + v2
+      expect(top.percentage).toBe(60); // 3/5
+    });
+
+    it("folds events without a usable href into (none)", () => {
+      const res = computeOutboundLinks(events);
+      const none = res.results.find((r) => r.value === "(none)");
+      expect(none).toBeDefined();
+      expect(none!.count).toBe(1);
+    });
+
+    it("sorts by count desc then value asc", () => {
+      const res = computeOutboundLinks([
+        { visitor_id: "v1", metadata: { href: "https://z.com/" } },
+        { visitor_id: "v2", metadata: { href: "https://a.com/" } },
+        { visitor_id: "v3", metadata: { href: "https://a.com/" } },
+      ]);
+      expect(res.results.map((r) => r.value)).toEqual([
+        "https://a.com/",
+        "https://z.com/",
+      ]);
+    });
+
+    it("returns zeroed result for empty/nullish input", () => {
+      for (const input of [[], null, undefined] as any[]) {
+        const res = computeOutboundLinks(input);
+        expect(res.total_events).toBe(0);
+        expect(res.total_unique_visitors).toBe(0);
+        expect(res.results).toEqual([]);
+      }
+    });
+
+    it("counts events with no visitor_id toward total but not unique", () => {
+      const res = computeOutboundLinks([
+        { metadata: { href: "https://a.com/" } },
+        { metadata: { href: "https://a.com/" } },
+      ]);
+      expect(res.total_events).toBe(2);
+      expect(res.total_unique_visitors).toBe(0);
+      expect(res.results[0].unique_visitors).toBe(0);
+      expect(res.results[0].count).toBe(2);
+    });
+
+    it("respects an explicit limit", () => {
+      const many: OutboundLinkEventRow[] = Array.from({ length: 5 }, (_, i) => ({
+        visitor_id: `v${i}`,
+        metadata: { href: `https://site-${i}.com/` },
+      }));
+      const res = computeOutboundLinks(many, 2);
+      expect(res.results).toHaveLength(2);
+      expect(res.total_events).toBe(5);
+    });
+
+    it("treats limit 0 as the default (falsy) and clamps negatives to 1", () => {
+      const many: OutboundLinkEventRow[] = Array.from({ length: 3 }, (_, i) => ({
+        visitor_id: `v${i}`,
+        metadata: { href: `https://site-${i}.com/` },
+      }));
+      // 0 is falsy -> falls back to DEFAULT (mirrors session-pages-lib)
+      expect(computeOutboundLinks(many, 0).results).toHaveLength(3);
+      // negative is truthy -> clamped up to 1
+      expect(computeOutboundLinks(many, -5).results).toHaveLength(1);
+    });
+
+    it("clamps limit above the max down to the max", () => {
+      const res = computeOutboundLinks(
+        [{ visitor_id: "v1", metadata: { href: "https://a.com/" } }],
+        MAX_OUTBOUND_LINKS_LIMIT + 50
+      );
+      // only one bucket, but the cap must not exceed the max
+      expect(res.results.length).toBeLessThanOrEqual(MAX_OUTBOUND_LINKS_LIMIT);
+    });
+
+    it("defaults the limit when given a non-finite value", () => {
+      expect(DEFAULT_OUTBOUND_LINKS_LIMIT).toBe(20);
+      const many: OutboundLinkEventRow[] = Array.from({ length: 25 }, (_, i) => ({
+        visitor_id: `v${i}`,
+        metadata: { href: `https://site-${String(i).padStart(2, "0")}.com/` },
+      }));
+      const res = computeOutboundLinks(many, NaN);
+      expect(res.results).toHaveLength(DEFAULT_OUTBOUND_LINKS_LIMIT);
+    });
+  });
+});

--- a/apps/backend/src/workflows/analytics/reports/get-outbound-links.ts
+++ b/apps/backend/src/workflows/analytics/reports/get-outbound-links.ts
@@ -1,0 +1,61 @@
+import { createStep, createWorkflow, StepResponse, WorkflowResponse } from "@medusajs/framework/workflows-sdk";
+import { ANALYTICS_MODULE } from "../../../modules/analytics";
+import {
+  computeOutboundLinks,
+  DEFAULT_OUTBOUND_LINKS_LIMIT,
+  type OutboundLinkEventRow,
+  type OutboundLinksResult,
+} from "./outbound-links-lib";
+
+/**
+ * Get Outbound Links (#569 S5a)
+ *
+ * Ranked aggregation of a website's `link_out` custom events (external link
+ * clicks) by their destination URL (`metadata.href`), over an optional date
+ * range. The client (`apps/analytics/src/analytics.js`) emits these events.
+ *
+ * Events are resolved directly off the custom_analytics service (mirrors
+ * get-analytics-breakdown's event fetch), scoped to `event_name = "link_out"`.
+ */
+export type GetOutboundLinksInput = {
+  website_id: string;
+  start_date?: Date;
+  end_date?: Date;
+  limit?: number;
+};
+
+export const getOutboundLinksStep = createStep(
+  "get-outbound-links-step",
+  async (input: GetOutboundLinksInput, { container }) => {
+    const analyticsService = container.resolve(ANALYTICS_MODULE) as any;
+
+    const filters: any = {
+      website_id: input.website_id,
+      event_name: "link_out",
+    };
+    if (input.start_date || input.end_date) {
+      filters.timestamp = {};
+      if (input.start_date) filters.timestamp.$gte = input.start_date;
+      if (input.end_date) filters.timestamp.$lte = input.end_date;
+    }
+
+    const [events] = await analyticsService.listAndCountAnalyticsEvents(filters, {
+      select: ["visitor_id", "metadata"],
+    });
+
+    const result: OutboundLinksResult = computeOutboundLinks(
+      events as OutboundLinkEventRow[],
+      input.limit ?? DEFAULT_OUTBOUND_LINKS_LIMIT
+    );
+
+    return new StepResponse(result);
+  }
+);
+
+export const getOutboundLinksWorkflow = createWorkflow(
+  "get-outbound-links",
+  (input: GetOutboundLinksInput) => {
+    const result = getOutboundLinksStep(input);
+    return new WorkflowResponse(result);
+  }
+);

--- a/apps/backend/src/workflows/analytics/reports/outbound-links-lib.ts
+++ b/apps/backend/src/workflows/analytics/reports/outbound-links-lib.ts
@@ -1,0 +1,109 @@
+/**
+ * Pure aggregation helpers for the top outbound-links report (#569 S5a).
+ *
+ * The client (`apps/analytics/src/analytics.js`) emits a `link_out` custom event
+ * whenever a visitor clicks an external-host `<a>`, carrying the resolved
+ * destination URL under `metadata.href`. These helpers group those events by
+ * `metadata.href` so the admin can render a "top outbound links" panel.
+ *
+ * Like `breakdown-lib.ts` / `session-pages-lib.ts` these are deliberately
+ * framework-free so they can be unit-tested in isolation (`TEST_TYPE=unit`);
+ * the workflow/route layer fetches the raw `link_out` events (scoped by website
+ * + date range) and delegates the grouping here. The result shape mirrors the
+ * breakdown envelope but counts events.
+ */
+
+/** Minimal shape of a `link_out` analytics event this module needs. */
+export type OutboundLinkEventRow = {
+  visitor_id?: string | null;
+  metadata?: Record<string, any> | null;
+};
+
+export type OutboundLinkBucket = {
+  /** The outbound destination URL (never null — see NULL_LABEL). */
+  value: string;
+  /** Number of link_out events to this href. */
+  count: number;
+  /** Distinct visitor_id count for this href. */
+  unique_visitors: number;
+  /** count / total_events as an integer percentage (0–100). */
+  percentage: number;
+};
+
+export type OutboundLinksResult = {
+  total_events: number;
+  total_unique_visitors: number;
+  /** Buckets sorted by count desc, then value asc, sliced to `limit`. */
+  results: OutboundLinkBucket[];
+};
+
+/** Default bucket cap, mirroring the events breakdown default. */
+export const DEFAULT_OUTBOUND_LINKS_LIMIT = 20;
+export const MAX_OUTBOUND_LINKS_LIMIT = 100;
+
+/** Label used when an event has no usable href in metadata. */
+const NULL_LABEL = "(none)";
+
+/** Pull the canonical href string out of an event's metadata blob. */
+export function extractHref(metadata: unknown): string {
+  if (!metadata || typeof metadata !== "object") {
+    return NULL_LABEL;
+  }
+  const raw = (metadata as Record<string, any>).href;
+  if (raw === null || raw === undefined || raw === "") {
+    return NULL_LABEL;
+  }
+  return String(raw);
+}
+
+/**
+ * Group `events` by their outbound `metadata.href` and compute count /
+ * unique_visitors / percentage per bucket. Buckets are sorted by count desc
+ * (ties broken by value asc) and capped to `limit` (clamped to
+ * [1, MAX_OUTBOUND_LINKS_LIMIT]).
+ */
+export function computeOutboundLinks(
+  events: OutboundLinkEventRow[] | null | undefined,
+  limit: number = DEFAULT_OUTBOUND_LINKS_LIMIT
+): OutboundLinksResult {
+  const rows = Array.isArray(events) ? events : [];
+  const cappedLimit = Math.max(
+    1,
+    Math.min(
+      MAX_OUTBOUND_LINKS_LIMIT,
+      Math.floor(limit) || DEFAULT_OUTBOUND_LINKS_LIMIT
+    )
+  );
+
+  const buckets = new Map<string, { count: number; visitors: Set<string> }>();
+  const allVisitors = new Set<string>();
+
+  for (const event of rows) {
+    const value = extractHref(event?.metadata);
+    const bucket = buckets.get(value) || { count: 0, visitors: new Set<string>() };
+    bucket.count++;
+    if (event?.visitor_id) {
+      bucket.visitors.add(event.visitor_id);
+      allVisitors.add(event.visitor_id);
+    }
+    buckets.set(value, bucket);
+  }
+
+  const total = rows.length;
+
+  const results: OutboundLinkBucket[] = Array.from(buckets.entries())
+    .map(([value, data]) => ({
+      value,
+      count: data.count,
+      unique_visitors: data.visitors.size,
+      percentage: total > 0 ? Math.round((data.count / total) * 100) : 0,
+    }))
+    .sort((a, b) => b.count - a.count || a.value.localeCompare(b.value))
+    .slice(0, cappedLimit);
+
+  return {
+    total_events: total,
+    total_unique_visitors: allVisitors.size,
+    results,
+  };
+}


### PR DESCRIPTION
## #569 S5a — Outbound link capture (client + backend)

Daemon BUILD chunk 3/5 on **#569** (Analytics dashboard v2, OpenPanel parity). Off `origin/main`, **independent** of #570 (S1) / #571 (S2).

### Client (`apps/analytics/src/analytics.js`)
External-host `<a>` clicks now emit a **`link_out`** custom event carrying the resolved absolute destination URL under `metadata.href` (replaces the previously-unused `outbound_click`/`{url}` shape — no backend consumer existed). `analytics.min.js` is a gitignored CDN build artifact and is **not** committed.

### Backend
New **`GET /admin/websites/:id/analytics/outbound`** — ranks `link_out` events by `metadata.href`:
- `{ total_events, total_unique_visitors, results: [{ value, count, unique_visitors, percentage }] }`
- Window: `days` (wins) | `start_date`&`end_date`; `limit` (default 20, capped 100).
- Pure `reports/outbound-links-lib.ts` (`computeOutboundLinks`/`extractHref`; null/empty href → `(none)`; sort count-desc then value-asc) + `reports/get-outbound-links.ts` workflow (fetches `event_name=link_out` via `custom_analytics` `listAndCountAnalyticsEvents`) + route.
- Additive read endpoint, **no migration**.

### Tests
- **13 unit** `reports/__tests__/outbound-links-lib.unit.spec.ts` (`TEST_TYPE=unit`)
- **3 integration** `integration-tests/http/analytics/website-outbound-links.spec.ts` (verifies grouping, limit, non-`link_out` exclusion, empty site)

Verify:
```
cd apps/backend && TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules npx jest --testPathPattern=outbound-links-lib.unit
pnpm test:integration:http:shared -- integration-tests/http/analytics/website-outbound-links.spec.ts
```

Tracker #352 · follows #559. **Do not merge — human review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)