### PR TITLE
fix(#664): upsert Person on order.placed so manual orders get scored + backfill job

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-order-persons.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-order-persons.unit.spec.ts
@@ -1,0 +1,103 @@
+import {
+  backfillOrderPersonsJob,
+  decideOrderPersonBackfill,
+  getMaintenanceJob,
+  MAINTENANCE_JOBS,
+  MAX_ORDER_PERSON_BACKFILL,
+  summarizeOrderPersonBackfill,
+} from "../registry"
+
+/**
+ * #664 — pure decision/summary logic for the `backfill-order-persons` job. The
+ * container-bound run() (query.graph over orders + Person upsert + conversion
+ * update) is exercised by the API contract integration test; here we lock down
+ * the link / create / skip decision and the summary string without booting the DB.
+ */
+describe("backfill-order-persons — decideOrderPersonBackfill", () => {
+  const order_id = "order_1"
+
+  it("skips a conversion that already has a person_id (idempotent)", () => {
+    expect(
+      decideOrderPersonBackfill({
+        conversion: { person_id: "per_1", order_id },
+        email: "a@b.com",
+        existingPersonId: null,
+      })
+    ).toEqual({ action: "skip", reason: "already linked" })
+  })
+
+  it("skips when there is no order_id to resolve an email from", () => {
+    expect(
+      decideOrderPersonBackfill({
+        conversion: { person_id: null, order_id: null },
+        email: null,
+        existingPersonId: null,
+      })
+    ).toEqual({ action: "skip", reason: "no order_id" })
+  })
+
+  it("skips when the order has no usable email", () => {
+    expect(
+      decideOrderPersonBackfill({
+        conversion: { person_id: null, order_id },
+        email: "not-an-email",
+        existingPersonId: null,
+      })
+    ).toEqual({ action: "skip", reason: "no usable email" })
+  })
+
+  it("links to an existing Person when the email matches", () => {
+    expect(
+      decideOrderPersonBackfill({
+        conversion: { person_id: null, order_id },
+        email: "a@b.com",
+        existingPersonId: "per_existing",
+      })
+    ).toEqual({ action: "link", person_id: "per_existing" })
+  })
+
+  it("creates a Person when the email is usable but unmatched", () => {
+    expect(
+      decideOrderPersonBackfill({
+        conversion: { person_id: null, order_id },
+        email: "a@b.com",
+        existingPersonId: null,
+      })
+    ).toEqual({ action: "create" })
+  })
+})
+
+describe("backfill-order-persons — summarizeOrderPersonBackfill", () => {
+  it("reports nothing-to-do", () => {
+    expect(summarizeOrderPersonBackfill(true, 5, 0, 0, 0)).toContain("No changes")
+    expect(summarizeOrderPersonBackfill(true, 5, 0, 0, 2)).toContain("2 errored")
+  })
+
+  it("uses conditional verbs for dry-run vs apply and counts link/create", () => {
+    const dry = summarizeOrderPersonBackfill(true, 10, 3, 4, 0)
+    expect(dry).toContain("Would repair 7 of 10")
+    expect(dry).toContain("would link 3")
+    expect(dry).toContain("would create 4")
+
+    const applied = summarizeOrderPersonBackfill(false, 10, 3, 4, 1)
+    expect(applied).toContain("Repaired 7 of 10")
+    expect(applied).toContain("linked 3")
+    expect(applied).toContain("created 4")
+    expect(applied).toContain("1 errored")
+  })
+})
+
+describe("backfill-order-persons — registration", () => {
+  it("is registered in MAINTENANCE_JOBS and resolvable by id", () => {
+    expect(MAINTENANCE_JOBS).toContain(backfillOrderPersonsJob)
+    expect(getMaintenanceJob("backfill-order-persons")).toBe(backfillOrderPersonsJob)
+  })
+
+  it("declares limit + order_id params and a sane cap", () => {
+    expect(backfillOrderPersonsJob.params.map((p) => p.name)).toEqual([
+      "limit",
+      "order_id",
+    ])
+    expect(MAX_ORDER_PERSON_BACKFILL).toBe(1000)
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -9,6 +9,12 @@ import { RAW_MATERIAL_MODULE } from "../../../../modules/raw_material"
 import { OPS_AUDIT_MODULE } from "../../../../modules/ops_audit"
 import { STATS_MODULE } from "../../../../modules/stats"
 import { PARTNER_BILLING_MODULE } from "../../../../modules/partner_billing"
+import { AD_PLANNING_MODULE } from "../../../../modules/ad-planning"
+import { PERSON_MODULE } from "../../../../modules/person"
+import {
+  derivePersonName,
+  isUsableEmail,
+} from "../../../../workflows/ad-planning/conversions/person-identity-lib"
 import { computeFee } from "../../../../modules/partner_billing/compute-fee"
 import { resolvePartnerFeeRate } from "../../../../modules/partner_billing/resolve-fee-rate"
 import partnerOrderLink from "../../../../links/partner-order"
@@ -2967,6 +2973,229 @@ export const backfillStatsPanelWindowJob: MaintenanceJob = {
   },
 }
 
+/** Hard cap on how many person-less purchase conversions one run repairs. */
+export const MAX_ORDER_PERSON_BACKFILL = 1000
+
+const backfillOrderPersonsParamsSchema = z.object({
+  /** Max conversions to repair this run (default 200, capped to MAX_ORDER_PERSON_BACKFILL). */
+  limit: z.number().int().positive().max(MAX_ORDER_PERSON_BACKFILL).optional().default(200),
+  /** Restrict to a single order's purchase conversion(s) (targeted repair). */
+  order_id: z.string().min(1).optional(),
+})
+
+export type OrderPersonBackfillDecision =
+  | { action: "skip"; reason: string }
+  | { action: "link"; person_id: string }
+  | { action: "create" }
+
+/**
+ * Pure: decide what to do with one person-less purchase conversion (#664).
+ *
+ *   - already has person_id        → skip (idempotent; a re-run matches nothing)
+ *   - no order_id / no usable email → skip (nothing to key a Person on)
+ *   - email matches a Person        → link to it
+ *   - otherwise                     → create a Person, then link
+ *
+ * `existingPersonId` is the id of a Person already matching the order email
+ * (looked up by the caller, OR resolved within this run for a repeat email),
+ * or null. Exported for unit testing — no DB needed.
+ */
+export function decideOrderPersonBackfill(input: {
+  conversion: { person_id?: string | null; order_id?: string | null }
+  email: string | null
+  existingPersonId: string | null
+}): OrderPersonBackfillDecision {
+  if (input.conversion.person_id) return { action: "skip", reason: "already linked" }
+  if (!input.conversion.order_id) return { action: "skip", reason: "no order_id" }
+  if (!isUsableEmail(input.email)) return { action: "skip", reason: "no usable email" }
+  if (input.existingPersonId) return { action: "link", person_id: input.existingPersonId }
+  return { action: "create" }
+}
+
+/** Pure human-facing summary for the order→person backfill. */
+export function summarizeOrderPersonBackfill(
+  dryRun: boolean,
+  scanned: number,
+  linked: number,
+  created: number,
+  errored: number
+): string {
+  const repaired = linked + created
+  if (repaired === 0) {
+    return `No changes — none of the ${scanned} scanned person-less conversion(s) could be matched to an order email${errored ? ` (${errored} errored)` : ""}`
+  }
+  const verb = dryRun ? "Would repair" : "Repaired"
+  return `${verb} ${repaired} of ${scanned} person-less conversion(s): ${dryRun ? "would link" : "linked"} ${linked} to existing Persons, ${dryRun ? "would create" : "created"} ${created} new Person(s)${errored ? `; ${errored} errored` : ""}`
+}
+
+/**
+ * Backfill the `person_id` on historical purchase conversions that were tracked
+ * before the order→Person upsert fix (#664). Manual orders had no matching
+ * Person, so ad-planning stored `person_id: null` and all scoring (CLV / churn /
+ * engagement) silently skipped — which also makes those buyers invisible to the
+ * AI-VP winback targeting (which joins on CustomerScore.person_id).
+ *
+ * This repairs IDENTITY only: it upserts a Person from each order's email + name
+ * and stamps `conversion.person_id`. Re-running the score recalculation over the
+ * repaired rows is a separate follow-up (the live workflow scores all NEW orders).
+ *
+ * Safe by default: dry-run (default) previews the exact person_id stamps without
+ * writing; apply upserts Persons + updates conversions. Idempotent — a conversion
+ * that already has a person_id is never re-touched, so a re-run matches nothing.
+ */
+export const backfillOrderPersonsJob: MaintenanceJob = {
+  id: "backfill-order-persons",
+  label: "Backfill order → Person on conversions",
+  description:
+    "Upsert a Person (by order email + name) and stamp person_id onto historical purchase conversions that have none (#664 — manual orders were never scored). Dry-run previews the stamps; apply writes them. Idempotent and capped; re-run to continue past the limit.",
+  params: [
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max conversions to repair this run (default 200, max ${MAX_ORDER_PERSON_BACKFILL}).`,
+    },
+    {
+      name: "order_id",
+      type: "string",
+      required: false,
+      description: "Restrict to a single order's purchase conversion(s).",
+    },
+  ],
+  run: async (container, { dry_run, params }) => {
+    const { limit, order_id } = backfillOrderPersonsParamsSchema.parse(params ?? {})
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const adPlanning: any = container.resolve(AD_PLANNING_MODULE)
+    const personService: any = container.resolve(PERSON_MODULE)
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    let linked = 0
+    let created = 0
+
+    // Candidate conversions: purchases with no person_id (optionally one order).
+    const convFilter: Record<string, unknown> = {
+      conversion_type: "purchase",
+      person_id: null,
+    }
+    if (order_id) convFilter.order_id = order_id
+
+    const candidates: any[] = await adPlanning.listConversions(convFilter, {
+      take: limit,
+      order: { converted_at: "ASC" },
+    })
+
+    // Within one run a repeat email must resolve to a single Person (avoid dup
+    // creates). Maps lowercased email → resolved-or-pending person id.
+    const emailToPersonId = new Map<string, string>()
+
+    for (const conv of candidates) {
+      if (changes.length >= limit) break
+      try {
+        // Resolve the order's email + name.
+        const { data: [order] } = await query.graph({
+          entity: "order",
+          fields: [
+            "id",
+            "email",
+            "billing_address.first_name",
+            "billing_address.last_name",
+            "shipping_address.first_name",
+            "shipping_address.last_name",
+            "customer.first_name",
+            "customer.last_name",
+          ],
+          filters: { id: conv.order_id },
+        })
+
+        const email: string | null = order?.email ?? null
+        const emailKey = email ? email.trim().toLowerCase() : null
+
+        // Has this email already been matched/created earlier in the run?
+        let existingPersonId: string | null =
+          emailKey && emailToPersonId.has(emailKey)
+            ? emailToPersonId.get(emailKey)!
+            : null
+
+        // Otherwise look it up in the Person module.
+        if (!existingPersonId && isUsableEmail(email)) {
+          const persons = await personService.listPeople({ email })
+          if (persons?.length > 0) existingPersonId = persons[0].id
+        }
+
+        const decision = decideOrderPersonBackfill({
+          conversion: conv,
+          email,
+          existingPersonId,
+        })
+
+        if (decision.action === "skip") continue
+
+        let personId: string
+        let personCreated = false
+
+        if (decision.action === "link") {
+          personId = decision.person_id
+        } else {
+          // create
+          if (dry_run) {
+            personId = "(new)"
+          } else {
+            const name = derivePersonName({
+              email,
+              billing_address: order?.billing_address,
+              shipping_address: order?.shipping_address,
+              customer: order?.customer,
+            })
+            const person = await personService.createPeople({
+              first_name: name.first_name,
+              last_name: name.last_name,
+              email,
+              metadata: { source: "backfill-order-persons" },
+            })
+            personId = person.id
+          }
+          personCreated = true
+          created++
+        }
+
+        if (decision.action === "link") linked++
+        if (emailKey && personId !== "(new)") emailToPersonId.set(emailKey, personId)
+
+        changes.push({
+          entity: "conversion",
+          id: conv.id,
+          field: "person_id",
+          before: null,
+          after: { person_id: personId, person_created: personCreated, email },
+        })
+
+        if (!dry_run) {
+          await adPlanning.updateConversions({ id: conv.id, person_id: personId })
+        }
+      } catch (e: any) {
+        errors.push({ id: conv.id, message: e?.message ?? String(e) })
+      }
+    }
+
+    return {
+      job_id: backfillOrderPersonsJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary: summarizeOrderPersonBackfill(
+        dry_run,
+        candidates.length,
+        linked,
+        created,
+        errors.length
+      ),
+      changes,
+      errors,
+    }
+  },
+}
+
 export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   recalculateDesignCostJob,
   recalculateDesignCostBulkJob,
@@ -2981,6 +3210,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   repairInventoryRawMaterialLinksJob,
   backfillPartnerOrderFeesJob,
   backfillStatsPanelWindowJob,
+  backfillOrderPersonsJob,
 ]
 
 export const getMaintenanceJob = (id: string): MaintenanceJob | undefined =>

--- a/apps/backend/src/workflows/ad-planning/conversions/__tests__/person-identity-lib.unit.spec.ts
+++ b/apps/backend/src/workflows/ad-planning/conversions/__tests__/person-identity-lib.unit.spec.ts
@@ -1,0 +1,100 @@
+import {
+  derivePersonName,
+  isUsableEmail,
+  splitFullName,
+} from "../person-identity-lib"
+
+/**
+ * #664 — pure name/email derivation shared by the live order→Person upsert
+ * (resolve-person step) and the backfill-order-persons maintenance job. No DB.
+ */
+describe("person-identity-lib — splitFullName", () => {
+  it("splits first token vs remainder", () => {
+    expect(splitFullName("Jane Q Public")).toEqual({
+      first_name: "Jane",
+      last_name: "Q Public",
+    })
+  })
+
+  it("single token → first only", () => {
+    expect(splitFullName("Madonna")).toEqual({ first_name: "Madonna", last_name: "" })
+  })
+
+  it("empty / whitespace → empty strings", () => {
+    expect(splitFullName("   ")).toEqual({ first_name: "", last_name: "" })
+    expect(splitFullName("")).toEqual({ first_name: "", last_name: "" })
+  })
+})
+
+describe("person-identity-lib — isUsableEmail", () => {
+  it("accepts a normal address", () => {
+    expect(isUsableEmail("jane@example.com")).toBe(true)
+  })
+
+  it("rejects null/empty/no-@/edge-@", () => {
+    expect(isUsableEmail(null)).toBe(false)
+    expect(isUsableEmail(undefined)).toBe(false)
+    expect(isUsableEmail("")).toBe(false)
+    expect(isUsableEmail("not-an-email")).toBe(false)
+    expect(isUsableEmail("@example.com")).toBe(false)
+    expect(isUsableEmail("jane@")).toBe(false)
+  })
+})
+
+describe("person-identity-lib — derivePersonName", () => {
+  it("prefers billing address", () => {
+    expect(
+      derivePersonName({
+        email: "x@y.com",
+        billing_address: { first_name: "Bill", last_name: "Ing" },
+        shipping_address: { first_name: "Ship", last_name: "Ping" },
+        customer: { first_name: "Cust", last_name: "Omer" },
+      })
+    ).toEqual({ first_name: "Bill", last_name: "Ing" })
+  })
+
+  it("falls back to shipping, then customer", () => {
+    expect(
+      derivePersonName({
+        billing_address: null,
+        shipping_address: { first_name: "Ship", last_name: "Ping" },
+        customer: { first_name: "Cust", last_name: "Omer" },
+      })
+    ).toEqual({ first_name: "Ship", last_name: "Ping" })
+
+    expect(
+      derivePersonName({
+        billing_address: { first_name: "", last_name: "" },
+        shipping_address: null,
+        customer: { first_name: "Cust", last_name: "Omer" },
+      })
+    ).toEqual({ first_name: "Cust", last_name: "Omer" })
+  })
+
+  it("accepts a partial address (first only) before falling through", () => {
+    expect(
+      derivePersonName({
+        billing_address: { first_name: "Solo", last_name: null },
+        customer: { first_name: "Cust", last_name: "Omer" },
+      })
+    ).toEqual({ first_name: "Solo", last_name: "" })
+  })
+
+  it("derives a title-cased name from the email local-part when no address/customer", () => {
+    expect(
+      derivePersonName({ email: "jane.doe@example.com" })
+    ).toEqual({ first_name: "Jane", last_name: "Doe" })
+
+    expect(
+      derivePersonName({ email: "support_team@example.com" })
+    ).toEqual({ first_name: "Support", last_name: "Team" })
+  })
+
+  it("returns empty strings when there is nothing to derive from", () => {
+    expect(derivePersonName({})).toEqual({ first_name: "", last_name: "" })
+    expect(derivePersonName({ email: "garbage" })).toEqual({
+      first_name: "",
+      last_name: "",
+    })
+  })
+})

--- a/apps/backend/src/workflows/ad-planning/conversions/person-identity-lib.ts
+++ b/apps/backend/src/workflows/ad-planning/conversions/person-identity-lib.ts
@@ -1,0 +1,81 @@
+/**
+ * Pure helpers for deriving a Person identity from an order (#664).
+ *
+ * Shared by the live purchase-conversion workflow (the forward fix in
+ * resolve-person) and the `backfill-order-persons` maintenance job. No
+ * container / IO here so the logic is unit-testable in isolation.
+ *
+ * Background: ad-planning scoring keys entirely off `person_id`. Manual orders
+ * historically had no matching Person row, so `resolvePersonStep` returned null
+ * and every downstream score (CLV / engagement / churn) silently skipped. The
+ * fix upserts a Person from the order's email + name; this module is the name
+ * derivation that both the forward fix and the backfill reuse.
+ */
+
+export type OrderIdentitySource = {
+  email?: string | null
+  billing_address?: { first_name?: string | null; last_name?: string | null } | null
+  shipping_address?: { first_name?: string | null; last_name?: string | null } | null
+  customer?: { first_name?: string | null; last_name?: string | null } | null
+}
+
+export type PersonName = { first_name: string; last_name: string }
+
+/**
+ * Split a free-text full name into {first,last}; the last name is the remainder
+ * after the first token (so "Jane Q Public" → first "Jane", last "Q Public").
+ */
+export function splitFullName(full: string): PersonName {
+  const parts = (full ?? "").trim().split(/\s+/).filter(Boolean)
+  if (parts.length === 0) return { first_name: "", last_name: "" }
+  if (parts.length === 1) return { first_name: parts[0], last_name: "" }
+  return { first_name: parts[0], last_name: parts.slice(1).join(" ") }
+}
+
+/**
+ * An order email is usable for Person upsert only if it actually looks like an
+ * address. Mirrors the loose `includes("@")` check already used across the
+ * codebase (auto-subscribe-customers.ts) rather than a strict RFC validator.
+ */
+export function isUsableEmail(email?: string | null): boolean {
+  const e = (email ?? "").trim()
+  return e.includes("@") && !e.startsWith("@") && !e.endsWith("@")
+}
+
+/**
+ * Derive a best-effort {first_name,last_name} for a Person created from an order.
+ * Precedence: billing address → shipping address → customer → email local-part.
+ * Always returns strings (never null) — Person.first_name/last_name are non-null
+ * `text` columns, so an empty string is the correct "unknown" value.
+ */
+export function derivePersonName(order: OrderIdentitySource): PersonName {
+  const candidates = [order.billing_address, order.shipping_address, order.customer]
+  for (const c of candidates) {
+    const first = (c?.first_name ?? "").trim()
+    const last = (c?.last_name ?? "").trim()
+    if (first || last) return { first_name: first, last_name: last }
+  }
+
+  // Last resort: turn the email local-part into a readable name
+  // ("jane.doe@x.com" → first "Jane", last "Doe").
+  const email = (order.email ?? "").trim()
+  if (isUsableEmail(email)) {
+    const local = email.split("@")[0].replace(/[._+-]+/g, " ")
+    const split = splitFullName(local)
+    // Title-case the derived tokens so they don't read as raw slugs.
+    return {
+      first_name: titleCase(split.first_name),
+      last_name: titleCase(split.last_name),
+    }
+  }
+
+  return { first_name: "", last_name: "" }
+}
+
+function titleCase(s: string): string {
+  return s
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ")
+}

--- a/apps/backend/src/workflows/ad-planning/conversions/track-purchase-conversion.ts
+++ b/apps/backend/src/workflows/ad-planning/conversions/track-purchase-conversion.ts
@@ -15,6 +15,7 @@ import { AD_PLANNING_MODULE } from "../../../modules/ad-planning";
 import type AdPlanningService from "../../../modules/ad-planning/service";
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { PERSON_MODULE } from "../../../modules/person";
+import { derivePersonName, isUsableEmail } from "./person-identity-lib";
 
 type TrackPurchaseConversionInput = {
   order_id: string;
@@ -46,6 +47,13 @@ const fetchOrderStep = createStep(
         "currency_code",
         "customer_id",
         "email",
+        // Name sources for Person upsert (#664) — billing/shipping/customer.
+        "billing_address.first_name",
+        "billing_address.last_name",
+        "shipping_address.first_name",
+        "shipping_address.last_name",
+        "customer.first_name",
+        "customer.last_name",
         "items.*",
       ],
       filters: { id: input.order_id },
@@ -55,12 +63,23 @@ const fetchOrderStep = createStep(
       throw new Error(`Order ${input.order_id} not found`);
     }
 
+    // Derive the person name once here so resolve-person can upsert a Person
+    // for manual orders that have no pre-existing Person row.
+    const personName = derivePersonName({
+      email: order.email,
+      billing_address: order.billing_address,
+      shipping_address: order.shipping_address,
+      customer: order.customer,
+    });
+
     return new StepResponse({
       id: order.id,
       total: Number(order.total) || 0,
       currency: order.currency_code,
       customer_id: order.customer_id,
       email: order.email,
+      first_name: personName.first_name,
+      last_name: personName.last_name,
       items: (order.items as any[])?.map((item: any) => ({
         product_id: item.product_id,
         variant_id: item.variant_id,
@@ -72,33 +91,97 @@ const fetchOrderStep = createStep(
 );
 
 /**
- * Step 2: Resolve person_id from order email
+ * Step 2: Resolve person_id from order email — UPSERT (#664).
+ *
+ * Previously this returned null when no Person matched the order email, which
+ * silently disabled all downstream scoring (CLV / journey / engagement / churn)
+ * for manual orders — those customers rarely have a pre-existing Person row.
+ *
+ * Now: match by email, and if there's no match, CREATE a Person from the order's
+ * email + derived name so scoring always has a subject to attach to. The
+ * compensation deletes the Person ONLY when this step created it (never an
+ * existing one).
  */
 const resolvePersonStep = createStep(
   "resolve-person",
   async (
-    input: { email?: string; person_id?: string },
+    input: {
+      email?: string;
+      person_id?: string;
+      first_name?: string;
+      last_name?: string;
+    },
     { container }
   ) => {
-    // If person_id already provided, use it
+    // If person_id already provided, use it (no creation → nothing to compensate)
     if (input.person_id) {
-      return new StepResponse({ person_id: input.person_id });
+      return new StepResponse(
+        { person_id: input.person_id },
+        { person_id: input.person_id, created: false }
+      );
     }
 
-    // Try to resolve person from order email
-    if (input.email) {
+    if (!isUsableEmail(input.email)) {
+      // No email to key a Person on — preserve the prior null behaviour.
+      return new StepResponse(
+        { person_id: null as string | null },
+        { person_id: null, created: false }
+      );
+    }
+
+    const personService = container.resolve(PERSON_MODULE) as any;
+
+    try {
+      const persons = await personService.listPeople({ email: input.email });
+      if (persons?.length > 0) {
+        return new StepResponse(
+          { person_id: persons[0].id },
+          { person_id: persons[0].id, created: false }
+        );
+      }
+
+      // No existing Person → create one from the order identity.
+      const created = await personService.createPeople({
+        first_name: input.first_name || "",
+        last_name: input.last_name || "",
+        email: input.email,
+        metadata: { source: "ad_planning_order_placed" },
+      });
+
+      return new StepResponse(
+        { person_id: created.id },
+        { person_id: created.id, created: true }
+      );
+    } catch (e: any) {
+      // A concurrent placement may win the unique-email race — re-read and reuse.
       try {
-        const personService = container.resolve(PERSON_MODULE) as any;
         const persons = await personService.listPeople({ email: input.email });
         if (persons?.length > 0) {
-          return new StepResponse({ person_id: persons[0].id });
+          return new StepResponse(
+            { person_id: persons[0].id },
+            { person_id: persons[0].id, created: false }
+          );
         }
       } catch {
-        // Person module lookup failed — non-fatal
+        // fall through to null — non-fatal, scoring just skips this order
+      }
+      console.error("[AdPlanning] Person upsert failed:", e?.message ?? e);
+      return new StepResponse(
+        { person_id: null as string | null },
+        { person_id: null, created: false }
+      );
+    }
+  },
+  async (comp, { container }) => {
+    // Only roll back a Person this step actually created.
+    if (comp?.created && comp.person_id) {
+      try {
+        const personService = container.resolve(PERSON_MODULE) as any;
+        await personService.deletePeople(comp.person_id);
+      } catch {
+        // best-effort cleanup
       }
     }
-
-    return new StepResponse({ person_id: null as string | null });
   }
 );
 
@@ -704,10 +787,13 @@ export const trackPurchaseConversionWorkflow = createWorkflow(
   (input: TrackPurchaseConversionInput) => {
     const order = fetchOrderStep({ order_id: input.order_id });
 
-    // Resolve person_id from input or order email
+    // Resolve person_id from input or order email — upserts a Person for manual
+    // orders so downstream scoring always has a subject (#664).
     const personResolution = resolvePersonStep({
       email: order.email,
       person_id: input.person_id,
+      first_name: order.first_name,
+      last_name: order.last_name,
     });
 
     const attribution = findAttributionStep({


### PR DESCRIPTION
Closes #664.

## Problem
ad-planning scoring keys entirely off \`person_id\`. \`resolvePersonStep\` (track-purchase-conversion.ts) returned \`person_id: null\` whenever no \`Person\` matched the order email — which is the common case for **manual orders** (no Person row is ever created for them). Result: CLV / engagement / churn / journey steps all silently skip, and those buyers are **invisible to the AI-VP winback targeting** (#659 slice 5), which joins on \`CustomerScore.person_id\`.

## Fix (two parts)
**1. Forward fix — `resolvePersonStep` upserts.** Matches by email; if no match, **creates** a Person from the order email + a derived name (billing → shipping → customer → email local-part). Compensation deletes the Person **only if this step created it** (never an existing one). Handles the unique-email race by re-reading on conflict.

**2. Backfill — `backfill-order-persons` Data Plumbing job (#457 registry).** Per your steer, the backfill is a guarded registry job (not a one-off script) so it inherits dry-run→apply, \`ops_audit\` run history, and the Settings → Data Plumbing UI. Scans person-less purchase \`Conversion\` rows, upserts a Person by email, and stamps \`conversion.person_id\`. Idempotent (already-linked rows are skipped), capped (default 200, max 1000), per-row \`errors[]\`, in-run dedup so a repeat email creates one Person.

## Scope note
The backfill repairs **identity** (Person + \`conversion.person_id\`). Re-running CLV/churn/engagement **scoring** over the repaired historical rows is a deliberate follow-up — the live workflow already scores all new orders, and identity is the prerequisite winbacks join on.

## Tests
- 19 new unit tests (pure \`derivePersonName\` / \`splitFullName\` / \`isUsableEmail\` + \`decideOrderPersonBackfill\` / summary + registration).
- Full maintenance-jobs unit suite **176/176 green**.
- Changed files typecheck clean (repo tsconfig).
- **Not** added this PR: an integration test booting an order through the workflow (container-bound path) — noted as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)