### PR TITLE
feat(analytics): partner storefront digest email (#581 S2) — stacked on #582

### DIFF
--- a/apps/backend/src/workflows/analytics/__tests__/partner-digest-email-lib.unit.spec.ts
+++ b/apps/backend/src/workflows/analytics/__tests__/partner-digest-email-lib.unit.spec.ts
@@ -1,0 +1,200 @@
+import {
+  buildKpiRows,
+  buildPartnerDigestTemplateData,
+  deltaLabel,
+  derivePartnerDigestFromEmail,
+  directionArrow,
+  formatDigestDate,
+  formatDuration,
+} from "../partner-digest-email-lib";
+import {
+  buildDigestKpis,
+  type PartnerStorefrontDigest,
+} from "../partner-digest-lib";
+
+const makeDigest = (
+  over: Partial<PartnerStorefrontDigest> = {}
+): PartnerStorefrontDigest => ({
+  partner_id: "part_1",
+  website: { id: "web_1", domain: "shop.example.com", name: "Example Shop" },
+  period: {
+    label: "last_7_days",
+    days: 7,
+    current: {
+      start: "2026-06-14T00:00:00.000Z",
+      end: "2026-06-21T00:00:00.000Z",
+    },
+    previous: {
+      start: "2026-06-07T00:00:00.000Z",
+      end: "2026-06-14T00:00:00.000Z",
+    },
+  },
+  kpis: buildDigestKpis(
+    {
+      unique_visitors: 150,
+      total_pageviews: 600,
+      total_sessions: 180,
+      bounce_rate: 0.42,
+      avg_session_duration: 95,
+      pages_per_session: 3.3,
+    },
+    {
+      unique_visitors: 120,
+      total_pageviews: 500,
+      total_sessions: 150,
+      bounce_rate: 0.5,
+      avg_session_duration: 80,
+      pages_per_session: 3,
+    }
+  ),
+  breakdowns: {
+    top_pages: [{ value: "/", count: 200, percentage: 40 }],
+    referrers: [{ value: "google", count: 100, percentage: 55 }],
+    devices: [{ value: "mobile", count: 120, percentage: 66 }],
+    countries: [{ value: "IN", count: 130, percentage: 72 }],
+  },
+  not_found_count: 3,
+  suggestions: [
+    {
+      id: "mobile_heavy_traffic",
+      severity: "opportunity",
+      title: "Optimize for mobile",
+      detail: "66% of traffic is on mobile.",
+    },
+  ],
+  ...over,
+});
+
+describe("derivePartnerDigestFromEmail", () => {
+  it("builds partner+<handle>@domain and slugifies the handle", () => {
+    expect(derivePartnerDigestFromEmail("Acme Co", "partner.jaalyantra.com")).toBe(
+      "partner+acme-co@partner.jaalyantra.com"
+    );
+  });
+  it("falls back to 'partner' for a missing handle", () => {
+    expect(derivePartnerDigestFromEmail(null, "x.com")).toBe("partner+partner@x.com");
+  });
+});
+
+describe("formatDigestDate", () => {
+  it("formats an ISO timestamp in UTC as 'Mon D, YYYY'", () => {
+    expect(formatDigestDate("2026-06-14T00:00:00.000Z")).toBe("Jun 14, 2026");
+  });
+  it("returns empty string for missing/invalid input", () => {
+    expect(formatDigestDate(undefined)).toBe("");
+    expect(formatDigestDate("not-a-date")).toBe("");
+  });
+});
+
+describe("directionArrow", () => {
+  it("maps direction to an arrow glyph", () => {
+    expect(directionArrow("up")).toBe("▲");
+    expect(directionArrow("down")).toBe("▼");
+    expect(directionArrow("flat")).toBe("—");
+  });
+});
+
+describe("deltaLabel", () => {
+  it("prefixes positive deltas with +", () => {
+    expect(deltaLabel({ current: 1, previous: 1, delta_pct: 12.3, direction: "up" })).toBe(
+      "+12.3%"
+    );
+  });
+  it("keeps the native minus for negatives and returns n/a without a baseline", () => {
+    expect(deltaLabel({ current: 1, previous: 2, delta_pct: -5, direction: "down" })).toBe(
+      "-5%"
+    );
+    expect(deltaLabel({ current: 1, previous: 0, delta_pct: null, direction: "up" })).toBe(
+      "n/a"
+    );
+    expect(deltaLabel(undefined)).toBe("n/a");
+  });
+});
+
+describe("formatDuration", () => {
+  it("formats sub-minute, minute and minute+second durations", () => {
+    expect(formatDuration(45)).toBe("45s");
+    expect(formatDuration(120)).toBe("2m");
+    expect(formatDuration(95)).toBe("1m 35s");
+    expect(formatDuration(null)).toBe("0s");
+  });
+});
+
+describe("buildKpiRows", () => {
+  const rows = buildKpiRows(makeDigest());
+
+  it("emits six rows in a stable order", () => {
+    expect(rows.map((r) => r.key)).toEqual([
+      "unique_visitors",
+      "pageviews",
+      "sessions",
+      "bounce_rate",
+      "avg_session_duration",
+      "pages_per_session",
+    ]);
+  });
+
+  it("renders counts as integers with a signed delta + arrow", () => {
+    const visitors = rows.find((r) => r.key === "unique_visitors")!;
+    expect(visitors.value).toBe("150");
+    expect(visitors.delta).toBe("+25%"); // (150-120)/120
+    expect(visitors.arrow).toBe("▲");
+  });
+
+  it("renders bounce rate as a percentage and session as duration", () => {
+    expect(rows.find((r) => r.key === "bounce_rate")!.value).toBe("42%");
+    expect(rows.find((r) => r.key === "avg_session_duration")!.value).toBe("1m 35s");
+    expect(rows.find((r) => r.key === "pages_per_session")!.value).toBe("3.3");
+  });
+});
+
+describe("buildPartnerDigestTemplateData", () => {
+  const data = buildPartnerDigestTemplateData({
+    partner: { name: "Acme Co", handle: "acme" },
+    admin: { first_name: "Jo", last_name: "Doe", email: "jo@acme.com" },
+    digest: makeDigest(),
+    dashboardUrl: "https://dash.example.com/",
+    storeUrl: "https://shop.example.com",
+    year: 2026,
+  });
+
+  it("flattens identity, website + period scalars to strings", () => {
+    expect(data.partner_name).toBe("Acme Co");
+    expect(data.admin_name).toBe("Jo Doe");
+    expect(data.website_domain).toBe("shop.example.com");
+    expect(data.website_name).toBe("Example Shop");
+    expect(data.period_label).toBe("last_7_days");
+    expect(data.period_start).toBe("Jun 14, 2026");
+    expect(data.period_end).toBe("Jun 21, 2026");
+    expect(data.current_year).toBe("2026");
+  });
+
+  it("strips a trailing slash off the dashboard CTA base", () => {
+    expect(data.dashboard_url).toBe("https://dash.example.com");
+  });
+
+  it("passes arrays through for {{#each}} and exposes suggestion flags", () => {
+    expect(Array.isArray(data.kpi_rows)).toBe(true);
+    expect(data.kpi_rows).toHaveLength(6);
+    expect(data.top_pages).toHaveLength(1);
+    expect(data.has_suggestions).toBe(true);
+    expect(data.suggestions_count).toBe("1");
+    expect(data.visitors_count).toBe("150");
+    expect(data.not_found_count).toBe("3");
+  });
+
+  it("falls back gracefully when partner/website fields are missing", () => {
+    const bare = buildPartnerDigestTemplateData({
+      partner: {},
+      admin: {},
+      digest: makeDigest({ website: null, suggestions: [] }),
+      year: 2026,
+    });
+    expect(bare.partner_name).toBe("Partner");
+    expect(bare.admin_name).toBe("");
+    expect(bare.website_name).toBe("your storefront");
+    expect(bare.has_website).toBe(false);
+    expect(bare.has_suggestions).toBe(false);
+    expect(bare.dashboard_url).toBe("");
+  });
+});

--- a/apps/backend/src/workflows/analytics/partner-digest-email-lib.ts
+++ b/apps/backend/src/workflows/analytics/partner-digest-email-lib.ts
@@ -1,0 +1,213 @@
+/**
+ * Partner storefront digest email — pure template-data helpers (#581 S2).
+ *
+ * Framework-free so the Handlebars template-data assembly + from-address
+ * derivation are unit-testable without booting Medusa or a mail provider.
+ *
+ * Co-located as `*-lib.ts` next to the digest workflow on purpose — NOT placed
+ * under `workflows/email/lib/` (that tree is being dissolved per #578). The
+ * tiny `derivePartnerFromEmail` helper is re-implemented here (rather than
+ * imported from `workflows/email/lib/partner-task-email.ts`) so this slice has
+ * no dependency on a directory scheduled for removal.
+ */
+
+import type {
+  DigestMetric,
+  PartnerStorefrontDigest,
+} from "./partner-digest-lib";
+
+export interface PartnerDigestEmailInput {
+  partner: { name?: string | null; handle?: string | null };
+  admin: {
+    first_name?: string | null;
+    last_name?: string | null;
+    email?: string | null;
+  };
+  digest: PartnerStorefrontDigest;
+  /** Base URL for the "View full analytics" CTA (partner dashboard). */
+  dashboardUrl?: string;
+  /** Storefront URL surfaced in the footer. */
+  storeUrl?: string;
+  /** Override for deterministic tests; defaults to the current year. */
+  year?: number;
+}
+
+/**
+ * Partner email from-address: partner+<handle>@<domain>.
+ * Mirrors `derivePartnerFromEmail` in the email module so digest, task and
+ * order emails all share one sender shape.
+ */
+export function derivePartnerDigestFromEmail(
+  handle: string | null | undefined,
+  fromDomain: string
+): string {
+  const safeHandle = (handle || "partner")
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, "-");
+  return `partner+${safeHandle}@${fromDomain}`;
+}
+
+const MONTHS = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+/** Format an ISO timestamp as e.g. "Jun 14, 2026" (UTC, locale-independent). */
+export function formatDigestDate(iso: string | null | undefined): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return `${MONTHS[d.getUTCMonth()]} ${d.getUTCDate()}, ${d.getUTCFullYear()}`;
+}
+
+/** "▲" up / "▼" down / "—" flat. */
+export function directionArrow(direction: string): string {
+  if (direction === "up") return "▲";
+  if (direction === "down") return "▼";
+  return "—";
+}
+
+/** Human delta label: "+12.3%", "-5%", or "n/a" when there is no baseline. */
+export function deltaLabel(metric: DigestMetric | null | undefined): string {
+  if (!metric || metric.delta_pct === null || metric.delta_pct === undefined) {
+    return "n/a";
+  }
+  const v = metric.delta_pct;
+  const sign = v > 0 ? "+" : "";
+  return `${sign}${v}%`;
+}
+
+const round = (v: number, dp = 0): number => {
+  if (!Number.isFinite(v)) return 0;
+  const f = Math.pow(10, dp);
+  return Math.round(v * f) / f;
+};
+
+/** Seconds → "1m 23s" / "45s". */
+export function formatDuration(seconds: number | null | undefined): string {
+  const s = Math.max(0, Math.round(Number(seconds) || 0));
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const rem = s % 60;
+  return rem ? `${m}m ${rem}s` : `${m}m`;
+}
+
+type KpiRow = {
+  key: string;
+  label: string;
+  value: string;
+  delta: string;
+  direction: string;
+  arrow: string;
+};
+
+const intRow = (key: string, label: string, m: DigestMetric): KpiRow => ({
+  key,
+  label,
+  value: String(round(m.current)),
+  delta: deltaLabel(m),
+  direction: m.direction,
+  arrow: directionArrow(m.direction),
+});
+
+/**
+ * Build the six KPI rows the email surfaces, pre-formatted for display.
+ * Bounce rate renders as a %, avg session duration as m/s, pages/session 1dp.
+ */
+export function buildKpiRows(digest: PartnerStorefrontDigest): KpiRow[] {
+  const k = digest.kpis;
+  return [
+    intRow("unique_visitors", "Unique visitors", k.unique_visitors),
+    intRow("pageviews", "Pageviews", k.pageviews),
+    intRow("sessions", "Sessions", k.sessions),
+    {
+      key: "bounce_rate",
+      label: "Bounce rate",
+      value: `${round(k.bounce_rate.current * 100)}%`,
+      delta: deltaLabel(k.bounce_rate),
+      direction: k.bounce_rate.direction,
+      arrow: directionArrow(k.bounce_rate.direction),
+    },
+    {
+      key: "avg_session_duration",
+      label: "Avg. session",
+      value: formatDuration(k.avg_session_duration.current),
+      delta: deltaLabel(k.avg_session_duration),
+      direction: k.avg_session_duration.direction,
+      arrow: directionArrow(k.avg_session_duration.direction),
+    },
+    {
+      key: "pages_per_session",
+      label: "Pages / session",
+      value: String(round(k.pages_per_session.current, 1)),
+      delta: deltaLabel(k.pages_per_session),
+      direction: k.pages_per_session.direction,
+      arrow: directionArrow(k.pages_per_session.direction),
+    },
+  ];
+}
+
+/**
+ * Assemble the Handlebars data for the `partner-storefront-digest` DB template.
+ * Scalars are coerced to strings so an undefined/null field renders blank
+ * rather than the literal "undefined"; arrays (kpi_rows, breakdowns,
+ * suggestions) are passed through for `{{#each}}` blocks.
+ */
+export function buildPartnerDigestTemplateData(
+  input: PartnerDigestEmailInput
+): Record<string, any> {
+  const { partner, admin, digest } = input;
+  const adminName = `${admin.first_name || ""} ${admin.last_name || ""}`.trim();
+  const dashboardBase = (input.dashboardUrl || "").replace(/\/$/, "");
+
+  const kpiRows = buildKpiRows(digest);
+  const suggestions = digest.suggestions || [];
+  const bd = digest.breakdowns || {
+    top_pages: [],
+    referrers: [],
+    devices: [],
+    countries: [],
+  };
+
+  return {
+    // Recipient + partner identity
+    partner_name: partner.name || "Partner",
+    partner_handle: partner.handle || "",
+    admin_name: adminName,
+    admin_first_name: admin.first_name || "",
+
+    // Storefront
+    website_name: digest.website?.name || digest.website?.domain || "your storefront",
+    website_domain: digest.website?.domain || "",
+    has_website: Boolean(digest.website),
+
+    // Period
+    period_label: digest.period?.label || "",
+    period_days: String(digest.period?.days ?? ""),
+    period_start: formatDigestDate(digest.period?.current?.start),
+    period_end: formatDigestDate(digest.period?.current?.end),
+
+    // KPIs (array for {{#each}} + a few headline scalars for the subject)
+    kpi_rows: kpiRows,
+    visitors_count: String(Math.round(digest.kpis.unique_visitors.current)),
+    visitors_delta: deltaLabel(digest.kpis.unique_visitors),
+
+    // Breakdowns
+    top_pages: bd.top_pages,
+    referrers: bd.referrers,
+    devices: bd.devices,
+    countries: bd.countries,
+    not_found_count: String(digest.not_found_count ?? 0),
+
+    // Suggestions
+    suggestions,
+    has_suggestions: suggestions.length > 0,
+    suggestions_count: String(suggestions.length),
+
+    // Links + footer
+    dashboard_url: dashboardBase,
+    store_url: input.storeUrl || "",
+    current_year: String(input.year ?? new Date().getFullYear()),
+  };
+}

--- a/apps/backend/src/workflows/analytics/send-partner-digest-email.ts
+++ b/apps/backend/src/workflows/analytics/send-partner-digest-email.ts
@@ -1,0 +1,160 @@
+import {
+  createWorkflow,
+  createStep,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk";
+import { Modules } from "@medusajs/framework/utils";
+import type { INotificationModuleService } from "@medusajs/types";
+import * as Handlebars from "handlebars";
+import { PARTNER_MODULE } from "../../modules/partner";
+import PartnerService from "../../modules/partner/service";
+import { EMAIL_TEMPLATES_MODULE } from "../../modules/email_templates";
+import EmailTemplatesService from "../../modules/email_templates/service";
+import type { PartnerStorefrontDigest } from "./partner-digest-lib";
+import {
+  buildPartnerDigestTemplateData,
+  derivePartnerDigestFromEmail,
+} from "./partner-digest-email-lib";
+
+const TEMPLATE_KEY = "partner-storefront-digest";
+
+export type SendPartnerDigestEmailInput = {
+  /** Pre-computed digest (from `get-partner-storefront-digest`). */
+  digest: PartnerStorefrontDigest;
+  /** Optional override; defaults to `digest.partner_id`. */
+  partner_id?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Step: resolve partner + active admins, compile the DB template and send a
+// "storefront analytics digest" email to each active partner admin.
+//
+// Mirrors sendPartnerTaskAssignedStep (send-partner-task-assigned-email.ts):
+//   - email_partner channel (Maileroo) so partner mail routes like the rest
+//   - DB template fetched/compiled via EmailTemplatesService + Handlebars
+//   - per-admin send is best-effort; a missing partner/template skips quietly
+//     so a weekly visual-flow run never crashes on one un-provisioned partner.
+// ---------------------------------------------------------------------------
+const sendPartnerDigestStep = createStep(
+  { name: "send-partner-storefront-digest-notification", store: true },
+  async (input: SendPartnerDigestEmailInput, { container }) => {
+    const digest = input.digest;
+    const partnerId = input.partner_id || digest?.partner_id;
+
+    if (!partnerId || !digest) {
+      return new StepResponse({ sent: 0, skipped: true });
+    }
+
+    // 1) Partner + active admins
+    const partnerService: PartnerService = container.resolve(PARTNER_MODULE);
+    let partner: any = null;
+    let admins: any[] = [];
+    try {
+      const partners = await partnerService.listPartners(
+        { id: partnerId },
+        { relations: ["admins"], select: ["id", "name", "handle"] }
+      );
+      partner = (partners as any[])?.[0] || null;
+      admins = (partner?.admins || []).filter((a: any) => a.is_active);
+    } catch (err) {
+      console.warn(
+        `[partner-digest-email] Failed to fetch partner ${partnerId}: ${
+          (err as Error).message
+        }`
+      );
+    }
+
+    if (!partner || admins.length === 0) {
+      console.log(
+        `[partner-digest-email] No partner/admins for ${partnerId} — skipping`
+      );
+      return new StepResponse({ sent: 0, skipped: true });
+    }
+
+    // 2) DB template (best-effort: a missing/inactive row never crashes the
+    //    weekly digest flow — it just skips that partner).
+    const emailTemplatesService: EmailTemplatesService =
+      container.resolve(EMAIL_TEMPLATES_MODULE);
+    let template: any;
+    try {
+      template = await emailTemplatesService.getTemplateByKey(TEMPLATE_KEY);
+    } catch (err) {
+      console.warn(
+        `[partner-digest-email] Template "${TEMPLATE_KEY}" missing/inactive: ${
+          (err as Error).message
+        }`
+      );
+      return new StepResponse({ sent: 0, skipped: true });
+    }
+
+    const compiledHtml = Handlebars.compile(template.html_content);
+    const compiledSubject = Handlebars.compile(template.subject);
+
+    const fromDomain =
+      process.env.MAILEROO_FROM_DOMAIN || "partner.jaalyantra.com";
+    const partnerFromEmail = derivePartnerDigestFromEmail(
+      partner.handle,
+      fromDomain
+    );
+    const partnerFromName = partner.name || "Jaal Yantra Textiles Partner";
+    const dashboardUrl = process.env.PARTNER_DASHBOARD_URL
+      ? `${process.env.PARTNER_DASHBOARD_URL}/analytics`
+      : "";
+
+    const notificationService = container.resolve(
+      Modules.NOTIFICATION
+    ) as INotificationModuleService;
+
+    let sentCount = 0;
+    for (const admin of admins) {
+      const templateData = buildPartnerDigestTemplateData({
+        partner,
+        admin,
+        digest,
+        dashboardUrl,
+        storeUrl: process.env.FRONTEND_URL || "",
+      });
+
+      const renderedHtml = compiledHtml(templateData);
+      const renderedSubject = compiledSubject(templateData);
+
+      try {
+        await notificationService.createNotifications({
+          to: admin.email,
+          channel: "email_partner",
+          template: TEMPLATE_KEY,
+          data: {
+            ...templateData,
+            _template_subject: renderedSubject,
+            _template_html_content: renderedHtml,
+            _template_from: partnerFromEmail,
+            _template_processed: true,
+            _partner_from_email: partnerFromEmail,
+            _partner_from_name: partnerFromName,
+          },
+        });
+        sentCount++;
+        console.log(
+          `[partner-digest-email] Sent ${TEMPLATE_KEY} to ${admin.email} (partner: ${partner.name})`
+        );
+      } catch (err) {
+        console.error(
+          `[partner-digest-email] Failed to send to ${admin.email}: ${
+            (err as Error).message
+          }`
+        );
+      }
+    }
+
+    return new StepResponse({ sent: sentCount, skipped: false });
+  }
+);
+
+export const sendPartnerDigestEmailWorkflow = createWorkflow(
+  { name: "send-partner-digest-email", store: true },
+  (input: SendPartnerDigestEmailInput) => {
+    const result = sendPartnerDigestStep(input);
+    return new WorkflowResponse(result);
+  }
+);


### PR DESCRIPTION
## #581 S2 — partner storefront digest email

**Stacked on #582 (merge parent-first).** S2 imports the digest type from S1's lib; off `main` it wouldn't exist yet. Base = `feat/581-partner-digest-compute`.

The email side of the per-partner storefront analytics digest (#581). Given a pre-computed digest (from S1's `get-partner-storefront-digest`), sends a "your storefront, last N days" email with KPI deltas, top breakdowns and rule-based sales suggestions to each active partner admin.

### What's here
- **`partner-digest-email-lib.ts`** — pure, framework-free template-data helpers (unit-testable without a container or mail provider):
  - `buildPartnerDigestTemplateData` flattens the S1 digest into Handlebars data — 6 pre-formatted KPI rows (counts as ints, bounce rate as %, session as `1m 35s`, signed deltas + ▲▼— arrows), breakdown arrays passed through for `{{#each}}`, suggestion flags.
  - `derivePartnerDigestFromEmail` / `formatDigestDate` (UTC, locale-independent) / `directionArrow` / `deltaLabel` / `formatDuration`.
  - From-address helper re-implemented locally (not imported from `workflows/email/lib/` — that tree is dissolving per #578).
- **`send-partner-digest-email.ts`** — `sendPartnerDigestEmailWorkflow`, mirrors `send-partner-task-assigned-email.ts` (#575): resolves partner + active admins, fetches/compiles the `partner-storefront-digest` DB template via `EmailTemplatesService` + Handlebars, sends per-admin through the **`email_partner` (Maileroo)** channel. Best-effort — a missing partner/template/admin skips quietly so a weekly flow never crashes on one un-provisioned partner.

### Tests
- 15 unit tests (`partner-digest-email-lib.unit.spec.ts`), all green.
- `TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules npx jest --testPathPattern=partner-digest-email-lib`
- 0 new tsc errors in changed files.

### Ops tail before prod delivery (daemon can't author content)
1. Author a **`partner-storefront-digest`** `email_template` row (active=true) — subject + Handlebars `html_content` consuming `kpi_rows`, `top_pages`/`referrers`/`devices`/`countries`, `suggestions`, `period_start`/`period_end`, `dashboard_url`.
2. Ensure env: `MAILEROO_FROM_DOMAIN`, `PARTNER_DASHBOARD_URL`, `FRONTEND_URL`.
3. Live email send is **not headless-verifiable** (base config lacks Maileroo creds).

### Next (#581)
- **S3** — visual-flow op `partner-analytics-digest` wrapping S1, feeds this workflow via `bulk-trigger-workflow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)