### PR TITLE
feat(designs): show raw-material photo when linking inventory to a design (#728)

### DIFF
--- a/apps/backend/src/admin/components/designs/hooks/use-inventory-columns.tsx
+++ b/apps/backend/src/admin/components/designs/hooks/use-inventory-columns.tsx
@@ -1,6 +1,7 @@
 import { Text, createDataTableColumnHelper, Checkbox } from "@medusajs/ui";
 import { InventoryItem } from "../../../hooks/api/raw-materials";
 import { Thumbnail } from "../../../components/common/thumbnail";
+import { firstMediaUrl } from "../../../lib/utils/first-media-url";
 
 const columnHelper = createDataTableColumnHelper<InventoryItem>();
 
@@ -117,11 +118,15 @@ export const useInventoryColumns = (selectionProps?: SelectionProps) => {
       header: "Material Name",
       cell: ({ row }) => {
         const name = row.original.raw_materials?.name || "-";
-        
+        const photo = firstMediaUrl(row.original.raw_materials?.media);
+
         return (
-          <Text size="small" leading="compact">
-            {name}
-          </Text>
+          <div className="flex items-center gap-x-3">
+            <Thumbnail src={photo} alt={name} size="small" />
+            <Text size="small" leading="compact">
+              {name}
+            </Text>
+          </div>
         );
       },
       enableSorting: true,

--- a/apps/backend/src/admin/lib/utils/__tests__/first-media-url.unit.spec.ts
+++ b/apps/backend/src/admin/lib/utils/__tests__/first-media-url.unit.spec.ts
@@ -1,0 +1,45 @@
+import { firstMediaUrl } from "../first-media-url"
+
+describe("firstMediaUrl", () => {
+  it("returns undefined for empty / null / undefined", () => {
+    expect(firstMediaUrl(undefined)).toBeUndefined()
+    expect(firstMediaUrl(null)).toBeUndefined()
+    expect(firstMediaUrl({})).toBeUndefined()
+    expect(firstMediaUrl([])).toBeUndefined()
+    expect(firstMediaUrl({ files: [] })).toBeUndefined()
+  })
+
+  it("reads the canonical { files: string[] } shape", () => {
+    expect(firstMediaUrl({ files: ["https://cdn/a.jpg", "https://cdn/b.jpg"] })).toBe(
+      "https://cdn/a.jpg"
+    )
+  })
+
+  it("reads { files: [{ url }] } object entries", () => {
+    expect(firstMediaUrl({ files: [{ url: "https://cdn/c.jpg" }] })).toBe("https://cdn/c.jpg")
+  })
+
+  it("reads a raw array of url strings", () => {
+    expect(firstMediaUrl(["https://cdn/d.jpg"])).toBe("https://cdn/d.jpg")
+  })
+
+  it("reads a raw array of objects via url/file_path/thumbnail/src keys", () => {
+    expect(firstMediaUrl([{ file_path: "https://cdn/e.jpg" }])).toBe("https://cdn/e.jpg")
+    expect(firstMediaUrl([{ thumbnail: "https://cdn/f.jpg" }])).toBe("https://cdn/f.jpg")
+    expect(firstMediaUrl([{ src: "https://cdn/g.jpg" }])).toBe("https://cdn/g.jpg")
+  })
+
+  it("reads a single object", () => {
+    expect(firstMediaUrl({ url: "https://cdn/h.jpg" })).toBe("https://cdn/h.jpg")
+  })
+
+  it("skips empty/whitespace entries and trims", () => {
+    expect(firstMediaUrl({ files: ["", "   ", "https://cdn/i.jpg"] })).toBe("https://cdn/i.jpg")
+    expect(firstMediaUrl(["  https://cdn/j.jpg  "])).toBe("https://cdn/j.jpg")
+  })
+
+  it("returns undefined when entries carry no usable url", () => {
+    expect(firstMediaUrl({ files: [{ name: "no-url" }] })).toBeUndefined()
+    expect(firstMediaUrl([42, false, {}])).toBeUndefined()
+  })
+})

--- a/apps/backend/src/admin/lib/utils/first-media-url.ts
+++ b/apps/backend/src/admin/lib/utils/first-media-url.ts
@@ -1,0 +1,60 @@
+/**
+ * Extract the first usable image URL from a raw-material (or inventory) `media`
+ * JSON blob, which has been persisted in several shapes over time:
+ *
+ *  - `{ files: ["https://…", …] }`              (canonical — admin form + bulk-import route)
+ *  - `{ files: [{ url: "…" }, …] }`             (object entries)
+ *  - `["https://…", …]`                          (raw array of urls)
+ *  - `[{ url|file_path|thumbnail|src: "…" }, …]` (raw array of objects)
+ *  - `{ url|file_path|thumbnail|src: "…" }`       (single object)
+ *
+ * Returns the first non-empty string URL found, or `undefined` when there is no
+ * usable image (so callers can render a graceful placeholder).
+ */
+export function firstMediaUrl(media: unknown): string | undefined {
+  if (!media) {
+    return undefined
+  }
+
+  // Unwrap `{ files: [...] }`
+  let candidate: unknown = media
+  if (
+    typeof media === "object" &&
+    !Array.isArray(media) &&
+    Array.isArray((media as { files?: unknown }).files)
+  ) {
+    candidate = (media as { files: unknown[] }).files
+  }
+
+  if (Array.isArray(candidate)) {
+    for (const entry of candidate) {
+      const url = coerceUrl(entry)
+      if (url) {
+        return url
+      }
+    }
+    return undefined
+  }
+
+  return coerceUrl(candidate)
+}
+
+const URL_KEYS = ["url", "file_path", "thumbnail", "src"] as const
+
+function coerceUrl(entry: unknown): string | undefined {
+  if (typeof entry === "string") {
+    const trimmed = entry.trim()
+    return trimmed.length ? trimmed : undefined
+  }
+
+  if (entry && typeof entry === "object") {
+    for (const key of URL_KEYS) {
+      const value = (entry as Record<string, unknown>)[key]
+      if (typeof value === "string" && value.trim().length) {
+        return value.trim()
+      }
+    }
+  }
+
+  return undefined
+}

--- a/apps/backend/src/admin/routes/designs/[id]/@inventory/[inventoryId]/page.tsx
+++ b/apps/backend/src/admin/routes/designs/[id]/@inventory/[inventoryId]/page.tsx
@@ -13,6 +13,8 @@ import { RouteDrawer } from "../../../../../components/modal/route-drawer/route-
 import { useDesignInventory, useUpdateInventoryLink } from "../../../../../hooks/api/designs"
 import { useParams } from "react-router-dom"
 import { useStockLocations } from "../../../../../hooks/api/stock_location"
+import { Thumbnail } from "../../../../../components/common/thumbnail"
+import { firstMediaUrl } from "../../../../../lib/utils/first-media-url"
 
 
 const formatConsumedAt = (consumedAt?: string) => {
@@ -143,18 +145,25 @@ const InventoryLinkDrawerPage = () => {
   return (
     <RouteDrawer>
       <RouteDrawer.Header>
-        <div className="space-y-1">
-          <Heading>{inventory?.title || link.inventory_item_id}</Heading>
-          {inventory?.sku && (
-            <Text size="small" className="text-ui-fg-subtle">
-              {inventory.sku}
-            </Text>
-          )}
-          {link.inventory_item_id && (
-            <Text size="small" className="text-ui-fg-muted">
-              #{link.inventory_item_id}
-            </Text>
-          )}
+        <div className="flex items-center gap-x-3">
+          <Thumbnail
+            src={firstMediaUrl((inventory as any)?.raw_materials?.media)}
+            alt={inventory?.title || link.inventory_item_id}
+            size="large"
+          />
+          <div className="space-y-1">
+            <Heading>{inventory?.title || link.inventory_item_id}</Heading>
+            {inventory?.sku && (
+              <Text size="small" className="text-ui-fg-subtle">
+                {inventory.sku}
+              </Text>
+            )}
+            {link.inventory_item_id && (
+              <Text size="small" className="text-ui-fg-muted">
+                #{link.inventory_item_id}
+              </Text>
+            )}
+          </div>
         </div>
       </RouteDrawer.Header>
       <RouteDrawer.Body>


### PR DESCRIPTION
## What & why

Closes #728. When linking inventory to a design (admin → `designs/[id]/@addinv`, and the inventory link drawer), the inventory item's photo wasn't shown — only name/status/type. The table fetched `raw_materials.media` but rendered **no image**. Partners use our inventory and want to see the photo.

## Changes

- **New pure helper** `src/admin/lib/utils/first-media-url.ts` — `firstMediaUrl(media)` tolerant of every persisted `media` shape (canonical `{ files: string[] }`, `{ files: [{url}] }`, raw url arrays, object entries via `url`/`file_path`/`thumbnail`/`src`), with graceful `undefined` fallback. **8 unit tests.**
- **`design-inventory-table` columns** (`use-inventory-columns.tsx`): render the first material photo as a `Thumbnail` adornment on the **Material Name** cell, placeholder when absent.
- **Inventory link drawer** (`@inventory/[inventoryId]/page.tsx`): photo `Thumbnail` next to the title in the header (data already available via `inventory_item.raw_materials.media` from `list-design-inventory` workflow).
- Reuses the existing `Thumbnail` component (Medusa UI tokens, Cloudflare resize, `<Photo>` placeholder) — no hardcoded colors, no backend changes.

## Verification

- `firstMediaUrl` unit spec: **8/8 green**.
- Typecheck: zero new errors in changed files (69 pre-existing errors all in `integration-tests/`, unrelated).
- **Live Playwright** against `yarn dev` on :9000 — seeded one raw material with an image, opened a design → Add Inventory: photo renders for the item with media, placeholder for the one without. Screenshot captured.

PR-only — leaving for human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)