### PR TITLE
fix(whatsapp): capture Meta error on failed delivery webhooks

### DIFF
--- a/apps/backend/src/api/webhooks/social/whatsapp/route.ts
+++ b/apps/backend/src/api/webhooks/social/whatsapp/route.ts
@@ -230,6 +230,21 @@ async function processWhatsAppWebhook(
         }
 
         for (const status of value.statuses) {
+          // Meta attaches an `errors` array ONLY on failed statuses, and it is
+          // the single record of WHY a message failed — Meta exposes no API to
+          // re-fetch a past webhook body by wamid (see the incoming-message note
+          // below). If we don't log it here the reason is lost forever and the
+          // message just shows as "failed" with no explanation. Log verbatim.
+          if (status.status === "failed" || status.errors?.length) {
+            const err = status.errors?.[0]
+            logger.error(
+              `[whatsapp-webhook] Message delivery failed — wamid=${status.id} ` +
+                `recipient=${status.recipient_id} code=${err?.code ?? "unknown"} ` +
+                `title=${err?.title ?? "unknown"} message=${err?.message ?? "unknown"} ` +
+                `details=${err?.error_data?.details ?? "none"}`
+            )
+          }
+
           // Update all messages matching this wa_message_id (handles duplicates)
           try {
             const messagingService = scope.resolve(MESSAGING_MODULE) as any
@@ -484,6 +499,15 @@ interface WhatsAppWebhookPayload {
           status: string
           timestamp: string
           recipient_id: string
+          // Present only on failed deliveries. Meta's error code/title/message
+          // is the only diagnosable record of why a send failed.
+          errors?: Array<{
+            code?: number
+            title?: string
+            message?: string
+            error_data?: { details?: string }
+            href?: string
+          }>
         }>
       }
     }>


### PR DESCRIPTION
## Problem
A partner "WhatsApp connection initiated" template (from `connect-partner-whatsapp.ts`) was **accepted** by Meta — it returned a wamid and we stored `status: "sent"` — then **failed delivery ~9s later** via Meta's status webhook. CloudWatch showed our send succeeded (`WhatsappAudit: recorded notification ...`) and the inbound `POST /webhooks/social/whatsapp` (from `facebookexternalua`) that flipped it to `failed`, but **no reason**.

Root cause: the status handler (`processWhatsAppWebhook`) updates the message row to `failed` but never reads `status.errors` — Meta's `code/title/message/error_data.details`. Meta has **no API to refetch a past webhook body** by wamid, so the reason is lost forever and a failed message shows with no explanation.

## Fix
- When a status arrives `failed` (or carries `errors`), log Meta's error at ERROR level: `code`, `title`, `message`, `details`, plus `wamid` and `recipient_id`.
- Extend the webhook payload type's `statuses[]` with the `errors` shape.

No behaviour change to status progression; this is purely diagnostic capture. The **next** failure (connecting a partner is a recurring admin action) will now be fully diagnosable from CloudWatch.

## Not in this PR (proposed follow-up)
Persist the failure reason on the message via a **new typed column** so it surfaces in the admin messaging UI. Not using `metadata`: the messaging update path replaces the whole JSON blob (would clobber existing metadata), and per project convention load-bearing/diagnostic state belongs in typed columns.

## Note on the specific message
The exact error code for the 12:06 message is unrecoverable (discarded before this fix). Likely causes for an accepted-then-failed template to an Indian mobile: `131026` (undeliverable — recipient not a reachable WhatsApp user), or marketing-template pacing for IN (`131049`/`130472`). Worth confirming the partner's number is actually on WhatsApp.