### PR TITLE
feat(partner-payments): JYT Stripe Connect onboarding in payment config (Half A)

### DIFF
--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -663,6 +663,14 @@ export default defineMiddlewares({
       bodyParser: { preserveRawBody: true },
     },
     {
+      // Stripe Connect account events (JYT platform account). Raw body is
+      // required to verify the Stripe signature against STRIPE_CONNECT_WEBHOOK_SECRET.
+      matcher: "/webhooks/stripe/connect",
+      method: "POST",
+      middlewares: [],
+      bodyParser: { preserveRawBody: true },
+    },
+    {
       matcher: "/webhooks/meta-ads/leadgen",
       method: "GET",
       middlewares: [],
@@ -1499,6 +1507,16 @@ export default defineMiddlewares({
     // Partner Payment Config (per-partner credentials)
     {
       matcher: "/partners/payment-config",
+      method: ["GET", "POST"],
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
+    // JYT Stripe Connect onboarding (must precede the /:configId matcher so
+    // "stripe-connect" isn't treated as a config id).
+    {
+      matcher: "/partners/payment-config/stripe-connect",
       method: ["GET", "POST"],
       middlewares: [
         createCorsPartnerMiddleware(),

--- a/apps/backend/src/api/partners/payment-config/stripe-connect/route.ts
+++ b/apps/backend/src/api/partners/payment-config/stripe-connect/route.ts
@@ -1,0 +1,152 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { logger } from "@medusajs/framework"
+import { getPartnerFromAuthContext } from "../../helpers"
+import { PARTNER_PAYMENT_CONFIG_MODULE } from "../../../../modules/partner-payment-config"
+import {
+  STRIPE_PROVIDER_ID,
+  getPlatformStripe,
+  accountToConnectFields,
+  assertSafeUrl,
+} from "../../../../modules/partner-payment-config/lib/stripe-connect"
+
+/**
+ * Shape returned to the partner UI describing their Connect state.
+ */
+const toStatusPayload = (config: any) => ({
+  connected: !!config?.connect_account_id,
+  account_id: config?.connect_account_id ?? null,
+  status: config?.connect_status ?? null,
+  charges_enabled: !!config?.connect_charges_enabled,
+  payouts_enabled: !!config?.connect_payouts_enabled,
+  details_submitted: !!config?.connect_details_submitted,
+})
+
+const getStripeConfig = async (configService: any, partnerId: string) => {
+  const configs = await configService.listPartnerPaymentConfigs({
+    partner_id: partnerId,
+    provider_id: STRIPE_PROVIDER_ID,
+  })
+  return configs?.[0] || null
+}
+
+/**
+ * GET /partners/payment-config/stripe-connect
+ *
+ * Returns the partner's current Stripe Connect status. When a connected
+ * account exists, we live-sync from Stripe (so returning from the hosted
+ * onboarding flow reflects charges_enabled immediately, without waiting for
+ * the async account.updated webhook).
+ */
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
+  if (!partner) {
+    throw new MedusaError(MedusaError.Types.UNAUTHORIZED, "Partner not found")
+  }
+
+  const configService = req.scope.resolve(PARTNER_PAYMENT_CONFIG_MODULE) as any
+  let config = await getStripeConfig(configService, partner.id)
+
+  if (config?.connect_account_id) {
+    try {
+      const stripe = await getPlatformStripe()
+      const account = await stripe.accounts.retrieve(config.connect_account_id)
+      const fields = accountToConnectFields(account)
+      config = await configService.updatePartnerPaymentConfigs({
+        id: config.id,
+        ...fields,
+      })
+    } catch (e: any) {
+      // Non-fatal: fall back to the persisted snapshot.
+      logger.warn(
+        `[stripe-connect] live sync failed for ${config.connect_account_id}: ${e?.message}`
+      )
+    }
+  }
+
+  res.json({ stripe_connect: toStatusPayload(config) })
+}
+
+/**
+ * POST /partners/payment-config/stripe-connect
+ *
+ * Creates (or reuses) a Standard connected account for the partner and returns
+ * a Stripe-hosted onboarding link. The partner is redirected to `url`.
+ *
+ * Body: { return_url, refresh_url } — both point back to the partner UI
+ * (the UI passes its own settings page URL, so no server-side origin guessing).
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
+  if (!partner) {
+    throw new MedusaError(MedusaError.Types.UNAUTHORIZED, "Partner not found")
+  }
+
+  const body = (req.body ?? {}) as { return_url?: string; refresh_url?: string }
+  const returnUrl = assertSafeUrl(body.return_url, "return_url")
+  const refreshUrl = assertSafeUrl(body.refresh_url ?? body.return_url, "refresh_url")
+
+  const configService = req.scope.resolve(PARTNER_PAYMENT_CONFIG_MODULE) as any
+  const stripe = await getPlatformStripe()
+
+  let config = await getStripeConfig(configService, partner.id)
+  let accountId = config?.connect_account_id as string | undefined
+
+  // Create the Standard account once; reuse it on subsequent "resume" clicks.
+  if (!accountId) {
+    const account = await stripe.accounts.create({
+      type: "standard",
+      email: (partner as any).contact_email || (partner as any).email || undefined,
+      metadata: {
+        partner_id: partner.id,
+        partner_name: (partner as any).name || "",
+        source: "jyt_partner_portal",
+      },
+    })
+    accountId = account.id
+
+    const connectFields = {
+      connect_account_id: accountId,
+      connect_status: "pending",
+      connect_charges_enabled: false,
+      connect_payouts_enabled: false,
+      connect_details_submitted: false,
+    }
+
+    if (config) {
+      config = await configService.updatePartnerPaymentConfigs({
+        id: config.id,
+        ...connectFields,
+      })
+    } else {
+      config = await configService.createPartnerPaymentConfigs({
+        partner_id: partner.id,
+        provider_id: STRIPE_PROVIDER_ID,
+        // No manual keys — Connect is the source. Kept as {} so the JSON
+        // column is never null.
+        credentials: {},
+        is_active: true,
+        ...connectFields,
+      })
+    }
+
+    logger.info(
+      `[stripe-connect] created Standard account ${accountId} for partner ${partner.id}`
+    )
+  }
+
+  const link = await stripe.accountLinks.create({
+    account: accountId,
+    refresh_url: refreshUrl,
+    return_url: returnUrl,
+    type: "account_onboarding",
+  })
+
+  res.json({ url: link.url, account_id: accountId })
+}

--- a/apps/backend/src/api/webhooks/stripe/connect/route.ts
+++ b/apps/backend/src/api/webhooks/stripe/connect/route.ts
@@ -1,0 +1,93 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { logger } from "@medusajs/framework"
+import { PARTNER_PAYMENT_CONFIG_MODULE } from "../../../../modules/partner-payment-config"
+import {
+  getPlatformStripe,
+  accountToConnectFields,
+} from "../../../../modules/partner-payment-config/lib/stripe-connect"
+
+/**
+ * POST /webhooks/stripe/connect
+ *
+ * Receives Stripe Connect account events for JYT's platform account. Keeps the
+ * partner_payment_config Connect columns in sync with Stripe as partners finish
+ * (or lose) onboarding.
+ *
+ * Signature is verified against STRIPE_CONNECT_WEBHOOK_SECRET using the raw
+ * request bytes (middleware sets bodyParser: { preserveRawBody: true }).
+ *
+ * Handled events:
+ *  - account.updated              → refresh charges/payouts/details + status
+ *  - account.application.deauthorized → partner disconnected → mark disconnected
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const secret = process.env.STRIPE_CONNECT_WEBHOOK_SECRET
+  const signature = req.headers["stripe-signature"] as string | undefined
+  const rawBody = (req as any).rawBody as Buffer | undefined
+
+  if (!secret) {
+    logger.error("[stripe-connect-webhook] STRIPE_CONNECT_WEBHOOK_SECRET not set")
+    // 500 so Stripe retries once the secret is configured.
+    return res.status(500).send("Webhook secret not configured")
+  }
+  if (!signature || !rawBody?.length) {
+    return res.status(400).send("Missing signature or body")
+  }
+
+  let event: any
+  try {
+    const stripe = await getPlatformStripe()
+    event = stripe.webhooks.constructEvent(rawBody, signature, secret)
+  } catch (e: any) {
+    logger.warn(`[stripe-connect-webhook] signature verification failed: ${e?.message}`)
+    return res.status(400).send(`Webhook Error: ${e?.message}`)
+  }
+
+  // On Connect events, the connected account id is at the top level.
+  const accountId: string | undefined = event.account
+  const configService = req.scope.resolve(PARTNER_PAYMENT_CONFIG_MODULE) as any
+
+  try {
+    switch (event.type) {
+      case "account.updated": {
+        const account = event.data.object
+        const id = account?.id || accountId
+        const config = await configService.findByConnectAccountId(id)
+        if (!config) {
+          logger.info(`[stripe-connect-webhook] no config for account ${id}; ignoring`)
+          break
+        }
+        const fields = accountToConnectFields(account)
+        await configService.updatePartnerPaymentConfigs({ id: config.id, ...fields })
+        logger.info(
+          `[stripe-connect-webhook] account ${id} → ${fields.connect_status} ` +
+            `(charges=${fields.connect_charges_enabled}) for partner ${config.partner_id}`
+        )
+        break
+      }
+      case "account.application.deauthorized": {
+        const config = await configService.findByConnectAccountId(accountId)
+        if (!config) break
+        await configService.updatePartnerPaymentConfigs({
+          id: config.id,
+          connect_status: "disconnected",
+          connect_charges_enabled: false,
+          connect_payouts_enabled: false,
+        })
+        logger.info(
+          `[stripe-connect-webhook] account ${accountId} deauthorized for partner ${config.partner_id}`
+        )
+        break
+      }
+      default:
+        // Acknowledge unhandled events so Stripe stops retrying.
+        break
+    }
+  } catch (e: any) {
+    logger.error(`[stripe-connect-webhook] handler error: ${e?.message}`)
+    // 500 → Stripe retries.
+    return res.status(500).send("Handler error")
+  }
+
+  res.json({ received: true })
+}

--- a/apps/backend/src/modules/partner-payment-config/__tests__/stripe-connect.unit.spec.ts
+++ b/apps/backend/src/modules/partner-payment-config/__tests__/stripe-connect.unit.spec.ts
@@ -1,0 +1,110 @@
+import {
+  deriveConnectStatus,
+  accountToConnectFields,
+  isConnectLive,
+  assertSafeUrl,
+} from "../lib/stripe-connect"
+
+describe("stripe-connect lib (Half A)", () => {
+  describe("deriveConnectStatus", () => {
+    it("is active when charges are enabled", () => {
+      expect(
+        deriveConnectStatus({ charges_enabled: true, details_submitted: true })
+      ).toBe("active")
+    })
+
+    it("is active even if payouts are not yet enabled (charges is what matters)", () => {
+      expect(
+        deriveConnectStatus({
+          charges_enabled: true,
+          payouts_enabled: false,
+          details_submitted: true,
+        })
+      ).toBe("active")
+    })
+
+    it("is restricted when details submitted but charges still disabled", () => {
+      expect(
+        deriveConnectStatus({ charges_enabled: false, details_submitted: true })
+      ).toBe("restricted")
+    })
+
+    it("is pending before any details are submitted", () => {
+      expect(
+        deriveConnectStatus({ charges_enabled: false, details_submitted: false })
+      ).toBe("pending")
+    })
+
+    it("is pending for an empty account object", () => {
+      expect(deriveConnectStatus({})).toBe("pending")
+    })
+  })
+
+  describe("accountToConnectFields", () => {
+    it("maps a fully-onboarded account onto typed columns", () => {
+      expect(
+        accountToConnectFields({
+          charges_enabled: true,
+          payouts_enabled: true,
+          details_submitted: true,
+        })
+      ).toEqual({
+        connect_status: "active",
+        connect_charges_enabled: true,
+        connect_payouts_enabled: true,
+        connect_details_submitted: true,
+      })
+    })
+
+    it("coerces missing flags to false", () => {
+      expect(accountToConnectFields({})).toEqual({
+        connect_status: "pending",
+        connect_charges_enabled: false,
+        connect_payouts_enabled: false,
+        connect_details_submitted: false,
+      })
+    })
+  })
+
+  describe("isConnectLive (\"Connect wins when active\")", () => {
+    it("is live only with both an account id and charges enabled", () => {
+      expect(
+        isConnectLive({ connect_account_id: "acct_1", connect_charges_enabled: true })
+      ).toBe(true)
+    })
+
+    it("is not live with an account id but charges disabled (onboarding)", () => {
+      expect(
+        isConnectLive({ connect_account_id: "acct_1", connect_charges_enabled: false })
+      ).toBe(false)
+    })
+
+    it("is not live without a connected account", () => {
+      expect(
+        isConnectLive({ connect_account_id: null, connect_charges_enabled: true })
+      ).toBe(false)
+    })
+  })
+
+  describe("assertSafeUrl", () => {
+    it("accepts https and http URLs", () => {
+      expect(assertSafeUrl("https://partners.jyt.com/settings", "return_url")).toBe(
+        "https://partners.jyt.com/settings"
+      )
+      expect(assertSafeUrl("http://localhost:5173/x", "return_url")).toBe(
+        "http://localhost:5173/x"
+      )
+    })
+
+    it("rejects non-http protocols (open-redirect / xss guard)", () => {
+      expect(() => assertSafeUrl("javascript:alert(1)", "return_url")).toThrow()
+      expect(() => assertSafeUrl("ftp://host/x", "return_url")).toThrow()
+    })
+
+    it("rejects missing or non-absolute values", () => {
+      expect(() => assertSafeUrl(undefined, "return_url")).toThrow()
+      expect(() => assertSafeUrl("", "return_url")).toThrow()
+      expect(() => assertSafeUrl("/relative/path", "return_url")).toThrow()
+    })
+  })
+})

--- a/apps/backend/src/modules/partner-payment-config/lib/stripe-connect.ts
+++ b/apps/backend/src/modules/partner-payment-config/lib/stripe-connect.ts
@@ -1,0 +1,94 @@
+import { MedusaError } from "@medusajs/framework/utils"
+
+export const STRIPE_PROVIDER_ID = "pp_stripe_stripe"
+
+export type ConnectStatus = "pending" | "active" | "restricted" | "disconnected"
+
+/**
+ * Resolve the platform's Stripe client (JYT's own account) — this is the
+ * account that owns the connected Standard accounts. Reuses STRIPE_API_KEY,
+ * the same secret the partner-subscription checkout already uses.
+ *
+ * `stripe` is a transitive dependency (resolved via the Medusa stripe
+ * provider), so we dynamic-import it exactly like the subscription route does.
+ */
+export const getPlatformStripe = async (): Promise<any> => {
+  const stripeKey = process.env.STRIPE_API_KEY
+  if (!stripeKey) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "Stripe is not configured on the platform (STRIPE_API_KEY missing)."
+    )
+  }
+  const Stripe = await import("stripe").then((m) => m.default)
+  return new Stripe(stripeKey)
+}
+
+/**
+ * Derive our coarse status enum from a Stripe Account object. Pure — safe to
+ * unit test. "active" means the partner can actually accept charges.
+ */
+export const deriveConnectStatus = (account: {
+  charges_enabled?: boolean
+  payouts_enabled?: boolean
+  details_submitted?: boolean
+}): ConnectStatus => {
+  if (account?.charges_enabled) return "active"
+  if (account?.details_submitted) return "restricted"
+  return "pending"
+}
+
+/**
+ * Map a Stripe Account onto the typed columns we persist. Pure.
+ */
+export const accountToConnectFields = (account: {
+  charges_enabled?: boolean
+  payouts_enabled?: boolean
+  details_submitted?: boolean
+}) => ({
+  connect_status: deriveConnectStatus(account),
+  connect_charges_enabled: !!account?.charges_enabled,
+  connect_payouts_enabled: !!account?.payouts_enabled,
+  connect_details_submitted: !!account?.details_submitted,
+})
+
+/**
+ * Whether a config row's connected account is the live/authoritative Stripe
+ * source ("Connect wins when active"). When true, the partner's manually
+ * entered keys are a fallback only.
+ */
+export const isConnectLive = (config: {
+  connect_account_id?: string | null
+  connect_charges_enabled?: boolean | null
+}): boolean => !!(config?.connect_account_id && config?.connect_charges_enabled)
+
+const SAFE_URL_PROTOCOLS = new Set(["http:", "https:"])
+
+/**
+ * Validate a client-supplied return/refresh URL before handing it to Stripe.
+ * Only http(s) — prevents open-redirect / javascript: shenanigans.
+ */
+export const assertSafeUrl = (url: unknown, label: string): string => {
+  if (typeof url !== "string" || !url) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `${label} is required.`
+    )
+  }
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `${label} must be a valid absolute URL.`
+    )
+  }
+  if (!SAFE_URL_PROTOCOLS.has(parsed.protocol)) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `${label} must be an http(s) URL.`
+    )
+  }
+  return parsed.toString()
+}

--- a/apps/backend/src/modules/partner-payment-config/migrations/Migration20260702120000.ts
+++ b/apps/backend/src/modules/partner-payment-config/migrations/Migration20260702120000.ts
@@ -1,0 +1,31 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * JYT Stripe Connect (Standard) columns on partner_payment_config.
+ *
+ * Hand-written ADD COLUMN IF NOT EXISTS so it lands on existing databases —
+ * editing the original `create table if not exists` migration would never run
+ * on an already-provisioned DB.
+ */
+export class Migration20260702120000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`ALTER TABLE IF EXISTS "partner_payment_config" ADD COLUMN IF NOT EXISTS "connect_account_id" text null;`);
+    this.addSql(`ALTER TABLE IF EXISTS "partner_payment_config" ADD COLUMN IF NOT EXISTS "connect_status" text null;`);
+    this.addSql(`ALTER TABLE IF EXISTS "partner_payment_config" ADD COLUMN IF NOT EXISTS "connect_charges_enabled" boolean not null default false;`);
+    this.addSql(`ALTER TABLE IF EXISTS "partner_payment_config" ADD COLUMN IF NOT EXISTS "connect_payouts_enabled" boolean not null default false;`);
+    this.addSql(`ALTER TABLE IF EXISTS "partner_payment_config" ADD COLUMN IF NOT EXISTS "connect_details_submitted" boolean not null default false;`);
+    // Fast webhook lookup by connected account id.
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_partner_payment_config_connect_account_id" ON "partner_payment_config" ("connect_account_id") WHERE "connect_account_id" IS NOT NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`DROP INDEX IF EXISTS "IDX_partner_payment_config_connect_account_id";`);
+    this.addSql(`ALTER TABLE IF EXISTS "partner_payment_config" DROP COLUMN IF EXISTS "connect_account_id";`);
+    this.addSql(`ALTER TABLE IF EXISTS "partner_payment_config" DROP COLUMN IF EXISTS "connect_status";`);
+    this.addSql(`ALTER TABLE IF EXISTS "partner_payment_config" DROP COLUMN IF EXISTS "connect_charges_enabled";`);
+    this.addSql(`ALTER TABLE IF EXISTS "partner_payment_config" DROP COLUMN IF EXISTS "connect_payouts_enabled";`);
+    this.addSql(`ALTER TABLE IF EXISTS "partner_payment_config" DROP COLUMN IF EXISTS "connect_details_submitted";`);
+  }
+
+}

--- a/apps/backend/src/modules/partner-payment-config/models/partner-payment-config.ts
+++ b/apps/backend/src/modules/partner-payment-config/models/partner-payment-config.ts
@@ -9,6 +9,18 @@ const PartnerPaymentConfig = model.define("partner_payment_config", {
   // PayU: { merchant_key, merchant_salt, mode }
   // Stripe: { api_key }
   credentials: model.json(),
+  // --- JYT Stripe Connect (Standard account) ---
+  // These are load-bearing, webhook-mutated fields, so they are typed columns
+  // (not metadata — Medusa replaces the whole metadata blob on update).
+  // Populated only for provider_id = "pp_stripe_stripe" when a partner
+  // onboards via JYT's platform Stripe Connect instead of bringing their keys.
+  connect_account_id: model.text().nullable(),
+  // "pending" (onboarding not finished) | "active" (charges enabled)
+  // | "restricted" (submitted but Stripe needs more) | "disconnected"
+  connect_status: model.text().nullable(),
+  connect_charges_enabled: model.boolean().default(false),
+  connect_payouts_enabled: model.boolean().default(false),
+  connect_details_submitted: model.boolean().default(false),
   metadata: model.json().nullable(),
 })
 

--- a/apps/backend/src/modules/partner-payment-config/service.ts
+++ b/apps/backend/src/modules/partner-payment-config/service.ts
@@ -25,6 +25,20 @@ class PartnerPaymentConfigService extends MedusaService({
       is_active: true,
     })
   }
+
+  /**
+   * Find the (single) config row that owns a given Stripe connected account.
+   * Used by the Connect webhook, which only knows the account id — not the
+   * partner. Ignores is_active so we can still process account.updated events
+   * for accounts that were deactivated.
+   */
+  async findByConnectAccountId(accountId: string) {
+    if (!accountId) return null
+    const configs = await this.listPartnerPaymentConfigs({
+      connect_account_id: accountId,
+    })
+    return configs?.[0] || null
+  }
 }
 
 export default PartnerPaymentConfigService

--- a/apps/partner-ui/src/hooks/api/payment-config.tsx
+++ b/apps/partner-ui/src/hooks/api/payment-config.tsx
@@ -21,8 +21,24 @@ export type PaymentConfig = {
   credentials: Record<string, any>
   is_active: boolean
   metadata?: Record<string, any>
+  // JYT Stripe Connect (Standard) — populated for pp_stripe_stripe when the
+  // partner onboards via JYT instead of bringing their own keys.
+  connect_account_id?: string | null
+  connect_status?: "pending" | "active" | "restricted" | "disconnected" | null
+  connect_charges_enabled?: boolean
+  connect_payouts_enabled?: boolean
+  connect_details_submitted?: boolean
   created_at: string
   updated_at: string
+}
+
+export type StripeConnectStatus = {
+  connected: boolean
+  account_id: string | null
+  status: "pending" | "active" | "restricted" | "disconnected" | null
+  charges_enabled: boolean
+  payouts_enabled: boolean
+  details_submitted: boolean
 }
 
 export type CreatePaymentConfigPayload = {
@@ -109,6 +125,62 @@ export const useUpdatePaymentConfig = (
       ),
     onSuccess: (data, variables, context) => {
       queryClient.invalidateQueries({ queryKey: paymentConfigQueryKeys.lists() })
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}
+
+const STRIPE_CONNECT_QUERY_KEY = "stripe_connect" as const
+export const stripeConnectQueryKeys = queryKeysFactory(STRIPE_CONNECT_QUERY_KEY)
+
+/**
+ * Current JYT Stripe Connect status for the partner. Server live-syncs from
+ * Stripe on each read, so this reflects onboarding completion immediately.
+ */
+export const useStripeConnectStatus = (
+  options?: Omit<
+    UseQueryOptions<
+      { stripe_connect: StripeConnectStatus },
+      FetchError,
+      { stripe_connect: StripeConnectStatus },
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: stripeConnectQueryKeys.details(),
+    queryFn: () =>
+      sdk.client.fetch<{ stripe_connect: StripeConnectStatus }>(
+        "/partners/payment-config/stripe-connect",
+        { method: "GET" }
+      ),
+    ...options,
+  })
+
+  return { stripe_connect: data?.stripe_connect, ...rest }
+}
+
+/**
+ * Start (or resume) JYT Stripe Connect onboarding. Returns a Stripe-hosted
+ * onboarding URL to redirect the partner to.
+ */
+export const useStartStripeConnect = (
+  options?: UseMutationOptions<
+    { url: string; account_id: string },
+    FetchError,
+    { return_url: string; refresh_url?: string }
+  >
+) => {
+  return useMutation({
+    mutationFn: (payload) =>
+      sdk.client.fetch<{ url: string; account_id: string }>(
+        "/partners/payment-config/stripe-connect",
+        { method: "POST", body: payload }
+      ),
+    onSuccess: (data, variables, context) => {
+      queryClient.invalidateQueries({ queryKey: stripeConnectQueryKeys.all })
       options?.onSuccess?.(data, variables, context)
     },
     ...options,

--- a/apps/partner-ui/src/i18n/translations/en.json
+++ b/apps/partner-ui/src/i18n/translations/en.json
@@ -3765,6 +3765,26 @@
         "created": "Payment method created"
       }
     },
+    "stripeConnect": {
+      "heading": "JYT Stripe Connect",
+      "payoutsPending": "payouts pending",
+      "badge": {
+        "active": "Active",
+        "pending": "Setup incomplete"
+      },
+      "description": {
+        "default": "Skip entering API keys. Connect a Stripe account through JYT to get paid faster, with payouts and refunds handled for you.",
+        "active": "Payments run through JYT's Stripe Connect. This is your live Stripe source — any manually entered keys below are used only as a fallback."
+      },
+      "actions": {
+        "connect": "Connect with Stripe",
+        "resume": "Finish setup",
+        "manage": "Update details"
+      },
+      "toast": {
+        "startFailed": "Could not start Stripe onboarding"
+      }
+    },
     "paymentProviders": {
       "heading": "Payment Credentials",
       "subHeading": "Your payment provider credentials. These override platform defaults for your store.",

--- a/apps/partner-ui/src/routes/settings/payment-providers/components/stripe-connect-card.tsx
+++ b/apps/partner-ui/src/routes/settings/payment-providers/components/stripe-connect-card.tsx
@@ -1,0 +1,126 @@
+import { CheckCircleSolid, ExclamationCircleSolid } from "@medusajs/icons"
+import { Badge, Button, Container, Heading, Text, toast } from "@medusajs/ui"
+import { useEffect } from "react"
+import { useTranslation } from "react-i18next"
+
+import {
+  useStripeConnectStatus,
+  useStartStripeConnect,
+} from "../../../../hooks/api/payment-config"
+
+/**
+ * "Get onboarded faster with JYT Stripe Connect" card, shown above the manual
+ * payment-provider list. Handles three states: not connected, onboarding in
+ * progress (resume), and active. When active, Connect is the authoritative
+ * Stripe source and manual keys become a fallback.
+ */
+export const StripeConnectCard = () => {
+  const { t } = useTranslation()
+  const { stripe_connect, isPending, refetch } = useStripeConnectStatus()
+  const { mutateAsync: startConnect, isPending: isStarting } =
+    useStartStripeConnect()
+
+  // Re-sync when Stripe redirects the partner back (?stripe_connect=return).
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    if (params.get("stripe_connect") === "return") {
+      refetch()
+      params.delete("stripe_connect")
+      const qs = params.toString()
+      window.history.replaceState(
+        {},
+        "",
+        window.location.pathname + (qs ? `?${qs}` : "")
+      )
+    }
+  }, [refetch])
+
+  const handleStart = async () => {
+    // Return the partner to this settings page; Stripe appends its own params.
+    const base = window.location.origin + window.location.pathname
+    const returnUrl = `${base}?stripe_connect=return`
+    await startConnect(
+      { return_url: returnUrl, refresh_url: returnUrl },
+      {
+        onSuccess: ({ url }) => {
+          window.location.href = url
+        },
+        onError: (e) =>
+          toast.error(e.message || t("partner.stripeConnect.toast.startFailed")),
+      }
+    )
+  }
+
+  const status = stripe_connect?.status
+  const isActive = status === "active" && stripe_connect?.charges_enabled
+  const isOnboarding =
+    stripe_connect?.connected && !isActive && status !== "disconnected"
+
+  return (
+    <Container className="flex flex-col gap-y-4 px-6 py-6">
+      <div className="flex items-start justify-between gap-x-4">
+        <div className="flex flex-col gap-y-1">
+          <div className="flex items-center gap-x-2">
+            <Heading level="h2">
+              {t("partner.stripeConnect.heading", "JYT Stripe Connect")}
+            </Heading>
+            {isActive && (
+              <Badge color="green" size="2xsmall" className="flex items-center gap-x-1">
+                <CheckCircleSolid className="text-ui-fg-on-color" />
+                {t("partner.stripeConnect.badge.active", "Active")}
+              </Badge>
+            )}
+            {isOnboarding && (
+              <Badge color="orange" size="2xsmall" className="flex items-center gap-x-1">
+                <ExclamationCircleSolid />
+                {t("partner.stripeConnect.badge.pending", "Setup incomplete")}
+              </Badge>
+            )}
+          </div>
+          <Text size="small" className="text-ui-fg-subtle max-w-[560px]">
+            {isActive
+              ? t(
+                  "partner.stripeConnect.description.active",
+                  "Payments run through JYT's Stripe Connect. This is your live Stripe source — any manually entered keys below are used only as a fallback."
+                )
+              : t(
+                  "partner.stripeConnect.description.default",
+                  "Skip entering API keys. Connect a Stripe account through JYT to get paid faster, with payouts and refunds handled for you."
+                )}
+          </Text>
+          {isActive && stripe_connect?.account_id && (
+            <Text size="xsmall" className="text-ui-fg-muted font-mono mt-1">
+              {stripe_connect.account_id}
+              {!stripe_connect.payouts_enabled &&
+                ` · ${t("partner.stripeConnect.payoutsPending", "payouts pending")}`}
+            </Text>
+          )}
+        </div>
+
+        <div className="shrink-0">
+          {isActive ? (
+            <Button
+              size="small"
+              variant="secondary"
+              isLoading={isStarting}
+              onClick={handleStart}
+            >
+              {t("partner.stripeConnect.actions.manage", "Update details")}
+            </Button>
+          ) : (
+            <Button
+              size="small"
+              variant="primary"
+              isLoading={isPending || isStarting}
+              onClick={handleStart}
+            >
+              {isOnboarding
+                ? t("partner.stripeConnect.actions.resume", "Finish setup")
+                : t("partner.stripeConnect.actions.connect", "Connect with Stripe")}
+            </Button>
+          )}
+        </div>
+      </div>
+    </Container>
+  )
+}

--- a/apps/partner-ui/src/routes/settings/payment-providers/payment-providers.tsx
+++ b/apps/partner-ui/src/routes/settings/payment-providers/payment-providers.tsx
@@ -15,6 +15,7 @@ import {
   useDeletePaymentConfig,
   type PaymentConfig,
 } from "../../../hooks/api/payment-config"
+import { StripeConnectCard } from "./components/stripe-connect-card"
 
 const PROVIDER_LABELS: Record<string, string> = {
   pp_payu_payu: "PayU",
@@ -31,6 +32,7 @@ export const PaymentProvidersPage = () => {
 
   return (
     <>
+      <StripeConnectCard />
       <Container className="divide-y px-0 py-0">
         <DataTable
           data={payment_configs}

--- a/deploy/aws/copilot/medusa-server/manifest.yml
+++ b/deploy/aws/copilot/medusa-server/manifest.yml
@@ -153,6 +153,11 @@ secrets:
   # Off by default in code; "true" here exposes them. See src/api/mcp/README.md.
   STORE_MCP_ENABLE_WRITE: /jyt/prod/STORE_MCP_ENABLE_WRITE
   STRIPE_API_KEY: /jyt/prod/STRIPE_API_KEY
+  # Signing secret for the Stripe *Connect* webhook (POST /webhooks/stripe/connect),
+  # which keeps partner_payment_config Connect status in sync (account.updated).
+  # Distinct from STRIPE_WEBHOOK_SECRET (the store/cart payment webhook) — it's the
+  # signing secret of the Connect endpoint registered in the Stripe dashboard.
+  STRIPE_CONNECT_WEBHOOK_SECRET: /jyt/prod/STRIPE_CONNECT_WEBHOOK_SECRET
   # Public client-side key (pk_…) for the self-hosted Stripe card page
   # (GET /stripe/pay/:cart_id). Non-secret, but env-specific so it's sourced from
   # SSM like the other Stripe params. Without it the hosted page won't render.


### PR DESCRIPTION
## What

Adds a **"Connect with Stripe"** path to **Settings → Payment Config** in the partner portal so partners onboard a **Standard** Stripe Connect account through JYT instead of pasting API keys. A webhook keeps the account status in sync, and when the account is active it becomes the authoritative Stripe source (manual keys become a fallback — *"Connect wins when active"*).

This is **Half A** of the Connect epic. Storefront charge-routing into the connected account (application fees, payouts, refunds, per-tenant provider) is the larger **Half B** and is **not** in this PR.

## Flow

1. Partner clicks **Connect with Stripe** → `POST /partners/payment-config/stripe-connect` creates a Standard connected account (once) and returns a Stripe-hosted onboarding link; UI redirects.
2. Partner finishes on Stripe → redirected back to the settings page (`?stripe_connect=return`) → UI re-syncs.
3. `GET /partners/payment-config/stripe-connect` live-syncs from Stripe so `charges_enabled` reflects immediately.
4. `POST /webhooks/stripe/connect` (`account.updated`, `account.application.deauthorized`) persists status asynchronously.

## Data

Typed columns on `partner_payment_config` (webhook-mutated / load-bearing → columns, **not** metadata):
`connect_account_id`, `connect_status`, `connect_charges_enabled`, `connect_payouts_enabled`, `connect_details_submitted`. Hand-written `ADD COLUMN IF NOT EXISTS` migration (`Migration20260702120000`) so it lands on existing DBs.

## Precedence

`isConnectLive(config)` = has account id **and** `charges_enabled`. When true, Connect is the live source; manual keys are fallback. Enforcing this in storefront checkout is Half B.

## Tests

- 13 unit tests for the pure lib (`deriveConnectStatus`, `accountToConnectFields`, `isConnectLive`, `assertSafeUrl`). ✅
- Backend + partner-UI `tsc`: no new errors in touched files (pre-existing repo errors unrelated).

## Deploy / ops

- Reuses `STRIPE_API_KEY` (platform secret, already used by subscription checkout).
- **New env: `STRIPE_CONNECT_WEBHOOK_SECRET`** — add to backend env (SSM for prod, copilot tags per repo convention).
- In the Stripe dashboard, add a **Connect** webhook endpoint → `https://<backend>/webhooks/stripe/connect` subscribed to `account.updated` (+ `account.application.deauthorized`).
- Until the secret + endpoint exist, onboarding still works (create account + link + GET live-sync); only the async push updates are dormant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)