### PR TITLE
feat(#604): design-brief admin CRUD API routes (slice B)

### DIFF
--- a/apps/backend/integration-tests/http/design-brief-routes.spec.ts
+++ b/apps/backend/integration-tests/http/design-brief-routes.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * Roadmap #604 — Design Brief, Slice B (admin CRUD API routes).
+ *
+ * Exercises GET/POST/PUT /admin/designs/:id/brief end-to-end through the HTTP
+ * stack (validators + middleware + update workflow + refetch shaper).
+ */
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { DESIGN_MODULE } from "../../src/modules/designs"
+
+jest.setTimeout(60 * 1000)
+
+setupSharedTestSuite(() => {
+  let headers: any
+  let designId: string
+
+  const { api, getContainer } = getSharedTestEnv()
+
+  beforeAll(async () => {
+    const container = getContainer()
+    await createAdminUser(container)
+    headers = await getAuthHeaders(api)
+  })
+
+  beforeEach(async () => {
+    // Fresh bare design per test (the shared harness truncates between files,
+    // not between its, but a clean design keeps the brief assertions isolated).
+    const designService: any = getContainer().resolve(DESIGN_MODULE)
+    const created = await designService.createDesigns({
+      name: `Brief Route Design ${Date.now()}-${Math.floor(Math.random() * 1e6)}`,
+      description: "brief route test",
+      design_type: "Original",
+      status: "Conceptual",
+      priority: "Medium",
+    })
+    designId = created.id
+  })
+
+  describe("GET /admin/designs/:id/brief", () => {
+    it("returns a null brief for a bare design", async () => {
+      const res = await api.get(`/admin/designs/${designId}/brief`, headers)
+      expect(res.status).toBe(200)
+      expect(res.data.brief).toEqual({
+        concept_theme: null,
+        persona: null,
+        competitors: null,
+        price_point: null,
+        design_budget: null,
+        cost_currency: null,
+      })
+    })
+
+    it("404s for an unknown design", async () => {
+      const err = await api
+        .get(`/admin/designs/design_does_not_exist/brief`, headers)
+        .catch((e) => e)
+      expect(err.response.status).toBe(404)
+    })
+  })
+
+  describe("POST /admin/designs/:id/brief", () => {
+    it("replaces the whole brief and reads it back", async () => {
+      const persona = {
+        age_range: "25-34",
+        lifestyle: "urban minimalist",
+        values: ["sustainability"],
+        pain_points: ["fast-fashion fatigue"],
+      }
+      const competitors = [
+        { name: "Acme Knits", url: "https://acme.example", differentiator: "hand-loomed" },
+        { name: "Bolt Co", differentiator: "lower price" },
+      ]
+
+      const res = await api.post(
+        `/admin/designs/${designId}/brief`,
+        {
+          concept_theme: "90s Tokyo Streetwear",
+          persona,
+          competitors,
+          price_point: "mid_market",
+          design_budget: 5000,
+          cost_currency: "inr",
+        },
+        headers
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.data.brief.concept_theme).toBe("90s Tokyo Streetwear")
+      expect(res.data.brief.persona).toEqual(persona)
+      expect(res.data.brief.competitors).toEqual(competitors)
+      expect(res.data.brief.price_point).toBe("mid_market")
+      expect(res.data.brief.design_budget).toBe(5000)
+      expect(res.data.brief.cost_currency).toBe("inr")
+
+      // GET reflects the persisted brief.
+      const get = await api.get(`/admin/designs/${designId}/brief`, headers)
+      expect(get.data.brief.concept_theme).toBe("90s Tokyo Streetwear")
+      expect(get.data.brief.design_budget).toBe(5000)
+    })
+
+    it("nulls out unset fields (full replace)", async () => {
+      await api.post(
+        `/admin/designs/${designId}/brief`,
+        { concept_theme: "First", price_point: "luxury", design_budget: 1000 },
+        headers
+      )
+      // Second POST omits concept_theme/design_budget → they reset to null.
+      const res = await api.post(
+        `/admin/designs/${designId}/brief`,
+        { price_point: "budget" },
+        headers
+      )
+      expect(res.data.brief.concept_theme).toBeNull()
+      expect(res.data.brief.design_budget).toBeNull()
+      expect(res.data.brief.price_point).toBe("budget")
+    })
+
+    it("rejects an invalid price_point", async () => {
+      const err = await api
+        .post(
+          `/admin/designs/${designId}/brief`,
+          { price_point: "ultra_premium" },
+          headers
+        )
+        .catch((e) => e)
+      expect(err.response.status).toBe(400)
+    })
+
+    it("rejects a competitor without a name", async () => {
+      const err = await api
+        .post(
+          `/admin/designs/${designId}/brief`,
+          { competitors: [{ differentiator: "no name" }] },
+          headers
+        )
+        .catch((e) => e)
+      expect(err.response.status).toBe(400)
+    })
+  })
+
+  describe("PUT /admin/designs/:id/brief", () => {
+    it("partially updates only provided fields", async () => {
+      await api.post(
+        `/admin/designs/${designId}/brief`,
+        { concept_theme: "Original", price_point: "luxury", design_budget: 9000 },
+        headers
+      )
+
+      const res = await api.put(
+        `/admin/designs/${designId}/brief`,
+        { price_point: "budget" },
+        headers
+      )
+
+      expect(res.status).toBe(200)
+      // Patched field changed…
+      expect(res.data.brief.price_point).toBe("budget")
+      // …untouched fields preserved.
+      expect(res.data.brief.concept_theme).toBe("Original")
+      expect(res.data.brief.design_budget).toBe(9000)
+    })
+  })
+})

--- a/apps/backend/src/api/admin/designs/[id]/brief/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/brief/route.ts
@@ -1,0 +1,100 @@
+/**
+ * @file Admin API routes for a design's brief (roadmap #604, slice B).
+ * @description Read + write the design-brief fields (concept_theme, persona,
+ * competitors, price_point, design_budget) on a single design as a
+ * self-contained sub-resource.
+ * @module API/Admin/Designs/Brief
+ *
+ * GET    /admin/designs/:id/brief  → read the brief
+ * POST   /admin/designs/:id/brief  → replace the whole brief (unset → null)
+ * PUT    /admin/designs/:id/brief  → partial update (only provided keys change)
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import updateDesignWorkflow from "../../../../../workflows/designs/update-design"
+import { refetchDesign } from "../../helpers"
+import {
+  DesignBrief,
+  UpdateDesignBrief,
+  DESIGN_BRIEF_FIELDS,
+  pickDesignBrief,
+} from "./validators"
+
+// Read the brief subset (refetchDesign always selects "*", so the brief
+// scalar columns are present without enumerating them).
+const readBrief = async (id: string, scope: MedusaRequest["scope"]) => {
+  const design = await refetchDesign(id, scope, [
+    "id",
+    ...DESIGN_BRIEF_FIELDS,
+  ] as any)
+  if (!design) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Design with id: ${id} was not found`
+    )
+  }
+  return pickDesignBrief(design)
+}
+
+export const GET = async (
+  req: MedusaRequest & { params: { id: string } },
+  res: MedusaResponse
+) => {
+  const brief = await readBrief(req.params.id, req.scope)
+  res.status(200).json({ brief })
+}
+
+// POST — full replace: every brief column is set, unset fields become null.
+export const POST = async (
+  req: MedusaRequest<DesignBrief> & { params: { id: string } },
+  res: MedusaResponse
+) => {
+  const body = req.validatedBody ?? {}
+  const input: Record<string, any> = {
+    id: req.params.id,
+    concept_theme: body.concept_theme ?? null,
+    persona: body.persona ?? null,
+    competitors: body.competitors ?? null,
+    price_point: body.price_point ?? null,
+    design_budget: body.design_budget ?? null,
+  }
+  // cost_currency is shared with manufacturing cost — only overwrite it when
+  // the caller explicitly sends one, never null it out on a brief replace.
+  if (body.cost_currency != null) {
+    input.cost_currency = body.cost_currency
+  }
+
+  const { errors } = await updateDesignWorkflow(req.scope).run({
+    input: input as any,
+  })
+  if (errors.length > 0) {
+    throw errors
+  }
+
+  const brief = await readBrief(req.params.id, req.scope)
+  res.status(200).json({ brief })
+}
+
+// PUT — partial update: only keys present in the body are written.
+export const PUT = async (
+  req: MedusaRequest<UpdateDesignBrief> & { params: { id: string } },
+  res: MedusaResponse
+) => {
+  const body = req.validatedBody ?? {}
+  const input: Record<string, any> = { id: req.params.id }
+  for (const key of DESIGN_BRIEF_FIELDS) {
+    if (key in body && (body as any)[key] !== undefined) {
+      input[key] = (body as any)[key]
+    }
+  }
+
+  const { errors } = await updateDesignWorkflow(req.scope).run({
+    input: input as any,
+  })
+  if (errors.length > 0) {
+    throw errors
+  }
+
+  const brief = await readBrief(req.params.id, req.scope)
+  res.status(200).json({ brief })
+}

--- a/apps/backend/src/api/admin/designs/[id]/brief/validators.ts
+++ b/apps/backend/src/api/admin/designs/[id]/brief/validators.ts
@@ -1,0 +1,89 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * Validators for the design-brief sub-resource (roadmap #604, slice B).
+ *
+ * The brief lives as typed columns on the `design` model (slice A, PR #653):
+ *   concept_theme  text
+ *   persona        json   { age_range?, lifestyle?, values?[], pain_points?[] }
+ *   competitors    json   [{ name, url?, differentiator? }]
+ *   price_point    enum   luxury | mid_market | budget
+ *   design_budget  bigNumber (paired with the shared cost_currency column)
+ *
+ * These are read+written as a whole through this dedicated route so the brief
+ * has a self-contained admin contract, distinct from the kitchen-sink design
+ * update route.
+ */
+
+// Section 2 — Target Audience value object.
+const personaSchema = z.object({
+  age_range: z.string().optional(),
+  lifestyle: z.string().optional(),
+  values: z.array(z.string()).optional(),
+  pain_points: z.array(z.string()).optional(),
+})
+
+// Section 2 — Market positioning: one competitor entry.
+const competitorSchema = z.object({
+  name: z.string().min(1, "Competitor name is required"),
+  url: z.string().url().optional(),
+  differentiator: z.string().optional(),
+})
+
+const pricePointSchema = z.enum(["luxury", "mid_market", "budget"])
+
+/**
+ * POST /admin/designs/:id/brief — replace the whole brief.
+ * Every field is optional (the brief is incremental), but unset fields are
+ * treated as `null` by the route so POST is a full replace.
+ */
+export const DesignBriefSchema = z.object({
+  concept_theme: z.string().nullish(),
+  persona: personaSchema.nullish(),
+  competitors: z.array(competitorSchema).nullish(),
+  price_point: pricePointSchema.nullish(),
+  design_budget: z.number().nonnegative().nullish(),
+  // Budget currency reuses the shared cost_currency column (e.g. "inr").
+  cost_currency: z.string().nullish(),
+})
+
+/**
+ * PUT /admin/designs/:id/brief — partial update (only provided keys change).
+ */
+export const UpdateDesignBriefSchema = DesignBriefSchema.partial()
+
+export type DesignBrief = z.infer<typeof DesignBriefSchema>
+export type UpdateDesignBrief = z.infer<typeof UpdateDesignBriefSchema>
+
+// The brief columns refetchDesign returns (it always selects "*", so these
+// scalar columns come back without extending DesignAllowedFields).
+export const DESIGN_BRIEF_FIELDS = [
+  "concept_theme",
+  "persona",
+  "competitors",
+  "price_point",
+  "design_budget",
+  "cost_currency",
+] as const
+
+/**
+ * Pure shaper — pick just the brief fields from a hydrated design record.
+ * Exported for unit testing and reuse by GET/POST/PUT so the response shape is
+ * identical across all three.
+ */
+export const pickDesignBrief = (design: Record<string, any> | undefined | null) => {
+  if (!design) {
+    return null
+  }
+  return {
+    concept_theme: design.concept_theme ?? null,
+    persona: design.persona ?? null,
+    competitors: design.competitors ?? null,
+    price_point: design.price_point ?? null,
+    design_budget:
+      design.design_budget === undefined || design.design_budget === null
+        ? null
+        : Number(design.design_budget),
+    cost_currency: design.cost_currency ?? null,
+  }
+}

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -67,6 +67,7 @@ import { rawMaterialSchema, UpdateRawMaterialSchema } from "./admin/inventory-it
 import { splitInventorySchema } from "./admin/inventory-items/[id]/split/validators";
 import { CreateMaterialTypeSchema, ReadRawMaterialCategoriesSchema } from "./admin/categories/rawmaterials/validators";
 import { CreateDesignLLMSchema, designSchema, LinkDesignPartnerSchema, ReadDesignsQuerySchema, UpdateDesignSchema } from "./admin/designs/validators";
+import { DesignBriefSchema, UpdateDesignBriefSchema } from "./admin/designs/[id]/brief/validators";
 import { SegmentImageSchema } from "./admin/designs/[id]/segment/validators";
 import { DepthImageSchema } from "./partners/designs/[designId]/segment/depth/validators";
 import { ReviseDesignSchema as PartnerReviseDesignSchema } from "./partners/designs/[designId]/revise/validators";
@@ -3025,7 +3026,20 @@ export default defineMiddlewares({
       middlewares: [],
     },
 
-    // Inventory linkin on designs 
+    // #604 slice B — design brief sub-resource (concept/persona/competitors/
+    // price_point/design_budget). GET reads, POST replaces, PUT patches.
+    {
+      matcher: "/admin/designs/:id/brief",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(DesignBriefSchema))],
+    },
+    {
+      matcher: "/admin/designs/:id/brief",
+      method: "PUT",
+      middlewares: [validateAndTransformBody(wrapSchema(UpdateDesignBriefSchema))],
+    },
+
+    // Inventory linkin on designs
 
     {
       matcher: "/admin/designs/:id/inventory",


### PR DESCRIPTION
## #604 Slice B — design-brief admin API routes

Builds on **slice A** (PR #653, merged: the 5 typed brief columns on the `design` model). Adds the admin CRUD API to read+write the brief as a self-contained sub-resource.

### Routes (`/admin/designs/:id/brief`)
| Method | Behaviour |
|--------|-----------|
| `GET`  | read the brief subset (`404` on unknown design) |
| `POST` | **replace** the whole brief — unset fields reset to `null` |
| `PUT`  | **partial** update — only keys present in the body change |

Fields: `concept_theme`, `persona` (VO `{age_range, lifestyle, values[], pain_points[]}`), `competitors` (`[{name, url?, differentiator}]`), `price_point` (`luxury|mid_market|budget`), `design_budget` (non-negative, paired with shared `cost_currency`).

### Design
- Zod validators (`DesignBriefSchema` / `UpdateDesignBriefSchema`) wired via `wrapSchema` + `validateAndTransformBody` in `middlewares.ts`, mirroring existing design sub-routes.
- Writes route through the existing `updateDesignWorkflow` — brief columns pass through `updateDesignStep` → `updateDesigns` (no workflow change needed).
- Pure `pickDesignBrief` shaper keeps GET/POST/PUT response shapes identical; `cost_currency` is only overwritten when explicitly sent (never nulled on a brief replace, since it's shared with manufacturing cost).

### Tests
Per-file HTTP integration spec — **7 tests, all green**: read-null, 404, full-replace + read-back, null-out-unset on re-POST, invalid `price_point` → 400, nameless competitor → 400, PUT partial-merge.

`tsc` 69 baseline / 0 new.

### Deferred (noted on #604)
- Partner-ui Brief tab (slice C/D, Playwright-gated)
- Admin print → brief PDF (slice D), public opt-in share (slice F)

🤖 Generated with [Claude Code](https://claude.com/claude-code)