### PR TITLE
fix(#704): surface real cause on failed outbound fetches (undici hides error.cause)

### DIFF
--- a/apps/backend/src/api/admin/marketing/newsletter/generate/route.ts
+++ b/apps/backend/src/api/admin/marketing/newsletter/generate/route.ts
@@ -27,6 +27,7 @@ import {
 } from "../../../../../workflows/marketing/generate-newsletter-draft"
 import { buildNewsletterPrefill } from "../../newsletter-prefill-lib"
 import { buildNoOutputError } from "../newsletter-generate-error-lib"
+import { describeFetchError } from "../../../../../utils/describe-fetch-error"
 
 const NEWSLETTER_AI_ROLE = "ai_newsletter_drafter"
 const DEFAULT_MODEL = "anthropic/claude-3.5-sonnet"
@@ -95,7 +96,10 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
       source = "env"
     }
   } catch (error: any) {
-    caughtError = error?.message || String(error)
+    // Unwrap undici's opaque "fetch failed" into the real network cause so the
+    // 503 names WHY the provider call failed, not just "fetch failed" (#704).
+    // Complements #702's buildNoOutputError (which still receives this string).
+    caughtError = describeFetchError(error)
     logger.error(`[newsletter/generate] AI error: ${caughtError}`)
   }
 

--- a/apps/backend/src/modules/social-provider/whatsapp-service.ts
+++ b/apps/backend/src/modules/social-provider/whatsapp-service.ts
@@ -1,5 +1,6 @@
-import { MedusaError } from "@medusajs/utils"
+import { MedusaError, ContainerRegistrationKeys } from "@medusajs/utils"
 import type { MedusaContainer } from "@medusajs/framework/types"
+import { describeFetchError } from "../../utils/describe-fetch-error"
 import { SOCIALS_MODULE } from "../socials"
 import { ENCRYPTION_MODULE } from "../encryption"
 import type EncryptionService from "../encryption/service"
@@ -610,6 +611,22 @@ export default class WhatsAppService {
     return this.sendDocumentMessage(to, mediaUrl, caption, filename)
   }
 
+  // Best-effort diagnostic log for the media fetches below. They return `null`
+  // on failure by contract (inbound media handling degrades gracefully), so we
+  // don't throw — but a bare "fetch failed" was undiagnosable in prod (#704).
+  // Unwrap error.cause + host and log it so the reason is recoverable.
+  private logFetchFailure(err: unknown, url: string, label: string): void {
+    const detail = describeFetchError(err, { url, label })
+    try {
+      const logger: any = this.appContainer_?.resolve(
+        ContainerRegistrationKeys.LOGGER
+      )
+      logger?.warn(`[whatsapp] ${detail}`)
+    } catch {
+      // No container/logger available — swallow; behavior is unchanged.
+    }
+  }
+
   /**
    * Retrieve media URL from Meta's Graph API.
    * WhatsApp webhooks provide a mediaId — this fetches the actual download URL.
@@ -620,8 +637,9 @@ export default class WhatsAppService {
 
     if (!this.accessToken) return null
 
+    const url = `${GRAPH_API_BASE}/${mediaId}`
     try {
-      const resp = await fetch(`${GRAPH_API_BASE}/${mediaId}`, {
+      const resp = await fetch(url, {
         headers: { Authorization: `Bearer ${this.accessToken}` },
       })
 
@@ -630,7 +648,8 @@ export default class WhatsAppService {
       const data = await resp.json() as { url?: string; mime_type?: string; file_size?: number }
       if (!data?.url) return null
       return { url: data.url, mime_type: data.mime_type, file_size: data.file_size }
-    } catch {
+    } catch (e) {
+      this.logFetchFailure(e, url, "WhatsApp media URL")
       return null
     }
   }
@@ -651,7 +670,8 @@ export default class WhatsAppService {
       const contentType = resp.headers.get("content-type") || "application/octet-stream"
       const arrayBuffer = await resp.arrayBuffer()
       return { buffer: Buffer.from(arrayBuffer), contentType }
-    } catch {
+    } catch (e) {
+      this.logFetchFailure(e, mediaUrl, "WhatsApp media download")
       return null
     }
   }
@@ -690,14 +710,27 @@ export default class WhatsAppService {
     }
 
     const url = `${GRAPH_API_BASE}/${this.phoneNumberId}/messages`
-    const resp = await fetch(url, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${this.accessToken}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(payload),
-    })
+    // Network-level failures (connect timeout, ECONNRESET, DNS) throw BEFORE a
+    // response and would otherwise bubble up as undici's opaque "fetch failed"
+    // (#704). Unwrap error.cause into an actionable message so the failure log
+    // names the real reason — mirroring the status+body detail the `!resp.ok`
+    // branch already records.
+    let resp: Response
+    try {
+      resp = await fetch(url, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.accessToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      })
+    } catch (e) {
+      throw new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        describeFetchError(e, { url, label: "WhatsApp send" })
+      )
+    }
 
     if (!resp.ok) {
       const err = await resp.json().catch(() => ({}))

--- a/apps/backend/src/utils/__tests__/describe-fetch-error.unit.spec.ts
+++ b/apps/backend/src/utils/__tests__/describe-fetch-error.unit.spec.ts
@@ -1,0 +1,85 @@
+import { describeFetchError } from "../describe-fetch-error"
+
+describe("describeFetchError", () => {
+  it("unwraps an undici-style TypeError with cause and full opts", () => {
+    const undiciErr = Object.assign(new TypeError("fetch failed"), {
+      cause: {
+        code: "ETIMEDOUT",
+        errno: -60,
+        syscall: "connect",
+        address: "157.240.1.1",
+        port: 443,
+      },
+    })
+
+    expect(
+      describeFetchError(undiciErr, {
+        url: "https://graph.facebook.com/v19.0/123/messages",
+        label: "WhatsApp send",
+      })
+    ).toBe(
+      "WhatsApp send to graph.facebook.com failed: connect ETIMEDOUT 157.240.1.1:443"
+    )
+  })
+
+  it("surfaces ECONNRESET from cause when no address is present", () => {
+    const resetErr = Object.assign(new TypeError("fetch failed"), {
+      cause: { syscall: "read", code: "ECONNRESET" },
+    })
+
+    expect(describeFetchError(resetErr)).toBe("read ECONNRESET")
+  })
+
+  it("renders ENOTFOUND with hostname from cause", () => {
+    const dnsErr = Object.assign(new TypeError("fetch failed"), {
+      cause: {
+        syscall: "getaddrinfo",
+        code: "ENOTFOUND",
+        hostname: "bad.example.com",
+      },
+    })
+
+    expect(describeFetchError(dnsErr)).toBe(
+      "getaddrinfo ENOTFOUND bad.example.com"
+    )
+  })
+
+  it("uses err.message for a plain Error with no cause and no opts", () => {
+    expect(describeFetchError(new Error("boom"))).toBe("boom")
+  })
+
+  it("stringifies non-Error thrown values", () => {
+    expect(describeFetchError("kaboom")).toBe("kaboom")
+    expect(describeFetchError(42)).toBe("42")
+  })
+
+  it("prefixes with only the host when url is provided without label", () => {
+    expect(
+      describeFetchError(new Error("boom"), {
+        url: "https://api.example.com/resource",
+      })
+    ).toBe("api.example.com failed: boom")
+  })
+
+  it("prefixes with only the label when label is provided without url", () => {
+    expect(
+      describeFetchError(new Error("boom"), { label: "API call" })
+    ).toBe("API call failed: boom")
+  })
+
+  it("surfaces the structured cause over a generic 'fetch failed' message", () => {
+    const undiciErr = Object.assign(new TypeError("fetch failed"), {
+      cause: {
+        code: "ETIMEDOUT",
+        errno: -60,
+        syscall: "connect",
+        address: "157.240.1.1",
+        port: 443,
+      },
+    })
+
+    expect(describeFetchError(undiciErr)).toBe(
+      "connect ETIMEDOUT 157.240.1.1:443"
+    )
+  })
+})

--- a/apps/backend/src/utils/describe-fetch-error.ts
+++ b/apps/backend/src/utils/describe-fetch-error.ts
@@ -1,0 +1,99 @@
+// Turn an opaque outbound-fetch failure into a single actionable string.
+//
+// Background (#704): when `fetch()` (undici, Node ≥18) fails at the network
+// level — connect timeout, connection reset, DNS lookup failure — it throws a
+// generic `TypeError: fetch failed` and the REAL reason lives on `error.cause`
+// (e.g. `{ code: "ETIMEDOUT", syscall: "connect", address: "157.240.1.1",
+// port: 443 }`). Recording only `err.message` ("fetch failed") makes prod
+// incidents undiagnosable. This helper unwraps that cause and the target host
+// so failure logs say WHY, mirroring the quality of a non-OK HTTP branch that
+// already records status + body.
+//
+// Pure: no I/O, no throws. Safe to call on any thrown value (Error, undici
+// TypeError, or a non-Error primitive).
+
+type FetchCause = {
+  code?: string
+  errno?: number
+  syscall?: string
+  address?: string
+  port?: number
+  hostname?: string
+  message?: string
+}
+
+function hostFromUrl(url?: string): string | undefined {
+  if (!url) return undefined
+  try {
+    return new URL(url).host
+  } catch {
+    return undefined
+  }
+}
+
+// Pull the undici-style cause off an Error, if present and object-shaped.
+function extractCause(err: unknown): FetchCause | undefined {
+  if (!err || typeof err !== "object") return undefined
+  const cause = (err as { cause?: unknown }).cause
+  if (!cause || typeof cause !== "object") return undefined
+  return cause as FetchCause
+}
+
+// Build the low-level network detail, e.g. "connect ETIMEDOUT 157.240.1.1:443"
+// or "getaddrinfo ENOTFOUND graph.facebook.com". Returns undefined when the
+// cause carries nothing useful.
+function describeCause(cause: FetchCause): string | undefined {
+  const parts: string[] = []
+  if (cause.syscall) parts.push(cause.syscall)
+  if (cause.code) parts.push(cause.code)
+
+  const target =
+    cause.address && cause.port != null
+      ? `${cause.address}:${cause.port}`
+      : cause.address || cause.hostname
+  if (target) parts.push(target)
+
+  if (parts.length) return parts.join(" ")
+  // Fall back to the cause's own message if it had no structured fields.
+  if (cause.message) return cause.message
+  return undefined
+}
+
+export function describeFetchError(
+  err: unknown,
+  opts?: { url?: string; label?: string }
+): string {
+  const label = opts?.label
+  const host = hostFromUrl(opts?.url)
+
+  // Prefix: "<label> to <host>" / "<label>" / "<host>" — whichever we have.
+  let prefix = ""
+  if (label && host) prefix = `${label} to ${host}`
+  else if (label) prefix = label
+  else if (host) prefix = host
+
+  const cause = extractCause(err)
+  const causeDetail = cause ? describeCause(cause) : undefined
+
+  // Base message: prefer the unwrapped network cause; otherwise the error's
+  // own message; otherwise the stringified non-Error value.
+  let baseMessage: string
+  if (err instanceof Error) {
+    baseMessage = err.message || "Error"
+  } else if (err && typeof err === "object" && "message" in err) {
+    baseMessage = String((err as { message?: unknown }).message ?? err)
+  } else {
+    baseMessage = String(err)
+  }
+
+  // When undici gives the generic "fetch failed" but we recovered a real
+  // cause, surface the cause instead of the useless top-line.
+  const isGenericFetchFailure = /fetch failed/i.test(baseMessage)
+  const detail =
+    causeDetail && (isGenericFetchFailure || causeDetail !== baseMessage)
+      ? causeDetail
+      : baseMessage
+
+  if (prefix) return `${prefix} failed: ${detail}`
+  return detail
+}

--- a/apps/backend/src/workflows/visual-flows/execute-visual-flow.ts
+++ b/apps/backend/src/workflows/visual-flows/execute-visual-flow.ts
@@ -8,6 +8,7 @@ import type { IEventBusModuleService } from "@medusajs/framework/types"
 import { Modules } from "@medusajs/framework/utils"
 import { VISUAL_FLOWS_MODULE } from "../../modules/visual_flows"
 import VisualFlowService from "../../modules/visual_flows/service"
+import { describeFetchError } from "../../utils/describe-fetch-error"
 import {
   operationRegistry,
   DataChain,
@@ -301,6 +302,10 @@ const executeOperationsStep = createStep(
 
       nodeIdToOperation.set(node.id, {
         id: node.id, // Use canvas node ID for graph traversal
+        // Real DB operation id (when this node maps to a stored operation) so
+        // execution logs can FK to it and the executions API can resolve the
+        // operation name — canvas node ids are not DB ids (#704).
+        db_operation_id: dbOp?.id,
         operation_key: opKey,
         operation_type: nodeData.operationType || dbOp?.operation_type || "unknown",
         name: nodeData.label || opKey,
@@ -534,9 +539,15 @@ async function executeSingleOperation(
   const rawOptions = operation.options || {}
   const resolvedOptionsForLog = interpolateVariables(rawOptions, dataChain)
 
-  // Log operation start - use null for operation_id since we're using canvas node IDs
+  // Real DB operation id for this node (when it maps to a stored operation), so
+  // logs FK to the operation and the executions API can resolve its name —
+  // previously left null because canvas node ids aren't DB ids (#704).
+  const dbOperationId: string | undefined = operation.db_operation_id
+
+  // Log operation start
   await service.addExecutionLog({
     execution_id: executionId,
+    operation_id: dbOperationId,
     operation_key: operation.operation_key,
     status: "running",
     input_data: resolvedOptionsForLog,
@@ -557,6 +568,7 @@ async function executeSingleOperation(
       // Log success
       await service.addExecutionLog({
         execution_id: executionId,
+        operation_id: dbOperationId,
         operation_key: operation.operation_key,
         status: "success",
         input_data: resolvedOptionsForLog,
@@ -569,6 +581,7 @@ async function executeSingleOperation(
       // Log failure
       await service.addExecutionLog({
         execution_id: executionId,
+        operation_id: dbOperationId,
         operation_key: operation.operation_key,
         status: "failure",
         input_data: resolvedOptionsForLog,
@@ -582,13 +595,20 @@ async function executeSingleOperation(
   } catch (error: any) {
     const duration = Date.now() - startTime
 
+    // Unwrap undici's opaque "fetch failed" into the real network cause
+    // (connect ETIMEDOUT / ECONNRESET / DNS) so the failure log says WHY —
+    // the WhatsApp notify_partner incident stored a bare "fetch failed" (#704).
+    // describeFetchError falls back to error.message for non-fetch errors.
+    const errorDetail = describeFetchError(error)
+
     // Log failure
     await service.addExecutionLog({
       execution_id: executionId,
+      operation_id: dbOperationId,
       operation_key: operation.operation_key,
       status: "failure",
       input_data: resolvedOptionsForLog,
-      error: error.message,
+      error: errorDetail,
       error_stack: error.stack,
       duration_ms: duration,
     })


### PR DESCRIPTION
Closes #704.

## Problem
A network-level `fetch` failure (connect timeout, ECONNRESET, DNS) surfaces undici's generic **`"fetch failed"`** and throws away the real reason, which lives on **`error.cause`**. Two real prod incidents: visual-flow `vflow_01KT1BYKKZA5C0KYTQ4GC27QEM` last step `notify_partner` (WhatsApp send) logged a bare `"fetch failed"` after a 12s hang; and `newsletter/generate` swallowed the underlying `generateText` error.

## What this does (focused — util + 3 boundaries + tests)
1. **NEW pure util** `src/utils/describe-fetch-error.ts` — `describeFetchError(err, { url?, label? })` unwraps `error.cause` (`code`/`errno`/`syscall`/`address`/`port`/`hostname`), derives host from `url`, returns one actionable string e.g. `WhatsApp send to graph.facebook.com failed: connect ETIMEDOUT 157.240.1.1:443`. Pure, no I/O; falls back to `err.message` for plain errors and `String(err)` for non-Error throws. **8 unit tests** (ETIMEDOUT/ECONNRESET/ENOTFOUND/plain-Error/non-Error/prefix variants).
2. **`whatsapp-service.ts`** — `sendRequest`'s network `fetch` is wrapped in try/catch → throws `MedusaError(UNEXPECTED_STATE, describeFetchError(e,{url,label:"WhatsApp send"}))`. The existing `if (!resp.ok)` status+body branch is untouched. The two media fetches keep their `null`-return contract (graceful degradation) but now **log** the real cause via the container logger.
3. **`execute-visual-flow.ts`** — failure log now stores the **unwrapped cause** in `error` (via the util), and **populates `operation_id`** on every step log (resolved from the `dbOpByKey` map; was `null` because canvas node ids ≠ DB ids), so the executions API can name the failing step. Behavior otherwise identical.
4. **`newsletter/generate/route.ts`** — the catch runs the caught error through the util so `caughtError` (and the 503 message) carry the real cause. Complements #702's `buildNoOutputError`, which still receives the string.

## Out of scope (deliberately)
No retry-logic change (the visual-flow incident was transient/deploy-related — diagnosability only). No blanket-wrapping of unrelated fetches. No success-path / response-shape changes.

## Tests
- `TEST_TYPE=unit jest describe-fetch-error.unit.spec` → **8/8 pass**.
- `tsc --noEmit` → zero new errors in changed files.
- The visual-flow failure-log wiring (`operation_id` + cause) is **not** unit-tested: the builder lives inside the un-exported `executeSingleOperation` (the existing harness injects a fake `execOp` that bypasses it), and the FK/DB-resolution path needs the full container+service. Verified by typecheck + reasoning; the field mapping is a 1:1 pass-through to `addExecutionLog` (which already accepts `operation_id`).

PR-only — leaving for human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)