### PR TITLE
fix(inventory-orders): stop Edit Order Lines wiping all lines on every save

### DIFF
--- a/apps/backend/integration-tests/http/inventory-order-line-update-persistence.spec.ts
+++ b/apps/backend/integration-tests/http/inventory-order-line-update-persistence.spec.ts
@@ -1,0 +1,250 @@
+/**
+ * Inventory-order line update persistence — core vs non-core.
+ *
+ * Motivated by a prod incident (inv_order_…M8SN / core order display #68): a
+ * single "Edit Order Lines" save wiped ALL of an inventory order's lines while
+ * the core mirror order kept its original items. This spec pins the actual
+ * data behaviour on both sides so the regression can't recur silently:
+ *
+ *   1. Baseline — creating a legacy inventory order dual-writes a core order
+ *      whose items mirror the lines at creation time.
+ *   2. Correct update (add / edit / remove-one) persists on the non-core
+ *      `inventory_order_line` table exactly as intended.
+ *   3. The CORE mirror never re-syncs its items after creation — line changes
+ *      on the inventory order do NOT propagate to core `order.items` (only
+ *      status is mirrored). This is the "core survives, non-core changed"
+ *      divergence the operator saw.
+ *   4. Repro of the #855 form bug: the edit form used react-hook-form's
+ *      `useFieldArray` field key (`fields[i].id`) as if it were the DB line id.
+ *      Because those id-spaces never match, every save re-sent the existing
+ *      lines under NON-matching ids (→ update no-op) AND emitted a removal
+ *      marker for every real DB id (→ soft-delete). The net payload wipes the
+ *      whole order. This test sends exactly that payload and asserts 0 lines
+ *      remain on the inventory order while the core mirror is untouched.
+ */
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+
+jest.setTimeout(60000)
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Inventory-order line update persistence (core vs non-core)", () => {
+    let adminHeaders: any
+    let itemA: string
+    let itemB: string
+    let itemC: string
+    let itemD: string
+    let stockLocationId: string
+    let fromStockLocationId: string
+
+    const createItem = async (title: string, sku: string) => {
+      const res = await api.post("/admin/inventory-items", { title, sku }, adminHeaders)
+      expect(res.status).toBe(200)
+      return res.data.inventory_item.id as string
+    }
+
+    const createRegion = async () => {
+      const regionService: any = getContainer().resolve(Modules.REGION)
+      await regionService
+        .createRegions({ name: "India", currency_code: "inr", countries: ["in"] })
+        .catch(() => undefined) // region may already exist on the shared DB
+    }
+
+    // Create a legacy inventory order with three lines (A, B, C).
+    const createOrderWithThreeLines = async () => {
+      const payload = {
+        order_lines: [
+          { inventory_item_id: itemA, quantity: 10, price: 100 },
+          { inventory_item_id: itemB, quantity: 5, price: 200 },
+          { inventory_item_id: itemC, quantity: 3, price: 50 },
+        ],
+        quantity: 18,
+        total_price: 2150,
+        status: "Pending",
+        expected_delivery_date: new Date().toISOString(),
+        order_date: new Date().toISOString(),
+        shipping_address: {},
+        stock_location_id: stockLocationId,
+        from_stock_location_id: fromStockLocationId,
+      }
+      const res = await api.post("/admin/inventory-orders", payload, adminHeaders)
+      expect(res.status).toBe(201)
+      return res.data.inventoryOrder
+    }
+
+    // Non-core: live (non-deleted) lines on the inventory order.
+    const fetchLegacyLines = async (id: string) => {
+      const query: any = getContainer().resolve(ContainerRegistrationKeys.QUERY)
+      const { data } = await query.graph({
+        entity: "inventory_orders",
+        filters: { id },
+        fields: ["id", "quantity", "total_price", "orderlines.id", "orderlines.quantity", "orderlines.price"],
+      })
+      return data?.[0]
+    }
+
+    // Core mirror: resolve via the order↔inventory_order link, then read items.
+    const resolveUnifiedOrderId = async (legacyId: string): Promise<string | undefined> => {
+      const query: any = getContainer().resolve(ContainerRegistrationKeys.QUERY)
+      const { data } = await query.graph({
+        entity: "inventory_orders",
+        filters: { id: legacyId },
+        fields: ["id", "order.id"],
+      })
+      return data?.[0]?.order?.id ?? undefined
+    }
+
+    const fetchCoreItems = async (unifiedOrderId: string) => {
+      const query: any = getContainer().resolve(ContainerRegistrationKeys.QUERY)
+      const { data } = await query.graph({
+        entity: "order",
+        filters: { id: unifiedOrderId },
+        fields: ["id", "status", "items.id", "items.title", "items.quantity"],
+      })
+      return data?.[0]
+    }
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+      await createRegion()
+
+      itemA = await createItem("Tangaliya Dress Suit Material", `MAT-A-${Date.now()}`)
+      itemB = await createItem("Tangaliya Shirt", `MAT-B-${Date.now()}`)
+      itemC = await createItem("Cotton Thread", `MAT-C-${Date.now()}`)
+      itemD = await createItem("Extra Material", `MAT-D-${Date.now()}`)
+
+      const to = await api.post("/admin/stock-locations", { name: "Main Warehouse" }, adminHeaders)
+      stockLocationId = to.data.stock_location.id
+      const from = await api.post("/admin/stock-locations", { name: "Secondary Warehouse" }, adminHeaders)
+      fromStockLocationId = from.data.stock_location.id
+    })
+
+    it("baseline: create dual-writes a core order mirroring the three lines", async () => {
+      const legacy = await createOrderWithThreeLines()
+      expect(legacy.orderlines).toHaveLength(3)
+
+      const unifiedId = await resolveUnifiedOrderId(legacy.id)
+      expect(unifiedId).toBeTruthy()
+      const core = await fetchCoreItems(unifiedId!)
+      expect(core.items).toHaveLength(3)
+    })
+
+    it("correct update (add a 4th line) persists all four lines on the inventory order", async () => {
+      const legacy = await createOrderWithThreeLines()
+      const [a, b, c] = legacy.orderlines
+
+      // The payload a CORRECT form should send: existing lines carry their real
+      // DB ids, plus one brand-new line with no id.
+      const res = await api.put(
+        `/admin/inventory-orders/${legacy.id}/order-lines`,
+        {
+          data: { quantity: 21, total_price: 2450 },
+          order_lines: [
+            { id: a.id, inventory_item_id: a.inventory_items?.[0]?.id ?? itemA, quantity: 10, price: 100 },
+            { id: b.id, inventory_item_id: b.inventory_items?.[0]?.id ?? itemB, quantity: 5, price: 200 },
+            { id: c.id, inventory_item_id: c.inventory_items?.[0]?.id ?? itemC, quantity: 3, price: 50 },
+            { inventory_item_id: itemD, quantity: 3, price: 100 },
+          ],
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+
+      const after = await fetchLegacyLines(legacy.id)
+      expect(after.orderlines).toHaveLength(4)
+    })
+
+    it("correct update (edit qty of an existing line) persists in place", async () => {
+      const legacy = await createOrderWithThreeLines()
+      const [a, b, c] = legacy.orderlines
+
+      const res = await api.put(
+        `/admin/inventory-orders/${legacy.id}/order-lines`,
+        {
+          order_lines: [
+            { id: a.id, inventory_item_id: a.inventory_items?.[0]?.id ?? itemA, quantity: 99, price: 100 },
+            { id: b.id, inventory_item_id: b.inventory_items?.[0]?.id ?? itemB, quantity: 5, price: 200 },
+            { id: c.id, inventory_item_id: c.inventory_items?.[0]?.id ?? itemC, quantity: 3, price: 50 },
+          ],
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+
+      const after = await fetchLegacyLines(legacy.id)
+      expect(after.orderlines).toHaveLength(3)
+      const edited = after.orderlines.find((l: any) => l.id === a.id)
+      expect(Number(edited.quantity)).toBe(99)
+    })
+
+    it("correct update (remove ONE line via marker) leaves the other two", async () => {
+      const legacy = await createOrderWithThreeLines()
+      const [a, b, c] = legacy.orderlines
+
+      const res = await api.put(
+        `/admin/inventory-orders/${legacy.id}/order-lines`,
+        {
+          order_lines: [
+            { id: a.id, inventory_item_id: a.inventory_items?.[0]?.id ?? itemA, quantity: 10, price: 100 },
+            { id: b.id, inventory_item_id: b.inventory_items?.[0]?.id ?? itemB, quantity: 5, price: 200 },
+            { id: c.id, remove: true },
+          ],
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+
+      const after = await fetchLegacyLines(legacy.id)
+      expect(after.orderlines).toHaveLength(2)
+      expect(after.orderlines.map((l: any) => l.id).sort()).toEqual([a.id, b.id].sort())
+    })
+
+    it("REPRO #855: the buggy form payload wipes ALL inventory lines but the core mirror survives", async () => {
+      const legacy = await createOrderWithThreeLines()
+      const lines = legacy.orderlines as any[]
+      const unifiedId = await resolveUnifiedOrderId(legacy.id)
+      expect(unifiedId).toBeTruthy()
+
+      // Faithful reproduction of what edit-order-lines.tsx emitted:
+      //  - "keep" entries re-sent under react-hook-form's field key (NOT the DB
+      //    id) → truthy but non-matching → the workflow update-by-id no-ops.
+      //  - a removal marker for every REAL DB id → soft-deletes every line.
+      const keepEntriesWithWrongIds = lines.map((l, i) => ({
+        id: `rhf-fieldarray-key-${i}`, // react-hook-form generated key, never a DB id
+        inventory_item_id: l.inventory_items?.[0]?.id ?? itemA,
+        quantity: l.quantity,
+        price: l.price,
+      }))
+      const removalMarkers = lines.map((l) => ({ id: l.id, remove: true }))
+
+      const res = await api.put(
+        `/admin/inventory-orders/${legacy.id}/order-lines`,
+        {
+          // header totals still reflect the on-screen (pre-delete) lines — this
+          // is why the operator saw a non-zero total over zero lines.
+          data: { quantity: 18, total_price: 2150 },
+          order_lines: [...keepEntriesWithWrongIds, ...removalMarkers],
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+
+      // Non-core: every line is gone.
+      const after = await fetchLegacyLines(legacy.id)
+      expect(after.orderlines).toHaveLength(0)
+      // …yet the header total was still written from the on-screen figure.
+      expect(Number(after.total_price)).toBe(2150)
+
+      // Core mirror: untouched — still holds the original three items. This is
+      // the exact divergence seen in prod (core order #68 kept its items while
+      // the inventory order lost all lines).
+      const core = await fetchCoreItems(unifiedId!)
+      expect(core.items).toHaveLength(3)
+    })
+  })
+})

--- a/apps/backend/src/admin/components/inventory-orders/__tests__/order-lines-payload.unit.spec.ts
+++ b/apps/backend/src/admin/components/inventory-orders/__tests__/order-lines-payload.unit.spec.ts
@@ -1,0 +1,96 @@
+import {
+  buildOrderLinesUpdatePayload,
+  computeOrderLineTotals,
+  type EditableOrderLine,
+} from "../order-lines-payload";
+
+const existing = (id: string, item: string, quantity: number, price: number): EditableOrderLine => ({
+  id,
+  inventory_item_id: item,
+  quantity,
+  price,
+  isExisting: true,
+});
+
+const THREE: EditableOrderLine[] = [
+  existing("ordli_A", "iitem_A", 10, 100),
+  existing("ordli_B", "iitem_B", 5, 200),
+  existing("ordli_C", "iitem_C", 3, 50),
+];
+
+describe("computeOrderLineTotals", () => {
+  it("sums quantity and quantity×price, ignoring rows without an item", () => {
+    const totals = computeOrderLineTotals([
+      ...THREE,
+      { inventory_item_id: "", quantity: 99, price: 99 }, // half-filled new row → ignored
+    ]);
+    expect(totals.totalQuantity).toBe(18);
+    expect(totals.totalPrice).toBe(10 * 100 + 5 * 200 + 3 * 50); // 2150
+  });
+});
+
+describe("buildOrderLinesUpdatePayload", () => {
+  it("no change: keeps all existing lines by DB id and emits ZERO removals", () => {
+    const payload = buildOrderLinesUpdatePayload(THREE, THREE);
+    const removals = payload.order_lines.filter((l) => l.remove);
+    const keeps = payload.order_lines.filter((l) => !l.remove);
+
+    expect(removals).toHaveLength(0); // <- the regression guard for the wipe bug
+    expect(keeps).toHaveLength(3);
+    expect(keeps.map((l) => l.id)).toEqual(["ordli_A", "ordli_B", "ordli_C"]);
+    expect(payload.data).toEqual({ quantity: 18, total_price: 2150 });
+  });
+
+  it("edit qty of an existing line: still no removals, id preserved", () => {
+    const edited = [{ ...THREE[0], quantity: 99 }, THREE[1], THREE[2]];
+    const payload = buildOrderLinesUpdatePayload(THREE, edited);
+    expect(payload.order_lines.filter((l) => l.remove)).toHaveLength(0);
+    const first = payload.order_lines.find((l) => l.id === "ordli_A");
+    expect(first).toMatchObject({ id: "ordli_A", quantity: 99 });
+  });
+
+  it("add a new row: new line has no id, no spurious removals", () => {
+    const withNew = [
+      ...THREE,
+      { inventory_item_id: "iitem_D", quantity: 3, price: 100, isExisting: false },
+    ];
+    const payload = buildOrderLinesUpdatePayload(THREE, withNew);
+    expect(payload.order_lines.filter((l) => l.remove)).toHaveLength(0);
+    const created = payload.order_lines.filter((l) => !l.remove && !l.id);
+    expect(created).toHaveLength(1);
+    expect(created[0].inventory_item_id).toBe("iitem_D");
+  });
+
+  it("remove ONE line: exactly one removal marker for the dropped DB id", () => {
+    const remaining = [THREE[0], THREE[1]]; // dropped ordli_C
+    const payload = buildOrderLinesUpdatePayload(THREE, remaining);
+    const removals = payload.order_lines.filter((l) => l.remove);
+    expect(removals).toHaveLength(1);
+    expect(removals[0]).toMatchObject({ id: "ordli_C", remove: true });
+    expect(removals[0].inventory_item_id).toBe("iitem_C"); // so the workflow dismisses the link
+    expect(payload.order_lines.filter((l) => !l.remove).map((l) => l.id)).toEqual([
+      "ordli_A",
+      "ordli_B",
+    ]);
+  });
+
+  it("remove ALL lines: a removal marker per line, no keeps", () => {
+    const payload = buildOrderLinesUpdatePayload(THREE, []);
+    expect(payload.order_lines.filter((l) => !l.remove)).toHaveLength(0);
+    expect(payload.order_lines.filter((l) => l.remove).map((l) => l.id)).toEqual([
+      "ordli_A",
+      "ordli_B",
+      "ordli_C",
+    ]);
+  });
+
+  it("REGRESSION: field-array KEYS (not DB ids) must never fabricate removals", () => {
+    // Simulate the #855 bug source: if currentLines carried react-hook-form
+    // field keys instead of DB ids, EVERY existing line looked "gone".
+    // The fix keeps DB ids on currentLines, so with all rows present there are
+    // no removals. Here we assert the correct-input contract holds.
+    const currentWithDbIds = THREE; // rows still present, real DB ids
+    const payload = buildOrderLinesUpdatePayload(THREE, currentWithDbIds);
+    expect(payload.order_lines.every((l) => !l.remove)).toBe(true);
+  });
+});

--- a/apps/backend/src/admin/components/inventory-orders/edit-order-lines.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/edit-order-lines.tsx
@@ -10,6 +10,11 @@ import { InventoryOrderLinesGrid } from "../creates/inventory-order-lines-grid";
 import { AddMaterialGroupControl } from "./add-material-group-control";
 import { AdminInventoryOrder } from "../../hooks/api/inventory-orders";
 import { useUpdateInventoryOrderLines } from "../../hooks/api/inventory-orders";
+import {
+  buildOrderLinesUpdatePayload,
+  computeOrderLineTotals,
+  type EditableOrderLine,
+} from "./order-lines-payload";
 
 // Schema for editing order lines
 const editOrderLinesSchema = z.object({
@@ -73,10 +78,16 @@ export const EditOrderLines = ({ inventoryOrder }: EditOrderLinesProps) => {
     limit: 1000,
   });
 
-  // Use Field Array for order lines
+  // Use Field Array for order lines.
+  // keyName MUST NOT be the default "id": react-hook-form overwrites the row's
+  // `id` with its own generated field key, and that key was being compared
+  // against DB line ids to compute removals — two id-spaces that never match, so
+  // every existing line was marked for deletion on every save (the prod wipe).
+  // A distinct keyName lets `fields[i].id` keep carrying the real DB id.
   const { fields, append, remove } = useFieldArray({
     control: form.control,
     name: "order_lines",
+    keyName: "_rhfId",
   });
 
   // Live inventory_item_ids on the form — feeds the add-by-group control so a
@@ -92,24 +103,18 @@ export const EditOrderLines = ({ inventoryOrder }: EditOrderLinesProps) => {
 
   const { mutateAsync, isPending } = useUpdateInventoryOrderLines();
 
-  // Calculate totals from order lines
-  const calculateTotals = () => {
-    const validLines = fields.filter((line: OrderLine) => line.inventory_item_id);
-    const totalQuantity = validLines.reduce((sum: number, line: OrderLine) => sum + (Number(line.quantity) || 0), 0);
-    const totalPrice = validLines.reduce((sum: number, line: OrderLine) => sum + (Number(line.price) || 0) * (Number(line.quantity) || 0), 0);
-    return { totalQuantity, totalPrice };
-  };
+  // Display totals from the LIVE watched rows (not the `fields` snapshot, whose
+  // quantity/price values go stale as soon as a cell is edited).
+  const displayTotals = computeOrderLineTotals((watchedForGroup ?? []) as EditableOrderLine[]);
 
   const handleSubmit = form.handleSubmit(async (data) => {
-    const { totalQuantity, totalPrice } = calculateTotals();
-
-    // Prepare order lines for the update workflow
-    const orderLines = fields.map((line: OrderLine, index: number) => {
+    // Merge the field-array rows (authoritative for the DB `id` + `isExisting`,
+    // preserved because keyName isn't "id") with the live submitted values.
+    const currentLines: EditableOrderLine[] = fields.map((line: OrderLine, index: number) => {
       const formLine = data.order_lines[index];
       return {
-        // Only include ID if it's marked as existing (from database)
-        // New lines added by user won't have isExisting flag
-        id: line.isExisting ? line.id : undefined,
+        id: line.id,
+        isExisting: line.isExisting,
         inventory_item_id: formLine.inventory_item_id,
         quantity: Number(formLine.quantity) || 0,
         price: Number(formLine.price) || 0,
@@ -117,35 +122,11 @@ export const EditOrderLines = ({ inventoryOrder }: EditOrderLinesProps) => {
       };
     });
 
-    // Dropping a line from the field array just removes it from the payload —
-    // the update workflow only DELETES a line when it receives an explicit
-    // { id, remove: true } marker, so without this a dropped existing line
-    // silently survives. Diff the original existing lines against the ones
-    // still present and send a removal marker for each that's gone.
-    const remainingExistingIds = new Set(
-      (fields as OrderLine[])
-        .filter((l) => l.isExisting && l.id)
-        .map((l) => l.id)
-    );
-    const removedLines = (existingLines as OrderLine[])
-      .filter((l) => l.id && !remainingExistingIds.has(l.id))
-      .map((l) => ({
-        id: l.id,
-        inventory_item_id: l.inventory_item_id || "",
-        // Ignored server-side for removals, but must satisfy the line schema.
-        quantity: l.quantity && l.quantity >= 1 ? l.quantity : 1,
-        price: typeof l.price === "number" && l.price >= 0 ? l.price : 0,
-        remove: true,
-      }));
-
-    const payload = {
-      id: inventoryOrder.id,
-      data: {
-        quantity: totalQuantity,
-        total_price: totalPrice,
-      },
-      order_lines: [...orderLines, ...removedLines],
-    };
+    // Pure, unit-tested payload builder: keeps present lines by their DB id and
+    // emits removal markers ONLY for existing lines actually dropped from the
+    // grid. See order-lines-payload.ts for why this must not use RHF field keys.
+    const built = buildOrderLinesUpdatePayload(existingLines as EditableOrderLine[], currentLines);
+    const payload = { id: inventoryOrder.id, ...built };
 
     try {
       await mutateAsync(payload);
@@ -215,11 +196,11 @@ export const EditOrderLines = ({ inventoryOrder }: EditOrderLinesProps) => {
             <div className="flex-shrink-0 border-t border-dashed p-8 bg-ui-bg-base">
               <div className="flex justify-between items-center mb-2">
                 <Text weight="plus">Total Order Quantity:</Text>
-                <Text weight="plus">{calculateTotals().totalQuantity}</Text>
+                <Text weight="plus">{displayTotals.totalQuantity}</Text>
               </div>
               <div className="flex justify-between items-center">
                 <Text weight="plus">Total Order Price:</Text>
-                <Text weight="plus">${calculateTotals().totalPrice.toFixed(2)}</Text>
+                <Text weight="plus">${displayTotals.totalPrice.toFixed(2)}</Text>
               </div>
             </div>
           </div>

--- a/apps/backend/src/admin/components/inventory-orders/order-lines-payload.ts
+++ b/apps/backend/src/admin/components/inventory-orders/order-lines-payload.ts
@@ -1,0 +1,98 @@
+/**
+ * Pure builders for the PUT /admin/inventory-orders/:id/order-lines payload.
+ *
+ * Extracted from the edit-order-lines form and unit-tested because a subtle
+ * id-identity bug here silently wiped whole orders in prod:
+ *
+ *   react-hook-form's `useFieldArray` overwrites each row's `id` with its OWN
+ *   generated field key (default keyName === "id"). The form compared those
+ *   field keys against the database line ids to decide which lines were
+ *   removed — two id-spaces that can NEVER match — so every existing line was
+ *   marked for removal on EVERY save, deleting the entire order.
+ *
+ * The fix is twofold: the form sets a non-"id" `keyName` so `fields[i].id`
+ * keeps carrying the DB id, and the removal diff lives here behind unit tests.
+ * These functions therefore assume existing rows carry their real DB id.
+ */
+
+export interface EditableOrderLine {
+  /** DB order-line id for existing lines; absent/undefined for brand-new rows. */
+  id?: string;
+  inventory_item_id: string;
+  quantity: number;
+  price: number;
+  batch_number?: number | null;
+  /** True for rows that already exist in the database. */
+  isExisting?: boolean;
+}
+
+export interface OrderLineUpdateEntry {
+  id?: string;
+  inventory_item_id?: string;
+  quantity?: number;
+  price?: number;
+  batch_number?: number | null;
+  remove?: boolean;
+}
+
+export interface OrderLinesUpdatePayload {
+  data: { quantity: number; total_price: number };
+  order_lines: OrderLineUpdateEntry[];
+}
+
+/** Sum quantity and quantity×price across the given lines. */
+export function computeOrderLineTotals(lines: EditableOrderLine[]): {
+  totalQuantity: number;
+  totalPrice: number;
+} {
+  const valid = lines.filter((l) => l && l.inventory_item_id);
+  const totalQuantity = valid.reduce((sum, l) => sum + (Number(l.quantity) || 0), 0);
+  const totalPrice = valid.reduce(
+    (sum, l) => sum + (Number(l.price) || 0) * (Number(l.quantity) || 0),
+    0
+  );
+  return { totalQuantity, totalPrice };
+}
+
+/**
+ * Build the update payload from the form's original existing lines and the rows
+ * currently present in the field array.
+ *
+ * - Each present row becomes a keep/update entry. Existing rows carry their DB
+ *   id (→ update in place); new rows omit it (→ create).
+ * - Every original existing line that is NO LONGER present becomes a removal
+ *   marker (soft-delete + link dismiss server-side). A removal only needs `id`;
+ *   `inventory_item_id` is included so the workflow can dismiss the item link.
+ *
+ * `currentLines[i].id` MUST be the DB id for existing rows (see file header).
+ */
+export function buildOrderLinesUpdatePayload(
+  existingLines: EditableOrderLine[],
+  currentLines: EditableOrderLine[]
+): OrderLinesUpdatePayload {
+  const keep: OrderLineUpdateEntry[] = currentLines.map((line) => ({
+    id: line.isExisting && line.id ? line.id : undefined,
+    inventory_item_id: line.inventory_item_id,
+    quantity: Number(line.quantity) || 0,
+    price: Number(line.price) || 0,
+    batch_number: line.batch_number ?? null,
+  }));
+
+  const remainingExistingIds = new Set(
+    currentLines.filter((l) => l.isExisting && l.id).map((l) => l.id as string)
+  );
+  const removals: OrderLineUpdateEntry[] = existingLines
+    .filter((l) => l.id && !remainingExistingIds.has(l.id))
+    .map((l) => ({
+      id: l.id,
+      inventory_item_id: l.inventory_item_id || undefined,
+      remove: true,
+    }));
+
+  const totals = computeOrderLineTotals(currentLines);
+
+  return {
+    data: { quantity: totals.totalQuantity, total_price: totals.totalPrice },
+    order_lines: [...keep, ...removals],
+  };
+}

--- a/apps/backend/src/admin/hooks/api/inventory-orders.ts
+++ b/apps/backend/src/admin/hooks/api/inventory-orders.ts
@@ -311,11 +311,14 @@ export interface UpdateInventoryOrderLinesPayload {
     quantity?: number;
     total_price?: number;
   };
+  // Fields are all optional to mirror the server validator (updateOrderLineSchema):
+  // a keep/update entry carries inventory_item_id/quantity/price; a removal marker
+  // needs only { id, remove: true }.
   order_lines: Array<{
     id?: string;
-    inventory_item_id: string;
-    quantity: number;
-    price: number;
+    inventory_item_id?: string;
+    quantity?: number;
+    price?: number;
     batch_number?: number | null;
     // Marks an existing line for deletion (soft-delete + link dismiss server-side).
     remove?: boolean;

--- a/apps/partner-ui/src/components/work-orders/inventory-order-lines.tsx
+++ b/apps/partner-ui/src/components/work-orders/inventory-order-lines.tsx
@@ -1,8 +1,9 @@
-import { Container, Heading, Text } from "@medusajs/ui"
+import { Badge, Container, Heading, Text } from "@medusajs/ui"
+import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 
-import { getStylizedAmount } from "../../lib/money-amount-helpers"
-import { WorkOrderLineCard, WorkOrderLineStat } from "./work-order-line-card"
+import { getLocaleAmount, getStylizedAmount } from "../../lib/money-amount-helpers"
+import { Thumbnail } from "../common/thumbnail"
 
 const fmt = (n: number) => {
   if (!Number.isFinite(n)) {
@@ -21,10 +22,12 @@ const lineFulfilled = (line: Record<string, any>): number =>
     : 0
 
 /**
- * The requested / fulfilled / remaining line items for an inventory work-order
- * (#342), rendered in the retail order-summary aesthetic: per-line cards
- * (`WorkOrderLineCard`) with a cost-breakdown + bold Total footer — so a
- * work-order reads like a normal order.
+ * Inventory work-order line items (#342), rendered in the Medusa core order
+ * line-item aesthetic (order-summary-section `Item`): a `grid-cols-2` row —
+ * product info on the left, an aligned `unit-price · {qty}x · total` money
+ * block on the right — with a subtle fulfillment badge so a work-order reads
+ * exactly like a normal order. Lines are sorted deterministically so the list
+ * never re-shuffles between fetches.
  */
 export const InventoryOrderLines = ({
   orderLines,
@@ -37,9 +40,23 @@ export const InventoryOrderLines = ({
 }) => {
   const { t } = useTranslation()
 
-  if (!orderLines.length) {
+  // Deterministic order: by creation time, then id — so rows don't jump around.
+  const lines = useMemo(
+    () =>
+      [...orderLines].sort((a, b) => {
+        const ta = Date.parse(a?.created_at ?? "") || 0
+        const tb = Date.parse(b?.created_at ?? "") || 0
+        if (ta !== tb) {
+          return ta - tb
+        }
+        return String(a?.id ?? "").localeCompare(String(b?.id ?? ""))
+      }),
+    [orderLines]
+  )
+
+  if (!lines.length) {
     return (
-      <Container className="divide-y p-0">
+      <Container className="divide-y divide-dashed p-0">
         <div className="px-6 py-4">
           <Heading level="h2">{t("partner.inventoryOrders.detail.linesHeading")}</Heading>
           <Text size="small" className="text-ui-fg-subtle">
@@ -50,16 +67,13 @@ export const InventoryOrderLines = ({
     )
   }
 
-  const totalRequested = orderLines.reduce(
-    (sum, l) => sum + (Number(l?.quantity) || 0),
-    0
-  )
   const cc = (currencyCode || "").toLowerCase()
-  const money = (amount: number) =>
-    cc ? getStylizedAmount(amount, cc) : fmt(amount)
+  const unitMoney = (amount: number) => (cc ? getLocaleAmount(amount, cc) : fmt(amount))
+  const totalMoney = (amount: number) => (cc ? getStylizedAmount(amount, cc) : fmt(amount))
+  const totalRequested = lines.reduce((sum, l) => sum + (Number(l?.quantity) || 0), 0)
 
   return (
-    <Container className="divide-y p-0">
+    <Container className="divide-y divide-dashed p-0">
       <div className="px-6 py-4">
         <Heading level="h2">{t("partner.inventoryOrders.detail.linesHeading")}</Heading>
         <Text size="small" className="text-ui-fg-subtle">
@@ -67,43 +81,82 @@ export const InventoryOrderLines = ({
         </Text>
       </div>
 
-      <div className="px-6 py-4">
-        {orderLines.map((line) => {
-          // #817 S2 — color identity is denormalized onto the line, so the card
-          // reads correctly even without the inventory_item relation loaded.
-          const title =
-            line?.material_name ||
-            line?.inventory_items?.[0]?.title ||
-            line?.inventory_items?.[0]?.name ||
-            line?.inventory_item_id ||
-            line?.id
-          const sku = line?.inventory_items?.[0]?.sku
-          const thumbnail = line?.inventory_items?.[0]?.thumbnail
-          const requested = Number(line?.quantity) || 0
-          const fulfilled = lineFulfilled(line)
-          const remaining = Math.max(0, requested - fulfilled)
-          const price = Number(line?.price) || 0
-          const subtitle =
-            [line?.color, sku ? `SKU ${sku}` : null].filter(Boolean).join(" · ") ||
-            `${t("partner.inventoryOrders.detail.linePrefix")}: ${line.id}`
+      {lines.map((line) => {
+        // #817 S2 — color identity is denormalized onto the line, so this reads
+        // correctly even without the inventory_item relation loaded.
+        const title =
+          line?.material_name ||
+          line?.inventory_items?.[0]?.title ||
+          line?.inventory_items?.[0]?.name ||
+          line?.inventory_item_id ||
+          line?.id
+        const sku = line?.inventory_items?.[0]?.sku
+        const thumbnail = line?.inventory_items?.[0]?.thumbnail
+        const requested = Number(line?.quantity) || 0
+        const fulfilled = lineFulfilled(line)
+        const remaining = Math.max(0, requested - fulfilled)
+        const price = Number(line?.price) || 0
+        const subtitle = [line?.color, sku ? `SKU ${sku}` : null]
+          .filter(Boolean)
+          .join(" · ")
 
-          return (
-            <WorkOrderLineCard
-              key={String(line.id)}
-              title={String(title)}
-              subtitle={subtitle}
-              thumbnail={thumbnail}
-            >
-              <WorkOrderLineStat label={t("partner.inventoryOrders.detail.columns.requested")} value={fmt(requested)} />
-              <WorkOrderLineStat label={t("partner.inventoryOrders.detail.columns.fulfilled")} value={fmt(fulfilled)} />
-              <WorkOrderLineStat label={t("partner.inventoryOrders.detail.columns.remaining")} value={fmt(remaining)} emphasis />
-              {price > 0 && (
-                <WorkOrderLineStat label={t("partner.workOrders.amount")} value={money(price * requested)} emphasis />
-              )}
-            </WorkOrderLineCard>
-          )
-        })}
-      </div>
+        return (
+          <div
+            key={String(line.id)}
+            className="text-ui-fg-subtle grid grid-cols-1 items-center gap-x-4 gap-y-3 px-6 py-4 sm:grid-cols-2"
+          >
+            {/* Left: product info — thumbnail + title/subtitle + fulfilment badge */}
+            <div className="flex items-start gap-x-4">
+              <Thumbnail src={thumbnail} alt={String(title)} />
+              <div className="flex min-w-0 flex-col gap-y-1">
+                <Text
+                  size="small"
+                  leading="compact"
+                  weight="plus"
+                  className="text-ui-fg-base truncate"
+                  title={String(title)}
+                >
+                  {String(title)}
+                </Text>
+                {subtitle && (
+                  <Text size="small" leading="compact" className="text-ui-fg-subtle truncate">
+                    {subtitle}
+                  </Text>
+                )}
+                <div className="flex items-center gap-x-1.5 pt-0.5">
+                  <Badge size="2xsmall" color={remaining === 0 ? "green" : "orange"}>
+                    {remaining === 0
+                      ? t("partner.inventoryOrders.detail.columns.fulfilled")
+                      : `${fmt(remaining)} ${t("partner.inventoryOrders.detail.columns.remaining")}`}
+                  </Badge>
+                  {fulfilled > 0 && remaining > 0 && (
+                    <Text size="xsmall" className="text-ui-fg-muted">
+                      {fmt(fulfilled)}/{fmt(requested)}
+                    </Text>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* Right: money block — mirrors core "unit  {qty}x  total" grid */}
+            <div className="grid grid-cols-3 items-center gap-x-4">
+              <div className="flex items-center justify-end">
+                <Text size="small">{price > 0 ? unitMoney(price) : "—"}</Text>
+              </div>
+              <div className="flex items-center justify-end">
+                <Text size="small">
+                  <span className="tabular-nums">{fmt(requested)}</span>x
+                </Text>
+              </div>
+              <div className="flex items-center justify-end">
+                <Text size="small" weight="plus" className="text-ui-fg-base text-nowrap">
+                  {price > 0 ? totalMoney(price * requested) : "—"}
+                </Text>
+              </div>
+            </div>
+          </div>
+        )
+      })}
 
       {/* Total footer — the retail order-summary money block */}
       <div className="flex flex-col gap-y-2 px-6 py-4">
@@ -117,7 +170,7 @@ export const InventoryOrderLines = ({
               {t("partner.workOrders.total")}
             </Text>
             <Text size="small" weight="plus">
-              {money(Number(totalPrice))}
+              {totalMoney(Number(totalPrice))}
             </Text>
           </div>
         )}


### PR DESCRIPTION
## Incident

A prod incident (`inv_order_…M8SN` / core mirror `order_…8258`, display #68): editing an inventory order's lines **deleted ALL of them on every save** — even a plain *open → Save* with no edits — and left a stale non-zero header total over zero lines. This hit **every** inventory-order edit, and was a same-day regression from #855.

## Root cause

`edit-order-lines.tsx` used react-hook-form's `useFieldArray` with the **default `keyName:"id"`**, so `fields[i].id` is RHF's *generated field key*, not the DB line id. #855's new removal-diff compared those field keys against DB ids — two id-spaces that never match — so every existing line got `{ id, remove: true }` on each save. The keep/update entries carried the same wrong id, so they update-no-op'd instead of re-persisting.

The core mirror order only re-syncs **status** (never items), so it kept its creation-snapshot lines while the inventory order diverged to zero — the confusing "core survives, non-core wiped" split the operator saw. Lost lines are **soft-deleted** (recoverable).

## Fix

- `useFieldArray({ keyName: "_rhfId" })` so `fields[i].id` keeps carrying the DB id. Safe because the grid keys rows by index, not `field.id` — and mirrors `edit-design-media-form` / `edit-folder-media-form`, which already set a custom `keyName` for exactly this reason.
- Extract payload building into a pure, unit-tested `order-lines-payload.ts` (`buildOrderLinesUpdatePayload` + `computeOrderLineTotals`). Removal markers now carry only `{ id, inventory_item_id, remove }`, matching the relaxed server validator.
- Display total now comes from the **live watched rows**, not the stale `fields` snapshot (fixes the wrong on-screen total too).
- Align `UpdateInventoryOrderLinesPayload.order_lines` field optionality with the server validator (a removal marker needs only `{ id, remove }`).
- **Partner-UI**: rework `inventory-order-lines.tsx` to the Medusa-core order-item row (`grid-cols-2`: info │ `unit · {qty}x · total`) with a fulfillment badge and stable ordering, replacing the cramped 3–4 stat-column cards.

## Tests / verification

- `order-lines-payload.unit.spec.ts` (7) — **no-change emits ZERO removals** (the regression guard), plus edit / add / remove-one / remove-all and the field-key contract.
- `inventory-order-line-update-persistence.spec.ts` (5) — maps core-vs-non-core persistence and reproduces the wipe at the workflow/API level.
- **Playwright** drove the real admin: seed a 3-line order → open **Edit Order Lines** → **Save** → all 3 lines preserved (was: wiped), toast "updated successfully".
- `pnpm build` green (backend + admin); partner-ui `tsup` build green.

## Follow-ups (not in this PR)

- Operator will **manually re-enter** the ~15 lost materials on `inv_order_…M8SN` after this deploys (their recovery choice; a restore job was the alternative).
- Unrelated `workflow-schemas.json` drift (from other workflows) was left out to keep this focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)