### PR TITLE
feat(#659): recover stacked children #673/#677/#680/#681 (squash-stack drain)

### DIFF
--- a/apps/backend/integration-tests/http/marketing-generate-ideas-email.spec.ts
+++ b/apps/backend/integration-tests/http/marketing-generate-ideas-email.spec.ts
@@ -1,0 +1,110 @@
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { MARKETING_MODULE } from "../../src/modules/marketing"
+import { generateIdeasEmail } from "../../src/workflows/marketing/generate-ideas-email"
+
+jest.setTimeout(60 * 1000)
+
+/**
+ * #659 slice 2, PR-2 — the generate-ideas-email orchestration with a STUBBED
+ * LLM (CI never calls a live model). We seed `marketing_metric_snapshot` rows,
+ * run `generateIdeasEmail` with an injected `aiGenerate`, and assert:
+ *   - a `marketing_ideas_log` row is persisted BEFORE any send (sent=false)
+ *   - clean {TOKEN}-only output passes the guard
+ *   - a stray-literal output fails the guard and triggers exactly one regenerate
+ *   - `prompt_snapshot` (the ground-truth fed in) is stored for replay
+ *
+ * NOTE: metric_keys are DIGIT-FREE on purpose — the guard's Layer B extracts
+ * numeric literals from the RAW output, so a digit inside a {TOKEN} name (e.g.
+ * "{Q3_GMV}") would be mis-read as a stray number. The daily-refresh job
+ * (slice 3) likewise emits digit-free metric_keys.
+ */
+setupSharedTestSuite(() => {
+  const { getContainer } = getSharedTestEnv()
+
+  describe("generateIdeasEmail (stubbed LLM)", () => {
+    it("persists a guard-passing ideas log without sending", async () => {
+      const container = getContainer()
+      const svc: any = container.resolve(MARKETING_MODULE)
+      // Far-future date so these rows sort newest-first regardless of what
+      // other suites seeded into the shared DB.
+      const day = new Date("2031-03-01T00:00:00.000Z")
+      await svc.createMarketingMetricSnapshots({
+        metric_key: "promo_gmv",
+        value: 184320,
+        unit: "INR",
+        captured_for_date: day,
+        source: "manual",
+        delta_dod: 4.5,
+      })
+      await svc.createMarketingMetricSnapshots({
+        metric_key: "promo_conv",
+        value: 0.034,
+        unit: "ratio",
+        captured_for_date: day,
+        source: "manual",
+      })
+
+      // Stub references ground-truth ONLY by {TOKEN}; no stray numbers.
+      const stub = async () =>
+        "Today, lift {PROMO_GMV} (trend {PROMO_GMV_DELTA_DOD}): launch a flash " +
+        "sale, spotlight a partner, and nudge carts toward {PROMO_CONV}."
+
+      const res = await generateIdeasEmail(container, {
+        aiGenerate: stub,
+        oneGoal: "Grow platform GMV.",
+        now: new Date("2031-03-01T12:00:00.000Z"),
+      })
+
+      expect(res.skipped).toBe(false)
+      expect(res.generated).toBe(true)
+      expect(res.guard_passed).toBe(true)
+      expect(res.regenerated).toBe(false)
+      expect(res.log_id).toBeTruthy()
+      // placeholders were substituted with display values in the final copy
+      expect(res.output_text).toContain("₹1,84,320")
+      expect(res.output_text).not.toContain("{PROMO_GMV}")
+
+      const [rows] = await svc.listAndCountMarketingIdeasLogs({ id: res.log_id })
+      expect(rows[0].guard_passed).toBe(true)
+      expect(rows[0].sent).toBe(false) // persist-before-send
+      expect(rows[0].prompt_snapshot.one_goal).toBe("Grow platform GMV.")
+      expect(rows[0].prompt_snapshot.date_ist).toBe("2031-03-01")
+    })
+
+    it("fails the guard on a stray literal and regenerates exactly once", async () => {
+      const container = getContainer()
+      const svc: any = container.resolve(MARKETING_MODULE)
+      const day = new Date("2031-03-02T00:00:00.000Z")
+      await svc.createMarketingMetricSnapshots({
+        metric_key: "pushday_gmv",
+        value: 50000,
+        unit: "INR",
+        captured_for_date: day,
+        source: "manual",
+      })
+
+      let calls = 0
+      // Both attempts emit a stray "47%" with no matching ground-truth → fail-closed.
+      const stub = async () => {
+        calls++
+        return "Push hard today: a 47% discount on {PUSHDAY_GMV} should move volume."
+      }
+
+      const res = await generateIdeasEmail(container, {
+        aiGenerate: stub,
+        oneGoal: "Grow platform GMV.",
+        now: new Date("2031-03-02T12:00:00.000Z"),
+      })
+
+      expect(calls).toBe(2) // generate + one regenerate
+      expect(res.regenerated).toBe(true)
+      expect(res.guard_passed).toBe(false)
+
+      const [rows] = await svc.listAndCountMarketingIdeasLogs({ id: res.log_id })
+      expect(rows[0].guard_passed).toBe(false)
+      expect(rows[0].regenerated).toBe(true)
+      expect(rows[0].sent).toBe(false)
+      expect(Array.isArray(rows[0].guard_failures)).toBe(true)
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/outreach-sync.http.spec.ts
+++ b/apps/backend/integration-tests/http/outreach-sync.http.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * #659 slice 4 / PR-4d — POST /admin/marketing/outreach/sync.
+ *
+ * Exercises the live engagement-reconciliation route against the shared test DB:
+ *   - dry-run previews the change set without writing,
+ *   - apply advances status + fills timestamps,
+ *   - re-applying the same events is idempotent (zero changes),
+ *   - events match by external_id, and unmatched events are counted not fatal,
+ *   - a missing `events` array 400s.
+ *
+ * Rows are seeded via the CRM create route under a unique campaign so the
+ * assertions are insensitive to rows left by other suites (shared DB TRUNCATEs
+ * between files, not between it()s).
+ */
+
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(60 * 1000)
+
+setupSharedTestSuite(() => {
+  let headers: any
+  const { api, getContainer } = getSharedTestEnv()
+
+  beforeAll(async () => {
+    await createAdminUser(getContainer())
+    headers = await getAuthHeaders(api)
+  })
+
+  const seedRow = async (over: Record<string, unknown> = {}) => {
+    const res = await api.post(
+      "/admin/marketing/outreach",
+      {
+        recipient_email: `sync-${Date.now()}-${Math.random()}@example.com`,
+        campaign: `sync-${Date.now()}`,
+        external_id: `msg-${Date.now()}-${Math.random()}`,
+        ...over,
+      },
+      headers
+    )
+    expect(res.status).toBe(201)
+    return res.data.outreach
+  }
+
+  describe("POST /admin/marketing/outreach/sync", () => {
+    it("previews on dry-run without writing", async () => {
+      const row = await seedRow()
+
+      const preview = await api.post(
+        "/admin/marketing/outreach/sync",
+        {
+          dry_run: true,
+          events: [{ id: row.id, opened_at: "2026-06-23T10:00:00.000Z" }],
+        },
+        headers
+      )
+
+      expect(preview.status).toBe(200)
+      expect(preview.data.dry_run).toBe(true)
+      expect(preview.data.applied).toBe(false)
+      expect(preview.data.matched).toBe(1)
+      expect(preview.data.changes.length).toBeGreaterThan(0)
+
+      // No write happened.
+      const after = await api.get(
+        `/admin/marketing/outreach/${row.id}`,
+        headers
+      )
+      expect(after.data.outreach.status).toBe("queued")
+      expect(after.data.outreach.opened_at).toBeFalsy()
+    })
+
+    it("applies engagement and is idempotent on re-apply", async () => {
+      const row = await seedRow()
+      const events = [{ id: row.id, opened_at: "2026-06-23T10:00:00.000Z" }]
+
+      const applied = await api.post(
+        "/admin/marketing/outreach/sync",
+        { dry_run: false, events },
+        headers
+      )
+      expect(applied.status).toBe(200)
+      expect(applied.data.applied).toBe(true)
+
+      const after = await api.get(
+        `/admin/marketing/outreach/${row.id}`,
+        headers
+      )
+      expect(after.data.outreach.status).toBe("opened")
+      expect(after.data.outreach.opened_at).toBeTruthy()
+
+      // Same events again → nothing to do.
+      const again = await api.post(
+        "/admin/marketing/outreach/sync",
+        { dry_run: false, events },
+        headers
+      )
+      expect(again.data.applied).toBe(false)
+      expect(again.data.changes).toHaveLength(0)
+    })
+
+    it("matches by external_id and counts unmatched events", async () => {
+      const ext = `ext-${Date.now()}`
+      const row = await seedRow({ external_id: ext })
+
+      const res = await api.post(
+        "/admin/marketing/outreach/sync",
+        {
+          dry_run: false,
+          events: [
+            { external_id: ext, replied_at: "2026-06-23T12:00:00.000Z" },
+            { external_id: "does-not-exist" },
+          ],
+        },
+        headers
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.data.matched).toBe(1)
+      expect(res.data.unmatched_events).toBe(1)
+
+      const after = await api.get(
+        `/admin/marketing/outreach/${row.id}`,
+        headers
+      )
+      expect(after.data.outreach.status).toBe("replied")
+    })
+
+    it("400s when events is missing", async () => {
+      await expect(
+        api.post("/admin/marketing/outreach/sync", { dry_run: true }, headers)
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/outreach.http.spec.ts
+++ b/apps/backend/integration-tests/http/outreach.http.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * #659 slice 4 / PR-4c — marketing-outreach CRM CRUD routes.
+ *
+ * Exercises the live HTTP surface end-to-end against the shared test DB:
+ *   GET    /admin/marketing/outreach        (list + q/status/channel filters + paginate)
+ *   POST   /admin/marketing/outreach        (log, with email normalisation)
+ *   GET    /admin/marketing/outreach/:id     (retrieve / 404)
+ *   POST   /admin/marketing/outreach/:id     (update CRM fields)
+ *   DELETE /admin/marketing/outreach/:id     (remove / 404 thereafter)
+ *
+ * Each test seeds its own rows under a unique campaign so the assertions are
+ * insensitive to rows left over from other tests in the shared suite.
+ */
+
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(60 * 1000)
+
+setupSharedTestSuite(() => {
+  let headers: any
+  const { api, getContainer } = getSharedTestEnv()
+
+  beforeAll(async () => {
+    await createAdminUser(getContainer())
+    headers = await getAuthHeaders(api)
+  })
+
+  describe("POST /admin/marketing/outreach", () => {
+    it("creates a row and normalises the email to lower-case", async () => {
+      const res = await api.post(
+        "/admin/marketing/outreach",
+        {
+          recipient_email: "  Winback@Example.COM ",
+          recipient_name: "Win Back",
+          company: "Acme",
+          campaign: `create-${Date.now()}`,
+        },
+        headers
+      )
+
+      expect(res.status).toBe(201)
+      expect(res.data.outreach.recipient_email).toBe("winback@example.com")
+      expect(res.data.outreach.status).toBe("queued")
+      expect(res.data.outreach.channel).toBe("email")
+      expect(res.data.outreach.id).toBeTruthy()
+    })
+
+    it("400s when recipient_email is missing", async () => {
+      await expect(
+        api.post("/admin/marketing/outreach", { company: "NoEmail" }, headers)
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+  })
+
+  describe("GET /admin/marketing/outreach", () => {
+    it("filters by campaign + status and returns the matched total as count", async () => {
+      const campaign = `list-${Date.now()}`
+      await api.post(
+        "/admin/marketing/outreach",
+        { recipient_email: "a@example.com", campaign, status: "sent" },
+        headers
+      )
+      await api.post(
+        "/admin/marketing/outreach",
+        { recipient_email: "b@example.com", campaign, status: "queued" },
+        headers
+      )
+
+      const res = await api.get(
+        `/admin/marketing/outreach?campaign=${campaign}`,
+        headers
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.count).toBe(2)
+      expect(res.data.outreach).toHaveLength(2)
+
+      const sent = await api.get(
+        `/admin/marketing/outreach?campaign=${campaign}&status=sent`,
+        headers
+      )
+      expect(sent.data.count).toBe(1)
+      expect(sent.data.outreach[0].status).toBe("sent")
+    })
+
+    it("honours q free-text search across recipient/company", async () => {
+      const campaign = `q-${Date.now()}`
+      await api.post(
+        "/admin/marketing/outreach",
+        { recipient_email: "needle@example.com", company: "Findme Co", campaign },
+        headers
+      )
+      await api.post(
+        "/admin/marketing/outreach",
+        { recipient_email: "other@example.com", company: "Nope", campaign },
+        headers
+      )
+
+      const res = await api.get(
+        `/admin/marketing/outreach?campaign=${campaign}&q=findme`,
+        headers
+      )
+      expect(res.data.count).toBe(1)
+      expect(res.data.outreach[0].recipient_email).toBe("needle@example.com")
+    })
+
+    it("paginates with count = total matched (not the page size)", async () => {
+      const campaign = `page-${Date.now()}`
+      for (let i = 0; i < 3; i++) {
+        await api.post(
+          "/admin/marketing/outreach",
+          { recipient_email: `p${i}@example.com`, campaign },
+          headers
+        )
+      }
+      const res = await api.get(
+        `/admin/marketing/outreach?campaign=${campaign}&limit=2&offset=0`,
+        headers
+      )
+      expect(res.data.count).toBe(3)
+      expect(res.data.outreach).toHaveLength(2)
+      expect(res.data.limit).toBe(2)
+    })
+  })
+
+  describe("GET/POST/DELETE /admin/marketing/outreach/:id", () => {
+    it("retrieves, updates and deletes a single row", async () => {
+      const created = await api.post(
+        "/admin/marketing/outreach",
+        { recipient_email: "single@example.com", campaign: `crud-${Date.now()}` },
+        headers
+      )
+      const id = created.data.outreach.id
+
+      const got = await api.get(`/admin/marketing/outreach/${id}`, headers)
+      expect(got.status).toBe(200)
+      expect(got.data.outreach.id).toBe(id)
+
+      const updated = await api.post(
+        `/admin/marketing/outreach/${id}`,
+        { status: "replied", notes: "called back" },
+        headers
+      )
+      expect(updated.status).toBe(200)
+      expect(updated.data.outreach.status).toBe("replied")
+      expect(updated.data.outreach.notes).toBe("called back")
+
+      const del = await api.delete(`/admin/marketing/outreach/${id}`, headers)
+      expect(del.status).toBe(200)
+      expect(del.data.deleted).toBe(true)
+
+      await expect(
+        api.get(`/admin/marketing/outreach/${id}`, headers)
+      ).rejects.toMatchObject({ response: { status: 404 } })
+    })
+
+    it("404s retrieving an unknown id", async () => {
+      await expect(
+        api.get("/admin/marketing/outreach/mko_does_not_exist", headers)
+      ).rejects.toMatchObject({ response: { status: 404 } })
+    })
+  })
+})

--- a/apps/backend/src/api/admin/marketing/outreach/[id]/route.ts
+++ b/apps/backend/src/api/admin/marketing/outreach/[id]/route.ts
@@ -1,0 +1,81 @@
+/**
+ * GET    /admin/marketing/outreach/:id  — retrieve one outreach row
+ * POST   /admin/marketing/outreach/:id  — update CRM fields (status/notes/…)
+ * DELETE /admin/marketing/outreach/:id  — remove an outreach row
+ *
+ * Single-record CRUD mirrors `inbound-emails/[id]/route.ts`. POST (rather than
+ * PATCH) is used for update to stay consistent with the admin SDK conventions
+ * elsewhere in this codebase. Body is parsed manually with the route validator
+ * (no middleware — see the list route header).
+ */
+
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { MARKETING_MODULE } from "../../../../../modules/marketing"
+import { updateOutreachBodySchema } from "../validators"
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params
+  const service = req.scope.resolve(MARKETING_MODULE) as any
+
+  const outreach = await service.retrieveMarketingOutreach(id).catch(() => null)
+
+  if (!outreach) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Marketing outreach ${id} not found`
+    )
+  }
+
+  res.status(200).json({ outreach })
+}
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params
+  const service = req.scope.resolve(MARKETING_MODULE) as any
+
+  const parsed = updateOutreachBodySchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    res
+      .status(400)
+      .json({ message: parsed.error.issues[0]?.message ?? "Invalid body" })
+    return
+  }
+
+  const existing = await service
+    .retrieveMarketingOutreach(id)
+    .catch(() => null)
+  if (!existing) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Marketing outreach ${id} not found`
+    )
+  }
+
+  const updated = await service.updateMarketingOutreaches({
+    id,
+    ...parsed.data,
+  })
+
+  res.status(200).json({ outreach: updated })
+}
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params
+  const service = req.scope.resolve(MARKETING_MODULE) as any
+
+  const existing = await service
+    .retrieveMarketingOutreach(id)
+    .catch(() => null)
+  if (!existing) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Marketing outreach ${id} not found`
+    )
+  }
+
+  await service.deleteMarketingOutreaches(id)
+
+  res.status(200).json({ id, object: "marketing_outreach", deleted: true })
+}

--- a/apps/backend/src/api/admin/marketing/outreach/route.ts
+++ b/apps/backend/src/api/admin/marketing/outreach/route.ts
@@ -1,0 +1,73 @@
+/**
+ * GET  /admin/marketing/outreach   — list hand-crafted outbound (Winbacks/Exec)
+ * POST /admin/marketing/outreach   — log a new outreach row
+ *
+ * The marketing-outreach table is a low-volume CRM (manual exec/winback sends),
+ * so the list path fetches the rows newest-first and filters/paginates in-app
+ * via the pure `filterAndPaginateOutreach` helper (PR-4b). Filtering the FULL
+ * set before slicing keeps `count` the authoritative total-matched — the
+ * recurring `q`/pagination regression from memory #484.
+ *
+ * No middleware: query + body are parsed manually with the route validators so
+ * the `/admin/marketing` matcher stays off the shared middlewares list (mirrors
+ * the PR-3c read routes) and undeclared query params never 400 (#508).
+ */
+
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+
+import { MARKETING_MODULE } from "../../../../modules/marketing"
+import { filterAndPaginateOutreach } from "../../../../modules/marketing/outreach-list-lib"
+import { logOutreachWorkflow } from "../../../../workflows/marketing/log-outreach"
+import {
+  createOutreachBodySchema,
+  listOutreachQuerySchema,
+} from "./validators"
+
+export async function GET(
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+): Promise<void> {
+  const parsed = listOutreachQuerySchema.safeParse(req.query ?? {})
+  if (!parsed.success) {
+    res.status(400).json({ message: parsed.error.issues[0]?.message ?? "Invalid query" })
+    return
+  }
+  const opts = parsed.data
+
+  const service = req.scope.resolve(MARKETING_MODULE) as any
+
+  // Pull the full set newest-first; the pure helper does the filter+paginate.
+  const rows = await service.listMarketingOutreaches(
+    {},
+    { order: { created_at: "DESC" } }
+  )
+
+  const result = filterAndPaginateOutreach((rows as any[]) ?? [], opts)
+
+  res.status(200).json({
+    outreach: result.items,
+    count: result.count,
+    offset: result.offset,
+    limit: result.limit,
+  })
+}
+
+export async function POST(
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+): Promise<void> {
+  const parsed = createOutreachBodySchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    res.status(400).json({ message: parsed.error.issues[0]?.message ?? "Invalid body" })
+    return
+  }
+
+  const { result } = await logOutreachWorkflow(req.scope).run({
+    input: parsed.data,
+  })
+
+  res.status(201).json({ outreach: result })
+}

--- a/apps/backend/src/api/admin/marketing/outreach/sync/route.ts
+++ b/apps/backend/src/api/admin/marketing/outreach/sync/route.ts
@@ -1,0 +1,94 @@
+/**
+ * POST /admin/marketing/outreach/sync — reconcile a batch of provider engagement
+ * events against the persisted `marketing_outreach` rows (#659 slice 4 / PR-4d).
+ *
+ * The body carries normalized provider message-events (e.g. relayed from a Resend
+ * webhook): each targets a row by `id` or by the provider `external_id`, and the
+ * forward-only state machine (`diffOutreachEngagement` → `reconcileOutreachBatch`)
+ * advances status + fills engagement timestamps idempotently. A bounce signal sets
+ * `bounce_unreliable=true` (flag, never auto-suppress).
+ *
+ * Same dry-run/apply contract as the ops maintenance jobs: `dry_run` defaults to
+ * true and previews the change set without writing; `dry_run=false` persists.
+ *
+ * No middleware — body is parsed manually with the route validator so the
+ * `/admin/marketing` matcher stays off the shared middlewares list (mirrors the
+ * sibling outreach routes; undeclared params never 400, #508).
+ */
+
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+
+import { MARKETING_MODULE } from "../../../../../modules/marketing"
+import {
+  reconcileOutreachBatch,
+  summarizeOutreachSync,
+  type OutreachSyncEvent,
+  type OutreachSyncRow,
+} from "../../../../../modules/marketing/outreach-sync-lib"
+import { syncOutreachBodySchema } from "../validators"
+
+const JOB_ID = "sync-marketing-outreach-engagement"
+
+export async function POST(
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+): Promise<void> {
+  const parsed = syncOutreachBodySchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    res
+      .status(400)
+      .json({ message: parsed.error.issues[0]?.message ?? "Invalid body" })
+    return
+  }
+  const { dry_run, events } = parsed.data
+
+  const service = req.scope.resolve(MARKETING_MODULE) as any
+
+  // Load only the rows the events can address (by id or external_id).
+  const ids = Array.from(
+    new Set(events.map((e) => e.id).filter((v): v is string => !!v))
+  )
+  const exts = Array.from(
+    new Set(events.map((e) => e.external_id).filter((v): v is string => !!v))
+  )
+
+  const byId = new Map<string, OutreachSyncRow>()
+  if (ids.length) {
+    const rows = (await service.listMarketingOutreaches({ id: ids })) as any[]
+    for (const r of rows ?? []) byId.set(r.id, r)
+  }
+  if (exts.length) {
+    const rows = (await service.listMarketingOutreaches({
+      external_id: exts,
+    })) as any[]
+    for (const r of rows ?? []) byId.set(r.id, r)
+  }
+  const rows = Array.from(byId.values())
+
+  const result = reconcileOutreachBatch(rows, events as OutreachSyncEvent[])
+
+  if (!dry_run && result.items.length > 0) {
+    for (const item of result.items) {
+      await service.updateMarketingOutreaches({ id: item.id, ...item.patch })
+    }
+  }
+
+  res.status(200).json({
+    job_id: JOB_ID,
+    dry_run,
+    applied: !dry_run && result.items.length > 0,
+    summary: summarizeOutreachSync({
+      dry_run,
+      eventsReceived: events.length,
+      matchedRows: result.matchedRowIds.length,
+      changedRows: result.items.length,
+      totalChanges: result.changes.length,
+    }),
+    changes: result.changes,
+    matched: result.matchedRowIds.length,
+    unmatched_events: result.unmatchedEvents,
+  })
+}

--- a/apps/backend/src/api/admin/marketing/outreach/validators.ts
+++ b/apps/backend/src/api/admin/marketing/outreach/validators.ts
@@ -1,0 +1,74 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * Validators for the marketing-outreach CRM routes (#659 slice 4 / PR-4c).
+ *
+ * These routes do NOT use `validateAndTransformBody`/`validateAndTransformQuery`
+ * middleware — the marketing read routes (PR-3c) parse manually to keep the
+ * `/admin/marketing` matcher off the shared `middlewares.ts` list (avoids the
+ * cross-PR matcher reconciliation churn). We mirror that here and parse with
+ * these schemas inside the handlers, so undeclared query params are simply
+ * ignored rather than producing a 400 (#508 watch-out).
+ */
+
+export const OUTREACH_STATUSES = [
+  "queued",
+  "sent",
+  "opened",
+  "replied",
+  "bounced",
+  "unknown",
+] as const
+
+export const OUTREACH_CHANNELS = ["email", "whatsapp", "manual"] as const
+
+// ── List query ───────────────────────────────────────────────────────────────
+export const listOutreachQuerySchema = z.object({
+  q: z.string().optional(),
+  status: z.enum(OUTREACH_STATUSES).optional(),
+  channel: z.enum(OUTREACH_CHANNELS).optional(),
+  campaign: z.string().optional(),
+  offset: z.preprocess(
+    (val) =>
+      val !== undefined && val !== null && val !== "" ? Number(val) : undefined,
+    z.number().int().min(0).default(0)
+  ),
+  limit: z.preprocess(
+    (val) =>
+      val !== undefined && val !== null && val !== "" ? Number(val) : undefined,
+    z.number().int().min(1).max(200).default(50)
+  ),
+})
+
+export type ListOutreachQuery = z.infer<typeof listOutreachQuerySchema>
+
+// ── Create body ──────────────────────────────────────────────────────────────
+export const createOutreachBodySchema = z.object({
+  recipient_email: z.string().min(1, "recipient_email is required"),
+  recipient_name: z.string().optional().nullable(),
+  company: z.string().optional().nullable(),
+  campaign: z.string().optional().nullable(),
+  channel: z.enum(OUTREACH_CHANNELS).optional(),
+  status: z.enum(OUTREACH_STATUSES).optional(),
+  notes: z.string().optional().nullable(),
+  external_id: z.string().optional().nullable(),
+})
+
+export type CreateOutreachBody = z.infer<typeof createOutreachBodySchema>
+
+// ── Update body ──────────────────────────────────────────────────────────────
+// Free-form CRM edits. Status transitions made via the UI are operator intent,
+// so unlike the engagement-sync state machine this allows any status value.
+export const updateOutreachBodySchema = z
+  .object({
+    recipient_name: z.string().optional().nullable(),
+    company: z.string().optional().nullable(),
+    campaign: z.string().optional().nullable(),
+    channel: z.enum(OUTREACH_CHANNELS).optional(),
+    status: z.enum(OUTREACH_STATUSES).optional(),
+    notes: z.string().optional().nullable(),
+    bounce_unreliable: z.boolean().optional(),
+  })
+  .strict()
+
+export type UpdateOutreachBody = z.infer<typeof updateOutreachBodySchema>

--- a/apps/backend/src/api/admin/marketing/outreach/validators.ts
+++ b/apps/backend/src/api/admin/marketing/outreach/validators.ts
@@ -72,3 +72,28 @@ export const updateOutreachBodySchema = z
   .strict()
 
 export type UpdateOutreachBody = z.infer<typeof updateOutreachBodySchema>
+
+// ── Engagement sync body (PR-4d) ─────────────────────────────────────────────
+// A batch of normalized provider message-events (e.g. relayed from a Resend
+// webhook) reconciled against the persisted rows via the forward-only state
+// machine. Each event targets a row by `id` or by the provider `external_id`;
+// timestamps are accepted as ISO strings. `dry_run` defaults to true (preview).
+const outreachSyncEventSchema = z
+  .object({
+    id: z.string().optional().nullable(),
+    external_id: z.string().optional().nullable(),
+    sent_at: z.string().optional().nullable(),
+    opened_at: z.string().optional().nullable(),
+    replied_at: z.string().optional().nullable(),
+    bounced_at: z.string().optional().nullable(),
+  })
+  .refine((e) => !!(e.id || e.external_id), {
+    message: "each event needs an id or external_id",
+  })
+
+export const syncOutreachBodySchema = z.object({
+  dry_run: z.boolean().optional().default(true),
+  events: z.array(outreachSyncEventSchema).min(1, "events is required"),
+})
+
+export type SyncOutreachBody = z.infer<typeof syncOutreachBodySchema>

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -27,6 +27,14 @@ import {
   resolvePartnerLandingBase,
 } from "../../../../workflows/google_merchant/steps/resolve-partner-landing-base"
 import { syncProductToGoogleWorkflow } from "../../../../workflows/google_merchant/workflows/sync-product-to-google"
+import { MARKETING_MODULE } from "../../../../modules/marketing"
+import {
+  reconcileOutreachBatch,
+  selectSyncableOutreach,
+  summarizeOutreachSync,
+  type OutreachSyncEvent,
+  type OutreachSyncRow,
+} from "../../../../modules/marketing/outreach-sync-lib"
 
 /**
  * Admin "data-plumbing" maintenance jobs (#457 / roadmap #33).
@@ -3196,6 +3204,142 @@ export const backfillOrderPersonsJob: MaintenanceJob = {
   },
 }
 
+/**
+ * Hard cap on the marketing-outreach engagement sync scan. Each scanned row may
+ * drive a provider lookup + one column write, so we bound the per-request blast
+ * radius. Bigger sweeps raise `limit` across chunked calls.
+ */
+export const MAX_OUTREACH_SYNC_SCAN = 2000
+
+const syncOutreachParamsSchema = z.object({
+  /** Restrict the sync to one campaign. */
+  campaign: z.string().min(1).optional(),
+  /** Max candidate outreach rows to scan in one call. */
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_OUTREACH_SYNC_SCAN)
+    .optional()
+    .default(500),
+})
+
+/**
+ * Optional provider adapter the deployment can register on the container under
+ * `OUTREACH_SYNC_PROVIDER_KEY` to pull engagement events (e.g. a Resend
+ * message-events client). When absent the job is a safe no-op — it never invents
+ * engagement. The `POST /admin/marketing/outreach/sync` route is the push path
+ * (webhook relays the events directly) and needs no provider.
+ */
+export const OUTREACH_SYNC_PROVIDER_KEY = "marketingOutreachSyncProvider"
+
+export type OutreachSyncProvider = {
+  fetchEvents: (
+    rows: OutreachSyncRow[]
+  ) => Promise<OutreachSyncEvent[]> | OutreachSyncEvent[]
+}
+
+function resolveOutreachSyncProvider(
+  container: any
+): OutreachSyncProvider | null {
+  try {
+    const provider = container.resolve(OUTREACH_SYNC_PROVIDER_KEY)
+    return provider && typeof provider.fetchEvents === "function"
+      ? (provider as OutreachSyncProvider)
+      : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * #659 slice 4 / PR-4d — pull engagement events for non-terminal outreach rows
+ * from the (optional) provider adapter and reconcile them forward-only. Inherits
+ * the Data Plumbing console + ops_audit history for free via the registry.
+ */
+export const syncMarketingOutreachEngagementJob: MaintenanceJob = {
+  id: "sync-marketing-outreach-engagement",
+  label: "Sync marketing outreach engagement",
+  description:
+    `Reconcile marketing-outreach rows against an email-provider engagement feed (#659). Scans non-terminal rows that carry a provider message id (external_id), pulls their latest sent/opened/replied/bounced signals from the registered provider adapter, and advances each row forward-only (fills engagement timestamps, advances status, flags bounces as unreliable — never auto-suppresses). Dry-run (default) previews the change set without writing; apply persists. Idempotent. Requires a provider adapter registered as '${OUTREACH_SYNC_PROVIDER_KEY}'; without one the job is a safe no-op (the push route POST /admin/marketing/outreach/sync reconciles events posted directly). Optionally scope to one campaign. Scans up to 'limit' rows per call (default 500, max ${MAX_OUTREACH_SYNC_SCAN}).`,
+  params: [
+    {
+      name: "campaign",
+      type: "string",
+      required: false,
+      description: "Restrict the sync to one campaign (default: all)",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max candidate rows to scan in one call (default 500, max ${MAX_OUTREACH_SYNC_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }) => {
+    const parsed = syncOutreachParamsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { campaign, limit } = parsed.data
+
+    const service: any = container.resolve(MARKETING_MODULE)
+    const filters: Record<string, unknown> = {}
+    if (campaign) filters.campaign = campaign
+
+    const allRows = (await service.listMarketingOutreaches(filters, {
+      order: { created_at: "DESC" },
+      take: limit,
+    })) as OutreachSyncRow[]
+    const candidates = selectSyncableOutreach(allRows ?? [])
+
+    const provider = resolveOutreachSyncProvider(container)
+    if (!provider) {
+      return {
+        job_id: syncMarketingOutreachEngagementJob.id,
+        dry_run,
+        applied: false,
+        summary: summarizeOutreachSync({
+          dry_run,
+          eventsReceived: 0,
+          matchedRows: 0,
+          changedRows: 0,
+          totalChanges: 0,
+          providerConfigured: false,
+        }),
+        changes: [],
+      }
+    }
+
+    const events = (await provider.fetchEvents(candidates)) ?? []
+    const result = reconcileOutreachBatch(candidates, events)
+
+    if (!dry_run && result.items.length > 0) {
+      for (const item of result.items) {
+        await service.updateMarketingOutreaches({ id: item.id, ...item.patch })
+      }
+    }
+
+    return {
+      job_id: syncMarketingOutreachEngagementJob.id,
+      dry_run,
+      applied: !dry_run && result.items.length > 0,
+      summary: summarizeOutreachSync({
+        dry_run,
+        eventsReceived: events.length,
+        matchedRows: result.matchedRowIds.length,
+        changedRows: result.items.length,
+        totalChanges: result.changes.length,
+        providerConfigured: true,
+      }),
+      changes: result.changes,
+    }
+  },
+}
+
 export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   recalculateDesignCostJob,
   recalculateDesignCostBulkJob,
@@ -3211,6 +3355,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   backfillPartnerOrderFeesJob,
   backfillStatsPanelWindowJob,
   backfillOrderPersonsJob,
+  syncMarketingOutreachEngagementJob,
 ]
 
 export const getMaintenanceJob = (id: string): MaintenanceJob | undefined =>

--- a/apps/backend/src/jobs/marketing-daily-refresh.ts
+++ b/apps/backend/src/jobs/marketing-daily-refresh.ts
@@ -1,0 +1,179 @@
+import { MedusaContainer } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { ANALYTICS_MODULE } from "../modules/analytics"
+import { MARKETING_MODULE } from "../modules/marketing"
+import {
+  computeSnapshotRows,
+  istDayStart,
+  type MarketingMetricInput,
+  type PriorSnapshotRow,
+} from "../modules/marketing/compute-snapshot"
+import { setHeadlineCache } from "../modules/marketing/cache"
+
+/**
+ * marketing-daily-refresh — #659 slice 3, PR-3b.
+ *
+ * Once a day, recompute the marketing headline metrics from JYT's EXISTING
+ * sources (paid orders via Query, the precomputed `analytics_daily_stats`
+ * rollup), write append-only `marketing_metric_snapshot` rows to Postgres FIRST,
+ * then best-effort warm the Redis hot path. Mirrors `aggregate-daily-analytics.ts`
+ * exactly (thin I/O here; the row math lives in the PURE, unit-tested
+ * `compute-snapshot.ts` — PR-3a).
+ *
+ * Cache discipline (spec §4): the snapshot table IS the durable cache; the admin
+ * tab (PR-3d) reads it / Redis and NEVER calls an integration on page load.
+ *
+ * The job computes for the LAST COMPLETE IST business day (yesterday), so a 1 AM
+ * UTC run reflects a finished day and aligns with `analytics_daily_stats` (which
+ * `aggregate-daily-analytics.ts` rolls up for yesterday). Cron fires in server TZ
+ * (UTC in prod) → the IST day is derived explicitly via `istDayStart`, never from
+ * local `new Date()` TZ (platform memory: "cron is server-TZ").
+ */
+export default async function marketingDailyRefresh(container: MedusaContainer) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const marketingService: any = container.resolve(MARKETING_MODULE)
+  const analyticsService: any = container.resolve(ANALYTICS_MODULE)
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  // Business day = the last COMPLETE IST calendar day (yesterday in IST).
+  const todayIstStart = istDayStart(new Date())
+  const dayStart = new Date(todayIstStart.getTime() - 24 * 60 * 60 * 1000)
+  const dayEnd = todayIstStart // exclusive upper bound
+  const dayLabel = dayStart.toISOString().split("T")[0]
+
+  logger.info(`[Marketing Refresh] Computing snapshot for IST day ${dayLabel}`)
+
+  const inputs: MarketingMetricInput[] = []
+
+  // --- (a) paid-order GMV + order count over the IST day window -----------
+  // NOTE: `total` is summed across orders; on a single-currency platform (INR)
+  // this is the GMV. Mixed-currency summing is a known v1 limitation — refine
+  // with per-currency breakdown when multi-currency GMV is needed.
+  try {
+    const { data: orders = [] } = await query.graph({
+      entity: "order",
+      fields: ["id", "total", "currency_code"],
+      filters: { created_at: { $gte: dayStart, $lt: dayEnd } },
+    })
+    const gmv = orders.reduce((sum: number, o: any) => sum + (Number(o.total) || 0), 0)
+    const unit = orders[0]?.currency_code?.toUpperCase() ?? null
+    inputs.push({ metric_key: "platform_net_gmv", value: gmv, unit })
+    inputs.push({ metric_key: "orders_count", value: orders.length, unit: "count" })
+    logger.info(`[Marketing Refresh] orders=${orders.length} gmv=${gmv}`)
+  } catch (e: any) {
+    logger.warn(`[Marketing Refresh] GMV gather failed (skipped): ${e?.message ?? e}`)
+  }
+
+  // --- (b) storefront sessions (reuse #559 precomputed rollup; never recompute
+  //         from raw events here) + derived conversion rate --------------------
+  try {
+    const stats = await analyticsService.listAnalyticsDailyStats(
+      { date: { $gte: dayStart, $lt: dayEnd } } as any,
+      { take: 1000 } as any
+    )
+    const sessions = (stats ?? []).reduce(
+      (sum: number, s: any) => sum + (Number(s.sessions) || 0),
+      0
+    )
+    inputs.push({ metric_key: "storefront_sessions", value: sessions, unit: "count" })
+
+    const ordersInput = inputs.find((i) => i.metric_key === "orders_count")
+    if (ordersInput && sessions > 0) {
+      const rate = Math.round((ordersInput.value / sessions) * 10000) / 10000
+      inputs.push({ metric_key: "storefront_conversion_rate", value: rate, unit: "ratio" })
+    }
+    logger.info(`[Marketing Refresh] sessions=${sessions}`)
+  } catch (e: any) {
+    logger.warn(`[Marketing Refresh] sessions gather failed (skipped): ${e?.message ?? e}`)
+  }
+
+  // --- (c) partner_activations — DEFERRED. The "partner w/ live storefront +
+  //         ≥1 paid order" metric is a multi-hop link query (partner → store →
+  //         sales_channel → order) that must be validated with a live
+  //         `medusa exec --dry-run` before shipping (memory:
+  //         reference_query_graph_filter_shapes). Added in a follow-up once the
+  //         join shape is verified; the schema is goal-agnostic so this does not
+  //         block the headline (default = platform_net_gmv).
+
+  if (inputs.length === 0) {
+    logger.info("[Marketing Refresh] No metrics gathered — nothing to persist")
+    return
+  }
+
+  const metricKeys = inputs.map((i) => i.metric_key)
+
+  // Prior snapshot rows (strictly before this business day) for day-over-day deltas.
+  let priorRows: PriorSnapshotRow[] = []
+  try {
+    priorRows = await marketingService.listMarketingMetricSnapshots(
+      { metric_key: metricKeys, captured_for_date: { $lt: dayStart } } as any,
+      { order: { captured_for_date: "DESC" }, take: 200 } as any
+    )
+  } catch (e: any) {
+    logger.warn(`[Marketing Refresh] prior-row read failed (deltas null): ${e?.message ?? e}`)
+  }
+
+  const rows = computeSnapshotRows(inputs, dayStart, priorRows, { source: "daily-refresh" })
+
+  // --- PERSIST FIRST (idempotent on the slice-1 unique index
+  //     (metric_key, captured_for_date)): update the existing row for this day
+  //     or insert a new one. Mirrors aggregate-daily-analytics.ts upsert. -----
+  let persisted = 0
+  for (const row of rows) {
+    try {
+      const [existing] = await marketingService.listMarketingMetricSnapshots(
+        { metric_key: row.metric_key, captured_for_date: row.captured_for_date } as any,
+        { take: 1 } as any
+      )
+      if (existing) {
+        await marketingService.updateMarketingMetricSnapshots({ id: existing.id, ...row } as any)
+      } else {
+        await marketingService.createMarketingMetricSnapshots(row as any)
+      }
+      persisted++
+    } catch (e: any) {
+      logger.warn(
+        `[Marketing Refresh] persist failed for ${row.metric_key} (skipped): ${e?.message ?? e}`
+      )
+    }
+  }
+  logger.info(`[Marketing Refresh] ✅ Persisted ${persisted}/${rows.length} snapshot rows`)
+
+  // --- THEN warm the cache (best-effort; failures are soft — the snapshot rows
+  //     already survived and the read route falls back to Postgres). Never throw
+  //     past persist. PR-3c owns the canonical blob shape; this seeds a minimal
+  //     headline blob so the hot path is non-empty after a refresh. -----------
+  try {
+    const headlineKey = "platform_net_gmv" // HEADLINE_METRIC_KEY default (One Goal — spec §1)
+    const headline = rows.find((r) => r.metric_key === headlineKey) ?? rows[0] ?? null
+    const blob = {
+      headline: headline
+        ? {
+            metric_key: headline.metric_key,
+            value: headline.value,
+            unit: headline.unit,
+            delta_dod: headline.delta_dod,
+            captured_for_date: headline.captured_for_date,
+          }
+        : null,
+      strip: rows.map((r) => ({
+        metric_key: r.metric_key,
+        value: r.value,
+        unit: r.unit,
+        delta_dod: r.delta_dod,
+      })),
+      stale: false,
+      generated_at: dayEnd.toISOString(),
+    }
+    const warmed = await setHeadlineCache(blob)
+    logger.info(`[Marketing Refresh] cache warm ${warmed ? "ok" : "skipped (no redis)"}`)
+  } catch (e: any) {
+    logger.warn(`[Marketing Refresh] cache warm failed (soft): ${e?.message ?? e}`)
+  }
+}
+
+export const config = {
+  name: "marketing-daily-refresh",
+  schedule: "0 1 * * *", // 1 AM UTC ≈ 6:30 AM IST — matches report §4.3 "6am daily-refresh"
+}

--- a/apps/backend/src/modules/marketing/__tests__/cache.unit.spec.ts
+++ b/apps/backend/src/modules/marketing/__tests__/cache.unit.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Unit test — marketing cache SWR shim (#659 slice 3, PR-3b)
+ *
+ * Verifies the FAIL-SOFT contract when REDIS_URL is unset: no Redis client is
+ * created, reads return null (caller falls back to Postgres), writes return
+ * false. No live Redis required — exercises the graceful-degradation path the
+ * daily-refresh job + read route rely on (spec §4.2).
+ *
+ * Run:
+ *   TEST_TYPE=unit npx jest --testPathPattern="marketing/__tests__/cache"
+ */
+import {
+  getMarketingRedis,
+  getHeadlineCache,
+  setHeadlineCache,
+  MARKETING_HEADLINE_KEY,
+  MARKETING_HEADLINE_TTL_SEC,
+} from "../cache"
+
+describe("marketing cache — fail-soft without REDIS_URL", () => {
+  const prev = process.env.REDIS_URL
+
+  beforeAll(() => {
+    delete process.env.REDIS_URL
+  })
+
+  afterAll(() => {
+    if (prev === undefined) delete process.env.REDIS_URL
+    else process.env.REDIS_URL = prev
+  })
+
+  it("getMarketingRedis returns null when REDIS_URL is unset", () => {
+    expect(getMarketingRedis()).toBeNull()
+  })
+
+  it("getHeadlineCache resolves null (Postgres fallback) instead of throwing", async () => {
+    await expect(getHeadlineCache()).resolves.toBeNull()
+  })
+
+  it("setHeadlineCache resolves false (no-op) instead of throwing", async () => {
+    await expect(setHeadlineCache({ headline: null })).resolves.toBe(false)
+  })
+
+  it("exposes a namespaced key and a TTL longer than the daily interval", () => {
+    expect(MARKETING_HEADLINE_KEY).toBe("marketing:headline")
+    expect(MARKETING_HEADLINE_TTL_SEC).toBeGreaterThan(24 * 60 * 60)
+  })
+})

--- a/apps/backend/src/modules/marketing/__tests__/outreach-sync-lib.unit.spec.ts
+++ b/apps/backend/src/modules/marketing/__tests__/outreach-sync-lib.unit.spec.ts
@@ -1,0 +1,172 @@
+import {
+  reconcileOutreachBatch,
+  selectSyncableOutreach,
+  summarizeOutreachSync,
+  type OutreachSyncEvent,
+  type OutreachSyncRow,
+} from "../outreach-sync-lib"
+
+/**
+ * #659 slice 4 / PR-4d — batch engagement reconciliation (pure).
+ * Verifies matching (id + external_id), forward-only folding, idempotency,
+ * candidate selection, and summary wording without a DB or provider.
+ */
+
+const row = (over: Partial<OutreachSyncRow> = {}): OutreachSyncRow => ({
+  id: "or_1",
+  status: "queued",
+  sent_at: null,
+  opened_at: null,
+  replied_at: null,
+  bounce_unreliable: null,
+  external_id: "msg_1",
+  ...over,
+})
+
+describe("reconcileOutreachBatch", () => {
+  it("matches by row id, advances status and fills timestamps", () => {
+    const rows = [row()]
+    const events: OutreachSyncEvent[] = [
+      { id: "or_1", opened_at: "2026-06-23T10:00:00.000Z" },
+    ]
+
+    const res = reconcileOutreachBatch(rows, events)
+
+    expect(res.matchedRowIds).toEqual(["or_1"])
+    expect(res.unmatchedEvents).toBe(0)
+    expect(res.items).toHaveLength(1)
+    expect(res.items[0].patch.status).toBe("opened")
+    expect(res.items[0].patch.opened_at).toBeInstanceOf(Date)
+    // status + opened_at = 2 field changes
+    expect(res.changes).toHaveLength(2)
+  })
+
+  it("matches by external_id when the event carries no row id", () => {
+    const rows = [row({ id: "or_9", external_id: "resend_abc" })]
+    const events: OutreachSyncEvent[] = [
+      { external_id: "resend_abc", sent_at: "2026-06-23T09:00:00.000Z" },
+    ]
+
+    const res = reconcileOutreachBatch(rows, events)
+
+    expect(res.matchedRowIds).toEqual(["or_9"])
+    expect(res.items[0].patch.status).toBe("sent")
+  })
+
+  it("counts events that match no row without throwing", () => {
+    const res = reconcileOutreachBatch(
+      [row()],
+      [{ id: "nope" }, { external_id: "missing" }]
+    )
+    expect(res.unmatchedEvents).toBe(2)
+    expect(res.items).toHaveLength(0)
+    expect(res.changes).toHaveLength(0)
+  })
+
+  it("is idempotent — re-applying the same event yields zero changes", () => {
+    const already = row({
+      status: "opened",
+      sent_at: new Date("2026-06-23T09:00:00.000Z"),
+      opened_at: new Date("2026-06-23T10:00:00.000Z"),
+    })
+    const res = reconcileOutreachBatch(already ? [already] : [], [
+      { id: "or_1", opened_at: "2026-06-23T10:00:00.000Z" },
+    ])
+    expect(res.items).toHaveLength(0)
+    expect(res.changes).toHaveLength(0)
+  })
+
+  it("folds multiple events for one row forward-only", () => {
+    const rows = [row()]
+    const events: OutreachSyncEvent[] = [
+      { id: "or_1", sent_at: "2026-06-23T08:00:00.000Z" },
+      { id: "or_1", opened_at: "2026-06-23T09:00:00.000Z" },
+      { id: "or_1", replied_at: "2026-06-23T10:00:00.000Z" },
+    ]
+
+    const res = reconcileOutreachBatch(rows, events)
+
+    expect(res.items).toHaveLength(1)
+    expect(res.items[0].nextStatus).toBe("replied")
+    expect(res.items[0].patch.status).toBe("replied")
+    expect(res.items[0].patch.sent_at).toBeInstanceOf(Date)
+    expect(res.items[0].patch.opened_at).toBeInstanceOf(Date)
+    expect(res.items[0].patch.replied_at).toBeInstanceOf(Date)
+  })
+
+  it("flags a bounce as unreliable", () => {
+    const res = reconcileOutreachBatch(
+      [row({ status: "sent", sent_at: new Date() })],
+      [{ id: "or_1", bounced_at: "2026-06-23T11:00:00.000Z" }]
+    )
+    expect(res.items[0].patch.status).toBe("bounced")
+    expect(res.items[0].patch.bounce_unreliable).toBe(true)
+  })
+})
+
+describe("selectSyncableOutreach", () => {
+  it("keeps non-terminal rows with an external_id", () => {
+    const rows = [
+      row({ id: "a", status: "sent", external_id: "m_a" }),
+      row({ id: "b", status: "queued", external_id: "m_b" }),
+    ]
+    expect(selectSyncableOutreach(rows).map((r) => r.id)).toEqual(["a", "b"])
+  })
+
+  it("drops rows without an external_id and already-replied rows", () => {
+    const rows = [
+      row({ id: "no_ext", external_id: null }),
+      row({ id: "blank_ext", external_id: "   " }),
+      row({ id: "replied", status: "replied", external_id: "m_r" }),
+    ]
+    expect(selectSyncableOutreach(rows)).toHaveLength(0)
+  })
+})
+
+describe("summarizeOutreachSync", () => {
+  it("flags an unconfigured provider", () => {
+    expect(
+      summarizeOutreachSync({
+        dry_run: true,
+        eventsReceived: 0,
+        matchedRows: 0,
+        changedRows: 0,
+        totalChanges: 0,
+        providerConfigured: false,
+      })
+    ).toMatch(/not configured/i)
+  })
+
+  it("reports a no-op when nothing changed", () => {
+    expect(
+      summarizeOutreachSync({
+        dry_run: true,
+        eventsReceived: 3,
+        matchedRows: 2,
+        changedRows: 0,
+        totalChanges: 0,
+      })
+    ).toMatch(/No engagement changes/i)
+  })
+
+  it("distinguishes dry-run preview from applied", () => {
+    expect(
+      summarizeOutreachSync({
+        dry_run: true,
+        eventsReceived: 2,
+        matchedRows: 2,
+        changedRows: 2,
+        totalChanges: 4,
+      })
+    ).toMatch(/Would update/i)
+    expect(
+      summarizeOutreachSync({
+        dry_run: false,
+        eventsReceived: 2,
+        matchedRows: 2,
+        changedRows: 2,
+        totalChanges: 4,
+      })
+    ).toMatch(/^Updated/i)
+  })
+})

--- a/apps/backend/src/modules/marketing/cache.ts
+++ b/apps/backend/src/modules/marketing/cache.ts
@@ -1,0 +1,77 @@
+/**
+ * cache.ts — thin stale-while-revalidate Redis shim for the marketing headline
+ * blob (#659 slice 3, PR-3b).
+ *
+ * Mirrors the `getIngestRedis()` singleton shape in
+ * `analytics/ingest-buffer.ts:117` — do NOT introduce a second Redis client
+ * pattern or a new dependency; this reuses the same `ioredis` + `REDIS_URL`
+ * discipline, keyed under the `marketing:headline` namespace.
+ *
+ * Cache discipline (spec §4.2): the durable cache is the
+ * `marketing_metric_snapshot` Postgres table; Redis is the hot path only. Every
+ * function here is FAIL-SOFT — a missing `REDIS_URL` or a down Redis never
+ * throws; reads return `null` (caller falls back to Postgres) and writes are
+ * best-effort. So the daily-refresh job's snapshot rows always survive even when
+ * the cache warm fails (job algorithm step 6: "never throw past persist").
+ */
+import Redis from "ioredis"
+
+/** Namespace key for the cached headline+strip+trend blob. */
+export const MARKETING_HEADLINE_KEY = "marketing:headline"
+
+/**
+ * Soft TTL (seconds) for the headline blob. 26h is intentionally longer than
+ * the daily refresh interval so a skipped cron still serves yesterday's number
+ * (the reader flags it `stale: true`) rather than a cold miss.
+ */
+export const MARKETING_HEADLINE_TTL_SEC = 26 * 60 * 60
+
+let _redis: Redis | null = null
+
+/**
+ * Singleton ioredis client for the marketing cache, or `null` when `REDIS_URL`
+ * is unset. Unlike `getIngestRedis()` (which throws), this returns null so the
+ * SWR path degrades to Postgres instead of crashing the job/route.
+ */
+export function getMarketingRedis(): Redis | null {
+  if (_redis) return _redis
+  const url = process.env.REDIS_URL
+  if (!url) return null
+  _redis = new Redis(url, { maxRetriesPerRequest: null })
+  return _redis
+}
+
+/**
+ * Read the cached headline blob. Returns `null` on miss, parse failure, no
+ * Redis, or any I/O error — callers MUST treat null as "fall back to Postgres".
+ */
+export async function getHeadlineCache<T = unknown>(): Promise<T | null> {
+  const redis = getMarketingRedis()
+  if (!redis) return null
+  try {
+    const raw = await redis.get(MARKETING_HEADLINE_KEY)
+    if (!raw) return null
+    return JSON.parse(raw) as T
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Best-effort write of the headline blob with a soft TTL. Swallows all errors
+ * (cache warm is non-critical — the snapshot rows are the source of truth).
+ * Returns true on a confirmed write, false otherwise.
+ */
+export async function setHeadlineCache(
+  blob: unknown,
+  ttlSec: number = MARKETING_HEADLINE_TTL_SEC
+): Promise<boolean> {
+  const redis = getMarketingRedis()
+  if (!redis) return false
+  try {
+    await redis.set(MARKETING_HEADLINE_KEY, JSON.stringify(blob), "EX", ttlSec)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/apps/backend/src/modules/marketing/outreach-sync-lib.ts
+++ b/apps/backend/src/modules/marketing/outreach-sync-lib.ts
@@ -1,0 +1,222 @@
+import type { MaintenanceChange } from "../../api/admin/ops/maintenance-jobs/registry"
+import {
+  diffOutreachEngagement,
+  type OutreachEngagementPatch,
+  type OutreachEngagementRow,
+  type OutreachProviderEvent,
+  type OutreachStatus,
+} from "./diff-outreach-engagement"
+
+/**
+ * Batch engagement reconciliation for `marketing_outreach` (#659 slice 4 / PR-4d).
+ *
+ * `diffOutreachEngagement` (PR-4b) reconciles ONE row against ONE provider event.
+ * This pure layer fans that out across a batch: it matches a set of normalized
+ * provider events to the persisted rows (by row id, falling back to the provider
+ * `external_id`), folds multiple events for the same row forward-only, and returns
+ * the minimal per-row patches + a flat change set for the dry-run/apply contract.
+ *
+ * Kept dependency-free so BOTH consumers stay verifiable without booting the DB,
+ * the workflow engine, or a live email provider:
+ *   - the `POST /admin/marketing/outreach/sync` route (events posted in the body,
+ *     e.g. from a Resend webhook relay), and
+ *   - the `sync-marketing-outreach-engagement` maintenance job (events pulled from
+ *     an optional provider client).
+ */
+
+/** A normalized provider event addressed to a specific outreach row. */
+export type OutreachSyncEvent = OutreachProviderEvent & {
+  /** Target the row directly by its `marketing_outreach` id … */
+  id?: string | null
+  /** … or by the provider message id persisted on the row. */
+  external_id?: string | null
+}
+
+/** The row columns this reconciliation reads (superset of the engagement row). */
+export type OutreachSyncRow = OutreachEngagementRow & {
+  external_id?: string | null
+}
+
+/** A single row that changed, with its cumulative patch + per-row change set. */
+export type OutreachReconcileItem = {
+  id: string
+  patch: OutreachEngagementPatch
+  changes: MaintenanceChange[]
+  nextStatus: OutreachStatus
+}
+
+export type OutreachReconcileResult = {
+  /** Rows that actually changed (empty patch rows are omitted). */
+  items: OutreachReconcileItem[]
+  /** Flat change set across every changed row (dry-run/apply payload). */
+  changes: MaintenanceChange[]
+  /** Distinct row ids an event matched (whether or not they changed). */
+  matchedRowIds: string[]
+  /** Events that matched no row (unknown id/external_id). */
+  unmatchedEvents: number
+}
+
+/** Status from which nothing can advance — a definitive reply. */
+function isTerminal(status: OutreachStatus | null | undefined): boolean {
+  return status === "replied"
+}
+
+/**
+ * Build the id → row + external_id → row lookup. Row id takes precedence; a blank
+ * external_id is never indexed (so it can't accidentally match a null event key).
+ */
+function indexRows(rows: OutreachSyncRow[]): {
+  byId: Map<string, OutreachSyncRow>
+  byExternalId: Map<string, OutreachSyncRow>
+} {
+  const byId = new Map<string, OutreachSyncRow>()
+  const byExternalId = new Map<string, OutreachSyncRow>()
+  for (const row of rows) {
+    if (row?.id) byId.set(row.id, row)
+    const ext = typeof row?.external_id === "string" ? row.external_id.trim() : ""
+    if (ext) byExternalId.set(ext, row)
+  }
+  return { byId, byExternalId }
+}
+
+function resolveTarget(
+  event: OutreachSyncEvent,
+  idx: ReturnType<typeof indexRows>
+): OutreachSyncRow | null {
+  const id = typeof event.id === "string" ? event.id.trim() : ""
+  if (id && idx.byId.has(id)) return idx.byId.get(id)!
+  const ext =
+    typeof event.external_id === "string" ? event.external_id.trim() : ""
+  if (ext && idx.byExternalId.has(ext)) return idx.byExternalId.get(ext)!
+  return null
+}
+
+/** Merge an engagement patch into a working row so later events fold forward. */
+function applyPatchToWorking(
+  working: OutreachSyncRow,
+  patch: OutreachEngagementPatch
+): OutreachSyncRow {
+  return {
+    ...working,
+    ...(patch.status !== undefined ? { status: patch.status } : {}),
+    ...(patch.sent_at !== undefined ? { sent_at: patch.sent_at } : {}),
+    ...(patch.opened_at !== undefined ? { opened_at: patch.opened_at } : {}),
+    ...(patch.replied_at !== undefined ? { replied_at: patch.replied_at } : {}),
+    ...(patch.bounce_unreliable !== undefined
+      ? { bounce_unreliable: patch.bounce_unreliable }
+      : {}),
+  }
+}
+
+/**
+ * Reconcile a batch of provider events against the given rows.
+ *
+ * - Events addressing the same row are folded forward-only (a second event can
+ *   only advance the row further, never downgrade it — `diffOutreachEngagement`
+ *   guarantees monotonicity).
+ * - Events that match no row are counted (`unmatchedEvents`) but never error.
+ * - Re-running with the same events after an apply yields zero changes
+ *   (idempotent), because the persisted timestamps/status already satisfy them.
+ *
+ * Never throws — bad dates are treated as "no signal" by the underlying diff.
+ */
+export function reconcileOutreachBatch(
+  rows: OutreachSyncRow[],
+  events: OutreachSyncEvent[]
+): OutreachReconcileResult {
+  const idx = indexRows(rows ?? [])
+  // Working copies so multiple events per row accumulate.
+  const working = new Map<string, OutreachSyncRow>()
+  // Accumulated patch + changes per row id.
+  const accPatch = new Map<string, OutreachEngagementPatch>()
+  const accChanges = new Map<string, MaintenanceChange[]>()
+  const accNext = new Map<string, OutreachStatus>()
+  const matched = new Set<string>()
+  let unmatchedEvents = 0
+
+  for (const event of events ?? []) {
+    const target = resolveTarget(event, idx)
+    if (!target) {
+      unmatchedEvents++
+      continue
+    }
+    const id = target.id
+    matched.add(id)
+    const current = working.get(id) ?? target
+    const diff = diffOutreachEngagement(current, event)
+    accNext.set(id, diff.nextStatus)
+    if (diff.changes.length === 0) {
+      if (!working.has(id)) working.set(id, current)
+      continue
+    }
+    working.set(id, applyPatchToWorking(current, diff.patch))
+    accPatch.set(id, { ...(accPatch.get(id) ?? {}), ...diff.patch })
+    accChanges.set(id, [...(accChanges.get(id) ?? []), ...diff.changes])
+  }
+
+  const items: OutreachReconcileItem[] = []
+  const changes: MaintenanceChange[] = []
+  for (const [id, patch] of accPatch) {
+    const rowChanges = accChanges.get(id) ?? []
+    if (rowChanges.length === 0) continue
+    items.push({
+      id,
+      patch,
+      changes: rowChanges,
+      nextStatus: accNext.get(id) ?? "queued",
+    })
+    changes.push(...rowChanges)
+  }
+
+  return {
+    items,
+    changes,
+    matchedRowIds: Array.from(matched),
+    unmatchedEvents,
+  }
+}
+
+/**
+ * Select the rows worth syncing: a stable provider message id (`external_id`) to
+ * look up, and not already in the terminal `replied` state (nothing can advance
+ * a reply). Pure so the maintenance job's candidate scan stays testable.
+ */
+export function selectSyncableOutreach(
+  rows: OutreachSyncRow[]
+): OutreachSyncRow[] {
+  return (rows ?? []).filter((row) => {
+    const ext =
+      typeof row?.external_id === "string" ? row.external_id.trim() : ""
+    return !!ext && !isTerminal(row?.status ?? "queued")
+  })
+}
+
+/** Human-facing one-liner for the dry-run/apply result + ops audit log. */
+export function summarizeOutreachSync(opts: {
+  dry_run: boolean
+  eventsReceived: number
+  matchedRows: number
+  changedRows: number
+  totalChanges: number
+  providerConfigured?: boolean
+}): string {
+  const {
+    dry_run,
+    eventsReceived,
+    matchedRows,
+    changedRows,
+    totalChanges,
+    providerConfigured,
+  } = opts
+
+  if (providerConfigured === false) {
+    return "Marketing outreach sync provider not configured — nothing to reconcile."
+  }
+
+  if (changedRows === 0) {
+    return `No engagement changes from ${eventsReceived} event(s) (${matchedRows} row(s) matched, already up to date).`
+  }
+
+  const verb = dry_run ? "Would update" : "Updated"
+  return `${verb} ${changedRows} outreach row(s) — ${totalChanges} field change(s) from ${eventsReceived} event(s) (${matchedRows} matched).`
+}

--- a/apps/backend/src/workflows/marketing/__tests__/generate-ideas-email.unit.spec.ts
+++ b/apps/backend/src/workflows/marketing/__tests__/generate-ideas-email.unit.spec.ts
@@ -1,0 +1,90 @@
+import {
+  buildGroundTruthFromSnapshots,
+  formatMetricDisplay,
+} from "../generate-ideas-email"
+
+/**
+ * #659 slice 2, PR-2 — unit tests for the PURE pieces of generate-ideas-email
+ * (no container, no LLM): the display formatter and the snapshot→GroundTruth
+ * mapping (token derivation, latest-per-metric dedup, delta_dod sub-token).
+ */
+describe("formatMetricDisplay", () => {
+  it("formats INR / USD as integer currency", () => {
+    expect(formatMetricDisplay(184320, "INR")).toBe("₹1,84,320")
+    expect(formatMetricDisplay(2500.9, "USD")).toBe("$2,501")
+  })
+  it("formats ratio as a percent and percent as-is", () => {
+    expect(formatMetricDisplay(0.034, "ratio")).toBe("3.4%")
+    expect(formatMetricDisplay(12.5, "percent")).toBe("12.5%")
+  })
+  it("formats count with grouping and falls back to String", () => {
+    expect(formatMetricDisplay(1200, "count")).toBe("1,200")
+    expect(formatMetricDisplay(7, null)).toBe("7")
+  })
+})
+
+describe("buildGroundTruthFromSnapshots", () => {
+  const opts = { dateIst: "2026-06-23", one_goal: "x" } as any
+  const base = { dateIst: "2026-06-23", oneGoal: "Grow GMV." }
+
+  it("maps metric_key → {TOKEN} and adds a delta_dod sub-token", () => {
+    const gt = buildGroundTruthFromSnapshots(
+      [
+        {
+          metric_key: "platform_gmv",
+          value: 1000,
+          unit: "INR",
+          captured_for_date: "2026-06-23",
+          delta_dod: 4.5,
+        },
+      ],
+      base
+    )
+    const tokens = gt.values.map((v) => v.token)
+    expect(tokens).toContain("PLATFORM_GMV")
+    expect(tokens).toContain("PLATFORM_GMV_DELTA_DOD")
+    expect(gt.one_goal).toBe("Grow GMV.")
+    expect(gt.date_ist).toBe("2026-06-23")
+    const delta = gt.values.find((v) => v.token === "PLATFORM_GMV_DELTA_DOD")!
+    expect(delta.display).toBe("+4.5%")
+  })
+
+  it("omits the delta sub-token when delta_dod is null/undefined", () => {
+    const gt = buildGroundTruthFromSnapshots(
+      [
+        {
+          metric_key: "partner_activations",
+          value: 12,
+          unit: "count",
+          captured_for_date: "2026-06-23",
+          delta_dod: null,
+        },
+      ],
+      base
+    )
+    expect(gt.values.map((v) => v.token)).toEqual(["PARTNER_ACTIVATIONS"])
+  })
+
+  it("keeps only the latest (first) row per metric_key", () => {
+    const gt = buildGroundTruthFromSnapshots(
+      [
+        { metric_key: "gmv", value: 999, captured_for_date: "2026-06-23" },
+        { metric_key: "gmv", value: 111, captured_for_date: "2026-06-22" },
+      ],
+      base
+    )
+    const gmv = gt.values.filter((v) => v.token === "GMV")
+    expect(gmv).toHaveLength(1)
+    expect(gmv[0].value).toBe(999)
+    void opts
+  })
+
+  it("formats negative delta with a leading minus", () => {
+    const gt = buildGroundTruthFromSnapshots(
+      [{ metric_key: "gmv", value: 1, captured_for_date: "x", delta_dod: -3.21 }],
+      base
+    )
+    const delta = gt.values.find((v) => v.token === "GMV_DELTA_DOD")!
+    expect(delta.display).toBe("-3.2%")
+  })
+})

--- a/apps/backend/src/workflows/marketing/generate-ideas-email.ts
+++ b/apps/backend/src/workflows/marketing/generate-ideas-email.ts
@@ -1,0 +1,319 @@
+/**
+ * generate-ideas-email.ts — #659 slice 2, PR-2.
+ *
+ * The "AI tactical-ideas email" generate workflow: read today's ground-truth
+ * numbers from `marketing_metric_snapshot`, ask the LLM for 3-5 tactical moves
+ * (referring to numbers ONLY by {TOKEN} placeholder), run the two-layer
+ * hallucination guard (`ideas-email-guard-lib.ts`), regenerate ONCE on failure,
+ * then persist a `marketing_ideas_log` row BEFORE anything is ever sent
+ * (report §4.3: "every job writes its result to Postgres before sending").
+ *
+ * Testability: the AI call is an INJECTABLE function (`AiGenerateFn`) — the
+ * integration test passes a stub returning fixed `{TOKEN}` copy, so CI NEVER
+ * calls a live LLM. The Medusa workflow wrapper injects the real OpenRouter
+ * call (mirrors the verified pattern in
+ * `src/workflows/ad-planning/sentiment/analyze-sentiment.ts:44-71`).
+ *
+ * This PR does NOT send the email — `sent` stays false; the send workflow
+ * (PR-3) flips it. The job that schedules this (PR-4) stays disabled until the
+ * One Goal is picked.
+ */
+
+import {
+  createWorkflow,
+  createStep,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import { generateText } from "ai"
+import { createOpenRouter } from "@openrouter/ai-sdk-provider"
+
+import { MARKETING_MODULE } from "../../modules/marketing"
+import type { GroundTruth, GroundTruthValue } from "./ideas-email-guard-lib"
+import { runGuard } from "./ideas-email-guard-lib"
+import { buildIdeasPrompt, STRICTER_SUFFIX } from "./ideas-email-prompt-lib"
+
+/** An injectable LLM call: prompt in, raw text out (or "" on failure). */
+export type AiGenerateFn = (prompt: string) => Promise<string>
+
+export type GenerateIdeasEmailOptions = {
+  /** Injected for tests; defaults to the real OpenRouter call. */
+  aiGenerate?: AiGenerateFn
+  /** The "One Goal" string; never invented in code (report §3.6). */
+  oneGoal?: string
+  /** Business description fed to the prompt. */
+  businessDescription?: string
+  /** Reference "now"; defaults to current time. Used only for the IST date. */
+  now?: Date
+  /** Stray-literal tolerance forwarded to the guard. */
+  tolerancePct?: number
+  /** Extra numeric literals the guard is allowed to ignore. */
+  allowList?: string[]
+}
+
+export type GenerateIdeasEmailResult = {
+  skipped: boolean
+  generated: boolean
+  guard_passed: boolean
+  regenerated: boolean
+  log_id: string | null
+  output_text: string
+  model_used: string
+  ground_truth: GroundTruth | null
+  reason?: string
+}
+
+const DEFAULT_MODEL = "anthropic/claude-3.5-sonnet"
+
+const DEFAULT_BUSINESS_DESCRIPTION =
+  "JYT is a textile-production commerce platform: it runs an admin storefront " +
+  "and onboards partner brands who sell their own products through per-partner " +
+  "storefronts. Revenue comes from product sales (GMV) across these stores."
+
+// IST = UTC+5:30. Return the IST calendar date (YYYY-MM-DD) for a UTC instant.
+function istDateString(d: Date): string {
+  const ist = new Date(d.getTime() + 5.5 * 60 * 60 * 1000)
+  return ist.toISOString().slice(0, 10)
+}
+
+/**
+ * Pure: format a canonical numeric value for human display in the email copy.
+ * The guard validates stray literals against the RAW (pre-substitution) output,
+ * so this display string only affects the final rendered copy — it can be as
+ * human-friendly as we like without tripping Layer B.
+ */
+export function formatMetricDisplay(
+  value: number,
+  unit?: string | null
+): string {
+  const u = (unit || "").toLowerCase()
+  if (u === "inr") return "₹" + Math.round(value).toLocaleString("en-IN")
+  if (u === "usd") return "$" + Math.round(value).toLocaleString("en-US")
+  if (u === "percent") return `${round1(value)}%`
+  if (u === "ratio") return `${round1(value * 100)}%`
+  if (u === "count") return Math.round(value).toLocaleString("en-IN")
+  return String(value)
+}
+
+function round1(n: number): number {
+  return Math.round(n * 10) / 10
+}
+
+function tokenFor(metricKey: string): string {
+  return metricKey.toUpperCase().replace(/[^A-Z0-9]+/g, "_")
+}
+
+/**
+ * Pure: map the latest snapshot row per metric_key into a GroundTruth. Each
+ * metric becomes a {METRIC_KEY} token; a present `delta_dod` becomes a separate
+ * {METRIC_KEY_DELTA_DOD} percent token so the model can reference the trend.
+ */
+export function buildGroundTruthFromSnapshots(
+  rows: Array<{
+    metric_key: string
+    value: number
+    unit?: string | null
+    captured_for_date: Date | string
+    delta_dod?: number | null
+  }>,
+  opts: { dateIst: string; oneGoal: string }
+): GroundTruth {
+  const seen = new Set<string>()
+  const values: GroundTruthValue[] = []
+
+  // rows arrive newest-first; keep the first (latest) row per metric_key.
+  for (const r of rows) {
+    if (seen.has(r.metric_key)) continue
+    seen.add(r.metric_key)
+
+    const token = tokenFor(r.metric_key)
+    values.push({
+      token,
+      value: r.value,
+      display: formatMetricDisplay(r.value, r.unit),
+      unit: r.unit ?? null,
+    })
+
+    if (r.delta_dod !== null && r.delta_dod !== undefined) {
+      const sign = r.delta_dod >= 0 ? "+" : ""
+      values.push({
+        token: `${token}_DELTA_DOD`,
+        value: r.delta_dod,
+        display: `${sign}${round1(r.delta_dod)}%`,
+        unit: "percent",
+      })
+    }
+  }
+
+  return { values, date_ist: opts.dateIst, one_goal: opts.oneGoal }
+}
+
+/** The real LLM call. Mirrors analyze-sentiment.ts:44-71 (try/catch → "" on error). */
+async function defaultAiGenerate(prompt: string): Promise<string> {
+  try {
+    const openrouter = createOpenRouter({
+      apiKey: process.env.OPENROUTER_API_KEY,
+    })
+    const result = await generateText({
+      model: openrouter(process.env.MARKETING_IDEAS_MODEL || DEFAULT_MODEL),
+      prompt,
+      maxOutputTokens: 700,
+    })
+    return (result.text || "").trim()
+  } catch (error: any) {
+    // eslint-disable-next-line no-console
+    console.error("[generate-ideas-email] AI error:", error?.message)
+    return ""
+  }
+}
+
+/**
+ * Core orchestration (no Medusa-step wrapper, so it's directly unit/integration
+ * testable with a stubbed `aiGenerate`): gather ground truth → generate → guard
+ * → regenerate-once → persist BEFORE send.
+ */
+export async function generateIdeasEmail(
+  container: any,
+  opts: GenerateIdeasEmailOptions = {}
+): Promise<GenerateIdeasEmailResult> {
+  const aiGenerate = opts.aiGenerate || defaultAiGenerate
+  const now = opts.now || new Date()
+  const oneGoal =
+    opts.oneGoal ||
+    process.env.MARKETING_ONE_GOAL ||
+    "Grow platform GMV (total sales across all stores)."
+  const businessDescription =
+    opts.businessDescription ||
+    process.env.MARKETING_BUSINESS_DESCRIPTION ||
+    DEFAULT_BUSINESS_DESCRIPTION
+  const modelId = process.env.MARKETING_IDEAS_MODEL || DEFAULT_MODEL
+
+  const empty: GenerateIdeasEmailResult = {
+    skipped: false,
+    generated: false,
+    guard_passed: false,
+    regenerated: false,
+    log_id: null,
+    output_text: "",
+    model_used: modelId,
+    ground_truth: null,
+  }
+
+  const marketing: any = container.resolve(MARKETING_MODULE)
+
+  // 1) gather ground truth — latest snapshot rows, newest first.
+  const rows: any[] = await marketing.listMarketingMetricSnapshots(
+    {},
+    { order: { captured_for_date: "DESC" }, take: 50 }
+  )
+
+  if (!rows || rows.length === 0) {
+    // Don't email "₹0" with no data — abort the run (report §4.1).
+    return { ...empty, skipped: true, reason: "no_snapshots" }
+  }
+
+  const dateIst = istDateString(now)
+  const gt = buildGroundTruthFromSnapshots(rows, { dateIst, oneGoal })
+
+  // 2) generate
+  const prompt = buildIdeasPrompt(gt, businessDescription)
+  let rawOutput = await aiGenerate(prompt)
+
+  if (!rawOutput) {
+    // AI failed: log the failure, do not send.
+    const failLog = await marketing.createMarketingIdeasLogs([
+      {
+        generated_for_date: new Date(`${dateIst}T00:00:00.000Z`),
+        model_used: modelId,
+        prompt_snapshot: gt,
+        output_text: "",
+        guard_passed: false,
+        guard_failures: [{ type: "ai_error", token: "ai_generate" }],
+        regenerated: false,
+        sent: false,
+      },
+    ])
+    return {
+      ...empty,
+      ground_truth: gt,
+      log_id: arrId(failLog),
+      reason: "ai_error",
+    }
+  }
+
+  // 3) guard → regenerate ONCE on failure → persist
+  let verdict = runGuard(rawOutput, gt, {
+    tolerancePct: opts.tolerancePct,
+    allowList: opts.allowList,
+  })
+  let regenerated = false
+  if (!verdict.passed) {
+    const second = await aiGenerate(prompt + STRICTER_SUFFIX)
+    regenerated = true
+    if (second) {
+      rawOutput = second
+      verdict = runGuard(second, gt, {
+        tolerancePct: opts.tolerancePct,
+        allowList: opts.allowList,
+      })
+    }
+  }
+
+  const log = await marketing.createMarketingIdeasLogs([
+    {
+      generated_for_date: new Date(`${dateIst}T00:00:00.000Z`),
+      model_used: modelId,
+      prompt_snapshot: gt,
+      output_text: verdict.finalText,
+      guard_passed: verdict.passed,
+      guard_failures: verdict.failures.length ? verdict.failures : null,
+      regenerated,
+      sent: false, // flipped true only after a successful send (PR-3)
+    },
+  ])
+
+  return {
+    skipped: false,
+    generated: true,
+    guard_passed: verdict.passed,
+    regenerated,
+    log_id: arrId(log),
+    output_text: verdict.finalText,
+    model_used: modelId,
+    ground_truth: gt,
+  }
+}
+
+function arrId(created: any): string | null {
+  const row = Array.isArray(created) ? created[0] : created
+  return row?.id ?? null
+}
+
+// ---------------------------------------------------------------------------
+// Medusa workflow wrapper (injects the real OpenRouter call).
+// ---------------------------------------------------------------------------
+export type GenerateIdeasEmailWorkflowInput = {
+  oneGoal?: string
+  businessDescription?: string
+}
+
+const generateIdeasEmailStep = createStep(
+  "generate-ideas-email",
+  async (input: GenerateIdeasEmailWorkflowInput, { container }) => {
+    const result = await generateIdeasEmail(container, {
+      oneGoal: input?.oneGoal,
+      businessDescription: input?.businessDescription,
+    })
+    return new StepResponse(result)
+  }
+)
+
+export const generateIdeasEmailWorkflow = createWorkflow(
+  "generate-ideas-email",
+  (input: GenerateIdeasEmailWorkflowInput) => {
+    const result = generateIdeasEmailStep(input)
+    return new WorkflowResponse(result)
+  }
+)
+
+export default generateIdeasEmailWorkflow

--- a/apps/backend/src/workflows/marketing/log-outreach.ts
+++ b/apps/backend/src/workflows/marketing/log-outreach.ts
@@ -1,0 +1,84 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+
+import { MARKETING_MODULE } from "../../modules/marketing"
+
+/**
+ * logOutreachWorkflow (#659 slice 4 / PR-4c).
+ *
+ * Persists a single hand-crafted outbound row into `marketing_outreach`
+ * (Winbacks / Exec outreach CRM). Mirrors the create-record workflow pattern
+ * used elsewhere (designs, inbound-emails): one step + a compensation that
+ * deletes the row if anything downstream fails.
+ *
+ * Normalisation happens HERE (not in the route) so every caller — route,
+ * future cron, provider-sync job — produces consistent rows:
+ *   - `recipient_email` is lower-cased + trimmed (matches the engagement-sync
+ *     lookup in `diff-outreach-engagement.ts`, which keys on the message id but
+ *     emails must still dedupe predictably).
+ *   - blank optional strings collapse to `null` so list filters stay clean.
+ */
+
+export type LogOutreachInput = {
+  recipient_email: string
+  recipient_name?: string | null
+  company?: string | null
+  campaign?: string | null
+  channel?: "email" | "whatsapp" | "manual"
+  status?: "queued" | "sent" | "opened" | "replied" | "bounced" | "unknown"
+  notes?: string | null
+  external_id?: string | null
+  sent_at?: Date | string | null
+}
+
+function blankToNull(v: string | null | undefined): string | null {
+  if (typeof v !== "string") {
+    return null
+  }
+  const trimmed = v.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+const logOutreachStep = createStep(
+  "log-outreach",
+  async (input: LogOutreachInput, { container }) => {
+    const service = container.resolve(MARKETING_MODULE) as any
+
+    const payload = {
+      recipient_email: input.recipient_email.trim().toLowerCase(),
+      recipient_name: blankToNull(input.recipient_name),
+      company: blankToNull(input.company),
+      campaign: blankToNull(input.campaign),
+      channel: input.channel ?? "email",
+      status: input.status ?? "queued",
+      notes: blankToNull(input.notes),
+      external_id: blankToNull(input.external_id),
+      sent_at: input.sent_at ?? null,
+    }
+
+    const created = await service.createMarketingOutreaches(payload)
+
+    return new StepResponse(created, created?.id)
+  },
+  async (id, { container }) => {
+    if (!id) {
+      return
+    }
+    const service = container.resolve(MARKETING_MODULE) as any
+    await service.deleteMarketingOutreaches(id)
+  }
+)
+
+export const logOutreachWorkflow = createWorkflow(
+  "log-outreach",
+  (input: LogOutreachInput) => {
+    const outreach = logOutreachStep(input)
+    return new WorkflowResponse(outreach)
+  }
+)
+
+export default logOutreachWorkflow


### PR DESCRIPTION
Recovers the 4 stacked children that GitHub auto-closed when their base branches were squash-merged + deleted (the documented stacked-PR drain gotcha):

- **#673** generate-ideas-email workflow (slice 2 · PR-2)
- **#677** daily-refresh snapshot cron + Redis SWR (slice 3 · PR-3b)
- **#680** outreach CRM CRUD routes + logOutreachWorkflow (slice 4 · PR-4c)
- **#681** outreach engagement sync route + maintenance job (slice 4 · PR-4d)

Each child's own delta (its tip commit, on top of an already-merged parent) was cherry-picked onto fresh main in dependency order — clean, no conflicts. All were verified green by the daemon (unit + per-file integration). Bases #672/#676/#679 + independents #674/#675/#678 already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)