### PR TITLE
infra(#707/#712): set PARTNER_APP_URL in prod copilot manifests

### DIFF
--- a/deploy/aws/copilot/medusa-server/manifest.yml
+++ b/deploy/aws/copilot/medusa-server/manifest.yml
@@ -53,6 +53,11 @@ network:
 variables:
   NODE_ENV: production
   MEDUSA_WORKER_MODE: server
+  # #707/#712 — base URL for partner-portal product links in WhatsApp confirmation
+  # messages. Read by buildPartnerProductUrl (src/workflows/whatsapp/partner-product-url.ts),
+  # which falls back to a hardcoded default if unset; this makes the prod value explicit.
+  # Non-secret, so it lives here (not under secrets:).
+  PARTNER_APP_URL: https://partner.jaalyantra.com
 
 # Secrets: rotating values come from Secrets Manager.
 # Non-rotating config (CORS, URLs, etc.) comes from SSM Parameter Store — listed

--- a/deploy/aws/copilot/medusa-worker/manifest.yml
+++ b/deploy/aws/copilot/medusa-worker/manifest.yml
@@ -25,6 +25,11 @@ variables:
   NODE_ENV: production
   MEDUSA_WORKER_MODE: worker
   DISABLE_MEDUSA_ADMIN: "true"
+  # #707/#712 — base URL for partner-portal product links in WhatsApp confirmation
+  # messages. The worker runs the subscribers (visual-flow-event-trigger →
+  # createDraftProductFromExtractionWorkflow) that build these links via
+  # buildPartnerProductUrl, so it needs the same explicit value as the server.
+  PARTNER_APP_URL: https://partner.jaalyantra.com
 
 # Worker needs DB + Redis + R2 (for export/report jobs that write files).
 # Does NOT need JWT/COOKIE/CORS (no HTTP surface).


### PR DESCRIPTION
## What

Set `PARTNER_APP_URL: https://partner.jaalyantra.com` under `variables:` in **both** prod copilot manifests (`medusa-server` and `medusa-worker`).

## Why

The WhatsApp product-create confirmation messages sent to partners build a partner-portal product link via `buildPartnerProductUrl` (`apps/backend/src/workflows/whatsapp/partner-product-url.ts`, from #707/#712). Base resolution order:

1. explicit `base` arg
2. `PARTNER_APP_URL`  ← **this var**
3. `PARTNER_PORTAL_URL`
4. `https://partner.jaalyantra.com` (hardcoded default)

Without the env set, prod falls back to the in-code default. This makes the prod value **explicit and correct** rather than implicit.

It's added to **both services** because both run the link-building code path:
- **server** — inbound webhook route (`api/webhooks/social/whatsapp/route.ts` → `handleIncomingMessage`)
- **worker** — subscriber `subscribers/visual-flow-event-trigger.ts` → `createDraftProductFromExtractionWorkflow`

It's a **non-secret** value, so it lives under `variables:` (not `secrets:`, which holds SSM refs).

## Verify

- YAML validated: new key is 2-space-indented under `variables:` in both files; no other values changed.
- ⚠️ **This is an infra change — it deploys on merge** (deploy-to-aws.yml) and sets the prod env var on the next ECS task start. Human review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
