### PR TITLE
feat(feedback): source #452 artwork from the media randomiser (no curated album required)

### DIFF
--- a/apps/backend/src/api/web/feedback/[id]/route.ts
+++ b/apps/backend/src/api/web/feedback/[id]/route.ts
@@ -3,6 +3,7 @@ import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/util
 
 import { FEEDBACK_MODULE } from "../../../../modules/feedback";
 import type FeedbackService from "../../../../modules/feedback/service";
+import { listAllMediasWorkflow } from "../../../../workflows/media/list-all-medias";
 import { listAlbumMediaWorkflow } from "../../../../workflows/media/list-album-media";
 import { listMediaFileWorkflow } from "../../../../workflows/media/list-media-file";
 import {
@@ -18,17 +19,41 @@ const ARTWORK_COUNT = 3;
 const POOL_TAKE = 100;
 
 /**
- * Fetch the curated pool of public artwork images, drawn from an Album first
- * (AlbumMedia → MediaFile) and falling back to a media FOLDER id — mirroring the
- * album-vs-folder resolution in `GET /web/media`. Stable order (no DB-side
- * randomisation); the per-token variation is applied by the pure
- * `selectArtworkChoices` seeded selector.
+ * Fetch the pool of public artwork images the seeded selector draws from.
+ *
+ * - DEFAULT (`sourceId` null): the GENERAL public-image pool — the same source
+ *   the media randomiser (`GET /web/media`) uses — so the feature works against
+ *   whatever media exists, with no curated album required.
+ * - OVERRIDE (`sourceId` set via `FEEDBACK_ARTWORK_ALBUM_ID`): scoped to that
+ *   Album first (AlbumMedia → MediaFile), falling back to a media FOLDER id —
+ *   mirroring the album-vs-folder resolution in `GET /web/media`.
+ *
+ * Stable order (no DB-side randomisation); the per-token variation is applied by
+ * the pure `selectArtworkChoices` seeded selector. An empty pool degrades the
+ * page to a plain rating (caller returns `artworks: []`).
  */
 async function fetchArtworkPool(
   req: MedusaRequest,
-  sourceId: string
+  sourceId: string | null
 ): Promise<ArtworkChoice[]> {
   let mediaFiles: any[] = [];
+
+  if (!sourceId) {
+    // General public-image pool via the media randomiser source. `file_type`
+    // (not `type`) is the column the media workflows whitelist server-side.
+    try {
+      const { result } = await listAllMediasWorkflow(req.scope).run({
+        input: {
+          filters: { is_public: true, file_type: "image" },
+          config: { take: POOL_TAKE, skip: 0 },
+        },
+      });
+      mediaFiles = ((result as any)?.media_files ?? []) as any[];
+    } catch {
+      mediaFiles = [];
+    }
+    return mediaFiles.map((m: any) => mapMediaToArtworkChoice(m));
+  }
 
   try {
     const { result } = await listAlbumMediaWorkflow(req.scope).run({

--- a/apps/backend/src/workflows/feedback/lib/__tests__/artwork-feedback.unit.spec.ts
+++ b/apps/backend/src/workflows/feedback/lib/__tests__/artwork-feedback.unit.spec.ts
@@ -1,7 +1,6 @@
 import {
   ArtworkChoice,
   buildArtworkPickUpdate,
-  DEFAULT_FEEDBACK_ARTWORK_SOURCE_ID,
   mapMediaToArtworkChoice,
   normalizeRatingValue,
   resolveArtworkSourceId,
@@ -42,15 +41,25 @@ describe("normalizeRatingValue", () => {
 });
 
 describe("resolveArtworkSourceId", () => {
-  it("prefers override, then env, then default", () => {
+  it("scopes to an explicit override album when given", () => {
     expect(resolveArtworkSourceId({}, "alb_x")).toBe("alb_x");
+  });
+  it("scopes to FEEDBACK_ARTWORK_ALBUM_ID when set", () => {
     expect(resolveArtworkSourceId({ FEEDBACK_ARTWORK_ALBUM_ID: "alb_env" })).toBe(
       "alb_env"
     );
-    expect(resolveArtworkSourceId({})).toBe(DEFAULT_FEEDBACK_ARTWORK_SOURCE_ID);
-    expect(resolveArtworkSourceId({ FEEDBACK_ARTWORK_ALBUM_ID: "  " })).toBe(
-      DEFAULT_FEEDBACK_ARTWORK_SOURCE_ID
-    );
+  });
+  it("returns null (general media pool) when no album is configured", () => {
+    // Null is the signal to draw from the general public-image pool via the
+    // media randomiser — no curated album required on a fresh admin.
+    expect(resolveArtworkSourceId({})).toBeNull();
+    expect(resolveArtworkSourceId({ FEEDBACK_ARTWORK_ALBUM_ID: "  " })).toBeNull();
+    expect(resolveArtworkSourceId({}, "  ")).toBeNull();
+  });
+  it("prefers the override over the env value", () => {
+    expect(
+      resolveArtworkSourceId({ FEEDBACK_ARTWORK_ALBUM_ID: "alb_env" }, "alb_x")
+    ).toBe("alb_x");
   });
 });
 
@@ -123,6 +132,27 @@ describe("selectArtworkChoices", () => {
     const dup = [...pool(2), ...pool(2)];
     const out = selectArtworkChoices(dup, "s", 5);
     expect(out).toHaveLength(2);
+  });
+
+  it("default path: N distinct, seed-reproducible artworks from the general media pool", () => {
+    // Models the randomiser default — no curated album, so `pool` is the
+    // general public-image set fetched via the media randomiser. The offered
+    // set must be exactly N distinct and reproducible for the same feedback id
+    // (the seed), so the POST can validate the pick against the GET's set.
+    const generalPool = pool(40);
+    const seed = "feedback_general_pool";
+    const offered = selectArtworkChoices(generalPool, seed, 3);
+    expect(offered).toHaveLength(3);
+    expect(new Set(offered.map((o) => o.id)).size).toBe(3);
+
+    const again = selectArtworkChoices(generalPool, seed, 3);
+    expect(again.map((o) => o.id)).toEqual(offered.map((o) => o.id));
+
+    // A different feedback id varies the offered set (per-token variation).
+    const other = selectArtworkChoices(generalPool, "feedback_other", 3);
+    expect(other.map((o) => o.id).join(",")).not.toBe(
+      offered.map((o) => o.id).join(",")
+    );
   });
 
   it("caps at pool size and handles empty/zero", () => {

--- a/apps/backend/src/workflows/feedback/lib/artwork-feedback.ts
+++ b/apps/backend/src/workflows/feedback/lib/artwork-feedback.ts
@@ -52,19 +52,20 @@ export function normalizeRatingValue(
 }
 
 /**
- * Resolve the curated media source (an Album or media Folder id) the artwork
- * pool is drawn from. Admin-editable via env rather than hardcoded; falls back
- * to the existing curated hero set so a fresh install still shows artwork.
- * Precedence: explicit override → FEEDBACK_ARTWORK_ALBUM_ID → default.
+ * Resolve the OPTIONAL curated media source (an Album or media Folder id) the
+ * artwork pool is scoped to. When `FEEDBACK_ARTWORK_ALBUM_ID` (or an explicit
+ * override) is set, the pool is scoped to that album/folder; when unset, this
+ * returns `null` — meaning "draw from the GENERAL public media pool via the
+ * media randomiser" (the same mechanism as `GET /web/media`). No curated album
+ * is required, so the feature works against whatever media a fresh admin has.
+ * Precedence: explicit override → FEEDBACK_ARTWORK_ALBUM_ID → null (general pool).
  */
-export const DEFAULT_FEEDBACK_ARTWORK_SOURCE_ID = "media_art_hero";
-
 export function resolveArtworkSourceId(
   env: Record<string, string | undefined> = {},
   override?: string | null
-): string {
+): string | null {
   const raw = (override || env.FEEDBACK_ARTWORK_ALBUM_ID || "").trim();
-  return raw || DEFAULT_FEEDBACK_ARTWORK_SOURCE_ID;
+  return raw || null;
 }
 
 export interface MediaLike {

--- a/apps/docs/notes/452_ARTWORK_FEEDBACK.md
+++ b/apps/docs/notes/452_ARTWORK_FEEDBACK.md
@@ -24,10 +24,12 @@ rating are untouched; the artwork pick is optional.
    `Migration20260624150000.ts` (hand-written `add column if not exists` ALTER —
    never edit the create-table migration).
 
-2. **Pure helpers** `src/workflows/feedback/lib/artwork-feedback.ts` (17 unit
+2. **Pure helpers** `src/workflows/feedback/lib/artwork-feedback.ts` (21 unit
    tests):
-   - `resolveArtworkSourceId(env, override?)` — curated source (Album/Folder id),
-     `FEEDBACK_ARTWORK_ALBUM_ID` env → default `media_art_hero`.
+   - `resolveArtworkSourceId(env, override?)` — returns the OPTIONAL album/folder
+     scope (`FEEDBACK_ARTWORK_ALBUM_ID` env / override), or **`null`** when unset.
+     `null` ⇒ draw from the **general public media pool** via the media
+     randomiser — no curated album required (works on a fresh admin).
    - `selectArtworkChoices(pool, seed, count=3)` — deterministic seeded selection
      (FNV-1a → mulberry32, same algo as `GET /web/media`). Same seed → same set
      (so the offered set is reproducible to validate a pick); different seed
@@ -42,9 +44,11 @@ rating are untouched; the artwork pick is optional.
 3. **Public page API** `src/api/web/feedback/[id]/route.ts` (CORS inherited from
    the global `/web/*` matcher; no auth — the id is the capability token):
    - `GET /web/feedback/:id` → `{ feedback, artworks }`. Artworks are the seeded
-     3-set drawn from the curated public-image pool (Album first, media Folder
-     fallback — mirrors `GET /web/media`). No pool configured ⇒ `artworks: []`
-     and the page degrades to a plain rating.
+     3-set. By DEFAULT the pool is the **general public-image pool** (the same
+     source as the media randomiser `GET /web/media`, filtered `file_type:image`);
+     if `FEEDBACK_ARTWORK_ALBUM_ID` is set, the pool is scoped to that Album
+     (with a media Folder fallback — mirrors `GET /web/media`). No media at all ⇒
+     `artworks: []` and the page degrades to a plain rating.
    - `POST /web/feedback/:id` `{ rating?, comment?, artwork_id?, affinity? }` →
      records rating/comment and the **validated** artwork pick into the typed
      columns. Pick validated against the same seeded set the GET returns. 400 if
@@ -52,10 +56,15 @@ rating are untouched; the artwork pick is optional.
 
 ## Artwork source
 
-Reuses the **media module** — a curated Album or media Folder of public images,
-exactly the mechanism the storefront hero already uses (folder `media_art_hero`,
-roadmap #22). Admin-editable via env `FEEDBACK_ARTWORK_ALBUM_ID`; no new model.
-To curate: drop artwork into that folder/album (public images).
+Reuses the **media module** via the same **media randomiser** as `GET /web/media`
+(seeded FNV-1a → mulberry32 selection). By default the pool is **all public
+image media** — so the feature works against whatever media a fresh admin has,
+with **no curated album required**. The per-feedback variation comes from seeding
+the selection by the feedback id (reproducible per token, varies across tokens).
+
+`FEEDBACK_ARTWORK_ALBUM_ID` (env) is an **optional override**: set it to a media
+Album or Folder id to scope the artwork pool to a curated set (e.g. the
+storefront hero folder `media_art_hero`, roadmap #22). No new model.
 
 ## Storefront page (follow-up — NOT in this PR)
 
@@ -71,14 +80,15 @@ Building it is Playwright-gated UI in a separate repo → deferred.
 ## Manual verification (curl)
 
 ```bash
-# Seed: put public images in a folder, set FEEDBACK_ARTWORK_ALBUM_ID=<folderId>.
+# Default: no env needed — any public image media is eligible (media randomiser).
+# (Optional) to curate, set FEEDBACK_ARTWORK_ALBUM_ID=<album-or-folder-id>.
 # Pick a pending feedback id (e.g. from a delivered test order).
-curl -s "$BACKEND/web/feedback/<id>" | jq '.artworks | length'   # → 3
+curl -s "$BACKEND/web/feedback/<id>" | jq '.artworks | length'   # → 3 (if ≥3 public images)
 curl -s -X POST "$BACKEND/web/feedback/<id>" \
   -H 'content-type: application/json' \
   -d '{"rating":5,"artwork_id":"<one-of-the-returned-ids>","affinity":"calm"}' | jq
 # → feedback.chosen_artwork_id == artwork_id, rating == "five"
 ```
 
-Automated coverage: `artwork-feedback.unit.spec.ts` (17) +
+Automated coverage: `artwork-feedback.unit.spec.ts` (21) +
 `integration-tests/http/artwork-feedback.spec.ts` (3, full GET/POST + persistence).


### PR DESCRIPTION
## What & why

The post-delivery artwork-rating page (#452, shipped in #716) sourced its artwork from `FEEDBACK_ARTWORK_ALBUM_ID` → a hardcoded default album `media_art_hero`. On a **fresh admin** that album/folder may not exist → the picker comes back empty. The user wants it to use the **existing media randomiser** so it works against whatever media is present.

This PR re-points the **default** artwork pool at the general public-image media pool (the same source as `GET /web/media`), keeping the curated album as an **optional override**.

## Changes (additive — does not break the merged #716 page/columns)

- **`workflows/feedback/lib/artwork-feedback.ts`** — `resolveArtworkSourceId(env, override?)` now returns `string | null`: the optional album/folder scope (`FEEDBACK_ARTWORK_ALBUM_ID`/override) or **`null`** = "use the general media pool". Removed the hardcoded `media_art_hero` default (and the now-unused `DEFAULT_FEEDBACK_ARTWORK_SOURCE_ID`).
- **`api/web/feedback/[id]/route.ts`** — `fetchArtworkPool` handles the null source by drawing from `listAllMediasWorkflow` over `{ is_public: true, file_type: "image" }` (the randomiser's general pool). When `FEEDBACK_ARTWORK_ALBUM_ID` is set, it still scopes to that Album → media Folder fallback (unchanged).
- The **seeded selection** (`selectArtworkChoices`, seeded by feedback id) is unchanged — only **where** the pool comes from changed. Empty media still degrades to a plain rating (`artworks: []`).

## Behaviour

| Config | Pool |
|--------|------|
| (default, no env) | general public-image media via the randomiser |
| `FEEDBACK_ARTWORK_ALBUM_ID` set | scoped to that Album → Folder fallback |
| no media at all | `artworks: []`, page falls back to plain 1..5 rating |

## Verify

- `artwork-feedback.unit.spec.ts` — **21 unit** pass (added: default path returns N distinct, seed-reproducible artworks; null = general pool; override still works).
- `integration-tests/http/artwork-feedback.spec.ts` — **3 integration** pass (override path, end-to-end GET/POST + persistence).
- Typecheck clean on changed files.

Doc `apps/docs/notes/452_ARTWORK_FEEDBACK.md` updated to reflect the randomiser default (no required album/env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)