### PR TITLE
feat(store-mcp): cart→checkout write tools, store-first discovery, PayU INR payments

### DIFF
--- a/apps/backend/integration-tests/http/store-mcp/store-mcp-multistore.spec.ts
+++ b/apps/backend/integration-tests/http/store-mcp/store-mcp-multistore.spec.ts
@@ -118,6 +118,42 @@ setupSharedTestSuite(() => {
       expect(found.publishable_key).toBe(publishableKey)
     })
 
+    it("list_stores includes the platform core/default store (is_default)", async () => {
+      // The shared env seeds a default (non-partner) store via createDefaultsWorkflow.
+      await fullSetup(api, getContainer)
+
+      const res = await api.post(
+        "/mcp",
+        rpc("tools/call", { name: "list_stores", arguments: {} }),
+        { headers: MCP_HEADERS }
+      )
+      expect(res.status).toBe(200)
+      expect(res.data?.result?.isError).toBeFalsy()
+
+      const payload = JSON.parse(res.data.result.content[0].text)
+      const def = payload.stores.find((s: any) => s.is_default === true)
+      expect(def).toBeTruthy()
+      expect(typeof def.store_id).toBe("string")
+      // Apex domain is attached (defaults to cicilabel.com / ROOT_DOMAIN).
+      expect(typeof def.domain === "string" || def.domain === null).toBe(true)
+    })
+
+    it("get_storefront_key resolves the core store via 'default'", async () => {
+      await fullSetup(api, getContainer)
+
+      const res = await api.post(
+        "/mcp",
+        rpc("tools/call", { name: "get_storefront_key", arguments: { store: "default" } }),
+        { headers: MCP_HEADERS }
+      )
+      expect(res.status).toBe(200)
+      expect(res.data?.result?.isError).toBeFalsy()
+
+      const info = JSON.parse(res.data.result.content[0].text)
+      expect(info.is_default).toBe(true)
+      expect(typeof info.store_id).toBe("string")
+    })
+
     it("get_storefront_key resolves the publishable key by handle", async () => {
       const { partner, publishableKey } = await fullSetup(api, getContainer)
 

--- a/apps/backend/integration-tests/http/store-mcp/store-mcp-multistore.spec.ts
+++ b/apps/backend/integration-tests/http/store-mcp/store-mcp-multistore.spec.ts
@@ -136,6 +136,11 @@ setupSharedTestSuite(() => {
       expect(typeof def.store_id).toBe("string")
       // Apex domain is attached (defaults to cicilabel.com / ROOT_DOMAIN).
       expect(typeof def.domain === "string" || def.domain === null).toBe(true)
+      // Store-first assembly carries the rich fields from the `store` entity.
+      expect(def).toHaveProperty("default_region_id")
+      expect(def).toHaveProperty("currency_code")
+      // Core/default store(s) are sorted first.
+      expect(payload.stores[0].is_default).toBe(true)
     })
 
     it("get_storefront_key resolves the core store via 'default'", async () => {

--- a/apps/backend/integration-tests/http/store-mcp/store-mcp-payu-live.spec.ts
+++ b/apps/backend/integration-tests/http/store-mcp/store-mcp-payu-live.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * LIVE PayU end-to-end test through the MCP. Opt-in only:
+ *   PAYU_LIVE_TEST=1 pnpm test:integration:http:shared \
+ *     ./integration-tests/http/store-mcp/store-mcp-payu-live.spec.ts
+ *
+ * Requires the PayU provider registered (medusa-config registers it when
+ * PAYU_MERCHANT_KEY is set) and, for the payment link, the OneAPI test creds
+ * (PAYU_CLIENT_ID/SECRET/MERCHANT_ID, PAYU_ONEAPI_MODE=test). Hits REAL PayU
+ * test endpoints, so it is skipped unless PAYU_LIVE_TEST is set.
+ */
+import { Modules } from "@medusajs/utils"
+import { createAdminUser, getAuthHeaders } from "../../helpers/create-admin-user"
+import { createTestCustomer } from "../../helpers/create-customer"
+import { getSharedTestEnv, setupSharedTestSuite } from "../shared-test-setup"
+
+jest.setTimeout(180000)
+
+const MCP_HEADERS = {
+  "Content-Type": "application/json",
+  Accept: "application/json, text/event-stream",
+}
+const rpc = (method: string, params: Record<string, unknown>, id = 1) => ({
+  jsonrpc: "2.0",
+  id,
+  method,
+  params,
+})
+
+const RUN = !!process.env.PAYU_LIVE_TEST
+const d = RUN ? describe : describe.skip
+
+setupSharedTestSuite(() => {
+  d("Store MCP — LIVE PayU flow (cart → UPI intent + payment link)", () => {
+    const { api, getContainer } = getSharedTestEnv()
+
+    let pk: string
+    let regionId: string
+    let variantId: string
+
+    const callTool = async (name: string, args: Record<string, unknown>) => {
+      const res = await api.post(
+        "/store/mcp",
+        rpc("tools/call", { name, arguments: args }),
+        { headers: { ...MCP_HEADERS, "x-publishable-api-key": pk } }
+      )
+      expect(res.status).toBe(200)
+      const text = res.data?.result?.content?.[0]?.text
+      if (res.data?.result?.isError) {
+        throw new Error(`${name} in-band error: ${text}`)
+      }
+      return JSON.parse(text)
+    }
+
+    beforeEach(async () => {
+      process.env.STORE_MCP_ENABLE_WRITE = "true"
+      const container = getContainer()
+      await createAdminUser(container)
+      const adminHeaders = await getAuthHeaders(api)
+      const { apiKey } = await createTestCustomer(container)
+      pk = apiKey.token
+
+      // Default sales channel the publishable key is linked to.
+      const storeService: any = container.resolve(Modules.STORE)
+      const store = (await storeService.listStores({}))?.[0]
+      const salesChannelId = store?.default_sales_channel_id
+
+      // INR region with the PayU provider enabled.
+      const region = await api.post(
+        "/admin/regions",
+        { name: "India", currency_code: "inr", countries: ["in"], payment_providers: ["pp_payu_payu"] },
+        adminHeaders
+      )
+      regionId = region.data.region.id
+
+      // A published INR product in the key's sales channel.
+      const product = await api.post(
+        "/admin/products",
+        {
+          title: `PayU Live Test ${Date.now()}`,
+          status: "published",
+          sales_channels: [{ id: salesChannelId }],
+          options: [{ title: "Size", values: ["M"] }],
+          variants: [
+            {
+              title: "M",
+              options: { Size: "M" },
+              prices: [{ amount: 499, currency_code: "inr" }],
+              manage_inventory: false,
+            },
+          ],
+        },
+        adminHeaders
+      )
+      variantId = product.data.product.variants[0].id
+    })
+
+    afterEach(() => {
+      delete process.env.STORE_MCP_ENABLE_WRITE
+    })
+
+    it("create_cart → initialize PayU session → payu_generate_upi_intent → upi://pay link", async () => {
+      const cart = await callTool("create_cart", {
+        region_id: regionId,
+        email: "buyer@jyt.test",
+        items: [{ variant_id: variantId, quantity: 1 }],
+      })
+      const cartId = cart.cart.id
+      expect(cartId).toBeTruthy()
+
+      const coll = await callTool("create_payment_collection", { cart_id: cartId })
+      const collId = coll.payment_collection.id
+
+      const init = await callTool("initialize_payment_session", {
+        id: collId,
+        provider_id: "pp_payu_payu",
+      })
+      // PayU initiate returns the hosted fields; next_action is a redirect_form.
+      expect(init.next_action?.provider).toBe("payu")
+
+      const intent = await callTool("payu_generate_upi_intent", { cart_id: cartId })
+      // eslint-disable-next-line no-console
+      console.log("[payu-live] UPI intent:", intent.upi_link)
+      expect(typeof intent.upi_link).toBe("string")
+      expect(intent.upi_link).toMatch(/^upi:\/\/pay\?/)
+    })
+
+    it("create_payment_link({cart_id}) → shareable v.payu.in link", async () => {
+      if (!process.env.PAYU_CLIENT_ID) {
+        // eslint-disable-next-line no-console
+        console.log("[payu-live] skipping payment link — no PAYU_CLIENT_ID")
+        return
+      }
+      const cart = await callTool("create_cart", {
+        region_id: regionId,
+        email: "buyer@jyt.test",
+        items: [{ variant_id: variantId, quantity: 1 }],
+      })
+      const link = await callTool("create_payment_link", { cart_id: cart.cart.id })
+      // eslint-disable-next-line no-console
+      console.log("[payu-live] payment link:", link.payment_link)
+      expect(typeof link.payment_link).toBe("string")
+      expect(link.payment_link).toMatch(/payu\.in/)
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/store-mcp/store-mcp-write.spec.ts
+++ b/apps/backend/integration-tests/http/store-mcp/store-mcp-write.spec.ts
@@ -1,0 +1,150 @@
+import { Modules } from "@medusajs/utils"
+import { createTestCustomer } from "../../helpers/create-customer"
+import { getSharedTestEnv, setupSharedTestSuite } from "../shared-test-setup"
+
+jest.setTimeout(120000)
+
+const MCP_HEADERS = {
+  "Content-Type": "application/json",
+  Accept: "application/json, text/event-stream",
+}
+
+const rpc = (method: string, params: Record<string, unknown>, id = 1) => ({
+  jsonrpc: "2.0",
+  id,
+  method,
+  params,
+})
+
+/** Call a tool on the gated mount and return the parsed text payload (or throw on in-band error). */
+const callTool = async (
+  api: any,
+  publishableKey: string,
+  name: string,
+  args: Record<string, unknown>
+) => {
+  const res = await api.post(
+    "/store/mcp",
+    rpc("tools/call", { name, arguments: args }),
+    { headers: { ...MCP_HEADERS, "x-publishable-api-key": publishableKey } }
+  )
+  expect(res.status).toBe(200)
+  if (res.data?.result?.isError) {
+    throw new Error(
+      `${name} returned in-band error: ${res.data.result.content?.[0]?.text}`
+    )
+  }
+  return JSON.parse(res.data.result.content[0].text)
+}
+
+setupSharedTestSuite(() => {
+  describe("Store MCP server — write (cart/checkout) tools", () => {
+    const { api, getContainer } = getSharedTestEnv()
+
+    let publishableKey: string
+    let regionId: string
+
+    beforeEach(async () => {
+      const { apiKey } = await createTestCustomer(getContainer())
+      publishableKey = apiKey.token
+      // The shared env doesn't seed a region; create one so cart/pricing context
+      // is well-defined (mirrors convert-design-order.spec.ts).
+      const regionService = getContainer().resolve(Modules.REGION) as any
+      const region = await regionService.createRegions({
+        name: "MCP Test Region",
+        currency_code: "usd",
+        countries: ["us"],
+      })
+      regionId = region.id
+    })
+
+    afterEach(() => {
+      delete process.env.STORE_MCP_ENABLE_WRITE
+    })
+
+    it("hides write tools from tools/list when STORE_MCP_ENABLE_WRITE is off", async () => {
+      delete process.env.STORE_MCP_ENABLE_WRITE
+      const res = await api.post("/mcp", rpc("tools/list", {}), {
+        headers: MCP_HEADERS,
+      })
+      expect(res.status).toBe(200)
+      const names = (res.data?.result?.tools ?? []).map((t: any) => t.name)
+      // Read tools are still present...
+      expect(names).toContain("list_products")
+      // ...but every write tool is hidden.
+      expect(names).not.toContain("create_cart")
+      expect(names).not.toContain("complete_cart")
+      expect(names).not.toContain("add_line_item")
+    })
+
+    it("rejects a write tool call with an in-band error when writes are off", async () => {
+      delete process.env.STORE_MCP_ENABLE_WRITE
+      const res = await api.post(
+        "/store/mcp",
+        rpc("tools/call", { name: "create_cart", arguments: {} }),
+        { headers: { ...MCP_HEADERS, "x-publishable-api-key": publishableKey } }
+      )
+      expect(res.status).toBe(200)
+      expect(res.data?.result?.isError).toBe(true)
+      expect(res.data.result.content[0].text).toMatch(/STORE_MCP_ENABLE_WRITE/)
+    })
+
+    it("exposes write tools in tools/list when STORE_MCP_ENABLE_WRITE is on", async () => {
+      process.env.STORE_MCP_ENABLE_WRITE = "true"
+      const res = await api.post("/mcp", rpc("tools/list", {}), {
+        headers: MCP_HEADERS,
+      })
+      expect(res.status).toBe(200)
+      const names = (res.data?.result?.tools ?? []).map((t: any) => t.name)
+      for (const t of [
+        "create_cart",
+        "get_cart",
+        "add_line_item",
+        "update_cart",
+        "list_shipping_options",
+        "add_shipping_method",
+        "list_payment_providers",
+        "create_payment_collection",
+        "initialize_payment_session",
+        "complete_cart",
+      ]) {
+        expect(names).toContain(t)
+      }
+    })
+
+    it("create_cart proxies POST /store/carts and returns a cart; get_cart reads it back", async () => {
+      process.env.STORE_MCP_ENABLE_WRITE = "true"
+
+      const created = await callTool(api, publishableKey, "create_cart", {
+        region_id: regionId,
+        email: "mcp-buyer@jyt.test",
+      })
+      expect(typeof created.cart?.id).toBe("string")
+      expect(created.cart.email).toBe("mcp-buyer@jyt.test")
+
+      const fetched = await callTool(api, publishableKey, "get_cart", {
+        id: created.cart.id,
+      })
+      expect(fetched.cart?.id).toBe(created.cart.id)
+    })
+
+    it("list_payment_providers is wired for a region (checkout read tool)", async () => {
+      process.env.STORE_MCP_ENABLE_WRITE = "true"
+
+      const res = await api.post(
+        "/store/mcp",
+        rpc("tools/call", {
+          name: "list_payment_providers",
+          arguments: { region_id: regionId },
+        }),
+        { headers: { ...MCP_HEADERS, "x-publishable-api-key": publishableKey } }
+      )
+      // 200 envelope; provider list may be empty if none configured, but it must
+      // not HTTP-500 and must return a valid payload shape.
+      expect(res.status).toBe(200)
+      expect(res.data?.result?.isError).toBeFalsy()
+      const payload = JSON.parse(res.data.result.content[0].text)
+      expect(Array.isArray(payload.payment_providers)).toBe(true)
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/store-mcp/store-mcp-write.spec.ts
+++ b/apps/backend/integration-tests/http/store-mcp/store-mcp-write.spec.ts
@@ -107,9 +107,60 @@ setupSharedTestSuite(() => {
         "create_payment_collection",
         "initialize_payment_session",
         "complete_cart",
+        "payu_complete_payment",
+        "payu_refresh_payment",
       ]) {
         expect(names).toContain(t)
       }
+    })
+
+    it("PayU tools are gated with the rest of the write surface", async () => {
+      delete process.env.STORE_MCP_ENABLE_WRITE
+      const res = await api.post("/mcp", rpc("tools/list", {}), {
+        headers: MCP_HEADERS,
+      })
+      const names = (res.data?.result?.tools ?? []).map((t: any) => t.name)
+      expect(names).not.toContain("payu_complete_payment")
+      expect(names).not.toContain("payu_refresh_payment")
+    })
+
+    it("payu_refresh_payment is wired and proxies POST /store/payu/refresh", async () => {
+      process.env.STORE_MCP_ENABLE_WRITE = "true"
+
+      const created = await callTool(api, publishableKey, "create_cart", {
+        region_id: regionId,
+        email: "payu-buyer@jyt.test",
+      })
+      const cartId = created.cart.id
+
+      // No PayU collection exists yet, but the route + workflow run and return a
+      // 200 message (refresh is a no-op reset). The MCP layer never HTTP-500s.
+      const res = await api.post(
+        "/store/mcp",
+        rpc("tools/call", {
+          name: "payu_refresh_payment",
+          arguments: { cart_id: cartId },
+        }),
+        { headers: { ...MCP_HEADERS, "x-publishable-api-key": publishableKey } }
+      )
+      expect(res.status).toBe(200)
+      expect(Array.isArray(res.data?.result?.content)).toBe(true)
+    })
+
+    it("payu_complete_payment requires cart_id (validation surfaces in-band)", async () => {
+      process.env.STORE_MCP_ENABLE_WRITE = "true"
+      const res = await api.post(
+        "/store/mcp",
+        rpc("tools/call", {
+          name: "payu_complete_payment",
+          arguments: { payu_status: "success" },
+        }),
+        { headers: { ...MCP_HEADERS, "x-publishable-api-key": publishableKey } }
+      )
+      // Missing `cart_id` → the /store/payu/complete route 400s, which the proxy
+      // surfaces as an in-band MCP error (never a transport-level HTTP 500).
+      expect(res.status).toBe(200)
+      expect(res.data?.result?.isError).toBe(true)
     })
 
     it("create_cart proxies POST /store/carts and returns a cart; get_cart reads it back", async () => {

--- a/apps/backend/integration-tests/http/store-mcp/store-mcp-write.spec.ts
+++ b/apps/backend/integration-tests/http/store-mcp/store-mcp-write.spec.ts
@@ -107,6 +107,7 @@ setupSharedTestSuite(() => {
         "create_payment_collection",
         "initialize_payment_session",
         "complete_cart",
+        "create_payment_link",
         "payu_generate_upi_intent",
         "payu_complete_payment",
         "payu_refresh_payment",

--- a/apps/backend/integration-tests/http/store-mcp/store-mcp-write.spec.ts
+++ b/apps/backend/integration-tests/http/store-mcp/store-mcp-write.spec.ts
@@ -107,6 +107,7 @@ setupSharedTestSuite(() => {
         "create_payment_collection",
         "initialize_payment_session",
         "complete_cart",
+        "payu_generate_upi_intent",
         "payu_complete_payment",
         "payu_refresh_payment",
       ]) {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -247,35 +247,46 @@ module.exports = defineConfig({
     //     ],
     //   },
     // },
-    // {
-    //   resolve: "@medusajs/medusa/payment",
-    //   options: {
-    //     providers: [
-    //       {
-    //         resolve: "@medusajs/medusa/payment-stripe",
-    //         id: "stripe",
-    //         options: {
-    //           apiKey: process.env.STRIPE_API_KEY,
-    //           webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
-    //         },
-    //       },
-    //       ...(process.env.PAYU_MERCHANT_KEY
-    //         ? [
-    //             {
-    //               resolve: "./src/modules/payu-payment",
-    //               id: "payu",
-    //               options: {
-    //                 merchant_key: process.env.PAYU_MERCHANT_KEY,
-    //                 merchant_salt: process.env.PAYU_MERCHANT_SALT,
-    //                 mode: process.env.PAYU_MODE || "test",
-    //                 auto_capture: true,
-    //               },
-    //             },
-    //           ]
-    //         : []),
-    //     ],
-    //   },
-    // },
+    // Payment module: register providers only when their creds are present, so
+    // dev/test stay clean without keys (mirrors medusa-config.prod.ts). The
+    // built-in system provider (pp_system_default) is always available.
+    ...(process.env.STRIPE_API_KEY || process.env.PAYU_MERCHANT_KEY
+      ? [
+          {
+            resolve: "@medusajs/medusa/payment",
+            options: {
+              providers: [
+                ...(process.env.STRIPE_API_KEY
+                  ? [
+                      {
+                        resolve: "@medusajs/medusa/payment-stripe",
+                        id: "stripe",
+                        options: {
+                          apiKey: process.env.STRIPE_API_KEY,
+                          webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
+                        },
+                      },
+                    ]
+                  : []),
+                ...(process.env.PAYU_MERCHANT_KEY
+                  ? [
+                      {
+                        resolve: "./src/modules/payu-payment",
+                        id: "payu",
+                        options: {
+                          merchant_key: process.env.PAYU_MERCHANT_KEY,
+                          merchant_salt: process.env.PAYU_MERCHANT_SALT,
+                          mode: process.env.PAYU_MODE || "test",
+                          auto_capture: true,
+                        },
+                      },
+                    ]
+                  : []),
+              ],
+            },
+          },
+        ]
+      : []),
     // {
     //   resolve: "@medusajs/medusa/fulfillment",
     //   options: {

--- a/apps/backend/src/api/mcp/README.md
+++ b/apps/backend/src/api/mcp/README.md
@@ -113,8 +113,11 @@ sales-channel scoping, pricing/tax, and validators still apply.
 `list_payment_providers`, `create_payment_collection`,
 `initialize_payment_session`, `complete_cart`
 
-**PayU (INR):** `payu_generate_upi_intent`, `payu_complete_payment`,
-`payu_refresh_payment` — PayU (`pp_payu_payu`) is a redirect gateway;
+**PayU (INR):** `create_payment_link` (OneAPI shareable `v.payu.in/…` link;
+paying it auto-completes the cart into an order via the verified
+`/webhooks/payu/link` webhook), `payu_generate_upi_intent`,
+`payu_complete_payment`, `payu_refresh_payment` — PayU (`pp_payu_payu`) is a
+redirect gateway;
 `initialize_payment_session` returns the `payment_url`/`hash`/`txnid` a browser
 posts to PayU's page, then `payu_complete_payment` finishes the order from the
 redirect callback (use it instead of `complete_cart`). `payu_generate_upi_intent`

--- a/apps/backend/src/api/mcp/README.md
+++ b/apps/backend/src/api/mcp/README.md
@@ -113,11 +113,13 @@ sales-channel scoping, pricing/tax, and validators still apply.
 `list_payment_providers`, `create_payment_collection`,
 `initialize_payment_session`, `complete_cart`
 
-**PayU (INR):** `payu_complete_payment`, `payu_refresh_payment` — PayU
-(`pp_payu_payu`) is a redirect gateway; `initialize_payment_session` returns the
-`payment_url`/`hash`/`txnid` a browser posts to PayU's page, then
-`payu_complete_payment` finishes the order from the redirect callback (use it
-instead of `complete_cart`). See the guide for the full flow + boundaries.
+**PayU (INR):** `payu_generate_upi_intent`, `payu_complete_payment`,
+`payu_refresh_payment` — PayU (`pp_payu_payu`) is a redirect gateway;
+`initialize_payment_session` returns the `payment_url`/`hash`/`txnid` a browser
+posts to PayU's page, then `payu_complete_payment` finishes the order from the
+redirect callback (use it instead of `complete_cart`). `payu_generate_upi_intent`
+turns the session into a `upi://pay` deep link + QR (no redirect, no card). See
+the guide for the full flow + boundaries.
 
 Typical agent flow:
 

--- a/apps/backend/src/api/mcp/README.md
+++ b/apps/backend/src/api/mcp/README.md
@@ -113,6 +113,12 @@ sales-channel scoping, pricing/tax, and validators still apply.
 `list_payment_providers`, `create_payment_collection`,
 `initialize_payment_session`, `complete_cart`
 
+**PayU (INR):** `payu_complete_payment`, `payu_refresh_payment` — PayU
+(`pp_payu_payu`) is a redirect gateway; `initialize_payment_session` returns the
+`payment_url`/`hash`/`txnid` a browser posts to PayU's page, then
+`payu_complete_payment` finishes the order from the redirect callback (use it
+instead of `complete_cart`). See the guide for the full flow + boundaries.
+
 Typical agent flow:
 
 ```

--- a/apps/backend/src/api/mcp/README.md
+++ b/apps/backend/src/api/mcp/README.md
@@ -96,11 +96,38 @@ search with a lexical fallback).
 
 To wrap another store endpoint, add one row to `lib/registry.ts`.
 
+## Write tools (cart & checkout) — opt-in
+
+Off by default. Set `STORE_MCP_ENABLE_WRITE=true` to expose the mutating
+cart → checkout → pay tools (otherwise they're hidden from `tools/list` and
+rejected by `tools/call`). They proxy the matching native `/store` routes, so
+sales-channel scoping, pricing/tax, and validators still apply.
+
+**Cart:** `create_cart`, `get_cart`, `update_cart`, `add_line_item`,
+`update_line_item`, `remove_line_item`, `add_promotion`
+
+**Checkout / pay:** `list_shipping_options`, `add_shipping_method`,
+`list_payment_providers`, `create_payment_collection`,
+`initialize_payment_session`, `complete_cart`
+
+Typical agent flow:
+
+```
+create_cart → add_line_item* → update_cart (email + address)
+→ list_shipping_options → add_shipping_method
+→ list_payment_providers → create_payment_collection
+→ initialize_payment_session → complete_cart   ⇒  { type: "order", order }
+```
+
+Architecture, the full route table, and how to author new tools:
+`apps/docs/notes/STORE_MCP_SERVER_GUIDE.md`.
+
 ## Configuration
 
 | Env var | Purpose |
 |---------|---------|
 | `STORE_MCP_DEFAULT_PUBLISHABLE_KEY` | Optional last-resort key when a call has no `store` arg and no header. Set to the main storefront's public key. |
+| `STORE_MCP_ENABLE_WRITE` | `true`/`1`/`yes` to enable cart & payment write tools. Default off (read-only). |
 | `STORE_MCP_LOOPBACK_URL` | Optional. Override the loopback origin (default: derived from the request, e.g. `http://localhost:9000`). |
 
 ## Layout

--- a/apps/backend/src/api/mcp/README.md
+++ b/apps/backend/src/api/mcp/README.md
@@ -59,12 +59,15 @@ const tools = await mcp.getTools()
 ## Multi-tenant: picking a store
 
 The platform runs many partner storefronts (each = one sales channel + one
-publishable key). Agents work in terms of **store names**, not raw `pk_` tokens:
+publishable key) **plus its own core store** (the apex `cicilabel.com`). Agents
+work in terms of **store names**, not raw `pk_` tokens:
 
 1. `list_stores` → discover storefronts (`handle`, `name`, `domain`, `store_id`,
-   `publishable_key`).
+   `publishable_key`, `is_default`). The platform core store is included with
+   `is_default: true` and listed first.
 2. `get_storefront_key({ store: "acme" })` → resolve a storefront's default key by
-   handle/subdomain or domain.
+   handle/subdomain or domain. Use `{ store: "default" }` (or the apex domain) for
+   the core store.
 3. Pass `store` to any catalog tool — the server resolves it to that store's key:
    ```
    list_products({ store: "acme", q: "saree" })
@@ -128,6 +131,7 @@ Architecture, the full route table, and how to author new tools:
 |---------|---------|
 | `STORE_MCP_DEFAULT_PUBLISHABLE_KEY` | Optional last-resort key when a call has no `store` arg and no header. Set to the main storefront's public key. |
 | `STORE_MCP_ENABLE_WRITE` | `true`/`1`/`yes` to enable cart & payment write tools. Default off (read-only). |
+| `STORE_MCP_DEFAULT_STORE_DOMAIN` | Optional. Apex domain reported for the platform core store. Falls back to `ROOT_DOMAIN`, then `cicilabel.com`. |
 | `STORE_MCP_LOOPBACK_URL` | Optional. Override the loopback origin (default: derived from the request, e.g. `http://localhost:9000`). |
 
 ## Layout

--- a/apps/backend/src/api/mcp/lib/__tests__/payment-next-action.unit.spec.ts
+++ b/apps/backend/src/api/mcp/lib/__tests__/payment-next-action.unit.spec.ts
@@ -1,0 +1,84 @@
+import { paymentNextAction, pickSession } from "../registry"
+
+describe("paymentNextAction — provider normalization", () => {
+  it("PayU → a redirect form with the hosted link and signed fields", () => {
+    const session = {
+      provider_id: "pp_payu_payu",
+      data: {
+        payment_url: "https://test.payu.in/_payment",
+        key: "mkey",
+        txnid: "medusa_123_abcd",
+        amount: "1499.00",
+        productinfo: "Order medusa_123_abcd",
+        firstname: "Asha",
+        email: "asha@example.in",
+        phone: "9999999999",
+        udf1: "ps_1",
+        hash: "deadbeef",
+        currency: "INR",
+        status: "pending",
+      },
+    }
+    const next = paymentNextAction(session)
+    expect(next.type).toBe("redirect_form")
+    expect(next.provider).toBe("payu")
+    expect(next.method).toBe("POST")
+    expect(next.url).toBe("https://test.payu.in/_payment")
+    expect(next.fields.key).toBe("mkey")
+    expect(next.fields.txnid).toBe("medusa_123_abcd")
+    expect(next.fields.hash).toBe("deadbeef")
+    expect(next.fields.amount).toBe("1499.00")
+    expect(next.txnid).toBe("medusa_123_abcd")
+  })
+
+  it("Stripe → the client_secret to collect the card client-side", () => {
+    const session = {
+      provider_id: "pp_stripe_stripe",
+      data: { client_secret: "pi_123_secret_abc", id: "pi_123" },
+    }
+    const next = paymentNextAction(session)
+    expect(next.type).toBe("client_secret")
+    expect(next.provider).toBe("stripe")
+    expect(next.client_secret).toBe("pi_123_secret_abc")
+  })
+
+  it("manual/system → session_ready (no client action)", () => {
+    const next = paymentNextAction({ provider_id: "pp_system_default", data: {} })
+    expect(next.type).toBe("session_ready")
+    expect(next.provider_id).toBe("pp_system_default")
+  })
+
+  it("missing provider data degrades to nulls, never throws", () => {
+    const next = paymentNextAction({ provider_id: "pp_payu_payu" })
+    expect(next.type).toBe("redirect_form")
+    expect(next.url).toBeNull()
+    expect(next.fields.hash).toBeNull()
+  })
+})
+
+describe("pickSession — locate the initialized session on a collection", () => {
+  const data = {
+    payment_collection: {
+      payment_sessions: [
+        { provider_id: "pp_system_default", data: {} },
+        { provider_id: "pp_payu_payu", data: { txnid: "t1" } },
+      ],
+    },
+  }
+
+  it("matches by exact provider_id", () => {
+    expect(pickSession(data, "pp_payu_payu").data.txnid).toBe("t1")
+  })
+
+  it("matches by provider substring (e.g. 'payu')", () => {
+    expect(pickSession(data, "payu").data.txnid).toBe("t1")
+  })
+
+  it("falls back to the last session when nothing matches", () => {
+    expect(pickSession(data, "nope").provider_id).toBe("pp_payu_payu")
+  })
+
+  it("returns null for an empty/absent collection", () => {
+    expect(pickSession({}, "pp_payu_payu")).toBeNull()
+  })
+})

--- a/apps/backend/src/api/mcp/lib/handler.ts
+++ b/apps/backend/src/api/mcp/lib/handler.ts
@@ -14,6 +14,15 @@ import { buildStoreMcpServer } from "./server"
 const PUBLISHABLE_HEADER = "x-publishable-api-key"
 
 /**
+ * Whether mutating cart/checkout tools are enabled. Off by default: the MCP
+ * server is read-only unless STORE_MCP_ENABLE_WRITE is explicitly truthy.
+ */
+function isWriteEnabled(): boolean {
+  const v = (process.env.STORE_MCP_ENABLE_WRITE || "").trim().toLowerCase()
+  return v === "true" || v === "1" || v === "yes"
+}
+
+/**
  * Loopback origin for proxying to /store/* on this same process.
  *
  * Derived from the incoming request by default (`proto://host`), which is
@@ -56,6 +65,7 @@ export async function handleMcpRequest(
     publishableKey,
     bearer,
     container: req.scope,
+    enableWrite: isWriteEnabled(),
   })
 
   const transport = new StreamableHTTPServerTransport({

--- a/apps/backend/src/api/mcp/lib/proxy.ts
+++ b/apps/backend/src/api/mcp/lib/proxy.ts
@@ -13,10 +13,18 @@ import qs from "qs"
 export type ProxyArgs = {
   /** Base origin of this backend, e.g. http://localhost:9000 (no trailing slash). */
   baseUrl: string
+  /** HTTP method. Defaults to GET (read tools). Write tools use POST/DELETE. */
+  method?: "GET" | "POST" | "DELETE"
   /** Store route path with params already substituted, e.g. /store/products/prod_1. */
   path: string
   /** Query params to forward. Arrays are serialized as key[]=a&key[]=b. */
   query?: Record<string, unknown>
+  /**
+   * JSON request body for write tools (POST/DELETE). Sent as application/json.
+   * The store route's own `validateAndTransformBody` validator runs on it, so we
+   * keep the MCP-side schema permissive and let Medusa be the source of truth.
+   */
+  body?: Record<string, unknown>
   /** Publishable key for sales-channel scoping (required by /store/*). */
   publishableKey?: string
   /** Optional customer auth header to forward (reserved for authed tools). */
@@ -27,8 +35,10 @@ export type ProxyError = Error & { status?: number; body?: unknown }
 
 export async function callStoreRoute({
   baseUrl,
+  method = "GET",
   path,
   query,
+  body,
   publishableKey,
   bearer,
 }: ProxyArgs): Promise<unknown> {
@@ -48,7 +58,14 @@ export async function callStoreRoute({
       : `Bearer ${bearer}`
   }
 
-  const resp = await fetch(url, { method: "GET", headers })
+  const init: RequestInit = { method, headers }
+  // Attach a JSON body for writes. GET never carries a body.
+  if (method !== "GET" && body && Object.keys(body).length) {
+    headers["content-type"] = "application/json"
+    init.body = JSON.stringify(body)
+  }
+
+  const resp = await fetch(url, init)
   const text = await resp.text()
 
   let json: any = null

--- a/apps/backend/src/api/mcp/lib/registry.ts
+++ b/apps/backend/src/api/mcp/lib/registry.ts
@@ -71,7 +71,7 @@ const STORE_PROP = {
   store: {
     type: "string",
     description:
-      "Storefront to scope to: a partner handle/subdomain (e.g. 'acme') or its domain. Resolved server-side to that store's default publishable key. Use list_stores to discover. If omitted, falls back to the x-publishable-api-key header or the server default key.",
+      "Storefront to scope to: a partner handle/subdomain (e.g. 'acme') or its domain, or 'default'/the apex domain for the platform core store (cicilabel.com). Resolved server-side to that store's default publishable key. Use list_stores to discover. If omitted, falls back to the x-publishable-api-key header or the server default key.",
   },
 } as const
 
@@ -662,7 +662,7 @@ export const STORE_MCP_TOOLS: McpToolDef[] = [
   {
     name: "list_stores",
     description:
-      "List live storefronts (partner stores) with handle, name, domain, store id, sales channel, and default publishable key. Use this to discover which store to scope catalog queries to.",
+      "List live storefronts with handle, name, domain, store id, sales channel, and default publishable key. Includes the platform's core/default store (is_default=true, e.g. cicilabel.com) and every partner store. Use this to discover which store to scope catalog queries to.",
     native: "list_stores",
     inputSchema: {
       type: "object",
@@ -673,7 +673,7 @@ export const STORE_MCP_TOOLS: McpToolDef[] = [
   {
     name: "get_storefront_key",
     description:
-      "Resolve a storefront's default publishable API key by partner handle/subdomain or domain. Returns { handle, name, domain, store_id, sales_channel_id, publishable_key }. Publishable keys are public storefront keys.",
+      "Resolve a storefront's default publishable API key by partner handle/subdomain or domain, OR the platform core store via 'default'/'main' or its apex domain (cicilabel.com). Returns { handle, name, domain, store_id, sales_channel_id, publishable_key, is_default }. Publishable keys are public storefront keys.",
     native: "get_storefront_key",
     inputSchema: {
       type: "object",

--- a/apps/backend/src/api/mcp/lib/registry.ts
+++ b/apps/backend/src/api/mcp/lib/registry.ts
@@ -49,6 +49,81 @@ export type McpToolDef = {
    * STORE_MCP_ENABLE_WRITE is set. Read tools omit this.
    */
   write?: boolean
+  /**
+   * Optional post-processor applied to a successful proxy response before it is
+   * returned to the agent. Used to normalize provider-specific payloads into an
+   * actionable shape (e.g. the payment `next_action`). Must be pure.
+   */
+  transform?: (data: any, args: Record<string, unknown>) => any
+}
+
+/**
+ * Normalize an initialized payment session into the concrete next step the
+ * client must take, per provider:
+ *  - PayU (INR): a redirect form — POST the signed fields to PayU's hosted page
+ *    (this resolves the "payment link"); finish with payu_complete_payment.
+ *  - Stripe: the client_secret to collect/confirm the card client-side, then
+ *    complete_cart.
+ *  - anything else (manual / system): the session is ready; complete_cart once
+ *    authorized.
+ */
+export const paymentNextAction = (session: any): Record<string, any> => {
+  const providerId: string = session?.provider_id || ""
+  const d: Record<string, any> = session?.data || {}
+
+  if (providerId.includes("payu")) {
+    return {
+      type: "redirect_form",
+      provider: "payu",
+      provider_id: providerId,
+      description:
+        "POST these fields as application/x-www-form-urlencoded to `url` to open PayU's hosted checkout (card/UPI/netbanking). Add your own surl/furl (success/failure return URLs). PayU redirects back signed; finish the order with payu_complete_payment.",
+      method: "POST",
+      url: d.payment_url ?? null,
+      fields: {
+        key: d.key ?? null,
+        txnid: d.txnid ?? null,
+        amount: d.amount ?? null,
+        productinfo: d.productinfo ?? null,
+        firstname: d.firstname ?? null,
+        email: d.email ?? null,
+        phone: d.phone ?? null,
+        udf1: d.udf1 ?? null,
+        hash: d.hash ?? null,
+      },
+      txnid: d.txnid ?? null,
+    }
+  }
+
+  if (providerId.includes("stripe")) {
+    return {
+      type: "client_secret",
+      provider: "stripe",
+      provider_id: providerId,
+      description:
+        "Hand this client_secret to Stripe.js / PaymentSheet on the client to collect and confirm the card, then call complete_cart.",
+      client_secret: d.client_secret ?? null,
+    }
+  }
+
+  return {
+    type: "session_ready",
+    provider_id: providerId || null,
+    description:
+      "Payment session initialized. Once the payment is authorized, call complete_cart.",
+  }
+}
+
+/** Find the just-initialized session (by provider_id) on a payment collection. */
+export const pickSession = (data: any, providerId: unknown): any => {
+  const sessions = data?.payment_collection?.payment_sessions || []
+  const pid = typeof providerId === "string" ? providerId : ""
+  return (
+    sessions.find((s: any) => s?.provider_id === pid) ||
+    sessions.find((s: any) => pid && String(s?.provider_id || "").includes(pid)) ||
+    sessions[sessions.length - 1] ||
+    null
+  )
 }
 
 const PAGINATION_PROPS = {
@@ -431,12 +506,16 @@ const CHECKOUT_WRITE_TOOLS: McpToolDef[] = [
   {
     name: "initialize_payment_session",
     description:
-      "Initialize a payment session on a payment collection for the chosen provider (e.g. 'pp_system_default' or a Stripe provider). Returns the payment collection with the session.",
+      "Initialize a payment session for the chosen provider ('pp_system_default', a Stripe provider, or 'pp_payu_payu' for INR) and resolve the concrete next step. Returns { next_action, payment_collection }: for PayU, next_action is a redirect_form with the hosted payment link (url) + signed fields; for Stripe, a client_secret to collect the card client-side; otherwise session_ready (call complete_cart). For PayU, finish with payu_complete_payment after the redirect.",
     write: true,
     method: "POST",
     path: "/store/payment-collections/:id/payment-sessions",
     pathParams: ["id"],
     bodyParams: ["provider_id", "data"],
+    transform: (data, args) => ({
+      next_action: paymentNextAction(pickSession(data, args.provider_id)),
+      payment_collection: data?.payment_collection ?? data,
+    }),
     inputSchema: {
       type: "object",
       additionalProperties: false,
@@ -452,7 +531,7 @@ const CHECKOUT_WRITE_TOOLS: McpToolDef[] = [
   {
     name: "complete_cart",
     description:
-      "Complete a cart and place the order. Run this last, after a payment session is initialized. Returns { type: 'order', order } on success or { type: 'cart', cart, error } if completion failed.",
+      "Complete a cart and place the order. Run this last, after a payment session is initialized. Returns { type: 'order', order } on success or { type: 'cart', cart, error } if completion failed. NOTE: for PayU/INR (provider pp_payu_payu) use payu_complete_payment instead — PayU needs its redirect-callback data before the cart can complete.",
     write: true,
     method: "POST",
     path: "/store/carts/:id/complete",
@@ -465,6 +544,53 @@ const CHECKOUT_WRITE_TOOLS: McpToolDef[] = [
       properties: {
         id: { type: "string", description: "Cart id (cart_...)." },
         idempotency_key: { type: "string", description: "Optional key to make completion idempotent on retry." },
+        ...STORE_PROP,
+      },
+    },
+  },
+  // --- PayU (INR) — redirect-gateway completion -------------------------
+  // PayU is a redirect/hash gateway: initialize_payment_session(provider_id
+  // "pp_payu_payu") returns session data with { payment_url, key, txnid, hash,
+  // amount, ... } that a BROWSER posts to PayU's hosted page. The shopper pays
+  // there (card/UPI/netbanking) and PayU redirects back with a signed callback.
+  // These two tools finish that flow once the callback fields are known.
+  {
+    name: "payu_complete_payment",
+    description:
+      "Finish a PayU (INR) checkout after the shopper returns from PayU's hosted page. Updates the PayU payment session with the redirect-callback fields and completes the cart. Returns { type: 'order', order_id } on success, or { type: 'cart', error } (collection auto-refreshed for retry) on failure. Use INSTEAD of complete_cart for pp_payu_payu sessions.",
+    write: true,
+    method: "POST",
+    path: "/store/payu/complete",
+    bodyParams: ["cart_id", "payu_status", "mihpayid", "txnid", "hash", "amount"],
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["cart_id"],
+      properties: {
+        cart_id: { type: "string", description: "Cart id (cart_...) being completed." },
+        payu_status: { type: "string", description: "PayU's status from the callback ('success' or a failure value). Non-success just refreshes the collection for retry." },
+        mihpayid: { type: "string", description: "PayU's gateway payment id from the callback." },
+        txnid: { type: "string", description: "The merchant transaction id used to initiate (from the session data)." },
+        hash: { type: "string", description: "PayU's response hash for verification." },
+        amount: { type: "string", description: "Amount reported by PayU in the callback." },
+        ...STORE_PROP,
+      },
+    },
+  },
+  {
+    name: "payu_refresh_payment",
+    description:
+      "Reset a cart's PayU payment collection — deletes stale payment sessions so a fresh PayU session (new txnid + hash) can be initialized for a retry. Use after a failed/abandoned PayU attempt before initializing a new session.",
+    write: true,
+    method: "POST",
+    path: "/store/payu/refresh",
+    bodyParams: ["cart_id"],
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["cart_id"],
+      properties: {
+        cart_id: { type: "string", description: "Cart id (cart_...) to refresh." },
         ...STORE_PROP,
       },
     },

--- a/apps/backend/src/api/mcp/lib/registry.ts
+++ b/apps/backend/src/api/mcp/lib/registry.ts
@@ -673,7 +673,7 @@ export const STORE_MCP_TOOLS: McpToolDef[] = [
   {
     name: "get_storefront_key",
     description:
-      "Resolve a storefront's default publishable API key by partner handle/subdomain or domain, OR the platform core store via 'default'/'main' or its apex domain (cicilabel.com). Returns { handle, name, domain, store_id, sales_channel_id, publishable_key, is_default }. Publishable keys are public storefront keys.",
+      "Resolve a storefront's default publishable API key by partner handle/subdomain or domain, OR the platform core store via 'default'/'main' or its apex domain (cicilabel.com). Returns { handle, name, domain, store_id, sales_channel_id, default_region_id, default_location_id, currency_code, publishable_key, is_default }. Publishable keys are public storefront keys.",
     native: "get_storefront_key",
     inputSchema: {
       type: "object",

--- a/apps/backend/src/api/mcp/lib/registry.ts
+++ b/apps/backend/src/api/mcp/lib/registry.ts
@@ -92,6 +92,9 @@ export const paymentNextAction = (session: any): Record<string, any> => {
         hash: d.hash ?? null,
       },
       txnid: d.txnid ?? null,
+      // If a UPI intent was already generated (payu_generate_upi_intent), surface it.
+      upi_link: d.upi_intent_uri ?? null,
+      upi_hint: "For UPI, call payu_generate_upi_intent to get a upi://pay deep link + QR.",
     }
   }
 
@@ -573,6 +576,32 @@ const CHECKOUT_WRITE_TOOLS: McpToolDef[] = [
         txnid: { type: "string", description: "The merchant transaction id used to initiate (from the session data)." },
         hash: { type: "string", description: "PayU's response hash for verification." },
         amount: { type: "string", description: "Amount reported by PayU in the callback." },
+        ...STORE_PROP,
+      },
+    },
+  },
+  {
+    name: "payu_generate_upi_intent",
+    description:
+      "Generate a UPI Intent (a upi://pay deep link the customer taps in any UPI app) for a cart that already has an initialized PayU session (run create_payment_collection → initialize_payment_session with provider_id 'pp_payu_payu' first). Returns { type:'upi_intent', upi_link, qr_url, txnid }. The order completes via the PayU webhook / payu_complete_payment.",
+    write: true,
+    method: "POST",
+    path: "/store/payu/intent",
+    bodyParams: ["cart_id", "upi_app", "return_url_base"],
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["cart_id"],
+      properties: {
+        cart_id: { type: "string", description: "Cart id (cart_...) with an initialized pp_payu_payu session." },
+        upi_app: {
+          type: "string",
+          description: "Optional UPI app hint: 'phonepe', 'googlepay', 'paytm', or 'genericintent' (default).",
+        },
+        return_url_base: {
+          type: "string",
+          description: "Optional storefront origin for success/failure return URLs (defaults to the owning store's domain).",
+        },
         ...STORE_PROP,
       },
     },

--- a/apps/backend/src/api/mcp/lib/registry.ts
+++ b/apps/backend/src/api/mcp/lib/registry.ts
@@ -27,14 +27,28 @@ export type McpToolDef = {
    * unset and use method/path below.
    */
   native?: "list_stores" | "get_storefront_key"
-  /** Only GET (read-only) endpoints are wrapped (proxy tools). */
-  method?: "GET"
+  /**
+   * HTTP method of the wrapped store route. GET = read tool (always exposed).
+   * POST/DELETE = write tool (cart/checkout), gated behind STORE_MCP_ENABLE_WRITE.
+   */
+  method?: "GET" | "POST" | "DELETE"
   /** Store route path, with `:param` placeholders, e.g. `/store/products/:id`. */
   path?: string
   /** Names of `:param` placeholders that must be supplied as arguments. */
   pathParams?: string[]
   /** Argument keys forwarded to the route as query-string params. */
   queryParams?: string[]
+  /**
+   * Argument keys assembled into the JSON request body (write tools only).
+   * The store route's own validator is the source of truth, so the MCP schema
+   * stays permissive — see proxy.ts.
+   */
+  bodyParams?: string[]
+  /**
+   * Mutating tool: hidden from `tools/list` and rejected by `tools/call` unless
+   * STORE_MCP_ENABLE_WRITE is set. Read tools omit this.
+   */
+  write?: boolean
 }
 
 const PAGINATION_PROPS = {
@@ -140,6 +154,322 @@ const getTool = (
     },
   },
 })
+
+// --- Write-tool helpers -----------------------------------------------
+// A cart/billing/shipping address. Mirrors Medusa's StoreAddAddress — kept
+// loose (all optional) so the store route's validator stays the source of truth.
+const ADDRESS_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    first_name: { type: "string" },
+    last_name: { type: "string" },
+    phone: { type: "string" },
+    company: { type: "string" },
+    address_1: { type: "string" },
+    address_2: { type: "string" },
+    city: { type: "string" },
+    country_code: {
+      type: "string",
+      description: "Two-letter ISO country code, e.g. 'in'.",
+    },
+    province: { type: "string" },
+    postal_code: { type: "string" },
+  },
+} as const
+
+const LINE_ITEM_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["variant_id", "quantity"],
+  properties: {
+    variant_id: { type: "string", description: "Product variant id (variant_...)." },
+    quantity: { type: "integer", minimum: 1, description: "Quantity to add." },
+  },
+} as const
+
+/**
+ * The cart -> checkout -> pay write tools. Every tool here is `write: true`, so
+ * it is hidden/blocked unless STORE_MCP_ENABLE_WRITE is set. Typical agent flow:
+ *
+ *   create_cart -> add_line_item* -> update_cart (email + addresses)
+ *   -> list_shipping_options -> add_shipping_method
+ *   -> list_payment_providers -> create_payment_collection
+ *   -> initialize_payment_session -> complete_cart (=> order)
+ */
+const CHECKOUT_WRITE_TOOLS: McpToolDef[] = [
+  {
+    name: "create_cart",
+    description:
+      "Create a cart in the storefront's sales channel. Optionally seed it with region, email, addresses, line items, and promo codes. Returns the cart (use cart.id for subsequent tools).",
+    write: true,
+    method: "POST",
+    path: "/store/carts",
+    bodyParams: [
+      "region_id",
+      "email",
+      "currency_code",
+      "items",
+      "shipping_address",
+      "billing_address",
+      "promo_codes",
+      "metadata",
+    ],
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        region_id: { type: "string", description: "Region id (reg_...). Defaults to the store's default region." },
+        email: { type: "string", description: "Customer email for the cart." },
+        currency_code: { type: "string", description: "Currency code; defaults to the region currency." },
+        items: { type: "array", items: LINE_ITEM_SCHEMA, description: "Initial line items." },
+        shipping_address: ADDRESS_SCHEMA,
+        billing_address: ADDRESS_SCHEMA,
+        promo_codes: { type: "array", items: { type: "string" }, description: "Promotion codes to apply." },
+        metadata: { type: "object", additionalProperties: true, description: "Custom key-value data." },
+        ...STORE_PROP,
+      },
+    },
+  },
+  {
+    name: "get_cart",
+    description: "Retrieve a cart by id, including line items, totals, and the chosen shipping/payment state.",
+    write: true,
+    method: "GET",
+    path: "/store/carts/:id",
+    pathParams: ["id"],
+    queryParams: ["fields"],
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["id"],
+      properties: {
+        id: { type: "string", description: "Cart id (cart_...)." },
+        ...FIELDS_PROP,
+        ...STORE_PROP,
+      },
+    },
+  },
+  {
+    name: "update_cart",
+    description:
+      "Update a cart's email, region, addresses, or promo codes. Use this to set the customer email and shipping/billing address before checkout.",
+    write: true,
+    method: "POST",
+    path: "/store/carts/:id",
+    pathParams: ["id"],
+    bodyParams: ["region_id", "email", "shipping_address", "billing_address", "promo_codes", "metadata"],
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["id"],
+      properties: {
+        id: { type: "string", description: "Cart id (cart_...)." },
+        region_id: { type: "string", description: "Region id (reg_...)." },
+        email: { type: "string", description: "Customer email." },
+        shipping_address: ADDRESS_SCHEMA,
+        billing_address: ADDRESS_SCHEMA,
+        promo_codes: { type: "array", items: { type: "string" }, description: "Promotion codes (replaces existing)." },
+        metadata: { type: "object", additionalProperties: true },
+        ...STORE_PROP,
+      },
+    },
+  },
+  {
+    name: "add_line_item",
+    description: "Add a product variant to a cart. Returns the updated cart.",
+    write: true,
+    method: "POST",
+    path: "/store/carts/:id/line-items",
+    pathParams: ["id"],
+    bodyParams: ["variant_id", "quantity", "metadata"],
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["id", "variant_id", "quantity"],
+      properties: {
+        id: { type: "string", description: "Cart id (cart_...)." },
+        variant_id: { type: "string", description: "Product variant id (variant_...)." },
+        quantity: { type: "integer", minimum: 1, description: "Quantity to add." },
+        metadata: { type: "object", additionalProperties: true },
+        ...STORE_PROP,
+      },
+    },
+  },
+  {
+    name: "update_line_item",
+    description: "Change the quantity of an existing cart line item. Returns the updated cart.",
+    write: true,
+    method: "POST",
+    path: "/store/carts/:id/line-items/:line_id",
+    pathParams: ["id", "line_id"],
+    bodyParams: ["quantity", "metadata"],
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["id", "line_id", "quantity"],
+      properties: {
+        id: { type: "string", description: "Cart id (cart_...)." },
+        line_id: { type: "string", description: "Line item id (item_...)." },
+        quantity: { type: "integer", minimum: 1, description: "New quantity." },
+        metadata: { type: "object", additionalProperties: true },
+        ...STORE_PROP,
+      },
+    },
+  },
+  {
+    name: "remove_line_item",
+    description: "Remove a line item from a cart. Returns the deletion result.",
+    write: true,
+    method: "DELETE",
+    path: "/store/carts/:id/line-items/:line_id",
+    pathParams: ["id", "line_id"],
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["id", "line_id"],
+      properties: {
+        id: { type: "string", description: "Cart id (cart_...)." },
+        line_id: { type: "string", description: "Line item id (item_...)." },
+        ...STORE_PROP,
+      },
+    },
+  },
+  {
+    name: "add_promotion",
+    description: "Apply one or more promotion codes to a cart. Returns the updated cart.",
+    write: true,
+    method: "POST",
+    path: "/store/carts/:id/promotions",
+    pathParams: ["id"],
+    bodyParams: ["promo_codes"],
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["id", "promo_codes"],
+      properties: {
+        id: { type: "string", description: "Cart id (cart_...)." },
+        promo_codes: { type: "array", items: { type: "string" }, description: "Promotion codes to apply." },
+        ...STORE_PROP,
+      },
+    },
+  },
+  {
+    name: "list_shipping_options",
+    description:
+      "List the shipping options available for a cart (call after the cart has a shipping address). Use a returned option id with add_shipping_method.",
+    write: true,
+    method: "GET",
+    path: "/store/shipping-options",
+    queryParams: ["cart_id", "fields"],
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["cart_id"],
+      properties: {
+        cart_id: { type: "string", description: "Cart id (cart_...) to price options for." },
+        ...FIELDS_PROP,
+        ...STORE_PROP,
+      },
+    },
+  },
+  {
+    name: "add_shipping_method",
+    description: "Select a shipping option for a cart. Returns the updated cart with the shipping method and totals.",
+    write: true,
+    method: "POST",
+    path: "/store/carts/:id/shipping-methods",
+    pathParams: ["id"],
+    bodyParams: ["option_id", "data"],
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["id", "option_id"],
+      properties: {
+        id: { type: "string", description: "Cart id (cart_...)." },
+        option_id: { type: "string", description: "Shipping option id (so_...) from list_shipping_options." },
+        data: { type: "object", additionalProperties: true, description: "Optional fulfillment-provider data." },
+        ...STORE_PROP,
+      },
+    },
+  },
+  {
+    name: "list_payment_providers",
+    description: "List the payment providers enabled for a region. Use a returned provider id with initialize_payment_session.",
+    write: true,
+    method: "GET",
+    path: "/store/payment-providers",
+    queryParams: ["region_id", "fields", "limit", "offset"],
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["region_id"],
+      properties: {
+        region_id: { type: "string", description: "Region id (reg_...) — the cart's region." },
+        ...FIELDS_PROP,
+        ...STORE_PROP,
+      },
+    },
+  },
+  {
+    name: "create_payment_collection",
+    description: "Create a payment collection for a cart (the container for its payment sessions). Returns the payment collection.",
+    write: true,
+    method: "POST",
+    path: "/store/payment-collections",
+    bodyParams: ["cart_id"],
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["cart_id"],
+      properties: {
+        cart_id: { type: "string", description: "Cart id (cart_...)." },
+        ...STORE_PROP,
+      },
+    },
+  },
+  {
+    name: "initialize_payment_session",
+    description:
+      "Initialize a payment session on a payment collection for the chosen provider (e.g. 'pp_system_default' or a Stripe provider). Returns the payment collection with the session.",
+    write: true,
+    method: "POST",
+    path: "/store/payment-collections/:id/payment-sessions",
+    pathParams: ["id"],
+    bodyParams: ["provider_id", "data"],
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["id", "provider_id"],
+      properties: {
+        id: { type: "string", description: "Payment collection id (paycol_...)." },
+        provider_id: { type: "string", description: "Payment provider id from list_payment_providers." },
+        data: { type: "object", additionalProperties: true, description: "Optional provider-specific data." },
+        ...STORE_PROP,
+      },
+    },
+  },
+  {
+    name: "complete_cart",
+    description:
+      "Complete a cart and place the order. Run this last, after a payment session is initialized. Returns { type: 'order', order } on success or { type: 'cart', cart, error } if completion failed.",
+    write: true,
+    method: "POST",
+    path: "/store/carts/:id/complete",
+    pathParams: ["id"],
+    bodyParams: ["idempotency_key"],
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["id"],
+      properties: {
+        id: { type: "string", description: "Cart id (cart_...)." },
+        idempotency_key: { type: "string", description: "Optional key to make completion idempotent on retry." },
+        ...STORE_PROP,
+      },
+    },
+  },
+]
 
 export const STORE_MCP_TOOLS: McpToolDef[] = [
   {
@@ -358,4 +688,8 @@ export const STORE_MCP_TOOLS: McpToolDef[] = [
       },
     },
   },
+  // --- Write tools: cart -> checkout -> pay -----------------------------
+  // Gated behind STORE_MCP_ENABLE_WRITE. Each proxies the matching native
+  // Medusa /store route, so the route's validators/pricing/scoping still run.
+  ...CHECKOUT_WRITE_TOOLS,
 ]

--- a/apps/backend/src/api/mcp/lib/registry.ts
+++ b/apps/backend/src/api/mcp/lib/registry.ts
@@ -581,6 +581,49 @@ const CHECKOUT_WRITE_TOOLS: McpToolDef[] = [
     },
   },
   {
+    name: "create_payment_link",
+    description:
+      "Create a shareable PayU payment link (INR) whose checkout offers UPI + cards. Pass cart_id to bill a cart's total (and, once paid, the PayU webhook completes the cart into an order automatically), or pass amount + customer for a standalone link. Returns { type:'payment_link', payment_link, invoice_number }. Requires PayU OneAPI env (PAYU_CLIENT_ID/SECRET/MERCHANT_ID).",
+    write: true,
+    method: "POST",
+    path: "/store/payu/payment-link",
+    bodyParams: [
+      "cart_id",
+      "amount",
+      "description",
+      "customer",
+      "invoice_number",
+      "is_partial_payment_allowed",
+      "success_url",
+      "failure_url",
+      "expiry_date",
+    ],
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        cart_id: { type: "string", description: "Cart to bill (derives amount + customer; paid link auto-completes the order via webhook)." },
+        amount: { type: "number", description: "Amount in INR (major units). Required if no cart_id." },
+        description: { type: "string", description: "Link description shown to the payer." },
+        customer: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            name: { type: "string" },
+            email: { type: "string" },
+            mobileNumber: { type: "string" },
+          },
+        },
+        invoice_number: { type: "string", description: "Optional unique invoice id (≤16 chars; auto-generated otherwise)." },
+        is_partial_payment_allowed: { type: "boolean" },
+        success_url: { type: "string" },
+        failure_url: { type: "string" },
+        expiry_date: { type: "string", description: "Optional ISO expiry timestamp." },
+        ...STORE_PROP,
+      },
+    },
+  },
+  {
     name: "payu_generate_upi_intent",
     description:
       "Generate a UPI Intent (a upi://pay deep link the customer taps in any UPI app) for a cart that already has an initialized PayU session (run create_payment_collection → initialize_payment_session with provider_id 'pp_payu_payu' first). Returns { type:'upi_intent', upi_link, qr_url, txnid }. The order completes via the PayU webhook / payu_complete_payment.",

--- a/apps/backend/src/api/mcp/lib/server.ts
+++ b/apps/backend/src/api/mcp/lib/server.ts
@@ -167,7 +167,9 @@ export function buildStoreMcpServer(ctx: StoreMcpContext): Server {
         publishableKey,
         bearer: ctx.bearer,
       })
-      return textResult(JSON.stringify(data, null, 2))
+      // Optional provider-specific normalization (e.g. payment next_action).
+      const out = def.transform ? def.transform(data, args) : data
+      return textResult(JSON.stringify(out, null, 2))
     } catch (e) {
       const err = e as ProxyError
       return textResult(

--- a/apps/backend/src/api/mcp/lib/server.ts
+++ b/apps/backend/src/api/mcp/lib/server.ts
@@ -33,6 +33,11 @@ export type StoreMcpContext = {
   bearer?: string
   /** Medusa container (req.scope) for native store-resolution tools. */
   container?: any
+  /**
+   * When false (default), mutating cart/checkout tools are hidden from
+   * tools/list and rejected by tools/call. Toggled by STORE_MCP_ENABLE_WRITE.
+   */
+  enableWrite?: boolean
 }
 
 const SERVER_INFO = { name: "jyt-store", version: "0.1.0" } as const
@@ -45,8 +50,13 @@ const textResult = (text: string, isError = false) => ({
 export function buildStoreMcpServer(ctx: StoreMcpContext): Server {
   const server = new Server(SERVER_INFO, { capabilities: { tools: {} } })
 
+  // Write (cart/checkout) tools are only visible/callable when writes are on.
+  const visibleTools = STORE_MCP_TOOLS.filter(
+    (t) => ctx.enableWrite || !t.write
+  )
+
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: STORE_MCP_TOOLS.map((t) => ({
+    tools: visibleTools.map((t) => ({
       name: t.name,
       description: t.description,
       inputSchema: t.inputSchema,
@@ -57,6 +67,13 @@ export function buildStoreMcpServer(ctx: StoreMcpContext): Server {
     const def = STORE_MCP_TOOLS.find((t) => t.name === req.params.name)
     if (!def) {
       return textResult(`Unknown tool: ${req.params.name}`, true)
+    }
+    // Refuse mutating tools unless writes are explicitly enabled on the server.
+    if (def.write && !ctx.enableWrite) {
+      return textResult(
+        `Tool '${def.name}' is a write/checkout tool and is disabled on this server. Set STORE_MCP_ENABLE_WRITE=true to enable cart & payment tools.`,
+        true
+      )
     }
     const args = (req.params.arguments ?? {}) as Record<string, unknown>
 
@@ -132,11 +149,21 @@ export function buildStoreMcpServer(ctx: StoreMcpContext): Server {
       }
     }
 
+    // Assemble the JSON body for write tools from the whitelisted body params.
+    const body: Record<string, unknown> = {}
+    for (const k of def.bodyParams ?? []) {
+      if (args[k] !== undefined && args[k] !== null) {
+        body[k] = args[k]
+      }
+    }
+
     try {
       const data = await callStoreRoute({
         baseUrl: ctx.baseUrl,
+        method: def.method ?? "GET",
         path,
         query,
+        body,
         publishableKey,
         bearer: ctx.bearer,
       })

--- a/apps/backend/src/api/mcp/lib/store-resolver.ts
+++ b/apps/backend/src/api/mcp/lib/store-resolver.ts
@@ -1,12 +1,18 @@
 /**
  * Multi-tenant store resolution for the MCP server.
  *
- * Each partner runs its own storefront: partner -> store -> default sales
- * channel -> a single publishable api_key. These helpers turn a store identity
- * (handle/subdomain or domain) into that storefront's default publishable key,
- * mirroring GET /web/storefront/[subdomain]. They run natively against the
- * container (query.graph) rather than the key-gated /store/* routes, because an
- * agent must be able to ASK for a key without already having one.
+ * The platform runs many partner storefronts (partner -> store -> default sales
+ * channel -> a single publishable api_key) PLUS its own core store (the apex
+ * cicilabel.com store, not linked to any partner). These helpers list every
+ * store and turn a store identity (handle/subdomain, domain, or "default") into
+ * that store's default publishable key.
+ *
+ * It is **store-first**: we enumerate the `store` entity (like core
+ * GET /admin/stores does) and join partner handle/domain on top, so EVERY store
+ * is returned — including the core store that iterating partners alone misses.
+ * Runs natively against the container (query.graph), not the key-gated /store/*
+ * routes, because an agent must be able to ASK for a key without already having
+ * one.
  *
  * Publishable keys are public (shipped as NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY in
  * every storefront), so returning them here leaks nothing not already public.
@@ -14,30 +20,39 @@
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
 export type StorefrontInfo = {
+  /** Partner handle/subdomain, or null for the platform core store. */
   handle: string | null
   name: string | null
   domain: string | null
   store_id: string | null
   store_name: string | null
   sales_channel_id: string | null
+  default_region_id: string | null
+  default_location_id: string | null
+  /** Default currency code (the store's is_default supported currency). */
+  currency_code: string | null
   publishable_key: string | null
   /**
-   * True for the platform's own store(s) — i.e. a store NOT linked to any
-   * partner, whose `sales_channel_id` is the default sales channel. Partner
-   * storefronts are false/omitted.
+   * True for the platform's own store — i.e. a store NOT linked to any partner
+   * (the apex cicilabel.com store). Partner storefronts are false.
    */
-  is_default?: boolean
+  is_default: boolean
 }
 
-const PARTNER_FIELDS = [
-  "handle",
+// Mirrors core defaultAdminStoreFields (api/admin/stores/query-config) so the
+// MCP sees the same rich store shape the admin does.
+const STORE_FIELDS = [
+  "id",
   "name",
-  "storefront_domain",
+  "default_sales_channel_id",
+  "default_region_id",
+  "default_location_id",
+  "supported_currencies.currency_code",
+  "supported_currencies.is_default",
   "metadata",
-  "stores.id",
-  "stores.name",
-  "stores.default_sales_channel_id",
 ]
+
+const PARTNER_FIELDS = ["handle", "name", "storefront_domain", "metadata", "stores.id"]
 
 const normalizeDomain = (s: string): string =>
   s
@@ -48,6 +63,26 @@ const normalizeDomain = (s: string): string =>
 
 const partnerDomain = (p: any): string | null =>
   p?.storefront_domain || p?.metadata?.storefront_domain || null
+
+/**
+ * Apex domain of the platform's own (core) store. Partner storefronts live on
+ * `*.cicilabel.com` subdomains; the bare apex is the core store. Mirrors the
+ * `ROOT_DOMAIN` convention used by the storefront provisioning scripts.
+ */
+const defaultStoreDomain = (): string | null => {
+  const d = (
+    process.env.STORE_MCP_DEFAULT_STORE_DOMAIN ||
+    process.env.ROOT_DOMAIN ||
+    "cicilabel.com"
+  ).trim()
+  return d ? normalizeDomain(d) : null
+}
+
+const defaultCurrency = (store: any): string | null => {
+  const currencies = store?.supported_currencies || []
+  const def = currencies.find((c: any) => c?.is_default) || currencies[0]
+  return def?.currency_code ?? null
+}
 
 /**
  * Build a sales_channel_id -> publishable token map in one query. (api_keys
@@ -73,154 +108,103 @@ async function buildSalesChannelKeyMap(
   return map
 }
 
-/**
- * Apex domain of the platform's own (default) store. Partner storefronts live on
- * `*.cicilabel.com` subdomains; the bare apex is the core store. Mirrors the
- * `ROOT_DOMAIN` convention used by the storefront provisioning scripts.
- */
-const defaultStoreDomain = (): string | null => {
-  const d = (
-    process.env.STORE_MCP_DEFAULT_STORE_DOMAIN ||
-    process.env.ROOT_DOMAIN ||
-    "cicilabel.com"
-  ).trim()
-  return d ? normalizeDomain(d) : null
-}
-
-/** Map a raw `store` row (not partner-owned) to a default StorefrontInfo. */
-const storeRowToInfo = (
-  s: any,
+/** Assemble one StorefrontInfo from a store row + its owning partner (or null). */
+const buildInfo = (
+  store: any,
+  partner: any | null,
   keyMap: Map<string, string>
 ): StorefrontInfo => {
-  const scId = s?.default_sales_channel_id || null
+  const scId = store?.default_sales_channel_id || null
   return {
-    handle: null,
-    name: s?.name ?? null,
-    domain: defaultStoreDomain(),
-    store_id: s?.id ?? null,
-    store_name: s?.name ?? null,
+    handle: partner?.handle ?? null,
+    name: partner?.name ?? store?.name ?? null,
+    domain: partner ? partnerDomain(partner) : defaultStoreDomain(),
+    store_id: store?.id ?? null,
+    store_name: store?.name ?? null,
     sales_channel_id: scId,
+    default_region_id: store?.default_region_id ?? null,
+    default_location_id: store?.default_location_id ?? null,
+    currency_code: defaultCurrency(store),
     publishable_key: scId ? keyMap.get(scId) ?? null : null,
-    is_default: true,
-  }
-}
-
-/** All `store` rows on the platform (partner-owned and the core store alike). */
-async function listAllStoreRows(query: any): Promise<any[]> {
-  const { data } = await query.graph({
-    entity: "stores",
-    fields: ["id", "name", "default_sales_channel_id"],
-  })
-  return data || []
-}
-
-const toInfo = (p: any, keyMap: Map<string, string>): StorefrontInfo | null => {
-  const store = (p?.stores || [])[0]
-  if (!store) {
-    return null
-  }
-  const scId = store.default_sales_channel_id || null
-  return {
-    handle: p.handle ?? null,
-    name: p.name ?? null,
-    domain: partnerDomain(p),
-    store_id: store.id ?? null,
-    store_name: store.name ?? null,
-    sales_channel_id: scId,
-    publishable_key: scId ? keyMap.get(scId) ?? null : null,
+    is_default: !partner,
   }
 }
 
 /**
- * List every live storefront and its default publishable key. Includes both
- * partner storefronts (partner → store) AND the platform's own core store(s) —
- * i.e. any `store` not linked to a partner (e.g. the apex cicilabel.com store),
- * which iterating partners alone would miss. Default store(s) come first.
+ * List every storefront and its default publishable key — store-first, so the
+ * platform core store is always included alongside partner storefronts. The
+ * core/default store(s) come first.
  */
 export async function listStorefronts(
   container: any
 ): Promise<StorefrontInfo[]> {
   const query = container.resolve(ContainerRegistrationKeys.QUERY)
-  const { data: partners } = await query.graph({
-    entity: "partners",
-    fields: PARTNER_FIELDS,
-  })
+  const [{ data: stores }, { data: partners }] = await Promise.all([
+    query.graph({ entity: "stores", fields: STORE_FIELDS }),
+    query.graph({ entity: "partners", fields: PARTNER_FIELDS }),
+  ])
   const keyMap = await buildSalesChannelKeyMap(query)
 
-  const partnerStorefronts = (partners || [])
-    .map((p: any) => toInfo(p, keyMap))
-    .filter((x: StorefrontInfo | null): x is StorefrontInfo => x !== null)
+  // store_id -> owning partner (a store linked to a partner is a partner store).
+  const storeIdToPartner = new Map<string, any>()
+  for (const p of partners || []) {
+    for (const s of p?.stores || []) {
+      if (s?.id) {
+        storeIdToPartner.set(s.id, p)
+      }
+    }
+  }
 
-  // Any store NOT owned by a partner is a platform/default store.
-  const partnerStoreIds = new Set(
-    partnerStorefronts.map((s) => s.store_id).filter(Boolean)
+  const infos = (stores || []).map((s: any) =>
+    buildInfo(s, storeIdToPartner.get(s.id) || null, keyMap)
   )
-  const defaultStores = (await listAllStoreRows(query))
-    .filter((s) => !partnerStoreIds.has(s.id))
-    .map((s) => storeRowToInfo(s, keyMap))
-
-  return [...defaultStores, ...partnerStorefronts]
+  // Core/default store(s) first, then partner storefronts.
+  return infos.sort(
+    (a: StorefrontInfo, b: StorefrontInfo) =>
+      Number(b.is_default) - Number(a.is_default)
+  )
 }
 
 /**
- * Resolve a single storefront by handle (subdomain) or domain.
- * Tries: exact handle -> storefront_domain -> first domain label as handle.
+ * Resolve a single storefront. Matches (in order): partner handle, exact domain,
+ * store id, default sales-channel id, store name, the first domain label as a
+ * handle, then the platform core store via "default"/"main" or the apex domain.
  */
 export async function resolveStorefront(
   container: any,
   identifier: string
 ): Promise<StorefrontInfo | null> {
-  const query = container.resolve(ContainerRegistrationKeys.QUERY)
   const raw = (identifier || "").trim()
   if (!raw) {
     return null
   }
-  const dom = normalizeDomain(raw)
-
-  const byFilter = async (filters: Record<string, unknown>) => {
-    const { data } = await query.graph({
-      entity: "partners",
-      fields: PARTNER_FIELDS,
-      filters,
-    })
-    return (data || [])[0] || null
-  }
-
-  let partner =
-    (await byFilter({ handle: raw })) || (await byFilter({ storefront_domain: dom }))
-
-  if (!partner && dom.includes(".")) {
-    partner = await byFilter({ handle: dom.split(".")[0] })
-  }
-
-  const keyMap = await buildSalesChannelKeyMap(query)
-  if (partner) {
-    return toInfo(partner, keyMap)
-  }
-
-  // No partner matched — try the platform/core store(s). Resolvable by the
-  // "default"/"main" keyword, the apex domain (cicilabel.com), or a store's
-  // name / id / default sales-channel id.
-  const partnerStoreIds = new Set(
-    (
-      await query.graph({ entity: "partners", fields: ["stores.id"] })
-    ).data?.flatMap((p: any) => (p?.stores || []).map((s: any) => s.id)) || []
-  )
-  const defaultRows = (await listAllStoreRows(query)).filter(
-    (s) => !partnerStoreIds.has(s.id)
-  )
   const lower = raw.toLowerCase()
+  const dom = normalizeDomain(raw)
   const apex = defaultStoreDomain()
+
+  const all = await listStorefronts(container)
+
+  const direct = all.find(
+    (s) =>
+      (s.handle && s.handle.toLowerCase() === lower) ||
+      (s.domain && s.domain === dom) ||
+      s.store_id === raw ||
+      s.sales_channel_id === raw ||
+      (s.store_name && s.store_name.toLowerCase() === lower) ||
+      (dom.includes(".") &&
+        s.handle &&
+        s.handle.toLowerCase() === dom.split(".")[0])
+  )
+  if (direct) {
+    return direct
+  }
+
+  // Fall through to the platform core store.
   const isDefaultKeyword = lower === "default" || lower === "main"
   const isApex = !!apex && (dom === apex || lower === apex)
+  if (isDefaultKeyword || isApex) {
+    return all.find((s) => s.is_default) ?? null
+  }
 
-  const match =
-    defaultRows.find(
-      (s) =>
-        s.id === raw ||
-        s.default_sales_channel_id === raw ||
-        (s.name && s.name.toLowerCase() === lower)
-    ) || (isDefaultKeyword || isApex ? defaultRows[0] : undefined)
-
-  return match ? storeRowToInfo(match, keyMap) : null
+  return null
 }

--- a/apps/backend/src/api/mcp/lib/store-resolver.ts
+++ b/apps/backend/src/api/mcp/lib/store-resolver.ts
@@ -166,6 +166,21 @@ export async function listStorefronts(
 }
 
 /**
+ * Resolve the storefront that owns a given sales channel (a cart's
+ * `sales_channel_id`). Used to derive a checkout's return-URL origin.
+ */
+export async function findStorefrontBySalesChannel(
+  container: any,
+  salesChannelId: string | null | undefined
+): Promise<StorefrontInfo | null> {
+  if (!salesChannelId) {
+    return null
+  }
+  const all = await listStorefronts(container)
+  return all.find((s) => s.sales_channel_id === salesChannelId) ?? null
+}
+
+/**
  * Resolve a single storefront. Matches (in order): partner handle, exact domain,
  * store id, default sales-channel id, store name, the first domain label as a
  * handle, then the platform core store via "default"/"main" or the apex domain.

--- a/apps/backend/src/api/mcp/lib/store-resolver.ts
+++ b/apps/backend/src/api/mcp/lib/store-resolver.ts
@@ -21,6 +21,12 @@ export type StorefrontInfo = {
   store_name: string | null
   sales_channel_id: string | null
   publishable_key: string | null
+  /**
+   * True for the platform's own store(s) — i.e. a store NOT linked to any
+   * partner, whose `sales_channel_id` is the default sales channel. Partner
+   * storefronts are false/omitted.
+   */
+  is_default?: boolean
 }
 
 const PARTNER_FIELDS = [
@@ -67,6 +73,47 @@ async function buildSalesChannelKeyMap(
   return map
 }
 
+/**
+ * Apex domain of the platform's own (default) store. Partner storefronts live on
+ * `*.cicilabel.com` subdomains; the bare apex is the core store. Mirrors the
+ * `ROOT_DOMAIN` convention used by the storefront provisioning scripts.
+ */
+const defaultStoreDomain = (): string | null => {
+  const d = (
+    process.env.STORE_MCP_DEFAULT_STORE_DOMAIN ||
+    process.env.ROOT_DOMAIN ||
+    "cicilabel.com"
+  ).trim()
+  return d ? normalizeDomain(d) : null
+}
+
+/** Map a raw `store` row (not partner-owned) to a default StorefrontInfo. */
+const storeRowToInfo = (
+  s: any,
+  keyMap: Map<string, string>
+): StorefrontInfo => {
+  const scId = s?.default_sales_channel_id || null
+  return {
+    handle: null,
+    name: s?.name ?? null,
+    domain: defaultStoreDomain(),
+    store_id: s?.id ?? null,
+    store_name: s?.name ?? null,
+    sales_channel_id: scId,
+    publishable_key: scId ? keyMap.get(scId) ?? null : null,
+    is_default: true,
+  }
+}
+
+/** All `store` rows on the platform (partner-owned and the core store alike). */
+async function listAllStoreRows(query: any): Promise<any[]> {
+  const { data } = await query.graph({
+    entity: "stores",
+    fields: ["id", "name", "default_sales_channel_id"],
+  })
+  return data || []
+}
+
 const toInfo = (p: any, keyMap: Map<string, string>): StorefrontInfo | null => {
   const store = (p?.stores || [])[0]
   if (!store) {
@@ -84,7 +131,12 @@ const toInfo = (p: any, keyMap: Map<string, string>): StorefrontInfo | null => {
   }
 }
 
-/** List every live storefront (partner with a store) and its default key. */
+/**
+ * List every live storefront and its default publishable key. Includes both
+ * partner storefronts (partner → store) AND the platform's own core store(s) —
+ * i.e. any `store` not linked to a partner (e.g. the apex cicilabel.com store),
+ * which iterating partners alone would miss. Default store(s) come first.
+ */
 export async function listStorefronts(
   container: any
 ): Promise<StorefrontInfo[]> {
@@ -94,9 +146,20 @@ export async function listStorefronts(
     fields: PARTNER_FIELDS,
   })
   const keyMap = await buildSalesChannelKeyMap(query)
-  return (partners || [])
+
+  const partnerStorefronts = (partners || [])
     .map((p: any) => toInfo(p, keyMap))
     .filter((x: StorefrontInfo | null): x is StorefrontInfo => x !== null)
+
+  // Any store NOT owned by a partner is a platform/default store.
+  const partnerStoreIds = new Set(
+    partnerStorefronts.map((s) => s.store_id).filter(Boolean)
+  )
+  const defaultStores = (await listAllStoreRows(query))
+    .filter((s) => !partnerStoreIds.has(s.id))
+    .map((s) => storeRowToInfo(s, keyMap))
+
+  return [...defaultStores, ...partnerStorefronts]
 }
 
 /**
@@ -129,10 +192,35 @@ export async function resolveStorefront(
   if (!partner && dom.includes(".")) {
     partner = await byFilter({ handle: dom.split(".")[0] })
   }
-  if (!partner) {
-    return null
-  }
 
   const keyMap = await buildSalesChannelKeyMap(query)
-  return toInfo(partner, keyMap)
+  if (partner) {
+    return toInfo(partner, keyMap)
+  }
+
+  // No partner matched — try the platform/core store(s). Resolvable by the
+  // "default"/"main" keyword, the apex domain (cicilabel.com), or a store's
+  // name / id / default sales-channel id.
+  const partnerStoreIds = new Set(
+    (
+      await query.graph({ entity: "partners", fields: ["stores.id"] })
+    ).data?.flatMap((p: any) => (p?.stores || []).map((s: any) => s.id)) || []
+  )
+  const defaultRows = (await listAllStoreRows(query)).filter(
+    (s) => !partnerStoreIds.has(s.id)
+  )
+  const lower = raw.toLowerCase()
+  const apex = defaultStoreDomain()
+  const isDefaultKeyword = lower === "default" || lower === "main"
+  const isApex = !!apex && (dom === apex || lower === apex)
+
+  const match =
+    defaultRows.find(
+      (s) =>
+        s.id === raw ||
+        s.default_sales_channel_id === raw ||
+        (s.name && s.name.toLowerCase() === lower)
+    ) || (isDefaultKeyword || isApex ? defaultRows[0] : undefined)
+
+  return match ? storeRowToInfo(match, keyMap) : null
 }

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -653,6 +653,14 @@ export default defineMiddlewares({
       bodyParser: false, // Need raw body for Svix signature verification
     },
     {
+      // PayU posts application/x-www-form-urlencoded; preserve the raw body so
+      // the route can parse it (and the reverse-hash uses the exact fields).
+      matcher: "/webhooks/payu/link",
+      method: "POST",
+      middlewares: [],
+      bodyParser: { preserveRawBody: true },
+    },
+    {
       matcher: "/webhooks/meta-ads/leadgen",
       method: "GET",
       middlewares: [],

--- a/apps/backend/src/api/store/payu/intent/__tests__/payu-intent-lib.unit.spec.ts
+++ b/apps/backend/src/api/store/payu/intent/__tests__/payu-intent-lib.unit.spec.ts
@@ -1,0 +1,111 @@
+import {
+  buildUpiIntentForm,
+  buildReturnUrls,
+  findPayuSession,
+  parseUpiIntentResponse,
+} from "../lib"
+
+describe("buildUpiIntentForm", () => {
+  const session = {
+    key: "Shrwii",
+    txnid: "mcp_123",
+    amount: "1.00",
+    productinfo: "Order mcp_123",
+    firstname: "Asha",
+    email: "asha@example.in",
+    phone: "9999999999",
+    udf1: "ps_1",
+    hash: "deadbeef",
+    payment_url: "https://test.payu.in/_payment",
+  }
+
+  it("replays the signed session fields and adds the UPI-intent switches", () => {
+    const f = buildUpiIntentForm(session, { surl: "https://s/ok", furl: "https://s/no" })
+    expect(f.key).toBe("Shrwii")
+    expect(f.txnid).toBe("mcp_123")
+    expect(f.hash).toBe("deadbeef")
+    expect(f.udf1).toBe("ps_1")
+    expect(f.pg).toBe("UPI")
+    expect(f.bankcode).toBe("INTENT")
+    expect(f.txn_s2s_flow).toBe("4")
+    expect(f.surl).toBe("https://s/ok")
+    expect(f.furl).toBe("https://s/no")
+    // sensible defaults so PayU doesn't reject the S2S call
+    expect(f.s2s_client_ip).toBe("127.0.0.1")
+    expect(f.s2s_device_info).toBe("Mozilla/5.0")
+  })
+
+  it("includes upiAppName only when provided, and uses given ip/device", () => {
+    const f = buildUpiIntentForm(session, {
+      surl: "x",
+      furl: "y",
+      clientIp: "1.2.3.4",
+      deviceInfo: "UA/1",
+      upiAppName: "phonepe",
+    })
+    expect(f.upiAppName).toBe("phonepe")
+    expect(f.s2s_client_ip).toBe("1.2.3.4")
+    expect(f.s2s_device_info).toBe("UA/1")
+
+    const f2 = buildUpiIntentForm(session, { surl: "x", furl: "y" })
+    expect(f2.upiAppName).toBeUndefined()
+  })
+})
+
+describe("parseUpiIntentResponse", () => {
+  it("prefixes upi://pay? when intentURIData has no scheme", () => {
+    const p = parseUpiIntentResponse({
+      metaData: { txnStatus: "pending" },
+      result: { paymentId: "403993715537778288", intentURIData: "pa=payu@hdfc&am=1.00&cu=INR" },
+    })
+    expect(p.upi_link).toBe("upi://pay?pa=payu@hdfc&am=1.00&cu=INR")
+    expect(p.payment_id).toBe("403993715537778288")
+    expect(p.txn_status).toBe("pending")
+  })
+
+  it("keeps an already-formed upi:// uri and surfaces a QR url", () => {
+    const p = parseUpiIntentResponse({
+      result: { intentUri: "upi://pay?pa=x", intentUrlWithQR: "https://payu.in/q?qr=1" },
+    })
+    expect(p.upi_link).toBe("upi://pay?pa=x")
+    expect(p.qr_url).toBe("https://payu.in/q?qr=1")
+  })
+
+  it("returns null link when PayU gave no intent data", () => {
+    const p = parseUpiIntentResponse({ status: 0, message: "nope" })
+    expect(p.upi_link).toBeNull()
+    expect(p.qr_url).toBeNull()
+  })
+})
+
+describe("findPayuSession", () => {
+  it("finds the pp_payu session among others", () => {
+    const cart = {
+      payment_collection: {
+        payment_sessions: [
+          { id: "ps_1", provider_id: "pp_system_default" },
+          { id: "ps_2", provider_id: "pp_payu_payu", data: { txnid: "t" } },
+        ],
+      },
+    }
+    expect(findPayuSession(cart)?.id).toBe("ps_2")
+  })
+
+  it("returns null when there is no PayU session / no collection", () => {
+    expect(findPayuSession({ payment_collection: { payment_sessions: [] } })).toBeNull()
+    expect(findPayuSession({})).toBeNull()
+  })
+})
+
+describe("buildReturnUrls", () => {
+  it("builds surl/furl with the cart id and strips a trailing slash", () => {
+    const { surl, furl } = buildReturnUrls("https://acme.cicilabel.com/", "cart_9")
+    expect(surl).toBe("https://acme.cicilabel.com/api/payu/success?cart_id=cart_9")
+    expect(furl).toBe("https://acme.cicilabel.com/api/payu/failure?cart_id=cart_9")
+  })
+
+  it("tolerates a null origin", () => {
+    const { surl } = buildReturnUrls(null, "cart_9")
+    expect(surl).toBe("/api/payu/success?cart_id=cart_9")
+  })
+})

--- a/apps/backend/src/api/store/payu/intent/lib.ts
+++ b/apps/backend/src/api/store/payu/intent/lib.ts
@@ -1,0 +1,111 @@
+/**
+ * Pure helpers for the PayU UPI-Intent route.
+ *
+ * A PayU payment session (created by initiatePayment in the payu-payment
+ * provider) already carries the signed hosted-checkout fields:
+ *   { key, txnid, amount, productinfo, firstname, email, phone, udf1, hash,
+ *     payment_url }
+ * The S2S UPI-Intent call reuses those exact fields (same SHA-512 hash) and
+ * just adds the UPI-intent switches, so we never need the salt here — we replay
+ * the already-signed session data to `payment_url` with `bankcode=INTENT`.
+ */
+
+export type PayuSessionData = {
+  key?: string
+  txnid?: string
+  amount?: string
+  productinfo?: string
+  firstname?: string
+  email?: string
+  phone?: string
+  udf1?: string
+  hash?: string
+  payment_url?: string
+  [k: string]: unknown
+}
+
+export type UpiIntentFormOpts = {
+  surl: string
+  furl: string
+  clientIp?: string
+  deviceInfo?: string
+  /** UPI app hint: phonepe | googlepay | paytm | genericintent (default). */
+  upiAppName?: string
+}
+
+/**
+ * Build the application/x-www-form-urlencoded field map for the S2S UPI-Intent
+ * call. Reuses the session's signed fields verbatim (the hash already covers
+ * key|txnid|amount|productinfo|firstname|email|udf1|…|salt).
+ */
+export function buildUpiIntentForm(
+  d: PayuSessionData,
+  opts: UpiIntentFormOpts
+): Record<string, string> {
+  return {
+    key: d.key ?? "",
+    txnid: d.txnid ?? "",
+    amount: d.amount ?? "",
+    productinfo: d.productinfo ?? "",
+    firstname: d.firstname ?? "",
+    email: d.email ?? "",
+    phone: d.phone ?? "",
+    udf1: d.udf1 ?? "",
+    surl: opts.surl,
+    furl: opts.furl,
+    hash: d.hash ?? "",
+    pg: "UPI",
+    bankcode: "INTENT",
+    txn_s2s_flow: "4",
+    s2s_client_ip: opts.clientIp || "127.0.0.1",
+    s2s_device_info: opts.deviceInfo || "Mozilla/5.0",
+    ...(opts.upiAppName ? { upiAppName: opts.upiAppName } : {}),
+  }
+}
+
+export type ParsedUpiIntent = {
+  upi_link: string | null
+  qr_url: string | null
+  payment_id: string | null
+  txn_status: string | null
+}
+
+/** Normalize PayU's S2S `/_payment` UPI-intent response into a UPI deep link. */
+export function parseUpiIntentResponse(json: any): ParsedUpiIntent {
+  const result = json?.result ?? {}
+  const raw: string | undefined =
+    result.intentURIData ?? result.intentUri ?? result.intentId
+  const upi_link = raw
+    ? raw.startsWith("upi://")
+      ? raw
+      : `upi://pay?${raw}`
+    : null
+  return {
+    upi_link,
+    qr_url: result.intentUrlWithQR ?? null,
+    payment_id: result.paymentId ?? null,
+    txn_status: json?.metaData?.txnStatus ?? json?.status ?? null,
+  }
+}
+
+/** Find the PayU payment session on a cart's payment collection. */
+export function findPayuSession(cart: any): any | null {
+  const sessions = cart?.payment_collection?.payment_sessions || []
+  return (
+    sessions.find((s: any) => String(s?.provider_id || "").includes("payu")) ||
+    null
+  )
+}
+
+/** Build success/failure return URLs from a storefront origin (mirrors storefront). */
+export function buildReturnUrls(
+  origin: string | null | undefined,
+  cartId: string
+): { surl: string; furl: string } {
+  const base = (origin || "").replace(/\/+$/, "")
+  const q = `?cart_id=${encodeURIComponent(cartId)}`
+  return {
+    surl: `${base}/api/payu/success${q}`,
+    furl: `${base}/api/payu/failure${q}`,
+  }
+}

--- a/apps/backend/src/api/store/payu/intent/route.ts
+++ b/apps/backend/src/api/store/payu/intent/route.ts
@@ -1,0 +1,148 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import {
+  buildUpiIntentForm,
+  buildReturnUrls,
+  findPayuSession,
+  parseUpiIntentResponse,
+} from "./lib"
+import { findStorefrontBySalesChannel } from "../../../mcp/lib/store-resolver"
+
+/**
+ * POST /store/payu/intent
+ * Generate a UPI Intent (`upi://pay?...` deep link) for a cart's PayU payment
+ * session, via PayU's S2S `/_payment` flow (bankcode=INTENT). The session must
+ * already be initialized (create_payment_collection + initialize_payment_session
+ * with provider pp_payu_payu). Returns the deep link the customer taps in any
+ * UPI app; the order completes via the PayU webhook / /store/payu/complete.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  const { cart_id, upi_app, return_url_base } = (req.body || {}) as {
+    cart_id?: string
+    upi_app?: string
+    return_url_base?: string
+  }
+
+  if (!cart_id) {
+    return res.status(400).json({ message: "cart_id is required" })
+  }
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data: carts } = await query.graph({
+    entity: "cart",
+    fields: [
+      "id",
+      "sales_channel_id",
+      "payment_collection.payment_sessions.id",
+      "payment_collection.payment_sessions.provider_id",
+      "payment_collection.payment_sessions.currency_code",
+      "payment_collection.payment_sessions.amount",
+      "payment_collection.payment_sessions.data",
+    ],
+    filters: { id: cart_id },
+  })
+
+  const cart = carts?.[0] as any
+  if (!cart) {
+    return res.status(404).json({ message: "Cart not found" })
+  }
+
+  const session = findPayuSession(cart)
+  if (!session) {
+    return res.status(400).json({
+      message:
+        "No PayU payment session on this cart. Create a payment collection and initialize a 'pp_payu_payu' session first.",
+    })
+  }
+
+  const data = session.data || {}
+  if (!data.payment_url || !data.hash || !data.txnid) {
+    return res
+      .status(400)
+      .json({ message: "PayU session is not fully initialized (missing hash/txnid)." })
+  }
+
+  // Return URLs: caller override → owning storefront origin → request origin.
+  let origin = return_url_base || null
+  if (!origin) {
+    try {
+      const sf = await findStorefrontBySalesChannel(req.scope, cart.sales_channel_id)
+      if (sf?.domain) origin = `https://${sf.domain}`
+    } catch {
+      /* best-effort */
+    }
+  }
+  if (!origin) {
+    const proto = (req.get("x-forwarded-proto") || req.protocol || "https").split(",")[0]
+    const host = req.get("host")
+    if (host) origin = `${proto}://${host}`
+  }
+  const { surl, furl } = buildReturnUrls(origin, cart_id)
+
+  const form = buildUpiIntentForm(data, {
+    surl,
+    furl,
+    clientIp: (req.get("x-forwarded-for") || (req as any).ip || "").split(",")[0].trim(),
+    deviceInfo: req.get("user-agent") || "Medusa",
+    upiAppName: upi_app,
+  })
+
+  let parsed
+  try {
+    const resp = await fetch(String(data.payment_url), {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
+      body: new URLSearchParams(form).toString(),
+    })
+    const text = await resp.text()
+    let json: any = null
+    try {
+      json = JSON.parse(text)
+    } catch {
+      // PayU returned the HTML hosted page → S2S UPI Intent not enabled for this MID.
+      logger.warn(`[PayU Intent] Non-JSON response for cart ${cart_id} (S2S/UPI likely not enabled)`)
+      return res.status(409).json({
+        type: "cart",
+        message:
+          "PayU returned the hosted page, not a UPI intent. Enable S2S UPI Intent on this merchant, or use the hosted checkout / payment link.",
+      })
+    }
+    parsed = parseUpiIntentResponse(json)
+  } catch (e: any) {
+    logger.error(`[PayU Intent] Request failed for cart ${cart_id}: ${e.message}`)
+    return res.status(502).json({ message: "PayU UPI intent request failed", error: e.message })
+  }
+
+  if (!parsed.upi_link) {
+    return res.status(409).json({
+      type: "cart",
+      message: "PayU did not return a UPI intent link (UPI intent may not be enabled).",
+    })
+  }
+
+  // Persist the intent on the session (best-effort) so later steps can read it.
+  try {
+    const paymentModule = req.scope.resolve(Modules.PAYMENT) as any
+    await paymentModule.updatePaymentSession({
+      id: session.id,
+      currency_code: session.currency_code,
+      amount: session.amount,
+      data: {
+        ...data,
+        upi_intent_uri: parsed.upi_link,
+        upi_payment_id: parsed.payment_id,
+      },
+    })
+  } catch (e: any) {
+    logger.warn(`[PayU Intent] Could not persist intent on session: ${e.message}`)
+  }
+
+  return res.json({
+    type: "upi_intent",
+    upi_link: parsed.upi_link,
+    qr_url: parsed.qr_url,
+    txnid: data.txnid,
+    payment_id: parsed.payment_id,
+  })
+}

--- a/apps/backend/src/api/store/payu/lib/complete-from-external.ts
+++ b/apps/backend/src/api/store/payu/lib/complete-from-external.ts
@@ -1,0 +1,82 @@
+/**
+ * Complete a cart into an order from an externally-verified payment (a paid
+ * PayU payment link). The link is collected out-of-band on PayU's side, so we
+ * model the Medusa payment with the manual/system provider and then run the
+ * standard completeCartWorkflow — the same end state as a normal checkout.
+ *
+ * Idempotent: if the cart is already completed (duplicate webhook), it returns
+ * the existing order id instead of throwing.
+ */
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import {
+  completeCartWorkflow,
+  createPaymentCollectionForCartWorkflow,
+  createPaymentSessionsWorkflow,
+} from "@medusajs/medusa/core-flows"
+
+export type CompleteResult = {
+  order_id: string | null
+  already_completed: boolean
+}
+
+export async function completeCartFromExternalPayment(
+  scope: any,
+  cartId: string,
+  ref?: Record<string, unknown>
+): Promise<CompleteResult> {
+  const logger: any = scope.resolve(ContainerRegistrationKeys.LOGGER)
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY)
+  const provider = process.env.PAYU_LINK_COMPLETE_PROVIDER || "pp_system_default"
+
+  const { data: carts } = await query.graph({
+    entity: "cart",
+    fields: [
+      "id",
+      "completed_at",
+      "payment_collection.id",
+      "payment_collection.payment_sessions.id",
+      "payment_collection.payment_sessions.provider_id",
+    ],
+    filters: { id: cartId },
+  })
+  const cart = carts?.[0] as any
+  if (!cart) {
+    throw new Error(`Cart ${cartId} not found`)
+  }
+
+  // Idempotency: already turned into an order by an earlier (duplicate) event.
+  if (cart.completed_at) {
+    const { data: orders } = await query.graph({
+      entity: "order",
+      fields: ["id"],
+      filters: { cart_id: cartId } as any,
+    })
+    return { order_id: orders?.[0]?.id ?? null, already_completed: true }
+  }
+
+  // Ensure a payment collection.
+  let pcId: string | undefined = cart.payment_collection?.id
+  if (!pcId) {
+    const { result } = await createPaymentCollectionForCartWorkflow(scope).run({
+      input: { cart_id: cartId },
+    })
+    pcId = (result as any).id
+  }
+
+  // Ensure a manual/system session to authorize (the link was paid out-of-band).
+  const sessions: any[] = cart.payment_collection?.payment_sessions || []
+  if (!sessions.some((s) => s.provider_id === provider)) {
+    await createPaymentSessionsWorkflow(scope).run({
+      input: {
+        payment_collection_id: pcId!,
+        provider_id: provider,
+        data: ref ? { external_payment: ref } : undefined,
+      },
+    })
+  }
+
+  // Standard completion → order.
+  const { result } = await completeCartWorkflow(scope).run({ input: { id: cartId } })
+  logger.info(`[PayU Link] cart ${cartId} completed → order ${(result as any)?.id}`)
+  return { order_id: (result as any)?.id ?? null, already_completed: false }
+}

--- a/apps/backend/src/api/store/payu/payment-link/__tests__/payment-link-lib.unit.spec.ts
+++ b/apps/backend/src/api/store/payu/payment-link/__tests__/payment-link-lib.unit.spec.ts
@@ -1,0 +1,129 @@
+import { createHash } from "crypto"
+import {
+  buildPaymentLinkBody,
+  isLinkPaid,
+  oneapiHosts,
+  oneapiLinkTxnsUrl,
+  parsePaymentLinkResponse,
+  verifyWebhookHash,
+} from "../lib"
+
+const sha512Hex = (s: string) => createHash("sha512").update(s).digest("hex")
+
+describe("buildPaymentLinkBody", () => {
+  it("coerces subAmount to an int ≥1, caps invoiceNumber at 16, sets source API", () => {
+    const b = buildPaymentLinkBody({
+      amount: "1499.7",
+      description: "Order x",
+      invoiceNumber: "this-invoice-number-is-way-too-long",
+    })
+    expect(b.subAmount).toBe(1500)
+    expect(b.source).toBe("API")
+    expect(b.invoiceNumber.length).toBe(16)
+    expect(b.subAmount).toBeGreaterThanOrEqual(1)
+  })
+
+  it("floors a sub-1 amount to 1 and includes customer only when present", () => {
+    const b = buildPaymentLinkBody({ amount: 0 })
+    expect(b.subAmount).toBe(1)
+    expect(b.customer).toBeUndefined()
+    const b2 = buildPaymentLinkBody({ amount: 5, customer: { email: "a@b.c" } })
+    expect(b2.customer).toEqual({ name: undefined, email: "a@b.c", mobileNumber: undefined })
+  })
+
+  it("carries cartId as nested udf.udf1 for webhook mapping", () => {
+    const b = buildPaymentLinkBody({ amount: 5, cartId: "cart_123" })
+    expect(b.udf).toEqual({ udf1: "cart_123", udf2: null, udf3: null, udf4: null, udf5: null })
+  })
+})
+
+describe("parsePaymentLinkResponse", () => {
+  it("extracts the shareable link + invoice", () => {
+    const p = parsePaymentLinkResponse({
+      status: 0,
+      message: "PaymentLink generated",
+      result: { paymentLink: "https://v.payu.in/PAYUMN/abc", invoiceNumber: "inv1", totalAmount: 1, active: true },
+    })
+    expect(p.payment_link).toBe("https://v.payu.in/PAYUMN/abc")
+    expect(p.invoice_number).toBe("inv1")
+    expect(p.active).toBe(true)
+  })
+})
+
+describe("oneapiHosts / oneapiLinkTxnsUrl", () => {
+  it("selects UAT by default and prod for live/prod", () => {
+    expect(oneapiHosts("test").links).toContain("uatoneapi")
+    expect(oneapiHosts(undefined).links).toContain("uatoneapi")
+    expect(oneapiHosts("prod").links).toBe("https://oneapi.payu.in/payment-links")
+    expect(oneapiHosts("live").links).toBe("https://oneapi.payu.in/payment-links")
+  })
+
+  it("builds the txns lookup url with the invoice path param", () => {
+    const u = oneapiLinkTxnsUrl("prod", "inv 1")
+    expect(u).toContain("https://oneapi.payu.in/payment-links/inv%201/txns")
+    expect(u).toContain("dateFrom=")
+  })
+})
+
+describe("verifyWebhookHash (reverse SHA512)", () => {
+  const salt = "TESTSALT"
+  const base = {
+    status: "success",
+    udf1: "cart_9",
+    udf2: "",
+    udf3: "",
+    udf4: "",
+    udf5: "",
+    email: "a@b.c",
+    firstname: "Asha",
+    productinfo: "Order cart_9",
+    amount: "1.00",
+    txnid: "txn_1",
+    key: "Shrwii",
+  }
+  const signFor = (p: any) => {
+    const tail = [
+      p.status, "", "", "", "", "",
+      p.udf5, p.udf4, p.udf3, p.udf2, p.udf1,
+      p.email, p.firstname, p.productinfo, p.amount, p.txnid, p.key,
+    ]
+    return sha512Hex([salt, ...tail].join("|"))
+  }
+
+  it("accepts a correctly reverse-hashed payload", () => {
+    const payload = { ...base, hash: signFor(base) }
+    expect(verifyWebhookHash(payload, salt, sha512Hex)).toBe(true)
+  })
+
+  it("rejects a tampered amount", () => {
+    const payload = { ...base, hash: signFor(base), amount: "9999.00" }
+    expect(verifyWebhookHash(payload, salt, sha512Hex)).toBe(false)
+  })
+
+  it("rejects when hash or salt missing", () => {
+    expect(verifyWebhookHash({ ...base }, salt, sha512Hex)).toBe(false)
+    expect(verifyWebhookHash({ ...base, hash: "x" }, "", sha512Hex)).toBe(false)
+  })
+})
+
+describe("isLinkPaid", () => {
+  const txns = (rows: any[]) => ({ status: 0, result: { data: rows } })
+
+  it("is paid when a success txn covers the min amount", () => {
+    const r = isLinkPaid(txns([{ status: "success", settledAmount: 1500, transactionId: "t1", mode: "UPI" }]), 1500)
+    expect(r.paid).toBe(true)
+    expect(r.transaction_id).toBe("t1")
+    expect(r.mode).toBe("UPI")
+  })
+
+  it("is NOT paid when settled is short of the min amount", () => {
+    const r = isLinkPaid(txns([{ status: "success", settledAmount: 100 }]), 1500)
+    expect(r.paid).toBe(false)
+    expect(r.settled_amount).toBe(100)
+  })
+
+  it("is NOT paid with no success row", () => {
+    expect(isLinkPaid(txns([{ status: "failed" }])).paid).toBe(false)
+    expect(isLinkPaid(txns([])).paid).toBe(false)
+  })
+})

--- a/apps/backend/src/api/store/payu/payment-link/lib.ts
+++ b/apps/backend/src/api/store/payu/payment-link/lib.ts
@@ -1,0 +1,162 @@
+/**
+ * Pure helpers for the PayU OneAPI "Payment Link" route (Rail B).
+ *
+ * OneAPI is OAuth-based: mint a bearer token from accounts.payu.in, then POST to
+ * oneapi.payu.in/payment-links with a `merchantId` header. The response carries a
+ * shareable `https://v.payu.in/…` link whose checkout offers UPI + cards.
+ */
+
+export const ONEAPI_HOSTS = {
+  test: {
+    token: "https://uat-accounts.payu.in/oauth/token",
+    links: "https://uatoneapi.payu.in/payment-links",
+  },
+  prod: {
+    token: "https://accounts.payu.in/oauth/token",
+    links: "https://oneapi.payu.in/payment-links",
+  },
+} as const
+
+/** Pick UAT vs production hosts. Anything but live/prod → test (UAT). */
+export function oneapiHosts(mode?: string) {
+  const m = (mode || "test").toLowerCase()
+  return m === "live" || m === "prod" || m === "production"
+    ? ONEAPI_HOSTS.prod
+    : ONEAPI_HOSTS.test
+}
+
+export type PaymentLinkInput = {
+  /** Amount in INR (major units). Coerced to an integer ≥ 1 (PayU subAmount). */
+  amount: number | string
+  description?: string
+  invoiceNumber?: string
+  isPartialPaymentAllowed?: boolean
+  successURL?: string
+  failureURL?: string
+  expiryDate?: string
+  customer?: { name?: string; email?: string; mobileNumber?: string }
+  /** Cart this link pays for — stored as udf1 so the webhook can map back. */
+  cartId?: string
+}
+
+/**
+ * Build the OneAPI create-payment-link JSON body. Enforces PayU's constraints:
+ * integer `subAmount` ≥ 1 and `invoiceNumber` ≤ 16 chars.
+ */
+export function buildPaymentLinkBody(input: PaymentLinkInput): Record<string, any> {
+  const subAmount = Math.max(1, Math.round(Number(input.amount) || 0))
+  const body: Record<string, any> = {
+    description: input.description || "Payment",
+    source: "API",
+    subAmount,
+    isPartialPaymentAllowed: !!input.isPartialPaymentAllowed,
+  }
+  if (input.invoiceNumber) {
+    body.invoiceNumber = String(input.invoiceNumber).slice(0, 16)
+  }
+  const c = input.customer
+  if (c && (c.name || c.email || c.mobileNumber)) {
+    body.customer = { name: c.name, email: c.email, mobileNumber: c.mobileNumber }
+  }
+  if (input.successURL) body.successURL = input.successURL
+  if (input.failureURL) body.failureURL = input.failureURL
+  if (input.expiryDate) body.expiryDate = input.expiryDate
+  // Carry the cart id in udf1 so the dashboard webhook can map the payment back.
+  if (input.cartId) {
+    body.udf = { udf1: input.cartId, udf2: null, udf3: null, udf4: null, udf5: null }
+  }
+  return body
+}
+
+export type ParsedPaymentLink = {
+  payment_link: string | null
+  invoice_number: string | null
+  total_amount: number | null
+  active: boolean | null
+  status: number | null
+  message: string | null
+}
+
+/** Normalize the OneAPI create-payment-link response. */
+export function parsePaymentLinkResponse(json: any): ParsedPaymentLink {
+  const r = json?.result ?? {}
+  return {
+    payment_link: r.paymentLink ?? null,
+    invoice_number: r.invoiceNumber ?? null,
+    total_amount: r.totalAmount ?? null,
+    active: typeof r.active === "boolean" ? r.active : null,
+    status: typeof json?.status === "number" ? json.status : null,
+    message: json?.message ?? null,
+  }
+}
+
+// ── Verify-then-complete helpers (webhook → order) ──────────────────────
+
+/**
+ * Verify a PayU dashboard webhook's reverse-SHA512 hash with the merchant salt.
+ * Formula (docs.payu.in/docs/webhook-events-and-sample-payloads):
+ *   sha512([additionalCharges|]salt|status||||||udf5|udf4|udf3|udf2|udf1|
+ *           email|firstname|productinfo|amount|txnid|key)
+ */
+export function verifyWebhookHash(
+  payload: Record<string, any>,
+  salt: string,
+  sha512Hex: (s: string) => string
+): boolean {
+  if (!payload?.hash || !salt) return false
+  const ac = payload.additionalCharges || ""
+  const tail = [
+    payload.status ?? "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    payload.udf5 ?? "",
+    payload.udf4 ?? "",
+    payload.udf3 ?? "",
+    payload.udf2 ?? "",
+    payload.udf1 ?? "",
+    payload.email ?? "",
+    payload.firstname ?? "",
+    payload.productinfo ?? "",
+    payload.amount ?? "",
+    payload.txnid ?? "",
+    payload.key ?? "",
+  ]
+  const signing = (ac ? [ac, salt, ...tail] : [salt, ...tail]).join("|")
+  return sha512Hex(signing).toLowerCase() === String(payload.hash).toLowerCase()
+}
+
+export type LinkPaidResult = {
+  paid: boolean
+  settled_amount: number | null
+  transaction_id: string | null
+  mode: string | null
+}
+
+/**
+ * Decide whether a payment-link is paid from its /txns response, optionally
+ * requiring the settled amount to cover `minAmount` (INR).
+ */
+export function isLinkPaid(txnsJson: any, minAmount?: number): LinkPaidResult {
+  const rows: any[] = txnsJson?.result?.data || []
+  const ok = rows.find((t) => String(t?.status || "").toLowerCase() === "success")
+  if (!ok) {
+    return { paid: false, settled_amount: null, transaction_id: null, mode: null }
+  }
+  const settled = Number(ok.settledAmount)
+  const enough = minAmount === undefined || (!isNaN(settled) && settled >= minAmount)
+  return {
+    paid: enough,
+    settled_amount: isNaN(settled) ? null : settled,
+    transaction_id: ok.transactionId ?? null,
+    mode: ok.mode ?? null,
+  }
+}
+
+export function oneapiLinkTxnsUrl(mode: string | undefined, invoiceNumber: string): string {
+  const base = oneapiHosts(mode).links
+  const q = `?dateFrom=2020-01-01&dateTo=2099-12-31`
+  return `${base}/${encodeURIComponent(invoiceNumber)}/txns${q}`
+}

--- a/apps/backend/src/api/store/payu/payment-link/route.ts
+++ b/apps/backend/src/api/store/payu/payment-link/route.ts
@@ -1,0 +1,164 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import {
+  buildPaymentLinkBody,
+  oneapiHosts,
+  parsePaymentLinkResponse,
+  type PaymentLinkInput,
+} from "./lib"
+
+/**
+ * POST /store/payu/payment-link
+ * Create a shareable PayU payment link (OneAPI / OAuth). Returns a
+ * `https://v.payu.in/…` URL whose checkout offers UPI + cards. Either pass
+ * `amount` (+ optional customer) directly, or `cart_id` to derive the amount and
+ * customer from the cart.
+ *
+ * Requires env: PAYU_CLIENT_ID, PAYU_CLIENT_SECRET, PAYU_MERCHANT_ID
+ * (+ optional PAYU_ONEAPI_MODE = test|prod, default test).
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  const clientId = process.env.PAYU_CLIENT_ID
+  const clientSecret = process.env.PAYU_CLIENT_SECRET
+  const merchantId = process.env.PAYU_MERCHANT_ID
+  if (!clientId || !clientSecret || !merchantId) {
+    return res.status(400).json({
+      message:
+        "PayU OneAPI is not configured. Set PAYU_CLIENT_ID, PAYU_CLIENT_SECRET and PAYU_MERCHANT_ID.",
+    })
+  }
+  const hosts = oneapiHosts(process.env.PAYU_ONEAPI_MODE)
+
+  const b = (req.body || {}) as Record<string, any>
+  const input: PaymentLinkInput = {
+    amount: b.amount,
+    description: b.description,
+    invoiceNumber: b.invoice_number,
+    isPartialPaymentAllowed: b.is_partial_payment_allowed,
+    successURL: b.success_url,
+    failureURL: b.failure_url,
+    expiryDate: b.expiry_date,
+    customer: b.customer,
+  }
+
+  // Derive amount + customer from a cart when cart_id is given.
+  if (b.cart_id) {
+    const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+    const { data: carts } = await query.graph({
+      entity: "cart",
+      fields: [
+        "id",
+        "email",
+        "currency_code",
+        "total",
+        "billing_address.first_name",
+        "billing_address.last_name",
+        "billing_address.phone",
+        "shipping_address.phone",
+      ],
+      filters: { id: b.cart_id },
+    })
+    const cart = carts?.[0] as any
+    if (!cart) {
+      return res.status(404).json({ message: "Cart not found" })
+    }
+    if ((cart.currency_code || "").toLowerCase() !== "inr") {
+      logger.warn(`[PayU Link] cart ${b.cart_id} currency is ${cart.currency_code}, not INR`)
+    }
+    if (input.amount === undefined || input.amount === null) {
+      input.amount = cart.total
+    }
+    if (!input.customer) {
+      const ba = cart.billing_address || {}
+      input.customer = {
+        name: [ba.first_name, ba.last_name].filter(Boolean).join(" ") || undefined,
+        email: cart.email || undefined,
+        mobileNumber: ba.phone || cart.shipping_address?.phone || undefined,
+      }
+    }
+    if (!input.description) input.description = `Order ${b.cart_id}`
+    input.cartId = b.cart_id // → udf1, so the webhook maps the payment back
+  }
+
+  if (input.amount === undefined || input.amount === null || Number(input.amount) <= 0) {
+    return res.status(400).json({ message: "amount (INR) or a cart_id with a total is required" })
+  }
+  if (!input.invoiceNumber) {
+    input.invoiceNumber = `inv${String(Date.now()).slice(-13)}` // ≤16 chars
+  }
+
+  // 1) OAuth token (client_credentials)
+  let token: string
+  try {
+    const tr = await fetch(hosts.token, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "client_credentials",
+        client_id: clientId,
+        client_secret: clientSecret,
+        scope: "create_payment_links",
+      }).toString(),
+    })
+    const tj: any = await tr.json().catch(() => ({}))
+    if (!tj.access_token) {
+      logger.error(`[PayU Link] token failed (${tr.status}): ${JSON.stringify(tj)}`)
+      return res.status(502).json({ message: "PayU token request failed", error: tj.error || tr.status })
+    }
+    token = tj.access_token
+  } catch (e: any) {
+    logger.error(`[PayU Link] token error: ${e.message}`)
+    return res.status(502).json({ message: "PayU token request failed", error: e.message })
+  }
+
+  // 2) Create the payment link
+  try {
+    const cr = await fetch(hosts.links, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        merchantId: String(merchantId),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(buildPaymentLinkBody(input)),
+    })
+    const cj: any = await cr.json().catch(() => ({}))
+    const parsed = parsePaymentLinkResponse(cj)
+    if (!parsed.payment_link) {
+      logger.warn(`[PayU Link] no link (${cr.status}): ${cj?.message || JSON.stringify(cj)}`)
+      return res.status(cr.status >= 400 ? cr.status : 502).json({
+        message: cj?.message || "PayU did not return a payment link",
+      })
+    }
+
+    // Persist the invoice number on the cart so the webhook can re-verify it via
+    // OneAPI before completing the order. Merge metadata (Medusa replaces the
+    // whole blob on update) — see the no-critical-data-in-metadata gotcha.
+    if (b.cart_id && parsed.invoice_number) {
+      try {
+        const cartModule: any = req.scope.resolve(Modules.CART)
+        const existing = await cartModule.retrieveCart(b.cart_id, { select: ["metadata"] })
+        await cartModule.updateCarts(b.cart_id, {
+          metadata: {
+            ...(existing?.metadata || {}),
+            payu_invoice_number: parsed.invoice_number,
+            payu_payment_link: parsed.payment_link,
+          },
+        })
+      } catch (e: any) {
+        logger.warn(`[PayU Link] could not persist invoice on cart ${b.cart_id}: ${e.message}`)
+      }
+    }
+
+    return res.json({
+      type: "payment_link",
+      payment_link: parsed.payment_link,
+      invoice_number: parsed.invoice_number,
+      total_amount: parsed.total_amount,
+    })
+  } catch (e: any) {
+    logger.error(`[PayU Link] create error: ${e.message}`)
+    return res.status(502).json({ message: "PayU payment link request failed", error: e.message })
+  }
+}

--- a/apps/backend/src/api/webhooks/payu/link/route.ts
+++ b/apps/backend/src/api/webhooks/payu/link/route.ts
@@ -1,0 +1,116 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { createHash } from "crypto"
+import {
+  isLinkPaid,
+  oneapiHosts,
+  oneapiLinkTxnsUrl,
+  verifyWebhookHash,
+} from "../../../store/payu/payment-link/lib"
+import { completeCartFromExternalPayment } from "../../../store/payu/lib/complete-from-external"
+
+/**
+ * POST /webhooks/payu/link — PayU dashboard webhook for payment-link payments.
+ *
+ * Lives outside /store (no publishable key). Verify-then-complete:
+ *  1) validate the reverse-SHA512 webhook hash with PAYU_MERCHANT_SALT,
+ *  2) re-query OneAPI /payment-links/{invoice}/txns to independently confirm the
+ *     payment is actually success + covers the amount (don't trust the webhook
+ *     alone — it can be replayed),
+ *  3) complete the cart (udf1) into an order via completeCartFromExternalPayment.
+ *
+ * Always returns 200 once the signature is valid so PayU stops retrying; the
+ * actual completion is best-effort and idempotent.
+ */
+const sha512Hex = (s: string) => createHash("sha512").update(s).digest("hex")
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+
+  // PayU posts application/x-www-form-urlencoded.
+  let payload = (req.body || {}) as Record<string, any>
+  if ((!payload || !Object.keys(payload).length) && (req as any).rawBody) {
+    payload = Object.fromEntries(new URLSearchParams((req as any).rawBody.toString()))
+  }
+
+  const salt = process.env.PAYU_MERCHANT_SALT
+  if (!salt) {
+    logger.error("[PayU Webhook] PAYU_MERCHANT_SALT not set; cannot verify")
+    return res.status(500).json({ message: "not configured" })
+  }
+  if (!verifyWebhookHash(payload, salt, sha512Hex)) {
+    logger.warn(`[PayU Webhook] hash verification failed (txnid=${payload.txnid})`)
+    return res.status(401).json({ message: "invalid signature" })
+  }
+
+  const status = String(payload.status || "").toLowerCase()
+  const cartId = payload.udf1
+  if (status !== "success" || !cartId) {
+    // Verified but not a successful link payment we own → ack, do nothing.
+    return res.status(200).json({ received: true })
+  }
+
+  // Independent re-verification via OneAPI (recommended), when configured.
+  try {
+    const clientId = process.env.PAYU_CLIENT_ID
+    const clientSecret = process.env.PAYU_CLIENT_SECRET
+    const merchantId = process.env.PAYU_MERCHANT_ID
+    const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+    const { data: carts } = await query.graph({
+      entity: "cart",
+      fields: ["id", "metadata", "total"],
+      filters: { id: cartId },
+    })
+    const cart = carts?.[0] as any
+    const invoice = cart?.metadata?.payu_invoice_number
+
+    if (clientId && clientSecret && merchantId && invoice) {
+      const hosts = oneapiHosts(process.env.PAYU_ONEAPI_MODE)
+      const tr = await fetch(hosts.token, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "client_credentials",
+          client_id: clientId,
+          client_secret: clientSecret,
+          scope: "read_payment_links",
+        }).toString(),
+      })
+      const tj: any = await tr.json().catch(() => ({}))
+      if (tj.access_token) {
+        const vr = await fetch(
+          oneapiLinkTxnsUrl(process.env.PAYU_ONEAPI_MODE, String(invoice)),
+          { headers: { Authorization: `Bearer ${tj.access_token}`, merchantId: String(merchantId) } }
+        )
+        const vj: any = await vr.json().catch(() => ({}))
+        const verdict = isLinkPaid(vj, cart?.total ? Math.round(Number(cart.total)) : undefined)
+        if (!verdict.paid) {
+          logger.warn(`[PayU Webhook] OneAPI says not paid for invoice ${invoice}; skipping completion`)
+          return res.status(200).json({ received: true, completed: false })
+        }
+      } else {
+        logger.warn("[PayU Webhook] could not get OneAPI token to re-verify; proceeding on hash only")
+      }
+    } else {
+      logger.warn("[PayU Webhook] OneAPI not configured or no invoice on cart; proceeding on hash only")
+    }
+  } catch (e: any) {
+    logger.warn(`[PayU Webhook] re-verification error (proceeding on hash): ${e.message}`)
+  }
+
+  // Verified → complete the cart into an order (idempotent).
+  try {
+    const result = await completeCartFromExternalPayment(req.scope, cartId, {
+      provider: "payu_link",
+      txnid: payload.txnid,
+      mihpayid: payload.mihpayid,
+      mode: payload.mode,
+      bank_ref_num: payload.bank_ref_num,
+    })
+    return res.status(200).json({ received: true, completed: true, order_id: result.order_id })
+  } catch (e: any) {
+    logger.error(`[PayU Webhook] completion failed for cart ${cartId}: ${e.message}`)
+    // Ack anyway so PayU doesn't hammer retries; reconcile out of band.
+    return res.status(200).json({ received: true, completed: false, error: e.message })
+  }
+}

--- a/apps/docs/notes/STORE_MCP_SERVER_GUIDE.md
+++ b/apps/docs/notes/STORE_MCP_SERVER_GUIDE.md
@@ -66,12 +66,17 @@ These are deliberate; don't "simplify" them away.
    sales channel → publishable token via `store-resolver.ts` (mirrors
    `GET /web/storefront/[subdomain]`). Any proxy tool also accepts an optional
    `store` arg that resolves the same way.
-   - **The core store is not partner-owned**, so iterating partners alone misses
-     it. `store-resolver.ts` therefore also queries the `stores` entity and
-     includes any store **not** linked to a partner, flagged `is_default: true`
-     and given the apex domain (`ROOT_DOMAIN`, default `cicilabel.com`). It is
-     resolvable by `"default"` / `"main"`, the apex domain, or its store
-     name/id/sales-channel id. `list_stores` returns default store(s) first.
+   - **Store-first assembly.** `store-resolver.ts` enumerates the `stores` entity
+     (the same rich field set as core `GET /admin/stores`:
+     `supported_currencies`, `default_region_id`, `default_location_id`, …) and
+     joins partner handle/domain on top. So **every** store is returned —
+     including the core store that iterating partners alone would miss. A store
+     not linked to a partner is flagged `is_default: true` with the apex domain
+     (`ROOT_DOMAIN`, default `cicilabel.com`) and sorted first. `resolveStorefront`
+     filters this assembled list, so `"default"` / `"main"` / the apex domain /
+     a store name/id/sales-channel id all resolve the core store.
+   - Each `StorefrontInfo` carries `default_region_id` and `currency_code`, handy
+     defaults for `create_cart`.
 
 5. **Stateless Streamable-HTTP transport.** Each POST is a self-contained
    JSON-RPC request (`sessionIdGenerator: undefined`, `enableJsonResponse: true`).

--- a/apps/docs/notes/STORE_MCP_SERVER_GUIDE.md
+++ b/apps/docs/notes/STORE_MCP_SERVER_GUIDE.md
@@ -187,10 +187,77 @@ create_cart ──▶ add_line_item* ──▶ update_cart (email + shipping/bil
 | `create_payment_collection` | POST | `/store/payment-collections` |
 | `initialize_payment_session` | POST | `/store/payment-collections/:id/payment-sessions` |
 | `complete_cart` | POST | `/store/carts/:id/complete` |
+| `payu_complete_payment` | POST | `/store/payu/complete` (INR) |
+| `payu_refresh_payment` | POST | `/store/payu/refresh` (INR) |
 
 `complete_cart` returns `{ type: "order", order }` on success or
 `{ type: "cart", cart, error }` if completion failed (e.g. payment not
 authorized) — surface both to the agent.
+
+### Resolving the actual payment step (`next_action`)
+
+`initialize_payment_session` doesn't just create the session — it normalizes the
+provider's payload into a concrete `next_action` so the agent knows what to do
+next, regardless of gateway:
+
+```jsonc
+// returns { next_action, payment_collection }
+// PayU (pp_payu_*):
+{ "next_action": { "type": "redirect_form", "provider": "payu",
+    "url": "https://secure.payu.in/_payment", "method": "POST",
+    "fields": { "key": "…", "txnid": "…", "amount": "…", "hash": "…", … } } }
+// Stripe (pp_stripe_*):
+{ "next_action": { "type": "client_secret", "provider": "stripe",
+    "client_secret": "pi_…_secret_…" } }
+// manual / pp_system_default:
+{ "next_action": { "type": "session_ready" } }   // just complete_cart
+```
+
+So **PayU resolves to a hosted payment link + signed form fields**, **Stripe hands
+over the `client_secret`** for client-side card collection, and manual providers
+are immediately completable. The normalization is a pure function
+(`paymentNextAction` in `registry.ts`, unit-tested) applied via the tool def's
+`transform` hook — the generic way a proxy tool reshapes its response.
+
+### PayU (INR) — the redirect-gateway exception
+
+PayU (provider `pp_payu_payu`, used for INR) is a **redirect + hash gateway**, not
+a server-side charge API. That changes the tail of the flow:
+
+```
+… create_payment_collection
+→ initialize_payment_session({ provider_id: "pp_payu_payu" })
+     ⇒ session.data = { payment_url, key, txnid, hash, amount, firstname, email, … }
+→ [BROWSER] POST those fields to payment_url (PayU hosted page); shopper pays
+     (card / UPI / netbanking); PayU redirects back with a signed callback
+→ payu_complete_payment({ cart_id, payu_status, mihpayid, txnid, hash, amount })
+     ⇒ { type: "order", order_id }   (or { type: "cart", error } + auto-refresh)
+```
+
+- **`initialize_payment_session`** already surfaces everything the redirect needs
+  (`payment_url`, `key`, `txnid`, `hash`) in `session.data`, because it proxies
+  the native payment-sessions route.
+- **`payu_complete_payment`** wraps `POST /store/payu/complete`: it writes the
+  callback fields onto the session and runs `completeCartWorkflow`. Use it
+  **instead of `complete_cart`** for PayU.
+- **`payu_refresh_payment`** wraps `POST /store/payu/refresh`: resets the payment
+  collection (deletes stale sessions) so a retry gets a fresh `txnid`/`hash`.
+
+**What the MCP cannot do for PayU (by design, not a gap):**
+- The hosted-page payment step itself is a **browser redirect** with a
+  hash-signed form POST to `test.payu.in` / `secure.payu.in`. An agent can
+  *initiate* and *complete*, but the actual card/UPI entry happens in a browser —
+  there is no server-side "charge" call to wrap.
+- Provider-internal lifecycle methods (`authorizePayment`, `capturePayment`,
+  `refundPayment`, `verifyPayment` in `payu-payment/service.ts`) are invoked **by
+  Medusa's workflows**, not exposed as `/store/*` routes — so they're out of
+  scope for the Store MCP. Refunds are an **admin** concern, not a store one.
+- Credentials resolve **per partner** (sales channel → store → partner →
+  `partner_payment_config`, falling back to global). The agent never handles
+  `merchant_key`/`merchant_salt`; scoping the call to the right `store` is enough.
+
+So: the two PayU **store** routes map cleanly onto MCP tools; the gateway redirect
+and the admin/provider-internal operations intentionally do not.
 
 ---
 

--- a/apps/docs/notes/STORE_MCP_SERVER_GUIDE.md
+++ b/apps/docs/notes/STORE_MCP_SERVER_GUIDE.md
@@ -187,6 +187,7 @@ create_cart ──▶ add_line_item* ──▶ update_cart (email + shipping/bil
 | `create_payment_collection` | POST | `/store/payment-collections` |
 | `initialize_payment_session` | POST | `/store/payment-collections/:id/payment-sessions` |
 | `complete_cart` | POST | `/store/carts/:id/complete` |
+| `payu_generate_upi_intent` | POST | `/store/payu/intent` (INR — UPI deep link) |
 | `payu_complete_payment` | POST | `/store/payu/complete` (INR) |
 | `payu_refresh_payment` | POST | `/store/payu/refresh` (INR) |
 
@@ -242,6 +243,23 @@ a server-side charge API. That changes the tail of the flow:
   **instead of `complete_cart`** for PayU.
 - **`payu_refresh_payment`** wraps `POST /store/payu/refresh`: resets the payment
   collection (deletes stale sessions) so a retry gets a fresh `txnid`/`hash`.
+
+**UPI Intent (`payu_generate_upi_intent`) — the no-redirect, no-card path.** After
+a PayU session is initialized, this generates a **`upi://pay?…` deep link** (+ QR)
+the customer taps in any UPI app — no hosted-page redirect, no card data:
+
+```
+… create_payment_collection → initialize_payment_session({ provider_id: "pp_payu_payu" })
+→ payu_generate_upi_intent({ cart_id })  ⇒ { upi_link: "upi://pay?pa=…&am=…&cu=INR", qr_url, txnid }
+→ [customer pays in their UPI app] → PayU webhook / payu_complete_payment
+```
+
+It wraps `POST /store/payu/intent`, which **replays the session's already-signed
+fields** to PayU's S2S `/_payment` (`bankcode=INTENT`) — so it needs no salt and
+reuses the same hash the provider built. If PayU returns its HTML page instead of
+JSON, S2S UPI Intent isn't enabled on that merchant (409 with a clear message);
+fall back to the hosted link. This is the most agent-friendly INR primitive: a
+returnable link/QR with zero PCI surface.
 
 **What the MCP cannot do for PayU (by design, not a gap):**
 - The hosted-page payment step itself is a **browser redirect** with a

--- a/apps/docs/notes/STORE_MCP_SERVER_GUIDE.md
+++ b/apps/docs/notes/STORE_MCP_SERVER_GUIDE.md
@@ -1,0 +1,226 @@
+# Store MCP Server — Architecture & Authoring Guide
+
+The Store MCP server exposes the Medusa **Store API** to AI agents (Claude Code,
+Cursor, Claude Desktop, internal Mastra agents) over the
+[Model Context Protocol](https://modelcontextprotocol.io). It started read-only
+(catalog browsing) and now also offers a **gated write path** for the full
+cart → checkout → pay flow.
+
+> Source: `apps/backend/src/api/mcp/`. Connection snippets live in
+> `apps/backend/src/api/mcp/README.md` (kept short, operator-facing). This doc is
+> the deeper "how it works / how to extend it" reference.
+
+---
+
+## 1. Design in one paragraph
+
+The MCP server is a **thin loopback proxy in front of a declarative registry**.
+Each MCP tool maps to exactly one live `/store/*` route. When a tool is called,
+the server forwards the arguments to that route over HTTP **on the same process**
+(`proxy.ts`), attaching a resolved publishable key. Because the call goes through
+the real route, every tool inherits Medusa's publishable-key/sales-channel
+scoping, pricing & tax context, request validators, and our custom route
+overrides — for free. **Adding a new tool is one row in `registry.ts`.**
+
+```
+agent ──JSON-RPC──▶ POST /mcp ──▶ handler.ts ──▶ server.ts (tools/list, tools/call)
+                                                     │
+                          native tool? ──────────────┤── store-resolver.ts (query.graph)
+                          proxy tool?  ───────────────┘── proxy.ts ──HTTP loopback──▶ /store/* route
+```
+
+---
+
+## 2. The five locked architecture decisions
+
+These are deliberate; don't "simplify" them away.
+
+1. **Loopback proxy + declarative registry, not re-querying.**
+   Tools forward to the live `/store/*` route rather than re-implementing the
+   query against `query.graph`. That's what makes every tool inherit pricing,
+   tax, scoping, validators, and custom overrides (e.g. our `/store/products`
+   index-engine bugfix). One registry row = one new tool. See `proxy.ts` and
+   `registry.ts`.
+
+2. **Dual mount.** The whole `/store` namespace is hard-gated by Medusa's
+   `ensurePublishableApiKeyMiddleware`, so we expose **two** entry points that
+   share one handler:
+   - `POST /mcp` — **open / zero-config.** Outside `/store`, so no key required
+     to connect. The handler injects a key per call (see §3).
+   - `POST /store/mcp` — **gated.** Inside `/store`, so a caller must always send
+     `x-publishable-api-key`. Good for clients pinned to one storefront.
+
+3. **Hybrid key resolution.** A tool's effective publishable key is chosen per
+   call with this precedence:
+   `store` argument → `x-publishable-api-key` header → `STORE_MCP_DEFAULT_PUBLISHABLE_KEY` env.
+   Publishable keys are **public** storefront keys (shipped as
+   `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`), so resolving/returning them leaks
+   nothing. If none resolve, the tool returns an **in-band error** explaining how
+   to scope the request — it never HTTP-500s.
+
+4. **Multi-tenant store resolution.** The platform runs many partner
+   storefronts (each = one sales channel = one publishable key). Agents work in
+   terms of **store names**, not raw `pk_` tokens. Native (container-backed)
+   tools `list_stores` and `get_storefront_key` resolve
+   partner handle/domain → store → default sales channel → publishable token via
+   `store-resolver.ts` (mirrors `GET /web/storefront/[subdomain]`). Any proxy
+   tool also accepts an optional `store` arg that resolves the same way.
+
+5. **Stateless Streamable-HTTP transport.** Each POST is a self-contained
+   JSON-RPC request (`sessionIdGenerator: undefined`, `enableJsonResponse: true`).
+   The low-level `Server` doesn't enforce initialize-first, so single-shot
+   `tools/list` / `tools/call` work with no session. `GET`/`DELETE` on the mount
+   return 405.
+
+---
+
+## 3. File layout
+
+```
+src/api/mcp/
+├── route.ts              POST /mcp        (open mount)
+└── lib/
+    ├── handler.ts        transport wiring + key resolution + write toggle
+    ├── server.ts         tools/list + tools/call dispatch (proxy vs native, gating)
+    ├── registry.ts       declarative tool -> endpoint table (read + write)
+    ├── proxy.ts          loopback fetch to /store/* (GET + write body)
+    └── store-resolver.ts native store discovery / key resolution
+src/api/store/mcp/route.ts  POST /store/mcp (gated mount; delegates to the same handler)
+```
+
+---
+
+## 4. Tool kinds
+
+| Kind | Set on the def | Runs via | Examples |
+|------|----------------|----------|----------|
+| **Proxy (read)** | `method: "GET"` + `path` | `proxy.ts` loopback | `list_products`, `get_product`, `semantic_search` |
+| **Proxy (write)** | `method: "POST"/"DELETE"` + `bodyParams` + `write: true` | `proxy.ts` loopback | `create_cart`, `add_line_item`, `complete_cart` |
+| **Native** | `native: "..."` | `store-resolver.ts` in-process | `list_stores`, `get_storefront_key` |
+
+`tools/list` and `tools/call` live in `server.ts`. Path params (`:id`) are
+substituted from args; whitelisted `queryParams` become the query string;
+whitelisted `bodyParams` become the JSON body. The `store` arg is consumed for
+key resolution and **never** forwarded to the route.
+
+---
+
+## 5. Adding a **read** tool (the 1-row case)
+
+Add an entry to `STORE_MCP_TOOLS` in `registry.ts`. Use the `listTool` /
+`getTool` builders for sales-channel list and retrieve-by-id endpoints:
+
+```ts
+listTool(
+  "list_return_reasons",
+  "List the store's return reasons.",
+  "/store/return-reasons"
+)
+getTool("get_region", "Retrieve a region by id.", "/store/regions/:id")
+```
+
+That's it — no other code changes. The builders attach the standard `fields`,
+`store`, and pagination props, and a `q` prop when `searchable: true`.
+
+---
+
+## 6. Adding a **write** tool (cart / checkout / pay)
+
+Write tools are proxy tools with `write: true`. They are **hidden from
+`tools/list` and rejected by `tools/call` unless `STORE_MCP_ENABLE_WRITE` is
+truthy** (`true` / `1` / `yes`). The toggle is read once per request in
+`handler.ts:isWriteEnabled()` and threaded through `StoreMcpContext.enableWrite`.
+
+Shape of a write def:
+
+```ts
+{
+  name: "add_line_item",
+  description: "Add a product variant to a cart. Returns the updated cart.",
+  write: true,                                  // gated
+  method: "POST",                               // or "DELETE"
+  path: "/store/carts/:id/line-items",
+  pathParams: ["id"],                           // :id <- args.id
+  bodyParams: ["variant_id", "quantity", "metadata"],  // -> JSON body
+  inputSchema: { /* JSON Schema, kept loose */ },
+}
+```
+
+**Why the schema stays loose:** the store route runs its own
+`validateAndTransformBody` validator, which is the real source of truth. The
+MCP-side `inputSchema` only needs to guide the agent and mark required fields;
+let Medusa reject malformed bodies with its precise errors.
+
+### The full checkout flow (the write tools today)
+
+```
+create_cart ──▶ add_line_item* ──▶ update_cart (email + shipping/billing address)
+   ──▶ list_shipping_options ──▶ add_shipping_method
+   ──▶ list_payment_providers ──▶ create_payment_collection
+   ──▶ initialize_payment_session ──▶ complete_cart  ⇒  { type: "order", order }
+```
+
+| Tool | Method | Route |
+|------|--------|-------|
+| `create_cart` | POST | `/store/carts` |
+| `get_cart` | GET | `/store/carts/:id` |
+| `update_cart` | POST | `/store/carts/:id` |
+| `add_line_item` | POST | `/store/carts/:id/line-items` |
+| `update_line_item` | POST | `/store/carts/:id/line-items/:line_id` |
+| `remove_line_item` | DELETE | `/store/carts/:id/line-items/:line_id` |
+| `add_promotion` | POST | `/store/carts/:id/promotions` |
+| `list_shipping_options` | GET | `/store/shipping-options?cart_id=` |
+| `add_shipping_method` | POST | `/store/carts/:id/shipping-methods` |
+| `list_payment_providers` | GET | `/store/payment-providers?region_id=` |
+| `create_payment_collection` | POST | `/store/payment-collections` |
+| `initialize_payment_session` | POST | `/store/payment-collections/:id/payment-sessions` |
+| `complete_cart` | POST | `/store/carts/:id/complete` |
+
+`complete_cart` returns `{ type: "order", order }` on success or
+`{ type: "cart", cart, error }` if completion failed (e.g. payment not
+authorized) — surface both to the agent.
+
+---
+
+## 7. Safety model
+
+- **Read by default, write opt-in.** Writes require `STORE_MCP_ENABLE_WRITE`.
+  With it off, the write tools don't even appear in `tools/list`.
+- **Scoping is enforced by the route, not the tool.** Every write proxies through
+  the publishable-key-scoped `/store/*` route, so a cart can only contain
+  products in that storefront's sales channel.
+- **Public keys only.** No admin auth is involved. The optional forwarded
+  `Authorization` bearer (`ctx.bearer`) is reserved for future customer-authed
+  tools (e.g. `orders/me`); the checkout tools work as guest checkout.
+- **Payment is provider-mediated.** `initialize_payment_session` only creates a
+  session for a provider; actual charge/authorization happens via the provider
+  (Stripe, manual/`pp_system_default`, etc.). The MCP server never sees card data.
+
+---
+
+## 8. Configuration
+
+| Env var | Purpose |
+|---------|---------|
+| `STORE_MCP_DEFAULT_PUBLISHABLE_KEY` | Last-resort key when a call has no `store` arg and no header. Set to the main storefront's public key. |
+| `STORE_MCP_ENABLE_WRITE` | `true`/`1`/`yes` to enable cart & payment write tools. Default off (read-only). |
+| `STORE_MCP_LOOPBACK_URL` | Override the loopback origin (default: derived from the request, e.g. `http://localhost:9000`). |
+
+---
+
+## 9. Gotchas (learned the hard way)
+
+- **`@modelcontextprotocol/sdk@1.29` only exports coarse subpaths.** Import the
+  `.js` specifiers (`/server/index.js`, `/server/streamableHttp.js`, `/types.js`).
+  The bare root `.` import is broken (no `dist/esm/index.js`).
+- **Test runner truncates the DB before every test except the first.** Seed in
+  `beforeEach`, not `beforeAll`, or only the first test sees the data.
+- **Stateless transport needs the parsed body handed in.** Medusa's body parser
+  already consumed the stream, so `handler.ts` passes `req.body` to
+  `transport.handleRequest(...)` explicitly.
+- **`semantic_search` is a GET** (the route doc-comment says POST but the handler
+  is GET).
+- **Write tools: let Medusa validate.** Don't tighten the MCP `inputSchema` to
+  mirror the route validator — you'll drift. Keep it loose and surface the
+  route's 400 message via the in-band error.
+</content>

--- a/apps/docs/notes/STORE_MCP_SERVER_GUIDE.md
+++ b/apps/docs/notes/STORE_MCP_SERVER_GUIDE.md
@@ -188,8 +188,12 @@ create_cart ──▶ add_line_item* ──▶ update_cart (email + shipping/bil
 | `initialize_payment_session` | POST | `/store/payment-collections/:id/payment-sessions` |
 | `complete_cart` | POST | `/store/carts/:id/complete` |
 | `payu_generate_upi_intent` | POST | `/store/payu/intent` (INR — UPI deep link) |
+| `create_payment_link` | POST | `/store/payu/payment-link` (INR — shareable link) |
 | `payu_complete_payment` | POST | `/store/payu/complete` (INR) |
 | `payu_refresh_payment` | POST | `/store/payu/refresh` (INR) |
+
+(The PayU dashboard webhook `POST /webhooks/payu/link` — outside `/store`, no tool —
+completes a paid payment link into an order.)
 
 `complete_cart` returns `{ type: "order", order }` on success or
 `{ type: "cart", cart, error }` if completion failed (e.g. payment not
@@ -261,6 +265,38 @@ JSON, S2S UPI Intent isn't enabled on that merchant (409 with a clear message);
 fall back to the hosted link. This is the most agent-friendly INR primitive: a
 returnable link/QR with zero PCI surface.
 
+### PayU Payment Link (`create_payment_link`) → order (verify-then-complete)
+
+A second INR rail (PayU **OneAPI**, OAuth) that returns a **shareable
+`https://v.payu.in/…` link** whose checkout offers UPI + cards. Unlike the
+session-based rails, the link is paid out-of-band — so completion is
+**webhook-verified**, never trust-the-redirect:
+
+```
+create_payment_link({ cart_id })           # amount+customer from the cart; udf1=cart_id
+   ⇒ { payment_link, invoice_number }       # invoice_number persisted on cart.metadata
+→ customer opens link, pays (UPI/card)
+→ PayU dashboard webhook  POST /webhooks/payu/link   (urlencoded, reverse-SHA512 hash)
+     1. verify the hash with PAYU_MERCHANT_SALT
+     2. re-query OneAPI GET /payment-links/{invoice}/txns → confirm success + amount
+     3. completeCartFromExternalPayment(cart) → manual session → completeCartWorkflow → ORDER
+```
+
+- **Verify-then-complete**, layered: the webhook hash proves PayU sent it; the
+  OneAPI `/txns` re-query proves it was actually paid (webhooks can be replayed).
+  Only then does the cart complete.
+- The link is collected on PayU's side, so the Medusa payment is modelled with the
+  **manual provider** (`PAYU_LINK_COMPLETE_PROVIDER`, default `pp_system_default`)
+  and the PayU `txnid`/`mihpayid`/`bank_ref_num` are stored on the session for
+  reconciliation. Completion is **idempotent** (duplicate webhook → existing order).
+- Pure, unit-tested: `verifyWebhookHash`, `isLinkPaid`, `buildPaymentLinkBody`.
+- **Webhook URL is configured in the PayU dashboard** (Developers → Webhooks),
+  pointing at `https://<backend>/webhooks/payu/link` — there is no per-link notify
+  field in PayU's API. Needs the OneAPI env (below) for the re-query step.
+- ⚠️ Assumes the OneAPI merchant and the classic `merchant_key`/`salt` are the
+  **same** PayU account (the webhook hash uses the classic salt). End-to-end
+  validation needs a live PayU sandbox + a public webhook URL.
+
 **What the MCP cannot do for PayU (by design, not a gap):**
 - The hosted-page payment step itself is a **browser redirect** with a
   hash-signed form POST to `test.payu.in` / `secure.payu.in`. An agent can
@@ -302,6 +338,10 @@ and the admin/provider-internal operations intentionally do not.
 | `STORE_MCP_DEFAULT_PUBLISHABLE_KEY` | Last-resort key when a call has no `store` arg and no header. Set to the main storefront's public key. |
 | `STORE_MCP_ENABLE_WRITE` | `true`/`1`/`yes` to enable cart & payment write tools. Default off (read-only). |
 | `STORE_MCP_LOOPBACK_URL` | Override the loopback origin (default: derived from the request, e.g. `http://localhost:9000`). |
+| `PAYU_MERCHANT_KEY` / `PAYU_MERCHANT_SALT` | Classic PayU creds — hosted checkout, UPI intent, and the payment-link webhook hash verification. |
+| `PAYU_CLIENT_ID` / `PAYU_CLIENT_SECRET` / `PAYU_MERCHANT_ID` | PayU **OneAPI** OAuth creds for `create_payment_link` + the webhook `/txns` re-verification. |
+| `PAYU_ONEAPI_MODE` | `test` (UAT, default) or `prod` — selects the `uatoneapi`/`uat-accounts` vs `oneapi`/`accounts` hosts. |
+| `PAYU_LINK_COMPLETE_PROVIDER` | Manual provider used to complete a paid link into an order. Default `pp_system_default`. |
 
 ---
 

--- a/apps/docs/notes/STORE_MCP_SERVER_GUIDE.md
+++ b/apps/docs/notes/STORE_MCP_SERVER_GUIDE.md
@@ -59,12 +59,19 @@ These are deliberate; don't "simplify" them away.
    to scope the request — it never HTTP-500s.
 
 4. **Multi-tenant store resolution.** The platform runs many partner
-   storefronts (each = one sales channel = one publishable key). Agents work in
-   terms of **store names**, not raw `pk_` tokens. Native (container-backed)
-   tools `list_stores` and `get_storefront_key` resolve
-   partner handle/domain → store → default sales channel → publishable token via
-   `store-resolver.ts` (mirrors `GET /web/storefront/[subdomain]`). Any proxy
-   tool also accepts an optional `store` arg that resolves the same way.
+   storefronts (each = one sales channel = one publishable key) **plus its own
+   core store** (the apex `cicilabel.com`). Agents work in terms of **store
+   names**, not raw `pk_` tokens. Native (container-backed) tools `list_stores`
+   and `get_storefront_key` resolve partner handle/domain → store → default
+   sales channel → publishable token via `store-resolver.ts` (mirrors
+   `GET /web/storefront/[subdomain]`). Any proxy tool also accepts an optional
+   `store` arg that resolves the same way.
+   - **The core store is not partner-owned**, so iterating partners alone misses
+     it. `store-resolver.ts` therefore also queries the `stores` entity and
+     includes any store **not** linked to a partner, flagged `is_default: true`
+     and given the apex domain (`ROOT_DOMAIN`, default `cicilabel.com`). It is
+     resolvable by `"default"` / `"main"`, the apex domain, or its store
+     name/id/sales-channel id. `list_stores` returns default store(s) first.
 
 5. **Stateless Streamable-HTTP transport.** Each POST is a self-contained
    JSON-RPC request (`sessionIdGenerator: undefined`, `enableJsonResponse: true`).


### PR DESCRIPTION
Builds on the read-only Store MCP server (#743/#744): adds the **write surface** (cart → checkout → pay), **store-first discovery**, and a full **PayU INR payments** integration — all gated, documented, and tested (incl. a live end-to-end run).

## 1. Cart → checkout → pay write tools
Gated behind `STORE_MCP_ENABLE_WRITE` (hidden from `tools/list` + rejected by `tools/call` when off). Each proxies the matching native `/store` route, so sales-channel scoping, pricing/tax, and Medusa's own validators still run.

`create_cart`, `get_cart`, `update_cart`, `add_line_item`, `update_line_item`, `remove_line_item`, `add_promotion`, `list_shipping_options`, `add_shipping_method`, `list_payment_providers`, `create_payment_collection`, `initialize_payment_session`, `complete_cart`.

`initialize_payment_session` resolves a per-provider **`next_action`**: PayU → hosted link + signed fields; Stripe → `client_secret`; manual → `session_ready`.

## 2. Store-first discovery
`list_stores` / `get_storefront_key` now enumerate the `store` entity (rich fields like core `/admin/stores`) and join partner handle/domain — so the platform **core store** (apex `cicilabel.com`, `is_default:true`) is always included, with `default_region_id` + `currency_code`. Resolvable by `"default"`/apex domain/store name/id.

## 3. PayU (INR) — two rails
- **UPI intent** (`payu_generate_upi_intent`): replays the cart's PayU session to S2S `/_payment` (`bankcode=INTENT`) → a `upi://pay?…` deep link + QR. No card/PCI surface.
- **Payment link** (`create_payment_link`): PayU OneAPI (OAuth) → a shareable `https://v.payu.in/…` link. Paying it completes the cart **into an order**, **verify-then-complete**: webhook (`/webhooks/payu/link`) verifies the reverse-SHA512 hash → re-queries OneAPI `/txns` to confirm paid → `completeCartWorkflow` (idempotent).
- Plus `payu_complete_payment` / `payu_refresh_payment` for the hosted-redirect flow.

Pure, unit-tested helpers throughout (`paymentNextAction`, `buildUpiIntentForm`/`parseUpiIntentResponse`, `verifyWebhookHash`/`isLinkPaid`/`buildPaymentLinkBody`).

## 4. Docs
`apps/docs/notes/STORE_MCP_SERVER_GUIDE.md` — architecture, the 5 locked decisions, read/write/PayU tool authoring, the full checkout + INR flows, safety model, env config, gotchas. README updated.

## Tests
- Unit: payment next_action (8), UPI-intent lib (9), payment-link lib (12).
- Integration: write-tools gating/proxy (8), multistore + default store (6).
- **Live e2e (opt-in `PAYU_LIVE_TEST=1`)**: drove the real `/mcp` tools against PayU's test gateway → confirmed a real `upi://pay?…` link **and** a real `https://v.payu.in/…` link. ✅

## Config / prod notes
- New env: `STORE_MCP_ENABLE_WRITE`, `PAYU_CLIENT_ID/SECRET/MERCHANT_ID`, `PAYU_ONEAPI_MODE`, `PAYU_LINK_COMPLETE_PROVIDER`, `STORE_MCP_DEFAULT_STORE_DOMAIN`.
- `medusa-config.ts` now conditionally registers the payment module (Stripe/PayU) when creds are present (mirrors `.prod.ts`); keyless CI unaffected.
- ⚠️ The payment-link webhook + order completion need a public webhook URL + live PayU dashboard config to validate e2e, and assume the classic key/salt and OneAPI OAuth are the same PayU merchant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)