### PR TITLE
chore(logging): #701 wave 1 — console.* → Medusa logger in subscribers + jobs

### DIFF
--- a/apps/backend/src/jobs/ad-planning/rebuild-segments-job.ts
+++ b/apps/backend/src/jobs/ad-planning/rebuild-segments-job.ts
@@ -6,11 +6,13 @@
  */
 
 import { MedusaContainer } from "@medusajs/framework";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { AD_PLANNING_MODULE } from "../../modules/ad-planning";
 import { buildSegmentWorkflow } from "../../workflows/ad-planning/segments/build-segment";
 
 export default async function rebuildSegmentsJob(container: MedusaContainer) {
-  console.log("[AdPlanning] Starting daily segment rebuild job...");
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER);
+  logger.info("[AdPlanning] Starting daily segment rebuild job...");
 
   const adPlanningService = container.resolve(AD_PLANNING_MODULE);
 
@@ -25,7 +27,7 @@ export default async function rebuildSegmentsJob(container: MedusaContainer) {
       (s: any) => s.auto_update !== false
     );
 
-    console.log(`[AdPlanning] Rebuilding ${dynamicSegments.length} dynamic segments...`);
+    logger.info(`[AdPlanning] Rebuilding ${dynamicSegments.length} dynamic segments...`);
 
     let processed = 0;
     let errors = 0;
@@ -36,27 +38,22 @@ export default async function rebuildSegmentsJob(container: MedusaContainer) {
           input: { segment_id: segment.id },
         });
 
-        console.log(`[AdPlanning] Rebuilt segment "${segment.name}":`, {
-          total_evaluated: result.result.total_evaluated,
-          matching_count: result.result.matching_count,
-          members_added: result.result.members_added,
-          members_removed: result.result.members_removed,
-        });
+        logger.info(
+          `[AdPlanning] Rebuilt segment "${segment.name}": total_evaluated=${result.result.total_evaluated}, matching_count=${result.result.matching_count}, members_added=${result.result.members_added}, members_removed=${result.result.members_removed}`
+        );
 
         processed++;
       } catch (error) {
         errors++;
-        console.error(`[AdPlanning] Failed to rebuild segment "${segment.name}":`, error);
+        logger.error(`[AdPlanning] Failed to rebuild segment "${segment.name}":`, error as Error);
       }
     }
 
-    console.log(`[AdPlanning] Segment rebuild complete:`, {
-      total_segments: dynamicSegments.length,
-      processed,
-      errors,
-    });
+    logger.info(
+      `[AdPlanning] Segment rebuild complete: total_segments=${dynamicSegments.length}, processed=${processed}, errors=${errors}`
+    );
   } catch (error) {
-    console.error("[AdPlanning] Segment rebuild job failed:", error);
+    logger.error("[AdPlanning] Segment rebuild job failed:", error as Error);
   }
 }
 

--- a/apps/backend/src/jobs/ad-planning/recalculate-scores-job.ts
+++ b/apps/backend/src/jobs/ad-planning/recalculate-scores-job.ts
@@ -8,6 +8,7 @@
  */
 
 import { MedusaContainer } from "@medusajs/framework";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { AD_PLANNING_MODULE } from "../../modules/ad-planning";
 import { calculateEngagementWorkflow } from "../../workflows/ad-planning/scoring/calculate-engagement";
 import { calculateChurnRiskWorkflow } from "../../workflows/ad-planning/predictive/calculate-churn-risk";
@@ -71,7 +72,8 @@ async function fetchRecentPersonIds(
 }
 
 export default async function recalculateScoresJob(container: MedusaContainer) {
-  console.log("[AdPlanning] Starting weekly score recalculation job...");
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER);
+  logger.info("[AdPlanning] Starting weekly score recalculation job...");
 
   const adPlanningService: any = container.resolve(AD_PLANNING_MODULE);
 
@@ -97,7 +99,7 @@ export default async function recalculateScoresJob(container: MedusaContainer) {
       new Set([...conversionPersonIds, ...journeyPersonIds])
     );
 
-    console.log(
+    logger.info(
       `[AdPlanning] Recalculating scores for ${personIds.length} customers with activity in the last ${ACTIVITY_WINDOW_DAYS} days...`
     );
 
@@ -123,26 +125,24 @@ export default async function recalculateScoresJob(container: MedusaContainer) {
         processed++;
 
         if (processed % 100 === 0) {
-          console.log(
+          logger.info(
             `[AdPlanning] Processed ${processed}/${personIds.length} customers...`
           );
         }
       } catch (error) {
         errors++;
-        console.error(
+        logger.error(
           `[AdPlanning] Failed to calculate scores for person ${personId}:`,
-          error
+          error as Error
         );
       }
     });
 
-    console.log(`[AdPlanning] Score recalculation complete:`, {
-      total_customers: personIds.length,
-      processed,
-      errors,
-    });
+    logger.info(
+      `[AdPlanning] Score recalculation complete: total_customers=${personIds.length}, processed=${processed}, errors=${errors}`
+    );
   } catch (error) {
-    console.error("[AdPlanning] Score recalculation job failed:", error);
+    logger.error("[AdPlanning] Score recalculation job failed:", error as Error);
   }
 }
 

--- a/apps/backend/src/jobs/ad-planning/resolve-attributions-job.ts
+++ b/apps/backend/src/jobs/ad-planning/resolve-attributions-job.ts
@@ -6,10 +6,12 @@
  */
 
 import { MedusaContainer } from "@medusajs/framework";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { bulkResolveAttributionsWorkflow } from "../../workflows/ad-planning/attribution/bulk-resolve-attributions";
 
 export default async function resolveAttributionsJob(container: MedusaContainer) {
-  console.log("[AdPlanning] Starting daily attribution resolution job...");
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER);
+  logger.info("[AdPlanning] Starting daily attribution resolution job...");
 
   try {
     const result = await bulkResolveAttributionsWorkflow(container).run({
@@ -19,13 +21,11 @@ export default async function resolveAttributionsJob(container: MedusaContainer)
       },
     });
 
-    console.log(`[AdPlanning] Attribution resolution complete:`, {
-      processed: result.result.processed,
-      resolved: result.result.resolved,
-      failed: result.result.failed,
-    });
+    logger.info(
+      `[AdPlanning] Attribution resolution complete: processed=${result.result.processed}, resolved=${result.result.resolved}, failed=${result.result.failed}`
+    );
   } catch (error) {
-    console.error("[AdPlanning] Attribution resolution job failed:", error);
+    logger.error("[AdPlanning] Attribution resolution job failed:", error as Error);
   }
 }
 

--- a/apps/backend/src/subscribers/ad-planning/analytics-event-created.ts
+++ b/apps/backend/src/subscribers/ad-planning/analytics-event-created.ts
@@ -5,6 +5,7 @@
  */
 
 import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { AD_PLANNING_MODULE } from "../../modules/ad-planning";
 import { trackConversionWorkflow } from "../../workflows/ad-planning/conversions/track-conversion";
 import { resolveSessionAttributionWorkflow } from "../../workflows/ad-planning/attribution/resolve-session-attribution";
@@ -41,6 +42,7 @@ export default async function analyticsEventCreatedHandler({
   event: { data },
   container,
 }: SubscriberArgs<AnalyticsEventCreatedEvent>) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER);
   try {
     const analyticsEvent = data;
 
@@ -93,7 +95,7 @@ export default async function analyticsEventCreatedHandler({
         },
       });
 
-      console.log(`[AdPlanning] Custom conversion tracked for event: ${eventName}`);
+      logger.info(`[AdPlanning] Custom conversion tracked for event: ${eventName}`);
       return;
     }
 
@@ -114,7 +116,7 @@ export default async function analyticsEventCreatedHandler({
       },
     });
 
-    console.log(`[AdPlanning] Conversion tracked for event: ${eventName}`);
+    logger.info(`[AdPlanning] Conversion tracked for event: ${eventName}`);
 
     // Auto-resolve attribution if session has UTM campaign data.
     // Nested inside the outer try/catch so that a failure here doesn't
@@ -135,15 +137,14 @@ export default async function analyticsEventCreatedHandler({
           message.includes("unique") ||
           message.includes("already exists");
         if (!isDuplicate) {
-          console.error(
-            "[AdPlanning] Attribution resolution failed:",
-            message
+          logger.error(
+            `[AdPlanning] Attribution resolution failed: ${message}`
           );
         }
       }
     }
   } catch (error) {
-    console.error("[AdPlanning] Failed to process analytics event:", error);
+    logger.error("[AdPlanning] Failed to process analytics event:", error as Error);
   }
 }
 

--- a/apps/backend/src/subscribers/ad-planning/feedback-created.ts
+++ b/apps/backend/src/subscribers/ad-planning/feedback-created.ts
@@ -5,6 +5,7 @@
  */
 
 import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { analyzeSentimentWorkflow } from "../../workflows/ad-planning/sentiment/analyze-sentiment";
 import { calculateNPSWorkflow } from "../../workflows/ad-planning/scoring/calculate-nps";
 
@@ -22,13 +23,14 @@ export default async function feedbackCreatedHandler({
   event: { data },
   container,
 }: SubscriberArgs<FeedbackCreatedEvent>) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER);
   try {
     const feedback = data;
 
     // Guard against malformed event payloads — workflows downstream
     // assume a real feedback ID.
     if (!feedback?.id) {
-      console.warn("[AdPlanning] feedback.created event missing id — skipping");
+      logger.warn("[AdPlanning] feedback.created event missing id — skipping");
       return;
     }
 
@@ -48,13 +50,13 @@ export default async function feedbackCreatedHandler({
             },
           },
         });
-        console.log(
+        logger.info(
           `[AdPlanning] Sentiment analyzed for feedback: ${feedback.id}`
         );
       } catch (error) {
-        console.error(
+        logger.error(
           "[AdPlanning] Failed to analyze feedback sentiment:",
-          error
+          error as Error
         );
       }
     }
@@ -80,18 +82,18 @@ export default async function feedbackCreatedHandler({
             source_type: "feedback",
           },
         });
-        console.log(
+        logger.info(
           `[AdPlanning] NPS calculated from feedback rating for: ${feedback.person_id}`
         );
       } catch (error) {
-        console.error(
+        logger.error(
           "[AdPlanning] Failed to calculate NPS from feedback:",
-          error
+          error as Error
         );
       }
     }
   } catch (error) {
-    console.error("[AdPlanning] feedback-created subscriber failed:", error);
+    logger.error("[AdPlanning] feedback-created subscriber failed:", error as Error);
   }
 }
 

--- a/apps/backend/src/subscribers/ad-planning/form-response-created.ts
+++ b/apps/backend/src/subscribers/ad-planning/form-response-created.ts
@@ -5,6 +5,7 @@
  */
 
 import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { trackLeadConversionWorkflow } from "../../workflows/ad-planning/conversions/track-lead-conversion";
 
 type FormResponseCreatedEvent = {
@@ -26,11 +27,12 @@ export default async function formResponseCreatedHandler({
   event: { data },
   container,
 }: SubscriberArgs<FormResponseCreatedEvent>) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER);
   try {
     const response = data;
 
     if (!response.id || !response.form_id) {
-      console.warn("[AdPlanning] Form response event missing required fields");
+      logger.warn("[AdPlanning] Form response event missing required fields");
       return;
     }
 
@@ -52,9 +54,9 @@ export default async function formResponseCreatedHandler({
       },
     });
 
-    console.log(`[AdPlanning] Form response conversion tracked: ${response.id}`);
+    logger.info(`[AdPlanning] Form response conversion tracked: ${response.id}`);
   } catch (error) {
-    console.error("[AdPlanning] Failed to track form response conversion:", error);
+    logger.error("[AdPlanning] Failed to track form response conversion:", error as Error);
   }
 }
 

--- a/apps/backend/src/subscribers/ad-planning/lead-created.ts
+++ b/apps/backend/src/subscribers/ad-planning/lead-created.ts
@@ -5,6 +5,7 @@
  */
 
 import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { trackLeadConversionWorkflow } from "../../workflows/ad-planning/conversions/track-lead-conversion";
 
 type LeadCreatedEvent = {
@@ -26,11 +27,12 @@ export default async function leadCreatedHandler({
   event: { data },
   container,
 }: SubscriberArgs<LeadCreatedEvent>) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER);
   try {
     const lead = data;
 
     if (!lead.id) {
-      console.warn("[AdPlanning] Lead created event missing lead ID");
+      logger.warn("[AdPlanning] Lead created event missing lead ID");
       return;
     }
 
@@ -52,9 +54,9 @@ export default async function leadCreatedHandler({
       },
     });
 
-    console.log(`[AdPlanning] Lead conversion tracked for lead: ${lead.id}`);
+    logger.info(`[AdPlanning] Lead conversion tracked for lead: ${lead.id}`);
   } catch (error) {
-    console.error("[AdPlanning] Failed to track lead conversion:", error);
+    logger.error("[AdPlanning] Failed to track lead conversion:", error as Error);
   }
 }
 

--- a/apps/backend/src/subscribers/ad-planning/order-placed.ts
+++ b/apps/backend/src/subscribers/ad-planning/order-placed.ts
@@ -5,17 +5,19 @@
  */
 
 import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { trackPurchaseConversionWorkflow } from "../../workflows/ad-planning/conversions/track-purchase-conversion";
 
 export default async function adPlanningOrderPlacedHandler({
   event: { data },
   container,
 }: SubscriberArgs<{ id: string }>) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER);
   try {
     const orderId = data.id;
 
     if (!orderId) {
-      console.warn("[AdPlanning] Order placed event missing order ID");
+      logger.warn("[AdPlanning] Order placed event missing order ID");
       return;
     }
 
@@ -26,9 +28,9 @@ export default async function adPlanningOrderPlacedHandler({
       },
     });
 
-    console.log(`[AdPlanning] Purchase conversion tracked for order: ${orderId}`);
+    logger.info(`[AdPlanning] Purchase conversion tracked for order: ${orderId}`);
   } catch (error) {
-    console.error("[AdPlanning] Failed to track purchase conversion:", error);
+    logger.error("[AdPlanning] Failed to track purchase conversion:", error as Error);
   }
 }
 

--- a/apps/backend/src/subscribers/design-assigned.ts
+++ b/apps/backend/src/subscribers/design-assigned.ts
@@ -1,4 +1,5 @@
 import { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { sendDesignAssignedEmailWorkflow } from "../workflows/email"
 
 export default async function designAssignedHandler({
@@ -11,6 +12,7 @@ export default async function designAssignedHandler({
   design_url?: string
   design_status?: string
 }>) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     await sendDesignAssignedEmailWorkflow(container).run({
       input: {
@@ -21,7 +23,7 @@ export default async function designAssignedHandler({
       },
     })
   } catch (error) {
-    console.error("[design-assigned] Failed to send notification email:", error)
+    logger.error("[design-assigned] Failed to send notification email:", error as Error)
   }
 }
 

--- a/apps/backend/src/subscribers/partner-assign-free-plan.ts
+++ b/apps/backend/src/subscribers/partner-assign-free-plan.ts
@@ -1,4 +1,5 @@
 import { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { PARTNER_PLAN_MODULE } from "../modules/partner-plan"
 import PartnerPlanService from "../modules/partner-plan/service"
 import { createPartnerSubscriptionWorkflow } from "../workflows/partner-subscription/create-subscription"
@@ -12,6 +13,7 @@ export default async function partnerAssignFreePlanHandler({
   email: string
   temp_password: string
 }>) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
   const service: PartnerPlanService = container.resolve(PARTNER_PLAN_MODULE)
 
   // Find the free plan (Simple)
@@ -46,7 +48,7 @@ export default async function partnerAssignFreePlanHandler({
     })
   } catch (e) {
     // Don't block partner creation if subscription assignment fails
-    console.error("Failed to assign free plan to partner:", e)
+    logger.error("Failed to assign free plan to partner:", e as Error)
   }
 }
 

--- a/apps/backend/src/subscribers/production-run-notifications.ts
+++ b/apps/backend/src/subscribers/production-run-notifications.ts
@@ -1,4 +1,4 @@
-import { Modules } from "@medusajs/framework/utils"
+import { Modules, ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
 
 /**
@@ -54,6 +54,8 @@ export default async function productionRunNotificationHandler({
       description = `Production run ${runId} — ${action}`
   }
 
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+
   try {
     const notificationService = container.resolve(Modules.NOTIFICATION) as any
     await notificationService.createNotifications({
@@ -63,7 +65,7 @@ export default async function productionRunNotificationHandler({
       data: { title, description },
     })
   } catch (e: any) {
-    console.error("[production-run-notifications] Failed to send notification:", e.message)
+    logger.error(`[production-run-notifications] Failed to send notification: ${e.message}`)
   }
 }
 

--- a/apps/backend/src/subscribers/sample-run-completed.ts
+++ b/apps/backend/src/subscribers/sample-run-completed.ts
@@ -17,6 +17,7 @@ export default async function sampleRunCompletedHandler({
   const runId = event.data?.id
   if (!runId) return
 
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
   const productionRunService = container.resolve("production_runs") as any
 
   let run: any
@@ -47,7 +48,7 @@ export default async function sampleRunCompletedHandler({
   )
 
   if (!logs.length) {
-    console.log(`[sample-run-completed] Design ${designId} / Run ${runId}: no committed logs for this run — skipping`)
+    logger.info(`[sample-run-completed] Design ${designId} / Run ${runId}: no committed logs for this run — skipping`)
     return
   }
 
@@ -243,11 +244,11 @@ export default async function sampleRunCompletedHandler({
         production_run_id: runId,
       },
     })
-    console.log(
+    logger.info(
       `[sample-run-completed] Design ${designId}: material=${materialCost}, energy=${energyCost}, labor=${laborCost}, production=${productionCost}, total=${totalEstimate}`
     )
   } catch (e: any) {
-    console.error(`[sample-run-completed] Failed to update design ${designId}:`, e.message)
+    logger.error(`[sample-run-completed] Failed to update design ${designId}: ${e.message}`)
   }
 }
 


### PR DESCRIPTION
## What

**#701 wave 1** (of the logger-standardization rollout). Migrates every runtime `console.*` call in **`src/subscribers/**`** and **`src/jobs/**`** to the structured Medusa logger so they surface in CloudWatch with levels + request correlation (background in #701).

Independent of wave 0 (#702) — branched off fresh `origin/main`, **not stacked**.

## Scope

12 files, **41 `console.*` calls** migrated. Zero `console.*` remain in either dir (`grep` clean).

| Dir | Files |
|---|---|
| subscribers | production-run-notifications, design-assigned, partner-assign-free-plan, sample-run-completed, ad-planning/{feedback-created, lead-created, order-placed, form-response-created, analytics-event-created} |
| jobs | ad-planning/{recalculate-scores-job, resolve-attributions-job, rebuild-segments-job} |

## Pattern (canonical, not invented)

- Subscribers & scheduled jobs have `{ container }` / `container` in scope → `const logger = container.resolve(ContainerRegistrationKeys.LOGGER)` (mirrors `src/workflows/tasks/run-task-assignment.ts:18`, 152 existing usages).
- Mapping: `console.log→logger.info`, `console.error→logger.error`, `console.warn→logger.warn`. Existing `[tag]` prefixes kept verbatim.
- `Logger.info/.warn` take a **single string** (per the `@medusajs/types` `Logger` interface), so the handful of `console.log(msg, {summaryObj})` calls were inlined into template strings (same fields, rendered `key=value`). `console.error(msg, errObj)` keeps the two-arg form — the interface is `error(messageOrError, error?: Error)`.

## Verification

- ✅ `grep -rn 'console\.' src/subscribers src/jobs` → **0**.
- ✅ `tsc --noEmit -p tsconfig.json` → **zero errors in the 12 touched files** (the ~69 baseline errors pre-exist on `main` and are unrelated — none in these dirs' source).
- No behavior change beyond logging transport; no test changes (mechanical 1:1 swaps).

## Not in scope

`src/scripts/**`, tests, and other dirs (waves 2–5: api-rest → workflows → mastra/services → modules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)