### PR TITLE
fix(storefront): cicilabel.com SEO audit — canonical/apex, favicon, title, H2s (#734)

### DIFF
--- a/apps/storefront/next.config.js
+++ b/apps/storefront/next.config.js
@@ -9,10 +9,46 @@ const S3_HOSTNAME = process.env.MEDUSA_CLOUD_S3_HOSTNAME
 const S3_PATHNAME = process.env.MEDUSA_CLOUD_S3_PATHNAME
 
 /**
+ * Domain consolidation (audit #734 #1 — canonical URL mismatch).
+ *
+ * The canonical domain is the apex `cicilabel.com`. When NEXT_PUBLIC_BASE_URL
+ * is set to the apex (e.g. https://cicilabel.com), getBaseURL() emits apex
+ * canonicals/sitemap/robots/JSON-LD AND we 301 the `www.` and `shop.`
+ * aliases here to the apex so ranking signals consolidate on one host.
+ *
+ * Derived from NEXT_PUBLIC_BASE_URL so there is a single source of truth and
+ * no hardcoded host. Returns [] (inert) when the env is unset or already
+ * points at a subdomain, so a misconfig can never create a redirect loop.
+ */
+const buildCanonicalRedirects = () => {
+  const base = process.env.NEXT_PUBLIC_BASE_URL
+  if (!base) return []
+  let host
+  try {
+    host = new URL(base).host
+  } catch {
+    return []
+  }
+  const apex = host.replace(/^(www|shop)\./, "")
+  // Skip if base is itself an alias subdomain (would loop) or has no alias form.
+  if (apex !== host || !apex.includes(".")) return []
+  const dest = `${base.replace(/\/$/, "")}/:path*`
+  return ["www", "shop"].map((sub) => ({
+    source: "/:path*",
+    has: [{ type: "host", value: `${sub}.${apex}` }],
+    destination: dest,
+    permanent: true,
+  }))
+}
+
+/**
  * @type {import('next').NextConfig}
  */
 const nextConfig = {
   reactStrictMode: true,
+  async redirects() {
+    return buildCanonicalRedirects()
+  },
   experimental: {
     serverActions: {
       bodySizeLimit: "25mb",

--- a/apps/storefront/src/app/[countryCode]/(main)/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/page.tsx
@@ -22,7 +22,11 @@ export async function generateMetadata(props: {
   const { countryCode } = await props.params
   const alternates = await buildLocalizedAlternates(countryCode, "")
 
-  const title = "Cici Label - Handmade, Locally Sourced Fashion"
+  // Display/OG title (also used for og:title + twitter:title below).
+  // 51 chars — the root layout's "%s | Cici Label Store" template pushed
+  // the homepage <title> to 65 chars, above the 50–60 target (audit #734 #4),
+  // so the page title below uses `absolute` to bypass that suffix.
+  const title = "Cici Label — Handmade, Locally Sourced Slow Fashion"
   const description =
     "Cici Label is a slow fashion brand focused on handmade, locally sourced, and ethically produced clothing. Shop handloom and natural-dyed garments."
 
@@ -34,7 +38,7 @@ export async function generateMetadata(props: {
   const ogImage = firstProductImage ?? `${baseUrl}/logo.png`
 
   return {
-    title,
+    title: { absolute: title },
     description,
     alternates,
     openGraph: {

--- a/apps/storefront/src/app/layout.tsx
+++ b/apps/storefront/src/app/layout.tsx
@@ -36,6 +36,14 @@ export const metadata: Metadata = {
     index: true,
     follow: true,
   },
+  // Emit an explicit <link rel="icon"> in <head>. public/favicon.ico is
+  // served at /favicon.ico but the App Router only auto-injects the <link>
+  // tag for icons living in the app/ dir or declared here (audit #734 #2).
+  icons: {
+    icon: "/favicon.ico",
+    shortcut: "/favicon.ico",
+    apple: "/logo.png",
+  },
 }
 
 export default function RootLayout(props: { children: React.ReactNode }) {

--- a/apps/storefront/src/lib/util/env.ts
+++ b/apps/storefront/src/lib/util/env.ts
@@ -2,7 +2,12 @@
  * Resolve the storefront's public base URL.
  *
  * Priority:
- * 1. NEXT_PUBLIC_BASE_URL — explicit override (rarely set per partner)
+ * 1. NEXT_PUBLIC_BASE_URL — explicit override. This is the canonical-domain
+ *    lever: set it to the apex (e.g. https://cicilabel.com) to make every
+ *    canonical tag, sitemap entry, robots `Sitemap:` line and JSON-LD `url`
+ *    resolve to the apex instead of whatever alias host Vercel injects
+ *    (audit #734 #1 — canonical pointed at shop.cicilabel.com). next.config.js
+ *    derives the www./shop. → apex 301s from this same value.
  * 2. VERCEL_PROJECT_PRODUCTION_URL — injected by Vercel into every
  *    deployment; resolves to the project's production domain (the
  *    partner's custom domain when one is attached). This is what makes

--- a/apps/storefront/src/modules/home/components/featured-products/product-rail/index.tsx
+++ b/apps/storefront/src/modules/home/components/featured-products/product-rail/index.tsx
@@ -1,6 +1,5 @@
 import { listProducts } from "@lib/data/products"
 import { HttpTypes } from "@medusajs/types"
-import { Text } from "@medusajs/ui"
 
 import InteractiveLink from "@modules/common/components/interactive-link"
 import ProductPreview from "@modules/products/components/product-preview"
@@ -29,9 +28,12 @@ export default async function ProductRail({
   return (
     <div className="content-container py-16 small:py-32">
       <div className="flex justify-between items-end mb-12">
-        <Text className="text-3xl font-medium tracking-tight bg-gradient-to-r from-gray-900 to-gray-600 bg-clip-text text-transparent">
+        {/* Render the collection name as a real <h2> so each featured rail
+            is a descriptive section heading for SEO + a11y (audit #734 #5).
+            Previously a <Text> (=<p>), leaving the homepage with only 2 h2s. */}
+        <h2 className="text-3xl font-medium tracking-tight bg-gradient-to-r from-gray-900 to-gray-600 bg-clip-text text-transparent">
           {collection.title}
-        </Text>
+        </h2>
         <InteractiveLink href={`/collections/${collection.handle}`}>
           View all
         </InteractiveLink>


### PR DESCRIPTION
Closes the actionable findings in the **cicilabel.com SEO & content audit** (#734). Storefront = `apps/storefront` (Next.js App Router, the live non-submodule storefront, fully Cici-Label-branded).

**Locked decision (operator, 2026-06-24):** canonical domain = **apex `cicilabel.com`**. `shop.`/`www.` redirect → apex.

## Fixed in this PR
| # | Audit item | Fix |
|---|-----------|-----|
| 1 | **CRITICAL** — canonical points to `shop.cicilabel.com/it` not the serving host | Canonical/sitemap/robots/JSON-LD all derive from `getBaseURL()` → `NEXT_PUBLIC_BASE_URL`. Set it to `https://cicilabel.com` and they all emit the apex. `next.config.js` now **derives the `www.`/`shop.` → apex 301s from that same env var** (single source of truth, no hardcoded host). |
| 2 | **HIGH** — favicon `<link rel="icon">` missing | Added `metadata.icons` in `app/layout.tsx`. `public/favicon.ico` already existed but App Router only injects the `<link>` tag for app-dir icons or an explicit `icons` declaration. |
| 4 | **HIGH** — homepage `<title>` 65 chars | Homepage `generateMetadata` now uses `title.absolute` (51 chars, in the 50–60 target), bypassing the root `"%s \| Cici Label Store"` template. og/twitter titles unchanged. |
| 5 | **HIGH** — only 2 `<h2>` on homepage | Featured-product rails rendered the collection name as `<Text>` (a `<p>`). Now a real `<h2>` → each rail is a descriptive section heading. |

## Deferred (with reasons)
- **#3 — sitemap times out.** `app/sitemap.ts` already paginates with a 45s timeout + per-section try/catch. The `robots.txt` `Sitemap:` line follows `getBaseURL()`, so it will reference the live apex once `NEXT_PUBLIC_BASE_URL` is set. The *timeout itself* needs a prod repro (likely cold-start product fetch) — can't reproduce in-daemon. Flagged for a follow-up.

## ⚠️ Operator infra steps required for #1 to take effect
These are deployment-config, not code (the code is ready and inert until set):
1. Attach **`cicilabel.com`** (apex) as a domain on the Vercel project.
2. Set env **`NEXT_PUBLIC_BASE_URL=https://cicilabel.com`** (prod) → flips canonical/sitemap/robots/JSON-LD to apex **and** activates the `www.`/`shop.` → apex 301s.
3. Keep `shop.cicilabel.com` / `www.cicilabel.com` attached to the same project so the 301s can fire.

> The redirect builder returns `[]` when `NEXT_PUBLIC_BASE_URL` is unset or points at a subdomain, so **merging this PR cannot break prod** — behaviour only changes once the operator sets the env after attaching the apex domain.

## Verification
- `tsc --noEmit`: **0 new errors** in the 5 changed files (the project carries 332 pre-existing errors behind `ignoreBuildErrors`; the only line flagged in a changed file is the pre-existing project-wide `Suspense cannot be used as a JSX component` React-types issue, unrelated to these edits).
- Redirect builder unit-validated: inert when unset; `https://cicilabel.com` → `www.`/`shop.` 301s; `https://shop.cicilabel.com` → `[]` (loop-safe); `localhost` → `[]`.
- **Manual (Playwright-gated, not run in-daemon):** after deploy with the env set, `view-source` the homepage and confirm (a) `<link rel="canonical" href="https://cicilabel.com/it">`, (b) `<link rel="icon" href="/favicon.ico">` present, (c) `<title>` ≤ 60 chars, (d) featured collection names render as `<h2>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)