### PR TITLE
feat(marketing): pure compute-snapshot metric math (#659 slice 3 · PR-3a)

### DIFF
--- a/apps/backend/src/modules/marketing/__tests__/compute-snapshot.unit.spec.ts
+++ b/apps/backend/src/modules/marketing/__tests__/compute-snapshot.unit.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit test — compute-snapshot (#659 slice 3, PR-3a)
+ *
+ * Pure metric-row math for the marketing daily-refresh job. No DI, no DB.
+ *
+ * Run:
+ *   TEST_TYPE=unit npx jest --testPathPattern="compute-snapshot"
+ */
+import {
+  computeSnapshotRows,
+  istDayStart,
+  priorValueFor,
+  type MarketingMetricInput,
+  type PriorSnapshotRow,
+} from "../compute-snapshot"
+
+describe("istDayStart", () => {
+  it("maps an afternoon-UTC instant to IST midnight of the SAME IST day", () => {
+    // 2026-06-23T10:00:00Z = 15:30 IST on 2026-06-23 → IST midnight = 2026-06-22T18:30:00Z
+    const out = istDayStart(new Date("2026-06-23T10:00:00Z"))
+    expect(out.toISOString()).toBe("2026-06-22T18:30:00.000Z")
+  })
+
+  it("rolls into the next IST day once UTC passes 18:30", () => {
+    // 2026-06-23T19:00:00Z = 00:30 IST on 2026-06-24 → IST midnight = 2026-06-23T18:30:00Z
+    const out = istDayStart(new Date("2026-06-23T19:00:00Z"))
+    expect(out.toISOString()).toBe("2026-06-23T18:30:00.000Z")
+  })
+
+  it("is idempotent — feeding its own output back yields the same instant", () => {
+    const once = istDayStart(new Date("2026-06-23T10:00:00Z"))
+    expect(istDayStart(once).toISOString()).toBe(once.toISOString())
+  })
+})
+
+describe("priorValueFor", () => {
+  const rows: PriorSnapshotRow[] = [
+    { metric_key: "platform_net_gmv", value: 100, captured_for_date: "2026-06-20T18:30:00Z" },
+    { metric_key: "platform_net_gmv", value: 140, captured_for_date: "2026-06-21T18:30:00Z" },
+    { metric_key: "partners_activated", value: 7, captured_for_date: "2026-06-21T18:30:00Z" },
+  ]
+  const asOfMs = new Date("2026-06-22T18:30:00Z").getTime()
+
+  it("returns the latest prior value strictly before asOf for the metric", () => {
+    expect(priorValueFor("platform_net_gmv", asOfMs, rows)).toBe(140)
+  })
+
+  it("isolates per metric_key", () => {
+    expect(priorValueFor("partners_activated", asOfMs, rows)).toBe(7)
+  })
+
+  it("ignores rows on/after asOf (same-day re-run is not 'prior')", () => {
+    const sameDay: PriorSnapshotRow[] = [
+      { metric_key: "x", value: 5, captured_for_date: "2026-06-22T18:30:00Z" },
+    ]
+    expect(priorValueFor("x", asOfMs, sameDay)).toBeNull()
+  })
+
+  it("returns null with no history / no matching metric", () => {
+    expect(priorValueFor("missing", asOfMs, rows)).toBeNull()
+    expect(priorValueFor("x", asOfMs, [])).toBeNull()
+    expect(priorValueFor("x", asOfMs, null)).toBeNull()
+  })
+
+  it("tolerates a gap — picks the latest available prior, not exactly yesterday", () => {
+    const gappy: PriorSnapshotRow[] = [
+      { metric_key: "g", value: 10, captured_for_date: "2026-06-18T18:30:00Z" },
+    ]
+    expect(priorValueFor("g", asOfMs, gappy)).toBe(10)
+  })
+})
+
+describe("computeSnapshotRows", () => {
+  const asOf = new Date("2026-06-23T10:00:00Z") // → IST day 2026-06-22T18:30:00Z
+  const capturedISO = "2026-06-22T18:30:00.000Z"
+
+  const inputs: MarketingMetricInput[] = [
+    { metric_key: "platform_net_gmv", value: 1500, unit: "INR" },
+    { metric_key: "partners_activated", value: 9, unit: "count" },
+    { metric_key: "storefront_conversion_rate", value: 0.0312, unit: "ratio" },
+  ]
+
+  it("short-circuits to [] for empty / nullish inputs (zero-activity day)", () => {
+    const cases: Array<MarketingMetricInput[] | null | undefined> = [[], null, undefined]
+    for (const i of cases) {
+      expect(computeSnapshotRows(i, asOf)).toEqual([])
+    }
+  })
+
+  it("normalises captured_for_date to IST midnight for every row", () => {
+    const rows = computeSnapshotRows(inputs, asOf)
+    expect(rows).toHaveLength(3)
+    for (const r of rows) {
+      expect(r.captured_for_date.toISOString()).toBe(capturedISO)
+      expect(r.source).toBe("daily-refresh")
+    }
+  })
+
+  it("reports delta_dod = null when there is no prior history", () => {
+    const rows = computeSnapshotRows(inputs, asOf)
+    expect(rows.every((r) => r.delta_dod === null)).toBe(true)
+  })
+
+  it("computes delta_dod against the latest prior row per metric", () => {
+    const prior: PriorSnapshotRow[] = [
+      { metric_key: "platform_net_gmv", value: 1000, captured_for_date: "2026-06-21T18:30:00Z" },
+      { metric_key: "partners_activated", value: 12, captured_for_date: "2026-06-21T18:30:00Z" },
+    ]
+    const rows = computeSnapshotRows(inputs, asOf, prior)
+    const gmv = rows.find((r) => r.metric_key === "platform_net_gmv")!
+    const partners = rows.find((r) => r.metric_key === "partners_activated")!
+    const conv = rows.find((r) => r.metric_key === "storefront_conversion_rate")!
+    expect(gmv.delta_dod).toBe(500) // 1500 - 1000
+    expect(partners.delta_dod).toBe(-3) // 9 - 12 (declines are negative)
+    expect(conv.delta_dod).toBeNull() // no prior for this metric
+  })
+
+  it("rounds delta to 2dp to avoid float drift on ratios", () => {
+    const rows = computeSnapshotRows(
+      [{ metric_key: "r", value: 0.3, unit: "ratio" }],
+      asOf,
+      [{ metric_key: "r", value: 0.1, captured_for_date: "2026-06-21T18:30:00Z" }]
+    )
+    expect(rows[0].delta_dod).toBe(0.2) // not 0.19999999999999998
+  })
+
+  it("passes through unit + breakdown and defaults nulls", () => {
+    const rows = computeSnapshotRows(
+      [
+        {
+          metric_key: "platform_net_gmv",
+          value: 100,
+          unit: "INR",
+          breakdown: [{ label: "IN", value: 80 }],
+        },
+        { metric_key: "bare", value: 1 },
+      ],
+      asOf
+    )
+    expect(rows[0].breakdown).toEqual([{ label: "IN", value: 80 }])
+    expect(rows[0].unit).toBe("INR")
+    expect(rows[1].breakdown).toBeNull()
+    expect(rows[1].unit).toBeNull()
+  })
+
+  it("honours an explicit source override (manual / backfill)", () => {
+    const rows = computeSnapshotRows(inputs, asOf, null, { source: "backfill" })
+    expect(rows.every((r) => r.source === "backfill")).toBe(true)
+  })
+})

--- a/apps/backend/src/modules/marketing/compute-snapshot.ts
+++ b/apps/backend/src/modules/marketing/compute-snapshot.ts
@@ -1,0 +1,134 @@
+/**
+ * compute-snapshot.ts — PURE metric-row math for the marketing daily-refresh job
+ * (#659 slice 3, PR-3a).
+ *
+ * This file contains NO I/O and NO Medusa container access. The cron entry
+ * (`marketing-daily-refresh.ts`, PR-3b) gathers raw inputs from Query / the
+ * analytics rollup and the prior snapshot rows, then calls `computeSnapshotRows`
+ * to shape the append-only `marketing_metric_snapshot` rows (model defined in
+ * slice 1). Keeping the math pure makes it unit-testable without booting Medusa
+ * (mirrors `analytics/compute-daily-stats.ts`).
+ *
+ * Field names align to the SHIPPED slice-1 model
+ * (`models/marketing-metric-snapshot.ts`): `value` / `captured_for_date` /
+ * `delta_dod` — NOT the stale spec names (`metric_value`/`as_of_date`/`dod_delta`).
+ * The model has no week-over-week column, so this slice computes day-over-day only.
+ */
+
+/** A single metric the job measured for the business day (pre-delta, pre-persist). */
+export type MarketingMetricInput = {
+  metric_key: string
+  value: number
+  unit?: string | null
+  /** optional drill-down rows for the snapshot's `breakdown` json column */
+  breakdown?: Array<{ label: string; value: number }> | null
+}
+
+/** A prior `marketing_metric_snapshot` row, as read back for delta math. */
+export type PriorSnapshotRow = {
+  metric_key: string
+  value: number
+  captured_for_date: Date | string
+}
+
+/** Shape ready to hand to `createMarketingMetricSnapshots` (slice-1 service). */
+export type ComputedSnapshotRow = {
+  metric_key: string
+  value: number
+  unit: string | null
+  captured_for_date: Date
+  source: string
+  breakdown: Array<{ label: string; value: number }> | null
+  delta_dod: number | null
+}
+
+const IST_OFFSET_MIN = 5 * 60 + 30 // UTC+05:30 — JYT business timezone (report §7)
+
+/**
+ * The UTC instant corresponding to IST midnight of the IST calendar day that
+ * contains `instant`. Cron fires in server TZ (UTC in prod), so the business day
+ * must be derived explicitly — never trust local `new Date()` TZ (platform memory:
+ * "cron is server-TZ"). Pure + deterministic for a given input.
+ */
+export function istDayStart(instant: Date): Date {
+  const shifted = new Date(instant.getTime() + IST_OFFSET_MIN * 60_000)
+  const istMidnightUtcMs =
+    Date.UTC(shifted.getUTCFullYear(), shifted.getUTCMonth(), shifted.getUTCDate()) -
+    IST_OFFSET_MIN * 60_000
+  return new Date(istMidnightUtcMs)
+}
+
+function toMs(d: Date | string): number {
+  return (d instanceof Date ? d : new Date(d)).getTime()
+}
+
+/**
+ * The most-recent prior snapshot value for a metric strictly BEFORE `asOfMs`.
+ * Tolerates gaps (a skipped cron day) by picking the latest available prior row
+ * rather than assuming exactly yesterday. Returns null when there is no history.
+ */
+export function priorValueFor(
+  metricKey: string,
+  asOfMs: number,
+  priorRows: PriorSnapshotRow[] | null | undefined
+): number | null {
+  if (!priorRows || priorRows.length === 0) return null
+  let bestMs = -Infinity
+  let bestValue: number | null = null
+  for (const row of priorRows) {
+    if (row.metric_key !== metricKey) continue
+    const ms = toMs(row.captured_for_date)
+    if (ms >= asOfMs) continue // same day or future → not "prior"
+    if (ms > bestMs) {
+      bestMs = ms
+      bestValue = row.value
+    }
+  }
+  return bestValue
+}
+
+export type ComputeSnapshotOptions = {
+  /** provenance stamp for the rows; defaults to "daily-refresh" */
+  source?: string
+}
+
+/**
+ * Shape append-only snapshot rows from the day's measured inputs + prior history.
+ *
+ * - `captured_for_date` is normalised to IST midnight so the slice-1 unique index
+ *   `(metric_key, captured_for_date)` makes daily re-runs idempotent.
+ * - `delta_dod` = today − latest-prior (null when no history; a brand-new metric
+ *   reports no delta rather than a misleading +value).
+ * - Empty `inputs` short-circuits to `[]` (zero-activity day writes nothing).
+ */
+export function computeSnapshotRows(
+  inputs: MarketingMetricInput[] | null | undefined,
+  asOfDate: Date,
+  priorRows?: PriorSnapshotRow[] | null,
+  options: ComputeSnapshotOptions = {}
+): ComputedSnapshotRow[] {
+  if (!inputs || inputs.length === 0) return []
+
+  const capturedFor = istDayStart(asOfDate)
+  const asOfMs = capturedFor.getTime()
+  const source = options.source ?? "daily-refresh"
+
+  return inputs.map((input) => {
+    const prior = priorValueFor(input.metric_key, asOfMs, priorRows)
+    const delta_dod = prior === null ? null : round2(input.value - prior)
+    return {
+      metric_key: input.metric_key,
+      value: input.value,
+      unit: input.unit ?? null,
+      captured_for_date: capturedFor,
+      source,
+      breakdown: input.breakdown ?? null,
+      delta_dod,
+    }
+  })
+}
+
+/** Avoid float drift in deltas (e.g. 0.1 - 0.3) without changing magnitude. */
+function round2(n: number): number {
+  return Math.round((n + Number.EPSILON) * 100) / 100
+}


### PR DESCRIPTION
## #659 marketing — slice 3, PR-3a (first build PR of slice 3)

Pure, unit-tested metric-row math for the upcoming **daily-refresh** snapshot job. This is the leaf of slice 3's ordered PR list (spec `apps/docs/marketing/03_DAILY_REFRESH_JOB_AND_ADMIN_TAB_SPEC.md` §6, row 3a) — off `origin/main`, no I/O, nothing wired yet.

### What's here
- `apps/backend/src/modules/marketing/compute-snapshot.ts`
  - `computeSnapshotRows(inputs, asOfDate, priorRows?, opts?)` → append-only `marketing_metric_snapshot` rows with day-over-day deltas.
  - `istDayStart(instant)` → UTC instant of IST midnight for the business day (cron fires in server TZ = UTC in prod; the business day is derived explicitly, never from local `new Date()`).
  - `priorValueFor(...)` → latest prior value strictly before asOf, **gap-tolerant** (a skipped cron day still gets a correct delta).
  - Pure, no DI, no DB — mirrors `analytics/compute-daily-stats.ts`.
- `__tests__/compute-snapshot.unit.spec.ts` — **15 unit tests** (IST boundary incl. the 18:30Z rollover + idempotence, per-metric prior isolation, gap tolerance, null-history → `delta_dod: null`, float-drift rounding, empty-input short-circuit, source override).

### Design notes
- Field names align to the **shipped slice-1 model** (`value` / `captured_for_date` / `delta_dod`), not the stale spec names (`metric_value`/`as_of_date`/`dod_delta`). Model has no WoW column → day-over-day only.
- `captured_for_date` normalised to IST midnight so slice-1's unique `(metric_key, captured_for_date)` index keeps daily re-runs idempotent.
- New metric (no history) reports `delta_dod: null`, not a misleading +value.
- **One Goal is NOT needed here** — this computes all metric families goal-agnostically; the One Goal only picks the headline `metric_key` in PR-3d.

### Verify
```
cd apps/backend && TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules npx jest --testPathPattern="compute-snapshot"
```
15/15 green; zero new typecheck errors.

### Next in slice 3
PR-3b (cron `marketing-daily-refresh.ts` + `cache.ts` Redis shim, stacked on this) → 3c (read routes) → 3d (admin tab + Playwright).

🤖 Generated with [Claude Code](https://claude.com/claude-code)