### PR TITLE
feat(marketing): daily-ideas-email scheduled job (#659 slice 2 · PR-4)

### DIFF
--- a/apps/backend/src/jobs/__tests__/daily-ideas-email.unit.spec.ts
+++ b/apps/backend/src/jobs/__tests__/daily-ideas-email.unit.spec.ts
@@ -1,0 +1,157 @@
+import {
+  isSendEnabled,
+  runDailyIdeasEmail,
+  type GenerateRunner,
+  type SendRunner,
+} from "../daily-ideas-email"
+
+/**
+ * #659 slice 2, PR-4 — unit tests for the daily-ideas-email orchestrator.
+ *
+ * Uses INJECTED stubs for the generate/send runners, so CI NEVER calls a live
+ * LLM or sends a real email. Asserts the chain wiring + operator-safety gate +
+ * fail-soft (never throws) discipline.
+ */
+
+// Minimal fake container — only `resolve(LOGGER)` is used; return a noop logger.
+const fakeLogger = { info: () => {}, warn: () => {}, error: () => {} }
+const fakeContainer = { resolve: () => fakeLogger } as any
+
+const genResult = (patch: Record<string, any> = {}) => ({
+  skipped: false,
+  generated: true,
+  guard_passed: true,
+  regenerated: false,
+  log_id: "log_1",
+  output_text: "ideas",
+  model_used: "test",
+  ground_truth: null,
+  ...patch,
+})
+
+const sendResult = (patch: Record<string, any> = {}) => ({
+  sent: 2,
+  skipped: false,
+  guard_passed: true,
+  review_notice_sent: false,
+  recipients: 2,
+  ...patch,
+})
+
+describe("isSendEnabled", () => {
+  it("is true only for explicit truthy opt-in values", () => {
+    expect(isSendEnabled({ MARKETING_IDEAS_EMAIL_ENABLED: "true" } as any)).toBe(true)
+    expect(isSendEnabled({ MARKETING_IDEAS_EMAIL_ENABLED: "1" } as any)).toBe(true)
+    expect(isSendEnabled({ MARKETING_IDEAS_EMAIL_ENABLED: "ON" } as any)).toBe(true)
+  })
+  it("defaults OFF (missing / falsey)", () => {
+    expect(isSendEnabled({} as any)).toBe(false)
+    expect(isSendEnabled({ MARKETING_IDEAS_EMAIL_ENABLED: "false" } as any)).toBe(false)
+    expect(isSendEnabled({ MARKETING_IDEAS_EMAIL_ENABLED: "" } as any)).toBe(false)
+  })
+})
+
+describe("runDailyIdeasEmail", () => {
+  it("(a) guard-passed log → send runner invoked with that logId", async () => {
+    let sentWith: any = null
+    const generate: GenerateRunner = async () => genResult({ log_id: "log_42" })
+    const send: SendRunner = async (input) => {
+      sentWith = input
+      return sendResult()
+    }
+
+    const summary = await runDailyIdeasEmail(fakeContainer, {
+      generate,
+      send,
+      sendEnabled: true,
+    })
+
+    expect(sentWith).toEqual({ logId: "log_42" })
+    expect(summary.send_attempted).toBe(true)
+    expect(summary.sent).toBe(2)
+    expect(summary.errored).toBe(false)
+  })
+
+  it("(b) guard-FAILED result → send runner NOT invoked", async () => {
+    const send = jest.fn<Promise<any>, [any]>()
+    const generate: GenerateRunner = async () =>
+      genResult({ guard_passed: false, reason: "guard_failed" })
+
+    const summary = await runDailyIdeasEmail(fakeContainer, {
+      generate,
+      send: send as any,
+      sendEnabled: true,
+    })
+
+    expect(send).not.toHaveBeenCalled()
+    expect(summary.send_attempted).toBe(false)
+    expect(summary.skipped_reason).toBe("guard_failed")
+  })
+
+  it("(b2) skipped generate (no snapshots) → send NOT invoked", async () => {
+    const send = jest.fn<Promise<any>, [any]>()
+    const generate: GenerateRunner = async () =>
+      genResult({ generated: false, guard_passed: false, skipped: true, log_id: null, reason: "no_snapshots" })
+
+    const summary = await runDailyIdeasEmail(fakeContainer, {
+      generate,
+      send: send as any,
+      sendEnabled: true,
+    })
+
+    expect(send).not.toHaveBeenCalled()
+    expect(summary.send_attempted).toBe(false)
+    expect(summary.skipped_reason).toBe("no_snapshots")
+  })
+
+  it("(c) send disabled by flag → generate ran, send skipped", async () => {
+    const send = jest.fn<Promise<any>, [any]>()
+    const generate: GenerateRunner = async () => genResult()
+
+    const summary = await runDailyIdeasEmail(fakeContainer, {
+      generate,
+      send: send as any,
+      sendEnabled: false,
+    })
+
+    expect(summary.generated).toBe(true)
+    expect(summary.guard_passed).toBe(true)
+    expect(send).not.toHaveBeenCalled()
+    expect(summary.send_attempted).toBe(false)
+    expect(summary.skipped_reason).toBe("send_disabled")
+  })
+
+  it("(d) thrown error inside generate is swallowed (never rejects)", async () => {
+    const generate: GenerateRunner = async () => {
+      throw new Error("LLM exploded")
+    }
+    const send = jest.fn<Promise<any>, [any]>()
+
+    const summary = await runDailyIdeasEmail(fakeContainer, {
+      generate,
+      send: send as any,
+      sendEnabled: true,
+    })
+
+    expect(summary.errored).toBe(true)
+    expect(summary.skipped_reason).toBe("generate_threw")
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it("(d2) thrown error inside send is swallowed (never rejects)", async () => {
+    const generate: GenerateRunner = async () => genResult()
+    const send: SendRunner = async () => {
+      throw new Error("Resend down")
+    }
+
+    const summary = await runDailyIdeasEmail(fakeContainer, {
+      generate,
+      send,
+      sendEnabled: true,
+    })
+
+    expect(summary.send_attempted).toBe(true)
+    expect(summary.errored).toBe(true)
+    expect(summary.skipped_reason).toBe("send_threw")
+  })
+})

--- a/apps/backend/src/jobs/daily-ideas-email.ts
+++ b/apps/backend/src/jobs/daily-ideas-email.ts
@@ -1,0 +1,206 @@
+import { MedusaContainer } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import {
+  generateIdeasEmailWorkflow,
+  type GenerateIdeasEmailResult,
+} from "../workflows/marketing/generate-ideas-email"
+import {
+  sendIdeasEmailWorkflow,
+  type SendIdeasEmailInput,
+  type SendIdeasEmailResult,
+} from "../workflows/marketing/send-ideas-email"
+
+/**
+ * daily-ideas-email — #659 slice 2, PR-4.
+ *
+ * The scheduled morning job that chains the two EXISTING marketing workflows:
+ *   1. generate-ideas-email  → read ground-truth snapshots, ask the LLM for
+ *      tactical moves, run the hallucination guard, persist a marketing_ideas_log
+ *      row (BEFORE any send).
+ *   2. send-ideas-email      → ONLY when the generated log passed the guard, mail
+ *      the operator recipients and flip sent=true.
+ *
+ * Runs AFTER `marketing-daily-refresh` (snapshot cron at "0 1 * * *") so the
+ * ground-truth rows exist before we generate from them — this fires at
+ * "30 1 * * *" (≈ 7 AM IST).
+ *
+ * Operator safety / explicit opt-in:
+ *   GENERATE always runs and logs (so the draft + guard verdict are persisted and
+ *   reviewable in the ideas log even when nothing is mailed). SEND is gated behind
+ *   the env flag `MARKETING_IDEAS_EMAIL_ENABLED` (default OFF). Set it to "true"
+ *   (or "1") in prod to turn the daily email on — an explicit operator action.
+ *
+ * Fail-soft discipline (mirrors marketing-daily-refresh): every workflow call is
+ * wrapped so a bad morning run can NEVER throw past the job boundary and crash the
+ * scheduler. The orchestrator returns a summary; the default export only logs it.
+ */
+
+/** Injectable generate runner — prompt+guard+persist; defaults to the real workflow. */
+export type GenerateRunner = () => Promise<GenerateIdeasEmailResult>
+/** Injectable send runner — mails a guarded log; defaults to the real workflow. */
+export type SendRunner = (
+  input: SendIdeasEmailInput
+) => Promise<SendIdeasEmailResult>
+
+export type RunDailyIdeasEmailDeps = {
+  /** Injected in tests so CI NEVER calls a live LLM. */
+  generate?: GenerateRunner
+  /** Injected in tests so CI NEVER sends a real email. */
+  send?: SendRunner
+  /** Override the env send-gate (else reads MARKETING_IDEAS_EMAIL_ENABLED). */
+  sendEnabled?: boolean
+}
+
+export type DailyIdeasEmailSummary = {
+  generated: boolean
+  guard_passed: boolean
+  log_id: string | null
+  send_enabled: boolean
+  send_attempted: boolean
+  sent: number
+  skipped_reason: string | null
+  errored: boolean
+}
+
+/** True only when the operator has explicitly opted in via the env flag. */
+export function isSendEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = (env.MARKETING_IDEAS_EMAIL_ENABLED || "").trim().toLowerCase()
+  return raw === "true" || raw === "1" || raw === "yes" || raw === "on"
+}
+
+/**
+ * Pure-ish orchestrator: chain generate → (guarded) send. The runner fns default
+ * to the real workflow `.run()` calls but are INJECTABLE so tests pass stubs.
+ * NEVER throws — a thrown error inside a runner is swallowed and reported in the
+ * returned summary (the job must not be able to crash the scheduler).
+ */
+export async function runDailyIdeasEmail(
+  container: MedusaContainer,
+  deps: RunDailyIdeasEmailDeps = {}
+): Promise<DailyIdeasEmailSummary> {
+  let logger: any
+  try {
+    logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  } catch {
+    logger = console
+  }
+
+  const generate: GenerateRunner =
+    deps.generate ||
+    (async () => {
+      const { result } = await generateIdeasEmailWorkflow(container as any).run({
+        input: {},
+      })
+      return result as GenerateIdeasEmailResult
+    })
+
+  const send: SendRunner =
+    deps.send ||
+    (async (input: SendIdeasEmailInput) => {
+      const { result } = await sendIdeasEmailWorkflow(container as any).run({
+        input,
+      })
+      return result as SendIdeasEmailResult
+    })
+
+  const sendEnabled = deps.sendEnabled ?? isSendEnabled()
+
+  const summary: DailyIdeasEmailSummary = {
+    generated: false,
+    guard_passed: false,
+    log_id: null,
+    send_enabled: sendEnabled,
+    send_attempted: false,
+    sent: 0,
+    skipped_reason: null,
+    errored: false,
+  }
+
+  // --- 1) GENERATE (always runs + logs; persists the draft/guard verdict) -----
+  let gen: GenerateIdeasEmailResult | null = null
+  try {
+    gen = await generate()
+  } catch (e: any) {
+    summary.errored = true
+    summary.skipped_reason = "generate_threw"
+    logger.error?.(
+      `[daily-ideas-email] generate threw (swallowed): ${e?.message ?? e}`
+    )
+    return summary
+  }
+
+  summary.generated = gen?.generated === true
+  summary.guard_passed = gen?.guard_passed === true
+  summary.log_id = gen?.log_id ?? null
+
+  // --- 2) SEND only when: generated && guard_passed && have a log id --------
+  const sendable =
+    summary.generated && summary.guard_passed && !!summary.log_id
+
+  if (!sendable) {
+    summary.skipped_reason =
+      gen?.reason ?? (gen?.skipped ? "generate_skipped" : "not_guard_passed")
+    logger.info?.(
+      `[daily-ideas-email] generated=${summary.generated} guard_passed=${summary.guard_passed} ` +
+        `log_id=${summary.log_id ?? "none"} → send skipped (${summary.skipped_reason})`
+    )
+    return summary
+  }
+
+  if (!sendEnabled) {
+    summary.skipped_reason = "send_disabled"
+    logger.info?.(
+      `[daily-ideas-email] log ${summary.log_id} guard-passed but MARKETING_IDEAS_EMAIL_ENABLED is off → not sent`
+    )
+    return summary
+  }
+
+  summary.send_attempted = true
+  try {
+    const sent = await send({ logId: summary.log_id as string })
+    summary.sent = sent?.sent ?? 0
+    logger.info?.(
+      `[daily-ideas-email] log ${summary.log_id} sent to ${summary.sent} recipient(s)` +
+        (sent?.skipped ? ` (skipped: ${sent?.reason ?? "unknown"})` : "")
+    )
+  } catch (e: any) {
+    summary.errored = true
+    summary.skipped_reason = "send_threw"
+    logger.error?.(
+      `[daily-ideas-email] send threw for log ${summary.log_id} (swallowed): ${
+        e?.message ?? e
+      }`
+    )
+  }
+
+  return summary
+}
+
+/**
+ * Scheduled-job entrypoint. Calls the orchestrator with real-workflow defaults
+ * and logs a one-line summary. Never rethrows.
+ */
+export default async function dailyIdeasEmailJob(container: MedusaContainer) {
+  let logger: any
+  try {
+    logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  } catch {
+    logger = console
+  }
+
+  const summary = await runDailyIdeasEmail(container)
+  logger.info?.(
+    `[daily-ideas-email] done — generated=${summary.generated} guard_passed=${summary.guard_passed} ` +
+      `send_enabled=${summary.send_enabled} send_attempted=${summary.send_attempted} ` +
+      `sent=${summary.sent} errored=${summary.errored}` +
+      (summary.skipped_reason ? ` reason=${summary.skipped_reason}` : "")
+  )
+}
+
+export const config = {
+  name: "daily-ideas-email",
+  // 30 min after marketing-daily-refresh ("0 1 * * *") so snapshot rows exist.
+  // 1:30 AM UTC ≈ 7 AM IST.
+  schedule: "30 1 * * *",
+}


### PR DESCRIPTION
## #659 slice 2 · PR-4 — the daily-ideas-email scheduled job

The marketing backend (slices 1–4) is **already merged** to main. This wires the two existing, merged marketing workflows into a once-a-day scheduled job.

### What it does
`apps/backend/src/jobs/daily-ideas-email.ts`:
1. runs `generateIdeasEmailWorkflow` → reads `result.{ log_id, generated, guard_passed }`
2. **only if** `generated && guard_passed && log_id` → runs `sendIdeasEmailWorkflow({ logId })`
3. logs a one-line summary; **never throws** past the workflow boundary (mirrors `marketing-daily-refresh`'s soft try/catch)

`config.schedule = "30 1 * * *"` — 30 min after `marketing-daily-refresh` (`"0 1 * * *"`) so the ground-truth snapshot rows exist first (≈7 AM IST).

### Testability
Exports `runDailyIdeasEmail(container, { generate?, send? })` — the `generate`/`send` runners **default** to the real workflow `.run()` calls but are **injectable**. The `export default` job calls it with defaults; tests pass stubs so CI **never** calls a live LLM or sends real email.

### Operator safety
SEND is gated behind `MARKETING_IDEAS_EMAIL_ENABLED` (default **OFF** in prod). GENERATE always runs + logs the draft/guard verdict (reviewable in the ideas log) even when nothing is mailed — turning the email on is an explicit operator opt-in.

### Tests (8 unit, green)
- (a) guard-passed log → send runner invoked with that `logId`
- (b) guard-failed / (b2) skipped result → send **not** invoked
- (c) send disabled by flag → generate ran, send skipped
- (d/d2) a throw inside either runner is swallowed — the job never rejects
- `isSendEnabled` flag parsing

Run: `cd apps/backend && TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules npx jest --testPathPattern="daily-ideas-email.unit"`

PR-only — no merge (human review). Next: convert this cron into an operator-editable visual-flow schedule (chunk 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)