### PR TITLE
feat(#659): marketing admin UI — /admin/marketing route + GMV headline strip + WinbacksView

### DIFF
--- a/apps/backend/src/admin/hooks/api/marketing.ts
+++ b/apps/backend/src/admin/hooks/api/marketing.ts
@@ -1,0 +1,36 @@
+import { useQuery, keepPreviousData } from "@tanstack/react-query"
+import { sdk } from "../../lib/config"
+
+// Response shape of GET /admin/marketing/headline — mirrors the
+// HeadlineResponse / HeadlineMetric types in marketing-read-lib.ts.
+export interface MarketingHeadlineMetric {
+  metric_key: string
+  value: number
+  unit: string | null
+  dod_delta: number | null
+  as_of_date: string | null
+}
+
+export interface MarketingHeadlineResponse {
+  headline: MarketingHeadlineMetric | null
+  strip: MarketingHeadlineMetric[]
+  trend: { as_of_date: string; value: number }[]
+  stale: boolean
+  generated_at: string
+}
+
+const MARKETING_QUERY_KEY = "marketing" as const
+
+export const useMarketingHeadline = () => {
+  return useQuery({
+    queryKey: [MARKETING_QUERY_KEY, "headline"],
+    queryFn: async () => {
+      const res = await sdk.client.fetch<MarketingHeadlineResponse>(
+        "/admin/marketing/headline"
+      )
+      return res as MarketingHeadlineResponse
+    },
+    staleTime: 5 * 60 * 1000,
+    placeholderData: keepPreviousData,
+  })
+}

--- a/apps/backend/src/admin/routes/marketing/page.tsx
+++ b/apps/backend/src/admin/routes/marketing/page.tsx
@@ -21,10 +21,11 @@ const formatValue = (value: number, unit: string | null): string => {
   return unit ? `${base} ${unit}` : base
 }
 
+// delta_dod is a day-over-day PERCENTAGE (matches how the ideas-email renders it).
 const formatDelta = (delta: number | null): string => {
   if (delta === null) return "-"
   const sign = delta >= 0 ? "+" : ""
-  return `${sign}${delta.toLocaleString(undefined, { maximumFractionDigits: 2 })}`
+  return `${sign}${delta.toLocaleString(undefined, { maximumFractionDigits: 2 })}%`
 }
 
 const MarketingPage = () => {

--- a/apps/backend/src/admin/routes/marketing/page.tsx
+++ b/apps/backend/src/admin/routes/marketing/page.tsx
@@ -1,0 +1,178 @@
+import { defineRouteConfig } from "@medusajs/admin-sdk"
+import { ChartBar } from "@medusajs/icons"
+import { Badge, Container, Heading, Skeleton, Text } from "@medusajs/ui"
+import { useMarketingHeadline } from "../../hooks/api/marketing"
+
+// Mirrors formatMetricDisplay in workflows/marketing/generate-ideas-email.ts so
+// the strip reads the SAME way as the AI email. The snapshot `unit` is the
+// uppercased currency_code (e.g. "INR") for money metrics, or "ratio"/"count"/
+// "percent" for derived ones.
+const round1 = (n: number): number => Math.round(n * 10) / 10
+
+const formatValue = (value: number, unit: string | null): string => {
+  const u = (unit || "").toLowerCase()
+  if (u === "inr") return "₹" + Math.round(value).toLocaleString("en-IN")
+  if (u === "usd") return "$" + Math.round(value).toLocaleString("en-US")
+  if (u === "eur") return "€" + Math.round(value).toLocaleString("en-IE")
+  if (u === "percent") return `${round1(value)}%`
+  if (u === "ratio") return `${round1(value * 100)}%`
+  if (u === "count") return Math.round(value).toLocaleString("en-IN")
+  const base = value.toLocaleString(undefined, { maximumFractionDigits: 2 })
+  return unit ? `${base} ${unit}` : base
+}
+
+const formatDelta = (delta: number | null): string => {
+  if (delta === null) return "-"
+  const sign = delta >= 0 ? "+" : ""
+  return `${sign}${delta.toLocaleString(undefined, { maximumFractionDigits: 2 })}`
+}
+
+const MarketingPage = () => {
+  const { data, isLoading, isError } = useMarketingHeadline()
+
+  if (isLoading) {
+    return (
+      <Container className="px-6 py-4">
+        <div className="flex flex-col gap-y-6">
+          <Skeleton className="h-8 w-48 rounded-md" />
+          <Skeleton className="h-32 w-full rounded-lg" />
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="h-24 w-full rounded-lg" />
+            ))}
+          </div>
+        </div>
+      </Container>
+    )
+  }
+
+  if (isError) {
+    return (
+      <Container className="px-6 py-4">
+        <Text className="text-ui-fg-error">
+          Failed to load marketing data.
+        </Text>
+      </Container>
+    )
+  }
+
+  const headline = data?.headline
+  const strip = data?.strip ?? []
+  const stale = data?.stale ?? false
+
+  return (
+    <Container className="px-6 py-4">
+      <div className="flex flex-col gap-y-6">
+        {/* Header + stale badge */}
+        <div className="flex items-center gap-3">
+          <Heading level="h1">Marketing</Heading>
+          {stale && (
+            <Badge color="orange" size="xsmall">
+              Stale
+            </Badge>
+          )}
+        </div>
+
+        {/* Headline / One-Goal card */}
+        {headline ? (
+          <div className="shadow-elevation-card-rest bg-ui-bg-component rounded-lg p-6">
+            <Text
+              size="xsmall"
+              leading="compact"
+              className="text-ui-fg-subtle uppercase tracking-wider"
+            >
+              {headline.metric_key.replace(/_/g, " ")}
+            </Text>
+            <div className="flex items-baseline gap-3 mt-2">
+              <Text size="xlarge" leading="compact" weight="plus">
+                {formatValue(headline.value, headline.unit)}
+              </Text>
+              {headline.dod_delta !== null && (
+                <Text
+                  size="small"
+                  leading="compact"
+                  weight="plus"
+                  className={
+                    headline.dod_delta >= 0
+                      ? "text-ui-fg-positive"
+                      : "text-ui-fg-error"
+                  }
+                >
+                  {formatDelta(headline.dod_delta)}
+                </Text>
+              )}
+            </div>
+            <Text
+              size="xsmall"
+              leading="compact"
+              className="text-ui-fg-muted mt-1"
+            >
+              {headline.as_of_date
+                ? `as of ${new Date(headline.as_of_date).toLocaleDateString()}`
+                : ""}
+            </Text>
+          </div>
+        ) : (
+          <div className="shadow-elevation-card-rest bg-ui-bg-component rounded-lg p-6">
+            <Text size="small" leading="compact" className="text-ui-fg-muted">
+              No headline metric available yet. Data will appear after the first
+              sync.
+            </Text>
+          </div>
+        )}
+
+        {/* Strip — secondary KPI cards */}
+        {strip.length > 0 && (
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+            {strip.map((metric) => (
+              <div
+                key={metric.metric_key}
+                className="shadow-elevation-card-rest bg-ui-bg-component rounded-lg p-4"
+              >
+                <Text
+                  size="xsmall"
+                  leading="compact"
+                  className="text-ui-fg-subtle"
+                >
+                  {metric.metric_key.replace(/_/g, " ")}
+                </Text>
+                <Text
+                  size="large"
+                  leading="compact"
+                  weight="plus"
+                  className="mt-1"
+                >
+                  {formatValue(metric.value, metric.unit)}
+                </Text>
+                {metric.dod_delta !== null && (
+                  <Text
+                    size="xsmall"
+                    leading="compact"
+                    className={
+                      metric.dod_delta >= 0
+                        ? "text-ui-fg-positive mt-0.5"
+                        : "text-ui-fg-error mt-0.5"
+                    }
+                  >
+                    {formatDelta(metric.dod_delta)}
+                  </Text>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </Container>
+  )
+}
+
+export const config = defineRouteConfig({
+  label: "Marketing",
+  icon: ChartBar,
+})
+
+export const handle = {
+  breadcrumb: () => "Marketing",
+}
+
+export default MarketingPage

--- a/apps/backend/src/admin/routes/marketing/winbacks/page.tsx
+++ b/apps/backend/src/admin/routes/marketing/winbacks/page.tsx
@@ -1,0 +1,207 @@
+import { defineRouteConfig } from "@medusajs/admin-sdk"
+import {
+  Badge,
+  Container,
+  DataTable,
+  type DataTablePaginationState,
+  Heading,
+  StatusBadge,
+  Text,
+  useDataTable,
+} from "@medusajs/ui"
+import { createColumnHelper } from "@tanstack/react-table"
+import { useQuery } from "@tanstack/react-query"
+import { useCallback } from "react"
+import { useSearchParams } from "react-router-dom"
+import { sdk } from "../../../lib/config"
+
+const PAGE_SIZE = 20
+
+type MarketingOutreach = {
+  id: string
+  recipient_email: string
+  recipient_name: string | null
+  company: string | null
+  status: "queued" | "sent" | "opened" | "replied" | "bounced" | "unknown"
+  channel: "email" | "whatsapp" | "manual"
+  campaign: string | null
+  sent_at: string | null
+  opened_at: string | null
+  replied_at: string | null
+  bounce_unreliable: boolean
+  notes: string | null
+  external_id: string | null
+  created_at: string
+  updated_at: string
+}
+
+const columnHelper = createColumnHelper<MarketingOutreach>()
+
+const statusToTone = (
+  status: MarketingOutreach["status"]
+): "green" | "blue" | "orange" | "purple" | "grey" => {
+  switch (status) {
+    case "replied":
+      return "green"
+    case "opened":
+      return "blue"
+    case "sent":
+      return "purple"
+    case "queued":
+      return "grey"
+    case "bounced":
+      return "orange"
+    default:
+      return "grey"
+  }
+}
+
+const formatDateTime = (iso: string | null): string => {
+  if (!iso) return "—"
+  try {
+    return new Date(iso).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    })
+  } catch {
+    return "—"
+  }
+}
+
+const WinbacksView = () => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const pageFromUrl = parseInt(searchParams.get("w_page") || "1", 10)
+
+  const pagination: DataTablePaginationState = {
+    pageIndex: Math.max(0, pageFromUrl - 1),
+    pageSize: PAGE_SIZE,
+  }
+
+  const offset = pagination.pageIndex * pagination.pageSize
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ["marketing", "winbacks", pagination],
+    queryFn: async () => {
+      const res = await sdk.client.fetch<{
+        outreach: MarketingOutreach[]
+        count: number
+        offset: number
+        limit: number
+      }>("/admin/marketing/outreach", {
+        query: {
+          campaign: "winback",
+          limit: pagination.pageSize,
+          offset,
+        },
+      })
+      return res
+    },
+    placeholderData: (prev) => prev,
+  })
+
+  const handlePaginationChange = useCallback(
+    (newPagination: DataTablePaginationState) => {
+      const params = new URLSearchParams(searchParams)
+      if (newPagination.pageIndex > 0)
+        params.set("w_page", String(newPagination.pageIndex + 1))
+      else params.delete("w_page")
+      setSearchParams(params, { replace: true })
+    },
+    [searchParams, setSearchParams]
+  )
+
+  const columns = [
+    columnHelper.accessor("recipient_email", {
+      header: "Email",
+      cell: (info) => info.getValue(),
+    }),
+    columnHelper.accessor("recipient_name", {
+      header: "Name",
+      cell: (info) => info.getValue() || "—",
+    }),
+    columnHelper.accessor("company", {
+      header: "Company",
+      cell: (info) => info.getValue() || "—",
+    }),
+    columnHelper.accessor("status", {
+      header: "Status",
+      cell: (info) => (
+        <span className="flex items-center gap-2">
+          <StatusBadge color={statusToTone(info.getValue())}>
+            {info.getValue()}
+          </StatusBadge>
+          {info.row.original.bounce_unreliable && (
+            <Badge color="orange" size="xsmall">
+              Bounce unreliable
+            </Badge>
+          )}
+        </span>
+      ),
+    }),
+    columnHelper.accessor("channel", {
+      header: "Channel",
+      cell: (info) => info.getValue() || "—",
+    }),
+    columnHelper.accessor("campaign", {
+      header: "Campaign",
+      cell: (info) => info.getValue() || "—",
+    }),
+    columnHelper.accessor("sent_at", {
+      header: "Sent",
+      cell: (info) => formatDateTime(info.getValue()),
+    }),
+    columnHelper.accessor("opened_at", {
+      header: "Opened",
+      cell: (info) => formatDateTime(info.getValue()),
+    }),
+    columnHelper.accessor("replied_at", {
+      header: "Replied",
+      cell: (info) => formatDateTime(info.getValue()),
+    }),
+  ]
+
+  const table = useDataTable({
+    data: data?.outreach || [],
+    columns,
+    rowCount: data?.count || 0,
+    getRowId: (row) => row.id,
+    isLoading,
+    pagination: {
+      state: pagination,
+      onPaginationChange: handlePaginationChange,
+    },
+  })
+
+  if (isError) throw error
+
+  return (
+    <Container className="divide-y p-0">
+      <DataTable instance={table}>
+        <DataTable.Toolbar className="flex flex-col md:flex-row justify-between gap-y-4 w-full px-6 py-4">
+          <div>
+            <Heading>Winbacks</Heading>
+            <Text className="text-ui-fg-subtle" size="small">
+              Winback outreach to re-engage lapsed customers.
+              <span className="ml-2">
+                <Badge color="orange" size="xsmall">
+                  Bounce unreliable
+                </Badge>{" "}
+                = provider bounce flags are unreliable — verify manually.
+              </span>
+            </Text>
+          </div>
+        </DataTable.Toolbar>
+        <DataTable.Table />
+        <DataTable.Pagination />
+      </DataTable>
+    </Container>
+  )
+}
+
+export const config = defineRouteConfig({
+  label: "Winbacks",
+})
+
+export default WinbacksView


### PR DESCRIPTION
## What
The operator-facing admin UI for the AI-VP-of-Marketing (#659) — a dedicated **`/admin/marketing`** nav route.

- **Headline strip** — GMV (One Goal = `platform_net_gmv`) hero card + day-over-day delta (green/red), secondary KPI strip, `stale` badge, empty state, Skeleton cold-load. Reads `GET /admin/marketing/headline` via a SWR hook (`staleTime` 5m + `keepPreviousData`).
- **WinbacksView** (`/admin/marketing/winbacks`) — DataTable over `GET /admin/marketing/outreach?campaign=winback`; real `marketing_outreach` columns; `bounce_unreliable` honesty badge (never auto-suppress); pagination + Skeleton.

Medusa UI primitives + design tokens only (no hardcoded colors → dark mode follows).

## Provenance
Drafted by the free-model opencode drafters (2 in parallel, disjoint files), then **verified + corrected by Claude** against the real model/route/lib:
- fixed `formatValue` to mirror the AI email's `formatMetricDisplay` (₹ INR / % ratio / counts) instead of hardcoded USD.
- fixed the SDK call (`query:` not `params:`) — caught by a tsc error.
- field names + DataTable API confirmed against `marketing-outreach.ts` / `ads-tab.tsx`.

Typecheck clean on all three files.

## ⚠️ Verify-before-merge
This is the **render slice** — it can't be Playwright-verified headless. Hold for a live check in the admin (Marketing page + Winbacks render correctly) before merging.

## Follow-up (not in this PR)
The **Newsletter** `page_type` editor option needs an enum migration → separate small PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)