### PR TITLE
fix(769): route inventory image-extraction through the role-based AI providers

### DIFF
--- a/apps/backend/src/admin/components/social-platforms/__tests__/ai-roles.unit.spec.ts
+++ b/apps/backend/src/admin/components/social-platforms/__tests__/ai-roles.unit.spec.ts
@@ -19,6 +19,7 @@ describe("ai-roles shared module", () => {
         "ai_image_gen",
         "ai_digest_summary",
         "ai_newsletter_drafter",
+        "ai_image_extraction",
       ])
     )
     // every entry carries a non-empty human label

--- a/apps/backend/src/admin/components/social-platforms/ai-roles.ts
+++ b/apps/backend/src/admin/components/social-platforms/ai-roles.ts
@@ -37,6 +37,10 @@ export const KNOWN_AI_ROLES: KnownAiRole[] = [
     value: "ai_newsletter_drafter",
     label: "Newsletter / Marketing — Write with AI",
   },
+  {
+    value: "ai_image_extraction",
+    label: "Inventory image → items (vision extraction)",
+  },
 ]
 
 /** Sentinel form value selected when the operator wants a free-form role. */

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/audit-ai-platforms.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/audit-ai-platforms.unit.spec.ts
@@ -59,8 +59,8 @@ describe("auditAiPlatformsJob", () => {
     expect(updates).toHaveLength(0)
     expect(res.applied).toBe(false)
     expect(res.summary).toContain("known AI roles configured")
-    // one coverage row per known role (6)
-    expect(res.changes.filter((c) => c.field === "coverage")).toHaveLength(6)
+    // one coverage row per known role (7)
+    expect(res.changes.filter((c) => c.field === "coverage")).toHaveLength(7)
     // no secret leaked into the coverage payload
     expect(JSON.stringify(res.changes)).not.toContain("sk-secret")
   })

--- a/apps/backend/src/mastra/agents/index.ts
+++ b/apps/backend/src/mastra/agents/index.ts
@@ -108,21 +108,47 @@ export const imageExtractionAgent = new Agent({
 })
 
 /**
- * Factory function to create an ImageExtractionAgent with dynamically selected model
- * Use this when you need the best available free vision model
+ * Factory function to create an ImageExtractionAgent.
+ *
+ * Pass a `model` (resolved via the role-based AI provider registry,
+ * `resolveRoleVisionModel("ai_image_extraction")`, #769) to use the
+ * admin-configured vision provider. When omitted, falls back to the
+ * auto-rotating OpenRouter free vision model so the feature keeps working
+ * without any External Platform configured.
  */
-export async function createImageExtractionAgent(): Promise<Agent> {
-  const modelId = await getVisionModelId()
-  console.log(`[ImageExtractionAgent] Using dynamic model: ${modelId}`)
+export async function createImageExtractionAgent(model?: any): Promise<Agent> {
+  const visionModel = model ?? openrouter(await getVisionModelId())
   return new Agent({
     name: "image-extraction-agent",
-    model: openrouter(modelId) as any,
+    model: visionModel as any,
     instructions:
       "You are an expert vision analyst that converts images of inventory lists, bills of materials, and packaging labels into clean, structured JSON. " +
       "Return only data that is visible or clearly implied. Use conservative estimates if uncertain and mark items with confidence scores. " +
       "Normalize units (e.g., pcs, m, kg) and include quantity as a number.",
     memory,
   })
+}
+
+/**
+ * Per-run hand-off registry for the image-extraction agent (#769).
+ *
+ * The Mastra workflow has no Medusa container, so the provider is resolved in
+ * the Medusa `run-mastra-extraction` step (which does) and the built agent is
+ * stashed here keyed by Mastra runId — a non-secret handle passed through the
+ * workflow input. The Mastra step `take`s it (read-once, race-free across
+ * concurrent extractions). Falls back to the free-vision factory when absent.
+ */
+const _extractionAgentByRun = new Map<string, Agent>()
+
+export function setExtractionAgentForRun(runId: string, agent: Agent): void {
+  if (runId) _extractionAgentByRun.set(runId, agent)
+}
+
+export function takeExtractionAgentForRun(runId?: string): Agent | undefined {
+  if (!runId) return undefined
+  const agent = _extractionAgentByRun.get(runId)
+  if (agent) _extractionAgentByRun.delete(runId)
+  return agent
 }
 
 // General chat agent for conversational tasks (text-only)

--- a/apps/backend/src/mastra/services/__tests__/resolve-role-vision-model.unit.spec.ts
+++ b/apps/backend/src/mastra/services/__tests__/resolve-role-vision-model.unit.spec.ts
@@ -1,0 +1,57 @@
+// Mock the OpenRouter provider so the free-vision fallback never hits the
+// network during unit tests (getVisionModelId() otherwise fetches the live
+// OpenRouter model list).
+jest.mock("../../providers/openrouter", () => ({
+  getVisionModelId: async () => "free/vision-model:free",
+}))
+
+import { resolveRoleVisionModel } from "../ai-platforms"
+
+describe("resolveRoleVisionModel (#769)", () => {
+  it("falls back to the free OpenRouter vision model when no platform resolves", async () => {
+    // container.resolve throws → getAiPlatformForRole returns null → free fallback
+    const container = {
+      resolve: () => {
+        throw new Error("no socials module")
+      },
+    } as any
+    const out = await resolveRoleVisionModel(container, "ai_image_extraction")
+    expect(out.source).toBe("free")
+    expect(out.providerType).toBe("openrouter")
+    expect(out.modelId).toBe("free/vision-model:free")
+    expect(out.model).toBeDefined()
+    expect(out.platformId).toBeUndefined()
+  })
+
+  it("resolves the admin-configured platform when it is the active default for the role", async () => {
+    const container = {
+      resolve: () => ({
+        listSocialPlatforms: async (filters: any) => {
+          // resolver filters on category=ai + status=active + metadata.role
+          expect(filters.category).toBe("ai")
+          expect(filters.status).toBe("active")
+          expect(filters.metadata?.role).toBe("ai_image_extraction")
+          return [
+            {
+              id: "01PLT",
+              status: "active",
+              base_url: "https://gateway.example/v1",
+              metadata: {
+                role: "ai_image_extraction",
+                provider_type: "vercel_ai_gateway",
+                is_default: true,
+              },
+              api_config: { api_key: "sk-test", default_model: "openai/gpt-4o-mini" },
+            },
+          ]
+        },
+      }),
+    } as any
+    const out = await resolveRoleVisionModel(container, "ai_image_extraction")
+    expect(out.source).toBe("platform")
+    expect(out.providerType).toBe("vercel_ai_gateway")
+    expect(out.platformId).toBe("01PLT")
+    expect(out.modelId).toBe("openai/gpt-4o-mini")
+    expect(out.model).toBeDefined()
+  })
+})

--- a/apps/backend/src/mastra/services/ai-platforms.ts
+++ b/apps/backend/src/mastra/services/ai-platforms.ts
@@ -59,6 +59,11 @@ export type AiRole =
   // provider from the admin-configured External Platform; falls back to the
   // OPENROUTER_API_KEY env var when no provider is tagged for this role.
   | "ai_newsletter_drafter"
+  // Vision extraction for inventory/import-from-image (#769). Resolves a
+  // vision-capable provider from the admin-configured External Platform;
+  // falls back to the auto-rotating OpenRouter free vision model. Previously
+  // hardcoded to OPENROUTER_API_KEY which made the feature go dark when unset.
+  | "ai_image_extraction"
   // String escape hatch so callers can use ad-hoc roles without
   // bumping this union every time.
   | (string & {})
@@ -390,6 +395,55 @@ export const resolveRoleTextModel = async (
   }
 }
 
+import { getVisionModelId } from "../providers/openrouter"
+
+/**
+ * Vision-capable sibling of `resolveRoleTextModel`. Used by image/vision
+ * features (inventory import-from-image, #769) so they pick their provider the
+ * same way text features do, instead of hardcoding OpenRouter.
+ *
+ *   1. Admin-configured External Platform for `role` (must be a vision-capable
+ *      model — the operator is responsible for picking one).
+ *   2. Free fallback — the auto-rotating OpenRouter `:free` vision model
+ *      (`getVisionModelId`). No paid hardcoded models.
+ *
+ * Never throws — a resolution failure degrades to the free vision fallback.
+ * Note `buildChatModel` is used for both text and vision: OpenRouter `.chat()`
+ * and the OpenAI-compatible `.chat()` both accept multimodal content arrays.
+ */
+export const resolveRoleVisionModel = async (
+  container: MedusaContainer,
+  role: AiRole,
+  modelOverride?: string
+): Promise<ResolvedRoleModel> => {
+  try {
+    const cfg = await getAiPlatformForRole(container, role)
+    if (cfg) {
+      return {
+        model: buildChatModel(cfg, modelOverride),
+        providerType: cfg.providerType,
+        source: "platform",
+        platformId: cfg.platformId,
+        modelId: modelOverride ?? cfg.defaultModel ?? undefined,
+      }
+    }
+  } catch (e: any) {
+    console.warn(
+      `[ai-platforms] resolveRoleVisionModel(${role}) failed, using free vision fallback: ${
+        e?.message ?? e
+      }`
+    )
+  }
+  const visionId = await getVisionModelId()
+  const router = createOpenRouter({ apiKey: process.env.OPENROUTER_API_KEY })
+  return {
+    model: router.chat(visionId),
+    providerType: "openrouter",
+    source: "free",
+    modelId: visionId,
+  }
+}
+
 import { generateText } from "ai"
 
 /**
@@ -648,4 +702,5 @@ export const AI_ROLES: AiRole[] = [
   "ai_image_gen",
   "ai_digest_summary",
   "ai_newsletter_drafter",
+  "ai_image_extraction",
 ]

--- a/apps/backend/src/mastra/workflows/imageExtraction/index.ts
+++ b/apps/backend/src/mastra/workflows/imageExtraction/index.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck - Ignore all TypeScript errors in this file
 import { createWorkflow, createStep } from "@mastra/core/workflows";
 import { z } from "zod";
-import { createImageExtractionAgent } from "../../agents";
+import { createImageExtractionAgent, takeExtractionAgentForRun } from "../../agents";
 
 // Trigger: image to analyze and optional entity type
 export const triggerSchema = z.object({
@@ -21,6 +21,9 @@ export const triggerSchema = z.object({
   // Optional memory context
   threadId: z.string().optional(),
   resourceId: z.string().optional(),
+  // Mastra runId handed in by the Medusa bridge step so we can pick up the
+  // provider-resolved agent for this run (#769). Non-secret handle.
+  run_id: z.string().optional(),
 });
 
 // Item structure extracted from the image
@@ -106,8 +109,11 @@ const extractItems = createStep({
       : 'image-extraction:inventory-extraction'
       console.log(stableResourceId)
 
-    // Create agent with dynamically selected best free vision model
-    const agent = await createImageExtractionAgent();
+    // Prefer the agent built by the Medusa bridge step from the role-resolved
+    // vision provider (#769); fall back to the free-vision factory.
+    const agent =
+      takeExtractionAgentForRun(inputData.run_id) ??
+      (await createImageExtractionAgent());
 
     const response = await agent.generate(
       [

--- a/apps/backend/src/workflows/ai/image-extraction.ts
+++ b/apps/backend/src/workflows/ai/image-extraction.ts
@@ -6,6 +6,15 @@ import {
 } from "@medusajs/framework/workflows-sdk";
 import { MedusaError } from "@medusajs/framework/utils";
 import { mastra } from "../../mastra";
+import {
+  resolveRoleVisionModel,
+  logAiUsage,
+} from "../../mastra/services/ai-platforms";
+import {
+  createImageExtractionAgent,
+  setExtractionAgentForRun,
+  takeExtractionAgentForRun,
+} from "../../mastra/agents";
 
 // Input mirrors AdminImageExtractionReqType to keep coupling minimal
 export type ImageExtractionInput = {
@@ -83,16 +92,64 @@ const deriveResourceId = createStep(
 
 const runMastraExtraction = createStep(
   "run-mastra-extraction",
-  async (input: ImageExtractionInput) => {
-    // Execute the Mastra imageExtractionWorkflow to unify behavior
-    const run  = await mastra.getWorkflow("imageExtractionWorkflow").createRun()
-    const workflowResult = await run.start({ inputData: {
-      image_url: input.image_url,
-      entity_type: input.entity_type || "raw_material",
-      notes: input.notes,
-      threadId: input.threadId,
-      resourceId: input.resourceId,
-    } })
+  async (input: ImageExtractionInput, { container }) => {
+    // Resolve the vision provider via the role-based AI platform registry
+    // (#769) — admin-configured "External Platform" for ai_image_extraction,
+    // else the auto-rotating OpenRouter free vision model. The Mastra workflow
+    // has no container, so we build the agent here and hand it off by runId.
+    let logger: any
+    try { logger = container.resolve("logger") } catch { /* optional */ }
+
+    const run = await mastra.getWorkflow("imageExtractionWorkflow").createRun()
+    let providerType: any = "openrouter"
+    let source: any = "free"
+    let modelId: string | undefined
+    let platformId: string | undefined
+    const started = Date.now()
+    try {
+      const resolved = await resolveRoleVisionModel(container, "ai_image_extraction")
+      providerType = resolved.providerType
+      source = resolved.source
+      modelId = resolved.modelId
+      platformId = resolved.platformId
+      const agent = await createImageExtractionAgent(resolved.model)
+      setExtractionAgentForRun(run.runId, agent)
+    } catch (e: any) {
+      // Provider resolution itself failed — let the Mastra step fall back to
+      // its own free-vision factory rather than blocking extraction.
+      console.warn(
+        `[image-extraction] vision provider resolution failed, using free fallback: ${e?.message ?? e}`
+      )
+    }
+
+    let workflowResult: any
+    try {
+      workflowResult = await run.start({ inputData: {
+        image_url: input.image_url,
+        entity_type: input.entity_type || "raw_material",
+        notes: input.notes,
+        threadId: input.threadId,
+        resourceId: input.resourceId,
+        run_id: run.runId,
+      } })
+    } finally {
+      // If the Mastra step never consumed the agent (early failure), drop it.
+      takeExtractionAgentForRun(run.runId)
+    }
+
+    const extractOk =
+      workflowResult.steps.validateExtraction?.status === "success" ||
+      workflowResult.steps.extractItems?.status === "success"
+    logAiUsage(logger, {
+      feature: "inventory/image-extraction",
+      role: "ai_image_extraction",
+      provider: providerType,
+      source,
+      model: modelId,
+      platformId,
+      ok: extractOk,
+      ms: Date.now() - started,
+    })
 
     // Validate steps
     if (workflowResult.steps.validateExtraction?.status === "failed") {

--- a/apps/docs/notes/INVENTORY_IMAGE_IMPORT_AND_FLOWS_CODEMAP.md
+++ b/apps/docs/notes/INVENTORY_IMAGE_IMPORT_AND_FLOWS_CODEMAP.md
@@ -1,0 +1,157 @@
+# Codemap — Inventory image-import, route nesting & inventory-order visual flows
+
+> Exploration record (2026-06-29) backing three roadmap tasks:
+> 1. (#769) Fix the failing `inventory/import-from-image` Mastra extraction (use the role-based AI providers).
+> 2. (#770) Move the "Import From Image" button off the Inventory Orders page + nest the API under Inventory (Option A — locked).
+> 3. (#771) Enable a visual flow that sends inventory-order events/messages so users can mark orders end-to-end; verify the partner APIs.
+> 4. (#772) Wire Shiprocket so partner inventory-order completion generates a real shipment + AWB + label (replace free-text tracking). See companion `SHIPROCKET_PROVIDER_CODEMAP.md`.
+>
+> All paths are under `apps/backend/` unless noted.
+
+---
+
+## Task 1 — `inventory/import-from-image` extraction & why it fails
+
+### The user-facing surface
+- Admin UI page: `src/admin/routes/inventory/import-from-image/page.tsx`
+  - sub-page `src/admin/routes/inventory/import-from-image/recent-extractions/page.tsx`
+  - component `src/admin/components/ai/import-inventory-from-image.tsx`, hooks `src/admin/hooks/api/ai.ts`
+- Inventory-orders admin page (the "inventory orders 1" the user referenced): `src/admin/routes/orders/inventory/page.tsx`
+
+### Backend route
+- `src/api/admin/ai/image-extraction/route.ts` — `POST /admin/ai/image-extraction` (lines 127-199)
+  - request: `{ image_url, entity_type?: "raw_material"|"inventory_item", notes?, threadId?, resourceId?, hints?, verify?, persist?, defaults? }` (lines 8-18)
+  - `persist=true` → `extractAndCreateInventoryWorkflow` (`src/workflows/ai/extract-and-create-inventory.ts`) → creates raw_materials + inventory; returns 201
+  - `persist=false` → `imageExtractionMedusaWorkflow`; returns 200
+- recent: `src/api/admin/ai/image-extraction/recent/route.ts`
+
+### Mastra workflow
+- `src/mastra/workflows/imageExtraction/index.ts` — workflow id `"image-extraction"`
+  - step `extractItems` (43-180) → `createImageExtractionAgent()` (110), HTTP-URL→base64 (83-101), `agent.generate()`, parse w/ fallback (139-175)
+  - step `validateExtraction` (183-199)
+- agent factory: `src/mastra/agents/index.ts:114-126`
+  - model via `getVisionModelId()` from `src/mastra/providers/openrouter.ts:319-349`
+  - **OpenRouter client is hardcoded**: `createOpenRouter({ apiKey: process.env.OPENROUTER_API_KEY })` (`agents/index.ts:10-12`)
+  - free-vision fallback list `FALLBACK_VISION_MODELS` (`openrouter.ts:307-313`): gemini-2.0-flash-exp:free, llama-3.2-90b/11b-vision:free, qwen2.5-vl-72b:free
+
+### ROOT CAUSE — does NOT use the role-based (social-platform) AI providers
+Every *working* AI feature resolves its provider through the DB-backed role registry; image-extraction does not.
+
+- Role resolver: `src/mastra/services/ai-platforms.ts`
+  - `getAiPlatformForRole(container, role)` (142-239): queries `social_platform` where `category="ai"` + `metadata.role="<role>"` + `status="active"`, decrypts the API key (195), returns provider/model; falls back to `dynamicFreeTextModel` (386)
+  - `makeRoleAiGenerate(container, role, …)` (403-451)
+  - `AI_ROLES` union (53, 644-651): `ai_search_chat`, `ai_search_embed`, `ai_product_description`, `ai_image_gen`, `ai_digest_summary`, `ai_newsletter_drafter`
+  - **There is NO `ai_image_extraction` role**, and no vision-equivalent of `makeRoleAiGenerate` either.
+- Working example: `src/workflows/marketing/generate-newsletter-draft.ts:248` → `makeRoleAiGenerate(container, NEWSLETTER_DRAFT_ROLE…)` (role `"ai_newsletter_drafter"`, line 35).
+
+Because image-extraction is pinned to `OPENROUTER_API_KEY` + ephemeral free models, it fails when:
+1. `OPENROUTER_API_KEY` is unset in the env (no DB fallback, no graceful error)
+2. OpenRouter `/models` is unreachable/rate-limited and the hardcoded free models have expired
+3. the vision model returns empty/non-JSON → `items: []` silent no-op (parse fallback `index.ts:139-175`)
+
+> Mirrors the prior `newsletter/generate` qwen3.7-plus "empty text" 503 class of bug — the fix there was switching the prod model. Here the deeper fix is to route through the role registry so operators can pick a vision provider in the admin UI.
+
+### Fix direction
+Add an `ai_image_extraction` (vision) role to `AI_ROLES`, add a vision-capable `resolveRoleVisionModel` / `makeRoleAiGenerate`-style helper, and have `createImageExtractionAgent()` resolve via `getAiPlatformForRole(container, "ai_image_extraction")` with `dynamicFreeTextModel`/OpenRouter vision fallback — matching newsletter-drafter et al. This also unblocks admin-configured providers (Cloudflare/DashScope/Vercel AI Gateway/custom OpenAI-compatible).
+
+---
+
+## Task 2 — Move the route under the Inventory nested hierarchy
+
+### Current inventory route tree (`src/api/admin/`)
+```
+inventory-items/route.ts                                 GET/POST
+inventory-items/[id]/labels/route.ts                     GET (barcode PDF)
+inventory-items/[id]/split/route.ts                      POST
+inventory-items/[id]/rawmaterials/route.ts               POST
+inventory-items/[id]/rawmaterials/[rawMaterialId]/route.ts  GET/PUT/DELETE
+inventory-items/bulk-import/route.ts                     POST
+inventory-items/raw-materials/route.ts                   GET (items enriched w/ raw materials)
+
+inventory-orders/route.ts                                GET/POST
+inventory-orders/[id]/route.ts                           GET/PUT/DELETE
+inventory-orders/[id]/order-lines/route.ts               GET/POST
+inventory-orders/[id]/feedbacks/route.ts                 POST
+inventory-orders/[id]/send-to-partner/route.ts           POST
+inventory-orders/[id]/tasks/route.ts                     GET/POST
+inventory-orders/[id]/tasks/[taskId]/route.ts            GET/PUT/DELETE
+```
+
+### Where image extraction sits today
+- **Entry button is on the wrong page**: `src/admin/routes/orders/inventory/page.tsx:491-497` — a `<Button>Import inventory</Button>` that `navigate("/inventory/import-from-image")`. It lives on the Inventory **Orders** list, not the Inventory route.
+- AI extraction endpoint is **AI-centric**, not inventory-centric: `src/api/admin/ai/image-extraction/route.ts` (`/admin/ai/image-extraction`).
+- A separate **manual** photo→raw-material binding (no AI, #730) lives at `src/api/admin/medias/file/[id]/raw-material/route.ts` (`/admin/medias/file/:id/raw-material`, GET/POST/DELETE).
+- The admin *UI* page already exists at `src/admin/routes/inventory/import-from-image/` (+ `recent-extractions/`).
+
+### Nesting convention (file-system routing)
+`/<resource>/[id]/<sub>/route.ts` → `/resource/:id/sub`; deeper via `[id]/<sub>/[subId]/route.ts` (e.g. `inventory-items/[id]/rawmaterials/[rawMaterialId]`).
+
+### What "move it under Inventory" means — Option A (LOCKED)
+1. **UI**: relabel `orders/inventory/page.tsx:491` "Import inventory" → **"Import From Image"** and surface it from the **Inventory** route (next to the inventory item) instead of the Inventory Orders list. Repoint the `navigate(...)` target.
+2. **API**: relocate from `/admin/ai/image-extraction` to `POST /admin/inventory-items/[id]/import-from-image`, following `send-to-partner`/`labels`/`split`. Update the admin hook in `src/admin/hooks/api/ai.ts`.
+
+**Open question** (decide before building): the "create from scratch" flow has no `[id]` — keep a non-nested `POST /admin/inventory-items/import-from-image` for it, or always require an item context? (Option B — nesting under `inventory-orders/[id]` — was considered and rejected.)
+
+---
+
+## Task 3 — Visual flow for inventory-order events/messages + partner-API parity
+
+### Visual-flow event trigger (already wired)
+- `src/subscribers/visual-flow-event-trigger.ts:1-283` — matches emitted events against active flows (`trigger_type="event"`, `status="active"`), runs `executeVisualFlowWorkflow` async (20-104). Matching precedence (113-131): `event_pattern` (shell wildcards) → `event_types[]` → `event_type` (legacy).
+- **Inventory-order events already registered** (212-215):
+  - `inventory_orders.inventory-orders.created`
+  - `inventory_orders.inventory-orders.updated`
+  - `inventory_orders.inventory-orders.deleted`
+- Executor: `src/workflows/visual-flows/execute-visual-flow.ts:669-704` (load → init → execute ops along connection graph 438-506 → complete; diamond-join dedup).
+- Message ops:
+  - `src/modules/visual_flows/operations/send-whatsapp.ts:29-178` (`send_whatsapp`; template/text/image/interactive; routes to SocialPlatform by country code; persists to messaging; dedup by (context_type, context_id); partner linking/`require_partner`).
+  - `src/modules/visual_flows/operations/send-email.ts:5-107` (`send_email`; template or custom body; interpolates flow data chain).
+
+### Inventory-order model & lifecycle
+- `src/modules/inventory_orders/models/order.ts:8-15` — status enum: `Pending` (default), `Processing`, `Shipped`, `Delivered`, `Cancelled`, `Partial`.
+- Events emit automatically via `MedusaService`:
+  - create: `src/workflows/inventory_orders/create-inventory-orders.ts` (`createInvWithLines`, 67-106) → `…created`
+  - update/status change: `src/workflows/inventory_orders/update-inventory-order.ts:25-47` → `…updated`
+- **No new event type required** — created/updated/deleted already cover every lifecycle transition; status transitions ride the `…updated` event.
+
+### Partner APIs — end-to-end marking (`src/api/partners/inventory-orders/`)
+| Method | Route | Transition | Action |
+|---|---|---|---|
+| GET | `/partners/inventory-orders` (`route.ts:135`) | — | list assigned orders (filter status/offset/limit) |
+| GET | `/partners/inventory-orders/[orderId]` | — | full detail incl. `partner_info.partner_status` |
+| POST | `/partners/inventory-orders/[orderId]/start` (`start/route.ts:86`, calls `updateInventoryOrderWorkflow` status `Processing` 163-175) | Pending → Processing | mark received; stamps `partner_started_at`; completes "partner-order-received" task |
+| POST | `/partners/inventory-orders/[orderId]/complete` (`complete/route.ts:128`; wf `partner-complete-inventory-order.ts`) | Processing → Shipped/Delivered | per-line fulfillment `{lines:[{order_line_id,quantity}], deliveryDate?, trackingNumber?, notes?}`; partial supported, returns `fullyFulfilled` |
+| POST | `/partners/inventory-orders/[orderId]/submit-payment` (`submit-payment/route.ts:25`) | — | `{amount, payment_type?, payment_date?, note?, attachments?}` |
+
+Partner status path: `assigned` → `in_progress` (start) → `completed` (complete). `partner_started_at` / `partner_completed_at` timestamps.
+
+### Net for Task 3
+The plumbing exists end-to-end: partner start/complete/submit-payment mutate the order → `…updated` fires → the event-trigger subscriber already lists the inventory-order events → a flow can `send_whatsapp`/`send_email`. **Remaining work is product/config, not infra:** author the actual inventory-order flow(s) (templates per transition), confirm the trigger config uses `inventory_orders.inventory-orders.updated` (+ a `status`-changed filter, since update fires on any field), and parity-test the partner endpoints. Watch-out: `…updated` fires on metadata-only changes too — flows must guard on the status delta to avoid spurious messages.
+
+---
+
+## Task 4 — Shiprocket for stock movement on partner completion (#772)
+
+Partner completing an inventory order has **no real shipment/label** — `trackingNumber` is free text. Full provider map in `SHIPROCKET_PROVIDER_CODEMAP.md`; summary of the gap:
+
+- Flow: `src/workflows/inventory_orders/partner-complete-inventory-order.ts` (input 16-28; fulfillment entries 140-219; metadata/tracking 338-356). Route `src/api/partners/inventory-orders/[orderId]/complete/route.ts:114-126`.
+- Today: `trackingNumber` → `metadata.partner_tracking_number` + `partner_delivery_history[]` + custom `line_fulfillments` metadata. No carrier shipment, no `sr_order_id`/`shipment_id`/`label_url`.
+- Have: `ShiprocketClient.createShipment()` (`src/modules/shipping-providers/shiprocket/client.ts:304-404`) + admin precedent `POST /admin/orders/:id/shiprocket-label`.
+- Addresses sufficient: to = `inventory_orders.shipping_address`; from = stock location (`*_stock_location_id` → `stock_location.address.*`, pickup name from `metadata.shiprocket_pickup_location`).
+- **Opt-in**: shipment generation is an OPTION the partner chooses (toggle/action) — keep the free-text path when off; default off.
+- **First-time pickup bootstrap**: before `createShipment()`, `listPickupLocations()` → if the partner/stock-location pickup isn't registered, follow-up `registerPickupLocation()` from the source address, then stamp `stock_location.metadata.shiprocket_pickup_location`. If the source address itself is missing, block with a clear "add pickup address" error.
+- Storage decision: create a Medusa core `fulfillment` (reuse existing label/track routes) vs. extend the custom `line_fulfillment` with carrier refs. Partial-delivery: per-completion shipment vs. ship-once-fully-fulfilled.
+- Watch-outs: pre-registered pickup location required (hence list→register); `registerPickupLocation` is async (pickup may be non-`shippable` briefly); label best-effort (`getLabel()` follow-up); JWT TTL; COD vs prepaid `payment_mode`.
+
+---
+
+## Quick file index
+- Route: `src/api/admin/ai/image-extraction/route.ts`
+- Mastra wf: `src/mastra/workflows/imageExtraction/index.ts`; agent `src/mastra/agents/index.ts:114-126`; vision model `src/mastra/providers/openrouter.ts:319-349`
+- Role registry: `src/mastra/services/ai-platforms.ts` (`getAiPlatformForRole` 142-239, `makeRoleAiGenerate` 403-451, `AI_ROLES` 644-651)
+- Inventory routes: `src/api/admin/inventory-items/**`, `src/api/admin/inventory-orders/**`
+- Visual flow: `src/subscribers/visual-flow-event-trigger.ts`, `src/workflows/visual-flows/execute-visual-flow.ts`, `src/modules/visual_flows/operations/{send-whatsapp,send-email}.ts`
+- Inventory-order module: `src/modules/inventory_orders/models/order.ts`, `src/workflows/inventory_orders/**`
+- Partner APIs: `src/api/partners/inventory-orders/**`
+</content>
+</invoke>

--- a/apps/docs/notes/SHIPROCKET_PROVIDER_CODEMAP.md
+++ b/apps/docs/notes/SHIPROCKET_PROVIDER_CODEMAP.md
@@ -1,0 +1,50 @@
+# Codemap — Shiprocket shipping provider (service surface & wiring)
+
+> Exploration record (2026-06-29). The reusable map of the Shiprocket integration, captured while scoping #772 (wire Shiprocket into partner inventory-order completion). All paths under `apps/backend/`.
+
+## Module layout — `src/modules/shipping-providers/`
+- `provider-interface.ts` — shared `ShippingProviderClient` interface (`CreateShipmentInput` 59-89, `ShippingProviderClient` 218-251). Both carriers implement it → resolver abstraction.
+- `shiprocket/client.ts` (1-542) — the HTTP client (JWT auth + endpoints).
+- `shiprocket/service.ts` (1-234) — Medusa fulfillment-provider service; `createFulfillment` (104-209) maps a Medusa fulfillment → Shiprocket shipment and persists refs.
+- `delhivery/service.ts` — contrast carrier: single-carrier, `create.json` returns waybill + assigns in one call, explicit `cod_amount`, API-key auth (no JWT expiry). Same interface.
+
+## ShiprocketClient API surface (`shiprocket/client.ts`)
+| Method | Line | Notes |
+|---|---|---|
+| `authenticate()` | 207-227 | JWT (email/password), ~10-day TTL, transparent 401-retry |
+| `createShipment(input)` | 304-404 | **3-step**: POST `/orders/create/adhoc` (→ `shipment_id`) → POST `/courier/assign/awb` (optional `courier_id`) → POST `/courier/generate/label` (→ `label_url`, best-effort). Returns unified `ShipmentResult` {awb, tracking_number, tracking_url, label_url, provider_refs} |
+| `getLabel(ref)` | 406-416 | fetch label by `shipment_id` (label may be generated later) |
+| `track(ref)` | 418-433 | by AWB or `shipment_id` |
+| `cancelShipment(ref)` | 435-445 | by `sr_order_id` |
+| `schedulePickup(input)` | 447-463 | |
+| `registerPickupLocation(input)` | 465-487 | register warehouse/pickup |
+| `listPickupLocations()` | 494-500 | with `shippable` status |
+| `getRates(query)` | 269-297 | courier options for a lane |
+| `checkServiceability(pin)` | 262-267 | stubbed |
+| `normalizeWebhook(payload)` | 503-519 | parse tracking webhook |
+
+## Persistence (today, for Medusa Order fulfillments)
+- `service.ts:185-204` — `createFulfillment` writes onto the Medusa `fulfillment.data`:
+  `{ carrier: "shiprocket", waybill: awb, tracking_number, ...provider_refs (sr_order_id, shipment_id, courier_company_id), ...raw }` and `labels: [{ tracking_number, tracking_url, label_url }]`.
+- Updated via `fulfillmentModule.updateFulfillment()`.
+
+## Admin trigger routes (#404 label-first MVP)
+- `POST /admin/orders/:id/fulfillments/:fulfillmentId/shiprocket-shipment` — `src/api/admin/orders/[id]/fulfillments/[fulfillmentId]/shiprocket-shipment/route.ts`; calls `createShiprocketShipmentForFulfillment()` (`src/workflows/orders/shiprocket-shipment.ts:120-235`). Body: `pickup_location_name?, weight_grams?, dimensions_cm?, preferred_courier_id?`.
+- `POST /admin/orders/:id/shiprocket-label` — Design-Orders convenience; `ensureOrderFulfillment()` then `createShiprocketShipmentForFulfillment()`. Body: `preferred_courier_id?`.
+- `GET /admin/orders/:id/fulfillments/:fulfillmentId/label` — fetch cached/manual label; delegates to `provider.getLabel()` for Shiprocket.
+
+## Pickup-location resolution
+- Resolved from the stock location metadata key `SHIPROCKET_PICKUP_METADATA_KEY` = `"shiprocket_pickup_location"` (`shiprocket-shipment.ts:163-171` queries `stock_location` by `fulfillment.location_id`, reads `metadata.shiprocket_pickup_location`). Register via `registerPickupLocation()` if missing.
+- **First-time bootstrap pattern (for #772 / partner-created shipments)**: `listPickupLocations()` → if the partner/stock-location pickup name isn't present, follow-up `registerPickupLocation()` from the source address, then persist the name into `stock_location.metadata.shiprocket_pickup_location` so later shipments skip it. Registration is async server-side (pickup may show non-`shippable` briefly) — surface that, don't hard-fail. If the source address itself is missing, block with an "add pickup address" error before calling Shiprocket.
+
+## `CreateShipmentInput` shape (`provider-interface.ts:59-89`)
+`reference_id`, `pickup_location_name`, `to` {name, phone, address_1, city, postal_code, province, country}, `items[]`, `weight_grams`, `dimensions_cm`, `sub_total`, `payment_mode` (prepaid/COD), preferred courier, etc.
+
+## Key gotchas
+- Shiprocket needs a **pre-registered pickup location name** — you can't pass a raw from-address; register it (or map the stock location's metadata key) first.
+- `createShipment` is multi-call; label generation is best-effort and may need a follow-up `getLabel()`.
+- JWT expires (~10 days) — the client auto-reauths on 401.
+- Today only **Medusa core Order** fulfillments flow through this. **Inventory orders use a custom `line_fulfillments` module — NO core fulfillment record** — so the inventory-order wiring must either create a core fulfillment or extend `line_fulfillment` to carry carrier refs (see #772).
+
+Related: #404 (admin Shiprocket/Delhivery MVP), #649 (global shipping-provider abstraction), #772 (inventory-order completion wiring).
+</content>


### PR DESCRIPTION
Fixes the failing **inventory → Import From Image** extraction (#769).

### Problem
The Mastra image-extraction agent was hardcoded to OpenRouter free vision models via `OPENROUTER_API_KEY` (`src/mastra/agents/index.ts`). It bypassed the role-based "External Platforms" registry that every other AI feature uses, so it silently failed (empty `items: []` / 500) when the key was unset or the rotating free vision models expired — with no admin-configurable provider and no graceful fallback.

### Fix — route it through the role registry (like newsletter/digest/search)
- **`ai-platforms.ts`**: new `ai_image_extraction` role + `resolveRoleVisionModel()` (mirrors `resolveRoleTextModel`; admin platform → free OpenRouter-vision fallback; never throws).
- **`agents/index.ts`**: `createImageExtractionAgent(model?)` takes a pre-built model; adds a per-run agent registry keyed by Mastra `runId`. Mastra has no Medusa container, so the provider is resolved in the Medusa bridge step and the agent handed off by runId — **no secrets cross Mastra's persisted run state** (the alternative, passing the API key through `run.start` inputData, would persist it to Mastra storage).
- **`imageExtraction` (Mastra) + `image-extraction.ts` (Medusa)**: bridge step resolves the vision model via the container, builds+registers the agent, passes `run_id`, emits an `[ai-usage]` line, cleans up. The API still flows entirely through workflows.
- **admin `ai-roles.ts`**: surfaces the new role in the "Create AI provider" dropdown so operators can assign a vision provider (Cloudflare / DashScope / Vercel AI Gateway / custom).

### Tests
- New `resolve-role-vision-model.unit.spec.ts` (platform path + free fallback, network mocked).
- Updated role-list assertions: `KNOWN_AI_ROLES` + audit coverage 6→7.
- `tsc --noEmit`: zero new errors in changed files; full affected unit suites green.

### Verify (final gate)
Settings → External Platforms → create an `ai` platform tagged role **"Inventory image → items (vision extraction)"** with a vision model, then Inventory → Import From Image and upload an image. With no platform configured it should still work via the free OpenRouter vision fallback.

Refs #769 · parent #773 · codemaps `apps/docs/notes/INVENTORY_IMAGE_IMPORT_AND_FLOWS_CODEMAP.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
