### PR TITLE
chore(logging): #701 wave 3a — console.* → Medusa logger in admin social/ads routes

### DIFF
--- a/apps/backend/src/api/admin/ad-planning/segments/route.ts
+++ b/apps/backend/src/api/admin/ad-planning/segments/route.ts
@@ -4,6 +4,7 @@
  */
 
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { z } from "@medusajs/framework/zod";
 import { AD_PLANNING_MODULE } from "../../../../modules/ad-planning";
 import { buildSegmentWorkflow } from "../../../../workflows/ad-planning/segments/build-segment";
@@ -82,6 +83,7 @@ const CreateSegmentSchema = z.object({
  * @route POST /admin/ad-planning/segments
  */
 export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER);
   const data = CreateSegmentSchema.parse(req.body);
   const adPlanningService = req.scope.resolve(AD_PLANNING_MODULE);
 
@@ -106,7 +108,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
       });
       return;
     } catch (error) {
-      console.error("[Segments] Failed to build segment:", error);
+      logger.error("[Segments] Failed to build segment:", error);
     }
   }
 

--- a/apps/backend/src/api/admin/meta-ads/accounts/[id]/route.ts
+++ b/apps/backend/src/api/admin/meta-ads/accounts/[id]/route.ts
@@ -31,6 +31,7 @@
  * // Response: { success: boolean }
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SOCIALS_MODULE } from "../../../../../modules/socials"
 import SocialsService from "../../../../../modules/socials/service"
 
@@ -43,6 +44,7 @@ export const GET = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const { id } = req.params
@@ -57,7 +59,7 @@ export const GET = async (
 
     res.json({ account })
   } catch (error: any) {
-    console.error("Failed to get ad account:", error)
+    logger.error("Failed to get ad account:", error)
     res.status(500).json({
       message: "Failed to get ad account",
       error: error.message,

--- a/apps/backend/src/api/admin/meta-ads/accounts/route.ts
+++ b/apps/backend/src/api/admin/meta-ads/accounts/route.ts
@@ -48,6 +48,7 @@
  * // }
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SOCIALS_MODULE } from "../../../../modules/socials"
 import SocialsService from "../../../../modules/socials/service"
 
@@ -60,6 +61,7 @@ export const GET = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     
@@ -72,7 +74,7 @@ export const GET = async (
       count: accounts.length,
     })
   } catch (error: any) {
-    console.error("Failed to list ad accounts:", error)
+    logger.error("Failed to list ad accounts:", error)
     res.status(500).json({
       message: "Failed to list ad accounts",
       error: error.message,
@@ -89,6 +91,7 @@ export const POST = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const body = req.body as Record<string, any>
@@ -97,7 +100,7 @@ export const POST = async (
 
     res.json({ account })
   } catch (error: any) {
-    console.error("Failed to create ad account:", error)
+    logger.error("Failed to create ad account:", error)
     res.status(500).json({
       message: "Failed to create ad account",
       error: error.message,

--- a/apps/backend/src/api/admin/meta-ads/accounts/sync/route.ts
+++ b/apps/backend/src/api/admin/meta-ads/accounts/sync/route.ts
@@ -22,6 +22,7 @@
  * @apiError (500: Internal Server Error) {String} error Error message
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SOCIALS_MODULE } from "../../../../../modules/socials"
 import SocialsService from "../../../../../modules/socials/service"
 import MetaAdsService from "../../../../../modules/social-provider/meta-ads-service"
@@ -39,6 +40,7 @@ export const POST = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const body = req.body as Record<string, any>
@@ -73,7 +75,7 @@ export const POST = async (
     
     // Fallback to generic access token if no user token
     if (!accessToken) {
-      console.log("No user_access_token found, trying generic access_token...")
+      logger.info("No user_access_token found, trying generic access_token...")
       accessToken = decryptAccessToken(apiConfig, req.scope)
     }
     
@@ -83,7 +85,7 @@ export const POST = async (
       })
     }
     
-    console.log("Using access token for ad accounts sync...")
+    logger.info("Using access token for ad accounts sync...")
 
     const metaAds = new MetaAdsService()
     const results = {
@@ -110,7 +112,7 @@ export const POST = async (
       throw error
     }
 
-    console.log(`Found ${metaAccounts.length} ad accounts from Meta`)
+    logger.info(`Found ${metaAccounts.length} ad accounts from Meta`)
 
     for (const metaAccount of metaAccounts) {
       try {
@@ -151,7 +153,7 @@ export const POST = async (
           results.created++
         }
       } catch (error) {
-        console.error(`Failed to sync account ${metaAccount.id}:`, error)
+        logger.error(`Failed to sync account ${metaAccount.id}:`, error)
         results.errors++
       }
     }
@@ -161,7 +163,7 @@ export const POST = async (
       results,
     })
   } catch (error: any) {
-    console.error("Failed to sync ad accounts:", error)
+    logger.error("Failed to sync ad accounts:", error)
     res.status(500).json({
       message: "Failed to sync ad accounts",
       error: error.message,

--- a/apps/backend/src/api/admin/meta-ads/ads/[id]/route.ts
+++ b/apps/backend/src/api/admin/meta-ads/ads/[id]/route.ts
@@ -35,10 +35,12 @@
  * - 500: Failed to get ad (with error details)
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SOCIALS_MODULE } from "../../../../../modules/socials"
 import SocialsService from "../../../../../modules/socials/service"
 
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const { id } = req.params
@@ -69,7 +71,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       },
     })
   } catch (error: any) {
-    console.error("Failed to get ad:", error)
+    logger.error("Failed to get ad:", error)
 
     if (error.type === "not_found" || error.message?.includes("was not found")) {
       return res.status(404).json({

--- a/apps/backend/src/api/admin/meta-ads/ads/[id]/status/route.ts
+++ b/apps/backend/src/api/admin/meta-ads/ads/[id]/status/route.ts
@@ -60,6 +60,7 @@
  *     .catch(error => console.error(error));
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SOCIALS_MODULE } from "../../../../../../modules/socials"
 import SocialsService from "../../../../../../modules/socials/service"
 import MetaAdsService from "../../../../../../modules/social-provider/meta-ads-service"
@@ -77,6 +78,7 @@ export const POST = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const { id } = req.params
@@ -157,7 +159,7 @@ export const POST = async (
       ad: updatedAd,
     })
   } catch (error: any) {
-    console.error("Failed to update ad status:", error)
+    logger.error("Failed to update ad status:", error)
     res.status(500).json({
       message: "Failed to update ad status",
       error: error.message,

--- a/apps/backend/src/api/admin/meta-ads/ads/route.ts
+++ b/apps/backend/src/api/admin/meta-ads/ads/route.ts
@@ -37,6 +37,7 @@
  * }
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SOCIALS_MODULE } from "../../../../modules/socials"
 import SocialsService from "../../../../modules/socials/service"
 
@@ -49,6 +50,7 @@ export const GET = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const { ad_set_id, campaign_id, ad_account_id, limit = "200", offset = "0" } = req.query as Record<string, string>
@@ -108,7 +110,7 @@ export const GET = async (
       offset: skip,
     })
   } catch (error: any) {
-    console.error("Failed to list ads:", error)
+    logger.error("Failed to list ads:", error)
     res.status(500).json({
       message: "Failed to list ads",
       error: error.message,
@@ -125,6 +127,7 @@ export const POST = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const body = req.body as Record<string, any>
@@ -133,7 +136,7 @@ export const POST = async (
 
     res.json({ ad })
   } catch (error: any) {
-    console.error("Failed to create ad:", error)
+    logger.error("Failed to create ad:", error)
     res.status(500).json({
       message: "Failed to create ad",
       error: error.message,

--- a/apps/backend/src/api/admin/meta-ads/adsets/[id]/route.ts
+++ b/apps/backend/src/api/admin/meta-ads/adsets/[id]/route.ts
@@ -45,10 +45,12 @@
  * }
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SOCIALS_MODULE } from "../../../../../modules/socials"
 import SocialsService from "../../../../../modules/socials/service"
 
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const { id } = req.params
@@ -75,7 +77,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       },
     })
   } catch (error: any) {
-    console.error("Failed to get ad set:", error)
+    logger.error("Failed to get ad set:", error)
 
     if (error.type === "not_found" || error.message?.includes("was not found")) {
       return res.status(404).json({

--- a/apps/backend/src/api/admin/meta-ads/adsets/[id]/status/route.ts
+++ b/apps/backend/src/api/admin/meta-ads/adsets/[id]/status/route.ts
@@ -65,6 +65,7 @@
  *     console.log(data);
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SOCIALS_MODULE } from "../../../../../../modules/socials"
 import SocialsService from "../../../../../../modules/socials/service"
 import MetaAdsService from "../../../../../../modules/social-provider/meta-ads-service"
@@ -82,6 +83,7 @@ export const POST = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const { id } = req.params
@@ -154,7 +156,7 @@ export const POST = async (
       adSet: updatedAdSet,
     })
   } catch (error: any) {
-    console.error("Failed to update ad set status:", error)
+    logger.error("Failed to update ad set status:", error)
     res.status(500).json({
       message: "Failed to update ad set status",
       error: error.message,

--- a/apps/backend/src/api/admin/meta-ads/adsets/route.ts
+++ b/apps/backend/src/api/admin/meta-ads/adsets/route.ts
@@ -40,6 +40,7 @@
  * }
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SOCIALS_MODULE } from "../../../../modules/socials"
 import SocialsService from "../../../../modules/socials/service"
 
@@ -52,6 +53,7 @@ export const GET = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const { campaign_id, ad_account_id, limit = "200", offset = "0" } = req.query as Record<string, string>
@@ -102,7 +104,7 @@ export const GET = async (
       offset: skip,
     })
   } catch (error: any) {
-    console.error("Failed to list ad sets:", error)
+    logger.error("Failed to list ad sets:", error)
     res.status(500).json({
       message: "Failed to list ad sets",
       error: error.message,
@@ -119,6 +121,7 @@ export const POST = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const body = req.body as Record<string, any>
@@ -127,7 +130,7 @@ export const POST = async (
 
     res.json({ adSet })
   } catch (error: any) {
-    console.error("Failed to create ad set:", error)
+    logger.error("Failed to create ad set:", error)
     res.status(500).json({
       message: "Failed to create ad set",
       error: error.message,

--- a/apps/backend/src/api/admin/meta-ads/campaigns/[id]/route.ts
+++ b/apps/backend/src/api/admin/meta-ads/campaigns/[id]/route.ts
@@ -136,6 +136,7 @@
  * }
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SOCIALS_MODULE } from "../../../../../modules/socials"
 import SocialsService from "../../../../../modules/socials/service"
 
@@ -148,6 +149,7 @@ export const GET = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const { id } = req.params
@@ -195,7 +197,7 @@ export const GET = async (
       },
     })
   } catch (error: any) {
-    console.error("Failed to get campaign:", error)
+    logger.error("Failed to get campaign:", error)
     
     // Check if it's a not_found error
     if (error.type === "not_found" || error.message?.includes("was not found")) {

--- a/apps/backend/src/api/admin/meta-ads/campaigns/[id]/status/route.ts
+++ b/apps/backend/src/api/admin/meta-ads/campaigns/[id]/status/route.ts
@@ -74,6 +74,7 @@
  * }
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SOCIALS_MODULE } from "../../../../../../modules/socials"
 import SocialsService from "../../../../../../modules/socials/service"
 import MetaAdsService from "../../../../../../modules/social-provider/meta-ads-service"
@@ -91,6 +92,7 @@ export const POST = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const { id } = req.params
@@ -158,7 +160,7 @@ export const POST = async (
       campaign: updatedCampaign,
     })
   } catch (error: any) {
-    console.error("Failed to update campaign status:", error)
+    logger.error("Failed to update campaign status:", error)
     res.status(500).json({
       message: "Failed to update campaign status",
       error: error.message,

--- a/apps/backend/src/api/admin/meta-ads/campaigns/route.ts
+++ b/apps/backend/src/api/admin/meta-ads/campaigns/route.ts
@@ -116,6 +116,7 @@
  * }
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SOCIALS_MODULE } from "../../../../modules/socials"
 import SocialsService from "../../../../modules/socials/service"
 
@@ -134,6 +135,7 @@ export const GET = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     
@@ -169,7 +171,7 @@ export const GET = async (
       offset: parseInt(offset, 10),
     })
   } catch (error: any) {
-    console.error("Failed to list campaigns:", error)
+    logger.error("Failed to list campaigns:", error)
     res.status(500).json({
       message: "Failed to list campaigns",
       error: error.message,
@@ -186,6 +188,7 @@ export const POST = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const body = req.body as Record<string, any>
@@ -194,7 +197,7 @@ export const POST = async (
 
     res.json({ campaign })
   } catch (error: any) {
-    console.error("Failed to create campaign:", error)
+    logger.error("Failed to create campaign:", error)
     res.status(500).json({
       message: "Failed to create campaign",
       error: error.message,

--- a/apps/backend/src/api/admin/meta-ads/campaigns/sync/route.ts
+++ b/apps/backend/src/api/admin/meta-ads/campaigns/sync/route.ts
@@ -80,6 +80,7 @@
  * }
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SOCIALS_MODULE } from "../../../../../modules/socials"
 import SocialsService from "../../../../../modules/socials/service"
 import MetaAdsService from "../../../../../modules/social-provider/meta-ads-service"
@@ -98,6 +99,7 @@ export const POST = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const body = req.body as Record<string, any>
@@ -171,7 +173,7 @@ export const POST = async (
       accessToken
     )
 
-    console.log(`Found ${metaCampaigns.length} campaigns from Meta`)
+    logger.info(`Found ${metaCampaigns.length} campaigns from Meta`)
 
     for (const metaCampaign of metaCampaigns) {
       try {
@@ -188,7 +190,7 @@ export const POST = async (
               date_preset: "last_30d",
             })
           } catch (e) {
-            console.warn(`Failed to get insights for campaign ${metaCampaign.id}`)
+            logger.warn(`Failed to get insights for campaign ${metaCampaign.id}`)
           }
         }
 
@@ -243,7 +245,7 @@ export const POST = async (
         // Sync Ad Sets for this campaign
         try {
           const metaAdSets = await metaAds.listAdSets(metaCampaign.id, accessToken)
-          console.log(`Found ${metaAdSets.length} ad sets for campaign ${metaCampaign.name}`)
+          logger.info(`Found ${metaAdSets.length} ad sets for campaign ${metaCampaign.name}`)
           
           for (const metaAdSet of metaAdSets) {
             try {
@@ -286,7 +288,7 @@ export const POST = async (
               // Sync Ads for this ad set
               try {
                 const metaAdsData = await metaAds.listAds(metaAdSet.id, accessToken)
-                console.log(`Found ${metaAdsData.length} ads for ad set ${metaAdSet.name}`)
+                logger.info(`Found ${metaAdsData.length} ads for ad set ${metaAdSet.name}`)
                 
                 for (const metaAd of metaAdsData) {
                   try {
@@ -316,23 +318,23 @@ export const POST = async (
                       results.ads_created++
                     }
                   } catch (adError) {
-                    console.error(`Failed to sync ad ${metaAd.id}:`, adError)
+                    logger.error(`Failed to sync ad ${metaAd.id}:`, adError)
                     results.errors++
                   }
                 }
               } catch (adsError) {
-                console.error(`Failed to fetch ads for ad set ${metaAdSet.id}:`, adsError)
+                logger.error(`Failed to fetch ads for ad set ${metaAdSet.id}:`, adsError)
               }
             } catch (adSetError) {
-              console.error(`Failed to sync ad set ${metaAdSet.id}:`, adSetError)
+              logger.error(`Failed to sync ad set ${metaAdSet.id}:`, adSetError)
               results.errors++
             }
           }
         } catch (adSetsError) {
-          console.error(`Failed to fetch ad sets for campaign ${metaCampaign.id}:`, adSetsError)
+          logger.error(`Failed to fetch ad sets for campaign ${metaCampaign.id}:`, adSetsError)
         }
       } catch (error) {
-        console.error(`Failed to sync campaign ${metaCampaign.id}:`, error)
+        logger.error(`Failed to sync campaign ${metaCampaign.id}:`, error)
         results.errors++
       }
     }
@@ -349,7 +351,7 @@ export const POST = async (
       },
     })
   } catch (error: any) {
-    console.error("Failed to sync campaigns:", error)
+    logger.error("Failed to sync campaigns:", error)
     res.status(500).json({
       message: "Failed to sync campaigns",
       error: error.message,

--- a/apps/backend/src/api/admin/meta-ads/campaigns/totals/route.ts
+++ b/apps/backend/src/api/admin/meta-ads/campaigns/totals/route.ts
@@ -53,6 +53,7 @@
  * }
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SOCIALS_MODULE } from "../../../../../modules/socials"
 import SocialsService from "../../../../../modules/socials/service"
 
@@ -69,6 +70,7 @@ export const GET = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const { ad_account_id, status } = req.query as Record<string, string>
@@ -142,7 +144,7 @@ export const GET = async (
       },
     })
   } catch (error: any) {
-    console.error("Failed to get campaign totals:", error)
+    logger.error("Failed to get campaign totals:", error)
     res.status(500).json({
       message: "Failed to get campaign totals",
       error: error.message,

--- a/apps/backend/src/api/admin/meta-ads/insights/route.ts
+++ b/apps/backend/src/api/admin/meta-ads/insights/route.ts
@@ -102,6 +102,7 @@
  * }
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SOCIALS_MODULE } from "../../../../modules/socials"
 import SocialsService from "../../../../modules/socials/service"
 
@@ -114,6 +115,7 @@ export const GET = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const { campaign_id, level } = req.query as Record<string, string>
@@ -133,7 +135,7 @@ export const GET = async (
       count: (insights as any[]).length,
     })
   } catch (error: any) {
-    console.error("Failed to list insights:", error)
+    logger.error("Failed to list insights:", error)
     res.status(500).json({
       message: "Failed to list insights",
       error: error.message,
@@ -150,6 +152,7 @@ export const POST = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const body = req.body as Record<string, any>
@@ -164,7 +167,7 @@ export const POST = async (
 
     res.json({ insight })
   } catch (error: any) {
-    console.error("Failed to create insight:", error)
+    logger.error("Failed to create insight:", error)
     res.status(500).json({
       message: "Failed to create insight",
       error: error.message,

--- a/apps/backend/src/api/admin/meta-ads/lead-forms/route.ts
+++ b/apps/backend/src/api/admin/meta-ads/lead-forms/route.ts
@@ -123,6 +123,7 @@
  * }
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SOCIALS_MODULE } from "../../../../modules/socials"
 import SocialsService from "../../../../modules/socials/service"
 
@@ -135,6 +136,7 @@ export const GET = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const { platform_id } = req.query as Record<string, string>
@@ -151,7 +153,7 @@ export const GET = async (
       count: leadForms.length,
     })
   } catch (error: any) {
-    console.error("Failed to list lead forms:", error)
+    logger.error("Failed to list lead forms:", error)
     res.status(500).json({
       message: "Failed to list lead forms",
       error: error.message,
@@ -168,6 +170,7 @@ export const POST = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const body = req.body as Record<string, any>
@@ -176,7 +179,7 @@ export const POST = async (
 
     res.json({ leadForm })
   } catch (error: any) {
-    console.error("Failed to create lead form:", error)
+    logger.error("Failed to create lead form:", error)
     res.status(500).json({
       message: "Failed to create lead form",
       error: error.message,

--- a/apps/backend/src/api/admin/meta-ads/leads/[id]/route.ts
+++ b/apps/backend/src/api/admin/meta-ads/leads/[id]/route.ts
@@ -122,6 +122,7 @@
  * }
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SOCIALS_MODULE } from "../../../../../modules/socials"
 import SocialsService from "../../../../../modules/socials/service"
 
@@ -134,6 +135,7 @@ export const GET = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const { id } = req.params
@@ -148,7 +150,7 @@ export const GET = async (
 
     res.json({ lead })
   } catch (error: any) {
-    console.error("Failed to get lead:", error)
+    logger.error("Failed to get lead:", error)
     res.status(500).json({
       message: "Failed to get lead",
       error: error.message,
@@ -172,6 +174,7 @@ export const PATCH = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const { id } = req.params
@@ -227,7 +230,7 @@ export const PATCH = async (
 
     res.json({ lead })
   } catch (error: any) {
-    console.error("Failed to update lead:", error)
+    logger.error("Failed to update lead:", error)
     res.status(500).json({
       message: "Failed to update lead",
       error: error.message,
@@ -244,6 +247,7 @@ export const DELETE = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const { id } = req.params
@@ -259,7 +263,7 @@ export const DELETE = async (
       deleted: true,
     })
   } catch (error: any) {
-    console.error("Failed to delete lead:", error)
+    logger.error("Failed to delete lead:", error)
     res.status(500).json({
       message: "Failed to delete lead",
       error: error.message,

--- a/apps/backend/src/api/admin/meta-ads/leads/route.ts
+++ b/apps/backend/src/api/admin/meta-ads/leads/route.ts
@@ -128,6 +128,7 @@
  * }
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SOCIALS_MODULE } from "../../../../modules/socials"
 import SocialsService from "../../../../modules/socials/service"
 
@@ -151,6 +152,7 @@ export const GET = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     
@@ -228,7 +230,7 @@ export const GET = async (
       offset: parseInt(offset, 10),
     })
   } catch (error: any) {
-    console.error("Failed to list leads:", error)
+    logger.error("Failed to list leads:", error)
     res.status(500).json({
       message: "Failed to list leads",
       error: error.message,
@@ -245,6 +247,7 @@ export const POST = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const body = req.body as Record<string, any>
@@ -253,7 +256,7 @@ export const POST = async (
 
     res.json({ lead })
   } catch (error: any) {
-    console.error("Failed to create lead:", error)
+    logger.error("Failed to create lead:", error)
     res.status(500).json({
       message: "Failed to create lead",
       error: error.message,

--- a/apps/backend/src/api/admin/meta-ads/leads/sync/route.ts
+++ b/apps/backend/src/api/admin/meta-ads/leads/sync/route.ts
@@ -88,6 +88,7 @@
  * }
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SOCIALS_MODULE } from "../../../../../modules/socials"
 import SocialsService from "../../../../../modules/socials/service"
 import MetaAdsService from "../../../../../modules/social-provider/meta-ads-service"
@@ -107,6 +108,7 @@ export const POST = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
     const body = req.body as Record<string, any>
@@ -169,12 +171,12 @@ export const POST = async (
           const forms = await metaAds.listLeadForms(page.id, pageToken)
           formsToSync.push(...forms.map(f => f.id))
         } catch (error) {
-          console.error(`Failed to get forms for page ${page.id}:`, error)
+          logger.error(`Failed to get forms for page ${page.id}:`, error)
         }
       }
     }
 
-    console.log(`Syncing leads from ${formsToSync.length} forms`)
+    logger.info(`Syncing leads from ${formsToSync.length} forms`)
 
     // Sync leads from each form
     for (const formId of formsToSync) {
@@ -242,13 +244,13 @@ export const POST = async (
 
             results.synced++
           } catch (error) {
-            console.error(`Failed to create lead ${leadData.id}:`, error)
+            logger.error(`Failed to create lead ${leadData.id}:`, error)
             results.errors++
           }
         }
       } catch (error: any) {
         const errorMsg = error.message || `Failed to sync leads from form ${formId}`
-        console.error(`Failed to sync leads from form ${formId}:`, error)
+        logger.error(`Failed to sync leads from form ${formId}:`, error)
         results.errors++
         results.error_messages.push(errorMsg)
       }
@@ -270,7 +272,7 @@ export const POST = async (
       results,
     })
   } catch (error: any) {
-    console.error("Failed to sync leads:", error)
+    logger.error("Failed to sync leads:", error)
     res.status(500).json({
       message: "Failed to sync leads",
       error: error.message,

--- a/apps/backend/src/api/admin/oauth/[platform]/route.ts
+++ b/apps/backend/src/api/admin/oauth/[platform]/route.ts
@@ -16,6 +16,7 @@
  * @property {string} expiresAt - ISO 8601 timestamp when the token expires
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SOCIAL_PROVIDER_MODULE, SocialProviderService } from "../../../../modules/social-provider"
 import { EXTERNAL_STORES_MODULE, ExternalStoresService } from "../../../../modules/external_stores"
 import { initiateOauthWorkflow } from "../../../../workflows/socials/initiate-oauth"
@@ -36,6 +37,7 @@ export const GET = async (
   req: MedusaRequest,
   res: MedusaResponse
 ): Promise<void> => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const platform = req.params.platform as string | undefined
 
   if (!platform) {
@@ -76,7 +78,7 @@ export const GET = async (
         state,
       })
     } catch (error: any) {
-      console.error(`[OAuth] Failed to get auth URL for ${platform}:`, error.message)
+      logger.error(`[OAuth] Failed to get auth URL for ${platform}: ${error.message}`)
       res.status(500).json({ message: error.message })
     }
     
@@ -100,12 +102,12 @@ export const GET = async (
     }
     try {
       const token = await provider.getAppBearerToken()
-      console.log(`[App-Only OAuth] Got token for ${platform}:`, { token: token.token.substring(0, 20) + '...', expiresAt: token.expiresAt })
+      logger.info(`[App-Only OAuth] Got token for ${platform}: ${JSON.stringify({ token: token.token.substring(0, 20) + '...', expiresAt: token.expiresAt })}`)
       
       // For app-only flow, we need to store the credentials in the platform
       // This is especially important for Twitter which needs both OAuth 2.0 and OAuth 1.0a
       const platformId = req.query.platform_id as string
-      console.log(`[App-Only OAuth] Platform ID: ${platformId}, Platform: ${platformLower}`)
+      logger.info(`[App-Only OAuth] Platform ID: ${platformId}, Platform: ${platformLower}`)
       
       if (platformId && (platformLower === "twitter" || platformLower === "x")) {
         const socialsService = req.scope.resolve(SOCIALS_MODULE) as any
@@ -119,9 +121,9 @@ export const GET = async (
         const apiKey = process.env.X_API_KEY || process.env.TWITTER_API_KEY
         const apiSecret = process.env.X_API_SECRET || process.env.TWITTER_API_SECRET
         
-        console.log(`[App-Only OAuth] Storing credentials for platform ${platformId}`)
-        console.log(`[App-Only OAuth] Has API Key: ${!!apiKey}, Has API Secret: ${!!apiSecret}`)
-        console.log(`[App-Only OAuth] Existing OAuth 2.0 token: ${!!existingPlatform?.api_config?.access_token}`)
+        logger.info(`[App-Only OAuth] Storing credentials for platform ${platformId}`)
+        logger.info(`[App-Only OAuth] Has API Key: ${!!apiKey}, Has API Secret: ${!!apiSecret}`)
+        logger.info(`[App-Only OAuth] Existing OAuth 2.0 token: ${!!existingPlatform?.api_config?.access_token}`)
         
         const updated = await socialsService.updateSocialPlatforms({
           selector: { id: platformId },
@@ -143,10 +145,10 @@ export const GET = async (
           },
         })
         
-        console.log(`[App-Only OAuth] ✓ Credentials stored successfully for platform ${platformId}`)
-        console.log(`[App-Only OAuth] Updated platforms:`, updated?.length || 0)
+        logger.info(`[App-Only OAuth] ✓ Credentials stored successfully for platform ${platformId}`)
+        logger.info(`[App-Only OAuth] Updated platforms: ${updated?.length || 0}`)
       } else {
-        console.log(`[App-Only OAuth] Skipping storage - platformId: ${platformId}, platform: ${platformLower}`)
+        logger.info(`[App-Only OAuth] Skipping storage - platformId: ${platformId}, platform: ${platformLower}`)
       }
       
       res.status(200).json(token)
@@ -169,11 +171,11 @@ export const GET = async (
     ? (process.env.X_SCOPE || process.env.TWITTER_SCOPE || "")
     : (process.env[scopeEnvKey] ?? "")
   
-  console.log(`[OAuth Initiate] Platform: ${platform}`)
-  console.log(`[OAuth Initiate] Env Platform: ${envPlatform}`)
-  console.log(`[OAuth Initiate] Redirect Env Key: ${redirectEnvKey}`)
-  console.log(`[OAuth Initiate] Redirect URI: ${redirectUri}`)
-  console.log(`[OAuth Initiate] Scope: ${scope}`)
+  logger.info(`[OAuth Initiate] Platform: ${platform}`)
+  logger.info(`[OAuth Initiate] Env Platform: ${envPlatform}`)
+  logger.info(`[OAuth Initiate] Redirect Env Key: ${redirectEnvKey}`)
+  logger.info(`[OAuth Initiate] Redirect URI: ${redirectUri}`)
+  logger.info(`[OAuth Initiate] Scope: ${scope}`)
 
   const { result, errors } = await initiateOauthWorkflow(req.scope).run({
     input: {
@@ -185,7 +187,7 @@ export const GET = async (
 
   if (errors?.length > 0) {
     // TODO: Better error logging
-    console.warn("Workflow reported errors:", errors)
+    logger.warn(`Workflow reported errors: ${JSON.stringify(errors)}`)
     res.status(500).json({ message: "Workflow execution failed." })
     return
   }

--- a/apps/backend/src/api/admin/social-platforms/[id]/debug-token/route.ts
+++ b/apps/backend/src/api/admin/social-platforms/[id]/debug-token/route.ts
@@ -96,6 +96,7 @@
  * }
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
 /**
  * Debug Facebook token permissions
@@ -106,6 +107,7 @@ export const GET = async (
   res: MedusaResponse
 ) => {
   const { id } = req.params
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
 
   try {
     const socials = req.scope.resolve("socialsModuleService") as any
@@ -146,7 +148,7 @@ export const GET = async (
       const meResponse = await fetch(`https://graph.facebook.com/v21.0/me?access_token=${accessToken}`)
       entityInfo = await meResponse.json()
     } catch (error) {
-      console.warn("Could not fetch entity info:", error)
+      logger.warn(`Could not fetch entity info: ${error}`)
     }
 
     return res.json({
@@ -176,7 +178,7 @@ export const GET = async (
     })
 
   } catch (error) {
-    console.error("[Debug Token] Error:", error)
+    logger.error("[Debug Token] Error:", error)
     return res.status(500).json({ 
       error: "Failed to debug token",
       message: error.message 

--- a/apps/backend/src/api/admin/social-posts/[id]/sync-insights/route.ts
+++ b/apps/backend/src/api/admin/social-posts/[id]/sync-insights/route.ts
@@ -70,6 +70,7 @@
  * }
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SOCIALS_MODULE } from "../../../../../modules/socials"
 import SocialsService from "../../../../../modules/socials/service"
 import { PostInsightsService } from "../../../../../modules/socials/services/post-insights-service"
@@ -85,6 +86,7 @@ export const POST = async (
   res: MedusaResponse
 ) => {
   const { id } = req.params
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
   const insightsService = new PostInsightsService()
 
@@ -144,7 +146,7 @@ export const POST = async (
       for (const result of insights.publish_results) {
         if (result.response?.id) {
           platformPostId = result.response.id
-          console.log("[Sync Insights] Found platform post ID in publish_results:", platformPostId)
+          logger.info(`[Sync Insights] Found platform post ID in publish_results: ${platformPostId}`)
           break
         }
       }
@@ -166,7 +168,7 @@ export const POST = async (
         const match = url.match(/instagram\.com\/p\/([^\/\?]+)/)
         if (match) {
           platformPostId = match[1]
-          console.log("[Sync Insights] Extracted Instagram shortcode from URL:", platformPostId)
+          logger.info(`[Sync Insights] Extracted Instagram shortcode from URL: ${platformPostId}`)
         }
       }
       // Extract Facebook post ID from URL
@@ -175,15 +177,15 @@ export const POST = async (
                      url.match(/facebook\.com\/permalink\.php\?story_fbid=(\d+)/)
         if (match) {
           platformPostId = match[match.length - 1]
-          console.log("[Sync Insights] Extracted Facebook post ID from URL:", platformPostId)
+          logger.info(`[Sync Insights] Extracted Facebook post ID from URL: ${platformPostId}`)
         }
       }
     }
 
     if (!platformPostId) {
-      console.log("[Sync Insights] Available insights keys:", Object.keys(insights))
-      console.log("[Sync Insights] Insights structure:", JSON.stringify(insights, null, 2))
-      console.log("[Sync Insights] Post URL:", post.post_url)
+      logger.info(`[Sync Insights] Available insights keys: ${JSON.stringify(Object.keys(insights))}`)
+      logger.info(`[Sync Insights] Insights structure: ${JSON.stringify(insights, null, 2)}`)
+      logger.info(`[Sync Insights] Post URL: ${post.post_url}`)
       
       return res.status(400).json({ 
         error: "No platform post ID found. Post may not have been published successfully.",
@@ -224,7 +226,7 @@ export const POST = async (
       }
     }
     
-    console.log(`[Sync Insights] Using platform type: ${platformType} (detected: ${detectedPlatformType || 'none'})`)
+    logger.info(`[Sync Insights] Using platform type: ${platformType} (detected: ${detectedPlatformType || 'none'})`)
 
     // Sync insights
     const syncedInsights = await insightsService.syncPostInsights(
@@ -240,7 +242,7 @@ export const POST = async (
       insights: syncedInsights,
     })
   } catch (error) {
-    console.error("Error syncing insights:", error)
+    logger.error("Error syncing insights:", error)
     res.status(500).json({ 
       error: "Failed to sync insights",
       details: error.message 

--- a/apps/backend/src/api/admin/social-posts/route.ts
+++ b/apps/backend/src/api/admin/social-posts/route.ts
@@ -105,6 +105,7 @@
  * }
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { SocialPost } from "./validators";
 import { refetchSocialPost } from "./helpers";
 import { createSocialPostWorkflow } from "../../../workflows/socials/create-social-post";
@@ -160,7 +161,8 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
 };
 
 export const POST = async (req: MedusaRequest<SocialPost>, res: MedusaResponse) => {
-  console.log(req.validatedBody)
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  logger.info(`${JSON.stringify(req.validatedBody)}`)
   const { result } = await createSocialPostWorkflow(req.scope).run({
     input: req.validatedBody,
   });

--- a/apps/backend/src/api/admin/social-posts/sync-all-insights/route.ts
+++ b/apps/backend/src/api/admin/social-posts/sync-all-insights/route.ts
@@ -95,6 +95,7 @@
  * }
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SOCIALS_MODULE } from "../../../../modules/socials"
 import SocialsService from "../../../../modules/socials/service"
 import { PostInsightsService } from "../../../../modules/socials/services/post-insights-service"
@@ -111,6 +112,7 @@ export const POST = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
   const insightsService = new PostInsightsService()
 
@@ -141,7 +143,7 @@ export const POST = async (
       })
     }
 
-    console.log(`[Bulk Insights Sync] Found ${posts.length} posts to sync`)
+    logger.info(`[Bulk Insights Sync] Found ${posts.length} posts to sync`)
 
     // Group posts by platform for efficient syncing
     const postsByPlatform: Record<string, any[]> = {}
@@ -165,7 +167,7 @@ export const POST = async (
         const [platform] = await socials.listSocialPlatforms({ id: platformId })
         
         if (!platform) {
-          console.warn(`Platform ${platformId} not found, skipping posts`)
+          logger.warn(`Platform ${platformId} not found, skipping posts`)
           platformPosts.forEach(post => {
             allResults.push({
               postId: (post as any).id,
@@ -180,7 +182,7 @@ export const POST = async (
         const accessToken = (platform as any)?.api_config?.access_token
         
         if (!accessToken) {
-          console.warn(`Platform ${platformId} has no access token, skipping posts`)
+          logger.warn(`Platform ${platformId} has no access token, skipping posts`)
           platformPosts.forEach(post => {
             allResults.push({
               postId: (post as any).id,
@@ -258,9 +260,9 @@ export const POST = async (
         totalFailed += failed
         allResults.push(...results)
 
-        console.log(`[Bulk Insights Sync] Platform ${platformId}: ${success} success, ${failed} failed`)
+        logger.info(`[Bulk Insights Sync] Platform ${platformId}: ${success} success, ${failed} failed`)
       } catch (error) {
-        console.error(`[Bulk Insights Sync] Error syncing platform ${platformId}:`, error)
+        logger.error(`[Bulk Insights Sync] Error syncing platform ${platformId}:`, error)
         platformPosts.forEach(post => {
           allResults.push({
             postId: (post as any).id,
@@ -280,7 +282,7 @@ export const POST = async (
       results: allResults,
     })
   } catch (error) {
-    console.error("Error in bulk insights sync:", error)
+    logger.error("Error in bulk insights sync:", error)
     res.status(500).json({ 
       error: "Failed to sync insights",
       details: error.message 

--- a/apps/backend/src/api/admin/socials/facebook/pages/route.ts
+++ b/apps/backend/src/api/admin/socials/facebook/pages/route.ts
@@ -91,6 +91,7 @@
  * }
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { publishSocialPostWorkflow } from "../../../../../workflows/socials/publish-post"
 import { SOCIALS_MODULE } from "../../../../../modules/socials"
 import SocialsService from "../../../../../modules/socials/service"
@@ -109,6 +110,7 @@ export const POST = async (
   req: MedusaRequest<PublishByPostIdBody>,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const { post_id, page_id } = req.body || {}
 
   if (!post_id) {
@@ -116,7 +118,7 @@ export const POST = async (
     return
   }
 
-  console.warn(
+  logger.warn(
     "[DEPRECATED] POST /admin/socials/facebook/pages is deprecated. " +
     "Use POST /admin/social-posts/:id/publish instead."
   )
@@ -145,13 +147,14 @@ export const GET = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const platform_id = (req.query?.platform_id as string) || ""
   if (!platform_id) {
     res.status(400).json({ message: "Missing platform_id" })
     return
   }
 
-  console.warn(
+  logger.warn(
     "[DEPRECATED] GET /admin/socials/facebook/pages is deprecated. " +
     "Use platform.api_config.metadata.pages from the social platform instead."
   )

--- a/apps/backend/src/api/admin/socials/hashtags/route.ts
+++ b/apps/backend/src/api/admin/socials/hashtags/route.ts
@@ -53,6 +53,7 @@
  * }
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SOCIALS_MODULE } from "../../../../modules/socials"
 import SocialsService from "../../../../modules/socials/service"
 import { HashtagSearchService } from "../../../../modules/socials/services/hashtag-search-service"
@@ -74,6 +75,7 @@ export const GET = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
   const searchService = new HashtagSearchService()
   
@@ -83,7 +85,7 @@ export const GET = async (
   const limit = parseInt(req.query.limit as string) || 10
   const type = req.query.type as "suggestions" | "popular" | "recent" || "suggestions"
 
-  console.log("Hashtag API called:", { query, platform, platformId, limit, type })
+  logger.info(`Hashtag API called: ${JSON.stringify({ query, platform, platformId, limit, type })}`)
 
   let hashtags
 
@@ -122,7 +124,7 @@ export const GET = async (
             }
           }
         } catch (error) {
-          console.log("Could not get Instagram credentials:", error)
+          logger.info(`Could not get Instagram credentials: ${error}`)
         }
       }
 
@@ -136,7 +138,7 @@ export const GET = async (
             pageId = pages[0].id
           }
         } catch (error) {
-          console.log("Could not get Facebook page ID:", error)
+          logger.info(`Could not get Facebook page ID: ${error}`)
         }
       }
 
@@ -154,7 +156,7 @@ export const GET = async (
       )
     }
 
-    console.log("Hashtags found:", hashtags.length)
+    logger.info(`Hashtags found: ${hashtags.length}`)
 
     res.json({
       hashtags: hashtags.map(h => ({
@@ -165,7 +167,7 @@ export const GET = async (
       })),
     })
   } catch (error) {
-    console.error("Error fetching hashtags:", error)
+    logger.error("Error fetching hashtags:", error)
     res.json({ hashtags: [] })
   }
 }

--- a/apps/backend/src/api/admin/socials/mentions/route.ts
+++ b/apps/backend/src/api/admin/socials/mentions/route.ts
@@ -82,6 +82,7 @@
  * }
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { SOCIALS_MODULE } from "../../../../modules/socials"
 import SocialsService from "../../../../modules/socials/service"
 
@@ -98,13 +99,14 @@ export const GET = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const socials = req.scope.resolve(SOCIALS_MODULE) as SocialsService
-  
+
   const query = req.query.q as string || ""
   const platform = req.query.platform as "facebook" | "instagram" | "twitter" | undefined
   const limit = parseInt(req.query.limit as string) || 10
 
-  console.log("Mention API called:", { query, platform, limit })
+  logger.info(`Mention API called: ${JSON.stringify({ query, platform, limit })}`)
 
   let mentions
 
@@ -124,7 +126,7 @@ export const GET = async (
       mentions = await socials.getMentionSuggestions(query, platform, limit)
     }
 
-    console.log("Mentions found:", mentions.length)
+    logger.info(`Mentions found: ${mentions.length}`)
 
     res.json({
       mentions: mentions.map(m => ({
@@ -136,7 +138,7 @@ export const GET = async (
       })),
     })
   } catch (error) {
-    console.error("Error fetching mentions:", error)
+    logger.error("Error fetching mentions:", error)
     res.json({ mentions: [] })
   }
 }

--- a/apps/backend/src/api/admin/socials/publish-both/route.ts
+++ b/apps/backend/src/api/admin/socials/publish-both/route.ts
@@ -160,6 +160,7 @@
  * }
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { MedusaError } from "@medusajs/utils"
 import { SOCIALS_MODULE } from "../../../../modules/socials"
 import SocialsService from "../../../../modules/socials/service"
@@ -186,8 +187,9 @@ export const POST = async (
   req: MedusaRequest<{ post_id: string }>,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   // Log deprecation warning
-  console.warn(
+  logger.warn(
     "[DEPRECATED] POST /admin/socials/publish-both is deprecated. " +
     "Use POST /admin/social-posts/:id/publish instead. " +
     "This endpoint will be removed in a future version."

--- a/apps/backend/src/api/admin/socials/sync-platform-data/route.ts
+++ b/apps/backend/src/api/admin/socials/sync-platform-data/route.ts
@@ -69,6 +69,7 @@
  * }
  */
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { syncPlatformHashtagsMentionsWorkflow } from "../../../../workflows/socials/sync-platform-hashtags-mentions"
 import { SOCIALS_MODULE } from "../../../../modules/socials"
 import { decryptAccessToken } from "../../../../modules/socials/utils/token-helpers"
@@ -85,6 +86,7 @@ export const POST = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const { platform_id } = req.body as { platform_id: string }
 
   if (!platform_id) {
@@ -131,7 +133,7 @@ export const POST = async (
       results: result,
     })
   } catch (error) {
-    console.error("Error syncing platform data:", error)
+    logger.error("Error syncing platform data:", error)
     res.status(500).json({ 
       error: "Failed to sync platform data",
       details: error.message 


### PR DESCRIPTION
## What

Wave **3a** of #701 (logger standardization). Migrates runtime `console.*` calls to the Medusa structured logger across part of `src/api/admin` — the social/ads subtrees:

- `src/api/admin/meta-ads` (49)
- `src/api/admin/social-posts` (15)
- `src/api/admin/oauth` (15)
- `src/api/admin/socials` (12)
- `src/api/admin/social-platforms` (2)
- `src/api/admin/ad-planning` (1)

**30 files, ~94 calls.**

## Pattern (mirrors the merged seed/wave references)

Each handler resolves the logger once:
```ts
import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
```
(Same as `src/api/admin/ops/maintenance-jobs/batches/route.ts:55`.)

Mapping: `console.log → logger.info`, `console.error → logger.error`, `console.warn → logger.warn`.
- `logger.error` keeps the `(message, error)` two-arg form.
- `info`/`warn`/`debug` take a **single string**, so any 2nd-arg object/value is folded into the template (`JSON.stringify` where it was an object).
- All `[tag]` prefixes and message text kept **verbatim**. No behavior change beyond the logging transport.

## Notes

- The only remaining `console.*` matches in these dirs are **4 JSDoc usage examples** (fetch/promise snippets in `/** */` comments in `ads/[id]/status` and `adsets/[id]/status`) — not runtime code, intentionally left.
- The bulk meta-ads edits were drafted by the free model and **verified by Claude** (diff reviewed + typechecked); the object-folding cases (oauth/socials/social-posts) were done by hand.

## Verify

- `npx tsc --noEmit` — **no new TS errors** in any edited file (69 pre-existing errors elsewhere — admin UI components, unrelated web routes — are not touched).
- Mechanical 1:1 transport swaps; no control-flow change, so no new tests.
- `grep -rn "console\." src/api/admin/{meta-ads,social-posts,oauth,socials,social-platforms,ad-planning}` → only the 4 documented JSDoc lines remain.

PR-only — leaving for human review. Does **not** touch `src/scripts` or tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)