### PR TITLE
fix(783): sync "Partial" status across constants/validators/admin filter (H8)

### DIFF
--- a/apps/backend/src/admin/lib/work-status.ts
+++ b/apps/backend/src/admin/lib/work-status.ts
@@ -51,6 +51,8 @@ export const getStatusBadgeColor = (
     case "started":
     case "processing":
     case "proposed":
+    // #778 H8 — a partial/short fulfillment needs attention, like in-progress.
+    case "partial":
       return "orange"
 
     case "awaiting_review":

--- a/apps/backend/src/admin/routes/orders/inventory/page.tsx
+++ b/apps/backend/src/admin/routes/orders/inventory/page.tsx
@@ -207,11 +207,15 @@ const InventoryOrdersPage = () => {
     filterHelper.accessor("status", {
       type: "select",
       label: "Status",
+      // Keep in sync with INVENTORY_ORDER_STATUS (modules/inventory_orders/
+      // constants.ts). "Partial" is system-set on short fulfillments but must
+      // be filterable here (#778 H8).
       options: [
         { label: "Pending", value: "Pending" },
         { label: "Processing", value: "Processing" },
         { label: "Ready for Delivery", value: "Ready for Delivery" },
         { label: "Shipped", value: "Shipped" },
+        { label: "Partial", value: "Partial" },
         { label: "Delivered", value: "Delivered" },
         { label: "Cancelled", value: "Cancelled" },
       ],

--- a/apps/backend/src/api/admin/inventory-orders/validators.ts
+++ b/apps/backend/src/api/admin/inventory-orders/validators.ts
@@ -1,6 +1,10 @@
 import { z } from "@medusajs/framework/zod";
 // Query schema for listing inventory orders
-import { INVENTORY_ORDER_STATUS } from "../../../modules/inventory_orders/constants";
+import {
+  INVENTORY_ORDER_STATUS,
+  INVENTORY_ORDER_STATUS_INPUT,
+  type InventoryOrderInputStatus,
+} from "../../../modules/inventory_orders/constants";
 
 // Input schema for inventory order lines
 export const inventoryOrderLineInputSchema = z.object({
@@ -20,7 +24,14 @@ const inventoryOrdersBaseSchema = z.object({
   // Allow decimal order quantity (sum of line quantities)
   quantity: z.number().nonnegative("Order quantity must be zero or positive"),
   total_price: z.number().nonnegative("Total price must be zero or positive"),
-  status: z.enum(["Pending", "Processing", "Ready for Delivery", "Shipped", "Delivered", "Cancelled"]),
+  // System-only statuses (e.g. "Partial") are intentionally excluded — see
+  // INVENTORY_ORDER_STATUS_INPUT in the module constants (#778 H8).
+  status: z.enum(
+    INVENTORY_ORDER_STATUS_INPUT as [
+      InventoryOrderInputStatus,
+      ...InventoryOrderInputStatus[]
+    ]
+  ),
   expected_delivery_date: z.coerce.date(),
   order_date: z.coerce.date(),
   metadata: z.record(z.string(), z.unknown()).optional(),

--- a/apps/backend/src/modules/inventory_orders/__tests__/status-constants.unit.spec.ts
+++ b/apps/backend/src/modules/inventory_orders/__tests__/status-constants.unit.spec.ts
@@ -1,0 +1,40 @@
+import {
+  INVENTORY_ORDER_STATUS,
+  INVENTORY_ORDER_STATUS_INPUT,
+  INVENTORY_ORDER_SYSTEM_STATUS,
+} from "../constants"
+
+describe("inventory-order status constants (#778 H8)", () => {
+  it("includes Partial in the canonical (queryable) status set", () => {
+    expect(INVENTORY_ORDER_STATUS).toContain("Partial")
+  })
+
+  it("treats Partial as system-set only — excluded from create/update input", () => {
+    expect(INVENTORY_ORDER_SYSTEM_STATUS).toContain("Partial")
+    expect(INVENTORY_ORDER_STATUS_INPUT).not.toContain("Partial")
+  })
+
+  it("input set = canonical set minus the system-only statuses", () => {
+    const expected = INVENTORY_ORDER_STATUS.filter(
+      (s) => !(INVENTORY_ORDER_SYSTEM_STATUS as readonly string[]).includes(s)
+    )
+    expect(INVENTORY_ORDER_STATUS_INPUT).toEqual(expected)
+  })
+
+  it("keeps the canonical set aligned with the DB enum on models/order.ts", () => {
+    // The model enum is the source the DB CHECK is built from; the canonical
+    // list must be a superset/equal so a stored status is always recognised.
+    const modelEnum = [
+      "Pending",
+      "Processing",
+      "Ready for Delivery",
+      "Shipped",
+      "Delivered",
+      "Cancelled",
+      "Partial",
+    ]
+    for (const s of modelEnum) {
+      expect(INVENTORY_ORDER_STATUS).toContain(s)
+    }
+  })
+})

--- a/apps/backend/src/modules/inventory_orders/constants.ts
+++ b/apps/backend/src/modules/inventory_orders/constants.ts
@@ -1,10 +1,36 @@
+// Canonical set of inventory-order statuses. This is the SINGLE source of truth
+// — the DB enum (models/order.ts), validators, services and admin filters all
+// derive from here so they can never drift again (#778 H8).
+//
+// "Partial" is system-set only: the complete-inventory-order workflow writes it
+// when a partner records a short/partial fulfillment. It is a real, queryable
+// status (you can filter by it), but it is NOT user-settable via create/update
+// — see INVENTORY_ORDER_STATUS_INPUT below.
 export const INVENTORY_ORDER_STATUS = [
   "Pending",
   "Processing",
   // #790 — packed/ready to hand to the carrier, before the shipment/AWB exists.
   "Ready for Delivery",
   "Shipped",
+  // #778 H8 — set by the system on a partial/short fulfillment.
+  "Partial",
   "Delivered",
   "Cancelled",
 ] as const;
 export type InventoryOrderStatus = typeof INVENTORY_ORDER_STATUS[number];
+
+// System-only statuses an API client may never set directly. Keep this list
+// here (next to the canonical set) so the exclusion is intentional and visible.
+export const INVENTORY_ORDER_SYSTEM_STATUS = ["Partial"] as const;
+export type InventoryOrderSystemStatus =
+  (typeof INVENTORY_ORDER_SYSTEM_STATUS)[number];
+
+// Statuses a create/update request is allowed to set. Derived from the
+// canonical set minus the system-only ones, so adding a new status in one place
+// keeps create/update validation correct without a second edit.
+export const INVENTORY_ORDER_STATUS_INPUT = INVENTORY_ORDER_STATUS.filter(
+  (s): s is Exclude<InventoryOrderStatus, InventoryOrderSystemStatus> =>
+    !(INVENTORY_ORDER_SYSTEM_STATUS as readonly string[]).includes(s)
+);
+export type InventoryOrderInputStatus =
+  (typeof INVENTORY_ORDER_STATUS_INPUT)[number];

--- a/apps/backend/src/modules/inventory_orders/service.ts
+++ b/apps/backend/src/modules/inventory_orders/service.ts
@@ -7,6 +7,7 @@ import {
 
 import InventoryOrder from "./models/order";
 import OrderLine from "./models/orderline";
+import type { InventoryOrderInputStatus } from "./constants";
 
 import { InferTypeOf, Context } from "@medusajs/framework/types"
 import {
@@ -18,7 +19,7 @@ export type OrderLinesResponse = InferTypeOf<typeof OrderLine>[]
 interface CreateInventoryOrder {
   quantity: number;
   total_price: number;
-  status: 'Pending' | 'Processing' | 'Ready for Delivery' | 'Shipped' | 'Delivered' | 'Cancelled';
+  status: InventoryOrderInputStatus;
   expected_delivery_date: Date | undefined;
   order_date: Date | undefined;
   metadata?: Record<string, unknown>;

--- a/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
@@ -12,6 +12,7 @@ import { transform } from "@medusajs/framework/workflows-sdk";
 import { InferTypeOf } from "@medusajs/framework/types"
 import InventoryOrder from "../../modules/inventory_orders/models/order";
 import InventoryOrderService from "../../modules/inventory_orders/service";
+import type { InventoryOrderInputStatus } from "../../modules/inventory_orders/constants";
 import type { Link } from "@medusajs/modules-sdk";
 import type { IInventoryService } from "@medusajs/types";
 import { dualWriteUnifiedOrderStep } from "./dual-write-unified-order";
@@ -28,7 +29,7 @@ export interface InventoryOrderLineInput {
 export interface CreateInventoryOrderInput {
   quantity: number;
   total_price: number;
-  status: 'Pending' | 'Processing' | 'Ready for Delivery' | 'Shipped' | 'Delivered' | 'Cancelled';
+  status: InventoryOrderInputStatus;
   expected_delivery_date: Date | undefined;
   order_date: Date | undefined;
   shipping_address: Record<string, unknown>;


### PR DESCRIPTION
Part of #783 (group 4 of the #778 inventory-orders audit) — **H8: `Partial` status drift**.

## Problem
The DB enum (`models/order.ts`) includes `Partial` and the complete-inventory-order workflow actively writes it on a short/partial fulfillment (`partner-complete:374`). But `Partial` was absent from `constants.ts`, the create/update type unions (`service.ts`, `create-inventory-orders.ts`), and the admin status filter — so **you could never filter by Partial even though the system creates Partial orders**.

## Fix
- **`constants.ts` is now the single source of truth.** Adds `Partial` to the canonical `INVENTORY_ORDER_STATUS`, plus a derived `INVENTORY_ORDER_STATUS_INPUT` (canonical minus system-only statuses) and `INVENTORY_ORDER_SYSTEM_STATUS`. Adding a status in one place now keeps create/update validation correct without a second hand-maintained list.
- **Admin body validator** (`create`/`update`) derives its enum from `INVENTORY_ORDER_STATUS_INPUT` — `Partial` stays intentionally excluded because it's system-set only. The list-query filter already used the canonical set, so it now accepts `Partial` automatically.
- **Type unions** in `create-inventory-orders.ts` + `service.ts` reference the canonical input type instead of redeclaring literals that had already drifted.
- **Admin status filter** gains a `Partial` option; `work-status` badge colors it orange (needs-attention).
- **4 unit tests** pin the invariants (canonical contains Partial; input excludes it; input = canonical − system; canonical ⊇ model enum).

## Verify
- Admin → Inventory orders → filter by **Partial** → returns the short-fulfilled orders.
- `POST/PUT` an inventory order with `status: "Partial"` → rejected (system-only).
- `pnpm jest --testPathPattern=status-constants` (4 green); full module suite 46 green.

Refs #783 #778