### PR TITLE
fix(783): single source of truth for inventory-order partner status (H3)

### DIFF
--- a/apps/backend/src/api/partners/inventory-orders/[orderId]/start/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/[orderId]/start/route.ts
@@ -167,11 +167,12 @@ export async function POST(
         input: {
             id: orderId,
             update: {
+                // #778 H3 — `status` is the single source of truth for partner
+                // progress; no `metadata.partner_status` copy (that was drift).
                 status: "Processing", // Change status from Pending to Processing
                 metadata: {
                     ...order.metadata,
                     partner_started_at: new Date().toISOString(),
-                    partner_status: 'started'
                 }
             }
         }

--- a/apps/backend/src/workflows/inventory_orders/partner-complete-inventory-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/partner-complete-inventory-order.ts
@@ -199,13 +199,14 @@ const validateAndFetchOrderStep = createStep(
 
     const order = orders[0]
 
-    // Allow Processing or Partial for subsequent partial deliveries (lint-safe cast)
+    // #778 H3 — the order's `status` column is the SINGLE source of truth for
+    // "is this order in a partner-started state". Processing (started) or Partial
+    // (mid partial-delivery) may receive a completion; anything else may not.
+    // (The old duplicate `metadata.partner_status` guard was redundant with this
+    // — status and that metadata field were always written in lockstep — and is
+    // removed along with the metadata writes to end the triple-source drift.)
     if (!(((order as any).status === "Processing") || ((order as any).status === "Partial"))) {
       throw new MedusaError(MedusaError.Types.NOT_ALLOWED, `Inventory order ${input.orderId} not in an updatable state (status: ${order.status})`)
-    }
-
-    if (order.metadata?.partner_status !== "started" && order.metadata?.partner_status !== "partial") {
-      throw new MedusaError(MedusaError.Types.NOT_ALLOWED, `Inventory order ${input.orderId} is not in started state`)
     }
 
     if (!Array.isArray(input.lines) || input.lines.length === 0) {
@@ -296,12 +297,14 @@ const validateAndFetchOrderStep = createStep(
       submitted_at: new Date().toISOString(),
     }
 
-    // Compute metadata patch with delivery info
+    // Compute metadata patch with delivery info. #778 H3 — no `partner_status`
+    // here anymore: the order's `status` column (Shipped/Partial/Delivered set by
+    // this workflow's update) is the single source of truth; the metadata copy
+    // was write-only drift.
     const completionMetadata = {
       ...(order.metadata || {}),
       // Bug 7 fix: only set partner_completed_at when fully fulfilled
       ...(fullyFulfilled ? { partner_completed_at: new Date().toISOString() } : {}),
-      partner_status: fullyFulfilled ? "completed" : "partial",
       partner_completion_notes: input.notes,
       partner_delivery_date: input.deliveryDate,
       partner_tracking_number: input.trackingNumber,


### PR DESCRIPTION
Part of #783 (group 4 of the #778 inventory-orders audit) — **H3: partner_status drift**.

## Problem
The same "has the partner started / how far along" concept lived in **three** places that could disagree:
1. the order `status` column (Processing/Partial/Shipped/…),
2. an `inventory_orders.metadata.partner_status` copy (`started`/`partial`/`completed`),
3. a task-derived value computed in the read routes.

## Why the metadata copy was safe to remove
It was written **in lockstep** with `status` (start → `Processing` + `'started'`; partial complete → `Partial` + `'partial'`) and the **only runtime reader** was a duplicate guard in `partner-complete` sitting right below an equivalent `status`-column guard:

```ts
if (!(status === "Processing" || status === "Partial")) throw …   // keep (canonical)
if (metadata.partner_status !== "started" && … !== "partial") throw … // redundant → removed
```

## Change
- **partner-complete**: drop the redundant `metadata.partner_status` guard — the `status` guard is the single source of truth (behaviour preserved).
- Stop writing the now-dead `metadata.partner_status` — removed from the **start route** and the **completion metadata** patch.

Result: `status` (canonical) → `unified_order_status` sidecar column (its mirror, already derived from status) → task-derived value (presentation-only). No drift-prone stored duplicate.

> Scope note: this is the **inventory_order's** metadata. The **unified order's** `metadata.partner_status` (a different entity, already promoted to a typed column by #342 PR-H) is untouched — its integration tests still pass.

## Verify
- 54 unit green; `tsc` clean on changed files.
- Confirmed no remaining runtime reader of `inventory_order.metadata.partner_status` (grep across `src/`).
- Flow unchanged: a `Pending` order still can't be completed (status guard); a started (`Processing`) or mid-`Partial` order still can.

Refs #783 #778