### PR TITLE
feat(analytics): seed weekly partner storefront digest flow (#581 S4)

### DIFF
--- a/apps/backend/src/scripts/__tests__/seed-partner-analytics-digest-flow.unit.spec.ts
+++ b/apps/backend/src/scripts/__tests__/seed-partner-analytics-digest-flow.unit.spec.ts
@@ -1,0 +1,88 @@
+import { FLOW_DEF } from "../seed-partner-analytics-digest-flow"
+
+/**
+ * Structural guards for the weekly partner-digest visual flow seed (#581 S4).
+ *
+ * This flow is editor-gated and cannot be live-verified by the daemon, and it
+ * wires the S3 op + S2 workflow by STRING name only. A typo in either string
+ * would silently no-op at runtime, so these tests pin the contract.
+ */
+describe("seed-partner-analytics-digest-flow FLOW_DEF", () => {
+  it("is a weekly schedule-triggered draft flow", () => {
+    expect(FLOW_DEF.status).toBe("draft")
+    expect(FLOW_DEF.trigger_type).toBe("schedule")
+    // Weekly Monday cron (day-of-week field = 1, single value, not a range).
+    expect(FLOW_DEF.trigger_config.cron).toBe("30 3 * * 1")
+    expect(
+      (FLOW_DEF.canvas_state.nodes[0].data as any).triggerConfig.cron
+    ).toBe(FLOW_DEF.trigger_config.cron)
+  })
+
+  it("wires compute → send → log via partner_analytics_digest + bulk_trigger", () => {
+    const byKey = Object.fromEntries(
+      FLOW_DEF.operations.map((o) => [o.operation_key, o])
+    )
+    expect(byKey.compute_digests.operation_type).toBe("partner_analytics_digest")
+    expect(byKey.send_digests.operation_type).toBe("bulk_trigger_workflow")
+    expect(byKey.log_summary.operation_type).toBe("log")
+
+    // sort_order is contiguous from 0 in execution order.
+    expect(FLOW_DEF.operations.map((o) => o.sort_order)).toEqual([0, 1, 2])
+  })
+
+  it("targets the S2 send-partner-digest-email workflow with the digest payload", () => {
+    const send = FLOW_DEF.operations.find(
+      (o) => o.operation_key === "send_digests"
+    )!.options as any
+    expect(send.workflow_name).toBe("send-partner-digest-email")
+    // Items pull the op's digests[] output; each item is fed as { digest }.
+    expect(send.items).toBe("{{ compute_digests.digests }}")
+    expect(send.input_template).toEqual({ digest: "{{ item }}" })
+    expect(send.continue_on_error).toBe(true)
+  })
+
+  it("computes a weekly digest for all active partners (no explicit selector)", () => {
+    const compute = FLOW_DEF.operations.find(
+      (o) => o.operation_key === "compute_digests"
+    )!.options as any
+    expect(compute.period).toBe("last_7_days")
+    expect(compute.partner_id).toBeUndefined()
+    expect(compute.partner_ids).toBeUndefined()
+    expect(compute.continue_on_error).toBe(true)
+  })
+
+  it("keeps op max_partners and send max_items aligned so neither truncates", () => {
+    const compute = FLOW_DEF.operations.find(
+      (o) => o.operation_key === "compute_digests"
+    )!.options as any
+    const send = FLOW_DEF.operations.find(
+      (o) => o.operation_key === "send_digests"
+    )!.options as any
+    expect(compute.max_partners).toBe(send.max_items)
+  })
+
+  it("has matching canvas edges and connection rows forming a linear chain", () => {
+    // connections (persisted graph) and canvas edges (editor view) agree.
+    const conn = FLOW_DEF.connections.map((c) => `${c.source_id}->${c.target_id}`)
+    const edges = FLOW_DEF.canvas_state.edges.map((e) => `${e.source}->${e.target}`)
+    expect(conn).toEqual(edges)
+    expect(conn).toEqual([
+      "trigger->compute_digests",
+      "compute_digests->send_digests",
+      "send_digests->log_summary",
+    ])
+  })
+
+  it("logs the real output keys emitted by the two ops", () => {
+    const log = FLOW_DEF.operations.find(
+      (o) => o.operation_key === "log_summary"
+    )!.options as any
+    // digest op output keys
+    expect(log.message).toContain("{{ compute_digests.count }}")
+    expect(log.message).toContain("{{ compute_digests.suggestion_count }}")
+    expect(log.message).toContain("{{ compute_digests.failed }}")
+    // bulk_trigger_workflow output keys
+    expect(log.message).toContain("{{ send_digests.triggered }}")
+    expect(log.message).toContain("{{ send_digests.failed }}")
+  })
+})

--- a/apps/backend/src/scripts/seed-partner-analytics-digest-flow.ts
+++ b/apps/backend/src/scripts/seed-partner-analytics-digest-flow.ts
@@ -1,0 +1,208 @@
+/**
+ * Seed: Partner Storefront Analytics Digest — Weekly Flow (#581 S4)
+ *
+ * A weekly scheduled visual flow that computes a per-partner storefront
+ * analytics digest (KPIs + breakdowns + rule-based suggestions) for every
+ * active partner and emails it to each partner's active admins.
+ *
+ * Graph:
+ *   schedule (weekly)
+ *     → partner_analytics_digest   (S3 op — fans out over active partners,
+ *                                    each digest computed by the S1 workflow)
+ *     → bulk_trigger_workflow       → send-partner-digest-email (S2 workflow,
+ *                                     once per digest, best-effort per partner)
+ *     → log summary
+ *
+ * The op + workflow are referenced by STRING name only (no imports), so this
+ * seed branches off main independently. It WON'T run end-to-end until the
+ * stack #582 (S1) / #583 (S2) / #584 (S3) has merged and deployed — the op
+ * type `partner_analytics_digest` and workflow `send-partner-digest-email`
+ * must exist in the registry first. Seed it as `draft` and only flip to
+ * `active` once those are live.
+ *
+ * Cadence (locked decision):
+ *   Cron `30 3 * * 1` = 09:00 IST Monday when the container runs UTC.
+ *   If the container runs in IST, change to `0 9 * * 1`. Confirm via `date`
+ *   on the deployed host before activating. Period defaults to last_7_days,
+ *   so a Monday run covers the previous calendar-ish week. The digest is
+ *   compared against the equal-length window immediately before it (S1).
+ *
+ * Thresholds:
+ *   The suggestion rules + their thresholds live in the S1 lib
+ *   (`DEFAULT_DIGEST_THRESHOLDS` in src/workflows/analytics/partner-digest-lib.ts).
+ *   Override per-run by adding a `thresholds` key to the digest op options
+ *   below (partial overrides are merged onto the defaults). Sample-gated
+ *   rules (referrer / page / mobile) only fire at >= 20 visitors.
+ *
+ * Run:
+ *   npx medusa exec ./src/scripts/seed-partner-analytics-digest-flow.ts
+ *
+ * Re-seed:
+ *   Delete the existing flow first (admin UI or by id) and re-run. The
+ *   script is idempotent and refuses to overwrite an existing flow.
+ */
+
+import { VISUAL_FLOWS_MODULE } from "../modules/visual_flows"
+import VisualFlowService from "../modules/visual_flows/service"
+
+const FLOW_NAME = "Partner Storefront Analytics Digest — Weekly"
+
+// Cron: 09:00 IST Monday assuming a UTC container (03:30 UTC).
+const DIGEST_CRON = "30 3 * * 1"
+
+// ─── Canvas positions ────────────────────────────────────────────────────────
+const X_CENTER = 500
+const Y_DIGEST = 140
+const Y_DISPATCH = 280
+const Y_LOG = 420
+
+// ─── Flow definition (exported for the structural unit test) ───────────────────
+
+export const FLOW_DEF = {
+  name: FLOW_NAME,
+  description:
+    "Weekly scheduled digest: computes a per-partner storefront analytics " +
+    "digest (KPIs + breakdowns + rule-based suggestions) for every active " +
+    "partner, then bulk-triggers send-partner-digest-email once per digest. " +
+    "Best-effort throughout — one un-provisioned partner cannot abort the run.",
+  status: "draft" as const,
+  trigger_type: "schedule" as const,
+  trigger_config: {
+    cron: DIGEST_CRON, // 09:00 IST Monday assuming UTC container
+  },
+
+  canvas_state: {
+    viewport: { x: 0, y: 0, zoom: 0.85 },
+    nodes: [
+      { id: "trigger",         type: "trigger",   position: { x: X_CENTER, y: -20 },        data: { label: "Schedule — 09:00 IST Monday", triggerType: "schedule", triggerConfig: { cron: DIGEST_CRON } } },
+      { id: "compute_digests", type: "operation", position: { x: X_CENTER, y: Y_DIGEST },   data: { label: "Compute Partner Digests", operationKey: "compute_digests", operationType: "partner_analytics_digest" } },
+      { id: "send_digests",    type: "operation", position: { x: X_CENTER, y: Y_DISPATCH }, data: { label: "Send Digest Emails",      operationKey: "send_digests",    operationType: "bulk_trigger_workflow" } },
+      { id: "log_summary",     type: "operation", position: { x: X_CENTER, y: Y_LOG },      data: { label: "Log Summary",            operationKey: "log_summary",     operationType: "log" } },
+    ],
+    edges: [
+      { id: "e-0", source: "trigger",         sourceHandle: "default", target: "compute_digests", targetHandle: "default" },
+      { id: "e-1", source: "compute_digests", sourceHandle: "default", target: "send_digests",    targetHandle: "default" },
+      { id: "e-2", source: "send_digests",    sourceHandle: "default", target: "log_summary",     targetHandle: "default" },
+    ],
+  },
+
+  operations: [
+    // ── 1. Compute a digest per active partner (S3 op wrapping S1) ──────────
+    {
+      operation_key: "compute_digests",
+      operation_type: "partner_analytics_digest",
+      name: "Compute Partner Digests",
+      sort_order: 0,
+      position_x: X_CENTER,
+      position_y: Y_DIGEST,
+      options: {
+        // No partner_id / partner_ids → fans out over all status:active
+        // partners (capped at max_partners). Period = weekly.
+        period: "last_7_days",
+        max_partners: 200,
+        continue_on_error: true,
+        // To tune the suggestion rules, add a partial threshold override:
+        //   thresholds: { bounce_rate_high: 0.7, mobile_share_high: 0.6 },
+      },
+    },
+
+    // ── 2. Email each digest (S2 workflow), once per partner ───────────────
+    {
+      operation_key: "send_digests",
+      operation_type: "bulk_trigger_workflow",
+      name: "Send Digest Emails",
+      sort_order: 1,
+      position_x: X_CENTER,
+      position_y: Y_DISPATCH,
+      options: {
+        workflow_name: "send-partner-digest-email",
+        // {{ compute_digests.digests }} → the array of per-partner digests.
+        // Empty array short-circuits to triggered:0.
+        items: "{{ compute_digests.digests }}",
+        input_template: {
+          // S2 accepts a pre-computed digest; partner_id is carried inside it.
+          digest: "{{ item }}",
+        },
+        continue_on_error: true,
+        // Match the op's max_partners so large weeks don't truncate sends.
+        max_items: 200,
+      },
+    },
+
+    // ── 3. Log summary line for observability ──────────────────────────────
+    {
+      operation_key: "log_summary",
+      operation_type: "log",
+      name: "Log Summary",
+      sort_order: 2,
+      position_x: X_CENTER,
+      position_y: Y_LOG,
+      options: {
+        message:
+          "Partner digest run — partners={{ compute_digests.count }} " +
+          "with_storefront={{ compute_digests.with_storefront }} " +
+          "with_suggestions={{ compute_digests.with_suggestions }} " +
+          "suggestions={{ compute_digests.suggestion_count }} " +
+          "failed_compute={{ compute_digests.failed }} " +
+          "emails_triggered={{ send_digests.triggered }} " +
+          "emails_failed={{ send_digests.failed }}",
+        level: "info",
+      },
+    },
+  ],
+
+  connections: [
+    { source_id: "trigger",         source_handle: "default", target_id: "compute_digests", connection_type: "default" as const },
+    { source_id: "compute_digests", source_handle: "default", target_id: "send_digests",    connection_type: "default" as const },
+    { source_id: "send_digests",    source_handle: "default", target_id: "log_summary",     connection_type: "default" as const },
+  ],
+}
+
+// ─── Runner ──────────────────────────────────────────────────────────────────
+
+export default async function seedPartnerAnalyticsDigestFlow({
+  container,
+}: {
+  container: any
+}) {
+  const service: VisualFlowService = container.resolve(VISUAL_FLOWS_MODULE)
+
+  const [existing] = await service.listVisualFlows({ name: FLOW_NAME } as any)
+  if (existing) {
+    console.log(`Flow "${FLOW_NAME}" already exists (${existing.id}) — skipping.`)
+    console.log(`Delete it in the admin UI (or by id) to re-seed.`)
+    return
+  }
+
+  console.log(`Creating flow "${FLOW_NAME}"...`)
+
+  const flow = await service.createCompleteFlow({
+    flow: {
+      name: FLOW_DEF.name,
+      description: FLOW_DEF.description,
+      status: FLOW_DEF.status,
+      trigger_type: FLOW_DEF.trigger_type,
+      trigger_config: FLOW_DEF.trigger_config,
+      // canvas_state holds the React Flow nodes/edges the editor renders.
+      // Without it the editor opens to an empty canvas.
+      canvas_state: FLOW_DEF.canvas_state,
+    },
+    operations: FLOW_DEF.operations,
+    connections: FLOW_DEF.connections,
+  })
+
+  console.log(`\nFlow created: ${flow.id}`)
+  console.log(`  Open: /app/visual-flows/${flow.id}\n`)
+  console.log(`Before activating (draft → active):`)
+  console.log(`  1. Ensure the #581 stack (S1 #582 / S2 #583 / S3 #584) is`)
+  console.log(`     MERGED + DEPLOYED — the op "partner_analytics_digest" and`)
+  console.log(`     workflow "send-partner-digest-email" must exist in the`)
+  console.log(`     registry, else the run no-ops / errors.`)
+  console.log(`  2. Author the "partner-storefront-digest" email_template row`)
+  console.log(`     (active) and set MAILEROO_FROM_DOMAIN / PARTNER_DASHBOARD_URL`)
+  console.log(`     / FRONTEND_URL (S2 ops tail).`)
+  console.log(`  3. Confirm the deployed container's local time matches the cron`)
+  console.log(`     assumption. This seed uses "${DIGEST_CRON}" = 09:00 IST Monday`)
+  console.log(`     assuming UTC. If the container is in IST, edit to "0 9 * * 1".`)
+  console.log(`  4. Flip flow status: draft → active in the admin editor.`)
+}

--- a/apps/docs/notes/581_PARTNER_STOREFRONT_DIGEST.md
+++ b/apps/docs/notes/581_PARTNER_STOREFRONT_DIGEST.md
@@ -1,0 +1,93 @@
+# #581 — Per-Partner Storefront Analytics Digest
+
+A weekly email digest of each partner's storefront analytics (KPIs +
+breakdowns + rule-based suggestions). Built as a 4-slice stack reusing the
+#569 analytics overview + #559 breakdown engines.
+
+## Slices / PRs
+
+| Slice | What | PR | Branch base |
+|-------|------|----|-------------|
+| S1 | Digest **compute** — pure `partner-digest-lib.ts` + `get-partner-storefront-digest` workflow | #582 | main |
+| S2 | Digest **email** — `partner-digest-email-lib.ts` + `send-partner-digest-email` workflow (`email_partner`/Maileroo) | #583 | #582 |
+| S3 | Visual-flow **op** `partner_analytics_digest` (fans out over partners, output `digests[]`) | #584 | #582 |
+| S4 | **Seed** the weekly flow + this doc | #585 | main |
+| S5 | (optional) AI suggestions via `ai-extract`, flagged | — | — |
+
+**Merge order:** #582 (S1) first, then #583 / #584 (both stack on S1), then
+S4's seed is independent (string refs only). The seed flow won't run
+end-to-end until S1+S2+S3 are merged and deployed.
+
+## Runtime graph (the seeded flow)
+
+```
+schedule (weekly, Mon 09:00 IST)
+  → partner_analytics_digest            (S3 op; no selector ⇒ all active partners)
+      • each partner's digest = S1 getPartnerStorefrontDigestWorkflow
+      • per-partner errors swallowed (continue_on_error)
+      • output: { digests[], count, with_storefront, with_suggestions,
+                  suggestion_count, requested, failed, errors }
+  → bulk_trigger_workflow               → send-partner-digest-email (S2)
+      • items: {{ compute_digests.digests }}
+      • input_template: { digest: "{{ item }}" }   (S2 takes a pre-computed digest)
+      • one best-effort send per partner; admins resolved inside S2
+  → log (observability summary line)
+```
+
+Seed script: `apps/backend/src/scripts/seed-partner-analytics-digest-flow.ts`
+(idempotent; refuses to overwrite). Run:
+`npx medusa exec ./src/scripts/seed-partner-analytics-digest-flow.ts`.
+
+## Cadence (locked)
+
+- Cron **`30 3 * * 1`** = **09:00 IST Monday** assuming a **UTC** container
+  (03:30 UTC). If the deployed container runs in IST, edit the flow to
+  `0 9 * * 1`. Confirm with `date` on the host before flipping to `active`.
+- Period defaults to **`last_7_days`** → a Monday run reports the trailing
+  week, compared (deltas) against the equal-length window immediately before
+  it (abutting, computed in S1 `resolvePeriodRange`).
+- Seeded as **`draft`**. Flip to `active` only after the S1/S2/S3 stack is
+  live and the email template + env are in place (see Ops tail).
+
+## Thresholds (suggestion rules)
+
+Defaults live in `DEFAULT_DIGEST_THRESHOLDS`
+(`apps/backend/src/workflows/analytics/partner-digest-lib.ts`).
+`buildDigestSuggestions` emits 6 thresholded rules; the referrer / page /
+mobile rules are **sample-gated at ≥ 20 visitors** so low-traffic partners
+don't get noisy advice.
+
+To override per-run, add a `thresholds` partial to the `compute_digests` op
+options in the seed (merged onto defaults), e.g.:
+
+```ts
+options: { period: "last_7_days", thresholds: { bounce_rate_high: 0.7 } }
+```
+
+To add/adjust a rule: edit `buildDigestSuggestions` + the corresponding key
+in `DigestThresholds` / `DEFAULT_DIGEST_THRESHOLDS` + a unit test in
+`partner-digest-lib`.
+
+## Ops tail (prod — daemon cannot author)
+
+Before activating the flow:
+
+1. **Merge + deploy** the #581 stack (#582 → #583/#584). The op type
+   `partner_analytics_digest` and workflow `send-partner-digest-email` must
+   exist in the registry, else the run no-ops / errors.
+2. Author an **active `partner-storefront-digest` `email_template` row**
+   consuming the S2 template data: `kpi_rows`, the breakdown arrays
+   (`{{#each}}`), `suggestions`, `period_start` / `period_end`,
+   `dashboard_url`.
+3. Set env: `MAILEROO_FROM_DOMAIN`, `PARTNER_DASHBOARD_URL`, `FRONTEND_URL`.
+4. Flip flow `draft → active` in the admin editor.
+
+## Verification
+
+- Pure logic only is headless-verifiable; email + live flow execution are not.
+- S1: `TEST_TYPE=unit … jest --testPathPattern=partner-digest-lib` (29)
+- S2: `… --testPathPattern=partner-digest-email-lib` (15)
+- S3: `… --testPathPattern=partner-analytics-digest` (16)
+- S4: `… --testPathPattern=seed-partner-analytics-digest-flow` (7 structural —
+  pin the op/workflow string refs + the linear graph since the seed is
+  editor-gated and can't be live-verified).


### PR DESCRIPTION
## #581 S4 — seed the weekly partner-digest visual flow

Final build slice of the per-partner storefront analytics digest (#581).
Seeds a **weekly scheduled** visual flow that:

```
schedule (Mon 09:00 IST)
  → partner_analytics_digest      (S3 op — all active partners → digests[])
  → bulk_trigger_workflow         → send-partner-digest-email (S2, per digest)
  → log summary
```

### What's here
- **`src/scripts/seed-partner-analytics-digest-flow.ts`** — idempotent seed
  (refuses to overwrite). Seeded as **`draft`**, cron `30 3 * * 1` = 09:00 IST
  Monday assuming a UTC container. Period `last_7_days`.
- The op (`partner_analytics_digest`) + workflow (`send-partner-digest-email`)
  are referenced by **string name only** (no imports) → this branches off
  **main independently**. It won't run end-to-end until the stack
  **#582 (S1) / #583 (S2) / #584 (S3)** merges + deploys.
- **7 structural unit tests** pin the op/workflow string refs + the linear
  graph — the seed is editor-gated and can't be live-verified, so a typo'd
  ref would otherwise silently no-op.
- **`apps/docs/notes/581_PARTNER_STOREFRONT_DIGEST.md`** — feature map, locked
  cadence, thresholds, and the prod ops tail (email template row + env +
  draft→active flip).

### Verify
```
cd apps/backend && TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules \
  npx jest --testPathPattern=seed-partner-analytics-digest-flow
```
7/7 green; 0 new tsc errors.

### Do NOT merge before
- Merge order isn't strict for *this* PR (independent of the stack), but the
  flow is dead until #582→#583/#584 land. Keep `draft` until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)