### PR TITLE
fix(778): close IDOR on partner inventory-order mutation routes (C1)

### DIFF
--- a/apps/backend/src/api/partners/__tests__/inventory-order-ownership.unit.spec.ts
+++ b/apps/backend/src/api/partners/__tests__/inventory-order-ownership.unit.spec.ts
@@ -1,0 +1,23 @@
+import { inventoryOrderOwnedByPartner } from "../helpers"
+
+describe("inventoryOrderOwnedByPartner (#778 C1)", () => {
+  it("is true only when the order's linked partner id matches the acting partner", () => {
+    expect(inventoryOrderOwnedByPartner({ id: "pa_1" }, "pa_1")).toBe(true)
+  })
+
+  it("is false when the partners differ (the IDOR case)", () => {
+    expect(inventoryOrderOwnedByPartner({ id: "pa_1" }, "pa_2")).toBe(false)
+  })
+
+  it("is false when the order has no linked partner", () => {
+    expect(inventoryOrderOwnedByPartner(null, "pa_1")).toBe(false)
+    expect(inventoryOrderOwnedByPartner(undefined, "pa_1")).toBe(false)
+    expect(inventoryOrderOwnedByPartner({}, "pa_1")).toBe(false)
+  })
+
+  it("is false when there is no acting partner id", () => {
+    expect(inventoryOrderOwnedByPartner({ id: "pa_1" }, null)).toBe(false)
+    expect(inventoryOrderOwnedByPartner({ id: "pa_1" }, undefined)).toBe(false)
+    expect(inventoryOrderOwnedByPartner({ id: "pa_1" }, "")).toBe(false)
+  })
+})

--- a/apps/backend/src/api/partners/helpers.ts
+++ b/apps/backend/src/api/partners/helpers.ts
@@ -196,6 +196,45 @@ export const validatePartnerEntityOwnership = async (
 }
 
 /**
+ * Pure ownership predicate (#778 C1): does this inventory order's linked partner
+ * match the acting partner? Exported for unit testing.
+ */
+export const inventoryOrderOwnedByPartner = (
+    orderPartner: { id?: string | null } | null | undefined,
+    partnerId: string | null | undefined,
+): boolean => Boolean(orderPartner?.id && partnerId && orderPartner.id === partnerId)
+
+/**
+ * Assert the acting partner owns the inventory order, else throw NOT_FOUND.
+ *
+ * Closes the IDOR on the partner mutation routes (start / complete /
+ * submit-payment, #778 C1): they previously fetched the order by bare id and
+ * never checked it belonged to the caller, so any authenticated partner could
+ * mutate any order. Mirrors the GET-detail ownership rule (`inventory_orders.partner`),
+ * but throws NOT_FOUND rather than NOT_ALLOWED so we don't leak the existence of
+ * other partners' orders.
+ */
+export const assertPartnerOwnsInventoryOrder = async (
+    container: MedusaContainer,
+    orderId: string,
+    partnerId: string,
+): Promise<void> => {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY)
+    const { data } = await query.graph({
+        entity: "inventory_orders",
+        fields: ["id", "partner.id"],
+        filters: { id: orderId },
+    })
+    const order = data?.[0] as any
+    if (!order || !inventoryOrderOwnedByPartner(order.partner, partnerId)) {
+        throw new MedusaError(
+            MedusaError.Types.NOT_FOUND,
+            `Inventory order ${orderId} not found`,
+        )
+    }
+}
+
+/**
  * Validates that an order belongs to the partner — by the SAME two scoping rules
  * the partner orders LIST uses (`list-partner-orders` workflow), so the detail +
  * its 27 sibling action routes accept exactly the orders the list shows:

--- a/apps/backend/src/api/partners/inventory-orders/[orderId]/complete/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/[orderId]/complete/route.ts
@@ -107,7 +107,7 @@
  */
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework";
 import { z } from "@medusajs/framework/zod";
-import { getPartnerFromAuthContext } from "../../../helpers";
+import { getPartnerFromAuthContext, assertPartnerOwnsInventoryOrder } from "../../../helpers";
 import { partnerCompleteInventoryOrderWorkflow } from "../../../../../workflows/inventory_orders/partner-complete-inventory-order";
 
 // Accept both snake_case and camelCase for backward compatibility, then normalize
@@ -158,6 +158,9 @@ export async function POST(
                 error: "Partner authentication required"
             });
         }
+        // #778 C1 — ownership guard: this order must belong to the acting partner.
+        // Throws NOT_FOUND (→404) otherwise; closes the IDOR.
+        await assertPartnerOwnsInventoryOrder(req.scope, orderId, partner.id);
         // Delegate to workflow which validates, updates, completes tasks, and signals conditionally
         const { result, errors } = await partnerCompleteInventoryOrderWorkflow(req.scope).run({
             input: {

--- a/apps/backend/src/api/partners/inventory-orders/[orderId]/start/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/[orderId]/start/route.ts
@@ -79,7 +79,7 @@ import { updateInventoryOrderWorkflow } from "../../../../../workflows/inventory
 import { ORDER_INVENTORY_MODULE } from "../../../../../modules/inventory_orders";
 import InventoryOrderService from "../../../../../modules/inventory_orders/service";
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
-import { getPartnerFromAuthContext } from "../../../helpers";
+import { getPartnerFromAuthContext, assertPartnerOwnsInventoryOrder } from "../../../helpers";
 import { TASKS_MODULE } from "../../../../../modules/tasks";
 import TaskService from "../../../../../modules/tasks/service";
 
@@ -102,6 +102,9 @@ export async function POST(
             error: "Partner authentication required"
         });
     }
+    // #778 C1 — ownership guard: this order must belong to the acting partner.
+    // Throws NOT_FOUND (→404) otherwise; closes the IDOR.
+    await assertPartnerOwnsInventoryOrder(req.scope, orderId, partner.id);
     const inventoryOrderService: InventoryOrderService = req.scope.resolve(ORDER_INVENTORY_MODULE);
     
     // Get the order to validate it exists and get transaction ID

--- a/apps/backend/src/api/partners/inventory-orders/[orderId]/submit-payment/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/[orderId]/submit-payment/route.ts
@@ -1,6 +1,6 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework";
 import { z } from "@medusajs/framework/zod";
-import { getPartnerFromAuthContext } from "../../../helpers";
+import { getPartnerFromAuthContext, assertPartnerOwnsInventoryOrder } from "../../../helpers";
 import { createPaymentAndLinkWorkflow } from "../../../../../workflows/internal_payments/create-payment-and-link";
 
 const attachmentSchema = z.object({
@@ -48,6 +48,9 @@ export async function POST(
             error: "Partner authentication required"
         });
     }
+    // #778 C1 — ownership guard: this order must belong to the acting partner.
+    // Throws NOT_FOUND (→404) otherwise; closes the IDOR.
+    await assertPartnerOwnsInventoryOrder(req.scope, orderId, partner.id);
 
     const { amount, payment_type, payment_date, note, paid_to_id, attachments } = validation.data;
 


### PR DESCRIPTION
**Security fix — closes the IDOR (issue #778, finding C1).**

The partner mutation routes authenticated the partner and then fetched the order by bare id, **never** checking it belonged to that partner. Any authenticated partner could `start`, `complete` (deliver + post stock), or `submit-payment` against **any** inventory order:
- `start/route.ts` (only checked `status !== 'Pending'`)
- `complete/route.ts` → `partner-complete-inventory-order` workflow
- `submit-payment/route.ts`

GET list/detail already scope to the partner; only the mutations were exposed.

### Fix
- `assertPartnerOwnsInventoryOrder(container, orderId, partnerId)` in `partners/helpers.ts` — verifies `inventory_orders.partner` (the same link the GET-detail ownership rule uses) and throws **NOT_FOUND** (→404). Uses NOT_FOUND rather than NOT_ALLOWED so it doesn't leak that another partner's order exists.
- Pure `inventoryOrderOwnedByPartner` predicate (**4 unit tests**).
- Applied in all three routes immediately after the acting partner is resolved, before any mutation.

Mirrors how `production-runs/[id]/{start,complete,accept,decline}` already validate `partner_id`.

`tsc --noEmit`: no new errors. Unit test green.

### Notes
- Defense-in-depth follow-up (threading `partner_id` into the completion workflow itself) can come later; the route-level guard fully closes the API hole.
- Minor same-file overlap with #777 in `complete/route.ts` (different regions) — trivial merge.

First fix from the #778 audit (CRITICAL group). Next: C2/C4 (admin Delivered/Cancel stock gaps + cancel workflow), C3 (transactional create + index-zip linking bug), C5 (wrong link key).

Refs #778 (C1) · #773

🤖 Generated with [Claude Code](https://claude.com/claude-code)
