### PR TITLE
fix(782): apply the configured await timeout to inventory-order async steps (H12)

### DIFF
--- a/apps/backend/src/workflows/inventory_orders/send-to-partner.ts
+++ b/apps/backend/src/workflows/inventory_orders/send-to-partner.ts
@@ -184,6 +184,9 @@ const awaitOrderStart = createStep(
     {
         name: 'await-order-start',
         async: true,
+        // #778 H12 — actually apply the configured await timeout (was computed
+        // but never wired), mirroring production-run lifecycle steps.
+        timeout: AWAIT_TIMEOUT_SECONDS,
         maxRetries: 2
     },
     async (_, { container }) => {
@@ -195,6 +198,8 @@ const awaitOrderCompletion = createStep(
     {
         name: 'await-order-completion',
         async: true,
+        // #778 H12 — apply the configured await timeout (see awaitOrderStart).
+        timeout: AWAIT_TIMEOUT_SECONDS,
         maxRetries: 2
     },
     async (_, { container }) => {


### PR DESCRIPTION
Part of #782 (group 3 of the #778 inventory-orders audit) — **H12**.

`AWAIT_TIMEOUT_SECONDS` is carefully computed in `send-to-partner.ts` (env override `INVENTORY_AWAIT_TIMEOUT_SECONDS`, 23-day default, Node `setTimeout` clamp) — but it was **never applied**: the `awaitOrderStart` / `awaitOrderCompletion` async steps had no `timeout`, so a partner order that's never started/completed could wait indefinitely for its external `setStepSuccess` signal.

Fix: add `timeout: AWAIT_TIMEOUT_SECONDS` to both async step configs, exactly mirroring the production-run lifecycle steps (`run-production-run-lifecycle.ts:69/79/89`).

## Verify
- Inventory module unit suite: 46 green.
- `tsc`: clean on touched file.

Refs #782 #778