### PR TITLE
feat(#453): admin broadcast notifications to all/filtered partners

### DIFF
--- a/apps/backend/integration-tests/http/admin-partner-broadcast.spec.ts
+++ b/apps/backend/integration-tests/http/admin-partner-broadcast.spec.ts
@@ -1,0 +1,145 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+
+const TEST_PARTNER_PASSWORD = "supersecret"
+
+jest.setTimeout(90 * 1000)
+
+/**
+ * Integration coverage for #453 — admin broadcast notifications.
+ * POST /admin/partners/notifications/broadcast fans a feed notification out
+ * to all (or a filtered subset of) partners, which then surface on each
+ * partner's bell feed (GET /partners/notifications).
+ */
+async function registerPartner(api: any, label: string) {
+  const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+  const email = `bcast-${label}-${unique}@medusa-test.com`
+
+  await api.post("/auth/partner/emailpass/register", {
+    email,
+    password: TEST_PARTNER_PASSWORD,
+  })
+  const login1 = await api.post("/auth/partner/emailpass", {
+    email,
+    password: TEST_PARTNER_PASSWORD,
+  })
+  let headers: Record<string, string> = {
+    Authorization: `Bearer ${login1.data.token}`,
+  }
+
+  const partnerRes = await api.post(
+    "/partners",
+    {
+      name: `Bcast ${label} ${unique}`,
+      handle: `bcast-${label}-${unique}`,
+      admin: { email, first_name: "Admin", last_name: label },
+    },
+    { headers }
+  )
+  const partnerId = partnerRes.data.partner.id
+
+  // Re-login so the token carries the partner association.
+  const login2 = await api.post("/auth/partner/emailpass", {
+    email,
+    password: TEST_PARTNER_PASSWORD,
+  })
+  headers = { Authorization: `Bearer ${login2.data.token}` }
+
+  return { partnerId, headers }
+}
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Admin partner broadcast notifications", () => {
+    let adminHeaders: Record<string, any>
+    let p1: Awaited<ReturnType<typeof registerPartner>>
+    let p2: Awaited<ReturnType<typeof registerPartner>>
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+      p1 = await registerPartner(api, "one")
+      p2 = await registerPartner(api, "two")
+    })
+
+    it("broadcasts to all partners and lands on each bell feed", async () => {
+      const res = await api.post(
+        "/admin/partners/notifications/broadcast",
+        {
+          title: "Platform maintenance tonight",
+          description: "Expect a short downtime at 02:00 IST.",
+          url: "/announcements/maint",
+        },
+        adminHeaders
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.data.broadcast.total).toBeGreaterThanOrEqual(2)
+      expect(res.data.broadcast.failed).toBe(0)
+      expect(res.data.broadcast.sent).toBe(res.data.broadcast.total)
+      expect(res.data.partner_ids).toEqual(
+        expect.arrayContaining([p1.partnerId, p2.partnerId])
+      )
+
+      const feed1 = await api.get("/partners/notifications", {
+        headers: p1.headers,
+      })
+      const titles1 = feed1.data.notifications.map((n: any) => n.data?.title)
+      expect(titles1).toContain("Platform maintenance tonight")
+
+      const feed2 = await api.get("/partners/notifications", {
+        headers: p2.headers,
+      })
+      const titles2 = feed2.data.notifications.map((n: any) => n.data?.title)
+      expect(titles2).toContain("Platform maintenance tonight")
+    })
+
+    it("targets only the explicit partner_ids when provided", async () => {
+      const res = await api.post(
+        "/admin/partners/notifications/broadcast",
+        {
+          title: "Targeted note",
+          partner_ids: [p1.partnerId],
+        },
+        adminHeaders
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.data.partner_ids).toEqual([p1.partnerId])
+      expect(res.data.broadcast.total).toBe(1)
+
+      const feed2 = await api.get("/partners/notifications", {
+        headers: p2.headers,
+      })
+      const titles2 = feed2.data.notifications.map((n: any) => n.data?.title)
+      expect(titles2).not.toContain("Targeted note")
+    })
+
+    it("drops unknown partner ids from the explicit target list", async () => {
+      const res = await api.post(
+        "/admin/partners/notifications/broadcast",
+        {
+          title: "Filtered targets",
+          partner_ids: [p1.partnerId, "partner_does_not_exist"],
+        },
+        adminHeaders
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.data.partner_ids).toEqual([p1.partnerId])
+      expect(res.data.broadcast.total).toBe(1)
+    })
+
+    it("rejects a broadcast without a title", async () => {
+      await expect(
+        api.post(
+          "/admin/partners/notifications/broadcast",
+          { description: "no title here" },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+  })
+})

--- a/apps/backend/src/api/admin/partners/notifications/broadcast/__tests__/lib.unit.spec.ts
+++ b/apps/backend/src/api/admin/partners/notifications/broadcast/__tests__/lib.unit.spec.ts
@@ -1,0 +1,114 @@
+import {
+  selectBroadcastPartnerIds,
+  summarizeBroadcast,
+  type PartnerLite,
+  type BroadcastResult,
+} from "../lib"
+
+/**
+ * Unit coverage for the admin partner-broadcast pure helpers (#453).
+ * No DI / notification module involved — just target resolution + summary.
+ */
+
+const partners: PartnerLite[] = [
+  { id: "p_1", status: "active" },
+  { id: "p_2", status: "pending" },
+  { id: "p_3", status: "inactive" },
+  { id: "p_4", status: "active" },
+]
+
+describe("selectBroadcastPartnerIds", () => {
+  it("returns all partner ids when no filter is given", () => {
+    expect(selectBroadcastPartnerIds(partners, {})).toEqual([
+      "p_1",
+      "p_2",
+      "p_3",
+      "p_4",
+    ])
+  })
+
+  it("filters by status when no explicit ids are given", () => {
+    expect(selectBroadcastPartnerIds(partners, { status: "active" })).toEqual([
+      "p_1",
+      "p_4",
+    ])
+  })
+
+  it("uses explicit partner_ids and ignores status filtering", () => {
+    expect(
+      selectBroadcastPartnerIds(partners, {
+        partner_ids: ["p_2", "p_3"],
+        status: "active",
+      })
+    ).toEqual(["p_2", "p_3"])
+  })
+
+  it("drops explicit ids that are not known partners", () => {
+    expect(
+      selectBroadcastPartnerIds(partners, {
+        partner_ids: ["p_1", "p_unknown", "p_4"],
+      })
+    ).toEqual(["p_1", "p_4"])
+  })
+
+  it("de-duplicates explicit ids while preserving first-seen order", () => {
+    expect(
+      selectBroadcastPartnerIds(partners, {
+        partner_ids: ["p_4", "p_1", "p_4"],
+      })
+    ).toEqual(["p_4", "p_1"])
+  })
+
+  it("returns an empty array when no partners match the status filter", () => {
+    expect(
+      selectBroadcastPartnerIds([{ id: "p_1", status: "active" }], {
+        status: "pending",
+      })
+    ).toEqual([])
+  })
+
+  it("treats an empty partner_ids array as 'broadcast to all'", () => {
+    expect(
+      selectBroadcastPartnerIds(partners, { partner_ids: [] })
+    ).toEqual(["p_1", "p_2", "p_3", "p_4"])
+  })
+})
+
+describe("summarizeBroadcast", () => {
+  it("counts sent and failed and lists failed ids", () => {
+    const results: BroadcastResult[] = [
+      { partner_id: "p_1", ok: true },
+      { partner_id: "p_2", ok: false },
+      { partner_id: "p_3", ok: true },
+      { partner_id: "p_4", ok: false },
+    ]
+    expect(summarizeBroadcast(results)).toEqual({
+      total: 4,
+      sent: 2,
+      failed: 2,
+      failures: ["p_2", "p_4"],
+    })
+  })
+
+  it("handles an all-success run", () => {
+    const results: BroadcastResult[] = [
+      { partner_id: "p_1", ok: true },
+      { partner_id: "p_2", ok: true },
+    ]
+    expect(summarizeBroadcast(results)).toEqual({
+      total: 2,
+      sent: 2,
+      failed: 0,
+      failures: [],
+    })
+  })
+
+  it("handles an empty run", () => {
+    expect(summarizeBroadcast([])).toEqual({
+      total: 0,
+      sent: 0,
+      failed: 0,
+      failures: [],
+    })
+  })
+})

--- a/apps/backend/src/api/admin/partners/notifications/broadcast/lib.ts
+++ b/apps/backend/src/api/admin/partners/notifications/broadcast/lib.ts
@@ -1,0 +1,67 @@
+/**
+ * Pure helpers for the admin partner-broadcast notification route.
+ *
+ * Kept side-effect-free so the target-resolution and result-summary logic
+ * can be unit-tested without booting Medusa or the notification module.
+ */
+
+export type PartnerLite = { id: string; status?: string | null }
+
+export type BroadcastTargetInput = {
+  /** Explicit partner ids. When present, only these (intersected with known partners) are targeted. */
+  partner_ids?: string[]
+  /** When no explicit ids are given, optionally restrict the all-partners fan-out by status. */
+  status?: "active" | "inactive" | "pending"
+}
+
+/**
+ * Resolve the final, de-duplicated list of partner ids to notify.
+ *
+ * - With explicit `partner_ids`: keep only ids that exist in `partners`
+ *   (unknown ids are silently dropped so a stale id can't fabricate a row).
+ * - Without explicit ids: take every partner, optionally filtered by `status`.
+ *
+ * Order is preserved (input order for explicit ids, list order otherwise).
+ */
+export function selectBroadcastPartnerIds(
+  partners: PartnerLite[],
+  input: BroadcastTargetInput
+): string[] {
+  const known = new Set(partners.map((p) => p.id))
+
+  let ids: string[]
+  if (input.partner_ids && input.partner_ids.length) {
+    ids = input.partner_ids.filter((id) => known.has(id))
+  } else {
+    ids = partners
+      .filter((p) => !input.status || p.status === input.status)
+      .map((p) => p.id)
+  }
+
+  return Array.from(new Set(ids))
+}
+
+export type BroadcastResult = { partner_id: string; ok: boolean }
+
+export type BroadcastSummary = {
+  total: number
+  sent: number
+  failed: number
+  /** partner ids whose notification row failed to create. */
+  failures: string[]
+}
+
+/**
+ * Summarize per-partner create results into counts + the list of failed ids.
+ */
+export function summarizeBroadcast(
+  results: BroadcastResult[]
+): BroadcastSummary {
+  const failures = results.filter((r) => !r.ok).map((r) => r.partner_id)
+  return {
+    total: results.length,
+    sent: results.length - failures.length,
+    failed: failures.length,
+    failures,
+  }
+}

--- a/apps/backend/src/api/admin/partners/notifications/broadcast/route.ts
+++ b/apps/backend/src/api/admin/partners/notifications/broadcast/route.ts
@@ -1,0 +1,87 @@
+/**
+ * @file Admin broadcast notifications route
+ * @description POST /admin/partners/notifications/broadcast — fan a single
+ * notification out to all (or a filtered subset of) partners, reusing the
+ * shared `createPartnerNotification` feed-channel helper. Mirrors the existing
+ * partner notification create path (src/lib/notifications/create-partner-notification.ts)
+ * rather than inventing a new write path.
+ * @module API/Admin/Partners/Notifications/Broadcast
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { createPartnerNotification } from "../../../../../lib/notifications/create-partner-notification"
+import {
+  selectBroadcastPartnerIds,
+  summarizeBroadcast,
+  type BroadcastResult,
+  type PartnerLite,
+} from "./lib"
+import type { AdminBroadcastNotificationSchema } from "./validators"
+
+const PAGE_SIZE = 200
+
+/**
+ * Page through every partner so a broadcast is never silently truncated.
+ */
+async function fetchAllPartners(scope: any): Promise<PartnerLite[]> {
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY)
+  const partners: PartnerLite[] = []
+  let skip = 0
+
+  // Bounded loop: stop when a page comes back short or we've hit the count.
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { data, metadata } = await query.graph({
+      entity: "partners",
+      fields: ["id", "status"],
+      pagination: { skip, take: PAGE_SIZE, order: { created_at: "ASC" } },
+    })
+
+    const page = (data as PartnerLite[]) || []
+    partners.push(...page)
+
+    const count = (metadata as any)?.count ?? partners.length
+    skip += PAGE_SIZE
+    if (page.length < PAGE_SIZE || partners.length >= count) break
+  }
+
+  return partners
+}
+
+export const POST = async (
+  req: MedusaRequest<AdminBroadcastNotificationSchema>,
+  res: MedusaResponse
+) => {
+  const body = req.validatedBody as AdminBroadcastNotificationSchema
+
+  const partners = await fetchAllPartners(req.scope)
+  const targetIds = selectBroadcastPartnerIds(partners, {
+    partner_ids: body.partner_ids,
+    status: body.status,
+  })
+
+  const results: BroadcastResult[] = await Promise.all(
+    targetIds.map(async (partner_id) => {
+      const ok = await createPartnerNotification(req.scope, {
+        partner_id,
+        title: body.title,
+        description: body.description ?? null,
+        url: body.url ?? null,
+        channel: body.channel,
+        trigger_type: body.trigger_type ?? "admin.broadcast",
+        resource_type: body.resource_type ?? "broadcast",
+        resource_id: body.resource_id ?? null,
+        data: body.data,
+      })
+      return { partner_id, ok }
+    })
+  )
+
+  const summary = summarizeBroadcast(results)
+
+  return res.status(200).json({
+    broadcast: summary,
+    partner_ids: targetIds,
+  })
+}

--- a/apps/backend/src/api/admin/partners/notifications/broadcast/validators.ts
+++ b/apps/backend/src/api/admin/partners/notifications/broadcast/validators.ts
@@ -1,0 +1,27 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * Body schema for POST /admin/partners/notifications/broadcast.
+ *
+ * `title` is the only required field. When `partner_ids` is omitted the
+ * notification fans out to ALL partners (optionally narrowed by `status`).
+ */
+export const AdminBroadcastNotificationSchema = z.object({
+  title: z.string().min(1),
+  description: z.string().optional(),
+  url: z.string().optional(),
+  /** Defaults to the in-app "feed" channel inside the route. */
+  channel: z.string().optional(),
+  /** When present, only these partners are notified (unknown ids dropped). */
+  partner_ids: z.array(z.string()).optional(),
+  /** Narrows the all-partners fan-out when no explicit ids are given. */
+  status: z.enum(["active", "inactive", "pending"]).optional(),
+  trigger_type: z.string().optional(),
+  resource_type: z.string().optional(),
+  resource_id: z.string().optional(),
+  data: z.record(z.string(), z.unknown()).optional(),
+})
+
+export type AdminBroadcastNotificationSchema = z.infer<
+  typeof AdminBroadcastNotificationSchema
+>

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -186,6 +186,7 @@ import { PartnerPostConsumptionLogReq } from "./partners/designs/[designId]/cons
 import { PartnerPostDesignTasksReq } from "./partners/designs/[designId]/tasks/validators";
 import { PartnerPostProductionRunConsumptionLogReq } from "./partners/production-runs/[id]/consumption-logs/validators";
 import { listPartnersQuerySchema, PostPartnerSchema } from "./admin/partners/validators";
+import { AdminBroadcastNotificationSchema } from "./admin/partners/notifications/broadcast/validators";
 import { ListIdentitiesQuerySchema } from "./admin/users/identities/validators";
 import { ListInventoryItemRawMaterialsQuerySchema } from "./admin/inventory-items/raw-materials/validators";
 import { BulkImportSchema } from "./admin/inventory-items/bulk-import/validators";
@@ -2869,6 +2870,11 @@ export default defineMiddlewares({
       middlewares: [validateAndTransformBody(wrapSchema(executeInboundEmailSchema))],
     },
     // Admin Partners routes
+    {
+      matcher: "/admin/partners/notifications/broadcast",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(AdminBroadcastNotificationSchema))],
+    },
     {
       matcher: "/admin/partners",
       method: "GET",


### PR DESCRIPTION
Closes #453.

## What
New `POST /admin/partners/notifications/broadcast` — send a single in-app feed notification to **all** partners, or a filtered subset, from the admin. Backs the "send news to all partners" admin feature requested in #453.

## How
- Reuses the existing partner-notification write path (`src/lib/notifications/create-partner-notification.ts`, channel `feed`) — no new model, no new write path invented (mirrors-admin convention).
- Pages through every partner so a broadcast is never silently truncated.
- Body: `title` (required), `description?`, `url?`, `channel?`, `partner_ids?`, `status?`, `trigger_type?`, `resource_type?`, `resource_id?`, `data?`.
  - `partner_ids` present → only those (unknown ids dropped).
  - else → all partners, optionally narrowed by `status`.
- Returns `{ broadcast: { total, sent, failed, failures[] }, partner_ids[] }`.
- Each row lands on the partner bell feed (`GET /partners/notifications`).

## Tests
- **10 unit** — `selectBroadcastPartnerIds` / `summarizeBroadcast` pure helpers.
- **4 integration** (`admin-partner-broadcast.spec.ts`, all green) — all-fan-out lands on each bell feed, explicit targeting, unknown-id drop, missing-title → 400.

Typecheck: 0 new TS errors. Backend route only (no UI) → no Playwright needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)