### PR TITLE
feat(partner): Shiprocket label + attach-AWB parity routes (#639)

### DIFF
--- a/apps/backend/integration-tests/http/partner-shiprocket-routes.spec.ts
+++ b/apps/backend/integration-tests/http/partner-shiprocket-routes.spec.ts
@@ -1,0 +1,129 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { IOrderModuleService } from "@medusajs/types"
+
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { PARTNER_MODULE } from "../../src/modules/partner"
+
+jest.setTimeout(60 * 1000)
+
+/**
+ * #639 — partner Shiprocket parity routes:
+ *   POST /partners/orders/:id/shiprocket-label
+ *   POST /partners/orders/:id/shiprocket-attach-awb
+ *
+ * The load-bearing new logic is the in-handler partner scoping
+ * (`validatePartnerOrderOwnership`): a partner can only drive carrier work for
+ * an order they own — a foreign order 404s BEFORE any fulfillment/carrier work.
+ * This asserts that isolation deterministically (no live Shiprocket needed): the
+ * ownership guard runs before body validation and before the carrier call.
+ */
+setupSharedTestSuite(() => {
+  describe("Partner API - Shiprocket label / attach-awb ownership (#639)", () => {
+    async function createPartner(unique: number) {
+      const { api } = getSharedTestEnv()
+      const email = `srp-${unique}@jyt.test`
+      const password = "supersecret"
+      await api.post("/auth/partner/emailpass/register", { email, password })
+      const login1 = await api.post("/auth/partner/emailpass", { email, password })
+      let headers = { Authorization: `Bearer ${login1.data.token}` }
+      const res = await api.post(
+        "/partners",
+        {
+          name: `SRP ${unique}`,
+          handle: `srp-${unique}`,
+          admin: { email, first_name: "Test", last_name: "Partner" },
+        },
+        { headers }
+      )
+      expect(res.status).toBe(200)
+      const login2 = await api.post("/auth/partner/emailpass", { email, password })
+      headers = { Authorization: `Bearer ${login2.data.token}` }
+
+      // Ownership guard needs the partner to have a store (getPartnerStore).
+      await api.post(
+        "/partners/stores",
+        {
+          store: {
+            name: `SRP Store ${unique}`,
+            supported_currencies: [{ currency_code: "usd", is_default: true }],
+          },
+          sales_channel: { name: `SRP Channel ${unique}`, description: "Default" },
+          region: { name: `SRP Region ${unique}`, currency_code: "usd", countries: ["us"] },
+          location: {
+            name: `SRP Warehouse ${unique}`,
+            address: {
+              address_1: "1 Mill Road",
+              city: "Austin",
+              postal_code: "73301",
+              country_code: "US",
+            },
+          },
+        },
+        { headers }
+      )
+
+      return { partnerId: res.data.partner.id as string, headers }
+    }
+
+    async function createOrder(unique: number) {
+      const container = getSharedTestEnv().getContainer()
+      const orderService = container.resolve(Modules.ORDER) as IOrderModuleService
+      return (await orderService.createOrders({
+        currency_code: "usd",
+        email: `srp-order-${unique}@jyt.test`,
+        items: [{ title: "Line A", quantity: 1, unit_price: 1000 }],
+      } as any)) as any
+    }
+
+    async function linkPartnerOrder(partnerId: string, orderId: string) {
+      const container = getSharedTestEnv().getContainer()
+      const remoteLink: any = container.resolve(ContainerRegistrationKeys.LINK)
+      await remoteLink.create([
+        {
+          [PARTNER_MODULE]: { partner_id: partnerId },
+          [Modules.ORDER]: { order_id: orderId },
+          data: { partner_id: partnerId, order_id: orderId },
+        },
+      ])
+    }
+
+    it("enforces partner ownership on both Shiprocket routes", async () => {
+      const { api } = getSharedTestEnv()
+      const unique = Date.now()
+
+      const owner = await createPartner(unique)
+      const intruder = await createPartner(unique + 1)
+      const order = await createOrder(unique)
+      await linkPartnerOrder(owner.partnerId, order.id)
+
+      // ── Intruder: doesn't own the order → 404 on BOTH routes, before any
+      //    body validation or carrier work. ────────────────────────────────
+      await expect(
+        api.post(
+          `/partners/orders/${order.id}/shiprocket-attach-awb`,
+          { awb: "FAKEAWB123" },
+          { headers: intruder.headers }
+        )
+      ).rejects.toMatchObject({ response: { status: 404 } })
+
+      await expect(
+        api.post(
+          `/partners/orders/${order.id}/shiprocket-label`,
+          {},
+          { headers: intruder.headers }
+        )
+      ).rejects.toMatchObject({ response: { status: 404 } })
+
+      // ── Owner: passes the ownership guard. An empty AWB then trips body
+      //    validation (400) — which proves the guard let the owner THROUGH
+      //    (a rejected owner would 404 before validation). ──────────────────
+      await expect(
+        api.post(
+          `/partners/orders/${order.id}/shiprocket-attach-awb`,
+          { awb: "" },
+          { headers: owner.headers }
+        )
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+  })
+})

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -4167,6 +4167,25 @@ export default defineMiddlewares({
       ],
     },
     {
+      // #639 — partner Shiprocket parity: generate a carrier label / attach an
+      // existing AWB for the partner's own order. Ownership is enforced inside
+      // the handler (validatePartnerOrderOwnership).
+      matcher: "/partners/orders/:id/shiprocket-label",
+      method: "POST",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
+    {
+      matcher: "/partners/orders/:id/shiprocket-attach-awb",
+      method: "POST",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
+    {
       matcher: "/partners/orders/:id/fulfillments/:fulfillmentId/cancel",
       method: "POST",
       middlewares: [

--- a/apps/backend/src/api/partners/orders/[id]/shiprocket-attach-awb/route.ts
+++ b/apps/backend/src/api/partners/orders/[id]/shiprocket-attach-awb/route.ts
@@ -1,0 +1,36 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import { validatePartnerOrderOwnership } from "../../../helpers"
+import { ensureOrderFulfillment } from "../../../../../workflows/orders/fulfillment-context"
+import { attachExistingShiprocketAwb } from "../../../../../workflows/orders/shiprocket-attach-awb"
+
+/**
+ * POST /partners/orders/:id/shiprocket-attach-awb
+ *
+ * #639 — partner mirror of `POST /admin/orders/:id/shiprocket-attach-awb`.
+ * Attaches an EXISTING Shiprocket AWB (parcel shipped outside this system) to
+ * one of the partner's own orders: reuses/creates a manual fulfillment, looks
+ * the AWB up on Shiprocket (read-only), stamps the carrier refs, and syncs the
+ * fulfillment status. Partner ownership is enforced INSIDE the handler via
+ * `validatePartnerOrderOwnership` before any carrier work runs.
+ */
+const Body = z.object({ awb: z.string().trim().min(1, "An AWB is required") })
+
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const orderId = req.params.id
+  await validatePartnerOrderOwnership(req.auth_context, orderId, req.scope)
+
+  const { awb } = Body.parse((req.body as Record<string, unknown>) ?? {})
+
+  const fulfillmentId = await ensureOrderFulfillment(req.scope, orderId)
+  const result = await attachExistingShiprocketAwb(req.scope, {
+    orderId,
+    fulfillmentId,
+    awb,
+  })
+
+  res.status(200).json({ shiprocket_awb: result })
+}

--- a/apps/backend/src/api/partners/orders/[id]/shiprocket-label/route.ts
+++ b/apps/backend/src/api/partners/orders/[id]/shiprocket-label/route.ts
@@ -1,0 +1,40 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { validatePartnerOrderOwnership } from "../../../helpers"
+import { ensureOrderFulfillment } from "../../../../../workflows/orders/fulfillment-context"
+import { createShiprocketShipmentForFulfillment } from "../../../../../workflows/orders/shiprocket-shipment"
+
+/**
+ * POST /partners/orders/:id/shiprocket-label
+ *
+ * #639 — partner mirror of `POST /admin/orders/:id/shiprocket-label`. Generates
+ * a Shiprocket label (create fulfillment → shipment → AWB) for one of the
+ * partner's own orders. Partner ownership is enforced INSIDE the handler via
+ * `validatePartnerOrderOwnership` (retail sales-channel OR the D3 partner↔order
+ * work link) — a foreign order 404s before any carrier work runs.
+ *
+ * Reuses the same `ensureOrderFulfillment` + `createShiprocketShipmentForFulfillment`
+ * the admin route drives, so wire contract + behaviour match exactly. Accepts an
+ * optional `preferred_courier_id` (#641 parity).
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const orderId = req.params.id
+  await validatePartnerOrderOwnership(req.auth_context, orderId, req.scope)
+
+  const body = (req.body || {}) as { preferred_courier_id?: string | number }
+  const preferredCourierId =
+    body.preferred_courier_id != null && body.preferred_courier_id !== ""
+      ? body.preferred_courier_id
+      : undefined
+
+  const fulfillmentId = await ensureOrderFulfillment(req.scope, orderId)
+  const shipment = await createShiprocketShipmentForFulfillment(req.scope, {
+    orderId,
+    fulfillmentId,
+    preferredCourierId,
+  })
+
+  res.status(200).json({ shiprocket_label: shipment })
+}

--- a/apps/docs/notes/639_PARTNER_SHIPROCKET_PARITY.md
+++ b/apps/docs/notes/639_PARTNER_SHIPROCKET_PARITY.md
@@ -1,0 +1,78 @@
+# #639 — Partner-side Shiprocket label / attach-AWB parity
+
+Status: **backend + partner-ui hooks BUILT** (PR pending). Button render slice
+DEFERRED (Playwright-gated — needs a partner-owned order WITH a fulfillment
+seeded at the live partner-ui).
+
+## Problem
+Partners could only mark-as-shipped with a hand-keyed tracking number
+(`POST /partners/fulfillments/:id/shipment` → core `createShipmentWorkflow`).
+There was no partner equivalent of the admin Shiprocket carrier flows
+(generate label / attach existing AWB), a parity gap under #337 / #404 / #437.
+
+## What shipped (this PR)
+
+### Backend routes (mirror admin, scoping INSIDE the handler)
+- `POST /partners/orders/:id/shiprocket-label`
+  — `apps/backend/src/api/partners/orders/[id]/shiprocket-label/route.ts`
+- `POST /partners/orders/:id/shiprocket-attach-awb`
+  — `apps/backend/src/api/partners/orders/[id]/shiprocket-attach-awb/route.ts`
+
+Both call `validatePartnerOrderOwnership(req.auth_context, orderId, req.scope)`
+FIRST (the partner-API-mirrors-admin convention: same wire contract as
+`/admin/orders/:id/shiprocket-*`, scoping lives in the handler). Ownership =
+retail (order in the partner's store sales-channel) OR the D3 `partner↔order`
+work link. A foreign order **404s before any fulfillment/carrier work runs**.
+
+They then reuse the exact admin building blocks:
+`ensureOrderFulfillment` → `createShiprocketShipmentForFulfillment`
+(label, accepts `preferred_courier_id` for #641 parity) /
+`attachExistingShiprocketAwb` (attach).
+
+Middleware: two matchers added to `apps/backend/src/api/middlewares.ts`
+(`createCorsPartnerMiddleware` + `authenticate("partner", …)`), next to the
+existing `/partners/orders/:id/fulfillments/:fulfillmentId/shipment` entry.
+
+Response envelopes match admin exactly:
+`{ shiprocket_label: {...} }` / `{ shiprocket_awb: {...} }`.
+
+### Partner-ui hooks
+`apps/partner-ui/src/hooks/api/shiprocket.tsx`:
+- `useGenerateShiprocketLabel(orderId)` — POST `…/shiprocket-label`, optional
+  `{ preferred_courier_id }`.
+- `useAttachShiprocketAwb(orderId)` — POST `…/shiprocket-attach-awb` with `awb`.
+Both invalidate `ordersQueryKeys.all` on success (mirror `fulfillment.tsx`).
+
+### Tests
+`integration-tests/http/partner-shiprocket-routes.spec.ts` — owner vs intruder:
+intruder → 404 on both routes (before validation/carrier); owner + empty AWB →
+400 (body validation, proving the guard let the owner through). 1/1 green.
+
+## Deferred render slice (next)
+Wire two buttons into the partner order-fulfillment section
+(`apps/partner-ui/src/routes/orders/order-detail/components/order-fulfillment-section/order-fulfillment-section.tsx`,
+the action row at ~L627 next to **Download Label** / `handleFetchLabel`):
+
+1. **Generate Shiprocket Label** — `useGenerateShiprocketLabel(order.id)`; show
+   when the fulfillment has no waybill yet and isn't canceled; toast the AWB.
+2. **Attach existing AWB** — open an inline input / drawer (mirror the admin
+   Design-Orders attach panel), call `useAttachShiprocketAwb(order.id)`.
+
+Mirror the admin handlers in
+`apps/backend/src/admin/routes/design-orders/[id]/page.tsx`
+(`handleGenerateLabel` / `handleAttachAwb`).
+
+**Why deferred:** the daemon rule requires Playwright verification of UI against
+the live partner-ui at :5173, which needs a partner-owned order WITH a
+fulfillment seeded + a partner browser login. That seeding wasn't done this
+chunk; the backend (the actual parity gap) is integration-tested and the hooks
+typecheck clean.
+
+## Open decision (none blocking)
+The admin label route is **order-keyed** (`/orders/:id/shiprocket-label`), so the
+partner mirror is too — even though the partner fulfillment UI is
+fulfillment-keyed. `ensureOrderFulfillment` reconciles (reuses/creates the
+order's fulfillment), so the button can live in the per-fulfillment section and
+still call the order-keyed route. No ambiguity for single-fulfillment orders
+(the design-order flow); multi-fulfillment partner orders would label the
+order's first/primary fulfillment — fine for the current converted-order flow.

--- a/apps/partner-ui/src/hooks/api/shiprocket.tsx
+++ b/apps/partner-ui/src/hooks/api/shiprocket.tsx
@@ -1,0 +1,92 @@
+import { useMutation, UseMutationOptions } from "@tanstack/react-query"
+
+import { sdk } from "../../lib/client"
+import { queryClient } from "../../lib/query-client"
+import { ordersQueryKeys } from "./orders"
+import { FetchError } from "@medusajs/js-sdk"
+
+/**
+ * Partner-side Shiprocket carrier mutations (#639) — mirror the admin
+ * Design-Orders hooks (`apps/backend/src/admin/hooks/api/design-orders.ts`)
+ * against the partner routes:
+ *   POST /partners/orders/:id/shiprocket-label
+ *   POST /partners/orders/:id/shiprocket-attach-awb
+ * Ownership is enforced server-side inside each handler.
+ */
+
+export type GenerateShiprocketLabelResponse = {
+  shiprocket_label: {
+    awb?: string
+    tracking_number?: string
+    label_url?: string
+    tracking_url?: string
+    fulfillment_id: string
+  }
+}
+
+export type GenerateShiprocketLabelVariables =
+  | { preferred_courier_id?: string | number }
+  | undefined
+
+/**
+ * Generate a Shiprocket label for one of the partner's own orders (create
+ * fulfillment → shipment → AWB). Optionally passes a chosen courier (#641).
+ */
+export const useGenerateShiprocketLabel = (
+  orderId: string,
+  options?: UseMutationOptions<
+    GenerateShiprocketLabelResponse,
+    FetchError,
+    GenerateShiprocketLabelVariables
+  >
+) => {
+  return useMutation({
+    mutationFn: (variables?: GenerateShiprocketLabelVariables) =>
+      sdk.client.fetch<GenerateShiprocketLabelResponse>(
+        `/partners/orders/${orderId}/shiprocket-label`,
+        {
+          method: "POST",
+          body: variables?.preferred_courier_id
+            ? { preferred_courier_id: variables.preferred_courier_id }
+            : {},
+        }
+      ),
+    onSuccess: (data: any, variables: any, context: any) => {
+      queryClient.invalidateQueries({ queryKey: ordersQueryKeys.all })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}
+
+export type AttachShiprocketAwbResponse = {
+  shiprocket_awb: {
+    awb: string
+    current_status?: string
+    synced_state: "delivered" | "shipped" | "pending"
+    fulfillment_id: string
+  }
+}
+
+/**
+ * Attach an EXISTING Shiprocket AWB (parcel shipped outside this system) to one
+ * of the partner's own orders. Read-only against Shiprocket — looks the AWB up,
+ * stamps it onto the fulfillment, and syncs the fulfillment status.
+ */
+export const useAttachShiprocketAwb = (
+  orderId: string,
+  options?: UseMutationOptions<AttachShiprocketAwbResponse, FetchError, string>
+) => {
+  return useMutation({
+    mutationFn: (awb: string) =>
+      sdk.client.fetch<AttachShiprocketAwbResponse>(
+        `/partners/orders/${orderId}/shiprocket-attach-awb`,
+        { method: "POST", body: { awb } }
+      ),
+    onSuccess: (data: any, variables: any, context: any) => {
+      queryClient.invalidateQueries({ queryKey: ordersQueryKeys.all })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}


### PR DESCRIPTION
Closes #639 (backend + partner-ui hooks; button render slice deferred).

## Gap
Partners could only mark-as-shipped with a hand-keyed tracking number (`POST /partners/fulfillments/:id/shipment` → core `createShipmentWorkflow`). No partner equivalent of the admin Shiprocket carrier flows (generate label / attach existing AWB). Parity gap under #337 / #404 / #437.

## Backend (mirror admin, scoping inside the handler)
- **`POST /partners/orders/:id/shiprocket-label`**
- **`POST /partners/orders/:id/shiprocket-attach-awb`**

Both call `validatePartnerOrderOwnership(req.auth_context, orderId, req.scope)` FIRST (partner-API-mirrors-admin convention — same wire contract as `/admin/orders/:id/shiprocket-*`, scoping lives in the handler). Ownership = retail (order in the partner's store sales-channel) OR the D3 `partner↔order` work link → a **foreign order 404s before any fulfillment/carrier work runs**. They then reuse the exact admin building blocks: `ensureOrderFulfillment` → `createShiprocketShipmentForFulfillment` (label, accepts `preferred_courier_id` for #641 parity) / `attachExistingShiprocketAwb`. Response envelopes match admin: `{ shiprocket_label }` / `{ shiprocket_awb }`.

Two matchers added to `api/middlewares.ts` (independent edit; not stacked).

## Partner-ui hooks
`apps/partner-ui/src/hooks/api/shiprocket.tsx` — `useGenerateShiprocketLabel(orderId)` / `useAttachShiprocketAwb(orderId)`, mirroring the admin design-orders hooks; invalidate `ordersQueryKeys.all`. Typechecks clean.

## Test
`integration-tests/http/partner-shiprocket-routes.spec.ts` — owner vs intruder: intruder → **404 on both routes** (before validation/carrier); owner + empty AWB → **400** (body validation, proving the guard let the owner through). 1/1 green.

## Deferred (next PR — Playwright-gated)
Wiring the two buttons into the partner order-fulfillment section needs a partner-owned order WITH a fulfillment seeded at the live partner-ui (:5173) + a browser login — not done this chunk. Full plan + grounded spec: `apps/docs/notes/639_PARTNER_SHIPROCKET_PARITY.md`. The backend (the actual parity gap) is integration-tested; the hooks are the verifiable consumable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)