### PR TITLE
feat(790): inventory-order shipping — Ready for Delivery status + shipment endpoints + admin UI

### DIFF
--- a/apps/backend/integration-tests/http/inventory-orders-api.spec.ts
+++ b/apps/backend/integration-tests/http/inventory-orders-api.spec.ts
@@ -439,4 +439,37 @@ setupSharedTestSuite(() => {
         expect(res.status).toBe(404);
       });
     });
+
+    // #790 slice 3 — admin "Mark Ready for Delivery" transition route.
+    describe("POST /admin/inventory-orders/:id/ready-for-delivery", () => {
+      const baseOrder = (status: string) => ({
+        order_lines: [{ inventory_item_id: inventoryItemId, quantity: 2, price: 100 }],
+        quantity: 2,
+        total_price: 200,
+        status,
+        expected_delivery_date: new Date().toISOString(),
+        order_date: new Date().toISOString(),
+        shipping_address: {},
+        stock_location_id: stockLocationId,
+        from_stock_location_id: fromStockLocationId,
+      });
+
+      it("transitions a Processing order to Ready for Delivery", async () => {
+        const created = await api.post("/admin/inventory-orders", baseOrder("Processing"), headers);
+        const id = created.data.inventoryOrder.id;
+        const res = await api.post(`/admin/inventory-orders/${id}/ready-for-delivery`, {}, headers);
+        expect(res.status).toBe(200);
+        const got = await api.get(`/admin/inventory-orders/${id}?fields=id,status`, headers);
+        expect(got.data.inventoryOrder.status).toBe("Ready for Delivery");
+      });
+
+      it("rejects from a non-allowed status (Pending)", async () => {
+        const created = await api.post("/admin/inventory-orders", baseOrder("Pending"), headers);
+        const id = created.data.inventoryOrder.id;
+        const res = await api
+          .post(`/admin/inventory-orders/${id}/ready-for-delivery`, {}, headers)
+          .catch((err) => err.response);
+        expect(res.status).toBe(400);
+      });
+    });
 });

--- a/apps/backend/integration-tests/http/inventory-orders-api.spec.ts
+++ b/apps/backend/integration-tests/http/inventory-orders-api.spec.ts
@@ -107,6 +107,28 @@ setupSharedTestSuite(() => {
         expect(res.status).toBe(400);
         expect(res.data || res.data).toBeDefined();
       });
+
+      // #790 — the new "Ready for Delivery" status must be accepted by the
+      // validator AND the DB check constraint (proves Migration20260630120000
+      // landed the new enum value).
+      it("should accept the new 'Ready for Delivery' status", async () => {
+        const orderPayload = {
+          order_lines: [
+            { inventory_item_id: inventoryItemId, quantity: 2, price: 100 },
+          ],
+          quantity: 2,
+          total_price: 200,
+          status: "Ready for Delivery",
+          expected_delivery_date: new Date().toISOString(),
+          order_date: new Date().toISOString(),
+          shipping_address: {},
+          stock_location_id: stockLocationId,
+          from_stock_location_id: fromStockLocationId,
+        };
+        const res = await api.post("/admin/inventory-orders", orderPayload, headers);
+        expect(res.status).toBe(201);
+        expect(res.data.inventoryOrder.status).toBe("Ready for Delivery");
+      });
     });
 
     type OrderLine = { inventory_item_id: string; quantity: number; price: number };

--- a/apps/backend/integration-tests/http/inventory-orders-api.spec.ts
+++ b/apps/backend/integration-tests/http/inventory-orders-api.spec.ts
@@ -404,4 +404,39 @@ setupSharedTestSuite(() => {
 
 
     });
+
+    // #790 slice 2 — standalone admin shipment endpoint. The status guard +
+    // not-found checks are deterministic (they fire before the carrier call), so
+    // they don't depend on a live shipping provider in the test env.
+    describe("POST /admin/inventory-orders/:id/shipment", () => {
+      it("rejects creating a shipment for a Pending order (status guard)", async () => {
+        const orderPayload = {
+          order_lines: [{ inventory_item_id: inventoryItemId, quantity: 2, price: 100 }],
+          quantity: 2,
+          total_price: 200,
+          status: "Pending",
+          expected_delivery_date: new Date().toISOString(),
+          order_date: new Date().toISOString(),
+          shipping_address: {},
+          stock_location_id: stockLocationId,
+          from_stock_location_id: fromStockLocationId,
+        };
+        const created = await api.post("/admin/inventory-orders", orderPayload, headers);
+        expect(created.status).toBe(201);
+        const id = created.data.inventoryOrder.id;
+
+        const res = await api
+          .post(`/admin/inventory-orders/${id}/shipment`, {}, headers)
+          .catch((err) => err.response);
+        expect(res.status).toBe(400);
+        expect(res.data.message).toMatch(/cannot create a shipment/i);
+      });
+
+      it("returns 404 for a non-existent order", async () => {
+        const res = await api
+          .post("/admin/inventory-orders/inv_order_does_not_exist/shipment", {}, headers)
+          .catch((err) => err.response);
+        expect(res.status).toBe(404);
+      });
+    });
 });

--- a/apps/backend/src/admin/components/inventory-orders/inventory-order-general-section.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/inventory-order-general-section.tsx
@@ -1,20 +1,40 @@
+import { useState } from "react";
 import { Container, Heading, Text, StatusBadge, toast, usePrompt } from "@medusajs/ui";
-import { PencilSquare, Trash, ArrowUpRightOnBox } from "@medusajs/icons";
+import { PencilSquare, Trash, ArrowUpRightOnBox, TruckFast, CheckCircle } from "@medusajs/icons";
 import { useNavigate } from "react-router-dom";
 import { ActionMenu } from "../common/action-menu";
-import { AdminInventoryOrder, useDeleteInventoryOrder } from "../../hooks/api/inventory-orders";
+import {
+  AdminInventoryOrder,
+  useDeleteInventoryOrder,
+  useMarkInventoryOrderReadyForDelivery,
+} from "../../hooks/api/inventory-orders";
 import {
   PARTNER_STATUS_LABELS,
   getPartnerWorkStatus,
   getStatusBadgeColor,
 } from "../../lib/work-status";
+import { InventoryOrderShipmentModal } from "./inventory-order-shipment-modal";
 
-
+// #790 — which statuses allow each action.
+const READY_FOR_DELIVERY_FROM = new Set(["Processing", "Partial"]);
+const SHIPPABLE = new Set(["Processing", "Ready for Delivery", "Partial", "Shipped"]);
 
 export const InventoryOrderGeneralSection = ({ inventoryOrder }: { inventoryOrder: AdminInventoryOrder }) => {
   const prompt = usePrompt();
   const navigate = useNavigate();
   const { mutateAsync } = useDeleteInventoryOrder(inventoryOrder.id);
+  const { mutateAsync: markReady } = useMarkInventoryOrderReadyForDelivery(inventoryOrder.id);
+  const [shipmentOpen, setShipmentOpen] = useState(false);
+
+  const canMarkReady = READY_FOR_DELIVERY_FROM.has(inventoryOrder.status);
+  const canShip = SHIPPABLE.has(inventoryOrder.status);
+
+  const handleMarkReady = async () => {
+    await markReady(undefined, {
+      onSuccess: () => toast.success('Marked "Ready for Delivery"'),
+      onError: (error: any) => toast.error(error?.message || "Failed to update status"),
+    });
+  };
 
   const handleDelete = async () => {
     const confirmed = await prompt({
@@ -52,6 +72,17 @@ export const InventoryOrderGeneralSection = ({ inventoryOrder }: { inventoryOrde
               ],
             },
             {
+              // #790 — fulfilment actions, gated by the order's current status.
+              actions: [
+                ...(canMarkReady
+                  ? [{ label: "Mark Ready for Delivery", icon: <CheckCircle />, onClick: handleMarkReady }]
+                  : []),
+                ...(canShip
+                  ? [{ label: "Create shipment", icon: <TruckFast />, onClick: () => setShipmentOpen(true) }]
+                  : []),
+              ],
+            },
+            {
               actions: [
                 { label: "Delete", icon: <Trash />, onClick: handleDelete },
               ],
@@ -59,6 +90,11 @@ export const InventoryOrderGeneralSection = ({ inventoryOrder }: { inventoryOrde
           ]}
         />
       </div>
+      <InventoryOrderShipmentModal
+        inventoryOrder={inventoryOrder}
+        open={shipmentOpen}
+        onOpenChange={setShipmentOpen}
+      />
       {getPartnerWorkStatus(inventoryOrder) && (
         <div className="text-ui-fg-subtle grid grid-cols-2 items-center px-6 py-4">
           <Text size="small" weight="plus">Work status</Text>

--- a/apps/backend/src/admin/components/inventory-orders/inventory-order-shipment-modal.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/inventory-order-shipment-modal.tsx
@@ -1,0 +1,111 @@
+import { useState } from "react";
+import { Drawer, Button, Input, Label, Text, toast } from "@medusajs/ui";
+import {
+  AdminInventoryOrder,
+  useCreateInventoryOrderShipment,
+} from "../../hooks/api/inventory-orders";
+
+type Props = {
+  inventoryOrder: AdminInventoryOrder;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+/**
+ * #790 slice 3 — admin "Create shipment" form. All fields are optional: the
+ * shipment workflow defaults the weight and resolves a registered carrier pickup
+ * when none is given, so the simplest path is to just submit. Surfaces the AWB on
+ * success and the workflow's actionable message on failure.
+ */
+export const InventoryOrderShipmentModal = ({ inventoryOrder, open, onOpenChange }: Props) => {
+  const [pickup, setPickup] = useState("");
+  const [weight, setWeight] = useState("");
+  const [length, setLength] = useState("");
+  const [breadth, setBreadth] = useState("");
+  const [height, setHeight] = useState("");
+  const [courier, setCourier] = useState("");
+
+  const { mutateAsync, isPending } = useCreateInventoryOrderShipment(inventoryOrder.id);
+
+  const handleSubmit = async () => {
+    const dims =
+      length || breadth || height
+        ? {
+            ...(length ? { length: Number(length) } : {}),
+            ...(breadth ? { breadth: Number(breadth) } : {}),
+            ...(height ? { height: Number(height) } : {}),
+          }
+        : undefined;
+
+    await mutateAsync(
+      {
+        ...(pickup ? { pickup_stock_location_id: pickup } : {}),
+        ...(weight ? { weight_grams: Number(weight) } : {}),
+        ...(dims ? { dimensions_cm: dims } : {}),
+        ...(courier ? { preferred_courier_id: courier } : {}),
+      },
+      {
+        onSuccess: (data) => {
+          const awb = data?.shipment?.awb || data?.shipment?.tracking_number;
+          toast.success(awb ? `Shipment created — AWB ${awb}` : "Shipment created");
+          onOpenChange(false);
+        },
+        onError: (error: any) => {
+          toast.error(error?.message || "Failed to create shipment");
+        },
+      },
+    );
+  };
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <Drawer.Content>
+        <Drawer.Header>
+          <Drawer.Title>Create shipment</Drawer.Title>
+        </Drawer.Header>
+        <Drawer.Body className="flex flex-col gap-4 overflow-auto">
+          <Text size="small" className="text-ui-fg-subtle">
+            Generate a carrier shipment (AWB + label) for this order. All fields are optional —
+            leave them blank to use the order's defaults and a registered pickup.
+          </Text>
+          <div className="flex flex-col gap-1">
+            <Label size="small" htmlFor="pickup">Pickup stock location ID</Label>
+            <Input id="pickup" value={pickup} onChange={(e) => setPickup(e.target.value)} placeholder="sloc_… (optional)" />
+          </div>
+          <div className="flex flex-col gap-1">
+            <Label size="small" htmlFor="weight">Weight (grams)</Label>
+            <Input id="weight" type="number" value={weight} onChange={(e) => setWeight(e.target.value)} placeholder="500" />
+          </div>
+          <div className="grid grid-cols-3 gap-2">
+            <div className="flex flex-col gap-1">
+              <Label size="small" htmlFor="length">Length (cm)</Label>
+              <Input id="length" type="number" value={length} onChange={(e) => setLength(e.target.value)} />
+            </div>
+            <div className="flex flex-col gap-1">
+              <Label size="small" htmlFor="breadth">Breadth (cm)</Label>
+              <Input id="breadth" type="number" value={breadth} onChange={(e) => setBreadth(e.target.value)} />
+            </div>
+            <div className="flex flex-col gap-1">
+              <Label size="small" htmlFor="height">Height (cm)</Label>
+              <Input id="height" type="number" value={height} onChange={(e) => setHeight(e.target.value)} />
+            </div>
+          </div>
+          <div className="flex flex-col gap-1">
+            <Label size="small" htmlFor="courier">Preferred courier ID</Label>
+            <Input id="courier" value={courier} onChange={(e) => setCourier(e.target.value)} placeholder="(optional)" />
+          </div>
+        </Drawer.Body>
+        <Drawer.Footer>
+          <Drawer.Close asChild>
+            <Button variant="secondary" size="small">Cancel</Button>
+          </Drawer.Close>
+          <Button size="small" onClick={handleSubmit} isLoading={isPending}>
+            Create shipment
+          </Button>
+        </Drawer.Footer>
+      </Drawer.Content>
+    </Drawer>
+  );
+};
+
+export default InventoryOrderShipmentModal;

--- a/apps/backend/src/admin/hooks/api/inventory-orders.ts
+++ b/apps/backend/src/admin/hooks/api/inventory-orders.ts
@@ -181,6 +181,61 @@ export const useUpdateInventoryOrder = (
   });
 };
 
+// #790 slice 3 — mark an order "Ready for Delivery" (Processing/Partial → it).
+export const useMarkInventoryOrderReadyForDelivery = (
+  id: string,
+  options?: UseMutationOptions<{ order: AdminInventoryOrder }, FetchError, void>,
+) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async () =>
+      sdk.client.fetch<{ order: AdminInventoryOrder }>(`/admin/inventory-orders/${id}/ready-for-delivery`, {
+        method: "POST",
+        body: {},
+      }),
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({ queryKey: inventoryOrderQueryKeys.detail(id) });
+      queryClient.invalidateQueries({ queryKey: inventoryOrderQueryKeys.lists() });
+      options?.onSuccess?.(...args);
+    },
+    ...options,
+  });
+};
+
+export interface CreateInventoryOrderShipmentPayload {
+  carrier?: string;
+  pickup_stock_location_id?: string;
+  weight_grams?: number;
+  dimensions_cm?: { length?: number; breadth?: number; height?: number };
+  preferred_courier_id?: string | number;
+  delivered_quantities?: Record<string, number>;
+}
+
+export interface CreateInventoryOrderShipmentResponse {
+  shipment?: { awb?: string; tracking_number?: string; label_url?: string; [k: string]: any };
+}
+
+// #790 slice 3 — generate a real carrier shipment (AWB + label) for the order.
+export const useCreateInventoryOrderShipment = (
+  id: string,
+  options?: UseMutationOptions<CreateInventoryOrderShipmentResponse, FetchError, CreateInventoryOrderShipmentPayload>,
+) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: CreateInventoryOrderShipmentPayload) =>
+      sdk.client.fetch<CreateInventoryOrderShipmentResponse>(`/admin/inventory-orders/${id}/shipment`, {
+        method: "POST",
+        body: payload,
+      }),
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({ queryKey: inventoryOrderQueryKeys.detail(id) });
+      queryClient.invalidateQueries({ queryKey: inventoryOrderQueryKeys.lists() });
+      options?.onSuccess?.(...args);
+    },
+    ...options,
+  });
+};
+
 export const useCreateInventoryOrderTasks = (
   id: string,
   options?: UseMutationOptions<any, FetchError, { type: string; template_names: string[]; dependency_type?: string }>,

--- a/apps/backend/src/admin/routes/orders/inventory/page.tsx
+++ b/apps/backend/src/admin/routes/orders/inventory/page.tsx
@@ -210,6 +210,7 @@ const InventoryOrdersPage = () => {
       options: [
         { label: "Pending", value: "Pending" },
         { label: "Processing", value: "Processing" },
+        { label: "Ready for Delivery", value: "Ready for Delivery" },
         { label: "Shipped", value: "Shipped" },
         { label: "Delivered", value: "Delivered" },
         { label: "Cancelled", value: "Cancelled" },

--- a/apps/backend/src/api/admin/inventory-orders/[id]/ready-for-delivery/route.ts
+++ b/apps/backend/src/api/admin/inventory-orders/[id]/ready-for-delivery/route.ts
@@ -1,0 +1,52 @@
+/**
+ * @route POST /admin/inventory-orders/:id/ready-for-delivery
+ * @scope admin
+ *
+ * #790 slice 2/3 — admin marks an inventory order "Ready for Delivery" (admin
+ * mirror of the partner route; feedback_partner_api_mirrors_admin). Routes
+ * through the singular update workflow so the #776 status-changed event +
+ * unified mirror fire — and so it isn't blocked by the generic PUT's
+ * "Pending/Processing only" edit lock (which would reject a Partial order).
+ *
+ * Allowed only from Processing or Partial. Success: 200 -> { order }.
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework";
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils";
+import { updateInventoryOrderWorkflow } from "../../../../../workflows/inventory_orders/update-inventory-order";
+
+const READY_FROM = new Set(["Processing", "Partial"]);
+
+export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
+  const id = req.params.id;
+
+  const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY);
+  const { data } = await query.graph({
+    entity: "inventory_orders",
+    fields: ["id", "status"],
+    filters: { id },
+  });
+  if (!data?.[0]) {
+    return res.status(404).json({ message: `Inventory order ${id} not found` });
+  }
+  const current = (data[0] as any).status;
+  if (!READY_FROM.has(String(current ?? ""))) {
+    return res.status(400).json({
+      message: `Cannot mark an inventory order "Ready for Delivery" from status '${current ?? "unknown"}'.`,
+    });
+  }
+
+  const { result, errors } = await updateInventoryOrderWorkflow(req.scope).run({
+    input: { id, update: { status: "Ready for Delivery" } },
+    throwOnError: false,
+  });
+
+  if (errors && errors.length > 0) {
+    const err = errors[0]?.error as any;
+    if ((err?.type || err?.constructor?.name) === MedusaError.Types.NOT_FOUND) {
+      return res.status(404).json({ message: err.message });
+    }
+    return res.status(400).json({ message: err?.message || "Failed to update status", errors });
+  }
+
+  return res.status(200).json({ order: result });
+}

--- a/apps/backend/src/api/admin/inventory-orders/[id]/shipment/route.ts
+++ b/apps/backend/src/api/admin/inventory-orders/[id]/shipment/route.ts
@@ -1,0 +1,75 @@
+/**
+ * @route POST /admin/inventory-orders/:id/shipment
+ * @scope admin
+ *
+ * #790 slice 2 — admin mirror of the partner standalone shipment endpoint
+ * (feedback_partner_api_mirrors_admin): generate a real carrier shipment
+ * (forward → AWB → label) for an inventory order. No ownership guard — admin
+ * sees all orders. The order must be in a shippable status.
+ *
+ * Body: { carrier?, pickup_stock_location_id?, weight_grams?, dimensions_cm?,
+ *         preferred_courier_id?, delivered_quantities? }
+ * Success: 200 -> { shipment }
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework";
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils";
+import { z } from "@medusajs/framework/zod";
+import { createInventoryOrderShipmentWorkflow } from "../../../../../workflows/inventory_orders/create-inventory-order-shipment";
+import { assertShipmentAllowed } from "../../../../../workflows/inventory_orders/lib/shipment-guard";
+
+const bodySchema = z.object({
+  carrier: z.string().optional(),
+  pickup_stock_location_id: z.string().optional(),
+  weight_grams: z.number().positive().optional(),
+  dimensions_cm: z.object({
+    length: z.number().positive(),
+    breadth: z.number().positive(),
+    height: z.number().positive(),
+  }).partial().optional(),
+  preferred_courier_id: z.union([z.string(), z.number()]).optional(),
+  delivered_quantities: z.record(z.string(), z.number()).optional(),
+});
+
+export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
+  const id = req.params.id;
+
+  const parsed = bodySchema.safeParse(req.body ?? {});
+  if (!parsed.success) {
+    return res.status(400).json({ error: "Invalid request body", details: parsed.error.issues });
+  }
+
+  const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY);
+  const { data } = await query.graph({
+    entity: "inventory_orders",
+    fields: ["id", "status"],
+    filters: { id },
+  });
+  if (!data?.[0]) {
+    return res.status(404).json({ message: `Inventory order ${id} not found` });
+  }
+  assertShipmentAllowed((data[0] as any).status);
+
+  const { result, errors } = await createInventoryOrderShipmentWorkflow(req.scope).run({
+    input: {
+      orderId: id,
+      carrier: parsed.data.carrier,
+      pickupStockLocationId: parsed.data.pickup_stock_location_id,
+      weightGrams: parsed.data.weight_grams,
+      dimensionsCm: parsed.data.dimensions_cm as any,
+      preferredCourierId: parsed.data.preferred_courier_id,
+      deliveredQuantities: parsed.data.delivered_quantities,
+    },
+    throwOnError: false,
+  });
+
+  if (errors && errors.length > 0) {
+    const err = errors[0]?.error as any;
+    const type = err?.type || err?.constructor?.name;
+    if (type === MedusaError.Types.NOT_FOUND) return res.status(404).json({ message: err.message });
+    if (type === MedusaError.Types.NOT_ALLOWED) return res.status(403).json({ message: err.message });
+    if (type === MedusaError.Types.INVALID_DATA) return res.status(400).json({ message: err.message });
+    return res.status(400).json({ message: err?.message || "Shipment creation failed", errors });
+  }
+
+  return res.status(200).json({ shipment: result });
+}

--- a/apps/backend/src/api/admin/inventory-orders/validators.ts
+++ b/apps/backend/src/api/admin/inventory-orders/validators.ts
@@ -20,7 +20,7 @@ const inventoryOrdersBaseSchema = z.object({
   // Allow decimal order quantity (sum of line quantities)
   quantity: z.number().nonnegative("Order quantity must be zero or positive"),
   total_price: z.number().nonnegative("Total price must be zero or positive"),
-  status: z.enum(["Pending", "Processing", "Shipped", "Delivered", "Cancelled"]),
+  status: z.enum(["Pending", "Processing", "Ready for Delivery", "Shipped", "Delivered", "Cancelled"]),
   expected_delivery_date: z.coerce.date(),
   order_date: z.coerce.date(),
   metadata: z.record(z.string(), z.unknown()).optional(),

--- a/apps/backend/src/api/admin/visual-flows/metadata/route.ts
+++ b/apps/backend/src/api/admin/visual-flows/metadata/route.ts
@@ -417,7 +417,7 @@ const WORKFLOW_INPUT_SCHEMAS: Record<string, WorkflowInputField[]> = {
   "create-inventory-order-workflow": [
     { name: "quantity",               type: "number",  required: true,  description: "Total unit count", placeholder: "{{ extracted.total_quantity }}" },
     { name: "total_price",            type: "number",  required: true,  description: "Total order price", placeholder: "{{ extracted.total }}" },
-    { name: "status",                 type: "string",  required: true,  description: "Pending | Processing | Shipped | Delivered | Cancelled", placeholder: "Pending" },
+    { name: "status",                 type: "string",  required: true,  description: "Pending | Processing | Ready for Delivery | Shipped | Delivered | Cancelled", placeholder: "Pending" },
     { name: "stock_location_id",      type: "id",      required: true,  description: "Destination stock location ID", placeholder: "sloc_..." },
     { name: "order_date",             type: "date",    required: false, description: "ISO date string", placeholder: "{{ $trigger.received_at }}" },
     { name: "expected_delivery_date", type: "date",    required: false, description: "ISO date string", placeholder: "{{ extracted.estimated_delivery }}" },
@@ -426,7 +426,7 @@ const WORKFLOW_INPUT_SCHEMAS: Record<string, WorkflowInputField[]> = {
   ],
   "update-inventory-order-workflow": [
     { name: "id",       type: "id",     required: true,  description: "Inventory order ID", placeholder: "{{ $last.id }}" },
-    { name: "status",   type: "string", required: false, description: "Pending | Processing | Shipped | Delivered | Cancelled", placeholder: "Shipped" },
+    { name: "status",   type: "string", required: false, description: "Pending | Processing | Ready for Delivery | Shipped | Delivered | Cancelled", placeholder: "Shipped" },
     { name: "metadata", type: "object", required: false, description: "Fields to merge into metadata", placeholder: '{ "key": "value" }' },
   ],
   "delete-inventory-order-workflow": [

--- a/apps/backend/src/api/partners/inventory-orders/[orderId]/ready-for-delivery/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/[orderId]/ready-for-delivery/route.ts
@@ -1,0 +1,58 @@
+/**
+ * @route POST /partners/inventory-orders/:orderId/ready-for-delivery
+ * @scope partner
+ *
+ * #790 slice 2 — partner marks an inventory order "Ready for Delivery" (goods
+ * packed, ready to hand to the carrier). The partner portal has no generic
+ * status PUT (admin reuses /admin/inventory-orders/:id), so this dedicated,
+ * IDOR-guarded route is the partner's transition. Routes through the singular
+ * update workflow so the #776 status-changed event + unified-order mirror fire.
+ *
+ * Allowed only from Processing or Partial. Success: 200 -> { order }.
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework";
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils";
+import { getPartnerFromAuthContext, assertPartnerOwnsInventoryOrder } from "../../../helpers";
+import { updateInventoryOrderWorkflow } from "../../../../../workflows/inventory_orders/update-inventory-order";
+
+const READY_FROM = new Set(["Processing", "Partial"]);
+
+export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
+  const orderId = req.params.orderId;
+
+  if (!req.auth_context?.actor_id) {
+    return res.status(401).json({ error: "Partner authentication required" });
+  }
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope);
+  if (!partner) {
+    return res.status(401).json({ error: "Partner authentication required" });
+  }
+  await assertPartnerOwnsInventoryOrder(req.scope, orderId, partner.id);
+
+  const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY);
+  const { data } = await query.graph({
+    entity: "inventory_orders",
+    fields: ["id", "status"],
+    filters: { id: orderId },
+  });
+  const current = (data?.[0] as any)?.status;
+  if (!READY_FROM.has(String(current ?? ""))) {
+    return res.status(400).json({
+      message: `Cannot mark an inventory order "Ready for Delivery" from status '${current ?? "unknown"}'.`,
+    });
+  }
+
+  const { result, errors } = await updateInventoryOrderWorkflow(req.scope).run({
+    input: { id: orderId, update: { status: "Ready for Delivery" } },
+    throwOnError: false,
+  });
+
+  if (errors && errors.length > 0) {
+    const err = errors[0]?.error as any;
+    const type = err?.type || err?.constructor?.name;
+    if (type === MedusaError.Types.NOT_FOUND) return res.status(404).json({ message: err.message });
+    return res.status(400).json({ message: err?.message || "Failed to update status", errors });
+  }
+
+  return res.status(200).json({ order: result });
+}

--- a/apps/backend/src/api/partners/inventory-orders/[orderId]/shipment/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/[orderId]/shipment/route.ts
@@ -1,0 +1,87 @@
+/**
+ * @route POST /partners/inventory-orders/:orderId/shipment
+ * @scope partner
+ *
+ * #790 slice 2 — standalone carrier-shipment creation for an inventory order
+ * (forward → AWB → label), decoupled from the partner /complete path. The
+ * acting partner must own the order (IDOR guard, #778 C1) and the order must be
+ * in a shippable status (Ready for Delivery / Processing / Partial / Shipped).
+ *
+ * Body: { carrier?, pickup_stock_location_id?, weight_grams?, dimensions_cm?,
+ *         preferred_courier_id?, delivered_quantities? }
+ * Success: 200 -> { shipment }
+ * Errors:  surfaced from the workflow's clean MedusaError (no pickup configured,
+ *          provider missing, …) as a proper 4xx with the actionable message.
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework";
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils";
+import { z } from "@medusajs/framework/zod";
+import { getPartnerFromAuthContext, assertPartnerOwnsInventoryOrder } from "../../../helpers";
+import { createInventoryOrderShipmentWorkflow } from "../../../../../workflows/inventory_orders/create-inventory-order-shipment";
+import { assertShipmentAllowed } from "../../../../../workflows/inventory_orders/lib/shipment-guard";
+
+const bodySchema = z.object({
+  carrier: z.string().optional(),
+  pickup_stock_location_id: z.string().optional(),
+  weight_grams: z.number().positive().optional(),
+  dimensions_cm: z.object({
+    length: z.number().positive(),
+    breadth: z.number().positive(),
+    height: z.number().positive(),
+  }).partial().optional(),
+  preferred_courier_id: z.union([z.string(), z.number()]).optional(),
+  delivered_quantities: z.record(z.string(), z.number()).optional(),
+});
+
+export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
+  const orderId = req.params.orderId;
+
+  const parsed = bodySchema.safeParse(req.body ?? {});
+  if (!parsed.success) {
+    return res.status(400).json({ error: "Invalid request body", details: parsed.error.issues });
+  }
+
+  if (!req.auth_context?.actor_id) {
+    return res.status(401).json({ error: "Partner authentication required" });
+  }
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope);
+  if (!partner) {
+    return res.status(401).json({ error: "Partner authentication required" });
+  }
+  // #778 C1 — ownership guard (throws NOT_FOUND → 404; closes the IDOR).
+  await assertPartnerOwnsInventoryOrder(req.scope, orderId, partner.id);
+
+  // #790 — only ship orders whose goods exist / are ready to move.
+  const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY);
+  const { data } = await query.graph({
+    entity: "inventory_orders",
+    fields: ["id", "status"],
+    filters: { id: orderId },
+  });
+  assertShipmentAllowed((data?.[0] as any)?.status);
+
+  const { result, errors } = await createInventoryOrderShipmentWorkflow(req.scope).run({
+    input: {
+      orderId,
+      carrier: parsed.data.carrier,
+      pickupStockLocationId: parsed.data.pickup_stock_location_id,
+      weightGrams: parsed.data.weight_grams,
+      dimensionsCm: parsed.data.dimensions_cm as any,
+      preferredCourierId: parsed.data.preferred_courier_id,
+      deliveredQuantities: parsed.data.delivered_quantities,
+      actingEmail: (partner as any)?.email || undefined,
+    },
+    throwOnError: false,
+  });
+
+  if (errors && errors.length > 0) {
+    const err = errors[0]?.error as any;
+    const type = err?.type || err?.constructor?.name;
+    if (type === MedusaError.Types.NOT_FOUND) return res.status(404).json({ message: err.message });
+    if (type === MedusaError.Types.NOT_ALLOWED) return res.status(403).json({ message: err.message });
+    if (type === MedusaError.Types.INVALID_DATA) return res.status(400).json({ message: err.message });
+    return res.status(400).json({ message: err?.message || "Shipment creation failed", errors });
+  }
+
+  return res.status(200).json({ shipment: result });
+}

--- a/apps/backend/src/modules/inventory_orders/constants.ts
+++ b/apps/backend/src/modules/inventory_orders/constants.ts
@@ -1,6 +1,8 @@
 export const INVENTORY_ORDER_STATUS = [
   "Pending",
   "Processing",
+  // #790 — packed/ready to hand to the carrier, before the shipment/AWB exists.
+  "Ready for Delivery",
   "Shipped",
   "Delivered",
   "Cancelled",

--- a/apps/backend/src/modules/inventory_orders/migrations/Migration20260630120000.ts
+++ b/apps/backend/src/modules/inventory_orders/migrations/Migration20260630120000.ts
@@ -1,0 +1,26 @@
+import { Migration } from '@mikro-orm/migrations';
+
+/**
+ * #790 — add the new "Ready for Delivery" inventory-order status (goods packed
+ * and ready to hand to the carrier, before the shipment/AWB is created).
+ *
+ * Hand-written idempotent ALTER (mirrors Migration20250810071843, which added
+ * 'Partial') — DROP IF EXISTS then re-add the check constraint with the new
+ * value. NEVER edit the create-table migration: that only runs on fresh DBs and
+ * would never land the new value on existing/prod databases (recurring hazard).
+ */
+export class Migration20260630120000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "inventory_orders" drop constraint if exists "inventory_orders_status_check";`);
+
+    this.addSql(`alter table if exists "inventory_orders" add constraint "inventory_orders_status_check" check("status" in ('Pending', 'Processing', 'Ready for Delivery', 'Shipped', 'Delivered', 'Cancelled', 'Partial'));`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "inventory_orders" drop constraint if exists "inventory_orders_status_check";`);
+
+    this.addSql(`alter table if exists "inventory_orders" add constraint "inventory_orders_status_check" check("status" in ('Pending', 'Processing', 'Shipped', 'Delivered', 'Cancelled', 'Partial'));`);
+  }
+
+}

--- a/apps/backend/src/modules/inventory_orders/models/order.ts
+++ b/apps/backend/src/modules/inventory_orders/models/order.ts
@@ -8,6 +8,9 @@ const InventoryOrder = model.define("inventory_orders", {
   status: model.enum([
     "Pending",
     "Processing",
+    // #790 — goods packed/ready to hand to the carrier, before the shipment/AWB
+    // is created. Sits between Processing and Shipped in the lifecycle.
+    "Ready for Delivery",
     "Shipped",
     "Delivered",
     "Cancelled",

--- a/apps/backend/src/modules/inventory_orders/service.ts
+++ b/apps/backend/src/modules/inventory_orders/service.ts
@@ -18,7 +18,7 @@ export type OrderLinesResponse = InferTypeOf<typeof OrderLine>[]
 interface CreateInventoryOrder {
   quantity: number;
   total_price: number;
-  status: 'Pending' | 'Processing' | 'Shipped' | 'Delivered' | 'Cancelled';
+  status: 'Pending' | 'Processing' | 'Ready for Delivery' | 'Shipped' | 'Delivered' | 'Cancelled';
   expected_delivery_date: Date | undefined;
   order_date: Date | undefined;
   metadata?: Record<string, unknown>;

--- a/apps/backend/src/scripts/__tests__/seed-inventory-order-status-flow.unit.spec.ts
+++ b/apps/backend/src/scripts/__tests__/seed-inventory-order-status-flow.unit.spec.ts
@@ -63,9 +63,9 @@ describe("seed-inventory-order-status-flow FLOW_DEF", () => {
     expect(code).toContain("$input.read_order?.records?.[0]")
   })
 
-  it("notifies exactly the five non-Pending statuses (Pending is skipped)", () => {
+  it("notifies the non-Pending statuses (Pending is skipped)", () => {
     const code = (byKey.resolve_message.options as any).code as string
-    for (const s of ["Processing", "Shipped", "Partial", "Delivered", "Cancelled"]) {
+    for (const s of ["Processing", "Ready for Delivery", "Shipped", "Partial", "Delivered", "Cancelled"]) {
       expect(code).toContain(`"${s}":`)
     }
     // Pending must NOT be a notified status — it is the initial state.

--- a/apps/backend/src/scripts/seed-inventory-order-status-flow.ts
+++ b/apps/backend/src/scripts/seed-inventory-order-status-flow.ts
@@ -10,6 +10,7 @@
  *
  * Status → notification mapping (defined inline in the resolve_message node):
  *   Processing → "In Production"        ┐
+ *   Ready for Delivery → "Ready for Delivery" │ all use the single generic template
  *   Shipped    → "Shipped"              │  all use the single generic template
  *   Partial    → "Partially Delivered"  │  jyt_inventory_order_status_v1 with
  *   Delivered  → "Delivered"            │  vars [partnerName, orderId, statusLabel]
@@ -109,6 +110,7 @@ if (!partner) {
 // initial state) and any unmapped/future status fall through to skip.
 const labels = {
   "Processing": "In Production",
+  "Ready for Delivery": "Ready for Delivery",
   "Shipped": "Shipped",
   "Partial": "Partially Delivered",
   "Delivered": "Delivered",

--- a/apps/backend/src/workflows/inventory_orders/__tests__/shipment-guard.unit.spec.ts
+++ b/apps/backend/src/workflows/inventory_orders/__tests__/shipment-guard.unit.spec.ts
@@ -1,0 +1,17 @@
+import { isShipmentAllowed, assertShipmentAllowed } from "../lib/shipment-guard"
+
+describe("shipment-guard (#790 slice 2)", () => {
+  it("allows shipping from the ready/in-flight states", () => {
+    for (const s of ["Processing", "Ready for Delivery", "Partial", "Shipped"]) {
+      expect(isShipmentAllowed(s)).toBe(true)
+      expect(() => assertShipmentAllowed(s)).not.toThrow()
+    }
+  })
+
+  it("rejects shipping from Pending / Delivered / Cancelled / unknown", () => {
+    for (const s of ["Pending", "Delivered", "Cancelled", "", null, undefined, "Weird"]) {
+      expect(isShipmentAllowed(s as any)).toBe(false)
+      expect(() => assertShipmentAllowed(s as any)).toThrow(/cannot create a shipment/i)
+    }
+  })
+})

--- a/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
@@ -28,7 +28,7 @@ export interface InventoryOrderLineInput {
 export interface CreateInventoryOrderInput {
   quantity: number;
   total_price: number;
-  status: 'Pending' | 'Processing' | 'Shipped' | 'Delivered' | 'Cancelled';
+  status: 'Pending' | 'Processing' | 'Ready for Delivery' | 'Shipped' | 'Delivered' | 'Cancelled';
   expected_delivery_date: Date | undefined;
   order_date: Date | undefined;
   shipping_address: Record<string, unknown>;

--- a/apps/backend/src/workflows/inventory_orders/dual-write-unified-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/dual-write-unified-order.ts
@@ -41,6 +41,8 @@ export const PROTECTED_UNIFICATION_METADATA_KEYS = [
 const LEGACY_TO_CORE_STATUS: Record<string, string> = {
   Pending: "pending",
   Processing: "pending",
+  // #790 — packed/ready, work still open → core stays "pending" (like Shipped).
+  "Ready for Delivery": "pending",
   Shipped: "pending",
   Partial: "pending",
   Delivered: "completed",
@@ -55,6 +57,9 @@ const LEGACY_TO_CORE_STATUS: Record<string, string> = {
 // existing value untouched rather than inventing one.
 const LEGACY_TO_PARTNER_STATUS: Record<string, string> = {
   Processing: "in_progress",
+  // #790 — packed/ready is still in-progress work (distinct from Shipped's
+  // "finished"); reuses the existing vocabulary so no panel/label changes.
+  "Ready for Delivery": "in_progress",
   Shipped: "finished",
   Partial: "partial",
   Delivered: "completed",

--- a/apps/backend/src/workflows/inventory_orders/lib/shipment-guard.ts
+++ b/apps/backend/src/workflows/inventory_orders/lib/shipment-guard.ts
@@ -1,0 +1,33 @@
+import { MedusaError } from "@medusajs/framework/utils"
+
+/**
+ * #790 slice 2 — guard for when a standalone carrier shipment may be created for
+ * an inventory order. Pure (no container) so it's unit-testable directly.
+ *
+ * Allowed from the "goods exist / ready to move" states:
+ *   - "Ready for Delivery" — the intended trigger (packed, ready for the carrier),
+ *   - "Processing" / "Partial" — backward-compat with the pre-#790 flow where a
+ *     shipment could be generated straight off a (partial) completion,
+ *   - "Shipped" — re-attempt after a transient carrier failure.
+ *
+ * Rejected for "Pending" (nothing produced yet), "Delivered" (already received),
+ * and "Cancelled" (dead order) with INVALID_DATA.
+ */
+const SHIPPABLE_STATUSES = new Set([
+  "Processing",
+  "Ready for Delivery",
+  "Partial",
+  "Shipped",
+])
+
+export const isShipmentAllowed = (status: string | null | undefined): boolean =>
+  SHIPPABLE_STATUSES.has(String(status ?? ""))
+
+export const assertShipmentAllowed = (status: string | null | undefined): void => {
+  if (!isShipmentAllowed(status)) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Cannot create a shipment for an inventory order in status '${status ?? "unknown"}'. Mark it "Ready for Delivery" first.`
+    )
+  }
+}

--- a/apps/backend/src/workflows/inventory_orders/update-inventory-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/update-inventory-order.ts
@@ -50,7 +50,7 @@ export const buildStatusChangedEvent = (
 type UpdateInventoryOrderStepInput = {
   id: string;
   update: {
-    status?: "Pending" | "Processing" | "Shipped" | "Delivered" | "Cancelled" | "Partial";
+    status?: "Pending" | "Processing" | "Ready for Delivery" | "Shipped" | "Delivered" | "Cancelled" | "Partial";
     metadata?: Record<string, any>;
     quantity?: number;
     total_price?: number;

--- a/apps/partner-ui/src/hooks/api/partner-inventory-orders.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-inventory-orders.tsx
@@ -205,6 +205,55 @@ export const useCompletePartnerInventoryOrder = (
   })
 }
 
+// #790 — mark an inventory order "Ready for Delivery" (Processing/Partial → it).
+export const useMarkPartnerInventoryOrderReadyForDelivery = (
+  orderId: string,
+  options?: UseMutationOptions<{ order: any }, FetchError, void>
+) => {
+  return useMutation({
+    mutationFn: async () =>
+      sdk.client.fetch<{ order: any }>(
+        `/partners/inventory-orders/${orderId}/ready-for-delivery`,
+        { method: "POST", body: {} }
+      ),
+    onSuccess: (data, variables, context) => {
+      queryClient.invalidateQueries({ queryKey: partnerInventoryOrdersQueryKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: partnerInventoryOrdersQueryKeys.detail(orderId) })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}
+
+// #790 — generate a standalone carrier shipment (AWB + label) for the order.
+export type PartnerCreateShipmentPayload = {
+  carrier?: string
+  pickup_stock_location_id?: string
+  weight_grams?: number
+  dimensions_cm?: { length?: number; breadth?: number; height?: number }
+  preferred_courier_id?: string | number
+  delivered_quantities?: Record<string, number>
+}
+
+export const useCreatePartnerInventoryOrderShipment = (
+  orderId: string,
+  options?: UseMutationOptions<{ shipment?: any }, FetchError, PartnerCreateShipmentPayload>
+) => {
+  return useMutation({
+    mutationFn: async (payload) =>
+      sdk.client.fetch<{ shipment?: any }>(
+        `/partners/inventory-orders/${orderId}/shipment`,
+        { method: "POST", body: payload }
+      ),
+    onSuccess: (data, variables, context) => {
+      queryClient.invalidateQueries({ queryKey: partnerInventoryOrdersQueryKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: partnerInventoryOrdersQueryKeys.detail(orderId) })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}
+
 export const useSubmitPartnerInventoryOrderPayment = (
   orderId: string,
   options?: UseMutationOptions<


### PR DESCRIPTION
Builds **#790** in slices on one branch (cohesive feature; avoids stacked-PR squash gotchas).

## Slice 1 — status foundation
New first-class status **"Ready for Delivery"** (packed/ready, before the AWB). Enum + idempotent ALTER `Migration20260630120000`; synced every status-union site (constants, validators, service/create input types, update-workflow union, admin list filter, visual-flows metadata); dual-write mapping → core `pending` + partner_status `in_progress` (reuses vocab, no panel changes); #788 installer notification label.

## Slice 2 — standalone endpoints
- `POST /partners/inventory-orders/:orderId/shipment` — IDOR-guarded + shippable-status guard, wraps `createInventoryOrderShipmentWorkflow`; surfaces the workflow's clean MedusaError as a proper 4xx (not 500).
- `POST /admin/inventory-orders/:id/shipment` — admin mirror.
- `POST /partners/inventory-orders/:orderId/ready-for-delivery` + `POST /admin/inventory-orders/:id/ready-for-delivery` — mark Ready for Delivery (Processing/Partial) via the singular update workflow (fires #776 status-changed + unified mirror; not blocked by the generic PUT's edit lock).
- Pure `assertShipmentAllowed` guard (lib/shipment-guard.ts) + unit tests.

## Slice 3a — admin UI
Status-gated actions in the inventory-order detail action menu: **"Mark Ready for Delivery"** + **"Create shipment"** (Medusa-native Drawer form, optional fields, surfaces the AWB / actionable error). New admin hooks (`useMarkInventoryOrderReadyForDelivery`, `useCreateInventoryOrderShipment`).

## Slice 3b — partner-ui hooks
`useMarkPartnerInventoryOrderReadyForDelivery` + `useCreatePartnerInventoryOrderShipment` (data layer; mirrors `useCompletePartnerInventoryOrder`).

## Verification
- `medusa build` clean; **22/22** integration (new-status accepted ⇒ migration landed; admin shipment guard 400 / 404; admin ready-for-delivery Processing→200 / Pending→400) + guard/deliver unit tests.
- ⚠️ **Admin UI not yet visually verified** (Playwright/running admin). Partner UI **page wiring** + visual verification of both still to come.

## Watch-outs
- Migration deploys on merge (idempotent ALTER).
- `Partial` still missing from `constants.ts` = #783 H8 (intentionally untouched).
- Shipment workflow only persists carrier refs — it does NOT change status (transitions are explicit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)