### PR TITLE
feat(raw-materials): mirror raw-material media onto inventory_item.thumbnail (+#457 backfill)

### DIFF
--- a/apps/backend/integration-tests/http/raw-material-inventory-thumbnail.spec.ts
+++ b/apps/backend/integration-tests/http/raw-material-inventory-thumbnail.spec.ts
@@ -1,0 +1,116 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(60000)
+
+/**
+ * The inventory item's own `thumbnail` is never populated by hand — the actual
+ * material image lives in `raw_material.media`. The create/update raw-material
+ * workflows mirror the first usable media URL onto the linked inventory item's
+ * thumbnail so the admin inventory table + storefront have something to show.
+ */
+setupSharedTestSuite(() => {
+  let headers
+  let inventoryItemId: string
+  const { api, getContainer } = getSharedTestEnv()
+
+  const mediaA = { files: ["https://cdn.example.com/material-a.jpg"] }
+  const mediaB = { files: ["https://cdn.example.com/material-b.jpg"] }
+
+  const fetchThumbnail = async () => {
+    const res = await api.get(
+      `/admin/inventory-items/${inventoryItemId}`,
+      { headers: headers.headers }
+    )
+    return res.data.inventory_item.thumbnail
+  }
+
+  beforeEach(async () => {
+    const container = getContainer()
+    await createAdminUser(container)
+    headers = await getAuthHeaders(api)
+
+    const inventoryResponse = await api.post(
+      "/admin/inventory-items",
+      { title: "Thumbnail Test Inventory Item" },
+      headers
+    )
+    inventoryItemId = inventoryResponse.data.inventory_item.id
+  })
+
+  it("sets the inventory item thumbnail from media on raw-material create", async () => {
+    expect(await fetchThumbnail()).toBeFalsy()
+
+    const response = await api.post(
+      `/admin/inventory-items/${inventoryItemId}/rawmaterials`,
+      {
+        rawMaterialData: {
+          name: "Cotton With Image",
+          description: "Cotton fabric with a catalog photo",
+          composition: "100% Cotton",
+          material_type: "Cotton",
+          status: "Active",
+          media: mediaA,
+        },
+      },
+      headers
+    )
+
+    expect(response.status).toBe(201)
+    expect(await fetchThumbnail()).toBe("https://cdn.example.com/material-a.jpg")
+  })
+
+  it("leaves the thumbnail untouched when the raw material has no media", async () => {
+    const response = await api.post(
+      `/admin/inventory-items/${inventoryItemId}/rawmaterials`,
+      {
+        rawMaterialData: {
+          name: "Cotton No Image",
+          description: "Cotton fabric without a catalog photo",
+          composition: "100% Cotton",
+          material_type: "Cotton",
+          status: "Active",
+        },
+      },
+      headers
+    )
+
+    expect(response.status).toBe(201)
+    expect(await fetchThumbnail()).toBeFalsy()
+  })
+
+  it("updates the inventory item thumbnail when media is added/changed on update", async () => {
+    // Create without media → thumbnail stays empty.
+    const createRes = await api.post(
+      `/admin/inventory-items/${inventoryItemId}/rawmaterials`,
+      {
+        rawMaterialData: {
+          name: "Cotton To Be Imaged",
+          description: "Cotton fabric imaged later via update",
+          composition: "100% Cotton",
+          material_type: "Cotton",
+          status: "Active",
+        },
+      },
+      headers
+    )
+    const rawMaterialId = createRes.data.raw_materials.id
+    expect(await fetchThumbnail()).toBeFalsy()
+
+    // Add media via update → thumbnail picks it up.
+    await api.put(
+      `/admin/inventory-items/${inventoryItemId}/rawmaterials/${rawMaterialId}`,
+      { rawMaterialData: { media: mediaA } },
+      headers
+    )
+    expect(await fetchThumbnail()).toBe("https://cdn.example.com/material-a.jpg")
+
+    // Change media → thumbnail follows.
+    await api.put(
+      `/admin/inventory-items/${inventoryItemId}/rawmaterials/${rawMaterialId}`,
+      { rawMaterialData: { media: mediaB } },
+      headers
+    )
+    expect(await fetchThumbnail()).toBe("https://cdn.example.com/material-b.jpg")
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/registry.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/registry.unit.spec.ts
@@ -7,6 +7,7 @@ import {
   diffEnergyCostFields,
   diffOrderCurrency,
   diffRunCostFields,
+  diffThumbnail,
   diffUnitCost,
   getMaintenanceJob,
   interpretRunCost,
@@ -23,6 +24,7 @@ import {
   summarizeBulkRecalc,
   summarizeEnergyBackfill,
   summarizeOrderCurrencyBackfill,
+  summarizeThumbnailBackfill,
   summarizeUnitCostBackfill,
 } from "../registry"
 
@@ -260,6 +262,75 @@ describe("ops/maintenance-jobs registry (#457)", () => {
       expect(MAINTENANCE_JOBS.map((j) => j.id)).toContain("backfill-inventory-unit-cost")
       expect(job?.params.some((p) => p.name === "force" && !p.required)).toBe(true)
       expect(job?.params.some((p) => p.name === "limit" && !p.required)).toBe(true)
+    })
+  })
+
+  describe("backfill-inventory-thumbnail registration", () => {
+    it("registers the job with optional force + limit params", () => {
+      const job = getMaintenanceJob("backfill-inventory-thumbnail-from-raw-material-media")
+      expect(job).toBeDefined()
+      expect(MAINTENANCE_JOBS.map((j) => j.id)).toContain(
+        "backfill-inventory-thumbnail-from-raw-material-media"
+      )
+      expect(job?.params.some((p) => p.name === "force" && !p.required)).toBe(true)
+      expect(job?.params.some((p) => p.name === "limit" && !p.required)).toBe(true)
+    })
+  })
+
+  describe("diffThumbnail", () => {
+    const media = { files: ["https://cdn/a.jpg"] }
+
+    it("reports a change when the thumbnail is empty (null/'' → url)", () => {
+      expect(diffThumbnail("inv_1", null, media, false)).toEqual([
+        { entity: "inventory_item", id: "inv_1", field: "thumbnail", before: null, after: "https://cdn/a.jpg" },
+      ])
+      expect(diffThumbnail("inv_1", "", media, false)).toEqual([
+        { entity: "inventory_item", id: "inv_1", field: "thumbnail", before: null, after: "https://cdn/a.jpg" },
+      ])
+    })
+
+    it("returns no change when media yields no usable url", () => {
+      expect(diffThumbnail("inv_1", null, null, false)).toEqual([])
+      expect(diffThumbnail("inv_1", null, { files: [] }, false)).toEqual([])
+      expect(diffThumbnail("inv_1", null, { files: [{ name: "no-url" }] }, false)).toEqual([])
+    })
+
+    it("leaves an already-set thumbnail alone unless force=true", () => {
+      expect(diffThumbnail("inv_1", "https://cdn/old.jpg", media, false)).toEqual([])
+      expect(diffThumbnail("inv_1", "https://cdn/old.jpg", media, true)).toEqual([
+        {
+          entity: "inventory_item",
+          id: "inv_1",
+          field: "thumbnail",
+          before: "https://cdn/old.jpg",
+          after: "https://cdn/a.jpg",
+        },
+      ])
+    })
+
+    it("is idempotent when the thumbnail already matches (even with force)", () => {
+      expect(diffThumbnail("inv_1", "https://cdn/a.jpg", media, false)).toEqual([])
+      expect(diffThumbnail("inv_1", "https://cdn/a.jpg", media, true)).toEqual([])
+    })
+  })
+
+  describe("summarizeThumbnailBackfill", () => {
+    it("reports no changes and keeps the scan count", () => {
+      expect(summarizeThumbnailBackfill(true, 7, 0, 0, 0, 0)).toMatch(
+        /No changes — scanned 7 inventory item/
+      )
+    })
+
+    it("uses 'Would set' for dry-run and appends skip breakdown", () => {
+      expect(summarizeThumbnailBackfill(true, 10, 3, 2, 1, 0)).toBe(
+        "Would set thumbnail on 3 inventory item(s) (scanned 10); 2 unlinked, 1 no usable media"
+      )
+    })
+
+    it("uses 'Set' on apply and appends an error count when present", () => {
+      expect(summarizeThumbnailBackfill(false, 10, 3, 0, 0, 1)).toBe(
+        "Set thumbnail on 3 inventory item(s) (scanned 10); 1 error(s)"
+      )
     })
   })
 

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -22,6 +22,7 @@ import partnerRegionLink from "../../../../links/partner-region"
 import productGoogleMerchantLink from "../../../../links/product-google-merchant-link"
 import productionRunConsumptionLogLink from "../../../../links/production-runs-consumption-logs"
 import { resolveStoreCurrency } from "../../../../lib/resolve-store-currency"
+import { firstMediaUrl } from "../../../../utils/first-media-url"
 import {
   normalizeLandingBase,
   resolvePartnerLandingBase,
@@ -812,6 +813,169 @@ export const backfillInventoryUnitCostJob: MaintenanceJob = {
         changedRawMaterials.size,
         noRawMaterial,
         noHistory,
+        errors.length
+      ),
+      changes,
+      errors,
+    }
+  },
+}
+
+const backfillThumbnailParamsSchema = z.object({
+  /** Overwrite a thumbnail that's already set (default: only fill empties). */
+  force: z.boolean().optional().default(false),
+  /** Max inventory items to scan in one call (1..MAX_INVENTORY_SCAN). */
+  limit: z.number().int().positive().max(MAX_INVENTORY_SCAN).optional().default(1000),
+})
+
+/**
+ * Pure: diff an inventory item's currently-stored thumbnail against the URL
+ * derived from its linked raw material's media. Returns a single `thumbnail`
+ * change (or none when already equal, or when there's no usable media URL).
+ * When `force` is false, an item that already has any non-empty thumbnail is
+ * left alone. Exported for unit testing.
+ */
+export function diffThumbnail(
+  inventoryItemId: string,
+  before: string | null | undefined,
+  media: unknown,
+  force: boolean
+): MaintenanceChange[] {
+  const after = firstMediaUrl(media)
+  if (!after) return []
+
+  const beforeValue = before == null || before === "" ? null : before
+  if (beforeValue && !force) return []
+  if (beforeValue === after) return []
+
+  return [{ entity: "inventory_item", id: inventoryItemId, field: "thumbnail", before: beforeValue, after }]
+}
+
+/**
+ * Pure summary builder for the inventory-thumbnail backfill — keeps the
+ * human-facing string verifiable without booting the DB.
+ */
+export function summarizeThumbnailBackfill(
+  dryRun: boolean,
+  scanned: number,
+  changedCount: number,
+  noRawMaterialCount: number,
+  noMediaCount: number,
+  errorCount: number
+): string {
+  const verb = dryRun ? "Would set" : "Set"
+  const head =
+    changedCount === 0
+      ? `No changes — scanned ${scanned} inventory item(s), none needed a thumbnail`
+      : `${verb} thumbnail on ${changedCount} inventory item(s) (scanned ${scanned})`
+  const skips: string[] = []
+  if (noRawMaterialCount > 0) skips.push(`${noRawMaterialCount} unlinked`)
+  if (noMediaCount > 0) skips.push(`${noMediaCount} no usable media`)
+  const tail = skips.length ? `; ${skips.join(", ")}` : ""
+  return errorCount > 0 ? `${head}${tail}; ${errorCount} error(s)` : `${head}${tail}`
+}
+
+/**
+ * #457 ops job: backfill the inventory item `thumbnail` from its linked raw
+ * material's `media`. The inventory item's own thumbnail was historically never
+ * populated — the material image lives in `raw_material.media` — so the admin
+ * inventory table + storefront had nothing to show for items created before the
+ * create/update workflows began mirroring it. For each inventory item linked to
+ * a raw material with usable media, this derives the first media URL and sets it
+ * as the thumbnail. Dry-run (default) previews every before→after without
+ * persisting; apply writes via the inventory module (idempotent). By default
+ * only fills empty thumbnails — set force=true to overwrite existing ones.
+ * Unlinked items / items whose media yields no URL are counted in the summary,
+ * not treated as errors; a genuine per-item failure is reported in `errors`.
+ */
+export const backfillInventoryThumbnailJob: MaintenanceJob = {
+  id: "backfill-inventory-thumbnail-from-raw-material-media",
+  label: "Backfill inventory thumbnail from raw-material media",
+  description:
+    `Set each inventory item's thumbnail from its linked raw material's first usable media URL. Dry-run previews the before/after without persisting; apply writes thumbnail back (idempotent). By default only fills empty thumbnails — set force=true to overwrite existing ones. Scans up to 'limit' items per call (default 1000, max ${MAX_INVENTORY_SCAN}).`,
+  params: [
+    {
+      name: "force",
+      type: "boolean",
+      required: false,
+      description: "Overwrite a thumbnail that is already set (default false)",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max inventory items to scan in one call (default 1000, max ${MAX_INVENTORY_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }) => {
+    const parsed = backfillThumbnailParamsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { force, limit } = parsed.data
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const inventoryService: any = container.resolve(Modules.INVENTORY)
+
+    const items: any[] = await inventoryService.listInventoryItems({}, { take: limit })
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    let noRawMaterial = 0
+    let noMedia = 0
+
+    for (const item of items) {
+      try {
+        let rawMaterial: any = null
+        try {
+          const { data: rmLinks } = await query.graph({
+            entity: "inventory_item_raw_materials",
+            filters: { inventory_item_id: item.id },
+            fields: ["raw_materials.media"],
+          })
+          rawMaterial = rmLinks?.[0]?.raw_materials
+        } catch {
+          // No link table row / not linked — treated as "unlinked" below.
+        }
+
+        if (!rawMaterial) {
+          noRawMaterial++
+          continue
+        }
+
+        const itemChanges = diffThumbnail(item.id, item.thumbnail, rawMaterial.media, force)
+        if (itemChanges.length === 0) {
+          // Either already correct, or media yields no URL — distinguish for the summary.
+          if (!firstMediaUrl(rawMaterial.media)) noMedia++
+          continue
+        }
+
+        changes.push(...itemChanges)
+
+        if (!dry_run) {
+          await inventoryService.updateInventoryItems({
+            id: item.id,
+            thumbnail: itemChanges[0].after as string,
+          })
+        }
+      } catch (e: any) {
+        errors.push({ id: item.id, message: e?.message ?? String(e) })
+      }
+    }
+
+    return {
+      job_id: backfillInventoryThumbnailJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary: summarizeThumbnailBackfill(
+        dry_run,
+        items.length,
+        changes.length,
+        noRawMaterial,
+        noMedia,
         errors.length
       ),
       changes,
@@ -4259,6 +4423,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   recalculateDesignCostBulkJob,
   correctProductionRunCostJob,
   backfillInventoryUnitCostJob,
+  backfillInventoryThumbnailJob,
   backfillDesignEnergyCostJob,
   backfillFinishedRunConsumptionJob,
   pruneOpsAuditRunsJob,

--- a/apps/backend/src/utils/__tests__/first-media-url.unit.spec.ts
+++ b/apps/backend/src/utils/__tests__/first-media-url.unit.spec.ts
@@ -1,0 +1,45 @@
+import { firstMediaUrl } from "../first-media-url"
+
+describe("firstMediaUrl (backend)", () => {
+  it("returns undefined for empty / null / undefined", () => {
+    expect(firstMediaUrl(undefined)).toBeUndefined()
+    expect(firstMediaUrl(null)).toBeUndefined()
+    expect(firstMediaUrl({})).toBeUndefined()
+    expect(firstMediaUrl([])).toBeUndefined()
+    expect(firstMediaUrl({ files: [] })).toBeUndefined()
+  })
+
+  it("reads the canonical { files: string[] } shape", () => {
+    expect(firstMediaUrl({ files: ["https://cdn/a.jpg", "https://cdn/b.jpg"] })).toBe(
+      "https://cdn/a.jpg"
+    )
+  })
+
+  it("reads { files: [{ url }] } object entries", () => {
+    expect(firstMediaUrl({ files: [{ url: "https://cdn/c.jpg" }] })).toBe("https://cdn/c.jpg")
+  })
+
+  it("reads a raw array of url strings", () => {
+    expect(firstMediaUrl(["https://cdn/d.jpg"])).toBe("https://cdn/d.jpg")
+  })
+
+  it("reads a raw array of objects via url/file_path/thumbnail/src keys", () => {
+    expect(firstMediaUrl([{ file_path: "https://cdn/e.jpg" }])).toBe("https://cdn/e.jpg")
+    expect(firstMediaUrl([{ thumbnail: "https://cdn/f.jpg" }])).toBe("https://cdn/f.jpg")
+    expect(firstMediaUrl([{ src: "https://cdn/g.jpg" }])).toBe("https://cdn/g.jpg")
+  })
+
+  it("reads a single object", () => {
+    expect(firstMediaUrl({ url: "https://cdn/h.jpg" })).toBe("https://cdn/h.jpg")
+  })
+
+  it("skips empty/whitespace entries and trims", () => {
+    expect(firstMediaUrl({ files: ["", "   ", "https://cdn/i.jpg"] })).toBe("https://cdn/i.jpg")
+    expect(firstMediaUrl(["  https://cdn/j.jpg  "])).toBe("https://cdn/j.jpg")
+  })
+
+  it("returns undefined when entries carry no usable url", () => {
+    expect(firstMediaUrl({ files: [{ name: "no-url" }] })).toBeUndefined()
+    expect(firstMediaUrl([42, false, {}])).toBeUndefined()
+  })
+})

--- a/apps/backend/src/utils/first-media-url.ts
+++ b/apps/backend/src/utils/first-media-url.ts
@@ -1,0 +1,64 @@
+/**
+ * Extract the first usable image URL from a raw-material (or inventory) `media`
+ * JSON blob, which has been persisted in several shapes over time:
+ *
+ *  - `{ files: ["https://…", …] }`              (canonical — admin form + bulk-import route)
+ *  - `{ files: [{ url: "…" }, …] }`             (object entries)
+ *  - `["https://…", …]`                          (raw array of urls)
+ *  - `[{ url|file_path|thumbnail|src: "…" }, …]` (raw array of objects)
+ *  - `{ url|file_path|thumbnail|src: "…" }`       (single object)
+ *
+ * Returns the first non-empty string URL found, or `undefined` when there is no
+ * usable image (so callers can render a graceful placeholder / skip the patch).
+ *
+ * Kept in sync with `apps/backend/src/admin/lib/utils/first-media-url.ts` — the
+ * admin (Vite) build can't import from the backend build and vice-versa, so the
+ * two intentionally mirror each other.
+ */
+export function firstMediaUrl(media: unknown): string | undefined {
+  if (!media) {
+    return undefined
+  }
+
+  // Unwrap `{ files: [...] }`
+  let candidate: unknown = media
+  if (
+    typeof media === "object" &&
+    !Array.isArray(media) &&
+    Array.isArray((media as { files?: unknown }).files)
+  ) {
+    candidate = (media as { files: unknown[] }).files
+  }
+
+  if (Array.isArray(candidate)) {
+    for (const entry of candidate) {
+      const url = coerceUrl(entry)
+      if (url) {
+        return url
+      }
+    }
+    return undefined
+  }
+
+  return coerceUrl(candidate)
+}
+
+const URL_KEYS = ["url", "file_path", "thumbnail", "src"] as const
+
+function coerceUrl(entry: unknown): string | undefined {
+  if (typeof entry === "string") {
+    const trimmed = entry.trim()
+    return trimmed.length ? trimmed : undefined
+  }
+
+  if (entry && typeof entry === "object") {
+    for (const key of URL_KEYS) {
+      const value = (entry as Record<string, unknown>)[key]
+      if (typeof value === "string" && value.trim().length) {
+        return value.trim()
+      }
+    }
+  }
+
+  return undefined
+}

--- a/apps/backend/src/workflows/raw-materials/create-raw-material.ts
+++ b/apps/backend/src/workflows/raw-materials/create-raw-material.ts
@@ -3,13 +3,15 @@ import {
   createStep,
   WorkflowResponse,
   StepResponse,
-  createWorkflow
+  createWorkflow,
+  transform
 } from "@medusajs/framework/workflows-sdk"
 import { RAW_MATERIAL_MODULE } from "../../modules/raw_material"
 import { LinkDefinition } from "@medusajs/framework/types"
 import RawMaterialService from "../../modules/raw_material/service"
 import type { Link } from "@medusajs/modules-sdk"
 import { generateSkuStep } from "./steps/generate-sku"
+import { syncInventoryThumbnailStep } from "./steps/sync-inventory-thumbnail"
 
 type CreateRawMaterialInput = {
   inventoryId: string
@@ -159,10 +161,18 @@ export const createRawMaterialWorkflow = createWorkflow(
       rawMaterialId: rawMaterialResult.id,
     })
 
+    // Mirror the raw material's primary image onto the inventory item thumbnail.
+    const media = transform(input, (i) => i.rawMaterialData?.media)
+    const thumbnailResult = syncInventoryThumbnailStep({
+      inventoryId: input.inventoryId,
+      media,
+    })
+
     return new WorkflowResponse([
       rawMaterialResult,
       rawMaterialLinkResult,
-      skuResult
+      skuResult,
+      thumbnailResult
     ])
   }
 )

--- a/apps/backend/src/workflows/raw-materials/steps/sync-inventory-thumbnail.ts
+++ b/apps/backend/src/workflows/raw-materials/steps/sync-inventory-thumbnail.ts
@@ -1,0 +1,95 @@
+import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { IInventoryService } from "@medusajs/types"
+import { firstMediaUrl } from "../../../utils/first-media-url"
+
+type SyncInventoryThumbnailInput = {
+  /** Inventory item to patch. If omitted, resolved from `rawMaterialId` via the link. */
+  inventoryId?: string
+  /** Used to resolve the linked inventory item when `inventoryId` is not supplied. */
+  rawMaterialId?: string
+  /** The raw material `media` blob — first usable URL becomes the thumbnail. */
+  media?: unknown
+}
+
+type Compensation = { inventoryId: string; previousThumbnail: string | null } | null
+
+type SyncResult = {
+  skipped: boolean
+  reason?: string
+  inventoryId?: string
+  thumbnail?: string
+}
+
+/**
+ * Mirror a raw material's primary image onto its linked inventory item's
+ * `thumbnail`. The inventory item's own `thumbnail` is otherwise never
+ * populated — the actual image lives in `raw_material.media` — so the admin
+ * inventory table and storefront have nothing to show. Runs on raw-material
+ * create/update whenever a `media` blob is present; a no-op (no write) when the
+ * media yields no URL, when the thumbnail already matches, or when the linked
+ * inventory item can't be resolved.
+ */
+export const syncInventoryThumbnailStep = createStep(
+  "sync-inventory-thumbnail",
+  async (input: SyncInventoryThumbnailInput, { container }) => {
+    const url = firstMediaUrl(input.media)
+    if (!url) {
+      return new StepResponse<SyncResult, Compensation>(
+        { skipped: true, reason: "no-media-url" },
+        null
+      )
+    }
+
+    const inventoryService: IInventoryService = container.resolve(Modules.INVENTORY)
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+    // Resolve the inventory item — directly, or via the raw-material link.
+    let inventoryId = input.inventoryId
+    if (!inventoryId && input.rawMaterialId) {
+      try {
+        const { data: links } = await query.graph({
+          entity: "inventory_item_raw_materials",
+          filters: { raw_materials_id: input.rawMaterialId },
+          fields: ["inventory_item_id"],
+        })
+        inventoryId = links?.[0]?.inventory_item_id
+      } catch {
+        // Link may not exist yet — nothing to patch.
+      }
+    }
+
+    if (!inventoryId) {
+      return new StepResponse<SyncResult, Compensation>(
+        { skipped: true, reason: "no-inventory-item" },
+        null
+      )
+    }
+
+    const inventoryItem = await inventoryService.retrieveInventoryItem(inventoryId)
+    const previousThumbnail = (inventoryItem.thumbnail as string | null) ?? null
+
+    // Idempotent: nothing to do when it already points at this image.
+    if (previousThumbnail === url) {
+      return new StepResponse<SyncResult, Compensation>(
+        { skipped: true, reason: "unchanged" },
+        null
+      )
+    }
+
+    await inventoryService.updateInventoryItems({ id: inventoryId, thumbnail: url })
+
+    return new StepResponse<SyncResult, Compensation>(
+      { skipped: false, inventoryId, thumbnail: url },
+      { inventoryId, previousThumbnail }
+    )
+  },
+  async (compensation, { container }) => {
+    if (!compensation) return
+    const inventoryService: IInventoryService = container.resolve(Modules.INVENTORY)
+    await inventoryService.updateInventoryItems({
+      id: compensation.inventoryId,
+      thumbnail: compensation.previousThumbnail as any,
+    })
+  }
+)

--- a/apps/backend/src/workflows/raw-materials/update-raw-material.ts
+++ b/apps/backend/src/workflows/raw-materials/update-raw-material.ts
@@ -4,9 +4,11 @@ import {
   createStep,
   StepResponse,
   WorkflowResponse,
+  transform,
 } from "@medusajs/framework/workflows-sdk";
 import { RAW_MATERIAL_MODULE } from "../../modules/raw_material"
 import RawMaterialService from "../../modules/raw_material/service"
+import { syncInventoryThumbnailStep } from "./steps/sync-inventory-thumbnail"
 
 type UpdateRawMaterialStepInput = {
   id: string;
@@ -31,6 +33,7 @@ type UpdateRawMaterialStepInput = {
     metadata?: Record<string, any> | null;
     material_type_id?: string;
     material_type?: string;
+    media?: Record<string, any> | null;
   };
 };
 
@@ -133,6 +136,15 @@ const updateRawMaterialWorkflow = createWorkflow(
   },
   (input: UpdateRawMaterialStepInput) => {
     const updatedRawMaterial = updateRawMaterialStep(input);
+
+    // When the update carries a new media blob, mirror its primary image onto
+    // the linked inventory item's thumbnail (resolved from the raw material id).
+    const media = transform(input, (i) => i.update?.media)
+    syncInventoryThumbnailStep({
+      rawMaterialId: input.id,
+      media,
+    })
+
     return new WorkflowResponse(updatedRawMaterial);
   },
 );


### PR DESCRIPTION
## Problem
The inventory item's own `thumbnail` is never populated by hand — the actual material image lives in `raw_material.media`. So the **admin inventory table** and **storefront** had nothing to show, and the field stayed null forever.

This is the **write-side + backfill** counterpart to the partner-ui read-side fix (#733) and the admin design-linking photo (#731).

## Changes
- **`src/utils/first-media-url.ts`** — backend copy of the admin/partner-ui helper; unwraps every persisted media shape (`{files:[…]}`, raw arrays, single objects via `url|file_path|thumbnail|src`). 8 unit tests.
- **`src/workflows/raw-materials/steps/sync-inventory-thumbnail.ts`** — shared step. Resolves the inventory item (directly on create, via the `inventory_item_raw_materials` link on update), sets `thumbnail` to the first media URL. Idempotent, with compensation. No-op when there's no media URL / no link / unchanged.
- Wired into **both** `create-raw-material` and `update-raw-material` workflows (the two places raw_material media is set).
- **`#457` Data Plumbing job** `backfill-inventory-thumbnail-from-raw-material-media` — dry-run → apply, `force`/`limit` params, only fills empty thumbnails by default. Repairs items created before this change.

## Verify
- ✅ Unit: `TEST_TYPE=unit jest first-media-url` (8) + `registry.unit` (89 incl. new `diffThumbnail` / `summarizeThumbnailBackfill` / registration).
- ✅ Integration: `pnpm test:integration:http:shared ./integration-tests/http/raw-material-inventory-thumbnail` — create-with-media sets thumbnail, create-without-media is a no-op, update adds/changes media → thumbnail follows (3/3).
- ✅ `tsc --noEmit` clean for all touched files.
- Backfill: run from **Settings → Data Plumbing** dry-run first, then apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)