### PR TITLE
chore(deploy): wire STRIPE_PUBLISHABLE_KEY into prod manifest (DO NOT MERGE until SSM param exists)

### DIFF
--- a/deploy/aws/copilot/medusa-server/manifest.yml
+++ b/deploy/aws/copilot/medusa-server/manifest.yml
@@ -153,6 +153,10 @@ secrets:
   # Off by default in code; "true" here exposes them. See src/api/mcp/README.md.
   STORE_MCP_ENABLE_WRITE: /jyt/prod/STORE_MCP_ENABLE_WRITE
   STRIPE_API_KEY: /jyt/prod/STRIPE_API_KEY
+  # Public client-side key (pk_…) for the self-hosted Stripe card page
+  # (GET /stripe/pay/:cart_id). Non-secret, but env-specific so it's sourced from
+  # SSM like the other Stripe params. Without it the hosted page won't render.
+  STRIPE_PUBLISHABLE_KEY: /jyt/prod/STRIPE_PUBLISHABLE_KEY
   STRIPE_WEBHOOK_SECRET: /jyt/prod/STRIPE_WEBHOOK_SECRET
   VERCEL_STOREFRONT_REPO: /jyt/prod/VERCEL_STOREFRONT_REPO
   VERCEL_TEAM_ID: /jyt/prod/VERCEL_TEAM_ID


### PR DESCRIPTION
Follow-up to #749. Re-adds the `STRIPE_PUBLISHABLE_KEY` SSM reference to `medusa-server/manifest.yml` that was deliberately dropped from #749 to keep the deploy safe.

## ⛔ Merge gate
**Do NOT merge until** the SSM param exists, or the prod deploy (auto-triggered on merge — this touches `deploy/aws/**`) will fail at ECS task start:

1. Create SSM param `/jyt/prod/STRIPE_PUBLISHABLE_KEY` = the `pk_live_…` publishable key.
2. Tag it `copilot-application=jyt` + `copilot-environment=prod` (untagged → ECS AccessDenied).
3. Then merge this PR → backend redeploys → the self-hosted Stripe card page (`GET /stripe/pay/:cart_id`) renders in prod.

Until merged, the page degrades gracefully ("unavailable" + a warning log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)