### PR TITLE
fix(storefront): make /chat message list scrollable under Lenis

### DIFF
--- a/apps/storefront/src/modules/home/components/ai-search-chat/index.tsx
+++ b/apps/storefront/src/modules/home/components/ai-search-chat/index.tsx
@@ -221,7 +221,24 @@ export default function AiSearchChat({ initialQuery }: AiSearchChatProps) {
         </div>
       </header>
 
-      <div ref={scrollRef} className="flex-1 overflow-y-auto">
+      {/*
+        Two things are required for this list to actually scroll:
+          1. `min-h-0` — a flex child defaults to `min-height: auto`, so
+             without this the list grows to fit its content instead of
+             constraining to `flex-1` and `overflow-y-auto` never engages.
+          2. `data-lenis-prevent` — the app is wrapped in `<ReactLenis root>`
+             (smooth-scroll.tsx), which hijacks wheel/touch on the whole
+             document. Lenis only lets a nested element scroll natively when
+             it (or an ancestor) carries this attribute. Without it the
+             message list "can't scroll" — wheel/touch drive the page, not
+             the list. `overscroll-contain` stops the bounce from chaining
+             back out to the page at the ends.
+      */}
+      <div
+        ref={scrollRef}
+        data-lenis-prevent
+        className="min-h-0 flex-1 overflow-y-auto overscroll-contain"
+      >
         {showOnboarding ? (
           <OnboardingForm
             ref={onboardingRef}


### PR DESCRIPTION
## Problem
The concierge chat list at `/[countryCode]/chat` **can't be scrolled** with wheel/touch (reported on prod: `https://cicilabel.com/it/chat?q=Cotton`).

## Root cause
The app is wrapped in `<ReactLenis root>` (`modules/common/components/smooth-scroll/index.tsx`), which hijacks wheel/touch on the **whole document**. A nested `overflow-y-auto` element only scrolls natively when it carries `data-lenis-prevent`. The chat list (added in #762) didn't have it, so the gesture drove Lenis (the page) instead of the list. This is the same scroll failure the old in-hero `FocusModal` had.

## Fix
On the message-list container:
- `data-lenis-prevent` — Lenis skips it, native scroll works (**decisive fix**).
- `min-h-0` — a `flex-1` child defaults to `min-height: auto`; without this `overflow-y-auto` may never engage.
- `overscroll-contain` — stops bounce chaining back out to the page.

## Verification
Couldn't drive prod directly — Vercel **Attack Challenge Mode** (Code 21) blocks automated browsers by design. Instead verified with a faithful local repro (real Lenis `root` + the exact flex layout), toggling the fix:

| | wheel scrolls list? |
|---|---|
| before (no attrs) | **No** — `list.scrollTop` stays `0` |
| after (this fix)  | **Yes** — `list.scrollTop → 1231`, page stays put |

🤖 Generated with [Claude Code](https://claude.com/claude-code)