### PR TITLE
fix(inventory-orders): re-project core mirror items on line update (stop drift)

### DIFF
--- a/apps/backend/integration-tests/http/inventory-order-line-update-persistence.spec.ts
+++ b/apps/backend/integration-tests/http/inventory-order-line-update-persistence.spec.ts
@@ -102,7 +102,8 @@ setupSharedTestSuite(() => {
       const { data } = await query.graph({
         entity: "order",
         filters: { id: unifiedOrderId },
-        fields: ["id", "status", "items.id", "items.title", "items.quantity"],
+        // `items.*` (wildcard) is required for the calculated `total` to resolve.
+        fields: ["id", "status", "total", "items.*"],
       })
       return data?.[0]
     }
@@ -204,7 +205,7 @@ setupSharedTestSuite(() => {
       expect(after.orderlines.map((l: any) => l.id).sort()).toEqual([a.id, b.id].sort())
     })
 
-    it("REPRO #855: the buggy form payload wipes ALL inventory lines but the core mirror survives", async () => {
+    it("REPRO #855: buggy payload wipes inventory lines; core mirror now re-syncs to match (no drift)", async () => {
       const legacy = await createOrderWithThreeLines()
       const lines = legacy.orderlines as any[]
       const unifiedId = await resolveUnifiedOrderId(legacy.id)
@@ -234,17 +235,53 @@ setupSharedTestSuite(() => {
       )
       expect(res.status).toBe(200)
 
-      // Non-core: every line is gone.
+      // Non-core: every line is gone (the wipe still happens at the workflow
+      // level when handed this payload — the real fix is client-side, so the
+      // buggy payload can no longer be produced by the form).
       const after = await fetchLegacyLines(legacy.id)
       expect(after.orderlines).toHaveLength(0)
       // …yet the header total was still written from the on-screen figure.
       expect(Number(after.total_price)).toBe(2150)
 
-      // Core mirror: untouched — still holds the original three items. This is
-      // the exact divergence seen in prod (core order #68 kept its items while
-      // the inventory order lost all lines).
+      // Core mirror: NO LONGER drifts. The update workflow now re-projects the
+      // mirror's items to match the live lines, so it follows the inventory
+      // order down to zero instead of stranding the original three (this is the
+      // systemic fix for the prod #68 "core kept old items" divergence).
+      const core = await fetchCoreItems(unifiedId!)
+      expect(core.items).toHaveLength(0)
+    })
+
+    it("core mirror re-projects on a correct edit (add one, drop one) to match the live lines", async () => {
+      const legacy = await createOrderWithThreeLines()
+      const [a, b, c] = legacy.orderlines
+      const unifiedId = await resolveUnifiedOrderId(legacy.id)
+      expect(unifiedId).toBeTruthy()
+      expect((await fetchCoreItems(unifiedId!)).items).toHaveLength(3)
+
+      // Keep A & B, drop C, add D — a well-formed edit.
+      const res = await api.put(
+        `/admin/inventory-orders/${legacy.id}/order-lines`,
+        {
+          order_lines: [
+            { id: a.id, inventory_item_id: a.inventory_items?.[0]?.id ?? itemA, quantity: 10, price: 100 },
+            { id: b.id, inventory_item_id: b.inventory_items?.[0]?.id ?? itemB, quantity: 5, price: 200 },
+            { id: c.id, remove: true },
+            { inventory_item_id: itemD, quantity: 3, price: 100 },
+          ],
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+
+      // Inventory order: A, B, D (3 lines).
+      const afterInv = await fetchLegacyLines(legacy.id)
+      expect(afterInv.orderlines).toHaveLength(3)
+
+      // Core mirror now tracks the same 3 lines, and the total reflects them:
+      // 10*100 + 5*200 + 3*100 = 2300.
       const core = await fetchCoreItems(unifiedId!)
       expect(core.items).toHaveLength(3)
+      expect(Number(core.total)).toBe(2300)
     })
   })
 })

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -25,6 +25,7 @@ import { PARTNER_MODULE } from "../../../../modules/partner"
 import productGoogleMerchantLink from "../../../../links/product-google-merchant-link"
 import productionRunConsumptionLogLink from "../../../../links/production-runs-consumption-logs"
 import { resolveStoreCurrency } from "../../../../lib/resolve-store-currency"
+import { reprojectInventoryMirrorItems } from "../../../../workflows/inventory_orders/reproject-inventory-mirror-items"
 import { firstMediaUrl } from "../../../../utils/first-media-url"
 import {
   normalizeLandingBase,
@@ -5158,6 +5159,83 @@ export const retitleGroupColorNamesJob: MaintenanceJob = {
   },
 }
 
+const reconcileInventoryMirrorParamsSchema = z.object({
+  inventory_order_id: z.string().min(1, "inventory_order_id is required"),
+})
+
+/**
+ * Reconcile an inventory order's core "unified" mirror so its line items match
+ * the LIVE inventory lines. The mirror is projected once at creation and (until
+ * the update workflow now re-projects) only its status was mirrored — so line
+ * edits left stale items + a stale total. Order totals are calculated from
+ * items, so replacing the items fixes the total for free. Idempotent: a mirror
+ * already in sync is a no-op; an order with no projected mirror is skipped.
+ */
+export const reconcileInventoryMirrorJob: MaintenanceJob = {
+  id: "reconcile-inventory-mirror",
+  label: "Reconcile inventory order → core mirror items",
+  description:
+    "Rebuild an inventory order's core mirror (unified order) line items to match its LIVE lines, fixing stale items + total after line edits. Dry-run previews the items that would be created/removed without persisting; apply writes them (idempotent — a mirror already in sync is a no-op). An inventory order with no projected core order is skipped.",
+  params: [
+    {
+      name: "inventory_order_id",
+      type: "string",
+      required: true,
+      description: "ID of the inventory order whose core mirror to reconcile",
+    },
+  ],
+  run: async (container, { dry_run, params }) => {
+    const parsed = reconcileInventoryMirrorParamsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { inventory_order_id } = parsed.data
+
+    const summary = await reprojectInventoryMirrorItems(container, inventory_order_id, {
+      dryRun: dry_run,
+    })
+
+    if (summary.skipped === "no_mirror") {
+      return {
+        job_id: reconcileInventoryMirrorJob.id,
+        dry_run,
+        applied: false,
+        summary: `Skipped — inventory order ${inventory_order_id} has no projected core mirror order.`,
+        changes: [],
+      }
+    }
+
+    const changes: MaintenanceChange[] = []
+    for (const c of summary.plan.create) {
+      changes.push({
+        entity: "order_line_item",
+        id: String(summary.unified_order_id),
+        field: "create",
+        after: `${c.title} ×${c.quantity} @ ${c.unit_price} (line ${c.metadata.legacy_orderline_id})`,
+      })
+    }
+    for (const removedId of summary.plan.removeItemIds) {
+      changes.push({ entity: "order_line_item", id: removedId, field: "remove", before: removedId })
+    }
+
+    const noop = summary.created === 0 && summary.removed === 0
+    const summaryText = noop
+      ? `No changes — core mirror ${summary.unified_order_id} already matches inventory order ${inventory_order_id} (${summary.unchanged} items in sync, total ${summary.before_total}).`
+      : `${dry_run ? "Would sync" : "Synced"} core mirror ${summary.unified_order_id}: +${summary.created} / -${summary.removed} item(s), ${summary.unchanged} kept (was total ${summary.before_total}).`
+
+    return {
+      job_id: reconcileInventoryMirrorJob.id,
+      dry_run,
+      applied: !dry_run && !noop,
+      summary: summaryText,
+      changes,
+    }
+  },
+}
+
 export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   recalculateDesignCostJob,
   recalculateDesignCostBulkJob,
@@ -5187,6 +5265,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   backfillDesignPartnerLinksJob,
   backfillGroupGlobalsToColorsJob,
   retitleGroupColorNamesJob,
+  reconcileInventoryMirrorJob,
 ]
 
 export const getMaintenanceJob = (id: string): MaintenanceJob | undefined =>

--- a/apps/backend/src/workflows/inventory_orders/__tests__/reproject-inventory-mirror-items.unit.spec.ts
+++ b/apps/backend/src/workflows/inventory_orders/__tests__/reproject-inventory-mirror-items.unit.spec.ts
@@ -1,0 +1,98 @@
+import {
+  planMirrorReprojection,
+  type LiveInventoryLine,
+  type MirrorItem,
+} from "../reproject-inventory-mirror-items"
+
+const line = (id: string, title: string, quantity: number, price: number): LiveInventoryLine => ({
+  id,
+  title,
+  quantity,
+  price,
+  inventory_item_id: `iitem_${id}`,
+})
+
+const item = (id: string, title: string, quantity: number, unit_price: number, legacy: string | null): MirrorItem => ({
+  id,
+  title,
+  quantity,
+  unit_price,
+  legacy_orderline_id: legacy,
+})
+
+describe("planMirrorReprojection", () => {
+  it("no drift: matching lines produce no creates and no removes", () => {
+    const lines = [line("l1", "Cotton", 10, 100), line("l2", "Silk", 5, 200)]
+    const items = [
+      item("it1", "Cotton", 10, 100, "l1"),
+      item("it2", "Silk", 5, 200, "l2"),
+    ]
+    const plan = planMirrorReprojection(lines, items)
+    expect(plan.create).toHaveLength(0)
+    expect(plan.removeItemIds).toHaveLength(0)
+    expect(plan.unchanged).toBe(2)
+  })
+
+  it("the prod incident: stale originals removed, new lines created", () => {
+    // mirror still holds the 2 original items keyed to now-deleted lines; the
+    // inventory order now has 3 different live lines.
+    const items = [
+      item("ordli_A", "Dress Suit Material", 15, 103.33, "old_line_A"),
+      item("ordli_B", "Shirt", 12, 50, "old_line_B"),
+    ]
+    const lines = [
+      line("new_1", "Tangaliya Weave — Black", 1, 1400),
+      line("new_2", "Tangaliya Weave — Blue", 1, 1400),
+      line("new_3", "Tangaliya Weave", 12, 600),
+    ]
+    const plan = planMirrorReprojection(lines, items)
+    expect(plan.removeItemIds.sort()).toEqual(["ordli_A", "ordli_B"])
+    expect(plan.create).toHaveLength(3)
+    expect(plan.unchanged).toBe(0)
+    // created items carry the legacy key + inventory linkage for future diffs
+    expect(plan.create[0].metadata).toMatchObject({
+      legacy_orderline_id: "new_1",
+      inventory_item_id: "iitem_new_1",
+    })
+  })
+
+  it("changed qty/price/title: remove old item + create fresh (never in-place)", () => {
+    const items = [item("it1", "Cotton", 10, 100, "l1")]
+    const lines = [line("l1", "Cotton", 20, 100)] // qty 10 -> 20
+    const plan = planMirrorReprojection(lines, items)
+    expect(plan.removeItemIds).toEqual(["it1"])
+    expect(plan.create).toHaveLength(1)
+    expect(plan.create[0].quantity).toBe(20)
+    expect(plan.unchanged).toBe(0)
+  })
+
+  it("mixed add + keep + remove in one pass", () => {
+    const items = [
+      item("keep", "Cotton", 10, 100, "l1"), // unchanged
+      item("stale", "Old", 1, 1, "l_gone"), // legacy no longer live
+    ]
+    const lines = [
+      line("l1", "Cotton", 10, 100), // matches keep
+      line("l2", "Silk", 5, 200), // new
+    ]
+    const plan = planMirrorReprojection(lines, items)
+    expect(plan.unchanged).toBe(1)
+    expect(plan.removeItemIds).toEqual(["stale"])
+    expect(plan.create.map((c) => c.metadata.legacy_orderline_id)).toEqual(["l2"])
+  })
+
+  it("keyless mirror items (no legacy_orderline_id) are always removed", () => {
+    const items = [item("legacyless", "Mystery", 1, 1, null)]
+    const lines = [line("l1", "Cotton", 10, 100)]
+    const plan = planMirrorReprojection(lines, items)
+    expect(plan.removeItemIds).toEqual(["legacyless"])
+    expect(plan.create).toHaveLength(1)
+  })
+
+  it("all lines removed: every mirror item is dropped, nothing created", () => {
+    const items = [item("it1", "Cotton", 10, 100, "l1")]
+    const plan = planMirrorReprojection([], items)
+    expect(plan.removeItemIds).toEqual(["it1"])
+    expect(plan.create).toHaveLength(0)
+  })
+})

--- a/apps/backend/src/workflows/inventory_orders/reproject-inventory-mirror-items.ts
+++ b/apps/backend/src/workflows/inventory_orders/reproject-inventory-mirror-items.ts
@@ -1,0 +1,243 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
+
+/**
+ * Re-project an inventory order's LIVE lines onto its core mirror order's items.
+ *
+ * The core "unified" order (#342) is a projection built once at creation
+ * (dual-write-unified-order.ts) and, until now, only its STATUS was mirrored on
+ * update — never its items. So editing an inventory order's lines left the core
+ * mirror showing stale items + a stale total (it kept the creation snapshot).
+ *
+ * Core order totals are CALCULATED from line items on read (verified), so
+ * reconciling is simply: make the mirror's line items match the live inventory
+ * lines and the total fixes itself. We key items by metadata.legacy_orderline_id
+ * and treat a changed line as remove-old + create-fresh (quantity lives on the
+ * order_item detail, so in-place updates are avoided).
+ */
+
+export interface LiveInventoryLine {
+  id: string
+  quantity: number
+  price: number
+  title: string
+  inventory_item_id: string | null
+}
+
+export interface MirrorItem {
+  id: string
+  title: string
+  quantity: number
+  unit_price: number
+  legacy_orderline_id: string | null
+}
+
+export interface MirrorItemCreate {
+  title: string
+  quantity: number
+  unit_price: number
+  metadata: Record<string, unknown>
+}
+
+export interface MirrorReprojectPlan {
+  create: MirrorItemCreate[]
+  removeItemIds: string[]
+  unchanged: number
+}
+
+/**
+ * Pure diff: what must change on the mirror so its items match the live lines.
+ * Keyed by legacy_orderline_id. A line that matches an existing item exactly is
+ * left untouched; anything else is (re)created, and every mirror item not
+ * explicitly kept is removed (stale originals, changed lines, keyless items).
+ * Exported for unit testing.
+ */
+export function planMirrorReprojection(
+  liveLines: LiveInventoryLine[],
+  mirrorItems: MirrorItem[]
+): MirrorReprojectPlan {
+  const mirrorByLegacy = new Map<string, MirrorItem>()
+  for (const it of mirrorItems) {
+    if (it.legacy_orderline_id) {
+      mirrorByLegacy.set(it.legacy_orderline_id, it)
+    }
+  }
+
+  const create: MirrorItemCreate[] = []
+  const keepItemIds = new Set<string>()
+  let unchanged = 0
+
+  for (const line of liveLines) {
+    const existing = mirrorByLegacy.get(line.id)
+    if (
+      existing &&
+      existing.title === line.title &&
+      Number(existing.quantity) === line.quantity &&
+      Number(existing.unit_price) === line.price
+    ) {
+      keepItemIds.add(existing.id)
+      unchanged++
+      continue
+    }
+    create.push({
+      title: line.title,
+      quantity: line.quantity,
+      unit_price: line.price,
+      metadata: {
+        inventory_item_id: line.inventory_item_id,
+        legacy_orderline_id: line.id,
+        legacy_unit_price: line.price,
+      },
+    })
+  }
+
+  const removeItemIds = mirrorItems
+    .filter((it) => !keepItemIds.has(it.id))
+    .map((it) => it.id)
+
+  return { create, removeItemIds, unchanged }
+}
+
+export interface ReprojectSummary {
+  inventory_order_id: string
+  unified_order_id: string | null
+  skipped?: string
+  created: number
+  removed: number
+  unchanged: number
+  before_total: number | null
+  plan: MirrorReprojectPlan
+  dry_run: boolean
+}
+
+const EMPTY_PLAN: MirrorReprojectPlan = { create: [], removeItemIds: [], unchanged: 0 }
+
+/**
+ * Read the live inventory lines + the current mirror items, compute the plan,
+ * and (unless dryRun) apply it via the order module. Never assumes a mirror
+ * exists — a legacy order with no projected core order is a no-op ("no_mirror").
+ */
+export async function reprojectInventoryMirrorItems(
+  container: any,
+  inventoryOrderId: string,
+  opts: { dryRun?: boolean } = {}
+): Promise<ReprojectSummary> {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  const orderService: any = container.resolve(Modules.ORDER)
+  const dryRun = !!opts.dryRun
+
+  const { data: invRows } = await query.graph({
+    entity: "inventory_orders",
+    filters: { id: inventoryOrderId },
+    fields: [
+      "id",
+      "order.id",
+      "orderlines.id",
+      "orderlines.quantity",
+      "orderlines.price",
+      "orderlines.material_name",
+      "orderlines.inventory_items.id",
+      "orderlines.inventory_items.title",
+      "orderlines.inventory_items.sku",
+    ],
+  })
+  const inv = invRows?.[0]
+  const unifiedOrderId: string | null = inv?.order?.id ?? null
+  if (!inv || !unifiedOrderId) {
+    return {
+      inventory_order_id: inventoryOrderId,
+      unified_order_id: null,
+      skipped: "no_mirror",
+      created: 0,
+      removed: 0,
+      unchanged: 0,
+      before_total: null,
+      plan: EMPTY_PLAN,
+      dry_run: dryRun,
+    }
+  }
+
+  const liveLines: LiveInventoryLine[] = (inv.orderlines || []).map((l: any) => ({
+    id: String(l.id),
+    quantity: Number(l.quantity) || 0,
+    price: Number(l.price) || 0,
+    title:
+      l.material_name ||
+      l.inventory_items?.[0]?.title ||
+      l.inventory_items?.[0]?.sku ||
+      "Raw material",
+    inventory_item_id: l.inventory_items?.[0]?.id ?? null,
+  }))
+
+  const { data: ordRows } = await query.graph({
+    entity: "order",
+    filters: { id: unifiedOrderId },
+    // `items.*` (wildcard) is what resolves the effective quantity + metadata.
+    fields: ["id", "total", "items.*"],
+  })
+  const mirror = ordRows?.[0]
+  const mirrorItems: MirrorItem[] = (mirror?.items || []).map((i: any) => ({
+    id: String(i.id),
+    title: i.title,
+    quantity: Number(i.quantity) || 0,
+    unit_price: Number(i.unit_price) || 0,
+    legacy_orderline_id: i.metadata?.legacy_orderline_id
+      ? String(i.metadata.legacy_orderline_id)
+      : null,
+  }))
+
+  const plan = planMirrorReprojection(liveLines, mirrorItems)
+
+  const summary: ReprojectSummary = {
+    inventory_order_id: inventoryOrderId,
+    unified_order_id: unifiedOrderId,
+    created: plan.create.length,
+    removed: plan.removeItemIds.length,
+    unchanged: plan.unchanged,
+    before_total: mirror?.total != null ? Number(mirror.total) : null,
+    plan,
+    dry_run: dryRun,
+  }
+
+  if (dryRun) {
+    return summary
+  }
+
+  // Create fresh items first so the order is never transiently empty, then drop
+  // the stale ones. Totals recompute on the next read either way.
+  if (plan.create.length) {
+    await orderService.createOrderLineItems(unifiedOrderId, plan.create as any)
+  }
+  if (plan.removeItemIds.length) {
+    await orderService.deleteOrderLineItems(plan.removeItemIds)
+  }
+
+  return summary
+}
+
+/**
+ * Best-effort workflow step — mirrors the item projection after a line update.
+ * Never throws: a mirror hiccup must not fail (or roll back) the inventory
+ * order update. Same contract as mirrorUnifiedOrderStatusStep.
+ */
+export const reprojectInventoryMirrorItemsStep = createStep(
+  "reproject-inventory-mirror-items",
+  async (input: { inventoryOrderId: string }, { container }) => {
+    const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+    try {
+      const summary = await reprojectInventoryMirrorItems(container, input.inventoryOrderId, {})
+      if (summary.unified_order_id && (summary.created || summary.removed)) {
+        logger.info(
+          `[orders-unification] mirror reprojected for ${input.inventoryOrderId}: ` +
+            `+${summary.created}/-${summary.removed} items (kept ${summary.unchanged})`
+        )
+      }
+      return new StepResponse(summary)
+    } catch (e: any) {
+      logger.warn(
+        `[orders-unification] mirror item reproject failed for ${input.inventoryOrderId}: ${e?.message}`
+      )
+      return new StepResponse(null)
+    }
+  }
+)

--- a/apps/backend/src/workflows/inventory_orders/update-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/update-inventory-orders.ts
@@ -13,6 +13,7 @@ import { createInventoryLevelsWorkflow, updateInventoryLevelsWorkflow } from "@m
 import { ORDER_INVENTORY_MODULE } from "../../modules/inventory_orders";
 import InventoryOrderService from "../../modules/inventory_orders/service";
 import { mirrorUnifiedOrderStatusStep } from "./dual-write-unified-order";
+import { reprojectInventoryMirrorItemsStep } from "./reproject-inventory-mirror-items";
 import { resolveExistingLevelsStep } from "./partner-complete-inventory-order";
 import inventoryOrdersStockLocations from "../../links/inventory-orders-stock-locations";
 import {
@@ -434,6 +435,9 @@ export const updateInventoryOrderWorkflow = createWorkflow(
 
     // #342 — best-effort §5 status mirror onto the unified core order
     mirrorUnifiedOrderStatusStep({ inventoryOrderId: input.id });
+    // Keep the core mirror's items in sync with the (just-updated) lines so the
+    // unified order never drifts from the inventory order again. Best-effort.
+    reprojectInventoryMirrorItemsStep({ inventoryOrderId: input.id });
     return new WorkflowResponse({ order: updatedOrder, orderlines: updatedOrderlines });
   },
 );


### PR DESCRIPTION
## Problem

The core "unified" order (#342) is a projection of an inventory order, but it was only built once at creation and, on update, **only its status was mirrored — never its items**. So editing an inventory order's lines left the core mirror stranded on the original items + a stale total.

Seen in prod on order **#68** (`inv_order_…M8SN`): after re-adding materials, the inventory order carried **16 live lines / total 28200** while the core mirror still showed the original **2 items / total 2150**. The partner reads the inventory order (correct); the drift was on the admin "unified orders" projection.

## Insight

Core order totals are **calculated from line items on read** (verified with a probe: mutating line items directly moved `order.total`). So reconciling is simply: **make the mirror's line items match the live inventory lines** — the total fixes itself. No order-edit ceremony, no stale-summary problem.

## Change

- **`reproject-inventory-mirror-items.ts`**
  - `planMirrorReprojection()` — pure diff keyed by `metadata.legacy_orderline_id`. An exact match is kept; anything else is (re)created; every mirror item not kept is removed (stale originals, changed lines, keyless items). A changed line is remove-old + create-fresh (quantity lives on the `order_item` detail, so in-place updates are avoided). **Unit-tested.**
  - `reprojectInventoryMirrorItems()` — reads live lines + mirror items, applies the plan via the order module.
  - `reprojectInventoryMirrorItemsStep` — **best-effort, never throws** (same contract as `mirrorUnifiedOrderStatusStep`).
- **Wire the step into `updateInventoryOrderWorkflow`** after the status mirror → the mirror can't drift again. Status-only updates (empty `order_lines`) are a no-op reproject.
- **New maintenance job `reconcile-inventory-mirror`** (dry-run→apply) to reconcile already-drifted orders (e.g. #68) with an audit trail, per the Data-Plumbing convention.

## Tests / verification

- `reproject-inventory-mirror-items.unit.spec.ts` (6): no-op, the prod incident (stale originals removed + new lines created), changed-line replace, mixed add/keep/remove, keyless removal, remove-all.
- `inventory-order-line-update-persistence.spec.ts`: the REPRO test now asserts the mirror **re-syncs** (no more drift), plus a new test that a correct edit re-projects the mirror to 3 items / total 2300. **All 6 green.**
- Local end-to-end (`medusa exec`): create → mirror matches; edit lines → mirror auto-reprojects; follow-up dry-run shows **zero residual drift**.
- `pnpm build` green (backend + admin).

## Rollout for prod #68

After deploy, run the **`reconcile-inventory-mirror`** job (Settings → Data Plumbing) with `inventory_order_id = inv_order_01KWAKAZE17CC95XDEY7Q0M8SN` — dry-run to preview (+16 / −2), then apply → mirror total becomes 28200. (Any future line edit now keeps it in sync automatically.)

Follow-up: unrelated `workflow-schemas.json` drift left out to keep this focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)