### PR TITLE
feat(shiprocket): inventory-order courier rates endpoint + shipment integration tests

### DIFF
--- a/apps/backend/integration-tests/http/inventory-order-shiprocket-shipment.spec.ts
+++ b/apps/backend/integration-tests/http/inventory-order-shiprocket-shipment.spec.ts
@@ -1,0 +1,155 @@
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user";
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup";
+import { shiprocketStubState } from "../../src/modules/shipping-providers/shiprocket/stub-fetch";
+
+jest.setTimeout(60000);
+
+/**
+ * End-to-end coverage for the inventory-order → Shiprocket shipment fixes:
+ *   - #864 destination address resolved from the to-location (billing_* filled)
+ *   - #869 L/B/H reach the courier (breadth → width mapping)
+ *   - #866 real per-line inventory_item SKU on order_items
+ *   - #641-inv courier rates endpoint (serviceability)
+ *
+ * Shiprocket has no sandbox; `SHIPROCKET_STUB=1` injects a deterministic
+ * transport (`shiprocket/stub-fetch.ts`) that also CAPTURES the adhoc-create
+ * body, so we can assert the exact payload the client would send.
+ */
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv();
+
+  let headers: any;
+  let inventoryItemId: string;
+  let toLocationId: string;
+  let fromLocationId: string;
+
+  let prevEmail: string | undefined;
+  let prevPassword: string | undefined;
+  let prevStub: string | undefined;
+
+  const TO_ADDRESS = {
+    address_1: "9 Mill Rd",
+    city: "Surat",
+    province: "GJ",
+    postal_code: "395003",
+    country_code: "in",
+    phone: "8887776665",
+  };
+
+  beforeAll(() => {
+    prevEmail = process.env.SHIPROCKET_EMAIL;
+    prevPassword = process.env.SHIPROCKET_PASSWORD;
+    prevStub = process.env.SHIPROCKET_STUB;
+    process.env.SHIPROCKET_EMAIL = "test@shiprocket.example";
+    process.env.SHIPROCKET_PASSWORD = "secret";
+    process.env.SHIPROCKET_STUB = "1";
+  });
+
+  afterAll(() => {
+    if (prevEmail === undefined) delete process.env.SHIPROCKET_EMAIL;
+    else process.env.SHIPROCKET_EMAIL = prevEmail;
+    if (prevPassword === undefined) delete process.env.SHIPROCKET_PASSWORD;
+    else process.env.SHIPROCKET_PASSWORD = prevPassword;
+    if (prevStub === undefined) delete process.env.SHIPROCKET_STUB;
+    else process.env.SHIPROCKET_STUB = prevStub;
+  });
+
+  beforeEach(async () => {
+    const container = getContainer();
+    await createAdminUser(container);
+    headers = await getAuthHeaders(api);
+    shiprocketStubState.lastAdhocBody = undefined;
+
+    const item = await api.post(
+      "/admin/inventory-items",
+      { title: "Tangaliya Weave — Black", sku: "OTH-TAN-BLA-001" },
+      headers
+    );
+    inventoryItemId = item.data.inventory_item.id;
+
+    // Destination stock location carries a complete address (the #864 source).
+    const toLoc = await api.post(
+      "/admin/stock-locations",
+      { name: "Surat Warehouse", address: TO_ADDRESS },
+      headers
+    );
+    toLocationId = toLoc.data.stock_location.id;
+
+    const fromLoc = await api.post(
+      "/admin/stock-locations",
+      { name: "Jaipur Source" },
+      headers
+    );
+    fromLocationId = fromLoc.data.stock_location.id;
+  });
+
+  const createShippableOrder = async (): Promise<string> => {
+    const res = await api.post(
+      "/admin/inventory-orders",
+      {
+        order_lines: [
+          { inventory_item_id: inventoryItemId, quantity: 3, price: 100 },
+        ],
+        quantity: 3,
+        total_price: 300,
+        status: "Ready for Delivery",
+        expected_delivery_date: new Date().toISOString(),
+        order_date: new Date().toISOString(),
+        shipping_address: {},
+        stock_location_id: toLocationId,
+        from_stock_location_id: fromLocationId,
+      },
+      headers
+    );
+    expect(res.status).toBe(201);
+    return res.data.inventoryOrder.id;
+  };
+
+  describe("GET /admin/inventory-orders/:id/shiprocket-rates (#641-inv)", () => {
+    it("returns the Shiprocket courier options for the order", async () => {
+      const id = await createShippableOrder();
+      const res = await api.get(
+        `/admin/inventory-orders/${id}/shiprocket-rates`,
+        headers
+      );
+      expect(res.status).toBe(200);
+      expect(res.data.destination_pincode).toBe(TO_ADDRESS.postal_code);
+      expect(Array.isArray(res.data.rates)).toBe(true);
+      expect(res.data.rates.length).toBeGreaterThan(0);
+      const recommended = res.data.rates.find((r: any) => r.is_recommended);
+      expect(recommended).toBeTruthy();
+      expect(recommended.courier_id).toBe(51);
+    });
+  });
+
+  describe("POST /admin/inventory-orders/:id/shipment — payload to the courier", () => {
+    it("fills billing address from the to-location, maps breadth, carries the SKU", async () => {
+      const id = await createShippableOrder();
+
+      const res = await api.post(
+        `/admin/inventory-orders/${id}/shipment`,
+        { dimensions_cm: { length: 30, breadth: 20, height: 10 }, weight_grams: 750 },
+        headers
+      );
+      expect(res.status).toBe(200);
+      expect(res.data.shipment.awb).toBe("STUBAWB123");
+
+      const body = shiprocketStubState.lastAdhocBody;
+      expect(body).toBeTruthy();
+      // #864 — destination billing address came from the to-location.
+      expect(body.billing_address).toBe(TO_ADDRESS.address_1);
+      expect(body.billing_pincode).toBe(TO_ADDRESS.postal_code);
+      expect(body.billing_city).toBe(TO_ADDRESS.city);
+      expect(body.billing_phone).toBe(TO_ADDRESS.phone);
+      // #869 — breadth (cm) reaches the courier (mapped from breadth → width).
+      expect(body.length).toBe(30);
+      expect(body.breadth).toBe(20);
+      expect(body.height).toBe(10);
+      expect(body.weight).toBeCloseTo(0.75);
+      // #866 — the real inventory_item SKU rides on the order item.
+      expect(Array.isArray(body.order_items)).toBe(true);
+      expect(body.order_items[0].sku).toBe("OTH-TAN-BLA-001");
+      expect(body.order_items[0].units).toBe(3);
+    });
+  });
+});

--- a/apps/backend/src/api/admin/inventory-orders/[id]/shiprocket-rates/route.ts
+++ b/apps/backend/src/api/admin/inventory-orders/[id]/shiprocket-rates/route.ts
@@ -1,0 +1,34 @@
+/**
+ * GET /admin/inventory-orders/:id/shiprocket-rates
+ *
+ * List Shiprocket courier options (rate / ETA / recommended) for an inventory
+ * order's stock-movement shipment, so the admin can pick a courier before
+ * creating the shipment. Mirrors the partner route; origin = from-location
+ * pickup, destination = to-location. Optional
+ * `?weight_grams=&length=&breadth=&height=` refine the quote.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import { getShiprocketRatesForInventoryOrder } from "../../../../../workflows/inventory_orders/shiprocket-rates";
+
+const num = (v: unknown): number | undefined => {
+  const n = v != null ? Number(v) : NaN;
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+};
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const orderId = req.params.id;
+
+  const length = num(req.query.length);
+  const breadth = num(req.query.breadth);
+  const height = num(req.query.height);
+  const dimensionsCm =
+    length || breadth || height ? { length, breadth, height } : undefined;
+
+  const result = await getShiprocketRatesForInventoryOrder(req.scope, {
+    orderId,
+    weightGrams: num(req.query.weight_grams),
+    dimensionsCm,
+  });
+
+  res.status(200).json(result);
+};

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -2420,6 +2420,16 @@ export default defineMiddlewares({
         authenticate("partner", ["session", "bearer"]),
       ],
     },
+    {
+      // #641-inv — partner lists Shiprocket courier rates for the order (so it
+      // can pick a courier before creating the shipment). GET still needs the
+      // matcher or req.auth_context is undefined (partner-route auth gotcha).
+      matcher: "/partners/inventory-orders/:orderId/shiprocket-rates",
+      method: "GET",
+      middlewares: [
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
     // Partner Payments APIs
     {
       matcher: "/partners/:id/payments",

--- a/apps/backend/src/api/partners/inventory-orders/[orderId]/shiprocket-rates/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/[orderId]/shiprocket-rates/route.ts
@@ -1,0 +1,50 @@
+/**
+ * @route GET /partners/inventory-orders/:orderId/shiprocket-rates
+ * @scope partner
+ *
+ * List Shiprocket courier options (rate / ETA / recommended) for the order's
+ * stock-movement shipment, so the partner can CHOOSE a courier before creating
+ * the shipment (else Shiprocket auto-assigns). Origin = the from-location's
+ * registered pickup pincode; destination = the to-location pincode. Optional
+ * `?weight_grams=&length=&breadth=&height=` refine the quote.
+ *
+ * The acting partner must own the order (IDOR guard, #778 C1).
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework";
+import {
+  getPartnerFromAuthContext,
+  assertPartnerOwnsInventoryOrder,
+} from "../../../helpers";
+import { getShiprocketRatesForInventoryOrder } from "../../../../../workflows/inventory_orders/shiprocket-rates";
+
+const num = (v: unknown): number | undefined => {
+  const n = v != null ? Number(v) : NaN;
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+};
+
+export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
+  const orderId = req.params.orderId;
+
+  if (!req.auth_context?.actor_id) {
+    return res.status(401).json({ error: "Partner authentication required" });
+  }
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope);
+  if (!partner) {
+    return res.status(401).json({ error: "Partner authentication required" });
+  }
+  await assertPartnerOwnsInventoryOrder(req.scope, orderId, partner.id);
+
+  const length = num(req.query.length);
+  const breadth = num(req.query.breadth);
+  const height = num(req.query.height);
+  const dimensionsCm =
+    length || breadth || height ? { length, breadth, height } : undefined;
+
+  const result = await getShiprocketRatesForInventoryOrder(req.scope, {
+    orderId,
+    weightGrams: num(req.query.weight_grams),
+    dimensionsCm,
+  });
+
+  res.status(200).json(result);
+}

--- a/apps/backend/src/modules/shipping-providers/shiprocket/stub-fetch.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/stub-fetch.ts
@@ -21,12 +21,60 @@ const json = (body: any, status = 200) =>
     text: async () => JSON.stringify(body),
   }) as any
 
+/**
+ * Captures what the stub last received, so integration specs can assert the
+ * exact payload the client would send to Shiprocket (billing address, order_items
+ * SKUs, L/B/H) end-to-end. Reset it in a test's `beforeEach` when needed.
+ */
+export const shiprocketStubState: { lastAdhocBody?: any; lastPickupBody?: any } = {}
+
+const parseBody = (init: any): any => {
+  try {
+    return init?.body ? JSON.parse(init.body) : undefined
+  } catch {
+    return undefined
+  }
+}
+
 export function createShiprocketStubFetch(): FetchLike {
-  return async (input: any) => {
+  return async (input: any, init?: any) => {
     const url = String(input)
 
     if (url.endsWith("/auth/login")) {
       return json({ token: "stub-token" })
+    }
+
+    // Adhoc order create — capture the body (the whole point of the #864/#866/#869
+    // end-to-end assertions) and return a shipment id.
+    if (url.endsWith("/orders/create/adhoc")) {
+      shiprocketStubState.lastAdhocBody = parseBody(init)
+      return json({ order_id: 9001, shipment_id: 8001 })
+    }
+
+    if (url.endsWith("/courier/assign/awb")) {
+      return json({
+        response: {
+          data: {
+            awb_code: "STUBAWB123",
+            courier_company_id: 51,
+            courier_name: "Xpressbees Surface",
+          },
+        },
+      })
+    }
+
+    if (url.endsWith("/courier/generate/label")) {
+      return json({ label_url: "https://shiprocket.stub/label.pdf" })
+    }
+
+    if (url.endsWith("/courier/generate/pickup")) {
+      shiprocketStubState.lastPickupBody = parseBody(init)
+      return json({
+        response: {
+          pickup_scheduled_date: "2026-07-05 10:00:00",
+          pickup_token_number: 555,
+        },
+      })
     }
 
     if (url.includes("/settings/company/pickup")) {

--- a/apps/backend/src/workflows/inventory_orders/shiprocket-rates.ts
+++ b/apps/backend/src/workflows/inventory_orders/shiprocket-rates.ts
@@ -1,0 +1,136 @@
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+} from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+import { resolveShippingProvider } from "../../modules/shipping-providers/resolver"
+import { SHIPROCKET_PICKUP_METADATA_KEY } from "../../modules/shipping-providers/pickup-locations"
+import type {
+  Dimensions,
+  RateOption,
+} from "../../modules/shipping-providers/provider-interface"
+import { pickRatesPickup } from "../orders/shiprocket-rates"
+import InventoryOrdersStockLocationsLink from "../../links/inventory-orders-stock-locations"
+import {
+  DEFAULT_INVENTORY_SHIPMENT_WEIGHT_GRAMS,
+  normalizeDimensionsCm,
+  resolveInventoryDestinationAddress,
+} from "./lib/inventory-order-shipment"
+
+/**
+ * Inventory-order analogue of `getShiprocketRatesForOrder` (#641) — surface the
+ * Shiprocket courier options (rate / ETA / recommended) for a stock-movement
+ * shipment so admin/partner can CHOOSE a courier before generating the label,
+ * instead of Shiprocket auto-assigning one.
+ *
+ * Origin = the registered pickup for the order's `from_location` (mirrors the
+ * shipment flow's pickup resolution). Destination = the `to_location`'s pincode
+ * (the same structured address the shipment ships to, #864/#772). The chosen
+ * `courier_id` then threads into the shipment via `preferredCourierId`.
+ */
+
+export type InventoryOrderRatesInput = {
+  orderId: string
+  weightGrams?: number
+  dimensionsCm?: Dimensions | { length?: number; breadth?: number; height?: number }
+}
+
+export type InventoryOrderRatesResult = {
+  origin_pincode: string
+  destination_pincode: string
+  weight_grams: number
+  cod: boolean
+  rates: RateOption[]
+}
+
+export async function getShiprocketRatesForInventoryOrder(
+  container: MedusaContainer,
+  input: InventoryOrderRatesInput
+): Promise<InventoryOrderRatesResult> {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: orders } = await query.graph({
+    entity: "inventory_orders",
+    fields: ["id", "metadata", "shipping_address"],
+    filters: { id: input.orderId },
+  })
+  const order = orders?.[0]
+  if (!order) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Inventory order ${input.orderId} not found`
+    )
+  }
+
+  // to/from stock-location links (extraColumns to_location/from_location).
+  const { data: links } = await query.graph({
+    entity: (InventoryOrdersStockLocationsLink as any).entryPoint,
+    fields: [
+      "to_location",
+      "from_location",
+      "stock_location.name",
+      "stock_location.metadata",
+      "stock_location.address.*",
+    ],
+    filters: { inventory_orders_id: order.id },
+  })
+  const toLocation = (links || []).find((l: any) => l?.to_location)?.stock_location || null
+  const fromLocation = (links || []).find((l: any) => l?.from_location)?.stock_location || null
+
+  // Destination pincode: the to-location address (explicit shipping_address wins).
+  const destinationAddress = resolveInventoryDestinationAddress(
+    (order as any)?.shipping_address,
+    toLocation?.address,
+    toLocation?.name
+  )
+  const destinationPincode = String(destinationAddress.postal_code || "").trim()
+  if (!destinationPincode) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "Order has no destination pincode to quote a delivery rate against. Set a complete address on the destination stock location."
+    )
+  }
+
+  const provider = await resolveShippingProvider(container, "shiprocket")
+  if (!provider.getRates || !provider.listPickupLocations) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "Shiprocket provider does not support rate quotes"
+    )
+  }
+
+  // Origin pincode: the registered pickup matching the from-location's nickname,
+  // else the shippable-first pickup (same heuristic the shipment flow uses).
+  const fromNickname = (fromLocation?.metadata as any)?.[
+    SHIPROCKET_PICKUP_METADATA_KEY
+  ]
+  const pickups = await provider.listPickupLocations()
+  const pickup = pickRatesPickup(pickups, fromNickname)
+  const originPincode = String(pickup?.pincode || "").trim()
+  if (!originPincode) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "No Shiprocket pickup location with a pincode is configured. Register a pickup for the source stock location before requesting courier rates."
+    )
+  }
+
+  const cod = (order as any).metadata?.payment_mode === "cod"
+  const weightGrams = input.weightGrams || DEFAULT_INVENTORY_SHIPMENT_WEIGHT_GRAMS
+  const dimensions_cm = normalizeDimensionsCm(input.dimensionsCm as any)
+
+  const rates = await provider.getRates({
+    origin_pincode: originPincode,
+    destination_pincode: destinationPincode,
+    weight_grams: weightGrams,
+    cod,
+    dimensions_cm,
+  })
+
+  return {
+    origin_pincode: originPincode,
+    destination_pincode: destinationPincode,
+    weight_grams: weightGrams,
+    cod,
+    rates,
+  }
+}


### PR DESCRIPTION
Groundwork for **courier selection** on the inventory-order shipment flow (#641 for inventory orders), plus the **integration coverage** the earlier Shiprocket fixes were missing.

## Backend
- `getShiprocketRatesForInventoryOrder`: serviceability quote — origin = the from-location's registered pickup pincode, destination = the to-location pincode (#864 resolution), dims normalized (breadth→width).
- `GET /partners/inventory-orders/:orderId/shiprocket-rates` (ownership guard + auth matcher) and `GET /admin/inventory-orders/:id/shiprocket-rates`.

## Integration tests (the ask)
Extended `shiprocket/stub-fetch` to answer create/assign/label/pickup and **capture the adhoc-create body**, so we assert the exact courier payload end-to-end:
- rates endpoint returns the courier options (recommended id 51);
- shipment payload **fills billing address from the to-location** (#864), **maps breadth→width so L/B/H reach the courier** (#869), and **carries the real `inventory_item` SKU** on `order_items` (#866).
- **2/2 green** locally.

## Next (follow-up PRs)
- Courier dropdown UI (admin modal + partner drawer) consuming this endpoint, threading the chosen `courier_id` into `preferred_courier_id`.
- Pickup-timing selection (Shiprocket schedule-pickup date).

Refs #772, #641.