### PR TITLE
feat(raw-material): S3 — group ordering (order a material in multiple colors) (#817)

### DIFF
--- a/apps/backend/integration-tests/http/raw-material-group-ordering-api.spec.ts
+++ b/apps/backend/integration-tests/http/raw-material-group-ordering-api.spec.ts
@@ -1,0 +1,181 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { RAW_MATERIAL_MODULE } from "../../src/modules/raw_material"
+
+jest.setTimeout(90000)
+
+/**
+ * #817 S3 — group-ordering API: create a raw_material_group, add per-color
+ * raw_materials, order the group in multiple colors (fanning out one line per
+ * color), and auto-create the per-color inventory_item when a color has none.
+ */
+setupSharedTestSuite(() => {
+  let headers: any
+  let stockLocationId: string
+  const { api, getContainer } = getSharedTestEnv()
+
+  const orderFields = (lines: any[]) => ({
+    lines,
+    status: "Pending",
+    order_date: "2026-07-01T00:00:00.000Z",
+    expected_delivery_date: "2026-08-01T00:00:00.000Z",
+    shipping_address: { city: "Delhi", country_code: "in" },
+    stock_location_id: stockLocationId,
+    is_sample: false,
+  })
+
+  beforeEach(async () => {
+    const container = getContainer()
+    await createAdminUser(container)
+    headers = await getAuthHeaders(api)
+
+    const stockLocation = await api.post(
+      "/admin/stock-locations",
+      { name: "Group Order Warehouse" },
+      headers
+    )
+    stockLocationId = stockLocation.data.stock_location.id
+  })
+
+  it("creates a group with enum defaults", async () => {
+    const res = await api.post(
+      "/admin/raw-material-groups",
+      { name: "Cotton Poplin", composition: "100% Cotton" },
+      headers
+    )
+    expect(res.status).toBe(201)
+    expect(res.data.raw_material_group.id).toBeTruthy()
+    expect(res.data.raw_material_group.status).toBe("Active")
+    expect(res.data.raw_material_group.unit_of_measure).toBe("Other")
+  })
+
+  it("adds colors and returns them (with their inventory_item + sku) on the group", async () => {
+    const { data: { raw_material_group: group } } = await api.post(
+      "/admin/raw-material-groups",
+      { name: "Linen Blend", composition: "80% Linen 20% Cotton", unit_of_measure: "Meter" },
+      headers
+    )
+
+    const blue = await api.post(
+      `/admin/raw-material-groups/${group.id}/colors`,
+      { name: "Linen Blend — Blue", color: "Blue" },
+      headers
+    )
+    expect(blue.status).toBe(201)
+    await api.post(
+      `/admin/raw-material-groups/${group.id}/colors`,
+      { name: "Linen Blend — Red", color: "Red" },
+      headers
+    )
+
+    const detail = await api.get(
+      `/admin/raw-material-groups/${group.id}`,
+      { headers: headers.headers }
+    )
+    expect(detail.status).toBe(200)
+    const colors = detail.data.raw_material_group.raw_materials
+    expect(colors).toHaveLength(2)
+    const colorNames = colors.map((c: any) => c.color).sort()
+    expect(colorNames).toEqual(["Blue", "Red"])
+    // each color has an inventory_item with a generated SKU
+    for (const c of colors) {
+      expect(c.inventory_item?.id).toBeTruthy()
+      expect(typeof c.inventory_item?.sku).toBe("string")
+    }
+  })
+
+  it("orders a group in multiple colors — one line per color, color denormalized (S2)", async () => {
+    const { data: { raw_material_group: group } } = await api.post(
+      "/admin/raw-material-groups",
+      { name: "Silk Charmeuse", composition: "100% Silk", unit_of_measure: "Meter" },
+      headers
+    )
+    // two colors, each already backed by an inventory_item (via add-color)
+    const ivory = (await api.post(
+      `/admin/raw-material-groups/${group.id}/colors`,
+      { name: "Silk — Ivory", color: "Ivory", material_type_id: undefined },
+      headers
+    ))
+    const { data: detail } = await api.get(
+      `/admin/raw-material-groups/${group.id}`,
+      { headers: headers.headers }
+    )
+    // add a second color
+    await api.post(
+      `/admin/raw-material-groups/${group.id}/colors`,
+      { name: "Silk — Black", color: "Black" },
+      headers
+    )
+    const { data: detail2 } = await api.get(
+      `/admin/raw-material-groups/${group.id}`,
+      { headers: headers.headers }
+    )
+    const colors = detail2.raw_material_group.raw_materials
+
+    const res = await api.post(
+      `/admin/raw-material-groups/${group.id}/orders`,
+      orderFields(colors.map((c: any, i: number) => ({
+        raw_material_id: c.id,
+        quantity: (i + 1) * 10,
+        price: 5,
+      }))),
+      headers
+    )
+
+    expect(res.status).toBe(201)
+    // no new items created — both colors already had one
+    expect(res.data.created_inventory_item_ids).toHaveLength(0)
+    const orderlines = res.data.inventoryOrder.orderlines
+    expect(orderlines).toHaveLength(2)
+    // S2 denormalization rode along: each line has its color + material_name
+    const lineColors = orderlines.map((l: any) => l.color).sort()
+    expect(lineColors).toEqual(["Black", "Ivory"])
+    for (const l of orderlines) {
+      expect(l.material_name).toBeTruthy()
+      expect(l.raw_material_id).toBeTruthy()
+    }
+  })
+
+  it("auto-creates the inventory_item for a color that has none", async () => {
+    const service: any = getContainer().resolve(RAW_MATERIAL_MODULE)
+    const group = await service.createRawMaterialGroups({
+      name: "Wool Melton",
+      composition: "100% Wool",
+      unit_of_measure: "Meter",
+    })
+    // a color created directly on the module → NO inventory_item linked yet
+    const orphanColor = await service.createRawMaterials({
+      name: "Wool Melton — Charcoal",
+      description: "no item yet",
+      composition: "100% Wool",
+      color: "Charcoal",
+      group_id: group.id,
+    })
+
+    const res = await api.post(
+      `/admin/raw-material-groups/${group.id}/orders`,
+      orderFields([{ raw_material_id: orphanColor.id, quantity: 25, price: 7 }]),
+      headers
+    )
+
+    expect(res.status).toBe(201)
+    // the resolve step created exactly one item for the orphan color
+    expect(res.data.created_inventory_item_ids).toHaveLength(1)
+    const orderlines = res.data.inventoryOrder.orderlines
+    expect(orderlines).toHaveLength(1)
+    expect(orderlines[0].color).toBe("Charcoal")
+    expect(orderlines[0].quantity).toBe(25)
+  })
+
+  it("rejects an empty color list", async () => {
+    const { data: { raw_material_group: group } } = await api.post(
+      "/admin/raw-material-groups",
+      { name: "Empty Test" },
+      headers
+    )
+    const res = await api
+      .post(`/admin/raw-material-groups/${group.id}/orders`, orderFields([]), headers)
+      .catch((e: any) => e.response)
+    expect(res.status).toBe(400)
+  })
+})

--- a/apps/backend/src/admin/hooks/api/raw-material-groups.ts
+++ b/apps/backend/src/admin/hooks/api/raw-material-groups.ts
@@ -1,0 +1,103 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { sdk } from "../../lib/config"
+
+// #817 S3 — raw-material groups: the "product" parents that tie per-color
+// raw_materials together, plus the group-ordering (fan-out) surface.
+
+export interface RawMaterialGroupColor {
+  id: string
+  name: string
+  color?: string | null
+  status?: string
+  inventory_item?: { id: string; sku?: string } | null
+}
+
+export interface RawMaterialGroup {
+  id: string
+  name: string
+  description?: string | null
+  composition?: string | null
+  unit_of_measure?: string
+  status?: string
+  material_type?: { id: string; name?: string; category?: string } | null
+  raw_materials?: RawMaterialGroupColor[]
+  created_at?: string
+}
+
+const groupKeys = {
+  all: ["raw-material-groups"] as const,
+  list: (q?: Record<string, unknown>) => ["raw-material-groups", "list", q] as const,
+  detail: (id: string) => ["raw-material-groups", "detail", id] as const,
+}
+
+export const useRawMaterialGroups = (query?: {
+  q?: string
+  status?: string
+  limit?: number
+  offset?: number
+}) =>
+  useQuery({
+    queryKey: groupKeys.list(query),
+    queryFn: () =>
+      sdk.client.fetch<{
+        raw_material_groups: RawMaterialGroup[]
+        count: number
+        offset: number
+        limit: number
+      }>("/admin/raw-material-groups", { query: query as any }),
+  })
+
+export const useRawMaterialGroup = (id?: string) =>
+  useQuery({
+    queryKey: groupKeys.detail(id!),
+    enabled: !!id,
+    queryFn: () =>
+      sdk.client.fetch<{ raw_material_group: RawMaterialGroup }>(
+        `/admin/raw-material-groups/${id}`
+      ),
+  })
+
+export const useCreateRawMaterialGroup = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (body: Record<string, unknown>) =>
+      sdk.client.fetch<{ raw_material_group: RawMaterialGroup }>(
+        "/admin/raw-material-groups",
+        { method: "POST", body }
+      ),
+    onSuccess: () => qc.invalidateQueries({ queryKey: groupKeys.all }),
+  })
+}
+
+export const useAddGroupColor = (groupId: string) => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (body: Record<string, unknown>) =>
+      sdk.client.fetch<{ raw_material_group: RawMaterialGroup }>(
+        `/admin/raw-material-groups/${groupId}/colors`,
+        { method: "POST", body }
+      ),
+    onSuccess: () => qc.invalidateQueries({ queryKey: groupKeys.detail(groupId) }),
+  })
+}
+
+export type GroupOrderLine = {
+  raw_material_id: string
+  quantity: number
+  price: number
+}
+
+export const useCreateGroupOrder = (groupId: string) => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (body: Record<string, unknown>) =>
+      sdk.client.fetch<{
+        inventoryOrder: { id: string }
+        created_inventory_item_ids: string[]
+      }>(`/admin/raw-material-groups/${groupId}/orders`, {
+        method: "POST",
+        body,
+      }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: groupKeys.detail(groupId) }),
+  })
+}

--- a/apps/backend/src/admin/routes/raw-material-groups/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/raw-material-groups/[id]/page.tsx
@@ -56,7 +56,9 @@ const AddColorModal = ({ groupId }: { groupId: string }) => {
         </FocusModal.Header>
         <FocusModal.Body className="flex flex-col items-center py-16">
           <div className="flex w-full max-w-lg flex-col gap-y-6">
-            <Heading>Add a color</Heading>
+            <FocusModal.Title asChild>
+              <Heading>Add a color</Heading>
+            </FocusModal.Title>
             <div className="flex flex-col gap-y-2">
               <Label>Name</Label>
               <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Cotton Poplin — Blue" />
@@ -143,10 +145,14 @@ const OrderInColorsModal = ({
         <FocusModal.Body className="flex flex-col items-center py-16">
           <div className="flex w-full max-w-2xl flex-col gap-y-6">
             <div>
-              <Heading>Order this group in colors</Heading>
-              <Text size="small" className="text-ui-fg-subtle">
-                One order line per selected color. Colors without stock are created automatically.
-              </Text>
+              <FocusModal.Title asChild>
+                <Heading>Order this group in colors</Heading>
+              </FocusModal.Title>
+              <FocusModal.Description asChild>
+                <Text size="small" className="text-ui-fg-subtle">
+                  One order line per selected color. Colors without stock are created automatically.
+                </Text>
+              </FocusModal.Description>
             </div>
             <div className="flex flex-col gap-y-2">
               <Label>Ship to location</Label>

--- a/apps/backend/src/admin/routes/raw-material-groups/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/raw-material-groups/[id]/page.tsx
@@ -1,0 +1,298 @@
+import {
+  Badge,
+  Button,
+  Container,
+  Heading,
+  Input,
+  Label,
+  Table,
+  Text,
+  FocusModal,
+  Select,
+  Checkbox,
+  Skeleton,
+  toast,
+} from "@medusajs/ui"
+import { useMemo, useState } from "react"
+import { useParams, useNavigate } from "react-router-dom"
+import {
+  useRawMaterialGroup,
+  useAddGroupColor,
+  useCreateGroupOrder,
+  type RawMaterialGroupColor,
+} from "../../../hooks/api/raw-material-groups"
+import { useStockLocations } from "../../../hooks/api/stock_location"
+
+const AddColorModal = ({ groupId }: { groupId: string }) => {
+  const [open, setOpen] = useState(false)
+  const [name, setName] = useState("")
+  const [color, setColor] = useState("")
+  const { mutateAsync, isPending } = useAddGroupColor(groupId)
+
+  const submit = async () => {
+    if (!name.trim() || !color.trim()) {
+      toast.error("Name and color are required")
+      return
+    }
+    try {
+      await mutateAsync({ name: name.trim(), color: color.trim() })
+      toast.success("Color added")
+      setOpen(false)
+      setName("")
+      setColor("")
+    } catch (e: any) {
+      toast.error(e?.message || "Failed to add color")
+    }
+  }
+
+  return (
+    <FocusModal open={open} onOpenChange={setOpen}>
+      <FocusModal.Trigger asChild>
+        <Button size="small" variant="secondary">Add color</Button>
+      </FocusModal.Trigger>
+      <FocusModal.Content>
+        <FocusModal.Header>
+          <Button size="small" onClick={submit} isLoading={isPending}>Save</Button>
+        </FocusModal.Header>
+        <FocusModal.Body className="flex flex-col items-center py-16">
+          <div className="flex w-full max-w-lg flex-col gap-y-6">
+            <Heading>Add a color</Heading>
+            <div className="flex flex-col gap-y-2">
+              <Label>Name</Label>
+              <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Cotton Poplin — Blue" />
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label>Color</Label>
+              <Input value={color} onChange={(e) => setColor(e.target.value)} placeholder="Blue" />
+            </div>
+          </div>
+        </FocusModal.Body>
+      </FocusModal.Content>
+    </FocusModal>
+  )
+}
+
+type LineDraft = { selected: boolean; quantity: string; price: string }
+
+const OrderInColorsModal = ({
+  groupId,
+  colors,
+}: {
+  groupId: string
+  colors: RawMaterialGroupColor[]
+}) => {
+  const [open, setOpen] = useState(false)
+  const [stockLocationId, setStockLocationId] = useState<string>("")
+  const [drafts, setDrafts] = useState<Record<string, LineDraft>>({})
+  const { stock_locations = [] } = useStockLocations()
+  const { mutateAsync, isPending } = useCreateGroupOrder(groupId)
+
+  const setDraft = (id: string, patch: Partial<LineDraft>) =>
+    setDrafts((d) => ({
+      ...d,
+      [id]: { selected: false, quantity: "", price: "", ...d[id], ...patch },
+    }))
+
+  const submit = async () => {
+    const lines = colors
+      .filter((c) => drafts[c.id]?.selected)
+      .map((c) => ({
+        raw_material_id: c.id,
+        quantity: Number(drafts[c.id]?.quantity) || 0,
+        price: Number(drafts[c.id]?.price) || 0,
+      }))
+    if (!lines.length) {
+      toast.error("Select at least one color")
+      return
+    }
+    if (!stockLocationId) {
+      toast.error("Select a stock location")
+      return
+    }
+    const now = new Date()
+    const eta = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000)
+    try {
+      const res = await mutateAsync({
+        lines,
+        status: "Pending",
+        order_date: now.toISOString(),
+        expected_delivery_date: eta.toISOString(),
+        shipping_address: {},
+        stock_location_id: stockLocationId,
+      })
+      const created = res.created_inventory_item_ids?.length
+        ? ` (${res.created_inventory_item_ids.length} new item(s) created)`
+        : ""
+      toast.success(`Order placed${created}`)
+      setOpen(false)
+      setDrafts({})
+    } catch (e: any) {
+      toast.error(e?.message || "Failed to place order")
+    }
+  }
+
+  return (
+    <FocusModal open={open} onOpenChange={setOpen}>
+      <FocusModal.Trigger asChild>
+        <Button size="small" disabled={!colors.length}>Order in colors</Button>
+      </FocusModal.Trigger>
+      <FocusModal.Content>
+        <FocusModal.Header>
+          <Button size="small" onClick={submit} isLoading={isPending}>Place order</Button>
+        </FocusModal.Header>
+        <FocusModal.Body className="flex flex-col items-center py-16">
+          <div className="flex w-full max-w-2xl flex-col gap-y-6">
+            <div>
+              <Heading>Order this group in colors</Heading>
+              <Text size="small" className="text-ui-fg-subtle">
+                One order line per selected color. Colors without stock are created automatically.
+              </Text>
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label>Ship to location</Label>
+              <Select value={stockLocationId} onValueChange={setStockLocationId}>
+                <Select.Trigger>
+                  <Select.Value placeholder="Select a stock location" />
+                </Select.Trigger>
+                <Select.Content>
+                  {stock_locations.map((sl: any) => (
+                    <Select.Item key={sl.id} value={sl.id}>{sl.name}</Select.Item>
+                  ))}
+                </Select.Content>
+              </Select>
+            </div>
+            <Table>
+              <Table.Header>
+                <Table.Row>
+                  <Table.HeaderCell> </Table.HeaderCell>
+                  <Table.HeaderCell>Color</Table.HeaderCell>
+                  <Table.HeaderCell>Quantity</Table.HeaderCell>
+                  <Table.HeaderCell>Unit price</Table.HeaderCell>
+                </Table.Row>
+              </Table.Header>
+              <Table.Body>
+                {colors.map((c) => {
+                  const d = drafts[c.id]
+                  return (
+                    <Table.Row key={c.id}>
+                      <Table.Cell>
+                        <Checkbox
+                          checked={!!d?.selected}
+                          onCheckedChange={(v) => setDraft(c.id, { selected: !!v })}
+                        />
+                      </Table.Cell>
+                      <Table.Cell>{c.color || c.name}</Table.Cell>
+                      <Table.Cell>
+                        <Input
+                          type="number"
+                          disabled={!d?.selected}
+                          value={d?.quantity ?? ""}
+                          onChange={(e) => setDraft(c.id, { quantity: e.target.value })}
+                        />
+                      </Table.Cell>
+                      <Table.Cell>
+                        <Input
+                          type="number"
+                          disabled={!d?.selected}
+                          value={d?.price ?? ""}
+                          onChange={(e) => setDraft(c.id, { price: e.target.value })}
+                        />
+                      </Table.Cell>
+                    </Table.Row>
+                  )
+                })}
+              </Table.Body>
+            </Table>
+          </div>
+        </FocusModal.Body>
+      </FocusModal.Content>
+    </FocusModal>
+  )
+}
+
+const RawMaterialGroupDetailPage = () => {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const { data, isLoading } = useRawMaterialGroup(id)
+  const group = data?.raw_material_group
+  const colors = useMemo(() => group?.raw_materials ?? [], [group])
+
+  if (isLoading) {
+    return (
+      <Container className="p-6">
+        <Skeleton className="mb-4 h-8 w-64" />
+        <Skeleton className="h-40 w-full" />
+      </Container>
+    )
+  }
+
+  if (!group) {
+    return (
+      <Container className="p-6">
+        <Text className="text-ui-fg-subtle">Group not found.</Text>
+      </Container>
+    )
+  }
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div>
+          <Heading level="h1">{group.name}</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            {group.composition || "—"}
+          </Text>
+        </div>
+        <div className="flex items-center gap-x-2">
+          <AddColorModal groupId={group.id} />
+          <OrderInColorsModal groupId={group.id} colors={colors} />
+        </div>
+      </div>
+
+      <div className="px-2 py-2">
+        {!colors.length ? (
+          <div className="px-6 py-8 text-center">
+            <Text className="text-ui-fg-subtle">No colors yet. Add one to order this group.</Text>
+          </div>
+        ) : (
+          <Table>
+            <Table.Header>
+              <Table.Row>
+                <Table.HeaderCell>Color</Table.HeaderCell>
+                <Table.HeaderCell>Name</Table.HeaderCell>
+                <Table.HeaderCell>SKU</Table.HeaderCell>
+                <Table.HeaderCell>Stock item</Table.HeaderCell>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {colors.map((c) => (
+                <Table.Row
+                  key={c.id}
+                  className={c.inventory_item?.id ? "cursor-pointer" : undefined}
+                  onClick={() =>
+                    c.inventory_item?.id && navigate(`/inventory/${c.inventory_item.id}`)
+                  }
+                >
+                  <Table.Cell>
+                    {c.color ? <Badge size="small" color="grey">{c.color}</Badge> : "—"}
+                  </Table.Cell>
+                  <Table.Cell>{c.name}</Table.Cell>
+                  <Table.Cell className="text-ui-fg-subtle">
+                    {c.inventory_item?.sku || "—"}
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Badge size="small" color={c.inventory_item?.id ? "green" : "orange"}>
+                      {c.inventory_item?.id ? "Yes" : "On first order"}
+                    </Badge>
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table>
+        )}
+      </div>
+    </Container>
+  )
+}
+
+export default RawMaterialGroupDetailPage

--- a/apps/backend/src/admin/routes/raw-material-groups/page.tsx
+++ b/apps/backend/src/admin/routes/raw-material-groups/page.tsx
@@ -1,0 +1,144 @@
+import { defineRouteConfig } from "@medusajs/admin-sdk"
+import { Swatch } from "@medusajs/icons"
+import {
+  Button,
+  Container,
+  Heading,
+  Input,
+  Label,
+  Table,
+  Text,
+  Textarea,
+  FocusModal,
+  Badge,
+  Skeleton,
+  toast,
+} from "@medusajs/ui"
+import { useState } from "react"
+import { useNavigate } from "react-router-dom"
+import {
+  useRawMaterialGroups,
+  useCreateRawMaterialGroup,
+} from "../../hooks/api/raw-material-groups"
+
+const CreateGroupModal = () => {
+  const [open, setOpen] = useState(false)
+  const [name, setName] = useState("")
+  const [composition, setComposition] = useState("")
+  const { mutateAsync, isPending } = useCreateRawMaterialGroup()
+
+  const submit = async () => {
+    if (!name.trim()) {
+      toast.error("Name is required")
+      return
+    }
+    try {
+      await mutateAsync({ name: name.trim(), composition: composition.trim() || undefined })
+      toast.success("Group created")
+      setOpen(false)
+      setName("")
+      setComposition("")
+    } catch (e: any) {
+      toast.error(e?.message || "Failed to create group")
+    }
+  }
+
+  return (
+    <FocusModal open={open} onOpenChange={setOpen}>
+      <FocusModal.Trigger asChild>
+        <Button size="small" variant="secondary">Create group</Button>
+      </FocusModal.Trigger>
+      <FocusModal.Content>
+        <FocusModal.Header>
+          <Button size="small" onClick={submit} isLoading={isPending}>Save</Button>
+        </FocusModal.Header>
+        <FocusModal.Body className="flex flex-col items-center py-16">
+          <div className="flex w-full max-w-lg flex-col gap-y-6">
+            <div>
+              <Heading>New raw-material group</Heading>
+              <Text size="small" className="text-ui-fg-subtle">
+                A group ties per-color materials together (e.g. "Cotton Poplin" in blue / red / green).
+              </Text>
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label>Name</Label>
+              <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Cotton Poplin" />
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label>Composition</Label>
+              <Textarea value={composition} onChange={(e) => setComposition(e.target.value)} placeholder="100% Cotton" />
+            </div>
+          </div>
+        </FocusModal.Body>
+      </FocusModal.Content>
+    </FocusModal>
+  )
+}
+
+const RawMaterialGroupsPage = () => {
+  const navigate = useNavigate()
+  const { data, isLoading } = useRawMaterialGroups({ limit: 50 })
+  const groups = data?.raw_material_groups ?? []
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div>
+          <Heading level="h1">Raw-material groups</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            Order a material in multiple colors without losing color identity.
+          </Text>
+        </div>
+        <CreateGroupModal />
+      </div>
+
+      {isLoading ? (
+        <div className="flex flex-col gap-2 px-6 py-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-10 w-full" />
+          ))}
+        </div>
+      ) : !groups.length ? (
+        <div className="px-6 py-8 text-center">
+          <Text className="text-ui-fg-subtle">No groups yet. Create one to get started.</Text>
+        </div>
+      ) : (
+        <Table>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>Name</Table.HeaderCell>
+              <Table.HeaderCell>Composition</Table.HeaderCell>
+              <Table.HeaderCell>Colors</Table.HeaderCell>
+              <Table.HeaderCell>Status</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {groups.map((g) => (
+              <Table.Row
+                key={g.id}
+                className="cursor-pointer"
+                onClick={() => navigate(`/raw-material-groups/${g.id}`)}
+              >
+                <Table.Cell>{g.name}</Table.Cell>
+                <Table.Cell className="text-ui-fg-subtle">{g.composition || "—"}</Table.Cell>
+                <Table.Cell>{g.raw_materials?.length ?? 0}</Table.Cell>
+                <Table.Cell>
+                  <Badge size="small" color={g.status === "Active" ? "green" : "grey"}>
+                    {g.status || "Active"}
+                  </Badge>
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      )}
+    </Container>
+  )
+}
+
+export const config = defineRouteConfig({
+  label: "Material Groups",
+  icon: Swatch,
+})
+
+export default RawMaterialGroupsPage

--- a/apps/backend/src/admin/routes/raw-material-groups/page.tsx
+++ b/apps/backend/src/admin/routes/raw-material-groups/page.tsx
@@ -55,10 +55,14 @@ const CreateGroupModal = () => {
         <FocusModal.Body className="flex flex-col items-center py-16">
           <div className="flex w-full max-w-lg flex-col gap-y-6">
             <div>
-              <Heading>New raw-material group</Heading>
-              <Text size="small" className="text-ui-fg-subtle">
-                A group ties per-color materials together (e.g. "Cotton Poplin" in blue / red / green).
-              </Text>
+              <FocusModal.Title asChild>
+                <Heading>New raw-material group</Heading>
+              </FocusModal.Title>
+              <FocusModal.Description asChild>
+                <Text size="small" className="text-ui-fg-subtle">
+                  A group ties per-color materials together (e.g. "Cotton Poplin" in blue / red / green).
+                </Text>
+              </FocusModal.Description>
             </div>
             <div className="flex flex-col gap-y-2">
               <Label>Name</Label>

--- a/apps/backend/src/api/admin/raw-material-groups/[id]/colors/route.ts
+++ b/apps/backend/src/api/admin/raw-material-groups/[id]/colors/route.ts
@@ -1,0 +1,74 @@
+/**
+ * API: /admin/raw-material-groups/:id/colors  (#817 S3)
+ *
+ * POST — add a color (a per-color raw_material) to the group: creates an
+ *        inventory_item, creates the raw_material with `group_id` set, links
+ *        them, and generates a SKU (reusing createRawMaterialWorkflow). Shared
+ *        specs (composition / unit_of_measure / material_type) default from the
+ *        group when omitted.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { createInventoryItemsWorkflow } from "@medusajs/medusa/core-flows"
+import { RAW_MATERIAL_MODULE } from "../../../../../modules/raw_material"
+import { createRawMaterialWorkflow } from "../../../../../workflows/raw-materials/create-raw-material"
+import { AddGroupColor } from "../../validators"
+import { refetchRawMaterialGroup } from "../../helpers"
+
+export const POST = async (
+  req: MedusaRequest<AddGroupColor>,
+  res: MedusaResponse
+) => {
+  const { id: groupId } = req.params
+  const body = req.validatedBody
+  const service: any = req.scope.resolve(RAW_MATERIAL_MODULE)
+
+  // Group must exist; pull shared specs to default from.
+  const group = await service
+    .retrieveRawMaterialGroup(groupId, { relations: ["material_type"] })
+    .catch(() => null)
+  if (!group) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Raw material group with id "${groupId}" not found`
+    )
+  }
+
+  // 1) Create the inventory item for this color.
+  const { result: created } = await createInventoryItemsWorkflow(req.scope).run({
+    input: { items: [{ title: body.name }] },
+  })
+  const inventoryItem = ((created as any)?.items || (created as any) || [])[0]
+  if (!inventoryItem?.id) {
+    throw new MedusaError(
+      MedusaError.Types.UNEXPECTED_STATE,
+      "Failed to create inventory item for the color"
+    )
+  }
+
+  // 2) Create the per-color raw_material (with group_id) + link + SKU.
+  const rawMaterialData = {
+    name: body.name,
+    color: body.color,
+    description: body.description ?? "",
+    composition: body.composition ?? group.composition ?? "",
+    unit_of_measure: body.unit_of_measure ?? group.unit_of_measure ?? "Other",
+    ...(body.material_type_id
+      ? { material_type_id: body.material_type_id }
+      : group.material_type_id
+        ? { material_type_id: group.material_type_id }
+        : {}),
+    ...(body.unit_cost != null ? { unit_cost: body.unit_cost } : {}),
+    ...(body.cost_currency ? { cost_currency: body.cost_currency } : {}),
+    ...(body.metadata ? { metadata: body.metadata } : {}),
+    ...(body.media ? { media: body.media } : {}),
+    group_id: groupId,
+  }
+
+  await createRawMaterialWorkflow(req.scope).run({
+    input: { inventoryId: inventoryItem.id, rawMaterialData },
+  })
+
+  const raw_material_group = await refetchRawMaterialGroup(groupId, req.scope)
+  res.status(201).json({ raw_material_group })
+}

--- a/apps/backend/src/api/admin/raw-material-groups/[id]/orders/route.ts
+++ b/apps/backend/src/api/admin/raw-material-groups/[id]/orders/route.ts
@@ -1,0 +1,85 @@
+/**
+ * API: /admin/raw-material-groups/:id/orders  (#817 S3)
+ *
+ * POST — order a group in multiple colors. Fans out one inventory-order line
+ *        per selected color, resolving (or auto-creating) each color's
+ *        inventory_item first, then delegating to createInventoryOrderWorkflow
+ *        (which denormalizes color identity onto each line per S2).
+ *
+ * Note: item resolution and order creation are two workflow runs, not one
+ * transaction. If order creation fails, any auto-created inventory_items are
+ * rolled back by the resolve workflow's compensation; a successful resolve
+ * followed by a failed create leaves the (reusable) items in place.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { createInventoryOrderWorkflow } from "../../../../../workflows/inventory_orders/create-inventory-orders"
+import { resolveGroupColorInventoryItemsWorkflow } from "../../../../../workflows/raw_material_groups/resolve-group-color-items"
+import { RAW_MATERIAL_MODULE } from "../../../../../modules/raw_material"
+import {
+  sumGroupOrderTotal,
+  sumGroupOrderQuantity,
+} from "../../../../../modules/raw_material/lib/group-order-helpers"
+import { refetchInventoryOrder } from "../../../inventory-orders/helpers"
+import { CreateGroupOrder } from "../../validators"
+
+export const POST = async (
+  req: MedusaRequest<CreateGroupOrder>,
+  res: MedusaResponse
+) => {
+  const { id: groupId } = req.params
+  const body = req.validatedBody
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+
+  // Group must exist.
+  const service: any = req.scope.resolve(RAW_MATERIAL_MODULE)
+  const group = await service.retrieveRawMaterialGroup(groupId).catch(() => null)
+  if (!group) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Raw material group with id "${groupId}" not found`
+    )
+  }
+
+  // 1) Resolve / auto-create the inventory_item for each selected color.
+  const { result: resolved, errors: resolveErrors } =
+    await resolveGroupColorInventoryItemsWorkflow(req.scope).run({
+      input: {
+        lines: body.lines,
+        stock_location_id: body.stock_location_id,
+      },
+    })
+  if (resolveErrors?.length) {
+    logger.warn(`[group-order] resolve failed: ${JSON.stringify(resolveErrors)}`)
+    throw resolveErrors
+  }
+
+  // 2) Create the inventory order from the fanned-out lines.
+  const { result, errors } = await createInventoryOrderWorkflow(req.scope).run({
+    input: {
+      order_lines: resolved.order_lines,
+      quantity: sumGroupOrderQuantity(body.lines),
+      total_price: sumGroupOrderTotal(body.lines),
+      currency_code: body.currency_code,
+      status: body.status,
+      order_date: body.order_date,
+      expected_delivery_date: body.expected_delivery_date,
+      shipping_address: body.shipping_address,
+      stock_location_id: body.stock_location_id,
+      from_stock_location_id: body.from_stock_location_id,
+      to_stock_location_id: body.to_stock_location_id,
+      is_sample: body.is_sample,
+      metadata: { ...(body.metadata ?? {}), raw_material_group_id: groupId },
+    } as any,
+  })
+  if (errors?.length) {
+    logger.warn(`[group-order] create failed: ${JSON.stringify(errors)}`)
+    throw errors
+  }
+
+  const inventoryOrder = await refetchInventoryOrder(result.order.id, req.scope)
+  res.status(201).json({
+    inventoryOrder,
+    created_inventory_item_ids: resolved.created_inventory_item_ids,
+  })
+}

--- a/apps/backend/src/api/admin/raw-material-groups/[id]/route.ts
+++ b/apps/backend/src/api/admin/raw-material-groups/[id]/route.ts
@@ -1,0 +1,14 @@
+/**
+ * API: /admin/raw-material-groups/:id  (#817 S3)
+ *
+ * GET — a group with its per-color raw_materials and each color's linked
+ *       inventory_item (id/sku). Feeds the group-ordering UI.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { refetchRawMaterialGroup } from "../helpers"
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params
+  const raw_material_group = await refetchRawMaterialGroup(id, req.scope)
+  res.status(200).json({ raw_material_group })
+}

--- a/apps/backend/src/api/admin/raw-material-groups/helpers.ts
+++ b/apps/backend/src/api/admin/raw-material-groups/helpers.ts
@@ -1,0 +1,65 @@
+import { MedusaContainer } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import RawMaterialInventoryLink from "../../../links/raw-material-data-inventory"
+
+/**
+ * Fetch a raw_material_group together with its per-color raw_materials (the
+ * "variants"), the shared material_type, and each color's linked inventory_item
+ * (id/sku). Powers the group detail + the group-ordering UI.
+ *
+ * The color→inventory_item info is attached via a second query over the
+ * raw_material↔inventory_item LINK entity (the proven direction — there is no
+ * nested raw_material→inventory_item graph path), so this stays deterministic.
+ */
+export const refetchRawMaterialGroup = async (
+  id: string,
+  container: MedusaContainer
+) => {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data } = await query.graph({
+    entity: "raw_material_group",
+    filters: { id },
+    fields: [
+      "*",
+      "material_type.*",
+      "raw_materials.id",
+      "raw_materials.name",
+      "raw_materials.color",
+      "raw_materials.status",
+    ],
+  })
+
+  if (!data?.length) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Raw material group with id "${id}" not found`
+    )
+  }
+
+  const group: any = data[0]
+  const colors: any[] = group.raw_materials ?? []
+
+  if (colors.length) {
+    const rawMaterialIds = colors.map((c) => c.id).filter(Boolean)
+    const { data: linkRows } = await query.graph({
+      entity: RawMaterialInventoryLink.entryPoint,
+      fields: ["raw_materials.id", "inventory_item.id", "inventory_item.sku"],
+      filters: { raw_materials_id: rawMaterialIds },
+    })
+    const itemByRawMaterialId = new Map<string, { id: string; sku?: string }>()
+    for (const row of (linkRows as any[]) ?? []) {
+      const rmId = row?.raw_materials?.id
+      const item = row?.inventory_item
+      if (rmId && item?.id && !itemByRawMaterialId.has(rmId)) {
+        itemByRawMaterialId.set(rmId, { id: item.id, sku: item.sku })
+      }
+    }
+    group.raw_materials = colors.map((c) => ({
+      ...c,
+      inventory_item: itemByRawMaterialId.get(c.id) ?? null,
+    }))
+  }
+
+  return group
+}

--- a/apps/backend/src/api/admin/raw-material-groups/route.ts
+++ b/apps/backend/src/api/admin/raw-material-groups/route.ts
@@ -1,0 +1,59 @@
+/**
+ * API: /admin/raw-material-groups  (#817 S3)
+ *
+ * GET  — list raw-material groups (the "product" parents that tie per-color
+ *        raw_materials together). Query: q, status, offset, limit.
+ * POST — create a group.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { RAW_MATERIAL_MODULE } from "../../../modules/raw_material"
+import {
+  CreateRawMaterialGroup,
+  ListRawMaterialGroupsQuery,
+} from "./validators"
+
+export const GET = async (
+  req: MedusaRequest<unknown, ListRawMaterialGroupsQuery>,
+  res: MedusaResponse
+) => {
+  const query = req.validatedQuery as unknown as ListRawMaterialGroupsQuery
+  const service: any = req.scope.resolve(RAW_MATERIAL_MODULE)
+
+  const filters: Record<string, unknown> = {}
+  if (query.status) filters.status = query.status
+  if (query.q) filters.name = { $ilike: `%${query.q}%` }
+
+  const [groups, count] = await service.listAndCountRawMaterialGroups(filters, {
+    skip: query.offset,
+    take: query.limit,
+    order: { created_at: "DESC" },
+    relations: ["material_type"],
+  })
+
+  res.status(200).json({
+    raw_material_groups: groups,
+    count,
+    offset: query.offset,
+    limit: query.limit,
+  })
+}
+
+export const POST = async (
+  req: MedusaRequest<CreateRawMaterialGroup>,
+  res: MedusaResponse
+) => {
+  const body = req.validatedBody
+  const service: any = req.scope.resolve(RAW_MATERIAL_MODULE)
+
+  const { material_type_id, ...rest } = body
+  const group = await service.createRawMaterialGroups({
+    ...rest,
+    ...(material_type_id ? { material_type_id } : {}),
+  })
+
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  logger.debug(`[raw-material-groups] created group ${group.id}`)
+
+  res.status(201).json({ raw_material_group: group })
+}

--- a/apps/backend/src/api/admin/raw-material-groups/validators.ts
+++ b/apps/backend/src/api/admin/raw-material-groups/validators.ts
@@ -1,0 +1,125 @@
+import { z } from "@medusajs/framework/zod"
+import {
+  INVENTORY_ORDER_STATUS_INPUT,
+  type InventoryOrderInputStatus,
+} from "../../../modules/inventory_orders/constants"
+
+const UNIT_OF_MEASURE = [
+  "Meter",
+  "Yard",
+  "Kilogram",
+  "Gram",
+  "Piece",
+  "Roll",
+  "Other",
+] as const
+
+const GROUP_STATUS = [
+  "Active",
+  "Discontinued",
+  "Under_Review",
+  "Development",
+] as const
+
+// --- Group CRUD ---
+
+export const createRawMaterialGroupSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  description: z.string().optional(),
+  composition: z.string().optional(),
+  specifications: z.record(z.string(), z.unknown()).optional(),
+  unit_of_measure: z.enum(UNIT_OF_MEASURE).optional(),
+  status: z.enum(GROUP_STATUS).optional(),
+  material_type_id: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  media: z.record(z.string(), z.unknown()).optional(),
+})
+export type CreateRawMaterialGroup = z.infer<typeof createRawMaterialGroupSchema>
+
+export const listRawMaterialGroupsQuerySchema = z.object({
+  q: z.string().optional(),
+  status: z.enum(GROUP_STATUS).optional(),
+  offset: z.preprocess(
+    (v) => (v !== undefined && v !== null ? Number(v) : undefined),
+    z.number().int().min(0).default(0)
+  ),
+  limit: z.preprocess(
+    (v) => (v !== undefined && v !== null ? Number(v) : undefined),
+    z.number().int().min(1).max(100).default(20)
+  ),
+})
+export type ListRawMaterialGroupsQuery = z.infer<typeof listRawMaterialGroupsQuerySchema>
+
+// --- Add a color (per-color raw_material) to a group ---
+
+export const addGroupColorSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  color: z.string().min(1, "Color is required"),
+  description: z.string().optional(),
+  composition: z.string().optional(),
+  unit_of_measure: z.enum(UNIT_OF_MEASURE).optional(),
+  material_type_id: z.string().optional(),
+  unit_cost: z.number().optional(),
+  cost_currency: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  media: z.record(z.string(), z.unknown()).optional(),
+})
+export type AddGroupColor = z.infer<typeof addGroupColorSchema>
+
+// --- Order a group in multiple colors (fan-out) ---
+
+const groupOrderLineSchema = z.object({
+  raw_material_id: z.string().min(1, "raw_material_id is required"),
+  quantity: z.number().nonnegative("Quantity must be zero or positive"),
+  price: z.number().nonnegative("Price must be zero or positive"),
+})
+
+export const createGroupOrderSchema = z
+  .object({
+    lines: z
+      .array(groupOrderLineSchema)
+      .min(1, "At least one color line is required"),
+    status: z.enum(
+      INVENTORY_ORDER_STATUS_INPUT as [
+        InventoryOrderInputStatus,
+        ...InventoryOrderInputStatus[]
+      ]
+    ),
+    currency_code: z.string().min(3).max(3).optional(),
+    expected_delivery_date: z.coerce.date(),
+    order_date: z.coerce.date(),
+    shipping_address: z.record(z.string(), z.unknown()),
+    stock_location_id: z.string(),
+    from_stock_location_id: z.string().optional(),
+    to_stock_location_id: z.string().optional(),
+    is_sample: z.boolean().optional().default(false),
+    metadata: z.record(z.string(), z.unknown()).optional(),
+  })
+  .superRefine((data, ctx) => {
+    const toId = data.to_stock_location_id || data.stock_location_id
+    if (!toId || toId.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "A 'to' stock location is required (use stock_location_id or to_stock_location_id)",
+        path: ["to_stock_location_id"],
+      })
+    }
+    if (
+      data.from_stock_location_id &&
+      toId &&
+      data.from_stock_location_id === toId
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "from_stock_location_id cannot be the same as the 'to' stock location",
+        path: ["from_stock_location_id"],
+      })
+    }
+  })
+export type CreateGroupOrder = z.infer<typeof createGroupOrderSchema>
+
+export const readGroupQuerySchema = z.object({
+  fields: z.string().optional(),
+})

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -101,6 +101,7 @@ import { updatePartnerMeSchema } from "./partners/me/validators";
 import { onboardingProfileUpdateSchema } from "./partners/onboarding-profile/validators";
 import { AdminGetPartnersParamsSchema } from "./admin/persons/partner/validators";
 import { createInventoryOrdersSchema, listInventoryOrdersQuerySchema, ReadSingleInventoryOrderQuerySchema, updateInventoryOrdersSchema, updateInventoryOrderLinesSchema } from "./admin/inventory-orders/validators";
+import { createRawMaterialGroupSchema, listRawMaterialGroupsQuerySchema, addGroupColorSchema, createGroupOrderSchema, readGroupQuerySchema } from "./admin/raw-material-groups/validators";
 // Import already defined above
 import { SendBlogSubscriptionSchema } from "./admin/websites/[id]/pages/[pageId]/subs/route";
 import { subscriptionSchema } from "./web/website/[domain]/validators";
@@ -2886,6 +2887,32 @@ export default defineMiddlewares({
       matcher: "/admin/inventory-orders/:id/order-lines",
       method: 'PUT',
       middlewares: [validateAndTransformBody(wrapSchema(updateInventoryOrderLinesSchema))],
+    },
+    // Raw-material groups (#817 S3)
+    {
+      matcher: "/admin/raw-material-groups",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(createRawMaterialGroupSchema))],
+    },
+    {
+      matcher: "/admin/raw-material-groups",
+      method: "GET",
+      middlewares: [validateAndTransformQuery(wrapSchema(listRawMaterialGroupsQuerySchema), {})],
+    },
+    {
+      matcher: "/admin/raw-material-groups/:id",
+      method: "GET",
+      middlewares: [validateAndTransformQuery(wrapSchema(readGroupQuerySchema), {})],
+    },
+    {
+      matcher: "/admin/raw-material-groups/:id/colors",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(addGroupColorSchema))],
+    },
+    {
+      matcher: "/admin/raw-material-groups/:id/orders",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(createGroupOrderSchema))],
     },
     // Inbound Emails routes
     {

--- a/apps/backend/src/modules/raw_material/__tests__/group-order-helpers.unit.spec.ts
+++ b/apps/backend/src/modules/raw_material/__tests__/group-order-helpers.unit.spec.ts
@@ -1,0 +1,98 @@
+import {
+  buildItemIdByRawMaterialId,
+  splitResolvedAndMissing,
+  buildResolvedOrderLines,
+  sumGroupOrderTotal,
+  sumGroupOrderQuantity,
+} from "../lib/group-order-helpers"
+
+describe("buildItemIdByRawMaterialId (#817 S3)", () => {
+  it("maps raw_material_id -> inventory_item_id from link rows", () => {
+    const map = buildItemIdByRawMaterialId([
+      { raw_materials: { id: "rm_blue" }, inventory_item: { id: "iitem_blue" } },
+      { raw_materials: { id: "rm_red" }, inventory_item: { id: "iitem_red" } },
+    ])
+    expect(map).toEqual({ rm_blue: "iitem_blue", rm_red: "iitem_red" })
+  })
+
+  it("skips rows missing either id and keeps the first item per raw material", () => {
+    const map = buildItemIdByRawMaterialId([
+      { raw_materials: { id: "rm_1" }, inventory_item: null },
+      { raw_materials: null, inventory_item: { id: "iitem_x" } },
+      { raw_materials: { id: "rm_2" }, inventory_item: { id: "iitem_2a" } },
+      { raw_materials: { id: "rm_2" }, inventory_item: { id: "iitem_2b" } },
+    ])
+    expect(map).toEqual({ rm_2: "iitem_2a" })
+  })
+
+  it("tolerates a nullish input", () => {
+    expect(buildItemIdByRawMaterialId(null as any)).toEqual({})
+  })
+})
+
+describe("splitResolvedAndMissing (#817 S3)", () => {
+  it("returns the deduped colors that have no inventory_item yet, in order", () => {
+    const lines = [
+      { raw_material_id: "rm_blue", quantity: 1, price: 1 },
+      { raw_material_id: "rm_red", quantity: 2, price: 2 },
+      { raw_material_id: "rm_red", quantity: 3, price: 3 },
+      { raw_material_id: "rm_green", quantity: 4, price: 4 },
+    ]
+    const { missingRawMaterialIds } = splitResolvedAndMissing(lines, {
+      rm_blue: "iitem_blue",
+    })
+    expect(missingRawMaterialIds).toEqual(["rm_red", "rm_green"])
+  })
+
+  it("returns nothing missing when every color is already resolved", () => {
+    const { missingRawMaterialIds } = splitResolvedAndMissing(
+      [{ raw_material_id: "rm_blue", quantity: 1, price: 1 }],
+      { rm_blue: "iitem_blue" }
+    )
+    expect(missingRawMaterialIds).toEqual([])
+  })
+})
+
+describe("buildResolvedOrderLines (#817 S3)", () => {
+  it("fans out each color line to its resolved inventory_item", () => {
+    const lines = [
+      { raw_material_id: "rm_blue", quantity: 10, price: 5 },
+      { raw_material_id: "rm_red", quantity: 4, price: 8 },
+    ]
+    expect(
+      buildResolvedOrderLines(lines, {
+        rm_blue: "iitem_blue",
+        rm_red: "iitem_red",
+      })
+    ).toEqual([
+      { inventory_item_id: "iitem_blue", quantity: 10, price: 5 },
+      { inventory_item_id: "iitem_red", quantity: 4, price: 8 },
+    ])
+  })
+
+  it("throws if a color could not be resolved to an item", () => {
+    expect(() =>
+      buildResolvedOrderLines(
+        [{ raw_material_id: "rm_ghost", quantity: 1, price: 1 }],
+        {}
+      )
+    ).toThrow(/No inventory item resolved/i)
+  })
+})
+
+describe("group order totals (#817 S3 — price is per-unit)", () => {
+  const lines = [
+    { raw_material_id: "rm_blue", quantity: 10, price: 5 },
+    { raw_material_id: "rm_red", quantity: 4, price: 8 },
+  ]
+  it("sums price × quantity per line", () => {
+    expect(sumGroupOrderTotal(lines)).toBeCloseTo(82)
+  })
+  it("sums total quantity", () => {
+    expect(sumGroupOrderQuantity(lines)).toBe(14)
+  })
+  it("treats missing/NaN as 0 and empty as 0", () => {
+    expect(sumGroupOrderTotal([{ price: NaN as any, quantity: 3 }])).toBe(0)
+    expect(sumGroupOrderQuantity([])).toBe(0)
+  })
+})

--- a/apps/backend/src/modules/raw_material/lib/group-order-helpers.ts
+++ b/apps/backend/src/modules/raw_material/lib/group-order-helpers.ts
@@ -1,0 +1,102 @@
+import { MedusaError } from "@medusajs/framework/utils"
+
+/**
+ * Pure helpers for #817 S3 — ordering a raw_material_group in multiple colors.
+ *
+ * The container-bound bits (query.graph, item creation, linking) live in the
+ * workflow step; everything here is pure so it's unit-testable in isolation.
+ */
+
+/** One requested color line in a group order. */
+export type GroupOrderLineInput = {
+  raw_material_id: string
+  quantity: number
+  price: number
+}
+
+/** A resolved order line, once each color maps to an inventory_item. */
+export type ResolvedGroupOrderLine = {
+  inventory_item_id: string
+  quantity: number
+  price: number
+}
+
+/**
+ * Build an `raw_material_id → inventory_item_id` map from the rows returned by
+ * a query over the raw_material↔inventory_item link. Rows missing either id are
+ * skipped. First win per raw_material_id (a color should have exactly one item).
+ */
+export const buildItemIdByRawMaterialId = (
+  linkRows: Array<{
+    raw_materials?: { id?: string | null } | null
+    inventory_item?: { id?: string | null } | null
+  }>
+): Record<string, string> => {
+  const map: Record<string, string> = {}
+  for (const row of linkRows ?? []) {
+    const rmId = row?.raw_materials?.id
+    const itemId = row?.inventory_item?.id
+    if (rmId && itemId && !map[rmId]) {
+      map[rmId] = itemId
+    }
+  }
+  return map
+}
+
+/**
+ * Split requested lines into those whose color already has an inventory_item
+ * and those whose item must be created first. Preserves input order.
+ */
+export const splitResolvedAndMissing = (
+  requestedLines: GroupOrderLineInput[],
+  itemIdByRawMaterialId: Record<string, string>
+): { missingRawMaterialIds: string[] } => {
+  const missing: string[] = []
+  const seen = new Set<string>()
+  for (const line of requestedLines ?? []) {
+    const id = line.raw_material_id
+    if (!itemIdByRawMaterialId[id] && !seen.has(id)) {
+      seen.add(id)
+      missing.push(id)
+    }
+  }
+  return { missingRawMaterialIds: missing }
+}
+
+/**
+ * Fan out requested color lines into inventory-order lines, resolving each
+ * color to its inventory_item via the (now-complete) map. Throws if any color
+ * still lacks an item — the caller must have created all missing ones first.
+ */
+export const buildResolvedOrderLines = (
+  requestedLines: GroupOrderLineInput[],
+  itemIdByRawMaterialId: Record<string, string>
+): ResolvedGroupOrderLine[] =>
+  (requestedLines ?? []).map((line) => {
+    const inventory_item_id = itemIdByRawMaterialId[line.raw_material_id]
+    if (!inventory_item_id) {
+      throw new MedusaError(
+        MedusaError.Types.UNEXPECTED_STATE,
+        `No inventory item resolved for raw_material ${line.raw_material_id}`
+      )
+    }
+    return { inventory_item_id, quantity: line.quantity, price: line.price }
+  })
+
+/**
+ * Sum the group order lines into an order total (per-unit price × quantity),
+ * mirroring sumLineTotals for the inventory_orders module.
+ */
+export const sumGroupOrderTotal = (
+  requestedLines: Pick<GroupOrderLineInput, "price" | "quantity">[]
+): number =>
+  (requestedLines ?? []).reduce(
+    (sum, l) => sum + (Number(l.price) || 0) * (Number(l.quantity) || 0),
+    0
+  )
+
+/** Total quantity across all requested color lines. */
+export const sumGroupOrderQuantity = (
+  requestedLines: Pick<GroupOrderLineInput, "quantity">[]
+): number =>
+  (requestedLines ?? []).reduce((sum, l) => sum + (Number(l.quantity) || 0), 0)

--- a/apps/backend/src/workflows/raw-materials/create-raw-material.ts
+++ b/apps/backend/src/workflows/raw-materials/create-raw-material.ts
@@ -36,6 +36,7 @@ type CreateRawMaterialInput = {
     metadata?: Record<string, any>
     material_type?: string | object  // Can be string (name) or object
     material_type_id?: string        // Or existing ID
+    group_id?: string                // #817 — the raw_material_group this color belongs to
     media?: Record<string, any>
   }
 }

--- a/apps/backend/src/workflows/raw_material_groups/resolve-group-color-items.ts
+++ b/apps/backend/src/workflows/raw_material_groups/resolve-group-color-items.ts
@@ -1,0 +1,194 @@
+import {
+  ContainerRegistrationKeys,
+  Modules,
+} from "@medusajs/framework/utils"
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import type { Link } from "@medusajs/modules-sdk"
+import type { IInventoryService, LinkDefinition } from "@medusajs/types"
+import { RAW_MATERIAL_MODULE } from "../../modules/raw_material"
+import RawMaterialInventoryLink from "../../links/raw-material-data-inventory"
+import {
+  buildSkuPrefix,
+  formatSku,
+  nextSequenceNumber,
+} from "../../utils/generate-sku"
+import {
+  buildItemIdByRawMaterialId,
+  splitResolvedAndMissing,
+  buildResolvedOrderLines,
+  type GroupOrderLineInput,
+  type ResolvedGroupOrderLine,
+} from "../../modules/raw_material/lib/group-order-helpers"
+
+export type ResolveGroupColorItemsInput = {
+  lines: GroupOrderLineInput[]
+  stock_location_id?: string
+}
+
+export type ResolveGroupColorItemsResult = {
+  order_lines: ResolvedGroupOrderLine[]
+  created_inventory_item_ids: string[]
+}
+
+/**
+ * #817 S3 — for each requested color (raw_material) in a group order, resolve
+ * its inventory_item, AUTO-CREATING the item (with SKU + link + a zero-stock
+ * level) when the color doesn't have one yet. Returns fan-out order lines
+ * ({ inventory_item_id, quantity, price }) ready for the create-order workflow.
+ *
+ * The item creation loop is data-dependent (N unknown at definition time) so it
+ * runs imperatively inside this one step, reusing the SKU util + link shape from
+ * create-raw-material. Compensation deletes only the items this step created.
+ */
+export const resolveOrCreateColorInventoryItemsStep = createStep(
+  "resolve-or-create-color-inventory-items",
+  async (input: ResolveGroupColorItemsInput, { container }) => {
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+    const inventoryService: IInventoryService = container.resolve(Modules.INVENTORY)
+    const rawMaterialService: any = container.resolve(RAW_MATERIAL_MODULE)
+
+    const rawMaterialIds = Array.from(
+      new Set((input.lines ?? []).map((l) => l.raw_material_id).filter(Boolean))
+    )
+    if (!rawMaterialIds.length) {
+      throw new Error("At least one color (raw_material_id) is required.")
+    }
+
+    // 1) Which colors already have an inventory_item?
+    const { data: linkRows } = await query.graph({
+      entity: RawMaterialInventoryLink.entryPoint,
+      fields: ["raw_materials.id", "inventory_item.id"],
+      filters: { raw_materials_id: rawMaterialIds },
+    })
+    const itemIdByRawMaterialId = buildItemIdByRawMaterialId(linkRows as any)
+
+    const { missingRawMaterialIds } = splitResolvedAndMissing(
+      input.lines,
+      itemIdByRawMaterialId
+    )
+
+    const createdInventoryItemIds: string[] = []
+    const createdLinks: LinkDefinition[] = []
+
+    // 2) Create the missing per-color inventory items (+ link + SKU + level).
+    if (missingRawMaterialIds.length) {
+      const rawMaterials = await rawMaterialService.listRawMaterials(
+        { id: missingRawMaterialIds },
+        { relations: ["material_type"] }
+      )
+      const rmById = new Map<string, any>(
+        (rawMaterials ?? []).map((rm: any) => [rm.id, rm])
+      )
+      // Track SKUs assigned within this batch so two new items sharing a prefix
+      // don't collide on the same sequence number.
+      const localSkusByPrefix: Record<string, string[]> = {}
+
+      for (const rawMaterialId of missingRawMaterialIds) {
+        const rm = rmById.get(rawMaterialId)
+        if (!rm) {
+          throw new Error(`Raw material ${rawMaterialId} not found for group order.`)
+        }
+
+        // 2a) Create the inventory item.
+        const [item] = await inventoryService.createInventoryItems([
+          { title: rm.name } as any,
+        ])
+        createdInventoryItemIds.push(item.id)
+
+        // 2b) Link it to the raw material (same shape as create-raw-material).
+        const link: LinkDefinition = {
+          [Modules.INVENTORY]: { inventory_item_id: item.id },
+          [RAW_MATERIAL_MODULE]: { raw_materials_id: rawMaterialId },
+          data: { raw_materials_id: rawMaterialId, inventory_id: item.id },
+        }
+        await remoteLink.create(link)
+        createdLinks.push(link)
+
+        // 2c) Generate + assign a descriptive SKU (mirrors generateSkuStep).
+        const category = rm.material_type?.category || "Other"
+        const prefix = buildSkuPrefix(category, rm.name, rm.color)
+        const { data: existingItems } = await query.graph({
+          entity: "inventory_item",
+          fields: ["sku"],
+          filters: { sku: { $like: `${prefix}-%` } },
+        })
+        const existingSkus = [
+          ...existingItems.map((i: any) => i.sku).filter(Boolean),
+          ...(localSkusByPrefix[prefix] ?? []),
+        ] as string[]
+        const sku = formatSku(prefix, nextSequenceNumber(existingSkus, prefix))
+        localSkusByPrefix[prefix] = [...(localSkusByPrefix[prefix] ?? []), sku]
+        await inventoryService.updateInventoryItems({ id: item.id, sku } as any)
+
+        // 2d) Seed a zero-stock level at the receiving location (best-effort).
+        if (input.stock_location_id) {
+          try {
+            await inventoryService.createInventoryLevels([
+              {
+                inventory_item_id: item.id,
+                location_id: input.stock_location_id,
+                stocked_quantity: 0,
+                incoming_quantity: 0,
+              } as any,
+            ])
+          } catch {
+            // non-fatal — the order can still be placed without a seeded level.
+          }
+        }
+
+        itemIdByRawMaterialId[rawMaterialId] = item.id
+      }
+    }
+
+    // 3) Fan out into resolved order lines (throws if any color still unresolved).
+    const order_lines = buildResolvedOrderLines(input.lines, itemIdByRawMaterialId)
+
+    return new StepResponse(
+      { order_lines, created_inventory_item_ids: createdInventoryItemIds } as ResolveGroupColorItemsResult,
+      { createdInventoryItemIds, createdLinks }
+    )
+  },
+  // Compensation — only undo items THIS step created.
+  async (compensationData, { container }) => {
+    if (!compensationData) return
+    const { createdInventoryItemIds, createdLinks } = compensationData as {
+      createdInventoryItemIds: string[]
+      createdLinks: LinkDefinition[]
+    }
+    const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+    const inventoryService: IInventoryService = container.resolve(Modules.INVENTORY)
+    try {
+      if (createdLinks?.length) {
+        await remoteLink.dismiss(createdLinks as any)
+      }
+    } catch {
+      /* best-effort */
+    }
+    try {
+      if (createdInventoryItemIds?.length) {
+        await inventoryService.deleteInventoryItems(createdInventoryItemIds)
+      }
+    } catch {
+      /* best-effort */
+    }
+  }
+)
+
+/**
+ * Standalone workflow so the route can resolve/create the per-color items first
+ * (with its own compensation), then hand the resulting order_lines to the
+ * existing createInventoryOrderWorkflow (which denormalizes color per S2).
+ */
+export const resolveGroupColorInventoryItemsWorkflow = createWorkflow(
+  "resolve-group-color-inventory-items",
+  (input: ResolveGroupColorItemsInput) => {
+    const result = resolveOrCreateColorInventoryItemsStep(input)
+    return new WorkflowResponse(result)
+  }
+)


### PR DESCRIPTION
## Summary

**S3 of #817** — the group-ordering UX. Order a `raw_material_group` in **multiple colors at once**: one inventory-order line is fanned out per selected color, each bound to that color's `inventory_item`, **auto-creating the per-color `inventory_item` on first order** if it doesn't exist yet.

Builds on S1 (the group model, #821) and S2 (color denormalized onto the order line, #822). Because the fan-out delegates to the existing `createInventoryOrderWorkflow`, **S2's color denormalization rides along** — each fanned-out line comes back tagged with its `color` / `material_name` / `raw_material_id`.

## Backend
- **Admin routes** `/admin/raw-material-groups`:
  - `GET` list · `POST` create
  - `GET :id` — group + its per-color raw_materials, each with its linked `inventory_item` (id/sku)
  - `POST :id/colors` — add a color (creates a per-color raw_material with `group_id`, its inventory_item, link, and SKU via `createRawMaterialWorkflow`; specs default from the group)
  - `POST :id/orders` — **fan-out order**
- **`resolve-group-color-items` workflow** — resolves each color's inventory_item, auto-creating it (item + raw_material link + SKU via the shared util + a zero-stock level) when missing. Compensation deletes **only** the items it created. Then the route hands the resolved lines to `createInventoryOrderWorkflow`.
- **Pure, unit-tested helpers** — `buildItemIdByRawMaterialId`, `splitResolvedAndMissing`, `buildResolvedOrderLines`, totals.
- `createRawMaterialWorkflow` input now accepts `group_id`; middlewares wired for the 5 new route/method pairs.

## Admin UI
- New **"Material Groups"** section: list + create groups; group detail with a per-color table (color badge, SKU, whether stock exists), an **Add color** modal, and an **Order in colors** modal (select colors → per-color qty/price → places the fan-out order, surfacing how many items were auto-created).
- Medusa-native UI, Skeleton loaders, `toast` from `@medusajs/ui`.

## Verification
- ✅ 10/10 unit (helpers)
- ✅ **5/5 integration** — create group; add colors (each gets an inventory_item + SKU); fan-out order **with S2 color on each line**; **auto-create path** (a group color with no item → 1 item created); empty-list → 400
- ✅ `medusa build` backend **and** frontend green

Behavioural UI verification is Playwright-gated (not run here); the frontend build compiles it.

## Next
- **S4** — optional: let a design pin a group and resolve color at production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)