### PR TITLE
fix(#659): show Write-with-AI toolbar button in blog/regular block editors

### DIFF
--- a/apps/backend/src/admin/components/edits/edit-blog-block.tsx
+++ b/apps/backend/src/admin/components/edits/edit-blog-block.tsx
@@ -272,10 +272,11 @@ const EditBlogBlockInner = ({ websiteId, pageId, blockId, block, onSuccess }: Ed
                 }
               }}
             /> */}
-            <SimpleEditor 
-              editorContent={editorContent} 
-              setEditorContent={handleEditorChange} 
+            <SimpleEditor
+              editorContent={editorContent}
+              setEditorContent={handleEditorChange}
               outputFormat="json"
+              showAiWrite
             />
           </div>
         </div>

--- a/apps/backend/src/admin/components/edits/edit-regular-block.tsx
+++ b/apps/backend/src/admin/components/edits/edit-regular-block.tsx
@@ -329,6 +329,7 @@ export const EditRegularBlock = ({ websiteId, pageId, blockId, block, onSuccess 
                                       setRichBodyDraft(content)
                                     }}
                                     outputFormat="json"
+                                    showAiWrite
                                   />
                                 </div>
                                 <StackedFocusModal.Footer>


### PR DESCRIPTION
The `AiWriteButton` was only enabled (`showAiWrite`) in `main-content-block-editor.tsx`, but blog/newsletter body content is edited via `edit-blog-block.tsx` / `edit-regular-block.tsx` — so the ✨ AI toolbar action never appeared there. Enabled `showAiWrite` in both. Verified visible in the editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)