### PR TITLE
feat(770): nest the Import-From-Image route under Inventory

### DIFF
--- a/apps/backend/src/admin/hooks/api/ai.ts
+++ b/apps/backend/src/admin/hooks/api/ai.ts
@@ -26,7 +26,9 @@ export const useImageExtraction = (
 ) => {
   return useMutation({
     mutationFn: async (payload: ImageExtractionPayload) => {
-      const response = (await sdk.client.fetch(`/admin/ai/image-extraction`, {
+      // #770: canonical inventory-nested path (legacy /admin/ai/image-extraction
+      // is retained server-side as a backward-compatible alias).
+      const response = (await sdk.client.fetch(`/admin/inventory-items/import-from-image`, {
         method: "POST",
         body: payload,
       })) as ImageExtractionResponse

--- a/apps/backend/src/admin/routes/orders/inventory/page.tsx
+++ b/apps/backend/src/admin/routes/orders/inventory/page.tsx
@@ -493,7 +493,7 @@ const InventoryOrdersPage = () => {
                   variant="secondary"
                   onClick={() => navigate("/inventory/import-from-image")}
                 >
-                  Import inventory
+                  Import From Image
                 </Button>
                 <Button
                   size="small"

--- a/apps/backend/src/api/admin/inventory-items/import-from-image/route.ts
+++ b/apps/backend/src/api/admin/inventory-items/import-from-image/route.ts
@@ -1,0 +1,17 @@
+/**
+ * @file Inventory "Import From Image" route (#770)
+ * @description Canonical, inventory-nested entry point for the AI image-import
+ * tool. Bulk-style (no `[id]`): extract a list of raw materials / inventory
+ * items from a single image, optionally persisting them.
+ *
+ * POST /admin/inventory-items/import-from-image
+ *
+ * The handler is shared with the legacy `/admin/ai/image-extraction` route,
+ * which is retained as a backward-compatible alias (and keeps its place in the
+ * AI OpenAPI group). New callers — the admin "Import From Image" page and its
+ * `useImageExtraction` hook — target this inventory-nested path.
+ *
+ * Validation is wired in `src/api/middlewares.ts` for this matcher, mirroring
+ * the legacy route (`validateAndTransformBody(wrapSchema(AdminImageExtractionReq))`).
+ */
+export { POST } from "../../ai/image-extraction/route"

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -2706,6 +2706,14 @@ export default defineMiddlewares({
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(AdminImageExtractionReq))],
     },
+    // Inventory-nested alias of the image-extraction endpoint (#770) — the
+    // canonical "Import From Image" path under the Inventory resource. Same
+    // validation as the legacy /admin/ai/image-extraction matcher above.
+    {
+      matcher: "/admin/inventory-items/import-from-image",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(AdminImageExtractionReq))],
+    },
     // AI Chat endpoints (BM25 + LLM hybrid)
     {
       matcher: "/admin/ai/chat/chat",


### PR DESCRIPTION
Nests the **Import From Image** entry under the Inventory resource (#770).

Per the locked decision (Option A, bulk-style, no `[id]`):

- **New route** `POST /admin/inventory-items/import-from-image` — the canonical path, delegating to the shared image-extraction handler. The legacy `POST /admin/ai/image-extraction` stays as a **backward-compatible alias** (so the AI OpenAPI group and the separate `/admin/ai/image-extraction/recent` audit endpoint keep working).
- **Middleware**: validates the new matcher with `AdminImageExtractionReq`, mirroring the legacy route.
- **Admin hook** `useImageExtraction` → new path (the Import From Image page uses this hook).
- **Button**: relabel the Inventory Orders toolbar button `"Import inventory"` → `"Import From Image"`.

`tsc --noEmit`: no new errors in changed files.

### Notes
- The `/recent` audit GET still targets the AI path; left as-is (out of scope, still works).
- Pairs with #769 (the provider fix). Independent branch off `main`.

Refs #770 · parent #773

🤖 Generated with [Claude Code](https://claude.com/claude-code)
