### PR TITLE
feat(781): cancel inventory order with stock reversal + cleanup (C2, C4)

### DIFF
--- a/apps/backend/src/api/admin/inventory-orders/[id]/cancel/route.ts
+++ b/apps/backend/src/api/admin/inventory-orders/[id]/cancel/route.ts
@@ -1,0 +1,57 @@
+/**
+ * @route POST /admin/inventory-orders/:id/cancel
+ * @scope admin
+ *
+ * Cancel an inventory order (#778 C2/C4). Reverses any stock that prior
+ * (partial or full) deliveries posted, cancels still-open tasks, flips the
+ * status to "Cancelled" while stamping the cancellation audit columns, and
+ * mirrors the cancel onto the unified core order. Idempotent guard: cancelling
+ * an already-Cancelled order returns 409.
+ *
+ * Body: { reason?: string }
+ * Success: 200 -> { success, orderId, reversedLevels }
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import { MedusaError } from "@medusajs/framework/utils";
+import { z } from "@medusajs/framework/zod";
+import { cancelInventoryOrderWorkflow } from "../../../../../workflows/inventory_orders/cancel-inventory-order";
+
+const cancelBodySchema = z.object({
+  reason: z.string().trim().max(1000).optional(),
+});
+
+export const POST = async (req: AuthenticatedMedusaRequest, res: MedusaResponse) => {
+  const id = req.params.id;
+  const parsed = cancelBodySchema.safeParse(req.body ?? {});
+  if (!parsed.success) {
+    return res.status(400).json({ errors: parsed.error.issues });
+  }
+
+  const cancelledBy = req.auth_context?.actor_id || "admin";
+
+  const { result, errors } = await cancelInventoryOrderWorkflow(req.scope).run({
+    input: {
+      orderId: id,
+      reason: parsed.data.reason ?? null,
+      cancelledBy,
+    },
+    throwOnError: false,
+  });
+
+  if (errors && errors.length > 0) {
+    const err = errors[0]?.error as any;
+    // Surface the cancel-guard (already-Cancelled / not-found) as a proper status.
+    if (err instanceof MedusaError || err?.type) {
+      const type = err.type || err?.constructor?.name;
+      if (type === MedusaError.Types.NOT_FOUND) {
+        return res.status(404).json({ message: err.message });
+      }
+      if (type === MedusaError.Types.NOT_ALLOWED) {
+        return res.status(409).json({ message: err.message });
+      }
+    }
+    return res.status(400).json({ errors });
+  }
+
+  return res.status(200).json(result);
+};

--- a/apps/backend/src/modules/inventory_orders/migrations/Migration20260629120000.ts
+++ b/apps/backend/src/modules/inventory_orders/migrations/Migration20260629120000.ts
@@ -1,0 +1,25 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * #778 C4 — cancellation audit columns on inventory_orders.
+ *
+ * Hand-written and idempotent (`add column if not exists`) so it applies
+ * cleanly on existing databases regardless of MikroORM's create-table
+ * snapshot, per the project's migration hazard (a column added by editing a
+ * `create table` migration never lands on already-migrated DBs).
+ */
+export class Migration20260629120000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "inventory_orders" add column if not exists "cancelled_at" timestamptz null;`);
+    this.addSql(`alter table if exists "inventory_orders" add column if not exists "cancellation_reason" text null;`);
+    this.addSql(`alter table if exists "inventory_orders" add column if not exists "cancelled_by" text null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "inventory_orders" drop column if exists "cancelled_at";`);
+    this.addSql(`alter table if exists "inventory_orders" drop column if exists "cancellation_reason";`);
+    this.addSql(`alter table if exists "inventory_orders" drop column if exists "cancelled_by";`);
+  }
+
+}

--- a/apps/backend/src/modules/inventory_orders/models/order.ts
+++ b/apps/backend/src/modules/inventory_orders/models/order.ts
@@ -19,6 +19,11 @@ const InventoryOrder = model.define("inventory_orders", {
   metadata: model.json().nullable(),
   shipping_address: model.json().nullable(),
   is_sample: model.boolean().default(false),
+  // Cancellation audit (#778 C4). Typed columns rather than metadata, because
+  // these are load-bearing state that must survive later metadata replacements.
+  cancelled_at: model.dateTime().nullable(),
+  cancellation_reason: model.text().nullable(),
+  cancelled_by: model.text().nullable(),
 }).cascades({
   delete: ['orderlines']
 });

--- a/apps/backend/src/workflows/inventory_orders/__tests__/cancel-helpers.unit.spec.ts
+++ b/apps/backend/src/workflows/inventory_orders/__tests__/cancel-helpers.unit.spec.ts
@@ -1,0 +1,132 @@
+import {
+  assertCancellable,
+  aggregateDeliveredByLine,
+  buildReversalLevels,
+  computeStockReversalUpdates,
+  selectOpenTaskIds,
+} from "../lib/cancel-helpers"
+
+describe("assertCancellable (#778 C4)", () => {
+  it("allows cancelling from any non-terminal status", () => {
+    for (const s of ["Pending", "Processing", "Shipped", "Partial", "Delivered"]) {
+      expect(() => assertCancellable(s)).not.toThrow()
+    }
+  })
+
+  it("rejects re-cancelling an already-Cancelled order", () => {
+    expect(() => assertCancellable("Cancelled")).toThrow(/cannot be cancelled/i)
+  })
+
+  it("rejects a missing/unknown status", () => {
+    expect(() => assertCancellable(null)).toThrow(/cannot be cancelled/i)
+    expect(() => assertCancellable(undefined)).toThrow(/cannot be cancelled/i)
+  })
+})
+
+describe("aggregateDeliveredByLine (#778 C2)", () => {
+  it("sums quantities per line and drops non-positive / malformed entries", () => {
+    expect(
+      aggregateDeliveredByLine([
+        { order_line_id: "ol_1", quantity: 3 },
+        { order_line_id: "ol_1", quantity: 2 },
+        { order_line_id: "ol_2", quantity: 4 },
+        { order_line_id: "ol_3", quantity: 0 },
+        { order_line_id: "", quantity: 5 } as any,
+      ])
+    ).toEqual({ ol_1: 5, ol_2: 4 })
+  })
+
+  it("handles empty / nullish input", () => {
+    expect(aggregateDeliveredByLine([])).toEqual({})
+    expect(aggregateDeliveredByLine(null)).toEqual({})
+  })
+})
+
+describe("buildReversalLevels (#778 C2)", () => {
+  const orderlines = [
+    { id: "ol_1", inventory_items: [{ id: "iitem_1", stock_locations: [{ id: "sloc_item" }] }] },
+    { id: "ol_2", inventory_items: [{ id: "iitem_2", stock_locations: [] }] },
+  ]
+
+  it("maps delivered lines to (item, dest-location, qty) at the order destination", () => {
+    const levels = buildReversalLevels(
+      orderlines,
+      [{ order_line_id: "ol_1", quantity: 6 }, { order_line_id: "ol_2", quantity: 4 }],
+      "sloc_dest"
+    )
+    expect(levels).toEqual([
+      { location_id: "sloc_dest", inventory_item_id: "iitem_1", quantity: 6 },
+      { location_id: "sloc_dest", inventory_item_id: "iitem_2", quantity: 4 },
+    ])
+  })
+
+  it("falls back to the item's own first location when no destination is given", () => {
+    const levels = buildReversalLevels(orderlines, [{ order_line_id: "ol_1", quantity: 6 }], null)
+    expect(levels).toEqual([
+      { location_id: "sloc_item", inventory_item_id: "iitem_1", quantity: 6 },
+    ])
+  })
+
+  it("skips lines with no delivered qty, no item, or no resolvable location", () => {
+    // ol_2 has no item location and no destination → skipped; undelivered → skipped
+    expect(buildReversalLevels(orderlines, [{ order_line_id: "ol_2", quantity: 4 }], null)).toEqual([])
+    expect(buildReversalLevels(orderlines, [], "sloc_dest")).toEqual([])
+  })
+})
+
+describe("computeStockReversalUpdates (#778 C2)", () => {
+  it("subtracts reversal qty from the matching existing level", () => {
+    const updates = computeStockReversalUpdates(
+      [{ location_id: "L", inventory_item_id: "I", quantity: 4 }],
+      [{ id: "lvl_1", location_id: "L", inventory_item_id: "I", stocked_quantity: 10 }]
+    )
+    expect(updates).toEqual([
+      { id: "lvl_1", inventory_item_id: "I", location_id: "L", stocked_quantity: 6 },
+    ])
+  })
+
+  it("floors at 0 — never drives stock negative", () => {
+    const updates = computeStockReversalUpdates(
+      [{ location_id: "L", inventory_item_id: "I", quantity: 99 }],
+      [{ id: "lvl_1", location_id: "L", inventory_item_id: "I", stocked_quantity: 10 }]
+    )
+    expect(updates[0].stocked_quantity).toBe(0)
+  })
+
+  it("sums duplicate (item,location) reversals before subtracting", () => {
+    const updates = computeStockReversalUpdates(
+      [
+        { location_id: "L", inventory_item_id: "I", quantity: 3 },
+        { location_id: "L", inventory_item_id: "I", quantity: 2 },
+      ],
+      [{ id: "lvl_1", location_id: "L", inventory_item_id: "I", stocked_quantity: 10 }]
+    )
+    expect(updates[0].stocked_quantity).toBe(5)
+  })
+
+  it("skips reversals with no matching existing level (nothing posted to take back)", () => {
+    expect(
+      computeStockReversalUpdates(
+        [{ location_id: "L", inventory_item_id: "I", quantity: 4 }],
+        [{ id: "lvl_2", location_id: "OTHER", inventory_item_id: "I", stocked_quantity: 10 }]
+      )
+    ).toEqual([])
+  })
+})
+
+describe("selectOpenTaskIds (#778 C4)", () => {
+  it("selects only still-open tasks, leaving terminal ones alone", () => {
+    expect(
+      selectOpenTaskIds([
+        { id: "t1", status: "pending" },
+        { id: "t2", status: "in_progress" },
+        { id: "t3", status: "assigned" },
+        { id: "t4", status: "accepted" },
+        { id: "t5", status: "completed" },
+        { id: "t6", status: "cancelled" },
+        { id: undefined, status: "pending" },
+        null,
+      ] as any)
+    ).toEqual(["t1", "t2", "t3", "t4"])
+  })
+})

--- a/apps/backend/src/workflows/inventory_orders/cancel-inventory-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/cancel-inventory-order.ts
@@ -1,0 +1,183 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+  transform,
+  when,
+} from "@medusajs/framework/workflows-sdk"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import type { RemoteQueryFunction, UpdateInventoryLevelInput } from "@medusajs/types"
+import { updateInventoryLevelsWorkflow } from "@medusajs/medusa/core-flows"
+import { ORDER_INVENTORY_MODULE } from "../../modules/inventory_orders"
+import { TASKS_MODULE } from "../../modules/tasks"
+import inventoryOrdersTasks from "../../links/inventory-orders-tasks"
+import { resolveExistingLevelsStep } from "./partner-complete-inventory-order"
+import { updateInventoryOrderWorkflow } from "./update-inventory-order"
+import {
+  assertCancellable,
+  buildReversalLevels,
+  computeStockReversalUpdates,
+  selectOpenTaskIds,
+  type DeliveredLine,
+} from "./lib/cancel-helpers"
+
+export type CancelInventoryOrderInput = {
+  orderId: string
+  /** Free-text reason, persisted to the typed `cancellation_reason` column. */
+  reason?: string | null
+  /** Actor id (admin user / partner) persisted to `cancelled_by`. */
+  cancelledBy?: string | null
+  /** Optional explicit reversal location; otherwise resolved off the order. */
+  stockLocationId?: string | null
+}
+
+/**
+ * Load the order for cancellation: guard existence (a real array check — not the
+ * broken truthy-array check the delete path had, #778 H11) and the cancel
+ * transition, and surface the delivered lines + destination location needed to
+ * reverse posted stock.
+ */
+export const loadOrderForCancelStep = createStep(
+  "load-inventory-order-for-cancel",
+  async (input: CancelInventoryOrderInput, { container }) => {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY) as Omit<RemoteQueryFunction, symbol>
+    const { data } = await query.graph({
+      entity: "inventory_orders",
+      filters: { id: input.orderId },
+      fields: [
+        "id",
+        "status",
+        "metadata",
+        "orderlines.id",
+        "orderlines.inventory_items.id",
+        "orderlines.inventory_items.stock_locations.id",
+        "stock_locations.id",
+      ],
+    })
+
+    const order = data?.[0] as any
+    if (!order) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Inventory order ${input.orderId} not found`
+      )
+    }
+    assertCancellable(order.status)
+
+    const deliveredLines = (order.metadata?.partner_delivered_lines || []) as DeliveredLine[]
+    const destLocationId =
+      input.stockLocationId ||
+      order.to_stock_location_id ||
+      order.stock_location_id ||
+      order.destination_stock_location_id ||
+      order.stock_locations?.[0]?.id ||
+      null
+
+    return new StepResponse({
+      order,
+      orderlines: order.orderlines || [],
+      deliveredLines,
+      destLocationId,
+    })
+  }
+)
+
+/**
+ * Cancel every still-open task linked to the order (leaves completed/cancelled
+ * tasks untouched). Best-effort: a task-cleanup failure must not block the
+ * cancellation itself.
+ */
+export const cancelOpenInventoryOrderTasksStep = createStep(
+  "cancel-open-inventory-order-tasks",
+  async (input: { orderId: string }, { container }) => {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY) as Omit<RemoteQueryFunction, symbol>
+    const taskService: any = container.resolve(TASKS_MODULE)
+
+    let openTaskIds: string[] = []
+    try {
+      const { data } = await query.graph({
+        entity: inventoryOrdersTasks.entryPoint,
+        filters: { inventory_orders_id: input.orderId },
+        fields: ["task.id", "task.status"],
+      })
+      const tasks = (data || []).map((row: any) => row.task)
+      openTaskIds = selectOpenTaskIds(tasks)
+      if (openTaskIds.length > 0) {
+        await taskService.updateTasks(
+          openTaskIds.map((id) => ({ id, status: "cancelled" }))
+        )
+      }
+    } catch {
+      /* best-effort — never block the cancellation on task cleanup */
+    }
+
+    return new StepResponse({ cancelledTaskIds: openTaskIds })
+  }
+)
+
+/**
+ * Cancel an inventory order (#778 C2/C4): reverse any stock prior deliveries
+ * posted, cancel open tasks, flip the status to Cancelled (stamping the
+ * cancellation audit columns), and — via the reused update workflow — emit the
+ * status-changed event and mirror the cancel onto the unified core order.
+ */
+export const cancelInventoryOrderWorkflow = createWorkflow(
+  {
+    name: "cancel-inventory-order",
+    store: true,
+  },
+  (input: CancelInventoryOrderInput) => {
+    const loaded = loadOrderForCancelStep(input)
+
+    // Resolve which (item, location, qty) levels need reversing, then look up
+    // the existing levels so we know their ids + current quantities.
+    const reversalLevels = transform({ loaded }, ({ loaded }) =>
+      buildReversalLevels(loaded.orderlines, loaded.deliveredLines, loaded.destLocationId)
+    )
+    const levelsForLookup = transform({ reversalLevels }, ({ reversalLevels }) =>
+      (reversalLevels as any[]).map((r) => ({
+        location_id: r.location_id,
+        inventory_item_id: r.inventory_item_id,
+        stocked_quantity: r.quantity,
+      }))
+    )
+    const resolved = resolveExistingLevelsStep({ levels: levelsForLookup as any }) as any
+    const existing = transform({ resolved }, ({ resolved }) => resolved?.existing || [])
+
+    const updates = transform(
+      { reversalLevels, existing },
+      ({ reversalLevels, existing }) =>
+        computeStockReversalUpdates(reversalLevels as any[], existing as any[])
+    )
+    const hasUpdates = transform({ updates }, ({ updates }) => Array.isArray(updates) && (updates as any[]).length > 0)
+
+    when(hasUpdates, (b) => Boolean(b)).then(() => {
+      updateInventoryLevelsWorkflow.runAsStep({
+        input: { updates: updates as unknown as UpdateInventoryLevelInput[] },
+      })
+    })
+
+    cancelOpenInventoryOrderTasksStep({ orderId: input.orderId })
+
+    // Flip status + stamp audit columns, reusing the update workflow so the
+    // status-changed event (#771) and unified-order mirror (Cancelled→canceled)
+    // fire for free.
+    const updateInput = transform({ input }, ({ input }) => ({
+      id: input.orderId,
+      update: {
+        status: "Cancelled" as const,
+        cancelled_at: new Date(),
+        cancellation_reason: input.reason ?? null,
+        cancelled_by: input.cancelledBy ?? null,
+      },
+    }))
+    updateInventoryOrderWorkflow.runAsStep({ input: updateInput })
+
+    return new WorkflowResponse(transform({ loaded, updates }, ({ loaded, updates }) => ({
+      success: true,
+      orderId: loaded.order.id,
+      reversedLevels: (updates as any[]).length,
+    })))
+  }
+)

--- a/apps/backend/src/workflows/inventory_orders/lib/cancel-helpers.ts
+++ b/apps/backend/src/workflows/inventory_orders/lib/cancel-helpers.ts
@@ -1,0 +1,141 @@
+import { MedusaError } from "@medusajs/framework/utils"
+
+/**
+ * Pure helpers for cancelling an inventory order and reversing any stock that
+ * prior (partial or full) deliveries posted (#778 C2/C4). Kept free of the
+ * container so the stock-reversal arithmetic — the risky part — is unit
+ * testable in isolation.
+ */
+
+export type DeliveredLine = { order_line_id: string; quantity: number }
+
+export type OrderLineForReversal = {
+  id: string
+  inventory_items?: Array<{ id?: string; stock_locations?: Array<{ id?: string }> }>
+  inventory_item_id?: string
+}
+
+export type ReversalLevel = {
+  location_id: string
+  inventory_item_id: string
+  quantity: number
+}
+
+export type ExistingLevel = {
+  id: string
+  location_id: string
+  inventory_item_id: string
+  stocked_quantity: number
+}
+
+export type LevelUpdate = {
+  id: string
+  inventory_item_id: string
+  location_id: string
+  stocked_quantity: number
+}
+
+/** Terminal statuses that cannot be cancelled again. */
+const NON_CANCELLABLE = new Set(["Cancelled"])
+
+/**
+ * Guard the cancel transition. An order that's already Cancelled is a no-op
+ * error (NOT_ALLOWED) rather than a silent re-cancel; everything else
+ * (Pending → Partial → Delivered) may be cancelled, reversing whatever stock
+ * it posted.
+ */
+export const assertCancellable = (status: string | null | undefined): void => {
+  if (!status || NON_CANCELLABLE.has(status)) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `Inventory order cannot be cancelled from status "${status ?? "unknown"}"`
+    )
+  }
+}
+
+/** Sum delivered quantities per order line (cumulative across partial deliveries). */
+export const aggregateDeliveredByLine = (
+  deliveredLines: DeliveredLine[] | undefined | null
+): Record<string, number> => {
+  const byLine: Record<string, number> = {}
+  for (const l of deliveredLines || []) {
+    if (l?.order_line_id && typeof l.quantity === "number" && l.quantity > 0) {
+      byLine[l.order_line_id] = (byLine[l.order_line_id] || 0) + l.quantity
+    }
+  }
+  return byLine
+}
+
+/**
+ * Resolve which (item, location, qty) levels a cancel must reverse, mirroring
+ * exactly how `partner-complete` posted them: per delivered order line, the
+ * line's first linked inventory item at the order's destination location (or
+ * the item's own first linked location as a fallback). Lines with no delivered
+ * quantity, no resolvable item, or no resolvable location are skipped.
+ */
+export const buildReversalLevels = (
+  orderlines: OrderLineForReversal[] | undefined | null,
+  deliveredLines: DeliveredLine[] | undefined | null,
+  destLocationId: string | null | undefined
+): ReversalLevel[] => {
+  const deliveredByLine = aggregateDeliveredByLine(deliveredLines)
+  const levels: ReversalLevel[] = []
+  for (const ol of (orderlines || []).filter(Boolean)) {
+    const qty = deliveredByLine[ol.id]
+    if (!qty) continue
+    const firstItem = ol.inventory_items?.[0]
+    const itemId = firstItem?.id || ol.inventory_item_id
+    const locId = destLocationId || firstItem?.stock_locations?.[0]?.id
+    if (itemId && locId) {
+      levels.push({
+        location_id: String(locId),
+        inventory_item_id: String(itemId),
+        quantity: Number(qty),
+      })
+    }
+  }
+  return levels
+}
+
+/**
+ * Compute the inventory-level updates that reverse the posted stock: subtract
+ * the reversal quantity from each matching existing level, floored at 0 (never
+ * drive stock negative). Reversal levels with no matching existing level are
+ * skipped — there's nothing posted to take back. Quantities for the same
+ * (item, location) pair are summed first so duplicate lines reverse correctly.
+ */
+export const computeStockReversalUpdates = (
+  reversalLevels: ReversalLevel[],
+  existingLevels: ExistingLevel[]
+): LevelUpdate[] => {
+  const key = (item: string, loc: string) => `${item}::${loc}`
+  const reverseByKey: Record<string, number> = {}
+  for (const r of reversalLevels) {
+    reverseByKey[key(r.inventory_item_id, r.location_id)] =
+      (reverseByKey[key(r.inventory_item_id, r.location_id)] || 0) + Number(r.quantity || 0)
+  }
+  const updates: LevelUpdate[] = []
+  for (const ex of existingLevels) {
+    const take = reverseByKey[key(ex.inventory_item_id, ex.location_id)]
+    if (!take) continue
+    updates.push({
+      id: String(ex.id),
+      inventory_item_id: String(ex.inventory_item_id),
+      location_id: String(ex.location_id),
+      stocked_quantity: Math.max(0, Number(ex.stocked_quantity || 0) - take),
+    })
+  }
+  return updates
+}
+
+/** Task statuses that are still open and should be cancelled along with the order. */
+const OPEN_TASK_STATUSES = new Set(["pending", "in_progress", "assigned", "accepted"])
+
+/** Pick the ids of still-open tasks to cancel (leaves completed/cancelled alone). */
+export const selectOpenTaskIds = (
+  tasks: Array<{ id?: string; status?: string } | null | undefined> | undefined | null
+): string[] =>
+  (tasks || [])
+    .filter((t): t is { id: string; status?: string } => Boolean(t?.id))
+    .filter((t) => OPEN_TASK_STATUSES.has(String(t.status)))
+    .map((t) => t.id)

--- a/apps/backend/src/workflows/inventory_orders/update-inventory-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/update-inventory-order.ts
@@ -58,6 +58,12 @@ type UpdateInventoryOrderStepInput = {
     order_date?: Date;
     shipping_address?: Record<string, any>;
     is_sample?: boolean;
+    // Cancellation audit columns (#778 C4) — passed straight through to the
+    // service update so the cancel workflow can stamp them while reusing the
+    // status-changed event + unified-order mirror.
+    cancelled_at?: Date | null;
+    cancellation_reason?: string | null;
+    cancelled_by?: string | null;
   };
 };
 


### PR DESCRIPTION
Second slice of **#781** (group 2 of the #778 inventory-orders audit). Covers **C4** (cancel was unreachable — no route/workflow) and the **cancel half of C2** (cancelling never reversed stock from prior partial deliveries → phantom stock).

## New: `cancel-inventory-order` workflow + `POST /admin/inventory-orders/:id/cancel`

- **Stock reversal** — recomputes exactly what `partner-complete` posted (delivered lines → first linked item @ the order's destination location) and subtracts it from the existing inventory levels, **floored at 0** (never negative). Reuses the same `resolveExistingLevelsStep` + `updateInventoryLevelsWorkflow` the posting path uses, so posting and reversal stay symmetric. Reversals with no matching existing level are skipped (nothing posted to take back).
- **Task cleanup** — cancels still-open linked tasks (`pending`/`in_progress`/`assigned`/`accepted`), leaves `completed`/`cancelled` alone. Best-effort (never blocks the cancel).
- **Status + audit** — flips to `Cancelled` and stamps **new typed columns** `cancelled_at` / `cancellation_reason` / `cancelled_by` (idempotent `ADD COLUMN IF NOT EXISTS` migration; typed not metadata, since it's load-bearing state). Reuses `updateInventoryOrderWorkflow` so the #771 **status-changed event** and the **unified-order mirror** (`Cancelled→canceled`) fire for free.
- **Guards** — `NOT_FOUND` via a real `data?.[0]` array check (404) and already-Cancelled via `NOT_ALLOWED` (409). (The delete path #778 H11 still has the broken truthy-array check — fixed in the next slice.)

## Consistency
Stock reversal runs before the status flip; if the flip throws, the SAGA compensation on `updateInventoryLevelsWorkflow` restores the levels.

## Tests
- Pure reversal/guard/task-selection logic in `lib/cancel-helpers.ts`; **13 unit tests** (floor-at-0, dup-summing, no-match skip, cancellable guard, open-task selection, dest-location fallback).
- `medusa build` green; `tsc` no new errors; **27** inventory_orders unit tests pass.

## Scope
The admin-`Delivered`-posts-stock half of C2 + the PUT state-machine enforcement are the MEDIUM items, deferred to after H11 per the issue's suggested order.

Parent: #778 · Issue: #781 · Stacks conceptually after #785 (independent files; both off `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)