### PR TITLE
fix(inventory-orders): partner-side security hardening (#780)

### DIFF
--- a/apps/backend/integration-tests/http/inventory-order-partner-security.spec.ts
+++ b/apps/backend/integration-tests/http/inventory-order-partner-security.spec.ts
@@ -1,0 +1,234 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { createInventoryLevelsWorkflow } from "@medusajs/medusa/core-flows"
+import { updateInventoryOrderWorkflow } from "../../src/workflows/inventory_orders/update-inventory-order"
+
+/**
+ * #780 (group 1) — partner-side inventory-order security hardening.
+ *
+ * Covers the four remaining items after the C1 IDOR guard (#779):
+ *  - A1: detail route returns NOT_FOUND (not NOT_ALLOWED) for a foreign order,
+ *        so a partner can't probe other tenants' order ids by status code.
+ *  - A2: the complete workflow itself rejects a mismatched partner_id
+ *        (defense-in-depth — not only the route).
+ *  - A3: submit-payment is idempotent on a repeated idempotency_key.
+ *  - A4: the start transition is an atomic compare-and-set — a stale concurrent
+ *        Pending→Processing write is rejected, not silently re-applied.
+ */
+
+const PARTNER_PASSWORD = "supersecret"
+
+jest.setTimeout(60 * 1000)
+
+const TEMPLATES = [
+  { name: "partner-order-sent", step: "sent", type: "partner_assignment", priority: "medium" },
+  { name: "partner-order-received", step: "received", type: "partner_assignment", priority: "medium" },
+  { name: "partner-order-shipped", step: "shipped", type: "partner_assignment", priority: "high" },
+]
+
+async function registerPartner(api: any, email: string, handle: string) {
+  await api.post("/auth/partner/emailpass/register", { email, password: PARTNER_PASSWORD })
+  const login1 = await api.post("/auth/partner/emailpass", { email, password: PARTNER_PASSWORD })
+  let headers = { Authorization: `Bearer ${login1.data.token}` }
+
+  const partnerRes = await api.post(
+    "/partners",
+    { name: handle, handle, admin: { email, first_name: "P", last_name: handle } },
+    { headers }
+  )
+  // Fresh token after partner creation (links partner ↔ auth identity).
+  const login2 = await api.post("/auth/partner/emailpass", { email, password: PARTNER_PASSWORD })
+  headers = { Authorization: `Bearer ${login2.data.token}` }
+  return { partnerId: partnerRes.data.partner.id, headers }
+}
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Partner inventory-orders — security hardening (#780)", () => {
+    let adminHeaders: any
+    let ownerHeaders: any
+    let attackerHeaders: any
+    let ownerPartnerId: string
+    let attackerPartnerId: string
+    let inventoryItemId: string
+    let stockLocationId: string
+    let inventoryOrderId: string
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+
+      const unique = `${Date.now()}${Math.random().toString(36).slice(2, 6)}`
+      const owner = await registerPartner(api, `owner-${unique}@sec-test.com`, `owner-${unique}`)
+      ownerHeaders = owner.headers
+      ownerPartnerId = owner.partnerId
+      const attacker = await registerPartner(api, `attacker-${unique}@sec-test.com`, `attacker-${unique}`)
+      attackerHeaders = attacker.headers
+      attackerPartnerId = attacker.partnerId
+
+      // Task templates the send-to-partner workflow needs to assign the order.
+      let categoryId: string | undefined
+      for (const t of TEMPLATES) {
+        const payload: any = {
+          name: t.name,
+          description: `Template ${t.name}`,
+          priority: t.priority,
+          estimated_duration: 30,
+          required_fields: { order_id: { type: "string", required: true }, partner_id: { type: "string", required: true } },
+          eventable: true,
+          notifiable: true,
+          message_template: "Order {{order_id}}.",
+          metadata: { workflow_type: t.type, workflow_step: t.step },
+        }
+        if (categoryId) payload.category_id = categoryId
+        else payload.category = "Partner Orders"
+        const res = await api.post("/admin/task-templates", payload, adminHeaders)
+        expect(res.status).toBe(201)
+        if (!categoryId) categoryId = res.data.task_template.category_id
+      }
+
+      const itemRes = await api.post("/admin/inventory-items", { title: `Sec Fabric ${unique}` }, adminHeaders)
+      expect(itemRes.status).toBe(200)
+      inventoryItemId = itemRes.data.inventory_item.id
+
+      const locRes = await api.post("/admin/stock-locations", { name: `Sec WH ${unique}` }, adminHeaders)
+      expect(locRes.status).toBe(200)
+      stockLocationId = locRes.data.stock_location.id
+
+      const fromLocRes = await api.post("/admin/stock-locations", { name: `Sec From ${unique}` }, adminHeaders)
+      expect(fromLocRes.status).toBe(200)
+      const fromStockLocationId = fromLocRes.data.stock_location.id
+
+      await createInventoryLevelsWorkflow(container).run({
+        input: { inventory_levels: [{ inventory_item_id: inventoryItemId, location_id: stockLocationId, stocked_quantity: 0 }] },
+      })
+
+      const orderRes = await api.post(
+        "/admin/inventory-orders",
+        {
+          order_lines: [{ inventory_item_id: inventoryItemId, quantity: 10, price: 5 }],
+          quantity: 10,
+          total_price: 50,
+          status: "Pending",
+          expected_delivery_date: new Date(Date.now() + 7 * 864e5).toISOString(),
+          order_date: new Date().toISOString(),
+          shipping_address: { address_1: "1 Sec St", city: "NY", postal_code: "10001", country_code: "US" },
+          stock_location_id: stockLocationId,
+          to_stock_location_id: stockLocationId,
+          from_stock_location_id: fromStockLocationId,
+          is_sample: false,
+        },
+        adminHeaders
+      )
+      expect(orderRes.status).toBe(201)
+      inventoryOrderId = orderRes.data.inventoryOrder.id
+
+      // Assign to the OWNER partner (creates the partner↔order ownership link).
+      const sendRes = await api.post(
+        `/admin/inventory-orders/${inventoryOrderId}/send-to-partner`,
+        { partnerId: ownerPartnerId, notes: "sec-test" },
+        adminHeaders
+      )
+      expect(sendRes.status).toBe(200)
+    })
+
+    it("A1: a foreign partner's GET returns 404, not 403 (no existence leak)", async () => {
+      // Owner can see it.
+      const ownerView = await api.get(`/partners/inventory-orders/${inventoryOrderId}`, { headers: ownerHeaders })
+      expect(ownerView.status).toBe(200)
+
+      // Attacker gets a flat 404 — identical to a non-existent id, leaking nothing.
+      const attackerView = await api
+        .get(`/partners/inventory-orders/${inventoryOrderId}`, { headers: attackerHeaders })
+        .catch((e: any) => e.response)
+      expect(attackerView.status).toBe(404)
+
+      const bogus = await api
+        .get(`/partners/inventory-orders/ior_does_not_exist`, { headers: attackerHeaders })
+        .catch((e: any) => e.response)
+      expect(bogus.status).toBe(404)
+    })
+
+    it("A2: a foreign partner cannot start/complete another partner's order (404)", async () => {
+      const start = await api
+        .post(`/partners/inventory-orders/${inventoryOrderId}/start`, {}, { headers: attackerHeaders })
+        .catch((e: any) => e.response)
+      expect(start.status).toBe(404)
+
+      const complete = await api
+        .post(
+          `/partners/inventory-orders/${inventoryOrderId}/complete`,
+          { lines: [{ order_line_id: "x", quantity: 1 }] },
+          { headers: attackerHeaders }
+        )
+        .catch((e: any) => e.response)
+      expect(complete.status).toBe(404)
+
+      const pay = await api
+        .post(
+          `/partners/inventory-orders/${inventoryOrderId}/submit-payment`,
+          { amount: 10 },
+          { headers: attackerHeaders }
+        )
+        .catch((e: any) => e.response)
+      expect(pay.status).toBe(404)
+    })
+
+    it("A3: submit-payment with a repeated idempotency_key does not duplicate the payment", async () => {
+      const key = `idem-${Date.now()}`
+      const body = { amount: 25, payment_type: "Cash", idempotency_key: key }
+
+      const first = await api.post(`/partners/inventory-orders/${inventoryOrderId}/submit-payment`, body, { headers: ownerHeaders })
+      expect(first.status).toBe(200)
+      expect(first.data.payment?.id).toBeDefined()
+      const firstId = first.data.payment.id
+
+      const second = await api.post(`/partners/inventory-orders/${inventoryOrderId}/submit-payment`, body, { headers: ownerHeaders })
+      expect(second.status).toBe(200)
+      expect(second.data.idempotent_replay).toBe(true)
+      expect(second.data.payment.id).toBe(firstId)
+
+      // Exactly one payment is linked to the order.
+      const detail = await api.get(`/partners/inventory-orders/${inventoryOrderId}`, { headers: ownerHeaders })
+      const matching = (detail.data.inventoryOrder.payments || []).filter((p: any) => p.id === firstId)
+      expect(matching.length).toBe(1)
+    })
+
+    it("A4: the start transition is an atomic compare-and-set (stale Pending write is rejected)", async () => {
+      const container = getContainer()
+
+      // First transition Pending→Processing succeeds.
+      const first = await updateInventoryOrderWorkflow(container).run({
+        input: { id: inventoryOrderId, expectedCurrentStatus: "Pending", update: { status: "Processing" } },
+        throwOnError: false,
+      })
+      expect(first.errors?.length ?? 0).toBe(0)
+
+      // A second writer that still expects "Pending" must be rejected (CONFLICT),
+      // not silently re-apply the transition — this is the TOCTOU guard.
+      const second = await updateInventoryOrderWorkflow(container).run({
+        input: { id: inventoryOrderId, expectedCurrentStatus: "Pending", update: { status: "Processing" } },
+        throwOnError: false,
+      })
+      expect(second.errors?.length ?? 0).toBeGreaterThan(0)
+      expect(String(second.errors[0].error?.message || "")).toContain("no longer")
+    })
+
+    it("A4: a double-clicked HTTP start yields exactly one success", async () => {
+      const [a, b] = await Promise.all([
+        api.post(`/partners/inventory-orders/${inventoryOrderId}/start`, {}, { headers: ownerHeaders }).catch((e: any) => e.response),
+        api.post(`/partners/inventory-orders/${inventoryOrderId}/start`, {}, { headers: ownerHeaders }).catch((e: any) => e.response),
+      ])
+      const statuses = [a.status, b.status]
+      expect(statuses.filter((s) => s === 200).length).toBe(1)
+      // The loser is a clean 4xx (409 race or 400 already-started), never a 500.
+      expect(statuses.filter((s) => s >= 500).length).toBe(0)
+
+      const view = await api.get(`/partners/inventory-orders/${inventoryOrderId}`, { headers: ownerHeaders })
+      expect(view.data.inventoryOrder.status).toBe("Processing")
+    })
+  })
+})

--- a/apps/backend/src/api/partners/inventory-orders/[orderId]/complete/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/[orderId]/complete/route.ts
@@ -182,7 +182,10 @@ export async function POST(
                 deliveryDate: normalizedDeliveryDate,
                 trackingNumber: normalizedTrackingNumber,
                 stock_location_id: normalizedStockLocationId,
-                lines
+                lines,
+                // #780 C1 defense-in-depth — re-verify ownership inside the
+                // workflow too (route already guards via assertPartnerOwnsInventoryOrder).
+                partnerId: partner.id,
             }
         })
         if (errors && errors.length > 0) {

--- a/apps/backend/src/api/partners/inventory-orders/[orderId]/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/[orderId]/route.ts
@@ -194,10 +194,14 @@ export async function GET(
     }
     
     const order = orders[0];
-    // Check if this order is assigned to the authenticated partner
+    // Check if this order is assigned to the authenticated partner.
+    // #778/#780 — throw NOT_FOUND (not NOT_ALLOWED): a partner must not be able
+    // to tell, by status code, whether some other partner's order id exists.
+    // Matches the mutation-route guard (assertPartnerOwnsInventoryOrder) which
+    // also 404s, so the whole partner surface leaks nothing about other tenants.
     const assignedPartner = order.partner;
     if (!assignedPartner || assignedPartner.id !== partner.id) {
-        throw new MedusaError(MedusaError.Types.NOT_ALLOWED, `Inventory order ${orderId} is not assigned to your partner account`)
+        throw new MedusaError(MedusaError.Types.NOT_FOUND, `Inventory order ${orderId} not found`)
     }
     
     // Extract partner workflow status from tasks instead of metadata

--- a/apps/backend/src/api/partners/inventory-orders/[orderId]/start/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/[orderId]/start/route.ts
@@ -166,6 +166,11 @@ export async function POST(
     const { result, errors } = await updateInventoryOrderWorkflow(req.scope).run({
         input: {
             id: orderId,
+            // #780 H7 — atomic compare-and-set on the transition. The pre-read
+            // above gives a friendly 400 on the common already-started path; this
+            // closes the residual TOCTOU window if two start requests race (the
+            // loser gets CONFLICT/409 instead of a second Processing write).
+            expectedCurrentStatus: "Pending",
             update: {
                 // #778 H3 — `status` is the single source of truth for partner
                 // progress; no `metadata.partner_status` copy (that was drift).

--- a/apps/backend/src/api/partners/inventory-orders/[orderId]/submit-payment/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/[orderId]/submit-payment/route.ts
@@ -1,5 +1,6 @@
 import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework";
 import { z } from "@medusajs/framework/zod";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { getPartnerFromAuthContext, assertPartnerOwnsInventoryOrder } from "../../../helpers";
 import { createPaymentAndLinkWorkflow } from "../../../../../workflows/internal_payments/create-payment-and-link";
 
@@ -20,6 +21,9 @@ const requestBodySchema = z.object({
     paid_to_id: z.string().optional(),
     // #496 — file attachments (receipts/invoices) persisted to the link table.
     attachments: z.array(attachmentSchema).optional(),
+    // #780 H7 — idempotency. A double-submit (network retry, double-click) with
+    // the same key returns the original payment instead of creating a duplicate.
+    idempotency_key: z.string().min(1).max(255).optional(),
 });
 
 export async function POST(
@@ -52,7 +56,31 @@ export async function POST(
     // Throws NOT_FOUND (→404) otherwise; closes the IDOR.
     await assertPartnerOwnsInventoryOrder(req.scope, orderId, partner.id);
 
-    const { amount, payment_type, payment_date, note, paid_to_id, attachments } = validation.data;
+    const { amount, payment_type, payment_date, note, paid_to_id, attachments, idempotency_key } = validation.data;
+
+    // #780 H7 — idempotency replay. If a payment was already recorded against this
+    // order with the same key, return it instead of creating a duplicate. The key
+    // lives on the (write-once) payment metadata, so re-reading is safe — no
+    // mutated-metadata hazard. Scoped to this order's linked payments only.
+    if (idempotency_key) {
+        const query = req.scope.resolve(ContainerRegistrationKeys.QUERY);
+        const { data: orders } = await query.graph({
+            entity: "inventory_orders",
+            fields: ["id", "internal_payments.id", "internal_payments.amount", "internal_payments.status", "internal_payments.payment_type", "internal_payments.payment_date", "internal_payments.metadata"],
+            filters: { id: orderId },
+        });
+        const existingPayments = ((orders?.[0] as any)?.internal_payments ?? []) as any[];
+        const arr = Array.isArray(existingPayments) ? existingPayments : [existingPayments];
+        const replay = arr.find((p: any) => p?.metadata?.idempotency_key === idempotency_key);
+        if (replay) {
+            return res.status(200).json({
+                message: "Payment already submitted (idempotent replay)",
+                payment: replay,
+                attachments: [],
+                idempotent_replay: true,
+            });
+        }
+    }
 
     const { result, errors } = await createPaymentAndLinkWorkflow(req.scope).run({
         input: {
@@ -61,7 +89,9 @@ export async function POST(
                 status: "Pending",
                 payment_type: payment_type || "Cash",
                 payment_date: payment_date || new Date(),
-                metadata: note ? { note } : undefined,
+                metadata: (note || idempotency_key)
+                    ? { ...(note ? { note } : {}), ...(idempotency_key ? { idempotency_key } : {}) }
+                    : undefined,
                 paid_to_id: paid_to_id || undefined,
             },
             inventoryOrderIds: [orderId],

--- a/apps/backend/src/workflows/inventory_orders/partner-complete-inventory-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/partner-complete-inventory-order.ts
@@ -25,6 +25,11 @@ export type PartnerCompleteInventoryOrderInput = {
   trackingNumber?: string
   stock_location_id?: string
   lines: PartnerCompleteOrderLine[]
+  // #780 C1 defense-in-depth — when supplied (the partner route always supplies
+  // it), the workflow re-verifies the order is linked to this partner and
+  // throws NOT_FOUND otherwise, so ownership is enforced inside the workflow and
+  // not only at the route. Optional so admin/internal callers can omit it.
+  partnerId?: string
 }
 
 // Step: prepare fulfillment payloads (filters happen inside the step)
@@ -189,6 +194,9 @@ const validateAndFetchOrderStep = createStep(
         "stock_locations.*",
         // include existing fulfillments to compute cumulative delivered qty
         "orderlines.line_fulfillments.quantity_delta",
+        // #780 C1 defense-in-depth — the linked partner, to re-verify ownership
+        // inside the workflow.
+        "partner.id",
       ],
       filters: { id: input.orderId },
     })
@@ -198,6 +206,13 @@ const validateAndFetchOrderStep = createStep(
     }
 
     const order = orders[0]
+
+    // #780 C1 defense-in-depth — enforce partner ownership inside the workflow,
+    // not just at the route. NOT_FOUND (not NOT_ALLOWED) so a foreign caller
+    // can't distinguish "exists but not yours" from "doesn't exist".
+    if (input.partnerId && (order as any).partner?.id !== input.partnerId) {
+      throw new MedusaError(MedusaError.Types.NOT_FOUND, `Inventory order ${input.orderId} not found`)
+    }
 
     // #778 H3 — the order's `status` column is the SINGLE source of truth for
     // "is this order in a partner-started state". Processing (started) or Partial

--- a/apps/backend/src/workflows/inventory_orders/update-inventory-order.ts
+++ b/apps/backend/src/workflows/inventory_orders/update-inventory-order.ts
@@ -4,7 +4,7 @@ import {
   StepResponse,
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk";
-import { Modules } from "@medusajs/framework/utils";
+import { Modules, MedusaError } from "@medusajs/framework/utils";
 import type { IEventBusModuleService } from "@medusajs/types";
 import InventoryOrderService from "../../modules/inventory_orders/service";
 import { ORDER_INVENTORY_MODULE } from "../../modules/inventory_orders";
@@ -49,6 +49,13 @@ export const buildStatusChangedEvent = (
 
 type UpdateInventoryOrderStepInput = {
   id: string;
+  // #780 H7 — optional compare-and-set precondition. When set, the row is
+  // updated only if its current status still equals this value (single atomic
+  // UPDATE ... WHERE status = expected). A 0-row result means a concurrent
+  // request already moved the order on → we throw CONFLICT instead of silently
+  // re-applying the transition. Closes the start route's read-Pending→write-
+  // Processing TOCTOU. Omitted by every other caller → unconditional update.
+  expectedCurrentStatus?: "Pending" | "Processing" | "Ready for Delivery" | "Shipped" | "Delivered" | "Cancelled" | "Partial";
   update: {
     status?: "Pending" | "Processing" | "Ready for Delivery" | "Shipped" | "Delivered" | "Cancelled" | "Partial";
     metadata?: Record<string, any>;
@@ -87,10 +94,28 @@ export const updateInventoryOrderStep = createStep(
       }
     }
 
-    const order = await inventoryOrderService.updateInventoryOrders({
-      id: input.id,
-      ...input.update
-    });
+    let order: any;
+    if (input.expectedCurrentStatus !== undefined) {
+      // #780 H7 — atomic compare-and-set: only rows still at the expected status
+      // are updated. Returns the updated rows (empty if none matched).
+      const updated = await inventoryOrderService.updateInventoryOrders({
+        selector: { id: input.id, status: input.expectedCurrentStatus },
+        data: { ...input.update },
+      });
+      const rows = Array.isArray(updated) ? updated : updated ? [updated] : [];
+      if (rows.length === 0) {
+        throw new MedusaError(
+          MedusaError.Types.CONFLICT,
+          `Inventory order ${input.id} is no longer in "${input.expectedCurrentStatus}" state (already updated by a concurrent request)`
+        );
+      }
+      order = rows[0];
+    } else {
+      order = await inventoryOrderService.updateInventoryOrders({
+        id: input.id,
+        ...input.update
+      });
+    }
 
     const event = buildStatusChangedEvent(
       input.id,


### PR DESCRIPTION
Closes the remaining **#780 (group 1)** items after the C1 IDOR guard (#779). Partner-side defense-in-depth on the inventory-order mutation/read surface.

## Changes
| # | Item | Fix |
|---|------|-----|
| **A1** | Existence leak (M) | Partner detail `GET` throws `NOT_FOUND` (was `NOT_ALLOWED`) for a foreign order → a partner can't distinguish "exists but not yours" from "doesn't exist" by status code. Matches the mutation-route guard. |
| **A2** | C1 defense-in-depth | `partnerId` threaded into `partnerCompleteInventoryOrderWorkflow`; ownership re-verified **inside** the workflow (`NOT_FOUND` on mismatch), not only at the route. |
| **A3** | H7 idempotency | `submit-payment` accepts optional `idempotency_key`; a repeated key **replays** the original payment instead of creating a duplicate. Key lives on write-once payment metadata; replay scoped to the order's linked payments. |
| **A4** | H7 TOCTOU | `updateInventoryOrderStep` gains an optional `expectedCurrentStatus` **compare-and-set** (single `UPDATE … WHERE status = expected`); 0 rows → `CONFLICT`. `start` passes `"Pending"` to close the read-Pending→write-Processing race while preserving the status-changed event. |

The `expectedCurrentStatus` param is optional and backward-compatible — every other caller (admin edit, complete, cancel) is unchanged; only `start` opts in.

## Out of scope (tracked, left open on #780)
- **Admin RBAC** — fine-grained per-action admin permissions need a product decision on the role model; deferred to its own slice.

## Verification
- New `integration-tests/http/inventory-order-partner-security.spec.ts` — **5/5 green** (existence-leak 404, cross-partner start/complete/pay rejection, idempotent payment replay, compare-and-set conflict + concurrent double-start).
- Existing `send-to-partner-complete-workflow.spec.ts` — **4/4 green** (no regression).
- `medusa build` — clean (exit 0).

Parent: #778 · Group: #780

🤖 Generated with [Claude Code](https://claude.com/claude-code)