### PR TITLE
fix(ci): scope analytics deploy install (fixes isolated-vm build failure)

### DIFF
--- a/.github/workflows/deploy-analytics.yml
+++ b/.github/workflows/deploy-analytics.yml
@@ -36,7 +36,12 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        # Scope to the analytics workspace only. A full install builds the
+        # backend's isolated-vm (it's in onlyBuiltDependencies, so no prebuild)
+        # from source, which fails on this Node 20 runner — isolated-vm@6.1.x
+        # needs Node 22+'s V8 (v8::SourceLocation). Analytics is pure JS
+        # (terser), so it needs none of the backend's native deps.
+        run: pnpm install --frozen-lockfile --filter @jyt/analytics
 
       - name: Build analytics script
         run: pnpm --filter @jyt/analytics build


### PR DESCRIPTION
## Problem
The **Deploy Analytics Script to CDN** workflow has failed since the #743 merge. Root cause in the `Install dependencies` step:
```
node_modules/isolated-vm install: 'SourceLocation' in namespace 'v8' does not name a type
gyp ERR! build error
```
The workflow runs `pnpm install --frozen-lockfile` over the **full workspace** on a **Node 20** runner. That builds the backend's `isolated-vm` from source (it's in `pnpm.onlyBuiltDependencies`, so no prebuild). `isolated-vm@6.1.x` needs **Node 22+**'s V8 (`v8::SourceLocation`), so it fails to compile. The break was *surfaced* (not caused) by my lockfile change — the workflow triggers on `pnpm-lock.yaml` changes.

## Fix
Analytics is a standalone Terser-minified script (`@jyt/analytics`, deps: `rimraf` + `terser`) and needs **none** of the backend's native modules. Scope the install:
```diff
- run: pnpm install --frozen-lockfile
+ run: pnpm install --frozen-lockfile --filter @jyt/analytics
```
So `isolated-vm` is never installed or built on this runner.

## Verified
Locally, `pnpm install --frozen-lockfile --filter @jyt/analytics` completes in ~2s without compiling isolated-vm. Merging re-triggers the workflow (it runs on its own file changing), which will confirm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)