### PR TITLE
feat(#348): partner tax-ID typed columns + platform fallback resolver

### DIFF
--- a/apps/backend/integration-tests/http/partner-tax-id-column.spec.ts
+++ b/apps/backend/integration-tests/http/partner-tax-id-column.spec.ts
@@ -1,0 +1,58 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { resolvePartnerTaxId } from "../../src/modules/partner/tax-id-lib"
+
+jest.setTimeout(60 * 1000)
+
+/**
+ * Issue #348 — verifies the partner `tax_id` / `tax_id_type` typed columns are
+ * wired (model + migration) and persist, and that the pure fallback resolver
+ * behaves end-to-end against a real partner row.
+ */
+setupSharedTestSuite(() => {
+  const { getContainer } = getSharedTestEnv()
+
+  it("persists tax_id / tax_id_type on the partner typed columns", async () => {
+    const container = getContainer()
+    const partnerService: any = container.resolve("partner")
+
+    const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+
+    // Partner WITH its own tax ID
+    const withTaxId = await partnerService.createPartners({
+      name: `TaxCol ${unique}`,
+      handle: `taxcol-${unique}`,
+      tax_id: "29ABCDE1234F1Z5",
+      tax_id_type: "GSTIN",
+    })
+    const reloaded = await partnerService.retrievePartner(withTaxId.id)
+    expect(reloaded.tax_id).toBe("29ABCDE1234F1Z5")
+    expect(reloaded.tax_id_type).toBe("GSTIN")
+
+    // Resolver prefers the partner's own ID
+    const partnerResolved = resolvePartnerTaxId({
+      partnerTaxId: reloaded.tax_id,
+      partnerTaxIdType: reloaded.tax_id_type,
+      brand: "JYT",
+      platformTaxIds: { JYT: "JYT-PLATFORM-GST" },
+    })
+    expect(partnerResolved.source).toBe("partner")
+    expect(partnerResolved.taxId).toBe("29ABCDE1234F1Z5")
+
+    // Partner WITHOUT a tax ID — column defaults to null
+    const withoutTaxId = await partnerService.createPartners({
+      name: `TaxColNone ${unique}`,
+      handle: `taxcolnone-${unique}`,
+    })
+    const reloadedNone = await partnerService.retrievePartner(withoutTaxId.id)
+    expect(reloadedNone.tax_id ?? null).toBeNull()
+
+    // Resolver falls back to the platform brand ID
+    const platformResolved = resolvePartnerTaxId({
+      partnerTaxId: reloadedNone.tax_id,
+      brand: "KHT",
+      platformTaxIds: { KHT: "KHT-PLATFORM-GST" },
+    })
+    expect(platformResolved.source).toBe("platform")
+    expect(platformResolved.taxId).toBe("KHT-PLATFORM-GST")
+  })
+})

--- a/apps/backend/src/modules/partner/__tests__/tax-id-lib.unit.spec.ts
+++ b/apps/backend/src/modules/partner/__tests__/tax-id-lib.unit.spec.ts
@@ -1,0 +1,147 @@
+import {
+  getPlatformTaxIds,
+  normalizeBrand,
+  resolvePartnerTaxId,
+} from "../tax-id-lib"
+
+describe("tax-id-lib (issue #348)", () => {
+  describe("normalizeBrand", () => {
+    it("returns the default brand when missing/empty/whitespace", () => {
+      expect(normalizeBrand(undefined)).toBe("JYT")
+      expect(normalizeBrand(null)).toBe("JYT")
+      expect(normalizeBrand("")).toBe("JYT")
+      expect(normalizeBrand("   ")).toBe("JYT")
+    })
+
+    it("is case-insensitive and trims", () => {
+      expect(normalizeBrand("kht")).toBe("KHT")
+      expect(normalizeBrand("  Kht  ")).toBe("KHT")
+      expect(normalizeBrand("JYT")).toBe("JYT")
+    })
+
+    it("falls back to default for unrecognised brands", () => {
+      expect(normalizeBrand("ACME")).toBe("JYT")
+      expect(normalizeBrand("xyz", "KHT")).toBe("KHT")
+    })
+
+    it("honours a custom default brand", () => {
+      expect(normalizeBrand(null, "KHT")).toBe("KHT")
+    })
+  })
+
+  describe("resolvePartnerTaxId", () => {
+    const platformTaxIds = { JYT: "JYT-GST-111", KHT: "KHT-GST-222" }
+
+    it("uses the partner's own tax ID when present (source=partner)", () => {
+      const res = resolvePartnerTaxId({
+        partnerTaxId: "PARTNER-GST-999",
+        partnerTaxIdType: "GSTIN",
+        brand: "JYT",
+        platformTaxIds,
+      })
+      expect(res).toEqual({
+        taxId: "PARTNER-GST-999",
+        source: "partner",
+        brand: "JYT",
+        taxIdType: "GSTIN",
+      })
+    })
+
+    it("trims the partner tax ID", () => {
+      const res = resolvePartnerTaxId({
+        partnerTaxId: "  PARTNER-GST-999  ",
+        platformTaxIds,
+      })
+      expect(res.taxId).toBe("PARTNER-GST-999")
+      expect(res.source).toBe("partner")
+    })
+
+    it("falls back to the platform tax ID for the brand when partner has none", () => {
+      const res = resolvePartnerTaxId({
+        partnerTaxId: null,
+        brand: "KHT",
+        platformTaxIds,
+      })
+      expect(res).toEqual({
+        taxId: "KHT-GST-222",
+        source: "platform",
+        brand: "KHT",
+        taxIdType: null,
+      })
+    })
+
+    it("treats empty / whitespace partner tax ID as missing", () => {
+      expect(resolvePartnerTaxId({ partnerTaxId: "", platformTaxIds }).source).toBe(
+        "platform"
+      )
+      expect(
+        resolvePartnerTaxId({ partnerTaxId: "   ", platformTaxIds }).source
+      ).toBe("platform")
+    })
+
+    it("resolves the platform fallback against the default brand when brand missing", () => {
+      const res = resolvePartnerTaxId({ partnerTaxId: null, platformTaxIds })
+      expect(res.brand).toBe("JYT")
+      expect(res.taxId).toBe("JYT-GST-111")
+      expect(res.source).toBe("platform")
+    })
+
+    it("returns source=none when neither partner nor platform have an ID", () => {
+      const res = resolvePartnerTaxId({
+        partnerTaxId: null,
+        brand: "JYT",
+        platformTaxIds: {},
+      })
+      expect(res).toEqual({
+        taxId: null,
+        source: "none",
+        brand: "JYT",
+        taxIdType: null,
+      })
+    })
+
+    it("returns source=none when platformTaxIds is omitted and partner has none", () => {
+      const res = resolvePartnerTaxId({ partnerTaxId: null })
+      expect(res.source).toBe("none")
+      expect(res.taxId).toBeNull()
+    })
+
+    it("does not leak the partner tax-ID type onto a platform fallback", () => {
+      const res = resolvePartnerTaxId({
+        partnerTaxId: "",
+        partnerTaxIdType: "GSTIN",
+        platformTaxIds,
+      })
+      expect(res.source).toBe("platform")
+      expect(res.taxIdType).toBeNull()
+    })
+
+    it("honours an unrecognised brand by mapping to defaultBrand for fallback", () => {
+      const res = resolvePartnerTaxId({
+        partnerTaxId: null,
+        brand: "UNKNOWN",
+        defaultBrand: "KHT",
+        platformTaxIds,
+      })
+      expect(res.brand).toBe("KHT")
+      expect(res.taxId).toBe("KHT-GST-222")
+    })
+  })
+
+  describe("getPlatformTaxIds", () => {
+    it("reads brand tax IDs from the injected env", () => {
+      const ids = getPlatformTaxIds({
+        JYT_PLATFORM_TAX_ID: "JYT-ENV-1",
+        KHT_PLATFORM_TAX_ID: "KHT-ENV-2",
+      })
+      expect(ids).toEqual({ JYT: "JYT-ENV-1", KHT: "KHT-ENV-2" })
+    })
+
+    it("returns nulls for missing / blank env values", () => {
+      expect(getPlatformTaxIds({})).toEqual({ JYT: null, KHT: null })
+      expect(
+        getPlatformTaxIds({ JYT_PLATFORM_TAX_ID: "   ", KHT_PLATFORM_TAX_ID: "" })
+      ).toEqual({ JYT: null, KHT: null })
+    })
+  })
+})

--- a/apps/backend/src/modules/partner/migrations/Migration20260622120000.ts
+++ b/apps/backend/src/modules/partner/migrations/Migration20260622120000.ts
@@ -1,0 +1,15 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+export class Migration20260622120000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "partner" add column if not exists "tax_id" text null;`);
+    this.addSql(`alter table if exists "partner" add column if not exists "tax_id_type" text null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "partner" drop column if exists "tax_id";`);
+    this.addSql(`alter table if exists "partner" drop column if exists "tax_id_type";`);
+  }
+
+}

--- a/apps/backend/src/modules/partner/models/partner.ts
+++ b/apps/backend/src/modules/partner/models/partner.ts
@@ -21,6 +21,13 @@ const Partner = model.define("partner", {
     whatsapp_number: model.text().nullable(),
     whatsapp_verified: model.boolean().default(false),
 
+    // Legal / billing identity — partner's own tax / GST / registration ID.
+    // When null, invoice/label generation falls back to the platform (JYT/KHT)
+    // tax ID so documents stay legally valid (see tax-id-lib.ts, issue #348).
+    // Typed column (NOT metadata) because it is load-bearing for compliance.
+    tax_id: model.text().nullable(),
+    tax_id_type: model.text().nullable(), // e.g. "GSTIN", "VAT", "PAN"
+
     // Storefront
     storefront_domain: model.text().nullable(),
     website_id: model.text().nullable(),

--- a/apps/backend/src/modules/partner/tax-id-lib.ts
+++ b/apps/backend/src/modules/partner/tax-id-lib.ts
@@ -1,0 +1,120 @@
+/**
+ * Tax-ID fallback resolution (issue #348).
+ *
+ * When a partner has not supplied their own tax / GST / registration ID, the
+ * platform must bill orders, invoices and shipping labels under its own brand
+ * tax ID (JYT or KHT, brand-dependent) so the documents stay legally valid.
+ *
+ * This module is a PURE library (no container, no I/O beyond an injectable env
+ * read) so the fallback logic can be unit-tested in isolation and reused at any
+ * generation point (Delhivery `seller_gst_tin`, Shiprocket `gstin`, invoices).
+ */
+
+export type TaxIdBrand = "JYT" | "KHT"
+
+export type ResolvedTaxIdSource = "partner" | "platform" | "none"
+
+export interface PlatformTaxIds {
+  JYT?: string | null
+  KHT?: string | null
+}
+
+export interface ResolvePartnerTaxIdInput {
+  /** The partner's own tax ID (e.g. `partner.tax_id`); may be null/empty. */
+  partnerTaxId?: string | null
+  /** The partner's tax-ID type (e.g. `partner.tax_id_type`); carried through. */
+  partnerTaxIdType?: string | null
+  /** Brand the order/document is billed under; defaults to `defaultBrand`. */
+  brand?: string | null
+  /** Platform fallback tax IDs, keyed by brand (see `getPlatformTaxIds`). */
+  platformTaxIds?: PlatformTaxIds | null
+  /** Brand used when `brand` is missing/unrecognised. Defaults to "JYT". */
+  defaultBrand?: TaxIdBrand
+}
+
+export interface ResolvedTaxId {
+  /** The effective tax ID to stamp on the document, or null if none available. */
+  taxId: string | null
+  /** Where `taxId` came from: the partner, the platform fallback, or nothing. */
+  source: ResolvedTaxIdSource
+  /** The brand the fallback resolved against (normalised). */
+  brand: TaxIdBrand
+  /** Tax-ID type when sourced from the partner; null for platform/none. */
+  taxIdType: string | null
+}
+
+export const KNOWN_BRANDS: TaxIdBrand[] = ["JYT", "KHT"]
+
+const DEFAULT_BRAND: TaxIdBrand = "JYT"
+
+/** Trim a string-ish value; treat empty/whitespace/non-strings as null. */
+function clean(value?: string | null): string | null {
+  if (typeof value !== "string") {
+    return null
+  }
+  const trimmed = value.trim()
+  return trimmed.length ? trimmed : null
+}
+
+/**
+ * Normalise an arbitrary brand string to a known `TaxIdBrand`, falling back to
+ * `defaultBrand` for missing/unrecognised values. Case-insensitive.
+ */
+export function normalizeBrand(
+  brand?: string | null,
+  defaultBrand: TaxIdBrand = DEFAULT_BRAND
+): TaxIdBrand {
+  const cleaned = clean(brand)
+  if (!cleaned) {
+    return defaultBrand
+  }
+  const upper = cleaned.toUpperCase()
+  return (KNOWN_BRANDS as string[]).includes(upper)
+    ? (upper as TaxIdBrand)
+    : defaultBrand
+}
+
+/**
+ * Resolve the effective tax ID for a document.
+ *
+ * Precedence: the partner's own tax ID wins; otherwise fall back to the
+ * platform tax ID for the resolved brand; otherwise `null` (source "none").
+ */
+export function resolvePartnerTaxId(
+  input: ResolvePartnerTaxIdInput
+): ResolvedTaxId {
+  const brand = normalizeBrand(input.brand, input.defaultBrand ?? DEFAULT_BRAND)
+  const partnerTaxId = clean(input.partnerTaxId)
+
+  if (partnerTaxId) {
+    return {
+      taxId: partnerTaxId,
+      source: "partner",
+      brand,
+      taxIdType: clean(input.partnerTaxIdType),
+    }
+  }
+
+  const platform = input.platformTaxIds ?? {}
+  const fallback = clean(platform[brand])
+  if (fallback) {
+    return { taxId: fallback, source: "platform", brand, taxIdType: null }
+  }
+
+  return { taxId: null, source: "none", brand, taxIdType: null }
+}
+
+/**
+ * Read the platform fallback tax IDs from the environment. Takes an explicit
+ * `env` object so it stays unit-testable; defaults to `process.env`.
+ *
+ * Configure via `JYT_PLATFORM_TAX_ID` / `KHT_PLATFORM_TAX_ID`.
+ */
+export function getPlatformTaxIds(
+  env: Record<string, string | undefined> = process.env
+): PlatformTaxIds {
+  return {
+    JYT: clean(env.JYT_PLATFORM_TAX_ID),
+    KHT: clean(env.KHT_PLATFORM_TAX_ID),
+  }
+}


### PR DESCRIPTION
Closes part of #348 (slice A — foundation).

## What
When a partner hasn't supplied their own tax / GST / registration ID, invoices/orders/shipping-labels must bill under the **platform (JYT/KHT, brand-dependent)** tax ID so the documents stay legally valid.

This slice lands the **data model + pure resolver** — the load-bearing, unit-tested core. It does **not** yet wire the resolver into the live carrier payloads (deferred, see below).

## Changes
- **`partner.tax_id` / `partner.tax_id_type`** — typed nullable columns on the partner model (NOT `metadata`; this is load-bearing for compliance per the project's "no-critical-data-in-metadata" rule) + a hand-written `add column if not exists` migration (avoids the create-if-not-exists hazard on existing DBs).
- **`modules/partner/tax-id-lib.ts`** — pure `resolvePartnerTaxId()`:
  - partner's own tax ID wins → `source: "partner"`
  - else platform fallback for the resolved brand → `source: "platform"`
  - else `source: "none"`
  - plus `normalizeBrand()` (case-insensitive, JYT/KHT, default JYT) and `getPlatformTaxIds(env)` reading `JYT_PLATFORM_TAX_ID` / `KHT_PLATFORM_TAX_ID`.
- **15 unit tests** for the resolver/brand/env + **1 per-file integration spec** asserting the columns persist end-to-end.

## Trigger decision (lower-risk option chosen)
Tax ID is stored **per-partner** (typed column) and the effective ID is resolved **lazily at generation time** (per-document) — no stored per-order copy that can go stale, no backfill needed. Noted on the issue.

## Deferred to next slice (noted on #348)
Wire `resolvePartnerTaxId` into the carrier payloads — the exact points found during investigation:
- Delhivery `delhivery/adapter.ts` `createShipment` → add `seller_gst_tin` (currently never passed).
- Shiprocket `shiprocket/client.ts:343` → `gstin: input.gstin || ...` (input.gstin currently never populated) + `registerPickupLocation`.
- No invoice-PDF generation exists in the codebase today (labels are carrier-generated).

## Verification
- `TEST_TYPE=unit ... jest tax-id-lib` → **15/15 pass**.
- tsc baseline for apps/backend unchanged (69, **0 new** errors).
- ⚠️ The integration spec could **not** be run locally: a long-running `medusa develop` server holds DB locks that deadlock the test-harness TRUNCATE. The spec is well-formed (mirrors the established `getContainer`/`resolve("partner")` pattern, verified method names `createPartners`/`retrievePartner`) and will run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)