### PR TITLE
feat(#576): order cancellation → customer email (slice A)

### DIFF
--- a/apps/backend/integration-tests/helpers/seed-email-templates.ts
+++ b/apps/backend/integration-tests/helpers/seed-email-templates.ts
@@ -38,6 +38,7 @@ const COMMON_EMAIL_TEMPLATES = [
     from: "designs@jaalyantra.com",
   },
   { name: "Order Placed", template_key: "order-placed", subject: "Your order is confirmed", html_content: "<div>Thanks for your order.</div>", from: "orders@jaalyantra.com" },
+  { name: "Order Canceled", template_key: "order-canceled", subject: "Your order has been canceled", html_content: "<div>Hi {{customer.first_name}}, order {{order.id}} was canceled.</div>", from: "orders@jaalyantra.com" },
   { name: "Order Shipment Created", template_key: "order-shipment-created", subject: "Your order has shipped", html_content: "<div>Shipped.</div>", from: "orders@jaalyantra.com" },
   { name: "Order Shipment Delivered", template_key: "order-shipment-delivered", subject: "Your order was delivered", html_content: "<div>Delivered.</div>", from: "orders@jaalyantra.com" },
   { name: "Customer Created", template_key: "customer-created", subject: "Welcome", html_content: "<div>Welcome.</div>", from: "orders@jaalyantra.com" },

--- a/apps/backend/integration-tests/http/order-canceled-customer-email.spec.ts
+++ b/apps/backend/integration-tests/http/order-canceled-customer-email.spec.ts
@@ -1,0 +1,85 @@
+import { Modules } from "@medusajs/framework/utils"
+import type { IOrderModuleService } from "@medusajs/types"
+
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { seedCommonEmailTemplates } from "../helpers/seed-email-templates"
+import { sendOrderCanceledCustomerEmailWorkflow } from "../../src/workflows/email/workflows/send-order-canceled-customer-email"
+import { shouldSendCustomerCancellationEmail } from "../../src/workflows/email/lib/order-canceled-customer-email"
+
+jest.setTimeout(60 * 1000)
+
+/**
+ * #576 slice A — customer order-cancellation email.
+ * The base/local config has no real email provider, so we assert the workflow
+ * compiles + resolves the active `order-canceled` template and runs end-to-end
+ * against a real order, plus exercise the pure skip-decision against live data.
+ */
+setupSharedTestSuite(() => {
+  describe("order.canceled → customer email (#576 slice A)", () => {
+    let adminHeaders: { headers: Record<string, string> }
+
+    beforeEach(async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+
+      // The shared runner truncates between tests, so (re)seed per test.
+      await seedCommonEmailTemplates(api, adminHeaders)
+    })
+
+    async function createOrder(unique: number, email = `cancel-${unique}@jyt.test`) {
+      const container = getSharedTestEnv().getContainer()
+      const orderService = container.resolve(
+        Modules.ORDER
+      ) as IOrderModuleService
+      const order: any = await orderService.createOrders({
+        currency_code: "usd",
+        email,
+        items: [{ title: "Line A", quantity: 1, unit_price: 1000 }],
+      } as any)
+      return order
+    }
+
+    it("has the active order-canceled customer template", async () => {
+      const { api } = getSharedTestEnv()
+      const res = await api.get("/admin/email-templates", adminHeaders)
+      const templates =
+        res.data.email_templates || res.data.emailTemplates || []
+      const tmpl = templates.find((t: any) => t.template_key === "order-canceled")
+      expect(tmpl).toBeDefined()
+      expect(tmpl.is_active).toBe(true)
+    })
+
+    it("runs the customer cancellation workflow against a real order", async () => {
+      const container = getSharedTestEnv().getContainer()
+      const order = await createOrder(Date.now())
+
+      // Resolves the active `order-canceled` template + dispatches the
+      // notification end-to-end. The workflow returns no WorkflowResponse
+      // (mirrors sendOrderConfirmationWorkflow), so completing without throwing
+      // is the success signal.
+      const run = await sendOrderCanceledCustomerEmailWorkflow(container).run({
+        input: { orderId: order.id },
+      })
+      expect(run.errors).toEqual([])
+    })
+
+    it("skips the send when the order has no email", () => {
+      const decision = shouldSendCustomerCancellationEmail({
+        order: { email: null },
+      })
+      expect(decision.send).toBe(false)
+    })
+
+    it("skips the send when no_notification is on the event", async () => {
+      const order = await createOrder(Date.now() + 1)
+      const decision = shouldSendCustomerCancellationEmail({
+        order,
+        eventNoNotification: true,
+      })
+      expect(decision.send).toBe(false)
+      expect(decision.reason).toMatch(/no_notification/)
+    })
+  })
+})

--- a/apps/backend/src/subscribers/order-canceled.ts
+++ b/apps/backend/src/subscribers/order-canceled.ts
@@ -1,13 +1,43 @@
 import { SubscriberArgs, type SubscriberConfig } from "@medusajs/framework"
-import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
-import type { Logger } from "@medusajs/types"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { IOrderModuleService, Logger } from "@medusajs/types"
 import { sendPartnerOrderCanceledWorkflow } from "../workflows/email/workflows/send-partner-order-email"
+import { sendOrderCanceledCustomerEmailWorkflow } from "../workflows/email/workflows/send-order-canceled-customer-email"
+import { shouldSendCustomerCancellationEmail } from "../workflows/email/lib/order-canceled-customer-email"
 
 export default async function orderCanceledHandler({
   event: { data },
   container,
-}: SubscriberArgs<{ id: string }>) {
+}: SubscriberArgs<{ id: string; no_notification?: boolean }>) {
   const logger = container.resolve(ContainerRegistrationKeys.LOGGER) as Logger
+
+  // Notify the customer about the cancellation (#576 slice A).
+  // Honours the same no_notification skip semantics the fulfillment email uses.
+  try {
+    const orderService = container.resolve(Modules.ORDER) as IOrderModuleService
+    const order: any = await orderService.retrieveOrder(data.id, {
+      relations: ["items"],
+    })
+
+    const decision = shouldSendCustomerCancellationEmail({
+      order,
+      eventNoNotification: data.no_notification,
+    })
+
+    if (decision.send) {
+      await sendOrderCanceledCustomerEmailWorkflow(container).run({
+        input: { orderId: data.id },
+      })
+    } else {
+      logger.info(
+        `[order.canceled] Skipped customer cancellation email for order ${data.id}: ${decision.reason}`
+      )
+    }
+  } catch (e: any) {
+    logger.warn(
+      `[order.canceled] Customer notification failed for order ${data.id}: ${e?.message || e}`
+    )
+  }
 
   // Notify the partner about the cancellation
   try {

--- a/apps/backend/src/workflows/email/index.ts
+++ b/apps/backend/src/workflows/email/index.ts
@@ -21,6 +21,7 @@ export * from "./workflows/send-design-assigned-email"
 export * from "./workflows/send-design-status-update-email"
 
 export * from "./workflows/send-partner-order-email"
+export * from "./workflows/send-order-canceled-customer-email"
 export * from "./steps/resolve-partner-from-order"
 
 // Export types

--- a/apps/backend/src/workflows/email/lib/__tests__/order-canceled-customer-email.unit.spec.ts
+++ b/apps/backend/src/workflows/email/lib/__tests__/order-canceled-customer-email.unit.spec.ts
@@ -1,0 +1,74 @@
+import {
+  shouldSendCustomerCancellationEmail,
+  buildOrderCanceledCustomerEmailData,
+} from "../order-canceled-customer-email"
+
+/**
+ * #576 slice A — pure helpers for the customer order-cancellation email.
+ * No container / provider — fast coverage of the send/skip decision and the
+ * Handlebars template-data assembly.
+ */
+describe("shouldSendCustomerCancellationEmail", () => {
+  it("sends to the order email when present and not suppressed", () => {
+    const d = shouldSendCustomerCancellationEmail({
+      order: { email: "buyer@example.com" },
+    })
+    expect(d.send).toBe(true)
+    expect(d.to).toBe("buyer@example.com")
+  })
+
+  it("trims surrounding whitespace from the recipient", () => {
+    const d = shouldSendCustomerCancellationEmail({
+      order: { email: "  buyer@example.com  " },
+    })
+    expect(d.send).toBe(true)
+    expect(d.to).toBe("buyer@example.com")
+  })
+
+  it("skips when the event carries no_notification", () => {
+    const d = shouldSendCustomerCancellationEmail({
+      order: { email: "buyer@example.com" },
+      eventNoNotification: true,
+    })
+    expect(d.send).toBe(false)
+    expect(d.to).toBeUndefined()
+    expect(d.reason).toMatch(/no_notification flag on event/)
+  })
+
+  it("skips when the order metadata sets no_notification", () => {
+    const d = shouldSendCustomerCancellationEmail({
+      order: { email: "buyer@example.com", metadata: { no_notification: true } },
+    })
+    expect(d.send).toBe(false)
+    expect(d.reason).toMatch(/no_notification flag on order metadata/)
+  })
+
+  it("skips when there is no customer email", () => {
+    expect(shouldSendCustomerCancellationEmail({ order: { email: "" } }).send).toBe(false)
+    expect(shouldSendCustomerCancellationEmail({ order: { email: null } }).send).toBe(false)
+    expect(shouldSendCustomerCancellationEmail({ order: null }).send).toBe(false)
+    expect(shouldSendCustomerCancellationEmail({}).reason).toMatch(/no customer email/)
+  })
+
+  it("prioritises the no_notification skip over the missing-email skip", () => {
+    const d = shouldSendCustomerCancellationEmail({
+      order: { email: "" },
+      eventNoNotification: true,
+    })
+    expect(d.reason).toMatch(/no_notification flag on event/)
+  })
+})
+
+describe("buildOrderCanceledCustomerEmailData", () => {
+  it("passes the order through and attaches a customer when customer_id is set", () => {
+    const order = { id: "order_1", customer_id: "cus_1", email: "buyer@example.com" }
+    const d = buildOrderCanceledCustomerEmailData(order)
+    expect(d.order).toBe(order)
+    expect(d.customer).toEqual({ first_name: "Customer" })
+  })
+
+  it("leaves customer null for guest orders (no customer_id)", () => {
+    const d = buildOrderCanceledCustomerEmailData({ id: "order_2" })
+    expect(d.customer).toBeNull()
+  })
+})

--- a/apps/backend/src/workflows/email/lib/order-canceled-customer-email.ts
+++ b/apps/backend/src/workflows/email/lib/order-canceled-customer-email.ts
@@ -1,0 +1,64 @@
+// Pure helpers for the customer "order canceled" email (#576 slice A).
+// Kept side-effect free so the send/skip decision and template-data assembly are
+// unit-testable without booting Medusa or a notification provider.
+
+export interface CustomerCancellationDecisionInput {
+  /** The retrieved order (only the fields that drive the decision). */
+  order?: {
+    email?: string | null
+    metadata?: Record<string, any> | null
+  } | null
+  /** `no_notification` flag carried on the order.canceled event payload, if any. */
+  eventNoNotification?: boolean | null
+}
+
+export interface CustomerCancellationDecision {
+  send: boolean
+  /** Recipient address — only set when `send` is true. */
+  to?: string
+  /** Human-readable reason a send was skipped (for the subscriber log). */
+  reason?: string
+}
+
+/**
+ * Decide whether to send the customer an order-cancellation email.
+ *
+ * Honours the same `no_notification` skip semantics the fulfillment email uses:
+ * an explicit flag on the event payload OR `metadata.no_notification` on the
+ * order suppresses the send. A missing/blank customer email also skips (there is
+ * nobody to mail) rather than throwing.
+ */
+export function shouldSendCustomerCancellationEmail(
+  input: CustomerCancellationDecisionInput
+): CustomerCancellationDecision {
+  if (input.eventNoNotification) {
+    return { send: false, reason: "no_notification flag on event" }
+  }
+
+  const order = input.order
+  if (order?.metadata?.no_notification) {
+    return { send: false, reason: "no_notification flag on order metadata" }
+  }
+
+  const to = (order?.email || "").trim()
+  if (!to) {
+    return { send: false, reason: "order has no customer email" }
+  }
+
+  return { send: true, to }
+}
+
+/**
+ * Assemble the Handlebars data for the `order-canceled` customer template.
+ * Mirrors the order-placed customer send so both share one shape:
+ * `{ order, customer }`.
+ */
+export function buildOrderCanceledCustomerEmailData(order: {
+  customer_id?: string | null
+  [key: string]: any
+}): { order: any; customer: { first_name: string } | null } {
+  return {
+    order,
+    customer: order?.customer_id ? { first_name: "Customer" } : null,
+  }
+}

--- a/apps/backend/src/workflows/email/workflows/send-order-canceled-customer-email.ts
+++ b/apps/backend/src/workflows/email/workflows/send-order-canceled-customer-email.ts
@@ -1,0 +1,49 @@
+import { createWorkflow, createStep, StepResponse, transform } from "@medusajs/framework/workflows-sdk"
+import { Modules } from "@medusajs/framework/utils"
+import type { IOrderModuleService } from "@medusajs/types"
+import { sendNotificationEmailStep } from "../steps/send-notification-email"
+import { fetchEmailTemplateStep } from "../steps/fetch-email-template"
+import { buildOrderCanceledCustomerEmailData } from "../lib/order-canceled-customer-email"
+
+const retrieveOrderStep = createStep(
+  { name: "retrieve-order-for-cancellation", store: true },
+  async ({ orderId }: { orderId: string }, { container }) => {
+    const orderService = container.resolve(Modules.ORDER) as IOrderModuleService
+    const order = await orderService.retrieveOrder(orderId, {
+      relations: ["items"],
+    })
+    return new StepResponse(order)
+  }
+)
+
+/**
+ * Send the CUSTOMER an order-cancellation email (#576 slice A).
+ * Mirrors `sendOrderConfirmationWorkflow` but uses the `order-canceled` DB
+ * template (active in prod) on the `email` channel (Resend). The send/skip
+ * decision lives in the subscriber via `shouldSendCustomerCancellationEmail`;
+ * this workflow assumes it should send.
+ */
+export const sendOrderCanceledCustomerEmailWorkflow = createWorkflow(
+  { name: "send-order-canceled-customer-email", store: true },
+  (input: { orderId: string }) => {
+    const order = retrieveOrderStep(input)
+
+    const emailData = transform({ order }, (d) =>
+      buildOrderCanceledCustomerEmailData(d.order)
+    )
+
+    const templateData = fetchEmailTemplateStep({
+      templateKey: "order-canceled",
+      data: emailData as unknown as Record<string, any>,
+    })
+
+    const emailWithTemplate = transform({ order, emailData, templateData }, (d) => ({
+      to: d.order.email || "customer@example.com",
+      template: "order-canceled",
+      data: d.emailData,
+      templateData: d.templateData,
+    }))
+
+    sendNotificationEmailStep(emailWithTemplate as any)
+  }
+)


### PR DESCRIPTION
Closes the first of the 3 decision-gated email-touchpoint gaps from the #332 audit (#576 slice **A**).

## What
`order.canceled` previously emailed **only the partner**. This adds the **customer** order-cancellation email using the **`order-canceled`** DB template (already **active in prod**) on the `email` channel (Resend), mirroring the order-placed customer send.

## Changes
- **`lib/order-canceled-customer-email.ts`** (pure, unit-tested):
  - `shouldSendCustomerCancellationEmail` — honours the same `no_notification` skip semantics the fulfillment email uses (event payload flag **and** `order.metadata.no_notification`); skips when the order has no customer email (never throws).
  - `buildOrderCanceledCustomerEmailData` — `{ order, customer }` shape mirroring order-placed.
- **`workflows/send-order-canceled-customer-email.ts`** — mirrors `sendOrderConfirmationWorkflow`, template key `order-canceled`.
- **`subscribers/order-canceled.ts`** — best-effort customer send (decision via the pure helper) before the existing partner notify; failures are logged, never block.
- **`integration-tests/helpers/seed-email-templates.ts`** — seed `order-canceled` (now a production template) in the shared helper.

## Tests
- 8 unit (`order-canceled-customer-email.unit.spec.ts`) — send/skip decision + data assembly.
- 4 integration (`order-canceled-customer-email.spec.ts`) — template active, workflow runs end-to-end against a real order (no errors), skip paths.

> Note: the shared HTTP runner truncates between tests, so templates are seeded in `beforeEach` (not `beforeAll`).

## Ops / human tail
No new template required — `order-canceled` is already active in prod. Live inbox delivery is the human verification tail (place order → cancel → check customer inbox). Slices **B** (production-run partner email) and **C** (region-request admin email) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)