### PR TITLE
feat(#613): warn on non-@cf Cloudflare AI model (free Workers AI vs paid Gateway)

### DIFF
--- a/apps/backend/src/admin/components/social-platforms/__tests__/cloudflare-model-warning.unit.spec.ts
+++ b/apps/backend/src/admin/components/social-platforms/__tests__/cloudflare-model-warning.unit.spec.ts
@@ -1,0 +1,51 @@
+import {
+  CF_FREE_MODEL_EXAMPLE,
+  CF_NATIVE_PREFIX,
+  getCloudflareModelWarning,
+} from "../cloudflare-model-warning"
+
+describe("getCloudflareModelWarning", () => {
+  it("returns null for non-cloudflare providers regardless of model", () => {
+    expect(getCloudflareModelWarning("openrouter", "minimax/m3")).toBeNull()
+    expect(getCloudflareModelWarning("dashscope", "qwen-turbo")).toBeNull()
+    expect(getCloudflareModelWarning("custom", "anything")).toBeNull()
+    expect(getCloudflareModelWarning(null, "minimax/m3")).toBeNull()
+    expect(getCloudflareModelWarning(undefined, "minimax/m3")).toBeNull()
+  })
+
+  it("returns null for cloudflare with an empty / whitespace model (provider default is used)", () => {
+    expect(getCloudflareModelWarning("cloudflare", "")).toBeNull()
+    expect(getCloudflareModelWarning("cloudflare", "   ")).toBeNull()
+    expect(getCloudflareModelWarning("cloudflare", null)).toBeNull()
+    expect(getCloudflareModelWarning("cloudflare", undefined)).toBeNull()
+  })
+
+  it("returns null for cloudflare with a native @cf/ model", () => {
+    expect(getCloudflareModelWarning("cloudflare", CF_FREE_MODEL_EXAMPLE)).toBeNull()
+    expect(
+      getCloudflareModelWarning("cloudflare", "@cf/baai/bge-base-en-v1.5")
+    ).toBeNull()
+    expect(
+      getCloudflareModelWarning("cloudflare", "@cf/meta/llama-3.3-70b-instruct-fp8-fast")
+    ).toBeNull()
+  })
+
+  it("trims surrounding whitespace before the @cf/ check", () => {
+    expect(
+      getCloudflareModelWarning("cloudflare", `  ${CF_FREE_MODEL_EXAMPLE}  `)
+    ).toBeNull()
+  })
+
+  it("warns for cloudflare with a non-native model id", () => {
+    const warning = getCloudflareModelWarning("cloudflare", "minimax/m3")
+    expect(warning).not.toBeNull()
+    expect(warning).toContain("minimax/m3")
+    expect(warning).toContain(CF_NATIVE_PREFIX)
+    expect(warning).toContain("Insufficient balance")
+  })
+
+  it("warns for a model that merely contains but does not start with @cf/", () => {
+    expect(getCloudflareModelWarning("cloudflare", "vendor/@cf/x")).not.toBeNull()
+    expect(getCloudflareModelWarning("cloudflare", "cf/meta/llama")).not.toBeNull()
+  })
+})

--- a/apps/backend/src/admin/components/social-platforms/cloudflare-model-warning.ts
+++ b/apps/backend/src/admin/components/social-platforms/cloudflare-model-warning.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure helper — Cloudflare Workers AI free-tier model guard.
+ *
+ * Cloudflare exposes two AI surfaces behind the same OpenAI-compatible shape:
+ *
+ *   - **Workers AI (free)** — native models prefixed `@cf/…`
+ *     (e.g. `@cf/meta/llama-3.1-8b-instruct`). These run on a free daily
+ *     Neuron allocation on the `…/accounts/<id>/ai/v1` endpoint. No gateway
+ *     balance / BYOK required.
+ *   - **AI Gateway (paid / BYOK)** — any non-`@cf/…` model id (e.g.
+ *     `minimax/m3`, `openai/gpt-4o`). These route through the paid gateway and
+ *     fail with `Insufficient balance; add money to your gateway or use BYOK`
+ *     (code 2021) unless a balance / BYOK key is configured.
+ *
+ * So a `cloudflare` AI platform whose `default_model` is a non-`@cf/…` id will
+ * very likely fail at runtime on free credits. This helper surfaces that as an
+ * admin warning. Kept pure (no React) so it's unit-testable and shareable by
+ * the create form and the platform detail view.
+ *
+ * Surfaced by #613 (live CF test on the #589 digest AI provider).
+ */
+
+export const CF_NATIVE_PREFIX = "@cf/"
+
+export const CF_FREE_MODEL_EXAMPLE = "@cf/meta/llama-3.1-8b-instruct"
+
+/**
+ * Returns a warning string when a Cloudflare AI platform's `default_model` is
+ * set to a non-native id (one that won't run on the free Workers AI
+ * allocation), or `null` when there's nothing to warn about:
+ *   - provider is not `cloudflare`        → null (not our concern)
+ *   - model is empty / whitespace         → null (provider default `@cf/…` is used)
+ *   - model already starts with `@cf/`    → null (native, free)
+ */
+export const getCloudflareModelWarning = (
+  providerType: string | null | undefined,
+  defaultModel: string | null | undefined
+): string | null => {
+  if (providerType !== "cloudflare") {
+    return null
+  }
+  const model = (defaultModel ?? "").trim()
+  if (model.length === 0) {
+    return null
+  }
+  if (model.startsWith(CF_NATIVE_PREFIX)) {
+    return null
+  }
+  return (
+    `“${model}” is not a native Workers AI model. Cloudflare runs native ` +
+    `${CF_NATIVE_PREFIX}… models on the free daily allocation; other ids route ` +
+    `through the paid AI Gateway / BYOK path and usually fail with ` +
+    `“Insufficient balance”. Use a ${CF_NATIVE_PREFIX}… model (e.g. ` +
+    `${CF_FREE_MODEL_EXAMPLE}) for free usage.`
+  )
+}

--- a/apps/backend/src/admin/components/social-platforms/create-ai-platform-component.tsx
+++ b/apps/backend/src/admin/components/social-platforms/create-ai-platform-component.tsx
@@ -1,4 +1,4 @@
-import { Button, Heading, Input, Select, Switch, Text, toast } from "@medusajs/ui"
+import { Alert, Button, Heading, Input, Select, Switch, Text, toast } from "@medusajs/ui"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { z } from "@medusajs/framework/zod"
@@ -7,6 +7,7 @@ import { KeyboundForm } from "../utilitites/key-bound-form"
 import { Form } from "../common/form"
 import { RouteFocusModal } from "../modal/route-focus-modal"
 import { useRouteModal } from "../modal/use-route-modal"
+import { getCloudflareModelWarning } from "./cloudflare-model-warning"
 
 /**
  * Tailored "Create AI provider" form.
@@ -125,6 +126,11 @@ export const CreateAiPlatformComponent = () => {
   })
 
   const providerType = form.watch("provider_type")
+  const defaultModel = form.watch("default_model")
+  const cloudflareModelWarning = getCloudflareModelWarning(
+    providerType,
+    defaultModel
+  )
 
   const onSubmit = form.handleSubmit(async (values) => {
     const apiConfig: Record<string, unknown> = {
@@ -346,6 +352,15 @@ export const CreateAiPlatformComponent = () => {
                   <Form.Hint>
                     Optional. If empty, a provider-specific default is used.
                   </Form.Hint>
+                  {cloudflareModelWarning && (
+                    <Alert
+                      variant="warning"
+                      className="mt-2"
+                      data-testid="cloudflare-model-warning"
+                    >
+                      {cloudflareModelWarning}
+                    </Alert>
+                  )}
                   <Form.ErrorMessage />
                 </Form.Item>
               )}

--- a/apps/backend/src/admin/components/social-platforms/social-platform-general-section.tsx
+++ b/apps/backend/src/admin/components/social-platforms/social-platform-general-section.tsx
@@ -7,8 +7,9 @@ import {
   useSetupResendWebhook,
 } from "../../hooks/api/social-platforms";
 import { CommonSection, CommonField } from "../common/section-views";
-import { usePrompt, toast } from "@medusajs/ui";
+import { usePrompt, toast, Alert } from "@medusajs/ui";
 import { useNavigate } from "react-router-dom";
+import { getCloudflareModelWarning } from "./cloudflare-model-warning";
 
 export const SocialPlatformGeneralSection = ({ platform }: { platform: AdminSocialPlatform }) => {
   const { t } = useTranslation();
@@ -25,6 +26,16 @@ export const SocialPlatformGeneralSection = ({ platform }: { platform: AdminSoci
   const isPayment = platform.category === "payment";
   const isShipping = platform.category === "shipping";
   const providerType = apiConfig?.provider as string | undefined;
+
+  // AI platforms keep their provider_type in metadata (not api_config.provider)
+  // and the chosen chat/embed model in api_config.default_model. Warn when a
+  // Cloudflare AI platform points at a non-native (non-`@cf/…`) model — it
+  // routes through the paid AI Gateway / BYOK path and fails on free credits.
+  const metadata = platform.metadata as Record<string, any> | null;
+  const cloudflareModelWarning = getCloudflareModelWarning(
+    metadata?.provider_type as string | undefined,
+    apiConfig?.default_model as string | undefined
+  );
 
   const handleDelete = async () => {
     const confirmation = await prompt({
@@ -253,11 +264,21 @@ export const SocialPlatformGeneralSection = ({ platform }: { platform: AdminSoci
   }
 
   return (
-    <CommonSection
-      title={t("socialPlatform.general.title", "General Information")}
-      description={t("socialPlatform.general.description", "Basic details of the social platform.")}
-      fields={generalFields}
-      actionGroups={actionGroups}
-    />
+    <div className="flex flex-col gap-y-3">
+      {cloudflareModelWarning && (
+        <Alert
+          variant="warning"
+          data-testid="cloudflare-model-warning"
+        >
+          {cloudflareModelWarning}
+        </Alert>
+      )}
+      <CommonSection
+        title={t("socialPlatform.general.title", "General Information")}
+        description={t("socialPlatform.general.description", "Basic details of the social platform.")}
+        fields={generalFields}
+        actionGroups={actionGroups}
+      />
+    </div>
   );
 };

--- a/apps/docs/notes/589_SOCIALS_AI_PROVIDER_ANALYSIS.md
+++ b/apps/docs/notes/589_SOCIALS_AI_PROVIDER_ANALYSIS.md
@@ -112,6 +112,15 @@ A `resolveDigestAiProvider(container)` helper that replaces the hardcoded `creat
 
 ---
 
+## Cloudflare: Workers AI (free) vs AI Gateway (paid / BYOK) — #613
+
+The `cloudflare` provider derives base URL `https://api.cloudflare.com/client/v4/accounts/<account_id>/ai/v1` (`apps/backend/src/mastra/services/ai-platforms.ts` ~L207), which is the **Workers AI** OpenAI-compatible endpoint. Whether a call is free depends entirely on the **model id**:
+
+- **Free — Workers AI native models** (`@cf/…`, e.g. `@cf/meta/llama-3.1-8b-instruct`, `@cf/meta/llama-3.3-70b-instruct-fp8-fast`, `@cf/baai/bge-base-en-v1.5` for embeddings). These run on a **free daily Neuron allocation** — no gateway balance, no BYOK. `PROVIDER_DEFAULTS.cloudflare.defaultModelHint` is already `@cf/meta/llama-3.1-8b-instruct`.
+- **Paid — any non-`@cf/…` model id** (e.g. `minimax/m3`, `openai/gpt-4o`). These route through the **paid AI Gateway / BYOK** path and fail with `Insufficient balance; add money to your gateway or use BYOK` (code 2021) unless a balance / BYOK key is configured. This was the live failure that surfaced #613 (the `ai_digest_summary` CF platform's `default_model` was `minimax/m3`).
+
+**Admin guard (#613):** the External Platforms admin warns when a `cloudflare` AI platform's `default_model` is set to a non-`@cf/…` id — both live in the Create AI provider form (under the Default model field) and on the platform detail page. The check is the pure helper `getCloudflareModelWarning(providerType, defaultModel)` in `apps/backend/src/admin/components/social-platforms/cloudflare-model-warning.ts` (empty model → no warning, provider default `@cf/…` is used). **Setting the prod `ai_digest_summary` platform's `default_model` to a `@cf/…` model is an operator action** (admin-API authored, not seeded).
+
 ## Gotchas
 
 1. **No `case "ai"` in `buildApiConfig`**: The admin form's `api-config.ts:buildApiConfig()` has no `case "ai"` branch. AI platforms are created by the backfill script (`apps/backend/src/scripts/backfill-ai-platforms-from-env.ts`) or manually via the admin External Platforms UI, which stores `api_config` as a raw JSON blob. Adding a new role via the UI requires the admin to set `metadata.role` and `metadata.provider_type` manually. There is no admin UI dropdown for the digest-summary role yet.


### PR DESCRIPTION
Closes part of #613 (admin warning + docs; prod model change + provider sub-type split are out of scope per run).

## What
When a `cloudflare` AI External Platform's `default_model` is set to a **non-native** id (anything not starting with `@cf/`), the admin now warns that it will hit the **paid AI Gateway / BYOK** path and likely fail with `Insufficient balance` (code 2021). Native `@cf/…` Workers AI models run on the **free daily allocation**. This is the live failure that surfaced #613 on the #589 digest AI provider (`minimax/m3`).

## Changes
- **Pure helper** `cloudflare-model-warning.ts` → `getCloudflareModelWarning(providerType, defaultModel)`: returns a warning string only for `provider=cloudflare` + non-empty, non-`@cf/` model (empty → provider default `@cf/…` used; trims whitespace). **6 unit tests.**
- **Create AI provider form** — live `Alert` (warning) under the Default model field as you type.
- **Platform detail General section** — `Alert` banner for existing CF platforms (AI `provider_type` is in `metadata`, model in `api_config.default_model`).
- **Docs** — free-vs-paid Cloudflare section in `589_SOCIALS_AI_PROVIDER_ANALYSIS.md`.

## Out of scope (per run / issue)
- Setting the prod `ai_digest_summary` CF platform's `default_model` to `@cf/…` — **operator action** (admin-API authored, not seeded).
- Optional `cloudflare_workers_ai` vs `cloudflare_ai_gateway` provider sub-type split.

## Verify
- Unit: `TEST_TYPE=unit ... jest --testPathPattern=cloudflare-model-warning` → 6/6 green.
- Typecheck: 0 new TS errors in changed files.
- **Playwright (live admin :9000):** selected Cloudflare + typed `minimax/m3` → warning appears; switched to `@cf/meta/llama-3.1-8b-instruct` → warning disappears. Screenshot captured (orange Alert with full guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)