### PR TITLE
fix(784): index + CHECK-constrain inventory-order tables (H-hygiene)

### DIFF
--- a/apps/backend/src/modules/inventory_orders/migrations/Migration20260630160000.ts
+++ b/apps/backend/src/modules/inventory_orders/migrations/Migration20260630160000.ts
@@ -1,0 +1,58 @@
+import { Migration } from '@mikro-orm/migrations';
+
+/**
+ * #778 group 5 (H-hygiene) — inventory-order data-layer hardening:
+ *
+ *  1. Indexes on the columns the admin/partner lists actually filter & sort by
+ *     (status, is_sample, order_date, expected_delivery_date). These were
+ *     missing despite the API supporting filtering/sorting on them.
+ *  2. CHECK constraints so quantity / price can never go negative at the DB
+ *     level — defence in depth behind the Zod validators (which already enforce
+ *     `nonnegative`). Note: `>= 0`, NOT `> 0` — sample orders and freshly seeded
+ *     order lines legitimately carry quantity 0.
+ *
+ * All statements are idempotent (hand-written ALTER, never edit the create-table
+ * migration — that only runs on fresh DBs and would never land on existing/prod
+ * databases; recurring hazard). `create index if not exists` is natively
+ * idempotent; CHECK constraints are guarded via pg_constraint DO-blocks because
+ * Postgres has no `add constraint if not exists`.
+ */
+export class Migration20260630160000 extends Migration {
+
+  override async up(): Promise<void> {
+    // --- Indexes -----------------------------------------------------------
+    this.addSql(`create index if not exists "IDX_inventory_orders_status" on "inventory_orders" ("status");`);
+    this.addSql(`create index if not exists "IDX_inventory_orders_is_sample" on "inventory_orders" ("is_sample");`);
+    this.addSql(`create index if not exists "IDX_inventory_orders_order_date" on "inventory_orders" ("order_date");`);
+    this.addSql(`create index if not exists "IDX_inventory_orders_expected_delivery_date" on "inventory_orders" ("expected_delivery_date");`);
+
+    // --- CHECK constraints (idempotent via pg_constraint guard) -------------
+    this.addSql(`do $$ begin
+      if not exists (select 1 from pg_constraint where conname = 'inventory_orders_quantity_check') then
+        alter table "inventory_orders" add constraint "inventory_orders_quantity_check" check ("quantity" >= 0);
+      end if;
+      if not exists (select 1 from pg_constraint where conname = 'inventory_orders_total_price_check') then
+        alter table "inventory_orders" add constraint "inventory_orders_total_price_check" check ("total_price" >= 0);
+      end if;
+      if not exists (select 1 from pg_constraint where conname = 'inventory_order_line_quantity_check') then
+        alter table "inventory_order_line" add constraint "inventory_order_line_quantity_check" check ("quantity" >= 0);
+      end if;
+      if not exists (select 1 from pg_constraint where conname = 'inventory_order_line_price_check') then
+        alter table "inventory_order_line" add constraint "inventory_order_line_price_check" check ("price" >= 0);
+      end if;
+    end $$;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "inventory_orders" drop constraint if exists "inventory_orders_quantity_check";`);
+    this.addSql(`alter table if exists "inventory_orders" drop constraint if exists "inventory_orders_total_price_check";`);
+    this.addSql(`alter table if exists "inventory_order_line" drop constraint if exists "inventory_order_line_quantity_check";`);
+    this.addSql(`alter table if exists "inventory_order_line" drop constraint if exists "inventory_order_line_price_check";`);
+
+    this.addSql(`drop index if exists "IDX_inventory_orders_status";`);
+    this.addSql(`drop index if exists "IDX_inventory_orders_is_sample";`);
+    this.addSql(`drop index if exists "IDX_inventory_orders_order_date";`);
+    this.addSql(`drop index if exists "IDX_inventory_orders_expected_delivery_date";`);
+  }
+
+}


### PR DESCRIPTION
Part of #784 (group 5 of the #778 inventory-orders audit) — **data-layer hygiene**.

## What
Idempotent, hand-written ALTER migration (`Migration20260630160000`):

**Indexes** — on the columns the admin/partner lists filter & sort by but had none:
`status`, `is_sample`, `order_date`, `expected_delivery_date`.

**CHECK constraints** — defence in depth behind the Zod `nonnegative` validators:
- `inventory_orders`: `quantity >= 0`, `total_price >= 0`
- `inventory_order_line`: `quantity >= 0`, `price >= 0`

`>= 0` (not `> 0`) on purpose — sample orders and freshly seeded order lines legitimately carry quantity `0`.

## Idempotency / prod-safety
`create index if not exists` is natively idempotent; CHECK constraints are guarded with `pg_constraint` DO-blocks (Postgres has no `add constraint if not exists`). Never edits the create-table migration (recurring on-main hazard).

**Verified against a real DB**: ran it; all 4 indexes + 4 constraints land and `Migration20260630160000` records in `mikro_orm_migrations`.

## Deferred
`created_by`/`updated_by` columns → better served by the #782 (H4) activity log (records the actor per action, not just last-writer on the row).

Refs #784 #778