### PR TITLE
feat(#659): daily ideas-email visual flow + install-from-console job

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/install-marketing-ideas-email-flow.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/install-marketing-ideas-email-flow.unit.spec.ts
@@ -1,0 +1,71 @@
+import { summarizeFlowInstall } from "../registry"
+
+describe("install-marketing-ideas-email-flow — summarizeFlowInstall", () => {
+  it("reports already-installed when existingId is set (dry-run, no apply)", () => {
+    const result = summarizeFlowInstall({
+      jobId: "install-marketing-ideas-email-flow",
+      dry_run: true,
+      flowName: "Marketing Daily Ideas Email — Daily",
+      cron: "30 1 * * *",
+      nodeCount: 3,
+      existingId: "vf_existing",
+      createdId: null,
+    })
+    expect(result.applied).toBe(false)
+    expect(result.changes).toEqual([])
+    expect(result.summary).toMatch(/already installed/)
+    expect(result.summary).toContain("vf_existing")
+    expect(result.job_id).toBe("install-marketing-ideas-email-flow")
+  })
+
+  it("reports would-create when dry-run and not existing", () => {
+    const result = summarizeFlowInstall({
+      jobId: "jid",
+      dry_run: true,
+      flowName: "My Flow",
+      cron: "30 1 * * *",
+      nodeCount: 3,
+      existingId: null,
+      createdId: null,
+    })
+    expect(result.applied).toBe(false)
+    expect(result.changes).toHaveLength(1)
+    expect(result.changes[0].entity).toBe("visual_flow")
+    expect(result.changes[0].field).toBe("created")
+    expect(result.changes[0].id).toBe("(new)")
+    expect(result.summary).toMatch(/Would create/)
+    expect(result.summary).toContain("My Flow")
+    expect(result.summary).toContain("30 1 * * *")
+    expect(result.summary).toContain("3")
+  })
+
+  it("reports created when apply succeeds with a new id", () => {
+    const result = summarizeFlowInstall({
+      jobId: "jid",
+      dry_run: false,
+      flowName: "My Flow",
+      cron: "30 1 * * *",
+      nodeCount: 3,
+      existingId: null,
+      createdId: "vf_new",
+    })
+    expect(result.applied).toBe(true)
+    expect(result.changes[0].id).toBe("vf_new")
+    expect(result.summary).toMatch(/Created/)
+    expect(result.summary).toContain("vf_new")
+  })
+
+  it("reports not applied when createdId is null on apply", () => {
+    const result = summarizeFlowInstall({
+      jobId: "jid",
+      dry_run: false,
+      flowName: "My Flow",
+      cron: "30 1 * * *",
+      nodeCount: 3,
+      existingId: null,
+      createdId: null,
+    })
+    expect(result.applied).toBe(false)
+    expect(result.changes[0].id).toBe("(new)")
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -40,6 +40,8 @@ import {
   type DailyIdeasEmailSummary,
 } from "../../../../workflows/marketing/run-daily-ideas-email"
 import { sendIdeasEmailWorkflow } from "../../../../workflows/marketing/send-ideas-email"
+import { VISUAL_FLOWS_MODULE } from "../../../../modules/visual_flows"
+import { FLOW_DEF as IDEAS_EMAIL_FLOW_DEF } from "../../../../scripts/seed-marketing-daily-ideas-email-flow"
 
 /**
  * Admin "data-plumbing" maintenance jobs (#457 / roadmap #33).
@@ -3516,6 +3518,109 @@ export const runMarketingIdeasEmailJob: MaintenanceJob = {
   },
 }
 
+// ---------------------------------------------------------------------------
+// install-marketing-ideas-email-flow (#659) — LOAD the daily ideas-email visual
+// flow into the system from the Data Plumbing console, instead of shelling in to
+// run `medusa exec ./src/scripts/seed-marketing-daily-ideas-email-flow.ts`. The
+// flow (schedule 30 1 * * * ≈ 07:00 IST → marketing_daily_ideas_email op → log)
+// runs hands-off daily and is retimable from the canvas. Same FLOW_DEF as the
+// CLI seed (single source of truth). Idempotent — refuses to overwrite an
+// existing flow; created as a DRAFT (send stays OFF until the operator opts in).
+// ---------------------------------------------------------------------------
+
+/**
+ * Pure: report the install-flow dry-run/apply outcome. Exported for unit testing
+ * so the preview/created/already-exists wording is verifiable without the DB.
+ */
+export function summarizeFlowInstall(args: {
+  jobId: string
+  dry_run: boolean
+  flowName: string
+  cron: string
+  nodeCount: number
+  existingId: string | null
+  createdId: string | null
+}): MaintenanceJobResult {
+  const { jobId, dry_run, flowName, cron, nodeCount, existingId, createdId } =
+    args
+  if (existingId) {
+    return {
+      job_id: jobId,
+      dry_run,
+      applied: false,
+      summary: `Visual flow "${flowName}" already installed (${existingId}) — nothing to do. Retime the schedule (${cron}) from the canvas.`,
+      changes: [],
+    }
+  }
+  const changes: MaintenanceChange[] = [
+    {
+      entity: "visual_flow",
+      id: createdId ?? "(new)",
+      field: "created",
+      after: { name: flowName, trigger: `schedule ${cron}`, nodes: nodeCount },
+    },
+  ]
+  const applied = !dry_run && !!createdId
+  const summary = dry_run
+    ? `Would create visual flow "${flowName}" (schedule ${cron}, ${nodeCount} nodes) — nothing written. Apply to install.`
+    : `Created visual flow "${flowName}" (${createdId}); schedule ${cron}. Flip draft→active + opt into send (MARKETING_IDEAS_EMAIL_ENABLED or the node's send_enabled) to go live.`
+  return { job_id: jobId, dry_run, applied, summary, changes }
+}
+
+export const installMarketingIdeasEmailFlowJob: MaintenanceJob = {
+  id: "install-marketing-ideas-email-flow",
+  label: "Install marketing ideas-email visual flow",
+  description:
+    "Load/create the 'Marketing Daily Ideas Email' visual flow into the system from the console — no shell or seed script needed (#659). The flow schedules the daily AI tactical-ideas email (generate + hallucination guard + gated send) and is retimable from the canvas. Dry-run previews the flow it would create (or reports it already exists); apply creates it idempotently as a DRAFT. Send stays OFF until you set MARKETING_IDEAS_EMAIL_ENABLED or the node's send_enabled and flip the flow draft→active. Re-running never overwrites an existing flow.",
+  params: [],
+  run: async (container, { dry_run }) => {
+    const service: any = container.resolve(VISUAL_FLOWS_MODULE)
+    const flowName = IDEAS_EMAIL_FLOW_DEF.name
+    const cron = IDEAS_EMAIL_FLOW_DEF.trigger_config?.cron ?? ""
+    const nodeCount = IDEAS_EMAIL_FLOW_DEF.canvas_state?.nodes?.length ?? 0
+
+    const [existing] = await service.listVisualFlows({ name: flowName })
+    if (existing) {
+      return summarizeFlowInstall({
+        jobId: installMarketingIdeasEmailFlowJob.id,
+        dry_run,
+        flowName,
+        cron,
+        nodeCount,
+        existingId: existing.id,
+        createdId: null,
+      })
+    }
+
+    let createdId: string | null = null
+    if (!dry_run) {
+      const flow = await service.createCompleteFlow({
+        flow: {
+          name: IDEAS_EMAIL_FLOW_DEF.name,
+          description: IDEAS_EMAIL_FLOW_DEF.description,
+          status: IDEAS_EMAIL_FLOW_DEF.status,
+          trigger_type: IDEAS_EMAIL_FLOW_DEF.trigger_type,
+          trigger_config: IDEAS_EMAIL_FLOW_DEF.trigger_config,
+          canvas_state: IDEAS_EMAIL_FLOW_DEF.canvas_state,
+        },
+        operations: IDEAS_EMAIL_FLOW_DEF.operations,
+        connections: IDEAS_EMAIL_FLOW_DEF.connections,
+      })
+      createdId = flow?.id ?? null
+    }
+
+    return summarizeFlowInstall({
+      jobId: installMarketingIdeasEmailFlowJob.id,
+      dry_run,
+      flowName,
+      cron,
+      nodeCount,
+      existingId: null,
+      createdId,
+    })
+  },
+}
+
 export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   recalculateDesignCostJob,
   recalculateDesignCostBulkJob,
@@ -3533,6 +3638,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   backfillOrderPersonsJob,
   syncMarketingOutreachEngagementJob,
   runMarketingIdeasEmailJob,
+  installMarketingIdeasEmailFlowJob,
 ]
 
 export const getMaintenanceJob = (id: string): MaintenanceJob | undefined =>

--- a/apps/backend/src/modules/visual_flows/operations/__tests__/marketing-daily-ideas-email.unit.spec.ts
+++ b/apps/backend/src/modules/visual_flows/operations/__tests__/marketing-daily-ideas-email.unit.spec.ts
@@ -1,0 +1,75 @@
+import {
+  resolveSendEnabledOption,
+  normalizeRecipientsOption,
+  marketingDailyIdeasEmailOperation,
+} from "../marketing-daily-ideas-email"
+
+/**
+ * #659 slice 2 — unit tests for the visual-flow operation's PURE option
+ * coercers and its registration shape. The orchestration itself is covered in
+ * workflows/marketing/__tests__/run-daily-ideas-email.unit.spec.ts (injected
+ * stubs, no live LLM/email).
+ */
+
+describe("resolveSendEnabledOption", () => {
+  it("returns undefined for unset/empty (caller falls back to env gate)", () => {
+    expect(resolveSendEnabledOption(undefined)).toBeUndefined()
+    expect(resolveSendEnabledOption(null)).toBeUndefined()
+    expect(resolveSendEnabledOption("")).toBeUndefined()
+  })
+  it("passes through real booleans", () => {
+    expect(resolveSendEnabledOption(true)).toBe(true)
+    expect(resolveSendEnabledOption(false)).toBe(false)
+  })
+  it("coerces truthy/falsy strings", () => {
+    expect(resolveSendEnabledOption("true")).toBe(true)
+    expect(resolveSendEnabledOption("1")).toBe(true)
+    expect(resolveSendEnabledOption("ON")).toBe(true)
+    expect(resolveSendEnabledOption("false")).toBe(false)
+    expect(resolveSendEnabledOption("0")).toBe(false)
+    expect(resolveSendEnabledOption("no")).toBe(false)
+  })
+  it("returns undefined for unrecognized strings", () => {
+    expect(resolveSendEnabledOption("maybe")).toBeUndefined()
+  })
+})
+
+describe("normalizeRecipientsOption", () => {
+  it("returns undefined when nothing usable", () => {
+    expect(normalizeRecipientsOption(undefined)).toBeUndefined()
+    expect(normalizeRecipientsOption([])).toBeUndefined()
+    expect(normalizeRecipientsOption("")).toBeUndefined()
+    expect(normalizeRecipientsOption("  , ")).toBeUndefined()
+  })
+  it("cleans an array", () => {
+    expect(normalizeRecipientsOption([" a@x.com ", "", "b@x.com"])).toEqual([
+      "a@x.com",
+      "b@x.com",
+    ])
+  })
+  it("splits a CSV string", () => {
+    expect(normalizeRecipientsOption("a@x.com, b@x.com ")).toEqual([
+      "a@x.com",
+      "b@x.com",
+    ])
+  })
+})
+
+describe("marketingDailyIdeasEmailOperation registration", () => {
+  it("has the expected type/category and a parseable schema", () => {
+    expect(marketingDailyIdeasEmailOperation.type).toBe(
+      "marketing_daily_ideas_email"
+    )
+    expect(marketingDailyIdeasEmailOperation.category).toBe("communication")
+    // empty options parse cleanly (env gate decides send)
+    expect(() =>
+      marketingDailyIdeasEmailOperation.optionsSchema.parse({})
+    ).not.toThrow()
+    expect(() =>
+      marketingDailyIdeasEmailOperation.optionsSchema.parse({
+        send_enabled: true,
+        recipients: ["a@x.com"],
+      })
+    ).not.toThrow()
+  })
+})

--- a/apps/backend/src/modules/visual_flows/operations/index.ts
+++ b/apps/backend/src/modules/visual_flows/operations/index.ts
@@ -31,6 +31,7 @@ export { aiExtractOperation } from "./ai-extract"
 export { aiExtractPlatformOperation } from "./ai-extract-platform"
 export { generatePartnerDeeplinkOperation } from "./generate-partner-deeplink"
 export { partnerAnalyticsDigestOperation } from "./partner-analytics-digest"
+export { marketingDailyIdeasEmailOperation } from "./marketing-daily-ideas-email"
 export { waitForEventOperation } from "./wait-for-event"
 
 // Import all operations and register them
@@ -63,6 +64,7 @@ import { aiExtractOperation } from "./ai-extract"
 import { aiExtractPlatformOperation } from "./ai-extract-platform"
 import { generatePartnerDeeplinkOperation } from "./generate-partner-deeplink"
 import { partnerAnalyticsDigestOperation } from "./partner-analytics-digest"
+import { marketingDailyIdeasEmailOperation } from "./marketing-daily-ideas-email"
 import { waitForEventOperation } from "./wait-for-event"
 
 // Register all built-in operations
@@ -85,6 +87,7 @@ export function registerBuiltInOperations(): void {
   operationRegistry.register(sendEmailOperation)
   operationRegistry.register(sendWhatsAppOperation)
   operationRegistry.register(notificationOperation)
+  operationRegistry.register(marketingDailyIdeasEmailOperation)
   
   // Integration operations
   operationRegistry.register(httpRequestOperation)

--- a/apps/backend/src/modules/visual_flows/operations/marketing-daily-ideas-email.ts
+++ b/apps/backend/src/modules/visual_flows/operations/marketing-daily-ideas-email.ts
@@ -1,0 +1,161 @@
+import { z } from "@medusajs/framework/zod"
+import { OperationDefinition, OperationContext, OperationResult } from "./types"
+import { interpolateVariables } from "./utils"
+import {
+  runDailyIdeasEmail,
+  isSendEnabled,
+  type RunDailyIdeasEmailDeps,
+} from "../../../workflows/marketing/run-daily-ideas-email"
+
+/**
+ * marketing_daily_ideas_email — #659 slice 2, visual-flow edition.
+ *
+ * A single operation node that runs the daily AI-VP-of-Marketing tactical-ideas
+ * email end to end by chaining the two EXISTING marketing workflows (it does NOT
+ * duplicate that logic — see `run-daily-ideas-email.ts`):
+ *   1. generate-ideas-email → reads ground-truth snapshots, prompts the LLM,
+ *      runs the hallucination guard, persists a `marketing_ideas_log` row.
+ *   2. send-ideas-email → ONLY when `generated && guard_passed && log_id` AND
+ *      the send gate is on → mails the operator recipients and flips sent=true.
+ *
+ * WHY A FLOW NODE (not a `src/jobs/*` cron): the operator owns the cadence. This
+ * node sits behind a schedule-trigger node on an editable canvas; the schedule is
+ * parsed and fired by `src/jobs/run-scheduled-visual-flows.ts`. Suggested cadence:
+ * "30 1 * * *" (≈ 7 AM IST) — AFTER `marketing-daily-refresh` ("0 1 * * *") so the
+ * snapshot rows exist. The operator can retime it from the canvas; no redeploy.
+ *
+ * OPERATOR SAFETY / explicit opt-in:
+ *   GENERATE always runs and logs (the draft + guard verdict are persisted and
+ *   reviewable even when nothing is mailed). SEND is OFF by default and only fires
+ *   when EITHER the node option `send_enabled: true` is set OR the env flag
+ *   `MARKETING_IDEAS_EMAIL_ENABLED` is truthy. Default OFF in prod.
+ *
+ * NEVER throws past the workflow boundary: the orchestrator swallows runner
+ * errors and reports them in the summary; `execute` additionally try/catches so a
+ * config error returns `success:false` rather than crashing the executor.
+ *
+ * Node output (the summary): { generated, guard_passed, log_id, send_enabled,
+ *   send_attempted, sent, skipped_reason, errored }.
+ */
+
+export const marketingDailyIdeasEmailOptionsSchema = z.object({
+  /**
+   * Enable the SEND step from the canvas. When omitted/undefined the env flag
+   * `MARKETING_IDEAS_EMAIL_ENABLED` decides (default OFF). When set, this
+   * explicit value wins. Accepts a `{{ variable }}` string that resolves to a
+   * boolean-ish value too.
+   */
+  send_enabled: z.union([z.boolean(), z.string()]).optional(),
+  /**
+   * Optional explicit recipient override (array, or a `{{ variable }}` string
+   * resolving to one). When unset, the send workflow falls back to its CSV env /
+   * platform-admin recipients.
+   */
+  recipients: z.union([z.array(z.string()), z.string()]).optional(),
+})
+
+export type MarketingDailyIdeasEmailOptions = z.infer<
+  typeof marketingDailyIdeasEmailOptionsSchema
+>
+
+/**
+ * Coerce a resolved `send_enabled` option into a tri-state:
+ *   - `undefined` → caller falls back to the env gate
+ *   - `true`/`false` → explicit override
+ * Pure so it's unit-testable. Mirrors `isSendEnabled`'s truthy vocabulary for
+ * strings ("true"/"1"/"yes"/"on" → true; "false"/"0"/"no"/"off" → false).
+ */
+export function resolveSendEnabledOption(
+  value: unknown
+): boolean | undefined {
+  if (value === undefined || value === null || value === "") return undefined
+  if (typeof value === "boolean") return value
+  const raw = String(value).trim().toLowerCase()
+  if (raw === "true" || raw === "1" || raw === "yes" || raw === "on") return true
+  if (raw === "false" || raw === "0" || raw === "no" || raw === "off") {
+    return false
+  }
+  return undefined
+}
+
+/** Normalize a resolved `recipients` option into a clean string[] (or undefined). */
+export function normalizeRecipientsOption(
+  value: unknown
+): string[] | undefined {
+  let list: unknown[] | null = null
+  if (Array.isArray(value)) {
+    list = value
+  } else if (typeof value === "string" && value.trim()) {
+    // Allow a CSV string for the canvas convenience.
+    list = value.split(",")
+  }
+  if (!list) return undefined
+  const out = list
+    .map((v) => (typeof v === "string" ? v.trim() : ""))
+    .filter((v) => v.length > 0)
+  return out.length > 0 ? out : undefined
+}
+
+export const marketingDailyIdeasEmailOperation: OperationDefinition = {
+  type: "marketing_daily_ideas_email",
+  name: "Marketing Daily Ideas Email",
+  description:
+    "Run the daily AI tactical-ideas email: generate (LLM + hallucination guard + persist a marketing_ideas_log), then send only when guard-passed AND enabled. Pair with a schedule-trigger node to run it every morning. Send is OFF unless send_enabled or MARKETING_IDEAS_EMAIL_ENABLED is set.",
+  icon: "envelope",
+  category: "communication",
+  optionsSchema: marketingDailyIdeasEmailOptionsSchema,
+
+  defaultOptions: {},
+
+  execute: async (
+    options: any,
+    context: OperationContext
+  ): Promise<OperationResult> => {
+    try {
+      const parsed = marketingDailyIdeasEmailOptionsSchema.parse(options ?? {})
+
+      // Resolve {{ variable }} references BEFORE interpreting the values
+      // (reference_visual_flow_template_items_resolution: interpolate string
+      // options before any type-narrowing checks).
+      const resolvedSendEnabled =
+        parsed.send_enabled !== undefined
+          ? interpolateVariables(parsed.send_enabled, context.dataChain)
+          : undefined
+      const resolvedRecipients =
+        parsed.recipients !== undefined
+          ? interpolateVariables(parsed.recipients, context.dataChain)
+          : undefined
+
+      const deps: RunDailyIdeasEmailDeps = {}
+      const sendOverride = resolveSendEnabledOption(resolvedSendEnabled)
+      if (sendOverride !== undefined) {
+        deps.sendEnabled = sendOverride
+      }
+      const recipients = normalizeRecipientsOption(resolvedRecipients)
+      if (recipients) {
+        deps.recipients = recipients
+      }
+
+      const summary = await runDailyIdeasEmail(context.container, deps)
+
+      return {
+        success: true,
+        data: {
+          ...summary,
+          // Convenience scalar so a downstream condition node can branch on it.
+          mailed: summary.sent > 0,
+        },
+      }
+    } catch (error: any) {
+      // The orchestrator never throws; this guards only config/parse errors.
+      return {
+        success: false,
+        error: error?.message ?? "Failed to run daily ideas email",
+        errorStack: error?.stack,
+      }
+    }
+  },
+}
+
+// Re-export so a flow/seed can read the env-only default without importing the lib.
+export { isSendEnabled }

--- a/apps/backend/src/scripts/__tests__/seed-marketing-daily-ideas-email-flow.unit.spec.ts
+++ b/apps/backend/src/scripts/__tests__/seed-marketing-daily-ideas-email-flow.unit.spec.ts
@@ -1,0 +1,60 @@
+import { FLOW_DEF } from "../seed-marketing-daily-ideas-email-flow"
+
+/**
+ * Structural guards for the daily ideas-email visual flow seed (#659 slice 2).
+ *
+ * The flow is editor-gated and cannot be live-verified by the daemon, and it
+ * wires the operation by STRING name only. A typo in the op type would silently
+ * no-op at runtime, so these tests pin the contract + the log node's keys.
+ */
+describe("seed-marketing-daily-ideas-email-flow FLOW_DEF", () => {
+  it("is a daily schedule-triggered draft flow at 30 1 * * *", () => {
+    expect(FLOW_DEF.status).toBe("draft")
+    expect(FLOW_DEF.trigger_type).toBe("schedule")
+    expect(FLOW_DEF.trigger_config.cron).toBe("30 1 * * *")
+    expect(
+      (FLOW_DEF.canvas_state.nodes[0].data as any).triggerConfig.cron
+    ).toBe(FLOW_DEF.trigger_config.cron)
+  })
+
+  it("wires run_ideas → log via marketing_daily_ideas_email", () => {
+    const byKey = Object.fromEntries(
+      FLOW_DEF.operations.map((o) => [o.operation_key, o])
+    )
+    expect(byKey.run_ideas.operation_type).toBe("marketing_daily_ideas_email")
+    expect(byKey.log_summary.operation_type).toBe("log")
+    expect(FLOW_DEF.operations.map((o) => o.sort_order)).toEqual([0, 1])
+  })
+
+  it("seeds send OFF (no send_enabled option → env gate decides)", () => {
+    const run = FLOW_DEF.operations.find(
+      (o) => o.operation_key === "run_ideas"
+    )!.options as any
+    expect(run.send_enabled).toBeUndefined()
+    expect(run.recipients).toBeUndefined()
+  })
+
+  it("has matching canvas edges and connection rows forming a linear chain", () => {
+    const conn = FLOW_DEF.connections.map((c) => `${c.source_id}->${c.target_id}`)
+    const edges = FLOW_DEF.canvas_state.edges.map((e) => `${e.source}->${e.target}`)
+    expect(conn).toEqual(edges)
+    expect(conn).toEqual(["trigger->run_ideas", "run_ideas->log_summary"])
+  })
+
+  it("logs the real summary keys emitted by the op", () => {
+    const log = FLOW_DEF.operations.find(
+      (o) => o.operation_key === "log_summary"
+    )!.options as any
+    for (const key of [
+      "{{ run_ideas.generated }}",
+      "{{ run_ideas.guard_passed }}",
+      "{{ run_ideas.log_id }}",
+      "{{ run_ideas.send_enabled }}",
+      "{{ run_ideas.sent }}",
+      "{{ run_ideas.skipped_reason }}",
+      "{{ run_ideas.errored }}",
+    ]) {
+      expect(log.message).toContain(key)
+    }
+  })
+})

--- a/apps/backend/src/scripts/seed-marketing-daily-ideas-email-flow.ts
+++ b/apps/backend/src/scripts/seed-marketing-daily-ideas-email-flow.ts
@@ -1,0 +1,170 @@
+/**
+ * Seed: Marketing Daily Ideas Email — Daily Flow (#659 slice 2, visual-flow edition)
+ *
+ * The daily AI-VP-of-Marketing tactical-ideas email, as an OPERATOR-EDITABLE
+ * visual flow instead of a hard-coded `src/jobs/*` cron. The operator owns the
+ * cadence from the canvas; the schedule is parsed + fired every minute by
+ * `src/jobs/run-scheduled-visual-flows.ts`.
+ *
+ * Graph:
+ *   schedule (daily, 30 1 * * *)
+ *     → marketing_daily_ideas_email   (chains generate-ideas-email → guard →
+ *                                       send-ideas-email; send gated, never throws)
+ *     → log summary
+ *
+ * The op is referenced by STRING name only (no imports) so this seed branches
+ * off main independently. The op type `marketing_daily_ideas_email` ships in the
+ * same PR; the generate/send workflows are already on main.
+ *
+ * Cadence (locked decision):
+ *   Cron `30 1 * * *` = 01:30 UTC ≈ 07:00 IST — 30 min AFTER
+ *   `marketing-daily-refresh` ("0 1 * * *") so the ground-truth snapshot rows
+ *   exist before we generate from them. If the deployed container runs in IST,
+ *   re-time from the canvas (no redeploy). Confirm host time before activating.
+ *
+ * Operator safety (send is OFF by default):
+ *   GENERATE always runs and persists a reviewable `marketing_ideas_log` row +
+ *   guard verdict. SEND only fires when EITHER the env flag
+ *   `MARKETING_IDEAS_EMAIL_ENABLED` is truthy OR the node option
+ *   `send_enabled: true` is set on the canvas. Seeded with NEITHER → generate +
+ *   log only until the operator explicitly opts in.
+ *
+ * Run:
+ *   npx medusa exec ./src/scripts/seed-marketing-daily-ideas-email-flow.ts
+ *
+ * Re-seed:
+ *   Delete the existing flow first (admin UI or by id) and re-run. The script is
+ *   idempotent and refuses to overwrite an existing flow.
+ */
+
+import { VISUAL_FLOWS_MODULE } from "../modules/visual_flows"
+import VisualFlowService from "../modules/visual_flows/service"
+
+const FLOW_NAME = "Marketing Daily Ideas Email — Daily"
+
+// Cron: 01:30 UTC ≈ 07:00 IST, 30 min after marketing-daily-refresh ("0 1 * * *").
+const IDEAS_CRON = "30 1 * * *"
+
+// ─── Canvas positions ────────────────────────────────────────────────────────
+const X_CENTER = 500
+const Y_RUN = 140
+const Y_LOG = 280
+
+// ─── Flow definition (exported for the structural unit test) ───────────────────
+
+export const FLOW_DEF = {
+  name: FLOW_NAME,
+  description:
+    "Daily scheduled AI tactical-ideas email: generate-ideas-email (LLM + " +
+    "hallucination guard + persist marketing_ideas_log), then send-ideas-email " +
+    "ONLY when guard-passed AND enabled. Send is OFF until the operator sets " +
+    "MARKETING_IDEAS_EMAIL_ENABLED or the node's send_enabled option. " +
+    "Never throws — a bad morning run cannot crash the executor.",
+  status: "draft" as const,
+  trigger_type: "schedule" as const,
+  trigger_config: {
+    cron: IDEAS_CRON, // 07:00 IST assuming a UTC container
+  },
+
+  canvas_state: {
+    viewport: { x: 0, y: 0, zoom: 0.9 },
+    nodes: [
+      { id: "trigger",     type: "trigger",   position: { x: X_CENTER, y: -20 },   data: { label: "Schedule — 07:00 IST daily", triggerType: "schedule", triggerConfig: { cron: IDEAS_CRON } } },
+      { id: "run_ideas",   type: "operation", position: { x: X_CENTER, y: Y_RUN }, data: { label: "Generate + Send Ideas Email", operationKey: "run_ideas", operationType: "marketing_daily_ideas_email", options: {} } },
+      { id: "log_summary", type: "operation", position: { x: X_CENTER, y: Y_LOG }, data: { label: "Log Summary", operationKey: "log_summary", operationType: "log", options: { message: "Daily ideas email — generated={{ run_ideas.generated }} guard_passed={{ run_ideas.guard_passed }} log_id={{ run_ideas.log_id }} send_enabled={{ run_ideas.send_enabled }} sent={{ run_ideas.sent }} skipped={{ run_ideas.skipped_reason }} errored={{ run_ideas.errored }}", level: "info" } } },
+    ],
+    edges: [
+      { id: "e-0", source: "trigger",   sourceHandle: "default", target: "run_ideas",   targetHandle: "default" },
+      { id: "e-1", source: "run_ideas", sourceHandle: "default", target: "log_summary", targetHandle: "default" },
+    ],
+  },
+
+  operations: [
+    // ── 1. Generate (always) → guarded Send (gated) ─────────────────────────
+    {
+      operation_key: "run_ideas",
+      operation_type: "marketing_daily_ideas_email",
+      name: "Generate + Send Ideas Email",
+      sort_order: 0,
+      position_x: X_CENTER,
+      position_y: Y_RUN,
+      options: {
+        // No send_enabled here → the env flag MARKETING_IDEAS_EMAIL_ENABLED
+        // decides (default OFF). To turn the email on from the canvas instead,
+        // set send_enabled: true. Optional recipients override:
+        //   recipients: ["ops@jyt.example"]
+      },
+    },
+
+    // ── 2. Log summary line for observability ──────────────────────────────
+    {
+      operation_key: "log_summary",
+      operation_type: "log",
+      name: "Log Summary",
+      sort_order: 1,
+      position_x: X_CENTER,
+      position_y: Y_LOG,
+      options: {
+        message:
+          "Daily ideas email — generated={{ run_ideas.generated }} " +
+          "guard_passed={{ run_ideas.guard_passed }} " +
+          "log_id={{ run_ideas.log_id }} " +
+          "send_enabled={{ run_ideas.send_enabled }} " +
+          "sent={{ run_ideas.sent }} " +
+          "skipped={{ run_ideas.skipped_reason }} " +
+          "errored={{ run_ideas.errored }}",
+        level: "info",
+      },
+    },
+  ],
+
+  connections: [
+    { source_id: "trigger",   source_handle: "default", target_id: "run_ideas",   connection_type: "default" as const },
+    { source_id: "run_ideas", source_handle: "default", target_id: "log_summary", connection_type: "default" as const },
+  ],
+}
+
+// ─── Runner ──────────────────────────────────────────────────────────────────
+
+export default async function seedMarketingDailyIdeasEmailFlow({
+  container,
+}: {
+  container: any
+}) {
+  const service: VisualFlowService = container.resolve(VISUAL_FLOWS_MODULE)
+
+  const [existing] = await service.listVisualFlows({ name: FLOW_NAME } as any)
+  if (existing) {
+    console.log(`Flow "${FLOW_NAME}" already exists (${existing.id}) — skipping.`)
+    console.log(`Delete it in the admin UI (or by id) to re-seed.`)
+    return
+  }
+
+  console.log(`Creating flow "${FLOW_NAME}"...`)
+
+  const flow = await service.createCompleteFlow({
+    flow: {
+      name: FLOW_DEF.name,
+      description: FLOW_DEF.description,
+      status: FLOW_DEF.status,
+      trigger_type: FLOW_DEF.trigger_type,
+      trigger_config: FLOW_DEF.trigger_config,
+      canvas_state: FLOW_DEF.canvas_state,
+    },
+    operations: FLOW_DEF.operations,
+    connections: FLOW_DEF.connections,
+  })
+
+  console.log(`\nFlow created: ${flow.id}`)
+  console.log(`  Open: /app/visual-flows/${flow.id}\n`)
+  console.log(`Before activating (draft → active):`)
+  console.log(`  1. The op "marketing_daily_ideas_email" ships in this PR (#659).`)
+  console.log(`     The generate/send marketing workflows are already on main.`)
+  console.log(`  2. Confirm the deployed container's local time matches the cron`)
+  console.log(`     assumption. This seed uses "${IDEAS_CRON}" = 07:00 IST assuming`)
+  console.log(`     a UTC container; re-time from the canvas if it runs in IST.`)
+  console.log(`  3. SEND stays OFF until you opt in: set MARKETING_IDEAS_EMAIL_ENABLED`)
+  console.log(`     (env) OR the node option send_enabled: true. Until then the flow`)
+  console.log(`     only generates + logs a reviewable marketing_ideas_log row.`)
+  console.log(`  4. Flip flow status: draft → active in the admin editor.`)
+}


### PR DESCRIPTION
## What
Brings the **scheduled visual-flow** path for the daily AI tactical-ideas email back (the earlier #684 approach), and adds a **Data Plumbing job that installs it from the console** — so loading the flow is a click, not a `medusa exec` seed over SSH.

End state — three surfaces, **one** shared `runDailyIdeasEmail` orchestrator:
| Surface | Purpose |
|---|---|
| `run-marketing-ideas-email` job (#685, merged) | manual / ad-hoc / test run from the console |
| **`marketing_daily_ideas_email` visual flow** (this PR) | hands-off **daily** send, retimable from the canvas |
| **`install-marketing-ideas-email-flow` job** (this PR) | **load/create** that flow from the console |

## How the install job works
- **Dry-run**: previews the flow it would create (`schedule 30 1 * * *` ≈ 07:00 IST → `marketing_daily_ideas_email` → log, 3 nodes) — or reports it's already installed. No writes.
- **Apply**: creates it idempotently as a **DRAFT** from the same `FLOW_DEF` the CLI seed uses (single source of truth). Never overwrites an existing flow.
- `ops_audit` history comes free via the registry.

## Safety
Send stays **OFF** until you (a) set `MARKETING_IDEAS_EMAIL_ENABLED` or the node's `send_enabled`, and (b) flip the flow **draft → active**. Until then it only generates + persists a reviewable `marketing_ideas_log` row. Cron assumes a UTC container — re-time from the canvas if the host runs IST.

## Tests
- `summarizeFlowInstall` pure helper — 4 cases (free-model drafted, Claude-verified + run).
- Recovered op-node + seed structural specs. `registry.unit.spec` green (registration valid). **98 tests** across the touched suites; typecheck clean.

Reuses the orchestrator merged in #685. Operation node + seed recovered from the closed #684.

🤖 Generated with [Claude Code](https://claude.com/claude-code)