### PR TITLE
chore: REGION_REQUEST_NOTIFY_EMAIL + digest-flow seed node options fix

### DIFF
--- a/apps/backend/src/scripts/seed-partner-analytics-digest-flow.ts
+++ b/apps/backend/src/scripts/seed-partner-analytics-digest-flow.ts
@@ -75,9 +75,9 @@ export const FLOW_DEF = {
     viewport: { x: 0, y: 0, zoom: 0.85 },
     nodes: [
       { id: "trigger",         type: "trigger",   position: { x: X_CENTER, y: -20 },        data: { label: "Schedule — 09:00 IST Monday", triggerType: "schedule", triggerConfig: { cron: DIGEST_CRON } } },
-      { id: "compute_digests", type: "operation", position: { x: X_CENTER, y: Y_DIGEST },   data: { label: "Compute Partner Digests", operationKey: "compute_digests", operationType: "partner_analytics_digest" } },
-      { id: "send_digests",    type: "operation", position: { x: X_CENTER, y: Y_DISPATCH }, data: { label: "Send Digest Emails",      operationKey: "send_digests",    operationType: "bulk_trigger_workflow" } },
-      { id: "log_summary",     type: "operation", position: { x: X_CENTER, y: Y_LOG },      data: { label: "Log Summary",            operationKey: "log_summary",     operationType: "log" } },
+      { id: "compute_digests", type: "operation", position: { x: X_CENTER, y: Y_DIGEST },   data: { label: "Compute Partner Digests", operationKey: "compute_digests", operationType: "partner_analytics_digest", options: { period: "last_7_days", max_partners: 200, continue_on_error: true } } },
+      { id: "send_digests",    type: "operation", position: { x: X_CENTER, y: Y_DISPATCH }, data: { label: "Send Digest Emails",      operationKey: "send_digests",    operationType: "bulk_trigger_workflow", options: { workflow_name: "send-partner-digest-email", items: "{{ compute_digests.digests }}", input_template: { digest: "{{ item }}" }, continue_on_error: true, max_items: 200 } } },
+      { id: "log_summary",     type: "operation", position: { x: X_CENTER, y: Y_LOG },      data: { label: "Log Summary",            operationKey: "log_summary",     operationType: "log", options: { message: "Partner digest run — partners={{ compute_digests.count }} with_storefront={{ compute_digests.with_storefront }} with_suggestions={{ compute_digests.with_suggestions }} suggestions={{ compute_digests.suggestion_count }} failed_compute={{ compute_digests.failed }} emails_triggered={{ send_digests.triggered }} emails_failed={{ send_digests.failed }}", level: "info" } } },
     ],
     edges: [
       { id: "e-0", source: "trigger",         sourceHandle: "default", target: "compute_digests", targetHandle: "default" },

--- a/deploy/aws/copilot/medusa-server/manifest.yml
+++ b/deploy/aws/copilot/medusa-server/manifest.yml
@@ -109,6 +109,9 @@ secrets:
   PAYU_MERCHANT_SALT: /jyt/prod/PAYU_MERCHANT_SALT
   PAYU_MODE: /jyt/prod/PAYU_MODE
   REDIS_URL: /jyt/prod/REDIS_URL
+  # #576 slice C — recipient for storefront region-request admin emails. Read by
+  # api/store/contact-region-request; unset → the route logs + skips (no error).
+  REGION_REQUEST_NOTIFY_EMAIL: /jyt/prod/REGION_REQUEST_NOTIFY_EMAIL
   RESEND_API_KEY: /jyt/prod/RESEND_API_KEY
   RESEND_FROM_EMAIL: /jyt/prod/RESEND_FROM_EMAIL
   ROOT_DOMAIN: /jyt/prod/ROOT_DOMAIN


### PR DESCRIPTION
Two activation-tail fixes:
- **#576 C**: wire `REGION_REQUEST_NOTIFY_EMAIL` (SSM `/jyt/prod/REGION_REQUEST_NOTIFY_EMAIL=partner.req@jaalyantra.com` already created) into the medusa-server manifest → region-request admin email now sends.
- **#581**: the digest seed's operation options lived only in the `operations` array, not the canvas `data.options` the live executor reads → 'Send Digest Emails' node errored `workflow_name is required`. Mirrored options (`workflow_name=send-partner-digest-email`, items, input_template, log message) onto all 3 operation nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)