### PR TITLE
feat(#861): artisan approval events + env-based core channel

### DIFF
--- a/apps/backend/.env.template
+++ b/apps/backend/.env.template
@@ -62,3 +62,10 @@ SHIPROCKET_API_PASSWORD=your_shiprocket_password
 # VFLOW_FETCH_TIMEOUT_MS  — sandboxed execute_code `fetch` timeout (default 30000).
 # MASTRA_STEP_TIMEOUT_MS=60000
 # VFLOW_FETCH_TIMEOUT_MS=30000
+
+# Artisan quasi-partner cross-listing (#859 / #861). The sales-channel id of the
+# core storefront ("JYT Medu Store") that approved artisan products get listed
+# onto. There is no "core store" entity — the channel id IS the identity. When
+# unset, the subscriber falls back to the is_default storefront (nondeterministic
+# if multiple stores are unlinked to a partner), so set this in prod.
+# CORE_SALES_CHANNEL_ID=sc_01JNQG1YX5549246DFCKKFTE0W

--- a/apps/backend/src/api/admin/partners/products/[id]/approve/route.ts
+++ b/apps/backend/src/api/admin/partners/products/[id]/approve/route.ts
@@ -1,0 +1,16 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { runArtisanApproval } from "../../lib/run-approval"
+
+/**
+ * Approve an artisan's proposed product (#859 S2 / #861).
+ *
+ * @route POST /admin/partners/products/:id/approve
+ * Publishes the product and emits `partner_product.approved`, which the
+ * cross-list subscriber uses to attach the core sales channel.
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  return runArtisanApproval(req, res, "approve")
+}

--- a/apps/backend/src/api/admin/partners/products/[id]/reject/route.ts
+++ b/apps/backend/src/api/admin/partners/products/[id]/reject/route.ts
@@ -1,0 +1,16 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { runArtisanApproval } from "../../lib/run-approval"
+
+/**
+ * Reject an artisan's proposed product (#859 S2 / #861).
+ *
+ * @route POST /admin/partners/products/:id/reject
+ * Sets status `rejected` and emits `partner_product.rejected`. The cross-list
+ * subscriber ignores rejected products.
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  return runArtisanApproval(req, res, "reject")
+}

--- a/apps/backend/src/api/admin/partners/products/lib/__tests__/artisan-approval.unit.spec.ts
+++ b/apps/backend/src/api/admin/partners/products/lib/__tests__/artisan-approval.unit.spec.ts
@@ -1,0 +1,89 @@
+import { decideApprovalTransition } from "../artisan-approval"
+
+// #859 S2 (#861) — the pure approve/reject transition guard.
+describe("decideApprovalTransition", () => {
+  describe("ownership guard", () => {
+    it("rejects any action on a non-artisan product", () => {
+      const d = decideApprovalTransition("approve", {
+        hasOwnerLink: false,
+        currentStatus: "proposed",
+      })
+      expect(d).toEqual(
+        expect.objectContaining({ ok: false, code: "not_artisan_owned" })
+      )
+    })
+  })
+
+  describe("approve", () => {
+    it("publishes a proposed product and emits approved", () => {
+      expect(
+        decideApprovalTransition("approve", {
+          hasOwnerLink: true,
+          currentStatus: "proposed",
+        })
+      ).toEqual({
+        ok: true,
+        nextStatus: "published",
+        event: "partner_product.approved",
+      })
+    })
+
+    it("allows re-approving a previously rejected product", () => {
+      expect(
+        decideApprovalTransition("approve", {
+          hasOwnerLink: true,
+          currentStatus: "rejected",
+        })
+      ).toEqual({
+        ok: true,
+        nextStatus: "published",
+        event: "partner_product.approved",
+      })
+    })
+
+    it("refuses to re-approve an already-published product", () => {
+      const d = decideApprovalTransition("approve", {
+        hasOwnerLink: true,
+        currentStatus: "published",
+      })
+      expect(d).toEqual(
+        expect.objectContaining({ ok: false, code: "invalid_status" })
+      )
+    })
+
+    it("refuses to approve a draft product", () => {
+      const d = decideApprovalTransition("approve", {
+        hasOwnerLink: true,
+        currentStatus: "draft",
+      })
+      expect(d).toEqual(
+        expect.objectContaining({ ok: false, code: "invalid_status" })
+      )
+    })
+  })
+
+  describe("reject", () => {
+    it("rejects a proposed product and emits rejected", () => {
+      expect(
+        decideApprovalTransition("reject", {
+          hasOwnerLink: true,
+          currentStatus: "proposed",
+        })
+      ).toEqual({
+        ok: true,
+        nextStatus: "rejected",
+        event: "partner_product.rejected",
+      })
+    })
+
+    it("refuses to reject a published product", () => {
+      const d = decideApprovalTransition("reject", {
+        hasOwnerLink: true,
+        currentStatus: "published",
+      })
+      expect(d).toEqual(
+        expect.objectContaining({ ok: false, code: "invalid_status" })
+      )
+    })
+  })
+})

--- a/apps/backend/src/api/admin/partners/products/lib/artisan-approval.ts
+++ b/apps/backend/src/api/admin/partners/products/lib/artisan-approval.ts
@@ -1,0 +1,61 @@
+// #859 S2 (#861) — pure decision for the admin approve/reject of an artisan's
+// proposed product. Kept free of container/query so it's unit-testable; the
+// route gathers the facts (ownership + current status) and delegates here.
+
+export type ApprovalAction = "approve" | "reject"
+
+export type ApprovalFacts = {
+  /** True when a partner-product link exists (product is artisan-owned). */
+  hasOwnerLink: boolean
+  /** Native ProductStatus of the product. */
+  currentStatus?: string | null
+}
+
+export type ApprovalDecision =
+  | { ok: true; nextStatus: "published" | "rejected"; event: string }
+  | { ok: false; code: "not_artisan_owned" | "invalid_status"; reason: string }
+
+/**
+ * Decide the status transition for an admin approve/reject of an artisan
+ * product.
+ *
+ * - Only artisan-owned products (with a partner-product link) can be actioned.
+ * - approve: allowed from `proposed` or `rejected` (re-approve) → `published`.
+ * - reject:  allowed from `proposed` → `rejected`.
+ * - Already-`published` products are not re-actionable (idempotent guard).
+ */
+export function decideApprovalTransition(
+  action: ApprovalAction,
+  facts: ApprovalFacts
+): ApprovalDecision {
+  if (!facts.hasOwnerLink) {
+    return {
+      ok: false,
+      code: "not_artisan_owned",
+      reason: "Product is not an artisan-proposed product",
+    }
+  }
+
+  const status = facts.currentStatus ?? null
+
+  if (action === "approve") {
+    if (status === "proposed" || status === "rejected") {
+      return { ok: true, nextStatus: "published", event: "partner_product.approved" }
+    }
+    return {
+      ok: false,
+      code: "invalid_status",
+      reason: `Cannot approve a product in status '${status}' (expected 'proposed' or 'rejected')`,
+    }
+  }
+
+  // reject
+  if (status === "proposed") {
+    return { ok: true, nextStatus: "rejected", event: "partner_product.rejected" }
+  }
+  return {
+    ok: false,
+    code: "invalid_status",
+    reason: `Cannot reject a product in status '${status}' (expected 'proposed')`,
+  }
+}

--- a/apps/backend/src/api/admin/partners/products/lib/run-approval.ts
+++ b/apps/backend/src/api/admin/partners/products/lib/run-approval.ts
@@ -1,0 +1,80 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+import { updateProductsWorkflow } from "@medusajs/medusa/core-flows"
+import type { IEventBusModuleService } from "@medusajs/framework/types"
+import partnerProductLink from "../../../../../links/partner-product"
+import { ApprovalAction, decideApprovalTransition } from "./artisan-approval"
+
+const LINK_ENTRY = partnerProductLink.entryPoint
+
+/**
+ * #859 S2 (#861) — shared handler for the admin approve/reject of an artisan's
+ * proposed product.
+ *
+ * approve → publishes the product and emits `partner_product.approved` (the
+ * cross-list subscriber + any visual flow react to it). reject → sets
+ * `rejected` and emits `partner_product.rejected`. The generic product editor
+ * is intentionally bypassed so the transition is an explicit, auditable action
+ * carrying a dedicated event rather than a noisy `product.updated`.
+ */
+export async function runArtisanApproval(
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse,
+  action: ApprovalAction
+) {
+  const productId = req.params.id
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY) as any
+
+  // Resolve ownership (artisan products carry a partner-product link).
+  const { data: ownerLinks = [] } = await query.graph({
+    entity: LINK_ENTRY,
+    fields: ["partner_id", "product_id"],
+    filters: { product_id: productId },
+  })
+  const partnerId = ownerLinks[0]?.partner_id ?? null
+
+  // Current product status.
+  const { data: products = [] } = await query.graph({
+    entity: "product",
+    fields: ["id", "status"],
+    filters: { id: productId },
+  })
+  const product = products[0]
+  if (!product) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, `Product ${productId} not found`)
+  }
+
+  const decision = decideApprovalTransition(action, {
+    hasOwnerLink: ownerLinks.length > 0,
+    currentStatus: product.status,
+  })
+  if (!decision.ok) {
+    throw new MedusaError(
+      decision.code === "not_artisan_owned"
+        ? MedusaError.Types.NOT_FOUND
+        : MedusaError.Types.INVALID_DATA,
+      decision.reason
+    )
+  }
+
+  await updateProductsWorkflow(req.scope).run({
+    input: { products: [{ id: productId, status: decision.nextStatus }] },
+  })
+
+  const eventBus = req.scope.resolve(Modules.EVENT_BUS) as IEventBusModuleService
+  await eventBus.emit({
+    name: decision.event,
+    data: { id: productId, partner_id: partnerId },
+  })
+
+  return res.json({
+    id: productId,
+    status: decision.nextStatus,
+    partner_id: partnerId,
+    event: decision.event,
+  })
+}

--- a/apps/backend/src/api/partners/products/route.ts
+++ b/apps/backend/src/api/partners/products/route.ts
@@ -195,6 +195,18 @@ export const POST = async (
       [PARTNER_MODULE]: { partner_id: partner.id },
       [Modules.PRODUCT]: { product_id: created.id },
     })
+
+    // Dedicated proposal event — the seam for admin-review notifications and
+    // visual flows (registered in visual-flow-event-trigger.ts). Kept off the
+    // generic `product.created`/`updated` firehose so flows only wake on real
+    // artisan proposals.
+    const eventBus = req.scope.resolve(Modules.EVENT_BUS) as any
+    await eventBus
+      .emit({
+        name: "partner_product.proposed",
+        data: { id: created.id, partner_id: partner.id },
+      })
+      .catch(() => {})
   }
 
   return res.status(201).json({

--- a/apps/backend/src/subscribers/__tests__/resolve-core-sales-channel.unit.spec.ts
+++ b/apps/backend/src/subscribers/__tests__/resolve-core-sales-channel.unit.spec.ts
@@ -1,0 +1,49 @@
+import { pickCoreSalesChannelId } from "../lib/resolve-core-sales-channel"
+
+// #859 S2 (#861) — the pure env-vs-fallback pick for the core sales channel.
+describe("pickCoreSalesChannelId", () => {
+  it("prefers the explicit env channel id", () => {
+    expect(
+      pickCoreSalesChannelId({
+        envChannelId: "sc_core",
+        defaultStorefrontChannelId: "sc_fallback",
+      })
+    ).toBe("sc_core")
+  })
+
+  it("trims whitespace around the env value", () => {
+    expect(
+      pickCoreSalesChannelId({
+        envChannelId: "  sc_core  ",
+        defaultStorefrontChannelId: "sc_fallback",
+      })
+    ).toBe("sc_core")
+  })
+
+  it("falls back to the default storefront channel when env is unset", () => {
+    expect(
+      pickCoreSalesChannelId({
+        envChannelId: undefined,
+        defaultStorefrontChannelId: "sc_fallback",
+      })
+    ).toBe("sc_fallback")
+  })
+
+  it("falls back when env is an empty / whitespace string", () => {
+    expect(
+      pickCoreSalesChannelId({
+        envChannelId: "   ",
+        defaultStorefrontChannelId: "sc_fallback",
+      })
+    ).toBe("sc_fallback")
+  })
+
+  it("returns null when neither is available", () => {
+    expect(
+      pickCoreSalesChannelId({
+        envChannelId: null,
+        defaultStorefrontChannelId: null,
+      })
+    ).toBeNull()
+  })
+})

--- a/apps/backend/src/subscribers/artisan-product-cross-list.ts
+++ b/apps/backend/src/subscribers/artisan-product-cross-list.ts
@@ -1,21 +1,29 @@
 import { SubscriberArgs, type SubscriberConfig } from "@medusajs/framework"
 import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import partnerProductLink from "../links/partner-product"
-import { listStorefronts } from "../api/mcp/lib/store-resolver"
 import { decideCrossList } from "./lib/artisan-cross-list-decision"
+import { resolveCoreSalesChannelId } from "./lib/resolve-core-sales-channel"
 
 const LINK_ENTRY = partnerProductLink.entryPoint
 
 /**
- * #859 S2 (#861) — cross-list an artisan's proposed product onto the core
- * cicilabel.com sales channel once an admin publishes it.
+ * #859 S2 (#861) — cross-list an artisan's approved product onto the core
+ * sales channel.
  *
  * An artisan (`core_channel_listing`) partner creates products as `proposed`,
  * bound only to their own channel, with a `partner-product` link recording
- * ownership. When an admin flips the product to `published`, this handler
- * attaches the core store's sales channel so it appears on the core storefront.
- * Non-artisan products (no partner-product link) are ignored, so this stays
- * cheap on the high-frequency `product.updated` event.
+ * ownership. An admin reviews and approves via
+ * `POST /admin/partners/products/:id/approve`, which publishes the product and
+ * emits `partner_product.approved`. This handler reacts to that dedicated
+ * event — NOT the high-frequency generic `product.updated` — and attaches the
+ * core sales channel so the product appears on the core storefront.
+ *
+ * The core channel is identified by its sales-channel id (CORE_SALES_CHANNEL_ID
+ * env); there is no "core store" entity. See resolve-core-sales-channel.ts.
+ *
+ * The same `partner_product.approved` event is also available to the visual
+ * flow editor (registered in visual-flow-event-trigger.ts), so operators can
+ * layer notifications/automations on approval without touching code.
  */
 export default async function artisanProductCrossListHandler({
   event: { data },
@@ -27,6 +35,8 @@ export default async function artisanProductCrossListHandler({
   const logger = container.resolve("logger") as any
 
   // Only artisan-owned products carry a partner-product link. No link → ignore.
+  // (The approve endpoint only emits for artisan products, but we re-check so a
+  // stray/hand-fired event can't cross-list an unrelated product.)
   let ownerLinks: any[] = []
   try {
     const res = await query.graph({
@@ -43,7 +53,7 @@ export default async function artisanProductCrossListHandler({
   }
   if (ownerLinks.length === 0) return
 
-  // Cross-list only once the product is published.
+  // Cross-list only once the product is published (approve publishes first).
   let product: any
   try {
     const res = await query.graph({
@@ -60,13 +70,11 @@ export default async function artisanProductCrossListHandler({
   }
   if (!product) return
 
-  // Resolve the core (platform) store's sales channel — the store not owned by
-  // any partner (apex cicilabel.com). Reuses the MCP store-resolver.
+  // Resolve the core sales channel by its id (env-configured), not by guessing
+  // a "default" store.
   let coreChannelId: string | null = null
   try {
-    const storefronts = await listStorefronts(container)
-    coreChannelId =
-      storefronts.find((s) => s.is_default)?.sales_channel_id || null
+    coreChannelId = await resolveCoreSalesChannelId(container)
   } catch (e: any) {
     logger?.warn?.(
       `[artisan cross-list] core channel resolve failed for ${data.id}: ${e.message}`
@@ -101,5 +109,6 @@ export default async function artisanProductCrossListHandler({
 }
 
 export const config: SubscriberConfig = {
-  event: ["product.updated"],
+  // Dedicated approval event — not the noisy generic product.updated.
+  event: ["partner_product.approved"],
 }

--- a/apps/backend/src/subscribers/lib/resolve-core-sales-channel.ts
+++ b/apps/backend/src/subscribers/lib/resolve-core-sales-channel.ts
@@ -1,0 +1,54 @@
+// #859 S2 (#861) — resolve the platform's core sales channel for artisan
+// cross-listing.
+//
+// There is no "core store" entity in this platform; the core storefront is
+// identified purely by its sales-channel id, held in the CORE_SALES_CHANNEL_ID
+// env var (e.g. sc_… of "JYT Medu Store"). We keep a fallback to the legacy
+// is_default heuristic so nothing breaks before the env is set — but that
+// heuristic is nondeterministic when more than one store is unlinked to a
+// partner (both read as is_default), which is exactly why the env var is the
+// source of truth.
+
+import { listStorefronts } from "../../api/mcp/lib/store-resolver"
+
+/** Env var holding the core storefront's sales-channel id. */
+export const CORE_SALES_CHANNEL_ENV = "CORE_SALES_CHANNEL_ID"
+
+/**
+ * Pure pick: prefer the explicitly-configured channel id, else fall back to the
+ * default storefront's channel. Kept free of the container so it's unit-testable.
+ */
+export function pickCoreSalesChannelId(opts: {
+  /** Value of CORE_SALES_CHANNEL_ID (or undefined/empty when unset). */
+  envChannelId?: string | null
+  /** sales_channel_id of the is_default storefront, or null. */
+  defaultStorefrontChannelId?: string | null
+}): string | null {
+  const env = (opts.envChannelId || "").trim()
+  if (env) return env
+  return opts.defaultStorefrontChannelId || null
+}
+
+/**
+ * Resolve the core sales-channel id from the container: env first, then the
+ * is_default storefront as a fallback. Returns null if neither resolves.
+ */
+export async function resolveCoreSalesChannelId(
+  container: any
+): Promise<string | null> {
+  const envChannelId = process.env[CORE_SALES_CHANNEL_ENV]
+
+  // Only pay for the storefront enumeration when the env var is unset.
+  let defaultStorefrontChannelId: string | null = null
+  if (!(envChannelId || "").trim()) {
+    try {
+      const storefronts = await listStorefronts(container)
+      defaultStorefrontChannelId =
+        storefronts.find((s) => s.is_default)?.sales_channel_id || null
+    } catch {
+      defaultStorefrontChannelId = null
+    }
+  }
+
+  return pickCoreSalesChannelId({ envChannelId, defaultStorefrontChannelId })
+}

--- a/apps/backend/src/subscribers/visual-flow-event-trigger.ts
+++ b/apps/backend/src/subscribers/visual-flow-event-trigger.ts
@@ -223,6 +223,13 @@ export const config: SubscriberConfig = {
     "partner.partner.updated",
     "partner.partner.deleted",
     "partner.created.fromAdmin",
+
+    // Artisan quasi-partner product proposals (#859 / #861). Dedicated events
+    // fired only on real artisan actions — not the generic product firehose —
+    // so flows can drive review notifications / cross-listing automations.
+    "partner_product.proposed",
+    "partner_product.approved",
+    "partner_product.rejected",
     
     // Tasks
     "tasks.task.created",


### PR DESCRIPTION
Follow-up to #874 (the artisan proposal spine). Hardens it against the two watch-outs flagged there.

## 1. Core channel resolution was nondeterministic
The spine picked the cross-list target with `storefronts.find(s => s.is_default)`. But **two** stores read as `is_default` — `JYT Medu Store` (the real core, EUR) **and** an unlinked `Sharhlo Store` (INR) — so cross-list could attach an artisan's product to the wrong storefront's channel.

There is no "core store" entity in this platform; the core storefront is identified purely by its **sales-channel id**. This PR introduces `CORE_SALES_CHANNEL_ID` (e.g. `sc_01JNQG1YX5549246DFCKKFTE0W`):
- `resolve-core-sales-channel.ts` reads the env, falls back to the `is_default` storefront only when unset.
- Pure `pickCoreSalesChannelId()` + 5 unit tests.

## 2. Cross-list hung off the generic `product.updated` firehose
- Partner route now emits **`partner_product.proposed`** on a `core_channel_listing` proposal.
- New admin endpoints **`POST /admin/partners/products/:id/approve`** and **`/reject`** publish/reject the product and emit **`partner_product.approved`** / **`partner_product.rejected`**. Pure `decideApprovalTransition()` guard (ownership + status transitions) + 7 unit tests.
- The cross-list subscriber moves **off `product.updated` onto `partner_product.approved`** — it only wakes on an explicit admin approval now, never on every product write.
- All three events are registered in `visual-flow-event-trigger.ts`, so operators can build review-notification / automation flows on them in the **visual flow editor**.

## Test
`TEST_TYPE=unit jest --testPathPattern="artisan-cross-list-decision|resolve-core-sales-channel|artisan-approval"` → **21/21 green**. Touched `src/` files type-check clean.

## Prod tail
Set `CORE_SALES_CHANNEL_ID=sc_01JNQG1YX5549246DFCKKFTE0W` in prod so the core channel is deterministic.

## Follow-ups
- Admin UI: "Approve / Reject" action on proposed artisan products + a review queue.
- Onboarding step-gating + guided Q&A product intake (later #859 slices).

Closes partial #861.

🤖 Generated with [Claude Code](https://claude.com/claude-code)