### PR TITLE
feat(marketing): daily-refresh cron + Redis SWR cache (#659 slice 3 · PR-3b) [stacked on #676]

### DIFF
--- a/apps/backend/src/jobs/marketing-daily-refresh.ts
+++ b/apps/backend/src/jobs/marketing-daily-refresh.ts
@@ -1,0 +1,179 @@
+import { MedusaContainer } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { ANALYTICS_MODULE } from "../modules/analytics"
+import { MARKETING_MODULE } from "../modules/marketing"
+import {
+  computeSnapshotRows,
+  istDayStart,
+  type MarketingMetricInput,
+  type PriorSnapshotRow,
+} from "../modules/marketing/compute-snapshot"
+import { setHeadlineCache } from "../modules/marketing/cache"
+
+/**
+ * marketing-daily-refresh — #659 slice 3, PR-3b.
+ *
+ * Once a day, recompute the marketing headline metrics from JYT's EXISTING
+ * sources (paid orders via Query, the precomputed `analytics_daily_stats`
+ * rollup), write append-only `marketing_metric_snapshot` rows to Postgres FIRST,
+ * then best-effort warm the Redis hot path. Mirrors `aggregate-daily-analytics.ts`
+ * exactly (thin I/O here; the row math lives in the PURE, unit-tested
+ * `compute-snapshot.ts` — PR-3a).
+ *
+ * Cache discipline (spec §4): the snapshot table IS the durable cache; the admin
+ * tab (PR-3d) reads it / Redis and NEVER calls an integration on page load.
+ *
+ * The job computes for the LAST COMPLETE IST business day (yesterday), so a 1 AM
+ * UTC run reflects a finished day and aligns with `analytics_daily_stats` (which
+ * `aggregate-daily-analytics.ts` rolls up for yesterday). Cron fires in server TZ
+ * (UTC in prod) → the IST day is derived explicitly via `istDayStart`, never from
+ * local `new Date()` TZ (platform memory: "cron is server-TZ").
+ */
+export default async function marketingDailyRefresh(container: MedusaContainer) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const marketingService: any = container.resolve(MARKETING_MODULE)
+  const analyticsService: any = container.resolve(ANALYTICS_MODULE)
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  // Business day = the last COMPLETE IST calendar day (yesterday in IST).
+  const todayIstStart = istDayStart(new Date())
+  const dayStart = new Date(todayIstStart.getTime() - 24 * 60 * 60 * 1000)
+  const dayEnd = todayIstStart // exclusive upper bound
+  const dayLabel = dayStart.toISOString().split("T")[0]
+
+  logger.info(`[Marketing Refresh] Computing snapshot for IST day ${dayLabel}`)
+
+  const inputs: MarketingMetricInput[] = []
+
+  // --- (a) paid-order GMV + order count over the IST day window -----------
+  // NOTE: `total` is summed across orders; on a single-currency platform (INR)
+  // this is the GMV. Mixed-currency summing is a known v1 limitation — refine
+  // with per-currency breakdown when multi-currency GMV is needed.
+  try {
+    const { data: orders = [] } = await query.graph({
+      entity: "order",
+      fields: ["id", "total", "currency_code"],
+      filters: { created_at: { $gte: dayStart, $lt: dayEnd } },
+    })
+    const gmv = orders.reduce((sum: number, o: any) => sum + (Number(o.total) || 0), 0)
+    const unit = orders[0]?.currency_code?.toUpperCase() ?? null
+    inputs.push({ metric_key: "platform_net_gmv", value: gmv, unit })
+    inputs.push({ metric_key: "orders_count", value: orders.length, unit: "count" })
+    logger.info(`[Marketing Refresh] orders=${orders.length} gmv=${gmv}`)
+  } catch (e: any) {
+    logger.warn(`[Marketing Refresh] GMV gather failed (skipped): ${e?.message ?? e}`)
+  }
+
+  // --- (b) storefront sessions (reuse #559 precomputed rollup; never recompute
+  //         from raw events here) + derived conversion rate --------------------
+  try {
+    const stats = await analyticsService.listAnalyticsDailyStats(
+      { date: { $gte: dayStart, $lt: dayEnd } } as any,
+      { take: 1000 } as any
+    )
+    const sessions = (stats ?? []).reduce(
+      (sum: number, s: any) => sum + (Number(s.sessions) || 0),
+      0
+    )
+    inputs.push({ metric_key: "storefront_sessions", value: sessions, unit: "count" })
+
+    const ordersInput = inputs.find((i) => i.metric_key === "orders_count")
+    if (ordersInput && sessions > 0) {
+      const rate = Math.round((ordersInput.value / sessions) * 10000) / 10000
+      inputs.push({ metric_key: "storefront_conversion_rate", value: rate, unit: "ratio" })
+    }
+    logger.info(`[Marketing Refresh] sessions=${sessions}`)
+  } catch (e: any) {
+    logger.warn(`[Marketing Refresh] sessions gather failed (skipped): ${e?.message ?? e}`)
+  }
+
+  // --- (c) partner_activations — DEFERRED. The "partner w/ live storefront +
+  //         ≥1 paid order" metric is a multi-hop link query (partner → store →
+  //         sales_channel → order) that must be validated with a live
+  //         `medusa exec --dry-run` before shipping (memory:
+  //         reference_query_graph_filter_shapes). Added in a follow-up once the
+  //         join shape is verified; the schema is goal-agnostic so this does not
+  //         block the headline (default = platform_net_gmv).
+
+  if (inputs.length === 0) {
+    logger.info("[Marketing Refresh] No metrics gathered — nothing to persist")
+    return
+  }
+
+  const metricKeys = inputs.map((i) => i.metric_key)
+
+  // Prior snapshot rows (strictly before this business day) for day-over-day deltas.
+  let priorRows: PriorSnapshotRow[] = []
+  try {
+    priorRows = await marketingService.listMarketingMetricSnapshots(
+      { metric_key: metricKeys, captured_for_date: { $lt: dayStart } } as any,
+      { order: { captured_for_date: "DESC" }, take: 200 } as any
+    )
+  } catch (e: any) {
+    logger.warn(`[Marketing Refresh] prior-row read failed (deltas null): ${e?.message ?? e}`)
+  }
+
+  const rows = computeSnapshotRows(inputs, dayStart, priorRows, { source: "daily-refresh" })
+
+  // --- PERSIST FIRST (idempotent on the slice-1 unique index
+  //     (metric_key, captured_for_date)): update the existing row for this day
+  //     or insert a new one. Mirrors aggregate-daily-analytics.ts upsert. -----
+  let persisted = 0
+  for (const row of rows) {
+    try {
+      const [existing] = await marketingService.listMarketingMetricSnapshots(
+        { metric_key: row.metric_key, captured_for_date: row.captured_for_date } as any,
+        { take: 1 } as any
+      )
+      if (existing) {
+        await marketingService.updateMarketingMetricSnapshots({ id: existing.id, ...row } as any)
+      } else {
+        await marketingService.createMarketingMetricSnapshots(row as any)
+      }
+      persisted++
+    } catch (e: any) {
+      logger.warn(
+        `[Marketing Refresh] persist failed for ${row.metric_key} (skipped): ${e?.message ?? e}`
+      )
+    }
+  }
+  logger.info(`[Marketing Refresh] ✅ Persisted ${persisted}/${rows.length} snapshot rows`)
+
+  // --- THEN warm the cache (best-effort; failures are soft — the snapshot rows
+  //     already survived and the read route falls back to Postgres). Never throw
+  //     past persist. PR-3c owns the canonical blob shape; this seeds a minimal
+  //     headline blob so the hot path is non-empty after a refresh. -----------
+  try {
+    const headlineKey = "platform_net_gmv" // HEADLINE_METRIC_KEY default (One Goal — spec §1)
+    const headline = rows.find((r) => r.metric_key === headlineKey) ?? rows[0] ?? null
+    const blob = {
+      headline: headline
+        ? {
+            metric_key: headline.metric_key,
+            value: headline.value,
+            unit: headline.unit,
+            delta_dod: headline.delta_dod,
+            captured_for_date: headline.captured_for_date,
+          }
+        : null,
+      strip: rows.map((r) => ({
+        metric_key: r.metric_key,
+        value: r.value,
+        unit: r.unit,
+        delta_dod: r.delta_dod,
+      })),
+      stale: false,
+      generated_at: dayEnd.toISOString(),
+    }
+    const warmed = await setHeadlineCache(blob)
+    logger.info(`[Marketing Refresh] cache warm ${warmed ? "ok" : "skipped (no redis)"}`)
+  } catch (e: any) {
+    logger.warn(`[Marketing Refresh] cache warm failed (soft): ${e?.message ?? e}`)
+  }
+}
+
+export const config = {
+  name: "marketing-daily-refresh",
+  schedule: "0 1 * * *", // 1 AM UTC ≈ 6:30 AM IST — matches report §4.3 "6am daily-refresh"
+}

--- a/apps/backend/src/modules/marketing/__tests__/cache.unit.spec.ts
+++ b/apps/backend/src/modules/marketing/__tests__/cache.unit.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Unit test — marketing cache SWR shim (#659 slice 3, PR-3b)
+ *
+ * Verifies the FAIL-SOFT contract when REDIS_URL is unset: no Redis client is
+ * created, reads return null (caller falls back to Postgres), writes return
+ * false. No live Redis required — exercises the graceful-degradation path the
+ * daily-refresh job + read route rely on (spec §4.2).
+ *
+ * Run:
+ *   TEST_TYPE=unit npx jest --testPathPattern="marketing/__tests__/cache"
+ */
+import {
+  getMarketingRedis,
+  getHeadlineCache,
+  setHeadlineCache,
+  MARKETING_HEADLINE_KEY,
+  MARKETING_HEADLINE_TTL_SEC,
+} from "../cache"
+
+describe("marketing cache — fail-soft without REDIS_URL", () => {
+  const prev = process.env.REDIS_URL
+
+  beforeAll(() => {
+    delete process.env.REDIS_URL
+  })
+
+  afterAll(() => {
+    if (prev === undefined) delete process.env.REDIS_URL
+    else process.env.REDIS_URL = prev
+  })
+
+  it("getMarketingRedis returns null when REDIS_URL is unset", () => {
+    expect(getMarketingRedis()).toBeNull()
+  })
+
+  it("getHeadlineCache resolves null (Postgres fallback) instead of throwing", async () => {
+    await expect(getHeadlineCache()).resolves.toBeNull()
+  })
+
+  it("setHeadlineCache resolves false (no-op) instead of throwing", async () => {
+    await expect(setHeadlineCache({ headline: null })).resolves.toBe(false)
+  })
+
+  it("exposes a namespaced key and a TTL longer than the daily interval", () => {
+    expect(MARKETING_HEADLINE_KEY).toBe("marketing:headline")
+    expect(MARKETING_HEADLINE_TTL_SEC).toBeGreaterThan(24 * 60 * 60)
+  })
+})

--- a/apps/backend/src/modules/marketing/cache.ts
+++ b/apps/backend/src/modules/marketing/cache.ts
@@ -1,0 +1,77 @@
+/**
+ * cache.ts — thin stale-while-revalidate Redis shim for the marketing headline
+ * blob (#659 slice 3, PR-3b).
+ *
+ * Mirrors the `getIngestRedis()` singleton shape in
+ * `analytics/ingest-buffer.ts:117` — do NOT introduce a second Redis client
+ * pattern or a new dependency; this reuses the same `ioredis` + `REDIS_URL`
+ * discipline, keyed under the `marketing:headline` namespace.
+ *
+ * Cache discipline (spec §4.2): the durable cache is the
+ * `marketing_metric_snapshot` Postgres table; Redis is the hot path only. Every
+ * function here is FAIL-SOFT — a missing `REDIS_URL` or a down Redis never
+ * throws; reads return `null` (caller falls back to Postgres) and writes are
+ * best-effort. So the daily-refresh job's snapshot rows always survive even when
+ * the cache warm fails (job algorithm step 6: "never throw past persist").
+ */
+import Redis from "ioredis"
+
+/** Namespace key for the cached headline+strip+trend blob. */
+export const MARKETING_HEADLINE_KEY = "marketing:headline"
+
+/**
+ * Soft TTL (seconds) for the headline blob. 26h is intentionally longer than
+ * the daily refresh interval so a skipped cron still serves yesterday's number
+ * (the reader flags it `stale: true`) rather than a cold miss.
+ */
+export const MARKETING_HEADLINE_TTL_SEC = 26 * 60 * 60
+
+let _redis: Redis | null = null
+
+/**
+ * Singleton ioredis client for the marketing cache, or `null` when `REDIS_URL`
+ * is unset. Unlike `getIngestRedis()` (which throws), this returns null so the
+ * SWR path degrades to Postgres instead of crashing the job/route.
+ */
+export function getMarketingRedis(): Redis | null {
+  if (_redis) return _redis
+  const url = process.env.REDIS_URL
+  if (!url) return null
+  _redis = new Redis(url, { maxRetriesPerRequest: null })
+  return _redis
+}
+
+/**
+ * Read the cached headline blob. Returns `null` on miss, parse failure, no
+ * Redis, or any I/O error — callers MUST treat null as "fall back to Postgres".
+ */
+export async function getHeadlineCache<T = unknown>(): Promise<T | null> {
+  const redis = getMarketingRedis()
+  if (!redis) return null
+  try {
+    const raw = await redis.get(MARKETING_HEADLINE_KEY)
+    if (!raw) return null
+    return JSON.parse(raw) as T
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Best-effort write of the headline blob with a soft TTL. Swallows all errors
+ * (cache warm is non-critical — the snapshot rows are the source of truth).
+ * Returns true on a confirmed write, false otherwise.
+ */
+export async function setHeadlineCache(
+  blob: unknown,
+  ttlSec: number = MARKETING_HEADLINE_TTL_SEC
+): Promise<boolean> {
+  const redis = getMarketingRedis()
+  if (!redis) return false
+  try {
+    await redis.set(MARKETING_HEADLINE_KEY, JSON.stringify(blob), "EX", ttlSec)
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## #659 marketing — slice 3, PR-3b

**Stacked on #676** (`feat/659-compute-snapshot`, PR-3a). **Merge #676 first**, then rebase/merge this onto main.

Implements spec §2 + §4 of `apps/docs/marketing/03_DAILY_REFRESH_JOB_AND_ADMIN_TAB_SPEC.md`.

### What
- **`jobs/marketing-daily-refresh.ts`** — thin-I/O daily cron mirroring `aggregate-daily-analytics.ts`. For the **last complete IST business day** (derived via `istDayStart`, not local TZ — cron is server-TZ=UTC in prod), gathers:
  - **`platform_net_gmv`** + **`orders_count`** — `query.graph({ entity: "order", fields: ["total","currency_code"], filters: { created_at: {$gte,$lt} } })`.
  - **`storefront_sessions`** — reuses #559's precomputed `analytics_daily_stats` rollup (never recompute from raw events).
  - **`storefront_conversion_rate`** — derived `orders / sessions`.
  - Each gather is **fail-soft** (try/catch, skip metric on error).
  - **Persists snapshot rows FIRST** (idempotent upsert on the slice-1 `(metric_key, captured_for_date)` unique index), **then best-effort warms the cache** — never throws past persist (cache failures are soft; Postgres is the durable cache).
  - `partner_activations` **deferred** with a TODO — it's a multi-hop link query (partner→store→sales_channel→order) that needs a live `medusa exec --dry-run` to verify the join shape (memory: `reference_query_graph_filter_shapes`). Schema is goal-agnostic so the headline default (`platform_net_gmv`) is unaffected.
- **`modules/marketing/cache.ts`** — fail-soft `ioredis` SWR shim mirroring `getIngestRedis()` (`ingest-buffer.ts:117`), namespaced `marketing:headline`, 26h soft TTL. Returns `null`/`false` (→ Postgres fallback) when `REDIS_URL` unset or Redis down. PR-3c's read route consumes `getHeadlineCache()`.

### Tests
- 4 unit tests for the cache fail-soft contract; **19 marketing unit tests green** (`TEST_TYPE=unit`). Typecheck clean (no new errors).
- No integration test for the cron itself (jobs aren't HTTP) — per spec §2.5; the read route gets per-file integration coverage in PR-3c.

### Next (slice 3)
- **PR-3c** — `GET /admin/marketing/snapshots` + `/headline` routes (off main, reconcile matcher w/ slice-1).
- **PR-3d** — admin `/admin/marketing` tab + headline strip (Playwright-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)