### PR TITLE
feat(partner-onboarding): subscription billing in the onboarding wizard

### DIFF
--- a/apps/backend/src/api/partners/subscription/route.ts
+++ b/apps/backend/src/api/partners/subscription/route.ts
@@ -31,10 +31,25 @@ export const GET = async (
     { order: { sort_order: "ASC" }, take: 100 }
   )
 
-  const partnerCurrency = (partner.metadata as any)?.currency_code || "inr"
+  // Prefer the typed column (set during onboarding); fall back to the legacy
+  // metadata.currency_code for partners onboarded before it existed.
+  const partnerCurrency = (
+    (partner as any).currency_code ||
+    (partner.metadata as any)?.currency_code ||
+    "inr"
+  ).toLowerCase()
   const recommended_provider = partnerCurrency === "inr" ? "payu" : "stripe"
 
-  res.json({ subscription, plans, recommended_provider })
+  // Only surface plans priced in the partner's billing currency (plus any free
+  // plan), so an INR partner never sees the EUR plan and vice-versa — the paid
+  // provider is chosen from the partner currency, so a mismatched-currency plan
+  // would otherwise be uncharge-able.
+  const visiblePlans = (plans || []).filter(
+    (p: any) =>
+      p.price === 0 || (p.currency_code || "").toLowerCase() === partnerCurrency
+  )
+
+  res.json({ subscription, plans: visiblePlans, recommended_provider })
 }
 
 export const POST = async (
@@ -65,7 +80,13 @@ export const POST = async (
   }
 
   // Paid plans — determine payment provider and create payment session
-  const partnerCurrency = (partner.metadata as any)?.currency_code || "inr"
+  // Prefer the typed column (set during onboarding); fall back to the legacy
+  // metadata.currency_code for partners onboarded before it existed.
+  const partnerCurrency = (
+    (partner as any).currency_code ||
+    (partner.metadata as any)?.currency_code ||
+    "inr"
+  ).toLowerCase()
   const provider = partnerCurrency === "inr" ? "payu" : "stripe"
 
   if (provider === "payu") {

--- a/apps/backend/src/api/partners/update/route.ts
+++ b/apps/backend/src/api/partners/update/route.ts
@@ -102,6 +102,8 @@ export const PUT = async (
     status?: "active" | "inactive" | "pending"
     is_verified?: boolean
     workspace_type?: "seller" | "manufacturer" | "individual"
+    country_code?: string | null
+    currency_code?: string | null
     metadata?: Record<string, any> | null
   }>,
   res: MedusaResponse

--- a/apps/backend/src/api/partners/validators.ts
+++ b/apps/backend/src/api/partners/validators.ts
@@ -25,5 +25,16 @@ export const partnerUpdateSchema = z.object({
     is_verified: z.boolean().optional(),
     workspace_type: z.enum(['seller', 'manufacturer', 'individual']).optional(),
     whatsapp_number: z.string().nullable().optional(),
+    // Billing locale (drives subscription provider routing). Currency is
+    // normalized to lower-case so the "inr" comparison in the subscription route
+    // is stable regardless of what the client sends.
+    country_code: z.string().min(2).max(2).nullable().optional(),
+    currency_code: z
+        .string()
+        .min(3)
+        .max(3)
+        .transform((c) => c.toLowerCase())
+        .nullable()
+        .optional(),
     metadata: z.record(z.string(), z.any()).nullable().optional(),
 })

--- a/apps/backend/src/modules/partner/migrations/Migration20260702140000.ts
+++ b/apps/backend/src/modules/partner/migrations/Migration20260702140000.ts
@@ -1,0 +1,25 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Partner billing locale — add `country_code` + `currency_code` to `partner`.
+ *
+ * Load-bearing for subscription payment-provider routing (INR → PayU, else
+ * Stripe), so typed columns rather than metadata. Set during onboarding; the
+ * subscription route prefers these over the legacy `metadata.currency_code`.
+ *
+ * Hand-written idempotent ALTER (add-column-if-not-exists) because `partner`
+ * already exists on live DBs (the create-if-not-exists migration hazard).
+ */
+export class Migration20260702140000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "partner" add column if not exists "country_code" text null;`);
+    this.addSql(`alter table if exists "partner" add column if not exists "currency_code" text null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "partner" drop column if exists "country_code";`);
+    this.addSql(`alter table if exists "partner" drop column if exists "currency_code";`);
+  }
+
+}

--- a/apps/backend/src/modules/partner/models/partner.ts
+++ b/apps/backend/src/modules/partner/models/partner.ts
@@ -28,6 +28,14 @@ const Partner = model.define("partner", {
     tax_id: model.text().nullable(),
     tax_id_type: model.text().nullable(), // e.g. "GSTIN", "VAT", "PAN"
 
+    // Billing locale — the partner's country and the currency their subscription
+    // is charged in. Load-bearing (drives subscription payment-provider routing:
+    // INR → PayU, everything else → Stripe), so typed columns NOT metadata.
+    // Set during onboarding; the subscription route prefers these over the legacy
+    // metadata.currency_code fallback.
+    country_code: model.text().nullable(), // ISO-3166 alpha-2, e.g. "IN", "DE"
+    currency_code: model.text().nullable(), // ISO-4217 lower, e.g. "inr", "eur"
+
     // Storefront
     storefront_domain: model.text().nullable(),
     website_id: model.text().nullable(),

--- a/apps/backend/src/workflows/partner-subscription/seed-plans.ts
+++ b/apps/backend/src/workflows/partner-subscription/seed-plans.ts
@@ -70,6 +70,44 @@ const DEFAULT_PLANS = [
     },
   },
   {
+    // Launch offer for partners billed outside India (charged via Stripe in EUR).
+    // list price €18/mo, discounted to €7/mo incl. tax. `price` is what's charged;
+    // `metadata.list_price` is the strikethrough shown in the UI.
+    name: "Growth",
+    slug: "growth-eur",
+    description:
+      "For scaling brands. Lower fees, AI support, and advanced analytics to grow faster.",
+    price: 7,
+    currency_code: "eur",
+    interval: PlanInterval.MONTHLY,
+    sort_order: 1,
+    is_active: true,
+    metadata: {
+      list_price: 18,
+      discount: true,
+      tax_inclusive: true,
+    },
+    features: {
+      unlimited_products: true,
+      unlimited_staff: true,
+      unlimited_selling: true,
+      storefront_source_code: true,
+      jyt_emails: true,
+      custom_domain: true,
+      theme_customization: "full",
+      live_shipping: true,
+      shipping_partners: ["delhivery", "dhl", "ups", "fedex", "auspost"],
+      payment_processing_fee: "2%",
+      payment_gateways: ["stripe"],
+      analytics: "advanced",
+      ai_chat_support: true,
+      custom_modules: false,
+      custom_apis: false,
+      priority_support: true,
+      white_label: false,
+    },
+  },
+  {
     name: "Enterprise",
     slug: "enterprise",
     description:

--- a/apps/backend/src/workflows/partners/update-partner.ts
+++ b/apps/backend/src/workflows/partners/update-partner.ts
@@ -15,6 +15,8 @@ export type UpdatePartnerInput = {
     logo: string | null
     status: "active" | "inactive" | "pending"
     is_verified: boolean
+    country_code: string | null
+    currency_code: string | null
     metadata: Record<string, any> | null
     website_id: string | null
     storefront_domain: string | null

--- a/apps/partner-ui/src/hooks/api/subscription.ts
+++ b/apps/partner-ui/src/hooks/api/subscription.ts
@@ -18,6 +18,7 @@ export type PartnerPlan = {
   currency_code: string
   interval: string
   features?: Record<string, unknown>
+  metadata?: Record<string, unknown> | null
   is_active: boolean
   sort_order: number
   created_at: string

--- a/apps/partner-ui/src/routes/home/home-onboarding/home-onboarding.tsx
+++ b/apps/partner-ui/src/routes/home/home-onboarding/home-onboarding.tsx
@@ -22,6 +22,7 @@ import { KeyboundForm } from "../../../components/utilities/keybound-form"
 import { useMe } from "../../../hooks/api/users"
 import { sdk } from "../../../lib/client"
 import { queryClient } from "../../../lib/query-client"
+import { OnboardingPlanStep } from "./onboarding-plan-step"
 
 type Person = {
   first_name: string
@@ -116,8 +117,37 @@ const mapBusinessTypeToWorkspaceType = (businessType: string): "seller" | "manuf
   return "manufacturer"
 }
 
-const STEPS = ["about", "business", "operations", "logo", "people"] as const
+const STEPS = ["about", "business", "operations", "logo", "people", "plan"] as const
 type Step = (typeof STEPS)[number]
+
+// Onboarding country → billing currency. India bills in INR (PayU); everywhere
+// else bills in EUR via Stripe (matches the seeded EUR launch plan). Curated
+// list of common partner countries; extend as needed.
+const COUNTRY_OPTIONS: { value: string; label: string }[] = [
+  { value: "IN", label: "India" },
+  { value: "DE", label: "Germany" },
+  { value: "FR", label: "France" },
+  { value: "IT", label: "Italy" },
+  { value: "ES", label: "Spain" },
+  { value: "NL", label: "Netherlands" },
+  { value: "BE", label: "Belgium" },
+  { value: "AT", label: "Austria" },
+  { value: "IE", label: "Ireland" },
+  { value: "PT", label: "Portugal" },
+  { value: "SE", label: "Sweden" },
+  { value: "DK", label: "Denmark" },
+  { value: "FI", label: "Finland" },
+  { value: "PL", label: "Poland" },
+  { value: "LV", label: "Latvia" },
+  { value: "LT", label: "Lithuania" },
+  { value: "EE", label: "Estonia" },
+  { value: "GB", label: "United Kingdom" },
+  { value: "US", label: "United States" },
+  { value: "AE", label: "United Arab Emirates" },
+]
+
+const currencyForCountry = (countryCode: string): "inr" | "eur" =>
+  countryCode === "IN" ? "inr" : "eur"
 
 const getOnboardingStorageKey = (partnerId: string) =>
   `partner_onboarding_${partnerId}`
@@ -170,6 +200,7 @@ const OnboardingForm = () => {
     operations: "Operations",
     logo: t("partner.onboardingModal.steps.logo"),
     people: t("partner.onboardingModal.steps.people"),
+    plan: "Plan",
   }
 
   const BUSINESS_TYPES = BUSINESS_TYPE_KEYS.map((key) => ({
@@ -220,6 +251,22 @@ const OnboardingForm = () => {
       metadata.contact_phone ||
       "",
   }))
+  const [countryCode, setCountryCode] = useState<string>(
+    () =>
+      savedState?.about?.country_code ||
+      (partner as any)?.country_code ||
+      metadata.country_code ||
+      ""
+  )
+  // Billing currency the subscription is charged in — drives which plans show and
+  // which payment provider the backend routes to (INR → PayU, EUR → Stripe).
+  const currencyCode = useMemo(
+    () =>
+      countryCode
+        ? currencyForCountry(countryCode)
+        : (partner as any)?.currency_code || metadata.currency_code || "inr",
+    [countryCode, partner, metadata]
+  )
   const [logo, setLogo] = useState<File | null>(null)
   const [people, setPeople] = useState<Person[]>(() => {
     const saved = savedState?.people as Person[] | undefined
@@ -350,10 +397,12 @@ const OnboardingForm = () => {
     }
   }
 
-  const handleSubmit = async () => {
-    if (!validatePeople()) return
-
-    setIsSubmitting(true)
+  // Persist all onboarding data (partner update + profile + wizard snapshot)
+  // WITHOUT navigating. Returns false on a validation error. Used both by the
+  // final "finish" action and by the plan step (which must save before a paid
+  // plan redirects the browser away to the payment page).
+  const persistOnboarding = async (): Promise<boolean> => {
+    if (!validatePeople()) return false
     setError(null)
 
     try {
@@ -362,6 +411,11 @@ const OnboardingForm = () => {
 
       if (aboutYou.business_type) {
         updateBody.workspace_type = mapBusinessTypeToWorkspaceType(aboutYou.business_type)
+      }
+      // Billing locale → typed columns (drive subscription provider routing).
+      if (countryCode) {
+        updateBody.country_code = countryCode
+        updateBody.currency_code = currencyCode
       }
       if (aboutYou.business_name) metadataUpdate.business_name = aboutYou.business_name
       if (aboutYou.description) metadataUpdate.business_description = aboutYou.description
@@ -421,7 +475,7 @@ const OnboardingForm = () => {
           JSON.stringify({
             completed: true,
             skipped: false,
-            about: aboutYou,
+            about: { ...aboutYou, country_code: countryCode },
             people: filledPeople,
             logo: logo ? { name: logo.name, type: logo.type, size: logo.size } : null,
             completed_at: new Date().toISOString(),
@@ -429,10 +483,21 @@ const OnboardingForm = () => {
         )
       }
 
-      toast.success(t("partner.onboardingModal.toast.completed"))
-      handleSuccess("/")
+      return true
     } catch (e) {
       setError(e instanceof Error ? e.message : t("partner.onboardingModal.errors.unknown"))
+      return false
+    }
+  }
+
+  // Finish onboarding without picking a paid plan here (free / choose later).
+  const handleSubmit = async () => {
+    setIsSubmitting(true)
+    try {
+      const ok = await persistOnboarding()
+      if (!ok) return
+      toast.success(t("partner.onboardingModal.toast.completed"))
+      handleSuccess("/")
     } finally {
       setIsSubmitting(false)
     }
@@ -518,6 +583,34 @@ const OnboardingForm = () => {
                       ))}
                     </Select.Content>
                   </Select>
+                </div>
+
+                <div className="md:col-span-2">
+                  <Text size="small" className="mb-1 block font-medium">
+                    Country
+                  </Text>
+                  <Select
+                    value={countryCode}
+                    onValueChange={(v) => setCountryCode(v)}
+                  >
+                    <Select.Trigger>
+                      <Select.Value placeholder="Select your country" />
+                    </Select.Trigger>
+                    <Select.Content>
+                      {COUNTRY_OPTIONS.map((c) => (
+                        <Select.Item key={c.value} value={c.value}>
+                          {c.label}
+                        </Select.Item>
+                      ))}
+                    </Select.Content>
+                  </Select>
+                  {countryCode && (
+                    <Text size="xsmall" className="text-ui-fg-subtle mt-1">
+                      {currencyCode === "inr"
+                        ? "Billed in ₹ (INR) via PayU."
+                        : "Billed in € (EUR) via Stripe."}
+                    </Text>
+                  )}
                 </div>
 
                 <div className="md:col-span-2">
@@ -894,6 +987,23 @@ const OnboardingForm = () => {
                 {t("partner.onboardingModal.team.addAnother")}
               </Button>
             </div>
+          </ProgressTabs.Content>
+
+          {/* Step 6: Plan */}
+          <ProgressTabs.Content value="plan" className="p-6">
+            {error && (
+              <div className="mx-auto w-full max-w-[820px] pt-6">
+                <Alert variant="error">{error}</Alert>
+              </div>
+            )}
+            <OnboardingPlanStep
+              currencyCode={currencyCode}
+              onBeforeSelect={persistOnboarding}
+              onFreeActivated={() => {
+                toast.success(t("partner.onboardingModal.toast.completed"))
+                handleSuccess("/")
+              }}
+            />
           </ProgressTabs.Content>
         </RouteFocusModal.Body>
 

--- a/apps/partner-ui/src/routes/home/home-onboarding/onboarding-plan-step.tsx
+++ b/apps/partner-ui/src/routes/home/home-onboarding/onboarding-plan-step.tsx
@@ -1,0 +1,178 @@
+import { useMemo, useState } from "react"
+import { Badge, Button, Heading, Text, clx } from "@medusajs/ui"
+import {
+  usePartnerSubscription,
+  useSubscribeToPlan,
+  type PartnerPlan,
+} from "../../../hooks/api/subscription"
+
+interface OnboardingPlanStepProps {
+  /** The partner's billing currency (lower-case, e.g. "inr" | "eur"). */
+  currencyCode: string
+  /**
+   * Persist the rest of the onboarding form BEFORE we leave for payment (a paid
+   * plan redirects away to Stripe/PayU). Returns false to abort selection.
+   */
+  onBeforeSelect: () => Promise<boolean>
+  /** Called after a FREE plan activates (no redirect happens). */
+  onFreeActivated: () => void
+}
+
+const formatPrice = (amount: number, currency: string) => {
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: currency.toUpperCase(),
+      maximumFractionDigits: amount % 1 === 0 ? 0 : 2,
+    }).format(amount)
+  } catch {
+    return `${currency.toUpperCase()} ${amount}`
+  }
+}
+
+/**
+ * Plan-picker step for partner onboarding — surfaces subscription billing INSIDE
+ * the wizard. Shows the plans that match the partner's billing currency (plus any
+ * free plan), honoring a launch discount (`metadata.list_price` → strikethrough).
+ * Selecting a paid plan persists the onboarding form, then hands off to the
+ * existing /partners/subscription flow (Stripe for non-IN, PayU for IN) which
+ * redirects to the hosted payment page.
+ */
+export const OnboardingPlanStep = ({
+  currencyCode,
+  onBeforeSelect,
+  onFreeActivated,
+}: OnboardingPlanStepProps) => {
+  const { plans, isPending } = usePartnerSubscription()
+  const { mutateAsync: subscribe } = useSubscribeToPlan()
+  const [selectingId, setSelectingId] = useState<string | null>(null)
+
+  // Show free plans to everyone; otherwise only plans priced in the partner's
+  // billing currency (so an EU partner sees the EUR plan, an IN partner INR).
+  const visiblePlans = useMemo(() => {
+    const cc = currencyCode.toLowerCase()
+    return (plans || [])
+      .filter(
+        (p) => p.is_active && (p.price === 0 || p.currency_code.toLowerCase() === cc)
+      )
+      .sort((a, b) => a.sort_order - b.sort_order)
+  }, [plans, currencyCode])
+
+  const handleSelect = async (plan: PartnerPlan) => {
+    setSelectingId(plan.id)
+    try {
+      const ok = await onBeforeSelect()
+      if (!ok) return
+      const res = await subscribe({ plan_id: plan.id })
+      // Paid plans redirect away inside the hook; a returned subscription means a
+      // free plan activated immediately with no redirect.
+      if (res?.subscription) {
+        onFreeActivated()
+      }
+    } finally {
+      setSelectingId(null)
+    }
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-[820px] flex-col gap-y-4 py-10">
+      <div>
+        <Heading>Choose your plan</Heading>
+        <Text size="small" className="text-ui-fg-subtle mt-1">
+          Pick a plan to finish setting up. You can change or upgrade it any time
+          from Settings.
+        </Text>
+      </div>
+
+      {isPending ? (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="h-48 animate-pulse rounded-lg border border-ui-border-base bg-ui-bg-subtle"
+            />
+          ))}
+        </div>
+      ) : visiblePlans.length === 0 ? (
+        <Text size="small" className="text-ui-fg-subtle">
+          No plans are available for your region yet — you can finish and choose a
+          plan later from Settings.
+        </Text>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          {visiblePlans.map((plan) => {
+            const meta = (plan.metadata as Record<string, any>) || {}
+            const listPrice =
+              typeof meta.list_price === "number" ? meta.list_price : null
+            const hasDiscount = listPrice != null && listPrice > plan.price
+            const isFree = plan.price === 0
+            const busy = selectingId === plan.id
+            return (
+              <div
+                key={plan.id}
+                className={clx(
+                  "flex flex-col gap-y-3 rounded-lg border p-4",
+                  hasDiscount
+                    ? "border-ui-border-interactive"
+                    : "border-ui-border-base"
+                )}
+              >
+                <div className="flex items-center justify-between">
+                  <Text weight="plus">{plan.name}</Text>
+                  {hasDiscount && (
+                    <Badge size="2xsmall" color="green">
+                      Launch offer
+                    </Badge>
+                  )}
+                </div>
+
+                <div className="flex items-baseline gap-x-2">
+                  {isFree ? (
+                    <Text size="xlarge" weight="plus">
+                      Free
+                    </Text>
+                  ) : (
+                    <>
+                      <Text size="xlarge" weight="plus">
+                        {formatPrice(plan.price, plan.currency_code)}
+                      </Text>
+                      {hasDiscount && (
+                        <Text
+                          size="small"
+                          className="text-ui-fg-muted line-through"
+                        >
+                          {formatPrice(listPrice!, plan.currency_code)}
+                        </Text>
+                      )}
+                      <Text size="small" className="text-ui-fg-subtle">
+                        /{plan.interval}
+                        {meta.tax_inclusive ? " · incl. tax" : ""}
+                      </Text>
+                    </>
+                  )}
+                </div>
+
+                {plan.description && (
+                  <Text size="small" className="text-ui-fg-subtle flex-1">
+                    {plan.description}
+                  </Text>
+                )}
+
+                <Button
+                  size="small"
+                  variant={hasDiscount ? "primary" : "secondary"}
+                  type="button"
+                  onClick={() => handleSelect(plan)}
+                  isLoading={busy}
+                  disabled={!!selectingId}
+                >
+                  {isFree ? "Start free" : "Choose & pay"}
+                </Button>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## What
Partners can choose and pay for their subscription **inside the onboarding wizard**, routed by country:
- **India → PayU (INR)**
- **Everywhere else → Stripe (EUR)** — matches the €18→€7 launch plan.

Reuses the existing `/partners/subscription` flow (Stripe Checkout / PayU form-post) end-to-end; nothing about the payment mechanics changes.

## Backend
- **`partner.country_code` + `partner.currency_code`** typed columns (+ idempotent ALTER `Migration20260702140000`) — load-bearing for provider routing, so columns not metadata.
- `/partners/update` accepts + persists them; validator lower-cases the currency.
- `/partners/subscription`:
  - prefers the typed `currency_code` column over the legacy `metadata.currency_code` fallback;
  - returns **only plans in the partner's currency (plus free)** so an INR partner never sees the EUR plan and vice-versa (a mismatched-currency plan would be uncharge-able, since the provider is chosen from the partner currency).
- Seeded **discounted EUR launch plan**: `price = 7` charged, `metadata.list_price = 18` (strikethrough), tax-inclusive.

## Partner UI (onboarding wizard)
- **Country selector** on the *About* step → sets `country_code` + derived currency (shows "Billed in € via Stripe" / "₹ via PayU").
- New **Plan** step (`OnboardingPlanStep`): lists currency-matched plans with the launch-discount strikethrough; selecting a plan **persists onboarding first**, then hands off to Stripe/PayU (paid) or activates a free plan. Payment returns to `settings/plan?payment=success` (existing handler).

## ⚠️ Before merge / post-deploy
- [ ] **Seed the EUR plan on the target env**: `POST /admin/partner-plans/seed` (idempotent by slug `growth-eur`).
- [ ] **Live-verify** the wizard: country → Plan step → Stripe checkout (non-IN) and PayU (IN), and the post-payment return. This is payment-facing, so verify before merging to prod (auto-deploy).

## Typecheck
Backend + partner-ui both clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)