### PR TITLE
feat(#730): manual photo→raw-material binding tool in media gallery

### DIFF
--- a/apps/backend/integration-tests/http/media-bind-raw-material.spec.ts
+++ b/apps/backend/integration-tests/http/media-bind-raw-material.spec.ts
@@ -1,0 +1,212 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { MEDIA_MODULE } from "../../src/modules/media"
+import { RAW_MATERIAL_MODULE } from "../../src/modules/raw_material"
+
+jest.setTimeout(60000)
+
+const makeMediaFile = async (mediaService: any, suffix: string) => {
+  const file = await mediaService.createMediaFiles({
+    file_name: `photo-${suffix}.jpg`,
+    original_name: `photo-${suffix}.jpg`,
+    file_path: `https://cdn.example.com/uploads/photo-${suffix}.jpg`,
+    file_size: 1234,
+    file_type: "image",
+    mime_type: "image/jpeg",
+    extension: "jpg",
+  })
+  return Array.isArray(file) ? file[0] : file
+}
+
+setupSharedTestSuite(() => {
+  let headers: any
+  let inventoryItemId: string
+  let rawMaterialId: string
+  const { api, getContainer } = getSharedTestEnv()
+
+  beforeEach(async () => {
+    const container = getContainer()
+    await createAdminUser(container)
+    headers = await getAuthHeaders(api)
+
+    const inventoryResponse = await api.post(
+      "/admin/inventory-items",
+      { title: "Bind Test Inventory Item" },
+      headers
+    )
+    inventoryItemId = inventoryResponse.data.inventory_item.id
+
+    const rmResponse = await api.post(
+      `/admin/inventory-items/${inventoryItemId}/rawmaterials`,
+      {
+        rawMaterialData: {
+          name: "Bind Test Fabric",
+          description: "Bind test fabric",
+          composition: "100% Cotton",
+          unit_of_measure: "Meter",
+          material_type: "Cotton",
+          status: "Active",
+        },
+      },
+      headers
+    )
+    rawMaterialId = rmResponse.data.raw_materials.id
+  })
+
+  describe("POST /admin/medias/file/:id/raw-material (bind)", () => {
+    it("binds the photo into raw_materials.media (canonical { files }) and is idempotent", async () => {
+      const container = getContainer()
+      const mediaService: any = container.resolve(MEDIA_MODULE)
+      const rawService: any = container.resolve(RAW_MATERIAL_MODULE)
+      const media = await makeMediaFile(mediaService, "bind")
+
+      const res = await api.post(
+        `/admin/medias/file/${media.id}/raw-material`,
+        { raw_material_id: rawMaterialId },
+        headers
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.data.bound).toBe(true)
+      expect(res.data.media_url).toBe(media.file_path)
+      expect(res.data.raw_material.media).toEqual({
+        files: [media.file_path],
+      })
+
+      // persisted on the raw material
+      const raw = await rawService.retrieveRawMaterial(rawMaterialId)
+      expect(raw.media).toEqual({ files: [media.file_path] })
+
+      // back-reference stamped on the media file
+      const refreshed = await mediaService.retrieveMediaFile(media.id)
+      expect(refreshed.metadata?.bound_raw_material_id).toBe(rawMaterialId)
+
+      // idempotent — binding the same url again does not duplicate
+      const again = await api.post(
+        `/admin/medias/file/${media.id}/raw-material`,
+        { raw_material_id: rawMaterialId },
+        headers
+      )
+      expect(again.status).toBe(200)
+      expect(again.data.raw_material.media).toEqual({
+        files: [media.file_path],
+      })
+    })
+
+    it("sets the SKU on the linked inventory item when provided", async () => {
+      const container = getContainer()
+      const mediaService: any = container.resolve(MEDIA_MODULE)
+      const inventoryService: any = container.resolve("inventory")
+      const media = await makeMediaFile(mediaService, "sku")
+
+      const res = await api.post(
+        `/admin/medias/file/${media.id}/raw-material`,
+        {
+          raw_material_id: rawMaterialId,
+          sku: "RM-SKU-12345",
+          inventory_item_id: inventoryItemId,
+        },
+        headers
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.data.sku).toBe("RM-SKU-12345")
+
+      const inv = await inventoryService.retrieveInventoryItem(inventoryItemId)
+      expect(inv.sku).toBe("RM-SKU-12345")
+    })
+
+    it("creates a new raw material inline and binds the photo", async () => {
+      const container = getContainer()
+      const mediaService: any = container.resolve(MEDIA_MODULE)
+      const rawService: any = container.resolve(RAW_MATERIAL_MODULE)
+      const media = await makeMediaFile(mediaService, "create")
+
+      const res = await api.post(
+        `/admin/medias/file/${media.id}/raw-material`,
+        { create: { name: "Unrecorded Scrap Piece", sku: "RM-NEW-001" } },
+        headers
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.data.bound).toBe(true)
+      const newId = res.data.raw_material_id
+      expect(newId).toBeTruthy()
+      expect(newId).not.toBe(rawMaterialId)
+
+      const raw = await rawService.retrieveRawMaterial(newId)
+      expect(raw.name).toBe("Unrecorded Scrap Piece")
+      expect(raw.media).toEqual({ files: [media.file_path] })
+    })
+
+    it("returns 400 when neither raw_material_id nor create is provided", async () => {
+      const container = getContainer()
+      const mediaService: any = container.resolve(MEDIA_MODULE)
+      const media = await makeMediaFile(mediaService, "bad")
+
+      await expect(
+        api.post(`/admin/medias/file/${media.id}/raw-material`, {}, headers)
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
+  })
+
+  describe("GET /admin/medias/file/:id/raw-material", () => {
+    it("reflects the current binding", async () => {
+      const container = getContainer()
+      const mediaService: any = container.resolve(MEDIA_MODULE)
+      const media = await makeMediaFile(mediaService, "get")
+
+      const before = await api.get(
+        `/admin/medias/file/${media.id}/raw-material`,
+        headers
+      )
+      expect(before.data.binding).toBeNull()
+
+      await api.post(
+        `/admin/medias/file/${media.id}/raw-material`,
+        { raw_material_id: rawMaterialId },
+        headers
+      )
+
+      const after = await api.get(
+        `/admin/medias/file/${media.id}/raw-material`,
+        headers
+      )
+      expect(after.data.binding).toMatchObject({
+        raw_material_id: rawMaterialId,
+      })
+    })
+  })
+
+  describe("DELETE /admin/medias/file/:id/raw-material (unbind)", () => {
+    it("removes the photo from raw_materials.media and clears the back-reference", async () => {
+      const container = getContainer()
+      const mediaService: any = container.resolve(MEDIA_MODULE)
+      const rawService: any = container.resolve(RAW_MATERIAL_MODULE)
+      const media = await makeMediaFile(mediaService, "unbind")
+
+      await api.post(
+        `/admin/medias/file/${media.id}/raw-material`,
+        { raw_material_id: rawMaterialId },
+        headers
+      )
+
+      const res = await api.delete(
+        `/admin/medias/file/${media.id}/raw-material`,
+        { ...headers, data: { raw_material_id: rawMaterialId } }
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.unbound).toBe(true)
+
+      const raw = await rawService.retrieveRawMaterial(rawMaterialId)
+      expect(raw.media).toEqual({ files: [] })
+
+      // binding is cleared per the GET contract
+      const after = await api.get(
+        `/admin/medias/file/${media.id}/raw-material`,
+        headers
+      )
+      expect(after.data.binding).toBeNull()
+    })
+  })
+})

--- a/apps/backend/src/admin/components/media/bind-raw-material-section.tsx
+++ b/apps/backend/src/admin/components/media/bind-raw-material-section.tsx
@@ -1,0 +1,255 @@
+import { useMemo, useState } from "react"
+import {
+  Badge,
+  Button,
+  Heading,
+  Input,
+  Label,
+  Text,
+  clx,
+  toast,
+} from "@medusajs/ui"
+import { Tag, Plus, XMark, MagnifyingGlass } from "@medusajs/icons"
+import { useInventoryWithRawMaterials } from "../../hooks/api/raw-materials"
+import {
+  useMediaRawMaterialBinding,
+  useBindMediaRawMaterial,
+  useUnbindMediaRawMaterial,
+} from "../../hooks/api/media-raw-material-binding"
+
+export type BindRawMaterialSectionProps = {
+  mediaId: string
+  mediaUrl?: string
+  mediaName?: string
+}
+
+/**
+ * Manual photo → raw-material binding tool (#730). Shown in the media gallery
+ * for an individual photo. Human-toggled, no AI.
+ */
+export const BindRawMaterialSection = ({
+  mediaId,
+  mediaName,
+}: BindRawMaterialSectionProps) => {
+  const [search, setSearch] = useState("")
+  const [creating, setCreating] = useState(false)
+  const [newName, setNewName] = useState("")
+  const [newSku, setNewSku] = useState("")
+
+  const { data: bindingData, isLoading: bindingLoading } =
+    useMediaRawMaterialBinding(mediaId)
+  const binding = bindingData?.binding ?? null
+
+  const { inventory_items, isFetching } = useInventoryWithRawMaterials(
+    { q: search || undefined, limit: 20 },
+    { enabled: !binding }
+  )
+
+  const bind = useBindMediaRawMaterial(mediaId)
+  const unbind = useUnbindMediaRawMaterial(mediaId)
+
+  const results = useMemo(
+    () => (inventory_items || []).filter((it) => it.raw_materials?.id),
+    [inventory_items]
+  )
+
+  const handleBindExisting = (
+    rawMaterialId: string,
+    inventoryItemId: string,
+    name?: string
+  ) => {
+    bind.mutate(
+      { raw_material_id: rawMaterialId, inventory_item_id: inventoryItemId },
+      {
+        onSuccess: () => toast.success(`Bound to “${name ?? "raw material"}”`),
+        onError: (e: any) =>
+          toast.error(e?.message || "Failed to bind raw material"),
+      }
+    )
+  }
+
+  const handleCreate = () => {
+    if (!newName.trim()) {
+      toast.error("Name is required")
+      return
+    }
+    bind.mutate(
+      { create: { name: newName.trim(), sku: newSku.trim() || undefined } },
+      {
+        onSuccess: () => {
+          toast.success(`Created & bound “${newName.trim()}”`)
+          setCreating(false)
+          setNewName("")
+          setNewSku("")
+        },
+        onError: (e: any) =>
+          toast.error(e?.message || "Failed to create raw material"),
+      }
+    )
+  }
+
+  const handleUnbind = () => {
+    if (!binding) return
+    unbind.mutate(
+      { raw_material_id: binding.raw_material_id },
+      {
+        onSuccess: () => toast.success("Unbound"),
+        onError: (e: any) => toast.error(e?.message || "Failed to unbind"),
+      }
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-y-4 p-4">
+      <div className="flex items-center gap-x-2">
+        <Tag className="text-ui-fg-subtle" />
+        <Heading level="h3">Raw material</Heading>
+      </div>
+      <Text size="small" className="text-ui-fg-subtle">
+        Bind {mediaName ? `“${mediaName}”` : "this photo"} to a raw material so it
+        shows wherever that material appears.
+      </Text>
+
+      {bindingLoading ? (
+        <div className="bg-ui-bg-component h-16 w-full animate-pulse rounded-lg" />
+      ) : binding ? (
+        <div className="border-ui-border-base flex flex-col gap-y-3 rounded-lg border p-3">
+          <div className="flex items-center justify-between gap-x-2">
+            <div className="flex flex-col">
+              <Text size="small" weight="plus">
+                {binding.raw_material_name || "Raw material"}
+              </Text>
+              {binding.sku ? (
+                <Badge size="2xsmall" className="mt-1 w-fit">
+                  {binding.sku}
+                </Badge>
+              ) : (
+                <Text size="xsmall" className="text-ui-fg-muted">
+                  No SKU
+                </Text>
+              )}
+            </div>
+            <Button
+              variant="secondary"
+              size="small"
+              onClick={handleUnbind}
+              isLoading={unbind.isPending}
+            >
+              <XMark />
+              Unbind
+            </Button>
+          </div>
+        </div>
+      ) : creating ? (
+        <div className="border-ui-border-base flex flex-col gap-y-3 rounded-lg border p-3">
+          <div className="flex flex-col gap-y-1">
+            <Label size="xsmall" weight="plus">
+              Name
+            </Label>
+            <Input
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="e.g. Leftover navy poplin"
+              autoFocus
+            />
+          </div>
+          <div className="flex flex-col gap-y-1">
+            <Label size="xsmall" weight="plus">
+              SKU (optional)
+            </Label>
+            <Input
+              value={newSku}
+              onChange={(e) => setNewSku(e.target.value)}
+              placeholder="auto-generated if blank"
+            />
+          </div>
+          <div className="flex items-center justify-end gap-x-2">
+            <Button
+              variant="secondary"
+              size="small"
+              onClick={() => setCreating(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              size="small"
+              onClick={handleCreate}
+              isLoading={bind.isPending}
+            >
+              Create & bind
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-y-3">
+          <div className="relative">
+            <MagnifyingGlass className="text-ui-fg-muted absolute left-2 top-1/2 -translate-y-1/2" />
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search raw materials by name or SKU"
+              className="pl-8"
+            />
+          </div>
+
+          <div className="flex max-h-72 flex-col gap-y-1 overflow-y-auto">
+            {isFetching && !results.length ? (
+              <div className="bg-ui-bg-component h-10 w-full animate-pulse rounded-lg" />
+            ) : results.length ? (
+              results.map((it) => {
+                const rm = it.raw_materials!
+                return (
+                  <button
+                    key={rm.id}
+                    type="button"
+                    onClick={() =>
+                      handleBindExisting(rm.id, it.id, rm.name)
+                    }
+                    disabled={bind.isPending}
+                    className={clx(
+                      "hover:bg-ui-bg-base-hover flex items-center justify-between gap-x-2 rounded-lg px-3 py-2 text-left transition-colors",
+                      "border-ui-border-base border"
+                    )}
+                  >
+                    <span className="flex flex-col">
+                      <Text size="small" weight="plus" leading="compact">
+                        {rm.name}
+                      </Text>
+                      <Text
+                        size="xsmall"
+                        leading="compact"
+                        className="text-ui-fg-muted"
+                      >
+                        {rm.composition || "—"}
+                      </Text>
+                    </span>
+                    {it.sku ? (
+                      <Badge size="2xsmall">{it.sku}</Badge>
+                    ) : null}
+                  </button>
+                )
+              })
+            ) : (
+              <Text size="small" className="text-ui-fg-muted px-1 py-2">
+                No raw materials found.
+              </Text>
+            )}
+          </div>
+
+          <Button
+            variant="transparent"
+            size="small"
+            className="w-fit"
+            onClick={() => setCreating(true)}
+          >
+            <Plus />
+            Create new raw material
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default BindRawMaterialSection

--- a/apps/backend/src/admin/hooks/api/media-raw-material-binding.ts
+++ b/apps/backend/src/admin/hooks/api/media-raw-material-binding.ts
@@ -1,0 +1,124 @@
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  UseMutationOptions,
+  UseQueryOptions,
+} from "@tanstack/react-query"
+import { FetchError } from "@medusajs/js-sdk"
+import { sdk } from "../../lib/config"
+
+/**
+ * Hooks for the manual photo → raw-material binding tool (#730).
+ * Talks to /admin/medias/file/:id/raw-material (GET/POST/DELETE).
+ */
+
+export type MediaBinding = {
+  raw_material_id: string
+  raw_material_name: string | null
+  sku: string | null
+}
+
+export type MediaBindingResponse = {
+  media_file_id: string
+  media_url: string
+  binding: MediaBinding | null
+}
+
+export type BindRawMaterialPayload = {
+  raw_material_id?: string
+  media_url?: string
+  sku?: string
+  inventory_item_id?: string
+  create?: { name: string; composition?: string; sku?: string }
+}
+
+export type BindRawMaterialResponse = {
+  bound: boolean
+  media_file_id: string
+  media_url: string
+  raw_material_id: string
+  raw_material: Record<string, any>
+  inventory_item_id: string | null
+  sku: string | null
+}
+
+const bindingQueryKey = (mediaId: string) => [
+  "media-raw-material-binding",
+  mediaId,
+]
+
+export const useMediaRawMaterialBinding = (
+  mediaId?: string,
+  options?: Omit<
+    UseQueryOptions<MediaBindingResponse, FetchError>,
+    "queryKey" | "queryFn"
+  >
+) => {
+  return useQuery<MediaBindingResponse, FetchError>({
+    queryKey: bindingQueryKey(mediaId || "none"),
+    queryFn: async () =>
+      sdk.client.fetch<MediaBindingResponse>(
+        `/admin/medias/file/${mediaId}/raw-material`,
+        { method: "GET" }
+      ),
+    enabled: !!mediaId,
+    ...options,
+  })
+}
+
+export const useBindMediaRawMaterial = (
+  mediaId: string,
+  options?: UseMutationOptions<
+    BindRawMaterialResponse,
+    FetchError,
+    BindRawMaterialPayload
+  >
+) => {
+  const queryClient = useQueryClient()
+  return useMutation<BindRawMaterialResponse, FetchError, BindRawMaterialPayload>({
+    mutationFn: async (payload) =>
+      sdk.client.fetch<BindRawMaterialResponse>(
+        `/admin/medias/file/${mediaId}/raw-material`,
+        { method: "POST", body: payload }
+      ),
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({ queryKey: bindingQueryKey(mediaId) })
+      queryClient.invalidateQueries({
+        queryKey: ["inventory_items_raw_materials"],
+      })
+      options?.onSuccess?.(...args)
+    },
+    ...options,
+  })
+}
+
+export const useUnbindMediaRawMaterial = (
+  mediaId: string,
+  options?: UseMutationOptions<
+    { unbound: boolean },
+    FetchError,
+    { raw_material_id: string; media_url?: string }
+  >
+) => {
+  const queryClient = useQueryClient()
+  return useMutation<
+    { unbound: boolean },
+    FetchError,
+    { raw_material_id: string; media_url?: string }
+  >({
+    mutationFn: async (payload) =>
+      sdk.client.fetch<{ unbound: boolean }>(
+        `/admin/medias/file/${mediaId}/raw-material`,
+        { method: "DELETE", body: payload }
+      ),
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({ queryKey: bindingQueryKey(mediaId) })
+      queryClient.invalidateQueries({
+        queryKey: ["inventory_items_raw_materials"],
+      })
+      options?.onSuccess?.(...args)
+    },
+    ...options,
+  })
+}

--- a/apps/backend/src/admin/routes/medias/[id]/@media/components/folder-media-gallery/folder-media-gallery.tsx
+++ b/apps/backend/src/admin/routes/medias/[id]/@media/components/folder-media-gallery/folder-media-gallery.tsx
@@ -1,4 +1,4 @@
-import { ArrowDownTray, ChatBubble, ThumbnailBadge, Trash, TriangleLeftMini, TriangleRightMini } from "@medusajs/icons"
+import { ArrowDownTray, ChatBubble, Tag, ThumbnailBadge, Trash, TriangleLeftMini, TriangleRightMini } from "@medusajs/icons"
 import { Button, IconButton, Text, Tooltip, clx } from "@medusajs/ui"
 import { useCallback, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -7,6 +7,7 @@ import { useFolderMediaViewContext } from "../folder-media-view/folder-media-vie
 import { RouteFocusModal } from "../../../../../../components/modal/route-focus-modal"
 import { getThumbUrl, isImageUrl } from "../../../../../../lib/media"
 import { MediaCommentsSection } from "../../../../../../components/media/folders/folder-comments-section"
+import { BindRawMaterialSection } from "../../../../../../components/media/bind-raw-material-section"
 
 export type FolderMediaGalleryProps = {
   folder: AdminMediaFolder
@@ -15,6 +16,7 @@ export type FolderMediaGalleryProps = {
 export const FolderMediaGallery = ({ folder }: FolderMediaGalleryProps) => {
   const [curr, setCurr] = useState<number>(0)
   const [commentsOpen, setCommentsOpen] = useState<boolean>(true)
+  const [bindOpen, setBindOpen] = useState<boolean>(false)
   const { t } = useTranslation()
   const { goToEdit } = useFolderMediaViewContext()
 
@@ -68,7 +70,27 @@ export const FolderMediaGallery = ({ folder }: FolderMediaGalleryProps) => {
           <IconButton
             size="small"
             type="button"
-            onClick={() => setCommentsOpen((v) => !v)}
+            onClick={() => {
+              setBindOpen((v) => !v)
+              setCommentsOpen(false)
+            }}
+            disabled={noMedia}
+            variant={bindOpen ? "primary" : "transparent"}
+          >
+            <Tag />
+            <span className="sr-only">
+              {bindOpen
+                ? t("media.hideBindRawMaterial", "Hide raw material binding")
+                : t("media.showBindRawMaterial", "Bind to raw material")}
+            </span>
+          </IconButton>
+          <IconButton
+            size="small"
+            type="button"
+            onClick={() => {
+              setCommentsOpen((v) => !v)
+              setBindOpen(false)
+            }}
             disabled={noMedia}
             variant={commentsOpen ? "primary" : "transparent"}
           >
@@ -98,6 +120,17 @@ export const FolderMediaGallery = ({ folder }: FolderMediaGalleryProps) => {
           <Canvas curr={curr} media={media} />
           <Preview curr={curr} media={media} prev={prev} next={next} goTo={goTo} />
         </div>
+        {/* Right: raw-material binding panel for the current media file */}
+        {bindOpen && currentMedia?.id && (
+          <div className="border-ui-border-base flex w-full max-w-sm shrink-0 flex-col overflow-y-auto border-l">
+            <BindRawMaterialSection
+              key={currentMedia.id}
+              mediaId={currentMedia.id}
+              mediaUrl={currentMedia.url}
+              mediaName={currentMedia.file_name}
+            />
+          </div>
+        )}
         {/* Right: comments panel for the current media file */}
         {commentsOpen && currentMedia?.id && (
           <div className="border-ui-border-base flex w-full max-w-sm shrink-0 flex-col overflow-y-auto border-l">

--- a/apps/backend/src/api/admin/medias/file/[id]/raw-material/route.ts
+++ b/apps/backend/src/api/admin/medias/file/[id]/raw-material/route.ts
@@ -1,0 +1,223 @@
+/**
+ * Route: /admin/medias/file/:id/raw-material
+ *
+ * Manual photo → raw-material binding tool (#730). Human-toggled, no AI.
+ *
+ *  - GET    : read the current binding stamped on the media file (or null).
+ *  - POST   : bind this media file to a raw material — appends the media url
+ *             into `raw_materials.media` ({ files: string[] }, idempotent) so the
+ *             photo renders everywhere a raw material is shown (#728 read side).
+ *             Optionally creates a new raw material inline, and/or sets the SKU
+ *             on the linked inventory item.
+ *  - DELETE : unbind — remove the url from `raw_materials.media` and clear the
+ *             media file's back-reference.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+import { MEDIA_MODULE } from "../../../../../../modules/media"
+import { RAW_MATERIAL_MODULE } from "../../../../../../modules/raw_material"
+import { createRawMaterialWorkflow } from "../../../../../../workflows/raw-materials/create-raw-material"
+import {
+  appendMediaFile,
+  removeMediaFile,
+  stampBinding,
+  clearBinding,
+  readBinding,
+} from "../../../../../../workflows/media/lib/media-binding"
+import {
+  BindRawMaterialSchema,
+  UnbindRawMaterialSchema,
+} from "./validators"
+
+const resolveServices = (req: MedusaRequest) => ({
+  logger: req.scope.resolve(ContainerRegistrationKeys.LOGGER) as any,
+  mediaService: req.scope.resolve(MEDIA_MODULE) as any,
+  rawService: req.scope.resolve(RAW_MATERIAL_MODULE) as any,
+  inventoryService: req.scope.resolve(Modules.INVENTORY) as any,
+})
+
+const getMediaFileOr404 = async (mediaService: any, id: string) => {
+  const file = await mediaService.retrieveMediaFile(id).catch(() => null)
+  if (!file) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Media file ${id} not found`
+    )
+  }
+  return file
+}
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params as { id: string }
+  const { mediaService } = resolveServices(req)
+  const file = await getMediaFileOr404(mediaService, id)
+
+  return res.status(200).json({
+    media_file_id: id,
+    media_url: file.file_path,
+    binding: readBinding(file.metadata),
+  })
+}
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params as { id: string }
+
+  const parsed = BindRawMaterialSchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      parsed.error.issues.map((i) => i.message).join(", ")
+    )
+  }
+  const body = parsed.data
+
+  const { logger, mediaService, rawService, inventoryService } =
+    resolveServices(req)
+
+  const file = await getMediaFileOr404(mediaService, id)
+  const mediaUrl = (body.media_url || file.file_path || "").trim()
+  if (!mediaUrl) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "Media file has no url to bind"
+    )
+  }
+
+  let rawMaterialId = body.raw_material_id
+  let createdInventoryItemId: string | undefined
+  let appliedSku: string | null = null
+
+  // --- create-new path (unrecorded piece): inventory item + raw material ---
+  if (!rawMaterialId && body.create) {
+    const [invItem] = await inventoryService.createInventoryItems([
+      {
+        sku: body.create.sku || undefined,
+        title: body.create.name,
+      },
+    ])
+    createdInventoryItemId = invItem.id
+    appliedSku = invItem.sku ?? body.create.sku ?? null
+
+    const { result } = await createRawMaterialWorkflow(req.scope).run({
+      input: {
+        inventoryId: invItem.id,
+        rawMaterialData: {
+          name: body.create.name,
+          // description + composition are required (non-nullable) on the model.
+          description: body.create.name,
+          composition: body.create.composition || "Unspecified",
+          media: { files: [mediaUrl] },
+        },
+      },
+    })
+    // Workflow returns [rawMaterialResult, linkResult, skuResult]
+    rawMaterialId = (result?.[0] as any)?.id
+    if (!rawMaterialId) {
+      throw new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        "Failed to create raw material for binding"
+      )
+    }
+  }
+
+  if (!rawMaterialId) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "raw_material_id is required to bind"
+    )
+  }
+
+  const raw = await rawService
+    .retrieveRawMaterial(rawMaterialId)
+    .catch(() => null)
+  if (!raw) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Raw material ${rawMaterialId} not found`
+    )
+  }
+
+  // --- idempotent append into raw_materials.media ---
+  const nextMedia = appendMediaFile(raw.media, mediaUrl)
+  await rawService.updateRawMaterials({ id: rawMaterialId, media: nextMedia })
+
+  // --- optional SKU set/confirm on an existing linked inventory item ---
+  if (body.sku && body.inventory_item_id) {
+    await inventoryService.updateInventoryItems([
+      { id: body.inventory_item_id, sku: body.sku },
+    ])
+    appliedSku = body.sku
+  }
+
+  // --- stamp display back-reference on the media file ---
+  await mediaService.updateMediaFiles({
+    id,
+    metadata: stampBinding(file.metadata, {
+      bound_raw_material_id: rawMaterialId,
+      bound_raw_material_name: raw.name ?? null,
+      bound_sku: appliedSku,
+    }),
+  })
+
+  logger?.info?.(
+    `Bound media ${id} -> raw_material ${rawMaterialId} (${mediaUrl})`
+  )
+
+  return res.status(200).json({
+    bound: true,
+    media_file_id: id,
+    media_url: mediaUrl,
+    raw_material_id: rawMaterialId,
+    raw_material: { ...raw, media: nextMedia },
+    inventory_item_id: createdInventoryItemId ?? body.inventory_item_id ?? null,
+    sku: appliedSku,
+  })
+}
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params as { id: string }
+
+  const parsed = UnbindRawMaterialSchema.safeParse(req.body ?? {})
+  if (!parsed.success) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      parsed.error.issues.map((i) => i.message).join(", ")
+    )
+  }
+  const body = parsed.data
+
+  const { logger, mediaService, rawService } = resolveServices(req)
+
+  const file = await getMediaFileOr404(mediaService, id)
+  const mediaUrl = (body.media_url || file.file_path || "").trim()
+
+  const raw = await rawService
+    .retrieveRawMaterial(body.raw_material_id)
+    .catch(() => null)
+  if (raw) {
+    const nextMedia = removeMediaFile(raw.media, mediaUrl)
+    await rawService.updateRawMaterials({
+      id: body.raw_material_id,
+      media: nextMedia,
+    })
+  }
+
+  await mediaService.updateMediaFiles({
+    id,
+    metadata: clearBinding(file.metadata),
+  })
+
+  logger?.info?.(
+    `Unbound media ${id} from raw_material ${body.raw_material_id}`
+  )
+
+  return res.status(200).json({
+    unbound: true,
+    media_file_id: id,
+    raw_material_id: body.raw_material_id,
+  })
+}

--- a/apps/backend/src/api/admin/medias/file/[id]/raw-material/validators.ts
+++ b/apps/backend/src/api/admin/medias/file/[id]/raw-material/validators.ts
@@ -1,0 +1,38 @@
+import { z } from "zod"
+
+/**
+ * Bind a media file to a raw material.
+ * Either bind an existing raw material (`raw_material_id`) OR create a new one
+ * inline (`create`, for unrecorded pieces). `media_url` defaults to the media
+ * file's own `file_path` on the server.
+ */
+export const BindRawMaterialSchema = z
+  .object({
+    raw_material_id: z.string().optional(),
+    // Optional explicit url; defaults to the media file's file_path server-side.
+    media_url: z.string().optional(),
+    // Set/confirm SKU on the linked inventory item (admin already has the id
+    // from the raw-materials list response).
+    sku: z.string().optional(),
+    inventory_item_id: z.string().optional(),
+    // Inline create for an unrecorded piece (minimal: name + optional sku).
+    create: z
+      .object({
+        name: z.string().min(1),
+        composition: z.string().optional(),
+        sku: z.string().optional(),
+      })
+      .optional(),
+  })
+  .refine((d) => Boolean(d.raw_material_id) || Boolean(d.create), {
+    message: "Provide either raw_material_id or create",
+  })
+
+export type BindRawMaterialType = z.infer<typeof BindRawMaterialSchema>
+
+export const UnbindRawMaterialSchema = z.object({
+  raw_material_id: z.string().min(1),
+  media_url: z.string().optional(),
+})
+
+export type UnbindRawMaterialType = z.infer<typeof UnbindRawMaterialSchema>

--- a/apps/backend/src/workflows/media/lib/__tests__/media-binding.unit.spec.ts
+++ b/apps/backend/src/workflows/media/lib/__tests__/media-binding.unit.spec.ts
@@ -1,0 +1,145 @@
+import {
+  normalizeMediaFiles,
+  appendMediaFile,
+  removeMediaFile,
+  isMediaBound,
+  stampBinding,
+  clearBinding,
+  readBinding,
+} from "../media-binding"
+
+describe("media-binding pure helpers", () => {
+  describe("normalizeMediaFiles", () => {
+    it("returns [] for null/undefined/garbage", () => {
+      expect(normalizeMediaFiles(null)).toEqual([])
+      expect(normalizeMediaFiles(undefined)).toEqual([])
+      expect(normalizeMediaFiles(42 as any)).toEqual([])
+      expect(normalizeMediaFiles({} as any)).toEqual([])
+    })
+
+    it("reads the canonical { files: string[] } shape", () => {
+      expect(normalizeMediaFiles({ files: ["a", "b"] })).toEqual(["a", "b"])
+    })
+
+    it("reads a bare string[]", () => {
+      expect(normalizeMediaFiles(["a", "b"])).toEqual(["a", "b"])
+    })
+
+    it("reads object entries via url/file_path", () => {
+      expect(
+        normalizeMediaFiles({ files: [{ url: "a" }, { file_path: "b" }] })
+      ).toEqual(["a", "b"])
+    })
+
+    it("de-dupes and drops blanks", () => {
+      expect(
+        normalizeMediaFiles({ files: ["a", "a", "", "  ", "b"] })
+      ).toEqual(["a", "b"])
+    })
+  })
+
+  describe("appendMediaFile (idempotent bind)", () => {
+    it("appends a new url in canonical shape", () => {
+      expect(appendMediaFile({ files: ["a"] }, "b")).toEqual({ files: ["a", "b"] })
+    })
+
+    it("is idempotent — re-binding the same url does not duplicate", () => {
+      expect(appendMediaFile({ files: ["a", "b"] }, "b")).toEqual({
+        files: ["a", "b"],
+      })
+    })
+
+    it("seeds from null media", () => {
+      expect(appendMediaFile(null, "a")).toEqual({ files: ["a"] })
+    })
+
+    it("trims and ignores empty urls", () => {
+      expect(appendMediaFile({ files: ["a"] }, "  ")).toEqual({ files: ["a"] })
+      expect(appendMediaFile({ files: ["a"] }, " b ")).toEqual({
+        files: ["a", "b"],
+      })
+    })
+  })
+
+  describe("removeMediaFile (unbind)", () => {
+    it("removes the url and keeps the rest", () => {
+      expect(removeMediaFile({ files: ["a", "b"] }, "a")).toEqual({
+        files: ["b"],
+      })
+    })
+
+    it("is a no-op when the url is absent", () => {
+      expect(removeMediaFile({ files: ["a"] }, "z")).toEqual({ files: ["a"] })
+    })
+
+    it("handles null media", () => {
+      expect(removeMediaFile(null, "a")).toEqual({ files: [] })
+    })
+  })
+
+  describe("isMediaBound", () => {
+    it("detects presence", () => {
+      expect(isMediaBound({ files: ["a", "b"] }, "b")).toBe(true)
+      expect(isMediaBound({ files: ["a"] }, "b")).toBe(false)
+    })
+  })
+
+  describe("metadata back-reference stamp/clear/read", () => {
+    it("stamps a binding while preserving existing metadata", () => {
+      const out = stampBinding(
+        { foo: "bar" },
+        { bound_raw_material_id: "rm_1", bound_raw_material_name: "Cotton", bound_sku: "SKU-1" }
+      )
+      expect(out).toEqual({
+        foo: "bar",
+        bound_raw_material_id: "rm_1",
+        bound_raw_material_name: "Cotton",
+        bound_sku: "SKU-1",
+      })
+    })
+
+    it("defaults name/sku to null", () => {
+      const out = stampBinding(null, { bound_raw_material_id: "rm_1" })
+      expect(out).toEqual({
+        bound_raw_material_id: "rm_1",
+        bound_raw_material_name: null,
+        bound_sku: null,
+      })
+    })
+
+    it("nulls the binding keys (merge-safe) and preserves other metadata", () => {
+      const out = clearBinding({
+        foo: "bar",
+        bound_raw_material_id: "rm_1",
+        bound_raw_material_name: "Cotton",
+        bound_sku: "SKU-1",
+      })
+      expect(out).toEqual({
+        foo: "bar",
+        bound_raw_material_id: null,
+        bound_raw_material_name: null,
+        bound_sku: null,
+      })
+      // readBinding treats the nulled binding as "not bound"
+      expect(readBinding(out)).toBeNull()
+    })
+
+    it("reads back a stamped binding (round-trip)", () => {
+      const stamped = stampBinding(null, {
+        bound_raw_material_id: "rm_9",
+        bound_raw_material_name: "Silk",
+        bound_sku: "SKU-9",
+      })
+      expect(readBinding(stamped)).toEqual({
+        raw_material_id: "rm_9",
+        raw_material_name: "Silk",
+        sku: "SKU-9",
+      })
+    })
+
+    it("returns null when no binding present", () => {
+      expect(readBinding(null)).toBeNull()
+      expect(readBinding({ foo: "bar" })).toBeNull()
+    })
+  })
+})

--- a/apps/backend/src/workflows/media/lib/media-binding.ts
+++ b/apps/backend/src/workflows/media/lib/media-binding.ts
@@ -1,0 +1,139 @@
+/**
+ * Pure helpers for binding a media-gallery photo to a raw material.
+ *
+ * The source-of-truth for "which photo does this raw material show" is the
+ * `raw_materials.media` json column, persisted in the canonical
+ * `{ files: string[] }` shape (same contract the raw-material form, bulk-import,
+ * and the design-inventory thumbnail readers — #728/#731/#733 — all use).
+ * Keeping the bind tool writing into that column is what makes the photo render
+ * bidirectionally everywhere a raw material is shown.
+ *
+ * These functions are intentionally pure (no IO) so the append/dedup/remove
+ * logic is unit-testable in isolation.
+ */
+
+export type RawMaterialMedia = { files: string[] }
+
+/**
+ * Normalize whatever is stored in `raw_materials.media` into a clean, de-duped
+ * `string[]` of urls. Tolerant of the historical shapes seen in the codebase:
+ *   - `{ files: string[] }`            (canonical — form + bulk-import)
+ *   - `string[]`                       (older rows)
+ *   - `{ files: { url|file_path }[] }` (object entries)
+ *   - `null` / malformed               → `[]`
+ */
+export function normalizeMediaFiles(media: unknown): string[] {
+  if (!media) return []
+  let arr: unknown[] = []
+  if (Array.isArray(media)) {
+    arr = media
+  } else if (typeof media === "object" && Array.isArray((media as any).files)) {
+    arr = (media as any).files
+  } else {
+    return []
+  }
+
+  const urls = arr
+    .map((entry) => {
+      if (typeof entry === "string") return entry
+      if (entry && typeof entry === "object") {
+        const obj = entry as any
+        return obj.url ?? obj.file_path ?? null
+      }
+      return null
+    })
+    .filter((u): u is string => typeof u === "string" && u.trim().length > 0)
+
+  // de-dupe while preserving insertion order
+  return Array.from(new Set(urls))
+}
+
+/**
+ * Append `url` to the media list idempotently. Returns the canonical
+ * `{ files }` shape ready to persist. Re-binding the same url is a no-op.
+ */
+export function appendMediaFile(media: unknown, url: string): RawMaterialMedia {
+  const files = normalizeMediaFiles(media)
+  const clean = typeof url === "string" ? url.trim() : ""
+  if (clean && !files.includes(clean)) {
+    files.push(clean)
+  }
+  return { files }
+}
+
+/**
+ * Remove `url` from the media list. Returns the canonical `{ files }` shape.
+ */
+export function removeMediaFile(media: unknown, url: string): RawMaterialMedia {
+  const clean = typeof url === "string" ? url.trim() : ""
+  const files = normalizeMediaFiles(media).filter((u) => u !== clean)
+  return { files }
+}
+
+/** Whether `url` is currently bound on the given media json. */
+export function isMediaBound(media: unknown, url: string): boolean {
+  const clean = typeof url === "string" ? url.trim() : ""
+  return normalizeMediaFiles(media).includes(clean)
+}
+
+/**
+ * Display-only back-reference stamped onto the media_file's `metadata` so the
+ * gallery can show "Bound to <raw material>" and offer unbind without a
+ * json-contains query. NOT the source of truth — that stays in
+ * `raw_materials.media`.
+ */
+export type MediaBindingRef = {
+  bound_raw_material_id: string
+  bound_raw_material_name?: string | null
+  bound_sku?: string | null
+}
+
+export function stampBinding(
+  metadata: unknown,
+  ref: MediaBindingRef
+): Record<string, any> {
+  const base =
+    metadata && typeof metadata === "object" && !Array.isArray(metadata)
+      ? { ...(metadata as Record<string, any>) }
+      : {}
+  return {
+    ...base,
+    bound_raw_material_id: ref.bound_raw_material_id,
+    bound_raw_material_name: ref.bound_raw_material_name ?? null,
+    bound_sku: ref.bound_sku ?? null,
+  }
+}
+
+export function clearBinding(metadata: unknown): Record<string, any> {
+  const base =
+    metadata && typeof metadata === "object" && !Array.isArray(metadata)
+      ? { ...(metadata as Record<string, any>) }
+      : {}
+  // Medusa's module-service `update` MERGES the metadata json (it does not
+  // replace it), so deleting keys here would leave the old values in place.
+  // Null them out instead — readBinding() treats a null id as "not bound".
+  base.bound_raw_material_id = null
+  base.bound_raw_material_name = null
+  base.bound_sku = null
+  return base
+}
+
+export type MediaBinding = {
+  raw_material_id: string
+  raw_material_name: string | null
+  sku: string | null
+}
+
+/** Read the display back-reference out of a media_file's metadata, if any. */
+export function readBinding(metadata: unknown): MediaBinding | null {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return null
+  }
+  const m = metadata as Record<string, any>
+  if (!m.bound_raw_material_id) return null
+  return {
+    raw_material_id: m.bound_raw_material_id,
+    raw_material_name: m.bound_raw_material_name ?? null,
+    sku: m.bound_sku ?? null,
+  }
+}


### PR DESCRIPTION
Closes part of #730 (the **write** side; #728 is the read side — together they close the loop).

## What
In the admin **media gallery**, viewing an individual photo now has a **"Bind to raw material"** panel (Tag icon toggle in the gallery header). You can:
- **Search** raw materials by name/SKU and bind the photo to one.
- **Create a new raw material inline** (name + optional SKU) for unrecorded pieces.
- See the **current binding** + **Unbind**.

Binding appends the photo url into `raw_materials.media` (canonical `{ files: string[] }` — the exact contract `#728/#731/#733` render from), **idempotently**, so the photo then shows everywhere that raw material appears (design-inventory table, partners). Optionally sets the linked inventory item's **SKU**. Human-toggled, **no AI**.

## Architecture decisions
- **Store in `raw_materials.media` json, not a new link table.** The whole point is bidirectional rendering, and every existing reader (form, bulk-import, `firstMediaUrl`, #728/#731/#733) reads `raw_materials.media`. A new link table wouldn't be picked up by those paths. The `media` column is dedicated (not the `metadata` blob), and writes are careful read-modify-write appends.
- **SKU lives on the linked `inventory_item`**, not on `raw_materials` — the UI passes `inventory_item_id` (it already has it from the raw-materials list) so the endpoint sets it directly.
- **Display back-reference** is stamped on the media file's `metadata` (`bound_raw_material_id/name/sku`) for cheap "Bound to X" display + unbind. Source of truth stays `raw_materials.media`. Unbind **nulls** these keys because Medusa **merges** metadata on module-service `update` (it doesn't replace).

## Endpoints (mirror existing `/admin/medias/*` patterns)
- `GET /admin/medias/file/:id/raw-material` → current binding (or null)
- `POST /admin/medias/file/:id/raw-material` → bind (existing `raw_material_id` **or** `create`), optional `sku` + `inventory_item_id`
- `DELETE /admin/medias/file/:id/raw-material` → unbind

## Tests
- **18 unit** — `workflows/media/lib/media-binding.ts` pure helpers (normalize/append-idempotent/remove/stamp/clear/read).
- **6 integration** — bind writes media + idempotent, sets SKU on linked inventory item, create-new, 400 guard, GET reflects, unbind clears (verified via GET contract + `raw_materials.media === { files: [] }`).
- Typecheck clean. Route verified **registered on the live dev server** (returns 401 unauth, not 404); `/app` admin bundle serves 200.

## ⚠️ Playwright UI verification — NOT run in this chunk
The admin UI is Playwright-gated. The Python Playwright framework isn't installed in the daemon environment (installing it + browser binaries is outside the allowed install scope), so the interactive drive + screenshot couldn't be captured here. The component is tsc-clean, mounted at a verified location, and the admin bundle compiles (`/app` → 200).

**Manual verification steps:**
1. Admin → **Media** → open a folder with photos → open an individual photo (gallery view).
2. Click the **Tag** icon in the header → right panel shows **"Raw material"** with a search box.
3. Search a raw material → click it → toast "Bound to …"; or **Create new raw material** (name + SKU).
4. Open that raw material's inventory row (or the design-inventory table from #728) → the photo renders.
5. Re-open the photo's bind panel → shows current binding + **Unbind** clears it.

PR-only; do not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)