### PR TITLE
fix(admin): raw-material create modal closes to the item, not an empty edit drawer

### DIFF
--- a/apps/backend/src/admin/routes/inventory/[id]/raw-materials/create/page.tsx
+++ b/apps/backend/src/admin/routes/inventory/[id]/raw-materials/create/page.tsx
@@ -1,9 +1,15 @@
+import { useParams } from "react-router-dom"
 import { RouteFocusModal } from "../../../../../components/modal/route-focus-modal"
 import { RawMaterialForm } from "../../../../../components/forms/raw-material/raw-material-form"
 
 export default function CreateRawMaterialPage() {
+  const { id } = useParams()
+  // Close (X / Esc) must return to the inventory item, NOT the default ".."
+  // — this route is nested under the raw-materials EDIT drawer, so ".." would
+  // land on that drawer rendered with an empty state (no raw material exists
+  // for a brand-new item yet). Matches the form's own success/cancel target.
   return (
-    <RouteFocusModal>
+    <RouteFocusModal prev={`/inventory/${id}`}>
       <RawMaterialForm />
     </RouteFocusModal>
   )


### PR DESCRIPTION
## Problem
Opening the raw-material **create** modal (`/inventory/:id/raw-materials/create`) and then **closing** it (X / Esc) dumped the user onto the raw-materials **edit drawer** rendered with an empty state.

## Cause
The create route is nested under the raw-materials edit route (`raw-materials/page.tsx` → `<Outlet/>`). `RouteFocusModal`'s default `prev=".."` therefore resolves to `.../raw-materials` — the edit drawer — which has no raw material to show for a brand-new item, so it renders empty.

## Fix
Pass `prev={`/inventory/${id}`}` to the create modal so closing returns to the inventory item detail — the same target the form already uses on success and cancel.

## Verification
Local Playwright pass: open the create modal → close (X → "Continue" on the unsaved-changes prompt) → lands on `/inventory/:id`, **not** `/inventory/:id/raw-materials`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)