### PR TITLE
fix(analytics): show GSC data when clicks are zero

### DIFF
--- a/apps/backend/src/admin/components/websites/analytics-search-discovery-card.tsx
+++ b/apps/backend/src/admin/components/websites/analytics-search-discovery-card.tsx
@@ -87,8 +87,7 @@ export const AnalyticsSearchDiscoveryCard = ({ websiteId, days }: Props) => {
   const loading = statusLoading || gscLoading
   const notBound = status && !status.bound
   const boundNoSync = gsc && gsc.bound && !gsc.synced
-  const hasData = gsc && gsc.bound && gsc.synced && (gsc.total.clicks > 0 || gsc.total.impressions > 0 || gsc.top_queries.length > 0)
-  const empty = gsc && gsc.bound && gsc.synced && !hasData
+  const showFullCard = gsc && gsc.bound && gsc.synced
 
   if (loading) {
     return (
@@ -157,31 +156,7 @@ export const AnalyticsSearchDiscoveryCard = ({ websiteId, days }: Props) => {
     )
   }
 
-  if (empty) {
-    return (
-      <Container className="p-0 overflow-hidden rounded-lg border border-ui-border-base bg-ui-bg-base">
-        <div className="p-4 border-b border-ui-border-base flex items-center justify-between">
-          <div className="flex items-center gap-x-2">
-            <MagnifyingGlass className="text-ui-fg-subtle" />
-            <Heading level="h3" className="text-sm font-medium">Search / Discovery</Heading>
-          </div>
-          <div className="flex items-center gap-x-2">
-            {gsc?.binding && (
-              <Text size="xsmall" className="text-ui-fg-subtle font-mono">
-                {gsc.binding.resource_id}
-              </Text>
-            )}
-            <SyncButton websiteId={websiteId} />
-          </div>
-        </div>
-        <div className="p-6 flex items-center justify-center">
-          <Text className="text-ui-fg-muted text-sm">No search data in this period.</Text>
-        </div>
-      </Container>
-    )
-  }
-
-  if (!gsc) return null
+  if (!showFullCard) return null
 
   const chartData = gsc.timeseries.map((d) => ({
     date: d.date.slice(5),

--- a/apps/backend/src/admin/components/websites/analytics-search-discovery-card.tsx
+++ b/apps/backend/src/admin/components/websites/analytics-search-discovery-card.tsx
@@ -87,8 +87,8 @@ export const AnalyticsSearchDiscoveryCard = ({ websiteId, days }: Props) => {
   const loading = statusLoading || gscLoading
   const notBound = status && !status.bound
   const boundNoSync = gsc && gsc.bound && !gsc.synced
-  const hasData = gsc && gsc.bound && gsc.synced && gsc.total.clicks > 0
-  const empty = gsc && gsc.bound && gsc.synced && gsc.total.clicks === 0
+  const hasData = gsc && gsc.bound && gsc.synced && (gsc.total.clicks > 0 || gsc.total.impressions > 0 || gsc.top_queries.length > 0)
+  const empty = gsc && gsc.bound && gsc.synced && !hasData
 
   if (loading) {
     return (

--- a/apps/backend/src/workflows/analytics/reports/get-search-console-analytics.ts
+++ b/apps/backend/src/workflows/analytics/reports/get-search-console-analytics.ts
@@ -1,5 +1,6 @@
 import { createStep, createWorkflow, StepResponse, WorkflowResponse } from "@medusajs/framework/workflows-sdk"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import type { Logger } from "@medusajs/types"
 import { SOCIALS_MODULE } from "../../../modules/socials"
 import { resolveSearchConsoleBindingForWebsite } from "../../../lib/search-console-resolver"
 
@@ -50,7 +51,7 @@ export const getSearchConsoleAnalyticsStep = createStep(
     input: GetSearchConsoleAnalyticsInput,
     { container }
   ): Promise<StepResponse<SearchConsoleAnalyticsOutput>> => {
-    const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+    const logger = container.resolve(ContainerRegistrationKeys.LOGGER) as Logger
 
     const endDate = input.to ? new Date(input.to) : new Date()
     const startDate = input.from


### PR DESCRIPTION
## Summary
Follow-up to #897. The GSC (Google Search Console) analytics card was gating its render on `clicks > 0`, so pages with impressions but zero clicks — common for new or low-ranking content — showed an empty state instead of the real data.

## Changes
- `fix(ui)`: show GSC data when impressions > 0 even if clicks are zero
- `fix(ui)`: always show GSC data when synced, remove the empty-state gate entirely
- `fix(build)`: cast logger from `container.resolve` as `Logger` type (TS18046)

## Related
- Follows up #897 (GSC analytics card)
- Closes out display tail on #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)