### PR TITLE
feat(analytics): #569 S7a — paginated website sessions list endpoint

### DIFF
--- a/apps/backend/integration-tests/http/analytics/website-sessions-list.spec.ts
+++ b/apps/backend/integration-tests/http/analytics/website-sessions-list.spec.ts
@@ -1,0 +1,97 @@
+import { setupSharedTestSuite } from "../shared-test-setup";
+import { createAdminUser, getAuthHeaders } from "../../helpers/create-admin-user";
+
+jest.setTimeout(100000);
+
+setupSharedTestSuite(({ api, getContainer }) => {
+  describe("GET /admin/websites/:id/analytics/sessions (#569 S7a)", () => {
+    let websiteId: string;
+    let adminHeaders: { headers: Record<string, string> };
+
+    beforeAll(async () => {
+      const container = await getContainer();
+      await createAdminUser(container);
+      adminHeaders = await getAuthHeaders(api);
+    });
+
+    beforeEach(async () => {
+      const container = await getContainer();
+      const websiteService = container.resolve("websites");
+      const website = await websiteService.createWebsites({
+        domain: `sessions-${Date.now()}.example.com`,
+        name: "Sessions Test Site",
+        status: "Active",
+        primary_language: "en",
+      });
+      websiteId = website.id;
+
+      const analyticsService = container.resolve("custom_analytics");
+      const base = Date.now();
+      // 5 sessions with increasing pageviews + started_at so ordering is testable.
+      const rows = Array.from({ length: 5 }).map((_, i) => ({
+        website_id: websiteId,
+        session_id: `${websiteId}-s${i}`,
+        visitor_id: `v${i}`,
+        entry_page: `/entry-${i}`,
+        exit_page: `/exit-${i}`,
+        pageviews: i + 1,
+        duration_seconds: (i + 1) * 10,
+        is_bounce: i === 0,
+        country: i % 2 === 0 ? "IN" : "US",
+        started_at: new Date(base + i * 1000),
+        last_activity_at: new Date(base + i * 1000 + 500),
+      }));
+      await analyticsService.createAnalyticsSessions(rows);
+    });
+
+    it("returns sessions with count, defaulting to DESC started_at and limit 20", async () => {
+      const res = await api.get(
+        `/admin/websites/${websiteId}/analytics/sessions`,
+        adminHeaders
+      );
+      expect(res.status).toBe(200);
+      expect(res.data.website_id).toBe(websiteId);
+      expect(res.data.count).toBe(5);
+      expect(res.data.limit).toBe(20);
+      expect(res.data.offset).toBe(0);
+      expect(res.data.sessions).toHaveLength(5);
+      // newest first → highest index (latest started_at) first
+      expect(res.data.sessions[0].session_id).toBe(`${websiteId}-s4`);
+      // projection exposes summary fields
+      expect(res.data.sessions[0]).toHaveProperty("entry_page");
+      expect(res.data.sessions[0]).toHaveProperty("pageviews");
+    });
+
+    it("paginates via limit/offset and reports the full count", async () => {
+      const res = await api.get(
+        `/admin/websites/${websiteId}/analytics/sessions?limit=2&offset=2`,
+        adminHeaders
+      );
+      expect(res.status).toBe(200);
+      expect(res.data.count).toBe(5);
+      expect(res.data.limit).toBe(2);
+      expect(res.data.offset).toBe(2);
+      expect(res.data.sessions).toHaveLength(2);
+    });
+
+    it("orders by a whitelisted column ascending", async () => {
+      const res = await api.get(
+        `/admin/websites/${websiteId}/analytics/sessions?order_by=pageviews&order_dir=ASC`,
+        adminHeaders
+      );
+      expect(res.status).toBe(200);
+      const pvs = res.data.sessions.map((s: any) => s.pageviews);
+      expect(pvs).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it("returns an empty page for an unknown website (best-effort, no throw)", async () => {
+      const res = await api.get(
+        `/admin/websites/web_does_not_exist/analytics/sessions`,
+        adminHeaders
+      );
+      expect(res.status).toBe(200);
+      expect(res.data.count).toBe(0);
+      expect(res.data.sessions).toEqual([]);
+    });
+  });
+});

--- a/apps/backend/src/api/admin/websites/[id]/analytics/sessions/route.ts
+++ b/apps/backend/src/api/admin/websites/[id]/analytics/sessions/route.ts
@@ -1,0 +1,76 @@
+/**
+ * GET /admin/websites/:id/analytics/sessions
+ *
+ * Paginated list of a website's analytics sessions (#569 S7a). Powers the
+ * "Sessions" tab of the analytics dashboard v2.
+ *
+ * Query parameters
+ * - days (number, optional): rolling window over `started_at`; takes precedence
+ *   over start_date/end_date when present.
+ * - start_date / end_date (ISO string, optional): explicit window over
+ *   `started_at`.
+ * - limit (number, optional): page size (default 20, capped 100).
+ * - offset (number, optional): rows to skip (default 0).
+ * - order_by (string, optional): one of started_at | last_activity_at |
+ *   ended_at | duration_seconds | pageviews (default started_at; unknown →
+ *   started_at).
+ * - order_dir (string, optional): ASC | DESC (default DESC).
+ *
+ * Response (200)
+ * {
+ *   website_id,
+ *   period: { start_date?, end_date?, days? },
+ *   limit, offset, count,
+ *   sessions: [ { id, session_id, visitor_id, entry_page, exit_page,
+ *                 pageviews, duration_seconds, is_bounce, referrer,
+ *                 referrer_source, country, device_type, browser, os,
+ *                 utm_*, started_at, ended_at, last_activity_at } ]
+ * }
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework";
+import { getWebsiteSessionsWorkflow } from "../../../../../../workflows/analytics/reports/get-website-sessions";
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params;
+  const { days, start_date, end_date, limit, offset, order_by, order_dir } =
+    req.query as Record<string, string>;
+
+  // Resolve date window — `days` wins over explicit start/end.
+  let startDate: Date | undefined;
+  let endDate: Date | undefined;
+  if (days) {
+    const daysNum = parseInt(days, 10);
+    if (!Number.isNaN(daysNum)) {
+      startDate = new Date(Date.now() - daysNum * 24 * 60 * 60 * 1000);
+      endDate = new Date();
+    }
+  } else {
+    if (start_date) startDate = new Date(start_date);
+    if (end_date) endDate = new Date(end_date);
+  }
+
+  const { result } = await getWebsiteSessionsWorkflow(req.scope).run({
+    input: {
+      website_id: id,
+      start_date: startDate,
+      end_date: endDate,
+      limit,
+      offset,
+      order_by,
+      order_dir,
+    },
+  });
+
+  res.json({
+    website_id: id,
+    period: {
+      start_date: startDate?.toISOString(),
+      end_date: endDate?.toISOString(),
+      days: days ? parseInt(days, 10) : undefined,
+    },
+    limit: result.limit,
+    offset: result.offset,
+    count: result.count,
+    sessions: result.sessions,
+  });
+};

--- a/apps/backend/src/workflows/analytics/reports/__tests__/sessions-list-lib.unit.spec.ts
+++ b/apps/backend/src/workflows/analytics/reports/__tests__/sessions-list-lib.unit.spec.ts
@@ -1,0 +1,112 @@
+import {
+  DEFAULT_SESSION_LIMIT,
+  MAX_SESSION_LIMIT,
+  SESSION_ORDER_FIELDS,
+  SESSION_SELECT,
+  isSessionOrderField,
+  resolveLimit,
+  resolveOffset,
+  resolveOrderDir,
+  resolveSessionListParams,
+} from "../sessions-list-lib";
+
+describe("sessions-list-lib", () => {
+  describe("resolveLimit", () => {
+    it("defaults when missing / non-numeric", () => {
+      expect(resolveLimit(undefined)).toBe(DEFAULT_SESSION_LIMIT);
+      expect(resolveLimit("abc")).toBe(DEFAULT_SESSION_LIMIT);
+      expect(resolveLimit(null)).toBe(DEFAULT_SESSION_LIMIT);
+    });
+
+    it("defaults on zero / negatives", () => {
+      expect(resolveLimit(0)).toBe(DEFAULT_SESSION_LIMIT);
+      expect(resolveLimit(-5)).toBe(DEFAULT_SESSION_LIMIT);
+    });
+
+    it("caps at MAX_SESSION_LIMIT", () => {
+      expect(resolveLimit(500)).toBe(MAX_SESSION_LIMIT);
+      expect(resolveLimit("1000")).toBe(MAX_SESSION_LIMIT);
+    });
+
+    it("passes valid values through and floors", () => {
+      expect(resolveLimit(25)).toBe(25);
+      expect(resolveLimit("50")).toBe(50);
+      expect(resolveLimit(33.9)).toBe(33);
+    });
+  });
+
+  describe("resolveOffset", () => {
+    it("defaults to 0 when missing / invalid / negative", () => {
+      expect(resolveOffset(undefined)).toBe(0);
+      expect(resolveOffset("abc")).toBe(0);
+      expect(resolveOffset(-10)).toBe(0);
+    });
+
+    it("passes positive values through and floors", () => {
+      expect(resolveOffset(40)).toBe(40);
+      expect(resolveOffset("100")).toBe(100);
+      expect(resolveOffset(20.7)).toBe(20);
+    });
+  });
+
+  describe("resolveOrderDir", () => {
+    it("defaults to DESC", () => {
+      expect(resolveOrderDir(undefined)).toBe("DESC");
+      expect(resolveOrderDir("nope")).toBe("DESC");
+      expect(resolveOrderDir("desc")).toBe("DESC");
+    });
+
+    it("recognises ASC case-insensitively", () => {
+      expect(resolveOrderDir("ASC")).toBe("ASC");
+      expect(resolveOrderDir("asc")).toBe("ASC");
+    });
+  });
+
+  describe("isSessionOrderField", () => {
+    it("accepts whitelisted fields only", () => {
+      for (const f of SESSION_ORDER_FIELDS) {
+        expect(isSessionOrderField(f)).toBe(true);
+      }
+      expect(isSessionOrderField("website_id")).toBe(false);
+      expect(isSessionOrderField("")).toBe(false);
+      expect(isSessionOrderField(undefined)).toBe(false);
+    });
+  });
+
+  describe("resolveSessionListParams", () => {
+    it("returns safe defaults for an empty input", () => {
+      expect(resolveSessionListParams()).toEqual({
+        take: DEFAULT_SESSION_LIMIT,
+        skip: 0,
+        order: { started_at: "DESC" },
+      });
+    });
+
+    it("clamps take/skip and whitelists order field + dir", () => {
+      expect(
+        resolveSessionListParams({
+          limit: 999,
+          offset: 60,
+          order_by: "duration_seconds",
+          order_dir: "asc",
+        })
+      ).toEqual({
+        take: MAX_SESSION_LIMIT,
+        skip: 60,
+        order: { duration_seconds: "ASC" },
+      });
+    });
+
+    it("falls back to started_at for an unknown order_by", () => {
+      const { order } = resolveSessionListParams({ order_by: "evil; DROP" });
+      expect(order).toEqual({ started_at: "DESC" });
+    });
+
+    it("never selects sensitive/internal columns", () => {
+      // sanity: the projection only exposes session summary fields
+      expect(SESSION_SELECT).toContain("session_id");
+      expect(SESSION_SELECT).toContain("started_at");
+      expect(SESSION_SELECT).not.toContain("website_id");
+    });
+  });
+});

--- a/apps/backend/src/workflows/analytics/reports/get-website-sessions.ts
+++ b/apps/backend/src/workflows/analytics/reports/get-website-sessions.ts
@@ -1,0 +1,82 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk";
+import { ANALYTICS_MODULE } from "../../../modules/analytics";
+import {
+  resolveSessionListParams,
+  SESSION_SELECT,
+  type SessionListParamsInput,
+} from "./sessions-list-lib";
+
+/**
+ * Get Website Sessions (#569 S7a)
+ *
+ * Paginated list of a website's analytics sessions, ordered by a whitelisted
+ * column. There is NO website→analytics_session module link, so sessions are
+ * fetched directly from the analytics module (`custom_analytics`). The fetch is
+ * best-effort: any error returns an empty page rather than throwing, mirroring
+ * the other session-backed report workflows (S1/S2).
+ */
+export type GetWebsiteSessionsInput = SessionListParamsInput & {
+  website_id: string;
+  start_date?: Date;
+  end_date?: Date;
+};
+
+export type WebsiteSessionsResult = {
+  sessions: any[];
+  count: number;
+  limit: number;
+  offset: number;
+};
+
+export const getWebsiteSessionsStep = createStep(
+  "get-website-sessions-step",
+  async (input: GetWebsiteSessionsInput, { container }) => {
+    const { take, skip, order } = resolveSessionListParams(input);
+
+    const filters: Record<string, any> = { website_id: input.website_id };
+    if (input.start_date || input.end_date) {
+      filters.started_at = {};
+      if (input.start_date) filters.started_at.$gte = input.start_date;
+      if (input.end_date) filters.started_at.$lte = input.end_date;
+    }
+
+    let sessions: any[] = [];
+    let count = 0;
+    try {
+      const analyticsService = container.resolve(ANALYTICS_MODULE) as any;
+      const [rows, total] =
+        await analyticsService.listAndCountAnalyticsSessions(filters as any, {
+          select: SESSION_SELECT as unknown as string[],
+          take,
+          skip,
+          order,
+        } as any);
+      sessions = rows ?? [];
+      count = total ?? 0;
+    } catch (e) {
+      // best-effort — never throw the overview/report surface
+      sessions = [];
+      count = 0;
+    }
+
+    return new StepResponse<WebsiteSessionsResult>({
+      sessions,
+      count,
+      limit: take,
+      offset: skip,
+    });
+  }
+);
+
+export const getWebsiteSessionsWorkflow = createWorkflow(
+  "get-website-sessions",
+  (input: GetWebsiteSessionsInput) => {
+    const result = getWebsiteSessionsStep(input);
+    return new WorkflowResponse(result);
+  }
+);

--- a/apps/backend/src/workflows/analytics/reports/sessions-list-lib.ts
+++ b/apps/backend/src/workflows/analytics/reports/sessions-list-lib.ts
@@ -1,0 +1,110 @@
+/**
+ * Sessions List helpers (#569 S7a)
+ *
+ * Pure, framework-free helpers for the paginated sessions list endpoint
+ * (`GET /admin/websites/:id/analytics/sessions`). Keeping pagination /
+ * ordering sanitisation here makes it unit-testable without booting Medusa.
+ */
+
+export const DEFAULT_SESSION_LIMIT = 20;
+export const MAX_SESSION_LIMIT = 100;
+
+/** Columns a caller may order the sessions list by. */
+export const SESSION_ORDER_FIELDS = [
+  "started_at",
+  "last_activity_at",
+  "ended_at",
+  "duration_seconds",
+  "pageviews",
+] as const;
+
+export type SessionOrderField = (typeof SESSION_ORDER_FIELDS)[number];
+export type SessionOrderDir = "ASC" | "DESC";
+
+/** Columns selected for each returned session row. */
+export const SESSION_SELECT = [
+  "id",
+  "session_id",
+  "visitor_id",
+  "entry_page",
+  "exit_page",
+  "pageviews",
+  "duration_seconds",
+  "is_bounce",
+  "referrer",
+  "referrer_source",
+  "country",
+  "device_type",
+  "browser",
+  "os",
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+  "started_at",
+  "ended_at",
+  "last_activity_at",
+] as const;
+
+export function isSessionOrderField(value: unknown): value is SessionOrderField {
+  return (
+    typeof value === "string" &&
+    (SESSION_ORDER_FIELDS as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Clamp a requested page size into [1, MAX_SESSION_LIMIT].
+ * Missing / non-numeric / <=0 → DEFAULT_SESSION_LIMIT; over the cap → cap.
+ */
+export function resolveLimit(raw: unknown): number {
+  const n = Math.floor(Number(raw));
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_SESSION_LIMIT;
+  return Math.min(n, MAX_SESSION_LIMIT);
+}
+
+/** Clamp a requested offset to a non-negative integer (default 0). */
+export function resolveOffset(raw: unknown): number {
+  const n = Math.floor(Number(raw));
+  if (!Number.isFinite(n) || n <= 0) return 0;
+  return n;
+}
+
+/** Normalise an order direction; default DESC. */
+export function resolveOrderDir(raw: unknown): SessionOrderDir {
+  if (typeof raw === "string" && raw.toUpperCase() === "ASC") return "ASC";
+  return "DESC";
+}
+
+export type SessionListParamsInput = {
+  limit?: unknown;
+  offset?: unknown;
+  order_by?: unknown;
+  order_dir?: unknown;
+};
+
+export type ResolvedSessionListParams = {
+  take: number;
+  skip: number;
+  order: Record<SessionOrderField, SessionOrderDir>;
+};
+
+/**
+ * Resolve raw query params into a safe `listAndCount` options object:
+ * clamped take/skip and a whitelisted single-column order map.
+ */
+export function resolveSessionListParams(
+  input: SessionListParamsInput = {}
+): ResolvedSessionListParams {
+  const field: SessionOrderField = isSessionOrderField(input.order_by)
+    ? input.order_by
+    : "started_at";
+  const dir = resolveOrderDir(input.order_dir);
+
+  return {
+    take: resolveLimit(input.limit),
+    skip: resolveOffset(input.offset),
+    order: { [field]: dir } as Record<SessionOrderField, SessionOrderDir>,
+  };
+}


### PR DESCRIPTION
## #569 S7a — Sessions list endpoint (Analytics dashboard v2)

Adds `GET /admin/websites/:id/analytics/sessions` — a paginated, ordered list of a website's analytics sessions, powering the "Sessions" tab of the dashboard v2 (OpenPanel parity, follow-up to #559 which is live in prod).

### What
- **Pure** `src/workflows/analytics/reports/sessions-list-lib.ts`:
  - `resolveLimit` clamp `[1,100]`, default 20 (zero/negative/NaN → default)
  - `resolveOffset` non-negative, default 0
  - `resolveOrderDir` `ASC|DESC` (case-insensitive), default `DESC`
  - `SESSION_ORDER_FIELDS` whitelist (`started_at|last_activity_at|ended_at|duration_seconds|pageviews`, unknown → `started_at`) — prevents arbitrary-column ordering
  - `SESSION_SELECT` fixed projection (summary fields only; never exposes `website_id`/internal cols)
- **Workflow** `reports/get-website-sessions.ts`: resolves `custom_analytics` + `listAndCountAnalyticsSessions` (there is **no website→analytics_session module link**); best-effort `try/catch` → empty page, mirroring S1/S2.
- **Route** `src/api/admin/websites/[id]/analytics/sessions/route.ts`: resolves date window (`days` wins over `start_date`/`end_date`), returns `{ website_id, period, limit, offset, count, sessions }`.

### Tests
- 13 unit — `reports/__tests__/sessions-list-lib.unit.spec.ts`
- 4 integration — `integration-tests/http/analytics/website-sessions-list.spec.ts` (count/default order, pagination, ASC order, unknown-website best-effort empty)

### Notes
- Additive read endpoint, **no migration**.
- Off `origin/main`, **independent** of #570 (S1) / #571 (S2) / #572 (S5a) / #573 (S6).
- UI render slice (S7b) is Playwright-gated and stacks after #566 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)