### PR TITLE
feat(771): emit inventory-order status-changed event for visual flows

### DIFF
--- a/apps/backend/src/subscribers/visual-flow-event-trigger.ts
+++ b/apps/backend/src/subscribers/visual-flow-event-trigger.ts
@@ -213,6 +213,10 @@ export const config: SubscriberConfig = {
     "inventory_orders.inventory-orders.created",
     "inventory_orders.inventory-orders.updated",
     "inventory_orders.inventory-orders.deleted",
+    // Fires only on a real status transition (previous → new), unlike the noisy
+    // generic "updated" above which also fires on metadata-only writes. Prefer
+    // this as the trigger for partner inventory-order notification flows (#771).
+    "inventory_orders.inventory-order.status-changed",
     
     // Partners
     "partner.partner.created",

--- a/apps/backend/src/workflows/inventory_orders/__tests__/status-changed-event.unit.spec.ts
+++ b/apps/backend/src/workflows/inventory_orders/__tests__/status-changed-event.unit.spec.ts
@@ -1,0 +1,32 @@
+import {
+  buildStatusChangedEvent,
+  INVENTORY_ORDER_STATUS_CHANGED_EVENT,
+} from "../update-inventory-order"
+
+describe("buildStatusChangedEvent (#771)", () => {
+  it("emits when a status change was intended and the value actually moved", () => {
+    const ev = buildStatusChangedEvent("io_1", "Pending", "Processing", true)
+    expect(ev).toEqual({
+      name: INVENTORY_ORDER_STATUS_CHANGED_EVENT,
+      data: { id: "io_1", previous_status: "Pending", status: "Processing" },
+    })
+  })
+
+  it("normalizes a missing previous status to null", () => {
+    const ev = buildStatusChangedEvent("io_1", undefined, "Shipped", true)
+    expect(ev?.data).toEqual({ id: "io_1", previous_status: null, status: "Shipped" })
+  })
+
+  it("no-ops when no status change was intended (metadata-only update)", () => {
+    expect(buildStatusChangedEvent("io_1", "Processing", "Processing", false)).toBeNull()
+  })
+
+  it("no-ops when the status did not actually change", () => {
+    expect(buildStatusChangedEvent("io_1", "Processing", "Processing", true)).toBeNull()
+  })
+
+  it("no-ops when the new status is missing", () => {
+    expect(buildStatusChangedEvent("io_1", "Processing", undefined, true)).toBeNull()
+    expect(buildStatusChangedEvent("io_1", "Processing", null, true)).toBeNull()
+  })
+})

--- a/apps/backend/src/workflows/inventory_orders/update-inventory-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/update-inventory-order.ts
@@ -4,9 +4,48 @@ import {
   StepResponse,
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk";
+import { Modules } from "@medusajs/framework/utils";
+import type { IEventBusModuleService } from "@medusajs/types";
 import InventoryOrderService from "../../modules/inventory_orders/service";
 import { ORDER_INVENTORY_MODULE } from "../../modules/inventory_orders";
 import { mirrorUnifiedOrderStatusStep } from "./dual-write-unified-order";
+
+/**
+ * Dedicated status-transition event (#771). The MedusaService auto-emits a
+ * generic `inventory_orders.inventory-orders.updated` on every write —
+ * including metadata-only ones — which is too noisy to trigger partner
+ * notification visual flows on. This fires only when the status actually
+ * changes, carrying previous → new so a flow can branch/guard cleanly. Every
+ * status transition (admin edit, partner start, partner complete) routes
+ * through `updateInventoryOrderStep`, so this is the single choke point.
+ */
+export const INVENTORY_ORDER_STATUS_CHANGED_EVENT =
+  "inventory_orders.inventory-order.status-changed";
+
+export type StatusChangedEvent = {
+  name: typeof INVENTORY_ORDER_STATUS_CHANGED_EVENT;
+  data: { id: string; previous_status: string | null; status: string };
+};
+
+/**
+ * Pure decision for whether (and what) status-changed event to emit. Emits only
+ * when a status change was intended AND the value actually moved. Returns null
+ * otherwise (no-op). Kept pure so it's unit-testable without a container. #771
+ */
+export const buildStatusChangedEvent = (
+  id: string,
+  previousStatus: string | undefined | null,
+  newStatus: string | undefined | null,
+  statusIntended: boolean
+): StatusChangedEvent | null => {
+  if (!statusIntended || !newStatus || newStatus === previousStatus) {
+    return null;
+  }
+  return {
+    name: INVENTORY_ORDER_STATUS_CHANGED_EVENT,
+    data: { id, previous_status: previousStatus ?? null, status: newStatus },
+  };
+};
 
 type UpdateInventoryOrderStepInput = {
   id: string;
@@ -26,10 +65,42 @@ export const updateInventoryOrderStep = createStep(
   "update-inventory-order-step",
   async (input: UpdateInventoryOrderStepInput, { container }) => {
     const inventoryOrderService: InventoryOrderService = container.resolve(ORDER_INVENTORY_MODULE);
+
+    // Capture the prior status only when a status change is intended, so we can
+    // emit a clean status-changed event without an extra read on metadata-only
+    // updates. #771
+    let previousStatus: string | undefined;
+    if (input.update.status !== undefined) {
+      try {
+        const existing = await inventoryOrderService.retrieveInventoryOrder(input.id, {
+          select: ["id", "status"],
+        });
+        previousStatus = (existing as any)?.status;
+      } catch {
+        /* best-effort — fall back to emitting without a previous_status */
+      }
+    }
+
     const order = await inventoryOrderService.updateInventoryOrders({
       id: input.id,
       ...input.update
     });
+
+    const event = buildStatusChangedEvent(
+      input.id,
+      previousStatus,
+      (order as any)?.status,
+      input.update.status !== undefined
+    );
+    if (event) {
+      try {
+        const eventBus = container.resolve(Modules.EVENT_BUS) as IEventBusModuleService;
+        await eventBus.emit(event);
+      } catch {
+        /* best-effort — never block the update if event emit fails */
+      }
+    }
+
     return new StepResponse(order);
   }
 );


### PR DESCRIPTION
Enables a visual flow to notify on inventory-order lifecycle/status changes (#771).

The infra already existed (event-trigger subscriber + `send_whatsapp`/`send_email` ops); the gap was a clean trigger. The auto-emitted `inventory_orders.inventory-orders.updated` fires on **every** write including metadata-only ones, so triggering partner notifications on it would spam.

### Change
- **New event** `inventory_orders.inventory-order.status-changed` (carries `previous_status` → `status`), emitted from `updateInventoryOrderStep` **only** on a real status transition. Every transition path — admin edit, partner `start` (→ Processing), partner `complete` (→ Shipped/Partial) — routes through `updateInventoryOrderWorkflow`, so this one choke point covers all of them. Emit is best-effort (never blocks the update).
- Emit decision extracted into a pure `buildStatusChangedEvent()` (**5 unit tests**).
- Registered the event in `visual-flow-event-trigger.ts` so flows can subscribe.

### Partner end-to-end (verified by trace)
`POST /partners/inventory-orders/:id/start` → `updateInventoryOrderWorkflow({status:"Processing"})` → event fires. `POST .../complete` → `updateInventoryOrderWorkflow({status: fullyFulfilled ? "Shipped" : "Partial"})` → event fires. `submit-payment` is metadata-only → correctly does **not** fire a status-changed event.

`tsc --noEmit`: no new errors. Unit suite green.

### Follow-up (config, not code)
Author the actual flow(s) in the visual-flow editor triggering on `inventory_orders.inventory-order.status-changed`, branching on `data.status`.

Refs #771 · parent #773 · codemap `apps/docs/notes/INVENTORY_IMAGE_IMPORT_AND_FLOWS_CODEMAP.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
