### PR TITLE
#659 marketing slice 4 · PR-4b: outreach engagement diff + list pure libs

### DIFF
--- a/apps/backend/src/modules/marketing/__tests__/diff-outreach-engagement.unit.spec.ts
+++ b/apps/backend/src/modules/marketing/__tests__/diff-outreach-engagement.unit.spec.ts
@@ -1,0 +1,144 @@
+import {
+  diffOutreachEngagement,
+  type OutreachEngagementRow,
+  type OutreachProviderEvent,
+} from "../diff-outreach-engagement"
+
+const baseRow = (
+  over: Partial<OutreachEngagementRow> = {}
+): OutreachEngagementRow => ({
+  id: "mko_1",
+  status: "queued",
+  sent_at: null,
+  opened_at: null,
+  replied_at: null,
+  bounce_unreliable: false,
+  ...over,
+})
+
+describe("diffOutreachEngagement", () => {
+  it("advances queued → sent and stamps sent_at", () => {
+    const event: OutreachProviderEvent = { sent_at: "2026-06-20T10:00:00Z" }
+    const { changes, patch, nextStatus } = diffOutreachEngagement(baseRow(), event)
+
+    expect(nextStatus).toBe("sent")
+    expect(patch.status).toBe("sent")
+    expect(patch.sent_at).toBeInstanceOf(Date)
+    const fields = changes.map((c) => c.field).sort()
+    expect(fields).toEqual(["sent_at", "status"])
+    expect(changes.every((c) => c.entity === "marketing_outreach" && c.id === "mko_1")).toBe(true)
+  })
+
+  it("advances to opened when an open is reported", () => {
+    const { patch, nextStatus } = diffOutreachEngagement(
+      baseRow({ status: "sent", sent_at: new Date("2026-06-20T10:00:00Z") }),
+      { opened_at: "2026-06-21T09:00:00Z" }
+    )
+    expect(nextStatus).toBe("opened")
+    expect(patch.status).toBe("opened")
+    expect(patch.opened_at).toBeInstanceOf(Date)
+    expect(patch.sent_at).toBeUndefined() // already stamped → not re-written
+  })
+
+  it("advances to replied (highest signal)", () => {
+    const { patch, nextStatus } = diffOutreachEngagement(baseRow({ status: "opened" }), {
+      replied_at: "2026-06-22T08:00:00Z",
+    })
+    expect(nextStatus).toBe("replied")
+    expect(patch.status).toBe("replied")
+    expect(patch.replied_at).toBeInstanceOf(Date)
+  })
+
+  it("never downgrades a stronger status", () => {
+    const { changes, patch, nextStatus } = diffOutreachEngagement(
+      baseRow({ status: "replied", replied_at: new Date("2026-06-22T08:00:00Z") }),
+      { opened_at: "2026-06-21T09:00:00Z", sent_at: "2026-06-20T10:00:00Z" }
+    )
+    // status stays replied; opened_at/sent_at get back-filled but status is untouched
+    expect(nextStatus).toBe("replied")
+    expect(patch.status).toBeUndefined()
+    expect(changes.find((c) => c.field === "status")).toBeUndefined()
+    expect(patch.opened_at).toBeInstanceOf(Date)
+    expect(patch.sent_at).toBeInstanceOf(Date)
+  })
+
+  it("on bounce sets status=bounced AND flags bounce_unreliable (never suppresses)", () => {
+    const { changes, patch, nextStatus } = diffOutreachEngagement(
+      baseRow({ status: "sent" }),
+      { bounced_at: "2026-06-21T11:00:00Z" }
+    )
+    expect(nextStatus).toBe("bounced")
+    expect(patch.status).toBe("bounced")
+    expect(patch.bounce_unreliable).toBe(true)
+    const flag = changes.find((c) => c.field === "bounce_unreliable")
+    expect(flag).toEqual({
+      entity: "marketing_outreach",
+      id: "mko_1",
+      field: "bounce_unreliable",
+      before: false,
+      after: true,
+    })
+  })
+
+  it("a reply outranks a bounce for status but still flags the bounce signal", () => {
+    const { patch, nextStatus } = diffOutreachEngagement(baseRow({ status: "sent" }), {
+      bounced_at: "2026-06-21T11:00:00Z",
+      replied_at: "2026-06-22T08:00:00Z",
+    })
+    expect(nextStatus).toBe("replied")
+    expect(patch.status).toBe("replied")
+    expect(patch.bounce_unreliable).toBe(true) // honesty flag still set
+  })
+
+  it("does not re-flag bounce_unreliable when already true", () => {
+    const { changes, patch } = diffOutreachEngagement(
+      baseRow({ status: "bounced", bounce_unreliable: true }),
+      { bounced_at: "2026-06-21T11:00:00Z" }
+    )
+    expect(patch.bounce_unreliable).toBeUndefined()
+    expect(changes.find((c) => c.field === "bounce_unreliable")).toBeUndefined()
+  })
+
+  it("is idempotent — re-diffing a fully-synced row yields no changes", () => {
+    const row = baseRow({
+      status: "replied",
+      sent_at: new Date("2026-06-20T10:00:00Z"),
+      opened_at: new Date("2026-06-21T09:00:00Z"),
+      replied_at: new Date("2026-06-22T08:00:00Z"),
+    })
+    const event: OutreachProviderEvent = {
+      sent_at: "2026-06-20T10:00:00Z",
+      opened_at: "2026-06-21T09:00:00Z",
+      replied_at: "2026-06-22T08:00:00Z",
+    }
+    const { changes, patch } = diffOutreachEngagement(row, event)
+    expect(changes).toEqual([])
+    expect(patch).toEqual({})
+  })
+
+  it("treats an empty event as a no-op", () => {
+    const { changes, patch, nextStatus } = diffOutreachEngagement(baseRow({ status: "sent" }), {})
+    expect(changes).toEqual([])
+    expect(patch).toEqual({})
+    expect(nextStatus).toBe("sent")
+  })
+
+  it("ignores invalid/NaN dates (no signal)", () => {
+    const { changes, patch, nextStatus } = diffOutreachEngagement(baseRow(), {
+      sent_at: "not-a-date",
+      opened_at: null,
+    })
+    expect(changes).toEqual([])
+    expect(patch).toEqual({})
+    expect(nextStatus).toBe("queued")
+  })
+
+  it("defaults a null status to queued before ranking", () => {
+    const { nextStatus, patch } = diffOutreachEngagement(
+      baseRow({ status: null }),
+      { sent_at: "2026-06-20T10:00:00Z" }
+    )
+    expect(nextStatus).toBe("sent")
+    expect(patch.status).toBe("sent")
+  })
+})

--- a/apps/backend/src/modules/marketing/__tests__/outreach-list-lib.unit.spec.ts
+++ b/apps/backend/src/modules/marketing/__tests__/outreach-list-lib.unit.spec.ts
@@ -1,0 +1,86 @@
+import {
+  filterAndPaginateOutreach,
+  type OutreachListRow,
+} from "../outreach-list-lib"
+
+const rows: OutreachListRow[] = [
+  { id: "1", recipient_email: "ana@acme.com", recipient_name: "Ana", company: "Acme", campaign: "q3-winbacks", status: "sent", channel: "email" },
+  { id: "2", recipient_email: "bob@globex.com", recipient_name: "Bob", company: "Globex", campaign: "q3-winbacks", status: "replied", channel: "email" },
+  { id: "3", recipient_email: "cal@acme.com", recipient_name: "Cal", company: "Acme", campaign: "exec-2026", status: "bounced", channel: "whatsapp" },
+  { id: "4", recipient_email: "deb@initech.com", recipient_name: "Deb", company: "Initech", campaign: "exec-2026", status: "queued", channel: "manual" },
+  { id: "5", recipient_email: "evan@acme.com", recipient_name: "Evan", company: "Acme", campaign: "q3-winbacks", status: "opened", channel: "email" },
+]
+
+describe("filterAndPaginateOutreach", () => {
+  it("returns all rows with defaults", () => {
+    const r = filterAndPaginateOutreach(rows)
+    expect(r.count).toBe(5)
+    expect(r.items).toHaveLength(5)
+    expect(r.offset).toBe(0)
+    expect(r.limit).toBe(50)
+  })
+
+  it("filters by status exactly", () => {
+    const r = filterAndPaginateOutreach(rows, { status: "replied" })
+    expect(r.count).toBe(1)
+    expect(r.items[0].id).toBe("2")
+  })
+
+  it("filters by campaign", () => {
+    const r = filterAndPaginateOutreach(rows, { campaign: "exec-2026" })
+    expect(r.count).toBe(2)
+    expect(r.items.map((i) => i.id).sort()).toEqual(["3", "4"])
+  })
+
+  it("filters by channel", () => {
+    const r = filterAndPaginateOutreach(rows, { channel: "whatsapp" })
+    expect(r.count).toBe(1)
+    expect(r.items[0].id).toBe("3")
+  })
+
+  it("q matches email, name, company and campaign (case-insensitive)", () => {
+    expect(filterAndPaginateOutreach(rows, { q: "ACME" }).count).toBe(3) // company
+    expect(filterAndPaginateOutreach(rows, { q: "bob" }).count).toBe(1) // name
+    expect(filterAndPaginateOutreach(rows, { q: "globex.com" }).count).toBe(1) // email
+    expect(filterAndPaginateOutreach(rows, { q: "exec-2026" }).count).toBe(2) // campaign
+  })
+
+  it("combines filters with AND", () => {
+    const r = filterAndPaginateOutreach(rows, { q: "acme", status: "opened" })
+    expect(r.count).toBe(1)
+    expect(r.items[0].id).toBe("5")
+  })
+
+  it("count is total matched, NOT per-page (the #484 regression)", () => {
+    // 3 Acme rows, page size 2 → count must stay 3, items only 2
+    const r = filterAndPaginateOutreach(rows, { q: "acme", limit: 2 })
+    expect(r.count).toBe(3)
+    expect(r.items).toHaveLength(2)
+    expect(r.items.map((i) => i.id)).toEqual(["1", "3"])
+  })
+
+  it("paginates with offset over the filtered set", () => {
+    const r = filterAndPaginateOutreach(rows, { q: "acme", offset: 2, limit: 2 })
+    expect(r.count).toBe(3)
+    expect(r.items.map((i) => i.id)).toEqual(["5"])
+  })
+
+  it("clamps invalid offset/limit to safe defaults", () => {
+    const r = filterAndPaginateOutreach(rows, { offset: -5, limit: 0 })
+    expect(r.offset).toBe(0)
+    expect(r.limit).toBe(50)
+    const capped = filterAndPaginateOutreach(rows, { limit: 9999 })
+    expect(capped.limit).toBe(200)
+  })
+
+  it("blank q is ignored (not treated as a filter)", () => {
+    expect(filterAndPaginateOutreach(rows, { q: "   " }).count).toBe(5)
+  })
+
+  it("handles empty/nullish input safely", () => {
+    expect(filterAndPaginateOutreach([] as OutreachListRow[]).count).toBe(0)
+    expect(
+      filterAndPaginateOutreach(undefined as unknown as OutreachListRow[]).count
+    ).toBe(0)
+  })
+})

--- a/apps/backend/src/modules/marketing/diff-outreach-engagement.ts
+++ b/apps/backend/src/modules/marketing/diff-outreach-engagement.ts
@@ -1,0 +1,180 @@
+import type { MaintenanceChange } from "../../api/admin/ops/maintenance-jobs/registry"
+
+/**
+ * Pure engagement reconciliation for `marketing_outreach` (#659 slice 4 / PR-4b).
+ *
+ * Given a persisted outreach row and a normalized provider message-event, compute
+ * the minimal forward-only change set + the patch to persist. Kept dependency-free
+ * so the dry-run/apply maintenance job (PR-4d) and the sync workflow are verifiable
+ * without booting the DB, the workflow engine, or a live email provider.
+ *
+ * Honesty rule (spec §3 + the model's `bounce_unreliable` flag): a provider bounce
+ * signal is best-effort. We stamp `status="bounced"` + flag `bounce_unreliable=true`
+ * so the operator can act — we NEVER auto-suppress the recipient here.
+ *
+ * Field names mirror the SHIPPED model
+ * (`src/modules/marketing/models/marketing-outreach.ts`), NOT the slice-4 draft spec:
+ *   status: queued | sent | opened | replied | bounced | unknown
+ *   timestamps: sent_at / opened_at / replied_at
+ *   bounce_unreliable: boolean
+ */
+
+export type OutreachStatus =
+  | "queued"
+  | "sent"
+  | "opened"
+  | "replied"
+  | "bounced"
+  | "unknown"
+
+/** Subset of `marketing_outreach` columns this reconciliation reads. */
+export type OutreachEngagementRow = {
+  id: string
+  status?: OutreachStatus | null
+  sent_at?: Date | string | null
+  opened_at?: Date | string | null
+  replied_at?: Date | string | null
+  bounce_unreliable?: boolean | null
+}
+
+/**
+ * Normalized provider event (e.g. mapped from a Resend message-events lookup).
+ * Every field optional — the provider only reports the signals it has. Dates are
+ * accepted as Date or ISO string; absent/null = "no signal".
+ */
+export type OutreachProviderEvent = {
+  sent_at?: Date | string | null
+  opened_at?: Date | string | null
+  replied_at?: Date | string | null
+  bounced_at?: Date | string | null
+}
+
+/** Fields the caller persists when applying. Only present when something changed. */
+export type OutreachEngagementPatch = {
+  status?: OutreachStatus
+  sent_at?: Date
+  opened_at?: Date
+  replied_at?: Date
+  bounce_unreliable?: boolean
+}
+
+export type OutreachEngagementDiff = {
+  changes: MaintenanceChange[]
+  patch: OutreachEngagementPatch
+  /** The resolved status (== row.status when no advance happened). */
+  nextStatus: OutreachStatus
+}
+
+const ENTITY = "marketing_outreach"
+
+/**
+ * Monotonic status ranking. We only ever advance a row forward, never downgrade —
+ * a later partial/empty sync must not clobber a strong signal already recorded.
+ * A `replied` outranks `bounced`: a genuine reply is definitive engagement and
+ * trumps a (best-effort, unreliable) bounce signal.
+ */
+const STATUS_RANK: Record<OutreachStatus, number> = {
+  queued: 0,
+  unknown: 0,
+  sent: 1,
+  opened: 2,
+  bounced: 3,
+  replied: 4,
+}
+
+function toDate(v: Date | string | null | undefined): Date | null {
+  if (v == null) {
+    return null
+  }
+  const d = v instanceof Date ? v : new Date(v)
+  return Number.isNaN(d.getTime()) ? null : d
+}
+
+/**
+ * Reconcile a single outreach row against a provider event.
+ *
+ * Behaviour:
+ *  - fills engagement timestamps that are currently null (never overwrites an
+ *    existing stamp — idempotent: re-diffing after apply yields zero changes);
+ *  - advances `status` forward only, by the strongest signal present in the event;
+ *  - on a bounce signal sets `bounce_unreliable=true` (flag, never suppress).
+ *
+ * Never throws — bad/NaN dates are treated as "no signal".
+ */
+export function diffOutreachEngagement(
+  row: OutreachEngagementRow,
+  event: OutreachProviderEvent
+): OutreachEngagementDiff {
+  const changes: MaintenanceChange[] = []
+  const patch: OutreachEngagementPatch = {}
+
+  const currentStatus: OutreachStatus = (row.status as OutreachStatus) ?? "queued"
+
+  // 1. Fill engagement timestamps (only when currently empty).
+  const stampFields: Array<["sent_at" | "opened_at" | "replied_at"]> = [
+    ["sent_at"],
+    ["opened_at"],
+    ["replied_at"],
+  ]
+  for (const [field] of stampFields) {
+    const existing = toDate(row[field])
+    const incoming = toDate(event[field])
+    if (existing == null && incoming != null) {
+      patch[field] = incoming
+      changes.push({
+        entity: ENTITY,
+        id: row.id,
+        field,
+        before: null,
+        after: incoming,
+      })
+    }
+  }
+
+  // 2. Derive the status implied by the event's signals.
+  const replied = toDate(event.replied_at) != null
+  const bounced = toDate(event.bounced_at) != null
+  const opened = toDate(event.opened_at) != null
+  const sent = toDate(event.sent_at) != null
+
+  let eventStatus: OutreachStatus | null = null
+  if (replied) {
+    eventStatus = "replied"
+  } else if (bounced) {
+    eventStatus = "bounced"
+  } else if (opened) {
+    eventStatus = "opened"
+  } else if (sent) {
+    eventStatus = "sent"
+  }
+
+  // 3. Advance status forward only.
+  let nextStatus = currentStatus
+  if (eventStatus != null && STATUS_RANK[eventStatus] > STATUS_RANK[currentStatus]) {
+    nextStatus = eventStatus
+    patch.status = nextStatus
+    changes.push({
+      entity: ENTITY,
+      id: row.id,
+      field: "status",
+      before: currentStatus,
+      after: nextStatus,
+    })
+  }
+
+  // 4. Bounce honesty flag — set whenever the event reports a bounce and the row
+  //    isn't already flagged. Independent of whether `status` ended up `bounced`
+  //    (a reply can outrank the bounce for status, but we still flag the signal).
+  if (bounced && row.bounce_unreliable !== true) {
+    patch.bounce_unreliable = true
+    changes.push({
+      entity: ENTITY,
+      id: row.id,
+      field: "bounce_unreliable",
+      before: row.bounce_unreliable ?? false,
+      after: true,
+    })
+  }
+
+  return { changes, patch, nextStatus }
+}

--- a/apps/backend/src/modules/marketing/outreach-list-lib.ts
+++ b/apps/backend/src/modules/marketing/outreach-list-lib.ts
@@ -1,0 +1,114 @@
+/**
+ * Pure list/filter/paginate for `marketing_outreach` (#659 slice 4 / PR-4b).
+ *
+ * Honours the `q` free-text search server-side and filters the FULL SET before
+ * paginating, so `count` is the total number of matched rows — NOT the per-page
+ * count. This is the recurring partner-search regression (memory #484: several
+ * `/partners/*` routes silently dropped `q`, and others paginated before filtering
+ * → wrong totals). Kept dependency-free so it's unit-testable without the DB.
+ *
+ * Field names mirror the SHIPPED model
+ * (`src/modules/marketing/models/marketing-outreach.ts`).
+ */
+
+import type { OutreachStatus } from "./diff-outreach-engagement"
+
+export type OutreachChannel = "email" | "whatsapp" | "manual"
+
+/** Subset of `marketing_outreach` columns the list view filters/searches on. */
+export type OutreachListRow = {
+  id: string
+  recipient_email?: string | null
+  recipient_name?: string | null
+  company?: string | null
+  campaign?: string | null
+  status?: OutreachStatus | null
+  channel?: OutreachChannel | null
+}
+
+export type OutreachListOptions = {
+  /** free-text — matched (case-insensitive substring) across recipient/company/campaign */
+  q?: string | null
+  status?: OutreachStatus | null
+  campaign?: string | null
+  channel?: OutreachChannel | null
+  offset?: number | null
+  limit?: number | null
+}
+
+export type OutreachListResult<T> = {
+  items: T[]
+  /** total rows matching the filters BEFORE pagination */
+  count: number
+  offset: number
+  limit: number
+}
+
+const DEFAULT_LIMIT = 50
+const MAX_LIMIT = 200
+
+function clampOffset(v: number | null | undefined): number {
+  const n = Number(v)
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 0
+}
+
+function clampLimit(v: number | null | undefined): number {
+  const n = Number(v)
+  if (!Number.isFinite(n) || n <= 0) {
+    return DEFAULT_LIMIT
+  }
+  return Math.min(Math.floor(n), MAX_LIMIT)
+}
+
+function matchesQuery(row: OutreachListRow, needle: string): boolean {
+  const haystack = [
+    row.recipient_email,
+    row.recipient_name,
+    row.company,
+    row.campaign,
+  ]
+  return haystack.some(
+    (field) => typeof field === "string" && field.toLowerCase().includes(needle)
+  )
+}
+
+/**
+ * Filter `rows` by the given options, then paginate. Input order is preserved
+ * (callers sort newest-first before calling). Returns matched `items` for the
+ * requested window plus the total matched `count`.
+ */
+export function filterAndPaginateOutreach<T extends OutreachListRow>(
+  rows: T[],
+  opts: OutreachListOptions = {}
+): OutreachListResult<T> {
+  const offset = clampOffset(opts.offset)
+  const limit = clampLimit(opts.limit)
+
+  const q = typeof opts.q === "string" ? opts.q.trim().toLowerCase() : ""
+  const status = opts.status ?? null
+  const campaign = opts.campaign ?? null
+  const channel = opts.channel ?? null
+
+  const matched = (rows ?? []).filter((row) => {
+    if (status && row.status !== status) {
+      return false
+    }
+    if (channel && row.channel !== channel) {
+      return false
+    }
+    if (campaign && row.campaign !== campaign) {
+      return false
+    }
+    if (q && !matchesQuery(row, q)) {
+      return false
+    }
+    return true
+  })
+
+  return {
+    items: matched.slice(offset, offset + limit),
+    count: matched.length,
+    offset,
+    limit,
+  }
+}


### PR DESCRIPTION
## #659 AI VP of Marketing — slice 4 (Winbacks / outreach), PR-4b

The highest-verifiability leaf of slice 4: two **dependency-free, unit-tested pure libs** for `marketing_outreach`. CI-safe, no container, no DB. Off `origin/main`, **independent** (slice-1 module + `marketing_outreach` model already on main).

### What ships
- **`modules/marketing/diff-outreach-engagement.ts`** — `diffOutreachEngagement(row, providerEvent)` → `{ changes: MaintenanceChange[], patch, nextStatus }`.
  - Forward-only status state machine: `queued→sent→opened→bounced→replied` (a reply outranks a bounce).
  - Fills `sent_at`/`opened_at`/`replied_at` only when currently null → **idempotent** (re-diff after apply = no changes).
  - **Honesty rule:** on a bounce signal sets `status=bounced` *and* `bounce_unreliable=true` — flags for the operator, never auto-suppresses.
  - Never throws (bad/NaN dates = no signal).
- **`modules/marketing/outreach-list-lib.ts`** — `filterAndPaginateOutreach(rows, opts)` honours `q` (case-insensitive across email/name/company/campaign) + `status`/`campaign`/`channel`, filters the **SET then paginates** so `count` = total matched (the #484 partner-search regression), clamps offset/limit.

### Alignment
Field names mirror the **shipped** `marketing_outreach` model (`campaign`, `bounce_unreliable`, `external_id`; status enum `queued|sent|opened|replied|bounced|unknown`) — **not** the slice-4 draft spec's `kind`/`bounce_reason`/`provider_message_id`. `MaintenanceChange` reused from the #457 maintenance-jobs registry so PR-4d's sync job consumes the diff directly.

### Tests
- `__tests__/diff-outreach-engagement.unit.spec.ts` (11) + `__tests__/outreach-list-lib.unit.spec.ts` (11) — **22 green** (`TEST_TYPE=unit`).
- Changed-file typecheck clean.

### Next in slice 4
- **PR-4c** — CRUD routes (`GET/POST /admin/marketing/outreach`, `/:id`, `DELETE`) + `logOutreachWorkflow` + per-file integration spec.
- **PR-4d** — provider-sync maintenance job (registry entry, mocked provider) consuming `diffOutreachEngagement`.
- **PR-4e** — `WinbacksView` UI (Playwright-gated, deferred). Spec: `apps/docs/marketing/04_MARKETING_OUTREACH_AND_WINBACKS_SPEC.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)