### PR TITLE
feat(store-mcp): [ai-usage] logging for the storefront chat route

### DIFF
--- a/apps/backend/src/api/store/ai/chat/__tests__/chat-usage-lib.unit.spec.ts
+++ b/apps/backend/src/api/store/ai/chat/__tests__/chat-usage-lib.unit.spec.ts
@@ -1,0 +1,42 @@
+import { parseChatProvider } from "../chat-usage-lib"
+
+describe("parseChatProvider", () => {
+  it("parses a DB-configured platform into source=platform + platformId", () => {
+    expect(parseChatProvider("db:dashscope:01KS4SEWZZ")).toEqual({
+      providerType: "dashscope",
+      source: "platform",
+      platformId: "01KS4SEWZZ",
+    })
+  })
+
+  it("parses an env-fallback provider:model into source=free + modelId", () => {
+    expect(parseChatProvider("dashscope:qwen-plus")).toEqual({
+      providerType: "dashscope",
+      source: "free",
+      modelId: "qwen-plus",
+    })
+  })
+
+  it("parses the openrouter free rotator", () => {
+    expect(parseChatProvider("openrouter:free")).toEqual({
+      providerType: "openrouter",
+      source: "free",
+      modelId: "free",
+    })
+  })
+
+  it("keeps a colon-containing model id intact (e.g. cloudflare / :free suffix)", () => {
+    expect(parseChatProvider("cloudflare:@cf/meta/llama-3.1-8b-instruct")).toEqual({
+      providerType: "cloudflare",
+      source: "free",
+      modelId: "@cf/meta/llama-3.1-8b-instruct",
+    })
+    expect(parseChatProvider("openrouter:meta-llama/llama-3.3-70b-instruct:free").modelId).toBe(
+      "meta-llama/llama-3.3-70b-instruct:free"
+    )
+  })
+
+  it("falls back gracefully on an empty/odd string", () => {
+    expect(parseChatProvider("")).toMatchObject({ providerType: "openrouter", source: "free" })
+  })
+})

--- a/apps/backend/src/api/store/ai/chat/chat-usage-lib.ts
+++ b/apps/backend/src/api/store/ai/chat/chat-usage-lib.ts
@@ -1,0 +1,40 @@
+import type { AiProviderType } from "../../../../mastra/services/ai-platforms"
+
+/**
+ * The storefront chat route resolves its model via `resolveStorefrontChatModel`
+ * (a pre-unification resolver), which returns a `provider` STRING rather than the
+ * structured shape `resolveRoleTextModel` gives. This maps that string into the
+ * fields `logAiUsage` needs so chat emits the same `[ai-usage]` telemetry as
+ * every other AI feature.
+ *
+ * Provider string shapes (see storefront-chat.ts):
+ *   - `db:<provider>:<platformId>`  → admin-configured External Platform
+ *   - `<provider>:<model>`          → env-var fallback chain (DashScope/Cloudflare)
+ *   - `openrouter:free`             → free OpenRouter rotator (last resort)
+ *
+ * `source` is binary (platform | free): `db:` → platform, everything else →
+ * free (env / last-resort fallbacks; the `provider` field still carries the
+ * real provider for those).  Pure / testable.
+ */
+export type ChatProviderInfo = {
+  providerType: AiProviderType
+  source: "platform" | "free"
+  platformId?: string
+  modelId?: string
+}
+
+export const parseChatProvider = (provider: string): ChatProviderInfo => {
+  const parts = (provider || "").split(":")
+  if (parts[0] === "db") {
+    return {
+      providerType: (parts[1] || "custom") as AiProviderType,
+      source: "platform",
+      platformId: parts[2] || undefined,
+    }
+  }
+  return {
+    providerType: (parts[0] || "openrouter") as AiProviderType,
+    source: "free",
+    modelId: parts.slice(1).join(":") || undefined,
+  }
+}

--- a/apps/backend/src/api/store/ai/chat/route.ts
+++ b/apps/backend/src/api/store/ai/chat/route.ts
@@ -39,6 +39,8 @@ import {
   createGetProductDetailsTool,
 } from "../../../../mastra/agents/tools/storefront-catalog-tools"
 import { foldSystemForProvider } from "./system-fold-lib"
+import { parseChatProvider } from "./chat-usage-lib"
+import { logAiUsage } from "../../../../mastra/services/ai-platforms"
 import type { StoreAiChatReq } from "./validators"
 
 export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
@@ -108,6 +110,11 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   // Only OpenRouter keeps the native `system` param. See system-fold-lib.ts.
   const folded = foldSystemForProvider(resolved.provider, system, messages)
 
+  // Map the chat resolver's `provider` string into structured [ai-usage] fields
+  // so chat emits the same telemetry as every other AI feature.
+  const usage = parseChatProvider(resolved.provider)
+  const startedAt = Date.now()
+
   let result
   try {
     result = streamText({
@@ -120,18 +127,45 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
       // while still capping runaway tool loops.
       stopWhen: stepCountIs(5),
       temperature: 0.6,
+      onFinish: ({ usage: u }: any) => {
+        logAiUsage(logger, {
+          feature: "store/ai/chat",
+          role: "ai_search_chat",
+          provider: usage.providerType,
+          source: usage.source,
+          platformId: usage.platformId,
+          model: usage.modelId,
+          ok: true,
+          ms: Date.now() - startedAt,
+          tokens: u?.totalTokens,
+        })
+      },
       onError: (err) => {
-        logger.warn(
-          `[store/ai/chat] streamText error (${resolved.provider}): ${
-            (err as any)?.error?.message ?? err
-          }`
-        )
+        logAiUsage(logger, {
+          feature: "store/ai/chat",
+          role: "ai_search_chat",
+          provider: usage.providerType,
+          source: usage.source,
+          platformId: usage.platformId,
+          model: usage.modelId,
+          ok: false,
+          ms: Date.now() - startedAt,
+          error: (err as any)?.error ?? err,
+        })
       },
     })
   } catch (e: any) {
-    logger.warn(
-      `[store/ai/chat] streamText threw (${resolved.provider}): ${e?.message ?? e}`
-    )
+    logAiUsage(logger, {
+      feature: "store/ai/chat",
+      role: "ai_search_chat",
+      provider: usage.providerType,
+      source: usage.source,
+      platformId: usage.platformId,
+      model: usage.modelId,
+      ok: false,
+      ms: Date.now() - startedAt,
+      error: e,
+    })
     res.status(502).json({ error: "chat provider failed" })
     return
   }


### PR DESCRIPTION
Closes the last telemetry gap from the AI-platform unification. The storefront chat route uses the pre-unification `resolveStorefrontChatModel` (returns a provider *string*), so it was the only AI feature not emitting `[ai-usage]`.

- New pure `parseChatProvider()` maps the provider string (`db:<provider>:<platformId>` | `<provider>:<model>` | `openrouter:free`) → structured `{providerType, source, platformId, modelId}`.
- Emits `logAiUsage` on `streamText` `onFinish` (ok + tokens + ms), `onError`, and the synchronous catch.
- Chat now appears in the same stream: `[ai-usage] feature=store/ai/chat role=ai_search_chat source=platform …`.

5 unit tests; tsc clean (0 new). Pure-helper only + log calls — no behavior change to the chat response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)