### PR TITLE
fix(781): admin Delivered posts stock + non-destructive update compensation (#778 MEDIUMs)

### DIFF
--- a/apps/backend/integration-tests/http/inventory-orders-api.spec.ts
+++ b/apps/backend/integration-tests/http/inventory-orders-api.spec.ts
@@ -380,6 +380,54 @@ setupSharedTestSuite(() => {
         expect(res.data.message).toBe('Invalid request: Value for field \'quantity\' too small, expected at least: \'0\'');
       });
 
+      // #778 C2 admin-half — admin marking an order Delivered must POST stock to
+      // the destination location (mirroring partner-complete), not just write the
+      // status column, and record the delivered lines so a later cancel reverses.
+      it("should post stock to the destination location when an admin marks an order Delivered", async () => {
+        const invRes = await api.post("/admin/inventory-items", {
+          title: "Deliverable Inventory",
+          description: "for admin-delivered stock posting",
+        }, headers);
+        expect(invRes.status).toBe(200);
+        const itemId = invRes.data.inventory_item.id;
+
+        const destLoc = await api.post("/admin/stock-locations", { name: "Dest Warehouse" }, headers);
+        const destLocId = destLoc.data.stock_location.id;
+
+        const orderPayload = {
+          order_lines: [{ inventory_item_id: itemId, quantity: 3, price: 100 }],
+          quantity: 3,
+          total_price: 300,
+          status: "Processing",
+          expected_delivery_date: new Date().toISOString(),
+          order_date: new Date().toISOString(),
+          shipping_address: {},
+          stock_location_id: destLocId,
+          from_stock_location_id: fromStockLocationId,
+        };
+        const orderRes = await api.post("/admin/inventory-orders", orderPayload, headers);
+        expect(orderRes.status).toBe(201);
+        const orderId = orderRes.data.inventoryOrder.id;
+
+        // Mark Delivered via the generic admin PUT.
+        const putRes = await api.put(`/admin/inventory-orders/${orderId}`, { status: "Delivered" }, headers);
+        expect(putRes.status).toBe(200);
+
+        // Stock for the item must now be posted at the destination location.
+        const levelRes = await api.get(`/admin/inventory-items/${itemId}?fields=*location_levels`, headers);
+        expect(levelRes.status).toBe(200);
+        const levels = levelRes.data.inventory_item.location_levels || [];
+        const destLevel = levels.find((l: any) => l.location_id === destLocId);
+        expect(destLevel).toBeDefined();
+        expect(destLevel.stocked_quantity).toBe(3);
+
+        // The delivered lines must be recorded for cancel reversal.
+        const orderGet = await api.get(`/admin/inventory-orders/${orderId}?fields=id,status,metadata`, headers);
+        expect(orderGet.data.inventoryOrder.status).toBe("Delivered");
+        const delivered = orderGet.data.inventoryOrder.metadata?.partner_delivered_lines || [];
+        expect(delivered).toEqual([{ order_line_id: expect.any(String), quantity: 3 }]);
+      });
+
 
     });
 });

--- a/apps/backend/src/workflows/inventory_orders/__tests__/deliver-helpers.unit.spec.ts
+++ b/apps/backend/src/workflows/inventory_orders/__tests__/deliver-helpers.unit.spec.ts
@@ -1,0 +1,104 @@
+import {
+  evaluateAdminStatusTransition,
+  computeAdminDeliveryPosting,
+} from "../lib/deliver-helpers"
+
+describe("evaluateAdminStatusTransition (#778 M / C2 admin-half)", () => {
+  it("allows field-only edits while Pending/Processing (no stock impact)", () => {
+    expect(evaluateAdminStatusTransition("Pending", undefined)).toEqual({ postStock: false })
+    expect(evaluateAdminStatusTransition("Processing", null)).toEqual({ postStock: false })
+    // same-status writes are field edits too
+    expect(evaluateAdminStatusTransition("Processing", "Processing")).toEqual({ postStock: false })
+  })
+
+  it("preserves the editor lock once the order has left Pending/Processing", () => {
+    for (const s of ["Shipped", "Delivered", "Cancelled", "Partial"]) {
+      expect(() => evaluateAdminStatusTransition(s, undefined)).toThrow(
+        "Order can only be updated if status is 'Pending' or 'Processing'."
+      )
+      // even a status change is blocked from a locked state
+      expect(() => evaluateAdminStatusTransition(s, "Delivered")).toThrow(/Pending' or 'Processing'/)
+    }
+  })
+
+  it("flags stock posting only when transitioning to Delivered", () => {
+    expect(evaluateAdminStatusTransition("Processing", "Delivered")).toEqual({ postStock: true })
+    expect(evaluateAdminStatusTransition("Pending", "Delivered")).toEqual({ postStock: true })
+  })
+
+  it("does not post stock for other transitions out of Pending/Processing", () => {
+    // These remain allowed (existing dual-write / unification flows drive them via PUT)
+    expect(evaluateAdminStatusTransition("Pending", "Processing")).toEqual({ postStock: false })
+    expect(evaluateAdminStatusTransition("Processing", "Shipped")).toEqual({ postStock: false })
+    expect(evaluateAdminStatusTransition("Processing", "Cancelled")).toEqual({ postStock: false })
+  })
+})
+
+describe("computeAdminDeliveryPosting (#778 C2 admin-half)", () => {
+  const lineWithItem = (id: string, quantity: number, itemId: string, locId?: string) => ({
+    id,
+    quantity,
+    inventory_items: [
+      { id: itemId, stock_locations: locId ? [{ id: locId }] : [] },
+    ],
+  })
+
+  it("posts the full ordered quantity at the order destination location when nothing delivered yet", () => {
+    const { levels, deliveredRecords } = computeAdminDeliveryPosting(
+      [lineWithItem("ol_1", 10, "iitem_1"), lineWithItem("ol_2", 5, "iitem_2")],
+      [],
+      "sloc_dest"
+    )
+    expect(levels).toEqual([
+      { location_id: "sloc_dest", inventory_item_id: "iitem_1", stocked_quantity: 10 },
+      { location_id: "sloc_dest", inventory_item_id: "iitem_2", stocked_quantity: 5 },
+    ])
+    expect(deliveredRecords).toEqual([
+      { order_line_id: "ol_1", quantity: 10 },
+      { order_line_id: "ol_2", quantity: 5 },
+    ])
+  })
+
+  it("posts only the remaining quantity for a partially-delivered order (no double-post)", () => {
+    const { levels, deliveredRecords } = computeAdminDeliveryPosting(
+      [lineWithItem("ol_1", 10, "iitem_1")],
+      [{ order_line_id: "ol_1", quantity: 4 }],
+      "sloc_dest"
+    )
+    expect(levels).toEqual([
+      { location_id: "sloc_dest", inventory_item_id: "iitem_1", stocked_quantity: 6 },
+    ])
+    expect(deliveredRecords).toEqual([{ order_line_id: "ol_1", quantity: 6 }])
+  })
+
+  it("skips lines already fully delivered", () => {
+    const { levels, deliveredRecords } = computeAdminDeliveryPosting(
+      [lineWithItem("ol_1", 10, "iitem_1")],
+      [{ order_line_id: "ol_1", quantity: 10 }],
+      "sloc_dest"
+    )
+    expect(levels).toEqual([])
+    expect(deliveredRecords).toEqual([])
+  })
+
+  it("falls back to the inventory item's own first linked location when the order has none", () => {
+    const { levels } = computeAdminDeliveryPosting(
+      [lineWithItem("ol_1", 3, "iitem_1", "sloc_item")],
+      [],
+      null
+    )
+    expect(levels).toEqual([
+      { location_id: "sloc_item", inventory_item_id: "iitem_1", stocked_quantity: 3 },
+    ])
+  })
+
+  it("records a remainder even when no location resolves (so cancel can reverse), but posts no level", () => {
+    const { levels, deliveredRecords } = computeAdminDeliveryPosting(
+      [{ id: "ol_1", quantity: 7, inventory_items: [{ id: "iitem_1", stock_locations: [] }] }],
+      [],
+      null
+    )
+    expect(levels).toEqual([])
+    expect(deliveredRecords).toEqual([{ order_line_id: "ol_1", quantity: 7 }])
+  })
+})

--- a/apps/backend/src/workflows/inventory_orders/lib/deliver-helpers.ts
+++ b/apps/backend/src/workflows/inventory_orders/lib/deliver-helpers.ts
@@ -1,0 +1,112 @@
+import { MedusaError } from "@medusajs/framework/utils"
+import {
+  aggregateDeliveredByLine,
+  type DeliveredLine,
+  type OrderLineForReversal,
+} from "./cancel-helpers"
+
+/**
+ * #778 C2 (admin half) + state-machine enforcement on the admin update path.
+ *
+ * The generic admin PUT (`update-inventory-orders` workflow) historically only
+ * checked the *current* status (must be Pending/Processing) and never the
+ * *target* — so an admin could write `status: "Delivered"` straight onto the
+ * column, jumping past the stock-posting that the partner-complete path does.
+ * These pure helpers make the transition rules explicit + unit-testable and
+ * compute the stock to post when an admin actually delivers an order.
+ */
+
+/** An order line shaped for delivery stock posting (mirrors the reversal shape). */
+export type OrderLineForDelivery = OrderLineForReversal & {
+  /** Ordered quantity for the line (what a full delivery posts, minus prior deliveries). */
+  quantity: number
+}
+
+/** A computed (item, location, qty) level to post on delivery. */
+export type DeliveryLevelInput = {
+  location_id: string
+  inventory_item_id: string
+  stocked_quantity: number
+}
+
+/** Outcome of evaluating a requested admin status transition. */
+export type AdminTransitionDecision = {
+  /** True when the transition is into "Delivered" and stock must be posted. */
+  postStock: boolean
+}
+
+const FIELD_EDIT_STATUSES = new Set(["Pending", "Processing"])
+
+/**
+ * Enforce the admin-editor status rule and decide whether the update must post
+ * stock. Pure (no container) so it can be unit-tested directly.
+ *
+ * The generic admin PUT only mutates orders that are still Pending or Processing
+ * — the long-standing lock (orders with prior deliveries are Partial/Shipped/
+ * Delivered and must go through their dedicated flows: partner-complete, the
+ * cancel workflow #778 C4, the shipment flow). That lock already prevents the
+ * dangerous "cancel/edit an order that posted stock" cases, so it is preserved
+ * verbatim (including its error message, which other flows assert on).
+ *
+ * The one correctness fix (#778 M / C2 admin-half): a transition *to Delivered*
+ * must POST stock (mirroring the partner-complete posting) rather than silently
+ * writing the status column and bypassing inventory movement. Throws
+ * `INVALID_DATA` when the order is no longer editable.
+ */
+export const evaluateAdminStatusTransition = (
+  current: string | null | undefined,
+  target: string | null | undefined
+): AdminTransitionDecision => {
+  if (!FIELD_EDIT_STATUSES.has(String(current ?? ""))) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "Order can only be updated if status is 'Pending' or 'Processing'."
+    )
+  }
+  const isChange = target !== undefined && target !== null && target !== current
+  return { postStock: isChange && target === "Delivered" }
+}
+
+/**
+ * Compute the stock to post when an admin delivers an order, plus the
+ * delivered-line records to append to `metadata.partner_delivered_lines`.
+ *
+ * Posts only the *remaining* quantity per line (ordered − already delivered, so
+ * delivering a Partial order never double-posts what the partner already
+ * posted), resolved to the same (item, location) the partner-complete path uses:
+ * the line's first linked inventory item at the order's destination location, or
+ * the item's own first linked location as a fallback. Lines with nothing
+ * remaining, or no resolvable item/location, are skipped for posting (but a
+ * resolvable remainder is still recorded so a later cancel reverses it).
+ */
+export const computeAdminDeliveryPosting = (
+  orderlines: OrderLineForDelivery[] | undefined | null,
+  alreadyDelivered: DeliveredLine[] | undefined | null,
+  destLocationId: string | null | undefined
+): { levels: DeliveryLevelInput[]; deliveredRecords: DeliveredLine[] } => {
+  const deliveredByLine = aggregateDeliveredByLine(alreadyDelivered)
+  const levels: DeliveryLevelInput[] = []
+  const deliveredRecords: DeliveredLine[] = []
+
+  for (const ol of (orderlines || []).filter(Boolean)) {
+    const ordered = Number(ol.quantity) || 0
+    const already = deliveredByLine[ol.id] || 0
+    const remaining = ordered - already
+    if (remaining <= 0) continue
+
+    deliveredRecords.push({ order_line_id: ol.id, quantity: remaining })
+
+    const firstItem = ol.inventory_items?.[0]
+    const itemId = firstItem?.id || ol.inventory_item_id
+    const locId = destLocationId || firstItem?.stock_locations?.[0]?.id
+    if (itemId && locId) {
+      levels.push({
+        location_id: String(locId),
+        inventory_item_id: String(itemId),
+        stocked_quantity: remaining,
+      })
+    }
+  }
+
+  return { levels, deliveredRecords }
+}

--- a/apps/backend/src/workflows/inventory_orders/update-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/update-inventory-orders.ts
@@ -1,9 +1,25 @@
-import { createStep, createWorkflow, StepResponse, WorkflowResponse } from "@medusajs/workflows-sdk";
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+  transform,
+  when,
+} from "@medusajs/framework/workflows-sdk";
 import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils";
+import type { Link } from "@medusajs/modules-sdk";
+import type { RemoteQueryFunction, UpdateInventoryLevelInput } from "@medusajs/types";
+import { createInventoryLevelsWorkflow, updateInventoryLevelsWorkflow } from "@medusajs/medusa/core-flows";
 import { ORDER_INVENTORY_MODULE } from "../../modules/inventory_orders";
 import InventoryOrderService from "../../modules/inventory_orders/service";
-import type { Link } from "@medusajs/modules-sdk";
 import { mirrorUnifiedOrderStatusStep } from "./dual-write-unified-order";
+import { resolveExistingLevelsStep } from "./partner-complete-inventory-order";
+import inventoryOrdersStockLocations from "../../links/inventory-orders-stock-locations";
+import {
+  evaluateAdminStatusTransition,
+  computeAdminDeliveryPosting,
+} from "./lib/deliver-helpers";
+import type { DeliveredLine } from "./lib/cancel-helpers";
 
 
 // Types
@@ -29,20 +45,21 @@ export type UpdateInventoryOrderInput = {
   order_lines: UpdateInventoryOrderLineInput[];
 };
 
-// Step 1: Fetch original order and orderlines for compensation
+// Step 1: Fetch original order, enforce the status transition, and decide whether
+// this update must post stock (#778 M1/C2 — admin marking Delivered).
 export const fetchOriginalOrderStep = createStep(
   "fetch-original-inventory-order-step",
-  async (input: { id: string }, { container }) => {
+  async (input: { id: string; data?: { status?: string } }, { container }) => {
     const inventoryOrderService: InventoryOrderService = container.resolve(ORDER_INVENTORY_MODULE);
     const originalOrder = await inventoryOrderService.retrieveInventoryOrder(input.id, { relations: ["orderlines"] });
-    // Only allow update if status is 'Pending' or 'Processing'
-    if (!["Pending", "Processing"].includes(originalOrder.status)) {
-      throw new MedusaError(
-        MedusaError.Types.INVALID_DATA,
-        "Order can only be updated if status is 'Pending' or 'Processing'."
-      );
-    }
-    return new StepResponse(originalOrder, originalOrder); // Save for compensation
+    // #778 — validate the requested transition (throws INVALID_DATA on an illegal
+    // jump, e.g. Processing→Delivered used to silently bypass stock) and learn
+    // whether stock must be posted.
+    const { postStock } = evaluateAdminStatusTransition(
+      (originalOrder as any).status,
+      input.data?.status
+    );
+    return new StepResponse({ originalOrder, postStock }, originalOrder); // Save original for compensation
   },
   // Compensation: no-op (fetch only)
   async () => {}
@@ -50,13 +67,13 @@ export const fetchOriginalOrderStep = createStep(
 
 // Step 2: Update inventory order fields
 export const updateInventoryOrderStep = createStep(
-  "update-inventory-order-step",
+  "update-inventory-order-fields-step",
   async (input: { id: string; data: any }, { container }) => {
     const inventoryOrderService: InventoryOrderService = container.resolve(ORDER_INVENTORY_MODULE);
     const updatedOrder = await inventoryOrderService.updateInventoryOrders({
       selector: {
         id: input.id
-      }, 
+      },
       data: {
         ...input.data
       }
@@ -81,12 +98,21 @@ export const updateOrderLinesStep = createStep(
   async (input: { order_id: string; order_lines: UpdateInventoryOrderLineInput[] }, { container }) => {
     const inventoryOrderService: InventoryOrderService = container.resolve(ORDER_INVENTORY_MODULE);
     const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link;
-    // Fetch current orderlines
+    // Fetch current orderlines so we can capture the exact prior state of every
+    // line we touch — the compensation inverts each operation precisely instead
+    // of nuking + recreating all lines (#778 M — the old compensation soft-deleted
+    // every line and recreated them with NEW ids, breaking external references).
     const currentOrder = await inventoryOrderService.retrieveInventoryOrder(input.order_id, { relations: ["orderlines"] });
     const currentOrderlines = currentOrder.orderlines || [];
-    const originalOrderlines = [...currentOrderlines];
+    const byId = new Map<string, any>(currentOrderlines.map((l: any) => [l.id, l]));
+
+    const created: Array<{ id: string; inventory_item_id?: string }> = [];
+    const updated: Array<{ id: string; prevQuantity: number; prevPrice: any }> = [];
+    const removed: Array<{ id: string; inventory_item_id?: string; quantity: number; price: any }> = [];
+
     // Remove orderlines marked for removal
     for (const line of input.order_lines.filter(l => l.remove && l.id)) {
+      const prev = byId.get(line.id!);
       // Soft delete orderline
       await inventoryOrderService.softDeleteOrderLines(line.id!);
       // Dismiss link between orderline and inventory_item
@@ -100,10 +126,19 @@ export const updateOrderLinesStep = createStep(
           }
         });
       }
+      removed.push({
+        id: line.id!,
+        inventory_item_id: line.inventory_item_id,
+        quantity: prev?.quantity,
+        price: prev?.price,
+      });
     }
     // Update or create orderlines and manage links
     for (const line of input.order_lines.filter(l => !l.remove)) {
       if (line.id) {
+        const prev = byId.get(line.id);
+        // Capture prior values before overwriting so compensation restores them in place.
+        updated.push({ id: line.id, prevQuantity: prev?.quantity, prevPrice: prev?.price });
         // Update orderline fields
         await inventoryOrderService.updateOrderLines({
           selector: { id: line.id },
@@ -115,7 +150,7 @@ export const updateOrderLinesStep = createStep(
         // If inventory_item_id changed, handle link update (not implemented here, but can be compared with currentOrderlines)
       } else {
         // Create orderline
-        const created = await inventoryOrderService.createOrderLines({
+        const created_line = await inventoryOrderService.createOrderLines({
           inventory_orders_id: input.order_id,
           quantity: line.quantity,
           price: line.price,
@@ -124,69 +159,238 @@ export const updateOrderLinesStep = createStep(
         if (line.inventory_item_id) {
           await remoteLink.create({
             [ORDER_INVENTORY_MODULE]: {
-              inventory_order_line_id: created.id
+              inventory_order_line_id: created_line.id
             },
             [Modules.INVENTORY]: {
               inventory_item_id: line.inventory_item_id
             },
             data: {
-              order_line_id: created.id,
+              order_line_id: created_line.id,
               inventory_item_id: line.inventory_item_id
             }
           });
         }
+        created.push({ id: created_line.id, inventory_item_id: line.inventory_item_id });
       }
     }
-    // Return new state and save original for compensation
+    // Return new state and save the precise per-line ops for compensation
     const updatedOrder = await inventoryOrderService.retrieveInventoryOrder(input.order_id, { relations: ["orderlines"] });
-    // Save originalOrderlines and order_id for compensation
-    return new StepResponse(updatedOrder, { originalOrderlines, order_id: input.order_id });
+    return new StepResponse(updatedOrder, { created, updated, removed, order_id: input.order_id });
   },
-  // Compensation: restore all original orderlines (delete new, restore old and relink)
-  async (compensationData: { originalOrderlines: any[]; order_id: string }, { container }) => {
+  // Compensation: invert each forward operation precisely (#778 M).
+  //   - lines we CREATED → soft-delete them + dismiss their links (only the new ids)
+  //   - lines we UPDATED → restore prior quantity/price IN PLACE (stable ids)
+  //   - lines we REMOVED → restore them by id + recreate their links (stable ids)
+  async (
+    compensationData: {
+      created: Array<{ id: string; inventory_item_id?: string }>;
+      updated: Array<{ id: string; prevQuantity: number; prevPrice: any }>;
+      removed: Array<{ id: string; inventory_item_id?: string; quantity: number; price: any }>;
+      order_id: string;
+    },
+    { container }
+  ) => {
     const inventoryOrderService: InventoryOrderService = container.resolve(ORDER_INVENTORY_MODULE);
     const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link;
-    // Remove all current orderlines
-    const currentOrder = await inventoryOrderService.retrieveInventoryOrder(compensationData.order_id, { relations: ["orderlines"] });
-    for (const line of currentOrder.orderlines || []) {
-      await inventoryOrderService.softDeleteOrderLines(line.id);
-      // Remove link if exists (need inventory_item_id, which may not be available for deleted lines)
-      // This is a best-effort cleanup
+
+    // Undo created lines
+    for (const c of compensationData.created || []) {
+      await inventoryOrderService.softDeleteOrderLines(c.id);
+      if (c.inventory_item_id) {
+        await remoteLink.dismiss({
+          [ORDER_INVENTORY_MODULE]: { inventory_order_line_id: c.id },
+          [Modules.INVENTORY]: { inventory_item_id: c.inventory_item_id },
+        });
+      }
     }
-    // Restore original orderlines and links
-    for (const orig of compensationData.originalOrderlines) {
-      const restored = await inventoryOrderService.createOrderLines({
-        inventory_orders_id: compensationData.order_id,
-        quantity: orig.quantity,
-        price: orig.price,
+    // Restore updated lines to their prior values (same ids)
+    for (const u of compensationData.updated || []) {
+      await inventoryOrderService.updateOrderLines({
+        selector: { id: u.id },
+        data: { quantity: u.prevQuantity, price: u.prevPrice },
       });
-      if (orig.inventory_item_id) {
+    }
+    // Restore removed lines (same ids) + recreate their links
+    for (const r of compensationData.removed || []) {
+      await inventoryOrderService.restoreOrderLines(r.id);
+      if (r.inventory_item_id) {
         await remoteLink.create({
-          [ORDER_INVENTORY_MODULE]: {
-            inventory_order_line_id: restored.id
-          },
-          [Modules.INVENTORY]: {
-            inventory_item_id: orig.inventory_item_id
-          },
-          data: {
-            order_line_id: restored.id,
-            inventory_item_id: orig.inventory_item_id
-          }
+          [ORDER_INVENTORY_MODULE]: { inventory_order_line_id: r.id },
+          [Modules.INVENTORY]: { inventory_item_id: r.inventory_item_id },
+          data: { order_line_id: r.id, inventory_item_id: r.inventory_item_id },
         });
       }
     }
   }
 );
 
+// Step 4: Load the delivery context (orderlines + their inventory items/locations +
+// the order's destination + prior deliveries) needed to post stock when an admin
+// marks an order Delivered (#778 C2 admin-half). Reused on every update; the
+// computed levels are empty for non-delivery edits so nothing is posted.
+export const loadDeliveryContextStep = createStep(
+  "load-inventory-order-delivery-context-step",
+  async (input: { id: string }, { container }) => {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY) as Omit<RemoteQueryFunction, symbol>;
+    const { data } = await query.graph({
+      entity: "inventory_orders",
+      filters: { id: input.id },
+      fields: [
+        "id",
+        "status",
+        "metadata",
+        "orderlines.id",
+        "orderlines.quantity",
+        "orderlines.inventory_items.id",
+        "orderlines.inventory_items.stock_locations.id",
+      ],
+    });
+    const order = (data?.[0] as any) || {};
+
+    // Resolve the DESTINATION (to_location) explicitly via the order↔stock-location
+    // link's `to_location` flag — the order links BOTH a from- and a to-location to
+    // the same relation, so a positional `[0]` could resolve to the wrong warehouse.
+    let destLocationId: string | null = null;
+    try {
+      const { data: locLinks } = await query.graph({
+        entity: inventoryOrdersStockLocations.entryPoint,
+        filters: { inventory_orders_id: input.id },
+        fields: ["stock_location_id", "to_location", "from_location"],
+      });
+      const links = (locLinks || []) as any[];
+      const toLink = links.find((l) => l?.to_location);
+      destLocationId =
+        toLink?.stock_location_id ||
+        links.find((l) => !l?.from_location)?.stock_location_id ||
+        null;
+    } catch {
+      /* fall back to the item's own linked location in the helper */
+    }
+    const alreadyDelivered = (order.metadata?.partner_delivered_lines || []) as DeliveredLine[];
+    return new StepResponse({
+      orderlines: order.orderlines || [],
+      alreadyDelivered,
+      destLocationId,
+    });
+  }
+);
+
+// Step 5: Append the admin-delivered line records to metadata.partner_delivered_lines
+// so a later cancel reverses the full posted stock (#778 C2/C4). Reads-then-merges
+// to avoid clobbering the rest of the metadata blob.
+export const appendDeliveredLinesStep = createStep(
+  "append-admin-delivered-lines-step",
+  async (input: { id: string; records: DeliveredLine[] }, { container }) => {
+    const inventoryOrderService: InventoryOrderService = container.resolve(ORDER_INVENTORY_MODULE);
+    const order = await inventoryOrderService.retrieveInventoryOrder(input.id, { select: ["id", "metadata"] });
+    const meta = ((order as any)?.metadata || {}) as Record<string, any>;
+    const prev = Array.isArray(meta.partner_delivered_lines) ? meta.partner_delivered_lines : [];
+    await inventoryOrderService.updateInventoryOrders({
+      id: input.id,
+      metadata: { ...meta, partner_delivered_lines: [...prev, ...input.records] },
+    });
+    return new StepResponse({ appended: input.records.length }, { id: input.id, metadata: meta });
+  },
+  // Compensation: restore the prior metadata blob.
+  async (comp: { id: string; metadata: Record<string, any> } | undefined, { container }) => {
+    if (!comp) return;
+    const inventoryOrderService: InventoryOrderService = container.resolve(ORDER_INVENTORY_MODULE);
+    await inventoryOrderService.updateInventoryOrders({ id: comp.id, metadata: comp.metadata });
+  }
+);
+
 export const updateInventoryOrderWorkflow = createWorkflow(
-  { 
+  {
     name: "update-inventory-order-workflow",
     store: true
   },
   (input: UpdateInventoryOrderInput) => {
-    const original = fetchOriginalOrderStep({ id: input.id });
+    const original = fetchOriginalOrderStep({ id: input.id, data: input.data });
     const updatedOrder = updateInventoryOrderStep({ id: input.id, data: input.data });
     const updatedOrderlines = updateOrderLinesStep({ order_id: input.id, order_lines: input.order_lines });
+
+    // #778 C2 admin-half — when this update delivers the order, post the remaining
+    // stock per line (ordered − already delivered) to the destination location,
+    // mirroring the partner-complete posting. Sequenced after the field/line
+    // updates so the metadata merge sees the latest order state.
+    const postStock = transform({ original }, ({ original }) => Boolean((original as any)?.postStock));
+    // Depend on both prior updates so the delivery context + metadata merge see the
+    // latest order state (and never clobber a metadata write from the field update).
+    const readyId = transform({ updatedOrder, updatedOrderlines, input }, ({ input }) => input.id);
+    const deliveryCtx = loadDeliveryContextStep({ id: readyId as unknown as string });
+
+    const computed = transform(
+      { deliveryCtx, postStock },
+      ({ deliveryCtx, postStock }) =>
+        postStock
+          ? computeAdminDeliveryPosting(
+              (deliveryCtx as any).orderlines,
+              (deliveryCtx as any).alreadyDelivered,
+              (deliveryCtx as any).destLocationId
+            )
+          : { levels: [], deliveredRecords: [] }
+    );
+    const levels = transform({ computed }, ({ computed }) => (computed as any).levels);
+    const deliveredRecords = transform({ computed }, ({ computed }) => (computed as any).deliveredRecords);
+
+    const resolved = resolveExistingLevelsStep({ levels: levels as any }) as any;
+    const existing = transform({ resolved }, ({ resolved }) => (resolved?.existing || []));
+
+    // (item, location) pairs with no existing level need creating first.
+    const missing = transform<{ existing: any[]; levels: any[] }, any[]>(
+      { existing, levels },
+      ({ existing, levels }) => {
+        const exArr = (existing as any[]) || [];
+        const lvlArr = (levels as any[]) || [];
+        return lvlArr.filter((l: any) =>
+          !exArr.some((ex: any) => ex.inventory_item_id === l.inventory_item_id && ex.location_id === l.location_id)
+        );
+      }
+    );
+    const createInputs = transform({ missing }, ({ missing }) =>
+      ((missing as any[]) || []).map((m: any) => ({
+        inventory_item_id: String(m.inventory_item_id),
+        location_id: String(m.location_id),
+        stocked_quantity: Number(m.stocked_quantity || 0),
+        incoming_quantity: 0,
+      }))
+    );
+    const hasCreates = transform({ createInputs }, ({ createInputs }) => Array.isArray(createInputs) && (createInputs as any[]).length > 0);
+    when(hasCreates, (b) => Boolean(b)).then(() => {
+      createInventoryLevelsWorkflow.runAsStep({
+        input: { inventory_levels: createInputs as unknown as any[] },
+      });
+    });
+
+    const updates = transform<{ existing: any[]; levels: any[] }, UpdateInventoryLevelInput[]>(
+      { existing, levels },
+      ({ existing, levels }) => {
+        const lvlArr = (levels as any[]) || [];
+        const exArr = (existing as any[]) || [];
+        return exArr.map((ex: any) => {
+          const found = lvlArr.find(
+            (l: any) => l.inventory_item_id === ex.inventory_item_id && l.location_id === ex.location_id
+          );
+          const add = Number(found?.stocked_quantity || 0);
+          return {
+            id: String(ex.id),
+            inventory_item_id: String(ex.inventory_item_id),
+            location_id: String(ex.location_id),
+            stocked_quantity: Number(ex.stocked_quantity || 0) + add,
+          };
+        });
+      }
+    );
+    const hasUpdates = transform({ updates }, ({ updates }) => Array.isArray(updates) && (updates as any[]).length > 0);
+    when(hasUpdates, (b) => Boolean(b)).then(() => {
+      updateInventoryLevelsWorkflow.runAsStep({ input: { updates: updates as unknown as UpdateInventoryLevelInput[] } });
+    });
+
+    const shouldRecord = transform({ deliveredRecords }, ({ deliveredRecords }) => Array.isArray(deliveredRecords) && (deliveredRecords as any[]).length > 0);
+    when(shouldRecord, (b) => Boolean(b)).then(() => {
+      appendDeliveredLinesStep({ id: input.id, records: deliveredRecords as unknown as DeliveredLine[] });
+    });
+
     // #342 — best-effort §5 status mirror onto the unified core order
     mirrorUnifiedOrderStatusStep({ inventoryOrderId: input.id });
     return new WorkflowResponse({ order: updatedOrder, orderlines: updatedOrderlines });

--- a/apps/backend/workflow-schemas.json
+++ b/apps/backend/workflow-schemas.json
@@ -1170,6 +1170,37 @@
     "source": "custom_ts",
     "sourceFile": "src/workflows/analytics/delete-analytics-event.ts"
   },
+  "get-partner-storefront-digest": {
+    "fields": [
+      {
+        "name": "partner_id",
+        "type": "id",
+        "required": true,
+        "placeholder": "{{ $last.partner_id }}"
+      },
+      {
+        "name": "period",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.period }}"
+      },
+      {
+        "name": "thresholds",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.thresholds }}"
+      },
+      {
+        "name": "now",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.now }}",
+        "description": "Compute a per-partner storefront analytics digest (#581 S1). Given a partner id + period it resolves the partner's website, runs the #569 overview for the current AND previous windows (for deltas), pulls the #559 breakdowns the digest surfaces, and assembles a digest JSON with rule-based suggestions (pure helpers in `partner-digest-lib.ts`). Per-partner scoping: a partner's analytics = their website's events. The website is resolved from the partner's `website_id` column (metadata fallback), then `storefront_domain` — mirroring `api/partners/storefront/helpers.ts#getPartnerWebsite`. / export type GetPartnerStorefrontDigestInput = { partner_id: string; period?: DigestPeriod; thresholds?: Partial<DigestThresholds>; /** ISO timestamp; injectable for deterministic runs. Defaults to now."
+      }
+    ],
+    "source": "custom_ts",
+    "sourceFile": "src/workflows/analytics/get-partner-storefront-digest.ts"
+  },
   "get-website-analytics-overview": {
     "fields": [
       {
@@ -1248,6 +1279,49 @@
     "source": "custom_ts",
     "sourceFile": "src/workflows/analytics/list-analytics-event.ts"
   },
+  "get-analytics-breakdown": {
+    "fields": [
+      {
+        "name": "website_id",
+        "type": "id",
+        "required": true,
+        "placeholder": "{{ $last.website_id }}"
+      },
+      {
+        "name": "dimension",
+        "type": "string",
+        "required": true,
+        "placeholder": "{{ $last.dimension }}"
+      },
+      {
+        "name": "start_date",
+        "type": "date",
+        "required": false,
+        "placeholder": "{{ $trigger.start_date }}"
+      },
+      {
+        "name": "end_date",
+        "type": "date",
+        "required": false,
+        "placeholder": "{{ $trigger.end_date }}"
+      },
+      {
+        "name": "filters",
+        "type": "object",
+        "required": false,
+        "placeholder": "{}",
+        "description": "Get Analytics Breakdown (#559 slice 3) Granular single-dimension breakdown of a website's events, with composable equality filters and an optional date range. Complements the high-level getAnalyticsStatsWorkflow which returns a fixed set of aggregates. / export type GetAnalyticsBreakdownInput = { website_id: string; dimension: BreakdownDimension; start_date?: Date; end_date?: Date; /** Composable equality filters keyed by filterable field name."
+      },
+      {
+        "name": "limit",
+        "type": "number",
+        "required": false,
+        "placeholder": "0"
+      }
+    ],
+    "source": "custom_ts",
+    "sourceFile": "src/workflows/analytics/reports/get-analytics-breakdown.ts"
+  },
   "get-analytics-stats": {
     "fields": [
       {
@@ -1301,6 +1375,91 @@
     ],
     "source": "custom_ts",
     "sourceFile": "src/workflows/analytics/reports/get-analytics-timeseries.ts"
+  },
+  "get-outbound-links": {
+    "fields": [
+      {
+        "name": "website_id",
+        "type": "id",
+        "required": true,
+        "placeholder": "{{ $last.website_id }}"
+      },
+      {
+        "name": "start_date",
+        "type": "date",
+        "required": false,
+        "placeholder": "{{ $trigger.start_date }}"
+      },
+      {
+        "name": "end_date",
+        "type": "date",
+        "required": false,
+        "placeholder": "{{ $trigger.end_date }}"
+      },
+      {
+        "name": "limit",
+        "type": "number",
+        "required": false,
+        "placeholder": "0"
+      }
+    ],
+    "source": "custom_ts",
+    "sourceFile": "src/workflows/analytics/reports/get-outbound-links.ts"
+  },
+  "get-session-pages": {
+    "fields": [
+      {
+        "name": "website_id",
+        "type": "id",
+        "required": true,
+        "placeholder": "{{ $last.website_id }}"
+      },
+      {
+        "name": "start_date",
+        "type": "date",
+        "required": false,
+        "placeholder": "{{ $trigger.start_date }}"
+      },
+      {
+        "name": "end_date",
+        "type": "date",
+        "required": false,
+        "placeholder": "{{ $trigger.end_date }}"
+      },
+      {
+        "name": "dimensions",
+        "type": "array",
+        "required": false,
+        "placeholder": "{{ $last.dimensions }}",
+        "description": "Get Session Pages Breakdown (#569 S2) Ranked aggregation of a website's analytics sessions by their entry and/or exit page, over an optional date range. Complements the events breakdown (getAnalyticsBreakdownWorkflow) which groups raw events; here we group sessions so the admin can see \"top landing pages\" and \"top exit pages\". There is NO website→analytics_session module link, so sessions are resolved directly off the custom_analytics service (mirrors get-website-analytics- overview's S1 session fetch). The fetch is best-effort: a missing service/method or query error degrades to empty (zeroed) breakdowns rather than throwing. / export type GetSessionPagesInput = { website_id: string; start_date?: Date; end_date?: Date; /** Which page dimensions to compute. Defaults to both entry + exit."
+      },
+      {
+        "name": "limit",
+        "type": "number",
+        "required": false,
+        "placeholder": "0"
+      }
+    ],
+    "source": "custom_ts",
+    "sourceFile": "src/workflows/analytics/reports/get-session-pages.ts"
+  },
+  "get-website-sessions": {
+    "fields": [
+      {
+        "name": "id",
+        "type": "id",
+        "required": false,
+        "placeholder": "{{ $last.id }}"
+      },
+      {
+        "name": "data",
+        "type": "object",
+        "required": false,
+        "placeholder": "{}"
+      }
+    ],
+    "source": "inferred",
+    "sourceFile": "src/workflows/analytics/reports/get-website-sessions.ts"
   },
   "track-analytics-event": {
     "fields": [
@@ -1363,6 +1522,30 @@
         "type": "date",
         "required": true,
         "placeholder": "{{ $trigger.timestamp }}"
+      },
+      {
+        "name": "client_event_id",
+        "type": "id",
+        "required": false,
+        "placeholder": "{{ $last.client_event_id }}"
+      },
+      {
+        "name": "country",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.country }}"
+      },
+      {
+        "name": "timezone",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.timezone }}"
+      },
+      {
+        "name": "locale",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.locale }}"
       },
       {
         "name": "query_string",
@@ -3089,6 +3272,12 @@
         "type": "array",
         "required": false,
         "placeholder": "{{ $last.inventoryOrderIds }}"
+      },
+      {
+        "name": "attachments",
+        "type": "array",
+        "required": false,
+        "placeholder": "{{ $last.attachments }}"
       }
     ],
     "source": "custom_ts",
@@ -3353,6 +3542,64 @@
     "source": "custom_ts",
     "sourceFile": "src/workflows/inventory/split-inventory-item.ts"
   },
+  "create-inventory-order-shipment": {
+    "fields": [
+      {
+        "name": "orderId",
+        "type": "string",
+        "required": true,
+        "placeholder": "{{ $last.orderId }}"
+      },
+      {
+        "name": "carrier",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.carrier }}",
+        "description": "Generate a real carrier shipment (forward → AWB → label) for a partner inventory-order completion and persist the carrier refs onto the inventory order (#772). Opt-in: invoked only when the partner asked to generate a shipment; the legacy free-text `partner_tracking_number` path is untouched otherwise. Pickup bootstrap: when a source stock location is given, ensure it's a registered carrier pickup via `registerShiprocketPickup` (lists first, then registers from the location's address — handles the \"first time, no pickup yet\" case). Otherwise fall back to any registered pickup. A clean MedusaError (not a 500) is thrown when no pickup can be resolved so the UI shows an actionable message. / export type CreateInventoryOrderShipmentInput = { orderId: string /** Defaults to \"shiprocket\"."
+      },
+      {
+        "name": "pickupStockLocationId",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.pickupStockLocationId }}",
+        "description": "Generate a real carrier shipment (forward → AWB → label) for a partner inventory-order completion and persist the carrier refs onto the inventory order (#772). Opt-in: invoked only when the partner asked to generate a shipment; the legacy free-text `partner_tracking_number` path is untouched otherwise. Pickup bootstrap: when a source stock location is given, ensure it's a registered carrier pickup via `registerShiprocketPickup` (lists first, then registers from the location's address — handles the \"first time, no pickup yet\" case). Otherwise fall back to any registered pickup. A clean MedusaError (not a 500) is thrown when no pickup can be resolved so the UI shows an actionable message. / export type CreateInventoryOrderShipmentInput = { orderId: string /** Defaults to \"shiprocket\". */ carrier?: string /** Source stock location to ship from; auto-registered as a pickup if new."
+      },
+      {
+        "name": "weightGrams",
+        "type": "number",
+        "required": false,
+        "placeholder": "0"
+      },
+      {
+        "name": "dimensionsCm",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.dimensionsCm }}"
+      },
+      {
+        "name": "preferredCourierId",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.preferredCourierId }}"
+      },
+      {
+        "name": "deliveredQuantities",
+        "type": "object",
+        "required": false,
+        "placeholder": "{}",
+        "description": "Generate a real carrier shipment (forward → AWB → label) for a partner inventory-order completion and persist the carrier refs onto the inventory order (#772). Opt-in: invoked only when the partner asked to generate a shipment; the legacy free-text `partner_tracking_number` path is untouched otherwise. Pickup bootstrap: when a source stock location is given, ensure it's a registered carrier pickup via `registerShiprocketPickup` (lists first, then registers from the location's address — handles the \"first time, no pickup yet\" case). Otherwise fall back to any registered pickup. A clean MedusaError (not a 500) is thrown when no pickup can be resolved so the UI shows an actionable message. / export type CreateInventoryOrderShipmentInput = { orderId: string /** Defaults to \"shiprocket\". */ carrier?: string /** Source stock location to ship from; auto-registered as a pickup if new. */ pickupStockLocationId?: string weightGrams?: number dimensionsCm?: Dimensions preferredCourierId?: string | number /** Delivered quantities keyed by order_line_id (restricts shipment items)."
+      },
+      {
+        "name": "actingEmail",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.actingEmail }}",
+        "description": "Generate a real carrier shipment (forward → AWB → label) for a partner inventory-order completion and persist the carrier refs onto the inventory order (#772). Opt-in: invoked only when the partner asked to generate a shipment; the legacy free-text `partner_tracking_number` path is untouched otherwise. Pickup bootstrap: when a source stock location is given, ensure it's a registered carrier pickup via `registerShiprocketPickup` (lists first, then registers from the location's address — handles the \"first time, no pickup yet\" case). Otherwise fall back to any registered pickup. A clean MedusaError (not a 500) is thrown when no pickup can be resolved so the UI shows an actionable message. / export type CreateInventoryOrderShipmentInput = { orderId: string /** Defaults to \"shiprocket\". */ carrier?: string /** Source stock location to ship from; auto-registered as a pickup if new. */ pickupStockLocationId?: string weightGrams?: number dimensionsCm?: Dimensions preferredCourierId?: string | number /** Delivered quantities keyed by order_line_id (restricts shipment items). */ deliveredQuantities?: Record<string, number> /** Acting user's email recorded on a freshly-registered pickup (#427)."
+      }
+    ],
+    "source": "custom_ts",
+    "sourceFile": "src/workflows/inventory_orders/create-inventory-order-shipment.ts"
+  },
   "create-inventory-order-tasks-from-templates": {
     "fields": [
       {
@@ -3491,6 +3738,120 @@
     ],
     "source": "custom_ts",
     "sourceFile": "src/workflows/inventory_orders/update-inventory-order.ts"
+  },
+  "generate-ideas-email": {
+    "fields": [
+      {
+        "name": "oneGoal",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.oneGoal }}",
+        "description": "generate-ideas-email.ts — #659 slice 2, PR-2. The \"AI tactical-ideas email\" generate workflow: read today's ground-truth numbers from `marketing_metric_snapshot`, ask the LLM for 3-5 tactical moves (referring to numbers ONLY by {TOKEN} placeholder), run the two-layer hallucination guard (`ideas-email-guard-lib.ts`), regenerate ONCE on failure, then persist a `marketing_ideas_log` row BEFORE anything is ever sent (report §4.3: \"every job writes its result to Postgres before sending\"). Testability: the AI call is an INJECTABLE function (`AiGenerateFn`) — the integration test passes a stub returning fixed `{TOKEN}` copy, so CI NEVER calls a live LLM. The Medusa workflow wrapper injects the real OpenRouter call (mirrors the verified pattern in `src/workflows/ad-planning/sentiment/analyze-sentiment.ts:44-71`). This PR does NOT send the email — `sent` stays false; the send workflow (PR-3) flips it. The job that schedules this (PR-4) stays disabled until the One Goal is picked. / import { createWorkflow, createStep, StepResponse, WorkflowResponse, } from \"@medusajs/framework/workflows-sdk\" import { makeRoleAiGenerate } from \"../../mastra/services/ai-platforms\" import { MARKETING_MODULE } from \"../../modules/marketing\" import type { GroundTruth, GroundTruthValue } from \"./ideas-email-guard-lib\" import { runGuard } from \"./ideas-email-guard-lib\" import { buildIdeasPrompt, STRICTER_SUFFIX } from \"./ideas-email-prompt-lib\" /** An injectable LLM call: prompt in, raw text out (or \"\" on failure). */ export type AiGenerateFn = (prompt: string) => Promise<string> export type GenerateIdeasEmailOptions = { /** Injected for tests; defaults to the role-resolved platform generator (ai_newsletter_drafter → configured platform, else free models). */ aiGenerate?: AiGenerateFn /** The \"One Goal\" string; never invented in code (report §3.6)."
+      },
+      {
+        "name": "businessDescription",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.businessDescription }}",
+        "description": "generate-ideas-email.ts — #659 slice 2, PR-2. The \"AI tactical-ideas email\" generate workflow: read today's ground-truth numbers from `marketing_metric_snapshot`, ask the LLM for 3-5 tactical moves (referring to numbers ONLY by {TOKEN} placeholder), run the two-layer hallucination guard (`ideas-email-guard-lib.ts`), regenerate ONCE on failure, then persist a `marketing_ideas_log` row BEFORE anything is ever sent (report §4.3: \"every job writes its result to Postgres before sending\"). Testability: the AI call is an INJECTABLE function (`AiGenerateFn`) — the integration test passes a stub returning fixed `{TOKEN}` copy, so CI NEVER calls a live LLM. The Medusa workflow wrapper injects the real OpenRouter call (mirrors the verified pattern in `src/workflows/ad-planning/sentiment/analyze-sentiment.ts:44-71`). This PR does NOT send the email — `sent` stays false; the send workflow (PR-3) flips it. The job that schedules this (PR-4) stays disabled until the One Goal is picked. / import { createWorkflow, createStep, StepResponse, WorkflowResponse, } from \"@medusajs/framework/workflows-sdk\" import { makeRoleAiGenerate } from \"../../mastra/services/ai-platforms\" import { MARKETING_MODULE } from \"../../modules/marketing\" import type { GroundTruth, GroundTruthValue } from \"./ideas-email-guard-lib\" import { runGuard } from \"./ideas-email-guard-lib\" import { buildIdeasPrompt, STRICTER_SUFFIX } from \"./ideas-email-prompt-lib\" /** An injectable LLM call: prompt in, raw text out (or \"\" on failure). */ export type AiGenerateFn = (prompt: string) => Promise<string> export type GenerateIdeasEmailOptions = { /** Injected for tests; defaults to the role-resolved platform generator (ai_newsletter_drafter → configured platform, else free models). */ aiGenerate?: AiGenerateFn /** The \"One Goal\" string; never invented in code (report §3.6). */ oneGoal?: string /** Business description fed to the prompt."
+      }
+    ],
+    "source": "custom_ts",
+    "sourceFile": "src/workflows/marketing/generate-ideas-email.ts"
+  },
+  "generate-newsletter-draft": {
+    "fields": [
+      {
+        "name": "topic",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.topic }}",
+        "description": "generate-newsletter-draft.ts — #659 slice (report §12.4). The \"AI newsletter draft generator\": ask the LLM for a customer-facing newsletter (subject / preheader / intro / sections / CTA) and persist it to the EXISTING `marketing_draft` model as an OPERATOR-REVIEW draft. Sending is NOT done here — drafts are reviewed/edited in the (separate) Newsletter editor UI and later enqueued through the existing `src/jobs/process-email-queue.ts`. Reuses the verified generate-ideas-email wiring: - the AI call is an INJECTABLE `AiGenerateFn` (prompt in, text out) so CI never calls a live LLM; the Medusa workflow wrapper injects the real OpenRouter call (mirrors generate-ideas-email.ts:152-168). Unlike the tactical-ideas email this is CUSTOMER-FACING, so it does NOT read internal metric snapshots — we never want raw platform GMV leaking into a brand newsletter. The model is told to avoid inventing specific numbers. Pure, unit-tested helpers: `buildNewsletterPrompt`, `parseNewsletterPayload`, `coerceNewsletterPayload`. / import { createWorkflow, createStep, StepResponse, WorkflowResponse, } from \"@medusajs/framework/workflows-sdk\" import { makeRoleAiGenerate } from \"../../mastra/services/ai-platforms\" import { MARKETING_MODULE } from \"../../modules/marketing\" import type { AiGenerateFn } from \"./generate-ideas-email\" /** Role this generator resolves a platform for (free-model fallback). */ const NEWSLETTER_DRAFT_ROLE = \"ai_newsletter_drafter\" const DEFAULT_BUSINESS_DESCRIPTION = \"JYT is a textile-production commerce platform: it runs an admin storefront \" + \"and onboards partner brands who sell their own products through per-partner \" + \"storefronts.\" /** v1 newsletter voice rules — kept pure (the workflow may pass an override). */ export const NEWSLETTER_VOICE_RULES = [ \"Warm and brand-forward, but never hype. Sound like a real person, not an ad.\", \"Lead with value for the reader; keep paragraphs short and scannable.\", \"Do NOT invent specific numbers, percentages, prices, discounts, or dates.\", \"End with one clear, low-pressure call to action.\", ].join(\"\\n- \") // IST = UTC+5:30. Return the IST calendar date (YYYY-MM-DD) for a UTC instant. function istDateString(d: Date): string { const ist = new Date(d.getTime() + 5.5 * 60 * 60 * 1000) return ist.toISOString().slice(0, 10) } export type NewsletterSection = { heading: string body: string } export type NewsletterPayload = { subject: string preheader: string intro: string sections: NewsletterSection[] cta: string /** true when the model output could not be parsed as JSON and we fell back. */ parse_error?: boolean } export type GenerateNewsletterDraftOptions = { /** Injected for tests; defaults to the real OpenRouter call. */ aiGenerate?: AiGenerateFn /** Operator topic/angle for this newsletter (free text)."
+      },
+      {
+        "name": "businessDescription",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.businessDescription }}",
+        "description": "generate-newsletter-draft.ts — #659 slice (report §12.4). The \"AI newsletter draft generator\": ask the LLM for a customer-facing newsletter (subject / preheader / intro / sections / CTA) and persist it to the EXISTING `marketing_draft` model as an OPERATOR-REVIEW draft. Sending is NOT done here — drafts are reviewed/edited in the (separate) Newsletter editor UI and later enqueued through the existing `src/jobs/process-email-queue.ts`. Reuses the verified generate-ideas-email wiring: - the AI call is an INJECTABLE `AiGenerateFn` (prompt in, text out) so CI never calls a live LLM; the Medusa workflow wrapper injects the real OpenRouter call (mirrors generate-ideas-email.ts:152-168). Unlike the tactical-ideas email this is CUSTOMER-FACING, so it does NOT read internal metric snapshots — we never want raw platform GMV leaking into a brand newsletter. The model is told to avoid inventing specific numbers. Pure, unit-tested helpers: `buildNewsletterPrompt`, `parseNewsletterPayload`, `coerceNewsletterPayload`. / import { createWorkflow, createStep, StepResponse, WorkflowResponse, } from \"@medusajs/framework/workflows-sdk\" import { makeRoleAiGenerate } from \"../../mastra/services/ai-platforms\" import { MARKETING_MODULE } from \"../../modules/marketing\" import type { AiGenerateFn } from \"./generate-ideas-email\" /** Role this generator resolves a platform for (free-model fallback). */ const NEWSLETTER_DRAFT_ROLE = \"ai_newsletter_drafter\" const DEFAULT_BUSINESS_DESCRIPTION = \"JYT is a textile-production commerce platform: it runs an admin storefront \" + \"and onboards partner brands who sell their own products through per-partner \" + \"storefronts.\" /** v1 newsletter voice rules — kept pure (the workflow may pass an override). */ export const NEWSLETTER_VOICE_RULES = [ \"Warm and brand-forward, but never hype. Sound like a real person, not an ad.\", \"Lead with value for the reader; keep paragraphs short and scannable.\", \"Do NOT invent specific numbers, percentages, prices, discounts, or dates.\", \"End with one clear, low-pressure call to action.\", ].join(\"\\n- \") // IST = UTC+5:30. Return the IST calendar date (YYYY-MM-DD) for a UTC instant. function istDateString(d: Date): string { const ist = new Date(d.getTime() + 5.5 * 60 * 60 * 1000) return ist.toISOString().slice(0, 10) } export type NewsletterSection = { heading: string body: string } export type NewsletterPayload = { subject: string preheader: string intro: string sections: NewsletterSection[] cta: string /** true when the model output could not be parsed as JSON and we fell back. */ parse_error?: boolean } export type GenerateNewsletterDraftOptions = { /** Injected for tests; defaults to the real OpenRouter call. */ aiGenerate?: AiGenerateFn /** Operator topic/angle for this newsletter (free text). */ topic?: string /** Business description fed to the prompt."
+      },
+      {
+        "name": "name",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.name }}",
+        "description": "generate-newsletter-draft.ts — #659 slice (report §12.4). The \"AI newsletter draft generator\": ask the LLM for a customer-facing newsletter (subject / preheader / intro / sections / CTA) and persist it to the EXISTING `marketing_draft` model as an OPERATOR-REVIEW draft. Sending is NOT done here — drafts are reviewed/edited in the (separate) Newsletter editor UI and later enqueued through the existing `src/jobs/process-email-queue.ts`. Reuses the verified generate-ideas-email wiring: - the AI call is an INJECTABLE `AiGenerateFn` (prompt in, text out) so CI never calls a live LLM; the Medusa workflow wrapper injects the real OpenRouter call (mirrors generate-ideas-email.ts:152-168). Unlike the tactical-ideas email this is CUSTOMER-FACING, so it does NOT read internal metric snapshots — we never want raw platform GMV leaking into a brand newsletter. The model is told to avoid inventing specific numbers. Pure, unit-tested helpers: `buildNewsletterPrompt`, `parseNewsletterPayload`, `coerceNewsletterPayload`. / import { createWorkflow, createStep, StepResponse, WorkflowResponse, } from \"@medusajs/framework/workflows-sdk\" import { makeRoleAiGenerate } from \"../../mastra/services/ai-platforms\" import { MARKETING_MODULE } from \"../../modules/marketing\" import type { AiGenerateFn } from \"./generate-ideas-email\" /** Role this generator resolves a platform for (free-model fallback). */ const NEWSLETTER_DRAFT_ROLE = \"ai_newsletter_drafter\" const DEFAULT_BUSINESS_DESCRIPTION = \"JYT is a textile-production commerce platform: it runs an admin storefront \" + \"and onboards partner brands who sell their own products through per-partner \" + \"storefronts.\" /** v1 newsletter voice rules — kept pure (the workflow may pass an override). */ export const NEWSLETTER_VOICE_RULES = [ \"Warm and brand-forward, but never hype. Sound like a real person, not an ad.\", \"Lead with value for the reader; keep paragraphs short and scannable.\", \"Do NOT invent specific numbers, percentages, prices, discounts, or dates.\", \"End with one clear, low-pressure call to action.\", ].join(\"\\n- \") // IST = UTC+5:30. Return the IST calendar date (YYYY-MM-DD) for a UTC instant. function istDateString(d: Date): string { const ist = new Date(d.getTime() + 5.5 * 60 * 60 * 1000) return ist.toISOString().slice(0, 10) } export type NewsletterSection = { heading: string body: string } export type NewsletterPayload = { subject: string preheader: string intro: string sections: NewsletterSection[] cta: string /** true when the model output could not be parsed as JSON and we fell back. */ parse_error?: boolean } export type GenerateNewsletterDraftOptions = { /** Injected for tests; defaults to the real OpenRouter call. */ aiGenerate?: AiGenerateFn /** Operator topic/angle for this newsletter (free text). */ topic?: string /** Business description fed to the prompt. */ businessDescription?: string /** Voice override. */ voiceRules?: string /** Human label for the draft row; defaults to `newsletter-<IST date>`."
+      },
+      {
+        "name": "markReady",
+        "type": "boolean",
+        "required": false,
+        "placeholder": "false",
+        "description": "generate-newsletter-draft.ts — #659 slice (report §12.4). The \"AI newsletter draft generator\": ask the LLM for a customer-facing newsletter (subject / preheader / intro / sections / CTA) and persist it to the EXISTING `marketing_draft` model as an OPERATOR-REVIEW draft. Sending is NOT done here — drafts are reviewed/edited in the (separate) Newsletter editor UI and later enqueued through the existing `src/jobs/process-email-queue.ts`. Reuses the verified generate-ideas-email wiring: - the AI call is an INJECTABLE `AiGenerateFn` (prompt in, text out) so CI never calls a live LLM; the Medusa workflow wrapper injects the real OpenRouter call (mirrors generate-ideas-email.ts:152-168). Unlike the tactical-ideas email this is CUSTOMER-FACING, so it does NOT read internal metric snapshots — we never want raw platform GMV leaking into a brand newsletter. The model is told to avoid inventing specific numbers. Pure, unit-tested helpers: `buildNewsletterPrompt`, `parseNewsletterPayload`, `coerceNewsletterPayload`. / import { createWorkflow, createStep, StepResponse, WorkflowResponse, } from \"@medusajs/framework/workflows-sdk\" import { makeRoleAiGenerate } from \"../../mastra/services/ai-platforms\" import { MARKETING_MODULE } from \"../../modules/marketing\" import type { AiGenerateFn } from \"./generate-ideas-email\" /** Role this generator resolves a platform for (free-model fallback). */ const NEWSLETTER_DRAFT_ROLE = \"ai_newsletter_drafter\" const DEFAULT_BUSINESS_DESCRIPTION = \"JYT is a textile-production commerce platform: it runs an admin storefront \" + \"and onboards partner brands who sell their own products through per-partner \" + \"storefronts.\" /** v1 newsletter voice rules — kept pure (the workflow may pass an override). */ export const NEWSLETTER_VOICE_RULES = [ \"Warm and brand-forward, but never hype. Sound like a real person, not an ad.\", \"Lead with value for the reader; keep paragraphs short and scannable.\", \"Do NOT invent specific numbers, percentages, prices, discounts, or dates.\", \"End with one clear, low-pressure call to action.\", ].join(\"\\n- \") // IST = UTC+5:30. Return the IST calendar date (YYYY-MM-DD) for a UTC instant. function istDateString(d: Date): string { const ist = new Date(d.getTime() + 5.5 * 60 * 60 * 1000) return ist.toISOString().slice(0, 10) } export type NewsletterSection = { heading: string body: string } export type NewsletterPayload = { subject: string preheader: string intro: string sections: NewsletterSection[] cta: string /** true when the model output could not be parsed as JSON and we fell back. */ parse_error?: boolean } export type GenerateNewsletterDraftOptions = { /** Injected for tests; defaults to the real OpenRouter call. */ aiGenerate?: AiGenerateFn /** Operator topic/angle for this newsletter (free text). */ topic?: string /** Business description fed to the prompt. */ businessDescription?: string /** Voice override. */ voiceRules?: string /** Human label for the draft row; defaults to `newsletter-<IST date>`. */ name?: string /** When true, persist as status=\"approved\" (ready); else status=\"draft\"."
+      }
+    ],
+    "source": "custom_ts",
+    "sourceFile": "src/workflows/marketing/generate-newsletter-draft.ts"
+  },
+  "log-outreach": {
+    "fields": [
+      {
+        "name": "recipient_email",
+        "type": "string",
+        "required": true,
+        "placeholder": "{{ $last.recipient_email }}"
+      },
+      {
+        "name": "recipient_name",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.recipient_name }}"
+      },
+      {
+        "name": "company",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.company }}"
+      },
+      {
+        "name": "campaign",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.campaign }}"
+      },
+      {
+        "name": "channel",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.channel }}"
+      },
+      {
+        "name": "status",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.status }}"
+      },
+      {
+        "name": "notes",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.notes }}"
+      },
+      {
+        "name": "external_id",
+        "type": "id",
+        "required": false,
+        "placeholder": "{{ $last.external_id }}"
+      },
+      {
+        "name": "sent_at",
+        "type": "date",
+        "required": false,
+        "placeholder": "{{ $trigger.sent_at }}"
+      }
+    ],
+    "source": "custom_ts",
+    "sourceFile": "src/workflows/marketing/log-outreach.ts"
   },
   "create-album-media": {
     "fields": [
@@ -4080,6 +4441,60 @@
     "source": "inferred",
     "sourceFile": "src/workflows/meta-ads/fetch-overview/index.ts"
   },
+  "list-partner-orders": {
+    "fields": [
+      {
+        "name": "partnerId",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.partnerId }}"
+      },
+      {
+        "name": "salesChannelId",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.salesChannelId }}"
+      },
+      {
+        "name": "kind",
+        "type": "string",
+        "required": true,
+        "placeholder": "{{ $last.kind }}"
+      },
+      {
+        "name": "fields",
+        "type": "array",
+        "required": true,
+        "placeholder": "{{ $last.fields }}"
+      },
+      {
+        "name": "baseFilters",
+        "type": "object",
+        "required": false,
+        "placeholder": "{}"
+      },
+      {
+        "name": "order",
+        "type": "object",
+        "required": false,
+        "placeholder": "{}"
+      },
+      {
+        "name": "skip",
+        "type": "number",
+        "required": true,
+        "placeholder": "0"
+      },
+      {
+        "name": "take",
+        "type": "number",
+        "required": true,
+        "placeholder": "0"
+      }
+    ],
+    "source": "custom_ts",
+    "sourceFile": "src/workflows/orders/list-partner-orders.ts"
+  },
   "associate-partner-person-types": {
     "fields": [
       {
@@ -4224,6 +4639,42 @@
     ],
     "source": "inferred",
     "sourceFile": "src/workflows/partner-subscription/seed-plans.ts"
+  },
+  "attach-storefront-domain": {
+    "fields": [
+      {
+        "name": "partner_id",
+        "type": "id",
+        "required": true,
+        "placeholder": "{{ $last.partner_id }}"
+      },
+      {
+        "name": "vercel_project_id",
+        "type": "id",
+        "required": true,
+        "placeholder": "{{ $last.vercel_project_id }}"
+      },
+      {
+        "name": "website_id",
+        "type": "id",
+        "required": true,
+        "placeholder": "{{ $last.website_id }}"
+      },
+      {
+        "name": "domain",
+        "type": "string",
+        "required": true,
+        "placeholder": "{{ $last.domain }}"
+      },
+      {
+        "name": "prev_metadata",
+        "type": "object",
+        "required": true,
+        "placeholder": "{}"
+      }
+    ],
+    "source": "custom_ts",
+    "sourceFile": "src/workflows/partners/attach-storefront-domain.ts"
   },
   "delete-partner": {
     "fields": [


### PR DESCRIPTION
Closes the remaining **#781** (#778 group-2) MEDIUMs on the admin inventory-order update path. The CRITICALs + H11 already merged (#785/#786/#787).

## What & why

### C2 admin-half / M (state machine) — admin Delivered now posts stock
Marking an order `Delivered` via the generic admin `PUT /admin/inventory-orders/:id` used to write only the status column, silently bypassing the stock movement the partner-complete path performs. Now a transition **to Delivered**:
- posts stock for the **remaining** quantity per line (`ordered − already-delivered`, from `metadata.partner_delivered_lines`, so a partially-delivered order never double-posts);
- to the order's **destination** location — resolved via the order↔stock-location link's `to_location` flag (a positional `[0]` could pick the *from*-warehouse);
- creating missing inventory levels then updating them, mirroring partner-complete exactly;
- and appends the delivered lines to `metadata.partner_delivered_lines` so a later **cancel (#786)** reverses the full posted stock.

The long-standing **"edit only while Pending/Processing"** lock is preserved verbatim (same error message other flows assert on). That lock already gates the dangerous cases (you can't cancel/edit an order that already posted stock), so transitions other flows legitimately drive via PUT (`→Shipped`, `→Cancelled`, the dual-write mirror) keep working — **only `→Delivered` changes behaviour**, to post stock. A richer transition graph is intentionally deferred to #790 (which introduces the "Ready for Delivery" status), to avoid breaking the unification dual-write flows that drive statuses via PUT.

### M (compensation) — non-destructive line compensation
`updateOrderLinesStep`'s compensation soft-deleted **all** lines and recreated them with **new ids**, breaking external references. It now inverts each forward op precisely:
- delete only the lines it **created** (+ dismiss their links),
- restore prior `quantity`/`price` **in place** on **updated** lines (stable ids),
- `restoreOrderLines` the **removed** ones (stable ids) + recreate their links.

## Tests
- `lib/deliver-helpers.ts` pure helpers (`evaluateAdminStatusTransition`, `computeAdminDeliveryPosting`) — **9 unit tests**.
- Integration test: an admin Delivered posts stock to the destination location + records the delivered lines (`inventory-orders-api.spec.ts`, now 18/18).
- Regression-checked: existing PUT-lock spec + `orders-unification-dual-write` / `-status-column` specs stay green.
- `medusa build` clean.

## Still open on #781's parent (#778), not in this PR
#783 (status & money model) · #782 (lifecycle observability) · #784 (API/UI/cleanup). The admin "Mark Delivered" UI button + Partial→Delivered admin completion ride with #790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)