### PR TITLE
feat(inventory-orders): mass batches in material-group quick-add

### DIFF
--- a/apps/backend/src/admin/components/creates/create-inventory-order.tsx
+++ b/apps/backend/src/admin/components/creates/create-inventory-order.tsx
@@ -29,6 +29,7 @@ export const inventoryOrderFormSchema = z
           inventory_item_id: z.string().min(1, "Item is required"),
           quantity: z.number().min(1, "Quantity must be at least 1"),
           price: z.number().min(0, "Price must be non-negative"),
+          batch_number: z.number().int().positive().nullish(), // batch tag (separate-batch adds)
         })
       )
       .min(1, "At least one order line is required"),
@@ -50,6 +51,7 @@ interface OrderLine {
   inventory_item_id: string;
   quantity: number;
   price: number;
+  batch_number?: number | null;
 }
 
 enum Tab {
@@ -170,10 +172,11 @@ export const CreateInventoryOrderComponent = () => {
       is_sample: data.is_sample,
       order_lines: fields
         .filter((l: OrderLine) => l.inventory_item_id)
-        .map(({ inventory_item_id, quantity, price }: OrderLine) => ({ 
-          inventory_item_id, 
-          quantity: Number(quantity) || 0, 
-          price: Number(price) || 0 
+        .map(({ inventory_item_id, quantity, price, batch_number }: OrderLine) => ({
+          inventory_item_id,
+          quantity: Number(quantity) || 0,
+          price: Number(price) || 0,
+          batch_number: batch_number ?? null,
         })),
     };
     if (data.from_stock_location_id) {

--- a/apps/backend/src/admin/components/creates/inventory-order-lines-grid.tsx
+++ b/apps/backend/src/admin/components/creates/inventory-order-lines-grid.tsx
@@ -107,6 +107,7 @@ interface InventoryOrderLine {
   inventory_item_id: string;
   quantity: number;
   price: number;
+  batch_number?: number | null;
 }
 
 interface InventoryOrderLinesGridProps<T> {
@@ -309,6 +310,27 @@ export const InventoryOrderLinesGrid = <T extends { id: string; title?: string; 
             {color ? (
               <Badge size="2xsmall" color="grey" className="capitalize">
                 {color}
+              </Badge>
+            ) : (
+              <Text size="small" className="text-ui-fg-muted">
+                —
+              </Text>
+            )}
+          </div>
+        );
+      },
+    }),
+    columnHelper.column({
+      id: "batch",
+      name: "Batch",
+      header: "Batch",
+      cell: (context: any) => {
+        const batch = lineAt(context.row.index)?.batch_number;
+        return (
+          <div className="flex h-full items-center px-4">
+            {batch ? (
+              <Badge size="2xsmall" color="blue">
+                {`#${batch}`}
               </Badge>
             ) : (
               <Text size="small" className="text-ui-fg-muted">

--- a/apps/backend/src/admin/components/inventory-orders/__tests__/group-batch-helpers.unit.spec.ts
+++ b/apps/backend/src/admin/components/inventory-orders/__tests__/group-batch-helpers.unit.spec.ts
@@ -1,0 +1,116 @@
+import {
+  expandGroupsToBatchLines,
+  summarizeExpansion,
+  type GroupForExpansion,
+} from "../group-batch-helpers"
+
+const group = (
+  name: string,
+  colors: Array<string | null>,
+  extra: Partial<GroupForExpansion> = {}
+): GroupForExpansion => ({
+  name,
+  raw_materials: colors.map((id) =>
+    id ? { inventory_item: { id } } : { inventory_item: null }
+  ),
+  ...extra,
+})
+
+describe("expandGroupsToBatchLines", () => {
+  it("summed mode: one line per color, quantity = MOQ × batches", () => {
+    const { lines, summary } = expandGroupsToBatchLines({
+      groups: [group("Cotton", ["ii_1", "ii_2"], { minimum_order_quantity: 50, unit_cost: 7 })],
+      existingItemIds: [],
+      batches: 4,
+      keepSeparate: false,
+    })
+    expect(lines).toHaveLength(2)
+    expect(lines[0]).toEqual({ inventory_item_id: "ii_1", quantity: 200, price: 7, batch_number: null })
+    expect(summary.added).toBe(2)
+    expect(summary.batches).toBe(4)
+  })
+
+  it("separate mode: N lines per color tagged 1..N", () => {
+    const { lines, summary } = expandGroupsToBatchLines({
+      groups: [group("Cotton", ["ii_1"], { minimum_order_quantity: 50 })],
+      existingItemIds: [],
+      batches: 3,
+      keepSeparate: true,
+    })
+    expect(lines).toHaveLength(3)
+    expect(lines.map((l) => l.batch_number)).toEqual([1, 2, 3])
+    expect(lines.every((l) => l.quantity === 50)).toBe(true)
+    expect(summary.colors).toBe(1)
+    expect(summary.added).toBe(3)
+  })
+
+  it("summed mode skips colors already in the order; separate mode does not", () => {
+    const summed = expandGroupsToBatchLines({
+      groups: [group("Cotton", ["ii_1", "ii_2"])],
+      existingItemIds: ["ii_1"],
+      batches: 1,
+      keepSeparate: false,
+    })
+    expect(summed.lines.map((l) => l.inventory_item_id)).toEqual(["ii_2"])
+    expect(summed.summary.skippedDuplicate).toBe(1)
+
+    const separate = expandGroupsToBatchLines({
+      groups: [group("Cotton", ["ii_1"])],
+      existingItemIds: ["ii_1"],
+      batches: 2,
+      keepSeparate: true,
+    })
+    expect(separate.lines).toHaveLength(2)
+    expect(separate.summary.skippedDuplicate).toBe(0)
+  })
+
+  it("dedupes the same color across multiple selected groups (summed)", () => {
+    const { lines, summary } = expandGroupsToBatchLines({
+      groups: [group("A", ["ii_1"]), group("B", ["ii_1", "ii_2"])],
+      existingItemIds: [],
+      batches: 1,
+      keepSeparate: false,
+    })
+    expect(lines.map((l) => l.inventory_item_id).sort()).toEqual(["ii_1", "ii_2"])
+    expect(summary.skippedDuplicate).toBe(1)
+  })
+
+  it("counts colors without a stock item as skipped, never emits them", () => {
+    const { lines, summary } = expandGroupsToBatchLines({
+      groups: [group("A", ["ii_1", null, null])],
+      existingItemIds: [],
+      batches: 1,
+      keepSeparate: false,
+    })
+    expect(lines).toHaveLength(1)
+    expect(summary.skippedNoItem).toBe(2)
+  })
+
+  it("defaults MOQ→1 and unit_cost→0 when unset, and clamps batches to >= 1", () => {
+    const { lines } = expandGroupsToBatchLines({
+      groups: [group("A", ["ii_1"])],
+      existingItemIds: [],
+      batches: 0,
+      keepSeparate: false,
+    })
+    expect(lines[0]).toEqual({ inventory_item_id: "ii_1", quantity: 1, price: 0, batch_number: null })
+  })
+})
+
+describe("summarizeExpansion", () => {
+  it("describes separate-batch adds", () => {
+    const s = { added: 6, colors: 2, skippedDuplicate: 0, skippedNoItem: 1, batches: 3, keepSeparate: true }
+    const msg = summarizeExpansion(s, 1)
+    expect(msg).toContain("6 lines")
+    expect(msg).toContain("2 colors × 3 batches")
+    expect(msg).toContain("1 without a stock item")
+  })
+
+  it("describes summed adds", () => {
+    const s = { added: 2, colors: 2, skippedDuplicate: 1, skippedNoItem: 0, batches: 4, keepSeparate: false }
+    const msg = summarizeExpansion(s, 2)
+    expect(msg).toContain("2 colors from 2 groups")
+    expect(msg).toContain("×4 batches summed")
+    expect(msg).toContain("1 already in the order")
+  })
+})

--- a/apps/backend/src/admin/components/inventory-orders/add-material-group-control.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/add-material-group-control.tsx
@@ -1,20 +1,32 @@
-import { useEffect, useState } from "react"
-import { Select, toast } from "@medusajs/ui"
+import { useMemo, useState } from "react"
 import {
-  useRawMaterialGroups,
-  useRawMaterialGroup,
-} from "../../hooks/api/raw-material-groups"
+  Button,
+  Checkbox,
+  Input,
+  Label,
+  Popover,
+  Switch,
+  Text,
+  toast,
+} from "@medusajs/ui"
+import { sdk } from "../../lib/config"
+import { useRawMaterialGroups } from "../../hooks/api/raw-material-groups"
+import type { RawMaterialGroup } from "../../hooks/api/raw-material-groups"
+import {
+  expandGroupsToBatchLines,
+  summarizeExpansion,
+  type BatchLineToAdd,
+} from "./group-batch-helpers"
 
-export type GroupLineToAdd = {
-  inventory_item_id: string
-  quantity: number
-  price: number
-}
+// Kept for backwards compatibility with earlier callers; the batch fields are
+// additive so the append() sites don't need to change.
+export type GroupLineToAdd = BatchLineToAdd
 
 interface AddMaterialGroupControlProps {
   /**
    * inventory_item_ids already present in the order-lines form — group members
-   * matching these are skipped so re-selecting a group never duplicates a line.
+   * matching these are skipped (summed mode) so re-selecting a group never
+   * duplicates a line.
    */
   existingItemIds: string[]
   /** Called with the resolved lines the parent should append to its field array. */
@@ -23,15 +35,16 @@ interface AddMaterialGroupControlProps {
 }
 
 /**
- * #846 — "add by Material Group" for the inventory order-lines picker. Selecting
- * a group fans out ALL of its per-color members that already have an inventory
- * item into order lines in one action, pre-filling quantity (group MOQ, else 1)
- * and price (group unit_cost, else 0) — both still editable in the grid.
+ * "Add by Material Group" for the inventory order-lines picker — now supports
+ * MASS BATCHES: pick several groups at once, choose a batch count N, and decide
+ * whether the batches collapse into one line per color (summed) or stay as N
+ * separate, individually-trackable lines (see group-batch-helpers).
  *
- * Colors that don't have an inventory item yet are skipped here (the create flow
- * needs a concrete inventory_item_id); the group-order endpoint's fan-out
- * (resolveGroupColorInventoryItemsWorkflow) is the path that auto-creates those,
- * so we surface a count rather than silently dropping them.
+ * Group detail (per-color members + their inventory items) is fetched on demand
+ * for the selected groups when "Add" is pressed — the list endpoint doesn't
+ * carry the linked inventory items. Colors without an inventory item yet are
+ * skipped (the create flow needs a concrete inventory_item_id) and surfaced in
+ * the toast rather than silently dropped.
  */
 export const AddMaterialGroupControl = ({
   existingItemIds,
@@ -41,95 +54,175 @@ export const AddMaterialGroupControl = ({
   const { data, isLoading } = useRawMaterialGroups({ limit: 100 })
   const groups = data?.raw_material_groups ?? []
 
-  // Two-step: pick a group -> fetch its detail (colors + linked items) -> add.
-  const [pendingId, setPendingId] = useState<string | null>(null)
-  const { data: detail, isFetching } = useRawMaterialGroup(pendingId ?? undefined)
+  const [open, setOpen] = useState(false)
+  const [selected, setSelected] = useState<Record<string, boolean>>({})
+  const [batches, setBatches] = useState(1)
+  const [keepSeparate, setKeepSeparate] = useState(false)
+  const [busy, setBusy] = useState(false)
 
-  useEffect(() => {
-    if (!pendingId) {
+  const selectedIds = useMemo(
+    () => Object.keys(selected).filter((id) => selected[id]),
+    [selected]
+  )
+
+  const reset = () => {
+    setSelected({})
+    setBatches(1)
+    setKeepSeparate(false)
+  }
+
+  const handleAdd = async () => {
+    if (!selectedIds.length) {
       return
     }
-    const group = detail?.raw_material_group
-    if (!group || group.id !== pendingId) {
-      return
-    }
-
-    const existing = new Set(existingItemIds)
-    const colors = group.raw_materials ?? []
-    const quantity =
-      group.minimum_order_quantity && group.minimum_order_quantity > 0
-        ? group.minimum_order_quantity
-        : 1
-    const price = typeof group.unit_cost === "number" ? group.unit_cost : 0
-
-    const toAdd: GroupLineToAdd[] = []
-    let skippedNoItem = 0
-    let skippedDuplicate = 0
-    for (const color of colors) {
-      const inventoryItemId = color.inventory_item?.id
-      if (!inventoryItemId) {
-        skippedNoItem++
-        continue
+    setBusy(true)
+    try {
+      // Fetch each selected group's detail (colors + linked inventory items).
+      const details = await Promise.all(
+        selectedIds.map((id) =>
+          sdk.client
+            .fetch<{ raw_material_group: RawMaterialGroup }>(
+              `/admin/raw-material-groups/${id}`
+            )
+            .then((r) => r.raw_material_group)
+            .catch(() => null)
+        )
+      )
+      const resolvedGroups = details.filter(Boolean) as RawMaterialGroup[]
+      if (!resolvedGroups.length) {
+        toast.error("Could not load the selected group(s)")
+        return
       }
-      if (existing.has(inventoryItemId)) {
-        skippedDuplicate++
-        continue
+
+      const { lines, summary } = expandGroupsToBatchLines({
+        groups: resolvedGroups.map((g) => ({
+          name: g.name,
+          minimum_order_quantity: g.minimum_order_quantity ?? null,
+          unit_cost: g.unit_cost ?? null,
+          raw_materials: (g.raw_materials ?? []).map((c) => ({
+            inventory_item: c.inventory_item ?? null,
+          })),
+        })),
+        existingItemIds,
+        batches,
+        keepSeparate,
+      })
+
+      if (lines.length) {
+        onAdd(lines)
       }
-      existing.add(inventoryItemId)
-      toAdd.push({ inventory_item_id: inventoryItemId, quantity, price })
-    }
+      const msg = summarizeExpansion(summary, resolvedGroups.length)
+      if (lines.length) {
+        toast.success(msg)
+      } else {
+        toast.info(msg)
+      }
 
-    if (toAdd.length) {
-      onAdd(toAdd)
+      reset()
+      setOpen(false)
+    } finally {
+      setBusy(false)
     }
+  }
 
-    const summary = [
-      `Added ${toAdd.length} ${toAdd.length === 1 ? "color" : "colors"} from “${group.name}”`,
-    ]
-    if (skippedDuplicate) {
-      summary.push(`${skippedDuplicate} already in the order`)
-    }
-    if (skippedNoItem) {
-      summary.push(`${skippedNoItem} without a stock item yet`)
-    }
-    if (toAdd.length) {
-      toast.success(summary.join(" · "))
-    } else {
-      toast.info(summary.join(" · "))
-    }
-
-    setPendingId(null)
-  }, [detail, pendingId, existingItemIds, onAdd])
+  const triggerDisabled = disabled || isLoading || groups.length === 0
 
   return (
-    <Select
-      size="small"
-      value=""
-      onValueChange={(value) => setPendingId(value)}
-      disabled={disabled || isLoading || isFetching || groups.length === 0}
-    >
-      <Select.Trigger className="min-w-[200px]">
-        <Select.Value
-          placeholder={
-            groups.length === 0
-              ? "No material groups"
-              : isFetching
-                ? "Adding…"
-                : "Add a material group…"
-          }
-        />
-      </Select.Trigger>
-      <Select.Content>
-        {groups.map((group) => {
-          const count = group.raw_materials?.length
-          return (
-            <Select.Item key={group.id} value={group.id}>
-              {group.name}
-              {count ? ` (${count})` : ""}
-            </Select.Item>
-          )
-        })}
-      </Select.Content>
-    </Select>
+    <Popover open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <Button size="small" variant="secondary" type="button" disabled={triggerDisabled}>
+          {groups.length === 0 ? "No material groups" : "Add material groups…"}
+        </Button>
+      </Popover.Trigger>
+      <Popover.Content className="w-80 p-0" align="end">
+        <div className="flex flex-col">
+          <div className="max-h-64 overflow-y-auto p-3">
+            {groups.length === 0 ? (
+              <Text size="small" className="text-ui-fg-subtle">
+                No material groups yet.
+              </Text>
+            ) : (
+              <div className="flex flex-col gap-y-2">
+                {groups.map((group) => {
+                  const count = group.raw_materials?.length
+                  return (
+                    <label
+                      key={group.id}
+                      className="flex items-center gap-x-2 cursor-pointer"
+                    >
+                      <Checkbox
+                        checked={!!selected[group.id]}
+                        onCheckedChange={(v) =>
+                          setSelected((s) => ({ ...s, [group.id]: !!v }))
+                        }
+                      />
+                      <Text size="small" className="flex-1">
+                        {group.name}
+                        {count ? (
+                          <span className="text-ui-fg-subtle">{` (${count})`}</span>
+                        ) : (
+                          ""
+                        )}
+                      </Text>
+                    </label>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+
+          <div className="border-t border-ui-border-base p-3 flex flex-col gap-y-3">
+            <div className="flex items-center justify-between">
+              <Label size="small" htmlFor="mg-batches" weight="plus">
+                Batches
+              </Label>
+              <Input
+                id="mg-batches"
+                type="number"
+                min={1}
+                className="w-20"
+                size="small"
+                value={batches}
+                onChange={(e) =>
+                  setBatches(Math.max(1, Math.floor(Number(e.target.value) || 1)))
+                }
+              />
+            </div>
+
+            <div className="flex items-center justify-between gap-x-2">
+              <div className="flex flex-col">
+                <Label size="small" htmlFor="mg-separate" weight="plus">
+                  Keep batches as separate lines
+                </Label>
+                <Text size="xsmall" className="text-ui-fg-subtle">
+                  {keepSeparate
+                    ? "One line per batch (trackable)"
+                    : "Summed into one line per color"}
+                </Text>
+              </div>
+              <Switch
+                id="mg-separate"
+                checked={keepSeparate}
+                onCheckedChange={setKeepSeparate}
+              />
+            </div>
+
+            <Button
+              size="small"
+              type="button"
+              onClick={handleAdd}
+              disabled={!selectedIds.length || busy}
+              isLoading={busy}
+            >
+              {selectedIds.length
+                ? `Add ${selectedIds.length} ${
+                    selectedIds.length === 1 ? "group" : "groups"
+                  }`
+                : "Select groups"}
+            </Button>
+          </div>
+        </div>
+      </Popover.Content>
+    </Popover>
   )
 }

--- a/apps/backend/src/admin/components/inventory-orders/edit-order-lines.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/edit-order-lines.tsx
@@ -20,6 +20,7 @@ const editOrderLinesSchema = z.object({
         inventory_item_id: z.string().min(1, "Item is required"),
         quantity: z.number().min(1, "Quantity must be at least 1"),
         price: z.number().min(0, "Price must be non-negative"),
+        batch_number: z.number().int().positive().nullish(), // batch tag (separate-batch adds)
         isExisting: z.boolean().optional(), // Flag to mark existing lines
       })
     )
@@ -33,6 +34,7 @@ interface OrderLine {
   inventory_item_id: string;
   quantity: number;
   price: number;
+  batch_number?: number | null;
   isExisting?: boolean;
 }
 
@@ -53,6 +55,7 @@ export const EditOrderLines = ({ inventoryOrder }: EditOrderLinesProps) => {
     inventory_item_id: line.inventory_items?.[0]?.id || line.inventory_item_id || "",
     quantity: line.quantity,
     price: line.price,
+    batch_number: line.batch_number ?? null,
     isExisting: true, // Mark as existing
   }));
 
@@ -110,6 +113,7 @@ export const EditOrderLines = ({ inventoryOrder }: EditOrderLinesProps) => {
         inventory_item_id: formLine.inventory_item_id,
         quantity: Number(formLine.quantity) || 0,
         price: Number(formLine.price) || 0,
+        batch_number: (formLine as any).batch_number ?? line.batch_number ?? null,
       };
     });
 

--- a/apps/backend/src/admin/components/inventory-orders/group-batch-helpers.ts
+++ b/apps/backend/src/admin/components/inventory-orders/group-batch-helpers.ts
@@ -1,0 +1,144 @@
+/**
+ * Pure batch-expansion logic for the material-group quick-add ("mass batches").
+ *
+ * Given one or more selected groups, a batch count N, and whether to keep
+ * batches as separate lines, produce the order-line rows to append. Kept pure
+ * (no React / no network) so it's unit-testable and the control stays thin.
+ *
+ * Two modes:
+ *  - summed (keepSeparate=false): each color → ONE line, quantity = baseQty × N,
+ *    batch_number null. Deduped against lines already in the order.
+ *  - separate (keepSeparate=true): each color → N lines tagged batch 1..N, each
+ *    quantity = baseQty. Not deduped — the operator explicitly wants the batches.
+ *
+ * baseQty = group MOQ (when > 0) else 1. price = group unit_cost else 0. Both
+ * stay editable in the grid afterwards. Colors without an inventory item yet are
+ * skipped (the create flow needs a concrete inventory_item_id) and surfaced in
+ * the summary rather than silently dropped.
+ */
+
+export type GroupColorMember = {
+  inventory_item?: { id?: string | null } | null
+}
+
+export type GroupForExpansion = {
+  name: string
+  minimum_order_quantity?: number | null
+  unit_cost?: number | null
+  raw_materials?: GroupColorMember[] | null
+}
+
+export type BatchLineToAdd = {
+  inventory_item_id: string
+  quantity: number
+  price: number
+  batch_number?: number | null
+}
+
+export type ExpandSummary = {
+  added: number
+  colors: number
+  skippedDuplicate: number
+  skippedNoItem: number
+  batches: number
+  keepSeparate: boolean
+}
+
+export function expandGroupsToBatchLines(opts: {
+  groups: GroupForExpansion[]
+  existingItemIds: string[]
+  batches: number
+  keepSeparate: boolean
+}): { lines: BatchLineToAdd[]; summary: ExpandSummary } {
+  const { groups, existingItemIds, keepSeparate } = opts
+  // Clamp to a sane minimum of 1 batch.
+  const batches = Math.max(1, Math.floor(Number(opts.batches) || 1))
+
+  const existing = new Set(existingItemIds)
+  const lines: BatchLineToAdd[] = []
+  let colors = 0
+  let skippedDuplicate = 0
+  let skippedNoItem = 0
+
+  for (const group of groups) {
+    const baseQty =
+      group.minimum_order_quantity && group.minimum_order_quantity > 0
+        ? group.minimum_order_quantity
+        : 1
+    const price = typeof group.unit_cost === "number" ? group.unit_cost : 0
+
+    for (const color of group.raw_materials ?? []) {
+      const itemId = color.inventory_item?.id
+      if (!itemId) {
+        skippedNoItem++
+        continue
+      }
+
+      if (keepSeparate) {
+        // N distinct batch lines — always added (batches are additive).
+        for (let b = 1; b <= batches; b++) {
+          lines.push({
+            inventory_item_id: itemId,
+            quantity: baseQty,
+            price,
+            batch_number: b,
+          })
+        }
+        colors++
+      } else {
+        // One summed line per color — skip if already present in the order or a
+        // sibling selected group already contributed it.
+        if (existing.has(itemId)) {
+          skippedDuplicate++
+          continue
+        }
+        existing.add(itemId)
+        lines.push({
+          inventory_item_id: itemId,
+          quantity: baseQty * batches,
+          price,
+          batch_number: null,
+        })
+        colors++
+      }
+    }
+  }
+
+  return {
+    lines,
+    summary: {
+      added: lines.length,
+      colors,
+      skippedDuplicate,
+      skippedNoItem,
+      batches,
+      keepSeparate,
+    },
+  }
+}
+
+/** Human-readable one-liner for the quick-add toast. */
+export function summarizeExpansion(s: ExpandSummary, groupCount: number): string {
+  const parts: string[] = []
+  const groupLabel = `${groupCount} ${groupCount === 1 ? "group" : "groups"}`
+  if (s.keepSeparate) {
+    parts.push(
+      `Added ${s.added} ${s.added === 1 ? "line" : "lines"} · ${s.colors} ${
+        s.colors === 1 ? "color" : "colors"
+      } × ${s.batches} ${s.batches === 1 ? "batch" : "batches"} from ${groupLabel}`
+    )
+  } else {
+    parts.push(
+      `Added ${s.added} ${s.added === 1 ? "color" : "colors"} from ${groupLabel}${
+        s.batches > 1 ? ` (×${s.batches} batches summed)` : ""
+      }`
+    )
+  }
+  if (s.skippedDuplicate) {
+    parts.push(`${s.skippedDuplicate} already in the order`)
+  }
+  if (s.skippedNoItem) {
+    parts.push(`${s.skippedNoItem} without a stock item yet`)
+  }
+  return parts.join(" · ")
+}

--- a/apps/backend/src/admin/hooks/api/inventory-orders.ts
+++ b/apps/backend/src/admin/hooks/api/inventory-orders.ts
@@ -16,6 +16,8 @@ export interface OrderLine {
   inventory_item_id: string;
   quantity: number;
   price: number;
+  // Batch tag for separate-batch quick-add lines (null ⇒ not batched).
+  batch_number?: number | null;
   // #817 S2 — denormalized color identity persisted on the line.
   color?: string | null;
   material_name?: string | null;
@@ -314,6 +316,7 @@ export interface UpdateInventoryOrderLinesPayload {
     inventory_item_id: string;
     quantity: number;
     price: number;
+    batch_number?: number | null;
   }>;
 }
 

--- a/apps/backend/src/api/admin/inventory-orders/validators.ts
+++ b/apps/backend/src/api/admin/inventory-orders/validators.ts
@@ -12,6 +12,8 @@ export const inventoryOrderLineInputSchema = z.object({
   // Allow decimal quantities >= 0 (0 allowed for empty seeded rows)
   quantity: z.number().nonnegative("Quantity must be zero or positive"),
   price: z.number().nonnegative("Price must be zero or positive"),
+  // Optional batch tag for the "keep batches as separate lines" quick-add mode.
+  batch_number: z.number().int().positive().nullish(),
   metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
@@ -161,6 +163,8 @@ export const updateOrderLineSchema = z.object({
   inventory_item_id: z.string().min(1, "Inventory item ID is required"),
   quantity: z.number().min(1, "Quantity must be at least 1"),
   price: z.number().min(0, "Price must be non-negative"),
+  // Optional batch tag (see inventoryOrderLineInputSchema).
+  batch_number: z.number().int().positive().nullish(),
 });
 
 export const updateInventoryOrderLinesSchema = z.object({

--- a/apps/backend/src/modules/inventory_orders/__tests__/create-helpers.unit.spec.ts
+++ b/apps/backend/src/modules/inventory_orders/__tests__/create-helpers.unit.spec.ts
@@ -45,8 +45,8 @@ describe("buildOrderLinePayloads (#778 C3)", () => {
       "invord_1"
     )
     expect(payloads).toEqual([
-      { quantity: 10, price: 50, metadata: { sku: "A" }, inventory_orders: "invord_1", color: null, material_name: null, raw_material_id: null },
-      { quantity: 4, price: 100, metadata: null, inventory_orders: "invord_1", color: null, material_name: null, raw_material_id: null },
+      { quantity: 10, price: 50, metadata: { sku: "A" }, inventory_orders: "invord_1", batch_number: null, color: null, material_name: null, raw_material_id: null },
+      { quantity: 4, price: 100, metadata: null, inventory_orders: "invord_1", batch_number: null, color: null, material_name: null, raw_material_id: null },
     ])
   })
 

--- a/apps/backend/src/modules/inventory_orders/lib/create-helpers.ts
+++ b/apps/backend/src/modules/inventory_orders/lib/create-helpers.ts
@@ -13,6 +13,8 @@ export type CreateOrderLineInput = {
   quantity: number
   price: number
   metadata?: Record<string, unknown>
+  // Batch tag for separate-batch quick-add lines (null ⇒ not batched).
+  batch_number?: number | null
   // #817 S2 — color identity denormalized off the line's inventory_item.
   color?: string | null
   material_name?: string | null
@@ -24,6 +26,7 @@ export type OrderLinePayload = {
   price: number
   metadata: Record<string, unknown> | null
   inventory_orders: string
+  batch_number: number | null
   // #817 S2 — persisted denormalized color identity (null when the line's
   // inventory_item has no linked raw_material).
   color: string | null
@@ -62,6 +65,7 @@ export const buildOrderLinePayloads = (
     price: line.price,
     metadata: line.metadata ?? null,
     inventory_orders: orderId,
+    batch_number: line.batch_number ?? null,
     // #817 S2 — pass through the denormalized color identity resolved by the
     // caller (the create step), defaulting to null when absent.
     color: line.color ?? null,

--- a/apps/backend/src/modules/inventory_orders/migrations/Migration20260702130000.ts
+++ b/apps/backend/src/modules/inventory_orders/migrations/Migration20260702130000.ts
@@ -1,0 +1,24 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Mass batches — add `batch_number` to `inventory_order_line`.
+ *
+ * When a material group is quick-added as N distinct batches ("keep batches as
+ * separate lines"), each batch becomes its own order line tagged 1..N so it can
+ * be priced/received/tracked independently. Null ⇒ not batched (a single summed
+ * line), the default.
+ *
+ * Hand-written idempotent ALTER because the table already exists on live DBs
+ * (the create-if-not-exists migration hazard). Existing lines stay null.
+ */
+export class Migration20260702130000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "inventory_order_line" add column if not exists "batch_number" integer null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "inventory_order_line" drop column if exists "batch_number";`);
+  }
+
+}

--- a/apps/backend/src/modules/inventory_orders/models/orderline.ts
+++ b/apps/backend/src/modules/inventory_orders/models/orderline.ts
@@ -13,6 +13,11 @@ const OrderLine = model.define("inventory_order_line", {
   color: model.text().nullable(),
   material_name: model.text().nullable(),
   raw_material_id: model.text().nullable(),
+  // Batch identity for the "keep batches as separate lines" quick-add mode: when
+  // a group is ordered as N distinct batches, each batch is its own line tagged
+  // 1..N so it can be priced/received/tracked independently. Null ⇒ not batched
+  // (a single summed line), which is the default.
+  batch_number: model.number().nullable(),
   metadata: model.json().nullable(),
 
   // Relationship

--- a/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
@@ -28,6 +28,7 @@ export interface InventoryOrderLineInput {
   inventory_item_id: string;
   quantity: number;
   price: number;
+  batch_number?: number | null;
   metadata?: Record<string, unknown>;
 }
 
@@ -61,6 +62,7 @@ export const createInventoryOrderWithLinesStep = createStep(
       inventory_id: line.inventory_item_id,
       quantity: line.quantity,
       price: line.price,
+      batch_number: line.batch_number ?? null,
       metadata: line.metadata
     }));
 

--- a/apps/backend/src/workflows/inventory_orders/update-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/update-inventory-orders.ts
@@ -32,6 +32,7 @@ export type UpdateInventoryOrderLineInput = {
   inventory_item_id: string;
   quantity: number;
   price: number;
+  batch_number?: number | null; // Batch tag for separate-batch quick-add lines
   remove?: boolean; // If true, remove this orderline
 };
 
@@ -175,6 +176,7 @@ export const updateOrderLinesStep = createStep(
           data: {
             quantity: line.quantity,
             price: line.price,
+            ...(line.batch_number !== undefined ? { batch_number: line.batch_number } : {}),
           }
         });
         // If inventory_item_id changed, handle link update (not implemented here, but can be compared with currentOrderlines)
@@ -185,6 +187,7 @@ export const updateOrderLinesStep = createStep(
           inventory_orders_id: input.order_id,
           quantity: line.quantity,
           price: line.price,
+          batch_number: line.batch_number ?? null,
           color: info?.color ?? null,
           material_name: info?.material_name ?? null,
           raw_material_id: info?.raw_material_id ?? null,


### PR DESCRIPTION
## What
Rework the "add by Material Group" quick-add into a **mass-batch** control: pick several groups at once, choose a batch count **N**, and decide whether batches collapse into one summed line per color or stay as **N separate, individually-trackable lines**.

## UI
- `AddMaterialGroupControl` → a Popover with **multi-select groups** + a **Batches** input + a **"keep batches as separate lines"** toggle.
  - **Off (default):** one line per color, `quantity = MOQ × N` (today's behavior + a multiplier).
  - **On:** each color → N lines tagged batch `1..N`, each at MOQ.
- Grid shows a **Batch** badge column so separate-batch rows are distinguishable.

## Data
- New nullable `inventory_order_line.batch_number` column (typed, not metadata) + idempotent ALTER migration (`Migration20260702130000`).
- Threaded through create + update workflows, `create-helpers` payloads, validators, admin hooks, and the `orderlines.*` read path (round-trips on edit).
- Null `batch_number` ⇒ a single summed line — fully backwards compatible.

## Tests
- Pure `expandGroupsToBatchLines` helper: 8 unit tests (summed vs separate, MOQ/unit_cost defaults, cross-group + already-in-order dedup, batch clamp).
- `create-helpers` test updated for the new field. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)