### PR TITLE
fix(#858): backfill partner email-verification + login 'not verified' UI

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-partner-email-verified.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-partner-email-verified.unit.spec.ts
@@ -1,0 +1,40 @@
+import {
+  decidePartnerVerifyAction,
+  backfillPartnerEmailVerifiedJob,
+} from "../backfill-partner-email-verified-job"
+
+/**
+ * Unit test — decidePartnerVerifyAction (#858 tail backfill).
+ * Pure decision: skip already-verified, set verified_at on requested rows,
+ * create a verified row when none exists. No DI, no DB.
+ */
+describe("decidePartnerVerifyAction", () => {
+  it("skips an already-verified identity (row has verified_at)", () => {
+    expect(decidePartnerVerifyAction({ verified_at: new Date() })).toBe(
+      "already_verified"
+    )
+    expect(
+      decidePartnerVerifyAction({ verified_at: "2026-01-01T00:00:00Z" })
+    ).toBe("already_verified")
+  })
+
+  it("updates a requested-but-unconfirmed row (verified_at null/absent)", () => {
+    expect(decidePartnerVerifyAction({ verified_at: null })).toBe("update")
+    expect(decidePartnerVerifyAction({})).toBe("update")
+  })
+
+  it("creates a verified row when there is no verification yet", () => {
+    expect(decidePartnerVerifyAction(undefined)).toBe("create")
+    expect(decidePartnerVerifyAction(null)).toBe("create")
+  })
+})
+
+describe("backfillPartnerEmailVerifiedJob metadata", () => {
+  it("is registered with the expected id + params", () => {
+    expect(backfillPartnerEmailVerifiedJob.id).toBe(
+      "backfill-partner-email-verified"
+    )
+    const names = backfillPartnerEmailVerifiedJob.params.map((p) => p.name)
+    expect(names).toEqual(expect.arrayContaining(["partner_id", "limit"]))
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-partner-email-verified-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-partner-email-verified-job.ts
@@ -1,0 +1,234 @@
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import type {
+  MaintenanceChange,
+  MaintenanceJob,
+  MaintenanceJobResult,
+} from "./registry"
+
+/**
+ * #858 tail — backfill email-verification for partners created BEFORE
+ * `PARTNER_EMAIL_VERIFICATION` was switched on.
+ *
+ * Native Medusa 2.16+ email verification (`authVerificationsPerActor`) blocks
+ * login when no `auth_verification` row for the partner's email has a
+ * `verified_at` (see `@medusajs/medusa/.../auth/utils/generate-jwt-token.js`:
+ * `if (requiresVerification && !verification?.verified_at)`). Partners created
+ * before the flag was enabled never went through the verify flow, so their
+ * login now returns `{ verification_required: true }` with an actorless token
+ * and they are locked out.
+ *
+ * This marks each existing partner's emailpass identity verified by upserting a
+ * verified `auth_verification` row (create when missing, set `verified_at` when
+ * a requested-but-unconfirmed row already exists). There is NO native admin API
+ * for this — the only native mutation is `confirmAuthVerification(code)`, which
+ * needs the emailed code — so a guarded Data Plumbing job (dry-run → apply,
+ * audited, UI-runnable) is the correct backfill surface.
+ *
+ * Idempotent: an already-verified identity is skipped. Scope to one partner via
+ * `partner_id`, or process all (capped by `limit`).
+ */
+
+/** Hard cap on partner identities processed in one call. */
+export const MAX_PARTNER_VERIFY_SCAN = 5000
+
+const paramsSchema = z.object({
+  /** Restrict to a single partner (its app_metadata.partner_id). */
+  partner_id: z.string().min(1).optional(),
+  /** Max partner identities to process in one call. */
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_PARTNER_VERIFY_SCAN)
+    .optional()
+    .default(1000),
+})
+
+export type PartnerVerifyAction = "already_verified" | "create" | "update"
+
+/**
+ * PURE: decide what to do for one partner identity given its existing
+ * emailpass `auth_verification` row (or undefined). Exported for unit testing.
+ *   - a row with `verified_at`  → already verified, nothing to do
+ *   - a row without `verified_at` (requested-but-unconfirmed) → set verified_at
+ *   - no row at all → create a verified row
+ */
+export function decidePartnerVerifyAction(
+  existing: { verified_at?: Date | string | null } | undefined | null
+): PartnerVerifyAction {
+  if (existing && existing.verified_at) return "already_verified"
+  if (existing) return "update"
+  return "create"
+}
+
+/**
+ * The entity_type the login check keys on, read from the same config the check
+ * reads (`authVerificationsPerActor.partner`). Falls back to "email".
+ */
+function partnerVerificationEntityType(container: any): string {
+  try {
+    const config = container.resolve(ContainerRegistrationKeys.CONFIG_MODULE)
+    const forPartner =
+      config?.projectConfig?.http?.authVerificationsPerActor?.partner
+    const emailpass = (forPartner || []).find(
+      (v: any) => v?.auth_provider === "emailpass"
+    )
+    return emailpass?.entity_type || "email"
+  } catch {
+    return "email"
+  }
+}
+
+export const backfillPartnerEmailVerifiedJob: MaintenanceJob = {
+  id: "backfill-partner-email-verified",
+  label: "Backfill partner email verification",
+  description:
+    `Mark existing partners' emails verified so they can log in after PARTNER_EMAIL_VERIFICATION was enabled. Partners created before the flag never verified, so their login now returns verification_required and they are locked out. Upserts a verified auth_verification row per partner emailpass identity (create if missing, set verified_at if requested-but-unconfirmed). Idempotent — already-verified identities are skipped. Dry-run lists who WOULD be verified without persisting; apply writes verified_at. Optionally scope to one partner_id. Processes up to 'limit' partner identities per call (default 1000, max ${MAX_PARTNER_VERIFY_SCAN}).`,
+  params: [
+    {
+      name: "partner_id",
+      type: "string",
+      required: false,
+      description: "Restrict to a single partner (default: all partners)",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max partner identities to process per call (default 1000, max ${MAX_PARTNER_VERIFY_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { partner_id, limit } = parsed.data
+
+    const authModule: any = container.resolve(Modules.AUTH)
+    const entityType = partnerVerificationEntityType(container)
+
+    // All auth identities carry app_metadata (the actor pointer) +
+    // provider_identities. Partner identities are those with a partner_id in
+    // app_metadata and an emailpass provider identity (entity_id = email).
+    const identities = await authModule.listAuthIdentities(
+      {},
+      { relations: ["provider_identities"] }
+    )
+
+    let partnerIdentities = (identities || []).filter((ai: any) => {
+      const pid = ai?.app_metadata?.partner_id
+      if (!pid) return false
+      if (partner_id && pid !== partner_id) return false
+      return (ai.provider_identities || []).some(
+        (p: any) => p?.provider === "emailpass"
+      )
+    })
+
+    const totalPartnerIdentities = partnerIdentities.length
+    partnerIdentities = partnerIdentities.slice(0, limit)
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    let verified = 0
+    let alreadyVerified = 0
+    let noEmail = 0
+    const now = new Date()
+
+    for (const ai of partnerIdentities) {
+      const pid = ai.app_metadata.partner_id
+      const emailpass = (ai.provider_identities || []).find(
+        (p: any) => p?.provider === "emailpass"
+      )
+      const email = emailpass?.entity_id
+      if (!email) {
+        noEmail++
+        continue
+      }
+
+      let existing: any
+      try {
+        const rows = await authModule.listAuthVerifications({
+          auth_identity_id: ai.id,
+          entity_id: email,
+          entity_type: entityType,
+        })
+        existing = rows?.[0]
+      } catch (e: any) {
+        errors.push({ id: pid, message: e?.message ?? String(e) })
+        continue
+      }
+
+      const action = decidePartnerVerifyAction(existing)
+      if (action === "already_verified") {
+        alreadyVerified++
+        continue
+      }
+
+      changes.push({
+        entity: "partner",
+        id: pid,
+        field: "email_verified",
+        before: action === "update" ? "requested (unconfirmed)" : "not verified",
+        after: `verified (${email})`,
+      })
+
+      if (dry_run) {
+        verified++
+        continue
+      }
+
+      try {
+        if (action === "update") {
+          await authModule.updateAuthVerifications({
+            id: existing.id,
+            verified_at: now,
+          })
+        } else {
+          await authModule.createAuthVerifications([
+            {
+              auth_identity_id: ai.id,
+              entity_id: email,
+              entity_type: entityType,
+              code_provider: "emailpass",
+              requested_at: now,
+              verified_at: now,
+            },
+          ])
+        }
+        verified++
+      } catch (e: any) {
+        errors.push({ id: pid, message: e?.message ?? String(e) })
+      }
+    }
+
+    const verb = dry_run ? "Would verify" : "Verified"
+    const capped =
+      totalPartnerIdentities > partnerIdentities.length
+        ? ` (capped at ${limit} of ${totalPartnerIdentities} — re-run to continue)`
+        : ""
+    const summary = `${verb} ${verified} partner identity(ies); ${alreadyVerified} already verified, ${noEmail} without an emailpass email${
+      errors.length ? `, ${errors.length} error(s)` : ""
+    }${capped}.`
+
+    return {
+      job_id: backfillPartnerEmailVerifiedJob.id,
+      dry_run,
+      applied: !dry_run && verified > 0,
+      summary,
+      changes,
+      errors,
+    }
+  },
+}
+
+export default backfillPartnerEmailVerifiedJob

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -72,6 +72,7 @@ import {
 import { seedEmailTemplatesJob } from "./seed-jobs"
 import { replayFxFanoutJob } from "./fanout-fx-job"
 import { backfillStoreCurrenciesJob } from "./backfill-store-currencies-job"
+import { backfillPartnerEmailVerifiedJob } from "./backfill-partner-email-verified-job"
 import {
   sweepAiPlatformsByCategory,
   AI_ROLES,
@@ -5270,6 +5271,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   reconcileInventoryMirrorJob,
   replayFxFanoutJob,
   backfillStoreCurrenciesJob,
+  backfillPartnerEmailVerifiedJob,
 ]
 
 export const getMaintenanceJob = (id: string): MaintenanceJob | undefined =>

--- a/apps/partner-ui/src/hooks/api/auth.tsx
+++ b/apps/partner-ui/src/hooks/api/auth.tsx
@@ -2,22 +2,67 @@ import { FetchError } from "@medusajs/js-sdk"
 import { HttpTypes } from "@medusajs/types"
 import { UseMutationOptions, useMutation } from "@tanstack/react-query"
 import { sdk } from "../../lib/client"
+import {
+  getTokenFromResponse,
+  isVerificationRequired,
+  resendPartnerVerification,
+} from "../../lib/partner-verification"
+
+export type SignInResult = {
+  /** True when the partner's email isn't verified — login is gated (2.16+). */
+  verificationRequired: boolean
+  /** Echoed back so the UI can show "we emailed <email>" / resend. */
+  email: string
+}
 
 export const useSignInWithEmailPass = (
   options?: UseMutationOptions<
-    | string
-    | {
-        location: string
-      },
+    SignInResult,
     FetchError,
     HttpTypes.AdminSignUpWithEmailPassword
   >
 ) => {
   return useMutation({
-    mutationFn: (payload) => sdk.auth.login("partner", "emailpass", payload),
+    // Raw login fetch (not sdk.auth.login) so we can see `verification_required`
+    // — the SDK swallows it, sets the actorless token, and returns it, which
+    // would let an unverified partner "log in" then break. We only persist the
+    // token when the email IS verified.
+    mutationFn: async (payload) => {
+      const res = await sdk.client.fetch<any>("/auth/partner/emailpass", {
+        method: "POST",
+        body: payload,
+      })
+      if (isVerificationRequired(res)) {
+        return { verificationRequired: true, email: (payload as any).email }
+      }
+      const token = getTokenFromResponse(res)
+      if (token) {
+        await sdk.client.setToken(token)
+      }
+      return { verificationRequired: false, email: (payload as any).email }
+    },
     onSuccess: async (data, variables, context) => {
       options?.onSuccess?.(data, variables, context)
     },
+    ...options,
+  })
+}
+
+/**
+ * Resend the verification email for an unverified partner. Re-logs-in to mint a
+ * fresh actorless token, then requests a new code (see `resendPartnerVerification`).
+ * Returns false when the identity is already verified (the user can just sign in).
+ */
+export const useResendPartnerVerification = (
+  options?: UseMutationOptions<
+    boolean,
+    FetchError,
+    { email: string; password: string }
+  >
+) => {
+  return useMutation({
+    mutationFn: ({ email, password }) =>
+      resendPartnerVerification(email, password),
     ...options,
   })
 }

--- a/apps/partner-ui/src/routes/login/login.tsx
+++ b/apps/partner-ui/src/routes/login/login.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod"
-import { Alert, Button, Heading, Hint, Input, Text } from "@medusajs/ui"
+import { Alert, Button, Heading, Hint, Input, Text, toast } from "@medusajs/ui"
+import { useState } from "react"
 import { useForm } from "react-hook-form"
 import { Trans, useTranslation } from "react-i18next"
 import { Link, useLocation, useNavigate } from "react-router-dom"
@@ -7,7 +8,10 @@ import { z as z } from "@medusajs/framework/zod"
 
 import { Form } from "../../components/common/form"
 import AvatarBox from "../../components/common/logo-box/avatar-box"
-import { useSignInWithEmailPass } from "../../hooks/api"
+import {
+  useResendPartnerVerification,
+  useSignInWithEmailPass,
+} from "../../hooks/api"
 import { isFetchError } from "../../lib/is-fetch-error"
 import { useExtension } from "../../providers/extension-provider"
 
@@ -33,6 +37,16 @@ export const Login = () => {
   })
 
   const { mutateAsync, isPending } = useSignInWithEmailPass()
+  const { mutateAsync: resend, isPending: isResending } =
+    useResendPartnerVerification()
+
+  // When set, the partner's email isn't verified yet — we show the
+  // "verify your email" panel instead of the sign-in form. The password is
+  // kept so "Resend" can mint a fresh actorless token.
+  const [unverified, setUnverified] = useState<{
+    email: string
+    password: string
+  } | null>(null)
 
   const handleSubmit = form.handleSubmit(async ({ email, password }) => {
     await mutateAsync(
@@ -58,12 +72,34 @@ export const Login = () => {
             message: error.message,
           })
         },
-        onSuccess: () => {
+        onSuccess: (data) => {
+          if (data.verificationRequired) {
+            setUnverified({ email, password })
+            return
+          }
           navigate(from, { replace: true })
         },
       }
     )
   })
+
+  const handleResend = async () => {
+    if (!unverified) return
+    try {
+      const stillRequired = await resend(unverified)
+      if (stillRequired) {
+        toast.success(
+          `Verification link sent to ${unverified.email}. Check your inbox.`
+        )
+      } else {
+        // The identity is already verified — login no longer gates.
+        toast.success("Your email is verified — you can sign in now.")
+        setUnverified(null)
+      }
+    } catch {
+      toast.error("Couldn't resend the verification email. Please try again.")
+    }
+  }
 
   const serverError = form.formState.errors?.root?.serverError?.message
   const validationError =
@@ -80,6 +116,42 @@ export const Login = () => {
             {t("login.hint")}
           </Text>
         </div>
+        {unverified ? (
+          <div className="flex w-full flex-col gap-y-4">
+            <Alert variant="warning" className="items-start p-3">
+              <div className="flex flex-col gap-y-1">
+                <Text size="small" weight="plus">
+                  Your email isn't verified yet
+                </Text>
+                <Text size="small" className="text-ui-fg-subtle">
+                  We sent a verification link to{" "}
+                  <span className="text-ui-fg-base font-medium">
+                    {unverified.email}
+                  </span>
+                  . Open it to finish signing in, or resend it below.
+                </Text>
+              </div>
+            </Alert>
+            <Button
+              className="w-full"
+              variant="secondary"
+              onClick={handleResend}
+              isLoading={isResending}
+            >
+              Resend verification email
+            </Button>
+            <Button
+              className="w-full"
+              variant="transparent"
+              onClick={() => setUnverified(null)}
+            >
+              Back to sign in
+            </Button>
+            <Text size="xsmall" className="text-ui-fg-muted text-center">
+              Already clicked the link? Just sign in again.
+            </Text>
+          </div>
+        ) : (
         <div className="flex w-full flex-col gap-y-3">
           {getWidgets("login.before").map((Component, i) => {
             return <Component key={i} />
@@ -154,6 +226,7 @@ export const Login = () => {
             return <Component key={i} />
           })}
         </div>
+        )}
         <div className="text-ui-fg-muted txt-small my-6 flex w-full flex-col items-center gap-y-3">
           <Trans
             i18nKey="login.forgotPassword"


### PR DESCRIPTION
## Problem
Turning on `PARTNER_EMAIL_VERIFICATION` locked out **existing** partners. They were created before verification existed, so they were never verified — native Medusa login now returns `{ verification_required: true }` with an *actorless* token (`actor_id: ""`), and they can't reach any `/partners/*` route. Root: `@medusajs/medusa/.../auth/utils/generate-jwt-token.js` blocks when no `auth_verification` row for the email has `verified_at`.

## Backend — Data Plumbing backfill (`backfill-partner-email-verified`)
Marks existing partners verified. Enumerates partner auth identities (`app_metadata.partner_id` + emailpass provider identity) and **upserts a verified `auth_verification` row** per identity — create when missing, set `verified_at` when a requested-but-unconfirmed row exists. Idempotent; dry-run previews; optional `partner_id` scope; capped by `limit`.

There's **no native admin API** for this (only `confirmAuthVerification(code)`, which needs the emailed code), so a guarded #457 job is the right surface — per the backfills-via-Data-Plumbing rule.

**Verified end-to-end** (`medusa exec`, local DB): dry-run found 4, apply verified **4 / 0 errors**, re-run → **4 already-verified** (idempotent).

## Partner-ui — surface the state instead of silently breaking
`sdk.auth.login` swallows `verification_required` (it sets the actorless token and returns it — so an unverified partner "logs in" then breaks). Now:
- `useSignInWithEmailPass` raw-fetches login, detects `verification_required`, and **only persists the token when the email is verified**.
- The login page shows a **"Your email isn't verified"** panel with a **Resend verification email** button + "check your email" guidance (reuses the #858 `partner-verification` lib).

## Tests
+4 unit (pure `decidePartnerVerifyAction` + job metadata). tsc + vite build green.

## Prod runbook after deploy
Run **Settings → Data Plumbing → "Backfill partner email verification"**: dry-run to preview, then apply. Existing partners can log in again; new partners still verify normally.

Refs #858.