### PR TITLE
feat(#449): per-partner storefront recovery URLs for abandoned carts

### DIFF
--- a/apps/backend/src/modules/visual_flows/operations/__tests__/resolve-cart-recovery-urls.unit.spec.ts
+++ b/apps/backend/src/modules/visual_flows/operations/__tests__/resolve-cart-recovery-urls.unit.spec.ts
@@ -1,0 +1,244 @@
+/**
+ * Unit tests for the visual-flows `resolve_cart_recovery_urls` operation (#449).
+ *
+ * The regression this guards: the "Cart Recovery — Hourly Discoverer" flow
+ * built every recovery link from a single global `STORE_URL`, so a cart on
+ * partner A's sales channel got a checkout link on the root/another store. This
+ * op resolves each cart's owning partner storefront from its `sales_channel_id`
+ * and falls back to the configured base when a cart isn't tied to a partner —
+ * so it's never worse than the old behaviour.
+ *
+ * The operation only reads `context.container` (the QUERY service) +
+ * `context.dataChain`, so we can invoke it directly without booting Medusa.
+ */
+
+import {
+  resolveCartRecoveryUrlsOperation,
+  buildRecoveryUrls,
+  summarizeRecoveryUrlRun,
+  type EnrichedCart,
+} from "../resolve-cart-recovery-urls"
+
+/**
+ * Fake QUERY whose `graph` mirrors the two hops in
+ * resolvePartnerStorefrontForSalesChannel: stores filtered by
+ * default_sales_channel_id, then all partners (matched in JS by the resolver).
+ */
+function makeQuery(opts: {
+  stores: Array<{ id: string; default_sales_channel_id: string }>
+  partners: Array<{
+    id: string
+    name?: string | null
+    handle?: string | null
+    storefront_domain?: string | null
+    metadata?: Record<string, any> | null
+    stores: Array<{ id: string }>
+  }>
+}): any {
+  return {
+    graph: async ({ entity, filters }: any) => {
+      if (entity === "stores") {
+        const wanted: string[] = filters?.default_sales_channel_id ?? []
+        return {
+          data: opts.stores.filter((s) =>
+            wanted.includes(s.default_sales_channel_id)
+          ),
+        }
+      }
+      if (entity === "partners") {
+        return { data: opts.partners }
+      }
+      return { data: [] }
+    },
+  }
+}
+
+function makeContext(dataChain: Record<string, any>, query: any): any {
+  return {
+    container: {
+      resolve: (name: string) => (name === "query" ? query : null),
+    } as any,
+    dataChain: {
+      $trigger: { payload: {}, timestamp: "2026-06-17T00:00:00.000Z" },
+      $accountability: {},
+      $env: {},
+      $last: null,
+      ...dataChain,
+    },
+    flowId: "flow_test",
+    executionId: "exec_test",
+    operationId: "op_test",
+    operationKey: "resolve_urls",
+  }
+}
+
+describe("buildRecoveryUrls (pure)", () => {
+  it("substitutes {id} and trims trailing slashes on the base", () => {
+    expect(buildRecoveryUrls("https://acme.com/", "cart_1")).toEqual({
+      cart_url: "https://acme.com/checkout/cart/cart_1",
+      unsubscribe_url: "https://acme.com/unsubscribe?cart_id=cart_1",
+    })
+  })
+
+  it("honours custom path templates", () => {
+    expect(
+      buildRecoveryUrls("https://x.io", "c9", {
+        cartPath: "/recover/{id}",
+        unsubscribePath: "/stop/{id}",
+      })
+    ).toEqual({
+      cart_url: "https://x.io/recover/c9",
+      unsubscribe_url: "https://x.io/stop/c9",
+    })
+  })
+
+  it("tolerates an empty base", () => {
+    const { cart_url } = buildRecoveryUrls("", "c1")
+    expect(cart_url).toBe("/checkout/cart/c1")
+  })
+})
+
+describe("summarizeRecoveryUrlRun (pure)", () => {
+  it("counts resolved vs fallback carts", () => {
+    const enriched = [
+      { partner_storefront_resolved: true },
+      { partner_storefront_resolved: false },
+      { partner_storefront_resolved: true },
+    ] as EnrichedCart[]
+    expect(summarizeRecoveryUrlRun(enriched)).toEqual({
+      count: 3,
+      with_partner_storefront: 2,
+      fallback_count: 1,
+    })
+  })
+})
+
+describe("resolve_cart_recovery_urls operation", () => {
+  const QUERY = makeQuery({
+    stores: [{ id: "store_A", default_sales_channel_id: "sc_A" }],
+    partners: [
+      {
+        id: "partner_A",
+        name: "Acme",
+        handle: "acme",
+        storefront_domain: "acme.cicilabel.com",
+        metadata: { custom_domain: "shop.acme.com" },
+        stores: [{ id: "store_A" }],
+      },
+    ],
+  })
+
+  it("points each cart at its owning partner storefront (custom_domain wins)", async () => {
+    const result = await resolveCartRecoveryUrlsOperation.execute(
+      { carts: "{{ discoverer.carts }}", fallback_base: "https://cicilabel.com" },
+      makeContext(
+        { discoverer: { carts: [{ id: "cart_1", sales_channel_id: "sc_A" }] } },
+        QUERY
+      )
+    )
+
+    expect(result.success).toBe(true)
+    const cart = result.data.carts[0]
+    expect(cart.cart_url).toBe("https://shop.acme.com/checkout/cart/cart_1")
+    expect(cart.unsubscribe_url).toBe(
+      "https://shop.acme.com/unsubscribe?cart_id=cart_1"
+    )
+    expect(cart.partner_id).toBe("partner_A")
+    expect(cart.partner_storefront_resolved).toBe(true)
+    expect(result.data.with_partner_storefront).toBe(1)
+    expect(result.data.fallback_count).toBe(0)
+  })
+
+  it("falls back to the configured base when a cart has no partner storefront", async () => {
+    const result = await resolveCartRecoveryUrlsOperation.execute(
+      { carts: "{{ discoverer.carts }}", fallback_base: "https://cicilabel.com" },
+      makeContext(
+        { discoverer: { carts: [{ id: "cart_x", sales_channel_id: "sc_UNKNOWN" }] } },
+        QUERY
+      )
+    )
+
+    expect(result.success).toBe(true)
+    const cart = result.data.carts[0]
+    expect(cart.cart_url).toBe("https://cicilabel.com/checkout/cart/cart_x")
+    expect(cart.partner_id).toBeNull()
+    expect(cart.partner_storefront_resolved).toBe(false)
+    expect(result.data.fallback_count).toBe(1)
+  })
+
+  it("falls back when a cart carries no sales_channel_id at all", async () => {
+    const result = await resolveCartRecoveryUrlsOperation.execute(
+      { carts: "{{ discoverer.carts }}", fallback_base: "https://fallback.io" },
+      makeContext(
+        { discoverer: { carts: [{ id: "cart_n" }] } },
+        QUERY
+      )
+    )
+    const cart = result.data.carts[0]
+    expect(cart.storefront_base).toBe("https://fallback.io")
+    expect(cart.cart_url).toBe("https://fallback.io/checkout/cart/cart_n")
+    expect(cart.partner_storefront_resolved).toBe(false)
+  })
+
+  it("resolves each sales channel at most once across many carts (cache)", async () => {
+    const graph = jest.fn(async ({ entity, filters }: any) => {
+      if (entity === "stores") {
+        const wanted: string[] = filters?.default_sales_channel_id ?? []
+        return {
+          data: [{ id: "store_A", default_sales_channel_id: "sc_A" }].filter(
+            (s) => wanted.includes(s.default_sales_channel_id)
+          ),
+        }
+      }
+      if (entity === "partners") {
+        return {
+          data: [
+            {
+              id: "partner_A",
+              storefront_domain: "acme.cicilabel.com",
+              metadata: {},
+              stores: [{ id: "store_A" }],
+            },
+          ],
+        }
+      }
+      return { data: [] }
+    })
+
+    const result = await resolveCartRecoveryUrlsOperation.execute(
+      { carts: "{{ discoverer.carts }}" },
+      makeContext(
+        {
+          discoverer: {
+            carts: [
+              { id: "c1", sales_channel_id: "sc_A" },
+              { id: "c2", sales_channel_id: "sc_A" },
+              { id: "c3", sales_channel_id: "sc_A" },
+            ],
+          },
+        },
+        { graph }
+      )
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.data.count).toBe(3)
+    expect(result.data.resolved_channels).toBe(1)
+    // 3 carts, 1 unique channel → 2 graph calls (stores + partners), not 6.
+    expect(graph).toHaveBeenCalledTimes(2)
+    // storefront_domain base (no custom/website domain) → normalized https.
+    expect(result.data.carts[0].cart_url).toBe(
+      "https://acme.cicilabel.com/checkout/cart/c1"
+    )
+  })
+
+  it("returns an empty result when `carts` resolves to a non-array", async () => {
+    const result = await resolveCartRecoveryUrlsOperation.execute(
+      { carts: "{{ discoverer.nope }}" },
+      makeContext({ discoverer: {} }, QUERY)
+    )
+    expect(result.success).toBe(true)
+    expect(result.data.count).toBe(0)
+    expect(result.data.carts).toEqual([])
+  })
+})

--- a/apps/backend/src/modules/visual_flows/operations/index.ts
+++ b/apps/backend/src/modules/visual_flows/operations/index.ts
@@ -22,6 +22,7 @@ export { aggregateProductAnalyticsOperation } from "./aggregate-product-analytic
 export { aggregateDataOperation } from "./aggregate-data"
 export { timeSeriesOperation } from "./time-series"
 export { cartRecoveryStatsOperation } from "./cart-recovery-stats"
+export { resolveCartRecoveryUrlsOperation } from "./resolve-cart-recovery-urls"
 export { bulkUpdateDataOperation } from "./bulk-update-data"
 export { bulkCreateDataOperation } from "./bulk-create-data"
 export { bulkHttpRequestOperation } from "./bulk-http-request"
@@ -53,6 +54,7 @@ import { aggregateProductAnalyticsOperation } from "./aggregate-product-analytic
 import { aggregateDataOperation } from "./aggregate-data"
 import { timeSeriesOperation } from "./time-series"
 import { cartRecoveryStatsOperation } from "./cart-recovery-stats"
+import { resolveCartRecoveryUrlsOperation } from "./resolve-cart-recovery-urls"
 import { bulkUpdateDataOperation } from "./bulk-update-data"
 import { bulkCreateDataOperation } from "./bulk-create-data"
 import { bulkHttpRequestOperation } from "./bulk-http-request"
@@ -103,6 +105,7 @@ export function registerBuiltInOperations(): void {
   operationRegistry.register(aggregateDataOperation)
   operationRegistry.register(timeSeriesOperation)
   operationRegistry.register(cartRecoveryStatsOperation)
+  operationRegistry.register(resolveCartRecoveryUrlsOperation)
   operationRegistry.register(partnerAnalyticsDigestOperation)
 }
 

--- a/apps/backend/src/modules/visual_flows/operations/resolve-cart-recovery-urls.ts
+++ b/apps/backend/src/modules/visual_flows/operations/resolve-cart-recovery-urls.ts
@@ -1,0 +1,229 @@
+import { z } from "@medusajs/framework/zod"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { OperationDefinition, OperationContext, OperationResult } from "./types"
+import { interpolateVariables } from "./utils"
+import { resolvePartnerStorefrontForSalesChannel } from "../../../workflows/google_merchant/steps/resolve-partner-landing-base"
+
+/**
+ * Resolve cart-recovery URLs operation (#449).
+ *
+ * The "Cart Recovery — Hourly Discoverer" flow builds the recovery link for
+ * every abandoned cart from a single global `STORE_URL` constant baked into an
+ * `execute_code` node (see `src/scripts/seed-cart-recovery-flow.ts`). On a
+ * multi-storefront platform that's wrong: a cart belonging to partner A's
+ * sales channel gets a checkout link on the root/another store, so the shopper
+ * lands on a storefront that doesn't hold their cart.
+ *
+ * This op enriches an already-discovered list of carts with a recovery link
+ * pointed at the storefront that actually owns each cart, derived from the
+ * cart's `sales_channel_id`:
+ *
+ *   sales_channel → store (default_sales_channel_id) → partner (partner_stores)
+ *
+ * It reuses {@link resolvePartnerStorefrontForSalesChannel} (built for #521's
+ * admin abandoned-cart view) so the resolution rules stay in one place, and
+ * falls back to a configurable base (default `STORE_URL`) whenever a cart isn't
+ * tied to a partner storefront — so behaviour is never *worse* than today.
+ *
+ * Why this isn't doable inside the existing `execute_code` discoverer:
+ *   - resolving the owning partner needs `query.graph` multi-hop joins that the
+ *     sandboxed code node can't safely run, and
+ *   - per-channel resolution should be cached across carts (many carts share a
+ *     channel) rather than re-queried per row.
+ *
+ * Output shape feeds straight back into the email/bulk-trigger step:
+ *   `{ carts: [...enriched], records, count, with_partner_storefront,
+ *      fallback_count, resolved_channels }`
+ * Each enriched cart keeps its original fields plus `cart_url`,
+ * `unsubscribe_url`, `storefront_base`, `partner_id` and
+ * `partner_storefront_resolved`.
+ */
+
+const DEFAULT_CART_PATH = "/checkout/cart/{id}"
+const DEFAULT_UNSUBSCRIBE_PATH = "/unsubscribe?cart_id={id}"
+
+const resolveCartRecoveryUrlsOptionsSchema = z.object({
+  /** Array of cart objects (or a `{{ variable }}` ref resolving to one). */
+  carts: z.union([z.string(), z.array(z.any())]).optional(),
+  /** Field on each cart holding its id. */
+  id_field: z.string().default("id"),
+  /** Field on each cart holding its sales-channel id. */
+  sales_channel_field: z.string().default("sales_channel_id"),
+  /** Path template appended to the base for the checkout link. `{id}` → cart id. */
+  cart_path: z.string().default(DEFAULT_CART_PATH),
+  /** Path template for the unsubscribe link. `{id}` → cart id. */
+  unsubscribe_path: z.string().default(DEFAULT_UNSUBSCRIBE_PATH),
+  /**
+   * Base used when a cart isn't tied to a partner storefront. Defaults to the
+   * `STORE_URL` env (matching the legacy seeded behaviour) then a hard default.
+   */
+  fallback_base: z.string().optional(),
+  /** Cap on carts processed in one run. */
+  max_carts: z.number().int().min(1).max(20_000).default(5_000),
+})
+
+export type EnrichableCart = Record<string, any>
+
+export type EnrichedCart = EnrichableCart & {
+  cart_url: string
+  unsubscribe_url: string
+  storefront_base: string
+  partner_id: string | null
+  partner_storefront_resolved: boolean
+}
+
+/**
+ * Pure: build the recovery + unsubscribe URLs for a cart from a storefront
+ * base and id. The base is trimmed of trailing slashes; `{id}` placeholders in
+ * the path templates are substituted. Exported for unit testing.
+ */
+export function buildRecoveryUrls(
+  base: string,
+  cartId: string,
+  opts?: { cartPath?: string; unsubscribePath?: string }
+): { cart_url: string; unsubscribe_url: string } {
+  const b = String(base ?? "").replace(/\/+$/, "")
+  const cartPath = opts?.cartPath ?? DEFAULT_CART_PATH
+  const unsubscribePath = opts?.unsubscribePath ?? DEFAULT_UNSUBSCRIBE_PATH
+  const sub = (p: string) => p.replace(/\{id\}/g, String(cartId ?? ""))
+  return {
+    cart_url: b + sub(cartPath),
+    unsubscribe_url: b + sub(unsubscribePath),
+  }
+}
+
+/**
+ * Pure: roll up counts over an enriched cart list. Exported for unit testing.
+ */
+export function summarizeRecoveryUrlRun(enriched: EnrichedCart[]): {
+  count: number
+  with_partner_storefront: number
+  fallback_count: number
+} {
+  const count = enriched.length
+  let withPartner = 0
+  for (const c of enriched) {
+    if (c.partner_storefront_resolved) withPartner++
+  }
+  return {
+    count,
+    with_partner_storefront: withPartner,
+    fallback_count: count - withPartner,
+  }
+}
+
+export const resolveCartRecoveryUrlsOperation: OperationDefinition = {
+  type: "resolve_cart_recovery_urls",
+  name: "Resolve Cart Recovery URLs",
+  description:
+    "Enriches abandoned carts with a recovery link pointed at the partner storefront that owns each cart (derived from sales_channel_id), instead of a single global STORE_URL. Falls back to the configured base when a cart isn't tied to a partner store. Feeds the recovery email/bulk-trigger step.",
+  icon: "shopping-cart",
+  category: "data",
+  optionsSchema: resolveCartRecoveryUrlsOptionsSchema,
+
+  defaultOptions: {
+    id_field: "id",
+    sales_channel_field: "sales_channel_id",
+    cart_path: DEFAULT_CART_PATH,
+    unsubscribe_path: DEFAULT_UNSUBSCRIBE_PATH,
+    max_carts: 5_000,
+  },
+
+  execute: async (
+    options: any,
+    context: OperationContext
+  ): Promise<OperationResult> => {
+    try {
+      const parsed = resolveCartRecoveryUrlsOptionsSchema.parse(options ?? {})
+
+      // `carts` is typically a `{{ discoverer.carts }}` reference — interpolate
+      // against the data chain so we get the actual array, not the literal.
+      const resolvedCarts =
+        parsed.carts !== undefined
+          ? interpolateVariables(parsed.carts, context.dataChain)
+          : context.dataChain.$last
+
+      const carts: EnrichableCart[] = Array.isArray(resolvedCarts)
+        ? resolvedCarts.slice(0, parsed.max_carts)
+        : []
+
+      const fallbackBase =
+        parsed.fallback_base ||
+        process.env.STORE_URL ||
+        "https://cicilabel.com"
+
+      const query: any = context.container.resolve(
+        ContainerRegistrationKeys.QUERY
+      )
+
+      // Cache resolution per sales-channel — many carts share a channel, so
+      // we resolve each channel's partner storefront base at most once.
+      const baseByChannel = new Map<string, string | null>()
+      const partnerByChannel = new Map<string, string | null>()
+
+      const enriched: EnrichedCart[] = []
+      for (const cart of carts) {
+        const cartId = String(cart?.[parsed.id_field] ?? "")
+        const channelId = cart?.[parsed.sales_channel_field] as
+          | string
+          | null
+          | undefined
+
+        let partnerBase: string | null = null
+        let partnerId: string | null = null
+        if (channelId) {
+          if (baseByChannel.has(channelId)) {
+            partnerBase = baseByChannel.get(channelId) ?? null
+            partnerId = partnerByChannel.get(channelId) ?? null
+          } else {
+            const owner = await resolvePartnerStorefrontForSalesChannel(
+              query,
+              channelId
+            )
+            partnerBase = owner?.storefront_base ?? null
+            partnerId = owner?.id ?? null
+            baseByChannel.set(channelId, partnerBase)
+            partnerByChannel.set(channelId, partnerId)
+          }
+        }
+
+        const resolved = Boolean(partnerBase)
+        const base = partnerBase || fallbackBase
+        const urls = buildRecoveryUrls(base, cartId, {
+          cartPath: parsed.cart_path,
+          unsubscribePath: parsed.unsubscribe_path,
+        })
+
+        enriched.push({
+          ...cart,
+          cart_url: urls.cart_url,
+          unsubscribe_url: urls.unsubscribe_url,
+          storefront_base: base,
+          partner_id: partnerId,
+          partner_storefront_resolved: resolved,
+        })
+      }
+
+      const summary = summarizeRecoveryUrlRun(enriched)
+
+      return {
+        success: true,
+        data: {
+          carts: enriched,
+          // `records` aliases `carts` so array-output panels work too.
+          records: enriched,
+          count: summary.count,
+          with_partner_storefront: summary.with_partner_storefront,
+          fallback_count: summary.fallback_count,
+          resolved_channels: baseByChannel.size,
+        },
+      }
+    } catch (error: any) {
+      return {
+        success: false,
+        error: error.message,
+        errorStack: error.stack,
+      }
+    }
+  },
+}


### PR DESCRIPTION
## #449 — cart-reminder sends a fixed root-store URL

The **Cart Recovery — Hourly Discoverer** visual flow builds the recovery link for every abandoned cart from a single global `STORE_URL` constant baked into an `execute_code` node (`src/scripts/seed-cart-recovery-flow.ts`). On a multi-storefront platform that's wrong: a cart on partner A's sales channel gets a checkout link on the root/another store, so the shopper lands on a storefront that doesn't hold their cart.

## Fix — a `resolve_cart_recovery_urls` data operation

New visual-flow operation that enriches an already-discovered list of carts with a recovery link pointed at the storefront that **owns** each cart, derived from its `sales_channel_id`:

```
sales_channel → store (default_sales_channel_id) → partner (partner_stores)
```

- Reuses `resolvePartnerStorefrontForSalesChannel` (built for #521's admin abandoned-cart view) so resolution rules live in one place.
- **Caches** resolution per sales channel — many carts share a channel.
- **Falls back** to the configured base (`fallback_base` → `STORE_URL` env → default) whenever a cart isn't tied to a partner store, so behaviour is **never worse** than today.
- Output (`{ carts, records, count, with_partner_storefront, fallback_count, resolved_channels }`) feeds straight back into the recovery email / bulk-trigger step; each cart keeps its fields plus `cart_url`, `unsubscribe_url`, `storefront_base`, `partner_id`, `partner_storefront_resolved`.

## Tests
Pure `buildRecoveryUrls` / `summarizeRecoveryUrlRun` + op resolution/fallback/cache — **9 unit tests, all green**. No new type errors in changed files.

## Ops tail (not in this PR)
Wiring the **live prod** flow to swap the `execute_code` URL-building for this op is an authored-via-admin change (prod visual flows aren't re-seeded on deploy). The discoverer must include `sales_channel_id` in its cart select and feed `{{ discoverer.carts }}` into the new node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)