### PR TITLE
feat(#881): audience backfill job + composition endpoint

### DIFF
--- a/apps/backend/src/api/admin/audience/composition/route.ts
+++ b/apps/backend/src/api/admin/audience/composition/route.ts
@@ -1,0 +1,55 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+
+import { AUDIENCE_MODULE } from "../../../../modules/audience"
+
+/**
+ * GET /admin/audience/composition
+ *
+ * The "who's in here" view (#881 S1): aggregates the materialized audience_entry
+ * rows into counts by source / tag / member_type, plus the group definitions.
+ * Populate/refresh the entries with the `backfill-audience-entries` DP job.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const audienceService: any = req.scope.resolve(AUDIENCE_MODULE)
+
+  const [entries, groups]: [any[], any[]] = await Promise.all([
+    audienceService.listAudienceEntries({}, { take: 100000 }).catch(() => []),
+    audienceService.listAudienceGroups({}).catch(() => []),
+  ])
+
+  const bySource: Record<string, number> = {}
+  const byTag: Record<string, number> = {}
+  const byMemberType: Record<string, number> = {}
+  let mailable = 0
+  for (const e of entries) {
+    bySource[e.source || "unknown"] = (bySource[e.source || "unknown"] ?? 0) + 1
+    byMemberType[e.member_type] = (byMemberType[e.member_type] ?? 0) + 1
+    for (const t of e.tags || []) byTag[t] = (byTag[t] ?? 0) + 1
+    if (e.mailable) mailable++
+  }
+
+  // Per-group mailable count (for the send-UI live count later).
+  const groupCounts = groups.map((g: any) => {
+    const inGroup = entries.filter((e) => (e.groups || []).includes(g.key))
+    return {
+      key: g.key,
+      label: g.label,
+      kind: g.kind,
+      total: inGroup.length,
+      mailable: inGroup.filter((e) => e.mailable).length,
+    }
+  })
+
+  res.json({
+    composition: {
+      total: entries.length,
+      mailable,
+      by_source: bySource,
+      by_tag: byTag,
+      by_member_type: byMemberType,
+    },
+    groups: groupCounts,
+    // Hint when the table is empty so the UI can prompt a backfill run.
+    needs_backfill: entries.length === 0,
+  })
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-audience-entries-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-audience-entries-job.ts
@@ -1,0 +1,167 @@
+import { Modules } from "@medusajs/framework/utils"
+
+import { PERSON_MODULE } from "../../../../modules/person"
+import { SOCIALS_MODULE } from "../../../../modules/socials"
+import { AUDIENCE_MODULE } from "../../../../modules/audience"
+import {
+  buildAudienceEntries,
+  summarizeEntries,
+  type SourceRecord,
+} from "../../../../modules/audience/build-entries"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * #457 / #881 — materialize the unified audience.
+ *
+ * Scans the three send sources (persons + customers + socials leads), classifies
+ * each contact (source / groups / tags / mailable) and upserts one
+ * `audience_entry` per email — the deduped, taggable "who's in here" list. Also
+ * seeds the source `audience_group` definitions.
+ *
+ * Dry-run reports the composition (counts by source/tag/type) without writing;
+ * apply upserts the entries. Idempotent — re-running refreshes in place.
+ */
+
+const SOURCE_GROUPS: Array<{ key: string; label: string }> = [
+  { key: "weaver-directory", label: "Weaver directory" },
+  { key: "organic", label: "Organic subscribers" },
+  { key: "customers", label: "Customers" },
+  { key: "ad-leads", label: "Ad leads" },
+]
+
+export const backfillAudienceEntriesJob: MaintenanceJob = {
+  id: "backfill-audience-entries",
+  label: "Backfill audience entries",
+  description:
+    "Materialize the unified audience: scan persons + customers + leads, classify each (source/groups/tags/mailable) and upsert one audience_entry per email. Seeds the source group definitions. Dry-run reports the composition without writing; apply refreshes the entries (idempotent).",
+  params: [],
+  run: async (container, { dry_run }): Promise<MaintenanceJobResult> => {
+    const personService: any = container.resolve(PERSON_MODULE)
+    const customerService: any = container.resolve(Modules.CUSTOMER)
+    const socialsService: any = container.resolve(SOCIALS_MODULE)
+    const audienceService: any = container.resolve(AUDIENCE_MODULE)
+
+    const records: SourceRecord[] = []
+
+    // Persons (with subscription state).
+    const persons: any[] = await personService
+      .listPeople(
+        {},
+        { relations: ["subscribed"], select: ["id", "email", "first_name", "last_name", "metadata", "state", "created_at"] }
+      )
+      .catch(() => [])
+    for (const p of persons) {
+      if (!p.email) continue
+      records.push({
+        member_type: "person",
+        member_id: p.id,
+        email: p.email,
+        first_name: p.first_name,
+        last_name: p.last_name,
+        metadata: p.metadata,
+        state: p.state,
+        sub_active: p.subscribed?.subscription_status === "active",
+        created_at: p.created_at,
+      })
+    }
+
+    // Customers.
+    const customers: any[] = await customerService
+      .listCustomers({}, { select: ["id", "email", "first_name", "last_name", "metadata", "created_at"] })
+      .catch(() => [])
+    for (const c of customers) {
+      if (!c.email) continue
+      records.push({
+        member_type: "customer",
+        member_id: c.id,
+        email: c.email,
+        first_name: c.first_name,
+        last_name: c.last_name,
+        metadata: c.metadata,
+        created_at: c.created_at,
+      })
+    }
+
+    // Socials leads (non-dead, same filter as the send).
+    const leads: any[] = await socialsService
+      .listLeads(
+        { status: { $nin: ["archived", "lost", "unqualified"] } },
+        { select: ["id", "email", "first_name", "last_name", "full_name", "metadata", "created_at"] }
+      )
+      .catch(() => [])
+    for (const l of leads) {
+      if (!l.email) continue
+      records.push({
+        member_type: "lead",
+        member_id: l.id,
+        email: l.email,
+        first_name: l.first_name || l.full_name?.split(" ")?.[0] || null,
+        last_name: l.last_name || l.full_name?.split(" ")?.slice(1).join(" ") || null,
+        metadata: l.metadata,
+        created_at: l.created_at,
+      })
+    }
+
+    const drafts = buildAudienceEntries(records)
+    const summary = summarizeEntries(drafts)
+
+    // Aggregate changes (one row per source bucket — keeps the audit readable).
+    const changes: MaintenanceChange[] = Object.entries(summary.bySource).map(
+      ([source, count]) => ({ entity: "audience_entry", id: source, field: "count", after: count })
+    )
+
+    if (!dry_run) {
+      // Seed source group definitions (upsert by key).
+      const existingGroups: any[] = await audienceService.listAudienceGroups({}).catch(() => [])
+      const groupKeys = new Set(existingGroups.map((g) => g.key))
+      const newGroups = SOURCE_GROUPS.filter((g) => !groupKeys.has(g.key)).map((g) => ({
+        key: g.key,
+        label: g.label,
+        kind: "source",
+      }))
+      if (newGroups.length) await audienceService.createAudienceGroups(newGroups)
+
+      // Upsert entries by email.
+      const existing: any[] = await audienceService
+        .listAudienceEntries({}, { select: ["id", "email"], take: 100000 })
+        .catch(() => [])
+      const idByEmail = new Map(existing.map((e) => [e.email, e.id]))
+
+      const toCreate: any[] = []
+      const toUpdate: any[] = []
+      for (const d of drafts) {
+        const row = {
+          email: d.email,
+          member_type: d.member_type,
+          member_id: d.member_id,
+          first_name: d.first_name,
+          last_name: d.last_name,
+          source: d.source,
+          groups: d.groups,
+          tags: d.tags,
+          mailable: d.mailable,
+        }
+        const id = idByEmail.get(d.email)
+        if (id) toUpdate.push({ id, ...row })
+        else toCreate.push(row)
+      }
+      if (toCreate.length) await audienceService.createAudienceEntries(toCreate)
+      for (const u of toUpdate) await audienceService.updateAudienceEntries(u)
+    }
+
+    const verb = dry_run ? "Would materialize" : "Materialized"
+    return {
+      job_id: backfillAudienceEntriesJob.id,
+      dry_run,
+      applied: !dry_run && drafts.length > 0,
+      summary:
+        `${verb} ${summary.total} audience entries (${summary.mailable} mailable) — ` +
+        Object.entries(summary.bySource)
+          .map(([s, n]) => `${s}:${n}`)
+          .join(", "),
+      changes,
+    }
+  },
+}
+
+export default backfillAudienceEntriesJob

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -76,6 +76,7 @@ import { backfillStoreCurrenciesJob } from "./backfill-store-currencies-job"
 import { backfillPartnerEmailVerifiedJob } from "./backfill-partner-email-verified-job"
 import { enableStripeConnectEurRegionsJob } from "./enable-stripe-connect-eur-regions-job"
 import { suppressBouncedSubscribersJob } from "./suppress-bounced-subscribers-job"
+import { backfillAudienceEntriesJob } from "./backfill-audience-entries-job"
 import {
   sweepAiPlatformsByCategory,
   AI_ROLES,
@@ -5345,6 +5346,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   backfillPartnerEmailVerifiedJob,
   enableStripeConnectEurRegionsJob,
   suppressBouncedSubscribersJob,
+  backfillAudienceEntriesJob,
 ]
 
 export const getMaintenanceJob = (id: string): MaintenanceJob | undefined =>

--- a/apps/backend/src/modules/audience/__tests__/build-entries.unit.spec.ts
+++ b/apps/backend/src/modules/audience/__tests__/build-entries.unit.spec.ts
@@ -1,0 +1,60 @@
+import { buildAudienceEntries, summarizeEntries } from "../build-entries"
+
+describe("buildAudienceEntries", () => {
+  it("dedupes by email and unions groups/tags across sources", () => {
+    const out = buildAudienceEntries([
+      { member_type: "person", member_id: "p1", email: "Jane@X.com", metadata: { metadata_district: "N" }, sub_active: true },
+      { member_type: "customer", member_id: "c1", email: "jane@x.com", metadata: {} },
+    ])
+    expect(out).toHaveLength(1)
+    const e = out[0]
+    expect(e.email).toBe("jane@x.com")
+    // person wins as primary (priority) → source weaver-directory
+    expect(e.member_type).toBe("person")
+    expect(e.source).toBe("weaver-directory")
+    // unioned across both records
+    expect(e.tags).toEqual(expect.arrayContaining(["weaver-directory", "subscriber", "customer"]))
+    expect(e.groups).toEqual(expect.arrayContaining(["weaver-directory", "customers"]))
+  })
+
+  it("skips invalid / empty emails", () => {
+    const out = buildAudienceEntries([
+      { member_type: "person", member_id: "p1", email: "nope" },
+      { member_type: "lead", member_id: "l1", email: "" },
+      { member_type: "customer", member_id: "c1", email: "ok@x.com" },
+    ])
+    expect(out).toHaveLength(1)
+    expect(out[0].email).toBe("ok@x.com")
+  })
+
+  it("bounced on any record makes the merged entry not mailable", () => {
+    const out = buildAudienceEntries([
+      { member_type: "person", member_id: "p1", email: "a@x.com", metadata: {}, sub_active: true },
+      { member_type: "customer", member_id: "c1", email: "a@x.com", metadata: { bounced: true } },
+    ])
+    expect(out[0].mailable).toBe(false)
+    expect(out[0].tags).toContain("bounced")
+  })
+
+  it("keeps distinct emails separate", () => {
+    const out = buildAudienceEntries([
+      { member_type: "customer", member_id: "c1", email: "a@x.com" },
+      { member_type: "customer", member_id: "c2", email: "b@x.com" },
+    ])
+    expect(out.map((e) => e.email).sort()).toEqual(["a@x.com", "b@x.com"])
+  })
+})
+
+describe("summarizeEntries", () => {
+  it("counts by source, tag, member_type + mailable", () => {
+    const s = summarizeEntries([
+      { email: "a@x.com", member_type: "person", member_id: "p", first_name: null, last_name: null, source: "organic", groups: ["organic"], tags: ["organic", "subscriber"], mailable: true },
+      { email: "b@x.com", member_type: "customer", member_id: "c", first_name: null, last_name: null, source: "customer", groups: ["customers"], tags: ["customer"], mailable: false },
+    ])
+    expect(s.total).toBe(2)
+    expect(s.mailable).toBe(1)
+    expect(s.bySource).toEqual({ organic: 1, customer: 1 })
+    expect(s.byMemberType).toEqual({ person: 1, customer: 1 })
+    expect(s.byTag.subscriber).toBe(1)
+  })
+})

--- a/apps/backend/src/modules/audience/build-entries.ts
+++ b/apps/backend/src/modules/audience/build-entries.ts
@@ -1,0 +1,116 @@
+import { classifyContact, type ClassifierOptions, type MemberType } from "./classifier"
+
+/**
+ * PURE audience-entry builder — collapse the three source lists (persons,
+ * customers, leads) into ONE row per email, merging classifications. This is the
+ * "merge the leads, customers and persons into one tagged list" step (#881).
+ *
+ * Dedup key = lowercased email. When the same email appears in multiple sources
+ * (e.g. a weaver who is also a customer), the groups/tags are UNIONED and the
+ * primary member_type is chosen by priority person > customer > lead (matching
+ * how the send dedupes). No IO — unit-testable.
+ */
+
+export type SourceRecord = {
+  member_type: MemberType
+  member_id: string
+  email: string
+  first_name?: string | null
+  last_name?: string | null
+  metadata?: Record<string, any> | null
+  state?: string | null
+  sub_active?: boolean
+  created_at?: string | Date | null
+}
+
+export type AudienceEntryDraft = {
+  email: string
+  member_type: MemberType
+  member_id: string
+  first_name: string | null
+  last_name: string | null
+  source: string
+  groups: string[]
+  tags: string[]
+  mailable: boolean
+}
+
+const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/
+const PRIORITY: Record<MemberType, number> = { person: 3, customer: 2, lead: 1 }
+
+export function buildAudienceEntries(
+  records: SourceRecord[],
+  opts: ClassifierOptions = {}
+): AudienceEntryDraft[] {
+  const byEmail = new Map<string, SourceRecord[]>()
+  for (const r of records ?? []) {
+    const email = String(r?.email ?? "").trim().toLowerCase()
+    if (!email || !EMAIL_RE.test(email)) continue
+    const list = byEmail.get(email)
+    if (list) list.push(r)
+    else byEmail.set(email, [r])
+  }
+
+  const out: AudienceEntryDraft[] = []
+  for (const [email, recs] of byEmail) {
+    // Primary record = highest priority (person > customer > lead).
+    const primary = recs.reduce((a, b) =>
+      PRIORITY[b.member_type] > PRIORITY[a.member_type] ? b : a
+    )
+
+    const groups = new Set<string>()
+    const tags = new Set<string>()
+    let anyMailable = false
+    let hardOff = false
+    let primarySource = "unknown"
+
+    for (const r of recs) {
+      const c = classifyContact(
+        {
+          member_type: r.member_type,
+          email,
+          metadata: r.metadata,
+          state: r.state,
+          sub_active: r.sub_active,
+          created_at: r.created_at,
+        },
+        opts
+      )
+      c.groups.forEach((g) => groups.add(g))
+      c.tags.forEach((t) => tags.add(t))
+      if (c.mailable) anyMailable = true
+      if (r === primary) primarySource = c.source
+    }
+
+    if (tags.has("bounced") || tags.has("unsubscribed")) hardOff = true
+
+    out.push({
+      email,
+      member_type: primary.member_type,
+      member_id: primary.member_id,
+      first_name: primary.first_name ?? null,
+      last_name: primary.last_name ?? null,
+      source: primarySource,
+      groups: [...groups],
+      tags: [...tags],
+      mailable: anyMailable && !hardOff,
+    })
+  }
+
+  return out
+}
+
+/** PURE: composition summary for the "who's in here" dashboard. */
+export function summarizeEntries(entries: AudienceEntryDraft[]) {
+  const bySource: Record<string, number> = {}
+  const byTag: Record<string, number> = {}
+  const byMemberType: Record<string, number> = {}
+  let mailable = 0
+  for (const e of entries) {
+    bySource[e.source] = (bySource[e.source] ?? 0) + 1
+    byMemberType[e.member_type] = (byMemberType[e.member_type] ?? 0) + 1
+    for (const t of e.tags) byTag[t] = (byTag[t] ?? 0) + 1
+    if (e.mailable) mailable++
+  }
+  return { total: entries.length, mailable, bySource, byTag, byMemberType }
+}


### PR DESCRIPTION
Data layer for #881 segmentation (builds on the backbone merged in #882).

- **Pure `build-entries`**: collapses persons+customers+leads into one row per email — unions groups/tags, primary member by person>customer>lead, mailable if any source is mailable and not bounced/unsubscribed. + `summarizeEntries`. 5 unit tests.
- **`backfill-audience-entries` DP job**: scans the 3 sources, classifies, upserts `audience_entry`, seeds source groups. Dry-run reports composition; apply refreshes (idempotent).
- **`GET /admin/audience/composition`**: the "who's in here" aggregation (by source/tag/member_type + per-group mailable counts) — powers the S1 dashboard.

No new migrations (tables landed in #882). **Next (later):** send-path group/tag filter + send-UI picker + admin dashboard view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)