### PR TITLE
chore(deploy): wire STRIPE_CONNECT_ENABLED go-live flag

### DIFF
--- a/deploy/aws/copilot/medusa-server/manifest.yml
+++ b/deploy/aws/copilot/medusa-server/manifest.yml
@@ -153,6 +153,11 @@ secrets:
   # Off by default in code; "true" here exposes them. See src/api/mcp/README.md.
   STORE_MCP_ENABLE_WRITE: /jyt/prod/STORE_MCP_ENABLE_WRITE
   STRIPE_API_KEY: /jyt/prod/STRIPE_API_KEY
+  # Go-live switch for the Stripe Connect *checkout routing* provider (Half B).
+  # "false" = the pp_stripe-connect provider is NOT registered (dormant). Flip the
+  # SSM value to "true" + redeploy to register it, then add it to the target
+  # region's payment providers. Half A onboarding does NOT need this.
+  STRIPE_CONNECT_ENABLED: /jyt/prod/STRIPE_CONNECT_ENABLED
   # Signing secret for the Stripe *Connect* webhook (POST /webhooks/stripe/connect),
   # which keeps partner_payment_config Connect status in sync (account.updated).
   # Distinct from STRIPE_WEBHOOK_SECRET (the store/cart payment webhook) — it's the


### PR DESCRIPTION
Adds the `STRIPE_CONNECT_ENABLED` go-live switch to the medusa-server copilot manifest so enabling **Half B** (Stripe Connect checkout routing, #851) is a single SSM flip.

- SSM `/jyt/prod/STRIPE_CONNECT_ENABLED` created, seeded `"false"` (dormant), copilot-tagged.
- Once deployed: set the value to `"true"` + redeploy → the `pp_stripe-connect_stripe-connect` provider registers; then add it to the target region's payment providers.
- Half A onboarding (#850) is unaffected either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)