### PR TITLE
feat(#888): S3+S4 — pickup WhatsApp flow + tracking timeline, pickup card, receipt nudge

### DIFF
--- a/apps/backend/src/admin/components/inventory-orders/inventory-order-shipments-section.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/inventory-order-shipments-section.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Badge, Container, Heading, Text } from "@medusajs/ui";
 import { ArrowUpRightOnBox, DocumentText } from "@medusajs/icons";
 
@@ -5,24 +6,40 @@ type InventoryOrderShipmentsSectionProps = {
   inventoryOrder: any;
 };
 
-const STATUS_COLOR: Record<string, "green" | "blue" | "red"> = {
+const STATUS_COLOR: Record<string, "green" | "blue" | "red" | "orange"> = {
   created: "blue",
-  pickup_scheduled: "green",
+  pickup_scheduled: "orange",
+  picked_up: "blue",
+  in_transit: "blue",
+  out_for_delivery: "orange",
+  delivered: "green",
+  rto: "red",
   cancelled: "red",
 };
 
 const STATUS_LABEL: Record<string, string> = {
   created: "Created",
   pickup_scheduled: "Pickup scheduled",
+  picked_up: "Picked up",
+  in_transit: "In transit",
+  out_for_delivery: "Out for delivery",
+  delivered: "Delivered",
+  rto: "RTO",
   cancelled: "Cancelled",
 };
 
 const ShipmentRow = ({ s }: { s: any }) => {
+  const [showTracking, setShowTracking] = useState(false);
   const awb = s.awb || s.tracking_number;
   const dims = s.dimensions_cm || {};
   const dimText = [dims.length, dims.width ?? dims.breadth, dims.height]
     .filter((v: any) => v != null)
     .join("×");
+  // #888 — carrier webhook tracking events (append-only, oldest first, capped
+  // 50). `last_webhook` is the raw carrier payload and is never rendered here.
+  const trackingEvents: any[] = Array.isArray(s?.metadata?.tracking_events)
+    ? s.metadata.tracking_events
+    : [];
   return (
     <div className="flex flex-col gap-y-2 py-3">
       <div className="flex items-center justify-between">
@@ -80,6 +97,35 @@ const ShipmentRow = ({ s }: { s: any }) => {
           </Text>
         )}
       </div>
+      {trackingEvents.length > 0 && (
+        <div className="pl-1">
+          <button
+            type="button"
+            onClick={() => setShowTracking((v) => !v)}
+            className="text-ui-fg-interactive hover:text-ui-fg-interactive-hover"
+          >
+            <Text size="xsmall">
+              Tracking history ({trackingEvents.length})
+            </Text>
+          </button>
+          {showTracking && (
+            <div className="mt-2 flex flex-col gap-y-1">
+              {[...trackingEvents].reverse().map((ev: any, idx: number) => (
+                <Text key={idx} size="xsmall" className="text-ui-fg-subtle">
+                  {ev.status}
+                  {ev.status_code != null && ev.status_code !== ""
+                    ? ` (${ev.status_code})`
+                    : ""}
+                  {ev.received_at
+                    ? ` · ${new Date(ev.received_at).toLocaleString()}`
+                    : ""}
+                  {ev.location ? ` · ${ev.location}` : ""}
+                </Text>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 };
@@ -99,6 +145,21 @@ export const InventoryOrderShipmentsSection = ({
   const rows =
     shipments.length > 0 ? shipments : legacy ? [{ id: "legacy", ...legacy, status: "created" }] : [];
 
+  // #888 S4 — confirm-receipt nudge. Stock receipt is MANUAL by design: when
+  // every real (non-legacy) shipment is delivered (and none are still in flight
+  // or cancelled-without-delivery), remind the admin to verify and record
+  // received quantities before closing the order. Shown only for first-class
+  // shipment rows, never the legacy blob.
+  const nonCancelledShipments = shipments.filter(
+    (s: any) => s?.status !== "cancelled"
+  );
+  const allDelivered =
+    shipments.length > 0 &&
+    nonCancelledShipments.length > 0 &&
+    nonCancelledShipments.every((s: any) => s?.status === "delivered");
+  const showReceiptNudge =
+    allDelivered && inventoryOrder?.status !== "Cancelled";
+
   return (
     <Container className="divide-y p-0">
       <div className="flex items-center justify-between px-6 py-4">
@@ -109,6 +170,18 @@ export const InventoryOrderShipmentsSection = ({
           </Badge>
         </div>
       </div>
+      {showReceiptNudge && (
+        <div className="bg-ui-bg-subtle border rounded-md p-3 m-3">
+          <Text size="small" className="text-ui-fg-base">
+            All shipments delivered — confirm stock receipt
+          </Text>
+          <Text size="small" className="text-ui-fg-subtle">
+            The carrier reports delivery, but stock receipt stays manual: verify
+            received quantities and record them via the order completion flow
+            before closing this order.
+          </Text>
+        </div>
+      )}
       {rows.length === 0 ? (
         <div className="px-6 py-4">
           <Text

--- a/apps/backend/src/api/admin/inventory-orders/[id]/route.ts
+++ b/apps/backend/src/api/admin/inventory-orders/[id]/route.ts
@@ -129,17 +129,24 @@ export const GET = async(
     // work-status (best-effort), mirroring the design-order detail + admin order
     // routes. `unified_order_status.partner_status` is a custom link sidecar the
     // inventory-order workflow doesn't expand, so resolve it via query.graph and
-    // attach. A graph hiccup just leaves the field off (plain rendering).
+    // attach. The same call also pulls the first-class inventory_shipments rows
+    // (#888 S4) so the admin detail can surface them. A graph hiccup just leaves
+    // both fields off (plain rendering).
     try {
       const query: any = req.scope.resolve(ContainerRegistrationKeys.QUERY)
       const { data } = await query.graph({
         entity: "inventory_orders",
-        fields: ["id", "order.id", "order.unified_order_status.partner_status"],
+        fields: ["id", "order.id", "order.unified_order_status.partner_status", "inventory_shipments.*"],
         filters: { id },
       })
       const link = data?.[0]
       if (link && inventoryOrder) {
         ;(inventoryOrder as any).unified_order_status = link.order?.unified_order_status ?? null
+        ;(inventoryOrder as any).shipments = (() => {
+          const raw = (link as any).inventory_shipments
+          const arr = !raw ? [] : Array.isArray(raw) ? raw : [raw]
+          return arr.filter(Boolean).sort((a: any, b: any) => String(b.created_at || '').localeCompare(String(a.created_at || '')))
+        })()
       }
     } catch {
       // leave as-is; the UI falls back to plain rendering

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -64,6 +64,7 @@ import {
 import { VISUAL_FLOWS_MODULE } from "../../../../modules/visual_flows"
 import { FLOW_DEF as IDEAS_EMAIL_FLOW_DEF } from "../../../../scripts/seed-marketing-daily-ideas-email-flow"
 import { FLOW_DEF as INVENTORY_ORDER_STATUS_FLOW_DEF } from "../../../../scripts/seed-inventory-order-status-flow"
+import { FLOW_DEF as INVENTORY_SHIPMENT_PICKUP_FLOW_DEF } from "../../../../scripts/seed-inventory-shipment-pickup-flow"
 import { FLOW_DEF as ARTISAN_PRODUCT_APPROVAL_FLOW_DEF } from "../../../../scripts/seed-artisan-product-approval-flow"
 import { ALL_WHATSAPP_TEMPLATES } from "../../../../scripts/whatsapp-templates/all-templates"
 import {
@@ -4251,6 +4252,70 @@ export const installInventoryOrderStatusFlowJob: MaintenanceJob = {
 }
 
 // ---------------------------------------------------------------------------
+// install-inventory-shipment-pickup-flow (#888 S3) — LOAD the inventory
+// shipment pickup WhatsApp visual flow from the Data Plumbing console. Same
+// FLOW_DEF as the CLI seed (single source of truth). Idempotent — refuses to
+// overwrite; created as a DRAFT (inert until the operator approves the
+// template and flips draft→active).
+// ---------------------------------------------------------------------------
+
+export const installInventoryShipmentPickupFlowJob: MaintenanceJob = {
+  id: "install-inventory-shipment-pickup-flow",
+  label: "Install inventory-shipment pickup visual flow",
+  description:
+    "Load/create the 'Partner WhatsApp — Inventory Shipment Pickup' visual flow into the system from the console — no shell or seed script needed (#888 S3). The flow listens to the inventory-shipment status-changed event (fired by the carrier tracking webhook and at shipment creation when a pickup is scheduled) and sends the partner a WhatsApp pickup notification (pickup scheduled with date / picked up) via the generic jyt_inventory_shipment_pickup_v1 template. Dry-run previews the flow it would create (or reports it already exists); apply creates it idempotently as a DRAFT. It stays inert until you approve the template and flip the flow draft→active. Re-running never overwrites an existing flow.",
+  params: [],
+  run: async (container, { dry_run }) => {
+    const service: any = container.resolve(VISUAL_FLOWS_MODULE)
+    const flowName = INVENTORY_SHIPMENT_PICKUP_FLOW_DEF.name
+    const eventTrigger =
+      INVENTORY_SHIPMENT_PICKUP_FLOW_DEF.trigger_config?.event_types?.[0] ?? "event"
+    const nodeCount =
+      INVENTORY_SHIPMENT_PICKUP_FLOW_DEF.canvas_state?.nodes?.length ?? 0
+
+    const [existing] = await service.listVisualFlows({ name: flowName })
+    if (existing) {
+      return summarizeEventFlowInstall({
+        jobId: installInventoryShipmentPickupFlowJob.id,
+        dry_run,
+        flowName,
+        eventTrigger,
+        nodeCount,
+        existingId: existing.id,
+        createdId: null,
+      })
+    }
+
+    let createdId: string | null = null
+    if (!dry_run) {
+      const flow = await service.createCompleteFlow({
+        flow: {
+          name: INVENTORY_SHIPMENT_PICKUP_FLOW_DEF.name,
+          description: INVENTORY_SHIPMENT_PICKUP_FLOW_DEF.description,
+          status: INVENTORY_SHIPMENT_PICKUP_FLOW_DEF.status,
+          trigger_type: INVENTORY_SHIPMENT_PICKUP_FLOW_DEF.trigger_type,
+          trigger_config: INVENTORY_SHIPMENT_PICKUP_FLOW_DEF.trigger_config,
+          canvas_state: INVENTORY_SHIPMENT_PICKUP_FLOW_DEF.canvas_state,
+        },
+        operations: INVENTORY_SHIPMENT_PICKUP_FLOW_DEF.operations,
+        connections: INVENTORY_SHIPMENT_PICKUP_FLOW_DEF.connections,
+      })
+      createdId = flow?.id ?? null
+    }
+
+    return summarizeEventFlowInstall({
+      jobId: installInventoryShipmentPickupFlowJob.id,
+      dry_run,
+      flowName,
+      eventTrigger,
+      nodeCount,
+      existingId: null,
+      createdId,
+    })
+  },
+}
+
+// ---------------------------------------------------------------------------
 // install-artisan-product-approval-flow (#859 S2 / #861) — LOAD the artisan
 // product review EMAIL flow from the Data Plumbing console. The flow listens to
 // partner_product.approved / .rejected → reads product + owning partner →
@@ -5332,6 +5397,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   runMarketingIdeasEmailJob,
   installMarketingIdeasEmailFlowJob,
   installInventoryOrderStatusFlowJob,
+  installInventoryShipmentPickupFlowJob,
   installArtisanProductApprovalFlowJob,
   syncWhatsAppTemplatesJob,
   generateWinbackTargetsJob,

--- a/apps/backend/src/api/partners/inventory-orders/[orderId]/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/[orderId]/route.ts
@@ -291,6 +291,10 @@ export async function GET(
                 .sort((a: any, b: any) =>
                     String(b.created_at || "").localeCompare(String(a.created_at || ""))
                 )
+                // last_webhook is the raw carrier payload kept for admin debugging (#888) — never ship it to the partner.
+                .map((s: any) =>
+                    ({ ...s, metadata: s?.metadata ? { ...s.metadata, last_webhook: undefined } : s?.metadata })
+                )
         })(),
         // #342 — submitted payments for the Payments section (newest first).
         payments: (() => {

--- a/apps/backend/src/scripts/__tests__/seed-inventory-shipment-pickup-flow.unit.spec.ts
+++ b/apps/backend/src/scripts/__tests__/seed-inventory-shipment-pickup-flow.unit.spec.ts
@@ -1,0 +1,130 @@
+import { FLOW_DEF } from "../seed-inventory-shipment-pickup-flow"
+
+/**
+ * Structural guards for the inventory-shipment pickup WhatsApp visual flow seed
+ * (#888 S3).
+ *
+ * This flow is editor-gated and cannot be live-verified by the daemon. It wires
+ * the #888 shipment status-changed event + the send_whatsapp op by STRING name
+ * only, and the resolve_message code references shipment-shaped trigger payload
+ * paths that only the carrier tracking webhook / shipment creation emit. A typo
+ * in any of these would silently no-op at runtime, so these tests pin the
+ * contract.
+ */
+describe("seed-inventory-shipment-pickup-flow FLOW_DEF", () => {
+  const byKey = Object.fromEntries(
+    FLOW_DEF.operations.map((o) => [o.operation_key, o])
+  )
+
+  it("is an event-triggered draft flow on the #888 shipment status-changed event", () => {
+    expect(FLOW_DEF.status).toBe("draft")
+    expect(FLOW_DEF.trigger_type).toBe("event")
+    expect(FLOW_DEF.trigger_config.event_types).toEqual([
+      "inventory_orders.inventory-shipment.status-changed",
+    ])
+    // canvas trigger node mirrors the persisted trigger_config exactly.
+    expect(
+      (FLOW_DEF.canvas_state.nodes[0].data as any).triggerConfig.event_types
+    ).toEqual(FLOW_DEF.trigger_config.event_types)
+  })
+
+  it("wires read_data → execute_code → condition → send_whatsapp / log", () => {
+    expect(byKey.read_order.operation_type).toBe("read_data")
+    expect(byKey.resolve_message.operation_type).toBe("execute_code")
+    expect(byKey.has_message.operation_type).toBe("condition")
+    expect(byKey.send.operation_type).toBe("send_whatsapp")
+    expect(byKey.log_skip.operation_type).toBe("log")
+    // sort_order is contiguous from 0 in execution order.
+    expect(FLOW_DEF.operations.map((o) => o.sort_order)).toEqual([0, 1, 2, 3, 4])
+  })
+
+  it("reads the inventory order by the shipment payload's order_id, with partner + admins", () => {
+    const read = byKey.read_order.options as any
+    expect(read.entity).toBe("inventory_orders")
+    // The event payload is shipment-shaped: order_id carries the order, NOT
+    // payload.id (that's the shipment id).
+    expect(read.filters).toEqual({ id: "{{ $trigger.payload.order_id }}" })
+    expect(read.limit).toBe(1)
+    // must pull the partner relation + admins to resolve a recipient.
+    expect(read.fields).toEqual(
+      expect.arrayContaining([
+        "partner.id",
+        "partner.name",
+        "partner.whatsapp_number",
+        "partner.admins.phone",
+        "partner.admins.is_active",
+      ])
+    )
+  })
+
+  it("resolve_message reads the shipment payload shape #888 emits", () => {
+    const code = (byKey.resolve_message.options as any).code as string
+    expect(code).toContain("$trigger?.payload?.id")
+    expect(code).toContain("$trigger?.payload?.order_id")
+    expect(code).toContain("$trigger?.payload?.status")
+    expect(code).toContain("$trigger?.payload?.awb")
+    expect(code).toContain("$trigger?.payload?.pickup_scheduled_date")
+    // reads the order the read_order node produced.
+    expect(code).toContain("$input.read_order?.records?.[0]")
+  })
+
+  it("notifies only the pickup milestones (transit/delivered are skipped)", () => {
+    const code = (byKey.resolve_message.options as any).code as string
+    expect(code).toContain('"pickup_scheduled"')
+    expect(code).toContain('"picked_up"')
+    // unmapped statuses fall through to a skip.
+    expect(code).toContain("status_not_notified")
+    // transit scans + order-level milestones are NOT notified here — the #771
+    // status flow handles Shipped/Delivered.
+    expect(code).not.toContain('"in_transit"')
+    expect(code).not.toContain('"out_for_delivery"')
+    expect(code).not.toContain('"delivered"')
+    expect(code).not.toContain('newStatus === "delivered"')
+  })
+
+  it("condition gates send on resolve_message.skipped === false", () => {
+    const cond = byKey.has_message.options as any
+    expect(cond.expression).toBe("resolve_message.skipped === false")
+    expect(cond.filter_rule).toEqual({
+      "resolve_message.skipped": { _eq: false },
+    })
+  })
+
+  it("send_whatsapp interpolates the resolved template payload with dedup", () => {
+    const send = byKey.send.options as any
+    expect(send.mode).toBe("template")
+    expect(send.template_name).toBe("{{ resolve_message.template_name }}")
+    expect(send.variables).toBe("{{ resolve_message.variables }}")
+    expect(send.to).toBe("{{ resolve_message.to }}")
+    expect(send.context_type).toBe("{{ resolve_message.context_type }}")
+    expect(send.context_id).toBe("{{ resolve_message.context_id }}")
+    expect(send.dedup_window_minutes).toBe(60)
+    expect(send.require_partner).toBe(true)
+  })
+
+  it("dedup context_id is per (shipment, milestone) so each pickup sends once", () => {
+    const code = (byKey.resolve_message.options as any).code as string
+    expect(code).toContain('shipmentId + ":" + newStatus')
+    expect(code).toContain('context_type: "inventory_shipment"')
+  })
+
+  it("has matching canvas edges and connection rows (success/failure fan-out)", () => {
+    const conn = FLOW_DEF.connections.map((c) => `${c.source_id}->${c.target_id}`)
+    const edges = FLOW_DEF.canvas_state.edges.map((e) => `${e.source}->${e.target}`)
+    expect(conn).toEqual(edges)
+    expect(conn).toEqual([
+      "trigger->read_order",
+      "read_order->resolve_message",
+      "resolve_message->has_message",
+      "has_message->send",
+      "has_message->log_skip",
+    ])
+    // the condition's two arms carry the right handles.
+    const arms = Object.fromEntries(
+      FLOW_DEF.connections
+        .filter((c) => c.source_id === "has_message")
+        .map((c) => [c.target_id, c.connection_type])
+    )
+    expect(arms).toEqual({ send: "success", log_skip: "failure" })
+  })
+})

--- a/apps/backend/src/scripts/seed-inventory-shipment-pickup-flow.ts
+++ b/apps/backend/src/scripts/seed-inventory-shipment-pickup-flow.ts
@@ -1,0 +1,354 @@
+/**
+ * Seed: Partner WhatsApp — Inventory Shipment Pickup (single dispatcher) [#888 S3]
+ *
+ * One active flow listens to the
+ * `inventory_orders.inventory-shipment.status-changed` event — fired only on a
+ * real shipment status transition, either by the carrier tracking webhook
+ * (sync-inventory-shipment-tracking.ts, forward-only guarded) or at shipment
+ * creation when a pickup was scheduled (create-inventory-order-shipment.ts).
+ * The flow reads the shipment's order + assigned partner, maps the milestone
+ * to the Meta-approved pickup template + variables, and sends via
+ * `send_whatsapp`.
+ *
+ * Shipment status → notification mapping (inline in resolve_message):
+ *   pickup_scheduled → "Pickup scheduled for <date>"  ┐ both use the single
+ *   picked_up        → "Picked up by the courier"     ┘ jyt_inventory_shipment_pickup_v1
+ *                        with vars [partnerName, orderId, awb, milestoneLabel]
+ *   in_transit / out_for_delivery / delivered / rto / cancelled → (skipped —
+ *     order-level Shipped/Delivered already notify via the #771 flow; transit
+ *     scans are noise; RTO/cancel are operator conversations, not templates)
+ *
+ * Orders with no assigned partner / no reachable phone hit the "skip" branch —
+ * no send (admin-only inventory orders never have a partner recipient).
+ *
+ * Why one generic template: WhatsApp templates need Meta approval per WABA. A
+ * single parameterized "pickup update … {milestone}" template keeps the
+ * operator's approval burden at ONE template for both pickup milestones.
+ *
+ * Run:
+ *   npx medusa exec ./src/scripts/seed-inventory-shipment-pickup-flow.ts
+ *
+ * Or, no shell: Settings → Data Plumbing → "Install inventory-shipment pickup
+ * visual flow" (the install-inventory-shipment-pickup-flow maintenance job
+ * seeds this same FLOW_DEF — single source of truth).
+ *
+ * Re-seed:
+ *   Delete the existing flow (admin UI or by id) and re-run. The script is
+ *   idempotent — it refuses to overwrite an existing flow with the same name.
+ *
+ * Before activating in admin:
+ *   1. Ensure this template is APPROVED on every WABA you target:
+ *        - jyt_inventory_shipment_pickup_v1   (body refs {{1}}–{{4}})
+ *      Push it via the sync-whatsapp-templates Data Plumbing job, or:
+ *        npx medusa exec ./src/scripts/manage-whatsapp-templates.ts
+ *   2. Flip flow status: draft → active in the admin editor.
+ */
+
+import { VISUAL_FLOWS_MODULE } from "../modules/visual_flows"
+import VisualFlowService from "../modules/visual_flows/service"
+
+const FLOW_NAME = "Partner WhatsApp — Inventory Shipment Pickup"
+
+// The #888 shipment-level status-changed event — fires only on a real transition.
+const STATUS_CHANGED_EVENT =
+  "inventory_orders.inventory-shipment.status-changed"
+
+// Single Meta-approved template covering both pickup milestones.
+const PICKUP_TEMPLATE = "jyt_inventory_shipment_pickup_v1"
+
+// ─── Canvas positions ────────────────────────────────────────────────────────
+const X_CENTER = 500
+const X_LEFT = 200
+const X_RIGHT = 800
+
+const Y_READ_ORDER = 140
+const Y_RESOLVE = 300
+const Y_COND = 460
+const Y_SEND = 620
+const Y_SKIP = 620
+
+// ─── Code for the resolve_message node ───────────────────────────────────────
+//
+// Returns the full send_whatsapp input payload so the downstream node can
+// interpolate from this one operation's output. Returns { skipped: true } with
+// a reason when the transition has no notification — drives the has_message
+// condition below.
+//
+// The trigger payload here is SHIPMENT-shaped (sync-inventory-shipment-tracking
+// / create-inventory-order-shipment emit): { id: shipment_id, awb, carrier,
+// previous_status, status, order_id, pickup_scheduled_date }. read_order
+// filters on payload.order_id — NOT payload.id (that's the shipment).
+//
+// Variables produced (positional, identical order across languages):
+//   [partnerName, orderId, awb, milestoneLabel]
+const RESOLVE_MESSAGE_CODE = `\
+const eventName = $trigger?.event || ""
+const shipmentId = $trigger?.payload?.id || null
+const orderId = $trigger?.payload?.order_id || null
+const newStatus = $trigger?.payload?.status || null
+const awb = $trigger?.payload?.awb || null
+const pickupDate = $trigger?.payload?.pickup_scheduled_date || null
+
+if (!shipmentId) {
+  return { skipped: true, reason: "missing_shipment_id_in_payload", event: eventName }
+}
+if (!orderId) {
+  return { skipped: true, reason: "missing_order_id_in_payload", event: eventName, shipment_id: shipmentId }
+}
+if (!newStatus) {
+  return { skipped: true, reason: "missing_status_in_payload", event: eventName, shipment_id: shipmentId }
+}
+
+// Milestone → human label. Only the pickup milestones notify the partner —
+// order-level Shipped/Delivered already go out via the #771 status flow, and
+// transit scans are noise. Unmapped/future statuses fall through to skip.
+let milestoneLabel = null
+if (newStatus === "pickup_scheduled") {
+  milestoneLabel = pickupDate
+    ? "Pickup scheduled for " + pickupDate
+    : "Pickup scheduled"
+} else if (newStatus === "picked_up") {
+  milestoneLabel = "Picked up by the courier"
+}
+if (!milestoneLabel) {
+  return { skipped: true, reason: "status_not_notified", event: eventName, shipment_id: shipmentId, status: newStatus }
+}
+
+const order = $input.read_order?.records?.[0]
+if (!order) {
+  return { skipped: true, reason: "order_not_found", event: eventName, order_id: orderId }
+}
+
+// The order ↔ partner link accessor is singular (\`order.partner\`), but defend
+// against an array shape just in case the query returns a list.
+const partner = Array.isArray(order.partner) ? order.partner[0] : order.partner
+if (!partner) {
+  return { skipped: true, reason: "no_partner_on_order", event: eventName, order_id: orderId }
+}
+
+// Pick the first active admin for greeting + phone routing.
+const admins = Array.isArray(partner.admins) ? partner.admins : []
+const activeAdmins = admins.filter(function (a) { return a && a.is_active !== false })
+const primary = activeAdmins[0] || admins[0] || null
+
+const partnerName = (primary && primary.first_name)
+  ? primary.first_name
+  : (partner.name || "Partner")
+
+const phone = (primary && primary.phone) ? primary.phone : (partner.whatsapp_number || null)
+if (!phone) {
+  return { skipped: true, reason: "no_phone_on_partner", event: eventName, order_id: orderId, partner_id: partner.id }
+}
+
+const languageCode = (primary && primary.preferred_language) ? primary.preferred_language : ""
+
+return {
+  skipped: false,
+  event: eventName,
+  to: phone,
+  partner_id: partner.id,
+  template_name: "${PICKUP_TEMPLATE}",
+  variables: [partnerName, orderId, awb || "-", milestoneLabel],
+  language_code: languageCode || "",
+  status: newStatus,
+  milestone_label: milestoneLabel,
+  context_type: "inventory_shipment",
+  // context_id is per (shipment, status) so each distinct milestone delivers
+  // once (pickup_scheduled then picked_up each send), while an event RETRY
+  // within the dedup window collapses to a single send.
+  context_id: shipmentId + ":" + newStatus,
+  shipment_id: shipmentId,
+  order_id: orderId,
+}
+`
+
+// ─── Flow definition (exported for the structural unit test + the job) ─────────
+
+export const FLOW_DEF = {
+  name: FLOW_NAME,
+  description:
+    "Single dispatcher for partner-facing WhatsApp pickup notifications on " +
+    "inventory-shipment status transitions. Listens to " +
+    "inventory_orders.inventory-shipment.status-changed (#888 — fired by the " +
+    "carrier tracking webhook and at shipment creation when a pickup is " +
+    "scheduled), reads the shipment's order + assigned partner, maps the " +
+    "milestone via an execute_code node, then dispatches the generic " +
+    "jyt_inventory_shipment_pickup_v1 template through send_whatsapp. Notifies " +
+    "on pickup_scheduled / picked_up; skips transit noise, order-level " +
+    "milestones (covered by the #771 status flow) and partner-less orders.",
+  status: "draft" as const,
+  trigger_type: "event" as const,
+  trigger_config: {
+    event_types: [STATUS_CHANGED_EVENT],
+  },
+
+  canvas_state: {
+    viewport: { x: 0, y: 0, zoom: 0.8 },
+    nodes: [
+      { id: "trigger",         type: "trigger",   position: { x: X_CENTER, y: -20 },          data: { label: "Inventory Shipment — status changed", triggerType: "event", triggerConfig: { event_types: [STATUS_CHANGED_EVENT] } } },
+      { id: "read_order",      type: "operation", position: { x: X_CENTER, y: Y_READ_ORDER }, data: { label: "Read Order + Partner", operationKey: "read_order",      operationType: "read_data"     } },
+      { id: "resolve_message", type: "operation", position: { x: X_CENTER, y: Y_RESOLVE },    data: { label: "Resolve Message",      operationKey: "resolve_message", operationType: "execute_code"  } },
+      { id: "has_message",     type: "operation", position: { x: X_CENTER, y: Y_COND },       data: { label: "Has Message?",         operationKey: "has_message",     operationType: "condition"     } },
+      { id: "send",            type: "operation", position: { x: X_LEFT,   y: Y_SEND },       data: { label: "Send WhatsApp",        operationKey: "send",            operationType: "send_whatsapp" } },
+      { id: "log_skip",        type: "operation", position: { x: X_RIGHT,  y: Y_SKIP },       data: { label: "Log: Skipped",         operationKey: "log_skip",        operationType: "log"           } },
+    ],
+    edges: [
+      { id: "e-0", source: "trigger",         sourceHandle: "default", target: "read_order",      targetHandle: "default" },
+      { id: "e-1", source: "read_order",      sourceHandle: "default", target: "resolve_message", targetHandle: "default" },
+      { id: "e-2", source: "resolve_message", sourceHandle: "default", target: "has_message",     targetHandle: "default" },
+      { id: "e-3", source: "has_message",     sourceHandle: "success", target: "send",            targetHandle: "default" },
+      { id: "e-4", source: "has_message",     sourceHandle: "failure", target: "log_skip",        targetHandle: "default" },
+    ],
+  },
+
+  operations: [
+    // ── 1. Read the shipment's inventory order + assigned partner ──────────
+    {
+      operation_key: "read_order",
+      operation_type: "read_data",
+      name: "Read Order + Partner",
+      sort_order: 0,
+      position_x: X_CENTER,
+      position_y: Y_READ_ORDER,
+      options: {
+        entity: "inventory_orders",
+        fields: [
+          "id",
+          "status",
+          "quantity",
+          "partner.id",
+          "partner.name",
+          "partner.whatsapp_number",
+          "partner.admins.id",
+          "partner.admins.first_name",
+          "partner.admins.phone",
+          "partner.admins.is_active",
+          "partner.admins.preferred_language",
+        ],
+        // The event payload is shipment-shaped: order_id carries the order.
+        filters: { id: "{{ $trigger.payload.order_id }}" },
+        limit: 1,
+      },
+    },
+
+    // ── 2. Resolve message config from the shipment milestone ──────────────
+    {
+      operation_key: "resolve_message",
+      operation_type: "execute_code",
+      name: "Resolve Message",
+      sort_order: 1,
+      position_x: X_CENTER,
+      position_y: Y_RESOLVE,
+      options: {
+        code: RESOLVE_MESSAGE_CODE,
+        timeout: 5000,
+      },
+    },
+
+    // ── 3. Condition: did we resolve a sendable message? ───────────────────
+    {
+      operation_key: "has_message",
+      operation_type: "condition",
+      name: "Has Message?",
+      sort_order: 2,
+      position_x: X_CENTER,
+      position_y: Y_COND,
+      options: {
+        condition_mode: "expression",
+        // skipped === false → success branch (send). true → failure (log only).
+        expression: "resolve_message.skipped === false",
+        filter_rule: { "resolve_message.skipped": { _eq: false } },
+      },
+    },
+
+    // ── 4a. Send WhatsApp template (success branch) ────────────────────────
+    {
+      operation_key: "send",
+      operation_type: "send_whatsapp",
+      name: "Send WhatsApp",
+      sort_order: 3,
+      position_x: X_LEFT,
+      position_y: Y_SEND,
+      options: {
+        to: "{{ resolve_message.to }}",
+        partner_id: "{{ resolve_message.partner_id }}",
+        mode: "template",
+        template_name: "{{ resolve_message.template_name }}",
+        variables: "{{ resolve_message.variables }}",
+        language_code: "{{ resolve_message.language_code }}",
+        context_type: "{{ resolve_message.context_type }}",
+        context_id: "{{ resolve_message.context_id }}",
+        // 60-min dedup blocks accidental double-sends from event retries.
+        // Distinct milestones carry distinct context_ids (shipment:status) so
+        // pickup_scheduled → picked_up both deliver.
+        dedup_window_minutes: 60,
+        require_partner: true,
+      },
+    },
+
+    // ── 4b. Log skip (failure branch) ──────────────────────────────────────
+    {
+      operation_key: "log_skip",
+      operation_type: "log",
+      name: "Log: Skipped",
+      sort_order: 4,
+      position_x: X_RIGHT,
+      position_y: Y_SKIP,
+      options: {
+        message:
+          "Skipping inventory-shipment pickup WhatsApp for {{ $trigger.payload.id }} " +
+          "(status {{ $trigger.payload.status }}) — reason: {{ resolve_message.reason }}",
+        level: "info",
+      },
+    },
+  ],
+
+  connections: [
+    { source_id: "trigger",         source_handle: "default", target_id: "read_order",      connection_type: "default" as const },
+    { source_id: "read_order",      source_handle: "default", target_id: "resolve_message", connection_type: "default" as const },
+    { source_id: "resolve_message", source_handle: "default", target_id: "has_message",     connection_type: "default" as const },
+    { source_id: "has_message",     source_handle: "success", target_id: "send",            connection_type: "success" as const },
+    { source_id: "has_message",     source_handle: "failure", target_id: "log_skip",        connection_type: "failure" as const },
+  ],
+}
+
+// ─── Runner ──────────────────────────────────────────────────────────────────
+
+export default async function seedInventoryShipmentPickupFlow({
+  container,
+}: {
+  container: any
+}) {
+  const service: VisualFlowService = container.resolve(VISUAL_FLOWS_MODULE)
+
+  const [existing] = await service.listVisualFlows({ name: FLOW_NAME } as any)
+  if (existing) {
+    console.log(`Flow "${FLOW_NAME}" already exists (${existing.id}) — skipping.`)
+    console.log(`Delete it in the admin UI (or by id) to re-seed.`)
+    return
+  }
+
+  console.log(`Creating flow "${FLOW_NAME}"...`)
+
+  const flow = await service.createCompleteFlow({
+    flow: {
+      name: FLOW_DEF.name,
+      description: FLOW_DEF.description,
+      status: FLOW_DEF.status,
+      trigger_type: FLOW_DEF.trigger_type,
+      trigger_config: FLOW_DEF.trigger_config,
+      canvas_state: FLOW_DEF.canvas_state,
+    },
+    operations: FLOW_DEF.operations,
+    connections: FLOW_DEF.connections,
+  })
+
+  console.log(`\nFlow created: ${flow.id}`)
+  console.log(`  Open: /app/visual-flows/${flow.id}\n`)
+  console.log(`Before activating:`)
+  console.log(`  1. Ensure this template is APPROVED on every WABA you target:`)
+  console.log(`     - ${PICKUP_TEMPLATE}   ({{1}} partner, {{2}} order id, {{3}} awb, {{4}} milestone)`)
+  console.log(`     Push via the sync-whatsapp-templates Data Plumbing job, or:`)
+  console.log(`       npx medusa exec ./src/scripts/manage-whatsapp-templates.ts`)
+  console.log(`  2. Flip flow status: draft → active in the admin editor.`)
+}

--- a/apps/backend/src/scripts/whatsapp-templates/__tests__/inventory-order-templates.unit.spec.ts
+++ b/apps/backend/src/scripts/whatsapp-templates/__tests__/inventory-order-templates.unit.spec.ts
@@ -1,5 +1,6 @@
 import { INVENTORY_ORDER_TEMPLATES } from "../inventory-order-templates"
 import { FLOW_DEF } from "../../seed-inventory-order-status-flow"
+import { FLOW_DEF as PICKUP_FLOW_DEF } from "../../seed-inventory-shipment-pickup-flow"
 
 /**
  * #771 — the inventory-order status flow sends `jyt_inventory_order_status_v1`.
@@ -41,5 +42,36 @@ describe("inventory-order WhatsApp template registry", () => {
       (o) => o.operation_key === "resolve_message"
     )!.options as any).code as string
     expect(code).toContain("jyt_inventory_order_status_v1")
+  })
+})
+
+describe("inventory-shipment pickup WhatsApp template registry (#888 S3)", () => {
+  const tpl = INVENTORY_ORDER_TEMPLATES.find(
+    (t) => t.name === "jyt_inventory_shipment_pickup_v1"
+  )
+
+  it("registers jyt_inventory_shipment_pickup_v1 as a UTILITY template", () => {
+    expect(tpl).toBeTruthy()
+    expect(tpl!.category).toBe("UTILITY")
+    expect(tpl!.languages.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it("uses exactly 4 positional placeholders, identical across languages, with matching examples", () => {
+    const counts = tpl!.languages.map((l) => countPlaceholders(l.body))
+    // Meta requires identical body shape across language variants.
+    expect(new Set(counts).size).toBe(1)
+    expect(counts[0]).toBe(4) // {{1}} partner, {{2}} order id, {{3}} awb, {{4}} milestone
+    // Every placeholder needs an example or Meta rejects the template.
+    for (const l of tpl!.languages) {
+      expect(l.examples.length).toBe(4)
+    }
+  })
+
+  it("the pickup flow sends exactly this template name (no drift)", () => {
+    // resolve_message embeds the template name as a literal in its code string.
+    const code = (PICKUP_FLOW_DEF.operations.find(
+      (o) => o.operation_key === "resolve_message"
+    )!.options as any).code as string
+    expect(code).toContain("jyt_inventory_shipment_pickup_v1")
   })
 })

--- a/apps/backend/src/scripts/whatsapp-templates/inventory-order-templates.ts
+++ b/apps/backend/src/scripts/whatsapp-templates/inventory-order-templates.ts
@@ -43,6 +43,54 @@ const TEMPLATE_INVENTORY_ORDER_STATUS: TemplateSpec = {
   ],
 }
 
+/**
+ * Shipment-level pickup milestones (#888 S3). Sent by the
+ * seed-inventory-shipment-pickup-flow dispatcher on the
+ * `inventory_orders.inventory-shipment.status-changed` event — pickup
+ * scheduled ("a courier arrives on <date>") and picked up. Order-level
+ * Shipped/Delivered stay on jyt_inventory_order_status_v1 above, so the two
+ * flows never say the same thing twice.
+ *
+ * Placeholders (positional, must match the flow's `variables` order):
+ *   {{1}} partner first name
+ *   {{2}} inventory order id
+ *   {{3}} AWB / tracking number
+ *   {{4}} milestone label ("Pickup scheduled for 2026-07-08", "Picked up by the courier")
+ */
+const TEMPLATE_INVENTORY_SHIPMENT_PICKUP: TemplateSpec = {
+  name: "jyt_inventory_shipment_pickup_v1",
+  category: "UTILITY",
+  languages: [
+    {
+      language: "en",
+      body:
+        "Hi {{1}}, pickup update for your inventory order {{2}} (AWB {{3}}): *{{4}}*.\n\n" +
+        "We'll keep you updated as it progresses. " +
+        "Thanks for working with us.",
+      examples: [
+        "Rajesh",
+        "inv_order_01ABC",
+        "776123456789",
+        "Pickup scheduled for 2026-07-08",
+      ],
+    },
+    {
+      language: "hi",
+      body:
+        "नमस्ते {{1}}, आपके इन्वेंटरी ऑर्डर {{2}} (AWB {{3}}) के पिकअप की जानकारी: *{{4}}*।\n\n" +
+        "प्रगति होने पर हम आपको सूचित करते रहेंगे। " +
+        "साथ काम करने के लिए धन्यवाद।",
+      examples: [
+        "राजेश",
+        "inv_order_01ABC",
+        "776123456789",
+        "Pickup scheduled for 2026-07-08",
+      ],
+    },
+  ],
+}
+
 export const INVENTORY_ORDER_TEMPLATES: TemplateSpec[] = [
   TEMPLATE_INVENTORY_ORDER_STATUS,
+  TEMPLATE_INVENTORY_SHIPMENT_PICKUP,
 ]

--- a/apps/backend/src/workflows/inventory_orders/create-inventory-order-shipment.ts
+++ b/apps/backend/src/workflows/inventory_orders/create-inventory-order-shipment.ts
@@ -4,8 +4,10 @@ import {
   StepResponse,
   WorkflowResponse,
 } from "@medusajs/framework/workflows-sdk"
-import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
 import type { MedusaContainer } from "@medusajs/framework/types"
+import type { IEventBusModuleService } from "@medusajs/types"
+import { INVENTORY_SHIPMENT_STATUS_CHANGED_EVENT } from "./sync-inventory-shipment-tracking"
 import { ORDER_INVENTORY_MODULE } from "../../modules/inventory_orders"
 import { FULLFILLED_ORDERS_MODULE } from "../../modules/fullfilled_orders"
 import InventoryOrdersStockLocationsLink from "../../links/inventory-orders-stock-locations"
@@ -277,6 +279,29 @@ export async function createInventoryOrderShipment(
         [FULLFILLED_ORDERS_MODULE]: { inventory_shipment_id: record.id },
       },
     ])
+    // A pickup was scheduled at creation, so the shipment is born past the
+    // webhook's created→pickup_scheduled transition — emit the shipment
+    // status-changed event ourselves so the #888 pickup WhatsApp flow tells
+    // the partner a courier is coming, regardless of who created the shipment.
+    if (pickup) {
+      try {
+        const eventBus = container.resolve(Modules.EVENT_BUS) as IEventBusModuleService
+        await eventBus.emit({
+          name: INVENTORY_SHIPMENT_STATUS_CHANGED_EVENT,
+          data: {
+            id: record.id,
+            awb: result.awb ?? null,
+            carrier,
+            previous_status: "created",
+            status: "pickup_scheduled",
+            order_id: order.id,
+            pickup_scheduled_date: pickup.scheduled_date ?? input.pickupDate ?? null,
+          },
+        })
+      } catch {
+        /* best-effort — shipment creation must not fail on event emit */
+      }
+    }
   } catch (e) {
     const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
     logger.error(

--- a/apps/partner-ui/src/components/work-orders/inventory-order-sections.tsx
+++ b/apps/partner-ui/src/components/work-orders/inventory-order-sections.tsx
@@ -1,4 +1,5 @@
 import { Container, Heading, StatusBadge, Text } from "@medusajs/ui"
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { useDate } from "../../hooks/use-date"
@@ -130,6 +131,120 @@ export const InventoryPaymentsSection = ({
 }
 
 /**
+ * #888 — Upcoming-pickup card for an inventory work-order. Surfaces shipments
+ * with a scheduled pickup (status 'pickup_scheduled' + pickup_scheduled_date) so
+ * the partner sees "a courier is coming" at a glance: date, pickup location, AWB.
+ */
+export const InventoryUpcomingPickupCard = ({
+  shipments,
+}: {
+  shipments: Array<Record<string, any>>
+}) => {
+  const { t } = useTranslation()
+  const { getFullDate } = useDate()
+
+  const upcoming = shipments.filter(
+    (s) =>
+      String(s?.status || "").toLowerCase() === "pickup_scheduled" &&
+      !!s?.pickup_scheduled_date
+  )
+
+  if (upcoming.length === 0) return null
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="px-6 py-4">
+        <Heading level="h2">{t("partner.workOrders.upcomingPickup")}</Heading>
+      </div>
+      {upcoming.map((s, idx) => {
+        const awb = s.awb || s.tracking_number
+        return (
+          <div
+            key={String(s.id ?? idx)}
+            className="flex items-center justify-between px-6 py-4"
+          >
+            <div className="min-w-0">
+              <Text size="small" weight="plus">
+                {/* pickup_scheduled_date is date-only (YYYY-MM-DD) — no time part */}
+                {getFullDate({ date: s.pickup_scheduled_date })}
+              </Text>
+              {s.pickup_location_name && (
+                <Text size="xsmall" className="text-ui-fg-subtle">
+                  {t("partner.workOrders.pickupFrom")}: {s.pickup_location_name}
+                </Text>
+              )}
+              {awb &&
+                (s.tracking_url ? (
+                  <a
+                    href={s.tracking_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-ui-fg-interactive hover:text-ui-fg-interactive-hover"
+                  >
+                    <Text size="xsmall">AWB {awb}</Text>
+                  </a>
+                ) : (
+                  <Text size="xsmall">AWB {awb}</Text>
+                ))}
+            </div>
+          </div>
+        )
+      })}
+    </Container>
+  )
+}
+
+/**
+ * #888 — Per-shipment tracking timeline fed by the carrier webhook. Renders a
+ * compact toggle; expanded shows events newest-first. Never renders
+ * metadata.last_webhook (the raw carrier payload).
+ */
+const ShipmentTrackingHistory = ({
+  shipment,
+}: {
+  shipment: Record<string, any>
+}) => {
+  const { t } = useTranslation()
+  const { getFullDate } = useDate()
+  const [open, setOpen] = useState(false)
+
+  const events = (() => {
+    const raw = shipment?.metadata?.tracking_events
+    if (!raw || !Array.isArray(raw)) return [] as any[]
+    return raw.slice(0, 50)
+  })()
+
+  if (events.length === 0) return null
+
+  return (
+    <div className="mt-2">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="text-ui-fg-interactive hover:text-ui-fg-interactive-hover"
+      >
+        <Text size="xsmall">
+          {t("partner.workOrders.trackingHistory")} ({events.length})
+        </Text>
+      </button>
+      {open && (
+        <div className="mt-1 flex flex-col gap-y-0.5">
+          {[...events].reverse().map((ev, i) => (
+            <Text key={i} size="xsmall" className="text-ui-fg-subtle">
+              {String(ev?.status || "")}
+              {ev?.received_at
+                ? ` · ${getFullDate({ date: ev.received_at, includeTime: true })}`
+                : ""}
+              {ev?.location ? ` · ${ev.location}` : ""}
+            </Text>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
  * Shipments section for an inventory work-order (#772 follow-up) — lists the
  * carrier shipments the partner generated (AWB · carrier · pickup · label),
  * reading the first-class shipment rows the detail endpoint now returns.
@@ -185,6 +300,7 @@ export const InventoryShipmentsSection = ({
                     ? ` · ${getFullDate({ date: s.created_at, includeTime: true })}`
                     : ""}
                 </Text>
+                <ShipmentTrackingHistory shipment={s} />
               </div>
               <div className="flex items-center gap-x-3">
                 {s.label_url && (

--- a/apps/partner-ui/src/i18n/translations/en.json
+++ b/apps/partner-ui/src/i18n/translations/en.json
@@ -3438,6 +3438,8 @@
       "noShipments": "No shipments created yet.",
       "pickupFrom": "Pickup",
       "trackingLabel": "Label",
+      "upcomingPickup": "Upcoming pickup",
+      "trackingHistory": "Tracking history",
       "payments": "Payments",
       "noPayments": "No payments submitted yet.",
       "delivered": "Delivered",

--- a/apps/partner-ui/src/lib/status-badge.ts
+++ b/apps/partner-ui/src/lib/status-badge.ts
@@ -14,6 +14,7 @@ export const getStatusBadgeColor = (
   switch (s) {
     case "complete":
     case "completed":
+    case "delivered":
     case "finish":
     case "finished":
     case "fulfilled":
@@ -27,6 +28,8 @@ export const getStatusBadgeColor = (
     case "started":
     case "processing":
     case "proposed":
+    case "pickup_scheduled":
+    case "out_for_delivery":
       return "orange"
 
     case "awaiting_review":
@@ -34,6 +37,8 @@ export const getStatusBadgeColor = (
     case "technical_review":
     case "under_review":
     case "sent_to_partner":
+    case "picked_up":
+    case "in_transit":
       return "blue"
 
     case "approved":
@@ -44,6 +49,7 @@ export const getStatusBadgeColor = (
     case "canceled":
     case "cancelled":
     case "rejected":
+    case "rto":
       return "red"
 
     case "incoming":

--- a/apps/partner-ui/src/routes/orders/order-detail/order-detail.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/order-detail.tsx
@@ -10,6 +10,7 @@ import {
   InventoryFulfillmentsSection,
   InventoryPaymentsSection,
   InventoryShipmentsSection,
+  InventoryUpcomingPickupCard,
 } from "../../../components/work-orders/inventory-order-sections"
 import { ProductionRunCard } from "../../../components/work-orders/production-run-card"
 import { WorkOrderActivitySection } from "../../../components/work-orders/work-order-activity-section"
@@ -214,6 +215,9 @@ export const OrderDetail = () => {
                 />
                 <InventoryFulfillmentsSection
                   orderLines={(inventoryOrder.order_lines ?? []) as Array<Record<string, any>>}
+                />
+                <InventoryUpcomingPickupCard
+                  shipments={((inventoryOrder as any).shipments ?? []) as Array<Record<string, any>>}
                 />
                 <InventoryShipmentsSection
                   shipments={((inventoryOrder as any).shipments ?? []) as Array<Record<string, any>>}


### PR DESCRIPTION
## What

#888 S3 + S4, on top of the merged webhook automation (#889).

### S3 — pickup WhatsApp notifications
- **Template** `jyt_inventory_shipment_pickup_v1` (en+hi, UTILITY, 4 positional vars: partner / order id / AWB / milestone). Pushed by the existing **sync-whatsapp-templates** DP job — no new push path.
- **Visual flow** `Partner WhatsApp — Inventory Shipment Pickup` (seed script `seed-inventory-shipment-pickup-flow.ts`): listens to `inventory_orders.inventory-shipment.status-changed`, notifies **pickup_scheduled** ("Pickup scheduled for <date>") and **picked_up**; skips transit noise — order-level Shipped/Delivered stay on the #771 flow so the partner is never double-pinged. Dedup context per (shipment, milestone).
- **DP job** `install-inventory-shipment-pickup-flow` — installs the flow from Settings → Data Plumbing, idempotent, created as DRAFT.
- `create-inventory-order-shipment` now **emits the shipment status-changed event when a pickup is scheduled at creation** — so the "courier is coming" ping fires for pickups scheduled via our own API, not only webhook transitions.

### S4 — UI surfaces
- **Admin**: `GET /admin/inventory-orders/:id` now attaches first-class `inventory_shipments` as `shipments` (the section previously only ever rendered the legacy `metadata.shipment` blob). Shipments section: badges for all 8 lifecycle statuses, expandable **Tracking history** from `metadata.tracking_events`, and a **confirm-receipt nudge** when every non-cancelled shipment is delivered (stock receipt stays manual — locked #888 decision). `metadata.last_webhook` is never rendered.
- **Partner UI**: new **Upcoming pickup** card (date, pickup location, AWB) mounted above the shipments section; per-shipment **Tracking history** timeline; shipment statuses added to `getStatusBadgeColor`; partner API strips `metadata.last_webhook` so the raw carrier payload never leaves the admin surface.

## Verification
- Unit: full suite **1969/1969** (12 new: template contract + flow structural guards).
- Integration: `shipping-tracking-webhook` **5/5**, `inventory-order-shiprocket-shipment` + `inventory-order-status-flow-install` + `inventory-order-status-flow-execution` **19/19**.
- Touched admin/partner-ui files esbuild-parse + tsc clean (only pre-existing baseline errors elsewhere).
- Drafting delegated to GLM 5.2 via the opencode drafter; every diff reviewed, typechecked and test-run by Claude. UI visual verification: operator.

## Ops tail (after merge)
1. Run DP **sync-whatsapp-templates** (pushes `jyt_inventory_shipment_pickup_v1` to Meta for approval).
2. Run DP **install-inventory-shipment-pickup-flow** (apply), then flip the flow draft→active once the template is approved.

Part of #888.

🤖 Generated with [Claude Code](https://claude.com/claude-code)