### PR TITLE
feat(#457): expose email-template seeds via Data Plumbing maintenance jobs

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/seed-email-templates.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/seed-email-templates.unit.spec.ts
@@ -1,0 +1,224 @@
+import {
+  buildEmailTemplateSeedResult,
+  EMAIL_TEMPLATE_SETS,
+  EMAIL_TEMPLATE_SET_KEYS,
+  planEmailTemplateSeed,
+  resolveEmailTemplateSpecs,
+  seedEmailTemplatesJob,
+  type EmailTemplateSpec,
+} from "../seed-jobs"
+import { getMaintenanceJob, MAINTENANCE_JOBS } from "../registry"
+
+/**
+ * #457 Data Plumbing — pure logic for the `seed-email-templates` maintenance
+ * job. The container-bound run() (listEmailTemplates + createEmailTemplates) is
+ * thin; here we lock down the dry-run/apply decision, idempotent skip-existing,
+ * set resolution + dedup, and the summary wording — no DB.
+ */
+describe("ops/maintenance-jobs seed-email-templates (#457)", () => {
+  const specs: EmailTemplateSpec[] = [
+    { template_key: "a", name: "Alpha" },
+    { template_key: "b", name: "Beta" },
+    { template_key: "c", name: "Gamma" },
+  ]
+
+  describe("planEmailTemplateSeed (idempotent partition)", () => {
+    it("creates everything when nothing exists yet (empty admin)", () => {
+      const plan = planEmailTemplateSeed(specs, new Set())
+      expect(plan.total).toBe(3)
+      expect(plan.toCreate.map((s) => s.template_key)).toEqual(["a", "b", "c"])
+      expect(plan.existingKeys).toEqual([])
+    })
+
+    it("skips template_keys that already exist (re-run is a no-op)", () => {
+      const plan = planEmailTemplateSeed(specs, new Set(["a", "c"]))
+      expect(plan.toCreate.map((s) => s.template_key)).toEqual(["b"])
+      expect(plan.existingKeys).toEqual(["a", "c"])
+    })
+
+    it("creates nothing when all exist", () => {
+      const plan = planEmailTemplateSeed(specs, ["a", "b", "c"])
+      expect(plan.toCreate).toEqual([])
+      expect(plan.existingKeys).toEqual(["a", "b", "c"])
+    })
+  })
+
+  describe("buildEmailTemplateSeedResult (wording + applied flag)", () => {
+    it("dry-run reports would-create and is never marked applied", () => {
+      const plan = planEmailTemplateSeed(specs, new Set(["a"]))
+      const res = buildEmailTemplateSeedResult(
+        "seed-email-templates",
+        true,
+        plan,
+        "email templates"
+      )
+      expect(res.dry_run).toBe(true)
+      expect(res.applied).toBe(false)
+      expect(res.changes).toHaveLength(2)
+      expect(res.changes[0]).toEqual({
+        entity: "email_template",
+        id: "b",
+        field: "template_key",
+        before: null,
+        after: "Beta",
+      })
+      expect(res.summary).toBe(
+        "Would create 2 of 3 email templates; 1 already exist"
+      )
+    })
+
+    it("apply with new rows is marked applied", () => {
+      const plan = planEmailTemplateSeed(specs, new Set())
+      const res = buildEmailTemplateSeedResult(
+        "seed-email-templates",
+        false,
+        plan,
+        "email templates"
+      )
+      expect(res.applied).toBe(true)
+      expect(res.summary).toBe(
+        "Created 3 of 3 email templates; 0 already exist"
+      )
+    })
+
+    it("apply with nothing to create is NOT marked applied (idempotent re-run)", () => {
+      const plan = planEmailTemplateSeed(specs, ["a", "b", "c"])
+      const res = buildEmailTemplateSeedResult(
+        "seed-email-templates",
+        false,
+        plan,
+        "email templates"
+      )
+      expect(res.applied).toBe(false)
+      expect(res.changes).toEqual([])
+      expect(res.summary).toBe(
+        "Created 0 of 3 email templates; 3 already exist"
+      )
+    })
+
+    it("falls back to template_key when a spec has no name", () => {
+      const res = buildEmailTemplateSeedResult(
+        "seed-email-templates",
+        true,
+        planEmailTemplateSeed([{ template_key: "x" }], new Set()),
+        "email templates"
+      )
+      expect(res.changes[0].after).toBe("x")
+    })
+  })
+
+  describe("resolveEmailTemplateSpecs (set selection + dedup)", () => {
+    it("defaults to ALL sets when set is blank/undefined", () => {
+      const all = resolveEmailTemplateSpecs(undefined)
+      expect(all.setKeys).toEqual(EMAIL_TEMPLATE_SET_KEYS)
+      const allEmpty = resolveEmailTemplateSpecs("")
+      expect(allEmpty.setKeys).toEqual(EMAIL_TEMPLATE_SET_KEYS)
+    })
+
+    it("treats 'all' (any case) as every set", () => {
+      expect(resolveEmailTemplateSpecs("ALL").setKeys).toEqual(
+        EMAIL_TEMPLATE_SET_KEYS
+      )
+    })
+
+    it("selects a single named set", () => {
+      const r = resolveEmailTemplateSpecs("reengagement")
+      expect(r.setKeys).toEqual(["reengagement"])
+      expect(r.specs.length).toBeGreaterThan(0)
+      expect(r.specs.every((s) => typeof s.template_key === "string")).toBe(true)
+    })
+
+    it("throws on an unknown set key", () => {
+      expect(() => resolveEmailTemplateSpecs("nope")).toThrow(/Unknown email-template set/)
+    })
+
+    it("dedupes template_keys across sets so 'all' never lists a key twice", () => {
+      const all = resolveEmailTemplateSpecs("all")
+      const keys = all.specs.map((s) => s.template_key)
+      expect(new Set(keys).size).toBe(keys.length)
+    })
+
+    it("every set carries at least one real template spec with a key", () => {
+      for (const set of EMAIL_TEMPLATE_SETS) {
+        expect(set.specs.length).toBeGreaterThan(0)
+        for (const spec of set.specs) {
+          expect(typeof spec.template_key).toBe("string")
+          expect(spec.template_key.length).toBeGreaterThan(0)
+        }
+      }
+    })
+  })
+
+  describe("registry wiring", () => {
+    it("is registered in MAINTENANCE_JOBS and resolvable by id", () => {
+      expect(MAINTENANCE_JOBS).toContain(seedEmailTemplatesJob)
+      expect(getMaintenanceJob("seed-email-templates")).toBe(seedEmailTemplatesJob)
+    })
+
+    it("exposes a single optional `set` param", () => {
+      expect(seedEmailTemplatesJob.params).toHaveLength(1)
+      expect(seedEmailTemplatesJob.params[0]).toMatchObject({
+        name: "set",
+        type: "string",
+        required: false,
+      })
+    })
+  })
+
+  describe("run() container branch (dry-run vs apply)", () => {
+    const makeContainer = (existingKeys: string[], created: string[]) => ({
+      resolve: () => ({
+        listEmailTemplates: async () =>
+          existingKeys.map((template_key) => ({ template_key })),
+        createEmailTemplates: async (rows: any[]) => {
+          for (const r of rows) created.push(r.template_key)
+          return rows
+        },
+      }),
+    })
+
+    it("dry-run writes nothing", async () => {
+      const created: string[] = []
+      const container = makeContainer([], created)
+      const res = await seedEmailTemplatesJob.run(container, {
+        dry_run: true,
+        params: { set: "reengagement" },
+      })
+      expect(created).toEqual([])
+      expect(res.dry_run).toBe(true)
+      expect(res.applied).toBe(false)
+      expect(res.changes.length).toBeGreaterThan(0)
+    })
+
+    it("apply creates only the missing template_keys", async () => {
+      const created: string[] = []
+      const reengagement = resolveEmailTemplateSpecs("reengagement").specs
+      const existing = [reengagement[0].template_key] // first already present
+      const container = makeContainer(existing, created)
+      const res = await seedEmailTemplatesJob.run(container, {
+        dry_run: false,
+        params: { set: "reengagement" },
+      })
+      // created everything except the one that already existed
+      expect(created).toEqual(
+        reengagement.slice(1).map((s) => s.template_key)
+      )
+      expect(res.applied).toBe(true)
+    })
+
+    it("re-run after apply is a no-op (idempotent)", async () => {
+      const created: string[] = []
+      const reengagement = resolveEmailTemplateSpecs("reengagement").specs
+      const container = makeContainer(
+        reengagement.map((s) => s.template_key),
+        created
+      )
+      const res = await seedEmailTemplatesJob.run(container, {
+        dry_run: false,
+        params: { set: "reengagement" },
+      })
+      expect(created).toEqual([])
+      expect(res.applied).toBe(false)
+    })
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -58,6 +58,7 @@ import {
 } from "../../marketing/marketing-summary-lib"
 import { VISUAL_FLOWS_MODULE } from "../../../../modules/visual_flows"
 import { FLOW_DEF as IDEAS_EMAIL_FLOW_DEF } from "../../../../scripts/seed-marketing-daily-ideas-email-flow"
+import { seedEmailTemplatesJob } from "./seed-jobs"
 
 /**
  * Admin "data-plumbing" maintenance jobs (#457 / roadmap #33).
@@ -4274,6 +4275,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   installMarketingIdeasEmailFlowJob,
   generateWinbackTargetsJob,
   sendMarketingDailySummaryJob,
+  seedEmailTemplatesJob,
 ]
 
 export const getMaintenanceJob = (id: string): MaintenanceJob | undefined =>

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/seed-jobs.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/seed-jobs.ts
@@ -1,0 +1,243 @@
+import { MedusaError } from "@medusajs/framework/utils"
+
+import { EMAIL_TEMPLATES_MODULE } from "../../../../modules/email_templates"
+import type {
+  MaintenanceChange,
+  MaintenanceJob,
+  MaintenanceJobResult,
+} from "./registry"
+
+// Template DATA (not the seed default fns) imported from the existing seed
+// scripts so the canonical content lives in ONE place. Importing the constants
+// has no side effects — the seed's default export only runs under `medusa exec`.
+import { emailTemplatesData } from "../../../../scripts/seed-email-templates"
+import { additionalEmailTemplates } from "../../../../scripts/seed-additional-email-templates"
+import { reengagementEmailTemplates } from "../../../../scripts/seed-reengagement-email-templates"
+import { partnerEmailTemplates } from "../../../../scripts/seed-partner-email-templates"
+import { TEMPLATE_DEFINITION as cartAbandonedTemplate } from "../../../../scripts/seed-cart-abandoned-email"
+import { tourEmailTemplate } from "../../../../scripts/seed-tour-email-template"
+import { visualFlowLifecycleTemplates } from "../../../../scripts/seed-visual-flow-lifecycle-email-templates"
+
+/**
+ * #457 Data Plumbing — SEED jobs.
+ *
+ * Exposes the idempotent email-template seed scripts through the guarded
+ * maintenance-jobs registry so a fresh / empty admin can seed the reference
+ * email templates from Settings → Data Plumbing (dry-run preview → apply)
+ * without a shell or `medusa exec`. Mirrors the seeds' own idempotency
+ * (skip-existing by `template_key`); dry-run writes NOTHING.
+ *
+ * Reference-data seeds (energy-rates, tax-regions, fx-rates, plans, …) each
+ * have bespoke exists/create logic (and seed-plans reads the filesystem, the
+ * tax/fx seeds do multi-step money writes) so they need per-seed preview logic —
+ * deferred to a follow-up. See SEED_INVENTORY in apps/docs/notes for the full
+ * expose/skip/defer map.
+ */
+
+export type EmailTemplateSpec = {
+  template_key: string
+  name?: string
+  [key: string]: unknown
+}
+
+/** Selectable email-template sets, each wrapping one seed script's data. */
+export const EMAIL_TEMPLATE_SETS: Array<{
+  key: string
+  label: string
+  specs: EmailTemplateSpec[]
+}> = [
+  {
+    key: "core",
+    label: "core email templates",
+    specs: emailTemplatesData as EmailTemplateSpec[],
+  },
+  {
+    key: "additional",
+    label: "additional customer/partner templates",
+    specs: additionalEmailTemplates as EmailTemplateSpec[],
+  },
+  {
+    key: "reengagement",
+    label: "re-engagement templates",
+    specs: reengagementEmailTemplates as EmailTemplateSpec[],
+  },
+  {
+    key: "partner",
+    label: "partner/admin templates",
+    specs: partnerEmailTemplates as EmailTemplateSpec[],
+  },
+  {
+    key: "cart-abandoned",
+    label: "cart-abandoned template",
+    specs: [cartAbandonedTemplate as EmailTemplateSpec],
+  },
+  {
+    key: "tour",
+    label: "tour itinerary template",
+    specs: [tourEmailTemplate as EmailTemplateSpec],
+  },
+  {
+    key: "visual-flow-lifecycle",
+    label: "visual-flow lifecycle templates",
+    specs: visualFlowLifecycleTemplates as EmailTemplateSpec[],
+  },
+]
+
+export const EMAIL_TEMPLATE_SET_KEYS = EMAIL_TEMPLATE_SETS.map((s) => s.key)
+
+/**
+ * PURE: resolve a `set` param to the spec list. "" / "all" → every set.
+ * Combines selected sets and dedupes by `template_key` (first occurrence wins,
+ * e.g. "cart-abandoned" ships in both `core` and the `cart-abandoned` set).
+ * Throws on an unknown set key (caller maps it to INVALID_DATA).
+ */
+export function resolveEmailTemplateSpecs(setParam?: string): {
+  setKeys: string[]
+  specs: EmailTemplateSpec[]
+} {
+  const raw = (setParam ?? "all").trim().toLowerCase()
+  let chosen: typeof EMAIL_TEMPLATE_SETS
+  if (raw === "" || raw === "all") {
+    chosen = EMAIL_TEMPLATE_SETS
+  } else {
+    const found = EMAIL_TEMPLATE_SETS.find((s) => s.key === raw)
+    if (!found) {
+      throw new Error(
+        `Unknown email-template set "${raw}". Valid: ${EMAIL_TEMPLATE_SET_KEYS.join(", ")}, all`
+      )
+    }
+    chosen = [found]
+  }
+
+  const seen = new Set<string>()
+  const specs: EmailTemplateSpec[] = []
+  for (const set of chosen) {
+    for (const spec of set.specs) {
+      if (!spec?.template_key || seen.has(spec.template_key)) {
+        continue
+      }
+      seen.add(spec.template_key)
+      specs.push(spec)
+    }
+  }
+  return { setKeys: chosen.map((s) => s.key), specs }
+}
+
+export type EmailTemplateSeedPlan = {
+  total: number
+  toCreate: EmailTemplateSpec[]
+  existingKeys: string[]
+}
+
+/**
+ * PURE: partition specs into create-vs-skip given the set of `template_key`s
+ * already present. Exported for unit testing so the dry-run/apply decision is
+ * verifiable without booting the DB.
+ */
+export function planEmailTemplateSeed(
+  specs: EmailTemplateSpec[],
+  existing: Set<string> | string[]
+): EmailTemplateSeedPlan {
+  const existingSet = existing instanceof Set ? existing : new Set(existing)
+  const toCreate: EmailTemplateSpec[] = []
+  const existingKeys: string[] = []
+  for (const spec of specs) {
+    if (existingSet.has(spec.template_key)) {
+      existingKeys.push(spec.template_key)
+    } else {
+      toCreate.push(spec)
+    }
+  }
+  return { total: specs.length, toCreate, existingKeys }
+}
+
+/**
+ * PURE: turn a plan into a MaintenanceJobResult. `applied` is true only when
+ * this was a real run (dry_run=false) that actually created at least one row.
+ */
+export function buildEmailTemplateSeedResult(
+  jobId: string,
+  dry_run: boolean,
+  plan: EmailTemplateSeedPlan,
+  setLabel: string
+): MaintenanceJobResult {
+  const verb = dry_run ? "Would create" : "Created"
+  const changes: MaintenanceChange[] = plan.toCreate.map((spec) => ({
+    entity: "email_template",
+    id: spec.template_key,
+    field: "template_key",
+    before: null,
+    after: spec.name ?? spec.template_key,
+  }))
+  const summary = `${verb} ${plan.toCreate.length} of ${plan.total} ${setLabel}; ${plan.existingKeys.length} already exist`
+  return {
+    job_id: jobId,
+    dry_run,
+    applied: !dry_run && plan.toCreate.length > 0,
+    summary,
+    changes,
+  }
+}
+
+export const seedEmailTemplatesJob: MaintenanceJob = {
+  id: "seed-email-templates",
+  label: "Seed email templates",
+  description:
+    "Seed the reference email templates into a fresh / empty admin from the console — no shell or `medusa exec` needed (#457). Wraps the idempotent email-template seed scripts. Pick a set with the `set` param (core, additional, reengagement, partner, cart-abandoned, tour, visual-flow-lifecycle) or leave it blank / 'all' to seed every set. Dry-run reports exactly which template_keys WOULD be created vs already exist (writes nothing); apply creates ONLY the missing ones (skip-existing by template_key). Safe to re-run — never overwrites an admin-edited template.",
+  params: [
+    {
+      name: "set",
+      type: "string",
+      required: false,
+      description: `Which template set to seed: ${EMAIL_TEMPLATE_SET_KEYS.join(", ")}, or "all" (default). Idempotent: only missing template_keys are created; dry-run writes nothing.`,
+    },
+  ],
+  run: async (container, { dry_run, params }) => {
+    const setParam =
+      params?.set != null ? String(params.set) : undefined
+
+    let resolved: { setKeys: string[]; specs: EmailTemplateSpec[] }
+    try {
+      resolved = resolveEmailTemplateSpecs(setParam)
+    } catch (e: any) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        e?.message ?? "Invalid email-template set"
+      )
+    }
+
+    const svc: any = container.resolve(EMAIL_TEMPLATES_MODULE)
+    // Existence check spans active AND inactive rows (broader than the seeds'
+    // getTemplateByKey, which is active-only) so we never create a duplicate
+    // template_key for a deactivated row.
+    const existingRows = await svc.listEmailTemplates(
+      {},
+      { select: ["template_key"], take: 100000 }
+    )
+    const existing = new Set<string>(
+      (existingRows ?? [])
+        .map((r: any) => r?.template_key)
+        .filter((k: unknown): k is string => typeof k === "string" && k.length > 0)
+    )
+
+    const plan = planEmailTemplateSeed(resolved.specs, existing)
+
+    if (!dry_run) {
+      for (const spec of plan.toCreate) {
+        await svc.createEmailTemplates([spec])
+      }
+    }
+
+    const setLabel =
+      resolved.setKeys.length === EMAIL_TEMPLATE_SETS.length
+        ? "email templates"
+        : `${resolved.setKeys.join("+")} email templates`
+
+    return buildEmailTemplateSeedResult(
+      seedEmailTemplatesJob.id,
+      dry_run,
+      plan,
+      setLabel
+    )
+  },
+}

--- a/apps/backend/src/scripts/seed-cart-abandoned-email.ts
+++ b/apps/backend/src/scripts/seed-cart-abandoned-email.ts
@@ -32,7 +32,7 @@ import { EMAIL_TEMPLATES_MODULE } from "../modules/email_templates"
 
 const TEMPLATE_KEY = "cart-abandoned"
 
-const TEMPLATE_DEFINITION = {
+export const TEMPLATE_DEFINITION = {
   name: "Abandoned Cart Reminder",
   template_key: TEMPLATE_KEY,
   from: "shop@jaalyantra.com",

--- a/apps/backend/src/scripts/seed-email-templates.ts
+++ b/apps/backend/src/scripts/seed-email-templates.ts
@@ -1,7 +1,7 @@
 import { EMAIL_TEMPLATES_MODULE } from "../modules/email_templates";
 import { MedusaError } from "@medusajs/framework/utils";
 
-const emailTemplatesData = [
+export const emailTemplatesData = [
   {
     name: "Order Confirmation",
     template_key: "order-placed",

--- a/apps/backend/src/scripts/seed-partner-email-templates.ts
+++ b/apps/backend/src/scripts/seed-partner-email-templates.ts
@@ -22,7 +22,7 @@
  */
 import { EMAIL_TEMPLATES_MODULE } from "../modules/email_templates"
 
-const partnerEmailTemplates = [
+export const partnerEmailTemplates = [
   {
     template_key: "partner-production-run-completed",
     name: "Partner — Production Run Completed",

--- a/apps/backend/src/scripts/seed-tour-email-template.ts
+++ b/apps/backend/src/scripts/seed-tour-email-template.ts
@@ -72,6 +72,34 @@ const HTML = `<!doctype html>
   </table>
 </body></html>`
 
+/**
+ * Full template spec — exported so the #457 Data Plumbing `seed-email-templates`
+ * maintenance job can preview/create it idempotently without `medusa exec`.
+ */
+export const tourEmailTemplate = {
+  name: TEMPLATE_NAME,
+  description:
+    "Sent to the customer when they confirm their tour itinerary on the visit page.",
+  template_key: TEMPLATE_KEY,
+  subject: SUBJECT,
+  html_content: HTML,
+  is_active: true,
+  template_type: "transactional",
+  variables: {
+    first_name: "string",
+    tour_title: "string",
+    tour_date: "ISO date",
+    visit_url: "string",
+    segments: "Array<{ title, duration?, required? }>",
+    has_payment: "boolean",
+    paid_provider: "string",
+    paid_amount: "number",
+    paid_currency: "ISO 4217",
+    add_ons_amount: "number",
+    add_ons_currency: "ISO 4217",
+  },
+}
+
 export default async function seedTourEmailTemplate({ container }: ExecArgs) {
   const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
   const templates: any = container.resolve(EMAIL_TEMPLATES_MODULE)
@@ -82,29 +110,7 @@ export default async function seedTourEmailTemplate({ container }: ExecArgs) {
   )
   const current = existing?.[0]
 
-  const fields = {
-    name: TEMPLATE_NAME,
-    description:
-      "Sent to the customer when they confirm their tour itinerary on the visit page.",
-    template_key: TEMPLATE_KEY,
-    subject: SUBJECT,
-    html_content: HTML,
-    is_active: true,
-    template_type: "transactional",
-    variables: {
-      first_name: "string",
-      tour_title: "string",
-      tour_date: "ISO date",
-      visit_url: "string",
-      segments: "Array<{ title, duration?, required? }>",
-      has_payment: "boolean",
-      paid_provider: "string",
-      paid_amount: "number",
-      paid_currency: "ISO 4217",
-      add_ons_amount: "number",
-      add_ons_currency: "ISO 4217",
-    },
-  }
+  const fields = tourEmailTemplate
 
   if (current) {
     await templates.updateEmailTemplates({ id: current.id, ...fields })

--- a/apps/backend/src/scripts/seed-visual-flow-lifecycle-email-templates.ts
+++ b/apps/backend/src/scripts/seed-visual-flow-lifecycle-email-templates.ts
@@ -155,6 +155,24 @@ const FAILURE: TemplateSpec = {
   },
 }
 
+/**
+ * Full template specs — exported so the #457 Data Plumbing `seed-email-templates`
+ * maintenance job can preview/create them idempotently without `medusa exec`.
+ * Mirrors the `fields` object built in `upsert` below (adds is_active +
+ * template_type to each TemplateSpec).
+ */
+export const visualFlowLifecycleTemplates = [STARTED, FAILURE].map((spec) => ({
+  name: spec.name,
+  description: spec.description,
+  template_key: spec.template_key,
+  from: spec.from,
+  subject: spec.subject,
+  html_content: spec.html_content,
+  is_active: true,
+  template_type: "transactional",
+  variables: spec.variables,
+}))
+
 async function upsert(templates: any, spec: TemplateSpec, logger: any) {
   const [existing] = await templates.listAndCountEmailTemplates(
     { template_key: spec.template_key },

--- a/apps/docs/notes/457_SEED_JOBS_INVENTORY.md
+++ b/apps/docs/notes/457_SEED_JOBS_INVENTORY.md
@@ -1,0 +1,80 @@
+# #457 Data Plumbing — Seed-script inventory (expose / defer / exclude)
+
+Maps every `apps/backend/src/scripts/seed-*.ts` to whether its logic should be
+reachable from **Settings → Data Plumbing** (the #457 maintenance-jobs
+registry). Follows the memory rule *"backfills/repairs/seeds must be #457
+registry jobs, not one-off scripts"* (`feedback_backfills_via_data_plumbing`).
+
+**Hard rule for any exposed job:** idempotent + **dry-run-safe** (a dry run
+writes nothing and reports what *would* change).
+
+This PR ships the **email-template** slice only — the urgent need for an empty
+admin — plus the reusable pattern (`seed-jobs.ts`) the rest slot into.
+
+## Status legend
+- **EXPOSE (this PR)** — wrapped by the `seed-email-templates` maintenance job.
+- **DEFER** — safe + idempotent + useful, but needs per-seed preview logic
+  (different exists/create shape). Next follow-up. The pattern is established.
+- **EXCLUDE** — must NOT be exposed (env/prod-snapshot/test/fixture, or already
+  has a dedicated job).
+
+## Email templates → EXPOSE (this PR)
+The `seed-email-templates` job wraps these via the `set` param
+(`core | additional | reengagement | partner | cart-abandoned | tour | visual-flow-lifecycle | all`).
+All already idempotent (skip-existing by `template_key`); the job dedupes keys
+across sets and only creates missing ones.
+
+| Seed script | `set` key | Notes |
+|---|---|---|
+| `seed-email-templates.ts` | `core` | ~40 base templates (order/design/partner/etc.) |
+| `seed-additional-email-templates.ts` | `additional` | partner-welcome, order-feedback-request, payment-receipt (#450) |
+| `seed-reengagement-email-templates.ts` | `reengagement` | win-back, back-in-stock, browse-abandonment, feedback-reminder (#450) |
+| `seed-partner-email-templates.ts` | `partner` | partner run completed/cancelled, region-request-admin, storefront-digest |
+| `seed-cart-abandoned-email.ts` | `cart-abandoned` | single `cart-abandoned` template (overlaps `core`; deduped) |
+| `seed-tour-email-template.ts` | `tour` | `tour-itinerary-confirmation` |
+| `seed-visual-flow-lifecycle-email-templates.ts` | `visual-flow-lifecycle` | `visual-flow-started`, `visual-flow-failure` |
+
+> Each of these now `export`s its template data (array/const) so `seed-jobs.ts`
+> imports the canonical content — single source of truth, no duplication.
+
+## Reference data → DEFER (next follow-up)
+Idempotent + generally useful, but each has bespoke exists/create logic, so the
+dry-run preview can't be reused from the email pattern as-is.
+
+| Seed script | Idempotency | Why deferred |
+|---|---|---|
+| `seed-energy-rates.ts` | skip by `name` | clean — easiest next; needs a `name`-keyed planner |
+| `seed-partner-plans.ts` | skip by `slug` | clean — second easiest; `slug`-keyed planner |
+| `seed-canonical-tax-regions.ts` | skip by root country | multi-step tax writes; money-sensitive — preview carefully |
+| `seed-in-textile-tax-class.ts` | skip by type/rate | multi-step (product_type + tax_region + tax_rate); money-sensitive |
+| `seed-initial-fx-rates.ts` | **upsert** (mutates) | not skip-existing — re-run UPDATES rows; make skip-only before exposing |
+| `seed-stats-dashboards.ts` | skip-existing | reference dashboards; verify dry-run shape |
+| `seed-tour-form-fields.ts` | skip-existing | reference form fields |
+| `seed-marketing-forms.ts` | skip-existing | reference forms |
+
+## Excluded → do NOT expose
+| Seed script | Reason |
+|---|---|
+| `seed-website-from-prod.ts` | prod snapshot import — not reference data |
+| `seed-partner-notification-test.ts` | test/dev fixture |
+| `seed-florence-tour.ts` | demo/fixture content |
+| `seed-partner-page-fixtures.ts` | fixture |
+| `seed-design-cart-links.ts` | fixture/link wiring |
+| `seed-plans.ts` | reads the filesystem (`fs.existsSync(plansPath)`) — unreliable in the API bundle; promote only if rewritten to inline data |
+| `seed-cart-recovery-dashboard.ts` | dashboard fixture (pairs with the flow) |
+| `seed-marketing-ideas-email.ts` | already has dedicated jobs (`run-marketing-ideas-email`, `install-marketing-ideas-email-flow`) |
+| **Visual-flow seeds** — `seed-cart-recovery-flow`, `seed-fx-refresh-flow`, `seed-fx-rerate-flow`, `seed-marketing-daily-ideas-email-flow`, `seed-order-upsert-flow`, `seed-partner-analytics-digest-flow`, `seed-partner-payment-status-flow`, `seed-partner-product-create-flow`, `seed-partner-run-whatsapp-flow`, `seed-production-run-reminders-flow`, `seed-production-run-whatsapp-flow` | visual flows install via dedicated `install-*-flow` jobs / the visual-flows console, not the seed registry |
+
+## Pattern (for the follow-up)
+`src/api/admin/ops/maintenance-jobs/seed-jobs.ts`:
+- `EMAIL_TEMPLATE_SETS` — set key → label + spec list (imported from each seed).
+- `resolveEmailTemplateSpecs(set)` — pure: set → deduped spec list.
+- `planEmailTemplateSeed(specs, existingKeys)` — pure: partition create-vs-skip.
+- `buildEmailTemplateSeedResult(...)` — pure: plan → `MaintenanceJobResult`.
+- `seedEmailTemplatesJob.run` — list existing `template_key`s once, plan, then
+  on apply `createEmailTemplates` only the missing ones.
+
+To add the reference-data seeds: generalise the planner to a
+`(spec) => naturalKey` extractor + a `(container, spec) => create` callback, then
+register one job per seed (energy-rates and partner-plans first — both are clean
+single-key skip-existing).


### PR DESCRIPTION
## What

Fresh / empty admins can now **seed the reference email templates from Settings → Data Plumbing** (dry-run preview → apply) instead of running `medusa exec` over each seed script. Establishes a reusable **"seed job"** pattern for the #457 maintenance-jobs registry (follows the memory rule *backfills/seeds = #457 registry jobs, not one-off scripts*).

## The job

One grouped job `seed-email-templates` with a `set` param:

`core | additional | reengagement | partner | cart-abandoned | tour | visual-flow-lifecycle | all` (default `all`)

- **Dry-run** (default, safe): reports exactly which `template_key`s **would** be created vs already exist — **writes nothing**.
- **Apply** (`dry_run:false`): creates **only the missing** templates (skip-existing by `template_key`, deduped across sets).
- **Idempotent**: re-run is a no-op; never overwrites an admin-edited template. Existence check spans active **and** inactive rows (broader than the seeds' active-only `getTemplateByKey`) so a deactivated key never gets a duplicate.

Each email-template seed now `export`s its template data, so the job imports the **canonical content** (single source of truth) — `seed-jobs.ts` imports DATA only; the seeds' default exports never run in the API layer.

## Verify

```
TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules npx jest src/api/admin/ops/maintenance-jobs/__tests__/seed-email-templates.unit.spec.ts
```
**18/18 pass** — `resolveEmailTemplateSpecs` (set selection + dedup), `planEmailTemplateSeed` (create-vs-skip partition), `buildEmailTemplateSeedResult` (wording + `applied` flag), and the `run()` dry-run/apply branch via a stub container. `tsc -p tsconfig.json` clean for all changed files (the ~69 remaining errors are pre-existing in unrelated integration tests / admin components).

## Scope (deliberately one slice)

**Exposed (this PR):** all 7 email-template seed sets — the urgent need for an empty admin.

**Deferred to follow-up** (safe + idempotent, but each needs per-seed preview logic): `seed-energy-rates`, `seed-partner-plans` (both clean single-key skip-existing → easiest next), `seed-canonical-tax-regions`, `seed-in-textile-tax-class`, `seed-initial-fx-rates` (upsert→mutates, make skip-only first), `seed-stats-dashboards`, `seed-tour-form-fields`, `seed-marketing-forms`.

**Excluded** (must not expose): `seed-website-from-prod` (prod snapshot), `seed-partner-notification-test` (test), `seed-florence-tour` / `seed-partner-page-fixtures` / `seed-design-cart-links` (fixtures), `seed-plans` (reads the filesystem), `seed-marketing-ideas-email` (has dedicated jobs), and all **visual-flow** `seed-*-flow.ts` (install via dedicated `install-*-flow` jobs).

Full expose/defer/exclude map for **every** seed: `apps/docs/notes/457_SEED_JOBS_INVENTORY.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)