### PR TITLE
fix(#558): raise analytics Filters popover above RouteFocusModal

### DIFF
--- a/apps/backend/src/admin/components/websites/website-analytics-modal.tsx
+++ b/apps/backend/src/admin/components/websites/website-analytics-modal.tsx
@@ -122,7 +122,7 @@ function FiltersPopover({
           sideOffset={8}
           collisionPadding={16}
           className={clx(
-            "bg-ui-bg-base shadow-elevation-flyout rounded-lg outline-none z-50",
+            "bg-ui-bg-base shadow-elevation-flyout rounded-lg outline-none z-[1000]",
             "w-72 flex flex-col"
           )}
         >


### PR DESCRIPTION
## #558 — analytics Filters popover renders behind the modal

The Filters `Popover.Content` in `website-analytics-modal.tsx` used `z-50`, which rendered **behind** the `RouteFocusModal`. Medusa's `FocusModal` overlay/content carry no explicit z-index (they rely on portal DOM order), so a same-portal popover at `z-50` could end up below the modal layer.

### Fix
Single-line change: `z-50` → `z-[1000]` on the `Popover.Content` className (~line 125).

### Verification (Playwright, live dev `:9000/app`)
- Opened `/app/websites/:id/analytics` (RouteFocusModal) → clicked **Filters**.
- Popover "Date Range" visible, hit-test confirms the popover content is the **topmost** element at its center (`topElContainedInPopover: true`, `z-[1000]`).
- Screenshot: Date Range / Advanced Filters / Apply all render above the analytics modal.

No merge — human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)