### PR TITLE
test(analytics): edge-case coverage for computeSessionMetrics (#594 delegation test)

### DIFF
--- a/apps/backend/src/workflows/analytics/__tests__/partner-digest-email-lib.edge.unit.spec.ts
+++ b/apps/backend/src/workflows/analytics/__tests__/partner-digest-email-lib.edge.unit.spec.ts
@@ -1,0 +1,32 @@
+import { formatDuration } from "../partner-digest-email-lib";
+
+describe("formatDuration (edge cases)", () => {
+  it("clamps negative, NaN, and non-numeric inputs to 0s", () => {
+    expect(formatDuration(0)).toBe("0s");
+    expect(formatDuration(-30)).toBe("0s");
+    expect(formatDuration(NaN)).toBe("0s");
+    expect(formatDuration("abc" as any)).toBe("0s");
+  });
+
+  it("rounds sub-minute values and numeric strings", () => {
+    expect(formatDuration(59)).toBe("59s");
+    expect(formatDuration(59.4)).toBe("59s");
+    expect(formatDuration("95" as any)).toBe("1m 35s");
+  });
+
+  it("rounds across the 60s minute boundary", () => {
+    expect(formatDuration(59.6)).toBe("1m");
+    expect(formatDuration(60)).toBe("1m");
+  });
+
+  it("formats minute-plus-seconds with remainder", () => {
+    expect(formatDuration(61)).toBe("1m 1s");
+    expect(formatDuration(90.4)).toBe("1m 30s");
+    expect(formatDuration(119.6)).toBe("2m");
+  });
+
+  it("handles large durations (>= 1 hour) as minutes only", () => {
+    expect(formatDuration(3600)).toBe("60m");
+    expect(formatDuration(3661)).toBe("61m 1s");
+  });
+});

--- a/apps/backend/src/workflows/analytics/__tests__/session-metrics-lib.edge.unit.spec.ts
+++ b/apps/backend/src/workflows/analytics/__tests__/session-metrics-lib.edge.unit.spec.ts
@@ -1,0 +1,73 @@
+import { computeSessionMetrics } from "../session-metrics-lib";
+
+describe("computeSessionMetrics — edge cases", () => {
+  it("excludes falsy empty-string visitor_id from unique visitors", () => {
+    const m = computeSessionMetrics([{ visitor_id: "", pageviews: 4 }]);
+    expect(m.total_sessions).toBe(1);
+    expect(m.pages_per_session).toBe(4);
+    expect(m.views_per_visitor).toBe(0);
+    expect(m.bounce_rate).toBe(0);
+    expect(m.avg_session_duration).toBe(0);
+  });
+
+  it("counts numeric-string pageviews", () => {
+    const m = computeSessionMetrics([{ pageviews: "5" as any }]);
+    expect(m.pages_per_session).toBe(5);
+    expect(m.total_sessions).toBe(1);
+  });
+
+  it("ignores negative pageviews", () => {
+    const m = computeSessionMetrics([{ pageviews: -3 }, { pageviews: 6 }]);
+    expect(m.pages_per_session).toBe(3);
+    expect(m.total_sessions).toBe(2);
+  });
+
+  it("ignores negative durations and counts numeric-string durations", () => {
+    const m = computeSessionMetrics([
+      { duration_seconds: -50 },
+      { duration_seconds: "60" as any },
+      { duration_seconds: 90 },
+    ]);
+    expect(m.avg_session_duration).toBe(75);
+  });
+
+  it("only counts is_bounce strictly equal to true (not truthy 1 or string)", () => {
+    const m = computeSessionMetrics([
+      { is_bounce: 1 as any },
+      { is_bounce: "true" as any },
+      { is_bounce: true },
+    ]);
+    expect(m.bounce_rate).toBe(0.3333);
+    expect(m.total_sessions).toBe(3);
+  });
+
+  it("dedupes visitor ids after String() coercion", () => {
+    const m = computeSessionMetrics([
+      { visitor_id: 123 as any, pageviews: 2 },
+      { visitor_id: "123", pageviews: 2 },
+    ]);
+    expect(m.views_per_visitor).toBe(4);
+    expect(m.total_sessions).toBe(2);
+  });
+
+  it("rounds bounce_rate to 4 decimal places", () => {
+    const rows = [
+      { is_bounce: true },
+      { is_bounce: true },
+      { is_bounce: false },
+      { is_bounce: false },
+      { is_bounce: false },
+      { is_bounce: false },
+      { is_bounce: false },
+    ];
+    const m = computeSessionMetrics(rows);
+    expect(m.bounce_rate).toBe(0.2857);
+    expect(m.total_sessions).toBe(7);
+  });
+
+  it("treats non-numeric-string pageviews as zero", () => {
+    const m = computeSessionMetrics([{ pageviews: "abc" as any }, { pageviews: 3 }]);
+    expect(m.pages_per_session).toBe(1.5);
+    expect(m.total_sessions).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
Edge-case unit coverage for two pure analytics digest helpers — a #594 delegation-test data point (free-model drafter authoring mechanical specs, human-verified).

- **Chunk 1** — `computeSessionMetrics` edge coverage (`session-metrics-lib.edge.unit.spec.ts`).
- **Chunk 2** — `formatDuration` edge coverage (`partner-digest-email-lib.edge.unit.spec.ts`): negative/NaN/non-numeric clamp → `0s`, sub-minute rounding, the 60s minute-boundary crossing (`59.6 → 1m`), exact-minute (no seconds), and durations ≥ 1h rendered as minutes only.

## #594 delegation outcome
Both specs were FIRST-DRAFTED by the free-model drafter (`scripts/agent-daemon/delegate.mjs`, deepseek-v4-flash-free) from a fully-specified prompt with authoritative expected outputs, then verified by the owner.
- Chunk 2 (`formatDuration`): drafter draft **KEPT AS-IS** — single correct import, jest globals, 5 grouped `it` blocks covering all 14 specified mappings. Typecheck zero-new-errors; 5/5 pass.

## Verify
```
cd apps/backend && TEST_TYPE=unit NODE_OPTIONS="--experimental-vm-modules" npx jest --testPathPattern="partner-digest-email-lib.edge.unit.spec"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)