### PR TITLE
fix(#501): server-side /admin/exchange-rates proxy to fix Rate Fetching Failed (CORS)

### DIFF
--- a/apps/backend/src/admin/hooks/api/use-create-product-from-media.ts
+++ b/apps/backend/src/admin/hooks/api/use-create-product-from-media.ts
@@ -63,14 +63,15 @@ export const useExchangeRates = (
     queryKey: ["exchange-rates", baseCurrency, targets.sort().join(",")],
     queryFn: async () => {
       const base = baseCurrency!.toUpperCase()
-      const url =
-        targets.length > 0
-          ? `https://api.frankfurter.app/latest?from=${base}&to=${targets.map((c) => c.toUpperCase()).join(",")}`
-          : `https://api.frankfurter.app/latest?from=${base}`
-
-      const res = await fetch(url)
-      if (!res.ok) throw new Error("Failed to fetch exchange rates")
-      const data = await res.json()
+      // Server-side proxy (#501) — the browser blocks a direct api.frankfurter.app
+      // call as a cross-origin request ("Rate Fetching Failed").
+      const qs = new URLSearchParams({ from: base })
+      if (targets.length > 0) {
+        qs.set("to", targets.map((c) => c.toUpperCase()).join(","))
+      }
+      const data = await sdk.client.fetch<{ base: string; rates: Record<string, number> }>(
+        `/admin/exchange-rates?${qs.toString()}`
+      )
       return { base: data.base, rates: data.rates ?? {} } as ExchangeRates
     },
     enabled: !!baseCurrency && targetCurrencies.length > 1,
@@ -174,13 +175,12 @@ export const useCreateProductFromMedia = () => {
           try {
             const base = defaultCurrency.toUpperCase()
             const targets = otherCurrencies.map((c) => c.toUpperCase()).join(",")
-            const res = await fetch(
-              `https://api.frankfurter.app/latest?from=${base}&to=${targets}`
+            // Server-side proxy (#501) — avoids the browser CORS block on
+            // api.frankfurter.app.
+            const data = await sdk.client.fetch<{ base: string; rates: Record<string, number> }>(
+              `/admin/exchange-rates?from=${base}&to=${targets}`
             )
-            if (res.ok) {
-              const data = await res.json()
-              rates = data.rates ?? {}
-            }
+            rates = data.rates ?? {}
           } catch {
             // Network failure — fall back to same amount for all currencies
           }

--- a/apps/backend/src/api/admin/exchange-rates/__tests__/parse.unit.spec.ts
+++ b/apps/backend/src/api/admin/exchange-rates/__tests__/parse.unit.spec.ts
@@ -1,0 +1,57 @@
+import { parseTargetCurrencies, buildRatesResponse } from "../parse"
+
+describe("exchange-rates parse helpers", () => {
+  describe("parseTargetCurrencies", () => {
+    it("splits, trims, upper-cases and de-dupes", () => {
+      expect(parseTargetCurrencies("eur, usd ,gbp", "INR")).toEqual([
+        "EUR",
+        "USD",
+        "GBP",
+      ])
+    })
+
+    it("excludes the base currency (case-insensitive)", () => {
+      expect(parseTargetCurrencies("inr,eur", "INR")).toEqual(["EUR"])
+      expect(parseTargetCurrencies("Inr,Eur", "inr")).toEqual(["EUR"])
+    })
+
+    it("drops duplicates", () => {
+      expect(parseTargetCurrencies("eur,EUR,usd,usd", "INR")).toEqual([
+        "EUR",
+        "USD",
+      ])
+    })
+
+    it("returns [] for empty/undefined input", () => {
+      expect(parseTargetCurrencies(undefined, "INR")).toEqual([])
+      expect(parseTargetCurrencies("", "INR")).toEqual([])
+      expect(parseTargetCurrencies(" , ,", "INR")).toEqual([])
+    })
+  })
+
+  describe("buildRatesResponse", () => {
+    it("upper-cases base and keeps finite numeric rates", () => {
+      expect(
+        buildRatesResponse("inr", [
+          ["eur", 0.011],
+          ["usd", 0.012],
+        ])
+      ).toEqual({ base: "INR", rates: { EUR: 0.011, USD: 0.012 } })
+    })
+
+    it("omits null / undefined / non-finite rates", () => {
+      expect(
+        buildRatesResponse("INR", [
+          ["eur", null],
+          ["usd", undefined],
+          ["gbp", NaN],
+          ["aud", 0.018],
+        ])
+      ).toEqual({ base: "INR", rates: { AUD: 0.018 } })
+    })
+
+    it("returns an empty rates map for no pairs", () => {
+      expect(buildRatesResponse("INR", [])).toEqual({ base: "INR", rates: {} })
+    })
+  })
+})

--- a/apps/backend/src/api/admin/exchange-rates/parse.ts
+++ b/apps/backend/src/api/admin/exchange-rates/parse.ts
@@ -1,0 +1,41 @@
+/**
+ * Pure helpers for the GET /admin/exchange-rates proxy route.
+ * Kept side-effect-free so they can be unit tested without the network.
+ */
+
+/**
+ * Parse a comma-separated `to` query param into a de-duplicated, upper-cased
+ * list of currency codes, excluding the base currency and any blanks.
+ */
+export function parseTargetCurrencies(
+  toRaw: string | undefined,
+  base: string
+): string[] {
+  const baseUpper = (base || "").toUpperCase()
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const part of String(toRaw || "").split(",")) {
+    const code = part.trim().toUpperCase()
+    if (!code || code === baseUpper || seen.has(code)) continue
+    seen.add(code)
+    out.push(code)
+  }
+  return out
+}
+
+/**
+ * Build the { base, rates } response payload from a list of resolved
+ * [currency, rate] pairs (rates that failed to resolve are simply omitted).
+ */
+export function buildRatesResponse(
+  base: string,
+  pairs: Array<[string, number | null | undefined]>
+): { base: string; rates: Record<string, number> } {
+  const rates: Record<string, number> = {}
+  for (const [code, rate] of pairs) {
+    if (typeof rate === "number" && Number.isFinite(rate)) {
+      rates[code.toUpperCase()] = rate
+    }
+  }
+  return { base: base.toUpperCase(), rates }
+}

--- a/apps/backend/src/api/admin/exchange-rates/route.ts
+++ b/apps/backend/src/api/admin/exchange-rates/route.ts
@@ -1,0 +1,45 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { fetchExchangeRate } from "../../../workflows/designs/create-draft-order-from-designs"
+import { parseTargetCurrencies, buildRatesResponse } from "./parse"
+
+/**
+ * GET /admin/exchange-rates?from=INR&to=EUR,USD
+ *
+ * Server-side proxy for the Frankfurter API (ECB data). The admin UI must not
+ * call api.frankfurter.app directly — the browser blocks it as a cross-origin
+ * request ("Rate Fetching Failed", #501). This route fetches the rates on the
+ * server (re-using the in-memory 1h cache in `fetchExchangeRate`) and returns a
+ * `{ base, rates }` payload in the same shape the Frankfurter `/latest` endpoint
+ * uses, so the admin hooks can swap a raw fetch() for sdk.client.fetch().
+ *
+ * Rates that fail to resolve for an individual target are omitted from `rates`
+ * (the caller then falls back to a 1:1 amount), so a single bad currency never
+ * fails the whole request.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const from = String(req.query.from || "").toUpperCase()
+
+  if (!from) {
+    return res.status(400).json({
+      error: "Missing required query param: from",
+    })
+  }
+
+  const targets = parseTargetCurrencies(req.query.to as string | undefined, from)
+
+  if (targets.length === 0) {
+    return res.json(buildRatesResponse(from, []))
+  }
+
+  const pairs = await Promise.all(
+    targets.map(async (to): Promise<[string, number | null]> => {
+      try {
+        return [to, await fetchExchangeRate(from, to)]
+      } catch {
+        return [to, null]
+      }
+    })
+  )
+
+  return res.json(buildRatesResponse(from, pairs))
+}


### PR DESCRIPTION
## #501 — "Rate Fetching Failed"

Root cause: a **browser CORS error**. The admin currency-conversion hooks fetched `https://api.frankfurter.app/latest` **directly from the browser**, which the browser blocks cross-origin (verified: a direct fetch from the admin throws `TypeError: Failed to fetch`).

### Fix
- New same-origin admin route `GET /admin/exchange-rates?from=INR&to=EUR,USD` (`src/api/admin/exchange-rates/route.ts`) — fetches rates **server-side**, re-using the cached `fetchExchangeRate`, returns `{ base, rates }`. Individual unresolved targets are omitted (never fails the whole request).
- Pointed the two raw `fetch()` call sites in `use-create-product-from-media.ts` (`useExchangeRates` + the inline conversion) at `sdk.client.fetch` of the new route.
- Pure helpers `parseTargetCurrencies` / `buildRatesResponse` + **7 unit tests**.

### Verification
- Unit: 7/7 pass.
- Live route (curl): `?from=INR&to=EUR,USD,GBP` → `{base, rates:{EUR,USD,GBP}}`; missing `from` → 400; no targets → `{rates:{}}`.
- Playwright (live `:9000/app`, logged in): the admin **browser** fetches `/admin/exchange-rates?from=INR&to=EUR,USD` → 200 with both rates; the **direct** `frankfurter.app` call from the same browser fails with CORS — confirming both the root cause and the fix.

Note: a singular `GET /admin/exchange-rate` (single `{from,to,rate}`) already existed for the draft-order flow; this adds the plural `{base,rates}` multi-target shape the product-from-media hooks need.

No merge — human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)