### PR TITLE
test(771): integration tests for inventory-order status WhatsApp flow (install + execution)

### DIFF
--- a/apps/backend/integration-tests/http/inventory-order-status-flow-execution.spec.ts
+++ b/apps/backend/integration-tests/http/inventory-order-status-flow-execution.spec.ts
@@ -1,0 +1,87 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import visualFlowEventTriggerHandler from "../../src/subscribers/visual-flow-event-trigger"
+import { VISUAL_FLOWS_MODULE } from "../../src/modules/visual_flows"
+import { FLOW_DEF } from "../../src/scripts/seed-inventory-order-status-flow"
+
+jest.setTimeout(60 * 1000)
+
+/**
+ * Execution-level integration for the #771/#788 inventory-order → WhatsApp flow.
+ *
+ * The install spec proves the flow gets CREATED; this proves it RUNS: firing the
+ * real `inventory_orders.inventory-order.status-changed` event dispatches the
+ * flow and it executes its whole graph (read_data → execute_code → condition →
+ * log/send) to completion.
+ *
+ * We drive a deterministic, provider-independent path: the event targets an order
+ * id that doesn't exist, so `resolve_message` returns `skipped` and the flow
+ * takes the log branch — exercising matching + the full graph WITHOUT needing a
+ * configured WhatsApp SocialPlatform (none exists in the test env). Asserting an
+ * actual Meta send needs a seeded provider + approved template and is out of
+ * scope here.
+ *
+ * ONE test on purpose: the medusa integration runner TRUNCATEs between tests and
+ * that reset can deadlock the @medusajs/index CONCURRENTLY sync; polling to
+ * completion also drains the detached (fire-and-forget) run before teardown.
+ */
+const EVENT_NAME = "inventory_orders.inventory-order.status-changed"
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+async function waitForCompletion(service: any, flowId: string) {
+  for (let i = 0; i < 120; i++) {
+    const execs: any[] = await service.listFlowExecutions(flowId)
+    const done = execs.find((e) => e.status === "completed" || e.status === "failed")
+    if (done) return done
+    await sleep(250)
+  }
+  return null
+}
+
+setupSharedTestSuite(() => {
+  const { getContainer } = getSharedTestEnv()
+
+  describe("inventory-order status flow — execution on status-changed (#771/#788)", () => {
+    it("the status-changed event dispatches the flow and it runs to completion", async () => {
+      const container = getContainer()
+      const service: any = container.resolve(VISUAL_FLOWS_MODULE)
+
+      // Install the real seeded flow, ACTIVE so the event subscriber matches it
+      // (the installer/seed creates it as draft; the subscriber only runs active).
+      const flow = await service.createCompleteFlow({
+        flow: {
+          name: FLOW_DEF.name,
+          description: FLOW_DEF.description,
+          status: "active",
+          trigger_type: FLOW_DEF.trigger_type,
+          trigger_config: FLOW_DEF.trigger_config,
+          canvas_state: FLOW_DEF.canvas_state,
+        },
+        operations: FLOW_DEF.operations,
+        connections: FLOW_DEF.connections,
+      })
+      const flowId = flow.id as string
+
+      // Fire the real #776 event. No such order → resolve_message skips →
+      // log branch → completes (no WhatsApp provider needed).
+      await visualFlowEventTriggerHandler({
+        event: {
+          name: EVENT_NAME,
+          data: {
+            id: "inv_order_does_not_exist_xyz",
+            previous_status: "Processing",
+            status: "Shipped",
+          },
+        },
+        container,
+      } as any)
+
+      const done = await waitForCompletion(service, flowId)
+      // It MATCHED (the trigger_config event_types include the event) and RAN.
+      // A null here means the event never matched the flow — the regression we
+      // care about (event name / trigger_config drift).
+      expect(done).not.toBeNull()
+      expect(done.status).toBe("completed")
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/inventory-order-status-flow-install.spec.ts
+++ b/apps/backend/integration-tests/http/inventory-order-status-flow-install.spec.ts
@@ -1,0 +1,100 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user";
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup";
+
+jest.setTimeout(60000);
+
+/**
+ * API integration test for the #771/#788 inventory-order status flow installer.
+ *
+ * #788 shipped the FLOW_DEF + the `install-inventory-order-status-flow`
+ * Data-Plumbing job with UNIT tests only (FLOW_DEF structure + summary wording).
+ * This exercises the real admin API end-to-end:
+ *   POST /admin/ops/maintenance-jobs/install-inventory-order-status-flow/run
+ * asserting dry-run previews without writing, apply creates the event-triggered
+ * DRAFT flow in the DB, and a re-run is idempotent.
+ */
+const JOB_ID = "install-inventory-order-status-flow";
+const FLOW_NAME = "Partner WhatsApp — Inventory Order Status";
+const EVENT = "inventory_orders.inventory-order.status-changed";
+const VISUAL_FLOWS_MODULE = "visual_flows";
+const RUN_URL = `/admin/ops/maintenance-jobs/${JOB_ID}/run`;
+
+setupSharedTestSuite(() => {
+  let headers;
+  const { api, getContainer } = getSharedTestEnv();
+
+  const flowService = () => getContainer().resolve(VISUAL_FLOWS_MODULE) as any;
+  const findFlow = async () => {
+    const [flow] = await flowService().listVisualFlows({ name: FLOW_NAME });
+    return flow;
+  };
+  const deleteFlowIfExists = async () => {
+    const flow = await findFlow();
+    if (flow) await flowService().deleteVisualFlows(flow.id);
+  };
+
+  beforeEach(async () => {
+    await createAdminUser(getContainer());
+    headers = await getAuthHeaders(api);
+  });
+
+  afterAll(async () => {
+    try {
+      await deleteFlowIfExists();
+    } catch {
+      /* best-effort cleanup */
+    }
+  });
+
+  describe("#788 — install-inventory-order-status-flow data-plumbing job", () => {
+    it("dry-run previews, apply creates the event-triggered draft, re-run is idempotent", async () => {
+      // Clean slate (the shared DB may carry a flow from a prior run).
+      await deleteFlowIfExists();
+
+      // 1) dry-run: previews, writes nothing.
+      const dry = await api.post(RUN_URL, { dry_run: true }, headers);
+      expect(dry.status).toBe(200);
+      expect(dry.data.result.job_id).toBe(JOB_ID);
+      expect(dry.data.result.applied).toBe(false);
+      expect(dry.data.result.summary).toMatch(/would create/i);
+      expect(await findFlow()).toBeFalsy();
+
+      // 2) apply: creates the flow.
+      const apply = await api.post(RUN_URL, { dry_run: false }, headers);
+      expect(apply.status).toBe(200);
+      expect(apply.data.result.applied).toBe(true);
+      expect(apply.data.result.summary).toMatch(/created/i);
+
+      const flow = await findFlow();
+      expect(flow).toBeTruthy();
+      expect(flow.name).toBe(FLOW_NAME);
+      expect(flow.status).toBe("draft");
+      expect(flow.trigger_type).toBe("event");
+      expect(flow.trigger_config?.event_types).toContain(EVENT);
+
+      // 3) re-run apply: idempotent, never overwrites.
+      const again = await api.post(RUN_URL, { dry_run: false }, headers);
+      expect(again.status).toBe(200);
+      expect(again.data.result.applied).toBe(false);
+      expect(again.data.result.summary).toMatch(/already installed/i);
+
+      // Still exactly one flow with this name.
+      const all = await flowService().listVisualFlows({ name: FLOW_NAME });
+      expect(all.length).toBe(1);
+    });
+
+    it("returns 404 for an unknown job id", async () => {
+      const res = await api
+        .post(`/admin/ops/maintenance-jobs/not-a-real-job/run`, { dry_run: true }, headers)
+        .catch((e) => e.response);
+      expect(res.status).toBe(404);
+    });
+
+    it("requires admin auth", async () => {
+      const res = await api
+        .post(RUN_URL, { dry_run: true })
+        .catch((e) => e.response);
+      expect([401, 403]).toContain(res.status);
+    });
+  });
+});


### PR DESCRIPTION
#788 shipped the inventory-order status flow + `install-inventory-order-status-flow` Data-Plumbing job with **unit tests only**. This adds the missing HTTP integration coverage.

- **`inventory-order-status-flow-install.spec.ts`** — `POST /admin/ops/maintenance-jobs/install-inventory-order-status-flow/run`: dry-run previews without writing; apply creates the event-triggered DRAFT flow (verified in DB: name, `status=draft`, `trigger_type=event`, `event_types` includes the #776 event); re-run idempotent. Plus 404 (unknown job) + auth-required.
- **`inventory-order-status-flow-execution.spec.ts`** — fires the real `inventory_orders.inventory-order.status-changed` event and asserts the flow **matches + executes its whole graph to completion** (read_data → execute_code → condition → log). Deterministic skip path → no WhatsApp provider needed; a real Meta-send assertion needs a seeded SocialPlatform (out of scope).

Both green via `pnpm test:integration:http:shared`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)