### PR TITLE
fix(781): atomic inventory-order create + fix line↔item mis-link (C5, C3)

### DIFF
--- a/apps/backend/src/modules/inventory_orders/__tests__/create-helpers.unit.spec.ts
+++ b/apps/backend/src/modules/inventory_orders/__tests__/create-helpers.unit.spec.ts
@@ -1,0 +1,57 @@
+import {
+  buildOrderLinePayloads,
+  buildInventoryLineLinkPairs,
+} from "../lib/create-helpers"
+
+describe("buildOrderLinePayloads (#778 C3)", () => {
+  it("maps each input line to a persistence payload bound to the order id", () => {
+    const payloads = buildOrderLinePayloads(
+      [
+        { inventory_id: "iitem_1", quantity: 10, price: 50, metadata: { sku: "A" } },
+        { inventory_id: "iitem_2", quantity: 4, price: 100 },
+      ],
+      "invord_1"
+    )
+    expect(payloads).toEqual([
+      { quantity: 10, price: 50, metadata: { sku: "A" }, inventory_orders: "invord_1" },
+      { quantity: 4, price: 100, metadata: null, inventory_orders: "invord_1" },
+    ])
+  })
+
+  it("does NOT carry inventory_id onto the payload (no such column on the line)", () => {
+    const [payload] = buildOrderLinePayloads(
+      [{ inventory_id: "iitem_1", quantity: 1, price: 1 }],
+      "invord_1"
+    )
+    expect(payload).not.toHaveProperty("inventory_id")
+  })
+})
+
+describe("buildInventoryLineLinkPairs (#778 C3)", () => {
+  const order_lines = [
+    { inventory_id: "iitem_1", quantity: 10, price: 50 },
+    { inventory_id: "iitem_2", quantity: 4, price: 100 },
+    { inventory_id: "iitem_3", quantity: 2, price: 25 },
+  ]
+
+  it("pairs each created line to the inventory item at the same position", () => {
+    const created = [{ id: "ol_1" }, { id: "ol_2" }, { id: "ol_3" }]
+    expect(buildInventoryLineLinkPairs(created, order_lines)).toEqual([
+      { order_line_id: "ol_1", inventory_item_id: "iitem_1" },
+      { order_line_id: "ol_2", inventory_item_id: "iitem_2" },
+      { order_line_id: "ol_3", inventory_item_id: "iitem_3" },
+    ])
+  })
+
+  it("throws on a length mismatch instead of silently mis-pairing (the old index-zip bug)", () => {
+    // A short created-lines array (what partial success used to produce) must
+    // NOT quietly shift item 2 onto line 3 — it must fail loudly.
+    expect(() =>
+      buildInventoryLineLinkPairs([{ id: "ol_1" }, { id: "ol_3" }], order_lines)
+    ).toThrow(/line count mismatch/i)
+  })
+
+  it("handles the empty case as an empty pairing", () => {
+    expect(buildInventoryLineLinkPairs([], [])).toEqual([])
+  })
+})

--- a/apps/backend/src/modules/inventory_orders/lib/create-helpers.ts
+++ b/apps/backend/src/modules/inventory_orders/lib/create-helpers.ts
@@ -1,0 +1,71 @@
+import { MedusaError } from "@medusajs/framework/utils"
+
+/**
+ * Pure helpers for creating an inventory order together with its lines (#778 C3).
+ *
+ * Kept free of any container / service dependency so they're unit-testable, and
+ * shared between the module service (`createInvWithLines`) and the create
+ * workflow's linking step.
+ */
+
+export type CreateOrderLineInput = {
+  inventory_id: string
+  quantity: number
+  price: number
+  metadata?: Record<string, unknown>
+}
+
+export type OrderLinePayload = {
+  quantity: number
+  price: number
+  metadata: Record<string, unknown> | null
+  inventory_orders: string
+}
+
+/** The line ↔ inventory-item pairing used to create the module links. */
+export type LineItemPair = {
+  order_line_id: string
+  inventory_item_id: string
+}
+
+/** Build the persistence payloads for the order lines of one inventory order. */
+export const buildOrderLinePayloads = (
+  order_lines: CreateOrderLineInput[],
+  orderId: string
+): OrderLinePayload[] =>
+  order_lines.map((line) => ({
+    quantity: line.quantity,
+    price: line.price,
+    metadata: line.metadata ?? null,
+    inventory_orders: orderId,
+  }))
+
+/**
+ * Pair each created order line to the inventory item it was created from, by
+ * position. Safe only because the order and its lines are now created
+ * atomically in one transaction (#778 C3) — the created lines come back 1:1 and
+ * in input order, so position `i` always corresponds to `order_lines[i]`.
+ *
+ * The OrderLine model has no column for the inventory item id (the relationship
+ * lives entirely in the module link), so the pairing is computed here, at
+ * creation time, while the correspondence is still known — rather than being
+ * re-derived downstream by zipping two independently-built arrays by index
+ * (the original bug: a dropped line shifted every later pairing onto the wrong
+ * item). Guards the length invariant and throws rather than silently
+ * mis-pairing if the counts ever diverge.
+ */
+export const buildInventoryLineLinkPairs = (
+  createdLines: { id: string }[],
+  order_lines: CreateOrderLineInput[]
+): LineItemPair[] => {
+  if (createdLines.length !== order_lines.length) {
+    throw new MedusaError(
+      MedusaError.Types.UNEXPECTED_STATE,
+      `Inventory order line count mismatch: created ${createdLines.length} lines for ${order_lines.length} inputs`
+    )
+  }
+  return createdLines.map((line, i) => ({
+    order_line_id: line.id,
+    inventory_item_id: order_lines[i].inventory_id,
+  }))
+}

--- a/apps/backend/src/modules/inventory_orders/service.ts
+++ b/apps/backend/src/modules/inventory_orders/service.ts
@@ -1,9 +1,18 @@
-import { MedusaService } from "@medusajs/framework/utils";
+import {
+  MedusaService,
+  MedusaError,
+  InjectTransactionManager,
+  MedusaContext,
+} from "@medusajs/framework/utils";
 
 import InventoryOrder from "./models/order";
 import OrderLine from "./models/orderline";
 
-import { InferTypeOf } from "@medusajs/framework/types"
+import { InferTypeOf, Context } from "@medusajs/framework/types"
+import {
+  buildOrderLinePayloads,
+  buildInventoryLineLinkPairs,
+} from "./lib/create-helpers";
 export type OrderLinesResponse = InferTypeOf<typeof OrderLine>[]
 
 interface CreateInventoryOrder {
@@ -41,8 +50,29 @@ class InventoryOrderService extends MedusaService({
   }
 
   
-  async createInvWithLines(inventory_order: CreateInventoryOrder, order_lines: CreateOrderLine[]) {
-    // Input validation
+  /**
+   * Create an inventory order together with its lines, atomically (#778 C3).
+   *
+   * `@InjectTransactionManager` wraps the whole method in a single module
+   * transaction; the shared context is threaded into the auto-generated
+   * `createInventoryOrders` / `createOrderLines` calls so they enlist in it.
+   * Either the order and ALL its lines commit, or nothing does — replacing the
+   * previous behaviour that created the order, then created lines in a loop that
+   * swallowed per-line failures and returned a partial `orderLines` (which the
+   * linking step then zipped against the full input by index, mis-linking the
+   * wrong inventory item to the wrong line).
+   *
+   * Returns the line ↔ inventory-item pairing computed at creation time so the
+   * downstream link step pairs explicitly rather than positionally.
+   */
+  @InjectTransactionManager()
+  async createInvWithLines(
+    inventory_order: CreateInventoryOrder,
+    order_lines: CreateOrderLine[],
+    @MedusaContext() sharedContext: Context = {}
+  ) {
+    // Input validation (runs inside the transaction; nothing is created yet, so
+    // a throw here simply aborts before any write).
     if (!Array.isArray(order_lines) || order_lines.length === 0) {
       throw new Error("At least one order line is required.");
     }
@@ -66,43 +96,31 @@ class InventoryOrderService extends MedusaService({
       }
     }
 
-    // Create the InventoryOrder
     let order: InferTypeOf<typeof InventoryOrder>;
+    let orderLines: OrderLinesResponse;
     try {
-      order = await this.createInventoryOrders({ ...inventory_order });
-    } catch (err) {
-      throw new Error(`Failed to create inventory order: ${err.message}`);
+      // Both writes share `sharedContext` → same transaction. A failure on the
+      // lines rolls the order back too (rethrow below keeps us inside the
+      // transaction's failure path).
+      order = (await this.createInventoryOrders(
+        { ...inventory_order },
+        sharedContext
+      )) as InferTypeOf<typeof InventoryOrder>;
+
+      orderLines = (await this.createOrderLines(
+        buildOrderLinePayloads(order_lines, order.id),
+        sharedContext
+      )) as OrderLinesResponse;
+    } catch (err: any) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Failed to create inventory order with lines: ${err?.message || String(err)}`
+      );
     }
 
-    // Create OrderLines, collecting errors
-    const orderLines: OrderLinesResponse = [];
-    const errors: { index: number; inventory_id: string; error: string }[] = [];
-    for (const [i, order_line] of order_lines.entries()) {
-      try {
-        const createdLine = await this.createOrderLines({
-          ...order_line,
-          inventory_orders: order.id
-        });
-        orderLines.push(createdLine);
-      } catch (lineErr) {
-        errors.push({
-          index: i,
-          inventory_id: order_line.inventory_id,
-          error: lineErr.message || String(lineErr)
-        });
-      }
-    }
+    const lineItemPairs = buildInventoryLineLinkPairs(orderLines, order_lines);
 
-    if (errors.length > 0) {
-      return {
-        order,
-        orderLines,
-        errors,
-        message: `Some order lines failed to be created. See 'errors' for details.`
-      };
-    }
-
-    return { order, orderLines };
+    return { order, orderLines, lineItemPairs };
   }
 } 
 

--- a/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
@@ -102,7 +102,26 @@ export const createInventoryOrderWithLinesStep = createStep(
     }
 
     const created = await inventoryOrderService.createInvWithLines(processedOrderData, orderLinesForService);
-    return new StepResponse(created);
+    // Compensation data so the SAGA can roll the order + lines back if a later
+    // (cross-module) step fails — the module-link writes are NOT part of the
+    // create transaction, so this is how we stay consistent across that boundary
+    // (#778 C3).
+    return new StepResponse(created, {
+      orderId: created?.order?.id,
+      lineIds: (created?.orderLines ?? []).map((l: any) => l.id),
+    });
+  },
+  async (compensationData, { container }) => {
+    if (!compensationData?.orderId) return;
+    const service = container.resolve(ORDER_INVENTORY_MODULE) as InventoryOrderService;
+    try {
+      if (compensationData.lineIds?.length) {
+        await (service as any).deleteOrderLines(compensationData.lineIds);
+      }
+      await service.deleteInventoryOrders(compensationData.orderId);
+    } catch {
+      /* best-effort rollback */
+    }
   }
 );
 
@@ -111,25 +130,35 @@ export const createInventoryOrderWithLinesStep = createStep(
 export const linkInventoryItemsWithLinesStep = createStep(
   "link-inventory-items-with-lines-step",
   async (
-    input: { order_id: string; orderline_ids: string[]; inventory_item_ids: string[] },
+    input: { order_id: string; line_pairs: { order_line_id: string; inventory_item_id: string }[] },
     { container }
   ) => {
     const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link;
-    const links: LinkDefinition[] = input.orderline_ids.map((orderlineId, idx) => ({
+    // Link each line to its inventory item by the explicit pairing computed at
+    // creation time (#778 C3) — never by re-zipping two arrays by index.
+    const links: LinkDefinition[] = (input.line_pairs ?? []).map(({ order_line_id, inventory_item_id }) => ({
       [ORDER_INVENTORY_MODULE]: {
-        inventory_order_line_id: orderlineId,
+        inventory_order_line_id: order_line_id,
       },
       [Modules.INVENTORY]: {
-        inventory_item_id: input.inventory_item_ids[idx],
+        inventory_item_id,
       },
       data: {
-        //order_id: input.order_id,
-        order_line_id: orderlineId,
-        inventory_item_id: input.inventory_item_ids[idx],
+        order_line_id,
+        inventory_item_id,
       },
     }));
     await remoteLink.create(links);
-    return new StepResponse(links);
+    return new StepResponse(links, links);
+  },
+  async (links, { container }) => {
+    if (!links?.length) return;
+    const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link;
+    try {
+      await remoteLink.dismiss(links as any);
+    } catch {
+      /* best-effort link cleanup */
+    }
   }
 );
 
@@ -216,8 +245,9 @@ export const createInventoryOrderWorkflow = createWorkflow(
         }
         return {
           order_id: created.order.id,
-          orderline_ids: created.orderLines.map((ol: any) => ol.id),
-          inventory_item_ids: input.order_lines.map((ol: any) => ol.inventory_item_id),
+          // Explicit line→item pairing from the create step (#778 C3) — not a
+          // positional zip of separately-derived id arrays.
+          line_pairs: created.lineItemPairs ?? [],
           order: created.order,
           orderLines: created.orderLines,
         }

--- a/apps/backend/src/workflows/inventory_orders/create-line-fulfillment.ts
+++ b/apps/backend/src/workflows/inventory_orders/create-line-fulfillment.ts
@@ -74,7 +74,7 @@ export const linkFulfillmentToOrderStep = createStep(
 
     const links: LinkDefinition[] = [
       {
-        [ORDER_INVENTORY_MODULE]: { inventory_order_lines_id: input.orderLineId },
+        [ORDER_INVENTORY_MODULE]: { inventory_order_line_id: input.orderLineId },
         [FULLFILLED_ORDERS_MODULE]: { line_fulfillment_id: input.entryId },
       },
       {


### PR DESCRIPTION
First slice of **#781** (group 2 of the #778 inventory-orders audit — data integrity).

## C5 — wrong link key (trivial)
`create-line-fulfillment.ts:77` linked the fulfillment to its order line via `inventory_order_lines_id` (plural) — a key that doesn't exist on the pivot. Corrected to the singular `inventory_order_line_id` used by every other file and matching the migration-snapshot column.

## C3 — non-transactional create + index-zip mis-link
`createInvWithLines` created the order, then created lines in a loop that **swallowed per-line failures** and returned a partial `orderLines`. The create workflow then zipped `orderLines.map(id)` against `input.order_lines.map(inventory_item_id)` **by index** → a single dropped line shifted every later pairing onto the **wrong inventory item**.

**Fix (true transaction, per design discussion):**
- Order + all lines created **atomically** in one module transaction (`@InjectTransactionManager` + threaded `@MedusaContext`) — all commit or none do. No more partial success.
- The service computes the line↔item pairing **at creation time** and returns it; the link step pairs **explicitly** (never by index) and **throws on a length mismatch** rather than silently mis-pairing.
- Module-link writes are cross-module (not in the create transaction), so the create step gains a **SAGA compensation** that rolls back the order + lines if the link step fails, and the link step **dismisses** its links on failure — closing the orphan gap across that boundary.

## Tests
- Pure helpers in `lib/create-helpers.ts`; **5 new unit tests** (payload mapping, explicit pairing, mismatch-throws, empty case).
- Existing inventory_orders unit suites green (**15 total**). `tsc`: no new errors.

Parent: #778 · Issue: #781 · Remaining in #781: C2+C4 (cancel workflow + stock reversal), H11 (delete safety), MEDIUMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)