### PR TITLE
feat(#861): surface artisan proposal lifecycle in partner product UI

### DIFF
--- a/apps/partner-ui/src/routes/products/product-detail/components/product-review-banner/product-review-banner.tsx
+++ b/apps/partner-ui/src/routes/products/product-detail/components/product-review-banner/product-review-banner.tsx
@@ -1,0 +1,50 @@
+import { Alert, Text } from "@medusajs/ui"
+import { HttpTypes } from "@medusajs/types"
+
+/**
+ * #859/#861 — surfaces the marketplace proposal lifecycle to the partner.
+ *
+ * Artisan (`core_channel_listing`) products move through the native
+ * ProductStatus flow proposed → published / rejected. Only that flow produces
+ * `proposed`/`rejected`, so keying the banner off status alone is reliable —
+ * ordinary partner products are draft/published and render nothing here.
+ */
+export const ProductReviewBanner = ({
+  product,
+}: {
+  product: HttpTypes.AdminProduct
+}) => {
+  const status = product?.status
+
+  if (status === "proposed") {
+    return (
+      <Alert variant="info">
+        <Text size="small" weight="plus">
+          Pending review
+        </Text>
+        <Text size="small" className="text-ui-fg-subtle">
+          You've proposed this product for the JYT marketplace. Our team reviews
+          it before it goes live — you'll see the status change to{" "}
+          <span className="font-medium">Published</span> once it's approved. No
+          further action needed.
+        </Text>
+      </Alert>
+    )
+  }
+
+  if (status === "rejected") {
+    return (
+      <Alert variant="error">
+        <Text size="small" weight="plus">
+          Not approved for the marketplace
+        </Text>
+        <Text size="small" className="text-ui-fg-subtle">
+          This proposal wasn't approved. You can edit the details and it will be
+          re-reviewed, or reach out to the JYT team if you'd like more context.
+        </Text>
+      </Alert>
+    )
+  }
+
+  return null
+}

--- a/apps/partner-ui/src/routes/products/product-detail/product-detail.tsx
+++ b/apps/partner-ui/src/routes/products/product-detail/product-detail.tsx
@@ -5,6 +5,7 @@ import { TwoColumnPage } from "../../../components/layout/pages"
 import { useProduct } from "../../../hooks/api/products"
 import { ProductAttributeSection } from "./components/product-attribute-section"
 import { ProductGeneralSection } from "./components/product-general-section"
+import { ProductReviewBanner } from "./components/product-review-banner/product-review-banner"
 import { ProductMediaSection } from "./components/product-media-section"
 import { ProductOptionSection } from "./components/product-option-section"
 import { ProductOrganizationSection } from "./components/product-organization-section"
@@ -65,6 +66,7 @@ export const ProductDetail = () => {
       data={product}
     >
       <TwoColumnPage.Main>
+        <ProductReviewBanner product={product} />
         <ProductGeneralSection product={product} />
         <ProductMediaSection product={product} />
         <ProductOptionSection product={product} />


### PR DESCRIPTION
Partner-side proposal lifecycle visibility (the 'surface proposal lifecycle' choice).

- **Product detail** gets a review-state banner:
  - `proposed` → info **"Pending review"** (we review before it goes live; no action needed)
  - `rejected` → error **"Not approved"** (edit to re-review, or contact the team)
- Only the artisan (`core_channel_listing`) flow produces `proposed`/`rejected`, so keying off `product.status` alone is reliable — ordinary partner products (draft/published) render nothing.
- The product **list** already badges `proposed` (orange) / `rejected` (red) via `ProductStatusCell`, so no list change needed.

Partner-ui type-checks clean.

Partial #861 / #859.

🤖 Generated with [Claude Code](https://claude.com/claude-code)