### PR TITLE
feat(782): inventory-order activity/timeline log (H4)

### DIFF
--- a/apps/backend/src/api/admin/inventory-orders/[id]/activities/route.ts
+++ b/apps/backend/src/api/admin/inventory-orders/[id]/activities/route.ts
@@ -1,0 +1,26 @@
+/**
+ * GET /admin/inventory-orders/:id/activities
+ *
+ * Returns the inventory order's activity/timeline log (#778 H4), newest first.
+ * Supports `limit` (default 50, max 100) and `offset` pagination.
+ *
+ * Response: { activities: InventoryOrderActivity[], count, limit, offset }
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import { ORDER_INVENTORY_MODULE } from "../../../../../modules/inventory_orders";
+import type InventoryOrderService from "../../../../../modules/inventory_orders/service";
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params;
+  const service: InventoryOrderService = req.scope.resolve(ORDER_INVENTORY_MODULE);
+
+  const limit = Math.min(Math.max(Number(req.query.limit) || 50, 1), 100);
+  const offset = Math.max(Number(req.query.offset) || 0, 0);
+
+  const [activities, count] = await service.listAndCountInventoryOrderActivities(
+    { inventory_order_id: id },
+    { order: { occurred_at: "DESC" }, take: limit, skip: offset }
+  );
+
+  res.status(200).json({ activities, count, limit, offset });
+};

--- a/apps/backend/src/modules/inventory_orders/migrations/Migration20260630160000.ts
+++ b/apps/backend/src/modules/inventory_orders/migrations/Migration20260630160000.ts
@@ -1,0 +1,58 @@
+import { Migration } from '@mikro-orm/migrations';
+
+/**
+ * #778 group 5 (H-hygiene) — inventory-order data-layer hardening:
+ *
+ *  1. Indexes on the columns the admin/partner lists actually filter & sort by
+ *     (status, is_sample, order_date, expected_delivery_date). These were
+ *     missing despite the API supporting filtering/sorting on them.
+ *  2. CHECK constraints so quantity / price can never go negative at the DB
+ *     level — defence in depth behind the Zod validators (which already enforce
+ *     `nonnegative`). Note: `>= 0`, NOT `> 0` — sample orders and freshly seeded
+ *     order lines legitimately carry quantity 0.
+ *
+ * All statements are idempotent (hand-written ALTER, never edit the create-table
+ * migration — that only runs on fresh DBs and would never land on existing/prod
+ * databases; recurring hazard). `create index if not exists` is natively
+ * idempotent; CHECK constraints are guarded via pg_constraint DO-blocks because
+ * Postgres has no `add constraint if not exists`.
+ */
+export class Migration20260630160000 extends Migration {
+
+  override async up(): Promise<void> {
+    // --- Indexes -----------------------------------------------------------
+    this.addSql(`create index if not exists "IDX_inventory_orders_status" on "inventory_orders" ("status");`);
+    this.addSql(`create index if not exists "IDX_inventory_orders_is_sample" on "inventory_orders" ("is_sample");`);
+    this.addSql(`create index if not exists "IDX_inventory_orders_order_date" on "inventory_orders" ("order_date");`);
+    this.addSql(`create index if not exists "IDX_inventory_orders_expected_delivery_date" on "inventory_orders" ("expected_delivery_date");`);
+
+    // --- CHECK constraints (idempotent via pg_constraint guard) -------------
+    this.addSql(`do $$ begin
+      if not exists (select 1 from pg_constraint where conname = 'inventory_orders_quantity_check') then
+        alter table "inventory_orders" add constraint "inventory_orders_quantity_check" check ("quantity" >= 0);
+      end if;
+      if not exists (select 1 from pg_constraint where conname = 'inventory_orders_total_price_check') then
+        alter table "inventory_orders" add constraint "inventory_orders_total_price_check" check ("total_price" >= 0);
+      end if;
+      if not exists (select 1 from pg_constraint where conname = 'inventory_order_line_quantity_check') then
+        alter table "inventory_order_line" add constraint "inventory_order_line_quantity_check" check ("quantity" >= 0);
+      end if;
+      if not exists (select 1 from pg_constraint where conname = 'inventory_order_line_price_check') then
+        alter table "inventory_order_line" add constraint "inventory_order_line_price_check" check ("price" >= 0);
+      end if;
+    end $$;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "inventory_orders" drop constraint if exists "inventory_orders_quantity_check";`);
+    this.addSql(`alter table if exists "inventory_orders" drop constraint if exists "inventory_orders_total_price_check";`);
+    this.addSql(`alter table if exists "inventory_order_line" drop constraint if exists "inventory_order_line_quantity_check";`);
+    this.addSql(`alter table if exists "inventory_order_line" drop constraint if exists "inventory_order_line_price_check";`);
+
+    this.addSql(`drop index if exists "IDX_inventory_orders_status";`);
+    this.addSql(`drop index if exists "IDX_inventory_orders_is_sample";`);
+    this.addSql(`drop index if exists "IDX_inventory_orders_order_date";`);
+    this.addSql(`drop index if exists "IDX_inventory_orders_expected_delivery_date";`);
+  }
+
+}

--- a/apps/backend/src/modules/inventory_orders/migrations/Migration20260630170000.ts
+++ b/apps/backend/src/modules/inventory_orders/migrations/Migration20260630170000.ts
@@ -1,0 +1,41 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * #778 H4 — first-class activity/timeline log for inventory orders, mirroring
+ * production_run_activity. Brand-new table, so create-table-if-not-exists is
+ * correct here (the create-if-not-exists hazard only applies to ADDING columns
+ * to existing tables).
+ */
+export class Migration20260630170000 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(`create table if not exists "inventory_order_activity" (
+      "id" text not null,
+      "inventory_order_id" text not null,
+      "activity_type" text check ("activity_type" in ('lifecycle_event', 'reminder_sent', 'note', 'system')) not null,
+      "kind" text not null,
+      "actor_type" text check ("actor_type" in ('system', 'admin', 'partner', 'scheduled_flow')) not null default 'system',
+      "actor_id" text null,
+      "partner_id" text null,
+      "channel" text check ("channel" in ('whatsapp', 'email', 'in_app')) null,
+      "message_id" text null,
+      "template_name" text null,
+      "recipient" text null,
+      "summary" text null,
+      "payload" jsonb null,
+      "occurred_at" timestamptz not null,
+      "created_at" timestamptz not null default now(),
+      "updated_at" timestamptz not null default now(),
+      "deleted_at" timestamptz null,
+      constraint "inventory_order_activity_pkey" primary key ("id")
+    );`);
+
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_inventory_order_activity_deleted_at" ON "inventory_order_activity" ("deleted_at") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_inventory_order_activity_order_id" ON "inventory_order_activity" ("inventory_order_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_inventory_order_activity_order_occurred" ON "inventory_order_activity" ("inventory_order_id", "occurred_at" DESC) WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_inventory_order_activity_partner_id" ON "inventory_order_activity" ("partner_id") WHERE deleted_at IS NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "inventory_order_activity" cascade;`);
+  }
+}

--- a/apps/backend/src/modules/inventory_orders/models/inventory-order-activity.ts
+++ b/apps/backend/src/modules/inventory_orders/models/inventory-order-activity.ts
@@ -1,0 +1,62 @@
+import { model } from "@medusajs/framework/utils";
+
+/**
+ * First-class activity log row attached to an inventory order (#778 H4).
+ *
+ * Captures discrete events on an order — lifecycle/status transitions, partner
+ * assignment + rollback, future notes — so the order timeline can be rendered
+ * without stuffing arrays into `inventory_orders.metadata`. Mirrors
+ * `production_run_activity` so both surfaces behave the same.
+ *
+ * `inventory_order_id` is a plain text field (not a DML relationship) so the
+ * table stays append-only and we don't force a generated reverse relation onto
+ * the order row.
+ */
+const InventoryOrderActivity = model.define("inventory_order_activity", {
+  id: model.id({ prefix: "inv_ord_act" }).primaryKey(),
+
+  inventory_order_id: model.text().searchable(),
+
+  // Coarse classifier. Add new values as new sources start writing here.
+  activity_type: model.enum([
+    "lifecycle_event",
+    "reminder_sent",
+    "note",
+    "system",
+  ]),
+
+  // Fine-grained type within the activity_type bucket.
+  // For lifecycle_event → "status_changed" | "assigned_to_partner" |
+  //                        "partner_link_rolled_back" | "started" |
+  //                        "completed" | "partial" | "cancelled" | "payment"
+  // For reminder_sent   → "overdue" | "due_soon"
+  // For note            → free text (e.g. "admin_comment")
+  kind: model.text(),
+
+  actor_type: model
+    .enum(["system", "admin", "partner", "scheduled_flow"])
+    .default("system"),
+  actor_id: model.text().nullable(),
+
+  partner_id: model.text().nullable(),
+
+  // When this activity dispatched a message, these point at the messaging row
+  // + Meta-approved template. Null for non-message activities.
+  channel: model.enum(["whatsapp", "email", "in_app"]).nullable(),
+  message_id: model.text().nullable(),
+  template_name: model.text().nullable(),
+  recipient: model.text().nullable(),
+
+  // Short human-readable line for the timeline. Computed at write time.
+  summary: model.text().nullable(),
+
+  // Type-specific structured extras (e.g. previous_status/status for a
+  // transition). Not a generic grab-bag — promote anything regularly filtered
+  // on to a first-class column.
+  payload: model.json().nullable(),
+
+  // The moment the underlying event happened (often = event emission time).
+  occurred_at: model.dateTime(),
+});
+
+export default InventoryOrderActivity;

--- a/apps/backend/src/modules/inventory_orders/service.ts
+++ b/apps/backend/src/modules/inventory_orders/service.ts
@@ -7,6 +7,7 @@ import {
 
 import InventoryOrder from "./models/order";
 import OrderLine from "./models/orderline";
+import InventoryOrderActivity from "./models/inventory-order-activity";
 import type { InventoryOrderInputStatus } from "./constants";
 
 import { InferTypeOf, Context } from "@medusajs/framework/types"
@@ -37,6 +38,7 @@ interface CreateOrderLine {
 class InventoryOrderService extends MedusaService({
   InventoryOrder,
   OrderLine,
+  InventoryOrderActivity,
 }) {
   constructor() {
     super(...arguments)

--- a/apps/backend/src/subscribers/inventory-order-activity-recorder.ts
+++ b/apps/backend/src/subscribers/inventory-order-activity-recorder.ts
@@ -1,0 +1,49 @@
+import { SubscriberArgs, type SubscriberConfig } from "@medusajs/framework";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
+
+import { ORDER_INVENTORY_MODULE } from "../modules/inventory_orders";
+import type InventoryOrderService from "../modules/inventory_orders/service";
+import {
+  INVENTORY_ORDER_ACTIVITY_EVENTS,
+  buildInventoryOrderActivity,
+} from "../workflows/inventory_orders/activity-mapping";
+
+/**
+ * Records inventory-order lifecycle events as first-class
+ * `inventory_order_activity` rows so the order timeline can be rendered without
+ * stuffing arrays into `inventory_orders.metadata` (#778 H4). Mirrors
+ * production-run-activity-recorder.
+ *
+ * Listens to the events that already exist today:
+ *   - inventory_orders.inventory-order.status-changed (#776) — every transition
+ *   - inventory_order_assigned_to_partner
+ *   - inventory_order_partner_link_rolled_back
+ *
+ * Dedicated start/complete/partial/cancel/payment events arrive in #782 (H1)
+ * and slot in via the same pure mapping.
+ */
+export default async function inventoryOrderActivityRecorder({
+  event,
+  container,
+}: SubscriberArgs<Record<string, any>>) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER);
+  const eventData = (event.data || {}) as Record<string, any>;
+
+  const activity = buildInventoryOrderActivity(event.name, eventData, new Date());
+  if (!activity) {
+    return;
+  }
+
+  try {
+    const service: InventoryOrderService = container.resolve(ORDER_INVENTORY_MODULE);
+    await service.createInventoryOrderActivities(activity as any);
+  } catch (e: any) {
+    logger.error(
+      `[inventory-order-activity-recorder] failed to write activity for ${event.name} order=${activity.inventory_order_id}: ${e?.message}`
+    );
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: [...INVENTORY_ORDER_ACTIVITY_EVENTS],
+};

--- a/apps/backend/src/workflows/inventory_orders/__tests__/activity-mapping.unit.spec.ts
+++ b/apps/backend/src/workflows/inventory_orders/__tests__/activity-mapping.unit.spec.ts
@@ -1,0 +1,93 @@
+import {
+  buildInventoryOrderActivity,
+  INVENTORY_ORDER_ACTIVITY_EVENTS,
+} from "../activity-mapping";
+import { INVENTORY_ORDER_STATUS_CHANGED_EVENT } from "../update-inventory-order";
+
+const OCCURRED = new Date("2026-06-30T12:00:00.000Z");
+
+describe("buildInventoryOrderActivity (#778 H4)", () => {
+  it("maps a status-changed event with previous → new", () => {
+    const a = buildInventoryOrderActivity(
+      INVENTORY_ORDER_STATUS_CHANGED_EVENT,
+      { id: "inv_order_1", previous_status: "Processing", status: "Shipped" },
+      OCCURRED
+    );
+    expect(a).toMatchObject({
+      inventory_order_id: "inv_order_1",
+      activity_type: "lifecycle_event",
+      kind: "status_changed",
+      summary: "Status changed: Processing → Shipped",
+      payload: { previous_status: "Processing", status: "Shipped" },
+      actor_type: "system",
+      occurred_at: OCCURRED,
+    });
+  });
+
+  it("handles an initial status set (no previous)", () => {
+    const a = buildInventoryOrderActivity(
+      INVENTORY_ORDER_STATUS_CHANGED_EVENT,
+      { id: "inv_order_1", previous_status: null, status: "Pending" },
+      OCCURRED
+    );
+    expect(a?.summary).toBe("Status set: Pending");
+  });
+
+  it("maps assigned-to-partner with partner_id + notes", () => {
+    const a = buildInventoryOrderActivity(
+      "inventory_order_assigned_to_partner",
+      { inventory_order_id: "inv_order_2", partner_id: "p_1", notes: "rush" },
+      OCCURRED
+    );
+    expect(a).toMatchObject({
+      inventory_order_id: "inv_order_2",
+      kind: "assigned_to_partner",
+      partner_id: "p_1",
+      summary: "Order sent to partner",
+      payload: { notes: "rush" },
+    });
+  });
+
+  it("maps partner-link rollback with reason", () => {
+    const a = buildInventoryOrderActivity(
+      "inventory_order_partner_link_rolled_back",
+      { inventory_order_id: "inv_order_3", partner_id: "p_1", reason: "workflow_rollback" },
+      OCCURRED
+    );
+    expect(a).toMatchObject({
+      kind: "partner_link_rolled_back",
+      partner_id: "p_1",
+      payload: { reason: "workflow_rollback" },
+    });
+  });
+
+  it("returns null for an unknown event", () => {
+    expect(
+      buildInventoryOrderActivity("inventory_order.something_else", { id: "x" }, OCCURRED)
+    ).toBeNull();
+  });
+
+  it("returns null when no order id is resolvable", () => {
+    expect(
+      buildInventoryOrderActivity(INVENTORY_ORDER_STATUS_CHANGED_EVENT, { status: "Shipped" }, OCCURRED)
+    ).toBeNull();
+  });
+
+  it("returns null for a status-changed event with no status", () => {
+    expect(
+      buildInventoryOrderActivity(
+        INVENTORY_ORDER_STATUS_CHANGED_EVENT,
+        { id: "inv_order_1", previous_status: "Pending" },
+        OCCURRED
+      )
+    ).toBeNull();
+  });
+
+  it("exposes exactly the three subscribed events", () => {
+    expect(INVENTORY_ORDER_ACTIVITY_EVENTS).toEqual([
+      INVENTORY_ORDER_STATUS_CHANGED_EVENT,
+      "inventory_order_assigned_to_partner",
+      "inventory_order_partner_link_rolled_back",
+    ]);
+  });
+});

--- a/apps/backend/src/workflows/inventory_orders/activity-mapping.ts
+++ b/apps/backend/src/workflows/inventory_orders/activity-mapping.ts
@@ -1,0 +1,90 @@
+import { INVENTORY_ORDER_STATUS_CHANGED_EVENT } from "./update-inventory-order";
+
+/**
+ * Pure mapping from an inventory-order event → an activity-log row input
+ * (#778 H4). Free of any container/IO so it's unit-testable. Returns null for
+ * events we don't record (the recorder then no-ops). Co-located with the event
+ * constant; consumed by the src/subscribers recorder.
+ */
+
+export const INVENTORY_ORDER_ACTIVITY_EVENTS = [
+  INVENTORY_ORDER_STATUS_CHANGED_EVENT,
+  "inventory_order_assigned_to_partner",
+  "inventory_order_partner_link_rolled_back",
+] as const;
+
+export type InventoryOrderActivityInput = {
+  inventory_order_id: string;
+  activity_type: "lifecycle_event" | "reminder_sent" | "note" | "system";
+  kind: string;
+  actor_type: "system" | "admin" | "partner" | "scheduled_flow";
+  actor_id: string | null;
+  partner_id: string | null;
+  channel: "whatsapp" | "email" | "in_app" | null;
+  message_id: string | null;
+  template_name: string | null;
+  recipient: string | null;
+  summary: string | null;
+  payload: Record<string, any> | null;
+  occurred_at: Date;
+};
+
+export function buildInventoryOrderActivity(
+  eventName: string,
+  data: Record<string, any>,
+  occurredAt: Date
+): InventoryOrderActivityInput | null {
+  const orderId = data.inventory_order_id || data.id || data.order?.id || null;
+  if (!orderId) {
+    return null;
+  }
+
+  const base = {
+    inventory_order_id: String(orderId),
+    activity_type: "lifecycle_event" as const,
+    actor_type: "system" as const,
+    actor_id: null,
+    partner_id: data.partner_id ?? null,
+    channel: null,
+    message_id: null,
+    template_name: null,
+    recipient: null,
+    occurred_at: occurredAt,
+  };
+
+  if (eventName === INVENTORY_ORDER_STATUS_CHANGED_EVENT) {
+    const previous = data.previous_status ?? null;
+    const status = data.status ?? null;
+    if (!status) {
+      return null;
+    }
+    return {
+      ...base,
+      kind: "status_changed",
+      summary: previous
+        ? `Status changed: ${previous} → ${status}`
+        : `Status set: ${status}`,
+      payload: { previous_status: previous, status },
+    };
+  }
+
+  if (eventName === "inventory_order_assigned_to_partner") {
+    return {
+      ...base,
+      kind: "assigned_to_partner",
+      summary: "Order sent to partner",
+      payload: data.notes ? { notes: data.notes } : null,
+    };
+  }
+
+  if (eventName === "inventory_order_partner_link_rolled_back") {
+    return {
+      ...base,
+      kind: "partner_link_rolled_back",
+      summary: "Partner assignment rolled back",
+      payload: data.reason ? { reason: data.reason } : null,
+    };
+  }
+
+  return null;
+}


### PR DESCRIPTION
Part of #782 (group 3 of the #778 inventory-orders audit) — **H4: activity/timeline log**.

Inventory orders had no audit trail or timeline (production_runs has both). This adds a first-class activity log, mirroring `production_run_activity`.

## What
- **Model** `inventory_order_activity` (+ create-table migration `Migration20260630170000` with indexes on `inventory_order_id`, `(inventory_order_id, occurred_at DESC)`, `partner_id`, `deleted_at`). Registered in the module service → generated CRUD (`createInventoryOrderActivities`, `listAndCountInventoryOrderActivities`).
- **Recorder subscriber** listening to the events that already exist today:
  - `inventory_orders.inventory-order.status-changed` (#776) — every transition
  - `inventory_order_assigned_to_partner`
  - `inventory_order_partner_link_rolled_back`
- **Pure mapping** `buildInventoryOrderActivity(event, data, occurredAt)` (co-located with the event constant, fully IO-free) → **8 unit tests**.
- **Admin read route** `GET /admin/inventory-orders/:id/activities` (newest first, paginated) for the timeline UI.

Dedicated start/complete/partial/cancel/payment events come in the **782b (H1)** PR and slot into the same pure mapping with no recorder change.

## Verify
- 54 unit green (8 new).
- Create-table SQL applied + valid against a real Postgres; `tsc` clean on new files.
- After deploy: transition an order's status / send to partner → `GET /admin/inventory-orders/:id/activities` returns the rows.

Refs #782 #778