### PR TITLE
feat(589): digest recipient filter — only mail partners with a live storefront

### DIFF
--- a/apps/backend/src/modules/visual_flows/operations/__tests__/partner-analytics-digest.unit.spec.ts
+++ b/apps/backend/src/modules/visual_flows/operations/__tests__/partner-analytics-digest.unit.spec.ts
@@ -8,6 +8,8 @@
 import {
   selectDigestPartnerIds,
   summarizeDigestRun,
+  isPartnerDigestEligible,
+  partitionEligibleDigests,
   partnerAnalyticsDigestOperation,
   partnerAnalyticsDigestOptionsSchema,
 } from "../partner-analytics-digest"
@@ -135,6 +137,62 @@ describe("summarizeDigestRun", () => {
     ] as any)
     expect(out.with_suggestions).toBe(0)
     expect(out.suggestion_count).toBe(0)
+  })
+})
+
+describe("isPartnerDigestEligible (#589 recipient filter)", () => {
+  it("is eligible when a live storefront (website.id) is present", () => {
+    expect(isPartnerDigestEligible({ website: { id: "web_1" } } as any)).toBe(
+      true
+    )
+  })
+
+  it("stays eligible for a has-store partner with zero traffic", () => {
+    // zero traffic is NOT exclusion — they get the zero-data nudge (item 2).
+    expect(
+      isPartnerDigestEligible({
+        website: { id: "web_1", domain: "shop.example" },
+      } as any)
+    ).toBe(true)
+  })
+
+  it("excludes no-store partners (website: null)", () => {
+    expect(isPartnerDigestEligible({ website: null } as any)).toBe(false)
+  })
+
+  it("excludes when website is missing, undefined, or id is empty/blank", () => {
+    expect(isPartnerDigestEligible(undefined)).toBe(false)
+    expect(isPartnerDigestEligible(null)).toBe(false)
+    expect(isPartnerDigestEligible({} as any)).toBe(false)
+    expect(isPartnerDigestEligible({ website: { id: "" } } as any)).toBe(false)
+    expect(isPartnerDigestEligible({ website: { id: "   " } } as any)).toBe(
+      false
+    )
+    expect(
+      isPartnerDigestEligible({ website: { id: 42 as any } } as any)
+    ).toBe(false)
+  })
+})
+
+describe("partitionEligibleDigests (#589 recipient filter)", () => {
+  it("keeps only storefront-eligible digests and counts the excluded", () => {
+    const digests = [
+      { partner_id: "p1", website: { id: "w1" } },
+      { partner_id: "p2", website: null },
+      { partner_id: "p3", website: { id: "w3" } },
+      { partner_id: "p4", website: { id: "" } },
+    ] as any
+    const { eligible, excluded } = partitionEligibleDigests(digests)
+    expect(eligible.map((d: any) => d.partner_id)).toEqual(["p1", "p3"])
+    expect(excluded).toBe(2)
+  })
+
+  it("handles an empty / nullish list", () => {
+    expect(partitionEligibleDigests([])).toEqual({ eligible: [], excluded: 0 })
+    expect(partitionEligibleDigests(undefined as any)).toEqual({
+      eligible: [],
+      excluded: 0,
+    })
   })
 })
 

--- a/apps/backend/src/modules/visual_flows/operations/partner-analytics-digest.ts
+++ b/apps/backend/src/modules/visual_flows/operations/partner-analytics-digest.ts
@@ -117,6 +117,38 @@ export function selectDigestPartnerIds(input: {
 }
 
 /**
+ * A partner is digest-eligible only when they have a **live storefront** — i.e.
+ * the S1 digest resolved a linked website (truthy `website.id`). Partners with
+ * no storefront (`website: null`) have nothing to report and must be excluded
+ * from the email fan-out entirely (#589): the first fan-out mis-emailed
+ * no-store partners. A has-store partner with zero traffic is STILL eligible —
+ * they get the zero-data "start sharing" nudge, not exclusion. Pure.
+ */
+export function isPartnerDigestEligible(
+  digest: Pick<PartnerStorefrontDigest, "website"> | null | undefined
+): boolean {
+  const w = digest?.website
+  return !!(w && typeof w.id === "string" && w.id.trim().length > 0)
+}
+
+/**
+ * Split computed digests into the storefront-eligible set (the email fan-out
+ * source) and a count of partners excluded for having no live storefront.
+ * Pure so it's unit-testable without booting Medusa.
+ */
+export function partitionEligibleDigests(
+  digests: PartnerStorefrontDigest[]
+): { eligible: PartnerStorefrontDigest[]; excluded: number } {
+  const eligible: PartnerStorefrontDigest[] = []
+  let excluded = 0
+  for (const d of digests ?? []) {
+    if (isPartnerDigestEligible(d)) eligible.push(d)
+    else excluded++
+  }
+  return { eligible, excluded }
+}
+
+/**
  * Roll digests up into the flat scalars a downstream condition/log node or a
  * metric panel can read. Pure.
  */
@@ -211,6 +243,8 @@ export const partnerAnalyticsDigestOperation: OperationDefinition = {
             with_storefront: 0,
             with_suggestions: 0,
             suggestion_count: 0,
+            computed: 0,
+            excluded: 0,
             requested: 0,
             failed: 0,
             errors: [],
@@ -218,7 +252,7 @@ export const partnerAnalyticsDigestOperation: OperationDefinition = {
         }
       }
 
-      const digests: PartnerStorefrontDigest[] = []
+      const computedDigests: PartnerStorefrontDigest[] = []
       const errors: Array<{ partner_id: string; error: string }> = []
 
       for (const partnerId of partnerIds) {
@@ -232,7 +266,7 @@ export const partnerAnalyticsDigestOperation: OperationDefinition = {
           const { result } = await getPartnerStorefrontDigestWorkflow(
             context.container
           ).run({ input })
-          if (result) digests.push(result as PartnerStorefrontDigest)
+          if (result) computedDigests.push(result as PartnerStorefrontDigest)
         } catch (err: any) {
           errors.push({
             partner_id: partnerId,
@@ -248,14 +282,21 @@ export const partnerAnalyticsDigestOperation: OperationDefinition = {
         }
       }
 
-      const summary = summarizeDigestRun(digests)
+      // Recipient filter (#589): only partners with a live storefront receive a
+      // digest email. No-store partners (`website: null`) are excluded from the
+      // `digests[]` fan-out source entirely so bulk_trigger_workflow →
+      // send-partner-digest-email never mails them.
+      const { eligible, excluded } = partitionEligibleDigests(computedDigests)
+      const summary = summarizeDigestRun(eligible)
 
       return {
         success: true,
         data: {
-          digests,
-          records: digests,
+          digests: eligible,
+          records: eligible,
           ...summary,
+          computed: computedDigests.length,
+          excluded,
           requested: partnerIds.length,
           failed: errors.length,
           errors,

--- a/apps/docs/notes/581_PARTNER_STOREFRONT_DIGEST.md
+++ b/apps/docs/notes/581_PARTNER_STOREFRONT_DIGEST.md
@@ -91,3 +91,21 @@ Before activating the flow:
 - S4: `… --testPathPattern=seed-partner-analytics-digest-flow` (7 structural —
   pin the op/workflow string refs + the linear graph since the seed is
   editor-gated and can't be live-verified).
+
+## #589 enhancements
+
+### 1. Recipient filter (live-storefront only) — DONE
+
+The first weekly fan-out mailed partners with **no store at all**. Fixed in
+`modules/visual_flows/operations/partner-analytics-digest.ts`: after computing
+each partner's digest, `partitionEligibleDigests` keeps only the
+storefront-eligible ones (`isPartnerDigestEligible` ⇒ truthy `website.id`) in
+the `digests[]` / `records` fan-out output, so `bulk_trigger_workflow` →
+`send-partner-digest-email` never mails a no-store partner. The op output gains
+`computed` (total digests computed) and `excluded` (no-store partners dropped)
+alongside the existing counts.
+
+A **has-store partner with zero traffic stays eligible** — they get the
+zero-data "start sharing" nudge (item 2, separate slice), not exclusion.
+Pure + unit-tested (`isPartnerDigestEligible`, `partitionEligibleDigests`;
+S3 spec now 22).


### PR DESCRIPTION
## #589 — slice 1 (PRIORITY): recipient filter

The first weekly partner-analytics digest fan-out **mailed partners with no storefront at all**. This was the priority bug in #589.

### Fix
`partner_analytics_digest` op (`modules/visual_flows/operations/partner-analytics-digest.ts`) now filters its `digests[]` / `records` fan-out output to **storefront-eligible** partners only — those whose S1 digest resolved a linked website (truthy `website.id`). So `bulk_trigger_workflow → send-partner-digest-email` never mails a no-store partner.

- New pure helpers: `isPartnerDigestEligible(digest)` + `partitionEligibleDigests(digests)` → `{ eligible, excluded }`.
- Reuses S1's website resolution (single source of truth) instead of duplicating the website→partner pivot.
- Op output gains `computed` (total digests computed) and `excluded` (no-store partners dropped) alongside existing counts.

### Behavior (locked by #589)
- **no store at all** (`website: null`) → excluded, no email.
- **has store + zero traffic** → STILL eligible; gets the zero-data "start sharing" nudge (item 2, a separate slice), not exclusion.

### Tests
Pure helpers unit-tested. S3 spec 16 → **22 green**:
```
TEST_TYPE=unit NODE_OPTIONS="--experimental-vm-modules" npx jest --testPathPattern="partner-analytics-digest.unit"
```
Zero new tsc errors in the changed file. Doc updated: `apps/docs/notes/581_PARTNER_STOREFRONT_DIGEST.md` (#589 section).

### Watch-outs
- Independent off `origin/main` (no stack). Email/live-flow execution not headless-verifiable → pure logic unit-tested only.
- Digest flow is ACTIVE in prod → this filter should land before the Monday run so no-store partners aren't mis-emailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)