### PR TITLE
feat(772): optional Shiprocket shipment on partner inventory-order completion

### DIFF
--- a/apps/backend/src/api/partners/inventory-orders/[orderId]/complete/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/[orderId]/complete/route.ts
@@ -109,6 +109,7 @@ import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework"
 import { z } from "@medusajs/framework/zod";
 import { getPartnerFromAuthContext } from "../../../helpers";
 import { partnerCompleteInventoryOrderWorkflow } from "../../../../../workflows/inventory_orders/partner-complete-inventory-order";
+import { createInventoryOrderShipmentWorkflow } from "../../../../../workflows/inventory_orders/create-inventory-order-shipment";
 
 // Accept both snake_case and camelCase for backward compatibility, then normalize
 const requestBodySchema = z.object({
@@ -122,7 +123,19 @@ const requestBodySchema = z.object({
     lines: z.array(z.object({
         order_line_id: z.string(),
         quantity: z.number().positive("Quantity must be greater than 0")
-    })).nonempty()
+    })).nonempty(),
+    // #772 — opt-in: generate a real carrier shipment (AWB + label) for this
+    // completion instead of (or in addition to) recording a free-text tracking
+    // number. Off by default — existing behaviour is unchanged.
+    generate_shipment: z.boolean().optional(),
+    pickup_stock_location_id: z.string().optional(),
+    weight_grams: z.number().positive().optional(),
+    dimensions_cm: z.object({
+        length: z.number().positive(),
+        breadth: z.number().positive(),
+        height: z.number().positive(),
+    }).partial().optional(),
+    preferred_courier_id: z.union([z.string(), z.number()]).optional(),
 });
 
 export async function POST(
@@ -140,7 +153,7 @@ export async function POST(
         });
     }
     
-    const { notes, deliveryDate, delivery_date, trackingNumber, tracking_number, stock_location_id, stockLocationId, lines } = validation.data;
+    const { notes, deliveryDate, delivery_date, trackingNumber, tracking_number, stock_location_id, stockLocationId, lines, generate_shipment, pickup_stock_location_id, weight_grams, dimensions_cm, preferred_courier_id } = validation.data;
     const normalizedDeliveryDate = deliveryDate || delivery_date;
     const normalizedTrackingNumber = trackingNumber || tracking_number;
     const normalizedStockLocationId = stock_location_id || stockLocationId;
@@ -175,9 +188,45 @@ export async function POST(
                 details: errors
             })
         }
+
+        // #772 — opt-in carrier shipment. Runs only after the completion
+        // succeeded, in its own workflow. Non-fatal: a shipment failure must
+        // not undo a completed delivery, so we surface it alongside the result
+        // rather than 500-ing.
+        let shipment: any = undefined;
+        let shipment_error: string | undefined = undefined;
+        if (generate_shipment) {
+            const deliveredQuantities = lines.reduce(
+                (acc: Record<string, number>, l) => {
+                    acc[l.order_line_id] = (acc[l.order_line_id] || 0) + l.quantity;
+                    return acc;
+                },
+                {} as Record<string, number>
+            );
+            const { result: shipResult, errors: shipErrors } = await createInventoryOrderShipmentWorkflow(req.scope).run({
+                input: {
+                    orderId,
+                    pickupStockLocationId: pickup_stock_location_id || normalizedStockLocationId,
+                    weightGrams: weight_grams,
+                    dimensionsCm: dimensions_cm as any,
+                    preferredCourierId: preferred_courier_id,
+                    deliveredQuantities,
+                    actingEmail: (partner as any)?.email || undefined,
+                },
+                throwOnError: false,
+            });
+            if (shipErrors && shipErrors.length > 0) {
+                shipment_error = shipErrors.map((e: any) => e.error?.message).filter(Boolean).join("; ") || "Shipment creation failed";
+            } else {
+                shipment = shipResult;
+            }
+        }
+
         return res.status(200).json({
             message: result?.fullyFulfilled ? "Order completed successfully" : "Order updated (partial delivery)",
-            result
+            result,
+            ...(shipment ? { shipment } : {}),
+            ...(shipment_error ? { shipment_error } : {}),
         })
-        
+
 }

--- a/apps/backend/src/workflows/inventory_orders/__tests__/inventory-order-shipment.unit.spec.ts
+++ b/apps/backend/src/workflows/inventory_orders/__tests__/inventory-order-shipment.unit.spec.ts
@@ -1,0 +1,85 @@
+import {
+  buildInventoryOrderShipmentInput,
+  DEFAULT_INVENTORY_SHIPMENT_WEIGHT_GRAMS,
+  type InventoryOrderForShipment,
+} from "../lib/inventory-order-shipment"
+
+const baseOrder: InventoryOrderForShipment = {
+  id: "invord_1",
+  total_price: 1200,
+  metadata: {},
+  shipping_address: {
+    first_name: "JYT",
+    last_name: "Warehouse",
+    phone: "9990001111",
+    address_1: "12 Loom St",
+    city: "Delhi",
+    province: "DL",
+    postal_code: "110001",
+    country_code: "in",
+  },
+  orderlines: [
+    { id: "ol_1", quantity: 10, price: 50, metadata: { title: "Cotton yarn", sku: "CY-1" } },
+    { id: "ol_2", quantity: 4, price: 100, metadata: { name: "Dye" } },
+  ],
+}
+
+describe("buildInventoryOrderShipmentInput (#772)", () => {
+  it("maps address, items and totals; defaults prepaid + weight + uppercased country", () => {
+    const input = buildInventoryOrderShipmentInput(baseOrder, { pickupLocationName: "warehouse-abc12345" })
+    expect(input.reference_id).toBe("invord_1")
+    expect(input.payment_mode).toBe("prepaid")
+    expect(input.cod_amount).toBeUndefined()
+    expect(input.pickup_location_name).toBe("warehouse-abc12345")
+    expect(input.weight_grams).toBe(DEFAULT_INVENTORY_SHIPMENT_WEIGHT_GRAMS)
+    expect(input.to).toMatchObject({
+      name: "JYT Warehouse",
+      phone: "9990001111",
+      address_1: "12 Loom St",
+      city: "Delhi",
+      state: "DL",
+      pincode: "110001",
+      country: "IN",
+    })
+    expect(input.items).toEqual([
+      { name: "Cotton yarn", sku: "CY-1", quantity: 10, unit_price: 50 },
+      { name: "Dye", sku: undefined, quantity: 4, unit_price: 100 },
+    ])
+    expect(input.sub_total).toBe(1200) // total_price wins when present
+  })
+
+  it("restricts items/quantities to delivered lines and drops zero-qty lines", () => {
+    const input = buildInventoryOrderShipmentInput(baseOrder, {
+      pickupLocationName: "wh",
+      deliveredQuantities: { ol_1: 6, ol_2: 0 },
+    })
+    expect(input.items).toEqual([
+      { name: "Cotton yarn", sku: "CY-1", quantity: 6, unit_price: 50 },
+    ])
+  })
+
+  it("computes sub_total from items when total_price is absent", () => {
+    const input = buildInventoryOrderShipmentInput(
+      { ...baseOrder, total_price: null },
+      { pickupLocationName: "wh" }
+    )
+    expect(input.sub_total).toBe(10 * 50 + 4 * 100)
+  })
+
+  it("emits a COD amount when payment_mode is cod", () => {
+    const input = buildInventoryOrderShipmentInput(
+      { ...baseOrder, metadata: { payment_mode: "cod" } },
+      { pickupLocationName: "wh" }
+    )
+    expect(input.payment_mode).toBe("cod")
+    expect(input.cod_amount).toBe(1200)
+  })
+
+  it("falls back to a default pickup ('') and 'Warehouse' name / IN country on a bare order", () => {
+    const input = buildInventoryOrderShipmentInput({ id: "x", orderlines: [] })
+    expect(input.pickup_location_name).toBe("")
+    expect(input.to.name).toBe("Warehouse")
+    expect(input.to.country).toBe("IN")
+    expect(input.items).toEqual([])
+  })
+})

--- a/apps/backend/src/workflows/inventory_orders/create-inventory-order-shipment.ts
+++ b/apps/backend/src/workflows/inventory_orders/create-inventory-order-shipment.ts
@@ -1,0 +1,155 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import { MedusaError } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+import { ORDER_INVENTORY_MODULE } from "../../modules/inventory_orders"
+import { resolveShippingProvider } from "../../modules/shipping-providers/resolver"
+import {
+  chooseRegisteredPickup,
+  registerShiprocketPickup,
+} from "../../modules/shipping-providers/pickup-locations"
+import { resolvePlatformTaxIdForCountry } from "../../modules/shipping-providers/seller-tax-id"
+import type {
+  Dimensions,
+  ShipmentResult,
+} from "../../modules/shipping-providers/provider-interface"
+import { buildInventoryOrderShipmentInput } from "./lib/inventory-order-shipment"
+
+/**
+ * Generate a real carrier shipment (forward → AWB → label) for a partner
+ * inventory-order completion and persist the carrier refs onto the inventory
+ * order (#772). Opt-in: invoked only when the partner asked to generate a
+ * shipment; the legacy free-text `partner_tracking_number` path is untouched
+ * otherwise.
+ *
+ * Pickup bootstrap: when a source stock location is given, ensure it's a
+ * registered carrier pickup via `registerShiprocketPickup` (lists first, then
+ * registers from the location's address — handles the "first time, no pickup
+ * yet" case). Otherwise fall back to any registered pickup. A clean
+ * MedusaError (not a 500) is thrown when no pickup can be resolved so the UI
+ * shows an actionable message.
+ */
+
+export type CreateInventoryOrderShipmentInput = {
+  orderId: string
+  /** Defaults to "shiprocket". */
+  carrier?: string
+  /** Source stock location to ship from; auto-registered as a pickup if new. */
+  pickupStockLocationId?: string
+  weightGrams?: number
+  dimensionsCm?: Dimensions
+  preferredCourierId?: string | number
+  /** Delivered quantities keyed by order_line_id (restricts shipment items). */
+  deliveredQuantities?: Record<string, number>
+  /** Acting user's email recorded on a freshly-registered pickup (#427). */
+  actingEmail?: string
+}
+
+export async function createInventoryOrderShipment(
+  container: MedusaContainer,
+  input: CreateInventoryOrderShipmentInput
+): Promise<ShipmentResult> {
+  const carrier = input.carrier || "shiprocket"
+  const inventoryOrderService: any = container.resolve(ORDER_INVENTORY_MODULE)
+
+  const order = await inventoryOrderService.retrieveInventoryOrder(input.orderId, {
+    select: ["id", "total_price", "metadata", "shipping_address"],
+    relations: ["orderlines"],
+  })
+  if (!order) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Inventory order ${input.orderId} not found`
+    )
+  }
+
+  // Pickup: register/confirm from the source stock location when provided
+  // (idempotent — lists then registers, recording the nickname on the
+  // location's metadata so later shipments skip it).
+  let pickupLocationName: string | undefined
+  if (input.pickupStockLocationId) {
+    const reg = await registerShiprocketPickup(container, input.pickupStockLocationId, {
+      email: input.actingEmail,
+    })
+    pickupLocationName = reg.name
+  }
+
+  const provider = await resolveShippingProvider(container, carrier)
+  if (!provider.createShipment) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `${carrier} provider does not support shipment creation`
+    )
+  }
+
+  if (!pickupLocationName && provider.listPickupLocations) {
+    try {
+      pickupLocationName = chooseRegisteredPickup(await provider.listPickupLocations())?.name
+    } catch {
+      // best-effort — the guard below produces the actionable error
+    }
+  }
+  if (!pickupLocationName) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "No carrier pickup location is configured. Register a pickup for the order's source stock location (or any carrier pickup) before generating a shipment."
+    )
+  }
+
+  const taxId = await resolvePlatformTaxIdForCountry(
+    container,
+    (order as any)?.shipping_address?.country_code || "IN"
+  )
+
+  const shipmentInput = buildInventoryOrderShipmentInput(order as any, {
+    pickupLocationName,
+    weightGrams: input.weightGrams,
+    dimensionsCm: input.dimensionsCm,
+    preferredCourierId: input.preferredCourierId,
+    taxId,
+    deliveredQuantities: input.deliveredQuantities,
+  })
+  const result = await provider.createShipment(shipmentInput)
+
+  // Persist carrier refs onto the inventory order, replacing the free-text
+  // tracking number with the real AWB. Spread the existing metadata so the
+  // whole blob isn't clobbered (Medusa replaces metadata wholesale).
+  await inventoryOrderService.updateInventoryOrders({
+    id: order.id,
+    metadata: {
+      ...((order as any).metadata || {}),
+      partner_tracking_number: result.tracking_number || result.awb,
+      shipment: {
+        carrier,
+        awb: result.awb,
+        tracking_number: result.tracking_number,
+        tracking_url: result.tracking_url,
+        label_url: result.label_url,
+        provider_refs: result.provider_refs,
+        created_at: new Date().toISOString(),
+      },
+    },
+  })
+
+  return result
+}
+
+const createInventoryOrderShipmentStep = createStep(
+  "create-inventory-order-shipment",
+  async (input: CreateInventoryOrderShipmentInput, { container }) => {
+    const result = await createInventoryOrderShipment(container, input)
+    return new StepResponse(result)
+  }
+)
+
+export const createInventoryOrderShipmentWorkflow = createWorkflow(
+  "create-inventory-order-shipment",
+  (input: CreateInventoryOrderShipmentInput) => {
+    const result = createInventoryOrderShipmentStep(input)
+    return new WorkflowResponse(result)
+  }
+)

--- a/apps/backend/src/workflows/inventory_orders/lib/inventory-order-shipment.ts
+++ b/apps/backend/src/workflows/inventory_orders/lib/inventory-order-shipment.ts
@@ -1,0 +1,116 @@
+import type {
+  CreateShipmentInput,
+  Dimensions,
+  ShipmentItem,
+} from "../../../modules/shipping-providers/provider-interface"
+
+/**
+ * Pure mapping from an inventory order onto a carrier `CreateShipmentInput`
+ * (#772). The inventory-order analogue of `buildCreateShipmentInput`
+ * (workflows/orders/shiprocket-shipment.ts) for the partner stock-movement
+ * shipment created on completion.
+ *
+ * Address semantics: `to` = the inventory order's `shipping_address`
+ * (destination warehouse). The ship-from / pickup is a registered carrier
+ * pickup referenced by `opts.pickupLocationName` (Shiprocket derives the origin
+ * address from it), resolved + auto-registered by the caller. COD vs prepaid
+ * follows `metadata.payment_mode` (stock movement is prepaid unless flagged).
+ *
+ * Pure & exported for unit testing.
+ */
+
+export const DEFAULT_INVENTORY_SHIPMENT_WEIGHT_GRAMS = 500
+
+export type InventoryOrderLineForShipment = {
+  id?: string | null
+  quantity?: number | null
+  price?: number | null
+  metadata?: Record<string, any> | null
+}
+
+export type InventoryOrderForShipment = {
+  id: string
+  total_price?: number | null
+  metadata?: Record<string, any> | null
+  shipping_address?: Record<string, any> | null
+  orderlines?: InventoryOrderLineForShipment[] | null
+}
+
+export type BuildInventoryShipmentOpts = {
+  /** Registered carrier pickup nickname (exact match). "" → client default. */
+  pickupLocationName?: string
+  weightGrams?: number
+  dimensionsCm?: Dimensions
+  preferredCourierId?: string | number
+  /** Seller tax/GST ID to stamp on the label (#348); resolved by the caller. */
+  taxId?: string
+  /**
+   * Restrict items (and quantities) to what was actually delivered in this
+   * completion, keyed by order_line_id. When omitted, the full ordered
+   * quantity ships.
+   */
+  deliveredQuantities?: Record<string, number>
+}
+
+const lineName = (l: InventoryOrderLineForShipment): string => {
+  const m = l.metadata || {}
+  return (m.title || m.name || m.description || m.sku || "Inventory item") as string
+}
+
+export function buildInventoryOrderShipmentInput(
+  order: InventoryOrderForShipment,
+  opts: BuildInventoryShipmentOpts = {}
+): CreateShipmentInput {
+  const addr = order.shipping_address || {}
+  const paymentMode: "prepaid" | "cod" =
+    order.metadata?.payment_mode === "cod" ? "cod" : "prepaid"
+
+  const items: ShipmentItem[] = (order.orderlines || [])
+    .map((l) => {
+      const delivered =
+        opts.deliveredQuantities && l.id != null
+          ? opts.deliveredQuantities[String(l.id)]
+          : undefined
+      const quantity = Number(delivered ?? l.quantity) || 0
+      return {
+        name: lineName(l),
+        sku: (l.metadata?.sku as string) || undefined,
+        quantity,
+        unit_price: Number(l.price) || 0,
+      }
+    })
+    .filter((i) => i.quantity > 0)
+
+  const subTotal =
+    order.total_price != null
+      ? Number(order.total_price)
+      : items.reduce((s, i) => s + i.unit_price * i.quantity, 0)
+
+  const name =
+    [addr.first_name, addr.last_name].filter(Boolean).join(" ") || "Warehouse"
+
+  return {
+    reference_id: order.id,
+    payment_mode: paymentMode,
+    cod_amount:
+      paymentMode === "cod" ? Number(order.total_price) || subTotal : undefined,
+    pickup_location_name: opts.pickupLocationName || "",
+    to: {
+      name,
+      phone: addr.phone || "",
+      email: addr.email || undefined,
+      address_1: addr.address_1 || "",
+      address_2: addr.address_2 || undefined,
+      city: addr.city || "",
+      state: addr.province || addr.state || "",
+      pincode: addr.postal_code || "",
+      country: addr.country_code ? String(addr.country_code).toUpperCase() : "IN",
+    },
+    items,
+    weight_grams: opts.weightGrams || DEFAULT_INVENTORY_SHIPMENT_WEIGHT_GRAMS,
+    dimensions_cm: opts.dimensionsCm,
+    sub_total: subTotal,
+    preferred_courier_id: opts.preferredCourierId,
+    tax_id: opts.taxId,
+  }
+}


### PR DESCRIPTION
Adds Shiprocket as the carrier for partner stock movement (#772). When a partner completes an inventory order, they can **optionally** generate a real shipment + AWB + label instead of only recording a free-text tracking number.

### Behaviour
- **Opt-in**: new `generate_shipment` flag on `POST /partners/inventory-orders/:id/complete`. Off by default → existing free-text path unchanged.
- **First-time pickup auto-register**: reuses the idempotent `registerShiprocketPickup` — lists existing pickups, and if the source stock location isn't registered yet, registers it from its address and records the nickname (the "their address might not be there for the first time" case). Falls back to any registered pickup; otherwise a clean actionable `MedusaError` (not a 500).
- **Through workflows**: shipment runs in its own `createInventoryOrderShipmentWorkflow`, invoked from the route **after** completion succeeds. Non-fatal — a shipment failure is surfaced as `shipment_error` in the response and never undoes the completed delivery.
- Persists `awb`/`label_url`/`tracking_url`/`provider_refs` onto the inventory order and replaces `partner_tracking_number` with the **real AWB**.
- Carrier-resolver-aware (Shiprocket default; same `ShippingProviderClient` interface as Delhivery).

### Structure
- `lib/inventory-order-shipment.ts` — pure `buildInventoryOrderShipmentInput` (maps `shipping_address` → `to`, orderlines → items, optional delivered-qty restriction, prepaid/COD). **5 unit tests.**
- `create-inventory-order-shipment.ts` — imperative fn + one-step workflow (mirrors the order-side `createShiprocketShipmentForFulfillment`).
- complete route — opt-in flag + post-completion shipment call.

`tsc --noEmit`: no new errors. Builder unit suite green.

### Open / follow-up
- **Address semantics**: `to` = the order's `shipping_address` (destination); pickup = source stock location. Partners aren't yet modelled with their own pickup address — `pickup_stock_location_id` (or the completion's `stock_location_id`) drives it. Refine partner→pickup mapping when partner addresses are first-class.
- **Partial deliveries** currently create a shipment per completion call (delivered-qty restricted). Revisit if "ship once fully fulfilled" is preferred.
- **Live gate**: exercise against a real Shiprocket account (pickup registration is async — may be briefly non-`shippable`; label is best-effort and may need a follow-up `getLabel`).

Refs #772 · parent #773 · codemaps `SHIPROCKET_PROVIDER_CODEMAP.md` + `INVENTORY_IMAGE_IMPORT_AND_FLOWS_CODEMAP.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
