### PR TITLE
feat(marketing): newsletter draft generator Data-Plumbing job (#659 §12.4)

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/generate-marketing-newsletter-draft.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/generate-marketing-newsletter-draft.unit.spec.ts
@@ -1,0 +1,88 @@
+import {
+  buildNewsletterDraftResult,
+  generateMarketingNewsletterDraftJob,
+} from "../registry"
+import type { GenerateNewsletterDraftResult } from "../../../../../workflows/marketing/generate-newsletter-draft"
+
+/**
+ * #659 §12.4 — unit tests for the newsletter-draft maintenance job's pure result
+ * builder. No DB / LLM: we feed a fabricated generate result and assert the
+ * dry-run vs apply reporting + parse-error wording + the `applied` flag.
+ */
+
+const baseResult = (
+  over: Partial<GenerateNewsletterDraftResult> = {}
+): GenerateNewsletterDraftResult => ({
+  generated: true,
+  draft_id: "draft_1",
+  name: "newsletter-2026-06-23",
+  status: "draft",
+  model_used: "stub",
+  payload: {
+    subject: "Subject",
+    preheader: "Pre",
+    intro: "Intro",
+    sections: [{ heading: "H", body: "B" }],
+    cta: "Shop",
+  },
+  parse_error: false,
+  ...over,
+})
+
+describe("buildNewsletterDraftResult", () => {
+  it("dry-run: reports a draft for review and is NOT applied", () => {
+    const r = buildNewsletterDraftResult("job", true, baseResult())
+    expect(r.dry_run).toBe(true)
+    expect(r.applied).toBe(false)
+    expect(r.summary).toContain("status=draft")
+    expect(r.summary.toLowerCase()).toContain("dry-run")
+    expect(r.changes).toHaveLength(1)
+    expect(r.changes[0].entity).toBe("marketing_draft")
+    expect(r.changes[0].id).toBe("draft_1")
+    expect((r.changes[0].after as any).sections).toBe(1)
+  })
+
+  it("apply: an approved draft is reported as applied", () => {
+    const r = buildNewsletterDraftResult(
+      "job",
+      false,
+      baseResult({ status: "approved" })
+    )
+    expect(r.applied).toBe(true)
+    expect(r.summary).toContain("status=approved")
+  })
+
+  it("apply with no draft_id is not applied", () => {
+    const r = buildNewsletterDraftResult(
+      "job",
+      false,
+      baseResult({ status: "approved", draft_id: null })
+    )
+    expect(r.applied).toBe(false)
+    expect(r.changes[0].id).toBe("(none)")
+  })
+
+  it("surfaces a parse_error note in the summary", () => {
+    const r = buildNewsletterDraftResult(
+      "job",
+      true,
+      baseResult({ parse_error: true })
+    )
+    expect(r.summary).toContain("not valid JSON")
+    expect((r.changes[0].after as any).parse_error).toBe(true)
+  })
+})
+
+describe("generateMarketingNewsletterDraftJob", () => {
+  it("is a well-formed, registered maintenance job", () => {
+    expect(generateMarketingNewsletterDraftJob.id).toBe(
+      "generate-marketing-newsletter-draft"
+    )
+    expect(generateMarketingNewsletterDraftJob.params.map((p) => p.name)).toEqual(
+      ["topic", "name"]
+    )
+    expect(
+      generateMarketingNewsletterDraftJob.params.every((p) => !p.required)
+    ).toBe(true)
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -40,6 +40,10 @@ import {
   type DailyIdeasEmailSummary,
 } from "../../../../workflows/marketing/run-daily-ideas-email"
 import { sendIdeasEmailWorkflow } from "../../../../workflows/marketing/send-ideas-email"
+import {
+  generateNewsletterDraft,
+  type GenerateNewsletterDraftResult,
+} from "../../../../workflows/marketing/generate-newsletter-draft"
 import { VISUAL_FLOWS_MODULE } from "../../../../modules/visual_flows"
 import { FLOW_DEF as IDEAS_EMAIL_FLOW_DEF } from "../../../../scripts/seed-marketing-daily-ideas-email-flow"
 
@@ -3621,6 +3625,99 @@ export const installMarketingIdeasEmailFlowJob: MaintenanceJob = {
   },
 }
 
+// ---------------------------------------------------------------------------
+// generate-marketing-newsletter-draft (#659, report §12.4) — generate a
+// customer-facing newsletter draft with the injectable AI pattern and persist it
+// to the EXISTING `marketing_draft` model for operator review. NO sending here
+// (that reuses src/jobs/process-email-queue.ts later, via the Newsletter editor
+// UI). dry_run = generate + persist as status="draft" (review); apply = generate
+// + persist as status="approved" (marked ready). Mirrors how the ideas-email job
+// always persists its output before any send — the draft IS the deliverable the
+// operator edits, so we persist on both paths and distinguish by status.
+// ---------------------------------------------------------------------------
+
+/**
+ * Pure: turn a generate result into a MaintenanceJobResult. Exported for unit
+ * testing so the dry-run/apply + parse-error wording is verifiable without the
+ * DB or the LLM.
+ */
+export function buildNewsletterDraftResult(
+  jobId: string,
+  dry_run: boolean,
+  result: GenerateNewsletterDraftResult
+): MaintenanceJobResult {
+  const draftId = result.draft_id ?? "(none)"
+  const sectionCount = result.payload?.sections?.length ?? 0
+  const changes: MaintenanceChange[] = [
+    {
+      entity: "marketing_draft",
+      id: draftId,
+      field: "created",
+      after: {
+        name: result.name,
+        status: result.status,
+        subject: result.payload?.subject || "(none)",
+        sections: sectionCount,
+        parse_error: result.parse_error,
+      },
+    },
+  ]
+  // "applied" means a ready (approved) draft was actually written.
+  const applied = !dry_run && result.status === "approved" && !!result.draft_id
+  const guardNote = result.parse_error
+    ? " ⚠ model output was not valid JSON — saved as a raw fallback for manual cleanup."
+    : ""
+  const summary = dry_run
+    ? `Dry-run: generated newsletter draft "${result.name}" (${draftId}) as status=draft for review — nothing marked ready.${guardNote} Edit it in the Newsletter UI, then re-run with apply to mark it ready.`
+    : `Generated newsletter draft "${result.name}" (${draftId}); marked ready (status=approved).${guardNote} Review/edit + enqueue to send via the email queue.`
+  return { job_id: jobId, dry_run, applied, summary, changes }
+}
+
+export const generateMarketingNewsletterDraftJob: MaintenanceJob = {
+  id: "generate-marketing-newsletter-draft",
+  label: "Generate marketing newsletter draft",
+  description:
+    "Generate a customer-facing newsletter draft with the AI editor and persist it to the marketing_draft store for operator review (#659, §12.4). NO email is sent — drafts are reviewed/edited in the Newsletter UI and enqueued later through the existing email queue. Dry-run (default) generates + saves the draft as status=draft for review; apply generates + saves it as status=approved (marked ready). Optionally pass a topic/angle for the edition and a name label. The AI call is injectable so it never runs in CI; a non-JSON model reply is saved as a safe raw fallback (never crashes).",
+  params: [
+    {
+      name: "topic",
+      type: "string",
+      required: false,
+      description:
+        "Topic / angle for this newsletter edition (free text). Omit to let the editor pick an evergreen angle.",
+    },
+    {
+      name: "name",
+      type: "string",
+      required: false,
+      description:
+        "Human label for the draft row (default: newsletter-<IST date>).",
+    },
+  ],
+  run: async (container, { dry_run, params }) => {
+    const topic =
+      typeof params.topic === "string" && params.topic.trim()
+        ? params.topic.trim()
+        : undefined
+    const name =
+      typeof params.name === "string" && params.name.trim()
+        ? params.name.trim()
+        : undefined
+
+    const result = await generateNewsletterDraft(container, {
+      ...(topic ? { topic } : {}),
+      ...(name ? { name } : {}),
+      markReady: !dry_run,
+    })
+
+    return buildNewsletterDraftResult(
+      generateMarketingNewsletterDraftJob.id,
+      dry_run,
+      result
+    )
+  },
+}
+
 export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   recalculateDesignCostJob,
   recalculateDesignCostBulkJob,
@@ -3639,6 +3736,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   syncMarketingOutreachEngagementJob,
   runMarketingIdeasEmailJob,
   installMarketingIdeasEmailFlowJob,
+  generateMarketingNewsletterDraftJob,
 ]
 
 export const getMaintenanceJob = (id: string): MaintenanceJob | undefined =>

--- a/apps/backend/src/workflows/marketing/__tests__/generate-newsletter-draft.unit.spec.ts
+++ b/apps/backend/src/workflows/marketing/__tests__/generate-newsletter-draft.unit.spec.ts
@@ -1,0 +1,184 @@
+import {
+  buildNewsletterPrompt,
+  parseNewsletterPayload,
+  coerceNewsletterPayload,
+  generateNewsletterDraft,
+  NEWSLETTER_VOICE_RULES,
+} from "../generate-newsletter-draft"
+
+/**
+ * #659 §12.4 — unit tests for the AI newsletter draft generator. The LLM call is
+ * INJECTED as a stub so CI never calls a live model; the marketing module is a
+ * tiny in-memory stub so no DB boots. Covers prompt assembly, tolerant JSON
+ * parsing (incl. fenced + malformed fallback), payload coercion, and the
+ * draft-vs-ready persist contract.
+ */
+
+describe("buildNewsletterPrompt", () => {
+  it("embeds the topic, business, date, and voice rules", () => {
+    const p = buildNewsletterPrompt({
+      topic: "spring linen collection",
+      businessDescription: "ACME textiles",
+      dateIst: "2026-06-23",
+    })
+    expect(p).toContain("spring linen collection")
+    expect(p).toContain("ACME textiles")
+    expect(p).toContain("2026-06-23")
+    expect(p).toContain('"subject"')
+    expect(p).toContain(NEWSLETTER_VOICE_RULES.split("\n")[0])
+  })
+
+  it("falls back to an evergreen-angle instruction when no topic is given", () => {
+    const p = buildNewsletterPrompt({ dateIst: "2026-06-23" })
+    expect(p).toContain("evergreen angle")
+  })
+})
+
+describe("coerceNewsletterPayload", () => {
+  it("normalises section variants and drops empty sections", () => {
+    const out = coerceNewsletterPayload({
+      subject: " Hi ",
+      preview: "peek",
+      introduction: "welcome",
+      sections: [
+        { title: "A", content: "body a" },
+        { heading: "B", text: "body b" },
+        { heading: "", body: "" },
+        "junk",
+      ],
+      call_to_action: "Shop now",
+    })
+    expect(out.subject).toBe("Hi")
+    expect(out.preheader).toBe("peek")
+    expect(out.intro).toBe("welcome")
+    expect(out.cta).toBe("Shop now")
+    expect(out.sections).toEqual([
+      { heading: "A", body: "body a" },
+      { heading: "B", body: "body b" },
+    ])
+  })
+
+  it("is total on garbage input", () => {
+    const out = coerceNewsletterPayload(null)
+    expect(out).toEqual({
+      subject: "",
+      preheader: "",
+      intro: "",
+      sections: [],
+      cta: "",
+    })
+  })
+})
+
+describe("parseNewsletterPayload", () => {
+  it("parses a clean JSON object", () => {
+    const out = parseNewsletterPayload(
+      JSON.stringify({
+        subject: "S",
+        preheader: "P",
+        intro: "I",
+        sections: [{ heading: "H", body: "B" }],
+        cta: "C",
+      })
+    )
+    expect(out.parse_error).toBeUndefined()
+    expect(out.subject).toBe("S")
+    expect(out.sections).toHaveLength(1)
+  })
+
+  it("strips ```json fences and surrounding prose", () => {
+    const raw =
+      'Here you go:\n```json\n{"subject":"S","intro":"I","sections":[{"heading":"H","body":"B"}],"cta":"C","preheader":"P"}\n```\nThanks!'
+    const out = parseNewsletterPayload(raw)
+    expect(out.parse_error).toBeUndefined()
+    expect(out.subject).toBe("S")
+    expect(out.cta).toBe("C")
+  })
+
+  it("falls back to a single raw section on malformed output", () => {
+    const out = parseNewsletterPayload("not json at all { broken")
+    expect(out.parse_error).toBe(true)
+    expect(out.sections).toHaveLength(1)
+    expect(out.sections[0].body).toContain("not json")
+  })
+
+  it("flags empty input as a parse error", () => {
+    const out = parseNewsletterPayload("")
+    expect(out.parse_error).toBe(true)
+    expect(out.sections).toHaveLength(0)
+  })
+
+  it("treats a parsed-but-empty object as a soft failure", () => {
+    const out = parseNewsletterPayload(JSON.stringify({ foo: "bar" }))
+    expect(out.parse_error).toBe(true)
+  })
+})
+
+describe("generateNewsletterDraft", () => {
+  const makeContainer = () => {
+    const created: any[] = []
+    const container: any = {
+      resolve: () => ({
+        createMarketingDrafts: async (rows: any[]) => {
+          const withIds = rows.map((r, i) => ({ id: `draft_${i + 1}`, ...r }))
+          created.push(...withIds)
+          return withIds
+        },
+      }),
+    }
+    return { container, created }
+  }
+
+  const goodJson = JSON.stringify({
+    subject: "S",
+    preheader: "P",
+    intro: "I",
+    sections: [{ heading: "H", body: "B" }],
+    cta: "C",
+  })
+
+  it("persists status=draft when markReady is false (dry-run path)", async () => {
+    const { container, created } = makeContainer()
+    const result = await generateNewsletterDraft(container, {
+      aiGenerate: async () => goodJson,
+      topic: "x",
+      now: new Date("2026-06-23T00:00:00.000Z"),
+      markReady: false,
+    })
+    expect(result.generated).toBe(true)
+    expect(result.draft_id).toBe("draft_1")
+    expect(result.status).toBe("draft")
+    expect(result.name).toBe("newsletter-2026-06-23")
+    expect(result.parse_error).toBe(false)
+    expect(created[0].kind).toBe("newsletter")
+    expect(created[0].status).toBe("draft")
+    expect(created[0].approved_by).toBeNull()
+  })
+
+  it("persists status=approved + approved_by when markReady is true (apply path)", async () => {
+    const { container, created } = makeContainer()
+    const result = await generateNewsletterDraft(container, {
+      aiGenerate: async () => goodJson,
+      name: "custom-name",
+      markReady: true,
+    })
+    expect(result.status).toBe("approved")
+    expect(result.name).toBe("custom-name")
+    expect(created[0].status).toBe("approved")
+    expect(created[0].approved_by).toBe(
+      "ops:generate-marketing-newsletter-draft"
+    )
+  })
+
+  it("still persists (with parse_error) when the model returns junk", async () => {
+    const { container, created } = makeContainer()
+    const result = await generateNewsletterDraft(container, {
+      aiGenerate: async () => "totally not json",
+      markReady: false,
+    })
+    expect(result.generated).toBe(true)
+    expect(result.parse_error).toBe(true)
+    expect(created).toHaveLength(1)
+    expect(created[0].payload.parse_error).toBe(true)
+  })
+})

--- a/apps/backend/src/workflows/marketing/generate-newsletter-draft.ts
+++ b/apps/backend/src/workflows/marketing/generate-newsletter-draft.ts
@@ -1,0 +1,338 @@
+/**
+ * generate-newsletter-draft.ts — #659 slice (report §12.4).
+ *
+ * The "AI newsletter draft generator": ask the LLM for a customer-facing
+ * newsletter (subject / preheader / intro / sections / CTA) and persist it to
+ * the EXISTING `marketing_draft` model as an OPERATOR-REVIEW draft. Sending is
+ * NOT done here — drafts are reviewed/edited in the (separate) Newsletter editor
+ * UI and later enqueued through the existing `src/jobs/process-email-queue.ts`.
+ *
+ * Reuses the verified generate-ideas-email wiring:
+ *   - the AI call is an INJECTABLE `AiGenerateFn` (prompt in, text out) so CI
+ *     never calls a live LLM; the Medusa workflow wrapper injects the real
+ *     OpenRouter call (mirrors generate-ideas-email.ts:152-168).
+ *
+ * Unlike the tactical-ideas email this is CUSTOMER-FACING, so it does NOT read
+ * internal metric snapshots — we never want raw platform GMV leaking into a
+ * brand newsletter. The model is told to avoid inventing specific numbers.
+ *
+ * Pure, unit-tested helpers: `buildNewsletterPrompt`, `parseNewsletterPayload`,
+ * `coerceNewsletterPayload`.
+ */
+
+import {
+  createWorkflow,
+  createStep,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import { generateText } from "ai"
+import { createOpenRouter } from "@openrouter/ai-sdk-provider"
+
+import { MARKETING_MODULE } from "../../modules/marketing"
+import type { AiGenerateFn } from "./generate-ideas-email"
+
+const DEFAULT_MODEL = "anthropic/claude-3.5-sonnet"
+
+const DEFAULT_BUSINESS_DESCRIPTION =
+  "JYT is a textile-production commerce platform: it runs an admin storefront " +
+  "and onboards partner brands who sell their own products through per-partner " +
+  "storefronts."
+
+/** v1 newsletter voice rules — kept pure (the workflow may pass an override). */
+export const NEWSLETTER_VOICE_RULES = [
+  "Warm and brand-forward, but never hype. Sound like a real person, not an ad.",
+  "Lead with value for the reader; keep paragraphs short and scannable.",
+  "Do NOT invent specific numbers, percentages, prices, discounts, or dates.",
+  "End with one clear, low-pressure call to action.",
+].join("\n- ")
+
+// IST = UTC+5:30. Return the IST calendar date (YYYY-MM-DD) for a UTC instant.
+function istDateString(d: Date): string {
+  const ist = new Date(d.getTime() + 5.5 * 60 * 60 * 1000)
+  return ist.toISOString().slice(0, 10)
+}
+
+export type NewsletterSection = {
+  heading: string
+  body: string
+}
+
+export type NewsletterPayload = {
+  subject: string
+  preheader: string
+  intro: string
+  sections: NewsletterSection[]
+  cta: string
+  /** true when the model output could not be parsed as JSON and we fell back. */
+  parse_error?: boolean
+}
+
+export type GenerateNewsletterDraftOptions = {
+  /** Injected for tests; defaults to the real OpenRouter call. */
+  aiGenerate?: AiGenerateFn
+  /** Operator topic/angle for this newsletter (free text). */
+  topic?: string
+  /** Business description fed to the prompt. */
+  businessDescription?: string
+  /** Voice override. */
+  voiceRules?: string
+  /** Human label for the draft row; defaults to `newsletter-<IST date>`. */
+  name?: string
+  /** When true, persist as status="approved" (ready); else status="draft". */
+  markReady?: boolean
+  /** Reference "now"; defaults to current time. Used only for the default name. */
+  now?: Date
+}
+
+export type GenerateNewsletterDraftResult = {
+  generated: boolean
+  draft_id: string | null
+  name: string
+  status: "draft" | "approved"
+  model_used: string
+  payload: NewsletterPayload
+  parse_error: boolean
+}
+
+/**
+ * Pure: build the newsletter generation prompt. Asks the model for a strict JSON
+ * object so the output is structured + parseable (no numbered-list scraping).
+ */
+export function buildNewsletterPrompt(opts: {
+  topic?: string
+  businessDescription?: string
+  voiceRules?: string
+  dateIst: string
+}): string {
+  const business = opts.businessDescription || DEFAULT_BUSINESS_DESCRIPTION
+  const voice = opts.voiceRules || NEWSLETTER_VOICE_RULES
+  const topicLine = opts.topic?.trim()
+    ? `TOPIC / ANGLE for this edition: ${opts.topic.trim()}`
+    : `TOPIC / ANGLE: pick a useful, evergreen angle relevant to the business.`
+
+  return [
+    `You are the marketing editor writing a customer newsletter for this business.`,
+    `Date: ${opts.dateIst}.`,
+    ``,
+    `BUSINESS:`,
+    business,
+    ``,
+    topicLine,
+    ``,
+    `Write ONE newsletter edition. Respond with ONLY a single JSON object — no`,
+    `prose, no markdown fences — with EXACTLY this shape:`,
+    `{`,
+    `  "subject": "string, <= 80 chars",`,
+    `  "preheader": "string, <= 120 chars",`,
+    `  "intro": "string, 1-2 short paragraphs",`,
+    `  "sections": [ { "heading": "string", "body": "string" } ],`,
+    `  "cta": "string, one clear call to action"`,
+    `}`,
+    `Provide 2-4 sections.`,
+    ``,
+    `VOICE:`,
+    `- ${voice}`,
+  ].join("\n")
+}
+
+function asString(v: unknown): string {
+  if (typeof v === "string") return v.trim()
+  if (v == null) return ""
+  return String(v).trim()
+}
+
+/**
+ * Pure: normalise an arbitrary parsed object into a well-formed NewsletterPayload.
+ * Tolerant of missing/extra keys and section shape variants.
+ */
+export function coerceNewsletterPayload(raw: unknown): NewsletterPayload {
+  const obj = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>
+
+  const rawSections = Array.isArray(obj.sections) ? obj.sections : []
+  const sections: NewsletterSection[] = rawSections
+    .map((s) => {
+      const sec = (s && typeof s === "object" ? s : {}) as Record<string, unknown>
+      return {
+        heading: asString(sec.heading ?? sec.title),
+        body: asString(sec.body ?? sec.content ?? sec.text),
+      }
+    })
+    .filter((s) => s.heading.length > 0 || s.body.length > 0)
+
+  return {
+    subject: asString(obj.subject),
+    preheader: asString(obj.preheader ?? obj.preview),
+    intro: asString(obj.intro ?? obj.introduction),
+    sections,
+    cta: asString(obj.cta ?? obj.call_to_action),
+  }
+}
+
+/**
+ * Pure: parse the model's raw text into a NewsletterPayload. Strips ```json
+ * fences and grabs the outermost {...} block. On any parse failure, returns a
+ * usable fallback (the raw text as a single section) with parse_error=true so
+ * the operator can still review/edit it — we never throw on bad model output.
+ */
+export function parseNewsletterPayload(rawText: string): NewsletterPayload {
+  const text = (rawText || "").trim()
+  if (!text) {
+    return {
+      subject: "",
+      preheader: "",
+      intro: "",
+      sections: [],
+      cta: "",
+      parse_error: true,
+    }
+  }
+
+  // strip code fences and isolate the outermost JSON object.
+  let candidate = text.replace(/```(?:json)?/gi, "").trim()
+  const first = candidate.indexOf("{")
+  const last = candidate.lastIndexOf("}")
+  if (first !== -1 && last !== -1 && last > first) {
+    candidate = candidate.slice(first, last + 1)
+  }
+
+  try {
+    const parsed = JSON.parse(candidate)
+    const payload = coerceNewsletterPayload(parsed)
+    // a parse that yields no usable content is treated as a soft failure.
+    const empty =
+      !payload.subject && !payload.intro && payload.sections.length === 0
+    return empty ? fallbackPayload(text) : payload
+  } catch {
+    return fallbackPayload(text)
+  }
+}
+
+function fallbackPayload(rawText: string): NewsletterPayload {
+  return {
+    subject: "",
+    preheader: "",
+    intro: "",
+    sections: [{ heading: "Draft", body: rawText }],
+    cta: "",
+    parse_error: true,
+  }
+}
+
+/** The real LLM call. Mirrors generate-ideas-email.ts:152-168 (try/catch → ""). */
+async function defaultAiGenerate(prompt: string): Promise<string> {
+  try {
+    const openrouter = createOpenRouter({
+      apiKey: process.env.OPENROUTER_API_KEY,
+    })
+    const result = await generateText({
+      model: openrouter(
+        process.env.MARKETING_NEWSLETTER_MODEL ||
+          process.env.MARKETING_IDEAS_MODEL ||
+          DEFAULT_MODEL
+      ),
+      prompt,
+      maxOutputTokens: 1200,
+    })
+    return (result.text || "").trim()
+  } catch (error: any) {
+    // eslint-disable-next-line no-console
+    console.error("[generate-newsletter-draft] AI error:", error?.message)
+    return ""
+  }
+}
+
+/**
+ * Core orchestration (no Medusa-step wrapper, so it's directly unit/integration
+ * testable with a stubbed `aiGenerate`): build prompt → generate → parse →
+ * persist a `marketing_draft` row (kind="newsletter").
+ */
+export async function generateNewsletterDraft(
+  container: any,
+  opts: GenerateNewsletterDraftOptions = {}
+): Promise<GenerateNewsletterDraftResult> {
+  const aiGenerate = opts.aiGenerate || defaultAiGenerate
+  const now = opts.now || new Date()
+  const dateIst = istDateString(now)
+  const businessDescription =
+    opts.businessDescription ||
+    process.env.MARKETING_BUSINESS_DESCRIPTION ||
+    DEFAULT_BUSINESS_DESCRIPTION
+  const modelId =
+    process.env.MARKETING_NEWSLETTER_MODEL ||
+    process.env.MARKETING_IDEAS_MODEL ||
+    DEFAULT_MODEL
+  const name = opts.name?.trim() || `newsletter-${dateIst}`
+  const status: "draft" | "approved" = opts.markReady ? "approved" : "draft"
+
+  const prompt = buildNewsletterPrompt({
+    topic: opts.topic,
+    businessDescription,
+    voiceRules: opts.voiceRules,
+    dateIst,
+  })
+
+  const rawOutput = await aiGenerate(prompt)
+  const payload = parseNewsletterPayload(rawOutput)
+  const parseError = payload.parse_error === true
+
+  const marketing: any = container.resolve(MARKETING_MODULE)
+  const created = await marketing.createMarketingDrafts([
+    {
+      name,
+      kind: "newsletter",
+      status,
+      payload,
+      model_used: modelId,
+      approved_by: opts.markReady ? "ops:generate-marketing-newsletter-draft" : null,
+    },
+  ])
+
+  return {
+    generated: true,
+    draft_id: arrId(created),
+    name,
+    status,
+    model_used: modelId,
+    payload,
+    parse_error: parseError,
+  }
+}
+
+function arrId(created: any): string | null {
+  const row = Array.isArray(created) ? created[0] : created
+  return row?.id ?? null
+}
+
+// ---------------------------------------------------------------------------
+// Medusa workflow wrapper (injects the real OpenRouter call).
+// ---------------------------------------------------------------------------
+export type GenerateNewsletterDraftWorkflowInput = {
+  topic?: string
+  businessDescription?: string
+  name?: string
+  markReady?: boolean
+}
+
+const generateNewsletterDraftStep = createStep(
+  "generate-newsletter-draft",
+  async (input: GenerateNewsletterDraftWorkflowInput, { container }) => {
+    const result = await generateNewsletterDraft(container, {
+      topic: input?.topic,
+      businessDescription: input?.businessDescription,
+      name: input?.name,
+      markReady: input?.markReady,
+    })
+    return new StepResponse(result)
+  }
+)
+
+export const generateNewsletterDraftWorkflow = createWorkflow(
+  "generate-newsletter-draft",
+  (input: GenerateNewsletterDraftWorkflowInput) => {
+    const result = generateNewsletterDraftStep(input)
+    return new WorkflowResponse(result)
+  }
+)
+
+export default generateNewsletterDraftWorkflow


### PR DESCRIPTION
## #659 AI VP of Marketing — newsletter draft generator (report §12.4)

Adds a #457 Data Plumbing job **`generate-marketing-newsletter-draft`** that generates a customer-facing newsletter draft with the injectable AI pattern and persists it to the **existing `marketing_draft`** model for operator review. **No sending here** — drafts are reviewed/edited in the (separate, Playwright-gated) Newsletter editor UI and enqueued later through the existing `src/jobs/process-email-queue.ts`.

### What it does
- **dry_run** (default) → generate + persist as `status="draft"` (review).
- **apply** → generate + persist as `status="approved"` (marked ready).
- Mirrors how the merged ideas-email job always persists its output before any send — the draft *is* the deliverable the operator edits, so we persist on both paths and distinguish by status.

### Reuses existing primitives (no new infra)
- Injectable `AiGenerateFn` + `createOpenRouter`/`generateText` wiring (mirrors `generate-ideas-email.ts`) so **CI never calls a live LLM**.
- Existing `marketing_draft` model (`kind="newsletter"`), `marketing` service `createMarketingDrafts`.
- Existing `#457` registry + Ops Data-Plumbing console UI + `ops_audit` (free).

### Files
- `src/workflows/marketing/generate-newsletter-draft.ts` — pure `buildNewsletterPrompt` / `parseNewsletterPayload` (tolerant JSON, strips ```json fences, raw fallback — **never throws** on bad model output) / `coerceNewsletterPayload` + `generateNewsletterDraft` core + Medusa workflow wrapper injecting the real OpenRouter call.
- `src/api/admin/ops/maintenance-jobs/registry.ts` — `buildNewsletterDraftResult` (pure) + job registration.
- 2 unit specs — **17 tests** (prompt assembly, parsing edge cases, coercion, draft-vs-ready persist contract, result builder).

### Verify
```
TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules npx jest \
  --testPathPattern="(generate-newsletter-draft|generate-marketing-newsletter-draft)\.unit\.spec"
```
17/17 green; typecheck clean on changed files.

### Out of scope (deferred)
- Newsletter editor UI (separate `page_type` "Newsletter" chunk, Playwright-gated).
- Sending (reuses `process-email-queue.ts` later).

Branched off fresh `origin/main`, independent. **PR-only — leave for human review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)