### PR TITLE
feat(partner): onboarding selling-mode + commission override wiring (#860)

### DIFF
--- a/apps/backend/integration-tests/http/partner-onboarding-profile-api.spec.ts
+++ b/apps/backend/integration-tests/http/partner-onboarding-profile-api.spec.ts
@@ -73,6 +73,8 @@ setupSharedTestSuite(() => {
         person_type: "manufacturer",
         team_size: 12,
         payment_collection: "through_us",
+        selling_mode: "core_channel_listing",
+        commission_bps: 1500,
         completed: true,
       }
 
@@ -107,6 +109,28 @@ setupSharedTestSuite(() => {
       expect(second.data.onboarding_profile.what_they_sell).toBe("fabric")
       expect(second.data.onboarding_profile.price_range).toBe("luxury")
       expect(second.data.onboarding_profile.completed).toBe(true)
+    })
+
+    it("PUT persists selling_mode + commission_bps (#859 S1 / #860)", async () => {
+      const put = await api.put(
+        "/partners/onboarding-profile",
+        { selling_mode: "dedicated_storefront", commission_bps: 0 },
+        { headers: partner.headers }
+      )
+      expect(put.status).toBe(200)
+      expect(put.data.onboarding_profile.selling_mode).toBe("dedicated_storefront")
+      expect(put.data.onboarding_profile.commission_bps).toBe(0)
+    })
+
+    it("PUT rejects an out-of-range commission_bps with 400", async () => {
+      const res = await api
+        .put(
+          "/partners/onboarding-profile",
+          { commission_bps: 20000 },
+          { headers: partner.headers }
+        )
+        .catch((e: any) => e.response)
+      expect(res.status).toBe(400)
     })
 
     it("PUT rejects an invalid enum value with 400", async () => {

--- a/apps/backend/src/api/partners/onboarding-profile/__tests__/validators.unit.spec.ts
+++ b/apps/backend/src/api/partners/onboarding-profile/__tests__/validators.unit.spec.ts
@@ -60,4 +60,44 @@ describe("onboardingProfileUpdateSchema (#648 slice 1)", () => {
       onboardingProfileUpdateSchema.safeParse({ not_real: "x" }).success
     ).toBe(false)
   })
+
+  // #859 S1 / #860 — selling_mode + commission_bps
+  it("accepts a valid selling_mode", () => {
+    expect(
+      onboardingProfileUpdateSchema.safeParse({
+        selling_mode: "core_channel_listing",
+      }).success
+    ).toBe(true)
+  })
+
+  it("rejects an out-of-enum selling_mode", () => {
+    expect(
+      onboardingProfileUpdateSchema.safeParse({ selling_mode: "franchise" })
+        .success
+    ).toBe(false)
+  })
+
+  it("accepts commission_bps within 0..10000", () => {
+    expect(
+      onboardingProfileUpdateSchema.safeParse({ commission_bps: 1500 }).success
+    ).toBe(true)
+    expect(
+      onboardingProfileUpdateSchema.safeParse({ commission_bps: 0 }).success
+    ).toBe(true)
+  })
+
+  it("rejects commission_bps above 100% (>10000) or negative", () => {
+    expect(
+      onboardingProfileUpdateSchema.safeParse({ commission_bps: 10001 }).success
+    ).toBe(false)
+    expect(
+      onboardingProfileUpdateSchema.safeParse({ commission_bps: -1 }).success
+    ).toBe(false)
+  })
+
+  it("rejects a non-integer commission_bps", () => {
+    expect(
+      onboardingProfileUpdateSchema.safeParse({ commission_bps: 12.5 }).success
+    ).toBe(false)
+  })
 })

--- a/apps/backend/src/api/partners/onboarding-profile/validators.ts
+++ b/apps/backend/src/api/partners/onboarding-profile/validators.ts
@@ -36,6 +36,13 @@ export const onboardingProfileUpdateSchema = z
       .enum(["through_us", "themselves"])
       .nullable()
       .optional(),
+    // #859 S1 / #860 — how the partner wants to sell.
+    selling_mode: z
+      .enum(["dedicated_storefront", "core_channel_listing"])
+      .nullable()
+      .optional(),
+    // Agreed commission in basis points (1000 = 10.00%). Capped at 100%.
+    commission_bps: z.number().int().min(0).max(10000).nullable().optional(),
     completed: z.boolean().optional(),
   })
   .strict()

--- a/apps/backend/src/modules/partner-onboarding-profile/migrations/Migration20260703170000.ts
+++ b/apps/backend/src/modules/partner-onboarding-profile/migrations/Migration20260703170000.ts
@@ -1,0 +1,35 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Adds selling_mode + commission_bps to partner_onboarding_profile (#859 S1 / #860).
+ *
+ * Hand-written (Claude-owned) ALTER migration. Editing the original
+ * create-table migration would never land on existing databases (the
+ * `create table if not exists` no-ops once the table exists — see the repo
+ * "migration create-if-not-exists hazard" note), so these are added as
+ * idempotent `ADD COLUMN IF NOT EXISTS` statements.
+ *
+ * - selling_mode: how the partner sells (own storefront vs core-channel listing).
+ * - commission_bps: agreed commission in basis points; null → platform default.
+ */
+export class Migration20260703170000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(
+      `alter table if exists "partner_onboarding_profile" add column if not exists "selling_mode" text check ("selling_mode" in ('dedicated_storefront', 'core_channel_listing')) null;`
+    );
+    this.addSql(
+      `alter table if exists "partner_onboarding_profile" add column if not exists "commission_bps" integer null;`
+    );
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(
+      `alter table if exists "partner_onboarding_profile" drop column if exists "selling_mode";`
+    );
+    this.addSql(
+      `alter table if exists "partner_onboarding_profile" drop column if exists "commission_bps";`
+    );
+  }
+
+}

--- a/apps/backend/src/modules/partner-onboarding-profile/models/partner-onboarding-profile.ts
+++ b/apps/backend/src/modules/partner-onboarding-profile/models/partner-onboarding-profile.ts
@@ -52,6 +52,20 @@ const PartnerOnboardingProfile = model.define("partner_onboarding_profile", {
   //    lives in /partners/payment-config (out of scope for slice 1).
   payment_collection: model.enum(["through_us", "themselves"]).nullable(),
 
+  // 9. How the partner wants to sell (#859 S1 / #860):
+  //    - dedicated_storefront: runs their own storefront/sales channel.
+  //    - core_channel_listing: Airbnb-style listing on the core cicilabel.com
+  //      sales channel, at an agreed commission (see commission_bps).
+  selling_mode: model
+    .enum(["dedicated_storefront", "core_channel_listing"])
+    .nullable(),
+
+  // 10. Agreed commission / revenue-share, in basis points (1000 = 10.00%).
+  //     Nullable — when unset the platform default (PLATFORM_TX_FEE_BPS, 2%)
+  //     applies. Wired into partner_billing/resolve-fee-rate as the per-partner
+  //     override (#336 override slot).
+  commission_bps: model.number().nullable(),
+
   // Set true once the partner submits the wizard.
   completed: model.boolean().default(false),
 

--- a/apps/backend/src/modules/partner_billing/__tests__/resolve-fee-rate.unit.spec.ts
+++ b/apps/backend/src/modules/partner_billing/__tests__/resolve-fee-rate.unit.spec.ts
@@ -10,8 +10,16 @@
 import {
   pickFeeRate,
   resolvePartnerFeeRate,
+  resolvePartnerCommissionOverrideBps,
   PLATFORM_DEFAULT_FEE_BPS,
 } from "../resolve-fee-rate"
+
+/** Minimal container stub whose onboarding-profile service returns `profile`. */
+const containerWithProfile = (profile: any) => ({
+  resolve: (_key: string) => ({
+    findByPartner: async (_partnerId: string) => profile,
+  }),
+})
 
 describe("pickFeeRate", () => {
   it("prefers a valid per-partner override over the default", () => {
@@ -78,10 +86,56 @@ describe("resolvePartnerFeeRate", () => {
     expect(r.fee_rate).toBe(PLATFORM_DEFAULT_FEE_BPS)
   })
 
-  it("never throws and ignores partnerId today (overrides deferred)", async () => {
+  it("uses the partner's onboarding commission_bps override over the default (#860)", async () => {
     process.env.PLATFORM_TX_FEE_BPS = "200"
-    const withPartner = await resolvePartnerFeeRate(null, { partnerId: "p_x" })
-    const without = await resolvePartnerFeeRate(null)
-    expect(withPartner).toEqual(without)
+    const container = containerWithProfile({ commission_bps: 1500 })
+    await expect(
+      resolvePartnerFeeRate(container, { partnerId: "p_artisan" })
+    ).resolves.toEqual({ fee_basis: "percentage", fee_rate: 1500 })
+  })
+
+  it("honours an explicit 0 bps override (fee-waived partner)", async () => {
+    process.env.PLATFORM_TX_FEE_BPS = "200"
+    const container = containerWithProfile({ commission_bps: 0 })
+    const r = await resolvePartnerFeeRate(container, { partnerId: "p_free" })
+    expect(r.fee_rate).toBe(0)
+  })
+
+  it("falls back to the default when the profile has no commission_bps", async () => {
+    process.env.PLATFORM_TX_FEE_BPS = "200"
+    const container = containerWithProfile({ commission_bps: null })
+    const r = await resolvePartnerFeeRate(container, { partnerId: "p_1" })
+    expect(r.fee_rate).toBe(PLATFORM_DEFAULT_FEE_BPS)
+  })
+
+  it("never throws when the container/module/profile is unavailable", async () => {
+    process.env.PLATFORM_TX_FEE_BPS = "200"
+    const withNullContainer = await resolvePartnerFeeRate(null, { partnerId: "p_x" })
+    const throwing = { resolve: () => { throw new Error("no module") } }
+    const withThrowingContainer = await resolvePartnerFeeRate(throwing, {
+      partnerId: "p_x",
+    })
+    expect(withNullContainer.fee_rate).toBe(PLATFORM_DEFAULT_FEE_BPS)
+    expect(withThrowingContainer.fee_rate).toBe(PLATFORM_DEFAULT_FEE_BPS)
+  })
+})
+
+describe("resolvePartnerCommissionOverrideBps", () => {
+  it("returns null without a partnerId (no lookup)", async () => {
+    await expect(resolvePartnerCommissionOverrideBps({}, null)).resolves.toBeNull()
+  })
+
+  it("returns the profile's commission_bps as a number", async () => {
+    const container = containerWithProfile({ commission_bps: "2500" })
+    await expect(
+      resolvePartnerCommissionOverrideBps(container, "p_1")
+    ).resolves.toBe(2500)
+  })
+
+  it("returns null when no profile exists", async () => {
+    const container = containerWithProfile(null)
+    await expect(
+      resolvePartnerCommissionOverrideBps(container, "p_1")
+    ).resolves.toBeNull()
   })
 })

--- a/apps/backend/src/modules/partner_billing/resolve-fee-rate.ts
+++ b/apps/backend/src/modules/partner_billing/resolve-fee-rate.ts
@@ -1,4 +1,5 @@
 import { parsePlatformFeeBps, type FeeBasis } from "./compute-fee"
+import { PARTNER_ONBOARDING_PROFILE_MODULE } from "../partner-onboarding-profile"
 
 /**
  * #336 Slice 1 — partner commission fee-rate resolution.
@@ -47,28 +48,56 @@ export function pickFeeRate(
 
 export type ResolvePartnerFeeRateOpts = {
   /**
-   * The partner the order is being accrued for. Reserved for the future
-   * per-partner override lookup; ignored today (overrides are a later slice).
+   * The partner the order is being accrued for. Used to look up a per-partner
+   * commission override (the agreed rate captured during onboarding).
    */
   partnerId?: string | null
 }
 
 /**
+ * The per-partner commission override, in basis points, or null.
+ *
+ * Source (#859 S1 / #860): the partner's onboarding profile `commission_bps`
+ * — the agreed revenue-share for a `core_channel_listing` artisan. Never
+ * throws: any resolution failure (missing module, no profile, bad value)
+ * falls back to null so the platform default applies and order placement is
+ * never broken. Exported for testing.
+ */
+export async function resolvePartnerCommissionOverrideBps(
+  container: any,
+  partnerId?: string | null
+): Promise<number | null> {
+  if (!partnerId) return null
+  try {
+    const service: any = container?.resolve?.(PARTNER_ONBOARDING_PROFILE_MODULE)
+    if (!service?.findByPartner) return null
+    const profile = await service.findByPartner(partnerId)
+    const bps = profile?.commission_bps
+    return bps == null ? null : Number(bps)
+  } catch {
+    return null
+  }
+}
+
+/**
  * Resolve the commission rate for a partner's order.
  *
- * Today: the platform default from `PLATFORM_TX_FEE_BPS` (200 = 2%), percentage
- * basis. Per-partner overrides are deferred (no `partner_fee_config` model yet);
- * when they land, query the override here and pass it to `pickFeeRate`.
+ * Precedence: the partner's onboarding-agreed `commission_bps` override →
+ * the platform default from `PLATFORM_TX_FEE_BPS` (200 = 2%), percentage basis.
+ * Best-effort: override lookup never throws (see
+ * `resolvePartnerCommissionOverrideBps`).
  */
 export async function resolvePartnerFeeRate(
-  _container: any,
-  _opts: ResolvePartnerFeeRateOpts = {}
+  container: any,
+  opts: ResolvePartnerFeeRateOpts = {}
 ): Promise<ResolvedFeeRate> {
   const defaultBps = parsePlatformFeeBps(
     process.env.PLATFORM_TX_FEE_BPS,
     PLATFORM_DEFAULT_FEE_BPS
   )
-  // Override resolution intentionally deferred (#336: "per-partner override later").
-  const overrideBps: number | null = null
+  const overrideBps = await resolvePartnerCommissionOverrideBps(
+    container,
+    opts.partnerId
+  )
   return pickFeeRate(overrideBps, defaultBps)
 }


### PR DESCRIPTION
Backend for **S1 of the artisan quasi-partner epic (#859)** — captures *how* a partner sells and their agreed commission during onboarding, and wires that commission into fee accrual.

## What
- **Model** `partner_onboarding_profile`: `selling_mode` enum (`dedicated_storefront` | `core_channel_listing`) + `commission_bps` (nullable int).
- **Migration** `Migration20260703170000`: hand-written `ADD COLUMN IF NOT EXISTS` (not editing the create migration — create-if-not-exists hazard).
- **Validators**: both fields added to `onboardingProfileUpdateSchema` (`commission_bps` 0..10000). Route already spreads `...data`, so no route change.
- **Fee wiring**: new never-throws `resolvePartnerCommissionOverrideBps` looks up the partner's onboarding `commission_bps` as the #336 per-partner override slot. Precedence: **onboarding override → `PLATFORM_TX_FEE_BPS` → 2% default**. The `order.placed` accrual subscriber already threads `partnerId` (`order-placed-accrue-fee.ts:71`), so zero call-site churn.

## Out of scope (later slices)
- Cross-listing onto the core channel + admin verify/approve (S2 / #861).
- The partner-ui "How you'll sell" wizard step — follow-up PR on this epic.

## Tests
- +11 unit: resolver override/fee-waived(0bps)/missing-profile/never-throws(null+throwing container), validator enum + range.
- +2 integration: PUT persists `selling_mode`+`commission_bps`; out-of-range → 400.
- **31 unit + 8 integration green** locally.

> Local note: these integration tests 401 if `PARTNER_EMAIL_VERIFICATION=true` is set locally (#858 opt-in flag returns an actorless token); green with it unset, as in CI.

Refs #859, #860