### PR TITLE
fix(partner-payments): rename connect-columns migration (name collision skipped it on prod)

### DIFF
--- a/apps/backend/src/modules/partner-payment-config/migrations/Migration20260702170000.ts
+++ b/apps/backend/src/modules/partner-payment-config/migrations/Migration20260702170000.ts
@@ -3,11 +3,15 @@ import { Migration } from "@medusajs/framework/mikro-orm/migrations";
 /**
  * JYT Stripe Connect (Standard) columns on partner_payment_config.
  *
- * Hand-written ADD COLUMN IF NOT EXISTS so it lands on existing databases —
- * editing the original `create table if not exists` migration would never run
- * on an already-provisioned DB.
+ * NOTE: renamed from Migration20260702120000 — that name COLLIDED with
+ * raw_material/Migration20260702120000 (#847). Medusa tracks migrations by name
+ * globally in mikro_orm_migrations, so the raw_material one recorded the name
+ * first and this module's identically-named migration was skipped as
+ * "already run" (columns never applied — bit prod). Unique name → runs on deploy.
+ *
+ * Hand-written ADD COLUMN IF NOT EXISTS so it lands on existing databases.
  */
-export class Migration20260702120000 extends Migration {
+export class Migration20260702170000 extends Migration {
 
   override async up(): Promise<void> {
     this.addSql(`ALTER TABLE IF EXISTS "partner_payment_config" ADD COLUMN IF NOT EXISTS "connect_account_id" text null;`);


### PR DESCRIPTION
## Root cause (diagnosed on prod, read-only)
`partner-payment-config/Migration20260702120000.ts` (Stripe Connect columns, #850) had the **identical class/file name** as `raw_material/Migration20260702120000.ts` (#847, `raw_material_group.dimensions` / `raw_materials.attributes`).

Medusa tracks migrations by **name, globally** in `mikro_orm_migrations`. #847 deployed first (07-02 morning) → recorded `Migration20260702120000` → when this module's same-named migration arrived in a later deploy, the migrator saw the name as already-executed and **silently skipped it** (recorded, but its `ADD COLUMN` SQL never ran).

**Impact:** prod's `partner_payment_config` was missing `connect_account_id` etc. → Half A "Connect with Stripe" would 500 on write.

Prod verification (one-off ECS task, read-only) — only the collided one was missing:

| Column | Migration | Prod |
|---|---|---|
| `partner_payment_config.connect_account_id` | mine — `…120000` | ❌ MISSING |
| `raw_material_group.dimensions` | #847 — `…120000` (same name) | ✅ EXISTS |
| `partner.country_code` | #849 — unique | ✅ EXISTS |
| `inventory_order_line.batch_number` | #848 — unique | ✅ EXISTS |

So it's **not** a systemic ALTER problem and nothing to do with the migration being hand-written — purely the duplicate name.

## Fix
Rename to **`Migration20260702170000`** (unique name + class), content unchanged (idempotent `ADD COLUMN IF NOT EXISTS` + index). On merge, the deploy's `predeploy:force` (`medusa db:migrate --execute-all-links`, run before `medusa start`) will see it as pending and apply the columns — **no direct prod DDL needed**.

Verified no other cross-module migration-name collisions remain (`find … uniq -d` → none).

## After merge
Confirm the columns landed on prod (I'll re-run the read-only column check), then Half A onboarding is unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)