### PR TITLE
style(storefront): full-width /chat concierge panel

### DIFF
--- a/apps/storefront/src/modules/home/components/ai-search-chat/index.tsx
+++ b/apps/storefront/src/modules/home/components/ai-search-chat/index.tsx
@@ -192,7 +192,7 @@ export default function AiSearchChat({ initialQuery }: AiSearchChatProps) {
     // message list owns a native scroll area and the page itself doesn't
     // scroll — sidestepping the Lenis / scroll-driven-nav conflict that
     // the old in-hero modal hit.
-    <div className="mx-auto flex h-[calc(100dvh-64px)] w-full max-w-2xl flex-col px-4 sm:px-6">
+    <div className="flex h-[calc(100dvh-64px)] w-full flex-col px-4 sm:px-6">
       <header className="flex items-center justify-between gap-2 border-b border-ui-border-base py-4">
         <div className="flex flex-col">
           <Heading level="h1" className="text-ui-fg-base">


### PR DESCRIPTION
Drops the centered `max-w-2xl` on the `/chat` container so the header, message list, and input span the full viewport width. Message bubbles keep their own relative max widths.

Follow-up to #762 (route move) and #763 (Lenis scroll fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)