### PR TITLE
feat(shiprocket): pickup timing on inventory-order shipments (#873)

### DIFF
--- a/apps/backend/integration-tests/http/inventory-order-shiprocket-shipment.spec.ts
+++ b/apps/backend/integration-tests/http/inventory-order-shiprocket-shipment.spec.ts
@@ -59,6 +59,7 @@ setupSharedTestSuite(() => {
     await createAdminUser(container);
     headers = await getAuthHeaders(api);
     shiprocketStubState.lastAdhocBody = undefined;
+    shiprocketStubState.lastPickupBody = undefined;
 
     const item = await api.post(
       "/admin/inventory-items",
@@ -150,6 +151,38 @@ setupSharedTestSuite(() => {
       expect(Array.isArray(body.order_items)).toBe(true);
       expect(body.order_items[0].sku).toBe("OTH-TAN-BLA-001");
       expect(body.order_items[0].units).toBe(3);
+    });
+
+    it("schedules the carrier pickup for the requested date", async () => {
+      const id = await createShippableOrder();
+
+      const res = await api.post(
+        `/admin/inventory-orders/${id}/shipment`,
+        { pickup_date: "2026-07-05" },
+        headers
+      );
+      expect(res.status).toBe(200);
+
+      // The pickup was scheduled for the requested date and the result is
+      // surfaced on the shipment.
+      const pickupBody = shiprocketStubState.lastPickupBody;
+      expect(pickupBody).toBeTruthy();
+      expect(pickupBody.pickup_date).toEqual(["2026-07-05"]);
+      expect(res.data.shipment.pickup?.scheduled_date).toBe("2026-07-05 10:00:00");
+    });
+
+    it("does not schedule a pickup when no date is given", async () => {
+      const id = await createShippableOrder();
+
+      const res = await api.post(
+        `/admin/inventory-orders/${id}/shipment`,
+        { weight_grams: 500 },
+        headers
+      );
+      expect(res.status).toBe(200);
+      // No pickup date → no pickup scheduling call (Shiprocket auto-slots).
+      expect(shiprocketStubState.lastPickupBody).toBeUndefined();
+      expect(res.data.shipment.pickup).toBeUndefined();
     });
   });
 });

--- a/apps/backend/src/admin/components/inventory-orders/inventory-order-shipment-modal.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/inventory-order-shipment-modal.tsx
@@ -32,6 +32,7 @@ export const InventoryOrderShipmentModal = ({ inventoryOrder, open, onOpenChange
   const [breadth, setBreadth] = useState("");
   const [height, setHeight] = useState("");
   const [courier, setCourier] = useState("");
+  const [pickupDate, setPickupDate] = useState("");
   const [rates, setRates] = useState<ShiprocketRateOption[] | null>(null);
 
   const { mutateAsync, isPending } = useCreateInventoryOrderShipment(inventoryOrder.id);
@@ -72,6 +73,7 @@ export const InventoryOrderShipmentModal = ({ inventoryOrder, open, onOpenChange
         ...(weight ? { weight_grams: Number(weight) } : {}),
         ...(dims ? { dimensions_cm: dims } : {}),
         ...(courier ? { preferred_courier_id: courier } : {}),
+        ...(pickupDate ? { pickup_date: pickupDate } : {}),
       },
       {
         onSuccess: (data) => {
@@ -166,6 +168,18 @@ export const InventoryOrderShipmentModal = ({ inventoryOrder, open, onOpenChange
                 placeholder="Courier ID (optional) — or click Get rates"
               />
             )}
+          </div>
+          <div className="flex flex-col gap-1">
+            <Label size="small" htmlFor="pickup_date">Pickup date</Label>
+            <Input
+              id="pickup_date"
+              type="date"
+              value={pickupDate}
+              onChange={(e) => setPickupDate(e.target.value)}
+            />
+            <Text size="xsmall" className="text-ui-fg-subtle">
+              Optional — leave blank to let the courier pick the earliest slot.
+            </Text>
           </div>
         </Drawer.Body>
         <Drawer.Footer>

--- a/apps/backend/src/admin/hooks/api/inventory-orders.ts
+++ b/apps/backend/src/admin/hooks/api/inventory-orders.ts
@@ -220,6 +220,8 @@ export interface CreateInventoryOrderShipmentPayload {
   dimensions_cm?: { length?: number; breadth?: number; height?: number };
   preferred_courier_id?: string | number;
   delivered_quantities?: Record<string, number>;
+  /** Requested carrier pickup date ("YYYY-MM-DD"). */
+  pickup_date?: string;
 }
 
 export interface CreateInventoryOrderShipmentResponse {

--- a/apps/backend/src/api/admin/inventory-orders/[id]/shipment/route.ts
+++ b/apps/backend/src/api/admin/inventory-orders/[id]/shipment/route.ts
@@ -28,6 +28,9 @@ const bodySchema = z.object({
   }).partial().optional(),
   preferred_courier_id: z.union([z.string(), z.number()]).optional(),
   delivered_quantities: z.record(z.string(), z.number()).optional(),
+  // Requested carrier pickup date ("YYYY-MM-DD"). Optional — omit to let
+  // Shiprocket pick the earliest slot.
+  pickup_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
 });
 
 export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
@@ -58,6 +61,7 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
       dimensionsCm: parsed.data.dimensions_cm as any,
       preferredCourierId: parsed.data.preferred_courier_id,
       deliveredQuantities: parsed.data.delivered_quantities,
+      pickupDate: parsed.data.pickup_date,
     },
     throwOnError: false,
   });

--- a/apps/backend/src/api/partners/inventory-orders/[orderId]/shipment/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/[orderId]/shipment/route.ts
@@ -31,6 +31,9 @@ const bodySchema = z.object({
   }).partial().optional(),
   preferred_courier_id: z.union([z.string(), z.number()]).optional(),
   delivered_quantities: z.record(z.string(), z.number()).optional(),
+  // Requested carrier pickup date ("YYYY-MM-DD"). Optional — omit to let
+  // Shiprocket pick the earliest slot.
+  pickup_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
 });
 
 export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse) {
@@ -69,6 +72,7 @@ export async function POST(req: AuthenticatedMedusaRequest, res: MedusaResponse)
       dimensionsCm: parsed.data.dimensions_cm as any,
       preferredCourierId: parsed.data.preferred_courier_id,
       deliveredQuantities: parsed.data.delivered_quantities,
+      pickupDate: parsed.data.pickup_date,
       actingEmail: (partner as any)?.email || undefined,
     },
     throwOnError: false,

--- a/apps/backend/src/modules/shipping-providers/provider-interface.ts
+++ b/apps/backend/src/modules/shipping-providers/provider-interface.ts
@@ -106,6 +106,8 @@ export type ShipmentResult = {
   tracking_url?: string
   label_url?: string
   provider_refs?: Record<string, any>
+  /** Set when a carrier pickup was scheduled alongside the shipment. */
+  pickup?: { scheduled_date?: string; token?: string }
   raw?: any
 }
 

--- a/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
@@ -494,9 +494,16 @@ export class ShiprocketClient implements ShippingProviderClient {
     if (!shipmentId) {
       throw new Error("Shiprocket schedulePickup requires ref.provider_refs.shipment_id")
     }
+    // Include the chosen pickup date when given — Shiprocket expects
+    // `pickup_date` as an array of "YYYY-MM-DD". Omitting it lets Shiprocket
+    // pick the earliest slot (previous behaviour).
+    const pickupBody: Record<string, any> = { shipment_id: [shipmentId] }
+    if (input.pickup_date) {
+      pickupBody.pickup_date = [String(input.pickup_date)]
+    }
     const json = await this.request<any>(`/courier/generate/pickup`, {
       method: "POST",
-      body: JSON.stringify({ shipment_id: [shipmentId] }),
+      body: JSON.stringify(pickupBody),
     })
     return {
       scheduled_date: json?.response?.pickup_scheduled_date,

--- a/apps/backend/src/workflows/inventory_orders/create-inventory-order-shipment.ts
+++ b/apps/backend/src/workflows/inventory_orders/create-inventory-order-shipment.ts
@@ -53,6 +53,12 @@ export type CreateInventoryOrderShipmentInput = {
   deliveredQuantities?: Record<string, number>
   /** Acting user's email recorded on a freshly-registered pickup (#427). */
   actingEmail?: string
+  /**
+   * Requested carrier pickup date ("YYYY-MM-DD"). When set, a pickup is
+   * scheduled for that date after the shipment is created; otherwise Shiprocket
+   * picks the earliest slot.
+   */
+  pickupDate?: string
 }
 
 export async function createInventoryOrderShipment(
@@ -188,6 +194,25 @@ export async function createInventoryOrderShipment(
   })
   const result = await provider.createShipment(shipmentInput)
 
+  // Schedule the carrier pickup for the requested date (best-effort — the
+  // shipment already exists; a scheduling hiccup must not fail the whole call).
+  let pickup: { scheduled_date?: string; token?: string } | undefined
+  if (input.pickupDate && provider.schedulePickup) {
+    try {
+      const scheduled = await provider.schedulePickup({
+        pickup_location_name: pickupLocationName,
+        ref: { awb: result.awb, provider_refs: result.provider_refs },
+        pickup_date: input.pickupDate,
+      })
+      pickup = {
+        scheduled_date: scheduled.scheduled_date,
+        token: scheduled.token,
+      }
+    } catch {
+      // non-fatal — operator can reschedule from the carrier dashboard
+    }
+  }
+
   // Persist carrier refs onto the inventory order, replacing the free-text
   // tracking number with the real AWB. Spread the existing metadata so the
   // whole blob isn't clobbered (Medusa replaces metadata wholesale).
@@ -204,11 +229,12 @@ export async function createInventoryOrderShipment(
         label_url: result.label_url,
         provider_refs: result.provider_refs,
         created_at: new Date().toISOString(),
+        ...(pickup ? { pickup } : {}),
       },
     },
   })
 
-  return result
+  return { ...result, ...(pickup ? { pickup } : {}) }
 }
 
 const createInventoryOrderShipmentStep = createStep(

--- a/apps/partner-ui/src/hooks/api/partner-inventory-orders.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-inventory-orders.tsx
@@ -233,6 +233,8 @@ export type PartnerCreateShipmentPayload = {
   dimensions_cm?: { length?: number; breadth?: number; height?: number }
   preferred_courier_id?: string | number
   delivered_quantities?: Record<string, number>
+  /** Requested carrier pickup date ("YYYY-MM-DD"). */
+  pickup_date?: string
 }
 
 export const useCreatePartnerInventoryOrderShipment = (

--- a/apps/partner-ui/src/routes/inventory-orders/inventory-order-create-shipment/inventory-order-create-shipment.tsx
+++ b/apps/partner-ui/src/routes/inventory-orders/inventory-order-create-shipment/inventory-order-create-shipment.tsx
@@ -36,6 +36,7 @@ const InventoryOrderCreateShipmentContent = () => {
   const [breadth, setBreadth] = useState("")
   const [height, setHeight] = useState("")
   const [courier, setCourier] = useState("")
+  const [pickupDate, setPickupDate] = useState("")
   const [rates, setRates] = useState<PartnerShiprocketRateOption[] | null>(null)
 
   const { mutateAsync, isPending } =
@@ -83,6 +84,7 @@ const InventoryOrderCreateShipmentContent = () => {
         ...(weight ? { weight_grams: Number(weight) } : {}),
         ...(dims() ? { dimensions_cm: dims() } : {}),
         ...(courier ? { preferred_courier_id: courier } : {}),
+        ...(pickupDate ? { pickup_date: pickupDate } : {}),
       },
       {
         onSuccess: (data) => {
@@ -197,6 +199,20 @@ const InventoryOrderCreateShipmentContent = () => {
               Shiprocket to auto-assign.
             </Text>
           )}
+        </div>
+        <div className="flex flex-col gap-y-1">
+          <Label size="small" htmlFor="pickup_date">
+            Pickup date
+          </Label>
+          <Input
+            id="pickup_date"
+            type="date"
+            value={pickupDate}
+            onChange={(e) => setPickupDate(e.target.value)}
+          />
+          <Text size="xsmall" className="text-ui-fg-subtle">
+            Optional — leave blank to let the courier pick the earliest slot.
+          </Text>
         </div>
         {!id && (
           <Text size="small" className="text-ui-fg-subtle">


### PR DESCRIPTION
## What

Shiprocket lets the shipper choose the pickup slot, but the inventory-order shipment flow (admin + partner) never exposed it — every pickup auto-slotted to Shiprocket's earliest. This wires an optional **pickup date** through the whole path.

## Changes

- **client** `schedulePickup` now includes `pickup_date` (Shiprocket wants an array of `"YYYY-MM-DD"`) when supplied. Same dropped-field bug class as the earlier breadth→width fix; omitting it preserves the earliest-slot default.
- **workflow** `createInventoryOrderShipment` schedules the pickup after AWB creation when `pickupDate` is set — **best-effort**: a scheduling failure never fails the already-created shipment (operator can reschedule from the carrier dashboard). Records it on `metadata.shipment.pickup` and returns it on the result. `ShipmentResult.pickup` is now a typed field.
- **routes** `pickup_date` (regex `YYYY-MM-DD`) added to both `POST /admin/inventory-orders/:id/shipment` and `POST /partners/inventory-orders/:orderId/shipment` schemas, threaded into the workflow input.
- **UI** admin modal + partner drawer each get a "Pickup date" input (optional, native date picker).

## Tests

`inventory-order-shiprocket-shipment.spec.ts` — added:
- schedules the pickup for the requested date (asserts the captured pickup body `pickup_date === ["2026-07-05"]` and `shipment.pickup.scheduled_date`)
- no date → no scheduling call, no `pickup` on the result

`SHIPROCKET_STUB=1`, **4/4 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)