### PR TITLE
feat(partner-payments): Stripe Connect checkout routing provider (Half B)

### DIFF
--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -265,6 +265,25 @@ module.exports = defineConfig({
               webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
             },
           },
+         ...(process.env.STRIPE_API_KEY &&
+          process.env.STRIPE_CONNECT_ENABLED === "true"
+            ? [
+                {
+                  resolve: "./src/modules/stripe-connect-payment",
+                  id: "stripe-connect",
+                  options: {
+                    apiKey: process.env.STRIPE_API_KEY,
+                    defaultFeePercent: process.env
+                      .STRIPE_CONNECT_DEFAULT_FEE_PERCENT
+                      ? Number(process.env.STRIPE_CONNECT_DEFAULT_FEE_PERCENT)
+                      : 0,
+                    refundApplicationFee: true,
+                    allowPlatformFallback:
+                      process.env.STRIPE_CONNECT_PLATFORM_FALLBACK === "true",
+                  },
+                },
+              ]
+            : []),
          ...(process.env.PAYU_MERCHANT_KEY
             ? [
                 {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -285,6 +285,28 @@ module.exports = defineConfig({
                       },
                     ]
                   : []),
+                ...(process.env.STRIPE_API_KEY &&
+                process.env.STRIPE_CONNECT_ENABLED === "true"
+                  ? [
+                      {
+                        resolve: "./src/modules/stripe-connect-payment",
+                        id: "stripe-connect",
+                        options: {
+                          apiKey: process.env.STRIPE_API_KEY,
+                          // Fee falls back to the partner plan's
+                          // payment_processing_fee at runtime; this is only used
+                          // when no plan is resolvable.
+                          defaultFeePercent: process.env
+                            .STRIPE_CONNECT_DEFAULT_FEE_PERCENT
+                            ? Number(process.env.STRIPE_CONNECT_DEFAULT_FEE_PERCENT)
+                            : 0,
+                          refundApplicationFee: true,
+                          allowPlatformFallback:
+                            process.env.STRIPE_CONNECT_PLATFORM_FALLBACK === "true",
+                        },
+                      },
+                    ]
+                  : []),
                 ...(process.env.PAYU_MERCHANT_KEY
                   ? [
                       {

--- a/apps/backend/src/modules/stripe-connect-payment/README.md
+++ b/apps/backend/src/modules/stripe-connect-payment/README.md
@@ -1,0 +1,59 @@
+# Stripe Connect payment provider (Half B)
+
+Routes a partner's **storefront** checkout INTO their Stripe Connect (Standard)
+account via **direct charges** with an `application_fee_amount` to the platform.
+The connected account is onboarded/stored by Half A (`partner_payment_config`
+columns `connect_account_id`, `connect_charges_enabled`, …).
+
+## How a charge is routed
+
+```
+cart.sales_channel_id
+  → store (default_sales_channel_id)      [query.graph]
+  → partner                                [partner-stores-link]
+  → partner_payment_config(pp_stripe_stripe, is_active)
+  → connect_account_id + connect_charges_enabled
+```
+
+`initiatePayment` creates the PaymentIntent **on** the connected account
+(`{ stripeAccount }`) with `application_fee_amount`. The fee % comes from the
+partner's active plan (`partner_subscription → plan.features.payment_processing_fee`,
+e.g. `"2%"`), falling back to `defaultFeePercent`. All later operations
+(authorize/capture/refund/cancel/update) re-scope to the same connected account
+via `connect_account_id` stored in the payment session `data`.
+
+Precedence — *"Connect wins when active"*: routing only happens when the partner
+has `connect_charges_enabled`. Otherwise `initiatePayment` throws (or, if
+`allowPlatformFallback`, charges the platform account with no fee).
+
+## Enabling
+
+Registered in `medusa-config(.prod).ts` only when **both** are set:
+
+| Env | Meaning |
+|-----|---------|
+| `STRIPE_API_KEY` | platform Stripe secret (owns connected accounts) |
+| `STRIPE_CONNECT_ENABLED=true` | opt-in flag — dormant until set |
+| `STRIPE_CONNECT_DEFAULT_FEE_PERCENT` | optional; fee % when no plan resolvable (default 0) |
+| `STRIPE_CONNECT_PLATFORM_FALLBACK=true` | optional; charge platform (no fee) when a store has no connected account instead of failing |
+
+Provider id: `pp_stripe-connect_stripe-connect`. After enabling, it must be
+added to the payment providers of the region(s) whose storefronts should route
+to partners.
+
+## v1 limitations (follow-ups)
+
+- **Webhook wiring**: direct-charge `payment_intent.*` events are delivered to
+  the platform's **Connect** webhook endpoint. `getWebhookActionAndData` maps
+  them, but the `/webhooks/stripe/connect` route is not yet wired to dispatch
+  payment events into the Medusa payment module — the happy path relies on
+  client-side confirmation + `authorizePayment` on return. Wiring the webhook is
+  the recommended next step for robustness.
+- **Refunds**: `refund_application_fee: true` by default (platform fee handed
+  back so the partner isn't out-of-pocket). Disputes/chargebacks land on the
+  **partner's** account (Standard direct-charge semantics) — no platform-side
+  dispute tooling yet.
+- **INR/GST**: launch EUR-first. Stripe India Connect + GST handling is out of
+  scope for this slice.
+- **Payouts**: handled by Stripe on the connected account's own schedule; not
+  orchestrated here.

--- a/apps/backend/src/modules/stripe-connect-payment/__tests__/fee.unit.spec.ts
+++ b/apps/backend/src/modules/stripe-connect-payment/__tests__/fee.unit.spec.ts
@@ -1,0 +1,107 @@
+import { PaymentSessionStatus } from "@medusajs/framework/utils"
+import {
+  currencyMultiplier,
+  toStripeMinorUnits,
+  parseFeePercent,
+  computeApplicationFee,
+  mapStripeStatus,
+} from "../lib/fee"
+
+describe("stripe-connect fee/amount lib (Half B)", () => {
+  describe("currencyMultiplier", () => {
+    it("is 100 for standard 2-decimal currencies", () => {
+      expect(currencyMultiplier("eur")).toBe(100)
+      expect(currencyMultiplier("USD")).toBe(100)
+      expect(currencyMultiplier("inr")).toBe(100)
+    })
+    it("is 1 for zero-decimal currencies", () => {
+      expect(currencyMultiplier("JPY")).toBe(1)
+      expect(currencyMultiplier("krw")).toBe(1)
+    })
+    it("is 1000 for three-decimal currencies", () => {
+      expect(currencyMultiplier("KWD")).toBe(1000)
+    })
+  })
+
+  describe("toStripeMinorUnits", () => {
+    it("converts EUR major → cents", () => {
+      expect(toStripeMinorUnits(12.5, "eur")).toBe(1250)
+      expect(toStripeMinorUnits("9.99", "EUR")).toBe(999)
+    })
+    it("passes zero-decimal currencies through", () => {
+      expect(toStripeMinorUnits(1500, "JPY")).toBe(1500)
+    })
+    it("rounds three-decimal currencies to the nearest ten", () => {
+      // 1.234 KWD → 1234 → ceil to 1240
+      expect(toStripeMinorUnits(1.234, "KWD")).toBe(1240)
+    })
+    it("handles rounding without float drift", () => {
+      expect(toStripeMinorUnits(19.99, "usd")).toBe(1999)
+      expect(toStripeMinorUnits(0.1 + 0.2, "usd")).toBe(30)
+    })
+    it("returns 0 for non-finite input", () => {
+      expect(toStripeMinorUnits("abc", "eur")).toBe(0)
+    })
+  })
+
+  describe("parseFeePercent", () => {
+    it("parses plan feature strings", () => {
+      expect(parseFeePercent("2%")).toBeCloseTo(0.02)
+      expect(parseFeePercent("4%")).toBeCloseTo(0.04)
+      expect(parseFeePercent("1%")).toBeCloseTo(0.01)
+      expect(parseFeePercent("2.5%")).toBeCloseTo(0.025)
+    })
+    it("parses bare numbers and numeric input", () => {
+      expect(parseFeePercent("2")).toBeCloseTo(0.02)
+      expect(parseFeePercent(3)).toBeCloseTo(0.03)
+    })
+    it("returns 0 for invalid / negative / missing", () => {
+      expect(parseFeePercent(null)).toBe(0)
+      expect(parseFeePercent(undefined)).toBe(0)
+      expect(parseFeePercent("free")).toBe(0)
+      expect(parseFeePercent("-1%")).toBe(0)
+    })
+  })
+
+  describe("computeApplicationFee", () => {
+    it("computes fee in minor units", () => {
+      // €50.00 = 5000 cents, 2% → 100 cents
+      expect(computeApplicationFee(5000, 0.02)).toBe(100)
+      // 4% of 999 → 39.96 → 40
+      expect(computeApplicationFee(999, 0.04)).toBe(40)
+    })
+    it("is 0 when amount or percent is non-positive", () => {
+      expect(computeApplicationFee(0, 0.02)).toBe(0)
+      expect(computeApplicationFee(5000, 0)).toBe(0)
+      expect(computeApplicationFee(-100, 0.02)).toBe(0)
+    })
+    it("never exceeds the charge", () => {
+      expect(computeApplicationFee(100, 2)).toBe(100)
+    })
+  })
+
+  describe("mapStripeStatus", () => {
+    it("maps the capture lifecycle", () => {
+      expect(mapStripeStatus("requires_capture")).toBe(
+        PaymentSessionStatus.AUTHORIZED
+      )
+      expect(mapStripeStatus("succeeded")).toBe(PaymentSessionStatus.CAPTURED)
+      expect(mapStripeStatus("canceled")).toBe(PaymentSessionStatus.CANCELED)
+      expect(mapStripeStatus("requires_action")).toBe(
+        PaymentSessionStatus.REQUIRES_MORE
+      )
+      expect(mapStripeStatus("processing")).toBe(PaymentSessionStatus.PENDING)
+    })
+    it("disambiguates requires_payment_method by last_payment_error", () => {
+      expect(mapStripeStatus("requires_payment_method", false)).toBe(
+        PaymentSessionStatus.PENDING
+      )
+      expect(mapStripeStatus("requires_payment_method", true)).toBe(
+        PaymentSessionStatus.ERROR
+      )
+    })
+    it("defaults unknown statuses to pending", () => {
+      expect(mapStripeStatus("something_new")).toBe(PaymentSessionStatus.PENDING)
+    })
+  })
+})

--- a/apps/backend/src/modules/stripe-connect-payment/index.ts
+++ b/apps/backend/src/modules/stripe-connect-payment/index.ts
@@ -1,0 +1,6 @@
+import { ModuleProvider, Modules } from "@medusajs/framework/utils"
+import StripeConnectPaymentProviderService from "./service"
+
+export default ModuleProvider(Modules.PAYMENT, {
+  services: [StripeConnectPaymentProviderService],
+})

--- a/apps/backend/src/modules/stripe-connect-payment/lib/fee.ts
+++ b/apps/backend/src/modules/stripe-connect-payment/lib/fee.ts
@@ -1,0 +1,93 @@
+import { PaymentSessionStatus } from "@medusajs/framework/utils"
+
+/**
+ * Pure helpers for the Stripe Connect payment provider — amount conversion,
+ * application-fee math, and Stripe→Medusa status mapping. Kept free of any
+ * Stripe/DB dependency so they are unit-testable.
+ */
+
+// https://docs.stripe.com/currencies — zero-decimal and three-decimal currencies.
+const ZERO_DECIMAL = new Set([
+  "BIF", "CLP", "DJF", "GNF", "JPY", "KMF", "KRW", "MGA", "PYG", "RWF",
+  "UGX", "VND", "VUV", "XAF", "XOF", "XPF",
+])
+const THREE_DECIMAL = new Set(["BHD", "IQD", "JOD", "KWD", "OMR", "TND"])
+
+export const currencyMultiplier = (currency: string): number => {
+  const c = (currency || "").toUpperCase()
+  if (ZERO_DECIMAL.has(c)) return 1
+  if (THREE_DECIMAL.has(c)) return 1000
+  return 100
+}
+
+/**
+ * Convert a major-unit amount (e.g. 12.50 EUR) into Stripe's smallest unit
+ * (1250). Mirrors @medusajs/payment-stripe getSmallestUnit, incl. the
+ * three-decimal rounding-to-ten rule.
+ */
+export const toStripeMinorUnits = (
+  amount: number | string,
+  currency: string
+): number => {
+  const n = typeof amount === "number" ? amount : Number(amount)
+  if (!isFinite(n)) return 0
+  const m = currencyMultiplier(currency)
+  let v = Math.round(n * m)
+  if (m === 1000) v = Math.ceil(v / 10) * 10
+  return v
+}
+
+/**
+ * Parse a plan's payment_processing_fee ("2%", "2", 2, "2.5%") into a fraction
+ * (0.02 / 0.025). Anything invalid or negative → 0 (no fee — the safe default).
+ */
+export const parseFeePercent = (input: unknown): number => {
+  if (input == null) return 0
+  const s = String(input).trim().replace("%", "")
+  const n = Number(s)
+  if (!isFinite(n) || n < 0) return 0
+  return n / 100
+}
+
+/**
+ * Platform application fee in minor units, given the charge amount (minor units)
+ * and a fee fraction. Never exceeds the charge itself.
+ */
+export const computeApplicationFee = (
+  minorAmount: number,
+  feePercent: number
+): number => {
+  if (!isFinite(minorAmount) || minorAmount <= 0) return 0
+  if (!isFinite(feePercent) || feePercent <= 0) return 0
+  return Math.min(Math.round(minorAmount * feePercent), minorAmount)
+}
+
+/**
+ * Map a Stripe PaymentIntent status onto a Medusa PaymentSessionStatus. Mirrors
+ * @medusajs/payment-stripe's mapping. `hasLastPaymentError` disambiguates the
+ * requires_payment_method case (a real failure vs. a fresh intent).
+ */
+export const mapStripeStatus = (
+  status: string,
+  hasLastPaymentError = false
+): PaymentSessionStatus => {
+  switch (status) {
+    case "requires_payment_method":
+      return hasLastPaymentError
+        ? PaymentSessionStatus.ERROR
+        : PaymentSessionStatus.PENDING
+    case "requires_confirmation":
+    case "processing":
+      return PaymentSessionStatus.PENDING
+    case "requires_action":
+      return PaymentSessionStatus.REQUIRES_MORE
+    case "canceled":
+      return PaymentSessionStatus.CANCELED
+    case "requires_capture":
+      return PaymentSessionStatus.AUTHORIZED
+    case "succeeded":
+      return PaymentSessionStatus.CAPTURED
+    default:
+      return PaymentSessionStatus.PENDING
+  }
+}

--- a/apps/backend/src/modules/stripe-connect-payment/service.ts
+++ b/apps/backend/src/modules/stripe-connect-payment/service.ts
@@ -1,0 +1,432 @@
+import {
+  AbstractPaymentProvider,
+  MedusaError,
+} from "@medusajs/framework/utils"
+import {
+  AuthorizePaymentInput,
+  AuthorizePaymentOutput,
+  CancelPaymentInput,
+  CancelPaymentOutput,
+  CapturePaymentInput,
+  CapturePaymentOutput,
+  DeletePaymentInput,
+  DeletePaymentOutput,
+  GetPaymentStatusInput,
+  GetPaymentStatusOutput,
+  InitiatePaymentInput,
+  InitiatePaymentOutput,
+  Logger,
+  RefundPaymentInput,
+  RefundPaymentOutput,
+  RetrievePaymentInput,
+  RetrievePaymentOutput,
+  UpdatePaymentInput,
+  UpdatePaymentOutput,
+  WebhookActionResult,
+} from "@medusajs/framework/types"
+import {
+  computeApplicationFee,
+  mapStripeStatus,
+  parseFeePercent,
+  toStripeMinorUnits,
+} from "./lib/fee"
+
+type StripeConnectOptions = {
+  // Platform Stripe secret (JYT's own account) — owns the connected accounts.
+  apiKey: string
+  // Fallback fee fraction when a partner's plan can't be resolved (e.g. 0.02).
+  // Default 0 (charge no platform fee rather than over-charging).
+  defaultFeePercent?: number
+  // Refund the platform application fee back to the customer on refunds
+  // (direct-charge semantics). Default true — partner isn't out-of-pocket.
+  refundApplicationFee?: boolean
+  // If a store has NO active connected account, charge on the platform account
+  // with no application fee instead of failing. Default false → throw, so we
+  // never silently collect a partner sale into the platform account.
+  allowPlatformFallback?: boolean
+}
+
+// partner_payment_config.provider_id under which Half A stores the Connect
+// account — NOT this payment provider's own id.
+const CONNECT_CONFIG_PROVIDER_ID = "pp_stripe_stripe"
+
+type ResolvedConnect = {
+  connectAccountId: string
+  partnerId: string
+}
+
+/**
+ * Storefront payment provider that routes a partner's checkout INTO their
+ * Stripe Connect (Standard) account via **direct charges** with an
+ * application_fee_amount to the platform. Mirrors the per-partner resolution
+ * pattern already proven by the PayU provider (cart → sales_channel → store →
+ * partner → partner_payment_config).
+ */
+class StripeConnectPaymentProviderService extends AbstractPaymentProvider<StripeConnectOptions> {
+  static identifier = "stripe-connect"
+
+  protected logger_: Logger
+  protected options_: StripeConnectOptions
+  protected container_: any
+  private stripe_: any
+
+  constructor(container: { logger: Logger }, options: StripeConnectOptions) {
+    super(container as any, options)
+    this.logger_ = container.logger
+    this.options_ = options
+    this.container_ = container
+  }
+
+  static validateOptions(options: Record<any, any>): void {
+    if (!options.apiKey) {
+      throw new Error("Stripe Connect provider requires `apiKey` (platform secret)")
+    }
+  }
+
+  private async getStripe(): Promise<any> {
+    if (!this.stripe_) {
+      const Stripe = await import("stripe").then((m) => m.default)
+      this.stripe_ = new Stripe(this.options_.apiKey)
+    }
+    return this.stripe_
+  }
+
+  /** Stripe request options that scope a call to the connected account. */
+  private accountOpts(accountId?: string | null): Record<string, any> {
+    return accountId ? { stripeAccount: accountId } : {}
+  }
+
+  /**
+   * Resolve the partner's ACTIVE connected account from the cart context.
+   * cart.sales_channel_id → store → partner → partner_payment_config. Returns
+   * null when the partner has no charge-enabled Connect account.
+   */
+  private async resolveConnect(
+    context?: Record<string, unknown>
+  ): Promise<ResolvedConnect | null> {
+    if (!context) return null
+    try {
+      const salesChannelId =
+        (context as any)?.extra?.sales_channel_id ||
+        (context as any)?.sales_channel_id
+      if (!salesChannelId) return null
+
+      const query = this.container_.resolve?.("query")
+      if (!query) return null
+
+      const { data: stores } = await query
+        .graph({
+          entity: "store",
+          filters: { default_sales_channel_id: salesChannelId },
+          fields: ["id", "partner.*"],
+        })
+        .catch(() => ({ data: [] }))
+
+      const partnerId = stores?.[0]?.partner?.id
+      if (!partnerId) return null
+
+      const configService = this.container_.resolve?.("partner_payment_config")
+      if (!configService) return null
+
+      const configs = await configService.listPartnerPaymentConfigs({
+        partner_id: partnerId,
+        provider_id: CONNECT_CONFIG_PROVIDER_ID,
+        is_active: true,
+      })
+      const config = configs?.[0]
+      if (
+        !config?.connect_account_id ||
+        !config?.connect_charges_enabled // "Connect wins when active"
+      ) {
+        return null
+      }
+
+      return { connectAccountId: config.connect_account_id, partnerId }
+    } catch (e: any) {
+      this.logger_.warn(
+        `[stripe-connect] failed to resolve connected account: ${e?.message}`
+      )
+      return null
+    }
+  }
+
+  /**
+   * Application fee fraction from the partner's active plan
+   * (partner_subscription → plan.features.payment_processing_fee). Falls back
+   * to options.defaultFeePercent (default 0).
+   */
+  private async resolveFeePercent(partnerId: string): Promise<number> {
+    const fallback = this.options_.defaultFeePercent ?? 0
+    try {
+      const query = this.container_.resolve?.("query")
+      if (!query) return fallback
+      const { data: subs } = await query
+        .graph({
+          entity: "partner_subscription",
+          filters: { partner_id: partnerId, status: "active" },
+          fields: ["id", "plan.features"],
+        })
+        .catch(() => ({ data: [] }))
+      const feeRaw = subs?.[0]?.plan?.features?.payment_processing_fee
+      if (feeRaw == null) return fallback
+      const pct = parseFeePercent(feeRaw)
+      return pct > 0 ? pct : fallback
+    } catch {
+      return fallback
+    }
+  }
+
+  async initiatePayment(
+    input: InitiatePaymentInput
+  ): Promise<InitiatePaymentOutput> {
+    const { amount, currency_code, context, data } = input
+    const stripe = await this.getStripe()
+    const minor = toStripeMinorUnits(Number(amount), currency_code)
+    const sessionId = (data?.session_id as string) || ""
+    const email =
+      (context as any)?.email || (context?.customer as any)?.email || undefined
+
+    const resolved = await this.resolveConnect(context)
+
+    if (resolved) {
+      const pct = await this.resolveFeePercent(resolved.partnerId)
+      const fee = computeApplicationFee(minor, pct)
+
+      const intent = await stripe.paymentIntents.create(
+        {
+          amount: minor,
+          currency: currency_code.toLowerCase(),
+          automatic_payment_methods: { enabled: true },
+          ...(fee > 0 ? { application_fee_amount: fee } : {}),
+          ...(email ? { receipt_email: email } : {}),
+          metadata: {
+            partner_id: resolved.partnerId,
+            session_id: sessionId,
+            platform: "jyt",
+          },
+        },
+        this.accountOpts(resolved.connectAccountId)
+      )
+
+      this.logger_.info(
+        `[stripe-connect] direct charge on ${resolved.connectAccountId} ` +
+          `amount=${minor}${currency_code} fee=${fee} (partner=${resolved.partnerId})`
+      )
+
+      return {
+        id: intent.id,
+        data: {
+          id: intent.id,
+          client_secret: intent.client_secret,
+          connect_account_id: resolved.connectAccountId,
+          partner_id: resolved.partnerId,
+          application_fee_amount: fee,
+          amount: minor,
+          currency: currency_code.toLowerCase(),
+          connected: true,
+        },
+      }
+    }
+
+    // No active connected account for this store.
+    if (!this.options_.allowPlatformFallback) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        "This store has no active Stripe Connect account. The partner must finish Stripe onboarding before accepting payments."
+      )
+    }
+
+    const intent = await stripe.paymentIntents.create({
+      amount: minor,
+      currency: currency_code.toLowerCase(),
+      automatic_payment_methods: { enabled: true },
+      ...(email ? { receipt_email: email } : {}),
+      metadata: { session_id: sessionId, platform: "jyt", connected: "false" },
+    })
+    this.logger_.info(
+      `[stripe-connect] platform fallback charge amount=${minor}${currency_code} (no connected account)`
+    )
+    return {
+      id: intent.id,
+      data: {
+        id: intent.id,
+        client_secret: intent.client_secret,
+        connect_account_id: null,
+        application_fee_amount: 0,
+        amount: minor,
+        currency: currency_code.toLowerCase(),
+        connected: false,
+      },
+    }
+  }
+
+  private async retrieveIntent(data?: Record<string, unknown>): Promise<any> {
+    const stripe = await this.getStripe()
+    const id = (data?.id as string) || (data?.payment_intent_id as string)
+    if (!id) throw new MedusaError(MedusaError.Types.INVALID_DATA, "Missing payment intent id")
+    return stripe.paymentIntents.retrieve(
+      id,
+      this.accountOpts(data?.connect_account_id as string)
+    )
+  }
+
+  async authorizePayment(
+    input: AuthorizePaymentInput
+  ): Promise<AuthorizePaymentOutput> {
+    const intent = await this.retrieveIntent(input.data)
+    const status = mapStripeStatus(intent.status, !!intent.last_payment_error)
+    return { status, data: { ...input.data, status: intent.status } }
+  }
+
+  async getPaymentStatus(
+    input: GetPaymentStatusInput
+  ): Promise<GetPaymentStatusOutput> {
+    const intent = await this.retrieveIntent(input.data)
+    return {
+      status: mapStripeStatus(intent.status, !!intent.last_payment_error),
+      data: { ...input.data, status: intent.status },
+    }
+  }
+
+  async capturePayment(
+    input: CapturePaymentInput
+  ): Promise<CapturePaymentOutput> {
+    const stripe = await this.getStripe()
+    const id = input.data?.id as string
+    try {
+      const intent = await stripe.paymentIntents.capture(
+        id,
+        {},
+        this.accountOpts(input.data?.connect_account_id as string)
+      )
+      return { data: { ...input.data, status: intent.status } }
+    } catch (e: any) {
+      // Already captured (auto-capture) → treat as success.
+      if (e?.code === "payment_intent_unexpected_state") {
+        return { data: { ...input.data } }
+      }
+      throw e
+    }
+  }
+
+  async refundPayment(input: RefundPaymentInput): Promise<RefundPaymentOutput> {
+    const stripe = await this.getStripe()
+    const id = input.data?.id as string
+    const currency = (input.data?.currency as string) || "eur"
+    const refundApplicationFee = this.options_.refundApplicationFee ?? true
+
+    const refund = await stripe.refunds.create(
+      {
+        payment_intent: id,
+        amount: toStripeMinorUnits(Number(input.amount), currency),
+        // Direct-charge refund: also hand back the platform fee so the partner
+        // isn't out-of-pocket for it.
+        ...(refundApplicationFee ? { refund_application_fee: true } : {}),
+      },
+      this.accountOpts(input.data?.connect_account_id as string)
+    )
+    return {
+      data: { ...input.data, refund_id: refund.id, refunded: true },
+    }
+  }
+
+  async cancelPayment(input: CancelPaymentInput): Promise<CancelPaymentOutput> {
+    const stripe = await this.getStripe()
+    const id = input.data?.id as string
+    try {
+      if (id) {
+        await stripe.paymentIntents.cancel(
+          id,
+          undefined,
+          this.accountOpts(input.data?.connect_account_id as string)
+        )
+      }
+    } catch (e: any) {
+      this.logger_.warn(`[stripe-connect] cancel failed: ${e?.message}`)
+    }
+    return { data: { ...input.data, status: "canceled" } }
+  }
+
+  async deletePayment(input: DeletePaymentInput): Promise<DeletePaymentOutput> {
+    return this.cancelPayment(input as any)
+  }
+
+  async retrievePayment(
+    input: RetrievePaymentInput
+  ): Promise<RetrievePaymentOutput> {
+    try {
+      const intent = await this.retrieveIntent(input.data)
+      return { data: { ...input.data, status: intent.status } }
+    } catch {
+      return { data: input.data }
+    }
+  }
+
+  async updatePayment(input: UpdatePaymentInput): Promise<UpdatePaymentOutput> {
+    const { amount, currency_code, data } = input
+    const id = data?.id as string
+    if (!id || amount == null) return { data: { ...data } }
+
+    const stripe = await this.getStripe()
+    const minor = toStripeMinorUnits(Number(amount), currency_code)
+    const connectAccountId = data?.connect_account_id as string
+
+    // Recompute the application fee for the new amount (direct charges allow
+    // updating application_fee_amount pre-capture).
+    let fee = (data?.application_fee_amount as number) ?? 0
+    if (connectAccountId && data?.partner_id) {
+      const pct = await this.resolveFeePercent(data.partner_id as string)
+      fee = computeApplicationFee(minor, pct)
+    }
+
+    try {
+      await stripe.paymentIntents.update(
+        id,
+        {
+          amount: minor,
+          ...(connectAccountId && fee > 0
+            ? { application_fee_amount: fee }
+            : {}),
+        },
+        this.accountOpts(connectAccountId)
+      )
+    } catch (e: any) {
+      this.logger_.warn(`[stripe-connect] update failed: ${e?.message}`)
+    }
+    return {
+      data: { ...data, amount: minor, application_fee_amount: fee },
+    }
+  }
+
+  /**
+   * Payment events for direct charges are delivered to the platform's Connect
+   * webhook endpoint. Wiring that route to dispatch here is a follow-up; this
+   * maps a already-parsed payment_intent event so it works once wired.
+   */
+  async getWebhookActionAndData(payload: {
+    data: Record<string, unknown>
+    rawData: string | Buffer
+    headers: Record<string, unknown>
+  }): Promise<WebhookActionResult> {
+    const event = payload.data as any
+    const type = event?.type as string
+    const intent = event?.data?.object || event?.object || {}
+    const sessionId = intent?.metadata?.session_id
+
+    if (!sessionId) return { action: "not_supported" }
+
+    const amount = intent?.amount
+    switch (type) {
+      case "payment_intent.succeeded":
+        return { action: "captured", data: { session_id: sessionId, amount } }
+      case "payment_intent.amount_capturable_updated":
+        return { action: "authorized", data: { session_id: sessionId, amount } }
+      case "payment_intent.payment_failed":
+        return { action: "failed", data: { session_id: sessionId, amount } }
+      default:
+        return { action: "not_supported" }
+    }
+  }
+}
+
+export default StripeConnectPaymentProviderService


### PR DESCRIPTION
## What

The **"Big Half"** — a custom Medusa payment provider that charges a partner's storefront cart **into their Stripe Connect (Standard) account** via **direct charges**, taking a platform **application fee**. Consumes Half A's `connect_account_id` / `connect_charges_enabled`.

> **Stacked on #850 (Half A).** Base branch = `feat/partner-stripe-connect-onboarding`. Merge #850 first, then rebase this onto `main`.

## The "key part" was already there

This mirrors the **existing, in-production PayU provider** (`src/modules/payu-payment/service.ts`), which already resolves per-partner credentials via `cart → sales_channel → store → partner → partner_payment_config`. Half B reuses that exact join for Stripe and adds the Connect-specific charge call.

## Flow

```
cart.sales_channel_id → store → partner → partner_payment_config(pp_stripe_stripe)
  → connect_account_id + connect_charges_enabled
```

`initiatePayment` creates the PaymentIntent **on** the connected account (`{ stripeAccount }`) with `application_fee_amount`; capture/refund/cancel/update re-scope to the same account via `connect_account_id` stashed in the session `data`.

## Decisions (locked with @saranshisatgit)

- **Direct charge + application fee** (Stripe-recommended for Standard; partner owns charge/refund/dispute, JYT fee auto-swept).
- **Fee from the plan** — `partner_subscription → plan.features.payment_processing_fee` (`4%`/`2%`/`1%`), fallback `defaultFeePercent`.
- **Connect wins when active** — routes only when `connect_charges_enabled`; else throws unless `STRIPE_CONNECT_PLATFORM_FALLBACK=true`.

## Enabling (dormant by default)

Registered only when `STRIPE_API_KEY` **and** `STRIPE_CONNECT_ENABLED=true`. Provider id `pp_stripe-connect_stripe-connect` must then be added to the target region(s). Other flags: `STRIPE_CONNECT_DEFAULT_FEE_PERCENT`, `STRIPE_CONNECT_PLATFORM_FALLBACK`.

## Tests
17 unit tests on the pure lib (minor-units conversion incl. zero/three-decimal currencies, `parseFeePercent`, `computeApplicationFee`, status mapping). ✅ Backend `tsc` clean (no new errors).

## v1 limitations (documented in module README)
- **Webhook wiring** — direct-charge `payment_intent.*` events hit the Connect endpoint; `getWebhookActionAndData` maps them but dispatch from `/webhooks/stripe/connect` into the payment module is a follow-up. Happy path uses client-side confirm + `authorizePayment`.
- **Refunds** default to `refund_application_fee: true`; disputes land on the partner's account (Standard semantics) — no platform dispute tooling yet.
- **INR/GST** out of scope — launch **EUR-first**.
- **Payouts** on Stripe's connected-account schedule; not orchestrated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)