### PR TITLE
fix(payments+inventory): PayU partner creds, order-line drop, Connect gating

### DIFF
--- a/apps/backend/src/admin/components/inventory-orders/edit-order-lines.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/edit-order-lines.tsx
@@ -117,13 +117,34 @@ export const EditOrderLines = ({ inventoryOrder }: EditOrderLinesProps) => {
       };
     });
 
+    // Dropping a line from the field array just removes it from the payload —
+    // the update workflow only DELETES a line when it receives an explicit
+    // { id, remove: true } marker, so without this a dropped existing line
+    // silently survives. Diff the original existing lines against the ones
+    // still present and send a removal marker for each that's gone.
+    const remainingExistingIds = new Set(
+      (fields as OrderLine[])
+        .filter((l) => l.isExisting && l.id)
+        .map((l) => l.id)
+    );
+    const removedLines = (existingLines as OrderLine[])
+      .filter((l) => l.id && !remainingExistingIds.has(l.id))
+      .map((l) => ({
+        id: l.id,
+        inventory_item_id: l.inventory_item_id || "",
+        // Ignored server-side for removals, but must satisfy the line schema.
+        quantity: l.quantity && l.quantity >= 1 ? l.quantity : 1,
+        price: typeof l.price === "number" && l.price >= 0 ? l.price : 0,
+        remove: true,
+      }));
+
     const payload = {
       id: inventoryOrder.id,
       data: {
         quantity: totalQuantity,
         total_price: totalPrice,
       },
-      order_lines: orderLines,
+      order_lines: [...orderLines, ...removedLines],
     };
 
     try {

--- a/apps/backend/src/admin/hooks/api/inventory-orders.ts
+++ b/apps/backend/src/admin/hooks/api/inventory-orders.ts
@@ -317,6 +317,8 @@ export interface UpdateInventoryOrderLinesPayload {
     quantity: number;
     price: number;
     batch_number?: number | null;
+    // Marks an existing line for deletion (soft-delete + link dismiss server-side).
+    remove?: boolean;
   }>;
 }
 

--- a/apps/backend/src/api/admin/inventory-orders/validators.ts
+++ b/apps/backend/src/api/admin/inventory-orders/validators.ts
@@ -158,14 +158,54 @@ export const listInventoryOrdersQuerySchema = z.object({
 export type ListInventoryOrdersQuery = z.infer<typeof listInventoryOrdersQuerySchema>;
 
 // Schema for updating order lines
-export const updateOrderLineSchema = z.object({
-  id: z.string().optional(), // Existing lines have IDs
-  inventory_item_id: z.string().min(1, "Inventory item ID is required"),
-  quantity: z.number().min(1, "Quantity must be at least 1"),
-  price: z.number().min(0, "Price must be non-negative"),
-  // Optional batch tag (see inventoryOrderLineInputSchema).
-  batch_number: z.number().int().positive().nullish(),
-});
+export const updateOrderLineSchema = z
+  .object({
+    id: z.string().optional(), // Existing lines have IDs
+    inventory_item_id: z.string().optional(),
+    quantity: z.number().optional(),
+    price: z.number().optional(),
+    // Optional batch tag (see inventoryOrderLineInputSchema).
+    batch_number: z.number().int().positive().nullish(),
+    // Explicit removal marker for an existing line: the update workflow
+    // soft-deletes the line (by `id`) and dismisses its inventory-item link.
+    // Without this key the middleware would strip it and a dropped line would
+    // silently survive. A removal marker only needs `id` — the other fields
+    // are ignored server-side (compensation reads the prior values).
+    remove: z.boolean().optional(),
+  })
+  .superRefine((val, ctx) => {
+    if (val.remove) {
+      if (!val.id) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["id"],
+          message: "A removal marker requires the existing line id",
+        });
+      }
+      return; // removals skip the create/update field requirements
+    }
+    if (!val.inventory_item_id || val.inventory_item_id.length < 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["inventory_item_id"],
+        message: "Inventory item ID is required",
+      });
+    }
+    if (val.quantity == null || val.quantity < 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["quantity"],
+        message: "Quantity must be at least 1",
+      });
+    }
+    if (val.price == null || val.price < 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["price"],
+        message: "Price must be non-negative",
+      });
+    }
+  });
 
 export const updateInventoryOrderLinesSchema = z.object({
   data: z.object({

--- a/apps/backend/src/api/partners/payment-config/stripe-connect/route.ts
+++ b/apps/backend/src/api/partners/payment-config/stripe-connect/route.ts
@@ -8,12 +8,17 @@ import {
   getPlatformStripe,
   accountToConnectFields,
   assertSafeUrl,
+  isStripeConnectEligible,
 } from "../../../../modules/partner-payment-config/lib/stripe-connect"
 
 /**
  * Shape returned to the partner UI describing their Connect state.
  */
-const toStatusPayload = (config: any) => ({
+const toStatusPayload = (config: any, eligible: boolean) => ({
+  // Whether the partner is on the EUR/Stripe Connect rail at all (see
+  // isStripeConnectEligible). The UI hides the "Connect with Stripe" card when
+  // false so India/non-EU partners never see or trigger onboarding.
+  eligible,
   connected: !!config?.connect_account_id,
   account_id: config?.connect_account_id ?? null,
   status: config?.connect_status ?? null,
@@ -67,7 +72,7 @@ export const GET = async (
     }
   }
 
-  res.json({ stripe_connect: toStatusPayload(config) })
+  res.json({ stripe_connect: toStatusPayload(config, isStripeConnectEligible(partner)) })
 }
 
 /**
@@ -86,6 +91,15 @@ export const POST = async (
   const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
   if (!partner) {
     throw new MedusaError(MedusaError.Types.UNAUTHORIZED, "Partner not found")
+  }
+
+  // India/non-EUR partners aren't on the Stripe Connect (EUR) rail — reject
+  // cleanly instead of surfacing a confusing Stripe onboarding error.
+  if (!isStripeConnectEligible(partner)) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "Stripe Connect is available for EUR partners only. Your account uses a different payment rail (e.g. PayU for India)."
+    )
   }
 
   const body = (req.body ?? {}) as { return_url?: string; refresh_url?: string }

--- a/apps/backend/src/api/store/payment-collections/[id]/payment-sessions/route.ts
+++ b/apps/backend/src/api/store/payment-collections/[id]/payment-sessions/route.ts
@@ -1,0 +1,73 @@
+import {
+  MedusaRequest,
+  MedusaResponse,
+  refetchEntity,
+} from "@medusajs/framework/http"
+import { createPaymentSessionsWorkflow } from "@medusajs/core-flows"
+import {
+  resolvePartnerPayuCredentials,
+  resolveSalesChannelForCollection,
+  payuContext,
+} from "../../../../../modules/payu-payment/lib/resolve-partner-creds"
+
+const DEFAULT_FIELDS = ["id", "currency_code", "amount", "*payment_sessions"]
+
+/**
+ * Override of the core store payment-sessions route
+ * (POST /store/payment-collections/:id/payment-sessions).
+ *
+ * Behaviourally identical to core, EXCEPT that for PayU we resolve the
+ * storefront's owning partner's merchant credentials UPSTREAM here — where
+ * `query` and other modules are available — and pass them to the provider via
+ * the payment-session `context`. The PayU provider runs in an isolated module
+ * container and cannot resolve the partner itself; without this it silently
+ * fell back to the platform's global PayU credentials, i.e. a partner's sale
+ * would be charged into JYT's own PayU account. Mirrors the Stripe Connect
+ * `resolvePartnerConnect` → context pattern.
+ *
+ * Resolution is best-effort: no partner / no active PayU config → empty context
+ * → provider keeps using the global credentials (unchanged legacy behaviour).
+ * Only PayU sessions incur the extra lookups.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const collectionId = req.params.id
+  const { provider_id, data } = req.body as {
+    provider_id: string
+    data?: Record<string, unknown>
+  }
+
+  let context: Record<string, unknown> | undefined
+  if (String(provider_id || "").includes("payu")) {
+    const salesChannelId = await resolveSalesChannelForCollection(
+      req.scope,
+      collectionId
+    ).catch(() => undefined)
+    const creds = await resolvePartnerPayuCredentials(
+      req.scope,
+      salesChannelId
+    ).catch(() => null)
+    const ctx = payuContext(creds)
+    if (Object.keys(ctx).length) {
+      context = ctx
+    }
+  }
+
+  await createPaymentSessionsWorkflow(req.scope).run({
+    input: {
+      payment_collection_id: collectionId,
+      provider_id,
+      customer_id: (req as any).auth_context?.actor_id,
+      data,
+      ...(context ? { context } : {}),
+    },
+  })
+
+  const paymentCollection = await refetchEntity({
+    entity: "payment_collection",
+    idOrFilter: collectionId,
+    scope: req.scope,
+    fields: req.queryConfig?.fields ?? DEFAULT_FIELDS,
+  })
+
+  res.status(200).json({ payment_collection: paymentCollection })
+}

--- a/apps/backend/src/modules/partner-payment-config/__tests__/stripe-connect.unit.spec.ts
+++ b/apps/backend/src/modules/partner-payment-config/__tests__/stripe-connect.unit.spec.ts
@@ -3,6 +3,7 @@ import {
   accountToConnectFields,
   isConnectLive,
   assertSafeUrl,
+  isStripeConnectEligible,
 } from "../lib/stripe-connect"
 
 describe("stripe-connect lib (Half A)", () => {
@@ -105,6 +106,28 @@ describe("stripe-connect lib (Half A)", () => {
       expect(() => assertSafeUrl(undefined, "return_url")).toThrow()
       expect(() => assertSafeUrl("", "return_url")).toThrow()
       expect(() => assertSafeUrl("/relative/path", "return_url")).toThrow()
+    })
+  })
+
+  describe("isStripeConnectEligible", () => {
+    it("is true for EUR partners", () => {
+      expect(isStripeConnectEligible({ currency_code: "eur" })).toBe(true)
+      expect(isStripeConnectEligible({ country_code: "DE", currency_code: "EUR" })).toBe(true)
+    })
+
+    it("is false for India partners (PayU/INR rail)", () => {
+      expect(isStripeConnectEligible({ country_code: "IN", currency_code: "inr" })).toBe(false)
+      expect(isStripeConnectEligible({ country_code: "in" })).toBe(false)
+      // India can never slip through even if currency were mislabelled EUR.
+      expect(isStripeConnectEligible({ country_code: "IN", currency_code: "eur" })).toBe(false)
+    })
+
+    it("is false for non-EUR / unknown partners", () => {
+      expect(isStripeConnectEligible({ currency_code: "usd" })).toBe(false)
+      expect(isStripeConnectEligible({ country_code: "US" })).toBe(false)
+      expect(isStripeConnectEligible({})).toBe(false)
+      expect(isStripeConnectEligible(null)).toBe(false)
+      expect(isStripeConnectEligible(undefined)).toBe(false)
     })
   })
 })

--- a/apps/backend/src/modules/partner-payment-config/lib/stripe-connect.ts
+++ b/apps/backend/src/modules/partner-payment-config/lib/stripe-connect.ts
@@ -5,6 +5,29 @@ export const STRIPE_PROVIDER_ID = "pp_stripe_stripe"
 export type ConnectStatus = "pending" | "active" | "restricted" | "disconnected"
 
 /**
+ * Whether a partner is eligible for JYT Stripe Connect.
+ *
+ * Stripe Connect (Half B) settles storefront checkout in EUR, so it's the
+ * EUR/EU rail only. India partners are on the PayU/INR rail and non-EUR
+ * partners have no Connect region — showing "Connect with Stripe" to them both
+ * clutters the UI and errors on the API (Stripe can't onboard them here). Gate
+ * on the partner's `currency_code` (set by the onboarding wizard, #849), with
+ * an explicit India exclusion as a belt-and-suspenders guard. Pure — unit
+ * tested.
+ */
+export const isStripeConnectEligible = (
+  partner: { country_code?: string | null; currency_code?: string | null } | null | undefined
+): boolean => {
+  if (!partner) return false
+  const country = (partner.country_code || "").trim().toUpperCase()
+  const currency = (partner.currency_code || "").trim().toLowerCase()
+  // India = PayU/INR rail — never Stripe Connect.
+  if (country === "IN" || currency === "inr") return false
+  // Only the EUR rail has a Connect region to settle into.
+  return currency === "eur"
+}
+
+/**
  * Resolve the platform's Stripe client (JYT's own account) — this is the
  * account that owns the connected Standard accounts. Reuses STRIPE_API_KEY,
  * the same secret the partner-subscription checkout already uses.

--- a/apps/backend/src/modules/payu-payment/__tests__/resolve-partner-creds.unit.spec.ts
+++ b/apps/backend/src/modules/payu-payment/__tests__/resolve-partner-creds.unit.spec.ts
@@ -1,0 +1,116 @@
+import {
+  payuContext,
+  resolvePartnerPayuCredentials,
+  resolveSalesChannelForCollection,
+} from "../lib/resolve-partner-creds"
+
+/** Minimal scope whose `query.graph` returns queued responses by call order. */
+function makeScope(opts: {
+  graphResponses?: any[]
+  configs?: any[]
+}) {
+  const graph = jest.fn()
+  ;(opts.graphResponses ?? []).forEach((r) => graph.mockResolvedValueOnce(r))
+  const configService = {
+    listPartnerPaymentConfigs: jest.fn().mockResolvedValue(opts.configs ?? []),
+  }
+  const scope = {
+    resolve: (key: string) => {
+      if (key === "partner_payment_config") return configService
+      return { graph }
+    },
+  }
+  return { scope, graph, configService }
+}
+
+describe("payuContext", () => {
+  it("is empty for null", () => {
+    expect(payuContext(null)).toEqual({})
+  })
+
+  it("carries key/salt/partner and omits mode when absent", () => {
+    expect(
+      payuContext({
+        partner_id: "p1",
+        merchant_key: "K",
+        merchant_salt: "S",
+      })
+    ).toEqual({
+      payu_partner_id: "p1",
+      payu_merchant_key: "K",
+      payu_merchant_salt: "S",
+    })
+  })
+
+  it("includes mode when set", () => {
+    expect(
+      payuContext({
+        partner_id: "p1",
+        merchant_key: "K",
+        merchant_salt: "S",
+        mode: "live",
+      })
+    ).toMatchObject({ payu_mode: "live" })
+  })
+})
+
+describe("resolvePartnerPayuCredentials", () => {
+  it("returns null without a sales channel", async () => {
+    const { scope } = makeScope({})
+    expect(await resolvePartnerPayuCredentials(scope, undefined)).toBeNull()
+  })
+
+  it("returns null when the sales channel has no owning partner", async () => {
+    const { scope } = makeScope({ graphResponses: [{ data: [] }] })
+    expect(await resolvePartnerPayuCredentials(scope, "sc_1")).toBeNull()
+  })
+
+  it("returns null when the partner has no usable PayU config", async () => {
+    const { scope } = makeScope({
+      graphResponses: [{ data: [{ id: "store_1", partner: { id: "p1" } }] }],
+      configs: [{ credentials: { merchant_key: "K" } }], // missing salt
+    })
+    expect(await resolvePartnerPayuCredentials(scope, "sc_1")).toBeNull()
+  })
+
+  it("returns partner credentials when configured", async () => {
+    const { scope, configService } = makeScope({
+      graphResponses: [{ data: [{ id: "store_1", partner: { id: "p1" } }] }],
+      configs: [
+        { credentials: { merchant_key: "K", merchant_salt: "S", mode: "test" } },
+      ],
+    })
+    expect(await resolvePartnerPayuCredentials(scope, "sc_1")).toEqual({
+      partner_id: "p1",
+      merchant_key: "K",
+      merchant_salt: "S",
+      mode: "test",
+    })
+    expect(configService.listPartnerPaymentConfigs).toHaveBeenCalledWith({
+      partner_id: "p1",
+      provider_id: "pp_payu_payu",
+      is_active: true,
+    })
+  })
+})
+
+describe("resolveSalesChannelForCollection", () => {
+  it("walks the cart_payment_collection link to the cart's sales channel", async () => {
+    const { scope, graph } = makeScope({
+      graphResponses: [
+        { data: [{ cart_id: "cart_1" }] },
+        { data: [{ sales_channel_id: "sc_9" }] },
+      ],
+    })
+    expect(await resolveSalesChannelForCollection(scope, "paycol_1")).toBe("sc_9")
+    expect(graph.mock.calls[0][0]).toMatchObject({
+      entity: "cart_payment_collection",
+      filters: { payment_collection_id: "paycol_1" },
+    })
+  })
+
+  it("returns undefined when the collection has no linked cart", async () => {
+    const { scope } = makeScope({ graphResponses: [{ data: [] }] })
+    expect(await resolveSalesChannelForCollection(scope, "paycol_x")).toBeUndefined()
+  })
+})

--- a/apps/backend/src/modules/payu-payment/lib/resolve-partner-creds.ts
+++ b/apps/backend/src/modules/payu-payment/lib/resolve-partner-creds.ts
@@ -1,0 +1,111 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+export const PAYU_CONFIG_PROVIDER_ID = "pp_payu_payu"
+
+export type ResolvedPayuCredentials = {
+  partner_id: string
+  merchant_key: string
+  merchant_salt: string
+  mode?: "test" | "live"
+}
+
+/**
+ * Resolve the sales channel a payment collection belongs to, by walking the
+ * core `cart_payment_collection` link back to its cart. The store
+ * payment-sessions route only receives a collection id, but partner resolution
+ * keys off the cart's sales channel.
+ */
+export const resolveSalesChannelForCollection = async (
+  scope: any,
+  collectionId: string
+): Promise<string | undefined> => {
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: links } = await query
+    .graph({
+      entity: "cart_payment_collection",
+      filters: { payment_collection_id: collectionId },
+      fields: ["cart_id"],
+    })
+    .catch(() => ({ data: [] }))
+
+  const cartId = links?.[0]?.cart_id
+  if (!cartId) return undefined
+
+  const { data: carts } = await query
+    .graph({
+      entity: "cart",
+      filters: { id: cartId },
+      fields: ["sales_channel_id"],
+    })
+    .catch(() => ({ data: [] }))
+
+  return carts?.[0]?.sales_channel_id
+}
+
+/**
+ * Resolve a storefront's owning partner's PayU merchant credentials from a
+ * cart's sales channel.
+ *
+ * MUST be called from a request/workflow scope (route, workflow, subscriber) —
+ * NOT from inside the PayU payment provider, whose isolated module container
+ * has no access to `query` or other modules. The result is passed to the
+ * provider via the payment-session `context`. Mirrors the Stripe Connect
+ * `resolvePartnerConnect` pattern.
+ *
+ * Returns null when there is no owning partner or no active PayU config with
+ * usable credentials — in which case the provider keeps using the platform's
+ * global PayU credentials.
+ */
+export const resolvePartnerPayuCredentials = async (
+  scope: any,
+  salesChannelId: string | undefined
+): Promise<ResolvedPayuCredentials | null> => {
+  if (!salesChannelId) return null
+
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: stores } = await query
+    .graph({
+      entity: "store",
+      filters: { default_sales_channel_id: salesChannelId },
+      fields: ["id", "partner.id"],
+    })
+    .catch(() => ({ data: [] }))
+
+  const partnerId = stores?.[0]?.partner?.id
+  if (!partnerId) return null
+
+  const configService = scope.resolve("partner_payment_config")
+  const configs = await configService.listPartnerPaymentConfigs({
+    partner_id: partnerId,
+    provider_id: PAYU_CONFIG_PROVIDER_ID,
+    is_active: true,
+  })
+  const creds = configs?.[0]?.credentials
+  if (!creds?.merchant_key || !creds?.merchant_salt) return null
+
+  return {
+    partner_id: partnerId,
+    merchant_key: creds.merchant_key,
+    merchant_salt: creds.merchant_salt,
+    mode: creds.mode,
+  }
+}
+
+/**
+ * Build the payment-session context fragment carrying partner PayU credentials
+ * down to the provider. Spread into `createPaymentSessionsWorkflow`'s
+ * `input.context`. Empty when there's no partner-specific config to route to.
+ */
+export const payuContext = (
+  resolved: ResolvedPayuCredentials | null
+): Record<string, unknown> =>
+  resolved
+    ? {
+        payu_partner_id: resolved.partner_id,
+        payu_merchant_key: resolved.merchant_key,
+        payu_merchant_salt: resolved.merchant_salt,
+        ...(resolved.mode ? { payu_mode: resolved.mode } : {}),
+      }
+    : {}

--- a/apps/backend/src/modules/payu-payment/service.ts
+++ b/apps/backend/src/modules/payu-payment/service.ts
@@ -65,64 +65,36 @@ class PayUPaymentProviderService extends AbstractPaymentProvider<PayUOptions> {
   /**
    * Resolve PayU credentials: partner-specific > global defaults.
    *
-   * Flow: context.extra.sales_channel_id → store → partner → partner_payment_config
-   * Falls back to this.options_ (global credentials from medusa-config.ts).
+   * Partner credentials are resolved UPSTREAM (in the store payment-sessions
+   * route via `resolvePartnerPayuCredentials`, which has `query` access) and
+   * handed down through the payment-session `context` as `payu_merchant_key` /
+   * `payu_merchant_salt` / `payu_mode`. Payment providers run in an isolated
+   * module container with no access to `query` or other modules, so they
+   * cannot resolve the partner themselves — an earlier version tried to and
+   * silently fell back to the platform's global creds every time. Mirrors the
+   * Stripe Connect provider, which reads its connected account from context.
+   *
+   * Falls back to this.options_ (global credentials from medusa-config.ts) when
+   * no partner-specific credentials were injected.
    */
-  private async resolveCredentials(context?: Record<string, unknown>): Promise<PayUOptions> {
+  private resolveCredentials(context?: Record<string, unknown>): PayUOptions {
     if (!context) return this.options_
 
-    try {
-      const salesChannelId = (context as any)?.extra?.sales_channel_id
-        || (context as any)?.sales_channel_id
-      if (!salesChannelId) return this.options_
+    const ctx = context as any
+    const merchant_key = ctx.payu_merchant_key ?? ctx.extra?.payu_merchant_key
+    const merchant_salt = ctx.payu_merchant_salt ?? ctx.extra?.payu_merchant_salt
+    const mode = ctx.payu_mode ?? ctx.extra?.payu_mode
 
-      // Resolve partner from sales channel → store → partner (via link)
-      const query = this.container_.resolve?.("query")
-      if (!query) return this.options_
-
-      // Find store linked to this sales channel, and traverse the partner link
-      const { data: stores } = await query.graph({
-        entity: "store",
-        filters: { default_sales_channel_id: salesChannelId },
-        fields: ["id", "partner.*"],
-      }).catch(() => ({ data: [] }))
-
-      if (!stores?.length) return this.options_
-
-      // The partner is resolved via the module link traversal
-      const partner = stores[0].partner
-      const partnerId = partner?.id
-
-      if (!partnerId) {
-        // Fallback: try to find partner from store metadata
-        this.logger_.debug(`[PayU] No partner link found for store ${stores[0].id}`)
-        return this.options_
+    if (merchant_key && merchant_salt) {
+      this.logger_.info(
+        `[PayU] Using partner credentials (partner=${ctx.payu_partner_id ?? "unknown"})`
+      )
+      return {
+        merchant_key,
+        merchant_salt,
+        mode: mode || this.options_.mode,
+        auto_capture: this.options_.auto_capture,
       }
-
-      // Look up partner payment config
-      const configService = this.container_.resolve?.("partner_payment_config")
-      if (!configService) return this.options_
-
-      const configs = await configService.listPartnerPaymentConfigs({
-        partner_id: partnerId,
-        provider_id: "pp_payu_payu",
-        is_active: true,
-      })
-
-      if (!configs?.length) return this.options_
-
-      const partnerCreds = configs[0].credentials
-      if (partnerCreds?.merchant_key && partnerCreds?.merchant_salt) {
-        this.logger_.info(`[PayU] Using partner credentials for partner=${partnerId}`)
-        return {
-          merchant_key: partnerCreds.merchant_key,
-          merchant_salt: partnerCreds.merchant_salt,
-          mode: partnerCreds.mode || this.options_.mode,
-          auto_capture: this.options_.auto_capture,
-        }
-      }
-    } catch (e: any) {
-      this.logger_.warn(`[PayU] Failed to resolve partner credentials, using defaults: ${e.message}`)
     }
 
     return this.options_
@@ -202,8 +174,8 @@ class PayUPaymentProviderService extends AbstractPaymentProvider<PayUOptions> {
   ): Promise<InitiatePaymentOutput> {
     const { amount, currency_code, context, data } = input
 
-    // Resolve partner-specific or global credentials
-    const opts = await this.resolveCredentials(context)
+    // Resolve partner-specific (injected via context upstream) or global credentials
+    const opts = this.resolveCredentials(context)
 
     const txnid = this.generateTxnId()
     const amountStr = this.toAmount(amount)
@@ -379,7 +351,7 @@ class PayUPaymentProviderService extends AbstractPaymentProvider<PayUOptions> {
 
   async updatePayment(input: UpdatePaymentInput): Promise<UpdatePaymentOutput> {
     const { amount, currency_code, context, data } = input
-    const opts = this.resolveFromSessionData(data) || await this.resolveCredentials(context) || this.options_
+    const opts = this.resolveFromSessionData(data) || this.resolveCredentials(context) || this.options_
 
     if (amount && data?.txnid) {
       const amountStr = this.toAmount(amount)

--- a/apps/backend/src/workflows/inventory_orders/update-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/update-inventory-orders.ts
@@ -29,9 +29,13 @@ import {
 // Types
 export type UpdateInventoryOrderLineInput = {
   id?: string; // If present, update; if not, create
-  inventory_item_id: string;
-  quantity: number;
-  price: number;
+  // Optional at the type level so a removal marker ({ id, remove: true }) is
+  // valid. For create/update lines the route validator (updateOrderLineSchema)
+  // enforces these are present, so the create/update branches below can rely on
+  // them at runtime.
+  inventory_item_id?: string;
+  quantity?: number;
+  price?: number;
   batch_number?: number | null; // Batch tag for separate-batch quick-add lines
   remove?: boolean; // If true, remove this orderline
 };
@@ -120,7 +124,7 @@ export const updateOrderLinesStep = createStep(
       const newItemIds = Array.from(new Set(
         input.order_lines
           .filter((l) => !l.remove && !l.id && l.inventory_item_id)
-          .map((l) => l.inventory_item_id)
+          .map((l) => l.inventory_item_id as string)
       ));
       if (newItemIds.length) {
         const query = container.resolve(ContainerRegistrationKeys.QUERY);
@@ -182,7 +186,7 @@ export const updateOrderLinesStep = createStep(
         // If inventory_item_id changed, handle link update (not implemented here, but can be compared with currentOrderlines)
       } else {
         // Create orderline (with denormalized color identity when resolvable).
-        const info = materialLookup[line.inventory_item_id];
+        const info = line.inventory_item_id ? materialLookup[line.inventory_item_id] : undefined;
         const created_line = await inventoryOrderService.createOrderLines({
           inventory_orders_id: input.order_id,
           quantity: line.quantity,

--- a/apps/partner-ui/src/hooks/api/payment-config.tsx
+++ b/apps/partner-ui/src/hooks/api/payment-config.tsx
@@ -33,6 +33,9 @@ export type PaymentConfig = {
 }
 
 export type StripeConnectStatus = {
+  // Whether the partner is on the EUR/Stripe Connect rail. False for India
+  // (PayU/INR) and non-EUR partners — the UI hides the card entirely.
+  eligible: boolean
   connected: boolean
   account_id: string | null
   status: "pending" | "active" | "restricted" | "disconnected" | null

--- a/apps/partner-ui/src/routes/settings/payment-providers/components/stripe-connect-card.tsx
+++ b/apps/partner-ui/src/routes/settings/payment-providers/components/stripe-connect-card.tsx
@@ -51,6 +51,13 @@ export const StripeConnectCard = () => {
     )
   }
 
+  // India (PayU/INR) and non-EUR partners aren't on the Stripe Connect rail —
+  // don't render the card at all for them. While the status is still loading
+  // (stripe_connect undefined) we also render nothing to avoid a flash.
+  if (!stripe_connect?.eligible) {
+    return null
+  }
+
   const status = stripe_connect?.status
   const isActive = status === "active" && stripe_connect?.charges_enabled
   const isOnboarding =


### PR DESCRIPTION
Three independent fixes bundled (all build-verified, `medusa build` green + 25 unit tests).

## 1. PayU isolated-container credential bug
The PayU provider resolved `query` inside its **isolated module container** (which throws), so the `try/catch` silently fell back to the platform's global merchant creds — a partner's sale could be charged into JYT's own PayU account.

Fix mirrors the Stripe Connect pattern: resolve partner creds **upstream** (new `payu-payment/lib/resolve-partner-creds.ts`, which has `query` access) and hand them to the provider via the payment-session `context`. Injected at the single choke point both storefront + MCP use, by overriding the core store `POST /store/payment-collections/:id/payment-sessions` route (behaviourally identical to core; best-effort — no partner ⇒ empty context ⇒ unchanged global-creds behaviour). Provider now reads `context.payu_merchant_*` instead of the dead `query` path.

## 2. edit-order-lines drop not persisting
Dropping a line just removed it from the payload; the update workflow only **deletes** on an explicit `{ id, remove: true }` marker. The form now diffs original vs remaining existing lines and sends removal markers, reusing the tested soft-delete + link-dismiss path. Validator relaxed via `superRefine` so a removal marker only needs `id`; hook + workflow input types aligned.

⚠️ Server-side "delete absent lines" reconciliation was **deliberately rejected** — `updateInventoryOrderWorkflow` is shared by 8 flows incl. status-only updates that pass empty `order_lines`, which would wipe every line.

## 3. Stripe Connect card shown for India / non-EU partners
New pure `isStripeConnectEligible()` gates on the **EUR rail** (India/INR + non-EUR excluded). UI card returns `null` when ineligible (server sends `eligible` on the status GET); onboarding `POST` throws a clean `NOT_ALLOWED` instead of a confusing Stripe error.

## Test plan
- `medusa build` — backend + admin frontend green
- partner-ui changed files typecheck clean
- 25 unit tests (9 PayU resolver + stripe-connect incl. new eligibility cases)
- Latent/not-live-verified: PayU partner-cred routing (no partner has a PayU config yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)