### PR TITLE
infra(#452): set FEEDBACK_ARTWORK_ALBUM_ID in prod server manifest

### DIFF
--- a/deploy/aws/copilot/medusa-server/manifest.yml
+++ b/deploy/aws/copilot/medusa-server/manifest.yml
@@ -58,6 +58,12 @@ variables:
   # which falls back to a hardcoded default if unset; this makes the prod value explicit.
   # Non-secret, so it lives here (not under secrets:).
   PARTNER_APP_URL: https://partner.jaalyantra.com
+  # #452 — scopes the public feedback artwork picker to a curated art album
+  # instead of the general media pool. Read by resolveArtworkSourceId
+  # (src/workflows/feedback/lib/artwork-feedback.ts); unset → general "everything
+  # in the media randomiser" pool. This album resolves to the 11 curated images
+  # on prod. Non-secret (just an album id), so it lives here (not under secrets:).
+  FEEDBACK_ARTWORK_ALBUM_ID: 01KS74M4JABCFKHB4WTF90KQYS
 
 # Secrets: rotating values come from Secrets Manager.
 # Non-rotating config (CORS, URLs, etc.) comes from SSM Parameter Store — listed


### PR DESCRIPTION
## What
Adds `FEEDBACK_ARTWORK_ALBUM_ID: 01KS74M4JABCFKHB4WTF90KQYS` to the **medusa-server** copilot manifest `variables:` block (non-secret, plain value — not under `secrets:`).

## Why
The public feedback artwork picker (#452) currently draws from the **general media pool** when this env var is unset. `resolveArtworkSourceId` in `apps/backend/src/workflows/feedback/lib/artwork-feedback.ts` reads `FEEDBACK_ARTWORK_ALBUM_ID`:

> Precedence: explicit override → `FEEDBACK_ARTWORK_ALBUM_ID` → null (general pool).

Setting it scopes the picker to the curated art album, which resolves to **11 curated images** on prod — so the feedback page shows art instead of random product/media.

## Scope
- One file: `deploy/aws/copilot/medusa-server/manifest.yml` (+6 lines: comment + var).
- No other manifest values changed. Worker manifest not touched (this is the public feedback page on the **server**).

## Verify
- YAML parses cleanly; `variables.FEEDBACK_ARTWORK_ALBUM_ID` resolves to the album id.
- 2-space indentation consistent with sibling vars (`NODE_ENV`, `PARTNER_APP_URL`).

⚠️ **INFRA** — merging this runs `deploy-to-aws.yml`, which redeploys the backend (~18–45m) and sets the prod env var. Human review intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)