### PR TITLE
fix(shiprocket): real per-line SKU + colour identity for inventory shipments (#772/#817)

### DIFF
--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/create-shipment.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/create-shipment.unit.spec.ts
@@ -1,4 +1,4 @@
-import { ShiprocketClient } from "../client"
+import { ShiprocketClient, buildShiprocketOrderItems } from "../client"
 
 /**
  * #404 PR-B — ShiprocketClient.createShipment sequences create-adhoc-order →
@@ -76,5 +76,48 @@ describe("ShiprocketClient.createShipment (#404 PR-B)", () => {
       sr_order_id: 222,
       courier_company_id: 5,
     })
+  })
+})
+
+describe("buildShiprocketOrderItems (dedupe repeated SKUs)", () => {
+  it("merges rows sharing a SKU, summing units (Shiprocket rejects repeats)", () => {
+    const rows = buildShiprocketOrderItems([
+      { name: "Linen — Red", sku: "LIN-1", quantity: 3, unit_price: 50 },
+      { name: "Linen — Blue", sku: "LIN-1", quantity: 2, unit_price: 50 },
+    ])
+    expect(rows).toHaveLength(1)
+    expect(rows[0].sku).toBe("LIN-1")
+    expect(rows[0].units).toBe(5)
+    expect(rows[0].name).toBe("Linen — Red") // first row's name kept
+  })
+
+  it("falls back to the item name as SKU and merges name collisions", () => {
+    const rows = buildShiprocketOrderItems([
+      { name: "Handloom Cotton", quantity: 4, unit_price: 80 },
+      { name: "Handloom Cotton", quantity: 1, unit_price: 80 },
+    ])
+    expect(rows).toHaveLength(1)
+    expect(rows[0].sku).toBe("Handloom Cotton")
+    expect(rows[0].units).toBe(5)
+  })
+
+  it("keeps distinct SKUs separate and preserves order", () => {
+    const rows = buildShiprocketOrderItems([
+      { name: "A", sku: "A-1", quantity: 1, unit_price: 10 },
+      { name: "B", sku: "B-1", quantity: 2, unit_price: 20 },
+      { name: "A again", sku: "A-1", quantity: 3, unit_price: 10 },
+    ])
+    expect(rows.map((r) => r.sku)).toEqual(["A-1", "B-1"])
+    expect(rows[0].units).toBe(4)
+    expect(rows[1].units).toBe(2)
+  })
+
+  it("carries hsn/tax through and defaults them", () => {
+    const rows = buildShiprocketOrderItems([
+      { name: "X", sku: "X-1", quantity: 1, unit_price: 5, hsn: "5208", tax: 5 },
+      { name: "Y", sku: "Y-1", quantity: 1, unit_price: 5 },
+    ])
+    expect(rows[0]).toMatchObject({ hsn: "5208", tax: 5 })
+    expect(rows[1]).toMatchObject({ hsn: "", tax: "" })
   })
 })

--- a/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
@@ -18,6 +18,7 @@ import {
   RegisterPickupLocationInput,
   SchedulePickupInput,
   SchedulePickupResult,
+  ShipmentItem,
   ShipmentRef,
   ShipmentResult,
   ShippingProviderClient,
@@ -163,6 +164,54 @@ export function normalizePickupLocation(r: any): PickupLocation {
     pincode: r?.pin_code,
     raw: r,
   }
+}
+
+/** A Shiprocket adhoc-order `order_items[]` row. */
+export type ShiprocketOrderItem = {
+  name: string
+  sku: string
+  units: number
+  selling_price: number
+  hsn: string
+  tax: number | string
+}
+
+/**
+ * Build Shiprocket `order_items[]` from shipment items, aggregating rows that
+ * share an effective SKU.
+ *
+ * Shiprocket's `/orders/create/adhoc` rejects a payload with a repeated SKU
+ * ("SKU cannot be repeated"). Our lines can collide on SKU legitimately —
+ * e.g. #817 colour variants of one material, or blank-SKU lines that fall back
+ * to the same product name. We merge same-SKU rows (summing `units`) so each
+ * SKU appears once; per-item declared value stays consistent because the order
+ * `sub_total` is sent separately from the line prices. Blank SKUs fall back to
+ * the item name (mirroring the single-item mapping). Order is preserved.
+ *
+ * Pure & exported for unit testing.
+ */
+export function buildShiprocketOrderItems(
+  items: ShipmentItem[]
+): ShiprocketOrderItem[] {
+  const bySku = new Map<string, ShiprocketOrderItem>()
+  for (const i of items) {
+    const sku = (i.sku && String(i.sku).trim()) || i.name
+    const units = Number(i.quantity) || 0
+    const existing = bySku.get(sku)
+    if (existing) {
+      existing.units += units
+    } else {
+      bySku.set(sku, {
+        name: i.name,
+        sku,
+        units,
+        selling_price: i.unit_price,
+        hsn: i.hsn || "",
+        tax: i.tax ?? "",
+      })
+    }
+  }
+  return Array.from(bySku.values())
 }
 
 /** Shiprocket numeric shipment_status_id → coarse scan_type. */
@@ -334,14 +383,10 @@ export class ShiprocketClient implements ShippingProviderClient {
       billing_email: input.to.email || "",
       billing_phone: input.to.phone,
       shipping_is_billing: true,
-      order_items: input.items.map((i) => ({
-        name: i.name,
-        sku: i.sku || i.name,
-        units: i.quantity,
-        selling_price: i.unit_price,
-        hsn: i.hsn || "",
-        tax: i.tax ?? "",
-      })),
+      // Aggregate same-SKU lines — Shiprocket rejects a repeated SKU (#817
+      // colour variants / blank-SKU name collisions would otherwise 400 with
+      // "SKU cannot be repeated").
+      order_items: buildShiprocketOrderItems(input.items),
       payment_method: input.payment_mode === "cod" ? "COD" : "Prepaid",
       sub_total: subTotal,
       length: input.dimensions_cm?.length || 10,

--- a/apps/backend/src/workflows/inventory_orders/__tests__/inventory-order-shipment.unit.spec.ts
+++ b/apps/backend/src/workflows/inventory_orders/__tests__/inventory-order-shipment.unit.spec.ts
@@ -86,6 +86,38 @@ describe("buildInventoryOrderShipmentInput (#772)", () => {
   })
 })
 
+describe("buildInventoryOrderShipmentInput colour-variant identity (#817 / SKU-repeat fix)", () => {
+  // Mirrors the real order #68: 16 colour variants, no line/metadata SKU, but a
+  // real inventory_item SKU + material_name + colour on each line.
+  const colourOrder: InventoryOrderForShipment = {
+    id: "inv_1",
+    orderlines: [
+      { id: "l1", quantity: 2, price: 100, sku: "OTH-TAN-BLA-001", color: "Black", material_name: "Tangaliya Weave — Black" },
+      { id: "l2", quantity: 3, price: 100, sku: "OTH-TAN-MID-001", color: "midnight blue", material_name: "Tangaliya Weave — midnight blue" },
+      // A no-SKU line whose base name does NOT embed the colour — colour is appended.
+      { id: "l3", quantity: 1, price: 100, color: "Soft pale yellow", material_name: "Tangaliya Weave" },
+    ],
+  }
+
+  it("gives each colour variant a distinct sku + name (no repeats)", () => {
+    const input = buildInventoryOrderShipmentInput(colourOrder, {})
+    expect(input.items).toHaveLength(3)
+    expect(input.items.map((i) => i.sku)).toEqual([
+      "OTH-TAN-BLA-001",
+      "OTH-TAN-MID-001",
+      undefined, // falls back to the (distinct) name
+    ])
+    // base already embeds the colour → not appended twice
+    expect(input.items[0].name).toBe("Tangaliya Weave — Black")
+    expect(input.items[1].name).toBe("Tangaliya Weave — midnight blue")
+    // base has no colour → colour appended for distinctness
+    expect(input.items[2].name).toBe("Tangaliya Weave — Soft pale yellow")
+    // The effective carrier key (sku || name) is unique across all lines.
+    const effective = input.items.map((i) => i.sku || i.name)
+    expect(new Set(effective).size).toBe(input.items.length)
+  })
+})
+
 describe("resolveInventoryDestinationAddress (#772 to-location fill)", () => {
   const locAddress = {
     address_1: "9 Mill Rd",

--- a/apps/backend/src/workflows/inventory_orders/create-inventory-order-shipment.ts
+++ b/apps/backend/src/workflows/inventory_orders/create-inventory-order-shipment.ts
@@ -139,8 +139,34 @@ export async function createInventoryOrderShipment(
     )
   }
 
+  // Resolve each line's real inventory_item SKU (the line itself has no sku
+  // column). Without this, no-SKU lines collapse to one repeated fallback and
+  // Shiprocket 400s "SKU cannot be repeated"; with it, colour variants carry
+  // their true unique SKUs (e.g. OTH-TAN-BLA-001). Best-effort — the builder
+  // still distinguishes lines by material_name + colour if this lookup fails.
+  let orderlines: any[] = (order as any).orderlines || []
+  try {
+    const { data: rows } = await query.graph({
+      entity: "inventory_orders",
+      fields: ["orderlines.id", "orderlines.inventory_items.sku"],
+      filters: { id: order.id },
+    })
+    const skuByLine = new Map<string, string>()
+    for (const ol of rows?.[0]?.orderlines || []) {
+      const sku = (ol?.inventory_items || [])[0]?.sku
+      if (ol?.id && sku) skuByLine.set(String(ol.id), String(sku))
+    }
+    orderlines = orderlines.map((l) => ({
+      ...l,
+      sku: l.sku ?? skuByLine.get(String(l.id)) ?? null,
+    }))
+  } catch {
+    // best-effort — name-based distinctness (material_name + colour) still holds
+  }
+
   const orderForShipment = {
     ...(order as any),
+    orderlines,
     shipping_address: destinationAddress,
   }
 

--- a/apps/backend/src/workflows/inventory_orders/lib/inventory-order-shipment.ts
+++ b/apps/backend/src/workflows/inventory_orders/lib/inventory-order-shipment.ts
@@ -26,6 +26,13 @@ export type InventoryOrderLineForShipment = {
   quantity?: number | null
   price?: number | null
   metadata?: Record<string, any> | null
+  // #817 denormalized identity on the line (self-describing colour variants).
+  color?: string | null
+  material_name?: string | null
+  // The linked inventory_item's real SKU, resolved by the caller. This is the
+  // stable, unique identity the carrier manifest should key on — the line
+  // itself has no sku column.
+  sku?: string | null
 }
 
 export type InventoryOrderForShipment = {
@@ -54,7 +61,32 @@ export type BuildInventoryShipmentOpts = {
 
 const lineName = (l: InventoryOrderLineForShipment): string => {
   const m = l.metadata || {}
-  return (m.title || m.name || m.description || m.sku || "Inventory item") as string
+  const base = (m.title ||
+    m.name ||
+    m.description ||
+    l.material_name ||
+    m.sku ||
+    l.sku ||
+    "Inventory item") as string
+  // Append the colour so colour variants of one material are distinguishable on
+  // the manifest (and don't collapse to the same effective SKU). Skip it when
+  // the base already embeds the colour (material_name often does, e.g.
+  // "Tangaliya Weave — midnight blue"). (#817)
+  const color = l.color ? String(l.color).trim() : ""
+  if (!color || base.toLowerCase().includes(color.toLowerCase())) return base
+  return `${base} — ${color}`
+}
+
+/**
+ * The line's effective carrier SKU: the resolved inventory_item SKU → an
+ * explicit metadata.sku → undefined (the client then falls back to the name,
+ * which carries material + colour so it stays distinct). The #817 model keeps
+ * colour at the inventory_item grain, so these SKUs are already unique per
+ * colour; any genuine repeat is merged by `buildShiprocketOrderItems`. (#817)
+ */
+const lineSku = (l: InventoryOrderLineForShipment): string | undefined => {
+  const explicit = l.sku || l.metadata?.sku
+  return explicit ? String(explicit) : undefined
 }
 
 /** Canonical destination-address fields Shiprocket's adhoc order needs. */
@@ -139,7 +171,7 @@ export function buildInventoryOrderShipmentInput(
       const quantity = Number(delivered ?? l.quantity) || 0
       return {
         name: lineName(l),
-        sku: (l.metadata?.sku as string) || undefined,
+        sku: lineSku(l),
         quantity,
         unit_price: Number(l.price) || 0,
       }


### PR DESCRIPTION
## Root cause (verified against prod order #68)
`inv_order_01KWAKAZE…` has **16 Tangaliya Weave colour variants**. Every line has **no SKU** (`variant_sku=None`, `metadata.sku=None`) — but each line's linked `inventory_item` has a **real unique SKU** (`OTH-TAN-BLA-001`, `OTH-TAN-MID-001`, …) plus `material_name` + `color`, one hop away.

The old shipment builder read only `metadata.sku` (unset) and `metadata.title` (unset), so all 16 lines collapsed to the fallback name **"Inventory item"** → the client sent the same SKU 16× → Shiprocket 400 **"SKU cannot be repeated."**

```
OLD effective SKU:  1 distinct of 16   ({'Inventory item': 16})
NEW effective SKU: 16 distinct of 16   (no dups)
```

## Fix (three layers)
1. **Builder** (`lib/inventory-order-shipment.ts`): item name from `material_name` + `color` (colour appended only when the base doesn't already embed it, so no "… — blue — blue"); SKU from the resolved `inventory_item` SKU / `metadata.sku`.
2. **Workflow** (`create-inventory-order-shipment.ts`): resolve each line's `inventory_item.sku` via `query.graph` and pass it + `color`/`material_name` into the builder (best-effort — name-based distinctness still holds if it fails).
3. **Client** (`shiprocket/client.ts`): `buildShiprocketOrderItems` aggregates any genuinely-repeated SKU (summing units) as a final safety net — covers both core and inventory paths.

## Tests
+9 unit (colour-variant identity mirroring order #68, SKU dedupe merge/fallback/order/hsn-tax). **14 unit green.**

Follows the destination-address fix (#864). Refs #772, #817.