### PR TITLE
feat(#452): playful artwork-rating on post-delivery feedback page

### DIFF
--- a/apps/backend/integration-tests/http/artwork-feedback.spec.ts
+++ b/apps/backend/integration-tests/http/artwork-feedback.spec.ts
@@ -1,0 +1,127 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { FEEDBACK_MODULE } from "../../src/modules/feedback"
+
+jest.setTimeout(60000)
+
+// #452 — playful artwork-rating on the public post-delivery feedback page.
+// GET /web/feedback/:id returns the feedback + a seeded set of curated artwork;
+// POST records the 1..5 rating and (optionally) the validated artwork pick into
+// the typed `chosen_artwork_id` / `artwork_affinity` columns.
+setupSharedTestSuite(() => {
+  describe("artwork feedback page (#452)", () => {
+    const { api, getContainer } = getSharedTestEnv()
+    let adminHeaders: any
+    const prevEnv = process.env.FEEDBACK_ARTWORK_ALBUM_ID
+
+    beforeAll(async () => {
+      await createAdminUser(getContainer())
+      adminHeaders = await getAuthHeaders(api)
+    })
+
+    afterAll(() => {
+      process.env.FEEDBACK_ARTWORK_ALBUM_ID = prevEnv
+    })
+
+    it("offers a seeded artwork set and records a validated pick + rating", async () => {
+      const unique = Date.now()
+      const service: any = getContainer().resolve(FEEDBACK_MODULE)
+
+      // A curated folder of public artwork = the artwork source.
+      const folderRes = await api.post(
+        "/admin/medias/folder",
+        { name: `Feedback Art ${unique}`, is_public: true },
+        adminHeaders
+      )
+      expect(folderRes.status).toBe(201)
+      const folderId = folderRes.data.folder.id
+      process.env.FEEDBACK_ARTWORK_ALBUM_ID = folderId
+
+      const mediaService: any = getContainer().resolve("media")
+      for (let n = 1; n <= 5; n++) {
+        await mediaService.createMediaFiles({
+          file_name: `art-${unique}-${n}.jpg`,
+          original_name: `art-${unique}-${n}.jpg`,
+          file_path: `https://cdn.example.com/art-${unique}-${n}.jpg`,
+          file_type: "image",
+          mime_type: "image/jpeg",
+          file_size: 1000,
+          file_hash: `arthash-${unique}-${n}`,
+          extension: "jpg",
+          is_public: true,
+          folder_id: folderId,
+        })
+      }
+
+      const feedback = await service.createFeedbacks({
+        order_id: `order_${unique}`,
+        submitted_by: "c@example.com",
+        submitted_at: new Date(),
+        status: "pending",
+        metadata: { source: "post_delivery_request" },
+      })
+
+      // GET — returns the feedback + a deterministic 3-artwork set.
+      const getRes = await api.get(`/web/feedback/${feedback.id}`)
+      expect(getRes.status).toBe(200)
+      expect(getRes.data.feedback.id).toBe(feedback.id)
+      const artworks = getRes.data.artworks
+      expect(Array.isArray(artworks)).toBe(true)
+      expect(artworks).toHaveLength(3)
+      expect(new Set(artworks.map((a: any) => a.id)).size).toBe(3)
+
+      // Same seed (same id) → stable set across renders.
+      const getRes2 = await api.get(`/web/feedback/${feedback.id}`)
+      expect(getRes2.data.artworks.map((a: any) => a.id)).toEqual(
+        artworks.map((a: any) => a.id)
+      )
+
+      // POST — rating + a valid offered artwork pick.
+      const chosen = artworks[1].id
+      const postRes = await api.post(`/web/feedback/${feedback.id}`, {
+        rating: 5,
+        artwork_id: chosen,
+        affinity: "calm",
+      })
+      expect(postRes.status).toBe(200)
+      expect(postRes.data.artwork_pick_rejected).toBe(false)
+      expect(postRes.data.feedback.rating).toBe("five")
+      expect(postRes.data.feedback.chosen_artwork_id).toBe(chosen)
+      expect(postRes.data.feedback.artwork_affinity).toBe("calm")
+
+      // Typed columns persisted durably.
+      const reloaded = (await service.listFeedbacks({ id: feedback.id }))[0]
+      expect(reloaded.chosen_artwork_id).toBe(chosen)
+      expect(reloaded.rating).toBe("five")
+      expect(reloaded.metadata?.artwork_pick?.artwork_id).toBe(chosen)
+      // Pre-existing metadata preserved.
+      expect(reloaded.metadata?.source).toBe("post_delivery_request")
+    })
+
+    it("rejects an artwork pick that was not offered", async () => {
+      const unique = Date.now() + 1
+      const service: any = getContainer().resolve(FEEDBACK_MODULE)
+      const feedback = await service.createFeedbacks({
+        order_id: `order_${unique}`,
+        submitted_by: "c2@example.com",
+        submitted_at: new Date(),
+        status: "pending",
+      })
+
+      const res = await api
+        .post(`/web/feedback/${feedback.id}`, { artwork_id: "art_not_offered" })
+        .catch((e: any) => e.response)
+      expect(res.status).toBe(400)
+
+      const reloaded = (await service.listFeedbacks({ id: feedback.id }))[0]
+      expect(reloaded.chosen_artwork_id).toBeFalsy()
+    })
+
+    it("404s an unknown feedback id", async () => {
+      const res = await api
+        .get(`/web/feedback/feedback_does_not_exist`)
+        .catch((e: any) => e.response)
+      expect(res.status).toBe(404)
+    })
+  })
+})

--- a/apps/backend/src/api/web/feedback/[id]/route.ts
+++ b/apps/backend/src/api/web/feedback/[id]/route.ts
@@ -1,0 +1,188 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils";
+
+import { FEEDBACK_MODULE } from "../../../../modules/feedback";
+import type FeedbackService from "../../../../modules/feedback/service";
+import { listAlbumMediaWorkflow } from "../../../../workflows/media/list-album-media";
+import { listMediaFileWorkflow } from "../../../../workflows/media/list-media-file";
+import {
+  ArtworkChoice,
+  buildArtworkPickUpdate,
+  mapMediaToArtworkChoice,
+  normalizeRatingValue,
+  resolveArtworkSourceId,
+  selectArtworkChoices,
+} from "../../../../workflows/feedback/lib/artwork-feedback";
+
+const ARTWORK_COUNT = 3;
+const POOL_TAKE = 100;
+
+/**
+ * Fetch the curated pool of public artwork images, drawn from an Album first
+ * (AlbumMedia → MediaFile) and falling back to a media FOLDER id — mirroring the
+ * album-vs-folder resolution in `GET /web/media`. Stable order (no DB-side
+ * randomisation); the per-token variation is applied by the pure
+ * `selectArtworkChoices` seeded selector.
+ */
+async function fetchArtworkPool(
+  req: MedusaRequest,
+  sourceId: string
+): Promise<ArtworkChoice[]> {
+  let mediaFiles: any[] = [];
+
+  try {
+    const { result } = await listAlbumMediaWorkflow(req.scope).run({
+      input: {
+        filters: { album: sourceId } as any,
+        config: { take: POOL_TAKE, skip: 0, relations: ["media"] },
+      },
+    });
+    const rows = (result as any)?.[0] ?? [];
+    mediaFiles = rows
+      .map((r: any) => r?.media)
+      .filter((m: any) => m && m.is_public !== false && m.file_type === "image");
+  } catch {
+    mediaFiles = [];
+  }
+
+  if (!mediaFiles.length) {
+    try {
+      const { result } = await listMediaFileWorkflow(req.scope).run({
+        input: {
+          filters: { folder_id: sourceId, is_public: true, file_type: "image" },
+          config: { take: POOL_TAKE, skip: 0 },
+        },
+      });
+      mediaFiles = ((result as any)?.[0] ?? []) as any[];
+    } catch {
+      mediaFiles = [];
+    }
+  }
+
+  return mediaFiles.map((m: any) => mapMediaToArtworkChoice(m));
+}
+
+/**
+ * Public, token-less feedback page payload (the token IS the feedback id, as in
+ * the post-delivery email link `${STORE_URL}/feedback/:id`). Returns the
+ * feedback request plus a small set of artwork images to pick from. Additive:
+ * if no artwork pool is configured, `artworks` is simply empty and the page
+ * falls back to a plain 1..5 rating.
+ *
+ * GET /web/feedback/:id
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params;
+  const service = req.scope.resolve(FEEDBACK_MODULE) as FeedbackService;
+
+  const rows = await service.listFeedbacks({ id });
+  const feedback = Array.isArray(rows) ? rows[0] : null;
+  if (!feedback) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Feedback not found");
+  }
+
+  const sourceId = resolveArtworkSourceId(process.env);
+  const pool = await fetchArtworkPool(req, sourceId);
+  const artworks = selectArtworkChoices(pool, id, ARTWORK_COUNT);
+
+  res.status(200).json({
+    feedback: {
+      id: feedback.id,
+      rating: feedback.rating,
+      status: feedback.status,
+      comment: feedback.comment ?? null,
+      chosen_artwork_id: feedback.chosen_artwork_id ?? null,
+      artwork_affinity: feedback.artwork_affinity ?? null,
+    },
+    artworks,
+  });
+};
+
+/**
+ * Record the customer's feedback from the page: the optional 1..5 rating, an
+ * optional comment, and the optional artwork pick. Every field is optional and
+ * additive — the artwork pick never replaces the rating. The chosen artwork is
+ * validated against the SAME seeded set the GET returns, so an arbitrary id
+ * can't be recorded.
+ *
+ * POST /web/feedback/:id  { rating?, comment?, artwork_id?, affinity? }
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params;
+  const body = (req.body || {}) as Record<string, any>;
+  const service = req.scope.resolve(FEEDBACK_MODULE) as FeedbackService;
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER);
+
+  const rows = await service.listFeedbacks({ id });
+  const feedback = Array.isArray(rows) ? rows[0] : null;
+  if (!feedback) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Feedback not found");
+  }
+
+  const update: Record<string, any> = { id };
+
+  const rating = normalizeRatingValue(body.rating);
+  if (rating) {
+    update.rating = rating;
+  }
+  if (typeof body.comment === "string" && body.comment.trim().length) {
+    update.comment = body.comment.trim();
+  }
+
+  let pickRejected = false;
+  const artworkId =
+    typeof body.artwork_id === "string" && body.artwork_id.trim().length
+      ? body.artwork_id.trim()
+      : null;
+
+  if (artworkId) {
+    const sourceId = resolveArtworkSourceId(process.env);
+    const pool = await fetchArtworkPool(req, sourceId);
+    const offeredIds = selectArtworkChoices(pool, id, ARTWORK_COUNT).map(
+      (a) => a.id
+    );
+    const pick = buildArtworkPickUpdate({
+      feedbackId: id,
+      artworkId,
+      affinity: body.affinity,
+      offeredIds,
+      existingMetadata: (feedback.metadata as any) ?? null,
+    });
+    if (pick) {
+      update.chosen_artwork_id = pick.chosen_artwork_id;
+      update.artwork_affinity = pick.artwork_affinity;
+      update.metadata = pick.metadata;
+    } else {
+      pickRejected = true;
+      logger.warn(
+        `Feedback ${id}: artwork pick ${artworkId} rejected (not among offered set)`
+      );
+    }
+  }
+
+  // Nothing valid to record — surface a 400 rather than a silent no-op.
+  const hasMutation = Object.keys(update).length > 1;
+  if (!hasMutation) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      pickRejected
+        ? "Selected artwork was not among the offered set"
+        : "No valid rating, comment or artwork pick supplied"
+    );
+  }
+
+  await service.updateFeedbacks(update);
+  const refreshed = (await service.listFeedbacks({ id }))?.[0] ?? null;
+
+  res.status(200).json({
+    feedback: refreshed && {
+      id: refreshed.id,
+      rating: refreshed.rating,
+      status: refreshed.status,
+      comment: refreshed.comment ?? null,
+      chosen_artwork_id: refreshed.chosen_artwork_id ?? null,
+      artwork_affinity: refreshed.artwork_affinity ?? null,
+    },
+    artwork_pick_rejected: pickRejected,
+  });
+};

--- a/apps/backend/src/modules/feedback/migrations/Migration20260624150000.ts
+++ b/apps/backend/src/modules/feedback/migrations/Migration20260624150000.ts
@@ -1,0 +1,28 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * #452 — playful artwork-rating in the post-delivery feedback flow.
+ *
+ * Add two durable, typed columns to the feedback model:
+ *  - `chosen_artwork_id`: the media_file id of the artwork the customer
+ *    identified with (load-bearing — we want to query/aggregate it).
+ *  - `artwork_affinity`: an optional human-readable affinity label.
+ *
+ * Hand-written `add column if not exists` ALTER (never edit the original
+ * `create table if not exists` migration — it won't land on existing DBs).
+ */
+export class Migration20260624150000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "feedback" add column if not exists "chosen_artwork_id" text null;`);
+    this.addSql(`alter table if exists "feedback" add column if not exists "artwork_affinity" text null;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_feedback_chosen_artwork_id" ON "feedback" ("chosen_artwork_id") WHERE chosen_artwork_id IS NOT NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop index if exists "IDX_feedback_chosen_artwork_id";`);
+    this.addSql(`alter table if exists "feedback" drop column if exists "artwork_affinity";`);
+    this.addSql(`alter table if exists "feedback" drop column if exists "chosen_artwork_id";`);
+  }
+
+}

--- a/apps/backend/src/modules/feedback/models/feedback.ts
+++ b/apps/backend/src/modules/feedback/models/feedback.ts
@@ -12,6 +12,13 @@ const Feedback = model.define("feedback", {
   // than in `metadata` so it survives metadata-replacing updates when the
   // customer later submits their rating.
   order_id: model.text().nullable(),
+  // Playful post-delivery feedback (#452): the customer is shown a small set
+  // of artwork images and picks the one they identify with. The chosen
+  // artwork (a media_file id) + an optional affinity label are load-bearing
+  // analytical state, so they live in typed columns rather than the metadata
+  // blob (which gets fully replaced on update — feedback_no_critical_data_in_metadata).
+  chosen_artwork_id: model.text().nullable(),
+  artwork_affinity: model.text().nullable(),
   reviewed_by: model.text().nullable(),
   reviewed_at: model.dateTime().nullable(),
   metadata: model.json().nullable(),

--- a/apps/backend/src/workflows/feedback/lib/__tests__/artwork-feedback.unit.spec.ts
+++ b/apps/backend/src/workflows/feedback/lib/__tests__/artwork-feedback.unit.spec.ts
@@ -1,0 +1,214 @@
+import {
+  ArtworkChoice,
+  buildArtworkPickUpdate,
+  DEFAULT_FEEDBACK_ARTWORK_SOURCE_ID,
+  mapMediaToArtworkChoice,
+  normalizeRatingValue,
+  resolveArtworkSourceId,
+  selectArtworkChoices,
+} from "../artwork-feedback";
+
+const pool = (n: number): ArtworkChoice[] =>
+  Array.from({ length: n }, (_, i) => ({
+    id: `art_${i.toString().padStart(2, "0")}`,
+    file_path: `/art/${i}.jpg`,
+    type: "image",
+    mime_type: "image/jpeg",
+    width: 800,
+    height: 600,
+    title: `Art ${i}`,
+    alt_text: null,
+    caption: null,
+  }));
+
+describe("normalizeRatingValue", () => {
+  it("accepts enum strings", () => {
+    expect(normalizeRatingValue("one")).toBe("one");
+    expect(normalizeRatingValue("FIVE")).toBe("five");
+    expect(normalizeRatingValue(" three ")).toBe("three");
+  });
+  it("accepts numeric forms 1..5", () => {
+    expect(normalizeRatingValue(4)).toBe("four");
+    expect(normalizeRatingValue("2")).toBe("two");
+  });
+  it("rejects out-of-range / junk", () => {
+    expect(normalizeRatingValue(0)).toBeUndefined();
+    expect(normalizeRatingValue(6)).toBeUndefined();
+    expect(normalizeRatingValue("six")).toBeUndefined();
+    expect(normalizeRatingValue(2.5)).toBeUndefined();
+    expect(normalizeRatingValue(null)).toBeUndefined();
+    expect(normalizeRatingValue(undefined)).toBeUndefined();
+  });
+});
+
+describe("resolveArtworkSourceId", () => {
+  it("prefers override, then env, then default", () => {
+    expect(resolveArtworkSourceId({}, "alb_x")).toBe("alb_x");
+    expect(resolveArtworkSourceId({ FEEDBACK_ARTWORK_ALBUM_ID: "alb_env" })).toBe(
+      "alb_env"
+    );
+    expect(resolveArtworkSourceId({})).toBe(DEFAULT_FEEDBACK_ARTWORK_SOURCE_ID);
+    expect(resolveArtworkSourceId({ FEEDBACK_ARTWORK_ALBUM_ID: "  " })).toBe(
+      DEFAULT_FEEDBACK_ARTWORK_SOURCE_ID
+    );
+  });
+});
+
+describe("mapMediaToArtworkChoice", () => {
+  it("maps the public-safe subset", () => {
+    const choice = mapMediaToArtworkChoice({
+      id: "m1",
+      file_name: "f.jpg",
+      original_name: "Original.jpg",
+      file_path: "/p/f.jpg",
+      file_type: "image",
+      mime_type: "image/jpeg",
+      width: 10,
+      height: 20,
+      title: "T",
+      alt_text: "A",
+      caption: "C",
+    });
+    expect(choice).toEqual({
+      id: "m1",
+      file_path: "/p/f.jpg",
+      type: "image",
+      mime_type: "image/jpeg",
+      width: 10,
+      height: 20,
+      title: "T",
+      alt_text: "A",
+      caption: "C",
+    });
+  });
+  it("coerces missing fields to null", () => {
+    const choice = mapMediaToArtworkChoice({ id: "m2" });
+    expect(choice.file_path).toBeNull();
+    expect(choice.type).toBeNull();
+    expect(choice.width).toBeNull();
+  });
+});
+
+describe("selectArtworkChoices", () => {
+  it("returns N distinct items", () => {
+    const out = selectArtworkChoices(pool(10), "fb_1", 3);
+    expect(out).toHaveLength(3);
+    expect(new Set(out.map((o) => o.id)).size).toBe(3);
+  });
+
+  it("is deterministic for the same seed", () => {
+    const a = selectArtworkChoices(pool(10), "fb_seed", 3).map((o) => o.id);
+    const b = selectArtworkChoices(pool(10), "fb_seed", 3).map((o) => o.id);
+    expect(a).toEqual(b);
+  });
+
+  it("varies across different seeds", () => {
+    // Compare several seeds — at least one ordering must differ.
+    const base = selectArtworkChoices(pool(12), "seed_A", 3).map((o) => o.id);
+    const others = ["seed_B", "seed_C", "seed_D", "seed_E"].map((s) =>
+      selectArtworkChoices(pool(12), s, 3).map((o) => o.id).join(",")
+    );
+    expect(others.some((o) => o !== base.join(","))).toBe(true);
+  });
+
+  it("does not leak DB pool order (sorted before shuffle)", () => {
+    const forward = selectArtworkChoices(pool(8), "s", 3).map((o) => o.id);
+    const reversed = selectArtworkChoices([...pool(8)].reverse(), "s", 3).map(
+      (o) => o.id
+    );
+    expect(forward).toEqual(reversed);
+  });
+
+  it("de-dupes by id", () => {
+    const dup = [...pool(2), ...pool(2)];
+    const out = selectArtworkChoices(dup, "s", 5);
+    expect(out).toHaveLength(2);
+  });
+
+  it("caps at pool size and handles empty/zero", () => {
+    expect(selectArtworkChoices(pool(2), "s", 5)).toHaveLength(2);
+    expect(selectArtworkChoices([], "s", 3)).toEqual([]);
+    expect(selectArtworkChoices(null, "s", 3)).toEqual([]);
+    expect(selectArtworkChoices(pool(5), "s", 0)).toEqual([]);
+  });
+});
+
+describe("buildArtworkPickUpdate", () => {
+  const now = new Date("2026-06-24T10:00:00.000Z");
+
+  it("builds typed columns + metadata audit for a valid offered pick", () => {
+    const out = buildArtworkPickUpdate({
+      feedbackId: "fb_1",
+      artworkId: "art_02",
+      affinity: " calm ",
+      offeredIds: ["art_01", "art_02", "art_03"],
+      existingMetadata: { source: "post_delivery_request" },
+      now,
+    });
+    expect(out).toEqual({
+      id: "fb_1",
+      chosen_artwork_id: "art_02",
+      artwork_affinity: "calm",
+      metadata: {
+        source: "post_delivery_request",
+        artwork_pick: {
+          artwork_id: "art_02",
+          affinity: "calm",
+          chosen_at: now.toISOString(),
+        },
+      },
+    });
+  });
+
+  it("normalises blank affinity to null", () => {
+    const out = buildArtworkPickUpdate({
+      feedbackId: "fb_1",
+      artworkId: "art_01",
+      affinity: "   ",
+      offeredIds: ["art_01"],
+      now,
+    });
+    expect(out?.artwork_affinity).toBeNull();
+    expect(out?.metadata.artwork_pick.affinity).toBeNull();
+  });
+
+  it("rejects a pick that was not offered", () => {
+    expect(
+      buildArtworkPickUpdate({
+        feedbackId: "fb_1",
+        artworkId: "art_99",
+        offeredIds: ["art_01", "art_02"],
+        now,
+      })
+    ).toBeNull();
+  });
+
+  it("rejects missing ids", () => {
+    expect(
+      buildArtworkPickUpdate({
+        feedbackId: "",
+        artworkId: "art_01",
+        offeredIds: ["art_01"],
+      })
+    ).toBeNull();
+    expect(
+      buildArtworkPickUpdate({
+        feedbackId: "fb_1",
+        artworkId: "",
+        offeredIds: ["art_01"],
+      })
+    ).toBeNull();
+  });
+
+  it("does not mutate the passed-in metadata", () => {
+    const meta = { source: "x" };
+    buildArtworkPickUpdate({
+      feedbackId: "fb_1",
+      artworkId: "art_01",
+      offeredIds: ["art_01"],
+      existingMetadata: meta,
+      now,
+    });
+    expect(meta).toEqual({ source: "x" });
+  });
+});

--- a/apps/backend/src/workflows/feedback/lib/artwork-feedback.ts
+++ b/apps/backend/src/workflows/feedback/lib/artwork-feedback.ts
@@ -1,0 +1,238 @@
+// Pure, side-effect-free helpers for the playful artwork-rating mechanic in the
+// post-delivery feedback flow (#452). Kept free of Medusa/container deps so the
+// artwork selection, pick validation and update-payload assembly are
+// unit-testable without booting Medusa or the media module.
+//
+// The customer opens the SAME feedback page+token they already get on delivery
+// (`/feedback/:id`). Instead of a boring "rate us", we present a small set of
+// artwork images and let them pick the one they identify with. The pick is
+// additive and optional — the 1..5 rating keeps working on its own.
+
+export type RatingEnum = "one" | "two" | "three" | "four" | "five";
+
+const RATING_BY_NUMBER: Record<number, RatingEnum> = {
+  1: "one",
+  2: "two",
+  3: "three",
+  4: "four",
+  5: "five",
+};
+
+const RATING_SET: ReadonlySet<string> = new Set([
+  "one",
+  "two",
+  "three",
+  "four",
+  "five",
+]);
+
+/**
+ * Normalise a rating supplied by the storefront. Accepts the enum string
+ * ("one".."five"), the numeric form (1..5, as number or numeric string), and
+ * returns `undefined` for anything out of range (so the rating is simply left
+ * untouched rather than throwing — the artwork pick can stand on its own).
+ */
+export function normalizeRatingValue(
+  input: unknown
+): RatingEnum | undefined {
+  if (typeof input === "string") {
+    const trimmed = input.trim().toLowerCase();
+    if (RATING_SET.has(trimmed)) {
+      return trimmed as RatingEnum;
+    }
+    if (/^[1-5]$/.test(trimmed)) {
+      return RATING_BY_NUMBER[Number(trimmed)];
+    }
+    return undefined;
+  }
+  if (typeof input === "number" && Number.isInteger(input)) {
+    return RATING_BY_NUMBER[input];
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the curated media source (an Album or media Folder id) the artwork
+ * pool is drawn from. Admin-editable via env rather than hardcoded; falls back
+ * to the existing curated hero set so a fresh install still shows artwork.
+ * Precedence: explicit override → FEEDBACK_ARTWORK_ALBUM_ID → default.
+ */
+export const DEFAULT_FEEDBACK_ARTWORK_SOURCE_ID = "media_art_hero";
+
+export function resolveArtworkSourceId(
+  env: Record<string, string | undefined> = {},
+  override?: string | null
+): string {
+  const raw = (override || env.FEEDBACK_ARTWORK_ALBUM_ID || "").trim();
+  return raw || DEFAULT_FEEDBACK_ARTWORK_SOURCE_ID;
+}
+
+export interface MediaLike {
+  id: string;
+  original_name?: string | null;
+  file_name?: string | null;
+  file_path?: string | null;
+  file_type?: string | null;
+  mime_type?: string | null;
+  width?: number | null;
+  height?: number | null;
+  title?: string | null;
+  description?: string | null;
+  alt_text?: string | null;
+  caption?: string | null;
+}
+
+export interface ArtworkChoice {
+  id: string;
+  file_path: string | null;
+  type: string | null;
+  mime_type: string | null;
+  width: number | null;
+  height: number | null;
+  title: string | null;
+  alt_text: string | null;
+  caption: string | null;
+}
+
+/**
+ * Map a media_file row to the lean, public-safe artwork shape returned to the
+ * storefront. Mirrors the sanitised subset exposed by `GET /web/media` so the
+ * frontend can build the image URL the same way (NEXT_PUBLIC_AWS_S3 + file_path).
+ */
+export function mapMediaToArtworkChoice(media: MediaLike): ArtworkChoice {
+  return {
+    id: media.id,
+    file_path: media.file_path ?? null,
+    type: media.file_type ?? null,
+    mime_type: media.mime_type ?? null,
+    width: media.width ?? null,
+    height: media.height ?? null,
+    title: media.title ?? null,
+    alt_text: media.alt_text ?? null,
+    caption: media.caption ?? null,
+  };
+}
+
+// --- Seeded RNG (FNV-1a → mulberry32), identical algorithm to GET /web/media so
+// the selection behaves consistently across the codebase and is fully
+// deterministic given a seed. ---
+
+function seedToInt(value: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < value.length; i++) {
+    h ^= value.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function mulberry32(a: number): () => number {
+  return () => {
+    let t = (a += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function seededShuffle<T>(arr: T[], seed: string): T[] {
+  const out = [...arr];
+  const rand = mulberry32(seedToInt(seed));
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+/**
+ * Pick `count` distinct artworks from `pool`, deterministically varied by
+ * `seed`. The same seed always yields the same set (so the offered set can be
+ * reproduced on the submit request to validate the pick), while different
+ * seeds — e.g. a different feedback id / order — yield a different set, which
+ * is the per-token variation the issue asks for.
+ *
+ * De-dupes by id, drops empty ids, and never returns more than the pool holds.
+ */
+export function selectArtworkChoices(
+  pool: ArtworkChoice[] | null | undefined,
+  seed: string,
+  count = 3
+): ArtworkChoice[] {
+  if (!Array.isArray(pool) || pool.length === 0 || count <= 0) {
+    return [];
+  }
+
+  // De-dupe by id, keeping a stable first-seen order so the shuffle is the only
+  // source of variation (pool order from the DB must not leak in).
+  const seen = new Set<string>();
+  const unique: ArtworkChoice[] = [];
+  for (const item of pool) {
+    if (!item || !item.id || seen.has(item.id)) {
+      continue;
+    }
+    seen.add(item.id);
+    unique.push(item);
+  }
+  unique.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+
+  return seededShuffle(unique, seed || "").slice(0, Math.min(count, unique.length));
+}
+
+export interface ArtworkPickInput {
+  feedbackId: string;
+  artworkId: string;
+  /** Optional affinity label the customer (or the UI) attaches to the pick. */
+  affinity?: string | null;
+  /** Ids that were actually offered for this feedback (the GET response). */
+  offeredIds: string[];
+  /** Existing feedback.metadata so the audit breadcrumb is merged, not lost. */
+  existingMetadata?: Record<string, any> | null;
+  now?: Date;
+}
+
+export interface ArtworkPickUpdate {
+  id: string;
+  chosen_artwork_id: string;
+  artwork_affinity: string | null;
+  metadata: Record<string, any>;
+}
+
+/**
+ * Build the feedback-update payload that records an artwork pick. Returns
+ * `null` (caller treats as a no-op / 400) when the chosen artwork was not among
+ * those offered — so a client can't record an arbitrary id. The load-bearing
+ * state goes into typed columns; metadata only carries a non-critical audit
+ * breadcrumb (chosen_at) merged onto whatever was already there.
+ */
+export function buildArtworkPickUpdate(
+  input: ArtworkPickInput
+): ArtworkPickUpdate | null {
+  const { feedbackId, artworkId, offeredIds } = input;
+  if (!feedbackId || !artworkId) {
+    return null;
+  }
+  if (!Array.isArray(offeredIds) || !offeredIds.includes(artworkId)) {
+    return null;
+  }
+
+  const now = input.now ?? new Date();
+  const affinity =
+    typeof input.affinity === "string" && input.affinity.trim().length
+      ? input.affinity.trim()
+      : null;
+
+  return {
+    id: feedbackId,
+    chosen_artwork_id: artworkId,
+    artwork_affinity: affinity,
+    metadata: {
+      ...(input.existingMetadata ?? {}),
+      artwork_pick: {
+        artwork_id: artworkId,
+        affinity,
+        chosen_at: now.toISOString(),
+      },
+    },
+  };
+}

--- a/apps/docs/notes/452_ARTWORK_FEEDBACK.md
+++ b/apps/docs/notes/452_ARTWORK_FEEDBACK.md
@@ -1,0 +1,84 @@
+# #452 — Playful artwork-rating in the post-delivery feedback flow
+
+Instead of a boring "rate us", the post-delivery feedback page presents the
+customer a small set of **artwork images** and lets them pick the one they
+**identify with** — art-led and playful. The pick is recorded alongside the
+order/feedback. This is **additive**: the existing trigger, email link and 1..5
+rating are untouched; the artwork pick is optional.
+
+## What already existed (NOT rebuilt)
+
+- `delivery.created` → subscriber `src/subscribers/order-delivered-feedback.ts`
+  → workflow `src/workflows/feedback/request-post-delivery-feedback.ts` creates
+  an idempotent pending feedback row (keyed on the typed `order_id` column) and
+  emails the customer a link to `${STORE_URL}/feedback/:id` (template
+  `order-feedback-request`). The **feedback id IS the page token**.
+
+## What this change adds (backend)
+
+1. **Typed columns** on `feedback` (`src/modules/feedback/models/feedback.ts`):
+   - `chosen_artwork_id` (text, nullable) — the picked artwork's `media_file` id.
+   - `artwork_affinity` (text, nullable) — optional affinity label.
+   Load-bearing analytical state ⇒ typed columns, **not** the metadata blob
+   (metadata is fully replaced on update). Migration
+   `Migration20260624150000.ts` (hand-written `add column if not exists` ALTER —
+   never edit the create-table migration).
+
+2. **Pure helpers** `src/workflows/feedback/lib/artwork-feedback.ts` (17 unit
+   tests):
+   - `resolveArtworkSourceId(env, override?)` — curated source (Album/Folder id),
+     `FEEDBACK_ARTWORK_ALBUM_ID` env → default `media_art_hero`.
+   - `selectArtworkChoices(pool, seed, count=3)` — deterministic seeded selection
+     (FNV-1a → mulberry32, same algo as `GET /web/media`). Same seed → same set
+     (so the offered set is reproducible to validate a pick); different seed
+     (different feedback id) → different set = the per-token variation the issue
+     asks for. De-dupes by id, sorts before shuffle so DB order never leaks.
+   - `buildArtworkPickUpdate(...)` — validates the pick is among the offered ids,
+     builds the typed-column update + a non-critical `metadata.artwork_pick`
+     audit breadcrumb (merged, not replacing). Returns `null` (→ 400) on an
+     un-offered/empty id.
+   - `normalizeRatingValue(...)` — accepts `"one".."five"` or `1..5`.
+
+3. **Public page API** `src/api/web/feedback/[id]/route.ts` (CORS inherited from
+   the global `/web/*` matcher; no auth — the id is the capability token):
+   - `GET /web/feedback/:id` → `{ feedback, artworks }`. Artworks are the seeded
+     3-set drawn from the curated public-image pool (Album first, media Folder
+     fallback — mirrors `GET /web/media`). No pool configured ⇒ `artworks: []`
+     and the page degrades to a plain rating.
+   - `POST /web/feedback/:id` `{ rating?, comment?, artwork_id?, affinity? }` →
+     records rating/comment and the **validated** artwork pick into the typed
+     columns. Pick validated against the same seeded set the GET returns. 400 if
+     nothing valid (or the artwork wasn't offered).
+
+## Artwork source
+
+Reuses the **media module** — a curated Album or media Folder of public images,
+exactly the mechanism the storefront hero already uses (folder `media_art_hero`,
+roadmap #22). Admin-editable via env `FEEDBACK_ARTWORK_ALBUM_ID`; no new model.
+To curate: drop artwork into that folder/album (public images).
+
+## Storefront page (follow-up — NOT in this PR)
+
+The customer page lives in the `storefront-starter` **submodule** and does not
+exist yet (the email currently links to a route the storefront must add). This
+PR ships the backend contract + logic so the page is pure presentation. The page
+should:
+1. `GET /web/feedback/:id` → render the 1..5 rating + the 3 artwork tiles
+   (image URL = `NEXT_PUBLIC_AWS_S3 + file_path`, same as the media gallery).
+2. On submit `POST /web/feedback/:id` with the chosen `artwork_id` (+ rating).
+Building it is Playwright-gated UI in a separate repo → deferred.
+
+## Manual verification (curl)
+
+```bash
+# Seed: put public images in a folder, set FEEDBACK_ARTWORK_ALBUM_ID=<folderId>.
+# Pick a pending feedback id (e.g. from a delivered test order).
+curl -s "$BACKEND/web/feedback/<id>" | jq '.artworks | length'   # → 3
+curl -s -X POST "$BACKEND/web/feedback/<id>" \
+  -H 'content-type: application/json' \
+  -d '{"rating":5,"artwork_id":"<one-of-the-returned-ids>","affinity":"calm"}' | jq
+# → feedback.chosen_artwork_id == artwork_id, rating == "five"
+```
+
+Automated coverage: `artwork-feedback.unit.spec.ts` (17) +
+`integration-tests/http/artwork-feedback.spec.ts` (3, full GET/POST + persistence).


### PR DESCRIPTION
Closes #452 (backend slice).

## What & why
The post-delivery feedback flow already emails delivered-order customers a link to `${STORE_URL}/feedback/:id` (subscriber `order-delivered-feedback.ts` → `request-post-delivery-feedback.ts`). This makes that page **art-led and playful** instead of a boring "rate us": it presents a small set of **artwork images** and lets the customer pick the one they **identify with**, recorded alongside the order/feedback. **Additive** — the existing trigger, email link, and 1..5 rating are untouched; the artwork pick is optional.

## Changes
- **Model** (`feedback.ts`): typed columns `chosen_artwork_id` + `artwork_affinity` (load-bearing analytical state → typed columns, **not** the metadata blob that gets fully replaced). Hand-written `add column if not exists` ALTER migration `Migration20260624150000` (never edits the create-table migration).
- **Pure helpers** `workflows/feedback/lib/artwork-feedback.ts` (**17 unit tests**):
  - `selectArtworkChoices(pool, seed, count=3)` — deterministic seeded N-distinct selection (FNV-1a → mulberry32, same algo as `GET /web/media`). Same seed (feedback id) → reproducible set so the pick can be validated; different token → different set = the per-render variation #452 asks for. Sorts before shuffle so DB order never leaks.
  - `buildArtworkPickUpdate(...)` — validates the pick is among the offered ids, writes typed columns + a non-critical `metadata.artwork_pick` audit breadcrumb (merged).
  - `resolveArtworkSourceId` / `normalizeRatingValue` (accepts `"one".."five"` or `1..5`).
- **Public API** `GET/POST /web/feedback/:id` (CORS via the global `/web/*` matcher; the feedback id is the capability token):
  - `GET` → `{ feedback, artworks }` — 3-set drawn from a curated public-image pool (Album → media Folder fallback, mirrors `GET /web/media`). No pool ⇒ `artworks: []`, page degrades to plain rating.
  - `POST { rating?, comment?, artwork_id?, affinity? }` → records rating/comment + the **validated** artwork pick into the typed columns; 400 if nothing valid / artwork not offered.
- **Artwork source**: reuses the **media module** — a curated Album/Folder of public images (admin-editable via env `FEEDBACK_ARTWORK_ALBUM_ID`, default `media_art_hero`). No new model.

## Tests
- `artwork-feedback.unit.spec.ts` — **17/17** green.
- `integration-tests/http/artwork-feedback.spec.ts` — **3/3** green (full GET/POST + typed-column persistence + un-offered-pick rejection + 404). Run per-file: `pnpm test:integration:http:shared -- integration-tests/http/artwork-feedback.spec.ts`.
- Typecheck: zero new errors in changed files.

## Not in this PR (deferred)
The customer-facing **storefront page** lives in the `storefront-starter` submodule and doesn't exist yet (Playwright-gated, separate repo). This PR ships the backend contract + logic so the page is pure presentation. Contract + manual `curl` verification documented in `apps/docs/notes/452_ARTWORK_FEEDBACK.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)