### PR TITLE
feat(#589): AI weekly summary generation for partner digest (default-off) [stacked on #592]

### DIFF
--- a/apps/backend/src/modules/visual_flows/operations/partner-analytics-digest.ts
+++ b/apps/backend/src/modules/visual_flows/operations/partner-analytics-digest.ts
@@ -1,7 +1,13 @@
 import { z } from "@medusajs/framework/zod"
+import { createOpenRouter } from "@openrouter/ai-sdk-provider"
+import { generateText } from "ai"
 import { OperationDefinition, OperationContext, OperationResult } from "./types"
 import { interpolateVariables } from "./utils"
 import { PARTNER_MODULE } from "../../partner"
+import {
+  composeDigestAiSummary,
+  type DigestAiGenerate,
+} from "../../../workflows/analytics/partner-digest-ai-lib"
 import {
   getPartnerStorefrontDigestWorkflow,
   type GetPartnerStorefrontDigestInput,
@@ -58,6 +64,15 @@ export const partnerAnalyticsDigestOptionsSchema = z.object({
   max_partners: z.number().int().min(1).max(1000).default(200),
   /** Keep going when a single partner's digest compute throws. */
   continue_on_error: z.boolean().default(true),
+  /**
+   * When true, enrich each eligible digest with a short AI-authored weekly
+   * summary (#589 item 3) before the email fan-out. Best-effort: an AI failure
+   * never aborts the run, it just leaves `ai_summary` unset. Default OFF so the
+   * live weekly flow's behaviour is unchanged until an admin opts in.
+   */
+  generate_ai_summary: z.boolean().default(false),
+  /** Override the model used for the AI summary (defaults to the ai_extract model). */
+  ai_summary_model: z.string().optional(),
 })
 
 export type PartnerAnalyticsDigestOptions = z.infer<
@@ -255,6 +270,24 @@ export const partnerAnalyticsDigestOperation: OperationDefinition = {
       const computedDigests: PartnerStorefrontDigest[] = []
       const errors: Array<{ partner_id: string; error: string }> = []
 
+      // Default-OFF AI summary enrichment (#589 item 3). Only build the
+      // OpenRouter-backed generator when the option is set; otherwise the
+      // weekly run never touches the model. The seam is the same pattern as
+      // the `ai_extract` operation.
+      const aiGenerate: DigestAiGenerate | null = parsed.generate_ai_summary
+        ? async ({ system, prompt, model }) => {
+            const openrouter = createOpenRouter({
+              apiKey: process.env.OPENROUTER_API_KEY,
+            })
+            const result = await generateText({
+              model: openrouter(model) as any,
+              system,
+              messages: [{ role: "user", content: prompt }],
+            })
+            return result.text ?? ""
+          }
+        : null
+
       for (const partnerId of partnerIds) {
         const input: GetPartnerStorefrontDigestInput = {
           partner_id: partnerId,
@@ -266,7 +299,16 @@ export const partnerAnalyticsDigestOperation: OperationDefinition = {
           const { result } = await getPartnerStorefrontDigestWorkflow(
             context.container
           ).run({ input })
-          if (result) computedDigests.push(result as PartnerStorefrontDigest)
+          if (result) {
+            const digest = result as PartnerStorefrontDigest
+            if (aiGenerate) {
+              // Best-effort: never let an AI hiccup abort the digest run.
+              digest.ai_summary = await composeDigestAiSummary(digest, aiGenerate, {
+                model: parsed.ai_summary_model,
+              })
+            }
+            computedDigests.push(digest)
+          }
         } catch (err: any) {
           errors.push({
             partner_id: partnerId,

--- a/apps/backend/src/workflows/analytics/__tests__/partner-digest-ai-lib.unit.spec.ts
+++ b/apps/backend/src/workflows/analytics/__tests__/partner-digest-ai-lib.unit.spec.ts
@@ -1,0 +1,175 @@
+import {
+  DIGEST_AI_DEFAULT_MODEL,
+  buildDigestAiPrompt,
+  composeDigestAiSummary,
+  type DigestAiGenerate,
+} from "../partner-digest-ai-lib";
+import { AI_SUMMARY_MAX_LEN } from "../partner-digest-email-lib";
+import {
+  buildDigestKpis,
+  type PartnerStorefrontDigest,
+} from "../partner-digest-lib";
+
+const makeDigest = (
+  over: Partial<PartnerStorefrontDigest> = {}
+): PartnerStorefrontDigest => ({
+  partner_id: "part_1",
+  website: { id: "web_1", domain: "shop.example.com", name: "Example Shop" },
+  period: {
+    label: "last_7_days",
+    days: 7,
+    current: { start: "2026-06-14T00:00:00.000Z", end: "2026-06-21T00:00:00.000Z" },
+    previous: { start: "2026-06-07T00:00:00.000Z", end: "2026-06-14T00:00:00.000Z" },
+  },
+  kpis: buildDigestKpis(
+    {
+      unique_visitors: 150,
+      total_pageviews: 600,
+      total_sessions: 180,
+      bounce_rate: 0.42,
+      avg_session_duration: 95,
+      pages_per_session: 3.3,
+    },
+    {
+      unique_visitors: 120,
+      total_pageviews: 500,
+      total_sessions: 150,
+      bounce_rate: 0.5,
+      avg_session_duration: 80,
+      pages_per_session: 3,
+    }
+  ),
+  breakdowns: {
+    top_pages: [
+      { value: "/", count: 200, percentage: 40 },
+      { value: "/shop", count: 90, percentage: 18 },
+    ],
+    referrers: [{ value: "google", count: 100, percentage: 55 }],
+    devices: [{ value: "mobile", count: 120, percentage: 66 }],
+    countries: [{ value: "IN", count: 130, percentage: 72 }],
+  },
+  not_found_count: 3,
+  suggestions: [
+    {
+      id: "mobile_heavy_traffic",
+      severity: "opportunity",
+      title: "Optimize for mobile",
+      detail: "66% of traffic is on mobile.",
+    },
+  ],
+  ...over,
+});
+
+const ZERO_STATS = {
+  unique_visitors: 0,
+  total_pageviews: 0,
+  total_sessions: 0,
+  bounce_rate: 0,
+  avg_session_duration: 0,
+  pages_per_session: 0,
+};
+
+describe("buildDigestAiPrompt", () => {
+  it("is deterministic: same digest in ⇒ identical prompt out", () => {
+    const a = buildDigestAiPrompt(makeDigest());
+    const b = buildDigestAiPrompt(makeDigest());
+    expect(a).toEqual(b);
+  });
+
+  it("embeds the store name, period, KPIs (with deltas) and top breakdowns", () => {
+    const { system, prompt } = buildDigestAiPrompt(makeDigest());
+    expect(system).toMatch(/plain-text/i);
+    expect(prompt).toContain("Store: Example Shop");
+    expect(prompt).toContain("Period: last_7_days");
+    expect(prompt).toContain("Unique visitors: 150");
+    expect(prompt).toContain("(+25% vs previous, up)"); // 150 vs 120
+    expect(prompt).toContain("Top pages: / (40%), /shop (18%)");
+    expect(prompt).toContain("Top referrers: google (55%)");
+    expect(prompt).toContain("Suggestions already surfaced: Optimize for mobile");
+  });
+
+  it("falls back to the domain when the store has no name", () => {
+    const { prompt } = buildDigestAiPrompt(
+      makeDigest({ website: { id: "web_1", domain: "shop.example.com", name: null } })
+    );
+    expect(prompt).toContain("Store: shop.example.com");
+  });
+
+  it("renders 'none' for empty breakdowns and never throws on a sparse digest", () => {
+    const sparse = makeDigest({
+      breakdowns: { top_pages: [], referrers: [], devices: [], countries: [] },
+      suggestions: [],
+    });
+    const { prompt } = buildDigestAiPrompt(sparse);
+    expect(prompt).toContain("Top pages: none");
+    expect(prompt).not.toContain("Suggestions already surfaced");
+  });
+
+  it("labels metrics with no baseline distinctly (delta_pct null)", () => {
+    const noBaseline = makeDigest({
+      kpis: buildDigestKpis(
+        { ...ZERO_STATS, unique_visitors: 10 },
+        ZERO_STATS // previous all-zero ⇒ delta_pct null
+      ),
+    });
+    const { prompt } = buildDigestAiPrompt(noBaseline);
+    expect(prompt).toContain("Unique visitors: 10 (no prior baseline)");
+  });
+});
+
+describe("composeDigestAiSummary", () => {
+  it("returns the sanitised model output for a digest with data", async () => {
+    const generate: DigestAiGenerate = async ({ model }) => {
+      expect(model).toBe(DIGEST_AI_DEFAULT_MODEL);
+      return "  Great week — visitors up 25%.\n\n";
+    };
+    const out = await composeDigestAiSummary(makeDigest(), generate);
+    expect(out).toBe("Great week — visitors up 25%.");
+  });
+
+  it("passes an explicit model override through to generate", async () => {
+    let seen = "";
+    const generate: DigestAiGenerate = async ({ model }) => {
+      seen = model;
+      return "ok";
+    };
+    await composeDigestAiSummary(makeDigest(), generate, { model: "anthropic/claude-3.5" });
+    expect(seen).toBe("anthropic/claude-3.5");
+  });
+
+  it("skips (null) for a zero-data digest WITHOUT calling generate", async () => {
+    let called = false;
+    const generate: DigestAiGenerate = async () => {
+      called = true;
+      return "should not run";
+    };
+    const zero = makeDigest({
+      kpis: buildDigestKpis(ZERO_STATS, ZERO_STATS),
+    });
+    const out = await composeDigestAiSummary(zero, generate);
+    expect(out).toBeNull();
+    expect(called).toBe(false);
+  });
+
+  it("returns null (never throws) when generate rejects", async () => {
+    const generate: DigestAiGenerate = async () => {
+      throw new Error("OpenRouter 503");
+    };
+    await expect(composeDigestAiSummary(makeDigest(), generate)).resolves.toBeNull();
+  });
+
+  it("returns null when the model output sanitises to empty", async () => {
+    const generate: DigestAiGenerate = async () => "   \n\t  ";
+    const out = await composeDigestAiSummary(makeDigest(), generate);
+    expect(out).toBeNull();
+  });
+
+  it("caps an over-long summary via sanitizeAiSummary (MAX_LEN + ellipsis)", async () => {
+    const generate: DigestAiGenerate = async () => "x".repeat(AI_SUMMARY_MAX_LEN + 200);
+    const out = await composeDigestAiSummary(makeDigest(), generate);
+    expect(out).not.toBeNull();
+    // sanitizeAiSummary hard-caps at MAX_LEN then appends a single "…".
+    expect((out as string).length).toBeLessThanOrEqual(AI_SUMMARY_MAX_LEN + 1);
+    expect((out as string).endsWith("…")).toBe(true);
+  });
+});

--- a/apps/backend/src/workflows/analytics/partner-digest-ai-lib.ts
+++ b/apps/backend/src/workflows/analytics/partner-digest-ai-lib.ts
@@ -1,0 +1,134 @@
+/**
+ * @file Partner storefront digest — AI summary generation (pure / injectable).
+ * @module workflows/analytics/partner-digest-ai-lib
+ *
+ * #589 item 3 (last slice). Turns a computed {@link PartnerStorefrontDigest}
+ * into a short, warm natural-language "how your week went" paragraph that the
+ * email renders above the KPIs (the `{{#if ai_summary}}` block added by the
+ * slice-3 data contract).
+ *
+ * Split so the deterministic parts are unit-testable WITHOUT a network call:
+ *   - {@link buildDigestAiPrompt} — PURE: digest → `{ system, prompt }`.
+ *   - {@link composeDigestAiSummary} — orchestration with an INJECTED model
+ *     call (`generate`), so tests pass a fake and never hit OpenRouter.
+ *
+ * The live wiring (a real OpenRouter-backed `generate`) lives in the
+ * `partner_analytics_digest` operation behind a default-OFF option, so the
+ * weekly flow's behaviour is unchanged until an admin opts in.
+ */
+
+import {
+  type DigestMetric,
+  type DigestBreakdownItem,
+  type PartnerStorefrontDigest,
+} from "./partner-digest-lib";
+import { digestHasData, sanitizeAiSummary } from "./partner-digest-email-lib";
+
+/** Mirrors the `ai_extract` operation default so flows stay consistent. */
+export const DIGEST_AI_DEFAULT_MODEL = "google/gemini-2.5-flash-preview";
+
+/**
+ * The model-call seam. The operation supplies a real OpenRouter-backed
+ * implementation; unit tests supply a fake. Must resolve to the raw text the
+ * model produced (sanitisation happens here, not in the caller).
+ */
+export type DigestAiGenerate = (args: {
+  system: string;
+  prompt: string;
+  model: string;
+}) => Promise<string>;
+
+/** Compact, deterministic one-liner for a single KPI (no unicode arrows). */
+function fmtMetric(label: string, m: DigestMetric | null | undefined): string {
+  if (!m) return `${label}: n/a`;
+  const cur = Number.isFinite(m.current) ? m.current : 0;
+  if (m.delta_pct === null || m.delta_pct === undefined) {
+    return `${label}: ${cur} (no prior baseline)`;
+  }
+  const sign = m.delta_pct > 0 ? "+" : "";
+  return `${label}: ${cur} (${sign}${m.delta_pct}% vs previous, ${m.direction})`;
+}
+
+/** Top-N breakdown rows rendered as "value (pct%)" for the prompt. */
+function fmtTop(items: DigestBreakdownItem[] | null | undefined, n: number): string {
+  const rows = (items ?? []).slice(0, n);
+  if (!rows.length) return "none";
+  return rows.map((r) => `${r.value} (${r.percentage}%)`).join(", ");
+}
+
+/**
+ * Build the system + user prompt for the weekly AI summary. PURE and
+ * deterministic — identical digest in ⇒ identical prompt out (unit-testable,
+ * cache-friendly). Never throws on partial digests.
+ */
+export function buildDigestAiPrompt(digest: PartnerStorefrontDigest): {
+  system: string;
+  prompt: string;
+} {
+  const system =
+    "You write a short, warm weekly storefront performance summary for a " +
+    "textile/handloom seller. Write 1-2 plain-text sentences (max ~70 words), " +
+    "no markdown, no bullet points, no greeting or sign-off. Be encouraging " +
+    "and specific to the numbers; if traffic fell, stay constructive. Return " +
+    "only the summary text.";
+
+  const store =
+    digest?.website?.name?.trim() ||
+    digest?.website?.domain?.trim() ||
+    "your storefront";
+  const periodLabel = digest?.period?.label ?? "this period";
+  const k = digest?.kpis;
+  const bd = digest?.breakdowns;
+
+  const lines = [
+    `Store: ${store}`,
+    `Period: ${periodLabel}`,
+    fmtMetric("Unique visitors", k?.unique_visitors),
+    fmtMetric("Pageviews", k?.pageviews),
+    fmtMetric("Sessions", k?.sessions),
+    fmtMetric("Bounce rate", k?.bounce_rate),
+    `Top pages: ${fmtTop(bd?.top_pages, 3)}`,
+    `Top referrers: ${fmtTop(bd?.referrers, 3)}`,
+    `Top devices: ${fmtTop(bd?.devices, 2)}`,
+  ];
+
+  const suggestions = Array.isArray(digest?.suggestions) ? digest.suggestions : [];
+  if (suggestions.length) {
+    lines.push(
+      `Suggestions already surfaced: ${suggestions
+        .slice(0, 4)
+        .map((s) => s.title)
+        .join("; ")}`
+    );
+  }
+
+  return { system, prompt: lines.join("\n") };
+}
+
+/**
+ * Generate (best-effort) a sanitised AI summary for one digest.
+ *
+ * - Skips entirely (returns `null`) when the digest has no traffic data — the
+ *   zero-data "start sharing" nudge (#589 item 2) covers that case instead.
+ * - Runs the model output through {@link sanitizeAiSummary} (collapse + cap).
+ * - NEVER throws: any model/parse failure resolves to `null` so the weekly
+ *   run is never aborted by an AI hiccup.
+ *
+ * Returns the summary string, or `null` to leave `digest.ai_summary` unset.
+ */
+export async function composeDigestAiSummary(
+  digest: PartnerStorefrontDigest,
+  generate: DigestAiGenerate,
+  opts?: { model?: string }
+): Promise<string | null> {
+  try {
+    if (!digest || !digestHasData(digest)) return null;
+    const { system, prompt } = buildDigestAiPrompt(digest);
+    const model = opts?.model?.trim() || DIGEST_AI_DEFAULT_MODEL;
+    const raw = await generate({ system, prompt, model });
+    const summary = sanitizeAiSummary(raw);
+    return summary.length > 0 ? summary : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## #589 item 3 — AI summary **generation** (the live-wiring piece)

Slice 3 (PR #592) shipped the *data contract* (`ai_summary` field + `sanitizeAiSummary` + the `{{#if ai_summary}}` template block). This slice ships the **generation** machinery + a **default-OFF** enrich option, so the last #589 piece becomes flippable without a code change.

### What
- **`workflows/analytics/partner-digest-ai-lib.ts`** (new, pure/injectable):
  - `buildDigestAiPrompt(digest)` → `{ system, prompt }` — PURE, deterministic (store/period/KPIs+deltas/top breakdowns/existing suggestion titles). Never throws on sparse digests.
  - `composeDigestAiSummary(digest, generate, opts?)` — orchestration with an **injected** `DigestAiGenerate` seam (tests pass a fake; never hits OpenRouter). Best-effort: skips zero-data digests (the #589 item-2 nudge covers those), sanitises + caps via `sanitizeAiSummary`, returns `null` on any failure (never aborts the run).
- **`partner_analytics_digest` operation**: new `generate_ai_summary` (default **false**) + `ai_summary_model` options. When enabled, builds an OpenRouter-backed `generate` (same `createOpenRouter`/`generateText` pattern as `ai_extract`) and sets `digest.ai_summary` per partner **before** the email fan-out. Default-off ⇒ live weekly flow behaviour is **unchanged**.

### Why this shape
The model call is the only un-unit-testable part, so it's isolated behind the `DigestAiGenerate` seam + a default-off flag (same safety posture as the slice-3 data contract and the isolated-vm flag). The pure prompt-builder + best-effort orchestration are fully covered; flipping `generate_ai_summary: true` on the live flow node is the remaining interactive step.

### Tests
- `partner-digest-ai-lib.unit` — **11 new** (prompt determinism/content/fallbacks, model override, zero-data skip, reject→null, empty→null, over-length cap).
- Related digest suites: **59 green** (`partner-digest-ai-lib` + `partner-digest-email-lib` + `partner-analytics-digest`). 0 new tsc.

### Stacking
**Stacked on #592** (`feat/589-digest-ai-summary-stack`) — depends on its `ai_summary` field + `sanitizeAiSummary`. **Merge order: #590 → #591 → #592 → this.** Branched off #592, not main.

### Not in scope
Enabling the option on the LIVE flow (needs a live flow editor + a real model key) — interactive. The email already branches on `{{#if ai_summary}}` (slice 3) and the live template still needs the manual html edit noted in #591/#592.