### PR TITLE
feat(#839/#881): unsubscribe + auto bounce suppression + audience segmentation + multi-account hosting backbone

### DIFF
--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -479,6 +479,9 @@ module.exports = defineConfig({
     resolve: "./src/modules/email-provider-manager",
   },
   {
+    resolve: "./src/modules/email_suppression",
+  },
+  {
       resolve: "./src/modules/partner-payment-config",
     },
     {

--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -482,6 +482,9 @@ module.exports = defineConfig({
     resolve: "./src/modules/email_suppression",
   },
   {
+    resolve: "./src/modules/audience",
+  },
+  {
       resolve: "./src/modules/partner-payment-config",
     },
     {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -525,6 +525,9 @@ module.exports = defineConfig({
     resolve: "./src/modules/email-provider-manager",
   },
   {
+    resolve: "./src/modules/email_suppression",
+  },
+  {
     resolve: "./src/modules/messaging",
   },
   {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -528,6 +528,9 @@ module.exports = defineConfig({
     resolve: "./src/modules/email_suppression",
   },
   {
+    resolve: "./src/modules/audience",
+  },
+  {
     resolve: "./src/modules/messaging",
   },
   {

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/suppress-bounced-subscribers-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/suppress-bounced-subscribers-job.ts
@@ -3,6 +3,7 @@ import { z } from "@medusajs/framework/zod"
 
 import { PERSON_MODULE } from "../../../../modules/person"
 import { SOCIALS_MODULE } from "../../../../modules/socials"
+import { EMAIL_SUPPRESSION_MODULE } from "../../../../modules/email_suppression"
 import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
 
 /**
@@ -123,6 +124,9 @@ export const suppressBouncedSubscribersJob: MaintenanceJob = {
     const changes: MaintenanceChange[] = []
     const errors: Array<{ id: string; message: string }> = []
     const matched = new Set<string>()
+    // Emails that had at least one record flipped — logged to email_suppression
+    // (the single source of truth shared with the provider bounce webhooks).
+    const suppressedEmails = new Set<string>()
     let personsSuppressed = 0
     let customersSuppressed = 0
     let leadsSuppressed = 0
@@ -155,6 +159,7 @@ export const suppressBouncedSubscribersJob: MaintenanceJob = {
           }
           if (nextMeta) await personService.updatePeople({ id: p.id, metadata: nextMeta })
         }
+        suppressedEmails.add(String(p.email || "").toLowerCase())
         personsSuppressed++
       } catch (e: any) {
         errors.push({ id: p.id, message: e?.message ?? String(e) })
@@ -172,6 +177,7 @@ export const suppressBouncedSubscribersJob: MaintenanceJob = {
         if (!nextMeta) continue
         changes.push({ entity: "customer", id: c.id, field: "metadata.bounced", before: false, after: true })
         if (!dry_run) await customerService.updateCustomers(c.id, { metadata: nextMeta })
+        suppressedEmails.add(String(c.email || "").toLowerCase())
         customersSuppressed++
       } catch (e: any) {
         errors.push({ id: c.id, message: e?.message ?? String(e) })
@@ -189,9 +195,31 @@ export const suppressBouncedSubscribersJob: MaintenanceJob = {
         if (!nextMeta) continue
         changes.push({ entity: "lead", id: l.id, field: "metadata.bounced", before: false, after: true })
         if (!dry_run) await socialsService.updateLeads({ id: l.id, metadata: nextMeta })
+        suppressedEmails.add(String(l.email || "").toLowerCase())
         leadsSuppressed++
       } catch (e: any) {
         errors.push({ id: l.id, message: e?.message ?? String(e) })
+      }
+    }
+
+    // Write the durable email_suppression rows (single source of truth shared
+    // with the provider bounce webhooks). Best-effort — the suppression already
+    // happened, so a logging failure must not fail the job.
+    if (!dry_run && suppressedEmails.size > 0) {
+      try {
+        const suppressionService: any = container.resolve(EMAIL_SUPPRESSION_MODULE)
+        await suppressionService.createEmailSuppressions(
+          [...suppressedEmails].map((email) => ({
+            email,
+            reason: parsed.data.reason === "hard_bounce" ? "hard_bounce" : "manual",
+            provider: "manual",
+            event_id: null,
+            event_at: at,
+            suppressed: true,
+          }))
+        )
+      } catch {
+        // swallow — suppression is already applied
       }
     }
 

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -655,6 +655,21 @@ export default defineMiddlewares({
       bodyParser: false, // Need raw body for Svix signature verification
     },
     {
+      // Resend delivery events (bounce/complaint) → auto-suppress. Svix-signed,
+      // so the raw body is required for verification.
+      matcher: "/webhooks/resend/email-events",
+      method: "POST",
+      middlewares: [],
+      bodyParser: false,
+    },
+    {
+      // Mailjet Event API (bounce/blocked/spam/unsub) → auto-suppress. Gated by
+      // MAILJET_WEBHOOK_SECRET (?token=), JSON body parsed normally.
+      matcher: "/webhooks/mailjet/events",
+      method: "POST",
+      middlewares: [],
+    },
+    {
       // PayU posts application/x-www-form-urlencoded; preserve the raw body so
       // the route can parse it (and the reverse-hash uses the exact fields).
       matcher: "/webhooks/payu/link",
@@ -3575,6 +3590,18 @@ export default defineMiddlewares({
       matcher: "/web/website/:domain/subscribe",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(subscriptionSchema))],
+    },
+    {
+      // Public unsubscribe — GET resolves the (masked) target for the confirm
+      // page; POST performs the opt-out. Both validated inline in the route.
+      matcher: "/web/website/:domain/unsubscribe",
+      method: "GET",
+      middlewares: [],
+    },
+    {
+      matcher: "/web/website/:domain/unsubscribe",
+      method: "POST",
+      middlewares: [],
     },
     {
       matcher: "/web/website/:domain/forms/:handle",

--- a/apps/backend/src/api/web/website/[domain]/unsubscribe/__tests__/unsubscribe.unit.spec.ts
+++ b/apps/backend/src/api/web/website/[domain]/unsubscribe/__tests__/unsubscribe.unit.spec.ts
@@ -1,0 +1,161 @@
+import {
+  isValidEmail,
+  maskEmail,
+  unsubscribeMetadata,
+  resolveEmailById,
+  suppressEmailEverywhere,
+} from "../lib"
+
+describe("unsubscribe — isValidEmail", () => {
+  it("accepts a normal address", () => {
+    expect(isValidEmail("jane@example.com")).toBe(true)
+  })
+  it("rejects garbage / non-strings", () => {
+    expect(isValidEmail("nope")).toBe(false)
+    expect(isValidEmail("a@b")).toBe(false)
+    expect(isValidEmail(undefined)).toBe(false)
+    expect(isValidEmail(123 as any)).toBe(false)
+  })
+})
+
+describe("unsubscribe — maskEmail", () => {
+  it("keeps the first two local chars + full domain", () => {
+    expect(maskEmail("jane.doe@example.com")).toBe("ja***@example.com")
+  })
+  it("handles a very short local part", () => {
+    expect(maskEmail("a@b.com")).toBe("a***@b.com")
+  })
+  it("lowercases", () => {
+    expect(maskEmail("JANE@Example.COM")).toBe("ja***@example.com")
+  })
+})
+
+describe("unsubscribe — unsubscribeMetadata", () => {
+  it("stamps unsubscribe fields while preserving existing metadata", () => {
+    expect(unsubscribeMetadata({ source: "web_form", note: "keep" }, "2026-07-03T00:00:00.000Z")).toEqual({
+      source: "web_form",
+      note: "keep",
+      unsubscribed: true,
+      unsubscribed_at: "2026-07-03T00:00:00.000Z",
+    })
+  })
+  it("is idempotent — returns null when already unsubscribed", () => {
+    expect(unsubscribeMetadata({ unsubscribed: true }, "2026-07-03T00:00:00.000Z")).toBeNull()
+  })
+  it("handles null/undefined existing metadata", () => {
+    expect(unsubscribeMetadata(null, "T")).toEqual({ unsubscribed: true, unsubscribed_at: "T" })
+    expect(unsubscribeMetadata(undefined, "T")?.unsubscribed).toBe(true)
+  })
+})
+
+function makeServices(overrides: any = {}) {
+  return {
+    personService: {
+      listPeople: jest.fn(async () => []),
+      updatePersonSubs: jest.fn(async () => ({})),
+      updatePeople: jest.fn(async () => ({})),
+      ...overrides.personService,
+    },
+    customerService: {
+      listCustomers: jest.fn(async () => []),
+      updateCustomers: jest.fn(async () => ({})),
+      ...overrides.customerService,
+    },
+    socialsService: {
+      listLeads: jest.fn(async () => []),
+      updateLeads: jest.fn(async () => ({})),
+      ...overrides.socialsService,
+    },
+  }
+}
+
+describe("unsubscribe — resolveEmailById", () => {
+  it("resolves a person id to its email (lowercased)", async () => {
+    const services = makeServices({
+      personService: { listPeople: jest.fn(async () => [{ id: "pers_1", email: "Jane@Example.com" }]) },
+    })
+    expect(await resolveEmailById(services as any, "pers_1")).toBe("jane@example.com")
+  })
+
+  it("falls through person → customer → lead", async () => {
+    const services = makeServices({
+      customerService: { listCustomers: jest.fn(async () => [{ id: "cus_1", email: "cust@x.com" }]) },
+    })
+    expect(await resolveEmailById(services as any, "cus_1")).toBe("cust@x.com")
+  })
+
+  it("resolves a lead id when person/customer miss", async () => {
+    const services = makeServices({
+      socialsService: { listLeads: jest.fn(async () => [{ id: "lead_1", email: "lead@x.com" }]) },
+    })
+    expect(await resolveEmailById(services as any, "lead_1")).toBe("lead@x.com")
+  })
+
+  it("returns null when nothing matches", async () => {
+    expect(await resolveEmailById(makeServices() as any, "nope")).toBeNull()
+  })
+})
+
+describe("unsubscribe — suppressEmailEverywhere", () => {
+  it("flips an active person: subscription inactive + metadata + counts", async () => {
+    const services = makeServices({
+      personService: {
+        listPeople: jest.fn(async () => [
+          { id: "pers_1", email: "jane@x.com", metadata: {}, subscribed: { id: "sub_1", subscription_status: "active" } },
+        ]),
+      },
+    })
+    const r = await suppressEmailEverywhere(services as any, "Jane@X.com", "T")
+    expect(r.suppressed).toBe(1)
+    expect(r.persons).toBe(1)
+    expect(r.alreadyOff).toBe(false)
+    expect(services.personService.updatePersonSubs).toHaveBeenCalledWith({
+      id: "sub_1",
+      subscription_status: "inactive",
+      email_subscribed: "false",
+    })
+    expect(services.personService.updatePeople).toHaveBeenCalledWith({
+      id: "pers_1",
+      metadata: { unsubscribed: true, unsubscribed_at: "T" },
+    })
+  })
+
+  it("suppresses the same email across customer + lead too", async () => {
+    const services = makeServices({
+      customerService: { listCustomers: jest.fn(async () => [{ id: "cus_1", email: "j@x.com", metadata: null }]) },
+      socialsService: { listLeads: jest.fn(async () => [{ id: "lead_1", email: "j@x.com", metadata: {} }]) },
+    })
+    const r = await suppressEmailEverywhere(services as any, "j@x.com", "T")
+    expect(r.customers).toBe(1)
+    expect(r.leads).toBe(1)
+    expect(r.suppressed).toBe(2)
+    expect(services.customerService.updateCustomers).toHaveBeenCalledWith("cus_1", {
+      metadata: { unsubscribed: true, unsubscribed_at: "T" },
+    })
+    expect(services.socialsService.updateLeads).toHaveBeenCalledWith({
+      id: "lead_1",
+      metadata: { unsubscribed: true, unsubscribed_at: "T" },
+    })
+  })
+
+  it("is idempotent: already-off record flips nothing and reports alreadyOff", async () => {
+    const services = makeServices({
+      personService: {
+        listPeople: jest.fn(async () => [
+          { id: "pers_1", email: "j@x.com", metadata: { unsubscribed: true }, subscribed: { id: "sub_1", subscription_status: "inactive" } },
+        ]),
+      },
+    })
+    const r = await suppressEmailEverywhere(services as any, "j@x.com", "T")
+    expect(r.suppressed).toBe(0)
+    expect(r.alreadyOff).toBe(true)
+    expect(services.personService.updatePersonSubs).not.toHaveBeenCalled()
+    expect(services.personService.updatePeople).not.toHaveBeenCalled()
+  })
+
+  it("no match anywhere → suppressed 0, alreadyOff false", async () => {
+    const r = await suppressEmailEverywhere(makeServices() as any, "ghost@x.com", "T")
+    expect(r.suppressed).toBe(0)
+    expect(r.alreadyOff).toBe(false)
+  })
+})

--- a/apps/backend/src/api/web/website/[domain]/unsubscribe/lib.ts
+++ b/apps/backend/src/api/web/website/[domain]/unsubscribe/lib.ts
@@ -1,0 +1,186 @@
+import { Modules } from "@medusajs/framework/utils"
+
+import { PERSON_MODULE } from "../../../../../modules/person"
+import { SOCIALS_MODULE } from "../../../../../modules/socials"
+
+/**
+ * Public unsubscribe — the counterpart to the newsletter/blog send.
+ *
+ * The email footer links to `${FRONTEND_URL}/unsubscribe?id=<id>&email=<email>`.
+ * The `id` is ambiguous — the send unions three sources
+ * (`workflows/blogs/send-blog-subscribers/steps/get-subscribers.ts`) and stamps
+ * `id` from whichever matched (person | customer | lead) — so we suppress by
+ * EMAIL, resolving the email from the id when the link doesn't carry it.
+ *
+ * Suppressing an email flips every record that shares it OUT of the audience:
+ *   - person   → subscription inactive + `metadata.unsubscribed`
+ *   - customer → `metadata.unsubscribed`
+ *   - lead     → `metadata.unsubscribed`
+ * The send path skips `metadata.unsubscribed` (and inactive person subs), so the
+ * address stops receiving mail across all three. Distinct from a hard bounce
+ * (`metadata.bounced`) — this is a recipient-initiated opt-out.
+ *
+ * Idempotent: an address already unsubscribed is a no-op.
+ */
+
+export type UnsubServices = {
+  personService: any
+  customerService: any
+  socialsService: any
+}
+
+/** Resolve the three module services from the request container. */
+export function resolveUnsubServices(container: any): UnsubServices {
+  return {
+    personService: container.resolve(PERSON_MODULE),
+    customerService: container.resolve(Modules.CUSTOMER),
+    socialsService: container.resolve(SOCIALS_MODULE),
+  }
+}
+
+const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/
+
+/** PURE: is this a syntactically valid, single email address? */
+export function isValidEmail(email: unknown): email is string {
+  return typeof email === "string" && email.length <= 254 && EMAIL_RE.test(email.trim())
+}
+
+/**
+ * PURE: mask an email for display on the confirmation page so we can echo which
+ * address is being unsubscribed without exposing the full address to whoever
+ * opened the link. e.g. `jane.doe@example.com` → `ja***@example.com`.
+ */
+export function maskEmail(email: string): string {
+  const [local = "", domain = ""] = String(email).trim().toLowerCase().split("@")
+  if (!domain) return "***"
+  const head = local.slice(0, 2)
+  const masked = local.length <= 2 ? `${head}***` : `${head}***`
+  return `${masked}@${domain}`
+}
+
+/**
+ * PURE: decide the metadata to persist when unsubscribing a record. Preserves
+ * existing metadata (Medusa replaces the whole blob on update). Returns null
+ * when the record is already unsubscribed (idempotent no-op).
+ */
+export function unsubscribeMetadata(
+  existing: Record<string, any> | null | undefined,
+  at: string
+): Record<string, any> | null {
+  if (existing && (existing as any).unsubscribed === true) return null
+  return {
+    ...(existing || {}),
+    unsubscribed: true,
+    unsubscribed_at: at,
+  }
+}
+
+/**
+ * Resolve an email address from an ambiguous subscriber id. The id may belong to
+ * a person, a customer, or a lead — try each until one matches. Returns the
+ * lower-cased email, or null if the id resolves to nothing.
+ */
+export async function resolveEmailById(
+  services: UnsubServices,
+  id: string
+): Promise<string | null> {
+  const { personService, customerService, socialsService } = services
+
+  const [person] = await personService
+    .listPeople({ id }, { select: ["id", "email"], take: 1 })
+    .catch(() => [])
+  if (person?.email && isValidEmail(person.email)) return person.email.toLowerCase()
+
+  const [customer] = await customerService
+    .listCustomers({ id }, { select: ["id", "email"], take: 1 })
+    .catch(() => [])
+  if (customer?.email && isValidEmail(customer.email)) return customer.email.toLowerCase()
+
+  const [lead] = await socialsService
+    .listLeads({ id }, { select: ["id", "email"], take: 1 })
+    .catch(() => [])
+  if (lead?.email && isValidEmail(lead.email)) return lead.email.toLowerCase()
+
+  return null
+}
+
+export type SuppressResult = {
+  email: string
+  suppressed: number
+  persons: number
+  customers: number
+  leads: number
+  alreadyOff: boolean
+}
+
+/**
+ * Suppress a single email across all three audience sources. Idempotent: records
+ * already unsubscribed (and person subs already inactive) are left untouched.
+ * Returns how many records were flipped so the endpoint can report + so the flow
+ * can distinguish "opted you out" from "you were already unsubscribed".
+ */
+export async function suppressEmailEverywhere(
+  services: UnsubServices,
+  email: string,
+  at: string
+): Promise<SuppressResult> {
+  const { personService, customerService, socialsService } = services
+  const target = email.toLowerCase()
+  let persons = 0
+  let customers = 0
+  let leads = 0
+
+  // Persons — subscription inactive + metadata.unsubscribed
+  const people: any[] = await personService
+    .listPeople({ email: target }, { relations: ["subscribed"] })
+    .catch(() => [])
+  for (const p of people) {
+    const sub = p.subscribed
+    const subNeedsOff = sub && sub.subscription_status !== "inactive"
+    const nextMeta = unsubscribeMetadata(p.metadata, at)
+    if (!subNeedsOff && !nextMeta) continue
+    if (subNeedsOff) {
+      await personService.updatePersonSubs({
+        id: sub.id,
+        subscription_status: "inactive",
+        email_subscribed: "false",
+      })
+    }
+    if (nextMeta) await personService.updatePeople({ id: p.id, metadata: nextMeta })
+    persons++
+  }
+
+  // Customers — metadata.unsubscribed
+  const custs: any[] = await customerService
+    .listCustomers({ email: target }, { select: ["id", "email", "metadata"] })
+    .catch(() => [])
+  for (const c of custs) {
+    const nextMeta = unsubscribeMetadata(c.metadata, at)
+    if (!nextMeta) continue
+    await customerService.updateCustomers(c.id, { metadata: nextMeta })
+    customers++
+  }
+
+  // Leads — metadata.unsubscribed (sales status untouched)
+  const lds: any[] = await socialsService
+    .listLeads({ email: target }, { select: ["id", "email", "metadata"] })
+    .catch(() => [])
+  for (const l of lds) {
+    const nextMeta = unsubscribeMetadata(l.metadata, at)
+    if (!nextMeta) continue
+    await socialsService.updateLeads({ id: l.id, metadata: nextMeta })
+    leads++
+  }
+
+  const suppressed = persons + customers + leads
+  const found = people.length + custs.length + lds.length
+  return {
+    email: target,
+    suppressed,
+    persons,
+    customers,
+    leads,
+    // Already off = we matched at least one record but flipped none.
+    alreadyOff: suppressed === 0 && found > 0,
+  }
+}

--- a/apps/backend/src/api/web/website/[domain]/unsubscribe/route.ts
+++ b/apps/backend/src/api/web/website/[domain]/unsubscribe/route.ts
@@ -1,0 +1,107 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework";
+import { MedusaError } from "@medusajs/framework/utils";
+
+import { findWebsiteByDomainWorkflow } from "../../../../../workflows/website/find-website-by-domain";
+import {
+  isValidEmail,
+  maskEmail,
+  resolveEmailById,
+  resolveUnsubServices,
+  suppressEmailEverywhere,
+} from "./lib";
+
+/**
+ * Public unsubscribe endpoint — the missing counterpart to `subscribe`.
+ *
+ * GET  /web/website/:domain/unsubscribe?id=&email=
+ *   Non-mutating. Resolves the target email (from `email`, else by `id`) and
+ *   returns it MASKED so the storefront confirmation page can echo which address
+ *   is about to be unsubscribed. A mutating link is deliberately NOT used on GET
+ *   so email-scanner prefetches can't opt people out — the storefront requires
+ *   an explicit confirm click that POSTs.
+ *
+ * POST /web/website/:domain/unsubscribe { id?, email? }
+ *   Suppresses the address across person/customer/lead. Idempotent.
+ */
+
+function readParams(source: Record<string, any>): { id?: string; email?: string } {
+  const id = typeof source.id === "string" && source.id.trim() ? source.id.trim() : undefined;
+  const rawEmail =
+    typeof source.email === "string" && source.email.trim()
+      ? source.email.trim().toLowerCase()
+      : undefined;
+  const email = rawEmail && isValidEmail(rawEmail) ? rawEmail : undefined;
+  return { id, email };
+}
+
+async function assertWebsite(req: MedusaRequest) {
+  const { domain } = req.params;
+  const websiteResponse = await findWebsiteByDomainWorkflow(req.scope).run({
+    input: { domain },
+  });
+  if (websiteResponse.errors.length > 0) {
+    throw websiteResponse.errors;
+  }
+}
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  await assertWebsite(req);
+  const { id, email } = readParams(req.query as Record<string, any>);
+
+  if (!id && !email) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "An id or email is required to identify the subscription"
+    );
+  }
+
+  const services = resolveUnsubServices(req.scope);
+  const target = email || (id ? await resolveEmailById(services, id) : null);
+
+  if (!target) {
+    // The link's id no longer resolves (record deleted, or bad link). Report
+    // gracefully rather than 500 — the page shows a neutral "already removed".
+    return res.status(200).json({ found: false, email: null });
+  }
+
+  return res.status(200).json({ found: true, email: maskEmail(target) });
+};
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  await assertWebsite(req);
+  // Body is not schema-validated in middleware (both fields optional); read from
+  // validatedBody when present, else the raw body.
+  const body = (req as any).validatedBody ?? req.body ?? {};
+  const { id, email } = readParams(body as Record<string, any>);
+
+  if (!id && !email) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "An id or email is required to unsubscribe"
+    );
+  }
+
+  const services = resolveUnsubServices(req.scope);
+  const target = email || (id ? await resolveEmailById(services, id) : null);
+
+  if (!target) {
+    // Nothing to unsubscribe — treat as success (the recipient's goal is met).
+    return res.status(200).json({
+      message: "You're not on our mailing list.",
+      email: null,
+      unsubscribed: 0,
+    });
+  }
+
+  const at = new Date().toISOString();
+  const result = await suppressEmailEverywhere(services, target, at);
+
+  return res.status(200).json({
+    message: result.alreadyOff
+      ? "You're already unsubscribed."
+      : "You've been unsubscribed. You won't receive these emails anymore.",
+    email: maskEmail(target),
+    unsubscribed: result.suppressed,
+    already_off: result.alreadyOff,
+  });
+};

--- a/apps/backend/src/api/webhooks/mailjet/events/route.ts
+++ b/apps/backend/src/api/webhooks/mailjet/events/route.ts
@@ -1,0 +1,64 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+import { parseMailjetEvents } from "../../../../modules/email_suppression/provider-parsers"
+import { suppressEmail } from "../../../../modules/email_suppression/suppress-core"
+
+/**
+ * POST /webhooks/mailjet/events
+ *
+ * Mailjet Event API (triggers) webhook. Handles bounce / blocked / spam / unsub
+ * → auto-suppresses the recipient across person/customer/lead + writes an
+ * `email_suppression` audit row.
+ *
+ * Mailjet does not HMAC-sign payloads, so the endpoint is gated by a shared
+ * secret: set `MAILJET_WEBHOOK_SECRET` and append `?token=<secret>` (or send
+ * header `x-webhook-token: <secret>`) on the Mailjet event trigger URL. When the
+ * env is unset the gate is open (dev only) and a warning is logged.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+
+  const secret = process.env.MAILJET_WEBHOOK_SECRET
+  if (secret) {
+    const provided =
+      (req.query?.token as string) || (req.headers["x-webhook-token"] as string) || ""
+    if (provided !== secret) {
+      logger.warn("[Mailjet Events] Rejected — bad or missing token")
+      return res.status(401).send("Unauthorized")
+    }
+  } else {
+    logger.warn("[Mailjet Events] MAILJET_WEBHOOK_SECRET not set — gate is open")
+  }
+
+  const body = req.body as any
+  const items = parseMailjetEvents(body)
+
+  // Ack immediately; process async (Mailjet retries on non-2xx).
+  res.status(200).send("OK")
+
+  processMailjetEvents(req.scope, body, items).catch((error) => {
+    logger.error("[Mailjet Events] Failed to process events:", error as Error)
+  })
+}
+
+async function processMailjetEvents(scope: any, body: any, items: any[]): Promise<void> {
+  const logger: any = scope.resolve(ContainerRegistrationKeys.LOGGER)
+  if (!items.length) {
+    logger.info("[Mailjet Events] No actionable events in payload")
+    return
+  }
+  for (const item of items) {
+    const outcome = await suppressEmail(scope, {
+      email: item.email,
+      reason: item.reason,
+      provider: "mailjet",
+      event_id: item.event_id,
+      event_at: item.event_at,
+      raw: item,
+    })
+    logger.info(
+      `[Mailjet Events] ${item.reason} ${item.email} → suppressed=${outcome.suppressed} (p:${outcome.persons} c:${outcome.customers} l:${outcome.leads})${outcome.duplicate ? " [dup]" : ""}`
+    )
+  }
+}

--- a/apps/backend/src/api/webhooks/resend/email-events/route.ts
+++ b/apps/backend/src/api/webhooks/resend/email-events/route.ts
@@ -1,0 +1,112 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { Webhook } from "svix"
+
+import { SOCIALS_MODULE } from "../../../../modules/socials"
+import { ENCRYPTION_MODULE } from "../../../../modules/encryption"
+import type EncryptionService from "../../../../modules/encryption/service"
+import type { EncryptedData } from "../../../../modules/encryption"
+import { parseResendEvent } from "../../../../modules/email_suppression/provider-parsers"
+import { suppressEmail } from "../../../../modules/email_suppression/suppress-core"
+
+/**
+ * POST /webhooks/resend/email-events
+ *
+ * Resend delivery-event webhook (Svix-signed). Handles `email.bounced` and
+ * `email.complained` → auto-suppresses the recipient across person/customer/lead
+ * and writes an `email_suppression` audit row. Distinct from the inbound-email
+ * webhook (`/webhooks/inbound-email/resend`, which handles `email.received`).
+ *
+ * Reuses the same signing secret stored on the Resend SocialPlatform config, so
+ * point Resend's bounce/complaint events at this URL with the same secret.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+
+  // Raw body for signature verification.
+  let rawBody = ""
+  await new Promise<void>((resolve, reject) => {
+    req.on("data", (chunk) => {
+      rawBody += chunk.toString("utf8")
+    })
+    req.on("end", () => resolve())
+    req.on("error", (err) => reject(err))
+  })
+
+  // Signing secret from the active Resend email platform config.
+  const socialsService = req.scope.resolve(SOCIALS_MODULE) as any
+  const platforms = await socialsService.listSocialPlatforms({})
+  const resendPlatform = platforms.find(
+    (p: any) =>
+      p.category === "email" &&
+      p.status === "active" &&
+      (p.api_config as any)?.provider === "resend"
+  )
+  if (!resendPlatform) {
+    logger.error("[Resend Events] No active Resend email provider configured")
+    return res.status(404).send("Resend provider not configured")
+  }
+
+  const apiConfig = resendPlatform.api_config as Record<string, any>
+  let signingSecret: string
+  if (apiConfig.webhook_signing_secret_encrypted) {
+    const encryptionService = req.scope.resolve(ENCRYPTION_MODULE) as EncryptionService
+    signingSecret = encryptionService.decrypt(
+      apiConfig.webhook_signing_secret_encrypted as EncryptedData
+    )
+  } else if (apiConfig.webhook_signing_secret) {
+    signingSecret = apiConfig.webhook_signing_secret
+  } else {
+    logger.error("[Resend Events] No webhook signing secret configured")
+    return res.status(500).send("Webhook signing secret not configured")
+  }
+
+  const svixId = req.headers["svix-id"] as string
+  const svixTimestamp = req.headers["svix-timestamp"] as string
+  const svixSignature = req.headers["svix-signature"] as string
+  if (!svixId || !svixTimestamp || !svixSignature) {
+    return res.status(401).send("Missing signature headers")
+  }
+
+  let payload: any
+  try {
+    const wh = new Webhook(signingSecret)
+    payload = wh.verify(rawBody, {
+      "svix-id": svixId,
+      "svix-timestamp": svixTimestamp,
+      "svix-signature": svixSignature,
+    }) as any
+  } catch (err: any) {
+    logger.error("[Resend Events] Signature verification failed:", err?.message)
+    return res.status(401).send("Invalid signature")
+  }
+
+  // Ack immediately, process async (Resend retries on non-2xx).
+  res.status(200).send("OK")
+
+  processResendDeliveryEvent(req.scope, payload).catch((error) => {
+    logger.error("[Resend Events] Failed to process event:", error as Error)
+  })
+}
+
+async function processResendDeliveryEvent(scope: any, payload: any): Promise<void> {
+  const logger: any = scope.resolve(ContainerRegistrationKeys.LOGGER)
+  const items = parseResendEvent(payload)
+  if (!items.length) {
+    logger.info(`[Resend Events] Ignoring event type: ${payload?.type}`)
+    return
+  }
+  for (const item of items) {
+    const outcome = await suppressEmail(scope, {
+      email: item.email,
+      reason: item.reason,
+      provider: "resend",
+      event_id: item.event_id,
+      event_at: item.event_at,
+      raw: payload,
+    })
+    logger.info(
+      `[Resend Events] ${item.reason} ${item.email} → suppressed=${outcome.suppressed} (p:${outcome.persons} c:${outcome.customers} l:${outcome.leads})${outcome.duplicate ? " [dup]" : ""}`
+    )
+  }
+}

--- a/apps/backend/src/modules/audience/__tests__/classifier.unit.spec.ts
+++ b/apps/backend/src/modules/audience/__tests__/classifier.unit.spec.ts
@@ -1,0 +1,87 @@
+import { classifyContact } from "../classifier"
+
+describe("audience classifier", () => {
+  it("customer → customer source/group/tag, mailable unconditionally", () => {
+    const c = classifyContact({ member_type: "customer", email: "c@x.com", metadata: {} })
+    expect(c.source).toBe("customer")
+    expect(c.groups).toEqual(["customers"])
+    expect(c.tags).toContain("customer")
+    expect(c.mailable).toBe(true)
+  })
+
+  it("lead → ad-lead", () => {
+    const c = classifyContact({ member_type: "lead", email: "l@x.com" })
+    expect(c.source).toBe("ad-lead")
+    expect(c.groups).toEqual(["ad-leads"])
+    expect(c.tags).toContain("ad-lead")
+  })
+
+  it("person with weaver metadata → weaver-directory (+gi tag)", () => {
+    const c = classifyContact({
+      member_type: "person",
+      email: "w@x.com",
+      metadata: { metadata_district: "Nadia", metadata_is_gi_product: "yes" },
+      sub_active: true,
+    })
+    expect(c.source).toBe("weaver-directory")
+    expect(c.tags).toEqual(expect.arrayContaining(["weaver-directory", "gi-product", "subscriber"]))
+  })
+
+  it("person imported on the bulk-import day (no weaver meta) still → weaver-directory", () => {
+    const c = classifyContact({
+      member_type: "person",
+      email: "w2@x.com",
+      metadata: {},
+      created_at: "2025-07-10T12:00:00.000Z",
+    })
+    expect(c.source).toBe("weaver-directory")
+  })
+
+  it("person, later date, no weaver meta → organic", () => {
+    const c = classifyContact({
+      member_type: "person",
+      email: "o@x.com",
+      metadata: {},
+      created_at: "2026-03-22T00:00:00.000Z",
+      sub_active: true,
+    })
+    expect(c.source).toBe("organic")
+    expect(c.tags).toEqual(expect.arrayContaining(["organic", "subscriber"]))
+  })
+
+  it("onboarding-finished person is tagged", () => {
+    const c = classifyContact({
+      member_type: "person",
+      email: "f@x.com",
+      metadata: { metadata_district: "X" },
+      state: "Onboarding Finished",
+      sub_active: true,
+    })
+    expect(c.tags).toContain("onboarding-finished")
+  })
+
+  it("bounced/unsubscribed persons are tagged and NOT mailable", () => {
+    const bounced = classifyContact({
+      member_type: "person", email: "b@x.com", metadata: { bounced: true }, sub_active: true,
+    })
+    expect(bounced.tags).toContain("bounced")
+    expect(bounced.mailable).toBe(false)
+
+    const unsub = classifyContact({
+      member_type: "person", email: "u@x.com", metadata: { unsubscribed: true }, sub_active: true,
+    })
+    expect(unsub.tags).toContain("unsubscribed")
+    expect(unsub.mailable).toBe(false)
+  })
+
+  it("person without an active sub is not mailable (no active email subscription)", () => {
+    const c = classifyContact({ member_type: "person", email: "n@x.com", metadata: {}, sub_active: false })
+    expect(c.mailable).toBe(false)
+    expect(c.tags).not.toContain("subscriber")
+  })
+
+  it("bounced customer is not mailable", () => {
+    const c = classifyContact({ member_type: "customer", email: "bc@x.com", metadata: { bounced: true } })
+    expect(c.mailable).toBe(false)
+  })
+})

--- a/apps/backend/src/modules/audience/classifier.ts
+++ b/apps/backend/src/modules/audience/classifier.ts
@@ -1,0 +1,115 @@
+/**
+ * PURE audience classifier — given a raw contact from any of the three sources,
+ * infer its `source`, `groups`, and `tags`. No IO; fully unit-testable.
+ *
+ * Grounded in the 2026-07-04 profiling of the real audience (#881): the person
+ * list is dominated by a handloom WEAVER DIRECTORY bulk-imported on 2025-07-10
+ * (weaver metadata: district / weave_practiced / technique / is_gi_product / …),
+ * with a smaller tail of organic subscribers, plus 22 customers and ~1 lead.
+ * There is no `person.source` column, so origin is inferred from these signals.
+ */
+
+export type MemberType = "person" | "customer" | "lead"
+
+export type ClassifierInput = {
+  member_type: MemberType
+  email: string
+  metadata?: Record<string, any> | null
+  /** person only — "Onboarding" | "Onboarding Finished" | … */
+  state?: string | null
+  /** person only — active email subscription? */
+  sub_active?: boolean
+  /** ISO or Date — used to detect the bulk-import cohort. */
+  created_at?: string | Date | null
+}
+
+export type Classification = {
+  source: string
+  groups: string[]
+  tags: string[]
+  mailable: boolean
+}
+
+export type ClassifierOptions = {
+  /** YYYY-MM-DD of the weaver bulk import. Default 2025-07-10. */
+  importDay?: string
+  /** metadata keys that mark a weaver-directory person. */
+  weaverKeys?: string[]
+}
+
+const DEFAULT_IMPORT_DAY = "2025-07-10"
+const DEFAULT_WEAVER_KEYS = [
+  "metadata_district",
+  "metadata_District",
+  "metadata_weave_practiced",
+  "metadata_technique",
+  "metadata_weaving_technique",
+  "metadata_is_gi_product",
+  "metadata_gi_product",
+  "metadata_product",
+  "metadata_award_received",
+  "metadata_photo_of_weaver",
+  "metadata_exclusive_handloom_products",
+]
+
+function dayOf(v: string | Date | null | undefined): string {
+  if (!v) return ""
+  const s = typeof v === "string" ? v : v.toISOString()
+  return s.slice(0, 10)
+}
+
+function hasWeaverMeta(meta: Record<string, any>, keys: string[]): boolean {
+  return keys.some((k) => k in meta)
+}
+
+export function classifyContact(
+  input: ClassifierInput,
+  opts: ClassifierOptions = {}
+): Classification {
+  const importDay = opts.importDay || DEFAULT_IMPORT_DAY
+  const weaverKeys = opts.weaverKeys || DEFAULT_WEAVER_KEYS
+  const meta = input.metadata || {}
+
+  const tags = new Set<string>()
+  let source: string
+  const groups: string[] = []
+
+  if (input.member_type === "customer") {
+    source = "customer"
+    groups.push("customers")
+    tags.add("customer")
+  } else if (input.member_type === "lead") {
+    source = "ad-lead"
+    groups.push("ad-leads")
+    tags.add("ad-lead")
+  } else {
+    // person — weaver directory vs organic
+    const weaver = hasWeaverMeta(meta, weaverKeys) || dayOf(input.created_at) === importDay
+    if (weaver) {
+      source = "weaver-directory"
+      groups.push("weaver-directory")
+      tags.add("weaver-directory")
+      // GI-tagged handloom products are a notable sub-segment.
+      if (meta.metadata_is_gi_product || meta.metadata_gi_product) tags.add("gi-product")
+    } else {
+      source = "organic"
+      groups.push("organic")
+      tags.add("organic")
+    }
+    if (input.state === "Onboarding Finished") tags.add("onboarding-finished")
+    if (input.sub_active) tags.add("subscriber")
+  }
+
+  // Cross-cutting suppression flags — mailability depends on these.
+  const bounced = !!meta.bounced
+  const unsubscribed = !!meta.unsubscribed
+  if (bounced) tags.add("bounced")
+  if (unsubscribed) tags.add("unsubscribed")
+
+  // Mailable = not suppressed, and for persons requires an active subscription
+  // (customers/leads are mailed unconditionally by the send today).
+  let mailable = !bounced && !unsubscribed
+  if (input.member_type === "person") mailable = mailable && !!input.sub_active
+
+  return { source, groups, tags: [...tags], mailable }
+}

--- a/apps/backend/src/modules/audience/index.ts
+++ b/apps/backend/src/modules/audience/index.ts
@@ -1,0 +1,12 @@
+import { Module } from "@medusajs/framework/utils"
+import AudienceService from "./service"
+
+export const AUDIENCE_MODULE = "audience"
+
+const AudienceModule = Module(AUDIENCE_MODULE, {
+  service: AudienceService,
+})
+
+export { AudienceModule }
+
+export default AudienceModule

--- a/apps/backend/src/modules/audience/migrations/Migration20260704130000.ts
+++ b/apps/backend/src/modules/audience/migrations/Migration20260704130000.ts
@@ -1,0 +1,21 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+export class Migration20260704130000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table if not exists "audience_group" ("id" text not null, "key" text not null, "label" text not null, "kind" text check ("kind" in ('source', 'manual', 'smart')) not null default 'source', "description" text null, "metadata" jsonb null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "audience_group_pkey" primary key ("id"));`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_audience_group_deleted_at" ON "audience_group" ("deleted_at") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_audience_group_key" ON "audience_group" ("key") WHERE deleted_at IS NULL;`);
+
+    this.addSql(`create table if not exists "audience_entry" ("id" text not null, "email" text not null, "member_type" text check ("member_type" in ('person', 'customer', 'lead')) not null, "member_id" text not null, "first_name" text null, "last_name" text null, "source" text null, "groups" jsonb null, "tags" jsonb null, "mailable" boolean not null default true, "metadata" jsonb null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "audience_entry_pkey" primary key ("id"));`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_audience_entry_deleted_at" ON "audience_entry" ("deleted_at") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_audience_entry_email" ON "audience_entry" ("email") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_audience_entry_source" ON "audience_entry" ("source") WHERE deleted_at IS NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "audience_entry" cascade;`);
+    this.addSql(`drop table if exists "audience_group" cascade;`);
+  }
+
+}

--- a/apps/backend/src/modules/audience/models/audience-entry.ts
+++ b/apps/backend/src/modules/audience/models/audience-entry.ts
@@ -1,0 +1,35 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * The unified, deduped audience — ONE row per email, merging the three sources
+ * the send unions (person / customer / lead). This is the "merge the leads,
+ * customers and persons into one tagged list" artifact (#881): each entry
+ * carries its inferred `source`, the `groups` it belongs to, and cross-cutting
+ * `tags`, so a send can target `groups`/`tags` and resolve to emails directly.
+ *
+ * Materialized by the classifier backfill from the source-of-truth records; a
+ * refresh job keeps it current. `member_type`/`member_id` point back at the
+ * primary source record for that email.
+ */
+const AudienceEntry = model.define("audience_entry", {
+  id: model.id({ prefix: "aud_entry" }).primaryKey(),
+  // The join key — unique per audience. Lower-cased.
+  email: model.text().searchable(),
+  member_type: model.enum(["person", "customer", "lead"]),
+  member_id: model.text(),
+  first_name: model.text().nullable(),
+  last_name: model.text().nullable(),
+  // Inferred origin (weaver-directory | organic | customer | ad-lead | unknown).
+  source: model.text().nullable(),
+  // Group keys this entry belongs to (denormalized for fast send-time filtering).
+  groups: model.json().nullable(),
+  // Cross-cutting labels (source + flags: subscriber | onboarding-finished |
+  // bounced | unsubscribed | gi-product | …).
+  tags: model.json().nullable(),
+  // Whether this contact is currently mailable (not bounced/unsubscribed, and —
+  // for persons — has an active email subscription).
+  mailable: model.boolean().default(true),
+  metadata: model.json().nullable(),
+})
+
+export default AudienceEntry

--- a/apps/backend/src/modules/audience/models/audience-group.ts
+++ b/apps/backend/src/modules/audience/models/audience-group.ts
@@ -1,0 +1,21 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * A named audience segment. Groups are how the operator targets a send at a
+ * subset instead of the whole flat list (#881). `kind`:
+ *   - source: auto-derived from where a contact came from (weaver-directory,
+ *     organic, customers, ad-leads) — populated by the classifier backfill.
+ *   - manual: an operator-curated list.
+ *   - smart: rule-defined (future).
+ */
+const AudienceGroup = model.define("audience_group", {
+  id: model.id({ prefix: "aud_grp" }).primaryKey(),
+  // Stable slug used by the send path + classifier (e.g. "weaver-directory").
+  key: model.text().searchable(),
+  label: model.text(),
+  kind: model.enum(["source", "manual", "smart"]).default("source"),
+  description: model.text().nullable(),
+  metadata: model.json().nullable(),
+})
+
+export default AudienceGroup

--- a/apps/backend/src/modules/audience/service.ts
+++ b/apps/backend/src/modules/audience/service.ts
@@ -1,0 +1,10 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import AudienceGroup from "./models/audience-group"
+import AudienceEntry from "./models/audience-entry"
+
+class AudienceService extends MedusaService({
+  AudienceGroup,
+  AudienceEntry,
+}) {}
+
+export default AudienceService

--- a/apps/backend/src/modules/deployment/__tests__/account-selector.unit.spec.ts
+++ b/apps/backend/src/modules/deployment/__tests__/account-selector.unit.spec.ts
@@ -1,0 +1,74 @@
+import {
+  remainingCapacity,
+  isFull,
+  isEligible,
+  selectDeploymentAccount,
+  type DeploymentAccountRow,
+} from "../account-selector"
+
+const acct = (o: Partial<DeploymentAccountRow>): DeploymentAccountRow => ({
+  id: o.id || "a", provider: o.provider || "vercel", label: o.label || "a",
+  cutoff_max: o.cutoff_max, project_count: o.project_count, priority: o.priority, status: o.status,
+})
+
+describe("deployment account-selector — capacity", () => {
+  it("remainingCapacity respects cap; uncapped = Infinity", () => {
+    expect(remainingCapacity(acct({ cutoff_max: 10, project_count: 7 }))).toBe(3)
+    expect(remainingCapacity(acct({ cutoff_max: null, project_count: 999 }))).toBe(Infinity)
+    expect(remainingCapacity(acct({ cutoff_max: 5, project_count: 5 }))).toBe(0)
+  })
+  it("isFull / isEligible", () => {
+    expect(isFull(acct({ cutoff_max: 5, project_count: 5 }))).toBe(true)
+    expect(isEligible(acct({ cutoff_max: 5, project_count: 5 }))).toBe(false)
+    expect(isEligible(acct({ status: "inactive", cutoff_max: 10, project_count: 0 }))).toBe(false)
+    expect(isEligible(acct({ status: "active", cutoff_max: 10, project_count: 2 }))).toBe(true)
+  })
+})
+
+describe("deployment account-selector — selection", () => {
+  it("picks the least-loaded eligible account", () => {
+    const pick = selectDeploymentAccount([
+      acct({ id: "v1", project_count: 8, cutoff_max: 10 }),
+      acct({ id: "v2", project_count: 3, cutoff_max: 10 }),
+      acct({ id: "v3", project_count: 5, cutoff_max: 10 }),
+    ])
+    expect(pick?.id).toBe("v2")
+  })
+
+  it("skips full and inactive accounts", () => {
+    const pick = selectDeploymentAccount([
+      acct({ id: "full", project_count: 10, cutoff_max: 10 }),
+      acct({ id: "off", status: "inactive", project_count: 0, cutoff_max: 10 }),
+      acct({ id: "ok", project_count: 9, cutoff_max: 10 }),
+    ])
+    expect(pick?.id).toBe("ok")
+  })
+
+  it("returns null when every account is full/inactive (add or round-up)", () => {
+    expect(
+      selectDeploymentAccount([
+        acct({ id: "a", project_count: 10, cutoff_max: 10 }),
+        acct({ id: "b", status: "full", project_count: 0, cutoff_max: 10 }),
+      ])
+    ).toBeNull()
+  })
+
+  it("filters by provider", () => {
+    const pick = selectDeploymentAccount(
+      [
+        acct({ id: "v", provider: "vercel", project_count: 0 }),
+        acct({ id: "cf", provider: "cloudflare", project_count: 2 }),
+      ],
+      { provider: "cloudflare" }
+    )
+    expect(pick?.id).toBe("cf")
+  })
+
+  it("tiebreaks equal load by priority then headroom", () => {
+    const pick = selectDeploymentAccount([
+      acct({ id: "lo", project_count: 2, cutoff_max: 10, priority: 0 }),
+      acct({ id: "hi", project_count: 2, cutoff_max: 20, priority: 5 }),
+    ])
+    expect(pick?.id).toBe("hi")
+  })
+})

--- a/apps/backend/src/modules/deployment/account-selector.ts
+++ b/apps/backend/src/modules/deployment/account-selector.ts
@@ -1,0 +1,73 @@
+/**
+ * PURE deployment-account selection — least-loaded-under-cap rotation. No IO;
+ * unit-testable. The workflow resolves the accounts list, calls this to pick
+ * one, then increments its project_count on success.
+ */
+
+export type DeploymentProvider = "vercel" | "cloudflare" | "render" | "netlify"
+
+export type DeploymentAccountRow = {
+  id: string
+  provider: DeploymentProvider
+  label: string
+  cutoff_max?: number | null
+  project_count?: number | null
+  priority?: number | null
+  status?: "active" | "full" | "inactive"
+}
+
+/** PURE: projects still allowed on this account (Infinity when uncapped). */
+export function remainingCapacity(a: DeploymentAccountRow): number {
+  const cap = a.cutoff_max
+  if (cap == null || !Number.isFinite(cap)) return Infinity
+  return Math.max(0, cap - (a.project_count ?? 0))
+}
+
+/** PURE: is this account at/over its cutoff cap? */
+export function isFull(a: DeploymentAccountRow): boolean {
+  return remainingCapacity(a) <= 0
+}
+
+/** PURE: eligible = active status AND under its cap. */
+export function isEligible(a: DeploymentAccountRow): boolean {
+  return (a.status ?? "active") === "active" && !isFull(a)
+}
+
+export type SelectOptions = {
+  /** restrict to one provider (e.g. only Cloudflare). */
+  provider?: DeploymentProvider
+}
+
+/**
+ * Pick the account a new storefront should provision onto:
+ *   1. eligible only (active + under cutoff), optionally provider-filtered
+ *   2. least-loaded first (fewest projects) — spreads load
+ *   3. tiebreak: higher priority, then most remaining capacity, then label
+ * Returns null when nothing is eligible (caller should alert: add or round-up an
+ * account).
+ */
+export function selectDeploymentAccount(
+  accounts: DeploymentAccountRow[],
+  opts: SelectOptions = {}
+): DeploymentAccountRow | null {
+  const pool = (accounts ?? [])
+    .filter((a) => (opts.provider ? a.provider === opts.provider : true))
+    .filter(isEligible)
+
+  if (!pool.length) return null
+
+  pool.sort((a, b) => {
+    const la = a.project_count ?? 0
+    const lb = b.project_count ?? 0
+    if (la !== lb) return la - lb // least-loaded first
+    const pa = a.priority ?? 0
+    const pb = b.priority ?? 0
+    if (pa !== pb) return pb - pa // higher priority first
+    const ra = remainingCapacity(a)
+    const rb = remainingCapacity(b)
+    if (ra !== rb) return rb - ra // more headroom first
+    return a.label.localeCompare(b.label)
+  })
+
+  return pool[0]
+}

--- a/apps/backend/src/modules/deployment/migrations/Migration20260704140000.ts
+++ b/apps/backend/src/modules/deployment/migrations/Migration20260704140000.ts
@@ -1,0 +1,15 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+export class Migration20260704140000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table if not exists "deployment_account" ("id" text not null, "provider" text check ("provider" in ('vercel', 'cloudflare', 'render', 'netlify')) not null, "role" text not null default 'hosting', "label" text not null, "api_config" jsonb null, "cutoff_max" integer null, "project_count" integer not null default 0, "priority" integer not null default 0, "status" text check ("status" in ('active', 'full', 'inactive')) not null default 'active', "metadata" jsonb null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "deployment_account_pkey" primary key ("id"));`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_deployment_account_deleted_at" ON "deployment_account" ("deleted_at") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_deployment_account_provider_status" ON "deployment_account" ("provider", "status") WHERE deleted_at IS NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "deployment_account" cascade;`);
+  }
+
+}

--- a/apps/backend/src/modules/deployment/models/deployment-account.ts
+++ b/apps/backend/src/modules/deployment/models/deployment-account.ts
@@ -1,0 +1,38 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * A hosting/DNS provider account the platform can provision partner storefronts
+ * onto — modelled on the "external platform with encrypted creds by role"
+ * pattern (like SocialPlatform), but dedicated to deployment so hosting concerns
+ * stay out of the socials module.
+ *
+ * Multiple accounts per provider are supported so provisioning can ROTATE across
+ * them: each account has a `cutoff_max` (what a free tier allows) and a live
+ * `project_count`. The selector picks the least-loaded active account under its
+ * cap; when an account fills, flip `status` to "full" (the "cutoff") and new
+ * partners flow to the next. When you upgrade an account to paid, raise
+ * `cutoff_max` ("round up"). (partner storefront provisioning)
+ */
+const DeploymentAccount = model.define("deployment_account", {
+  id: model.id({ prefix: "dep_acct" }).primaryKey(),
+  provider: model.enum(["vercel", "cloudflare", "render", "netlify"]),
+  // Reserved for future non-hosting roles (e.g. dns). Hosting for now.
+  role: model.text().default("hosting"),
+  // Human label, e.g. "vercel-free-1", "cf-pages-main".
+  label: model.text().searchable(),
+  // Encrypted credentials + provider ids:
+  //   { token_encrypted, team_id, account_id, zone_id, ... }
+  // token stored as an EncryptedData object via the encryption module.
+  api_config: model.json().nullable(),
+  // Max projects this account may hold (free-tier ceiling). null = unlimited.
+  cutoff_max: model.number().nullable(),
+  // Live count of storefronts provisioned onto this account.
+  project_count: model.number().default(0),
+  // Tiebreaker when several accounts are equally loaded (higher = preferred).
+  priority: model.number().default(0),
+  // active = eligible; full = hit cutoff (manual or auto); inactive = disabled.
+  status: model.enum(["active", "full", "inactive"]).default("active"),
+  metadata: model.json().nullable(),
+})
+
+export default DeploymentAccount

--- a/apps/backend/src/modules/deployment/service.ts
+++ b/apps/backend/src/modules/deployment/service.ts
@@ -7,6 +7,8 @@
 
 import { MedusaService } from "@medusajs/framework/utils";
 
+import DeploymentAccount from "./models/deployment-account";
+
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 export type VercelProject = {
@@ -82,7 +84,7 @@ export type ApplyRecommendedDnsResult = {
 const VERCEL_API_BASE = "https://api.vercel.com"
 const CLOUDFLARE_API_BASE = "https://api.cloudflare.com/client/v4"
 
-class DeploymentService extends MedusaService({}) {
+class DeploymentService extends MedusaService({ DeploymentAccount }) {
   private log(level: "info" | "warn" | "error", msg: string, data?: any) {
     const prefix = `[DeploymentService]`
     if (data) {

--- a/apps/backend/src/modules/email_suppression/__tests__/bounce-suppression.unit.spec.ts
+++ b/apps/backend/src/modules/email_suppression/__tests__/bounce-suppression.unit.spec.ts
@@ -1,0 +1,107 @@
+import { parseMailjetEvents, parseResendEvent } from "../provider-parsers"
+import { normalizeEmail, reasonSuppresses, suppressionMetadata } from "../suppress-core"
+
+describe("provider-parsers — parseMailjetEvents", () => {
+  it("maps a hard bounce", () => {
+    expect(
+      parseMailjetEvents({ event: "bounce", email: "A@X.com", hard_bounce: true, MessageID: 42, time: 1_700_000_000 })
+    ).toEqual([
+      { email: "a@x.com", reason: "hard_bounce", event_id: "mj:bounce:42", event_at: new Date(1_700_000_000_000).toISOString() },
+    ])
+  })
+  it("maps a soft bounce (hard_bounce false)", () => {
+    expect(parseMailjetEvents({ event: "bounce", email: "a@x.com", hard_bounce: false })[0].reason).toBe("soft_bounce")
+  })
+  it("maps blocked→hard, spam→complaint, unsub→unsubscribe", () => {
+    expect(parseMailjetEvents({ event: "blocked", email: "a@x.com" })[0].reason).toBe("hard_bounce")
+    expect(parseMailjetEvents({ event: "spam", email: "a@x.com" })[0].reason).toBe("spam_complaint")
+    expect(parseMailjetEvents({ event: "unsub", email: "a@x.com" })[0].reason).toBe("unsubscribe")
+  })
+  it("ignores non-suppressing events + accepts arrays", () => {
+    const arr = [
+      { event: "sent", email: "a@x.com" },
+      { event: "open", email: "a@x.com" },
+      { event: "bounce", email: "b@y.com", hard_bounce: "true" },
+    ]
+    const out = parseMailjetEvents(arr)
+    expect(out).toHaveLength(1)
+    expect(out[0]).toMatchObject({ email: "b@y.com", reason: "hard_bounce" })
+  })
+  it("skips events with no email + tolerates junk", () => {
+    expect(parseMailjetEvents({ event: "bounce", hard_bounce: true })).toEqual([])
+    expect(parseMailjetEvents(null)).toEqual([])
+  })
+})
+
+describe("provider-parsers — parseResendEvent", () => {
+  it("maps email.bounced (default hard) across all recipients", () => {
+    const out = parseResendEvent({
+      type: "email.bounced",
+      created_at: "2026-07-04T00:00:00.000Z",
+      data: { email_id: "e1", to: ["A@X.com", "b@y.com"] },
+    })
+    expect(out).toHaveLength(2)
+    expect(out[0]).toEqual({
+      email: "a@x.com",
+      reason: "hard_bounce",
+      event_id: "rs:email.bounced:e1:a@x.com",
+      event_at: "2026-07-04T00:00:00.000Z",
+    })
+  })
+  it("classifies soft/transient bounce", () => {
+    expect(parseResendEvent({ type: "email.bounced", data: { to: "a@x.com", bounce: { type: "Transient" } } })[0].reason).toBe("soft_bounce")
+    expect(parseResendEvent({ type: "email.bounced", data: { to: "a@x.com", bounce: { type: "soft" } } })[0].reason).toBe("soft_bounce")
+  })
+  it("maps email.complained → spam_complaint", () => {
+    expect(parseResendEvent({ type: "email.complained", data: { to: ["a@x.com"] } })[0].reason).toBe("spam_complaint")
+  })
+  it("ignores delivered/other + empty recipients", () => {
+    expect(parseResendEvent({ type: "email.delivered", data: { to: ["a@x.com"] } })).toEqual([])
+    expect(parseResendEvent({ type: "email.bounced", data: { to: [] } })).toEqual([])
+  })
+})
+
+describe("suppress-core — normalizeEmail", () => {
+  it("lowercases + trims valid; empty for invalid", () => {
+    expect(normalizeEmail("  Jane@X.com ")).toBe("jane@x.com")
+    expect(normalizeEmail("nope")).toBe("")
+    expect(normalizeEmail(null)).toBe("")
+  })
+})
+
+describe("suppress-core — reasonSuppresses", () => {
+  it("suppresses everything except soft bounces", () => {
+    expect(reasonSuppresses("hard_bounce")).toBe(true)
+    expect(reasonSuppresses("spam_complaint")).toBe(true)
+    expect(reasonSuppresses("unsubscribe")).toBe(true)
+    expect(reasonSuppresses("manual")).toBe(true)
+    expect(reasonSuppresses("soft_bounce")).toBe(false)
+  })
+})
+
+describe("suppress-core — suppressionMetadata", () => {
+  const at = "2026-07-04T00:00:00.000Z"
+  it("hard_bounce → bounced, preserving existing", () => {
+    expect(suppressionMetadata({ keep: 1 }, "hard_bounce", at)).toEqual({
+      keep: 1, bounced: true, bounced_at: at, bounce_reason: "hard_bounce",
+    })
+  })
+  it("spam_complaint → bounced + complained", () => {
+    expect(suppressionMetadata(null, "spam_complaint", at)).toEqual({
+      bounced: true, bounced_at: at, complained: true, complained_at: at, bounce_reason: "spam_complaint",
+    })
+  })
+  it("unsubscribe → unsubscribed", () => {
+    expect(suppressionMetadata(null, "unsubscribe", at)).toEqual({ unsubscribed: true, unsubscribed_at: at })
+  })
+  it("is idempotent per reason", () => {
+    expect(suppressionMetadata({ bounced: true }, "hard_bounce", at)).toBeNull()
+    expect(suppressionMetadata({ unsubscribed: true }, "unsubscribe", at)).toBeNull()
+    expect(suppressionMetadata({ bounced: true, complained: true }, "spam_complaint", at)).toBeNull()
+  })
+  it("upgrades a bounced record to also complained", () => {
+    expect(suppressionMetadata({ bounced: true, bounced_at: "old" }, "spam_complaint", at)).toEqual({
+      bounced: true, bounced_at: "old", complained: true, complained_at: at, bounce_reason: "spam_complaint",
+    })
+  })
+})

--- a/apps/backend/src/modules/email_suppression/index.ts
+++ b/apps/backend/src/modules/email_suppression/index.ts
@@ -1,0 +1,12 @@
+import { Module } from "@medusajs/framework/utils"
+import EmailSuppressionService from "./service"
+
+export const EMAIL_SUPPRESSION_MODULE = "email_suppression"
+
+const EmailSuppressionModule = Module(EMAIL_SUPPRESSION_MODULE, {
+  service: EmailSuppressionService,
+})
+
+export { EmailSuppressionModule }
+
+export default EmailSuppressionModule

--- a/apps/backend/src/modules/email_suppression/migrations/Migration20260704120000.ts
+++ b/apps/backend/src/modules/email_suppression/migrations/Migration20260704120000.ts
@@ -1,0 +1,16 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+export class Migration20260704120000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table if not exists "email_suppression" ("id" text not null, "email" text not null, "reason" text check ("reason" in ('hard_bounce', 'soft_bounce', 'spam_complaint', 'unsubscribe', 'manual')) not null default 'hard_bounce', "provider" text check ("provider" in ('mailjet', 'resend', 'manual', 'other')) not null default 'other', "event_id" text null, "event_at" timestamptz null, "suppressed" boolean not null default false, "persons" integer not null default 0, "customers" integer not null default 0, "leads" integer not null default 0, "raw" jsonb null, "metadata" jsonb null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "email_suppression_pkey" primary key ("id"));`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_email_suppression_deleted_at" ON "email_suppression" ("deleted_at") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_email_suppression_email" ON "email_suppression" ("email") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_email_suppression_event_id" ON "email_suppression" ("event_id") WHERE deleted_at IS NULL AND event_id IS NOT NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "email_suppression" cascade;`);
+  }
+
+}

--- a/apps/backend/src/modules/email_suppression/models/email-suppression.ts
+++ b/apps/backend/src/modules/email_suppression/models/email-suppression.ts
@@ -1,0 +1,37 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * One row per suppression event — the durable, queryable log of "why is this
+ * address off the list". Written by BOTH the provider bounce/complaint webhooks
+ * (Mailjet + Resend) and the manual CSV Data-Plumbing job, so bounce state has a
+ * single source of truth instead of only living in scattered `metadata.bounced`
+ * flags (those become a denormalized cache of the latest row here). (#881 / #839)
+ */
+const EmailSuppression = model.define("email_suppression", {
+  id: model.id({ prefix: "email_supp" }).primaryKey(),
+  // The join key — the send path dedupes recipients by email across
+  // person/customer/lead, so email is what we suppress on.
+  email: model.text().searchable(),
+  reason: model
+    .enum(["hard_bounce", "soft_bounce", "spam_complaint", "unsubscribe", "manual"])
+    .default("hard_bounce"),
+  provider: model
+    .enum(["mailjet", "resend", "manual", "other"])
+    .default("other"),
+  // Provider-side event id — used for idempotency so a re-delivered webhook is a
+  // no-op. Nullable (manual runs have none).
+  event_id: model.text().nullable(),
+  // When the provider recorded the event (not when we processed it).
+  event_at: model.dateTime().nullable(),
+  // Did this event actually flip a record off (vs already-off / no match)?
+  suppressed: model.boolean().default(false),
+  // How many records were flipped, per source.
+  persons: model.number().default(0),
+  customers: model.number().default(0),
+  leads: model.number().default(0),
+  // Raw provider payload snippet (for debugging / audit).
+  raw: model.json().nullable(),
+  metadata: model.json().nullable(),
+})
+
+export default EmailSuppression

--- a/apps/backend/src/modules/email_suppression/provider-parsers.ts
+++ b/apps/backend/src/modules/email_suppression/provider-parsers.ts
@@ -1,0 +1,91 @@
+import type { SuppressReason } from "./suppress-core"
+
+/**
+ * PURE provider→normalized-event parsers. Each ESP posts a different shape; both
+ * reduce to a flat list of suppression items the webhook routes feed to
+ * `suppressEmail`. No IO here — fully unit-testable.
+ */
+
+export type SuppressItem = {
+  email: string
+  reason: SuppressReason
+  event_id: string | null
+  event_at: string | null
+}
+
+/**
+ * Mailjet Event API. Payload is a single event object OR an array of them (when
+ * "group events" is enabled). Relevant events:
+ *   bounce (hard_bounce flag) · blocked · spam · unsub
+ * Everything else (sent/open/click/…) is ignored.
+ * Docs: https://dev.mailjet.com/email/guides/webhooks/
+ */
+export function parseMailjetEvents(body: any): SuppressItem[] {
+  const events = Array.isArray(body) ? body : body ? [body] : []
+  const out: SuppressItem[] = []
+  for (const e of events) {
+    if (!e || typeof e !== "object") continue
+    const email = String(e.email || "").trim().toLowerCase()
+    if (!email) continue
+    const type = String(e.event || "").toLowerCase()
+    let reason: SuppressReason | null = null
+    if (type === "bounce") {
+      // hard_bounce may arrive as boolean true or string "true".
+      const hard = e.hard_bounce === true || e.hard_bounce === "true"
+      reason = hard ? "hard_bounce" : "soft_bounce"
+    } else if (type === "blocked") {
+      reason = "hard_bounce"
+    } else if (type === "spam") {
+      reason = "spam_complaint"
+    } else if (type === "unsub") {
+      reason = "unsubscribe"
+    }
+    if (!reason) continue
+    // MessageID/MessageGUID identify the send; combine with event type so a
+    // bounce and a later spam on the same message are distinct rows.
+    const mid = e.MessageID ?? e.MessageGUID ?? e.mid ?? ""
+    const event_id = mid ? `mj:${type}:${mid}` : null
+    const at =
+      typeof e.time === "number" ? new Date(e.time * 1000).toISOString() : null
+    out.push({ email, reason, event_id, event_at: at })
+  }
+  return out
+}
+
+/**
+ * Resend webhook event. Single object: { type, created_at, data:{ email_id, to[],
+ * bounce?:{ type } } }. Relevant types: email.bounced, email.complained.
+ * Docs: https://resend.com/docs/dashboard/webhooks/event-types
+ */
+export function parseResendEvent(body: any): SuppressItem[] {
+  if (!body || typeof body !== "object") return []
+  const type = String(body.type || "").toLowerCase()
+  const data = body.data || {}
+  const recipients: string[] = Array.isArray(data.to)
+    ? data.to
+    : data.to
+    ? [data.to]
+    : []
+  const emails = recipients.map((r) => String(r || "").trim().toLowerCase()).filter(Boolean)
+  if (!emails.length) return []
+
+  let reason: SuppressReason | null = null
+  if (type === "email.bounced") {
+    // bounce.type: "hard"/"soft" or Resend's "Permanent"/"Transient".
+    const bt = String(data.bounce?.type || data.bounce_type || "").toLowerCase()
+    reason = bt.startsWith("soft") || bt.startsWith("transient") ? "soft_bounce" : "hard_bounce"
+  } else if (type === "email.complained") {
+    reason = "spam_complaint"
+  }
+  if (!reason) return []
+
+  const at = body.created_at ? new Date(body.created_at).toISOString() : null
+  const baseId = data.email_id || body.id || ""
+  return emails.map((email) => ({
+    email,
+    reason: reason as SuppressReason,
+    // email_id is per-message; pair with recipient + type for a stable key.
+    event_id: baseId ? `rs:${type}:${baseId}:${email}` : null,
+    event_at: at,
+  }))
+}

--- a/apps/backend/src/modules/email_suppression/service.ts
+++ b/apps/backend/src/modules/email_suppression/service.ts
@@ -1,0 +1,8 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import EmailSuppression from "./models/email-suppression"
+
+class EmailSuppressionService extends MedusaService({
+  EmailSuppression,
+}) {}
+
+export default EmailSuppressionService

--- a/apps/backend/src/modules/email_suppression/suppress-core.ts
+++ b/apps/backend/src/modules/email_suppression/suppress-core.ts
@@ -1,0 +1,224 @@
+import { Modules } from "@medusajs/framework/utils"
+
+import { PERSON_MODULE } from "../person"
+import { SOCIALS_MODULE } from "../socials"
+import { EMAIL_SUPPRESSION_MODULE } from "./index"
+
+/**
+ * Shared suppression core — the ONE place an email gets taken out of the
+ * newsletter/blog audience, called from:
+ *   - the provider bounce/complaint webhooks (Mailjet + Resend), and
+ *   - the manual CSV Data-Plumbing job.
+ *
+ * It flips person/customer/lead records (the three sources the send unions) and
+ * writes an `email_suppression` audit row. Idempotent on `event_id` so a
+ * re-delivered webhook is a no-op.
+ */
+
+export type SuppressReason =
+  | "hard_bounce"
+  | "soft_bounce"
+  | "spam_complaint"
+  | "unsubscribe"
+  | "manual"
+
+export type SuppressProvider = "mailjet" | "resend" | "manual" | "other"
+
+export type SuppressInput = {
+  email: string
+  reason: SuppressReason
+  provider: SuppressProvider
+  /** Provider event id for idempotency (optional). */
+  event_id?: string | null
+  /** When the provider recorded the event (ISO). */
+  event_at?: string | null
+  /** Raw provider payload snippet for audit. */
+  raw?: any
+}
+
+export type SuppressOutcome = {
+  email: string
+  reason: SuppressReason
+  /** true when we flipped at least one record off. */
+  suppressed: boolean
+  persons: number
+  customers: number
+  leads: number
+  matched: number
+  /** true when skipped because the same event_id was already processed. */
+  duplicate: boolean
+  /** true when this reason only logs and doesn't flip records (soft bounce). */
+  logged_only: boolean
+}
+
+const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/
+
+/** PURE: normalize + validate an email; "" if invalid. */
+export function normalizeEmail(raw: unknown): string {
+  const e = String(raw ?? "").trim().toLowerCase()
+  return EMAIL_RE.test(e) ? e : ""
+}
+
+/**
+ * PURE: which reasons actually remove someone from the list. Soft bounces are
+ * transient (mailbox full, greylisting) so we LOG them but keep the recipient —
+ * only hard bounces, spam complaints, explicit unsubscribes and manual entries
+ * suppress. This is the deliverability policy in one place.
+ */
+export function reasonSuppresses(reason: SuppressReason): boolean {
+  return reason !== "soft_bounce"
+}
+
+/**
+ * PURE: the metadata fields to stamp for a suppression reason, merged over
+ * existing metadata (Medusa replaces the whole blob on update). Returns null
+ * when the record already carries the flag (idempotent no-op).
+ *
+ *  - hard_bounce / soft_bounce  → metadata.bounced
+ *  - spam_complaint             → metadata.bounced + metadata.complained
+ *  - unsubscribe                → metadata.unsubscribed
+ *  - manual                     → metadata.bounced (treated as a hard suppression)
+ */
+export function suppressionMetadata(
+  existing: Record<string, any> | null | undefined,
+  reason: SuppressReason,
+  at: string
+): Record<string, any> | null {
+  const m = existing || {}
+  if (reason === "unsubscribe") {
+    if (m.unsubscribed === true) return null
+    return { ...m, unsubscribed: true, unsubscribed_at: at }
+  }
+  if (reason === "spam_complaint") {
+    if (m.bounced === true && m.complained === true) return null
+    return {
+      ...m,
+      bounced: true,
+      bounced_at: m.bounced_at || at,
+      complained: true,
+      complained_at: at,
+      bounce_reason: "spam_complaint",
+    }
+  }
+  // hard_bounce | soft_bounce | manual → bounced
+  if (m.bounced === true) return null
+  return {
+    ...m,
+    bounced: true,
+    bounced_at: at,
+    bounce_reason: reason,
+  }
+}
+
+/**
+ * Suppress a single email across all three sources + write the audit row.
+ * Container-driven (resolves person / customer / socials / email_suppression).
+ */
+export async function suppressEmail(
+  container: any,
+  input: SuppressInput
+): Promise<SuppressOutcome> {
+  const email = normalizeEmail(input.email)
+  const reason = input.reason
+  const at = input.event_at || new Date().toISOString()
+
+  const personService: any = container.resolve(PERSON_MODULE)
+  const customerService: any = container.resolve(Modules.CUSTOMER)
+  const socialsService: any = container.resolve(SOCIALS_MODULE)
+  const suppressionService: any = container.resolve(EMAIL_SUPPRESSION_MODULE)
+
+  const base: SuppressOutcome = {
+    email,
+    reason,
+    suppressed: false,
+    persons: 0,
+    customers: 0,
+    leads: 0,
+    matched: 0,
+    duplicate: false,
+    logged_only: false,
+  }
+
+  if (!email) return base
+
+  // Idempotency: same provider event already processed → no-op.
+  if (input.event_id) {
+    const existing = await suppressionService
+      .listEmailSuppressions({ event_id: input.event_id }, { take: 1 })
+      .catch(() => [])
+    if (existing?.length) return { ...base, duplicate: true }
+  }
+
+  const flip = reasonSuppresses(reason)
+
+  if (flip) {
+    // Persons — subscription inactive + metadata flag.
+    const people: any[] = await personService
+      .listPeople({ email }, { relations: ["subscribed"] })
+      .catch(() => [])
+    for (const p of people) {
+      base.matched++
+      const sub = p.subscribed
+      const subNeedsOff =
+        sub && sub.subscription_status !== "inactive" && reason !== "soft_bounce"
+      const nextMeta = suppressionMetadata(p.metadata, reason, at)
+      if (!subNeedsOff && !nextMeta) continue
+      if (subNeedsOff) {
+        await personService.updatePersonSubs({
+          id: sub.id,
+          subscription_status: "inactive",
+          email_subscribed: "false",
+        })
+      }
+      if (nextMeta) await personService.updatePeople({ id: p.id, metadata: nextMeta })
+      base.persons++
+    }
+
+    // Customers — metadata flag.
+    const custs: any[] = await customerService
+      .listCustomers({ email }, { select: ["id", "email", "metadata"] })
+      .catch(() => [])
+    for (const c of custs) {
+      base.matched++
+      const nextMeta = suppressionMetadata(c.metadata, reason, at)
+      if (!nextMeta) continue
+      await customerService.updateCustomers(c.id, { metadata: nextMeta })
+      base.customers++
+    }
+
+    // Leads — metadata flag.
+    const lds: any[] = await socialsService
+      .listLeads({ email }, { select: ["id", "email", "metadata"] })
+      .catch(() => [])
+    for (const l of lds) {
+      base.matched++
+      const nextMeta = suppressionMetadata(l.metadata, reason, at)
+      if (!nextMeta) continue
+      await socialsService.updateLeads({ id: l.id, metadata: nextMeta })
+      base.leads++
+    }
+  }
+
+  base.suppressed = base.persons + base.customers + base.leads > 0
+  base.logged_only = !flip
+
+  // Durable audit row (best-effort — a logging failure never fails the caller).
+  try {
+    await suppressionService.createEmailSuppressions({
+      email,
+      reason,
+      provider: input.provider,
+      event_id: input.event_id ?? null,
+      event_at: at,
+      suppressed: base.suppressed,
+      persons: base.persons,
+      customers: base.customers,
+      leads: base.leads,
+      raw: input.raw ?? null,
+    })
+  } catch {
+    // swallow — the suppression already happened
+  }
+
+  return base
+}

--- a/apps/backend/src/workflows/blogs/send-blog-subscribers/steps/get-subscribers.ts
+++ b/apps/backend/src/workflows/blogs/send-blog-subscribers/steps/get-subscribers.ts
@@ -56,6 +56,7 @@ export const getSubscribersStep = createStep(
 
       for (const person of persons as any[]) {
         if (person.metadata?.bounced) continue // hard-bounced — never mail
+        if (person.metadata?.unsubscribed) continue // opted out — never mail
         const sub = person.subscribed
         if (!sub || sub.subscription_status !== "active") continue
         for (const email of extractEmails(person.email)) {
@@ -80,6 +81,7 @@ export const getSubscribersStep = createStep(
 
       for (const customer of customers) {
         if ((customer as any).metadata?.bounced) continue // hard-bounced — never mail
+        if ((customer as any).metadata?.unsubscribed) continue // opted out — never mail
         for (const email of extractEmails(customer.email)) {
           const key = email.toLowerCase()
           if (!uniqueSubscribers.has(key)) {
@@ -102,6 +104,7 @@ export const getSubscribersStep = createStep(
 
       for (const lead of leads as any[]) {
         if (lead.metadata?.bounced) continue // hard-bounced — never mail
+        if (lead.metadata?.unsubscribed) continue // opted out — never mail
         for (const email of extractEmails(lead.email)) {
           const key = email.toLowerCase()
           if (!uniqueSubscribers.has(key)) {

--- a/apps/backend/src/workflows/blogs/send-blog-subscribers/steps/process-all-batches.ts
+++ b/apps/backend/src/workflows/blogs/send-blog-subscribers/steps/process-all-batches.ts
@@ -65,7 +65,11 @@ function buildEmailData(
     subscriber_id: subscriber.id,
     subject: emailConfig.subject,
     custom_message: emailConfig.customMessage || "",
-    unsubscribe_url: `${frontend}/unsubscribe?id=${subscriber.id}`,
+    // Carry the email alongside the (ambiguous person|customer|lead) id so the
+    // unsubscribe endpoint suppresses by email even when the id can't resolve.
+    unsubscribe_url: `${frontend}/unsubscribe?id=${encodeURIComponent(
+      subscriber.id
+    )}&email=${encodeURIComponent(subscriber.email)}`,
     website_url: withUtm(frontend),
     // Two doors: buy finished pieces on cicilabel.com; design & produce on jaalyantra.com.
     shop_url: withUtm("https://cicilabel.com"),

--- a/apps/docs/notes/MULTI_ACCOUNT_HOSTING_PROVISIONING.md
+++ b/apps/docs/notes/MULTI_ACCOUNT_HOSTING_PROVISIONING.md
@@ -1,0 +1,61 @@
+# Multi-account storefront hosting provisioning (Vercel / Cloudflare Pages / Render / Netlify)
+
+Status: **in progress** — slice 1 built (2026-07-04). Branch `feat/839-unsubscribe-bounce-webhooks`.
+
+## Goal
+
+Add Cloudflare Pages (later Render, Netlify) as storefront **hosting** targets
+alongside Vercel, and **rotate across multiple accounts per provider** so we can
+run on free tiers and "cut off" a full account so new partners flow to the next.
+Keep the existing provision workflow shape unchanged.
+
+## Current architecture (as-is)
+
+- One workflow `provisionStorefrontWorkflow` (`src/workflows/stores/provision-storefront.ts`),
+  8 steps: create website row → seed pages → **Vercel** project (GH repo) → env vars →
+  add domain (+verification) → **Cloudflare DNS** CNAME → Vercel TXT verification →
+  trigger deploy → save partner columns.
+- `DeploymentService` (`src/modules/deployment/service.ts`) holds all Vercel (hosting)
+  + Cloudflare (DNS-only) API calls. Single-account creds from env:
+  `VERCEL_TOKEN`/`VERCEL_TEAM_ID`, `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ZONE_ID`.
+- Partner columns: `storefront_domain`, `website_id`, `vercel_project_id`,
+  `vercel_project_name`, `vercel_last_deployment_id`, `vercel_linked`, `storefront_repo`,
+  `storefront_root_dir`, `storefront_branch`. Website row = content only (no provider field).
+- Cloudflare is **DNS only** today; `deploy/cloudflare/` has mothballed Containers skeleton.
+- **No provider choice, no rotation** — every partner → same Vercel team + CF zone.
+
+## Decisions (2026-07-04)
+
+- **Provider model**: providers-by-role with encrypted creds, à la `SocialPlatform`,
+  but a dedicated `deployment_account` (kept out of socials). Providers: vercel,
+  cloudflare, render, netlify. Each account has a free-tier `cutoff_max`.
+- **Selection**: least-loaded active account under its cap; **manual cutoff** = flip
+  `status` to `full`; **round up** = raise `cutoff_max` when the account goes paid.
+- **Credentials**: DB table, tokens encrypted via the encryption module (add/cutoff at
+  runtime, no redeploy).
+- **Provider choice per partner**: new partners default to Cloudflare Pages; existing
+  stay on Vercel (round-robin across all accounts within the chosen provider).
+
+## Slices
+
+- **S1 (DONE)** — `deployment_account` model (provider/role/label/api_config/cutoff_max/
+  project_count/priority/status) + migration + pure `account-selector.ts`
+  (least-loaded-under-cap, provider filter) + 7 unit tests.
+- **S2** — `HostingProvider` interface (createProject, setEnvVars, addDomain+verification,
+  triggerDeploy, getProject). Extract `VercelHostingProvider` from today's service; add
+  `CloudflarePagesProvider` (CF Pages API: project ← GH repo, env vars, custom domain,
+  deployment). DNS steps stay (CNAME → `<project>.pages.dev` for Pages).
+- **S3** — workflow dispatch: select account (S1) → resolve its decrypted creds → run
+  steps 3-7 via the provider (S2) → on success increment `project_count` + stamp
+  `partner.hosting_provider` + `partner.deployment_account_id`. Add those two columns.
+- **S4** — admin/DP account management: add account (encrypt token), set cutoff_max,
+  cutoff toggle, per-account partner counts; backfill existing partners → current env
+  account; capacity-exhausted alert.
+- **S5** — Render + Netlify providers (same interface).
+
+## Free-tier cutoff references (fill when configuring)
+
+- Vercel Hobby: ~limited projects/deploys per account → set conservative `cutoff_max`.
+- Cloudflare Pages free: generous project count, 500 builds/mo.
+- Render / Netlify free: per-account app/site caps.
+Set each account's `cutoff_max` to the safe ceiling; raise on upgrade.


### PR DESCRIPTION
Four related tracks, all with unit tests.

## 1. Unsubscribe (#839) — the dead link now works
- Public `GET/POST /web/website/:domain/unsubscribe` — GET resolves a masked target (prefetch-safe), POST suppresses by email across person/customer/lead.
- Storefront `/unsubscribe` confirm page (submodule, already pushed). Send path emits `?id=&email=` and skips `metadata.unsubscribed`.
- 16 unit tests.

## 2. Auto bounce/complaint suppression
Mass sends load-balance across **Mailjet + Resend**, so both report bounces:
- New `email_suppression` module = durable queryable log + migration.
- Shared `suppress-core` (idempotent on event_id; soft bounces log-only) + provider parsers.
- `/webhooks/resend/email-events` (Svix-signed) + `/webhooks/mailjet/events` (`MAILJET_WEBHOOK_SECRET`-gated).
- Manual `suppress-bounced-subscribers` DP job now writes the same log → one source of truth.
- 23 unit tests. **Prod tail:** set `MAILJET_WEBHOOK_SECRET` + point both ESP dashboards at the webhook URLs.

## 3. Audience segmentation backbone (#881)
Profiling showed "subscribers" = weavers + 22 customers + ~1 lead, no source field.
- `audience` module: `audience_group` + unified per-email `audience_entry` (merges the 3 sources with source/groups/tags/mailable) + migration.
- Pure classifier (weaver-directory / organic / customer / ad-lead + flags). 9 unit tests.

## 4. Multi-account hosting provisioning backbone
Toward Cloudflare Pages/Render/Netlify hosting + account rotation:
- `deployment_account` model (providers-by-role, encrypted creds, free-tier `cutoff_max`) + migration.
- Pure least-loaded-under-cap selector. 7 unit tests. Design: `apps/docs/notes/MULTI_ACCOUNT_HOSTING_PROVISIONING.md`.

**55 unit tests total.** New DB migrations: email_suppression, audience_group/entry, deployment_account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)