### PR TITLE
feat(#568): Goals create modal + fix edit drawer crash + fix custom-goal subscriber

### DIFF
--- a/apps/backend/src/admin/routes/ad-planning/goals/[id]/@edit/page.tsx
+++ b/apps/backend/src/admin/routes/ad-planning/goals/[id]/@edit/page.tsx
@@ -11,7 +11,6 @@ import {
 
 export default function GoalEditDrawerPage() {
   const { id } = useParams<{ id: string }>()
-  const { handleSuccess } = useRouteModal()
 
   const { data, isLoading } = useQuery({
     queryKey: ["ad-planning", "goals", id, "edit"],
@@ -39,15 +38,39 @@ export default function GoalEditDrawerPage() {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <Heading>Edit goal</Heading>
+        <RouteDrawer.Title asChild>
+          <Heading>Edit goal</Heading>
+        </RouteDrawer.Title>
+        <RouteDrawer.Description className="sr-only">
+          Edit conversion goal
+        </RouteDrawer.Description>
       </RouteDrawer.Header>
-      <GoalForm
-        initial={initial}
-        goalId={id}
-        mode="edit"
-        onCancel={() => handleSuccess()}
-        onSuccess={() => handleSuccess()}
-      />
+      <EditGoalBody initial={initial} goalId={id} />
     </RouteDrawer>
+  )
+}
+
+/**
+ * Rendered INSIDE <RouteDrawer> so it sits within the RouteModalProvider that
+ * RouteDrawer mounts. Calling useRouteModal() in the page component (a parent
+ * of RouteDrawer) threw "useRouteModal must be used within a RouteModalProvider"
+ * and crashed the whole edit drawer (#568).
+ */
+function EditGoalBody({
+  initial,
+  goalId,
+}: {
+  initial: Partial<GoalFormValues>
+  goalId?: string
+}) {
+  const { handleSuccess } = useRouteModal()
+  return (
+    <GoalForm
+      initial={initial}
+      goalId={goalId}
+      mode="edit"
+      onCancel={() => handleSuccess()}
+      onSuccess={() => handleSuccess()}
+    />
   )
 }

--- a/apps/backend/src/admin/routes/ad-planning/goals/create/page.tsx
+++ b/apps/backend/src/admin/routes/ad-planning/goals/create/page.tsx
@@ -1,27 +1,36 @@
-import { Container, Heading, Text } from "@medusajs/ui"
-import { useNavigate, UIMatch } from "react-router-dom"
+import { Heading, Text } from "@medusajs/ui"
+import { useNavigate } from "react-router-dom"
+import { RouteFocusModal } from "../../../../components/modal/route-focus-modal"
 import { GoalForm } from "../../../../components/ad-planning/goals/goal-form"
 
 export default function CreateGoalPage() {
   const navigate = useNavigate()
 
   return (
-    <Container className="p-0 divide-y">
-      <div className="px-6 py-4">
-        <Heading level="h2">Create goal</Heading>
-        <Text size="small" className="text-ui-fg-subtle mt-1">
-          Define a new conversion goal. After creation you can wire its
-          Google Ads mapping from the detail page.
-        </Text>
-      </div>
+    <RouteFocusModal prev="/ad-planning/goals">
+      <RouteFocusModal.Header>
+        <div className="flex flex-col">
+          <RouteFocusModal.Title asChild>
+            <Heading>Create goal</Heading>
+          </RouteFocusModal.Title>
+          <RouteFocusModal.Description asChild>
+            <Text size="small" className="text-ui-fg-subtle">
+              Define a new conversion goal. After creation you can wire its
+              Google Ads mapping from the detail page.
+            </Text>
+          </RouteFocusModal.Description>
+        </div>
+      </RouteFocusModal.Header>
       <GoalForm
         mode="create"
+        bodyClassName="flex flex-1 flex-col gap-y-5 overflow-y-auto px-6 py-6 mx-auto w-full max-w-2xl"
+        footerClassName="px-6 py-3 border-t border-ui-border-base"
         onCancel={() => navigate("/ad-planning/goals")}
         onSuccess={(goalId) =>
           navigate(`/ad-planning/goals/${goalId}`, { replace: true })
         }
       />
-    </Container>
+    </RouteFocusModal>
   )
 }
 

--- a/apps/backend/src/subscribers/ad-planning/__tests__/match-custom-goal.unit.spec.ts
+++ b/apps/backend/src/subscribers/ad-planning/__tests__/match-custom-goal.unit.spec.ts
@@ -1,0 +1,38 @@
+import { findMatchingCustomGoal } from "../match-custom-goal"
+
+describe("findMatchingCustomGoal (#568)", () => {
+  const goals = [
+    { id: "g1", conditions: { event_name: "Checkout_Complete" } },
+    { id: "g2", conditions: { event_name: "newsletter_signup" } },
+    { id: "g3", conditions: {} },
+    { id: "g4", conditions: null },
+  ]
+
+  it("matches on conditions.event_name (case-insensitive)", () => {
+    expect(findMatchingCustomGoal(goals, "checkout_complete")?.id).toBe("g1")
+    expect(findMatchingCustomGoal(goals, "CHECKOUT_COMPLETE")?.id).toBe("g1")
+    expect(findMatchingCustomGoal(goals, "newsletter_signup")?.id).toBe("g2")
+  })
+
+  it("returns undefined when no goal matches", () => {
+    expect(findMatchingCustomGoal(goals, "unknown_event")).toBeUndefined()
+  })
+
+  it("returns undefined for empty / nullish event names", () => {
+    expect(findMatchingCustomGoal(goals, "")).toBeUndefined()
+    expect(findMatchingCustomGoal(goals, "   ")).toBeUndefined()
+    expect(findMatchingCustomGoal(goals, undefined)).toBeUndefined()
+    expect(findMatchingCustomGoal(goals, null)).toBeUndefined()
+  })
+
+  it("ignores goals without a conditions.event_name", () => {
+    expect(findMatchingCustomGoal([{ id: "x", conditions: {} }], "anything")).toBeUndefined()
+    expect(findMatchingCustomGoal([{ id: "y", conditions: null }], "anything")).toBeUndefined()
+  })
+
+  it("does NOT read a legacy trigger_event_name field (the #568 bug)", () => {
+    // Goals that only had the (non-existent) trigger_event_name must never match.
+    const legacy = [{ id: "z", trigger_event_name: "purchase", conditions: {} }]
+    expect(findMatchingCustomGoal(legacy as any, "purchase")).toBeUndefined()
+  })
+})

--- a/apps/backend/src/subscribers/ad-planning/analytics-event-created.ts
+++ b/apps/backend/src/subscribers/ad-planning/analytics-event-created.ts
@@ -8,6 +8,7 @@ import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework";
 import { AD_PLANNING_MODULE } from "../../modules/ad-planning";
 import { trackConversionWorkflow } from "../../workflows/ad-planning/conversions/track-conversion";
 import { resolveSessionAttributionWorkflow } from "../../workflows/ad-planning/attribution/resolve-session-attribution";
+import { findMatchingCustomGoal } from "./match-custom-goal";
 
 type AnalyticsEventCreatedEvent = {
   id: string;
@@ -57,15 +58,16 @@ export default async function analyticsEventCreatedHandler({
       // Check if there's a custom conversion goal for this event
       const adPlanningService = container.resolve(AD_PLANNING_MODULE);
 
+      // #568: the goal_type enum value is "custom_event" (not "custom"), and
+      // the matched event name is stored in conditions.event_name — the model
+      // has no trigger_event_name column. Both bugs made this branch dead, so a
+      // custom_event goal never matched an incoming analytics event.
       const customGoals = await adPlanningService.listConversionGoals({
-        goal_type: "custom",
+        goal_type: "custom_event",
         is_active: true,
       });
 
-      const matchingGoal = customGoals.find((goal: any) => {
-        const goalEventName = goal.trigger_event_name?.toLowerCase();
-        return goalEventName === eventName;
-      });
+      const matchingGoal = findMatchingCustomGoal(customGoals, eventName);
 
       if (!matchingGoal) {
         // No matching conversion type or goal

--- a/apps/backend/src/subscribers/ad-planning/match-custom-goal.ts
+++ b/apps/backend/src/subscribers/ad-planning/match-custom-goal.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure matcher for the analytics_event.created → custom-goal branch.
+ *
+ * Extracted from the subscriber so the matching contract is unit-testable
+ * (and so the #568 regression — querying goal_type "custom" and reading a
+ * non-existent `trigger_event_name` column — can never silently come back).
+ *
+ * A custom goal matches when its `conditions.event_name` equals the incoming
+ * analytics event name (case-insensitive). The event name lives in the
+ * `conditions` JSON; the ConversionGoal model has no `trigger_event_name`
+ * column.
+ */
+export type CustomGoalLike = {
+  conditions?: { event_name?: string | null } | null
+  [key: string]: any
+}
+
+export function findMatchingCustomGoal<T extends CustomGoalLike>(
+  goals: T[],
+  eventName: string | null | undefined
+): T | undefined {
+  const target = (eventName || "").trim().toLowerCase()
+  if (!target) return undefined
+
+  return goals.find((goal) => {
+    const goalEventName = goal?.conditions?.event_name
+      ?.toString()
+      .trim()
+      .toLowerCase()
+    return !!goalEventName && goalEventName === target
+  })
+}


### PR DESCRIPTION
## #568 — Ad-planning Goals

Three fixes (see `apps/docs/notes/568_AD_PLANNING_MODULE_ANALYSIS.md`):

### (a) Create goal → RouteFocusModal
`Create goal` was a full-page `<Link to="/ad-planning/goals/create">` rendering a plain `Container`. Converted `goals/create/page.tsx` to a **`RouteFocusModal`** (`prev=/ad-planning/goals`), consistent with the `@edit` drawer. The shared `GoalForm` is reused as-is (it already accepts `onCancel`/`onSuccess` + `body/footerClassName`). Added accessible `RouteFocusModal.Title`/`Description`.

### (b) Per-goal Edit was crashing
Root cause (found via Playwright console): `@edit/page.tsx` called `useRouteModal()` at the **page level**, i.e. **outside** `<RouteDrawer>` — but `RouteDrawer` is what mounts the `RouteModalProvider`. Every edit threw:

> Error: useRouteModal must be used within a RouteModalProvider

…and React Router rendered the error boundary instead of the drawer. Fixed by moving `useRouteModal()` into an inner `EditGoalBody` rendered **inside** `<RouteDrawer>` (the canonical Medusa pattern). Added `RouteDrawer.Title` for a11y.

The backend `PUT /admin/ad-planning/goals/:id` was verified working all along (name/active/priority persist) — the break was purely client-side.

### (c) Latent subscriber bug — custom-goal branch was dead
`subscribers/ad-planning/analytics-event-created.ts` looked up custom goals with `goal_type: "custom"` (the enum value is **`custom_event`**) and matched on `goal.trigger_event_name` — **a column the `ConversionGoal` model doesn't have**. The event name is stored in `conditions.event_name` (where the create/update form writes it). Both bugs meant a custom_event goal **never** matched an incoming analytics event.

Decision: **read from `conditions.event_name`** (no migration — the data already lives there). Extracted the matcher into a pure `findMatchingCustomGoal` helper + **5 unit tests**, including a regression test asserting the legacy `trigger_event_name` field is never read.

## Verification
- Unit: 5/5 (`match-custom-goal`).
- Typecheck: 0 new errors on all changed files.
- **Playwright (live `:9000/app`, logged in):**
  - Create → opens as a focus-modal overlay (`role=dialog`), heading visible; on submit navigates to the new goal's detail page.
  - Edit → drawer opens populated, Save persists, edited name shows on detail. **0 `useRouteModal` crashes, 0 console errors.**

No merge — human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)