### PR TITLE
feat(whatsapp): persist delivery-failure reason + show in messaging UI

### DIFF
--- a/apps/backend/src/admin/hooks/api/messaging.ts
+++ b/apps/backend/src/admin/hooks/api/messaging.ts
@@ -34,6 +34,7 @@ export interface Message {
   context_snapshot: Record<string, any> | null
   media_url: string | null
   media_mime_type: string | null
+  fail_reason: string | null
   reply_to_id: string | null
   reply_to_snapshot: {
     content: string

--- a/apps/backend/src/admin/routes/messaging/components/message-bubble.tsx
+++ b/apps/backend/src/admin/routes/messaging/components/message-bubble.tsx
@@ -267,6 +267,17 @@ export const MessageBubble = ({
             </span>
           )}
         </div>
+
+        {/* Why a delivery failed (Meta error). Captured from the WhatsApp status
+            webhook so the operator sees the reason instead of a bare ✗. */}
+        {isOutbound && message.status === "failed" && message.fail_reason && (
+          <div
+            className="mt-1 text-[10px] text-red-300 text-right break-words"
+            title={message.fail_reason}
+          >
+            {message.fail_reason}
+          </div>
+        )}
       </div>
 
       {/* Reply + actions (right side for inbound) */}

--- a/apps/backend/src/api/webhooks/social/whatsapp/route.ts
+++ b/apps/backend/src/api/webhooks/social/whatsapp/route.ts
@@ -235,8 +235,21 @@ async function processWhatsAppWebhook(
           // re-fetch a past webhook body by wamid (see the incoming-message note
           // below). If we don't log it here the reason is lost forever and the
           // message just shows as "failed" with no explanation. Log verbatim.
+          let failReason: string | null = null
           if (status.status === "failed" || status.errors?.length) {
             const err = status.errors?.[0]
+            // Compact, human-readable reason persisted on the message + shown in
+            // the admin messaging UI: "<code> · <title> — <message> (<details>)".
+            failReason = err
+              ? [
+                  err.code != null ? `${err.code} · ` : "",
+                  err.title ?? "Delivery failed",
+                  err.message ? ` — ${err.message}` : "",
+                  err.error_data?.details ? ` (${err.error_data.details})` : "",
+                ]
+                  .join("")
+                  .slice(0, 500)
+              : "Delivery failed (no error detail from Meta)"
             logger.error(
               `[whatsapp-webhook] Message delivery failed — wamid=${status.id} ` +
                 `recipient=${status.recipient_id} code=${err?.code ?? "unknown"} ` +
@@ -263,6 +276,7 @@ async function processWhatsAppWebhook(
                 await messagingService.updateMessagingMessages({
                   id: msg.id,
                   status: status.status as any,
+                  ...(failReason ? { fail_reason: failReason } : {}),
                 })
               }
             }

--- a/apps/backend/src/modules/messaging/migrations/Migration20260630140000.ts
+++ b/apps/backend/src/modules/messaging/migrations/Migration20260630140000.ts
@@ -1,0 +1,22 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Add fail_reason to messaging_message — the human-readable reason a WhatsApp
+ * delivery failed (Meta error code/title/message), set from the status webhook
+ * when a message flips to "failed". Hand-written idempotent ALTER (never edit
+ * the create-table migration: it only runs on fresh DBs and would never land
+ * the column on existing/prod databases).
+ */
+export class Migration20260630140000 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(
+      `alter table if exists "messaging_message" add column if not exists "fail_reason" text null;`
+    );
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(
+      `alter table if exists "messaging_message" drop column if exists "fail_reason";`
+    );
+  }
+}

--- a/apps/backend/src/modules/messaging/models/message.ts
+++ b/apps/backend/src/modules/messaging/models/message.ts
@@ -17,6 +17,9 @@ const Message = model.define("messaging_message", {
     media_mime_type: model.text().nullable(),
     reply_to_id: model.text().nullable(),
     reply_to_snapshot: model.json().nullable(),
+    // Human-readable reason a delivery failed (Meta error code/title/message).
+    // Set from the WhatsApp status webhook when status flips to "failed".
+    fail_reason: model.text().nullable(),
     metadata: model.json().nullable(),
 })
 


### PR DESCRIPTION
Follow-up to #800 (which only logged Meta's error). Now the reason a WhatsApp message failed delivery is **persisted and shown to operators**.

## Changes
- **`messaging_message`**: new typed `fail_reason` text column — DML field + hand-written idempotent ALTER migration `Migration20260630140000`. Deliberately a typed column, not `metadata` (the messaging update path replaces the whole JSON blob, which would clobber existing metadata).
- **WhatsApp webhook**: on a `failed` status, build a compact `"<code> · <title> — <message> (<details>)"` from `status.errors[0]` and write it alongside `status="failed"` (still logged too, from #800).
- **Admin messaging UI**: `message-bubble` renders the `fail_reason` in small red text under a failed outbound message (instead of a bare ✗); `Message` type gains `fail_reason`. The conversation API returns the full message relation, so the field flows through with no route change.

## Verification (local)
- Migration applies; `fail_reason` column present (`\d messaging_message`).
- Conversation API returns `fail_reason`.
- Bubble renders e.g. `131026 · Message Undeliverable — Receiver is incapable of receiving this message` in red under the failed message.

(Note: required a backend restart locally so MikroORM picked up the new model field — prod boots fresh so it's automatic.)

Refs #800