### PR TITLE
feat(#892): S1 — AI tech-pack scene-builder (pure lib)

### DIFF
--- a/apps/backend/src/workflows/designs/moodboard/__tests__/build-moodboard-scene.unit.spec.ts
+++ b/apps/backend/src/workflows/designs/moodboard/__tests__/build-moodboard-scene.unit.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * Unit test — buildMoodboardScene / mergeFramesIntoScene (#892)
+ *
+ * Pure scene-builder tests. No DI, no DB. Asserts the Excalidraw scene contract,
+ * frame grouping, image-file wiring, suggested-measurement dimming, determinism,
+ * merge semantics, and the minimal-input path.
+ *
+ * Run:
+ *   TEST_TYPE=unit npx jest --testPathPattern="build-moodboard-scene"
+ */
+import {
+  buildMoodboardScene,
+  mergeFramesIntoScene,
+} from "../build-moodboard-scene"
+import { SS26_CR_TP08 } from "./tech-pack.fixture"
+
+describe("buildMoodboardScene", () => {
+  const scene = buildMoodboardScene(SS26_CR_TP08)
+
+  it("produces an excalidraw scene of version 2", () => {
+    expect(scene.type).toBe("excalidraw")
+    expect(scene.version).toBe(2)
+  })
+
+  it("builds 4 frames with the expected names", () => {
+    const frames = scene.elements.filter((e) => e.type === "frame")
+    expect(frames).toHaveLength(4)
+    expect(frames.map((f) => f.name)).toEqual([
+      "1 · Header & Flats",
+      "2 · Measurements",
+      "3 · Zoom details",
+      "5 · Colorways",
+    ])
+  })
+
+  it("attaches every non-frame element to a frame (no orphans)", () => {
+    const frameIds = new Set(
+      scene.elements.filter((e) => e.type === "frame").map((f) => f.id)
+    )
+    const nonFrames = scene.elements.filter((e) => e.type !== "frame")
+    expect(nonFrames.length).toBeGreaterThan(0)
+    for (const el of nonFrames) {
+      expect(frameIds.has(el.frameId ?? "")).toBe(true)
+    }
+  })
+
+  it("registers a file for every image element's fileId", () => {
+    const images = scene.elements.filter((e) => e.type === "image")
+    expect(images.length).toBeGreaterThan(0)
+    for (const img of images) {
+      expect(img.fileId).toBeDefined()
+      expect(scene.files[img.fileId as string]).toBeDefined()
+    }
+  })
+
+  it("dims suggested measurement texts (opacity 50) and leaves spec ones at 100", () => {
+    const texts = scene.elements.filter((e) => e.type === "text")
+    const yoke = texts.find((t) => (t.text ?? "").includes("Yoke Drop"))
+    const totalLength = texts.find((t) =>
+      (t.text ?? "").includes("Total Length Hps")
+    )
+    expect(yoke).toBeDefined()
+    expect(totalLength).toBeDefined()
+    expect(yoke?.opacity).toBe(50)
+    expect(totalLength?.opacity).toBe(100)
+  })
+
+  it("is deterministic — two builds of the same fixture are deeply equal", () => {
+    const a = buildMoodboardScene(SS26_CR_TP08)
+    const b = buildMoodboardScene(SS26_CR_TP08)
+    expect(JSON.stringify(a)).toEqual(JSON.stringify(b))
+  })
+
+  it("builds a minimal input without throwing and yields exactly 1 frame", () => {
+    const minimal = buildMoodboardScene({
+      design: { title: "Solo" },
+      garment_type: "top",
+      flats: {},
+    })
+    const frames = minimal.elements.filter((e) => e.type === "frame")
+    expect(frames).toHaveLength(1)
+    expect(frames[0].name).toBe("1 · Header & Flats")
+  })
+})
+
+describe("mergeFramesIntoScene", () => {
+  it("replaces same-named frames without duplicating element count", () => {
+    const base = buildMoodboardScene(SS26_CR_TP08)
+    const incoming = buildMoodboardScene(SS26_CR_TP08)
+    const merged = mergeFramesIntoScene(base, incoming)
+    // All frame names match → every base frame+child is dropped, incoming appended.
+    expect(merged.elements).toHaveLength(base.elements.length)
+  })
+})

--- a/apps/backend/src/workflows/designs/moodboard/__tests__/tech-pack.fixture.ts
+++ b/apps/backend/src/workflows/designs/moodboard/__tests__/tech-pack.fixture.ts
@@ -1,0 +1,54 @@
+/**
+ * Fixture modeled on the real tech pack SS26–CR–TP-08 (Craft Revival top) — the gold
+ * standard from GitHub #892. Used to unit-test build-moodboard-scene.ts frame builders.
+ * Measurement values are the real callouts from page 2 of that tech pack; unit is cm.
+ */
+import type { TechPackSceneInput } from "../build-moodboard-scene"
+
+export const SS26_CR_TP08: TechPackSceneInput = {
+  design: {
+    title: "Craft Revival Top",
+    style_code: "SS26–CR–TP-08",
+    season: "SS26",
+    category: "Womenswear / Top",
+    capsule: "Craft Revival",
+  },
+  garment_type: "blouse",
+  flats: {
+    front_image_url: "https://cdn.example.com/ss26-cr-tp08-front.png",
+    back_image_url: "https://cdn.example.com/ss26-cr-tp08-back.png",
+  },
+  sizeSet: {
+    size_label: "M",
+    unit: "cm",
+    measurements: {
+      total_length_hps: 66,
+      shoulder_across: 38,
+      neck_width: 24,
+      neck_drop: 12,
+      yoke_drop: 30,
+      sleeve_length: 62,
+      hem_opening: 160,
+    },
+    // yoke_drop is a vision guess in this fixture; the rest are spec-confirmed.
+    suggested: ["yoke_drop"],
+  },
+  regions: [
+    {
+      label: "Neckline embroidery",
+      bbox: [120, 40, 180, 120],
+      note: "width 2–2.5 cm emb",
+    },
+    {
+      label: "Sleeve embroidery",
+      bbox: [30, 220, 140, 160],
+      note: "flower emb 3.5 cm wide",
+    },
+  ],
+  colorways: [
+    { name: "Natural / Indigo", hex_code: "#2e3a59", thread_ref: "K-7" },
+    { name: "Natural / Madder", hex_code: "#a83232", thread_ref: "K-10" },
+    { name: "Natural / Myrobalan", hex_code: "#c9a227", thread_ref: "K-14" },
+  ],
+  seed: 42,
+}

--- a/apps/backend/src/workflows/designs/moodboard/build-moodboard-scene.ts
+++ b/apps/backend/src/workflows/designs/moodboard/build-moodboard-scene.ts
@@ -420,14 +420,301 @@ export function buildHeaderFlatsFrame(
   return { elements, files }
 }
 
-// ── DELEGATED (see draft task): mirror buildHeaderFlatsFrame ─────────────────────
-// buildMeasurementFrame(input, rng, originX)  — Page 2: flats + dimension callout
-//     arrows (type:"arrow") with a bound/adjacent text per sizeSet.measurements entry,
-//     via formatMeasurement(); suggested keys rendered at opacity 50.
-// buildZoomLensFrame(input, rng, originX)     — Page 3: ellipse "lens" per region with
-//     an arrow to a spec-note text (region.note).
-// buildColorwayFrame(input, rng, originX)     — Page 5: a rectangle chip per colorway
-//     (backgroundColor: hex_code) with name + thread_ref text under it.
+// ── Frame builders (mirror buildHeaderFlatsFrame) ───────────────────────────────
+
+/**
+ * Page 2 — measurement callouts. One row per `sizeSet.measurements` entry: a short
+ * right-pointing arrow + a `formatMeasurement()` text label. Vision-suggested keys
+ * (listed in `sizeSet.suggested`) render dimmed (opacity 50).
+ */
+export function buildMeasurementFrame(
+  input: TechPackSceneInput,
+  rng: SceneRng,
+  originX: number
+): FrameResult {
+  const frameId = rng.id("frame")
+  const frame = makeElement(
+    {
+      type: "frame",
+      id: frameId,
+      x: originX,
+      y: 0,
+      width: FRAME.width,
+      height: FRAME.height,
+      name: "2 · Measurements",
+    },
+    rng
+  )
+
+  const elements: ExcalidrawElement[] = [frame]
+  const files: Record<string, ExcalidrawFile> = {}
+
+  if (!input.sizeSet) {
+    elements.push(
+      makeElement(
+        {
+          type: "text",
+          x: originX + FRAME.pad,
+          y: FRAME.pad,
+          width: 300,
+          height: 24,
+          text: "No measurements",
+          fontSize: 18,
+        },
+        rng,
+        frameId
+      )
+    )
+    return { elements, files }
+  }
+
+  const { measurements, unit, suggested } = input.sizeSet
+  const suggestedSet = new Set(suggested ?? [])
+  const rowGap = 40
+  const arrowW = 60
+  const labelX = originX + FRAME.pad + arrowW + 16
+
+  Object.entries(measurements).forEach(([key, value], i) => {
+    const rowY = FRAME.pad + i * rowGap
+    elements.push(
+      makeElement(
+        {
+          type: "arrow",
+          x: originX + FRAME.pad,
+          y: rowY,
+          width: arrowW,
+          height: 0,
+          points: [
+            [0, 0],
+            [arrowW, 0],
+          ],
+        },
+        rng,
+        frameId
+      )
+    )
+    elements.push(
+      makeElement(
+        {
+          type: "text",
+          x: labelX,
+          y: rowY - 12,
+          width: 420,
+          height: 24,
+          text: formatMeasurement(key, value, unit),
+          fontSize: 16,
+          opacity: suggestedSet.has(key) ? 50 : 100,
+        },
+        rng,
+        frameId
+      )
+    )
+  })
+
+  return { elements, files }
+}
+
+/**
+ * Page 3 — zoom-lens detail callouts. Per region: an ellipse "lens" with an arrow to a
+ * text showing `region.label` (and `region.note` on the next line when present).
+ */
+export function buildZoomLensFrame(
+  input: TechPackSceneInput,
+  rng: SceneRng,
+  originX: number
+): FrameResult {
+  const frameId = rng.id("frame")
+  const frame = makeElement(
+    {
+      type: "frame",
+      id: frameId,
+      x: originX,
+      y: 0,
+      width: FRAME.width,
+      height: FRAME.height,
+      name: "3 · Zoom details",
+    },
+    rng
+  )
+
+  const elements: ExcalidrawElement[] = [frame]
+  const files: Record<string, ExcalidrawFile> = {}
+
+  const regions = input.regions ?? []
+  if (regions.length === 0) {
+    elements.push(
+      makeElement(
+        {
+          type: "text",
+          x: originX + FRAME.pad,
+          y: FRAME.pad,
+          width: 300,
+          height: 24,
+          text: "No detail regions",
+          fontSize: 18,
+        },
+        rng,
+        frameId
+      )
+    )
+    return { elements, files }
+  }
+
+  const lensW = 160
+  const lensH = 160
+  const rowGap = 220
+  const textX = originX + FRAME.pad + lensW + 80
+
+  regions.forEach((region, i) => {
+    const rowY = FRAME.pad + i * rowGap
+    elements.push(
+      makeElement(
+        {
+          type: "ellipse",
+          x: originX + FRAME.pad,
+          y: rowY,
+          width: lensW,
+          height: lensH,
+          strokeColor: "#1e1e1e",
+          backgroundColor: "transparent",
+          fillStyle: "solid",
+        },
+        rng,
+        frameId
+      )
+    )
+    elements.push(
+      makeElement(
+        {
+          type: "arrow",
+          x: originX + FRAME.pad + lensW,
+          y: rowY + lensH / 2,
+          width: 80,
+          height: 0,
+          points: [
+            [0, 0],
+            [80, 0],
+          ],
+        },
+        rng,
+        frameId
+      )
+    )
+    const noteLines = [region.label, region.note].filter(Boolean) as string[]
+    elements.push(
+      makeElement(
+        {
+          type: "text",
+          x: textX,
+          y: rowY + lensH / 2 - 12,
+          width: 360,
+          height: noteLines.length * 22,
+          text: noteLines.join("\n"),
+          fontSize: 16,
+          lineHeight: 1.35,
+        },
+        rng,
+        frameId
+      )
+    )
+  })
+
+  return { elements, files }
+}
+
+/**
+ * Page 5 — colorway chips. Per colorway: a solid rectangle chip filled with
+ * `hex_code`, the colorway `name` under it, and a `Thread <ref>` line when
+ * `thread_ref` is present. Chips laid out left-to-right.
+ */
+export function buildColorwayFrame(
+  input: TechPackSceneInput,
+  rng: SceneRng,
+  originX: number
+): FrameResult {
+  const frameId = rng.id("frame")
+  const frame = makeElement(
+    {
+      type: "frame",
+      id: frameId,
+      x: originX,
+      y: 0,
+      width: FRAME.width,
+      height: FRAME.height,
+      name: "5 · Colorways",
+    },
+    rng
+  )
+
+  const elements: ExcalidrawElement[] = [frame]
+  const files: Record<string, ExcalidrawFile> = {}
+
+  const colorways = input.colorways ?? []
+  if (colorways.length === 0) {
+    elements.push(
+      makeElement(
+        {
+          type: "text",
+          x: originX + FRAME.pad,
+          y: FRAME.pad,
+          width: 300,
+          height: 24,
+          text: "No colorways",
+          fontSize: 18,
+        },
+        rng,
+        frameId
+      )
+    )
+    return { elements, files }
+  }
+
+  const chipW = 120
+  const chipH = 120
+  const colGap = 60
+
+  colorways.forEach((colorway, i) => {
+    const chipX = originX + FRAME.pad + i * (chipW + colGap)
+    const chipY = FRAME.pad
+    elements.push(
+      makeElement(
+        {
+          type: "rectangle",
+          x: chipX,
+          y: chipY,
+          width: chipW,
+          height: chipH,
+          backgroundColor: colorway.hex_code,
+          fillStyle: "solid",
+          strokeColor: "#1e1e1e",
+        },
+        rng,
+        frameId
+      )
+    )
+    const nameLines = [colorway.name, colorway.thread_ref && `Thread ${colorway.thread_ref}`].filter(
+      Boolean
+    ) as string[]
+    elements.push(
+      makeElement(
+        {
+          type: "text",
+          x: chipX,
+          y: chipY + chipH + 12,
+          width: chipW,
+          height: nameLines.length * 22,
+          text: nameLines.join("\n"),
+          fontSize: 14,
+          lineHeight: 1.35,
+        },
+        rng,
+        frameId
+      )
+    )
+  })
+
+  return { elements, files }
+}
 
 // ── Scene assembler ──────────────────────────────────────────────────────────────
 
@@ -442,8 +729,9 @@ export function buildMoodboardScene(input: TechPackSceneInput): MoodboardScene {
     r: SceneRng,
     x: number
   ) => FrameResult)[] = [buildHeaderFlatsFrame]
-  // NOTE: append buildMeasurementFrame / buildZoomLensFrame / buildColorwayFrame here
-  // once implemented (guard each on the data it needs — sizeSet, regions, colorways).
+  if (input.sizeSet) builders.push(buildMeasurementFrame)
+  if (input.regions?.length) builders.push(buildZoomLensFrame)
+  if (input.colorways?.length) builders.push(buildColorwayFrame)
 
   const elements: ExcalidrawElement[] = []
   let files: Record<string, ExcalidrawFile> = {}

--- a/apps/backend/src/workflows/designs/moodboard/build-moodboard-scene.ts
+++ b/apps/backend/src/workflows/designs/moodboard/build-moodboard-scene.ts
@@ -1,0 +1,502 @@
+/**
+ * build-moodboard-scene.ts — pure, server-side scene builder for the AI tech-pack
+ * moodboard (GitHub #892). Given a garment's flats + structured spec data, it emits
+ * a complete Excalidraw scene (the exact shape persisted on `design.moodboard`, see
+ * `apps/backend/src/admin/hooks/use-moodboard.ts:saveExcalidrawState`) as native,
+ * editable elements grouped into frames — one frame ≈ one tech-pack page.
+ *
+ * ARCHITECTURE NOTE (decided 2026-07-05, do not "fix" back):
+ * We hand-emit fully-qualified Excalidraw elements via `makeElement()` and do NOT use
+ * `@excalidraw/excalidraw`'s `convertToExcalidrawElements()`. That package fails to
+ * import in plain Node/Jest (it pulls browser-only JSON-import deps), so it cannot run
+ * in this server-side, unit-tested lib. This module therefore stays dependency-free and
+ * fully deterministic (seeded ids/nonces — no Date.now()/Math.random()), so its output
+ * is byte-stable and unit-testable against a fixture.
+ *
+ * Measurements are AUTHORITATIVE only from `DesignSizeSet.measurements`
+ * (`Record<string, number>`, see `size-set-utils.ts:NormalizedSizeSet`). There is no
+ * unit field on the model, so the unit is passed in explicitly and rendered next to each
+ * value. Values the caller marks `suggested` are rendered dimmed (vision guesses, not spec).
+ */
+
+// ── Public input contract ──────────────────────────────────────────────────────
+
+export type MeasurementUnit = "cm" | "in"
+
+export interface TechPackHeader {
+  title: string
+  style_code?: string
+  season?: string
+  category?: string
+  capsule?: string
+}
+
+export interface TechPackFlats {
+  /** CDN URL of the generated/segmented FRONT flat (already a moodboard file URL). */
+  front_image_url?: string
+  back_image_url?: string
+}
+
+export interface TechPackSizeSet {
+  size_label: string
+  /** Canonical measurement store: key → value in `unit`. From DesignSizeSet.measurements. */
+  measurements: Record<string, number>
+  unit: MeasurementUnit
+  /** Keys whose values are vision-suggested (not from spec data) — rendered dimmed. */
+  suggested?: string[]
+}
+
+export interface TechPackColorway {
+  name: string
+  hex_code: string
+  /** Optional thread/yarn reference (e.g. a K-number) shown under the chip. */
+  thread_ref?: string
+}
+
+/** A detected garment region for a zoom-lens crop (bbox in the flat's own px space). */
+export interface TechPackRegion {
+  label: string
+  /** [x, y, w, h] within the source flat image. */
+  bbox: [number, number, number, number]
+  /** Spec note shown beside the lens (e.g. "flower emb 3.5 cm wide"). */
+  note?: string
+}
+
+export interface TechPackSceneInput {
+  design: TechPackHeader
+  garment_type: string
+  flats: TechPackFlats
+  sizeSet?: TechPackSizeSet
+  colorways?: TechPackColorway[]
+  regions?: TechPackRegion[]
+  /** Optional stable seed so ids/nonces are reproducible across builds. Default 1. */
+  seed?: number
+}
+
+// ── Excalidraw scene / element shapes (local, minimal — matches saveExcalidrawState) ──
+
+export interface ExcalidrawFile {
+  id: string
+  dataURL: string
+  mimeType: string
+  created: number
+  lastRetrieved: number
+}
+
+export interface MoodboardScene {
+  type: "excalidraw"
+  version: 2
+  source: string
+  elements: ExcalidrawElement[]
+  appState: {
+    viewBackgroundColor: string
+    gridSize: number | null
+    theme: "light" | "dark"
+  }
+  files: Record<string, ExcalidrawFile>
+}
+
+/** Fully-qualified Excalidraw element (superset; unused fields default per makeElement). */
+export interface ExcalidrawElement {
+  id: string
+  type:
+    | "rectangle"
+    | "ellipse"
+    | "text"
+    | "image"
+    | "arrow"
+    | "line"
+    | "frame"
+  x: number
+  y: number
+  width: number
+  height: number
+  angle: number
+  strokeColor: string
+  backgroundColor: string
+  fillStyle: string
+  strokeWidth: number
+  strokeStyle: string
+  roughness: number
+  opacity: number
+  groupIds: string[]
+  frameId: string | null
+  roundness: { type: number } | null
+  seed: number
+  version: number
+  versionNonce: number
+  isDeleted: boolean
+  boundElements: { id: string; type: string }[] | null
+  updated: number
+  link: string | null
+  locked: boolean
+  // text-only
+  text?: string
+  fontSize?: number
+  fontFamily?: number
+  textAlign?: string
+  verticalAlign?: string
+  containerId?: string | null
+  originalText?: string
+  lineHeight?: number
+  // image-only
+  fileId?: string
+  status?: "pending" | "saved"
+  scale?: [number, number]
+  // arrow/line-only
+  points?: [number, number][]
+  lastCommittedPoint?: [number, number] | null
+  startBinding?: unknown
+  endBinding?: unknown
+  startArrowhead?: string | null
+  endArrowhead?: string | null
+  // frame-only
+  name?: string
+}
+
+// ── Deterministic element factory ───────────────────────────────────────────────
+
+/** Minimal skeleton the frame builders author; makeElement fills all boilerplate. */
+export interface ElementSkeleton extends Partial<ExcalidrawElement> {
+  type: ExcalidrawElement["type"]
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+/**
+ * Deterministic id/nonce source. Given a seed, produces a monotonic sequence — so a
+ * scene built twice from the same input is byte-identical (required for unit tests and
+ * to avoid spurious moodboard diffs).
+ */
+export class SceneRng {
+  private n: number
+  constructor(seed = 1) {
+    this.n = seed >>> 0
+  }
+  next(): number {
+    // xorshift32 — deterministic, no Math.random.
+    let x = this.n || 1
+    x ^= x << 13
+    x ^= x >>> 17
+    x ^= x << 5
+    this.n = x >>> 0
+    return this.n
+  }
+  id(prefix: string): string {
+    return `${prefix}-${this.next().toString(36)}`
+  }
+}
+
+/** Fill a skeleton into a fully-qualified, Excalidraw-valid element. */
+export function makeElement(
+  skel: ElementSkeleton,
+  rng: SceneRng,
+  frameId: string | null = null
+): ExcalidrawElement {
+  const base: ExcalidrawElement = {
+    id: skel.id ?? rng.id(skel.type),
+    type: skel.type,
+    x: skel.x,
+    y: skel.y,
+    width: skel.width,
+    height: skel.height,
+    angle: skel.angle ?? 0,
+    strokeColor: skel.strokeColor ?? "#1e1e1e",
+    backgroundColor: skel.backgroundColor ?? "transparent",
+    fillStyle: skel.fillStyle ?? "solid",
+    strokeWidth: skel.strokeWidth ?? 1,
+    strokeStyle: skel.strokeStyle ?? "solid",
+    roughness: skel.roughness ?? 0,
+    opacity: skel.opacity ?? 100,
+    groupIds: skel.groupIds ?? [],
+    frameId: skel.frameId ?? frameId,
+    roundness: skel.roundness ?? null,
+    seed: skel.seed ?? rng.next(),
+    version: skel.version ?? 1,
+    versionNonce: skel.versionNonce ?? rng.next(),
+    isDeleted: false,
+    boundElements: skel.boundElements ?? null,
+    updated: skel.updated ?? 1,
+    link: skel.link ?? null,
+    locked: skel.locked ?? false,
+  }
+  if (skel.type === "text") {
+    base.text = skel.text ?? ""
+    base.originalText = skel.originalText ?? skel.text ?? ""
+    base.fontSize = skel.fontSize ?? 16
+    base.fontFamily = skel.fontFamily ?? 1
+    base.textAlign = skel.textAlign ?? "left"
+    base.verticalAlign = skel.verticalAlign ?? "top"
+    base.containerId = skel.containerId ?? null
+    base.lineHeight = skel.lineHeight ?? 1.25
+  }
+  if (skel.type === "image") {
+    base.fileId = skel.fileId
+    base.status = skel.status ?? "saved"
+    base.scale = skel.scale ?? [1, 1]
+  }
+  if (skel.type === "arrow" || skel.type === "line") {
+    base.points = skel.points ?? [
+      [0, 0],
+      [skel.width, skel.height],
+    ]
+    base.lastCommittedPoint = skel.lastCommittedPoint ?? null
+    base.startBinding = skel.startBinding ?? null
+    base.endBinding = skel.endBinding ?? null
+    base.startArrowhead = skel.startArrowhead ?? null
+    base.endArrowhead =
+      skel.endArrowhead ?? (skel.type === "arrow" ? "arrow" : null)
+  }
+  if (skel.type === "frame") {
+    base.name = skel.name ?? "Frame"
+  }
+  return base
+}
+
+// ── Layout constants (shared by all frame builders) ─────────────────────────────
+
+export const FRAME = {
+  width: 1200,
+  height: 900,
+  gap: 120, // horizontal gap between page-frames
+  pad: 48, // inner padding
+}
+
+/** A frame builder returns the frame + its child elements and any image files. */
+export interface FrameResult {
+  elements: ExcalidrawElement[]
+  files: Record<string, ExcalidrawFile>
+}
+
+/** Human label + `unit`-suffixed value, e.g. "Total length (HPS)  66 cm". */
+export function formatMeasurement(
+  key: string,
+  value: number,
+  unit: MeasurementUnit
+): string {
+  const label = key
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+  return `${label}  ${value} ${unit}`
+}
+
+// ── REFERENCE FRAME BUILDER — copy this pattern for the other three ───────────────
+//
+// buildHeaderFlatsFrame is the fully-worked reference. buildMeasurementFrame,
+// buildZoomLensFrame, and buildColorwayFrame (below) MUST mirror this structure:
+//   1. a "frame" element at (originX, 0) sized FRAME.width × FRAME.height,
+//   2. child elements authored as skeletons through makeElement(skel, rng, frameId),
+//   3. every child's frameId === the frame's id, positioned WITHIN the frame bounds,
+//   4. image children register a file in `files` keyed by fileId (dataURL = the URL;
+//      moodboard files carry the URL in dataURL, see normalizeMoodboard in partner-ui),
+//   5. return { elements: [frame, ...children], files }.
+
+/**
+ * Page 1 — header block + clean FRONT/BACK flats side by side.
+ */
+export function buildHeaderFlatsFrame(
+  input: TechPackSceneInput,
+  rng: SceneRng,
+  originX: number
+): FrameResult {
+  // The frame's own id IS frameId — children reference it via frameId, so it must be
+  // the same value (pass id explicitly; don't let makeElement generate a second one).
+  const frameId = rng.id("frame")
+  const frame = makeElement(
+    {
+      type: "frame",
+      id: frameId,
+      x: originX,
+      y: 0,
+      width: FRAME.width,
+      height: FRAME.height,
+      name: "1 · Header & Flats",
+    },
+    rng
+  )
+
+  const elements: ExcalidrawElement[] = [frame]
+  const files: Record<string, ExcalidrawFile> = {}
+
+  // Header text block (top-left).
+  const { design, garment_type } = input
+  const headerLines = [
+    design.title,
+    design.style_code && `Style  ${design.style_code}`,
+    design.season && `Season  ${design.season}`,
+    design.category && `Category  ${design.category}`,
+    design.capsule && `Capsule  ${design.capsule}`,
+    `Type  ${garment_type}`,
+  ].filter(Boolean) as string[]
+
+  elements.push(
+    makeElement(
+      {
+        type: "text",
+        x: originX + FRAME.pad,
+        y: FRAME.pad,
+        width: 420,
+        height: headerLines.length * 24,
+        text: headerLines.join("\n"),
+        fontSize: 18,
+        lineHeight: 1.35,
+      },
+      rng,
+      frameId
+    )
+  )
+
+  // FRONT + BACK flats side by side, below the header.
+  const flatW = 420
+  const flatH = 560
+  const flatsY = FRAME.pad + headerLines.length * 28 + 40
+  const flats: [string, string | undefined][] = [
+    ["FRONT", input.flats.front_image_url],
+    ["BACK", input.flats.back_image_url],
+  ]
+  flats.forEach(([caption, url], i) => {
+    const flatX = originX + FRAME.pad + i * (flatW + 80)
+    if (url) {
+      const fileId = rng.id("file")
+      files[fileId] = {
+        id: fileId,
+        dataURL: url,
+        mimeType: "image/png",
+        created: 1,
+        lastRetrieved: 1,
+      }
+      elements.push(
+        makeElement(
+          {
+            type: "image",
+            x: flatX,
+            y: flatsY,
+            width: flatW,
+            height: flatH,
+            fileId,
+          },
+          rng,
+          frameId
+        )
+      )
+    } else {
+      // Placeholder rectangle when the flat hasn't been generated yet.
+      elements.push(
+        makeElement(
+          {
+            type: "rectangle",
+            x: flatX,
+            y: flatsY,
+            width: flatW,
+            height: flatH,
+            strokeColor: "#9e9e9e",
+            strokeStyle: "dashed",
+          },
+          rng,
+          frameId
+        )
+      )
+    }
+    elements.push(
+      makeElement(
+        {
+          type: "text",
+          x: flatX,
+          y: flatsY + flatH + 12,
+          width: flatW,
+          height: 24,
+          text: caption,
+          fontSize: 16,
+          textAlign: "center",
+        },
+        rng,
+        frameId
+      )
+    )
+  })
+
+  return { elements, files }
+}
+
+// ── DELEGATED (see draft task): mirror buildHeaderFlatsFrame ─────────────────────
+// buildMeasurementFrame(input, rng, originX)  — Page 2: flats + dimension callout
+//     arrows (type:"arrow") with a bound/adjacent text per sizeSet.measurements entry,
+//     via formatMeasurement(); suggested keys rendered at opacity 50.
+// buildZoomLensFrame(input, rng, originX)     — Page 3: ellipse "lens" per region with
+//     an arrow to a spec-note text (region.note).
+// buildColorwayFrame(input, rng, originX)     — Page 5: a rectangle chip per colorway
+//     (backgroundColor: hex_code) with name + thread_ref text under it.
+
+// ── Scene assembler ──────────────────────────────────────────────────────────────
+
+/**
+ * Assemble the full moodboard scene: runs each applicable frame builder left-to-right
+ * and merges their elements + files into one Excalidraw scene.
+ */
+export function buildMoodboardScene(input: TechPackSceneInput): MoodboardScene {
+  const rng = new SceneRng(input.seed ?? 1)
+  const builders: ((
+    i: TechPackSceneInput,
+    r: SceneRng,
+    x: number
+  ) => FrameResult)[] = [buildHeaderFlatsFrame]
+  // NOTE: append buildMeasurementFrame / buildZoomLensFrame / buildColorwayFrame here
+  // once implemented (guard each on the data it needs — sizeSet, regions, colorways).
+
+  const elements: ExcalidrawElement[] = []
+  let files: Record<string, ExcalidrawFile> = {}
+  builders.forEach((build, i) => {
+    const originX = i * (FRAME.width + FRAME.gap)
+    const res = build(input, rng, originX)
+    elements.push(...res.elements)
+    files = { ...files, ...res.files }
+  })
+
+  return {
+    type: "excalidraw",
+    version: 2,
+    source: "jyt:techpack-scene-builder",
+    elements,
+    appState: {
+      viewBackgroundColor: "#ffffff",
+      gridSize: null,
+      theme: "light",
+    },
+    files,
+  }
+}
+
+/**
+ * Merge freshly-built frames into an EXISTING scene without clobbering it. Required
+ * because the moodboard is a full-scene replace (no incremental append API — see
+ * `use-moodboard.ts:saveExcalidrawState`); a "regenerate one view" flow must
+ * read-merge-write. Replaces any frame (and its children) whose `name` matches an
+ * incoming frame; otherwise appends. Non-frame stray elements are preserved.
+ */
+export function mergeFramesIntoScene(
+  existing: MoodboardScene | null | undefined,
+  incoming: MoodboardScene
+): MoodboardScene {
+  if (!existing || !existing.elements?.length) return incoming
+
+  const incomingFrameNames = new Set(
+    incoming.elements.filter((e) => e.type === "frame").map((e) => e.name)
+  )
+  // Drop existing frames (and their children) that the incoming scene replaces.
+  const replacedFrameIds = new Set(
+    existing.elements
+      .filter((e) => e.type === "frame" && incomingFrameNames.has(e.name))
+      .map((e) => e.id)
+  )
+  const keptElements = existing.elements.filter(
+    (e) => !replacedFrameIds.has(e.id) && !replacedFrameIds.has(e.frameId ?? "")
+  )
+
+  return {
+    ...existing,
+    elements: [...keptElements, ...incoming.elements],
+    files: { ...existing.files, ...incoming.files },
+  }
+}

--- a/apps/docs/notes/modules/design-techpack-data-audit.md
+++ b/apps/docs/notes/modules/design-techpack-data-audit.md
@@ -1,0 +1,345 @@
+# Photo → Measured Tech-Pack Pipeline — Data & Seam Audit
+
+Code audit feeding build plan (GitHub issue #892). Every claim cites a
+`path/to/file.ts:Symbol` (or HTTP route) grounded in code actually read.
+Anything not grounded is marked `(unverified)`.
+
+---
+
+## 1. Purpose
+
+This document audits the existing data models and CV/vision seams in the JYT
+backend (Medusa 2.x, TypeScript) to determine what a "photo → measured
+tech-pack" pipeline can render as **authoritative** versus **suggested**. It
+maps which fields could hold real centimetre measurements, which vision
+endpoints already exist, and concretely what is missing.
+
+---
+
+## 2. Entry points (vision / CV seams)
+
+- `POST /admin/designs/:id/segment` — `apps/backend/src/api/admin/designs/[id]/segment/route.ts:POST`
+  — runs fal.ai BiRefNet v2 background removal; returns `{ segment: { cutout_url, mask_url } }`.
+- `POST /admin/designs/:id/segment/depth` — `apps/backend/src/api/admin/designs/[id]/segment/depth/route.ts:POST`
+  — runs fal.ai MiDaS; returns `{ depth: { depth_url, normal_url } }`.
+- `imageGenerationWorkflow` — `apps/backend/src/mastra/workflows/imagegen/index.ts:imageGenerationWorkflow`
+  — text/badge → image generation (preview/commit). Not a measurement pipeline.
+- `imageExtractionWorkflow` — `apps/backend/src/mastra/workflows/imageExtraction/index.ts:imageExtractionWorkflow`
+  — vision extraction of inventory items (name/quantity/sku), not garment measurements.
+- `designValidatorWorkflow` (design data generator) — `apps/backend/src/mastra/workflows/designValidator/index.ts:generateDesignData`
+  — LLM-generates a full design object incl. `custom_sizes` from a text prompt (no image input).
+- Moodboard save (admin UI) — `apps/backend/src/admin/hooks/use-moodboard.ts:saveExcalidrawState`
+  — writes Excalidraw scene JSON to `design.moodboard` via `updateDesign`.
+
+---
+
+## 3. Data models & links
+
+All models live under `apps/backend/src/modules/designs/models/`.
+
+### 3.1 `Design` — `apps/backend/src/modules/designs/models/design.ts:Design`
+
+Table `design`. PK `id` (`model.id().primaryKey()`).
+
+Fields relevant to this audit (full field list is larger; only measurement/
+spec/moodboard-adjacent fields enumerated, plus the moodboard field):
+
+| Field | `model.*` type | Captures |
+|---|---|---|
+| `id` | `model.id().primaryKey()` | PK |
+| `custom_sizes` | `model.json().nullable()` | Legacy free-form size specs (superseded by `size_sets` relation) |
+| `color_palette` | `model.json().nullable()` | Legacy free-form color list (superseded by `colors` relation) |
+| `moodboard` | `model.json().nullable()` | Excalidraw scene JSON (see §5) |
+| `media_files` | `model.json().nullable()` | Media asset references |
+| `design_files` | `model.json().nullable()` | URLs to design files |
+| `metadata` | `model.json().nullable()` | Free-form metadata |
+
+Relations (all `hasMany`, cascade-delete): `specifications`, `colors`,
+`size_sets`, `components`, `used_in` — `apps/backend/src/modules/designs/models/design.ts:Design`
+(lines 85–93).
+
+### 3.2 `DesignSizeSet` — `apps/backend/src/modules/designs/models/design_size_set.ts:DesignSizeSet`
+
+Table `design_size_sets`. PK `id`.
+
+| Field | `model.*` type | Captures |
+|---|---|---|
+| `id` | `model.id().primaryKey()` | PK |
+| `size_label` | `model.text()` | Size label e.g. "M", "L" |
+| `measurements` | `model.json().nullable()` | **The canonical cm/inch measurement store** — `Record<string, number>` keyed by measurement name (chest/length/…) per `apps/backend/src/workflows/designs/helpers/size-set-utils.ts:NormalizedSizeSet` |
+| `metadata` | `model.json().nullable()` | Free-form |
+| `design` | `model.belongsTo(() => Design, { mappedBy: "size_sets" })` | FK to design |
+
+### 3.3 `DesignSpecification` — `apps/backend/src/modules/designs/models/design_specification.ts:DesignSpecification`
+
+Table `design_specifications`. PK `id`.
+
+| Field | `model.*` type | Captures |
+|---|---|---|
+| `id` | `model.id().primaryKey()` | PK |
+| `title` | `model.text().translatable()` | Spec line title |
+| `category` | `model.enum(["Measurements","Materials","Construction","Finishing","Packaging","Quality","Other"])` | Spec category; `"Measurements"` exists as a bucket |
+| `details` | `model.text().translatable()` | Free-text spec body |
+| `measurements` | `model.json().nullable()` | Size-specific measurements (comment: "For storing size-specific measurements") |
+| `materials_required` | `model.json().nullable()` | List of required materials |
+| `special_instructions` | `model.text().translatable().nullable()` | Notes |
+| `attachments` | `model.json().nullable()` | URLs to spec documents |
+| `version` | `model.text()` | Spec version string |
+| `status` | `model.enum(["Draft","Under_Review","Approved","Rejected","Needs_Revision"]).default("Draft")` | Review state |
+| `reviewer_notes` | `model.text().translatable().nullable()` | Notes |
+| `metadata` | `model.json().nullable()` | Free-form |
+| `design` | `model.belongsTo(() => Design, { mappedBy: "specifications" })` | FK to design |
+
+### 3.4 `DesignColor` — `apps/backend/src/modules/designs/models/design_color.ts:DesignColor`
+
+Table `design_colors`. PK `id`.
+
+| Field | `model.*` type | Captures |
+|---|---|---|
+| `id` | `model.id().primaryKey()` | PK |
+| `name` | `model.text().translatable()` | Color name |
+| `hex_code` | `model.text()` | Hex color code |
+| `usage_notes` | `model.text().translatable().nullable()` | Notes |
+| `order` | `model.number().nullable()` | Display order |
+| `metadata` | `model.json().nullable()` | Free-form |
+| `design` | `model.belongsTo(() => Design, { mappedBy: "colors" })` | FK to design |
+
+### 3.5 `DesignComponent` — `apps/backend/src/modules/designs/models/design_component.ts:DesignComponent`
+
+Table `design_component`. PK `id`. Self-referential bundle joiner.
+
+| Field | `model.*` type | Captures |
+|---|---|---|
+| `id` | `model.id().primaryKey()` | PK |
+| `quantity` | `model.number().default(1)` | Component count |
+| `role` | `model.text().translatable().nullable()` | e.g. "embroidery", "lining", "trim", "main_fabric" |
+| `notes` | `model.text().translatable().nullable()` | Notes |
+| `order` | `model.number().default(0)` | Display order |
+| `metadata` | `model.json().nullable()` | Free-form |
+| `parent_design` | `model.belongsTo(() => Design, { mappedBy: "components" })` | Parent FK |
+| `component_design` | `model.belongsTo(() => Design, { mappedBy: "used_in" })` | Child FK |
+
+### Module links
+
+No cross-module `Module.link()` declarations were read in this audit; the
+designs module is self-contained with internal `hasMany`/`belongsTo` only
+(unverified — `apps/backend/src/modules/designs/index.ts` not read).
+
+---
+
+## 4. Key behaviours
+
+### 4.1 Which fields could hold real centimetre values?
+
+**Authoritative measurement stores (numeric, structured):**
+- `DesignSizeSet.measurements` — `apps/backend/src/modules/designs/models/design_size_set.ts:DesignSizeSet`
+  — typed downstream as `Record<string, number>` per
+  `apps/backend/src/workflows/designs/helpers/size-set-utils.ts:NormalizedSizeSet`
+  (line 6). This is the only field with a numeric-measurement contract.
+  Keys are free-form strings (e.g. `chest`, `length`, `shoulder`, `sleeve`,
+  `waist`, `hip`) as evidenced by the designValidator prompt at
+  `apps/backend/src/mastra/workflows/designValidator/index.ts:generateDesignData`
+  (lines 82–100). **No unit field exists** — unit is implicit (the validator
+  prompt asks for inches; nothing enforces cm).
+- `DesignSpecification.measurements` — `apps/backend/src/modules/designs/models/design_specification.ts:DesignSpecification`
+  — `model.json().nullable()`, comment "For storing size-specific measurements".
+  Shape is unconstrained JSON (no schema found), so it *could* hold numbers
+  but has no enforced numeric contract.
+
+**Labels / notes only (NOT measurement values):**
+- `Design.size_label`? — does not exist; `size_label` is on `DesignSizeSet` and is a text label, not a value.
+- `DesignSpecification.title`, `.details`, `.special_instructions`, `.reviewer_notes` — all `model.text()`, free text.
+- `DesignColor.*` — color metadata only, no measurements.
+- `DesignComponent.quantity`, `.order` — counts/ordering, not garment dimensions.
+- `Design.custom_sizes` — legacy JSON blob; superseded by `size_sets` but still
+  written when no structured size_sets are provided
+  (`apps/backend/src/workflows/designs/create-design.ts:createDesignStep`,
+  line 73: `custom_sizes: normalizedSizeSets ? null : input.custom_sizes`).
+
+**Conclusion:** Only `DesignSizeSet.measurements` (and loosely
+`DesignSpecification.measurements`) can carry authoritative numeric
+measurements. Everything else is label/notes. There is **no dedicated
+landmark/keypoint/drop/hem field** — those would have to live as keys inside
+the `measurements` JSON.
+
+### 4.2 Segmentation endpoint — `POST /admin/designs/:id/segment`
+
+`apps/backend/src/api/admin/designs/[id]/segment/route.ts:POST`.
+
+- Request body (`apps/backend/src/api/admin/designs/[id]/segment/validators.ts:SegmentImageSchema`):
+  `image_url?`, `image_base64?`, `model?` (enum, default `"General Use (Light)"`).
+- Calls `fal.subscribe("fal-ai/birefnet/v2", …)` with `output_mask: true`,
+  `refine_foreground: true`, `operating_resolution: "1024x1024"`.
+- **Returns:** `{ segment: { cutout_url: string, mask_url: string | null } }`
+  (lines 94–99). Reads `data.image.url` and `data.mask_image.url` from the
+  fal result.
+- **Does NOT return** `bbox`, landmarks, keypoints, or any measurement.
+
+### 4.3 Depth endpoint — `POST /admin/designs/:id/segment/depth`
+
+`apps/backend/src/api/admin/designs/[id]/segment/depth/route.ts:POST`.
+
+- Request body: `{ image_url?, image_base64? }` (read from `req.body`, no
+  zod validator file — inline typed destructure, lines 25–28).
+- Calls `fal.subscribe("fal-ai/image-preprocessors/midas", …)`.
+- **Returns:** `{ depth: { depth_url: string, normal_url: string | null } }`
+  (lines 96–101). Reads `data.depth_map.url` and `data.normal_map.url`.
+- Adds depth + normal maps vs. the segment route. Still no measurements.
+
+### 4.4 Image generation workflow — `imageGenerationWorkflow`
+
+`apps/backend/src/mastra/workflows/imagegen/index.ts:imageGenerationWorkflow`.
+
+Trigger schema (`triggerSchema`, lines 65–106) accepts:
+- `mode`: `"preview" | "commit"` (default `"preview"`)
+- `badges`: optional object (`style`, `color_family`, `body_type`,
+  `embellishment_level`, `occasion`, `budget_sensitivity`, `custom`)
+- `materials_prompt`: optional string
+- `reference_images`: optional array (max 3) of `{ url, weight?, prompt? }` —
+  **yes, reference images are accepted**
+- `canvas_snapshot`: optional `{ width, height, layers: [{ id, type, data }] }`
+  — **yes, a canvas snapshot is accepted**
+- `preview_cache_key`, `customer_id` (required), `threadId`, `resourceId`
+
+Output schema (`outputSchema`, lines 109–116): `{ image_url?, enhanced_prompt,
+style_context, quota_remaining, provider_used?, error? }`.
+
+This workflow **generates** images from text+references; it does **not**
+extract measurements or produce a tech-pack.
+
+### 4.5 Image extraction workflow — `imageExtractionWorkflow`
+
+`apps/backend/src/mastra/workflows/imageExtraction/index.ts:imageExtractionWorkflow`.
+
+Trigger (`triggerSchema`, lines 7–27): `{ image_url, entity_type
+("raw_material"|"inventory_item"), notes?, threadId?, resourceId?, run_id? }`.
+
+Output (`extractionResultSchema`, lines 39–43):
+```
+{ entity_type: string, items: Array<{ name, quantity, unit?, sku?, confidence?, metadata? }>, summary? }
+```
+(item schema at lines 30–37).
+
+This extracts **inventory item counts**, not garment measurements. There is
+no field for length/width/drop/hem in the output schema.
+
+### 4.6 Moodboard scene shape stored on `design.moodboard`
+
+`apps/backend/src/admin/hooks/use-moodboard.ts:saveExcalidrawState` (lines
+125–132) constructs and persists:
+```ts
+{
+  type: "excalidraw",
+  version: 2,
+  source: "https://excalidraw.com",
+  elements: processedElements,   // Excalidraw element array (image/text/shape)
+  appState: { viewBackgroundColor, gridSize, theme, zoom },
+  files: processedFiles          // { [fileId]: { id, dataURL, mimeType, created, lastRetrieved } }
+}
+```
+This is written via `updateDesign({ moodboard: excalidrawData })` (line 153).
+`design.moodboard` is `model.json().nullable()` —
+`apps/backend/src/modules/designs/models/design.ts:Design` (line 83).
+
+---
+
+## 5. Gotchas / invariants
+
+- **No unit enforcement.** `DesignSizeSet.measurements` is `Record<string,
+  number>` with no unit field. The designValidator prompt asks for *inches*
+  (`apps/backend/src/mastra/workflows/designValidator/index.ts:generateDesignData`,
+  line 100); nothing in the schema or model enforces cm. A photo→cm pipeline
+  must decide a unit convention or add a unit field.
+- **`custom_sizes` vs `size_sets` dual-write.** `createDesignStep` nulls
+  `custom_sizes` when structured `size_sets` are provided
+  (`apps/backend/src/workflows/designs/create-design.ts:createDesignStep`,
+  line 73), but legacy `custom_sizes` is still written otherwise. A pipeline
+  must target `size_sets`, not `custom_sizes`.
+- **Segment/depth routes are stateless image transforms.** They take an image
+  and return URLs; they do **not** persist anything to the design record
+  (`apps/backend/src/api/admin/designs/[id]/segment/route.ts:POST` makes no
+  DB call). The caller is responsible for storing results.
+- **Moodboard is a full-scene replace.** `saveExcalidrawState` writes the
+  entire Excalidraw scene as one JSON blob
+  (`apps/backend/src/admin/hooks/use-moodboard.ts:saveExcalidrawState`,
+  line 153). There is no incremental element append API; a photo-seeding
+  step would have to read-merge-write the whole scene.
+- **`imageExtraction` normalizes many key aliases** (e.g. `qty`, `count`,
+  `amount`) — `apps/backend/src/mastra/workflows/imageExtraction/index.ts:extractItems`
+  (lines 156–173) — but none map to garment dimensions.
+
+---
+
+## 6. The gap (grounded, not speculative)
+
+Based **only** on the code read above:
+
+### 6.1 No code seeds `design.moodboard` from a photo.
+
+Every write of `moodboard` passes through user-supplied Excalidraw data:
+- Admin UI: `apps/backend/src/admin/hooks/use-moodboard.ts:saveExcalidrawState`
+  (line 153) — builds scene from the live Excalidraw editor.
+- Create workflow: `apps/backend/src/workflows/designs/create-design.ts:createDesignStep`
+  (line 81) — `moodboard: input.moodboard` (passthrough only).
+- Update workflow: `apps/backend/src/workflows/designs/update-design.ts`
+  (line 37) — `moodboard?: Record<string, any>` passthrough.
+- Revise workflow: `apps/backend/src/workflows/designs/revise-design.ts`
+  (line 205) — copies `original.moodboard` verbatim.
+- Store/partner routes: `apps/backend/src/api/store/custom/designs/route.ts`
+  (line 389), `apps/backend/src/api/store/custom/designs/[id]/route.ts`
+  (line 130), `apps/backend/src/api/partners/designs/validators.ts` (line 84)
+  — all accept arbitrary `moodboard` JSON from the client.
+
+**No producer constructs a moodboard scene from an uploaded photo URL.**
+(unverified — searched all `moodboard` references via grep across
+`apps/backend/src/**/*.ts`; none transform a photo into scene elements.)
+
+### 6.2 No landmark / keypoint / measurement-extraction code.
+
+Searched `apps/backend/src/**/*.ts` for
+`keypoint|landmark|measurement_extract|measure_extract|pose_estimate|pose-estimate`.
+The only `landmark` hits are unrelated shipping-address fields
+(`apps/backend/src/modules/shipping-providers/shiprocket/client.ts:575`,
+`apps/backend/src/api/mcp/lib/registry.ts:435`). **None found (unverified —
+searched via grep for the patterns above).**
+
+### 6.3 Measurement fields with NO producer feeding them.
+
+- `DesignSizeSet.measurements` — the only producer is the
+  `designValidatorWorkflow` LLM text→JSON generator
+  (`apps/backend/src/mastra/workflows/designValidator/index.ts:generateDesignData`,
+  lines 82–100), which fabricates measurements from a text prompt with no
+  image input. No vision/CV path writes to this field.
+- `DesignSpecification.measurements` — no producer found at all in the code
+  read (unverified — no write site located; only the model definition and
+  migration were read).
+- There is no field for `drop`, `hem`, `inseam`, etc. — these would have to
+  be invented as keys inside `DesignSizeSet.measurements`.
+
+### 6.4 No "tech-pack" concept exists.
+
+Searched `apps/backend/src/**/*.ts` for `techpack|tech_pack|tech-pack|techPack`
+— **no matches**. The tech-pack is an unbuilt artifact; the closest existing
+structures are `DesignSpecification` (category `"Measurements"`) and
+`DesignSizeSet.measurements`.
+
+---
+
+## 7. Open questions / (unverified)
+
+- **Module link declarations** — `apps/backend/src/modules/designs/index.ts`
+  was not read; whether `Design` is linked to other modules (e.g. product,
+  inventory) via `Module.link()` is unverified.
+- **`DesignSpecification.measurements` write sites** — only the model + a
+  migration were read; no code path that populates this JSON field was
+  located (unverified).
+- **Depth/normal map persistence** — the depth route returns URLs but the
+  audit did not find where (if anywhere) `depth_url`/`normal_url` are stored
+  back onto a design record (unverified — no grep for `depth_url` storage
+  performed).
+- **Unit convention** — no `unit` field exists on `DesignSizeSet`; whether
+  any downstream consumer assumes cm vs inches is unverified beyond the
+  designValidator prompt asking for inches.
+- **`canvas_snapshot` consumers** — the imagegen workflow accepts
+  `canvas_snapshot` but the audit did not trace whether any caller passes a
+  moodboard-derived snapshot into it (unverified).


### PR DESCRIPTION
## #892 S1 — AI tech-pack scene-builder (pure lib)

First slice of the photo → measured tech-pack moodboard. **Pure, server-side, unit-tested** scene-builder — no routes/UI yet (that's S2).

### What's here
- `apps/backend/src/workflows/designs/moodboard/build-moodboard-scene.ts`
  - `buildMoodboardScene(input)` → full `{type:"excalidraw",version:2,elements,appState,files}` scene (the exact shape persisted on `design.moodboard`).
  - 4 frame builders — header+flats (reference), measurements, zoom-lens, colorways — each a tech-pack page as an Excalidraw frame.
  - `makeElement` deterministic factory + `SceneRng` (xorshift32; **no Date.now/Math.random** → byte-stable output).
  - `mergeFramesIntoScene` — read-merge-write, because the moodboard is a full-scene **replace** (no incremental append API).
- Fixture `__tests__/tech-pack.fixture.ts` modeled on SS26–CR–TP-08; spec `__tests__/build-moodboard-scene.unit.spec.ts` — **8/8 green** (no-orphan-frames, `fileId`→`files`, suggested-opacity, determinism, merge-replace).
- Data audit `apps/docs/notes/modules/design-techpack-data-audit.md` (GLM analysis-mode draft, Claude-verified).

### Key decisions
- **Hand-emit Excalidraw elements** — `convertToExcalidrawElements()` can't import in Node/Jest (browser JSON deps); the survey's skeleton-convert doesn't survive server-side.
- **Measurements authoritative only from `DesignSizeSet.measurements`** (`Record<string,number>`); no unit field on the model → `unit` passed explicitly; vision-`suggested` keys render dimmed.

### Known follow-ups (tracked in #892 handoff)
- Spec lives under `src/workflows/…`; repo jest `testMatch` only scans `src/modules/*` → **not in CI yet** (extend testMatch or add a re-export spec).
- Unit convention (cm vs in) to decide before S2 writes measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
