### PR TITLE
feat(analytics): partner storefront digest compute (#581 S1)

### DIFF
--- a/apps/backend/src/workflows/analytics/__tests__/partner-digest-lib.unit.spec.ts
+++ b/apps/backend/src/workflows/analytics/__tests__/partner-digest-lib.unit.spec.ts
@@ -1,0 +1,289 @@
+import {
+  breakdownToItems,
+  buildDigestKpis,
+  buildDigestSuggestions,
+  computeDigestMetric,
+  DEFAULT_DIGEST_THRESHOLDS,
+  resolvePeriodRange,
+  type DigestBreakdowns,
+  type DigestKpis,
+} from "../partner-digest-lib";
+
+// Helper to build a full kpis block tersely.
+const metric = (current: number, previous: number) =>
+  computeDigestMetric(current, previous);
+
+const kpis = (over: Partial<Record<keyof DigestKpis, [number, number]>> = {}): DigestKpis => ({
+  unique_visitors: metric(...(over.unique_visitors ?? [100, 100])),
+  pageviews: metric(...(over.pageviews ?? [300, 300])),
+  sessions: metric(...(over.sessions ?? [120, 120])),
+  bounce_rate: metric(...(over.bounce_rate ?? [0.3, 0.3])),
+  avg_session_duration: metric(...(over.avg_session_duration ?? [60, 60])),
+  pages_per_session: metric(...(over.pages_per_session ?? [3, 3])),
+});
+
+const breakdowns = (over: Partial<DigestBreakdowns> = {}): DigestBreakdowns => ({
+  top_pages: over.top_pages ?? [],
+  referrers: over.referrers ?? [],
+  devices: over.devices ?? [],
+  countries: over.countries ?? [],
+});
+
+describe("resolvePeriodRange", () => {
+  const now = new Date("2026-06-21T00:00:00.000Z");
+
+  it("resolves last_7_days into current + equal-length previous windows", () => {
+    const r = resolvePeriodRange("last_7_days", now);
+    expect(r.days).toBe(7);
+    expect(r.label).toBe("last_7_days");
+    expect(r.current.end).toBe("2026-06-21T00:00:00.000Z");
+    expect(r.current.start).toBe("2026-06-14T00:00:00.000Z");
+    // previous window abuts the current start, equal length
+    expect(r.previous.end).toBe("2026-06-14T00:00:00.000Z");
+    expect(r.previous.start).toBe("2026-06-07T00:00:00.000Z");
+  });
+
+  it("supports named 28/30-day periods", () => {
+    expect(resolvePeriodRange("last_28_days", now).days).toBe(28);
+    expect(resolvePeriodRange("last_30_days", now).days).toBe(30);
+  });
+
+  it("supports an explicit {days} period and labels it", () => {
+    const r = resolvePeriodRange({ days: 14 }, now);
+    expect(r.days).toBe(14);
+    expect(r.label).toBe("last_14_days");
+  });
+
+  it("falls back to 7 days for invalid day counts", () => {
+    expect(resolvePeriodRange({ days: 0 }, now).days).toBe(7);
+    expect(resolvePeriodRange({ days: -5 }, now).days).toBe(7);
+    expect(resolvePeriodRange({ days: NaN }, now).days).toBe(7);
+  });
+});
+
+describe("computeDigestMetric", () => {
+  it("computes positive delta + up direction", () => {
+    const m = computeDigestMetric(150, 100);
+    expect(m).toEqual({ current: 150, previous: 100, delta_pct: 50, direction: "up" });
+  });
+
+  it("computes negative delta + down direction", () => {
+    const m = computeDigestMetric(80, 100);
+    expect(m).toEqual({ current: 80, previous: 100, delta_pct: -20, direction: "down" });
+  });
+
+  it("is flat when equal", () => {
+    expect(computeDigestMetric(100, 100).direction).toBe("flat");
+    expect(computeDigestMetric(100, 100).delta_pct).toBe(0);
+  });
+
+  it("returns null delta with no baseline but marks up when current > 0", () => {
+    const m = computeDigestMetric(40, 0);
+    expect(m.delta_pct).toBeNull();
+    expect(m.direction).toBe("up");
+  });
+
+  it("returns flat null when both zero", () => {
+    const m = computeDigestMetric(0, 0);
+    expect(m.delta_pct).toBeNull();
+    expect(m.direction).toBe("flat");
+  });
+
+  it("coerces non-numeric/garbage to 0", () => {
+    expect(computeDigestMetric(undefined, null)).toEqual({
+      current: 0,
+      previous: 0,
+      delta_pct: null,
+      direction: "flat",
+    });
+  });
+
+  it("rounds delta to 1 dp", () => {
+    expect(computeDigestMetric(1, 3).delta_pct).toBe(-66.7);
+  });
+});
+
+describe("buildDigestKpis", () => {
+  it("maps overview stats into delta-annotated KPIs", () => {
+    const out = buildDigestKpis(
+      { unique_visitors: 120, total_pageviews: 400, bounce_rate: 0.5 },
+      { unique_visitors: 100, total_pageviews: 500, bounce_rate: 0.4 }
+    );
+    expect(out.unique_visitors).toMatchObject({ current: 120, previous: 100, direction: "up" });
+    expect(out.pageviews.direction).toBe("down");
+    expect(out.bounce_rate.current).toBe(0.5);
+  });
+
+  it("handles null inputs without throwing", () => {
+    const out = buildDigestKpis(null, undefined);
+    expect(out.unique_visitors.current).toBe(0);
+    expect(out.bounce_rate.delta_pct).toBeNull();
+  });
+});
+
+describe("breakdownToItems", () => {
+  it("maps top-N rows and coerces types", () => {
+    const items = breakdownToItems(
+      {
+        total_events: 10,
+        results: [
+          { value: "/home", count: 6, percentage: 60 },
+          { value: "/about", count: 4, percentage: 40 },
+        ],
+      },
+      5
+    );
+    expect(items).toEqual([
+      { value: "/home", count: 6, percentage: 60 },
+      { value: "/about", count: 4, percentage: 40 },
+    ]);
+  });
+
+  it("limits to N and labels null values", () => {
+    const items = breakdownToItems(
+      { results: [{ value: null, count: 3, percentage: 100 }, { value: "x", count: 1, percentage: 0 }] },
+      1
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].value).toBe("(none)");
+  });
+
+  it("returns [] for missing/empty input", () => {
+    expect(breakdownToItems(null)).toEqual([]);
+    expect(breakdownToItems({})).toEqual([]);
+    expect(breakdownToItems({ results: [] })).toEqual([]);
+  });
+});
+
+describe("buildDigestSuggestions", () => {
+  const ids = (s: ReturnType<typeof buildDigestSuggestions>) => s.map((x) => x.id);
+
+  it("returns no suggestions for a healthy storefront", () => {
+    const out = buildDigestSuggestions({
+      kpis: kpis(),
+      breakdowns: breakdowns({ devices: [{ value: "desktop", count: 100, percentage: 100 }] }),
+      not_found_count: 0,
+    });
+    expect(out).toEqual([]);
+  });
+
+  it("flags high bounce rate", () => {
+    const out = buildDigestSuggestions({
+      kpis: kpis({ bounce_rate: [0.75, 0.7] }),
+      breakdowns: breakdowns(),
+      not_found_count: 0,
+    });
+    expect(ids(out)).toContain("bounce_rate_high");
+  });
+
+  it("flags a sharply rising bounce rate even below the absolute threshold", () => {
+    const out = buildDigestSuggestions({
+      kpis: kpis({ bounce_rate: [0.5, 0.3] }), // +66% up
+      breakdowns: breakdowns(),
+      not_found_count: 0,
+    });
+    expect(ids(out)).toContain("bounce_rate_high");
+  });
+
+  it("flags mobile-heavy traffic with enough sample", () => {
+    const out = buildDigestSuggestions({
+      kpis: kpis({ unique_visitors: [50, 40] }),
+      breakdowns: breakdowns({
+        devices: [
+          { value: "mobile", count: 70, percentage: 70 },
+          { value: "desktop", count: 30, percentage: 30 },
+        ],
+      }),
+      not_found_count: 0,
+    });
+    expect(ids(out)).toContain("mobile_heavy_traffic");
+  });
+
+  it("suppresses sample-gated rules on tiny traffic", () => {
+    const out = buildDigestSuggestions({
+      kpis: kpis({ unique_visitors: [5, 4] }), // below minVisitorsForRules
+      breakdowns: breakdowns({
+        devices: [{ value: "mobile", count: 5, percentage: 100 }],
+        referrers: [{ value: "google", count: 5, percentage: 100 }],
+      }),
+      not_found_count: 0,
+    });
+    expect(ids(out)).not.toContain("mobile_heavy_traffic");
+    expect(ids(out)).not.toContain("single_top_referrer");
+  });
+
+  it("suggests leaning into a single dominant referrer", () => {
+    const out = buildDigestSuggestions({
+      kpis: kpis({ unique_visitors: [60, 50] }),
+      breakdowns: breakdowns({
+        referrers: [{ value: "instagram", count: 50, percentage: 80 }],
+      }),
+      not_found_count: 0,
+    });
+    const s = out.find((x) => x.id === "single_top_referrer");
+    expect(s).toBeTruthy();
+    expect(s!.title).toContain("instagram");
+  });
+
+  it("does not lean into a '(none)' referrer", () => {
+    const out = buildDigestSuggestions({
+      kpis: kpis({ unique_visitors: [60, 50] }),
+      breakdowns: breakdowns({ referrers: [{ value: "(none)", count: 50, percentage: 90 }] }),
+      not_found_count: 0,
+    });
+    expect(ids(out)).not.toContain("single_top_referrer");
+  });
+
+  it("flags a low-engagement dominant top page", () => {
+    const out = buildDigestSuggestions({
+      kpis: kpis({ unique_visitors: [60, 50], pages_per_session: [1.2, 1.3] }),
+      breakdowns: breakdowns({ top_pages: [{ value: "/product/x", count: 40, percentage: 60 }] }),
+      not_found_count: 0,
+    });
+    expect(ids(out)).toContain("low_engagement_top_page");
+  });
+
+  it("flags many 404s", () => {
+    const out = buildDigestSuggestions({
+      kpis: kpis(),
+      breakdowns: breakdowns(),
+      not_found_count: 12,
+    });
+    expect(ids(out)).toContain("many_404s");
+  });
+
+  it("suggests a promo when visitors decline beyond the drop threshold", () => {
+    const out = buildDigestSuggestions({
+      kpis: kpis({ unique_visitors: [70, 100] }), // -30%
+      breakdowns: breakdowns(),
+      not_found_count: 0,
+    });
+    expect(ids(out)).toContain("visitors_declining");
+  });
+
+  it("does not suggest a promo on a small dip", () => {
+    const out = buildDigestSuggestions({
+      kpis: kpis({ unique_visitors: [97, 100] }), // -3%
+      breakdowns: breakdowns(),
+      not_found_count: 0,
+    });
+    expect(ids(out)).not.toContain("visitors_declining");
+  });
+
+  it("honours overridden thresholds", () => {
+    const lenient = buildDigestSuggestions(
+      { kpis: kpis({ bounce_rate: [0.65, 0.6] }), breakdowns: breakdowns(), not_found_count: 0 },
+      { ...DEFAULT_DIGEST_THRESHOLDS, bounceRateHigh: 0.9 }
+    );
+    expect(ids(lenient)).not.toContain("bounce_rate_high");
+  });
+
+  it("merges a partial threshold override with defaults", () => {
+    // Only notFoundHigh overridden; the rest fall back to defaults.
+    const out = buildDigestSuggestions(
+      { kpis: kpis(), breakdowns: breakdowns(), not_found_count: 3 },
+      { notFoundHigh: 2 } as any
+    );
+    expect(ids(out)).toContain("many_404s");
+  });
+});

--- a/apps/backend/src/workflows/analytics/get-partner-storefront-digest.ts
+++ b/apps/backend/src/workflows/analytics/get-partner-storefront-digest.ts
@@ -1,0 +1,206 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
+import { WEBSITE_MODULE } from "../../modules/website";
+import { getWebsiteAnalyticsOverviewWorkflow } from "./get-website-analytics-overview";
+import { getAnalyticsBreakdownWorkflow } from "./reports/get-analytics-breakdown";
+import {
+  breakdownToItems,
+  buildDigestKpis,
+  buildDigestSuggestions,
+  resolvePeriodRange,
+  type DigestPeriod,
+  type DigestThresholds,
+  type PartnerStorefrontDigest,
+} from "./partner-digest-lib";
+
+/**
+ * Compute a per-partner storefront analytics digest (#581 S1).
+ *
+ * Given a partner id + period it resolves the partner's website, runs the
+ * #569 overview for the current AND previous windows (for deltas), pulls the
+ * #559 breakdowns the digest surfaces, and assembles a digest JSON with
+ * rule-based suggestions (pure helpers in `partner-digest-lib.ts`).
+ *
+ * Per-partner scoping: a partner's analytics = their website's events. The
+ * website is resolved from the partner's `website_id` column (metadata
+ * fallback), then `storefront_domain` — mirroring
+ * `api/partners/storefront/helpers.ts#getPartnerWebsite`.
+ */
+export type GetPartnerStorefrontDigestInput = {
+  partner_id: string;
+  period?: DigestPeriod;
+  thresholds?: Partial<DigestThresholds>;
+  /** ISO timestamp; injectable for deterministic runs. Defaults to now. */
+  now?: string;
+};
+
+const resolvePartnerWebsiteId = async (
+  partnerId: string,
+  container: any
+): Promise<{ websiteId: string | null; partner: any }> => {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY);
+  const { data } = await query.graph({
+    entity: "partners",
+    filters: { id: partnerId },
+    fields: ["id", "website_id", "storefront_domain", "metadata"],
+  });
+  const partner = (data || [])[0] || null;
+  if (!partner) {
+    return { websiteId: null, partner: null };
+  }
+
+  const websiteService: any = container.resolve(WEBSITE_MODULE);
+
+  // 1. Direct id (column or metadata fallback).
+  const directId = partner.website_id || partner.metadata?.website_id;
+  if (directId) {
+    try {
+      const w = await websiteService.retrieveWebsite(directId);
+      if (w) return { websiteId: w.id, partner };
+    } catch {
+      // stale id — fall through to domain lookup
+    }
+  }
+
+  // 2. Fallback by storefront domain.
+  const domain =
+    partner.storefront_domain || partner.metadata?.storefront_domain;
+  if (domain) {
+    const [websites] = await websiteService.listAndCountWebsites(
+      { domain },
+      { take: 1 }
+    );
+    if (websites?.[0]) return { websiteId: websites[0].id, partner };
+  }
+
+  return { websiteId: null, partner };
+};
+
+export const getPartnerStorefrontDigestStep = createStep(
+  "get-partner-storefront-digest-step",
+  async (input: GetPartnerStorefrontDigestInput, { container }) => {
+    const now = input.now ? new Date(input.now) : new Date();
+    const ranges = resolvePeriodRange(input.period ?? "last_7_days", now);
+
+    const { websiteId, partner } = await resolvePartnerWebsiteId(
+      input.partner_id,
+      container
+    );
+
+    // No storefront yet → empty digest (no suggestions). Never throws so the
+    // visual flow can skip un-provisioned partners gracefully.
+    if (!websiteId) {
+      const empty: PartnerStorefrontDigest = {
+        partner_id: input.partner_id,
+        website: null,
+        period: {
+          label: ranges.label,
+          days: ranges.days,
+          current: ranges.current,
+          previous: ranges.previous,
+        },
+        kpis: buildDigestKpis(null, null),
+        breakdowns: { top_pages: [], referrers: [], devices: [], countries: [] },
+        not_found_count: 0,
+        suggestions: [],
+      };
+      return new StepResponse(empty);
+    }
+
+    const curStart = new Date(ranges.current.start);
+    const curEnd = new Date(ranges.current.end);
+
+    // Overview for both windows (for deltas).
+    const { result: currentOverview }: any =
+      await getWebsiteAnalyticsOverviewWorkflow(container).run({
+        input: {
+          website_id: websiteId,
+          from: ranges.current.start,
+          to: ranges.current.end,
+        },
+      });
+    const { result: previousOverview }: any =
+      await getWebsiteAnalyticsOverviewWorkflow(container).run({
+        input: {
+          website_id: websiteId,
+          from: ranges.previous.start,
+          to: ranges.previous.end,
+        },
+      });
+
+    const runBreakdown = (dimension: any, filters?: Record<string, string>) =>
+      getAnalyticsBreakdownWorkflow(container)
+        .run({
+          input: {
+            website_id: websiteId,
+            dimension,
+            start_date: curStart,
+            end_date: curEnd,
+            ...(filters ? { filters } : {}),
+            limit: 5,
+          },
+        })
+        .then((r: any) => r.result);
+
+    const [topPages, referrers, devices, countries, notFound] = await Promise.all([
+      runBreakdown("pathname"),
+      runBreakdown("referrer_source"),
+      runBreakdown("device_type"),
+      runBreakdown("country"),
+      runBreakdown("is_404", { is_404: "true" }),
+    ]);
+
+    const notFoundCount = Number((notFound as any)?.total_events ?? 0) || 0;
+
+    const breakdowns = {
+      top_pages: breakdownToItems(topPages as any),
+      referrers: breakdownToItems(referrers as any),
+      devices: breakdownToItems(devices as any),
+      countries: breakdownToItems(countries as any),
+    };
+
+    const kpis = buildDigestKpis(
+      (currentOverview as any)?.stats,
+      (previousOverview as any)?.stats
+    );
+
+    const websiteOut = (currentOverview as any)?.website;
+
+    const digest: PartnerStorefrontDigest = {
+      partner_id: input.partner_id,
+      website: websiteOut
+        ? { id: websiteOut.id, domain: websiteOut.domain, name: websiteOut.name }
+        : { id: websiteId, domain: partner?.storefront_domain ?? "", name: null },
+      period: {
+        label: ranges.label,
+        days: ranges.days,
+        current: ranges.current,
+        previous: ranges.previous,
+      },
+      kpis,
+      breakdowns,
+      not_found_count: notFoundCount,
+      suggestions: [],
+    };
+
+    digest.suggestions = buildDigestSuggestions(
+      digest,
+      { ...input.thresholds } as DigestThresholds
+    );
+
+    return new StepResponse(digest);
+  }
+);
+
+export const getPartnerStorefrontDigestWorkflow = createWorkflow(
+  "get-partner-storefront-digest",
+  (input: GetPartnerStorefrontDigestInput) => {
+    const digest = getPartnerStorefrontDigestStep(input);
+    return new WorkflowResponse(digest);
+  }
+);

--- a/apps/backend/src/workflows/analytics/partner-digest-lib.ts
+++ b/apps/backend/src/workflows/analytics/partner-digest-lib.ts
@@ -1,0 +1,417 @@
+/**
+ * Partner storefront digest — pure compute helpers (#581 S1).
+ *
+ * Framework-free so they can be unit-tested without a container and reused by
+ * the `get-partner-storefront-digest` workflow (and later the visual-flow
+ * operation in S3). The heavy lifting (analytics aggregation) is done by the
+ * #569 endpoints/libs; this module only:
+ *   - resolves a period into a current + previous comparison window,
+ *   - turns raw current/previous KPI numbers into delta-annotated metrics,
+ *   - maps #559 breakdown results into compact digest items,
+ *   - derives rule-based, thresholded "how to boost sales" suggestions.
+ *
+ * Co-located as `*-lib.ts` next to the workflow on purpose — these are NOT
+ * email helpers (do not move into workflows/email/lib; that tree is being
+ * dissolved per #578).
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A named period or an explicit day count. */
+export type DigestPeriod =
+  | "last_7_days"
+  | "last_28_days"
+  | "last_30_days"
+  | { days: number };
+
+export type DigestDateRange = {
+  /** ISO start (inclusive). */
+  start: string;
+  /** ISO end (inclusive). */
+  end: string;
+};
+
+export type DigestPeriodRanges = {
+  label: string;
+  /** Number of days each window spans. */
+  days: number;
+  current: DigestDateRange;
+  /** Immediately-preceding window of equal length, for WoW-style deltas. */
+  previous: DigestDateRange;
+};
+
+export type DigestDirection = "up" | "down" | "flat";
+
+export type DigestMetric = {
+  current: number;
+  previous: number;
+  /**
+   * Percentage change vs the previous window, rounded to 1 dp.
+   * `null` when the previous value is 0 (no meaningful baseline).
+   */
+  delta_pct: number | null;
+  direction: DigestDirection;
+};
+
+export type DigestBreakdownItem = {
+  value: string;
+  count: number;
+  /** Share of the window total, integer percentage (0–100). */
+  percentage: number;
+};
+
+/** Minimal subset of the #569 overview `stats` the digest consumes. */
+export type DigestStatsInput = {
+  unique_visitors?: number | null;
+  total_pageviews?: number | null;
+  total_sessions?: number | null;
+  bounce_rate?: number | null; // ratio 0..1
+  avg_session_duration?: number | null; // seconds
+  pages_per_session?: number | null;
+};
+
+export type DigestKpis = {
+  unique_visitors: DigestMetric;
+  pageviews: DigestMetric;
+  sessions: DigestMetric;
+  bounce_rate: DigestMetric;
+  avg_session_duration: DigestMetric;
+  pages_per_session: DigestMetric;
+};
+
+export type DigestBreakdowns = {
+  top_pages: DigestBreakdownItem[];
+  referrers: DigestBreakdownItem[];
+  devices: DigestBreakdownItem[];
+  countries: DigestBreakdownItem[];
+};
+
+export type DigestSuggestionSeverity = "info" | "warning" | "opportunity";
+
+export type DigestSuggestion = {
+  /** Stable rule id so consumers/templates can key off it. */
+  id: string;
+  severity: DigestSuggestionSeverity;
+  title: string;
+  detail: string;
+};
+
+export type PartnerStorefrontDigest = {
+  partner_id: string;
+  website: { id: string; domain: string; name?: string | null } | null;
+  period: { label: string; days: number; current: DigestDateRange; previous: DigestDateRange };
+  kpis: DigestKpis;
+  breakdowns: DigestBreakdowns;
+  /** Number of 404 pageviews in the current window. */
+  not_found_count: number;
+  suggestions: DigestSuggestion[];
+};
+
+/** Shape mirrors #559 `BreakdownResult` closely enough for mapping. */
+export type DigestBreakdownResultLike = {
+  total_events?: number | null;
+  results?: Array<{ value?: unknown; count?: unknown; percentage?: unknown }> | null;
+};
+
+// ---------------------------------------------------------------------------
+// Thresholds
+// ---------------------------------------------------------------------------
+
+export type DigestThresholds = {
+  /** Bounce rate (ratio) at/above which we flag the landing page. */
+  bounceRateHigh: number;
+  /** Mobile traffic share (0..1) at/above which we nudge mobile checkout. */
+  mobileShareHigh: number;
+  /** Top-referrer share (0..1) at/above which we suggest leaning in. */
+  singleReferrerShare: number;
+  /** 404 count at/above which we flag broken links. */
+  notFoundHigh: number;
+  /** Visitor delta_pct at/below which we suggest a promo (negative number). */
+  visitorDropPct: number;
+  /** pages_per_session at/below which a dominant top page reads as low-engagement. */
+  lowEngagementPagesPerSession: number;
+  /** Minimum visitors before referrer/page rules fire (avoid noise on tiny samples). */
+  minVisitorsForRules: number;
+};
+
+export const DEFAULT_DIGEST_THRESHOLDS: DigestThresholds = {
+  bounceRateHigh: 0.6,
+  mobileShareHigh: 0.6,
+  singleReferrerShare: 0.7,
+  notFoundHigh: 5,
+  visitorDropPct: -10,
+  lowEngagementPagesPerSession: 1.5,
+  minVisitorsForRules: 20,
+};
+
+// ---------------------------------------------------------------------------
+// Period resolution
+// ---------------------------------------------------------------------------
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const periodDays = (period: DigestPeriod): number => {
+  if (typeof period === "object" && period) {
+    const d = Math.floor(Number(period.days));
+    return Number.isFinite(d) && d > 0 ? d : 7;
+  }
+  switch (period) {
+    case "last_28_days":
+      return 28;
+    case "last_30_days":
+      return 30;
+    case "last_7_days":
+    default:
+      return 7;
+  }
+};
+
+const periodLabel = (period: DigestPeriod, days: number): string => {
+  if (typeof period === "string") return period;
+  return `last_${days}_days`;
+};
+
+/**
+ * Resolve a period into a current window ending at `now` plus an
+ * equal-length previous window for comparison. `now` is injectable for
+ * deterministic tests; defaults to the wall clock at call time.
+ */
+export const resolvePeriodRange = (
+  period: DigestPeriod,
+  now: Date = new Date()
+): DigestPeriodRanges => {
+  const days = periodDays(period);
+  const span = days * DAY_MS;
+  const end = now.getTime();
+  const currentStart = end - span;
+  const previousStart = currentStart - span;
+
+  return {
+    label: periodLabel(period, days),
+    days,
+    current: {
+      start: new Date(currentStart).toISOString(),
+      end: new Date(end).toISOString(),
+    },
+    previous: {
+      start: new Date(previousStart).toISOString(),
+      end: new Date(currentStart).toISOString(),
+    },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Metrics
+// ---------------------------------------------------------------------------
+
+const num = (v: unknown): number => {
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) ? n : 0;
+};
+
+const round = (value: number, dp: number): number => {
+  if (!Number.isFinite(value)) return 0;
+  const f = Math.pow(10, dp);
+  return Math.round(value * f) / f;
+};
+
+/**
+ * Build a delta-annotated metric from current/previous raw values.
+ * `delta_pct` is null when there is no baseline (previous == 0).
+ */
+export const computeDigestMetric = (
+  current: unknown,
+  previous: unknown
+): DigestMetric => {
+  const cur = num(current);
+  const prev = num(previous);
+
+  let delta_pct: number | null = null;
+  let direction: DigestDirection = "flat";
+
+  if (prev !== 0) {
+    delta_pct = round(((cur - prev) / Math.abs(prev)) * 100, 1);
+    if (delta_pct > 0) direction = "up";
+    else if (delta_pct < 0) direction = "down";
+  } else if (cur > 0) {
+    // No baseline but we have current activity — treat as upward, unknown %.
+    direction = "up";
+  }
+
+  return { current: cur, previous: prev, delta_pct, direction };
+};
+
+/** Assemble the KPI block from current + previous overview stats. */
+export const buildDigestKpis = (
+  current: DigestStatsInput | null | undefined,
+  previous: DigestStatsInput | null | undefined
+): DigestKpis => {
+  const c = current ?? {};
+  const p = previous ?? {};
+  return {
+    unique_visitors: computeDigestMetric(c.unique_visitors, p.unique_visitors),
+    pageviews: computeDigestMetric(c.total_pageviews, p.total_pageviews),
+    sessions: computeDigestMetric(c.total_sessions, p.total_sessions),
+    bounce_rate: computeDigestMetric(c.bounce_rate, p.bounce_rate),
+    avg_session_duration: computeDigestMetric(
+      c.avg_session_duration,
+      p.avg_session_duration
+    ),
+    pages_per_session: computeDigestMetric(
+      c.pages_per_session,
+      p.pages_per_session
+    ),
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Breakdown mapping
+// ---------------------------------------------------------------------------
+
+/** Map a #559 BreakdownResult into compact, top-N digest items. */
+export const breakdownToItems = (
+  result: DigestBreakdownResultLike | null | undefined,
+  limit = 5
+): DigestBreakdownItem[] => {
+  const rows = Array.isArray(result?.results) ? result!.results! : [];
+  const n = Math.max(1, Math.floor(limit) || 5);
+  return rows.slice(0, n).map((r) => ({
+    value: r?.value === null || r?.value === undefined ? "(none)" : String(r.value),
+    count: num(r?.count),
+    percentage: num(r?.percentage),
+  }));
+};
+
+// ---------------------------------------------------------------------------
+// Suggestions (rule-based v1)
+// ---------------------------------------------------------------------------
+
+const MOBILE_VALUES = new Set(["mobile", "tablet"]);
+
+const mobileShare = (devices: DigestBreakdownItem[]): number => {
+  const total = devices.reduce((s, d) => s + d.count, 0);
+  if (total <= 0) return 0;
+  const mobile = devices
+    .filter((d) => MOBILE_VALUES.has(d.value.toLowerCase()))
+    .reduce((s, d) => s + d.count, 0);
+  return mobile / total;
+};
+
+/**
+ * Derive thresholded, rule-based suggestions from a digest. Pure and
+ * deterministic; ordered most-actionable first. v2 will optionally feed the
+ * digest JSON to an `ai-extract` node (S5) for natural-language tips.
+ */
+export const buildDigestSuggestions = (
+  digest: Pick<PartnerStorefrontDigest, "kpis" | "breakdowns" | "not_found_count">,
+  thresholds: DigestThresholds = DEFAULT_DIGEST_THRESHOLDS
+): DigestSuggestion[] => {
+  const t = { ...DEFAULT_DIGEST_THRESHOLDS, ...thresholds };
+  const out: DigestSuggestion[] = [];
+
+  const kpis = digest.kpis;
+  const bd = digest.breakdowns ?? {
+    top_pages: [],
+    referrers: [],
+    devices: [],
+    countries: [],
+  };
+  const visitors = kpis?.unique_visitors?.current ?? 0;
+  const hasSample = visitors >= t.minVisitorsForRules;
+
+  // 1. High / rising bounce rate → landing page + speed.
+  const bounce = kpis?.bounce_rate;
+  if (
+    bounce &&
+    (bounce.current >= t.bounceRateHigh ||
+      (bounce.direction === "up" && (bounce.delta_pct ?? 0) >= 10))
+  ) {
+    out.push({
+      id: "bounce_rate_high",
+      severity: "warning",
+      title: "Reduce your bounce rate",
+      detail: `Your bounce rate is ${Math.round(
+        bounce.current * 100
+      )}%. Tighten your landing page copy and improve page load speed so more visitors stay.`,
+    });
+  }
+
+  // 2. Mobile-heavy traffic → optimise mobile checkout.
+  const mShare = mobileShare(bd.devices ?? []);
+  if (hasSample && mShare >= t.mobileShareHigh) {
+    out.push({
+      id: "mobile_heavy_traffic",
+      severity: "opportunity",
+      title: "Optimize for mobile",
+      detail: `${Math.round(
+        mShare * 100
+      )}% of your traffic is on mobile. Make sure your product pages and checkout are fast and easy on small screens.`,
+    });
+  }
+
+  // 3. Single dominant referrer → lean into that channel.
+  const topReferrer = (bd.referrers ?? [])[0];
+  if (
+    hasSample &&
+    topReferrer &&
+    topReferrer.percentage >= t.singleReferrerShare * 100 &&
+    topReferrer.value !== "(none)"
+  ) {
+    out.push({
+      id: "single_top_referrer",
+      severity: "info",
+      title: `Lean into ${topReferrer.value}`,
+      detail: `${topReferrer.percentage}% of your visitors come from ${topReferrer.value}. Double down on that channel — and diversify so you're not reliant on one source.`,
+    });
+  }
+
+  // 4. Dominant top page + low engagement → review pricing/images.
+  const topPage = (bd.top_pages ?? [])[0];
+  const pps = kpis?.pages_per_session?.current ?? 0;
+  if (
+    hasSample &&
+    topPage &&
+    topPage.value !== "(none)" &&
+    pps > 0 &&
+    pps <= t.lowEngagementPagesPerSession
+  ) {
+    out.push({
+      id: "low_engagement_top_page",
+      severity: "opportunity",
+      title: "Improve your most-visited page",
+      detail: `Most visits land on ${topPage.value} but engagement is low (${pps} pages/session). Review its pricing, images and call-to-action.`,
+    });
+  }
+
+  // 5. Many 404s → fix broken links / add redirects.
+  if ((digest.not_found_count ?? 0) >= t.notFoundHigh) {
+    out.push({
+      id: "many_404s",
+      severity: "warning",
+      title: "Fix broken links",
+      detail: `Visitors hit ${digest.not_found_count} "page not found" errors. Fix broken links or add redirects so you don't lose them.`,
+    });
+  }
+
+  // 6. Visitors dropping WoW → run a promo / post on social.
+  const uv = kpis?.unique_visitors;
+  if (
+    uv &&
+    uv.direction === "down" &&
+    uv.delta_pct !== null &&
+    uv.delta_pct <= t.visitorDropPct
+  ) {
+    out.push({
+      id: "visitors_declining",
+      severity: "opportunity",
+      title: "Win back visitors",
+      detail: `Visitors are down ${Math.abs(
+        uv.delta_pct
+      )}% vs the previous period. Run a promotion or post on social to bring traffic back.`,
+    });
+  }
+
+  return out;
+};


### PR DESCRIPTION
## #581 Slice S1 — digest compute

First slice of the per-partner storefront **analytics digest** (#581). Pure, unit-tested compute layer that later slices build on (S2 email, S3 visual-flow op, S4 weekly flow). Off `main`, independent.

### What
- **`partner-digest-lib.ts`** — framework-free, co-located `*-lib.ts` next to the workflow (NOT in `workflows/email/lib` — that tree is dissolving per #578):
  - `resolvePeriodRange(period, now?)` — named (`last_7_days`/`28`/`30`) or `{days}` → current window + an equal-length previous window for WoW-style deltas (`now` injectable for deterministic tests).
  - `computeDigestMetric` / `buildDigestKpis` — current/previous → delta-annotated KPI metrics (`delta_pct` null when no baseline, direction up/down/flat).
  - `breakdownToItems` — maps a #559 `BreakdownResult` into compact top-N digest items.
  - `buildDigestSuggestions(digest, thresholds?)` — rule-based v1 "boost sales" tips, thresholded + sample-gated: high/rising bounce, mobile-heavy traffic, single dominant referrer, low-engagement top page, many 404s, declining visitors. `DEFAULT_DIGEST_THRESHOLDS` exported; partial overrides merge with defaults.
- **`get-partner-storefront-digest.ts`** — thin orchestrator workflow `{partner_id, period?, thresholds?, now?}` → digest JSON:
  - resolves partner → website (`website_id` col → metadata → `storefront_domain`, mirroring `api/partners/storefront/helpers.ts#getPartnerWebsite`),
  - runs the #569 overview for current + previous windows and the #559 breakdowns (pathname/referrer_source/device_type/country + an `is_404` filtered count) via the established `workflow(container).run()` pattern,
  - assembles KPIs + breakdowns + suggestions. **Never throws** for an un-provisioned partner — returns an empty digest so the flow (S3/S4) can skip gracefully.

### Tests
- **29 unit tests** (`__tests__/partner-digest-lib.unit.spec.ts`) — `TEST_TYPE=unit … --testPathPattern=partner-digest-lib`, all green. Cover period math, delta edge cases (no baseline, both-zero, rounding), breakdown mapping, and every suggestion rule incl. threshold/sample gating.
- `tsc --noEmit` — 0 new errors in the added files (repo has a pre-existing baseline unrelated to this change).

### Verify
```
cd apps/backend
TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules npx jest --testPathPattern=partner-digest-lib
```

### Notes / next
- The workflow's live data path isn't integration-verifiable headless (needs a seeded partner+website+analytics events); the verifiable contract here is the pure lib. The orchestrator reuses already-tested #569/#559 workflows.
- **Next:** S2 — `partner-storefront-digest` template + `send-partner-digest-email` workflow (email_partner→Maileroo, mirror #576). S3 — visual-flow `partner-analytics-digest` op wrapping this workflow.

Part of #581. No-merge — for human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)