### PR TITLE
fix(consumption_log): widen consumption_type check constraint on prod (#697)

### DIFF
--- a/apps/backend/src/modules/consumption_log/migrations/Migration20260624140000.ts
+++ b/apps/backend/src/modules/consumption_log/migrations/Migration20260624140000.ts
@@ -1,0 +1,61 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Repair migration — widen the `consumption_type` check constraint on
+ * `consumption_log` to include the energy/labor values.
+ *
+ * Why this is needed (#697): the model enum
+ * (`models/consumption-log.ts`) AND the `create table` statement in
+ * `Migration20260414104644` both already list all 7 values
+ * (`sample`, `production`, `wastage`, `energy_electricity`,
+ * `energy_water`, `energy_gas`, `labor`). But on databases where
+ * `consumption_log` was first created by that migration BEFORE the
+ * energy and labor values were added, the `create table IF NOT EXISTS`
+ * was a no-op on every later run, so the live check constraint still
+ * only permits the original narrow set
+ * (`sample`, `production`, `wastage`). No ALTER ever widened it.
+ *
+ * Symptom on prod (verified 2026-06-24): the
+ * `backfill-finished-run-consumption` job applied but every labor/energy
+ * INSERT was rejected with
+ * `new row for relation "consumption_log" violates check constraint
+ *  "consumption_log_consumption_type_check"` — so production-run
+ * cost-summary energy/labor totals stayed 0.
+ *
+ * `medusa db:generate` produces NO diff here (model and snapshot already
+ * match), so this drift can only be fixed with a hand-written ALTER.
+ *
+ * The constraint name is MikroORM's inline-column-check convention:
+ * `<table>_<column>_check` = `consumption_log_consumption_type_check`
+ * (confirmed by the prod error message).
+ *
+ * drop-if-exists + re-add makes this idempotent and safe to run on DBs
+ * that already have the wide constraint (created fresh from the newer
+ * create statement).
+ *
+ * AFTER deploy: re-run the `backfill-finished-run-consumption` job
+ * (dry-run → apply) via Settings → Data Plumbing for the energy/labor
+ * logs to actually land.
+ */
+export class Migration20260624140000 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(
+      `alter table if exists "consumption_log" drop constraint if exists "consumption_log_consumption_type_check";`
+    );
+    this.addSql(
+      `alter table if exists "consumption_log" add constraint "consumption_log_consumption_type_check" check ("consumption_type" in ('sample', 'production', 'wastage', 'energy_electricity', 'energy_water', 'energy_gas', 'labor'));`
+    );
+  }
+
+  override async down(): Promise<void> {
+    // Widening is non-destructive; the prior narrower set is not reliably
+    // known across DBs, so re-add the same wide constraint rather than
+    // guessing and rejecting rows that were valid at down-migration time.
+    this.addSql(
+      `alter table if exists "consumption_log" drop constraint if exists "consumption_log_consumption_type_check";`
+    );
+    this.addSql(
+      `alter table if exists "consumption_log" add constraint "consumption_log_consumption_type_check" check ("consumption_type" in ('sample', 'production', 'wastage', 'energy_electricity', 'energy_water', 'energy_gas', 'labor'));`
+    );
+  }
+}


### PR DESCRIPTION
## #697 — `consumption_log_consumption_type_check` too narrow on prod

### Root cause (verified on prod 2026-06-24)
The `backfill-finished-run-consumption` job applied, but **every** labor/energy INSERT was rejected:

```
new row for relation "consumption_log" violates check constraint
"consumption_log_consumption_type_check"   (consumption_type='labor')
```

The model enum (`models/consumption-log.ts`) **and** the create-table statement in `Migration20260414104644` **and** the module snapshot all already list all 7 values (`sample, production, wastage, energy_electricity, energy_water, energy_gas, labor`). So `medusa db:generate consumption_log` produces **no diff**.

The drift is between the model and **prod's live DB**: prod's `consumption_log` table was created by `Migration20260414104644`'s `create table if not exists` **before** the energy/labor values were added. Once the table existed, the `if not exists` guard made every later run a no-op, so the widened check never landed and no ALTER ever shipped. `cost-summary` reads `energy_electricity/energy_water/energy_gas` + `labor` → stays 0.

This is the documented `create table if not exists` hazard (same class as the `production_run_id` repair in `Migration20260605120000` and the `page_page_type_check` ALTER for #659).

### The fix
New hand-written migration `Migration20260624140000.ts`:
- `up()` — `drop constraint if exists` then `add constraint ... check (consumption_type in (<all 7 values>))`
- `down()` — same drop + re-add of the wide set (widening is non-destructive; the prior narrow set isn't reliably known across DBs)
- Idempotent (`drop ... if exists`) and safe on DBs that already have the wide constraint (fresh DBs created from the newer create statement).

Constraint name `consumption_log_consumption_type_check` follows MikroORM's inline-column-check convention (`<table>_<column>_check`) and is confirmed by the prod error.

Model and create-table migration are **untouched** (both already correct).

### Verification
- ✅ Typecheck clean on the changed file (`tsc --noEmit`).
- ⚠️ **No integration test added — and here's why:** a fresh test DB is built from migrations where `Migration20260414104644`'s create-table statement *already* contains the wide constraint, so inserting `consumption_type='labor'` succeeds **with or without** this migration. A test would pass regardless and would not guard the prod-only drift. The fix is a pure DDL repair for live databases.

### ⚠️ Operator action required AFTER merge + deploy
The migration only widens the constraint. The energy/labor logs that were previously rejected are **not** retroactively inserted. The operator must **re-run** the `backfill-finished-run-consumption` job (dry-run → apply) via **Settings → Data Plumbing**. Only then does `cost-summary` show non-zero energy/labor (e.g. run `prod_run_01KMQ7SFAFV4AV7EJZADNG7D5W`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)