### PR TITLE
fix(769): admin media upload corrupts binary images (latin1→utf8) — store base64

### DIFF
--- a/apps/backend/integration-tests/http/media-upload-binary-integrity.spec.ts
+++ b/apps/backend/integration-tests/http/media-upload-binary-integrity.spec.ts
@@ -1,0 +1,126 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user";
+import FormData from "form-data";
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup";
+import fs from "fs";
+import path from "path";
+
+jest.setTimeout(30000);
+
+/**
+ * Regression guard for #769: POST /admin/medias must store binary uploads
+ * byte-for-byte.
+ *
+ * The bug: the route serialized file content with `buffer.toString("binary")`
+ * (Latin-1). The Medusa file provider (local-file / file-s3) format-detects the
+ * content string by attempting a base64 round-trip and, when that fails, falls
+ * back to `Buffer.from(content, "utf8")` — which UTF-8-re-encodes every byte
+ * >= 0x80. A real JPEG (`FF D8 FF E0 …`) thus landed on disk as mojibake
+ * (`C3 BF C3 98 …`), ~1.5x larger and unreadable by any image decoder, which is
+ * why import-from-image failed with "cannot identify image file". The fix sends
+ * base64 so the provider takes the lossless decode branch.
+ *
+ * The pre-existing media-upload tests only used ASCII text ("This is test
+ * image content"), whose bytes are all < 0x80 — so they never exercised the
+ * corrupting path. These tests deliberately use bytes >= 0x80.
+ */
+setupSharedTestSuite(() => {
+  let headers;
+  const { api, getContainer } = getSharedTestEnv();
+
+  beforeEach(async () => {
+    const container = getContainer();
+    await createAdminUser(container);
+    headers = await getAuthHeaders(api);
+  });
+
+  // Build a deterministic "image" that contains every byte value 0x00-0xFF
+  // (so it includes the >= 0x80 bytes that trigger the bug), framed with JPEG
+  // SOI/EOI markers so a successful round-trip is also recognizable.
+  const buildBinaryImage = (): Buffer => {
+    const body: number[] = []
+    for (let rep = 0; rep < 8; rep++) {
+      for (let b = 0; b <= 255; b++) body.push(b)
+    }
+    return Buffer.concat([
+      Buffer.from([0xff, 0xd8, 0xff, 0xe0]), // JPEG SOI + APP0
+      Buffer.from(body),
+      Buffer.from([0xff, 0xd9]), // JPEG EOI
+    ])
+  }
+
+  // Resolve the on-disk path the local file provider wrote to from the public
+  // file_path URL (…/static/<key>). The default provider stores under
+  // `${cwd}/static`.
+  const readStoredFile = (filePath: string): Buffer | null => {
+    const marker = "/static/"
+    const idx = filePath.indexOf(marker)
+    if (idx === -1) return null
+    const key = decodeURIComponent(filePath.slice(idx + marker.length))
+    const onDisk = path.join(process.cwd(), "static", key)
+    return fs.existsSync(onDisk) ? fs.readFileSync(onDisk) : null
+  }
+
+  const uploadOne = async (buf: Buffer, filename: string) => {
+    const formData = new FormData()
+    formData.append("files", buf, { filename, contentType: "image/jpeg" })
+    const formHeaders = formData.getHeaders()
+    const response = await api.post("/admin/medias", formData, {
+      ...headers,
+      headers: { ...headers.headers, ...formHeaders },
+    })
+    return response
+  }
+
+  describe("POST /admin/medias — binary integrity (#769)", () => {
+    it("stores a binary image byte-for-byte (no Latin-1 -> UTF-8 corruption)", async () => {
+      const original = buildBinaryImage()
+
+      const response = await uploadOne(original, "binary-int.jpg")
+      expect(response.status).toBe(201)
+      const media = response.data.result.mediaFiles[0]
+      expect(media).toBeTruthy()
+      expect(media.file_path).toBeTruthy()
+
+      const stored = readStoredFile(media.file_path)
+      // If the provider isn't the local disk provider in this env, we can't read
+      // it back — fail loudly rather than silently passing.
+      expect(stored).not.toBeNull()
+
+      // The corruption inflates size (~1.5x) and rewrites the magic bytes.
+      expect(stored!.length).toBe(original.length)
+      expect(stored!.equals(original)).toBe(true)
+      // Magic bytes survive intact (would be C3 BF C3 98 if corrupted).
+      expect(stored!.subarray(0, 4).toString("hex")).toBe("ffd8ffe0")
+      expect(stored!.subarray(-2).toString("hex")).toBe("ffd9")
+    })
+
+    it("does NOT exhibit the latin1->utf8 mojibake signature", async () => {
+      // A pure high-byte payload: every byte is 0xFF, which UTF-8 encoding would
+      // double to C3 BF … doubling the length. Byte-exact + length-exact proves
+      // the lossless path.
+      const original = Buffer.alloc(2048, 0xff)
+
+      const response = await uploadOne(original, "high-bytes.bin")
+      expect(response.status).toBe(201)
+      const media = response.data.result.mediaFiles[0]
+      const stored = readStoredFile(media.file_path)
+      expect(stored).not.toBeNull()
+
+      expect(stored!.length).toBe(original.length) // corruption would be ~4096
+      expect(stored!.equals(original)).toBe(true)
+      // Explicitly assert the corruption signature is absent.
+      expect(stored!.subarray(0, 2).toString("hex")).not.toBe("c3bf")
+    })
+
+    it("still stores plain ASCII text uploads correctly (no regression)", async () => {
+      const original = Buffer.from("This is plain ascii content", "utf-8")
+
+      const response = await uploadOne(original, "ascii.txt")
+      expect(response.status).toBe(201)
+      const media = response.data.result.mediaFiles[0]
+      const stored = readStoredFile(media.file_path)
+      expect(stored).not.toBeNull()
+      expect(stored!.equals(original)).toBe(true)
+    })
+  })
+})

--- a/apps/backend/src/api/admin/medias/[id]/upload/route.ts
+++ b/apps/backend/src/api/admin/medias/[id]/upload/route.ts
@@ -104,13 +104,15 @@ export const POST = async (
       throw new MedusaError(MedusaError.Types.INVALID_DATA, "No files provided for upload")
     }
 
+    // base64 (not "binary"/latin1): the Medusa file provider UTF-8-re-encodes
+    // non-base64 content and corrupts any byte >= 0x80 in real images (#769).
     const files = uploadedFiles.map((file) => {
       const hasBuffer = (file as any).buffer && Buffer.isBuffer((file as any).buffer)
       const hasPath = (file as any).path && typeof (file as any).path === "string"
       const contentStr = hasBuffer
-        ? (file as any).buffer.toString("binary")
+        ? (file as any).buffer.toString("base64")
         : hasPath
-          ? fs.readFileSync((file as any).path).toString("binary")
+          ? fs.readFileSync((file as any).path).toString("base64")
           : ""
       return {
         filename: file.originalname,

--- a/apps/backend/src/api/admin/medias/folder/[id]/upload/route.ts
+++ b/apps/backend/src/api/admin/medias/folder/[id]/upload/route.ts
@@ -95,11 +95,14 @@ export const POST = async (
       throw new MedusaError(MedusaError.Types.INVALID_DATA, "No files provided for upload")
     }
 
-    // Build workflow files using string content to avoid Buffer serialization in workflows
+    // Build workflow files using base64 string content to avoid Buffer
+    // serialization in workflows. NOT "binary"/latin1: the Medusa file provider
+    // UTF-8-re-encodes non-base64 content, corrupting any byte >= 0x80 in real
+    // images (#769).
     const files = uploadedFiles.map((file) => ({
       filename: file.originalname,
       mimeType: file.mimetype,
-      content: (file as any).buffer?.toString("binary"),
+      content: (file as any).buffer?.toString("base64"),
       size: file.size,
     }))
 

--- a/apps/backend/src/api/admin/medias/route.ts
+++ b/apps/backend/src/api/admin/medias/route.ts
@@ -145,15 +145,20 @@ import { UploadMediaRequest } from "./validator";
         );
       }
 
-      // Transform multer files to workflow input format
-      // Pass content as a binary string to avoid Buffer in workflow inputs
+      // Transform multer files to workflow input format.
+      // Content MUST be base64, not "binary"/latin1: the Medusa file provider
+      // (local-file/file-s3) tries `Buffer.from(content, "base64")` and only
+      // keeps the decoded bytes when it round-trips as base64 — otherwise it
+      // falls back to `Buffer.from(content, "utf8")`, which UTF-8-re-encodes any
+      // byte >= 0x80 and corrupts every real image (#769). base64 avoids Buffer
+      // in the (serialized) workflow input while staying loss-free.
       const files = uploadedFiles.map((file) => {
         const hasBuffer = (file as any).buffer && Buffer.isBuffer((file as any).buffer)
         const hasPath = (file as any).path && typeof (file as any).path === "string"
         const contentStr = hasBuffer
-          ? (file as any).buffer.toString("binary")
+          ? (file as any).buffer.toString("base64")
           : hasPath
-            ? fs.readFileSync((file as any).path).toString("binary")
+            ? fs.readFileSync((file as any).path).toString("base64")
             : ""
         return {
           filename: file.originalname,

--- a/apps/backend/src/workflows/ai/__tests__/summarize-ai-step-error.unit.spec.ts
+++ b/apps/backend/src/workflows/ai/__tests__/summarize-ai-step-error.unit.spec.ts
@@ -1,0 +1,77 @@
+import { summarizeAiStepError } from "../image-extraction"
+
+/**
+ * #769 — the image-extraction step used to swallow the real provider failure as
+ * a generic "Mastra image extraction workflow failed". These fixtures are the
+ * actual error shapes seen in prod CloudWatch, asserting the operator now gets
+ * the real reason.
+ */
+describe("summarizeAiStepError", () => {
+  it("digs the nested Cloudflare AiError reason out of responseBody", () => {
+    // Real shape: AI SDK APICallError wrapping Cloudflare's double-nested AiError.
+    const err = {
+      statusCode: 400,
+      responseBody: JSON.stringify({
+        errors: [
+          {
+            message:
+              'AiError: AiError: {"error":{"message":"Failed to load image: cannot identify image file <_io.BytesIO object>","type":"BadRequestError","code":400}} (abc-123)',
+            code: 8007,
+          },
+        ],
+        success: false,
+      }),
+    }
+    const msg = summarizeAiStepError(err)
+    expect(msg).toContain("HTTP 400")
+    expect(msg).toContain("cannot identify image file")
+    // The generic wrapper text must NOT be what surfaces.
+    expect(msg).not.toMatch(/workflow failed/i)
+  })
+
+  it("surfaces an authentication error from responseBody", () => {
+    const err = {
+      statusCode: 401,
+      responseBody: JSON.stringify({
+        success: false,
+        errors: [{ code: 10000, message: "Authentication error" }],
+      }),
+    }
+    const msg = summarizeAiStepError(err)
+    expect(msg).toBe("HTTP 401: Authentication error")
+  })
+
+  it("handles OpenAI-style error.message shape", () => {
+    const err = {
+      statusCode: 400,
+      responseBody: JSON.stringify({
+        error: { message: "Unable to process input image", code: "invalid" },
+      }),
+    }
+    expect(summarizeAiStepError(err)).toBe("HTTP 400: Unable to process input image")
+  })
+
+  it("falls back to the raw responseBody snippet when not parseable", () => {
+    const err = { statusCode: 502, responseBody: "<html>Bad Gateway</html>" }
+    const msg = summarizeAiStepError(err)
+    expect(msg).toContain("HTTP 502")
+    expect(msg).toContain("Bad Gateway")
+  })
+
+  it("uses describeFetchError for undici network failures (no responseBody)", () => {
+    const err: any = new Error("fetch failed")
+    err.cause = { code: "ENOTFOUND", hostname: "api.cloudflare.com", syscall: "getaddrinfo" }
+    const msg = summarizeAiStepError(err)
+    expect(msg).toMatch(/ENOTFOUND|api\.cloudflare\.com|fetch failed/)
+  })
+
+  it("handles a plain string error and a bare Error", () => {
+    expect(summarizeAiStepError("boom")).toContain("boom")
+    expect(summarizeAiStepError(new Error("something broke"))).toContain("something broke")
+  })
+
+  it("caps the message length", () => {
+    const err = { statusCode: 400, responseBody: "x".repeat(5000) }
+    expect(summarizeAiStepError(err).length).toBeLessThanOrEqual(500)
+  })
+})

--- a/apps/backend/src/workflows/ai/image-extraction.ts
+++ b/apps/backend/src/workflows/ai/image-extraction.ts
@@ -5,7 +5,48 @@ import {
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk";
 import { MedusaError } from "@medusajs/framework/utils";
+import { describeFetchError } from "../../utils/describe-fetch-error";
 import { mastra } from "../../mastra";
+
+/**
+ * Pull the most actionable message out of a failed Mastra step error so the
+ * route returns the REAL reason instead of a generic "workflow failed" (#769).
+ *
+ * The vision call surfaces AI SDK `APICallError`s whose `responseBody` carries
+ * the provider's real error (e.g. Cloudflare "cannot identify image file",
+ * "Authentication error", quota), nested 1-2 levels deep in JSON. Network
+ * failures arrive as undici "fetch failed" with the detail on `.cause` —
+ * handled by `describeFetchError`. Pure + exported for unit testing.
+ */
+export function summarizeAiStepError(err: unknown): string {
+  const e = err as any
+  const status = e?.statusCode ?? e?.status
+  const rawBody = typeof e?.responseBody === "string" ? e.responseBody : undefined
+
+  let providerMsg: string | undefined
+  if (rawBody) {
+    try {
+      const parsed = JSON.parse(rawBody)
+      providerMsg =
+        parsed?.errors?.[0]?.message ??
+        parsed?.error?.message ??
+        parsed?.message
+    } catch {
+      /* responseBody wasn't JSON */
+    }
+    // Providers (e.g. Cloudflare) double-nest the real reason as an AiError
+    // string: `AiError: {"error":{"message":"..."}}`. Dig the innermost message.
+    if (typeof providerMsg === "string") {
+      const nested = providerMsg.match(/"message"\s*:\s*"([^"]+)"/)
+      if (nested) providerMsg = nested[1]
+    }
+    if (!providerMsg) providerMsg = rawBody.slice(0, 300)
+  }
+
+  const base = providerMsg ?? describeFetchError(err)
+  const prefix = status ? `HTTP ${status}: ` : ""
+  return `${prefix}${base}`.slice(0, 500)
+}
 import {
   resolveRoleVisionModel,
   logAiUsage,
@@ -176,7 +217,22 @@ const runMastraExtraction = createStep(
       })
     }
 
-    throw new MedusaError(MedusaError.Types.UNEXPECTED_STATE, "Mastra image extraction workflow failed")
+    // Surface the REAL failure instead of a generic message (#769). The vision
+    // call lives in extractItems; its error carries the provider's actual reason
+    // (e.g. "cannot identify image file", auth/quota, network), which is what an
+    // operator needs to fix their AI-platform config or the source image.
+    const extractErr = (workflowResult.steps.extractItems as any)?.error
+    if (workflowResult.steps.extractItems?.status === "failed" && extractErr) {
+      throw new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        `Image extraction failed: ${summarizeAiStepError(extractErr)}`
+      )
+    }
+
+    throw new MedusaError(
+      MedusaError.Types.UNEXPECTED_STATE,
+      "Image extraction produced no result (no items and no step error)"
+    )
   }
 )
 


### PR DESCRIPTION
## Root cause (proven end-to-end via prod CloudWatch + live repro)

`import-from-image` failed with Cloudflare `cannot identify image file <_io.BytesIO object>`. It was **not** the AI provider — Gemma-4 + our exact OpenAI-compat request reads a valid JPEG fine (verified live against the prod CF account). The stored image at `automatic.jaalyantra.com/automatica/…` was **binary-corrupted**:

- Valid JPEG: `FF D8 FF E0 …` → stored as `C3 BF C3 98 …`, 220 KB → 328 KB.
- `stored.decode("utf-8").encode("latin-1")` reconstructs the original **byte-for-byte**.

**Why:** `POST /admin/medias` (and the `[id]/upload` + `folder/[id]/upload` variants) serialized content with `buffer.toString("binary")` (latin1). The Medusa file provider (`local-file`/`file-s3`, `services/*-file.js`) does:
```js
const decoded = Buffer.from(content, "base64")
if (decoded.toString("base64") === content) content = decoded   // base64 → lossless
else content = Buffer.from(content, "utf8")                      // else → UTF-8 re-encode (corruption)
```
A latin1 binary string isn't valid base64 → it takes the `utf8` branch → every byte ≥ 0x80 doubles.

## Fix
`toString("binary")` → **`toString("base64")`** in the 3 admin routes. The provider then takes the lossless base64 branch (verified identical in local + prod S3 providers).

## Won't break other uploads
Every other upload path **already uses base64** — `partners/uploads`, `partners/designs|production-runs media`, `payment-submissions/documents`, `whatsapp-media-helper` (which documents this exact mojibake), `ai/generate-design-image`. The 3 admin routes were the only ones on `"binary"`. ASCII uploads are unaffected (they round-trip either way).

## Tests
New `integration-tests/http/media-upload-binary-integrity.spec.ts` uploads byte ≥0x80 payloads via the real route and asserts the stored file is byte-for-byte identical. **Red/green verified:** reverting to `"binary"` fails it (2054→3084, 2048→4096); ASCII + the existing 7-test media suite stay green. `tsc` clean on touched files.

## Existing corrupted files
The already-stored corrupted images are losslessly reversible (`utf-8`-decode → `latin-1`-encode). Re-upload after deploy, or I can add a `repair-corrupted-media` Data-Plumbing job if you want to heal them in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)