### PR TITLE
#697 Backfill finished-run energy & labor consumption logs (cost-summary energy=0 fix)

### DIFF
--- a/apps/backend/integration-tests/http/ops-maintenance-jobs.spec.ts
+++ b/apps/backend/integration-tests/http/ops-maintenance-jobs.spec.ts
@@ -119,6 +119,45 @@ setupSharedTestSuite(() => {
       )
     })
 
+    it("GET lists the backfill-finished-run-consumption job (#697)", async () => {
+      const res = await api.get("/admin/ops/maintenance-jobs", adminHeaders)
+      expect(res.status).toBe(200)
+      const job = res.data.jobs.find(
+        (j: any) => j.id === "backfill-finished-run-consumption"
+      )
+      expect(job).toBeDefined()
+      expect(job.params.map((p: any) => p.name)).toEqual([
+        "production_run_id",
+        "work_days",
+        "hours_per_day",
+        "kwh_per_day",
+        "limit",
+      ])
+    })
+
+    it("POST backfill-finished-run-consumption for a missing run → 404", async () => {
+      await expect(
+        api.post(
+          "/admin/ops/maintenance-jobs/backfill-finished-run-consumption/run",
+          { dry_run: true, params: { production_run_id: "prod_run_does_not_exist" } },
+          adminHeaders
+        )
+      ).rejects.toMatchObject({ response: { status: 404 } })
+    })
+
+    it("POST backfill-finished-run-consumption dry-run sweep → 200, no changes on an empty DB", async () => {
+      const res = await api.post(
+        "/admin/ops/maintenance-jobs/backfill-finished-run-consumption/run",
+        { dry_run: true, params: {} },
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.result.dry_run).toBe(true)
+      expect(res.data.result.applied).toBe(false)
+      expect(res.data.result.changes).toEqual([])
+      expect(res.data.result.summary).toContain("No changes")
+    })
+
     it("GET lists the correct-production-run-cost job", async () => {
       const res = await api.get("/admin/ops/maintenance-jobs", adminHeaders)
       expect(res.status).toBe(200)

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-finished-run-consumption.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-finished-run-consumption.unit.spec.ts
@@ -1,0 +1,168 @@
+import {
+  backfillFinishedRunConsumptionJob,
+  buildEnergyRateMap,
+  buildRunConsumptionLogs,
+  computeRunConsumptionQuantities,
+  getMaintenanceJob,
+  MAINTENANCE_JOBS,
+  MAX_RUN_CONSUMPTION_SCAN,
+  summarizeRunConsumptionBackfill,
+} from "../registry"
+
+/**
+ * #697 — pure logic for the `backfill-finished-run-consumption` maintenance job.
+ * The container-bound run() (consumption-log lookups + createConsumptionLogs)
+ * is exercised against the live DB by the API contract integration test; here we
+ * lock down the quantity math, the per-run log drafts (incl. pricing + skip),
+ * and the summary string without booting anything.
+ */
+describe("backfill-finished-run-consumption — computeRunConsumptionQuantities", () => {
+  it("multiplies the day assumption into labor hours and electricity kWh", () => {
+    expect(computeRunConsumptionQuantities(2.5, 8, 12)).toEqual({
+      laborHours: 20,
+      energyKwh: 30,
+    })
+  })
+
+  it("rounds to 2 decimals", () => {
+    expect(computeRunConsumptionQuantities(1.333, 8, 12)).toEqual({
+      laborHours: 10.66,
+      energyKwh: 16,
+    })
+  })
+
+  it("collapses non-positive inputs to 0 (bucket later skipped)", () => {
+    expect(computeRunConsumptionQuantities(0, 8, 12)).toEqual({
+      laborHours: 0,
+      energyKwh: 0,
+    })
+    expect(computeRunConsumptionQuantities(2.5, -1, 0)).toEqual({
+      laborHours: 0,
+      energyKwh: 0,
+    })
+  })
+})
+
+describe("backfill-finished-run-consumption — buildRunConsumptionLogs", () => {
+  const rateMap = buildEnergyRateMap([
+    {
+      energy_type: "labor",
+      rate_per_unit: 250,
+      name: "Labor",
+      effective_from: "2026-01-01",
+    },
+    {
+      energy_type: "energy_electricity",
+      rate_per_unit: 9.5,
+      name: "Electricity",
+      effective_from: "2026-01-01",
+    },
+  ])
+
+  it("builds one labor + one electricity log priced from the active rates", () => {
+    const drafts = buildRunConsumptionLogs(
+      { id: "prod_run_1", design_id: "design_1" },
+      { laborHours: 20, energyKwh: 30 },
+      rateMap
+    )
+    expect(drafts).toEqual([
+      {
+        design_id: "design_1",
+        production_run_id: "prod_run_1",
+        consumption_type: "labor",
+        unit_of_measure: "Hour",
+        quantity: 20,
+        unit_cost: 250,
+      },
+      {
+        design_id: "design_1",
+        production_run_id: "prod_run_1",
+        consumption_type: "energy_electricity",
+        unit_of_measure: "kWh",
+        quantity: 30,
+        unit_cost: 9.5,
+      },
+    ])
+  })
+
+  it("leaves unit_cost null when no rate exists (cost-summary falls back at read)", () => {
+    const drafts = buildRunConsumptionLogs(
+      { id: "prod_run_1", design_id: "design_1" },
+      { laborHours: 20, energyKwh: 30 },
+      new Map()
+    )
+    expect(drafts.map((d) => d.unit_cost)).toEqual([null, null])
+  })
+
+  it("omits a zero-quantity bucket", () => {
+    const labourOnly = buildRunConsumptionLogs(
+      { id: "prod_run_1", design_id: "design_1" },
+      { laborHours: 20, energyKwh: 0 },
+      rateMap
+    )
+    expect(labourOnly).toHaveLength(1)
+    expect(labourOnly[0].consumption_type).toBe("labor")
+
+    const none = buildRunConsumptionLogs(
+      { id: "prod_run_1", design_id: "design_1" },
+      { laborHours: 0, energyKwh: 0 },
+      rateMap
+    )
+    expect(none).toHaveLength(0)
+  })
+
+  it("tolerates a missing design_id (empty string)", () => {
+    const drafts = buildRunConsumptionLogs(
+      { id: "prod_run_1", design_id: null },
+      { laborHours: 20, energyKwh: 30 },
+      rateMap
+    )
+    expect(drafts.every((d) => d.design_id === "")).toBe(true)
+  })
+})
+
+describe("backfill-finished-run-consumption — summarizeRunConsumptionBackfill", () => {
+  it("reports no-change when nothing needed a backfill", () => {
+    expect(summarizeRunConsumptionBackfill(true, 5, 0, 0, 5, 0)).toBe(
+      "No changes — scanned 5 finished run(s), none needed energy/labor consumption logs; 5 already had energy/labor logs"
+    )
+  })
+
+  it("distinguishes dry-run (would) from apply (created)", () => {
+    expect(summarizeRunConsumptionBackfill(true, 3, 2, 4, 1, 0)).toBe(
+      "Would create 4 consumption log(s) across 2 finished run(s) (scanned 3); 1 already had energy/labor logs"
+    )
+    expect(summarizeRunConsumptionBackfill(false, 3, 2, 4, 0, 0)).toBe(
+      "Created 4 consumption log(s) across 2 finished run(s) (scanned 3)"
+    )
+  })
+
+  it("appends an error count when present", () => {
+    expect(summarizeRunConsumptionBackfill(false, 3, 1, 2, 0, 1)).toBe(
+      "Created 2 consumption log(s) across 1 finished run(s) (scanned 3); 1 error(s)"
+    )
+  })
+})
+
+describe("backfill-finished-run-consumption — registration", () => {
+  it("is registered and resolvable by id", () => {
+    expect(getMaintenanceJob("backfill-finished-run-consumption")).toBe(
+      backfillFinishedRunConsumptionJob
+    )
+    expect(MAINTENANCE_JOBS).toContain(backfillFinishedRunConsumptionJob)
+  })
+
+  it("exposes the documented params", () => {
+    expect(backfillFinishedRunConsumptionJob.params.map((p) => p.name)).toEqual([
+      "production_run_id",
+      "work_days",
+      "hours_per_day",
+      "kwh_per_day",
+      "limit",
+    ])
+  })
+
+  it("caps the sweep scan", () => {
+    expect(MAX_RUN_CONSUMPTION_SCAN).toBe(2000)
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -1280,6 +1280,318 @@ export const backfillDesignEnergyCostJob: MaintenanceJob = {
 }
 
 /**
+ * Hard cap on how many finished production runs a single consumption-backfill
+ * sweep may scan. Each run runs a consumption-log lookup (and, on apply, creates
+ * a couple of rows), so we bound the per-request blast radius; bigger backfills
+ * raise the `limit` across chunked calls.
+ */
+export const MAX_RUN_CONSUMPTION_SCAN = 2000
+
+const backfillRunConsumptionParamsSchema = z.object({
+  /** Target a single completed production run instead of sweeping all of them. */
+  production_run_id: z.string().min(1).optional(),
+  /** Assumed working days per finished run (the #697 "most took 2-3 days" assumption). */
+  work_days: z.number().positive().max(60).optional().default(2.5),
+  /** Labor hours per working day → labor log quantity = work_days × hours_per_day. */
+  hours_per_day: z.number().positive().max(24).optional().default(8),
+  /** Electricity kWh per working day → energy log quantity = work_days × kwh_per_day. */
+  kwh_per_day: z.number().positive().max(1000).optional().default(12),
+  /** Max finished runs to scan in one sweep when no production_run_id is given. */
+  limit: z.number().int().positive().max(MAX_RUN_CONSUMPTION_SCAN).optional().default(1000),
+})
+
+/**
+ * Pure: turn the "days of work" assumption into the labor-hours and electricity
+ * kWh quantities a finished run should carry. Non-positive inputs collapse to 0
+ * (that bucket is then skipped by `buildRunConsumptionLogs`). Exported for unit
+ * testing the cost-quantity math without a DB.
+ */
+export function computeRunConsumptionQuantities(
+  workDays: number,
+  hoursPerDay: number,
+  kwhPerDay: number
+): { laborHours: number; energyKwh: number } {
+  const safeDays = workDays > 0 ? workDays : 0
+  return {
+    laborHours: round2(safeDays * (hoursPerDay > 0 ? hoursPerDay : 0)),
+    energyKwh: round2(safeDays * (kwhPerDay > 0 ? kwhPerDay : 0)),
+  }
+}
+
+export type RunConsumptionLogDraft = {
+  design_id: string
+  production_run_id: string
+  consumption_type: "labor" | "energy_electricity"
+  unit_of_measure: "Hour" | "kWh"
+  quantity: number
+  /** Priced from the latest active energy_rate; null when no rate exists (the
+   * cost-summary endpoint then falls back to the live rate at read time). */
+  unit_cost: number | null
+}
+
+/**
+ * Pure: build the labor + electricity consumption-log drafts for one finished
+ * run from the assumed quantities, priced from the active energy rate map. A
+ * zero-quantity bucket is omitted. Exported so the create payload is verifiable
+ * without booting the consumption-log service.
+ */
+export function buildRunConsumptionLogs(
+  run: { id: string; design_id?: string | null },
+  quantities: { laborHours: number; energyKwh: number },
+  rateMap: Map<string, { rate_per_unit: number; name: string }>
+): RunConsumptionLogDraft[] {
+  const designId = run.design_id || ""
+  const drafts: RunConsumptionLogDraft[] = []
+  if (quantities.laborHours > 0) {
+    const rate = rateMap.get("labor")?.rate_per_unit
+    drafts.push({
+      design_id: designId,
+      production_run_id: run.id,
+      consumption_type: "labor",
+      unit_of_measure: "Hour",
+      quantity: quantities.laborHours,
+      unit_cost: rate && rate > 0 ? rate : null,
+    })
+  }
+  if (quantities.energyKwh > 0) {
+    const rate = rateMap.get("energy_electricity")?.rate_per_unit
+    drafts.push({
+      design_id: designId,
+      production_run_id: run.id,
+      consumption_type: "energy_electricity",
+      unit_of_measure: "kWh",
+      quantity: quantities.energyKwh,
+      unit_cost: rate && rate > 0 ? rate : null,
+    })
+  }
+  return drafts
+}
+
+/**
+ * Pure summary builder for the finished-run consumption backfill — keeps the
+ * human-facing string verifiable without booting the DB.
+ */
+export function summarizeRunConsumptionBackfill(
+  dryRun: boolean,
+  scanned: number,
+  backfilledRuns: number,
+  logsCreated: number,
+  alreadyHad: number,
+  errorCount: number
+): string {
+  const verb = dryRun ? "Would create" : "Created"
+  const head =
+    backfilledRuns === 0
+      ? `No changes — scanned ${scanned} finished run(s), none needed energy/labor consumption logs`
+      : `${verb} ${logsCreated} consumption log(s) across ${backfilledRuns} finished run(s) (scanned ${scanned})`
+  const tail = alreadyHad > 0 ? `; ${alreadyHad} already had energy/labor logs` : ""
+  return errorCount > 0 ? `${head}${tail}; ${errorCount} error(s)` : `${head}${tail}`
+}
+
+/**
+ * Backfill energy & labor CONSUMPTION LOGS onto finished production runs (#697).
+ *
+ * Root cause: finished/completed runs that were never logged carry NO
+ * energy/labor consumption logs, so `GET /admin/production-runs/:id/cost-summary`
+ * reports `energy.total = 0` and `labor.total = 0` (only the partner estimate
+ * survives). This job synthesises the missing logs from the issue's stated
+ * assumption — "most took 2-3 days of work" — creating one `labor` log
+ * (work_days × hours_per_day, priced from the active labor rate) and one
+ * `energy_electricity` log (work_days × kwh_per_day, priced from the active
+ * electricity rate) per completed run that has none yet.
+ *
+ * It is the consumption-log INPUT side of the cost pipeline; the existing
+ * `backfill-design-energy-costs` job is the design cost_breakdown OUTPUT side —
+ * run this first, then that, to fully repair a finished design's costs.
+ *
+ * Safe-by-default: dry-run (default) previews the logs it WOULD create without
+ * writing; apply persists committed logs. Idempotent — a run that already has
+ * ANY energy/labor log is skipped (so re-running never duplicates). NOTE: this
+ * does NOT touch material consumption (`consumed_quantity` on the
+ * design↔inventory link) — that needs real bill-of-materials data and can't be
+ * honestly synthesised; it's a separate follow-up.
+ */
+export const backfillFinishedRunConsumptionJob: MaintenanceJob = {
+  id: "backfill-finished-run-consumption",
+  label: "Backfill finished-run energy & labor consumption logs",
+  description:
+    `Create the missing energy (electricity) + labor consumption logs on COMPLETED production runs so the cost-summary endpoint stops reporting energy/labor as 0 (#697). Quantities are derived from the "most took 2-3 days of work" assumption (work_days × hours_per_day labor hours, work_days × kwh_per_day electricity kWh), priced from the latest active energy_rate. Dry-run previews the logs it would create; apply persists committed logs. Idempotent — runs that already have an energy/labor log are skipped. Pass production_run_id to target one completed run, or sweep up to 'limit' completed runs (default 1000, max ${MAX_RUN_CONSUMPTION_SCAN}). Does NOT backfill material consumption.`,
+  params: [
+    {
+      name: "production_run_id",
+      type: "string",
+      required: false,
+      description: "Target a single completed run instead of sweeping all completed runs",
+    },
+    {
+      name: "work_days",
+      type: "number",
+      required: false,
+      description: "Assumed working days per finished run (default 2.5)",
+    },
+    {
+      name: "hours_per_day",
+      type: "number",
+      required: false,
+      description: "Labor hours per working day → labor log quantity = work_days × hours_per_day (default 8)",
+    },
+    {
+      name: "kwh_per_day",
+      type: "number",
+      required: false,
+      description: "Electricity kWh per working day → energy log quantity = work_days × kwh_per_day (default 12)",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max completed runs to scan in one sweep when no production_run_id is given (default 1000, max ${MAX_RUN_CONSUMPTION_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }) => {
+    const parsed = backfillRunConsumptionParamsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { production_run_id, work_days, hours_per_day, kwh_per_day, limit } = parsed.data
+
+    const productionRunService: any = container.resolve("production_runs")
+    const consumptionLogService: any = container.resolve("consumption_log")
+    const energyRateService: any = container.resolve("energy_rates")
+
+    // Latest active rate per energy_type (pure) — labor + electricity priced from it.
+    const [activeRates] = await energyRateService.listAndCountEnergyRates(
+      { is_active: true },
+      { take: null }
+    )
+    const rateMap = buildEnergyRateMap(activeRates || [])
+
+    const quantities = computeRunConsumptionQuantities(work_days, hours_per_day, kwh_per_day)
+
+    // Resolve the target run set: one explicit run, or all completed runs.
+    let runs: any[]
+    if (production_run_id) {
+      const run = await productionRunService
+        .retrieveProductionRun(production_run_id)
+        .catch(() => null)
+      if (!run) {
+        throw new MedusaError(
+          MedusaError.Types.NOT_FOUND,
+          `Production run not found: ${production_run_id}`
+        )
+      }
+      runs = [run]
+    } else {
+      const [completedRuns] = await productionRunService.listAndCountProductionRuns(
+        { status: "completed" },
+        { take: null }
+      )
+      runs = (completedRuns || []).slice(0, limit)
+    }
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    const backfilledRuns = new Set<string>()
+    let logsCreated = 0
+    let alreadyHad = 0
+
+    for (const run of runs) {
+      try {
+        // Only finished work gets synthetic costs. A single-run target that
+        // isn't completed is surfaced as a per-row error (never an abort).
+        if (run.status !== "completed") {
+          errors.push({ id: run.id, message: `Run status is ${run.status}, not completed` })
+          continue
+        }
+
+        // Idempotency: skip if the run already has ANY energy or labor log.
+        const [runLogs] = await consumptionLogService.listAndCountConsumptionLogs(
+          { production_run_id: run.id },
+          { take: null }
+        )
+        const hasEnergyOrLabor = (runLogs || []).some(
+          (l: any) =>
+            l.consumption_type === "labor" ||
+            ENERGY_CONSUMPTION_TYPES.includes(l.consumption_type)
+        )
+        if (hasEnergyOrLabor) {
+          alreadyHad++
+          continue
+        }
+
+        const drafts = buildRunConsumptionLogs(run, quantities, rateMap)
+        if (!drafts.length) continue
+
+        for (const d of drafts) {
+          changes.push({
+            entity: "production_run",
+            id: run.id,
+            field: d.consumption_type,
+            before: null,
+            after: {
+              quantity: d.quantity,
+              unit_cost: d.unit_cost,
+              unit_of_measure: d.unit_of_measure,
+            },
+          })
+        }
+        backfilledRuns.add(run.id)
+        logsCreated += drafts.length
+
+        if (!dry_run) {
+          const consumedAt =
+            run.completed_at || run.finished_at || run.started_at || new Date()
+          for (const d of drafts) {
+            await consumptionLogService.createConsumptionLogs({
+              design_id: d.design_id,
+              production_run_id: d.production_run_id,
+              inventory_item_id: null,
+              raw_material_id: null,
+              quantity: d.quantity,
+              unit_cost: d.unit_cost,
+              unit_of_measure: d.unit_of_measure,
+              consumption_type: d.consumption_type,
+              is_committed: true,
+              consumed_by: "admin",
+              consumed_at: consumedAt,
+              notes: `Backfilled (≈${work_days} day(s) of work) by ops_maintenance_backfill_finished_run_consumption`,
+              location_id: null,
+              metadata: {
+                source: "ops_maintenance_backfill_finished_run_consumption",
+                work_days,
+                hours_per_day,
+                kwh_per_day,
+              },
+            })
+          }
+        }
+      } catch (e: any) {
+        errors.push({ id: run.id, message: e?.message ?? String(e) })
+      }
+    }
+
+    return {
+      job_id: backfillFinishedRunConsumptionJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary: summarizeRunConsumptionBackfill(
+        dry_run,
+        runs.length,
+        backfilledRuns.size,
+        logsCreated,
+        alreadyHad,
+        errors.length
+      ),
+      changes,
+      errors,
+    }
+  },
+}
+
+/**
  * Hard cap on how many audit rows a single prune call may delete. Each pruned
  * row is enumerated in `changes` (and therefore stored in THIS prune run's own
  * audit row), so we bound the per-call blast radius and avoid bloating the very
@@ -3947,6 +4259,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   correctProductionRunCostJob,
   backfillInventoryUnitCostJob,
   backfillDesignEnergyCostJob,
+  backfillFinishedRunConsumptionJob,
   pruneOpsAuditRunsJob,
   backfillPartnerOrderCurrencyJob,
   repairPartnerRegionLinksJob,


### PR DESCRIPTION
## Why
`GET /admin/production-runs/:id/cost-summary` returns `energy.total = 0` and `labor.total = 0` for finished/completed runs (e.g. `prod_run_01KMQ7SFAFV4AV7EJZADNG7D5W`) because those runs were never logged — they carry **no energy/labor consumption logs**, so only the partner estimate survives. Closes part of #697.

## What
New #457-style **data-plumbing maintenance job** `backfill-finished-run-consumption` (registry-driven, guarded dry-run→apply, audit-logged, runnable from Settings → Data Plumbing). For each `completed` production run with no energy/labor logs it synthesises the missing logs from the issue's stated assumption — *"most took 2-3 days of work"*:

- one `labor` log = `work_days × hours_per_day` hours (default 2.5 × 8 = **20h**), priced from the active **labor** energy_rate;
- one `energy_electricity` log = `work_days × kwh_per_day` kWh (default 2.5 × 12 = **30 kWh**), priced from the active **electricity** energy_rate.

All assumptions are params (`work_days`, `hours_per_day`, `kwh_per_day`, `limit`, plus `production_run_id` to target one run).

### Safety / contract
- **Dry-run by default** — previews the logs it would create, no writes; `apply` persists committed logs.
- **Idempotent** — a run already carrying ANY energy/labor log is skipped (re-running never duplicates).
- Per-run errors collected in `errors[]`; a single bad run never aborts the sweep. Sweep capped at `MAX_RUN_CONSUMPTION_SCAN=2000`.
- Reuses the existing energy-rate map + cost conventions; complements `backfill-design-energy-costs` (this is the consumption-log INPUT side; that is the design `cost_breakdown` OUTPUT side — run this first, then that).

### Out of scope
Material consumption (`consumed_quantity` on the design↔inventory link) is **not** backfilled — it needs real bill-of-materials data and can't be honestly synthesised. Noted as a follow-up.

## Tests
- 13 unit (`backfill-finished-run-consumption.unit.spec.ts`) — quantity math, log drafts + pricing/skip, summary, registration.
- 3 integration added to `ops-maintenance-jobs.spec.ts` (job listed; missing run → 404; dry-run sweep → 200 no-change). **42/42 green.**
- 0 new tsc errors (69 baseline).

## Verify after deploy
`POST /admin/ops/maintenance-jobs/backfill-finished-run-consumption/run {"dry_run":true,"params":{"production_run_id":"prod_run_01KMQ7SFAFV4AV7EJZADNG7D5W"}}` on v3.jaalyantra.com → preview labor+electricity logs; then `dry_run:false` to apply, and re-fetch `/cost-summary` to confirm energy/labor are non-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)