### PR TITLE
fix(#486): partner orders list honors all filters + sort

### DIFF
--- a/apps/backend/src/api/partners/orders/__tests__/list-params.unit.spec.ts
+++ b/apps/backend/src/api/partners/orders/__tests__/list-params.unit.spec.ts
@@ -1,0 +1,80 @@
+import {
+  buildPartnerOrderListParams,
+  parseOrderParam,
+} from "../list-params"
+
+describe("parseOrderParam (#486 partner orders sort)", () => {
+  it("defaults to newest-first when unset/blank", () => {
+    expect(parseOrderParam(undefined)).toEqual({ created_at: "DESC" })
+    expect(parseOrderParam("")).toEqual({ created_at: "DESC" })
+    expect(parseOrderParam("   ")).toEqual({ created_at: "DESC" })
+  })
+
+  it("maps a leading '-' to DESC and a bare field to ASC", () => {
+    expect(parseOrderParam("-created_at")).toEqual({ created_at: "DESC" })
+    expect(parseOrderParam("display_id")).toEqual({ display_id: "ASC" })
+    expect(parseOrderParam("-updated_at")).toEqual({ updated_at: "DESC" })
+  })
+
+  it("ignores non-string input and falls back to the default", () => {
+    expect(parseOrderParam(42 as any)).toEqual({ created_at: "DESC" })
+    expect(parseOrderParam({} as any)).toEqual({ created_at: "DESC" })
+  })
+})
+
+describe("buildPartnerOrderListParams (#486 partner orders filters)", () => {
+  it("forwards universal filters for every kind (the dropped-filter bug)", () => {
+    const created = { $gte: "2026-01-01", $lte: "2026-02-01" }
+    const { baseFilters } = buildPartnerOrderListParams(
+      { status: "completed", q: "acme", created_at: created, updated_at: created },
+      "retail"
+    )
+    expect(baseFilters).toEqual({
+      status: "completed",
+      q: "acme",
+      created_at: created,
+      updated_at: created,
+    })
+  })
+
+  it("forwards region/sales_channel ONLY for retail", () => {
+    const q = { region_id: ["reg_1"], sales_channel_id: ["sc_1"], q: "x" }
+    expect(buildPartnerOrderListParams(q, "retail").baseFilters).toEqual({
+      q: "x",
+      region_id: ["reg_1"],
+      sales_channel_id: ["sc_1"],
+    })
+    // Work-order kinds live in the internal channel + carry no region, so these
+    // must be dropped or they'd filter every work-order out (empty table).
+    expect(buildPartnerOrderListParams(q, "design").baseFilters).toEqual({ q: "x" })
+    expect(buildPartnerOrderListParams(q, "inventory").baseFilters).toEqual({ q: "x" })
+    expect(buildPartnerOrderListParams(q, "all").baseFilters).toEqual({ q: "x" })
+  })
+
+  it("omits absent / blank filters rather than sending empty values", () => {
+    const { baseFilters } = buildPartnerOrderListParams(
+      { status: "", q: "   ", created_at: undefined },
+      "retail"
+    )
+    expect(baseFilters).toEqual({})
+  })
+
+  it("derives skip/take from offset/limit with sane defaults", () => {
+    expect(buildPartnerOrderListParams({}, "retail")).toMatchObject({
+      skip: 0,
+      take: 20,
+    })
+    expect(
+      buildPartnerOrderListParams({ offset: "40", limit: "50" }, "retail")
+    ).toMatchObject({ skip: 40, take: 50 })
+  })
+
+  it("always returns a sort (default newest-first), honoring the UI's order param", () => {
+    expect(buildPartnerOrderListParams({}, "design").order).toEqual({
+      created_at: "DESC",
+    })
+    expect(
+      buildPartnerOrderListParams({ order: "display_id" }, "retail").order
+    ).toEqual({ display_id: "ASC" })
+  })
+})

--- a/apps/backend/src/api/partners/orders/list-params.ts
+++ b/apps/backend/src/api/partners/orders/list-params.ts
@@ -1,0 +1,78 @@
+import type { PartnerOrderKind } from "./validators"
+
+// #486 — the partner orders list (GET /partners/orders) used to forward ONLY
+// `status` + `q` into the orders workflow, so every other filter the partner-UI
+// sends (date ranges, region, sales channel) AND the sort dropdown were silently
+// dropped → "the filters don't work". Admin's orders route honors all of these
+// via `req.filterableFields` + `req.queryConfig.pagination.order`; we don't run
+// that middleware (the `?kind=` discriminator must not reach the orders filters),
+// so we map the same params here, by hand, in a pure + unit-testable helper.
+
+// Filters that apply to EVERY order row regardless of kind.
+const UNIVERSAL_FILTER_KEYS = ["status", "q", "created_at", "updated_at"] as const
+
+// Region / sales-channel are a retail concept. Design/inventory work-orders live
+// in the internal PARTNER_WORK_ORDERS_CHANNEL and carry no region, so forwarding
+// these for a work-order kind would filter every work-order out (empty table).
+// They're only meaningful on the retail tab.
+const RETAIL_ONLY_FILTER_KEYS = ["region_id", "sales_channel_id"] as const
+
+export type PartnerOrderListParams = {
+  baseFilters: Record<string, any>
+  order: Record<string, "ASC" | "DESC">
+  skip: number
+  take: number
+}
+
+const isPresent = (v: unknown): boolean =>
+  v !== undefined &&
+  v !== null &&
+  !(typeof v === "string" && v.trim() === "")
+
+// Translate the UI's `order` query param (`-created_at`, `display_id`, …) into
+// the remote-query order object (`{ created_at: "DESC" }`). Leading `-` = DESC.
+// Unset / blank → newest-first (`-created_at`), matching the UI's own default —
+// so design/inventory work-orders stop coming back in arbitrary DB order.
+export function parseOrderParam(
+  raw: unknown
+): Record<string, "ASC" | "DESC"> {
+  const str =
+    typeof raw === "string" && raw.trim() ? raw.trim() : "-created_at"
+  const desc = str.startsWith("-")
+  const field = (desc ? str.slice(1) : str).trim()
+  if (!field) {
+    return { created_at: "DESC" }
+  }
+  return { [field]: desc ? "DESC" : "ASC" }
+}
+
+export function buildPartnerOrderListParams(
+  query: Record<string, unknown> = {},
+  kind: PartnerOrderKind = "retail"
+): PartnerOrderListParams {
+  const baseFilters: Record<string, any> = {}
+
+  for (const key of UNIVERSAL_FILTER_KEYS) {
+    if (isPresent(query[key])) {
+      baseFilters[key] = query[key]
+    }
+  }
+
+  if (kind === "retail") {
+    for (const key of RETAIL_ONLY_FILTER_KEYS) {
+      if (isPresent(query[key])) {
+        baseFilters[key] = query[key]
+      }
+    }
+  }
+
+  const take = Number(query.limit) || 20
+  const skip = Number(query.offset) || 0
+
+  return {
+    baseFilters,
+    order: parseOrderParam(query.order),
+    skip,
+    take,
+  }
+}

--- a/apps/backend/src/api/partners/orders/route.ts
+++ b/apps/backend/src/api/partners/orders/route.ts
@@ -1,6 +1,7 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { tryGetPartnerSalesChannelId } from "../helpers"
 import { PartnerGetOrdersKindParam } from "./validators"
+import { buildPartnerOrderListParams } from "./list-params"
 import { listPartnerOrdersWorkflow } from "../../../workflows/orders/list-partner-orders"
 
 // IMPORTANT: use the `relation.*` suffix syntax, not `*relation` prefix.
@@ -48,28 +49,31 @@ export const GET = async (
   const { kind } = PartnerGetOrdersKindParam.parse({
     kind: (req.query as Record<string, unknown>)?.kind,
   })
+  const resolvedKind = kind ?? "retail"
 
   const { partner, salesChannelId } = await tryGetPartnerSalesChannelId(
     req.auth_context,
     req.scope
   )
 
-  const query = req.query || {}
-  const limit = Number(query.limit) || 20
-  const offset = Number(query.offset) || 0
+  // #486: honor ALL the filter + sort params the partner-UI sends (date ranges,
+  // region/sales-channel for retail, search) — not just status/q — plus the
+  // `order` sort, mirroring admin. Pure helper keeps the param mapping testable.
+  const { baseFilters, order, skip, take } = buildPartnerOrderListParams(
+    (req.query as Record<string, unknown>) || {},
+    resolvedKind
+  )
 
   const { result } = await listPartnerOrdersWorkflow(req.scope).run({
     input: {
       partnerId: partner?.id ?? null,
       salesChannelId,
-      kind: kind ?? "retail",
+      kind: resolvedKind,
       fields: DEFAULT_FIELDS,
-      baseFilters: {
-        ...(query.status ? { status: query.status } : {}),
-        ...(query.q ? { q: query.q } : {}),
-      },
-      skip: offset,
-      take: limit,
+      baseFilters,
+      order,
+      skip,
+      take,
     },
   })
 

--- a/apps/backend/src/workflows/orders/list-partner-orders.ts
+++ b/apps/backend/src/workflows/orders/list-partner-orders.ts
@@ -29,8 +29,12 @@ export type ListPartnerOrdersWorkflowInput = {
   salesChannelId?: string | null
   kind: PartnerOrderKind
   fields: string[]
-  // status / q passthrough — folded into every kind's filter unchanged.
+  // status / q / date / region passthrough — folded into every kind's filter
+  // unchanged (the route's pure helper decides which are kind-safe). #486.
   baseFilters?: Record<string, any>
+  // Remote-query sort, e.g. `{ created_at: "DESC" }` — mirrors admin's
+  // `queryConfig.pagination.order`. Defaults to newest-first at the route. #486.
+  order?: Record<string, "ASC" | "DESC">
   skip: number
   take: number
 }
@@ -155,6 +159,9 @@ export const listPartnerOrdersWorkflow = createWorkflow(
         filters: plan.filters,
         skip: input.skip,
         take: input.take,
+        // #486: sort is a sibling of `filters` in remote-query variables, exactly
+        // as admin's route spreads `queryConfig.pagination` (skip/take/order).
+        ...(input.order ? { order: input.order } : {}),
       },
     }))
 


### PR DESCRIPTION
Closes part of #486 (parts 1 & 2 — filters + ordering).

## Root cause
`apps/backend/src/api/partners/orders/route.ts` forwarded **only** `status` and `q` into the orders workflow's `baseFilters`. The partner-UI (`useOrderTableQuery`) sends far more — `created_at`/`updated_at` date ranges, `region_id`, `sales_channel_id`, and the `order` sort param — **all silently dropped**.

- **#486.1 "filters don't work":** the date / region / sales-channel filters in the partner-UI did nothing because the API never read them. The UI side is correct; this is a backend bug.
- **#486.2 "orders/design shows weird data":** the workflow never set `order` in the remote-query `variables`, so design/inventory work-orders came back in arbitrary DB order. Honoring the sort (default `-created_at`) makes them deterministic — newest/incoming first.

Admin's orders route honors all these via `req.filterableFields` + `req.queryConfig.pagination.order`. We deliberately skip that middleware (the `?kind=` discriminator must not reach the orders filters), so we mirror the same mapping by hand.

## Change (backend-only)
- **New pure helper** `src/api/partners/orders/list-params.ts` — `buildPartnerOrderListParams(query, kind)` + `parseOrderParam`:
  - forwards `status`, `q`, `created_at`, `updated_at` for **every** kind;
  - forwards `region_id`, `sales_channel_id` **only for `retail`** (work orders live in the internal `PARTNER_WORK_ORDERS_CHANNEL` and carry no region — forwarding these for a work-order kind would filter every row out);
  - parses `order` (`-created_at` → `{ created_at: "DESC" }`), defaulting to newest-first.
- **`route.ts`** uses the helper instead of the hand-picked `status`/`q` only.
- **`list-partner-orders.ts` workflow** accepts an optional `order` and threads it into the remote-query `variables` as a sibling of `filters` — exactly how admin spreads `queryConfig.pagination` (skip/take/order).

## Verification
- `src/api/partners/orders/__tests__/list-params.unit.spec.ts` — **8 unit tests** (dropped-filter fix, retail-only region/channel, blank-omission, skip/take defaults, sort parsing incl. default). All green.
- `tsc --noEmit`: zero new errors (total 69 ≤ pre-existing ~70 baseline).

## Manual verification (partner-UI, not Playwright-gated since UI is unchanged)
On the partner portal Orders list: apply a created-at date filter / change the sort dropdown / (on retail) a region or sales-channel filter — results now actually filter & reorder. The `/orders/design` and `/orders/inventory` tabs now list newest-first instead of arbitrary order.

## Out of scope (left for follow-up under #486)
- **#486.2 status-priority ordering** ("not-yet-accepted on top, completed at bottom"): needs a *derived* sort on the linked `unified_order_status.partner_status` sidecar, which remote-query can't order on cleanly (enum string ≠ lifecycle priority). Deferred — the deterministic newest-first default already removes the "weird/arbitrary" ordering.
- **#486.3** the inventory-order→partner WhatsApp admin visual flow — a separate feature, not part of this filter/table fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)