### PR TITLE
[#699] AI provider creator: surface all resolver roles + custom free-form roles

### DIFF
--- a/apps/backend/src/admin/components/social-platforms/__tests__/ai-roles.unit.spec.ts
+++ b/apps/backend/src/admin/components/social-platforms/__tests__/ai-roles.unit.spec.ts
@@ -1,0 +1,101 @@
+import {
+  KNOWN_AI_ROLES,
+  KNOWN_ROLE_VALUES,
+  CUSTOM_ROLE_SENTINEL,
+  ROLE_SLUG_REGEX,
+  isKnownAiRole,
+  isValidRoleSlug,
+  roleToFormState,
+  resolveRoleValue,
+} from "../ai-roles"
+
+describe("ai-roles shared module", () => {
+  it("includes the 4 original roles plus the 2 resolver roles that previously drifted", () => {
+    expect(KNOWN_ROLE_VALUES).toEqual(
+      expect.arrayContaining([
+        "ai_search_chat",
+        "ai_search_embed",
+        "ai_product_description",
+        "ai_image_gen",
+        "ai_digest_summary",
+        "ai_newsletter_drafter",
+      ])
+    )
+    // every entry carries a non-empty human label
+    for (const r of KNOWN_AI_ROLES) {
+      expect(r.label.length).toBeGreaterThan(0)
+    }
+  })
+
+  describe("slug validation", () => {
+    it("accepts sane custom role slugs", () => {
+      expect(isValidRoleSlug("ai_marketing_vp")).toBe(true)
+      expect(isValidRoleSlug("ai_blog_drafter")).toBe(true)
+      expect(ROLE_SLUG_REGEX.test("x9_y")).toBe(true)
+    })
+
+    it("rejects empty, uppercase, leading-digit, and punctuation slugs", () => {
+      expect(isValidRoleSlug("")).toBe(false)
+      expect(isValidRoleSlug(null)).toBe(false)
+      expect(isValidRoleSlug("AiMarketing")).toBe(false)
+      expect(isValidRoleSlug("1role")).toBe(false)
+      expect(isValidRoleSlug("ai marketing")).toBe(false)
+      expect(isValidRoleSlug("ai-marketing")).toBe(false)
+      // single char fails (needs 2+ to match `[a-z][a-z0-9_]+`)
+      expect(isValidRoleSlug("a")).toBe(false)
+    })
+  })
+
+  describe("resolveRoleValue", () => {
+    it("passes the 4 existing known roles through verbatim (no regression)", () => {
+      for (const value of [
+        "ai_search_chat",
+        "ai_search_embed",
+        "ai_product_description",
+        "ai_image_gen",
+      ]) {
+        expect(resolveRoleValue({ role: value, custom_role: "" })).toBe(value)
+      }
+    })
+
+    it("maps the sentinel + custom slug into the final role string (trimmed)", () => {
+      expect(
+        resolveRoleValue({
+          role: CUSTOM_ROLE_SENTINEL,
+          custom_role: "  ai_marketing_vp  ",
+        })
+      ).toBe("ai_marketing_vp")
+    })
+  })
+
+  describe("roleToFormState (edit-path round-trip)", () => {
+    it("round-trips a known role into its own dropdown value with empty custom", () => {
+      expect(roleToFormState("ai_newsletter_drafter")).toEqual({
+        role: "ai_newsletter_drafter",
+        custom_role: "",
+      })
+    })
+
+    it("round-trips a custom stored metadata.role back as sentinel + custom value (not blank)", () => {
+      expect(roleToFormState("ai_marketing_vp")).toEqual({
+        role: CUSTOM_ROLE_SENTINEL,
+        custom_role: "ai_marketing_vp",
+      })
+    })
+
+    it("falls back to the first known role when nothing is stored", () => {
+      expect(roleToFormState(null)).toEqual({
+        role: KNOWN_ROLE_VALUES[0],
+        custom_role: "",
+      })
+    })
+  })
+
+  describe("isKnownAiRole", () => {
+    it("distinguishes known from custom roles", () => {
+      expect(isKnownAiRole("ai_digest_summary")).toBe(true)
+      expect(isKnownAiRole("ai_marketing_vp")).toBe(false)
+      expect(isKnownAiRole(undefined)).toBe(false)
+    })
+  })
+})

--- a/apps/backend/src/admin/components/social-platforms/ai-roles.ts
+++ b/apps/backend/src/admin/components/social-platforms/ai-roles.ts
@@ -1,0 +1,94 @@
+/**
+ * Single source of truth for the *suggested* AI-provider roles surfaced in the
+ * admin "Create AI provider" form.
+ *
+ * Why this exists: the canonical role set used to live in two places that
+ * silently drifted — the `AiRole` union in
+ * `src/mastra/services/ai-platforms.ts` (resolver side) and a hardcoded
+ * `RoleEnum` / `ROLE_LABELS` pair inside `create-ai-platform-component.tsx`
+ * (UI side). When #589 added `ai_digest_summary` and #659 added
+ * `ai_newsletter_drafter`, only the resolver learned about them — operators
+ * couldn't pick them in the UI and had to hand-edit `metadata.role` in the DB.
+ *
+ * The resolver stays deliberately string-tolerant (`AiRole` has a
+ * `(string & {})` escape hatch and resolution is a pure `metadata.role ===
+ * role` DB lookup). This module is just the *labelled, suggested* set plus the
+ * helpers that let the creator offer a "Custom role…" free-form entry that maps
+ * to any new role string without a code change.
+ *
+ * Keep `KNOWN_AI_ROLES` in sync with the labelled roles in the `AiRole` union;
+ * adding a future suggested role is a one-line change here.
+ */
+
+export type KnownAiRole = {
+  /** The literal stored verbatim into `metadata.role`. */
+  value: string
+  /** Friendly label shown in the dropdown. */
+  label: string
+}
+
+export const KNOWN_AI_ROLES: KnownAiRole[] = [
+  { value: "ai_search_chat", label: "Storefront search — chat / extraction" },
+  { value: "ai_search_embed", label: "Storefront search — embeddings" },
+  { value: "ai_product_description", label: "Product image → description" },
+  { value: "ai_image_gen", label: "Image generation / segmentation (FAL)" },
+  { value: "ai_digest_summary", label: "Partner digest — AI summary" },
+  {
+    value: "ai_newsletter_drafter",
+    label: "Newsletter / Marketing — Write with AI",
+  },
+]
+
+/** Sentinel form value selected when the operator wants a free-form role. */
+export const CUSTOM_ROLE_SENTINEL = "__custom__"
+
+/**
+ * Valid custom-role slug: lowercase, starts with a letter, then letters /
+ * digits / underscores. Mirrors the resolver's expectation that a role is a
+ * stable identifier (e.g. `ai_marketing_vp`, `ai_blog_drafter`).
+ */
+export const ROLE_SLUG_REGEX = /^[a-z][a-z0-9_]+$/
+
+export const KNOWN_ROLE_VALUES: string[] = KNOWN_AI_ROLES.map((r) => r.value)
+
+/** True if `role` is one of the labelled, suggested roles. */
+export const isKnownAiRole = (role: string | undefined | null): boolean =>
+  !!role && KNOWN_ROLE_VALUES.includes(role)
+
+export const isValidRoleSlug = (slug: string | undefined | null): boolean =>
+  !!slug && ROLE_SLUG_REGEX.test(slug)
+
+/**
+ * Map a stored `metadata.role` into the creator/edit form's split
+ * representation. A known role selects its dropdown option with an empty
+ * custom field; an unknown (custom) role selects the sentinel and surfaces the
+ * stored value in the custom text input — so editing round-trips instead of
+ * showing blank.
+ */
+export const roleToFormState = (
+  storedRole: string | undefined | null
+): { role: string; custom_role: string } => {
+  if (storedRole && !isKnownAiRole(storedRole)) {
+    return { role: CUSTOM_ROLE_SENTINEL, custom_role: storedRole }
+  }
+  return {
+    role: storedRole && isKnownAiRole(storedRole) ? storedRole : KNOWN_ROLE_VALUES[0],
+    custom_role: "",
+  }
+}
+
+/**
+ * Resolve the final role string to persist into `metadata.role` from the
+ * form's split `{ role, custom_role }` values. When the sentinel is selected,
+ * the trimmed custom slug wins; otherwise the chosen known role passes through
+ * verbatim.
+ */
+export const resolveRoleValue = (values: {
+  role: string
+  custom_role?: string | null
+}): string => {
+  if (values.role === CUSTOM_ROLE_SENTINEL) {
+    return (values.custom_role ?? "").trim()
+  }
+  return values.role
+}

--- a/apps/backend/src/admin/components/social-platforms/create-ai-platform-component.tsx
+++ b/apps/backend/src/admin/components/social-platforms/create-ai-platform-component.tsx
@@ -9,6 +9,13 @@ import { RouteFocusModal } from "../modal/route-focus-modal"
 import { useRouteModal } from "../modal/use-route-modal"
 import { getCloudflareModelWarning } from "./cloudflare-model-warning"
 import { buildApiConfig } from "./api-config"
+import {
+  KNOWN_AI_ROLES,
+  KNOWN_ROLE_VALUES,
+  CUSTOM_ROLE_SENTINEL,
+  ROLE_SLUG_REGEX,
+  resolveRoleValue,
+} from "./ai-roles"
 
 /**
  * Tailored "Create AI provider" form.
@@ -23,7 +30,7 @@ import { buildApiConfig } from "./api-config"
  *   - category = "ai"
  *   - auth_type = "bearer"
  *   - metadata.provider_type ∈ {openrouter, dashscope, cloudflare, vercel_ai_gateway, custom}
- *   - metadata.role ∈ {ai_search_chat, ai_search_embed, ai_product_description}
+ *   - metadata.role ∈ KNOWN_AI_ROLES (see ai-roles.ts) OR any custom slug
  *   - metadata.is_default = true/false
  *   - api_config.api_key (plaintext on the wire — the
  *     social-platform-credentials-encryption subscriber encrypts in
@@ -44,23 +51,37 @@ const ProviderTypeEnum = z.enum([
   "custom",
 ])
 
-const RoleEnum = z.enum([
-  "ai_search_chat",
-  "ai_search_embed",
-  "ai_product_description",
-  "ai_image_gen",
-])
-
 const Schema = z.object({
   name: z.string().min(1, "Name is required"),
   provider_type: ProviderTypeEnum,
-  role: RoleEnum,
+  // `role` holds either a known role value or the CUSTOM_ROLE_SENTINEL; when
+  // the sentinel is selected, `custom_role` carries the free-form slug. The
+  // resolver (mastra/services/ai-platforms.ts) is string-tolerant, so any slug
+  // works — we only enforce a sane shape here.
+  role: z.string().min(1, "Role is required"),
+  custom_role: z.string().optional().default(""),
   is_default: z.boolean().optional().default(true),
   api_key: z.string().min(1, "API key is required"),
   default_model: z.string().optional(),
   account_id: z.string().optional(),
   base_url: z.string().url("Must be a valid URL").optional().or(z.literal("")),
 }).superRefine((data, ctx) => {
+  if (data.role === CUSTOM_ROLE_SENTINEL) {
+    if (!ROLE_SLUG_REGEX.test((data.custom_role ?? "").trim())) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["custom_role"],
+        message:
+          "Use a lowercase slug like ai_marketing_vp (letters, digits, underscores)",
+      })
+    }
+  } else if (!KNOWN_ROLE_VALUES.includes(data.role)) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["role"],
+      message: "Select a role or choose Custom role…",
+    })
+  }
   if (data.provider_type === "cloudflare" && !data.account_id) {
     ctx.addIssue({
       code: "custom",
@@ -92,13 +113,6 @@ const PROVIDER_LABELS: Record<z.infer<typeof ProviderTypeEnum>, string> = {
   custom: "Custom (OpenAI-compatible)",
 }
 
-const ROLE_LABELS: Record<z.infer<typeof RoleEnum>, string> = {
-  ai_search_chat: "Storefront search — chat / extraction",
-  ai_search_embed: "Storefront search — embeddings",
-  ai_product_description: "Product image → description",
-  ai_image_gen: "Image generation / segmentation (FAL)",
-}
-
 const DEFAULT_MODEL_HINTS: Record<z.infer<typeof ProviderTypeEnum>, string> = {
   openrouter: "meta-llama/llama-3.3-70b-instruct:free",
   dashscope: "qwen-turbo  (chat) / text-embedding-v3 (embed)",
@@ -117,7 +131,8 @@ export const CreateAiPlatformComponent = () => {
     defaultValues: {
       name: "",
       provider_type: "openrouter" as const,
-      role: "ai_search_chat" as const,
+      role: "ai_search_chat",
+      custom_role: "",
       is_default: true,
       api_key: "",
       default_model: "",
@@ -127,6 +142,7 @@ export const CreateAiPlatformComponent = () => {
   })
 
   const providerType = form.watch("provider_type")
+  const roleSelection = form.watch("role")
   const defaultModel = form.watch("default_model")
   const cloudflareModelWarning = getCloudflareModelWarning(
     providerType,
@@ -151,7 +167,7 @@ export const CreateAiPlatformComponent = () => {
         api_config: apiConfig,
         metadata: {
           provider_type: values.provider_type,
-          role: values.role,
+          role: resolveRoleValue(values),
           is_default: values.is_default ?? true,
           source: "admin_ui",
         },
@@ -255,11 +271,14 @@ export const CreateAiPlatformComponent = () => {
                           <Select.Value placeholder="Select role" />
                         </Select.Trigger>
                         <Select.Content>
-                          {Object.entries(ROLE_LABELS).map(([v, label]) => (
-                            <Select.Item key={v} value={v}>
-                              {label}
+                          {KNOWN_AI_ROLES.map((r) => (
+                            <Select.Item key={r.value} value={r.value}>
+                              {r.label}
                             </Select.Item>
                           ))}
+                          <Select.Item value={CUSTOM_ROLE_SENTINEL}>
+                            Custom role…
+                          </Select.Item>
                         </Select.Content>
                       </Select>
                     </Form.Control>
@@ -268,6 +287,31 @@ export const CreateAiPlatformComponent = () => {
                 )}
               />
             </div>
+
+            {roleSelection === CUSTOM_ROLE_SENTINEL && (
+              <Form.Field
+                control={form.control}
+                name="custom_role"
+                render={({ field }) => (
+                  <Form.Item>
+                    <Form.Label>Custom role</Form.Label>
+                    <Form.Control>
+                      <Input
+                        {...field}
+                        placeholder="e.g. ai_marketing_vp"
+                        autoComplete="off"
+                      />
+                    </Form.Control>
+                    <Form.Hint>
+                      Any new role string the resolver should match on
+                      (lowercase slug). Workflows look this up verbatim via{" "}
+                      <code>getAiPlatformForRole</code>.
+                    </Form.Hint>
+                    <Form.ErrorMessage />
+                  </Form.Item>
+                )}
+              />
+            )}
 
             <Form.Field
               control={form.control}


### PR DESCRIPTION
Closes #699.

## Problem
The "Add AI Platform" creator (`create-ai-platform-component.tsx`) hardcoded its role dropdown to **only 4 roles** via `RoleEnum`, while the resolver (`mastra/services/ai-platforms.ts` `getAiPlatformForRole` / `AiRole`) already supports more roles that are live in prod — `ai_digest_summary` (#589), `ai_newsletter_drafter` (#659) — **plus any arbitrary role string** via the `(string & {})` escape hatch (resolution is a pure `metadata.role === role` DB lookup). The UI was the only blocker: operators had to hand-edit `metadata.role` in the DB to wire a newsletter/digest/marketing-VP provider.

## Changes
1. **New shared module `ai-roles.ts`** — single source of truth for the *labelled, suggested* role set (now includes the 2 missing resolver roles) + pure helpers. Kills the `RoleEnum` ⇄ `AiRole` drift; adding a future suggested role is a one-line change.
2. **Creator dropdown** lists all known roles with friendly labels:
   - `ai_digest_summary` → "Partner digest — AI summary"
   - `ai_newsletter_drafter` → "Newsletter / Marketing — Write with AI"
   …plus a **"Custom role…"** option that reveals a free-form slug input (validated `^[a-z][a-z0-9_]+$`) persisted verbatim into `metadata.role` — no code change needed for future roles like `ai_marketing_vp`.
3. **Round-trip helper** `roleToFormState` maps a stored custom `metadata.role` back to the sentinel + custom value (so an edit surface shows the custom value, not blank).

## Guardrails honored
- No change to **where** fields are stored (`metadata` vs `api_config`) or `is_default` per-role semantics.
- The 4 existing roles still build the identical config shape (unit-tested no-regression).
- Resolver env-var fallback (`null` → `OPENROUTER_API_KEY`) untouched.
- **No DB migration** (roles are JSON `metadata`, not a column).

## Tests
- 9 unit (`ai-roles.unit.spec.ts`): slug validation, known-role passthrough (no regression), custom round-trip via `roleToFormState`, first-known fallback.
- Typecheck: 0 new errors in changed files.
- **UI verified with Playwright** against live admin (`/app/settings/external-platforms/create-ai`): dropdown shows all 6 roles + "Custom role…"; selecting Custom reveals the slug input (filled `ai_marketing_vp` cleanly).

PR-only — leaving for human review (no auto-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)