### PR TITLE
feat(771): inventory-order status WhatsApp flow + data-plumbing installer

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/install-inventory-order-status-flow.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/install-inventory-order-status-flow.unit.spec.ts
@@ -1,0 +1,76 @@
+import { summarizeEventFlowInstall } from "../registry"
+
+const EVENT = "inventory_orders.inventory-order.status-changed"
+
+describe("install-inventory-order-status-flow — summarizeEventFlowInstall", () => {
+  it("reports already-installed when existingId is set (dry-run, no apply)", () => {
+    const result = summarizeEventFlowInstall({
+      jobId: "install-inventory-order-status-flow",
+      dry_run: true,
+      flowName: "Partner WhatsApp — Inventory Order Status",
+      eventTrigger: EVENT,
+      nodeCount: 6,
+      existingId: "vf_existing",
+      createdId: null,
+    })
+    expect(result.applied).toBe(false)
+    expect(result.changes).toEqual([])
+    expect(result.summary).toMatch(/already installed/)
+    expect(result.summary).toContain("vf_existing")
+    expect(result.summary).toContain(EVENT)
+    expect(result.job_id).toBe("install-inventory-order-status-flow")
+  })
+
+  it("reports would-create when dry-run and not existing", () => {
+    const result = summarizeEventFlowInstall({
+      jobId: "jid",
+      dry_run: true,
+      flowName: "My Flow",
+      eventTrigger: EVENT,
+      nodeCount: 6,
+      existingId: null,
+      createdId: null,
+    })
+    expect(result.applied).toBe(false)
+    expect(result.changes).toHaveLength(1)
+    expect(result.changes[0].entity).toBe("visual_flow")
+    expect(result.changes[0].field).toBe("created")
+    expect(result.changes[0].id).toBe("(new)")
+    expect(result.summary).toMatch(/Would create/)
+    expect(result.summary).toContain("My Flow")
+    expect(result.summary).toContain(EVENT)
+    expect(result.summary).toContain("6")
+  })
+
+  it("reports created when apply succeeds with a new id", () => {
+    const result = summarizeEventFlowInstall({
+      jobId: "jid",
+      dry_run: false,
+      flowName: "My Flow",
+      eventTrigger: EVENT,
+      nodeCount: 6,
+      existingId: null,
+      createdId: "vf_new",
+    })
+    expect(result.applied).toBe(true)
+    expect(result.changes[0].id).toBe("vf_new")
+    expect(result.summary).toMatch(/Created/)
+    expect(result.summary).toContain("vf_new")
+    // nudges the operator toward the two go-live steps.
+    expect(result.summary).toContain("jyt_inventory_order_status_v1")
+  })
+
+  it("reports not applied when createdId is null on apply", () => {
+    const result = summarizeEventFlowInstall({
+      jobId: "jid",
+      dry_run: false,
+      flowName: "My Flow",
+      eventTrigger: EVENT,
+      nodeCount: 6,
+      existingId: null,
+      createdId: null,
+    })
+    expect(result.applied).toBe(false)
+    expect(result.changes[0].id).toBe("(new)")
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -59,6 +59,7 @@ import {
 } from "../../marketing/marketing-summary-lib"
 import { VISUAL_FLOWS_MODULE } from "../../../../modules/visual_flows"
 import { FLOW_DEF as IDEAS_EMAIL_FLOW_DEF } from "../../../../scripts/seed-marketing-daily-ideas-email-flow"
+import { FLOW_DEF as INVENTORY_ORDER_STATUS_FLOW_DEF } from "../../../../scripts/seed-inventory-order-status-flow"
 import { seedEmailTemplatesJob } from "./seed-jobs"
 import {
   sweepAiPlatformsByCategory,
@@ -4124,6 +4125,115 @@ export const installMarketingIdeasEmailFlowJob: MaintenanceJob = {
 }
 
 // ---------------------------------------------------------------------------
+// install-inventory-order-status-flow (#771) — LOAD the partner WhatsApp
+// inventory-order status notification flow from the Data Plumbing console,
+// instead of shelling in to run the seed script. The flow listens to the #776
+// status-changed event → reads order + partner → maps status to the generic
+// jyt_inventory_order_status_v1 template → send_whatsapp. Same FLOW_DEF as the
+// CLI seed (single source of truth). Idempotent — refuses to overwrite an
+// existing flow; created as a DRAFT (stays inert until the operator approves
+// the template + flips draft→active).
+// ---------------------------------------------------------------------------
+
+/**
+ * Pure: report the event-flow install dry-run/apply outcome. Sibling of
+ * `summarizeFlowInstall` (which is schedule/cron-worded) for event-triggered
+ * flows whose trigger is described by an event name rather than a cron. Exported
+ * for unit testing so the preview/created/already-exists wording is verifiable
+ * without the DB.
+ */
+export function summarizeEventFlowInstall(args: {
+  jobId: string
+  dry_run: boolean
+  flowName: string
+  eventTrigger: string
+  nodeCount: number
+  existingId: string | null
+  createdId: string | null
+}): MaintenanceJobResult {
+  const { jobId, dry_run, flowName, eventTrigger, nodeCount, existingId, createdId } =
+    args
+  if (existingId) {
+    return {
+      job_id: jobId,
+      dry_run,
+      applied: false,
+      summary: `Visual flow "${flowName}" already installed (${existingId}) — nothing to do. Edit it on the canvas (trigger: ${eventTrigger}).`,
+      changes: [],
+    }
+  }
+  const changes: MaintenanceChange[] = [
+    {
+      entity: "visual_flow",
+      id: createdId ?? "(new)",
+      field: "created",
+      after: { name: flowName, trigger: `event ${eventTrigger}`, nodes: nodeCount },
+    },
+  ]
+  const applied = !dry_run && !!createdId
+  const summary = dry_run
+    ? `Would create visual flow "${flowName}" (event ${eventTrigger}, ${nodeCount} nodes) — nothing written. Apply to install.`
+    : `Created visual flow "${flowName}" (${createdId}); event ${eventTrigger}. Approve the jyt_inventory_order_status_v1 WhatsApp template, then flip draft→active to go live.`
+  return { job_id: jobId, dry_run, applied, summary, changes }
+}
+
+export const installInventoryOrderStatusFlowJob: MaintenanceJob = {
+  id: "install-inventory-order-status-flow",
+  label: "Install inventory-order status visual flow",
+  description:
+    "Load/create the 'Partner WhatsApp — Inventory Order Status' visual flow into the system from the console — no shell or seed script needed (#771). The flow listens to the inventory-order status-changed event and sends the partner a WhatsApp notification (Processing / Shipped / Partial / Delivered / Cancelled) via the generic jyt_inventory_order_status_v1 template. Dry-run previews the flow it would create (or reports it already exists); apply creates it idempotently as a DRAFT. It stays inert until you approve the template and flip the flow draft→active. Re-running never overwrites an existing flow.",
+  params: [],
+  run: async (container, { dry_run }) => {
+    const service: any = container.resolve(VISUAL_FLOWS_MODULE)
+    const flowName = INVENTORY_ORDER_STATUS_FLOW_DEF.name
+    const eventTrigger =
+      INVENTORY_ORDER_STATUS_FLOW_DEF.trigger_config?.event_types?.[0] ?? "event"
+    const nodeCount =
+      INVENTORY_ORDER_STATUS_FLOW_DEF.canvas_state?.nodes?.length ?? 0
+
+    const [existing] = await service.listVisualFlows({ name: flowName })
+    if (existing) {
+      return summarizeEventFlowInstall({
+        jobId: installInventoryOrderStatusFlowJob.id,
+        dry_run,
+        flowName,
+        eventTrigger,
+        nodeCount,
+        existingId: existing.id,
+        createdId: null,
+      })
+    }
+
+    let createdId: string | null = null
+    if (!dry_run) {
+      const flow = await service.createCompleteFlow({
+        flow: {
+          name: INVENTORY_ORDER_STATUS_FLOW_DEF.name,
+          description: INVENTORY_ORDER_STATUS_FLOW_DEF.description,
+          status: INVENTORY_ORDER_STATUS_FLOW_DEF.status,
+          trigger_type: INVENTORY_ORDER_STATUS_FLOW_DEF.trigger_type,
+          trigger_config: INVENTORY_ORDER_STATUS_FLOW_DEF.trigger_config,
+          canvas_state: INVENTORY_ORDER_STATUS_FLOW_DEF.canvas_state,
+        },
+        operations: INVENTORY_ORDER_STATUS_FLOW_DEF.operations,
+        connections: INVENTORY_ORDER_STATUS_FLOW_DEF.connections,
+      })
+      createdId = flow?.id ?? null
+    }
+
+    return summarizeEventFlowInstall({
+      jobId: installInventoryOrderStatusFlowJob.id,
+      dry_run,
+      flowName,
+      eventTrigger,
+      nodeCount,
+      existingId: null,
+      createdId,
+    })
+  },
+}
+
+// ---------------------------------------------------------------------------
 // generate-winback-targets (#659, report §12.5) — read ad_planning churn-risk
 // (+ optional CLV) scores, resolve each scored Person's email, and select
 // winback targets with a PURE, unit-tested selector (threshold + optional CLV
@@ -4545,6 +4655,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   syncMarketingOutreachEngagementJob,
   runMarketingIdeasEmailJob,
   installMarketingIdeasEmailFlowJob,
+  installInventoryOrderStatusFlowJob,
   generateWinbackTargetsJob,
   sendMarketingDailySummaryJob,
   auditAiPlatformsJob,

--- a/apps/backend/src/scripts/__tests__/seed-inventory-order-status-flow.unit.spec.ts
+++ b/apps/backend/src/scripts/__tests__/seed-inventory-order-status-flow.unit.spec.ts
@@ -1,0 +1,122 @@
+import { FLOW_DEF } from "../seed-inventory-order-status-flow"
+
+/**
+ * Structural guards for the inventory-order status WhatsApp visual flow seed
+ * (#771).
+ *
+ * This flow is editor-gated and cannot be live-verified by the daemon. It wires
+ * the #776 status-changed event + the send_whatsapp op by STRING name only, and
+ * the resolve_message code references trigger payload paths that only #776
+ * emits. A typo in any of these would silently no-op at runtime, so these tests
+ * pin the contract.
+ */
+describe("seed-inventory-order-status-flow FLOW_DEF", () => {
+  const byKey = Object.fromEntries(
+    FLOW_DEF.operations.map((o) => [o.operation_key, o])
+  )
+
+  it("is an event-triggered draft flow on the #776 status-changed event", () => {
+    expect(FLOW_DEF.status).toBe("draft")
+    expect(FLOW_DEF.trigger_type).toBe("event")
+    expect(FLOW_DEF.trigger_config.event_types).toEqual([
+      "inventory_orders.inventory-order.status-changed",
+    ])
+    // canvas trigger node mirrors the persisted trigger_config exactly.
+    expect(
+      (FLOW_DEF.canvas_state.nodes[0].data as any).triggerConfig.event_types
+    ).toEqual(FLOW_DEF.trigger_config.event_types)
+  })
+
+  it("wires read_data → execute_code → condition → send_whatsapp / log", () => {
+    expect(byKey.read_order.operation_type).toBe("read_data")
+    expect(byKey.resolve_message.operation_type).toBe("execute_code")
+    expect(byKey.has_message.operation_type).toBe("condition")
+    expect(byKey.send.operation_type).toBe("send_whatsapp")
+    expect(byKey.log_skip.operation_type).toBe("log")
+    // sort_order is contiguous from 0 in execution order.
+    expect(FLOW_DEF.operations.map((o) => o.sort_order)).toEqual([0, 1, 2, 3, 4])
+  })
+
+  it("reads the inventory order by the event payload id, with partner + admins", () => {
+    const read = byKey.read_order.options as any
+    expect(read.entity).toBe("inventory_orders")
+    expect(read.filters).toEqual({ id: "{{ $trigger.payload.id }}" })
+    expect(read.limit).toBe(1)
+    // must pull the partner relation + admins to resolve a recipient.
+    expect(read.fields).toEqual(
+      expect.arrayContaining([
+        "partner.id",
+        "partner.name",
+        "partner.whatsapp_number",
+        "partner.admins.phone",
+        "partner.admins.is_active",
+      ])
+    )
+  })
+
+  it("resolve_message reads the status-changed payload shape #776 emits", () => {
+    const code = (byKey.resolve_message.options as any).code as string
+    expect(code).toContain("$trigger?.payload?.id")
+    expect(code).toContain("$trigger?.payload?.status")
+    expect(code).toContain("$trigger?.payload?.previous_status")
+    // reads the order the read_order node produced.
+    expect(code).toContain("$input.read_order?.records?.[0]")
+  })
+
+  it("notifies exactly the five non-Pending statuses (Pending is skipped)", () => {
+    const code = (byKey.resolve_message.options as any).code as string
+    for (const s of ["Processing", "Shipped", "Partial", "Delivered", "Cancelled"]) {
+      expect(code).toContain(`"${s}":`)
+    }
+    // Pending must NOT be a notified status — it is the initial state.
+    expect(code).not.toContain(`"Pending":`)
+    // unmapped statuses fall through to a skip.
+    expect(code).toContain("status_not_notified")
+  })
+
+  it("condition gates send on resolve_message.skipped === false", () => {
+    const cond = byKey.has_message.options as any
+    expect(cond.expression).toBe("resolve_message.skipped === false")
+    expect(cond.filter_rule).toEqual({
+      "resolve_message.skipped": { _eq: false },
+    })
+  })
+
+  it("send_whatsapp interpolates the resolved template payload with dedup", () => {
+    const send = byKey.send.options as any
+    expect(send.mode).toBe("template")
+    expect(send.template_name).toBe("{{ resolve_message.template_name }}")
+    expect(send.variables).toBe("{{ resolve_message.variables }}")
+    expect(send.to).toBe("{{ resolve_message.to }}")
+    expect(send.context_type).toBe("{{ resolve_message.context_type }}")
+    expect(send.context_id).toBe("{{ resolve_message.context_id }}")
+    expect(send.dedup_window_minutes).toBe(60)
+    expect(send.require_partner).toBe(true)
+  })
+
+  it("dedup context_id is per (order, status) so each transition sends once", () => {
+    const code = (byKey.resolve_message.options as any).code as string
+    expect(code).toContain('orderId + ":" + newStatus')
+    expect(code).toContain('context_type: "inventory_order"')
+  })
+
+  it("has matching canvas edges and connection rows (success/failure fan-out)", () => {
+    const conn = FLOW_DEF.connections.map((c) => `${c.source_id}->${c.target_id}`)
+    const edges = FLOW_DEF.canvas_state.edges.map((e) => `${e.source}->${e.target}`)
+    expect(conn).toEqual(edges)
+    expect(conn).toEqual([
+      "trigger->read_order",
+      "read_order->resolve_message",
+      "resolve_message->has_message",
+      "has_message->send",
+      "has_message->log_skip",
+    ])
+    // the condition's two arms carry the right handles.
+    const arms = Object.fromEntries(
+      FLOW_DEF.connections
+        .filter((c) => c.source_id === "has_message")
+        .map((c) => [c.target_id, c.connection_type])
+    )
+    expect(arms).toEqual({ send: "success", log_skip: "failure" })
+  })
+})

--- a/apps/backend/src/scripts/seed-inventory-order-status-flow.ts
+++ b/apps/backend/src/scripts/seed-inventory-order-status-flow.ts
@@ -1,0 +1,346 @@
+/**
+ * Seed: Partner WhatsApp — Inventory Order Status (single dispatcher) [#771]
+ *
+ * One active flow listens to the `inventory_orders.inventory-order.status-changed`
+ * event emitted by `updateInventoryOrderStep` (#776) — which fires ONLY on a
+ * real status transition (previous → new), unlike the noisy generic
+ * `inventory_orders.inventory-orders.updated` that also fires on metadata-only
+ * writes. The flow reads the order + its assigned partner, maps the new status
+ * to a Meta-approved template + variables, and sends via `send_whatsapp`.
+ *
+ * Status → notification mapping (defined inline in the resolve_message node):
+ *   Processing → "In Production"        ┐
+ *   Shipped    → "Shipped"              │  all use the single generic template
+ *   Partial    → "Partially Delivered"  │  jyt_inventory_order_status_v1 with
+ *   Delivered  → "Delivered"            │  vars [partnerName, orderId, statusLabel]
+ *   Cancelled  → "Cancelled"            ┘
+ *   Pending    → (skipped — initial state, no partner-facing ping)
+ *
+ * Orders with no assigned partner / no reachable phone hit the "skip" branch —
+ * no send (admin-only inventory orders never have a partner recipient).
+ *
+ * Why one generic template instead of one per status: WhatsApp templates need
+ * Meta approval per WABA. A single parameterized "your order {id} is now
+ * {status}" template keeps the operator's approval burden at ONE template; the
+ * canvas can later be branched into per-status templates or an email arm.
+ *
+ * Run:
+ *   npx medusa exec ./src/scripts/seed-inventory-order-status-flow.ts
+ *
+ * Or, no shell: Settings → Data Plumbing → "Install inventory-order status
+ * visual flow" (the install-inventory-order-status-flow maintenance job seeds
+ * this same FLOW_DEF — single source of truth).
+ *
+ * Re-seed:
+ *   Delete the existing flow (admin UI or by id) and re-run. The script is
+ *   idempotent — it refuses to overwrite an existing flow with the same name.
+ *
+ * Before activating in admin:
+ *   1. Ensure this template is APPROVED on every WABA you target:
+ *        - jyt_inventory_order_status_v1   (body refs {{1}} {{2}} {{3}})
+ *      Push it via:
+ *        npx medusa exec ./src/scripts/manage-whatsapp-templates.ts
+ *   2. Flip flow status: draft → active in the admin editor.
+ */
+
+import { VISUAL_FLOWS_MODULE } from "../modules/visual_flows"
+import VisualFlowService from "../modules/visual_flows/service"
+
+const FLOW_NAME = "Partner WhatsApp — Inventory Order Status"
+
+// The #776 status-changed event — fires only on a real transition.
+const STATUS_CHANGED_EVENT =
+  "inventory_orders.inventory-order.status-changed"
+
+// Single Meta-approved template covering every notified status.
+const STATUS_TEMPLATE = "jyt_inventory_order_status_v1"
+
+// ─── Canvas positions ────────────────────────────────────────────────────────
+const X_CENTER = 500
+const X_LEFT = 200
+const X_RIGHT = 800
+
+const Y_READ_ORDER = 140
+const Y_RESOLVE = 300
+const Y_COND = 460
+const Y_SEND = 620
+const Y_SKIP = 620
+
+// ─── Code for the resolve_message node ───────────────────────────────────────
+//
+// Returns the full send_whatsapp input payload so the downstream node can
+// interpolate from this one operation's output. Returns { skipped: true } with
+// a reason when the transition has no notification — drives the has_message
+// condition below.
+//
+// Variables produced (positional, identical order across languages):
+//   [partnerName, orderId, statusLabel]
+//
+// Recipient resolution mirrors the partner payment-status flow: first ACTIVE
+// admin's first_name + phone for a real greeting, falling back to
+// partner.whatsapp_number. Language is the admin's preferred_language when set,
+// else send_whatsapp's own chain (conv metadata → phone heuristic → env → hi).
+const RESOLVE_MESSAGE_CODE = `\
+const eventName = $trigger?.event || ""
+const orderId = $trigger?.payload?.id || null
+const previousStatus = $trigger?.payload?.previous_status || null
+const newStatus = $trigger?.payload?.status || null
+
+if (!orderId) {
+  return { skipped: true, reason: "missing_order_id_in_payload", event: eventName }
+}
+if (!newStatus) {
+  return { skipped: true, reason: "missing_status_in_payload", event: eventName, order_id: orderId }
+}
+
+const order = $input.read_order?.records?.[0]
+if (!order) {
+  return { skipped: true, reason: "order_not_found", event: eventName, order_id: orderId }
+}
+
+// The order ↔ partner link accessor is singular (\`order.partner\`), but defend
+// against an array shape just in case the query returns a list.
+const partner = Array.isArray(order.partner) ? order.partner[0] : order.partner
+if (!partner) {
+  return { skipped: true, reason: "no_partner_on_order", event: eventName, order_id: orderId }
+}
+
+// Status → human label. Only these statuses notify the partner. Pending (the
+// initial state) and any unmapped/future status fall through to skip.
+const labels = {
+  "Processing": "In Production",
+  "Shipped": "Shipped",
+  "Partial": "Partially Delivered",
+  "Delivered": "Delivered",
+  "Cancelled": "Cancelled",
+}
+const statusLabel = labels[newStatus]
+if (!statusLabel) {
+  return { skipped: true, reason: "status_not_notified", event: eventName, order_id: orderId, status: newStatus }
+}
+
+// Pick the first active admin for greeting + phone routing.
+const admins = Array.isArray(partner.admins) ? partner.admins : []
+const activeAdmins = admins.filter(function (a) { return a && a.is_active !== false })
+const primary = activeAdmins[0] || admins[0] || null
+
+const partnerName = (primary && primary.first_name)
+  ? primary.first_name
+  : (partner.name || "Partner")
+
+const phone = (primary && primary.phone) ? primary.phone : (partner.whatsapp_number || null)
+if (!phone) {
+  return { skipped: true, reason: "no_phone_on_partner", event: eventName, order_id: orderId, partner_id: partner.id }
+}
+
+const languageCode = (primary && primary.preferred_language) ? primary.preferred_language : ""
+
+return {
+  skipped: false,
+  event: eventName,
+  to: phone,
+  partner_id: partner.id,
+  template_name: "${STATUS_TEMPLATE}",
+  variables: [partnerName, orderId, statusLabel],
+  language_code: languageCode || "",
+  status: newStatus,
+  status_label: statusLabel,
+  previous_status: previousStatus,
+  context_type: "inventory_order",
+  // context_id is per (order, status) so each distinct transition delivers once
+  // (Processing → Shipped → Delivered each send), while an event RETRY within
+  // the dedup window collapses to a single send. Stable across retries because
+  // both order id and the new status are deterministic for one transition.
+  context_id: orderId + ":" + newStatus,
+  order_id: orderId,
+}
+`
+
+// ─── Flow definition (exported for the structural unit test + the job) ─────────
+
+export const FLOW_DEF = {
+  name: FLOW_NAME,
+  description:
+    "Single dispatcher for partner-facing WhatsApp notifications on every " +
+    "inventory-order status transition. Listens to " +
+    "inventory_orders.inventory-order.status-changed (fires only on a real " +
+    "status delta, #776), reads the order + assigned partner, maps the new " +
+    "status to a label via an execute_code node, then dispatches the generic " +
+    "jyt_inventory_order_status_v1 template through send_whatsapp. Notifies on " +
+    "Processing / Shipped / Partial / Delivered / Cancelled; skips Pending and " +
+    "partner-less orders.",
+  status: "draft" as const,
+  trigger_type: "event" as const,
+  trigger_config: {
+    event_types: [STATUS_CHANGED_EVENT],
+  },
+
+  canvas_state: {
+    viewport: { x: 0, y: 0, zoom: 0.8 },
+    nodes: [
+      { id: "trigger",         type: "trigger",   position: { x: X_CENTER, y: -20 },          data: { label: "Inventory Order — status changed", triggerType: "event", triggerConfig: { event_types: [STATUS_CHANGED_EVENT] } } },
+      { id: "read_order",      type: "operation", position: { x: X_CENTER, y: Y_READ_ORDER }, data: { label: "Read Order + Partner", operationKey: "read_order",      operationType: "read_data"     } },
+      { id: "resolve_message", type: "operation", position: { x: X_CENTER, y: Y_RESOLVE },    data: { label: "Resolve Message",      operationKey: "resolve_message", operationType: "execute_code"  } },
+      { id: "has_message",     type: "operation", position: { x: X_CENTER, y: Y_COND },       data: { label: "Has Message?",         operationKey: "has_message",     operationType: "condition"     } },
+      { id: "send",            type: "operation", position: { x: X_LEFT,   y: Y_SEND },       data: { label: "Send WhatsApp",        operationKey: "send",            operationType: "send_whatsapp" } },
+      { id: "log_skip",        type: "operation", position: { x: X_RIGHT,  y: Y_SKIP },       data: { label: "Log: Skipped",         operationKey: "log_skip",        operationType: "log"           } },
+    ],
+    edges: [
+      { id: "e-0", source: "trigger",         sourceHandle: "default", target: "read_order",      targetHandle: "default" },
+      { id: "e-1", source: "read_order",      sourceHandle: "default", target: "resolve_message", targetHandle: "default" },
+      { id: "e-2", source: "resolve_message", sourceHandle: "default", target: "has_message",     targetHandle: "default" },
+      { id: "e-3", source: "has_message",     sourceHandle: "success", target: "send",            targetHandle: "default" },
+      { id: "e-4", source: "has_message",     sourceHandle: "failure", target: "log_skip",        targetHandle: "default" },
+    ],
+  },
+
+  operations: [
+    // ── 1. Read inventory order + assigned partner (+ admins) ──────────────
+    {
+      operation_key: "read_order",
+      operation_type: "read_data",
+      name: "Read Order + Partner",
+      sort_order: 0,
+      position_x: X_CENTER,
+      position_y: Y_READ_ORDER,
+      options: {
+        entity: "inventory_orders",
+        fields: [
+          "id",
+          "status",
+          "quantity",
+          "partner.id",
+          "partner.name",
+          "partner.whatsapp_number",
+          "partner.admins.id",
+          "partner.admins.first_name",
+          "partner.admins.phone",
+          "partner.admins.is_active",
+          "partner.admins.preferred_language",
+        ],
+        filters: { id: "{{ $trigger.payload.id }}" },
+        limit: 1,
+      },
+    },
+
+    // ── 2. Resolve message config from the status transition ───────────────
+    {
+      operation_key: "resolve_message",
+      operation_type: "execute_code",
+      name: "Resolve Message",
+      sort_order: 1,
+      position_x: X_CENTER,
+      position_y: Y_RESOLVE,
+      options: {
+        code: RESOLVE_MESSAGE_CODE,
+        timeout: 5000,
+      },
+    },
+
+    // ── 3. Condition: did we resolve a sendable message? ───────────────────
+    {
+      operation_key: "has_message",
+      operation_type: "condition",
+      name: "Has Message?",
+      sort_order: 2,
+      position_x: X_CENTER,
+      position_y: Y_COND,
+      options: {
+        condition_mode: "expression",
+        // skipped === false → success branch (send). true → failure (log only).
+        expression: "resolve_message.skipped === false",
+        filter_rule: { "resolve_message.skipped": { _eq: false } },
+      },
+    },
+
+    // ── 4a. Send WhatsApp template (success branch) ────────────────────────
+    {
+      operation_key: "send",
+      operation_type: "send_whatsapp",
+      name: "Send WhatsApp",
+      sort_order: 3,
+      position_x: X_LEFT,
+      position_y: Y_SEND,
+      options: {
+        to: "{{ resolve_message.to }}",
+        partner_id: "{{ resolve_message.partner_id }}",
+        mode: "template",
+        template_name: "{{ resolve_message.template_name }}",
+        variables: "{{ resolve_message.variables }}",
+        language_code: "{{ resolve_message.language_code }}",
+        context_type: "{{ resolve_message.context_type }}",
+        context_id: "{{ resolve_message.context_id }}",
+        // 60-min dedup blocks accidental double-sends from event retries.
+        // Distinct transitions carry distinct context_ids (order:status) so
+        // legitimate progression (Processing → Shipped → Delivered) all deliver.
+        dedup_window_minutes: 60,
+        require_partner: true,
+      },
+    },
+
+    // ── 4b. Log skip (failure branch) ──────────────────────────────────────
+    {
+      operation_key: "log_skip",
+      operation_type: "log",
+      name: "Log: Skipped",
+      sort_order: 4,
+      position_x: X_RIGHT,
+      position_y: Y_SKIP,
+      options: {
+        message:
+          "Skipping inventory-order WhatsApp for {{ $trigger.payload.id }} " +
+          "(status {{ $trigger.payload.status }}) — reason: {{ resolve_message.reason }}",
+        level: "info",
+      },
+    },
+  ],
+
+  connections: [
+    { source_id: "trigger",         source_handle: "default", target_id: "read_order",      connection_type: "default" as const },
+    { source_id: "read_order",      source_handle: "default", target_id: "resolve_message", connection_type: "default" as const },
+    { source_id: "resolve_message", source_handle: "default", target_id: "has_message",     connection_type: "default" as const },
+    { source_id: "has_message",     source_handle: "success", target_id: "send",            connection_type: "success" as const },
+    { source_id: "has_message",     source_handle: "failure", target_id: "log_skip",        connection_type: "failure" as const },
+  ],
+}
+
+// ─── Runner ──────────────────────────────────────────────────────────────────
+
+export default async function seedInventoryOrderStatusFlow({
+  container,
+}: {
+  container: any
+}) {
+  const service: VisualFlowService = container.resolve(VISUAL_FLOWS_MODULE)
+
+  const [existing] = await service.listVisualFlows({ name: FLOW_NAME } as any)
+  if (existing) {
+    console.log(`Flow "${FLOW_NAME}" already exists (${existing.id}) — skipping.`)
+    console.log(`Delete it in the admin UI (or by id) to re-seed.`)
+    return
+  }
+
+  console.log(`Creating flow "${FLOW_NAME}"...`)
+
+  const flow = await service.createCompleteFlow({
+    flow: {
+      name: FLOW_DEF.name,
+      description: FLOW_DEF.description,
+      status: FLOW_DEF.status,
+      trigger_type: FLOW_DEF.trigger_type,
+      trigger_config: FLOW_DEF.trigger_config,
+      canvas_state: FLOW_DEF.canvas_state,
+    },
+    operations: FLOW_DEF.operations,
+    connections: FLOW_DEF.connections,
+  })
+
+  console.log(`\nFlow created: ${flow.id}`)
+  console.log(`  Open: /app/visual-flows/${flow.id}\n`)
+  console.log(`Before activating:`)
+  console.log(`  1. Ensure this template is APPROVED on every WABA you target:`)
+  console.log(`     - ${STATUS_TEMPLATE}   (body uses {{1}} partner, {{2}} order id, {{3}} status)`)
+  console.log(`     Push via:`)
+  console.log(`       npx medusa exec ./src/scripts/manage-whatsapp-templates.ts`)
+  console.log(`  2. Flip flow status: draft → active in the admin editor.`)
+}


### PR DESCRIPTION
## What & why

PR #776 shipped the **backend event** `inventory_orders.inventory-order.status-changed` (fires only on a real status delta) but **nothing consumed it**. The codemap called this out: *"Remaining work is product/config, not infra: author the actual inventory-order flow(s)... and parity-test the partner endpoints."* This PR delivers that remainder — the **UI/flow config** + the **data-plumbing operation** that were left over from the #773 cluster.

## Changes

**1. The flow** — `src/scripts/seed-inventory-order-status-flow.ts` (exports `FLOW_DEF`)
- Event-triggered on `…status-changed` → `read_data` (order + `partner.*` + `partner.admins.*`) → `execute_code` (status→label map, recipient resolution, skip guards) → `condition` → `send_whatsapp` / `log`.
- Notifies on **Processing / Shipped / Partial / Delivered / Cancelled**; skips **Pending** and partner-less/admin-only orders.
- One generic Meta template `jyt_inventory_order_status_v1` (vars `[partnerName, orderId, statusLabel]`) → **one approval** for the operator.
- Per-`(order, status)` dedup `context_id` so each transition delivers once but event retries collapse.
- Created as **DRAFT** — inert until the operator approves the template + flips draft→active.
- Directly mirrors the proven `seed-partner-payment-status-flow` dispatcher.

**2. The data-plumbing operation** — `install-inventory-order-status-flow` (#457 maintenance-job)
- Settings → Data Plumbing → dry-run preview → apply (idempotent, refuses to overwrite). No shell.
- Reuses the **same `FLOW_DEF`** (single source of truth) like `install-marketing-ideas-email-flow`.
- New pure `summarizeEventFlowInstall` (event-trigger-worded sibling of `summarizeFlowInstall`).

**3. Tests** — 13 unit tests: `FLOW_DEF` structural contract (trigger/event-name/op-wiring/payload-paths/dedup/edges) + installer summary wording.

## Verify
- `pnpm jest src/scripts/__tests__/seed-inventory-order-status-flow.unit.spec.ts src/api/admin/ops/maintenance-jobs/__tests__/install-inventory-order-status-flow.unit.spec.ts` → 13 green.
- Live (post-merge): Settings → Data Plumbing → "Install inventory-order status visual flow" → apply → open the flow, approve `jyt_inventory_order_status_v1`, flip draft→active → transition an order's status and confirm the partner WhatsApp.

## Notes / decisions
- **WhatsApp only** for the seeded arm (partner's primary channel); an email branch can be added on the canvas later.
- `tsc --noEmit` clean for both touched files (70 pre-existing baseline errors in unrelated files, none mine).
- Closes the #771 "author the flow" remainder. Partner-API parity (start/complete all route through `updateInventoryOrderWorkflow` → emit the event) is covered by #776's event being the single trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)