### PR TITLE
feat(#623): per-order partner fee on the order view (admin + partner-ui)

### DIFF
--- a/apps/backend/integration-tests/http/order-partner-fee-api.spec.ts
+++ b/apps/backend/integration-tests/http/order-partner-fee-api.spec.ts
@@ -1,0 +1,191 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { IOrderModuleService } from "@medusajs/types"
+
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import orderPlacedAccrueFeeHandler from "../../src/subscribers/order-placed-accrue-fee"
+import { PARTNER_MODULE } from "../../src/modules/partner"
+
+jest.setTimeout(60 * 1000)
+
+/**
+ * #623 (follow-up to #336) — per-order partner fee read routes.
+ *   GET /admin/orders/:id/partner-fee
+ *   GET /partners/orders/:id/partner-fee  (ownership-scoped)
+ */
+setupSharedTestSuite(() => {
+  describe("GET .../orders/:id/partner-fee", () => {
+    let adminHeaders: { headers: Record<string, string> }
+
+    beforeAll(async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+    })
+
+    async function createPartner(unique: number) {
+      const { api } = getSharedTestEnv()
+      const email = `ofee-${unique}@jyt.test`
+      const password = "supersecret"
+      await api.post("/auth/partner/emailpass/register", { email, password })
+      const login1 = await api.post("/auth/partner/emailpass", { email, password })
+      let headers = { Authorization: `Bearer ${login1.data.token}` }
+      const res = await api.post(
+        "/partners",
+        {
+          name: `OFee ${unique}`,
+          handle: `ofee-${unique}`,
+          admin: { email, first_name: "Test", last_name: "Partner" },
+        },
+        { headers }
+      )
+      expect(res.status).toBe(200)
+      // Re-login so the token carries the partner association.
+      const login2 = await api.post("/auth/partner/emailpass", { email, password })
+      headers = { Authorization: `Bearer ${login2.data.token}` }
+
+      // The order-ownership guard requires the partner to have a store
+      // (getPartnerStore). Provision one (mirrors orders-unification tests).
+      await api.post(
+        "/partners/stores",
+        {
+          store: {
+            name: `OFee Store ${unique}`,
+            supported_currencies: [{ currency_code: "usd", is_default: true }],
+          },
+          sales_channel: { name: `OFee Channel ${unique}`, description: "Default" },
+          region: { name: `OFee Region ${unique}`, currency_code: "usd", countries: ["us"] },
+          location: {
+            name: `OFee Warehouse ${unique}`,
+            address: {
+              address_1: "1 Mill Road",
+              city: "Austin",
+              postal_code: "73301",
+              country_code: "US",
+            },
+          },
+        },
+        { headers }
+      )
+
+      return { partnerId: res.data.partner.id as string, headers }
+    }
+
+    async function createOrder(unique: number, currency = "usd") {
+      const container = getSharedTestEnv().getContainer()
+      const orderService = container.resolve(Modules.ORDER) as IOrderModuleService
+      return (await orderService.createOrders({
+        currency_code: currency,
+        email: `ofee-order-${unique}@jyt.test`,
+        items: [
+          { title: "Line A", quantity: 2, unit_price: 1000 },
+          { title: "Line B", quantity: 1, unit_price: 500 },
+        ],
+      } as any)) as any
+    }
+
+    async function linkPartnerOrder(partnerId: string, orderId: string) {
+      const container = getSharedTestEnv().getContainer()
+      const remoteLink: any = container.resolve(ContainerRegistrationKeys.LINK)
+      await remoteLink.create([
+        {
+          [PARTNER_MODULE]: { partner_id: partnerId },
+          [Modules.ORDER]: { order_id: orderId },
+          data: { partner_id: partnerId, order_id: orderId },
+        },
+      ])
+    }
+
+    it("admin route returns the accrued fee + display for a partner order", async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      const container = getContainer()
+      const unique = Date.now()
+
+      const { partnerId } = await createPartner(unique)
+      const order = await createOrder(unique)
+      await linkPartnerOrder(partnerId, order.id)
+      await orderPlacedAccrueFeeHandler({
+        event: { data: { id: order.id } },
+        container,
+      } as any)
+
+      const res = await api.get(
+        `/admin/orders/${order.id}/partner-fee`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.order_id).toBe(order.id)
+      expect(res.data.fee).toBeTruthy()
+      expect(res.data.fee.order_id).toBe(order.id)
+      expect(res.data.fee.partner_id).toBe(partnerId)
+      // display contract
+      expect(res.data.display).toMatchObject({
+        order_id: order.id,
+        status: "accrued",
+        fee_basis: "percentage",
+        is_collectible: true,
+        currency_code: "USD",
+      })
+      expect(res.data.display.rate_label).toMatch(/%$/)
+      expect(res.data.display.fee_amount).toBeGreaterThan(0)
+    })
+
+    it("admin route returns null fee for a retail order (no fee accrued)", async () => {
+      const { api } = getSharedTestEnv()
+      const unique = Date.now() + 1
+      const order = await createOrder(unique)
+
+      const res = await api.get(
+        `/admin/orders/${order.id}/partner-fee`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.fee).toBeNull()
+      expect(res.data.display).toBeNull()
+    })
+
+    it("partner route returns the fee for an order the partner owns", async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      const container = getContainer()
+      const unique = Date.now() + 2
+
+      const { partnerId, headers } = await createPartner(unique)
+      const order = await createOrder(unique)
+      await linkPartnerOrder(partnerId, order.id)
+      await orderPlacedAccrueFeeHandler({
+        event: { data: { id: order.id } },
+        container,
+      } as any)
+
+      const res = await api.get(
+        `/partners/orders/${order.id}/partner-fee`,
+        { headers }
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.fee.partner_id).toBe(partnerId)
+      expect(res.data.display.is_collectible).toBe(true)
+    })
+
+    it("partner route does NOT leak another partner's order fee (ownership)", async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      const container = getContainer()
+      const unique = Date.now() + 3
+
+      const owner = await createPartner(unique)
+      const intruder = await createPartner(unique + 1)
+      const order = await createOrder(unique)
+      await linkPartnerOrder(owner.partnerId, order.id)
+      await orderPlacedAccrueFeeHandler({
+        event: { data: { id: order.id } },
+        container,
+      } as any)
+
+      // Intruder (has their own store, but doesn't own this order) → 404.
+      await expect(
+        api.get(`/partners/orders/${order.id}/partner-fee`, {
+          headers: intruder.headers,
+        })
+      ).rejects.toMatchObject({ response: { status: 404 } })
+    })
+  })
+})

--- a/apps/backend/src/admin/widgets/order-partner-fee.tsx
+++ b/apps/backend/src/admin/widgets/order-partner-fee.tsx
@@ -1,0 +1,126 @@
+import { defineWidgetConfig } from "@medusajs/admin-sdk"
+import { Container, Heading, Text, StatusBadge } from "@medusajs/ui"
+import { DetailWidgetProps } from "@medusajs/framework/types"
+import { useQuery } from "@tanstack/react-query"
+import { sdk } from "../lib/config"
+
+// #623 (follow-up to #336): show the platform commission accrued for THIS order
+// on the admin order detail page. The partner detail page already shows the
+// aggregate ledger (`/admin/partners/:id/fees`); this surfaces the single
+// per-order fee from `/admin/orders/:id/partner-fee`. Retail orders (no fee)
+// render nothing — no empty card.
+
+type AdminOrder = { id: string }
+
+type DescribedFee = {
+  order_id: string
+  status: string
+  fee_basis: "percentage" | "flat"
+  rate_label: string
+  fee_amount: number
+  order_total: number
+  currency_code: string
+  is_collectible: boolean
+}
+
+type PartnerFeeResponse = {
+  order_id: string
+  fee: unknown | null
+  display: DescribedFee | null
+}
+
+const STATUS_COLOR: Record<string, "green" | "orange" | "grey" | "red"> = {
+  accrued: "orange",
+  invoiced: "green",
+  waived: "grey",
+  reversed: "red",
+}
+
+function formatMoney(amount: number, currency: string) {
+  const safe = Number.isFinite(amount) ? amount : 0
+  try {
+    return new Intl.NumberFormat("en-IN", {
+      style: "currency",
+      currency: (currency || "INR").toUpperCase(),
+      maximumFractionDigits: 2,
+    }).format(safe)
+  } catch {
+    return `${safe.toFixed(2)} ${(currency || "").toUpperCase()}`
+  }
+}
+
+const OrderPartnerFeeWidget = ({ data: order }: DetailWidgetProps<AdminOrder>) => {
+  const { data, isLoading } = useQuery({
+    queryFn: () =>
+      sdk.client.fetch<PartnerFeeResponse>(
+        `/admin/orders/${order.id}/partner-fee`,
+        { method: "GET" }
+      ),
+    queryKey: ["order-partner-fee", order.id],
+  })
+
+  // Retail order / never accrued → nothing to show.
+  if (!isLoading && !data?.display) {
+    return null
+  }
+
+  const fee = data?.display
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div>
+          <Heading level="h2">Platform commission</Heading>
+          <Text size="small" leading="compact" className="text-ui-fg-subtle">
+            The platform's cut on this order, deducted from the partner payout.
+          </Text>
+        </div>
+        {fee ? (
+          <StatusBadge color={STATUS_COLOR[fee.status] ?? "grey"}>
+            {fee.status}
+          </StatusBadge>
+        ) : null}
+      </div>
+
+      {isLoading || !fee ? (
+        <div className="px-6 py-4">
+          <div className="bg-ui-bg-subtle h-4 w-32 animate-pulse rounded" />
+          <div className="bg-ui-bg-subtle mt-2 h-4 w-24 animate-pulse rounded" />
+        </div>
+      ) : (
+        <div className="flex flex-col gap-y-3 px-6 py-4">
+          <div className="flex items-center justify-between">
+            <Text size="small" className="text-ui-fg-subtle">
+              Rate
+            </Text>
+            <Text size="small" weight="plus">
+              {fee.rate_label}
+            </Text>
+          </div>
+          <div className="flex items-center justify-between">
+            <Text size="small" className="text-ui-fg-subtle">
+              Commission
+            </Text>
+            <Text size="small" weight="plus">
+              {formatMoney(fee.fee_amount, fee.currency_code)}
+            </Text>
+          </div>
+          <div className="flex items-center justify-between">
+            <Text size="small" className="text-ui-fg-subtle">
+              Order total
+            </Text>
+            <Text size="small" className="text-ui-fg-subtle">
+              {formatMoney(fee.order_total, fee.currency_code)}
+            </Text>
+          </div>
+        </div>
+      )}
+    </Container>
+  )
+}
+
+export const config = defineWidgetConfig({
+  zone: "order.details.side.after",
+})
+
+export default OrderPartnerFeeWidget

--- a/apps/backend/src/api/admin/orders/[id]/partner-fee/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/partner-fee/route.ts
@@ -1,0 +1,31 @@
+/**
+ * @file Admin API route for a single order's partner fee (commission).
+ * @description Read-only — the platform commission accrued for ONE order (#623,
+ * follow-up to #336). Surfaces the per-order fee on the admin order detail page
+ * (the partner detail page already shows the aggregate ledger via
+ * `/admin/partners/:id/fees`). Returns `fee: null` for a retail order that never
+ * accrued a fee. Fees are accrued/reversed by the order.placed / order.canceled
+ * subscribers — never mutated here.
+ * @module API/Admin/Orders/PartnerFee
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { PARTNER_BILLING_MODULE } from "../../../../../modules/partner_billing"
+import { describeFee } from "../../../../../modules/partner_billing/lib/describe-fee"
+
+/**
+ * GET /admin/orders/:id/partner-fee
+ * → { order_id, fee: PartnerFee | null, display: DescribedFee | null }
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const orderId = req.params.id
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const billing: any = req.scope.resolve(PARTNER_BILLING_MODULE)
+  const fee = await billing.findFeeForOrder(orderId)
+
+  return res.status(200).json({
+    order_id: orderId,
+    fee: fee || null,
+    display: describeFee(fee),
+  })
+}

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -4132,6 +4132,17 @@ export default defineMiddlewares({
       ],
     },
     {
+      // #623 — per-order partner fee (commission). Read-only; no field
+      // selection, so no validateAndTransformQuery. Ownership is enforced in
+      // the route via validatePartnerOrderOwnership.
+      matcher: "/partners/orders/:id/partner-fee",
+      method: ["GET"],
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
+    {
       matcher: "/partners/orders/:id/cancel",
       method: "POST",
       middlewares: [

--- a/apps/backend/src/api/partners/orders/[id]/partner-fee/route.ts
+++ b/apps/backend/src/api/partners/orders/[id]/partner-fee/route.ts
@@ -1,0 +1,35 @@
+/**
+ * @file Partner API route for a single order's partner fee (commission).
+ * @description Mirrors `GET /admin/orders/:id/partner-fee`, scoped to the
+ * authenticated partner so they can see the platform commission deducted on
+ * each order they fulfil (#623, follow-up to #336). Ownership is asserted first
+ * via `validatePartnerOrderOwnership` — a partner can never read a fee for an
+ * order that isn't theirs (no cross-tenant leak). Read-only.
+ * @module API/Partners/Orders/PartnerFee
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { validatePartnerOrderOwnership } from "../../../helpers"
+import { PARTNER_BILLING_MODULE } from "../../../../../modules/partner_billing"
+import { describeFee } from "../../../../../modules/partner_billing/lib/describe-fee"
+
+/**
+ * GET /partners/orders/:id/partner-fee
+ * → { order_id, fee: PartnerFee | null, display: DescribedFee | null }
+ */
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  // Throws (403/404) if the authenticated partner does not own this order.
+  await validatePartnerOrderOwnership(req.auth_context, req.params.id, req.scope)
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const billing: any = req.scope.resolve(PARTNER_BILLING_MODULE)
+  const fee = await billing.findFeeForOrder(req.params.id)
+
+  return res.status(200).json({
+    order_id: req.params.id,
+    fee: fee || null,
+    display: describeFee(fee),
+  })
+}

--- a/apps/backend/src/modules/partner_billing/lib/__tests__/describe-fee.unit.spec.ts
+++ b/apps/backend/src/modules/partner_billing/lib/__tests__/describe-fee.unit.spec.ts
@@ -1,0 +1,78 @@
+import { describeFee, formatFeeRate } from "../describe-fee"
+
+describe("formatFeeRate (#623)", () => {
+  it("renders percentage basis points as a percent (2 dp)", () => {
+    expect(formatFeeRate("percentage", 200)).toBe("2.00%")
+    expect(formatFeeRate("percentage", 250)).toBe("2.50%")
+    expect(formatFeeRate("percentage", 0)).toBe("0.00%")
+    expect(formatFeeRate("percentage", "175")).toBe("1.75%")
+  })
+
+  it("renders a flat fee as an amount + currency", () => {
+    expect(formatFeeRate("flat", 50, "inr")).toBe("50.00 INR")
+    expect(formatFeeRate("flat", "12.5", "usd")).toBe("12.50 USD")
+  })
+
+  it("coerces non-finite rates to 0", () => {
+    expect(formatFeeRate("percentage", null)).toBe("0.00%")
+    expect(formatFeeRate("percentage", undefined)).toBe("0.00%")
+    expect(formatFeeRate("percentage", "nope")).toBe("0.00%")
+  })
+})
+
+describe("describeFee (#623)", () => {
+  it("returns null for nullish / order-less rows", () => {
+    expect(describeFee(null)).toBeNull()
+    expect(describeFee(undefined)).toBeNull()
+    expect(describeFee({})).toBeNull()
+    expect(describeFee({ fee_amount: 100 })).toBeNull()
+  })
+
+  it("shapes a percentage fee into a display object", () => {
+    expect(
+      describeFee({
+        order_id: "order_1",
+        currency_code: "inr",
+        fee_basis: "percentage",
+        fee_rate: 200,
+        fee_amount: "199.99",
+        order_total: "9999.50",
+        status: "accrued",
+      })
+    ).toEqual({
+      order_id: "order_1",
+      status: "accrued",
+      fee_basis: "percentage",
+      rate_label: "2.00%",
+      fee_amount: 199.99,
+      order_total: 9999.5,
+      currency_code: "INR",
+      is_collectible: true,
+    })
+  })
+
+  it("defaults basis to percentage and status to accrued", () => {
+    const d = describeFee({ order_id: "o", fee_rate: 200 })!
+    expect(d.fee_basis).toBe("percentage")
+    expect(d.status).toBe("accrued")
+    expect(d.currency_code).toBe("")
+  })
+
+  it("marks reversed / waived fees as not collectible", () => {
+    expect(describeFee({ order_id: "o", status: "reversed" })!.is_collectible).toBe(false)
+    expect(describeFee({ order_id: "o", status: "waived" })!.is_collectible).toBe(false)
+    expect(describeFee({ order_id: "o", status: "invoiced" })!.is_collectible).toBe(true)
+  })
+
+  it("handles a flat fee", () => {
+    const d = describeFee({
+      order_id: "o",
+      fee_basis: "flat",
+      fee_rate: 50,
+      fee_amount: 50,
+      currency_code: "INR",
+    })!
+    expect(d.rate_label).toBe("50.00 INR")
+    expect(d.fee_basis).toBe("flat")
+  })
+})

--- a/apps/backend/src/modules/partner_billing/lib/describe-fee.ts
+++ b/apps/backend/src/modules/partner_billing/lib/describe-fee.ts
@@ -1,0 +1,86 @@
+/**
+ * Pure display contract for a single `partner_fee` row (#623, follow-up to #336).
+ *
+ * Kept dependency-free so it's trivially unit-testable and so BOTH read routes
+ * (`GET /admin/orders/:id/partner-fee` and the partner mirror) can return an
+ * already-shaped `display` object — the two UIs (admin widget + partner-ui
+ * order view) then just render it, instead of each re-deriving the rate label.
+ * Never throws — a reporting payload must not 500 on a malformed row.
+ *
+ * Money fields are Medusa `bigNumber` (number | numeric string); everything is
+ * coerced with `Number(...)` and non-finite values count as 0.
+ */
+
+export type PartnerFeeBasis = "percentage" | "flat"
+
+export type PartnerFeeRowLike = {
+  order_id?: string | null
+  currency_code?: string | null
+  fee_basis?: PartnerFeeBasis | string | null
+  fee_rate?: number | string | null
+  fee_amount?: number | string | null
+  order_total?: number | string | null
+  status?: string | null
+}
+
+export type DescribedFee = {
+  order_id: string
+  status: string
+  fee_basis: PartnerFeeBasis
+  /** Human label for the rate: "2.00%" (percentage, bps→%) or "50.00 INR" (flat). */
+  rate_label: string
+  fee_amount: number
+  order_total: number
+  currency_code: string
+  /** Whether this fee currently counts toward collected commission (accrued/invoiced). */
+  is_collectible: boolean
+}
+
+const toNum = (v: unknown): number => {
+  const n = Number(v ?? 0)
+  return Number.isFinite(n) ? n : 0
+}
+
+/**
+ * Format the fee rate for display.
+ * - percentage: `fee_rate` is basis points → "2.00%" (200 bps), "2.50%" (250).
+ * - flat: `fee_rate` is an amount in `currency_code` → "50.00 INR".
+ */
+export function formatFeeRate(
+  basis: string | null | undefined,
+  rate: number | string | null | undefined,
+  currency?: string | null
+): string {
+  const r = toNum(rate)
+  if (basis === "flat") {
+    return `${r.toFixed(2)} ${(currency || "").toUpperCase()}`.trim()
+  }
+  return `${(r / 100).toFixed(2)}%`
+}
+
+/**
+ * Shape a raw `partner_fee` row into a display object, or `null` when there's
+ * no fee (retail order / never accrued). A "collectible" fee is one the
+ * platform still expects to collect (`accrued` or `invoiced`); `reversed` /
+ * `waived` are not.
+ */
+export function describeFee(
+  fee: PartnerFeeRowLike | null | undefined
+): DescribedFee | null {
+  if (!fee || !fee.order_id) {
+    return null
+  }
+  const fee_basis: PartnerFeeBasis = fee.fee_basis === "flat" ? "flat" : "percentage"
+  const currency_code = (fee.currency_code || "").toUpperCase()
+  const status = String(fee.status || "accrued")
+  return {
+    order_id: String(fee.order_id),
+    status,
+    fee_basis,
+    rate_label: formatFeeRate(fee_basis, fee.fee_rate, currency_code),
+    fee_amount: toNum(fee.fee_amount),
+    order_total: toNum(fee.order_total),
+    currency_code,
+    is_collectible: status === "accrued" || status === "invoiced",
+  }
+}

--- a/apps/partner-ui/src/hooks/api/partner-order-fee.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-order-fee.tsx
@@ -1,0 +1,48 @@
+import { FetchError } from "@medusajs/js-sdk"
+import { useQuery, UseQueryOptions } from "@tanstack/react-query"
+
+import { sdk } from "../../lib/client"
+
+// #623 (follow-up to #336): read the platform commission accrued for a single
+// order the partner fulfils, from the partner mirror route
+// `GET /partners/orders/:id/partner-fee` (ownership-scoped server-side).
+
+export type PartnerOrderFeeDisplay = {
+  order_id: string
+  status: string
+  fee_basis: "percentage" | "flat"
+  rate_label: string
+  fee_amount: number
+  order_total: number
+  currency_code: string
+  is_collectible: boolean
+}
+
+export type PartnerOrderFeeResponse = {
+  order_id: string
+  fee: unknown | null
+  display: PartnerOrderFeeDisplay | null
+}
+
+export const usePartnerOrderFee = (
+  orderId: string,
+  options?: Omit<
+    UseQueryOptions<
+      PartnerOrderFeeResponse,
+      FetchError,
+      PartnerOrderFeeResponse,
+      (string | undefined)[]
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  return useQuery({
+    queryFn: () =>
+      sdk.client.fetch<PartnerOrderFeeResponse>(
+        `/partners/orders/${orderId}/partner-fee`,
+        { method: "GET" }
+      ),
+    queryKey: ["partner-order-fee", orderId],
+    ...options,
+  })
+}

--- a/apps/partner-ui/src/routes/orders/order-detail/components/order-partner-fee-section.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/components/order-partner-fee-section.tsx
@@ -1,0 +1,95 @@
+import { Container, Heading, StatusBadge, Text } from "@medusajs/ui"
+
+import { usePartnerOrderFee } from "../../../../hooks/api/partner-order-fee"
+
+// #623 (follow-up to #336): show the platform commission deducted on THIS order
+// in the partner's own order view — parity with the admin order-detail widget.
+// Renders nothing for a retail order / one that never accrued a fee.
+
+const STATUS_COLOR: Record<string, "green" | "orange" | "grey" | "red"> = {
+  accrued: "orange",
+  invoiced: "green",
+  waived: "grey",
+  reversed: "red",
+}
+
+function formatMoney(amount: number, currency: string) {
+  const safe = Number.isFinite(amount) ? amount : 0
+  try {
+    return new Intl.NumberFormat("en-IN", {
+      style: "currency",
+      currency: (currency || "INR").toUpperCase(),
+      maximumFractionDigits: 2,
+    }).format(safe)
+  } catch {
+    return `${safe.toFixed(2)} ${(currency || "").toUpperCase()}`
+  }
+}
+
+type OrderPartnerFeeSectionProps = {
+  orderId: string
+}
+
+export const OrderPartnerFeeSection = ({
+  orderId,
+}: OrderPartnerFeeSectionProps) => {
+  const { data, isLoading } = usePartnerOrderFee(orderId)
+  const fee = data?.display
+
+  // No fee for this order (retail / never accrued) → no card.
+  if (!isLoading && !fee) {
+    return null
+  }
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div>
+          <Heading level="h2">Platform commission</Heading>
+          <Text size="small" leading="compact" className="text-ui-fg-subtle">
+            The platform's cut on this order, deducted from your payout.
+          </Text>
+        </div>
+        {fee ? (
+          <StatusBadge color={STATUS_COLOR[fee.status] ?? "grey"}>
+            {fee.status}
+          </StatusBadge>
+        ) : null}
+      </div>
+
+      {isLoading || !fee ? (
+        <div className="px-6 py-4">
+          <div className="bg-ui-bg-subtle h-4 w-32 animate-pulse rounded" />
+          <div className="bg-ui-bg-subtle mt-2 h-4 w-24 animate-pulse rounded" />
+        </div>
+      ) : (
+        <div className="flex flex-col gap-y-3 px-6 py-4">
+          <div className="flex items-center justify-between">
+            <Text size="small" className="text-ui-fg-subtle">
+              Rate
+            </Text>
+            <Text size="small" weight="plus">
+              {fee.rate_label}
+            </Text>
+          </div>
+          <div className="flex items-center justify-between">
+            <Text size="small" className="text-ui-fg-subtle">
+              Commission
+            </Text>
+            <Text size="small" weight="plus">
+              {formatMoney(fee.fee_amount, fee.currency_code)}
+            </Text>
+          </div>
+          <div className="flex items-center justify-between">
+            <Text size="small" className="text-ui-fg-subtle">
+              Order total
+            </Text>
+            <Text size="small" className="text-ui-fg-subtle">
+              {formatMoney(fee.order_total, fee.currency_code)}
+            </Text>
+          </div>
+        </div>
+      )}
+    </Container>
+  )
+}

--- a/apps/partner-ui/src/routes/orders/order-detail/order-detail.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/order-detail.tsx
@@ -26,6 +26,7 @@ import { OrderActivitySection } from "./components/order-activity-section"
 import { OrderCustomerSection } from "./components/order-customer-section"
 import { OrderFulfillmentSection } from "./components/order-fulfillment-section"
 import { OrderGeneralSection } from "./components/order-general-section"
+import { OrderPartnerFeeSection } from "./components/order-partner-fee-section"
 import { OrderPaymentSection } from "./components/order-payment-section"
 import { OrderSummarySection } from "./components/order-summary-section"
 import { WorkOrderStatusSection } from "./components/work-order-status-section"
@@ -193,6 +194,7 @@ export const OrderDetail = () => {
       </TwoColumnPage.Main>
       <TwoColumnPage.Sidebar>
         {!isWorkOrder && <OrderCustomerSection order={order} />}
+        <OrderPartnerFeeSection orderId={id!} />
         {kind === "design" ? (
           <WorkOrderActivitySection order={order} productionRun={production_run} />
         ) : (


### PR DESCRIPTION
Closes #623 (follow-up to #336).

## Why
The platform commission is accrued **per order** at `order.placed` (one `partner_fee` row: `order_id`, `order_total`, `fee_basis`, `fee_rate`, `fee_amount`, `status`; reversed on cancel) and **rolls up on the partner detail page** ("Transaction fees"). But it was **not visible on the order itself** — neither the admin order detail page nor the partner-ui order view showed "this order's commission = ₹X". This closes that loop.

## What
- **Pure helper** `describeFee` / `formatFeeRate` (`partner_billing/lib/describe-fee.ts`) — bps→"2.00%", flat amount, `is_collectible` (accrued/invoiced). Never throws. **8 unit tests.**
- **Admin route** `GET /admin/orders/:id/partner-fee` → `{ order_id, fee, display }`.
- **Partner route** `GET /partners/orders/:id/partner-fee` → same, **ownership-scoped** via `validatePartnerOrderOwnership` (a partner can never read a fee for an order they don't own — cross-tenant → 404).
- **Admin widget** in `order.details.side.after` + **partner-ui** order-detail sidebar section. Both render **nothing** for a retail / no-fee order (no empty card). Money formatted with `Intl.NumberFormat`, status as a `StatusBadge`.
- **4 integration tests**: admin (fee present + display), admin (retail → null), partner (owns order), partner (cross-tenant → 404).

## Verification
- `describe-fee` unit: **8/8** green.
- `order-partner-fee-api` integration (shared DB): **4/4** green.
- `tsc --noEmit` clean for all new files (backend + partner-ui).

## Notes
- Read-only — fees are still accrued/reversed only by the `order.placed`/`order.canceled` subscribers.
- Partner route mirrors the admin wire shape exactly (per the partner-mirrors-admin convention); scoping lives in the handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)