### PR TITLE
feat(raw-material-groups): additive variant dimensions + member attributes

### DIFF
--- a/apps/backend/src/api/admin/raw-material-groups/[id]/colors/route.ts
+++ b/apps/backend/src/api/admin/raw-material-groups/[id]/colors/route.ts
@@ -80,6 +80,9 @@ export const POST = async (
       "minimum_order_quantity",
       inherit(body.minimum_order_quantity, group.minimum_order_quantity)
     ),
+    // Generic variant coordinates: always seed `color` (the built-in axis) and
+    // fold in any extra axes the caller supplied per the group's `dimensions`.
+    attributes: { ...(body.attributes ?? {}), color: body.color },
     ...(body.metadata ? { metadata: body.metadata } : {}),
     ...(body.media ? { media: body.media } : {}),
     group_id: groupId,

--- a/apps/backend/src/api/admin/raw-material-groups/__tests__/validators.unit.spec.ts
+++ b/apps/backend/src/api/admin/raw-material-groups/__tests__/validators.unit.spec.ts
@@ -1,0 +1,43 @@
+import {
+  createRawMaterialGroupSchema,
+  updateRawMaterialGroupSchema,
+  addGroupColorSchema,
+} from "../validators"
+
+describe("raw-material-group validators — dimensions/attributes (additive flexibility)", () => {
+  it("accepts operator-defined dimensions on create", () => {
+    const parsed = createRawMaterialGroupSchema.parse({
+      name: "Cotton Poplin",
+      dimensions: [
+        { key: "color", label: "Color" },
+        { key: "finish", label: "Finish", values: ["Matte", "Gloss"] },
+      ],
+    })
+    expect(parsed.dimensions).toHaveLength(2)
+    expect(parsed.dimensions?.[1]).toEqual({
+      key: "finish",
+      label: "Finish",
+      values: ["Matte", "Gloss"],
+    })
+  })
+
+  it("omits dimensions entirely when not provided (color-only default)", () => {
+    const parsed = createRawMaterialGroupSchema.parse({ name: "Linen" })
+    expect("dimensions" in parsed).toBe(false)
+  })
+
+  it("rejects a dimension missing its key/label", () => {
+    expect(() =>
+      updateRawMaterialGroupSchema.parse({ dimensions: [{ label: "Finish" }] })
+    ).toThrow()
+  })
+
+  it("accepts per-member attributes on a color add", () => {
+    const parsed = addGroupColorSchema.parse({
+      name: "Blue Matte",
+      color: "Blue",
+      attributes: { color: "Blue", finish: "Matte" },
+    })
+    expect(parsed.attributes).toEqual({ color: "Blue", finish: "Matte" })
+  })
+})

--- a/apps/backend/src/api/admin/raw-material-groups/validators.ts
+++ b/apps/backend/src/api/admin/raw-material-groups/validators.ts
@@ -23,10 +23,20 @@ const GROUP_STATUS = [
 
 // --- Group CRUD ---
 
+// Operator-defined variant axes a group varies its members along. `color` is the
+// built-in axis and never needs declaring here; `dimensions` is additive room
+// for extra axes (finish, pattern, size, …) — see raw_material_group.dimensions.
+const groupDimensionSchema = z.object({
+  key: z.string().min(1),
+  label: z.string().min(1),
+  values: z.array(z.string()).optional(),
+})
+
 // #829 — global specs the group holds once; new colors inherit these fill-blank.
 const groupGlobalsShape = {
   composition: z.string().optional(),
   specifications: z.record(z.string(), z.unknown()).optional(),
+  dimensions: z.array(groupDimensionSchema).optional(),
   unit_of_measure: z.enum(UNIT_OF_MEASURE).optional(),
   material_type_id: z.string().optional(),
   // A category NAME (find-or-create); resolved to material_type_id server-side.
@@ -85,6 +95,9 @@ export const addGroupColorSchema = z.object({
   cost_currency: z.string().optional(),
   lead_time_days: z.number().int().optional(),
   minimum_order_quantity: z.number().int().optional(),
+  // Per-member variant coordinates keyed by the group's `dimensions`
+  // (e.g. { color: "Blue", finish: "Matte" }). `color` above stays canonical.
+  attributes: z.record(z.string(), z.unknown()).optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
   media: z.record(z.string(), z.unknown()).optional(),
 })

--- a/apps/backend/src/modules/raw_material/migrations/Migration20260702120000.ts
+++ b/apps/backend/src/modules/raw_material/migrations/Migration20260702120000.ts
@@ -1,0 +1,29 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Material-group flexibility (additive) — generalize groups beyond the built-in
+ * `color` axis WITHOUT breaking anything.
+ *
+ * - `raw_material_group.dimensions` (jsonb): operator-defined extra variant axes
+ *   ({ key, label, values? }[]). Null/empty ⇒ color-only (today's behavior).
+ * - `raw_materials.attributes` (jsonb): per-member variant coordinates keyed by
+ *   those dimensions ({ color, finish, … }). `color` column stays the canonical
+ *   display/denorm key.
+ *
+ * Hand-written idempotent ALTER (add-column-if-not-exists): both tables already
+ * exist on live DBs, so editing their create-table migrations would never land
+ * these columns on existing databases (the create-if-not-exists hazard).
+ */
+export class Migration20260702120000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "raw_material_group" add column if not exists "dimensions" jsonb null;`);
+    this.addSql(`alter table if exists "raw_materials" add column if not exists "attributes" jsonb null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "raw_material_group" drop column if exists "dimensions";`);
+    this.addSql(`alter table if exists "raw_materials" drop column if exists "attributes";`);
+  }
+
+}

--- a/apps/backend/src/modules/raw_material/models/raw_material.ts
+++ b/apps/backend/src/modules/raw_material/models/raw_material.ts
@@ -22,6 +22,11 @@ const RawMaterial = model.define("raw_materials", {
   minimum_order_quantity: model.number().nullable(),
   lead_time_days: model.number().nullable(),
   color: model.text().nullable(),
+  // Generic per-member variant coordinates keyed by the parent group's
+  // `dimensions` (e.g. { color: "Blue", finish: "Matte" }). `color` above stays
+  // the canonical display/denorm key; `attributes` is additive room for new axes
+  // introduced on the group later — no migration required to add an axis.
+  attributes: model.json().nullable(),
   width: model.text().nullable(), // For fabrics and similar materials
   weight: model.text().nullable(), // Weight per unit
   grade: model.text().nullable(),

--- a/apps/backend/src/modules/raw_material/models/raw_material_group.ts
+++ b/apps/backend/src/modules/raw_material/models/raw_material_group.ts
@@ -16,6 +16,12 @@ const RawMaterialGroup = model.define("raw_material_group", {
   description: model.text().translatable().nullable(),
   composition: model.text().translatable().nullable(), // shared, e.g. "100% Cotton"
   specifications: model.json().nullable(), // shared technical specifications
+  // Operator-defined variant axes this group varies its members along. `color`
+  // is the built-in, always-present axis (kept as a first-class column on the
+  // member for display/denorm); `dimensions` lets a group declare additional
+  // axes later (finish, pattern, size, …) WITHOUT a schema change — each entry
+  // is { key, label, values? }. Empty/null ⇒ color-only (today's behavior).
+  dimensions: model.json().nullable(),
   unit_of_measure: model.enum([
     "Meter",
     "Yard",


### PR DESCRIPTION
## What
Generalize material groups beyond the built-in `color` axis — **additively**, so nothing existing breaks.

- **`raw_material_group.dimensions`** (jsonb): operator-defined extra variant axes (`{ key, label, values? }[]`). Null/empty ⇒ color-only (today's behavior).
- **`raw_materials.attributes`** (jsonb): per-member variant coordinates keyed by those dimensions (e.g. `{ color: "Blue", finish: "Matte" }`). `color` stays the canonical display/denorm key; the color-add route always seeds `attributes.color`.

## Why
Foundation so new variant axes (finish, pattern, size, …) can be introduced **later with no migration churn**.

## How
- Hand-written idempotent ALTER migration (`Migration20260702120000`) — both tables already exist on live DBs (create-if-not-exists hazard).
- Validators accept `dimensions` (group create/update) + `attributes` (color add); routes already spread `...rest` so they flow through.

## Tests
- 4 validator unit tests (`raw-material-groups/__tests__/validators.unit.spec.ts`) — green.
- Typecheck clean.

## Note
The dimensions **editor UI** is intentionally deferred ("define later") until a concrete second axis is needed — this PR is the data-layer foundation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)