### PR TITLE
chore(#701): logger standardization wave 3c (admin platform/flows)

### DIFF
--- a/apps/backend/src/api/admin/ai/chat/resolve/route.ts
+++ b/apps/backend/src/api/admin/ai/chat/resolve/route.ts
@@ -26,6 +26,7 @@
  */
 
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { HybridQueryResolverService } from "../../../../../mastra/services/hybrid-query-resolver"
 
 // Singleton instance
@@ -82,7 +83,8 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
       },
     })
   } catch (error: any) {
-    console.error("[AI Chat Resolve] Error:", error)
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger.error(`[AI Chat Resolve] Error: ${error}`)
     res.status(500).json({
       error: error.message || "Failed to resolve query",
     })
@@ -124,7 +126,8 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       },
     })
   } catch (error: any) {
-    console.error("[AI Chat Resolve] Error:", error)
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger.error(`[AI Chat Resolve] Error: ${error}`)
     res.status(500).json({
       error: error.message || "Failed to get resolver status",
     })

--- a/apps/backend/src/api/admin/ai/openapi/catalog/route.ts
+++ b/apps/backend/src/api/admin/ai/openapi/catalog/route.ts
@@ -131,6 +131,7 @@
  * }
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import yaml from "js-yaml"
 import { OpenApiGeneratorV31 } from "@asteasolutions/zod-to-openapi"
 import { buildRegistry } from "../custom/registry"
@@ -242,7 +243,10 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       }
       doc.paths = basePaths
     } catch (e: any) {
-      try { console.warn("[openapi][catalog] failed to merge custom spec", e?.message || e) } catch { }
+      try {
+        const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+        logger.warn(`[openapi][catalog] failed to merge custom spec ${e?.message || e}`)
+      } catch { }
     }
 
     const items: Array<{

--- a/apps/backend/src/api/admin/ai/openapi/custom/registry.ts
+++ b/apps/backend/src/api/admin/ai/openapi/custom/registry.ts
@@ -2,6 +2,7 @@ import { OpenAPIRegistry } from "@asteasolutions/zod-to-openapi"
 import { z } from "zod"
 import * as fs from "fs"
 import * as path from "path"
+import { logger } from "@medusajs/framework"
 import "./zod-openapi-extend"
 
 let cachedRegistry: OpenAPIRegistry | null = null
@@ -13,7 +14,7 @@ export const buildRegistry = () => {
 
   // Diagnostics: verify Zod is extended
   const zodHasOpenApi = typeof (z as any)?.ZodType?.prototype?.openapi === "function"
-  console.log("[openapi] Zod has openapi on prototype:", zodHasOpenApi)
+  logger.info(`[openapi] Zod has openapi on prototype: ${zodHasOpenApi}`)
 
   // -----------------------------
   // OpenAPI-safe schema variants
@@ -134,9 +135,9 @@ export const buildRegistry = () => {
   const tryRegister = (name: string, schema: any) => {
     try {
       registry.register(name, schema)
-      console.log(`[openapi] registered schema: ${name}`)
+      logger.debug(`[openapi] registered schema: ${name}`)
     } catch (e) {
-      console.error(`[openapi] failed to register schema: ${name}`, e)
+      logger.error(`[openapi] failed to register schema: ${name}: ${e}`)
       throw e
     }
   }
@@ -149,9 +150,9 @@ export const buildRegistry = () => {
       }
       registeredPathKeys.add(key)
       registry.registerPath(path)
-      console.log(`[openapi] registered path: ${path.path}`)
+      logger.debug(`[openapi] registered path: ${path.path}`)
     } catch (e) {
-      console.error(`[openapi] failed to register path: ${path.path}`, e)
+      logger.error(`[openapi] failed to register path: ${path.path}: ${e}`)
       throw e
     }
   }
@@ -443,10 +444,10 @@ export const buildRegistry = () => {
           }
         }
         try {
-          console.log(`[openapi][auto] registering ${m} ${pth} from ${rel}`)
+          logger.debug(`[openapi][auto] registering ${m} ${pth} from ${rel}`)
           tryRegisterPath(def)
         } catch (e) {
-          console.error(`[openapi][auto] failed to register ${m} ${pth} from ${rel}`, e)
+          logger.error(`[openapi][auto] failed to register ${m} ${pth} from ${rel}: ${e}`)
         }
       }
     }
@@ -455,7 +456,7 @@ export const buildRegistry = () => {
   try {
     autoRegister()
   } catch (e) {
-    console.warn("[openapi] autoRegister failed", (e as any)?.message || e)
+    logger.warn(`[openapi] autoRegister failed ${(e as any)?.message || e}`)
   }
 
   // --- Paths: Persons ---

--- a/apps/backend/src/api/admin/ai/workflows/[runId]/resume/route.ts
+++ b/apps/backend/src/api/admin/ai/workflows/[runId]/resume/route.ts
@@ -37,6 +37,7 @@
  * @property {string} message - Error message
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { mastra, mastraStorageInit } from "../../../../../../mastra"
 import { runStorage } from "../../../../../../mastra/run-storage"
 import { generalChatAgent } from "../../../../../../mastra/agents"
@@ -187,7 +188,8 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
             error: (workflowOutput as any)?.error,
         })
     } catch (error: any) {
-        console.error("[HITL Resume] Error:", error)
+        const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+        logger.error(`[HITL Resume] Error: ${error}`)
         return res.status(500).json({
             message: error?.message || "Workflow resume failed",
         })

--- a/apps/backend/src/api/admin/ai/workflows/multi-step/route.ts
+++ b/apps/backend/src/api/admin/ai/workflows/multi-step/route.ts
@@ -80,6 +80,7 @@
  * }
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { mastra, mastraStorageInit } from "../../../../../mastra"
 import { runStorage } from "../../../../../mastra/run-storage"
 import { v4 as uuidv4 } from "uuid"
@@ -153,7 +154,8 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
             result: result.state?.[0]?.output,
         })
     } catch (error: any) {
-        console.error("[HITL Trigger] Error:", error)
+        const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+        logger.error(`[HITL Trigger] Error: ${error}`)
         return res.status(500).json({
             message: error?.message || "Workflow execution failed",
         })

--- a/apps/backend/src/api/admin/analytics/live/route.ts
+++ b/apps/backend/src/api/admin/analytics/live/route.ts
@@ -64,7 +64,7 @@
  *
  * : heartbeat
  */
-import { MedusaRequest, MedusaResponse } from "@medusajs/framework";
+import { MedusaRequest, MedusaResponse, logger } from "@medusajs/framework";
 import { analyticsConnections } from "../../../../subscribers/analytics-realtime";
 import { ANALYTICS_MODULE } from "../../../../modules/analytics";
 import AnalyticsService from "../../../../modules/analytics/service";
@@ -201,7 +201,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     const stats = await getCurrentStats(analyticsService, website_id as string);
     res.write(`data: ${JSON.stringify({ type: 'connected', data: stats })}\n\n`);
   } catch (error) {
-    console.error("[Analytics Live] Error getting initial stats:", error);
+    logger.error(`[Analytics Live] Error getting initial stats: ${error}`);
   }
 
   // Send heartbeat every 30 seconds to keep connection alive
@@ -226,7 +226,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       res.write(`data: ${JSON.stringify({ type: 'connected', data: stats })}\n\n`);
     } catch (error) {
       // Keep the stream alive on a transient query/write error; the next tick retries.
-      console.error("[Analytics Live] Error refreshing stats:", error);
+      logger.error(`[Analytics Live] Error refreshing stats: ${error}`);
     }
   }, refreshMs);
 

--- a/apps/backend/src/api/admin/categories/rawmaterials/route.ts
+++ b/apps/backend/src/api/admin/categories/rawmaterials/route.ts
@@ -110,6 +110,7 @@
  * @see createRawMaterialCategoryWorkflow
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { listRawMaterialCategoriesWorkflow } from "../../../../workflows/raw-materials/list-raw-material-category";
 import { CreateMaterialTypeType, ReadRawMaterialCategoriesType } from "./validators";
 import { createRawMaterialCategoryWorkflow } from "../../../../workflows/raw-materials/create-raw-material-category";
@@ -150,7 +151,8 @@ export const GET = async (
 
 
     if (errors && errors.length > 0) {
-      console.warn("Error reported at", errors);
+      const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+      logger.warn(`Error reported at ${JSON.stringify(errors)}`);
       throw errors;
     }
 
@@ -190,7 +192,8 @@ export const POST = async (
   });
 
   if (errors && errors.length > 0) {
-    console.warn("Error reported at", errors);
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`);
     return res.status(400).json({ error: errors[0] });
   }
 

--- a/apps/backend/src/api/admin/inventory-orders/[id]/feedbacks/route.ts
+++ b/apps/backend/src/api/admin/inventory-orders/[id]/feedbacks/route.ts
@@ -99,7 +99,8 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       count: feedbacks.length,
     });
   } catch (error) {
-    console.error("Error fetching inventory order feedbacks:", error);
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger.error(`Error fetching inventory order feedbacks: ${error}`);
     return res.status(500).json({
       message: "Failed to fetch inventory order feedbacks",
       error: error instanceof Error ? error.message : String(error),
@@ -131,7 +132,8 @@ export const POST = async (
       feedback: result.feedback,
     });
   } catch (error) {
-    console.error("Error creating inventory order feedback:", error);
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger.error(`Error creating inventory order feedback: ${error}`);
     return res.status(500).json({
       message: "Failed to create inventory order feedback",
       error: error instanceof Error ? error.message : String(error),

--- a/apps/backend/src/api/admin/inventory-orders/[id]/tasks/route.ts
+++ b/apps/backend/src/api/admin/inventory-orders/[id]/tasks/route.ts
@@ -87,6 +87,7 @@
  *  - Use the `fields` query on GET to limit returned task fields and reduce payload size.
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { createTasksFromTemplatesWorkflow } from "../../../../../workflows/inventory_orders/create-tasks-from-templates"
 import { getInventoryOrderTasksWorkflow } from "../../../../../workflows/inventory_orders/get-inventory-order-tasks"
 import { AdminPostInventoryOrderTasksReqType } from "./validators"
@@ -96,7 +97,8 @@ import { refetchTask } from "./helpers"
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const { id } = req.params
   const fields = req.query.fields ? (req.query.fields as string).split(',') : undefined
-  console.log(req.queryConfig)
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  logger.debug(`queryConfig: ${JSON.stringify(req.queryConfig)}`)
   // Use the workflow which handles validation and retrieval
   const { result } = await getInventoryOrderTasksWorkflow(req.scope).run({
     input: {

--- a/apps/backend/src/api/admin/inventory-orders/route.ts
+++ b/apps/backend/src/api/admin/inventory-orders/route.ts
@@ -105,7 +105,8 @@ export const POST = async (
   });
 
   if (errors.length > 0) {
-    console.warn("Error reported at", errors);
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`);
     throw errors;
   }
 

--- a/apps/backend/src/api/admin/messaging/[conversationId]/route.ts
+++ b/apps/backend/src/api/admin/messaging/[conversationId]/route.ts
@@ -3,6 +3,7 @@ import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/util
 import { MESSAGING_MODULE } from "../../../../modules/messaging"
 import { SOCIAL_PROVIDER_MODULE } from "../../../../modules/social-provider"
 import type SocialProviderService from "../../../../modules/social-provider/service"
+import { logger } from "@medusajs/framework"
 import { buildContextSnapshot } from "../context-builder"
 import type { SendMessageInput } from "../validators"
 
@@ -263,10 +264,7 @@ async function resolveConversationSender(
         conversation.default_sender_platform_id
       )
     } catch (e: any) {
-      console.warn(
-        "[messaging] Pinned sender no longer available, falling back:",
-        e.message
-      )
+      logger.warn(`[messaging] Pinned sender no longer available, falling back: ${e.message}`)
     }
   }
 

--- a/apps/backend/src/api/admin/partners/[id]/feedbacks/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/feedbacks/route.ts
@@ -139,7 +139,8 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       count: feedbacks.length,
     });
   } catch (error) {
-    console.error("Error fetching partner feedbacks:", error);
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger.error(`Error fetching partner feedbacks: ${error}`);
     return res.status(500).json({
       message: "Failed to fetch partner feedbacks",
       error: error instanceof Error ? error.message : String(error),
@@ -171,7 +172,8 @@ export const POST = async (
       feedback: result.feedback,
     });
   } catch (error) {
-    console.error("Error creating partner feedback:", error);
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger.error(`Error creating partner feedback: ${error}`);
     return res.status(500).json({
       message: "Failed to create partner feedback",
       error: error instanceof Error ? error.message : String(error),

--- a/apps/backend/src/api/admin/partners/[id]/tasks/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/tasks/route.ts
@@ -171,7 +171,8 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
             count: tasks.length
         });
     } catch (error) {
-        console.error("Error fetching partner tasks:", error);
+        const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+        logger.error(`Error fetching partner tasks: ${error}`);
         return res.status(500).json({ 
             message: "Failed to fetch partner tasks",
             error: error instanceof Error ? error.message : String(error)
@@ -266,7 +267,8 @@ export const POST = async (req: MedusaRequest<AdminCreatePartnerTaskReq>, res: M
             task: task
         });
     } catch (error) {
-        console.error("Error creating partner task:", error);
+        const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+        logger.error(`Error creating partner task: ${error}`);
         return res.status(500).json({ 
             message: "Failed to create partner task",
             error: error instanceof Error ? error.message : String(error)

--- a/apps/backend/src/api/admin/partners/route.ts
+++ b/apps/backend/src/api/admin/partners/route.ts
@@ -155,7 +155,7 @@
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { listPartnersWorkflow } from "../../../workflows/partners/list-partners"
-import { MedusaError, Modules } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
 import { createPartnerAdminWithRegistrationWorkflow } from "../../../workflows/partner/create-partner-admin"
 import { buildQSearchFilter } from "../../../lib/list-search-filters"
 import { PostPartnerWithAdminSchema } from "./validators"
@@ -254,7 +254,8 @@ export const POST = async (
 
   // Emit partner.created.fromAdmin with the workflow-provided temp password
   const eventService = req.scope.resolve(Modules.EVENT_BUS)
-  console.log("Emitting partner.created.fromAdmin event",payload)
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  logger.info(`Emitting partner.created.fromAdmin event ${JSON.stringify(payload)}`)
   eventService.emit({
     name: "partner.created.fromAdmin",
     data: {

--- a/apps/backend/src/api/admin/persontypes/[id]/route.ts
+++ b/apps/backend/src/api/admin/persontypes/[id]/route.ts
@@ -119,7 +119,7 @@ import { deletePersonTypeWorkflow } from "../../../../workflows/person_type/dele
 import { PERSON_TYPE_MODULE } from "../../../../modules/persontype";
 import PersonTypeService from "../../../../modules/persontype/service";
 import { PersonTypeAllowedFields, refetchPersonType } from "../helpers";
-import { MedusaError } from "@medusajs/framework/utils";
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils";
 import { updatePersonTypeWorkflow } from "../../../../workflows/person_type/update-person_type";
 import { AdminPersonTypeResponse } from "../../../../admin/hooks/api/personandtype";
 
@@ -135,7 +135,8 @@ export const DELETE = async (
     },
   });
   if (errors.length > 1) {
-    console.warn("Error reported at", errors);
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER);
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`);
     throw errors;
   }
   res.status(200).json({

--- a/apps/backend/src/api/admin/production-runs/[id]/cancel/route.ts
+++ b/apps/backend/src/api/admin/production-runs/[id]/cancel/route.ts
@@ -4,6 +4,7 @@ import { PRODUCTION_RUNS_MODULE } from "../../../../../modules/production_runs"
 import type ProductionRunService from "../../../../../modules/production_runs/service"
 import { TASKS_MODULE } from "../../../../../modules/tasks"
 import { mirrorRunStatusToUnifiedOrder } from "../../../../../workflows/production-runs/dual-write-unified-run-order"
+import { logger } from "@medusajs/framework"
 
 /**
  * Cancel a single run: update status, cancel tasks.
@@ -45,7 +46,7 @@ async function cancelSingleRun(
       }
     }
   } catch (e: any) {
-    console.error(`[cancel-production-run] Failed to cancel tasks for ${runId}:`, e.message)
+    logger.error(`[cancel-production-run] Failed to cancel tasks for ${runId}: ${e.message}`)
   }
 
   const updated = await productionRunService.retrieveProductionRun(runId)
@@ -109,7 +110,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
       if (!skipped) cancelledChildren.push(child.id)
     }
   } catch (e: any) {
-    console.error("[cancel-production-run] Failed to cancel children:", e.message)
+    logger.error(`[cancel-production-run] Failed to cancel children: ${e.message}`)
   }
 
   // If this is a child run, check if all siblings are now terminal → cancel parent
@@ -137,7 +138,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
         }
       }
     } catch (e: any) {
-      console.error("[cancel-production-run] Failed to check/cancel parent:", e.message)
+      logger.error(`[cancel-production-run] Failed to check/cancel parent: ${e.message}`)
     }
   }
 

--- a/apps/backend/src/api/admin/task-templates/[id]/route.ts
+++ b/apps/backend/src/api/admin/task-templates/[id]/route.ts
@@ -111,6 +111,7 @@ import {
   MedusaRequest,
   MedusaResponse,
 } from "@medusajs/framework/http";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { UpdateTaskTemplate } from "../validators";
 import { updateTaskTemplateWorkflow } from "../../../../workflows/task-templates/update-template";
 import { deleteTaskTemplateWorkflow } from "../../../../workflows/task-templates/delete-template";
@@ -161,7 +162,8 @@ export const PUT = async (
   });
 
   if (errors.length > 0) {
-    console.warn("Error reported at", errors);
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`);
     throw errors;
   }
 
@@ -189,7 +191,8 @@ export const DELETE = async (
   });
 
   if (errors.length > 0) {
-    console.warn("Error reported at", errors);
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`);
     throw errors;
   }
 

--- a/apps/backend/src/api/admin/task-templates/categories/route.ts
+++ b/apps/backend/src/api/admin/task-templates/categories/route.ts
@@ -66,6 +66,7 @@
  * }
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { listTaskTemplatesCategoriesWorkflow } from "../../../../workflows/task-templates/list-template-categories";
 
 type TaskTemplateCategoriesAllowedFields =
@@ -105,10 +106,11 @@ export const GET = async (
       });
   
       if (errors.length > 0) {
-        console.warn("Error reported at", errors);
+        const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+        logger.warn(`Error reported at ${JSON.stringify(errors)}`);
         throw errors;
       }
-  
+
       const { categories, count } = result;
   
       res.status(200).json({

--- a/apps/backend/src/api/admin/task-templates/route.ts
+++ b/apps/backend/src/api/admin/task-templates/route.ts
@@ -152,6 +152,7 @@ import {
   MedusaRequest,
   MedusaResponse,
 } from "@medusajs/framework/http";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 
 import { TaskTemplate } from "./validators";
 import { createTaskTemplateWorkflow } from "../../../workflows/task-templates/create-template";
@@ -173,7 +174,8 @@ export const POST = async (
   });
 
   if (errors.length > 0) {
-    console.warn("Error reported at", errors);
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`);
     throw errors;
   }
 
@@ -222,7 +224,8 @@ export const GET = async (
     });
 
     if (errors.length > 0) {
-      console.warn("Error reported at", errors);
+      const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+      logger.warn(`Error reported at ${JSON.stringify(errors)}`);
       throw errors;
     }
 

--- a/apps/backend/src/api/admin/tasks/[id]/comments/route.ts
+++ b/apps/backend/src/api/admin/tasks/[id]/comments/route.ts
@@ -114,7 +114,7 @@
  * }
  */
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework";
-import { MedusaError } from "@medusajs/framework/utils";
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils";
 import { TASKS_MODULE } from "../../../../../modules/tasks";
 import TaskService from "../../../../../modules/tasks/service";
 
@@ -189,7 +189,8 @@ export async function POST(
             }
         } catch (error) {
             // If we can't fetch admin info, use default
-            console.warn("Could not fetch admin user info:", error);
+            const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+            logger.warn(`Could not fetch admin user info: ${error}`);
         }
 
         // Create new comment
@@ -226,7 +227,8 @@ export async function POST(
             });
         }
         
-        console.error("Error adding comment to task:", error);
+        const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+        logger.error(`Error adding comment to task: ${error}`);
         return res.status(500).json({
             message: "Failed to add comment to task"
         });
@@ -273,7 +275,8 @@ export async function GET(
             });
         }
         
-        console.error("Error fetching task comments:", error);
+        const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+        logger.error(`Error fetching task comments: ${error}`);
         return res.status(500).json({
             message: "Failed to fetch task comments"
         });

--- a/apps/backend/src/api/admin/tasks/[id]/feedbacks/route.ts
+++ b/apps/backend/src/api/admin/tasks/[id]/feedbacks/route.ts
@@ -139,7 +139,8 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       count: feedbacks.length,
     });
   } catch (error) {
-    console.error("Error fetching task feedbacks:", error);
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger.error(`Error fetching task feedbacks: ${error}`);
     return res.status(500).json({
       message: "Failed to fetch task feedbacks",
       error: error instanceof Error ? error.message : String(error),
@@ -171,7 +172,8 @@ export const POST = async (
       feedback: result.feedback,
     });
   } catch (error) {
-    console.error("Error creating task feedback:", error);
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger.error(`Error creating task feedback: ${error}`);
     return res.status(500).json({
       message: "Failed to create task feedback",
       error: error instanceof Error ? error.message : String(error),

--- a/apps/backend/src/api/admin/visual-flows/[id]/execute/route.ts
+++ b/apps/backend/src/api/admin/visual-flows/[id]/execute/route.ts
@@ -57,6 +57,7 @@
  * }
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { z } from "@medusajs/framework/zod"
 import { executeVisualFlowWorkflow } from "../../../../../workflows/visual-flows"
 import { VISUAL_FLOWS_MODULE } from "../../../../../modules/visual_flows"
@@ -113,7 +114,8 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     })
     
     if (errors?.length) {
-      console.error("[visual-flows] Execute workflow errors:", errors)
+      const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+      logger.error(`[visual-flows] Execute workflow errors: ${JSON.stringify(errors)}`)
       return res.status(500).json({ 
         error: "Failed to execute flow", 
         details: errors 

--- a/apps/backend/src/api/admin/visual-flows/[id]/route.ts
+++ b/apps/backend/src/api/admin/visual-flows/[id]/route.ts
@@ -69,7 +69,7 @@
  * - 500: Workflow execution errors
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { MedusaError } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 import { VISUAL_FLOWS_MODULE } from "../../../../modules/visual_flows"
 import VisualFlowService from "../../../../modules/visual_flows/service"
 import { z } from "@medusajs/framework/zod"
@@ -147,12 +147,13 @@ export const PUT = async (req: MedusaRequest, res: MedusaResponse) => {
   }
   const data = parsed.data
 
-  console.log("[visual-flows PUT] Received update:", {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  logger.info(`[visual-flows PUT] Received update: ${JSON.stringify({
     id,
     operationsCount: data.operations?.length || 0,
     connectionsCount: data.connections?.length || 0,
     operations: data.operations?.map((o) => ({ key: o.operation_key, type: o.operation_type })),
-  })
+  })}`)
 
   const { result: flow, errors } = await updateVisualFlowWorkflow(req.scope).run({
     input: {
@@ -172,7 +173,7 @@ export const PUT = async (req: MedusaRequest, res: MedusaResponse) => {
   })
 
   if (errors?.length) {
-    console.error("[visual-flows] Update workflow errors:", errors)
+    logger.error(`[visual-flows] Update workflow errors: ${JSON.stringify(errors)}`)
     throw new MedusaError(
       MedusaError.Types.UNEXPECTED_STATE,
       `Failed to update flow: ${errors.map((e: any) => e?.error?.message ?? String(e)).join("; ")}`
@@ -194,7 +195,8 @@ export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
   })
 
   if (errors?.length) {
-    console.error("[visual-flows] Delete workflow errors:", errors)
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger.error(`[visual-flows] Delete workflow errors: ${JSON.stringify(errors)}`)
     throw new MedusaError(
       MedusaError.Types.UNEXPECTED_STATE,
       `Failed to delete flow: ${errors.map((e: any) => e?.error?.message ?? String(e)).join("; ")}`

--- a/apps/backend/src/api/admin/visual-flows/metadata/route.ts
+++ b/apps/backend/src/api/admin/visual-flows/metadata/route.ts
@@ -94,6 +94,7 @@
  * of module discovery, entity query testing, and workflow extraction.
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { logger } from "@medusajs/framework"
 import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import { WorkflowManager } from "@medusajs/orchestration"
 import { DmlEntity, camelToSnakeCase, pluralize } from "@medusajs/utils"
@@ -715,7 +716,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       },
     })
   } catch (error: any) {
-    console.error("[visual-flows/metadata] Error:", error)
+    logger.error(`[visual-flows/metadata] Error: ${error}`)
     res.status(500).json({ error: error.message })
   }
 }
@@ -1381,14 +1382,14 @@ function getRegisteredEventsFromContainer(container: any): EventMetadata[] {
     const eventBusService = container.resolve(Modules.EVENT_BUS) as any
     
     if (!eventBusService) {
-      console.log("[metadata] Event Bus service not found, returning fallback events")
+      logger.info("[metadata] Event Bus service not found, returning fallback events")
       return getFallbackEvents()
     }
     // Access the eventToSubscribersMap_ which contains all registered events
     const eventMap = eventBusService.eventToSubscribersMap_ as Map<string, any[]> | undefined
     
     if (!eventMap || eventMap.size === 0) {
-      console.log("[metadata] No events found in Event Bus, returning fallback events")
+      logger.info("[metadata] No events found in Event Bus, returning fallback events")
       return getFallbackEvents()
     }
     
@@ -1419,11 +1420,11 @@ function getRegisteredEventsFromContainer(container: any): EventMetadata[] {
       return a.name.localeCompare(b.name)
     })
     
-    console.log(`[metadata] Found ${events.length} registered events from Event Bus`)
+    logger.info(`[metadata] Found ${events.length} registered events from Event Bus`)
     return events
     
   } catch (error: any) {
-    console.error("[metadata] Error getting events from Event Bus:", error.message)
+    logger.error(`[metadata] Error getting events from Event Bus: ${error.message}`)
     return getFallbackEvents()
   }
 }
@@ -1535,7 +1536,7 @@ async function getTriggerableFlows(container: any): Promise<TriggerableFlow[]> {
     const visualFlowsModule = container.resolve("visual_flows") as any
     
     if (!visualFlowsModule) {
-      console.log("[metadata] Visual Flows module not found")
+      logger.info("[metadata] Visual Flows module not found")
       return []
     }
     
@@ -1555,11 +1556,11 @@ async function getTriggerableFlows(container: any): Promise<TriggerableFlow[]> {
         status: flow.status,
       }))
     
-    console.log(`[metadata] Found ${triggerableFlows.length} triggerable flows`)
+    logger.info(`[metadata] Found ${triggerableFlows.length} triggerable flows`)
     return triggerableFlows
     
   } catch (error: any) {
-    console.error("[metadata] Error getting triggerable flows:", error.message)
+    logger.error(`[metadata] Error getting triggerable flows: ${error.message}`)
     return []
   }
 }

--- a/apps/backend/src/api/admin/visual-flows/route.ts
+++ b/apps/backend/src/api/admin/visual-flows/route.ts
@@ -85,7 +85,7 @@
  * }
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { MedusaError } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 import { VISUAL_FLOWS_MODULE } from "../../../modules/visual_flows"
 import VisualFlowService from "../../../modules/visual_flows/service"
 import { z } from "@medusajs/framework/zod"
@@ -226,7 +226,8 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   })
 
   if (errors?.length) {
-    console.error("[visual-flows] Create workflow errors:", errors)
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger.error(`[visual-flows] Create workflow errors: ${JSON.stringify(errors)}`)
     throw new MedusaError(
       MedusaError.Types.UNEXPECTED_STATE,
       `Failed to create flow: ${errors.map((e: any) => e?.error?.message ?? String(e)).join("; ")}`

--- a/apps/backend/src/api/admin/websites/[id]/blogs/categories/route.ts
+++ b/apps/backend/src/api/admin/websites/[id]/blogs/categories/route.ts
@@ -42,6 +42,7 @@
  * }
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { fetchAllCategoriesPerSiteWorkflow } from "../../../../../../workflows/website/website-page/fetch-all-categories-per-site";
 
 export async function GET(req: MedusaRequest, res: MedusaResponse) {
@@ -59,7 +60,8 @@ export async function GET(req: MedusaRequest, res: MedusaResponse) {
 
     return res.status(200).json({ categories });
   } catch (error) {
-    console.error("Error fetching blog categories by website ID:", error);
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger.error(`Error fetching blog categories by website ID: ${error}`);
     // Consider more specific error handling based on workflow errors
     return res.status(500).json({ message: "Internal server error" });
   }

--- a/apps/backend/src/api/admin/websites/[id]/pages/[pageId]/route.ts
+++ b/apps/backend/src/api/admin/websites/[id]/pages/[pageId]/route.ts
@@ -25,6 +25,7 @@ import {
   MedusaRequest,
   MedusaResponse,
 } from "@medusajs/framework";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { DeletePageSchema, UpdatePageSchema } from "../validators";
 import { deletePageWorkflow } from "../../../../../../workflows/website/website-page/delete-page";
 import { WEBSITE_MODULE } from "../../../../../../modules/website";
@@ -45,7 +46,8 @@ export const DELETE = async (
   });
 
   if (errors.length > 1) {
-    console.warn("Error reported at", errors);
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`);
     throw errors;
   }
   res.status(200).json({
@@ -82,7 +84,8 @@ export const PUT = async (
   });
 
   if (errors.length > 1) {
-    console.warn("Error reported at", errors);
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`);
     throw errors;
   }
   // Refetch by the URL-derived `pageId`, not the workflow result —

--- a/apps/backend/src/api/admin/websites/[id]/pages/[pageId]/subs/route.ts
+++ b/apps/backend/src/api/admin/websites/[id]/pages/[pageId]/subs/route.ts
@@ -61,6 +61,7 @@
  * }
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { z } from "@medusajs/framework/zod";
 import { sendBlogSubscribersWorkflow } from "../../../../../../../workflows/blogs/send-blog-subscribers";
 import { WEBSITE_MODULE } from "../../../../../../../modules/website";
@@ -141,7 +142,8 @@ export const POST = async (
       subscribers: result.totalSubscribers
     });
   } catch (error) {
-    console.error("Error sending blog to subscribers:", error);
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger.error(`Error sending blog to subscribers: ${error}`);
     
     return res.status(500).json({
       message: "Failed to send blog to subscribers",

--- a/apps/backend/src/api/admin/websites/[id]/pages/[pageId]/subs/test/route.ts
+++ b/apps/backend/src/api/admin/websites/[id]/pages/[pageId]/subs/test/route.ts
@@ -121,6 +121,7 @@
  * }
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { z } from "@medusajs/framework/zod";
 import { sendTestBlogEmailWorkflow } from "../../../../../../../../workflows/blogs/send-blog-subscribers";
 import { WEBSITE_MODULE } from "../../../../../../../../modules/website";
@@ -202,7 +203,8 @@ export const POST = async (
       error: result.error
     });
   } catch (error) {
-    console.error("Error sending test blog email:", error);
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger.error(`Error sending test blog email: ${error}`);
     
     return res.status(500).json({
       message: "Failed to send test blog email",

--- a/apps/backend/src/api/admin/websites/[id]/route.ts
+++ b/apps/backend/src/api/admin/websites/[id]/route.ts
@@ -124,6 +124,7 @@ import {
   MedusaRequest,
   MedusaResponse,
 } from "@medusajs/framework";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { DeleteWebsiteSchema, UpdateWebsiteSchema } from "../validators";
 import { deleteWebsiteWorkflow } from "../../../../workflows/website/delete-website";
 import { WEBSITE_MODULE } from "../../../../modules/website";
@@ -143,7 +144,8 @@ export const DELETE = async (
     },
   });
   if (errors.length > 1) {
-    console.warn("Error reported at", errors);
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`);
     throw errors;
   }
   res.status(200).json({
@@ -183,7 +185,8 @@ export const PUT = async (
   });
 
   if (errors.length > 1) {
-    console.warn("Error reported at", errors);
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger.warn(`Error reported at ${JSON.stringify(errors)}`);
     throw errors;
   }
 


### PR DESCRIPTION
## #701 logger standardization — wave 3c (admin platform/flows)

Continues the `console.*` → Medusa logger migration. **Part of `src/api/admin`** (waves 0/1/2 already merged for marketing, subscribers/jobs, non-admin api; wave 3a social/ads, 3b designs/catalog are separate open PRs). Off fresh `origin/main`.

### Scope (this wave only, ~63 calls / 30 files)
`visual-flows`, `ai`, `websites`, `tasks`, `task-templates`, `partners`, `inventory-orders`, `production-runs`, `categories`, `analytics`, `persontypes`, `messaging`.

`editor-files` — its only `console.log` is inside a JSDoc fetch example, left untouched. The `categories/rawmaterials` JSDoc line referencing `console.warn` is also a comment, untouched.

### Patterns (mirror, not invent)
- **Route handlers** (`req` in scope): `const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)` — canonical admin pattern (matches merged `marketing/newsletter/generate` & `ops/maintenance-jobs/batches`).
- **Helper files / helper functions / SSE `setInterval` closures** with no `req`: global `import { logger } from "@medusajs/framework"` — `ai/openapi/custom/registry.ts`, `visual-flows/metadata` helper fns, `messaging` sender resolver, `production-runs/[id]/cancel` helper, `analytics/live` SSE.
- Logger methods take a **single string**: extra args folded into the template (`${JSON.stringify(obj)}`, `${error}`, `${e.message}`). Message text + `[tags]` preserved verbatim.
- Mapping: `log→info` (`debug` for chatty openapi-registry loop traces), `warn→warn`, `error→error`.

### Verify
- `grep -rn console\. <listed dirs>` → zero (excl. the 2 documented JSDoc-comment lines).
- `npx tsc --noEmit` → no new errors in touched files (the ~69 pre-existing errors are all in `integration-tests/`, `src/admin/*` UI, and unrelated `api/web` routes).

Mechanical 1:1 transport swaps — no behavior change, no new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)