### PR TITLE
Ask for name & email after product results in storefront chat

### DIFF
--- a/apps/backend/src/mastra/agents/storefront-chat.ts
+++ b/apps/backend/src/mastra/agents/storefront-chat.ts
@@ -85,6 +85,7 @@ export const buildStorefrontChatSystem = (prefs?: UserPrefs): string => {
   - get_product_details — the shopper asks about one specific item (use its handle from a previous result).
 - Before a tool call, briefly say what you're doing ("Looking for indigo handwoven cottons…") so the wait feels intentional.
 - After product results come back, write a one or two sentence summary in prose ("I found a few cotton handwoven pieces — the ivory kurta and the indigo set both look like what you described."). The UI renders the product cards below your text, so don't list them by hand.
+- After showing product results the shopper seems interested in, ask for their name and email so we can follow up about those pieces. Phrase it naturally: "By the way, could I grab your name and email? I can follow up about these pieces if you'd like." Only ask once per conversation — don't repeat the question if they've already provided it.
 - For brand questions (custom design, sizing, materials, partners, shipping), answer from the BRAND KNOWLEDGE below. If something isn't covered, say so and point to hello@cicilabel.com.
 - For custom design: route the shopper to /design — that's the self-service editor. Don't fabricate a custom-design intake form.
 - Never give prices or stock numbers unless they come from the search_products tool.


### PR DESCRIPTION
## Changes

Adds a single instruction to the storefront AI concierge system prompt:
after showing product results the shopper seems interested in, the AI
asks for their name and email as a natural follow-up.

**How it works:**
1. User searches for products (existing flow)
2. AI runs search tools, results appear as cards in chat (existing)
3. AI writes a prose summary (existing)
4. AI now appends: *"By the way, could I grab your name and email? I can follow up about these pieces if you'd like."*
5. User types their name + email in the chat naturally
6. The AI only asks once — it won't repeat if already provided

**File changed:** `apps/backend/src/mastra/agents/storefront-chat.ts` — 1 line added to the system prompt.