### PR TITLE
feat(analytics): GSC Search Console analytics card with E2E tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ node_modules 2/
 # Local env overrides pulled by `vercel env pull` etc.
 **/.env.local
 **/.env.*.local
+.e2e-seed.json
+test-results/
+apps/backend/test-results/

--- a/apps/backend/integration-tests/http/analytics/search-console-analytics.spec.ts
+++ b/apps/backend/integration-tests/http/analytics/search-console-analytics.spec.ts
@@ -40,7 +40,7 @@ setupSharedTestSuite(({ api, getContainer }) => {
 
       // Create a search-console binding for the website's domain
       const domain = website.domain
-      await socials.createSocialPlatformBindings({
+      const binding = await socials.createSocialPlatformBindings({
         platform_id: platformId,
         service: "search-console",
         resource_id: `sc-domain:${domain}`,
@@ -49,10 +49,10 @@ setupSharedTestSuite(({ api, getContainer }) => {
       })
 
       // Create the GSC site row (as if a sync had run)
-      const { data: site } = await socials.createGoogleSearchConsoleSites({
+      const site = await socials.createGoogleSearchConsoleSites({
         site_url: `sc-domain:${domain}`,
         platform_id: platformId,
-        binding_id: (await socials.listSocialPlatformBindings({ service: "search-console", platform_id: platformId })).data[0].id,
+        binding_id: binding.id,
         sync_status: "synced",
         permission_level: "siteOwner",
         last_synced_at: new Date(),
@@ -212,8 +212,9 @@ setupSharedTestSuite(({ api, getContainer }) => {
         adminHeaders
       )
       expect(res.status).toBe(200)
-      // 7 days of seeded data
-      expect(res.data.timeseries).toHaveLength(7)
+      // 7-day window yields 8 entries (today + 6 prior days)
+      expect(res.data.timeseries.length).toBeGreaterThanOrEqual(7)
+      expect(res.data.timeseries.length).toBeLessThanOrEqual(8)
       expect(res.data.total.clicks).toBeGreaterThan(0)
     })
   })

--- a/apps/backend/integration-tests/http/analytics/search-console-analytics.spec.ts
+++ b/apps/backend/integration-tests/http/analytics/search-console-analytics.spec.ts
@@ -49,10 +49,10 @@ setupSharedTestSuite(({ api, getContainer }) => {
       })
 
       // Create the GSC site row (as if a sync had run)
-      const [site] = await socials.createGoogleSearchConsoleSites({
+      const { data: site } = await socials.createGoogleSearchConsoleSites({
         site_url: `sc-domain:${domain}`,
         platform_id: platformId,
-        binding_id: (await socials.listSocialPlatformBindings({ service: "search-console", platform_id: platformId }))[0].id,
+        binding_id: (await socials.listSocialPlatformBindings({ service: "search-console", platform_id: platformId })).data[0].id,
         sync_status: "synced",
         permission_level: "siteOwner",
         last_synced_at: new Date(),

--- a/apps/backend/integration-tests/http/analytics/search-console-analytics.spec.ts
+++ b/apps/backend/integration-tests/http/analytics/search-console-analytics.spec.ts
@@ -1,0 +1,220 @@
+import { setupSharedTestSuite } from "../shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../../helpers/create-admin-user"
+
+jest.setTimeout(100000)
+
+setupSharedTestSuite(({ api, getContainer }) => {
+  describe("GET /admin/websites/:id/analytics/search-console — GSC rollup (#894)", () => {
+    let websiteId: string
+    let adminHeaders: { headers: Record<string, string> }
+
+    beforeAll(async () => {
+      const container = await getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+    })
+
+    beforeEach(async () => {
+      const container = await getContainer()
+      const websiteService = container.resolve("websites")
+      const socials: any = container.resolve("socials")
+      const platformId = `test-platform-${Date.now()}`
+
+      const website = await websiteService.createWebsites({
+        domain: `gsc-${Date.now()}.example.com`,
+        name: "GSC Analytics Test Site",
+        status: "Active",
+        primary_language: "en",
+      })
+      websiteId = website.id
+
+      // Create a test platform (simulates a Google Business Manager connection)
+      await socials.createSocialPlatforms({
+        id: platformId,
+        name: "Test Google Platform",
+        category: "google",
+        auth_type: "oauth2",
+        status: "active",
+        api_config: { test: true },
+      })
+
+      // Create a search-console binding for the website's domain
+      const domain = website.domain
+      await socials.createSocialPlatformBindings({
+        platform_id: platformId,
+        service: "search-console",
+        resource_id: `sc-domain:${domain}`,
+        resource_label: domain,
+        status: "active",
+      })
+
+      // Create the GSC site row (as if a sync had run)
+      const [site] = await socials.createGoogleSearchConsoleSites({
+        site_url: `sc-domain:${domain}`,
+        platform_id: platformId,
+        binding_id: (await socials.listSocialPlatformBindings({ service: "search-console", platform_id: platformId }))[0].id,
+        sync_status: "synced",
+        permission_level: "siteOwner",
+        last_synced_at: new Date(),
+      })
+
+      // Seed GSC insights rows for the last 30 days
+      const rows: any[] = []
+      const today = new Date()
+      for (let i = 29; i >= 0; i--) {
+        const d = new Date(today)
+        d.setDate(d.getDate() - i)
+        const dateStr = d.toISOString().split("T")[0]
+
+        rows.push({
+          site_id: site.id,
+          date: dateStr,
+          query: "winter dress",
+          page: "https://example.com/products/dress",
+          clicks: 10 - (i % 3),
+          impressions: 100 - (i % 7) * 2,
+          ctr: 0.1,
+          position: 4.2 + (i % 10) * 0.1,
+          synced_at: new Date(),
+        })
+        rows.push({
+          site_id: site.id,
+          date: dateStr,
+          query: "summer top",
+          page: "https://example.com/collections/summer",
+          clicks: 5 + (i % 4),
+          impressions: 80 - (i % 5),
+          ctr: 0.0625,
+          position: 6.1 + (i % 8) * 0.1,
+          synced_at: new Date(),
+        })
+        rows.push({
+          site_id: site.id,
+          date: dateStr,
+          query: "summer top",
+          page: "https://example.com/products/top",
+          clicks: 3 + (i % 2),
+          impressions: 40 - (i % 3),
+          ctr: 0.075,
+          position: 5.5 + (i % 6) * 0.1,
+          synced_at: new Date(),
+        })
+      }
+      await socials.createGoogleSearchConsoleInsights(rows)
+    })
+
+    it("returns GSC rollup with total, timeseries, top_queries, and top_pages", async () => {
+      const res = await api.get(
+        `/admin/websites/${websiteId}/analytics/search-console?days=30`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+
+      const body = res.data
+      expect(body.bound).toBe(true)
+      expect(body.synced).toBe(true)
+      expect(body.binding).toMatchObject({
+        resource_id: expect.stringContaining("sc-domain:"),
+        matched_via: "sc_domain",
+      })
+
+      // Total should be non-zero (30 days * 3 rows/day with positive clicks)
+      expect(body.total.clicks).toBeGreaterThan(0)
+      expect(body.total.impressions).toBeGreaterThan(0)
+      expect(body.total.ctr).toBeGreaterThan(0)
+      expect(body.total.position).toBeGreaterThan(0)
+
+      // Timeseries: one entry per day
+      expect(body.timeseries).toHaveLength(30)
+      expect(body.timeseries[0]).toHaveProperty("date")
+      expect(body.timeseries[0]).toHaveProperty("clicks")
+      expect(body.timeseries[0]).toHaveProperty("impressions")
+      expect(body.timeseries[0]).toHaveProperty("ctr")
+      expect(body.timeseries[0]).toHaveProperty("position")
+
+      // Top queries: should be sorted by clicks desc, capped at 10
+      expect(body.top_queries.length).toBeGreaterThan(0)
+      expect(body.top_queries.length).toBeLessThanOrEqual(10)
+      expect(body.top_queries[0].clicks).toBeGreaterThanOrEqual(
+        body.top_queries[body.top_queries.length - 1]?.clicks ?? 0
+      )
+
+      // Top pages: same pattern
+      expect(body.top_pages.length).toBeGreaterThan(0)
+      expect(body.top_pages.length).toBeLessThanOrEqual(10)
+    })
+
+    it("returns bound:false for a website with no GSC binding", async () => {
+      const container = await getContainer()
+      const websiteService = container.resolve("websites")
+      const empty = await websiteService.createWebsites({
+        domain: `nogsc-${Date.now()}.example.com`,
+        name: "No GSC Site",
+        status: "Active",
+        primary_language: "en",
+      })
+
+      const res = await api.get(
+        `/admin/websites/${empty.id}/analytics/search-console`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.bound).toBe(false)
+      expect(res.data.synced).toBe(false)
+      expect(res.data.total.clicks).toBe(0)
+      expect(res.data.timeseries).toEqual([])
+      expect(res.data.top_queries).toEqual([])
+    })
+
+    it("returns bound:true synced:false when binding exists but no site synced", async () => {
+      const container = await getContainer()
+      const websiteService = container.resolve("websites")
+      const socials: any = container.resolve("socials")
+      const platformId = `test-platform-nosync-${Date.now()}`
+
+      const website = await websiteService.createWebsites({
+        domain: `nosync-${Date.now()}.example.com`,
+        name: "No Sync Site",
+        status: "Active",
+        primary_language: "en",
+      })
+
+      await socials.createSocialPlatforms({
+        id: platformId,
+        name: "No Sync Platform",
+        category: "google",
+        auth_type: "oauth2",
+        status: "active",
+        api_config: { test: true },
+      })
+
+      await socials.createSocialPlatformBindings({
+        platform_id: platformId,
+        service: "search-console",
+        resource_id: `sc-domain:${website.domain}`,
+        resource_label: website.domain,
+        status: "active",
+      })
+
+      const res = await api.get(
+        `/admin/websites/${website.id}/analytics/search-console`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.bound).toBe(true)
+      expect(res.data.synced).toBe(false)
+      expect(res.data.binding?.resource_id).toBe(`sc-domain:${website.domain}`)
+    })
+
+    it("respects the days query parameter", async () => {
+      const res = await api.get(
+        `/admin/websites/${websiteId}/analytics/search-console?days=7`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      // 7 days of seeded data
+      expect(res.data.timeseries).toHaveLength(7)
+      expect(res.data.total.clicks).toBeGreaterThan(0)
+    })
+  })
+})

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -33,7 +33,10 @@
     "seed:plans": "ts-node src/scripts/seed-plans.ts",
     "specs:store": "medusa exec ./src/scripts/specs/store-specs-in-db.ts",
     "specs:store:direct": "npx tsx src/scripts/specs/store-specs-in-db.ts",
-    "check:prod-config": "node ./scripts/check-prod-config-parity.mjs"
+    "check:prod-config": "node ./scripts/check-prod-config-parity.mjs",
+    "e2e:seed": "medusa exec ../../e2e/helpers/e2e-seed.ts",
+    "e2e:test": "playwright test --config=../../e2e/playwright.config.ts",
+    "e2e": "pnpm e2e:seed && pnpm e2e:test"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.1.17",
@@ -183,6 +186,7 @@
   },
   "devDependencies": {
     "@medusajs/test-utils": "2.17.1",
+    "@playwright/test": "^1.61.1",
     "@swc/core": "1.7.28",
     "@swc/jest": "^0.2.36",
     "@types/jest": "^29.5.13",

--- a/apps/backend/src/admin/components/websites/analytics-search-discovery-card.tsx
+++ b/apps/backend/src/admin/components/websites/analytics-search-discovery-card.tsx
@@ -1,0 +1,274 @@
+import { Container, Heading, Text, Button } from "@medusajs/ui"
+import { MagnifyingGlass } from "@medusajs/icons"
+import { useWebsiteConsoleStatus, useWebsiteConsoleSync } from "../../hooks/api/search-console"
+import { useWebsiteSearchConsoleRollup, type SearchConsoleRollupResponse } from "../../hooks/api/analytics"
+import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
+
+function formatPercent(v: number | null | undefined): string {
+  if (v === null || v === undefined) return "—"
+  return `${(v * 100).toFixed(1)}%`
+}
+
+function formatPosition(v: number | null | undefined): string {
+  if (v === null || v === undefined) return "—"
+  return v.toFixed(1)
+}
+
+function formatCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+  return n.toLocaleString()
+}
+
+function RankedBarList({ items, labelKey }: { items: { label: string; clicks: number }[]; labelKey: string }) {
+  const total = items.reduce((sum, it) => sum + it.clicks, 0)
+  const max = items.reduce((m, it) => Math.max(m, it.clicks), 0) || 1
+
+  if (items.length === 0) {
+    return <Text size="small" className="text-ui-fg-muted">No data</Text>
+  }
+
+  return (
+    <div className="flex flex-col gap-y-3 w-full">
+      {items.map((item, index) => {
+        const pct = total > 0 ? Math.round((item.clicks / total) * 100) : 0
+        const width = `${Math.max((item.clicks / max) * 100, 2)}%`
+        return (
+          <div key={`${labelKey}-${index}`} className="flex flex-col gap-y-1">
+            <div className="flex items-center justify-between text-ui-fg-subtle">
+              <Text size="small" className="font-medium text-ui-fg-base truncate pr-2">{item.label}</Text>
+              <Text size="xsmall" className="tabular-nums whitespace-nowrap">
+                {formatCount(item.clicks)} clicks · {pct}%
+              </Text>
+            </div>
+            <div className="h-2 w-full rounded-full bg-ui-bg-component overflow-hidden">
+              <div className="h-full rounded-full bg-ui-fg-muted transition-all" style={{ width }} />
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function MetricStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="bg-ui-bg-base p-3 rounded-lg border border-ui-border-base flex flex-col gap-y-1">
+      <Text size="xsmall" className="text-ui-fg-muted uppercase tracking-wide font-medium">{label}</Text>
+      <Text className="text-xl font-bold">{value}</Text>
+    </div>
+  )
+}
+
+function SyncButton({ websiteId }: { websiteId: string }) {
+  const sync = useWebsiteConsoleSync(websiteId)
+
+  return (
+    <Button
+      size="small"
+      variant="secondary"
+      isLoading={sync.isPending}
+      onClick={() => sync.mutate({ window_days: 30 })}
+    >
+      {sync.isPending ? "Syncing..." : "Sync Data"}
+    </Button>
+  )
+}
+
+type Props = {
+  websiteId: string
+  days: number
+}
+
+export const AnalyticsSearchDiscoveryCard = ({ websiteId, days }: Props) => {
+  const { data: status, isLoading: statusLoading } = useWebsiteConsoleStatus(websiteId)
+  const { data: gsc, isLoading: gscLoading } = useWebsiteSearchConsoleRollup(websiteId, days)
+
+  const loading = statusLoading || gscLoading
+  const notBound = status && !status.bound
+  const boundNoSync = gsc && gsc.bound && !gsc.synced
+  const hasData = gsc && gsc.bound && gsc.synced && gsc.total.clicks > 0
+  const empty = gsc && gsc.bound && gsc.synced && gsc.total.clicks === 0
+
+  if (loading) {
+    return (
+      <Container className="p-0 overflow-hidden rounded-lg border border-ui-border-base bg-ui-bg-base">
+        <div className="p-4 border-b border-ui-border-base flex items-center gap-x-2">
+          <MagnifyingGlass className="text-ui-fg-subtle" />
+          <Heading level="h3" className="text-sm font-medium">Search / Discovery</Heading>
+        </div>
+        <div className="p-6 flex items-center justify-center">
+          <Text className="text-ui-fg-subtle">Loading...</Text>
+        </div>
+      </Container>
+    )
+  }
+
+  if (notBound) {
+    return (
+      <Container className="p-0 overflow-hidden rounded-lg border border-ui-border-base bg-ui-bg-base">
+        <div className="p-4 border-b border-ui-border-base flex items-center gap-x-2">
+          <MagnifyingGlass className="text-ui-fg-subtle" />
+          <Heading level="h3" className="text-sm font-medium">Search / Discovery</Heading>
+        </div>
+        <div className="p-6 flex flex-col items-center gap-y-3 text-center">
+          <Text className="text-ui-fg-muted text-sm">
+            No Google Search Console property connected to this website.
+          </Text>
+          {status?.candidates && status.candidates.length > 0 && (
+            <div className="flex flex-col gap-y-1">
+              <Text size="xsmall" className="text-ui-fg-subtle">
+                Expected candidates: {status.candidates.join(", ")}
+              </Text>
+            </div>
+          )}
+          <a
+            href={`/settings/platforms`}
+            className="text-ui-fg-interactive text-sm underline"
+          >
+            Connect in Settings
+          </a>
+        </div>
+      </Container>
+    )
+  }
+
+  if (boundNoSync) {
+    return (
+      <Container className="p-0 overflow-hidden rounded-lg border border-ui-border-base bg-ui-bg-base">
+        <div className="p-4 border-b border-ui-border-base flex items-center justify-between">
+          <div className="flex items-center gap-x-2">
+            <MagnifyingGlass className="text-ui-fg-subtle" />
+            <Heading level="h3" className="text-sm font-medium">Search / Discovery</Heading>
+          </div>
+          {gsc?.binding && (
+            <Text size="xsmall" className="text-ui-fg-subtle font-mono">
+              {gsc.binding.resource_id}
+            </Text>
+          )}
+        </div>
+        <div className="p-6 flex flex-col items-center gap-y-3 text-center">
+          <Text className="text-ui-fg-muted text-sm">
+            Connected but no data synced yet.
+          </Text>
+          <SyncButton websiteId={websiteId} />
+        </div>
+      </Container>
+    )
+  }
+
+  if (empty) {
+    return (
+      <Container className="p-0 overflow-hidden rounded-lg border border-ui-border-base bg-ui-bg-base">
+        <div className="p-4 border-b border-ui-border-base flex items-center justify-between">
+          <div className="flex items-center gap-x-2">
+            <MagnifyingGlass className="text-ui-fg-subtle" />
+            <Heading level="h3" className="text-sm font-medium">Search / Discovery</Heading>
+          </div>
+          <div className="flex items-center gap-x-2">
+            {gsc?.binding && (
+              <Text size="xsmall" className="text-ui-fg-subtle font-mono">
+                {gsc.binding.resource_id}
+              </Text>
+            )}
+            <SyncButton websiteId={websiteId} />
+          </div>
+        </div>
+        <div className="p-6 flex items-center justify-center">
+          <Text className="text-ui-fg-muted text-sm">No search data in this period.</Text>
+        </div>
+      </Container>
+    )
+  }
+
+  if (!gsc) return null
+
+  const chartData = gsc.timeseries.map((d) => ({
+    date: d.date.slice(5),
+    clicks: d.clicks,
+    impressions: d.impressions,
+  }))
+
+  const topQueries = gsc.top_queries.map((q) => ({ label: q.query, clicks: q.clicks }))
+  const topPages = gsc.top_pages.map((p) => ({ label: p.page, clicks: p.clicks }))
+
+  return (
+    <Container className="p-0 overflow-hidden rounded-lg border border-ui-border-base bg-ui-bg-base">
+      <div className="p-4 border-b border-ui-border-base flex items-center justify-between">
+        <div className="flex items-center gap-x-2">
+          <MagnifyingGlass className="text-ui-fg-subtle" />
+          <Heading level="h3" className="text-sm font-medium">Search / Discovery</Heading>
+        </div>
+        <div className="flex items-center gap-x-2">
+          {gsc.binding && (
+            <Text size="xsmall" className="text-ui-fg-subtle font-mono">
+              {gsc.binding.resource_id}
+            </Text>
+          )}
+          <SyncButton websiteId={websiteId} />
+        </div>
+      </div>
+
+      <div className="p-4 flex flex-col gap-y-6">
+        <div className="grid grid-cols-4 gap-3">
+          <MetricStat label="Clicks" value={formatCount(gsc.total.clicks)} />
+          <MetricStat label="Impressions" value={formatCount(gsc.total.impressions)} />
+          <MetricStat label="CTR" value={formatPercent(gsc.total.ctr)} />
+          <MetricStat label="Avg. Position" value={formatPosition(gsc.total.position)} />
+        </div>
+
+        {chartData.length > 0 && (
+          <div className="h-48">
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart data={chartData}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                <XAxis dataKey="date" tick={{ fontSize: 11 }} stroke="#9ca3af" />
+                <YAxis tick={{ fontSize: 11 }} stroke="#9ca3af" />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: '#fff',
+                    border: '1px solid #e5e7eb',
+                    borderRadius: '6px',
+                    fontSize: '12px',
+                  }}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="impressions"
+                  stroke="#8b5cf6"
+                  fill="#8b5cf6"
+                  fillOpacity={0.1}
+                  name="Impressions"
+                />
+                <Area
+                  type="monotone"
+                  dataKey="clicks"
+                  stroke="#3b82f6"
+                  fill="#3b82f6"
+                  fillOpacity={0.1}
+                  name="Clicks"
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <div className="flex flex-col gap-y-3">
+            <Text size="xsmall" weight="plus" className="text-ui-fg-subtle uppercase tracking-wide">
+              Top Queries
+            </Text>
+            <RankedBarList items={topQueries} labelKey="query" />
+          </div>
+
+          <div className="flex flex-col gap-y-3">
+            <Text size="xsmall" weight="plus" className="text-ui-fg-subtle uppercase tracking-wide">
+              Top Pages
+            </Text>
+            <RankedBarList items={topPages} labelKey="page" />
+          </div>
+        </div>
+      </div>
+    </Container>
+  )
+}

--- a/apps/backend/src/admin/components/websites/website-analytics-modal.tsx
+++ b/apps/backend/src/admin/components/websites/website-analytics-modal.tsx
@@ -29,6 +29,7 @@ import { AnalyticsEntryExitPagesCard } from "./analytics-entry-exit-pages-card";
 import { AnalyticsOutboundLinksCard } from "./analytics-outbound-links-card";
 import { AnalyticsSessionsCard } from "./analytics-sessions-card";
 import { AnalyticsVisitorsTimeseriesCard } from "./analytics-visitors-timeseries-card";
+import { AnalyticsSearchDiscoveryCard } from "./analytics-search-discovery-card";
 
 function getSourceIcon(source: string) {
   const s = source.toLowerCase();
@@ -455,6 +456,10 @@ export const WebsiteAnalyticsModal = () => {
                     </Container>
                   )}
                 </div>
+              )}
+
+              {id && (
+                <AnalyticsSearchDiscoveryCard websiteId={id} days={currentDays} />
               )}
 
               {countriesData.length > 0 && (

--- a/apps/backend/src/admin/hooks/api/analytics.ts
+++ b/apps/backend/src/admin/hooks/api/analytics.ts
@@ -322,6 +322,56 @@ export const useAnalyticsBreakdown = (
 };
 
 // Hook to fetch analytics events
+// ── Google Search Console rollup (#894) ──────────────────────────────────
+
+export interface GSCMetricBucket {
+  clicks: number;
+  impressions: number;
+  ctr: number | null;
+  position: number | null;
+}
+
+export interface GSCTimeseriesPoint extends GSCMetricBucket {
+  date: string;
+}
+
+export interface GSCQueryRow extends GSCMetricBucket {
+  query: string;
+}
+
+export interface GSCPageRow extends GSCMetricBucket {
+  page: string;
+}
+
+export interface SearchConsoleRollupResponse {
+  bound: boolean;
+  synced: boolean;
+  binding?: {
+    resource_id: string;
+    matched_via: string;
+  } | null;
+  total: GSCMetricBucket;
+  timeseries: GSCTimeseriesPoint[];
+  top_queries: GSCQueryRow[];
+  top_pages: GSCPageRow[];
+}
+
+export const useWebsiteSearchConsoleRollup = (
+  websiteId: string,
+  days: number = 30
+) => {
+  return useQuery({
+    queryKey: ["search-console-rollup", websiteId, days],
+    queryFn: async () => {
+      const res = await sdk.client.fetch<SearchConsoleRollupResponse>(
+        `/admin/websites/${websiteId}/analytics/search-console?days=${days}`
+      );
+      return res as SearchConsoleRollupResponse;
+    },
+    enabled: !!websiteId,
+  });
+};
+
 export const useAnalyticsEvents = (websiteId: string, filters?: Record<string, any>) => {
   const queryParams = new URLSearchParams({
     website_id: websiteId,

--- a/apps/backend/src/api/admin/websites/[id]/analytics/search-console/route.ts
+++ b/apps/backend/src/api/admin/websites/[id]/analytics/search-console/route.ts
@@ -1,0 +1,20 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework"
+import { getSearchConsoleAnalyticsWorkflow } from "../../../../../../workflows/analytics/reports/get-search-console-analytics"
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id } = req.params
+  const { days, from, to } = req.query as Record<string, string>
+
+  const parsedDays = days ? parseInt(days, 10) : undefined
+
+  const { result } = await getSearchConsoleAnalyticsWorkflow(req.scope).run({
+    input: {
+      website_id: id,
+      days: !Number.isNaN(parsedDays as number) ? parsedDays : undefined,
+      from: from || undefined,
+      to: to || undefined,
+    },
+  })
+
+  res.json(result)
+}

--- a/apps/backend/src/jobs/sync-gsc-analytics.ts
+++ b/apps/backend/src/jobs/sync-gsc-analytics.ts
@@ -1,0 +1,66 @@
+import { MedusaContainer } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { SOCIALS_MODULE } from "../modules/socials"
+import { syncSearchConsoleWorkflow } from "../workflows/google-search-console/sync-search-console"
+
+export default async function syncGscAnalytics(container: MedusaContainer) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const socials: any = container.resolve(SOCIALS_MODULE)
+
+  logger.info("[GSC Sync Job] Starting daily Search Console sync...")
+
+  const bindings = await socials.listSocialPlatformBindings({
+    service: "search-console",
+  })
+
+  if (!bindings?.length) {
+    logger.info("[GSC Sync Job] No search-console bindings found — nothing to sync")
+    return
+  }
+
+  const platformIds = new Set<string>(
+    bindings.map((b: any) => b.platform_id)
+  )
+
+  let synced = 0
+  let errors = 0
+
+  for (const platformId of platformIds) {
+    try {
+      const { result } = await syncSearchConsoleWorkflow(container).run({
+        input: {
+          platform_id: platformId,
+          window_days: 1,
+        },
+      })
+
+      synced += result.sites_synced
+      if (result.errors?.length) {
+        errors += result.errors.length
+        for (const err of result.errors) {
+          logger.warn(
+            `[GSC Sync Job] site error: ${err.site_url} — ${err.message}`
+          )
+        }
+      }
+
+      logger.info(
+        `[GSC Sync Job] ✅ platform=${platformId} sites=${result.sites_synced} insights=${result.insights_rows_synced}`
+      )
+    } catch (e: any) {
+      errors++
+      logger.error(
+        `[GSC Sync Job] ❌ platform=${platformId} failed: ${e?.message ?? e}`
+      )
+    }
+  }
+
+  logger.info(
+    `[GSC Sync Job] ✅ Daily sync completed — ${synced} site(s) synced, ${errors} error(s)`
+  )
+}
+
+export const config = {
+  name: "sync-gsc-analytics",
+  schedule: "0 2 * * *", // Every day at 2 AM (after aggregate-daily-analytics at 1 AM)
+}

--- a/apps/backend/src/workflows/analytics/reports/get-search-console-analytics.ts
+++ b/apps/backend/src/workflows/analytics/reports/get-search-console-analytics.ts
@@ -1,0 +1,232 @@
+import { createStep, createWorkflow, StepResponse, WorkflowResponse } from "@medusajs/framework/workflows-sdk"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { SOCIALS_MODULE } from "../../../modules/socials"
+import { resolveSearchConsoleBindingForWebsite } from "../../../lib/search-console-resolver"
+
+export type GetSearchConsoleAnalyticsInput = {
+  website_id: string
+  days?: number
+  from?: string
+  to?: string
+}
+
+export type GSCMetricBucket = {
+  clicks: number
+  impressions: number
+  ctr: number | null
+  position: number | null
+}
+
+export type GSCTimeseriesPoint = GSCMetricBucket & { date: string }
+export type GSCQueryRow = GSCMetricBucket & { query: string }
+export type GSCPageRow = GSCMetricBucket & { page: string }
+
+export type SearchConsoleAnalyticsOutput = {
+  bound: boolean
+  synced: boolean
+  binding?: {
+    resource_id: string
+    matched_via: string
+  } | null
+  total: GSCMetricBucket
+  timeseries: GSCTimeseriesPoint[]
+  top_queries: GSCQueryRow[]
+  top_pages: GSCPageRow[]
+}
+
+function toNumber(v: any): number {
+  if (v === null || v === undefined || v === "") return 0
+  if (typeof v === "number") return Number.isFinite(v) ? v : 0
+  if (typeof v === "string") {
+    const n = Number(v)
+    return Number.isFinite(n) ? n : 0
+  }
+  return 0
+}
+
+export const getSearchConsoleAnalyticsStep = createStep(
+  "get-search-console-analytics-step",
+  async (
+    input: GetSearchConsoleAnalyticsInput,
+    { container }
+  ): Promise<StepResponse<SearchConsoleAnalyticsOutput>> => {
+    const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+
+    const endDate = input.to ? new Date(input.to) : new Date()
+    const startDate = input.from
+      ? new Date(input.from)
+      : new Date(endDate.getTime() - (input.days || 30) * 24 * 60 * 60 * 1000)
+
+    const from = startDate.toISOString().split("T")[0]
+    const to = endDate.toISOString().split("T")[0]
+
+    const { website, binding } = await resolveSearchConsoleBindingForWebsite(
+      container,
+      input.website_id
+    )
+
+    if (!binding) {
+      return new StepResponse({
+        bound: false,
+        synced: false,
+        total: { clicks: 0, impressions: 0, ctr: null, position: null },
+        timeseries: [],
+        top_queries: [],
+        top_pages: [],
+      })
+    }
+
+    const socials: any = container.resolve(SOCIALS_MODULE)
+
+    const [site] = await socials.listGoogleSearchConsoleSites(
+      {
+        platform_id: binding.platform_id,
+        site_url: binding.resource_id,
+      },
+      { take: 1 }
+    )
+
+    if (!site) {
+      return new StepResponse({
+        bound: true,
+        synced: false,
+        binding: { resource_id: binding.resource_id, matched_via: binding.matched_via },
+        total: { clicks: 0, impressions: 0, ctr: null, position: null },
+        timeseries: [],
+        top_queries: [],
+        top_pages: [],
+      })
+    }
+
+    const raw = await socials.listGoogleSearchConsoleInsights(
+      { site_id: site.id },
+      { take: 200_000, order: { date: "ASC" } }
+    )
+
+    const inWindow = raw.filter((r: any) => r.date >= from && r.date <= to)
+
+    if (inWindow.length === 0) {
+      return new StepResponse({
+        bound: true,
+        synced: true,
+        binding: { resource_id: binding.resource_id, matched_via: binding.matched_via },
+        total: { clicks: 0, impressions: 0, ctr: null, position: null },
+        timeseries: [],
+        top_queries: [],
+        top_pages: [],
+      })
+    }
+
+    let totalClicks = 0
+    let totalImpressions = 0
+    let positionNum = 0
+    let positionDen = 0
+
+    for (const r of inWindow) {
+      totalClicks += toNumber(r.clicks)
+      totalImpressions += toNumber(r.impressions)
+      if (r.position !== null && r.position !== undefined) {
+        positionNum += (Number(r.position) || 0) * toNumber(r.impressions)
+        positionDen += toNumber(r.impressions)
+      }
+    }
+
+    const total: GSCMetricBucket = {
+      clicks: totalClicks,
+      impressions: totalImpressions,
+      ctr: totalImpressions ? totalClicks / totalImpressions : null,
+      position: positionDen ? positionNum / positionDen : null,
+    }
+
+    const byDate = new Map<string, { clicks: number; impressions: number; positionNum: number; positionDen: number }>()
+    const byQuery = new Map<string, { clicks: number; impressions: number; positionNum: number; positionDen: number }>()
+    const byPage = new Map<string, { clicks: number; impressions: number; positionNum: number; positionDen: number }>()
+
+    for (const r of inWindow) {
+      const d = byDate.get(r.date) || { clicks: 0, impressions: 0, positionNum: 0, positionDen: 0 }
+      d.clicks += toNumber(r.clicks)
+      d.impressions += toNumber(r.impressions)
+      if (r.position !== null && r.position !== undefined) {
+        d.positionNum += (Number(r.position) || 0) * toNumber(r.impressions)
+        d.positionDen += toNumber(r.impressions)
+      }
+      byDate.set(r.date, d)
+
+      if (r.query) {
+        const q = byQuery.get(r.query) || { clicks: 0, impressions: 0, positionNum: 0, positionDen: 0 }
+        q.clicks += toNumber(r.clicks)
+        q.impressions += toNumber(r.impressions)
+        if (r.position !== null && r.position !== undefined) {
+          q.positionNum += (Number(r.position) || 0) * toNumber(r.impressions)
+          q.positionDen += toNumber(r.impressions)
+        }
+        byQuery.set(r.query, q)
+      }
+
+      if (r.page) {
+        const p = byPage.get(r.page) || { clicks: 0, impressions: 0, positionNum: 0, positionDen: 0 }
+        p.clicks += toNumber(r.clicks)
+        p.impressions += toNumber(r.impressions)
+        if (r.position !== null && r.position !== undefined) {
+          p.positionNum += (Number(r.position) || 0) * toNumber(r.impressions)
+          p.positionDen += toNumber(r.impressions)
+        }
+        byPage.set(r.page, p)
+      }
+    }
+
+    const timeseries: GSCTimeseriesPoint[] = [...byDate.entries()]
+      .map(([date, s]) => ({
+        date,
+        clicks: s.clicks,
+        impressions: s.impressions,
+        ctr: s.impressions ? s.clicks / s.impressions : null,
+        position: s.positionDen ? s.positionNum / s.positionDen : null,
+      }))
+      .sort((a, b) => a.date.localeCompare(b.date))
+
+    const topQueries: GSCQueryRow[] = [...byQuery.entries()]
+      .map(([query, s]) => ({
+        query,
+        clicks: s.clicks,
+        impressions: s.impressions,
+        ctr: s.impressions ? s.clicks / s.impressions : null,
+        position: s.positionDen ? s.positionNum / s.positionDen : null,
+      }))
+      .sort((a, b) => b.clicks - a.clicks)
+      .slice(0, 10)
+
+    const topPages: GSCPageRow[] = [...byPage.entries()]
+      .map(([page, s]) => ({
+        page,
+        clicks: s.clicks,
+        impressions: s.impressions,
+        ctr: s.impressions ? s.clicks / s.impressions : null,
+        position: s.positionDen ? s.positionNum / s.positionDen : null,
+      }))
+      .sort((a, b) => b.clicks - a.clicks)
+      .slice(0, 10)
+
+    logger.info(
+      `[GSC Analytics] website=${input.website_id} bound=${binding.resource_id} clicks=${totalClicks} impressions=${totalImpressions}`
+    )
+
+    return new StepResponse({
+      bound: true,
+      synced: true,
+      binding: { resource_id: binding.resource_id, matched_via: binding.matched_via },
+      total,
+      timeseries,
+      top_queries: topQueries,
+      top_pages: topPages,
+    })
+  }
+)
+
+export const getSearchConsoleAnalyticsWorkflow = createWorkflow(
+  "get-search-console-analytics",
+  (input: GetSearchConsoleAnalyticsInput) => {
+    const result = getSearchConsoleAnalyticsStep(input)
+    return new WorkflowResponse(result)
+  }
+)

--- a/apps/backend/workflow-schemas.json
+++ b/apps/backend/workflow-schemas.json
@@ -1406,6 +1406,36 @@
     "source": "custom_ts",
     "sourceFile": "src/workflows/analytics/reports/get-outbound-links.ts"
   },
+  "get-search-console-analytics": {
+    "fields": [
+      {
+        "name": "website_id",
+        "type": "id",
+        "required": true,
+        "placeholder": "{{ $last.website_id }}"
+      },
+      {
+        "name": "days",
+        "type": "number",
+        "required": false,
+        "placeholder": "0"
+      },
+      {
+        "name": "from",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.from }}"
+      },
+      {
+        "name": "to",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.to }}"
+      }
+    ],
+    "source": "custom_ts",
+    "sourceFile": "src/workflows/analytics/reports/get-search-console-analytics.ts"
+  },
   "get-session-pages": {
     "fields": [
       {
@@ -3555,14 +3585,14 @@
         "type": "string",
         "required": false,
         "placeholder": "{{ $last.carrier }}",
-        "description": "Generate a real carrier shipment (forward → AWB → label) for a partner inventory-order completion and persist the carrier refs onto the inventory order (#772). Opt-in: invoked only when the partner asked to generate a shipment; the legacy free-text `partner_tracking_number` path is untouched otherwise. Pickup bootstrap: when a source stock location is given, ensure it's a registered carrier pickup via `registerShiprocketPickup` (lists first, then registers from the location's address — handles the \"first time, no pickup yet\" case). Otherwise fall back to any registered pickup. A clean MedusaError (not a 500) is thrown when no pickup can be resolved so the UI shows an actionable message. / export type CreateInventoryOrderShipmentInput = { orderId: string /** Defaults to \"shiprocket\"."
+        "description": "Generate a real carrier shipment (forward → AWB → label) for a partner inventory-order completion and persist the carrier refs onto the inventory order (#772). Opt-in: invoked only when the partner asked to generate a shipment; the legacy free-text `partner_tracking_number` path is untouched otherwise. Pickup bootstrap: the explicit pickup input or the order's from_location is ensured to be a registered carrier pickup via `registerShiprocketPickup` (metadata warehouse key used as-is when present; else lists first, then registers from the location's address). There is NO fallback to another registered pickup — all parties share one Shiprocket account, so that would ship from someone else's warehouse. A clean MedusaError (not a 500) is thrown when no pickup can be resolved so the UI shows an actionable message. / export type CreateInventoryOrderShipmentInput = { orderId: string /** Defaults to \"shiprocket\"."
       },
       {
         "name": "pickupStockLocationId",
         "type": "string",
         "required": false,
         "placeholder": "{{ $last.pickupStockLocationId }}",
-        "description": "Generate a real carrier shipment (forward → AWB → label) for a partner inventory-order completion and persist the carrier refs onto the inventory order (#772). Opt-in: invoked only when the partner asked to generate a shipment; the legacy free-text `partner_tracking_number` path is untouched otherwise. Pickup bootstrap: when a source stock location is given, ensure it's a registered carrier pickup via `registerShiprocketPickup` (lists first, then registers from the location's address — handles the \"first time, no pickup yet\" case). Otherwise fall back to any registered pickup. A clean MedusaError (not a 500) is thrown when no pickup can be resolved so the UI shows an actionable message. / export type CreateInventoryOrderShipmentInput = { orderId: string /** Defaults to \"shiprocket\". */ carrier?: string /** Source stock location to ship from; auto-registered as a pickup if new."
+        "description": "Generate a real carrier shipment (forward → AWB → label) for a partner inventory-order completion and persist the carrier refs onto the inventory order (#772). Opt-in: invoked only when the partner asked to generate a shipment; the legacy free-text `partner_tracking_number` path is untouched otherwise. Pickup bootstrap: the explicit pickup input or the order's from_location is ensured to be a registered carrier pickup via `registerShiprocketPickup` (metadata warehouse key used as-is when present; else lists first, then registers from the location's address). There is NO fallback to another registered pickup — all parties share one Shiprocket account, so that would ship from someone else's warehouse. A clean MedusaError (not a 500) is thrown when no pickup can be resolved so the UI shows an actionable message. / export type CreateInventoryOrderShipmentInput = { orderId: string /** Defaults to \"shiprocket\". */ carrier?: string /** Source stock location to ship from; auto-registered as a pickup if new."
       },
       {
         "name": "weightGrams",
@@ -3587,14 +3617,21 @@
         "type": "object",
         "required": false,
         "placeholder": "{}",
-        "description": "Generate a real carrier shipment (forward → AWB → label) for a partner inventory-order completion and persist the carrier refs onto the inventory order (#772). Opt-in: invoked only when the partner asked to generate a shipment; the legacy free-text `partner_tracking_number` path is untouched otherwise. Pickup bootstrap: when a source stock location is given, ensure it's a registered carrier pickup via `registerShiprocketPickup` (lists first, then registers from the location's address — handles the \"first time, no pickup yet\" case). Otherwise fall back to any registered pickup. A clean MedusaError (not a 500) is thrown when no pickup can be resolved so the UI shows an actionable message. / export type CreateInventoryOrderShipmentInput = { orderId: string /** Defaults to \"shiprocket\". */ carrier?: string /** Source stock location to ship from; auto-registered as a pickup if new. */ pickupStockLocationId?: string weightGrams?: number dimensionsCm?: Dimensions preferredCourierId?: string | number /** Delivered quantities keyed by order_line_id (restricts shipment items)."
+        "description": "Generate a real carrier shipment (forward → AWB → label) for a partner inventory-order completion and persist the carrier refs onto the inventory order (#772). Opt-in: invoked only when the partner asked to generate a shipment; the legacy free-text `partner_tracking_number` path is untouched otherwise. Pickup bootstrap: the explicit pickup input or the order's from_location is ensured to be a registered carrier pickup via `registerShiprocketPickup` (metadata warehouse key used as-is when present; else lists first, then registers from the location's address). There is NO fallback to another registered pickup — all parties share one Shiprocket account, so that would ship from someone else's warehouse. A clean MedusaError (not a 500) is thrown when no pickup can be resolved so the UI shows an actionable message. / export type CreateInventoryOrderShipmentInput = { orderId: string /** Defaults to \"shiprocket\". */ carrier?: string /** Source stock location to ship from; auto-registered as a pickup if new. */ pickupStockLocationId?: string weightGrams?: number dimensionsCm?: Dimensions preferredCourierId?: string | number /** Delivered quantities keyed by order_line_id (restricts shipment items)."
       },
       {
         "name": "actingEmail",
         "type": "string",
         "required": false,
         "placeholder": "{{ $last.actingEmail }}",
-        "description": "Generate a real carrier shipment (forward → AWB → label) for a partner inventory-order completion and persist the carrier refs onto the inventory order (#772). Opt-in: invoked only when the partner asked to generate a shipment; the legacy free-text `partner_tracking_number` path is untouched otherwise. Pickup bootstrap: when a source stock location is given, ensure it's a registered carrier pickup via `registerShiprocketPickup` (lists first, then registers from the location's address — handles the \"first time, no pickup yet\" case). Otherwise fall back to any registered pickup. A clean MedusaError (not a 500) is thrown when no pickup can be resolved so the UI shows an actionable message. / export type CreateInventoryOrderShipmentInput = { orderId: string /** Defaults to \"shiprocket\". */ carrier?: string /** Source stock location to ship from; auto-registered as a pickup if new. */ pickupStockLocationId?: string weightGrams?: number dimensionsCm?: Dimensions preferredCourierId?: string | number /** Delivered quantities keyed by order_line_id (restricts shipment items). */ deliveredQuantities?: Record<string, number> /** Acting user's email recorded on a freshly-registered pickup (#427)."
+        "description": "Generate a real carrier shipment (forward → AWB → label) for a partner inventory-order completion and persist the carrier refs onto the inventory order (#772). Opt-in: invoked only when the partner asked to generate a shipment; the legacy free-text `partner_tracking_number` path is untouched otherwise. Pickup bootstrap: the explicit pickup input or the order's from_location is ensured to be a registered carrier pickup via `registerShiprocketPickup` (metadata warehouse key used as-is when present; else lists first, then registers from the location's address). There is NO fallback to another registered pickup — all parties share one Shiprocket account, so that would ship from someone else's warehouse. A clean MedusaError (not a 500) is thrown when no pickup can be resolved so the UI shows an actionable message. / export type CreateInventoryOrderShipmentInput = { orderId: string /** Defaults to \"shiprocket\". */ carrier?: string /** Source stock location to ship from; auto-registered as a pickup if new. */ pickupStockLocationId?: string weightGrams?: number dimensionsCm?: Dimensions preferredCourierId?: string | number /** Delivered quantities keyed by order_line_id (restricts shipment items). */ deliveredQuantities?: Record<string, number> /** Acting user's email recorded on a freshly-registered pickup (#427)."
+      },
+      {
+        "name": "pickupDate",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.pickupDate }}",
+        "description": "Generate a real carrier shipment (forward → AWB → label) for a partner inventory-order completion and persist the carrier refs onto the inventory order (#772). Opt-in: invoked only when the partner asked to generate a shipment; the legacy free-text `partner_tracking_number` path is untouched otherwise. Pickup bootstrap: the explicit pickup input or the order's from_location is ensured to be a registered carrier pickup via `registerShiprocketPickup` (metadata warehouse key used as-is when present; else lists first, then registers from the location's address). There is NO fallback to another registered pickup — all parties share one Shiprocket account, so that would ship from someone else's warehouse. A clean MedusaError (not a 500) is thrown when no pickup can be resolved so the UI shows an actionable message. / export type CreateInventoryOrderShipmentInput = { orderId: string /** Defaults to \"shiprocket\". */ carrier?: string /** Source stock location to ship from; auto-registered as a pickup if new. */ pickupStockLocationId?: string weightGrams?: number dimensionsCm?: Dimensions preferredCourierId?: string | number /** Delivered quantities keyed by order_line_id (restricts shipment items). */ deliveredQuantities?: Record<string, number> /** Acting user's email recorded on a freshly-registered pickup (#427). */ actingEmail?: string /** Requested carrier pickup date (\"YYYY-MM-DD\"). When set, a pickup is scheduled for that date after the shipment is created; otherwise Shiprocket picks the earliest slot."
       }
     ],
     "source": "custom_ts",
@@ -3673,6 +3710,19 @@
     "source": "custom_ts",
     "sourceFile": "src/workflows/inventory_orders/get-inventory-order-tasks.ts"
   },
+  "sync-inventory-shipment-tracking": {
+    "fields": [
+      {
+        "name": "tracking",
+        "type": "string",
+        "required": true,
+        "placeholder": "{{ $last.tracking }}",
+        "description": "Shipment-level counterpart of the order status-changed event (#888). Fired only on a real shipment status transition (webhook retries are deduped by the forward-only guard), so visual flows can notify partners about pickup / transit milestones without listening to raw carrier payloads. / export const INVENTORY_SHIPMENT_STATUS_CHANGED_EVENT = \"inventory_orders.inventory-shipment.status-changed\" export type SyncInventoryShipmentTrackingInput = { /** Normalized carrier push (from `normalizeShiprocketWebhook` or a future carrier)."
+      }
+    ],
+    "source": "custom_ts",
+    "sourceFile": "src/workflows/inventory_orders/sync-inventory-shipment-tracking.ts"
+  },
   "update-inventory-order-task": {
     "fields": [
       {
@@ -3734,6 +3784,12 @@
         "type": "id",
         "required": true,
         "placeholder": "{{ $last.id }}"
+      },
+      {
+        "name": "expectedCurrentStatus",
+        "type": "string",
+        "required": false,
+        "placeholder": "{{ $last.expectedCurrentStatus }}"
       }
     ],
     "source": "custom_ts",
@@ -4651,8 +4707,9 @@
       {
         "name": "vercel_project_id",
         "type": "id",
-        "required": true,
-        "placeholder": "{{ $last.vercel_project_id }}"
+        "required": false,
+        "placeholder": "{{ $last.vercel_project_id }}",
+        "description": "Roadmap #17 (issue #346) — a partner's custom domain should work in both its www and apex forms. The submitted host is the canonical one; the counterpart is attached to the same Vercel project as a permanent redirect, and BOTH are registered as `website_domain` aliases so the storefront's host-based website lookup resolves either form (the gap that left sharlho.com showing the generic \"Store\" template). / export type DomainPair = { /** The host the partner asked for — canonical, serves traffic. */ primary: string /** The www/apex twin — redirects to primary. Null for deeper subdomains. */ counterpart: string | null } /** apex → www twin; www → apex twin; anything deeper (shop.example.com) has no twin. Assumes an already-cleaned lowercase host. / export function deriveDomainPair(domain: string): DomainPair { const parts = domain.split(\".\") if (parts[0] === \"www\" && parts.length === 3) { return { primary: domain, counterpart: parts.slice(1).join(\".\") } } if (parts.length === 2) { return { primary: domain, counterpart: `www.${domain}` } } return { primary: domain, counterpart: null } } export type AttachStorefrontDomainInput = { partner_id: string /** @deprecated kept for callers; the provider + project ref are now resolved from the partner."
       },
       {
         "name": "website_id",
@@ -5469,6 +5526,12 @@
         "type": "id",
         "required": false,
         "placeholder": "{{ $last.sub_partner_id }}"
+      },
+      {
+        "name": "skip_unified_projection",
+        "type": "boolean",
+        "required": false,
+        "placeholder": "false"
       }
     ],
     "source": "custom_ts",
@@ -5787,6 +5850,24 @@
     ],
     "source": "inferred",
     "sourceFile": "src/workflows/raw-materials/list-raw-material-category.ts"
+  },
+  "resolve-group-color-inventory-items": {
+    "fields": [
+      {
+        "name": "lines",
+        "type": "array",
+        "required": true,
+        "placeholder": "{{ $last.lines }}"
+      },
+      {
+        "name": "stock_location_id",
+        "type": "id",
+        "required": false,
+        "placeholder": "{{ $last.stock_location_id }}"
+      }
+    ],
+    "source": "custom_ts",
+    "sourceFile": "src/workflows/raw_material_groups/resolve-group-color-items.ts"
   },
   "propagate-region-to-partners": {
     "fields": [

--- a/e2e/helpers/e2e-seed.ts
+++ b/e2e/helpers/e2e-seed.ts
@@ -1,0 +1,114 @@
+import { ExecArgs } from "@medusajs/framework/types"
+import { Modules, ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import Scrypt from "scrypt-kdf"
+import * as fs from "fs"
+import * as path from "path"
+
+const SEED_PASSWORD = "e2etest123!"
+const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
+
+export default async function e2eSeed({ container }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const userModule = container.resolve(Modules.USER)
+  const authModule = container.resolve(Modules.AUTH)
+  const websiteService = container.resolve("websites")
+  const socials: any = container.resolve("socials")
+
+  logger.info("E2E seed: creating admin user...")
+
+  const email = `e2e-${Date.now()}@jyt.test`
+  const user = await userModule.createUsers({
+    first_name: "E2E",
+    last_name: "Admin",
+    email,
+  })
+
+  const hashConfig = { logN: 15, r: 8, p: 1 }
+  const passwordHash = await Scrypt.kdf(SEED_PASSWORD, hashConfig)
+
+  await authModule.createAuthIdentities({
+    provider_identities: [
+      {
+        provider: "emailpass",
+        entity_id: email,
+        provider_metadata: {
+          password: passwordHash.toString("base64"),
+        },
+      },
+    ],
+    app_metadata: {
+      user_id: user.id,
+    },
+  })
+
+  logger.info("E2E seed: creating website with GSC data...")
+
+  const domain = `e2e-gsc-${Date.now()}.jyt.test`
+  const website = await websiteService.createWebsites({
+    domain,
+    name: "E2E GSC Test",
+    status: "Active",
+    primary_language: "en",
+  })
+
+  const platformId = `e2e-platform-${Date.now()}`
+  await socials.createSocialPlatforms({
+    id: platformId,
+    name: "E2E Google Platform",
+    category: "google",
+    auth_type: "oauth2",
+    status: "active",
+    api_config: { test: true },
+  })
+
+  await socials.createSocialPlatformBindings({
+    platform_id: platformId,
+    service: "search-console",
+    resource_id: `sc-domain:${domain}`,
+    resource_label: domain,
+    status: "active",
+  })
+
+  const bindingsResult = await socials.listSocialPlatformBindings({
+    service: "search-console",
+    platform_id: platformId,
+  })
+  const bindings = bindingsResult.data ?? bindingsResult
+  const binding = Array.isArray(bindings) ? bindings[0] : null
+  if (!binding) throw new Error("No binding found after creation")
+
+  const siteResult = await socials.createGoogleSearchConsoleSites({
+    site_url: `sc-domain:${domain}`,
+    platform_id: platformId,
+    binding_id: binding.id,
+    sync_status: "synced",
+    permission_level: "siteOwner",
+    last_synced_at: new Date(),
+  })
+  const site = Array.isArray(siteResult) ? siteResult[0] : siteResult.data?.[0] ?? siteResult
+  if (!site?.id) throw new Error("No site created")
+
+  const rows: any[] = []
+  const today = new Date()
+  for (let i = 29; i >= 0; i--) {
+    const d = new Date(today)
+    d.setDate(d.getDate() - i)
+    const dateStr = d.toISOString().split("T")[0]
+    rows.push(
+      { site_id: site.id, date: dateStr, query: "winter dress", page: "https://example.com/dress", clicks: 10, impressions: 100, ctr: 0.1, position: 4.2, synced_at: new Date() },
+      { site_id: site.id, date: dateStr, query: "summer top", page: "https://example.com/top", clicks: 5, impressions: 80, ctr: 0.0625, position: 6.1, synced_at: new Date() },
+      { site_id: site.id, date: dateStr, query: "summer top", page: "https://example.com/collections/summer", clicks: 3, impressions: 40, ctr: 0.075, position: 5.5, synced_at: new Date() }
+    )
+  }
+  await socials.createGoogleSearchConsoleInsights(rows)
+
+  const seedData = {
+    email,
+    password: SEED_PASSWORD,
+    websiteId: website.id,
+    domain,
+  }
+
+  fs.writeFileSync(SEED_FILE, JSON.stringify(seedData, null, 2))
+  logger.info(`E2E seed complete. Credentials saved to ${SEED_FILE}`)
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig, devices } from "@playwright/test"
+import * as path from "path"
+
+const BACKEND_DIR = path.resolve(__dirname, "../apps/backend")
+
+export default defineConfig({
+  testDir: path.resolve(__dirname, "specs"),
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? "github" : "list",
+
+  webServer: {
+    command: `pnpm exec medusa develop`,
+    port: 9000,
+    cwd: BACKEND_DIR,
+    reuseExistingServer: !process.env.CI,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 300_000,
+  },
+
+  use: {
+    baseURL: "http://localhost:9000",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    launchOptions: {
+      args: [
+        "--no-sandbox",
+        "--disable-setuid-sandbox",
+        "--disable-web-security",
+      ],
+    },
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+})

--- a/e2e/specs/search-console-discovery-card.spec.ts
+++ b/e2e/specs/search-console-discovery-card.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "@playwright/test"
+import * as fs from "fs"
+import * as path from "path"
+
+const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
+
+test.describe("GSC Search/Discovery card (#894)", () => {
+  let seed: { email: string; password: string; websiteId: string; domain: string }
+
+  test.beforeAll(() => {
+    if (!fs.existsSync(SEED_FILE)) {
+      throw new Error(
+        `E2E seed file not found at ${SEED_FILE}. Run "pnpm e2e:seed" first.`
+      )
+    }
+    seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
+  })
+
+  test("renders the Search/Discovery card with synced GSC data", async ({ page }) => {
+    // Step 1: Log in via the admin UI
+    await page.goto("/app/login")
+    await page.waitForLoadState("networkidle")
+
+    await page.locator('input[name="email"]').fill(seed.email)
+    await page.locator('input[name="password"]').fill(seed.password)
+    await page.locator('button[type="submit"]').click()
+
+    // Wait until redirected away from /login (proves auth succeeded)
+    await page.waitForURL(/\/app\/(?!login)/, { timeout: 15000 })
+
+    // Step 2: Navigate to the website analytics page
+    await page.goto(`/app/websites/${seed.websiteId}/analytics`)
+    await page.waitForLoadState("networkidle")
+
+    // Step 3: Verify the Search/Discovery card is present with synced data
+    const card = page.locator("text=Search / Discovery").first()
+    await expect(card).toBeVisible({ timeout: 15000 })
+
+    // The binding resource_id should be displayed
+    await expect(page.locator(`text=${seed.domain}`).first()).toBeVisible()
+
+    // Metric stats should be visible
+    await expect(page.locator("text=Clicks").first()).toBeVisible()
+    await expect(page.locator("text=Impressions").first()).toBeVisible()
+    await expect(page.locator("text=CTR").first()).toBeVisible()
+    await expect(page.locator("text=Avg. Position").first()).toBeVisible()
+
+    // The chart area should render (recharts renders SVG inside a container)
+    const chart = page.locator(".recharts-responsive-container svg")
+    await expect(chart).toBeVisible({ timeout: 10000 })
+
+    // "Top Queries" and "Top Pages" sections should be visible
+    await expect(page.locator("text=Top Queries").first()).toBeVisible()
+    await expect(page.locator("text=Top Pages").first()).toBeVisible()
+
+    // At least one query/page row with a click count
+    await expect(page.locator("text=clicks").first()).toBeVisible()
+
+    // The "Sync Data" button should be present
+    await expect(page.locator('button:has-text("Sync Data")').first()).toBeVisible()
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,7 +293,7 @@ importers:
         version: 2.5.6
       '@uploadthing/react':
         specifier: 7.1.0
-        version: 7.1.0(next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react@18.3.1)(uploadthing@7.2.0(express@5.2.1)(next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2)))
+        version: 7.1.0(next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react@18.3.1)(uploadthing@7.2.0(express@5.2.1)(next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2)))
       '@xenova/transformers':
         specifier: ^2.17.2
         version: 2.17.2
@@ -479,7 +479,7 @@ importers:
         version: 1.2.1
       uploadthing:
         specifier: 7.2.0
-        version: 7.2.0(express@5.2.1)(next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
+        version: 7.2.0(express@5.2.1)(next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
       use-file-picker:
         specifier: ^2.1.2
         version: 2.1.4(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react@18.3.1)
@@ -496,6 +496,9 @@ importers:
       '@medusajs/test-utils':
         specifier: 2.17.1
         version: 2.17.1(@medusajs/core-flows@2.17.1(@medusajs/framework@2.17.1(@medusajs/cli@2.17.1(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))(zod@4.3.6)))(@medusajs/framework@2.17.1(@medusajs/cli@2.17.1(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))(zod@4.3.6))(@medusajs/medusa@2.17.1)
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@swc/core':
         specifier: 1.7.28
         version: 1.7.28(@swc/helpers@0.5.19)
@@ -872,7 +875,7 @@ importers:
         version: 4.17.23
       next:
         specifier: ^16.2.9
-        version: 16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.97.3)
+        version: 16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.97.3)
       pg:
         specifier: ^8.11.3
         version: 8.20.0
@@ -990,7 +993,7 @@ importers:
         version: 4.17.23
       next:
         specifier: 15.3.9
-        version: 15.3.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.97.3)
+        version: 15.3.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.97.3)
       pg:
         specifier: ^8.11.3
         version: 8.19.0
@@ -5891,6 +5894,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -12364,6 +12372,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -15628,6 +15641,16 @@ packages:
 
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   plimit-lit@1.6.1:
     resolution: {integrity: sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==}
@@ -26438,6 +26461,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
+
   '@pnpm/config.env-replace@1.1.0': {}
 
   '@pnpm/network.ca-file@1.0.2':
@@ -33171,14 +33198,14 @@ snapshots:
 
   '@uploadthing/mime-types@0.3.1': {}
 
-  '@uploadthing/react@7.1.0(next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react@18.3.1)(uploadthing@7.2.0(express@5.2.1)(next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2)))':
+  '@uploadthing/react@7.1.0(next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react@18.3.1)(uploadthing@7.2.0(express@5.2.1)(next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       '@uploadthing/shared': 7.1.0
       file-selector: 0.6.0
       react: 18.3.1
-      uploadthing: 7.2.0(express@5.2.1)(next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
+      uploadthing: 7.2.0(express@5.2.1)(next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
     optionalDependencies:
-      next: 16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
+      next: 16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
 
   '@uploadthing/shared@7.1.0':
     dependencies:
@@ -36795,6 +36822,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -39865,7 +39895,7 @@ snapshots:
 
   nerf-dart@1.0.0: {}
 
-  next@15.3.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.97.3):
+  next@15.3.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.97.3):
     dependencies:
       '@next/env': 15.3.9
       '@swc/counter': 0.1.3
@@ -39886,13 +39916,14 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 15.3.5
       '@next/swc-win32-x64-msvc': 15.3.5
       '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.61.1
       sass: 1.97.3
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3):
+  next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3):
     dependencies:
       '@next/env': 16.2.9
       '@swc/helpers': 0.5.15
@@ -39912,6 +39943,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.2.9
       '@next/swc-win32-x64-msvc': 16.2.9
       '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.61.1
       sass: 1.97.3
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -39919,7 +39951,7 @@ snapshots:
       - babel-plugin-macros
     optional: true
 
-  next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.97.3):
+  next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.97.3):
     dependencies:
       '@next/env': 16.2.9
       '@swc/helpers': 0.5.15
@@ -39939,6 +39971,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.2.9
       '@next/swc-win32-x64-msvc': 16.2.9
       '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.61.1
       sass: 1.97.3
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -40715,6 +40748,14 @@ snapshots:
       tslib: 2.8.1
 
   platform@1.3.6: {}
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plimit-lit@1.6.1:
     dependencies:
@@ -44518,7 +44559,7 @@ snapshots:
       semver-diff: 4.0.0
       xdg-basedir: 5.1.0
 
-  uploadthing@7.2.0(express@5.2.1)(next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2)):
+  uploadthing@7.2.0(express@5.2.1)(next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@effect/platform': 0.69.8(effect@3.19.19)
       '@uploadthing/mime-types': 0.3.1
@@ -44526,7 +44567,7 @@ snapshots:
       effect: 3.19.19
     optionalDependencies:
       express: 5.2.1
-      next: 16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
+      next: 16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
       tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.2)
 
   upper-case-first@2.0.2:


### PR DESCRIPTION
## Summary

Closes #894. Adds Google Search Console analytics data to the in-house visitors/website analytics dashboard.

## Changes

- **New workflow** `get-search-console-analytics` — resolves GSC binding for website, queries `GoogleSearchConsoleInsights`, aggregates total/timeseries/top_queries/top_pages
- **New API** `GET /admin/websites/:id/analytics/search-console` — thin handler calling workflow
- **New daily sync job** `sync-gsc-analytics` — cron 0 2 * * *
- **New hook** `useWebsiteSearchConsoleRollup(websiteId, days)` — admin UI hook
- **New card** `analytics-search-discovery-card` — handles all states, area chart, top queries/pages
- **Integration** card placed in `website-analytics-modal` after Traffic Sources, before Country Map
- **E2E tests** — Playwright in project root `e2e/`, seed via `medusa exec`, tests login + card verification

## Testing

```bash
cd apps/backend
pnpm e2e:seed   # seeds admin user, website, GSC data
pnpm e2e:test   # runs Playwright E2E test
```