### PR TITLE
feat(#659): daily ideas-email as operator-editable visual flow (slice 2)

### DIFF
--- a/apps/backend/src/modules/visual_flows/operations/__tests__/marketing-daily-ideas-email.unit.spec.ts
+++ b/apps/backend/src/modules/visual_flows/operations/__tests__/marketing-daily-ideas-email.unit.spec.ts
@@ -1,0 +1,75 @@
+import {
+  resolveSendEnabledOption,
+  normalizeRecipientsOption,
+  marketingDailyIdeasEmailOperation,
+} from "../marketing-daily-ideas-email"
+
+/**
+ * #659 slice 2 — unit tests for the visual-flow operation's PURE option
+ * coercers and its registration shape. The orchestration itself is covered in
+ * workflows/marketing/__tests__/run-daily-ideas-email.unit.spec.ts (injected
+ * stubs, no live LLM/email).
+ */
+
+describe("resolveSendEnabledOption", () => {
+  it("returns undefined for unset/empty (caller falls back to env gate)", () => {
+    expect(resolveSendEnabledOption(undefined)).toBeUndefined()
+    expect(resolveSendEnabledOption(null)).toBeUndefined()
+    expect(resolveSendEnabledOption("")).toBeUndefined()
+  })
+  it("passes through real booleans", () => {
+    expect(resolveSendEnabledOption(true)).toBe(true)
+    expect(resolveSendEnabledOption(false)).toBe(false)
+  })
+  it("coerces truthy/falsy strings", () => {
+    expect(resolveSendEnabledOption("true")).toBe(true)
+    expect(resolveSendEnabledOption("1")).toBe(true)
+    expect(resolveSendEnabledOption("ON")).toBe(true)
+    expect(resolveSendEnabledOption("false")).toBe(false)
+    expect(resolveSendEnabledOption("0")).toBe(false)
+    expect(resolveSendEnabledOption("no")).toBe(false)
+  })
+  it("returns undefined for unrecognized strings", () => {
+    expect(resolveSendEnabledOption("maybe")).toBeUndefined()
+  })
+})
+
+describe("normalizeRecipientsOption", () => {
+  it("returns undefined when nothing usable", () => {
+    expect(normalizeRecipientsOption(undefined)).toBeUndefined()
+    expect(normalizeRecipientsOption([])).toBeUndefined()
+    expect(normalizeRecipientsOption("")).toBeUndefined()
+    expect(normalizeRecipientsOption("  , ")).toBeUndefined()
+  })
+  it("cleans an array", () => {
+    expect(normalizeRecipientsOption([" a@x.com ", "", "b@x.com"])).toEqual([
+      "a@x.com",
+      "b@x.com",
+    ])
+  })
+  it("splits a CSV string", () => {
+    expect(normalizeRecipientsOption("a@x.com, b@x.com ")).toEqual([
+      "a@x.com",
+      "b@x.com",
+    ])
+  })
+})
+
+describe("marketingDailyIdeasEmailOperation registration", () => {
+  it("has the expected type/category and a parseable schema", () => {
+    expect(marketingDailyIdeasEmailOperation.type).toBe(
+      "marketing_daily_ideas_email"
+    )
+    expect(marketingDailyIdeasEmailOperation.category).toBe("communication")
+    // empty options parse cleanly (env gate decides send)
+    expect(() =>
+      marketingDailyIdeasEmailOperation.optionsSchema.parse({})
+    ).not.toThrow()
+    expect(() =>
+      marketingDailyIdeasEmailOperation.optionsSchema.parse({
+        send_enabled: true,
+        recipients: ["a@x.com"],
+      })
+    ).not.toThrow()
+  })
+})

--- a/apps/backend/src/modules/visual_flows/operations/index.ts
+++ b/apps/backend/src/modules/visual_flows/operations/index.ts
@@ -31,6 +31,7 @@ export { aiExtractOperation } from "./ai-extract"
 export { aiExtractPlatformOperation } from "./ai-extract-platform"
 export { generatePartnerDeeplinkOperation } from "./generate-partner-deeplink"
 export { partnerAnalyticsDigestOperation } from "./partner-analytics-digest"
+export { marketingDailyIdeasEmailOperation } from "./marketing-daily-ideas-email"
 export { waitForEventOperation } from "./wait-for-event"
 
 // Import all operations and register them
@@ -63,6 +64,7 @@ import { aiExtractOperation } from "./ai-extract"
 import { aiExtractPlatformOperation } from "./ai-extract-platform"
 import { generatePartnerDeeplinkOperation } from "./generate-partner-deeplink"
 import { partnerAnalyticsDigestOperation } from "./partner-analytics-digest"
+import { marketingDailyIdeasEmailOperation } from "./marketing-daily-ideas-email"
 import { waitForEventOperation } from "./wait-for-event"
 
 // Register all built-in operations
@@ -85,6 +87,7 @@ export function registerBuiltInOperations(): void {
   operationRegistry.register(sendEmailOperation)
   operationRegistry.register(sendWhatsAppOperation)
   operationRegistry.register(notificationOperation)
+  operationRegistry.register(marketingDailyIdeasEmailOperation)
   
   // Integration operations
   operationRegistry.register(httpRequestOperation)

--- a/apps/backend/src/modules/visual_flows/operations/marketing-daily-ideas-email.ts
+++ b/apps/backend/src/modules/visual_flows/operations/marketing-daily-ideas-email.ts
@@ -1,0 +1,161 @@
+import { z } from "@medusajs/framework/zod"
+import { OperationDefinition, OperationContext, OperationResult } from "./types"
+import { interpolateVariables } from "./utils"
+import {
+  runDailyIdeasEmail,
+  isSendEnabled,
+  type RunDailyIdeasEmailDeps,
+} from "../../../workflows/marketing/run-daily-ideas-email"
+
+/**
+ * marketing_daily_ideas_email — #659 slice 2, visual-flow edition.
+ *
+ * A single operation node that runs the daily AI-VP-of-Marketing tactical-ideas
+ * email end to end by chaining the two EXISTING marketing workflows (it does NOT
+ * duplicate that logic — see `run-daily-ideas-email.ts`):
+ *   1. generate-ideas-email → reads ground-truth snapshots, prompts the LLM,
+ *      runs the hallucination guard, persists a `marketing_ideas_log` row.
+ *   2. send-ideas-email → ONLY when `generated && guard_passed && log_id` AND
+ *      the send gate is on → mails the operator recipients and flips sent=true.
+ *
+ * WHY A FLOW NODE (not a `src/jobs/*` cron): the operator owns the cadence. This
+ * node sits behind a schedule-trigger node on an editable canvas; the schedule is
+ * parsed and fired by `src/jobs/run-scheduled-visual-flows.ts`. Suggested cadence:
+ * "30 1 * * *" (≈ 7 AM IST) — AFTER `marketing-daily-refresh` ("0 1 * * *") so the
+ * snapshot rows exist. The operator can retime it from the canvas; no redeploy.
+ *
+ * OPERATOR SAFETY / explicit opt-in:
+ *   GENERATE always runs and logs (the draft + guard verdict are persisted and
+ *   reviewable even when nothing is mailed). SEND is OFF by default and only fires
+ *   when EITHER the node option `send_enabled: true` is set OR the env flag
+ *   `MARKETING_IDEAS_EMAIL_ENABLED` is truthy. Default OFF in prod.
+ *
+ * NEVER throws past the workflow boundary: the orchestrator swallows runner
+ * errors and reports them in the summary; `execute` additionally try/catches so a
+ * config error returns `success:false` rather than crashing the executor.
+ *
+ * Node output (the summary): { generated, guard_passed, log_id, send_enabled,
+ *   send_attempted, sent, skipped_reason, errored }.
+ */
+
+export const marketingDailyIdeasEmailOptionsSchema = z.object({
+  /**
+   * Enable the SEND step from the canvas. When omitted/undefined the env flag
+   * `MARKETING_IDEAS_EMAIL_ENABLED` decides (default OFF). When set, this
+   * explicit value wins. Accepts a `{{ variable }}` string that resolves to a
+   * boolean-ish value too.
+   */
+  send_enabled: z.union([z.boolean(), z.string()]).optional(),
+  /**
+   * Optional explicit recipient override (array, or a `{{ variable }}` string
+   * resolving to one). When unset, the send workflow falls back to its CSV env /
+   * platform-admin recipients.
+   */
+  recipients: z.union([z.array(z.string()), z.string()]).optional(),
+})
+
+export type MarketingDailyIdeasEmailOptions = z.infer<
+  typeof marketingDailyIdeasEmailOptionsSchema
+>
+
+/**
+ * Coerce a resolved `send_enabled` option into a tri-state:
+ *   - `undefined` → caller falls back to the env gate
+ *   - `true`/`false` → explicit override
+ * Pure so it's unit-testable. Mirrors `isSendEnabled`'s truthy vocabulary for
+ * strings ("true"/"1"/"yes"/"on" → true; "false"/"0"/"no"/"off" → false).
+ */
+export function resolveSendEnabledOption(
+  value: unknown
+): boolean | undefined {
+  if (value === undefined || value === null || value === "") return undefined
+  if (typeof value === "boolean") return value
+  const raw = String(value).trim().toLowerCase()
+  if (raw === "true" || raw === "1" || raw === "yes" || raw === "on") return true
+  if (raw === "false" || raw === "0" || raw === "no" || raw === "off") {
+    return false
+  }
+  return undefined
+}
+
+/** Normalize a resolved `recipients` option into a clean string[] (or undefined). */
+export function normalizeRecipientsOption(
+  value: unknown
+): string[] | undefined {
+  let list: unknown[] | null = null
+  if (Array.isArray(value)) {
+    list = value
+  } else if (typeof value === "string" && value.trim()) {
+    // Allow a CSV string for the canvas convenience.
+    list = value.split(",")
+  }
+  if (!list) return undefined
+  const out = list
+    .map((v) => (typeof v === "string" ? v.trim() : ""))
+    .filter((v) => v.length > 0)
+  return out.length > 0 ? out : undefined
+}
+
+export const marketingDailyIdeasEmailOperation: OperationDefinition = {
+  type: "marketing_daily_ideas_email",
+  name: "Marketing Daily Ideas Email",
+  description:
+    "Run the daily AI tactical-ideas email: generate (LLM + hallucination guard + persist a marketing_ideas_log), then send only when guard-passed AND enabled. Pair with a schedule-trigger node to run it every morning. Send is OFF unless send_enabled or MARKETING_IDEAS_EMAIL_ENABLED is set.",
+  icon: "envelope",
+  category: "communication",
+  optionsSchema: marketingDailyIdeasEmailOptionsSchema,
+
+  defaultOptions: {},
+
+  execute: async (
+    options: any,
+    context: OperationContext
+  ): Promise<OperationResult> => {
+    try {
+      const parsed = marketingDailyIdeasEmailOptionsSchema.parse(options ?? {})
+
+      // Resolve {{ variable }} references BEFORE interpreting the values
+      // (reference_visual_flow_template_items_resolution: interpolate string
+      // options before any type-narrowing checks).
+      const resolvedSendEnabled =
+        parsed.send_enabled !== undefined
+          ? interpolateVariables(parsed.send_enabled, context.dataChain)
+          : undefined
+      const resolvedRecipients =
+        parsed.recipients !== undefined
+          ? interpolateVariables(parsed.recipients, context.dataChain)
+          : undefined
+
+      const deps: RunDailyIdeasEmailDeps = {}
+      const sendOverride = resolveSendEnabledOption(resolvedSendEnabled)
+      if (sendOverride !== undefined) {
+        deps.sendEnabled = sendOverride
+      }
+      const recipients = normalizeRecipientsOption(resolvedRecipients)
+      if (recipients) {
+        deps.recipients = recipients
+      }
+
+      const summary = await runDailyIdeasEmail(context.container, deps)
+
+      return {
+        success: true,
+        data: {
+          ...summary,
+          // Convenience scalar so a downstream condition node can branch on it.
+          mailed: summary.sent > 0,
+        },
+      }
+    } catch (error: any) {
+      // The orchestrator never throws; this guards only config/parse errors.
+      return {
+        success: false,
+        error: error?.message ?? "Failed to run daily ideas email",
+        errorStack: error?.stack,
+      }
+    }
+  },
+}
+
+// Re-export so a flow/seed can read the env-only default without importing the lib.
+export { isSendEnabled }

--- a/apps/backend/src/scripts/__tests__/seed-marketing-daily-ideas-email-flow.unit.spec.ts
+++ b/apps/backend/src/scripts/__tests__/seed-marketing-daily-ideas-email-flow.unit.spec.ts
@@ -1,0 +1,60 @@
+import { FLOW_DEF } from "../seed-marketing-daily-ideas-email-flow"
+
+/**
+ * Structural guards for the daily ideas-email visual flow seed (#659 slice 2).
+ *
+ * The flow is editor-gated and cannot be live-verified by the daemon, and it
+ * wires the operation by STRING name only. A typo in the op type would silently
+ * no-op at runtime, so these tests pin the contract + the log node's keys.
+ */
+describe("seed-marketing-daily-ideas-email-flow FLOW_DEF", () => {
+  it("is a daily schedule-triggered draft flow at 30 1 * * *", () => {
+    expect(FLOW_DEF.status).toBe("draft")
+    expect(FLOW_DEF.trigger_type).toBe("schedule")
+    expect(FLOW_DEF.trigger_config.cron).toBe("30 1 * * *")
+    expect(
+      (FLOW_DEF.canvas_state.nodes[0].data as any).triggerConfig.cron
+    ).toBe(FLOW_DEF.trigger_config.cron)
+  })
+
+  it("wires run_ideas → log via marketing_daily_ideas_email", () => {
+    const byKey = Object.fromEntries(
+      FLOW_DEF.operations.map((o) => [o.operation_key, o])
+    )
+    expect(byKey.run_ideas.operation_type).toBe("marketing_daily_ideas_email")
+    expect(byKey.log_summary.operation_type).toBe("log")
+    expect(FLOW_DEF.operations.map((o) => o.sort_order)).toEqual([0, 1])
+  })
+
+  it("seeds send OFF (no send_enabled option → env gate decides)", () => {
+    const run = FLOW_DEF.operations.find(
+      (o) => o.operation_key === "run_ideas"
+    )!.options as any
+    expect(run.send_enabled).toBeUndefined()
+    expect(run.recipients).toBeUndefined()
+  })
+
+  it("has matching canvas edges and connection rows forming a linear chain", () => {
+    const conn = FLOW_DEF.connections.map((c) => `${c.source_id}->${c.target_id}`)
+    const edges = FLOW_DEF.canvas_state.edges.map((e) => `${e.source}->${e.target}`)
+    expect(conn).toEqual(edges)
+    expect(conn).toEqual(["trigger->run_ideas", "run_ideas->log_summary"])
+  })
+
+  it("logs the real summary keys emitted by the op", () => {
+    const log = FLOW_DEF.operations.find(
+      (o) => o.operation_key === "log_summary"
+    )!.options as any
+    for (const key of [
+      "{{ run_ideas.generated }}",
+      "{{ run_ideas.guard_passed }}",
+      "{{ run_ideas.log_id }}",
+      "{{ run_ideas.send_enabled }}",
+      "{{ run_ideas.sent }}",
+      "{{ run_ideas.skipped_reason }}",
+      "{{ run_ideas.errored }}",
+    ]) {
+      expect(log.message).toContain(key)
+    }
+  })
+})

--- a/apps/backend/src/scripts/seed-marketing-daily-ideas-email-flow.ts
+++ b/apps/backend/src/scripts/seed-marketing-daily-ideas-email-flow.ts
@@ -1,0 +1,170 @@
+/**
+ * Seed: Marketing Daily Ideas Email — Daily Flow (#659 slice 2, visual-flow edition)
+ *
+ * The daily AI-VP-of-Marketing tactical-ideas email, as an OPERATOR-EDITABLE
+ * visual flow instead of a hard-coded `src/jobs/*` cron. The operator owns the
+ * cadence from the canvas; the schedule is parsed + fired every minute by
+ * `src/jobs/run-scheduled-visual-flows.ts`.
+ *
+ * Graph:
+ *   schedule (daily, 30 1 * * *)
+ *     → marketing_daily_ideas_email   (chains generate-ideas-email → guard →
+ *                                       send-ideas-email; send gated, never throws)
+ *     → log summary
+ *
+ * The op is referenced by STRING name only (no imports) so this seed branches
+ * off main independently. The op type `marketing_daily_ideas_email` ships in the
+ * same PR; the generate/send workflows are already on main.
+ *
+ * Cadence (locked decision):
+ *   Cron `30 1 * * *` = 01:30 UTC ≈ 07:00 IST — 30 min AFTER
+ *   `marketing-daily-refresh` ("0 1 * * *") so the ground-truth snapshot rows
+ *   exist before we generate from them. If the deployed container runs in IST,
+ *   re-time from the canvas (no redeploy). Confirm host time before activating.
+ *
+ * Operator safety (send is OFF by default):
+ *   GENERATE always runs and persists a reviewable `marketing_ideas_log` row +
+ *   guard verdict. SEND only fires when EITHER the env flag
+ *   `MARKETING_IDEAS_EMAIL_ENABLED` is truthy OR the node option
+ *   `send_enabled: true` is set on the canvas. Seeded with NEITHER → generate +
+ *   log only until the operator explicitly opts in.
+ *
+ * Run:
+ *   npx medusa exec ./src/scripts/seed-marketing-daily-ideas-email-flow.ts
+ *
+ * Re-seed:
+ *   Delete the existing flow first (admin UI or by id) and re-run. The script is
+ *   idempotent and refuses to overwrite an existing flow.
+ */
+
+import { VISUAL_FLOWS_MODULE } from "../modules/visual_flows"
+import VisualFlowService from "../modules/visual_flows/service"
+
+const FLOW_NAME = "Marketing Daily Ideas Email — Daily"
+
+// Cron: 01:30 UTC ≈ 07:00 IST, 30 min after marketing-daily-refresh ("0 1 * * *").
+const IDEAS_CRON = "30 1 * * *"
+
+// ─── Canvas positions ────────────────────────────────────────────────────────
+const X_CENTER = 500
+const Y_RUN = 140
+const Y_LOG = 280
+
+// ─── Flow definition (exported for the structural unit test) ───────────────────
+
+export const FLOW_DEF = {
+  name: FLOW_NAME,
+  description:
+    "Daily scheduled AI tactical-ideas email: generate-ideas-email (LLM + " +
+    "hallucination guard + persist marketing_ideas_log), then send-ideas-email " +
+    "ONLY when guard-passed AND enabled. Send is OFF until the operator sets " +
+    "MARKETING_IDEAS_EMAIL_ENABLED or the node's send_enabled option. " +
+    "Never throws — a bad morning run cannot crash the executor.",
+  status: "draft" as const,
+  trigger_type: "schedule" as const,
+  trigger_config: {
+    cron: IDEAS_CRON, // 07:00 IST assuming a UTC container
+  },
+
+  canvas_state: {
+    viewport: { x: 0, y: 0, zoom: 0.9 },
+    nodes: [
+      { id: "trigger",     type: "trigger",   position: { x: X_CENTER, y: -20 },   data: { label: "Schedule — 07:00 IST daily", triggerType: "schedule", triggerConfig: { cron: IDEAS_CRON } } },
+      { id: "run_ideas",   type: "operation", position: { x: X_CENTER, y: Y_RUN }, data: { label: "Generate + Send Ideas Email", operationKey: "run_ideas", operationType: "marketing_daily_ideas_email", options: {} } },
+      { id: "log_summary", type: "operation", position: { x: X_CENTER, y: Y_LOG }, data: { label: "Log Summary", operationKey: "log_summary", operationType: "log", options: { message: "Daily ideas email — generated={{ run_ideas.generated }} guard_passed={{ run_ideas.guard_passed }} log_id={{ run_ideas.log_id }} send_enabled={{ run_ideas.send_enabled }} sent={{ run_ideas.sent }} skipped={{ run_ideas.skipped_reason }} errored={{ run_ideas.errored }}", level: "info" } } },
+    ],
+    edges: [
+      { id: "e-0", source: "trigger",   sourceHandle: "default", target: "run_ideas",   targetHandle: "default" },
+      { id: "e-1", source: "run_ideas", sourceHandle: "default", target: "log_summary", targetHandle: "default" },
+    ],
+  },
+
+  operations: [
+    // ── 1. Generate (always) → guarded Send (gated) ─────────────────────────
+    {
+      operation_key: "run_ideas",
+      operation_type: "marketing_daily_ideas_email",
+      name: "Generate + Send Ideas Email",
+      sort_order: 0,
+      position_x: X_CENTER,
+      position_y: Y_RUN,
+      options: {
+        // No send_enabled here → the env flag MARKETING_IDEAS_EMAIL_ENABLED
+        // decides (default OFF). To turn the email on from the canvas instead,
+        // set send_enabled: true. Optional recipients override:
+        //   recipients: ["ops@jyt.example"]
+      },
+    },
+
+    // ── 2. Log summary line for observability ──────────────────────────────
+    {
+      operation_key: "log_summary",
+      operation_type: "log",
+      name: "Log Summary",
+      sort_order: 1,
+      position_x: X_CENTER,
+      position_y: Y_LOG,
+      options: {
+        message:
+          "Daily ideas email — generated={{ run_ideas.generated }} " +
+          "guard_passed={{ run_ideas.guard_passed }} " +
+          "log_id={{ run_ideas.log_id }} " +
+          "send_enabled={{ run_ideas.send_enabled }} " +
+          "sent={{ run_ideas.sent }} " +
+          "skipped={{ run_ideas.skipped_reason }} " +
+          "errored={{ run_ideas.errored }}",
+        level: "info",
+      },
+    },
+  ],
+
+  connections: [
+    { source_id: "trigger",   source_handle: "default", target_id: "run_ideas",   connection_type: "default" as const },
+    { source_id: "run_ideas", source_handle: "default", target_id: "log_summary", connection_type: "default" as const },
+  ],
+}
+
+// ─── Runner ──────────────────────────────────────────────────────────────────
+
+export default async function seedMarketingDailyIdeasEmailFlow({
+  container,
+}: {
+  container: any
+}) {
+  const service: VisualFlowService = container.resolve(VISUAL_FLOWS_MODULE)
+
+  const [existing] = await service.listVisualFlows({ name: FLOW_NAME } as any)
+  if (existing) {
+    console.log(`Flow "${FLOW_NAME}" already exists (${existing.id}) — skipping.`)
+    console.log(`Delete it in the admin UI (or by id) to re-seed.`)
+    return
+  }
+
+  console.log(`Creating flow "${FLOW_NAME}"...`)
+
+  const flow = await service.createCompleteFlow({
+    flow: {
+      name: FLOW_DEF.name,
+      description: FLOW_DEF.description,
+      status: FLOW_DEF.status,
+      trigger_type: FLOW_DEF.trigger_type,
+      trigger_config: FLOW_DEF.trigger_config,
+      canvas_state: FLOW_DEF.canvas_state,
+    },
+    operations: FLOW_DEF.operations,
+    connections: FLOW_DEF.connections,
+  })
+
+  console.log(`\nFlow created: ${flow.id}`)
+  console.log(`  Open: /app/visual-flows/${flow.id}\n`)
+  console.log(`Before activating (draft → active):`)
+  console.log(`  1. The op "marketing_daily_ideas_email" ships in this PR (#659).`)
+  console.log(`     The generate/send marketing workflows are already on main.`)
+  console.log(`  2. Confirm the deployed container's local time matches the cron`)
+  console.log(`     assumption. This seed uses "${IDEAS_CRON}" = 07:00 IST assuming`)
+  console.log(`     a UTC container; re-time from the canvas if it runs in IST.`)
+  console.log(`  3. SEND stays OFF until you opt in: set MARKETING_IDEAS_EMAIL_ENABLED`)
+  console.log(`     (env) OR the node option send_enabled: true. Until then the flow`)
+  console.log(`     only generates + logs a reviewable marketing_ideas_log row.`)
+  console.log(`  4. Flip flow status: draft → active in the admin editor.`)
+}

--- a/apps/backend/src/workflows/marketing/__tests__/run-daily-ideas-email.unit.spec.ts
+++ b/apps/backend/src/workflows/marketing/__tests__/run-daily-ideas-email.unit.spec.ts
@@ -1,0 +1,186 @@
+import {
+  runDailyIdeasEmail,
+  isSendEnabled,
+  type GenerateRunner,
+  type SendRunner,
+} from "../run-daily-ideas-email"
+import type { GenerateIdeasEmailResult } from "../generate-ideas-email"
+import type { SendIdeasEmailResult } from "../send-ideas-email"
+
+/**
+ * #659 slice 2 — unit tests for the visual-flow orchestrator (no container LLM,
+ * no real email). The two workflow `.run()` calls are INJECTED as stubs so CI
+ * never touches a model or mailer. Covers the four contract cases:
+ *   (a) guard-passed → send runner invoked with the log id
+ *   (b) guard-failed / skipped → send NOT invoked
+ *   (c) send disabled by the gate → generate ran, send skipped
+ *   (d) a thrown error inside either runner is swallowed (never rejects)
+ */
+
+// Minimal container stub — only `.resolve(LOGGER)` is exercised; we let it throw
+// so the orchestrator falls back to `console`, proving the resolve is optional.
+const container: any = {
+  resolve: () => {
+    throw new Error("no logger in unit test")
+  },
+}
+
+const baseGen = (over: Partial<GenerateIdeasEmailResult> = {}): GenerateIdeasEmailResult => ({
+  skipped: false,
+  generated: true,
+  guard_passed: true,
+  regenerated: false,
+  log_id: "log_123",
+  output_text: "ideas",
+  model_used: "stub",
+  ground_truth: null,
+  ...over,
+})
+
+const baseSend = (over: Partial<SendIdeasEmailResult> = {}): SendIdeasEmailResult => ({
+  sent: 2,
+  skipped: false,
+  guard_passed: true,
+  review_notice_sent: false,
+  recipients: 2,
+  ...over,
+})
+
+describe("runDailyIdeasEmail", () => {
+  it("(a) guard-passed + send enabled → invokes send with the log id", async () => {
+    const sendCalls: any[] = []
+    const generate: GenerateRunner = async () => baseGen()
+    const send: SendRunner = async (input) => {
+      sendCalls.push(input)
+      return baseSend({ sent: 3, recipients: 3 })
+    }
+
+    const summary = await runDailyIdeasEmail(container, {
+      generate,
+      send,
+      sendEnabled: true,
+    })
+
+    expect(sendCalls).toHaveLength(1)
+    expect(sendCalls[0]).toEqual({ logId: "log_123" })
+    expect(summary).toMatchObject({
+      generated: true,
+      guard_passed: true,
+      log_id: "log_123",
+      send_enabled: true,
+      send_attempted: true,
+      sent: 3,
+      errored: false,
+      skipped_reason: null,
+    })
+  })
+
+  it("(a') forwards an explicit recipients override into the send input", async () => {
+    const sendCalls: any[] = []
+    const summary = await runDailyIdeasEmail(container, {
+      generate: async () => baseGen(),
+      send: async (input) => {
+        sendCalls.push(input)
+        return baseSend()
+      },
+      sendEnabled: true,
+      recipients: ["a@x.com", "b@x.com"],
+    })
+    expect(sendCalls[0]).toEqual({
+      logId: "log_123",
+      recipients: ["a@x.com", "b@x.com"],
+    })
+    expect(summary.send_attempted).toBe(true)
+  })
+
+  it("(b) guard-failed → does NOT invoke send", async () => {
+    let sendInvoked = false
+    const summary = await runDailyIdeasEmail(container, {
+      generate: async () => baseGen({ guard_passed: false, reason: "guard_failed" }),
+      send: async () => {
+        sendInvoked = true
+        return baseSend()
+      },
+      sendEnabled: true,
+    })
+
+    expect(sendInvoked).toBe(false)
+    expect(summary.send_attempted).toBe(false)
+    expect(summary.sent).toBe(0)
+    expect(summary.guard_passed).toBe(false)
+    expect(summary.skipped_reason).toBe("guard_failed")
+  })
+
+  it("(b') skipped generate → does NOT invoke send", async () => {
+    let sendInvoked = false
+    const summary = await runDailyIdeasEmail(container, {
+      generate: async () =>
+        baseGen({ skipped: true, generated: false, guard_passed: false, log_id: null }),
+      send: async () => {
+        sendInvoked = true
+        return baseSend()
+      },
+      sendEnabled: true,
+    })
+    expect(sendInvoked).toBe(false)
+    expect(summary.send_attempted).toBe(false)
+    expect(summary.skipped_reason).toBe("generate_skipped")
+  })
+
+  it("(c) send disabled by gate → generate ran, send skipped", async () => {
+    let sendInvoked = false
+    const summary = await runDailyIdeasEmail(container, {
+      generate: async () => baseGen(),
+      send: async () => {
+        sendInvoked = true
+        return baseSend()
+      },
+      sendEnabled: false,
+    })
+
+    expect(sendInvoked).toBe(false)
+    expect(summary.generated).toBe(true)
+    expect(summary.guard_passed).toBe(true)
+    expect(summary.send_enabled).toBe(false)
+    expect(summary.send_attempted).toBe(false)
+    expect(summary.skipped_reason).toBe("send_disabled")
+  })
+
+  it("(d) a thrown error in generate is swallowed (never rejects)", async () => {
+    const summary = await runDailyIdeasEmail(container, {
+      generate: async () => {
+        throw new Error("LLM boom")
+      },
+      send: async () => baseSend(),
+      sendEnabled: true,
+    })
+    expect(summary.errored).toBe(true)
+    expect(summary.skipped_reason).toBe("generate_threw")
+    expect(summary.send_attempted).toBe(false)
+  })
+
+  it("(d') a thrown error in send is swallowed (never rejects)", async () => {
+    const summary = await runDailyIdeasEmail(container, {
+      generate: async () => baseGen(),
+      send: async () => {
+        throw new Error("mailer boom")
+      },
+      sendEnabled: true,
+    })
+    expect(summary.errored).toBe(true)
+    expect(summary.skipped_reason).toBe("send_threw")
+    expect(summary.send_attempted).toBe(true)
+    expect(summary.sent).toBe(0)
+  })
+})
+
+describe("isSendEnabled", () => {
+  it("is true only for truthy env vocabulary", () => {
+    expect(isSendEnabled({ MARKETING_IDEAS_EMAIL_ENABLED: "true" } as any)).toBe(true)
+    expect(isSendEnabled({ MARKETING_IDEAS_EMAIL_ENABLED: "1" } as any)).toBe(true)
+    expect(isSendEnabled({ MARKETING_IDEAS_EMAIL_ENABLED: "on" } as any)).toBe(true)
+    expect(isSendEnabled({ MARKETING_IDEAS_EMAIL_ENABLED: "false" } as any)).toBe(false)
+    expect(isSendEnabled({ MARKETING_IDEAS_EMAIL_ENABLED: "" } as any)).toBe(false)
+    expect(isSendEnabled({} as any)).toBe(false)
+  })
+})

--- a/apps/backend/src/workflows/marketing/run-daily-ideas-email.ts
+++ b/apps/backend/src/workflows/marketing/run-daily-ideas-email.ts
@@ -1,0 +1,187 @@
+import { MedusaContainer } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import {
+  generateIdeasEmailWorkflow,
+  type GenerateIdeasEmailResult,
+} from "./generate-ideas-email"
+import {
+  sendIdeasEmailWorkflow,
+  type SendIdeasEmailInput,
+  type SendIdeasEmailResult,
+} from "./send-ideas-email"
+
+/**
+ * run-daily-ideas-email — #659 slice 2 orchestrator (visual-flow edition).
+ *
+ * Chains the two EXISTING marketing workflows for the daily tactical-ideas email:
+ *   1. generate-ideas-email  → read ground-truth snapshots, ask the LLM for
+ *      tactical moves, run the hallucination guard, persist a `marketing_ideas_log`
+ *      row (BEFORE any send).
+ *   2. send-ideas-email      → ONLY when the generated log passed the guard, mail
+ *      the operator recipients and flip sent=true.
+ *
+ * KEY DESIGN (operator decision, #659): the SCHEDULE does NOT live in a
+ * `src/jobs/*` cron file. This module is pure orchestration logic that the
+ * `marketing_daily_ideas_email` visual-flow operation node calls — the cadence
+ * is owned by a schedule-trigger node on an operator-editable canvas, fired by
+ * `src/jobs/run-scheduled-visual-flows.ts`. There is intentionally no `config`
+ * export and no default scheduled-job export here.
+ *
+ * Operator safety / explicit opt-in:
+ *   GENERATE always runs and logs (so the draft + guard verdict are persisted and
+ *   reviewable in the ideas log even when nothing is mailed). SEND is gated behind
+ *   the env flag `MARKETING_IDEAS_EMAIL_ENABLED` (default OFF). Set it to "true"
+ *   (or "1") in prod to turn the daily email on — an explicit operator action.
+ *
+ * Fail-soft discipline (mirrors `marketing-daily-refresh`): every workflow call is
+ * wrapped so a bad morning run can NEVER throw past this boundary and crash the
+ * visual-flow executor. The caller gets a summary object; failures are reported
+ * in `errored` / `skipped_reason`, never as a thrown exception.
+ */
+
+/** Injectable generate runner — prompt+guard+persist; defaults to the real workflow. */
+export type GenerateRunner = () => Promise<GenerateIdeasEmailResult>
+/** Injectable send runner — mails a guarded log; defaults to the real workflow. */
+export type SendRunner = (
+  input: SendIdeasEmailInput
+) => Promise<SendIdeasEmailResult>
+
+export type RunDailyIdeasEmailDeps = {
+  /** Injected in tests so CI NEVER calls a live LLM. */
+  generate?: GenerateRunner
+  /** Injected in tests so CI NEVER sends a real email. */
+  send?: SendRunner
+  /** Override the env send-gate (else reads MARKETING_IDEAS_EMAIL_ENABLED). */
+  sendEnabled?: boolean
+  /** Optional explicit recipient override forwarded to the send workflow. */
+  recipients?: string[]
+}
+
+export type DailyIdeasEmailSummary = {
+  generated: boolean
+  guard_passed: boolean
+  log_id: string | null
+  send_enabled: boolean
+  send_attempted: boolean
+  sent: number
+  skipped_reason: string | null
+  errored: boolean
+}
+
+/** True only when the operator has explicitly opted in via the env flag. */
+export function isSendEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = (env.MARKETING_IDEAS_EMAIL_ENABLED || "").trim().toLowerCase()
+  return raw === "true" || raw === "1" || raw === "yes" || raw === "on"
+}
+
+/**
+ * Chain generate → (guarded) send. The runner fns default to the real workflow
+ * `.run()` calls but are INJECTABLE so tests pass stubs. NEVER throws — a thrown
+ * error inside a runner is swallowed and reported in the returned summary (the
+ * operation node must not be able to crash the visual-flow executor).
+ */
+export async function runDailyIdeasEmail(
+  container: MedusaContainer,
+  deps: RunDailyIdeasEmailDeps = {}
+): Promise<DailyIdeasEmailSummary> {
+  let logger: any
+  try {
+    logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  } catch {
+    logger = console
+  }
+
+  const generate: GenerateRunner =
+    deps.generate ||
+    (async () => {
+      const { result } = await generateIdeasEmailWorkflow(container as any).run({
+        input: {},
+      })
+      return result as GenerateIdeasEmailResult
+    })
+
+  const send: SendRunner =
+    deps.send ||
+    (async (input: SendIdeasEmailInput) => {
+      const { result } = await sendIdeasEmailWorkflow(container as any).run({
+        input,
+      })
+      return result as SendIdeasEmailResult
+    })
+
+  const sendEnabled = deps.sendEnabled ?? isSendEnabled()
+
+  const summary: DailyIdeasEmailSummary = {
+    generated: false,
+    guard_passed: false,
+    log_id: null,
+    send_enabled: sendEnabled,
+    send_attempted: false,
+    sent: 0,
+    skipped_reason: null,
+    errored: false,
+  }
+
+  // --- 1) GENERATE (always runs + logs; persists the draft/guard verdict) -----
+  let gen: GenerateIdeasEmailResult | null = null
+  try {
+    gen = await generate()
+  } catch (e: any) {
+    summary.errored = true
+    summary.skipped_reason = "generate_threw"
+    logger.error?.(
+      `[daily-ideas-email] generate threw (swallowed): ${e?.message ?? e}`
+    )
+    return summary
+  }
+
+  summary.generated = gen?.generated === true
+  summary.guard_passed = gen?.guard_passed === true
+  summary.log_id = gen?.log_id ?? null
+
+  // --- 2) SEND only when: generated && guard_passed && have a log id --------
+  const sendable = summary.generated && summary.guard_passed && !!summary.log_id
+
+  if (!sendable) {
+    summary.skipped_reason =
+      gen?.reason ?? (gen?.skipped ? "generate_skipped" : "not_guard_passed")
+    logger.info?.(
+      `[daily-ideas-email] generated=${summary.generated} guard_passed=${summary.guard_passed} ` +
+        `log_id=${summary.log_id ?? "none"} → send skipped (${summary.skipped_reason})`
+    )
+    return summary
+  }
+
+  if (!sendEnabled) {
+    summary.skipped_reason = "send_disabled"
+    logger.info?.(
+      `[daily-ideas-email] log ${summary.log_id} guard-passed but MARKETING_IDEAS_EMAIL_ENABLED is off → not sent`
+    )
+    return summary
+  }
+
+  summary.send_attempted = true
+  try {
+    const sendInput: SendIdeasEmailInput = { logId: summary.log_id as string }
+    if (Array.isArray(deps.recipients) && deps.recipients.length > 0) {
+      sendInput.recipients = deps.recipients
+    }
+    const sent = await send(sendInput)
+    summary.sent = sent?.sent ?? 0
+    logger.info?.(
+      `[daily-ideas-email] log ${summary.log_id} sent to ${summary.sent} recipient(s)` +
+        (sent?.skipped ? ` (skipped: ${sent?.reason ?? "unknown"})` : "")
+    )
+  } catch (e: any) {
+    summary.errored = true
+    summary.skipped_reason = "send_threw"
+    logger.error?.(
+      `[daily-ideas-email] send threw for log ${summary.log_id} (swallowed): ${
+        e?.message ?? e
+      }`
+    )
+  }
+
+  return summary
+}


### PR DESCRIPTION
## #659 slice 2 — daily ideas-email as a visual flow (not a cron)

Per the operator decision (memory `project_659_ideas_email_visual_flow`): the daily AI tactical-ideas email becomes an **operator-editable visual flow** — a schedule-trigger node → one operation node — instead of a hard-coded `src/jobs/*` cron. The cadence is edited from the canvas and fired by the existing `run-scheduled-visual-flows` scanner. **No new cron file.**

### What's here
- **`workflows/marketing/run-daily-ideas-email.ts`** — pure, injectable, never-throws orchestrator. Chains the EXISTING `generateIdeasEmailWorkflow` → guard → `sendIdeasEmailWorkflow` (no logic duplication). GENERATE always runs + persists a reviewable `marketing_ideas_log` row; SEND only fires when `generated && guard_passed && log_id` **and** the gate is on. Gate = env `MARKETING_IDEAS_EMAIL_ENABLED` (default **OFF**) or the node's `send_enabled` option.
- **`marketing_daily_ideas_email` operation node** + registry registration (mirrors `partner_analytics_digest`). Interpolates `{{ }}` options before type-narrowing (`reference_visual_flow_template_items_resolution`). Optional `send_enabled` / `recipients` canvas options.
- **`seed-marketing-daily-ideas-email-flow.ts`** — idempotent **draft** flow `schedule(30 1 * * *)` ≈ 07:00 IST (after `marketing-daily-refresh` at `0 1 * * *`) → `run_ideas` → `log`. Mirrors the digest seed; `createCompleteFlow`.

### Tests (no live LLM / email)
21 unit tests, 3 suites, green; typecheck clean on changed files:
- orchestrator 4 contract cases via **injected stubs**: (a) guard-passed → send invoked with logId; (b) guard-failed/skipped → send NOT invoked; (c) send disabled → generate ran, send skipped; (d) thrown runner error swallowed (never rejects). Plus recipients passthrough + `isSendEnabled` vocabulary.
- operation option coercers (`resolveSendEnabledOption`, `normalizeRecipientsOption`) + registration shape.
- seed `FLOW_DEF` structural guards (op-type string, send-OFF, linear chain, log keys).

### Operator activation (after merge + deploy)
1. `npx medusa exec ./src/scripts/seed-marketing-daily-ideas-email-flow.ts`
2. Confirm host time vs the `30 1 * * *` (UTC→IST) assumption; re-time from canvas if needed.
3. Opt in to SEND: set `MARKETING_IDEAS_EMAIL_ENABLED` or node `send_enabled: true`.
4. Flip flow status draft → active.

PR-only — no merge (human review). Branched off fresh `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)