### PR TITLE
fix(790): partner auth for ready-for-delivery + shipment routes (401 fix)

### DIFF
--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -2382,6 +2382,24 @@ export default defineMiddlewares({
         authenticate("partner", ["session", "bearer"]),
       ],
     },
+    {
+      // #790 — partner marks an order Ready for Delivery. Without this
+      // matcher authenticate("partner") never runs, req.auth_context is
+      // undefined, and the route's own guard returns 401.
+      matcher: "/partners/inventory-orders/:orderId/ready-for-delivery",
+      method: "POST",
+      middlewares: [
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
+    {
+      // #790 — partner creates a carrier shipment for the order.
+      matcher: "/partners/inventory-orders/:orderId/shipment",
+      method: "POST",
+      middlewares: [
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
     // Partner Payments APIs
     {
       matcher: "/partners/:id/payments",


### PR DESCRIPTION
## Bug
The partner fulfilment routes added in #798 —
`POST /partners/inventory-orders/:orderId/ready-for-delivery` and `…/shipment` — were **missing their `authenticate("partner")` matchers** in `src/api/middlewares.ts`. Without the matcher the auth middleware never runs, `req.auth_context` is undefined, and each route's own guard returns **401** — so the partner-ui "Mark ready for delivery" and "Create shipment" actions (#802) failed with 401 even for a logged-in partner. The partner GET routes are matched separately, which masked it.

## Fix
Add the two missing matchers right after `/submit-payment`, mirroring the existing `/start`, `/complete`, `/submit-payment` entries (`authenticate("partner", ["session", "bearer"])`).

## Verification
Reproduced and fixed against the running partner-ui (logged-in partner, Partial order):
- **Before**: `POST …/ready-for-delivery → 401`
- **After**: `POST …/ready-for-delivery → 200`, order transitions **Partial → Ready for Delivery**.
- Same matcher covers `/shipment`, so its auth is fixed identically (full shipment still needs a carrier provider/pickup configured).

Surfaced while doing the #802 partner-login visual verification.

Refs #790, #802