### PR TITLE
feat(#861): artisan proposal spine — proposed on create + cross-list on publish

### DIFF
--- a/apps/backend/src/api/partners/products/route.ts
+++ b/apps/backend/src/api/partners/products/route.ts
@@ -122,6 +122,8 @@ import { MedusaError, ContainerRegistrationKeys, Modules } from "@medusajs/frame
 import { PartnerCreateProductReq } from "./validators"
 import { createProductsWorkflow } from "@medusajs/medusa/core-flows"
 import { getPartnerFromAuthContext } from "../helpers"
+import { PARTNER_MODULE } from "../../../modules/partner"
+import { PARTNER_ONBOARDING_PROFILE_MODULE } from "../../../modules/partner-onboarding-profile"
 
 export const POST = async (
   req: AuthenticatedMedusaRequest,
@@ -151,10 +153,25 @@ export const POST = async (
     )
   }
 
+  // #859 S2 (#861) — artisan proposal flow. A `core_channel_listing` partner
+  // doesn't publish directly: their product enters as `proposed` (native
+  // ProductStatus) bound only to their own channel, and an admin publishes it
+  // to cross-list onto the core cicilabel.com channel (via the cross-list
+  // subscriber). Other selling modes keep the existing behaviour.
+  const onboardingService: any = req.scope.resolve(
+    PARTNER_ONBOARDING_PROFILE_MODULE
+  )
+  const profile = await onboardingService
+    .findByPartner(partner.id)
+    .catch(() => null)
+  const isCoreChannelListing = profile?.selling_mode === "core_channel_listing"
+
   // Ensure product is associated to the store's default sales channel
   const productInput = {
     ...body.product,
     title: body.product.title || "",
+    // Proposal override wins over any client-supplied status for artisans.
+    ...(isCoreChannelListing ? { status: "proposed" as const } : {}),
     sales_channels: [
       {
         id: store.default_sales_channel_id,
@@ -170,8 +187,18 @@ export const POST = async (
 
   const created = result?.[0]
 
+  // Record product → owning partner so the cross-list subscriber can resolve
+  // ownership cleanly on publish (see links/partner-product.ts).
+  if (isCoreChannelListing && created?.id) {
+    const remoteLink = req.scope.resolve(ContainerRegistrationKeys.LINK) as any
+    await remoteLink.create({
+      [PARTNER_MODULE]: { partner_id: partner.id },
+      [Modules.PRODUCT]: { product_id: created.id },
+    })
+  }
+
   return res.status(201).json({
-    message: "Product created",
+    message: isCoreChannelListing ? "Product proposed" : "Product created",
     partner_id: partner.id,
     store_id: store.id,
     product: created,

--- a/apps/backend/src/links/partner-product.ts
+++ b/apps/backend/src/links/partner-product.ts
@@ -1,0 +1,20 @@
+import { defineLink } from "@medusajs/framework/utils"
+import PartnerModule from "../modules/partner"
+import ProductModule from "@medusajs/medusa/product"
+
+// #859 S2 (#861): partner ↔ product ownership link for the artisan quasi-partner
+// flow. A `core_channel_listing` partner proposes a product (status=proposed);
+// this link lets the cross-list subscriber resolve product → owning partner
+// cleanly on publish (instead of the fragile product → sales_channel → store →
+// partner multi-hop). One partner owns many products; a product has one owner.
+export default defineLink(
+  {
+    linkable: PartnerModule.linkable.partner,
+    isList: true,
+    field: "products",
+  },
+  {
+    linkable: ProductModule.linkable.product,
+    isList: true,
+  }
+)

--- a/apps/backend/src/subscribers/__tests__/artisan-cross-list-decision.unit.spec.ts
+++ b/apps/backend/src/subscribers/__tests__/artisan-cross-list-decision.unit.spec.ts
@@ -1,0 +1,63 @@
+import { decideCrossList } from "../lib/artisan-cross-list-decision"
+
+const CORE = "sc_core"
+
+describe("decideCrossList (#861 artisan cross-list)", () => {
+  it("cross-lists a published, artisan-owned product not yet on the core channel", () => {
+    expect(
+      decideCrossList({
+        hasOwnerLink: true,
+        status: "published",
+        coreChannelId: CORE,
+        currentChannelIds: ["sc_partner"],
+      })
+    ).toEqual({ action: "cross_list", channelId: CORE })
+  })
+
+  it("skips a product with no partner-product link (not artisan-owned)", () => {
+    expect(
+      decideCrossList({
+        hasOwnerLink: false,
+        status: "published",
+        coreChannelId: CORE,
+        currentChannelIds: [],
+      })
+    ).toEqual({ action: "skip", reason: "not_artisan_owned" })
+  })
+
+  it.each(["proposed", "draft", "rejected", null, undefined])(
+    "skips when status is %s (only 'published' cross-lists)",
+    (status) => {
+      expect(
+        decideCrossList({
+          hasOwnerLink: true,
+          status: status as any,
+          coreChannelId: CORE,
+          currentChannelIds: [],
+        })
+      ).toEqual({ action: "skip", reason: "not_published" })
+    }
+  )
+
+  it("skips when the core channel could not be resolved", () => {
+    expect(
+      decideCrossList({
+        hasOwnerLink: true,
+        status: "published",
+        coreChannelId: null,
+        currentChannelIds: [],
+      })
+    ).toEqual({ action: "skip", reason: "no_core_channel" })
+  })
+
+  it("is idempotent — skips when the product is already on the core channel", () => {
+    expect(
+      decideCrossList({
+        hasOwnerLink: true,
+        status: "published",
+        coreChannelId: CORE,
+        currentChannelIds: ["sc_partner", CORE],
+      })
+    ).toEqual({ action: "skip", reason: "already_listed" })
+  })
+})

--- a/apps/backend/src/subscribers/artisan-product-cross-list.ts
+++ b/apps/backend/src/subscribers/artisan-product-cross-list.ts
@@ -1,0 +1,105 @@
+import { SubscriberArgs, type SubscriberConfig } from "@medusajs/framework"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import partnerProductLink from "../links/partner-product"
+import { listStorefronts } from "../api/mcp/lib/store-resolver"
+import { decideCrossList } from "./lib/artisan-cross-list-decision"
+
+const LINK_ENTRY = partnerProductLink.entryPoint
+
+/**
+ * #859 S2 (#861) — cross-list an artisan's proposed product onto the core
+ * cicilabel.com sales channel once an admin publishes it.
+ *
+ * An artisan (`core_channel_listing`) partner creates products as `proposed`,
+ * bound only to their own channel, with a `partner-product` link recording
+ * ownership. When an admin flips the product to `published`, this handler
+ * attaches the core store's sales channel so it appears on the core storefront.
+ * Non-artisan products (no partner-product link) are ignored, so this stays
+ * cheap on the high-frequency `product.updated` event.
+ */
+export default async function artisanProductCrossListHandler({
+  event: { data },
+  container,
+}: SubscriberArgs<{ id: string }>) {
+  if (!data?.id) return
+
+  const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+  const logger = container.resolve("logger") as any
+
+  // Only artisan-owned products carry a partner-product link. No link → ignore.
+  let ownerLinks: any[] = []
+  try {
+    const res = await query.graph({
+      entity: LINK_ENTRY,
+      fields: ["partner_id", "product_id"],
+      filters: { product_id: data.id },
+    })
+    ownerLinks = res?.data || []
+  } catch (e: any) {
+    logger?.warn?.(
+      `[artisan cross-list] owner lookup failed for product ${data.id}: ${e.message}`
+    )
+    return
+  }
+  if (ownerLinks.length === 0) return
+
+  // Cross-list only once the product is published.
+  let product: any
+  try {
+    const res = await query.graph({
+      entity: "product",
+      fields: ["id", "status", "sales_channels.id"],
+      filters: { id: data.id },
+    })
+    product = res?.data?.[0]
+  } catch (e: any) {
+    logger?.warn?.(
+      `[artisan cross-list] product lookup failed for ${data.id}: ${e.message}`
+    )
+    return
+  }
+  if (!product) return
+
+  // Resolve the core (platform) store's sales channel — the store not owned by
+  // any partner (apex cicilabel.com). Reuses the MCP store-resolver.
+  let coreChannelId: string | null = null
+  try {
+    const storefronts = await listStorefronts(container)
+    coreChannelId =
+      storefronts.find((s) => s.is_default)?.sales_channel_id || null
+  } catch (e: any) {
+    logger?.warn?.(
+      `[artisan cross-list] core channel resolve failed for ${data.id}: ${e.message}`
+    )
+    return
+  }
+
+  const decision = decideCrossList({
+    hasOwnerLink: ownerLinks.length > 0,
+    status: product.status,
+    coreChannelId,
+    currentChannelIds: (product.sales_channels || [])
+      .map((sc: any) => sc?.id)
+      .filter(Boolean),
+  })
+  if (decision.action === "skip") return
+
+  try {
+    const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as any
+    await remoteLink.create({
+      [Modules.PRODUCT]: { product_id: data.id },
+      [Modules.SALES_CHANNEL]: { sales_channel_id: decision.channelId },
+    })
+    logger?.info?.(
+      `[artisan cross-list] product ${data.id} cross-listed to core channel ${decision.channelId}`
+    )
+  } catch (e: any) {
+    logger?.warn?.(
+      `[artisan cross-list] failed to attach product ${data.id} to core channel ${decision.channelId}: ${e.message}`
+    )
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: ["product.updated"],
+}

--- a/apps/backend/src/subscribers/lib/artisan-cross-list-decision.ts
+++ b/apps/backend/src/subscribers/lib/artisan-cross-list-decision.ts
@@ -1,0 +1,35 @@
+// #859 S2 (#861) — pure decision for the artisan cross-list subscriber.
+//
+// Kept free of container/query so it's unit-testable in isolation; the
+// subscriber gathers the facts (owner link, product status, core channel,
+// current channels) and delegates the verdict here.
+
+export type CrossListFacts = {
+  /** True when a partner-product link exists (product is artisan-owned). */
+  hasOwnerLink: boolean
+  /** Native ProductStatus of the product. */
+  status?: string | null
+  /** Core (platform) store's sales channel id, or null if unresolved. */
+  coreChannelId?: string | null
+  /** Sales channel ids the product is already on. */
+  currentChannelIds: string[]
+}
+
+export type CrossListDecision =
+  | { action: "skip"; reason: string }
+  | { action: "cross_list"; channelId: string }
+
+/**
+ * Decide whether a just-updated product should be cross-listed to the core
+ * channel. Only an artisan-owned, published product not already on the core
+ * channel gets listed; everything else is skipped with a reason.
+ */
+export function decideCrossList(facts: CrossListFacts): CrossListDecision {
+  if (!facts.hasOwnerLink) return { action: "skip", reason: "not_artisan_owned" }
+  if (facts.status !== "published") return { action: "skip", reason: "not_published" }
+  if (!facts.coreChannelId) return { action: "skip", reason: "no_core_channel" }
+  if (facts.currentChannelIds.includes(facts.coreChannelId)) {
+    return { action: "skip", reason: "already_listed" }
+  }
+  return { action: "cross_list", channelId: facts.coreChannelId }
+}


### PR DESCRIPTION
## What

S2 of the artisan quasi-partner epic (#859). A `core_channel_listing` partner **proposes** a product; an admin **publishes** it, and it cross-lists onto the core `cicilabel.com` sales channel. Native `ProductStatus`, no new columns.

- `links/partner-product.ts` — Partner ↔ Product ownership link (subscriber resolves product → owning partner cleanly; no sales_channel→store→partner hop).
- `partners/products/route.ts` — when the acting partner's `selling_mode` is `core_channel_listing`, create the product as `proposed`, bound to the partner's own channel only, and record the partner-product link. Other selling modes unchanged.
- `subscribers/artisan-product-cross-list.ts` — on `product.updated`, when an artisan-owned product is `published`, attach the core store's sales channel. Cheap no-op for non-artisan products (owner-link guard first); idempotent.
- Pure `decideCrossList()` helper + 9 unit tests.

Admin approval = native publish; reject = set `rejected` (subscriber ignores).

## Test
`TEST_TYPE=unit jest --testPathPattern=artisan-cross-list-decision` → 9/9 green.

## Follow-ups (next slice)
- Replace the `is_default` core-store heuristic with an explicit **opt-in store flag** ("accepts partner listings") resolved to its sales channel.
- Emit a **dedicated partner-product event** so the flow doesn't hang off generic `product.updated` (visual-flow seam).

Closes partial #861.

🤖 Generated with [Claude Code](https://claude.com/claude-code)