### PR TITLE
chore(#861): set CORE_SALES_CHANNEL_ID in prod manifests

### DIFF
--- a/deploy/aws/copilot/medusa-server/manifest.yml
+++ b/deploy/aws/copilot/medusa-server/manifest.yml
@@ -64,6 +64,12 @@ variables:
   # in the media randomiser" pool. This album resolves to the 11 curated images
   # on prod. Non-secret (just an album id), so it lives here (not under secrets:).
   FEEDBACK_ARTWORK_ALBUM_ID: 01KS74M4JABCFKHB4WTF90KQYS
+  # #859/#861 — sales-channel id of the core storefront ("JYT Medu Store") that
+  # approved artisan products are cross-listed onto. There is NO "core store"
+  # entity; the channel id IS the identity. Read by resolve-core-sales-channel.ts
+  # (the cross-list subscriber runs on the WORKER — set there too). Non-secret.
+  # Unset → falls back to the nondeterministic is_default storefront pick.
+  CORE_SALES_CHANNEL_ID: sc_01JNQG1YX5549246DFCKKFTE0W
 
 # Secrets: rotating values come from Secrets Manager.
 # Non-rotating config (CORS, URLs, etc.) comes from SSM Parameter Store — listed

--- a/deploy/aws/copilot/medusa-worker/manifest.yml
+++ b/deploy/aws/copilot/medusa-worker/manifest.yml
@@ -30,6 +30,10 @@ variables:
   # createDraftProductFromExtractionWorkflow) that build these links via
   # buildPartnerProductUrl, so it needs the same explicit value as the server.
   PARTNER_APP_URL: https://partner.jaalyantra.com
+  # #859/#861 — the artisan cross-list subscriber (artisan-product-cross-list.ts)
+  # runs HERE (worker mode) and reads this to resolve the core storefront's sales
+  # channel. Must mirror the server manifest value. Non-secret (just a channel id).
+  CORE_SALES_CHANNEL_ID: sc_01JNQG1YX5549246DFCKKFTE0W
 
 # Worker needs DB + Redis + R2 (for export/report jobs that write files).
 # Does NOT need JWT/COOKIE/CORS (no HTTP surface).


### PR DESCRIPTION
Sets `CORE_SALES_CHANNEL_ID=sc_01JNQG1YX5549246DFCKKFTE0W` (JYT Medu Store's sales channel) on both the medusa-server and medusa-worker manifests so artisan cross-listing resolves the core channel deterministically instead of the nondeterministic `is_default` fallback (two stores read as default).

- Worker gets it too — the cross-list subscriber runs in worker mode.
- Non-secret → `variables:` block, not `secrets:`.
- Merging triggers `copilot svc deploy`, applying the manifest.

Prod tail for #861 / #875.

🤖 Generated with [Claude Code](https://claude.com/claude-code)