### PR TITLE
feat(#730): set inventory_item.thumbnail when binding a photo to a raw material

### DIFF
--- a/apps/backend/integration-tests/http/media-bind-raw-material.spec.ts
+++ b/apps/backend/integration-tests/http/media-bind-raw-material.spec.ts
@@ -116,6 +116,53 @@ setupSharedTestSuite(() => {
       expect(inv.sku).toBe("RM-SKU-12345")
     })
 
+    it("mirrors the bound photo onto the linked inventory item's thumbnail (resolved via link)", async () => {
+      const container = getContainer()
+      const mediaService: any = container.resolve(MEDIA_MODULE)
+      const inventoryService: any = container.resolve("inventory")
+      const media = await makeMediaFile(mediaService, "thumb")
+
+      // no thumbnail before binding
+      const before = await inventoryService.retrieveInventoryItem(inventoryItemId)
+      expect(before.thumbnail ?? null).toBeNull()
+
+      // bind WITHOUT passing inventory_item_id — the route resolves it from the
+      // inventory_item_raw_materials link.
+      const res = await api.post(
+        `/admin/medias/file/${media.id}/raw-material`,
+        { raw_material_id: rawMaterialId },
+        headers
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.inventory_thumbnail).toBe(media.file_path)
+
+      const after = await inventoryService.retrieveInventoryItem(inventoryItemId)
+      expect(after.thumbnail).toBe(media.file_path)
+    })
+
+    it("does not clobber an inventory item that already has a thumbnail", async () => {
+      const container = getContainer()
+      const mediaService: any = container.resolve(MEDIA_MODULE)
+      const inventoryService: any = container.resolve("inventory")
+      const media = await makeMediaFile(mediaService, "noclobber")
+
+      const existing = "https://cdn.example.com/manual-thumbnail.jpg"
+      await inventoryService.updateInventoryItems([
+        { id: inventoryItemId, thumbnail: existing },
+      ])
+
+      const res = await api.post(
+        `/admin/medias/file/${media.id}/raw-material`,
+        { raw_material_id: rawMaterialId, inventory_item_id: inventoryItemId },
+        headers
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.inventory_thumbnail).toBeNull()
+
+      const after = await inventoryService.retrieveInventoryItem(inventoryItemId)
+      expect(after.thumbnail).toBe(existing)
+    })
+
     it("creates a new raw material inline and binds the photo", async () => {
       const container = getContainer()
       const mediaService: any = container.resolve(MEDIA_MODULE)

--- a/apps/backend/src/api/admin/medias/file/[id]/raw-material/route.ts
+++ b/apps/backend/src/api/admin/medias/file/[id]/raw-material/route.ts
@@ -32,6 +32,7 @@ import {
   BindRawMaterialSchema,
   UnbindRawMaterialSchema,
 } from "./validators"
+import { pickInventoryThumbnail } from "../../../../../../utils/inventory-thumbnail-decision"
 
 const resolveServices = (req: MedusaRequest) => ({
   logger: req.scope.resolve(ContainerRegistrationKeys.LOGGER) as any,
@@ -153,6 +154,46 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     appliedSku = body.sku
   }
 
+  // --- mirror the bound photo onto the linked inventory item's thumbnail (#730) ---
+  // This append path writes raw_materials.media directly, bypassing the
+  // create/update workflows that run syncInventoryThumbnailStep (#739), so the
+  // inventory item's thumbnail would otherwise stay null (admin table /
+  // storefront show nothing) until the #457 backfill. Best-effort: a failure
+  // here must not fail the bind.
+  let syncedInventoryThumbnail: string | null = null
+  try {
+    let invItemId: string | undefined =
+      createdInventoryItemId ?? body.inventory_item_id
+    if (!invItemId) {
+      const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+      const { data: links } = await query.graph({
+        entity: "inventory_item_raw_materials",
+        filters: { raw_materials_id: rawMaterialId },
+        fields: ["inventory_item_id"],
+      })
+      invItemId = links?.[0]?.inventory_item_id
+    }
+
+    if (invItemId) {
+      const invItem = await inventoryService
+        .retrieveInventoryItem(invItemId)
+        .catch(() => null)
+      const nextThumbnail = pickInventoryThumbnail(invItem?.thumbnail, nextMedia)
+      if (invItem && nextThumbnail) {
+        await inventoryService.updateInventoryItems([
+          { id: invItemId, thumbnail: nextThumbnail },
+        ])
+        syncedInventoryThumbnail = nextThumbnail
+      }
+    }
+  } catch (e: any) {
+    logger?.warn?.(
+      `Bound media ${id} but failed to sync inventory thumbnail: ${
+        e?.message ?? e
+      }`
+    )
+  }
+
   // --- stamp display back-reference on the media file ---
   await mediaService.updateMediaFiles({
     id,
@@ -175,6 +216,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     raw_material: { ...raw, media: nextMedia },
     inventory_item_id: createdInventoryItemId ?? body.inventory_item_id ?? null,
     sku: appliedSku,
+    inventory_thumbnail: syncedInventoryThumbnail,
   })
 }
 

--- a/apps/backend/src/utils/__tests__/inventory-thumbnail-decision.unit.spec.ts
+++ b/apps/backend/src/utils/__tests__/inventory-thumbnail-decision.unit.spec.ts
@@ -1,0 +1,41 @@
+import { pickInventoryThumbnail } from "../inventory-thumbnail-decision"
+
+const URL_A = "https://cdn.example.com/a.jpg"
+const URL_B = "https://cdn.example.com/b.jpg"
+
+describe("pickInventoryThumbnail", () => {
+  it("returns the first media url when the inventory item has no thumbnail", () => {
+    expect(pickInventoryThumbnail(null, { files: [URL_A] })).toBe(URL_A)
+    expect(pickInventoryThumbnail(undefined, { files: [URL_A, URL_B] })).toBe(
+      URL_A
+    )
+    expect(pickInventoryThumbnail("", [URL_A])).toBe(URL_A)
+    expect(pickInventoryThumbnail("   ", [{ url: URL_A }])).toBe(URL_A)
+  })
+
+  it("returns undefined when the media blob yields no usable url", () => {
+    expect(pickInventoryThumbnail(null, undefined)).toBeUndefined()
+    expect(pickInventoryThumbnail(null, { files: [] })).toBeUndefined()
+    expect(pickInventoryThumbnail(null, {})).toBeUndefined()
+  })
+
+  it("is idempotent — skips when the thumbnail already equals the media url", () => {
+    expect(pickInventoryThumbnail(URL_A, { files: [URL_A] })).toBeUndefined()
+    // tolerant of surrounding whitespace on the stored thumbnail
+    expect(pickInventoryThumbnail(`  ${URL_A}  `, { files: [URL_A] })).toBeUndefined()
+  })
+
+  it("does not clobber a different, manually-set thumbnail by default", () => {
+    expect(pickInventoryThumbnail(URL_B, { files: [URL_A] })).toBeUndefined()
+  })
+
+  it("replaces a different thumbnail only when overwrite is requested", () => {
+    expect(
+      pickInventoryThumbnail(URL_B, { files: [URL_A] }, { overwrite: true })
+    ).toBe(URL_A)
+    // still idempotent under overwrite when already equal
+    expect(
+      pickInventoryThumbnail(URL_A, { files: [URL_A] }, { overwrite: true })
+    ).toBeUndefined()
+  })
+})

--- a/apps/backend/src/utils/inventory-thumbnail-decision.ts
+++ b/apps/backend/src/utils/inventory-thumbnail-decision.ts
@@ -1,0 +1,39 @@
+import { firstMediaUrl } from "./first-media-url"
+
+/**
+ * Decide whether to mirror a raw material's primary image onto its linked
+ * inventory item's `thumbnail`, returning the url to set or `undefined` to skip.
+ *
+ * Used by the manual photo→raw-material bind route (#730/#737), whose append
+ * path writes `raw_materials.media` directly — bypassing the create/update
+ * workflows that run `syncInventoryThumbnailStep` (#739) — so the linked
+ * inventory item's thumbnail would otherwise stay null until the #457 backfill.
+ *
+ * Decision (reuses {@link firstMediaUrl} for shape parsing — no new parser):
+ *  - skip when the media blob yields no usable url
+ *  - skip when the inventory item already shows that exact url (idempotent)
+ *  - by default skip when the item already has a (different) thumbnail so a
+ *    manually-set image is never clobbered; pass `overwrite: true` to replace it
+ */
+export function pickInventoryThumbnail(
+  current: unknown,
+  media: unknown,
+  opts: { overwrite?: boolean } = {}
+): string | undefined {
+  const url = firstMediaUrl(media)
+  if (!url) {
+    return undefined
+  }
+
+  const hasCurrent = typeof current === "string" && current.trim().length > 0
+  if (hasCurrent) {
+    if ((current as string).trim() === url) {
+      return undefined // already points at this image — idempotent no-op
+    }
+    if (!opts.overwrite) {
+      return undefined // don't clobber a manually-set thumbnail
+    }
+  }
+
+  return url
+}


### PR DESCRIPTION
## What & why

Closes the #730 loop with merged #737 (manual photo→raw-material bind) + #739 (`syncInventoryThumbnailStep`).

**Problem:** #737's bind path (`POST /admin/medias/file/:id/raw-material`) appends the photo URL into `raw_materials.media` **directly** (read-modify-write), bypassing the create/update raw-material workflows that run #739's `syncInventoryThumbnailStep`. So a freshly-bound photo showed on the raw material, but the linked `inventory_item.thumbnail` stayed `null` until the #457 backfill ran — admin inventory table + storefront showed nothing.

**Fix:** after the idempotent media append, resolve the linked inventory item (the handler's `inventory_item_id` when provided, else via the `inventory_item_raw_materials` link filtered by `raw_materials_id`) and mirror the bound photo onto its `thumbnail`.

## Design
- Reuses `firstMediaUrl` (no new media-shape parser) via a small pure `pickInventoryThumbnail(current, media, { overwrite })` decision helper.
- Sets only when the item has **no** thumbnail — won't clobber a manually-set one; idempotent when already equal.
- **Best-effort:** a sync failure is logged (`logger.warn`) and never fails the bind.
- The **create-new path** already syncs via `createRawMaterialWorkflow` (#739) — this re-runs idempotently (no-op).
- Unbind path intentionally unchanged — leaving a stale thumbnail on unbind is an accepted follow-up.

## Tests
- Unit: `pickInventoryThumbnail` — 5 cases (set-when-empty, no-url, idempotent, no-clobber, overwrite).
- Integration (`media-bind-raw-material.spec.ts`): bind resolves inventory via link & sets thumbnail; existing thumbnail left unchanged. **8/8 green.**
- `tsc --noEmit` clean for changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)