### PR TITLE
chore(#701): logger standardization wave 3b — admin catalog/ops routes

### DIFF
--- a/apps/backend/src/api/admin/designs/[id]/[path]/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/[path]/route.ts
@@ -89,6 +89,7 @@
  * }
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 
 
 export const GET = async (
@@ -128,14 +129,11 @@ export const POST = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const { id, path } = req.params
 
   if (path[0] === "notes") {
-    console.log("Received POST request for notes path:", { 
-      designId: id, 
-      path,
-      body: req.body 
-    })
+    logger.info(`Received POST request for notes path: ${JSON.stringify({ designId: id, path, body: req.body })}`)
     return res.json({
       message: "Notes path handler - POST",
       designId: id,

--- a/apps/backend/src/api/admin/designs/[id]/approve/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/approve/route.ts
@@ -25,6 +25,7 @@ export async function POST(
   req: MedusaRequest & { params: { id: string } },
   res: MedusaResponse
 ): Promise<void> {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const designId = req.params.id;
     const query = req.scope.resolve(ContainerRegistrationKeys.QUERY) as any;
@@ -62,7 +63,7 @@ export async function POST(
       });
 
     if (updateErrors && updateErrors.length > 0) {
-      console.error("[Admin] Error updating design status:", updateErrors);
+      logger.error(`[Admin] Error updating design status: ${JSON.stringify(updateErrors)}`);
       res.status(500).json({
         message: "Failed to update design status",
         errors: updateErrors,
@@ -82,7 +83,7 @@ export async function POST(
       });
 
     if (productErrors && productErrors.length > 0) {
-      console.error("[Admin] Error creating product:", productErrors);
+      logger.error(`[Admin] Error creating product: ${JSON.stringify(productErrors)}`);
       res.status(500).json({
         message: "Failed to create product from design",
         errors: productErrors,
@@ -111,7 +112,7 @@ export async function POST(
       variant_id: productResult.variant_id,
     });
   } catch (error) {
-    console.error("[Admin] Error in design approve:", error);
+    logger.error(`[Admin] Error in design approve: ${error}`, error);
     res.status(500).json({
       message: "Failed to approve design",
       error: error instanceof Error ? error.message : "Unknown error",

--- a/apps/backend/src/api/admin/designs/[id]/consumption-logs/commit/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/consumption-logs/commit/route.ts
@@ -1,4 +1,5 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { AdminPostCommitConsumptionReq } from "../validators"
 import { commitConsumptionWorkflow } from "../../../../../../workflows/consumption-logs/commit-consumption"
 
@@ -6,6 +7,7 @@ export const POST = async (
   req: MedusaRequest<AdminPostCommitConsumptionReq>,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const designId = req.params.id
 
   const { result, errors } = await commitConsumptionWorkflow(req.scope).run({
@@ -17,7 +19,7 @@ export const POST = async (
   })
 
   if (errors.length > 0) {
-    console.warn("Error reported at", errors)
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`)
     throw errors
   }
 

--- a/apps/backend/src/api/admin/designs/[id]/consumption-logs/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/consumption-logs/route.ts
@@ -1,4 +1,5 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { AdminPostConsumptionLogReq } from "./validators"
 import { logConsumptionWorkflow } from "../../../../../workflows/consumption-logs/log-consumption"
 import { listConsumptionLogsWorkflow } from "../../../../../workflows/consumption-logs/list-consumption-logs"
@@ -7,6 +8,7 @@ export const POST = async (
   req: MedusaRequest<AdminPostConsumptionLogReq>,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const designId = req.params.id
 
   const { result, errors } = await logConsumptionWorkflow(req.scope).run({
@@ -27,7 +29,7 @@ export const POST = async (
   })
 
   if (errors.length > 0) {
-    console.warn("Error reported at", errors)
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`)
     throw errors
   }
 
@@ -35,6 +37,7 @@ export const POST = async (
 }
 
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const designId = req.params.id
   const query = req.query as Record<string, any>
 
@@ -55,7 +58,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   })
 
   if (errors.length > 0) {
-    console.warn("Error reported at", errors)
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`)
     throw errors
   }
 

--- a/apps/backend/src/api/admin/designs/[id]/inventory/[inventoryLinkId]/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/inventory/[inventoryLinkId]/route.ts
@@ -96,7 +96,8 @@ import {
   MedusaRequest,
   MedusaResponse,
 } from "@medusajs/framework/http"
-
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+ 
 import { AdminPatchDesignInventoryLinkReq } from "../validators"
 import { DesignInventoryAllowedFields, refetchDesign } from "../helpers"
 import { updateDesignInventoryLinkWorkflow } from "../../../../../../workflows/designs/inventory/link-inventory"
@@ -105,6 +106,7 @@ export const PATCH = async (
   req: MedusaRequest<AdminPatchDesignInventoryLinkReq>,
   res: MedusaResponse,
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const designId = req.params.id
   const { inventoryLinkId } = req.params as { inventoryLinkId: string }
   const body = (req.validatedBody ?? req.body ?? {}) as AdminPatchDesignInventoryLinkReq
@@ -121,7 +123,7 @@ export const PATCH = async (
   })
 
   if (errors.length > 0) {
-    console.warn("Error reported at", errors)
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`)
     throw errors
   }
 

--- a/apps/backend/src/api/admin/designs/[id]/inventory/delink/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/inventory/delink/route.ts
@@ -41,7 +41,8 @@ import {
   MedusaRequest,
   MedusaResponse,
 } from "@medusajs/framework/http";
-
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
+ 
 import { AdminDeleteDesignInventoryReq } from "../validators";
 import { delinkDesignInventoryWorkflow } from "../../../../../../workflows/designs/inventory/link-inventory";
 import { refetchDesign, DesignInventoryAllowedFields } from "../helpers";
@@ -50,6 +51,7 @@ export const POST = async (
   req: MedusaRequest<AdminDeleteDesignInventoryReq>,
   res: MedusaResponse,
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const designId = req.params.id
   
   const { result, errors } = await delinkDesignInventoryWorkflow(req.scope).run({
@@ -60,7 +62,7 @@ export const POST = async (
   })
 
   if (errors.length > 0) {
-    console.warn("Error reported at", errors);
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`);
     throw errors;
   }
 

--- a/apps/backend/src/api/admin/designs/[id]/inventory/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/inventory/route.ts
@@ -162,8 +162,9 @@ import {
     MedusaRequest,
     MedusaResponse,
   } from "@medusajs/framework/http";
-
-import { AdminPatchDesignInventoryLinkReq, AdminPostDesignInventoryReq } from "../inventory/validators";
+  import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
+ 
+  import { AdminPatchDesignInventoryLinkReq, AdminPostDesignInventoryReq } from "../inventory/validators";
 import { linkDesignInventoryWorkflow, updateDesignInventoryLinkWorkflow } from "../../../../../workflows/designs/inventory/link-inventory";
 import { DesignInventoryAllowedFields, refetchDesign } from "../inventory/helpers";
 import { listDesignInventoryWorkflow } from "../../../../../workflows/designs/inventory/list-design-inventory";
@@ -172,6 +173,7 @@ import { listDesignInventoryWorkflow } from "../../../../../workflows/designs/in
     req: MedusaRequest<AdminPostDesignInventoryReq>,
     res: MedusaResponse,
   ) => {
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
 
     const designId = req.params.id
     
@@ -189,7 +191,7 @@ import { listDesignInventoryWorkflow } from "../../../../../workflows/designs/in
     })
   
     if (errors.length > 0) {
-      console.warn("Error reported at", errors);
+      logger.warn(`Error reported at ${JSON.stringify(errors)}`);
       throw errors;
     }
   
@@ -207,6 +209,7 @@ import { listDesignInventoryWorkflow } from "../../../../../workflows/designs/in
     req: MedusaRequest,
     res: MedusaResponse,
   ) => {
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
     const designId = req.params.id
     
     const { result, errors } = await listDesignInventoryWorkflow(req.scope).run({
@@ -216,7 +219,7 @@ import { listDesignInventoryWorkflow } from "../../../../../workflows/designs/in
     })  
 
     if (errors.length > 0) { 
-      console.warn("Error reported at", errors);
+      logger.warn(`Error reported at ${JSON.stringify(errors)}`);
       throw errors;
     }
 
@@ -227,6 +230,7 @@ import { listDesignInventoryWorkflow } from "../../../../../workflows/designs/in
     req: MedusaRequest<AdminPatchDesignInventoryLinkReq>,
     res: MedusaResponse,
   ) => {
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
     const designId = req.params.id;
     const { inventoryLinkId } = req.params as { inventoryLinkId: string };
 
@@ -241,7 +245,7 @@ import { listDesignInventoryWorkflow } from "../../../../../workflows/designs/in
     });
 
     if (errors.length > 0) {
-      console.warn("Error reported at", errors);
+      logger.warn(`Error reported at ${JSON.stringify(errors)}`);
       throw errors;
     }
 

--- a/apps/backend/src/api/admin/designs/[id]/partner/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/partner/route.ts
@@ -37,6 +37,7 @@ import { PARTNER_MODULE } from "../../../../../modules/partner";
     req: MedusaRequest<LinkDesignPartner>,
     res: MedusaResponse,
   ) => {
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
 
     const designId = req.params.id
     
@@ -48,7 +49,7 @@ import { PARTNER_MODULE } from "../../../../../modules/partner";
     })
   
     if (errors.length > 0) {
-      console.warn("Error reported at", errors);
+      logger.warn(`Error reported at ${JSON.stringify(errors)}`);
       throw errors;
     }
   

--- a/apps/backend/src/api/admin/designs/[id]/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/route.ts
@@ -114,7 +114,7 @@ import {
   MedusaRequest,
   MedusaResponse,
 } from "@medusajs/framework/http";
-import { MedusaError } from "@medusajs/framework/utils";
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils";
 import { UpdateDesign } from "../validators";
 import updateDesignWorkflow from "../../../../workflows/designs/update-design";
 import deleteDesignWorkflow from "../../../../workflows/designs/delete-design";
@@ -159,6 +159,7 @@ export const PUT = async (
   },
   res: MedusaResponse,
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   // Scoped run — an unscoped workflow.run() uses a bare container that
   // can't resolve request-scoped registrations like "query".
   const { result, errors } = await updateDesignWorkflow(req.scope).run({
@@ -169,7 +170,7 @@ export const PUT = async (
   });
 
   if (errors.length > 0) {
-    console.warn("Error reported at", errors);
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`);
     throw errors;
   }
 
@@ -189,6 +190,7 @@ export const DELETE = async (
   },
   res: MedusaResponse,
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   // 404 on unknown ids (soft-deleting a missing design 500s deep in the
   // workflow otherwise).
   const existing = await refetchDesign(req.params.id, req.scope, ["id"] as any);
@@ -206,7 +208,7 @@ export const DELETE = async (
   });
 
   if (errors.length > 0) {
-    console.warn("Error reported at", errors);
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`);
     throw errors;
   }
 

--- a/apps/backend/src/api/admin/designs/[id]/segment/depth/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/segment/depth/route.ts
@@ -2,7 +2,7 @@ import {
   AuthenticatedMedusaRequest,
   MedusaResponse,
 } from "@medusajs/framework/http"
-import { MedusaError } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 import { resolveFalCredentials } from "../../../../../../mastra/services/fal-credentials"
 
 /**
@@ -21,6 +21,7 @@ export const POST = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const { image_url, image_base64 } = req.body as {
     image_url?: string
     image_base64?: string
@@ -64,7 +65,7 @@ export const POST = async (
     resolvedImageUrl = await fal.storage.upload(file)
   }
 
-  console.log(
+  logger.info(
     `[Depth] Running MiDaS on image: ${resolvedImageUrl!.substring(0, 80)}…`
   )
 
@@ -81,9 +82,8 @@ export const POST = async (
   const normalUrl = data?.normal_map?.url
 
   if (!depthUrl) {
-    console.error(
-      "[Depth] MiDaS result shape:",
-      JSON.stringify(result).substring(0, 400)
+    logger.error(
+      `[Depth] MiDaS result shape: ${JSON.stringify(result).substring(0, 400)}`
     )
     throw new MedusaError(
       MedusaError.Types.UNEXPECTED_STATE,
@@ -91,7 +91,7 @@ export const POST = async (
     )
   }
 
-  console.log(`[Depth] Success — depth: ${depthUrl.substring(0, 80)}…`)
+  logger.info(`[Depth] Success — depth: ${depthUrl.substring(0, 80)}…`)
 
   return res.status(200).json({
     depth: {

--- a/apps/backend/src/api/admin/designs/[id]/segment/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/segment/route.ts
@@ -2,7 +2,7 @@ import {
   AuthenticatedMedusaRequest,
   MedusaResponse,
 } from "@medusajs/framework/http"
-import { MedusaError } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 import { resolveFalCredentials } from "../../../../../mastra/services/fal-credentials"
 import { SegmentImageReq } from "./validators"
 
@@ -19,6 +19,7 @@ export const POST = async (
   req: AuthenticatedMedusaRequest<SegmentImageReq>,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const { image_url, image_base64, model } = req.validatedBody
 
   if (!image_url && !image_base64) {
@@ -59,7 +60,7 @@ export const POST = async (
     resolvedImageUrl = await fal.storage.upload(file)
   }
 
-  console.log(
+  logger.info(
     `[Segment] Running BiRefNet v2 on image: ${resolvedImageUrl!.substring(0, 80)}…`
   )
 
@@ -79,9 +80,8 @@ export const POST = async (
   const maskUrl = data?.mask_image?.url
 
   if (!cutoutUrl) {
-    console.error(
-      "[Segment] BiRefNet result shape:",
-      JSON.stringify(result).substring(0, 300)
+    logger.error(
+      `[Segment] BiRefNet result shape: ${JSON.stringify(result).substring(0, 300)}`
     )
     throw new MedusaError(
       MedusaError.Types.UNEXPECTED_STATE,
@@ -89,7 +89,7 @@ export const POST = async (
     )
   }
 
-  console.log(`[Segment] Success — cutout: ${cutoutUrl.substring(0, 80)}…`)
+  logger.info(`[Segment] Success — cutout: ${cutoutUrl.substring(0, 80)}…`)
 
   return res.status(200).json({
     segment: {

--- a/apps/backend/src/api/admin/designs/auto/route.ts
+++ b/apps/backend/src/api/admin/designs/auto/route.ts
@@ -50,6 +50,7 @@
  *     }'
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import createDesignFromLLMWorkflow from "../../../../workflows/designs/create-design-from-llm";
 import { refetchDesign } from "../helpers";
 import { CreateDesignLLM } from "../validators";
@@ -58,12 +59,13 @@ export const POST = async (
     req: MedusaRequest<CreateDesignLLM>,
     res: MedusaResponse,
 ) => {
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
     const { result, errors } = await createDesignFromLLMWorkflow(req.scope).run({
         input: req.validatedBody,
     });
 
     if (errors.length > 0) {
-        console.warn("Error reported at", errors);
+        logger.warn(`Error reported at ${JSON.stringify(errors)}`);
         throw errors;
     }
 

--- a/apps/backend/src/api/admin/designs/orders/[lineItemId]/route.ts
+++ b/apps/backend/src/api/admin/designs/orders/[lineItemId]/route.ts
@@ -16,6 +16,7 @@ export async function GET(
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
 ): Promise<void> {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const { lineItemId } = req.params
     const query = req.scope.resolve(ContainerRegistrationKeys.QUERY) as any
@@ -120,7 +121,7 @@ export async function GET(
       )
       lineItem = items?.[0] || null
     } catch (e) {
-      console.warn("[design-order detail] Failed to fetch line item:", e)
+      logger.warn(`[design-order detail] Failed to fetch line item: ${e}`)
     }
 
     // 4. Fetch cart details for currency and customer fallback
@@ -274,7 +275,7 @@ export async function GET(
       },
     })
   } catch (error) {
-    console.error("[design-order detail] Error:", error)
+    logger.error(`[design-order detail] Error: ${error}`, error)
     res.status(500).json({
       message: "Failed to fetch design order",
       error: error instanceof Error ? error.message : "Unknown error",

--- a/apps/backend/src/api/admin/designs/orders/route.ts
+++ b/apps/backend/src/api/admin/designs/orders/route.ts
@@ -21,6 +21,7 @@ export async function GET(
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
 ): Promise<void> {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const query = req.scope.resolve(ContainerRegistrationKeys.QUERY) as any;
     const limit = Number(req.query.limit) || 20;
@@ -219,7 +220,7 @@ export async function GET(
 
     res.status(200).json({ design_orders: rows, count: total, offset, limit });
   } catch (error) {
-    console.error("[Admin] Error fetching design orders:", error);
+    logger.error(`[Admin] Error fetching design orders: ${error}`, error);
     res.status(500).json({
       message: "Failed to fetch design orders",
       error: error instanceof Error ? error.message : "Unknown error",

--- a/apps/backend/src/api/admin/designs/route.ts
+++ b/apps/backend/src/api/admin/designs/route.ts
@@ -163,7 +163,7 @@ export const POST = async (
   },
   res: MedusaResponse,
 ) => {
-  
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
 
   const { result, errors } = await createDesignWorkflow(req.scope).run({
     input: {
@@ -173,7 +173,7 @@ export const POST = async (
   })
 
   if (errors.length > 0) {
-    console.warn("Error reported at", errors);
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`);
     throw errors;
   }
 
@@ -207,6 +207,7 @@ export const GET = async (
   },
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
 
   try {
     // If customer_id is provided, fetch designs directly via the link table (bypassing the
@@ -293,7 +294,7 @@ export const GET = async (
   
 
     if (errors.length > 0) {
-      console.warn("Error reported at", errors);
+      logger.warn(`Error reported at ${JSON.stringify(errors)}`);
       throw errors;
     }
 

--- a/apps/backend/src/api/admin/inventory-items/[id]/rawmaterials/[rawMaterialId]/route.ts
+++ b/apps/backend/src/api/admin/inventory-items/[id]/rawmaterials/[rawMaterialId]/route.ts
@@ -107,6 +107,7 @@ import {
   MedusaRequest,
   MedusaResponse,
 } from "@medusajs/framework";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { RAW_MATERIAL_MODULE } from "../../../../../../modules/raw_material";
 import RawMaterialService from "../../../../../../modules/raw_material/service";
 import updateRawMaterialWorkflow from "../../../../../../workflows/raw-materials/update-raw-material";
@@ -130,6 +131,7 @@ export const PUT = async (
   req: MedusaRequest<UpdateRawMaterial>,
   res: MedusaResponse,
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const { rawMaterialId } = req.params;
 
   const {  errors } = await updateRawMaterialWorkflow(req.scope).run({
@@ -140,7 +142,7 @@ export const PUT = async (
   });
 
   if (errors.length > 0) {
-    console.warn("Error reported at", errors);
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`);
     throw errors;
   }
 

--- a/apps/backend/src/api/admin/inventory-items/[id]/rawmaterials/helpers.ts
+++ b/apps/backend/src/api/admin/inventory-items/[id]/rawmaterials/helpers.ts
@@ -38,6 +38,7 @@ export const getAllInventoryWithRawMaterial = async (
   fields: RawMaterialAllowedFields[] = ["*"]
 ) => {
   const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
 
   // Debug: incoming filters
   // Note: In Medusa v2, query.graph cannot filter on linked entity properties.
@@ -58,9 +59,9 @@ export const getAllInventoryWithRawMaterial = async (
     }
   })
 
-  console.log("[getAllInventoryWithRawMaterial] incoming filters:", incoming)
-  console.log("[getAllInventoryWithRawMaterial] apiFilters (applied in query.graph):", apiFilters)
-  console.log("[getAllInventoryWithRawMaterial] postFilters (applied in app):", postFilters, "q:", q)
+  logger.debug(`[getAllInventoryWithRawMaterial] incoming filters: ${JSON.stringify(incoming)}`)
+  logger.debug(`[getAllInventoryWithRawMaterial] apiFilters (applied in query.graph): ${JSON.stringify(apiFilters)}`)
+  logger.debug(`[getAllInventoryWithRawMaterial] postFilters (applied in app): ${JSON.stringify(postFilters)} q: ${q}`)
 
   const { data } = await query.graph({
     entity: RawMaterialInventoryLink.entryPoint,
@@ -70,7 +71,7 @@ export const getAllInventoryWithRawMaterial = async (
   })
 
   const items = Array.isArray(data) ? data : []
-  console.log("[getAllInventoryWithRawMaterial] fetched count:", items.length)
+  logger.debug(`[getAllInventoryWithRawMaterial] fetched count: ${items.length}`)
 
   // Apply q search against common text fields from linked entities
   const applyQ = (list: any[], queryStr?: unknown) => {
@@ -109,13 +110,13 @@ export const getAllInventoryWithRawMaterial = async (
   const beforeQ = result.length
   result = applyQ(result, q)
   if (beforeQ !== result.length) {
-    console.log(`[getAllInventoryWithRawMaterial] q filter applied: ${beforeQ} -> ${result.length}`)
+    logger.debug(`[getAllInventoryWithRawMaterial] q filter applied: ${beforeQ} -> ${result.length}`)
   }
 
   const beforePost = result.length
   result = applyPostFilters(result, postFilters)
   if (beforePost !== result.length) {
-    console.log(`[getAllInventoryWithRawMaterial] postFilters applied: ${beforePost} -> ${result.length}`)
+    logger.debug(`[getAllInventoryWithRawMaterial] postFilters applied: ${beforePost} -> ${result.length}`)
   }
 
   return result

--- a/apps/backend/src/api/admin/inventory-items/[id]/rawmaterials/route.ts
+++ b/apps/backend/src/api/admin/inventory-items/[id]/rawmaterials/route.ts
@@ -75,6 +75,7 @@ import {
   MedusaRequest,
   MedusaResponse,
 } from "@medusajs/framework/http";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { RawMaterial } from "./validators";
 import { createRawMaterialWorkflow } from "../../../../../workflows/raw-materials/create-raw-material";
 import { RawMaterialAllowedFields, refetchRawMaterial } from "./helpers";
@@ -87,6 +88,7 @@ export const POST = async (
   },
   res: MedusaResponse,
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const { errors } = await createRawMaterialWorkflow(req.scope).run({
     input: {
       inventoryId: req.params.id,
@@ -95,7 +97,7 @@ export const POST = async (
   });
 
   if (errors.length > 0) {
-    console.warn("Error reported at", errors);
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`);
     throw errors;
   }
 

--- a/apps/backend/src/api/admin/inventory-items/[id]/split/route.ts
+++ b/apps/backend/src/api/admin/inventory-items/[id]/split/route.ts
@@ -1,4 +1,5 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { splitInventoryItemWorkflow } from "../../../../../workflows/inventory/split-inventory-item"
 
 export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
@@ -16,6 +17,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     }
   }
 
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const { result, errors } = await splitInventoryItemWorkflow(req.scope).run({
     input: {
       sourceInventoryItemId: req.params.id,
@@ -27,7 +29,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   })
 
   if (errors && errors.length > 0) {
-    console.warn("Split inventory workflow errors:", errors)
+    logger.warn(`Split inventory workflow errors: ${JSON.stringify(errors)}`)
     throw errors[0]
   }
 

--- a/apps/backend/src/api/admin/medias/[id]/upload/route.ts
+++ b/apps/backend/src/api/admin/medias/[id]/upload/route.ts
@@ -71,7 +71,7 @@
  * - Workflow failure -> 500 { "message": "Failed to upload media: <error messages>" }
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { MedusaError } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 import { uploadAndOrganizeMediaWorkflow } from "../../../../../workflows/media/upload-and-organize-media"
 import fs from "fs"
 
@@ -80,6 +80,7 @@ export const POST = async (
   req: MedusaRequest & { files?: Express.Multer.File[]; file?: Express.Multer.File },
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   // Soft deprecation notice in headers
   res.setHeader("Deprecation", "true")
   res.setHeader(
@@ -149,10 +150,10 @@ export const POST = async (
       result,
     })
   } catch (error) {
-    console.error("Folder upload error:", error)
+    logger.error(`Folder upload error: ${error}`, error)
     if (error instanceof MedusaError) {
       const status = error.type === MedusaError.Types.INVALID_DATA ? 400 : 500
-      console.error("Medusa error:", error)
+      logger.error(`Medusa error: ${error}`, error)
       return res.status(status).json({ message: (error as Error).message })
     }
     return res.status(500).json({ message: (error as any)?.message || "An unexpected error occurred in the media upload" })

--- a/apps/backend/src/api/admin/medias/albums/route.ts
+++ b/apps/backend/src/api/admin/medias/albums/route.ts
@@ -58,7 +58,7 @@
  */
 
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
-import { MedusaError } from "@medusajs/framework/utils";
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils";
 import { listAlbumWorkflow } from "../../../../workflows/media/list-album";
 
 
@@ -66,6 +66,7 @@ export const GET = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const { result } = await listAlbumWorkflow(req.scope).run({
       input: {
@@ -84,7 +85,7 @@ export const GET = async (
       count: result[1] || albums.length,
     });
   } catch (error) {
-    console.error("Error listing albums:", error);
+    logger.error(`Error listing albums: ${error}`, error);
     throw new MedusaError(
       MedusaError.Types.UNEXPECTED_STATE,
       "Failed to list albums"

--- a/apps/backend/src/api/admin/medias/extract-features/[transaction_id]/confirm/route.ts
+++ b/apps/backend/src/api/admin/medias/extract-features/[transaction_id]/confirm/route.ts
@@ -37,6 +37,7 @@
  */
 
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { IWorkflowEngineService } from "@medusajs/framework/types";
 import { Modules, TransactionHandlerType } from "@medusajs/framework/utils";
 import { StepResponse } from "@medusajs/framework/workflows-sdk";
@@ -46,6 +47,7 @@ import {
 } from "../../../../../../workflows/ai/textile-product-extraction";
 
 export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const workflowEngineService: IWorkflowEngineService = req.scope.resolve(
       Modules.WORKFLOW_ENGINE
@@ -76,7 +78,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
       transaction_id: transactionId,
     });
   } catch (error) {
-    console.error("[ExtractFeatures/Confirm] Error:", error);
+    logger.error(`[ExtractFeatures/Confirm] Error: ${error}`, error);
 
     // Check if it's a "workflow not found" type error
     const errorMessage = (error as Error)?.message || "";

--- a/apps/backend/src/api/admin/medias/extract-features/route.ts
+++ b/apps/backend/src/api/admin/medias/extract-features/route.ts
@@ -47,7 +47,7 @@
  */
 
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
-import { MedusaError } from "@medusajs/framework/utils";
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils";
 import { ExtractFeaturesRequestSchema, ExtractFeaturesRequest } from "./validators";
 import {
   textileProductExtractionMedusaWorkflow,
@@ -57,6 +57,7 @@ export const POST = async (
   req: MedusaRequest<ExtractFeaturesRequest>,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     // Validate request body
     const parsed = ExtractFeaturesRequestSchema.safeParse(
@@ -115,7 +116,7 @@ export const POST = async (
       summary: result,
     });
   } catch (error) {
-    console.error("[ExtractFeatures] Error:", error);
+    logger.error(`[ExtractFeatures] Error: ${error}`, error);
 
     if (error instanceof MedusaError) {
       const status =

--- a/apps/backend/src/api/admin/medias/folder/[id]/upload/route.ts
+++ b/apps/backend/src/api/admin/medias/folder/[id]/upload/route.ts
@@ -68,7 +68,7 @@
  *   { "message": "Failed to create media records: <details>" }
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { MedusaError } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 import { uploadAndOrganizeMediaWorkflow } from "../../../../../../workflows/media/upload-and-organize-media"
 import { UploadMediaRequest } from "../../../validator";
  
@@ -78,6 +78,7 @@ export const POST = async (
   req: MedusaRequest<UploadMediaRequest> & { files?: Express.Multer.File[]; file?: Express.Multer.File },
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const { id: folderId } = req.params as { id?: string }
     if (!folderId) {
@@ -121,11 +122,11 @@ export const POST = async (
     return res.status(200).json({ result })
   } catch (error) {
     if (error instanceof MedusaError) {
-      console.error("Folder upload Medusa error:", error)
+      logger.error(`Folder upload Medusa error: ${error}`, error)
       const status = error.type === MedusaError.Types.INVALID_DATA ? 400 : 500
       return res.status(status).json({ message: (error as Error).message })
     }
-    console.error("Folder upload error:", error)
+    logger.error(`Folder upload error: ${error}`, error)
     return res.status(500).json({ message: (error as any)?.message || "An unexpected error occurred" })
   }
 }

--- a/apps/backend/src/api/admin/medias/folder/route.ts
+++ b/apps/backend/src/api/admin/medias/folder/route.ts
@@ -65,7 +65,7 @@ import {
     MedusaRequest,
     MedusaResponse,
   } from "@medusajs/framework/http";
-  import { MedusaError } from "@medusajs/framework/utils";
+  import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils";
   import { createFolderWorkflow } from "../../../../workflows/media/create-folder";
 import { FolderRequest } from "../validator";
 
@@ -74,6 +74,7 @@ import { FolderRequest } from "../validator";
     req: MedusaRequest<FolderRequest>,
     res: MedusaResponse
   ) => {
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
     // Body is validated by middleware (validateAndTransformBody)
     const folderData = req.validatedBody as FolderRequest;
   
@@ -96,7 +97,7 @@ import { FolderRequest } from "../validator";
       });
   
       if (errors.length > 0) {
-        console.error("Errors occurred during folder creation:", errors);
+        logger.error(`Errors occurred during folder creation: ${JSON.stringify(errors)}`);
         throw new MedusaError(
           MedusaError.Types.UNEXPECTED_STATE,
           `Failed to create folder: ${errors.map(e => e.error?.message || "Unknown error").join(", ")}`
@@ -108,7 +109,7 @@ import { FolderRequest } from "../validator";
         folder: result,
       });
     } catch (error) {
-      console.error("Error creating folder:", error);
+      logger.error(`Error creating folder: ${error}`, error);
       throw error;
     }
   };

--- a/apps/backend/src/api/admin/medias/folders/route.ts
+++ b/apps/backend/src/api/admin/medias/folders/route.ts
@@ -47,7 +47,7 @@
  * @public
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
-import { MedusaError } from "@medusajs/framework/utils";
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils";
 import { listFolderWorkflow } from "../../../../workflows/media/list-folder";
 
 /**
@@ -58,6 +58,7 @@ export const GET = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   try {
     const { result } = await listFolderWorkflow(req.scope).run({
       input: {
@@ -76,7 +77,7 @@ export const GET = async (
       count: result[1] || folders.length,
     });
   } catch (error) {
-    console.error("Error listing folders:", error);
+    logger.error(`Error listing folders: ${error}`, error);
     throw new MedusaError(
       MedusaError.Types.UNEXPECTED_STATE,
       "Failed to list folders"

--- a/apps/backend/src/api/admin/medias/route.ts
+++ b/apps/backend/src/api/admin/medias/route.ts
@@ -118,7 +118,7 @@ import {
     MedusaRequest,
     MedusaResponse,
   } from "@medusajs/framework/http";
-  import { MedusaError } from "@medusajs/framework/utils";
+  import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils";
   import { uploadAndOrganizeMediaWorkflow } from "../../../workflows/media/upload-and-organize-media";
   import { listAllMediasWorkflow } from "../../../workflows/media/list-all-medias";
 import { UploadMediaRequest } from "./validator";
@@ -131,6 +131,7 @@ import { UploadMediaRequest } from "./validator";
     },
     res: MedusaResponse
   ) => {
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
     try {
       // Normalize uploaded files (support single or multiple)
       const uploadedFiles: Express.Multer.File[] = Array.isArray(req.files)
@@ -177,7 +178,7 @@ import { UploadMediaRequest } from "./validator";
       });
 
       if (errors.length > 0) {
-        console.error("Errors occurred during media upload:", errors);
+        logger.error(`Errors occurred during media upload: ${JSON.stringify(errors)}`);
         throw new MedusaError(
           MedusaError.Types.UNEXPECTED_STATE,
           `Failed to upload media: ${errors.map(e => e.error?.message || "Unknown error").join(", ")}`
@@ -198,7 +199,7 @@ import { UploadMediaRequest } from "./validator";
         result,
       });
     } catch (error) {
-      console.error("Error uploading media:", error);
+      logger.error(`Error uploading media: ${error}`, error);
       if (error instanceof MedusaError) {
         const status = error.type === MedusaError.Types.INVALID_DATA ? 400 : 500
         return res.status(status).json({ message: (error as Error).message })
@@ -212,6 +213,7 @@ import { UploadMediaRequest } from "./validator";
     req: MedusaRequest,
     res: MedusaResponse
   ) => {
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
     try {
       // Optionally forward query filters/config if provided, but normalize types first
       const { filters: rawFilters, config: rawConfig, ...restQuery } = (req.query || {}) as Record<string, any>
@@ -315,7 +317,7 @@ import { UploadMediaRequest } from "./validator";
 
       res.status(200).json(result);
     } catch (error) {
-      console.error("Error listing medias:", error);
+      logger.error(`Error listing medias: ${error}`, error);
       throw new MedusaError(
         MedusaError.Types.UNEXPECTED_STATE,
         "Failed to list media entities"

--- a/apps/backend/src/api/admin/persons/[id]/addresses/[addressId]/route.ts
+++ b/apps/backend/src/api/admin/persons/[id]/addresses/[addressId]/route.ts
@@ -101,6 +101,7 @@
  * No content
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { addressSchema } from "../validators";
 import { refetchPersonAddress, AddressAllowedFields } from "../helpers";
 import { MedusaError } from "@medusajs/utils";
@@ -115,6 +116,7 @@ export const POST = async (
   },
   res: MedusaResponse,
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const personId = req.params.id;
   const addressId = req.params.addressId;
 
@@ -146,7 +148,7 @@ export const POST = async (
     });
 
     if (errors.length > 0) {
-      console.warn("Error reported at", errors);
+      logger.warn(`Error reported at ${JSON.stringify(errors)}`);
       throw errors;
     }
 
@@ -168,10 +170,9 @@ export const DELETE = async (
   req: MedusaRequest,
   res: MedusaResponse,
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const personId = req.params.id;
   const addressId = req.params.addressId;
- 
-  
 
   try {
     // Check if the address exists for this person
@@ -195,7 +196,7 @@ export const DELETE = async (
     });
 
     if (errors.length > 0) {
-      console.warn("Error reported at", errors);
+      logger.warn(`Error reported at ${JSON.stringify(errors)}`);
       throw errors;
     }
 

--- a/apps/backend/src/api/admin/persons/[id]/addresses/route.ts
+++ b/apps/backend/src/api/admin/persons/[id]/addresses/route.ts
@@ -136,7 +136,8 @@
  * }
  */
 import { MedusaRequest, MedusaResponse, refetchEntity } from "@medusajs/framework/http";
-
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
+ 
 import { Address } from "./validators";
 import createAddressWorkflow from "../../../../../workflows/persons/create-address";
 import retrieveAddressesWorkflow from "../../../../../workflows/persons/retrieve-addresses";
@@ -146,6 +147,7 @@ export const POST = async (
   req: MedusaRequest<Address>,
   res: MedusaResponse,
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   
   const personId = req.params.id;
   // Check if the person exists in the personID or is validPersonId
@@ -171,7 +173,7 @@ export const POST = async (
   });
 
   if (errors.length > 0) {
-    console.warn("Error reported at", errors);
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`);
     res.status(400).json({ error: errors });
     throw errors;
   }
@@ -180,6 +182,7 @@ export const POST = async (
 };
 
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const personId = req.params.id;
 
   try {
@@ -192,7 +195,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     const [addresses, count] = result
 
     if (errors.length > 0) {
-      console.warn("Error reported at", errors);
+      logger.warn(`Error reported at ${JSON.stringify(errors)}`);
       throw errors;
     }
 

--- a/apps/backend/src/api/admin/persons/[id]/contacts/[contactId]/route.ts
+++ b/apps/backend/src/api/admin/persons/[id]/contacts/[contactId]/route.ts
@@ -107,6 +107,7 @@
  * No content
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { contactSchema } from "../validators";
 import { refetchPersonContact, ContactAllowedFields } from "../helpers";
 import { MedusaError } from "@medusajs/utils";
@@ -121,6 +122,7 @@ export const POST = async (
   },
   res: MedusaResponse,
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const personId = req.params.id;
   const contactId = req.params.contactId;
 
@@ -152,7 +154,7 @@ export const POST = async (
     });
 
     if (errors.length > 0) {
-      console.warn("Error reported at", errors);
+      logger.warn(`Error reported at ${JSON.stringify(errors)}`);
       throw errors;
     }
 
@@ -174,6 +176,7 @@ export const DELETE = async (
   req: MedusaRequest,
   res: MedusaResponse,
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const personId = req.params.id;
   const contactId = req.params.contactId;
 
@@ -200,7 +203,7 @@ export const DELETE = async (
     });
 
     if (errors.length > 0) {
-      console.warn("Error reported at", errors);
+      logger.warn(`Error reported at ${JSON.stringify(errors)}`);
       throw errors;
     }
 

--- a/apps/backend/src/api/admin/persons/[id]/contacts/route.ts
+++ b/apps/backend/src/api/admin/persons/[id]/contacts/route.ts
@@ -106,6 +106,7 @@
  * }
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { contactSchema } from "./validators";
 import { ContactAllowedFields, refetchPersonContact } from "./helpers";
 import createContactWorkflow from "../../../../../workflows/persons/create-contact";
@@ -119,6 +120,7 @@ export const POST = async (
   },
   res: MedusaResponse,
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const personId = req.params.id;
   const validatedBody = contactSchema.parse(req.body);
 
@@ -131,7 +133,7 @@ export const POST = async (
     });
 
     if (errors.length > 0) {
-      console.warn("Error reported at", errors);
+      logger.warn(`Error reported at ${JSON.stringify(errors)}`);
       throw errors;
     }
 
@@ -155,6 +157,7 @@ export const GET = async (
   },
   res: MedusaResponse,
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const personId = req.params.id;
 
   try {
@@ -165,7 +168,7 @@ export const GET = async (
     });
 
     if (errors.length > 0) {
-      console.warn("Error reported at", errors);
+      logger.warn(`Error reported at ${JSON.stringify(errors)}`);
       throw errors;
     }
 

--- a/apps/backend/src/api/admin/persons/[id]/geocode-addresses/route.ts
+++ b/apps/backend/src/api/admin/persons/[id]/geocode-addresses/route.ts
@@ -43,6 +43,7 @@ import {
   MedusaRequest,
   MedusaResponse,
 } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { geocodeAllAddressesWorkflow } from "../../../../../workflows/persons/geocode-all-addresses"
 
 /**
@@ -70,11 +71,12 @@ export const POST = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const { id: person_id } =  req.params;
   const workflow = geocodeAllAddressesWorkflow(req.scope)
   const { result, transaction } = await workflow.run({
     input: { person_id },
   })
-  console.log(transaction.getState())
+  logger.info(`Transaction state: ${transaction.getState()}`)
   res.status(202).json({ summary: result, transaction_id: transaction.transactionId })
 }

--- a/apps/backend/src/api/admin/persons/[id]/route.ts
+++ b/apps/backend/src/api/admin/persons/[id]/route.ts
@@ -124,6 +124,7 @@
  */
 // src/api/admin/persons/[id]/route.ts
 import { MedusaRequest, MedusaResponse, refetchEntity } from "@medusajs/framework/http";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import PersonService from "../../../../modules/person/service";
 import { PERSON_MODULE } from "../../../../modules/person";
 import updatePersonWorkflow from "../../../../workflows/update-person";
@@ -153,6 +154,7 @@ export const POST = async (
   },
   res: MedusaResponse,
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const {  ...update } = req.validatedBody
   const existingPerson = await refetchEntity({
     entity: "person",
@@ -179,7 +181,7 @@ export const POST = async (
     },
   });
   if (errors.length > 1) {
-    console.warn("Error reported at", errors);
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`);
     throw errors;
   } 
   const person = await refetchPerson(
@@ -191,6 +193,7 @@ export const POST = async (
 };
 
 export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const { id } = req.params;
     const {result, errors} = await  deletePersonWorkflow(req.scope).run({
       input: {
@@ -198,7 +201,7 @@ export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
       },
     });
     if (errors.length > 1) {
-      console.warn("Error reported at", errors);
+      logger.warn(`Error reported at ${JSON.stringify(errors)}`);
       throw errors;
     }
     res.status(201).json({

--- a/apps/backend/src/api/admin/persons/[id]/tags/[tagId]/route.ts
+++ b/apps/backend/src/api/admin/persons/[id]/tags/[tagId]/route.ts
@@ -59,6 +59,7 @@
  * }
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { TagAllowedFields } from "../helpers";
 import deletePersonTagsWorkflow from "../../../../../../workflows/persons/delete-person-tags";
 import { DeleteTagForPerson } from "../validators";
@@ -71,6 +72,7 @@ export const DELETE = async (
     },
     res: MedusaResponse,
   ) => {
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   
     const personId = req.params.id;
     const tagId = req.params.tagId;
@@ -83,7 +85,7 @@ export const DELETE = async (
       });
   
       if (errors.length > 0) {
-        console.warn("Error reported at", errors);
+        logger.warn(`Error reported at ${JSON.stringify(errors)}`);
         throw errors;
       }
   

--- a/apps/backend/src/api/admin/persons/[id]/tags/route.ts
+++ b/apps/backend/src/api/admin/persons/[id]/tags/route.ts
@@ -137,6 +137,7 @@
  * }
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import {  deleteTagSchema, tagSchema, UpdateTagsForPerson } from "./validators";
 import { TagAllowedFields, refetchPersonTags } from "./helpers";
 
@@ -152,6 +153,7 @@ export const POST = async (
   },
   res: MedusaResponse,
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const personId = req.params.id;
   const validatedBody = tagSchema.parse(req.body);
     const { result, errors } = await createPersonTagsWorkflow.run({
@@ -161,7 +163,7 @@ export const POST = async (
       },
     });
     if (errors.length > 0) {
-      console.warn("Error reported at", errors);
+      logger.warn(`Error reported at ${JSON.stringify(errors)}`);
       throw errors;
     }
   
@@ -178,6 +180,7 @@ export const GET = async (
   },
   res: MedusaResponse,
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const personId = req.params.id;
 
   try {
@@ -188,7 +191,7 @@ export const GET = async (
     });
 
     if (errors.length > 0) {
-      console.warn("Error reported at", errors);
+      logger.warn(`Error reported at ${JSON.stringify(errors)}`);
       throw errors;
     }
 
@@ -206,6 +209,7 @@ export const PUT = async (
   },
   res: MedusaResponse,
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const personId = req.params.id;
 
   try {
@@ -217,7 +221,7 @@ export const PUT = async (
     });
 
     if (errors.length > 0) {
-      console.warn("Error reported at", errors);
+      logger.warn(`Error reported at ${JSON.stringify(errors)}`);
       throw errors;
     }
 

--- a/apps/backend/src/api/admin/persons/route.ts
+++ b/apps/backend/src/api/admin/persons/route.ts
@@ -140,6 +140,7 @@ import {
   MedusaResponse,
   
 } from "@medusajs/framework/http";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { Person, ListPersonsQuery } from "./validators";
 import createPersonWorkflow from "../../../workflows/create-person";
 import { PersonAllowedFields, refetchPerson } from "./helpers";
@@ -153,11 +154,12 @@ export const POST = async (
   },
   res: MedusaResponse,
 ) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const { result, errors, transaction } = await createPersonWorkflow.run({
     input: req.validatedBody,
   });
   if (errors.length > 1) {
-    console.warn("Error reported at", errors);
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`);
     throw errors;
   }
   const person = await refetchPerson(

--- a/apps/backend/src/api/admin/products/[id]/linkDesign/route.ts
+++ b/apps/backend/src/api/admin/products/[id]/linkDesign/route.ts
@@ -3,6 +3,7 @@
  * request
  */
 
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework";
 import { LinkDesignValidator } from "./validators";
 import { linkProductWithDesignWorkflow } from "../../../../../workflows/products/link-unlink-products-with-designs";
@@ -16,6 +17,7 @@ export const POST = async(
 
   const { designId } = req.validatedBody
 
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const { errors } = await linkProductWithDesignWorkflow(req.scope).run({
     input: {
       productId: id,
@@ -24,7 +26,7 @@ export const POST = async(
   })
   
   if (errors.length > 0) {
-    console.warn("Error reported at", errors);
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`);
     throw errors;
   }
 

--- a/apps/backend/src/api/admin/products/[id]/linkPerson/route.ts
+++ b/apps/backend/src/api/admin/products/[id]/linkPerson/route.ts
@@ -129,6 +129,7 @@
  *   }
  * }
  */
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
 import { LinkPersonValidator } from "./validators"
 import { linkProductWithPersonWorkflow } from "../../../../../workflows/products/link-unlink-products-with-people"
@@ -142,12 +143,13 @@ export const POST = async (
   const { id } = req.params
   const { personId } = req.validatedBody
 
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const { errors } = await linkProductWithPersonWorkflow(req.scope).run({
     input: { productId: id, personId },
   })
 
   if (errors.length) {
-    console.warn("Error reported at", errors)
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`)
     throw errors
   }
 

--- a/apps/backend/src/api/admin/products/[id]/unlinkDesign/route.ts
+++ b/apps/backend/src/api/admin/products/[id]/unlinkDesign/route.ts
@@ -55,6 +55,7 @@
  *   "type": "invalid_data"
  * }
  */
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework";
 import { unlinkProductFromDesignWorkflow } from "../../../../../workflows/products/link-unlink-products-with-designs";
 import { UnlinkDesignValidator } from "../linkDesign/validators";
@@ -76,6 +77,7 @@ export const POST = async (
     throw new MedusaError(MedusaError.Types.NOT_FOUND, `Design with id ${designId} was not found`)
   }
 
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const { errors } = await unlinkProductFromDesignWorkflow(req.scope).run({
     input: {
       productId: id,
@@ -84,7 +86,7 @@ export const POST = async (
   })
 
   if (errors.length > 0) {
-    console.warn("Error reported at", errors);
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`);
     throw errors;
   }
   // We must verify using the refetch if the design is unlinked

--- a/apps/backend/src/api/admin/products/[id]/unlinkPerson/route.ts
+++ b/apps/backend/src/api/admin/products/[id]/unlinkPerson/route.ts
@@ -88,6 +88,7 @@
  *   }
  * }
  */
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
 import { UnlinkPersonValidator } from "../linkPerson/validators"
 import { unlinkProductFromPersonWorkflow } from "../../../../../workflows/products/link-unlink-products-with-people"
@@ -100,12 +101,13 @@ export const POST = async (
   const { id } = req.params
   const { personId } = req.validatedBody
 
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
   const { errors } = await unlinkProductFromPersonWorkflow(req.scope).run({
     input: { productId: id, personId },
   })
 
   if (errors.length) {
-    console.warn("Error reported at", errors)
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`)
     throw errors
   }
 


### PR DESCRIPTION
Part of #701 (console.* → Medusa logger standardization). **Wave 3b**: admin catalog/ops route handlers.

## Scope
Migrated every runtime `console.*` → the Medusa logger in (~80 calls, 40 files):
- `src/api/admin/designs`
- `src/api/admin/medias`
- `src/api/admin/persons`
- `src/api/admin/inventory-items`
- `src/api/admin/products`

No other `src/api/admin` dirs touched (waves 0/1/2 already merged).

## Pattern (mirrors merged waves)
- Route handlers: `const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)` (import from `@medusajs/framework/utils`).
- Helper `getAllInventoryWithRawMaterial` (no `req`, has a `container` param): resolves logger from `container`; its chatty filter-trace logs → `logger.debug`.
- Mapping: `console.log/info`→`info`, `warn`→`warn`, `error`→`error`.
- Medusa Logger takes a **single string** (except `.error(string, error)`); multi-arg / object payloads folded into one template string — no logged data dropped.
- `[tag]` prefixes + message text preserved verbatim. JSDoc-comment `console` examples left untouched.

## Verify
- `grep -rn 'console\.' <the 5 dirs>` → only JSDoc/comment examples remain (zero runtime calls).
- `npx tsc --noEmit -p tsconfig.json` → 69 errors = pre-existing baseline, **zero new**.
- Mechanical 1:1 transport swap; no control-flow change → no new unit tests.

## Notes
- Bulk drafted by the free model (delegate.mjs), then Claude-verified + typechecked. Two trap files (`medias/folders/route.ts` JSDoc-comment trap, `inventory-items/[id]/rawmaterials/helpers.ts` container-param) + one missed POST-handler call in `persons/[id]/contacts/route.ts` were fixed by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)