### PR TITLE
feat(marketing): generate-ideas-email workflow + guard wiring (#659 slice 2 · PR-2)

### DIFF
--- a/apps/backend/integration-tests/http/marketing-generate-ideas-email.spec.ts
+++ b/apps/backend/integration-tests/http/marketing-generate-ideas-email.spec.ts
@@ -1,0 +1,110 @@
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { MARKETING_MODULE } from "../../src/modules/marketing"
+import { generateIdeasEmail } from "../../src/workflows/marketing/generate-ideas-email"
+
+jest.setTimeout(60 * 1000)
+
+/**
+ * #659 slice 2, PR-2 — the generate-ideas-email orchestration with a STUBBED
+ * LLM (CI never calls a live model). We seed `marketing_metric_snapshot` rows,
+ * run `generateIdeasEmail` with an injected `aiGenerate`, and assert:
+ *   - a `marketing_ideas_log` row is persisted BEFORE any send (sent=false)
+ *   - clean {TOKEN}-only output passes the guard
+ *   - a stray-literal output fails the guard and triggers exactly one regenerate
+ *   - `prompt_snapshot` (the ground-truth fed in) is stored for replay
+ *
+ * NOTE: metric_keys are DIGIT-FREE on purpose — the guard's Layer B extracts
+ * numeric literals from the RAW output, so a digit inside a {TOKEN} name (e.g.
+ * "{Q3_GMV}") would be mis-read as a stray number. The daily-refresh job
+ * (slice 3) likewise emits digit-free metric_keys.
+ */
+setupSharedTestSuite(() => {
+  const { getContainer } = getSharedTestEnv()
+
+  describe("generateIdeasEmail (stubbed LLM)", () => {
+    it("persists a guard-passing ideas log without sending", async () => {
+      const container = getContainer()
+      const svc: any = container.resolve(MARKETING_MODULE)
+      // Far-future date so these rows sort newest-first regardless of what
+      // other suites seeded into the shared DB.
+      const day = new Date("2031-03-01T00:00:00.000Z")
+      await svc.createMarketingMetricSnapshots({
+        metric_key: "promo_gmv",
+        value: 184320,
+        unit: "INR",
+        captured_for_date: day,
+        source: "manual",
+        delta_dod: 4.5,
+      })
+      await svc.createMarketingMetricSnapshots({
+        metric_key: "promo_conv",
+        value: 0.034,
+        unit: "ratio",
+        captured_for_date: day,
+        source: "manual",
+      })
+
+      // Stub references ground-truth ONLY by {TOKEN}; no stray numbers.
+      const stub = async () =>
+        "Today, lift {PROMO_GMV} (trend {PROMO_GMV_DELTA_DOD}): launch a flash " +
+        "sale, spotlight a partner, and nudge carts toward {PROMO_CONV}."
+
+      const res = await generateIdeasEmail(container, {
+        aiGenerate: stub,
+        oneGoal: "Grow platform GMV.",
+        now: new Date("2031-03-01T12:00:00.000Z"),
+      })
+
+      expect(res.skipped).toBe(false)
+      expect(res.generated).toBe(true)
+      expect(res.guard_passed).toBe(true)
+      expect(res.regenerated).toBe(false)
+      expect(res.log_id).toBeTruthy()
+      // placeholders were substituted with display values in the final copy
+      expect(res.output_text).toContain("₹1,84,320")
+      expect(res.output_text).not.toContain("{PROMO_GMV}")
+
+      const [rows] = await svc.listAndCountMarketingIdeasLogs({ id: res.log_id })
+      expect(rows[0].guard_passed).toBe(true)
+      expect(rows[0].sent).toBe(false) // persist-before-send
+      expect(rows[0].prompt_snapshot.one_goal).toBe("Grow platform GMV.")
+      expect(rows[0].prompt_snapshot.date_ist).toBe("2031-03-01")
+    })
+
+    it("fails the guard on a stray literal and regenerates exactly once", async () => {
+      const container = getContainer()
+      const svc: any = container.resolve(MARKETING_MODULE)
+      const day = new Date("2031-03-02T00:00:00.000Z")
+      await svc.createMarketingMetricSnapshots({
+        metric_key: "pushday_gmv",
+        value: 50000,
+        unit: "INR",
+        captured_for_date: day,
+        source: "manual",
+      })
+
+      let calls = 0
+      // Both attempts emit a stray "47%" with no matching ground-truth → fail-closed.
+      const stub = async () => {
+        calls++
+        return "Push hard today: a 47% discount on {PUSHDAY_GMV} should move volume."
+      }
+
+      const res = await generateIdeasEmail(container, {
+        aiGenerate: stub,
+        oneGoal: "Grow platform GMV.",
+        now: new Date("2031-03-02T12:00:00.000Z"),
+      })
+
+      expect(calls).toBe(2) // generate + one regenerate
+      expect(res.regenerated).toBe(true)
+      expect(res.guard_passed).toBe(false)
+
+      const [rows] = await svc.listAndCountMarketingIdeasLogs({ id: res.log_id })
+      expect(rows[0].guard_passed).toBe(false)
+      expect(rows[0].regenerated).toBe(true)
+      expect(rows[0].sent).toBe(false)
+      expect(Array.isArray(rows[0].guard_failures)).toBe(true)
+    })
+  })
+})

--- a/apps/backend/src/workflows/marketing/__tests__/generate-ideas-email.unit.spec.ts
+++ b/apps/backend/src/workflows/marketing/__tests__/generate-ideas-email.unit.spec.ts
@@ -1,0 +1,90 @@
+import {
+  buildGroundTruthFromSnapshots,
+  formatMetricDisplay,
+} from "../generate-ideas-email"
+
+/**
+ * #659 slice 2, PR-2 — unit tests for the PURE pieces of generate-ideas-email
+ * (no container, no LLM): the display formatter and the snapshot→GroundTruth
+ * mapping (token derivation, latest-per-metric dedup, delta_dod sub-token).
+ */
+describe("formatMetricDisplay", () => {
+  it("formats INR / USD as integer currency", () => {
+    expect(formatMetricDisplay(184320, "INR")).toBe("₹1,84,320")
+    expect(formatMetricDisplay(2500.9, "USD")).toBe("$2,501")
+  })
+  it("formats ratio as a percent and percent as-is", () => {
+    expect(formatMetricDisplay(0.034, "ratio")).toBe("3.4%")
+    expect(formatMetricDisplay(12.5, "percent")).toBe("12.5%")
+  })
+  it("formats count with grouping and falls back to String", () => {
+    expect(formatMetricDisplay(1200, "count")).toBe("1,200")
+    expect(formatMetricDisplay(7, null)).toBe("7")
+  })
+})
+
+describe("buildGroundTruthFromSnapshots", () => {
+  const opts = { dateIst: "2026-06-23", one_goal: "x" } as any
+  const base = { dateIst: "2026-06-23", oneGoal: "Grow GMV." }
+
+  it("maps metric_key → {TOKEN} and adds a delta_dod sub-token", () => {
+    const gt = buildGroundTruthFromSnapshots(
+      [
+        {
+          metric_key: "platform_gmv",
+          value: 1000,
+          unit: "INR",
+          captured_for_date: "2026-06-23",
+          delta_dod: 4.5,
+        },
+      ],
+      base
+    )
+    const tokens = gt.values.map((v) => v.token)
+    expect(tokens).toContain("PLATFORM_GMV")
+    expect(tokens).toContain("PLATFORM_GMV_DELTA_DOD")
+    expect(gt.one_goal).toBe("Grow GMV.")
+    expect(gt.date_ist).toBe("2026-06-23")
+    const delta = gt.values.find((v) => v.token === "PLATFORM_GMV_DELTA_DOD")!
+    expect(delta.display).toBe("+4.5%")
+  })
+
+  it("omits the delta sub-token when delta_dod is null/undefined", () => {
+    const gt = buildGroundTruthFromSnapshots(
+      [
+        {
+          metric_key: "partner_activations",
+          value: 12,
+          unit: "count",
+          captured_for_date: "2026-06-23",
+          delta_dod: null,
+        },
+      ],
+      base
+    )
+    expect(gt.values.map((v) => v.token)).toEqual(["PARTNER_ACTIVATIONS"])
+  })
+
+  it("keeps only the latest (first) row per metric_key", () => {
+    const gt = buildGroundTruthFromSnapshots(
+      [
+        { metric_key: "gmv", value: 999, captured_for_date: "2026-06-23" },
+        { metric_key: "gmv", value: 111, captured_for_date: "2026-06-22" },
+      ],
+      base
+    )
+    const gmv = gt.values.filter((v) => v.token === "GMV")
+    expect(gmv).toHaveLength(1)
+    expect(gmv[0].value).toBe(999)
+    void opts
+  })
+
+  it("formats negative delta with a leading minus", () => {
+    const gt = buildGroundTruthFromSnapshots(
+      [{ metric_key: "gmv", value: 1, captured_for_date: "x", delta_dod: -3.21 }],
+      base
+    )
+    const delta = gt.values.find((v) => v.token === "GMV_DELTA_DOD")!
+    expect(delta.display).toBe("-3.2%")
+  })
+})

--- a/apps/backend/src/workflows/marketing/generate-ideas-email.ts
+++ b/apps/backend/src/workflows/marketing/generate-ideas-email.ts
@@ -1,0 +1,319 @@
+/**
+ * generate-ideas-email.ts — #659 slice 2, PR-2.
+ *
+ * The "AI tactical-ideas email" generate workflow: read today's ground-truth
+ * numbers from `marketing_metric_snapshot`, ask the LLM for 3-5 tactical moves
+ * (referring to numbers ONLY by {TOKEN} placeholder), run the two-layer
+ * hallucination guard (`ideas-email-guard-lib.ts`), regenerate ONCE on failure,
+ * then persist a `marketing_ideas_log` row BEFORE anything is ever sent
+ * (report §4.3: "every job writes its result to Postgres before sending").
+ *
+ * Testability: the AI call is an INJECTABLE function (`AiGenerateFn`) — the
+ * integration test passes a stub returning fixed `{TOKEN}` copy, so CI NEVER
+ * calls a live LLM. The Medusa workflow wrapper injects the real OpenRouter
+ * call (mirrors the verified pattern in
+ * `src/workflows/ad-planning/sentiment/analyze-sentiment.ts:44-71`).
+ *
+ * This PR does NOT send the email — `sent` stays false; the send workflow
+ * (PR-3) flips it. The job that schedules this (PR-4) stays disabled until the
+ * One Goal is picked.
+ */
+
+import {
+  createWorkflow,
+  createStep,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import { generateText } from "ai"
+import { createOpenRouter } from "@openrouter/ai-sdk-provider"
+
+import { MARKETING_MODULE } from "../../modules/marketing"
+import type { GroundTruth, GroundTruthValue } from "./ideas-email-guard-lib"
+import { runGuard } from "./ideas-email-guard-lib"
+import { buildIdeasPrompt, STRICTER_SUFFIX } from "./ideas-email-prompt-lib"
+
+/** An injectable LLM call: prompt in, raw text out (or "" on failure). */
+export type AiGenerateFn = (prompt: string) => Promise<string>
+
+export type GenerateIdeasEmailOptions = {
+  /** Injected for tests; defaults to the real OpenRouter call. */
+  aiGenerate?: AiGenerateFn
+  /** The "One Goal" string; never invented in code (report §3.6). */
+  oneGoal?: string
+  /** Business description fed to the prompt. */
+  businessDescription?: string
+  /** Reference "now"; defaults to current time. Used only for the IST date. */
+  now?: Date
+  /** Stray-literal tolerance forwarded to the guard. */
+  tolerancePct?: number
+  /** Extra numeric literals the guard is allowed to ignore. */
+  allowList?: string[]
+}
+
+export type GenerateIdeasEmailResult = {
+  skipped: boolean
+  generated: boolean
+  guard_passed: boolean
+  regenerated: boolean
+  log_id: string | null
+  output_text: string
+  model_used: string
+  ground_truth: GroundTruth | null
+  reason?: string
+}
+
+const DEFAULT_MODEL = "anthropic/claude-3.5-sonnet"
+
+const DEFAULT_BUSINESS_DESCRIPTION =
+  "JYT is a textile-production commerce platform: it runs an admin storefront " +
+  "and onboards partner brands who sell their own products through per-partner " +
+  "storefronts. Revenue comes from product sales (GMV) across these stores."
+
+// IST = UTC+5:30. Return the IST calendar date (YYYY-MM-DD) for a UTC instant.
+function istDateString(d: Date): string {
+  const ist = new Date(d.getTime() + 5.5 * 60 * 60 * 1000)
+  return ist.toISOString().slice(0, 10)
+}
+
+/**
+ * Pure: format a canonical numeric value for human display in the email copy.
+ * The guard validates stray literals against the RAW (pre-substitution) output,
+ * so this display string only affects the final rendered copy — it can be as
+ * human-friendly as we like without tripping Layer B.
+ */
+export function formatMetricDisplay(
+  value: number,
+  unit?: string | null
+): string {
+  const u = (unit || "").toLowerCase()
+  if (u === "inr") return "₹" + Math.round(value).toLocaleString("en-IN")
+  if (u === "usd") return "$" + Math.round(value).toLocaleString("en-US")
+  if (u === "percent") return `${round1(value)}%`
+  if (u === "ratio") return `${round1(value * 100)}%`
+  if (u === "count") return Math.round(value).toLocaleString("en-IN")
+  return String(value)
+}
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10
+}
+
+function tokenFor(metricKey: string): string {
+  return metricKey.toUpperCase().replace(/[^A-Z0-9]+/g, "_")
+}
+
+/**
+ * Pure: map the latest snapshot row per metric_key into a GroundTruth. Each
+ * metric becomes a {METRIC_KEY} token; a present `delta_dod` becomes a separate
+ * {METRIC_KEY_DELTA_DOD} percent token so the model can reference the trend.
+ */
+export function buildGroundTruthFromSnapshots(
+  rows: Array<{
+    metric_key: string
+    value: number
+    unit?: string | null
+    captured_for_date: Date | string
+    delta_dod?: number | null
+  }>,
+  opts: { dateIst: string; oneGoal: string }
+): GroundTruth {
+  const seen = new Set<string>()
+  const values: GroundTruthValue[] = []
+
+  // rows arrive newest-first; keep the first (latest) row per metric_key.
+  for (const r of rows) {
+    if (seen.has(r.metric_key)) continue
+    seen.add(r.metric_key)
+
+    const token = tokenFor(r.metric_key)
+    values.push({
+      token,
+      value: r.value,
+      display: formatMetricDisplay(r.value, r.unit),
+      unit: r.unit ?? null,
+    })
+
+    if (r.delta_dod !== null && r.delta_dod !== undefined) {
+      const sign = r.delta_dod >= 0 ? "+" : ""
+      values.push({
+        token: `${token}_DELTA_DOD`,
+        value: r.delta_dod,
+        display: `${sign}${round1(r.delta_dod)}%`,
+        unit: "percent",
+      })
+    }
+  }
+
+  return { values, date_ist: opts.dateIst, one_goal: opts.oneGoal }
+}
+
+/** The real LLM call. Mirrors analyze-sentiment.ts:44-71 (try/catch → "" on error). */
+async function defaultAiGenerate(prompt: string): Promise<string> {
+  try {
+    const openrouter = createOpenRouter({
+      apiKey: process.env.OPENROUTER_API_KEY,
+    })
+    const result = await generateText({
+      model: openrouter(process.env.MARKETING_IDEAS_MODEL || DEFAULT_MODEL),
+      prompt,
+      maxOutputTokens: 700,
+    })
+    return (result.text || "").trim()
+  } catch (error: any) {
+    // eslint-disable-next-line no-console
+    console.error("[generate-ideas-email] AI error:", error?.message)
+    return ""
+  }
+}
+
+/**
+ * Core orchestration (no Medusa-step wrapper, so it's directly unit/integration
+ * testable with a stubbed `aiGenerate`): gather ground truth → generate → guard
+ * → regenerate-once → persist BEFORE send.
+ */
+export async function generateIdeasEmail(
+  container: any,
+  opts: GenerateIdeasEmailOptions = {}
+): Promise<GenerateIdeasEmailResult> {
+  const aiGenerate = opts.aiGenerate || defaultAiGenerate
+  const now = opts.now || new Date()
+  const oneGoal =
+    opts.oneGoal ||
+    process.env.MARKETING_ONE_GOAL ||
+    "Grow platform GMV (total sales across all stores)."
+  const businessDescription =
+    opts.businessDescription ||
+    process.env.MARKETING_BUSINESS_DESCRIPTION ||
+    DEFAULT_BUSINESS_DESCRIPTION
+  const modelId = process.env.MARKETING_IDEAS_MODEL || DEFAULT_MODEL
+
+  const empty: GenerateIdeasEmailResult = {
+    skipped: false,
+    generated: false,
+    guard_passed: false,
+    regenerated: false,
+    log_id: null,
+    output_text: "",
+    model_used: modelId,
+    ground_truth: null,
+  }
+
+  const marketing: any = container.resolve(MARKETING_MODULE)
+
+  // 1) gather ground truth — latest snapshot rows, newest first.
+  const rows: any[] = await marketing.listMarketingMetricSnapshots(
+    {},
+    { order: { captured_for_date: "DESC" }, take: 50 }
+  )
+
+  if (!rows || rows.length === 0) {
+    // Don't email "₹0" with no data — abort the run (report §4.1).
+    return { ...empty, skipped: true, reason: "no_snapshots" }
+  }
+
+  const dateIst = istDateString(now)
+  const gt = buildGroundTruthFromSnapshots(rows, { dateIst, oneGoal })
+
+  // 2) generate
+  const prompt = buildIdeasPrompt(gt, businessDescription)
+  let rawOutput = await aiGenerate(prompt)
+
+  if (!rawOutput) {
+    // AI failed: log the failure, do not send.
+    const failLog = await marketing.createMarketingIdeasLogs([
+      {
+        generated_for_date: new Date(`${dateIst}T00:00:00.000Z`),
+        model_used: modelId,
+        prompt_snapshot: gt,
+        output_text: "",
+        guard_passed: false,
+        guard_failures: [{ type: "ai_error", token: "ai_generate" }],
+        regenerated: false,
+        sent: false,
+      },
+    ])
+    return {
+      ...empty,
+      ground_truth: gt,
+      log_id: arrId(failLog),
+      reason: "ai_error",
+    }
+  }
+
+  // 3) guard → regenerate ONCE on failure → persist
+  let verdict = runGuard(rawOutput, gt, {
+    tolerancePct: opts.tolerancePct,
+    allowList: opts.allowList,
+  })
+  let regenerated = false
+  if (!verdict.passed) {
+    const second = await aiGenerate(prompt + STRICTER_SUFFIX)
+    regenerated = true
+    if (second) {
+      rawOutput = second
+      verdict = runGuard(second, gt, {
+        tolerancePct: opts.tolerancePct,
+        allowList: opts.allowList,
+      })
+    }
+  }
+
+  const log = await marketing.createMarketingIdeasLogs([
+    {
+      generated_for_date: new Date(`${dateIst}T00:00:00.000Z`),
+      model_used: modelId,
+      prompt_snapshot: gt,
+      output_text: verdict.finalText,
+      guard_passed: verdict.passed,
+      guard_failures: verdict.failures.length ? verdict.failures : null,
+      regenerated,
+      sent: false, // flipped true only after a successful send (PR-3)
+    },
+  ])
+
+  return {
+    skipped: false,
+    generated: true,
+    guard_passed: verdict.passed,
+    regenerated,
+    log_id: arrId(log),
+    output_text: verdict.finalText,
+    model_used: modelId,
+    ground_truth: gt,
+  }
+}
+
+function arrId(created: any): string | null {
+  const row = Array.isArray(created) ? created[0] : created
+  return row?.id ?? null
+}
+
+// ---------------------------------------------------------------------------
+// Medusa workflow wrapper (injects the real OpenRouter call).
+// ---------------------------------------------------------------------------
+export type GenerateIdeasEmailWorkflowInput = {
+  oneGoal?: string
+  businessDescription?: string
+}
+
+const generateIdeasEmailStep = createStep(
+  "generate-ideas-email",
+  async (input: GenerateIdeasEmailWorkflowInput, { container }) => {
+    const result = await generateIdeasEmail(container, {
+      oneGoal: input?.oneGoal,
+      businessDescription: input?.businessDescription,
+    })
+    return new StepResponse(result)
+  }
+)
+
+export const generateIdeasEmailWorkflow = createWorkflow(
+  "generate-ideas-email",
+  (input: GenerateIdeasEmailWorkflowInput) => {
+    const result = generateIdeasEmailStep(input)
+    return new WorkflowResponse(result)
+  }
+)
+
+export default generateIdeasEmailWorkflow


### PR DESCRIPTION
## #659 slice 2, PR-2 — the generate workflow

Stacked on **#672** (PR-1, the pure guard + prompt libs). **Merge #672 first**; base is `feat/659-ideas-email-guard-lib`.

### What this adds
`src/workflows/marketing/generate-ideas-email.ts` — the AI tactical-ideas email **generate** step (no send yet):

1. **gather ground truth** — read latest `marketing_metric_snapshot` rows (newest-first), map to `GroundTruth` ({METRIC_KEY} + {METRIC_KEY_DELTA_DOD} tokens, human `display`). No snapshots ⇒ `{ skipped: true }` (never emails "₹0").
2. **generate** — injectable `aiGenerate` fn; default mirrors the verified OpenRouter call in `analyze-sentiment.ts:44-71` (try/catch → "" on error).
3. **guard + persist** — `runGuard` (Layer A placeholder-substitution + Layer B stray-literal ±2% fail-closed); regenerate **exactly once** with `STRICTER_SUFFIX` on failure; then persist a `marketing_ideas_log` row **before any send** (`sent: false`). The send step (PR-3) flips `sent`.

Also exposes a `generateIdeasEmailWorkflow` Medusa-workflow wrapper that injects the real LLM call.

### Why injectable
The AI call is a function param so CI **never** hits a live model — the integration test passes a stub returning fixed `{TOKEN}` copy (mirrors the `execOp` injection pattern used elsewhere).

### Tests
- **7 unit** (`__tests__/generate-ideas-email.unit.spec.ts`) — pure `formatMetricDisplay` + `buildGroundTruthFromSnapshots` (token derivation, latest-per-metric dedup, delta sub-token, ±sign).
- **2 integration** (`marketing-generate-ideas-email.spec.ts`, stubbed LLM) — guard-passing log persisted with `sent=false`; stray-literal output fails guard + regenerates once. Both green on shared DB.
- Zero new typecheck errors.

### Watch-out
metric_keys must be **digit-free** — Layer B extracts numeric literals from RAW output, so a digit inside a `{TOKEN}` name reads as a stray number. (The slice-3 daily-refresh job emits digit-free keys.)

### Next (slice 2)
PR-3 send workflow (mirror `send-partner-digest-email.ts` + seed `marketing-ideas-email` template) → PR-4 daily job behind `MARKETING_IDEAS_EMAIL_ENABLED` → PR-5 admin read route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)