### PR TITLE
chore(#701): wave 0 logger standardization — marketing + newsletter/generate 503 fix

### DIFF
--- a/apps/backend/src/api/admin/marketing/newsletter/__tests__/newsletter-generate-error-lib.unit.spec.ts
+++ b/apps/backend/src/api/admin/marketing/newsletter/__tests__/newsletter-generate-error-lib.unit.spec.ts
@@ -1,0 +1,56 @@
+import {
+  buildNoOutputError,
+  NO_PROVIDER_CONFIGURED_MESSAGE,
+} from "../newsletter-generate-error-lib"
+
+describe("buildNoOutputError", () => {
+  it("(a) no provider resolved AND no env key → keeps the configure-a-provider message", () => {
+    expect(
+      buildNoOutputError({ providerResolved: false, hasEnvKey: false })
+    ).toBe(NO_PROVIDER_CONFIGURED_MESSAGE)
+  })
+
+  it("(b) provider resolved but threw → names providerType/model + the real error", () => {
+    expect(
+      buildNoOutputError({
+        providerResolved: true,
+        providerType: "dashscope",
+        model: "qwen3.7-plus",
+        error: "rate limited",
+        hasEnvKey: false,
+      })
+    ).toBe(
+      "AI provider (dashscope/qwen3.7-plus) returned no output: rate limited"
+    )
+  })
+
+  it("(b) provider resolved, no throw, empty output → reports 'no text in response'", () => {
+    // The motivating case: a DashScope "thinking" model returns empty result.text.
+    expect(
+      buildNoOutputError({
+        providerResolved: true,
+        providerType: "dashscope",
+        model: "qwen3.7-plus",
+        hasEnvKey: false,
+      })
+    ).toBe(
+      "AI provider (dashscope/qwen3.7-plus) returned no output: no text in response"
+    )
+  })
+
+  it("(b) falls back to default/unknown labels when type/model missing", () => {
+    expect(
+      buildNoOutputError({ providerResolved: true, hasEnvKey: false })
+    ).toBe("AI provider (unknown/default) returned no output: no text in response")
+  })
+
+  it("(b) env-fallback path (no platform but env key set) reports openrouter/env", () => {
+    expect(
+      buildNoOutputError({
+        providerResolved: false,
+        hasEnvKey: true,
+        error: "401 unauthorized",
+      })
+    ).toBe("AI provider (openrouter/env) returned no output: 401 unauthorized")
+  })
+})

--- a/apps/backend/src/api/admin/marketing/newsletter/generate/route.ts
+++ b/apps/backend/src/api/admin/marketing/newsletter/generate/route.ts
@@ -13,6 +13,7 @@
  * Body (optional): { topic?: string } — an angle for this edition.
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { generateText } from "ai"
 import { createOpenRouter } from "@openrouter/ai-sdk-provider"
 import {
@@ -25,6 +26,7 @@ import {
   parseNewsletterPayload,
 } from "../../../../../workflows/marketing/generate-newsletter-draft"
 import { buildNewsletterPrefill } from "../../newsletter-prefill-lib"
+import { buildNoOutputError } from "../newsletter-generate-error-lib"
 
 const NEWSLETTER_AI_ROLE = "ai_newsletter_drafter"
 const DEFAULT_MODEL = "anthropic/claude-3.5-sonnet"
@@ -48,8 +50,16 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     dateIst: istDateString(new Date()),
   })
 
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+
   let rawOutput = ""
   let source: "platform" | "env" | "none" = "none"
+  // Track WHY no output came back, so the 503 stops conflating
+  // "no provider configured" with "the resolved provider failed" (#701).
+  let providerResolved = false
+  let providerType: string | undefined
+  let providerModel: string | undefined
+  let caughtError: string | undefined
   try {
     // 1) admin-configured provider for the role (preferred)
     const aiPlatform = await getAiPlatformForRole(
@@ -57,6 +67,9 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
       NEWSLETTER_AI_ROLE
     )
     if (aiPlatform) {
+      providerResolved = true
+      providerType = aiPlatform.providerType
+      providerModel = aiPlatform.defaultModel || undefined
       const chatModel = buildChatModel(
         aiPlatform,
         aiPlatform.defaultModel || undefined
@@ -82,15 +95,24 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
       source = "env"
     }
   } catch (error: any) {
-    // eslint-disable-next-line no-console
-    console.error("[newsletter/generate] AI error:", error?.message)
+    caughtError = error?.message || String(error)
+    logger.error(`[newsletter/generate] AI error: ${caughtError}`)
   }
 
   if (!rawOutput) {
-    res.status(503).json({
-      error:
-        "No AI provider available. Configure a social-platform AI provider with role 'ai_newsletter_drafter', or set OPENROUTER_API_KEY.",
+    const message = buildNoOutputError({
+      providerResolved,
+      providerType,
+      model: providerModel,
+      error: caughtError,
+      hasEnvKey: !!process.env.OPENROUTER_API_KEY,
     })
+    // Log at error level only when a provider actually ran but produced
+    // nothing — the pure "not configured" case is operator-expected, not an error.
+    if (providerResolved || process.env.OPENROUTER_API_KEY) {
+      logger.error(`[newsletter/generate] ${message}`)
+    }
+    res.status(503).json({ error: message })
     return
   }
 

--- a/apps/backend/src/api/admin/marketing/newsletter/newsletter-generate-error-lib.ts
+++ b/apps/backend/src/api/admin/marketing/newsletter/newsletter-generate-error-lib.ts
@@ -1,0 +1,49 @@
+/**
+ * Pure helper for POST /admin/marketing/newsletter/generate — decides WHICH
+ * 503 body to return when the AI produced no output, so the message stops
+ * conflating "no provider configured" with "the resolved provider failed".
+ *
+ * Two decision branches (see #701):
+ *  (a) no provider resolved AND no OPENROUTER_API_KEY → "configure a provider"
+ *  (b) a provider DID resolve (or the env fallback ran) but the call threw /
+ *      returned empty → name the resolved providerType + model + the real error.
+ */
+
+export const NO_PROVIDER_CONFIGURED_MESSAGE =
+  "No AI provider available. Configure a social-platform AI provider with role 'ai_newsletter_drafter', or set OPENROUTER_API_KEY."
+
+export type NoOutputErrorInput = {
+  /** true when getAiPlatformForRole returned a non-null platform */
+  providerResolved: boolean
+  /** resolved provider type (e.g. "dashscope"), when providerResolved */
+  providerType?: string | null
+  /** resolved model id, when providerResolved */
+  model?: string | null
+  /** message of any error thrown by generateText, if it threw */
+  error?: string | null
+  /** true when OPENROUTER_API_KEY is set (env fallback path) */
+  hasEnvKey: boolean
+}
+
+/**
+ * @returns the 503 `error` body string. Branch (a) keeps the legacy
+ * "configure a provider" copy; branch (b) names the provider that actually
+ * ran and the real failure, so an empty "thinking"-model response no longer
+ * masquerades as a config problem.
+ */
+export function buildNoOutputError(input: NoOutputErrorInput): string {
+  const { providerResolved, providerType, model, error, hasEnvKey } = input
+
+  // (a) nothing was even attempted — the genuine "not configured" case.
+  if (!providerResolved && !hasEnvKey) {
+    return NO_PROVIDER_CONFIGURED_MESSAGE
+  }
+
+  // (b) a real provider ran (admin platform or env fallback) but yielded
+  // nothing. Name who ran and surface the underlying error.
+  const who = providerResolved
+    ? `${providerType || "unknown"}/${model || "default"}`
+    : "openrouter/env"
+  const detail = error && error.trim() ? error.trim() : "no text in response"
+  return `AI provider (${who}) returned no output: ${detail}`
+}


### PR DESCRIPTION
## Wave 0 (seed) of #701 — logger standardization

First, smallest wave of the [#701](https://github.com/Jaal-Yantra-Textiles/v2/issues/701) rollout. Scope = the `src/api/admin/marketing/**` surface, which contains exactly **one** `console.*` (the newsletter/generate route), plus the bug fix that motivated the issue.

### What changed
**`api/admin/marketing/newsletter/generate/route.ts`**
- Resolve the Medusa logger via `req.scope.resolve(ContainerRegistrationKeys.LOGGER)` (canonical pattern, mirrors `ops/maintenance-jobs/batches/route.ts:55`).
- Replace the catch's `console.error("[newsletter/generate] AI error:", …)` with `logger.error(...)` so AI failures actually surface in CloudWatch (the issue's root motivation — `console.*` didn't).
- **Stop the misleading 503.** The route swallowed `generateText` errors and always returned "No AI provider available…", even when a provider *did* resolve and just returned empty (real-world trigger: a DashScope "thinking" model puts output in `reasoning_content`, so `result.text` is `""` with no throw). Now it tracks whether a provider resolved + captures any thrown error and picks the message accordingly.

**New pure helper `newsletter/newsletter-generate-error-lib.ts` — `buildNoOutputError()`**
- (a) no provider resolved **and** no `OPENROUTER_API_KEY` → keeps the legacy "configure a provider" copy.
- (b) a provider resolved (or the env fallback ran) but threw/returned empty → `AI provider (<providerType>/<model>) returned no output: <error>` — and `logger.error`s the same.

Success path / response shape (`{ title, content, payload, source }`) is **unchanged**; status stays 503.

### Tests
- 5 unit tests on the branch-decision helper (no-provider, provider-threw, provider-empty, missing-labels, env-fallback). `TEST_TYPE=unit` green.
- `tsc --noEmit`: zero new errors in changed files.

### Out of scope (later waves, per #701 rollout list)
`src/subscribers`+`src/jobs` → `src/api` (rest) → `src/workflows` → `src/mastra/services` → `src/modules`. No `src/scripts` / tests touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)