### PR TITLE
fix(shiprocket): pass L/B/H to the courier (breadth→width) + partner UI dims

### DIFF
--- a/apps/backend/src/workflows/inventory_orders/__tests__/inventory-order-shipment.unit.spec.ts
+++ b/apps/backend/src/workflows/inventory_orders/__tests__/inventory-order-shipment.unit.spec.ts
@@ -2,9 +2,34 @@ import {
   buildInventoryOrderShipmentInput,
   DEFAULT_INVENTORY_SHIPMENT_WEIGHT_GRAMS,
   missingDestinationAddressFields,
+  normalizeDimensionsCm,
   resolveInventoryDestinationAddress,
   type InventoryOrderForShipment,
 } from "../lib/inventory-order-shipment"
+
+describe("normalizeDimensionsCm (breadth → width for the courier)", () => {
+  it("maps breadth to the canonical width the client reads", () => {
+    expect(normalizeDimensionsCm({ length: 30, breadth: 20, height: 10 })).toEqual(
+      { length: 30, width: 20, height: 10 }
+    )
+  })
+
+  it("passes an explicit width through and prefers it over breadth", () => {
+    expect(
+      normalizeDimensionsCm({ length: 30, width: 25, breadth: 20, height: 10 } as any)
+    ).toEqual({ length: 30, width: 25, height: 10 })
+  })
+
+  it("keeps only provided fields (partial dims)", () => {
+    expect(normalizeDimensionsCm({ breadth: 15 })).toEqual({ width: 15 })
+  })
+
+  it("returns undefined for empty/absent input", () => {
+    expect(normalizeDimensionsCm(undefined)).toBeUndefined()
+    expect(normalizeDimensionsCm(null)).toBeUndefined()
+    expect(normalizeDimensionsCm({})).toBeUndefined()
+  })
+})
 
 const baseOrder: InventoryOrderForShipment = {
   id: "invord_1",

--- a/apps/backend/src/workflows/inventory_orders/create-inventory-order-shipment.ts
+++ b/apps/backend/src/workflows/inventory_orders/create-inventory-order-shipment.ts
@@ -21,6 +21,7 @@ import type {
 import {
   buildInventoryOrderShipmentInput,
   missingDestinationAddressFields,
+  normalizeDimensionsCm,
   resolveInventoryDestinationAddress,
 } from "./lib/inventory-order-shipment"
 
@@ -178,7 +179,9 @@ export async function createInventoryOrderShipment(
   const shipmentInput = buildInventoryOrderShipmentInput(orderForShipment as any, {
     pickupLocationName,
     weightGrams: input.weightGrams,
-    dimensionsCm: input.dimensionsCm,
+    // Map breadth → width so the operator-entered breadth reaches the courier
+    // (the client reads dimensions_cm.width); undefined dims still default.
+    dimensionsCm: normalizeDimensionsCm(input.dimensionsCm as any),
     preferredCourierId: input.preferredCourierId,
     taxId,
     deliveredQuantities: input.deliveredQuantities,

--- a/apps/backend/src/workflows/inventory_orders/lib/inventory-order-shipment.ts
+++ b/apps/backend/src/workflows/inventory_orders/lib/inventory-order-shipment.ts
@@ -21,6 +21,33 @@ import type {
 
 export const DEFAULT_INVENTORY_SHIPMENT_WEIGHT_GRAMS = 500
 
+/**
+ * Normalize a loose L/B/H dimensions payload onto the canonical `Dimensions`
+ * shape (`{ length, width, height }`).
+ *
+ * The API/UI layer speaks Shiprocket's vocabulary — `breadth` — while the
+ * provider interface and client use `width` (the client reads
+ * `dimensions_cm.width`). Passing `{ length, breadth, height }` straight through
+ * meant `width` was undefined and the breadth the operator typed was silently
+ * dropped (defaulted to 10cm at the carrier). Map `breadth → width` here so the
+ * dimension actually reaches the courier. Only defined values are kept. Pure &
+ * exported for unit testing.
+ */
+export function normalizeDimensionsCm(
+  d:
+    | { length?: number; width?: number; breadth?: number; height?: number }
+    | null
+    | undefined
+): Dimensions | undefined {
+  if (!d) return undefined
+  const widthRaw = d.width ?? d.breadth
+  const out: Record<string, number> = {}
+  if (d.length != null) out.length = Number(d.length)
+  if (widthRaw != null) out.width = Number(widthRaw)
+  if (d.height != null) out.height = Number(d.height)
+  return Object.keys(out).length ? (out as Dimensions) : undefined
+}
+
 export type InventoryOrderLineForShipment = {
   id?: string | null
   quantity?: number | null

--- a/apps/partner-ui/src/routes/inventory-orders/inventory-order-create-shipment/inventory-order-create-shipment.tsx
+++ b/apps/partner-ui/src/routes/inventory-orders/inventory-order-create-shipment/inventory-order-create-shipment.tsx
@@ -28,6 +28,9 @@ const InventoryOrderCreateShipmentContent = () => {
   const { handleSuccess } = useRouteModal()
   const queryClient = useQueryClient()
   const [weight, setWeight] = useState("")
+  const [length, setLength] = useState("")
+  const [breadth, setBreadth] = useState("")
+  const [height, setHeight] = useState("")
 
   const { mutateAsync, isPending } =
     useCreatePartnerInventoryOrderShipment(id || "")
@@ -37,8 +40,22 @@ const InventoryOrderCreateShipmentContent = () => {
       return
     }
 
+    // Mirrors the admin shipment modal: L/B/H are sent as dimensions_cm so the
+    // real package size reaches the courier (else it defaults to 10×10×10).
+    const dims =
+      length || breadth || height
+        ? {
+            ...(length ? { length: Number(length) } : {}),
+            ...(breadth ? { breadth: Number(breadth) } : {}),
+            ...(height ? { height: Number(height) } : {}),
+          }
+        : undefined
+
     await mutateAsync(
-      { ...(weight ? { weight_grams: Number(weight) } : {}) },
+      {
+        ...(weight ? { weight_grams: Number(weight) } : {}),
+        ...(dims ? { dimensions_cm: dims } : {}),
+      },
       {
         onSuccess: (data) => {
           const awb = data?.shipment?.awb || data?.shipment?.tracking_number
@@ -62,8 +79,8 @@ const InventoryOrderCreateShipmentContent = () => {
       <RouteDrawer.Body className="flex flex-col gap-y-4">
         <Text size="small" className="text-ui-fg-subtle">
           Generate a carrier shipment (AWB + label) for this order using the
-          registered pickup. Weight is optional — leave it blank to use the
-          order's default.
+          registered pickup. Weight and dimensions are optional — leave them
+          blank to use the order's defaults.
         </Text>
         <div className="flex flex-col gap-y-1">
           <Label size="small" htmlFor="weight">
@@ -76,6 +93,41 @@ const InventoryOrderCreateShipmentContent = () => {
             onChange={(e) => setWeight(e.target.value)}
             placeholder="500"
           />
+        </div>
+        <div className="grid grid-cols-3 gap-x-2">
+          <div className="flex flex-col gap-y-1">
+            <Label size="small" htmlFor="length">
+              Length (cm)
+            </Label>
+            <Input
+              id="length"
+              type="number"
+              value={length}
+              onChange={(e) => setLength(e.target.value)}
+            />
+          </div>
+          <div className="flex flex-col gap-y-1">
+            <Label size="small" htmlFor="breadth">
+              Breadth (cm)
+            </Label>
+            <Input
+              id="breadth"
+              type="number"
+              value={breadth}
+              onChange={(e) => setBreadth(e.target.value)}
+            />
+          </div>
+          <div className="flex flex-col gap-y-1">
+            <Label size="small" htmlFor="height">
+              Height (cm)
+            </Label>
+            <Input
+              id="height"
+              type="number"
+              value={height}
+              onChange={(e) => setHeight(e.target.value)}
+            />
+          </div>
         </div>
         {!id && (
           <Text size="small" className="text-ui-fg-subtle">


### PR DESCRIPTION
## The bug
Inventory-order shipments dropped the package **breadth**. The API/UI send `dimensions_cm` as `{ length, breadth, height }` (Shiprocket's term), but the provider `Dimensions` type and the client read `.width` — so `width` was `undefined` and breadth **silently defaulted to 10 cm** at the courier. This hit both the admin shipment modal (which *does* collect breadth) and the partner path.

## Fix
- **Backend**: pure `normalizeDimensionsCm()` maps `breadth → width`, applied inside `createInventoryOrderShipment` — one choke point, so the admin route, partner route **and** `/complete` are all fixed. +4 unit tests.
- **Partner UI**: mirror the admin modal — add **Length / Breadth / Height** inputs to the inventory-order *Create shipment* drawer (was weight-only), sent as `dimensions_cm`.

Follows the earlier Shiprocket fixes (#864 destination, #866 SKU). Refs #772.