### PR TITLE
fix(784): inventory-order API correctness — proper error codes & shapes (H10)

### DIFF
--- a/apps/backend/src/api/admin/inventory-orders/[id]/order-lines/route.ts
+++ b/apps/backend/src/api/admin/inventory-orders/[id]/order-lines/route.ts
@@ -70,13 +70,16 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
 import { updateInventoryOrderWorkflow } from "../../../../../workflows/inventory_orders/update-inventory-orders";
 import { refetchInventoryOrder } from "../../helpers";
+import type { UpdateInventoryOrderLines } from "../../validators";
 
 export const PUT = async (
   req: MedusaRequest,
   res: MedusaResponse
 ) => {
   const { id } = req.params;
-  const payload = req.body as any;
+  // #778 H10 — use the validated/transformed body (a validator is registered
+  // for this route in middlewares.ts), not the raw req.body.
+  const payload = req.validatedBody as UpdateInventoryOrderLines;
 
   const { result, errors } = await updateInventoryOrderWorkflow(req.scope).run({
     input: {
@@ -87,7 +90,9 @@ export const PUT = async (
   });
 
   if (errors.length > 0) {
-    throw errors;
+    // Throw the underlying MedusaError so it maps to the right 4xx, not the
+    // raw errors array.
+    throw errors[0].error;
   }
 
   const inventoryOrder = await refetchInventoryOrder(id, req.scope);

--- a/apps/backend/src/api/admin/inventory-orders/[id]/route.ts
+++ b/apps/backend/src/api/admin/inventory-orders/[id]/route.ts
@@ -102,10 +102,14 @@ export const PUT = async (
 
   const { errors } = await updateInventoryOrderWorkflow(req.scope).run({ input });
   if (errors.length > 0) {
-    return res.status(400).json({ errors });
+    // #778 H10 — surface the underlying MedusaError so the status reflects the
+    // failure type (NOT_FOUND→404, NOT_ALLOWED→403, …) instead of a blanket 400.
+    throw errors[0].error;
   }
   const inventoryOrder = await refetchInventoryOrder(id, req.scope);
-  return res.status(200).json(inventoryOrder);
+  // #778 H10 — wrap the payload as { inventoryOrder } to match GET and the
+  // admin hook's expected shape (an unwrapped object broke cache/parse).
+  return res.status(200).json({ inventoryOrder });
 };
 
 

--- a/apps/backend/src/api/partners/inventory-orders/[orderId]/complete/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/[orderId]/complete/route.ts
@@ -186,10 +186,10 @@ export async function POST(
             }
         })
         if (errors && errors.length > 0) {
-            return res.status(500).json({
-                error: "Failed to complete inventory order",
-                details: errors
-            })
+            // #778 H10 — let the underlying error drive the HTTP status. A
+            // MedusaError (NOT_ALLOWED/INVALID_DATA/NOT_FOUND) maps to the right
+            // 4xx via the framework error handler; only genuine failures 500.
+            throw errors[0].error
         }
 
         // #772 — opt-in carrier shipment. Runs only after the completion

--- a/apps/backend/src/api/partners/inventory-orders/[orderId]/start/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/[orderId]/start/route.ts
@@ -178,11 +178,8 @@ export async function POST(
     });
     
     if (errors && errors.length > 0) {
-        console.warn("Error updating inventory order:", errors);
-        return res.status(500).json({
-            error: "Failed to update inventory order",
-            details: errors
-        });
+        // #778 H10 — surface the real error; MedusaError types map to 4xx.
+        throw errors[0].error
     }
     
     // Mark the "received" task as completed to update partner status
@@ -226,11 +223,8 @@ export async function POST(
     });
     
     if (stepErrors && stepErrors.length > 0) {
-        console.warn("Error signaling workflow:", stepErrors);
-        return res.status(500).json({
-            error: "Failed to update workflow",
-            details: stepErrors
-        });
+        // #778 H10 — surface the real error; MedusaError types map to 4xx.
+        throw stepErrors[0].error
     }
     
     res.status(200).json({

--- a/apps/backend/src/api/partners/inventory-orders/[orderId]/submit-payment/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/[orderId]/submit-payment/route.ts
@@ -70,10 +70,8 @@ export async function POST(
     });
 
     if (errors && errors.length > 0) {
-        return res.status(500).json({
-            error: "Failed to submit payment",
-            details: errors
-        });
+        // #778 H10 — surface the real error; MedusaError types map to 4xx.
+        throw errors[0].error
     }
 
     return res.status(200).json({

--- a/apps/backend/src/api/partners/inventory-orders/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/route.ts
@@ -262,10 +262,14 @@ export async function GET(
             offset
         });
     } catch (error) {
-        console.error("[Inventory Orders] Error:", error);
-        return res.status(500).json({
-            error: "Failed to fetch inventory orders",
-            details: error instanceof Error ? error.message : String(error)
-        });
+        const logger = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+        logger.error(
+            "[partner inventory-orders] list failed",
+            error instanceof Error ? error : new Error(String(error))
+        )
+        // #778 H10 — don't leak internal error details to the client; let the
+        // framework error handler produce a sanitized response (MedusaError
+        // types still map to the right 4xx).
+        throw error
     }
 }


### PR DESCRIPTION
Part of #784 (group 5 of the #778 inventory-orders audit) — **H10: API correctness**.

## Problem
Partner mutation routes returned a blanket **500** even for business errors (invalid state, not-allowed, not-found), the partner list route **leaked internal `error.message`** to the client, and two admin routes were sloppy: `PUT /:id/order-lines` ignored its validated body (`req.body as any`) and `PUT /:id` returned an **unwrapped** object the admin hook didn't expect.

## Fix (mirrors the production-runs pattern)
Surface the underlying `MedusaError` so the framework maps it to the correct status — `NOT_FOUND→404`, `NOT_ALLOWED→403`, `INVALID_DATA→400` — and only genuine failures 500.

- **partners** `complete` / `start` / `submit-payment`: `throw errors[0].error` instead of `res.status(500)` (start had two blocks + a `console.warn`).
- **partners** inventory-orders **list**: stop returning raw `error.message`; log via the container logger and re-throw for a sanitized framework response.
- **admin** `PUT /:id/order-lines`: read `req.validatedBody` (a validator *is* registered in `middlewares.ts`) instead of `req.body as any`; `throw errors[0].error` not the raw array.
- **admin** `PUT /:id`: wrap as `{ inventoryOrder }` (matches `GET` and the typed `AdminInventoryOrderResponse` hook shape — the unwrapped object broke cache/parse) and throw the mapped error instead of a blanket 400.

## Verify
- As partner A, `POST /partners/inventory-orders/:B/start` (B owned by another partner) → **404** (was already 404 via C1; confirms the global handler maps MedusaError).
- `start` an order not in `Pending` → **400** with the business message (already explicit) ; a workflow business error now returns its real 4xx instead of 500.
- Admin edit order lines → response is `{ inventoryOrder }`; detail view refreshes without a parse glitch.
- Inventory module unit suite: 46 green; `tsc` clean on touched files.

Refs #784 #778