### PR TITLE
#659 marketing slice-3 PR-3c: GET /admin/marketing/snapshots + /headline read routes

### DIFF
--- a/apps/backend/integration-tests/http/marketing-snapshots-route.spec.ts
+++ b/apps/backend/integration-tests/http/marketing-snapshots-route.spec.ts
@@ -1,0 +1,107 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { MARKETING_MODULE } from "../../src/modules/marketing"
+
+jest.setTimeout(60 * 1000)
+
+/**
+ * #659 slice 3 PR-3c — read routes over `marketing_metric_snapshot`:
+ *   GET /admin/marketing/snapshots  (windowed/filtered list)
+ *   GET /admin/marketing/headline   (SWR hero metric + strip + trend)
+ *
+ * The shared HTTP test DB is TRUNCATEd between it()s, so each test seeds its own
+ * snapshot rows via the module service in beforeEach (handoff watch-out).
+ */
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+  let headers: any
+
+  const HEADLINE = "platform_net_gmv"
+
+  beforeEach(async () => {
+    const container = getContainer()
+    await createAdminUser(container)
+    headers = await getAuthHeaders(api)
+
+    const svc: any = container.resolve(MARKETING_MODULE)
+    // Three days of headline GMV + a couple of secondary-strip metrics, all on
+    // distinct (metric_key, captured_for_date) pairs (unique index).
+    await svc.createMarketingMetricSnapshots([
+      { metric_key: HEADLINE, value: 100, unit: "INR", captured_for_date: new Date("2026-06-20T00:00:00.000Z"), delta_dod: null, source: "daily-refresh" },
+      { metric_key: HEADLINE, value: 150, unit: "INR", captured_for_date: new Date("2026-06-21T00:00:00.000Z"), delta_dod: 50, source: "daily-refresh" },
+      { metric_key: HEADLINE, value: 210, unit: "INR", captured_for_date: new Date("2026-06-22T00:00:00.000Z"), delta_dod: 40, source: "daily-refresh" },
+      { metric_key: "orders_count", value: 12, unit: "count", captured_for_date: new Date("2026-06-22T00:00:00.000Z"), source: "daily-refresh" },
+      { metric_key: "storefront_sessions", value: 800, unit: "count", captured_for_date: new Date("2026-06-22T00:00:00.000Z"), source: "daily-refresh" },
+    ])
+  })
+
+  describe("GET /admin/marketing/snapshots", () => {
+    it("returns rows newest-first with count and pagination echo", async () => {
+      const res = await api.get("/admin/marketing/snapshots", headers)
+      expect(res.status).toBe(200)
+      expect(res.data.count).toBe(5)
+      expect(res.data.limit).toBe(100)
+      expect(res.data.offset).toBe(0)
+      // newest-first: the most recent captured_for_date leads
+      const dates = res.data.snapshots.map((s: any) =>
+        new Date(s.captured_for_date).toISOString()
+      )
+      expect(new Date(dates[0]).getTime()).toBeGreaterThanOrEqual(
+        new Date(dates[dates.length - 1]).getTime()
+      )
+    })
+
+    it("filters by metric_key", async () => {
+      const res = await api.get(
+        `/admin/marketing/snapshots?metric_key=${HEADLINE}`,
+        headers
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.count).toBe(3)
+      expect(res.data.metric_key).toBe(HEADLINE)
+      expect(
+        res.data.snapshots.every((s: any) => s.metric_key === HEADLINE)
+      ).toBe(true)
+    })
+
+    it("honours limit pagination", async () => {
+      const res = await api.get("/admin/marketing/snapshots?limit=2", headers)
+      expect(res.status).toBe(200)
+      expect(res.data.count).toBe(5) // total, not page size
+      expect(res.data.snapshots).toHaveLength(2)
+    })
+  })
+
+  describe("GET /admin/marketing/headline", () => {
+    it("returns the newest headline metric + strip + trend", async () => {
+      const res = await api.get("/admin/marketing/headline", headers)
+      expect(res.status).toBe(200)
+      expect(res.data.headline).toMatchObject({
+        metric_key: HEADLINE,
+        value: 210,
+        unit: "INR",
+        dod_delta: 40,
+      })
+      // strip excludes the headline metric, sorted by key
+      expect(res.data.strip.map((s: any) => s.metric_key)).toEqual([
+        "orders_count",
+        "storefront_sessions",
+      ])
+      // trend is the headline series oldest→newest
+      expect(res.data.trend.map((t: any) => t.value)).toEqual([100, 150, 210])
+      expect(typeof res.data.stale).toBe("boolean")
+      expect(typeof res.data.generated_at).toBe("string")
+    })
+
+    it("respects an explicit metric_key override", async () => {
+      const res = await api.get(
+        "/admin/marketing/headline?metric_key=orders_count",
+        headers
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.headline.metric_key).toBe("orders_count")
+      expect(res.data.headline.value).toBe(12)
+      expect(res.data.strip.map((s: any) => s.metric_key)).toContain(HEADLINE)
+    })
+  })
+})

--- a/apps/backend/src/api/admin/marketing/__tests__/marketing-read-lib.unit.spec.ts
+++ b/apps/backend/src/api/admin/marketing/__tests__/marketing-read-lib.unit.spec.ts
@@ -1,0 +1,187 @@
+import {
+  HEADLINE_METRIC_KEY,
+  HEADLINE_STALE_AFTER_DAYS,
+  MAX_SNAPSHOTS_LIMIT,
+  DEFAULT_SNAPSHOTS_LIMIT,
+  parseNonNegativeInt,
+  parseSnapshotQuery,
+  sortSnapshotsNewestFirst,
+  latestPerMetricKey,
+  buildHeadlineResponse,
+  snapshotEpoch,
+  SnapshotRow,
+} from "../marketing-read-lib"
+
+const DAY = 24 * 60 * 60 * 1000
+const NOW = new Date("2026-06-23T12:00:00.000Z")
+
+function row(
+  metric_key: string,
+  value: number,
+  daysAgo: number,
+  extra: Partial<SnapshotRow> = {}
+): SnapshotRow {
+  return {
+    metric_key,
+    value,
+    captured_for_date: new Date(NOW.getTime() - daysAgo * DAY),
+    ...extra,
+  }
+}
+
+describe("parseNonNegativeInt", () => {
+  it("returns fallback on missing/blank/invalid/negative", () => {
+    expect(parseNonNegativeInt(undefined, 7)).toBe(7)
+    expect(parseNonNegativeInt("", 7)).toBe(7)
+    expect(parseNonNegativeInt("abc", 7)).toBe(7)
+    expect(parseNonNegativeInt("-3", 7)).toBe(7)
+  })
+  it("parses valid ints and array-form query values", () => {
+    expect(parseNonNegativeInt("12", 0)).toBe(12)
+    expect(parseNonNegativeInt(["5", "9"], 0)).toBe(5)
+    expect(parseNonNegativeInt("0", 7)).toBe(0)
+  })
+})
+
+describe("parseSnapshotQuery", () => {
+  it("defaults limit/offset and omits filters when query is empty", () => {
+    const q = parseSnapshotQuery({}, NOW)
+    expect(q.metric_key).toBeUndefined()
+    expect(q.startDate).toBeUndefined()
+    expect(q.endDate).toBeUndefined()
+    expect(q.limit).toBe(DEFAULT_SNAPSHOTS_LIMIT)
+    expect(q.offset).toBe(0)
+  })
+
+  it("derives a rolling window from days (takes precedence over explicit dates)", () => {
+    const q = parseSnapshotQuery(
+      { days: "7", start_date: "2000-01-01" },
+      NOW
+    )
+    expect(q.endDate).toEqual(NOW)
+    expect(q.startDate).toEqual(new Date(NOW.getTime() - 7 * DAY))
+  })
+
+  it("uses explicit start_date/end_date when no days", () => {
+    const q = parseSnapshotQuery(
+      { start_date: "2026-06-01T00:00:00.000Z", end_date: "2026-06-10T00:00:00.000Z" },
+      NOW
+    )
+    expect(q.startDate).toEqual(new Date("2026-06-01T00:00:00.000Z"))
+    expect(q.endDate).toEqual(new Date("2026-06-10T00:00:00.000Z"))
+  })
+
+  it("ignores invalid dates and non-positive days", () => {
+    const q = parseSnapshotQuery(
+      { days: "0", start_date: "not-a-date" },
+      NOW
+    )
+    expect(q.startDate).toBeUndefined()
+    expect(q.endDate).toBeUndefined()
+  })
+
+  it("caps limit at MAX and passes metric_key through", () => {
+    const q = parseSnapshotQuery({ metric_key: "platform_net_gmv", limit: "99999" }, NOW)
+    expect(q.metric_key).toBe("platform_net_gmv")
+    expect(q.limit).toBe(MAX_SNAPSHOTS_LIMIT)
+  })
+})
+
+describe("snapshotEpoch + sortSnapshotsNewestFirst", () => {
+  it("accepts both Date and ISO-string captured_for_date", () => {
+    expect(snapshotEpoch(row("a", 1, 0))).toBe(NOW.getTime())
+    expect(
+      snapshotEpoch({ metric_key: "a", value: 1, captured_for_date: NOW.toISOString() })
+    ).toBe(NOW.getTime())
+  })
+  it("orders newest first without mutating input", () => {
+    const input = [row("a", 1, 3), row("a", 2, 0), row("a", 3, 1)]
+    const sorted = sortSnapshotsNewestFirst(input)
+    expect(sorted.map((r) => r.value)).toEqual([2, 3, 1])
+    expect(input.map((r) => r.value)).toEqual([1, 2, 3]) // untouched
+  })
+})
+
+describe("latestPerMetricKey", () => {
+  it("keeps the newest row per metric regardless of input order", () => {
+    const map = latestPerMetricKey([
+      row("gmv", 10, 2),
+      row("gmv", 30, 0),
+      row("gmv", 20, 1),
+      row("orders", 5, 1),
+    ])
+    expect(map.get("gmv")!.value).toBe(30)
+    expect(map.get("orders")!.value).toBe(5)
+    expect(map.size).toBe(2)
+  })
+})
+
+describe("buildHeadlineResponse", () => {
+  it("returns empty/stale state on no data", () => {
+    const out = buildHeadlineResponse([], HEADLINE_METRIC_KEY, NOW)
+    expect(out.headline).toBeNull()
+    expect(out.strip).toEqual([])
+    expect(out.trend).toEqual([])
+    expect(out.stale).toBe(true)
+    expect(out.generated_at).toBe(NOW.toISOString())
+  })
+
+  it("picks the newest headline row, fills dod_delta/unit, and is fresh within window", () => {
+    const rows = [
+      row(HEADLINE_METRIC_KEY, 100, 1, { delta_dod: 4.2, unit: "INR" }),
+      row(HEADLINE_METRIC_KEY, 200, 0, { delta_dod: -1.5, unit: "INR" }),
+      row("orders_count", 12, 0, { unit: "count" }),
+    ]
+    const out = buildHeadlineResponse(rows, HEADLINE_METRIC_KEY, NOW)
+    expect(out.headline).toEqual({
+      metric_key: HEADLINE_METRIC_KEY,
+      value: 200,
+      unit: "INR",
+      dod_delta: -1.5,
+      as_of_date: new Date(NOW.getTime()).toISOString(),
+    })
+    expect(out.stale).toBe(false)
+  })
+
+  it("puts other metrics in the strip (sorted, excluding the headline metric)", () => {
+    const rows = [
+      row(HEADLINE_METRIC_KEY, 200, 0),
+      row("orders_count", 12, 0, { unit: "count" }),
+      row("storefront_sessions", 999, 0),
+    ]
+    const out = buildHeadlineResponse(rows, HEADLINE_METRIC_KEY, NOW)
+    expect(out.strip.map((s) => s.metric_key)).toEqual([
+      "orders_count",
+      "storefront_sessions",
+    ])
+    expect(out.headline!.metric_key).toBe(HEADLINE_METRIC_KEY)
+  })
+
+  it("emits the trend oldest→newest for the headline metric only", () => {
+    const rows = [
+      row(HEADLINE_METRIC_KEY, 100, 2),
+      row(HEADLINE_METRIC_KEY, 300, 0),
+      row(HEADLINE_METRIC_KEY, 200, 1),
+      row("orders_count", 9, 0),
+    ]
+    const out = buildHeadlineResponse(rows, HEADLINE_METRIC_KEY, NOW)
+    expect(out.trend.map((t) => t.value)).toEqual([100, 200, 300])
+  })
+
+  it("flags stale when the freshest headline day is older than the threshold", () => {
+    const rows = [row(HEADLINE_METRIC_KEY, 50, HEADLINE_STALE_AFTER_DAYS + 1)]
+    const out = buildHeadlineResponse(rows, HEADLINE_METRIC_KEY, NOW)
+    expect(out.headline!.value).toBe(50)
+    expect(out.stale).toBe(true)
+  })
+
+  it("respects a custom metric key", () => {
+    const rows = [
+      row("partners_activated", 7, 0),
+      row(HEADLINE_METRIC_KEY, 200, 0),
+    ]
+    const out = buildHeadlineResponse(rows, "partners_activated", NOW)
+    expect(out.headline!.metric_key).toBe("partners_activated")
+    expect(out.strip.map((s) => s.metric_key)).toEqual([HEADLINE_METRIC_KEY])
+  })
+})

--- a/apps/backend/src/api/admin/marketing/headline/route.ts
+++ b/apps/backend/src/api/admin/marketing/headline/route.ts
@@ -1,0 +1,48 @@
+/**
+ * GET /admin/marketing/headline
+ *
+ * The stale-while-revalidate endpoint the headline strip calls (#659 slice 3).
+ * Serves the One-Goal hero metric + day-over-day delta + a secondary KPI strip
+ * + a trend series, reading ONLY the latest `marketing_metric_snapshot` rows
+ * the cron already materialised. Never recomputes and never calls an
+ * integration on a page load (report §11.1) — the snapshot table is the
+ * durable cache.
+ *
+ * Empty table → 200 with `headline: null`, `stale: true` (never a 500), so the
+ * admin tab can render an empty state before the first cron run.
+ *
+ * Note: the Redis hot-path read (`cache.ts` `getHeadlineCache()`, slice-3
+ * PR-3b / #677) is a fail-soft optimisation layered on top of this Postgres
+ * read once that lands on main; the table read here is already the correct,
+ * self-sufficient SWR server half.
+ *
+ * Response (200)
+ * { headline: { metric_key, value, unit, dod_delta, as_of_date } | null,
+ *   strip: [...KPI rows], trend: [{ as_of_date, value }],
+ *   stale: boolean, generated_at }
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { MARKETING_MODULE } from "../../../../modules/marketing"
+import {
+  HEADLINE_METRIC_KEY,
+  HEADLINE_SCAN_TAKE,
+  buildHeadlineResponse,
+} from "../marketing-read-lib"
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const metricKey =
+    (req.query.metric_key as string | undefined) || HEADLINE_METRIC_KEY
+
+  const marketingService: any = req.scope.resolve(MARKETING_MODULE)
+  // Scan the most-recent rows once; the pure lib derives the headline, the
+  // per-metric strip and the headline trend from this single window.
+  const rows = await marketingService.listMarketingMetricSnapshots(
+    {},
+    {
+      take: HEADLINE_SCAN_TAKE,
+      order: { captured_for_date: "DESC" },
+    }
+  )
+
+  res.json(buildHeadlineResponse(rows, metricKey))
+}

--- a/apps/backend/src/api/admin/marketing/marketing-read-lib.ts
+++ b/apps/backend/src/api/admin/marketing/marketing-read-lib.ts
@@ -1,0 +1,207 @@
+/**
+ * Pure helpers for the marketing read routes (#659 slice 3 PR-3c).
+ *
+ * Kept free of Medusa/HTTP imports so the query-parsing, latest-per-metric,
+ * headline-blob and staleness math are unit-testable without booting the app.
+ * The routes (`snapshots/route.ts`, `headline/route.ts`) are thin I/O over
+ * the `marketing` module service; all shaping lives here.
+ *
+ * Field names track the SHIPPED slice-1 model (`value`, `captured_for_date`,
+ * `delta_dod`) — NOT the stale spec names (`metric_value`/`as_of_date`/`wow_delta`).
+ * The response still exposes `as_of_date`/`dod_delta` aliases for the UI contract.
+ */
+
+/**
+ * The One-Goal hook (spec §1). Until the operator picks the One Goal, the
+ * headline number defaults to platform net GMV. This is the ONLY place the
+ * still-open product decision changes shipped behaviour; flipping the constant
+ * (or sourcing it from config) is the whole change when the goal is chosen.
+ */
+export const HEADLINE_METRIC_KEY = "platform_net_gmv"
+
+/** A snapshot row is considered stale once its business day is this many days behind "now". */
+export const HEADLINE_STALE_AFTER_DAYS = 3
+
+/** Default/cap for the `/snapshots` page size and the headline scan window. */
+export const DEFAULT_SNAPSHOTS_LIMIT = 100
+export const MAX_SNAPSHOTS_LIMIT = 500
+/** How many recent rows the headline route scans to derive the strip + trend. */
+export const HEADLINE_SCAN_TAKE = 200
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+export type SnapshotRow = {
+  metric_key: string
+  value: number
+  unit?: string | null
+  captured_for_date: Date | string
+  source?: string | null
+  breakdown?: unknown
+  delta_dod?: number | null
+}
+
+export type SnapshotQuery = {
+  metric_key?: string
+  startDate?: Date
+  endDate?: Date
+  limit: number
+  offset: number
+}
+
+export type HeadlineMetric = {
+  metric_key: string
+  value: number
+  unit: string | null
+  dod_delta: number | null
+  as_of_date: string | null
+}
+
+export type HeadlineResponse = {
+  headline: HeadlineMetric | null
+  strip: HeadlineMetric[]
+  trend: { as_of_date: string; value: number }[]
+  stale: boolean
+  generated_at: string
+}
+
+function firstOf(raw: unknown): string | undefined {
+  if (raw === undefined || raw === null || raw === "") return undefined
+  return Array.isArray(raw) ? String(raw[0]) : String(raw)
+}
+
+/** Parse a non-negative int, returning `fallback` on missing/invalid input. */
+export function parseNonNegativeInt(raw: unknown, fallback: number): number {
+  const s = firstOf(raw)
+  if (s === undefined) return fallback
+  const n = parseInt(s, 10)
+  return Number.isNaN(n) || n < 0 ? fallback : n
+}
+
+/** Coerce a snapshot's captured_for_date (Date | ISO string) to epoch ms. */
+export function snapshotEpoch(row: SnapshotRow): number {
+  const d = row.captured_for_date
+  const t = d instanceof Date ? d.getTime() : new Date(d).getTime()
+  return Number.isNaN(t) ? 0 : t
+}
+
+function asIso(d: Date | string): string {
+  return d instanceof Date ? d.toISOString() : new Date(d).toISOString()
+}
+
+/**
+ * Parse the `/admin/marketing/snapshots` query string into a normalised filter.
+ * Mirrors the breakdown route param shape: `metric_key` equality, a `days`
+ * rolling window (takes precedence) or explicit `start_date`/`end_date`,
+ * plus `limit`/`offset` pagination (limit capped at MAX_SNAPSHOTS_LIMIT).
+ */
+export function parseSnapshotQuery(
+  query: Record<string, unknown>,
+  now: Date = new Date()
+): SnapshotQuery {
+  const metric_key = firstOf(query.metric_key)
+
+  let startDate: Date | undefined
+  let endDate: Date | undefined
+  const daysRaw = firstOf(query.days)
+  if (daysRaw !== undefined) {
+    const days = parseInt(daysRaw, 10)
+    if (!Number.isNaN(days) && days > 0) {
+      startDate = new Date(now.getTime() - days * DAY_MS)
+      endDate = now
+    }
+  } else {
+    const sd = firstOf(query.start_date)
+    const ed = firstOf(query.end_date)
+    if (sd) {
+      const d = new Date(sd)
+      if (!Number.isNaN(d.getTime())) startDate = d
+    }
+    if (ed) {
+      const d = new Date(ed)
+      if (!Number.isNaN(d.getTime())) endDate = d
+    }
+  }
+
+  const limit = Math.min(
+    parseNonNegativeInt(query.limit, DEFAULT_SNAPSHOTS_LIMIT) || DEFAULT_SNAPSHOTS_LIMIT,
+    MAX_SNAPSHOTS_LIMIT
+  )
+  const offset = parseNonNegativeInt(query.offset, 0)
+
+  return { metric_key, startDate, endDate, limit, offset }
+}
+
+/** Newest-first by captured_for_date (stable for equal timestamps). */
+export function sortSnapshotsNewestFirst(rows: SnapshotRow[]): SnapshotRow[] {
+  return [...rows].sort((a, b) => snapshotEpoch(b) - snapshotEpoch(a))
+}
+
+/**
+ * Reduce rows to the single newest row per metric_key. Input need not be sorted.
+ */
+export function latestPerMetricKey(rows: SnapshotRow[]): Map<string, SnapshotRow> {
+  const latest = new Map<string, SnapshotRow>()
+  for (const row of rows) {
+    const cur = latest.get(row.metric_key)
+    if (!cur || snapshotEpoch(row) > snapshotEpoch(cur)) {
+      latest.set(row.metric_key, row)
+    }
+  }
+  return latest
+}
+
+function toHeadlineMetric(row: SnapshotRow): HeadlineMetric {
+  return {
+    metric_key: row.metric_key,
+    value: row.value,
+    unit: row.unit ?? null,
+    dod_delta: row.delta_dod ?? null,
+    as_of_date: asIso(row.captured_for_date),
+  }
+}
+
+/**
+ * Build the SWR headline blob from already-fetched recent snapshot rows.
+ *
+ * - `headline` = newest row for `metricKey` (null if none yet → UI shows empty
+ *   state, never a 500).
+ * - `strip` = newest row for every OTHER metric_key (the secondary KPI cards),
+ *   ordered by metric_key for stable rendering.
+ * - `trend` = the `metricKey` series oldest→newest (for the sparkline).
+ * - `stale` = true when the freshest headline business day is more than
+ *   HEADLINE_STALE_AFTER_DAYS behind `now` (the cron likely missed a run), or
+ *   when there is no data at all.
+ */
+export function buildHeadlineResponse(
+  rows: SnapshotRow[],
+  metricKey: string,
+  now: Date = new Date()
+): HeadlineResponse {
+  const latest = latestPerMetricKey(rows)
+  const headlineRow = latest.get(metricKey) ?? null
+
+  const strip = [...latest.entries()]
+    .filter(([key]) => key !== metricKey)
+    .map(([, row]) => toHeadlineMetric(row))
+    .sort((a, b) => a.metric_key.localeCompare(b.metric_key))
+
+  const trend = sortSnapshotsNewestFirst(
+    rows.filter((r) => r.metric_key === metricKey)
+  )
+    .reverse() // oldest → newest for the sparkline
+    .map((r) => ({ as_of_date: asIso(r.captured_for_date), value: r.value }))
+
+  let stale = true
+  if (headlineRow) {
+    const ageMs = now.getTime() - snapshotEpoch(headlineRow)
+    stale = ageMs > HEADLINE_STALE_AFTER_DAYS * DAY_MS
+  }
+
+  return {
+    headline: headlineRow ? toHeadlineMetric(headlineRow) : null,
+    strip,
+    trend,
+    stale,
+    generated_at: now.toISOString(),
+  }
+}

--- a/apps/backend/src/api/admin/marketing/snapshots/route.ts
+++ b/apps/backend/src/api/admin/marketing/snapshots/route.ts
@@ -1,0 +1,58 @@
+/**
+ * GET /admin/marketing/snapshots
+ *
+ * Append-only metric snapshot rows over a window (#659 slice 3). Powers the
+ * trend line and a future drill-down table on the marketing admin tab. Reads
+ * ONLY the `marketing_metric_snapshot` table — the table IS the durable cache
+ * (materialised daily by `jobs/marketing-daily-refresh.ts`), so no integration
+ * call ever happens on a page load (report §11.1).
+ *
+ * Query parameters
+ * - metric_key (string, optional): equality filter on the metric.
+ * - days (number, optional): rolling window on captured_for_date; takes
+ *   precedence over start_date/end_date.
+ * - start_date / end_date (ISO string, optional): explicit window.
+ * - limit (number, optional): page size (default 100, capped 500).
+ * - offset (number, optional): page offset (default 0).
+ *
+ * Response (200)
+ * { snapshots: [...], count, limit, offset, metric_key, period: { start_date?, end_date? } }
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { MARKETING_MODULE } from "../../../../modules/marketing"
+import { parseSnapshotQuery } from "../marketing-read-lib"
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { metric_key, startDate, endDate, limit, offset } = parseSnapshotQuery(
+    req.query as Record<string, unknown>
+  )
+
+  const filters: Record<string, unknown> = {}
+  if (metric_key) filters.metric_key = metric_key
+  if (startDate || endDate) {
+    const range: Record<string, Date> = {}
+    if (startDate) range.$gte = startDate
+    if (endDate) range.$lte = endDate
+    filters.captured_for_date = range
+  }
+
+  const marketingService: any = req.scope.resolve(MARKETING_MODULE)
+  const [snapshots, count] =
+    await marketingService.listAndCountMarketingMetricSnapshots(filters, {
+      take: limit,
+      skip: offset,
+      order: { captured_for_date: "DESC" },
+    })
+
+  res.json({
+    snapshots,
+    count,
+    limit,
+    offset,
+    metric_key: metric_key ?? null,
+    period: {
+      start_date: startDate?.toISOString(),
+      end_date: endDate?.toISOString(),
+    },
+  })
+}


### PR DESCRIPTION
## #659 — AI VP of Marketing · slice 3 PR-3c (read routes)

Adds the two admin read endpoints over the slice-1 `marketing_metric_snapshot`
table (spec `apps/docs/marketing/03_DAILY_REFRESH_JOB_AND_ADMIN_TAB_SPEC.md` §3).
Both serve **only** snapshot rows the daily-refresh cron materialised — the table
**is** the durable cache, so no integration call ever happens on a page load
(report §11.1).

### Endpoints
- **`GET /admin/marketing/snapshots`** — windowed/filtered list. Params:
  `metric_key` (equality), `days` (rolling window, precedence) or
  `start_date`/`end_date`, `limit` (default 100, cap 500), `offset`. Newest-first.
  Response: `{ snapshots, count, limit, offset, metric_key, period }`.
- **`GET /admin/marketing/headline`** — the SWR hero blob the headline strip calls.
  Response: `{ headline: {metric_key,value,unit,dod_delta,as_of_date}|null, strip[], trend[], stale, generated_at }`.
  `headline.metric_key` = `HEADLINE_METRIC_KEY` (the **One-Goal hook**, defaults
  `platform_net_gmv` until the operator picks — flip one constant to change).
  Empty table → `200` with `headline: null`, `stale: true` (never a 500).

### Shape & conventions
- Pure `src/api/admin/marketing/marketing-read-lib.ts` (`parseSnapshotQuery` /
  `sortSnapshotsNewestFirst` / `latestPerMetricKey` / `buildHeadlineResponse` /
  staleness math) keeps all shaping unit-testable; routes are thin I/O.
- Manual query parse, **no middleware** — mirrors `analytics-events/breakdown`
  and the existing `marketing/ideas-log` route.
- Field names track the **SHIPPED** model (`value`/`captured_for_date`/`delta_dod`),
  not the stale spec names (`metric_value`/`as_of_date`/`wow_delta`).

### Branching
Branched off **origin/main** — **INDEPENDENT** of the open slice-3 stack
(#676←#677). It does **not** import `cache.ts` (still only on #677); `/headline`
reads Postgres directly, which is the correct, self-sufficient SWR server half.
The Redis hot-path read is a fail-soft optimisation to layer on once `cache.ts`
lands on main.

### Tests
- **16 unit** — `marketing-read-lib.unit.spec.ts` (`TEST_TYPE=unit`).
- **5 integration** — `integration-tests/http/marketing-snapshots-route.spec.ts`
  (shared DB, per-file): list newest-first + count/pagination, metric_key filter,
  limit page, headline hero+strip+trend, metric_key override. All green.
- Changed-file typecheck clean.

### Next (slice 3)
- **PR-3d** — admin `/admin/marketing` tab + headline strip (Playwright-gated UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Do NOT merge — left for human review (daemon = PR-only).