### PR TITLE
feat(marketing): outreach CRM CRUD routes + logOutreachWorkflow (#659 slice 4 · PR-4c) [stacked on #679]

### DIFF
--- a/apps/backend/integration-tests/http/outreach.http.spec.ts
+++ b/apps/backend/integration-tests/http/outreach.http.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * #659 slice 4 / PR-4c — marketing-outreach CRM CRUD routes.
+ *
+ * Exercises the live HTTP surface end-to-end against the shared test DB:
+ *   GET    /admin/marketing/outreach        (list + q/status/channel filters + paginate)
+ *   POST   /admin/marketing/outreach        (log, with email normalisation)
+ *   GET    /admin/marketing/outreach/:id     (retrieve / 404)
+ *   POST   /admin/marketing/outreach/:id     (update CRM fields)
+ *   DELETE /admin/marketing/outreach/:id     (remove / 404 thereafter)
+ *
+ * Each test seeds its own rows under a unique campaign so the assertions are
+ * insensitive to rows left over from other tests in the shared suite.
+ */
+
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(60 * 1000)
+
+setupSharedTestSuite(() => {
+  let headers: any
+  const { api, getContainer } = getSharedTestEnv()
+
+  beforeAll(async () => {
+    await createAdminUser(getContainer())
+    headers = await getAuthHeaders(api)
+  })
+
+  describe("POST /admin/marketing/outreach", () => {
+    it("creates a row and normalises the email to lower-case", async () => {
+      const res = await api.post(
+        "/admin/marketing/outreach",
+        {
+          recipient_email: "  Winback@Example.COM ",
+          recipient_name: "Win Back",
+          company: "Acme",
+          campaign: `create-${Date.now()}`,
+        },
+        headers
+      )
+
+      expect(res.status).toBe(201)
+      expect(res.data.outreach.recipient_email).toBe("winback@example.com")
+      expect(res.data.outreach.status).toBe("queued")
+      expect(res.data.outreach.channel).toBe("email")
+      expect(res.data.outreach.id).toBeTruthy()
+    })
+
+    it("400s when recipient_email is missing", async () => {
+      await expect(
+        api.post("/admin/marketing/outreach", { company: "NoEmail" }, headers)
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+  })
+
+  describe("GET /admin/marketing/outreach", () => {
+    it("filters by campaign + status and returns the matched total as count", async () => {
+      const campaign = `list-${Date.now()}`
+      await api.post(
+        "/admin/marketing/outreach",
+        { recipient_email: "a@example.com", campaign, status: "sent" },
+        headers
+      )
+      await api.post(
+        "/admin/marketing/outreach",
+        { recipient_email: "b@example.com", campaign, status: "queued" },
+        headers
+      )
+
+      const res = await api.get(
+        `/admin/marketing/outreach?campaign=${campaign}`,
+        headers
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.count).toBe(2)
+      expect(res.data.outreach).toHaveLength(2)
+
+      const sent = await api.get(
+        `/admin/marketing/outreach?campaign=${campaign}&status=sent`,
+        headers
+      )
+      expect(sent.data.count).toBe(1)
+      expect(sent.data.outreach[0].status).toBe("sent")
+    })
+
+    it("honours q free-text search across recipient/company", async () => {
+      const campaign = `q-${Date.now()}`
+      await api.post(
+        "/admin/marketing/outreach",
+        { recipient_email: "needle@example.com", company: "Findme Co", campaign },
+        headers
+      )
+      await api.post(
+        "/admin/marketing/outreach",
+        { recipient_email: "other@example.com", company: "Nope", campaign },
+        headers
+      )
+
+      const res = await api.get(
+        `/admin/marketing/outreach?campaign=${campaign}&q=findme`,
+        headers
+      )
+      expect(res.data.count).toBe(1)
+      expect(res.data.outreach[0].recipient_email).toBe("needle@example.com")
+    })
+
+    it("paginates with count = total matched (not the page size)", async () => {
+      const campaign = `page-${Date.now()}`
+      for (let i = 0; i < 3; i++) {
+        await api.post(
+          "/admin/marketing/outreach",
+          { recipient_email: `p${i}@example.com`, campaign },
+          headers
+        )
+      }
+      const res = await api.get(
+        `/admin/marketing/outreach?campaign=${campaign}&limit=2&offset=0`,
+        headers
+      )
+      expect(res.data.count).toBe(3)
+      expect(res.data.outreach).toHaveLength(2)
+      expect(res.data.limit).toBe(2)
+    })
+  })
+
+  describe("GET/POST/DELETE /admin/marketing/outreach/:id", () => {
+    it("retrieves, updates and deletes a single row", async () => {
+      const created = await api.post(
+        "/admin/marketing/outreach",
+        { recipient_email: "single@example.com", campaign: `crud-${Date.now()}` },
+        headers
+      )
+      const id = created.data.outreach.id
+
+      const got = await api.get(`/admin/marketing/outreach/${id}`, headers)
+      expect(got.status).toBe(200)
+      expect(got.data.outreach.id).toBe(id)
+
+      const updated = await api.post(
+        `/admin/marketing/outreach/${id}`,
+        { status: "replied", notes: "called back" },
+        headers
+      )
+      expect(updated.status).toBe(200)
+      expect(updated.data.outreach.status).toBe("replied")
+      expect(updated.data.outreach.notes).toBe("called back")
+
+      const del = await api.delete(`/admin/marketing/outreach/${id}`, headers)
+      expect(del.status).toBe(200)
+      expect(del.data.deleted).toBe(true)
+
+      await expect(
+        api.get(`/admin/marketing/outreach/${id}`, headers)
+      ).rejects.toMatchObject({ response: { status: 404 } })
+    })
+
+    it("404s retrieving an unknown id", async () => {
+      await expect(
+        api.get("/admin/marketing/outreach/mko_does_not_exist", headers)
+      ).rejects.toMatchObject({ response: { status: 404 } })
+    })
+  })
+})

--- a/apps/backend/src/api/admin/marketing/outreach/[id]/route.ts
+++ b/apps/backend/src/api/admin/marketing/outreach/[id]/route.ts
@@ -1,0 +1,81 @@
+/**
+ * GET    /admin/marketing/outreach/:id  — retrieve one outreach row
+ * POST   /admin/marketing/outreach/:id  — update CRM fields (status/notes/…)
+ * DELETE /admin/marketing/outreach/:id  — remove an outreach row
+ *
+ * Single-record CRUD mirrors `inbound-emails/[id]/route.ts`. POST (rather than
+ * PATCH) is used for update to stay consistent with the admin SDK conventions
+ * elsewhere in this codebase. Body is parsed manually with the route validator
+ * (no middleware — see the list route header).
+ */
+
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { MARKETING_MODULE } from "../../../../../modules/marketing"
+import { updateOutreachBodySchema } from "../validators"
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params
+  const service = req.scope.resolve(MARKETING_MODULE) as any
+
+  const outreach = await service.retrieveMarketingOutreach(id).catch(() => null)
+
+  if (!outreach) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Marketing outreach ${id} not found`
+    )
+  }
+
+  res.status(200).json({ outreach })
+}
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params
+  const service = req.scope.resolve(MARKETING_MODULE) as any
+
+  const parsed = updateOutreachBodySchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    res
+      .status(400)
+      .json({ message: parsed.error.issues[0]?.message ?? "Invalid body" })
+    return
+  }
+
+  const existing = await service
+    .retrieveMarketingOutreach(id)
+    .catch(() => null)
+  if (!existing) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Marketing outreach ${id} not found`
+    )
+  }
+
+  const updated = await service.updateMarketingOutreaches({
+    id,
+    ...parsed.data,
+  })
+
+  res.status(200).json({ outreach: updated })
+}
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params
+  const service = req.scope.resolve(MARKETING_MODULE) as any
+
+  const existing = await service
+    .retrieveMarketingOutreach(id)
+    .catch(() => null)
+  if (!existing) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Marketing outreach ${id} not found`
+    )
+  }
+
+  await service.deleteMarketingOutreaches(id)
+
+  res.status(200).json({ id, object: "marketing_outreach", deleted: true })
+}

--- a/apps/backend/src/api/admin/marketing/outreach/route.ts
+++ b/apps/backend/src/api/admin/marketing/outreach/route.ts
@@ -1,0 +1,73 @@
+/**
+ * GET  /admin/marketing/outreach   — list hand-crafted outbound (Winbacks/Exec)
+ * POST /admin/marketing/outreach   — log a new outreach row
+ *
+ * The marketing-outreach table is a low-volume CRM (manual exec/winback sends),
+ * so the list path fetches the rows newest-first and filters/paginates in-app
+ * via the pure `filterAndPaginateOutreach` helper (PR-4b). Filtering the FULL
+ * set before slicing keeps `count` the authoritative total-matched — the
+ * recurring `q`/pagination regression from memory #484.
+ *
+ * No middleware: query + body are parsed manually with the route validators so
+ * the `/admin/marketing` matcher stays off the shared middlewares list (mirrors
+ * the PR-3c read routes) and undeclared query params never 400 (#508).
+ */
+
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+
+import { MARKETING_MODULE } from "../../../../modules/marketing"
+import { filterAndPaginateOutreach } from "../../../../modules/marketing/outreach-list-lib"
+import { logOutreachWorkflow } from "../../../../workflows/marketing/log-outreach"
+import {
+  createOutreachBodySchema,
+  listOutreachQuerySchema,
+} from "./validators"
+
+export async function GET(
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+): Promise<void> {
+  const parsed = listOutreachQuerySchema.safeParse(req.query ?? {})
+  if (!parsed.success) {
+    res.status(400).json({ message: parsed.error.issues[0]?.message ?? "Invalid query" })
+    return
+  }
+  const opts = parsed.data
+
+  const service = req.scope.resolve(MARKETING_MODULE) as any
+
+  // Pull the full set newest-first; the pure helper does the filter+paginate.
+  const rows = await service.listMarketingOutreaches(
+    {},
+    { order: { created_at: "DESC" } }
+  )
+
+  const result = filterAndPaginateOutreach((rows as any[]) ?? [], opts)
+
+  res.status(200).json({
+    outreach: result.items,
+    count: result.count,
+    offset: result.offset,
+    limit: result.limit,
+  })
+}
+
+export async function POST(
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+): Promise<void> {
+  const parsed = createOutreachBodySchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    res.status(400).json({ message: parsed.error.issues[0]?.message ?? "Invalid body" })
+    return
+  }
+
+  const { result } = await logOutreachWorkflow(req.scope).run({
+    input: parsed.data,
+  })
+
+  res.status(201).json({ outreach: result })
+}

--- a/apps/backend/src/api/admin/marketing/outreach/validators.ts
+++ b/apps/backend/src/api/admin/marketing/outreach/validators.ts
@@ -1,0 +1,74 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * Validators for the marketing-outreach CRM routes (#659 slice 4 / PR-4c).
+ *
+ * These routes do NOT use `validateAndTransformBody`/`validateAndTransformQuery`
+ * middleware — the marketing read routes (PR-3c) parse manually to keep the
+ * `/admin/marketing` matcher off the shared `middlewares.ts` list (avoids the
+ * cross-PR matcher reconciliation churn). We mirror that here and parse with
+ * these schemas inside the handlers, so undeclared query params are simply
+ * ignored rather than producing a 400 (#508 watch-out).
+ */
+
+export const OUTREACH_STATUSES = [
+  "queued",
+  "sent",
+  "opened",
+  "replied",
+  "bounced",
+  "unknown",
+] as const
+
+export const OUTREACH_CHANNELS = ["email", "whatsapp", "manual"] as const
+
+// ── List query ───────────────────────────────────────────────────────────────
+export const listOutreachQuerySchema = z.object({
+  q: z.string().optional(),
+  status: z.enum(OUTREACH_STATUSES).optional(),
+  channel: z.enum(OUTREACH_CHANNELS).optional(),
+  campaign: z.string().optional(),
+  offset: z.preprocess(
+    (val) =>
+      val !== undefined && val !== null && val !== "" ? Number(val) : undefined,
+    z.number().int().min(0).default(0)
+  ),
+  limit: z.preprocess(
+    (val) =>
+      val !== undefined && val !== null && val !== "" ? Number(val) : undefined,
+    z.number().int().min(1).max(200).default(50)
+  ),
+})
+
+export type ListOutreachQuery = z.infer<typeof listOutreachQuerySchema>
+
+// ── Create body ──────────────────────────────────────────────────────────────
+export const createOutreachBodySchema = z.object({
+  recipient_email: z.string().min(1, "recipient_email is required"),
+  recipient_name: z.string().optional().nullable(),
+  company: z.string().optional().nullable(),
+  campaign: z.string().optional().nullable(),
+  channel: z.enum(OUTREACH_CHANNELS).optional(),
+  status: z.enum(OUTREACH_STATUSES).optional(),
+  notes: z.string().optional().nullable(),
+  external_id: z.string().optional().nullable(),
+})
+
+export type CreateOutreachBody = z.infer<typeof createOutreachBodySchema>
+
+// ── Update body ──────────────────────────────────────────────────────────────
+// Free-form CRM edits. Status transitions made via the UI are operator intent,
+// so unlike the engagement-sync state machine this allows any status value.
+export const updateOutreachBodySchema = z
+  .object({
+    recipient_name: z.string().optional().nullable(),
+    company: z.string().optional().nullable(),
+    campaign: z.string().optional().nullable(),
+    channel: z.enum(OUTREACH_CHANNELS).optional(),
+    status: z.enum(OUTREACH_STATUSES).optional(),
+    notes: z.string().optional().nullable(),
+    bounce_unreliable: z.boolean().optional(),
+  })
+  .strict()
+
+export type UpdateOutreachBody = z.infer<typeof updateOutreachBodySchema>

--- a/apps/backend/src/workflows/marketing/log-outreach.ts
+++ b/apps/backend/src/workflows/marketing/log-outreach.ts
@@ -1,0 +1,84 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+
+import { MARKETING_MODULE } from "../../modules/marketing"
+
+/**
+ * logOutreachWorkflow (#659 slice 4 / PR-4c).
+ *
+ * Persists a single hand-crafted outbound row into `marketing_outreach`
+ * (Winbacks / Exec outreach CRM). Mirrors the create-record workflow pattern
+ * used elsewhere (designs, inbound-emails): one step + a compensation that
+ * deletes the row if anything downstream fails.
+ *
+ * Normalisation happens HERE (not in the route) so every caller — route,
+ * future cron, provider-sync job — produces consistent rows:
+ *   - `recipient_email` is lower-cased + trimmed (matches the engagement-sync
+ *     lookup in `diff-outreach-engagement.ts`, which keys on the message id but
+ *     emails must still dedupe predictably).
+ *   - blank optional strings collapse to `null` so list filters stay clean.
+ */
+
+export type LogOutreachInput = {
+  recipient_email: string
+  recipient_name?: string | null
+  company?: string | null
+  campaign?: string | null
+  channel?: "email" | "whatsapp" | "manual"
+  status?: "queued" | "sent" | "opened" | "replied" | "bounced" | "unknown"
+  notes?: string | null
+  external_id?: string | null
+  sent_at?: Date | string | null
+}
+
+function blankToNull(v: string | null | undefined): string | null {
+  if (typeof v !== "string") {
+    return null
+  }
+  const trimmed = v.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+const logOutreachStep = createStep(
+  "log-outreach",
+  async (input: LogOutreachInput, { container }) => {
+    const service = container.resolve(MARKETING_MODULE) as any
+
+    const payload = {
+      recipient_email: input.recipient_email.trim().toLowerCase(),
+      recipient_name: blankToNull(input.recipient_name),
+      company: blankToNull(input.company),
+      campaign: blankToNull(input.campaign),
+      channel: input.channel ?? "email",
+      status: input.status ?? "queued",
+      notes: blankToNull(input.notes),
+      external_id: blankToNull(input.external_id),
+      sent_at: input.sent_at ?? null,
+    }
+
+    const created = await service.createMarketingOutreaches(payload)
+
+    return new StepResponse(created, created?.id)
+  },
+  async (id, { container }) => {
+    if (!id) {
+      return
+    }
+    const service = container.resolve(MARKETING_MODULE) as any
+    await service.deleteMarketingOutreaches(id)
+  }
+)
+
+export const logOutreachWorkflow = createWorkflow(
+  "log-outreach",
+  (input: LogOutreachInput) => {
+    const outreach = logOutreachStep(input)
+    return new WorkflowResponse(outreach)
+  }
+)
+
+export default logOutreachWorkflow


### PR DESCRIPTION
## #659 marketing slice 4 — PR-4c (CRM CRUD routes)

Builds the `/admin/marketing/outreach` HTTP surface on top of the PR-4b pure libs (#679).

### What
- **`workflows/marketing/log-outreach.ts`** — `logOutreachWorkflow`: one create step + delete compensation. Normalises `recipient_email` (trim + lower-case, matches the engagement-sync key space) and collapses blank optional strings to `null`.
- **`api/admin/marketing/outreach/route.ts`** — `GET` list (fetch newest-first, then `filterAndPaginateOutreach` → `count` = total matched, the #484 regression guard) + `POST` create.
- **`api/admin/marketing/outreach/[id]/route.ts`** — `GET` / `POST` update / `DELETE` single, mirroring `inbound-emails/[id]`; 404 on unknown id.
- **`api/admin/marketing/outreach/validators.ts`** — zod schemas parsed manually in-handler (no middleware), so the `/admin/marketing` matcher stays off `middlewares.ts` (mirrors PR-3c read routes) and undeclared query params don't 400 (#508).
- **`integration-tests/http/outreach.http.spec.ts`** — 7 HTTP tests.

### Decisions
- `owner_user_id` stamping (mentioned in the chunk-8 handoff) was **dropped** — the SHIPPED `marketing_outreach` model has no such column, and we don't smuggle load-bearing state into `metadata`.
- Update uses `POST /:id` (not `PATCH`) for SDK consistency; it allows any status value (operator intent), unlike the forward-only engagement state machine.

### Verify
`pnpm test:integration:http:shared -- integration-tests/http/outreach.http.spec.ts` → **7/7 green**. Changed-file typecheck clean (new files add 0 errors).

### Merge order
**Stacked on #679 (PR-4b) — merge #679 first.** Once #679 lands, rebase onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)