### PR TITLE
fix(shiprocket): resolve inv-order shipment destination from to-location (#772)

### DIFF
--- a/apps/backend/src/workflows/inventory_orders/__tests__/inventory-order-shipment.unit.spec.ts
+++ b/apps/backend/src/workflows/inventory_orders/__tests__/inventory-order-shipment.unit.spec.ts
@@ -1,6 +1,8 @@
 import {
   buildInventoryOrderShipmentInput,
   DEFAULT_INVENTORY_SHIPMENT_WEIGHT_GRAMS,
+  missingDestinationAddressFields,
+  resolveInventoryDestinationAddress,
   type InventoryOrderForShipment,
 } from "../lib/inventory-order-shipment"
 
@@ -81,5 +83,56 @@ describe("buildInventoryOrderShipmentInput (#772)", () => {
     expect(input.to.name).toBe("Warehouse")
     expect(input.to.country).toBe("IN")
     expect(input.items).toEqual([])
+  })
+})
+
+describe("resolveInventoryDestinationAddress (#772 to-location fill)", () => {
+  const locAddress = {
+    address_1: "9 Mill Rd",
+    city: "Surat",
+    province: "GJ",
+    postal_code: "395003",
+    country_code: "in",
+    phone: "8887776665",
+  }
+
+  it("fills a sparse shipping_address from the to-location stock-location address", () => {
+    const resolved = resolveInventoryDestinationAddress(
+      { city: "Delhi", country_code: "in" }, // typical minimal blob
+      locAddress,
+      "Surat Warehouse"
+    )
+    expect(resolved.address_1).toBe("9 Mill Rd")
+    expect(resolved.postal_code).toBe("395003")
+    expect(resolved.phone).toBe("8887776665")
+    // explicit shipping_address value wins over the location value
+    expect(resolved.city).toBe("Delhi")
+    // no contact name → fall back to the location name
+    expect(resolved.first_name).toBe("Surat Warehouse")
+    expect(missingDestinationAddressFields(resolved)).toEqual([])
+  })
+
+  it("keeps explicit shipping_address contact fields over the location name", () => {
+    const resolved = resolveInventoryDestinationAddress(
+      { first_name: "Amit", phone: "9001112223" },
+      locAddress,
+      "Surat Warehouse"
+    )
+    expect(resolved.first_name).toBe("Amit")
+    expect(resolved.phone).toBe("9001112223")
+    expect(resolved.address_1).toBe("9 Mill Rd")
+  })
+
+  it("reports the specific missing fields when neither source is complete", () => {
+    const resolved = resolveInventoryDestinationAddress(
+      { city: "Delhi", country_code: "in" },
+      { city: "Delhi" }, // location has no street/pincode/phone either
+      "Delhi Warehouse"
+    )
+    expect(missingDestinationAddressFields(resolved)).toEqual([
+      "street address",
+      "pincode",
+      "phone",
+    ])
   })
 })

--- a/apps/backend/src/workflows/inventory_orders/create-inventory-order-shipment.ts
+++ b/apps/backend/src/workflows/inventory_orders/create-inventory-order-shipment.ts
@@ -4,9 +4,10 @@ import {
   StepResponse,
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
-import { MedusaError } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 import type { MedusaContainer } from "@medusajs/framework/types"
 import { ORDER_INVENTORY_MODULE } from "../../modules/inventory_orders"
+import InventoryOrdersStockLocationsLink from "../../links/inventory-orders-stock-locations"
 import { resolveShippingProvider } from "../../modules/shipping-providers/resolver"
 import {
   chooseRegisteredPickup,
@@ -17,7 +18,11 @@ import type {
   Dimensions,
   ShipmentResult,
 } from "../../modules/shipping-providers/provider-interface"
-import { buildInventoryOrderShipmentInput } from "./lib/inventory-order-shipment"
+import {
+  buildInventoryOrderShipmentInput,
+  missingDestinationAddressFields,
+  resolveInventoryDestinationAddress,
+} from "./lib/inventory-order-shipment"
 
 /**
  * Generate a real carrier shipment (forward → AWB → label) for a partner
@@ -100,12 +105,51 @@ export async function createInventoryOrderShipment(
     )
   }
 
-  const taxId = await resolvePlatformTaxIdForCountry(
-    container,
-    (order as any)?.shipping_address?.country_code || "IN"
+  // Destination (ship-to) address: the order's linked `to_location` stock
+  // location is the physical destination and carries a complete structured
+  // address; the free-form `shipping_address` JSON is often just
+  // `{ city, country_code }`. Fill from the to-location, letting any explicit
+  // shipping_address field win, so Shiprocket's required billing fields are
+  // populated (#772 — "The billing address field is required").
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  let toLocation: any = null
+  try {
+    const { data: links } = await query.graph({
+      entity: (InventoryOrdersStockLocationsLink as any).entryPoint,
+      fields: ["to_location", "stock_location.name", "stock_location.address.*"],
+      filters: { inventory_orders_id: order.id },
+    })
+    toLocation = (links || []).find((l: any) => l?.to_location)?.stock_location || null
+  } catch {
+    // best-effort — the guard below produces the actionable error
+  }
+
+  const destinationAddress = resolveInventoryDestinationAddress(
+    (order as any)?.shipping_address,
+    toLocation?.address,
+    toLocation?.name
   )
 
-  const shipmentInput = buildInventoryOrderShipmentInput(order as any, {
+  const missing = missingDestinationAddressFields(destinationAddress)
+  if (missing.length) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Destination address is incomplete (missing ${missing.join(", ")}). ` +
+        `Set a complete address on the order's destination stock location, or on the order's shipping address, before generating a shipment.`
+    )
+  }
+
+  const orderForShipment = {
+    ...(order as any),
+    shipping_address: destinationAddress,
+  }
+
+  const taxId = await resolvePlatformTaxIdForCountry(
+    container,
+    destinationAddress.country_code || "IN"
+  )
+
+  const shipmentInput = buildInventoryOrderShipmentInput(orderForShipment as any, {
     pickupLocationName,
     weightGrams: input.weightGrams,
     dimensionsCm: input.dimensionsCm,

--- a/apps/backend/src/workflows/inventory_orders/lib/inventory-order-shipment.ts
+++ b/apps/backend/src/workflows/inventory_orders/lib/inventory-order-shipment.ts
@@ -57,6 +57,71 @@ const lineName = (l: InventoryOrderLineForShipment): string => {
   return (m.title || m.name || m.description || m.sku || "Inventory item") as string
 }
 
+/** Canonical destination-address fields Shiprocket's adhoc order needs. */
+const DEST_ADDRESS_KEYS = [
+  "first_name",
+  "last_name",
+  "company",
+  "address_1",
+  "address_2",
+  "city",
+  "province",
+  "postal_code",
+  "country_code",
+  "phone",
+] as const
+
+const nonEmpty = (v: unknown): boolean =>
+  v !== undefined && v !== null && String(v).trim() !== ""
+
+/**
+ * Resolve the shipment destination (ship-to) address for an inventory order.
+ *
+ * The inventory order's free-form `shipping_address` JSON is frequently minimal
+ * (often just `{ city, country_code }`), which left Shiprocket's required
+ * `billing_address`/pincode/phone empty → "The billing address field is
+ * required" (#772). The destination warehouse is the order's linked
+ * `to_location` stock location, which carries a proper structured address — so
+ * we fill from the stock-location address and let any explicit non-empty
+ * `shipping_address` field win on top (contact name/phone the order captured).
+ *
+ * Pure & exported for unit testing.
+ */
+export function resolveInventoryDestinationAddress(
+  shippingAddress: Record<string, any> | null | undefined,
+  stockLocationAddress: Record<string, any> | null | undefined,
+  locationName?: string | null
+): Record<string, any> {
+  const ship = shippingAddress || {}
+  const loc = stockLocationAddress || {}
+  const out: Record<string, any> = {}
+  for (const key of DEST_ADDRESS_KEYS) {
+    // stock-location value as the base, overridden by an explicit shipping value
+    if (nonEmpty(loc[key])) out[key] = loc[key]
+    if (nonEmpty(ship[key])) out[key] = ship[key]
+  }
+  // Shiprocket needs a customer name; fall back to the warehouse/location name
+  // so the label isn't a bare "Warehouse".
+  if (!nonEmpty(out.first_name) && !nonEmpty(out.last_name) && nonEmpty(locationName)) {
+    out.first_name = locationName
+  }
+  return out
+}
+
+/** The subset Shiprocket rejects the order without. */
+export function missingDestinationAddressFields(
+  addr: Record<string, any> | null | undefined
+): string[] {
+  const a = addr || {}
+  const required: Array<[string, string]> = [
+    ["address_1", "street address"],
+    ["city", "city"],
+    ["postal_code", "pincode"],
+    ["phone", "phone"],
+  ]
+  return required.filter(([k]) => !nonEmpty(a[k])).map(([, label]) => label)
+}
+
 export function buildInventoryOrderShipmentInput(
   order: InventoryOrderForShipment,
   opts: BuildInventoryShipmentOpts = {}


### PR DESCRIPTION
## Problem
Partner inventory-order shipment creation failed with Shiprocket **"The billing address field is required"**.

`buildInventoryOrderShipmentInput` reads the ship-to address only from the inventory order's free-form `shipping_address` JSON, which is typically minimal (`{ city, country_code }`). So `billing_address` (← `to.address_1`), `billing_pincode`, and `billing_phone` came out empty → carrier 400.

## Fix
The destination warehouse is the order's linked **`to_location`** stock location, which carries a complete structured address. `createInventoryOrderShipment` now:
- queries the `to_location` stock-location `address.*`,
- fills the destination via new pure `resolveInventoryDestinationAddress` (location as base, explicit `shipping_address` fields win, location name → customer name fallback),
- guards with a clean `MedusaError` listing missing fields (street/city/pincode/phone) instead of letting Shiprocket 400,
- resolves the platform tax-ID country from the resolved address.

Symmetric with the ship-**from** side, which already reads `stock_location.address.*`.

## Tests
3 new unit tests on the pure helpers (fill-from-location, explicit-wins, missing-field reporting). Full `inventory-order-shipment.unit` suite green (8/8).

Refs #772.