### PR TITLE
fix(#498): stop double-counting parent vs child production runs in product widget

### DIFF
--- a/apps/backend/src/admin/widgets/__tests__/production-run-totals.unit.spec.ts
+++ b/apps/backend/src/admin/widgets/__tests__/production-run-totals.unit.spec.ts
@@ -1,0 +1,94 @@
+import {
+  leafProductionRuns,
+  summarizeProductionRunTotals,
+  type ProductionRunLike,
+} from "../production-run-totals"
+
+describe("summarizeProductionRunTotals (#498 double-count)", () => {
+  it("does NOT double-count a parent against its children", () => {
+    const runs: ProductionRunLike[] = [
+      { id: "parent", parent_run_id: null, status: "completed", quantity: 10 },
+      { id: "c1", parent_run_id: "parent", status: "completed", quantity: 4 },
+      { id: "c2", parent_run_id: "parent", status: "completed", quantity: 6 },
+    ]
+    // Naive sum would be 20; leaf-only sum is 4 + 6 = 10.
+    expect(summarizeProductionRunTotals(runs).completed).toBe(10)
+  })
+
+  it("counts a simple run with no children exactly once", () => {
+    const runs: ProductionRunLike[] = [
+      { id: "solo", parent_run_id: null, status: "completed", quantity: 7 },
+    ]
+    const totals = summarizeProductionRunTotals(runs)
+    expect(totals.completed).toBe(7)
+    expect(totals.leafCount).toBe(1)
+  })
+
+  it("splits completed vs in-progress by leaf status, not the parent's", () => {
+    const runs: ProductionRunLike[] = [
+      // parent is 'completed' but its children carry the real per-leaf status
+      { id: "p", parent_run_id: null, status: "completed", quantity: 10 },
+      { id: "c1", parent_run_id: "p", status: "completed", quantity: 4 },
+      { id: "c2", parent_run_id: "p", status: "in_progress", quantity: 6 },
+    ]
+    const totals = summarizeProductionRunTotals(runs)
+    expect(totals.completed).toBe(4)
+    expect(totals.inProgress).toBe(6)
+  })
+
+  it("recognises all in-progress-family statuses", () => {
+    const runs: ProductionRunLike[] = [
+      { id: "a", status: "in_progress", quantity: 1 },
+      { id: "b", status: "sent_to_partner", quantity: 2 },
+      { id: "c", status: "approved", quantity: 3 },
+      { id: "d", status: "completed", quantity: 4 },
+    ]
+    const totals = summarizeProductionRunTotals(runs)
+    expect(totals.inProgress).toBe(6)
+    expect(totals.completed).toBe(4)
+  })
+
+  it("handles missing/zero quantities and unknown statuses safely", () => {
+    const runs: ProductionRunLike[] = [
+      { id: "a", status: "completed" }, // no quantity
+      { id: "b", status: "draft", quantity: 5 }, // unknown status
+      { id: "c", status: "completed", quantity: 0 },
+    ]
+    const totals = summarizeProductionRunTotals(runs)
+    expect(totals.completed).toBe(0)
+    expect(totals.inProgress).toBe(0)
+  })
+
+  it("is depth-agnostic (a child that is itself a parent is not a leaf)", () => {
+    const runs: ProductionRunLike[] = [
+      { id: "p", parent_run_id: null, status: "completed", quantity: 10 },
+      { id: "mid", parent_run_id: "p", status: "completed", quantity: 10 },
+      { id: "leaf1", parent_run_id: "mid", status: "completed", quantity: 4 },
+      { id: "leaf2", parent_run_id: "mid", status: "completed", quantity: 6 },
+    ]
+    expect(summarizeProductionRunTotals(runs).completed).toBe(10)
+    expect(leafProductionRuns(runs).map((r) => r.id)).toEqual(["leaf1", "leaf2"])
+  })
+
+  it("tolerates empty / non-array input", () => {
+    expect(summarizeProductionRunTotals([])).toEqual({
+      completed: 0,
+      inProgress: 0,
+      leafCount: 0,
+      total: 0,
+    })
+    // @ts-expect-error - guarding runtime misuse
+    expect(summarizeProductionRunTotals(undefined).completed).toBe(0)
+  })
+
+  it("reports total run records (parents + children) distinct from leafCount", () => {
+    const runs: ProductionRunLike[] = [
+      { id: "p", parent_run_id: null, status: "completed", quantity: 10 },
+      { id: "c1", parent_run_id: "p", status: "completed", quantity: 4 },
+      { id: "c2", parent_run_id: "p", status: "completed", quantity: 6 },
+    ]
+    const totals = summarizeProductionRunTotals(runs)
+    expect(totals.total).toBe(3)
+    expect(totals.leafCount).toBe(2)
+  })
+})

--- a/apps/backend/src/admin/widgets/product-designs.tsx
+++ b/apps/backend/src/admin/widgets/product-designs.tsx
@@ -7,6 +7,7 @@ import { PencilSquare, Plus, Trash } from "@medusajs/icons"
 import { useProduct, useUnlinkProductDesign } from "../hooks/api/products"
 import { useDesignInventory } from "../hooks/api/designs"
 import { AdminProductionRun, useProductionRuns } from "../hooks/api/production-runs"
+import { summarizeProductionRunTotals } from "./production-run-totals"
 
 const designStatusColor = (status: string): "green" | "blue" | "orange" | "grey" | "red" | "purple" => {
   switch (status) {
@@ -128,13 +129,10 @@ function DesignAdminProductionRunsSection({ designId }: { designId: string }) {
     <Text size="xsmall" className="text-ui-fg-muted px-1">No production runs linked to this design.</Text>
   )
 
-  const totalProduced = runs
-    .filter((r: AdminProductionRun) => r.status === "completed")
-    .reduce((sum: number, r: AdminProductionRun) => sum + (r.quantity ?? 0), 0)
-
-  const inProgress = runs
-    .filter((r: AdminProductionRun) => ["in_progress", "sent_to_partner", "approved"].includes(r.status ?? ""))
-    .reduce((sum: number, r: AdminProductionRun) => sum + (r.quantity ?? 0), 0)
+  // #498: a design's runs come back as a parent + one child per partner
+  // assignment (all sharing design_id). The parent's quantity already equals
+  // the sum of its children, so sum LEAF runs only to avoid double-counting.
+  const { completed: totalProduced, inProgress } = summarizeProductionRunTotals(runs)
 
   return (
     <div className="flex flex-col gap-y-3">

--- a/apps/backend/src/admin/widgets/production-run-totals.ts
+++ b/apps/backend/src/admin/widgets/production-run-totals.ts
@@ -1,0 +1,79 @@
+/**
+ * Pure helpers for summarising a design's production runs without double-counting.
+ *
+ * Background (#498): a design's production runs come back as a PARENT run plus
+ * one CHILD run per partner assignment, all sharing the same `design_id` (the
+ * children are created in `approveProductionRunWorkflow` with
+ * `parent_run_id = parent.id` and `design_id = parent.design_id`). The parent's
+ * `quantity` already equals the sum of its children's quantities, so naively
+ * summing every returned run double-counts the parent against its children
+ * (e.g. parent 10 + child 4 + child 6 = 20 instead of 10).
+ *
+ * The fix is to sum only LEAF runs — runs that are not referenced as any other
+ * run's `parent_run_id`, at any depth. A simple run with no children is itself
+ * a leaf, so non-assigned runs are still counted exactly once.
+ */
+
+export type ProductionRunLike = {
+  id?: string | null
+  parent_run_id?: string | null
+  status?: string | null
+  quantity?: number | null
+}
+
+export const COMPLETED_STATUSES = ["completed"] as const
+export const IN_PROGRESS_STATUSES = [
+  "in_progress",
+  "sent_to_partner",
+  "approved",
+] as const
+
+export type ProductionRunTotals = {
+  /** Sum of completed leaf-run quantities. */
+  completed: number
+  /** Sum of in-progress leaf-run quantities. */
+  inProgress: number
+  /** Number of leaf runs (parents with children are excluded). */
+  leafCount: number
+  /** Total number of run records returned (parents + children). */
+  total: number
+}
+
+/**
+ * Return only the leaf runs — runs that are NOT the `parent_run_id` of any other
+ * run in the set. Leaf detection uses the full set (so status filtering can't
+ * accidentally promote a parent to a leaf) and is depth-agnostic.
+ */
+export function leafProductionRuns<T extends ProductionRunLike>(runs: T[]): T[] {
+  const list = Array.isArray(runs) ? runs : []
+  const parentIds = new Set<string>()
+  for (const r of list) {
+    if (r?.parent_run_id) {
+      parentIds.add(String(r.parent_run_id))
+    }
+  }
+  return list.filter((r) => !(r?.id != null && parentIds.has(String(r.id))))
+}
+
+/**
+ * Summarise a design's production runs, counting each unit of work exactly once
+ * by summing leaf runs only. See file header for the #498 rationale.
+ */
+export function summarizeProductionRunTotals(
+  runs: ProductionRunLike[]
+): ProductionRunTotals {
+  const list = Array.isArray(runs) ? runs : []
+  const leaves = leafProductionRuns(list)
+
+  const sumByStatus = (statuses: readonly string[]) =>
+    leaves
+      .filter((r) => statuses.includes(r?.status ?? ""))
+      .reduce((acc, r) => acc + (Number(r?.quantity) || 0), 0)
+
+  return {
+    completed: sumByStatus(COMPLETED_STATUSES),
+    inProgress: sumByStatus(IN_PROGRESS_STATUSES),
+    leafCount: leaves.length,
+    total: list.length,
+  }
+}


### PR DESCRIPTION
Closes #498.

## Problem
On a product detail page, the **Designs** widget's production-run summary badges
showed an inflated quantity (e.g. **20** when the design's real run total is **10**).

## Root cause
A design's production runs are created as a **parent** run plus **one child run
per partner assignment** (`approveProductionRunWorkflow` sets
`parent_run_id = parent.id` and `design_id = parent.design_id`). The parent's
`quantity` already equals the sum of its children's quantities. The widget
(`product-designs.tsx`) summed `quantity` over **every** run returned by
`GET /admin/production-runs?design_id=…` — which returns parents **and** children —
so the parent was counted on top of its children (`10 + 4 + 6 = 20`).

## Fix
New pure helpers `summarizeProductionRunTotals()` / `leafProductionRuns()`
(`src/admin/widgets/production-run-totals.ts`) sum **leaf runs only** — runs not
referenced as any other run's `parent_run_id` (depth-agnostic), splitting
completed vs in-progress by each leaf's **own** status. A simple run with no
children is itself a leaf, so non-assigned runs are still counted exactly once.
The widget's two badge reduces are replaced by one call to the helper.

## Tests
- 8 unit tests (`__tests__/production-run-totals.unit.spec.ts`), incl. the exact
  repro (parent 10 / children 4+6 → **10**), per-leaf status split, depth-agnostic
  nesting, missing/zero qty, empty input. `TEST_TYPE=unit` → **8/8 green**.
- `tsc --noEmit`: **0 new errors** (70 baseline).

## Verification note
Display-layer fix; logic is exhaustively unit-tested. A live before/after needs
the prod repro data (design `01KMDCWAKKXQAQGCT3XQGY8MB8`, which has the
parent+child run set) — not present in the dev DB — so **visual verification is
deferred to prod-verify** after deploy: open that design's linked product detail
and confirm the "completed/in production" badges match the true total, not the
doubled sum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)