### PR TITLE
feat(marketing): ideas-email hallucination guard + prompt lib (#659 slice 2 · PR-1)

### DIFF
--- a/apps/backend/src/workflows/marketing/__tests__/ideas-email-guard-lib.unit.spec.ts
+++ b/apps/backend/src/workflows/marketing/__tests__/ideas-email-guard-lib.unit.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit test — ideas-email hallucination guard (#659 slice 2, spec 02 §3/§8).
+ * Pure number-parsing + tolerance + fail-closed logic. No DI, no DB, no LLM.
+ *
+ * Run:
+ *   TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules npx jest --testPathPattern="ideas-email-guard"
+ */
+import {
+  parseNumberToken,
+  extractNumericTokens,
+  substitutePlaceholders,
+  validateStrayNumbers,
+  runGuard,
+  type GroundTruth,
+} from "../ideas-email-guard-lib"
+
+const GT: GroundTruth = {
+  date_ist: "2026-06-23",
+  one_goal: "Grow GMV",
+  values: [
+    { token: "TODAY_GMV", value: 184320.5, display: "₹1,84,320", unit: "INR" },
+    { token: "DELTA_DOD", value: 12.5, display: "+12.5%", unit: "percent" },
+    { token: "ORDERS", value: 42, display: "42", unit: "count" },
+    { token: "ZERO_METRIC", value: 0, display: "0", unit: "count" },
+  ],
+}
+
+describe("parseNumberToken", () => {
+  it("parses Indian comma grouping", () => {
+    expect(parseNumberToken("1,84,320")).toBe(184320)
+  })
+  it("parses percentage to its numeric value", () => {
+    expect(parseNumberToken("12.5%")).toBe(12.5)
+  })
+  it("expands ₹4.5L to 450000 (lakh)", () => {
+    expect(parseNumberToken("₹4.5L")).toBe(450000)
+  })
+  it("expands $1.2M to 1200000", () => {
+    expect(parseNumberToken("$1.2M")).toBe(1200000)
+  })
+  it("expands crore", () => {
+    expect(parseNumberToken("2Cr")).toBe(20000000)
+    expect(parseNumberToken("1.5 crore")).toBe(15000000)
+  })
+  it("expands K", () => {
+    expect(parseNumberToken("5K")).toBe(5000)
+  })
+  it("handles negatives and decimals", () => {
+    expect(parseNumberToken("-3")).toBe(-3)
+    expect(parseNumberToken("0.42")).toBe(0.42)
+  })
+  it("returns null for non-numbers", () => {
+    expect(parseNumberToken("abc")).toBeNull()
+    expect(parseNumberToken("")).toBeNull()
+    expect(parseNumberToken(null as any)).toBeNull()
+  })
+})
+
+describe("extractNumericTokens", () => {
+  it("extracts each number-shaped literal with canonical value", () => {
+    const toks = extractNumericTokens("GMV ₹1,84,320 up 12.5% over 42 orders")
+    const vals = toks.map((t) => t.value)
+    expect(vals).toEqual([184320, 12.5, 42])
+  })
+  it("returns [] for text with no numbers", () => {
+    expect(extractNumericTokens("no digits here")).toEqual([])
+    expect(extractNumericTokens("")).toEqual([])
+  })
+  it("does not parse a single letter following a space as a suffix", () => {
+    // "5 Killer ideas" must be 5, not 5000
+    const toks = extractNumericTokens("5 Killer ideas")
+    expect(toks[0].value).toBe(5)
+  })
+})
+
+describe("substitutePlaceholders", () => {
+  it("replaces known tokens with their display value", () => {
+    const r = substitutePlaceholders(
+      "GMV is {TODAY_GMV}, change {DELTA_DOD}.",
+      GT
+    )
+    expect(r.text).toBe("GMV is ₹1,84,320, change +12.5%.")
+    expect(r.substituted.sort()).toEqual(["DELTA_DOD", "TODAY_GMV"])
+    expect(r.missing).toEqual([])
+  })
+  it("reports unknown placeholders as missing and leaves them intact (fail-closed)", () => {
+    const r = substitutePlaceholders("invented {MADE_UP_TOKEN} here", GT)
+    expect(r.missing).toEqual(["MADE_UP_TOKEN"])
+    expect(r.text).toContain("{MADE_UP_TOKEN}")
+  })
+})
+
+describe("validateStrayNumbers", () => {
+  it("passes a literal within ±2% of a ground-truth value", () => {
+    // 184320 is within 2% of 184320.5
+    const r = validateStrayNumbers("we hit 184320 today", GT)
+    expect(r.passed).toBe(true)
+    expect(r.failures).toEqual([])
+  })
+  it("fails an out-of-tolerance literal with correct deviationPct", () => {
+    const r = validateStrayNumbers("we hit 999999 today", GT)
+    expect(r.passed).toBe(false)
+    expect(r.failures).toHaveLength(1)
+    expect(r.failures[0].value).toBe(999999)
+    expect(r.failures[0].nearest).toBe(184320.5)
+    expect(r.failures[0].deviationPct).toBeGreaterThan(2)
+  })
+  it("whitelists the business-day year", () => {
+    const r = validateStrayNumbers("plan for 2026 holidays", GT)
+    expect(r.passed).toBe(true)
+  })
+  it("whitelists small list-marker ordinals (1. 2) etc)", () => {
+    const r = validateStrayNumbers("1. do this\n2) do that", GT)
+    expect(r.passed).toBe(true)
+  })
+  it("honours a caller allow-list of exact raw literals", () => {
+    const r = validateStrayNumbers("target a 20% lift", GT, 2, ["20%"])
+    expect(r.passed).toBe(true)
+  })
+  it("does not divide-by-zero against an exact-0 ground truth", () => {
+    const r = validateStrayNumbers("we had 0 refunds", GT)
+    expect(r.passed).toBe(true)
+    // a non-zero stray near zero is still out of tolerance, not NaN
+    const r2 = validateStrayNumbers("we had 7 refunds", GT)
+    const zeroFail = r2.failures.find((f) => f.nearest === 0)
+    if (zeroFail) expect(zeroFail.deviationPct).not.toBeNaN()
+  })
+})
+
+describe("runGuard", () => {
+  it("passes clean placeholder-only text and applies substitution", () => {
+    const raw = "1. Push {TODAY_GMV} GMV.\n2. DoD is {DELTA_DOD}."
+    const v = runGuard(raw, GT)
+    expect(v.passed).toBe(true)
+    expect(v.finalText).toContain("₹1,84,320")
+    expect(v.finalText).toContain("+12.5%")
+    expect(v.substituted.sort()).toEqual(["DELTA_DOD", "TODAY_GMV"])
+    expect(v.failures).toEqual([])
+  })
+  it("fails closed on a stray hallucinated number", () => {
+    const raw = "Revenue jumped to ₹5,00,000 today, push harder."
+    const v = runGuard(raw, GT)
+    expect(v.passed).toBe(false)
+    expect(v.failures.some((f) => f.type === "stray_number")).toBe(true)
+  })
+  it("fails closed on a missing/invented placeholder", () => {
+    const raw = "Our {INVENTED_METRIC} is great."
+    const v = runGuard(raw, GT)
+    expect(v.passed).toBe(false)
+    expect(v.failures.some((f) => f.type === "missing_placeholder")).toBe(true)
+  })
+  it("does not flag placeholder-derived numbers as stray after substitution", () => {
+    // {TODAY_GMV} → ₹1,84,320 — the 184320 in finalText must not trip Layer B
+    const v = runGuard("GMV {TODAY_GMV} now.", GT)
+    expect(v.passed).toBe(true)
+  })
+  it("respects a custom tolerance", () => {
+    // 190000 is ~3.1% off 184320.5; passes at 5% tolerance, fails at default 2%
+    expect(runGuard("hit 190000", GT, { tolerancePct: 5 }).passed).toBe(true)
+    expect(runGuard("hit 190000", GT).passed).toBe(false)
+  })
+})

--- a/apps/backend/src/workflows/marketing/__tests__/ideas-email-prompt-lib.unit.spec.ts
+++ b/apps/backend/src/workflows/marketing/__tests__/ideas-email-prompt-lib.unit.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit test — ideas-email prompt assembly (#659 slice 2, spec 02 §4.4/§8).
+ * Pure: ground truth + voice in → prompt string out. No DI, no DB, no LLM.
+ *
+ * Run:
+ *   TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules npx jest --testPathPattern="ideas-email-prompt"
+ */
+import {
+  buildIdeasPrompt,
+  MARKETING_VOICE_RULES,
+  STRICTER_SUFFIX,
+} from "../ideas-email-prompt-lib"
+import type { GroundTruth } from "../ideas-email-guard-lib"
+
+const GT: GroundTruth = {
+  date_ist: "2026-06-23",
+  one_goal: "Grow GMV",
+  values: [
+    { token: "TODAY_GMV", value: 184320.5, display: "₹1,84,320", unit: "INR" },
+    { token: "DELTA_DOD", value: 12.5, display: "+12.5%", unit: "percent" },
+  ],
+}
+
+describe("buildIdeasPrompt", () => {
+  const prompt = buildIdeasPrompt(GT, "JYT — textile production e-commerce")
+
+  it("includes every ground-truth {TOKEN} placeholder", () => {
+    expect(prompt).toContain("{TODAY_GMV}")
+    expect(prompt).toContain("{DELTA_DOD}")
+  })
+  it("interpolates the date and the one goal", () => {
+    expect(prompt).toContain("2026-06-23")
+    expect(prompt).toContain("Grow GMV")
+  })
+  it("contains the placeholder-only hard rule", () => {
+    expect(prompt).toContain("ONLY by its {TOKEN} placeholder")
+    expect(prompt.toLowerCase()).toContain("never write a literal number")
+  })
+  it("includes the business description and the voice rules", () => {
+    expect(prompt).toContain("JYT — textile production e-commerce")
+    expect(prompt).toContain(MARKETING_VOICE_RULES.split("\n")[0])
+  })
+  it("is deterministic given the same input", () => {
+    expect(buildIdeasPrompt(GT, "X")).toBe(buildIdeasPrompt(GT, "X"))
+  })
+  it("accepts a voice-rules override", () => {
+    expect(buildIdeasPrompt(GT, "X", "TERSE ONLY")).toContain("TERSE ONLY")
+  })
+  it("handles an empty ground-truth value set gracefully", () => {
+    const p = buildIdeasPrompt({ ...GT, values: [] }, "X")
+    expect(p).toContain("(no metrics available)")
+  })
+})
+
+describe("STRICTER_SUFFIX", () => {
+  it("reinforces the placeholder-only rule for the regenerate attempt", () => {
+    expect(STRICTER_SUFFIX.toLowerCase()).toContain("placeholder")
+    expect(STRICTER_SUFFIX.toLowerCase()).toContain("forbidden")
+  })
+})

--- a/apps/backend/src/workflows/marketing/ideas-email-guard-lib.ts
+++ b/apps/backend/src/workflows/marketing/ideas-email-guard-lib.ts
@@ -1,0 +1,281 @@
+/**
+ * ideas-email-guard-lib.ts — the two-layer hallucination guard for the daily
+ * AI tactical-ideas email (#659 slice 2, spec 02_IDEAS_EMAIL_HALLUCINATION_GUARD_SPEC.md §3).
+ *
+ * PURE + framework-free + deterministic → fully unit-testable with no DB or LLM.
+ * The workflow (generate-ideas-email.ts) calls `runGuard` and persists the verdict
+ * to `marketing_ideas_log` BEFORE any send, so every guard decision is replayable.
+ *
+ * Two layers (report §7 / source spec §7.2, NON-negotiable — ship before first send):
+ *   Layer A — token-placeholder substitution: the LLM references numbers ONLY via
+ *             `{TOKEN}` placeholders; the server substitutes ground-truth display
+ *             values. A placeholder-derived number is impossible to get wrong.
+ *   Layer B — stray-literal regex validation: any number-shaped literal the LLM
+ *             emitted ANYWAY is checked against the ground-truth set within ±2%.
+ *             A stray with no match ⇒ the email is FLAGGED and NOT sent (fail-closed).
+ */
+
+export interface GroundTruthValue {
+  token: string // "TODAY_GMV"
+  value: number // 184320.5  (canonical numeric)
+  display: string // "₹1,84,320"  (what gets substituted into the copy)
+  unit?: string | null // "INR" | "count" | "ratio" | "percent"
+}
+
+export interface GroundTruth {
+  values: GroundTruthValue[] // from marketing_metric_snapshot rows + computed deltas
+  date_ist: string // "2026-06-23" — IST business day, passed into the prompt
+  one_goal: string // interpolated, never invented in code
+}
+
+export interface GuardFailure {
+  type: "missing_placeholder" | "stray_number"
+  token: string
+  value?: number | null
+  nearest?: number | null
+  deviationPct?: number | null
+}
+
+/** Small epsilon so an exact-0 / tiny-count ground-truth never divides by zero. */
+const EPS = 1e-9
+
+/** Default tolerance the source spec mandates for stray-literal matching. */
+export const DEFAULT_TOLERANCE_PCT = 2
+
+/**
+ * Matches a number-shaped literal: optional currency prefix, optional sign, a digit
+ * body with Indian/western comma grouping + optional decimal, and an OPTIONAL
+ * IMMEDIATELY-ADJACENT suffix (%, K, L, M, B, Cr, Lakh, Crore). The suffix must be
+ * adjacent (no space) so "5 Killer ideas" parses as 5, not 5K.
+ */
+const NUMERIC_RE = /(?:([₹$€£])\s?)?(-?\d[\d,]*(?:\.\d+)?)(%|Cr|Crore|Lakh|[KLMB])?/gi
+
+const PLACEHOLDER_RE = /\{([A-Z0-9_]+)\}/g
+
+/**
+ * Normalize a matched raw token to a canonical number.
+ * Strips ₹/$/€/£ and commas; expands %, K/L(akh)/M/B/Cr(ore) suffixes.
+ * Returns null if the string is not a parseable number.
+ *
+ *   "1,84,320" → 184320   "12.5%" → 12.5   "₹4.5L" → 450000
+ *   "$1.2M" → 1200000     "-3" → -3        "0.42" → 0.42
+ */
+export function parseNumberToken(raw: string): number | null {
+  if (raw == null) return null
+  let s = String(raw).trim()
+  if (!s) return null
+  // strip currency symbols
+  s = s.replace(/[₹$€£]/g, "").trim()
+
+  let multiplier = 1
+  const suffixMatch = s.match(/(%|Cr|Crore|Lakh|[KLMB])\s*$/i)
+  if (suffixMatch) {
+    const suf = suffixMatch[1].toLowerCase()
+    if (suf === "%") multiplier = 1 // percent value stays as-is (12.5% → 12.5)
+    else if (suf === "k") multiplier = 1e3
+    else if (suf === "l" || suf === "lakh") multiplier = 1e5
+    else if (suf === "m") multiplier = 1e6
+    else if (suf === "cr" || suf === "crore") multiplier = 1e7
+    else if (suf === "b") multiplier = 1e9
+    s = s.slice(0, s.length - suffixMatch[1].length).trim()
+  }
+
+  // strip Indian + western grouping commas
+  s = s.replace(/,/g, "")
+  if (!/^-?\d*\.?\d+$/.test(s)) return null
+  const n = parseFloat(s)
+  if (Number.isNaN(n)) return null
+  return n * multiplier
+}
+
+/**
+ * Extract every number-shaped substring with its canonical value and index.
+ * Substrings that don't parse to a number are skipped.
+ */
+export function extractNumericTokens(
+  text: string
+): Array<{ raw: string; value: number; index: number }> {
+  if (!text) return []
+  const out: Array<{ raw: string; value: number; index: number }> = []
+  NUMERIC_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = NUMERIC_RE.exec(text)) !== null) {
+    // guard against zero-width matches (the body group requires ≥1 digit, but be safe)
+    if (m[0].length === 0) {
+      NUMERIC_RE.lastIndex++
+      continue
+    }
+    const raw = m[0].trim()
+    const value = parseNumberToken(raw)
+    if (value === null) continue
+    out.push({ raw, value, index: m.index })
+  }
+  return out
+}
+
+/**
+ * Layer A — substitute `{TOKEN}` → ground-truth display.
+ * Returns the rewritten text, the unique tokens substituted, and any placeholders
+ * the LLM used that we have NO ground-truth for (→ caller fails closed).
+ */
+export function substitutePlaceholders(
+  text: string,
+  gt: GroundTruth
+): { text: string; substituted: string[]; missing: string[] } {
+  const byToken = new Map<string, GroundTruthValue>()
+  for (const v of gt.values || []) byToken.set(v.token, v)
+
+  const substituted = new Set<string>()
+  const missing = new Set<string>()
+
+  const out = (text || "").replace(PLACEHOLDER_RE, (whole, token: string) => {
+    const v = byToken.get(token)
+    if (v) {
+      substituted.add(token)
+      return v.display
+    }
+    missing.add(token)
+    return whole // leave intact so it's visible in the flagged log
+  })
+
+  return {
+    text: out,
+    substituted: Array.from(substituted),
+    missing: Array.from(missing),
+  }
+}
+
+/** Tolerance window around a ground-truth value g (±tolerancePct, floored at EPS). */
+function toleranceFor(g: number, tolerancePct: number): number {
+  return Math.max(Math.abs(g) * (tolerancePct / 100), EPS)
+}
+
+/**
+ * Determine if an extracted literal is obviously-safe and should NOT be treated as
+ * a claimed metric: the business-day year, a small list-marker ordinal ("1." / "2)"),
+ * or a caller-supplied allow-list of exact raw literals (e.g. target "20%").
+ */
+function isWhitelisted(
+  tok: { raw: string; value: number; index: number },
+  text: string,
+  yearValue: number | null,
+  allowList: string[]
+): boolean {
+  if (allowList.includes(tok.raw)) return true
+  if (yearValue !== null && tok.value === yearValue) return true
+  // list marker: small integer immediately followed by "." or ")"
+  if (Number.isInteger(tok.value) && tok.value >= 1 && tok.value <= 20) {
+    const after = text.charAt(tok.index + tok.raw.length)
+    if (after === "." || after === ")") return true
+  }
+  return false
+}
+
+/**
+ * Layer B — every stray literal in `text` must match SOME ground-truth value within
+ * tolerance, else the run fails closed. `text` should be the RAW LLM output (before
+ * placeholder substitution) so legit placeholder-derived numbers aren't present yet.
+ */
+export function validateStrayNumbers(
+  text: string,
+  gt: GroundTruth,
+  tolerancePct: number = DEFAULT_TOLERANCE_PCT,
+  allowList: string[] = []
+): {
+  passed: boolean
+  failures: Array<{
+    token: string
+    value: number
+    nearest: number | null
+    deviationPct: number | null
+  }>
+} {
+  const yearValue = (() => {
+    const y = parseInt(String(gt.date_ist || "").slice(0, 4), 10)
+    return Number.isNaN(y) ? null : y
+  })()
+
+  const gtValues = (gt.values || []).map((v) => v.value)
+  const failures: Array<{
+    token: string
+    value: number
+    nearest: number | null
+    deviationPct: number | null
+  }> = []
+
+  for (const tok of extractNumericTokens(text)) {
+    if (isWhitelisted(tok, text, yearValue, allowList)) continue
+
+    // find the nearest ground-truth value (smallest absolute distance)
+    let nearest: number | null = null
+    let bestDist = Infinity
+    for (const g of gtValues) {
+      const d = Math.abs(tok.value - g)
+      if (d < bestDist) {
+        bestDist = d
+        nearest = g
+      }
+    }
+
+    const within =
+      nearest !== null && bestDist <= toleranceFor(nearest, tolerancePct)
+    if (within) continue
+
+    const deviationPct =
+      nearest === null
+        ? null
+        : Math.abs(nearest) < EPS
+          ? bestDist < EPS
+            ? 0
+            : Infinity
+          : (bestDist / Math.abs(nearest)) * 100
+
+    failures.push({ token: tok.raw, value: tok.value, nearest, deviationPct })
+  }
+
+  return { passed: failures.length === 0, failures }
+}
+
+/**
+ * Orchestrator over a SINGLE candidate (no I/O): substitute placeholders, validate
+ * stray literals against the RAW output, return a verdict. Fail-closed: any missing
+ * placeholder OR any unmatched stray literal ⇒ passed = false.
+ */
+export function runGuard(
+  rawOutput: string,
+  gt: GroundTruth,
+  opts?: { tolerancePct?: number; allowList?: string[] }
+): {
+  finalText: string
+  passed: boolean
+  failures: GuardFailure[]
+  substituted: string[]
+} {
+  const tolerancePct = opts?.tolerancePct ?? DEFAULT_TOLERANCE_PCT
+  const allowList = opts?.allowList ?? []
+
+  const sub = substitutePlaceholders(rawOutput, gt)
+  // Layer B runs on the RAW output (placeholders are still {TOKEN}, not numbers).
+  const stray = validateStrayNumbers(rawOutput, gt, tolerancePct, allowList)
+
+  const failures: GuardFailure[] = []
+  for (const token of sub.missing) {
+    failures.push({ type: "missing_placeholder", token })
+  }
+  for (const f of stray.failures) {
+    failures.push({
+      type: "stray_number",
+      token: f.token,
+      value: f.value,
+      nearest: f.nearest,
+      deviationPct: f.deviationPct,
+    })
+  }
+
+  return {
+    finalText: sub.text,
+    passed: sub.missing.length === 0 && stray.passed,
+    failures,
+    substituted: sub.substituted,
+  }
+}

--- a/apps/backend/src/workflows/marketing/ideas-email-prompt-lib.ts
+++ b/apps/backend/src/workflows/marketing/ideas-email-prompt-lib.ts
@@ -1,0 +1,71 @@
+/**
+ * ideas-email-prompt-lib.ts — pure prompt assembly for the daily AI tactical-ideas
+ * email (#659 slice 2, spec 02 §4.4). Implements the source-spec §5.4 skeleton, with
+ * the hallucination-guard contract baked in: the LLM may reference numbers ONLY via
+ * `{TOKEN}` placeholders, never literals. PURE: ground truth + voice in → prompt out.
+ */
+
+import type { GroundTruth } from "./ideas-email-guard-lib"
+
+/**
+ * v1 voice rules embedded as a constant (report §7: voice rules live in CLAUDE.md;
+ * later sourced from a `marketing_manual_override` settings row). Keep this pure —
+ * the workflow can pass an override string instead.
+ */
+export const MARKETING_VOICE_RULES = [
+  "Be concrete and operator-facing: each idea is a move someone can do today.",
+  "No fluff, no hype, no congratulating. Lead with the action, not the metric.",
+  "Prefer 3–5 ideas; one or two sentences each.",
+  "Tie every idea back to the ONE GOAL.",
+].join("\n- ")
+
+/**
+ * Build the prompt. Lists each ground-truth value as `LABEL: {TOKEN}` (so the model
+ * sees the placeholder it must reuse) plus the human display value for context, then
+ * hard-instructs placeholder-only number usage and interpolates the date + goal.
+ */
+export function buildIdeasPrompt(
+  gt: GroundTruth,
+  businessDescription: string,
+  voiceRules: string = MARKETING_VOICE_RULES
+): string {
+  const numbersBlock =
+    (gt.values || [])
+      .map((v) => {
+        const unit = v.unit ? ` (${v.unit})` : ""
+        return `- ${v.token}: {${v.token}} = ${v.display}${unit}`
+      })
+      .join("\n") || "- (no metrics available)"
+
+  return [
+    `You are the AI VP of Marketing for this business. Date: ${gt.date_ist}.`,
+    ``,
+    `BUSINESS:`,
+    businessDescription,
+    ``,
+    `THE ONE GOAL (optimise every suggestion toward this): ${gt.one_goal}`,
+    ``,
+    `TODAY'S GROUND-TRUTH NUMBERS (reference each ONLY by its {TOKEN} placeholder):`,
+    numbersBlock,
+    ``,
+    `HARD RULES — these are non-negotiable:`,
+    `- Refer to any number ONLY by its {TOKEN} placeholder.`,
+    `- Never write a literal number, percentage, or currency amount.`,
+    `- If you need a number that is not in the list above, do not use it.`,
+    `- Output 3–5 concrete tactical moves for today, each tied to the ONE GOAL.`,
+    ``,
+    `VOICE:`,
+    `- ${voiceRules}`,
+  ].join("\n")
+}
+
+/**
+ * Appended to the prompt on the single regeneration attempt after a guard failure
+ * (source spec §7.2: "regenerate once, then flag"). Tightens the placeholder rule.
+ */
+export const STRICTER_SUFFIX = [
+  ``,
+  `IMPORTANT: Your previous answer included a literal number, which is forbidden.`,
+  `Rewrite using ONLY the {TOKEN} placeholders listed above. Do not type any digit`,
+  `that is not part of a {TOKEN} placeholder.`,
+].join("\n")


### PR DESCRIPTION
## #659 marketing slice 2 — PR-1 of 5 (the hallucination guard, pure)

Implements **PR-1** from `apps/docs/marketing/02_IDEAS_EMAIL_HALLUCINATION_GUARD_SPEC.md` §9 — the highest-value, lowest-risk piece. **Pure logic only, no wiring**, so it can land and be trusted independently before the workflows/job depend on it.

### What
The two-layer hallucination guard for the daily AI tactical-ideas email (report §7 / source spec §7.2 — ship the guard *before* the first send):

- **`ideas-email-guard-lib.ts`** (the heart):
  - `extractNumericTokens` / `parseNumberToken` — number-shaped literal extraction handling Indian (`1,84,320`) + western grouping, `%`, `₹/$/€/£`, and `K`/`L`(akh)/`M`/`B`/`Cr`(ore) suffixes.
  - `substitutePlaceholders` (**Layer A**) — `{TOKEN}` → ground-truth display; unknown placeholders reported as `missing` (fail-closed).
  - `validateStrayNumbers` (**Layer B**) — every stray literal must match a ground-truth value within **±2%** (EPS-floored so exact-0 metrics don't divide-by-zero). Whitelists the business-day year, list-marker ordinals (`1.`/`2)`), and a caller allow-list.
  - `runGuard` — orchestrates substitute → validate-on-raw → verdict. **Fail-closed:** any missing placeholder OR unmatched stray ⇒ `passed=false`. Layer B runs on the *raw* output so placeholder-derived numbers aren't mis-flagged as stray.
- **`ideas-email-prompt-lib.ts`** — `buildIdeasPrompt` (placeholder-only hard rule, date + One-Goal interpolation), `MARKETING_VOICE_RULES`, `STRICTER_SUFFIX` (regenerate-once tightening).

### Tests
- 32 unit tests green: `TEST_TYPE=unit npx jest --testPathPattern="ideas-email"`.
- Zero new typecheck errors on changed files.

### Not in this PR (later slice-2 PRs, all off `origin/main`)
- PR-2 generate workflow (writes `marketing_ideas_log` before send, stubbed/injectable AI step)
- PR-3 send workflow + seed `marketing-ideas-email` template row
- PR-4 scheduled job behind `MARKETING_IDEAS_EMAIL_ENABLED` (default off until the One Goal is picked)
- PR-5 (optional) admin read route

### Notes
- The **One Goal** decision does **not** block this PR (the goal is a prompt string, read from config in PR-2+).
- Does not merge — for human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)