### PR TITLE
audit(partner-api): Sales Channel parity audit + DELETE envelope wire fix

### DIFF
--- a/apps/backend/src/api/partners/stores/[id]/sales-channels/[channelId]/route.ts
+++ b/apps/backend/src/api/partners/stores/[id]/sales-channels/[channelId]/route.ts
@@ -80,5 +80,8 @@ export const DELETE = async (
 
   await deleteSalesChannelsWorkflow(req.scope).run({ input: { ids: [req.params.channelId] } })
 
-  res.json({ id: req.params.channelId, object: "sales_channel", deleted: true })
+  // PARITY-NOTE: admin's DELETE envelope uses the hyphenated object name
+  // ("sales-channel"), not "sales_channel". Mirror it exactly so the wire
+  // contract matches @medusajs/medusa/dist/api/admin/sales-channels/[id]/route.js.
+  res.json({ id: req.params.channelId, object: "sales-channel", deleted: true })
 }

--- a/apps/docs/notes/PARTNER_API_PARITY.md
+++ b/apps/docs/notes/PARTNER_API_PARITY.md
@@ -82,7 +82,31 @@ One section per partner module. Status: ✅ matches admin / ⚠️ drift identif
 
 ### Sales Channel
 
-- **Status:** 🆕 audit not yet run — scheduled for PR C.
+- **Status:** ⚠️ audited 2026-06-21 (daemon) — route already exists; drifts identified below. One safe wire fix applied (`audit/partner-sales-channel-parity`); behavior-changing drifts deferred (decision-bearing).
+- **Admin source:** `apps/backend/node_modules/@medusajs/medusa/dist/api/admin/sales-channels/` (`route.js`, `[id]/route.js`, `validators.js`, `query-config.js`)
+- **Partner source:** `apps/backend/src/api/partners/stores/[id]/sales-channels/` (`route.ts` = LIST/CREATE, `[channelId]/route.ts` = GET/UPDATE/DELETE, `[channelId]/products/batch/route.ts`). Validators in `apps/backend/src/api/partners/stores/[id]/validators.ts` (`PartnerCreateSalesChannelReq`/`PartnerUpdateSalesChannelReq`). Middlewares registered in `apps/backend/src/api/middlewares.ts` (~L1963–2005).
+- **Scoping path:** there is **no `partner_sales_channel` link**. Partner scope is derived: partner → `partner_stores` link → store → (`store.default_sales_channel_id` + `stock_locations.sales_channels` of `store.default_location_id`). The single-resource routes (`[channelId]`) scope **only to `store.default_sales_channel_id`** — narrower than LIST.
+
+| Aspect | Admin (authoritative) | Partner today | Action |
+|---|---|---|---|
+| List response envelope | `{ sales_channels, count, offset, limit }` | `{ sales_channels, count, offset, limit }` ✓ | none |
+| Single response envelope | `{ sales_channel }` | `{ sales_channel }` ✓ | none |
+| Delete response envelope | `{ id, object: "sales-channel", deleted: true }` | was `object: "sales_channel"` → **fixed to `"sales-channel"`** | ✅ applied |
+| Create body validator | `AdminCreateSalesChannel` (name, description?, is_disabled?, metadata?) | `PartnerCreateSalesChannelReq` — same fields ✓ | none |
+| Update body validator | `AdminUpdateSalesChannel` (all optional) | `PartnerUpdateSalesChannelReq` — same fields ✓ | none |
+| Update HTTP verb | POST | POST ✓ | none |
+| Workflow / service call | create=`createSalesChannelsWorkflow`, update=`updateSalesChannelsWorkflow`, delete=`deleteSalesChannelsWorkflow` | create=workflow ✓, **update=`scService.updateSalesChannels` direct ⚠️**, delete=workflow ✓ | switch update to `updateSalesChannelsWorkflow` (PR C) |
+| Default `fields` selection | `defaultAdminSalesChannelFields` + respects `?fields=` | hardcoded `["*"]`, **no `validateAndTransformQuery`** ⚠️ | wire query middleware (PR C) |
+| List filters accepted | `q, id, name, description, is_disabled, created_at/updated_at/deleted_at` ops, `$and/$or`, `location_id`, `publishable_key_id` | none — handler ignores all query params ⚠️ | add list validator passthrough (PR C) |
+| Pagination defaults | limit 20 / offset 0 via `listTransformQueryConfig` | **hardcoded** `offset:0, limit:20`, count = array length (no real paging) ⚠️ | pass through query config (PR C) |
+
+- **Behavior-changing drifts (deferred — decision-bearing, not in this audit PR):**
+  1. **CREATE returns `201`; admin returns `200`.** Also returns the raw workflow `result[0]`, not a refetched graph row → resource shape can differ. Changing the status may break partner-ui consumers → needs a check before flipping.
+  2. **CREATE does not link the new channel** to the store/location → a partner-created channel is **invisible in the partner's own LIST** afterward (LIST scopes by location's channels + default). Real functional gap; pairs with the missing `partner_sales_channel`/location link decision.
+  3. **Single GET/UPDATE/DELETE scope to `default_sales_channel_id` only**, while LIST can return *additional* location channels → a partner sees a non-default channel in the list but gets `404` fetching/updating it by id. Inconsistent scope; pick one (probably scope single routes to the same location-channel set as LIST).
+  4. **DELETE allows deleting the store's default sales channel** → would break that store's storefront. A partner-side guard ("cannot delete the default sales channel") is warranted; admin has no such guard because admin isn't partner-scoped.
+- **Partner-only additions:** none yet. A `partner_sales_channel` link (or reuse of the location→sales_channel link as the source of truth) is the open modeling decision before the CREATE-invisibility and single-route-scope drifts can be fixed cleanly.
+- **Intentional divergences:** none asserted yet — the LIST scope (partner sees only its store/location channels, not all platform channels) is correct partner behavior and the parity test must assert **shape-only**, not the row set.
 
 ### Shipping Option
 


### PR DESCRIPTION
## What

Runs the **Sales Channel** partner-API parity audit (was 🆕 scheduled for "PR C" in `PARTNER_API_PARITY.md`) and applies the single safe wire-contract fix found.

The partner sales-channels routes already exist (`/partners/stores/:id/sales-channels[/:channelId]`) — this PR audits them against the admin source and records the result, rather than building net-new routes.

## Changes
- **`PARTNER_API_PARITY.md`** — Sales Channel section filled in: 8-row audit table + scoping-path note + list of behavior-changing drifts deferred to a future PR.
- **`.../sales-channels/[channelId]/route.ts`** — DELETE envelope `object` `"sales_channel"` → `"sales-channel"` to mirror admin (`@medusajs/medusa/dist/api/admin/sales-channels/[id]/route.js`) exactly. `PARITY-NOTE` added. Verified no `partner-ui` source depends on the old string.

## Drifts found (documented, **not** fixed here — decision-bearing)
1. CREATE returns `201` (admin `200`) and the raw workflow result, not a refetched row.
2. CREATE does not link the new channel → it's **invisible in the partner's own LIST** afterward.
3. Single GET/UPDATE/DELETE scope only to `default_sales_channel_id`, but LIST returns the store location's channels too → list-visible-but-404-on-fetch inconsistency.
4. DELETE can remove the store's **default** sales channel (would break the storefront) — needs a partner-side guard.
5. UPDATE calls `scService.updateSalesChannels` directly instead of `updateSalesChannelsWorkflow`; LIST/single ignore query middleware (no `?fields=`, no filters, hardcoded paging).

All hinge on the open `partner_sales_channel` link / location-scope modeling decision → future PR C.

## Verify
- `tsc` on changed file: 0 new errors (70 = baseline).
- Wire fix is a string-literal mirror of admin; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)