### PR TITLE
feat(782): overdue inventory-order reminders (H5)

### DIFF
--- a/apps/backend/src/jobs/send-inventory-order-overdue-reminders.ts
+++ b/apps/backend/src/jobs/send-inventory-order-overdue-reminders.ts
@@ -1,0 +1,123 @@
+import { MedusaContainer } from "@medusajs/framework/types";
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils";
+
+import { ORDER_INVENTORY_MODULE } from "../modules/inventory_orders";
+import type InventoryOrderService from "../modules/inventory_orders/service";
+import {
+  selectOverdueReminders,
+  INVENTORY_ORDER_REMINDER_OVERDUE_EVENT,
+} from "../workflows/inventory_orders/overdue-reminders";
+
+/**
+ * #778 H5 — overdue inventory-order reminders.
+ *
+ * Finds open inventory orders whose `expected_delivery_date` is in the past and
+ * nudges once per cooldown window. Idempotency uses the #778-H4 activity log: an
+ * `overdue` reminder activity is written per order (so the next run sees it and
+ * skips), and a `reminder-overdue` event is emitted for downstream notifications
+ * / visual flows. Best-effort — one bad order never aborts the batch.
+ */
+const COOLDOWN_DAYS = Number(process.env.INVENTORY_OVERDUE_REMINDER_COOLDOWN_DAYS || 3);
+const MAX_BATCH = Number(process.env.INVENTORY_OVERDUE_REMINDER_MAX_BATCH || 200);
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export default async function sendInventoryOrderOverdueReminders(
+  container: MedusaContainer
+) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER);
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY);
+  const service: InventoryOrderService = container.resolve(ORDER_INVENTORY_MODULE);
+  const eventBus: any = container.resolve(Modules.EVENT_BUS);
+  const now = new Date();
+
+  try {
+    // 1) Candidate open orders with a past expected delivery date. The pure
+    //    selector re-applies the open/overdue checks so this stays testable.
+    const { data: orders } = await query.graph({
+      entity: "inventory_orders",
+      fields: ["id", "status", "expected_delivery_date", "partner.id"],
+      filters: {
+        status: { $nin: ["Delivered", "Cancelled"] },
+        expected_delivery_date: { $lt: now },
+      },
+      pagination: { take: MAX_BATCH },
+    });
+
+    const candidates = (orders || []).map((o: any) => ({
+      id: o.id,
+      status: o.status,
+      expected_delivery_date: o.expected_delivery_date,
+      partner_id: Array.isArray(o.partner) ? o.partner[0]?.id ?? null : o.partner?.id ?? null,
+    }));
+    if (!candidates.length) {
+      return;
+    }
+
+    // 2) Orders already reminded within the cooldown window (from the activity
+    //    log) — skip them.
+    const cutoff = new Date(now.getTime() - COOLDOWN_DAYS * MS_PER_DAY);
+    const recent = await service.listInventoryOrderActivities(
+      { kind: "overdue", occurred_at: { $gte: cutoff } } as any,
+      { take: 5000 } as any
+    );
+    const recentIds = new Set((recent || []).map((a: any) => a.inventory_order_id));
+
+    // 3) Pure selection.
+    const due = selectOverdueReminders(candidates, recentIds, now);
+    if (!due.length) {
+      return;
+    }
+
+    // 4) Record an activity row (idempotency marker) + emit an event per order.
+    let reminded = 0;
+    for (const d of due) {
+      try {
+        await service.createInventoryOrderActivities({
+          inventory_order_id: d.id,
+          activity_type: "reminder_sent",
+          kind: "overdue",
+          actor_type: "scheduled_flow",
+          actor_id: null,
+          partner_id: d.partner_id,
+          channel: null,
+          message_id: null,
+          template_name: null,
+          recipient: null,
+          summary: `Overdue: ${d.days_overdue} day(s) past expected delivery`,
+          payload: {
+            days_overdue: d.days_overdue,
+            expected_delivery_date: d.expected_delivery_date,
+          },
+          occurred_at: now,
+        } as any);
+
+        await eventBus.emit({
+          name: INVENTORY_ORDER_REMINDER_OVERDUE_EVENT,
+          data: {
+            inventory_order_id: d.id,
+            partner_id: d.partner_id,
+            days_overdue: d.days_overdue,
+            expected_delivery_date: d.expected_delivery_date,
+          },
+        });
+        reminded++;
+      } catch (e: any) {
+        logger.error(
+          `[inventory-overdue-reminders] failed for ${d.id}: ${e?.message}`
+        );
+      }
+    }
+
+    logger.info(
+      `[inventory-overdue-reminders] reminded ${reminded}/${due.length} overdue order(s)`
+    );
+  } catch (e: any) {
+    logger.error(`[inventory-overdue-reminders] batch failed: ${e?.message}`);
+  }
+}
+
+export const config = {
+  name: "inventory-order-overdue-reminders",
+  // Daily at 09:00.
+  schedule: "0 9 * * *",
+};

--- a/apps/backend/src/workflows/inventory_orders/__tests__/overdue-reminders.unit.spec.ts
+++ b/apps/backend/src/workflows/inventory_orders/__tests__/overdue-reminders.unit.spec.ts
@@ -1,0 +1,94 @@
+import {
+  selectOverdueReminders,
+  INVENTORY_ORDER_REMINDER_OVERDUE_EVENT,
+} from "../overdue-reminders";
+
+const NOW = new Date("2026-06-30T12:00:00.000Z");
+const past = (days: number) =>
+  new Date(NOW.getTime() - days * 86400000).toISOString();
+const future = (days: number) =>
+  new Date(NOW.getTime() + days * 86400000).toISOString();
+
+describe("selectOverdueReminders (#778 H5)", () => {
+  it("selects an open order past its expected delivery date", () => {
+    const due = selectOverdueReminders(
+      [{ id: "o1", status: "Processing", expected_delivery_date: past(3), partner_id: "p1" }],
+      new Set(),
+      NOW
+    );
+    expect(due).toEqual([
+      {
+        id: "o1",
+        partner_id: "p1",
+        expected_delivery_date: new Date(past(3)).toISOString(),
+        days_overdue: 3,
+      },
+    ]);
+  });
+
+  it("skips Delivered and Cancelled orders", () => {
+    const due = selectOverdueReminders(
+      [
+        { id: "d", status: "Delivered", expected_delivery_date: past(5) },
+        { id: "c", status: "Cancelled", expected_delivery_date: past(5) },
+      ],
+      new Set(),
+      NOW
+    );
+    expect(due).toEqual([]);
+  });
+
+  it("skips orders not yet overdue", () => {
+    const due = selectOverdueReminders(
+      [{ id: "o", status: "Processing", expected_delivery_date: future(2) }],
+      new Set(),
+      NOW
+    );
+    expect(due).toEqual([]);
+  });
+
+  it("skips orders with no expected delivery date", () => {
+    const due = selectOverdueReminders(
+      [{ id: "o", status: "Processing", expected_delivery_date: null }],
+      new Set(),
+      NOW
+    );
+    expect(due).toEqual([]);
+  });
+
+  it("skips orders already reminded within the cooldown", () => {
+    const due = selectOverdueReminders(
+      [{ id: "o1", status: "Partial", expected_delivery_date: past(10) }],
+      new Set(["o1"]),
+      NOW
+    );
+    expect(due).toEqual([]);
+  });
+
+  it("includes Partial orders (still open)", () => {
+    const due = selectOverdueReminders(
+      [{ id: "o1", status: "Partial", expected_delivery_date: past(1) }],
+      new Set(),
+      NOW
+    );
+    expect(due.map((d) => d.id)).toEqual(["o1"]);
+  });
+
+  it("ignores rows with no id or unparseable dates", () => {
+    const due = selectOverdueReminders(
+      [
+        { id: "", status: "Processing", expected_delivery_date: past(2) },
+        { id: "bad", status: "Processing", expected_delivery_date: "not-a-date" },
+      ],
+      new Set(),
+      NOW
+    );
+    expect(due).toEqual([]);
+  });
+
+  it("exports a stable event name", () => {
+    expect(INVENTORY_ORDER_REMINDER_OVERDUE_EVENT).toBe(
+      "inventory_orders.inventory-order.reminder-overdue"
+    );
+  });
+});

--- a/apps/backend/src/workflows/inventory_orders/overdue-reminders.ts
+++ b/apps/backend/src/workflows/inventory_orders/overdue-reminders.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure selection logic for inventory-order overdue reminders (#778 H5).
+ *
+ * An order is "overdue" when it has an `expected_delivery_date` in the past and
+ * is still open (not Delivered/Cancelled). To avoid re-nudging on every run, the
+ * caller passes the set of order ids already reminded within the cooldown window
+ * (derived from the inventory_order_activity log) — those are skipped.
+ *
+ * Kept free of any container/IO so it's unit-testable.
+ */
+
+export const INVENTORY_ORDER_REMINDER_OVERDUE_EVENT =
+  "inventory_orders.inventory-order.reminder-overdue";
+
+// Terminal statuses never get an overdue nudge.
+const CLOSED_STATUSES = new Set(["Delivered", "Cancelled"]);
+
+export type OverdueCandidate = {
+  id: string;
+  status?: string | null;
+  expected_delivery_date?: string | Date | null;
+  partner_id?: string | null;
+};
+
+export type OverdueReminder = {
+  id: string;
+  partner_id: string | null;
+  expected_delivery_date: string;
+  days_overdue: number;
+};
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export function selectOverdueReminders(
+  orders: OverdueCandidate[],
+  recentlyRemindedIds: Set<string>,
+  now: Date
+): OverdueReminder[] {
+  const out: OverdueReminder[] = [];
+  for (const o of orders || []) {
+    if (!o?.id) continue;
+    if (o.status && CLOSED_STATUSES.has(o.status)) continue;
+    if (!o.expected_delivery_date) continue;
+    if (recentlyRemindedIds.has(o.id)) continue;
+
+    const edd = new Date(o.expected_delivery_date);
+    if (Number.isNaN(edd.getTime())) continue;
+    if (edd.getTime() >= now.getTime()) continue; // not overdue yet
+
+    const daysOverdue = Math.floor((now.getTime() - edd.getTime()) / MS_PER_DAY);
+    out.push({
+      id: o.id,
+      partner_id: o.partner_id ?? null,
+      expected_delivery_date: edd.toISOString(),
+      days_overdue: daysOverdue,
+    });
+  }
+  return out;
+}


### PR DESCRIPTION
Part of #782 (group 3 of the #778 inventory-orders audit) — **H5: overdue reminders**.

Inventory orders never used `expected_delivery_date` for overdue alerts (production runs have a reminder system). This adds a daily job that nudges open orders past their expected delivery date.

## What
- **Pure `selectOverdueReminders`** (8 unit tests): an order is due when it's open (not `Delivered`/`Cancelled`), `expected_delivery_date` is in the past, and it wasn't reminded within the cooldown window.
- **Job `send-inventory-order-overdue-reminders`** (daily 09:00):
  1. queries candidate open + past-due orders,
  2. derives the cooldown skip-set from the **#778-H4 activity log** (no new tracking infra),
  3. per due order: writes an `overdue` reminder activity row (which is also the idempotency marker) and emits `inventory_orders.inventory-order.reminder-overdue` for downstream notifications / visual flows.
- Best-effort: one bad order never aborts the batch. Cooldown (`INVENTORY_OVERDUE_REMINDER_COOLDOWN_DAYS`, default 3) and batch size are env-tunable.

The emitted event is intentionally **not** subscribed by the activity recorder (the job writes the row directly), so reminders aren't double-recorded.

## Verify
- 8 unit green; `tsc` clean on new files.
- After deploy: an open order with `expected_delivery_date` in the past gets one `overdue` activity row per cooldown window; re-running the job same-day is a no-op.

Refs #782 #778