### PR TITLE
feat(#659): context-aware Write-with-AI (improve/expand existing content)

### DIFF
--- a/apps/backend/src/admin/components/creates/create-blog.tsx
+++ b/apps/backend/src/admin/components/creates/create-blog.tsx
@@ -164,10 +164,14 @@ export function CreateBlogComponent({ websiteId }: CreateBlogComponentProps) {
   const { mutateAsync: writeNewsletter, isPending: isWriting } = useNewsletterAiWrite();
   const aiWriteNewsletter = async () => {
     try {
-      const res = await writeNewsletter();
+      const cur = [form.getValues("title"), form.getValues("content")]
+        .filter(Boolean)
+        .join("\n\n")
+        .trim();
+      const res = await writeNewsletter(cur ? { context: cur } : undefined);
       form.setValue("title", res.title || "");
       form.setValue("content", res.content || "");
-      toast.success("Drafted with AI — edit as needed.");
+      toast.success(cur ? "Rewrote with AI — edit as needed." : "Drafted with AI — edit as needed.");
     } catch {
       toast.error("AI draft failed — configure an AI provider (role ai_newsletter_drafter) or OPENROUTER_API_KEY.");
     }

--- a/apps/backend/src/admin/components/creates/create-page.tsx
+++ b/apps/backend/src/admin/components/creates/create-page.tsx
@@ -111,10 +111,14 @@ export function CreatePageComponent({ websiteId, website }: CreatePageComponentP
   const { mutateAsync: writeNewsletter, isPending: isWriting } = useNewsletterAiWrite();
   const aiWriteNewsletter = async (index: number) => {
     try {
-      const res = await writeNewsletter();
+      const cur = [
+        form.getValues(`pages.${index}.title`),
+        form.getValues(`pages.${index}.content`),
+      ].filter(Boolean).join("\n\n").trim();
+      const res = await writeNewsletter(cur ? { context: cur } : undefined);
       form.setValue(`pages.${index}.title`, res.title || "");
       form.setValue(`pages.${index}.content`, res.content || "");
-      toast.success("Drafted with AI — edit as needed.");
+      toast.success(cur ? "Rewrote with AI — edit as needed." : "Drafted with AI — edit as needed.");
     } catch {
       toast.error("AI draft failed — configure an AI provider (role ai_newsletter_drafter) or OPENROUTER_API_KEY.");
     }

--- a/apps/backend/src/admin/components/tiptap-ui/ai-write-button/ai-write-button.tsx
+++ b/apps/backend/src/admin/components/tiptap-ui/ai-write-button/ai-write-button.tsx
@@ -69,7 +69,15 @@ export const AiWriteButton = React.forwardRef<
         onClick?.(e)
         if (e.defaultPrevented || !editor || isPending) return
         try {
-          const res = await writeNewsletter()
+          // Context-aware: use the SELECTED text (if any), else the whole body,
+          // so the AI improves/expands what's there instead of starting fresh.
+          const sel = editor.state.selection
+          const selected = sel.empty
+            ? ""
+            : editor.state.doc.textBetween(sel.from, sel.to, "\n").trim()
+          const context = (selected || editor.getText().trim()) || undefined
+
+          const res = await writeNewsletter(context ? { context } : undefined)
           const html = newsletterPayloadToHtml(
             (res as { payload?: unknown }).payload,
             res.content || ""
@@ -78,8 +86,15 @@ export const AiWriteButton = React.forwardRef<
             toast.info("The AI returned nothing — try again.")
             return
           }
-          editor.chain().focus().insertContent(html).run()
-          toast.success("Drafted with AI — edit inline.")
+          if (selected) {
+            // replace just the selected text with the rewrite
+            editor.chain().focus().deleteSelection().insertContent(html).run()
+          } else {
+            editor.chain().focus().insertContent(html).run()
+          }
+          toast.success(
+            context ? "Rewrote with AI — edit inline." : "Drafted with AI — edit inline."
+          )
         } catch {
           toast.error(
             "AI draft failed — configure an AI provider (role ai_newsletter_drafter) or OPENROUTER_API_KEY."

--- a/apps/backend/src/admin/hooks/api/marketing.ts
+++ b/apps/backend/src/admin/hooks/api/marketing.ts
@@ -48,19 +48,27 @@ export interface NewsletterAiWriteResponse {
 /**
  * In-editor "Write with AI" for newsletters. Calls the generate endpoint and
  * returns { title, content } for the form to drop in. Exposes mutateAsync +
- * isPending for the button's loading state. Optional `{ topic }` angle.
+ * isPending for the button's loading state. Optional `{ topic }` angle and
+ * `{ context }` (existing draft/notes to IMPROVE + EXPAND instead of starting fresh).
  */
 export const useNewsletterAiWrite = () => {
-  return useMutation<NewsletterAiWriteResponse, Error, { topic?: string } | void>({
-    mutationFn: async (vars) =>
-      sdk.client.fetch<NewsletterAiWriteResponse>(
+  return useMutation<
+    NewsletterAiWriteResponse,
+    Error,
+    { topic?: string; context?: string } | void
+  >({
+    mutationFn: async (vars) => {
+      const v = (vars || {}) as { topic?: string; context?: string }
+      const body: Record<string, string> = {}
+      if (v.topic) body.topic = v.topic
+      if (v.context) body.context = v.context
+      return sdk.client.fetch<NewsletterAiWriteResponse>(
         "/admin/marketing/newsletter/generate",
         {
           method: "POST",
-          body: vars && (vars as { topic?: string }).topic
-            ? { topic: (vars as { topic?: string }).topic }
-            : {},
+          body,
         }
-      ),
+      )
+    },
   })
 }

--- a/apps/backend/src/api/admin/marketing/newsletter/generate/route.ts
+++ b/apps/backend/src/api/admin/marketing/newsletter/generate/route.ts
@@ -36,11 +36,14 @@ function istDateString(d: Date): string {
 }
 
 export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
-  const body = (req.body ?? {}) as { topic?: string }
+  const body = (req.body ?? {}) as { topic?: string; context?: string }
   const topic = typeof body.topic === "string" ? body.topic.trim() : undefined
+  const context =
+    typeof body.context === "string" ? body.context.trim() : undefined
 
   const prompt = buildNewsletterPrompt({
     topic,
+    context,
     businessDescription: process.env.MARKETING_BUSINESS_DESCRIPTION,
     dateIst: istDateString(new Date()),
   })

--- a/apps/backend/src/workflows/marketing/generate-newsletter-draft.ts
+++ b/apps/backend/src/workflows/marketing/generate-newsletter-draft.ts
@@ -104,12 +104,26 @@ export function buildNewsletterPrompt(opts: {
   businessDescription?: string
   voiceRules?: string
   dateIst: string
+  /** Existing operator draft/notes to IMPROVE + EXPAND (context-aware mode). */
+  context?: string
 }): string {
   const business = opts.businessDescription || DEFAULT_BUSINESS_DESCRIPTION
   const voice = opts.voiceRules || NEWSLETTER_VOICE_RULES
   const topicLine = opts.topic?.trim()
     ? `TOPIC / ANGLE for this edition: ${opts.topic.trim()}`
     : `TOPIC / ANGLE: pick a useful, evergreen angle relevant to the business.`
+  const context = opts.context?.trim()
+  const contextLines = context
+    ? [
+        ``,
+        `The operator already has this DRAFT / NOTES — IMPROVE and EXPAND it into a`,
+        `polished edition, keeping their intent, facts and any specifics. Do NOT`,
+        `start over or contradict it:`,
+        `"""`,
+        context.slice(0, 4000),
+        `"""`,
+      ]
+    : []
 
   return [
     `You are the marketing editor writing a customer newsletter for this business.`,
@@ -119,6 +133,7 @@ export function buildNewsletterPrompt(opts: {
     business,
     ``,
     topicLine,
+    ...contextLines,
     ``,
     `Write ONE newsletter edition. Respond with ONLY a single JSON object — no`,
     `prose, no markdown fences — with EXACTLY this shape:`,


### PR DESCRIPTION
Follow-up: the AI-write now takes your **existing content** as context instead of always generating fresh.

- `buildNewsletterPrompt` gains an optional `context` → IMPROVE+EXPAND the operator's draft/notes (keeps intent/facts), not start over.
- `POST /admin/marketing/newsletter/generate` accepts `{ context }` (capped 4k chars).
- **TipTap ✨ AI button:** uses the **selected text** (replaces it) or the **whole body** as context; fresh-generate when empty.
- **Create-blog/create-page** button passes the current title+summary as context.

Typecheck clean. Needs a configured `ai_newsletter_drafter` provider / `OPENROUTER_API_KEY` to see live output (same as the base feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)