### PR TITLE
feat(analytics): partner-analytics-digest visual-flow op (#581 S3) — stacked on #582

### DIFF
--- a/apps/backend/src/modules/visual_flows/operations/__tests__/partner-analytics-digest.unit.spec.ts
+++ b/apps/backend/src/modules/visual_flows/operations/__tests__/partner-analytics-digest.unit.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for the `partner_analytics_digest` operation's pure helpers
+ * (#581 S3). The orchestration in `execute` resolves the container + runs the
+ * S1 workflow per partner, which isn't headless-testable; the selection and
+ * summary logic IS pure, so we assert it directly without booting Medusa.
+ */
+
+import {
+  selectDigestPartnerIds,
+  summarizeDigestRun,
+  partnerAnalyticsDigestOperation,
+  partnerAnalyticsDigestOptionsSchema,
+} from "../partner-analytics-digest"
+
+describe("selectDigestPartnerIds", () => {
+  it("uses an explicit single partner_id", () => {
+    expect(
+      selectDigestPartnerIds({ partnerId: "p_1", listedPartnerIds: ["p_9"] })
+    ).toEqual(["p_1"])
+  })
+
+  it("uses an explicit partner_ids array (ignores listed)", () => {
+    expect(
+      selectDigestPartnerIds({
+        partnerIds: ["p_1", "p_2"],
+        listedPartnerIds: ["p_9"],
+      })
+    ).toEqual(["p_1", "p_2"])
+  })
+
+  it("merges partner_id + partner_ids when both supplied", () => {
+    expect(
+      selectDigestPartnerIds({ partnerId: "p_1", partnerIds: ["p_2", "p_3"] })
+    ).toEqual(["p_1", "p_2", "p_3"])
+  })
+
+  it("accepts partner_ids as a single string", () => {
+    expect(selectDigestPartnerIds({ partnerIds: "p_5" })).toEqual(["p_5"])
+  })
+
+  it("falls back to listed partners when no explicit selection", () => {
+    expect(
+      selectDigestPartnerIds({ listedPartnerIds: ["p_a", "p_b"] })
+    ).toEqual(["p_a", "p_b"])
+  })
+
+  it("de-dupes preserving first-seen order", () => {
+    expect(
+      selectDigestPartnerIds({
+        partnerId: "p_1",
+        partnerIds: ["p_1", "p_2", "p_2", "p_3"],
+      })
+    ).toEqual(["p_1", "p_2", "p_3"])
+  })
+
+  it("trims whitespace and drops empty entries", () => {
+    expect(
+      selectDigestPartnerIds({
+        partnerId: "  p_1  ",
+        partnerIds: ["", "  ", "p_2 "],
+      })
+    ).toEqual(["p_1", "p_2"])
+  })
+
+  it("caps to maxPartners", () => {
+    expect(
+      selectDigestPartnerIds({
+        listedPartnerIds: ["a", "b", "c", "d"],
+        maxPartners: 2,
+      })
+    ).toEqual(["a", "b"])
+  })
+
+  it("returns [] when nothing is selectable", () => {
+    expect(selectDigestPartnerIds({})).toEqual([])
+    expect(
+      selectDigestPartnerIds({ listedPartnerIds: ["", null as any] })
+    ).toEqual([])
+  })
+
+  it("ignores non-string entries in partner_ids", () => {
+    expect(
+      selectDigestPartnerIds({
+        partnerIds: ["p_1", 42 as any, null as any, "p_2"],
+      })
+    ).toEqual(["p_1", "p_2"])
+  })
+
+  it("defaults maxPartners sanely when invalid", () => {
+    const ids = Array.from({ length: 250 }, (_, i) => `p_${i}`)
+    expect(
+      selectDigestPartnerIds({ listedPartnerIds: ids, maxPartners: 0 }).length
+    ).toBe(200)
+  })
+})
+
+describe("summarizeDigestRun", () => {
+  const digest = (overrides: any = {}) => ({
+    partner_id: "p",
+    website: { id: "web_1" },
+    period: {} as any,
+    kpis: {} as any,
+    breakdowns: {} as any,
+    not_found_count: 0,
+    suggestions: [],
+    ...overrides,
+  })
+
+  it("counts empty as all zero", () => {
+    expect(summarizeDigestRun([])).toEqual({
+      count: 0,
+      with_storefront: 0,
+      with_suggestions: 0,
+      suggestion_count: 0,
+    })
+  })
+
+  it("tallies storefronts, suggestion-bearing partners, and total suggestions", () => {
+    const out = summarizeDigestRun([
+      digest({ website: { id: "w1" }, suggestions: [{}, {}] }),
+      digest({ website: null, suggestions: [] }),
+      digest({ website: { id: "w3" }, suggestions: [{}] }),
+    ] as any)
+    expect(out).toEqual({
+      count: 3,
+      with_storefront: 2,
+      with_suggestions: 2,
+      suggestion_count: 3,
+    })
+  })
+
+  it("treats a missing suggestions array as zero", () => {
+    const out = summarizeDigestRun([
+      digest({ suggestions: undefined }),
+    ] as any)
+    expect(out.with_suggestions).toBe(0)
+    expect(out.suggestion_count).toBe(0)
+  })
+})
+
+describe("partnerAnalyticsDigestOperation definition", () => {
+  it("registers under a stable type with a default options schema", () => {
+    expect(partnerAnalyticsDigestOperation.type).toBe("partner_analytics_digest")
+    expect(partnerAnalyticsDigestOperation.category).toBe("data")
+    // schema parses an empty object via defaults
+    const parsed = partnerAnalyticsDigestOptionsSchema.parse({})
+    expect(parsed.max_partners).toBe(200)
+    expect(parsed.continue_on_error).toBe(true)
+  })
+
+  it("accepts a named period and a {days} period", () => {
+    expect(
+      partnerAnalyticsDigestOptionsSchema.parse({ period: "last_30_days" })
+        .period
+    ).toBe("last_30_days")
+    expect(
+      partnerAnalyticsDigestOptionsSchema.parse({ period: { days: 14 } }).period
+    ).toEqual({ days: 14 })
+  })
+})

--- a/apps/backend/src/modules/visual_flows/operations/index.ts
+++ b/apps/backend/src/modules/visual_flows/operations/index.ts
@@ -29,6 +29,7 @@ export { bulkTriggerWorkflowOperation } from "./bulk-trigger-workflow"
 export { aiExtractOperation } from "./ai-extract"
 export { aiExtractPlatformOperation } from "./ai-extract-platform"
 export { generatePartnerDeeplinkOperation } from "./generate-partner-deeplink"
+export { partnerAnalyticsDigestOperation } from "./partner-analytics-digest"
 export { waitForEventOperation } from "./wait-for-event"
 
 // Import all operations and register them
@@ -59,6 +60,7 @@ import { bulkTriggerWorkflowOperation } from "./bulk-trigger-workflow"
 import { aiExtractOperation } from "./ai-extract"
 import { aiExtractPlatformOperation } from "./ai-extract-platform"
 import { generatePartnerDeeplinkOperation } from "./generate-partner-deeplink"
+import { partnerAnalyticsDigestOperation } from "./partner-analytics-digest"
 import { waitForEventOperation } from "./wait-for-event"
 
 // Register all built-in operations
@@ -101,6 +103,7 @@ export function registerBuiltInOperations(): void {
   operationRegistry.register(aggregateDataOperation)
   operationRegistry.register(timeSeriesOperation)
   operationRegistry.register(cartRecoveryStatsOperation)
+  operationRegistry.register(partnerAnalyticsDigestOperation)
 }
 
 // Auto-register on import

--- a/apps/backend/src/modules/visual_flows/operations/partner-analytics-digest.ts
+++ b/apps/backend/src/modules/visual_flows/operations/partner-analytics-digest.ts
@@ -1,0 +1,272 @@
+import { z } from "@medusajs/framework/zod"
+import { OperationDefinition, OperationContext, OperationResult } from "./types"
+import { interpolateVariables } from "./utils"
+import { PARTNER_MODULE } from "../../partner"
+import {
+  getPartnerStorefrontDigestWorkflow,
+  type GetPartnerStorefrontDigestInput,
+} from "../../../workflows/analytics/get-partner-storefront-digest"
+import type {
+  DigestPeriod,
+  PartnerStorefrontDigest,
+} from "../../../workflows/analytics/partner-digest-lib"
+
+/**
+ * Partner storefront analytics digest operation (#581 S3).
+ *
+ * Wraps the S1 `getPartnerStorefrontDigestWorkflow` so a visual flow can
+ * compute a per-partner storefront analytics digest (#569 KPIs + #559
+ * breakdowns + rule-based suggestions) for one partner, an explicit list, or
+ * every active partner — without an admin building a bespoke loop node.
+ *
+ * Why this isn't doable with `trigger_workflow` alone:
+ *   - the weekly flow needs ALL active partners as its fan-out source, which
+ *     means listing them (a query) before any per-item invocation
+ *   - per-partner digest compute must never crash the run (one un-provisioned
+ *     partner shouldn't abort the others) — this op swallows per-partner errors
+ *   - the output is shaped as an array under `digests` so it feeds straight
+ *     into `bulk_trigger_workflow` (items: `{{ partner_digest.digests }}`,
+ *     input_template: `{ digest: "{{ item }}" }`) → `send-partner-digest-email`
+ *
+ * Output:
+ *   `{ digests: PartnerStorefrontDigest[], records, count, with_storefront,
+ *      with_suggestions, requested, failed, errors }`
+ *   `records` aliases `digests` so panels that read `display.field`-style
+ *   array outputs work too.
+ */
+
+export const partnerAnalyticsDigestOptionsSchema = z.object({
+  /** Single partner id (or a {{ variable }} reference). */
+  partner_id: z.string().optional(),
+  /** Explicit partner ids (or a {{ variable }} reference resolving to an array). */
+  partner_ids: z.union([z.string(), z.array(z.string())]).optional(),
+  /**
+   * Named window or `{ days }`. Defaults to last 7 days — a weekly digest.
+   * Passed through verbatim to the S1 workflow.
+   */
+  period: z
+    .union([
+      z.enum(["last_7_days", "last_28_days", "last_30_days"]),
+      z.object({ days: z.number().int().min(1).max(365) }),
+    ])
+    .optional(),
+  /** Partial threshold overrides for the suggestion rules (S1). */
+  thresholds: z.record(z.string(), z.any()).optional(),
+  /** ISO timestamp; injectable for deterministic runs. Defaults to now. */
+  now: z.string().optional(),
+  /** Cap on partners processed in one run. */
+  max_partners: z.number().int().min(1).max(1000).default(200),
+  /** Keep going when a single partner's digest compute throws. */
+  continue_on_error: z.boolean().default(true),
+})
+
+export type PartnerAnalyticsDigestOptions = z.infer<
+  typeof partnerAnalyticsDigestOptionsSchema
+>
+
+/**
+ * Resolve the final, de-duplicated, capped list of partner ids to process.
+ *
+ * Precedence: an explicit `partner_id` / `partner_ids` selection wins; only
+ * when neither is supplied do we fall back to the listed (active) partners.
+ * Pure so it's unit-testable without booting Medusa.
+ */
+export function selectDigestPartnerIds(input: {
+  partnerId?: string | null
+  partnerIds?: unknown
+  listedPartnerIds?: string[]
+  maxPartners?: number
+}): string[] {
+  const cap =
+    Number.isFinite(input.maxPartners) && (input.maxPartners as number) > 0
+      ? Math.floor(input.maxPartners as number)
+      : 200
+
+  const explicit: string[] = []
+  if (typeof input.partnerId === "string" && input.partnerId.trim()) {
+    explicit.push(input.partnerId.trim())
+  }
+  if (Array.isArray(input.partnerIds)) {
+    for (const v of input.partnerIds) {
+      if (typeof v === "string" && v.trim()) explicit.push(v.trim())
+    }
+  } else if (
+    typeof input.partnerIds === "string" &&
+    (input.partnerIds as string).trim()
+  ) {
+    explicit.push((input.partnerIds as string).trim())
+  }
+
+  const source =
+    explicit.length > 0
+      ? explicit
+      : (input.listedPartnerIds ?? []).filter(
+          (v): v is string => typeof v === "string" && v.trim().length > 0
+        )
+
+  // De-dupe preserving first-seen order, then cap.
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const id of source) {
+    if (seen.has(id)) continue
+    seen.add(id)
+    out.push(id)
+    if (out.length >= cap) break
+  }
+  return out
+}
+
+/**
+ * Roll digests up into the flat scalars a downstream condition/log node or a
+ * metric panel can read. Pure.
+ */
+export function summarizeDigestRun(digests: PartnerStorefrontDigest[]): {
+  count: number
+  with_storefront: number
+  with_suggestions: number
+  suggestion_count: number
+} {
+  let withStorefront = 0
+  let withSuggestions = 0
+  let suggestionCount = 0
+  for (const d of digests) {
+    if (d?.website) withStorefront++
+    const n = Array.isArray(d?.suggestions) ? d.suggestions.length : 0
+    if (n > 0) withSuggestions++
+    suggestionCount += n
+  }
+  return {
+    count: digests.length,
+    with_storefront: withStorefront,
+    with_suggestions: withSuggestions,
+    suggestion_count: suggestionCount,
+  }
+}
+
+export const partnerAnalyticsDigestOperation: OperationDefinition = {
+  type: "partner_analytics_digest",
+  name: "Partner Analytics Digest",
+  description:
+    "Compute a per-partner storefront analytics digest (KPIs + breakdowns + rule-based suggestions) for one partner, an explicit list, or every active partner. Output `digests[]` feeds bulk_trigger_workflow → send-partner-digest-email.",
+  icon: "chart-bar",
+  category: "data",
+  optionsSchema: partnerAnalyticsDigestOptionsSchema,
+
+  defaultOptions: {
+    period: "last_7_days",
+    max_partners: 200,
+    continue_on_error: true,
+  },
+
+  execute: async (
+    options: any,
+    context: OperationContext
+  ): Promise<OperationResult> => {
+    try {
+      const parsed = partnerAnalyticsDigestOptionsSchema.parse(options ?? {})
+      const continueOnError = parsed.continue_on_error !== false
+
+      // Resolve {{ variable }} references in the partner selectors.
+      const resolvedPartnerId = parsed.partner_id
+        ? interpolateVariables(parsed.partner_id, context.dataChain)
+        : undefined
+      const resolvedPartnerIds =
+        parsed.partner_ids !== undefined
+          ? interpolateVariables(parsed.partner_ids, context.dataChain)
+          : undefined
+
+      // Only list partners when no explicit selection was supplied.
+      const hasExplicit =
+        (typeof resolvedPartnerId === "string" && resolvedPartnerId.trim()) ||
+        (Array.isArray(resolvedPartnerIds) && resolvedPartnerIds.length > 0) ||
+        (typeof resolvedPartnerIds === "string" && resolvedPartnerIds.trim())
+
+      let listedPartnerIds: string[] = []
+      if (!hasExplicit) {
+        const partnerService: any = context.container.resolve(PARTNER_MODULE)
+        const [partners] = await partnerService.listAndCountPartners(
+          { status: "active" },
+          { take: parsed.max_partners, select: ["id"] }
+        )
+        listedPartnerIds = (partners ?? [])
+          .map((p: any) => p?.id)
+          .filter((id: any): id is string => typeof id === "string")
+      }
+
+      const partnerIds = selectDigestPartnerIds({
+        partnerId:
+          typeof resolvedPartnerId === "string" ? resolvedPartnerId : undefined,
+        partnerIds: resolvedPartnerIds,
+        listedPartnerIds,
+        maxPartners: parsed.max_partners,
+      })
+
+      if (partnerIds.length === 0) {
+        return {
+          success: true,
+          data: {
+            digests: [],
+            records: [],
+            count: 0,
+            with_storefront: 0,
+            with_suggestions: 0,
+            suggestion_count: 0,
+            requested: 0,
+            failed: 0,
+            errors: [],
+          },
+        }
+      }
+
+      const digests: PartnerStorefrontDigest[] = []
+      const errors: Array<{ partner_id: string; error: string }> = []
+
+      for (const partnerId of partnerIds) {
+        const input: GetPartnerStorefrontDigestInput = {
+          partner_id: partnerId,
+          period: parsed.period as DigestPeriod | undefined,
+          thresholds: parsed.thresholds as any,
+          now: parsed.now,
+        }
+        try {
+          const { result } = await getPartnerStorefrontDigestWorkflow(
+            context.container
+          ).run({ input })
+          if (result) digests.push(result as PartnerStorefrontDigest)
+        } catch (err: any) {
+          errors.push({
+            partner_id: partnerId,
+            error: err?.message ?? String(err),
+          })
+          if (!continueOnError) {
+            return {
+              success: false,
+              error: `Digest compute failed for partner ${partnerId}: ${err?.message ?? err}`,
+              errorStack: err?.stack,
+            }
+          }
+        }
+      }
+
+      const summary = summarizeDigestRun(digests)
+
+      return {
+        success: true,
+        data: {
+          digests,
+          records: digests,
+          ...summary,
+          requested: partnerIds.length,
+          failed: errors.length,
+          errors,
+        },
+      }
+    } catch (error: any) {
+      return {
+        success: false,
+        error: error.message,
+        errorStack: error.stack,
+      }
+    }
+  },
+}


### PR DESCRIPTION
## #581 S3 — visual-flow operation `partner_analytics_digest`

Wraps the S1 `getPartnerStorefrontDigestWorkflow` (#582) as a visual-flow operation so a weekly flow can compute per-partner storefront analytics digests and fan out to `send-partner-digest-email` (S2, #583) via `bulk_trigger_workflow`.

**Stacked on #582 (S1)** — imports S1's workflow + digest types (which only exist on the S1 branch). **Merge #582 first.** Independent of #583 (S2); no S2 imports.

### What it does
- New op `partner_analytics_digest` (category `data`), mirrors `operations/cart-recovery-stats.ts`.
- Targets **one** partner (`partner_id`), an **explicit list** (`partner_ids`, supports `{{ }}` refs), or **every active partner** (lists `status: active` when no explicit selection).
- Runs the S1 workflow per partner via `getPartnerStorefrontDigestWorkflow(container).run()`; **per-partner errors are swallowed** (`continue_on_error` default true) so one un-provisioned partner can't abort the weekly run.
- Output `{ digests: PartnerStorefrontDigest[], records, count, with_storefront, with_suggestions, suggestion_count, requested, failed, errors }`. `digests[]` feeds `bulk_trigger_workflow` (`items: {{ partner_digest.digests }}`, `input_template: { digest: "{{ item }}" }`) → `send-partner-digest-email`.
- Registered in `operations/index.ts`.

### Pure, unit-tested helpers
- `selectDigestPartnerIds` — explicit-wins precedence, merge `partner_id`+`partner_ids`, trim/dedupe/cap.
- `summarizeDigestRun` — storefront/suggestion rollups for downstream condition/log/metric nodes.

### Tests
16 unit (`__tests__/partner-analytics-digest.unit.spec.ts`, `TEST_TYPE=unit`). 0 new tsc errors. Operation orchestration (container resolve + per-partner workflow run) isn't headless-verifiable — pure logic asserted instead.

### Next (S4)
Seed the weekly flow (schedule → `partner_analytics_digest` → `bulk_trigger_workflow` send) + document cadence/thresholds (editor-gated → seed + document).

🤖 Generated with [Claude Code](https://claude.com/claude-code)