### PR TITLE
feat(#648): partner onboarding questionnaire wizard — slice 1

### DIFF
--- a/apps/backend/integration-tests/http/partner-onboarding-profile-api.spec.ts
+++ b/apps/backend/integration-tests/http/partner-onboarding-profile-api.spec.ts
@@ -1,0 +1,141 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+
+const TEST_PARTNER_PASSWORD = "supersecret"
+
+jest.setTimeout(90 * 1000)
+
+async function createPartner(api: any) {
+  const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+  const email = `partner-onb-${unique}@medusa-test.com`
+
+  await api.post("/auth/partner/emailpass/register", {
+    email,
+    password: TEST_PARTNER_PASSWORD,
+  })
+  const login1 = await api.post("/auth/partner/emailpass", {
+    email,
+    password: TEST_PARTNER_PASSWORD,
+  })
+  let headers: Record<string, string> = {
+    Authorization: `Bearer ${login1.data.token}`,
+  }
+
+  const partnerRes = await api.post(
+    "/partners",
+    {
+      name: `OnbTest ${unique}`,
+      handle: `onbtest-${unique}`,
+      admin: { email, first_name: "Admin", last_name: "Onb" },
+    },
+    { headers }
+  )
+  const partnerId = partnerRes.data.partner.id
+
+  // Re-login so the bearer token carries partner actor context.
+  const login2 = await api.post("/auth/partner/emailpass", {
+    email,
+    password: TEST_PARTNER_PASSWORD,
+  })
+  headers = { Authorization: `Bearer ${login2.data.token}` }
+
+  return { headers, partnerId }
+}
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Partner Onboarding Profile API (#648 slice 1)", () => {
+    let partner: Awaited<ReturnType<typeof createPartner>>
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      await getAuthHeaders(api)
+      partner = await createPartner(api)
+    })
+
+    it("GET returns null before the wizard is started", async () => {
+      const res = await api.get("/partners/onboarding-profile", {
+        headers: partner.headers,
+      })
+      expect(res.status).toBe(200)
+      expect(res.data.onboarding_profile).toBeNull()
+    })
+
+    it("PUT creates then reads back the profile for the partner", async () => {
+      const body = {
+        what_they_sell: "apparel",
+        price_range: "premium",
+        has_inventory_info: true,
+        does_stock: false,
+        does_weaving: true,
+        person_type: "manufacturer",
+        team_size: 12,
+        payment_collection: "through_us",
+        completed: true,
+      }
+
+      const put = await api.put("/partners/onboarding-profile", body, {
+        headers: partner.headers,
+      })
+      expect(put.status).toBe(200)
+      expect(put.data.onboarding_profile).toMatchObject(body)
+      expect(put.data.onboarding_profile.partner_id).toBe(partner.partnerId)
+
+      const get = await api.get("/partners/onboarding-profile", {
+        headers: partner.headers,
+      })
+      expect(get.status).toBe(200)
+      expect(get.data.onboarding_profile).toMatchObject(body)
+    })
+
+    it("PUT upserts (second call updates, does not duplicate)", async () => {
+      const first = await api.put(
+        "/partners/onboarding-profile",
+        { what_they_sell: "fabric", completed: false },
+        { headers: partner.headers }
+      )
+      const firstId = first.data.onboarding_profile.id
+
+      const second = await api.put(
+        "/partners/onboarding-profile",
+        { price_range: "luxury", completed: true },
+        { headers: partner.headers }
+      )
+      expect(second.data.onboarding_profile.id).toBe(firstId)
+      expect(second.data.onboarding_profile.what_they_sell).toBe("fabric")
+      expect(second.data.onboarding_profile.price_range).toBe("luxury")
+      expect(second.data.onboarding_profile.completed).toBe(true)
+    })
+
+    it("PUT rejects an invalid enum value with 400", async () => {
+      const res = await api
+        .put(
+          "/partners/onboarding-profile",
+          { what_they_sell: "spaceships" },
+          { headers: partner.headers }
+        )
+        .catch((e: any) => e.response)
+      expect(res.status).toBe(400)
+    })
+
+    it("PUT rejects an unknown field with 400 (strict schema)", async () => {
+      const res = await api
+        .put(
+          "/partners/onboarding-profile",
+          { not_a_real_field: "x" },
+          { headers: partner.headers }
+        )
+        .catch((e: any) => e.response)
+      expect(res.status).toBe(400)
+    })
+
+    it("requires partner authentication", async () => {
+      const res = await api
+        .get("/partners/onboarding-profile")
+        .catch((e: any) => e.response)
+      expect([401, 403]).toContain(res.status)
+    })
+  })
+})

--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -438,6 +438,9 @@ module.exports = defineConfig({
       resolve: "./src/modules/partner-payment-config",
     },
     {
+      resolve: "./src/modules/partner-onboarding-profile",
+    },
+    {
       resolve: "./src/modules/partner_billing",
     },
     {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -115,6 +115,9 @@ module.exports = defineConfig({
       resolve: "./src/modules/partner-payment-config",
     },
     {
+      resolve: "./src/modules/partner-onboarding-profile",
+    },
+    {
       resolve: "./src/modules/partner_billing",
     },
     {

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -98,6 +98,7 @@ import { AdminCreateEnergyRateReq, AdminUpdateEnergyRateReq } from "./admin/ener
 import { partnerSchema, partnerUpdateSchema } from "./partners/validators";
 import { partnerPeopleSchema } from "./partners/[id]/validators";
 import { updatePartnerMeSchema } from "./partners/me/validators";
+import { onboardingProfileUpdateSchema } from "./partners/onboarding-profile/validators";
 import { AdminGetPartnersParamsSchema } from "./admin/persons/partner/validators";
 import { createInventoryOrdersSchema, listInventoryOrdersQuerySchema, ReadSingleInventoryOrderQuerySchema, updateInventoryOrdersSchema, updateInventoryOrderLinesSchema } from "./admin/inventory-orders/validators";
 // Import already defined above
@@ -737,6 +738,24 @@ export default defineMiddlewares({
         createCorsPartnerMiddleware(),
         authenticate("partner", ["session", "bearer"]),
         validateAndTransformBody(wrapSchema(partnerUpdateSchema)),
+      ],
+    },
+
+    {
+      matcher: "/partners/onboarding-profile",
+      method: "PUT",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+        validateAndTransformBody(wrapSchema(onboardingProfileUpdateSchema)),
+      ],
+    },
+    {
+      matcher: "/partners/onboarding-profile",
+      method: "GET",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
       ],
     },
 

--- a/apps/backend/src/api/partners/onboarding-profile/__tests__/validators.unit.spec.ts
+++ b/apps/backend/src/api/partners/onboarding-profile/__tests__/validators.unit.spec.ts
@@ -1,0 +1,63 @@
+import { onboardingProfileUpdateSchema } from "../validators"
+
+describe("onboardingProfileUpdateSchema (#648 slice 1)", () => {
+  it("accepts a full valid payload", () => {
+    const res = onboardingProfileUpdateSchema.safeParse({
+      what_they_sell: "apparel",
+      price_range: "premium",
+      has_inventory_info: true,
+      does_stock: false,
+      does_weaving: true,
+      person_type: "manufacturer",
+      team_size: 12,
+      payment_collection: "through_us",
+      completed: true,
+    })
+    expect(res.success).toBe(true)
+  })
+
+  it("accepts an empty payload (partial save)", () => {
+    expect(onboardingProfileUpdateSchema.safeParse({}).success).toBe(true)
+  })
+
+  it("accepts nullable fields set to null", () => {
+    const res = onboardingProfileUpdateSchema.safeParse({
+      what_they_sell: null,
+      team_size: null,
+      payment_collection: null,
+    })
+    expect(res.success).toBe(true)
+  })
+
+  it("rejects an out-of-enum what_they_sell value", () => {
+    expect(
+      onboardingProfileUpdateSchema.safeParse({ what_they_sell: "spaceships" })
+        .success
+    ).toBe(false)
+  })
+
+  it("rejects an out-of-enum payment_collection value", () => {
+    expect(
+      onboardingProfileUpdateSchema.safeParse({ payment_collection: "crypto" })
+        .success
+    ).toBe(false)
+  })
+
+  it("rejects a non-integer team_size", () => {
+    expect(
+      onboardingProfileUpdateSchema.safeParse({ team_size: 3.5 }).success
+    ).toBe(false)
+  })
+
+  it("rejects a negative team_size", () => {
+    expect(
+      onboardingProfileUpdateSchema.safeParse({ team_size: -1 }).success
+    ).toBe(false)
+  })
+
+  it("rejects unknown fields (strict)", () => {
+    expect(
+      onboardingProfileUpdateSchema.safeParse({ not_real: "x" }).success
+    ).toBe(false)
+  })
+})

--- a/apps/backend/src/api/partners/onboarding-profile/route.ts
+++ b/apps/backend/src/api/partners/onboarding-profile/route.ts
@@ -1,0 +1,73 @@
+/**
+ * @file Partner onboarding-profile API (issue #648, slice 1)
+ * @description Read + upsert the post-registration onboarding questionnaire
+ *   profile for the authenticated partner.
+ * @module API/Partners/OnboardingProfile
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { getPartnerFromAuthContext } from "../helpers"
+import { PARTNER_ONBOARDING_PROFILE_MODULE } from "../../../modules/partner-onboarding-profile"
+import type { OnboardingProfileUpdateInput } from "./validators"
+
+/**
+ * GET /partners/onboarding-profile
+ * Returns the authenticated partner's onboarding profile, or null if the
+ * partner has not started the wizard yet.
+ */
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
+  if (!partner?.id) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "Partner authentication required"
+    )
+  }
+
+  const service: any = req.scope.resolve(PARTNER_ONBOARDING_PROFILE_MODULE)
+  const profile = await service.findByPartner(partner.id)
+
+  return res.status(200).json({ onboarding_profile: profile })
+}
+
+/**
+ * PUT /partners/onboarding-profile
+ * Upserts the authenticated partner's onboarding profile. Creates the row on
+ * first save, updates it thereafter. Only the supplied fields are written, so
+ * the wizard can persist progress step-by-step.
+ */
+export const PUT = async (
+  req: AuthenticatedMedusaRequest<OnboardingProfileUpdateInput>,
+  res: MedusaResponse
+) => {
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
+  if (!partner?.id) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "Partner authentication required"
+    )
+  }
+
+  const data = (req.validatedBody || {}) as OnboardingProfileUpdateInput
+
+  const service: any = req.scope.resolve(PARTNER_ONBOARDING_PROFILE_MODULE)
+  const existing = await service.findByPartner(partner.id)
+
+  let profile
+  if (existing) {
+    profile = await service.updatePartnerOnboardingProfiles({
+      id: existing.id,
+      ...data,
+    })
+  } else {
+    profile = await service.createPartnerOnboardingProfiles({
+      partner_id: partner.id,
+      ...data,
+    })
+  }
+
+  return res.status(200).json({ onboarding_profile: profile })
+}

--- a/apps/backend/src/api/partners/onboarding-profile/validators.ts
+++ b/apps/backend/src/api/partners/onboarding-profile/validators.ts
@@ -1,0 +1,45 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * Validator for PUT /partners/onboarding-profile (issue #648, slice 1).
+ *
+ * Every field is optional so the wizard can save partial progress per step.
+ * Enums are pinned to the model's allowed values — garbage is rejected.
+ */
+export const onboardingProfileUpdateSchema = z
+  .object({
+    what_they_sell: z
+      .enum(["apparel", "home_textiles", "fabric", "yarn", "accessories", "other"])
+      .nullable()
+      .optional(),
+    price_range: z
+      .enum(["economy", "mid", "premium", "luxury"])
+      .nullable()
+      .optional(),
+    has_inventory_info: z.boolean().nullable().optional(),
+    does_stock: z.boolean().nullable().optional(),
+    does_weaving: z.boolean().nullable().optional(),
+    person_type: z
+      .enum([
+        "individual",
+        "business",
+        "manufacturer",
+        "wholesaler",
+        "retailer",
+        "artisan",
+        "other",
+      ])
+      .nullable()
+      .optional(),
+    team_size: z.number().int().min(0).max(100000).nullable().optional(),
+    payment_collection: z
+      .enum(["through_us", "themselves"])
+      .nullable()
+      .optional(),
+    completed: z.boolean().optional(),
+  })
+  .strict()
+
+export type OnboardingProfileUpdateInput = z.infer<
+  typeof onboardingProfileUpdateSchema
+>

--- a/apps/backend/src/modules/partner-onboarding-profile/index.ts
+++ b/apps/backend/src/modules/partner-onboarding-profile/index.ts
@@ -1,0 +1,8 @@
+import { Module } from "@medusajs/framework/utils"
+import PartnerOnboardingProfileService from "./service"
+
+export const PARTNER_ONBOARDING_PROFILE_MODULE = "partner_onboarding_profile"
+
+export default Module(PARTNER_ONBOARDING_PROFILE_MODULE, {
+  service: PartnerOnboardingProfileService,
+})

--- a/apps/backend/src/modules/partner-onboarding-profile/migrations/Migration20260624170000.ts
+++ b/apps/backend/src/modules/partner-onboarding-profile/migrations/Migration20260624170000.ts
@@ -1,0 +1,23 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Creates the partner_onboarding_profile table (issue #648, slice 1).
+ *
+ * Hand-written (Claude-owned) create migration. Mirrors what DML would
+ * generate for the model: enum columns become `text check (...)`, the
+ * unique partner_id gets a partial unique index, plus the standard
+ * deleted_at index.
+ */
+export class Migration20260624170000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table if not exists "partner_onboarding_profile" ("id" text not null, "partner_id" text not null, "what_they_sell" text check ("what_they_sell" in ('apparel', 'home_textiles', 'fabric', 'yarn', 'accessories', 'other')) null, "price_range" text check ("price_range" in ('economy', 'mid', 'premium', 'luxury')) null, "has_inventory_info" boolean null, "does_stock" boolean null, "does_weaving" boolean null, "person_type" text check ("person_type" in ('individual', 'business', 'manufacturer', 'wholesaler', 'retailer', 'artisan', 'other')) null, "team_size" integer null, "payment_collection" text check ("payment_collection" in ('through_us', 'themselves')) null, "completed" boolean not null default false, "metadata" jsonb null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "partner_onboarding_profile_pkey" primary key ("id"));`);
+    this.addSql(`CREATE UNIQUE INDEX IF NOT EXISTS "IDX_partner_onboarding_profile_partner_id_unique" ON "partner_onboarding_profile" ("partner_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_partner_onboarding_profile_deleted_at" ON "partner_onboarding_profile" ("deleted_at") WHERE deleted_at IS NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "partner_onboarding_profile" cascade;`);
+  }
+
+}

--- a/apps/backend/src/modules/partner-onboarding-profile/models/partner-onboarding-profile.ts
+++ b/apps/backend/src/modules/partner-onboarding-profile/models/partner-onboarding-profile.ts
@@ -1,0 +1,61 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * Partner onboarding profile (issue #648, slice 1).
+ *
+ * Captures the post-registration onboarding questionnaire answers for a
+ * partner. One row per partner (`partner_id` is unique). Typed columns —
+ * NOT a metadata blob — because these answers are load-bearing for partner
+ * segmentation, fulfilment routing and the future KYC / payment-config
+ * slices (see feedback_no_critical_data_in_metadata).
+ */
+const PartnerOnboardingProfile = model.define("partner_onboarding_profile", {
+  id: model.id().primaryKey(),
+  // The partner this profile belongs to. Unique — one profile per partner.
+  partner_id: model.text().unique(),
+
+  // 1. What the partner sells (broad textile category).
+  what_they_sell: model
+    .enum(["apparel", "home_textiles", "fabric", "yarn", "accessories", "other"])
+    .nullable(),
+
+  // 2. Typical price band of their products.
+  price_range: model.enum(["economy", "mid", "premium", "luxury"]).nullable(),
+
+  // 3. Do they keep structured inventory information?
+  has_inventory_info: model.boolean().nullable(),
+
+  // 4. Do they hold / carry stock themselves?
+  does_stock: model.boolean().nullable(),
+
+  // 5. Do they do weaving in-house?
+  does_weaving: model.boolean().nullable(),
+
+  // 6. The kind of entity the partner is.
+  person_type: model
+    .enum([
+      "individual",
+      "business",
+      "manufacturer",
+      "wholesaler",
+      "retailer",
+      "artisan",
+      "other",
+    ])
+    .nullable(),
+
+  // 7. How many people work in the partner's team.
+  team_size: model.number().nullable(),
+
+  // 8. Who collects customer payments — JYT ("through_us") or the partner
+  //    themselves. This only RECORDS the choice; the actual payment wiring
+  //    lives in /partners/payment-config (out of scope for slice 1).
+  payment_collection: model.enum(["through_us", "themselves"]).nullable(),
+
+  // Set true once the partner submits the wizard.
+  completed: model.boolean().default(false),
+
+  metadata: model.json().nullable(),
+})
+
+export default PartnerOnboardingProfile

--- a/apps/backend/src/modules/partner-onboarding-profile/service.ts
+++ b/apps/backend/src/modules/partner-onboarding-profile/service.ts
@@ -1,0 +1,18 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import PartnerOnboardingProfile from "./models/partner-onboarding-profile"
+
+class PartnerOnboardingProfileService extends MedusaService({
+  PartnerOnboardingProfile,
+}) {
+  /**
+   * Fetch the onboarding profile for a partner, or null if none exists yet.
+   */
+  async findByPartner(partnerId: string) {
+    const profiles = await this.listPartnerOnboardingProfiles({
+      partner_id: partnerId,
+    })
+    return profiles?.[0] || null
+  }
+}
+
+export default PartnerOnboardingProfileService

--- a/apps/partner-ui/src/routes/home/home-onboarding/home-onboarding.tsx
+++ b/apps/partner-ui/src/routes/home/home-onboarding/home-onboarding.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import {
   Alert,
   Button,
@@ -6,6 +6,7 @@ import {
   Input,
   ProgressTabs,
   Select,
+  Switch,
   Text,
   Textarea,
   toast,
@@ -42,6 +43,63 @@ const personSchema = z.object({
   email: z.string().email("Invalid email address"),
 })
 
+// --- Onboarding profile (issue #648, slice 1) ---------------------------
+// Mirrors the partner_onboarding_profile model / validator on the backend.
+type PaymentCollection = "through_us" | "themselves"
+
+type OnboardingProfile = {
+  what_they_sell: string
+  price_range: string
+  person_type: string
+  has_inventory_info: boolean
+  does_stock: boolean
+  does_weaving: boolean
+  team_size: string // kept as string for the input; coerced to number on save
+  payment_collection: PaymentCollection | ""
+}
+
+const WHAT_THEY_SELL_OPTIONS = [
+  { value: "apparel", label: "Apparel / Garments" },
+  { value: "home_textiles", label: "Home textiles" },
+  { value: "fabric", label: "Fabric" },
+  { value: "yarn", label: "Yarn" },
+  { value: "accessories", label: "Accessories" },
+  { value: "other", label: "Other" },
+]
+
+const PRICE_RANGE_OPTIONS = [
+  { value: "economy", label: "Economy" },
+  { value: "mid", label: "Mid-range" },
+  { value: "premium", label: "Premium" },
+  { value: "luxury", label: "Luxury" },
+]
+
+const PERSON_TYPE_OPTIONS = [
+  { value: "individual", label: "Individual" },
+  { value: "business", label: "Business" },
+  { value: "manufacturer", label: "Manufacturer" },
+  { value: "wholesaler", label: "Wholesaler" },
+  { value: "retailer", label: "Retailer" },
+  { value: "artisan", label: "Artisan" },
+  { value: "other", label: "Other" },
+]
+
+const PAYMENT_COLLECTION_OPTIONS: { value: PaymentCollection; label: string }[] = [
+  { value: "through_us", label: "Through JYT (we collect on your behalf)" },
+  { value: "themselves", label: "Myself (I collect payments directly)" },
+]
+
+const emptyProfile: OnboardingProfile = {
+  what_they_sell: "",
+  price_range: "",
+  person_type: "",
+  has_inventory_info: false,
+  does_stock: false,
+  does_weaving: false,
+  team_size: "",
+  payment_collection: "",
+}
+
 const BUSINESS_TYPE_KEYS = [
   "manufacturer",
   "seller",
@@ -58,7 +116,7 @@ const mapBusinessTypeToWorkspaceType = (businessType: string): "seller" | "manuf
   return "manufacturer"
 }
 
-const STEPS = ["about", "logo", "people"] as const
+const STEPS = ["about", "business", "operations", "logo", "people"] as const
 type Step = (typeof STEPS)[number]
 
 const getOnboardingStorageKey = (partnerId: string) =>
@@ -76,6 +134,8 @@ function getStepStatus(
   if (stepIdx > currentIdx) return "not-started"
   if (step === "about") return aboutYou.business_name.trim() ? "completed" : "in-progress"
   if (step === "logo") return hasLogo ? "completed" : "in-progress"
+  // Any earlier step the user has moved past counts as completed.
+  if (stepIdx < currentIdx) return "completed"
   return "not-started"
 }
 
@@ -106,6 +166,8 @@ const OnboardingForm = () => {
 
   const STEP_LABELS: Record<Step, string> = {
     about: t("partner.onboardingModal.steps.about"),
+    business: "Business",
+    operations: "Operations",
     logo: t("partner.onboardingModal.steps.logo"),
     people: t("partner.onboardingModal.steps.people"),
   }
@@ -164,9 +226,46 @@ const OnboardingForm = () => {
     if (saved && saved.length > 0) return saved
     return [{ first_name: "", last_name: "", email: "" }]
   })
+  const [profile, setProfile] = useState<OnboardingProfile>(emptyProfile)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [success] = useState(false)
+
+  // Hydrate the onboarding profile from the server if the partner has
+  // started the wizard before (returning users / resumed onboarding).
+  useEffect(() => {
+    let cancelled = false
+    if (!partnerId) return
+    ;(async () => {
+      try {
+        const res = (await sdk.client.fetch(
+          "/partners/onboarding-profile"
+        )) as { onboarding_profile?: Record<string, any> | null }
+        const p = res?.onboarding_profile
+        if (!p || cancelled) return
+        setProfile((prev) => ({
+          ...prev,
+          what_they_sell: p.what_they_sell ?? prev.what_they_sell,
+          price_range: p.price_range ?? prev.price_range,
+          person_type: p.person_type ?? prev.person_type,
+          has_inventory_info: Boolean(p.has_inventory_info),
+          does_stock: Boolean(p.does_stock),
+          does_weaving: Boolean(p.does_weaving),
+          team_size:
+            p.team_size === null || p.team_size === undefined
+              ? prev.team_size
+              : String(p.team_size),
+          payment_collection: (p.payment_collection ??
+            prev.payment_collection) as PaymentCollection | "",
+        }))
+      } catch {
+        // non-blocking — first-time partners have no profile yet
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [partnerId])
 
   const handleLogoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
@@ -283,6 +382,33 @@ const OnboardingForm = () => {
         } catch {
           // non-blocking
         }
+      }
+
+      // Persist the onboarding profile (#648 slice 1). Only send fields the
+      // partner actually set; booleans always go through.
+      const profileBody: Record<string, any> = {
+        has_inventory_info: profile.has_inventory_info,
+        does_stock: profile.does_stock,
+        does_weaving: profile.does_weaving,
+        completed: true,
+      }
+      if (profile.what_they_sell) profileBody.what_they_sell = profile.what_they_sell
+      if (profile.price_range) profileBody.price_range = profile.price_range
+      if (profile.person_type) profileBody.person_type = profile.person_type
+      if (profile.payment_collection)
+        profileBody.payment_collection = profile.payment_collection
+      if (profile.team_size.trim() !== "") {
+        const n = Number.parseInt(profile.team_size, 10)
+        if (Number.isFinite(n)) profileBody.team_size = n
+      }
+
+      try {
+        await sdk.client.fetch("/partners/onboarding-profile", {
+          method: "PUT",
+          body: profileBody,
+        })
+      } catch {
+        // non-blocking — wizard state is also kept in localStorage below
       }
 
       const filledPeople = people.filter(
@@ -445,7 +571,201 @@ const OnboardingForm = () => {
             </div>
           </ProgressTabs.Content>
 
-          {/* Step 2: Logo */}
+          {/* Step 2: Business profile */}
+          <ProgressTabs.Content value="business" className="p-6">
+            <div className="mx-auto flex w-full max-w-[720px] flex-col gap-y-4 py-10">
+              <div>
+                <Heading>Your business</Heading>
+                <Text size="small" className="text-ui-fg-subtle mt-1">
+                  Tell us a bit about what you sell so we can tailor your workspace.
+                </Text>
+              </div>
+
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div>
+                  <Text size="small" className="mb-1 block font-medium">
+                    What do you sell?
+                  </Text>
+                  <Select
+                    value={profile.what_they_sell}
+                    onValueChange={(v) =>
+                      setProfile((prev) => ({ ...prev, what_they_sell: v }))
+                    }
+                  >
+                    <Select.Trigger>
+                      <Select.Value placeholder="Select a category" />
+                    </Select.Trigger>
+                    <Select.Content>
+                      {WHAT_THEY_SELL_OPTIONS.map((o) => (
+                        <Select.Item key={o.value} value={o.value}>
+                          {o.label}
+                        </Select.Item>
+                      ))}
+                    </Select.Content>
+                  </Select>
+                </div>
+
+                <div>
+                  <Text size="small" className="mb-1 block font-medium">
+                    Typical price range
+                  </Text>
+                  <Select
+                    value={profile.price_range}
+                    onValueChange={(v) =>
+                      setProfile((prev) => ({ ...prev, price_range: v }))
+                    }
+                  >
+                    <Select.Trigger>
+                      <Select.Value placeholder="Select a price band" />
+                    </Select.Trigger>
+                    <Select.Content>
+                      {PRICE_RANGE_OPTIONS.map((o) => (
+                        <Select.Item key={o.value} value={o.value}>
+                          {o.label}
+                        </Select.Item>
+                      ))}
+                    </Select.Content>
+                  </Select>
+                </div>
+
+                <div className="md:col-span-2">
+                  <Text size="small" className="mb-1 block font-medium">
+                    What kind of partner are you?
+                  </Text>
+                  <Select
+                    value={profile.person_type}
+                    onValueChange={(v) =>
+                      setProfile((prev) => ({ ...prev, person_type: v }))
+                    }
+                  >
+                    <Select.Trigger>
+                      <Select.Value placeholder="Select a type" />
+                    </Select.Trigger>
+                    <Select.Content>
+                      {PERSON_TYPE_OPTIONS.map((o) => (
+                        <Select.Item key={o.value} value={o.value}>
+                          {o.label}
+                        </Select.Item>
+                      ))}
+                    </Select.Content>
+                  </Select>
+                </div>
+              </div>
+            </div>
+          </ProgressTabs.Content>
+
+          {/* Step 3: Operations */}
+          <ProgressTabs.Content value="operations" className="p-6">
+            <div className="mx-auto flex w-full max-w-[720px] flex-col gap-y-4 py-10">
+              <div>
+                <Heading>How you operate</Heading>
+                <Text size="small" className="text-ui-fg-subtle mt-1">
+                  This helps us set up inventory, production and payments for you.
+                </Text>
+              </div>
+
+              <div className="flex flex-col gap-y-3">
+                <div className="flex items-center justify-between rounded-lg border px-4 py-3">
+                  <div>
+                    <Text size="small" weight="plus">
+                      Do you keep inventory information?
+                    </Text>
+                    <Text size="xsmall" className="text-ui-fg-subtle">
+                      You track stock counts, SKUs or product catalogues.
+                    </Text>
+                  </div>
+                  <Switch
+                    checked={profile.has_inventory_info}
+                    onCheckedChange={(c) =>
+                      setProfile((prev) => ({ ...prev, has_inventory_info: c }))
+                    }
+                  />
+                </div>
+
+                <div className="flex items-center justify-between rounded-lg border px-4 py-3">
+                  <div>
+                    <Text size="small" weight="plus">
+                      Do you hold stock?
+                    </Text>
+                    <Text size="xsmall" className="text-ui-fg-subtle">
+                      You carry physical stock yourself.
+                    </Text>
+                  </div>
+                  <Switch
+                    checked={profile.does_stock}
+                    onCheckedChange={(c) =>
+                      setProfile((prev) => ({ ...prev, does_stock: c }))
+                    }
+                  />
+                </div>
+
+                <div className="flex items-center justify-between rounded-lg border px-4 py-3">
+                  <div>
+                    <Text size="small" weight="plus">
+                      Do you do weaving?
+                    </Text>
+                    <Text size="xsmall" className="text-ui-fg-subtle">
+                      You produce woven textiles in-house.
+                    </Text>
+                  </div>
+                  <Switch
+                    checked={profile.does_weaving}
+                    onCheckedChange={(c) =>
+                      setProfile((prev) => ({ ...prev, does_weaving: c }))
+                    }
+                  />
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div>
+                  <Text size="small" className="mb-1 block font-medium">
+                    Team size{" "}
+                    <span className="text-ui-fg-muted font-normal">(optional)</span>
+                  </Text>
+                  <Input
+                    value={profile.team_size}
+                    onChange={(e) =>
+                      setProfile((prev) => ({
+                        ...prev,
+                        team_size: e.target.value.replace(/[^0-9]/g, ""),
+                      }))
+                    }
+                    placeholder="e.g. 8"
+                    inputMode="numeric"
+                  />
+                </div>
+
+                <div>
+                  <Text size="small" className="mb-1 block font-medium">
+                    How are payments collected?
+                  </Text>
+                  <Select
+                    value={profile.payment_collection}
+                    onValueChange={(v) =>
+                      setProfile((prev) => ({
+                        ...prev,
+                        payment_collection: v as PaymentCollection,
+                      }))
+                    }
+                  >
+                    <Select.Trigger>
+                      <Select.Value placeholder="Select an option" />
+                    </Select.Trigger>
+                    <Select.Content>
+                      {PAYMENT_COLLECTION_OPTIONS.map((o) => (
+                        <Select.Item key={o.value} value={o.value}>
+                          {o.label}
+                        </Select.Item>
+                      ))}
+                    </Select.Content>
+                  </Select>
+                </div>
+              </div>
+            </div>
+          </ProgressTabs.Content>
+
+          {/* Step 4: Logo */}
           <ProgressTabs.Content value="logo" className="p-6">
             <div className="mx-auto flex w-full max-w-[720px] flex-col gap-y-4 py-10">
               <div>
@@ -507,7 +827,7 @@ const OnboardingForm = () => {
             </div>
           </ProgressTabs.Content>
 
-          {/* Step 3: Team */}
+          {/* Step 5: Team */}
           <ProgressTabs.Content value="people" className="p-6">
             <div className="mx-auto flex w-full max-w-[720px] flex-col gap-y-4 py-10">
               <div>


### PR DESCRIPTION
## #648 slice 1 — partner onboarding questionnaire wizard (post-registration)

Builds on the **existing** partner-ui onboarding wizard (`routes/home/home-onboarding`) and the partner model — extends, doesn't rebuild. Captures a partner **onboarding profile** right after registration.

### Backend
- **New `partner_onboarding_profile` module** — a separate, extensible model (mirrors `partner-payment-config`), **one row per partner** (`partner_id` unique). **Typed columns, not a metadata blob** (per `feedback_no_critical_data_in_metadata`):
  - `what_they_sell` (enum: apparel / home_textiles / fabric / yarn / accessories / other)
  - `price_range` (enum: economy / mid / premium / luxury)
  - `has_inventory_info`, `does_stock`, `does_weaving` (bool)
  - `person_type` (enum: individual / business / manufacturer / wholesaler / retailer / artisan / other)
  - `team_size` (int, nullable)
  - `payment_collection` (enum: `through_us` | `themselves`) — **records the choice only**; payment wiring (`/partners/payment-config`) is out of scope.
  - `completed` (bool)
- **Hand-written create migration** (Claude-owned) `Migration20260624170000` — `text check (...)` enums + partial-unique `partner_id` index. Registered in **both** `medusa-config.ts` and `medusa-config.prod.ts`.
- **`GET` / `PUT` `/partners/onboarding-profile`** — read + upsert the authenticated partner's profile. Mirrors existing `/partners/*` patterns: `getPartnerFromAuthContext`, `wrapSchema` + `validateAndTransformBody`, strict zod schema. PUT is an upsert (creates on first save, updates after) so the wizard can persist partial progress.

### Frontend
- Extends the existing wizard with **two new steps**:
  - **Business** — what they sell / price range / partner type (dropdowns)
  - **Operations** — inventory / stock / weaving (toggles) + team size + payment collection
- Saves via the new API and marks the profile `completed` on submit; hydrates from the server for returning partners. (No KYC/Verify step — that's slice 2.)

### Verification
- ✅ **6 HTTP integration tests** (`partner-onboarding-profile-api.spec.ts`): GET null before start; PUT create → read-back per partner; upsert (no duplicate); invalid-enum → 400; unknown-field strict → 400; auth required. All pass on shared DB.
- ✅ **8 validator unit tests** (`validators.unit.spec.ts`).
- ✅ Backend + partner-ui typecheck: **zero new errors** (pre-existing errors in unrelated files only).
- ⏳ **Wizard UI is Playwright-gated** — not driven live this run (needs medusa + partner-ui dev + a registered partner). **Manual verify:** register a new partner on partner.jaalyantra.com → onboarding wizard opens → step through **Business** + **Operations** → Complete → confirm `GET /partners/onboarding-profile` returns the saved fields with `completed: true`.

### Scope guardrails
Slice 1 only — **no** KYC/Verify (slice 2), **no** payment wiring (choice captured only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)