### PR TITLE
audit(partner-parity): Shipping Option parity — refetch create response [stacked on #596]

### DIFF
--- a/apps/backend/src/api/partners/stores/[id]/sales-channels/[channelId]/route.ts
+++ b/apps/backend/src/api/partners/stores/[id]/sales-channels/[channelId]/route.ts
@@ -80,5 +80,8 @@ export const DELETE = async (
 
   await deleteSalesChannelsWorkflow(req.scope).run({ input: { ids: [req.params.channelId] } })
 
-  res.json({ id: req.params.channelId, object: "sales_channel", deleted: true })
+  // PARITY-NOTE: admin's DELETE envelope uses the hyphenated object name
+  // ("sales-channel"), not "sales_channel". Mirror it exactly so the wire
+  // contract matches @medusajs/medusa/dist/api/admin/sales-channels/[id]/route.js.
+  res.json({ id: req.params.channelId, object: "sales-channel", deleted: true })
 }

--- a/apps/backend/src/api/partners/stores/[id]/shipping-options/route.ts
+++ b/apps/backend/src/api/partners/stores/[id]/shipping-options/route.ts
@@ -96,5 +96,19 @@ export const POST = async (
     input: [body as any],
   })
 
-  res.status(201).json({ shipping_option: result[0] })
+  // Refetch the created option with its prices/relations so the create
+  // response mirrors admin (`refetchShippingOption`) AND the sibling
+  // update route ([optionId] POST). The bare workflow result omits the
+  // resolved `prices`/`rules`/`type` rows, so a client reading
+  // `shipping_option.prices` off the create response would get
+  // `undefined`. `prices.price_rules.*` is expanded for the same
+  // pricing-grid bucketing reason documented on the GET/update routes.
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data: options } = await query.graph({
+    entity: "shipping_options",
+    fields: ["*", "prices.*", "prices.price_rules.*", "rules.*", "type.*", "shipping_profile.*"],
+    filters: { id: result[0].id },
+  })
+
+  res.status(201).json({ shipping_option: options?.[0] ?? result[0] })
 }

--- a/apps/docs/notes/PARTNER_API_PARITY.md
+++ b/apps/docs/notes/PARTNER_API_PARITY.md
@@ -82,7 +82,31 @@ One section per partner module. Status: ✅ matches admin / ⚠️ drift identif
 
 ### Sales Channel
 
-- **Status:** 🆕 audit not yet run — scheduled for PR C.
+- **Status:** ⚠️ audited 2026-06-21 (daemon) — route already exists; drifts identified below. One safe wire fix applied (`audit/partner-sales-channel-parity`); behavior-changing drifts deferred (decision-bearing).
+- **Admin source:** `apps/backend/node_modules/@medusajs/medusa/dist/api/admin/sales-channels/` (`route.js`, `[id]/route.js`, `validators.js`, `query-config.js`)
+- **Partner source:** `apps/backend/src/api/partners/stores/[id]/sales-channels/` (`route.ts` = LIST/CREATE, `[channelId]/route.ts` = GET/UPDATE/DELETE, `[channelId]/products/batch/route.ts`). Validators in `apps/backend/src/api/partners/stores/[id]/validators.ts` (`PartnerCreateSalesChannelReq`/`PartnerUpdateSalesChannelReq`). Middlewares registered in `apps/backend/src/api/middlewares.ts` (~L1963–2005).
+- **Scoping path:** there is **no `partner_sales_channel` link**. Partner scope is derived: partner → `partner_stores` link → store → (`store.default_sales_channel_id` + `stock_locations.sales_channels` of `store.default_location_id`). The single-resource routes (`[channelId]`) scope **only to `store.default_sales_channel_id`** — narrower than LIST.
+
+| Aspect | Admin (authoritative) | Partner today | Action |
+|---|---|---|---|
+| List response envelope | `{ sales_channels, count, offset, limit }` | `{ sales_channels, count, offset, limit }` ✓ | none |
+| Single response envelope | `{ sales_channel }` | `{ sales_channel }` ✓ | none |
+| Delete response envelope | `{ id, object: "sales-channel", deleted: true }` | was `object: "sales_channel"` → **fixed to `"sales-channel"`** | ✅ applied |
+| Create body validator | `AdminCreateSalesChannel` (name, description?, is_disabled?, metadata?) | `PartnerCreateSalesChannelReq` — same fields ✓ | none |
+| Update body validator | `AdminUpdateSalesChannel` (all optional) | `PartnerUpdateSalesChannelReq` — same fields ✓ | none |
+| Update HTTP verb | POST | POST ✓ | none |
+| Workflow / service call | create=`createSalesChannelsWorkflow`, update=`updateSalesChannelsWorkflow`, delete=`deleteSalesChannelsWorkflow` | create=workflow ✓, **update=`scService.updateSalesChannels` direct ⚠️**, delete=workflow ✓ | switch update to `updateSalesChannelsWorkflow` (PR C) |
+| Default `fields` selection | `defaultAdminSalesChannelFields` + respects `?fields=` | hardcoded `["*"]`, **no `validateAndTransformQuery`** ⚠️ | wire query middleware (PR C) |
+| List filters accepted | `q, id, name, description, is_disabled, created_at/updated_at/deleted_at` ops, `$and/$or`, `location_id`, `publishable_key_id` | none — handler ignores all query params ⚠️ | add list validator passthrough (PR C) |
+| Pagination defaults | limit 20 / offset 0 via `listTransformQueryConfig` | **hardcoded** `offset:0, limit:20`, count = array length (no real paging) ⚠️ | pass through query config (PR C) |
+
+- **Behavior-changing drifts (deferred — decision-bearing, not in this audit PR):**
+  1. **CREATE returns `201`; admin returns `200`.** Also returns the raw workflow `result[0]`, not a refetched graph row → resource shape can differ. Changing the status may break partner-ui consumers → needs a check before flipping.
+  2. **CREATE does not link the new channel** to the store/location → a partner-created channel is **invisible in the partner's own LIST** afterward (LIST scopes by location's channels + default). Real functional gap; pairs with the missing `partner_sales_channel`/location link decision.
+  3. **Single GET/UPDATE/DELETE scope to `default_sales_channel_id` only**, while LIST can return *additional* location channels → a partner sees a non-default channel in the list but gets `404` fetching/updating it by id. Inconsistent scope; pick one (probably scope single routes to the same location-channel set as LIST).
+  4. **DELETE allows deleting the store's default sales channel** → would break that store's storefront. A partner-side guard ("cannot delete the default sales channel") is warranted; admin has no such guard because admin isn't partner-scoped.
+- **Partner-only additions:** none yet. A `partner_sales_channel` link (or reuse of the location→sales_channel link as the source of truth) is the open modeling decision before the CREATE-invisibility and single-route-scope drifts can be fixed cleanly.
+- **Intentional divergences:** none asserted yet — the LIST scope (partner sees only its store/location channels, not all platform channels) is correct partner behavior and the parity test must assert **shape-only**, not the row set.
 
 ### Shipping Option
 

--- a/apps/docs/notes/PARTNER_API_PARITY.md
+++ b/apps/docs/notes/PARTNER_API_PARITY.md
@@ -110,7 +110,41 @@ One section per partner module. Status: ✅ matches admin / ⚠️ drift identif
 
 ### Shipping Option
 
-- **Status:** 🆕 audit not yet run — scheduled for PR C.
+- **Status:** ✅ audited (chunk 3, 2026-06-21) — routes already exist at
+  `/partners/stores/:id/shipping-options[/:optionId]`. One consumer-safe
+  parity fix applied; remaining drifts deferred (decision-bearing).
+- **Routes audited:** `GET`/`POST` (list/create) on `route.ts`,
+  `GET`/`POST`/`DELETE` (read/update/delete) on `[optionId]/route.ts`.
+- **DELETE envelope:** ✅ matches admin exactly —
+  `{ id, object: "shipping_option", deleted: true }` (admin uses snake_case
+  `"shipping_option"` here, unlike sales-channel's kebab — no rename needed).
+- **Applied (consumer-safe):** **CREATE now refetches the created option via
+  `query.graph`** (`*, prices.*, prices.price_rules.*, rules.*, type.*,
+  shipping_profile.*`) before responding, instead of returning the bare
+  workflow `result[0]`. This mirrors admin (`refetchShippingOption`) **and**
+  the sibling update route, which already refetched. Purely additive: the
+  response gains `prices`/`rules`/`type`/`shipping_profile`; nothing is
+  removed. `useCreateShippingOptions` in partner-ui invalidates queries and
+  ignores the response body, so zero break risk.
+- **Behavior-changing drifts (deferred — decision-bearing):**
+  1. **CREATE returns `201`; admin returns `200`.** Status-only divergence;
+     partner-ui's `onSuccess` fires on any 2xx so it's harmless there, but an
+     external consumer could check the code → defer the flip (same call as the
+     sales-channel CREATE-201 drift).
+  2. **LIST ignores all query params** (`q`, filters, pagination) — it walks
+     `location → fulfillment_sets → service_zones → shipping_options` and
+     returns `count = array.length`, `offset: 0`, `limit: 20` hardcoded. No
+     real paging/filtering. Same shape as the sales-channel LIST drift; fix
+     needs a list-validator passthrough (PR C).
+  3. **No query middleware / `queryConfig`** on the partner routes (field set
+     is hardcoded per route), so the client can't shape `fields` like admin.
+     Intentional for now — the hardcoded field set is tuned for the
+     partner-ui pricing grid; revisit only if a consumer needs custom fields.
+- **Partner-only additions:** the GET routes inject
+  `service_zone.fulfillment_set.location` into each option so the partner-ui
+  order-create-fulfillment form can default its location selector — admin
+  doesn't need this (not partner-scoped). Correct divergence; the parity test
+  must assert **shape-superset**, not exact equality.
 
 ### Fulfillment Set / Location
 


### PR DESCRIPTION
## What

Partner-API parity audit of **Shipping Option** (`/partners/stores/:id/shipping-options[/:optionId]`) against admin's `shipping-options` routes. Continues the chunk-2 Sales Channel audit (#596).

**Stacked on #596** (both append to the shared `apps/docs/notes/PARTNER_API_PARITY.md`) — **merge #596 first**.

## Applied (consumer-safe)

- **CREATE now refetches the created option** via `query.graph` (`*, prices.*, prices.price_rules.*, rules.*, type.*, shipping_profile.*`) before responding, instead of returning the bare workflow `result[0]`.
  - Mirrors admin's `refetchShippingOption` **and** the sibling update route (`[optionId]` POST), which already refetched.
  - Purely **additive**: the create response gains the resolved `prices`/`rules`/`type`/`shipping_profile` rows; nothing removed.
  - `useCreateShippingOptions` in partner-ui invalidates queries and ignores the response body → **zero break risk**.

## Verified at parity (no change needed)

- **DELETE envelope** already matches admin exactly: `{ id, object: "shipping_option", deleted: true }` (admin uses snake_case here, unlike sales-channel's kebab).

## Deferred (decision-bearing — documented in the doc, not changed)

1. CREATE returns `201`; admin returns `200` (same call as the SC CREATE-201 drift).
2. LIST ignores all query params (`q`/filters/pagination); `count = array.length`, hardcoded `offset:0/limit:20`.
3. No query middleware / `queryConfig` on the partner routes (hardcoded field set, tuned for the partner-ui pricing grid).

## Test

No integration test — the `integration-tests/http/partner-api-parity/` suite doesn't exist yet (needs partner-auth seeding to build). Changed-file `tsc` clean (0 new errors). Fulfillment Set/Location remains 🆕 for a follow-up audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)