### PR TITLE
feat(790): partner-ui Mark Ready for Delivery + Create shipment actions

### DIFF
--- a/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
+++ b/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
@@ -684,6 +684,20 @@ export function getPartnerRouteMap(): RouteObject[] {
                           "../../routes/inventory-orders/inventory-order-submit-payment"
                         ),
                     },
+                    {
+                      path: "inventory/ready-for-delivery",
+                      lazy: () =>
+                        import(
+                          "../../routes/inventory-orders/inventory-order-ready-for-delivery"
+                        ),
+                    },
+                    {
+                      path: "inventory/create-shipment",
+                      lazy: () =>
+                        import(
+                          "../../routes/inventory-orders/inventory-order-create-shipment"
+                        ),
+                    },
                     // #342 — design work-order task detail, folded onto the
                     // unified order detail (was `/production-runs/:id/tasks/:task_id`).
                     // Standalone partner tasks (not tied to a run) keep their own

--- a/apps/partner-ui/src/i18n/translations/en.json
+++ b/apps/partner-ui/src/i18n/translations/en.json
@@ -3424,6 +3424,8 @@
       "producing": "Producing",
       "start": "Start",
       "complete": "Complete",
+      "readyForDelivery": "Mark ready for delivery",
+      "createShipment": "Create shipment",
       "submitPayment": "Submit payment",
       "fulfillments": "Fulfillments",
       "noFulfillments": "No deliveries recorded yet.",

--- a/apps/partner-ui/src/routes/inventory-orders/inventory-order-create-shipment/index.ts
+++ b/apps/partner-ui/src/routes/inventory-orders/inventory-order-create-shipment/index.ts
@@ -1,0 +1,1 @@
+export { InventoryOrderCreateShipment as Component } from "./inventory-order-create-shipment.tsx"

--- a/apps/partner-ui/src/routes/inventory-orders/inventory-order-create-shipment/inventory-order-create-shipment.tsx
+++ b/apps/partner-ui/src/routes/inventory-orders/inventory-order-create-shipment/inventory-order-create-shipment.tsx
@@ -1,0 +1,105 @@
+import { useState } from "react"
+import { Button, Heading, Input, Label, Text, toast } from "@medusajs/ui"
+import { useQueryClient } from "@tanstack/react-query"
+
+import { RouteDrawer, useRouteModal } from "../../../components/modals"
+import { ordersQueryKeys } from "../../../hooks/api/orders"
+import { useCreatePartnerInventoryOrderShipment } from "../../../hooks/api/partner-inventory-orders"
+import { useInventoryActionTarget } from "../../../hooks/use-inventory-action-target"
+
+export const InventoryOrderCreateShipment = () => {
+  return (
+    <RouteDrawer>
+      <RouteDrawer.Header>
+        <RouteDrawer.Title asChild>
+          <Heading>Create shipment</Heading>
+        </RouteDrawer.Title>
+        <RouteDrawer.Description className="sr-only">
+          Generate a carrier shipment for this inventory order
+        </RouteDrawer.Description>
+      </RouteDrawer.Header>
+      <InventoryOrderCreateShipmentContent />
+    </RouteDrawer>
+  )
+}
+
+const InventoryOrderCreateShipmentContent = () => {
+  const { inventoryOrderId: id, unifiedOrderId } = useInventoryActionTarget()
+  const { handleSuccess } = useRouteModal()
+  const queryClient = useQueryClient()
+  const [weight, setWeight] = useState("")
+
+  const { mutateAsync, isPending } =
+    useCreatePartnerInventoryOrderShipment(id || "")
+
+  const handleConfirm = async () => {
+    if (!id) {
+      return
+    }
+
+    await mutateAsync(
+      { ...(weight ? { weight_grams: Number(weight) } : {}) },
+      {
+        onSuccess: (data) => {
+          const awb = data?.shipment?.awb || data?.shipment?.tracking_number
+          toast.success(awb ? `Shipment created — AWB ${awb}` : "Shipment created")
+          if (unifiedOrderId) {
+            queryClient.invalidateQueries({
+              queryKey: ordersQueryKeys.detail(unifiedOrderId),
+            })
+          }
+          handleSuccess()
+        },
+        onError: (e) => {
+          toast.error(e.message)
+        },
+      }
+    )
+  }
+
+  return (
+    <>
+      <RouteDrawer.Body className="flex flex-col gap-y-4">
+        <Text size="small" className="text-ui-fg-subtle">
+          Generate a carrier shipment (AWB + label) for this order using the
+          registered pickup. Weight is optional — leave it blank to use the
+          order's default.
+        </Text>
+        <div className="flex flex-col gap-y-1">
+          <Label size="small" htmlFor="weight">
+            Weight (grams)
+          </Label>
+          <Input
+            id="weight"
+            type="number"
+            value={weight}
+            onChange={(e) => setWeight(e.target.value)}
+            placeholder="500"
+          />
+        </div>
+        {!id && (
+          <Text size="small" className="text-ui-fg-subtle">
+            Missing inventory order id.
+          </Text>
+        )}
+      </RouteDrawer.Body>
+      <RouteDrawer.Footer>
+        <div className="flex items-center gap-x-2">
+          <RouteDrawer.Close asChild>
+            <Button size="small" variant="secondary">
+              Cancel
+            </Button>
+          </RouteDrawer.Close>
+          <Button
+            size="small"
+            isLoading={isPending}
+            onClick={handleConfirm}
+            disabled={!id}
+          >
+            Create shipment
+          </Button>
+        </div>
+      </RouteDrawer.Footer>
+    </>
+  )
+}

--- a/apps/partner-ui/src/routes/inventory-orders/inventory-order-ready-for-delivery/index.ts
+++ b/apps/partner-ui/src/routes/inventory-orders/inventory-order-ready-for-delivery/index.ts
@@ -1,0 +1,1 @@
+export { InventoryOrderReadyForDelivery as Component } from "./inventory-order-ready-for-delivery.tsx"

--- a/apps/partner-ui/src/routes/inventory-orders/inventory-order-ready-for-delivery/inventory-order-ready-for-delivery.tsx
+++ b/apps/partner-ui/src/routes/inventory-orders/inventory-order-ready-for-delivery/inventory-order-ready-for-delivery.tsx
@@ -1,0 +1,86 @@
+import { Button, Heading, Text, toast } from "@medusajs/ui"
+import { useQueryClient } from "@tanstack/react-query"
+
+import { RouteDrawer, useRouteModal } from "../../../components/modals"
+import { ordersQueryKeys } from "../../../hooks/api/orders"
+import { useMarkPartnerInventoryOrderReadyForDelivery } from "../../../hooks/api/partner-inventory-orders"
+import { useInventoryActionTarget } from "../../../hooks/use-inventory-action-target"
+
+export const InventoryOrderReadyForDelivery = () => {
+  return (
+    <RouteDrawer>
+      <RouteDrawer.Header>
+        <RouteDrawer.Title asChild>
+          <Heading>Mark Ready for Delivery</Heading>
+        </RouteDrawer.Title>
+        <RouteDrawer.Description className="sr-only">
+          Mark the inventory order ready for delivery
+        </RouteDrawer.Description>
+      </RouteDrawer.Header>
+      <InventoryOrderReadyForDeliveryContent />
+    </RouteDrawer>
+  )
+}
+
+const InventoryOrderReadyForDeliveryContent = () => {
+  const { inventoryOrderId: id, unifiedOrderId } = useInventoryActionTarget()
+  const { handleSuccess } = useRouteModal()
+  const queryClient = useQueryClient()
+
+  const { mutateAsync, isPending } =
+    useMarkPartnerInventoryOrderReadyForDelivery(id || "")
+
+  const handleConfirm = async () => {
+    if (!id) {
+      return
+    }
+
+    await mutateAsync(undefined, {
+      onSuccess: () => {
+        toast.success("Marked ready for delivery")
+        if (unifiedOrderId) {
+          queryClient.invalidateQueries({
+            queryKey: ordersQueryKeys.detail(unifiedOrderId),
+          })
+        }
+        handleSuccess()
+      },
+      onError: (e) => {
+        toast.error(e.message)
+      },
+    })
+  }
+
+  return (
+    <>
+      <RouteDrawer.Body>
+        <Text size="small" className="text-ui-fg-subtle">
+          This marks the order as packed and ready to hand to the carrier.
+          You can create the shipment next.
+        </Text>
+        {!id && (
+          <Text size="small" className="text-ui-fg-subtle">
+            Missing inventory order id.
+          </Text>
+        )}
+      </RouteDrawer.Body>
+      <RouteDrawer.Footer>
+        <div className="flex items-center gap-x-2">
+          <RouteDrawer.Close asChild>
+            <Button size="small" variant="secondary">
+              Cancel
+            </Button>
+          </RouteDrawer.Close>
+          <Button
+            size="small"
+            isLoading={isPending}
+            onClick={handleConfirm}
+            disabled={!id}
+          >
+            Mark Ready for Delivery
+          </Button>
+        </div>
+      </RouteDrawer.Footer>
+    </>
+  )
+}

--- a/apps/partner-ui/src/routes/orders/order-detail/components/work-order-status-section/work-order-status-section.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/components/work-order-status-section/work-order-status-section.tsx
@@ -3,6 +3,7 @@ import {
   CheckCircle,
   CurrencyDollar,
   PlaySolid,
+  TruckFast,
 } from "@medusajs/icons"
 import { Container, Copy, Heading, StatusBadge, Text } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
@@ -36,16 +37,29 @@ const buildInventoryActions = (
 ): ActionGroup[] => {
   const info = inventoryOrder?.partner_info || {}
   const status = info.partner_status
+  // #790 fulfilment actions gate on the order's CORE status (same sets the admin
+  // uses), which the partner view exposes as `inventoryOrder.status`. The
+  // endpoints enforce validity and surface a 4xx if the state is wrong.
+  const coreStatus = inventoryOrder?.status
   const showStart =
     (status === "assigned" || status === "incoming") && !info.partner_started_at
   const showComplete =
     (status === "in_progress" || status === "finished") &&
     !info.partner_completed_at
   const showSubmitPayment = !!info.partner_started_at
+  const showReadyForDelivery =
+    coreStatus === "Processing" || coreStatus === "Partial"
+  const showCreateShipment =
+    coreStatus === "Processing" ||
+    coreStatus === "Ready for Delivery" ||
+    coreStatus === "Partial" ||
+    coreStatus === "Shipped"
 
   const actions = [
     showStart && { label: t("partner.workOrders.start"), icon: <PlaySolid />, to: "inventory/start" },
     showComplete && { label: t("partner.workOrders.complete"), icon: <CheckCircle />, to: "inventory/complete" },
+    showReadyForDelivery && { label: t("partner.workOrders.readyForDelivery"), icon: <CheckCircle />, to: "inventory/ready-for-delivery" },
+    showCreateShipment && { label: t("partner.workOrders.createShipment"), icon: <TruckFast />, to: "inventory/create-shipment" },
     showSubmitPayment && { label: t("partner.workOrders.submitPayment"), icon: <CurrencyDollar />, to: "inventory/submit-payment" },
   ].filter(Boolean) as ActionGroup["actions"]
 


### PR DESCRIPTION
Wires the already-merged partner hooks (`useMarkPartnerInventoryOrderReadyForDelivery`, `useCreatePartnerInventoryOrderShipment`, from #798) into the partner app, so partners can drive inventory-order fulfilment — mirroring the admin actions.

## Changes
- **New action-route pages** (`RouteDrawer`, mirroring `inventory-order-start`):
  - `inventory/ready-for-delivery` → Mark Ready for Delivery
  - `inventory/create-shipment` → Create shipment (optional weight; shows AWB on success)
- Registered both in `get-partner-route.map.tsx`.
- **`work-order-status-section`**: gate the two actions on the order's **core** status (`inventoryOrder.status`, which the partner view exposes), using the same sets as admin:
  - Mark Ready for Delivery ← `{Processing, Partial}`
  - Create shipment ← `{Processing, Ready for Delivery, Partial, Shipped}`
  - The partner endpoints enforce validity and return a 4xx on a wrong state.
- `en.json`: `workOrders.readyForDelivery` / `workOrders.createShipment` labels.

## Verification
- `tsc --noEmit` clean on the new files.
- All four touched modules transpile via the Vite dev server with no errors.
- Full partner-login visual check needs a partner account + a seeded assigned order in the right status (heavier setup) — can do on request; the pages mirror the verified `start`/`complete` pattern exactly.

Refs #790