### PR TITLE
fix(781): make inventory-order delete safe + clean up all links (H11)

### DIFF
--- a/apps/backend/src/api/admin/inventory-orders/[id]/route.ts
+++ b/apps/backend/src/api/admin/inventory-orders/[id]/route.ts
@@ -78,7 +78,7 @@
  *  - Errors returned from workflows are forwarded as 400 with an `errors` array.
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
-import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils";
 import { UpdateInventoryOrder } from "../validators";
 import { refetchInventoryOrder } from "../helpers";
 import updateInventoryOrderWorkflow from "../../../../workflows/inventory_orders/update-inventory-orders";
@@ -154,8 +154,20 @@ export const GET = async(
       input: {
         id,
       },
+      throwOnError: false,
     });
     if (errors.length > 0) {
+      // #778 H11 — surface the delete guards with proper status codes:
+      // NOT_FOUND → 404 (missing order, now actually detected) and
+      // NOT_ALLOWED → 409 (Shipped/Delivered/Partial — cancel it first).
+      const err = errors[0]?.error as any;
+      const type = err?.type || err?.constructor?.name;
+      if (type === MedusaError.Types.NOT_FOUND) {
+        return res.status(404).json({ message: err.message });
+      }
+      if (type === MedusaError.Types.NOT_ALLOWED) {
+        return res.status(409).json({ message: err.message });
+      }
       return res.status(400).json({ errors });
     }
     res.status(200).json({});

--- a/apps/backend/src/workflows/inventory_orders/__tests__/delete-helpers.unit.spec.ts
+++ b/apps/backend/src/workflows/inventory_orders/__tests__/delete-helpers.unit.spec.ts
@@ -1,0 +1,23 @@
+import { assertDeletable, isDeletableStatus } from "../lib/delete-helpers"
+
+describe("isDeletableStatus / assertDeletable (#778 H11)", () => {
+  it("allows deleting orders with no posted stock / fulfillment", () => {
+    for (const s of ["Pending", "Processing", "Cancelled"]) {
+      expect(isDeletableStatus(s)).toBe(true)
+      expect(() => assertDeletable(s)).not.toThrow()
+    }
+  })
+
+  it("blocks deleting orders that posted stock or have active fulfillments", () => {
+    for (const s of ["Shipped", "Delivered", "Partial"]) {
+      expect(isDeletableStatus(s)).toBe(false)
+      expect(() => assertDeletable(s)).toThrow(/cancel it first/i)
+    }
+  })
+
+  it("treats missing status as deletable (legacy rows)", () => {
+    expect(isDeletableStatus(null)).toBe(true)
+    expect(isDeletableStatus(undefined)).toBe(true)
+    expect(() => assertDeletable(null)).not.toThrow()
+  })
+})

--- a/apps/backend/src/workflows/inventory_orders/delete-inventory-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/delete-inventory-order.ts
@@ -1,4 +1,4 @@
-import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils";
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils";
 import {
   createWorkflow,
   createStep,
@@ -12,6 +12,7 @@ import { ORDER_INVENTORY_MODULE } from "../../modules/inventory_orders";
 import InventoryOrderService from "../../modules/inventory_orders/service";
 import { InferTypeOf } from "@medusajs/framework/types"
 import { default as InventoryOrderModel } from "../../modules/inventory_orders/models/order";
+import { assertDeletable } from "./lib/delete-helpers";
 export type InventoryOrder = InferTypeOf<typeof InventoryOrderModel>;
 
 // --- Interfaces for API Input ---
@@ -33,11 +34,14 @@ export const fetchInventoryOrderStep = createStep(
       filters: {
         id: input.id
       },
-      fields: ["id", "orderlines.*", "orderlines.inventory_items.*", "stock_locations.*"]
+      fields: ["id", "status", "orderlines.*", "orderlines.inventory_items.*", "stock_locations.*"]
     });
 
-    if (!inventoryOrder) {
-      throw new MedusaError(MedusaError.Types.NOT_FOUND, 
+    // #778 H11 — query.graph returns an array (truthy even when empty), so the
+    // old `if (!inventoryOrder)` check never fired and a missing order fell
+    // through. Check the first element instead.
+    if (!inventoryOrder || inventoryOrder.length === 0 || !inventoryOrder[0]) {
+      throw new MedusaError(MedusaError.Types.NOT_FOUND,
         `Inventory order with id ${input.id} not found`
       );
     }
@@ -46,58 +50,45 @@ export const fetchInventoryOrderStep = createStep(
   }
 );
 
-export const dismissInventoryItemLinksStep = createStep(
-  "dismiss-inventory-item-links-step",
-  async (input: { 
+/**
+ * Cascade-delete EVERY link the inventory order (and each of its lines)
+ * participates in (#778 H11). The old steps only dismissed the inventory-item
+ * and stock-location links, orphaning the partner, task, internal-payment,
+ * feedback, inbound-email and unified-order links (and the per-line fulfillment
+ * links). `remoteLink.delete({ [MODULE]: { <fk>: id } })` removes all link rows
+ * for that record across every registered link definition, so nothing is left
+ * dangling. Best-effort per record so one failing link table doesn't abort the
+ * whole delete.
+ */
+export const dismissInventoryOrderLinksStep = createStep(
+  "dismiss-inventory-order-links-step",
+  async (input: {
     inventoryOrder: any;
   }, { container }) => {
     const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link;
-    
-    // Only proceed if there are order lines with inventory items
-    if (!input.inventoryOrder.orderlines || input.inventoryOrder.orderlines.length === 0) {
-      return new StepResponse([]);
+    const order = input.inventoryOrder;
+
+    // Order-level links (partner / task / internal_payments / feedback /
+    // stock_location / inbound_email / unified core order).
+    try {
+      await remoteLink.delete({
+        [ORDER_INVENTORY_MODULE]: { inventory_orders_id: order.id },
+      });
+    } catch {
+      /* best-effort */
     }
 
-    // Dismiss links between order lines and inventory items
-    const dismissPromises = input.inventoryOrder.orderlines.map(async (orderLine: any) => {
-      if (orderLine.inventory_items && orderLine.inventory_items.length > 0) {
-        await remoteLink.dismiss({
-          [ORDER_INVENTORY_MODULE]: {
-            inventory_order_line_id: orderLine.id,
-          },
-          [Modules.INVENTORY]: {
-            inventory_item_id: orderLine.inventory_items[0].id,
-          }
+    // Per-line links (inventory_item + line_fulfillment).
+    for (const orderLine of order.orderlines || []) {
+      if (!orderLine?.id) continue;
+      try {
+        await remoteLink.delete({
+          [ORDER_INVENTORY_MODULE]: { inventory_order_line_id: orderLine.id },
         });
+      } catch {
+        /* best-effort */
       }
-    });
-
-    await Promise.all(dismissPromises);
-    return new StepResponse();
-  }
-);
-
-export const dismissStockLocationLinkStep = createStep(
-  "dismiss-stock-location-link-step",
-  async (input: { 
-    inventoryOrder: any;
-  }, { container }) => {
-    const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link;
-    
-    // Only proceed if there's a stock location
-    if (!input.inventoryOrder.stock_locations || input.inventoryOrder.stock_locations.length === 0) {
-      return new StepResponse(true);
     }
-
-    // Dismiss link between inventory order and stock location
-    await remoteLink.dismiss({
-      [ORDER_INVENTORY_MODULE]: {
-        inventory_orders_id: input.inventoryOrder.id,
-      },
-      [Modules.STOCK_LOCATION]: {
-        stock_location_id: input.inventoryOrder.stock_locations[0].id,
-      }
-    });
 
     return new StepResponse(true);
   }
@@ -132,29 +123,31 @@ export const deleteInventoryOrderWorkflow = createWorkflow(
       // Step 1: Fetch the inventory order with its relations
       const inventoryOrder = fetchInventoryOrderStep(input);
       
-      // Step 2: Transform the data for the next steps
+      // Step 2: Transform the data + guard the delete transition (#778 H11):
+      // refuse to hard-delete an order that has posted stock / active
+      // fulfillments (Shipped / Delivered / Partial) — it must be cancelled
+      // first so the stock is reversed.
       const transformedData = transform(
         { inventoryOrder },
         ({ inventoryOrder }) => {
           const orderData = inventoryOrder[0]
-          
+
           if (!orderData) {
             throw new Error("No inventory order data found");
           }
-          
+
+          assertDeletable((orderData as any).status);
+
           return {
             inventoryOrder: orderData
           };
         }
       );
-      
-      // Step 3: Dismiss links between order lines and inventory items
-      dismissInventoryItemLinksStep(transformedData);
-      
-      // Step 4: Dismiss link between inventory order and stock location
-      dismissStockLocationLinkStep(transformedData);
-      
-      // Step 5: Delete the inventory order and its order lines
+
+      // Step 3: Cascade-delete ALL links the order + its lines participate in
+      dismissInventoryOrderLinksStep(transformedData);
+
+      // Step 4: Delete the inventory order and its order lines
       deleteInventoryOrderStep(transformedData);
       
       return new WorkflowResponse(true);

--- a/apps/backend/src/workflows/inventory_orders/lib/delete-helpers.ts
+++ b/apps/backend/src/workflows/inventory_orders/lib/delete-helpers.ts
@@ -1,0 +1,26 @@
+import { MedusaError } from "@medusajs/framework/utils"
+
+/**
+ * Pure guards for deleting an inventory order (#778 H11). Kept container-free so
+ * they're unit testable.
+ */
+
+/**
+ * Statuses that must NOT be hard-deleted: stock has been posted and/or a carrier
+ * fulfillment is active. Deleting these silently orphans posted stock and live
+ * shipments. The order must be cancelled first (which reverses posted stock and
+ * moves it to "Cancelled"), then it can be deleted.
+ */
+const NON_DELETABLE = new Set(["Shipped", "Delivered", "Partial"])
+
+export const isDeletableStatus = (status: string | null | undefined): boolean =>
+  !status || !NON_DELETABLE.has(status)
+
+export const assertDeletable = (status: string | null | undefined): void => {
+  if (!isDeletableStatus(status)) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `Inventory order in status "${status}" cannot be deleted; cancel it first (which reverses any posted stock and active fulfillments).`
+    )
+  }
+}


### PR DESCRIPTION
Third slice of **#781** (group 2 of the #778 inventory-orders audit) — **H11**: the delete path was broken and unsafe.

## Fixes
- **NOT_FOUND never fired** — the guard tested `!inventoryOrder` where `inventoryOrder` is the (always-truthy) array from `query.graph`, so a missing order fell through to a no-op "success". Now checks `inventoryOrder[0]`; the admin route maps it to **404**.
- **No status guard** — a `Shipped` / `Delivered` / `Partial` order (posted stock and/or active carrier fulfillment) could be hard-deleted, silently orphaning that stock and shipment. Added `assertDeletable`; those statuses now **409** ("cancel it first", which reverses posted stock via the cancel workflow in #786). `Pending` / `Processing` / `Cancelled` stay deletable.
- **Orphaned links** — the old steps only dismissed the inventory-item + stock-location links, leaving **partner / task / internal-payment / feedback / inbound-email / unified-order** links (and per-line **fulfillment** links) dangling. Replaced with a single step that `remoteLink.delete({ [MODULE]: { <fk>: id } })`s every link the order and each line participate in (cascades across all registered link definitions) — best-effort per record.

## Tests
- Pure guard in `lib/delete-helpers.ts`; **3 unit tests** (deletable set, blocked set, legacy null).
- `medusa build` green; `tsc` no new errors; inventory_orders unit suite green.

## Notes
The 409 "cancel it first" guard pairs with the cancel workflow in **#786** — together they give a safe lifecycle: cancel (reverses stock) → then delete.

Parent: #778 · Issue: #781 · Independent files, off `main`. Remaining in #781: the MEDIUM items (admin-`Delivered`-posts-stock + PUT state-machine enforcement + the destructive update compensation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)