### PR TITLE
fix(#861): align supplier Switch row with wizard toggle pattern

### DIFF
--- a/apps/partner-ui/src/routes/home/home-onboarding/home-onboarding.tsx
+++ b/apps/partner-ui/src/routes/home/home-onboarding/home-onboarding.tsx
@@ -1031,8 +1031,8 @@ const OnboardingForm = () => {
               {/* #859/#861 — supplier capability. Orthogonal to the selling
                   choice above: a partner can list on the marketplace AND supply
                   us, or be a supplier only. */}
-              <div className="flex items-start justify-between gap-x-3 rounded-lg border px-4 py-3">
-                <div>
+              <div className="flex items-center justify-between rounded-lg border px-4 py-3">
+                <div className="pr-4">
                   <Text size="small" weight="plus">
                     We also order from you (supplier)
                   </Text>
@@ -1043,6 +1043,7 @@ const OnboardingForm = () => {
                   </Text>
                 </div>
                 <Switch
+                  className="shrink-0"
                   checked={profile.supplies_to_platform}
                   onCheckedChange={(c) =>
                     setProfile((prev) => ({ ...prev, supplies_to_platform: c }))


### PR DESCRIPTION
The supplier toggle in the onboarding Selling step looked off — it used `items-start` + `gap-x-3`, top-aligning the `@medusajs/ui` `Switch` against its 2-line description (and letting it squish). Now mirrors the Operations-step Switch rows: `items-center justify-between`, `pr-4` on the text, `shrink-0` on the Switch → a fixed-size, vertically-centered toggle. Playwright-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)