### PR TITLE
chore(784): remove inventory-order debug logs, dead steps & stale API docs

### DIFF
--- a/apps/backend/src/admin/routes/orders/inventory/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/orders/inventory/[id]/page.tsx
@@ -12,12 +12,12 @@ import { inventoryOrderLoader } from "./loader";
 import InventoryOrderIDSection from "../../../../components/inventory-orders/inventory-order-general-orderId";
 
 const InventoryOrderDetailPage = () => {
-  const intialData = useLoaderData() as Awaited<AdminInventoryOrderResponse>
+  const initialData = useLoaderData() as Awaited<AdminInventoryOrderResponse>
   const { id } = useParams();
   const { inventoryOrder, isLoading, isError, error } = useInventoryOrder(id!, {
     fields: ['orderlines.*', 'orderlines.inventory_items.*', 'stock_locations.*', 'stock_locations.address.*', '+tasks.*', '+partner.*', '+internal_payments.*', '+internal_payments.attachments.*']
   }, {
-    initialData: intialData
+    initialData
   });
   
   // Show loading skeleton while data is being fetched

--- a/apps/backend/src/api/admin/inventory-orders/[id]/order-lines/route.ts
+++ b/apps/backend/src/api/admin/inventory-orders/[id]/order-lines/route.ts
@@ -11,9 +11,10 @@
  * Request:
  * - Path parameter:
  *   - id: string — the inventory order id to update
- * - Body (JSON):
- *   - data?: Record<string, any> — optional top-level metadata/attributes to update
- *   - order_lines?: Array<any> — optional array of order line updates
+ * - Body (JSON): see updateInventoryOrderLinesSchema (validators.ts)
+ *   - data?: { quantity?: number; total_price?: number } — optional order totals
+ *   - order_lines: Array<{ id?: string; inventory_item_id: string; quantity: number; price: number }>
+ *     The full desired set of lines (existing lines carry `id`; new lines omit it).
  *
  * Response:
  * - 200: { inventoryOrder: object } — the refreshed inventory order after the update
@@ -21,31 +22,31 @@
  * Errors:
  * - Throws the workflow errors if the update workflow returns any errors.
  *
- * @param req - MedusaRequest; req.params.id is required, body should contain `data` and/or `order_lines`
+ * @param req - MedusaRequest; req.params.id is required, body must contain `order_lines` (and optional `data`)
  * @param res - MedusaResponse; used to return the updated inventoryOrder
  *
  * @example Curl
- * curl -X PUT "https://example.com/admin/inventory-orders/ord_123/order-lines" \
+ * curl -X PUT "https://example.com/admin/inventory-orders/inv_order_123/order-lines" \
  *   -H "Content-Type: application/json" \
  *   -H "Authorization: Bearer <ADMIN_TOKEN>" \
  *   -d '{
- *     "data": { "status": "received", "notes": "Updated via API" },
+ *     "data": { "quantity": 15, "total_price": 120 },
  *     "order_lines": [
- *       { "id": "ol_1", "quantity": 10 },
- *       { "id": "ol_2", "quantity": 0, "action": "remove" }
+ *       { "id": "ol_1", "inventory_item_id": "iitem_A", "quantity": 10, "price": 8 },
+ *       { "inventory_item_id": "iitem_B", "quantity": 5, "price": 8 }
  *     ]
  *   }'
  *
  * @example Fetch (Node / Browser)
- * const res = await fetch("/admin/inventory-orders/ord_123/order-lines", {
+ * const res = await fetch("/admin/inventory-orders/inv_order_123/order-lines", {
  *   method: "PUT",
  *   headers: {
  *     "Content-Type": "application/json",
  *     "Authorization": "Bearer <ADMIN_TOKEN>"
  *   },
  *   body: JSON.stringify({
- *     data: { status: "received" },
- *     order_lines: [{ id: "ol_1", quantity: 5 }]
+ *     data: { quantity: 5 },
+ *     order_lines: [{ id: "ol_1", inventory_item_id: "iitem_A", quantity: 5, price: 8 }]
  *   })
  * });
  * const { inventoryOrder } = await res.json();

--- a/apps/backend/src/api/admin/inventory-orders/route.ts
+++ b/apps/backend/src/api/admin/inventory-orders/route.ts
@@ -4,30 +4,35 @@
  * POST /admin/inventory-orders
  * - Description: Create a new inventory order via the createInventoryOrderWorkflow.
  * - Permissions: Admin
- * - Request Body (application/json): CreateInventoryOrder
+ * - Request Body (application/json): see createInventoryOrdersSchema (validators.ts)
  *   Example:
  *   {
- *     "supplier_id": "sup_123",
- *     "items": [
- *       { "sku": "FABRIC_A", "quantity": 200, "unit_price": 4.5 },
- *       { "sku": "TRIM_B", "quantity": 50, "unit_price": 1.25 }
+ *     "order_lines": [
+ *       { "inventory_item_id": "iitem_FABRIC_A", "quantity": 200, "price": 4.5 },
+ *       { "inventory_item_id": "iitem_TRIM_B", "quantity": 50, "price": 1.25 }
  *     ],
+ *     "quantity": 250,
+ *     "total_price": 962.5,
+ *     "status": "Pending",
+ *     "order_date": "2026-01-14T00:00:00.000Z",
  *     "expected_delivery_date": "2026-02-15T00:00:00.000Z",
- *     "notes": "Urgent run for spring collection"
+ *     "shipping_address": { "city": "Delhi", "country_code": "in" },
+ *     "stock_location_id": "sloc_warehouse",
+ *     "is_sample": false
  *   }
  * - Success (201):
  *   Content-Type: application/json
  *   Example:
  *   {
  *     "inventoryOrder": {
- *       "id": "invord_abc123",
- *       "supplier_id": "sup_123",
- *       "status": "pending",
- *       "items": [
- *         { "sku": "FABRIC_A", "quantity": 200, "unit_price": 4.5 },
- *         { "sku": "TRIM_B", "quantity": 50, "unit_price": 1.25 }
+ *       "id": "inv_order_abc123",
+ *       "status": "Pending",
+ *       "quantity": 250,
+ *       "total_price": 962.5,
+ *       "orderlines": [
+ *         { "id": "...", "inventory_id": "iitem_FABRIC_A", "quantity": 200, "price": 4.5 },
+ *         { "id": "...", "inventory_id": "iitem_TRIM_B", "quantity": 50, "price": 1.25 }
  *       ],
- *       "total_price": 1000.0,
  *       "expected_delivery_date": "2026-02-15T00:00:00.000Z",
  *       "created_at": "2026-01-14T12:00:00.000Z"
  *     }
@@ -40,7 +45,7 @@
  * curl -X POST "https://api.example.com/admin/inventory-orders" \
  *   -H "Authorization: Bearer <ADMIN_TOKEN>" \
  *   -H "Content-Type: application/json" \
- *   -d '{ "supplier_id":"sup_123", "items":[{"sku":"FABRIC_A","quantity":200,"unit_price":4.5}], "expected_delivery_date":"2026-02-15T00:00:00.000Z" }'
+ *   -d '{ "order_lines":[{"inventory_item_id":"iitem_FABRIC_A","quantity":200,"price":4.5}], "quantity":200, "total_price":900, "status":"Pending", "order_date":"2026-01-14T00:00:00.000Z", "expected_delivery_date":"2026-02-15T00:00:00.000Z", "shipping_address":{"city":"Delhi","country_code":"in"}, "stock_location_id":"sloc_warehouse" }'
  *
  * --------------------------------------------------------------------------
  *
@@ -49,14 +54,14 @@
  * - Permissions: Admin
  * - Query Parameters (see listInventoryOrdersQuerySchema):
  *   - q (string)         : text search / id
- *   - status (string)    : one of InventoryOrderStatus (e.g. pending, received, cancelled)
+ *   - status (string)    : one of INVENTORY_ORDER_STATUS (e.g. "Pending", "Processing", "Partial", "Delivered", "Cancelled")
  *   - quantity (number)  : exact quantity filter
  *   - total_price (number): exact total price filter
  *   - expected_delivery_date (ISO date)
  *   - order_date (ISO date)
  *   - order (string)     : "created_at:desc" or "total_price:asc" (parsed by parseOrderParam)
  *   - offset (number)    : pagination offset (default 0)
- *   - limit (number)     : pagination limit (default 50)
+ *   - limit (number)     : pagination limit (default 20, max 100)
  * - Success (200):
  *   Content-Type: application/json
  *   Example:

--- a/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
@@ -1,4 +1,4 @@
-import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils";
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils";
 import {
   createWorkflow,
   createStep,
@@ -14,7 +14,6 @@ import InventoryOrder from "../../modules/inventory_orders/models/order";
 import InventoryOrderService from "../../modules/inventory_orders/service";
 import type { InventoryOrderInputStatus } from "../../modules/inventory_orders/constants";
 import type { Link } from "@medusajs/modules-sdk";
-import type { IInventoryService } from "@medusajs/types";
 import { dualWriteUnifiedOrderStep } from "./dual-write-unified-order";
 export type InventoryOrder = InferTypeOf<typeof InventoryOrder>;
 
@@ -41,29 +40,6 @@ export interface CreateInventoryOrderInput {
 }
 
 // --- Inventory Orders Steps ---
-
-export const validateInventoryStep = createStep(
-  "validate-inventory-step",
-  async (input: CreateInventoryOrderInput, { container }) => {
-    const inventoryService = container.resolve(Modules.INVENTORY) as IInventoryService;
-    const missingItems: string[] = [];
-    for (const line of input.order_lines) {
-      try {
-        await inventoryService.retrieveInventoryItem(line.inventory_item_id);
-      } catch (err) {
-        // If not found, Medusa's retrieveInventoryItem should throw
-        missingItems.push(line.inventory_item_id);
-      }
-    }
-    if (missingItems.length > 0) {
-      throw new MedusaError(
-        MedusaError.Types.NOT_FOUND,
-        `Inventory items not found: ${missingItems.join(", ")}`
-      );
-    }
-    return new StepResponse(true);
-  }
-);
 
 export const createInventoryOrderWithLinesStep = createStep(
   "create-inventory-order-with-lines-step",

--- a/apps/backend/src/workflows/inventory_orders/create-tasks-from-templates.ts
+++ b/apps/backend/src/workflows/inventory_orders/create-tasks-from-templates.ts
@@ -158,12 +158,8 @@ export const createTasksFromTemplatesWorkflow = createWorkflow(
       { input },
       (data) => {
         const { inventoryOrderId, ...taskInput } = data.input;
-        // CRITICAL: Ensure that workflow input metadata (including assignment_notes) 
-        // is preserved and will be merged with template metadata
-        if ('metadata' in taskInput && taskInput.metadata) {
-        }
-        console.log(taskInput)
-        
+        // Workflow input metadata (including assignment_notes) is preserved here
+        // and merged with template metadata downstream.
         return taskInput;
       }
     );

--- a/apps/backend/src/workflows/inventory_orders/inventory-order-steps.ts
+++ b/apps/backend/src/workflows/inventory_orders/inventory-order-steps.ts
@@ -21,14 +21,14 @@ export const setInventoryOrderStepSuccessStep = createStep(
         { stepId, updatedOrder }: SetInventoryOrderStepSuccessInput,
         { container, context }
     ) {
-        console.log("setInventoryOrderStepSuccessStep", updatedOrder)
+        const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
         const engineService = container.resolve(
             Modules.WORKFLOW_ENGINE
         ) as IWorkflowEngineService
-        
+
         // Get the workflow transaction ID from associated tasks instead of order metadata
         const query = container.resolve(ContainerRegistrationKeys.QUERY) as Omit<RemoteQueryFunction, symbol>
-        
+
         // Find tasks linked to this inventory order that have a transaction ID
         const taskLinksResult = await query.graph({
             entity: "inventory_orders",
@@ -42,14 +42,7 @@ export const setInventoryOrderStepSuccessStep = createStep(
             }
         })
         const taskLinks = taskLinksResult.data || []
-        try {
-            const first = Array.isArray(taskLinks) ? taskLinks[0] : undefined
-            const tasksPreview = first?.tasks ? first.tasks.map((t: any) => ({ id: t.id, status: t.status })) : []
-            console.log("taskLinksResult preview", { count: taskLinks.length, tasksPreview })
-        } catch (e) {
-            console.warn("Unable to log taskLinksResult safely")
-        }
-        
+
         // Find a task with a transaction ID (should be one of the partner workflow tasks)
         let workflowTransactionId: string | null = null
         for (const order of taskLinks) {
@@ -68,12 +61,10 @@ export const setInventoryOrderStepSuccessStep = createStep(
             throw new Error(`No workflow transaction ID found in tasks for inventory order ${updatedOrder.id}`);
         }
         
-        console.log("Setting inventory order step success:", {
-            stepId,
-            workflowTransactionId,
-            workflowName: sendInventoryOrderToPartnerWorkflow.getName()
-        });
-        
+        logger.debug(
+            `[inventory-order] step success stepId=${stepId} txn=${workflowTransactionId} workflow=${sendInventoryOrderToPartnerWorkflow.getName()}`
+        )
+
         await engineService.setStepSuccess({
             idempotencyKey: {
                 action: TransactionHandlerType.INVOKE,
@@ -98,6 +89,7 @@ export const setInventoryOrderStepFailedStep = createStep(
         { stepId, updatedOrder, error }: SetInventoryOrderStepFailedInput,
         { container }
     ) {
+        const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
         const engineService = container.resolve(
             Modules.WORKFLOW_ENGINE
         ) as IWorkflowEngineService
@@ -138,13 +130,10 @@ export const setInventoryOrderStepFailedStep = createStep(
             throw new Error(`No workflow transaction ID found in tasks for inventory order ${updatedOrder.id}`);
         }
         
-        console.log("Setting inventory order step failure:", {
-            stepId,
-            workflowTransactionId,
-            error,
-            workflowName: sendInventoryOrderToPartnerWorkflow.getName()
-        });
-        
+        logger.debug(
+            `[inventory-order] step failure stepId=${stepId} txn=${workflowTransactionId} error=${error ?? ""} workflow=${sendInventoryOrderToPartnerWorkflow.getName()}`
+        )
+
         await engineService.setStepFailure({
             idempotencyKey: {
                 action: TransactionHandlerType.INVOKE,

--- a/apps/backend/src/workflows/inventory_orders/partner-complete-inventory-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/partner-complete-inventory-order.ts
@@ -29,37 +29,6 @@ export type PartnerCompleteInventoryOrderInput = {
 
 // Step: prepare fulfillment payloads (filters happen inside the step)
 
-// Debug step: logs stock posting decisions and computed arrays
-const debugStockPostingStep = createStep(
-  "partner-complete-debug-stock-posting",
-  async (
-    input: {
-      orderId: string
-      orderDestLocation?: string | null
-      deliveredLines?: Array<{ order_line_id: string; quantity: number }>
-      levels?: Array<{ location_id: string; inventory_item_id: string; stocked_quantity: number }>
-      existing?: Array<{ id: string; location_id: string; inventory_item_id: string; stocked_quantity: number }>
-      missing?: Array<{ location_id: string; inventory_item_id: string; stocked_quantity: number }>
-      createInputs?: Array<{ inventory_item_id: string; location_id: string; stocked_quantity: number; incoming_quantity?: number }>
-      updates?: Array<{ id: string; inventory_item_id: string; location_id: string; stocked_quantity: number }>
-    }
-  ) => {
-    try {
-      console.log("[WF][partner-complete] orderId=", input.orderId)
-      console.log("[WF][partner-complete] orderDestLocation=", input.orderDestLocation)
-      console.log("[WF][partner-complete] deliveredLines=", JSON.stringify(input.deliveredLines || [], null, 2))
-      console.log("[WF][partner-complete] inventoryLevelsInput (levels)=", JSON.stringify(input.levels || [], null, 2))
-      console.log("[WF][partner-complete] existingLevels=", JSON.stringify(input.existing || [], null, 2))
-      console.log("[WF][partner-complete] missingPairs=", JSON.stringify(input.missing || [], null, 2))
-      console.log("[WF][partner-complete] createInputs=", JSON.stringify(input.createInputs || [], null, 2))
-      console.log("[WF][partner-complete] updates=", JSON.stringify(input.updates || [], null, 2))
-    } catch (e) {
-      // no-op
-    }
-    return new StepResponse(null)
-  }
-)
-
 // Step: resolve existing inventory levels for given (item, location) pairs
 export const resolveExistingLevelsStep = createStep(
   "partner-complete-resolve-existing-levels",
@@ -94,21 +63,6 @@ export const resolveExistingLevelsStep = createStep(
   }
 )
 
-// Debug step: logs partial completion context at execution time
-const debugPartialCompletionStep = createStep(
-  "partner-complete-debug-partial",
-  async (
-    input: { orderId: string; shortages: Array<{ orderLineId?: string; shortage?: number }>; transactionId?: string },
-    { context }
-  ) => {
-    try {
-      const shortages = Array.isArray(input.shortages) ? input.shortages : []
-      const compact = shortages.map((s: any) => ({ line: s.orderLineId || s.order_line_id, shortage: s.shortage }))
-    } catch (e) {
-    }
-    return new StepResponse(null)
-  }
-)
 const prepareFulfillmentPayloadsStep = createStep(
   "partner-complete-prepare-fulfillment-payloads",
   async (
@@ -562,18 +516,12 @@ export const partnerCompleteInventoryOrderWorkflow = createWorkflow(
         ...summaryTask,
       }))
 
-      // Protect API from being blocked by task creation issues in partial path
-      try {
-        createTasksFromTemplatesWorkflow.runAsStep({
-          input: taskWorkflowInput as any,
-        })
-      } catch (e) {
-      }
-
-      // Additional focused debug log for partial completion
-      debugPartialCompletionStep({
-        orderId: input.orderId,
-        shortages: shortagesList as unknown as any[],
+      // Create the partial-completion summary task. NOTE: a try/catch here is
+      // ineffective — runAsStep registers a step at composition time, so it
+      // cannot swallow a runtime failure. If task creation must be non-blocking,
+      // that has to be handled inside the workflow itself.
+      createTasksFromTemplatesWorkflow.runAsStep({
+        input: taskWorkflowInput as any,
       })
     })
 
@@ -670,23 +618,6 @@ export const partnerCompleteInventoryOrderWorkflow = createWorkflow(
         })
       }
     )
-
-    // Log computed state for debugging stock postings
-    const orderDestLocationForLog = transform({ v: validated, input }, ({ v, input }) => {
-      const order = v.order as any
-      return String(input?.stock_location_id || order.to_stock_location_id || order.stock_location_id || order.destination_stock_location_id || "")
-    })
-    const deliveredLinesForLog = transform({ v: validated }, ({ v }) => (v.completionMetadata?.partner_delivered_lines || []))
-    debugStockPostingStep({
-      orderId: input.orderId,
-      orderDestLocation: orderDestLocationForLog as unknown as string,
-      deliveredLines: deliveredLinesForLog as unknown as any[],
-      levels: inventoryLevelsInput as unknown as any[],
-      existing: existing as unknown as any[],
-      missing: missing as unknown as any[],
-      createInputs: createInputs as unknown as any[],
-      updates: updates as unknown as any[],
-    })
 
     const hasUpdates = transform({ updates }, ({ updates }) => Array.isArray(updates) && (updates as any[]).length > 0)
 

--- a/apps/backend/src/workflows/inventory_orders/send-to-partner.ts
+++ b/apps/backend/src/workflows/inventory_orders/send-to-partner.ts
@@ -70,60 +70,6 @@ const validateInventoryOrderStep = createStep(
     }
 )
 
-// Detect if this order already has the partner workflow tasks (idempotency guard)
-const checkExistingPartnerAssignmentStep = createStep(
-    "check-existing-partner-assignment",
-    async (input: { orderId: string }, { container }) => {
-        const query = container.resolve(ContainerRegistrationKeys.QUERY) as Omit<RemoteQueryFunction, symbol>
-        const { data } = await query.graph({
-            entity: "inventory_orders",
-            fields: ["id", "tasks.*"],
-            filters: { id: input.orderId },
-        })
-        const orders = data || []
-        let taskIds: string[] = []
-        let hasAssignment = false
-        if (orders.length > 0) {
-            const order: any = orders[0]
-            const tasks: any[] = Array.isArray(order.tasks) ? order.tasks : []
-            taskIds = tasks.map((t) => t.id).filter(Boolean)
-            // Consider assigned if any of the partner templates exist
-            hasAssignment = tasks.some((t) =>
-                ["partner-order-sent", "partner-order-received", "partner-order-shipped"].includes(t?.title)
-            )
-        }
-        return new StepResponse({ hasAssignment, taskIds })
-    }
-)
-
-// If tasks already exist, just (re)set their transaction IDs for coordination
-const setExistingTasksTransactionIdsStep = createStep(
-    "set-existing-task-transaction-ids",
-    async (input: { orderId: string }, { container, context }) => {
-        const taskService: TaskService = container.resolve(TASKS_MODULE)
-        const query = container.resolve(ContainerRegistrationKeys.QUERY) as Omit<RemoteQueryFunction, symbol>
-        const workflowTransactionId = context.transactionId
-
-        const { data } = await query.graph({
-            entity: "inventory_orders",
-            fields: ["id", "tasks.*"],
-            filters: { id: input.orderId },
-        })
-        const orders = data || []
-        const tasks: any[] = orders.length > 0 ? (orders[0] as any).tasks || [] : []
-        const updated: any[] = []
-        for (const t of tasks) {
-            const upd = await taskService.updateTasks({
-                id: t.id,
-                transaction_id: workflowTransactionId,
-                status: (t.title || "").includes("sent") ? "completed" : t.status || "pending",
-            })
-            updated.push(upd)
-        }
-        return new StepResponse({ count: updated.length })
-    }
-)
-
 const validatePartnerStep = createStep(
     "validate-partner",
     async (input: SendInventoryOrderToPartnerInput, { container }) => {


### PR DESCRIPTION
Part of #784 (group 5 of the #778 inventory-orders audit) — **cleanup (LOW)**. No behavior change.

## Removed
- The two no-op **debug steps** `debugStockPostingStep` / `debugPartialCompletionStep` (one just dumped `console.log`s, the other computed and discarded) + their log-only feeder transforms.
- The **ineffective try/catch** around `createTasksFromTemplatesWorkflow.runAsStep` — `runAsStep` registers a step at composition time, so the catch can never swallow a runtime failure. Kept the call; corrected the misleading "Protect API…" comment.
- **Dead steps** `checkExistingPartnerAssignmentStep`, `setExistingTasksTransactionIdsStep` (defined, never invoked) and the unused exported `validateInventoryStep` (already removed from the workflow per its own comment) + the imports that became unused.

## Logging
- Converted the two operational `console.log`s in `inventory-order-steps.ts` (step success/failure) to `logger.debug` (single-string, per #701).
- Dropped pure debug dumps in `inventory-order-steps.ts` and `create-tasks-from-templates.ts`.

## Fixes
- `intialData` → `initialData` typo on the inventory-order detail page.
- **Stale API docs**: the POST example used non-existent `supplier_id` / `items[].sku` / `unit_price` / lowercase status; the GET note listed a bogus `received` status and wrong limit default; the order-lines doc referenced a non-existent `action:"remove"` and a free-form `data` blob. All rewritten to match `createInventoryOrdersSchema` / `updateInventoryOrderLinesSchema`.

## Not in this PR
- "Duplicate step IDs across files" (issue note) — step IDs are scoped per workflow, so cross-file duplicates aren't an actual collision; left as-is.
- `id!` on the detail page — kept; it's the established admin-route pattern (params are guaranteed by the route) and an early return before the data hook would violate rules-of-hooks.
- Admin `PUT /order-lines` ignoring its validated body + `PUT /:id` response wrapping → these are correctness bugs, handled in the **784a** PR.

## Verify
- Inventory module unit suite: 46 green.
- `tsc`: no new errors in touched files.

Refs #784 #778