### PR TITLE
feat(admin): #817 material-groups UI polish — DataTable, section layout, add-color

### DIFF
--- a/apps/backend/integration-tests/http/raw-material-group-ordering-api.spec.ts
+++ b/apps/backend/integration-tests/http/raw-material-group-ordering-api.spec.ts
@@ -178,4 +178,118 @@ setupSharedTestSuite(() => {
       .catch((e: any) => e.response)
     expect(res.status).toBe(400)
   })
+
+  it("adds a color with the full material-spec envelope (/colors/full)", async () => {
+    const { data: { raw_material_group: group } } = await api.post(
+      "/admin/raw-material-groups",
+      { name: "Denim Twill", composition: "100% Cotton", unit_of_measure: "Meter" },
+      headers
+    )
+
+    const res = await api.post(
+      `/admin/raw-material-groups/${group.id}/colors/full`,
+      {
+        rawMaterialData: {
+          name: "Denim Twill — Indigo",
+          color: "Indigo",
+          composition: "100% Cotton",
+          unit_of_measure: "Meter",
+          unit_cost: 12,
+          cost_currency: "inr",
+        },
+      },
+      headers
+    )
+    expect(res.status).toBe(201)
+    const colors = res.data.raw_material_group.raw_materials
+    expect(colors).toHaveLength(1)
+    expect(colors[0].color).toBe("Indigo")
+    // the endpoint provisions the inventory item for the new color
+    expect(colors[0].inventory_item?.id).toBeTruthy()
+    expect(typeof colors[0].inventory_item?.sku).toBe("string")
+  })
+
+  it("rejects /colors/full without a color", async () => {
+    const { data: { raw_material_group: group } } = await api.post(
+      "/admin/raw-material-groups",
+      { name: "No Color Full" },
+      headers
+    )
+    const res = await api
+      .post(
+        `/admin/raw-material-groups/${group.id}/colors/full`,
+        { rawMaterialData: { name: "Missing color" } },
+        headers
+      )
+      .catch((e: any) => e.response)
+    expect(res.status).toBe(400)
+  })
+
+  it("links existing ungrouped raw_materials as colors (/colors/link)", async () => {
+    const service: any = getContainer().resolve(RAW_MATERIAL_MODULE)
+    const { data: { raw_material_group: group } } = await api.post(
+      "/admin/raw-material-groups",
+      { name: "Poplin Link", composition: "100% Cotton" },
+      headers
+    )
+    // an ungrouped raw material created directly on the module
+    const loose = await service.createRawMaterials({
+      name: "Loose Poplin — Teal",
+      description: "ungrouped",
+      composition: "100% Cotton",
+      color: "Teal",
+    })
+
+    const res = await api.post(
+      `/admin/raw-material-groups/${group.id}/colors/link`,
+      { raw_material_ids: [loose.id] },
+      headers
+    )
+    expect(res.status).toBe(200)
+    const colors = res.data.raw_material_group.raw_materials
+    expect(colors.map((c: any) => c.id)).toContain(loose.id)
+  })
+
+  it("returns the group's color order-lines grouped-ready (GET /orders)", async () => {
+    const { data: { raw_material_group: group } } = await api.post(
+      "/admin/raw-material-groups",
+      { name: "Canvas Orders", composition: "100% Cotton", unit_of_measure: "Meter" },
+      headers
+    )
+    await api.post(
+      `/admin/raw-material-groups/${group.id}/colors`,
+      { name: "Canvas — Natural", color: "Natural" },
+      headers
+    )
+    const { data: detail } = await api.get(
+      `/admin/raw-material-groups/${group.id}`,
+      { headers: headers.headers }
+    )
+    const colors = detail.raw_material_group.raw_materials
+
+    // empty before any order
+    const before = await api.get(
+      `/admin/raw-material-groups/${group.id}/orders`,
+      { headers: headers.headers }
+    )
+    expect(before.status).toBe(200)
+    expect(before.data.order_lines).toHaveLength(0)
+
+    await api.post(
+      `/admin/raw-material-groups/${group.id}/orders`,
+      orderFields(colors.map((c: any) => ({ raw_material_id: c.id, quantity: 15, price: 4 }))),
+      headers
+    )
+
+    const after = await api.get(
+      `/admin/raw-material-groups/${group.id}/orders`,
+      { headers: headers.headers }
+    )
+    expect(after.status).toBe(200)
+    expect(after.data.order_lines.length).toBeGreaterThanOrEqual(1)
+    const line = after.data.order_lines[0]
+    expect(line.color).toBe("Natural")
+    expect(line.inventory_orders?.id).toBeTruthy()
+    expect(line.inventory_orders?.status).toBe("Pending")
+  })
 })

--- a/apps/backend/src/admin/components/forms/raw-material/raw-material-form.tsx
+++ b/apps/backend/src/admin/components/forms/raw-material/raw-material-form.tsx
@@ -7,6 +7,7 @@ import { useParams, useNavigate } from "react-router-dom"
 import { RouteFocusModal } from "../../modal/route-focus-modal"
 import { KeyboundForm } from "../../utilitites/key-bound-form"
 import { useCreateRawMaterial, useRawMaterialCategories } from "../../../hooks/api/raw-materials"
+import { useCreateGroupColorFull } from "../../../hooks/api/raw-material-groups"
 import { useRouteModal } from "../../modal/use-route-modal"
 import { useState, useEffect } from "react"
 import { CategorySearch } from "../../common/category-search"
@@ -22,8 +23,23 @@ enum Tab {
 
 type TabState = Record<Tab, ProgressStatus>
 
-export const RawMaterialForm = () => {
-  const { id: inventoryId } = useParams();
+type RawMaterialFormProps = {
+  // "inventory" (default): create a raw material on the current inventory item.
+  // "group": create a new per-color raw material under a raw-material group,
+  // reusing the exact same spec form (the group endpoint provisions the
+  // inventory item). `color` is required in group mode.
+  mode?: "inventory" | "group"
+  groupId?: string
+}
+
+export const RawMaterialForm = ({
+  mode = "inventory",
+  groupId,
+}: RawMaterialFormProps = {}) => {
+  const { id: routeId } = useParams();
+  const inventoryId = routeId;
+  const isGroup = mode === "group";
+  const backTo = isGroup ? `/raw-material-groups/${groupId}` : `/inventory/${inventoryId}`;
   const navigate = useNavigate();
   const { handleSuccess } = useRouteModal();
   
@@ -82,6 +98,7 @@ export const RawMaterialForm = () => {
   });
 
   const createMutation = useCreateRawMaterial(inventoryId!);
+  const createGroupColorMutation = useCreateGroupColorFull(groupId ?? "");
 
   const onNext = async (currentTab: Tab) => {
     // For General tab, only validate fields in General tab
@@ -174,7 +191,26 @@ export const RawMaterialForm = () => {
     // Cleanup helper fields
     delete (submissionData as any).material_type_properties;
     delete (submissionData as any).additional_properties_json;
-    
+
+    // Group mode: a color is what makes this a distinct variant of the group.
+    if (isGroup && !(submissionData as any).color?.trim?.()) {
+      toast.error("Color is required when adding a color to a group");
+      return;
+    }
+
+    if (isGroup) {
+      await createGroupColorMutation.mutateAsync(submissionData as any, {
+        onSuccess: () => {
+          toast.success("Color added to group");
+          handleSuccess(backTo);
+        },
+        onError: (error: any) => {
+          toast.error(error?.message || "Failed to add color");
+        },
+      });
+      return;
+    }
+
     await createMutation.mutateAsync(
       {
         rawMaterialData: submissionData as any // Cast to any to bypass type checking
@@ -182,7 +218,7 @@ export const RawMaterialForm = () => {
       {
         onSuccess: () => {
           toast.success("Raw material created successfully");
-          handleSuccess(`/inventory/${inventoryId}`);
+          handleSuccess(backTo);
         },
         onError: (error) => {
           toast.error(error.message);
@@ -348,9 +384,27 @@ export const RawMaterialForm = () => {
                         </Form.Item>
                       )}
                     />
-                    
+
+                    <Form.Field
+                      control={form.control}
+                      name="color"
+                      render={({ field }) => (
+                        <Form.Item>
+                          <Form.Label optional>{"Color"}</Form.Label>
+                          <Form.Control>
+                            <Input
+                              placeholder="e.g. Blue"
+                              {...field}
+                              value={field.value ?? ""}
+                            />
+                          </Form.Control>
+                          <Form.ErrorMessage />
+                        </Form.Item>
+                      )}
+                    />
+
                   </div>
-                  
+
                 </div>
                 <div className="mt-4">
                   <h2 className="text-base-semi">Media</h2>
@@ -454,20 +508,6 @@ export const RawMaterialForm = () => {
                               {...field}
                               onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : undefined)}
                             />
-                          </Form.Control>
-                          <Form.ErrorMessage />
-                        </Form.Item>
-                      )}
-                    />
-
-                    <Form.Field
-                      control={form.control}
-                      name="color"
-                      render={({ field }) => (
-                        <Form.Item>
-                          <Form.Label>{"Color"}</Form.Label>
-                          <Form.Control>
-                            <Input autoComplete="off" {...field} />
                           </Form.Control>
                           <Form.ErrorMessage />
                         </Form.Item>
@@ -711,7 +751,7 @@ export const RawMaterialForm = () => {
                 type="button"
                 variant="secondary"
                 size="small"
-                onClick={() => navigate(`/inventory/${inventoryId}`)}
+                onClick={() => navigate(backTo)}
               >
                 Cancel
               </Button>

--- a/apps/backend/src/admin/components/raw-material-groups/group-sections.tsx
+++ b/apps/backend/src/admin/components/raw-material-groups/group-sections.tsx
@@ -3,6 +3,9 @@ import {
   Button,
   Checkbox,
   Container,
+  DataTable,
+  DataTablePaginationState,
+  DataTableRowSelectionState,
   Heading,
   Input,
   Label,
@@ -10,7 +13,9 @@ import {
   Table,
   Text,
   FocusModal,
+  createDataTableColumnHelper,
   toast,
+  useDataTable,
 } from "@medusajs/ui"
 import { PencilSquare, Plus, Component as ComponentIcon, Link as LinkIcon } from "@medusajs/icons"
 import { useMemo, useState } from "react"
@@ -27,6 +32,7 @@ import {
 } from "../../hooks/api/raw-material-groups"
 import { useInventoryWithRawMaterials } from "../../hooks/api/raw-materials"
 import { useStockLocations } from "../../hooks/api/stock_location"
+import { useDebouncedSearch } from "../../hooks/use-debounce"
 
 // ---------------------------------------------------------------------------
 // General section
@@ -133,6 +139,31 @@ const QuickAddColorModal = ({
 // Add-color: link an existing raw material
 // ---------------------------------------------------------------------------
 
+type LinkCandidate = {
+  rawMaterialId: string
+  name: string
+  color: string
+  sku: string
+}
+
+const linkColumnHelper = createDataTableColumnHelper<LinkCandidate>()
+
+const linkColumns = [
+  linkColumnHelper.select(),
+  linkColumnHelper.accessor("name", { header: "Name" }),
+  linkColumnHelper.accessor("color", {
+    header: "Color",
+    cell: ({ getValue }) =>
+      getValue() ? <Badge size="small" color="grey">{getValue()}</Badge> : "—",
+  }),
+  linkColumnHelper.accessor("sku", {
+    header: "SKU",
+    cell: ({ getValue }) => (
+      <span className="text-ui-fg-subtle">{getValue() || "—"}</span>
+    ),
+  }),
+]
+
 const LinkExistingColorsModal = ({
   groupId,
   open,
@@ -142,51 +173,76 @@ const LinkExistingColorsModal = ({
   open: boolean
   onOpenChange: (v: boolean) => void
 }) => {
-  const [search, setSearch] = useState("")
-  const [selected, setSelected] = useState<Record<string, string>>({})
+  const { searchValue, onSearchValueChange, query } = useDebouncedSearch()
+  const [rowSelection, setRowSelection] = useState<DataTableRowSelectionState>({})
+  const [pagination, setPagination] = useState<DataTablePaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  })
   const { mutateAsync, isPending } = useLinkGroupColors(groupId)
+  // Search is done server-side (the endpoint's full-text `q` across inventory +
+  // raw-material fields), not with a local filter.
   const { inventory_items = [], isLoading } = useInventoryWithRawMaterials({
+    q: query,
     fields: "+raw_materials.*",
     limit: 200,
   })
 
   // Only ungrouped raw materials can be linked — a color belongs to one group.
-  const candidates = useMemo(() => {
-    const rows = inventory_items
-      .filter((it: any) => it.raw_materials && !it.raw_materials.group_id)
-      .map((it: any) => ({
-        rawMaterialId: it.raw_materials.id as string,
-        name: it.raw_materials.name as string,
-        color: (it.raw_materials.color as string) || "",
-        sku: it.inventory_item?.sku || it.sku || "",
-      }))
-    if (!search) return rows
-    const q = search.toLowerCase()
-    return rows.filter(
-      (r) => `${r.name} ${r.color} ${r.sku}`.toLowerCase().includes(q)
-    )
-  }, [inventory_items, search])
+  // This is a business rule, not search, so it stays client-side.
+  const candidates: LinkCandidate[] = useMemo(
+    () =>
+      inventory_items
+        .filter((it: any) => it.raw_materials && !it.raw_materials.group_id)
+        .map((it: any) => ({
+          rawMaterialId: it.raw_materials.id as string,
+          name: it.raw_materials.name as string,
+          color: (it.raw_materials.color as string) || "",
+          sku: it.inventory_item?.sku || it.sku || "",
+        })),
+    [inventory_items]
+  )
 
-  const toggle = (id: string, name: string) =>
-    setSelected((s) => {
-      if (s[id]) {
-        const { [id]: _, ...rest } = s
-        return rest
-      }
-      return { ...s, [id]: name }
-    })
+  const paginated = useMemo(() => {
+    const start = pagination.pageIndex * pagination.pageSize
+    return candidates.slice(start, start + pagination.pageSize)
+  }, [candidates, pagination])
+
+  const table = useDataTable({
+    columns: linkColumns,
+    data: paginated,
+    getRowId: (row) => row.rawMaterialId,
+    rowCount: candidates.length,
+    isLoading,
+    rowSelection: {
+      state: rowSelection,
+      onRowSelectionChange: setRowSelection,
+    },
+    pagination: {
+      state: pagination,
+      onPaginationChange: setPagination,
+    },
+    search: {
+      state: searchValue,
+      onSearchChange: onSearchValueChange,
+    },
+  })
+
+  const selectedIds = useMemo(
+    () => Object.keys(rowSelection).filter((id) => rowSelection[id]),
+    [rowSelection]
+  )
 
   const submit = async () => {
-    const ids = Object.keys(selected)
-    if (!ids.length) {
+    if (!selectedIds.length) {
       toast.error("Select at least one raw material")
       return
     }
     try {
-      await mutateAsync(ids)
-      toast.success(`Linked ${ids.length} color(s)`)
+      await mutateAsync(selectedIds)
+      toast.success(`Linked ${selectedIds.length} color(s)`)
       onOpenChange(false)
-      setSelected({})
+      setRowSelection({})
     } catch (e: any) {
       toast.error(e?.message || "Failed to link colors")
     }
@@ -194,77 +250,30 @@ const LinkExistingColorsModal = ({
 
   return (
     <FocusModal open={open} onOpenChange={onOpenChange}>
-      <FocusModal.Content>
+      <FocusModal.Content className="flex flex-col">
         <FocusModal.Header>
           <Button size="small" onClick={submit} isLoading={isPending}>
-            Link {Object.keys(selected).length || ""}
+            Link {selectedIds.length || ""}
           </Button>
         </FocusModal.Header>
-        <FocusModal.Body className="flex flex-col items-center py-10">
-          <div className="flex w-full max-w-2xl flex-col gap-y-4">
-            <div>
-              <FocusModal.Title asChild>
-                <Heading>Link existing raw materials</Heading>
-              </FocusModal.Title>
-              <FocusModal.Description asChild>
-                <Text size="small" className="text-ui-fg-subtle">
-                  Attach materials that already exist (with their stock item) as colors of this group.
-                </Text>
-              </FocusModal.Description>
-            </div>
-            <Input
-              placeholder="Search by name, color or SKU"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-            />
-            <div className="max-h-[420px] overflow-y-auto">
-              <Table>
-                <Table.Header>
-                  <Table.Row>
-                    <Table.HeaderCell> </Table.HeaderCell>
-                    <Table.HeaderCell>Name</Table.HeaderCell>
-                    <Table.HeaderCell>Color</Table.HeaderCell>
-                    <Table.HeaderCell>SKU</Table.HeaderCell>
-                  </Table.Row>
-                </Table.Header>
-                <Table.Body>
-                  {isLoading ? (
-                    <Table.Row>
-                      <Table.Cell colSpan={4} className="text-ui-fg-subtle">
-                        Loading…
-                      </Table.Cell>
-                    </Table.Row>
-                  ) : !candidates.length ? (
-                    <Table.Row>
-                      <Table.Cell colSpan={4} className="text-ui-fg-subtle">
-                        No ungrouped raw materials found.
-                      </Table.Cell>
-                    </Table.Row>
-                  ) : (
-                    candidates.map((c) => (
-                      <Table.Row
-                        key={c.rawMaterialId}
-                        className="cursor-pointer"
-                        onClick={() => toggle(c.rawMaterialId, c.name)}
-                      >
-                        <Table.Cell>
-                          <Checkbox
-                            checked={!!selected[c.rawMaterialId]}
-                            onCheckedChange={() => toggle(c.rawMaterialId, c.name)}
-                          />
-                        </Table.Cell>
-                        <Table.Cell>{c.name}</Table.Cell>
-                        <Table.Cell>
-                          {c.color ? <Badge size="small" color="grey">{c.color}</Badge> : "—"}
-                        </Table.Cell>
-                        <Table.Cell className="text-ui-fg-subtle">{c.sku || "—"}</Table.Cell>
-                      </Table.Row>
-                    ))
-                  )}
-                </Table.Body>
-              </Table>
-            </div>
-          </div>
+        <FocusModal.Body className="flex flex-1 flex-col overflow-hidden p-0">
+          <DataTable instance={table}>
+            <DataTable.Toolbar className="flex flex-col items-start gap-y-3 px-6 py-4">
+              <div>
+                <FocusModal.Title asChild>
+                  <Heading>Link existing raw materials</Heading>
+                </FocusModal.Title>
+                <FocusModal.Description asChild>
+                  <Text size="small" className="text-ui-fg-subtle">
+                    Attach materials that already exist (with their stock item) as colors of this group.
+                  </Text>
+                </FocusModal.Description>
+              </div>
+              <DataTable.Search placeholder="Search by name, color or SKU" />
+            </DataTable.Toolbar>
+            <DataTable.Table />
+            <DataTable.Pagination />
+          </DataTable>
         </FocusModal.Body>
       </FocusModal.Content>
     </FocusModal>
@@ -601,7 +610,7 @@ export const GroupOrdersSection = ({ groupId }: { groupId: string }) => {
                     key={l.id}
                     className={order?.id ? "cursor-pointer" : undefined}
                     onClick={() =>
-                      order?.id && navigate(`/inventory-orders/${order.id}`)
+                      order?.id && navigate(`/orders/inventory/${order.id}`)
                     }
                   >
                     <Table.Cell>

--- a/apps/backend/src/admin/components/raw-material-groups/group-sections.tsx
+++ b/apps/backend/src/admin/components/raw-material-groups/group-sections.tsx
@@ -1,0 +1,641 @@
+import {
+  Badge,
+  Button,
+  Checkbox,
+  Container,
+  Heading,
+  Input,
+  Label,
+  Select,
+  Table,
+  Text,
+  FocusModal,
+  toast,
+} from "@medusajs/ui"
+import { PencilSquare, Plus, Component as ComponentIcon, Link as LinkIcon } from "@medusajs/icons"
+import { useMemo, useState } from "react"
+import { useNavigate } from "react-router-dom"
+
+import { ActionMenu } from "../common/action-menu"
+import {
+  RawMaterialGroup,
+  RawMaterialGroupColor,
+  useAddGroupColor,
+  useLinkGroupColors,
+  useCreateGroupOrder,
+  useRawMaterialGroupOrders,
+} from "../../hooks/api/raw-material-groups"
+import { useInventoryWithRawMaterials } from "../../hooks/api/raw-materials"
+import { useStockLocations } from "../../hooks/api/stock_location"
+
+// ---------------------------------------------------------------------------
+// General section
+// ---------------------------------------------------------------------------
+
+export const GroupGeneralSection = ({ group }: { group: RawMaterialGroup }) => {
+  const rows: Array<[string, React.ReactNode]> = [
+    ["Composition", group.composition || "—"],
+    ["Unit of measure", group.unit_of_measure || "—"],
+    ["Material type", group.material_type?.name || "—"],
+    ["Colors", group.raw_materials?.length ?? 0],
+  ]
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <Heading>{group.name}</Heading>
+        <Badge size="small" color={group.status === "Active" || !group.status ? "green" : "grey"}>
+          {group.status || "Active"}
+        </Badge>
+      </div>
+      {rows.map(([label, value]) => (
+        <div
+          key={label}
+          className="text-ui-fg-subtle grid grid-cols-2 items-center px-6 py-4"
+        >
+          <Text size="small" leading="compact" weight="plus">
+            {label}
+          </Text>
+          <Text size="small">{value}</Text>
+        </div>
+      ))}
+    </Container>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Add-color: quick modal (name + color)
+// ---------------------------------------------------------------------------
+
+const QuickAddColorModal = ({
+  groupId,
+  open,
+  onOpenChange,
+}: {
+  groupId: string
+  open: boolean
+  onOpenChange: (v: boolean) => void
+}) => {
+  const [name, setName] = useState("")
+  const [color, setColor] = useState("")
+  const { mutateAsync, isPending } = useAddGroupColor(groupId)
+
+  const submit = async () => {
+    if (!name.trim() || !color.trim()) {
+      toast.error("Name and color are required")
+      return
+    }
+    try {
+      await mutateAsync({ name: name.trim(), color: color.trim() })
+      toast.success("Color added")
+      onOpenChange(false)
+      setName("")
+      setColor("")
+    } catch (e: any) {
+      toast.error(e?.message || "Failed to add color")
+    }
+  }
+
+  return (
+    <FocusModal open={open} onOpenChange={onOpenChange}>
+      <FocusModal.Content>
+        <FocusModal.Header>
+          <Button size="small" onClick={submit} isLoading={isPending}>Save</Button>
+        </FocusModal.Header>
+        <FocusModal.Body className="flex flex-col items-center py-16">
+          <div className="flex w-full max-w-lg flex-col gap-y-6">
+            <div>
+              <FocusModal.Title asChild>
+                <Heading>Quick add a color</Heading>
+              </FocusModal.Title>
+              <FocusModal.Description asChild>
+                <Text size="small" className="text-ui-fg-subtle">
+                  Capture just a name and color now. The stock item is created on the first order.
+                </Text>
+              </FocusModal.Description>
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label>Name</Label>
+              <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Cotton Poplin — Blue" />
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label>Color</Label>
+              <Input value={color} onChange={(e) => setColor(e.target.value)} placeholder="Blue" />
+            </div>
+          </div>
+        </FocusModal.Body>
+      </FocusModal.Content>
+    </FocusModal>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Add-color: link an existing raw material
+// ---------------------------------------------------------------------------
+
+const LinkExistingColorsModal = ({
+  groupId,
+  open,
+  onOpenChange,
+}: {
+  groupId: string
+  open: boolean
+  onOpenChange: (v: boolean) => void
+}) => {
+  const [search, setSearch] = useState("")
+  const [selected, setSelected] = useState<Record<string, string>>({})
+  const { mutateAsync, isPending } = useLinkGroupColors(groupId)
+  const { inventory_items = [], isLoading } = useInventoryWithRawMaterials({
+    fields: "+raw_materials.*",
+    limit: 200,
+  })
+
+  // Only ungrouped raw materials can be linked — a color belongs to one group.
+  const candidates = useMemo(() => {
+    const rows = inventory_items
+      .filter((it: any) => it.raw_materials && !it.raw_materials.group_id)
+      .map((it: any) => ({
+        rawMaterialId: it.raw_materials.id as string,
+        name: it.raw_materials.name as string,
+        color: (it.raw_materials.color as string) || "",
+        sku: it.inventory_item?.sku || it.sku || "",
+      }))
+    if (!search) return rows
+    const q = search.toLowerCase()
+    return rows.filter(
+      (r) => `${r.name} ${r.color} ${r.sku}`.toLowerCase().includes(q)
+    )
+  }, [inventory_items, search])
+
+  const toggle = (id: string, name: string) =>
+    setSelected((s) => {
+      if (s[id]) {
+        const { [id]: _, ...rest } = s
+        return rest
+      }
+      return { ...s, [id]: name }
+    })
+
+  const submit = async () => {
+    const ids = Object.keys(selected)
+    if (!ids.length) {
+      toast.error("Select at least one raw material")
+      return
+    }
+    try {
+      await mutateAsync(ids)
+      toast.success(`Linked ${ids.length} color(s)`)
+      onOpenChange(false)
+      setSelected({})
+    } catch (e: any) {
+      toast.error(e?.message || "Failed to link colors")
+    }
+  }
+
+  return (
+    <FocusModal open={open} onOpenChange={onOpenChange}>
+      <FocusModal.Content>
+        <FocusModal.Header>
+          <Button size="small" onClick={submit} isLoading={isPending}>
+            Link {Object.keys(selected).length || ""}
+          </Button>
+        </FocusModal.Header>
+        <FocusModal.Body className="flex flex-col items-center py-10">
+          <div className="flex w-full max-w-2xl flex-col gap-y-4">
+            <div>
+              <FocusModal.Title asChild>
+                <Heading>Link existing raw materials</Heading>
+              </FocusModal.Title>
+              <FocusModal.Description asChild>
+                <Text size="small" className="text-ui-fg-subtle">
+                  Attach materials that already exist (with their stock item) as colors of this group.
+                </Text>
+              </FocusModal.Description>
+            </div>
+            <Input
+              placeholder="Search by name, color or SKU"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+            <div className="max-h-[420px] overflow-y-auto">
+              <Table>
+                <Table.Header>
+                  <Table.Row>
+                    <Table.HeaderCell> </Table.HeaderCell>
+                    <Table.HeaderCell>Name</Table.HeaderCell>
+                    <Table.HeaderCell>Color</Table.HeaderCell>
+                    <Table.HeaderCell>SKU</Table.HeaderCell>
+                  </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                  {isLoading ? (
+                    <Table.Row>
+                      <Table.Cell colSpan={4} className="text-ui-fg-subtle">
+                        Loading…
+                      </Table.Cell>
+                    </Table.Row>
+                  ) : !candidates.length ? (
+                    <Table.Row>
+                      <Table.Cell colSpan={4} className="text-ui-fg-subtle">
+                        No ungrouped raw materials found.
+                      </Table.Cell>
+                    </Table.Row>
+                  ) : (
+                    candidates.map((c) => (
+                      <Table.Row
+                        key={c.rawMaterialId}
+                        className="cursor-pointer"
+                        onClick={() => toggle(c.rawMaterialId, c.name)}
+                      >
+                        <Table.Cell>
+                          <Checkbox
+                            checked={!!selected[c.rawMaterialId]}
+                            onCheckedChange={() => toggle(c.rawMaterialId, c.name)}
+                          />
+                        </Table.Cell>
+                        <Table.Cell>{c.name}</Table.Cell>
+                        <Table.Cell>
+                          {c.color ? <Badge size="small" color="grey">{c.color}</Badge> : "—"}
+                        </Table.Cell>
+                        <Table.Cell className="text-ui-fg-subtle">{c.sku || "—"}</Table.Cell>
+                      </Table.Row>
+                    ))
+                  )}
+                </Table.Body>
+              </Table>
+            </div>
+          </div>
+        </FocusModal.Body>
+      </FocusModal.Content>
+    </FocusModal>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Order the group in colors (fan-out)
+// ---------------------------------------------------------------------------
+
+type LineDraft = { selected: boolean; quantity: string; price: string }
+
+const OrderInColorsModal = ({
+  groupId,
+  colors,
+  open,
+  onOpenChange,
+}: {
+  groupId: string
+  colors: RawMaterialGroupColor[]
+  open: boolean
+  onOpenChange: (v: boolean) => void
+}) => {
+  const [stockLocationId, setStockLocationId] = useState<string>("")
+  const [drafts, setDrafts] = useState<Record<string, LineDraft>>({})
+  const { stock_locations = [] } = useStockLocations()
+  const { mutateAsync, isPending } = useCreateGroupOrder(groupId)
+
+  const setDraft = (id: string, patch: Partial<LineDraft>) =>
+    setDrafts((d) => ({
+      ...d,
+      [id]: { selected: false, quantity: "", price: "", ...d[id], ...patch },
+    }))
+
+  const submit = async () => {
+    const lines = colors
+      .filter((c) => drafts[c.id]?.selected)
+      .map((c) => ({
+        raw_material_id: c.id,
+        quantity: Number(drafts[c.id]?.quantity) || 0,
+        price: Number(drafts[c.id]?.price) || 0,
+      }))
+    if (!lines.length) {
+      toast.error("Select at least one color")
+      return
+    }
+    if (!stockLocationId) {
+      toast.error("Select a stock location")
+      return
+    }
+    const now = new Date()
+    const eta = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000)
+    try {
+      const res = await mutateAsync({
+        lines,
+        status: "Pending",
+        order_date: now.toISOString(),
+        expected_delivery_date: eta.toISOString(),
+        shipping_address: {},
+        stock_location_id: stockLocationId,
+      })
+      const created = res.created_inventory_item_ids?.length
+        ? ` (${res.created_inventory_item_ids.length} new item(s) created)`
+        : ""
+      toast.success(`Order placed${created}`)
+      onOpenChange(false)
+      setDrafts({})
+    } catch (e: any) {
+      toast.error(e?.message || "Failed to place order")
+    }
+  }
+
+  return (
+    <FocusModal open={open} onOpenChange={onOpenChange}>
+      <FocusModal.Content>
+        <FocusModal.Header>
+          <Button size="small" onClick={submit} isLoading={isPending}>Place order</Button>
+        </FocusModal.Header>
+        <FocusModal.Body className="flex flex-col items-center py-16">
+          <div className="flex w-full max-w-2xl flex-col gap-y-6">
+            <div>
+              <FocusModal.Title asChild>
+                <Heading>Order this group in colors</Heading>
+              </FocusModal.Title>
+              <FocusModal.Description asChild>
+                <Text size="small" className="text-ui-fg-subtle">
+                  One order line per selected color. Colors without stock are created automatically.
+                </Text>
+              </FocusModal.Description>
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label>Ship to location</Label>
+              <Select value={stockLocationId} onValueChange={setStockLocationId}>
+                <Select.Trigger>
+                  <Select.Value placeholder="Select a stock location" />
+                </Select.Trigger>
+                <Select.Content>
+                  {stock_locations.map((sl: any) => (
+                    <Select.Item key={sl.id} value={sl.id}>{sl.name}</Select.Item>
+                  ))}
+                </Select.Content>
+              </Select>
+            </div>
+            <Table>
+              <Table.Header>
+                <Table.Row>
+                  <Table.HeaderCell> </Table.HeaderCell>
+                  <Table.HeaderCell>Color</Table.HeaderCell>
+                  <Table.HeaderCell>Quantity</Table.HeaderCell>
+                  <Table.HeaderCell>Unit price</Table.HeaderCell>
+                </Table.Row>
+              </Table.Header>
+              <Table.Body>
+                {colors.map((c) => {
+                  const d = drafts[c.id]
+                  return (
+                    <Table.Row key={c.id}>
+                      <Table.Cell>
+                        <Checkbox
+                          checked={!!d?.selected}
+                          onCheckedChange={(v) => setDraft(c.id, { selected: !!v })}
+                        />
+                      </Table.Cell>
+                      <Table.Cell>{c.color || c.name}</Table.Cell>
+                      <Table.Cell>
+                        <Input
+                          type="number"
+                          disabled={!d?.selected}
+                          value={d?.quantity ?? ""}
+                          onChange={(e) => setDraft(c.id, { quantity: e.target.value })}
+                        />
+                      </Table.Cell>
+                      <Table.Cell>
+                        <Input
+                          type="number"
+                          disabled={!d?.selected}
+                          value={d?.price ?? ""}
+                          onChange={(e) => setDraft(c.id, { price: e.target.value })}
+                        />
+                      </Table.Cell>
+                    </Table.Row>
+                  )
+                })}
+              </Table.Body>
+            </Table>
+          </div>
+        </FocusModal.Body>
+      </FocusModal.Content>
+    </FocusModal>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Colors section
+// ---------------------------------------------------------------------------
+
+export const GroupColorsSection = ({ group }: { group: RawMaterialGroup }) => {
+  const colors = useMemo(() => group.raw_materials ?? [], [group])
+  const [quickOpen, setQuickOpen] = useState(false)
+  const [linkOpen, setLinkOpen] = useState(false)
+  const [orderOpen, setOrderOpen] = useState(false)
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div>
+          <Heading level="h2">Colors</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            Each color is its own stock item; ordering fans out one line per color.
+          </Text>
+        </div>
+        <div className="flex items-center gap-x-2">
+          <Button size="small" onClick={() => setOrderOpen(true)} disabled={!colors.length}>
+            Order in colors
+          </Button>
+          <ActionMenu
+            groups={[
+              {
+                actions: [
+                  {
+                    icon: <Plus />,
+                    label: "Quick add (name + color)",
+                    onClick: () => setQuickOpen(true),
+                  },
+                  {
+                    icon: <ComponentIcon />,
+                    label: "Add with full material spec",
+                    to: `/raw-material-groups/${group.id}/colors/create`,
+                  },
+                  {
+                    icon: <LinkIcon />,
+                    label: "Link an existing raw material",
+                    onClick: () => setLinkOpen(true),
+                  },
+                ],
+              },
+            ]}
+          >
+            <Button size="small" variant="secondary">Add color</Button>
+          </ActionMenu>
+        </div>
+      </div>
+
+      {!colors.length ? (
+        <div className="px-6 py-8 text-center">
+          <Text className="text-ui-fg-subtle">No colors yet. Add one to order this group.</Text>
+        </div>
+      ) : (
+        <Table>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>Color</Table.HeaderCell>
+              <Table.HeaderCell>Name</Table.HeaderCell>
+              <Table.HeaderCell>SKU</Table.HeaderCell>
+              <Table.HeaderCell>Stock item</Table.HeaderCell>
+              <Table.HeaderCell> </Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {colors.map((c) => (
+              <Table.Row key={c.id}>
+                <Table.Cell>
+                  {c.color ? <Badge size="small" color="grey">{c.color}</Badge> : "—"}
+                </Table.Cell>
+                <Table.Cell>{c.name}</Table.Cell>
+                <Table.Cell className="text-ui-fg-subtle">
+                  {c.inventory_item?.sku || "—"}
+                </Table.Cell>
+                <Table.Cell>
+                  <Badge size="small" color={c.inventory_item?.id ? "green" : "orange"}>
+                    {c.inventory_item?.id ? "Yes" : "On first order"}
+                  </Badge>
+                </Table.Cell>
+                <Table.Cell onClick={(e) => e.stopPropagation()}>
+                  <ActionMenu
+                    groups={[
+                      {
+                        actions: [
+                          {
+                            icon: <PencilSquare />,
+                            label: "View stock item",
+                            to: c.inventory_item?.id
+                              ? `/inventory/${c.inventory_item.id}`
+                              : `/raw-material-groups/${group.id}`,
+                            disabled: !c.inventory_item?.id,
+                          },
+                        ],
+                      },
+                    ]}
+                  />
+                </Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      )}
+
+      <QuickAddColorModal groupId={group.id} open={quickOpen} onOpenChange={setQuickOpen} />
+      <LinkExistingColorsModal groupId={group.id} open={linkOpen} onOpenChange={setLinkOpen} />
+      <OrderInColorsModal
+        groupId={group.id}
+        colors={colors}
+        open={orderOpen}
+        onOpenChange={setOrderOpen}
+      />
+    </Container>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Orders section — order lines for this group's colors, grouped by color
+// ---------------------------------------------------------------------------
+
+const STATUS_COLOR: Record<string, "green" | "orange" | "red" | "grey" | "blue"> = {
+  Pending: "orange",
+  Processing: "blue",
+  Shipped: "blue",
+  Delivered: "green",
+  Cancelled: "red",
+}
+
+export const GroupOrdersSection = ({ groupId }: { groupId: string }) => {
+  const navigate = useNavigate()
+  const { data, isLoading } = useRawMaterialGroupOrders(groupId)
+  const lines = data?.order_lines ?? []
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, typeof lines>()
+    for (const l of lines) {
+      const key = l.color || l.material_name || "Unspecified"
+      const arr = map.get(key) ?? []
+      arr.push(l)
+      map.set(key, arr)
+    }
+    return Array.from(map.entries())
+  }, [lines])
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div>
+          <Heading level="h2">Orders</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            Every inventory order placed for this group's colors.
+          </Text>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="px-6 py-8 text-center">
+          <Text className="text-ui-fg-subtle">Loading orders…</Text>
+        </div>
+      ) : !lines.length ? (
+        <div className="px-6 py-8 text-center">
+          <Text className="text-ui-fg-subtle">No orders yet for this group.</Text>
+        </div>
+      ) : (
+        <Table>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>Color</Table.HeaderCell>
+              <Table.HeaderCell>Order</Table.HeaderCell>
+              <Table.HeaderCell>Status</Table.HeaderCell>
+              <Table.HeaderCell>Quantity</Table.HeaderCell>
+              <Table.HeaderCell>Ordered</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {grouped.map(([color, colorLines]) =>
+              colorLines.map((l, idx) => {
+                const order = l.inventory_orders
+                return (
+                  <Table.Row
+                    key={l.id}
+                    className={order?.id ? "cursor-pointer" : undefined}
+                    onClick={() =>
+                      order?.id && navigate(`/inventory-orders/${order.id}`)
+                    }
+                  >
+                    <Table.Cell>
+                      {idx === 0 ? (
+                        <Badge size="small" color="grey">{color}</Badge>
+                      ) : (
+                        ""
+                      )}
+                    </Table.Cell>
+                    <Table.Cell className="text-ui-fg-subtle">
+                      {order?.id ? `#${order.id.slice(-8)}` : "—"}
+                    </Table.Cell>
+                    <Table.Cell>
+                      {order?.status ? (
+                        <Badge size="small" color={STATUS_COLOR[order.status] || "grey"}>
+                          {order.status}
+                        </Badge>
+                      ) : (
+                        "—"
+                      )}
+                    </Table.Cell>
+                    <Table.Cell>{l.quantity}</Table.Cell>
+                    <Table.Cell className="text-ui-fg-subtle">
+                      {order?.order_date
+                        ? new Date(order.order_date).toLocaleDateString()
+                        : "—"}
+                    </Table.Cell>
+                  </Table.Row>
+                )
+              })
+            )}
+          </Table.Body>
+        </Table>
+      )}
+    </Container>
+  )
+}

--- a/apps/backend/src/admin/components/raw-material-groups/group-sections.tsx
+++ b/apps/backend/src/admin/components/raw-material-groups/group-sections.tsx
@@ -1,7 +1,6 @@
 import {
   Badge,
   Button,
-  Checkbox,
   Container,
   DataTable,
   DataTablePaginationState,
@@ -18,7 +17,7 @@ import {
   useDataTable,
 } from "@medusajs/ui"
 import { PencilSquare, Plus, Component as ComponentIcon, Link as LinkIcon } from "@medusajs/icons"
-import { useMemo, useState } from "react"
+import { useCallback, useMemo, useState } from "react"
 import { useNavigate } from "react-router-dom"
 
 import { ActionMenu } from "../common/action-menu"
@@ -284,7 +283,36 @@ const LinkExistingColorsModal = ({
 // Order the group in colors (fan-out)
 // ---------------------------------------------------------------------------
 
-type LineDraft = { selected: boolean; quantity: string; price: string }
+type LineDraft = { quantity: string; price: string }
+
+// Self-contained numeric input so per-row edits keep focus across DataTable
+// re-renders; the value is lifted to the parent's drafts on change.
+const NumberCell = ({
+  initial,
+  placeholder,
+  onChange,
+}: {
+  initial: string
+  placeholder: string
+  onChange: (v: string) => void
+}) => {
+  const [v, setV] = useState(initial)
+  return (
+    <Input
+      type="number"
+      min="0"
+      placeholder={placeholder}
+      value={v}
+      onClick={(e) => e.stopPropagation()}
+      onChange={(e) => {
+        setV(e.target.value)
+        onChange(e.target.value)
+      }}
+    />
+  )
+}
+
+const orderColumnHelper = createDataTableColumnHelper<RawMaterialGroupColor>()
 
 const OrderInColorsModal = ({
   groupId,
@@ -299,23 +327,73 @@ const OrderInColorsModal = ({
 }) => {
   const [stockLocationId, setStockLocationId] = useState<string>("")
   const [drafts, setDrafts] = useState<Record<string, LineDraft>>({})
+  const [rowSelection, setRowSelection] = useState<DataTableRowSelectionState>({})
   const { stock_locations = [] } = useStockLocations()
   const { mutateAsync, isPending } = useCreateGroupOrder(groupId)
 
-  const setDraft = (id: string, patch: Partial<LineDraft>) =>
-    setDrafts((d) => ({
-      ...d,
-      [id]: { selected: false, quantity: "", price: "", ...d[id], ...patch },
-    }))
+  const setDraft = useCallback(
+    (id: string, patch: Partial<LineDraft>) =>
+      setDrafts((d) => ({
+        ...d,
+        [id]: { quantity: "", price: "", ...d[id], ...patch },
+      })),
+    []
+  )
+
+  const columns = useMemo(
+    () => [
+      orderColumnHelper.select(),
+      orderColumnHelper.accessor("color", {
+        header: "Color",
+        cell: ({ row }) => row.original.color || row.original.name,
+      }),
+      orderColumnHelper.display({
+        id: "quantity",
+        header: "Quantity",
+        cell: ({ row }) => (
+          <NumberCell
+            initial={drafts[row.original.id]?.quantity ?? ""}
+            placeholder="0"
+            onChange={(v) => setDraft(row.original.id, { quantity: v })}
+          />
+        ),
+      }),
+      orderColumnHelper.display({
+        id: "price",
+        header: "Unit price",
+        cell: ({ row }) => (
+          <NumberCell
+            initial={drafts[row.original.id]?.price ?? ""}
+            placeholder="0"
+            onChange={(v) => setDraft(row.original.id, { price: v })}
+          />
+        ),
+      }),
+    ],
+    // `drafts` intentionally omitted: NumberCell owns its live value, we only
+    // need the initial when the modal (re)opens. Depending on drafts here would
+    // recreate the cells on every keystroke and drop focus.
+    [setDraft]
+  )
+
+  const table = useDataTable({
+    columns,
+    data: colors,
+    getRowId: (row) => row.id,
+    rowCount: colors.length,
+    rowSelection: {
+      state: rowSelection,
+      onRowSelectionChange: setRowSelection,
+    },
+  })
 
   const submit = async () => {
-    const lines = colors
-      .filter((c) => drafts[c.id]?.selected)
-      .map((c) => ({
-        raw_material_id: c.id,
-        quantity: Number(drafts[c.id]?.quantity) || 0,
-        price: Number(drafts[c.id]?.price) || 0,
-      }))
+    const selectedIds = Object.keys(rowSelection).filter((id) => rowSelection[id])
+    const lines = selectedIds.map((id) => ({
+      raw_material_id: id,
+      quantity: Number(drafts[id]?.quantity) || 0,
+      price: Number(drafts[id]?.price) || 0,
+    }))
     if (!lines.length) {
       toast.error("Select at least one color")
       return
@@ -341,6 +419,7 @@ const OrderInColorsModal = ({
       toast.success(`Order placed${created}`)
       onOpenChange(false)
       setDrafts({})
+      setRowSelection({})
     } catch (e: any) {
       toast.error(e?.message || "Failed to place order")
     }
@@ -348,78 +427,39 @@ const OrderInColorsModal = ({
 
   return (
     <FocusModal open={open} onOpenChange={onOpenChange}>
-      <FocusModal.Content>
+      <FocusModal.Content className="flex flex-col">
         <FocusModal.Header>
           <Button size="small" onClick={submit} isLoading={isPending}>Place order</Button>
         </FocusModal.Header>
-        <FocusModal.Body className="flex flex-col items-center py-16">
-          <div className="flex w-full max-w-2xl flex-col gap-y-6">
-            <div>
-              <FocusModal.Title asChild>
-                <Heading>Order this group in colors</Heading>
-              </FocusModal.Title>
-              <FocusModal.Description asChild>
-                <Text size="small" className="text-ui-fg-subtle">
-                  One order line per selected color. Colors without stock are created automatically.
-                </Text>
-              </FocusModal.Description>
-            </div>
-            <div className="flex flex-col gap-y-2">
-              <Label>Ship to location</Label>
-              <Select value={stockLocationId} onValueChange={setStockLocationId}>
-                <Select.Trigger>
-                  <Select.Value placeholder="Select a stock location" />
-                </Select.Trigger>
-                <Select.Content>
-                  {stock_locations.map((sl: any) => (
-                    <Select.Item key={sl.id} value={sl.id}>{sl.name}</Select.Item>
-                  ))}
-                </Select.Content>
-              </Select>
-            </div>
-            <Table>
-              <Table.Header>
-                <Table.Row>
-                  <Table.HeaderCell> </Table.HeaderCell>
-                  <Table.HeaderCell>Color</Table.HeaderCell>
-                  <Table.HeaderCell>Quantity</Table.HeaderCell>
-                  <Table.HeaderCell>Unit price</Table.HeaderCell>
-                </Table.Row>
-              </Table.Header>
-              <Table.Body>
-                {colors.map((c) => {
-                  const d = drafts[c.id]
-                  return (
-                    <Table.Row key={c.id}>
-                      <Table.Cell>
-                        <Checkbox
-                          checked={!!d?.selected}
-                          onCheckedChange={(v) => setDraft(c.id, { selected: !!v })}
-                        />
-                      </Table.Cell>
-                      <Table.Cell>{c.color || c.name}</Table.Cell>
-                      <Table.Cell>
-                        <Input
-                          type="number"
-                          disabled={!d?.selected}
-                          value={d?.quantity ?? ""}
-                          onChange={(e) => setDraft(c.id, { quantity: e.target.value })}
-                        />
-                      </Table.Cell>
-                      <Table.Cell>
-                        <Input
-                          type="number"
-                          disabled={!d?.selected}
-                          value={d?.price ?? ""}
-                          onChange={(e) => setDraft(c.id, { price: e.target.value })}
-                        />
-                      </Table.Cell>
-                    </Table.Row>
-                  )
-                })}
-              </Table.Body>
-            </Table>
-          </div>
+        <FocusModal.Body className="flex flex-1 flex-col overflow-hidden p-0">
+          <DataTable instance={table}>
+            <DataTable.Toolbar className="flex flex-col items-start gap-y-3 px-6 py-4">
+              <div>
+                <FocusModal.Title asChild>
+                  <Heading>Order this group in colors</Heading>
+                </FocusModal.Title>
+                <FocusModal.Description asChild>
+                  <Text size="small" className="text-ui-fg-subtle">
+                    One order line per selected color. Colors without stock are created automatically.
+                  </Text>
+                </FocusModal.Description>
+              </div>
+              <div className="flex w-full max-w-sm flex-col gap-y-2">
+                <Label>Ship to location</Label>
+                <Select value={stockLocationId} onValueChange={setStockLocationId}>
+                  <Select.Trigger>
+                    <Select.Value placeholder="Select a stock location" />
+                  </Select.Trigger>
+                  <Select.Content>
+                    {stock_locations.map((sl: any) => (
+                      <Select.Item key={sl.id} value={sl.id}>{sl.name}</Select.Item>
+                    ))}
+                  </Select.Content>
+                </Select>
+              </div>
+            </DataTable.Toolbar>
+            <DataTable.Table />
+          </DataTable>
         </FocusModal.Body>
       </FocusModal.Content>
     </FocusModal>

--- a/apps/backend/src/admin/hooks/api/raw-material-groups.ts
+++ b/apps/backend/src/admin/hooks/api/raw-material-groups.ts
@@ -24,10 +24,26 @@ export interface RawMaterialGroup {
   created_at?: string
 }
 
+export interface GroupOrderLineRow {
+  id: string
+  quantity: number
+  price: number
+  color?: string | null
+  material_name?: string | null
+  raw_material_id?: string | null
+  inventory_orders?: {
+    id: string
+    status?: string
+    order_date?: string
+    expected_delivery_date?: string
+  } | null
+}
+
 const groupKeys = {
   all: ["raw-material-groups"] as const,
   list: (q?: Record<string, unknown>) => ["raw-material-groups", "list", q] as const,
   detail: (id: string) => ["raw-material-groups", "detail", id] as const,
+  orders: (id: string) => ["raw-material-groups", "orders", id] as const,
 }
 
 export const useRawMaterialGroups = (query?: {
@@ -57,6 +73,16 @@ export const useRawMaterialGroup = (id?: string) =>
       ),
   })
 
+export const useRawMaterialGroupOrders = (id?: string) =>
+  useQuery({
+    queryKey: groupKeys.orders(id!),
+    enabled: !!id,
+    queryFn: () =>
+      sdk.client.fetch<{ order_lines: GroupOrderLineRow[] }>(
+        `/admin/raw-material-groups/${id}/orders`
+      ),
+  })
+
 export const useCreateRawMaterialGroup = () => {
   const qc = useQueryClient()
   return useMutation({
@@ -76,6 +102,32 @@ export const useAddGroupColor = (groupId: string) => {
       sdk.client.fetch<{ raw_material_group: RawMaterialGroup }>(
         `/admin/raw-material-groups/${groupId}/colors`,
         { method: "POST", body }
+      ),
+    onSuccess: () => qc.invalidateQueries({ queryKey: groupKeys.detail(groupId) }),
+  })
+}
+
+// Full-detail color add — posts the shared RawMaterialForm's { rawMaterialData }.
+export const useCreateGroupColorFull = (groupId: string) => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (rawMaterialData: Record<string, unknown>) =>
+      sdk.client.fetch<{ raw_material_group: RawMaterialGroup }>(
+        `/admin/raw-material-groups/${groupId}/colors/full`,
+        { method: "POST", body: { rawMaterialData } }
+      ),
+    onSuccess: () => qc.invalidateQueries({ queryKey: groupKeys.detail(groupId) }),
+  })
+}
+
+// Attach existing raw_materials to the group as colors.
+export const useLinkGroupColors = (groupId: string) => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (raw_material_ids: string[]) =>
+      sdk.client.fetch<{ raw_material_group: RawMaterialGroup }>(
+        `/admin/raw-material-groups/${groupId}/colors/link`,
+        { method: "POST", body: { raw_material_ids } }
       ),
     onSuccess: () => qc.invalidateQueries({ queryKey: groupKeys.detail(groupId) }),
   })

--- a/apps/backend/src/admin/routes/inventory/[id]/raw-materials/create/page.tsx
+++ b/apps/backend/src/admin/routes/inventory/[id]/raw-materials/create/page.tsx
@@ -1,9 +1,14 @@
+import { useParams } from "react-router-dom"
 import { RouteFocusModal } from "../../../../../components/modal/route-focus-modal"
 import { RawMaterialForm } from "../../../../../components/forms/raw-material/raw-material-form"
 
 export default function CreateRawMaterialPage() {
+  const { id } = useParams()
+  // Close the create modal straight back to the inventory item. The default
+  // `prev` ("..") lands on the parent `/raw-materials` route, which is an edit
+  // RouteDrawer that renders an empty form for a brand-new item (#825).
   return (
-    <RouteFocusModal>
+    <RouteFocusModal prev={`/inventory/${id}`}>
       <RawMaterialForm />
     </RouteFocusModal>
   )

--- a/apps/backend/src/admin/routes/raw-material-groups/[id]/colors/create/page.tsx
+++ b/apps/backend/src/admin/routes/raw-material-groups/[id]/colors/create/page.tsx
@@ -1,0 +1,14 @@
+import { useParams } from "react-router-dom"
+import { RouteFocusModal } from "../../../../../components/modal/route-focus-modal"
+import { RawMaterialForm } from "../../../../../components/forms/raw-material/raw-material-form"
+
+// Add a color to a group with the full material-spec form (reuses the shared
+// RawMaterialForm in "group" mode — the group endpoint provisions the item).
+export default function CreateGroupColorPage() {
+  const { id } = useParams()
+  return (
+    <RouteFocusModal prev={`/raw-material-groups/${id}`}>
+      <RawMaterialForm mode="group" groupId={id} />
+    </RouteFocusModal>
+  )
+}

--- a/apps/backend/src/admin/routes/raw-material-groups/[id]/loader.ts
+++ b/apps/backend/src/admin/routes/raw-material-groups/[id]/loader.ts
@@ -1,0 +1,16 @@
+import { sdk } from "../../../lib/config"
+import { queryClient } from "../../../lib/query-client"
+
+const groupDetailQuery = (id: string) => ({
+  queryKey: ["raw-material-groups", "detail", id],
+  queryFn: async () =>
+    sdk.client.fetch<{ raw_material_group: any }>(
+      `/admin/raw-material-groups/${id}`,
+      { method: "GET" }
+    ),
+})
+
+export const groupLoader = async ({ params }: any) => {
+  const id = params.id
+  return queryClient.ensureQueryData(groupDetailQuery(id!))
+}

--- a/apps/backend/src/admin/routes/raw-material-groups/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/raw-material-groups/[id]/page.tsx
@@ -1,235 +1,28 @@
 import {
-  Badge,
-  Button,
-  Container,
-  Heading,
-  Input,
-  Label,
-  Table,
-  Text,
-  FocusModal,
-  Select,
-  Checkbox,
-  Skeleton,
-  toast,
-} from "@medusajs/ui"
-import { useMemo, useState } from "react"
-import { useParams, useNavigate } from "react-router-dom"
+  LoaderFunctionArgs,
+  Outlet,
+  UIMatch,
+  useLoaderData,
+  useParams,
+} from "react-router-dom"
+import { Container, Text } from "@medusajs/ui"
+import { SingleColumnPageSkeleton } from "../../../components/table/skeleton"
+import { useRawMaterialGroup } from "../../../hooks/api/raw-material-groups"
 import {
-  useRawMaterialGroup,
-  useAddGroupColor,
-  useCreateGroupOrder,
-  type RawMaterialGroupColor,
-} from "../../../hooks/api/raw-material-groups"
-import { useStockLocations } from "../../../hooks/api/stock_location"
-
-const AddColorModal = ({ groupId }: { groupId: string }) => {
-  const [open, setOpen] = useState(false)
-  const [name, setName] = useState("")
-  const [color, setColor] = useState("")
-  const { mutateAsync, isPending } = useAddGroupColor(groupId)
-
-  const submit = async () => {
-    if (!name.trim() || !color.trim()) {
-      toast.error("Name and color are required")
-      return
-    }
-    try {
-      await mutateAsync({ name: name.trim(), color: color.trim() })
-      toast.success("Color added")
-      setOpen(false)
-      setName("")
-      setColor("")
-    } catch (e: any) {
-      toast.error(e?.message || "Failed to add color")
-    }
-  }
-
-  return (
-    <FocusModal open={open} onOpenChange={setOpen}>
-      <FocusModal.Trigger asChild>
-        <Button size="small" variant="secondary">Add color</Button>
-      </FocusModal.Trigger>
-      <FocusModal.Content>
-        <FocusModal.Header>
-          <Button size="small" onClick={submit} isLoading={isPending}>Save</Button>
-        </FocusModal.Header>
-        <FocusModal.Body className="flex flex-col items-center py-16">
-          <div className="flex w-full max-w-lg flex-col gap-y-6">
-            <FocusModal.Title asChild>
-              <Heading>Add a color</Heading>
-            </FocusModal.Title>
-            <div className="flex flex-col gap-y-2">
-              <Label>Name</Label>
-              <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Cotton Poplin — Blue" />
-            </div>
-            <div className="flex flex-col gap-y-2">
-              <Label>Color</Label>
-              <Input value={color} onChange={(e) => setColor(e.target.value)} placeholder="Blue" />
-            </div>
-          </div>
-        </FocusModal.Body>
-      </FocusModal.Content>
-    </FocusModal>
-  )
-}
-
-type LineDraft = { selected: boolean; quantity: string; price: string }
-
-const OrderInColorsModal = ({
-  groupId,
-  colors,
-}: {
-  groupId: string
-  colors: RawMaterialGroupColor[]
-}) => {
-  const [open, setOpen] = useState(false)
-  const [stockLocationId, setStockLocationId] = useState<string>("")
-  const [drafts, setDrafts] = useState<Record<string, LineDraft>>({})
-  const { stock_locations = [] } = useStockLocations()
-  const { mutateAsync, isPending } = useCreateGroupOrder(groupId)
-
-  const setDraft = (id: string, patch: Partial<LineDraft>) =>
-    setDrafts((d) => ({
-      ...d,
-      [id]: { selected: false, quantity: "", price: "", ...d[id], ...patch },
-    }))
-
-  const submit = async () => {
-    const lines = colors
-      .filter((c) => drafts[c.id]?.selected)
-      .map((c) => ({
-        raw_material_id: c.id,
-        quantity: Number(drafts[c.id]?.quantity) || 0,
-        price: Number(drafts[c.id]?.price) || 0,
-      }))
-    if (!lines.length) {
-      toast.error("Select at least one color")
-      return
-    }
-    if (!stockLocationId) {
-      toast.error("Select a stock location")
-      return
-    }
-    const now = new Date()
-    const eta = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000)
-    try {
-      const res = await mutateAsync({
-        lines,
-        status: "Pending",
-        order_date: now.toISOString(),
-        expected_delivery_date: eta.toISOString(),
-        shipping_address: {},
-        stock_location_id: stockLocationId,
-      })
-      const created = res.created_inventory_item_ids?.length
-        ? ` (${res.created_inventory_item_ids.length} new item(s) created)`
-        : ""
-      toast.success(`Order placed${created}`)
-      setOpen(false)
-      setDrafts({})
-    } catch (e: any) {
-      toast.error(e?.message || "Failed to place order")
-    }
-  }
-
-  return (
-    <FocusModal open={open} onOpenChange={setOpen}>
-      <FocusModal.Trigger asChild>
-        <Button size="small" disabled={!colors.length}>Order in colors</Button>
-      </FocusModal.Trigger>
-      <FocusModal.Content>
-        <FocusModal.Header>
-          <Button size="small" onClick={submit} isLoading={isPending}>Place order</Button>
-        </FocusModal.Header>
-        <FocusModal.Body className="flex flex-col items-center py-16">
-          <div className="flex w-full max-w-2xl flex-col gap-y-6">
-            <div>
-              <FocusModal.Title asChild>
-                <Heading>Order this group in colors</Heading>
-              </FocusModal.Title>
-              <FocusModal.Description asChild>
-                <Text size="small" className="text-ui-fg-subtle">
-                  One order line per selected color. Colors without stock are created automatically.
-                </Text>
-              </FocusModal.Description>
-            </div>
-            <div className="flex flex-col gap-y-2">
-              <Label>Ship to location</Label>
-              <Select value={stockLocationId} onValueChange={setStockLocationId}>
-                <Select.Trigger>
-                  <Select.Value placeholder="Select a stock location" />
-                </Select.Trigger>
-                <Select.Content>
-                  {stock_locations.map((sl: any) => (
-                    <Select.Item key={sl.id} value={sl.id}>{sl.name}</Select.Item>
-                  ))}
-                </Select.Content>
-              </Select>
-            </div>
-            <Table>
-              <Table.Header>
-                <Table.Row>
-                  <Table.HeaderCell> </Table.HeaderCell>
-                  <Table.HeaderCell>Color</Table.HeaderCell>
-                  <Table.HeaderCell>Quantity</Table.HeaderCell>
-                  <Table.HeaderCell>Unit price</Table.HeaderCell>
-                </Table.Row>
-              </Table.Header>
-              <Table.Body>
-                {colors.map((c) => {
-                  const d = drafts[c.id]
-                  return (
-                    <Table.Row key={c.id}>
-                      <Table.Cell>
-                        <Checkbox
-                          checked={!!d?.selected}
-                          onCheckedChange={(v) => setDraft(c.id, { selected: !!v })}
-                        />
-                      </Table.Cell>
-                      <Table.Cell>{c.color || c.name}</Table.Cell>
-                      <Table.Cell>
-                        <Input
-                          type="number"
-                          disabled={!d?.selected}
-                          value={d?.quantity ?? ""}
-                          onChange={(e) => setDraft(c.id, { quantity: e.target.value })}
-                        />
-                      </Table.Cell>
-                      <Table.Cell>
-                        <Input
-                          type="number"
-                          disabled={!d?.selected}
-                          value={d?.price ?? ""}
-                          onChange={(e) => setDraft(c.id, { price: e.target.value })}
-                        />
-                      </Table.Cell>
-                    </Table.Row>
-                  )
-                })}
-              </Table.Body>
-            </Table>
-          </div>
-        </FocusModal.Body>
-      </FocusModal.Content>
-    </FocusModal>
-  )
-}
+  GroupGeneralSection,
+  GroupColorsSection,
+  GroupOrdersSection,
+} from "../../../components/raw-material-groups/group-sections"
+import { groupLoader } from "./loader"
 
 const RawMaterialGroupDetailPage = () => {
   const { id } = useParams()
-  const navigate = useNavigate()
+  const initialData = useLoaderData() as Awaited<ReturnType<typeof groupLoader>>
   const { data, isLoading } = useRawMaterialGroup(id)
-  const group = data?.raw_material_group
-  const colors = useMemo(() => group?.raw_materials ?? [], [group])
+  const group = data?.raw_material_group ?? initialData?.raw_material_group
 
-  if (isLoading) {
-    return (
-      <Container className="p-6">
-        <Skeleton className="mb-4 h-8 w-64" />
-        <Skeleton className="h-40 w-full" />
-      </Container>
-    )
+  if (isLoading && !group) {
+    return <SingleColumnPageSkeleton sections={3} />
   }
 
   if (!group) {
@@ -241,64 +34,24 @@ const RawMaterialGroupDetailPage = () => {
   }
 
   return (
-    <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
-        <div>
-          <Heading level="h1">{group.name}</Heading>
-          <Text size="small" className="text-ui-fg-subtle">
-            {group.composition || "—"}
-          </Text>
-        </div>
-        <div className="flex items-center gap-x-2">
-          <AddColorModal groupId={group.id} />
-          <OrderInColorsModal groupId={group.id} colors={colors} />
-        </div>
-      </div>
-
-      <div className="px-2 py-2">
-        {!colors.length ? (
-          <div className="px-6 py-8 text-center">
-            <Text className="text-ui-fg-subtle">No colors yet. Add one to order this group.</Text>
-          </div>
-        ) : (
-          <Table>
-            <Table.Header>
-              <Table.Row>
-                <Table.HeaderCell>Color</Table.HeaderCell>
-                <Table.HeaderCell>Name</Table.HeaderCell>
-                <Table.HeaderCell>SKU</Table.HeaderCell>
-                <Table.HeaderCell>Stock item</Table.HeaderCell>
-              </Table.Row>
-            </Table.Header>
-            <Table.Body>
-              {colors.map((c) => (
-                <Table.Row
-                  key={c.id}
-                  className={c.inventory_item?.id ? "cursor-pointer" : undefined}
-                  onClick={() =>
-                    c.inventory_item?.id && navigate(`/inventory/${c.inventory_item.id}`)
-                  }
-                >
-                  <Table.Cell>
-                    {c.color ? <Badge size="small" color="grey">{c.color}</Badge> : "—"}
-                  </Table.Cell>
-                  <Table.Cell>{c.name}</Table.Cell>
-                  <Table.Cell className="text-ui-fg-subtle">
-                    {c.inventory_item?.sku || "—"}
-                  </Table.Cell>
-                  <Table.Cell>
-                    <Badge size="small" color={c.inventory_item?.id ? "green" : "orange"}>
-                      {c.inventory_item?.id ? "Yes" : "On first order"}
-                    </Badge>
-                  </Table.Cell>
-                </Table.Row>
-              ))}
-            </Table.Body>
-          </Table>
-        )}
-      </div>
-    </Container>
+    <div className="flex flex-col gap-y-3">
+      <GroupGeneralSection group={group} />
+      <GroupColorsSection group={group} />
+      <GroupOrdersSection groupId={group.id} />
+      <Outlet />
+    </div>
   )
 }
 
 export default RawMaterialGroupDetailPage
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  return groupLoader({ params })
+}
+
+export const handle = {
+  breadcrumb: (match: UIMatch<{ id: string }>) => {
+    const data = match.data as any
+    return data?.raw_material_group?.name || "Group"
+  },
+}

--- a/apps/backend/src/admin/routes/raw-material-groups/page.tsx
+++ b/apps/backend/src/admin/routes/raw-material-groups/page.tsx
@@ -143,6 +143,8 @@ const RawMaterialGroupsPage = () => {
 export const config = defineRouteConfig({
   label: "Material Groups",
   icon: Swatch,
+  // Nest under the core Inventory menu instead of a top-level Extensions item.
+  nested: "/inventory",
 })
 
 export default RawMaterialGroupsPage

--- a/apps/backend/src/admin/routes/raw-material-groups/page.tsx
+++ b/apps/backend/src/admin/routes/raw-material-groups/page.tsx
@@ -3,20 +3,25 @@ import { Swatch } from "@medusajs/icons"
 import {
   Button,
   Container,
+  DataTable,
+  DataTableFilteringState,
+  DataTablePaginationState,
   Heading,
   Input,
   Label,
-  Table,
   Text,
   Textarea,
   FocusModal,
   Badge,
-  Skeleton,
+  createDataTableColumnHelper,
+  createDataTableFilterHelper,
   toast,
+  useDataTable,
 } from "@medusajs/ui"
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import { useNavigate } from "react-router-dom"
 import {
+  RawMaterialGroup,
   useRawMaterialGroups,
   useCreateRawMaterialGroup,
 } from "../../hooks/api/raw-material-groups"
@@ -79,63 +84,118 @@ const CreateGroupModal = () => {
   )
 }
 
+const columnHelper = createDataTableColumnHelper<RawMaterialGroup>()
+const filterHelper = createDataTableFilterHelper<RawMaterialGroup>()
+
+const columns = [
+  columnHelper.accessor("name", {
+    header: "Name",
+    enableSorting: true,
+  }),
+  columnHelper.accessor("composition", {
+    header: "Composition",
+    cell: ({ getValue }) => (
+      <span className="text-ui-fg-subtle">{getValue() || "—"}</span>
+    ),
+  }),
+  columnHelper.display({
+    id: "colors",
+    header: "Colors",
+    cell: ({ row }) => row.original.raw_materials?.length ?? 0,
+  }),
+  columnHelper.accessor("status", {
+    header: "Status",
+    cell: ({ getValue }) => {
+      const status = getValue() || "Active"
+      return (
+        <Badge size="small" color={status === "Active" ? "green" : "grey"}>
+          {status}
+        </Badge>
+      )
+    },
+  }),
+]
+
+const filters = [
+  filterHelper.accessor("status", {
+    type: "select",
+    label: "Status",
+    options: [
+      { label: "Active", value: "Active" },
+      { label: "Discontinued", value: "Discontinued" },
+      { label: "Under Review", value: "Under_Review" },
+      { label: "Development", value: "Development" },
+    ],
+  }),
+]
+
+const PAGE_SIZE = 20
+
 const RawMaterialGroupsPage = () => {
   const navigate = useNavigate()
-  const { data, isLoading } = useRawMaterialGroups({ limit: 50 })
-  const groups = data?.raw_material_groups ?? []
+
+  const [pagination, setPagination] = useState<DataTablePaginationState>({
+    pageIndex: 0,
+    pageSize: PAGE_SIZE,
+  })
+  const [filtering, setFiltering] = useState<DataTableFilteringState>({})
+  const [search, setSearch] = useState("")
+
+  const statusFilter = filtering.status
+  const status = Array.isArray(statusFilter)
+    ? (statusFilter[0] as string | undefined)
+    : (statusFilter as string | undefined)
+
+  const { data, isLoading } = useRawMaterialGroups({
+    q: search || undefined,
+    status: status || undefined,
+    limit: pagination.pageSize,
+    offset: pagination.pageIndex * pagination.pageSize,
+  })
+
+  const groups = useMemo(() => data?.raw_material_groups ?? [], [data])
+
+  const table = useDataTable({
+    columns,
+    data: groups,
+    getRowId: (row) => row.id,
+    rowCount: data?.count ?? 0,
+    isLoading,
+    onRowClick: (_, row) => navigate(`/raw-material-groups/${row.id}`),
+    filters,
+    pagination: {
+      state: pagination,
+      onPaginationChange: setPagination,
+    },
+    search: {
+      state: search,
+      onSearchChange: setSearch,
+    },
+    filtering: {
+      state: filtering,
+      onFilteringChange: setFiltering,
+    },
+  })
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
-        <div>
-          <Heading level="h1">Raw-material groups</Heading>
-          <Text size="small" className="text-ui-fg-subtle">
-            Order a material in multiple colors without losing color identity.
-          </Text>
-        </div>
-        <CreateGroupModal />
-      </div>
-
-      {isLoading ? (
-        <div className="flex flex-col gap-2 px-6 py-4">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <Skeleton key={i} className="h-10 w-full" />
-          ))}
-        </div>
-      ) : !groups.length ? (
-        <div className="px-6 py-8 text-center">
-          <Text className="text-ui-fg-subtle">No groups yet. Create one to get started.</Text>
-        </div>
-      ) : (
-        <Table>
-          <Table.Header>
-            <Table.Row>
-              <Table.HeaderCell>Name</Table.HeaderCell>
-              <Table.HeaderCell>Composition</Table.HeaderCell>
-              <Table.HeaderCell>Colors</Table.HeaderCell>
-              <Table.HeaderCell>Status</Table.HeaderCell>
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            {groups.map((g) => (
-              <Table.Row
-                key={g.id}
-                className="cursor-pointer"
-                onClick={() => navigate(`/raw-material-groups/${g.id}`)}
-              >
-                <Table.Cell>{g.name}</Table.Cell>
-                <Table.Cell className="text-ui-fg-subtle">{g.composition || "—"}</Table.Cell>
-                <Table.Cell>{g.raw_materials?.length ?? 0}</Table.Cell>
-                <Table.Cell>
-                  <Badge size="small" color={g.status === "Active" ? "green" : "grey"}>
-                    {g.status || "Active"}
-                  </Badge>
-                </Table.Cell>
-              </Table.Row>
-            ))}
-          </Table.Body>
-        </Table>
-      )}
+      <DataTable instance={table}>
+        <DataTable.Toolbar className="flex items-center justify-between px-6 py-4">
+          <div>
+            <Heading level="h1">Material Groups</Heading>
+            <Text size="small" className="text-ui-fg-subtle">
+              Order a material in multiple colors without losing color identity.
+            </Text>
+          </div>
+          <div className="flex items-center gap-x-2">
+            <DataTable.Search placeholder="Search groups" />
+            <DataTable.FilterMenu tooltip="Filter groups" />
+            <CreateGroupModal />
+          </div>
+        </DataTable.Toolbar>
+        <DataTable.Table />
+        <DataTable.Pagination />
+      </DataTable>
     </Container>
   )
 }

--- a/apps/backend/src/admin/routes/raw-material-groups/page.tsx
+++ b/apps/backend/src/admin/routes/raw-material-groups/page.tsx
@@ -207,4 +207,9 @@ export const config = defineRouteConfig({
   nested: "/inventory",
 })
 
+// Parent crumb so the detail page reads "Material Groups > <name>".
+export const handle = {
+  breadcrumb: () => "Material Groups",
+}
+
 export default RawMaterialGroupsPage

--- a/apps/backend/src/api/admin/raw-material-groups/[id]/colors/full/route.ts
+++ b/apps/backend/src/api/admin/raw-material-groups/[id]/colors/full/route.ts
@@ -1,0 +1,62 @@
+/**
+ * API: /admin/raw-material-groups/:id/colors/full  (#817)
+ *
+ * POST — add a color capturing ALL material specs. Accepts the same
+ *        `{ rawMaterialData }` envelope the shared RawMaterialForm submits:
+ *        creates the inventory item, then runs createRawMaterialWorkflow with
+ *        `group_id` injected (link + SKU + material_type handling included).
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { createInventoryItemsWorkflow } from "@medusajs/medusa/core-flows"
+import { RAW_MATERIAL_MODULE } from "../../../../../../modules/raw_material"
+import { createRawMaterialWorkflow } from "../../../../../../workflows/raw-materials/create-raw-material"
+import { AddGroupColorFull } from "../../../validators"
+import { refetchRawMaterialGroup } from "../../../helpers"
+
+export const POST = async (
+  req: MedusaRequest<AddGroupColorFull>,
+  res: MedusaResponse
+) => {
+  const { id: groupId } = req.params
+  const rawMaterialData = { ...(req.validatedBody.rawMaterialData as any) }
+
+  const service: any = req.scope.resolve(RAW_MATERIAL_MODULE)
+  const group = await service.retrieveRawMaterialGroup(groupId).catch(() => null)
+  if (!group) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Raw material group with id "${groupId}" not found`
+    )
+  }
+
+  const title = rawMaterialData.name || `${group.name} — ${rawMaterialData.color}`
+
+  const { result: created } = await createInventoryItemsWorkflow(req.scope).run({
+    input: { items: [{ title }] },
+  })
+  const inventoryItem = ((created as any)?.items || (created as any) || [])[0]
+  if (!inventoryItem?.id) {
+    throw new MedusaError(
+      MedusaError.Types.UNEXPECTED_STATE,
+      "Failed to create inventory item for the color"
+    )
+  }
+
+  await createRawMaterialWorkflow(req.scope).run({
+    input: {
+      inventoryId: inventoryItem.id,
+      rawMaterialData: {
+        // Sensible defaults inherited from the group when omitted.
+        composition: group.composition ?? "",
+        unit_of_measure: group.unit_of_measure ?? "Other",
+        ...rawMaterialData,
+        name: title,
+        group_id: groupId,
+      },
+    },
+  })
+
+  const raw_material_group = await refetchRawMaterialGroup(groupId, req.scope)
+  res.status(201).json({ raw_material_group })
+}

--- a/apps/backend/src/api/admin/raw-material-groups/[id]/colors/full/route.ts
+++ b/apps/backend/src/api/admin/raw-material-groups/[id]/colors/full/route.ts
@@ -51,6 +51,9 @@ export const POST = async (
         composition: group.composition ?? "",
         unit_of_measure: group.unit_of_measure ?? "Other",
         ...rawMaterialData,
+        // `description` is required on the model; the spec form leaves it
+        // optional, so default it here (same as the quick-add /colors route).
+        description: rawMaterialData.description ?? "",
         name: title,
         group_id: groupId,
       },

--- a/apps/backend/src/api/admin/raw-material-groups/[id]/colors/link/route.ts
+++ b/apps/backend/src/api/admin/raw-material-groups/[id]/colors/link/route.ts
@@ -1,0 +1,36 @@
+/**
+ * API: /admin/raw-material-groups/:id/colors/link  (#817)
+ *
+ * POST — attach existing raw_materials to the group as colors by setting their
+ *        group_id. No new inventory items are created (they keep whatever stock
+ *        item they already have).
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { RAW_MATERIAL_MODULE } from "../../../../../../modules/raw_material"
+import { LinkGroupColors } from "../../../validators"
+import { refetchRawMaterialGroup } from "../../../helpers"
+
+export const POST = async (
+  req: MedusaRequest<LinkGroupColors>,
+  res: MedusaResponse
+) => {
+  const { id: groupId } = req.params
+  const { raw_material_ids } = req.validatedBody
+  const service: any = req.scope.resolve(RAW_MATERIAL_MODULE)
+
+  const group = await service.retrieveRawMaterialGroup(groupId).catch(() => null)
+  if (!group) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Raw material group with id "${groupId}" not found`
+    )
+  }
+
+  await service.updateRawMaterials(
+    raw_material_ids.map((id: string) => ({ id, group_id: groupId }))
+  )
+
+  const raw_material_group = await refetchRawMaterialGroup(groupId, req.scope)
+  res.status(200).json({ raw_material_group })
+}

--- a/apps/backend/src/api/admin/raw-material-groups/[id]/orders/route.ts
+++ b/apps/backend/src/api/admin/raw-material-groups/[id]/orders/route.ts
@@ -42,7 +42,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   }
 
   const { data: colors } = await query.graph({
-    entity: "raw_material",
+    entity: "raw_materials",
     fields: ["id"],
     filters: { group_id: groupId },
   })

--- a/apps/backend/src/api/admin/raw-material-groups/[id]/orders/route.ts
+++ b/apps/backend/src/api/admin/raw-material-groups/[id]/orders/route.ts
@@ -23,6 +23,55 @@ import {
 import { refetchInventoryOrder } from "../../../inventory-orders/helpers"
 import { CreateGroupOrder } from "../../validators"
 
+/**
+ * GET — list the inventory-order lines that belong to this group's colors,
+ * each with its parent order. Powers the group detail "Orders" section so a
+ * color's order history reads back without re-traversing links (S2 denorm).
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id: groupId } = req.params
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const service: any = req.scope.resolve(RAW_MATERIAL_MODULE)
+  const group = await service.retrieveRawMaterialGroup(groupId).catch(() => null)
+  if (!group) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Raw material group with id "${groupId}" not found`
+    )
+  }
+
+  const { data: colors } = await query.graph({
+    entity: "raw_material",
+    fields: ["id"],
+    filters: { group_id: groupId },
+  })
+  const rawMaterialIds = (colors as any[]).map((c) => c.id).filter(Boolean)
+
+  if (!rawMaterialIds.length) {
+    return res.json({ order_lines: [] })
+  }
+
+  const { data: lines } = await query.graph({
+    entity: "inventory_order_line",
+    fields: [
+      "id",
+      "quantity",
+      "price",
+      "color",
+      "material_name",
+      "raw_material_id",
+      "inventory_orders.id",
+      "inventory_orders.status",
+      "inventory_orders.order_date",
+      "inventory_orders.expected_delivery_date",
+    ],
+    filters: { raw_material_id: rawMaterialIds },
+  })
+
+  res.json({ order_lines: lines ?? [] })
+}
+
 export const POST = async (
   req: MedusaRequest<CreateGroupOrder>,
   res: MedusaResponse

--- a/apps/backend/src/api/admin/raw-material-groups/validators.ts
+++ b/apps/backend/src/api/admin/raw-material-groups/validators.ts
@@ -66,6 +66,24 @@ export const addGroupColorSchema = z.object({
 })
 export type AddGroupColor = z.infer<typeof addGroupColorSchema>
 
+// Full-detail color add: accepts the same `rawMaterialData` envelope the shared
+// RawMaterialForm submits (createRawMaterialWorkflow validates the shape), so a
+// color can be created with all material specs. `color` is required for a variant.
+export const addGroupColorFullSchema = z.object({
+  rawMaterialData: z
+    .object({ color: z.string().min(1, "Color is required") })
+    .passthrough(),
+})
+export type AddGroupColorFull = z.infer<typeof addGroupColorFullSchema>
+
+// Link existing raw_materials to a group as its colors.
+export const linkGroupColorsSchema = z.object({
+  raw_material_ids: z
+    .array(z.string().min(1))
+    .min(1, "At least one raw material is required"),
+})
+export type LinkGroupColors = z.infer<typeof linkGroupColorsSchema>
+
 // --- Order a group in multiple colors (fan-out) ---
 
 const groupOrderLineSchema = z.object({

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -101,7 +101,7 @@ import { updatePartnerMeSchema } from "./partners/me/validators";
 import { onboardingProfileUpdateSchema } from "./partners/onboarding-profile/validators";
 import { AdminGetPartnersParamsSchema } from "./admin/persons/partner/validators";
 import { createInventoryOrdersSchema, listInventoryOrdersQuerySchema, ReadSingleInventoryOrderQuerySchema, updateInventoryOrdersSchema, updateInventoryOrderLinesSchema } from "./admin/inventory-orders/validators";
-import { createRawMaterialGroupSchema, listRawMaterialGroupsQuerySchema, addGroupColorSchema, createGroupOrderSchema, readGroupQuerySchema } from "./admin/raw-material-groups/validators";
+import { createRawMaterialGroupSchema, listRawMaterialGroupsQuerySchema, addGroupColorSchema, addGroupColorFullSchema, linkGroupColorsSchema, createGroupOrderSchema, readGroupQuerySchema } from "./admin/raw-material-groups/validators";
 import { pinDesignGroupSchema, updateDesignGroupSchema } from "./admin/designs/[id]/material-groups/validators";
 // Import already defined above
 import { SendBlogSubscriptionSchema } from "./admin/websites/[id]/pages/[pageId]/subs/route";
@@ -2909,6 +2909,16 @@ export default defineMiddlewares({
       matcher: "/admin/raw-material-groups/:id/colors",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(addGroupColorSchema))],
+    },
+    {
+      matcher: "/admin/raw-material-groups/:id/colors/full",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(addGroupColorFullSchema))],
+    },
+    {
+      matcher: "/admin/raw-material-groups/:id/colors/link",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(linkGroupColorsSchema))],
     },
     {
       matcher: "/admin/raw-material-groups/:id/orders",


### PR DESCRIPTION
Polishes the #817 raw-material **Material Groups** admin UI to match core-admin conventions (mirrors the Collections detail pattern), plus folds in the #825 create-modal close fix.

## What changed

### Groups list → full Medusa `DataTable`
- `@medusajs/ui` `DataTable` with server-side **search**, **pagination**, and a **status filter**, and clickable rows — replacing the ad-hoc table.

### Group detail → breadcrumb + section-based layout
- Route `handle.breadcrumb` + `loader` so the group name shows in the admin breadcrumb.
- Three stacked sections (mirrors Collections detail):
  - **General** — name, composition, unit, material type, colors count, status badge.
  - **Colors** — per-color stock item (SKU + provisioned state), an **Add color** `ActionMenu` with three mechanisms, and **Order in colors** (fan-out).
  - **Orders** — every inventory-order line for the group's colors, **grouped by color**, with parent-order status/qty/date. Backed by new `GET /admin/raw-material-groups/:id/orders` (reads the S2 denormalized `color`/`raw_material_id` off order lines).

### Three ways to add a color
- **Quick add** (name + color) — existing `/colors` endpoint.
- **Full material spec** — reuses the shared `RawMaterialForm` in a new `mode="group"` (color surfaced in Basic Information; removed a duplicate buried color field). Route `/raw-material-groups/:id/colors/create` → `POST /colors/full` provisions the inventory item + runs `createRawMaterialWorkflow`.
- **Link an existing raw material** — searchable picker of *ungrouped* materials → `POST /colors/link` sets `group_id`.

### Bug fix (#825)
- Closing the create-raw-material modal now returns to `/inventory/:id` instead of the parent edit `RouteDrawer` (which rendered an empty form for a brand-new item).

## Verification
- `npx medusa build` green (backend + admin frontend).
- Playwright against local admin: list (DataTable, 4 rows), detail (breadcrumb + 3 sections, 0 console errors), Add-color menu (all 3 options), full-form route renders in group mode, Orders section shows real fan-out data.
- `GET /orders` returns 200 with real lines (fixed an entity-alias 500 — model is `raw_materials`).

Closes #825.

🤖 Generated with [Claude Code](https://claude.com/claude-code)