### PR TITLE
fix(desk+790): single desk empty-state container + stock-location dropdown for shipment "ship from"

### DIFF
--- a/apps/backend/src/admin/components/inventory-orders/inventory-order-shipment-modal.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/inventory-order-shipment-modal.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
-import { Drawer, Button, Input, Label, Text, toast } from "@medusajs/ui";
+import { Drawer, Button, Input, Label, Select, Text, toast } from "@medusajs/ui";
 import {
   AdminInventoryOrder,
   useCreateInventoryOrderShipment,
 } from "../../hooks/api/inventory-orders";
+import { useStockLocations } from "../../hooks/api/stock_location";
 
 type Props = {
   inventoryOrder: AdminInventoryOrder;
@@ -18,7 +19,12 @@ type Props = {
  * success and the workflow's actionable message on failure.
  */
 export const InventoryOrderShipmentModal = ({ inventoryOrder, open, onOpenChange }: Props) => {
-  const [pickup, setPickup] = useState("");
+  // Default the pickup ("ship from") to the order's own from-location when one
+  // is assigned — a shipment is created per order, so the location the goods
+  // leave from is the natural default; the user can still pick another.
+  const orderFromLocationId =
+    (inventoryOrder as any).from_stock_location?.id ?? "";
+  const [pickup, setPickup] = useState(orderFromLocationId);
   const [weight, setWeight] = useState("");
   const [length, setLength] = useState("");
   const [breadth, setBreadth] = useState("");
@@ -26,6 +32,7 @@ export const InventoryOrderShipmentModal = ({ inventoryOrder, open, onOpenChange
   const [courier, setCourier] = useState("");
 
   const { mutateAsync, isPending } = useCreateInventoryOrderShipment(inventoryOrder.id);
+  const { stock_locations = [] } = useStockLocations({ limit: 100 });
 
   const handleSubmit = async () => {
     const dims =
@@ -69,8 +76,19 @@ export const InventoryOrderShipmentModal = ({ inventoryOrder, open, onOpenChange
             leave them blank to use the order's defaults and a registered pickup.
           </Text>
           <div className="flex flex-col gap-1">
-            <Label size="small" htmlFor="pickup">Pickup stock location ID</Label>
-            <Input id="pickup" value={pickup} onChange={(e) => setPickup(e.target.value)} placeholder="sloc_… (optional)" />
+            <Label size="small" htmlFor="pickup">Ship from (pickup location)</Label>
+            <Select value={pickup} onValueChange={setPickup}>
+              <Select.Trigger id="pickup">
+                <Select.Value placeholder="Use registered carrier pickup (optional)" />
+              </Select.Trigger>
+              <Select.Content>
+                {stock_locations.map((loc) => (
+                  <Select.Item key={loc.id} value={loc.id}>
+                    {loc.name}
+                  </Select.Item>
+                ))}
+              </Select.Content>
+            </Select>
           </div>
           <div className="flex flex-col gap-1">
             <Label size="small" htmlFor="weight">Weight (grams)</Label>

--- a/apps/backend/src/admin/routes/desk/EmptyDesk.tsx
+++ b/apps/backend/src/admin/routes/desk/EmptyDesk.tsx
@@ -1,10 +1,14 @@
-import { Container, Heading, Text } from "@medusajs/ui"
 import { EntityPickerGrid, type EntityKey } from "./EntityPicker"
 
 /**
- * Centered empty state shown when the workspace has no tabs. Mirrors
- * the visual of the existing /operations + /content hub pages so it
- * feels native to the admin.
+ * Empty state shown when the workspace has no tabs.
+ *
+ * Renders only the entity-picker grid — NOT its own `<Container>` or heading.
+ * It sits inside the Desk page-level `<Container>` (see page.tsx), which now
+ * carries the "Open a workspace tab" heading; wrapping it again stacked two
+ * `shadow-elevation-card-rest` cards (a card-in-a-card) that read as two
+ * overlapping containers. The grid is centered in the available area so the
+ * spacing above and below it is equal.
  */
 export const EmptyDesk = ({
   onSelect,
@@ -14,18 +18,8 @@ export const EmptyDesk = ({
   onOpenCore?: (path: string) => void
 }) => (
   <div className="flex items-center justify-center h-full p-6">
-    <Container className="max-w-2xl w-full p-0">
-      <div className="px-6 py-4 border-b border-ui-border-base">
-        <Heading>Open a workspace tab</Heading>
-        <Text size="small" className="text-ui-fg-subtle">
-          Pick what you want to work on. Each tab is its own routing
-          context — you can open several side by side and drag them to
-          split. Press <kbd>⌘⇧K</kbd> anywhere in the Desk to search.
-        </Text>
-      </div>
-      <div className="px-6 py-4">
-        <EntityPickerGrid onSelect={onSelect} onOpenCore={onOpenCore} />
-      </div>
-    </Container>
+    <div className="max-w-2xl w-full">
+      <EntityPickerGrid onSelect={onSelect} onOpenCore={onOpenCore} />
+    </div>
   </div>
 )

--- a/apps/backend/src/admin/routes/desk/page.tsx
+++ b/apps/backend/src/admin/routes/desk/page.tsx
@@ -360,9 +360,11 @@ const Desk = () => {
     >
       {!hasTabs && (
         <div className="px-6 py-4 shrink-0">
-          <Heading>Desk</Heading>
+          <Heading>Open a workspace tab</Heading>
           <Text size="small" className="text-ui-fg-subtle">
-            Multi-pane workspace. Open entities as tabs and drag them to split panes.
+            Pick what you want to work on. Each tab is its own routing
+            context — you can open several side by side and drag them to
+            split. Press <kbd>⌘⇧K</kbd> anywhere in the Desk to search.
           </Text>
         </div>
       )}


### PR DESCRIPTION
## What

Two admin UI fixes verified locally via Playwright.

### 1. Desk empty state (`/admin/desk`) — two overlapping containers
`EmptyDesk` wrapped the entity picker in its **own** `<Container>` while already rendering inside the Desk page-level `<Container>` → two stacked `shadow-elevation-card-rest` rounded cards (a card-in-a-card) that read as two overlapping containers in the empty state. DOM probe confirmed two overlapping rounded cards.

- Drop the inner `<Container>` so only the page frame remains.
- Move the "Open a workspace tab" heading + description into the page header (replacing the redundant "Desk" heading); the picker grid now renders centered with equal spacing above/below.

| before | after |
|---|---|
| outer page card **+** inner "Open a workspace tab" card (two overlapping cards) | single page container, heading on top, grid centered |

### 2. #790 shipment modal — "Ship from" location dropdown
A shipment is created **per order**, so the pickup ("ship from") location should be chosen, not typed. Replace the free-text "Pickup stock location ID" `Input` with a `Select` of stock locations, defaulting to the order's own from-location when assigned. Maps to the same `pickup_stock_location_id` payload; blank still falls back to the registered carrier pickup.

## Verification (Playwright, local admin)
- Empty desk renders a **single** container (DOM probe: was 2 card-chrome cards → now 1 page frame + entity cards only).
- Shipment drawer "Ship from" dropdown lists all stock locations.
- #790 action-menu gating correct for a Processing order (Mark Ready for Delivery · Create shipment); `Mark Ready for Delivery` transitions Processing → Ready for Delivery.

## Note (not in this PR)
During verification, `Mark Ready` first failed locally with `violates check constraint "inventory_orders_status_check"` — the local DB was missing `Migration20260630120000` (adds `'Ready for Delivery'`). Running migrations fixed it. Flagging the recurring on-main migration hazard: worth confirming the constraint is live in prod (deployed with #798).

Refs #790