### PR TITLE
feat(#659): marketing module + 5 typed models + migration (slice 1)

### DIFF
--- a/apps/backend/integration-tests/http/marketing-module-service.spec.ts
+++ b/apps/backend/integration-tests/http/marketing-module-service.spec.ts
@@ -1,0 +1,104 @@
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { MARKETING_MODULE } from "../../src/modules/marketing"
+
+jest.setTimeout(60 * 1000)
+
+/**
+ * #659 slice 1 — the `marketing` module foundation. This slice ships no routes,
+ * so we exercise the module service directly: boot the app (which validates the
+ * module is registered + its migration ran against the shared test DB), then
+ * round-trip one row of each of the 5 models and assert the typed columns,
+ * json payloads, enum defaults, and the idempotency-critical unique index.
+ */
+setupSharedTestSuite(() => {
+  const { getContainer } = getSharedTestEnv()
+
+  describe("marketing module service", () => {
+    it("resolves from the container", () => {
+      const svc: any = getContainer().resolve(MARKETING_MODULE)
+      expect(svc).toBeDefined()
+      expect(typeof svc.createMarketingMetricSnapshots).toBe("function")
+    })
+
+    it("round-trips a metric snapshot with json breakdown + float value", async () => {
+      const svc: any = getContainer().resolve(MARKETING_MODULE)
+      const created = await svc.createMarketingMetricSnapshots({
+        metric_key: "platform_gmv",
+        value: 12345.67,
+        unit: "INR",
+        captured_for_date: new Date("2026-06-23T00:00:00.000Z"),
+        source: "daily-refresh",
+        breakdown: [{ label: "a", value: 1 }],
+        delta_dod: -4.5,
+      })
+
+      const [rows, count] = await svc.listAndCountMarketingMetricSnapshots({
+        id: created.id,
+      })
+      expect(count).toBe(1)
+      expect(rows[0].metric_key).toBe("platform_gmv")
+      expect(rows[0].value).toBeCloseTo(12345.67, 1)
+      expect(rows[0].breakdown).toEqual([{ label: "a", value: 1 }])
+      expect(rows[0].delta_dod).toBeCloseTo(-4.5, 1)
+    })
+
+    it("enforces the unique (metric_key, captured_for_date) index", async () => {
+      const svc: any = getContainer().resolve(MARKETING_MODULE)
+      const day = new Date("2026-05-01T00:00:00.000Z")
+      await svc.createMarketingMetricSnapshots({
+        metric_key: "partner_activations",
+        captured_for_date: day,
+      })
+      await expect(
+        svc.createMarketingMetricSnapshots({
+          metric_key: "partner_activations",
+          captured_for_date: day,
+        })
+      ).rejects.toBeDefined()
+    })
+
+    it("applies enum defaults on outreach (status=queued, channel=email)", async () => {
+      const svc: any = getContainer().resolve(MARKETING_MODULE)
+      const created = await svc.createMarketingOutreaches({
+        recipient_email: "winback@example.com",
+      })
+      expect(created.status).toBe("queued")
+      expect(created.channel).toBe("email")
+      expect(created.bounce_unreliable).toBe(false)
+    })
+
+    it("applies enum defaults on draft (kind=newsletter, status=draft) + json payload", async () => {
+      const svc: any = getContainer().resolve(MARKETING_MODULE)
+      const created = await svc.createMarketingDrafts({
+        name: "weekly-2026-06-23",
+        payload: { subject: "hi", sections: [] },
+      })
+      expect(created.kind).toBe("newsletter")
+      expect(created.status).toBe("draft")
+      expect(created.payload).toEqual({ subject: "hi", sections: [] })
+    })
+
+    it("round-trips a manual override and an ideas log", async () => {
+      const svc: any = getContainer().resolve(MARKETING_MODULE)
+
+      const override = await svc.createMarketingManualOverrides({
+        metric_key: "platform_gmv",
+        effective_date: new Date("2026-06-20T00:00:00.000Z"),
+        override_value: 999.99,
+        reason: "correcting a mis-attributed refund",
+        actor_id: "user_test",
+      })
+      expect(override.active).toBe(true)
+      expect(override.reason).toContain("refund")
+
+      const log = await svc.createMarketingIdeasLogs({
+        generated_for_date: new Date("2026-06-23T00:00:00.000Z"),
+        prompt_snapshot: { gmv: 12345 },
+        output_text: "Idea: run a winback campaign.",
+      })
+      expect(log.guard_passed).toBe(false)
+      expect(log.sent).toBe(false)
+      expect(log.prompt_snapshot).toEqual({ gmv: 12345 })
+    })
+  })
+})

--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -465,6 +465,9 @@ module.exports = defineConfig({
     resolve: "./src/modules/ops_audit",
   },
   {
+    resolve: "./src/modules/marketing",
+  },
+  {
     resolve: "./src/modules/ai_usage",
   },
   {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -403,6 +403,9 @@ module.exports = defineConfig({
     resolve: "./src/modules/ops_audit",
   },
   {
+    resolve: "./src/modules/marketing",
+  },
+  {
     resolve: "./src/modules/encryption",
     definition: { isQueryable: false },
   },

--- a/apps/backend/src/modules/marketing/index.ts
+++ b/apps/backend/src/modules/marketing/index.ts
@@ -1,0 +1,9 @@
+import { Module } from "@medusajs/framework/utils"
+
+import MarketingService from "./service"
+
+export const MARKETING_MODULE = "marketing"
+
+export default Module(MARKETING_MODULE, {
+  service: MarketingService,
+})

--- a/apps/backend/src/modules/marketing/migrations/Migration20260623120000.ts
+++ b/apps/backend/src/modules/marketing/migrations/Migration20260623120000.ts
@@ -1,0 +1,55 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * #659 slice 1 — the `marketing` module foundation: 5 typed tables for the
+ * AI-VP-of-Marketing data layer. Hand-written (not db:generate) so it lands on
+ * existing DBs; every table uses `create table if not exists` (safe on existing
+ * DBs — the hazard is only column-ADDs to a create-if-not-exists table).
+ *
+ * Class name Migration20260623120000 is globally unique across all modules
+ * (grep-verified) — Medusa tracks migrations by class name in a SHARED table, so
+ * a collision would silently skip this and the tables would never land.
+ */
+export class Migration20260623120000 extends Migration {
+
+  override async up(): Promise<void> {
+    // marketing_metric_snapshot — append-only headline/trend rows
+    this.addSql(`create table if not exists "marketing_metric_snapshot" ("id" text not null, "metric_key" text not null, "value" real not null default 0, "unit" text null, "captured_for_date" timestamptz not null, "source" text null, "breakdown" jsonb null, "delta_dod" real null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "marketing_metric_snapshot_pkey" primary key ("id"));`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_marketing_metric_snapshot_deleted_at" ON "marketing_metric_snapshot" ("deleted_at") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE UNIQUE INDEX IF NOT EXISTS "IDX_marketing_metric_snapshot_key_date" ON "marketing_metric_snapshot" ("metric_key", "captured_for_date") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_marketing_metric_snapshot_captured_for_date" ON "marketing_metric_snapshot" ("captured_for_date") WHERE deleted_at IS NULL;`);
+
+    // marketing_outreach — hand-crafted outbound (Winbacks / Exec)
+    this.addSql(`create table if not exists "marketing_outreach" ("id" text not null, "recipient_email" text not null, "recipient_name" text null, "company" text null, "status" text check ("status" in ('queued', 'sent', 'opened', 'replied', 'bounced', 'unknown')) not null default 'queued', "channel" text check ("channel" in ('email', 'whatsapp', 'manual')) not null default 'email', "campaign" text null, "sent_at" timestamptz null, "opened_at" timestamptz null, "replied_at" timestamptz null, "bounce_unreliable" boolean not null default false, "notes" text null, "external_id" text null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "marketing_outreach_pkey" primary key ("id"));`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_marketing_outreach_deleted_at" ON "marketing_outreach" ("deleted_at") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_marketing_outreach_recipient_email" ON "marketing_outreach" ("recipient_email") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_marketing_outreach_campaign" ON "marketing_outreach" ("campaign") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_marketing_outreach_status" ON "marketing_outreach" ("status") WHERE deleted_at IS NULL;`);
+
+    // marketing_draft — newsletter/campaign drafts by name
+    this.addSql(`create table if not exists "marketing_draft" ("id" text not null, "name" text not null, "kind" text check ("kind" in ('newsletter', 'campaign', 'ideas_email')) not null default 'newsletter', "status" text check ("status" in ('draft', 'approved', 'sent', 'discarded')) not null default 'draft', "payload" jsonb not null, "model_used" text null, "approved_by" text null, "sent_at" timestamptz null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "marketing_draft_pkey" primary key ("id"));`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_marketing_draft_deleted_at" ON "marketing_draft" ("deleted_at") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_marketing_draft_name" ON "marketing_draft" ("name") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_marketing_draft_kind_status" ON "marketing_draft" ("kind", "status") WHERE deleted_at IS NULL;`);
+
+    // marketing_manual_override — operator corrections to computed data
+    this.addSql(`create table if not exists "marketing_manual_override" ("id" text not null, "metric_key" text not null, "effective_date" timestamptz not null, "override_value" real not null, "reason" text not null, "actor_id" text not null, "active" boolean not null default true, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "marketing_manual_override_pkey" primary key ("id"));`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_marketing_manual_override_deleted_at" ON "marketing_manual_override" ("deleted_at") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_marketing_manual_override_key_date" ON "marketing_manual_override" ("metric_key", "effective_date") WHERE deleted_at IS NULL;`);
+
+    // marketing_ideas_log — one row per generated tactical-ideas email
+    this.addSql(`create table if not exists "marketing_ideas_log" ("id" text not null, "generated_for_date" timestamptz not null, "model_used" text null, "prompt_snapshot" jsonb not null, "output_text" text not null, "guard_passed" boolean not null default false, "guard_failures" jsonb null, "regenerated" boolean not null default false, "sent" boolean not null default false, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "marketing_ideas_log_pkey" primary key ("id"));`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_marketing_ideas_log_deleted_at" ON "marketing_ideas_log" ("deleted_at") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_marketing_ideas_log_generated_for_date" ON "marketing_ideas_log" ("generated_for_date") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_marketing_ideas_log_guard_passed" ON "marketing_ideas_log" ("guard_passed") WHERE deleted_at IS NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "marketing_metric_snapshot" cascade;`);
+    this.addSql(`drop table if exists "marketing_outreach" cascade;`);
+    this.addSql(`drop table if exists "marketing_draft" cascade;`);
+    this.addSql(`drop table if exists "marketing_manual_override" cascade;`);
+    this.addSql(`drop table if exists "marketing_ideas_log" cascade;`);
+  }
+
+}

--- a/apps/backend/src/modules/marketing/models/marketing-draft.ts
+++ b/apps/backend/src/modules/marketing/models/marketing-draft.ts
@@ -1,0 +1,25 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * marketing_draft — newsletter/campaign drafts by name (#659 slice 1).
+ * Report §4.5: operator-review, never auto-send. Slice 4 (newsletter generator)
+ * writes here; slice 2's ideas email may also persist as kind="ideas_email".
+ */
+const MarketingDraft = model
+  .define("marketing_draft", {
+    id: model.id().primaryKey(),
+    name: model.text(), // human label, e.g. "weekly-2026-06-23"
+    kind: model
+      .enum(["newsletter", "campaign", "ideas_email"])
+      .default("newsletter"),
+    status: model
+      .enum(["draft", "approved", "sent", "discarded"])
+      .default("draft"),
+    payload: model.json(), // {subject, preheader, intro, sections[], ...}
+    model_used: model.text().nullable(), // which LLM produced it (for recall/A-B)
+    approved_by: model.text().nullable(),
+    sent_at: model.dateTime().nullable(),
+  })
+  .indexes([{ on: ["name"] }, { on: ["kind", "status"] }])
+
+export default MarketingDraft

--- a/apps/backend/src/modules/marketing/models/marketing-ideas-log.ts
+++ b/apps/backend/src/modules/marketing/models/marketing-ideas-log.ts
@@ -1,0 +1,24 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * marketing_ideas_log — one row per generated tactical-ideas email (#659 slice 1).
+ * Report §4.4. Exists for recall, A/B, and the hallucination-guard post-mortem.
+ * `prompt_snapshot` (the ground-truth numbers fed in) + `guard_failures` make
+ * slice 2's hallucination guard auditable and replayable — which is exactly why
+ * this is a typed table, not metadata.
+ */
+const MarketingIdeasLog = model
+  .define("marketing_ideas_log", {
+    id: model.id().primaryKey(),
+    generated_for_date: model.dateTime(),
+    model_used: model.text().nullable(),
+    prompt_snapshot: model.json(), // the ground-truth numbers fed in (guard input)
+    output_text: model.text(), // the generated email body
+    guard_passed: model.boolean().default(false), // did the §7 number-guard pass?
+    guard_failures: model.json().nullable(), // [{token, expected, found}] when it didn't
+    regenerated: model.boolean().default(false),
+    sent: model.boolean().default(false), // did it actually go out, or flag-for-review?
+  })
+  .indexes([{ on: ["generated_for_date"] }, { on: ["guard_passed"] }])
+
+export default MarketingIdeasLog

--- a/apps/backend/src/modules/marketing/models/marketing-manual-override.ts
+++ b/apps/backend/src/modules/marketing/models/marketing-manual-override.ts
@@ -1,0 +1,22 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * marketing_manual_override — operator corrections to computed data (#659 slice 1).
+ * Report §6: when the operator overrides a computed number, record it WITH a
+ * reason so the AI guard and dashboard show the human-corrected value, audited.
+ * `active` soft-disables instead of deleting. Slice 3 reads these to override the
+ * snapshot headline.
+ */
+const MarketingManualOverride = model
+  .define("marketing_manual_override", {
+    id: model.id().primaryKey(),
+    metric_key: model.text(), // which snapshot metric this overrides
+    effective_date: model.dateTime(), // the day the override applies to
+    override_value: model.float(),
+    reason: model.text(), // required — never a silent override
+    actor_id: model.text(), // who made the override
+    active: model.boolean().default(true), // soft-disable instead of delete
+  })
+  .indexes([{ on: ["metric_key", "effective_date"] }])
+
+export default MarketingManualOverride

--- a/apps/backend/src/modules/marketing/models/marketing-metric-snapshot.ts
+++ b/apps/backend/src/modules/marketing/models/marketing-metric-snapshot.ts
@@ -1,0 +1,28 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * marketing_metric_snapshot — append-only headline/trend rows (#659 slice 1).
+ *
+ * Goal-agnostic: one row per (metric_key, captured_for_date) storing any named
+ * metric, so the still-open "One Goal" decision doesn't gate this table. The One
+ * Goal only picks WHICH metric_key is rendered as the headline (slice 3); it is a
+ * value here, not a schema change. The unique index makes slice 3's daily upsert
+ * idempotent.
+ */
+const MarketingMetricSnapshot = model
+  .define("marketing_metric_snapshot", {
+    id: model.id().primaryKey(),
+    metric_key: model.text(), // "platform_gmv" | "partner_activations" | "storefront_conversion" | ...
+    value: model.float().default(0), // float covers currency + ratio (see spec §3.6 on money)
+    unit: model.text().nullable(), // "INR" | "count" | "ratio" | null
+    captured_for_date: model.dateTime(), // the business day this snapshot is FOR (IST midnight)
+    source: model.text().nullable(), // "daily-refresh" | "manual" | "backfill"
+    breakdown: model.json().nullable(), // optional [{label, value}] for drill-downs
+    delta_dod: model.float().nullable(), // day-over-day delta, precomputed by the job
+  })
+  .indexes([
+    { on: ["metric_key", "captured_for_date"], unique: true }, // idempotent daily upsert
+    { on: ["captured_for_date"] },
+  ])
+
+export default MarketingMetricSnapshot

--- a/apps/backend/src/modules/marketing/models/marketing-outreach.ts
+++ b/apps/backend/src/modules/marketing/models/marketing-outreach.ts
@@ -1,0 +1,33 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * marketing_outreach — hand-crafted outbound (Winbacks / Exec) (#659 slice 1).
+ * Powers slice 5 (WinbacksView). Honesty rule (report §6): bounce status is
+ * unreliable, so `bounce_unreliable` flags it for a yellow warning rather than
+ * silently suppressing the recipient.
+ */
+const MarketingOutreach = model
+  .define("marketing_outreach", {
+    id: model.id().primaryKey(),
+    recipient_email: model.text(),
+    recipient_name: model.text().nullable(),
+    company: model.text().nullable(),
+    status: model
+      .enum(["queued", "sent", "opened", "replied", "bounced", "unknown"])
+      .default("queued"),
+    channel: model.enum(["email", "whatsapp", "manual"]).default("email"),
+    campaign: model.text().nullable(), // free-text grouping ("q3-winbacks")
+    sent_at: model.dateTime().nullable(),
+    opened_at: model.dateTime().nullable(),
+    replied_at: model.dateTime().nullable(),
+    bounce_unreliable: model.boolean().default(false),
+    notes: model.text().nullable(),
+    external_id: model.text().nullable(), // provider message id for sync (slice 5)
+  })
+  .indexes([
+    { on: ["recipient_email"] },
+    { on: ["campaign"] },
+    { on: ["status"] },
+  ])
+
+export default MarketingOutreach

--- a/apps/backend/src/modules/marketing/service.ts
+++ b/apps/backend/src/modules/marketing/service.ts
@@ -1,0 +1,28 @@
+import { MedusaService } from "@medusajs/framework/utils"
+
+import MarketingMetricSnapshot from "./models/marketing-metric-snapshot"
+import MarketingOutreach from "./models/marketing-outreach"
+import MarketingDraft from "./models/marketing-draft"
+import MarketingManualOverride from "./models/marketing-manual-override"
+import MarketingIdeasLog from "./models/marketing-ideas-log"
+
+/**
+ * marketing module service — the AI-VP-of-Marketing data foundation (#659).
+ *
+ * MedusaService auto-generates per-model CRUD, e.g.
+ * `createMarketingMetricSnapshots` / `listAndCountMarketingMetricSnapshots`,
+ * `createMarketingOutreaches`, `createMarketingDrafts`,
+ * `createMarketingManualOverrides`, `createMarketingIdeasLogs`, etc.
+ *
+ * This module is INDEPENDENT of `ad_planning` (own module + admin menu); later
+ * slices READ ad_planning/analytics via Query (query.graph), never the reverse.
+ */
+class MarketingService extends MedusaService({
+  MarketingMetricSnapshot,
+  MarketingOutreach,
+  MarketingDraft,
+  MarketingManualOverride,
+  MarketingIdeasLog,
+}) {}
+
+export default MarketingService


### PR DESCRIPTION
Part of #659 (AI VP of Marketing). **Slice 1 — the data foundation.** No routes, jobs, AI, or UI; those are slices 2–6. This stands up the typed tables every later slice writes into.

## What's here
New \`marketing\` Medusa module (mirrors \`ops_audit\`) with 5 \`model.define\` models — all load-bearing state in typed columns, never \`metadata\`:

| Model | Purpose | Slice that uses it |
|---|---|---|
| \`marketing_metric_snapshot\` | append-only headline/trend rows; **unique (metric_key, captured_for_date)** for idempotent daily upsert | 3 |
| \`marketing_outreach\` | hand-crafted Winbacks/Exec outbound; \`bounce_unreliable\` honesty flag | 5 |
| \`marketing_draft\` | newsletter/campaign drafts, operator-review | 4 |
| \`marketing_manual_override\` | audited corrections with a required \`reason\` | 3 |
| \`marketing_ideas_log\` | per-email guard audit trail (\`prompt_snapshot\` + \`guard_failures\`) | 2 |

Plus \`index.ts\`, \`service.ts\` (auto-CRUD), and one hand-written migration.

## Key correctness notes
- **Migration class name \`Migration20260623120000\` is globally unique** (grep-verified across all modules) — Medusa tracks migrations by class name in a *shared* table, so a collision silently drops the tables (the #348-A/#604-A bug). Uses \`create table if not exists\` → safe + idempotent on existing DBs.
- **Registered in BOTH** \`medusa-config.ts\` and \`medusa-config.prod.ts\` (prod runs the \`.prod.ts\`; a module in only the base file is invisible in prod).
- \`model.float()\` → \`real\`; enums → \`text check (...)\`; matches Medusa's own emission.
- **Independent of \`ad_planning\`** (own module + menu); later slices read ad_planning/analytics via \`query.graph\`, never the reverse (adaptation report §3a).

## The "One Goal" is NOT a blocker for this slice
The snapshot table is goal-agnostic (named-metric rows). The still-open One-Goal decision (GMV vs partner-activation vs storefront-conversion) only picks *which* \`metric_key\` renders as the headline in slice 3 — a value here, not a schema change.

## Verification
- **6 integration tests green** on the shared DB (\`marketing-module-service.spec.ts\`): module resolves from the container, all 5 tables land (migration ran), the unique index rejects a duplicate, enum defaults land (\`status=queued\`, \`kind=newsletter\`), and \`json\` columns round-trip.
- Changed files typecheck clean (repo tsconfig).
- Idempotent re-migrate guaranteed by \`if not exists\` on every table + index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)