### PR TITLE
fix(#638): Shiprocket generate-label — resolve pickup from registered locations + clean error

### DIFF
--- a/apps/backend/src/modules/shipping-providers/__tests__/choose-registered-pickup.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/__tests__/choose-registered-pickup.unit.spec.ts
@@ -1,0 +1,54 @@
+import { chooseRegisteredPickup } from "../pickup-locations"
+import type { PickupLocation } from "../provider-interface"
+
+/**
+ * #638 — when a fulfillment's stock location carries no Shiprocket nickname,
+ * Generate-Label falls back to a registered pickup. `chooseRegisteredPickup`
+ * picks which one: prefer a shippable pickup, else the first registered one,
+ * else undefined (caller then throws a clean "configure a pickup" error).
+ */
+describe("chooseRegisteredPickup (#638)", () => {
+  const p = (name: string, shippable?: boolean): PickupLocation => ({
+    name,
+    shippable,
+  })
+
+  it("returns undefined for no registered pickups", () => {
+    expect(chooseRegisteredPickup([])).toBeUndefined()
+    expect(chooseRegisteredPickup(undefined)).toBeUndefined()
+    expect(chooseRegisteredPickup(null)).toBeUndefined()
+  })
+
+  it("prefers a shippable pickup over a non-shippable earlier one", () => {
+    const chosen = chooseRegisteredPickup([
+      p("warehouse-a", false),
+      p("warehouse-b", true),
+    ])
+    expect(chosen?.name).toBe("warehouse-b")
+  })
+
+  it("returns the first shippable pickup when several are shippable", () => {
+    const chosen = chooseRegisteredPickup([
+      p("warehouse-a", false),
+      p("warehouse-b", true),
+      p("warehouse-c", true),
+    ])
+    expect(chosen?.name).toBe("warehouse-b")
+  })
+
+  it("falls back to the first registered pickup when none are shippable", () => {
+    const chosen = chooseRegisteredPickup([
+      p("warehouse-a", false),
+      p("warehouse-b", false),
+    ])
+    expect(chosen?.name).toBe("warehouse-a")
+  })
+
+  it("treats an undefined shippable flag as not-preferred but still selectable", () => {
+    const chosen = chooseRegisteredPickup([p("warehouse-a"), p("warehouse-b", true)])
+    expect(chosen?.name).toBe("warehouse-b")
+
+    const onlyUnknown = chooseRegisteredPickup([p("warehouse-a"), p("warehouse-b")])
+    expect(onlyUnknown?.name).toBe("warehouse-a")
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/pickup-locations.ts
+++ b/apps/backend/src/modules/shipping-providers/pickup-locations.ts
@@ -34,6 +34,19 @@ export function pickupNicknameForLocation(locationId: string): string {
   return `warehouse-${locationId.slice(-8)}`
 }
 
+/**
+ * Choose which registered Shiprocket pickup to ship from when a fulfillment's
+ * stock location carries no nickname. Prefer a shippable pickup; otherwise fall
+ * back to the first registered one. Returns undefined when there are none.
+ * Pure — unit-tested. (#638)
+ */
+export function chooseRegisteredPickup(
+  pickups: PickupLocation[] | undefined | null
+): PickupLocation | undefined {
+  if (!pickups?.length) return undefined
+  return pickups.find((p) => p.shippable) ?? pickups[0]
+}
+
 export type PickupRegistrationResult = {
   /** The nickname now recorded on the stock location. */
   name: string

--- a/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
@@ -292,7 +292,12 @@ export class ShiprocketClient implements ShippingProviderClient {
   async createShipment(input: CreateShipmentInput): Promise<ShipmentResult> {
     const pickup = input.pickup_location_name || this.defaultPickup
     if (!pickup) {
-      throw new Error("Shiprocket createShipment requires a pickup_location_name")
+      // MedusaError (not a raw Error) so callers surface a clean toast, mirroring
+      // the credentials/serviceability errors. (#638)
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "Shiprocket createShipment requires a pickup_location_name"
+      )
     }
 
     const [firstName, ...rest] = (input.to.name || "Customer").split(" ")

--- a/apps/backend/src/workflows/orders/shiprocket-shipment.ts
+++ b/apps/backend/src/workflows/orders/shiprocket-shipment.ts
@@ -11,7 +11,10 @@ import type {
   ShipmentItem,
   ShipmentResult,
 } from "../../modules/shipping-providers/provider-interface"
-import { SHIPROCKET_PICKUP_METADATA_KEY } from "../../modules/shipping-providers/pickup-locations"
+import {
+  SHIPROCKET_PICKUP_METADATA_KEY,
+  chooseRegisteredPickup,
+} from "../../modules/shipping-providers/pickup-locations"
 
 /**
  * #404 (#31) PR-B — generate a Shiprocket shipment (forward order → AWB → label)
@@ -168,6 +171,28 @@ export async function createShiprocketShipmentForFulfillment(
     throw new MedusaError(
       MedusaError.Types.NOT_ALLOWED,
       "Shiprocket provider does not support shipment creation"
+    )
+  }
+
+  // Fallback: when neither an explicit name nor the fulfillment's stock-location
+  // nickname resolves a pickup, ship from a registered Shiprocket pickup (prefer
+  // a shippable one). This is what makes Generate-Label work for converted
+  // design orders whose fulfillment landed on a non-registered stock location.
+  // (#638)
+  if (!pickupLocationName && provider.listPickupLocations) {
+    try {
+      const registered = await provider.listPickupLocations()
+      pickupLocationName = chooseRegisteredPickup(registered)?.name
+    } catch {
+      // Listing is best-effort; the guard below produces the actionable error.
+    }
+  }
+
+  if (!pickupLocationName) {
+    // A clean MedusaError (not a raw 500) so the UI shows an actionable toast. (#638)
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "No Shiprocket pickup location is configured. Register a pickup location for the order's stock location (or any Shiprocket pickup) before generating a label."
     )
   }
 


### PR DESCRIPTION
## What
Fixes #638 — the admin **Generate Shipping Label** path (`POST /admin/orders/:id/shiprocket-label`) returned an opaque **500** for converted design orders whose fulfillment landed on a stock location with no Shiprocket pickup nickname.

## Changes
- **Resolve pickup from registered locations.** When neither an explicit name nor the fulfillment's stock-location nickname resolves a pickup, the shipment workflow now falls back to a **registered Shiprocket pickup** via `provider.listPickupLocations()`, preferring a `shippable` one. New pure helper `chooseRegisteredPickup()` (unit-tested).
- **Clean error, no 500.** If no pickup resolves, throw a `MedusaError` with an actionable 'register a pickup' message (clean toast). Also converted `client.createShipment`'s plain `Error` to a `MedusaError`, mirroring the credentials/serviceability errors right next to it.

## Verification
- 24 related unit tests green (5 new in `choose-registered-pickup.unit.spec.ts`).
- Live local: the path now returns a structured **400** (`No Shiprocket pickup location is configured…`) instead of the opaque HTML 500.

## Notes / follow-ups
- The live **success** path (registered pickup → real AWB/label) couldn't be exercised locally — local Shiprocket creds return 403; prod creds are valid. Once merged + deployed, this unblocks the #437 generate-label live tail.
- Partner-side has no Shiprocket label route at all — tracked separately in #639.

Refs #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)