### PR TITLE
feat(#496): inventory-order payment file attachments via link table

### DIFF
--- a/apps/backend/integration-tests/http/payment-attachments-api.spec.ts
+++ b/apps/backend/integration-tests/http/payment-attachments-api.spec.ts
@@ -1,0 +1,93 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { INTERNAL_PAYMENTS_MODULE } from "../../src/modules/internal_payments"
+
+jest.setTimeout(40000)
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+  let headers: any
+
+  beforeEach(async () => {
+    const container = getContainer()
+    await createAdminUser(container)
+    headers = await getAuthHeaders(api)
+  })
+
+  it("persists payment attachments to the link table on /admin/payments/link", async () => {
+    const stamp = Date.now()
+    const linkRes = await api.post(
+      `/admin/payments/link`,
+      {
+        payment: {
+          amount: 2500,
+          payment_type: "Bank",
+          payment_date: new Date().toISOString(),
+          metadata: { memo: "with attachments" },
+        },
+        attachments: [
+          {
+            file_id: `file_${stamp}_a`,
+            url: `https://cdn.example.com/${stamp}/receipt.pdf`,
+            filename: "receipt.pdf",
+            mime_type: "application/pdf",
+            size: 4096,
+          },
+          {
+            file_id: `file_${stamp}_b`,
+            url: `https://cdn.example.com/${stamp}/invoice.png`,
+            filename: "invoice.png",
+            mime_type: "image/png",
+          },
+          // duplicate of the first file_id — should be deduped away
+          {
+            file_id: `file_${stamp}_a`,
+            url: `https://cdn.example.com/${stamp}/receipt-dup.pdf`,
+          },
+        ],
+      },
+      headers
+    )
+
+    expect(linkRes.status).toBe(201)
+    const paymentId = linkRes.data?.payment?.id
+    expect(paymentId).toBeTruthy()
+
+    // Workflow returns the created attachment rows
+    const returned = linkRes.data?.attachments || []
+    expect(Array.isArray(returned)).toBe(true)
+    expect(returned).toHaveLength(2)
+
+    // And they are persisted + queryable from the module service
+    const service: any = getContainer().resolve(INTERNAL_PAYMENTS_MODULE)
+    const rows = await service.listPaymentAttachments({ payment_id: paymentId })
+    expect(rows).toHaveLength(2)
+    const fileIds = rows.map((r: any) => r.file_id).sort()
+    expect(fileIds).toEqual([`file_${stamp}_a`, `file_${stamp}_b`].sort())
+    const pdf = rows.find((r: any) => r.file_id === `file_${stamp}_a`)
+    expect(pdf.filename).toBe("receipt.pdf")
+    expect(pdf.url).toBe(`https://cdn.example.com/${stamp}/receipt.pdf`)
+    expect(Number(pdf.size)).toBe(4096)
+  })
+
+  it("creates a payment with no attachments when none are provided", async () => {
+    const linkRes = await api.post(
+      `/admin/payments/link`,
+      {
+        payment: {
+          amount: 999,
+          payment_type: "Cash",
+          payment_date: new Date().toISOString(),
+        },
+      },
+      headers
+    )
+    expect(linkRes.status).toBe(201)
+    const paymentId = linkRes.data?.payment?.id
+    expect(paymentId).toBeTruthy()
+
+    const service: any = getContainer().resolve(INTERNAL_PAYMENTS_MODULE)
+    const rows = await service.listPaymentAttachments({ payment_id: paymentId })
+    expect(rows).toHaveLength(0)
+  })
+})

--- a/apps/backend/src/admin/components/inventory-orders/inventory-order-payments-section.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/inventory-order-payments-section.tsx
@@ -1,5 +1,5 @@
 import { Badge, Container, Heading, Text, toast } from "@medusajs/ui";
-import { Plus, Check } from "@medusajs/icons";
+import { Plus, Check, DocumentText } from "@medusajs/icons";
 import { ActionMenu } from "../common/action-menu";
 import { useUpdatePayment } from "../../hooks/api/payments";
 import { useState } from "react";
@@ -31,30 +31,52 @@ const PaymentRow = ({ p }: { p: any }) => {
     void onMarkCompleted();
   };
 
+  const attachments: any[] = Array.isArray(p?.attachments) ? p.attachments : [];
+
   return (
-    <div className="flex items-center justify-between py-3">
-      <div className="flex items-center gap-x-3">
-        <Badge size="2xsmall">{p.status}</Badge>
-        <Text size="small" className="text-ui-fg-base">{p.payment_type}</Text>
-        <Text size="small" className="text-ui-fg-subtle">{new Date(p.payment_date).toLocaleDateString()}</Text>
+    <div className="flex flex-col gap-y-2 py-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-x-3">
+          <Badge size="2xsmall">{p.status}</Badge>
+          <Text size="small" className="text-ui-fg-base">{p.payment_type}</Text>
+          <Text size="small" className="text-ui-fg-subtle">{new Date(p.payment_date).toLocaleDateString()}</Text>
+        </div>
+        <div className="flex items-center gap-x-3">
+          <Text size="small" className="text-ui-fg-base font-medium">₹ {p.amount ?? p?.raw_amount?.value}</Text>
+          <ActionMenu
+            groups={[
+              {
+                actions: [
+                  {
+                    label: isCompleted ? "Already Completed" : "Mark as Completed",
+                    icon: <Check />,
+                    onClick: handleClick,
+                    disabled: isCompleted || loading || isPending,
+                  },
+                ],
+              },
+            ]}
+          />
+        </div>
       </div>
-      <div className="flex items-center gap-x-3">
-        <Text size="small" className="text-ui-fg-base font-medium">₹ {p.amount ?? p?.raw_amount?.value}</Text>
-        <ActionMenu
-          groups={[
-            {
-              actions: [
-                {
-                  label: isCompleted ? "Already Completed" : "Mark as Completed",
-                  icon: <Check />,
-                  onClick: handleClick,
-                  disabled: isCompleted || loading || isPending,
-                },
-              ],
-            },
-          ]}
-        />
-      </div>
+      {attachments.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2 pl-1">
+          {attachments.map((a: any) => (
+            <a
+              key={a.id || a.file_id}
+              href={a.url}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-x-1 rounded-md border border-ui-border-base bg-ui-bg-subtle px-2 py-1 text-ui-fg-subtle transition-colors hover:bg-ui-bg-base hover:text-ui-fg-base"
+            >
+              <DocumentText className="text-ui-fg-muted" />
+              <Text size="xsmall" className="max-w-[180px] truncate">
+                {a.filename || a.file_id || "attachment"}
+              </Text>
+            </a>
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/apps/backend/src/admin/routes/orders/inventory/[id]/@add-payments/page.tsx
+++ b/apps/backend/src/admin/routes/orders/inventory/[id]/@add-payments/page.tsx
@@ -1,10 +1,21 @@
 import { RouteDrawer } from "../../../../../components/modal/route-drawer/route-drawer";
-import { Button, Input, Label, Select, Textarea, DatePicker, toast } from "@medusajs/ui";
+import { Button, Input, Label, Select, Textarea, DatePicker, Text, IconButton, toast } from "@medusajs/ui";
+import { Trash, DocumentText } from "@medusajs/icons";
 import { useParams, useNavigate } from "react-router-dom";
 import { useState } from "react";
 import { useListPartnerPaymentMethods } from "../../../../../hooks/api/payment-methods";
 import { useCreatePaymentAndLink } from "../../../../../hooks/api/payments";
+import { useFileUpload } from "../../../../../hooks/api/upload";
+import { FileUpload } from "../../../../../components/common/file-upload";
 import { useInventoryOrder } from "../../../../../hooks/api/inventory-orders";
+
+type PaymentAttachment = {
+  file_id: string;
+  url: string;
+  filename?: string;
+  mime_type?: string;
+  size?: number;
+};
 
 const AddPaymentForInventoryOrder = () => {
   const { id } = useParams();
@@ -17,11 +28,47 @@ const AddPaymentForInventoryOrder = () => {
     enabled: !!partnerId,
   });
   const { mutateAsync, isPending } = useCreatePaymentAndLink();
+  const { mutateAsync: uploadFile } = useFileUpload();
 
   const [amount, setAmount] = useState<string>("");
   const [note, setNote] = useState<string>("");
   const [paymentDate, setPaymentDate] = useState<Date | null>(() => new Date());
   const [paidToId, setPaidToId] = useState<string>("__none__");
+  const [attachments, setAttachments] = useState<PaymentAttachment[]>([]);
+  const [uploading, setUploading] = useState(false);
+
+  const onUploaded = async (files: { file: File; url: string }[]) => {
+    if (!files?.length) return;
+    setUploading(true);
+    try {
+      const uploaded: PaymentAttachment[] = [];
+      for (const { file } of files) {
+        const res = await uploadFile({ files: [file] });
+        const f = res.files?.[0];
+        if (f?.id && f?.url) {
+          uploaded.push({
+            file_id: f.id,
+            url: f.url,
+            filename: file.name,
+            mime_type: file.type || undefined,
+            size: typeof file.size === "number" ? file.size : undefined,
+          });
+        }
+      }
+      if (uploaded.length) {
+        setAttachments((prev) => [...prev, ...uploaded]);
+        toast.success(`${uploaded.length} file(s) attached`);
+      }
+    } catch (e: any) {
+      toast.error(e?.message || "Failed to upload attachment");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const removeAttachment = (fileId: string) => {
+    setAttachments((prev) => prev.filter((a) => a.file_id !== fileId));
+  };
 
   const onCreate = async () => {
     // derive payment_type from selected payment method if any
@@ -45,6 +92,7 @@ const AddPaymentForInventoryOrder = () => {
           paid_to_id: paidToId === "__none__" ? undefined : paidToId,
         },
         inventoryOrderIds: [id!],
+        attachments: attachments.length ? attachments : undefined,
       });
       toast.success("Payment created successfully");
       navigate("..", { replace: true });
@@ -93,6 +141,41 @@ const AddPaymentForInventoryOrder = () => {
         <div className="grid gap-y-2">
           <Label htmlFor="note">Note</Label>
           <Textarea id="note" placeholder="Optional note" value={note} onChange={(e) => setNote(e.target.value)} />
+        </div>
+        <div className="grid gap-y-2">
+          <Label>Attachments (optional)</Label>
+          <FileUpload
+            label={uploading ? "Uploading..." : "Upload receipts / invoices"}
+            hint="PDF or image references for this payment"
+            multiple
+            isLoading={uploading}
+            onUploaded={onUploaded}
+          />
+          {attachments.length > 0 && (
+            <div className="flex flex-col gap-y-1 pt-1">
+              {attachments.map((a) => (
+                <div
+                  key={a.file_id}
+                  className="flex items-center justify-between rounded-md border border-ui-border-base bg-ui-bg-subtle px-2 py-1"
+                >
+                  <div className="flex items-center gap-x-2 overflow-hidden">
+                    <DocumentText className="text-ui-fg-muted" />
+                    <Text size="xsmall" className="truncate text-ui-fg-subtle">
+                      {a.filename || a.file_id}
+                    </Text>
+                  </div>
+                  <IconButton
+                    size="small"
+                    variant="transparent"
+                    onClick={() => removeAttachment(a.file_id)}
+                    aria-label="Remove attachment"
+                  >
+                    <Trash />
+                  </IconButton>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       </RouteDrawer.Body>
       <RouteDrawer.Footer className="sticky bottom-0 bg-ui-bg-base border-t border-ui-border-base">

--- a/apps/backend/src/admin/routes/orders/inventory/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/orders/inventory/[id]/page.tsx
@@ -15,7 +15,7 @@ const InventoryOrderDetailPage = () => {
   const intialData = useLoaderData() as Awaited<AdminInventoryOrderResponse>
   const { id } = useParams();
   const { inventoryOrder, isLoading, isError, error } = useInventoryOrder(id!, {
-    fields: ['orderlines.*', 'orderlines.inventory_items.*', 'stock_locations.*', 'stock_locations.address.*', '+tasks.*', '+partner.*', '+internal_payments.*']
+    fields: ['orderlines.*', 'orderlines.inventory_items.*', 'stock_locations.*', 'stock_locations.address.*', '+tasks.*', '+partner.*', '+internal_payments.*', '+internal_payments.attachments.*']
   }, {
     initialData: intialData
   });

--- a/apps/backend/src/api/admin/payments/link/validators.ts
+++ b/apps/backend/src/api/admin/payments/link/validators.ts
@@ -1,7 +1,17 @@
 import { z } from "@medusajs/framework/zod"
 
-const StatusEnum = z.enum(["Pending", "Processing", "Completed", "Failed", "Cancelled"]) 
-const PaymentTypeEnum = z.enum(["Bank", "Cash", "Digital_Wallet"]) 
+const StatusEnum = z.enum(["Pending", "Processing", "Completed", "Failed", "Cancelled"])
+const PaymentTypeEnum = z.enum(["Bank", "Cash", "Digital_Wallet"])
+
+// #496 — file attachments (receipts/invoices) persisted to the link table.
+export const PaymentAttachmentSchema = z.object({
+  file_id: z.string().min(1),
+  url: z.string().min(1),
+  filename: z.string().optional().nullable(),
+  mime_type: z.string().optional().nullable(),
+  size: z.number().nonnegative().optional().nullable(),
+  metadata: z.record(z.string(), z.any()).nullish(),
+})
 
 export const CreatePaymentAndLinkSchema = z.object({
   payment: z.object({
@@ -15,6 +25,7 @@ export const CreatePaymentAndLinkSchema = z.object({
   personIds: z.array(z.string()).optional(),
   partnerIds: z.array(z.string()).optional(),
   inventoryOrderIds: z.array(z.string()).optional(),
+  attachments: z.array(PaymentAttachmentSchema).optional(),
 })
 
 export type CreatePaymentAndLink = z.infer<typeof CreatePaymentAndLinkSchema>

--- a/apps/backend/src/api/partners/inventory-orders/[orderId]/submit-payment/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/[orderId]/submit-payment/route.ts
@@ -3,12 +3,23 @@ import { z } from "@medusajs/framework/zod";
 import { getPartnerFromAuthContext } from "../../../helpers";
 import { createPaymentAndLinkWorkflow } from "../../../../../workflows/internal_payments/create-payment-and-link";
 
+const attachmentSchema = z.object({
+    file_id: z.string().min(1),
+    url: z.string().min(1),
+    filename: z.string().optional().nullable(),
+    mime_type: z.string().optional().nullable(),
+    size: z.number().nonnegative().optional().nullable(),
+    metadata: z.record(z.string(), z.any()).nullish(),
+});
+
 const requestBodySchema = z.object({
     amount: z.number().gt(0),
     payment_type: z.enum(["Bank", "Cash", "Digital_Wallet"]).optional(),
     payment_date: z.coerce.date().optional(),
     note: z.string().optional(),
     paid_to_id: z.string().optional(),
+    // #496 — file attachments (receipts/invoices) persisted to the link table.
+    attachments: z.array(attachmentSchema).optional(),
 });
 
 export async function POST(
@@ -38,7 +49,7 @@ export async function POST(
         });
     }
 
-    const { amount, payment_type, payment_date, note, paid_to_id } = validation.data;
+    const { amount, payment_type, payment_date, note, paid_to_id, attachments } = validation.data;
 
     const { result, errors } = await createPaymentAndLinkWorkflow(req.scope).run({
         input: {
@@ -51,6 +62,7 @@ export async function POST(
                 paid_to_id: paid_to_id || undefined,
             },
             inventoryOrderIds: [orderId],
+            attachments: attachments && attachments.length ? attachments : undefined,
         }
     });
 
@@ -63,6 +75,7 @@ export async function POST(
 
     return res.status(200).json({
         message: "Payment submitted successfully",
-        payment: result?.payment
+        payment: result?.payment,
+        attachments: result?.attachments ?? []
     });
 }

--- a/apps/backend/src/modules/internal_payments/lib/__tests__/normalize-attachments.unit.spec.ts
+++ b/apps/backend/src/modules/internal_payments/lib/__tests__/normalize-attachments.unit.spec.ts
@@ -1,0 +1,116 @@
+import {
+  normalizePaymentAttachments,
+  summarizePaymentAttachments,
+} from "../normalize-attachments";
+
+describe("normalizePaymentAttachments", () => {
+  it("returns [] for nullish / empty / non-array input", () => {
+    expect(normalizePaymentAttachments(undefined)).toEqual([]);
+    expect(normalizePaymentAttachments(null)).toEqual([]);
+    expect(normalizePaymentAttachments([])).toEqual([]);
+    expect(normalizePaymentAttachments("nope" as any)).toEqual([]);
+  });
+
+  it("maps a valid attachment to a persistable row", () => {
+    const rows = normalizePaymentAttachments([
+      {
+        file_id: "file_1",
+        url: "https://cdn/x.pdf",
+        filename: "receipt.pdf",
+        mime_type: "application/pdf",
+        size: 1234,
+        metadata: { source: "admin" },
+      },
+    ]);
+    expect(rows).toEqual([
+      {
+        file_id: "file_1",
+        url: "https://cdn/x.pdf",
+        filename: "receipt.pdf",
+        mime_type: "application/pdf",
+        size: 1234,
+        metadata: { source: "admin" },
+      },
+    ]);
+  });
+
+  it("drops entries missing file_id or url", () => {
+    const rows = normalizePaymentAttachments([
+      { file_id: "", url: "https://cdn/a" },
+      { file_id: "file_2", url: "" },
+      { url: "https://cdn/c" },
+      { file_id: "file_4" },
+      { file_id: "  ", url: "  " },
+    ]);
+    expect(rows).toEqual([]);
+  });
+
+  it("trims strings and nulls blank optionals", () => {
+    const rows = normalizePaymentAttachments([
+      {
+        file_id: "  file_5  ",
+        url: "  https://cdn/d  ",
+        filename: "   ",
+        mime_type: "",
+      },
+    ]);
+    expect(rows[0]).toMatchObject({
+      file_id: "file_5",
+      url: "https://cdn/d",
+      filename: null,
+      mime_type: null,
+      size: null,
+      metadata: null,
+    });
+  });
+
+  it("dedupes by file_id (first wins)", () => {
+    const rows = normalizePaymentAttachments([
+      { file_id: "dup", url: "https://cdn/first" },
+      { file_id: "dup", url: "https://cdn/second" },
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].url).toBe("https://cdn/first");
+  });
+
+  it("coerces size to a non-negative integer, else null", () => {
+    const rows = normalizePaymentAttachments([
+      { file_id: "a", url: "u", size: 10.9 },
+      { file_id: "b", url: "u", size: -5 },
+      { file_id: "c", url: "u", size: NaN },
+      { file_id: "d", url: "u", size: "100" as any },
+    ]);
+    expect(rows.map((r) => r.size)).toEqual([10, null, null, null]);
+  });
+
+  it("ignores array / non-object metadata", () => {
+    const rows = normalizePaymentAttachments([
+      { file_id: "a", url: "u", metadata: [1, 2] as any },
+      { file_id: "b", url: "u", metadata: "x" as any },
+    ]);
+    expect(rows.map((r) => r.metadata)).toEqual([null, null]);
+  });
+});
+
+describe("summarizePaymentAttachments", () => {
+  it("counts, sums size, and lists file ids", () => {
+    const summary = summarizePaymentAttachments([
+      { file_id: "a", url: "u", filename: null, mime_type: null, size: 100, metadata: null },
+      { file_id: "b", url: "u", filename: null, mime_type: null, size: null, metadata: null },
+      { file_id: "c", url: "u", filename: null, mime_type: null, size: 50, metadata: null },
+    ]);
+    expect(summary).toEqual({
+      count: 3,
+      total_size: 150,
+      file_ids: ["a", "b", "c"],
+    });
+  });
+
+  it("handles nullish", () => {
+    expect(summarizePaymentAttachments(null)).toEqual({
+      count: 0,
+      total_size: 0,
+      file_ids: [],
+    });
+  });
+});

--- a/apps/backend/src/modules/internal_payments/lib/normalize-attachments.ts
+++ b/apps/backend/src/modules/internal_payments/lib/normalize-attachments.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure helpers for #496 payment file attachments.
+ *
+ * Keep all the validation/normalization here so it can be unit-tested without
+ * booting Medusa, and reused by both the admin (`/admin/payments/link`) and
+ * partner (`/partners/inventory-orders/:orderId/submit-payment`) routes.
+ */
+
+export type PaymentAttachmentInput = {
+  file_id?: unknown;
+  url?: unknown;
+  filename?: unknown;
+  mime_type?: unknown;
+  size?: unknown;
+  metadata?: unknown;
+};
+
+export type NormalizedPaymentAttachment = {
+  file_id: string;
+  url: string;
+  filename: string | null;
+  mime_type: string | null;
+  size: number | null;
+  metadata: Record<string, any> | null;
+};
+
+const toTrimmedString = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : null;
+};
+
+const toSize = (value: unknown): number | null => {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return null;
+  }
+  return Math.floor(value);
+};
+
+/**
+ * Normalize a raw list of attachment inputs into persistable rows.
+ *
+ * - drops entries missing a usable `file_id` or `url`
+ * - dedupes by `file_id` (first wins)
+ * - trims strings, coerces `size` to a non-negative integer (else null)
+ */
+export const normalizePaymentAttachments = (
+  input: PaymentAttachmentInput[] | null | undefined
+): NormalizedPaymentAttachment[] => {
+  if (!Array.isArray(input) || !input.length) return [];
+
+  const seen = new Set<string>();
+  const rows: NormalizedPaymentAttachment[] = [];
+
+  for (const raw of input) {
+    if (!raw || typeof raw !== "object") continue;
+
+    const file_id = toTrimmedString(raw.file_id);
+    const url = toTrimmedString(raw.url);
+    if (!file_id || !url) continue;
+    if (seen.has(file_id)) continue;
+    seen.add(file_id);
+
+    rows.push({
+      file_id,
+      url,
+      filename: toTrimmedString(raw.filename),
+      mime_type: toTrimmedString(raw.mime_type),
+      size: toSize(raw.size),
+      metadata:
+        raw.metadata && typeof raw.metadata === "object" && !Array.isArray(raw.metadata)
+          ? (raw.metadata as Record<string, any>)
+          : null,
+    });
+  }
+
+  return rows;
+};
+
+export type PaymentAttachmentSummary = {
+  count: number;
+  total_size: number;
+  file_ids: string[];
+};
+
+/** Small rollup used in workflow/route responses + logs. */
+export const summarizePaymentAttachments = (
+  rows: NormalizedPaymentAttachment[] | null | undefined
+): PaymentAttachmentSummary => {
+  const list = Array.isArray(rows) ? rows : [];
+  return {
+    count: list.length,
+    total_size: list.reduce((acc, r) => acc + (r.size ?? 0), 0),
+    file_ids: list.map((r) => r.file_id),
+  };
+};

--- a/apps/backend/src/modules/internal_payments/migrations/Migration20260622103000.ts
+++ b/apps/backend/src/modules/internal_payments/migrations/Migration20260622103000.ts
@@ -1,0 +1,37 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * #496 — file↔payment link table for internal payments.
+ * New table only (safe `create table if not exists`); no column-add to an
+ * existing create-if-not-exists table.
+ */
+export class Migration20260622103000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table if not exists "internal_payment_attachment" (
+      "id" text not null,
+      "file_id" text not null,
+      "url" text not null,
+      "filename" text null,
+      "mime_type" text null,
+      "size" integer null,
+      "metadata" jsonb null,
+      "payment_id" text not null,
+      "created_at" timestamptz not null default now(),
+      "updated_at" timestamptz not null default now(),
+      "deleted_at" timestamptz null,
+      constraint "internal_payment_attachment_pkey" primary key ("id")
+    );`);
+
+    this.addSql(`create index if not exists "IDX_internal_payment_attachment_payment_id" on "internal_payment_attachment" ("payment_id") where "deleted_at" is null;`);
+    this.addSql(`create index if not exists "IDX_internal_payment_attachment_deleted_at" on "internal_payment_attachment" ("deleted_at") where "deleted_at" is null;`);
+
+    this.addSql(`alter table if exists "internal_payment_attachment" drop constraint if exists "internal_payment_attachment_payment_id_foreign";`);
+    this.addSql(`alter table if exists "internal_payment_attachment" add constraint "internal_payment_attachment_payment_id_foreign" foreign key ("payment_id") references "internal_payments" ("id") on update cascade on delete cascade;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "internal_payment_attachment" cascade;`);
+  }
+
+}

--- a/apps/backend/src/modules/internal_payments/models/payment.ts
+++ b/apps/backend/src/modules/internal_payments/models/payment.ts
@@ -1,5 +1,6 @@
 import { model } from "@medusajs/framework/utils";
 import PaymentDetails from "./payment_details";
+import PaymentAttachment from "./payment_attachment";
 
 const Payment = model.define("internal_payments", {
   id: model.id().primaryKey(),
@@ -21,6 +22,9 @@ const Payment = model.define("internal_payments", {
   
   // Relationship with PaymentDetails
   paid_to: model.belongsTo(() => PaymentDetails, { mappedBy: "payments" }).nullable(),
+
+  // File attachments (receipts, invoices, references) — see payment_attachment.ts (#496)
+  attachments: model.hasMany(() => PaymentAttachment, { mappedBy: "payment" }),
 });
 
 export default Payment;

--- a/apps/backend/src/modules/internal_payments/models/payment_attachment.ts
+++ b/apps/backend/src/modules/internal_payments/models/payment_attachment.ts
@@ -1,0 +1,25 @@
+import { model } from "@medusajs/framework/utils";
+import Payment from "./payment";
+
+/**
+ * PaymentAttachment is the file↔payment link table for internal payments.
+ *
+ * Decision (#496): attachments live in a dedicated link table — NOT in
+ * `internal_payments.metadata` — because Medusa rewrites the whole metadata
+ * blob on every update, which would silently drop previously-attached file
+ * refs. Each row references an uploaded file (file module id + url) and the
+ * owning payment.
+ */
+const PaymentAttachment = model.define("internal_payment_attachment", {
+  id: model.id().primaryKey(),
+  // File module reference (from `sdk.admin.upload` / Modules.FILE)
+  file_id: model.text(),
+  url: model.text(),
+  filename: model.text().nullable(),
+  mime_type: model.text().nullable(),
+  size: model.number().nullable(),
+  metadata: model.json().nullable(),
+  payment: model.belongsTo(() => Payment, { mappedBy: "attachments" }),
+});
+
+export default PaymentAttachment;

--- a/apps/backend/src/modules/internal_payments/service.ts
+++ b/apps/backend/src/modules/internal_payments/service.ts
@@ -1,10 +1,12 @@
 import { MedusaService } from "@medusajs/framework/utils";
 import Payment from "./models/payment";
 import PaymentDetail from "./models/payment_details";
+import PaymentAttachment from "./models/payment_attachment";
 
 class InternalPaymentService extends MedusaService({
   Payment,
   PaymentDetail,
+  PaymentAttachment,
 }) {
   constructor() {
     super(...arguments)

--- a/apps/backend/src/workflows/internal_payments/create-payment-and-link.ts
+++ b/apps/backend/src/workflows/internal_payments/create-payment-and-link.ts
@@ -15,6 +15,10 @@ import { PERSON_MODULE } from "../../modules/person"
 import { PARTNER_MODULE } from "../../modules/partner"
 import { ORDER_INVENTORY_MODULE } from "../../modules/inventory_orders"
 import InternalPaymentService from "../../modules/internal_payments/service"
+import {
+  normalizePaymentAttachments,
+  type PaymentAttachmentInput,
+} from "../../modules/internal_payments/lib/normalize-attachments"
 
 export type CreatePaymentAndLinkInput = {
   payment: {
@@ -28,6 +32,8 @@ export type CreatePaymentAndLinkInput = {
   personIds?: string[]
   partnerIds?: string[]
   inventoryOrderIds?: string[]
+  // #496 — file attachments (receipts/invoices) persisted to the link table.
+  attachments?: PaymentAttachmentInput[]
 }
 
 export const createPaymentStep = createStep(
@@ -148,6 +154,34 @@ export const linkPaymentToInventoryOrdersStep = createStep(
   }
 )
 
+export const createPaymentAttachmentsStep = createStep(
+  "create-payment-attachments-step",
+  async (
+    input: { payment_id: string; attachments: PaymentAttachmentInput[] },
+    { container }
+  ) => {
+    const rows = normalizePaymentAttachments(input.attachments)
+    if (!rows.length) {
+      return new StepResponse([], [])
+    }
+
+    const service: InternalPaymentService = container.resolve(INTERNAL_PAYMENTS_MODULE)
+    const created = await service.createPaymentAttachments(
+      rows.map((row) => ({ ...row, payment_id: input.payment_id }))
+    )
+    const createdList = Array.isArray(created) ? created : [created]
+    return new StepResponse(
+      createdList,
+      createdList.map((a: any) => a.id)
+    )
+  },
+  async (ids: string[], { container }) => {
+    if (!ids?.length) return
+    const service: InternalPaymentService = container.resolve(INTERNAL_PAYMENTS_MODULE)
+    await service.deletePaymentAttachments(ids)
+  }
+)
+
 export const createPaymentAndLinkWorkflow = createWorkflow(
   "create-payment-and-link",
   (input: CreatePaymentAndLinkInput) => {
@@ -174,6 +208,13 @@ export const createPaymentAndLinkWorkflow = createWorkflow(
       })
     )
 
-    return new WorkflowResponse({ payment, personLinks, partnerLinks, inventoryOrderLinks })
+    const attachments = when(input, (i) => Boolean(i.attachments && i.attachments.length)).then(() =>
+      createPaymentAttachmentsStep({
+        payment_id: payment.id,
+        attachments: input.attachments as PaymentAttachmentInput[],
+      })
+    )
+
+    return new WorkflowResponse({ payment, personLinks, partnerLinks, inventoryOrderLinks, attachments })
   }
 )


### PR DESCRIPTION
Closes #496.

## What
Adds file/PDF attachments (receipts, invoices, references) to inventory-order payments — surfaced on both the admin add-payment form and the partner submit-payment route.

Per the **locked decision (2026-06-21)** on #496, attachments are stored in a **proper file↔payment link table**, NOT in `internal_payments.metadata` (Medusa rewrites the whole metadata blob on update, which would silently drop previously-attached refs).

## Backend
- **New model** `internal_payment_attachment` (`models/payment_attachment.ts`): `belongsTo` Payment (`payment_id` FK) + `file_id`/`url`/`filename`/`mime_type`/`size`/`metadata`. Payment gains a `hasMany attachments`.
- **Migration** `Migration20260622103000` — new table only (safe `create table if not exists`, FK to `internal_payments` with `on delete cascade`).
- `PaymentAttachment` registered on `InternalPaymentService`.
- **Pure helper** `lib/normalize-attachments.ts` (`normalizePaymentAttachments`/`summarizePaymentAttachments`): dedupe by `file_id`, drop entries missing `file_id`/`url`, trim, coerce `size` to non-negative int. Reused by both routes.
- `createPaymentAndLinkWorkflow` gains a compensatable `createPaymentAttachmentsStep` gated behind `when(attachments?.length)`.
- `attachments[]` accepted on `POST /admin/payments/link` and `POST /partners/inventory-orders/:orderId/submit-payment`.

## Admin UI
- **Add Payment drawer**: `FileUpload` → `sdk.admin.upload` → collects `{file_id,url,filename,mime_type,size}` → sends as `attachments`. Removable chips before submit.
- **Inventory-order Payments section**: renders attachment chips (open in new tab) under each payment row; detail query gains `+internal_payments.attachments.*`.

## Tests / verification
- 9 unit (`normalize-attachments.unit.spec.ts`) + 2 integration (`payment-attachments-api.spec.ts`) green.
- Live-verified against dev: create+link with attachments persists & dedupes; read path resolves through `inventory_order → internal_payments → attachments`.
- **Playwright-verified** both admin surfaces (screenshots): attachment chip in Payments section + "Attachments" upload dropzone in Add Payment drawer.

## Notes / watch-outs
- Migration is additive (new table). Prod auto-deploys on merge; `db:migrate` runs as part of deploy.
- Partner submit-payment now returns `attachments` in its response.
- No `.snapshot-*.json` (hand-written migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)