### PR TITLE
feat(designs): #826 collate designs into one order — lifecycle inline (partner + admin)

### DIFF
--- a/apps/backend/integration-tests/http/design-order-produce-fanout.spec.ts
+++ b/apps/backend/integration-tests/http/design-order-produce-fanout.spec.ts
@@ -1,4 +1,4 @@
-import { Modules } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import type { IRegionModuleService } from "@medusajs/types"
 import { createOrderWorkflow } from "@medusajs/medusa/core-flows"
 
@@ -107,9 +107,46 @@ setupSharedTestSuite(() => {
         expect(run.order_line_item_id).toBe(lineItemByDesign[run.design_id])
       }
 
-      // Idempotent: producing the same order again creates no duplicate runs.
+      // ── Collation (#826 S3a) ────────────────────────────────────────────
+      // The N runs fold into ONE kind=design work-order with a line per design.
+      expect(result.work_order_id).toBeTruthy()
+      const workOrderId = result.work_order_id!
+
+      const orderService: any = container.resolve(Modules.ORDER)
+      const workOrder = await orderService.retrieveOrder(workOrderId, {
+        relations: ["items"],
+      })
+      expect(workOrder.items).toHaveLength(designIds.length)
+      expect(workOrder.metadata?.collated_design_order).toBe(true)
+      expect(workOrder.metadata?.source_order_id).toBe(orderId)
+
+      // Every run links to that ONE work-order (order↔run is now 1:many).
+      const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+      const { data: linkRows } = await query.graph({
+        entity: "production_runs",
+        fields: ["id", "order.id"],
+        filters: { id: runs.map((r: any) => r.id) },
+      })
+      expect(linkRows).toHaveLength(designIds.length)
+      for (const r of linkRows as any[]) {
+        expect(r.order?.id).toBe(workOrderId)
+      }
+
+      // The work-order reads as kind=design: order.production_runs is the
+      // collated array of N runs.
+      const { data: wo } = await query.graph({
+        entity: "orders",
+        fields: ["id", "production_runs.id"],
+        filters: { id: workOrderId },
+      })
+      const linkedRunIds = (wo?.[0]?.production_runs || []).map((x: any) => x.id)
+      expect(linkedRunIds.sort()).toEqual(runs.map((r: any) => r.id).sort())
+
+      // Idempotent: producing the same order again creates no duplicate runs
+      // and resolves the SAME collated work-order (no second order).
       const again = await createRunsForDesignOrder(container, orderId)
       expect(again.created).toBe(0)
+      expect(again.work_order_id).toBe(workOrderId)
       const runsAfter = await runService.listProductionRuns({ order_id: [orderId] })
       expect(runsAfter).toHaveLength(designIds.length)
     })

--- a/apps/backend/integration-tests/http/design-order-produce-fanout.spec.ts
+++ b/apps/backend/integration-tests/http/design-order-produce-fanout.spec.ts
@@ -5,6 +5,7 @@ import { createOrderWorkflow } from "@medusajs/medusa/core-flows"
 import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
 import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
 import { createRunsForDesignOrder } from "../../src/workflows/designs/create-runs-for-design-order"
+import { mirrorRunStatusToUnifiedOrder } from "../../src/workflows/production-runs/dual-write-unified-run-order"
 import { PRODUCTION_RUNS_MODULE } from "../../src/modules/production_runs"
 
 jest.setTimeout(90 * 1000)
@@ -149,6 +150,69 @@ setupSharedTestSuite(() => {
       expect(again.work_order_id).toBe(workOrderId)
       const runsAfter = await runService.listProductionRuns({ order_id: [orderId] })
       expect(runsAfter).toHaveLength(designIds.length)
+    })
+
+    // #826 — the collated order's status is the ROLL-UP across all its runs, so
+    // a single run transition mirrors the aggregate, not just that one run.
+    it("aggregates the collated order status across ALL runs on each transition", async () => {
+      const container = getContainer()
+      const runService: any = container.resolve(PRODUCTION_RUNS_MODULE)
+      const orderService: any = container.resolve(Modules.ORDER)
+      const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+
+      // The runner rolls back per-`it` writes, so (re)produce the collated
+      // work-order + runs within this test.
+      const produce = await createRunsForDesignOrder(container, orderId)
+      const workOrderId = produce.work_order_id!
+      expect(workOrderId).toBeTruthy()
+
+      const runs = await runService.listProductionRuns(
+        { order_id: [orderId] },
+        { select: ["id", "status"] }
+      )
+      expect(runs).toHaveLength(2)
+      const [runA, runB] = runs
+
+      const readOrder = async () =>
+        orderService.retrieveOrder(workOrderId, { select: ["id", "status"] })
+      const readPartnerStatus = async () => {
+        const { data } = await query.graph({
+          entity: "order",
+          fields: ["id", "unified_order_status.partner_status"],
+          filters: { id: workOrderId },
+        })
+        return data?.[0]?.unified_order_status?.partner_status
+      }
+
+      // runA is further along (accepted) than runB (just assigned). The order's
+      // partner_status is the LEAST-advanced = "assigned", and core stays pending
+      // — the order isn't done until every run is.
+      await runService.updateProductionRuns([
+        { id: runA.id, status: "in_progress", accepted_at: new Date() },
+      ])
+      await runService.updateProductionRuns([
+        { id: runB.id, status: "sent_to_partner" },
+      ])
+      await mirrorRunStatusToUnifiedOrder(container, runA.id)
+
+      expect((await readOrder()).status).not.toBe("completed")
+      expect(await readPartnerStatus()).toBe("assigned")
+
+      // Complete only runA → order is STILL not completed (runB in-flight).
+      await runService.updateProductionRuns([
+        { id: runA.id, status: "completed", completed_at: new Date() },
+      ])
+      await mirrorRunStatusToUnifiedOrder(container, runA.id)
+      expect((await readOrder()).status).not.toBe("completed")
+
+      // Complete runB too → NOW every run is done, so the order rolls up to
+      // completed and partner_status to "completed".
+      await runService.updateProductionRuns([
+        { id: runB.id, status: "completed", completed_at: new Date() },
+      ])
+      await mirrorRunStatusToUnifiedOrder(container, runB.id)
+      expect((await readOrder()).status).toBe("completed")
+      expect(await readPartnerStatus()).toBe("completed")
     })
   })
 })

--- a/apps/backend/integration-tests/http/design-order-produce-fanout.spec.ts
+++ b/apps/backend/integration-tests/http/design-order-produce-fanout.spec.ts
@@ -1,0 +1,117 @@
+import { Modules } from "@medusajs/framework/utils"
+import type { IRegionModuleService } from "@medusajs/types"
+import { createOrderWorkflow } from "@medusajs/medusa/core-flows"
+
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { createRunsForDesignOrder } from "../../src/workflows/designs/create-runs-for-design-order"
+import { PRODUCTION_RUNS_MODULE } from "../../src/modules/production_runs"
+
+jest.setTimeout(90 * 1000)
+
+/**
+ * #826 S3 (step 1) — createRunsForDesignOrder fans out one production_run per
+ * design line item on a commissioning order, stamping order_id (the collation
+ * group key) + order_line_item_id + design_id, and is idempotent.
+ */
+setupSharedTestSuite(() => {
+  describe("#826 — produce a design order (per-line run fan-out)", () => {
+    let adminHeaders: { headers: Record<string, string> }
+    let regionId: string
+    let designIds: string[] = []
+    let orderId: string
+    let lineItemByDesign: Record<string, string> = {}
+
+    const { api, getContainer } = getSharedTestEnv()
+
+    beforeAll(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+
+      const regionsRes = await api.get("/admin/regions", adminHeaders)
+      if (regionsRes.data.regions?.length) {
+        regionId = regionsRes.data.regions[0].id
+      } else {
+        const regionService = container.resolve(
+          Modules.REGION
+        ) as IRegionModuleService
+        const region = await regionService.createRegions({
+          name: "Produce Fanout Region",
+          currency_code: "inr",
+          countries: ["in"],
+        })
+        regionId = region.id
+      }
+
+      const unique = Date.now()
+      for (let i = 0; i < 2; i++) {
+        const res = await api.post(
+          "/admin/designs",
+          {
+            name: `Produce Fanout Design ${unique}-${i}`,
+            description: "produce fan-out test",
+            design_type: "Original",
+            status: "Approved",
+            priority: "Medium",
+            estimated_cost: 100 + i * 40,
+          },
+          adminHeaders
+        )
+        expect(res.status).toBe(201)
+        designIds.push(res.data.design.id)
+      }
+
+      // A commissioning-style order: TITLE-ONLY line items, each carrying
+      // metadata.design_id (exactly what convert-design-order produces).
+      const { result: order }: any = await createOrderWorkflow(container).run({
+        input: {
+          is_draft_order: true,
+          status: "draft",
+          no_notification: true,
+          region_id: regionId,
+          currency_code: "inr",
+          items: designIds.map((design_id, i) => ({
+            title: `Design ${i}`,
+            quantity: i + 1,
+            unit_price: 100 + i * 40,
+            metadata: { design_id },
+          })) as any,
+          metadata: { source: "design-order-convert" },
+        } as any,
+      })
+      orderId = order.id
+      for (const li of order.items as any[]) {
+        lineItemByDesign[li.metadata.design_id] = li.id
+      }
+    })
+
+    it("creates one run per design line (stamped with order + line + design) and is idempotent", async () => {
+      const container = getContainer()
+
+      const result = await createRunsForDesignOrder(container, orderId)
+      expect(result.created).toBe(designIds.length)
+      expect(result.design_ids.sort()).toEqual([...designIds].sort())
+
+      const runService: any = container.resolve(PRODUCTION_RUNS_MODULE)
+      const runs = await runService.listProductionRuns(
+        { order_id: [orderId] },
+        { select: ["id", "design_id", "order_id", "order_line_item_id"] }
+      )
+      expect(runs).toHaveLength(designIds.length)
+
+      for (const run of runs) {
+        expect(run.order_id).toBe(orderId)
+        expect(designIds).toContain(run.design_id)
+        // The run points back at the exact commissioning line item for its design.
+        expect(run.order_line_item_id).toBe(lineItemByDesign[run.design_id])
+      }
+
+      // Idempotent: producing the same order again creates no duplicate runs.
+      const again = await createRunsForDesignOrder(container, orderId)
+      expect(again.created).toBe(0)
+      const runsAfter = await runService.listProductionRuns({ order_id: [orderId] })
+      expect(runsAfter).toHaveLength(designIds.length)
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/designs-collated-order-s1.spec.ts
+++ b/apps/backend/integration-tests/http/designs-collated-order-s1.spec.ts
@@ -1,0 +1,153 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { IRegionModuleService } from "@medusajs/types"
+
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { createTestCustomer } from "../helpers/create-customer"
+import { DESIGN_MODULE } from "../../src/modules/designs"
+import designLineItemLink from "../../src/links/design-line-item-link"
+
+jest.setTimeout(90 * 1000)
+
+/**
+ * #826 S1 — "Create Order" from the general Designs list.
+ *
+ * The admin selects N designs on the general list and creates ONE collated
+ * commissioning order (the grouping key the partner-side collation later keys
+ * on via run.order_id). This exercises the two backend behaviours S1 added/
+ * relies on:
+ *   1. GET /admin/designs enriches each design with its linked `customer_id`
+ *      (so the UI can auto-resolve a single customer for the selection).
+ *   2. POST /admin/customers/:id/design-order collates the selected designs
+ *      into one cart with one line item per design (already `design_ids[]`-native).
+ */
+setupSharedTestSuite(() => {
+  describe("#826 S1 — collated design order from the Designs list", () => {
+    let adminHeaders: { headers: Record<string, string> }
+    let customerId: string
+    let designIds: string[] = []
+
+    const { api, getContainer } = getSharedTestEnv()
+
+    beforeAll(async () => {
+      const container = getContainer()
+
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+
+      // A region is required for the draft-order/cart create.
+      const regionsRes = await api.get("/admin/regions", adminHeaders)
+      if (!regionsRes.data.regions?.length) {
+        const regionService = container.resolve(
+          Modules.REGION
+        ) as IRegionModuleService
+        await regionService.createRegions({
+          name: "S1 Test Region",
+          currency_code: "inr",
+          countries: ["in"],
+        })
+      }
+
+      const { customer } = await createTestCustomer(container)
+      customerId = customer.id
+
+      // Two commerce-ready designs, both linked to the SAME customer — the
+      // single-customer selection S1 supports.
+      const unique = Date.now()
+      for (let i = 0; i < 2; i++) {
+        const designRes = await api.post(
+          "/admin/designs",
+          {
+            name: `S1 Collated Design ${unique}-${i}`,
+            description: "S1 collated order test",
+            design_type: "Original",
+            status: "Commerce_Ready",
+            priority: "Medium",
+            estimated_cost: 100 + i * 50,
+          },
+          adminHeaders
+        )
+        expect(designRes.status).toBe(201)
+        const id = designRes.data.design.id
+        designIds.push(id)
+
+        const remoteLink = container.resolve(
+          ContainerRegistrationKeys.LINK
+        ) as any
+        await remoteLink.create({
+          [DESIGN_MODULE]: { design_id: id },
+          [Modules.CUSTOMER]: { customer_id: customerId },
+        })
+      }
+    })
+
+    it("enriches GET /admin/designs with each design's linked customer_id", async () => {
+      const res = await api.get("/admin/designs?limit=100", adminHeaders)
+      expect(res.status).toBe(200)
+
+      const byId: Record<string, any> = {}
+      for (const d of res.data.designs as any[]) {
+        byId[d.id] = d
+      }
+
+      for (const id of designIds) {
+        expect(byId[id]).toBeDefined()
+        // The enrichment attaches the linked customer so the list-level
+        // multi-select can auto-resolve a single customer.
+        expect(byId[id].customer_id).toBe(customerId)
+      }
+    })
+
+    it("previews all selected designs as line items in one estimate", async () => {
+      const res = await api.post(
+        `/admin/customers/${customerId}/design-order/preview`,
+        { design_ids: designIds },
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(Array.isArray(res.data.estimates)).toBe(true)
+      expect(res.data.estimates).toHaveLength(designIds.length)
+
+      const previewedDesignIds = (res.data.estimates as any[])
+        .map((e) => e.design_id)
+        .sort()
+      expect(previewedDesignIds).toEqual([...designIds].sort())
+    })
+
+    it("collates the selected designs into ONE order with a line per design", async () => {
+      const container = getContainer()
+      const res = await api.post(
+        `/admin/customers/${customerId}/design-order`,
+        { design_ids: designIds },
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.cart).toBeDefined()
+
+      const cart = res.data.cart
+      expect(res.data.checkout_url).toContain(cart.id)
+
+      // One cart (one order), one line item per selected design — the collation.
+      // The workflow returns the cart without its items relation hydrated, so
+      // read the persisted line items directly.
+      const cartService = container.resolve(Modules.CART) as any
+      const lineItems = await cartService.listLineItems(
+        { cart_id: [cart.id] },
+        { select: ["id"] }
+      )
+      expect(lineItems).toHaveLength(designIds.length)
+
+      // Each design is linked to exactly one of the cart's line items.
+      const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+      const { data: designLinks } = await query.graph({
+        entity: designLineItemLink.entryPoint,
+        filters: { line_item_id: lineItems.map((li: any) => li.id) },
+        fields: ["design_id"],
+      })
+      const linkedDesignIds = (designLinks as any[])
+        .map((l) => l.design_id)
+        .sort()
+      expect(linkedDesignIds).toEqual([...designIds].sort())
+    })
+  })
+})

--- a/apps/backend/integration-tests/http/designs-produce-no-customer.spec.ts
+++ b/apps/backend/integration-tests/http/designs-produce-no-customer.spec.ts
@@ -7,6 +7,7 @@ import { produceDesignsAsWorkOrder } from "../../src/workflows/designs/produce-d
 import { PRODUCTION_RUNS_MODULE } from "../../src/modules/production_runs"
 import { PARTNER_MODULE } from "../../src/modules/partner"
 import partnerOrderLink from "../../src/links/partner-order"
+import designPartnerLink from "../../src/links/design-partners-link"
 
 jest.setTimeout(90 * 1000)
 
@@ -132,6 +133,21 @@ setupSharedTestSuite(() => {
       })
       const partnerLinkIds = (partnerLinks ?? []).map((r: any) => r.partner_id)
       expect(partnerLinkIds).toContain(partnerId)
+
+      // design↔partner link per design — without it partner-ui design-details
+      // (`GET /partners/designs/:id`) 404s "Design not found for this partner"
+      // (the "nothing found" bug). Every produced design must be assigned.
+      const { data: designPartnerLinks } = await query.graph({
+        entity: designPartnerLink.entryPoint,
+        fields: ["design_id", "partner_id"],
+        filters: { partner_id: partnerId },
+      })
+      const assignedDesignIds = (designPartnerLinks ?? []).map(
+        (r: any) => r.design_id
+      )
+      for (const designId of designIds) {
+        expect(assignedDesignIds).toContain(designId)
+      }
     })
   })
 })

--- a/apps/backend/integration-tests/http/designs-produce-no-customer.spec.ts
+++ b/apps/backend/integration-tests/http/designs-produce-no-customer.spec.ts
@@ -1,0 +1,137 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { IRegionModuleService } from "@medusajs/types"
+
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { produceDesignsAsWorkOrder } from "../../src/workflows/designs/produce-designs-as-work-order"
+import { PRODUCTION_RUNS_MODULE } from "../../src/modules/production_runs"
+import { PARTNER_MODULE } from "../../src/modules/partner"
+import partnerOrderLink from "../../src/links/partner-order"
+
+jest.setTimeout(90 * 1000)
+
+/**
+ * #826 — produceDesignsAsWorkOrder is the "Send to Production" path from the
+ * designs list: pick N designs + a partner → one production run per design (born
+ * sent_to_partner, NO commissioning order) collated into ONE kind=design
+ * work-order the partner sees. The design analog of an inventory order, with no
+ * customer/sale attached.
+ */
+setupSharedTestSuite(() => {
+  describe("#826 — send designs to production (no customer)", () => {
+    let adminHeaders: { headers: Record<string, string> }
+    let regionId: string
+    let designIds: string[] = []
+    let partnerId: string
+
+    const { api, getContainer } = getSharedTestEnv()
+
+    beforeAll(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+
+      const regionsRes = await api.get("/admin/regions", adminHeaders)
+      if (regionsRes.data.regions?.length) {
+        regionId = regionsRes.data.regions[0].id
+      } else {
+        const regionService = container.resolve(
+          Modules.REGION
+        ) as IRegionModuleService
+        const region = await regionService.createRegions({
+          name: "Produce No-Customer Region",
+          currency_code: "inr",
+          countries: ["in"],
+        })
+        regionId = region.id
+      }
+
+      const partnerService: any = container.resolve(PARTNER_MODULE)
+      const unique = Date.now()
+      const partner = await partnerService.createPartners({
+        name: `Produce NoCust Partner ${unique}`,
+        handle: `produce-nocust-${unique}`,
+      })
+      partnerId = partner.id
+
+      for (let i = 0; i < 3; i++) {
+        const res = await api.post(
+          "/admin/designs",
+          {
+            name: `Produce NoCust Design ${unique}-${i}`,
+            description: "produce no-customer test",
+            design_type: "Original",
+            status: "Approved",
+            priority: "Medium",
+            estimated_cost: 100 + i * 40,
+          },
+          adminHeaders
+        )
+        expect(res.status).toBe(201)
+        designIds.push(res.data.design.id)
+      }
+    })
+
+    it("creates one partner-facing run per design and collates them into ONE work-order (no commissioning order)", async () => {
+      const container = getContainer()
+
+      const result = await produceDesignsAsWorkOrder(
+        container,
+        designIds,
+        partnerId
+      )
+      expect(result.created).toBe(designIds.length)
+      expect(result.design_ids.sort()).toEqual([...designIds].sort())
+      expect(result.work_order_id).toBeTruthy()
+      const workOrderId = result.work_order_id!
+
+      // Each run is partner-facing (sent_to_partner) and carries NO commissioning
+      // order_id (there is no sale) — that's the whole point of this path.
+      const runService: any = container.resolve(PRODUCTION_RUNS_MODULE)
+      const runs = await runService.listProductionRuns(
+        { id: result.run_ids },
+        { select: ["id", "design_id", "order_id", "partner_id", "status"] }
+      )
+      expect(runs).toHaveLength(designIds.length)
+      for (const run of runs) {
+        expect(designIds).toContain(run.design_id)
+        expect(run.partner_id).toBe(partnerId)
+        expect(run.status).toBe("sent_to_partner")
+        expect(run.order_id).toBeFalsy()
+      }
+
+      // The collated work-order: N lines, kind=design, and explicitly no source
+      // (commissioning) order.
+      const orderService: any = container.resolve(Modules.ORDER)
+      const workOrder = await orderService.retrieveOrder(workOrderId, {
+        relations: ["items"],
+      })
+      expect(workOrder.items).toHaveLength(designIds.length)
+      expect(workOrder.metadata?.collated_design_order).toBe(true)
+      expect(workOrder.metadata?.source_order_id).toBeNull()
+
+      // order↔run 1:many — all runs link to that ONE work-order.
+      const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+      const { data: wo } = await query.graph({
+        entity: "orders",
+        fields: ["id", "production_runs.id"],
+        filters: { id: workOrderId },
+      })
+      const linkedRunIds = (wo?.[0]?.production_runs || []).map((x: any) => x.id)
+      expect(linkedRunIds.sort()).toEqual(
+        [...result.run_ids].sort()
+      )
+
+      // partner↔order (D3) — the committed partner can see the work-order. Read
+      // the link table directly by entryPoint (the source of truth, same as
+      // list-partner-orders), not via a graph accessor.
+      const { data: partnerLinks } = await query.graph({
+        entity: partnerOrderLink.entryPoint,
+        fields: ["partner_id", "order_id"],
+        filters: { order_id: workOrderId },
+      })
+      const partnerLinkIds = (partnerLinks ?? []).map((r: any) => r.partner_id)
+      expect(partnerLinkIds).toContain(partnerId)
+    })
+  })
+})

--- a/apps/backend/src/admin/components/designs/design-order-production-section.tsx
+++ b/apps/backend/src/admin/components/designs/design-order-production-section.tsx
@@ -1,22 +1,16 @@
 import {
   Badge,
-  Button,
   Container,
   Heading,
   StatusBadge,
   Text,
   clx,
-  toast,
-  usePrompt,
 } from "@medusajs/ui"
-import { ArrowRightMini, PencilSquare, XCircle } from "@medusajs/icons"
+import { ArrowRightMini, ArrowUpRightOnBox, PencilSquare } from "@medusajs/icons"
 import { Link } from "react-router-dom"
 
 import { ActionMenu } from "../../components/common/action-menu"
-import {
-  useProductionRuns,
-  useCancelProductionRun,
-} from "../../hooks/api/production-runs"
+import { useProductionRuns } from "../../hooks/api/production-runs"
 import { usePartners } from "../../hooks/api/partners"
 
 // ── Lifecycle helpers ────────────────────────────────────────────────
@@ -139,12 +133,7 @@ const RunCard = ({
   partnerName?: string | null
   currencyCode?: string
 }) => {
-  const prompt = usePrompt()
-  const { mutateAsync: cancel, isPending: isCanceling } =
-    useCancelProductionRun(String(run.id))
-
   const status = String(run.status || "")
-  const isTerminal = status === "completed" || status === "cancelled"
   const title = design?.name || run?.snapshot?.design?.name || `Design ${run.design_id}`
   const nextStep = partnerNextStep(run)
   const targetDate = fmtDate(design?.target_completion_date)
@@ -152,23 +141,6 @@ const RunCard = ({
     run?.partner_cost_estimate ?? design?.estimated_cost,
     (design as any)?.cost_currency ?? currencyCode
   )
-
-  const handleCancel = async () => {
-    const confirmed = await prompt({
-      title: "Cancel production run?",
-      description: `Cancel the run for "${title}"? The partner can no longer act on it.`,
-      confirmText: "Cancel run",
-      cancelText: "Go back",
-    })
-    if (!confirmed) return
-    await cancel(
-      {},
-      {
-        onSuccess: () => toast.success(`Run for "${title}" cancelled`),
-        onError: (e) => toast.error(e.message),
-      }
-    )
-  }
 
   return (
     <div
@@ -211,26 +183,23 @@ const RunCard = ({
             {` · ${partnerName ? partnerName : "Unassigned"}`}
           </Text>
         </div>
+        {/* Lifecycle actions (approve / dispatch / cost / cancel / tasks) live on
+            the canonical run page — link there instead of duplicating them. */}
         <ActionMenu
           groups={[
             {
               actions: [
+                {
+                  label: "Manage run",
+                  icon: <ArrowUpRightOnBox />,
+                  to: `/production-runs/${run.id}`,
+                },
                 ...(design?.id
                   ? [
                       {
                         label: "View design",
                         icon: <PencilSquare />,
                         to: `/designs/${design.id}`,
-                      },
-                    ]
-                  : []),
-                ...(!isTerminal
-                  ? [
-                      {
-                        label: isCanceling ? "Cancelling…" : "Cancel run",
-                        icon: <XCircle />,
-                        onClick: handleCancel,
-                        disabled: isCanceling,
                       },
                     ]
                   : []),

--- a/apps/backend/src/admin/components/designs/design-order-production-section.tsx
+++ b/apps/backend/src/admin/components/designs/design-order-production-section.tsx
@@ -1,0 +1,340 @@
+import {
+  Badge,
+  Button,
+  Container,
+  Heading,
+  StatusBadge,
+  Text,
+  clx,
+  toast,
+  usePrompt,
+} from "@medusajs/ui"
+import { ArrowRightMini, PencilSquare, XCircle } from "@medusajs/icons"
+import { Link } from "react-router-dom"
+
+import { ActionMenu } from "../../components/common/action-menu"
+import {
+  useProductionRuns,
+  useCancelProductionRun,
+} from "../../hooks/api/production-runs"
+import { usePartners } from "../../hooks/api/partners"
+
+// ── Lifecycle helpers ────────────────────────────────────────────────
+
+const STEPS = ["Received", "Accepted", "Started", "Finished", "Completed"]
+
+const stepIndex = (run: any): number => {
+  const s = String(run?.status || "")
+  if (run?.completed_at || s === "completed") return 4
+  if (run?.finished_at) return 3
+  if (run?.started_at || s === "in_progress") return 2
+  if (run?.accepted_at) return 1
+  return 0
+}
+
+const runStatusColor = (
+  status: string
+): "green" | "orange" | "red" | "blue" | "grey" => {
+  switch (status) {
+    case "completed":
+      return "green"
+    case "in_progress":
+      return "orange"
+    case "sent_to_partner":
+      return "blue"
+    case "cancelled":
+      return "red"
+    default:
+      return "grey"
+  }
+}
+
+/** What's happening right now, admin-facing. */
+const adminStatusHint = (run: any): string => {
+  const s = String(run?.status || "")
+  if (s === "completed") return "Completed"
+  if (s === "cancelled") return "Cancelled"
+  if (s === "in_progress") {
+    if (run.finished_at) return "Finished — awaiting completion"
+    if (run.started_at) return "Partner is producing"
+    if (run.accepted_at) return "Accepted — not started"
+    return "In progress"
+  }
+  if (s === "sent_to_partner") return "Sent — awaiting acceptance"
+  return "Not sent to a partner yet"
+}
+
+/** The partner's NEXT step in the lifecycle ("up ahead"), or null when none. */
+const partnerNextStep = (run: any): string | null => {
+  const s = String(run?.status || "")
+  if (s === "sent_to_partner") return "Accept the run"
+  if (s === "in_progress") {
+    if (run.finished_at) return "Complete with output + cost"
+    if (run.started_at) return "Mark finished"
+    if (run.accepted_at) return "Start working"
+    return "Start working"
+  }
+  return null
+}
+
+const fmtDate = (date?: string | null) =>
+  date
+    ? new Date(date).toLocaleDateString("en-IN", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      })
+    : null
+
+const fmtCost = (cost?: number | null, currency?: string | null) => {
+  if (cost == null) return null
+  const cur = (currency || "").toUpperCase()
+  return cur ? `${cur} ${cost}` : String(cost)
+}
+
+// ── Compact progress stepper ─────────────────────────────────────────
+
+const MiniStepper = ({ run }: { run: any }) => {
+  if (String(run?.status) === "cancelled") return null
+  const idx = stepIndex(run)
+  return (
+    <div className="flex items-center gap-1">
+      {STEPS.map((label, i) => {
+        const done = i <= idx
+        return (
+          <div key={label} className="flex flex-1 flex-col items-center gap-1">
+            <div
+              className={clx("h-1.5 w-full rounded-full", {
+                "bg-ui-fg-interactive": done,
+                "bg-ui-border-base": !done,
+              })}
+            />
+            <Text
+              size="xsmall"
+              className={clx({
+                "text-ui-fg-base font-medium": i === idx,
+                "text-ui-fg-subtle": done && i !== idx,
+                "text-ui-fg-muted": !done,
+              })}
+            >
+              {label}
+            </Text>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+// ── Per-design run card ──────────────────────────────────────────────
+
+const RunCard = ({
+  run,
+  design,
+  partnerName,
+  currencyCode,
+}: {
+  run: any
+  design?: any
+  partnerName?: string | null
+  currencyCode?: string
+}) => {
+  const prompt = usePrompt()
+  const { mutateAsync: cancel, isPending: isCanceling } =
+    useCancelProductionRun(String(run.id))
+
+  const status = String(run.status || "")
+  const isTerminal = status === "completed" || status === "cancelled"
+  const title = design?.name || run?.snapshot?.design?.name || `Design ${run.design_id}`
+  const nextStep = partnerNextStep(run)
+  const targetDate = fmtDate(design?.target_completion_date)
+  const cost = fmtCost(
+    run?.partner_cost_estimate ?? design?.estimated_cost,
+    (design as any)?.cost_currency ?? currencyCode
+  )
+
+  const handleCancel = async () => {
+    const confirmed = await prompt({
+      title: "Cancel production run?",
+      description: `Cancel the run for "${title}"? The partner can no longer act on it.`,
+      confirmText: "Cancel run",
+      cancelText: "Go back",
+    })
+    if (!confirmed) return
+    await cancel(
+      {},
+      {
+        onSuccess: () => toast.success(`Run for "${title}" cancelled`),
+        onError: (e) => toast.error(e.message),
+      }
+    )
+  }
+
+  return (
+    <div
+      className={clx("flex flex-col gap-y-3 px-6 py-4", {
+        "opacity-60": status === "cancelled",
+      })}
+    >
+      {/* Title row: design + key badges + actions */}
+      <div className="flex items-start justify-between gap-x-3">
+        <div className="flex min-w-0 flex-col gap-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            {design?.id ? (
+              <Link
+                to={`/designs/${design.id}`}
+                className="text-ui-fg-base hover:text-ui-fg-interactive"
+              >
+                <Text size="small" weight="plus" className="truncate">
+                  {title}
+                </Text>
+              </Link>
+            ) : (
+              <Text size="small" weight="plus" className="truncate">
+                {title}
+              </Text>
+            )}
+            {design?.design_type && (
+              <Badge size="2xsmall" color="grey">
+                {String(design.design_type)}
+              </Badge>
+            )}
+            <StatusBadge color={runStatusColor(status)}>
+              {status.replace(/_/g, " ")}
+            </StatusBadge>
+          </div>
+          {/* Important design details */}
+          <Text size="xsmall" className="text-ui-fg-subtle">
+            Qty {run.quantity ?? "—"}
+            {cost ? ` · ${cost}` : ""}
+            {targetDate ? ` · due ${targetDate}` : ""}
+            {` · ${partnerName ? partnerName : "Unassigned"}`}
+          </Text>
+        </div>
+        <ActionMenu
+          groups={[
+            {
+              actions: [
+                ...(design?.id
+                  ? [
+                      {
+                        label: "View design",
+                        icon: <PencilSquare />,
+                        to: `/designs/${design.id}`,
+                      },
+                    ]
+                  : []),
+                ...(!isTerminal
+                  ? [
+                      {
+                        label: isCanceling ? "Cancelling…" : "Cancel run",
+                        icon: <XCircle />,
+                        onClick: handleCancel,
+                        disabled: isCanceling,
+                      },
+                    ]
+                  : []),
+              ],
+            },
+          ]}
+        />
+      </div>
+
+      <MiniStepper run={run} />
+
+      {/* Now + what the partner will do next ("up ahead") */}
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+        <Text size="xsmall" className="text-ui-fg-subtle">
+          Now: <span className="text-ui-fg-base">{adminStatusHint(run)}</span>
+        </Text>
+        {nextStep && (
+          <div className="flex items-center gap-x-1">
+            <ArrowRightMini className="text-ui-fg-muted" />
+            <Text size="xsmall" className="text-ui-fg-subtle">
+              Partner's next:{" "}
+              <span className="text-ui-fg-base">{nextStep}</span>
+            </Text>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ── Section ──────────────────────────────────────────────────────────
+
+/**
+ * #826 — the admin mirror of the collated production lifecycle. Once a design
+ * order is produced, this lists every per-design run (fanned out from the ONE
+ * commissioning order) with its status, a progress stepper, the important design
+ * details, and — surfaced for the operator — what the PARTNER will do next.
+ */
+export const DesignOrderProductionSection = ({
+  designOrder,
+}: {
+  designOrder: any
+}) => {
+  const orderId = designOrder?.order?.id as string | undefined
+  const currencyCode = designOrder?.order?.currency_code || "inr"
+
+  const { production_runs = [], isLoading } = useProductionRuns(
+    { order_id: orderId, limit: 100 },
+    { enabled: !!orderId } as any
+  )
+
+  const hasRuns = production_runs.length > 0
+
+  // Design details map (this line + its siblings) to enrich each run.
+  const designById: Record<string, any> = {}
+  if (designOrder?.design?.id) designById[designOrder.design.id] = designOrder.design
+  for (const s of designOrder?.sibling_items ?? []) {
+    if (s?.design?.id) designById[s.design.id] = s.design
+  }
+
+  const partnerIds = Array.from(
+    new Set(production_runs.map((r: any) => r.partner_id).filter(Boolean))
+  )
+  const { partners = [] } = usePartners(
+    { limit: 200 },
+    { enabled: hasRuns && partnerIds.length > 0 } as any
+  )
+  const partnerNameById: Record<string, string> = {}
+  for (const p of partners as any[]) partnerNameById[p.id] = p.name
+
+  // Nothing produced yet → the Produce action lives in the Order section.
+  if (!orderId || (!isLoading && !hasRuns)) return null
+
+  // Sort: sample runs first is not meaningful here; keep created order.
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex items-center gap-x-2">
+          <Heading level="h2">Production</Heading>
+          {hasRuns && (
+            <Badge size="2xsmall" color="grey">
+              {production_runs.length}
+            </Badge>
+          )}
+        </div>
+      </div>
+
+      {isLoading && !hasRuns ? (
+        <div className="px-6 py-4">
+          <Text size="small" className="text-ui-fg-subtle">
+            Loading production…
+          </Text>
+        </div>
+      ) : (
+        production_runs.map((run: any) => (
+          <RunCard
+            key={String(run.id)}
+            run={run}
+            design={designById[run.design_id]}
+            partnerName={run.partner_id ? partnerNameById[run.partner_id] : null}
+            currencyCode={currencyCode}
+          />
+        ))
+      )}
+    </Container>
+  )
+}

--- a/apps/backend/src/admin/components/designs/send-to-production-drawer.tsx
+++ b/apps/backend/src/admin/components/designs/send-to-production-drawer.tsx
@@ -1,0 +1,232 @@
+import { useState, useMemo } from "react"
+import {
+  Badge,
+  Button,
+  Drawer,
+  Input,
+  Label,
+  Text,
+  toast,
+} from "@medusajs/ui"
+import { useNavigate } from "react-router-dom"
+import { AdminDesign } from "../../hooks/api/designs"
+import { usePartners, AdminPartner } from "../../hooks/api/partners"
+import { sdk } from "../../lib/config"
+import { useQueryClient } from "@tanstack/react-query"
+import { queryKeysFactory } from "../../lib/query-key-factory"
+
+const designQueryKeys = queryKeysFactory("designs" as const)
+
+interface ProduceDesignsResponse {
+  design_production: {
+    created: number
+    run_ids: string[]
+    design_ids: string[]
+    work_order_id: string | null
+  }
+}
+
+interface SendToProductionDrawerProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  selectedDesigns: AdminDesign[]
+  onComplete: () => void
+}
+
+/**
+ * #826 — "Send to Production" from the designs list, WITHOUT a customer/sale.
+ * Pick a partner → one production run per selected design, collated into ONE
+ * kind=design work-order the partner sees (the design analog of an inventory
+ * order). Backed by POST /admin/designs/produce.
+ */
+export const SendToProductionDrawer = ({
+  open,
+  onOpenChange,
+  selectedDesigns,
+  onComplete,
+}: SendToProductionDrawerProps) => {
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+  const { partners = [] } = usePartners({ limit: 100, offset: 0 })
+
+  const [search, setSearch] = useState("")
+  const [selectedPartnerId, setSelectedPartnerId] = useState("")
+  const [isSending, setIsSending] = useState(false)
+
+  const filteredPartners = useMemo(() => {
+    if (!search) return partners
+    const q = search.toLowerCase()
+    return partners.filter(
+      (p: AdminPartner) =>
+        p.name?.toLowerCase().includes(q) ||
+        p.handle?.toLowerCase().includes(q)
+    )
+  }, [partners, search])
+
+  const selectedPartner = partners.find(
+    (p: AdminPartner) => p.id === selectedPartnerId
+  )
+
+  const handleSubmit = async () => {
+    if (!selectedPartnerId) {
+      toast.error("Please select a partner")
+      return
+    }
+
+    setIsSending(true)
+    try {
+      const { design_production } =
+        await sdk.client.fetch<ProduceDesignsResponse>(
+          `/admin/designs/produce`,
+          {
+            method: "POST",
+            body: {
+              design_ids: selectedDesigns.map((d) => d.id),
+              partner_id: selectedPartnerId,
+            },
+          }
+        )
+
+      queryClient.invalidateQueries({ queryKey: designQueryKeys.lists() })
+      toast.success(
+        `Sent ${design_production.created} design${
+          design_production.created > 1 ? "s" : ""
+        } to ${selectedPartner?.name || "partner"}`,
+        {
+          description: design_production.work_order_id
+            ? "One work-order created — open it to track production."
+            : undefined,
+          action: design_production.work_order_id
+            ? {
+                label: "View work-order",
+                altText: "View the created work-order",
+                onClick: () =>
+                  navigate(`/orders/${design_production.work_order_id}`),
+              }
+            : undefined,
+        }
+      )
+      handleClose()
+      onComplete()
+    } catch (err: any) {
+      toast.error("Failed to send to production", {
+        description: err?.message || "An unexpected error occurred.",
+      })
+    } finally {
+      setIsSending(false)
+    }
+  }
+
+  const handleClose = () => {
+    if (isSending) return
+    setSelectedPartnerId("")
+    setSearch("")
+    onOpenChange(false)
+  }
+
+  return (
+    <Drawer open={open} onOpenChange={handleClose}>
+      <Drawer.Content>
+        <Drawer.Header>
+          <Drawer.Title>Send to Production</Drawer.Title>
+          <Drawer.Description>
+            Hand {selectedDesigns.length} design
+            {selectedDesigns.length > 1 ? "s" : ""} to a partner as ONE
+            work-order — no customer or sale required.
+          </Drawer.Description>
+        </Drawer.Header>
+        <Drawer.Body className="flex flex-col gap-y-4 overflow-y-auto">
+          <div>
+            <Text size="small" weight="plus" className="text-ui-fg-subtle mb-2">
+              Selected Designs
+            </Text>
+            <div className="flex flex-wrap gap-1.5">
+              {selectedDesigns.map((d) => (
+                <Badge key={d.id} size="2xsmall" color="blue">
+                  {d.name || d.id}
+                </Badge>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <Label className="mb-1.5">Select Partner</Label>
+            <Input
+              placeholder="Search partners..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="mb-2"
+            />
+            <div className="flex flex-col gap-1.5 max-h-[300px] overflow-y-auto">
+              {filteredPartners.length === 0 ? (
+                <Text size="small" className="text-ui-fg-subtle py-4 text-center">
+                  No partners found
+                </Text>
+              ) : (
+                filteredPartners.map((partner: AdminPartner) => (
+                  <button
+                    key={partner.id}
+                    type="button"
+                    onClick={() => setSelectedPartnerId(partner.id)}
+                    className={`flex items-center gap-3 rounded-md px-3 py-2.5 text-left transition-colors ${
+                      selectedPartnerId === partner.id
+                        ? "bg-ui-bg-interactive text-ui-fg-on-color"
+                        : "bg-ui-bg-component hover:bg-ui-bg-component-hover text-ui-fg-base"
+                    }`}
+                  >
+                    <div className="flex flex-1 flex-col">
+                      <span className="text-sm font-medium">{partner.name}</span>
+                      <span
+                        className={`text-xs ${
+                          selectedPartnerId === partner.id
+                            ? "text-ui-fg-on-color/70"
+                            : "text-ui-fg-subtle"
+                        }`}
+                      >
+                        {partner.handle}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-1.5">
+                      {partner.is_verified && (
+                        <Badge
+                          size="2xsmall"
+                          color={selectedPartnerId === partner.id ? "grey" : "green"}
+                        >
+                          verified
+                        </Badge>
+                      )}
+                      <Badge
+                        size="2xsmall"
+                        color={
+                          partner.status === "active"
+                            ? selectedPartnerId === partner.id
+                              ? "grey"
+                              : "green"
+                            : "orange"
+                        }
+                      >
+                        {partner.status}
+                      </Badge>
+                    </div>
+                  </button>
+                ))
+              )}
+            </div>
+          </div>
+        </Drawer.Body>
+        <Drawer.Footer>
+          <Button variant="secondary" onClick={handleClose} disabled={isSending}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={!selectedPartnerId || isSending}>
+            {isSending
+              ? "Sending..."
+              : `Send ${selectedDesigns.length} Design${
+                  selectedDesigns.length > 1 ? "s" : ""
+                } to Production`}
+          </Button>
+        </Drawer.Footer>
+      </Drawer.Content>
+    </Drawer>
+  )
+}

--- a/apps/backend/src/admin/hooks/api/design-orders.ts
+++ b/apps/backend/src/admin/hooks/api/design-orders.ts
@@ -266,6 +266,46 @@ export const useConvertDesignOrder = (
   });
 };
 
+// #826 S3a — produce a design order: fan out one production run per design line
+// and collate them into ONE kind=design work-order. Optional partner_id commits
+// the work (runs born sent_to_partner → the work-order is visible to that
+// partner). Idempotent.
+export interface ProduceDesignOrderPayload {
+  partner_id?: string;
+}
+export interface ProduceDesignOrderResponse {
+  design_order_production: {
+    created: number;
+    run_ids: string[];
+    design_ids: string[];
+    work_order_id: string | null;
+  };
+}
+export const useProduceDesignOrder = (
+  orderId: string,
+  options?: UseMutationOptions<
+    ProduceDesignOrderResponse,
+    FetchError,
+    ProduceDesignOrderPayload
+  >
+) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: ProduceDesignOrderPayload = {}) =>
+      sdk.client.fetch<ProduceDesignOrderResponse>(
+        `/admin/orders/${orderId}/design/produce`,
+        { method: "POST", body: payload }
+      ),
+    onSuccess: (...args) => {
+      queryClient.invalidateQueries({
+        queryKey: designOrdersQueryKeys.lists(),
+      });
+      options?.onSuccess?.(...args);
+    },
+    ...options,
+  });
+};
+
 export type ShiprocketRateOption = {
   courier_id?: string | number;
   courier_name?: string;

--- a/apps/backend/src/admin/routes/design-orders/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/design-orders/[id]/page.tsx
@@ -8,6 +8,7 @@ import {
   StatusBadge,
   Button,
   Input,
+  Select,
   toast,
   usePrompt,
   Skeleton,
@@ -30,10 +31,12 @@ import {
   useApproveDesign,
   useCancelDesignOrder,
   useConvertDesignOrder,
+  useProduceDesignOrder,
   useGenerateShiprocketLabel,
   useAttachShiprocketAwb,
   useShiprocketRates,
 } from "../../../hooks/api/design-orders"
+import { usePartners } from "../../../hooks/api/partners"
 import {
   PARTNER_STATUS_LABELS,
   getPartnerWorkStatus,
@@ -291,6 +294,36 @@ const OrderSection = ({
   const [selectedCourierId, setSelectedCourierId] = useState<
     string | number | null
   >(null)
+  // #826 S3a — produce (fan out per-design runs + collate into one work-order).
+  const { mutateAsync: produce, isPending: isProducing } =
+    useProduceDesignOrder(order?.id ?? "")
+  const [produceOpen, setProduceOpen] = useState(false)
+  const [selectedPartnerId, setSelectedPartnerId] = useState<string>("")
+  const { partners = [] } = usePartners(
+    { limit: 100 },
+    { enabled: produceOpen } as any
+  )
+
+  const handleProduce = async () => {
+    await produce(
+      { partner_id: selectedPartnerId || undefined },
+      {
+        onSuccess: (res) => {
+          const p = res.design_order_production
+          toast.success(
+            `Produced ${p.created} design${p.created === 1 ? "" : "s"} into one collated work-order`,
+            {
+              description: selectedPartnerId
+                ? "Assigned to the partner — visible in their Design Orders."
+                : "Assign a partner to make it visible in the partner portal.",
+            }
+          )
+          setProduceOpen(false)
+        },
+        onError: (e) => toast.error(e.message),
+      }
+    )
+  }
   const {
     data: ratesData,
     isLoading: isLoadingRates,
@@ -413,6 +446,12 @@ const OrderSection = ({
               ...(!isCanceled
                 ? [
                     {
+                      label: "Produce (collate to work-order)",
+                      icon: <SquareTwoStack />,
+                      onClick: () => setProduceOpen(true),
+                      disabled: isProducing,
+                    },
+                    {
                       label: "Choose courier & generate label",
                       icon: <HandTruck />,
                       onClick: () => setCourierOpen(true),
@@ -436,6 +475,53 @@ const OrderSection = ({
           }]}
         />
       </div>
+      {produceOpen && (
+        <div className="px-6 py-4 bg-ui-bg-subtle">
+          <div className="flex items-center justify-between mb-2">
+            <Text size="xsmall" className="text-ui-fg-subtle">
+              Fan out one production run per design and collate them into ONE
+              work-order. Pick a partner to assign the work (they'll see one
+              order with all designs); leave blank to collate unassigned.
+            </Text>
+            <Button
+              variant="transparent"
+              size="small"
+              onClick={() => setProduceOpen(false)}
+            >
+              Close
+            </Button>
+          </div>
+          <div className="flex items-end gap-2">
+            <div className="flex-1">
+              <Text size="xsmall" className="text-ui-fg-subtle mb-1">
+                Partner (optional)
+              </Text>
+              <Select
+                value={selectedPartnerId}
+                onValueChange={setSelectedPartnerId}
+              >
+                <Select.Trigger>
+                  <Select.Value placeholder="Unassigned" />
+                </Select.Trigger>
+                <Select.Content>
+                  {partners.map((p: any) => (
+                    <Select.Item key={p.id} value={p.id}>
+                      {p.name}
+                    </Select.Item>
+                  ))}
+                </Select.Content>
+              </Select>
+            </div>
+            <Button
+              size="small"
+              isLoading={isProducing}
+              onClick={handleProduce}
+            >
+              Produce
+            </Button>
+          </div>
+        </div>
+      )}
       {courierOpen && (
         <div className="px-6 py-4 bg-ui-bg-subtle">
           <div className="flex items-center justify-between mb-2">

--- a/apps/backend/src/admin/routes/design-orders/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/design-orders/[id]/page.tsx
@@ -42,6 +42,7 @@ import {
   getPartnerWorkStatus,
   getStatusBadgeColor,
 } from "../../../lib/work-status"
+import { DesignOrderProductionSection } from "../../../components/designs/design-order-production-section"
 
 // ─── Status helpers ─────────────────────────────────────────────────────────
 
@@ -828,6 +829,7 @@ const DesignOrderDetailPage = () => {
         <DesignOrderHeaderSection designOrder={designOrder} />
         <LineItemSection designOrder={designOrder} />
         <OrderSection designOrder={designOrder} lineItemId={id!} />
+        <DesignOrderProductionSection designOrder={designOrder} />
       </TwoColumnPage.Main>
       <TwoColumnPage.Sidebar>
         <CustomerSection designOrder={designOrder} />

--- a/apps/backend/src/admin/routes/designs/page.tsx
+++ b/apps/backend/src/admin/routes/designs/page.tsx
@@ -6,13 +6,14 @@ import {
   useDataTable,
   createDataTableFilterHelper,
   createDataTableColumnHelper,
-  createDataTableCommandHelper,
   DataTablePaginationState,
   DataTableFilteringState,
   DataTableRowSelectionState,
   Button,
   Badge,
   toast,
+  CommandBar,
+  Tooltip,
 } from "@medusajs/ui";
 import { Outlet, useNavigate, useSearchParams } from "react-router-dom";
 import { keepPreviousData } from "@tanstack/react-query";
@@ -23,7 +24,8 @@ import { BulkLinkPartnerDrawer } from "../../components/designs/bulk-link-partne
 import { BulkUpdateStatusDrawer } from "../../components/designs/bulk-update-status-drawer";
 import { BulkAssignTagsDrawer } from "../../components/designs/bulk-assign-tags-drawer";
 import { BulkDeleteDialog } from "../../components/designs/bulk-delete-dialog";
-import { useMemo, useState, useCallback, useEffect } from "react";
+import { SendToProductionDrawer } from "../../components/designs/send-to-production-drawer";
+import { useMemo, useState, useCallback, useEffect, Fragment } from "react";
 import { EntityActions } from "../../components/persons/personsActions";
 import { AdminDesign, useDesigns } from "../../hooks/api/designs";
 import { useDesignsTableColumns } from "../../hooks/columns/useDesignsTableColumns";
@@ -42,10 +44,14 @@ import type {
 } from "../../hooks/api/designs";
 const columnHelper = createDataTableColumnHelper<AdminDesign>();
 
-const commandHelper = createDataTableCommandHelper();
+// Plain command descriptors — the compact CommandBar below renders them (letter
+// badge + hover tooltip) and CommandBar.Command owns the keyboard shortcut, so
+// there's no need for the DataTable command helper / its (ctx) => action shape.
+type DesignCommand = { label: string; shortcut: string; action: () => void };
 
 const useCommands = (callbacks: {
   onCreateOrder: () => void
+  onSendToProduction: () => void
   onProductionRun: () => void
   onRecreate: () => void
   onEdit: () => void
@@ -54,54 +60,33 @@ const useCommands = (callbacks: {
   onUpdateStatus: () => void
   onDelete: () => void
   onRevise: () => void
-}) => {
+}): DesignCommand[] => {
   return [
     // #826 S1 — collate the selected designs into ONE customer order.
-    commandHelper.command({
-      label: "Create Order",
-      shortcut: "o",
-      action: callbacks.onCreateOrder,
-    }),
-    commandHelper.command({
+    { label: "Create Order", shortcut: "o", action: callbacks.onCreateOrder },
+    // #826 — collate the selected designs into ONE partner work-order with NO
+    // customer/sale (the "just make these" path).
+    {
+      label: "Send to Production",
+      shortcut: "g",
+      action: callbacks.onSendToProduction,
+    },
+    {
       label: "Run Production Run",
       shortcut: "p",
       action: callbacks.onProductionRun,
-    }),
-    commandHelper.command({
+    },
+    {
       label: "Re-Create for Production",
       shortcut: "r",
       action: callbacks.onRecreate,
-    }),
-    commandHelper.command({
-      label: "Edit Design",
-      shortcut: "e",
-      action: callbacks.onEdit,
-    }),
-    commandHelper.command({
-      label: "Link to Partner",
-      shortcut: "l",
-      action: callbacks.onLinkPartner,
-    }),
-    commandHelper.command({
-      label: "Assign Tags",
-      shortcut: "t",
-      action: callbacks.onAssignTags,
-    }),
-    commandHelper.command({
-      label: "Update Status",
-      shortcut: "s",
-      action: callbacks.onUpdateStatus,
-    }),
-    commandHelper.command({
-      label: "Delete",
-      shortcut: "d",
-      action: callbacks.onDelete,
-    }),
-    commandHelper.command({
-      label: "Revise Design",
-      shortcut: "v",
-      action: callbacks.onRevise,
-    }),
+    },
+    { label: "Edit Design", shortcut: "e", action: callbacks.onEdit },
+    { label: "Link to Partner", shortcut: "l", action: callbacks.onLinkPartner },
+    { label: "Assign Tags", shortcut: "t", action: callbacks.onAssignTags },
+    { label: "Update Status", shortcut: "s", action: callbacks.onUpdateStatus },
+    { label: "Delete", shortcut: "d", action: callbacks.onDelete },
+    { label: "Revise Design", shortcut: "v", action: callbacks.onRevise },
   ];
 };
 
@@ -171,6 +156,7 @@ const DesignsPage = () => {
   const [isUpdateStatusOpen, setIsUpdateStatusOpen] = useState(false);
   const [isAssignTagsOpen, setIsAssignTagsOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isSendToProductionOpen, setIsSendToProductionOpen] = useState(false);
   // #826 S1 — collated "Create Order" from the general Designs list.
   const [orderCustomerId, setOrderCustomerId] = useState<string | null>(null);
   const [orderDesignIds, setOrderDesignIds] = useState<string[]>([]);
@@ -573,6 +559,7 @@ const DesignsPage = () => {
 
   const commands = useCommands({
     onCreateOrder: () => handleCreateOrder(),
+    onSendToProduction: () => setIsSendToProductionOpen(true),
     onProductionRun: () => {
       if (selectedDesignIds.length === 1) {
         navigate(`/designs/${selectedDesignIds[0]}/production-run`)
@@ -611,7 +598,9 @@ const DesignsPage = () => {
     rowCount: count,
     isLoading,
     filters,
-    commands,
+    // NOTE: commands are rendered by the custom compact CommandBar below (letter
+    // badge + hover tooltip); it owns the keyboard shortcuts, so they are NOT
+    // passed here to avoid double registration.
     rowSelection: {
       state: rowSelection,
       onRowSelectionChange: setRowSelection,
@@ -791,8 +780,29 @@ const DesignsPage = () => {
         
         <DataTable.Table />
         <DataTable.Pagination />
-        <DataTable.CommandBar selectedLabel={(count) => `${count} selected`} />
       </DataTable>
+      {/* #826 — compact command bar: each action is just its shortcut letter;
+          hover reveals the full label. Owns its own keyboard shortcuts (the
+          DataTable's `commands` were removed to avoid double registration). */}
+      <CommandBar open={selectedDesignIds.length > 0}>
+        <CommandBar.Bar>
+          <CommandBar.Value>
+            {selectedDesignIds.length} selected
+          </CommandBar.Value>
+          {commands.map((cmd) => (
+            <Fragment key={cmd.shortcut}>
+              <CommandBar.Seperator />
+              <Tooltip content={cmd.label}>
+                <CommandBar.Command
+                  label=""
+                  shortcut={cmd.shortcut}
+                  action={cmd.action}
+                />
+              </Tooltip>
+            </Fragment>
+          ))}
+        </CommandBar.Bar>
+      </CommandBar>
     </Container>
     <Outlet></Outlet>
     {isSaveDialogOpen && (
@@ -846,6 +856,12 @@ const DesignsPage = () => {
         <BulkDeleteDialog
           open={isDeleteDialogOpen}
           onOpenChange={setIsDeleteDialogOpen}
+          selectedDesigns={selectedDesigns}
+          onComplete={clearSelection}
+        />
+        <SendToProductionDrawer
+          open={isSendToProductionOpen}
+          onOpenChange={setIsSendToProductionOpen}
           selectedDesigns={selectedDesigns}
           onComplete={clearSelection}
         />

--- a/apps/backend/src/admin/routes/designs/page.tsx
+++ b/apps/backend/src/admin/routes/designs/page.tsx
@@ -12,6 +12,7 @@ import {
   DataTableRowSelectionState,
   Button,
   Badge,
+  toast,
 } from "@medusajs/ui";
 import { Outlet, useNavigate, useSearchParams } from "react-router-dom";
 import { keepPreviousData } from "@tanstack/react-query";
@@ -33,11 +34,18 @@ import { SaveViewDialog } from "../../components/views/save-view-dialog";
 import { useViewConfigurationActions } from "../../hooks/use-view-configurations";
 import type { ViewConfiguration } from "../../hooks/api/views";
 import { usePartners } from "../../hooks/api/partners";
+import { sdk } from "../../lib/config";
+import { DesignOrderPreviewDrawer } from "../../components/designs/design-order-preview-drawer";
+import type {
+  PreviewDesignOrderResponse,
+  CreateDesignOrderResponse,
+} from "../../hooks/api/designs";
 const columnHelper = createDataTableColumnHelper<AdminDesign>();
 
 const commandHelper = createDataTableCommandHelper();
 
 const useCommands = (callbacks: {
+  onCreateOrder: () => void
   onProductionRun: () => void
   onRecreate: () => void
   onEdit: () => void
@@ -48,6 +56,12 @@ const useCommands = (callbacks: {
   onRevise: () => void
 }) => {
   return [
+    // #826 S1 — collate the selected designs into ONE customer order.
+    commandHelper.command({
+      label: "Create Order",
+      shortcut: "o",
+      action: callbacks.onCreateOrder,
+    }),
     commandHelper.command({
       label: "Run Production Run",
       shortcut: "p",
@@ -157,6 +171,13 @@ const DesignsPage = () => {
   const [isUpdateStatusOpen, setIsUpdateStatusOpen] = useState(false);
   const [isAssignTagsOpen, setIsAssignTagsOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  // #826 S1 — collated "Create Order" from the general Designs list.
+  const [orderCustomerId, setOrderCustomerId] = useState<string | null>(null);
+  const [orderDesignIds, setOrderDesignIds] = useState<string[]>([]);
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const [previewData, setPreviewData] = useState<PreviewDesignOrderResponse | null>(null);
+  const [isPreviewing, setIsPreviewing] = useState(false);
+  const [isCreatingOrder, setIsCreatingOrder] = useState(false);
 
   const {
     listViews,
@@ -551,6 +572,7 @@ const DesignsPage = () => {
   ) : null;
 
   const commands = useCommands({
+    onCreateOrder: () => handleCreateOrder(),
     onProductionRun: () => {
       if (selectedDesignIds.length === 1) {
         navigate(`/designs/${selectedDesignIds[0]}/production-run`)
@@ -613,6 +635,94 @@ const DesignsPage = () => {
   });
 
   const clearSelection = () => setRowSelection({});
+
+  // #826 S1 — collate the selected designs into ONE customer order.
+  // Option A: the order is the commissioning order; per-design production runs
+  // stay per-design downstream. Resolves the customer from the selected
+  // designs' customer link (enriched onto the list response); requires a single
+  // shared customer for now (picker fallback deferred).
+  const handleCreateOrder = async () => {
+    if (selectedDesigns.length === 0 || isPreviewing) return;
+
+    const customerIds = Array.from(
+      new Set(
+        selectedDesigns
+          .map((d) => (d as any).customer_id)
+          .filter((id): id is string => Boolean(id))
+      )
+    );
+
+    if (customerIds.length === 0) {
+      toast.error("No customer linked", {
+        description:
+          "The selected designs aren't linked to a customer. Link a customer first, then create the order.",
+      });
+      return;
+    }
+    if (customerIds.length > 1) {
+      toast.error("Multiple customers selected", {
+        description:
+          "An order collates designs for a single customer. Select designs that all belong to the same customer.",
+      });
+      return;
+    }
+
+    const customerId = customerIds[0];
+    const designIds = selectedDesigns.map((d) => d.id as string);
+
+    setOrderCustomerId(customerId);
+    setOrderDesignIds(designIds);
+    setIsPreviewing(true);
+    try {
+      const preview = await sdk.client.fetch<PreviewDesignOrderResponse>(
+        `/admin/customers/${customerId}/design-order/preview`,
+        { method: "POST", body: { design_ids: designIds } }
+      );
+      setPreviewData(preview);
+      setPreviewOpen(true);
+    } catch (err: any) {
+      toast.error("Failed to estimate order", {
+        description: err?.message || "An unexpected error occurred.",
+      });
+    } finally {
+      setIsPreviewing(false);
+    }
+  };
+
+  const handleConfirmOrder = async (
+    priceOverrides: Record<string, number>,
+    overrideCurrency?: string
+  ) => {
+    if (!orderCustomerId || orderDesignIds.length === 0) return;
+    setIsCreatingOrder(true);
+    try {
+      await sdk.client.fetch<CreateDesignOrderResponse>(
+        `/admin/customers/${orderCustomerId}/design-order`,
+        {
+          method: "POST",
+          body: {
+            design_ids: orderDesignIds,
+            price_overrides:
+              Object.keys(priceOverrides).length > 0 ? priceOverrides : undefined,
+            override_currency: overrideCurrency,
+          },
+        }
+      );
+      setPreviewOpen(false);
+      setPreviewData(null);
+      clearSelection();
+      toast.success("Checkout cart created", {
+        description:
+          "Share the checkout link with the customer to complete payment.",
+      });
+    } catch (err: any) {
+      toast.error("Failed to create order", {
+        description: err?.message || "An unexpected error occurred.",
+      });
+    } finally {
+      setIsCreatingOrder(false);
+    }
+  };
 
   if (isError) {
     throw error;
@@ -692,6 +802,18 @@ const DesignsPage = () => {
         editingView={editingView}
         onClose={handleDialogClose}
         onSaved={handleViewSaved}
+      />
+    )}
+
+    {previewData && (
+      <DesignOrderPreviewDrawer
+        open={previewOpen}
+        onOpenChange={setPreviewOpen}
+        estimates={previewData.estimates}
+        currencyCode={previewData.currency_code}
+        total={previewData.total}
+        onConfirm={handleConfirmOrder}
+        isConfirming={isCreatingOrder}
       />
     )}
 

--- a/apps/backend/src/api/admin/designs/orders/[lineItemId]/route.ts
+++ b/apps/backend/src/api/admin/designs/orders/[lineItemId]/route.ts
@@ -40,7 +40,7 @@ export async function GET(
       query.graph({
         entity: "design",
         filters: { id: designId },
-        fields: ["id", "name", "status", "description", "thumbnail_url", "estimated_cost", "design_type"],
+        fields: ["id", "name", "status", "description", "thumbnail_url", "estimated_cost", "design_type", "priority", "target_completion_date"],
       }),
       query.graph({
         entity: designCustomerLink.entryPoint,
@@ -207,7 +207,7 @@ export async function GET(
             const { data: siblingDesigns } = await query.graph({
               entity: "design",
               filters: { id: siblingDesignIds },
-              fields: ["id", "name", "status", "estimated_cost"],
+              fields: ["id", "name", "status", "estimated_cost", "design_type", "priority", "target_completion_date"],
             })
             const siblingDesignById: Record<string, any> = {}
             for (const d of siblingDesigns || []) siblingDesignById[d.id] = d

--- a/apps/backend/src/api/admin/designs/produce/route.ts
+++ b/apps/backend/src/api/admin/designs/produce/route.ts
@@ -1,0 +1,39 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { z } from "zod"
+import { produceDesignsAsWorkOrder } from "../../../../workflows/designs/produce-designs-as-work-order"
+
+/**
+ * POST /admin/designs/produce
+ *
+ * #826 — "send to production" straight from the designs list, WITHOUT a
+ * commissioning (sales) order. Pick N designs + a partner → one production run
+ * per design (born sent_to_partner) collated into ONE kind=design work-order.
+ *
+ * Contrast with POST /admin/orders/:id/design/produce, which fans runs out of a
+ * commissioning order's line items (there IS a customer/sale). This path is the
+ * no-customer analog for when the operator just wants a partner to make things.
+ */
+const ProduceBody = z.object({
+  design_ids: z.array(z.string()).min(1),
+  partner_id: z.string().min(1),
+})
+
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+): Promise<void> => {
+  const { design_ids, partner_id } = ProduceBody.parse(
+    (req.body as Record<string, unknown>) ?? {}
+  )
+
+  const result = await produceDesignsAsWorkOrder(
+    req.scope,
+    design_ids,
+    partner_id
+  )
+
+  res.status(200).json({ design_production: result })
+}

--- a/apps/backend/src/api/admin/designs/route.ts
+++ b/apps/backend/src/api/admin/designs/route.ts
@@ -300,8 +300,50 @@ export const GET = async (
 
     const { designs, count } = result;
 
+    // #826 S1 — attach each design's linked customer so the general Designs
+    // list can collate a multi-select "Create Order" for a single customer
+    // without an extra round-trip. One link query for the returned page only.
+    let designsWithCustomer = designs;
+    if (Array.isArray(designs) && designs.length > 0) {
+      try {
+        const query = req.scope.resolve(ContainerRegistrationKeys.QUERY);
+        const { data: customerLinks } = await query.graph({
+          entity: designCustomerLink.entryPoint,
+          filters: { design_id: designs.map((d: any) => d.id) },
+          fields: [
+            "design_id",
+            "customer_id",
+            "customer.email",
+            "customer.first_name",
+            "customer.last_name",
+          ],
+        });
+        const customerByDesignId: Record<string, any> = {};
+        for (const link of (customerLinks || []) as any[]) {
+          // First link wins if a design is linked to multiple customers.
+          if (!customerByDesignId[link.design_id]) {
+            customerByDesignId[link.design_id] = {
+              customer_id: link.customer_id,
+              customer: link.customer || null,
+            };
+          }
+        }
+        designsWithCustomer = designs.map((d: any) => ({
+          ...d,
+          customer_id: customerByDesignId[d.id]?.customer_id ?? null,
+          customer: customerByDesignId[d.id]?.customer ?? null,
+        }));
+      } catch (e) {
+        logger.warn(
+          `#826 customer enrichment failed, returning designs without customer: ${
+            e instanceof Error ? e.message : e
+          }`
+        );
+      }
+    }
+
     res.status(200).json({
-      designs,
+      designs: designsWithCustomer,
       count,
       offset: req.query.offset || 0,
       limit: req.query.limit || 10,

--- a/apps/backend/src/api/admin/orders/[id]/design/produce/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/design/produce/route.ts
@@ -1,0 +1,36 @@
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { z } from "zod"
+import { createRunsForDesignOrder } from "../../../../../../workflows/designs/create-runs-for-design-order"
+
+/**
+ * POST /admin/orders/:id/design/produce
+ *
+ * #826 S3a — produce a design commissioning order: fan out one production_run
+ * per design line item and COLLATE them into ONE kind=design work-order (a line
+ * per design), so the partner sees one order with many designs instead of N
+ * separate work-orders.
+ *
+ * Optional `partner_id` commits the work to a partner (runs are born
+ * sent_to_partner, so the collated work-order is scoped/visible to them).
+ * Idempotent — re-producing resolves the same work-order.
+ */
+const ProduceBody = z.object({
+  partner_id: z.string().optional(),
+})
+
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+): Promise<void> => {
+  const { id } = req.params
+  const { partner_id } = ProduceBody.parse(
+    (req.body as Record<string, unknown>) ?? {}
+  )
+
+  const result = await createRunsForDesignOrder(req.scope, id, { partner_id })
+
+  res.status(200).json({ design_order_production: result })
+}

--- a/apps/backend/src/api/admin/production-runs/route.ts
+++ b/apps/backend/src/api/admin/production-runs/route.ts
@@ -172,6 +172,11 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   if (q.design_id) {
     filters.design_id = q.design_id
   }
+  // #826 — filter by the commissioning order so the admin design-order detail
+  // can list all the per-design runs a produce fanned out for that one order.
+  if (q.order_id) {
+    filters.order_id = q.order_id
+  }
   if (q.status) {
     filters.status = q.status
   }

--- a/apps/backend/src/links/order-production-run.ts
+++ b/apps/backend/src/links/order-production-run.ts
@@ -32,6 +32,17 @@ export default defineLink(
   OrderModule.linkable.order,
   {
     linkable: ProductionRunsModule.linkable.productionRuns,
+    // #826 S3a — was 1:1 (one order per run). Now 1:many: ONE unified work-order
+    // COLLATES the N per-design runs of a commissioning order (grouped by
+    // run.order_id), the design analog of one inventory_order → N orderlines →
+    // one order. A run still belongs to at most one work-order (run side stays
+    // single), so the forward accessor (production_runs.order) is unchanged;
+    // only the reverse (order.production_runs) now returns an array. Existing
+    // readers already tolerate array-or-object (list-partner-orders `linked()`,
+    // both detail-route attaches, use-order-kind), and legacy_id keeps pointing
+    // at a run via order.metadata. Existing per-run work-orders (one run each)
+    // remain valid 1:many rows.
+    isList: true,
     filterable: ["id"],
     // adds the singular `production_run` alias to the INDEX (query.index) so the
     // admin retail anti-join can filter `production_run: { id: null }`. Does NOT

--- a/apps/backend/src/workflows/designs/create-runs-for-design-order.ts
+++ b/apps/backend/src/workflows/designs/create-runs-for-design-order.ts
@@ -3,6 +3,7 @@ import type { MedusaContainer } from "@medusajs/framework/types"
 import type { IOrderModuleService } from "@medusajs/types"
 
 import { createProductionRunWorkflow } from "../production-runs/create-production-run"
+import { projectDesignOrderToUnifiedOrder } from "../production-runs/dual-write-unified-run-order"
 import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
 import type ProductionRunService from "../../modules/production_runs/service"
 
@@ -31,7 +32,12 @@ export async function createRunsForDesignOrder(
   container: MedusaContainer,
   orderId: string,
   opts?: { partner_id?: string | null }
-): Promise<{ created: number; run_ids: string[]; design_ids: string[] }> {
+): Promise<{
+  created: number
+  run_ids: string[]
+  design_ids: string[]
+  work_order_id: string | null
+}> {
   const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
   const orderService = container.resolve(Modules.ORDER) as IOrderModuleService
   const runService = container.resolve(
@@ -75,6 +81,9 @@ export async function createRunsForDesignOrder(
           order_id: orderId,
           order_line_item_id: lineItemId,
           partner_id: opts?.partner_id ?? undefined,
+          // Collated into ONE work-order by projectDesignOrderToUnifiedOrder
+          // below — do NOT let each run mint its own per-run work-order.
+          skip_unified_projection: true,
           metadata: {
             source: "design-order-produce",
             source_order_id: orderId,
@@ -93,5 +102,15 @@ export async function createRunsForDesignOrder(
     }
   }
 
-  return { created: runIds.length, run_ids: runIds, design_ids: designIds }
+  // Collate the order's runs (the just-created ones + any pre-existing) into ONE
+  // kind=design work-order with a line per design (#826 S3a). Idempotent, so a
+  // re-produce that created nothing new still resolves the existing work-order.
+  const projection = await projectDesignOrderToUnifiedOrder(container, orderId)
+
+  return {
+    created: runIds.length,
+    run_ids: runIds,
+    design_ids: designIds,
+    work_order_id: projection.unified_order_id,
+  }
 }

--- a/apps/backend/src/workflows/designs/create-runs-for-design-order.ts
+++ b/apps/backend/src/workflows/designs/create-runs-for-design-order.ts
@@ -1,0 +1,97 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+import type { IOrderModuleService } from "@medusajs/types"
+
+import { createProductionRunWorkflow } from "../production-runs/create-production-run"
+import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
+import type ProductionRunService from "../../modules/production_runs/service"
+
+/**
+ * #826 S3 (step 1) — fan out one production_run per design line item on a
+ * commissioning order.
+ *
+ * A design commissioning order (created by createDraftOrderFromDesignsWorkflow +
+ * convert-design-order) carries one TITLE-ONLY line item per design, each with
+ * `metadata.design_id`. Auto-run-creation is DELIBERATELY off for these (the
+ * line items have no product_id precisely so order-placed skips them — see
+ * convert-design-order header). Producing a design order is therefore an
+ * explicit admin step: this function.
+ *
+ * Each run is stamped with `order_id` = the commissioning order and
+ * `order_line_item_id` = its design line. `order_id` is the group key the
+ * collated projection (#826 S3a) uses to fold N runs into ONE partner
+ * work-order — the design analog of inventory's one-order-many-lines shape.
+ *
+ * Idempotent: a line item that already has a run (matched on
+ * `order_line_item_id`, mirroring order-placed) is skipped. Shared as a plain
+ * function (like linkDesignsToOrder) so a route, subscriber or backfill can all
+ * reuse the exact traversal.
+ */
+export async function createRunsForDesignOrder(
+  container: MedusaContainer,
+  orderId: string,
+  opts?: { partner_id?: string | null }
+): Promise<{ created: number; run_ids: string[]; design_ids: string[] }> {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const orderService = container.resolve(Modules.ORDER) as IOrderModuleService
+  const runService = container.resolve(
+    PRODUCTION_RUNS_MODULE
+  ) as ProductionRunService
+
+  const order: any = await orderService.retrieveOrder(orderId, {
+    relations: ["items"],
+  })
+  const items: any[] = order?.items || []
+
+  // Idempotency: which line items already spawned a run. One authoritative
+  // (synchronous) read of the order's existing runs — filtering by
+  // `order_line_item_id` directly proved unreliable, but `order_id` is exact.
+  const existingRuns = await runService.listProductionRuns(
+    { order_id: [orderId] } as any,
+    { select: ["id", "order_line_item_id"] }
+  )
+  const alreadyProduced = new Set(
+    (existingRuns || [])
+      .map((r: any) => r.order_line_item_id)
+      .filter(Boolean) as string[]
+  )
+
+  const runIds: string[] = []
+  const designIds: string[] = []
+
+  for (const item of items) {
+    const lineItemId = item?.id
+    // Design lines are the title-only items carrying design_id in metadata.
+    const designId = item?.metadata?.design_id as string | undefined
+    if (!lineItemId || !designId || alreadyProduced.has(lineItemId)) {
+      continue
+    }
+
+    try {
+      const { result } = await createProductionRunWorkflow(container).run({
+        input: {
+          design_id: designId,
+          quantity: Number(item?.quantity) || 1,
+          order_id: orderId,
+          order_line_item_id: lineItemId,
+          partner_id: opts?.partner_id ?? undefined,
+          metadata: {
+            source: "design-order-produce",
+            source_order_id: orderId,
+          },
+        },
+      })
+      const run = (result as any)?.production_run ?? (result as any)?.run ?? result
+      if (run?.id) {
+        runIds.push(run.id)
+        designIds.push(designId)
+      }
+    } catch (e: any) {
+      logger.warn(
+        `[create-runs-for-design-order] run creation failed for line ${lineItemId} (design ${designId}) on order ${orderId}: ${e?.message}`
+      )
+    }
+  }
+
+  return { created: runIds.length, run_ids: runIds, design_ids: designIds }
+}

--- a/apps/backend/src/workflows/designs/create-runs-for-design-order.ts
+++ b/apps/backend/src/workflows/designs/create-runs-for-design-order.ts
@@ -81,6 +81,11 @@ export async function createRunsForDesignOrder(
           order_id: orderId,
           order_line_item_id: lineItemId,
           partner_id: opts?.partner_id ?? undefined,
+          // Producing a design order commits it to a partner, so the runs are
+          // born partner-facing (sent_to_partner) when a partner is assigned —
+          // that's the status the collated projection needs to create the
+          // partner↔order link (else the work-order is invisible to the partner).
+          ...(opts?.partner_id ? { status: "sent_to_partner" as const } : {}),
           // Collated into ONE work-order by projectDesignOrderToUnifiedOrder
           // below — do NOT let each run mint its own per-run work-order.
           skip_unified_projection: true,

--- a/apps/backend/src/workflows/designs/produce-designs-as-work-order.ts
+++ b/apps/backend/src/workflows/designs/produce-designs-as-work-order.ts
@@ -1,0 +1,94 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+
+import { createProductionRunWorkflow } from "../production-runs/create-production-run"
+import { collateRunsIntoWorkOrder } from "../production-runs/dual-write-unified-run-order"
+import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
+import type ProductionRunService from "../../modules/production_runs/service"
+
+/**
+ * #826 — "send to production" straight from the designs list, WITHOUT a
+ * commissioning (sales) order.
+ *
+ * The commissioning path (createRunsForDesignOrder) fans runs out of an order's
+ * design line items and keys collation on `order_id`. But an operator often just
+ * wants to hand N designs to a partner to make — there is no customer, no sale,
+ * no commissioning order. This function is that path: create one production run
+ * per design (partner-assigned, born `sent_to_partner`) and collate them into
+ * ONE kind=design work-order via the shared `collateRunsIntoWorkOrder` core.
+ *
+ * There is no group key to be idempotent against (no order), so every call
+ * creates a fresh batch — the caller (a one-shot admin action) owns that.
+ */
+export async function produceDesignsAsWorkOrder(
+  container: MedusaContainer,
+  designIds: string[],
+  partnerId: string
+): Promise<{
+  created: number
+  run_ids: string[]
+  design_ids: string[]
+  work_order_id: string | null
+}> {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const runService = container.resolve(
+    PRODUCTION_RUNS_MODULE
+  ) as ProductionRunService
+
+  const runIds: string[] = []
+  const producedDesignIds: string[] = []
+
+  for (const designId of designIds) {
+    if (!designId) {
+      continue
+    }
+    try {
+      const { result } = await createProductionRunWorkflow(container).run({
+        input: {
+          design_id: designId,
+          quantity: 1,
+          partner_id: partnerId,
+          // Committed to a partner up front → born partner-facing so the
+          // collated work-order gets its partner↔order link (else invisible).
+          status: "sent_to_partner" as const,
+          // Collated into ONE work-order below — don't mint a per-run order.
+          skip_unified_projection: true,
+          metadata: {
+            source: "designs-produce-no-customer",
+          },
+        },
+      })
+      const run = (result as any)?.production_run ?? (result as any)?.run ?? result
+      if (run?.id) {
+        runIds.push(run.id)
+        producedDesignIds.push(designId)
+      }
+    } catch (e: any) {
+      logger.warn(
+        `[produce-designs-as-work-order] run creation failed for design ${designId}: ${e?.message}`
+      )
+    }
+  }
+
+  if (!runIds.length) {
+    return { created: 0, run_ids: [], design_ids: [], work_order_id: null }
+  }
+
+  // Re-read the created runs with their snapshot (design name, cost) so the
+  // collated work-order lines are self-describing.
+  const runs = await runService.listProductionRuns(
+    { id: runIds } as any,
+    { select: ["*"] }
+  )
+
+  const projection = await collateRunsIntoWorkOrder(container, runs as any[], {
+    sourceOrderId: null,
+  })
+
+  return {
+    created: runIds.length,
+    run_ids: runIds,
+    design_ids: producedDesignIds,
+    work_order_id: projection.unified_order_id ?? null,
+  }
+}

--- a/apps/backend/src/workflows/production-runs/create-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/create-production-run.ts
@@ -58,6 +58,10 @@ export type CreateProductionRunInput = {
     | "cancelled"
   execution_mode?: "in_house" | "outsourced"
   sub_partner_id?: string | null
+  // #826 S3a — suppress the per-run unified-order projection. Design-order runs
+  // are collated into ONE work-order by the batch projection
+  // (projectDesignOrderToUnifiedOrder), so they must NOT each mint their own.
+  skip_unified_projection?: boolean
 }
 
 const fetchDesignSnapshotStep = createStep(
@@ -276,8 +280,12 @@ export const createProductionRunWorkflow = createWorkflow(
       })
     })
 
-    // #342 — best-effort projection onto a kind=design core order
-    dualWriteUnifiedRunOrderStep({ production_run_id: productionRunId })
+    // #342 — best-effort projection onto a kind=design core order. Skipped for
+    // design-order runs (#826 S3a): they're collated into one work-order by the
+    // batch projection instead of each minting their own.
+    when({ input }, (data) => !data.input.skip_unified_projection).then(() => {
+      dualWriteUnifiedRunOrderStep({ production_run_id: productionRunId })
+    })
 
     return new WorkflowResponse(run)
   }

--- a/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
+++ b/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
@@ -664,23 +664,54 @@ export const mirrorRunStatusToUnifiedOrder = async (
       return { linked: false, skipped: "no_unified_order" }
     }
 
-    // coreStatus/partnerStatus derive from `run` (read above, a different
-    // entity), so they're computed outside the unified-order lock.
-    const coreStatus = RUN_TO_CORE_STATUS[run.status]
-    const partnerStatus = deriveRunPartnerStatus(run, opts)
+    // Fetch the order's metadata + ALL its linked runs in one graph read. A
+    // COLLATED design work-order (#826) has N runs → 1 order, so its status is
+    // the roll-up across every run, not just the one that transitioned; a plain
+    // per-run order simply resolves to its own single run.
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const { data: orderRows } = await query.graph({
+      entity: "order",
+      fields: [
+        "id",
+        "metadata",
+        "production_runs.id",
+        "production_runs.status",
+        "production_runs.accepted_at",
+        "production_runs.started_at",
+        "production_runs.finished_at",
+      ],
+      filters: { id: unifiedOrderId },
+    })
+    const unifiedOrder = orderRows?.[0]
 
     // A parent order superseded by a run split stays canceled forever — the
     // child orders carry the commercial reality. `superseded_by_run_ids` is the
     // one metadata key still read here; it's write-once at approve, so this is a
     // plain read (PR-H retired the per-order metadata lock — partner_status now
     // lives on the sidecar column, which has no RMW to serialize).
-    const orderService: any = container.resolve(Modules.ORDER)
-    const unifiedOrder = await orderService.retrieveOrder(unifiedOrderId, {
-      select: ["id", "metadata"],
-    })
     if (unifiedOrder?.metadata?.superseded_by_run_ids) {
       return { linked: false, skipped: "superseded" }
     }
+
+    // #826 — coreStatus/partnerStatus for a COLLATED order aggregate across all
+    // its runs (least-advanced partner_status; completed/canceled only when
+    // every run is). A single-run order keeps the exact per-run mapping — the
+    // aggregate helpers deliberately don't model the draft/decline nuances the
+    // per-run path needs.
+    const linkedRuns: any[] = (unifiedOrder?.production_runs ?? []).filter(
+      Boolean
+    )
+    let coreStatus: string | undefined
+    let partnerStatus: string | undefined
+    if (linkedRuns.length > 1) {
+      coreStatus = aggregateCoreStatus(linkedRuns)
+      partnerStatus = aggregatePartnerStatus(linkedRuns)
+    } else {
+      coreStatus = RUN_TO_CORE_STATUS[run.status]
+      partnerStatus = deriveRunPartnerStatus(run, opts)
+    }
+
+    const orderService: any = container.resolve(Modules.ORDER)
 
     // core order.status — single-column blind write, no lock.
     if (coreStatus) {

--- a/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
+++ b/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
@@ -448,136 +448,155 @@ export const projectDesignOrderToUnifiedOrder = async (
       return { unified_order_id: already, skipped: "already_projected" }
     }
 
-    const { regionId, currencyCode } = await resolveRegionAndCurrency(container)
-    if (!regionId) {
-      logger.warn(
-        `[orders-unification] skipped collated design-order projection for ${commissioningOrderId}: no region exists`
-      )
-      return { unified_order_id: null, skipped: "no_region" }
-    }
-    const channel = await ensureWorkOrdersChannel(container)
-
-    // One line item per run — self-describing (design name + run pointer).
-    const items = runs.map((run) => {
-      const quantity = Number(run.quantity) || 1
-      const estimate = Number(run.partner_cost_estimate) || 0
-      const unitPrice =
-        run.cost_type === "per_unit"
-          ? estimate
-          : quantity > 0
-          ? estimate / quantity
-          : estimate
-      return {
-        title: run.snapshot?.design?.name ?? `Design ${run.design_id}`,
-        quantity,
-        unit_price: unitPrice,
-        metadata: {
-          design_id: run.design_id,
-          production_run_id: run.id,
-          cost_type: run.cost_type ?? null,
-          legacy_cost_estimate: run.partner_cost_estimate ?? null,
-        },
-      }
+    return await collateRunsIntoWorkOrder(container, runs, {
+      sourceOrderId: commissioningOrderId,
     })
-
-    const { result: unified }: any = await createOrderWorkflow(container).run({
-      input: {
-        region_id: regionId,
-        sales_channel_id: channel.id,
-        currency_code: currencyCode,
-        status: aggregateCoreStatus(runs) as any,
-        items: items as any,
-        metadata: {
-          // The commissioning order this collates (the group key).
-          source_order_id: commissioningOrderId,
-          collated_design_order: true,
-          production_run_ids: runs.map((r) => r.id),
-          // Keep a legacy_id pointer so use-order-kind consumers that read
-          // order.metadata.legacy_id still resolve a run (S3b renders N lines
-          // off the order items rather than this single pointer).
-          legacy_id: runs[0].id,
-          currency_assumed: true,
-        },
-      },
-    })
-
-    // order↔run for EACH run (1:many). First via the rollback path so the
-    // kind=design discriminator link exists-or-the-order-rolls-back; the rest
-    // best-effort (a stray link failure must not orphan the whole order).
-    await linkUnifiedOrderOrRollback(container, unified.id, {
-      [Modules.ORDER]: { order_id: unified.id },
-      [PRODUCTION_RUNS_MODULE]: { production_runs_id: runs[0].id },
-    })
-    const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
-    for (const run of runs.slice(1)) {
-      await remoteLink
-        .create([
-          {
-            [Modules.ORDER]: { order_id: unified.id },
-            [PRODUCTION_RUNS_MODULE]: { production_runs_id: run.id },
-          },
-        ])
-        .catch((e: any) =>
-          logger.warn(
-            `[orders-unification] collated order↔run link failed for run ${run.id}: ${e?.message}`
-          )
-        )
-    }
-
-    // design↔order per distinct design (reuse #29 design-order link infra).
-    const designIds = Array.from(
-      new Set(runs.map((r) => r.design_id).filter(Boolean))
-    )
-    for (const designId of designIds) {
-      await remoteLink
-        .create([
-          {
-            [DESIGN_MODULE]: { design_id: designId },
-            [Modules.ORDER]: { order_id: unified.id },
-          },
-        ])
-        .catch((e: any) =>
-          logger.warn(
-            `[orders-unification] collated design link failed for ${designId}: ${e?.message}`
-          )
-        )
-    }
-
-    // partner↔order (D3) per distinct partner among runs already at/past
-    // sent_to_partner (the partner is committed).
-    const partnerIds = Array.from(
-      new Set(
-        runs
-          .filter(
-            (r) =>
-              r.partner_id &&
-              ["sent_to_partner", "in_progress", "completed"].includes(r.status)
-          )
-          .map((r) => r.partner_id)
-      )
-    )
-    for (const partnerId of partnerIds) {
-      await createPartnerOrderLink(container, partnerId as string, unified.id)
-    }
-
-    // Aggregate partner_status onto the sidecar column (best-effort).
-    const partnerStatus = aggregatePartnerStatus(runs)
-    if (partnerStatus) {
-      await setUnifiedOrderPartnerStatus(container, unified.id, partnerStatus).catch(
-        (e: any) =>
-          logger.warn(
-            `[orders-unification] collated sidecar status write failed for ${unified.id}: ${e?.message}`
-          )
-      )
-    }
-
-    return { unified_order_id: unified.id, line_count: items.length }
   } catch (e: any) {
     logger.warn(
       `[orders-unification] collated design-order projection failed for ${commissioningOrderId}: ${e?.message}`
     )
     return { unified_order_id: null, error: e?.message }
   }
+}
+
+/**
+ * #826 — the shared core: given a set of production runs, create ONE collated
+ * kind=design work-order (a line per run/design) and wire all the links +
+ * aggregated status. Used by both the commissioning-order path
+ * (projectDesignOrderToUnifiedOrder) and the no-customer path
+ * (produceDesignsAsWorkOrder). `sourceOrderId` is the commissioning order when
+ * there is one (null for a direct produce).
+ */
+export const collateRunsIntoWorkOrder = async (
+  container: MedusaContainer,
+  runs: any[],
+  opts: { sourceOrderId?: string | null } = {}
+): Promise<CollatedProjectionResult> => {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const { regionId, currencyCode } = await resolveRegionAndCurrency(container)
+  if (!regionId) {
+    logger.warn(
+      `[orders-unification] skipped collated work-order: no region exists`
+    )
+    return { unified_order_id: null, skipped: "no_region" }
+  }
+  const channel = await ensureWorkOrdersChannel(container)
+
+  // One line item per run — self-describing (design name + run pointer).
+  const items = runs.map((run) => {
+    const quantity = Number(run.quantity) || 1
+    const estimate = Number(run.partner_cost_estimate) || 0
+    const unitPrice =
+      run.cost_type === "per_unit"
+        ? estimate
+        : quantity > 0
+        ? estimate / quantity
+        : estimate
+    return {
+      title: run.snapshot?.design?.name ?? `Design ${run.design_id}`,
+      quantity,
+      unit_price: unitPrice,
+      metadata: {
+        design_id: run.design_id,
+        production_run_id: run.id,
+        cost_type: run.cost_type ?? null,
+        legacy_cost_estimate: run.partner_cost_estimate ?? null,
+      },
+    }
+  })
+
+  const { result: unified }: any = await createOrderWorkflow(container).run({
+    input: {
+      region_id: regionId,
+      sales_channel_id: channel.id,
+      currency_code: currencyCode,
+      status: aggregateCoreStatus(runs) as any,
+      items: items as any,
+      metadata: {
+        // The commissioning order this collates (null for a direct produce).
+        source_order_id: opts.sourceOrderId ?? null,
+        collated_design_order: true,
+        production_run_ids: runs.map((r) => r.id),
+        // Keep a legacy_id pointer so use-order-kind consumers that read
+        // order.metadata.legacy_id still resolve a run (S3b renders N lines
+        // off the order items rather than this single pointer).
+        legacy_id: runs[0].id,
+        currency_assumed: true,
+      },
+    },
+  })
+
+  // order↔run for EACH run (1:many). First via the rollback path so the
+  // kind=design discriminator link exists-or-the-order-rolls-back; the rest
+  // best-effort (a stray link failure must not orphan the whole order).
+  await linkUnifiedOrderOrRollback(container, unified.id, {
+    [Modules.ORDER]: { order_id: unified.id },
+    [PRODUCTION_RUNS_MODULE]: { production_runs_id: runs[0].id },
+  })
+  const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+  for (const run of runs.slice(1)) {
+    await remoteLink
+      .create([
+        {
+          [Modules.ORDER]: { order_id: unified.id },
+          [PRODUCTION_RUNS_MODULE]: { production_runs_id: run.id },
+        },
+      ])
+      .catch((e: any) =>
+        logger.warn(
+          `[orders-unification] collated order↔run link failed for run ${run.id}: ${e?.message}`
+        )
+      )
+  }
+
+  // design↔order per distinct design (reuse #29 design-order link infra).
+  const designIds = Array.from(
+    new Set(runs.map((r) => r.design_id).filter(Boolean))
+  )
+  for (const designId of designIds) {
+    await remoteLink
+      .create([
+        {
+          [DESIGN_MODULE]: { design_id: designId },
+          [Modules.ORDER]: { order_id: unified.id },
+        },
+      ])
+      .catch((e: any) =>
+        logger.warn(
+          `[orders-unification] collated design link failed for ${designId}: ${e?.message}`
+        )
+      )
+  }
+
+  // partner↔order (D3) per distinct partner among runs already at/past
+  // sent_to_partner (the partner is committed).
+  const partnerIds = Array.from(
+    new Set(
+      runs
+        .filter(
+          (r) =>
+            r.partner_id &&
+            ["sent_to_partner", "in_progress", "completed"].includes(r.status)
+        )
+        .map((r) => r.partner_id)
+    )
+  )
+  for (const partnerId of partnerIds) {
+    await createPartnerOrderLink(container, partnerId as string, unified.id)
+  }
+
+  // Aggregate partner_status onto the sidecar column (best-effort).
+  const partnerStatus = aggregatePartnerStatus(runs)
+  if (partnerStatus) {
+    await setUnifiedOrderPartnerStatus(container, unified.id, partnerStatus).catch(
+      (e: any) =>
+        logger.warn(
+          `[orders-unification] collated sidecar status write failed for ${unified.id}: ${e?.message}`
+        )
+    )
+  }
+
+  return { unified_order_id: unified.id, line_count: items.length }
 }
 
 /**

--- a/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
+++ b/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
@@ -358,6 +358,228 @@ export const projectRunToUnifiedOrder = async (
   }
 }
 
+// #826 S3a — aggregate the core order.status for a COLLATED design work-order
+// from its N runs: completed iff every run completed, canceled iff every run
+// cancelled, else pending (in-flight). Deliberately conservative — a collated
+// order is "done" only when all its design lines are.
+const aggregateCoreStatus = (runs: any[]): string => {
+  const statuses = runs.map((r) => r.status)
+  if (statuses.length && statuses.every((s) => s === "completed")) return "completed"
+  if (statuses.length && statuses.every((s) => s === "cancelled")) return "canceled"
+  return "pending"
+}
+
+// #826 S3a — aggregate partner_status for a collated design work-order: the
+// LEAST-advanced non-empty per-run status along assigned→accepted→in_progress→
+// finished→completed (the order isn't "completed" until every line is).
+const PARTNER_STATUS_ORDER = [
+  "assigned",
+  "accepted",
+  "in_progress",
+  "finished",
+  "completed",
+]
+const aggregatePartnerStatus = (runs: any[]): string | undefined => {
+  const perRun = runs
+    .map((r) => deriveRunPartnerStatus(r))
+    .filter((s): s is string => Boolean(s))
+  if (!perRun.length) return undefined
+  let minIdx = PARTNER_STATUS_ORDER.length - 1
+  for (const s of perRun) {
+    const idx = PARTNER_STATUS_ORDER.indexOf(s)
+    if (idx >= 0 && idx < minIdx) minIdx = idx
+  }
+  return PARTNER_STATUS_ORDER[minIdx]
+}
+
+type CollatedProjectionResult = ProjectionResult & { line_count?: number }
+
+/**
+ * #826 S3a — project a design COMMISSIONING order's runs onto ONE collated
+ * kind=design work-order: N line items, one per run/design (the design analog
+ * of inventory's one-order → N-orderlines → one work-order projection). Grouped
+ * by `run.order_id` = the commissioning order. The per-run projection is
+ * suppressed for these runs (skip_unified_projection), so this is the SOLE
+ * projection and the order↔run link is 1:many (all N runs → this one order).
+ *
+ * Idempotent: if the order's runs already share a linked work-order, returns it.
+ * Best-effort like the per-run projection — never throws to the caller.
+ */
+export const projectDesignOrderToUnifiedOrder = async (
+  container: MedusaContainer,
+  commissioningOrderId: string
+): Promise<CollatedProjectionResult> => {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  try {
+    const runService: ProductionRunService =
+      container.resolve(PRODUCTION_RUNS_MODULE)
+    const runs: any[] = await runService.listProductionRuns(
+      { order_id: [commissioningOrderId] } as any,
+      {
+        select: [
+          "id",
+          "design_id",
+          "partner_id",
+          "quantity",
+          "status",
+          "cost_type",
+          "partner_cost_estimate",
+          "execution_mode",
+          "sub_partner_id",
+          "order_line_item_id",
+          "snapshot",
+        ],
+      }
+    )
+    if (!runs.length) {
+      return { unified_order_id: null, skipped: "no_runs" }
+    }
+
+    // Idempotency: any run already linked to a work-order → that IS the collated
+    // order (forward run→order link is authoritative). query.graph, never index.
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const { data: linkedRuns } = await query.graph({
+      entity: "production_runs",
+      fields: ["id", "order.id"],
+      filters: { id: runs.map((r) => r.id) },
+    })
+    const already = (linkedRuns || []).find((r: any) => r?.order?.id)?.order?.id
+    if (already) {
+      return { unified_order_id: already, skipped: "already_projected" }
+    }
+
+    const { regionId, currencyCode } = await resolveRegionAndCurrency(container)
+    if (!regionId) {
+      logger.warn(
+        `[orders-unification] skipped collated design-order projection for ${commissioningOrderId}: no region exists`
+      )
+      return { unified_order_id: null, skipped: "no_region" }
+    }
+    const channel = await ensureWorkOrdersChannel(container)
+
+    // One line item per run — self-describing (design name + run pointer).
+    const items = runs.map((run) => {
+      const quantity = Number(run.quantity) || 1
+      const estimate = Number(run.partner_cost_estimate) || 0
+      const unitPrice =
+        run.cost_type === "per_unit"
+          ? estimate
+          : quantity > 0
+          ? estimate / quantity
+          : estimate
+      return {
+        title: run.snapshot?.design?.name ?? `Design ${run.design_id}`,
+        quantity,
+        unit_price: unitPrice,
+        metadata: {
+          design_id: run.design_id,
+          production_run_id: run.id,
+          cost_type: run.cost_type ?? null,
+          legacy_cost_estimate: run.partner_cost_estimate ?? null,
+        },
+      }
+    })
+
+    const { result: unified }: any = await createOrderWorkflow(container).run({
+      input: {
+        region_id: regionId,
+        sales_channel_id: channel.id,
+        currency_code: currencyCode,
+        status: aggregateCoreStatus(runs) as any,
+        items: items as any,
+        metadata: {
+          // The commissioning order this collates (the group key).
+          source_order_id: commissioningOrderId,
+          collated_design_order: true,
+          production_run_ids: runs.map((r) => r.id),
+          // Keep a legacy_id pointer so use-order-kind consumers that read
+          // order.metadata.legacy_id still resolve a run (S3b renders N lines
+          // off the order items rather than this single pointer).
+          legacy_id: runs[0].id,
+          currency_assumed: true,
+        },
+      },
+    })
+
+    // order↔run for EACH run (1:many). First via the rollback path so the
+    // kind=design discriminator link exists-or-the-order-rolls-back; the rest
+    // best-effort (a stray link failure must not orphan the whole order).
+    await linkUnifiedOrderOrRollback(container, unified.id, {
+      [Modules.ORDER]: { order_id: unified.id },
+      [PRODUCTION_RUNS_MODULE]: { production_runs_id: runs[0].id },
+    })
+    const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+    for (const run of runs.slice(1)) {
+      await remoteLink
+        .create([
+          {
+            [Modules.ORDER]: { order_id: unified.id },
+            [PRODUCTION_RUNS_MODULE]: { production_runs_id: run.id },
+          },
+        ])
+        .catch((e: any) =>
+          logger.warn(
+            `[orders-unification] collated order↔run link failed for run ${run.id}: ${e?.message}`
+          )
+        )
+    }
+
+    // design↔order per distinct design (reuse #29 design-order link infra).
+    const designIds = Array.from(
+      new Set(runs.map((r) => r.design_id).filter(Boolean))
+    )
+    for (const designId of designIds) {
+      await remoteLink
+        .create([
+          {
+            [DESIGN_MODULE]: { design_id: designId },
+            [Modules.ORDER]: { order_id: unified.id },
+          },
+        ])
+        .catch((e: any) =>
+          logger.warn(
+            `[orders-unification] collated design link failed for ${designId}: ${e?.message}`
+          )
+        )
+    }
+
+    // partner↔order (D3) per distinct partner among runs already at/past
+    // sent_to_partner (the partner is committed).
+    const partnerIds = Array.from(
+      new Set(
+        runs
+          .filter(
+            (r) =>
+              r.partner_id &&
+              ["sent_to_partner", "in_progress", "completed"].includes(r.status)
+          )
+          .map((r) => r.partner_id)
+      )
+    )
+    for (const partnerId of partnerIds) {
+      await createPartnerOrderLink(container, partnerId as string, unified.id)
+    }
+
+    // Aggregate partner_status onto the sidecar column (best-effort).
+    const partnerStatus = aggregatePartnerStatus(runs)
+    if (partnerStatus) {
+      await setUnifiedOrderPartnerStatus(container, unified.id, partnerStatus).catch(
+        (e: any) =>
+          logger.warn(
+            `[orders-unification] collated sidecar status write failed for ${unified.id}: ${e?.message}`
+          )
+      )
+    }
+
+    return { unified_order_id: unified.id, line_count: items.length }
+  } catch (e: any) {
+    logger.warn(
+      `[orders-unification] collated design-order projection failed for ${commissioningOrderId}: ${e?.message}`
+    )
+    return { unified_order_id: null, error: e?.message }
+  }
+}
+
 /**
  * Mirror a run's current status onto its unified order per §5. Re-reads the
  * run from DB (not workflow input) so compensations mirror correctly too.

--- a/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
+++ b/apps/backend/src/workflows/production-runs/dual-write-unified-run-order.ts
@@ -585,6 +585,37 @@ export const collateRunsIntoWorkOrder = async (
     await createPartnerOrderLink(container, partnerId as string, unified.id)
   }
 
+  // design↔partner link per (design, committed-partner) pair. WITHOUT this the
+  // partner UI's design-details (`GET /partners/designs/:id`, scoped on the
+  // design_partner link) 404s "Design not found for this partner" — the
+  // "nothing found" the operator sees when opening a design from the collated
+  // work-order. Producing a design to a partner IS the assignment, so the link
+  // belongs here. Best-effort + idempotent (a re-produce just re-hits it).
+  for (const run of runs) {
+    if (
+      !run.partner_id ||
+      !run.design_id ||
+      !["sent_to_partner", "in_progress", "completed"].includes(run.status)
+    ) {
+      continue
+    }
+    await remoteLink
+      .create([
+        {
+          [DESIGN_MODULE]: { design_id: run.design_id },
+          [PARTNER_MODULE]: { partner_id: run.partner_id },
+        },
+      ])
+      .catch((e: any) => {
+        // A duplicate (design already assigned to this partner) is fine.
+        if (!/duplicate|already exists|unique/i.test(e?.message || "")) {
+          logger.warn(
+            `[orders-unification] collated design↔partner link failed for design ${run.design_id} / partner ${run.partner_id}: ${e?.message}`
+          )
+        }
+      })
+  }
+
   // Aggregate partner_status onto the sidecar column (best-effort).
   const partnerStatus = aggregatePartnerStatus(runs)
   if (partnerStatus) {

--- a/apps/docs/notes/826_DESIGN_ORDER_COLLATION.md
+++ b/apps/docs/notes/826_DESIGN_ORDER_COLLATION.md
@@ -83,10 +83,24 @@ instead ensure the projection stamps design identity (name/status) onto each lin
 item it creates (it already sets title from `run.snapshot.design.name`). Revised
 slices below drop S2.
 
+### CORRECTION (2026-07-01): "Bug #8" is INTENTIONAL, not a bug
+`convert-design-order.ts:169-179` builds **title-only** order line items (no
+`product_id`) *specifically* so `order-placed.ts` does NOT auto-spawn runs for a
+customer design order (draft order, `no_notification`). The order line items DO
+inherit `metadata.design_id` + `source_cart_line_item_id` from the cart line
+items (draft workflow stamps `metadata.design_id` at create). So run creation for
+design orders is a DELIBERATE explicit admin step, not order-placed.
+=> Collation entry point is an **explicit "send design order to production"
+fan-out**, NOT an order-placed change. Runs today (admin `/designs/:id/
+production-runs`) do NOT carry the commissioning `order_id`, so there's no group
+key yet — the fan-out must stamp it.
+
 ### Revised build order
-1. **Bug #8** — `order-placed.ts:48-53`: fan out one production_run per design
-   line item (resolve `design_id` from design↔line-item link; `order_line_item_id`
-   already the run key; stamp `order_id`). Prereq: runs must exist per design line.
+1. **Fan-out-runs-for-design-order** (new workflow + admin action): given a
+   commissioning order, create one production_run per design line item, each
+   stamped `order_id`=commissioning order + `order_line_item_id`=that line +
+   `design_id` (from line `metadata.design_id`). This gives the collation its
+   `run.order_id` group key while respecting the deliberate no-auto-run design.
 2. **S3a — collated projection:** batch `projectRunToUnifiedOrder` so N runs
    sharing `order_id` → ONE unified work-order with N line items; `order↔run`
    1:many; idempotent on the collated order. Mirror `dual-write-unified-order.ts`.

--- a/apps/docs/notes/826_DESIGN_ORDER_COLLATION.md
+++ b/apps/docs/notes/826_DESIGN_ORDER_COLLATION.md
@@ -196,12 +196,32 @@ Both "next session" features below are now built (branch
      (runA completes → order still pending; runB completes → order completed;
      partner_status tracks least-advanced then "completed").
 
+### Standardised collated order UI (SHIPPED, same session)
+The collated design order now runs its whole lifecycle + specs INLINE in the one
+order span (no jumping to production-runs / tasks / design-details), styled like
+the Medusa core order page (stacked Containers + SectionRows). The operator picks
+how the N designs lay out, remembered **per order** (localStorage
+`collated-design-view:<orderId>`) — so different orders can read differently:
+- **expandable** (default) — collapsible `Container` per design; header shows
+  name + qty + run status, body reveals specs + `ProductionRunCard`. First open.
+- **stacked** — every design expanded, mirroring the single-design order layout.
+- **focus** — compact list; the selected design's specs + lifecycle render below.
+
+Files: `components/work-orders/collated-design-detail.tsx` (shared
+`useDesignLineRun` / `runPartnerBadge` / `DesignSpecs` [general + `DesignInventoryBomSection`
++ `DesignCostSection`] / `DesignLineDetail` [specs + `ProductionRunCard`]) +
+`collated-design-runs.tsx` (orchestrator + `ModeToggle` + the 3 layouts). Tasks
+stay inline in `ProductionRunCard` (drawer at `tasks/:id`, still in the order
+span). Design "Open design manager" (`/designs/:id`) kept as the escape hatch.
+Future: per-order view preference could move from localStorage to a real setting
+("ask per order how they want to see").
+
 ### Still open / next
 - **Admin mirror** — the admin collated work-order detail should likewise list
   per-design run status/actions (the produce button already exists on the design
   order; extend the resulting-runs view). Not yet built.
-- Live-verify in partner-ui (multi-design produce → open order → per-design cards
-  drive lifecycle; each card's "Design details" link resolves its own design).
+- Live-verify in partner-ui (multi-design produce → open order → toggle the 3
+  layouts; each design drives its lifecycle inline; specs render under the order).
 
 ---
 

--- a/apps/docs/notes/826_DESIGN_ORDER_COLLATION.md
+++ b/apps/docs/notes/826_DESIGN_ORDER_COLLATION.md
@@ -1,0 +1,108 @@
+# #826 — Collate designs as line items on one order (partner sees one order, many designs)
+
+Grounded in the existing #342 orders-unification work (`ORDERS_UNIFICATION_342.md`,
+`DESIGN-ORDER-ANALYSIS.md`). Decision layer: **Option A** (collate at the order;
+per-design production runs stay per-design underneath).
+
+## Two different "orders" exist today — don't conflate them
+1. **Commissioning / sales order** — `createDraftOrderFromDesignsWorkflow` →
+   customer cart with N design line items (design↔line-item link). This is *who
+   pays*. Admin creates it (customer widget; now also the general Designs list —
+   S1 below). Runs carry its id as `run.order_id` / projection `source_order_id`.
+2. **Partner work-order** — `projectRunToUnifiedOrder`
+   (`production-runs/dual-write-unified-run-order.ts`) mints ONE unified core
+   order **per production_run** ("JYT commissions partner X to make design Y") —
+   one line item per design — links the partner (D3 `partner↔order`) and links
+   `order↔production_run` (D5, **1:1**, the kind=design discriminator). This is
+   *what the partner's "Design Orders" panel actually shows.*
+
+**The fragmentation** the user feels: N designs → N runs → **N work-orders**,
+each with a single design line. Inventory already collates (one `inventory_order`
+→ N `orderline`s → one unified order via `dual-write-unified-order.ts`; partner
+renders `<InventoryOrderLines>`). Design orders never got the collated projection.
+
+## Current partner render asymmetry (`order-detail.tsx`)
+- inventory kind → `<InventoryOrderLines>` (one order, N lines) ✅
+- design kind → resolves `production_run.design_id` → **one** design, single
+  `WorkOrderSummarySection` ❌  (this is the gap)
+
+## Recommendation (revised by the #342 review)
+Collate at the **work-order projection layer**, mirroring the inventory dual-write
+— NOT by separately surfacing the customer commissioning order. The projection
+already creates a partner-linked, kind-discriminated order with design line
+items; we make it hold **N lines (one per run)** instead of minting N orders.
+
+- **Collation key:** `run.order_id` (already stamped; projection reads it as
+  `source_order_id`). Sibling design runs sharing a source/commissioning order →
+  ONE work-order with N line items. (So the user's "commissioning order" instinct
+  = the *grouping key*, while the *anchor the partner sees* is the collated
+  work-order projection.)
+- **Link change:** `order↔production_run` 1:1 → **1:many** (order side lists
+  runs). The partner list discriminator already tolerates arrays
+  (`resolvePartnerWorkOrderIdsStep`'s `linked()` checks `Array.isArray || .id`).
+  Detail route (`use-order-kind.ts`, `legacyId = production_run id`) assumes 1:1
+  and MUST be revisited — this is the main #342 invariant touched.
+- **Per-line status:** each design line ↔ its run (`run.order_line_item_id`,
+  already exists) → line shows that run's status. Denormalize
+  `design_name`/`design_status`/`sequence` onto the design↔order link (extraColumns,
+  mirrors #817 S2) for self-describing display.
+
+## Slices
+- **S1 — admin curate (DONE, this session):** "Create Order" command on the
+  general Designs list (`admin/routes/designs/page.tsx`) — multi-select → reuse
+  `DesignOrderPreviewDrawer` + `/admin/customers/:id/design-order[/preview]`.
+  Auto-resolves customer from the design↔customer link (enriched onto
+  `GET /admin/designs` response); single-customer required (picker deferred).
+  Creates the **commissioning order** (layer 1). Backend already `design_ids[]`.
+- **S2 — model:** extraColumns on `design-order-link` (`design_name`,
+  `design_status`, `sequence`, nullable `quantity`) + migration; populate on
+  create/convert fan-out.
+- **S3a — collated projection:** batch `projectRunToUnifiedOrder` — N runs sharing
+  `order_id` → one unified work-order with N design line items (mirror inventory
+  dual-write). Requires `order↔production_run` 1:many + detail-route de-1:1.
+- **S3b — partner view:** `<DesignOrderLines>` (mirror `inventory-order-lines.tsx`)
+  rendering one line per design w/ per-run status; partner Design Orders list =
+  one row per collated order.
+- **Bug #8 (prereq for runs off a design order):** `order-placed.ts:48-53` skips
+  run creation for design line items (`product_id` null → `continue`). Resolve
+  `design_id` from the design↔line-item link + fan out one run per design line
+  (`order_line_item_id` already the run key).
+
+## DECISION (2026-07-01, user): anchor = collated work-order projection.
+Collate at `projectRunToUnifiedOrder`; grouping key `run.order_id`; order↔run
+1:1 → 1:many; de-1:1 the partner detail route. NOT the customer commissioning
+order (would duplicate order surfaces for the partner).
+
+### Simplification this unlocks — S2 (extraColumns) is likely UNNEEDED
+Under the work-order anchor the design lines ARE the collated order's core
+**line items** (one per design, created by the projection from `run.snapshot`),
+joined to their run via `order_line_item_id`. So per-line display/status rides on
+the order line items + run join — exactly like inventory uses `inventory_order_line`,
+not a denormalized link. => We do NOT denormalize onto `design-order-link`;
+instead ensure the projection stamps design identity (name/status) onto each line
+item it creates (it already sets title from `run.snapshot.design.name`). Revised
+slices below drop S2.
+
+### Revised build order
+1. **Bug #8** — `order-placed.ts:48-53`: fan out one production_run per design
+   line item (resolve `design_id` from design↔line-item link; `order_line_item_id`
+   already the run key; stamp `order_id`). Prereq: runs must exist per design line.
+2. **S3a — collated projection:** batch `projectRunToUnifiedOrder` so N runs
+   sharing `order_id` → ONE unified work-order with N line items; `order↔run`
+   1:many; idempotent on the collated order. Mirror `dual-write-unified-order.ts`.
+3. **S3b — partner render:** de-1:1 `use-order-kind.ts` (order → runs plural);
+   `<DesignOrderLines>` (mirror `<InventoryOrderLines>`), one line per design w/
+   per-run status; partner Design Orders list = one row per collated order.
+4. Admin collated detail (Bug #9 / #15) — cart/order-level view + mixed-status.
+
+## Key files
+- projection: `src/workflows/production-runs/dual-write-unified-run-order.ts`
+  (`projectRunToUnifiedOrder`, `dualWriteChildRunOrdersStep`, `linkPartnerToOrder`)
+- inventory template: `src/workflows/inventory_orders/dual-write-unified-order.ts`
+- partner list scoping: `src/workflows/orders/list-partner-orders.ts`
+  (`resolvePartnerWorkOrderIdsStep`)
+- partner detail + kind: `apps/partner-ui/src/routes/orders/order-detail/order-detail.tsx`
+  + `use-order-kind.ts`; render `components/work-orders/inventory-order-lines.tsx`
+- run fan-out gate (Bug #8): `src/subscribers/order-placed.ts`
+- links: `order-production-run.ts` (D5 1:1), `design-order-link.ts`,
+  `design-line-item-link.ts`, `design-customer-link.ts`, partner↔order (D3)

--- a/apps/docs/notes/826_DESIGN_ORDER_COLLATION.md
+++ b/apps/docs/notes/826_DESIGN_ORDER_COLLATION.md
@@ -156,7 +156,56 @@ key yet — the fan-out must stamp it.
   design↔partner link per (design, committed-partner) pair (best-effort,
   idempotent). Test asserts every produced design is assigned.
 
-### NEXT SESSION — capture the collated lifecycle in the ONE order space
+## Session 2026-07-01c — collated lifecycle in the ONE order space (SHIPPED)
+
+Both "next session" features below are now built (branch
+`feat/826-design-order-collation`, PR #828):
+
+1. **Per-design details navigation.**
+   - `DesignOrderLines` (`components/work-orders/design-order-lines.tsx`) now
+     wraps each design card in a `<Link to="/orders/:id/design-details/:designId">`
+     (design id from `line.metadata.design_id`), so each card opens ITS OWN
+     design (no more "first-run-only").
+   - New route `design-details/:designId` in `get-partner-route.map.tsx`
+     (sibling of the legacy `design-details`, sharing the extracted
+     `designDetailsChildren` media/moodboard array).
+   - `OrderDesignDetails` reads `useParams().designId` and resolves that design
+     directly; falls back to the order's `legacy_id`→run→design only when no
+     param (legacy single-design orders). `useResolvedDesignId` (media/moodboard
+     uploads) likewise prefers `:designId`.
+
+2. **Per-design run lifecycle from the collated order.**
+   - New `CollatedDesignRuns` (`components/work-orders/collated-design-runs.tsx`)
+     renders a full `<ProductionRunCard>` per design line — each child card
+     fetches its own run + design + consumption logs
+     (`usePartnerProductionRun` / `usePartnerDesign` /
+     `usePartnerConsumptionLogs` keyed off the line metadata) so the partner
+     drives accept→start→finish→complete + material logging + tasks for EVERY
+     design from the single order screen. Rendered under `DesignOrderLines` in
+     `order-detail.tsx` for `metadata.collated_design_order` orders.
+   - **Backend aggregation fix** — `mirrorRunStatusToUnifiedOrder`
+     (`dual-write-unified-run-order.ts`) now fetches the order's metadata + ALL
+     its linked runs in one `query.graph` and, when the order has >1 run,
+     aggregates `aggregateCoreStatus` / `aggregatePartnerStatus` across them
+     (completed/canceled only when every run is; partner_status = least-advanced).
+     Single-run orders keep the exact per-run mapping (the aggregate helpers
+     don't model the draft/decline nuances). So a single run transition rolls the
+     WHOLE collated order forward correctly.
+   - Test: `design-order-produce-fanout.spec.ts` → new
+     "aggregates the collated order status across ALL runs on each transition"
+     (runA completes → order still pending; runB completes → order completed;
+     partner_status tracks least-advanced then "completed").
+
+### Still open / next
+- **Admin mirror** — the admin collated work-order detail should likewise list
+  per-design run status/actions (the produce button already exists on the design
+  order; extend the resulting-runs view). Not yet built.
+- Live-verify in partner-ui (multi-design produce → open order → per-design cards
+  drive lifecycle; each card's "Design details" link resolves its own design).
+
+---
+
+### (archived) NEXT SESSION — capture the collated lifecycle in the ONE order space
 Two UI features remain (both partner-ui, some admin), grounded here so a clean
 session can start immediately:
 

--- a/apps/docs/notes/826_DESIGN_ORDER_COLLATION.md
+++ b/apps/docs/notes/826_DESIGN_ORDER_COLLATION.md
@@ -226,10 +226,13 @@ produced, lists every per-design run fanned out from the ONE commissioning order
   design-order payload's `design` + `sibling_items[].design` (endpoint enriched
   with `design_type`/`priority`/`target_completion_date`).
 - Per run: design name (link) + type/status badges, a 5-step progress stepper,
-  important details (qty · cost · due date · partner name), an **admin action
-  menu** (View design / Cancel run), and — surfaced for the operator — **"Now:
-  <what's happening>  →  Partner's next: <the partner's upcoming lifecycle
-  action>"** (accept → start → finish → complete).
+  important details (qty · cost · due date · partner name), and — surfaced for
+  the operator — **"Now: <what's happening>  →  Partner's next: <the partner's
+  upcoming lifecycle action>"** (accept → start → finish → complete).
+- Lifecycle ACTIONS are NOT reinvented here — the canonical
+  `/production-runs/:id` page already has Approve / Dispatch-to-partner (send to
+  production) / Edit cost / Cancel / tasks. Each card's ⋯ menu deep-links there
+  ("Manage run") + "View design".
 - Live-verified in admin :9000 on the produced commissioning order #29 (3 runs
   "sent to partner"): all three show "Now: Sent — awaiting acceptance → Partner's
   next: Accept the run", stepper at Received, partner name + INR cost.

--- a/apps/docs/notes/826_DESIGN_ORDER_COLLATION.md
+++ b/apps/docs/notes/826_DESIGN_ORDER_COLLATION.md
@@ -120,3 +120,96 @@ key yet — the fan-out must stamp it.
 - run fan-out gate (Bug #8): `src/subscribers/order-placed.ts`
 - links: `order-production-run.ts` (D5 1:1), `design-order-link.ts`,
   `design-line-item-link.ts`, `design-customer-link.ts`, partner↔order (D3)
+
+---
+
+## Session 2026-07-01b — command bar, no-customer produce, design↔partner fix
+
+### Shipped (PR #828, branch `feat/826-design-order-collation`)
+- **Compact command bar** (`src/admin/routes/designs/page.tsx`): the Designs
+  list command bar now renders each action as just its shortcut-letter badge
+  (`<CommandBar.Command label="" shortcut="x">`) wrapped in a `<Tooltip>` that
+  reveals the full label on hover. Custom `<CommandBar>` (from `@medusajs/ui`)
+  replaces `<DataTable.CommandBar>`; `CommandBar.Command` registers its OWN
+  keydown, so `commands` was dropped from `useDataTable` to avoid double
+  registration. `useCommands` now returns plain `{label,shortcut,action}` (no
+  `createDataTableCommandHelper`).
+- **"Send to Production" (no customer)** — collate N selected designs into ONE
+  partner work-order WITHOUT a commissioning order / sale ("just make these"):
+  - `collateRunsIntoWorkOrder(container, runs, {sourceOrderId})` — extracted
+    shared core from `projectDesignOrderToUnifiedOrder` (region/channel + one
+    line per run + order↔run 1:many + design↔order + partner↔order + aggregate
+    status). Both the commissioning path and the no-customer path call it.
+  - `produceDesignsAsWorkOrder(container, design_ids, partner_id)`
+    (`src/workflows/designs/produce-designs-as-work-order.ts`): one run/design
+    (born `sent_to_partner`, `skip_unified_projection`, NO `order_id`) → collate.
+    `source_order_id` on the collated order is `null` for this path.
+  - `POST /admin/designs/produce {design_ids, partner_id}` → `{design_production}`.
+  - `SendToProductionDrawer` partner picker (mirrors `BulkLinkPartnerDrawer`);
+    "Send to Production" command (shortcut `g`) on the designs list.
+  - Test: `integration-tests/http/designs-produce-no-customer.spec.ts`.
+- **Fix "design-details shows nothing found"** — root cause: `GET
+  /partners/designs/:id` (`src/api/partners/designs/[designId]/route.ts:157`)
+  scopes on the **design_partner** link and 404s ("Design not found for this
+  partner") when absent. The produce paths created design↔order + partner↔order
+  but never design↔partner. `collateRunsIntoWorkOrder` now creates a
+  design↔partner link per (design, committed-partner) pair (best-effort,
+  idempotent). Test asserts every produced design is assigned.
+
+### NEXT SESSION — capture the collated lifecycle in the ONE order space
+Two UI features remain (both partner-ui, some admin), grounded here so a clean
+session can start immediately:
+
+1. **Per-design details navigation (finish the "nothing found" UX).** The
+   collated order (`order-detail.tsx`) shows N `<DesignOrderLines>` cards but
+   only ONE top "Design details" link, and `OrderDesignDetails`
+   (`routes/orders/order-design-details/order-design-details.tsx`) resolves the
+   design via `order.metadata.legacy_id` = **runs[0].id only** → always the
+   first design. Plan:
+   - Make each `<DesignOrderLines>` card link to its OWN design, e.g.
+     `/orders/:id/design-details/:designId` (design_id is on
+     `line.metadata.design_id`; run id on `line.metadata.production_run_id`).
+   - `OrderDesignDetails`: read the `:designId` route param when present and
+     resolve THAT design (fall back to legacy_id for legacy single-design
+     orders). Register the nested route in `get-partner-route.map.tsx`.
+   - Now that design↔partner links exist, each design resolves (no more 404).
+
+2. **Manage all production runs' lifecycle from the collated order space** (the
+   user's core ask). Today the collated `<DesignOrderLines>` shows qty/amount
+   only — no run status, no lifecycle actions. The single-design order uses
+   `<ProductionRunCard>` (accept/start/finish/complete + consumption). Plan:
+   - The collated order has `order.production_runs` (1:many) — one run per
+     design line (`line.metadata.production_run_id` ↔ run). Fetch the runs for
+     the order and join to lines by `production_run_id`.
+   - Per design card: show the run's `partner_status` badge + inline lifecycle
+     actions (reuse the partner run mutation hooks used by `ProductionRunCard`;
+     `usePartnerProductionRun` per run, or a batch fetch). So a partner can drive
+     accept→start→finish→complete for EVERY design of the collated order from
+     one screen — the "same place where the collated designs lifecycle is
+     captured".
+   - Order-level roll-up already exists: `aggregatePartnerStatus`/
+     `aggregateCoreStatus` (least-advanced). On each per-run lifecycle
+     transition, re-aggregate onto the collated order — see the OPEN follow-up:
+     `mirrorRunStatusToUnifiedOrder` currently writes the collated order's status
+     from a SINGLE run; it must aggregate across all the order's runs (noted in
+     commit `2ee9ff7f1`). This is the backend piece that makes the collated
+     lifecycle correct as individual runs advance.
+   - Admin mirror: the collated work-order detail should likewise list per-design
+     run status/actions (admin already has the produce button on the design
+     order; extend to show/advance the resulting runs).
+
+### Key files (this session + next)
+- shared collate core: `src/workflows/production-runs/dual-write-unified-run-order.ts`
+  (`collateRunsIntoWorkOrder`, `projectDesignOrderToUnifiedOrder`,
+  `mirrorRunStatusToUnifiedOrder` ← aggregation TODO)
+- no-customer produce: `src/workflows/designs/produce-designs-as-work-order.ts`
+  + `src/api/admin/designs/produce/route.ts`
+- commissioning produce: `src/workflows/designs/create-runs-for-design-order.ts`
+  + `src/api/admin/orders/[id]/design/produce/route.ts`
+- designs list UI: `src/admin/routes/designs/page.tsx` +
+  `src/admin/components/designs/send-to-production-drawer.tsx`
+- partner collated render: `apps/partner-ui/src/routes/orders/order-detail/order-detail.tsx`
+  + `components/work-orders/design-order-lines.tsx`
+  + `routes/orders/order-design-details/order-design-details.tsx` (per-design TODO)
+- partner run lifecycle card (reuse): `apps/partner-ui/src/components/work-orders/production-run-card.tsx`
+- partner design scoping (404 cause): `src/api/partners/designs/[designId]/route.ts:157`

--- a/apps/docs/notes/826_DESIGN_ORDER_COLLATION.md
+++ b/apps/docs/notes/826_DESIGN_ORDER_COLLATION.md
@@ -216,12 +216,29 @@ span). Design "Open design manager" (`/designs/:id`) kept as the escape hatch.
 Future: per-order view preference could move from localStorage to a real setting
 ("ask per order how they want to see").
 
+### Admin mirror (SHIPPED, same session)
+The admin design-order detail (`admin/routes/design-orders/[id]/page.tsx`, where
+the Produce button lives) now has a **Production** section
+(`admin/components/designs/design-order-production-section.tsx`) that, once
+produced, lists every per-design run fanned out from the ONE commissioning order:
+- Fetched via `useProductionRuns({ order_id })` — needed a new `order_id` filter
+  on `GET /admin/production-runs` (route.ts). Design details joined from the
+  design-order payload's `design` + `sibling_items[].design` (endpoint enriched
+  with `design_type`/`priority`/`target_completion_date`).
+- Per run: design name (link) + type/status badges, a 5-step progress stepper,
+  important details (qty · cost · due date · partner name), an **admin action
+  menu** (View design / Cancel run), and — surfaced for the operator — **"Now:
+  <what's happening>  →  Partner's next: <the partner's upcoming lifecycle
+  action>"** (accept → start → finish → complete).
+- Live-verified in admin :9000 on the produced commissioning order #29 (3 runs
+  "sent to partner"): all three show "Now: Sent — awaiting acceptance → Partner's
+  next: Accept the run", stepper at Received, partner name + INR cost.
+
 ### Still open / next
-- **Admin mirror** — the admin collated work-order detail should likewise list
-  per-design run status/actions (the produce button already exists on the design
-  order; extend the resulting-runs view). Not yet built.
-- Live-verify in partner-ui (multi-design produce → open order → toggle the 3
-  layouts; each design drives its lifecycle inline; specs render under the order).
+- Admin section could grow admin-driven actions (send-to-partner with template
+  pick, approve/complete on review) — today it's status + View design + Cancel.
+- Operator picks a preferred default partner layout; maybe promote the per-order
+  view preference from localStorage to a real setting.
 
 ---
 

--- a/apps/partner-ui/src/components/work-orders/collated-design-detail.tsx
+++ b/apps/partner-ui/src/components/work-orders/collated-design-detail.tsx
@@ -1,0 +1,218 @@
+import { ArrowUpRightOnBox } from "@medusajs/icons"
+import { Badge, Button, Container, Heading, Skeleton, Text } from "@medusajs/ui"
+import { Link } from "react-router-dom"
+import { useTranslation } from "react-i18next"
+
+import { SectionRow } from "../common/section"
+import { useDate } from "../../hooks/use-date"
+import { getStatusBadgeColor } from "../../lib/status-badge"
+import { usePartnerConsumptionLogs } from "../../hooks/api/partner-consumption-logs"
+import { usePartnerDesign } from "../../hooks/api/partner-designs"
+import { usePartnerProductionRun } from "../../hooks/api/partner-production-runs"
+import { DesignCostSection } from "../../routes/designs/design-detail/components/design-cost-section"
+import { DesignInventoryBomSection } from "../../routes/designs/design-detail/components/design-inventory-bom-section"
+import { ProductionRunCard } from "./production-run-card"
+
+/**
+ * #826 — the per-design pieces of a COLLATED design work-order, shared by the
+ * three collated-order layouts (expandable / stacked / focus). Each design line
+ * carries its own run + design ids on `line.metadata`; the specs + full
+ * production lifecycle (runs, tasks) render INLINE in the order span so the
+ * partner never leaves the order to drive a design.
+ */
+
+export type CollatedLine = Record<string, any>
+
+/** Resolve a line's run + design (light — for headers/rows that show status). */
+export const useDesignLineRun = (line: CollatedLine) => {
+  const runId = line?.metadata?.production_run_id as string | undefined
+  const designId = line?.metadata?.design_id as string | undefined
+  const { production_run, isLoading } = usePartnerProductionRun(runId ?? "", {
+    enabled: !!runId,
+  })
+  return { runId, designId, production_run, isLoading }
+}
+
+/** The partner-facing status of a run, from its status + lifecycle timestamps. */
+export const runPartnerBadge = (
+  run: any
+): { label: string; color: "green" | "orange" | "red" | "blue" | "grey" } => {
+  const s = String(run?.status || "")
+  if (s === "completed") return { label: "Completed", color: "green" }
+  if (s === "cancelled") return { label: "Cancelled", color: "red" }
+  if (s === "in_progress") {
+    if (run?.finished_at) return { label: "Finished", color: "orange" }
+    if (run?.started_at) return { label: "In progress", color: "orange" }
+    if (run?.accepted_at) return { label: "Accepted", color: "blue" }
+    return { label: "In progress", color: "orange" }
+  }
+  if (s === "sent_to_partner") return { label: "Assigned", color: "blue" }
+  return { label: s ? s.replace(/_/g, " ") : "Pending", color: "grey" }
+}
+
+/** Compact header bits (title + qty) shared by the layouts. */
+export const designLineTitle = (line: CollatedLine, design?: any): string =>
+  String(design?.name || line?.title || line?.metadata?.design_id || line?.id)
+
+/**
+ * The design's specs, rendered as stacked Medusa Containers (general → BOM →
+ * cost), mirroring how the standalone design page and the single-design order
+ * surface a design — so "the design specs live under the order form".
+ */
+export const DesignSpecs = ({ design }: { design: any }) => {
+  const { t } = useTranslation()
+  const { getFullDate } = useDate()
+
+  const materials = Array.isArray(design?.inventory_items)
+    ? design.inventory_items.length
+    : 0
+  const cost = design?.estimated_cost
+  const costCurrency = design?.cost_currency
+
+  return (
+    <>
+      <Container className="divide-y p-0">
+        <div className="flex items-center justify-between px-6 py-4">
+          <Heading level="h2">{t("partner.workOrders.summary")}</Heading>
+          {/* Escape hatch to the full design-management surface. */}
+          <Button size="small" variant="secondary" asChild>
+            <Link to={`/designs/${design.id}`}>
+              {t("partner.workOrders.openDesignManager")}
+              <ArrowUpRightOnBox />
+            </Link>
+          </Button>
+        </div>
+
+        {design?.design_type && (
+          <SectionRow
+            title={t("partner.workOrders.type")}
+            value={
+              <Badge size="2xsmall" color="blue">
+                {String(design.design_type)}
+              </Badge>
+            }
+          />
+        )}
+        {design?.status && (
+          <SectionRow
+            title={t("partner.workOrders.designStatus")}
+            value={
+              <Badge size="2xsmall" color={getStatusBadgeColor(design.status)}>
+                {String(design.status)}
+              </Badge>
+            }
+          />
+        )}
+        {design?.priority && (
+          <SectionRow
+            title={t("partner.workOrders.priority")}
+            value={
+              <Badge
+                size="2xsmall"
+                color={
+                  design.priority === "urgent"
+                    ? "red"
+                    : design.priority === "high"
+                    ? "orange"
+                    : design.priority === "medium"
+                    ? "blue"
+                    : "grey"
+                }
+              >
+                {String(design.priority)}
+              </Badge>
+            }
+          />
+        )}
+        {design?.target_completion_date && (
+          <SectionRow
+            title={t("partner.workOrders.targetDate")}
+            value={getFullDate({ date: design.target_completion_date })}
+          />
+        )}
+        {cost != null && (
+          <SectionRow
+            title={t("partner.workOrders.estimatedCost")}
+            value={
+              <Text size="small" weight="plus">
+                {costCurrency
+                  ? `${String(costCurrency).toUpperCase()} ${cost}`
+                  : String(cost)}
+              </Text>
+            }
+          />
+        )}
+        <SectionRow
+          title={t("partner.workOrders.materials")}
+          value={String(materials)}
+        />
+        {design?.description && (
+          <div className="px-6 py-4">
+            <Text size="small" className="text-ui-fg-subtle whitespace-pre-line">
+              {String(design.description)}
+            </Text>
+          </div>
+        )}
+      </Container>
+
+      {/* Full BOM + cost breakdown — the design "specs" the operator asked to
+          keep under the order form. Each self-fetches off the design id. */}
+      <DesignInventoryBomSection design={design} />
+      <DesignCostSection design={design} />
+    </>
+  )
+}
+
+/**
+ * The full inline detail for ONE design of a collated order: its specs stacked
+ * above its production run card (lifecycle + tasks). Fetches the run, design and
+ * consumption logs off the line metadata.
+ */
+export const DesignLineDetail = ({
+  line,
+  onActionSuccess,
+}: {
+  line: CollatedLine
+  onActionSuccess?: () => void
+}) => {
+  const runId = line?.metadata?.production_run_id as string | undefined
+  const designId = line?.metadata?.design_id as string | undefined
+
+  const { production_run } = usePartnerProductionRun(runId ?? "", {
+    enabled: !!runId,
+  })
+  const { design } = usePartnerDesign(designId ?? "", { enabled: !!designId })
+  const { logs = [], count = 0 } = usePartnerConsumptionLogs(
+    designId ?? "",
+    undefined,
+    { enabled: !!designId }
+  )
+
+  if (!runId || !designId) {
+    return null
+  }
+
+  if (!production_run || !design) {
+    return (
+      <Container className="p-6">
+        <Skeleton className="h-6 w-40" />
+        <Skeleton className="mt-3 h-24 w-full" />
+      </Container>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-y-3">
+      <DesignSpecs design={design} />
+      <ProductionRunCard
+        run={production_run}
+        design={design}
+        consumptionLogs={logs}
+        consumptionCount={count}
+        onActionSuccess={onActionSuccess}
+        showTimeline={false}
+        taskLinkBase="tasks"
+      />
+    </div>
+  )
+}

--- a/apps/partner-ui/src/components/work-orders/collated-design-runs.tsx
+++ b/apps/partner-ui/src/components/work-orders/collated-design-runs.tsx
@@ -1,64 +1,229 @@
-import { Container, Skeleton, Text } from "@medusajs/ui"
+import { TriangleDownMini, TriangleRightMini } from "@medusajs/icons"
+import { Container, Heading, StatusBadge, Text, clx } from "@medusajs/ui"
+import { useEffect, useState } from "react"
+import { useParams } from "react-router-dom"
 
-import { usePartnerConsumptionLogs } from "../../hooks/api/partner-consumption-logs"
-import { usePartnerDesign } from "../../hooks/api/partner-designs"
-import { usePartnerProductionRun } from "../../hooks/api/partner-production-runs"
-import { ProductionRunCard } from "./production-run-card"
+import {
+  CollatedLine,
+  DesignLineDetail,
+  designLineTitle,
+  runPartnerBadge,
+  useDesignLineRun,
+} from "./collated-design-detail"
 
 /**
- * #826 — the production lifecycle for a COLLATED design work-order, one full
- * <ProductionRunCard> per design line, so a partner drives accept → start →
- * finish → complete (plus material logging + tasks) for EVERY design of the
- * order from the single order screen. Each line carries its own run + design ids
- * (metadata.production_run_id / design_id); the card is the same one the design
- * page renders N-up, reused here for the order context.
+ * #826 — the production surface of a COLLATED design work-order. Every design's
+ * specs + full lifecycle (runs, tasks) render INLINE in the one order span
+ * (never navigating out to production-runs / tasks screens), styled like the
+ * Medusa core order page (stacked Containers + SectionRows).
+ *
+ * The operator can switch how the N designs are laid out — the choice is
+ * remembered PER ORDER (localStorage) so different orders can read differently:
+ *   • expandable — collapsible Container per design (default; scales to many)
+ *   • stacked    — every design expanded, mirroring the single-design order
+ *   • focus      — a compact list; one selected design's detail below
  */
 
-const DesignRunLifecycleCard = ({
-  line,
-  onActionSuccess,
-}: {
-  line: Record<string, any>
-  onActionSuccess?: () => void
-}) => {
-  const runId = line?.metadata?.production_run_id as string | undefined
-  const designId = line?.metadata?.design_id as string | undefined
+type ViewMode = "expandable" | "stacked" | "focus"
 
-  const { production_run } = usePartnerProductionRun(runId ?? "", {
-    enabled: !!runId,
-  })
-  const { design } = usePartnerDesign(designId ?? "", { enabled: !!designId })
-  const { logs = [], count = 0 } = usePartnerConsumptionLogs(
-    designId ?? "",
-    undefined,
-    { enabled: !!designId }
-  )
+const MODES: { value: ViewMode; label: string }[] = [
+  { value: "expandable", label: "Expandable" },
+  { value: "stacked", label: "Stacked" },
+  { value: "focus", label: "Focus" },
+]
 
-  if (!runId || !designId) {
-    return null
-  }
+const STORAGE_PREFIX = "collated-design-view:"
 
-  if (!production_run || !design) {
-    return (
-      <Container className="p-6">
-        <Skeleton className="h-6 w-40" />
-        <Skeleton className="mt-3 h-16 w-full" />
-      </Container>
-    )
-  }
+const readStoredMode = (orderId?: string): ViewMode => {
+  if (!orderId || typeof window === "undefined") return "expandable"
+  const v = window.localStorage.getItem(`${STORAGE_PREFIX}${orderId}`)
+  return v === "stacked" || v === "focus" ? v : "expandable"
+}
 
+// ── Compact status/qty summary shared by headers + list rows ──────────
+
+const DesignLineHeadline = ({ line }: { line: CollatedLine }) => {
+  const { production_run } = useDesignLineRun(line)
+  const quantity = Number(line?.quantity) || 0
+  const badge = production_run ? runPartnerBadge(production_run) : null
   return (
-    <ProductionRunCard
-      run={production_run}
-      design={design}
-      consumptionLogs={logs}
-      consumptionCount={count}
-      onActionSuccess={onActionSuccess}
-      showTimeline={false}
-      taskLinkBase="tasks"
-    />
+    <div className="flex min-w-0 flex-1 items-center gap-x-3">
+      <Heading level="h3" className="truncate">
+        {designLineTitle(line, production_run)}
+      </Heading>
+      <Text size="xsmall" className="text-ui-fg-subtle shrink-0">
+        Qty {quantity}
+      </Text>
+      {badge && (
+        <StatusBadge color={badge.color} className="shrink-0">
+          {badge.label}
+        </StatusBadge>
+      )}
+    </div>
   )
 }
+
+// ── Mode toggle (segmented button group, Medusa tokens) ───────────────
+
+const ModeToggle = ({
+  mode,
+  onChange,
+}: {
+  mode: ViewMode
+  onChange: (m: ViewMode) => void
+}) => (
+  <div className="border-ui-border-base flex overflow-hidden rounded-lg border">
+    {MODES.map((m, i) => (
+      <button
+        key={m.value}
+        type="button"
+        onClick={() => onChange(m.value)}
+        className={clx(
+          "txt-compact-small-plus px-3 py-1.5 transition-colors",
+          i > 0 && "border-ui-border-base border-l",
+          mode === m.value
+            ? "bg-ui-bg-base-pressed text-ui-fg-base"
+            : "bg-ui-bg-subtle text-ui-fg-subtle hover:bg-ui-bg-subtle-hover"
+        )}
+      >
+        {m.label}
+      </button>
+    ))}
+  </div>
+)
+
+// ── Expandable: collapsible Container per design ──────────────────────
+
+const ExpandableDesignCard = ({
+  line,
+  defaultOpen,
+  onActionSuccess,
+}: {
+  line: CollatedLine
+  defaultOpen?: boolean
+  onActionSuccess?: () => void
+}) => {
+  const [open, setOpen] = useState(!!defaultOpen)
+  return (
+    <Container className="p-0">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="hover:bg-ui-bg-base-hover flex w-full items-center gap-x-3 px-6 py-4 text-left transition-colors"
+      >
+        <span className="text-ui-fg-muted shrink-0">
+          {open ? <TriangleDownMini /> : <TriangleRightMini />}
+        </span>
+        <DesignLineHeadline line={line} />
+      </button>
+      {open && (
+        <div className="border-ui-border-base border-t p-4">
+          <DesignLineDetail line={line} onActionSuccess={onActionSuccess} />
+        </div>
+      )}
+    </Container>
+  )
+}
+
+const ExpandableLayout = ({
+  lines,
+  onActionSuccess,
+}: {
+  lines: CollatedLine[]
+  onActionSuccess?: () => void
+}) => (
+  <div className="flex flex-col gap-y-3">
+    {lines.map((line, i) => (
+      <ExpandableDesignCard
+        key={String(line.id)}
+        line={line}
+        defaultOpen={i === 0}
+        onActionSuccess={onActionSuccess}
+      />
+    ))}
+  </div>
+)
+
+// ── Stacked: every design expanded (mirrors the single-design order) ──
+
+const StackedLayout = ({
+  lines,
+  onActionSuccess,
+}: {
+  lines: CollatedLine[]
+  onActionSuccess?: () => void
+}) => (
+  <div className="flex flex-col gap-y-4">
+    {lines.map((line) => (
+      <div key={String(line.id)} className="flex flex-col gap-y-3">
+        <div className="px-1">
+          <DesignLineHeadline line={line} />
+        </div>
+        <DesignLineDetail line={line} onActionSuccess={onActionSuccess} />
+      </div>
+    ))}
+  </div>
+)
+
+// ── Focus: compact list + one selected design's detail ────────────────
+
+const FocusRow = ({
+  line,
+  active,
+  onSelect,
+}: {
+  line: CollatedLine
+  active: boolean
+  onSelect: () => void
+}) => (
+  <button
+    type="button"
+    onClick={onSelect}
+    className={clx(
+      "flex w-full items-center gap-x-3 px-6 py-3 text-left transition-colors",
+      active ? "bg-ui-bg-base-pressed" : "hover:bg-ui-bg-base-hover"
+    )}
+  >
+    <span
+      className={clx(
+        "size-2 shrink-0 rounded-full",
+        active ? "bg-ui-fg-interactive" : "bg-ui-border-strong"
+      )}
+    />
+    <DesignLineHeadline line={line} />
+  </button>
+)
+
+const FocusLayout = ({
+  lines,
+  onActionSuccess,
+}: {
+  lines: CollatedLine[]
+  onActionSuccess?: () => void
+}) => {
+  const [activeId, setActiveId] = useState<string>(String(lines[0]?.id))
+  const activeLine =
+    lines.find((l) => String(l.id) === activeId) ?? lines[0]
+  return (
+    <div className="flex flex-col gap-y-3">
+      <Container className="divide-y p-0">
+        {lines.map((line) => (
+          <FocusRow
+            key={String(line.id)}
+            line={line}
+            active={String(line.id) === String(activeLine?.id)}
+            onSelect={() => setActiveId(String(line.id))}
+          />
+        ))}
+      </Container>
+      {activeLine && (
+        <DesignLineDetail line={activeLine} onActionSuccess={onActionSuccess} />
+      )}
+    </div>
+  )
+}
+
+// ── Orchestrator ──────────────────────────────────────────────────────
 
 export const CollatedDesignRuns = ({
   lines,
@@ -67,9 +232,17 @@ export const CollatedDesignRuns = ({
   lines: Array<Record<string, any>>
   onActionSuccess?: () => void
 }) => {
+  const { id: orderId } = useParams()
   const runLines = (lines ?? []).filter(
     (l) => l?.metadata?.production_run_id && l?.metadata?.design_id
   )
+
+  const [mode, setMode] = useState<ViewMode>(() => readStoredMode(orderId))
+  useEffect(() => {
+    if (orderId && typeof window !== "undefined") {
+      window.localStorage.setItem(`${STORAGE_PREFIX}${orderId}`, mode)
+    }
+  }, [mode, orderId])
 
   if (!runLines.length) {
     return null
@@ -77,18 +250,20 @@ export const CollatedDesignRuns = ({
 
   return (
     <div className="flex flex-col gap-y-3">
-      <div className="flex items-center gap-x-2 px-1">
+      <div className="flex items-center justify-between px-1">
         <Text size="small" weight="plus" className="text-ui-fg-subtle">
           Production ({runLines.length})
         </Text>
+        {runLines.length > 1 && <ModeToggle mode={mode} onChange={setMode} />}
       </div>
-      {runLines.map((line) => (
-        <DesignRunLifecycleCard
-          key={String(line.id)}
-          line={line}
-          onActionSuccess={onActionSuccess}
-        />
-      ))}
+
+      {mode === "stacked" ? (
+        <StackedLayout lines={runLines} onActionSuccess={onActionSuccess} />
+      ) : mode === "focus" ? (
+        <FocusLayout lines={runLines} onActionSuccess={onActionSuccess} />
+      ) : (
+        <ExpandableLayout lines={runLines} onActionSuccess={onActionSuccess} />
+      )}
     </div>
   )
 }

--- a/apps/partner-ui/src/components/work-orders/collated-design-runs.tsx
+++ b/apps/partner-ui/src/components/work-orders/collated-design-runs.tsx
@@ -1,0 +1,94 @@
+import { Container, Skeleton, Text } from "@medusajs/ui"
+
+import { usePartnerConsumptionLogs } from "../../hooks/api/partner-consumption-logs"
+import { usePartnerDesign } from "../../hooks/api/partner-designs"
+import { usePartnerProductionRun } from "../../hooks/api/partner-production-runs"
+import { ProductionRunCard } from "./production-run-card"
+
+/**
+ * #826 — the production lifecycle for a COLLATED design work-order, one full
+ * <ProductionRunCard> per design line, so a partner drives accept → start →
+ * finish → complete (plus material logging + tasks) for EVERY design of the
+ * order from the single order screen. Each line carries its own run + design ids
+ * (metadata.production_run_id / design_id); the card is the same one the design
+ * page renders N-up, reused here for the order context.
+ */
+
+const DesignRunLifecycleCard = ({
+  line,
+  onActionSuccess,
+}: {
+  line: Record<string, any>
+  onActionSuccess?: () => void
+}) => {
+  const runId = line?.metadata?.production_run_id as string | undefined
+  const designId = line?.metadata?.design_id as string | undefined
+
+  const { production_run } = usePartnerProductionRun(runId ?? "", {
+    enabled: !!runId,
+  })
+  const { design } = usePartnerDesign(designId ?? "", { enabled: !!designId })
+  const { logs = [], count = 0 } = usePartnerConsumptionLogs(
+    designId ?? "",
+    undefined,
+    { enabled: !!designId }
+  )
+
+  if (!runId || !designId) {
+    return null
+  }
+
+  if (!production_run || !design) {
+    return (
+      <Container className="p-6">
+        <Skeleton className="h-6 w-40" />
+        <Skeleton className="mt-3 h-16 w-full" />
+      </Container>
+    )
+  }
+
+  return (
+    <ProductionRunCard
+      run={production_run}
+      design={design}
+      consumptionLogs={logs}
+      consumptionCount={count}
+      onActionSuccess={onActionSuccess}
+      showTimeline={false}
+      taskLinkBase="tasks"
+    />
+  )
+}
+
+export const CollatedDesignRuns = ({
+  lines,
+  onActionSuccess,
+}: {
+  lines: Array<Record<string, any>>
+  onActionSuccess?: () => void
+}) => {
+  const runLines = (lines ?? []).filter(
+    (l) => l?.metadata?.production_run_id && l?.metadata?.design_id
+  )
+
+  if (!runLines.length) {
+    return null
+  }
+
+  return (
+    <div className="flex flex-col gap-y-3">
+      <div className="flex items-center gap-x-2 px-1">
+        <Text size="small" weight="plus" className="text-ui-fg-subtle">
+          Production ({runLines.length})
+        </Text>
+      </div>
+      {runLines.map((line) => (
+        <DesignRunLifecycleCard
+          key={String(line.id)}
+          line={line}
+          onActionSuccess={onActionSuccess}
+        />
+      ))}
+    </div>
+  )
+}

--- a/apps/partner-ui/src/components/work-orders/design-order-lines.tsx
+++ b/apps/partner-ui/src/components/work-orders/design-order-lines.tsx
@@ -1,4 +1,5 @@
 import { Container, Heading, Text, Badge } from "@medusajs/ui"
+import { Link, useParams } from "react-router-dom"
 
 import { getStylizedAmount } from "../../lib/money-amount-helpers"
 import { WorkOrderLineCard, WorkOrderLineStat } from "./work-order-line-card"
@@ -27,6 +28,8 @@ export const DesignOrderLines = ({
   currencyCode?: string
   totalPrice?: number | null
 }) => {
+  const { id: orderId } = useParams()
+
   if (!lines?.length) {
     return null
   }
@@ -58,9 +61,12 @@ export const DesignOrderLines = ({
           const title = line?.title || line?.metadata?.design_id || line?.id
           const quantity = Number(line?.quantity) || 0
           const unit = Number(line?.unit_price ?? line?.unit_price_incl_tax) || 0
-          return (
+          // #826 — each card opens ITS OWN design's details (collated orders
+          // carry the design id on the line metadata). Falls back to a plain
+          // card when the design or order id is unknown.
+          const designId = line?.metadata?.design_id as string | undefined
+          const card = (
             <WorkOrderLineCard
-              key={String(line.id)}
               title={String(title)}
               subtitle={`Qty ${fmt(quantity)}`}
             >
@@ -73,6 +79,17 @@ export const DesignOrderLines = ({
                 />
               )}
             </WorkOrderLineCard>
+          )
+          return designId && orderId ? (
+            <Link
+              key={String(line.id)}
+              to={`/orders/${orderId}/design-details/${designId}`}
+              className="block outline-none focus-visible:shadow-borders-interactive-with-active rounded-xl"
+            >
+              {card}
+            </Link>
+          ) : (
+            <div key={String(line.id)}>{card}</div>
           )
         })}
       </div>

--- a/apps/partner-ui/src/components/work-orders/design-order-lines.tsx
+++ b/apps/partner-ui/src/components/work-orders/design-order-lines.tsx
@@ -1,0 +1,99 @@
+import { Container, Heading, Text, Badge } from "@medusajs/ui"
+
+import { getStylizedAmount } from "../../lib/money-amount-helpers"
+import { WorkOrderLineCard, WorkOrderLineStat } from "./work-order-line-card"
+
+const fmt = (n: number) => {
+  if (!Number.isFinite(n)) {
+    return "0"
+  }
+  const s = (Math.round(n * 1000) / 1000).toFixed(3)
+  return s.replace(/\.0+$/, "").replace(/(\.[0-9]*?)0+$/, "$1")
+}
+
+/**
+ * #826 S3b — the design line items of a COLLATED design work-order, rendered
+ * one card per design (mirrors <InventoryOrderLines>). The collated work-order
+ * carries one core line item per design (title = design name, metadata.design_id
+ * / production_run_id), so a partner sees ONE order with many designs instead of
+ * N separate design work-orders.
+ */
+export const DesignOrderLines = ({
+  lines,
+  currencyCode,
+  totalPrice,
+}: {
+  lines: Array<Record<string, any>>
+  currencyCode?: string
+  totalPrice?: number | null
+}) => {
+  if (!lines?.length) {
+    return null
+  }
+
+  const cc = (currencyCode || "").toLowerCase()
+  const money = (amount: number) =>
+    cc ? getStylizedAmount(amount, cc) : fmt(amount)
+
+  const totalQuantity = lines.reduce((sum, l) => sum + (Number(l?.quantity) || 0), 0)
+  const computedTotal =
+    totalPrice != null
+      ? Number(totalPrice)
+      : lines.reduce(
+          (sum, l) => sum + (Number(l?.unit_price) || 0) * (Number(l?.quantity) || 0),
+          0
+        )
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center gap-x-3 px-6 py-4">
+        <Heading level="h2">Designs</Heading>
+        <Badge size="2xsmall" color="blue">
+          {lines.length}
+        </Badge>
+      </div>
+
+      <div className="px-6 py-4">
+        {lines.map((line) => {
+          const title = line?.title || line?.metadata?.design_id || line?.id
+          const quantity = Number(line?.quantity) || 0
+          const unit = Number(line?.unit_price ?? line?.unit_price_incl_tax) || 0
+          return (
+            <WorkOrderLineCard
+              key={String(line.id)}
+              title={String(title)}
+              subtitle={`Qty ${fmt(quantity)}`}
+            >
+              <WorkOrderLineStat label="Quantity" value={fmt(quantity)} />
+              {unit > 0 && (
+                <WorkOrderLineStat
+                  label="Amount"
+                  value={money(unit * quantity)}
+                  emphasis
+                />
+              )}
+            </WorkOrderLineCard>
+          )
+        })}
+      </div>
+
+      {/* Total footer — the retail order-summary money block. */}
+      <div className="flex flex-col gap-y-2 px-6 py-4">
+        <div className="text-ui-fg-subtle flex items-center justify-between">
+          <Text size="small">Total designs</Text>
+          <Text size="small">{fmt(totalQuantity)}</Text>
+        </div>
+        {computedTotal > 0 && (
+          <div className="flex items-center justify-between">
+            <Text size="small" weight="plus">
+              Total
+            </Text>
+            <Text size="small" weight="plus">
+              {money(computedTotal)}
+            </Text>
+          </div>
+        )}
+      </div>
+    </Container>
+  )
+}

--- a/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
+++ b/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
@@ -10,6 +10,25 @@ import { ErrorBoundary } from "../../components/utilities/error-boundary"
 import { TaxRegionDetailBreadcrumb } from "../../routes/tax-regions/tax-region-detail/breadcrumb"
 import { taxRegionLoader } from "../../routes/tax-regions/tax-region-detail/loader"
 
+// #826 — media / moodboard UPLOAD children for the in-order design-details
+// sub-route. Shared by both the legacy single-design `design-details` route and
+// the per-design `design-details/:designId` route (collated orders). The upload
+// components resolve the design id via useResolvedDesignId (prefers :designId).
+const designDetailsChildren: RouteObject[] = [
+  {
+    path: "media",
+    lazy: () => import("../../routes/designs/design-media"),
+  },
+  {
+    path: "media-preview",
+    lazy: () => import("../../routes/designs/design-media-preview"),
+  },
+  {
+    path: "moodboard",
+    lazy: () => import("../../routes/designs/design-moodboard"),
+  },
+]
+
 export function getPartnerRouteMap(): RouteObject[] {
   return [
     {
@@ -638,25 +657,18 @@ export function getPartnerRouteMap(): RouteObject[] {
                       lazy: () =>
                         import("../../routes/orders/order-design-details"),
                       handle: { breadcrumb: () => "Design details" },
-                      children: [
-                        // Media / moodboard UPLOAD for the assigned design, in
-                        // the order context. The components resolve the design
-                        // id from the order via useResolvedDesignId.
-                        {
-                          path: "media",
-                          lazy: () => import("../../routes/designs/design-media"),
-                        },
-                        {
-                          path: "media-preview",
-                          lazy: () =>
-                            import("../../routes/designs/design-media-preview"),
-                        },
-                        {
-                          path: "moodboard",
-                          lazy: () =>
-                            import("../../routes/designs/design-moodboard"),
-                        },
-                      ],
+                      children: designDetailsChildren,
+                    },
+                    // #826 — per-design details for a COLLATED order (many
+                    // designs on one order). `:designId` selects WHICH design;
+                    // OrderDesignDetails resolves it directly instead of via the
+                    // order's single legacy_id run pointer.
+                    {
+                      path: "design-details/:designId",
+                      lazy: () =>
+                        import("../../routes/orders/order-design-details"),
+                      handle: { breadcrumb: () => "Design details" },
+                      children: designDetailsChildren,
                     },
                     // #342 — inventory work-order actions folded onto the
                     // unified order detail. Nested under `inventory/` to avoid

--- a/apps/partner-ui/src/hooks/use-resolved-design-id.tsx
+++ b/apps/partner-ui/src/hooks/use-resolved-design-id.tsx
@@ -11,19 +11,25 @@ import { usePartnerProductionRun } from "./api/partner-production-runs"
  * standalone design manager and the in-order design-details sub-route.
  */
 export const useResolvedDesignId = (): string => {
-  const { id } = useParams()
+  const { id, designId: designIdParam } = useParams()
   const location = useLocation()
   const underOrder = location.pathname.startsWith("/orders/")
 
+  // #826 — a collated order's per-design route (`/design-details/:designId`)
+  // names the design directly; use it and skip the legacy_id run resolution.
   const { order } = useOrder(
     id || "",
     { fields: "id,metadata" },
-    { enabled: underOrder && !!id }
+    { enabled: underOrder && !designIdParam && !!id }
   )
   const runId = (order?.metadata as any)?.legacy_id as string | undefined
   const { production_run } = usePartnerProductionRun(runId ?? "", {
-    enabled: underOrder && !!runId,
+    enabled: underOrder && !designIdParam && !!runId,
   })
+
+  if (designIdParam) {
+    return designIdParam
+  }
 
   return (
     (underOrder ? ((production_run as any)?.design_id as string | undefined) : id) ||

--- a/apps/partner-ui/src/routes/orders/order-design-details/order-design-details.tsx
+++ b/apps/partner-ui/src/routes/orders/order-design-details/order-design-details.tsx
@@ -25,19 +25,27 @@ import { DesignMoodboardSection } from "../../designs/design-detail/components/d
  */
 export const OrderDesignDetails = () => {
   const { t } = useTranslation()
-  const { id } = useParams()
+  const { id, designId: designIdParam } = useParams()
 
   const { order } = useOrder(id!, { fields: "id,metadata" })
+  // #826 — a collated order links each card to `/design-details/:designId`, so
+  // the param names the design directly. Only fall back to the order's single
+  // legacy_id run pointer (legacy single-design orders) when no param is given.
   const runId = order?.metadata?.legacy_id as string | undefined
   const { production_run } = usePartnerProductionRun(runId ?? "", {
-    enabled: !!runId,
+    enabled: !designIdParam && !!runId,
   })
-  const designId = (production_run as any)?.design_id as string | undefined
+  const designId =
+    designIdParam ?? ((production_run as any)?.design_id as string | undefined)
   const { design, isPending } = usePartnerDesign(designId ?? "", {
     enabled: !!designId,
   })
 
-  if (!order || (runId && !production_run) || (designId && isPending)) {
+  if (
+    !order ||
+    (!designIdParam && runId && !production_run) ||
+    (designId && isPending)
+  ) {
     return <TwoColumnPageSkeleton mainSections={3} sidebarSections={1} showJSON={false} />
   }
 

--- a/apps/partner-ui/src/routes/orders/order-detail/order-detail.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/order-detail.tsx
@@ -4,6 +4,7 @@ import { Outlet, useLoaderData, useLocation, useParams } from "react-router-dom"
 import { TwoColumnPageSkeleton } from "../../../components/common/skeleton"
 import { TwoColumnPage } from "../../../components/layout/pages"
 import { InventoryOrderLines } from "../../../components/work-orders/inventory-order-lines"
+import { DesignOrderLines } from "../../../components/work-orders/design-order-lines"
 import {
   InventoryFulfillmentsSection,
   InventoryPaymentsSection,
@@ -158,20 +159,36 @@ export const OrderDetail = () => {
               productionRun={production_run}
               inventoryOrder={inventoryOrder}
             />
-            {kind === "design" && design && (
-              <WorkOrderSummarySection kind="design" design={design} designId={designId} />
-            )}
-            {kind === "design" && production_run && design && (
-              <ProductionRunCard
-                run={production_run}
-                design={design}
-                consumptionLogs={consumptionLogs}
-                consumptionCount={consumptionCount}
-                onActionSuccess={invalidateOrder}
-                showTimeline={false}
-                taskLinkBase="tasks"
-              />
-            )}
+            {/* #826 S3b — a COLLATED design work-order shows one line per design
+                (the "one order, many designs" view). Legacy per-run design
+                orders (one design each) keep the single-design detail below. */}
+            {kind === "design" &&
+              (order as any)?.metadata?.collated_design_order && (
+                <DesignOrderLines
+                  lines={((order as any).items ?? []) as Array<Record<string, any>>}
+                  currencyCode={(order as any).currency_code}
+                  totalPrice={(order as any).total}
+                />
+              )}
+            {kind === "design" &&
+              !(order as any)?.metadata?.collated_design_order &&
+              design && (
+                <WorkOrderSummarySection kind="design" design={design} designId={designId} />
+              )}
+            {kind === "design" &&
+              !(order as any)?.metadata?.collated_design_order &&
+              production_run &&
+              design && (
+                <ProductionRunCard
+                  run={production_run}
+                  design={design}
+                  consumptionLogs={consumptionLogs}
+                  consumptionCount={consumptionCount}
+                  onActionSuccess={invalidateOrder}
+                  showTimeline={false}
+                  taskLinkBase="tasks"
+                />
+              )}
             {kind === "inventory" && inventoryOrder && (
               <>
                 <WorkOrderSummarySection kind="inventory" inventoryOrder={inventoryOrder} />

--- a/apps/partner-ui/src/routes/orders/order-detail/order-detail.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/order-detail.tsx
@@ -5,6 +5,7 @@ import { TwoColumnPageSkeleton } from "../../../components/common/skeleton"
 import { TwoColumnPage } from "../../../components/layout/pages"
 import { InventoryOrderLines } from "../../../components/work-orders/inventory-order-lines"
 import { DesignOrderLines } from "../../../components/work-orders/design-order-lines"
+import { CollatedDesignRuns } from "../../../components/work-orders/collated-design-runs"
 import {
   InventoryFulfillmentsSection,
   InventoryPaymentsSection,
@@ -164,11 +165,20 @@ export const OrderDetail = () => {
                 orders (one design each) keep the single-design detail below. */}
             {kind === "design" &&
               (order as any)?.metadata?.collated_design_order && (
-                <DesignOrderLines
-                  lines={((order as any).items ?? []) as Array<Record<string, any>>}
-                  currencyCode={(order as any).currency_code}
-                  totalPrice={(order as any).total}
-                />
+                <>
+                  <DesignOrderLines
+                    lines={((order as any).items ?? []) as Array<Record<string, any>>}
+                    currencyCode={(order as any).currency_code}
+                    totalPrice={(order as any).total}
+                  />
+                  {/* #826 — per-design production lifecycle (accept → start →
+                      finish → complete) for EVERY design of the collated order,
+                      driven from this one screen. */}
+                  <CollatedDesignRuns
+                    lines={((order as any).items ?? []) as Array<Record<string, any>>}
+                    onActionSuccess={invalidateOrder}
+                  />
+                </>
               )}
             {kind === "design" &&
               !(order as any)?.metadata?.collated_design_order &&


### PR DESCRIPTION
Part of #826 — collate designs so a partner sees ONE order with N design line items (design analog of the inventory order collation).

## What's here (2 slices, both tested)

### S1 — admin "Create Order" from the Designs list (`03e9c12d0`)
Multi-select N designs on the general Designs list → create ONE collated commissioning order (one line item per design), the grouping key the partner-side collation keys on via `run.order_id`.
- `admin/routes/designs/page.tsx`: "Create Order" command on the existing DataTable CommandBar; reuses `DesignOrderPreviewDrawer` + `/admin/customers/:id/design-order[/preview]`; auto-resolves the target customer from the selected designs (single-customer required, picker deferred).
- `api/admin/designs/route.ts`: enrich `GET /admin/designs` with each design's linked `customer_id` (one link query for the page) so the list can auto-resolve.
- Integration: `designs-collated-order-s1.spec.ts` (enrichment + collated create) — 3/3.
- Verified: admin UI Playwright (drawer shows both designs, ₹ total, 0 console errors).

### S3 step 1 — produce a design order / per-line run fan-out (`2817b1698`)
`createRunsForDesignOrder(container, orderId)`: fan out one `production_run` per design line item, each stamped `order_id` (collation group key) + `order_line_item_id` + `design_id`. Idempotent.
- Design orders DELIBERATELY build title-only line items so `order-placed` doesn't auto-spawn runs; producing is an explicit step, and runs previously carried no commissioning `order_id`. This gives the collated projection its group key.
- Integration: `design-order-produce-fanout.spec.ts` — 1/1 (create + idempotent re-produce).

## Design
`apps/docs/notes/826_DESIGN_ORDER_COLLATION.md` — #342-grounded: Option A, work-order-projection anchor, `order↔run` 1:1→1:many.

## Baseline (before)
Verified live on partner-ui: N designs currently render as N separate "Design Orders" — the fragmentation this closes.

## Still to come (separate passes)
- **S3a** — batch `projectRunToUnifiedOrder` (N runs sharing `order_id` → one work-order, N lines); `order↔run` 1:many + migration; status aggregation; de-1:1 partner detail route.
- **S3b** — `<DesignOrderLines>` partner render (mirror `<InventoryOrderLines>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)