### PR TITLE
docs(analytics): #660 UTM tracker verified — deployed bundle is current, not stale (no code fix)

### DIFF
--- a/apps/docs/notes/660_UTM_TRACKER_VERIFICATION.md
+++ b/apps/docs/notes/660_UTM_TRACKER_VERIFICATION.md
@@ -1,0 +1,80 @@
+# #660 — utm_source=(none): tracker verification (NOT a stale-build bug)
+
+**Date:** 2026-06-24
+**Outcome:** No code fix required. The deployed analytics tracker correctly
+captures UTM. The `(none)` values are legitimate untagged organic/direct
+traffic. Recommend close-as-not-a-bug after the one tagged-URL test below.
+
+## TL;DR
+The hypothesis in #660 (and the daemon brief) was that the **deployed**
+`analytics.min.js` is a stale build that never sends UTM. **This is false.**
+
+- `apps/analytics/dist/` is **gitignored** (`apps/analytics/.gitignore` → `dist/`).
+  Nothing in `dist/` is committed. The local `dist/analytics.min.js` (mtime
+  Jun 20) is just a throwaway local artifact — it is NOT what prod serves.
+- The deployed bundle is built **fresh by CI** from `src/analytics.js` on every
+  push to `main` touching `apps/analytics/**`
+  (`.github/workflows/deploy-analytics.yml` → Terser build → Cloudflare R2 →
+  cache purge). CDN: `https://automatic.jaalyantra.com/analytics.min.js`.
+
+## Evidence (2026-06-24)
+1. **origin/main source already captures UTM.** `src/analytics.js:82 getUTMParams()`
+   reads `new URLSearchParams(window.location.search)` over all 5 keys
+   (`utm_source/medium/campaign/term/content`), stores first-touch in
+   `sessionStorage['jyt_utm']`, and merges into the pageview payload
+   (`trackPageview()` ~L191-195). Last commit touching it: #572 (Jun 21 09:59).
+2. **The LIVE CDN bundle contains UTM capture.**
+   `curl -s https://automatic.jaalyantra.com/analytics.min.js` → 5× `utm_source`,
+   19× `utm_`, `URLSearchParams`, `jyt_utm`. Preamble `v1.0.0`.
+3. **Live bundle == fresh source build, byte-for-byte.**
+   `node apps/analytics/scripts/build.js` then
+   `diff <live> <dist/analytics.min.js>` → IDENTICAL. Deployed == current source.
+4. **Backend ingestion works live.** `POST https://v3.jaalyantra.com/web/analytics/track`
+   with `utm_source/medium/campaign` → HTTP 200. Routes
+   `src/api/web/analytics/track/route.ts` + `ingest-batch/route.ts` accept utm_*
+   (zod optional); `src/workflows/analytics/track-analytics-event.ts` persists
+   `input.utm_source || null` as first-touch on the session.
+5. **DB (from #660):** 33/33 sessions have `utm_source=NULL`, split 18
+   `referrer_source=google` (organic) + 15 `direct` — all legitimately UTM-less.
+
+Conclusion: client → endpoint → store is fully functional. `(none)` = no
+UTM-tagged traffic has landed yet, not a capture/build defect.
+
+## Why "commit the rebuilt dist" would be WRONG
+`dist/` is intentionally gitignored and rebuilt by CI. Committing it would
+(a) contradict the deploy design and (b) create exactly the stale-committed-dist
+risk the issue feared (a hand-committed copy drifting from source). Do not
+un-gitignore `dist/`.
+
+## Definitive test to close the issue
+Visit any partner storefront that loads the snippet with a tagged URL:
+```
+https://<partner-storefront>/?utm_source=test&utm_medium=cpc&utm_campaign=qa
+```
+Then on the analytics DB:
+```sql
+SELECT utm_source, utm_medium, utm_campaign, referrer_source, created_at
+FROM analytics_session ORDER BY created_at DESC LIMIT 3;
+```
+- New row shows `utm_source=test` → tracker works; close as not-a-bug.
+- Stays NULL → snippet not installed on that storefront, or `data-api-url`
+  points away from the session-creating route → fix snippet/wiring (suspect #3),
+  NOT the bundle.
+
+## Campaign-link QA checklist (prevent future `(none)` confusion)
+- Always tag outbound campaign links with `utm_source` + `utm_medium`
+  (+ `utm_campaign` for attribution back-fill).
+- First landing pageview must fire with the `?utm…` query intact — don't strip
+  query before the tracker loads (server redirect that drops query = lost UTM).
+- SPA navigations after landing reuse first-touch `jyt_utm` from sessionStorage;
+  the landing pageview is the one that must carry UTM.
+
+## Deploy-path reference
+- Source: `apps/analytics/src/analytics.js`
+- Build: `node apps/analytics/scripts/build.js` (or `pnpm --filter @jyt/analytics build`)
+- Output (gitignored): `apps/analytics/dist/analytics.min.js`
+- CI: `.github/workflows/deploy-analytics.yml` (push to main on `apps/analytics/**`)
+- CDN: `https://automatic.jaalyantra.com/analytics.min.js` (R2, 1y cache, purged on deploy)
+- Endpoint default: `https://v3.jaalyantra.com/web/analytics/track`
+- To force a redeploy without a source change: re-run the workflow via
+  `workflow_dispatch` (it has `workflow_dispatch:` enabled).


### PR DESCRIPTION
## Summary
Investigated #660 (`utm_source=(none)` for ~all sessions). The brief's hypothesis was that the **deployed** `apps/analytics/dist/analytics.min.js` is a stale build that never sends UTM. **That is false** — verified end-to-end. No code fix is required; this PR adds a grounded verification note + the test to close the issue.

## Why "rebuild + commit the dist" is not the fix
- `apps/analytics/dist/` is **gitignored** (`apps/analytics/.gitignore` → `dist/`). Nothing in `dist/` is committed. The Jun‑20 local artifact is irrelevant — it is **not** what prod serves.
- The deployed bundle is built **fresh by CI** from `src/analytics.js` on every push to `main` touching `apps/analytics/**` (`.github/workflows/deploy-analytics.yml` → Terser → Cloudflare R2 → cache purge). CDN: `https://automatic.jaalyantra.com/analytics.min.js`.
- Committing `dist/` would contradict the deploy design and reintroduce the exact stale‑committed‑dist drift the issue feared. **Do not un‑gitignore `dist/`.**

## Evidence (2026-06-24)
1. origin/main `src/analytics.js:82 getUTMParams()` captures all 5 utm keys from `window.location.search`, first‑touch to `sessionStorage['jyt_utm']`, merged into the pageview payload (~L191). Last touched by #572 (Jun 21).
2. **Live CDN bundle contains UTM capture:** `curl` → 5× `utm_source`, 19× `utm_`, `URLSearchParams`, `jyt_utm`.
3. **Live bundle == fresh source build, byte‑for‑byte:** `node apps/analytics/scripts/build.js` then `diff` vs the CDN file → IDENTICAL. Deployed == current source.
4. **Backend ingestion works live:** `POST https://v3.jaalyantra.com/web/analytics/track` with `utm_*` → **HTTP 200**. Routes accept utm_* (zod optional); workflow persists first‑touch `utm_source || null`.
5. DB (from #660): 33/33 sessions `utm_source=NULL` = 18 google‑organic + 15 direct — all legitimately UTM‑less.

**Conclusion:** client → endpoint → store is fully functional. `(none)` = no UTM‑tagged traffic has landed yet, not a capture/build defect.

## To close #660 (one manual step — needs analytics DB access)
Visit a partner storefront with `?utm_source=test&utm_medium=cpc&utm_campaign=qa`, then:
```sql
SELECT utm_source, utm_medium, utm_campaign, referrer_source, created_at
FROM analytics_session ORDER BY created_at DESC LIMIT 3;
```
- Shows `utm_source=test` → close as **not‑a‑bug**.
- Stays NULL → snippet not installed / `data-api-url` misrouted on that storefront (suspect #3) → fix wiring, **not** the bundle.

## Deploy note
No prod redeploy needed (the CDN already serves the correct bundle). If a forced redeploy is ever wanted, the workflow has `workflow_dispatch` enabled.

Doc: `apps/docs/notes/660_UTM_TRACKER_VERIFICATION.md`. Docs‑only; no code/test changes.

Refs #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)