### PR TITLE
feat(ai): route all AI features through configured platforms + usage logging

### DIFF
--- a/apps/backend/src/api/store/ai/search/extract.ts
+++ b/apps/backend/src/api/store/ai/search/extract.ts
@@ -29,7 +29,10 @@ import { z } from "zod"
 import { dynamicFreeTextModel } from "../../../../mastra/providers/dynamic-text-model"
 import {
   buildChatModel,
+  buildGenerateArgs,
   getAiPlatformForRole,
+  logAiUsage,
+  type AiProviderType,
 } from "../../../../mastra/services/ai-platforms"
 
 const SearchInterpretationSchema = z.object({
@@ -108,13 +111,20 @@ const getCloudflare = () => {
 
 type Attempt = { name: string; call: () => Promise<SearchInterpretation> }
 
+/**
+ * generateObject args with the system prompt placed where the provider accepts
+ * it: OpenRouter keeps the native `system` role; OpenAI-compatible providers
+ * (DashScope/Cloudflare) get it folded into the user message via
+ * `buildGenerateArgs`, since @ai-sdk/openai would otherwise emit role
+ * `developer` and DashScope rejects it (same bug as the chat route, #752).
+ */
+const buildObjectArgs = (query: string, providerType: AiProviderType) => ({
+  schema: SearchInterpretationSchema,
+  ...buildGenerateArgs({ providerType }, SYSTEM_PROMPT, query),
+  temperature: 0.1,
+})
+
 const buildAttempts = (query: string): Attempt[] => {
-  const opts = {
-    schema: SearchInterpretationSchema,
-    system: SYSTEM_PROMPT,
-    prompt: query,
-    temperature: 0.1,
-  }
   const attempts: Attempt[] = []
 
   // 1. OpenRouter free models (via existing dynamic rotator)
@@ -123,7 +133,7 @@ const buildAttempts = (query: string): Attempt[] => {
       name: "openrouter:free",
       call: async () => {
         const { object } = await generateObject({
-          ...opts,
+          ...buildObjectArgs(query, "openrouter"),
           model: dynamicFreeTextModel,
         })
         return object
@@ -140,7 +150,7 @@ const buildAttempts = (query: string): Attempt[] => {
       name: `dashscope:${modelId}`,
       call: async () => {
         const { object } = await generateObject({
-          ...opts,
+          ...buildObjectArgs(query, "dashscope"),
           model: dashscope(modelId),
         })
         return object
@@ -158,7 +168,7 @@ const buildAttempts = (query: string): Attempt[] => {
       name: `cloudflare:${modelId}`,
       call: async () => {
         const { object } = await generateObject({
-          ...opts,
+          ...buildObjectArgs(query, "cloudflare"),
           model: cloudflare(modelId),
         })
         return object
@@ -217,34 +227,44 @@ export const extractSearchInterpretation = async (
   query: string,
   container?: MedusaContainer
 ): Promise<SearchInterpretation> => {
-  const opts = {
-    schema: SearchInterpretationSchema,
-    system: SYSTEM_PROMPT,
-    prompt: query,
-    temperature: 0.1,
-  }
-
   // 1. DB-configured platform — wins if present.
   if (container) {
     try {
       const cfg = await getAiPlatformForRole(container, "ai_search_chat")
       if (cfg) {
+        const started = Date.now()
         try {
           const { object } = await withTimeout(
             generateObject({
-              ...opts,
+              ...buildObjectArgs(query, cfg.providerType),
               model: buildChatModel(cfg),
             }),
             EXTRACT_BUDGET_MS,
             `db-platform:${cfg.providerType}`
           )
+          logAiUsage(logger, {
+            feature: "store/ai/search",
+            role: "ai_search_chat",
+            provider: cfg.providerType,
+            source: "platform",
+            model: cfg.defaultModel ?? undefined,
+            platformId: cfg.platformId,
+            ok: true,
+            ms: Date.now() - started,
+          })
           return object
         } catch (e: any) {
-          logger.warn(
-            `[store/ai/search] db-platform ${cfg.platformId} (${cfg.providerType}) failed: ${
-              e?.message ?? e
-            }`
-          )
+          logAiUsage(logger, {
+            feature: "store/ai/search",
+            role: "ai_search_chat",
+            provider: cfg.providerType,
+            source: "platform",
+            model: cfg.defaultModel ?? undefined,
+            platformId: cfg.platformId,
+            ok: false,
+            ms: Date.now() - started,
+            error: e,
+          })
           // Fall through to env chain — better degraded behaviour
           // than failing the search outright when one DB-configured
           // provider has a transient issue.

--- a/apps/backend/src/mastra/services/__tests__/resolve-role-text-model.unit.spec.ts
+++ b/apps/backend/src/mastra/services/__tests__/resolve-role-text-model.unit.spec.ts
@@ -5,6 +5,7 @@ import {
   summarizeAiPlatformCatalog,
   groupAiCatalogByRole,
   sweepAiPlatformsByCategory,
+  foldSystemContentMessages,
   type AiUsage,
 } from "../ai-platforms"
 
@@ -170,6 +171,51 @@ describe("sweepAiPlatformsByCategory", () => {
 
     await sweepAiPlatformsByCategory(container, { includeInactive: true })
     expect(seen[1]).toEqual({ category: "ai" })
+  })
+})
+
+describe("foldSystemContentMessages", () => {
+  const msgs = [
+    { role: "system", content: "SYS" },
+    { role: "user", content: "hi" },
+    { role: "assistant", content: "yo" },
+    { role: "user", content: "again" },
+  ]
+
+  it("keeps system role untouched for OpenRouter", () => {
+    const out = foldSystemContentMessages("openrouter", msgs)
+    expect(out).toEqual(msgs)
+    expect(out).not.toBe(msgs) // copied
+  })
+
+  it("folds system into the first user message for DashScope (no system role)", () => {
+    const out = foldSystemContentMessages("dashscope", msgs)
+    expect(out.find((m) => m.role === "system")).toBeUndefined()
+    expect(out[0]).toEqual({ role: "user", content: "SYS\n\nhi" })
+    expect(out[2]).toEqual({ role: "user", content: "again" }) // later user untouched
+  })
+
+  it("joins multiple system messages", () => {
+    const out = foldSystemContentMessages("cloudflare", [
+      { role: "system", content: "A" },
+      { role: "system", content: "B" },
+      { role: "user", content: "q" },
+    ])
+    expect(out).toEqual([{ role: "user", content: "A\n\nB\n\nq" }])
+  })
+
+  it("prepends a user message when none exists", () => {
+    const out = foldSystemContentMessages("dashscope", [
+      { role: "system", content: "SYS" },
+      { role: "assistant", content: "hello" },
+    ])
+    expect(out[0]).toEqual({ role: "user", content: "SYS" })
+    expect(out[1].role).toBe("assistant")
+  })
+
+  it("is a no-op (minus system) when there's no system text", () => {
+    const out = foldSystemContentMessages("dashscope", [{ role: "user", content: "q" }])
+    expect(out).toEqual([{ role: "user", content: "q" }])
   })
 })
 

--- a/apps/backend/src/mastra/services/ai-platforms.ts
+++ b/apps/backend/src/mastra/services/ai-platforms.ts
@@ -390,6 +390,66 @@ export const resolveRoleTextModel = async (
   }
 }
 
+import { generateText } from "ai"
+
+/**
+ * Build a `(prompt) => Promise<string>` generator bound to a role — the shape
+ * the marketing orchestrators (`opts.aiGenerate`) and any prompt-in/text-out
+ * caller expect. Resolves the configured platform for `role` (free-model
+ * fallback), folds the system prompt for OpenAI-compatible providers via
+ * `buildGenerateArgs`, emits one `[ai-usage]` line, and returns "" on error so
+ * callers keep their existing graceful-degrade contract.
+ */
+export const makeRoleAiGenerate = (
+  container: MedusaContainer,
+  role: AiRole,
+  feature: string,
+  opts: { system?: string; maxOutputTokens?: number } = {}
+): ((prompt: string) => Promise<string>) => {
+  return async (prompt: string): Promise<string> => {
+    const resolved = await resolveRoleTextModel(container, role)
+    let logger: any
+    try {
+      logger = container.resolve("logger")
+    } catch {
+      /* logger optional */
+    }
+    const started = Date.now()
+    try {
+      const res = await generateText({
+        model: resolved.model,
+        ...buildGenerateArgs({ providerType: resolved.providerType }, opts.system, prompt),
+        ...(opts.maxOutputTokens ? { maxOutputTokens: opts.maxOutputTokens } : {}),
+      })
+      logAiUsage(logger, {
+        feature,
+        role,
+        provider: resolved.providerType,
+        source: resolved.source,
+        model: resolved.modelId,
+        platformId: resolved.platformId,
+        ok: true,
+        ms: Date.now() - started,
+        tokens: (res as any)?.usage?.totalTokens,
+      })
+      return (res.text || "").trim()
+    } catch (error: any) {
+      logAiUsage(logger, {
+        feature,
+        role,
+        provider: resolved.providerType,
+        source: resolved.source,
+        model: resolved.modelId,
+        platformId: resolved.platformId,
+        ok: false,
+        ms: Date.now() - started,
+        error,
+      })
+      return ""
+    }
+  }
+}
+
 export type AiUsage = {
   /** Stable feature key, e.g. "store/ai/search", "marketing/ideas_email". */
   feature: string
@@ -442,6 +502,45 @@ export const logAiUsage = (logger: any, u: AiUsage): void => {
   } catch {
     /* logging must never break the AI call */
   }
+}
+
+/**
+ * Place the system prompt for a `{role, content}` message list (the shape
+ * Mastra's admin chat uses). OpenRouter keeps the native `system` role;
+ * OpenAI-compatible providers get all system messages folded into the first
+ * user message (avoids @ai-sdk/openai's `developer` role that DashScope
+ * rejects — same fix as the storefront chat route, #752). Pure / testable.
+ */
+export const foldSystemContentMessages = <
+  M extends { role: string; content: string }
+>(
+  providerType: AiProviderType,
+  messages: M[]
+): Array<{ role: string; content: string }> => {
+  if (providerType === "openrouter") return messages.map((m) => ({ ...m }))
+
+  const systemText = messages
+    .filter((m) => m.role === "system")
+    .map((m) => m.content)
+    .join("\n\n")
+    .trim()
+  const rest = messages
+    .filter((m) => m.role !== "system")
+    .map((m) => ({ role: m.role, content: m.content }))
+
+  if (!systemText) return rest
+
+  const firstUser = rest.findIndex((m) => m.role === "user")
+  if (firstUser === -1) {
+    return [{ role: "user", content: systemText }, ...rest]
+  }
+  rest[firstUser] = {
+    ...rest[firstUser],
+    content: rest[firstUser].content
+      ? `${systemText}\n\n${rest[firstUser].content}`
+      : systemText,
+  }
+  return rest
 }
 
 // ── Category sweep / discovery (auto-pick up new providers + roles) ─────

--- a/apps/backend/src/mastra/workflows/aiChat/index.ts
+++ b/apps/backend/src/mastra/workflows/aiChat/index.ts
@@ -48,6 +48,13 @@ import {
   waitAfterRateLimit,
 } from "../../services/model-rotator"
 
+import {
+  getAiPlatformForRole,
+  buildChatModel,
+  foldSystemContentMessages,
+  logAiUsage,
+} from "../../services/ai-platforms"
+
 // Logger
 import { workflowLogger as log } from "../../services/logger"
 
@@ -761,10 +768,64 @@ const generateResponseStep = createStep({
       { role: "user" as const, content: message },
     ]
 
-    // Generate response with model rotation
+    // Generate response. Prefer the admin-configured ai_search_chat platform;
+    // fall back to the free-model rotation when none is set or it fails.
     let reply = ""
     let usedModel = ""
-    const responseModels = await getModelsForStep("response_generation", requestId)
+
+    try {
+      const cfg = await getAiPlatformForRole(container, "ai_search_chat")
+      if (cfg) {
+        const started = Date.now()
+        try {
+          pushStep("trying_platform", {
+            provider: cfg.providerType,
+            platformId: cfg.platformId,
+          })
+          const result = await generateText({
+            model: buildChatModel(cfg) as any,
+            // Fold the system message for OpenAI-compatible providers
+            // (DashScope rejects the `developer` role @ai-sdk/openai emits).
+            messages: foldSystemContentMessages(cfg.providerType, messages) as any,
+            maxTokens: 2000,
+          })
+          reply = result.text || ""
+          usedModel = `platform:${cfg.providerType}:${cfg.defaultModel ?? ""}`
+          logAiUsage(log, {
+            feature: "admin/ai-chat",
+            role: "ai_search_chat",
+            provider: cfg.providerType,
+            source: "platform",
+            model: cfg.defaultModel ?? undefined,
+            platformId: cfg.platformId,
+            ok: Boolean(reply),
+            ms: Date.now() - started,
+            tokens: (result as any)?.usage?.totalTokens,
+          })
+          if (reply) pushStep("response_generated", { modelId: usedModel, length: reply.length })
+        } catch (error: any) {
+          logAiUsage(log, {
+            feature: "admin/ai-chat",
+            role: "ai_search_chat",
+            provider: cfg.providerType,
+            source: "platform",
+            model: cfg.defaultModel ?? undefined,
+            platformId: cfg.platformId,
+            ok: false,
+            ms: Date.now() - started,
+            error,
+          })
+          log.warn("Configured platform failed, falling back to free rotation", {
+            error: String(error),
+          })
+        }
+      }
+    } catch (e: any) {
+      log.warn("getAiPlatformForRole failed for admin chat", { error: String(e) })
+    }
+
+    const responseModels =
+      reply ? [] : await getModelsForStep("response_generation", requestId)
 
     for (const modelId of responseModels) {
       try {

--- a/apps/backend/src/workflows/ad-planning/sentiment/analyze-sentiment.ts
+++ b/apps/backend/src/workflows/ad-planning/sentiment/analyze-sentiment.ts
@@ -13,7 +13,13 @@ import {
 import { AD_PLANNING_MODULE } from "../../../modules/ad-planning";
 import type AdPlanningService from "../../../modules/ad-planning/service";
 import { generateText } from "ai";
-import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+import {
+  resolveRoleTextModel,
+  logAiUsage,
+} from "../../../mastra/services/ai-platforms";
+
+/** Role this step resolves a platform for (free-model fallback). */
+const SENTIMENT_ROLE = "ai_digest_summary";
 
 type AnalyzeSentimentInput = {
   text: string;
@@ -41,9 +47,15 @@ type SentimentResult = {
 const aiAnalyzeStep = createStep(
   "ai-analyze-sentiment",
   async (input: { text: string }, { container }) => {
-    const openrouter = createOpenRouter({
-      apiKey: process.env.OPENROUTER_API_KEY,
-    });
+    // Resolve the configured platform for the sentiment/summary role
+    // (admin-configured External Platform → free models when none).
+    const resolved = await resolveRoleTextModel(container, SENTIMENT_ROLE);
+    let logger: any;
+    try {
+      logger = container.resolve("logger");
+    } catch {
+      /* logger optional */
+    }
 
     const prompt = `Analyze the sentiment of the following text and respond in JSON format only:
 
@@ -63,9 +75,11 @@ Respond with a JSON object containing:
 
 Only respond with the JSON object, no other text.`;
 
+    const started = Date.now();
     try {
+      // Prompt-only (no system message) → no provider system-role concerns.
       const result = await generateText({
-        model: openrouter("anthropic/claude-3.5-sonnet"),
+        model: resolved.model,
         prompt,
         maxOutputTokens: 500,
       });
@@ -74,10 +88,31 @@ Only respond with the JSON object, no other text.`;
       const jsonStr = result.text.trim();
       const analysis = JSON.parse(jsonStr) as SentimentResult;
 
+      logAiUsage(logger, {
+        feature: "ad-planning/sentiment",
+        role: SENTIMENT_ROLE,
+        provider: resolved.providerType,
+        source: resolved.source,
+        model: resolved.modelId,
+        platformId: resolved.platformId,
+        ok: true,
+        ms: Date.now() - started,
+        tokens: (result as any)?.usage?.totalTokens,
+      });
       return new StepResponse(analysis);
     } catch (error: any) {
       // Return neutral sentiment on error
-      console.error("[SentimentAnalysis] AI error:", error.message);
+      logAiUsage(logger, {
+        feature: "ad-planning/sentiment",
+        role: SENTIMENT_ROLE,
+        provider: resolved.providerType,
+        source: resolved.source,
+        model: resolved.modelId,
+        platformId: resolved.platformId,
+        ok: false,
+        ms: Date.now() - started,
+        error,
+      });
       return new StepResponse({
         sentiment_score: 0,
         sentiment_label: "neutral" as const,

--- a/apps/backend/src/workflows/marketing/generate-ideas-email.ts
+++ b/apps/backend/src/workflows/marketing/generate-ideas-email.ts
@@ -25,8 +25,7 @@ import {
   StepResponse,
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
-import { generateText } from "ai"
-import { createOpenRouter } from "@openrouter/ai-sdk-provider"
+import { makeRoleAiGenerate } from "../../mastra/services/ai-platforms"
 
 import { MARKETING_MODULE } from "../../modules/marketing"
 import type { GroundTruth, GroundTruthValue } from "./ideas-email-guard-lib"
@@ -37,7 +36,8 @@ import { buildIdeasPrompt, STRICTER_SUFFIX } from "./ideas-email-prompt-lib"
 export type AiGenerateFn = (prompt: string) => Promise<string>
 
 export type GenerateIdeasEmailOptions = {
-  /** Injected for tests; defaults to the real OpenRouter call. */
+  /** Injected for tests; defaults to the role-resolved platform generator
+   *  (ai_newsletter_drafter → configured platform, else free models). */
   aiGenerate?: AiGenerateFn
   /** The "One Goal" string; never invented in code (report §3.6). */
   oneGoal?: string
@@ -63,7 +63,8 @@ export type GenerateIdeasEmailResult = {
   reason?: string
 }
 
-const DEFAULT_MODEL = "anthropic/claude-3.5-sonnet"
+/** Role this generator resolves a platform for (free-model fallback). */
+const IDEAS_EMAIL_ROLE = "ai_newsletter_drafter"
 
 const DEFAULT_BUSINESS_DESCRIPTION =
   "JYT is a textile-production commerce platform: it runs an admin storefront " +
@@ -148,25 +149,6 @@ export function buildGroundTruthFromSnapshots(
   return { values, date_ist: opts.dateIst, one_goal: opts.oneGoal }
 }
 
-/** The real LLM call. Mirrors analyze-sentiment.ts:44-71 (try/catch → "" on error). */
-async function defaultAiGenerate(prompt: string): Promise<string> {
-  try {
-    const openrouter = createOpenRouter({
-      apiKey: process.env.OPENROUTER_API_KEY,
-    })
-    const result = await generateText({
-      model: openrouter(process.env.MARKETING_IDEAS_MODEL || DEFAULT_MODEL),
-      prompt,
-      maxOutputTokens: 700,
-    })
-    return (result.text || "").trim()
-  } catch (error: any) {
-    // eslint-disable-next-line no-console
-    console.error("[generate-ideas-email] AI error:", error?.message)
-    return ""
-  }
-}
-
 /**
  * Core orchestration (no Medusa-step wrapper, so it's directly unit/integration
  * testable with a stubbed `aiGenerate`): gather ground truth → generate → guard
@@ -176,7 +158,11 @@ export async function generateIdeasEmail(
   container: any,
   opts: GenerateIdeasEmailOptions = {}
 ): Promise<GenerateIdeasEmailResult> {
-  const aiGenerate = opts.aiGenerate || defaultAiGenerate
+  const aiGenerate =
+    opts.aiGenerate ||
+    makeRoleAiGenerate(container, IDEAS_EMAIL_ROLE, "marketing/ideas_email", {
+      maxOutputTokens: 700,
+    })
   const now = opts.now || new Date()
   const oneGoal =
     opts.oneGoal ||
@@ -186,7 +172,7 @@ export async function generateIdeasEmail(
     opts.businessDescription ||
     process.env.MARKETING_BUSINESS_DESCRIPTION ||
     DEFAULT_BUSINESS_DESCRIPTION
-  const modelId = process.env.MARKETING_IDEAS_MODEL || DEFAULT_MODEL
+  const modelId = `role:${IDEAS_EMAIL_ROLE}`
 
   const empty: GenerateIdeasEmailResult = {
     skipped: false,

--- a/apps/backend/src/workflows/marketing/generate-newsletter-draft.ts
+++ b/apps/backend/src/workflows/marketing/generate-newsletter-draft.ts
@@ -26,13 +26,13 @@ import {
   StepResponse,
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
-import { generateText } from "ai"
-import { createOpenRouter } from "@openrouter/ai-sdk-provider"
+import { makeRoleAiGenerate } from "../../mastra/services/ai-platforms"
 
 import { MARKETING_MODULE } from "../../modules/marketing"
 import type { AiGenerateFn } from "./generate-ideas-email"
 
-const DEFAULT_MODEL = "anthropic/claude-3.5-sonnet"
+/** Role this generator resolves a platform for (free-model fallback). */
+const NEWSLETTER_DRAFT_ROLE = "ai_newsletter_drafter"
 
 const DEFAULT_BUSINESS_DESCRIPTION =
   "JYT is a textile-production commerce platform: it runs an admin storefront " +
@@ -234,29 +234,6 @@ function fallbackPayload(rawText: string): NewsletterPayload {
   }
 }
 
-/** The real LLM call. Mirrors generate-ideas-email.ts:152-168 (try/catch → ""). */
-async function defaultAiGenerate(prompt: string): Promise<string> {
-  try {
-    const openrouter = createOpenRouter({
-      apiKey: process.env.OPENROUTER_API_KEY,
-    })
-    const result = await generateText({
-      model: openrouter(
-        process.env.MARKETING_NEWSLETTER_MODEL ||
-          process.env.MARKETING_IDEAS_MODEL ||
-          DEFAULT_MODEL
-      ),
-      prompt,
-      maxOutputTokens: 1200,
-    })
-    return (result.text || "").trim()
-  } catch (error: any) {
-    // eslint-disable-next-line no-console
-    console.error("[generate-newsletter-draft] AI error:", error?.message)
-    return ""
-  }
-}
-
 /**
  * Core orchestration (no Medusa-step wrapper, so it's directly unit/integration
  * testable with a stubbed `aiGenerate`): build prompt → generate → parse →
@@ -266,17 +243,18 @@ export async function generateNewsletterDraft(
   container: any,
   opts: GenerateNewsletterDraftOptions = {}
 ): Promise<GenerateNewsletterDraftResult> {
-  const aiGenerate = opts.aiGenerate || defaultAiGenerate
+  const aiGenerate =
+    opts.aiGenerate ||
+    makeRoleAiGenerate(container, NEWSLETTER_DRAFT_ROLE, "marketing/newsletter_draft", {
+      maxOutputTokens: 1200,
+    })
   const now = opts.now || new Date()
   const dateIst = istDateString(now)
   const businessDescription =
     opts.businessDescription ||
     process.env.MARKETING_BUSINESS_DESCRIPTION ||
     DEFAULT_BUSINESS_DESCRIPTION
-  const modelId =
-    process.env.MARKETING_NEWSLETTER_MODEL ||
-    process.env.MARKETING_IDEAS_MODEL ||
-    DEFAULT_MODEL
+  const modelId = `role:${NEWSLETTER_DRAFT_ROLE}`
   const name = opts.name?.trim() || `newsletter-${dateIst}`
   const status: "draft" | "approved" = opts.markReady ? "approved" : "draft"
 


### PR DESCRIPTION
Follow-up to #753. Migrates the **5 remaining hardcoded-OpenRouter AI paths** onto the unified `resolveRoleTextModel` resolver so they honor the operator's configured External Platforms (`category=ai`, `metadata.role`), with a **free-model** fallback (no more paid hardcoded models) and an `[ai-usage]` log line per call.

| Feature | Role | Before | After |
|---|---|---|---|
| `store/ai/search` (`extract.ts`) | `ai_search_chat` | `system:` raw → DashScope rejected `developer` role → silent degrade to keyword | system folded via `buildGenerateArgs` (DB + env attempts) + `[ai-usage]` |
| `marketing/ideas_email` | `ai_newsletter_drafter` | hardcoded paid `claude-3.5-sonnet` default | `makeRoleAiGenerate` (platform → free) |
| `marketing/newsletter_draft` | `ai_newsletter_drafter` | hardcoded paid default | `makeRoleAiGenerate` |
| `ad-planning/sentiment` | `ai_digest_summary` | hardcoded paid `claude-3.5-sonnet` | resolver (free fallback); prompt-only, no system concern |
| admin `aiChat` | `ai_search_chat` | free-model rotation only | prefer configured platform (system folded) → fall back to existing free rotation |

### New shared helpers (in `ai-platforms.ts`)
- `makeRoleAiGenerate(container, role, feature, opts)` — `(prompt) => Promise<string>` bound to a role; resolves platform→free, folds system for OpenAI-compatible providers, logs `[ai-usage]`, returns `""` on error (preserves callers' graceful-degrade). Powers the marketing `opts.aiGenerate` seam.
- `foldSystemContentMessages(providerType, messages)` — `{role,content}` system fold for the admin chat's message shape (companion to the chat route's parts-shape helper).

### Notes
- Injectable `aiGenerate` seams preserved → marketing unit tests untouched.
- Watch-out: if a configured DashScope model doesn't support structured output, `store/ai/search` will still degrade through its env chain (logged) — the role fix removes the `developer` blocker, not provider JSON-mode gaps.

### Test
`jest --testPathPattern="resolve-role-text-model|ideas-email|newsletter-draft|send-ideas-email|run-daily-ideas"` → **125/125 green**. `tsc`: no new errors (baseline 71 pre-existing, 0 in changed files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)