### PR TITLE
fix(store-mcp): restore storefront AI chat (developer-role rejection on DashScope)

### DIFF
--- a/apps/backend/src/api/store/ai/chat/__tests__/system-fold-lib.unit.spec.ts
+++ b/apps/backend/src/api/store/ai/chat/__tests__/system-fold-lib.unit.spec.ts
@@ -1,0 +1,80 @@
+import {
+  foldSystemForProvider,
+  type ChatUiMessage,
+} from "../system-fold-lib"
+
+const msg = (role: string, text: string): ChatUiMessage => ({
+  role,
+  parts: [{ type: "text", text }],
+})
+
+describe("foldSystemForProvider", () => {
+  const SYSTEM = "You are a concierge."
+
+  it("keeps the native system param for OpenRouter (env fallback id)", () => {
+    const messages = [msg("user", "hi")]
+    const out = foldSystemForProvider("openrouter:free", SYSTEM, messages)
+    expect(out.system).toBe(SYSTEM)
+    expect(out.messages).toEqual(messages)
+  })
+
+  it("keeps the native system param for a DB-configured OpenRouter platform", () => {
+    const out = foldSystemForProvider("db:openrouter:01ABC", SYSTEM, [msg("user", "hi")])
+    expect(out.system).toBe(SYSTEM)
+  })
+
+  it("folds system into the first user message for DashScope (no system role)", () => {
+    const out = foldSystemForProvider("db:dashscope:01XYZ", SYSTEM, [msg("user", "hi there")])
+    expect(out.system).toBeUndefined()
+    expect(out.messages[0].role).toBe("user")
+    expect(out.messages[0].parts[0].text).toBe(`${SYSTEM}\n\nhi there`)
+  })
+
+  it("folds for Cloudflare too (any non-openrouter provider)", () => {
+    const out = foldSystemForProvider("cloudflare:@cf/meta/llama-3.1-8b-instruct", SYSTEM, [
+      msg("user", "hi"),
+    ])
+    expect(out.system).toBeUndefined()
+    expect(out.messages[0].parts[0].text).toBe(`${SYSTEM}\n\nhi`)
+  })
+
+  it("folds into the FIRST user message when history has assistant turns", () => {
+    const messages = [
+      msg("user", "first"),
+      msg("assistant", "reply"),
+      msg("user", "second"),
+    ]
+    const out = foldSystemForProvider("dashscope:qwen-plus", SYSTEM, messages)
+    expect(out.messages[0].parts[0].text).toBe(`${SYSTEM}\n\nfirst`)
+    // later turns untouched
+    expect(out.messages[1].parts[0].text).toBe("reply")
+    expect(out.messages[2].parts[0].text).toBe("second")
+  })
+
+  it("prepends a user message when there's no user turn", () => {
+    const out = foldSystemForProvider("dashscope:qwen-plus", SYSTEM, [msg("assistant", "hello")])
+    expect(out.messages[0].role).toBe("user")
+    expect(out.messages[0].parts[0].text).toBe(SYSTEM)
+    expect(out.messages[1].role).toBe("assistant")
+  })
+
+  it("inserts a text part when the first user message has none", () => {
+    const out = foldSystemForProvider("dashscope:qwen-plus", SYSTEM, [
+      { role: "user", parts: [] },
+    ])
+    expect(out.messages[0].parts[0]).toEqual({ type: "text", text: SYSTEM })
+  })
+
+  it("does not pass an empty system param when system is blank", () => {
+    const out = foldSystemForProvider("dashscope:qwen-plus", "   ", [msg("user", "hi")])
+    expect(out.system).toBeUndefined()
+    expect(out.messages[0].parts[0].text).toBe("hi")
+  })
+
+  it("does not mutate the caller's messages array or parts", () => {
+    const messages = [msg("user", "hi")]
+    const snapshot = JSON.stringify(messages)
+    foldSystemForProvider("dashscope:qwen-plus", SYSTEM, messages)
+    expect(JSON.stringify(messages)).toBe(snapshot)
+  })
+})

--- a/apps/backend/src/api/store/ai/chat/route.ts
+++ b/apps/backend/src/api/store/ai/chat/route.ts
@@ -38,6 +38,7 @@ import {
   createGetCategoryProductsTool,
   createGetProductDetailsTool,
 } from "../../../../mastra/agents/tools/storefront-catalog-tools"
+import { foldSystemForProvider } from "./system-fold-lib"
 import type { StoreAiChatReq } from "./validators"
 
 export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
@@ -100,12 +101,19 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     }
   })
 
+  // Place the system prompt where the resolved provider accepts it. For
+  // OpenAI-compatible endpoints (DashScope/Cloudflare/…), @ai-sdk/openai emits
+  // the system message with role `developer` for any non-GPT model id, which
+  // DashScope rejects — so we fold it into the first user message instead.
+  // Only OpenRouter keeps the native `system` param. See system-fold-lib.ts.
+  const folded = foldSystemForProvider(resolved.provider, system, messages)
+
   let result
   try {
     result = streamText({
       model: resolved.model,
-      system,
-      messages: convertToModelMessages(messages as any),
+      ...(folded.system ? { system: folded.system } : {}),
+      messages: convertToModelMessages(folded.messages as any),
       tools,
       // Allow a couple of tool round-trips per turn (e.g. get_categories
       // then get_category_products, or search then get_product_details)

--- a/apps/backend/src/api/store/ai/chat/system-fold-lib.ts
+++ b/apps/backend/src/api/store/ai/chat/system-fold-lib.ts
@@ -1,0 +1,80 @@
+/**
+ * Provider-aware placement of the chat system prompt.
+ *
+ * Why this exists:
+ *   `@ai-sdk/openai` (used for every OpenAI-compatible provider — DashScope,
+ *   Cloudflare, Vercel AI Gateway, custom) decides how to emit the system
+ *   message from the model id alone:
+ *
+ *     isReasoningModel = !(id.startsWith("gpt-3"|"gpt-4"|"chatgpt-4o"|"gpt-5-chat"))
+ *     systemMessageMode = isReasoningModel ? "developer" : "system"
+ *
+ *   So ANY non-GPT id (e.g. DashScope's `qwen-plus`) is treated as a
+ *   "reasoning model" and the system prompt is sent with role `developer`.
+ *   DashScope's API rejects it:
+ *     "developer is not one of ['system','assistant','user','tool','function']
+ *      - 'messages.[0].role'"
+ *   — which surfaces to the shopper as "Something went wrong. Try again."
+ *
+ *   There's no per-call override for `systemMessageMode` in the pinned
+ *   `@ai-sdk/openai` (v2, spec v2). The fix mirrors `buildGenerateArgs` in
+ *   `mastra/services/ai-platforms.ts`: keep the native `system` param for
+ *   OpenRouter (which accepts the role), and for everything else fold the
+ *   system text into the first user message so no `system`/`developer` role
+ *   is ever emitted. Folding into a user message is accepted everywhere.
+ *
+ * Pure — no container, no SDK. Unit-tested.
+ */
+
+export type ChatTextPart = { type: string; text: string }
+export type ChatUiMessage = { role: string; parts: ChatTextPart[] }
+
+export type FoldedChatInput = {
+  /** Pass to streamText({ system }) only when present (OpenRouter). */
+  system?: string
+  /** The (possibly rewritten) UI messages to convert + stream. */
+  messages: ChatUiMessage[]
+}
+
+/**
+ * Decide where the system prompt goes for the resolved provider.
+ *
+ * @param provider  the `resolved.provider` string, e.g. `db:dashscope:01..`,
+ *                  `dashscope:qwen-plus`, `db:openrouter:01..`, `openrouter:free`.
+ * @param system    the built system prompt.
+ * @param messages  normalised UI messages (text-only parts).
+ */
+export const foldSystemForProvider = (
+  provider: string,
+  system: string,
+  messages: ChatUiMessage[]
+): FoldedChatInput => {
+  // OpenRouter accepts the AI-SDK `system` role natively — leave it alone.
+  if (provider.includes("openrouter")) {
+    return { system, messages }
+  }
+
+  const sys = (system || "").trim()
+  if (!sys) return { messages }
+
+  // Deep-copy so callers' arrays/parts aren't mutated.
+  const out: ChatUiMessage[] = messages.map((m) => ({
+    role: m.role,
+    parts: m.parts.map((p) => ({ ...p })),
+  }))
+
+  const firstUser = out.find((m) => m.role === "user")
+  if (!firstUser) {
+    // No user turn (shouldn't happen — validator requires ≥1 message) — add one.
+    out.unshift({ role: "user", parts: [{ type: "text", text: sys }] })
+    return { messages: out }
+  }
+
+  const firstText = firstUser.parts.find((p) => p.type === "text")
+  if (firstText) {
+    firstText.text = firstText.text ? `${sys}\n\n${firstText.text}` : sys
+  } else {
+    firstUser.parts.unshift({ type: "text", text: sys })
+  }
+  return { messages: out }
+}


### PR DESCRIPTION
## Prod-down hotfix

The storefront concierge chat streams `{"type":"error"}` → "Something went wrong. Try again." in prod.

**Root cause:** `@ai-sdk/openai@2.0.94` (pulled in by a recent `pnpm-lock` bump) classifies any model id that isn't `gpt-3*/gpt-4*/chatgpt-4o/gpt-5-chat` as a "reasoning model" and emits the system prompt with role `developer`. DashScope (`qwen-*`) — our configured `ai_search_chat` platform — rejects it:

```
developer is not one of ['system','assistant','user','tool','function'] - 'messages.[0].role'
```

Confirmed in CloudWatch `/copilot/jyt-prod-medusa-server`.

`@ai-sdk/openai` has no per-call `systemMessageMode` override, and `@ai-sdk/openai-compatible` isn't a drop-in (it ships spec **v3** models while `ai@5.0.52` runs the spec **v2** models from `@ai-sdk/openai`).

**Fix:** mirror the existing `buildGenerateArgs` pattern — keep the native `system` param for OpenRouter (accepts the role), and for every OpenAI-compatible provider fold the system prompt into the first user message so no `system`/`developer` role is ever emitted. New pure helper `foldSystemForProvider` (9 unit tests) wired into the chat route.

## Scope
Isolated to the storefront chat path. A follow-up PR will unify model resolution across all AI features (route through configured platform roles, free-model fallback) — tracked separately.

## Test
`TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules npx jest --testPathPattern="system-fold-lib"` → 9/9 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)