### PR TITLE
feat(#659): Newsletter page_type + AI-draft pre-fill (last #659 item)

### DIFF
--- a/apps/backend/integration-tests/http/marketing-newsletter-prefill.spec.ts
+++ b/apps/backend/integration-tests/http/marketing-newsletter-prefill.spec.ts
@@ -1,0 +1,65 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { MARKETING_MODULE } from "../../src/modules/marketing"
+
+jest.setTimeout(60 * 1000)
+
+/**
+ * #659 — GET /admin/marketing/newsletter-prefill
+ *
+ * The wiring that lets the blog editor pre-fill a `page_type="Newsletter"` page
+ * from the latest AI newsletter draft (the #687 generate-newsletter-draft job
+ * persists these as `marketing_draft` rows, kind="newsletter"). Proves the
+ * end-to-end chain: a seeded draft payload → the endpoint's mapped title/content.
+ *
+ * Shared HTTP test DB TRUNCATEs between it()s, so each test seeds its own draft.
+ */
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+  let headers: any
+
+  beforeEach(async () => {
+    const container = getContainer()
+    await createAdminUser(container)
+    headers = await getAuthHeaders(api)
+  })
+
+  it("returns draft:null + empty fields when no newsletter draft exists", async () => {
+    const res = await api.get("/admin/marketing/newsletter-prefill", headers)
+    expect(res.status).toBe(200)
+    expect(res.data.draft).toBeNull()
+    expect(res.data.title).toBe("")
+    expect(res.data.content).toBe("")
+  })
+
+  it("maps the latest newsletter draft payload to editor title + content", async () => {
+    const svc: any = getContainer().resolve(MARKETING_MODULE)
+    await svc.createMarketingDrafts([
+      {
+        name: "weekly-2026-06-23",
+        kind: "newsletter",
+        payload: {
+          subject: "Weekly JYT — New Fabrics In",
+          preheader: "Fresh drops + a flash sale",
+          intro: "Hello! Here's what's new this week.",
+          sections: [
+            { heading: "New Arrivals", body: "Handloom cottons just landed." },
+            { heading: "Flash Sale", body: "20% off through Sunday." },
+          ],
+        },
+      },
+    ])
+
+    const res = await api.get("/admin/marketing/newsletter-prefill", headers)
+    expect(res.status).toBe(200)
+    expect(res.data.draft).not.toBeNull()
+    expect(res.data.draft.name).toBe("weekly-2026-06-23")
+    expect(res.data.title).toBe("Weekly JYT — New Fabrics In")
+    // content = intro, then "## heading / body" per section, blank-line joined.
+    expect(res.data.content).toBe(
+      "Hello! Here's what's new this week.\n\n" +
+        "## New Arrivals\n\nHandloom cottons just landed.\n\n" +
+        "## Flash Sale\n\n20% off through Sunday."
+    )
+  })
+})

--- a/apps/backend/integration-tests/http/websites-api.spec.ts
+++ b/apps/backend/integration-tests/http/websites-api.spec.ts
@@ -125,6 +125,29 @@ setupSharedTestSuite(() => {
           pageId = response.data.page.id;
         });
 
+        it("should create a Newsletter page (page_type enum + DB check constraint allow it)", async () => {
+          const newsletter = {
+            title: "Spring Newsletter",
+            slug: "spring-newsletter",
+            content: "<p>Hello subscribers</p>",
+            page_type: "Newsletter",
+            status: "Draft",
+          };
+
+          const response = await api.post(
+            `/admin/websites/${websiteId}/pages`,
+            newsletter,
+            headers
+          );
+
+          expect(response.status).toBe(201);
+          expect(response.data.page).toMatchObject({
+            ...newsletter,
+            id: expect.any(String),
+            website_id: websiteId,
+          });
+        });
+
         it("should create multiple pages in batch", async () => {
           const pages = [
             {

--- a/apps/backend/src/admin/components/creates/create-page.tsx
+++ b/apps/backend/src/admin/components/creates/create-page.tsx
@@ -28,7 +28,8 @@ const pageSchema = z.object({
       "Service",
       "Portfolio",
       "Landing",
-      "Custom"
+      "Custom",
+      "Newsletter"
     ]),
     status: z.enum(["Draft", "Published", "Archived"]).default("Draft"),
     meta_title: z.string().optional(),
@@ -64,6 +65,7 @@ const pageTypeOptions = [
   { value: "Portfolio", label: "Portfolio" },
   { value: "Landing", label: "Landing" },
   { value: "Custom", label: "Custom" },
+  { value: "Newsletter", label: "Newsletter" },
 ]
 
 type PageFormValues = z.infer<typeof pageSchema>;

--- a/apps/backend/src/admin/components/creates/create-page.tsx
+++ b/apps/backend/src/admin/components/creates/create-page.tsx
@@ -13,6 +13,7 @@ import { RouteFocusModal } from "../modal/route-focus-modal";
 import { KeyboundForm } from "../utilitites/key-bound-form";
 import { AdminWebsite } from "../../hooks/api/websites";
 import { useCreatePages } from "../../hooks/api/pages";
+import { sdk } from "../../lib/config";
 
 const pageSchema = z.object({
   pages: z.array(z.object({
@@ -104,6 +105,28 @@ export function CreatePageComponent({ websiteId, website }: CreatePageComponentP
     control: form.control,
     name: "pages",
   });
+
+  // Pre-fill a Newsletter page from the latest AI newsletter draft (#687 job →
+  // marketing_draft). Maps subject→title + intro/sections→content via the
+  // /admin/marketing/newsletter-prefill endpoint; the operator then edits + sends.
+  const prefillNewsletter = async (index: number) => {
+    try {
+      const res = await sdk.client.fetch<{
+        draft: { id: string } | null;
+        title: string;
+        content: string;
+      }>("/admin/marketing/newsletter-prefill");
+      if (!res?.draft) {
+        toast.info("No AI newsletter draft yet — generate one from Data Plumbing first.");
+        return;
+      }
+      form.setValue(`pages.${index}.title`, res.title || "");
+      form.setValue(`pages.${index}.content`, res.content || "");
+      toast.success("Pre-filled from the latest AI newsletter draft.");
+    } catch {
+      toast.error("Couldn't load the newsletter draft.");
+    }
+  };
 
   const addNewPage = () => {
     append({
@@ -309,6 +332,17 @@ export function CreatePageComponent({ websiteId, website }: CreatePageComponentP
                           )}
                         />
                         
+                        {form.watch(`pages.${index}.page_type`) === "Newsletter" && (
+                          <Button
+                            type="button"
+                            variant="secondary"
+                            size="small"
+                            onClick={() => prefillNewsletter(index)}
+                          >
+                            Prefill from latest AI draft
+                          </Button>
+                        )}
+
                         <Form.Field
                           control={form.control}
                           name={`pages.${index}.status`}

--- a/apps/backend/src/admin/components/websites/page-general-section.tsx
+++ b/apps/backend/src/admin/components/websites/page-general-section.tsx
@@ -103,8 +103,8 @@ export const PageGeneralSection = ({ page, websiteId }: PageGeneralSectionProps)
                   },
                 ],
               },
-              /* Only show Send to Subscribers action for Blog pages */
-              ...(page.page_type === "Blog" ? [
+              /* Only show Send to Subscribers action for Blog and Newsletter pages */
+              ...(page.page_type === "Blog" || page.page_type === "Newsletter" ? [
                 {
                   actions: [
                     {

--- a/apps/backend/src/admin/hooks/api/pages.ts
+++ b/apps/backend/src/admin/hooks/api/pages.ts
@@ -48,7 +48,7 @@ export type AdminPage = {
   title: string;
   slug: string;
   content: string;
-  page_type: "Home" | "About" | "Contact" | "Blog" | "Product" | "Service" | "Portfolio" | "Landing" | "Custom";
+  page_type: "Home" | "About" | "Contact" | "Blog" | "Product" | "Service" | "Portfolio" | "Landing" | "Custom" | "Newsletter";
   status: "Draft" | "Published" | "Archived";
   meta_title?: string;
   meta_description?: string;

--- a/apps/backend/src/admin/hooks/api/websites.ts
+++ b/apps/backend/src/admin/hooks/api/websites.ts
@@ -21,7 +21,7 @@ type Pages= [ {
   title: string,
   slug: string, 
   content: string,
-  page_type: "Home" | "About" | "Contact" | "Blog" | "Product" | "Service" | "Portfolio" | "Landing" | "Custom";
+  page_type: "Home" | "About" | "Contact" | "Blog" | "Product" | "Service" | "Portfolio" | "Landing" | "Custom" | "Newsletter";
   status: "Draft" | "Published" | "Archived";
   meta_title?: string;
   meta_description?: string;

--- a/apps/backend/src/admin/routes/websites/[id]/pages/[pageId]/page.tsx
+++ b/apps/backend/src/admin/routes/websites/[id]/pages/[pageId]/page.tsx
@@ -40,7 +40,7 @@ const PageDetailPage = () => {
           <WebsiteBlocksSection websiteId={id!} pageId={page.id}/>
         </TwoColumnPage.Main>
         <TwoColumnPage.Sidebar>
-          {page.page_type === "Blog" && (
+          {(page.page_type === "Blog" || page.page_type === "Newsletter") && (
             <div className="flex flex-col gap-y-2">
               <PageAuthorSection page={page} websiteId={id!} />
               <BlogSubscriptionInfo page={page} websiteId={id!} />

--- a/apps/backend/src/api/admin/marketing/__tests__/newsletter-prefill-lib.unit.spec.ts
+++ b/apps/backend/src/api/admin/marketing/__tests__/newsletter-prefill-lib.unit.spec.ts
@@ -1,0 +1,69 @@
+import { buildNewsletterPrefill } from "../newsletter-prefill-lib"
+
+describe("buildNewsletterPrefill", () => {
+  it("handles null/undefined/empty payload", () => {
+    expect(buildNewsletterPrefill(null)).toEqual({ title: "", content: "" })
+    expect(buildNewsletterPrefill(undefined)).toEqual({ title: "", content: "" })
+    expect(buildNewsletterPrefill({})).toEqual({ title: "", content: "" })
+  })
+
+  it("trims and maps subject to title", () => {
+    expect(buildNewsletterPrefill({ subject: "  Weekly Update  " }).title).toBe(
+      "Weekly Update"
+    )
+    expect(
+      buildNewsletterPrefill({ subject: "  Weekly Update  " }).content
+    ).toBe("")
+  })
+
+  it("builds full content with intro and sections", () => {
+    expect(
+      buildNewsletterPrefill({
+        subject: "S",
+        intro: "Welcome back.",
+        sections: [
+          { heading: "New Arrivals", body: "Fresh stock." },
+          { heading: "Sale", body: "20% off." },
+        ],
+      })
+    ).toEqual({
+      title: "S",
+      content:
+        "Welcome back.\n\n## New Arrivals\n\nFresh stock.\n\n## Sale\n\n20% off.",
+    })
+  })
+
+  it("handles section with only heading", () => {
+    expect(
+      buildNewsletterPrefill({
+        subject: "S",
+        sections: [{ heading: "Just A Heading" }],
+      }).content
+    ).toBe("## Just A Heading")
+  })
+
+  it("handles section with only body", () => {
+    expect(
+      buildNewsletterPrefill({
+        subject: "S",
+        sections: [{ body: "Just a body" }],
+      }).content
+    ).toBe("Just a body")
+  })
+
+  it("skips section when both heading and body are empty/whitespace", () => {
+    expect(
+      buildNewsletterPrefill({
+        subject: "S",
+        intro: "I",
+        sections: [{ heading: "  ", body: "" }],
+      }).content
+    ).toBe("I")
+  })
+
+  it("coerces non-string subject to empty title", () => {
+    expect(
+      buildNewsletterPrefill({ subject: 123 as unknown as string }).title
+    ).toBe("")
+  })
+})

--- a/apps/backend/src/api/admin/marketing/newsletter-prefill-lib.ts
+++ b/apps/backend/src/api/admin/marketing/newsletter-prefill-lib.ts
@@ -1,0 +1,54 @@
+/**
+ * newsletter-prefill-lib — #659. Pure mapping from a `marketing_draft`
+ * (kind="newsletter") payload — produced by the #687 generate-newsletter-draft
+ * job — into the fields the blog editor's create-page form needs to pre-fill a
+ * `page_type="Newsletter"` page: a `title` (the subject line) and a `content`
+ * body (the intro + each section as a "## heading / body" block).
+ *
+ * Pure + unit-tested so the endpoint and the integration test share ONE mapping.
+ */
+
+export type NewsletterSection = {
+  heading?: string | null
+  body?: string | null
+}
+
+export type NewsletterDraftPayload = {
+  subject?: string | null
+  preheader?: string | null
+  intro?: string | null
+  sections?: NewsletterSection[] | null
+}
+
+export type NewsletterPrefill = {
+  title: string
+  content: string
+}
+
+const clean = (v: unknown): string => (typeof v === "string" ? v.trim() : "")
+
+/**
+ * Build the editor prefill from a newsletter draft payload. The content is
+ * Markdown-ish (intro paragraph, then `## heading` + body per section) so it
+ * drops cleanly into the editor for the operator to refine. Never throws — a
+ * missing/garbage payload yields empty strings (the form just isn't pre-filled).
+ */
+export function buildNewsletterPrefill(
+  payload: NewsletterDraftPayload | null | undefined
+): NewsletterPrefill {
+  const title = clean(payload?.subject)
+  const parts: string[] = []
+
+  const intro = clean(payload?.intro)
+  if (intro) parts.push(intro)
+
+  const sections = Array.isArray(payload?.sections) ? payload!.sections! : []
+  for (const s of sections) {
+    const heading = clean(s?.heading)
+    const body = clean(s?.body)
+    if (heading) parts.push(`## ${heading}`)
+    if (body) parts.push(body)
+  }
+
+  return { title, content: parts.join("\n\n") }
+}

--- a/apps/backend/src/api/admin/marketing/newsletter-prefill/route.ts
+++ b/apps/backend/src/api/admin/marketing/newsletter-prefill/route.ts
@@ -1,0 +1,33 @@
+/**
+ * GET /admin/marketing/newsletter-prefill — return the latest AI-generated
+ * newsletter draft (the #687 `generate-marketing-newsletter-draft` job persists
+ * these as `marketing_draft` rows, kind="newsletter") mapped to the blog
+ * editor's `{ title, content }` so the operator can create a `page_type=
+ * "Newsletter"` page pre-filled with the AI copy, then edit + send it.
+ *
+ * No middleware: a simple read. Empty when no newsletter draft exists yet
+ * (→ 200 with draft:null), so the editor just opens blank.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { MARKETING_MODULE } from "../../../../modules/marketing"
+import { buildNewsletterPrefill } from "../newsletter-prefill-lib"
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const marketingService: any = req.scope.resolve(MARKETING_MODULE)
+
+  const [draft] = await marketingService.listMarketingDrafts(
+    { kind: "newsletter" },
+    { order: { created_at: "DESC" }, take: 1 }
+  )
+
+  if (!draft) {
+    res.json({ draft: null, title: "", content: "" })
+    return
+  }
+
+  const prefill = buildNewsletterPrefill(draft.payload)
+  res.json({
+    draft: { id: draft.id, name: draft.name, created_at: draft.created_at },
+    ...prefill,
+  })
+}

--- a/apps/backend/src/api/admin/websites/[id]/pages/[pageId]/subs/route.ts
+++ b/apps/backend/src/api/admin/websites/[id]/pages/[pageId]/subs/route.ts
@@ -104,11 +104,11 @@ export const POST = async (
       });
     }
     
-    // Verify it's a blog page
-    if (page.page_type !== "Blog") {
+    // Verify it's a blog or newsletter page
+    if (page.page_type !== "Blog" && page.page_type !== "Newsletter") {
       return res.status(400).json({
         message: "Invalid page type",
-        error: "Only blog pages can be sent to subscribers"
+        error: "Only blog or newsletter pages can be sent to subscribers"
       });
     }
     

--- a/apps/backend/src/api/admin/websites/[id]/pages/[pageId]/subs/test/route.ts
+++ b/apps/backend/src/api/admin/websites/[id]/pages/[pageId]/subs/test/route.ts
@@ -165,11 +165,11 @@ export const POST = async (
       });
     }
     
-    // Verify it's a blog page
-    if (page.page_type !== "Blog") {
+    // Verify it's a blog or newsletter page
+    if (page.page_type !== "Blog" && page.page_type !== "Newsletter") {
       return res.status(400).json({
         message: "Invalid page type",
-        error: "Only blog pages can be sent as test emails"
+        error: "Only blog or newsletter pages can be sent as test emails"
       });
     }
     

--- a/apps/backend/src/api/admin/websites/[id]/pages/__tests__/validators.unit.spec.ts
+++ b/apps/backend/src/api/admin/websites/[id]/pages/__tests__/validators.unit.spec.ts
@@ -1,0 +1,52 @@
+import { pageSchema, createPagesSchema, updatePageSchema } from "../validators"
+
+const validBase = {
+  title: "Spring Newsletter",
+  slug: "spring-newsletter",
+  content: "<p>Hello subscribers</p>",
+}
+
+describe("page validators — Newsletter page_type", () => {
+  describe("pageSchema", () => {
+    it("accepts page_type = 'Newsletter'", () => {
+      const parsed = pageSchema.parse({ ...validBase, page_type: "Newsletter" })
+      expect(parsed.page_type).toBe("Newsletter")
+    })
+
+    it("still accepts the existing 'Blog' page_type", () => {
+      const parsed = pageSchema.parse({ ...validBase, page_type: "Blog" })
+      expect(parsed.page_type).toBe("Blog")
+    })
+
+    it("rejects a garbage page_type", () => {
+      expect(() =>
+        pageSchema.parse({ ...validBase, page_type: "NotARealType" })
+      ).toThrow()
+    })
+
+    it("treats page_type as optional (don't-touch on partial intents)", () => {
+      const parsed = pageSchema.parse({ ...validBase })
+      expect(parsed.page_type).toBeUndefined()
+    })
+  })
+
+  describe("createPagesSchema", () => {
+    it("accepts a Newsletter page in the pages array", () => {
+      const parsed = createPagesSchema.parse({
+        pages: [{ ...validBase, page_type: "Newsletter" }],
+      })
+      expect(parsed.pages[0].page_type).toBe("Newsletter")
+    })
+  })
+
+  describe("updatePageSchema", () => {
+    it("accepts switching a page to Newsletter", () => {
+      const parsed = updatePageSchema.parse({ page_type: "Newsletter" })
+      expect(parsed.page_type).toBe("Newsletter")
+    })
+
+    it("rejects an invalid page_type on update", () => {
+      expect(() => updatePageSchema.parse({ page_type: "Bogus" })).toThrow()
+    })
+  })
+})

--- a/apps/backend/src/api/admin/websites/[id]/pages/validators.ts
+++ b/apps/backend/src/api/admin/websites/[id]/pages/validators.ts
@@ -13,7 +13,8 @@ const pageBaseSchema = z.object({
     "Service",
     "Portfolio",
     "Landing",
-    "Custom"
+    "Custom",
+    "Newsletter"
   ]).optional(),
   status: z.enum([
     "Draft",

--- a/apps/backend/src/api/web/website/[domain]/route.ts
+++ b/apps/backend/src/api/web/website/[domain]/route.ts
@@ -40,7 +40,8 @@ export const GET = async (
         published_at: page.published_at,
         // Only include published pages
       })).filter(page => page.status === "Published" &&
-        page.page_type !== "Blog"
+        page.page_type !== "Blog" &&
+        page.page_type !== "Newsletter"
       ) || [],
     };
 

--- a/apps/backend/src/modules/website/migrations/Migration20260623130000.ts
+++ b/apps/backend/src/modules/website/migrations/Migration20260623130000.ts
@@ -1,0 +1,26 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Adds "Newsletter" to the page.page_type check constraint so operators can
+ * create/edit a Newsletter by reusing the existing blog editor and inherit the
+ * blog → subscriber send path. MikroORM names the inline column check
+ * "<table>_<column>_check" → "page_page_type_check".
+ *
+ * NOTE: must NOT edit the create-table migration (Migration20250417085315) —
+ * `create table if not exists` never re-runs on existing DBs. This is a
+ * hand-written ALTER that drops + re-adds the constraint, mirroring the
+ * precedent in payment_reports/Migration20260311034841.
+ */
+export class Migration20260623130000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "page" drop constraint if exists "page_page_type_check";`);
+    this.addSql(`alter table if exists "page" add constraint "page_page_type_check" check ("page_type" in ('Home', 'About', 'Contact', 'Blog', 'Product', 'Service', 'Portfolio', 'Landing', 'Custom', 'Newsletter'));`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "page" drop constraint if exists "page_page_type_check";`);
+    this.addSql(`alter table if exists "page" add constraint "page_page_type_check" check ("page_type" in ('Home', 'About', 'Contact', 'Blog', 'Product', 'Service', 'Portfolio', 'Landing', 'Custom'));`);
+  }
+
+}

--- a/apps/backend/src/modules/website/models/page.ts
+++ b/apps/backend/src/modules/website/models/page.ts
@@ -17,7 +17,8 @@ const Page = model.define("page", {
     "Service",
     "Portfolio",
     "Landing",
-    "Custom"
+    "Custom",
+    "Newsletter"
   ]).default("Custom"),
   status: model.enum([
     "Draft",

--- a/apps/backend/src/workflows/blogs/send-blog-subscribers/steps/fetch-blog-data.ts
+++ b/apps/backend/src/workflows/blogs/send-blog-subscribers/steps/fetch-blog-data.ts
@@ -30,10 +30,10 @@ export const fetchBlogDataStep = createStep(
         )
       }
       
-      if (page.page_type !== "Blog") {
+      if (page.page_type !== "Blog" && page.page_type !== "Newsletter") {
         throw new MedusaError(
           MedusaError.Types.INVALID_DATA,
-          "Only blog pages can be sent to subscribers"
+          "Only blog or newsletter pages can be sent to subscribers"
         )
       }
       

--- a/apps/backend/src/workflows/website/website-page/create-page.ts
+++ b/apps/backend/src/workflows/website/website-page/create-page.ts
@@ -16,7 +16,7 @@ export type CreatePageStepInput = {
   title: string;
   slug: string;
   content: string;
-  page_type?: "Home" | "About" | "Contact" | "Blog" | "Product" | "Service" | "Portfolio" | "Landing" | "Custom";
+  page_type?: "Home" | "About" | "Contact" | "Blog" | "Product" | "Service" | "Portfolio" | "Landing" | "Custom" | "Newsletter";
   status?: "Draft" | "Published" | "Archived";
   meta_title?: string;
   meta_description?: string;

--- a/apps/backend/src/workflows/website/website-page/update-page.ts
+++ b/apps/backend/src/workflows/website/website-page/update-page.ts
@@ -15,7 +15,7 @@ export type UpdatePageStepInput = {
   title?: string;
   slug?: string;
   content?: string;
-  page_type?: "Home" | "About" | "Contact" | "Blog" | "Product" | "Service" | "Portfolio" | "Landing" | "Custom";
+  page_type?: "Home" | "About" | "Contact" | "Blog" | "Product" | "Service" | "Portfolio" | "Landing" | "Custom" | "Newsletter";
   status?: "Draft" | "Published" | "Archived";
   meta_title?: string;
   meta_description?: string;


### PR DESCRIPTION
## What & why
Last #659 (AI VP of Marketing) **build** item: the **Newsletter editor option**. Instead of a new editor or send pipeline, this adds a `"Newsletter"` value to the website `page.page_type` enum. Operators create/edit a newsletter with the **existing blog editor**, and newsletters **inherit** the existing blog → subscriber send (`src/workflows/blogs/send-blog-subscribers/`) + the per-day `process-email-queue` job. **No new model, no new editor, no new send infra.**

## Changes
- **Enum source-of-truth:** `page.page_type` model enum + admin `validators.ts` z.enum + the two workflow input TS unions (`website-page/create-page.ts`, `update-page.ts`) + the two admin hook TS unions (`hooks/api/pages.ts`, `websites.ts`) all gain `"Newsletter"`.
- **Migration (hand-written, Claude-owned):** `Migration20260623130000` drops + re-adds `page_page_type_check` to include `'Newsletter'`, with a `down()` that restores the old set. Mirrors the `payment_reports` precedent. Does **not** touch the create-table migration (`create table if not exists` never re-runs on existing DBs — see repo memory).
- **Send guards widened** (Blog-only → Blog **or** Newsletter): `send-blog-subscribers/steps/fetch-blog-data.ts`, `subs/route.ts`, `subs/test/route.ts` — so newsletters can be sent and test-sent.
- **Admin UI:** Newsletter is selectable in the create-page form; the *Send to Subscribers* action and the subscription sidebar now render for Newsletter pages.
- **Storefront:** the public-pages route excludes `Newsletter` (mirrors `Blog` — it's email content, not a storefront page).

## Tests
- 7 validator unit tests (accepts `Newsletter`, still accepts `Blog`, rejects garbage, optional pass-through) — green.
- 1 integration test: a `page_type:"Newsletter"` page persists via `POST /admin/websites/:id/pages` (proves the migration/CHECK constraint accepts it) — green.
- Typecheck: zero **new** errors in changed files (pre-existing repo TS errors untouched).
- ⚠️ Two pre-existing failures in `websites-api.spec.ts` (batch duplicate-slug `207`/`400` status codes) are **unrelated** to this change.

## Out of scope / future follow-up
Wiring the merged #687 AI `marketing_draft` (kind=newsletter) generator output **into** a Newsletter page is a separate follow-up — noted, not built here.

## Verify
- `TEST_TYPE=unit npx jest --testPathPattern="websites/\[id\]/pages/__tests__/validators.unit.spec.ts"`
- `pnpm test:integration:http:shared -- integration-tests/http/websites-api.spec.ts -t "Newsletter"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)