### PR TITLE
feat(marketing): outreach engagement sync route + maintenance job (#659 slice 4 · PR-4d) [stacked on #680]

### DIFF
--- a/apps/backend/integration-tests/http/outreach-sync.http.spec.ts
+++ b/apps/backend/integration-tests/http/outreach-sync.http.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * #659 slice 4 / PR-4d — POST /admin/marketing/outreach/sync.
+ *
+ * Exercises the live engagement-reconciliation route against the shared test DB:
+ *   - dry-run previews the change set without writing,
+ *   - apply advances status + fills timestamps,
+ *   - re-applying the same events is idempotent (zero changes),
+ *   - events match by external_id, and unmatched events are counted not fatal,
+ *   - a missing `events` array 400s.
+ *
+ * Rows are seeded via the CRM create route under a unique campaign so the
+ * assertions are insensitive to rows left by other suites (shared DB TRUNCATEs
+ * between files, not between it()s).
+ */
+
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(60 * 1000)
+
+setupSharedTestSuite(() => {
+  let headers: any
+  const { api, getContainer } = getSharedTestEnv()
+
+  beforeAll(async () => {
+    await createAdminUser(getContainer())
+    headers = await getAuthHeaders(api)
+  })
+
+  const seedRow = async (over: Record<string, unknown> = {}) => {
+    const res = await api.post(
+      "/admin/marketing/outreach",
+      {
+        recipient_email: `sync-${Date.now()}-${Math.random()}@example.com`,
+        campaign: `sync-${Date.now()}`,
+        external_id: `msg-${Date.now()}-${Math.random()}`,
+        ...over,
+      },
+      headers
+    )
+    expect(res.status).toBe(201)
+    return res.data.outreach
+  }
+
+  describe("POST /admin/marketing/outreach/sync", () => {
+    it("previews on dry-run without writing", async () => {
+      const row = await seedRow()
+
+      const preview = await api.post(
+        "/admin/marketing/outreach/sync",
+        {
+          dry_run: true,
+          events: [{ id: row.id, opened_at: "2026-06-23T10:00:00.000Z" }],
+        },
+        headers
+      )
+
+      expect(preview.status).toBe(200)
+      expect(preview.data.dry_run).toBe(true)
+      expect(preview.data.applied).toBe(false)
+      expect(preview.data.matched).toBe(1)
+      expect(preview.data.changes.length).toBeGreaterThan(0)
+
+      // No write happened.
+      const after = await api.get(
+        `/admin/marketing/outreach/${row.id}`,
+        headers
+      )
+      expect(after.data.outreach.status).toBe("queued")
+      expect(after.data.outreach.opened_at).toBeFalsy()
+    })
+
+    it("applies engagement and is idempotent on re-apply", async () => {
+      const row = await seedRow()
+      const events = [{ id: row.id, opened_at: "2026-06-23T10:00:00.000Z" }]
+
+      const applied = await api.post(
+        "/admin/marketing/outreach/sync",
+        { dry_run: false, events },
+        headers
+      )
+      expect(applied.status).toBe(200)
+      expect(applied.data.applied).toBe(true)
+
+      const after = await api.get(
+        `/admin/marketing/outreach/${row.id}`,
+        headers
+      )
+      expect(after.data.outreach.status).toBe("opened")
+      expect(after.data.outreach.opened_at).toBeTruthy()
+
+      // Same events again → nothing to do.
+      const again = await api.post(
+        "/admin/marketing/outreach/sync",
+        { dry_run: false, events },
+        headers
+      )
+      expect(again.data.applied).toBe(false)
+      expect(again.data.changes).toHaveLength(0)
+    })
+
+    it("matches by external_id and counts unmatched events", async () => {
+      const ext = `ext-${Date.now()}`
+      const row = await seedRow({ external_id: ext })
+
+      const res = await api.post(
+        "/admin/marketing/outreach/sync",
+        {
+          dry_run: false,
+          events: [
+            { external_id: ext, replied_at: "2026-06-23T12:00:00.000Z" },
+            { external_id: "does-not-exist" },
+          ],
+        },
+        headers
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.data.matched).toBe(1)
+      expect(res.data.unmatched_events).toBe(1)
+
+      const after = await api.get(
+        `/admin/marketing/outreach/${row.id}`,
+        headers
+      )
+      expect(after.data.outreach.status).toBe("replied")
+    })
+
+    it("400s when events is missing", async () => {
+      await expect(
+        api.post("/admin/marketing/outreach/sync", { dry_run: true }, headers)
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+  })
+})

--- a/apps/backend/src/api/admin/marketing/outreach/sync/route.ts
+++ b/apps/backend/src/api/admin/marketing/outreach/sync/route.ts
@@ -1,0 +1,94 @@
+/**
+ * POST /admin/marketing/outreach/sync — reconcile a batch of provider engagement
+ * events against the persisted `marketing_outreach` rows (#659 slice 4 / PR-4d).
+ *
+ * The body carries normalized provider message-events (e.g. relayed from a Resend
+ * webhook): each targets a row by `id` or by the provider `external_id`, and the
+ * forward-only state machine (`diffOutreachEngagement` → `reconcileOutreachBatch`)
+ * advances status + fills engagement timestamps idempotently. A bounce signal sets
+ * `bounce_unreliable=true` (flag, never auto-suppress).
+ *
+ * Same dry-run/apply contract as the ops maintenance jobs: `dry_run` defaults to
+ * true and previews the change set without writing; `dry_run=false` persists.
+ *
+ * No middleware — body is parsed manually with the route validator so the
+ * `/admin/marketing` matcher stays off the shared middlewares list (mirrors the
+ * sibling outreach routes; undeclared params never 400, #508).
+ */
+
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+
+import { MARKETING_MODULE } from "../../../../../modules/marketing"
+import {
+  reconcileOutreachBatch,
+  summarizeOutreachSync,
+  type OutreachSyncEvent,
+  type OutreachSyncRow,
+} from "../../../../../modules/marketing/outreach-sync-lib"
+import { syncOutreachBodySchema } from "../validators"
+
+const JOB_ID = "sync-marketing-outreach-engagement"
+
+export async function POST(
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+): Promise<void> {
+  const parsed = syncOutreachBodySchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    res
+      .status(400)
+      .json({ message: parsed.error.issues[0]?.message ?? "Invalid body" })
+    return
+  }
+  const { dry_run, events } = parsed.data
+
+  const service = req.scope.resolve(MARKETING_MODULE) as any
+
+  // Load only the rows the events can address (by id or external_id).
+  const ids = Array.from(
+    new Set(events.map((e) => e.id).filter((v): v is string => !!v))
+  )
+  const exts = Array.from(
+    new Set(events.map((e) => e.external_id).filter((v): v is string => !!v))
+  )
+
+  const byId = new Map<string, OutreachSyncRow>()
+  if (ids.length) {
+    const rows = (await service.listMarketingOutreaches({ id: ids })) as any[]
+    for (const r of rows ?? []) byId.set(r.id, r)
+  }
+  if (exts.length) {
+    const rows = (await service.listMarketingOutreaches({
+      external_id: exts,
+    })) as any[]
+    for (const r of rows ?? []) byId.set(r.id, r)
+  }
+  const rows = Array.from(byId.values())
+
+  const result = reconcileOutreachBatch(rows, events as OutreachSyncEvent[])
+
+  if (!dry_run && result.items.length > 0) {
+    for (const item of result.items) {
+      await service.updateMarketingOutreaches({ id: item.id, ...item.patch })
+    }
+  }
+
+  res.status(200).json({
+    job_id: JOB_ID,
+    dry_run,
+    applied: !dry_run && result.items.length > 0,
+    summary: summarizeOutreachSync({
+      dry_run,
+      eventsReceived: events.length,
+      matchedRows: result.matchedRowIds.length,
+      changedRows: result.items.length,
+      totalChanges: result.changes.length,
+    }),
+    changes: result.changes,
+    matched: result.matchedRowIds.length,
+    unmatched_events: result.unmatchedEvents,
+  })
+}

--- a/apps/backend/src/api/admin/marketing/outreach/validators.ts
+++ b/apps/backend/src/api/admin/marketing/outreach/validators.ts
@@ -72,3 +72,28 @@ export const updateOutreachBodySchema = z
   .strict()
 
 export type UpdateOutreachBody = z.infer<typeof updateOutreachBodySchema>
+
+// ── Engagement sync body (PR-4d) ─────────────────────────────────────────────
+// A batch of normalized provider message-events (e.g. relayed from a Resend
+// webhook) reconciled against the persisted rows via the forward-only state
+// machine. Each event targets a row by `id` or by the provider `external_id`;
+// timestamps are accepted as ISO strings. `dry_run` defaults to true (preview).
+const outreachSyncEventSchema = z
+  .object({
+    id: z.string().optional().nullable(),
+    external_id: z.string().optional().nullable(),
+    sent_at: z.string().optional().nullable(),
+    opened_at: z.string().optional().nullable(),
+    replied_at: z.string().optional().nullable(),
+    bounced_at: z.string().optional().nullable(),
+  })
+  .refine((e) => !!(e.id || e.external_id), {
+    message: "each event needs an id or external_id",
+  })
+
+export const syncOutreachBodySchema = z.object({
+  dry_run: z.boolean().optional().default(true),
+  events: z.array(outreachSyncEventSchema).min(1, "events is required"),
+})
+
+export type SyncOutreachBody = z.infer<typeof syncOutreachBodySchema>

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -27,6 +27,14 @@ import {
   resolvePartnerLandingBase,
 } from "../../../../workflows/google_merchant/steps/resolve-partner-landing-base"
 import { syncProductToGoogleWorkflow } from "../../../../workflows/google_merchant/workflows/sync-product-to-google"
+import { MARKETING_MODULE } from "../../../../modules/marketing"
+import {
+  reconcileOutreachBatch,
+  selectSyncableOutreach,
+  summarizeOutreachSync,
+  type OutreachSyncEvent,
+  type OutreachSyncRow,
+} from "../../../../modules/marketing/outreach-sync-lib"
 
 /**
  * Admin "data-plumbing" maintenance jobs (#457 / roadmap #33).
@@ -3196,6 +3204,142 @@ export const backfillOrderPersonsJob: MaintenanceJob = {
   },
 }
 
+/**
+ * Hard cap on the marketing-outreach engagement sync scan. Each scanned row may
+ * drive a provider lookup + one column write, so we bound the per-request blast
+ * radius. Bigger sweeps raise `limit` across chunked calls.
+ */
+export const MAX_OUTREACH_SYNC_SCAN = 2000
+
+const syncOutreachParamsSchema = z.object({
+  /** Restrict the sync to one campaign. */
+  campaign: z.string().min(1).optional(),
+  /** Max candidate outreach rows to scan in one call. */
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_OUTREACH_SYNC_SCAN)
+    .optional()
+    .default(500),
+})
+
+/**
+ * Optional provider adapter the deployment can register on the container under
+ * `OUTREACH_SYNC_PROVIDER_KEY` to pull engagement events (e.g. a Resend
+ * message-events client). When absent the job is a safe no-op — it never invents
+ * engagement. The `POST /admin/marketing/outreach/sync` route is the push path
+ * (webhook relays the events directly) and needs no provider.
+ */
+export const OUTREACH_SYNC_PROVIDER_KEY = "marketingOutreachSyncProvider"
+
+export type OutreachSyncProvider = {
+  fetchEvents: (
+    rows: OutreachSyncRow[]
+  ) => Promise<OutreachSyncEvent[]> | OutreachSyncEvent[]
+}
+
+function resolveOutreachSyncProvider(
+  container: any
+): OutreachSyncProvider | null {
+  try {
+    const provider = container.resolve(OUTREACH_SYNC_PROVIDER_KEY)
+    return provider && typeof provider.fetchEvents === "function"
+      ? (provider as OutreachSyncProvider)
+      : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * #659 slice 4 / PR-4d — pull engagement events for non-terminal outreach rows
+ * from the (optional) provider adapter and reconcile them forward-only. Inherits
+ * the Data Plumbing console + ops_audit history for free via the registry.
+ */
+export const syncMarketingOutreachEngagementJob: MaintenanceJob = {
+  id: "sync-marketing-outreach-engagement",
+  label: "Sync marketing outreach engagement",
+  description:
+    `Reconcile marketing-outreach rows against an email-provider engagement feed (#659). Scans non-terminal rows that carry a provider message id (external_id), pulls their latest sent/opened/replied/bounced signals from the registered provider adapter, and advances each row forward-only (fills engagement timestamps, advances status, flags bounces as unreliable — never auto-suppresses). Dry-run (default) previews the change set without writing; apply persists. Idempotent. Requires a provider adapter registered as '${OUTREACH_SYNC_PROVIDER_KEY}'; without one the job is a safe no-op (the push route POST /admin/marketing/outreach/sync reconciles events posted directly). Optionally scope to one campaign. Scans up to 'limit' rows per call (default 500, max ${MAX_OUTREACH_SYNC_SCAN}).`,
+  params: [
+    {
+      name: "campaign",
+      type: "string",
+      required: false,
+      description: "Restrict the sync to one campaign (default: all)",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max candidate rows to scan in one call (default 500, max ${MAX_OUTREACH_SYNC_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }) => {
+    const parsed = syncOutreachParamsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { campaign, limit } = parsed.data
+
+    const service: any = container.resolve(MARKETING_MODULE)
+    const filters: Record<string, unknown> = {}
+    if (campaign) filters.campaign = campaign
+
+    const allRows = (await service.listMarketingOutreaches(filters, {
+      order: { created_at: "DESC" },
+      take: limit,
+    })) as OutreachSyncRow[]
+    const candidates = selectSyncableOutreach(allRows ?? [])
+
+    const provider = resolveOutreachSyncProvider(container)
+    if (!provider) {
+      return {
+        job_id: syncMarketingOutreachEngagementJob.id,
+        dry_run,
+        applied: false,
+        summary: summarizeOutreachSync({
+          dry_run,
+          eventsReceived: 0,
+          matchedRows: 0,
+          changedRows: 0,
+          totalChanges: 0,
+          providerConfigured: false,
+        }),
+        changes: [],
+      }
+    }
+
+    const events = (await provider.fetchEvents(candidates)) ?? []
+    const result = reconcileOutreachBatch(candidates, events)
+
+    if (!dry_run && result.items.length > 0) {
+      for (const item of result.items) {
+        await service.updateMarketingOutreaches({ id: item.id, ...item.patch })
+      }
+    }
+
+    return {
+      job_id: syncMarketingOutreachEngagementJob.id,
+      dry_run,
+      applied: !dry_run && result.items.length > 0,
+      summary: summarizeOutreachSync({
+        dry_run,
+        eventsReceived: events.length,
+        matchedRows: result.matchedRowIds.length,
+        changedRows: result.items.length,
+        totalChanges: result.changes.length,
+        providerConfigured: true,
+      }),
+      changes: result.changes,
+    }
+  },
+}
+
 export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   recalculateDesignCostJob,
   recalculateDesignCostBulkJob,
@@ -3211,6 +3355,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   backfillPartnerOrderFeesJob,
   backfillStatsPanelWindowJob,
   backfillOrderPersonsJob,
+  syncMarketingOutreachEngagementJob,
 ]
 
 export const getMaintenanceJob = (id: string): MaintenanceJob | undefined =>

--- a/apps/backend/src/modules/marketing/__tests__/outreach-sync-lib.unit.spec.ts
+++ b/apps/backend/src/modules/marketing/__tests__/outreach-sync-lib.unit.spec.ts
@@ -1,0 +1,172 @@
+import {
+  reconcileOutreachBatch,
+  selectSyncableOutreach,
+  summarizeOutreachSync,
+  type OutreachSyncEvent,
+  type OutreachSyncRow,
+} from "../outreach-sync-lib"
+
+/**
+ * #659 slice 4 / PR-4d — batch engagement reconciliation (pure).
+ * Verifies matching (id + external_id), forward-only folding, idempotency,
+ * candidate selection, and summary wording without a DB or provider.
+ */
+
+const row = (over: Partial<OutreachSyncRow> = {}): OutreachSyncRow => ({
+  id: "or_1",
+  status: "queued",
+  sent_at: null,
+  opened_at: null,
+  replied_at: null,
+  bounce_unreliable: null,
+  external_id: "msg_1",
+  ...over,
+})
+
+describe("reconcileOutreachBatch", () => {
+  it("matches by row id, advances status and fills timestamps", () => {
+    const rows = [row()]
+    const events: OutreachSyncEvent[] = [
+      { id: "or_1", opened_at: "2026-06-23T10:00:00.000Z" },
+    ]
+
+    const res = reconcileOutreachBatch(rows, events)
+
+    expect(res.matchedRowIds).toEqual(["or_1"])
+    expect(res.unmatchedEvents).toBe(0)
+    expect(res.items).toHaveLength(1)
+    expect(res.items[0].patch.status).toBe("opened")
+    expect(res.items[0].patch.opened_at).toBeInstanceOf(Date)
+    // status + opened_at = 2 field changes
+    expect(res.changes).toHaveLength(2)
+  })
+
+  it("matches by external_id when the event carries no row id", () => {
+    const rows = [row({ id: "or_9", external_id: "resend_abc" })]
+    const events: OutreachSyncEvent[] = [
+      { external_id: "resend_abc", sent_at: "2026-06-23T09:00:00.000Z" },
+    ]
+
+    const res = reconcileOutreachBatch(rows, events)
+
+    expect(res.matchedRowIds).toEqual(["or_9"])
+    expect(res.items[0].patch.status).toBe("sent")
+  })
+
+  it("counts events that match no row without throwing", () => {
+    const res = reconcileOutreachBatch(
+      [row()],
+      [{ id: "nope" }, { external_id: "missing" }]
+    )
+    expect(res.unmatchedEvents).toBe(2)
+    expect(res.items).toHaveLength(0)
+    expect(res.changes).toHaveLength(0)
+  })
+
+  it("is idempotent — re-applying the same event yields zero changes", () => {
+    const already = row({
+      status: "opened",
+      sent_at: new Date("2026-06-23T09:00:00.000Z"),
+      opened_at: new Date("2026-06-23T10:00:00.000Z"),
+    })
+    const res = reconcileOutreachBatch(already ? [already] : [], [
+      { id: "or_1", opened_at: "2026-06-23T10:00:00.000Z" },
+    ])
+    expect(res.items).toHaveLength(0)
+    expect(res.changes).toHaveLength(0)
+  })
+
+  it("folds multiple events for one row forward-only", () => {
+    const rows = [row()]
+    const events: OutreachSyncEvent[] = [
+      { id: "or_1", sent_at: "2026-06-23T08:00:00.000Z" },
+      { id: "or_1", opened_at: "2026-06-23T09:00:00.000Z" },
+      { id: "or_1", replied_at: "2026-06-23T10:00:00.000Z" },
+    ]
+
+    const res = reconcileOutreachBatch(rows, events)
+
+    expect(res.items).toHaveLength(1)
+    expect(res.items[0].nextStatus).toBe("replied")
+    expect(res.items[0].patch.status).toBe("replied")
+    expect(res.items[0].patch.sent_at).toBeInstanceOf(Date)
+    expect(res.items[0].patch.opened_at).toBeInstanceOf(Date)
+    expect(res.items[0].patch.replied_at).toBeInstanceOf(Date)
+  })
+
+  it("flags a bounce as unreliable", () => {
+    const res = reconcileOutreachBatch(
+      [row({ status: "sent", sent_at: new Date() })],
+      [{ id: "or_1", bounced_at: "2026-06-23T11:00:00.000Z" }]
+    )
+    expect(res.items[0].patch.status).toBe("bounced")
+    expect(res.items[0].patch.bounce_unreliable).toBe(true)
+  })
+})
+
+describe("selectSyncableOutreach", () => {
+  it("keeps non-terminal rows with an external_id", () => {
+    const rows = [
+      row({ id: "a", status: "sent", external_id: "m_a" }),
+      row({ id: "b", status: "queued", external_id: "m_b" }),
+    ]
+    expect(selectSyncableOutreach(rows).map((r) => r.id)).toEqual(["a", "b"])
+  })
+
+  it("drops rows without an external_id and already-replied rows", () => {
+    const rows = [
+      row({ id: "no_ext", external_id: null }),
+      row({ id: "blank_ext", external_id: "   " }),
+      row({ id: "replied", status: "replied", external_id: "m_r" }),
+    ]
+    expect(selectSyncableOutreach(rows)).toHaveLength(0)
+  })
+})
+
+describe("summarizeOutreachSync", () => {
+  it("flags an unconfigured provider", () => {
+    expect(
+      summarizeOutreachSync({
+        dry_run: true,
+        eventsReceived: 0,
+        matchedRows: 0,
+        changedRows: 0,
+        totalChanges: 0,
+        providerConfigured: false,
+      })
+    ).toMatch(/not configured/i)
+  })
+
+  it("reports a no-op when nothing changed", () => {
+    expect(
+      summarizeOutreachSync({
+        dry_run: true,
+        eventsReceived: 3,
+        matchedRows: 2,
+        changedRows: 0,
+        totalChanges: 0,
+      })
+    ).toMatch(/No engagement changes/i)
+  })
+
+  it("distinguishes dry-run preview from applied", () => {
+    expect(
+      summarizeOutreachSync({
+        dry_run: true,
+        eventsReceived: 2,
+        matchedRows: 2,
+        changedRows: 2,
+        totalChanges: 4,
+      })
+    ).toMatch(/Would update/i)
+    expect(
+      summarizeOutreachSync({
+        dry_run: false,
+        eventsReceived: 2,
+        matchedRows: 2,
+        changedRows: 2,
+        totalChanges: 4,
+      })
+    ).toMatch(/^Updated/i)
+  })
+})

--- a/apps/backend/src/modules/marketing/outreach-sync-lib.ts
+++ b/apps/backend/src/modules/marketing/outreach-sync-lib.ts
@@ -1,0 +1,222 @@
+import type { MaintenanceChange } from "../../api/admin/ops/maintenance-jobs/registry"
+import {
+  diffOutreachEngagement,
+  type OutreachEngagementPatch,
+  type OutreachEngagementRow,
+  type OutreachProviderEvent,
+  type OutreachStatus,
+} from "./diff-outreach-engagement"
+
+/**
+ * Batch engagement reconciliation for `marketing_outreach` (#659 slice 4 / PR-4d).
+ *
+ * `diffOutreachEngagement` (PR-4b) reconciles ONE row against ONE provider event.
+ * This pure layer fans that out across a batch: it matches a set of normalized
+ * provider events to the persisted rows (by row id, falling back to the provider
+ * `external_id`), folds multiple events for the same row forward-only, and returns
+ * the minimal per-row patches + a flat change set for the dry-run/apply contract.
+ *
+ * Kept dependency-free so BOTH consumers stay verifiable without booting the DB,
+ * the workflow engine, or a live email provider:
+ *   - the `POST /admin/marketing/outreach/sync` route (events posted in the body,
+ *     e.g. from a Resend webhook relay), and
+ *   - the `sync-marketing-outreach-engagement` maintenance job (events pulled from
+ *     an optional provider client).
+ */
+
+/** A normalized provider event addressed to a specific outreach row. */
+export type OutreachSyncEvent = OutreachProviderEvent & {
+  /** Target the row directly by its `marketing_outreach` id … */
+  id?: string | null
+  /** … or by the provider message id persisted on the row. */
+  external_id?: string | null
+}
+
+/** The row columns this reconciliation reads (superset of the engagement row). */
+export type OutreachSyncRow = OutreachEngagementRow & {
+  external_id?: string | null
+}
+
+/** A single row that changed, with its cumulative patch + per-row change set. */
+export type OutreachReconcileItem = {
+  id: string
+  patch: OutreachEngagementPatch
+  changes: MaintenanceChange[]
+  nextStatus: OutreachStatus
+}
+
+export type OutreachReconcileResult = {
+  /** Rows that actually changed (empty patch rows are omitted). */
+  items: OutreachReconcileItem[]
+  /** Flat change set across every changed row (dry-run/apply payload). */
+  changes: MaintenanceChange[]
+  /** Distinct row ids an event matched (whether or not they changed). */
+  matchedRowIds: string[]
+  /** Events that matched no row (unknown id/external_id). */
+  unmatchedEvents: number
+}
+
+/** Status from which nothing can advance — a definitive reply. */
+function isTerminal(status: OutreachStatus | null | undefined): boolean {
+  return status === "replied"
+}
+
+/**
+ * Build the id → row + external_id → row lookup. Row id takes precedence; a blank
+ * external_id is never indexed (so it can't accidentally match a null event key).
+ */
+function indexRows(rows: OutreachSyncRow[]): {
+  byId: Map<string, OutreachSyncRow>
+  byExternalId: Map<string, OutreachSyncRow>
+} {
+  const byId = new Map<string, OutreachSyncRow>()
+  const byExternalId = new Map<string, OutreachSyncRow>()
+  for (const row of rows) {
+    if (row?.id) byId.set(row.id, row)
+    const ext = typeof row?.external_id === "string" ? row.external_id.trim() : ""
+    if (ext) byExternalId.set(ext, row)
+  }
+  return { byId, byExternalId }
+}
+
+function resolveTarget(
+  event: OutreachSyncEvent,
+  idx: ReturnType<typeof indexRows>
+): OutreachSyncRow | null {
+  const id = typeof event.id === "string" ? event.id.trim() : ""
+  if (id && idx.byId.has(id)) return idx.byId.get(id)!
+  const ext =
+    typeof event.external_id === "string" ? event.external_id.trim() : ""
+  if (ext && idx.byExternalId.has(ext)) return idx.byExternalId.get(ext)!
+  return null
+}
+
+/** Merge an engagement patch into a working row so later events fold forward. */
+function applyPatchToWorking(
+  working: OutreachSyncRow,
+  patch: OutreachEngagementPatch
+): OutreachSyncRow {
+  return {
+    ...working,
+    ...(patch.status !== undefined ? { status: patch.status } : {}),
+    ...(patch.sent_at !== undefined ? { sent_at: patch.sent_at } : {}),
+    ...(patch.opened_at !== undefined ? { opened_at: patch.opened_at } : {}),
+    ...(patch.replied_at !== undefined ? { replied_at: patch.replied_at } : {}),
+    ...(patch.bounce_unreliable !== undefined
+      ? { bounce_unreliable: patch.bounce_unreliable }
+      : {}),
+  }
+}
+
+/**
+ * Reconcile a batch of provider events against the given rows.
+ *
+ * - Events addressing the same row are folded forward-only (a second event can
+ *   only advance the row further, never downgrade it — `diffOutreachEngagement`
+ *   guarantees monotonicity).
+ * - Events that match no row are counted (`unmatchedEvents`) but never error.
+ * - Re-running with the same events after an apply yields zero changes
+ *   (idempotent), because the persisted timestamps/status already satisfy them.
+ *
+ * Never throws — bad dates are treated as "no signal" by the underlying diff.
+ */
+export function reconcileOutreachBatch(
+  rows: OutreachSyncRow[],
+  events: OutreachSyncEvent[]
+): OutreachReconcileResult {
+  const idx = indexRows(rows ?? [])
+  // Working copies so multiple events per row accumulate.
+  const working = new Map<string, OutreachSyncRow>()
+  // Accumulated patch + changes per row id.
+  const accPatch = new Map<string, OutreachEngagementPatch>()
+  const accChanges = new Map<string, MaintenanceChange[]>()
+  const accNext = new Map<string, OutreachStatus>()
+  const matched = new Set<string>()
+  let unmatchedEvents = 0
+
+  for (const event of events ?? []) {
+    const target = resolveTarget(event, idx)
+    if (!target) {
+      unmatchedEvents++
+      continue
+    }
+    const id = target.id
+    matched.add(id)
+    const current = working.get(id) ?? target
+    const diff = diffOutreachEngagement(current, event)
+    accNext.set(id, diff.nextStatus)
+    if (diff.changes.length === 0) {
+      if (!working.has(id)) working.set(id, current)
+      continue
+    }
+    working.set(id, applyPatchToWorking(current, diff.patch))
+    accPatch.set(id, { ...(accPatch.get(id) ?? {}), ...diff.patch })
+    accChanges.set(id, [...(accChanges.get(id) ?? []), ...diff.changes])
+  }
+
+  const items: OutreachReconcileItem[] = []
+  const changes: MaintenanceChange[] = []
+  for (const [id, patch] of accPatch) {
+    const rowChanges = accChanges.get(id) ?? []
+    if (rowChanges.length === 0) continue
+    items.push({
+      id,
+      patch,
+      changes: rowChanges,
+      nextStatus: accNext.get(id) ?? "queued",
+    })
+    changes.push(...rowChanges)
+  }
+
+  return {
+    items,
+    changes,
+    matchedRowIds: Array.from(matched),
+    unmatchedEvents,
+  }
+}
+
+/**
+ * Select the rows worth syncing: a stable provider message id (`external_id`) to
+ * look up, and not already in the terminal `replied` state (nothing can advance
+ * a reply). Pure so the maintenance job's candidate scan stays testable.
+ */
+export function selectSyncableOutreach(
+  rows: OutreachSyncRow[]
+): OutreachSyncRow[] {
+  return (rows ?? []).filter((row) => {
+    const ext =
+      typeof row?.external_id === "string" ? row.external_id.trim() : ""
+    return !!ext && !isTerminal(row?.status ?? "queued")
+  })
+}
+
+/** Human-facing one-liner for the dry-run/apply result + ops audit log. */
+export function summarizeOutreachSync(opts: {
+  dry_run: boolean
+  eventsReceived: number
+  matchedRows: number
+  changedRows: number
+  totalChanges: number
+  providerConfigured?: boolean
+}): string {
+  const {
+    dry_run,
+    eventsReceived,
+    matchedRows,
+    changedRows,
+    totalChanges,
+    providerConfigured,
+  } = opts
+
+  if (providerConfigured === false) {
+    return "Marketing outreach sync provider not configured — nothing to reconcile."
+  }
+
+  if (changedRows === 0) {
+    return `No engagement changes from ${eventsReceived} event(s) (${matchedRows} row(s) matched, already up to date).`
+  }
+
+  const verb = dry_run ? "Would update" : "Updated"
+  return `${verb} ${changedRows} outreach row(s) — ${totalChanges} field change(s) from ${eventsReceived} event(s) (${matchedRows} matched).`
+}


### PR DESCRIPTION
Part of #659 (AI VP of Marketing) — slice 4 (Winbacks / `marketing_outreach`), **PR-4d**.

**Stacked on #680** (base `feat/659-outreach-crud-routes`) which is itself stacked on #679. **Merge order: #679 → #680 → this.**

## What
Reconcile `marketing_outreach` engagement against an email-provider feed using the forward-only state machine `diffOutreachEngagement` (PR-4b, #679). Two consumers share one pure core:

- **Pure** `src/modules/marketing/outreach-sync-lib.ts`
  - `reconcileOutreachBatch(rows, events)` — match each event to a row by `id` (fallback provider `external_id`), fold multiple events per row forward-only (a later event can only advance status, never downgrade), idempotent (re-running after apply → 0 changes), unmatched events counted not fatal.
  - `selectSyncableOutreach(rows)` — candidates = non-terminal (`status != replied`) with an `external_id`.
  - `summarizeOutreachSync(...)` — dry-run/apply/no-op/provider-unconfigured wording.
- **Push path** `POST /admin/marketing/outreach/sync` — reconcile events posted in the body (e.g. a Resend webhook relay). `dry_run` defaults to true (preview, no write); `dry_run=false` persists. Manual-parse validator, no middleware (keeps `/admin/marketing` off `middlewares.ts`, #508).
- **Pull path** `sync-marketing-outreach-engagement` maintenance job — scans candidate rows and reconciles against an **optional** provider adapter resolved from the container (`OUTREACH_SYNC_PROVIDER_KEY`). When no adapter is registered it's a safe no-op (never invents engagement). Inherits the Data Plumbing console + `ops_audit` history for free via the registry.

Bounce signals set `bounce_unreliable=true` (honesty flag) and never auto-suppress.

## Tests
- 11 unit (`outreach-sync-lib.unit.spec.ts`): match by id/external_id, forward-only folding, idempotency, bounce flag, candidate selection, summary wording.
- 4 integration (`outreach-sync.http.spec.ts`): dry-run no-write, apply + idempotent re-apply, external_id match + unmatched count, 400 on missing `events`.
- Typecheck clean (no new errors; the pre-existing unrelated socials/whatsapp/orders tsc hits are untouched).

## Verify
```
cd apps/backend
TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules npx jest src/modules/marketing/__tests__/outreach-sync-lib.unit.spec.ts
pnpm test:integration:http:shared -- integration-tests/http/outreach-sync.http.spec.ts
```

## Notes / decisions
- The provider adapter (real Resend message-events client) is intentionally **not** wired here — Resend reports opens/replies via webhooks, so the push route is the immediately-useful path; the job is the guarded scaffold for a future scheduled pull. Registering an adapter under `OUTREACH_SYNC_PROVIDER_KEY` activates the job with zero further changes.
- Registry edit (`MAINTENANCE_JOBS` array) does not conflict with #679/#680 (they don't touch the registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)