### PR TITLE
feat(#576): production-run lifecycle → partner email (slice B)

### DIFF
--- a/apps/backend/src/subscribers/production-run-partner-email.ts
+++ b/apps/backend/src/subscribers/production-run-partner-email.ts
@@ -1,0 +1,63 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import type { Logger } from "@medusajs/types"
+import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+import { sendPartnerProductionRunEmailWorkflow } from "../workflows/email/workflows/send-partner-production-run-email"
+import {
+  resolvePartnerProductionRunTemplateKey,
+  type ProductionRunEmailAction,
+} from "../workflows/email/lib/partner-production-run-email"
+
+/**
+ * #576 slice B — email the owning partner's active admins when a production run
+ * is completed or cancelled. Runs alongside the feed-only
+ * production-run-notifications subscriber.
+ *
+ * partner_id may be absent from the event payload (the admin cancel route emits
+ * production_run.cancelled without it) — the workflow resolves the partner from
+ * the run itself. Best-effort: a missing template/partner is logged + skipped,
+ * never thrown, so the lifecycle event handler is unaffected.
+ */
+export default async function productionRunPartnerEmailHandler({
+  event,
+  container,
+}: SubscriberArgs<{
+  id: string
+  production_run_id?: string
+  partner_id?: string
+  action?: string
+  notes?: string
+}>) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER) as Logger
+  const data = event.data
+  if (!data) return
+
+  const productionRunId = data.production_run_id || data.id
+  if (!productionRunId) return
+
+  // Derive the lifecycle action from the payload or the event suffix.
+  const action = (data.action ||
+    event.name?.split(".").pop() ||
+    "") as ProductionRunEmailAction
+  if (!resolvePartnerProductionRunTemplateKey(action)) {
+    return
+  }
+
+  try {
+    await sendPartnerProductionRunEmailWorkflow(container).run({
+      input: {
+        productionRunId,
+        partnerId: data.partner_id,
+        action,
+        notes: data.notes,
+      },
+    })
+  } catch (e: any) {
+    logger.warn(
+      `[production_run.${action}] Partner email failed for run ${productionRunId}: ${e?.message || e}`
+    )
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: ["production_run.completed", "production_run.cancelled"],
+}

--- a/apps/backend/src/workflows/email/index.ts
+++ b/apps/backend/src/workflows/email/index.ts
@@ -22,6 +22,7 @@ export * from "./workflows/send-design-status-update-email"
 
 export * from "./workflows/send-partner-order-email"
 export * from "./workflows/send-order-canceled-customer-email"
+export * from "./workflows/send-partner-production-run-email"
 export * from "./steps/resolve-partner-from-order"
 
 // Export types

--- a/apps/backend/src/workflows/email/lib/__tests__/partner-production-run-email.unit.spec.ts
+++ b/apps/backend/src/workflows/email/lib/__tests__/partner-production-run-email.unit.spec.ts
@@ -1,0 +1,143 @@
+import {
+  buildPartnerProductionRunTemplateData,
+  derivePartnerFromEmail,
+  resolvePartnerProductionRunTemplateKey,
+} from "../partner-production-run-email"
+
+/**
+ * #576 slice B — pure helpers for the partner production-run lifecycle email.
+ * No container / provider: fast coverage of template-key resolution, the shared
+ * from-address derivation, and the Handlebars template-data assembly.
+ */
+describe("resolvePartnerProductionRunTemplateKey", () => {
+  it("maps completed → partner-production-run-completed", () => {
+    expect(resolvePartnerProductionRunTemplateKey("completed")).toBe(
+      "partner-production-run-completed"
+    )
+  })
+
+  it("maps cancelled → partner-production-run-cancelled", () => {
+    expect(resolvePartnerProductionRunTemplateKey("cancelled")).toBe(
+      "partner-production-run-cancelled"
+    )
+  })
+
+  it("returns null for actions without a partner email", () => {
+    expect(resolvePartnerProductionRunTemplateKey("started")).toBeNull()
+    expect(resolvePartnerProductionRunTemplateKey("finished")).toBeNull()
+    expect(resolvePartnerProductionRunTemplateKey("accepted")).toBeNull()
+    expect(resolvePartnerProductionRunTemplateKey(undefined)).toBeNull()
+    expect(resolvePartnerProductionRunTemplateKey(null)).toBeNull()
+    expect(resolvePartnerProductionRunTemplateKey("")).toBeNull()
+  })
+})
+
+describe("derivePartnerFromEmail", () => {
+  it("builds partner+<handle>@<domain>", () => {
+    expect(derivePartnerFromEmail("acme", "partner.jaalyantra.com")).toBe(
+      "partner+acme@partner.jaalyantra.com"
+    )
+  })
+
+  it("lowercases and dash-collapses whitespace, falls back to 'partner'", () => {
+    expect(derivePartnerFromEmail("  Acme  Mills ", "x.com")).toBe(
+      "partner+acme-mills@x.com"
+    )
+    expect(derivePartnerFromEmail(null, "x.com")).toBe("partner+partner@x.com")
+    expect(derivePartnerFromEmail("", "x.com")).toBe("partner+partner@x.com")
+  })
+})
+
+describe("buildPartnerProductionRunTemplateData", () => {
+  const base = {
+    partner: { name: "Acme Mills", handle: "acme" },
+    admin: { first_name: "Asha", last_name: "Rao" },
+    run: {
+      id: "prun_1",
+      status: "completed",
+      quantity: 100,
+      produced_quantity: 98,
+      rejected_quantity: 2,
+      design_id: "design_1",
+      order_id: "order_1",
+    },
+    action: "completed" as const,
+    notes: "All good",
+    storeUrl: "https://shop.example.com",
+    runUrlBase: "https://dash.example.com/production-runs",
+    year: 2026,
+  }
+
+  it("assembles the full template data with the run CTA url", () => {
+    const data = buildPartnerProductionRunTemplateData(base)
+    expect(data).toMatchObject({
+      partner_name: "Acme Mills",
+      partner_handle: "acme",
+      admin_name: "Asha Rao",
+      admin_first_name: "Asha",
+      run_id: "prun_1",
+      run_action: "completed",
+      run_status: "completed",
+      run_quantity: "100",
+      produced_quantity: "98",
+      rejected_quantity: "2",
+      design_id: "design_1",
+      order_id: "order_1",
+      notes: "All good",
+      run_url: "https://dash.example.com/production-runs/prun_1",
+      current_year: "2026",
+      store_url: "https://shop.example.com",
+    })
+  })
+
+  it("carries the cancelled action + reason through", () => {
+    const data = buildPartnerProductionRunTemplateData({
+      ...base,
+      action: "cancelled",
+      run: { ...base.run, status: "cancelled" },
+      notes: "Out of stock",
+    })
+    expect(data.run_action).toBe("cancelled")
+    expect(data.run_status).toBe("cancelled")
+    expect(data.notes).toBe("Out of stock")
+  })
+
+  it("blanks the run url when base or id is missing", () => {
+    expect(
+      buildPartnerProductionRunTemplateData({ ...base, runUrlBase: "" }).run_url
+    ).toBe("")
+    expect(
+      buildPartnerProductionRunTemplateData({
+        ...base,
+        run: { ...base.run, id: "" },
+      }).run_url
+    ).toBe("")
+  })
+
+  it("renders missing/null fields as blank, never 'undefined'", () => {
+    const data = buildPartnerProductionRunTemplateData({
+      partner: {},
+      admin: {},
+      run: {},
+      action: "completed",
+    })
+    expect(data.partner_name).toBe("Partner")
+    expect(data.admin_name).toBe("")
+    expect(data.run_id).toBe("")
+    expect(data.run_quantity).toBe("")
+    expect(data.produced_quantity).toBe("")
+    expect(data.rejected_quantity).toBe("")
+    expect(data.design_id).toBe("")
+    expect(data.notes).toBe("")
+    expect(Object.values(data)).not.toContain("undefined")
+  })
+
+  it("treats a zero produced/rejected quantity as a real value, not blank", () => {
+    const data = buildPartnerProductionRunTemplateData({
+      ...base,
+      run: { ...base.run, produced_quantity: 0, rejected_quantity: 0 },
+    })
+    expect(data.produced_quantity).toBe("0")
+    expect(data.rejected_quantity).toBe("0")
+  })
+})

--- a/apps/backend/src/workflows/email/lib/partner-production-run-email.ts
+++ b/apps/backend/src/workflows/email/lib/partner-production-run-email.ts
@@ -1,0 +1,93 @@
+// Pure helpers for the partner "production run lifecycle" email (#576 slice B).
+// Side-effect free so the template-key resolution + Handlebars data assembly are
+// unit-testable without booting Medusa or a notification provider.
+//
+// Mirrors lib/partner-task-email.ts so partner task + run emails share one shape.
+
+export type ProductionRunEmailAction = "completed" | "cancelled"
+
+export interface PartnerProductionRunTemplateInput {
+  partner: { name?: string | null; handle?: string | null }
+  admin: { first_name?: string | null; last_name?: string | null }
+  run: {
+    id?: string | null
+    status?: string | null
+    quantity?: number | null
+    produced_quantity?: number | null
+    rejected_quantity?: number | null
+    design_id?: string | null
+    order_id?: string | null
+  }
+  action: ProductionRunEmailAction
+  /** Free-text notes/reason surfaced in the body (completion notes or cancel reason). */
+  notes?: string | null
+  /** Storefront URL (FRONTEND_URL) surfaced in the footer. */
+  storeUrl?: string
+  /** Base URL for the "View Run" CTA; `${base}/${runId}` when both present. */
+  runUrlBase?: string
+  /** Override for deterministic tests; defaults to the current year. */
+  year?: number
+}
+
+/**
+ * DB template key for a production-run lifecycle email.
+ * Only `completed` and `cancelled` have partner emails (#576 slice B); any other
+ * action returns null so the workflow can skip without guessing a key.
+ */
+export function resolvePartnerProductionRunTemplateKey(
+  action: string | null | undefined
+): string | null {
+  if (action === "completed") return "partner-production-run-completed"
+  if (action === "cancelled") return "partner-production-run-cancelled"
+  return null
+}
+
+/**
+ * Partner email from-address: partner+<handle>@<domain>.
+ * Mirrors derivePartnerFromEmail in partner-task-email.ts so all partner mail
+ * shares one sender shape; re-declared here to keep this lib dependency-free.
+ */
+export function derivePartnerFromEmail(
+  handle: string | null | undefined,
+  fromDomain: string
+): string {
+  const safeHandle = (handle || "partner").toLowerCase().trim().replace(/\s+/g, "-")
+  return `partner+${safeHandle}@${fromDomain}`
+}
+
+/**
+ * Assemble the Handlebars data for the partner-production-run-* DB template.
+ * All values are coerced to strings so an undefined/null field renders blank
+ * rather than the literal "undefined".
+ */
+export function buildPartnerProductionRunTemplateData(
+  input: PartnerProductionRunTemplateInput
+): Record<string, string> {
+  const { partner, admin, run, action } = input
+  const adminName = `${admin.first_name || ""} ${admin.last_name || ""}`.trim()
+  const runId = run.id || ""
+  const base = (input.runUrlBase || "").replace(/\/$/, "")
+  const runUrl = base && runId ? `${base}/${runId}` : ""
+
+  const numOrEmpty = (v: number | null | undefined): string =>
+    v === null || v === undefined ? "" : String(v)
+
+  return {
+    partner_name: partner.name || "Partner",
+    partner_handle: partner.handle || "",
+    admin_name: adminName,
+    admin_first_name: admin.first_name || "",
+    run_id: runId,
+    run_action: action,
+    run_status: run.status || "",
+    run_quantity: numOrEmpty(run.quantity),
+    produced_quantity: numOrEmpty(run.produced_quantity),
+    rejected_quantity: numOrEmpty(run.rejected_quantity),
+    design_id: run.design_id || "",
+    order_id: run.order_id || "",
+    notes: input.notes || "",
+    run_url: runUrl,
+    current_year: String(input.year ?? new Date().getFullYear()),
+    store_url: input.storeUrl || "",
+  }
+}

--- a/apps/backend/src/workflows/email/workflows/send-partner-production-run-email.ts
+++ b/apps/backend/src/workflows/email/workflows/send-partner-production-run-email.ts
@@ -1,0 +1,183 @@
+import {
+  createWorkflow,
+  createStep,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import { Modules } from "@medusajs/framework/utils"
+import type { INotificationModuleService } from "@medusajs/types"
+import * as Handlebars from "handlebars"
+import { PARTNER_MODULE } from "../../../modules/partner"
+import PartnerService from "../../../modules/partner/service"
+import { PRODUCTION_RUNS_MODULE } from "../../../modules/production_runs"
+import ProductionRunsService from "../../../modules/production_runs/service"
+import { EMAIL_TEMPLATES_MODULE } from "../../../modules/email_templates"
+import EmailTemplatesService from "../../../modules/email_templates/service"
+import {
+  buildPartnerProductionRunTemplateData,
+  derivePartnerFromEmail,
+  resolvePartnerProductionRunTemplateKey,
+  type ProductionRunEmailAction,
+} from "../lib/partner-production-run-email"
+
+// ---------------------------------------------------------------------------
+// Step: resolve partner (from the run when the event omits partner_id) + active
+// admins + run detail, compile the DB template and email each active partner
+// admin about a completed/cancelled production run (#576 slice B).
+//
+// Mirrors sendPartnerTaskAssignedStep (send-partner-task-assigned-email.ts):
+//   - email_partner channel (Maileroo) so partner mail routes like the rest
+//   - DB template fetched/compiled via EmailTemplatesService + Handlebars
+//   - per-admin send is best-effort; a missing partner/template skips quietly
+// ---------------------------------------------------------------------------
+const sendPartnerProductionRunStep = createStep(
+  { name: "send-partner-production-run-notification", store: true },
+  async (
+    input: {
+      productionRunId: string
+      partnerId?: string
+      action: ProductionRunEmailAction
+      notes?: string
+    },
+    { container }
+  ) => {
+    const { productionRunId, action } = input
+
+    const templateKey = resolvePartnerProductionRunTemplateKey(action)
+    if (!productionRunId || !templateKey) {
+      return new StepResponse({ sent: 0, skipped: true })
+    }
+
+    // 1) Run detail — also the partner_id fallback when the event omits it
+    //    (the admin cancel route emits production_run.cancelled with no partner_id).
+    const runService: ProductionRunsService = container.resolve(
+      PRODUCTION_RUNS_MODULE
+    )
+    let run: any = null
+    try {
+      run = await runService.retrieveProductionRun(productionRunId)
+    } catch (err) {
+      console.warn(
+        `[partner-run-email] Failed to fetch run ${productionRunId}: ${(err as Error).message}`
+      )
+      return new StepResponse({ sent: 0, skipped: true })
+    }
+
+    const partnerId = input.partnerId || run?.partner_id || null
+    if (!partnerId) {
+      console.log(
+        `[partner-run-email] No partner for run ${productionRunId} — skipping`
+      )
+      return new StepResponse({ sent: 0, skipped: true })
+    }
+
+    // 2) Partner + active admins
+    const partnerService: PartnerService = container.resolve(PARTNER_MODULE)
+    let partner: any = null
+    let admins: any[] = []
+    try {
+      const partners = await partnerService.listPartners(
+        { id: partnerId },
+        { relations: ["admins"], select: ["id", "name", "handle"] }
+      )
+      partner = (partners as any[])?.[0] || null
+      admins = (partner?.admins || []).filter((a: any) => a.is_active)
+    } catch (err) {
+      console.warn(
+        `[partner-run-email] Failed to fetch partner ${partnerId}: ${(err as Error).message}`
+      )
+    }
+
+    if (!partner || admins.length === 0) {
+      console.log(
+        `[partner-run-email] No partner/admins for run ${productionRunId} — skipping`
+      )
+      return new StepResponse({ sent: 0, skipped: true })
+    }
+
+    // 3) DB template (best-effort: a missing/inactive row never crashes the
+    //    production-run lifecycle subscriber).
+    const emailTemplatesService: EmailTemplatesService =
+      container.resolve(EMAIL_TEMPLATES_MODULE)
+    let template: any
+    try {
+      template = await emailTemplatesService.getTemplateByKey(templateKey)
+    } catch (err) {
+      console.warn(
+        `[partner-run-email] Template "${templateKey}" missing/inactive: ${(err as Error).message}`
+      )
+      return new StepResponse({ sent: 0, skipped: true })
+    }
+
+    const compiledHtml = Handlebars.compile(template.html_content)
+    const compiledSubject = Handlebars.compile(template.subject)
+
+    const fromDomain =
+      process.env.MAILEROO_FROM_DOMAIN || "partner.jaalyantra.com"
+    const partnerFromEmail = derivePartnerFromEmail(partner.handle, fromDomain)
+    const partnerFromName = partner.name || "Jaal Yantra Textiles Partner"
+    const runUrlBase = process.env.PARTNER_DASHBOARD_URL
+      ? `${process.env.PARTNER_DASHBOARD_URL}/production-runs`
+      : ""
+
+    const notificationService = container.resolve(
+      Modules.NOTIFICATION
+    ) as INotificationModuleService
+
+    let sentCount = 0
+    for (const admin of admins) {
+      const templateData = buildPartnerProductionRunTemplateData({
+        partner,
+        admin,
+        run,
+        action,
+        notes: input.notes,
+        storeUrl: process.env.FRONTEND_URL || "",
+        runUrlBase,
+      })
+
+      const renderedHtml = compiledHtml(templateData)
+      const renderedSubject = compiledSubject(templateData)
+
+      try {
+        await notificationService.createNotifications({
+          to: admin.email,
+          channel: "email_partner",
+          template: templateKey,
+          data: {
+            ...templateData,
+            _template_subject: renderedSubject,
+            _template_html_content: renderedHtml,
+            _template_from: partnerFromEmail,
+            _template_processed: true,
+            _partner_from_email: partnerFromEmail,
+            _partner_from_name: partnerFromName,
+          },
+        })
+        sentCount++
+        console.log(
+          `[partner-run-email] Sent ${templateKey} to ${admin.email} (partner: ${partner.name})`
+        )
+      } catch (err) {
+        console.error(
+          `[partner-run-email] Failed to send to ${admin.email}: ${(err as Error).message}`
+        )
+      }
+    }
+
+    return new StepResponse({ sent: sentCount, skipped: false })
+  }
+)
+
+export const sendPartnerProductionRunEmailWorkflow = createWorkflow(
+  { name: "send-partner-production-run-email", store: true },
+  (input: {
+    productionRunId: string
+    partnerId?: string
+    action: ProductionRunEmailAction
+    notes?: string
+  }) => {
+    const result = sendPartnerProductionRunStep(input)
+    return new WorkflowResponse(result)
+  }
+)

--- a/apps/docs/notes/332_PARTNER_EMAIL_E2E_AUDIT.md
+++ b/apps/docs/notes/332_PARTNER_EMAIL_E2E_AUDIT.md
@@ -120,3 +120,36 @@ partner-task-assigned, partner-verified, password-reset, design-assigned,
 order-placed, order-canceled, order-fulfillment-procured/created, delivery-created,
 visual-flow-started, visual-flow-failure. (Full list via
 `GET /admin/email-templates?limit=100`.)
+
+---
+
+## #576 Slice B — production-run lifecycle → PARTNER email (built, PR pending)
+
+`production_run.completed` and `production_run.cancelled` now email the owning
+partner's active admins, mirroring `partner-task-assigned`:
+
+- **Subscriber:** `src/subscribers/production-run-partner-email.ts` (dedicated,
+  runs alongside the feed-only `production-run-notifications.ts`).
+- **Workflow:** `send-partner-production-run-email.ts` → channel `email_partner`
+  (Maileroo). Resolves the partner from `event.data.partner_id` **or**, when the
+  event omits it (the admin cancel route emits `production_run.cancelled` with no
+  `partner_id`), from `run.partner_id` after `retrieveProductionRun`.
+- **Pure lib:** `lib/partner-production-run-email.ts`
+  (`resolvePartnerProductionRunTemplateKey` + `buildPartnerProductionRunTemplateData`),
+  10 unit tests. Best-effort: missing partner/admins/template → log + skip, never throws.
+
+### OPS TAIL — required before this delivers in prod (daemon can't author content)
+1. **Author 2 prod template rows** in admin (`POST /admin/email-templates`,
+   `template_type` required, `is_active: true`):
+   - key `partner-production-run-completed`
+   - key `partner-production-run-cancelled`
+   Available Handlebars vars: `partner_name`, `partner_handle`, `admin_name`,
+   `admin_first_name`, `run_id`, `run_action`, `run_status`, `run_quantity`,
+   `produced_quantity`, `rejected_quantity`, `design_id`, `order_id`, `notes`,
+   `run_url`, `current_year`, `store_url`.
+2. No new env needed (reuses `MAILEROO_FROM_DOMAIN`, `PARTNER_DASHBOARD_URL`,
+   `FRONTEND_URL`). Until the rows exist the step skips silently (warn log only).
+
+### Human verification (add to checklist above)
+9. Complete a production run → partner admin inbox gets `partner-production-run-completed`.
+10. Cancel a production run (admin + partner-decline paths) → `partner-production-run-cancelled`.


### PR DESCRIPTION
## #576 Slice B — production_run.{completed,cancelled} → PARTNER email

Second of the 3 decision-gated email touchpoints from the #332 audit. Independent off `origin/main` (does **not** depend on slice A / PR #577).

### What
`production_run.completed` and `production_run.cancelled` now email the owning partner's **active admins** via the `email_partner` channel (Maileroo), mirroring the `partner-task-assigned` send wired in #332.

- **Subscriber** `src/subscribers/production-run-partner-email.ts` — dedicated, runs alongside the feed-only `production-run-notifications.ts`. Listens to `production_run.completed` + `production_run.cancelled`.
- **Workflow** `send-partner-production-run-email.ts` — resolves the partner from `event.data.partner_id` **or**, when absent (the admin cancel route emits `production_run.cancelled` with no `partner_id`), from `run.partner_id` via `retrieveProductionRun`. Fetches the DB template, compiles Handlebars, sends per active admin. Best-effort: missing partner/admins/template → log + skip, never throws.
- **Pure lib** `lib/partner-production-run-email.ts` — `resolvePartnerProductionRunTemplateKey` (completed/cancelled → key, else null) + `buildPartnerProductionRunTemplateData`. **10 unit tests.**

### Tests
- `TEST_TYPE=unit npx jest --testPathPattern=partner-production-run-email.unit` → 10/10 green.
- Typecheck of changed files clean.
- No integration spec: base `medusa-config.ts` lacks the Maileroo (`email_partner`) provider, so a real partner send isn't assertable headless (same constraint documented for the existing partner emails).

### ⚠️ Ops tail (required before this delivers in prod — daemon can't author content)
Author **2 prod template rows** in admin (`is_active: true`):
- `partner-production-run-completed`
- `partner-production-run-cancelled`

Handlebars vars available: `partner_name`, `partner_handle`, `admin_name`, `admin_first_name`, `run_id`, `run_action`, `run_status`, `run_quantity`, `produced_quantity`, `rejected_quantity`, `design_id`, `order_id`, `notes`, `run_url`, `current_year`, `store_url`. No new env (reuses `MAILEROO_FROM_DOMAIN`, `PARTNER_DASHBOARD_URL`, `FRONTEND_URL`). Until the rows exist the step skips silently. Details appended to `apps/docs/notes/332_PARTNER_EMAIL_E2E_AUDIT.md`.

Remaining #576: **Slice C** — region-request → ADMIN email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)