### PR TITLE
feat(771): register jyt_inventory_order_status_v1 WhatsApp template for Meta approval

### DIFF
--- a/apps/backend/src/scripts/manage-whatsapp-templates.ts
+++ b/apps/backend/src/scripts/manage-whatsapp-templates.ts
@@ -40,6 +40,7 @@ import {
   type TemplateLanguageVariant,
 } from "./whatsapp-templates/partner-run-templates"
 import { PARTNER_PAYMENT_TEMPLATES } from "./whatsapp-templates/partner-payment-templates"
+import { INVENTORY_ORDER_TEMPLATES } from "./whatsapp-templates/inventory-order-templates"
 
 // All templates this script manages. Add a new TemplateSpec[] here when
 // a new domain (e.g. shipping notifications) joins the system — Meta
@@ -47,6 +48,7 @@ import { PARTNER_PAYMENT_TEMPLATES } from "./whatsapp-templates/partner-payment-
 const ALL_TEMPLATES: TemplateSpec[] = [
   ...PARTNER_RUN_TEMPLATES,
   ...PARTNER_PAYMENT_TEMPLATES,
+  ...INVENTORY_ORDER_TEMPLATES, // #771 inventory-order status notifications
 ]
 
 const GRAPH_API_BASE = "https://graph.facebook.com/v21.0"

--- a/apps/backend/src/scripts/whatsapp-templates/__tests__/inventory-order-templates.unit.spec.ts
+++ b/apps/backend/src/scripts/whatsapp-templates/__tests__/inventory-order-templates.unit.spec.ts
@@ -1,0 +1,45 @@
+import { INVENTORY_ORDER_TEMPLATES } from "../inventory-order-templates"
+import { FLOW_DEF } from "../../seed-inventory-order-status-flow"
+
+/**
+ * #771 — the inventory-order status flow sends `jyt_inventory_order_status_v1`.
+ * This template must (a) exist in the registry so manage-whatsapp-templates.ts
+ * pushes it to Meta for approval, and (b) match the contract the flow relies on
+ * (name + 3 positional vars). Meta also enforces an identical body shape across
+ * languages, so we pin that too.
+ */
+const countPlaceholders = (body: string): number => {
+  const set = new Set((body.match(/\{\{\s*(\d+)\s*\}\}/g) ?? []).map((m) => m.replace(/\D/g, "")))
+  return set.size
+}
+
+describe("inventory-order WhatsApp template registry", () => {
+  const tpl = INVENTORY_ORDER_TEMPLATES.find(
+    (t) => t.name === "jyt_inventory_order_status_v1"
+  )
+
+  it("registers jyt_inventory_order_status_v1 as a UTILITY template", () => {
+    expect(tpl).toBeTruthy()
+    expect(tpl!.category).toBe("UTILITY")
+    expect(tpl!.languages.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it("uses exactly 3 positional placeholders, identical across languages, with matching examples", () => {
+    const counts = tpl!.languages.map((l) => countPlaceholders(l.body))
+    // Meta requires identical body shape across language variants.
+    expect(new Set(counts).size).toBe(1)
+    expect(counts[0]).toBe(3) // {{1}} partner, {{2}} order id, {{3}} status label
+    // Every placeholder needs an example or Meta rejects the template.
+    for (const l of tpl!.languages) {
+      expect(l.examples.length).toBe(3)
+    }
+  })
+
+  it("the flow sends exactly this template name (no drift)", () => {
+    // resolve_message embeds the template name as a literal in its code string.
+    const code = (FLOW_DEF.operations.find(
+      (o) => o.operation_key === "resolve_message"
+    )!.options as any).code as string
+    expect(code).toContain("jyt_inventory_order_status_v1")
+  })
+})

--- a/apps/backend/src/scripts/whatsapp-templates/inventory-order-templates.ts
+++ b/apps/backend/src/scripts/whatsapp-templates/inventory-order-templates.ts
@@ -1,0 +1,48 @@
+/**
+ * WhatsApp template spec for inventory-order status notifications (#771).
+ *
+ * One generic UTILITY template the inventory-order status flow
+ * (seed-inventory-order-status-flow.ts) sends on every notified transition
+ * (Processing / Shipped / Partial / Delivered / Cancelled). A single
+ * parameterized template keeps the Meta-approval burden at ONE template instead
+ * of one per status; the human status label is passed as a positional variable.
+ *
+ * Placeholders (positional, must match the flow's `variables` order):
+ *   {{1}} partner first name
+ *   {{2}} inventory order id
+ *   {{3}} human status label ("In Production", "Shipped", "Delivered", …)
+ *
+ * Format follows partner-payment-templates.ts — text-only (no buttons/header)
+ * for fastest approval; body shape identical across languages (Meta enforces);
+ * every placeholder needs an example for approval. Promote to a `_v2` (IMAGE
+ * header) only if we ever need delivery outside the 24h customer-care window.
+ */
+
+import type { TemplateSpec } from "./partner-run-templates"
+
+const TEMPLATE_INVENTORY_ORDER_STATUS: TemplateSpec = {
+  name: "jyt_inventory_order_status_v1",
+  category: "UTILITY",
+  languages: [
+    {
+      language: "en",
+      body:
+        "Hi {{1}}, your inventory order {{2}} is now *{{3}}*.\n\n" +
+        "We'll keep you updated as it progresses. " +
+        "Thanks for working with us.",
+      examples: ["Rajesh", "inv_order_01ABC", "Shipped"],
+    },
+    {
+      language: "hi",
+      body:
+        "नमस्ते {{1}}, आपका इन्वेंटरी ऑर्डर {{2}} अब *{{3}}* है।\n\n" +
+        "प्रगति होने पर हम आपको सूचित करते रहेंगे। " +
+        "साथ काम करने के लिए धन्यवाद।",
+      examples: ["राजेश", "inv_order_01ABC", "Shipped"],
+    },
+  ],
+}
+
+export const INVENTORY_ORDER_TEMPLATES: TemplateSpec[] = [
+  TEMPLATE_INVENTORY_ORDER_STATUS,
+]


### PR DESCRIPTION
## Why
The #788 inventory-order status flow sends the template **`jyt_inventory_order_status_v1`**, but that template was never added to the template manager — so there was **nothing to push to Meta/FB for approval**, and the flow can't actually send once activated. (Flagged by @saranshforgpay.)

## Changes
- **`src/scripts/whatsapp-templates/inventory-order-templates.ts`** — one `UTILITY` template, `en` + `hi`, 3 positional vars (`{{1}}` partner, `{{2}}` order id, `{{3}}` status label) matching the flow's `variables` order. Text-only (fastest approval).
- **`manage-whatsapp-templates.ts`** — added to `ALL_TEMPLATES` so dry-run/upsert/cleanup submit it to every configured WABA.
- **3 unit tests** — registered + UTILITY; identical 3-placeholder shape across languages with matching examples (Meta-enforced); the flow's literal template name matches the registry (drift guard).

## Go-live (operator)
```
MODE=dry-run npx medusa exec ./src/scripts/manage-whatsapp-templates.ts   # preview
MODE=upsert  npx medusa exec ./src/scripts/manage-whatsapp-templates.ts   # submit to Meta
```
Then (after Meta approves): Settings → Data Plumbing → "Install inventory-order status visual flow" → flip the flow draft→active.

## Related
- #788 (flow + installer, merged), #791 (integration tests). Completes the send path for #771.

🤖 Generated with [Claude Code](https://claude.com/claude-code)