### PR TITLE
feat(#452): post-delivery feedback request + email trigger

### DIFF
--- a/apps/backend/integration-tests/http/post-delivery-feedback.spec.ts
+++ b/apps/backend/integration-tests/http/post-delivery-feedback.spec.ts
@@ -1,0 +1,41 @@
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { FEEDBACK_MODULE } from "../../src/modules/feedback"
+import { selectExistingFeedbackRequest } from "../../src/workflows/feedback/lib/post-delivery-feedback"
+
+jest.setTimeout(60 * 1000)
+
+setupSharedTestSuite(() => {
+  describe("post-delivery feedback request (#452)", () => {
+    it("persists the durable order_id column and reuses the live request idempotently", async () => {
+      const { getContainer } = getSharedTestEnv()
+      const container = getContainer()
+      const service: any = container.resolve(FEEDBACK_MODULE)
+
+      const orderId = `order_${Date.now()}`
+
+      // 1) The new typed order_id column persists and is queryable.
+      const created = await service.createFeedbacks({
+        order_id: orderId,
+        submitted_by: "c@example.com",
+        submitted_at: new Date(),
+        status: "pending",
+        metadata: { source: "post_delivery_request" },
+      })
+
+      expect(created.id).toBeTruthy()
+      expect(created.order_id).toBe(orderId)
+      expect(created.status).toBe("pending")
+
+      const rows = await service.listFeedbacks({ order_id: orderId })
+      expect(rows).toHaveLength(1)
+      expect(rows[0].id).toBe(created.id)
+
+      // 2) Idempotency: a re-fired event reuses the existing live request.
+      const reuse = selectExistingFeedbackRequest(rows as any)
+      expect(reuse?.id).toBe(created.id)
+
+      const after = await service.listFeedbacks({ order_id: orderId })
+      expect(after).toHaveLength(1)
+    })
+  })
+})

--- a/apps/backend/src/modules/feedback/migrations/Migration20260622000000.ts
+++ b/apps/backend/src/modules/feedback/migrations/Migration20260622000000.ts
@@ -1,0 +1,23 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * #452 — add a durable `order_id` link to the feedback model so a
+ * post-delivery feedback request can be tied to its order (and made
+ * idempotent) without relying on the metadata blob.
+ *
+ * Hand-written `add column if not exists` ALTER (never edit the original
+ * `create table if not exists` migration — it won't land on existing DBs).
+ */
+export class Migration20260622000000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "feedback" add column if not exists "order_id" text null;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_feedback_order_id" ON "feedback" ("order_id") WHERE order_id IS NOT NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop index if exists "IDX_feedback_order_id";`);
+    this.addSql(`alter table if exists "feedback" drop column if exists "order_id";`);
+  }
+
+}

--- a/apps/backend/src/modules/feedback/models/feedback.ts
+++ b/apps/backend/src/modules/feedback/models/feedback.ts
@@ -7,6 +7,11 @@ const Feedback = model.define("feedback", {
   status: model.enum(["pending","reviewed","resolved"]).default("pending"),
   submitted_by: model.text(),
   submitted_at: model.dateTime(),
+  // Durable link back to the order this feedback is about (e.g. a
+  // post-delivery feedback request, #452). Kept as a typed column rather
+  // than in `metadata` so it survives metadata-replacing updates when the
+  // customer later submits their rating.
+  order_id: model.text().nullable(),
   reviewed_by: model.text().nullable(),
   reviewed_at: model.dateTime().nullable(),
   metadata: model.json().nullable(),

--- a/apps/backend/src/subscribers/order-delivered-feedback.ts
+++ b/apps/backend/src/subscribers/order-delivered-feedback.ts
@@ -1,0 +1,45 @@
+import { SubscriberArgs, type SubscriberConfig } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import type { Logger } from "@medusajs/types"
+
+import { requestPostDeliveryFeedbackWorkflow } from "../workflows/feedback/request-post-delivery-feedback"
+import { shouldRequestPostDeliveryFeedback } from "../workflows/feedback/lib/post-delivery-feedback"
+
+/**
+ * #452 — post-delivery feedback trigger.
+ *
+ * Runs ALONGSIDE `delivery-created.ts` (which sends the "delivered" shipment
+ * email). On delivery it creates an idempotent pending feedback request tied
+ * to the order and emails the customer a feedback link (backend trigger only;
+ * the storefront rating UX is a later slice).
+ *
+ * Best-effort: a missing template / unconfigured store URL / provider error
+ * must never break delivery processing.
+ */
+export default async function orderDeliveredFeedbackHandler({
+  event: { data },
+  container,
+}: SubscriberArgs<{ id: string; no_notification?: boolean }>) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER) as Logger
+
+  const decision = shouldRequestPostDeliveryFeedback({
+    eventNoNotification: data.no_notification,
+  })
+  if (!decision.request) {
+    return
+  }
+
+  try {
+    await requestPostDeliveryFeedbackWorkflow(container).run({
+      input: { shipment_id: data.id },
+    })
+  } catch (e: any) {
+    logger.warn(
+      `[delivery.created] post-delivery feedback request failed: ${e?.message || e}`
+    )
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: "delivery.created",
+}

--- a/apps/backend/src/workflows/feedback/lib/__tests__/post-delivery-feedback.unit.spec.ts
+++ b/apps/backend/src/workflows/feedback/lib/__tests__/post-delivery-feedback.unit.spec.ts
@@ -1,0 +1,142 @@
+import {
+  shouldRequestPostDeliveryFeedback,
+  selectExistingFeedbackRequest,
+  resolveFeedbackStoreBase,
+  buildFeedbackUrl,
+  buildPostDeliveryFeedbackEmailData,
+} from "../post-delivery-feedback"
+
+describe("post-delivery-feedback pure helpers (#452)", () => {
+  describe("shouldRequestPostDeliveryFeedback", () => {
+    it("requests by default", () => {
+      expect(shouldRequestPostDeliveryFeedback({})).toEqual({ request: true })
+    })
+
+    it("skips on event no_notification flag", () => {
+      const r = shouldRequestPostDeliveryFeedback({ eventNoNotification: true })
+      expect(r.request).toBe(false)
+      expect(r.reason).toMatch(/event/)
+    })
+
+    it("skips on order metadata.no_notification", () => {
+      const r = shouldRequestPostDeliveryFeedback({
+        order: { metadata: { no_notification: true } },
+      })
+      expect(r.request).toBe(false)
+      expect(r.reason).toMatch(/metadata/)
+    })
+
+    it("does NOT skip merely because the order has no email", () => {
+      expect(
+        shouldRequestPostDeliveryFeedback({ order: { metadata: {} } }).request
+      ).toBe(true)
+    })
+  })
+
+  describe("selectExistingFeedbackRequest (idempotency)", () => {
+    it("returns null for empty / nullish input", () => {
+      expect(selectExistingFeedbackRequest(null)).toBeNull()
+      expect(selectExistingFeedbackRequest(undefined)).toBeNull()
+      expect(selectExistingFeedbackRequest([])).toBeNull()
+    })
+
+    it("returns the first live row", () => {
+      const r = selectExistingFeedbackRequest([
+        { id: "fb_1", order_id: "o1" },
+        { id: "fb_2", order_id: "o1" },
+      ])
+      expect(r?.id).toBe("fb_1")
+    })
+
+    it("ignores soft-deleted rows", () => {
+      const r = selectExistingFeedbackRequest([
+        { id: "fb_1", order_id: "o1", deleted_at: new Date() },
+        { id: "fb_2", order_id: "o1" },
+      ])
+      expect(r?.id).toBe("fb_2")
+    })
+
+    it("returns null when all rows are soft-deleted", () => {
+      const r = selectExistingFeedbackRequest([
+        { id: "fb_1", order_id: "o1", deleted_at: "2020-01-01" },
+      ])
+      expect(r).toBeNull()
+    })
+  })
+
+  describe("resolveFeedbackStoreBase", () => {
+    it("prefers explicit override", () => {
+      expect(
+        resolveFeedbackStoreBase({ STORE_URL: "https://s.com" }, "https://o.com/")
+      ).toBe("https://o.com")
+    })
+
+    it("falls back STORE_URL → FRONTEND_URL → ''", () => {
+      expect(resolveFeedbackStoreBase({ STORE_URL: "https://s.com/" })).toBe(
+        "https://s.com"
+      )
+      expect(resolveFeedbackStoreBase({ FRONTEND_URL: "https://f.com" })).toBe(
+        "https://f.com"
+      )
+      expect(resolveFeedbackStoreBase({})).toBe("")
+    })
+
+    it("trims trailing slashes", () => {
+      expect(resolveFeedbackStoreBase({ STORE_URL: "https://s.com///" })).toBe(
+        "https://s.com"
+      )
+    })
+  })
+
+  describe("buildFeedbackUrl", () => {
+    it("composes a /feedback/:id url", () => {
+      expect(buildFeedbackUrl("https://s.com", "fb_1")).toBe(
+        "https://s.com/feedback/fb_1"
+      )
+    })
+
+    it("returns '' without a base or id", () => {
+      expect(buildFeedbackUrl("", "fb_1")).toBe("")
+      expect(buildFeedbackUrl("https://s.com", "")).toBe("")
+    })
+  })
+
+  describe("buildPostDeliveryFeedbackEmailData", () => {
+    const now = new Date("2026-06-22T00:00:00Z")
+
+    it("assembles the order-feedback-request template data", () => {
+      const out = buildPostDeliveryFeedbackEmailData({
+        order: { id: "order_1", display_id: 1042, email: "c@x.com" },
+        customerName: "Asha",
+        feedbackId: "fb_9",
+        storeBase: "https://s.com",
+        now,
+      })
+      expect(out.to).toBe("c@x.com")
+      expect(out.template).toBe("order-feedback-request")
+      expect(out.data).toMatchObject({
+        customer_name: "Asha",
+        order_id: "order_1",
+        order_display: "#1042",
+        feedback_url: "https://s.com/feedback/fb_9",
+        store_url: "https://s.com",
+        current_year: 2026,
+        feedback_id: "fb_9",
+      })
+    })
+
+    it("falls back to order id when display_id missing and to 'there' for blank name", () => {
+      const out = buildPostDeliveryFeedbackEmailData({
+        order: { id: "order_2", email: "" },
+        customerName: "  ",
+        feedbackId: "fb_2",
+        storeBase: "",
+        now,
+      })
+      expect(out.to).toBe("")
+      expect(out.data.order_display).toBe("order_2")
+      expect(out.data.customer_name).toBe("there")
+      expect(out.data.feedback_url).toBe("")
+    })
+  })
+})

--- a/apps/backend/src/workflows/feedback/lib/post-delivery-feedback.ts
+++ b/apps/backend/src/workflows/feedback/lib/post-delivery-feedback.ts
@@ -1,0 +1,144 @@
+// Pure, side-effect-free helpers for the post-delivery feedback request (#452).
+// Kept free of Medusa/container deps so the request/skip decision, idempotency
+// selection, store-base resolution and email-data assembly are unit-testable
+// without booting Medusa or a notification provider.
+
+export interface FeedbackRequestDecisionInput {
+  order?: {
+    metadata?: Record<string, any> | null
+  } | null
+  /** `no_notification` flag carried on the delivery.created event payload. */
+  eventNoNotification?: boolean | null
+}
+
+export interface FeedbackRequestDecision {
+  request: boolean
+  /** Human-readable reason a request was skipped (for the subscriber log). */
+  reason?: string
+}
+
+/**
+ * Decide whether to create a post-delivery feedback request + email.
+ * Honours the same `no_notification` skip semantics the delivery/shipment
+ * emails use: an explicit flag on the event OR `metadata.no_notification`
+ * on the order suppresses the touchpoint.
+ *
+ * Note: a missing customer email does NOT skip the request — the feedback
+ * record is still created (durable, can be surfaced in-app later); only the
+ * email send is guarded separately on a present recipient.
+ */
+export function shouldRequestPostDeliveryFeedback(
+  input: FeedbackRequestDecisionInput
+): FeedbackRequestDecision {
+  if (input.eventNoNotification) {
+    return { request: false, reason: "no_notification flag on event" }
+  }
+  if (input.order?.metadata?.no_notification) {
+    return { request: false, reason: "no_notification flag on order metadata" }
+  }
+  return { request: true }
+}
+
+export interface ExistingFeedbackLike {
+  id: string
+  order_id?: string | null
+  deleted_at?: Date | string | null
+}
+
+/**
+ * Idempotency selector: given the existing feedback rows for an order, return
+ * the one that already represents a request (so we reuse it) or `null` when a
+ * new request should be created. Ignores soft-deleted rows.
+ */
+export function selectExistingFeedbackRequest(
+  existing: ExistingFeedbackLike[] | null | undefined
+): ExistingFeedbackLike | null {
+  if (!Array.isArray(existing) || existing.length === 0) {
+    return null
+  }
+  const live = existing.find((f) => f && f.id && !f.deleted_at)
+  return live ?? null
+}
+
+/**
+ * Resolve the storefront base URL used to build the feedback link.
+ * Precedence: explicit override → STORE_URL → FRONTEND_URL → "".
+ * Returns a trailing-slash-trimmed string (or "" when none configured).
+ */
+export function resolveFeedbackStoreBase(
+  env: Record<string, string | undefined> = {},
+  override?: string | null
+): string {
+  const raw = (override || env.STORE_URL || env.FRONTEND_URL || "").trim()
+  return raw.replace(/\/+$/, "")
+}
+
+/**
+ * Build the customer-facing feedback URL. Returns "" when no store base is
+ * configured (the email template hides the CTA when `feedback_url` is falsy).
+ */
+export function buildFeedbackUrl(storeBase: string, feedbackId: string): string {
+  const base = (storeBase || "").replace(/\/+$/, "")
+  if (!base || !feedbackId) {
+    return ""
+  }
+  return `${base}/feedback/${feedbackId}`
+}
+
+export interface PostDeliveryFeedbackEmailOrder {
+  id?: string | null
+  display_id?: number | string | null
+  email?: string | null
+}
+
+export interface PostDeliveryFeedbackEmailInput {
+  order: PostDeliveryFeedbackEmailOrder
+  customerName?: string | null
+  feedbackId: string
+  storeBase: string
+  now?: Date
+}
+
+export interface PostDeliveryFeedbackEmail {
+  /** Recipient — may be "" when the order has no email (send is then skipped). */
+  to: string
+  template: "order-feedback-request"
+  data: {
+    customer_name: string
+    order_id: string
+    order_display: string
+    feedback_url: string
+    store_url: string
+    current_year: number
+    feedback_id: string
+  }
+}
+
+/**
+ * Assemble the Handlebars data for the `order-feedback-request` template.
+ * Mirrors the variables seeded in `seed-additional-email-templates.ts` (#450).
+ */
+export function buildPostDeliveryFeedbackEmailData(
+  input: PostDeliveryFeedbackEmailInput
+): PostDeliveryFeedbackEmail {
+  const { order, customerName, feedbackId, storeBase } = input
+  const now = input.now ?? new Date()
+  const displayId =
+    order?.display_id !== undefined && order?.display_id !== null && `${order.display_id}` !== ""
+      ? `#${order.display_id}`
+      : order?.id || ""
+
+  return {
+    to: (order?.email || "").trim(),
+    template: "order-feedback-request",
+    data: {
+      customer_name: (customerName || "").trim() || "there",
+      order_id: order?.id || "",
+      order_display: displayId,
+      feedback_url: buildFeedbackUrl(storeBase, feedbackId),
+      store_url: storeBase,
+      current_year: now.getFullYear(),
+      feedback_id: feedbackId,
+    },
+  }
+}

--- a/apps/backend/src/workflows/feedback/request-post-delivery-feedback.ts
+++ b/apps/backend/src/workflows/feedback/request-post-delivery-feedback.ts
@@ -1,0 +1,125 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+  transform,
+  when,
+} from "@medusajs/framework/workflows-sdk"
+
+import { FEEDBACK_MODULE } from "../../modules/feedback"
+import type FeedbackService from "../../modules/feedback/service"
+import { retrieveShipmentDetailsStep } from "../email/steps/retrieve-shipment-details"
+import { fetchEmailTemplateStep } from "../email/steps/fetch-email-template"
+import { sendNotificationEmailStep } from "../email/steps/send-notification-email"
+import {
+  buildPostDeliveryFeedbackEmailData,
+  resolveFeedbackStoreBase,
+  selectExistingFeedbackRequest,
+} from "./lib/post-delivery-feedback"
+
+export interface RequestPostDeliveryFeedbackInput {
+  /** The delivered fulfillment (delivery.created carries this as `id`). */
+  shipment_id: string
+  /** Optional override for the storefront base used in the feedback link. */
+  store_base?: string
+}
+
+/**
+ * Idempotently create (or reuse) a pending feedback request tied to the order.
+ * Uses the durable `order_id` column (#452) for the idempotency lookup so a
+ * re-delivered/re-emitted event never produces a duplicate request.
+ */
+const createFeedbackRequestStep = createStep(
+  "create-post-delivery-feedback-request",
+  async (
+    { order_id, submitted_by }: { order_id: string; submitted_by: string },
+    { container }
+  ) => {
+    const service = container.resolve(FEEDBACK_MODULE) as FeedbackService
+
+    const existingRows = await service.listFeedbacks({ order_id })
+    const existing = selectExistingFeedbackRequest(existingRows as any)
+    if (existing) {
+      return new StepResponse({ feedback: existing, created: false }, null)
+    }
+
+    const created = await service.createFeedbacks({
+      order_id,
+      submitted_by: submitted_by || "customer",
+      submitted_at: new Date(),
+      status: "pending",
+      metadata: { source: "post_delivery_request" },
+    })
+
+    return new StepResponse({ feedback: created, created: true }, created.id)
+  },
+  // Compensation: only undo what we created.
+  async (createdId: string | null, { container }) => {
+    if (!createdId) {
+      return
+    }
+    const service = container.resolve(FEEDBACK_MODULE) as FeedbackService
+    await service.softDeleteFeedbacks(createdId)
+  }
+)
+
+export const requestPostDeliveryFeedbackWorkflow = createWorkflow(
+  { name: "request-post-delivery-feedback", store: true },
+  (input: RequestPostDeliveryFeedbackInput) => {
+    const shipmentData = retrieveShipmentDetailsStep({
+      shipment_id: input.shipment_id,
+    })
+
+    const feedbackResult = createFeedbackRequestStep(
+      transform({ shipmentData }, ({ shipmentData }) => ({
+        order_id: shipmentData.order.id,
+        submitted_by: shipmentData.customer_email || shipmentData.order.id,
+      }))
+    )
+
+    const emailInput = transform(
+      { shipmentData, feedbackResult, input },
+      ({ shipmentData, feedbackResult, input }) => {
+        const storeBase = resolveFeedbackStoreBase(
+          process.env as Record<string, string | undefined>,
+          input.store_base
+        )
+        const email = buildPostDeliveryFeedbackEmailData({
+          order: shipmentData.order,
+          customerName: shipmentData.customer_name,
+          feedbackId: feedbackResult.feedback.id,
+          storeBase,
+        })
+        return {
+          to: email.to,
+          template: email.template,
+          data: email.data,
+          has_recipient: !!email.to,
+        }
+      }
+    )
+
+    // Only send when the order actually has a customer email.
+    when({ emailInput }, ({ emailInput }) => emailInput.has_recipient).then(() => {
+      const templateData = fetchEmailTemplateStep({
+        templateKey: "order-feedback-request",
+        data: emailInput.data as unknown as Record<string, any>,
+      })
+
+      const emailWithTemplate = transform(
+        { emailInput, templateData },
+        ({ emailInput, templateData }) => ({
+          to: emailInput.to,
+          template: emailInput.template,
+          data: emailInput.data,
+          templateData,
+        })
+      )
+
+      sendNotificationEmailStep(emailWithTemplate as any)
+    })
+
+    return new WorkflowResponse(feedbackResult)
+  }
+)


### PR DESCRIPTION
Closes part of #452 (backend trigger; storefront rating UX is a later slice).

## What
On `delivery.created`, create an idempotent **pending feedback request** tied to the order and email the customer a feedback link.

## Changes
- **feedback model** — new durable nullable `order_id` column (+ partial idempotency index). Typed column, not metadata, so it survives the metadata-replacing update when the customer later submits their rating (per the no-critical-data-in-metadata rule). Hand-written `add column if not exists` ALTER migration.
- **subscriber** `src/subscribers/order-delivered-feedback.ts` — listens on `delivery.created`, runs alongside the existing `delivery-created.ts` shipment-email subscriber. Best-effort try/catch; honours `no_notification`.
- **workflow** `src/workflows/feedback/request-post-delivery-feedback.ts` — reuses `retrieveShipmentDetailsStep` to resolve order+customer, an idempotent create-or-reuse feedback step (keyed on `order_id`), then conditionally (`when` recipient email present) sends via `fetchEmailTemplateStep` + `sendNotificationEmailStep` using the `order-feedback-request` template (added in #450 / PR #618).
- **pure helpers** `src/workflows/feedback/lib/post-delivery-feedback.ts` — decision / idempotency selector / store-base resolution / feedback-url / email-data assembly.

## Tests
- 15 unit (pure helpers) — green.
- 1 integration (`post-delivery-feedback.spec.ts`) — verifies the new `order_id` column persists, is queryable, and the idempotency selector reuses the live request — green against the migrated DB.
- Typecheck: 0 new errors (70 = existing baseline).

## Notes / watch-outs
- **Template dependency:** consumes the `order-feedback-request` email template from #450 (PR #618, still open). Send is best-effort — a missing template just logs a warning, never breaks delivery. Prod templates are admin-authored + not re-seeded on deploy, so author the row (or run `seed-additional-email-templates`) before relying on the live email.
- Full e2e (real delivered fulfillment → email) isn't verifiable headlessly; covered by unit + service-level integration instead.
- `feedback_url` = `<STORE_URL|FRONTEND_URL>/feedback/<feedback_id>`; the storefront `/feedback/:id` rating page is the later slice.
- Independent branch off `origin/main`; no stacking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)