### PR TITLE
feat(email): region-request → admin email alert (#576 slice C)

### DIFF
--- a/apps/backend/integration-tests/http/region-request-admin-email.spec.ts
+++ b/apps/backend/integration-tests/http/region-request-admin-email.spec.ts
@@ -1,0 +1,111 @@
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { sendRegionRequestAdminEmailWorkflow } from "../../src/workflows/email/workflows/send-region-request-admin-email"
+import {
+  buildRegionRequestAdminEmailData,
+  resolveRegionRequestRecipient,
+} from "../../src/workflows/email/lib/region-request-admin-email"
+
+jest.setTimeout(60 * 1000)
+
+/**
+ * #576 slice C — region-request → admin email.
+ * The base/local config has no real email provider, so we assert the workflow
+ * compiles + resolves the seeded `region-request-admin` template and runs
+ * end-to-end, plus exercise the pure recipient/data helpers against the route's
+ * data shape.
+ */
+setupSharedTestSuite(() => {
+  describe("region request → admin email (#576 slice C)", () => {
+    let adminHeaders: { headers: Record<string, string> }
+
+    beforeEach(async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+
+      // The shared runner truncates between tests, so (re)seed per test.
+      // This template key is not part of the common seed set.
+      try {
+        await api.post(
+          "/admin/email-templates",
+          {
+            name: "Region Request Admin",
+            template_key: "region-request-admin",
+            subject: "{{title}}",
+            html_content:
+              "<div>{{name}} <{{email}}> — {{country_code}} — {{message}}</div>",
+            from: "ops@jaalyantra.com",
+            variables: {},
+            template_type: "email",
+          },
+          adminHeaders
+        )
+      } catch {
+        // already seeded in a prior test within this shared DB — ignore
+      }
+    })
+
+    it("has the seeded region-request-admin template", async () => {
+      const { api } = getSharedTestEnv()
+      const res = await api.get("/admin/email-templates", adminHeaders)
+      const templates =
+        res.data.email_templates || res.data.emailTemplates || []
+      const tmpl = templates.find(
+        (t: any) => t.template_key === "region-request-admin"
+      )
+      expect(tmpl).toBeDefined()
+      expect(tmpl.is_active).toBe(true)
+    })
+
+    it("runs the admin email workflow against the seeded template", async () => {
+      const container = getSharedTestEnv().getContainer()
+
+      const data = buildRegionRequestAdminEmailData({
+        name: "Asha",
+        email: "asha@example.com",
+        message: "Please ship to Nepal",
+        countryCode: "np",
+        productHandle: "silk-saree",
+        storeName: "Asha Textiles",
+        receivedAt: new Date().toISOString(),
+      })
+
+      // The workflow returns no WorkflowResponse (mirrors slice A), so
+      // completing without errors is the success signal.
+      const run = await sendRegionRequestAdminEmailWorkflow(container).run({
+        input: { to: "ops@jaalyantra.com", data },
+      })
+      expect(run.errors).toEqual([])
+    })
+
+    it("does not throw when run with throwOnError:false (route best-effort contract)", async () => {
+      const container = getSharedTestEnv().getContainer()
+      const data = buildRegionRequestAdminEmailData({
+        name: "Bo",
+        email: "bo@example.com",
+      })
+
+      // The route calls the workflow with throwOnError:false and wraps it in a
+      // try/catch so a provider/template problem can never 500 the storefront
+      // submission. Assert the run resolves to an errors array rather than
+      // rejecting.
+      const run = await sendRegionRequestAdminEmailWorkflow(container).run({
+        input: { to: "ops@jaalyantra.com", data },
+        throwOnError: false,
+      })
+      expect(Array.isArray(run.errors)).toBe(true)
+    })
+
+    it("resolves the recipient from REGION_REQUEST_NOTIFY_EMAIL", () => {
+      const recipient = resolveRegionRequestRecipient({
+        REGION_REQUEST_NOTIFY_EMAIL: "ops@jaalyantra.com",
+      })
+      expect(recipient?.email).toBe("ops@jaalyantra.com")
+    })
+
+    it("returns null recipient when nothing is configured (route skips email)", () => {
+      expect(resolveRegionRequestRecipient({})).toBeNull()
+    })
+  })
+})

--- a/apps/backend/src/api/store/contact-region-request/route.ts
+++ b/apps/backend/src/api/store/contact-region-request/route.ts
@@ -5,6 +5,11 @@ import {
 import { MedusaError, Modules } from "@medusajs/framework/utils"
 import type { INotificationModuleService } from "@medusajs/types"
 import { getStoreFromPublishableKey } from "../helpers"
+import { sendRegionRequestAdminEmailWorkflow } from "../../../workflows/email/workflows/send-region-request-admin-email"
+import {
+  buildRegionRequestAdminEmailData,
+  resolveRegionRequestRecipient,
+} from "../../../workflows/email/lib/region-request-admin-email"
 
 /**
  * POST /store/contact-region-request
@@ -120,9 +125,59 @@ export const POST = async (
     },
   })
 
+  // Best-effort admin email alert (#576 slice C). The feed notification above
+  // is the source of truth; emailing an ops/admin inbox is a courtesy on top of
+  // it. Anything that can fail here (no recipient configured, missing
+  // `region-request-admin` template row, provider error) is swallowed so the
+  // storefront submission always succeeds.
+  let emailed = false
+  try {
+    const recipient = resolveRegionRequestRecipient(
+      process.env as Record<string, string | undefined>
+    )
+    if (!recipient) {
+      console.log(
+        "[contact-region-request] No admin recipient configured (REGION_REQUEST_NOTIFY_EMAIL) — skipping email"
+      )
+    } else {
+      const emailData = buildRegionRequestAdminEmailData({
+        name,
+        email,
+        message,
+        countryCode,
+        productHandle,
+        storeId,
+        storeName,
+        receivedAt: new Date().toISOString(),
+      })
+
+      const run = await sendRegionRequestAdminEmailWorkflow(req.scope).run({
+        input: { to: recipient.email, data: emailData },
+        throwOnError: false,
+      })
+
+      if (run?.errors?.length) {
+        console.warn(
+          `[contact-region-request] Admin email workflow reported errors: ${run.errors
+            .map((e: any) => e?.error?.message || e?.message)
+            .join("; ")}`
+        )
+      } else {
+        emailed = true
+      }
+    }
+  } catch (err) {
+    console.warn(
+      `[contact-region-request] Admin email send failed (non-fatal): ${
+        (err as Error)?.message
+      }`
+    )
+  }
+
   res.json({
     id: notification?.id,
     received: true,
     store_id: storeId ?? null,
+    emailed,
   })
 }

--- a/apps/backend/src/workflows/email/lib/__tests__/region-request-admin-email.unit.spec.ts
+++ b/apps/backend/src/workflows/email/lib/__tests__/region-request-admin-email.unit.spec.ts
@@ -1,0 +1,116 @@
+import {
+  buildRegionRequestAdminEmailData,
+  resolveRegionRequestRecipient,
+} from "../region-request-admin-email"
+
+describe("region-request-admin-email lib (#576 slice C)", () => {
+  describe("resolveRegionRequestRecipient", () => {
+    it("prefers REGION_REQUEST_NOTIFY_EMAIL", () => {
+      const r = resolveRegionRequestRecipient({
+        REGION_REQUEST_NOTIFY_EMAIL: "ops@jaalyantra.com",
+        ADMIN_NOTIFY_EMAIL: "admin@jaalyantra.com",
+        MAILJET_FROM_EMAIL: "from@jaalyantra.com",
+      })
+      expect(r).toEqual({
+        email: "ops@jaalyantra.com",
+        source: "REGION_REQUEST_NOTIFY_EMAIL",
+      })
+    })
+
+    it("falls back to ADMIN_NOTIFY_EMAIL when the primary is unset", () => {
+      const r = resolveRegionRequestRecipient({
+        ADMIN_NOTIFY_EMAIL: "admin@jaalyantra.com",
+        MAILJET_FROM_EMAIL: "from@jaalyantra.com",
+      })
+      expect(r?.email).toBe("admin@jaalyantra.com")
+      expect(r?.source).toBe("ADMIN_NOTIFY_EMAIL")
+    })
+
+    it("falls back to MAILJET_FROM_EMAIL as the last resort", () => {
+      const r = resolveRegionRequestRecipient({
+        MAILJET_FROM_EMAIL: "from@jaalyantra.com",
+      })
+      expect(r?.email).toBe("from@jaalyantra.com")
+      expect(r?.source).toMatch(/MAILJET_FROM_EMAIL/)
+    })
+
+    it("trims surrounding whitespace", () => {
+      const r = resolveRegionRequestRecipient({
+        REGION_REQUEST_NOTIFY_EMAIL: "  ops@jaalyantra.com  ",
+      })
+      expect(r?.email).toBe("ops@jaalyantra.com")
+    })
+
+    it("returns null when nothing is configured", () => {
+      expect(resolveRegionRequestRecipient({})).toBeNull()
+    })
+
+    it("ignores non-email values (no @)", () => {
+      const r = resolveRegionRequestRecipient({
+        REGION_REQUEST_NOTIFY_EMAIL: "not-an-email",
+        ADMIN_NOTIFY_EMAIL: "real@jaalyantra.com",
+      })
+      expect(r?.email).toBe("real@jaalyantra.com")
+    })
+
+    it("treats empty strings as unset", () => {
+      const r = resolveRegionRequestRecipient({
+        REGION_REQUEST_NOTIFY_EMAIL: "",
+        ADMIN_NOTIFY_EMAIL: "   ",
+        MAILJET_FROM_EMAIL: "floor@jaalyantra.com",
+      })
+      expect(r?.email).toBe("floor@jaalyantra.com")
+    })
+  })
+
+  describe("buildRegionRequestAdminEmailData", () => {
+    it("assembles a full payload and upper-cases the country code", () => {
+      const data = buildRegionRequestAdminEmailData({
+        name: "Asha",
+        email: "asha@example.com",
+        message: "Please ship to Nepal",
+        countryCode: "np",
+        productHandle: "silk-saree",
+        storeId: "store_1",
+        storeName: "Asha Textiles",
+        receivedAt: "2026-06-21T00:00:00.000Z",
+      })
+      expect(data).toEqual({
+        title: "Region request: customer in NP",
+        name: "Asha",
+        email: "asha@example.com",
+        message: "Please ship to Nepal",
+        country_code: "NP",
+        product_handle: "silk-saree",
+        store_id: "store_1",
+        store_name: "Asha Textiles",
+        received_at: "2026-06-21T00:00:00.000Z",
+      })
+    })
+
+    it("uses the generic title and nulls when country code is absent", () => {
+      const data = buildRegionRequestAdminEmailData({
+        name: "Bo",
+        email: "bo@example.com",
+      })
+      expect(data.title).toBe("Region request: storefront contact")
+      expect(data.country_code).toBeNull()
+      expect(data.message).toBeNull()
+      expect(data.product_handle).toBeNull()
+      expect(data.store_name).toBeNull()
+    })
+
+    it("coerces blank optional fields to null", () => {
+      const data = buildRegionRequestAdminEmailData({
+        name: "Cy",
+        email: "cy@example.com",
+        message: "   ",
+        productHandle: "  ",
+        storeName: "",
+      })
+      expect(data.message).toBeNull()
+      expect(data.product_handle).toBeNull()
+      expect(data.store_name).toBeNull()
+    })
+  })
+})

--- a/apps/backend/src/workflows/email/lib/region-request-admin-email.ts
+++ b/apps/backend/src/workflows/email/lib/region-request-admin-email.ts
@@ -1,0 +1,91 @@
+// Pure helpers for the "region request → admin" email (#576 slice C).
+// Side-effect free so recipient resolution + template-data assembly are
+// unit-testable without booting Medusa or a notification provider.
+//
+// Trigger: POST /store/contact-region-request (the storefront "we don't ship
+// here yet" fallback form). The route already drops a feed notification for the
+// partner; this slice additionally alerts an ops/admin inbox by email so the
+// lead isn't only visible inside the admin activity feed.
+
+export interface RegionRequestRecipientEnv {
+  /** Primary, purpose-built recipient (set in prod SSM). */
+  REGION_REQUEST_NOTIFY_EMAIL?: string | null
+  /** Generic admin alert inbox, if the platform has one configured. */
+  ADMIN_NOTIFY_EMAIL?: string | null
+  /** Last-resort floor so a region request never silently no-ops. */
+  MAILJET_FROM_EMAIL?: string | null
+}
+
+export interface RegionRequestRecipient {
+  email: string
+  /** Which env key supplied the address (for the route log). */
+  source: string
+}
+
+/**
+ * Resolve the admin recipient for a region-request alert (first non-empty,
+ * @-containing value wins). Returns null when nothing is configured so the
+ * caller can skip the email send without throwing — the feed notification has
+ * already captured the lead regardless.
+ *
+ * Order mirrors `visual-flow-lifecycle-email.ts::resolveRecipient`:
+ *   1. REGION_REQUEST_NOTIFY_EMAIL — purpose-built, set in prod SSM
+ *   2. ADMIN_NOTIFY_EMAIL          — generic admin alert inbox
+ *   3. MAILJET_FROM_EMAIL          — from-address floor the team controls
+ */
+export function resolveRegionRequestRecipient(
+  env: RegionRequestRecipientEnv
+): RegionRequestRecipient | null {
+  const candidates: Array<[string | null | undefined, string]> = [
+    [env.REGION_REQUEST_NOTIFY_EMAIL, "REGION_REQUEST_NOTIFY_EMAIL"],
+    [env.ADMIN_NOTIFY_EMAIL, "ADMIN_NOTIFY_EMAIL"],
+    [env.MAILJET_FROM_EMAIL, "MAILJET_FROM_EMAIL (fallback)"],
+  ]
+
+  for (const [value, source] of candidates) {
+    const trimmed = (value || "").trim()
+    if (trimmed && trimmed.includes("@")) {
+      return { email: trimmed, source }
+    }
+  }
+
+  return null
+}
+
+export interface RegionRequestAdminEmailInput {
+  name: string
+  email: string
+  message?: string | null
+  countryCode?: string | null
+  productHandle?: string | null
+  storeId?: string | null
+  storeName?: string | null
+  receivedAt?: string | null
+}
+
+/**
+ * Assemble the Handlebars data for the `region-request-admin` template.
+ * Normalises optional fields to safe display values so the compiled template
+ * never renders "undefined". `country_code` is upper-cased to match the feed
+ * notification title the same request produces.
+ */
+export function buildRegionRequestAdminEmailData(
+  input: RegionRequestAdminEmailInput
+): Record<string, any> {
+  const countryCode = (input.countryCode || "").trim().toUpperCase()
+  const title = countryCode
+    ? `Region request: customer in ${countryCode}`
+    : "Region request: storefront contact"
+
+  return {
+    title,
+    name: input.name,
+    email: input.email,
+    message: (input.message || "").trim() || null,
+    country_code: countryCode || null,
+    product_handle: (input.productHandle || "").trim() || null,
+    store_id: input.storeId || null,
+    store_name: (input.storeName || "").trim() || null,
+    received_at: input.receivedAt || null,
+  }
+}

--- a/apps/backend/src/workflows/email/workflows/send-region-request-admin-email.ts
+++ b/apps/backend/src/workflows/email/workflows/send-region-request-admin-email.ts
@@ -1,0 +1,39 @@
+import {
+  createWorkflow,
+  transform,
+} from "@medusajs/framework/workflows-sdk"
+import { sendNotificationEmailStep } from "../steps/send-notification-email"
+import { fetchEmailTemplateStep } from "../steps/fetch-email-template"
+
+/**
+ * Email an admin/ops inbox about a storefront region request (#576 slice C).
+ *
+ * Mirrors `sendOrderCanceledCustomerEmailWorkflow` (slice A): resolves the DB
+ * template `region-request-admin` and dispatches on the `email` channel
+ * (Resend). The recipient + template data are decided in the route via
+ * `resolveRegionRequestRecipient` / `buildRegionRequestAdminEmailData`; this
+ * workflow assumes it should send.
+ *
+ * Best-effort by contract: `fetchEmailTemplateStep` throws when the template
+ * row is absent, so the route invokes this inside a try/catch and never lets a
+ * missing template fail the storefront submission (the feed notification has
+ * already captured the lead).
+ */
+export const sendRegionRequestAdminEmailWorkflow = createWorkflow(
+  { name: "send-region-request-admin-email", store: true },
+  (input: { to: string; data: Record<string, any> }) => {
+    const templateData = fetchEmailTemplateStep({
+      templateKey: "region-request-admin",
+      data: input.data,
+    })
+
+    const emailWithTemplate = transform({ input, templateData }, (d) => ({
+      to: d.input.to,
+      template: "region-request-admin",
+      data: d.input.data,
+      templateData: d.templateData,
+    }))
+
+    sendNotificationEmailStep(emailWithTemplate as any)
+  }
+)


### PR DESCRIPTION
Closes the **last** of the three decision-gated email touchpoints in #576 (follow-up to #332). Slices A (#577) and B (#579) are independent OPEN PRs; this one is also independent off `main`.

## What
The storefront "we don't ship here yet" fallback — `POST /store/contact-region-request` — previously only created a **feed** notification for the partner. It now **also best-effort emails an ops/admin inbox** on the `email` channel (Resend) using the `region-request-admin` DB template, mirroring slice A's customer order-cancellation send.

## How
- **Pure lib** `src/workflows/email/lib/region-request-admin-email.ts`
  - `resolveRegionRequestRecipient` — first non-empty `@`-containing value wins: `REGION_REQUEST_NOTIFY_EMAIL` → `ADMIN_NOTIFY_EMAIL` → `MAILJET_FROM_EMAIL` (floor); returns `null` when nothing is configured (route then skips the email).
  - `buildRegionRequestAdminEmailData` — normalises optional fields, upper-cases the country code to match the feed title.
- **Workflow** `send-region-request-admin-email.ts` — fetch `region-request-admin` template + send notification; no `WorkflowResponse` (mirrors slice A).
- **Route** wires the send **best-effort**: `throwOnError:false` + `try/catch` so a missing template / unconfigured recipient / provider error can **never 500** the storefront submission. The feed notification remains the source of truth; the response gains an `emailed` boolean.

## Tests
- **10 unit** (`region-request-admin-email.unit`) — recipient precedence/fallback/null + data assembly.
- **5 integration** (`region-request-admin-email.spec.ts`) — seeds the template per-test (shared runner truncates between tests), runs the workflow end-to-end, asserts `run.errors == []` + the best-effort contract.
- Types clean on changed files.

## Ops tail (prod content — daemon can't author)
Before this delivers in prod:
1. Set env **`REGION_REQUEST_NOTIFY_EMAIL`** to the ops/admin inbox (else it falls back to `MAILJET_FROM_EMAIL`, or skips if neither is set).
2. Author an active **`region-request-admin`** email-template row. Available vars: `title`, `name`, `email`, `message`, `country_code`, `product_handle`, `store_id`, `store_name`, `received_at`.

No-merge — human review. Live inbox send is not verifiable headless (base config lacks Resend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)