### PR TITLE
feat(ops): AI-platform coverage audit Data Plumbing job (#756)

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/ai-platform-sweep-lib.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/ai-platform-sweep-lib.unit.spec.ts
@@ -1,0 +1,150 @@
+import {
+  buildAiPlatformCoverageReport,
+  planAiPlatformNormalization,
+} from "../ai-platform-sweep-lib"
+import type { AiPlatformCatalogEntry } from "../../../../../mastra/services/ai-platforms"
+
+const KNOWN = [
+  "ai_search_chat",
+  "ai_search_embed",
+  "ai_product_description",
+  "ai_image_gen",
+  "ai_digest_summary",
+  "ai_newsletter_drafter",
+] as const
+
+const entry = (
+  over: Partial<AiPlatformCatalogEntry> & { platformId: string }
+): AiPlatformCatalogEntry => ({
+  name: over.platformId,
+  role: null,
+  providerType: null,
+  defaultModel: null,
+  isDefault: false,
+  status: "active",
+  hasApiKey: true,
+  ...over,
+})
+
+describe("buildAiPlatformCoverageReport", () => {
+  it("reports every known role even with an empty catalog (all free-fallback)", () => {
+    const report = buildAiPlatformCoverageReport([], KNOWN)
+    expect(report.roles.map((r) => r.role)).toEqual([...KNOWN])
+    expect(report.totals).toEqual({
+      knownRoles: 6,
+      configuredRoles: 0,
+      freeFallbackRoles: 6,
+      untaggedPlatforms: 0,
+    })
+    expect(report.roles.every((r) => r.flags.includes("no-platform→free-fallback"))).toBe(true)
+    expect(report.summary).toContain("0/6 known AI roles configured")
+  })
+
+  it("counts a configured (active+keyed+default) role and omits free-fallback flag", () => {
+    const catalog = [
+      entry({ platformId: "p1", role: "ai_search_chat", isDefault: true }),
+    ]
+    const report = buildAiPlatformCoverageReport(catalog, KNOWN)
+    const chat = report.roles.find((r) => r.role === "ai_search_chat")!
+    expect(chat.configured).toBe(true)
+    expect(chat.hasDefault).toBe(true)
+    expect(chat.flags).toEqual([])
+    expect(report.totals.configuredRoles).toBe(1)
+    expect(report.totals.freeFallbackRoles).toBe(5)
+  })
+
+  it("flags missing-api-key and no-default", () => {
+    const catalog = [
+      entry({ platformId: "p1", role: "ai_search_chat", hasApiKey: false }),
+    ]
+    const report = buildAiPlatformCoverageReport(catalog, KNOWN)
+    const chat = report.roles.find((r) => r.role === "ai_search_chat")!
+    expect(chat.configured).toBe(false) // no usable platform
+    expect(chat.flags).toEqual(
+      expect.arrayContaining(["no-usable-platform", "missing-api-key", "no-default"])
+    )
+  })
+
+  it("flags ambiguous-default when >1 usable platform and none default", () => {
+    const catalog = [
+      entry({ platformId: "p1", role: "ai_search_chat" }),
+      entry({ platformId: "p2", role: "ai_search_chat" }),
+    ]
+    const report = buildAiPlatformCoverageReport(catalog, KNOWN)
+    const chat = report.roles.find((r) => r.role === "ai_search_chat")!
+    expect(chat.configured).toBe(true)
+    expect(chat.flags).toEqual(expect.arrayContaining(["no-default", "ambiguous-default"]))
+  })
+
+  it("buckets untagged platforms and surfaces unknown custom roles", () => {
+    const catalog = [
+      entry({ platformId: "p1" }), // no role → _untagged
+      entry({ platformId: "p2", role: "ai_marketing_vp", isDefault: true }), // custom
+    ]
+    const report = buildAiPlatformCoverageReport(catalog, KNOWN)
+    const untagged = report.roles.find((r) => r.role === "_untagged")!
+    expect(untagged.flags).toContain("untagged-role")
+    expect(untagged.configured).toBe(false)
+    const custom = report.roles.find((r) => r.role === "ai_marketing_vp")!
+    expect(custom.known).toBe(false)
+    expect(custom.flags).toContain("unknown-role")
+    expect(report.totals.untaggedPlatforms).toBe(1)
+    expect(report.summary).toContain("1 platform(s) have no role tag")
+  })
+
+  it("never leaks secrets — only hasApiKey boolean is surfaced", () => {
+    const catalog = [
+      entry({ platformId: "p1", role: "ai_search_chat", hasApiKey: true }),
+    ]
+    const report = buildAiPlatformCoverageReport(catalog, KNOWN)
+    const platform = report.roles.find((r) => r.role === "ai_search_chat")!.platforms[0]
+    expect(Object.keys(platform)).toEqual(
+      expect.not.arrayContaining(["api_key", "apiKey", "api_key_encrypted"])
+    )
+    expect(platform.hasApiKey).toBe(true)
+  })
+})
+
+describe("planAiPlatformNormalization", () => {
+  it("marks the sole usable platform of a role as default", () => {
+    const catalog = [entry({ platformId: "p1", role: "ai_search_chat" })]
+    const plan = planAiPlatformNormalization(catalog)
+    expect(plan).toEqual([
+      {
+        platformId: "p1",
+        role: "ai_search_chat",
+        field: "metadata.is_default",
+        before: false,
+        after: true,
+        reason: "sole usable platform for role — marking default",
+      },
+    ])
+  })
+
+  it("is idempotent — no action once a default exists", () => {
+    const catalog = [
+      entry({ platformId: "p1", role: "ai_search_chat", isDefault: true }),
+    ]
+    expect(planAiPlatformNormalization(catalog)).toEqual([])
+  })
+
+  it("does not touch ambiguous roles (>1 usable platform)", () => {
+    const catalog = [
+      entry({ platformId: "p1", role: "ai_search_chat" }),
+      entry({ platformId: "p2", role: "ai_search_chat" }),
+    ]
+    expect(planAiPlatformNormalization(catalog)).toEqual([])
+  })
+
+  it("ignores unusable (inactive / unkeyed) sole platforms", () => {
+    const catalog = [
+      entry({ platformId: "p1", role: "ai_search_chat", status: "inactive" }),
+    ]
+    expect(planAiPlatformNormalization(catalog)).toEqual([])
+  })
+
+  it("skips the _untagged bucket", () => {
+    const catalog = [entry({ platformId: "p1" })]
+    expect(planAiPlatformNormalization(catalog)).toEqual([])
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/audit-ai-platforms.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/audit-ai-platforms.unit.spec.ts
@@ -1,0 +1,126 @@
+import { auditAiPlatformsJob, MAINTENANCE_JOBS } from "../registry"
+
+/**
+ * #756 — job-level tests for the AI-platform coverage audit. The pure
+ * report/plan logic is covered in ai-platform-sweep-lib.unit.spec.ts; here we
+ * exercise the job's container wiring (sweep → report → optional normalize)
+ * with a fake socials service. No DB.
+ */
+
+type FakeRow = {
+  id: string
+  category?: string
+  status?: string
+  metadata?: Record<string, any>
+  api_config?: Record<string, any>
+}
+
+const makeContainer = (rows: FakeRow[], updates: any[]) => {
+  const socials = {
+    listSocialPlatforms: async (filters: any = {}) => {
+      if (filters?.id) return rows.filter((r) => r.id === filters.id)
+      // sweep call: category=ai (+ status=active unless includeInactive)
+      return rows.filter((r) => r.category === "ai")
+    },
+    updateSocialPlatforms: async (payload: any) => {
+      updates.push(payload)
+      return payload
+    },
+  }
+  return {
+    resolve: (_key: string) => socials,
+  } as any
+}
+
+const aiRow = (over: Partial<FakeRow> & { id: string }): FakeRow => ({
+  category: "ai",
+  status: "active",
+  metadata: { role: "ai_search_chat" },
+  api_config: { api_key: "sk-secret", default_model: "qwen-plus" },
+  ...over,
+})
+
+describe("auditAiPlatformsJob", () => {
+  it("is registered in MAINTENANCE_JOBS", () => {
+    expect(MAINTENANCE_JOBS).toContain(auditAiPlatformsJob)
+    expect(auditAiPlatformsJob.id).toBe("audit-ai-platforms")
+  })
+
+  it("dry-run reports coverage and writes nothing", async () => {
+    const updates: any[] = []
+    const container = makeContainer(
+      [aiRow({ id: "p1", metadata: { role: "ai_search_chat", is_default: true } })],
+      updates
+    )
+    const res = await auditAiPlatformsJob.run(container, {
+      dry_run: true,
+      params: {},
+    })
+    expect(updates).toHaveLength(0)
+    expect(res.applied).toBe(false)
+    expect(res.summary).toContain("known AI roles configured")
+    // one coverage row per known role (6)
+    expect(res.changes.filter((c) => c.field === "coverage")).toHaveLength(6)
+    // no secret leaked into the coverage payload
+    expect(JSON.stringify(res.changes)).not.toContain("sk-secret")
+  })
+
+  it("dry-run flags a planned default fix without applying it", async () => {
+    const updates: any[] = []
+    // sole usable platform for the role, not marked default → plannable
+    const container = makeContainer(
+      [aiRow({ id: "p1", metadata: { role: "ai_newsletter_drafter" } })],
+      updates
+    )
+    const res = await auditAiPlatformsJob.run(container, {
+      dry_run: true,
+      params: {},
+    })
+    expect(updates).toHaveLength(0)
+    expect(res.applied).toBe(false)
+    expect(res.summary).toContain("would be set")
+  })
+
+  it("apply marks the sole usable platform default (merging metadata)", async () => {
+    const updates: any[] = []
+    const container = makeContainer(
+      [
+        aiRow({
+          id: "p1",
+          metadata: { role: "ai_newsletter_drafter", note: "keep-me" },
+        }),
+      ],
+      updates
+    )
+    const res = await auditAiPlatformsJob.run(container, {
+      dry_run: false,
+      params: {},
+    })
+    expect(res.applied).toBe(true)
+    expect(updates).toHaveLength(1)
+    expect(updates[0]).toEqual({
+      selector: { id: "p1" },
+      data: { metadata: { role: "ai_newsletter_drafter", note: "keep-me", is_default: true } },
+    })
+    // mutation surfaced as a change row
+    expect(
+      res.changes.some(
+        (c) => c.field === "metadata.is_default" && c.id === "p1" && c.after === true
+      )
+    ).toBe(true)
+  })
+
+  it("apply is a no-op when defaults are already set", async () => {
+    const updates: any[] = []
+    const container = makeContainer(
+      [aiRow({ id: "p1", metadata: { role: "ai_search_chat", is_default: true } })],
+      updates
+    )
+    const res = await auditAiPlatformsJob.run(container, {
+      dry_run: false,
+      params: {},
+    })
+    expect(updates).toHaveLength(0)
+    expect(res.applied).toBe(false)
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/ai-platform-sweep-lib.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/ai-platform-sweep-lib.ts
@@ -1,0 +1,182 @@
+// Pure report/plan builders for the "AI platform sweep & report" maintenance
+// job (#756). Kept free of any container / I/O so the coverage logic is unit
+// testable: feed it a catalog (the output of `sweepAiPlatformsByCategory`) and
+// the list of expected roles, get back a coverage report and an idempotent
+// normalization plan. No secrets are ever surfaced — only a `hasApiKey`
+// boolean.
+
+import type { AiPlatformCatalogEntry } from "../../../../mastra/services/ai-platforms"
+import { groupAiCatalogByRole } from "../../../../mastra/services/ai-platforms"
+
+/** A platform within a role bucket, secret-free. */
+export type CoveragePlatform = {
+  platformId: string
+  name?: string
+  providerType: string | null
+  defaultModel: string | null
+  isDefault: boolean
+  hasApiKey: boolean
+  status: string
+}
+
+export type RoleCoverage = {
+  role: string
+  /** True when `role` is one of the expected (known) roles. */
+  known: boolean
+  platformCount: number
+  /** At least one active, api-keyed platform → the role won't fall back to free. */
+  configured: boolean
+  hasDefault: boolean
+  /** Flags an operator should act on. */
+  flags: string[]
+  platforms: CoveragePlatform[]
+}
+
+export type AiPlatformCoverageReport = {
+  roles: RoleCoverage[]
+  /** Counts for the summary line. */
+  totals: {
+    knownRoles: number
+    configuredRoles: number
+    freeFallbackRoles: number
+    untaggedPlatforms: number
+  }
+  summary: string
+}
+
+const toCoveragePlatform = (e: AiPlatformCatalogEntry): CoveragePlatform => ({
+  platformId: e.platformId,
+  name: e.name,
+  providerType: e.providerType,
+  defaultModel: e.defaultModel,
+  isDefault: e.isDefault,
+  hasApiKey: e.hasApiKey,
+  status: e.status,
+})
+
+const isUsable = (e: AiPlatformCatalogEntry): boolean =>
+  e.status === "active" && e.hasApiKey
+
+/**
+ * Build a per-role coverage report from a swept catalog. Every expected role
+ * appears (even with zero platforms → free-fallback), plus any extra roles the
+ * operator coined. Platforms with no `metadata.role` land in the synthetic
+ * `_untagged` bucket (flagged, never counted as configured).
+ *
+ * Pure — no container, no I/O, no secrets.
+ */
+export const buildAiPlatformCoverageReport = (
+  catalog: AiPlatformCatalogEntry[],
+  knownRoles: readonly string[]
+): AiPlatformCoverageReport => {
+  const grouped = groupAiCatalogByRole(catalog ?? [])
+
+  // Union of expected roles + whatever the sweep discovered, _untagged last.
+  const discovered = Object.keys(grouped).filter((r) => r !== "_untagged")
+  const roleOrder: string[] = []
+  for (const r of knownRoles) if (!roleOrder.includes(r)) roleOrder.push(r)
+  for (const r of discovered) if (!roleOrder.includes(r)) roleOrder.push(r)
+  if (grouped["_untagged"]?.length) roleOrder.push("_untagged")
+
+  const roles: RoleCoverage[] = roleOrder.map((role) => {
+    const entries = grouped[role] ?? []
+    const platforms = entries.map(toCoveragePlatform)
+    const usable = entries.filter(isUsable)
+    const hasDefault = entries.some((e) => e.isDefault)
+    const known = knownRoles.includes(role)
+
+    const flags: string[] = []
+    if (role === "_untagged") {
+      flags.push("untagged-role")
+    } else if (entries.length === 0) {
+      flags.push("no-platform→free-fallback")
+    } else {
+      if (usable.length === 0) flags.push("no-usable-platform")
+      if (entries.some((e) => !e.hasApiKey)) flags.push("missing-api-key")
+      if (!hasDefault) flags.push("no-default")
+      if (usable.length > 1 && !hasDefault) flags.push("ambiguous-default")
+      if (!known) flags.push("unknown-role")
+    }
+
+    return {
+      role,
+      known,
+      platformCount: entries.length,
+      configured: role !== "_untagged" && usable.length > 0,
+      hasDefault,
+      flags,
+      platforms,
+    }
+  })
+
+  const knownRoleRows = roles.filter((r) => r.role !== "_untagged" && r.known)
+  const configuredRoles = knownRoleRows.filter((r) => r.configured).length
+  const freeFallbackRoles = knownRoleRows.filter((r) => !r.configured).length
+  const untaggedPlatforms = grouped["_untagged"]?.length ?? 0
+
+  const totals = {
+    knownRoles: knownRoles.length,
+    configuredRoles,
+    freeFallbackRoles,
+    untaggedPlatforms,
+  }
+
+  const fallbackNames = knownRoleRows
+    .filter((r) => !r.configured)
+    .map((r) => r.role)
+  const summary =
+    `${configuredRoles}/${knownRoles.length} known AI roles configured` +
+    (freeFallbackRoles > 0
+      ? `; ${freeFallbackRoles} fall back to free models (${fallbackNames.join(", ")})`
+      : "") +
+    (untaggedPlatforms > 0
+      ? `; ${untaggedPlatforms} platform(s) have no role tag`
+      : "")
+
+  return { roles, totals, summary }
+}
+
+/** An idempotent normalization the apply pass can perform. */
+export type NormalizationAction = {
+  platformId: string
+  role: string
+  field: "metadata.is_default"
+  before: boolean
+  after: boolean
+  reason: string
+}
+
+/**
+ * Plan the safe, unambiguous normalizations. Currently one rule: a role whose
+ * ONLY usable (active + keyed) platform is not marked default → mark it
+ * default, so role resolution is deterministic. Idempotent: once the platform
+ * is default, re-planning yields nothing. We deliberately do NOT auto-rename
+ * `metadata.role` typos (too easy to mis-correct); those surface as
+ * `unknown-role` / `untagged-role` flags in the report for the operator.
+ *
+ * Pure — returns the plan; the job performs the writes.
+ */
+export const planAiPlatformNormalization = (
+  catalog: AiPlatformCatalogEntry[]
+): NormalizationAction[] => {
+  const grouped = groupAiCatalogByRole(catalog ?? [])
+  const actions: NormalizationAction[] = []
+
+  for (const [role, entries] of Object.entries(grouped)) {
+    if (role === "_untagged") continue
+    const usable = entries.filter(isUsable)
+    const anyDefault = entries.some((e) => e.isDefault)
+    if (usable.length === 1 && !anyDefault) {
+      actions.push({
+        platformId: usable[0].platformId,
+        role,
+        field: "metadata.is_default",
+        before: false,
+        after: true,
+        reason: "sole usable platform for role — marking default",
+      })
+    }
+  }
+
+  return actions
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -60,6 +60,15 @@ import {
 import { VISUAL_FLOWS_MODULE } from "../../../../modules/visual_flows"
 import { FLOW_DEF as IDEAS_EMAIL_FLOW_DEF } from "../../../../scripts/seed-marketing-daily-ideas-email-flow"
 import { seedEmailTemplatesJob } from "./seed-jobs"
+import {
+  sweepAiPlatformsByCategory,
+  AI_ROLES,
+} from "../../../../mastra/services/ai-platforms"
+import { SOCIALS_MODULE } from "../../../../modules/socials"
+import {
+  buildAiPlatformCoverageReport,
+  planAiPlatformNormalization,
+} from "./ai-platform-sweep-lib"
 
 /**
  * Admin "data-plumbing" maintenance jobs (#457 / roadmap #33).
@@ -4418,6 +4427,104 @@ export const sendMarketingDailySummaryJob: MaintenanceJob = {
   },
 }
 
+/**
+ * Audit configured AI External Platforms by role (#756). Sweeps every
+ * `category=ai` platform (`sweepAiPlatformsByCategory`, #753) and reports, per
+ * known role, whether a usable (active + api-keyed) default platform is
+ * configured or the role falls back to a free model — plus untagged / unknown /
+ * missing-default flags the operator should act on. No secrets are surfaced
+ * (only a `hasApiKey` boolean).
+ *
+ * Dry-run (default) reports only — writes nothing. Apply performs ONLY the safe,
+ * unambiguous normalization: a role whose single usable platform isn't marked
+ * default gets `metadata.is_default = true` (idempotent). It never auto-renames
+ * role typos; those stay as report flags for a human.
+ */
+export const auditAiPlatformsJob: MaintenanceJob = {
+  id: "audit-ai-platforms",
+  label: "Audit AI platforms by role",
+  description:
+    "Sweep category=ai External Platforms and report coverage per known role: which roles have a usable (active, api-keyed, default) platform vs which fall back to free models, plus untagged/unknown-role and missing/ambiguous-default flags. No secrets are shown (only a hasApiKey boolean). Dry-run (default) reports only; apply performs the single safe normalization — mark a role's sole usable platform as default (idempotent). Role-name typos are reported, never auto-corrected.",
+  params: [],
+  run: async (container, { dry_run }) => {
+    const catalog = await sweepAiPlatformsByCategory(container, {
+      includeInactive: true,
+    })
+
+    const report = buildAiPlatformCoverageReport(catalog, AI_ROLES)
+
+    // Coverage rows — one per role, always present (the report payload).
+    const changes: MaintenanceChange[] = report.roles.map((r) => ({
+      entity: "ai-platform-role",
+      id: r.role,
+      field: "coverage",
+      after: {
+        configured: r.configured,
+        hasDefault: r.hasDefault,
+        platformCount: r.platformCount,
+        flags: r.flags,
+        platforms: r.platforms,
+      },
+    }))
+
+    const errors: Array<{ id: string; message: string }> = []
+    let normalized = 0
+
+    // Apply: only the safe sole-usable-platform → default normalization.
+    const plan = planAiPlatformNormalization(catalog)
+    if (plan.length > 0) {
+      const socials: any = container.resolve(SOCIALS_MODULE)
+      for (const action of plan) {
+        if (!dry_run) {
+          try {
+            const [row] = await socials.listSocialPlatforms({
+              id: action.platformId,
+            })
+            const nextMeta = {
+              ...((row?.metadata as Record<string, any>) ?? {}),
+              is_default: true,
+            }
+            await socials.updateSocialPlatforms({
+              selector: { id: action.platformId },
+              data: { metadata: nextMeta },
+            })
+            normalized++
+          } catch (e: any) {
+            errors.push({
+              id: action.platformId,
+              message: e?.message ?? String(e),
+            })
+            continue
+          }
+        }
+        changes.push({
+          entity: "social_platform",
+          id: action.platformId,
+          field: action.field,
+          before: action.before,
+          after: action.after,
+        })
+      }
+    }
+
+    const planNote =
+      plan.length > 0
+        ? dry_run
+          ? `; ${plan.length} default(s) would be set (apply to fix)`
+          : `; set ${normalized} default(s)`
+        : ""
+
+    return {
+      job_id: auditAiPlatformsJob.id,
+      dry_run,
+      applied: !dry_run && normalized > 0,
+      summary: report.summary + planNote,
+      changes,
+      ...(errors.length ? { errors } : {}),
+    }
+  },
+}
+
 export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   recalculateDesignCostJob,
   recalculateDesignCostBulkJob,
@@ -4440,6 +4547,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   installMarketingIdeasEmailFlowJob,
   generateWinbackTargetsJob,
   sendMarketingDailySummaryJob,
+  auditAiPlatformsJob,
   seedEmailTemplatesJob,
 ]
 

--- a/apps/backend/src/mastra/services/ai-platforms.ts
+++ b/apps/backend/src/mastra/services/ai-platforms.ts
@@ -636,9 +636,16 @@ export const PROVIDER_TYPES: AiProviderType[] = [
   "custom",
 ]
 
+// Backend canonical list of the known AI roles. Keep in sync with the admin
+// dropdown (`src/admin/components/social-platforms/ai-roles.ts`
+// → KNOWN_AI_ROLES). Custom (operator-coined) roles are still discovered at
+// runtime by the category sweep — this list only drives "expected role"
+// reporting (e.g. the AI-platform coverage Data Plumbing job, #756).
 export const AI_ROLES: AiRole[] = [
   "ai_search_chat",
   "ai_search_embed",
   "ai_product_description",
+  "ai_image_gen",
+  "ai_digest_summary",
   "ai_newsletter_drafter",
 ]


### PR DESCRIPTION
Closes #756. Builds on #753 (category sweep).

## What
A guarded `#457` maintenance job — **`audit-ai-platforms`** — runnable from **Settings → Data Plumbing**, that sweeps every `category=ai` External Platform and reports coverage **per known role**: which roles have a usable (active + api-keyed + default) platform vs which fall back to free models, plus actionable flags (`untagged-role`, `unknown-role`, `missing-api-key`, `no-default`, `ambiguous-default`, `no-platform→free-fallback`).

**No secrets are ever surfaced** — only a `hasApiKey` boolean.

## Behavior
- **dry-run (default)** → reports only, writes nothing. One coverage row per role + a summary line (`"4/6 known AI roles configured; 2 fall back to free models (…)"`).
- **apply** → performs the *single safe, unambiguous* normalization: a role whose **sole usable platform** isn't marked default gets `metadata.is_default = true` (idempotent, merges existing metadata so nothing is clobbered). Role-name typos are **reported, never auto-corrected**.

## Implementation
- New pure `ai-platform-sweep-lib.ts`: `buildAiPlatformCoverageReport` + `planAiPlatformNormalization` — no container/I/O, fully unit-testable.
- Reuses #753 `sweepAiPlatformsByCategory` + `groupAiCatalogByRole`.
- Registered in `MAINTENANCE_JOBS`.
- Fixed the backend `AI_ROLES` canonical list to the full known set of **6** (was 4 and unused) — kept in sync with the admin role dropdown.

## Tests
16 unit tests (pure report/plan builders + job-level dry-run/apply wiring with a fake socials service, incl. a no-secret-leak assertion). All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)