### PR TITLE
fix(designs): re-apply 6 design-brief columns missing on prod (unblocks /components + /used-in 500s)

### DIFF
--- a/apps/backend/src/modules/designs/migrations/Migration20260624180000.ts
+++ b/apps/backend/src/modules/designs/migrations/Migration20260624180000.ts
@@ -1,0 +1,68 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Roadmap #604 (Design Brief / Collection Concept) — Slice A RE-APPLY.
+ *
+ * Migration20260622120000 added 6 design-brief columns to the `design` table,
+ * but on prod NONE of them landed: the migration was recorded-but-not-executed
+ * on first deploy (the same failure mode as #722). Because it is already
+ * recorded in mikro_orm_migrations it will never re-run, so prod is left
+ * missing every brief column. The design service selects ALL design columns
+ * (incl. concept_theme) when loading related Design entities, so
+ * `/admin/designs/:id/components` and `/admin/designs/:id/used-in` 500 with
+ * `column c1.concept_theme does not exist` / `p1.concept_theme does not exist`.
+ *
+ * This migration re-issues the EXACT same idempotent ALTER statements as
+ * Migration20260622120000.up() under a fresh (un-recorded) class name so it
+ * actually executes on the next deploy. `add column if not exists` makes it a
+ * safe no-op anywhere the columns already exist (e.g. local/dev DBs where the
+ * original migration did run) and adds the missing ones on prod.
+ *
+ * After merge + deploy this unblocks /admin/designs/:id/components and
+ * /admin/designs/:id/used-in on prod.
+ */
+export class Migration20260624180000 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(
+      `alter table if exists "design" add column if not exists "concept_theme" text null;`
+    );
+    this.addSql(
+      `alter table if exists "design" add column if not exists "persona" jsonb null;`
+    );
+    this.addSql(
+      `alter table if exists "design" add column if not exists "competitors" jsonb null;`
+    );
+    this.addSql(
+      `alter table if exists "design" add column if not exists "price_point" text null;`
+    );
+    this.addSql(
+      `alter table if exists "design" add column if not exists "design_budget" numeric null;`
+    );
+    // bigNumber columns carry a companion raw_* jsonb column holding the
+    // full-precision value (mirrors raw_estimated_cost / raw_material_cost).
+    this.addSql(
+      `alter table if exists "design" add column if not exists "raw_design_budget" jsonb null;`
+    );
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(
+      `alter table if exists "design" drop column if exists "concept_theme";`
+    );
+    this.addSql(
+      `alter table if exists "design" drop column if exists "persona";`
+    );
+    this.addSql(
+      `alter table if exists "design" drop column if exists "competitors";`
+    );
+    this.addSql(
+      `alter table if exists "design" drop column if exists "price_point";`
+    );
+    this.addSql(
+      `alter table if exists "design" drop column if exists "design_budget";`
+    );
+    this.addSql(
+      `alter table if exists "design" drop column if exists "raw_design_budget";`
+    );
+  }
+}


### PR DESCRIPTION
## Why (URGENT — live prod 500s)

`/admin/designs/:id/components` and `/admin/designs/:id/used-in` are **500ing on prod** (verified 2026-06-24):

```
column c1.concept_theme does not exist
column p1.concept_theme does not exist
```

Those routes (`src/api/admin/designs/[id]/components/route.ts`, `.../used-in/route.ts`) load related `Design` entities (`component_design` / `parent_design`), which selects **all** design columns — including the 6 design-brief columns added by `Migration20260622120000` (#604 slice A).

**Root cause:** `Migration20260622120000` is recorded in `mikro_orm_migrations` on prod but its DDL never executed (recorded-but-not-executed on first deploy). Because it's already recorded, MikroORM will never re-run it — so the columns stay missing forever.

## Fix

A **new** idempotent migration `Migration20260624180000` (fresh, un-recorded class name — does not edit the original) that re-issues the **exact** same statements as `Migration20260622120000.up()`:

```sql
alter table if exists "design" add column if not exists "concept_theme" text null;
alter table if exists "design" add column if not exists "persona" jsonb null;
alter table if exists "design" add column if not exists "competitors" jsonb null;
alter table if exists "design" add column if not exists "price_point" text null;
alter table if exists "design" add column if not exists "design_budget" numeric null;
alter table if exists "design" add column if not exists "raw_design_budget" jsonb null;
```

`add column if not exists` → safe no-op on DBs where the original did apply (local/dev), adds the missing columns on prod. `down()` mirrors the original (drop if exists).

Class name uniqueness confirmed by grep (`20260624170000` was taken by partner-onboarding-profile → used `…180000`). Same column types/nullability as the original.

## Verify
- `tsc --noEmit` clean (no new errors).
- After merge + deploy: `/admin/designs/:id/components` and `/admin/designs/:id/used-in` stop 500ing on prod.

## ⚠️ Systemic flag
This is the **2nd migration this week** that was recorded-but-not-executed on prod first deploy (after **#722**). Two occurrences suggests a systemic prod-migration issue (boot ordering / partial-apply / transaction) worth a **separate investigation** — these re-apply patches treat the symptom, not the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)