### PR TITLE
feat(#460): email-driven lead capture + follow-up nudge (slice 1)

### DIFF
--- a/apps/backend/src/jobs/ingest-lead-emails.ts
+++ b/apps/backend/src/jobs/ingest-lead-emails.ts
@@ -1,0 +1,128 @@
+import { MedusaContainer } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { SOCIALS_MODULE } from "../modules/socials"
+import type SocialsService from "../modules/socials/service"
+import { INBOUND_EMAIL_MODULE } from "../modules/inbound_emails"
+import {
+  buildEmailLeadKey,
+  buildLeadInputFromEmail,
+  resolveLeadFolders,
+  selectLeadEmailsToIngest,
+} from "../workflows/leads/lib/email-lead"
+
+/**
+ * #460 slice 1 — email-driven lead capture.
+ *
+ * Scans inbound emails (synced from iCloud/IMAP or delivered via Resend) that
+ * landed in a configured "leads" folder and upserts a `Lead` in the socials
+ * module. Idempotent: the lead's `meta_lead_id` is a stable key derived from the
+ * email message-id, so a re-scan never double-creates. Fail-soft — one bad row
+ * never aborts the batch.
+ *
+ * The "leads folder" signal: set `LEADS_EMAIL_FOLDERS` (comma-separated IMAP
+ * folder names, default `Leads`). The categorisation flow that *moves* emails
+ * into that folder is the next step (documented in the #460 handoff); this job
+ * only reacts to the folder once an email is there.
+ *
+ * Emits `lead.created_from_email` per new lead so an event-triggered visual flow
+ * can drive downstream follow-up without code.
+ */
+const MAX_BATCH = Number(process.env.LEADS_INGEST_MAX_BATCH || 200)
+
+export default async function ingestLeadEmails(container: MedusaContainer) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const socials = container.resolve(SOCIALS_MODULE) as SocialsService
+  const inboundEmails: any = container.resolve(INBOUND_EMAIL_MODULE)
+
+  const folders = resolveLeadFolders(process.env.LEADS_EMAIL_FOLDERS)
+
+  try {
+    // Pull recent inbound emails; the pure selector applies folder + idempotency
+    // filters so this stays unit-testable.
+    const emails = await inboundEmails.listInboundEmails({}, { take: 1000 })
+
+    if (!Array.isArray(emails) || emails.length === 0) {
+      return
+    }
+
+    // Existing email-source leads keyed by meta_lead_id, to skip re-ingest.
+    const existing = (await socials.listLeads(
+      { source_platform: "email" },
+      { take: 2000 }
+    )) as any[]
+    const existingKeys = new Set(
+      (existing || []).map((l) => l.meta_lead_id).filter(Boolean)
+    )
+
+    const toIngest = selectLeadEmailsToIngest(emails as any, {
+      folders,
+      existingKeys,
+      maxBatch: MAX_BATCH,
+    })
+
+    if (toIngest.length === 0) {
+      return
+    }
+
+    let created = 0
+    let skipped = 0
+    for (const email of toIngest) {
+      try {
+        const input = buildLeadInputFromEmail(email as any)
+
+        // Double-check against the DB (a concurrent run could have inserted it).
+        const dupes = (await socials.listLeads({
+          meta_lead_id: input.meta_lead_id,
+        })) as any[]
+        if (dupes && dupes.length > 0) {
+          skipped++
+          continue
+        }
+
+        const lead = await socials.createLeads(input as any)
+        const leadId = Array.isArray(lead) ? lead[0]?.id : (lead as any)?.id
+
+        // Best-effort back-link stamp on the inbound email (preserve metadata).
+        if (email.id) {
+          try {
+            await inboundEmails.updateInboundEmails({
+              id: email.id,
+              metadata: {
+                ...((email as any).metadata || {}),
+                lead_id: leadId || null,
+                lead_ingested_at: new Date().toISOString(),
+              },
+            })
+          } catch {
+            // non-fatal — the lead exists; the stamp is only a convenience.
+          }
+        }
+
+        created++
+      } catch (e: any) {
+        skipped++
+        logger.warn(
+          `[lead-ingest] failed for email ${
+            (email as any).id || buildEmailLeadKey(email as any)
+          }: ${e?.message || e}`
+        )
+      }
+    }
+
+    if (created + skipped > 0) {
+      logger.info(
+        `[lead-ingest] done — created=${created} skipped=${skipped} folders=${folders.join(
+          ","
+        )}`
+      )
+    }
+  } catch (e: any) {
+    logger.error(`[lead-ingest] batch error: ${e?.message || e}`)
+  }
+}
+
+export const config = {
+  name: "ingest-lead-emails",
+  schedule: "*/15 * * * *", // every 15 minutes
+}

--- a/apps/backend/src/jobs/send-lead-followup-reminders.ts
+++ b/apps/backend/src/jobs/send-lead-followup-reminders.ts
@@ -1,0 +1,94 @@
+import { MedusaContainer } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { IEventBusModuleService } from "@medusajs/framework/types"
+
+import { SOCIALS_MODULE } from "../modules/socials"
+import type SocialsService from "../modules/socials/service"
+import {
+  LEAD_FOLLOWUP_DUE_EVENT,
+  selectLeadsNeedingFollowup,
+} from "../workflows/leads/lib/email-lead"
+
+/**
+ * #460 slice 1 — email lead follow-up nudge.
+ *
+ * Finds email-source leads (captured by `ingest-lead-emails`) that are still
+ * open (`new`/`contacted`) with no activity after N days and emits a
+ * `lead.followup_due` event for each. That event is picked up by the
+ * visual-flow event trigger, so the operator can wire a follow-up flow (send an
+ * email, create a task, ping a channel) with no code.
+ *
+ * Idempotent: each nudged lead is stamped with `metadata.followup_nudged_at`, so
+ * a re-run never re-fires. Fail-soft — a single bad lead never aborts the batch.
+ */
+const MIN_AGE_DAYS = Number(process.env.LEADS_FOLLOWUP_MIN_AGE_DAYS || 3)
+const MAX_BATCH = Number(process.env.LEADS_FOLLOWUP_MAX_BATCH || 100)
+
+export default async function sendLeadFollowupReminders(
+  container: MedusaContainer
+) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const socials = container.resolve(SOCIALS_MODULE) as SocialsService
+  const eventBus = container.resolve(
+    Modules.EVENT_BUS
+  ) as IEventBusModuleService
+
+  try {
+    const leads = (await socials.listLeads(
+      { source_platform: "email" },
+      { take: 1000 }
+    )) as any[]
+
+    const due = selectLeadsNeedingFollowup(leads as any, {
+      minAgeDays: MIN_AGE_DAYS,
+      maxBatch: MAX_BATCH,
+    })
+
+    if (due.length === 0) {
+      return
+    }
+
+    let nudged = 0
+    let skipped = 0
+    for (const lead of due) {
+      try {
+        await eventBus.emit({
+          name: LEAD_FOLLOWUP_DUE_EVENT,
+          data: {
+            id: lead.id,
+            email: lead.email || null,
+            full_name: lead.full_name || null,
+            status: lead.status || "new",
+          },
+        })
+
+        await socials.updateLeads([
+          {
+            id: lead.id,
+            metadata: {
+              ...(lead.metadata || {}),
+              followup_nudged_at: new Date().toISOString(),
+            },
+          },
+        ] as any)
+        nudged++
+      } catch (e: any) {
+        skipped++
+        logger.warn(
+          `[lead-followup] failed for lead ${lead.id}: ${e?.message || e}`
+        )
+      }
+    }
+
+    if (nudged + skipped > 0) {
+      logger.info(`[lead-followup] done — nudged=${nudged} skipped=${skipped}`)
+    }
+  } catch (e: any) {
+    logger.error(`[lead-followup] batch error: ${e?.message || e}`)
+  }
+}
+
+export const config = {
+  name: "send-lead-followup-reminders",
+  schedule: "0 9 * * *", // daily at 09:00
+}

--- a/apps/backend/src/workflows/leads/lib/__tests__/email-lead.unit.spec.ts
+++ b/apps/backend/src/workflows/leads/lib/__tests__/email-lead.unit.spec.ts
@@ -1,0 +1,277 @@
+import {
+  buildEmailLeadKey,
+  buildEmailSnippet,
+  buildLeadInputFromEmail,
+  DEFAULT_LEAD_FOLDERS,
+  isLeadEmail,
+  leadFollowupAlreadyNudged,
+  parseFromAddress,
+  resolveLeadFolders,
+  selectLeadEmailsToIngest,
+  selectLeadsNeedingFollowup,
+  splitName,
+} from "../email-lead"
+
+const NOW = new Date("2026-06-24T10:00:00.000Z")
+const daysAgo = (n: number) => new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000)
+
+const email = (over: Record<string, any> = {}) => ({
+  id: "inb_1",
+  imap_uid: "100",
+  message_id: "<msg-1@mail.com>",
+  from_address: "Jane Doe <jane@buyer.com>",
+  subject: "Interested in bulk fabric",
+  text_body: "Hi, we'd like a quote for 500m of cotton.",
+  folder: "Leads",
+  status: "received",
+  received_at: daysAgo(1),
+  metadata: {},
+  ...over,
+})
+
+describe("resolveLeadFolders", () => {
+  it("defaults when empty/undefined", () => {
+    expect(resolveLeadFolders()).toEqual(DEFAULT_LEAD_FOLDERS)
+    expect(resolveLeadFolders("")).toEqual(DEFAULT_LEAD_FOLDERS)
+    expect(resolveLeadFolders([])).toEqual(DEFAULT_LEAD_FOLDERS)
+  })
+  it("splits a comma string and trims", () => {
+    expect(resolveLeadFolders("Leads, Sales Inbox ,VIP")).toEqual([
+      "Leads",
+      "Sales Inbox",
+      "VIP",
+    ])
+  })
+  it("accepts an array", () => {
+    expect(resolveLeadFolders(["A", "B"])).toEqual(["A", "B"])
+  })
+})
+
+describe("parseFromAddress / splitName", () => {
+  it("parses display name + angle address (lowercased)", () => {
+    expect(parseFromAddress("Jane Doe <Jane@Buyer.com>")).toEqual({
+      email: "jane@buyer.com",
+      fullName: "Jane Doe",
+    })
+  })
+  it("parses a bare address", () => {
+    expect(parseFromAddress("bob@x.com")).toEqual({
+      email: "bob@x.com",
+      fullName: "",
+    })
+  })
+  it("strips surrounding quotes from the name", () => {
+    expect(parseFromAddress('"Acme Co" <sales@acme.com>').fullName).toBe(
+      "Acme Co"
+    )
+  })
+  it("handles empty input", () => {
+    expect(parseFromAddress("")).toEqual({ email: "", fullName: "" })
+    expect(parseFromAddress(null)).toEqual({ email: "", fullName: "" })
+  })
+  it("splits names", () => {
+    expect(splitName("Jane Doe")).toEqual({
+      first_name: "Jane",
+      last_name: "Doe",
+    })
+    expect(splitName("Cher")).toEqual({ first_name: "Cher", last_name: null })
+    expect(splitName("")).toEqual({ first_name: null, last_name: null })
+  })
+})
+
+describe("buildEmailLeadKey (idempotency key)", () => {
+  it("prefers message-id", () => {
+    expect(buildEmailLeadKey(email())).toBe("email:<msg-1@mail.com>")
+  })
+  it("falls back to folder+uid when no message-id", () => {
+    expect(buildEmailLeadKey(email({ message_id: null }))).toBe(
+      "email:Leads:100"
+    )
+  })
+  it("falls back to from+subject when no message-id/uid", () => {
+    expect(
+      buildEmailLeadKey(
+        email({ message_id: "", imap_uid: "", from_address: "A@B.com" })
+      )
+    ).toBe("email:a@b.com:interested in bulk fabric")
+  })
+  it("is stable across two reads of the same email", () => {
+    const e = email()
+    expect(buildEmailLeadKey(e)).toBe(buildEmailLeadKey({ ...e }))
+  })
+})
+
+describe("isLeadEmail", () => {
+  it("matches a configured folder case-insensitively", () => {
+    expect(isLeadEmail(email({ folder: "leads" }), ["Leads"])).toBe(true)
+    expect(isLeadEmail(email({ folder: "LEADS" }), ["leads"])).toBe(true)
+  })
+  it("rejects other folders", () => {
+    expect(isLeadEmail(email({ folder: "INBOX" }), ["Leads"])).toBe(false)
+  })
+  it("rejects ignored emails", () => {
+    expect(isLeadEmail(email({ status: "ignored" }), ["Leads"])).toBe(false)
+  })
+  it("rejects missing folder", () => {
+    expect(isLeadEmail(email({ folder: "" }))).toBe(false)
+  })
+})
+
+describe("buildEmailSnippet", () => {
+  it("collapses whitespace", () => {
+    expect(buildEmailSnippet(email({ text_body: "a\n\n  b   c" }))).toBe("a b c")
+  })
+  it("truncates long bodies with an ellipsis", () => {
+    const long = "x".repeat(400)
+    const snip = buildEmailSnippet(email({ text_body: long }), 280)
+    expect(snip.length).toBe(280)
+    expect(snip.endsWith("…")).toBe(true)
+  })
+  it("returns empty for no body", () => {
+    expect(buildEmailSnippet(email({ text_body: null }))).toBe("")
+  })
+})
+
+describe("buildLeadInputFromEmail", () => {
+  it("maps an email into a new lead with a stable key", () => {
+    const input = buildLeadInputFromEmail(email(), NOW)
+    expect(input.meta_lead_id).toBe("email:<msg-1@mail.com>")
+    expect(input.email).toBe("jane@buyer.com")
+    expect(input.full_name).toBe("Jane Doe")
+    expect(input.first_name).toBe("Jane")
+    expect(input.last_name).toBe("Doe")
+    expect(input.source_platform).toBe("email")
+    expect(input.status).toBe("new")
+    expect(input.created_time).toEqual(daysAgo(1))
+    expect(input.metadata.source).toBe("inbound_email")
+    expect(input.metadata.inbound_email_id).toBe("inb_1")
+    expect(input.notes).toContain("cotton")
+  })
+  it("uses now when received_at is missing/invalid", () => {
+    const input = buildLeadInputFromEmail(email({ received_at: null }), NOW)
+    expect(input.created_time).toEqual(NOW)
+  })
+  it("falls back to subject for notes when body empty", () => {
+    const input = buildLeadInputFromEmail(
+      email({ text_body: "" }),
+      NOW
+    )
+    expect(input.notes).toBe("Interested in bulk fabric")
+  })
+})
+
+describe("selectLeadEmailsToIngest", () => {
+  it("selects only lead-folder emails not already ingested", () => {
+    const emails = [
+      email({ id: "a", message_id: "<a@m>" }),
+      email({ id: "b", message_id: "<b@m>", folder: "INBOX" }), // wrong folder
+      email({ id: "c", message_id: "<c@m>" }),
+    ]
+    const out = selectLeadEmailsToIngest(emails, {
+      existingKeys: ["email:<c@m>"],
+    })
+    expect(out.map((e) => e.id)).toEqual(["a"])
+  })
+  it("de-duplicates within the batch", () => {
+    const emails = [
+      email({ id: "a", message_id: "<dup@m>" }),
+      email({ id: "b", message_id: "<dup@m>" }),
+    ]
+    expect(selectLeadEmailsToIngest(emails).map((e) => e.id)).toEqual(["a"])
+  })
+  it("caps at maxBatch", () => {
+    const emails = Array.from({ length: 5 }, (_, i) =>
+      email({ id: `e${i}`, message_id: `<${i}@m>` })
+    )
+    expect(selectLeadEmailsToIngest(emails, { maxBatch: 2 })).toHaveLength(2)
+  })
+  it("returns [] for empty input", () => {
+    expect(selectLeadEmailsToIngest([])).toEqual([])
+    expect(selectLeadEmailsToIngest(null)).toEqual([])
+  })
+})
+
+describe("selectLeadsNeedingFollowup", () => {
+  const lead = (over: Record<string, any> = {}) => ({
+    id: "lead_1",
+    email: "jane@buyer.com",
+    status: "new",
+    source_platform: "email",
+    created_time: daysAgo(5),
+    metadata: {},
+    ...over,
+  })
+
+  it("selects open, stale, un-nudged email leads", () => {
+    const out = selectLeadsNeedingFollowup([lead()], {
+      now: NOW,
+      minAgeDays: 3,
+    })
+    expect(out.map((l) => l.id)).toEqual(["lead_1"])
+  })
+  it("skips non-email leads", () => {
+    expect(
+      selectLeadsNeedingFollowup([lead({ source_platform: "facebook" })], {
+        now: NOW,
+      })
+    ).toHaveLength(0)
+  })
+  it("skips converted/lost leads", () => {
+    expect(
+      selectLeadsNeedingFollowup([lead({ status: "converted" })], { now: NOW })
+    ).toHaveLength(0)
+  })
+  it("skips already-nudged leads (idempotent)", () => {
+    expect(
+      selectLeadsNeedingFollowup(
+        [lead({ metadata: { followup_nudged_at: "2026-06-23T00:00:00Z" } })],
+        { now: NOW }
+      )
+    ).toHaveLength(0)
+  })
+  it("skips leads younger than minAgeDays", () => {
+    expect(
+      selectLeadsNeedingFollowup([lead({ created_time: daysAgo(1) })], {
+        now: NOW,
+        minAgeDays: 3,
+      })
+    ).toHaveLength(0)
+  })
+  it("uses contacted_at over created_time as the activity clock", () => {
+    expect(
+      selectLeadsNeedingFollowup(
+        [lead({ created_time: daysAgo(30), contacted_at: daysAgo(1) })],
+        { now: NOW, minAgeDays: 3 }
+      )
+    ).toHaveLength(0)
+  })
+  it("skips soft-deleted leads", () => {
+    expect(
+      selectLeadsNeedingFollowup([lead({ deleted_at: daysAgo(1) })], {
+        now: NOW,
+      })
+    ).toHaveLength(0)
+  })
+  it("sorts oldest-first and caps at maxBatch", () => {
+    const leads = [
+      lead({ id: "young", created_time: daysAgo(4) }),
+      lead({ id: "old", created_time: daysAgo(20) }),
+      lead({ id: "mid", created_time: daysAgo(10) }),
+    ]
+    const out = selectLeadsNeedingFollowup(leads, {
+      now: NOW,
+      minAgeDays: 3,
+      maxBatch: 2,
+    })
+    expect(out.map((l) => l.id)).toEqual(["old", "mid"])
+  })
+
+  it("leadFollowupAlreadyNudged reflects the stamp", () => {
+    expect(leadFollowupAlreadyNudged(lead())).toBe(false)
+    expect(
+      leadFollowupAlreadyNudged(
+        lead({ metadata: { followup_nudged_at: "x" } })
+      )
+    ).toBe(true)
+  })
+})

--- a/apps/backend/src/workflows/leads/lib/email-lead.ts
+++ b/apps/backend/src/workflows/leads/lib/email-lead.ts
@@ -1,0 +1,337 @@
+// Pure, side-effect-free helpers for the email-driven lead pipeline (#460, slice 1).
+//
+// Kept free of Medusa/container deps so the "is this email a lead?", the
+// idempotent Lead-create input assembly, and the follow-up selection logic are
+// all unit-testable without booting Medusa, a DB, or a mail provider.
+//
+// Pairs with two scheduled jobs:
+//   - `ingest-lead-emails.ts`        — scans inbound emails landing in a "leads"
+//     folder and upserts a `Lead` (socials module), idempotent on `meta_lead_id`.
+//   - `send-lead-followup-reminders.ts` — nudges email-source leads with no
+//     activity after N days by emitting `lead.followup_due` (idempotent stamp).
+//
+// Mirrors the feedback-reminder pattern (pure selector + scheduled job +
+// idempotent metadata stamp + fail-soft) in `workflows/feedback/lib`.
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+/** Lead.source_platform value used for email-captured leads. */
+export const EMAIL_LEAD_SOURCE = "email"
+
+/** Default IMAP folders / categories that mark an email as a sales lead. */
+export const DEFAULT_LEAD_FOLDERS = ["Leads", "leads"]
+
+/** Event emitted when an email-source lead has gone stale and needs follow-up. */
+export const LEAD_FOLLOWUP_DUE_EVENT = "lead.followup_due"
+
+export interface InboundEmailRow {
+  id?: string | null
+  imap_uid?: string | null
+  message_id?: string | null
+  from_address?: string | null
+  subject?: string | null
+  text_body?: string | null
+  html_body?: string | null
+  folder?: string | null
+  status?: string | null
+  received_at?: Date | string | null
+  metadata?: Record<string, any> | null
+}
+
+/**
+ * Normalise the configured "leads" folder list. Accepts a comma-separated env
+ * string or an array; falls back to {@link DEFAULT_LEAD_FOLDERS}. Comparison is
+ * always case-insensitive (see {@link isLeadEmail}).
+ */
+export function resolveLeadFolders(
+  configured?: string | string[] | null
+): string[] {
+  if (Array.isArray(configured)) {
+    const cleaned = configured.map((f) => String(f).trim()).filter(Boolean)
+    return cleaned.length > 0 ? cleaned : [...DEFAULT_LEAD_FOLDERS]
+  }
+  if (typeof configured === "string" && configured.trim()) {
+    const cleaned = configured
+      .split(",")
+      .map((f) => f.trim())
+      .filter(Boolean)
+    if (cleaned.length > 0) {
+      return cleaned
+    }
+  }
+  return [...DEFAULT_LEAD_FOLDERS]
+}
+
+/**
+ * Parse a raw `From` header ("Jane Doe <jane@x.com>" or "jane@x.com") into a
+ * display name + lowercased email address. Either part may be empty.
+ */
+export function parseFromAddress(from?: string | null): {
+  email: string
+  fullName: string
+} {
+  const raw = (from || "").trim()
+  if (!raw) {
+    return { email: "", fullName: "" }
+  }
+
+  const angle = raw.match(/^(.*)<([^>]+)>\s*$/)
+  if (angle) {
+    const name = angle[1].trim().replace(/^["']|["']$/g, "")
+    const email = angle[2].trim().toLowerCase()
+    return { email, fullName: name }
+  }
+
+  // Bare address — no display name.
+  if (raw.includes("@")) {
+    return { email: raw.toLowerCase(), fullName: "" }
+  }
+  return { email: "", fullName: raw }
+}
+
+/** Split a display name into best-effort first / last parts. */
+export function splitName(fullName?: string | null): {
+  first_name: string | null
+  last_name: string | null
+} {
+  const name = (fullName || "").trim()
+  if (!name) {
+    return { first_name: null, last_name: null }
+  }
+  const parts = name.split(/\s+/)
+  if (parts.length === 1) {
+    return { first_name: parts[0], last_name: null }
+  }
+  return {
+    first_name: parts[0],
+    last_name: parts.slice(1).join(" "),
+  }
+}
+
+/**
+ * Stable idempotency key for an email-sourced lead. Prefers the RFC message-id
+ * (unique per message), then the IMAP uid + folder, then a from+subject
+ * composite. Stored as `Lead.meta_lead_id` so a re-scan never double-creates.
+ */
+export function buildEmailLeadKey(email: InboundEmailRow): string {
+  const mid = (email.message_id || "").trim()
+  if (mid) {
+    return `email:${mid}`
+  }
+  const uid = (email.imap_uid || "").trim()
+  if (uid) {
+    return `email:${(email.folder || "INBOX").trim()}:${uid}`
+  }
+  const from = (email.from_address || "unknown").trim().toLowerCase()
+  const subj = (email.subject || "").trim().toLowerCase()
+  return `email:${from}:${subj}`
+}
+
+/**
+ * Does this inbound email count as a lead? It must live in a configured "leads"
+ * folder (case-insensitive) and not already be ignored.
+ */
+export function isLeadEmail(
+  email: InboundEmailRow,
+  folders: string[] = DEFAULT_LEAD_FOLDERS
+): boolean {
+  if (!email || email.status === "ignored") {
+    return false
+  }
+  const folder = (email.folder || "").trim().toLowerCase()
+  if (!folder) {
+    return false
+  }
+  return folders.some((f) => f.trim().toLowerCase() === folder)
+}
+
+/** Short plain-text snippet for the lead note / metadata (no HTML). */
+export function buildEmailSnippet(
+  email: InboundEmailRow,
+  maxLen = 280
+): string {
+  const body = (email.text_body || "").replace(/\s+/g, " ").trim()
+  if (!body) {
+    return ""
+  }
+  return body.length > maxLen ? `${body.slice(0, maxLen - 1)}…` : body
+}
+
+export interface EmailLeadInput {
+  meta_lead_id: string
+  email: string | null
+  full_name: string | null
+  first_name: string | null
+  last_name: string | null
+  source_platform: string
+  status: "new"
+  created_time: Date
+  notes: string | null
+  field_data: Array<{ name: string; values: string[] }>
+  metadata: Record<string, any>
+}
+
+/**
+ * Assemble the `socials.createLeads` input for an inbound lead email. The
+ * `created_time` mirrors when the email was received; `status` starts at `new`;
+ * `metadata.source` records provenance + a back-link to the inbound email row.
+ */
+export function buildLeadInputFromEmail(
+  email: InboundEmailRow,
+  now: Date = new Date()
+): EmailLeadInput {
+  const { email: addr, fullName } = parseFromAddress(email.from_address)
+  const { first_name, last_name } = splitName(fullName)
+  const received = email.received_at ? new Date(email.received_at) : now
+  const createdTime = Number.isNaN(received.getTime()) ? now : received
+  const snippet = buildEmailSnippet(email)
+  const subject = (email.subject || "").trim() || "(no subject)"
+
+  return {
+    meta_lead_id: buildEmailLeadKey(email),
+    email: addr || null,
+    full_name: fullName || null,
+    first_name,
+    last_name,
+    source_platform: EMAIL_LEAD_SOURCE,
+    status: "new",
+    created_time: createdTime,
+    notes: snippet || subject,
+    field_data: [
+      { name: "subject", values: [subject] },
+      ...(snippet ? [{ name: "snippet", values: [snippet] }] : []),
+    ],
+    metadata: {
+      source: "inbound_email",
+      inbound_email_id: email.id || null,
+      message_id: email.message_id || null,
+      folder: email.folder || null,
+      subject,
+    },
+  }
+}
+
+export interface SelectLeadEmailsOptions {
+  folders?: string[]
+  /** Set of `meta_lead_id` keys already present, to skip re-ingest. */
+  existingKeys?: Set<string> | string[]
+  maxBatch?: number
+}
+
+/**
+ * From a batch of inbound emails, select the ones in a leads folder that have
+ * not yet been turned into a Lead (key not in `existingKeys`). De-duplicates by
+ * key within the batch and caps at `maxBatch`.
+ */
+export function selectLeadEmailsToIngest(
+  emails: InboundEmailRow[] | null | undefined,
+  options: SelectLeadEmailsOptions = {}
+): InboundEmailRow[] {
+  if (!Array.isArray(emails) || emails.length === 0) {
+    return []
+  }
+  const folders = options.folders ?? DEFAULT_LEAD_FOLDERS
+  const existing =
+    options.existingKeys instanceof Set
+      ? options.existingKeys
+      : new Set(options.existingKeys || [])
+  const maxBatch = options.maxBatch ?? 200
+
+  const seen = new Set<string>()
+  const out: InboundEmailRow[] = []
+  for (const email of emails) {
+    if (!isLeadEmail(email, folders)) {
+      continue
+    }
+    const key = buildEmailLeadKey(email)
+    if (existing.has(key) || seen.has(key)) {
+      continue
+    }
+    seen.add(key)
+    out.push(email)
+    if (out.length >= maxBatch) {
+      break
+    }
+  }
+  return out
+}
+
+// ============ FOLLOW-UP SELECTION ============
+
+export interface LeadRow {
+  id: string
+  email?: string | null
+  full_name?: string | null
+  status?: string | null
+  source_platform?: string | null
+  created_time?: Date | string | null
+  contacted_at?: Date | string | null
+  deleted_at?: Date | string | null
+  metadata?: Record<string, any> | null
+}
+
+export interface SelectLeadFollowupsOptions {
+  now?: Date
+  minAgeDays?: number
+  maxBatch?: number
+}
+
+/**
+ * Idempotency guard: a lead is stamped with `metadata.followup_nudged_at` after
+ * a successful nudge, so its presence means "already nudged this cycle".
+ */
+export function leadFollowupAlreadyNudged(lead: LeadRow): boolean {
+  return !!lead?.metadata?.followup_nudged_at
+}
+
+/**
+ * The reference moment a lead's "no response" clock starts from: the last
+ * contact if any, else when the lead was created.
+ */
+function leadActivityAt(lead: LeadRow): number {
+  const ref = lead.contacted_at || lead.created_time
+  const t = ref ? new Date(ref).getTime() : NaN
+  return t
+}
+
+/**
+ * Select email-source leads that need a follow-up nudge: still open
+ * (`new` / `contacted`), originated from email, older than `minAgeDays` with no
+ * activity, not soft-deleted, and not already nudged. Oldest first, capped.
+ */
+export function selectLeadsNeedingFollowup(
+  leads: LeadRow[] | null | undefined,
+  options: SelectLeadFollowupsOptions = {}
+): LeadRow[] {
+  if (!Array.isArray(leads) || leads.length === 0) {
+    return []
+  }
+  const now = options.now ?? new Date()
+  const minAgeDays = options.minAgeDays ?? 3
+  const maxBatch = options.maxBatch ?? 100
+  const cutoff = now.getTime() - minAgeDays * MS_PER_DAY
+
+  return leads
+    .filter((l) => {
+      if (!l || !l.id || l.deleted_at) {
+        return false
+      }
+      if (l.source_platform !== EMAIL_LEAD_SOURCE) {
+        return false
+      }
+      const status = l.status ?? "new"
+      if (status !== "new" && status !== "contacted") {
+        return false
+      }
+      if (leadFollowupAlreadyNudged(l)) {
+        return false
+      }
+      const at = leadActivityAt(l)
+      if (Number.isNaN(at)) {
+        return false
+      }
+      return at <= cutoff
+    })
+    .sort((a, b) => leadActivityAt(a) - leadActivityAt(b))
+    .slice(0, Math.max(0, maxBatch))
+}


### PR DESCRIPTION
## #460 slice 1 — Email-driven lead follow-up flow

Builds on existing infra (socials `Lead` model + the `inbound_emails` IMAP/iCloud + Resend pipeline). No new frontend, no migration, no new email template.

### What's wired
1. **Email → Lead capture** — `jobs/ingest-lead-emails.ts` (every 15 min) scans inbound emails landing in a configured **leads folder** (`LEADS_EMAIL_FOLDERS`, default `Leads`) and upserts a `Lead` (`source_platform="email"`, `status="new"`).
   - **Idempotent** on `Lead.meta_lead_id` = stable key derived from the email message-id (→ folder+uid → from+subject fallback), so a re-scan never double-creates.
   - Back-links the inbound email (`metadata.lead_id` / `lead_ingested_at`), fail-soft per row.
2. **Follow-up nudge** — `jobs/send-lead-followup-reminders.ts` (daily) selects open (`new`/`contacted`) email leads with no activity after N days (`LEADS_FOLLOWUP_MIN_AGE_DAYS`, default 3) and emits **`lead.followup_due`**, which the existing **visual-flow event trigger** picks up — so the operator can wire a follow-up flow (email/task/ping) with no code.
   - **Idempotent** via `metadata.followup_nudged_at`; fail-soft.
3. **Pure lib** `workflows/leads/lib/email-lead.ts` — folder-signal detection, key derivation, email→Lead assembly, and the follow-up selector. Mirrors the `feedback-reminder` pattern (pure selector + scheduled job + idempotent stamp + fail-soft + logger).

### Documented as next (out of scope here)
- The **categorisation flow** that *moves* an email into the leads folder (the signal this PR reacts to). This PR reacts once an email is in the folder; the auto-categorisation flow is the wiring step.
- **Slice 2** (browser-extension capture) and **slice 3** (social-DM ingestion) per the #460 plan.

### Verify
- `cd apps/backend && TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules npx jest src/workflows/leads/lib/__tests__/email-lead.unit.spec.ts` → **35 passing**.
- `npx tsc --noEmit` → **0 new errors** in the added files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)