### PR TITLE
fix(790): require completion before "Ready for Delivery" (block Processing)

### DIFF
--- a/apps/backend/integration-tests/http/inventory-orders-api.spec.ts
+++ b/apps/backend/integration-tests/http/inventory-orders-api.spec.ts
@@ -503,8 +503,13 @@ setupSharedTestSuite(() => {
       });
 
       it("transitions a Partial order to Ready for Delivery", async () => {
-        const created = await api.post("/admin/inventory-orders", baseOrder("Partial"), headers);
+        const created = await api.post("/admin/inventory-orders", baseOrder("Processing"), headers);
         const id = created.data.inventoryOrder.id;
+        // "Partial" is a system-set status (only the complete workflow sets it on
+        // partial fulfilment) — the create/update API validators don't accept it,
+        // so put the order into Partial directly via the module service.
+        const svc: any = getContainer().resolve("inventory_orders");
+        await svc.updateInventoryOrders({ id, status: "Partial" });
         const res = await api.post(`/admin/inventory-orders/${id}/ready-for-delivery`, {}, headers);
         expect(res.status).toBe(200);
         const got = await api.get(`/admin/inventory-orders/${id}?fields=id,status`, headers);

--- a/apps/backend/integration-tests/http/inventory-orders-api.spec.ts
+++ b/apps/backend/integration-tests/http/inventory-orders-api.spec.ts
@@ -502,13 +502,22 @@ setupSharedTestSuite(() => {
         from_stock_location_id: fromStockLocationId,
       });
 
-      it("transitions a Processing order to Ready for Delivery", async () => {
-        const created = await api.post("/admin/inventory-orders", baseOrder("Processing"), headers);
+      it("transitions a Partial order to Ready for Delivery", async () => {
+        const created = await api.post("/admin/inventory-orders", baseOrder("Partial"), headers);
         const id = created.data.inventoryOrder.id;
         const res = await api.post(`/admin/inventory-orders/${id}/ready-for-delivery`, {}, headers);
         expect(res.status).toBe(200);
         const got = await api.get(`/admin/inventory-orders/${id}?fields=id,status`, headers);
         expect(got.data.inventoryOrder.status).toBe("Ready for Delivery");
+      });
+
+      it("rejects from Processing (completion not recorded yet)", async () => {
+        const created = await api.post("/admin/inventory-orders", baseOrder("Processing"), headers);
+        const id = created.data.inventoryOrder.id;
+        const res = await api
+          .post(`/admin/inventory-orders/${id}/ready-for-delivery`, {}, headers)
+          .catch((err) => err.response);
+        expect(res.status).toBe(400);
       });
 
       it("rejects from a non-allowed status (Pending)", async () => {

--- a/apps/backend/src/admin/components/inventory-orders/inventory-order-general-section.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/inventory-order-general-section.tsx
@@ -15,8 +15,10 @@ import {
 } from "../../lib/work-status";
 import { InventoryOrderShipmentModal } from "./inventory-order-shipment-modal";
 
-// #790 — which statuses allow each action.
-const READY_FOR_DELIVERY_FROM = new Set(["Processing", "Partial"]);
+// #790 — which statuses allow each action. Ready-for-delivery requires the
+// order to be at least partially fulfilled (completion recorded) — not raw
+// "Processing", where nothing has been produced yet.
+const READY_FOR_DELIVERY_FROM = new Set(["Partial"]);
 const SHIPPABLE = new Set(["Processing", "Ready for Delivery", "Partial", "Shipped"]);
 
 export const InventoryOrderGeneralSection = ({ inventoryOrder }: { inventoryOrder: AdminInventoryOrder }) => {

--- a/apps/backend/src/admin/hooks/api/inventory-orders.ts
+++ b/apps/backend/src/admin/hooks/api/inventory-orders.ts
@@ -181,7 +181,8 @@ export const useUpdateInventoryOrder = (
   });
 };
 
-// #790 slice 3 — mark an order "Ready for Delivery" (Processing/Partial → it).
+// #790 slice 3 — mark an order "Ready for Delivery" (Partial → it; completion
+// must be recorded first, so raw "Processing" is rejected by the API).
 export const useMarkInventoryOrderReadyForDelivery = (
   id: string,
   options?: UseMutationOptions<{ order: AdminInventoryOrder }, FetchError, void>,

--- a/apps/backend/src/api/admin/inventory-orders/[id]/ready-for-delivery/route.ts
+++ b/apps/backend/src/api/admin/inventory-orders/[id]/ready-for-delivery/route.ts
@@ -8,13 +8,17 @@
  * unified mirror fire — and so it isn't blocked by the generic PUT's
  * "Pending/Processing only" edit lock (which would reject a Partial order).
  *
- * Allowed only from Processing or Partial. Success: 200 -> { order }.
+ * Allowed only from Partial (completion must be recorded first). Success: 200 -> { order }.
  */
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework";
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils";
 import { updateInventoryOrderWorkflow } from "../../../../../workflows/inventory_orders/update-inventory-order";
 
-const READY_FROM = new Set(["Processing", "Partial"]);
+// Only a partially-fulfilled order may be marked Ready for Delivery: completion
+// must be recorded first. "Processing" means started but nothing fulfilled yet,
+// so marking it ready would claim goods are packed before any were produced.
+// (Full completion already moves the order straight to "Shipped".)
+const READY_FROM = new Set(["Partial"]);
 
 export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
   const id = req.params.id;
@@ -31,7 +35,7 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
   const current = (data[0] as any).status;
   if (!READY_FROM.has(String(current ?? ""))) {
     return res.status(400).json({
-      message: `Cannot mark an inventory order "Ready for Delivery" from status '${current ?? "unknown"}'.`,
+      message: `Cannot mark "Ready for Delivery" from status '${current ?? "unknown"}' — record completion (fulfill the order) first; only a partially-fulfilled (Partial) order can be marked ready.`,
     });
   }
 

--- a/apps/backend/src/api/partners/inventory-orders/[orderId]/ready-for-delivery/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/[orderId]/ready-for-delivery/route.ts
@@ -8,14 +8,18 @@
  * IDOR-guarded route is the partner's transition. Routes through the singular
  * update workflow so the #776 status-changed event + unified-order mirror fire.
  *
- * Allowed only from Processing or Partial. Success: 200 -> { order }.
+ * Allowed only from Partial (completion must be recorded first). Success: 200 -> { order }.
  */
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework";
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils";
 import { getPartnerFromAuthContext, assertPartnerOwnsInventoryOrder } from "../../../helpers";
 import { updateInventoryOrderWorkflow } from "../../../../../workflows/inventory_orders/update-inventory-order";
 
-const READY_FROM = new Set(["Processing", "Partial"]);
+// Only a partially-fulfilled order may be marked Ready for Delivery: completion
+// must be recorded first. "Processing" means started but nothing fulfilled yet,
+// so marking it ready would claim goods are packed before any were produced.
+// (Full completion already moves the order straight to "Shipped".)
+const READY_FROM = new Set(["Partial"]);
 
 export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
   const orderId = req.params.orderId;
@@ -38,7 +42,7 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
   const current = (data?.[0] as any)?.status;
   if (!READY_FROM.has(String(current ?? ""))) {
     return res.status(400).json({
-      message: `Cannot mark an inventory order "Ready for Delivery" from status '${current ?? "unknown"}'.`,
+      message: `Cannot mark "Ready for Delivery" from status '${current ?? "unknown"}' — complete (fulfill) the order first; only a partially-fulfilled (Partial) order can be marked ready.`,
     });
   }
 

--- a/apps/partner-ui/src/routes/orders/order-detail/components/work-order-status-section/work-order-status-section.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/components/work-order-status-section/work-order-status-section.tsx
@@ -47,8 +47,9 @@ const buildInventoryActions = (
     (status === "in_progress" || status === "finished") &&
     !info.partner_completed_at
   const showSubmitPayment = !!info.partner_started_at
-  const showReadyForDelivery =
-    coreStatus === "Processing" || coreStatus === "Partial"
+  // Ready-for-delivery requires completion recorded (Partial) — not raw
+  // "Processing", where nothing has been fulfilled yet. The API enforces this.
+  const showReadyForDelivery = coreStatus === "Partial"
   const showCreateShipment =
     coreStatus === "Processing" ||
     coreStatus === "Ready for Delivery" ||


### PR DESCRIPTION
## Why
"Ready for Delivery" means goods are packed and ready for the carrier — it must come **after** completion is recorded. Previously it was allowed from `{Processing, Partial}`, so a partner could mark an order ready while still **Processing** (started, **nothing fulfilled yet**), claiming goods are packed before any were produced.

## Decision
Gate to **`{Partial}`** — a partial **Complete** records fulfilled quantities first. (Full completion already moves straight to **Shipped**, so "Ready for Delivery" is the pre-ship state for partially-fulfilled orders.)

We considered **auto-completing** on ready-for-delivery instead, but rejected it: it would assume 100% fulfillment and bypass the per-line quantity + **shortage** tracking that the explicit Complete action captures — corrupting fulfillment data for short-shipped orders.

## Changes (all four sites kept in sync)
- **admin route** + **partner route**: `READY_FROM = {Partial}`; actionable 400 message — *"complete (fulfill) the order first; only a partially-fulfilled (Partial) order can be marked ready."*
- **admin UI** (`inventory-order-general-section`) + **partner-ui** (`work-order-status-section`): only surface the action from Partial.
- **integration tests**: success path now uses a Partial order; added an explicit **"rejects from Processing"** assertion.

## Verification (local, running server)
- `POST …/ready-for-delivery` on a **Processing** order → **400** with the message above.
- On a **Partial** order → **200**, transitions to Ready for Delivery.

Refs #790