### PR TITLE
feat(inventory-orders): admin list polish — recent-first, sorting, filter cleanup (#784)

### DIFF
--- a/apps/backend/src/admin/hooks/api/inventory-orders.ts
+++ b/apps/backend/src/admin/hooks/api/inventory-orders.ts
@@ -87,6 +87,10 @@ export interface AdminInventoryOrdersQuery {
   order_date?: string;
   expected_delivery_date?: string;
   q?: string;
+  // Sort directive, e.g. "order_date:DESC" — parsed server-side by
+  // parseOrderParam. Drives the table's default recent-first ordering and
+  // column-header sorting (#784).
+  order?: string;
 }
 
 const INVENTORY_ORDER_QUERY_KEY = "inventory-orders" as const;

--- a/apps/backend/src/admin/routes/orders/inventory/page.tsx
+++ b/apps/backend/src/admin/routes/orders/inventory/page.tsx
@@ -7,6 +7,7 @@ import {
   createDataTableFilterHelper,
   DataTablePaginationState,
   DataTableFilteringState,
+  DataTableSortingState,
   Button,
   Badge,
   StatusBadge,
@@ -35,11 +36,12 @@ import {
 const columnHelper = createColumnHelper<AdminInventoryOrder>();
 export const useColumns = () => {
   const columns = useMemo(() => [
-    columnHelper.accessor("id", { header: "Order ID" }),
-    columnHelper.accessor("status", { header: "Status" }),
+    columnHelper.accessor("id", { header: "Order ID", enableSorting: true }),
+    columnHelper.accessor("status", { header: "Status", enableSorting: true }),
     columnHelper.display({
       id: "work_status",
       header: "Work status",
+      // Derived (not a DB column) → not server-sortable.
       cell: ({ row }) => {
         const ws = getPartnerWorkStatus(row.original);
         if (!ws) return <span className="text-ui-fg-muted">—</span>;
@@ -50,10 +52,11 @@ export const useColumns = () => {
         );
       },
     }),
-    columnHelper.accessor("quantity", { header: "Quantity" }),
-    columnHelper.accessor("total_price", { header: "Total Price" }),
+    columnHelper.accessor("quantity", { header: "Quantity", enableSorting: true }),
+    columnHelper.accessor("total_price", { header: "Total Price", enableSorting: true }),
     columnHelper.accessor("order_date", {
       header: "Order Date",
+      enableSorting: true,
       cell: info => {
         const val = info.getValue<string>();
         return val ? new Date(val).toLocaleDateString() : "-";
@@ -61,6 +64,7 @@ export const useColumns = () => {
     }),
     columnHelper.accessor("expected_delivery_date", {
       header: "Expected Delivery",
+      enableSorting: true,
       cell: info => {
         const val = info.getValue<string>();
         return val ? new Date(val).toLocaleDateString() : "-";
@@ -104,6 +108,12 @@ const InventoryOrdersPage = () => {
     pageIndex: 0,
   });
   const [filtering, setFiltering] = useState<DataTableFilteringState>({});
+  // Default to newest-first so the most recent orders are on top (#784). Maps to
+  // the server `order=order_date:DESC` directive; users can re-sort any column.
+  const [sorting, setSorting] = useState<DataTableSortingState | null>({
+    id: "order_date",
+    desc: true,
+  });
   const [search, setSearch] = useState<string>("");
   const [selectedViewId, setSelectedViewId] = useState("default");
   const [initializedFromView, setInitializedFromView] = useState(false);
@@ -142,17 +152,23 @@ const InventoryOrdersPage = () => {
 
   const offset = pagination.pageIndex * pagination.pageSize;
 
+  const orderParam = sorting?.id
+    ? `${sorting.id}:${sorting.desc ? "DESC" : "ASC"}`
+    : undefined;
+
   const {
     inventory_orders,
     count,
     isLoading,
     isError,
     error,
+    refetch,
   } = useInventoryOrders(
     {
       limit: pagination.pageSize,
       offset: offset,
       q: search || undefined,
+      order: orderParam,
       ...(Object.keys(filtering).length > 0 ?
         Object.entries(filtering).reduce((acc: AdminInventoryOrdersQuery, [key, value]) => {
           if (!value) return acc;
@@ -164,14 +180,6 @@ const InventoryOrdersPage = () => {
               }
             } else {
               acc.status = value as string;
-            }
-          } else if (key === 'quantity') {
-            if (Array.isArray(value)) {
-              if (value.length > 0) {
-                acc.quantity = Number(value[0]);
-              }
-            } else {
-              acc.quantity = Number(value);
             }
           } else if (key === 'order_date') {
             acc.order_date = value as string;
@@ -190,7 +198,10 @@ const InventoryOrdersPage = () => {
   );
 
   const columns = useColumns();
-  const { partners: partnerResults = [] } = usePartners({ limit: 100, offset: 0 });
+  // Load enough partners that the filter dropdown isn't silently truncated
+  // (#784 — was capped at 100). If the partner roster ever outgrows this, the
+  // filter should move to an async/typeahead lookup.
+  const { partners: partnerResults = [] } = usePartners({ limit: 1000, offset: 0 });
   const partnerFilterOptions = useMemo(
     () =>
       (partnerResults || [])
@@ -218,16 +229,6 @@ const InventoryOrdersPage = () => {
         { label: "Partial", value: "Partial" },
         { label: "Delivered", value: "Delivered" },
         { label: "Cancelled", value: "Cancelled" },
-      ],
-    }),
-    filterHelper.accessor("quantity", {
-      type: "select",
-      label: "Quantity",
-      options: [
-        { label: "1", value: "1" },
-        { label: "5", value: "5" },
-        { label: "10", value: "10" },
-        { label: "20", value: "20" },
       ],
     }),
     filterHelper.accessor("order_date", {
@@ -431,11 +432,11 @@ const InventoryOrdersPage = () => {
       state: filtering,
       onFilteringChange: handleFilterChange,
     },
+    sorting: {
+      state: sorting,
+      onSortingChange: setSorting,
+    },
   });
-
-  if (isError) {
-    throw error;
-  }
 
   return (
     <div>
@@ -512,8 +513,29 @@ const InventoryOrdersPage = () => {
             </div>
           </DataTable.Toolbar>
 
-          <DataTable.Table />
-          <DataTable.Pagination />
+          {isError ? (
+            // #784 — inline, recoverable error instead of throwing to the route
+            // error boundary (which blanked the whole page). The toolbar/filters
+            // stay usable and the user can retry without a full reload.
+            <div className="flex flex-col items-center justify-center gap-3 px-6 py-16 text-center">
+              <Text className="text-ui-fg-base" weight="plus">
+                Couldn’t load inventory orders
+              </Text>
+              <Text size="small" className="text-ui-fg-subtle">
+                {error instanceof Error && error.message
+                  ? error.message
+                  : "Something went wrong while fetching orders."}
+              </Text>
+              <Button size="small" variant="secondary" onClick={() => refetch()}>
+                Retry
+              </Button>
+            </div>
+          ) : (
+            <>
+              <DataTable.Table />
+              <DataTable.Pagination />
+            </>
+          )}
         </DataTable>
       </Container>
       <Outlet />


### PR DESCRIPTION
The **#784 admin UI** tail for the inventory-orders audit. Frontend-only — the list API already supports `?order=field:dir` (`parseOrderParam`), so no backend change.

## Changes (`routes/orders/inventory/page.tsx` + the list hook)
- **Recent-first by default** — table defaults to `order=order_date:DESC` so the newest orders are on top (the requested win), and **column-header sorting** is wired for id / status / quantity / total_price / order_date / expected_delivery → server `order` param.
- **Removed the useless quantity filter** — the fixed `{1,5,10,20}` select was meaningless; Status / Order Date / Partner remain.
- **Partner filter no longer truncated** — cap raised 100 → 1000 (comment notes async typeahead as the future move if the roster grows).
- **Inline error recovery** — replaced `if (isError) throw error` (which blanked the page via the route error boundary) with an inline message + **Retry**.

## Verification (Playwright vs the running local admin)
- Default first row = **6/15/2026** (newest); clicking **Order Date** flips first row to **5/30/2026** (oldest) → sorting works.
- Filter menu shows **Status / Order Date / Partner**, **no Quantity**.
- `medusa build` clean.

Screenshots captured locally (table + open filter menu).

## Not in this PR (tracked on #784)
- **Bulk actions / CSV export** — needs a new backend endpoint; deferred as the heaviest, least-used item.
- **Partner-list load-all-then-filter** scaling (documented MikroORM limitation; needs link-table status denormalization).

Parent: #778 · Group: #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)