### PR TITLE
feat(shipping): #348 slice B — platform tax-ID fallback in carrier labels

### DIFF
--- a/apps/backend/integration-tests/http/partner-tax-id-labels.spec.ts
+++ b/apps/backend/integration-tests/http/partner-tax-id-labels.spec.ts
@@ -1,0 +1,65 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import {
+  resolvePlatformTaxIdForCountry,
+  resolveSellerTaxIdForOrder,
+} from "../../src/modules/shipping-providers/seller-tax-id"
+
+jest.setTimeout(60 * 1000)
+
+/**
+ * Issue #348 slice B — verifies the seller-tax-ID resolution that threads into
+ * carrier label payloads (Delhivery `seller_gst_tin`, Shiprocket `gstin`).
+ *
+ * `resolveSellerTaxIdForOrder` does the I/O (partner↔order link + partner row)
+ * and delegates the precedence math to the pure `resolveTaxIdForCountry`. With
+ * no partner link it must degrade to the platform fallback chosen by country —
+ * never throw — so a missing partner / un-migrated tax_id column can't block a
+ * label.
+ */
+setupSharedTestSuite(() => {
+  const { getContainer } = getSharedTestEnv()
+
+  const ORIG_ENV = { ...process.env }
+  beforeAll(() => {
+    process.env.PLATFORM_TAX_ID_JYT = "JYT-PLATFORM-GSTIN"
+    process.env.PLATFORM_TAX_ID_KHT = "KHT-PLATFORM-VAT"
+  })
+  afterAll(() => {
+    process.env.PLATFORM_TAX_ID_JYT = ORIG_ENV.PLATFORM_TAX_ID_JYT
+    process.env.PLATFORM_TAX_ID_KHT = ORIG_ENV.PLATFORM_TAX_ID_KHT
+  })
+
+  it("falls back to the platform GSTIN by country when no partner link exists", async () => {
+    const container = getContainer()
+    // A non-existent order id → no partner↔order link → platform fallback.
+    const inTaxId = await resolveSellerTaxIdForOrder(
+      container,
+      "order_does_not_exist_in",
+      "IN"
+    )
+    expect(inTaxId).toBe("JYT-PLATFORM-GSTIN")
+
+    const euTaxId = await resolveSellerTaxIdForOrder(
+      container,
+      "order_does_not_exist_eu",
+      "DE"
+    )
+    expect(euTaxId).toBe("KHT-PLATFORM-VAT")
+  })
+
+  it("returns undefined for a jurisdiction the platform has no entity in", async () => {
+    const container = getContainer()
+    const usTaxId = await resolveSellerTaxIdForOrder(
+      container,
+      "order_does_not_exist_us",
+      "US"
+    )
+    expect(usTaxId).toBeUndefined()
+  })
+
+  it("resolvePlatformTaxIdForCountry maps country→platform GSTIN/VAT (no I/O)", () => {
+    expect(resolvePlatformTaxIdForCountry("India")).toBe("JYT-PLATFORM-GSTIN")
+    expect(resolvePlatformTaxIdForCountry("FR")).toBe("KHT-PLATFORM-VAT")
+    expect(resolvePlatformTaxIdForCountry("US")).toBeUndefined()
+  })
+})

--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -1,5 +1,6 @@
 import { loadEnv, defineConfig, Modules } from "@medusajs/framework/utils";
 import path from "path";
+import { getPlatformTaxIdConfig } from "./src/modules/partner/tax-id-lib";
 
 loadEnv(process.env.NODE_ENV || 'development', process.cwd())
 
@@ -475,3 +476,15 @@ module.exports = defineConfig({
   },
 ],
 });
+
+/**
+ * Platform tax-ID fallback (#348) — country→brand→{tax_id, tax_id_type}.
+ *
+ * When a partner has no own tax ID, carrier labels stamp the platform's brand
+ * tax ID, chosen by the order / ship-from country (IN→JYT GSTIN, EU→KHT VAT).
+ * The country→brand map is jurisdiction logic in src/modules/partner/tax-id-lib;
+ * the tax-ID NUMBERS come from env (placeholders until the real numbers are
+ * supplied): PLATFORM_TAX_ID_JYT / PLATFORM_TAX_ID_KHT (+ optional
+ * PLATFORM_TAX_ID_TYPE_JYT / PLATFORM_TAX_ID_TYPE_KHT overrides).
+ */
+module.exports.platformTaxIds = getPlatformTaxIdConfig(process.env);

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -1,5 +1,6 @@
 import { loadEnv, defineConfig, Modules } from "@medusajs/framework/utils";
 import path from "path";
+import { getPlatformTaxIdConfig } from "./src/modules/partner/tax-id-lib";
 
 loadEnv(process.env.NODE_ENV || 'development', process.cwd())
 
@@ -450,3 +451,15 @@ module.exports = defineConfig({
   },
 ],
 });
+
+/**
+ * Platform tax-ID fallback (#348) — country→brand→{tax_id, tax_id_type}.
+ *
+ * When a partner has no own tax ID, carrier labels stamp the platform's brand
+ * tax ID, chosen by the order / ship-from country (IN→JYT GSTIN, EU→KHT VAT).
+ * The country→brand map is jurisdiction logic in src/modules/partner/tax-id-lib;
+ * the tax-ID NUMBERS come from env (placeholders until the real numbers are
+ * supplied): PLATFORM_TAX_ID_JYT / PLATFORM_TAX_ID_KHT (+ optional
+ * PLATFORM_TAX_ID_TYPE_JYT / PLATFORM_TAX_ID_TYPE_KHT overrides).
+ */
+module.exports.platformTaxIds = getPlatformTaxIdConfig(process.env);

--- a/apps/backend/src/modules/partner/__tests__/tax-id-lib.unit.spec.ts
+++ b/apps/backend/src/modules/partner/__tests__/tax-id-lib.unit.spec.ts
@@ -1,0 +1,171 @@
+import {
+  EU_VAT_COUNTRY_CODES,
+  getPlatformTaxIdConfig,
+  getPlatformTaxIds,
+  normalizeBrand,
+  resolveBrandForCountry,
+  resolvePartnerTaxId,
+  resolveTaxIdForCountry,
+} from "../tax-id-lib"
+
+describe("tax-id-lib (#348)", () => {
+  describe("normalizeBrand", () => {
+    it("passes through known brands, case-insensitively", () => {
+      expect(normalizeBrand("JYT")).toBe("JYT")
+      expect(normalizeBrand("kht")).toBe("KHT")
+    })
+    it("falls back to the default brand for missing/unknown values", () => {
+      expect(normalizeBrand(null)).toBe("JYT")
+      expect(normalizeBrand("  ")).toBe("JYT")
+      expect(normalizeBrand("ACME")).toBe("JYT")
+      expect(normalizeBrand("ACME", "KHT")).toBe("KHT")
+    })
+  })
+
+  describe("resolveBrandForCountry", () => {
+    it("maps India (IN / India / IND) → JYT", () => {
+      expect(resolveBrandForCountry("IN")).toBe("JYT")
+      expect(resolveBrandForCountry("in")).toBe("JYT")
+      expect(resolveBrandForCountry("India")).toBe("JYT")
+      expect(resolveBrandForCountry("IND")).toBe("JYT")
+    })
+    it("maps EU member states → KHT", () => {
+      expect(resolveBrandForCountry("DE")).toBe("KHT")
+      expect(resolveBrandForCountry("fr")).toBe("KHT")
+      expect(resolveBrandForCountry("NL")).toBe("KHT")
+    })
+    it("returns null for non-IN / non-EU and empty input", () => {
+      expect(resolveBrandForCountry("US")).toBeNull()
+      expect(resolveBrandForCountry("GB")).toBeNull() // UK left the EU
+      expect(resolveBrandForCountry(null)).toBeNull()
+      expect(resolveBrandForCountry("")).toBeNull()
+    })
+    it("keeps the EU set free of non-members", () => {
+      expect(EU_VAT_COUNTRY_CODES.has("GB")).toBe(false)
+      expect(EU_VAT_COUNTRY_CODES.has("CH")).toBe(false)
+      expect(EU_VAT_COUNTRY_CODES.has("DE")).toBe(true)
+    })
+  })
+
+  describe("resolvePartnerTaxId (brand-keyed)", () => {
+    const platformTaxIds = { JYT: "JYT-GSTIN-123", KHT: "KHT-VAT-456" }
+
+    it("prefers the partner's own tax ID, carrying through its type", () => {
+      const r = resolvePartnerTaxId({
+        partnerTaxId: "PARTNER-GST-9",
+        partnerTaxIdType: "gstin",
+        brand: "JYT",
+        platformTaxIds,
+      })
+      expect(r).toMatchObject({
+        taxId: "PARTNER-GST-9",
+        source: "partner",
+        brand: "JYT",
+        taxIdType: "gstin",
+      })
+    })
+
+    it("falls back to the platform tax ID for the brand", () => {
+      const r = resolvePartnerTaxId({ brand: "KHT", platformTaxIds })
+      expect(r).toMatchObject({
+        taxId: "KHT-VAT-456",
+        source: "platform",
+        brand: "KHT",
+        taxIdType: "vat",
+      })
+    })
+
+    it("returns none when neither partner nor platform has an ID", () => {
+      const r = resolvePartnerTaxId({ brand: "JYT", platformTaxIds: {} })
+      expect(r).toMatchObject({ taxId: null, source: "none", brand: "JYT" })
+    })
+  })
+
+  describe("resolveTaxIdForCountry (country-aware, slice B)", () => {
+    const config = getPlatformTaxIdConfig({
+      PLATFORM_TAX_ID_JYT: "JYT-GSTIN-123",
+      PLATFORM_TAX_ID_KHT: "KHT-VAT-456",
+    })
+
+    it("IN with no partner ID → JYT platform GSTIN", () => {
+      const r = resolveTaxIdForCountry({ countryCode: "IN", config })
+      expect(r).toMatchObject({
+        taxId: "JYT-GSTIN-123",
+        source: "platform",
+        brand: "JYT",
+        taxIdType: "gstin",
+      })
+    })
+
+    it("an EU country (DE) with no partner ID → KHT platform VAT", () => {
+      const r = resolveTaxIdForCountry({ countryCode: "DE", config })
+      expect(r).toMatchObject({
+        taxId: "KHT-VAT-456",
+        source: "platform",
+        brand: "KHT",
+        taxIdType: "vat",
+      })
+    })
+
+    it("partner-owned tax ID wins over the platform fallback (any country)", () => {
+      const r = resolveTaxIdForCountry({
+        partnerTaxId: "PARTNER-GST-9",
+        partnerTaxIdType: "gstin",
+        countryCode: "IN",
+        config,
+      })
+      expect(r).toMatchObject({
+        taxId: "PARTNER-GST-9",
+        source: "partner",
+        brand: "JYT",
+        taxIdType: "gstin",
+      })
+    })
+
+    it("unknown country with no partner ID → none", () => {
+      const r = resolveTaxIdForCountry({ countryCode: "US", config })
+      expect(r).toMatchObject({ taxId: null, source: "none" })
+    })
+
+    it("known country but unconfigured platform ID → none", () => {
+      const r = resolveTaxIdForCountry({
+        countryCode: "IN",
+        config: getPlatformTaxIdConfig({}),
+      })
+      expect(r).toMatchObject({ taxId: null, source: "none", brand: "JYT" })
+    })
+
+    it("partner ID still wins even for an unknown jurisdiction", () => {
+      const r = resolveTaxIdForCountry({
+        partnerTaxId: "PARTNER-X",
+        countryCode: "US",
+        config,
+      })
+      expect(r).toMatchObject({ taxId: "PARTNER-X", source: "partner" })
+    })
+  })
+
+  describe("getPlatformTaxIdConfig / getPlatformTaxIds (env)", () => {
+    it("reads brand IDs + type overrides from env, with type defaults", () => {
+      const cfg = getPlatformTaxIdConfig({
+        PLATFORM_TAX_ID_JYT: "  JYT-1  ",
+        PLATFORM_TAX_ID_KHT: "KHT-2",
+        PLATFORM_TAX_ID_TYPE_KHT: "eu_vat",
+      })
+      expect(cfg.JYT).toEqual({ taxId: "JYT-1", taxIdType: "gstin" })
+      expect(cfg.KHT).toEqual({ taxId: "KHT-2", taxIdType: "eu_vat" })
+    })
+
+    it("treats blank/missing env as null IDs", () => {
+      const cfg = getPlatformTaxIdConfig({ PLATFORM_TAX_ID_JYT: "   " })
+      expect(cfg.JYT.taxId).toBeNull()
+      expect(cfg.KHT.taxId).toBeNull()
+    })
+
+    it("getPlatformTaxIds reads the same env keys", () => {
+      expect(
+        getPlatformTaxIds({ PLATFORM_TAX_ID_JYT: "J", PLATFORM_TAX_ID_KHT: "K" })
+      ).toEqual({ JYT: "J", KHT: "K" })
+    })
+  })
+})

--- a/apps/backend/src/modules/partner/tax-id-lib.ts
+++ b/apps/backend/src/modules/partner/tax-id-lib.ts
@@ -1,0 +1,279 @@
+/**
+ * Tax-ID fallback resolution (issue #348).
+ *
+ * When a partner has not supplied their own tax / GST / registration ID, the
+ * platform must bill orders and shipping labels under its own brand tax ID so
+ * the documents stay legally valid. The partner sells *through us*, so the brand
+ * is jurisdiction-driven by the order / ship-from country:
+ *
+ *   - India (IN)        → JYT ("Jaal Yantra Textiles Private Limited", GSTIN)
+ *   - EU member states  → KHT ("Kind Health Tech", EU VAT)
+ *
+ * Resolution order: `partner.tax_id` (own) → platform-by-country → none.
+ *
+ * This module is a PURE library (no container, no I/O beyond an injectable env
+ * read) so the fallback logic can be unit-tested in isolation and reused at any
+ * generation point (Delhivery `seller_gst_tin`, Shiprocket `gstin`, …).
+ *
+ * Slice A (PR #652) shipped the partner columns + the brand-keyed resolver.
+ * Slice B adds the country→brand mapping + config so carrier labels can resolve
+ * the fallback at generation time without a stored per-partner brand flag.
+ */
+
+export type TaxIdBrand = "JYT" | "KHT"
+
+export type ResolvedTaxIdSource = "partner" | "platform" | "none"
+
+export interface PlatformTaxIds {
+  JYT?: string | null
+  KHT?: string | null
+}
+
+export interface ResolvePartnerTaxIdInput {
+  /** The partner's own tax ID (e.g. `partner.tax_id`); may be null/empty. */
+  partnerTaxId?: string | null
+  /** The partner's tax-ID type (e.g. `partner.tax_id_type`); carried through. */
+  partnerTaxIdType?: string | null
+  /** Brand the order/document is billed under; defaults to `defaultBrand`. */
+  brand?: string | null
+  /** Platform fallback tax IDs, keyed by brand (see `getPlatformTaxIds`). */
+  platformTaxIds?: PlatformTaxIds | null
+  /** Brand used when `brand` is missing/unrecognised. Defaults to "JYT". */
+  defaultBrand?: TaxIdBrand
+}
+
+export interface ResolvedTaxId {
+  /** The effective tax ID to stamp on the document, or null if none available. */
+  taxId: string | null
+  /** Where `taxId` came from: the partner, the platform fallback, or nothing. */
+  source: ResolvedTaxIdSource
+  /** The brand the fallback resolved against (normalised). */
+  brand: TaxIdBrand
+  /** Tax-ID type (partner-supplied or the platform brand's type); null if none. */
+  taxIdType: string | null
+}
+
+export const KNOWN_BRANDS: TaxIdBrand[] = ["JYT", "KHT"]
+
+const DEFAULT_BRAND: TaxIdBrand = "JYT"
+
+/** Default tax-ID type per brand (overridable via env). */
+const DEFAULT_BRAND_TAX_ID_TYPE: Record<TaxIdBrand, string> = {
+  JYT: "gstin",
+  KHT: "vat",
+}
+
+/**
+ * ISO 3166-1 alpha-2 codes of the EU member states (KHT / EU-VAT jurisdiction).
+ * Kept as code (not config) because it's stable jurisdiction logic, not a
+ * deployment secret — only the tax-ID *numbers* come from env.
+ */
+export const EU_VAT_COUNTRY_CODES: ReadonlySet<string> = new Set([
+  "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI", "FR", "DE", "GR",
+  "HU", "IE", "IT", "LV", "LT", "LU", "MT", "NL", "PL", "PT", "RO", "SK",
+  "SI", "ES", "SE",
+])
+
+/** Trim a string-ish value; treat empty/whitespace/non-strings as null. */
+function clean(value?: string | null): string | null {
+  if (typeof value !== "string") {
+    return null
+  }
+  const trimmed = value.trim()
+  return trimmed.length ? trimmed : null
+}
+
+/** Normalise a country code/name to an upper-case ISO alpha-2 where possible. */
+function normalizeCountry(country?: string | null): string | null {
+  const cleaned = clean(country)
+  if (!cleaned) {
+    return null
+  }
+  const upper = cleaned.toUpperCase()
+  // Common full-name aliases for the platform's primary jurisdiction.
+  if (upper === "INDIA" || upper === "IND") {
+    return "IN"
+  }
+  return upper
+}
+
+/**
+ * Normalise an arbitrary brand string to a known `TaxIdBrand`, falling back to
+ * `defaultBrand` for missing/unrecognised values. Case-insensitive.
+ */
+export function normalizeBrand(
+  brand?: string | null,
+  defaultBrand: TaxIdBrand = DEFAULT_BRAND
+): TaxIdBrand {
+  const cleaned = clean(brand)
+  if (!cleaned) {
+    return defaultBrand
+  }
+  const upper = cleaned.toUpperCase()
+  return (KNOWN_BRANDS as string[]).includes(upper)
+    ? (upper as TaxIdBrand)
+    : defaultBrand
+}
+
+/**
+ * Map an order / ship-from country onto the platform brand whose tax ID applies:
+ * India → JYT, EU member states → KHT. Returns `null` for jurisdictions the
+ * platform has no registered entity in (→ no fallback, source "none").
+ */
+export function resolveBrandForCountry(
+  country?: string | null
+): TaxIdBrand | null {
+  const code = normalizeCountry(country)
+  if (!code) {
+    return null
+  }
+  if (code === "IN") {
+    return "JYT"
+  }
+  if (EU_VAT_COUNTRY_CODES.has(code)) {
+    return "KHT"
+  }
+  return null
+}
+
+/**
+ * Resolve the effective tax ID for a document by an explicit brand.
+ *
+ * Precedence: the partner's own tax ID wins; otherwise fall back to the
+ * platform tax ID for the resolved brand; otherwise `null` (source "none").
+ */
+export function resolvePartnerTaxId(
+  input: ResolvePartnerTaxIdInput
+): ResolvedTaxId {
+  const brand = normalizeBrand(input.brand, input.defaultBrand ?? DEFAULT_BRAND)
+  const partnerTaxId = clean(input.partnerTaxId)
+
+  if (partnerTaxId) {
+    return {
+      taxId: partnerTaxId,
+      source: "partner",
+      brand,
+      taxIdType: clean(input.partnerTaxIdType),
+    }
+  }
+
+  const platform = input.platformTaxIds ?? {}
+  const fallback = clean(platform[brand])
+  if (fallback) {
+    return {
+      taxId: fallback,
+      source: "platform",
+      brand,
+      taxIdType: DEFAULT_BRAND_TAX_ID_TYPE[brand],
+    }
+  }
+
+  return { taxId: null, source: "none", brand, taxIdType: null }
+}
+
+/** Platform tax-ID config, keyed by brand. Values typically come from env. */
+export type PlatformTaxIdConfig = Record<
+  TaxIdBrand,
+  { taxId: string | null; taxIdType: string }
+>
+
+export interface ResolveTaxIdForCountryInput {
+  /** The partner's own tax ID (`partner.tax_id`); may be null/empty. */
+  partnerTaxId?: string | null
+  /** The partner's tax-ID type (`partner.tax_id_type`); carried through. */
+  partnerTaxIdType?: string | null
+  /** Order / ship-from country (ISO alpha-2 or a name like "India"). */
+  countryCode?: string | null
+  /** Platform fallback config keyed by brand (see `getPlatformTaxIdConfig`). */
+  config?: PlatformTaxIdConfig | null
+}
+
+/**
+ * Country-aware resolution (slice B). Precedence:
+ *   1. the partner's own tax ID (any country),
+ *   2. the platform tax ID for the brand the country maps to (IN→JYT, EU→KHT),
+ *   3. none.
+ *
+ * The brand for a platform fallback is derived from the country — there is no
+ * stored per-partner brand flag, so labels stay stateless (no staleness/backfill).
+ */
+export function resolveTaxIdForCountry(
+  input: ResolveTaxIdForCountryInput
+): ResolvedTaxId {
+  const brandForCountry = resolveBrandForCountry(input.countryCode)
+  // Brand the *result* reports even when there's no fallback: prefer the
+  // country's brand, else the platform default. Keeps `brand` meaningful.
+  const reportBrand = brandForCountry ?? DEFAULT_BRAND
+
+  const partnerTaxId = clean(input.partnerTaxId)
+  if (partnerTaxId) {
+    return {
+      taxId: partnerTaxId,
+      source: "partner",
+      brand: reportBrand,
+      taxIdType: clean(input.partnerTaxIdType),
+    }
+  }
+
+  // No partner ID and no platform entity for this jurisdiction → none.
+  if (!brandForCountry) {
+    return { taxId: null, source: "none", brand: reportBrand, taxIdType: null }
+  }
+
+  const config = input.config ?? null
+  const entry = config?.[brandForCountry]
+  const fallback = clean(entry?.taxId)
+  if (fallback) {
+    return {
+      taxId: fallback,
+      source: "platform",
+      brand: brandForCountry,
+      taxIdType: entry?.taxIdType || DEFAULT_BRAND_TAX_ID_TYPE[brandForCountry],
+    }
+  }
+
+  return { taxId: null, source: "none", brand: brandForCountry, taxIdType: null }
+}
+
+/**
+ * Read the platform fallback tax IDs from the environment. Takes an explicit
+ * `env` object so it stays unit-testable; defaults to `process.env`.
+ *
+ * Configure via `PLATFORM_TAX_ID_JYT` / `PLATFORM_TAX_ID_KHT`.
+ */
+export function getPlatformTaxIds(
+  env: Record<string, string | undefined> = process.env
+): PlatformTaxIds {
+  return {
+    JYT: clean(env.PLATFORM_TAX_ID_JYT),
+    KHT: clean(env.PLATFORM_TAX_ID_KHT),
+  }
+}
+
+/**
+ * Build the brand-keyed platform tax-ID config from the environment. Takes an
+ * explicit `env` for unit-testing; defaults to `process.env`.
+ *
+ * Env vars (placeholders until the real numbers are supplied):
+ *   - `PLATFORM_TAX_ID_JYT`        — JYT GSTIN
+ *   - `PLATFORM_TAX_ID_KHT`        — KHT EU VAT
+ *   - `PLATFORM_TAX_ID_TYPE_JYT`   — optional, defaults to "gstin"
+ *   - `PLATFORM_TAX_ID_TYPE_KHT`   — optional, defaults to "vat"
+ *
+ * This is also surfaced (documented) in `medusa-config.ts` / `.prod.ts` so the
+ * mapping has a single discoverable home for ops; the runtime reads the same env.
+ */
+export function getPlatformTaxIdConfig(
+  env: Record<string, string | undefined> = process.env
+): PlatformTaxIdConfig {
+  return {
+    JYT: {
+      taxId: clean(env.PLATFORM_TAX_ID_JYT),
+      taxIdType: clean(env.PLATFORM_TAX_ID_TYPE_JYT) || DEFAULT_BRAND_TAX_ID_TYPE.JYT,
+    },
+    KHT: {
+      taxId: clean(env.PLATFORM_TAX_ID_KHT),
+      taxIdType: clean(env.PLATFORM_TAX_ID_TYPE_KHT) || DEFAULT_BRAND_TAX_ID_TYPE.KHT,
+    },
+  }
+}

--- a/apps/backend/src/modules/shipping-providers/delhivery/adapter.ts
+++ b/apps/backend/src/modules/shipping-providers/delhivery/adapter.ts
@@ -86,6 +86,8 @@ export class DelhiveryProviderAdapter implements ShippingProviderClient {
       seller_city: input.from?.city,
       seller_pin: input.from?.pincode,
       seller_state: input.from?.state,
+      // Seller GST registration (#348): partner-own → platform-by-country fallback.
+      seller_gst_tin: input.tax_id || undefined,
     })
 
     const awb =

--- a/apps/backend/src/modules/shipping-providers/delhivery/service.ts
+++ b/apps/backend/src/modules/shipping-providers/delhivery/service.ts
@@ -9,6 +9,7 @@ import {
   CreateShippingOptionDTO,
 } from "@medusajs/framework/types"
 import { DelhiveryClient, DelhiveryOptions } from "./client"
+import { resolvePlatformTaxIdForCountry } from "../seller-tax-id"
 import { Logger } from "@medusajs/framework/types"
 
 type InjectedDeps = { logger: Logger }
@@ -284,6 +285,11 @@ class DelhiveryFulfillmentService extends AbstractFulfillmentProviderService {
         seller_city: fromLocation.address?.city || "",
         seller_pin: fromLocation.address?.postal_code || "",
         seller_state: fromLocation.address?.province || "",
+        // Seller GST (#348): platform fallback by ship-to country (IN→JYT GSTIN).
+        // Partner-own GSTIN override flows via the generic adapter path.
+        seller_gst_tin: resolvePlatformTaxIdForCountry(
+          shippingAddress.country_code || "India"
+        ),
       })
 
       // Extract auto-assigned waybill from response

--- a/apps/backend/src/modules/shipping-providers/pickup-locations.ts
+++ b/apps/backend/src/modules/shipping-providers/pickup-locations.ts
@@ -20,6 +20,7 @@ import { MedusaError, Modules } from "@medusajs/framework/utils"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { PickupLocation } from "./provider-interface"
 import { resolveShippingProvider } from "./resolver"
+import { resolvePlatformTaxIdForCountry } from "./seller-tax-id"
 
 /** Metadata key recording the Shiprocket nickname for a stock location. */
 export const SHIPROCKET_PICKUP_METADATA_KEY = "shiprocket_pickup_location"
@@ -165,6 +166,8 @@ export async function registerShiprocketPickup(
         state: addr.province || "",
         pincode: addr.postal_code,
         country: "India",
+        // Seller GST on the pickup (#348): platform GSTIN for the pickup country.
+        gstin: resolvePlatformTaxIdForCountry(addr.country_code || "India"),
       })
     } catch (e: any) {
       // Shiprocket rejects a duplicate nickname — treat that as already-present.

--- a/apps/backend/src/modules/shipping-providers/provider-interface.ts
+++ b/apps/backend/src/modules/shipping-providers/provider-interface.ts
@@ -78,6 +78,13 @@ export type CreateShipmentInput = {
    *  single-carrier providers. When omitted, the provider auto-selects. */
   preferred_courier_id?: string | number
   product_description?: string
+  /**
+   * Seller tax / GST / VAT registration ID to stamp on the label (#348). The
+   * partner's own ID when supplied, else the platform fallback resolved by the
+   * order / ship-from country (IN→JYT GSTIN, EU→KHT VAT). Maps to Delhivery
+   * `seller_gst_tin`. Resolve with `resolveTaxIdForCountry` (modules/partner/tax-id-lib).
+   */
+  tax_id?: string
 }
 
 /**

--- a/apps/backend/src/modules/shipping-providers/seller-tax-id.ts
+++ b/apps/backend/src/modules/shipping-providers/seller-tax-id.ts
@@ -1,0 +1,80 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+import partnerOrderLink from "../../links/partner-order"
+import {
+  getPlatformTaxIdConfig,
+  resolveBrandForCountry,
+  resolveTaxIdForCountry,
+} from "../partner/tax-id-lib"
+
+/**
+ * Resolve the seller tax / GST / VAT registration ID to stamp on a carrier label
+ * for an order (#348 slice B).
+ *
+ * Precedence (see modules/partner/tax-id-lib): the order's partner's OWN tax ID
+ * wins; otherwise the platform fallback for the order / ship-from country
+ * (IN→JYT GSTIN, EU→KHT VAT); otherwise none.
+ *
+ * I/O lives here (container + the partner↔order link); the precedence math is the
+ * pure `resolveTaxIdForCountry`. The partner lookup is BEST-EFFORT — a missing
+ * partner, an un-migrated `partner.tax_id` column (slice A / PR #652 not yet
+ * merged), or any query error degrades to the platform fallback rather than
+ * blocking label generation.
+ *
+ * @returns the tax ID string, or `undefined` when none applies.
+ */
+export async function resolveSellerTaxIdForOrder(
+  container: MedusaContainer,
+  orderId: string | null | undefined,
+  countryCode: string | null | undefined
+): Promise<string | undefined> {
+  let partnerTaxId: string | null = null
+  let partnerTaxIdType: string | null = null
+
+  if (orderId) {
+    try {
+      const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+      const { data: links } = await query.graph({
+        entity: partnerOrderLink.entryPoint,
+        fields: ["partner_id"],
+        filters: { order_id: orderId },
+      })
+      const partnerId = links?.[0]?.partner_id
+      if (partnerId) {
+        const { data: partners } = await query.graph({
+          entity: "partner",
+          fields: ["id", "tax_id", "tax_id_type"],
+          filters: { id: partnerId },
+        })
+        const partner = partners?.[0]
+        partnerTaxId = partner?.tax_id ?? null
+        partnerTaxIdType = partner?.tax_id_type ?? null
+      }
+    } catch {
+      // Best-effort: degrade to the platform fallback (e.g. tax_id column not yet
+      // migrated, no partner link, or query error). Never block the label.
+    }
+  }
+
+  const resolved = resolveTaxIdForCountry({
+    partnerTaxId,
+    partnerTaxIdType,
+    countryCode,
+    config: getPlatformTaxIdConfig(),
+  })
+  return resolved.taxId || undefined
+}
+
+/**
+ * Platform-only seller tax ID for a country (no partner/order context, e.g.
+ * registering a Shiprocket pickup location). India→JYT GSTIN, EU→KHT VAT.
+ */
+export function resolvePlatformTaxIdForCountry(
+  countryCode: string | null | undefined
+): string | undefined {
+  const brand = resolveBrandForCountry(countryCode)
+  if (!brand) {
+    return undefined
+  }
+  return getPlatformTaxIdConfig()[brand].taxId || undefined
+}

--- a/apps/backend/src/workflows/orders/shiprocket-shipment.ts
+++ b/apps/backend/src/workflows/orders/shiprocket-shipment.ts
@@ -15,6 +15,7 @@ import {
   SHIPROCKET_PICKUP_METADATA_KEY,
   chooseRegisteredPickup,
 } from "../../modules/shipping-providers/pickup-locations"
+import { resolveSellerTaxIdForOrder } from "../../modules/shipping-providers/seller-tax-id"
 
 /**
  * #404 (#31) PR-B — generate a Shiprocket shipment (forward order → AWB → label)
@@ -49,6 +50,8 @@ export type BuildShipmentOpts = {
   weightGrams?: number
   dimensionsCm?: Dimensions
   preferredCourierId?: string | number
+  /** Seller tax/GST ID to stamp on the label (#348); resolved by the caller. */
+  taxId?: string
 }
 
 /**
@@ -101,6 +104,7 @@ export function buildCreateShipmentInput(
     dimensions_cm: opts.dimensionsCm,
     sub_total: subTotal,
     preferred_courier_id: opts.preferredCourierId,
+    tax_id: opts.taxId,
   }
 }
 
@@ -196,11 +200,19 @@ export async function createShiprocketShipmentForFulfillment(
     )
   }
 
+  // Seller tax/GST ID (#348): partner-own → platform-by-country fallback.
+  const taxId = await resolveSellerTaxIdForOrder(
+    container,
+    order.id,
+    (order as any)?.shipping_address?.country_code
+  )
+
   const shipmentInput = buildCreateShipmentInput(order as OrderForShipment, {
     pickupLocationName,
     weightGrams: input.weightGrams,
     dimensionsCm: input.dimensionsCm,
     preferredCourierId: input.preferredCourierId,
+    taxId,
   })
   const result = await provider.createShipment(shipmentInput)
 


### PR DESCRIPTION
## #348 slice B — platform tax-ID fallback in carrier labels

Builds on **slice A (PR #652)**. Wires the partner→platform tax-ID fallback into the **Shiprocket (`gstin`)** and **Delhivery (`seller_gst_tin`)** label payloads.

### Locked decision (#348)
When a partner has **no own tax ID**, stamp the **platform brand tax ID chosen by order / ship-from country** (partner sells *through us*):
- **India (IN)** → **JYT** GSTIN
- **EU member states** → **KHT** EU VAT
- Resolution order: `partner.tax_id` (own) → **platform-by-country** → none.

### What's in this PR
- **Pure lib** `modules/partner/tax-id-lib.ts` (re-derived from slice A + extended): `resolveBrandForCountry` (IN→JYT, EU set→KHT), `getPlatformTaxIdConfig(env)`, country-aware `resolveTaxIdForCountry`. EU country list is jurisdiction *code*; only the tax-ID **numbers** come from env. **18 unit tests**.
- **I/O helper** `modules/shipping-providers/seller-tax-id.ts`: `resolveSellerTaxIdForOrder` (best-effort partner↔order link lookup → pure resolver; **never throws** so a missing partner / un-migrated `tax_id` column can't block a label) + `resolvePlatformTaxIdForCountry` (platform-only, no context).
- **Threaded into**: `CreateShipmentInput.tax_id` → Delhivery adapter `seller_gst_tin`; Delhivery service direct path; Shiprocket forward shipment (`buildCreateShipmentInput` `opts.taxId`); Shiprocket pickup registration `gstin`.
- **Config**: `platformTaxIds` documented in `medusa-config.ts` + `.prod.ts`; values via `PLATFORM_TAX_ID_JYT` / `PLATFORM_TAX_ID_KHT` (+ optional `*_TYPE_*`).
- **3 integration tests** (platform fallback against a real container).

### ⚠ Notes for the reviewer
- **Branched off `main`, NOT stacked on #652** (per directive). It therefore **re-derives `tax-id-lib.ts`** (+ unit spec). It does **not** re-include slice A's partner model field / migration — the helper reads `partner.tax_id` **defensively** (degrades to the platform fallback until #652 merges). **Merge #652 first**, then resolve the trivial `tax-id-lib.ts` / unit-spec overlap (this PR is a superset), or merge this alone for the platform-fallback path.
- **Real GSTIN / VAT numbers still TBD** — env placeholders until supplied.
- Partner-own GSTIN override on the legacy Delhivery *service* path + Shiprocket *pickup* registration is a noted follow-up (those paths lack cheap partner/order context; full precedence applies on the order-context paths).

### Verify
- `cd apps/backend && TEST_TYPE=unit npx jest --testPathPattern="tax-id-lib.unit"` → 18 pass
- `pnpm test:integration:http:shared -- integration-tests/http/partner-tax-id-labels.spec.ts` → 3 pass
- tsc baseline unchanged (69, 0 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)