### PR TITLE
feat(shiprocket): courier picker UI for inventory-order shipments

### DIFF
--- a/apps/backend/src/admin/components/inventory-orders/inventory-order-shipment-modal.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/inventory-order-shipment-modal.tsx
@@ -2,7 +2,9 @@ import { useState } from "react";
 import { Drawer, Button, Input, Label, Select, Text, toast } from "@medusajs/ui";
 import {
   AdminInventoryOrder,
+  ShiprocketRateOption,
   useCreateInventoryOrderShipment,
+  useInventoryOrderShiprocketRates,
 } from "../../hooks/api/inventory-orders";
 import { useStockLocations } from "../../hooks/api/stock_location";
 
@@ -30,9 +32,29 @@ export const InventoryOrderShipmentModal = ({ inventoryOrder, open, onOpenChange
   const [breadth, setBreadth] = useState("");
   const [height, setHeight] = useState("");
   const [courier, setCourier] = useState("");
+  const [rates, setRates] = useState<ShiprocketRateOption[] | null>(null);
 
   const { mutateAsync, isPending } = useCreateInventoryOrderShipment(inventoryOrder.id);
+  const { mutateAsync: fetchRates, isPending: isFetchingRates } =
+    useInventoryOrderShiprocketRates(inventoryOrder.id);
   const { stock_locations = [] } = useStockLocations({ limit: 100 });
+
+  const handleGetRates = async () => {
+    try {
+      const res = await fetchRates({
+        ...(weight ? { weight_grams: Number(weight) } : {}),
+        ...(length ? { length: Number(length) } : {}),
+        ...(breadth ? { breadth: Number(breadth) } : {}),
+        ...(height ? { height: Number(height) } : {}),
+      });
+      setRates(res.rates || []);
+      const recommended = res.rates?.find((r) => r.is_recommended) || res.rates?.[0];
+      if (recommended) setCourier(String(recommended.courier_id));
+      if (!res.rates?.length) toast.info("No couriers available for this route.");
+    } catch (error: any) {
+      toast.error(error?.message || "Failed to fetch courier rates");
+    }
+  };
 
   const handleSubmit = async () => {
     const dims =
@@ -109,8 +131,41 @@ export const InventoryOrderShipmentModal = ({ inventoryOrder, open, onOpenChange
             </div>
           </div>
           <div className="flex flex-col gap-1">
-            <Label size="small" htmlFor="courier">Preferred courier ID</Label>
-            <Input id="courier" value={courier} onChange={(e) => setCourier(e.target.value)} placeholder="(optional)" />
+            <div className="flex items-center justify-between">
+              <Label size="small" htmlFor="courier">Courier</Label>
+              <Button
+                variant="transparent"
+                size="small"
+                type="button"
+                onClick={handleGetRates}
+                isLoading={isFetchingRates}
+              >
+                Get rates
+              </Button>
+            </div>
+            {rates && rates.length > 0 ? (
+              <Select value={courier} onValueChange={setCourier}>
+                <Select.Trigger id="courier">
+                  <Select.Value placeholder="Select a courier" />
+                </Select.Trigger>
+                <Select.Content>
+                  {rates.map((r) => (
+                    <Select.Item key={String(r.courier_id)} value={String(r.courier_id)}>
+                      {r.courier_name} — ₹{r.amount}
+                      {r.estimated_days ? ` · ${r.estimated_days}d` : ""}
+                      {r.is_recommended ? " · recommended" : ""}
+                    </Select.Item>
+                  ))}
+                </Select.Content>
+              </Select>
+            ) : (
+              <Input
+                id="courier"
+                value={courier}
+                onChange={(e) => setCourier(e.target.value)}
+                placeholder="Courier ID (optional) — or click Get rates"
+              />
+            )}
           </div>
         </Drawer.Body>
         <Drawer.Footer>

--- a/apps/backend/src/admin/hooks/api/inventory-orders.ts
+++ b/apps/backend/src/admin/hooks/api/inventory-orders.ts
@@ -247,6 +247,63 @@ export const useCreateInventoryOrderShipment = (
   });
 };
 
+export type ShiprocketRateOption = {
+  courier_id: number | string;
+  courier_name: string;
+  amount: number;
+  currency_code: string;
+  estimated_days?: number;
+  cod_charges?: number;
+  is_recommended?: boolean;
+};
+
+export type InventoryOrderShiprocketRatesResponse = {
+  origin_pincode: string;
+  destination_pincode: string;
+  weight_grams: number;
+  cod: boolean;
+  rates: ShiprocketRateOption[];
+};
+
+export type ShiprocketRatesParams = {
+  weight_grams?: number;
+  length?: number;
+  breadth?: number;
+  height?: number;
+};
+
+const ratesQuery = (params: ShiprocketRatesParams): string => {
+  const qs = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v != null && Number.isFinite(Number(v)) && Number(v) > 0) qs.set(k, String(v));
+  }
+  const s = qs.toString();
+  return s ? `?${s}` : "";
+};
+
+/**
+ * On-demand Shiprocket courier rates for an inventory order (#641-inv). A
+ * mutation so the modal can fetch when the operator clicks "Get rates" and pass
+ * the current weight/dimensions, without a query key/enabled dance.
+ */
+export const useInventoryOrderShiprocketRates = (
+  id: string,
+  options?: UseMutationOptions<
+    InventoryOrderShiprocketRatesResponse,
+    FetchError,
+    ShiprocketRatesParams
+  >,
+) => {
+  return useMutation({
+    mutationFn: async (params: ShiprocketRatesParams) =>
+      sdk.client.fetch<InventoryOrderShiprocketRatesResponse>(
+        `/admin/inventory-orders/${id}/shiprocket-rates${ratesQuery(params)}`,
+        { method: "GET" },
+      ),
+    ...options,
+  });
+};
+
 export const useCreateInventoryOrderTasks = (
   id: string,
   options?: UseMutationOptions<any, FetchError, { type: string; template_names: string[]; dependency_type?: string }>,

--- a/apps/partner-ui/src/hooks/api/partner-inventory-orders.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-inventory-orders.tsx
@@ -254,6 +254,59 @@ export const useCreatePartnerInventoryOrderShipment = (
   })
 }
 
+// #641-inv — on-demand Shiprocket courier rates for the order.
+export type PartnerShiprocketRateOption = {
+  courier_id: number | string
+  courier_name: string
+  amount: number
+  currency_code: string
+  estimated_days?: number
+  cod_charges?: number
+  is_recommended?: boolean
+}
+
+export type PartnerShiprocketRatesResponse = {
+  origin_pincode: string
+  destination_pincode: string
+  weight_grams: number
+  cod: boolean
+  rates: PartnerShiprocketRateOption[]
+}
+
+export type PartnerShiprocketRatesParams = {
+  weight_grams?: number
+  length?: number
+  breadth?: number
+  height?: number
+}
+
+const partnerRatesQuery = (params: PartnerShiprocketRatesParams): string => {
+  const qs = new URLSearchParams()
+  for (const [k, v] of Object.entries(params)) {
+    if (v != null && Number.isFinite(Number(v)) && Number(v) > 0) qs.set(k, String(v))
+  }
+  const s = qs.toString()
+  return s ? `?${s}` : ""
+}
+
+export const usePartnerInventoryOrderShiprocketRates = (
+  orderId: string,
+  options?: UseMutationOptions<
+    PartnerShiprocketRatesResponse,
+    FetchError,
+    PartnerShiprocketRatesParams
+  >
+) => {
+  return useMutation({
+    mutationFn: async (params: PartnerShiprocketRatesParams) =>
+      sdk.client.fetch<PartnerShiprocketRatesResponse>(
+        `/partners/inventory-orders/${orderId}/shiprocket-rates${partnerRatesQuery(params)}`,
+        { method: "GET" }
+      ),
+    ...options,
+  })
+}
+
 export const useSubmitPartnerInventoryOrderPayment = (
   orderId: string,
   options?: UseMutationOptions<

--- a/apps/partner-ui/src/routes/inventory-orders/inventory-order-create-shipment/inventory-order-create-shipment.tsx
+++ b/apps/partner-ui/src/routes/inventory-orders/inventory-order-create-shipment/inventory-order-create-shipment.tsx
@@ -1,10 +1,14 @@
 import { useState } from "react"
-import { Button, Heading, Input, Label, Text, toast } from "@medusajs/ui"
+import { Button, Heading, Input, Label, Select, Text, toast } from "@medusajs/ui"
 import { useQueryClient } from "@tanstack/react-query"
 
 import { RouteDrawer, useRouteModal } from "../../../components/modals"
 import { ordersQueryKeys } from "../../../hooks/api/orders"
-import { useCreatePartnerInventoryOrderShipment } from "../../../hooks/api/partner-inventory-orders"
+import {
+  useCreatePartnerInventoryOrderShipment,
+  usePartnerInventoryOrderShiprocketRates,
+  type PartnerShiprocketRateOption,
+} from "../../../hooks/api/partner-inventory-orders"
 import { useInventoryActionTarget } from "../../../hooks/use-inventory-action-target"
 
 export const InventoryOrderCreateShipment = () => {
@@ -31,30 +35,54 @@ const InventoryOrderCreateShipmentContent = () => {
   const [length, setLength] = useState("")
   const [breadth, setBreadth] = useState("")
   const [height, setHeight] = useState("")
+  const [courier, setCourier] = useState("")
+  const [rates, setRates] = useState<PartnerShiprocketRateOption[] | null>(null)
 
   const { mutateAsync, isPending } =
     useCreatePartnerInventoryOrderShipment(id || "")
+  const { mutateAsync: fetchRates, isPending: isFetchingRates } =
+    usePartnerInventoryOrderShiprocketRates(id || "")
+
+  // Mirrors the admin shipment modal: L/B/H are sent as dimensions_cm so the
+  // real package size reaches the courier (else it defaults to 10×10×10).
+  const dims = () =>
+    length || breadth || height
+      ? {
+          ...(length ? { length: Number(length) } : {}),
+          ...(breadth ? { breadth: Number(breadth) } : {}),
+          ...(height ? { height: Number(height) } : {}),
+        }
+      : undefined
+
+  const handleGetRates = async () => {
+    if (!id) return
+    try {
+      const res = await fetchRates({
+        ...(weight ? { weight_grams: Number(weight) } : {}),
+        ...(length ? { length: Number(length) } : {}),
+        ...(breadth ? { breadth: Number(breadth) } : {}),
+        ...(height ? { height: Number(height) } : {}),
+      })
+      setRates(res.rates || [])
+      const recommended =
+        res.rates?.find((r) => r.is_recommended) || res.rates?.[0]
+      if (recommended) setCourier(String(recommended.courier_id))
+      if (!res.rates?.length) toast.info("No couriers available for this route.")
+    } catch (e: any) {
+      toast.error(e?.message || "Failed to fetch courier rates")
+    }
+  }
 
   const handleConfirm = async () => {
     if (!id) {
       return
     }
 
-    // Mirrors the admin shipment modal: L/B/H are sent as dimensions_cm so the
-    // real package size reaches the courier (else it defaults to 10×10×10).
-    const dims =
-      length || breadth || height
-        ? {
-            ...(length ? { length: Number(length) } : {}),
-            ...(breadth ? { breadth: Number(breadth) } : {}),
-            ...(height ? { height: Number(height) } : {}),
-          }
-        : undefined
-
     await mutateAsync(
       {
         ...(weight ? { weight_grams: Number(weight) } : {}),
-        ...(dims ? { dimensions_cm: dims } : {}),
+        ...(dims() ? { dimensions_cm: dims() } : {}),
+        ...(courier ? { preferred_courier_id: courier } : {}),
       },
       {
         onSuccess: (data) => {
@@ -128,6 +156,47 @@ const InventoryOrderCreateShipmentContent = () => {
               onChange={(e) => setHeight(e.target.value)}
             />
           </div>
+        </div>
+        <div className="flex flex-col gap-y-1">
+          <div className="flex items-center justify-between">
+            <Label size="small" htmlFor="courier">
+              Courier
+            </Label>
+            <Button
+              variant="transparent"
+              size="small"
+              type="button"
+              onClick={handleGetRates}
+              isLoading={isFetchingRates}
+              disabled={!id}
+            >
+              Get rates
+            </Button>
+          </div>
+          {rates && rates.length > 0 ? (
+            <Select value={courier} onValueChange={setCourier}>
+              <Select.Trigger id="courier">
+                <Select.Value placeholder="Select a courier" />
+              </Select.Trigger>
+              <Select.Content>
+                {rates.map((r) => (
+                  <Select.Item
+                    key={String(r.courier_id)}
+                    value={String(r.courier_id)}
+                  >
+                    {r.courier_name} — ₹{r.amount}
+                    {r.estimated_days ? ` · ${r.estimated_days}d` : ""}
+                    {r.is_recommended ? " · recommended" : ""}
+                  </Select.Item>
+                ))}
+              </Select.Content>
+            </Select>
+          ) : (
+            <Text size="xsmall" className="text-ui-fg-subtle">
+              Optional — click “Get rates” to choose a courier, or leave it for
+              Shiprocket to auto-assign.
+            </Text>
+          )}
         </div>
         {!id && (
           <Text size="small" className="text-ui-fg-subtle">


### PR DESCRIPTION
Consumes the #641-inv rates endpoint (PR #871) so the operator/partner **selects a courier** from Shiprocket's returned options instead of Shiprocket auto-assigning.

- **Admin modal + partner drawer**: a **Get rates** button fetches serviceability with the current weight/dims → **Select of couriers** (name — ₹rate · ETA · recommended), auto-selects the recommended one, and threads the chosen `courier_id` into `preferred_courier_id`. Falls back to free-text ID / Shiprocket auto-assign when no rates fetched.
- Hooks: `useInventoryOrderShiprocketRates` (admin) + `usePartnerInventoryOrderShiprocketRates` (partner), mutation-style on-demand.

tsc + vite build green. Answers the "select courier from Shiprocket's returned list" ask for inventory orders. Refs #772, #641.