### PR TITLE
feat(designs): S4 — pin a raw_material_group to a design (#817)

### DIFF
--- a/apps/backend/integration-tests/http/design-material-groups-api.spec.ts
+++ b/apps/backend/integration-tests/http/design-material-groups-api.spec.ts
@@ -1,0 +1,125 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { RAW_MATERIAL_MODULE } from "../../src/modules/raw_material"
+
+jest.setTimeout(60000)
+
+/**
+ * #817 S4 — a design can pin one or more raw_material_groups (its material
+ * palette at the group grain), optionally resolving a specific color, and unpin.
+ */
+setupSharedTestSuite(() => {
+  let headers: any
+  let designId: string
+  let groupId: string
+  let blueColorId: string
+  const { api, getContainer } = getSharedTestEnv()
+
+  beforeEach(async () => {
+    const container = getContainer()
+    await createAdminUser(container)
+    headers = await getAuthHeaders(api)
+
+    const design = await api.post(
+      "/admin/designs",
+      {
+        name: "Group-Pin Tee",
+        description: "S4 test",
+        design_type: "Original",
+        status: "In_Development",
+        priority: "Medium",
+      },
+      headers
+    )
+    designId = design.data.design.id
+
+    // A group + one color (created via the module directly — no route dependency).
+    const service: any = container.resolve(RAW_MATERIAL_MODULE)
+    const group = await service.createRawMaterialGroups({
+      name: "Jersey Knit",
+      composition: "95% Cotton 5% Elastane",
+      unit_of_measure: "Meter",
+    })
+    groupId = group.id
+    const blue = await service.createRawMaterials({
+      name: "Jersey Knit — Blue",
+      description: "blue",
+      composition: "95% Cotton 5% Elastane",
+      color: "Blue",
+      group_id: group.id,
+    })
+    blueColorId = blue.id
+  })
+
+  it("pins a group to a design and lists it with its colors", async () => {
+    const pin = await api.post(
+      `/admin/designs/${designId}/material-groups`,
+      { raw_material_group_id: groupId, note: "primary body fabric" },
+      headers
+    )
+    expect(pin.status).toBe(201)
+
+    const list = await api.get(
+      `/admin/designs/${designId}/material-groups`,
+      { headers: headers.headers }
+    )
+    expect(list.status).toBe(200)
+    expect(list.data.count).toBe(1)
+    const row = list.data.material_groups[0]
+    expect(row.raw_material_group.id).toBe(groupId)
+    expect(row.note).toBe("primary body fabric")
+    expect(row.resolved_raw_material_id ?? null).toBeNull()
+    const colors = row.raw_material_group.raw_materials.map((c: any) => c.color)
+    expect(colors).toContain("Blue")
+  })
+
+  it("resolves a color on the pin (production-time)", async () => {
+    await api.post(
+      `/admin/designs/${designId}/material-groups`,
+      { raw_material_group_id: groupId },
+      headers
+    )
+    const upd = await api.post(
+      `/admin/designs/${designId}/material-groups/${groupId}`,
+      { resolved_raw_material_id: blueColorId },
+      headers
+    )
+    expect(upd.status).toBe(200)
+
+    const list = await api.get(
+      `/admin/designs/${designId}/material-groups`,
+      { headers: headers.headers }
+    )
+    expect(list.data.material_groups[0].resolved_raw_material_id).toBe(blueColorId)
+  })
+
+  it("unpins a group from a design", async () => {
+    await api.post(
+      `/admin/designs/${designId}/material-groups`,
+      { raw_material_group_id: groupId },
+      headers
+    )
+    const del = await api.delete(
+      `/admin/designs/${designId}/material-groups/${groupId}`,
+      { headers: headers.headers }
+    )
+    expect(del.status).toBe(200)
+
+    const list = await api.get(
+      `/admin/designs/${designId}/material-groups`,
+      { headers: headers.headers }
+    )
+    expect(list.data.count).toBe(0)
+  })
+
+  it("404s pinning a group that does not exist", async () => {
+    const res = await api
+      .post(
+        `/admin/designs/${designId}/material-groups`,
+        { raw_material_group_id: "rmgrp_missing" },
+        headers
+      )
+      .catch((e: any) => e.response)
+    expect(res.status).toBe(404)
+  })
+})

--- a/apps/backend/src/api/admin/designs/[id]/material-groups/[groupId]/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/material-groups/[groupId]/route.ts
@@ -1,0 +1,49 @@
+/**
+ * API: /admin/designs/:id/material-groups/:groupId  (#817 S4)
+ *
+ * POST   — update the pin (e.g. resolve the color at production time).
+ * DELETE — unpin the group from the design.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import type { Link } from "@medusajs/modules-sdk"
+import { DESIGN_MODULE } from "../../../../../../modules/designs"
+import { RAW_MATERIAL_MODULE } from "../../../../../../modules/raw_material"
+import { UpdateDesignGroup } from "../validators"
+
+export const POST = async (
+  req: MedusaRequest<UpdateDesignGroup>,
+  res: MedusaResponse
+) => {
+  const { id: designId, groupId } = req.params
+  const body = req.validatedBody
+  const remoteLink = req.scope.resolve(ContainerRegistrationKeys.LINK) as Link
+
+  // Re-creating the link with the same keys updates its pivot data in place.
+  const data: Record<string, unknown> = {}
+  if (body.resolved_raw_material_id !== undefined) {
+    data.resolved_raw_material_id = body.resolved_raw_material_id
+  }
+  if (body.note !== undefined) data.note = body.note
+  if (body.metadata !== undefined) data.metadata = body.metadata
+
+  await remoteLink.create({
+    [DESIGN_MODULE]: { design_id: designId },
+    [RAW_MATERIAL_MODULE]: { raw_material_group_id: groupId },
+    data,
+  })
+
+  res.status(200).json({ design_id: designId, raw_material_group_id: groupId, updated: true })
+}
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id: designId, groupId } = req.params
+  const remoteLink = req.scope.resolve(ContainerRegistrationKeys.LINK) as Link
+
+  await remoteLink.dismiss({
+    [DESIGN_MODULE]: { design_id: designId },
+    [RAW_MATERIAL_MODULE]: { raw_material_group_id: groupId },
+  })
+
+  res.status(200).json({ design_id: designId, raw_material_group_id: groupId, unpinned: true })
+}

--- a/apps/backend/src/api/admin/designs/[id]/material-groups/route.ts
+++ b/apps/backend/src/api/admin/designs/[id]/material-groups/route.ts
@@ -1,0 +1,77 @@
+/**
+ * API: /admin/designs/:id/material-groups  (#817 S4)
+ *
+ * GET  — list the raw_material_groups pinned to a design (with the resolved
+ *        color, if any, and the group's colors).
+ * POST — pin a group to the design.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+} from "@medusajs/framework/utils"
+import type { Link } from "@medusajs/modules-sdk"
+import { DESIGN_MODULE } from "../../../../../modules/designs"
+import { RAW_MATERIAL_MODULE } from "../../../../../modules/raw_material"
+import DesignRawMaterialGroupLink from "../../../../../links/design-raw-material-group"
+import { PinDesignGroup } from "./validators"
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const designId = req.params.id
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data } = await query.graph({
+    entity: DesignRawMaterialGroupLink.entryPoint,
+    fields: [
+      "resolved_raw_material_id",
+      "note",
+      "metadata",
+      "raw_material_group.id",
+      "raw_material_group.name",
+      "raw_material_group.composition",
+      "raw_material_group.status",
+      "raw_material_group.raw_materials.id",
+      "raw_material_group.raw_materials.name",
+      "raw_material_group.raw_materials.color",
+    ],
+    filters: { design_id: designId },
+  })
+
+  res.status(200).json({
+    material_groups: data ?? [],
+    count: (data ?? []).length,
+  })
+}
+
+export const POST = async (
+  req: MedusaRequest<PinDesignGroup>,
+  res: MedusaResponse
+) => {
+  const designId = req.params.id
+  const body = req.validatedBody
+  const remoteLink = req.scope.resolve(ContainerRegistrationKeys.LINK) as Link
+
+  // The group must exist.
+  const service: any = req.scope.resolve(RAW_MATERIAL_MODULE)
+  const group = await service
+    .retrieveRawMaterialGroup(body.raw_material_group_id)
+    .catch(() => null)
+  if (!group) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Raw material group with id "${body.raw_material_group_id}" not found`
+    )
+  }
+
+  await remoteLink.create({
+    [DESIGN_MODULE]: { design_id: designId },
+    [RAW_MATERIAL_MODULE]: { raw_material_group_id: body.raw_material_group_id },
+    data: {
+      resolved_raw_material_id: body.resolved_raw_material_id ?? null,
+      note: body.note ?? null,
+      metadata: body.metadata ?? null,
+    },
+  })
+
+  res.status(201).json({ design_id: designId, raw_material_group: group })
+}

--- a/apps/backend/src/api/admin/designs/[id]/material-groups/validators.ts
+++ b/apps/backend/src/api/admin/designs/[id]/material-groups/validators.ts
@@ -1,0 +1,19 @@
+import { z } from "@medusajs/framework/zod"
+
+// #817 S4 — pin / update a raw_material_group on a design.
+
+export const pinDesignGroupSchema = z.object({
+  raw_material_group_id: z.string().min(1, "raw_material_group_id is required"),
+  resolved_raw_material_id: z.string().optional(),
+  note: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+})
+export type PinDesignGroup = z.infer<typeof pinDesignGroupSchema>
+
+export const updateDesignGroupSchema = z.object({
+  // null clears a previously-resolved color.
+  resolved_raw_material_id: z.string().nullable().optional(),
+  note: z.string().nullable().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+})
+export type UpdateDesignGroup = z.infer<typeof updateDesignGroupSchema>

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -101,6 +101,7 @@ import { updatePartnerMeSchema } from "./partners/me/validators";
 import { onboardingProfileUpdateSchema } from "./partners/onboarding-profile/validators";
 import { AdminGetPartnersParamsSchema } from "./admin/persons/partner/validators";
 import { createInventoryOrdersSchema, listInventoryOrdersQuerySchema, ReadSingleInventoryOrderQuerySchema, updateInventoryOrdersSchema, updateInventoryOrderLinesSchema } from "./admin/inventory-orders/validators";
+import { pinDesignGroupSchema, updateDesignGroupSchema } from "./admin/designs/[id]/material-groups/validators";
 // Import already defined above
 import { SendBlogSubscriptionSchema } from "./admin/websites/[id]/pages/[pageId]/subs/route";
 import { subscriptionSchema } from "./web/website/[domain]/validators";
@@ -3105,6 +3106,18 @@ export default defineMiddlewares({
       matcher: "/admin/designs/:id/inventory/delink",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(AdminDeleteDesignInventoryReq))],
+    },
+
+    // Raw-material groups pinned to a design (#817 S4)
+    {
+      matcher: "/admin/designs/:id/material-groups",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(pinDesignGroupSchema))],
+    },
+    {
+      matcher: "/admin/designs/:id/material-groups/:groupId",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(updateDesignGroupSchema))],
     },
 
     // Consumption logs on Designs

--- a/apps/backend/src/links/design-raw-material-group.ts
+++ b/apps/backend/src/links/design-raw-material-group.ts
@@ -1,0 +1,24 @@
+import { defineLink } from "@medusajs/framework/utils"
+import DesignModule from "../modules/designs"
+import RawMaterialModule from "../modules/raw_material"
+
+/**
+ * #817 S4 — let a design pin one or more raw_material_groups (its material
+ * palette at the group grain). The color stays unresolved until production,
+ * where `resolved_raw_material_id` records which specific color variant was
+ * chosen (consumption still targets a concrete inventory_item = one color).
+ */
+export default defineLink(
+  { linkable: DesignModule.linkable.design, isList: true },
+  { linkable: RawMaterialModule.linkable.rawMaterialGroup, isList: true },
+  {
+    database: {
+      extraColumns: {
+        // The color chosen at production time (a raw_material in the group).
+        resolved_raw_material_id: { type: "text", nullable: true },
+        note: { type: "text", nullable: true },
+        metadata: { type: "json", nullable: true },
+      },
+    },
+  }
+)


### PR DESCRIPTION
## Summary

**S4 of #817** (the optional final slice) — a design can **pin one or more `raw_material_group`s** as its material palette at the group grain, with the specific **color resolved later at production time**. Consumption still targets a concrete `inventory_item` (= one color), so nothing about the existing consumption/production flow changes; this just adds the pin.

Depends on S1 (the group model, already on main).

## Changes
- **New link** `design ↔ raw_material_group` (isList both) with pivot columns `resolved_raw_material_id` (the color chosen at production), `note`, `metadata`.
- **Admin routes** `/admin/designs/:id/material-groups`:
  - `GET` — list pinned groups (each with the group's colors + the resolved color, if any)
  - `POST` — pin a group (404s if the group doesn't exist)
  - `POST :groupId` — update the pin (e.g. resolve the color at production)
  - `DELETE :groupId` — unpin
- Validators + middlewares wired.

## Verification
- ✅ `medusa build` backend **and** frontend green
- ✅ Link table synced (`design_design_raw_materials_raw_material_group`) via `db:migrate` (prod picks it up through the existing `--execute-safe-links` predeploy)
- ✅ **4/4 integration** — pin + list (with colors), resolve a color, unpin, 404 on unknown group

## Wraps up #817
S1 (#821) + S2 (#822) merged; S3 (#823) + this S4 open. Together they deliver: group parent → color-aware order lines → group-ordering fan-out with auto-created per-color items → design pinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)