### PR TITLE
feat(#659): run marketing ideas-email from Data Plumbing console (manual dry-run/apply)

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/run-marketing-ideas-email.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/run-marketing-ideas-email.unit.spec.ts
@@ -1,0 +1,180 @@
+import {
+  buildIdeasEmailGenerateResult,
+  buildIdeasEmailSendExistingResult,
+  parseRecipientsCsv,
+} from "../registry"
+
+/**
+ * Pure-unit coverage for the run-marketing-ideas-email job's container-free
+ * helpers. The container-bound run() (LLM generation, guard, send) is exercised
+ * by the workflow integration test; here we lock down the CSV parser and the
+ * two result builders without booting the DB or invoking any workflow.
+ */
+describe("run-marketing-ideas-email — parseRecipientsCsv", () => {
+  it("returns undefined for undefined input", () => {
+    expect(parseRecipientsCsv(undefined)).toBeUndefined()
+  })
+
+  it("returns undefined for null input", () => {
+    expect(parseRecipientsCsv(null)).toBeUndefined()
+  })
+
+  it("returns undefined for empty string", () => {
+    expect(parseRecipientsCsv("")).toBeUndefined()
+  })
+
+  it("returns undefined for whitespace-only string", () => {
+    expect(parseRecipientsCsv("   ")).toBeUndefined()
+  })
+
+  it("parses a comma-separated string with trimming and blank dropping", () => {
+    expect(parseRecipientsCsv("a@x.com, b@y.com ,")).toEqual([
+      "a@x.com",
+      "b@y.com",
+    ])
+  })
+
+  it("parses an array with trimming and blank dropping", () => {
+    expect(parseRecipientsCsv([" a@x.com ", "b@y.com", ""])).toEqual([
+      "a@x.com",
+      "b@y.com",
+    ])
+  })
+
+  it("returns undefined for a non-array/non-string input", () => {
+    expect(parseRecipientsCsv(123)).toBeUndefined()
+  })
+})
+
+describe("run-marketing-ideas-email — buildIdeasEmailGenerateResult", () => {
+  it("dry-run, generated, guard-passed: previews would-send and reports no apply", () => {
+    const result = buildIdeasEmailGenerateResult(
+      "run-marketing-ideas-email",
+      true,
+      {
+        generated: true,
+        guard_passed: true,
+        log_id: "log_1",
+        send_enabled: false,
+        send_attempted: false,
+        sent: 0,
+        skipped_reason: null,
+        errored: false,
+      }
+    )
+    expect(result.job_id).toBe("run-marketing-ideas-email")
+    expect(result.dry_run).toBe(true)
+    expect(result.applied).toBe(false)
+    expect(result.summary).toMatch(/Dry-run/)
+    expect(result.summary).toMatch(/would send/)
+    expect(result.changes.find((c) => c.field === "generated")?.id).toBe(
+      "log_1"
+    )
+    const sentChange = result.changes.find((c) => c.field === "sent")
+    expect(sentChange?.after).toBe("(would send)")
+    expect(sentChange?.before).toBe(false)
+  })
+
+  it("apply, generated, guard-passed, sent > 0: reports applied and sent", () => {
+    const result = buildIdeasEmailGenerateResult("jid", false, {
+      generated: true,
+      guard_passed: true,
+      log_id: "log_2",
+      send_enabled: true,
+      send_attempted: true,
+      sent: 2,
+      skipped_reason: null,
+      errored: false,
+    })
+    expect(result.applied).toBe(true)
+    const sentChange = result.changes.find((c) => c.field === "sent")
+    expect(sentChange?.after).toBe(true)
+    expect(result.summary).toMatch(/sent to 2/)
+  })
+
+  it("guard failed: no sent change, summary contains FAILED, not applied", () => {
+    const result = buildIdeasEmailGenerateResult("jid", false, {
+      generated: true,
+      guard_passed: false,
+      log_id: "log_3",
+      send_enabled: true,
+      send_attempted: false,
+      sent: 0,
+      skipped_reason: "not_guard_passed",
+      errored: false,
+    })
+    expect(result.changes.find((c) => c.field === "sent")).toBeUndefined()
+    expect(result.summary).toMatch(/FAILED/)
+    expect(result.applied).toBe(false)
+  })
+
+  it("not generated: no generated change, not applied", () => {
+    const result = buildIdeasEmailGenerateResult("jid", true, {
+      generated: false,
+      guard_passed: false,
+      log_id: null,
+      send_enabled: false,
+      send_attempted: false,
+      sent: 0,
+      skipped_reason: "no_snapshots",
+      errored: false,
+    })
+    expect(result.changes.find((c) => c.field === "generated")).toBeUndefined()
+    expect(result.applied).toBe(false)
+  })
+})
+
+describe("run-marketing-ideas-email — buildIdeasEmailSendExistingResult", () => {
+  it("dry-run, sendable: would-send, not applied", () => {
+    const result = buildIdeasEmailSendExistingResult(
+      "jid",
+      true,
+      "log_1",
+      { guard_passed: true, sent: false },
+      0
+    )
+    expect(result.applied).toBe(false)
+    const sentChange = result.changes.find((c) => c.field === "sent")
+    expect(sentChange?.after).toBe("(would send)")
+    expect(result.summary).toMatch(/would send/)
+  })
+
+  it("apply, sendable: sent, applied, summary mentions count", () => {
+    const result = buildIdeasEmailSendExistingResult(
+      "jid",
+      false,
+      "log_1",
+      { guard_passed: true, sent: false },
+      3
+    )
+    expect(result.applied).toBe(true)
+    const sentChange = result.changes.find((c) => c.field === "sent")
+    expect(sentChange?.after).toBe(true)
+    expect(result.summary).toMatch(/Sent/)
+    expect(result.summary).toMatch(/3/)
+  })
+
+  it("not sendable (guard failed): empty changes, not applied", () => {
+    const result = buildIdeasEmailSendExistingResult(
+      "jid",
+      false,
+      "log_9",
+      { guard_passed: false, sent: false },
+      0
+    )
+    expect(result.changes).toEqual([])
+    expect(result.applied).toBe(false)
+  })
+
+  it("not sendable (already sent): empty changes, not applied", () => {
+    const result = buildIdeasEmailSendExistingResult(
+      "jid",
+      false,
+      "log_9",
+      { guard_passed: true, sent: true },
+      0
+    )
+    expect(result.changes).toEqual([])
+    expect(result.applied).toBe(false)
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -35,6 +35,11 @@ import {
   type OutreachSyncEvent,
   type OutreachSyncRow,
 } from "../../../../modules/marketing/outreach-sync-lib"
+import {
+  runDailyIdeasEmail,
+  type DailyIdeasEmailSummary,
+} from "../../../../workflows/marketing/run-daily-ideas-email"
+import { sendIdeasEmailWorkflow } from "../../../../workflows/marketing/send-ideas-email"
 
 /**
  * Admin "data-plumbing" maintenance jobs (#457 / roadmap #33).
@@ -3340,6 +3345,177 @@ export const syncMarketingOutreachEngagementJob: MaintenanceJob = {
   },
 }
 
+// ---------------------------------------------------------------------------
+// run-marketing-ideas-email (#659) — operate the daily AI tactical-ideas email
+// from the Data-Plumbing console (manual, audited dry-run → apply) instead of a
+// hidden cron. Reuses the SAME injectable, never-throws `runDailyIdeasEmail`
+// orchestrator (chains generate-ideas-email → guard → send-ideas-email) — no
+// logic duplicated here. dry_run = generate + guard + persist the draft to
+// `marketing_ideas_log` for review WITHOUT emailing; apply = email it (the apply
+// click is the explicit consent, so it sends regardless of the env send-gate).
+// Pass `log_id` to send a specific already-generated, guard-passed draft without
+// a second LLM call (the dry-run returns the log id to paste back into apply).
+// ---------------------------------------------------------------------------
+
+/** Pure: parse a CSV/array `recipients` param into a clean string[] (or undefined). */
+export function parseRecipientsCsv(raw: unknown): string[] | undefined {
+  let list: unknown[] | null = null
+  if (Array.isArray(raw)) {
+    list = raw
+  } else if (typeof raw === "string" && raw.trim()) {
+    list = raw.split(",")
+  }
+  if (!list) return undefined
+  const out = list
+    .map((v) => (typeof v === "string" ? v.trim() : String(v ?? "").trim()))
+    .filter((v) => v.length > 0)
+  return out.length > 0 ? out : undefined
+}
+
+/**
+ * Pure: turn the orchestrator summary (generate path) into a MaintenanceJobResult.
+ * Exported for unit testing — keeps the dry-run/apply reporting verifiable without
+ * booting the DB or the LLM.
+ */
+export function buildIdeasEmailGenerateResult(
+  jobId: string,
+  dry_run: boolean,
+  summary: DailyIdeasEmailSummary
+): MaintenanceJobResult {
+  const logId = summary.log_id ?? "(none)"
+  const changes: MaintenanceChange[] = []
+  if (summary.generated) {
+    changes.push({
+      entity: "marketing_ideas_log",
+      id: logId,
+      field: "generated",
+      after: { guard_passed: summary.guard_passed, errored: summary.errored },
+    })
+  }
+  if (summary.guard_passed && summary.log_id) {
+    changes.push({
+      entity: "marketing_ideas_log",
+      id: logId,
+      field: "sent",
+      before: false,
+      after: dry_run ? "(would send)" : summary.sent > 0,
+    })
+  }
+  const applied = !dry_run && summary.sent > 0
+  const guardLabel = summary.guard_passed ? "passed" : "FAILED"
+  const summaryText = dry_run
+    ? `Dry-run: generated ideas log ${logId} (guard ${guardLabel}); ${
+        summary.guard_passed ? "would send" : "send blocked"
+      } — nothing emailed.`
+    : `Generated ideas log ${logId} (guard ${guardLabel}); sent to ${summary.sent} recipient(s)${
+        summary.skipped_reason ? ` (${summary.skipped_reason})` : ""
+      }.`
+  return { job_id: jobId, dry_run, applied, summary: summaryText, changes }
+}
+
+/**
+ * Pure: report the send-an-existing-log path (when `log_id` is supplied). A log
+ * is sendable only when it passed the guard and hasn't been sent yet.
+ */
+export function buildIdeasEmailSendExistingResult(
+  jobId: string,
+  dry_run: boolean,
+  logId: string,
+  log: { guard_passed?: boolean; sent?: boolean },
+  sentCount: number
+): MaintenanceJobResult {
+  const sendable = log?.guard_passed === true && log?.sent !== true
+  const changes: MaintenanceChange[] = []
+  if (sendable) {
+    changes.push({
+      entity: "marketing_ideas_log",
+      id: logId,
+      field: "sent",
+      before: false,
+      after: dry_run ? "(would send)" : sentCount > 0,
+    })
+  }
+  const applied = !dry_run && sentCount > 0
+  const summaryText = !sendable
+    ? `Ideas log ${logId} is not sendable (guard_passed=${
+        log?.guard_passed === true
+      }, sent=${log?.sent === true}) — nothing emailed.`
+    : dry_run
+    ? `Dry-run: ideas log ${logId} is guard-passed + unsent — would send. Nothing emailed.`
+    : `Sent ideas log ${logId} to ${sentCount} recipient(s).`
+  return { job_id: jobId, dry_run, applied, summary: summaryText, changes }
+}
+
+export const runMarketingIdeasEmailJob: MaintenanceJob = {
+  id: "run-marketing-ideas-email",
+  label: "Run marketing tactical-ideas email",
+  description:
+    "Run the daily AI VP-of-Marketing tactical-ideas email on demand (#659). Dry-run (default) generates the email, runs the hallucination guard, and persists the draft to marketing_ideas_log for review — but emails NO ONE. Apply emails it (the apply click is the explicit send consent, so it overrides the MARKETING_IDEAS_EMAIL_ENABLED env gate). Optionally pass log_id to send a specific already-generated, guard-passed draft without a second LLM call, and/or recipients (comma-separated) to override the default operator recipients.",
+  params: [
+    {
+      name: "log_id",
+      type: "string",
+      required: false,
+      description:
+        "Send a specific existing marketing_ideas_log draft (skips regeneration). Omit to generate a fresh email.",
+    },
+    {
+      name: "recipients",
+      type: "string",
+      required: false,
+      description:
+        "Comma-separated recipient override (default: MARKETING_IDEAS_RECIPIENTS env / platform admins).",
+    },
+  ],
+  run: async (container, { dry_run, params }) => {
+    const recipients = parseRecipientsCsv(params.recipients)
+    const logId =
+      typeof params.log_id === "string" && params.log_id.trim()
+        ? params.log_id.trim()
+        : undefined
+
+    // --- send-an-existing-draft path -------------------------------------
+    if (logId) {
+      const marketing: any = container.resolve(MARKETING_MODULE)
+      let log: any
+      try {
+        log = await marketing.retrieveMarketingIdeasLog(logId)
+      } catch {
+        throw new MedusaError(
+          MedusaError.Types.NOT_FOUND,
+          `marketing_ideas_log ${logId} not found`
+        )
+      }
+      const sendable = log?.guard_passed === true && log?.sent !== true
+      let sentCount = 0
+      if (!dry_run && sendable) {
+        const { result } = await sendIdeasEmailWorkflow(container).run({
+          input: { logId, ...(recipients ? { recipients } : {}) },
+        })
+        sentCount = result?.sent ?? 0
+      }
+      return buildIdeasEmailSendExistingResult(
+        runMarketingIdeasEmailJob.id,
+        dry_run,
+        logId,
+        log,
+        sentCount
+      )
+    }
+
+    // --- generate (+ send on apply) path; apply is the explicit consent ----
+    const summary = await runDailyIdeasEmail(container, {
+      sendEnabled: !dry_run,
+      ...(recipients ? { recipients } : {}),
+    })
+    return buildIdeasEmailGenerateResult(
+      runMarketingIdeasEmailJob.id,
+      dry_run,
+      summary
+    )
+  },
+}
+
 export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   recalculateDesignCostJob,
   recalculateDesignCostBulkJob,
@@ -3356,6 +3532,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   backfillStatsPanelWindowJob,
   backfillOrderPersonsJob,
   syncMarketingOutreachEngagementJob,
+  runMarketingIdeasEmailJob,
 ]
 
 export const getMaintenanceJob = (id: string): MaintenanceJob | undefined =>

--- a/apps/backend/src/workflows/marketing/__tests__/run-daily-ideas-email.unit.spec.ts
+++ b/apps/backend/src/workflows/marketing/__tests__/run-daily-ideas-email.unit.spec.ts
@@ -1,0 +1,186 @@
+import {
+  runDailyIdeasEmail,
+  isSendEnabled,
+  type GenerateRunner,
+  type SendRunner,
+} from "../run-daily-ideas-email"
+import type { GenerateIdeasEmailResult } from "../generate-ideas-email"
+import type { SendIdeasEmailResult } from "../send-ideas-email"
+
+/**
+ * #659 slice 2 — unit tests for the visual-flow orchestrator (no container LLM,
+ * no real email). The two workflow `.run()` calls are INJECTED as stubs so CI
+ * never touches a model or mailer. Covers the four contract cases:
+ *   (a) guard-passed → send runner invoked with the log id
+ *   (b) guard-failed / skipped → send NOT invoked
+ *   (c) send disabled by the gate → generate ran, send skipped
+ *   (d) a thrown error inside either runner is swallowed (never rejects)
+ */
+
+// Minimal container stub — only `.resolve(LOGGER)` is exercised; we let it throw
+// so the orchestrator falls back to `console`, proving the resolve is optional.
+const container: any = {
+  resolve: () => {
+    throw new Error("no logger in unit test")
+  },
+}
+
+const baseGen = (over: Partial<GenerateIdeasEmailResult> = {}): GenerateIdeasEmailResult => ({
+  skipped: false,
+  generated: true,
+  guard_passed: true,
+  regenerated: false,
+  log_id: "log_123",
+  output_text: "ideas",
+  model_used: "stub",
+  ground_truth: null,
+  ...over,
+})
+
+const baseSend = (over: Partial<SendIdeasEmailResult> = {}): SendIdeasEmailResult => ({
+  sent: 2,
+  skipped: false,
+  guard_passed: true,
+  review_notice_sent: false,
+  recipients: 2,
+  ...over,
+})
+
+describe("runDailyIdeasEmail", () => {
+  it("(a) guard-passed + send enabled → invokes send with the log id", async () => {
+    const sendCalls: any[] = []
+    const generate: GenerateRunner = async () => baseGen()
+    const send: SendRunner = async (input) => {
+      sendCalls.push(input)
+      return baseSend({ sent: 3, recipients: 3 })
+    }
+
+    const summary = await runDailyIdeasEmail(container, {
+      generate,
+      send,
+      sendEnabled: true,
+    })
+
+    expect(sendCalls).toHaveLength(1)
+    expect(sendCalls[0]).toEqual({ logId: "log_123" })
+    expect(summary).toMatchObject({
+      generated: true,
+      guard_passed: true,
+      log_id: "log_123",
+      send_enabled: true,
+      send_attempted: true,
+      sent: 3,
+      errored: false,
+      skipped_reason: null,
+    })
+  })
+
+  it("(a') forwards an explicit recipients override into the send input", async () => {
+    const sendCalls: any[] = []
+    const summary = await runDailyIdeasEmail(container, {
+      generate: async () => baseGen(),
+      send: async (input) => {
+        sendCalls.push(input)
+        return baseSend()
+      },
+      sendEnabled: true,
+      recipients: ["a@x.com", "b@x.com"],
+    })
+    expect(sendCalls[0]).toEqual({
+      logId: "log_123",
+      recipients: ["a@x.com", "b@x.com"],
+    })
+    expect(summary.send_attempted).toBe(true)
+  })
+
+  it("(b) guard-failed → does NOT invoke send", async () => {
+    let sendInvoked = false
+    const summary = await runDailyIdeasEmail(container, {
+      generate: async () => baseGen({ guard_passed: false, reason: "guard_failed" }),
+      send: async () => {
+        sendInvoked = true
+        return baseSend()
+      },
+      sendEnabled: true,
+    })
+
+    expect(sendInvoked).toBe(false)
+    expect(summary.send_attempted).toBe(false)
+    expect(summary.sent).toBe(0)
+    expect(summary.guard_passed).toBe(false)
+    expect(summary.skipped_reason).toBe("guard_failed")
+  })
+
+  it("(b') skipped generate → does NOT invoke send", async () => {
+    let sendInvoked = false
+    const summary = await runDailyIdeasEmail(container, {
+      generate: async () =>
+        baseGen({ skipped: true, generated: false, guard_passed: false, log_id: null }),
+      send: async () => {
+        sendInvoked = true
+        return baseSend()
+      },
+      sendEnabled: true,
+    })
+    expect(sendInvoked).toBe(false)
+    expect(summary.send_attempted).toBe(false)
+    expect(summary.skipped_reason).toBe("generate_skipped")
+  })
+
+  it("(c) send disabled by gate → generate ran, send skipped", async () => {
+    let sendInvoked = false
+    const summary = await runDailyIdeasEmail(container, {
+      generate: async () => baseGen(),
+      send: async () => {
+        sendInvoked = true
+        return baseSend()
+      },
+      sendEnabled: false,
+    })
+
+    expect(sendInvoked).toBe(false)
+    expect(summary.generated).toBe(true)
+    expect(summary.guard_passed).toBe(true)
+    expect(summary.send_enabled).toBe(false)
+    expect(summary.send_attempted).toBe(false)
+    expect(summary.skipped_reason).toBe("send_disabled")
+  })
+
+  it("(d) a thrown error in generate is swallowed (never rejects)", async () => {
+    const summary = await runDailyIdeasEmail(container, {
+      generate: async () => {
+        throw new Error("LLM boom")
+      },
+      send: async () => baseSend(),
+      sendEnabled: true,
+    })
+    expect(summary.errored).toBe(true)
+    expect(summary.skipped_reason).toBe("generate_threw")
+    expect(summary.send_attempted).toBe(false)
+  })
+
+  it("(d') a thrown error in send is swallowed (never rejects)", async () => {
+    const summary = await runDailyIdeasEmail(container, {
+      generate: async () => baseGen(),
+      send: async () => {
+        throw new Error("mailer boom")
+      },
+      sendEnabled: true,
+    })
+    expect(summary.errored).toBe(true)
+    expect(summary.skipped_reason).toBe("send_threw")
+    expect(summary.send_attempted).toBe(true)
+    expect(summary.sent).toBe(0)
+  })
+})
+
+describe("isSendEnabled", () => {
+  it("is true only for truthy env vocabulary", () => {
+    expect(isSendEnabled({ MARKETING_IDEAS_EMAIL_ENABLED: "true" } as any)).toBe(true)
+    expect(isSendEnabled({ MARKETING_IDEAS_EMAIL_ENABLED: "1" } as any)).toBe(true)
+    expect(isSendEnabled({ MARKETING_IDEAS_EMAIL_ENABLED: "on" } as any)).toBe(true)
+    expect(isSendEnabled({ MARKETING_IDEAS_EMAIL_ENABLED: "false" } as any)).toBe(false)
+    expect(isSendEnabled({ MARKETING_IDEAS_EMAIL_ENABLED: "" } as any)).toBe(false)
+    expect(isSendEnabled({} as any)).toBe(false)
+  })
+})

--- a/apps/backend/src/workflows/marketing/run-daily-ideas-email.ts
+++ b/apps/backend/src/workflows/marketing/run-daily-ideas-email.ts
@@ -1,0 +1,187 @@
+import { MedusaContainer } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import {
+  generateIdeasEmailWorkflow,
+  type GenerateIdeasEmailResult,
+} from "./generate-ideas-email"
+import {
+  sendIdeasEmailWorkflow,
+  type SendIdeasEmailInput,
+  type SendIdeasEmailResult,
+} from "./send-ideas-email"
+
+/**
+ * run-daily-ideas-email — #659 slice 2 orchestrator (visual-flow edition).
+ *
+ * Chains the two EXISTING marketing workflows for the daily tactical-ideas email:
+ *   1. generate-ideas-email  → read ground-truth snapshots, ask the LLM for
+ *      tactical moves, run the hallucination guard, persist a `marketing_ideas_log`
+ *      row (BEFORE any send).
+ *   2. send-ideas-email      → ONLY when the generated log passed the guard, mail
+ *      the operator recipients and flip sent=true.
+ *
+ * KEY DESIGN (operator decision, #659): the SCHEDULE does NOT live in a
+ * `src/jobs/*` cron file. This module is pure orchestration logic that the
+ * `marketing_daily_ideas_email` visual-flow operation node calls — the cadence
+ * is owned by a schedule-trigger node on an operator-editable canvas, fired by
+ * `src/jobs/run-scheduled-visual-flows.ts`. There is intentionally no `config`
+ * export and no default scheduled-job export here.
+ *
+ * Operator safety / explicit opt-in:
+ *   GENERATE always runs and logs (so the draft + guard verdict are persisted and
+ *   reviewable in the ideas log even when nothing is mailed). SEND is gated behind
+ *   the env flag `MARKETING_IDEAS_EMAIL_ENABLED` (default OFF). Set it to "true"
+ *   (or "1") in prod to turn the daily email on — an explicit operator action.
+ *
+ * Fail-soft discipline (mirrors `marketing-daily-refresh`): every workflow call is
+ * wrapped so a bad morning run can NEVER throw past this boundary and crash the
+ * visual-flow executor. The caller gets a summary object; failures are reported
+ * in `errored` / `skipped_reason`, never as a thrown exception.
+ */
+
+/** Injectable generate runner — prompt+guard+persist; defaults to the real workflow. */
+export type GenerateRunner = () => Promise<GenerateIdeasEmailResult>
+/** Injectable send runner — mails a guarded log; defaults to the real workflow. */
+export type SendRunner = (
+  input: SendIdeasEmailInput
+) => Promise<SendIdeasEmailResult>
+
+export type RunDailyIdeasEmailDeps = {
+  /** Injected in tests so CI NEVER calls a live LLM. */
+  generate?: GenerateRunner
+  /** Injected in tests so CI NEVER sends a real email. */
+  send?: SendRunner
+  /** Override the env send-gate (else reads MARKETING_IDEAS_EMAIL_ENABLED). */
+  sendEnabled?: boolean
+  /** Optional explicit recipient override forwarded to the send workflow. */
+  recipients?: string[]
+}
+
+export type DailyIdeasEmailSummary = {
+  generated: boolean
+  guard_passed: boolean
+  log_id: string | null
+  send_enabled: boolean
+  send_attempted: boolean
+  sent: number
+  skipped_reason: string | null
+  errored: boolean
+}
+
+/** True only when the operator has explicitly opted in via the env flag. */
+export function isSendEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = (env.MARKETING_IDEAS_EMAIL_ENABLED || "").trim().toLowerCase()
+  return raw === "true" || raw === "1" || raw === "yes" || raw === "on"
+}
+
+/**
+ * Chain generate → (guarded) send. The runner fns default to the real workflow
+ * `.run()` calls but are INJECTABLE so tests pass stubs. NEVER throws — a thrown
+ * error inside a runner is swallowed and reported in the returned summary (the
+ * operation node must not be able to crash the visual-flow executor).
+ */
+export async function runDailyIdeasEmail(
+  container: MedusaContainer,
+  deps: RunDailyIdeasEmailDeps = {}
+): Promise<DailyIdeasEmailSummary> {
+  let logger: any
+  try {
+    logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  } catch {
+    logger = console
+  }
+
+  const generate: GenerateRunner =
+    deps.generate ||
+    (async () => {
+      const { result } = await generateIdeasEmailWorkflow(container as any).run({
+        input: {},
+      })
+      return result as GenerateIdeasEmailResult
+    })
+
+  const send: SendRunner =
+    deps.send ||
+    (async (input: SendIdeasEmailInput) => {
+      const { result } = await sendIdeasEmailWorkflow(container as any).run({
+        input,
+      })
+      return result as SendIdeasEmailResult
+    })
+
+  const sendEnabled = deps.sendEnabled ?? isSendEnabled()
+
+  const summary: DailyIdeasEmailSummary = {
+    generated: false,
+    guard_passed: false,
+    log_id: null,
+    send_enabled: sendEnabled,
+    send_attempted: false,
+    sent: 0,
+    skipped_reason: null,
+    errored: false,
+  }
+
+  // --- 1) GENERATE (always runs + logs; persists the draft/guard verdict) -----
+  let gen: GenerateIdeasEmailResult | null = null
+  try {
+    gen = await generate()
+  } catch (e: any) {
+    summary.errored = true
+    summary.skipped_reason = "generate_threw"
+    logger.error?.(
+      `[daily-ideas-email] generate threw (swallowed): ${e?.message ?? e}`
+    )
+    return summary
+  }
+
+  summary.generated = gen?.generated === true
+  summary.guard_passed = gen?.guard_passed === true
+  summary.log_id = gen?.log_id ?? null
+
+  // --- 2) SEND only when: generated && guard_passed && have a log id --------
+  const sendable = summary.generated && summary.guard_passed && !!summary.log_id
+
+  if (!sendable) {
+    summary.skipped_reason =
+      gen?.reason ?? (gen?.skipped ? "generate_skipped" : "not_guard_passed")
+    logger.info?.(
+      `[daily-ideas-email] generated=${summary.generated} guard_passed=${summary.guard_passed} ` +
+        `log_id=${summary.log_id ?? "none"} → send skipped (${summary.skipped_reason})`
+    )
+    return summary
+  }
+
+  if (!sendEnabled) {
+    summary.skipped_reason = "send_disabled"
+    logger.info?.(
+      `[daily-ideas-email] log ${summary.log_id} guard-passed but MARKETING_IDEAS_EMAIL_ENABLED is off → not sent`
+    )
+    return summary
+  }
+
+  summary.send_attempted = true
+  try {
+    const sendInput: SendIdeasEmailInput = { logId: summary.log_id as string }
+    if (Array.isArray(deps.recipients) && deps.recipients.length > 0) {
+      sendInput.recipients = deps.recipients
+    }
+    const sent = await send(sendInput)
+    summary.sent = sent?.sent ?? 0
+    logger.info?.(
+      `[daily-ideas-email] log ${summary.log_id} sent to ${summary.sent} recipient(s)` +
+        (sent?.skipped ? ` (skipped: ${sent?.reason ?? "unknown"})` : "")
+    )
+  } catch (e: any) {
+    summary.errored = true
+    summary.skipped_reason = "send_threw"
+    logger.error?.(
+      `[daily-ideas-email] send threw for log ${summary.log_id} (swallowed): ${
+        e?.message ?? e
+      }`
+    )
+  }
+
+  return summary
+}


### PR DESCRIPTION
## What
Exposes the daily AI VP-of-Marketing **tactical-ideas email** as a #457 **Data Plumbing maintenance job** (`run-marketing-ideas-email`), so you run it on demand from **Settings → Data Plumbing** — audited dry-run → apply — instead of a hidden cron.

## How it maps to dry-run / apply
- **Dry-run** (default): generate the email, run the hallucination guard, and **persist the draft** to `marketing_ideas_log` for review — **emails no one**.
- **Apply**: emails it. The apply click is the explicit send consent, so it **overrides** the `MARKETING_IDEAS_EMAIL_ENABLED` env gate.
- **`log_id` param** (optional): send a specific already-generated, guard-passed draft **without a second LLM call** (dry-run returns the log id to paste back into apply).
- **`recipients` param** (optional): comma-separated override.

## Reuse, not duplication
Calls the existing injectable, never-throws `runDailyIdeasEmail` orchestrator (`generate-ideas-email` → guard → `send-ideas-email`). For the `log_id` path it calls `sendIdeasEmailWorkflow` directly. No generate/guard/send logic is re-implemented.

## Tests
- Pure helpers `parseRecipientsCsv` / `buildIdeasEmailGenerateResult` / `buildIdeasEmailSendExistingResult` — **15 unit cases** (drafted by the free-model drafter, verified + run by Claude).
- `registry.unit.spec` still green (registration valid). Typecheck clean on changed files.
- `ops_audit` history + the Data Plumbing console UI come for free via the registry contract.

## Supersedes
Closes the scheduled visual-flow approach (#684) per operator decision — the Data Plumbing console is the control surface. The orchestrator lib from #684 is carried over here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)