### PR TITLE
fix(ai): system prompt compat for Cloudflare/OpenAI-compatible providers

### DIFF
--- a/apps/backend/src/mastra/services/__tests__/ai-platforms-generate-args.unit.spec.ts
+++ b/apps/backend/src/mastra/services/__tests__/ai-platforms-generate-args.unit.spec.ts
@@ -1,0 +1,37 @@
+import { buildGenerateArgs } from "../ai-platforms"
+
+describe("buildGenerateArgs", () => {
+  it("keeps the native system param for openrouter", () => {
+    const a = buildGenerateArgs({ providerType: "openrouter" }, "be terse", "hi")
+    expect(a).toEqual({ system: "be terse", messages: [{ role: "user", content: "hi" }] })
+  })
+
+  it("omits the system key for openrouter when system is empty/whitespace", () => {
+    expect(buildGenerateArgs({ providerType: "openrouter" }, "", "hi")).toEqual({
+      messages: [{ role: "user", content: "hi" }],
+    })
+    expect(buildGenerateArgs({ providerType: "openrouter" }, "   ", "hi")).toEqual({
+      messages: [{ role: "user", content: "hi" }],
+    })
+  })
+
+  it("folds system into the user message for OpenAI-compatible providers (no system key)", () => {
+    for (const providerType of ["cloudflare", "dashscope", "vercel_ai_gateway", "custom"] as const) {
+      expect(buildGenerateArgs({ providerType }, "be terse", "hi")).toEqual({
+        messages: [{ role: "user", content: "be terse\n\nhi" }],
+      })
+    }
+  })
+
+  it("sends only the prompt when there is no system text (compat path)", () => {
+    expect(buildGenerateArgs({ providerType: "cloudflare" }, undefined, "hi")).toEqual({
+      messages: [{ role: "user", content: "hi" }],
+    })
+  })
+
+  it("never emits a system-role message for the compat path (the live minimax failure)", () => {
+    const a = buildGenerateArgs({ providerType: "cloudflare" }, "sys", "user")
+    expect("system" in a).toBe(false)
+    expect(a.messages.every((m) => m.role === "user")).toBe(true)
+  })
+})

--- a/apps/backend/src/mastra/services/ai-platforms.ts
+++ b/apps/backend/src/mastra/services/ai-platforms.ts
@@ -275,6 +275,30 @@ export const buildChatModel = (
 }
 
 /**
+ * Build the `generateText` arguments for a system + user prompt, in a shape the
+ * given provider accepts.
+ *
+ * OpenRouter handles the AI-SDK `system` param natively. But OpenAI-compatible
+ * endpoints (Cloudflare/DashScope/Vercel-AI-Gateway/custom) reject the role the
+ * SDK emits for the system message — verified live against a Cloudflare minimax
+ * platform: `Invalid value at messages[0].role: expected one of system|user|
+ * assistant|tool`. Folding the system text into the single user message is
+ * accepted everywhere, so we do that for the non-openrouter path. Pure.
+ */
+export const buildGenerateArgs = (
+  config: Pick<AiPlatformConfig, "providerType">,
+  system: string | undefined,
+  prompt: string
+): { system?: string; messages: Array<{ role: "user"; content: string }> } => {
+  const sys = (system || "").trim()
+  if (config.providerType === "openrouter") {
+    return { ...(sys ? { system: sys } : {}), messages: [{ role: "user", content: prompt }] }
+  }
+  const content = sys ? `${sys}\n\n${prompt}` : prompt
+  return { messages: [{ role: "user", content }] }
+}
+
+/**
  * Build an AI SDK embedding model from a resolved platform config. The
  * caller is responsible for the dimension lock-in (see productCatalog
  * docstring).

--- a/apps/backend/src/modules/visual_flows/operations/ai-extract-platform.ts
+++ b/apps/backend/src/modules/visual_flows/operations/ai-extract-platform.ts
@@ -5,6 +5,7 @@ import { interpolateString } from "./utils"
 import {
   getAiPlatformForRole,
   buildChatModel,
+  buildGenerateArgs,
 } from "../../../mastra/services/ai-platforms"
 
 interface SchemaField {
@@ -165,8 +166,7 @@ export const aiExtractPlatformOperation: OperationDefinition = {
 
       const result = await generateText({
         model: model as any,
-        messages: [{ role: "user", content: input }],
-        ...(systemPrompt ? { system: systemPrompt } : {}),
+        ...buildGenerateArgs(config, systemPrompt, input),
       })
 
       const object = extractJson(result.text)

--- a/apps/backend/src/modules/visual_flows/operations/partner-analytics-digest.ts
+++ b/apps/backend/src/modules/visual_flows/operations/partner-analytics-digest.ts
@@ -11,6 +11,7 @@ import {
 import {
   getAiPlatformForRole,
   buildChatModel,
+  buildGenerateArgs,
 } from "../../../mastra/services/ai-platforms"
 import {
   getPartnerStorefrontDigestWorkflow,
@@ -306,8 +307,7 @@ export const partnerAnalyticsDigestOperation: OperationDefinition = {
             const chatModel = buildChatModel(aiPlatform, modelOverride)
             const result = await generateText({
               model: chatModel as any,
-              system,
-              messages: [{ role: "user", content: prompt }],
+              ...buildGenerateArgs(aiPlatform, system, prompt),
             })
             return result.text ?? ""
           }


### PR DESCRIPTION
Follow-up to the live CF platform test (#589 item 4). The AI-SDK `system` message uses a role minimax/Cloudflare's OpenAI-compatible endpoint rejects (`Invalid value at messages[0].role`). New pure `buildGenerateArgs()` keeps the native `system` param for openrouter and folds system→user for the compat path. Wired into `ai_extract_platform` + the digest AI generator. 5 unit tests; typecheck clean.

Verified live: with system removed, the same CF request was accepted (next error was the gateway's own 'insufficient balance' — account-side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)