### PR TITLE
chore(build): silence non-fatal prod-build TS diagnostics

### DIFF
--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -14,12 +14,16 @@ module.exports = defineConfig({
       cookieSecret: process.env.COOKIE_SECRET || "supersecret",
       // Require email verification for partners registering with emailpass.
       // Opt-in via PARTNER_EMAIL_VERIFICATION=true. See medusa-config.ts.
-      authVerificationsPerActor: {
-        partner:
-          process.env.PARTNER_EMAIL_VERIFICATION === "true"
-            ? [{ entity_type: "email", auth_provider: "emailpass" }]
-            : [],
-      },
+      // Spread a cast object so the key doesn't trip the excess-property check
+      // on older @medusajs/types (prod build version drift); runtime unchanged.
+      ...({
+        authVerificationsPerActor: {
+          partner:
+            process.env.PARTNER_EMAIL_VERIFICATION === "true"
+              ? [{ entity_type: "email", auth_provider: "emailpass" }]
+              : [],
+        },
+      } as any),
     },
     redisUrl: process.env.REDIS_URL,
     workerMode: process.env.MEDUSA_WORKER_MODE as "shared" | "worker" | "server",

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -23,12 +23,18 @@ module.exports = defineConfig({
       // can't reach `/partners/*` until they verify. Left OFF by default so the
       // existing partner test suite (which never verifies) is unaffected; set
       // PARTNER_EMAIL_VERIFICATION=true in dev/prod to switch it on.
-      authVerificationsPerActor: {
-        partner:
-          process.env.PARTNER_EMAIL_VERIFICATION === "true"
-            ? [{ entity_type: "email", auth_provider: "emailpass" }]
-            : [],
-      },
+      // Spread a cast object so the extra key doesn't trip the excess-property
+      // check on @medusajs/types versions that predate authVerificationsPerActor
+      // (the prod build resolves an older type than local 2.17.1). Runtime is
+      // unchanged — validate-verification reads projectConfig.http.authVerificationsPerActor.
+      ...({
+        authVerificationsPerActor: {
+          partner:
+            process.env.PARTNER_EMAIL_VERIFICATION === "true"
+              ? [{ entity_type: "email", auth_provider: "emailpass" }]
+              : [],
+        },
+      } as any),
     },
     //redisUrl: process.env.REDIS_URL,
     //workerMode: process.env.MEDUSA_WORKER_MODE as "shared" | "worker" | "server",

--- a/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/create-inventory-orders.ts
@@ -77,7 +77,7 @@ export const createInventoryOrderWithLinesStep = createStep(
         new Set(orderLinesForService.map((l) => l.inventory_id).filter(Boolean))
       );
       if (inventoryItemIds.length) {
-        const query = container.resolve(ContainerRegistrationKeys.QUERY);
+        const query: any = container.resolve(ContainerRegistrationKeys.QUERY);
         const { data: inventoryItems } = await query.graph({
           entity: "inventory_item",
           fields: ["id", "raw_materials.id", "raw_materials.color", "raw_materials.name"],

--- a/apps/backend/src/workflows/inventory_orders/inventory-order-steps.ts
+++ b/apps/backend/src/workflows/inventory_orders/inventory-order-steps.ts
@@ -21,7 +21,7 @@ export const setInventoryOrderStepSuccessStep = createStep(
         { stepId, updatedOrder }: SetInventoryOrderStepSuccessInput,
         { container, context }
     ) {
-        const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+        const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
         const engineService = container.resolve(
             Modules.WORKFLOW_ENGINE
         ) as IWorkflowEngineService
@@ -89,7 +89,7 @@ export const setInventoryOrderStepFailedStep = createStep(
         { stepId, updatedOrder, error }: SetInventoryOrderStepFailedInput,
         { container }
     ) {
-        const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+        const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
         const engineService = container.resolve(
             Modules.WORKFLOW_ENGINE
         ) as IWorkflowEngineService

--- a/apps/backend/src/workflows/inventory_orders/update-inventory-orders.ts
+++ b/apps/backend/src/workflows/inventory_orders/update-inventory-orders.ts
@@ -128,7 +128,7 @@ export const updateOrderLinesStep = createStep(
           .map((l) => l.inventory_item_id as string)
       ));
       if (newItemIds.length) {
-        const query = container.resolve(ContainerRegistrationKeys.QUERY);
+        const query: any = container.resolve(ContainerRegistrationKeys.QUERY);
         const { data: inventoryItems } = await query.graph({
           entity: "inventory_item",
           fields: ["id", "raw_materials.id", "raw_materials.color", "raw_materials.name"],
@@ -273,7 +273,7 @@ export const updateOrderLinesStep = createStep(
 export const loadDeliveryContextStep = createStep(
   "load-inventory-order-delivery-context-step",
   async (input: { id: string }, { container }) => {
-    const query = container.resolve(ContainerRegistrationKeys.QUERY) as Omit<RemoteQueryFunction, symbol>;
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY) as Omit<RemoteQueryFunction, symbol>;
     const { data } = await query.graph({
       entity: "inventory_orders",
       filters: { id: input.id },


### PR DESCRIPTION
The prod `medusa build` log shows TS errors, but **the build passes** (medusa build transpiles regardless). Cleaning them so a real error can't hide in the noise:

- **`authVerificationsPerActor`** (`medusa-config.ts` + `.prod.ts`): the prod build resolves an older `@medusajs/types` than local 2.17.1 that predates the property → excess-property check (TS2769). Spread a cast object — key is set identically at runtime, check bypassed on any types version.
- **TS18046 'unknown'** on `container.resolve` results (`create-inventory-orders`, `update-inventory-orders`, `inventory-order-steps`): annotate `query`/`logger` as `any` — the established repo pattern for this inference flip.

No runtime change.