### PR TITLE
feat(analytics): full-URL referrer breakdown dimension (#569 S6)

### DIFF
--- a/apps/backend/integration-tests/http/analytics/analytics-breakdown.spec.ts
+++ b/apps/backend/integration-tests/http/analytics/analytics-breakdown.spec.ts
@@ -29,11 +29,11 @@ setupSharedTestSuite(({ api, getContainer }) => {
       const analyticsService = container.resolve("custom_analytics");
       const now = new Date();
       const rows = [
-        { country: "IN", device_type: "mobile", pathname: "/home", visitor_id: "v1" },
-        { country: "IN", device_type: "desktop", pathname: "/home", visitor_id: "v2" },
-        { country: "US", device_type: "desktop", pathname: "/about", visitor_id: "v3" },
-        { country: "US", device_type: "mobile", pathname: "/home", visitor_id: "v3" },
-        { country: null, device_type: "unknown", pathname: "/404", visitor_id: "v4" },
+        { country: "IN", device_type: "mobile", pathname: "/home", visitor_id: "v1", referrer: "https://google.com/search?q=a" },
+        { country: "IN", device_type: "desktop", pathname: "/home", visitor_id: "v2", referrer: "https://google.com/search?q=a" },
+        { country: "US", device_type: "desktop", pathname: "/about", visitor_id: "v3", referrer: "https://t.co/xyz" },
+        { country: "US", device_type: "mobile", pathname: "/home", visitor_id: "v3", referrer: null },
+        { country: null, device_type: "unknown", pathname: "/404", visitor_id: "v4", referrer: null },
       ];
       await analyticsService.createAnalyticsEvents(
         rows.map((r, i) => ({
@@ -44,6 +44,7 @@ setupSharedTestSuite(({ api, getContainer }) => {
           session_id: `s${i}`,
           country: r.country,
           device_type: r.device_type,
+          referrer: r.referrer,
           timestamp: now,
         }))
       );
@@ -110,6 +111,38 @@ setupSharedTestSuite(({ api, getContainer }) => {
       );
       expect(byValue["IN"]).toBe(1);
       expect(byValue["US"]).toBe(1);
+    });
+
+    it("breaks down by full referrer URL, folding null into 'direct' (#569 S6)", async () => {
+      const res = await api.get(
+        `/admin/analytics-events/breakdown?website_id=${websiteId}&dimension=referrer`,
+        adminHeaders
+      );
+      expect(res.status).toBe(200);
+      expect(res.data.dimension).toBe("referrer");
+      const byValue = Object.fromEntries(
+        res.data.breakdown.results.map((r: any) => [r.value, r])
+      );
+      expect(byValue["https://google.com/search?q=a"].count).toBe(2);
+      expect(byValue["https://google.com/search?q=a"].unique_visitors).toBe(2);
+      expect(byValue["https://t.co/xyz"].count).toBe(1);
+      // null referrer folds under "direct"
+      expect(byValue["direct"].count).toBe(2);
+    });
+
+    it("filters by full referrer URL (#569 S6)", async () => {
+      const res = await api.get(
+        `/admin/analytics-events/breakdown?website_id=${websiteId}&dimension=country&referrer=${encodeURIComponent(
+          "https://google.com/search?q=a"
+        )}`,
+        adminHeaders
+      );
+      expect(res.status).toBe(200);
+      expect(res.data.filters.referrer).toBe("https://google.com/search?q=a");
+      expect(res.data.breakdown.total_events).toBe(2);
+      expect(
+        res.data.breakdown.results.every((r: any) => r.value === "IN")
+      ).toBe(true);
     });
 
     it("respects the limit parameter", async () => {

--- a/apps/backend/src/admin/hooks/api/__tests__/analytics-breakdown-query.unit.spec.ts
+++ b/apps/backend/src/admin/hooks/api/__tests__/analytics-breakdown-query.unit.spec.ts
@@ -81,6 +81,19 @@ describe("buildBreakdownQuery", () => {
     expect(q.days).toBeUndefined();
   });
 
+  it("supports the full-URL referrer dimension and filter", () => {
+    expect(BREAKDOWN_DIMENSIONS).toContain("referrer");
+    const q = parse(
+      buildBreakdownQuery({
+        website_id: "web_1",
+        dimension: "referrer",
+        filters: { referrer: "https://t.co/abc" },
+      })
+    );
+    expect(q.dimension).toBe("referrer");
+    expect(q.referrer).toBe("https://t.co/abc");
+  });
+
   it("appends recognized composable equality filters", () => {
     const q = parse(
       buildBreakdownQuery({

--- a/apps/backend/src/admin/hooks/api/analytics-breakdown-query.ts
+++ b/apps/backend/src/admin/hooks/api/analytics-breakdown-query.ts
@@ -19,6 +19,7 @@ export type BreakdownDimension =
   | "browser"
   | "os"
   | "referrer_source"
+  | "referrer"
   | "utm_source"
   | "utm_medium"
   | "utm_campaign"
@@ -36,6 +37,7 @@ export const BREAKDOWN_DIMENSIONS: BreakdownDimension[] = [
   "browser",
   "os",
   "referrer_source",
+  "referrer",
   "utm_source",
   "utm_medium",
   "utm_campaign",

--- a/apps/backend/src/api/admin/analytics-events/breakdown/route.ts
+++ b/apps/backend/src/api/admin/analytics-events/breakdown/route.ts
@@ -7,9 +7,9 @@
  * Query parameters
  * - website_id (string, required): website to report on. 400 if missing.
  * - dimension (string, required): one of BREAKDOWN_DIMENSIONS (country,
- *   device_type, browser, os, referrer_source, utm_source, utm_medium,
- *   utm_campaign, utm_term, utm_content, pathname, is_404, event_type,
- *   event_name). 400 if missing/unknown.
+ *   device_type, browser, os, referrer_source, referrer, utm_source,
+ *   utm_medium, utm_campaign, utm_term, utm_content, pathname, is_404,
+ *   event_type, event_name). 400 if missing/unknown.
  * - days (number, optional): rolling window; takes precedence over
  *   start_date/end_date when present.
  * - start_date / end_date (ISO string, optional): explicit window.

--- a/apps/backend/src/workflows/analytics/reports/__tests__/breakdown-lib.unit.spec.ts
+++ b/apps/backend/src/workflows/analytics/reports/__tests__/breakdown-lib.unit.spec.ts
@@ -45,6 +45,17 @@ describe("normalizeFieldValue", () => {
     expect(normalizeFieldValue("referrer_source", null)).toBe("direct");
   });
 
+  it("maps null/empty referrer (full URL) to 'direct'", () => {
+    expect(normalizeFieldValue("referrer", null)).toBe("direct");
+    expect(normalizeFieldValue("referrer", "")).toBe("direct");
+  });
+
+  it("keeps the full referrer URL verbatim when present", () => {
+    expect(normalizeFieldValue("referrer", "https://t.co/abc?x=1")).toBe(
+      "https://t.co/abc?x=1"
+    );
+  });
+
   it("maps null/empty country to 'unknown'", () => {
     expect(normalizeFieldValue("country", null)).toBe("unknown");
     expect(normalizeFieldValue("country", "")).toBe("unknown");
@@ -139,6 +150,25 @@ describe("computeBreakdown", () => {
     const events = [ev({ referrer_source: null }), ev({ referrer_source: "google" })];
     const out = computeBreakdown(events, "referrer_source");
     expect(out.results.map((r) => r.value).sort()).toEqual(["direct", "google"]);
+  });
+
+  it("breaks down by full referrer URL, folding null into 'direct'", () => {
+    const events = [
+      ev({ referrer: "https://google.com/search?q=a", visitor_id: "a" }),
+      ev({ referrer: "https://google.com/search?q=a", visitor_id: "b" }),
+      ev({ referrer: "https://t.co/xyz", visitor_id: "c" }),
+      ev({ referrer: null, visitor_id: "d" }),
+    ];
+    const out = computeBreakdown(events, "referrer");
+    expect(out.dimension).toBe("referrer");
+    expect(out.total_events).toBe(4);
+
+    const g = out.results.find((r) => r.value === "https://google.com/search?q=a")!;
+    expect(g.count).toBe(2);
+    expect(g.unique_visitors).toBe(2);
+
+    const direct = out.results.find((r) => r.value === "direct")!;
+    expect(direct.count).toBe(1);
   });
 
   it("handles is_404 boolean buckets", () => {

--- a/apps/backend/src/workflows/analytics/reports/breakdown-lib.ts
+++ b/apps/backend/src/workflows/analytics/reports/breakdown-lib.ts
@@ -13,6 +13,7 @@ export type BreakdownDimension =
   | "browser"
   | "os"
   | "referrer_source"
+  | "referrer"
   | "utm_source"
   | "utm_medium"
   | "utm_campaign"
@@ -30,6 +31,7 @@ export const BREAKDOWN_DIMENSIONS: BreakdownDimension[] = [
   "browser",
   "os",
   "referrer_source",
+  "referrer",
   "utm_source",
   "utm_medium",
   "utm_campaign",
@@ -56,6 +58,7 @@ export type AnalyticsEventRow = {
   browser?: string | null;
   os?: string | null;
   referrer_source?: string | null;
+  referrer?: string | null;
   utm_source?: string | null;
   utm_medium?: string | null;
   utm_campaign?: string | null;
@@ -93,6 +96,7 @@ export const MAX_BREAKDOWN_LIMIT = 100;
 /** Labels used when a dimension value is null/empty, per dimension. */
 const NULL_LABELS: Partial<Record<BreakdownDimension, string>> = {
   referrer_source: "direct",
+  referrer: "direct",
   country: "unknown",
   device_type: "unknown",
   event_type: "unknown",

--- a/apps/backend/src/workflows/analytics/reports/get-analytics-breakdown.ts
+++ b/apps/backend/src/workflows/analytics/reports/get-analytics-breakdown.ts
@@ -47,6 +47,7 @@ export const getAnalyticsBreakdownStep = createStep(
         "browser",
         "os",
         "referrer_source",
+        "referrer",
         "utm_source",
         "utm_medium",
         "utm_campaign",


### PR DESCRIPTION
## #569 S6 — Referrer full-URL breakdown dimension

Adds a **`referrer`** dimension to the granular analytics breakdown so the dashboard can group/filter on the **full referrer URL** (distinct from the already-existing parsed `referrer_source`). Null/empty referrers fold into `direct`.

### Changes
**Server**
- `workflows/analytics/reports/breakdown-lib.ts` — `referrer` added to `BreakdownDimension` union, `BREAKDOWN_DIMENSIONS`, `AnalyticsEventRow`, and `NULL_LABELS` (null → `direct`).
- `workflows/analytics/reports/get-analytics-breakdown.ts` — `referrer` added to the event `select[]`.
- `api/admin/analytics-events/breakdown/route.ts` — doc comment only; validation auto-derives from `BREAKDOWN_DIMENSIONS`/`FILTERABLE_FIELDS`, so `referrer` is accepted as both dimension and filter with no logic change.

**Admin mirror**
- `admin/hooks/api/analytics-breakdown-query.ts` — `referrer` added to the union + `BREAKDOWN_DIMENSIONS` to keep the client query builder in sync with the server contract.

### Tests
- Unit (both libs): null/empty referrer → `direct`, full-URL verbatim, and a referrer grouping case. **34 unit green.**
- Integration: full-URL breakdown with null→`direct` fold + referrer equality filter. **`analytics-breakdown.spec.ts` 8/8 green.**

Additive read-path only, no migration. Off `origin/main`, independent of #570/#571/#572.

🤖 Generated with [Claude Code](https://claude.com/claude-code)