### PR TITLE
fix(partner-ui): unwrap { files: [...] } media shape for raw-material thumbnails

### DIFF
--- a/apps/partner-ui/src/hooks/api/partner-design-inventory.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-design-inventory.tsx
@@ -8,6 +8,7 @@ import {
 } from "@tanstack/react-query"
 
 import { sdk } from "../../lib/client"
+import { firstMediaUrl } from "../../lib/first-media-url"
 import { queryClient } from "../../lib/query-client"
 import { partnerDesignsQueryKeys } from "./partner-designs"
 
@@ -96,16 +97,6 @@ export type PartnerRawMaterialRow = {
   media_url?: string | null
 }
 
-const firstMediaUrl = (media: any): string | null => {
-  if (!media) return null
-  const arr = Array.isArray(media) ? media : [media]
-  for (const m of arr) {
-    if (typeof m === "string") return m
-    if (m && typeof m.url === "string") return m.url
-  }
-  return null
-}
-
 const normalizeRawMaterialRow = (row: any): PartnerRawMaterialRow => {
   const inv = row?.inventory_item || {}
   const rm = Array.isArray(row?.raw_materials)
@@ -119,7 +110,8 @@ const normalizeRawMaterialRow = (row: any): PartnerRawMaterialRow => {
     composition: rm?.composition ?? null,
     color: rm?.color ?? null,
     unit_of_measure: rm?.unit_of_measure ?? null,
-    media_url: firstMediaUrl(rm?.media) ?? firstMediaUrl(inv?.metadata?.media),
+    media_url:
+      firstMediaUrl(rm?.media) ?? firstMediaUrl(inv?.metadata?.media) ?? null,
   }
 }
 

--- a/apps/partner-ui/src/lib/__tests__/first-media-url.spec.ts
+++ b/apps/partner-ui/src/lib/__tests__/first-media-url.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest"
+
+import { firstMediaUrl, mediaUrls } from "../first-media-url"
+
+describe("firstMediaUrl", () => {
+  it("returns undefined for empty / null / undefined", () => {
+    expect(firstMediaUrl(undefined)).toBeUndefined()
+    expect(firstMediaUrl(null)).toBeUndefined()
+    expect(firstMediaUrl({})).toBeUndefined()
+    expect(firstMediaUrl([])).toBeUndefined()
+    expect(firstMediaUrl({ files: [] })).toBeUndefined()
+  })
+
+  it("reads the canonical { files: string[] } prod shape", () => {
+    expect(
+      firstMediaUrl({ files: ["https://cdn/a.jpg", "https://cdn/b.jpg"] })
+    ).toBe("https://cdn/a.jpg")
+  })
+
+  it("reads { files: [{ url }] } object entries", () => {
+    expect(firstMediaUrl({ files: [{ url: "https://cdn/c.jpg" }] })).toBe(
+      "https://cdn/c.jpg"
+    )
+  })
+
+  it("reads a raw array of url strings", () => {
+    expect(firstMediaUrl(["https://cdn/d.jpg"])).toBe("https://cdn/d.jpg")
+  })
+
+  it("reads a raw array of objects via url/file_path/thumbnail/src keys", () => {
+    expect(firstMediaUrl([{ file_path: "https://cdn/e.jpg" }])).toBe(
+      "https://cdn/e.jpg"
+    )
+    expect(firstMediaUrl([{ thumbnail: "https://cdn/f.jpg" }])).toBe(
+      "https://cdn/f.jpg"
+    )
+    expect(firstMediaUrl([{ src: "https://cdn/g.jpg" }])).toBe("https://cdn/g.jpg")
+  })
+
+  it("reads a single { url } object", () => {
+    expect(firstMediaUrl({ url: "https://cdn/h.jpg" })).toBe("https://cdn/h.jpg")
+  })
+
+  it("skips empty/whitespace entries and trims", () => {
+    expect(firstMediaUrl({ files: ["", "   ", "https://cdn/i.jpg"] })).toBe(
+      "https://cdn/i.jpg"
+    )
+    expect(firstMediaUrl(["  https://cdn/j.jpg  "])).toBe("https://cdn/j.jpg")
+  })
+
+  it("returns undefined when entries carry no usable url", () => {
+    expect(firstMediaUrl({ files: [{ name: "no-url" }] })).toBeUndefined()
+    expect(firstMediaUrl([42, false, {}])).toBeUndefined()
+  })
+})
+
+describe("mediaUrls", () => {
+  it("returns [] for empty / null", () => {
+    expect(mediaUrls(null)).toEqual([])
+    expect(mediaUrls({ files: [] })).toEqual([])
+  })
+
+  it("returns all urls from { files: [...] }", () => {
+    expect(mediaUrls({ files: ["https://cdn/a.jpg", "https://cdn/b.jpg"] })).toEqual(
+      ["https://cdn/a.jpg", "https://cdn/b.jpg"]
+    )
+  })
+
+  it("returns all urls from a raw array of mixed shapes", () => {
+    expect(
+      mediaUrls(["https://cdn/a.jpg", { url: "https://cdn/b.jpg" }, { name: "x" }])
+    ).toEqual(["https://cdn/a.jpg", "https://cdn/b.jpg"])
+  })
+
+  it("wraps a single object/string into a one-element array", () => {
+    expect(mediaUrls({ url: "https://cdn/h.jpg" })).toEqual(["https://cdn/h.jpg"])
+    expect(mediaUrls("https://cdn/s.jpg")).toEqual(["https://cdn/s.jpg"])
+  })
+})

--- a/apps/partner-ui/src/lib/first-media-url.ts
+++ b/apps/partner-ui/src/lib/first-media-url.ts
@@ -1,0 +1,82 @@
+/**
+ * Extract image URL(s) from a raw-material (or inventory) `media` JSON blob,
+ * which has been persisted in several shapes over time:
+ *
+ *  - `{ files: ["https://…", …] }`              (canonical — admin form + bulk-import route)
+ *  - `{ files: [{ url: "…" }, …] }`             (object entries)
+ *  - `["https://…", …]`                          (raw array of urls)
+ *  - `[{ url|file_path|thumbnail|src: "…" }, …]` (raw array of objects)
+ *  - `{ url|file_path|thumbnail|src: "…" }`       (single object)
+ *
+ * Mirrors the admin helper (apps/backend/src/admin/lib/utils/first-media-url.ts)
+ * so the partner UI doesn't drift. The partner side previously only handled raw
+ * strings + `{ url }` objects, so the canonical `{ files: [...] }` prod shape
+ * returned null → blank thumbnails in the design→inventory linking flow.
+ */
+
+const URL_KEYS = ["url", "file_path", "thumbnail", "src"] as const
+
+function coerceUrl(entry: unknown): string | undefined {
+  if (typeof entry === "string") {
+    const trimmed = entry.trim()
+    return trimmed.length ? trimmed : undefined
+  }
+
+  if (entry && typeof entry === "object") {
+    for (const key of URL_KEYS) {
+      const value = (entry as Record<string, unknown>)[key]
+      if (typeof value === "string" && value.trim().length) {
+        return value.trim()
+      }
+    }
+  }
+
+  return undefined
+}
+
+/** Unwrap `{ files: [...] }` to the inner array; otherwise return as-is. */
+function unwrapFiles(media: unknown): unknown {
+  if (
+    media &&
+    typeof media === "object" &&
+    !Array.isArray(media) &&
+    Array.isArray((media as { files?: unknown }).files)
+  ) {
+    return (media as { files: unknown[] }).files
+  }
+  return media
+}
+
+/**
+ * Return every usable image URL from a single `media` blob, in order.
+ * Empty/whitespace entries are skipped; returns `[]` when none.
+ */
+export function mediaUrls(media: unknown): string[] {
+  if (!media) {
+    return []
+  }
+
+  const candidate = unwrapFiles(media)
+
+  if (Array.isArray(candidate)) {
+    const urls: string[] = []
+    for (const entry of candidate) {
+      const url = coerceUrl(entry)
+      if (url) {
+        urls.push(url)
+      }
+    }
+    return urls
+  }
+
+  const single = coerceUrl(candidate)
+  return single ? [single] : []
+}
+
+/**
+ * Return the first usable image URL from a `media` blob, or `undefined` when
+ * there is no usable image (so callers can render a graceful placeholder).
+ */
+export function firstMediaUrl(media: unknown): string | undefined {
+  return mediaUrls(media)[0]
+}

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-inventory-bom-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-inventory-bom-section.tsx
@@ -11,6 +11,7 @@ import {
 import { Link } from "react-router-dom"
 
 import { Skeleton } from "../../../../components/common/skeleton"
+import { mediaUrls } from "../../../../lib/first-media-url"
 
 import { ActionMenu } from "../../../../components/common/action-menu"
 import { PartnerDesign } from "../../../../hooks/api/partner-designs"
@@ -32,23 +33,20 @@ function toArray<T = any>(val: any): T[] {
   return Array.isArray(val) ? val : [val]
 }
 
-/** Pull image URLs out of a raw_material.media / inventory media json blob. */
+/**
+ * Pull image URLs out of a raw_material.media / inventory media json blob.
+ * Delegates to the shared `mediaUrls` helper so every supported shape
+ * (`{ files: [...] }`, raw arrays, single object/string) is unwrapped — the
+ * canonical prod shape `{ files: ["…"] }` previously returned nothing here.
+ */
 function extractMedia(line: PartnerDesignInventoryItem): string[] {
   const urls: string[] = []
-  const push = (m: any) => {
-    if (!m) return
-    if (typeof m === "string") urls.push(m)
-    else if (typeof m?.url === "string") urls.push(m.url)
-  }
   for (const rm of toArray(line.inventory_item?.raw_materials)) {
-    const media = (rm as any)?.media
-    if (Array.isArray(media)) media.forEach(push)
-    else push(media)
+    urls.push(...mediaUrls((rm as any)?.media))
   }
   // Fall back to the inventory item's own media if the raw material has none.
   if (!urls.length) {
-    const im = (line.inventory_item as any)?.metadata?.media
-    if (Array.isArray(im)) im.forEach(push)
+    urls.push(...mediaUrls((line.inventory_item as any)?.metadata?.media))
   }
   return urls.slice(0, 4)
 }


### PR DESCRIPTION
## Problem
On prod, `raw_materials.media` is shaped `{ "files": ["https://…/WhatsApp Image ….jpeg"] }`. The **partner-ui** media-url extraction only handled raw strings + `{ url }` objects and did **not** unwrap `.files`, so it returned null → blank thumbnail in the **design → Add Inventory** linking flow (and the BOM list). The admin helper `first-media-url.ts` (#731) already handles this; the partner side had drifted.

## Root cause (confirmed)
- `firstMediaUrl` in `apps/partner-ui/src/hooks/api/partner-design-inventory.tsx` (old lines ~99-107) only checked `typeof m === "string"` / `m.url`. → `media_url` null → no thumbnail in the linking picker (`add-inventory-form.tsx` `<Thumbnail src={r.media_url}>`).
- `extractMedia` in `design-detail/components/design-inventory-bom-section.tsx` had the **same `{files}` gap** in its own inline logic (BOM list thumbnails).

## Fix
- **New shared util** `apps/partner-ui/src/lib/first-media-url.ts` mirroring the admin helper — `firstMediaUrl` + `mediaUrls` (multi) unwrap `{ files: [...] }`, raw string/object arrays, and single string/object via `url|file_path|thumbnail|src`.
- Wire the hook's `normalizeRawMaterialRow` (linking-picker thumbnail) **and** the BOM `extractMedia` to the shared util; deleted their inline string/`{url}`-only logic so they can't drift again (preferred shared-util approach).
- Admin helper untouched (already correct, #731).

## Audit results
- **Linking picker** (`add-inventory-form.tsx`) consumes the hook's `media_url` and already renders `<Thumbnail src={r.media_url}>` per row → fixing the hook lights it up. No render change needed.
- **Backend** route `/partners/inventory-items/raw-materials` already fetches `raw_materials.*` (incl. `media`) → no backend change.

## Verify
- ✅ 12 vitest unit tests (`src/lib/__tests__/first-media-url.spec.ts`) cover `{files:["url"]}`, `{files:[{url}]}`, `["url"]`, `{url}`, null, whitespace-trim, and the multi `mediaUrls` variant — all pass.
- ✅ `tsc --noEmit` — zero new errors in changed files (4 pre-existing errors in unrelated `order-create-claim`/`order-create-exchange` files).
- ⏳ **Playwright-gated / manual:** partner-ui needs prod-shaped `{files:[...]}` media in the raw-material catalog to exercise visually (a fresh local catalog has no such rows). Manual: open a design → **Add Inventory** → rows show the material photo; thumbnails also appear in the BOM (Materials) list.

Relates to #728, #731, #730. PR-only — leaving for human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)