### PR TITLE
feat(visual-flows): migrate legacy ai_extract to platform resolution

### DIFF
--- a/apps/backend/src/modules/visual_flows/operations/__tests__/ai-extract.unit.spec.ts
+++ b/apps/backend/src/modules/visual_flows/operations/__tests__/ai-extract.unit.spec.ts
@@ -1,0 +1,25 @@
+import { aiExtractOperation } from "../ai-extract"
+
+describe("aiExtractOperation (platform migration)", () => {
+  it("defaults role to ai_search_chat and no longer hardcodes a model", () => {
+    expect(aiExtractOperation.type).toBe("ai_extract")
+    expect((aiExtractOperation.defaultOptions as any).role).toBe("ai_search_chat")
+    // legacy `model` default removed (now an optional deprecated override)
+    expect((aiExtractOperation.defaultOptions as any).model).toBeUndefined()
+  })
+
+  it("optionsSchema applies role default and keeps model optional", () => {
+    const parsed = aiExtractOperation.optionsSchema!.parse({ input: "some text" }) as any
+    expect(parsed.role).toBe("ai_search_chat")
+    expect(parsed.model).toBeUndefined()
+    expect(parsed.fallback_on_error).toBe(false)
+  })
+
+  it("mock_response short-circuits the AI call (backward-compatible)", async () => {
+    const res = await aiExtractOperation.execute(
+      { role: "ai_search_chat", input: "x", mock_response: { title: "Tee", price: 1200 } },
+      { container: {}, dataChain: {} } as any
+    )
+    expect(res).toEqual({ success: true, data: { title: "Tee", price: 1200 } })
+  })
+})

--- a/apps/backend/src/modules/visual_flows/operations/ai-extract.ts
+++ b/apps/backend/src/modules/visual_flows/operations/ai-extract.ts
@@ -1,9 +1,13 @@
 import { z } from "@medusajs/framework/zod"
-import { createOpenRouter } from "@openrouter/ai-sdk-provider"
 import { generateText } from "ai"
 import { OperationDefinition, OperationContext, OperationResult } from "./types"
 import { interpolateString } from "./utils"
 import { extractionEvalWorkflow } from "../../../mastra/workflows/extractionEval"
+import {
+  resolveRoleTextModel,
+  buildGenerateArgs,
+  logAiUsage,
+} from "../../../mastra/services/ai-platforms"
 
 interface SchemaField {
   name: string
@@ -65,10 +69,21 @@ export const aiExtractOperation: OperationDefinition = {
   category: "integration",
 
   optionsSchema: z.object({
+    role: z
+      .string()
+      .default("ai_search_chat")
+      .describe(
+        "AI role to resolve the platform for (metadata.role on the external " +
+          "platform row). The model/provider/key come from Settings → External " +
+          "Platforms (category=ai); falls back to free models when none is set."
+      ),
     model: z
       .string()
-      .default("google/gemini-2.5-flash-preview")
-      .describe("OpenRouter model ID"),
+      .optional()
+      .describe(
+        "DEPRECATED — legacy OpenRouter model id. Ignored once a platform is " +
+          "configured for `role`; configure the model on the platform instead."
+      ),
     input: z
       .string()
       .describe("Input text sent to the model (supports {{ variable }} interpolation)"),
@@ -106,7 +121,7 @@ export const aiExtractOperation: OperationDefinition = {
   }),
 
   defaultOptions: {
-    model: "google/gemini-2.5-flash-preview",
+    role: "ai_search_chat",
     input: "",
     system_prompt: "Extract order information from this email.",
     schema_fields: [],
@@ -133,7 +148,9 @@ export const aiExtractOperation: OperationDefinition = {
             input,
             system_prompt: options.system_prompt,
             schema_fields: options.schema_fields ?? [],
-            model: options.model,
+            // Opt-in legacy eval path still runs on OpenRouter; the platform
+            // migration covers the default (non-eval) path. See #755.
+            model: options.model || "google/gemini-2.5-flash-preview",
           },
         })
 
@@ -159,10 +176,26 @@ export const aiExtractOperation: OperationDefinition = {
       }
     }
 
+    const role = options.role || "ai_search_chat"
+    let logger: any
+    try {
+      logger = (context.container as any)?.resolve?.("logger")
+    } catch {
+      /* logger optional */
+    }
+
+    // Resolve the model from the admin-configured platform for the role, else
+    // free models. Folds the system prompt for OpenAI-compatible providers
+    // (DashScope rejects the `developer` role @ai-sdk/openai emits — #752).
+    const resolved = await resolveRoleTextModel(
+      context.container as any,
+      role,
+      options.model || undefined
+    )
+    const started = Date.now()
     try {
       const fields: SchemaField[] = options.schema_fields || []
       const input = interpolateString(options.input, context.dataChain)
-      const modelId: string = options.model || "google/gemini-2.5-flash-preview"
 
       // Build the full system prompt: user instructions + JSON shape hint from fields
       const systemPrompt = [
@@ -172,26 +205,23 @@ export const aiExtractOperation: OperationDefinition = {
         .join("")
         .trim()
 
-      console.log("[ai_extract] Calling model:", modelId, {
-        inputLength: input.length,
-        inputPreview: input.slice(0, 150) + (input.length > 150 ? `… [${input.length} chars]` : ""),
-        fields: fields.map((f) => f.name),
-      })
-
-      const openrouter = createOpenRouter({ apiKey: process.env.OPENROUTER_API_KEY })
-
       const result = await generateText({
-        model: openrouter(modelId) as any,
-        messages: [{ role: "user", content: input }],
-        ...(systemPrompt ? { system: systemPrompt } : {}),
+        model: resolved.model as any,
+        ...buildGenerateArgs({ providerType: resolved.providerType }, systemPrompt, input),
       })
 
       const object = extractJson(result.text)
 
-      console.log("[ai_extract] Extraction complete:", {
-        model: modelId,
-        usage: result.usage,
-        keys: Object.keys(object),
+      logAiUsage(logger, {
+        feature: "visual-flow/ai_extract",
+        role,
+        provider: resolved.providerType,
+        source: resolved.source,
+        model: resolved.modelId,
+        platformId: resolved.platformId,
+        ok: true,
+        ms: Date.now() - started,
+        tokens: (result as any)?.usage?.totalTokens,
       })
 
       return {
@@ -201,7 +231,17 @@ export const aiExtractOperation: OperationDefinition = {
     } catch (error: any) {
       const message =
         error?.responseBody ?? error?.cause?.message ?? error?.message ?? String(error)
-      console.error("[ai_extract] Error:", message)
+      logAiUsage(logger, {
+        feature: "visual-flow/ai_extract",
+        role,
+        provider: resolved.providerType,
+        source: resolved.source,
+        model: resolved.modelId,
+        platformId: resolved.platformId,
+        ok: false,
+        ms: Date.now() - started,
+        error,
+      })
 
       if (options.fallback_on_error) {
         return { success: true, data: {} }

--- a/apps/backend/src/scripts/seed-order-upsert-flow.ts
+++ b/apps/backend/src/scripts/seed-order-upsert-flow.ts
@@ -192,7 +192,9 @@ const FLOW_DEF = {
       position_x: X_CENTER,
       position_y: Y_PARSE,
       options: {
-        model: "google/gemini-2.5-flash-preview",
+        // Model/provider resolved from the admin-configured AI platform for
+        // this role (category=ai, metadata.role=ai_search_chat); free fallback.
+        role: "ai_search_chat",
         input: "Subject: {{ read_email.records[0].subject }}\n\n{{ read_email.records[0].text_body }}",
         system_prompt:
           "Extract purchase order details from this supplier email. " +


### PR DESCRIPTION
Part of #755. Migrates the legacy `ai_extract` op off hardcoded OpenRouter onto the configured External Platforms.

The op's default (non-eval) path now resolves via `resolveRoleTextModel(role)` (#753): admin-configured platform for the role → **free-model** fallback, with the system prompt folded for OpenAI-compatible providers (`buildGenerateArgs`, avoids the DashScope `developer`-role rejection #752) and an `[ai-usage]` line.

## Changes
- New **`role`** option (default `ai_search_chat` — a configured DashScope platform in prod).
- **`model`** is now optional + DEPRECATED (legacy OpenRouter override, ignored once a platform is configured); removed from defaults + the seed.
- Opt-in `use_mastra_eval` path unchanged (still OpenRouter; full eval migration tracked on #755).

## Backward compatibility
- The **only live legacy consumer** is `seed-order-upsert-flow` (email parse) — `seed-partner-product-create-flow` already uses `ai_extract_platform`.
- Existing prod flow rows with no `role` in their stored options **default to `ai_search_chat` at execute time** → no re-seed required; that flow moves from gemini→DashScope qwen-plus.
- `mock_response` short-circuit preserved.

## Verify
`jest --testPathPattern="operations/__tests__/ai-extract"` → 3/3. `tsc` clean (0 new). After deploy, the order-upsert email-parse flow extracts via the configured platform (`[ai-usage] feature=visual-flow/ai_extract … source=platform`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)