### PR TITLE
fix(whatsapp): draft-product confirmation links point to partner portal (#707)

### DIFF
--- a/apps/backend/src/scripts/seed-partner-product-create-flow.ts
+++ b/apps/backend/src/scripts/seed-partner-product-create-flow.ts
@@ -257,7 +257,7 @@ const FLOW_DEF = {
         mode:       "interactive",
         interactive_body:
           "✅ Draft product created: *{{ create_draft.result.product_title }}*\n" +
-          "Admin: {{ create_draft.result.admin_url }}\n\n" +
+          "Open in your portal: {{ create_draft.result.admin_url }}\n\n" +
           "Tap *Confirm* to publish, or *Cancel* to remove the draft.",
         interactive_buttons: [
           { id: "wa_pc_confirm:{{ create_draft.result.product_id }}", title: "✅ Confirm" },

--- a/apps/backend/src/workflows/whatsapp/__tests__/partner-product-url.unit.spec.ts
+++ b/apps/backend/src/workflows/whatsapp/__tests__/partner-product-url.unit.spec.ts
@@ -1,0 +1,55 @@
+import { buildPartnerProductUrl } from "../partner-product-url"
+
+describe("buildPartnerProductUrl", () => {
+  const ORIGINAL = { ...process.env }
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL }
+  })
+
+  it("uses an explicit base + partner product-detail path", () => {
+    expect(
+      buildPartnerProductUrl("prod_123", "https://partner.jaalyantra.com")
+    ).toBe("https://partner.jaalyantra.com/products/prod_123")
+  })
+
+  it("trims a trailing slash from the base", () => {
+    expect(
+      buildPartnerProductUrl("prod_123", "https://partner.jaalyantra.com/")
+    ).toBe("https://partner.jaalyantra.com/products/prod_123")
+  })
+
+  it("falls back to PARTNER_APP_URL when no base is given", () => {
+    delete process.env.PARTNER_PORTAL_URL
+    process.env.PARTNER_APP_URL = "https://app.example.com"
+    expect(buildPartnerProductUrl("prod_9")).toBe(
+      "https://app.example.com/products/prod_9"
+    )
+  })
+
+  it("falls back to PARTNER_PORTAL_URL when PARTNER_APP_URL is unset", () => {
+    delete process.env.PARTNER_APP_URL
+    process.env.PARTNER_PORTAL_URL = "https://portal.example.com"
+    expect(buildPartnerProductUrl("prod_9")).toBe(
+      "https://portal.example.com/products/prod_9"
+    )
+  })
+
+  it("defaults to partner.jaalyantra.com when nothing is configured", () => {
+    delete process.env.PARTNER_APP_URL
+    delete process.env.PARTNER_PORTAL_URL
+    expect(buildPartnerProductUrl("prod_x")).toBe(
+      "https://partner.jaalyantra.com/products/prod_x"
+    )
+  })
+
+  it("ignores the admin base (MEDUSA_BACKEND_URL) entirely", () => {
+    delete process.env.PARTNER_APP_URL
+    delete process.env.PARTNER_PORTAL_URL
+    process.env.MEDUSA_BACKEND_URL = "https://v3.jaalyantra.com"
+    const url = buildPartnerProductUrl("prod_x")
+    expect(url).not.toContain("v3.jaalyantra.com")
+    expect(url).not.toContain("/app/products")
+    expect(url).toBe("https://partner.jaalyantra.com/products/prod_x")
+  })
+})

--- a/apps/backend/src/workflows/whatsapp/create-draft-product-from-extraction.ts
+++ b/apps/backend/src/workflows/whatsapp/create-draft-product-from-extraction.ts
@@ -12,6 +12,7 @@ import {
 } from "@medusajs/framework/utils"
 import { createProductsWorkflow } from "@medusajs/medusa/core-flows"
 import { downloadAndSaveWhatsAppMedia } from "./whatsapp-media-helper"
+import { buildPartnerProductUrl } from "./partner-product-url"
 
 /**
  * Build a draft product from WhatsApp message extraction.
@@ -303,13 +304,11 @@ export const createDraftProductFromExtractionWorkflow = createWorkflow(
         ({ created, media }): CreateDraftProductFromExtractionResult => ({
           product_id: created.product_id,
           product_title: created.product_title,
-          // Build an absolute admin URL when MEDUSA_BACKEND_URL is set so the
-          // partner can tap the link from the WhatsApp reply directly. Falls
-          // back to the relative path for local dev and tests where no
-          // public hostname is configured.
-          admin_url: process.env.MEDUSA_BACKEND_URL
-            ? `${process.env.MEDUSA_BACKEND_URL.replace(/\/$/, "")}/app/products/${created.product_id}`
-            : `/app/products/${created.product_id}`,
+          // The confirmation message is sent to the PARTNER, who can only open
+          // the partner portal — never the admin app. Build an absolute partner
+          // portal product link (#707). Field name kept as `admin_url` so the
+          // already-seeded message template binding stays intact.
+          admin_url: buildPartnerProductUrl(created.product_id),
           rehosted_image_urls: media.image_urls,
           status: "draft",
         })

--- a/apps/backend/src/workflows/whatsapp/partner-product-url.ts
+++ b/apps/backend/src/workflows/whatsapp/partner-product-url.ts
@@ -1,0 +1,26 @@
+/**
+ * Build an absolute partner-portal product-detail URL.
+ *
+ * The WhatsApp product-create confirmation messages are sent to the PARTNER,
+ * who can only open the partner portal (partner.jaalyantra.com) — never the
+ * admin app (v3.jaalyantra.com/app/...). This helper centralises the one true
+ * partner product link so both construction sites stay in sync.
+ *
+ * Base resolution (first non-empty wins):
+ *   1. explicit `base` arg
+ *   2. env PARTNER_APP_URL          (the env named in #707)
+ *   3. env PARTNER_PORTAL_URL       (existing partner-deeplink convention)
+ *   4. https://partner.jaalyantra.com (hard default)
+ *
+ * Path mirrors the partner-ui product-detail route
+ * (apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx →
+ * `/products/:id`), which is NOT the admin `/app/products/:id`.
+ */
+export function buildPartnerProductUrl(productId: string, base?: string): string {
+  const resolved =
+    (base && base.trim()) ||
+    process.env.PARTNER_APP_URL ||
+    process.env.PARTNER_PORTAL_URL ||
+    "https://partner.jaalyantra.com"
+  return `${resolved.replace(/\/$/, "")}/products/${productId}`
+}

--- a/apps/backend/src/workflows/whatsapp/whatsapp-message-handler.ts
+++ b/apps/backend/src/workflows/whatsapp/whatsapp-message-handler.ts
@@ -23,6 +23,7 @@ import {
   getPartnerOpenWork,
 } from "./whatsapp-media-helper"
 import { BUTTON_TITLE_ACTIONS } from "../../scripts/whatsapp-templates/partner-run-templates"
+import { buildPartnerProductUrl } from "./partner-product-url"
 
 interface IncomingMessage {
   from: string // WhatsApp phone number
@@ -1821,14 +1822,14 @@ async function handleProductCreateButtonReply(
     return { handled: true, action: "product_create_button_not_found" }
   }
 
-  const adminBase = (process.env.MEDUSA_BACKEND_URL || "").replace(/\/$/, "")
-  const adminLink = adminBase ? `${adminBase}/app/products/${productId}` : `/app/products/${productId}`
+  // Sent to the PARTNER → link to the partner portal, not the admin app (#707).
+  const portalLink = buildPartnerProductUrl(productId)
 
   if (action === "confirm") {
     if (product.status === "published") {
       await whatsapp.sendTextMessage(
         message.from,
-        `Already published: *${product.title}*\n${adminLink}`
+        `Already published: *${product.title}*\n${portalLink}`
       )
       return { handled: true, action: "product_create_confirm_already_published" }
     }
@@ -1837,13 +1838,13 @@ async function handleProductCreateButtonReply(
     } catch (e: any) {
       await whatsapp.sendTextMessage(
         message.from,
-        `Couldn't publish *${product.title}* — ${e?.message || "unknown error"}. Try again from admin: ${adminLink}`
+        `Couldn't publish *${product.title}* — ${e?.message || "unknown error"}. Try again from your portal: ${portalLink}`
       )
       return { handled: true, action: "product_create_confirm_failed" }
     }
     await whatsapp.sendTextMessage(
       message.from,
-      `✅ Published: *${product.title}*\n${adminLink}`
+      `✅ Published: *${product.title}*\n${portalLink}`
     )
     return { handled: true, action: "product_create_confirmed" }
   }
@@ -1854,7 +1855,7 @@ async function handleProductCreateButtonReply(
       // admin if they really mean it.
       await whatsapp.sendTextMessage(
         message.from,
-        `*${product.title}* is already published. Open admin to unpublish or delete:\n${adminLink}`
+        `*${product.title}* is already published. Open your portal to unpublish or delete:\n${portalLink}`
       )
       return { handled: true, action: "product_create_cancel_after_publish" }
     }
@@ -1876,7 +1877,7 @@ async function handleProductCreateButtonReply(
 
   await whatsapp.sendTextMessage(
     message.from,
-    "Unrecognised action — open admin to manage this product."
+    "Unrecognised action — open your portal to manage this product."
   )
   return { handled: true, action: "product_create_button_unknown" }
 }


### PR DESCRIPTION
Closes #707.

## Problem
The `whatsapp_product_create` flow sends the **partner** a `✅ Draft product created` message, but the product link pointed to the **admin** app (`https://v3.jaalyantra.com/app/products/{id}`, labelled `Admin:`). Partners can't open admin URLs.

## Fix
Both link-construction sites + the message template now use the partner portal.

- **New pure helper** `src/workflows/whatsapp/partner-product-url.ts` → `buildPartnerProductUrl(productId, base?)` builds `${base}/products/{id}`, mirroring the partner-ui product-detail route (`get-partner-route.map.tsx` → `/products/:id`, **not** admin `/app/products/:id`). Base resolution: `PARTNER_APP_URL` (the env named in #707) → `PARTNER_PORTAL_URL` (existing `generate_partner_deeplink` convention) → `https://partner.jaalyantra.com`. Trailing slash trimmed. **6 unit tests** (explicit base, trailing slash, each env fallback, default, and *admin base ignored*).
- `create-draft-product-from-extraction.ts` — the `admin_url` result field now holds the partner portal link. **Field name intentionally kept** so the already-seeded message template binding (`{{ create_draft.result.admin_url }}`) keeps working in prod immediately on deploy (no re-seed required to fix the link).
- `whatsapp-message-handler.ts` — product-create button replies (`handleProductCreateButtonReply`, which is partner-directed) now link to the portal and say "your portal" instead of "admin".
- `seed-partner-product-create-flow.ts` — template label `Admin:` → `Open in your portal:` (label corrects on next re-seed; the link value is already fixed by the workflow code above).

## Notes / decisions
- Issue asked for env `PARTNER_APP_URL`. The repo already has `PARTNER_PORTAL_URL` (used by `generate_partner_deeplink` in the same WhatsApp subsystem). To honor both the issue and the existing convention, the helper accepts `PARTNER_APP_URL` first, then falls back to `PARTNER_PORTAL_URL`, then the hard default — so no env change is required for it to work in prod today.
- Scope limited to the partner-directed product-create confirmation/button messages. No genuinely admin-directed message touched.

## Verify
- `pnpm --filter ... jest partner-product-url.unit` → 6/6 green.
- Grep confirms no partner-facing message emits `/app/products` or the `Admin:` label.
- Changed files typecheck clean (one pre-existing unrelated `.js`-extension lint in an integration spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)