### PR TITLE
feat(ai): unified role→platform resolver + usage logging + category sweep

### DIFF
--- a/apps/backend/src/api/admin/ai/platforms/route.ts
+++ b/apps/backend/src/api/admin/ai/platforms/route.ts
@@ -1,0 +1,35 @@
+/**
+ * @file GET /admin/ai/platforms — AI External Platform discovery (category sweep).
+ *
+ * "Discovery, not declaration": sweeps every `category=ai` External Platform and
+ * returns the configured catalog grouped by `metadata.role`. Any provider the
+ * operator adds — including under a brand-new custom role — shows up here with no
+ * code change. Powers the visual-flow AI op's role/platform picker and ops
+ * visibility into what's wired.
+ *
+ * Query:
+ *   - include_inactive=true  → include draft/inactive platforms (default: active only)
+ *
+ * Returns: { catalog: AiPlatformCatalogEntry[], by_role: Record<role, entries[]>, roles: string[] }
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import {
+  sweepAiPlatformsByCategory,
+  groupAiCatalogByRole,
+} from "../../../../mastra/services/ai-platforms"
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const includeInactive =
+    String((req.query?.include_inactive as string) ?? "").toLowerCase() === "true"
+
+  const catalog = await sweepAiPlatformsByCategory(req.scope as any, {
+    includeInactive,
+  })
+  const byRole = groupAiCatalogByRole(catalog)
+
+  res.json({
+    catalog,
+    by_role: byRole,
+    roles: Object.keys(byRole).sort(),
+  })
+}

--- a/apps/backend/src/mastra/services/__tests__/resolve-role-text-model.unit.spec.ts
+++ b/apps/backend/src/mastra/services/__tests__/resolve-role-text-model.unit.spec.ts
@@ -1,0 +1,192 @@
+import {
+  formatAiUsage,
+  logAiUsage,
+  resolveRoleTextModel,
+  summarizeAiPlatformCatalog,
+  groupAiCatalogByRole,
+  sweepAiPlatformsByCategory,
+  type AiUsage,
+} from "../ai-platforms"
+
+describe("formatAiUsage", () => {
+  const base: AiUsage = {
+    feature: "store/ai/search",
+    role: "ai_search_chat",
+    provider: "dashscope",
+    source: "platform",
+    ok: true,
+  }
+
+  it("renders a full success line with optional fields", () => {
+    const line = formatAiUsage({
+      ...base,
+      model: "qwen-plus",
+      platformId: "01ABC",
+      ms: 412.7,
+      tokens: 1234,
+    })
+    expect(line).toBe(
+      "[ai-usage] feature=store/ai/search role=ai_search_chat provider=dashscope source=platform model=qwen-plus platform=01ABC ok=true ms=413 tokens=1234"
+    )
+  })
+
+  it("omits absent optionals and rounds ms", () => {
+    const line = formatAiUsage({ ...base, ms: 9.9 })
+    expect(line).toBe(
+      "[ai-usage] feature=store/ai/search role=ai_search_chat provider=dashscope source=platform ok=true ms=10"
+    )
+    expect(line).not.toContain("model=")
+    expect(line).not.toContain("tokens=")
+  })
+
+  it("renders a failure line with a truncated error and no tokens", () => {
+    const line = formatAiUsage({
+      ...base,
+      ok: false,
+      source: "free",
+      provider: "openrouter",
+      error: new Error("x".repeat(500)),
+    })
+    expect(line).toContain("ok=false")
+    expect(line).toContain("source=free")
+    expect(line).toMatch(/error=x{200}$/) // capped at 200 chars
+  })
+
+  it("accepts a plain-string error", () => {
+    const line = formatAiUsage({ ...base, ok: false, error: "boom" })
+    expect(line).toContain("error=boom")
+  })
+})
+
+describe("logAiUsage", () => {
+  it("routes success to info and failure to warn", () => {
+    const calls: { level: string; msg: string }[] = []
+    const logger = {
+      info: (m: string) => calls.push({ level: "info", msg: m }),
+      warn: (m: string) => calls.push({ level: "warn", msg: m }),
+    }
+    logAiUsage(logger, {
+      feature: "f", role: "ai_search_chat", provider: "dashscope", source: "platform", ok: true,
+    })
+    logAiUsage(logger, {
+      feature: "f", role: "ai_search_chat", provider: "openrouter", source: "free", ok: false, error: "e",
+    })
+    expect(calls.map((c) => c.level)).toEqual(["info", "warn"])
+    expect(calls[0].msg).toContain("[ai-usage]")
+  })
+
+  it("never throws when the logger is missing methods", () => {
+    expect(() =>
+      logAiUsage({} as any, {
+        feature: "f", role: "ai_search_chat", provider: "dashscope", source: "platform", ok: true,
+      })
+    ).not.toThrow()
+  })
+})
+
+describe("summarizeAiPlatformCatalog", () => {
+  it("maps rows, reading role/provider/model/default/key from metadata+api_config", () => {
+    const rows = [
+      {
+        id: "01A",
+        name: "Qwen prod",
+        status: "active",
+        metadata: { role: "ai_search_chat", provider_type: "dashscope", is_default: true },
+        api_config: { default_model: "qwen-plus", api_key_encrypted: "xx" },
+      },
+      {
+        id: "01B",
+        status: "draft",
+        metadata: { role: "ai_newsletter_drafter" },
+        api_config: { provider_type: "openrouter", default_model: "x/y:free" },
+      },
+    ]
+    const cat = summarizeAiPlatformCatalog(rows)
+    expect(cat[0]).toEqual({
+      platformId: "01A",
+      name: "Qwen prod",
+      role: "ai_search_chat",
+      providerType: "dashscope",
+      defaultModel: "qwen-plus",
+      isDefault: true,
+      status: "active",
+      hasApiKey: true,
+    })
+    expect(cat[1].role).toBe("ai_newsletter_drafter")
+    expect(cat[1].providerType).toBe("openrouter")
+    expect(cat[1].isDefault).toBe(false)
+    expect(cat[1].hasApiKey).toBe(false)
+  })
+
+  it("tolerates empty / missing fields", () => {
+    expect(summarizeAiPlatformCatalog([])).toEqual([])
+    const [e] = summarizeAiPlatformCatalog([{ id: "x" }])
+    expect(e.role).toBeNull()
+    expect(e.providerType).toBeNull()
+    expect(e.hasApiKey).toBe(false)
+  })
+
+  it("auto-discovers an unknown/custom role verbatim (no allow-list)", () => {
+    const [e] = summarizeAiPlatformCatalog([
+      { id: "z", metadata: { role: "ai_my_custom_thing", provider_type: "custom" } },
+    ])
+    expect(e.role).toBe("ai_my_custom_thing")
+  })
+})
+
+describe("groupAiCatalogByRole", () => {
+  it("groups by role and buckets untagged platforms under _untagged", () => {
+    const grouped = groupAiCatalogByRole(
+      summarizeAiPlatformCatalog([
+        { id: "1", metadata: { role: "ai_search_chat" } },
+        { id: "2", metadata: { role: "ai_search_chat" } },
+        { id: "3", metadata: {} },
+      ])
+    )
+    expect(grouped["ai_search_chat"].map((e) => e.platformId)).toEqual(["1", "2"])
+    expect(grouped["_untagged"].map((e) => e.platformId)).toEqual(["3"])
+  })
+})
+
+describe("sweepAiPlatformsByCategory", () => {
+  it("returns [] when the socials module can't be resolved", async () => {
+    const container = { resolve: () => { throw new Error("no module") } } as any
+    expect(await sweepAiPlatformsByCategory(container)).toEqual([])
+  })
+
+  it("queries category=ai and active-only by default, includeInactive widens it", async () => {
+    const seen: any[] = []
+    const container = {
+      resolve: () => ({
+        listSocialPlatforms: async (filters: any) => {
+          seen.push(filters)
+          return [{ id: "1", metadata: { role: "ai_search_chat" } }]
+        },
+      }),
+    } as any
+    const out = await sweepAiPlatformsByCategory(container)
+    expect(seen[0]).toEqual({ category: "ai", status: "active" })
+    expect(out[0].platformId).toBe("1")
+
+    await sweepAiPlatformsByCategory(container, { includeInactive: true })
+    expect(seen[1]).toEqual({ category: "ai" })
+  })
+})
+
+describe("resolveRoleTextModel", () => {
+  it("falls back to the free rotator when the container can't resolve a platform", async () => {
+    // container.resolve throws → getAiPlatformForRole returns null → free fallback
+    const container = {
+      resolve: () => {
+        throw new Error("no socials module")
+      },
+    } as any
+    const out = await resolveRoleTextModel(container, "ai_search_chat")
+    expect(out.source).toBe("free")
+    expect(out.provider ?? out.providerType).toBeDefined()
+    expect(out.providerType).toBe("openrouter")
+    expect(out.modelId).toBe("free-rotator")
+    expect(out.model).toBeDefined()
+    expect(out.platformId).toBeUndefined()
+  })
+})

--- a/apps/backend/src/mastra/services/ai-platforms.ts
+++ b/apps/backend/src/mastra/services/ai-platforms.ts
@@ -330,6 +330,205 @@ export const buildEmbeddingModel = (
   return client.embedding(id)
 }
 
+// ── Unified role → model resolution + usage logging ────────────────────
+
+import { dynamicFreeTextModel } from "../providers/dynamic-text-model"
+
+export type ResolvedRoleModel = {
+  /** AI-SDK LanguageModel for generateText / generateObject / streamText. */
+  model: any
+  /** Provider behind the model — drives system-prompt placement (buildGenerateArgs). */
+  providerType: AiProviderType
+  /** "platform" when an admin-configured External Platform served the role,
+   *  "free" when we fell back to the auto-rotating OpenRouter free models. */
+  source: "platform" | "free"
+  /** Set only when source==="platform". */
+  platformId?: string
+  /** Resolved model id (platform default, or "free-rotator" sentinel). */
+  modelId?: string
+}
+
+/**
+ * Single entry point every text AI feature should use to pick its model.
+ *
+ *   1. Admin-configured External Platform for `role` (metadata.role lookup) —
+ *      this is the source of truth; uses the operator's chosen provider/model.
+ *   2. Free fallback — the auto-rotating OpenRouter `:free` resolver
+ *      (`dynamicFreeTextModel`). No paid hardcoded models.
+ *
+ * Never throws — a resolution failure degrades to the free fallback so a
+ * feature never goes dark because of a transient platform error.
+ */
+export const resolveRoleTextModel = async (
+  container: MedusaContainer,
+  role: AiRole,
+  modelOverride?: string
+): Promise<ResolvedRoleModel> => {
+  try {
+    const cfg = await getAiPlatformForRole(container, role)
+    if (cfg) {
+      return {
+        model: buildChatModel(cfg, modelOverride),
+        providerType: cfg.providerType,
+        source: "platform",
+        platformId: cfg.platformId,
+        modelId: modelOverride ?? cfg.defaultModel ?? undefined,
+      }
+    }
+  } catch (e: any) {
+    console.warn(
+      `[ai-platforms] resolveRoleTextModel(${role}) failed, using free fallback: ${
+        e?.message ?? e
+      }`
+    )
+  }
+  return {
+    model: dynamicFreeTextModel,
+    providerType: "openrouter",
+    source: "free",
+    modelId: "free-rotator",
+  }
+}
+
+export type AiUsage = {
+  /** Stable feature key, e.g. "store/ai/search", "marketing/ideas_email". */
+  feature: string
+  role: AiRole
+  provider: AiProviderType
+  source: "platform" | "free"
+  ok: boolean
+  model?: string
+  platformId?: string
+  /** Wall-clock duration of the model call, ms. */
+  ms?: number
+  /** Total tokens if the SDK reported usage. */
+  tokens?: number
+  /** Error message when ok===false. */
+  error?: unknown
+}
+
+/**
+ * Format a single structured AI-usage line. Pure — returned string is what
+ * `logAiUsage` emits, so it's unit-testable without a logger.
+ *
+ * Shape: `[ai-usage] feature=… role=… provider=… source=… model=… ok=… ms=… tokens=… error=…`
+ * Designed for CloudWatch grep/metric-filters ("when & how each AI feature ran").
+ */
+export const formatAiUsage = (u: AiUsage): string => {
+  const parts = [
+    `feature=${u.feature}`,
+    `role=${u.role}`,
+    `provider=${u.provider}`,
+    `source=${u.source}`,
+    u.model ? `model=${u.model}` : null,
+    u.platformId ? `platform=${u.platformId}` : null,
+    `ok=${u.ok}`,
+    u.ms != null ? `ms=${Math.round(u.ms)}` : null,
+    u.tokens != null ? `tokens=${u.tokens}` : null,
+    u.ok ? null : `error=${String((u.error as any)?.message ?? u.error ?? "").slice(0, 200)}`,
+  ].filter(Boolean)
+  return `[ai-usage] ${parts.join(" ")}`
+}
+
+/**
+ * Emit one structured AI-usage line. Medusa's Logger takes a single string;
+ * success → info, failure → warn. Best-effort — never throws into the caller.
+ */
+export const logAiUsage = (logger: any, u: AiUsage): void => {
+  try {
+    const line = formatAiUsage(u)
+    if (u.ok) logger?.info?.(line)
+    else logger?.warn?.(line)
+  } catch {
+    /* logging must never break the AI call */
+  }
+}
+
+// ── Category sweep / discovery (auto-pick up new providers + roles) ─────
+
+export type AiPlatformCatalogEntry = {
+  platformId: string
+  name?: string
+  /** metadata.role — null when the operator hasn't tagged one. */
+  role: string | null
+  providerType: AiProviderType | null
+  defaultModel: string | null
+  /** metadata.is_default — the chosen platform for its role. */
+  isDefault: boolean
+  status: string
+  /** True when an api key is present (encrypted or plaintext) — usable now. */
+  hasApiKey: boolean
+}
+
+/**
+ * Pure: map raw `social_platform` rows (category=ai) into catalog entries.
+ * Exported for unit testing — no container, no decryption.
+ */
+export const summarizeAiPlatformCatalog = (
+  rows: any[]
+): AiPlatformCatalogEntry[] =>
+  (rows ?? []).map((p) => {
+    const apiConfig = (p?.api_config ?? {}) as Record<string, any>
+    const meta = (p?.metadata ?? {}) as Record<string, any>
+    return {
+      platformId: p?.id,
+      name: p?.name ?? undefined,
+      role: (meta.role as string) ?? null,
+      providerType: normalizeProviderType(meta.provider_type ?? apiConfig.provider_type),
+      defaultModel: apiConfig.default_model ?? meta.default_model ?? null,
+      isDefault: meta.is_default === true,
+      status: p?.status ?? "unknown",
+      hasApiKey: Boolean(
+        apiConfig.api_key_encrypted || apiConfig.api_key || apiConfig.encrypted_api_key
+      ),
+    }
+  })
+
+/**
+ * Group a catalog by role. Roles with no `metadata.role` tag land under the
+ * `"_untagged"` bucket. Pure — testable.
+ */
+export const groupAiCatalogByRole = (
+  catalog: AiPlatformCatalogEntry[]
+): Record<string, AiPlatformCatalogEntry[]> => {
+  const out: Record<string, AiPlatformCatalogEntry[]> = {}
+  for (const e of catalog) {
+    const key = e.role ?? "_untagged"
+    ;(out[key] ??= []).push(e)
+  }
+  return out
+}
+
+/**
+ * Sweep every `category=ai` External Platform and return the discovered
+ * catalog. This is the "discovery, not declaration" mechanism: any provider the
+ * operator adds — including under a brand-new custom `metadata.role` — is picked
+ * up automatically, no code change. Powers the visual-flow op role picker, an
+ * admin discovery endpoint, and ops reporting. Never throws → `[]` on failure.
+ */
+export const sweepAiPlatformsByCategory = async (
+  container: MedusaContainer,
+  opts: { includeInactive?: boolean } = {}
+): Promise<AiPlatformCatalogEntry[]> => {
+  let socials: SocialsService
+  try {
+    socials = container.resolve(SOCIALS_MODULE) as unknown as SocialsService
+  } catch {
+    return []
+  }
+  try {
+    const filters: any = { category: "ai" }
+    if (!opts.includeInactive) filters.status = "active"
+    const rows = await socials.listSocialPlatforms(filters, { take: 200 })
+    return summarizeAiPlatformCatalog(rows ?? [])
+  } catch (e: any) {
+    console.warn(
+      `[ai-platforms] sweepAiPlatformsByCategory failed: ${e?.message ?? e}`
+    )
+    return []
+  }
+}
+
 export const PROVIDER_TYPES: AiProviderType[] = [
   "openrouter",
   "dashscope",


### PR DESCRIPTION
Foundation for the AI-platform unification work (follow-up to the chat hotfix #752). Routes every AI feature through the operator-configured **External Platforms** (`category=ai`) by `metadata.role`, with a **free-model** fallback and structured usage logging.

**No existing feature is rewired in this PR** — it only adds the shared primitives + a discovery endpoint, so it's zero behavior-change and safe to merge. Caller migrations land in a follow-up.

## What's here
- **`resolveRoleTextModel(container, role)`** — admin-configured platform for the role (`getAiPlatformForRole` → `buildChatModel`), else the auto-rotating OpenRouter `:free` resolver. Never throws → degrades to free.
- **`formatAiUsage` / `logAiUsage`** — one structured line per call: `[ai-usage] feature=… role=… provider=… source=platform|free ok=… ms=… tokens=…` (success→info, failure→warn). Answers "when & how each AI feature ran" via CloudWatch.
- **Category sweep (discovery, not declaration)** — `sweepAiPlatformsByCategory` + `summarizeAiPlatformCatalog` + `groupAiCatalogByRole` enumerate every `category=ai` platform grouped by `metadata.role`. Any new provider — **including under a brand-new custom role** — is picked up with no code change.
- **`GET /admin/ai/platforms`** — serves the swept catalog (`by_role` + `roles`) for the upcoming visual-flow AI op's role picker and ops visibility.

## Next (separate PRs)
- PR C — migrate the 5 hardcoded callers (storefront search, newsletter draft, ideas email, sentiment, admin chat) onto `resolveRoleTextModel` + logging.
- PR D — general-purpose `ai_generate` visual-flow op (category/role-aware, output into the data chain).
- PR E — Data Plumbing "sweep & report" job (audit configured AI platforms by role).

## Test
`TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules npx jest --testPathPattern="resolve-role-text-model"` → 13/13 green. `tsc` clean for changed files (pre-existing integration-test errors unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)