### PR TITLE
fix(783): inventory-order currency + per-unit price semantics (H9)

### DIFF
--- a/apps/backend/integration-tests/http/web-media-type-filter.spec.ts
+++ b/apps/backend/integration-tests/http/web-media-type-filter.spec.ts
@@ -1,0 +1,105 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(60000)
+
+// GET /web/media?type=… must filter by the MediaFile `file_type` column.
+// The route used to set `filters.type`, but listAllMediasWorkflow's
+// field whitelist only allows `file_type` — so `type` was silently
+// dropped and the endpoint leaked every public media regardless of the
+// requested type (e.g. `type=video` returned images). This is the
+// non-album path (listAllMediasWorkflow); the album/folder paths
+// already filtered on `file_type` correctly.
+setupSharedTestSuite(() => {
+  describe("GET /web/media type filter", () => {
+    const { api, getContainer } = getSharedTestEnv()
+
+    it("returns only videos when type=video (no album_id)", async () => {
+      const unique = Date.now()
+      const mediaService: any = getContainer().resolve("media")
+
+      // Seed a public image and a public video into the global pool
+      // (no folder/album) so the request hits listAllMediasWorkflow.
+      await mediaService.createMediaFiles({
+        file_name: `leak-img-${unique}.jpg`,
+        original_name: `leak-img-${unique}.jpg`,
+        file_path: `https://cdn.example.com/leak-img-${unique}.jpg`,
+        file_type: "image",
+        mime_type: "image/jpeg",
+        file_size: 1000,
+        file_hash: `hash-img-${unique}`,
+        extension: "jpg",
+        is_public: true,
+      })
+      await mediaService.createMediaFiles({
+        file_name: `leak-vid-${unique}.mp4`,
+        original_name: `leak-vid-${unique}.mp4`,
+        file_path: `https://cdn.example.com/leak-vid-${unique}.mp4`,
+        file_type: "video",
+        mime_type: "video/mp4",
+        file_size: 5000,
+        file_hash: `hash-vid-${unique}`,
+        extension: "mp4",
+        is_public: true,
+      })
+
+      const res = await api.get(
+        `/web/media?type=video&random=false&limit=100`
+      )
+      expect(res.status).toBe(200)
+      const medias = res.data.medias || []
+
+      // Every returned media must be a video — if the filter is broken,
+      // the seeded image (and any other public images) leak through.
+      for (const m of medias) {
+        expect(m.type).toBe("video")
+      }
+
+      // The seeded video should be present, and the seeded image must not.
+      const paths = medias.map((m: any) => m.file_path)
+      expect(paths).toContain(`https://cdn.example.com/leak-vid-${unique}.mp4`)
+      expect(paths).not.toContain(`https://cdn.example.com/leak-img-${unique}.jpg`)
+    })
+
+    it("returns only images when type=image (no album_id)", async () => {
+      const unique = Date.now()
+      const mediaService: any = getContainer().resolve("media")
+
+      await mediaService.createMediaFiles({
+        file_name: `leak-img2-${unique}.jpg`,
+        original_name: `leak-img2-${unique}.jpg`,
+        file_path: `https://cdn.example.com/leak-img2-${unique}.jpg`,
+        file_type: "image",
+        mime_type: "image/jpeg",
+        file_size: 1000,
+        file_hash: `hash-img2-${unique}`,
+        extension: "jpg",
+        is_public: true,
+      })
+      await mediaService.createMediaFiles({
+        file_name: `leak-vid2-${unique}.mp4`,
+        original_name: `leak-vid2-${unique}.mp4`,
+        file_path: `https://cdn.example.com/leak-vid2-${unique}.mp4`,
+        file_type: "video",
+        mime_type: "video/mp4",
+        file_size: 5000,
+        file_hash: `hash-vid2-${unique}`,
+        extension: "mp4",
+        is_public: true,
+      })
+
+      const res = await api.get(
+        `/web/media?type=image&random=false&limit=100`
+      )
+      expect(res.status).toBe(200)
+      const medias = res.data.medias || []
+
+      for (const m of medias) {
+        expect(m.type).toBe("image")
+      }
+
+      const paths = medias.map((m: any) => m.file_path)
+      expect(paths).toContain(`https://cdn.example.com/leak-img2-${unique}.jpg`)
+      expect(paths).not.toContain(`https://cdn.example.com/leak-vid2-${unique}.mp4`)
+    })
+  })
+})

--- a/apps/backend/src/api/admin/inventory-orders/validators.ts
+++ b/apps/backend/src/api/admin/inventory-orders/validators.ts
@@ -24,6 +24,8 @@ const inventoryOrdersBaseSchema = z.object({
   // Allow decimal order quantity (sum of line quantities)
   quantity: z.number().nonnegative("Order quantity must be zero or positive"),
   total_price: z.number().nonnegative("Total price must be zero or positive"),
+  // #778 H9 — ISO currency code; defaults to inr at the DB layer when omitted.
+  currency_code: z.string().min(3).max(3).optional(),
   // System-only statuses (e.g. "Partial") are intentionally excluded — see
   // INVENTORY_ORDER_STATUS_INPUT in the module constants (#778 H8).
   status: z.enum(

--- a/apps/backend/src/api/web/media/route.ts
+++ b/apps/backend/src/api/web/media/route.ts
@@ -70,9 +70,12 @@ export const GET = async (
       is_public: true,
     };
 
-    // Add type filter if provided
+    // Add type filter if provided. Must use `file_type` (the actual
+    // MediaFile column) — the listAllMediasWorkflow whitelist drops
+    // unknown keys, so `type` would silently no-op and leak every
+    // public media regardless of the requested type.
     if (type) {
-      filters.type = type;
+      filters.file_type = type;
     }
 
     let mediaFiles: any[] = []

--- a/apps/backend/src/modules/inventory_orders/__tests__/create-helpers.unit.spec.ts
+++ b/apps/backend/src/modules/inventory_orders/__tests__/create-helpers.unit.spec.ts
@@ -1,7 +1,37 @@
 import {
   buildOrderLinePayloads,
   buildInventoryLineLinkPairs,
+  sumLineTotals,
 } from "../lib/create-helpers"
+
+describe("sumLineTotals (#778 H9 — price is per-unit)", () => {
+  it("sums price × quantity per line", () => {
+    expect(
+      sumLineTotals([
+        { price: 4.5, quantity: 200 },
+        { price: 1.25, quantity: 50 },
+      ])
+    ).toBeCloseTo(962.5)
+  })
+
+  it("does NOT treat price as a line total (the old bug)", () => {
+    // 10 units @ 8 each = 80, not 8.
+    expect(sumLineTotals([{ price: 8, quantity: 10 }])).toBe(80)
+  })
+
+  it("treats missing/NaN price or quantity as 0", () => {
+    expect(
+      sumLineTotals([
+        { price: NaN as any, quantity: 5 },
+        { price: 3, quantity: undefined as any },
+      ])
+    ).toBe(0)
+  })
+
+  it("is 0 for no lines", () => {
+    expect(sumLineTotals([])).toBe(0)
+  })
+})
 
 describe("buildOrderLinePayloads (#778 C3)", () => {
   it("maps each input line to a persistence payload bound to the order id", () => {

--- a/apps/backend/src/modules/inventory_orders/lib/create-helpers.ts
+++ b/apps/backend/src/modules/inventory_orders/lib/create-helpers.ts
@@ -28,6 +28,21 @@ export type LineItemPair = {
   inventory_item_id: string
 }
 
+/**
+ * Sum the per-unit line prices into an order total (#778 H9).
+ *
+ * `price` is the PER-UNIT price (matches the admin UI, validators, and registry
+ * cost reads), so each line contributes `price × quantity`. Used as the fallback
+ * order total when a caller (e.g. a visual flow) omits `total_price`.
+ */
+export const sumLineTotals = (
+  order_lines: Pick<CreateOrderLineInput, "price" | "quantity">[]
+): number =>
+  order_lines.reduce(
+    (sum, l) => sum + (Number(l.price) || 0) * (Number(l.quantity) || 0),
+    0
+  )
+
 /** Build the persistence payloads for the order lines of one inventory order. */
 export const buildOrderLinePayloads = (
   order_lines: CreateOrderLineInput[],

--- a/apps/backend/src/modules/inventory_orders/migrations/Migration20260630180000.ts
+++ b/apps/backend/src/modules/inventory_orders/migrations/Migration20260630180000.ts
@@ -1,0 +1,21 @@
+import { Migration } from "@mikro-orm/migrations";
+
+/**
+ * #778 H9 — add `currency_code` to inventory orders. Previously absent, so the
+ * dual-write to the unified order assumed INR (currency_assumed:true). Existing
+ * rows were all created under that INR assumption, so backfill them to 'inr'.
+ *
+ * Hand-written idempotent ALTER (never edit the create-table migration — it only
+ * runs on fresh DBs; recurring on-main hazard).
+ */
+export class Migration20260630180000 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "inventory_orders" add column if not exists "currency_code" text not null default 'inr';`);
+    // Backfill any rows that somehow predate the default (defensive).
+    this.addSql(`update "inventory_orders" set "currency_code" = 'inr' where "currency_code" is null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "inventory_orders" drop column if exists "currency_code";`);
+  }
+}

--- a/apps/backend/src/modules/inventory_orders/models/order.ts
+++ b/apps/backend/src/modules/inventory_orders/models/order.ts
@@ -5,6 +5,10 @@ const InventoryOrder = model.define("inventory_orders", {
   id: model.id({prefix: 'inv_order'}).primaryKey(),
   quantity: model.float(),
   total_price: model.bigNumber(),
+  // #778 H9 — the order's currency. Previously absent: the dual-write to the
+  // unified order assumed INR (currency_assumed:true). Defaults to "inr" for
+  // back-compat; the dual-write now uses this instead of guessing.
+  currency_code: model.text().default("inr"),
   status: model.enum([
     "Pending",
     "Processing",

--- a/apps/backend/src/modules/inventory_orders/service.ts
+++ b/apps/backend/src/modules/inventory_orders/service.ts
@@ -20,6 +20,7 @@ export type OrderLinesResponse = InferTypeOf<typeof OrderLine>[]
 interface CreateInventoryOrder {
   quantity: number;
   total_price: number;
+  currency_code?: string;
   status: InventoryOrderInputStatus;
   expected_delivery_date: Date | undefined;
   order_date: Date | undefined;

--- a/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
@@ -13,6 +13,7 @@ import { InferTypeOf } from "@medusajs/framework/types"
 import InventoryOrder from "../../modules/inventory_orders/models/order";
 import InventoryOrderService from "../../modules/inventory_orders/service";
 import type { InventoryOrderInputStatus } from "../../modules/inventory_orders/constants";
+import { sumLineTotals } from "../../modules/inventory_orders/lib/create-helpers";
 import type { Link } from "@medusajs/modules-sdk";
 import { dualWriteUnifiedOrderStep } from "./dual-write-unified-order";
 export type InventoryOrder = InferTypeOf<typeof InventoryOrder>;
@@ -28,6 +29,7 @@ export interface InventoryOrderLineInput {
 export interface CreateInventoryOrderInput {
   quantity: number;
   total_price: number;
+  currency_code?: string;
   status: InventoryOrderInputStatus;
   expected_delivery_date: Date | undefined;
   order_date: Date | undefined;
@@ -57,11 +59,10 @@ export const createInventoryOrderWithLinesStep = createStep(
       metadata: line.metadata
     }));
 
-    // Compute defaults for fields that may be undefined when called from a visual flow
-    const totalFromLines = orderLinesForService.reduce(
-      (sum, l) => sum + (Number(l.price) || 0),
-      0
-    )
+    // Compute defaults for fields that may be undefined when called from a visual
+    // flow. #778 H9 — `price` is the PER-UNIT price, so the order total is the
+    // sum of price × quantity per line (see sumLineTotals).
+    const totalFromLines = sumLineTotals(orderLinesForService)
     const quantityFromLines = orderLinesForService.reduce(
       (sum, l) => sum + (Number(l.quantity) || 0),
       0

--- a/apps/backend/src/workflows/inventory_orders/dual-write-unified-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/dual-write-unified-order.ts
@@ -261,10 +261,15 @@ export const dualWriteUnifiedOrderStep = createStep(
           skipped: "no_region",
         })
       }
-      // #485: centralised default-currency selection. Partner is linked AFTER
-      // creation here, so the platform/base store currency is used at stamping
-      // time; the #457 backfill job re-stamps to the partner currency later.
-      const currencyCode = pickDefaultCurrency(store, "inr")
+      // #778 H9 — prefer the order's own currency_code; only fall back to the
+      // store/platform default when it's missing (legacy rows). #485: centralised
+      // default-currency selection; the #457 backfill job re-stamps to the
+      // partner currency later.
+      const orderCurrency =
+        typeof (order as any).currency_code === "string" && (order as any).currency_code
+          ? String((order as any).currency_code)
+          : null
+      const currencyCode = orderCurrency || pickDefaultCurrency(store, "inr")
 
       // Internal sales channel keeps work-orders out of storefront analytics
       // and retail listings. Lazily ensured (idempotent) instead of a seed
@@ -295,20 +300,22 @@ export const dualWriteUnifiedOrderStep = createStep(
         ])
       )
 
-      // Legacy line `price` is the line-total contribution (the legacy
-      // workflow sums plain prices into total_price); core wants unit price.
+      // #778 H9 — legacy line `price` is the PER-UNIT price (matches the admin
+      // UI, validators, and registry cost reads). Core also wants unit price, so
+      // pass it straight through — do NOT divide by quantity (that was the money
+      // bug: it under-priced every multi-unit line on the unified order).
       const items = orderLines.map((line: any, idx: number) => {
         const legacyLine = input.order_lines[idx]
         const quantity = Number(line.quantity)
-        const lineTotal = Number(line.price)
+        const unitPrice = Number(line.price)
         return {
           title: titleByItemId.get(legacyLine?.inventory_item_id) ?? "Raw material",
           quantity,
-          unit_price: quantity > 0 ? lineTotal / quantity : lineTotal,
+          unit_price: unitPrice,
           metadata: {
             inventory_item_id: legacyLine?.inventory_item_id,
             legacy_orderline_id: line.id,
-            legacy_line_price: lineTotal,
+            legacy_unit_price: unitPrice,
           },
         }
       })
@@ -326,7 +333,8 @@ export const dualWriteUnifiedOrderStep = createStep(
         to_stock_location_id:
           input.to_stock_location_id || input.stock_location_id,
         from_stock_location_id: input.from_stock_location_id ?? null,
-        currency_assumed: true,
+        // #778 H9 — only "assumed" when the order didn't carry its own currency.
+        currency_assumed: !orderCurrency,
         ...(extra ? { shipping_address_extra: extra } : {}),
       }
 


### PR DESCRIPTION
Part of #783 (group 4 of the #778 inventory-orders audit) — **H9: currency + price semantics**.

## The money bug
`orderline.price` was treated **inconsistently**:
- The admin UI (`total_price = Σ price × quantity`), validators, API docs, and the registry cost-read all treat it as **per-unit**.
- But the create-total fallback summed `Σ price` and the unified-order dual-write divided `price / quantity` to get `unit_price` — i.e. they treated it as a **line total**.

The dual-write division **under-priced every multi-unit line** on the unified order.

**Canonical decision: `price` is PER-UNIT** (matches the UI/validators/docs). Fixes:
- **Dual-write**: `unit_price = line.price` directly (no division); metadata renamed `legacy_unit_price`.
- **Create fallback total**: `Σ(price × quantity)` via a new pure, unit-tested `sumLineTotals` — matches the admin UI's own computed total exactly.

## Currency
- Add `currency_code` to the order (model + **idempotent ALTER migration**, default `'inr'`, backfill existing rows under the old INR assumption).
- Create accepts an optional 3-letter `currency_code`.
- Dual-write now stamps the **order's own** `currency_code` and only flags `currency_assumed` when the order didn't carry one (was hard-coded `true`).

## Verify
- 58 unit green (4 new `sumLineTotals`, incl. an explicit "does NOT treat price as a line total" regression guard).
- `currency_code` migration applied + verified on a real Postgres; `tsc` clean on all changed source files.

Refs #783 #778