### PR TITLE
fix(shiprocket): accept SHIPROCKET_API_PASSWORD env fallback (#642)

### DIFF
--- a/apps/backend/.env.template
+++ b/apps/backend/.env.template
@@ -49,3 +49,9 @@ WHATSAPP_ACCESS_TOKEN=your_permanent_access_token
 WHATSAPP_WEBHOOK_VERIFY_TOKEN=your_webhook_verify_token
 # WHATSAPP_APP_SECRET defaults to FACEBOOK_CLIENT_SECRET if not set
 # WHATSAPP_APP_SECRET=your_app_secret
+# Shiprocket carrier (local-dev fallback; prod reads from the encrypted
+# shipping_platform.api_config record instead). The resolver accepts either
+# SHIPROCKET_API_PASSWORD (repo convention) or SHIPROCKET_PASSWORD.
+SHIPROCKET_EMAIL=shipping@example.com
+SHIPROCKET_API_PASSWORD=your_shiprocket_password
+# SHIPROCKET_PICKUP_LOCATION=Primary

--- a/apps/backend/src/modules/shipping-providers/__tests__/resolver.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/__tests__/resolver.unit.spec.ts
@@ -1,0 +1,64 @@
+import { MedusaError } from "@medusajs/framework/utils"
+import { resolveShippingProvider } from "../resolver"
+import { ShiprocketClient } from "../shiprocket/client"
+
+/**
+ * Container-mocked unit coverage for the Shiprocket env-fallback (#642).
+ * A fake container whose `resolve` always throws forces the resolver down the
+ * env-var path (no socials platform record, no encryption module).
+ */
+const throwingContainer = {
+  resolve() {
+    throw new Error("module unavailable")
+  },
+} as any
+
+describe("resolveShippingProvider — Shiprocket env fallback (#642)", () => {
+  const saved = {
+    email: process.env.SHIPROCKET_EMAIL,
+    password: process.env.SHIPROCKET_PASSWORD,
+    apiPassword: process.env.SHIPROCKET_API_PASSWORD,
+  }
+
+  afterEach(() => {
+    for (const k of [
+      "SHIPROCKET_EMAIL",
+      "SHIPROCKET_PASSWORD",
+      "SHIPROCKET_API_PASSWORD",
+    ] as const) {
+      delete process.env[k]
+    }
+  })
+
+  afterAll(() => {
+    if (saved.email !== undefined) process.env.SHIPROCKET_EMAIL = saved.email
+    if (saved.password !== undefined)
+      process.env.SHIPROCKET_PASSWORD = saved.password
+    if (saved.apiPassword !== undefined)
+      process.env.SHIPROCKET_API_PASSWORD = saved.apiPassword
+  })
+
+  it("authenticates from SHIPROCKET_API_PASSWORD (repo convention)", async () => {
+    process.env.SHIPROCKET_EMAIL = "shipping@example.com"
+    process.env.SHIPROCKET_API_PASSWORD = "from-api-password"
+    const client = await resolveShippingProvider(throwingContainer, "shiprocket")
+    expect(client).toBeInstanceOf(ShiprocketClient)
+  })
+
+  it("still accepts the legacy SHIPROCKET_PASSWORD name", async () => {
+    process.env.SHIPROCKET_EMAIL = "shipping@example.com"
+    process.env.SHIPROCKET_PASSWORD = "from-legacy-password"
+    const client = await resolveShippingProvider(throwingContainer, "shiprocket")
+    expect(client).toBeInstanceOf(ShiprocketClient)
+  })
+
+  it("throws a clean MedusaError naming both env vars when neither is set", async () => {
+    process.env.SHIPROCKET_EMAIL = "shipping@example.com"
+    await expect(
+      resolveShippingProvider(throwingContainer, "shiprocket")
+    ).rejects.toThrow(MedusaError)
+    await expect(
+      resolveShippingProvider(throwingContainer, "shiprocket")
+    ).rejects.toThrow(/SHIPROCKET_API_PASSWORD/)
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/resolver.ts
+++ b/apps/backend/src/modules/shipping-providers/resolver.ts
@@ -145,11 +145,13 @@ export async function resolveShippingProvider(
     const email =
       cfg.email || cfg.username || process.env.SHIPROCKET_EMAIL
     const password =
-      readSecret(cfg, "password", encryption) || process.env.SHIPROCKET_PASSWORD
+      readSecret(cfg, "password", encryption) ||
+      process.env.SHIPROCKET_PASSWORD ||
+      process.env.SHIPROCKET_API_PASSWORD
     if (!email || !password) {
       throw new MedusaError(
         MedusaError.Types.UNEXPECTED_STATE,
-        "Shiprocket credentials not configured (no shipping platform record or SHIPROCKET_EMAIL/SHIPROCKET_PASSWORD)"
+        "Shiprocket credentials not configured (no shipping platform record or SHIPROCKET_EMAIL + SHIPROCKET_API_PASSWORD/SHIPROCKET_PASSWORD)"
       )
     }
     return new ShiprocketClient({


### PR DESCRIPTION
Closes #642.

## Problem
`resolveShippingProvider`'s Shiprocket env fallback (`src/modules/shipping-providers/resolver.ts`) only read `process.env.SHIPROCKET_PASSWORD`, but the repo `.env` and documented convention use `SHIPROCKET_API_PASSWORD`. On a fresh local checkout (no DB platform record) the env fallback silently never authenticated → confusing `credentials not configured` error. Low blast radius (prod authenticates from the encrypted `shipping_platform.api_config`, not env), but a real local-dev papercut.

## Fix
- Accept **both** env names: `readSecret(...) || process.env.SHIPROCKET_PASSWORD || process.env.SHIPROCKET_API_PASSWORD`.
- Update the `credentials not configured` `MedusaError` message to name both accepted vars.
- Document `SHIPROCKET_EMAIL` / `SHIPROCKET_API_PASSWORD` (+ optional pickup location) in `.env.template`.
- Add a container-mocked unit test covering both env names + the throw path.

## Verify
```
TEST_TYPE=unit NODE_OPTIONS="--experimental-vm-modules" npx jest --testPathPattern="shipping-providers/__tests__/resolver.unit"
```
3/3 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)