### PR TITLE
feat(visual-flows): ai_generate operation — call External Platforms by role

### DIFF
--- a/apps/backend/src/modules/visual_flows/migrations/Migration20260628120000.ts
+++ b/apps/backend/src/modules/visual_flows/migrations/Migration20260628120000.ts
@@ -1,0 +1,28 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Adds `ai_generate` to the visual_flow_operation.operation_type CHECK
+ * constraint. The new operation is implemented at
+ * `src/modules/visual_flows/operations/ai-generate.ts` — general-purpose AI
+ * text generation that resolves the model from the admin-configured External
+ * Platform for a role (category=ai), with free-model fallback.
+ *
+ * Without this migration, inserting a flow operation row with
+ * operation_type='ai_generate' fails the CHECK and rolls back the write.
+ * Idempotent ALTER (drop-if-exists → re-add); never edits the create-table.
+ */
+export class Migration20260628120000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "visual_flow_operation" drop constraint if exists "visual_flow_operation_operation_type_check";`);
+
+    this.addSql(`alter table if exists "visual_flow_operation" add constraint "visual_flow_operation_operation_type_check" check("operation_type" in ('condition', 'create_data', 'read_data', 'update_data', 'delete_data', 'bulk_update_data', 'bulk_create_data', 'bulk_http_request', 'bulk_trigger_workflow', 'http_request', 'run_script', 'send_email', 'send_whatsapp', 'notification', 'transform', 'trigger_workflow', 'trigger_flow', 'execute_code', 'sleep', 'log', 'ai_extract', 'ai_extract_platform', 'ai_generate', 'aggregate_product_analytics', 'generate_partner_deeplink', 'wait_for_event'));`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "visual_flow_operation" drop constraint if exists "visual_flow_operation_operation_type_check";`);
+
+    this.addSql(`alter table if exists "visual_flow_operation" add constraint "visual_flow_operation_operation_type_check" check("operation_type" in ('condition', 'create_data', 'read_data', 'update_data', 'delete_data', 'bulk_update_data', 'bulk_create_data', 'bulk_http_request', 'bulk_trigger_workflow', 'http_request', 'run_script', 'send_email', 'send_whatsapp', 'notification', 'transform', 'trigger_workflow', 'trigger_flow', 'execute_code', 'sleep', 'log', 'ai_extract', 'ai_extract_platform', 'aggregate_product_analytics', 'generate_partner_deeplink', 'wait_for_event'));`);
+  }
+
+}

--- a/apps/backend/src/modules/visual_flows/models/visual-flow-operation.ts
+++ b/apps/backend/src/modules/visual_flows/models/visual-flow-operation.ts
@@ -35,6 +35,7 @@ export const VisualFlowOperation = model.define("visual_flow_operation", {
     "log",
     "ai_extract",
     "ai_extract_platform",
+    "ai_generate",
     "aggregate_product_analytics",
     "generate_partner_deeplink",
   ]),

--- a/apps/backend/src/modules/visual_flows/operations/__tests__/ai-generate.unit.spec.ts
+++ b/apps/backend/src/modules/visual_flows/operations/__tests__/ai-generate.unit.spec.ts
@@ -1,0 +1,36 @@
+import { aiGenerateOperation } from "../ai-generate"
+
+describe("aiGenerateOperation", () => {
+  it("is defined with the expected type, category and output contract", () => {
+    expect(aiGenerateOperation.type).toBe("ai_generate")
+    expect(aiGenerateOperation.category).toBe("integration")
+    expect((aiGenerateOperation.defaultOptions as any).role).toBe("ai_search_chat")
+  })
+
+  it("optionsSchema applies sensible defaults", () => {
+    const parsed = aiGenerateOperation.optionsSchema!.parse({ input: "hello" }) as any
+    expect(parsed.role).toBe("ai_search_chat")
+    expect(parsed.fallback_on_error).toBe(false)
+    expect(parsed.input).toBe("hello")
+  })
+
+  it("requires input", () => {
+    expect(() => aiGenerateOperation.optionsSchema!.parse({})).toThrow()
+  })
+
+  it("mock_response short-circuits the AI call and returns text into the data chain", async () => {
+    const res = await aiGenerateOperation.execute(
+      { role: "ai_search_chat", input: "ignored", mock_response: "canned reply" },
+      { container: {}, dataChain: {} } as any
+    )
+    expect(res).toEqual({ success: true, data: { text: "canned reply" } })
+  })
+
+  it("mock_response of empty string is honored (not treated as absent)", async () => {
+    const res = await aiGenerateOperation.execute(
+      { role: "ai_search_chat", input: "x", mock_response: "" },
+      { container: {}, dataChain: {} } as any
+    )
+    expect(res).toEqual({ success: true, data: { text: "" } })
+  })
+})

--- a/apps/backend/src/modules/visual_flows/operations/ai-generate.ts
+++ b/apps/backend/src/modules/visual_flows/operations/ai-generate.ts
@@ -1,0 +1,143 @@
+import { z } from "@medusajs/framework/zod"
+import { generateText } from "ai"
+import { OperationDefinition, OperationContext, OperationResult } from "./types"
+import { interpolateString } from "./utils"
+import {
+  resolveRoleTextModel,
+  buildGenerateArgs,
+  logAiUsage,
+} from "../../../mastra/services/ai-platforms"
+
+/**
+ * General-purpose AI text generation, platform-aware.
+ *
+ * The composable building block for "call External Platforms by category/role"
+ * in the flow editor: resolves the admin-configured platform for `role`
+ * (category=ai, metadata.role) via the shared resolver, falling back to FREE
+ * models when none is configured. Free-form text is written to the data chain
+ * as `{{ $last.text }}` so downstream operations can consume it.
+ *
+ * Sibling of `ai_extract_platform` (structured JSON out). This one returns text
+ * and uses `resolveRoleTextModel`, so it degrades to free models instead of
+ * erroring when a role has no platform. System prompt is folded for
+ * OpenAI-compatible providers (DashScope/Cloudflare) via `buildGenerateArgs`,
+ * which keeps DashScope from rejecting the `developer` role (see #752).
+ */
+export const aiGenerateOperation: OperationDefinition = {
+  type: "ai_generate",
+  name: "AI Generate (Platform)",
+  description:
+    "Generate free-form text using the admin-configured AI platform for the " +
+    "given role (Settings → External Platforms, category=ai). Falls back to " +
+    "free models when no platform is set. Output: {{ $last.text }}.",
+  icon: "sparkles",
+  category: "integration",
+
+  optionsSchema: z.object({
+    role: z
+      .string()
+      .default("ai_search_chat")
+      .describe(
+        "AI role to resolve the platform for (metadata.role on the external " +
+          "platform row, e.g. ai_search_chat, ai_newsletter_drafter)."
+      ),
+    input: z
+      .string()
+      .describe("Prompt sent to the model (supports {{ variable }} interpolation)"),
+    system_prompt: z
+      .string()
+      .optional()
+      .describe("System instructions (supports {{ variable }} interpolation)"),
+    model_override: z
+      .string()
+      .optional()
+      .describe("Override the platform's default_model for this call only"),
+    max_output_tokens: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Cap the response length"),
+    fallback_on_error: z
+      .boolean()
+      .default(false)
+      .describe("Return empty text instead of failing the flow on error"),
+    mock_response: z
+      .string()
+      .optional()
+      .describe("If set, skip the AI call and return this text directly (testing)"),
+  }),
+
+  defaultOptions: {
+    role: "ai_search_chat",
+    input: "",
+    system_prompt: "",
+    fallback_on_error: false,
+  },
+
+  execute: async (options, context: OperationContext): Promise<OperationResult> => {
+    if (typeof options.mock_response === "string") {
+      return { success: true, data: { text: options.mock_response } }
+    }
+
+    const role = options.role || "ai_search_chat"
+    const input = interpolateString(options.input, context.dataChain)
+    const system = options.system_prompt
+      ? interpolateString(options.system_prompt, context.dataChain)
+      : undefined
+
+    let logger: any
+    try {
+      logger = (context.container as any)?.resolve?.("logger")
+    } catch {
+      /* logger optional */
+    }
+
+    const resolved = await resolveRoleTextModel(
+      context.container as any,
+      role,
+      options.model_override || undefined
+    )
+    const started = Date.now()
+    try {
+      const result = await generateText({
+        model: resolved.model as any,
+        ...buildGenerateArgs({ providerType: resolved.providerType }, system, input),
+        ...(options.max_output_tokens
+          ? { maxOutputTokens: options.max_output_tokens }
+          : {}),
+      })
+      const text = (result.text || "").trim()
+      logAiUsage(logger, {
+        feature: "visual-flow/ai_generate",
+        role,
+        provider: resolved.providerType,
+        source: resolved.source,
+        model: resolved.modelId,
+        platformId: resolved.platformId,
+        ok: true,
+        ms: Date.now() - started,
+        tokens: (result as any)?.usage?.totalTokens,
+      })
+      return { success: true, data: { text } }
+    } catch (error: any) {
+      const message =
+        error?.responseBody ?? error?.cause?.message ?? error?.message ?? String(error)
+      logAiUsage(logger, {
+        feature: "visual-flow/ai_generate",
+        role,
+        provider: resolved.providerType,
+        source: resolved.source,
+        model: resolved.modelId,
+        platformId: resolved.platformId,
+        ok: false,
+        ms: Date.now() - started,
+        error,
+      })
+      if (options.fallback_on_error) {
+        return { success: true, data: { text: "" } }
+      }
+      return { success: false, error: message, errorStack: error?.stack }
+    }
+  },
+}

--- a/apps/backend/src/modules/visual_flows/operations/index.ts
+++ b/apps/backend/src/modules/visual_flows/operations/index.ts
@@ -29,6 +29,7 @@ export { bulkHttpRequestOperation } from "./bulk-http-request"
 export { bulkTriggerWorkflowOperation } from "./bulk-trigger-workflow"
 export { aiExtractOperation } from "./ai-extract"
 export { aiExtractPlatformOperation } from "./ai-extract-platform"
+export { aiGenerateOperation } from "./ai-generate"
 export { generatePartnerDeeplinkOperation } from "./generate-partner-deeplink"
 export { partnerAnalyticsDigestOperation } from "./partner-analytics-digest"
 export { marketingDailyIdeasEmailOperation } from "./marketing-daily-ideas-email"
@@ -62,6 +63,7 @@ import { bulkHttpRequestOperation } from "./bulk-http-request"
 import { bulkTriggerWorkflowOperation } from "./bulk-trigger-workflow"
 import { aiExtractOperation } from "./ai-extract"
 import { aiExtractPlatformOperation } from "./ai-extract-platform"
+import { aiGenerateOperation } from "./ai-generate"
 import { generatePartnerDeeplinkOperation } from "./generate-partner-deeplink"
 import { partnerAnalyticsDigestOperation } from "./partner-analytics-digest"
 import { marketingDailyIdeasEmailOperation } from "./marketing-daily-ideas-email"
@@ -95,6 +97,7 @@ export function registerBuiltInOperations(): void {
   operationRegistry.register(triggerFlowOperation)
   operationRegistry.register(aiExtractOperation)
   operationRegistry.register(aiExtractPlatformOperation)
+  operationRegistry.register(aiGenerateOperation)
   
   // Utility operations
   operationRegistry.register(transformOperation)


### PR DESCRIPTION
First slice of #755. A general-purpose **`ai_generate`** visual-flow operation: calls the admin-configured External Platform for a role (`category=ai`, `metadata.role`) and writes free-form text into the data chain as `{{ $last.text }}` for downstream ops.

Built on the #753 foundation — resolves via `resolveRoleTextModel` (platform → **free-model** fallback), folds the system prompt for OpenAI-compatible providers (`buildGenerateArgs`, avoids the DashScope `developer`-role rejection from #752), and emits an `[ai-usage]` line.

Sibling of `ai_extract_platform` (structured JSON); this returns text and degrades to free models rather than erroring when a role has no platform.

## In this PR
- `operations/ai-generate.ts` — the op (options: `role`, `input`, `system_prompt`, `model_override`, `max_output_tokens`, `fallback_on_error`, `mock_response`).
- Registered in `operations/index.ts`; added `ai_generate` to the `operation_type` enum + idempotent CHECK ALTER migration (`Migration20260628120000`, mirrors the `ai_extract_platform` one).
- 5 unit tests. `tsc` clean (0 new errors).

## Deferred (tracked on #755)
- Dynamic **role picker** in the editor fed by `GET /admin/ai/platforms` (the category sweep) — Playwright-gated frontend.
- Migrate the **legacy `ai_extract`** op to platforms (it's used by `seed-order-upsert-flow` + `seed-partner-product-create-flow`; must stay backward-compatible — see #755 comment).

## Verify
`jest --testPathPattern="ai-generate"` → 5/5. After deploy, `ai_generate` appears in `/admin/visual-flows/metadata`; a flow `read-data → ai_generate → log {{ $last.text }}` produces text from the configured DashScope/Cloudflare platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)