### PR TITLE
feat(marketing): admin ideas-log read route + roll-up (#659 slice 2 · PR-5)

### DIFF
--- a/apps/backend/integration-tests/http/marketing-ideas-log-route.spec.ts
+++ b/apps/backend/integration-tests/http/marketing-ideas-log-route.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * #659 slice 2, PR-5 — admin read route GET /admin/marketing/ideas-log.
+ * Seeds `marketing_ideas_log` rows via the module service, then asserts the
+ * read route returns them newest-first with a correct roll-up summary and that
+ * the `guard_passed` / `sent` boolean filters + pagination work.
+ */
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { MARKETING_MODULE } from "../../src/modules/marketing"
+
+jest.setTimeout(60 * 1000)
+
+setupSharedTestSuite(() => {
+  let headers: any
+  const { api, getContainer } = getSharedTestEnv()
+
+  beforeAll(async () => {
+    const container = getContainer()
+    await createAdminUser(container)
+    headers = await getAuthHeaders(api)
+  })
+
+  // Re-seed before every test: the shared test DB does not retain these rows
+  // across tests in this suite, so each test plants its own fixtures.
+  beforeEach(async () => {
+    const svc: any = getContainer().resolve(MARKETING_MODULE)
+    // Three rows on distinct days with distinct guard/sent combinations.
+    await svc.createMarketingIdeasLogs({
+      generated_for_date: new Date("2026-06-21T00:00:00.000Z"),
+      prompt_snapshot: { gmv: 100 },
+      output_text: "old idea",
+      guard_passed: true,
+      sent: true,
+      regenerated: false,
+    })
+    await svc.createMarketingIdeasLogs({
+      generated_for_date: new Date("2026-06-23T00:00:00.000Z"),
+      prompt_snapshot: { gmv: 200 },
+      output_text: "newest idea",
+      guard_passed: true,
+      sent: false,
+      regenerated: true,
+    })
+    await svc.createMarketingIdeasLogs({
+      generated_for_date: new Date("2026-06-22T00:00:00.000Z"),
+      prompt_snapshot: { gmv: 150 },
+      output_text: "guard-failed idea",
+      guard_passed: false,
+      sent: false,
+      regenerated: false,
+    })
+  })
+
+  describe("GET /admin/marketing/ideas-log", () => {
+    it("lists rows newest-first with a correct summary roll-up", async () => {
+      const res = await api.get("/admin/marketing/ideas-log", headers)
+      expect(res.status).toBe(200)
+      expect(res.data.count).toBeGreaterThanOrEqual(3)
+
+      // newest-first: the 06-23 row precedes the 06-22 and 06-21 rows
+      const texts = res.data.ideas_log.map((r: any) => r.output_text)
+      const iNew = texts.indexOf("newest idea")
+      const iMid = texts.indexOf("guard-failed idea")
+      const iOld = texts.indexOf("old idea")
+      expect(iNew).toBeGreaterThanOrEqual(0)
+      expect(iNew).toBeLessThan(iMid)
+      expect(iMid).toBeLessThan(iOld)
+
+      // summary is over the full set
+      expect(res.data.summary.total).toBe(res.data.count)
+      expect(res.data.summary.guard_passed).toBeGreaterThanOrEqual(2)
+      expect(res.data.summary.guard_failed).toBeGreaterThanOrEqual(1)
+      expect(res.data.summary.sent).toBeGreaterThanOrEqual(1)
+      expect(res.data.summary.regenerated).toBeGreaterThanOrEqual(1)
+    })
+
+    it("filters by guard_passed=false", async () => {
+      const res = await api.get(
+        "/admin/marketing/ideas-log?guard_passed=false",
+        headers
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.count).toBeGreaterThanOrEqual(1)
+      for (const row of res.data.ideas_log) {
+        expect(row.guard_passed).toBe(false)
+      }
+      expect(res.data.summary.guard_passed).toBe(0)
+    })
+
+    it("filters by sent=true", async () => {
+      const res = await api.get(
+        "/admin/marketing/ideas-log?sent=true",
+        headers
+      )
+      expect(res.status).toBe(200)
+      for (const row of res.data.ideas_log) {
+        expect(row.sent).toBe(true)
+      }
+      expect(res.data.summary.not_sent).toBe(0)
+    })
+
+    it("paginates with limit/offset while keeping count over the full set", async () => {
+      const res = await api.get(
+        "/admin/marketing/ideas-log?limit=1&offset=0",
+        headers
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.ideas_log.length).toBe(1)
+      expect(res.data.limit).toBe(1)
+      expect(res.data.offset).toBe(0)
+      // count reflects the full filtered set, not the page
+      expect(res.data.count).toBeGreaterThanOrEqual(3)
+    })
+  })
+})

--- a/apps/backend/src/api/admin/marketing/ideas-log/__tests__/summarize-ideas-log.unit.spec.ts
+++ b/apps/backend/src/api/admin/marketing/ideas-log/__tests__/summarize-ideas-log.unit.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for the pure ideas-log read-route helpers (#659 slice 2, PR-5).
+ * Run: TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules npx jest --testPathPattern=summarize-ideas-log
+ */
+import {
+  parseBoolFilter,
+  parseNonNegativeInt,
+  sortIdeasLogNewestFirst,
+  summarizeIdeasLog,
+  type IdeasLogRowLike,
+} from "../summarize-ideas-log"
+
+describe("summarizeIdeasLog", () => {
+  it("returns an all-zero summary for an empty / non-array input", () => {
+    expect(summarizeIdeasLog([])).toEqual({
+      total: 0,
+      guard_passed: 0,
+      guard_failed: 0,
+      sent: 0,
+      not_sent: 0,
+      regenerated: 0,
+    })
+    // defensive: non-array
+    expect(summarizeIdeasLog(undefined as any).total).toBe(0)
+  })
+
+  it("counts guard pass/fail, sent/not-sent and regenerated independently", () => {
+    const rows: IdeasLogRowLike[] = [
+      { guard_passed: true, sent: true, regenerated: false },
+      { guard_passed: true, sent: false, regenerated: true },
+      { guard_passed: false, sent: false, regenerated: false },
+      { guard_passed: null, sent: null }, // null guard/sent => failed / not_sent
+    ]
+    expect(summarizeIdeasLog(rows)).toEqual({
+      total: 4,
+      guard_passed: 2,
+      guard_failed: 2,
+      sent: 1,
+      not_sent: 3,
+      regenerated: 1,
+    })
+  })
+
+  it("treats only strict true as passed/sent (fail-closed on undefined)", () => {
+    const rows: IdeasLogRowLike[] = [{}, { guard_passed: true, sent: true }]
+    const s = summarizeIdeasLog(rows)
+    expect(s.guard_passed).toBe(1)
+    expect(s.guard_failed).toBe(1)
+    expect(s.sent).toBe(1)
+    expect(s.not_sent).toBe(1)
+  })
+})
+
+describe("sortIdeasLogNewestFirst", () => {
+  it("orders by generated_for_date descending and does not mutate input", () => {
+    const rows: IdeasLogRowLike[] = [
+      { id: "a", generated_for_date: "2026-06-20T00:00:00.000Z" },
+      { id: "b", generated_for_date: "2026-06-23T00:00:00.000Z" },
+      { id: "c", generated_for_date: "2026-06-21T00:00:00.000Z" },
+    ]
+    const sorted = sortIdeasLogNewestFirst(rows)
+    expect(sorted.map((r) => r.id)).toEqual(["b", "c", "a"])
+    // original untouched
+    expect(rows.map((r) => r.id)).toEqual(["a", "b", "c"])
+  })
+
+  it("accepts Date objects and pushes missing dates last", () => {
+    const rows: IdeasLogRowLike[] = [
+      { id: "none", generated_for_date: null },
+      { id: "new", generated_for_date: new Date("2026-06-23T00:00:00.000Z") },
+      { id: "old", generated_for_date: new Date("2026-06-01T00:00:00.000Z") },
+    ]
+    expect(sortIdeasLogNewestFirst(rows).map((r) => r.id)).toEqual([
+      "new",
+      "old",
+      "none",
+    ])
+  })
+
+  it("returns [] for non-array input", () => {
+    expect(sortIdeasLogNewestFirst(undefined as any)).toEqual([])
+  })
+})
+
+describe("parseNonNegativeInt", () => {
+  it("parses valid non-negative integers", () => {
+    expect(parseNonNegativeInt("0", 50)).toBe(0)
+    expect(parseNonNegativeInt("25", 50)).toBe(25)
+    expect(parseNonNegativeInt(10, 50)).toBe(10)
+  })
+
+  it("falls back on negatives, non-numerics and missing values", () => {
+    expect(parseNonNegativeInt("-5", 50)).toBe(50)
+    expect(parseNonNegativeInt("abc", 50)).toBe(50)
+    expect(parseNonNegativeInt(undefined, 50)).toBe(50)
+    expect(parseNonNegativeInt(null, 0)).toBe(0)
+  })
+})
+
+describe("parseBoolFilter", () => {
+  it("parses truthy/falsy strings and booleans", () => {
+    expect(parseBoolFilter("true")).toBe(true)
+    expect(parseBoolFilter("1")).toBe(true)
+    expect(parseBoolFilter("FALSE")).toBe(false)
+    expect(parseBoolFilter("0")).toBe(false)
+    expect(parseBoolFilter(true)).toBe(true)
+    expect(parseBoolFilter(false)).toBe(false)
+  })
+
+  it("returns undefined for absent / unrecognised values (filter not applied)", () => {
+    expect(parseBoolFilter(undefined)).toBeUndefined()
+    expect(parseBoolFilter("maybe")).toBeUndefined()
+    expect(parseBoolFilter(["true"])).toBeUndefined()
+  })
+})

--- a/apps/backend/src/api/admin/marketing/ideas-log/route.ts
+++ b/apps/backend/src/api/admin/marketing/ideas-log/route.ts
@@ -1,0 +1,71 @@
+/**
+ * @file Admin read route for the marketing tactical-ideas log (#659 slice 2, PR-5).
+ * @description Read-only listing + roll-up of `marketing_ideas_log` rows so an
+ * operator can audit what the daily AI-VP ideas email generated, whether the
+ * hallucination guard passed, and whether it was actually sent. Mirrors the
+ * money-rollup envelope of `src/api/admin/partners/[id]/fees/route.ts`
+ * (spec 02 §7). No writes here — rows are produced by the generate/send
+ * workflows; this is purely the audit surface.
+ * @module API/Admin/Marketing/IdeasLog
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
+
+import { MARKETING_MODULE } from "../../../../modules/marketing"
+import {
+  parseBoolFilter,
+  parseNonNegativeInt,
+  sortIdeasLogNewestFirst,
+  summarizeIdeasLog,
+  type IdeasLogRowLike,
+} from "./summarize-ideas-log"
+
+/**
+ * GET /admin/marketing/ideas-log
+ *
+ * Lists recent `marketing_ideas_log` rows (newest first) plus a roll-up summary
+ * (total, guard pass/fail, sent/not-sent, regenerated).
+ *
+ * Query:
+ *   - `guard_passed` (`true|false|1|0`) — filter to guard-passed / guard-failed rows.
+ *   - `sent` (`true|false|1|0`) — filter to sent / unsent rows.
+ *   - `offset` / `limit` — pagination (defaults 0 / 50).
+ *
+ * The summary is computed over the FULL filtered set (not the paginated page)
+ * so totals stay correct regardless of offset/limit (the page-vs-set bug, #484).
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const offset = parseNonNegativeInt(req.query.offset, 0)
+  const limit = parseNonNegativeInt(req.query.limit, 50) || 50
+
+  const guardPassed = parseBoolFilter(req.query.guard_passed)
+  const sent = parseBoolFilter(req.query.sent)
+
+  const filters: Record<string, unknown> = {}
+  if (guardPassed !== undefined) {
+    filters.guard_passed = guardPassed
+  }
+  if (sent !== undefined) {
+    filters.sent = sent
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const marketing: any = req.scope.resolve(MARKETING_MODULE)
+
+  // List the full filtered set once: the summary must be over the whole set,
+  // and the table is one-row-per-day so it stays small. Sort + paginate in-app
+  // (matches the documented fees-route reference).
+  const all: IdeasLogRowLike[] =
+    (await marketing.listMarketingIdeasLogs(filters)) || []
+
+  const sorted = sortIdeasLogNewestFirst(all)
+  const summary = summarizeIdeasLog(sorted)
+  const ideas_log = sorted.slice(offset, offset + limit)
+
+  return res.status(200).json({
+    ideas_log,
+    count: sorted.length,
+    offset,
+    limit,
+    summary,
+  })
+}

--- a/apps/backend/src/api/admin/marketing/ideas-log/summarize-ideas-log.ts
+++ b/apps/backend/src/api/admin/marketing/ideas-log/summarize-ideas-log.ts
@@ -1,0 +1,125 @@
+/**
+ * summarize-ideas-log.ts — pure helpers for the admin ideas-log read route
+ * (#659 slice 2, PR-5). Kept pure (no container/DB) so the roll-up + sort logic
+ * is unit-testable in isolation and the route stays a thin adapter.
+ */
+
+/** The subset of a `marketing_ideas_log` row the read route exposes/aggregates. */
+export type IdeasLogRowLike = {
+  id?: string
+  generated_for_date?: string | Date | null
+  model_used?: string | null
+  guard_passed?: boolean | null
+  guard_failures?: unknown
+  regenerated?: boolean | null
+  sent?: boolean | null
+  output_text?: string | null
+}
+
+export type IdeasLogSummary = {
+  total: number
+  /** Rows whose hallucination guard passed. */
+  guard_passed: number
+  /** Rows whose guard failed (generated but withheld / flagged for review). */
+  guard_failed: number
+  /** Rows that were actually emailed out. */
+  sent: number
+  /** Generated-but-not-sent (guard fail OR send skipped). */
+  not_sent: number
+  /** Rows the AI had to regenerate once before guarding. */
+  regenerated: number
+}
+
+/**
+ * Roll up a set of ideas-log rows. Computed over the FULL filtered set (not a
+ * paginated page) so totals stay correct regardless of offset/limit — the
+ * page-vs-set bug (#484).
+ */
+export function summarizeIdeasLog(rows: IdeasLogRowLike[]): IdeasLogSummary {
+  const summary: IdeasLogSummary = {
+    total: 0,
+    guard_passed: 0,
+    guard_failed: 0,
+    sent: 0,
+    not_sent: 0,
+    regenerated: 0,
+  }
+  if (!Array.isArray(rows)) {
+    return summary
+  }
+  for (const row of rows) {
+    summary.total++
+    if (row?.guard_passed === true) {
+      summary.guard_passed++
+    } else {
+      summary.guard_failed++
+    }
+    if (row?.sent === true) {
+      summary.sent++
+    } else {
+      summary.not_sent++
+    }
+    if (row?.regenerated === true) {
+      summary.regenerated++
+    }
+  }
+  return summary
+}
+
+/** Epoch millis for a row's `generated_for_date`; 0 when missing/invalid. */
+function toTime(value: string | Date | null | undefined): number {
+  if (!value) {
+    return 0
+  }
+  const t = value instanceof Date ? value.getTime() : new Date(value).getTime()
+  return Number.isFinite(t) ? t : 0
+}
+
+/**
+ * Sort newest-first by `generated_for_date` (the operator audits the most recent
+ * sends first). Pure — returns a new array, does not mutate the input.
+ */
+export function sortIdeasLogNewestFirst<T extends IdeasLogRowLike>(
+  rows: T[]
+): T[] {
+  if (!Array.isArray(rows)) {
+    return []
+  }
+  return [...rows].sort((a, b) => toTime(b?.generated_for_date) - toTime(a?.generated_for_date))
+}
+
+/** Parse a query string into a non-negative integer with a fallback. */
+export function parseNonNegativeInt(
+  value: unknown,
+  fallback: number
+): number {
+  if (typeof value !== "string" && typeof value !== "number") {
+    return fallback
+  }
+  const n = Math.floor(Number(value))
+  if (!Number.isFinite(n) || n < 0) {
+    return fallback
+  }
+  return n
+}
+
+/**
+ * Parse a `?flag=true|false|1|0` query value into a boolean filter, or undefined
+ * when the param is absent/unrecognised (so it isn't applied as a filter).
+ */
+export function parseBoolFilter(value: unknown): boolean | undefined {
+  if (value === true || value === false) {
+    return value
+  }
+  if (typeof value !== "string") {
+    return undefined
+  }
+  const v = value.trim().toLowerCase()
+  if (v === "true" || v === "1") {
+    return true
+  }
+  if (v === "false" || v === "0") {
+    return false
+  }
+  return undefined
+}


### PR DESCRIPTION
## #659 marketing — slice 2, PR-5 (admin read route)

The final slice-2 PR: the operator audit surface for the daily AI-VP tactical-ideas email.

### What
`GET /admin/marketing/ideas-log` — read-only list of `marketing_ideas_log` rows (newest-first) plus a roll-up summary so an operator can see what was generated, whether the hallucination guard passed, and whether it was actually sent.

- **Filters:** `guard_passed` / `sent` (`true|false|1|0`), `offset` / `limit` (defaults 0 / 50).
- **Summary** is computed over the FULL filtered set (not the paginated page) so totals stay correct regardless of offset/limit (the page-vs-set bug, #484).
- Mirrors the money-rollup envelope of `src/api/admin/partners/[id]/fees/route.ts` (spec 02 §7). **No writes** — rows are produced by the generate/send workflows.
- **No React UI** in this slice (the email is the surface; a dashboard card is slice 3).

### Files
- `src/api/admin/marketing/ideas-log/route.ts` — the GET handler (thin adapter).
- `src/api/admin/marketing/ideas-log/summarize-ideas-log.ts` — pure helpers (`summarizeIdeasLog`, `sortIdeasLogNewestFirst`, `parseNonNegativeInt`, `parseBoolFilter`).
- `__tests__/summarize-ideas-log.unit.spec.ts` — 10 unit tests.
- `integration-tests/http/marketing-ideas-log-route.spec.ts` — 4 HTTP integration tests.

### Independence
Branched off **main** — INDEPENDENT of the other open slice-2 PRs (#672 guard lib, #673 generate, #674 send). Only depends on the `marketing` module + `marketing_ideas_log` model already merged to main (slice 1, #671). Can merge in any order.

### Verify
- `TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules npx jest --testPathPattern=summarize-ideas-log` → 10/10
- `pnpm test:integration:http:shared -- marketing-ideas-log-route` → 4/4
- Zero new typecheck errors in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)