### PR TITLE
feat(#604 slice C): partner design-brief CRUD API routes

### DIFF
--- a/apps/backend/integration-tests/http/partner-design-brief.spec.ts
+++ b/apps/backend/integration-tests/http/partner-design-brief.spec.ts
@@ -1,0 +1,221 @@
+/**
+ * Partner design-brief CRUD — self-serve, ownership-scoped (roadmap #604, slice C).
+ *
+ * Mirrors the admin slice-B brief contract (`/admin/designs/:id/brief`) on the
+ * partner side: a partner can read + write the brief of their OWN design, the
+ * routes are isolated (a second partner gets 404), POST is a full replace, and
+ * PUT is a partial merge. cost_currency is never nulled on a POST replace.
+ *
+ * Run:
+ *   pnpm test:integration:http:shared ./integration-tests/http/partner-design-brief
+ */
+
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+const PARTNER_PASSWORD = "supersecret"
+
+jest.setTimeout(180_000)
+
+async function createPartner(api: any, label: string) {
+  const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+  const email = `pdbrief-${label}-${unique}@jyt.test`
+  await api.post("/auth/partner/emailpass/register", {
+    email,
+    password: PARTNER_PASSWORD,
+  })
+  let login = await api.post("/auth/partner/emailpass", {
+    email,
+    password: PARTNER_PASSWORD,
+  })
+  let headers: Record<string, string> = {
+    Authorization: `Bearer ${login.data.token}`,
+  }
+  const partnerRes = await api.post(
+    "/partners",
+    {
+      name: `PDBrief ${label} ${unique}`,
+      handle: `pdbrief-${label}-${unique}`,
+      admin: { email, first_name: "Test", last_name: "Partner" },
+    },
+    { headers }
+  )
+  expect(partnerRes.status).toBe(200)
+  login = await api.post("/auth/partner/emailpass", {
+    email,
+    password: PARTNER_PASSWORD,
+  })
+  headers = { Authorization: `Bearer ${login.data.token}` }
+  return { partnerId: partnerRes.data.partner.id as string, partnerHeaders: headers }
+}
+
+async function createOwnedDesign(api: any, partnerHeaders: any) {
+  const res = await api.post(
+    "/partners/designs",
+    { name: "Brief Test Design", design_type: "Original" },
+    { headers: partnerHeaders }
+  )
+  expect(res.status).toBe(201)
+  return res.data.design.id as string
+}
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Partner design brief (roadmap #604 slice C)", () => {
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      const adminHeaders = await getAuthHeaders(api)
+      // Partner creation fires a "partner-created-from-admin" email — seed the
+      // template so the /partners POST doesn't 400 on a missing template.
+      try {
+        await api.post(
+          "/admin/email-templates",
+          {
+            name: "Admin Partner Created",
+            template_key: "partner-created-from-admin",
+            subject: "s",
+            html_content: "<div>ok</div>",
+            from: "t@t.com",
+            variables: {},
+            template_type: "email",
+          },
+          adminHeaders
+        )
+      } catch {
+        /* pre-existing */
+      }
+    })
+
+    it("GET returns a fully-null brief for a fresh design", async () => {
+      const { partnerHeaders } = await createPartner(api, "freshget")
+      const designId = await createOwnedDesign(api, partnerHeaders)
+
+      const res = await api.get(`/partners/designs/${designId}/brief`, {
+        headers: partnerHeaders,
+      })
+      expect(res.status).toBe(200)
+      expect(res.data.brief).toEqual({
+        concept_theme: null,
+        persona: null,
+        competitors: null,
+        price_point: null,
+        design_budget: null,
+        cost_currency: null,
+      })
+    })
+
+    it("POST replaces the whole brief and GET reads it back", async () => {
+      const { partnerHeaders } = await createPartner(api, "post")
+      const designId = await createOwnedDesign(api, partnerHeaders)
+
+      const persona = { age_range: "25-34", values: ["sustainable", "modern"] }
+      const competitors = [
+        { name: "Acme", url: "https://acme.example", differentiator: "cheap" },
+      ]
+      const postRes = await api.post(
+        `/partners/designs/${designId}/brief`,
+        {
+          concept_theme: "Coastal minimalism",
+          persona,
+          competitors,
+          price_point: "luxury",
+          design_budget: 1500,
+          cost_currency: "inr",
+        },
+        { headers: partnerHeaders }
+      )
+      expect(postRes.status).toBe(200)
+      expect(postRes.data.brief).toEqual({
+        concept_theme: "Coastal minimalism",
+        persona,
+        competitors,
+        price_point: "luxury",
+        design_budget: 1500,
+        cost_currency: "inr",
+      })
+
+      const getRes = await api.get(`/partners/designs/${designId}/brief`, {
+        headers: partnerHeaders,
+      })
+      expect(getRes.data.brief.concept_theme).toBe("Coastal minimalism")
+      expect(getRes.data.brief.price_point).toBe("luxury")
+      expect(getRes.data.brief.design_budget).toBe(1500)
+    })
+
+    it("POST is a full replace — unset fields become null (cost_currency preserved)", async () => {
+      const { partnerHeaders } = await createPartner(api, "replace")
+      const designId = await createOwnedDesign(api, partnerHeaders)
+
+      await api.post(
+        `/partners/designs/${designId}/brief`,
+        { concept_theme: "First", price_point: "budget", cost_currency: "inr" },
+        { headers: partnerHeaders }
+      )
+      // Second POST omits everything except concept_theme.
+      const res = await api.post(
+        `/partners/designs/${designId}/brief`,
+        { concept_theme: "Second" },
+        { headers: partnerHeaders }
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.brief.concept_theme).toBe("Second")
+      expect(res.data.brief.price_point).toBeNull()
+      // cost_currency is shared with manufacturing cost — never nulled on replace.
+      expect(res.data.brief.cost_currency).toBe("inr")
+    })
+
+    it("PUT partially merges — only provided keys change", async () => {
+      const { partnerHeaders } = await createPartner(api, "put")
+      const designId = await createOwnedDesign(api, partnerHeaders)
+
+      await api.post(
+        `/partners/designs/${designId}/brief`,
+        { concept_theme: "Keep me", price_point: "mid_market" },
+        { headers: partnerHeaders }
+      )
+      const res = await api.put(
+        `/partners/designs/${designId}/brief`,
+        { price_point: "luxury" },
+        { headers: partnerHeaders }
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.brief.concept_theme).toBe("Keep me")
+      expect(res.data.brief.price_point).toBe("luxury")
+    })
+
+    it("rejects an invalid price_point enum", async () => {
+      const { partnerHeaders } = await createPartner(api, "badenum")
+      const designId = await createOwnedDesign(api, partnerHeaders)
+
+      const res = await api.post(
+        `/partners/designs/${designId}/brief`,
+        { price_point: "platinum" },
+        { headers: partnerHeaders, validateStatus: () => true }
+      )
+      expect(res.status).toBe(400)
+    })
+
+    it("isolates the brief — a second partner cannot read or write it", async () => {
+      const { partnerHeaders } = await createPartner(api, "owner2")
+      const { partnerHeaders: otherHeaders } = await createPartner(api, "intruder")
+      const designId = await createOwnedDesign(api, partnerHeaders)
+
+      // assertPartnerOwnsDesign throws NOT_ALLOWED (→ 400) for an owner
+      // mismatch on an existing design (404 only when the design is absent).
+      const getRes = await api.get(`/partners/designs/${designId}/brief`, {
+        headers: otherHeaders,
+        validateStatus: () => true,
+      })
+      expect([400, 404]).toContain(getRes.status)
+
+      const postRes = await api.post(
+        `/partners/designs/${designId}/brief`,
+        { concept_theme: "hijack" },
+        { headers: otherHeaders, validateStatus: () => true }
+      )
+      expect([400, 404]).toContain(postRes.status)
+    })
+  })
+})

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -185,6 +185,7 @@ import { PartnerPostDesignInventoryReq, PartnerPatchDesignInventoryLinkReq, Part
 import { PartnerCreateProductionRunReq } from "./partners/designs/[designId]/production-runs/validators";
 import { PartnerPostConsumptionLogReq } from "./partners/designs/[designId]/consumption-logs/validators";
 import { PartnerPostDesignTasksReq } from "./partners/designs/[designId]/tasks/validators";
+import { DesignBriefSchema as PartnerDesignBriefSchema, UpdateDesignBriefSchema as PartnerUpdateDesignBriefSchema } from "./partners/designs/[designId]/brief/validators";
 import { PartnerPostProductionRunConsumptionLogReq } from "./partners/production-runs/[id]/consumption-logs/validators";
 import { listPartnersQuerySchema, PostPartnerSchema } from "./admin/partners/validators";
 import { AdminBroadcastNotificationSchema } from "./admin/partners/notifications/broadcast/validators";
@@ -3964,6 +3965,33 @@ export default defineMiddlewares({
       middlewares: [
         authenticate("partner", ["session", "bearer"]),
         validateAndTransformBody(wrapSchema(PartnerReviseDesignSchema)),
+      ],
+    },
+    {
+      // Roadmap #604 slice C — partner reads the brief of their OWN design
+      // (mirrors GET /admin/designs/:id/brief). Ownership-guarded in handler.
+      matcher: "/partners/designs/:designId/brief",
+      method: "GET",
+      middlewares: [authenticate("partner", ["session", "bearer"])],
+    },
+    {
+      // Roadmap #604 slice C — partner full-replaces the brief of their OWN
+      // design (mirrors POST /admin/designs/:id/brief). Ownership-guarded.
+      matcher: "/partners/designs/:designId/brief",
+      method: "POST",
+      middlewares: [
+        authenticate("partner", ["session", "bearer"]),
+        validateAndTransformBody(wrapSchema(PartnerDesignBriefSchema)),
+      ],
+    },
+    {
+      // Roadmap #604 slice C — partner partial-updates the brief of their OWN
+      // design (mirrors PUT /admin/designs/:id/brief). Ownership-guarded.
+      matcher: "/partners/designs/:designId/brief",
+      method: "PUT",
+      middlewares: [
+        authenticate("partner", ["session", "bearer"]),
+        validateAndTransformBody(wrapSchema(PartnerUpdateDesignBriefSchema)),
       ],
     },
     {

--- a/apps/backend/src/api/partners/designs/[designId]/brief/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/brief/route.ts
@@ -1,0 +1,135 @@
+/**
+ * @file Partner API routes for a partner-owned design's brief (roadmap #604, slice C).
+ * @description Read + write the design-brief fields (concept_theme, persona,
+ * competitors, price_point, design_budget) on a single PARTNER-OWNED design as a
+ * self-contained sub-resource. Mirrors the admin slice-B contract
+ * (`/admin/designs/:id/brief`) wire-for-wire, but every operation is guarded to
+ * the OWNING partner via `assertPartnerOwnsDesign`.
+ * @module API/Partners/Designs/Brief
+ *
+ * GET    /partners/designs/:designId/brief  → read the brief
+ * POST   /partners/designs/:designId/brief  → replace the whole brief (unset → null)
+ * PUT    /partners/designs/:designId/brief  → partial update (only provided keys change)
+ *
+ * Why these mutating routes are safe to self-serve: they operate on the
+ * partner's OWN design only, and the brief columns are pure metadata of that
+ * design (no product creation, no email, no cross-tenant fields) — the same
+ * boundary that makes the partner `revise`/`tasks` mutations safe.
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import updateDesignWorkflow from "../../../../../workflows/designs/update-design"
+import { assertPartnerOwnsDesign } from "../../helpers"
+import {
+  DesignBrief,
+  UpdateDesignBrief,
+  DESIGN_BRIEF_FIELDS,
+  pickDesignBrief,
+} from "./validators"
+
+/**
+ * Read the brief subset for a design. Ownership is asserted by the caller; this
+ * issues a second query.graph for the brief scalar columns (the ownership guard
+ * only selects id/owner/name/status).
+ */
+const readBrief = async (
+  designId: string,
+  scope: AuthenticatedMedusaRequest["scope"]
+) => {
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data } = await query.graph({
+    entity: "design",
+    filters: { id: designId },
+    fields: ["id", ...DESIGN_BRIEF_FIELDS] as any,
+  })
+  const design = (data || [])[0]
+  return pickDesignBrief(design)
+}
+
+/**
+ * @route GET /partners/designs/{designId}/brief
+ * @returns {Object} 200 - { brief }
+ * @throws {MedusaError} 401 - Partner authentication required
+ * @throws {MedusaError} 404 - Design not found
+ * @throws {MedusaError} 400 (NOT_ALLOWED) - Design not owned by this partner
+ */
+export async function GET(
+  req: AuthenticatedMedusaRequest & { params: { designId: string } },
+  res: MedusaResponse
+): Promise<void> {
+  const { designId } = req.params
+  await assertPartnerOwnsDesign(req, designId)
+  const brief = await readBrief(designId, req.scope)
+  res.status(200).json({ brief })
+}
+
+/**
+ * Full replace — every brief column is set; unset fields become null.
+ * @route POST /partners/designs/{designId}/brief
+ */
+export async function POST(
+  req: AuthenticatedMedusaRequest<DesignBrief> & {
+    params: { designId: string }
+  },
+  res: MedusaResponse
+): Promise<void> {
+  const { designId } = req.params
+  await assertPartnerOwnsDesign(req, designId)
+
+  const body = req.validatedBody ?? {}
+  const input: Record<string, any> = {
+    id: designId,
+    concept_theme: body.concept_theme ?? null,
+    persona: body.persona ?? null,
+    competitors: body.competitors ?? null,
+    price_point: body.price_point ?? null,
+    design_budget: body.design_budget ?? null,
+  }
+  // cost_currency is shared with manufacturing cost — only overwrite it when
+  // the caller explicitly sends one, never null it out on a brief replace.
+  if (body.cost_currency != null) {
+    input.cost_currency = body.cost_currency
+  }
+
+  const { errors } = await updateDesignWorkflow(req.scope).run({
+    input: input as any,
+  })
+  if (errors.length > 0) {
+    throw errors
+  }
+
+  const brief = await readBrief(designId, req.scope)
+  res.status(200).json({ brief })
+}
+
+/**
+ * Partial update — only keys present in the body are written.
+ * @route PUT /partners/designs/{designId}/brief
+ */
+export async function PUT(
+  req: AuthenticatedMedusaRequest<UpdateDesignBrief> & {
+    params: { designId: string }
+  },
+  res: MedusaResponse
+): Promise<void> {
+  const { designId } = req.params
+  await assertPartnerOwnsDesign(req, designId)
+
+  const body = req.validatedBody ?? {}
+  const input: Record<string, any> = { id: designId }
+  for (const key of DESIGN_BRIEF_FIELDS) {
+    if (key in body && (body as any)[key] !== undefined) {
+      input[key] = (body as any)[key]
+    }
+  }
+
+  const { errors } = await updateDesignWorkflow(req.scope).run({
+    input: input as any,
+  })
+  if (errors.length > 0) {
+    throw errors
+  }
+
+  const brief = await readBrief(designId, req.scope)
+  res.status(200).json({ brief })
+}

--- a/apps/backend/src/api/partners/designs/[designId]/brief/validators.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/brief/validators.ts
@@ -1,0 +1,90 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * Validators for the PARTNER design-brief sub-resource (roadmap #604, slice C).
+ *
+ * Mirrors the admin brief contract (`/admin/designs/:id/brief`, slice B) so the
+ * partner-ui talks to an identical wire shape — only the auth + ownership
+ * scoping differs (see route.ts `assertPartnerOwnsDesign`).
+ *
+ * The brief lives as typed columns on the `design` model (slice A, PR #653):
+ *   concept_theme  text
+ *   persona        json   { age_range?, lifestyle?, values?[], pain_points?[] }
+ *   competitors    json   [{ name, url?, differentiator? }]
+ *   price_point    enum   luxury | mid_market | budget
+ *   design_budget  bigNumber (paired with the shared cost_currency column)
+ */
+
+// Section 2 — Target Audience value object.
+const personaSchema = z.object({
+  age_range: z.string().optional(),
+  lifestyle: z.string().optional(),
+  values: z.array(z.string()).optional(),
+  pain_points: z.array(z.string()).optional(),
+})
+
+// Section 2 — Market positioning: one competitor entry.
+const competitorSchema = z.object({
+  name: z.string().min(1, "Competitor name is required"),
+  url: z.string().url().optional(),
+  differentiator: z.string().optional(),
+})
+
+const pricePointSchema = z.enum(["luxury", "mid_market", "budget"])
+
+/**
+ * POST /partners/designs/:designId/brief — replace the whole brief.
+ * Every field is optional (the brief is incremental), but unset fields are
+ * treated as `null` by the route so POST is a full replace.
+ */
+export const DesignBriefSchema = z.object({
+  concept_theme: z.string().nullish(),
+  persona: personaSchema.nullish(),
+  competitors: z.array(competitorSchema).nullish(),
+  price_point: pricePointSchema.nullish(),
+  design_budget: z.number().nonnegative().nullish(),
+  // Budget currency reuses the shared cost_currency column (e.g. "inr").
+  cost_currency: z.string().nullish(),
+})
+
+/**
+ * PUT /partners/designs/:designId/brief — partial update (only provided keys change).
+ */
+export const UpdateDesignBriefSchema = DesignBriefSchema.partial()
+
+export type DesignBrief = z.infer<typeof DesignBriefSchema>
+export type UpdateDesignBrief = z.infer<typeof UpdateDesignBriefSchema>
+
+// The brief columns to read back from a hydrated design record.
+export const DESIGN_BRIEF_FIELDS = [
+  "concept_theme",
+  "persona",
+  "competitors",
+  "price_point",
+  "design_budget",
+  "cost_currency",
+] as const
+
+/**
+ * Pure shaper — pick just the brief fields from a hydrated design record.
+ * Exported for unit testing and reuse by GET/POST/PUT so the response shape is
+ * identical across all three (and identical to the admin slice-B shape).
+ */
+export const pickDesignBrief = (
+  design: Record<string, any> | undefined | null
+) => {
+  if (!design) {
+    return null
+  }
+  return {
+    concept_theme: design.concept_theme ?? null,
+    persona: design.persona ?? null,
+    competitors: design.competitors ?? null,
+    price_point: design.price_point ?? null,
+    design_budget:
+      design.design_budget === undefined || design.design_budget === null
+        ? null
+        : Number(design.design_budget),
+    cost_currency: design.cost_currency ?? null,
+  }
+}

--- a/apps/backend/src/api/partners/designs/__tests__/brief-shaper.unit.spec.ts
+++ b/apps/backend/src/api/partners/designs/__tests__/brief-shaper.unit.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit tests for the pure partner design-brief shaper (roadmap #604, slice C).
+ * Mirrors the admin slice-B shape so partner-ui + admin-ui see identical bodies.
+ *
+ * Run:
+ *   TEST_TYPE=unit pnpm jest apps/backend/src/api/partners/designs/__tests__/brief-shaper.unit.spec.ts
+ */
+import { pickDesignBrief } from "../[designId]/brief/validators"
+
+describe("pickDesignBrief (partner #604 slice C)", () => {
+  it("returns null for a missing design", () => {
+    expect(pickDesignBrief(undefined)).toBeNull()
+    expect(pickDesignBrief(null)).toBeNull()
+  })
+
+  it("coerces all-unset columns to a fully-null brief", () => {
+    expect(pickDesignBrief({ id: "design_1" })).toEqual({
+      concept_theme: null,
+      persona: null,
+      competitors: null,
+      price_point: null,
+      design_budget: null,
+      cost_currency: null,
+    })
+  })
+
+  it("passes through populated brief fields and numifies the bigNumber budget", () => {
+    const persona = { age_range: "25-34", values: ["sustainable"] }
+    const competitors = [{ name: "Acme", differentiator: "cheaper" }]
+    expect(
+      pickDesignBrief({
+        id: "design_2",
+        concept_theme: "Coastal minimalism",
+        persona,
+        competitors,
+        price_point: "luxury",
+        design_budget: "1500", // bigNumber arrives as string
+        cost_currency: "inr",
+        // extraneous columns must be dropped
+        name: "should-not-leak",
+        status: "in_progress",
+      })
+    ).toEqual({
+      concept_theme: "Coastal minimalism",
+      persona,
+      competitors,
+      price_point: "luxury",
+      design_budget: 1500,
+      cost_currency: "inr",
+    })
+  })
+
+  it("treats a zero budget as the number 0, not null", () => {
+    expect(pickDesignBrief({ id: "d", design_budget: 0 })?.design_budget).toBe(0)
+  })
+
+  it("keeps null budget null (not NaN)", () => {
+    expect(pickDesignBrief({ id: "d", design_budget: null })?.design_budget).toBeNull()
+  })
+})


### PR DESCRIPTION
Roadmap **#604 slice C** — promote the design brief to partner self-serve, mirroring the admin slice-B contract (PR #657) wire-for-wire on the partner side.

> ⚠️ **Stacked on #661** (`fix/partner-migration-name-collision`) — partner creation is broken on `main` until that migration fix lands, so these integration tests can only pass on top of it. **Merge #661 first**, then this PR's base auto-retargets to `main`.

## Routes (all ownership-scoped via `assertPartnerOwnsDesign`)
- `GET /partners/designs/:designId/brief` — read the brief
- `POST /partners/designs/:designId/brief` — full replace (unset → null)
- `PUT /partners/designs/:designId/brief` — partial merge

## Design
- Writes route through the existing `updateDesignWorkflow` — the brief columns (`concept_theme`, `persona`, `competitors`, `price_point`, `design_budget`) pass straight through `updateDesignStep`; **no workflow change**.
- `cost_currency` is shared with manufacturing cost → POST only overwrites it when explicitly sent, never nulls it on a replace.
- Zod validators via `wrapSchema` + `validateAndTransformBody` (persona VO, competitor[], `price_point` enum, non-negative budget). GET intentionally has no body-validation middleware.
- Pure `pickDesignBrief` shaper keeps the response shape identical to admin slice B.

## Tests
- **5 unit** — `pickDesignBrief` (null/all-null/passthrough+numify budget/zero-vs-null).
- **6 HTTP integration** — fresh GET, POST round-trip, full-replace nulls unset (currency preserved), PUT partial merge, invalid enum → 400, cross-partner isolation → 400/404. All green.
- tsc 69 baseline / 0 new.

Deferred (Playwright-gated, noted on #604): partner-ui Brief tab (slice D), public opt-in share (slice F).

🤖 Generated with [Claude Code](https://claude.com/claude-code)