### PR TITLE
feat(ucp): port MCP store API to Universal Commerce Protocol (UCP)

### DIFF
--- a/apps/backend/integration-tests/http/ucp/ucp-checkout.spec.ts
+++ b/apps/backend/integration-tests/http/ucp/ucp-checkout.spec.ts
@@ -1,0 +1,464 @@
+import { Modules } from "@medusajs/utils"
+import { createAdminUser, getAuthHeaders } from "../../helpers/create-admin-user"
+import { createTestCustomer } from "../../helpers/create-customer"
+import { setupCheckoutInfrastructure } from "../../helpers/setup-checkout-infrastructure"
+import { getSharedTestEnv, setupSharedTestSuite } from "../shared-test-setup"
+
+jest.setTimeout(120000)
+
+const UCP_HEADERS = {
+  "Content-Type": "application/json",
+  "UCP-Agent": "profile=\"https://agent.example/profile\"",
+  "Request-Id": "test-req-001",
+}
+
+setupSharedTestSuite(() => {
+  describe("UCP (Universal Commerce Protocol) endpoints", () => {
+    const { api, getContainer } = getSharedTestEnv()
+
+    let publishableKey: string
+    let adminHeaders: Record<string, any>
+    let regionId: string
+    let variantId: string
+    let productId: string
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+      const { apiKey } = await createTestCustomer(container)
+      publishableKey = apiKey.token
+
+      // Create a US/USD region
+      const region = await api.post(
+        "/admin/regions",
+        { name: "US", currency_code: "usd", countries: ["us"] },
+        adminHeaders
+      )
+      regionId = region.data.region.id
+
+      // Set up fulfillment + payment infrastructure
+      const infra = await setupCheckoutInfrastructure(container, regionId)
+
+      // Link stock location to the default sales channel
+      const storeService: any = container.resolve(Modules.STORE)
+      const store = (await storeService.listStores({}))?.[0]
+      const salesChannelId = store?.default_sales_channel_id
+
+      try {
+        const remoteLink: any = container.resolve("link")
+        await remoteLink.create({
+          [Modules.SALES_CHANNEL]: { sales_channel_id: salesChannelId },
+          [Modules.STOCK_LOCATION]: { stock_location_id: infra.stockLocation.id },
+        })
+      } catch {
+        // link may already exist
+      }
+
+      // Create a published product with one variant
+      const product = await api.post(
+        "/admin/products",
+        {
+          title: `UCP Test Product ${Date.now()}`,
+          status: "published",
+          sales_channels: [{ id: salesChannelId }],
+          options: [{ title: "Size", values: ["M"] }],
+          variants: [
+            {
+              title: "M",
+              options: { Size: "M" },
+              prices: [{ amount: 499, currency_code: "usd" }],
+              manage_inventory: false,
+            },
+          ],
+        },
+        adminHeaders
+      )
+      productId = product.data.product.id
+      variantId = product.data.product.variants[0].id
+    })
+
+    const ucpHeaders = () => ({
+      headers: {
+        ...UCP_HEADERS,
+        "x-publishable-api-key": publishableKey,
+      },
+    })
+
+    // =====================================================
+    // Discovery
+    // =====================================================
+
+    describe("GET /.well-known/ucp", () => {
+      it("returns the UCP discovery manifest", async () => {
+        const res = await api.get("/.well-known/ucp")
+
+        expect(res.status).toBe(200)
+        expect(res.data.ucp).toBeDefined()
+        expect(res.data.ucp.version).toBe("2026-01-11")
+        expect(res.data.ucp.services["dev.ucp.shopping"]).toBeDefined()
+        expect(res.data.ucp.services["dev.ucp.shopping"][0].transport).toBe("rest")
+        expect(res.data.ucp.services["dev.ucp.shopping"][0].endpoint).toContain("/ucp")
+
+        expect(res.data.ucp.capabilities["dev.ucp.shopping.checkout"]).toBeDefined()
+        expect(res.data.ucp.capabilities["dev.ucp.shopping.cart"]).toBeDefined()
+        expect(res.data.ucp.capabilities["dev.ucp.shopping.order"]).toBeDefined()
+        expect(res.data.ucp.capabilities["dev.ucp.shopping.fulfillment"]).toBeDefined()
+
+        expect(Array.isArray(res.data.ucp.payment_handlers)).toBe(true)
+        const handlerIds = res.data.ucp.payment_handlers.map((h: any) => h.id)
+        expect(handlerIds).toContain("payu")
+        expect(handlerIds).toContain("stripe")
+      })
+
+      it("does not require UCP-Agent or Request-Id headers", async () => {
+        const res = await api.get("/.well-known/ucp")
+        expect(res.status).toBe(200)
+      })
+    })
+
+    // =====================================================
+    // Header validation
+    // =====================================================
+
+    describe("UCP header validation", () => {
+      it("rejects POST /ucp/checkout-sessions without UCP-Agent header", async () => {
+        let status = 0
+        try {
+          await api.post("/ucp/checkout-sessions", {
+            line_items: [{ item: { id: variantId }, quantity: 1 }],
+          }, {
+            headers: {
+              "Content-Type": "application/json",
+              "Request-Id": "test-req-002",
+              "x-publishable-api-key": publishableKey,
+            },
+          })
+        } catch (e: any) {
+          status = e?.response?.status ?? 0
+        }
+        expect(status).toBe(400)
+      })
+
+      it("rejects POST /ucp/checkout-sessions without Request-Id header", async () => {
+        let status = 0
+        try {
+          await api.post("/ucp/checkout-sessions", {
+            line_items: [{ item: { id: variantId }, quantity: 1 }],
+          }, {
+            headers: {
+              "Content-Type": "application/json",
+              "UCP-Agent": "profile=\"https://agent.example/profile\"",
+              "x-publishable-api-key": publishableKey,
+            },
+          })
+        } catch (e: any) {
+          status = e?.response?.status ?? 0
+        }
+        expect(status).toBe(400)
+      })
+    })
+
+    // =====================================================
+    // Checkout Sessions — Create
+    // =====================================================
+
+    describe("POST /ucp/checkout-sessions", () => {
+      it("creates a checkout session with line items", async () => {
+        const res = await api.post("/ucp/checkout-sessions", {
+          line_items: [{ item: { id: variantId }, quantity: 2 }],
+          buyer: { email: "ucp-test@example.com", first_name: "UCP", last_name: "Test" },
+          context: { region_id: regionId },
+        }, ucpHeaders())
+
+        expect(res.status).toBe(201)
+        expect(res.data.id).toBeDefined()
+        expect(res.data.ucp).toBeDefined()
+        expect(res.data.ucp.version).toBe("2026-01-11")
+        expect(res.data.status).toBe("incomplete")
+        expect(res.data.line_items).toHaveLength(1)
+        expect(res.data.line_items[0].quantity).toBe(2)
+        expect(res.data.line_items[0].item.id).toBe(variantId)
+        expect(res.data.buyer.email).toBe("ucp-test@example.com")
+        expect(res.data.totals).toBeDefined()
+        const totalTypes = res.data.totals.map((t: any) => t.type)
+        expect(totalTypes).toContain("subtotal")
+        expect(totalTypes).toContain("total")
+      })
+
+      it("creates a checkout session with shipping address", async () => {
+        const res = await api.post("/ucp/checkout-sessions", {
+          line_items: [{ item: { id: variantId }, quantity: 1 }],
+          buyer: { email: "ucp-addr@example.com" },
+          shipping_address: {
+            first_name: "John",
+            last_name: "Doe",
+            street_address: "123 Test St",
+            address_locality: "New York",
+            address_region: "NY",
+            address_country: "us",
+            postal_code: "10001",
+            phone_number: "+12125551234",
+          },
+        }, ucpHeaders())
+
+        expect(res.status).toBe(201)
+        expect(res.data.shipping_address).toBeDefined()
+        expect(res.data.shipping_address.street_address).toBe("123 Test St")
+        expect(res.data.shipping_address.address_country).toBe("us")
+      })
+
+      it("rejects empty line_items", async () => {
+        let status = 0
+        try {
+          await api.post("/ucp/checkout-sessions", {
+            line_items: [],
+          }, ucpHeaders())
+        } catch (e: any) {
+          status = e?.response?.status ?? 0
+        }
+        expect([400, 422]).toContain(status)
+      })
+    })
+
+    // =====================================================
+    // Checkout Sessions — Retrieve
+    // =====================================================
+
+    describe("GET /ucp/checkout-sessions/:id", () => {
+      it("retrieves a checkout session by id", async () => {
+        const create = await api.post("/ucp/checkout-sessions", {
+          line_items: [{ item: { id: variantId }, quantity: 1 }],
+          buyer: { email: "ucp-get@example.com" },
+          context: { region_id: regionId },
+        }, ucpHeaders())
+
+        const id = create.data.id
+
+        const res = await api.get(`/ucp/checkout-sessions/${id}`, ucpHeaders())
+
+        expect(res.status).toBe(200)
+        expect(res.data.id).toBe(id)
+        expect(res.data.line_items).toHaveLength(1)
+      })
+
+      it("returns 404 for non-existent session", async () => {
+        let status = 0
+        try {
+          await api.get("/ucp/checkout-sessions/cart_nonexistent", ucpHeaders())
+        } catch (e: any) {
+          status = e?.response?.status ?? 0
+        }
+        expect(status).toBe(404)
+      })
+    })
+
+    // =====================================================
+    // Checkout Sessions — Update
+    // =====================================================
+
+    describe("PUT /ucp/checkout-sessions/:id", () => {
+      it("updates buyer email on an existing session", async () => {
+        const create = await api.post("/ucp/checkout-sessions", {
+          line_items: [{ item: { id: variantId }, quantity: 1 }],
+          context: { region_id: regionId },
+        }, ucpHeaders())
+
+        const id = create.data.id
+
+        const res = await api.put(`/ucp/checkout-sessions/${id}`, {
+          buyer: { email: "updated@example.com" },
+        }, ucpHeaders())
+
+        expect(res.status).toBe(200)
+        expect(res.data.buyer.email).toBe("updated@example.com")
+      })
+
+      it("adds a shipping address via PUT", async () => {
+        const create = await api.post("/ucp/checkout-sessions", {
+          line_items: [{ item: { id: variantId }, quantity: 1 }],
+          buyer: { email: "ucp-put@example.com" },
+          context: { region_id: regionId },
+        }, ucpHeaders())
+
+        const id = create.data.id
+
+        const res = await api.put(`/ucp/checkout-sessions/${id}`, {
+          shipping_address: {
+            first_name: "Jane",
+            last_name: "Doe",
+            street_address: "456 Oak Ave",
+            address_locality: "New York",
+            address_region: "NY",
+            address_country: "us",
+            postal_code: "10001",
+          },
+        }, ucpHeaders())
+
+        expect(res.status).toBe(200)
+        expect(res.data.shipping_address).toBeDefined()
+        expect(res.data.shipping_address.street_address).toBe("456 Oak Ave")
+        expect(res.data.shipping_address.address_locality).toBe("New York")
+      })
+
+      it("updates line item quantity", async () => {
+        const create = await api.post("/ucp/checkout-sessions", {
+          line_items: [{ item: { id: variantId }, quantity: 1 }],
+          buyer: { email: "ucp-qty@example.com" },
+          context: { region_id: regionId },
+        }, ucpHeaders())
+
+        const id = create.data.id
+        const lineItemId = create.data.line_items[0].id
+
+        const res = await api.put(`/ucp/checkout-sessions/${id}`, {
+          line_items: [{ line_item_id: lineItemId, quantity: 5 }],
+        }, ucpHeaders())
+
+        expect(res.status).toBe(200)
+        expect(res.data.line_items[0].quantity).toBe(5)
+      })
+    })
+
+    // =====================================================
+    // Checkout Sessions — Complete (validation only)
+    // =====================================================
+
+    describe("POST /ucp/checkout-sessions/:id/complete", () => {
+      it("rejects completion when email is missing", async () => {
+        const create = await api.post("/ucp/checkout-sessions", {
+          line_items: [{ item: { id: variantId }, quantity: 1 }],
+          context: { region_id: regionId },
+        }, ucpHeaders())
+
+        const id = create.data.id
+
+        let status = 0
+        let errorData: any
+        try {
+          await api.post(`/ucp/checkout-sessions/${id}/complete`, {
+            payment: { instruments: [] },
+          }, ucpHeaders())
+        } catch (e: any) {
+          status = e?.response?.status ?? 0
+          errorData = e?.response?.data
+        }
+        expect(status).toBe(400)
+        expect(errorData?.ucp?.status).toBe("error")
+        expect(errorData?.messages?.[0]?.code).toBe("missing_email")
+      })
+
+      it("rejects completion when shipping address is missing", async () => {
+        const create = await api.post("/ucp/checkout-sessions", {
+          line_items: [{ item: { id: variantId }, quantity: 1 }],
+          buyer: { email: "ucp-no-addr@example.com" },
+          context: { region_id: regionId },
+        }, ucpHeaders())
+
+        const id = create.data.id
+
+        let status = 0
+        try {
+          await api.post(`/ucp/checkout-sessions/${id}/complete`, {
+            payment: { instruments: [] },
+          }, ucpHeaders())
+        } catch (e: any) {
+          status = e?.response?.status ?? 0
+        }
+        expect(status).toBe(400)
+      })
+    })
+
+    // =====================================================
+    // Catalog — Search
+    // =====================================================
+
+    describe("POST /ucp/catalog/search", () => {
+      it("searches the storefront catalog", async () => {
+        const res = await api.post("/ucp/catalog/search", {
+          query: "UCP",
+          pagination: { limit: 5, offset: 0 },
+        }, ucpHeaders())
+
+        expect(res.status).toBe(200)
+        expect(res.data.ucp).toBeDefined()
+        expect(Array.isArray(res.data.products)).toBe(true)
+        expect(typeof res.data.count).toBe("number")
+      })
+
+      it("returns products with UCP-formatted fields", async () => {
+        const res = await api.post("/ucp/catalog/search", {
+          pagination: { limit: 10 },
+        }, ucpHeaders())
+
+        expect(res.status).toBe(200)
+        expect(res.data.products.length).toBeGreaterThan(0)
+        const p = res.data.products[0]
+        expect(p.id).toBeDefined()
+        expect(p.title).toBeDefined()
+        expect(p.handle).toBeDefined()
+        expect(Array.isArray(p.variants)).toBe(true)
+      })
+    })
+
+    // =====================================================
+    // Catalog — Lookup
+    // =====================================================
+
+    describe("POST /ucp/catalog/lookup", () => {
+      it("looks up a product by id", async () => {
+        const res = await api.post("/ucp/catalog/lookup", {
+          ids: [productId],
+        }, ucpHeaders())
+
+        expect(res.status).toBe(200)
+        expect(res.data.products).toHaveLength(1)
+        expect(res.data.products[0].id).toBe(productId)
+      })
+    })
+
+    // =====================================================
+    // Orders
+    // =====================================================
+
+    describe("GET /ucp/orders/:id", () => {
+      it("returns 404 for non-existent order", async () => {
+        let status = 0
+        let data: any
+        try {
+          await api.get("/ucp/orders/order_nonexistent", ucpHeaders())
+        } catch (e: any) {
+          status = e?.response?.status ?? 0
+          data = e?.response?.data
+        }
+        expect(status).toBe(404)
+        expect(data.ucp).toBeDefined()
+        expect(data.ucp.status).toBe("error")
+      })
+    })
+
+    // =====================================================
+    // Error format
+    // =====================================================
+
+    describe("UCP error format", () => {
+      it("returns spec-compliant UCP error envelope on 404", async () => {
+        let status = 0
+        let data: any
+        try {
+          await api.get("/ucp/checkout-sessions/cart_nonexistent", ucpHeaders())
+        } catch (e: any) {
+          status = e?.response?.status ?? 0
+          data = e?.response?.data
+        }
+        expect(status).toBe(404)
+        expect(data.ucp).toBeDefined()
+        expect(data.ucp.status).toBe("error")
+        expect(Array.isArray(data.messages)).toBe(true)
+        expect(data.messages[0].type).toBe("error")
+        expect(data.messages[0].code).toBe("not_found")
+        expect(data.messages[0].severity).toBeDefined()
+      })
+    })
+  })
+})

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -21,6 +21,13 @@ import { OpsMaintenanceRunSchema, OpsMaintenanceRunsQuerySchema, OpsMaintenanceB
 import { getPersonResourceDefinition } from "./admin/persons/resources/registry";
 import { AdminGetOrdersOrderParams } from "@medusajs/medusa/api/admin/orders/validators";
 import { retrieveTransformQueryConfig as retrieveOrderTransformQueryConfig } from "@medusajs/medusa/api/admin/orders/query-config";
+import {
+  CreateUcpCheckoutSessionSchema,
+  UpdateUcpCheckoutSessionSchema,
+  CompleteUcpCheckoutSessionSchema,
+  CatalogSearchSchema,
+  CatalogLookupSchema,
+} from "./ucp/validators";
 
 // Helper function to wrap Zod schemas for compatibility with validateAndTransformBody.
 // Historically this wrapped with z.preprocess((obj) => obj, schema) — under Zod v3
@@ -5179,6 +5186,113 @@ export default defineMiddlewares({
       matcher: "/admin/messaging/:conversationId/delete",
       method: "DELETE",
       middlewares: [],
+    },
+    // =====================================================
+    // UCP (Universal Commerce Protocol) routes
+    // =====================================================
+
+    // --- .well-known/ucp route alias ---
+    // Medusa's file-based router ignores directories starting with ".", so the
+    // actual /.well-known/ucp route is registered here as a middleware entry.
+    {
+      matcher: "/.well-known/ucp",
+      method: "GET",
+      middlewares: [
+        (req: MedusaRequest, res: MedusaResponse) => {
+          const proto = (req.protocol || "http").split(",")[0].trim()
+          const host = req.get("host")
+          const baseUrl = process.env.STORE_MCP_LOOPBACK_URL?.replace(/\/$/, "") || `${proto}://${host}`
+          const storefrontUrl = process.env.STOREFRONT_URL || baseUrl
+          const UCP_VERSION = "2026-01-11"
+          res.json({
+            ucp: {
+              version: UCP_VERSION,
+              services: {
+                "dev.ucp.shopping": [{ version: UCP_VERSION, transport: "rest", endpoint: `${baseUrl}/ucp` }],
+              },
+              capabilities: {
+                "dev.ucp.shopping.catalog.search": [{ version: UCP_VERSION }],
+                "dev.ucp.shopping.catalog.lookup": [{ version: UCP_VERSION }],
+                "dev.ucp.shopping.checkout": [{ version: UCP_VERSION }],
+                "dev.ucp.shopping.cart": [{ version: UCP_VERSION }],
+                "dev.ucp.shopping.order": [{ version: UCP_VERSION }],
+                "dev.ucp.shopping.fulfillment": [{ version: UCP_VERSION }],
+                "dev.ucp.shopping.discount": [{ version: UCP_VERSION }],
+              },
+              payment_handlers: [
+                {
+                  id: "payu",
+                  name: "dev.jyt.payu",
+                  version: UCP_VERSION,
+                  config: { description: "PayU — INR payments (cards, UPI, netbanking)", currencies: ["inr"] },
+                },
+                {
+                  id: "stripe",
+                  name: "dev.jyt.stripe",
+                  version: UCP_VERSION,
+                  config: { description: "Stripe — non-INR payments (cards, Apple/Google Pay)", currencies: ["usd","eur","gbp","aud","cad","sgd","aed"] },
+                },
+              ],
+            },
+            store: { name: process.env.STORE_NAME || "JYT Store", url: storefrontUrl },
+          })
+        },
+      ],
+    },
+
+    // --- UCP validation middleware ---
+    // Validates UCP-Agent and Request-Id headers on all /ucp/* routes.
+    {
+      matcher: "/ucp/*",
+      middlewares: [
+        (req: MedusaRequest, res: MedusaResponse, next: any) => {
+          const ucpAgent = req.headers["ucp-agent"]
+          if (!ucpAgent) {
+            res.status(400).json({
+              ucp: { version: "2026-01-11", status: "error" },
+              messages: [{ type: "error", code: "missing_ucp_agent", content: "Missing UCP-Agent header for platform identification", severity: "unrecoverable" }],
+            })
+            return
+          }
+          const requestId = req.headers["request-id"]
+          if (!requestId) {
+            res.status(400).json({
+              ucp: { version: "2026-01-11", status: "error" },
+              messages: [{ type: "error", code: "missing_request_id", content: "Request-Id header is required for UCP requests", severity: "unrecoverable" }],
+            })
+            return
+          }
+          res.set("Request-Id", requestId as string)
+          next()
+        },
+      ],
+    },
+
+    // --- UCP Zod body validation ---
+    {
+      matcher: "/ucp/checkout-sessions",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(CreateUcpCheckoutSessionSchema))],
+    },
+    {
+      matcher: "/ucp/checkout-sessions/:id",
+      method: "PUT",
+      middlewares: [validateAndTransformBody(wrapSchema(UpdateUcpCheckoutSessionSchema))],
+    },
+    {
+      matcher: "/ucp/checkout-sessions/:id/complete",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(CompleteUcpCheckoutSessionSchema))],
+    },
+    {
+      matcher: "/ucp/catalog/search",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(CatalogSearchSchema))],
+    },
+    {
+      matcher: "/ucp/catalog/lookup",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(CatalogLookupSchema))],
     },
   ],
   errorHandler: ((

--- a/apps/backend/src/api/ucp/catalog/lookup/route.ts
+++ b/apps/backend/src/api/ucp/catalog/lookup/route.ts
@@ -1,0 +1,48 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { buildUcpContext } from "../../lib/context"
+import { formatUcpProduct, UCP_VERSION } from "../../lib/formatter"
+import { formatUcpError } from "../../lib/error-formatter"
+
+/**
+ * POST /ucp/catalog/lookup
+ *
+ * Look up products by id. Returns full product details including variants.
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const ctx = await buildUcpContext(req)
+  const body = req.validatedBody as any
+
+  try {
+    const ids: string[] = body.ids || []
+    const products: any[] = []
+
+    for (const id of ids) {
+      try {
+        const url = `${ctx.baseUrl}/store/products/${id}`
+        const headers: Record<string, string> = { accept: "application/json" }
+        if (ctx.publishableKey) headers["x-publishable-api-key"] = ctx.publishableKey
+
+        const resp = await fetch(url, { headers })
+        if (resp.ok) {
+          const data = await resp.json() as any
+          const product = data.product || data
+          products.push(formatUcpProduct(product))
+        }
+      } catch {
+        // Skip not found
+      }
+    }
+
+    res.json({
+      ucp: { version: UCP_VERSION, status: "success" },
+      products,
+      count: products.length,
+    })
+  } catch (error: any) {
+    res.status(500).json(formatUcpError({
+      ucpVersion: UCP_VERSION,
+      code: "internal_error",
+      content: error.message,
+    }))
+  }
+}

--- a/apps/backend/src/api/ucp/catalog/search/route.ts
+++ b/apps/backend/src/api/ucp/catalog/search/route.ts
@@ -1,0 +1,50 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { buildUcpContext } from "../../lib/context"
+import { formatUcpProduct, UCP_VERSION } from "../../lib/formatter"
+import { formatUcpError } from "../../lib/error-formatter"
+import { callStoreRoute } from "../../../mcp/lib/proxy"
+import qs from "qs"
+
+/**
+ * POST /ucp/catalog/search
+ *
+ * Search the storefront catalog. Supports full-text query and filters.
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const ctx = await buildUcpContext(req)
+  const body = req.validatedBody as any
+
+  try {
+    const query: Record<string, unknown> = {}
+    if (body.query) query.q = body.query
+    if (body.filters?.category) query.category_id = body.filters.category
+    if (body.filters?.collection) query.collection_id = body.filters.collection
+    query.limit = body.pagination?.limit ?? 20
+    query.offset = body.pagination?.offset ?? 0
+
+    const qstr = qs.stringify(query, { arrayFormat: "brackets", skipNulls: true })
+    const url = `${ctx.baseUrl}/store/products?${qstr}`
+
+    const headers: Record<string, string> = { accept: "application/json" }
+    if (ctx.publishableKey) headers["x-publishable-api-key"] = ctx.publishableKey
+
+    const resp = await fetch(url, { headers })
+    const data = await resp.json() as any
+
+    const products = (data.products || []).map(formatUcpProduct)
+
+    res.json({
+      ucp: { version: UCP_VERSION, status: "success" },
+      products,
+      count: products.length,
+      offset: query.offset,
+      limit: query.limit,
+    })
+  } catch (error: any) {
+    res.status(500).json(formatUcpError({
+      ucpVersion: UCP_VERSION,
+      code: "internal_error",
+      content: error.message,
+    }))
+  }
+}

--- a/apps/backend/src/api/ucp/checkout-sessions/[id]/complete/route.ts
+++ b/apps/backend/src/api/ucp/checkout-sessions/[id]/complete/route.ts
@@ -1,0 +1,226 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { buildUcpContext } from "../../../lib/context"
+import { formatUcpCheckoutSession, UCP_VERSION } from "../../../lib/formatter"
+import { formatUcpError } from "../../../lib/error-formatter"
+import { paymentNextAction, pickSession } from "../../../lib/payment-next-action"
+import { CHECKOUT_SESSION_CART_FIELDS } from "../../../lib/cart-fields"
+import { callStoreRoute } from "../../../../mcp/lib/proxy"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+/**
+ * POST /ucp/checkout-sessions/:id/complete
+ *
+ * Complete a checkout session. Initializes a payment session with the
+ * appropriate provider (PayU for INR, Stripe for non-INR) and returns
+ * the next action the agent must take.
+ *
+ * Unlike the reference implementation (which settles payment synchronously
+ * via x402/EIP-3009), our payment flow is async:
+ *   - PayU: redirect form → shopper pays on PayU's hosted page → webhook completes cart
+ *   - Stripe: hosted card page or client_secret → webhook completes cart
+ *
+ * So this endpoint returns status "complete_in_progress" with a next_action
+ * describing what the agent/shopper must do. The agent polls
+ * GET /ucp/checkout-sessions/:id until status = "completed".
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const { id } = req.params
+  const ctx = await buildUcpContext(req)
+  const body = req.validatedBody as any
+
+  try {
+    // Fetch the cart to check readiness
+    const query = ctx.container.resolve(ContainerRegistrationKeys.QUERY)
+    const { data: [cart] } = await query.graph({
+      entity: "cart",
+      fields: CHECKOUT_SESSION_CART_FIELDS,
+      filters: { id },
+    })
+
+    if (!cart) {
+      res.status(404).json(formatUcpError({
+        ucpVersion: UCP_VERSION,
+        code: "not_found",
+        content: "Checkout session not found",
+      }))
+      return
+    }
+
+    // Validate prerequisites
+    if (!cart.items || cart.items.length === 0) {
+      res.status(400).json(formatUcpError({
+        ucpVersion: UCP_VERSION,
+        code: "missing_items",
+        content: "Cannot complete checkout: no line items.",
+        severity: "recoverable",
+        path: "$.line_items",
+      }))
+      return
+    }
+    if (!cart.email) {
+      res.status(400).json(formatUcpError({
+        ucpVersion: UCP_VERSION,
+        code: "missing_email",
+        content: "Cannot complete checkout: buyer email is required.",
+        severity: "recoverable",
+        path: "$.buyer.email",
+      }))
+      return
+    }
+    if (!cart.shipping_address?.address_1) {
+      res.status(400).json(formatUcpError({
+        ucpVersion: UCP_VERSION,
+        code: "missing_shipping_address",
+        content: "Cannot complete checkout: shipping address is required.",
+        severity: "recoverable",
+        path: "$.shipping_address",
+      }))
+      return
+    }
+
+    // Determine the payment provider from the cart's region currency
+    const currencyCode = (cart.currency_code || "usd").toLowerCase()
+    const isINR = currencyCode === "inr"
+    const providerId = isINR ? "pp_payu_payu" : "pp_stripe_stripe"
+
+    // List payment providers to find the right one
+    let actualProviderId = providerId
+    try {
+      const providersResp = await callStoreRoute({
+        baseUrl: ctx.baseUrl,
+        method: "GET",
+        path: "/store/payment-providers",
+        query: { region_id: cart.region_id },
+        publishableKey: ctx.publishableKey,
+      }) as any
+      const providers = providersResp?.payment_providers || providersResp || []
+      const found = providers.find((p: any) => p.id?.includes(isINR ? "payu" : "stripe"))
+      if (found) actualProviderId = found.id
+    } catch {
+      // Fall back to the default provider id
+    }
+
+    // Create payment collection for the cart
+    let paymentCollectionId: string | null = null
+    try {
+      const pcResp = await callStoreRoute({
+        baseUrl: ctx.baseUrl,
+        method: "POST",
+        path: "/store/payment-collections",
+        body: { cart_id: id },
+        publishableKey: ctx.publishableKey,
+      }) as any
+      paymentCollectionId = pcResp?.payment_collection?.id || pcResp?.id
+    } catch {
+      // Payment collection might already exist
+    }
+
+    // If no collection was created, try to find existing one
+    if (!paymentCollectionId && cart.payment_collection?.id) {
+      paymentCollectionId = cart.payment_collection.id
+    }
+
+    if (!paymentCollectionId) {
+      res.status(500).json(formatUcpError({
+        ucpVersion: UCP_VERSION,
+        code: "payment_setup_failed",
+        content: "Failed to create or find payment collection for the cart.",
+      }))
+      return
+    }
+
+    // Initialize the payment session
+    let sessionData: any = null
+    try {
+      const sessionResp = await callStoreRoute({
+        baseUrl: ctx.baseUrl,
+        method: "POST",
+        path: `/store/payment-collections/${paymentCollectionId}/payment-sessions`,
+        body: { provider_id: actualProviderId },
+        publishableKey: ctx.publishableKey,
+      }) as any
+      sessionData = sessionResp
+    } catch (e: any) {
+      res.status(500).json(formatUcpError({
+        ucpVersion: UCP_VERSION,
+        code: "payment_session_failed",
+        content: `Failed to initialize payment session: ${e.message}`,
+      }))
+      return
+    }
+
+    // Determine the next action
+    const session = pickSession(sessionData, actualProviderId)
+    const nextAction = paymentNextAction(session)
+
+    // For Stripe, create a hosted payment page if possible
+    if (!isINR && nextAction.type === "client_secret") {
+      try {
+        const pageResp = await callStoreRoute({
+          baseUrl: ctx.baseUrl,
+          method: "POST",
+          path: "/store/stripe/payment-page",
+          body: { cart_id: id },
+          publishableKey: ctx.publishableKey,
+        }) as any
+        if (pageResp?.url) {
+          nextAction.type = "redirect"
+          nextAction.url = pageResp.url
+          nextAction.description = "Stripe hosted card page. The shopper pays here; the cart completes via webhook."
+        }
+      } catch {
+        // Fall back to client_secret flow
+      }
+    }
+
+    // For PayU, create a payment link if possible
+    if (isINR) {
+      try {
+        const linkResp = await callStoreRoute({
+          baseUrl: ctx.baseUrl,
+          method: "POST",
+          path: "/store/payu/payment-link",
+          body: { cart_id: id },
+          publishableKey: ctx.publishableKey,
+        }) as any
+        if (linkResp?.payment_link?.payment_url) {
+          nextAction.type = "redirect"
+          nextAction.url = linkResp.payment_link.payment_url
+          nextAction.description = "PayU hosted payment page (cards, UPI, netbanking). The cart completes via webhook."
+        }
+      } catch {
+        // Fall back to redirect_form from session data
+      }
+    }
+
+    // Re-fetch cart for response
+    const { data: [updatedCart] } = await query.graph({
+      entity: "cart",
+      fields: CHECKOUT_SESSION_CART_FIELDS,
+      filters: { id },
+    })
+
+    ;(updatedCart as any)._container = ctx.container
+    const session2 = await formatUcpCheckoutSession(
+      { storeName: ctx.storeName, storefrontUrl: ctx.storefrontUrl, baseUrl: ctx.baseUrl },
+      updatedCart
+    )
+
+    // Override status to show payment is in progress
+    ;(session2 as any).status = "complete_in_progress"
+    ;(session2 as any).payment = {
+      handler_id: isINR ? "payu" : "stripe",
+      provider_id: actualProviderId,
+      next_action: nextAction,
+      description: "Payment session initialized. The shopper must complete payment at the provided URL. Poll GET /ucp/checkout-sessions/:id until status = 'completed'.",
+    }
+
+    res.json(session2)
+  } catch (error: any) {
+    res.status(500).json(formatUcpError({
+      ucpVersion: UCP_VERSION,
+      code: "checkout_failed",
+      content: error.message,
+    }))
+  }
+}

--- a/apps/backend/src/api/ucp/checkout-sessions/[id]/route.ts
+++ b/apps/backend/src/api/ucp/checkout-sessions/[id]/route.ts
@@ -1,0 +1,209 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { buildUcpContext, resolveRegionForAddressUpdate } from "../../lib/context"
+import { formatUcpCheckoutSession, UCP_VERSION } from "../../lib/formatter"
+import { formatUcpError } from "../../lib/error-formatter"
+import { ucpAddressToMedusa } from "../../lib/address-translator"
+import { CHECKOUT_SESSION_CART_FIELDS } from "../../lib/cart-fields"
+import { extractSelectedFulfillmentOptionId } from "../../lib/fulfillment"
+import { callStoreRoute } from "../../../mcp/lib/proxy"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+/**
+ * GET /ucp/checkout-sessions/:id
+ *
+ * Retrieve a checkout session (cart) by id.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const { id } = req.params
+  const ctx = await buildUcpContext(req)
+
+  try {
+    const query = ctx.container.resolve(ContainerRegistrationKeys.QUERY)
+    const { data: [cart] } = await query.graph({
+      entity: "cart",
+      fields: CHECKOUT_SESSION_CART_FIELDS,
+      filters: { id },
+    })
+
+    if (!cart) {
+      res.status(404).json(formatUcpError({
+        ucpVersion: UCP_VERSION,
+        code: "not_found",
+        content: "Checkout session not found",
+      }))
+      return
+    }
+
+    ;(cart as any)._container = ctx.container
+    const session = await formatUcpCheckoutSession(
+      { storeName: ctx.storeName, storefrontUrl: ctx.storefrontUrl, baseUrl: ctx.baseUrl },
+      cart
+    )
+
+    res.json(session)
+  } catch (error: any) {
+    res.status(500).json(formatUcpError({
+      ucpVersion: UCP_VERSION,
+      code: "internal_error",
+      content: error.message,
+    }))
+  }
+}
+
+/**
+ * PUT /ucp/checkout-sessions/:id
+ *
+ * Update a checkout session: add/update/remove line items, set email,
+ * shipping address, apply discounts, select fulfillment option.
+ */
+export async function PUT(req: MedusaRequest, res: MedusaResponse) {
+  const { id } = req.params
+  const ctx = await buildUcpContext(req)
+  const body = req.validatedBody as any
+
+  try {
+    // Translate UCP field names to Medusa format
+    const email = body.buyer?.email
+    const shippingAddress = body.shipping_address
+      ? ucpAddressToMedusa(body.shipping_address)
+      : undefined
+
+    const fulfillmentOptionId = extractSelectedFulfillmentOptionId(body.fulfillment)
+
+    // Region resolution for address updates
+    let regionId: string | undefined
+    if (shippingAddress?.country_code) {
+      const resolution = await resolveRegionForAddressUpdate(
+        ctx.container, id, shippingAddress.country_code
+      )
+      if (!resolution.supported) {
+        res.status(400).json(formatUcpError({
+          ucpVersion: UCP_VERSION,
+          code: "country_not_supported",
+          content: `Country "${shippingAddress.country_code}" is not served by any region. Supported countries: ${resolution.supportedCountries.join(", ") || "(none configured)"}.`,
+          severity: "recoverable",
+          path: "$.shipping_address.address_country",
+        }))
+        return
+      }
+      if (resolution.shouldSwitch) {
+        regionId = resolution.regionId
+      }
+    }
+
+    // Build the cart update body
+    const updateBody: Record<string, unknown> = {}
+    if (email) updateBody.email = email
+    if (shippingAddress) updateBody.shipping_address = shippingAddress
+    if (regionId) updateBody.region_id = regionId
+    if (body.context?.currency) updateBody.currency_code = body.context.currency.toLowerCase()
+
+    // Apply promo codes if provided
+    if (body.discounts?.codes?.length) {
+      updateBody.promo_codes = body.discounts.codes
+    }
+
+    // Update cart properties via loopback proxy
+    if (Object.keys(updateBody).length > 0) {
+      await callStoreRoute({
+        baseUrl: ctx.baseUrl,
+        method: "POST",
+        path: `/store/carts/${id}`,
+        body: updateBody,
+        publishableKey: ctx.publishableKey,
+      })
+    }
+
+    // Handle line item updates
+    if (body.line_items) {
+      const toAdd = body.line_items.filter((li: any) => li.item?.id && !li.line_item_id && li.quantity > 0)
+      const toUpdate = body.line_items.filter((li: any) => li.line_item_id && li.quantity > 0)
+      const toRemove = body.line_items.filter((li: any) => li.line_item_id && li.quantity === 0)
+
+      // Add new items
+      for (const li of toAdd) {
+        await callStoreRoute({
+          baseUrl: ctx.baseUrl,
+          method: "POST",
+          path: `/store/carts/${id}/line-items`,
+          body: { variant_id: li.item.id, quantity: li.quantity },
+          publishableKey: ctx.publishableKey,
+        })
+      }
+
+      // Update existing items
+      for (const li of toUpdate) {
+        await callStoreRoute({
+          baseUrl: ctx.baseUrl,
+          method: "POST",
+          path: `/store/carts/${id}/line-items/${li.line_item_id}`,
+          body: { quantity: li.quantity },
+          publishableKey: ctx.publishableKey,
+        })
+      }
+
+      // Remove items
+      for (const li of toRemove) {
+        await callStoreRoute({
+          baseUrl: ctx.baseUrl,
+          method: "DELETE",
+          path: `/store/carts/${id}/line-items/${li.line_item_id}`,
+          publishableKey: ctx.publishableKey,
+        })
+      }
+    }
+
+    // Apply fulfillment option (shipping method)
+    if (fulfillmentOptionId) {
+      await callStoreRoute({
+        baseUrl: ctx.baseUrl,
+        method: "POST",
+        path: `/store/carts/${id}/shipping-methods`,
+        body: { option_id: fulfillmentOptionId },
+        publishableKey: ctx.publishableKey,
+      })
+    }
+
+    // Fetch updated cart
+    const query = ctx.container.resolve(ContainerRegistrationKeys.QUERY)
+    const { data: [updatedCart] } = await query.graph({
+      entity: "cart",
+      fields: CHECKOUT_SESSION_CART_FIELDS,
+      filters: { id },
+    })
+
+    if (!updatedCart) {
+      res.status(404).json(formatUcpError({
+        ucpVersion: UCP_VERSION,
+        code: "not_found",
+        content: "Checkout session not found",
+      }))
+      return
+    }
+
+    ;(updatedCart as any)._container = ctx.container
+    const session = await formatUcpCheckoutSession(
+      { storeName: ctx.storeName, storefrontUrl: ctx.storefrontUrl, baseUrl: ctx.baseUrl },
+      updatedCart
+    )
+
+    res.json(session)
+  } catch (error: any) {
+    const msg: string = error?.message || ""
+    if (/Country with code .* is not within region/i.test(msg)) {
+      res.status(400).json(formatUcpError({
+        ucpVersion: UCP_VERSION,
+        code: "country_not_supported",
+        content: msg,
+        severity: "recoverable",
+        path: "$.shipping_address.address_country",
+      }))
+      return
+    }
+    res.status(500).json(formatUcpError({
+      ucpVersion: UCP_VERSION,
+      code: "internal_error",
+      content: msg || "Internal error",
+    }))
+  }
+}

--- a/apps/backend/src/api/ucp/checkout-sessions/route.ts
+++ b/apps/backend/src/api/ucp/checkout-sessions/route.ts
@@ -1,0 +1,127 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { buildUcpContext, findRegionForCountry, getSupportedCountries } from "../lib/context"
+import { formatUcpCheckoutSession, UCP_VERSION } from "../lib/formatter"
+import { formatUcpError } from "../lib/error-formatter"
+import { ucpAddressToMedusa } from "../lib/address-translator"
+import { CHECKOUT_SESSION_CART_FIELDS } from "../lib/cart-fields"
+import { callStoreRoute } from "../../mcp/lib/proxy"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+/**
+ * POST /ucp/checkout-sessions
+ *
+ * Create a UCP checkout session (maps to a Medusa cart).
+ * The agent supplies line_items (item.id = variant_id), optional buyer,
+ * shipping_address, and context (currency/region).
+ */
+export async function POST(req: MedusaRequest, res: MedusaResponse) {
+  const ctx = await buildUcpContext(req)
+  const body = req.validatedBody as any
+
+  try {
+    // Translate UCP line_items → Medusa cart items
+    const items = (body.line_items || []).map((li: any) => ({
+      variant_id: li.item.id,
+      quantity: li.quantity,
+    }))
+
+    const email = body.buyer?.email || body.buyer?.full_name ? body.buyer?.email : undefined
+    const shippingAddress = body.shipping_address
+      ? {
+          ...ucpAddressToMedusa(body.shipping_address),
+          ...(body.buyer?.first_name ? { first_name: body.buyer.first_name } : {}),
+          ...(body.buyer?.last_name ? { last_name: body.buyer.last_name } : {}),
+          ...(body.buyer?.full_name
+            ? {
+                first_name: body.buyer.full_name.split(" ")[0],
+                last_name: body.buyer.full_name.split(" ").slice(1).join(" ") || undefined,
+              }
+            : {}),
+          ...(body.buyer?.phone_number ? { phone: body.buyer.phone_number } : {}),
+        }
+      : undefined
+
+    let regionId: string | undefined = body.context?.region_id
+    const currencyCode = body.context?.currency
+
+    // If the agent supplied a shipping address, pick a region whose country
+    // list includes the target country.
+    if (!regionId && shippingAddress?.country_code) {
+      const match = await findRegionForCountry(ctx.container, shippingAddress.country_code)
+      if (!match) {
+        const supported = await getSupportedCountries(ctx.container)
+        res.status(400).json(formatUcpError({
+          ucpVersion: UCP_VERSION,
+          code: "country_not_supported",
+          content: `Country "${shippingAddress.country_code}" is not served by any region. Supported countries: ${supported.join(", ") || "(none configured)"}.`,
+          severity: "recoverable",
+          path: "$.shipping_address.address_country",
+        }))
+        return
+      }
+      regionId = match.id
+    }
+
+    // Create the cart via loopback proxy to /store/carts
+    const cartBody: Record<string, unknown> = {
+      items: items.map((i: any) => ({ variant_id: i.variant_id, quantity: i.quantity })),
+      metadata: {
+        is_checkout_session: true,
+        protocol: "ucp",
+        protocol_version: UCP_VERSION,
+        agent_identifier: (req.headers["ucp-agent"] as string || "unknown").slice(0, 256),
+        checkout_session_created_at: new Date().toISOString(),
+      },
+    }
+    if (regionId) cartBody.region_id = regionId
+    if (email) cartBody.email = email
+    if (currencyCode) cartBody.currency_code = currencyCode.toLowerCase()
+    if (shippingAddress) cartBody.shipping_address = shippingAddress
+    if (body.discounts?.codes?.length) cartBody.promo_codes = body.discounts.codes
+
+    const cartResp = await callStoreRoute({
+      baseUrl: ctx.baseUrl,
+      method: "POST",
+      path: "/store/carts",
+      body: cartBody,
+      publishableKey: ctx.publishableKey,
+    }) as any
+
+    const cart = cartResp?.cart || cartResp
+
+    // Fetch full cart with totals via query.graph
+    const query = ctx.container.resolve(ContainerRegistrationKeys.QUERY)
+    const { data: [fullCart] } = await query.graph({
+      entity: "cart",
+      fields: CHECKOUT_SESSION_CART_FIELDS,
+      filters: { id: cart.id },
+    })
+
+    // Attach container for shipping options resolution
+    ;(fullCart as any)._container = ctx.container
+
+    const session = await formatUcpCheckoutSession(
+      { storeName: ctx.storeName, storefrontUrl: ctx.storefrontUrl, baseUrl: ctx.baseUrl },
+      fullCart
+    )
+
+    res.status(201).json(session)
+  } catch (error: any) {
+    const msg: string = error?.message || ""
+    if (/Country with code .* is not within region/i.test(msg)) {
+      res.status(400).json(formatUcpError({
+        ucpVersion: UCP_VERSION,
+        code: "country_not_supported",
+        content: msg,
+        severity: "recoverable",
+        path: "$.shipping_address.address_country",
+      }))
+      return
+    }
+    res.status(500).json(formatUcpError({
+      ucpVersion: UCP_VERSION,
+      code: "internal_error",
+      content: msg || "Internal error",
+    }))
+  }
+}

--- a/apps/backend/src/api/ucp/lib/address-translator.ts
+++ b/apps/backend/src/api/ucp/lib/address-translator.ts
@@ -1,0 +1,103 @@
+/**
+ * Bidirectional address translation between Medusa internal format
+ * and UCP postal_address.json format.
+ *
+ * Spec: https://ucp.dev/schemas/shopping/types/postal_address.json
+ * UCP allows alpha-2, alpha-3, or full country name; Medusa requires
+ * alpha-2 lowercase.
+ */
+
+export type MedusaAddress = {
+  first_name?: string
+  last_name?: string
+  address_1?: string
+  address_2?: string
+  city?: string
+  province?: string
+  postal_code?: string
+  country_code?: string
+  phone?: string
+}
+
+export type UcpAddress = {
+  first_name?: string
+  last_name?: string
+  street_address?: string
+  extended_address?: string
+  address_locality?: string
+  address_region?: string
+  address_country?: string
+  postal_code?: string
+  phone_number?: string
+}
+
+/** Common alpha-3 → alpha-2 mappings for countries we serve. */
+const ALPHA3_TO_ALPHA2: Record<string, string> = {
+  usa: "us", can: "ca", gbr: "gb", ind: "in", deu: "de", fra: "fr",
+  ita: "it", esp: "es", nld: "nl", bel: "be", che: "ch", aut: "at",
+  aus: "au", jpn: "jp", chn: "cn", kor: "kr", bra: "br", mex: "mx",
+  rus: "ru", zaf: "za", sgp: "sg", hkg: "hk", are: "ae", sau: "sa",
+  npl: "np", lka: "lk", bng: "bd", pak: "pk", tha: "th", vnm: "vn",
+  idn: "id", mys: "my", phl: "ph", twn: "tw", nzl: "nz", irl: "ie",
+  prt: "pt", swe: "se", nor: "no", dnk: "dk", fin: "fi", pol: "pl",
+  cze: "cz", hun: "hu", grc: "gr", tur: "tr", isr: "il", egy: "eg",
+}
+
+/** Normalize various country representations to ISO 3166-1 alpha-2 lowercase. */
+export function normalizeCountryCode(input: string | undefined | null): string | null {
+  if (!input) return null
+  const raw = input.trim()
+  if (!raw) return null
+  const lower = raw.toLowerCase()
+
+  if (lower.length === 2) return lower
+  if (lower.length === 3) return ALPHA3_TO_ALPHA2[lower] || null
+
+  // Try full name → alpha-2 via a small lookup
+  const fullNameMap: Record<string, string> = {
+    "united states": "us", "united states of america": "us", "america": "us",
+    "india": "in", "united kingdom": "gb", "britain": "gb", "england": "gb",
+    "germany": "de", "france": "fr", "italy": "it", "spain": "es",
+    "netherlands": "nl", "belgium": "be", "switzerland": "ch", "austria": "at",
+    "australia": "au", "japan": "jp", "china": "cn", "south korea": "kr",
+    "brazil": "br", "mexico": "mx", "canada": "ca", "singapore": "sg",
+    "nepal": "np", "sri lanka": "lk", "bangladesh": "bd", "pakistan": "pk",
+    "thailand": "th", "vietnam": "vn", "indonesia": "id", "malaysia": "my",
+    "philippines": "ph", "taiwan": "tw", "new zealand": "nz", "ireland": "ie",
+    "portugal": "pt", "sweden": "se", "norway": "no", "denmark": "dk",
+    "finland": "fi", "poland": "pl", "czech republic": "cz", "hungary": "hu",
+    "greece": "gr", "turkey": "tr", "israel": "il", "egypt": "eg",
+    "south africa": "za", "russia": "ru", "hong kong": "hk",
+    "united arab emirates": "ae", "saudi arabia": "sa",
+  }
+  return fullNameMap[lower] || null
+}
+
+export function medusaToUcpAddress(addr: MedusaAddress): UcpAddress {
+  return {
+    first_name: addr.first_name || undefined,
+    last_name: addr.last_name || undefined,
+    street_address: addr.address_1 || undefined,
+    extended_address: addr.address_2 || undefined,
+    address_locality: addr.city || undefined,
+    address_region: addr.province || undefined,
+    address_country: addr.country_code || undefined,
+    postal_code: addr.postal_code || undefined,
+    phone_number: addr.phone || undefined,
+  }
+}
+
+export function ucpAddressToMedusa(addr: UcpAddress): MedusaAddress {
+  const country = normalizeCountryCode(addr.address_country) || undefined
+  return {
+    first_name: addr.first_name || undefined,
+    last_name: addr.last_name || undefined,
+    address_1: addr.street_address || undefined,
+    address_2: addr.extended_address || undefined,
+    city: addr.address_locality || undefined,
+    province: addr.address_region || undefined,
+    postal_code: addr.postal_code || undefined,
+    country_code: country,
+    phone: addr.phone_number || undefined,
+  }
+}

--- a/apps/backend/src/api/ucp/lib/cart-fields.ts
+++ b/apps/backend/src/api/ucp/lib/cart-fields.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared cart field constants for query.graph calls.
+ * Ensures consistent data loading across all UCP route handlers.
+ */
+export const CHECKOUT_SESSION_CART_FIELDS = [
+  "id",
+  "region_id",
+  "currency_code",
+  "email",
+  "completed_at",
+  "metadata",
+  "subtotal",
+  "total",
+  "tax_total",
+  "shipping_total",
+  "discount_total",
+  "item_subtotal",
+  "item_total",
+  "items.*",
+  "items.variant.*",
+  "items.variant.product.*",
+  "shipping_address.*",
+  "shipping_methods.*",
+  "payment_collection.*",
+  "payment_collection.payment_sessions.*",
+  "payment_collection.payments.*",
+  "order.id",
+  "order.display_id",
+]
+
+export const CART_VALIDATION_FIELDS = [
+  "id",
+  "email",
+  "completed_at",
+  "metadata",
+  "items.id",
+  "shipping_address.id",
+  "shipping_methods.id",
+  "payment_collection.id",
+  "payment_collection.payment_sessions.*",
+]

--- a/apps/backend/src/api/ucp/lib/context.ts
+++ b/apps/backend/src/api/ucp/lib/context.ts
@@ -1,0 +1,127 @@
+/**
+ * UCP context — resolves publishable key, loopback URL, and store info
+ * for each UCP request. Reuses the MCP store-resolver for multi-tenancy.
+ */
+
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { resolveStorefront, type StorefrontInfo } from "../../mcp/lib/store-resolver"
+
+export type UcpContext = {
+  baseUrl: string
+  publishableKey: string | undefined
+  container: any
+  storeName: string
+  storefrontUrl: string
+}
+
+const PUBLISHABLE_HEADER = "x-publishable-api-key"
+
+export function resolveBaseUrl(req: any): string {
+  const override = process.env.STORE_MCP_LOOPBACK_URL
+  if (override) return override.replace(/\/$/, "")
+  const proto = (req.protocol || "http").split(",")[0].trim()
+  const host = req.get("host")
+  if (host) return `${proto}://${host}`
+  const port = process.env.PORT || "9000"
+  return `http://localhost:${port}`
+}
+
+export function resolvePublicUrl(req: any): string {
+  return process.env.STOREFRONT_URL || `${req.protocol}://${req.get("host")}`
+}
+
+export async function buildUcpContext(req: any): Promise<UcpContext> {
+  const container = req.scope
+  const baseUrl = resolveBaseUrl(req)
+  const storefrontUrl = resolvePublicUrl(req)
+
+  const callerKey =
+    req.get(PUBLISHABLE_HEADER) ||
+    (req as any).publishable_key_context?.key ||
+    undefined
+  const publishableKey = callerKey || process.env.STORE_MCP_DEFAULT_PUBLISHABLE_KEY
+
+  let storeName = process.env.STORE_NAME || "JYT Store"
+  let resolvedStorefrontUrl = storefrontUrl
+
+  // Try to resolve store info for the name/URL
+  try {
+    const info: StorefrontInfo | null = await resolveStorefront(container, "default")
+    if (info) {
+      storeName = info.name || info.store_name || storeName
+      if (info.domain) {
+        resolvedStorefrontUrl = `https://${info.domain}`
+      }
+    }
+  } catch {
+    // Fall back to env defaults
+  }
+
+  return {
+    baseUrl,
+    publishableKey,
+    container,
+    storeName,
+    storefrontUrl: resolvedStorefrontUrl,
+  }
+}
+
+/**
+ * Region resolution — find a region that serves a given country.
+ */
+export async function findRegionForCountry(
+  scope: any,
+  countryCode: string
+): Promise<{ id: string; name: string; currency_code: string } | null> {
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data: regions } = await query.graph({
+    entity: "region",
+    fields: ["id", "name", "currency_code", "countries.iso_2"],
+  })
+
+  for (const region of regions || []) {
+    const codes = (region.countries || []).map((c: any) => c.iso_2?.toLowerCase())
+    if (codes.includes(countryCode.toLowerCase())) {
+      return { id: region.id, name: region.name, currency_code: region.currency_code }
+    }
+  }
+  return null
+}
+
+export async function getSupportedCountries(scope: any): Promise<string[]> {
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data: regions } = await query.graph({
+    entity: "region",
+    fields: ["countries.iso_2"],
+  })
+
+  const set = new Set<string>()
+  for (const region of regions || []) {
+    for (const c of region.countries || []) {
+      if (c.iso_2) set.add(c.iso_2.toLowerCase())
+    }
+  }
+  return Array.from(set).sort()
+}
+
+export async function resolveRegionForAddressUpdate(
+  scope: any,
+  cartId: string,
+  countryCode: string
+): Promise<
+  | { supported: true; regionId: string; shouldSwitch: boolean }
+  | { supported: false; supportedCountries: string[] }
+> {
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY)
+  const [{ data: [cart] }, match] = await Promise.all([
+    query.graph({ entity: "cart", fields: ["id", "region_id"], filters: { id: cartId } }),
+    findRegionForCountry(scope, countryCode),
+  ])
+
+  if (!match) {
+    return { supported: false, supportedCountries: await getSupportedCountries(scope) }
+  }
+
+  const shouldSwitch = cart && cart.region_id !== match.id
+  return { supported: true, regionId: match.id, shouldSwitch }
+}

--- a/apps/backend/src/api/ucp/lib/error-formatter.ts
+++ b/apps/backend/src/api/ucp/lib/error-formatter.ts
@@ -1,0 +1,54 @@
+/**
+ * UCP error response formatter.
+ *
+ * Spec error_response.json:
+ *   { ucp: { version, status: "error" }, messages: [message_error, ...] }
+ *
+ * message_error.json required fields: type, code, content, severity
+ *   severity enum: recoverable | requires_buyer_input | requires_buyer_review | unrecoverable
+ */
+
+export type UcpErrorSeverity =
+  | "recoverable"
+  | "requires_buyer_input"
+  | "requires_buyer_review"
+  | "unrecoverable"
+
+export type UcpErrorResponse = {
+  ucp: {
+    version: string
+    status: "error"
+  }
+  messages: {
+    type: "error"
+    code: string
+    content: string
+    severity: UcpErrorSeverity
+    path?: string
+    content_type?: "plain" | "markdown"
+  }[]
+}
+
+export function formatUcpError(params: {
+  ucpVersion: string
+  code: string
+  content: string
+  severity?: UcpErrorSeverity
+  path?: string
+}): UcpErrorResponse {
+  return {
+    ucp: {
+      version: params.ucpVersion,
+      status: "error",
+    },
+    messages: [
+      {
+        type: "error",
+        code: params.code,
+        content: params.content,
+        severity: params.severity || "unrecoverable",
+        ...(params.path ? { path: params.path } : {}),
+      },
+    ],
+  }
+}

--- a/apps/backend/src/api/ucp/lib/formatter.ts
+++ b/apps/backend/src/api/ucp/lib/formatter.ts
@@ -1,0 +1,319 @@
+/**
+ * UCP Protocol Formatter
+ *
+ * Transforms Medusa internal objects into UCP-compliant response shapes.
+ * Spec: https://github.com/Universal-Commerce-Protocol/ucp
+ */
+
+import { medusaToUcpAddress } from "./address-translator"
+import { resolveUcpStatus, resolveMissingRequirements, type UcpStatus } from "./status-maps"
+import { buildUcpFulfillment } from "./fulfillment"
+import { listShippingOptionsSafe } from "./shipping-options"
+import { paymentNextAction } from "./payment-next-action"
+
+export const UCP_VERSION = "2026-01-11"
+
+export type UcpFormatterContext = {
+  storeName: string
+  storefrontUrl: string
+  baseUrl: string
+}
+
+// =====================================================
+// UCP Envelope
+// =====================================================
+
+function ucpEnvelope(ctx: UcpFormatterContext, cartMetadata?: Record<string, unknown>) {
+  return {
+    version: UCP_VERSION,
+    status: "success" as const,
+    capabilities: {
+      "dev.ucp.shopping.catalog.search": [{ version: UCP_VERSION }],
+      "dev.ucp.shopping.catalog.lookup": [{ version: UCP_VERSION }],
+      "dev.ucp.shopping.checkout": [{ version: UCP_VERSION }],
+      "dev.ucp.shopping.cart": [{ version: UCP_VERSION }],
+      "dev.ucp.shopping.order": [{ version: UCP_VERSION }],
+      "dev.ucp.shopping.fulfillment": [{ version: UCP_VERSION }],
+      "dev.ucp.shopping.discount": [{ version: UCP_VERSION }],
+    },
+  }
+}
+
+// =====================================================
+// Messages
+// =====================================================
+
+type UcpMessage =
+  | { type: "error"; code: string; content: string; severity: string; path?: string }
+  | { type: "info"; code?: string; content: string }
+
+function buildCheckoutMessages(ctx: UcpFormatterContext, cart: any, status: UcpStatus): UcpMessage[] {
+  const messages: UcpMessage[] = []
+
+  if (status === "completed") {
+    messages.push({ type: "info", code: "checkout_completed", content: "Checkout completed successfully." })
+    return messages
+  }
+  if (status === "canceled") {
+    messages.push({ type: "info", code: "checkout_canceled", content: "This checkout session has been canceled." })
+    return messages
+  }
+
+  const missing = resolveMissingRequirements(cart)
+
+  if (missing.includes("items")) {
+    messages.push({
+      type: "error", code: "missing_items",
+      content: "Checkout session has no line items. Add items via PUT /ucp/checkout-sessions/{id}.",
+      severity: "recoverable", path: "$.line_items",
+    })
+  }
+  if (missing.includes("email")) {
+    messages.push({
+      type: "error", code: "missing_email",
+      content: "Buyer email is required. Provide it via PUT /ucp/checkout-sessions/{id} with buyer.email.",
+      severity: "recoverable", path: "$.buyer.email",
+    })
+  }
+  if (missing.includes("shipping_address")) {
+    messages.push({
+      type: "error", code: "missing_shipping_address",
+      content: "Shipping address is required. Provide it via PUT /ucp/checkout-sessions/{id} with shipping_address.",
+      severity: "recoverable", path: "$.shipping_address",
+    })
+  }
+
+  if (status === "ready_for_complete") {
+    messages.push({
+      type: "info", code: "ready_for_complete",
+      content: "Checkout is ready. POST /ucp/checkout-sessions/{id}/complete with payment.instruments[].",
+    })
+  } else if (missing.length === 0) {
+    messages.push({ type: "info", code: "checkout_in_progress", content: `Checkout session for ${ctx.storeName}.` })
+  }
+
+  return messages
+}
+
+// =====================================================
+// Line Items
+// =====================================================
+
+function formatLineItems(items: any[]) {
+  return items.map((item: any) => {
+    const unitAmount = item.unit_price ?? item.raw_unit_price?.value ?? 0
+    return {
+      id: item.id,
+      item: {
+        id: item.variant_id || item.id,
+        title: item.title || item.product_title || "",
+        price: unitAmount,
+      },
+      quantity: item.quantity,
+      totals: [
+        { type: "line_total", display_text: "Line total", amount: unitAmount * item.quantity },
+      ],
+    }
+  })
+}
+
+// =====================================================
+// Totals
+// =====================================================
+
+function computeSubtotal(cart: any): number {
+  const items = cart.items || []
+  if (items.length > 0) {
+    return items.reduce((acc: number, item: any) => {
+      const unit = item.unit_price ?? item.raw_unit_price?.value ?? 0
+      return acc + unit * (item.quantity || 0)
+    }, 0)
+  }
+  return cart.item_subtotal ?? cart.item_total ?? cart.subtotal ?? cart.raw_subtotal?.value ?? 0
+}
+
+function formatTotals(cart: any) {
+  const totals: { type: string; display_text: string; amount: number }[] = []
+
+  totals.push({ type: "subtotal", display_text: "Subtotal", amount: computeSubtotal(cart) })
+
+  const shipping = cart.shipping_total ?? cart.raw_shipping_total?.value ?? 0
+  if (shipping > 0) {
+    totals.push({ type: "fulfillment", display_text: "Shipping", amount: shipping })
+  }
+
+  const tax = cart.tax_total ?? cart.raw_tax_total?.value ?? 0
+  if (tax > 0) {
+    totals.push({ type: "tax", display_text: "Tax", amount: tax })
+  }
+
+  const discount = cart.discount_total ?? cart.raw_discount_total?.value ?? 0
+  if (discount > 0) {
+    totals.push({ type: "discount", display_text: "Discount", amount: -discount })
+  }
+
+  totals.push({ type: "total", display_text: "Total", amount: cart.total ?? cart.raw_total?.value ?? 0 })
+
+  return totals
+}
+
+// =====================================================
+// Checkout Session
+// =====================================================
+
+export async function formatUcpCheckoutSession(
+  ctx: UcpFormatterContext,
+  cart: any,
+  includePaymentHandlers: boolean = true
+) {
+  const currency = (cart.currency_code || "usd").toUpperCase()
+  const status = resolveUcpStatus(cart)
+
+  const createdAt = cart.created_at || cart.metadata?.checkout_session_created_at
+  const expiresAt = createdAt
+    ? new Date(new Date(createdAt as string).getTime() + 6 * 60 * 60 * 1000).toISOString()
+    : undefined
+
+  const shippingOptions = await listShippingOptionsSafe(
+    (cart as any)._container,
+    cart.id
+  )
+
+  const session: Record<string, unknown> = {
+    ucp: ucpEnvelope(ctx, cart.metadata),
+    id: cart.id,
+    status,
+    currency,
+    line_items: formatLineItems(cart.items || []),
+    totals: formatTotals(cart),
+    messages: buildCheckoutMessages(ctx, cart, status),
+    links: [
+      { type: "terms_of_service", url: `${ctx.storefrontUrl}/terms` },
+      { type: "privacy_policy", url: `${ctx.storefrontUrl}/privacy` },
+    ],
+  }
+
+  if (cart.email || cart.shipping_address?.first_name || cart.shipping_address?.phone) {
+    session.buyer = {
+      ...(cart.shipping_address?.first_name ? { first_name: cart.shipping_address.first_name } : {}),
+      ...(cart.shipping_address?.last_name ? { last_name: cart.shipping_address.last_name } : {}),
+      ...(cart.email ? { email: cart.email } : {}),
+      ...(cart.shipping_address?.phone ? { phone_number: cart.shipping_address.phone } : {}),
+    }
+  }
+
+  if (cart.shipping_address?.address_1) {
+    session.shipping_address = medusaToUcpAddress(cart.shipping_address)
+  }
+
+  const fulfillment = buildUcpFulfillment(cart, shippingOptions)
+  if (fulfillment) session.fulfillment = fulfillment
+
+  if (expiresAt) session.expires_at = expiresAt
+
+  return session
+}
+
+// =====================================================
+// Product
+// =====================================================
+
+export function formatUcpProduct(product: any) {
+  const variants = (product.variants || []).map((v: any) => {
+    const price = v.prices?.[0] || v.calculated_price || null
+    const priceAmount = price ? (price.amount ?? price.calculated_amount ?? 0) : null
+    const priceCurrency = price?.currency_code || "usd"
+
+    return {
+      id: v.id,
+      title: v.title || "",
+      sku: v.sku || null,
+      price: priceAmount != null
+        ? { amount: priceAmount, currency: priceCurrency }
+        : null,
+      availability: {
+        available: v.inventory_quantity != null ? v.inventory_quantity > 0 : true,
+        status: v.inventory_quantity != null
+          ? v.inventory_quantity > 0 ? "in_stock" : "out_of_stock"
+          : "in_stock",
+      },
+    }
+  })
+
+  const variantPrices = variants.map((v: any) => v.price?.amount).filter((p: any) => p != null)
+  const priceRange = variantPrices.length > 0
+    ? {
+        min: { amount: Math.min(...variantPrices), currency: variants[0]?.price?.currency || "usd" },
+        max: { amount: Math.max(...variantPrices), currency: variants[0]?.price?.currency || "usd" },
+      }
+    : null
+
+  const media = (product.images || []).map((img: any) => ({ url: img.url, type: "image" as const }))
+  if (product.thumbnail) media.unshift({ url: product.thumbnail, type: "image" as const })
+
+  return {
+    id: product.id,
+    title: product.title || "",
+    description: product.description || "",
+    handle: product.handle || "",
+    categories: (product.categories || []).map((c: any) => c.name),
+    price_range: priceRange,
+    variants,
+    media,
+  }
+}
+
+// =====================================================
+// Order
+// =====================================================
+
+export function formatUcpOrder(ctx: UcpFormatterContext, order: any) {
+  const currency = (order.currency_code || "usd").toUpperCase()
+
+  const lineItems = (order.items || []).map((item: any) => {
+    const unitAmount = item.unit_price ?? item.raw_unit_price?.value ?? 0
+    return {
+      id: item.id,
+      item: {
+        id: item.variant_id || item.variant?.id || item.id,
+        title: item.title || item.product_title || "",
+        price: unitAmount,
+      },
+      quantity: item.quantity,
+      totals: [{ type: "line_total", display_text: "Line total", amount: unitAmount * item.quantity }],
+    }
+  })
+
+  const fulfillmentEvents = (order.fulfillments || []).map((f: any) => ({
+    type: f.shipped_at ? "shipped" : "created",
+    timestamp: f.shipped_at || f.created_at,
+    tracking_number: f.labels?.[0]?.tracking_number || null,
+    carrier: f.provider?.id || null,
+    items: (f.items || []).map((i: any) => ({
+      product_id: i.line_item?.product_id || null,
+      quantity: i.quantity,
+    })),
+  }))
+
+  const result: Record<string, unknown> = {
+    ucp: ucpEnvelope(ctx),
+    id: order.id,
+    display_id: order.display_id || null,
+    checkout_id: order.cart_id || null,
+    permalink_url: `${ctx.storefrontUrl}/orders/${order.id}`,
+    status: order.status || "pending",
+    currency,
+    line_items: lineItems,
+    totals: formatTotals(order),
+    fulfillment_status: order.fulfillment_status || "not_fulfilled",
+    fulfillment_events: fulfillmentEvents,
+    created_at: order.created_at,
+    updated_at: order.updated_at,
+    links: [{ type: "self", url: `${ctx.baseUrl}/ucp/orders/${order.id}` }],
+  }
+
+  if (order.email) result.buyer = { email: order.email }
+  if (order.shipping_address) result.shipping_address = medusaToUcpAddress(order.shipping_address)
+
+  return result
+}

--- a/apps/backend/src/api/ucp/lib/fulfillment.ts
+++ b/apps/backend/src/api/ucp/lib/fulfillment.ts
@@ -1,0 +1,113 @@
+/**
+ * UCP Fulfillment Extension formatter.
+ *
+ * Builds the spec-compliant `fulfillment` object for a UCP checkout session.
+ * Spec: https://ucp.dev/specification/fulfillment/
+ *
+ * Mapping from Medusa v2 → UCP:
+ *   - A cart gets exactly ONE fulfillment_method of type "shipping" covering
+ *     all line items. If/when pickup support is added, a second method of
+ *     type "pickup" can be emitted here.
+ *   - The method contains ONE fulfillment_group holding all line items and
+ *     the list of available shipping options as fulfillment_options.
+ *   - The cart's current shipping_address becomes a single shipping
+ *     destination. The cart's currently selected shipping_method (if any)
+ *     sets selected_option_id on the group.
+ */
+
+import { medusaToUcpAddress } from "./address-translator"
+
+export const UCP_FULFILLMENT_METHOD_SHIPPING_ID = "shipping"
+export const UCP_FULFILLMENT_GROUP_DEFAULT_ID = "default"
+
+type ShippingOption = {
+  id: string
+  name?: string
+  amount?: number
+  provider_id?: string
+  data?: Record<string, unknown>
+}
+
+type ShippingMethod = {
+  id: string
+  shipping_option_id?: string
+  name?: string
+  amount?: number
+}
+
+/**
+ * Build the UCP fulfillment object for a cart.
+ * Returns undefined if the cart has no line items (nothing to fulfill).
+ */
+export function buildUcpFulfillment(
+  cart: any,
+  shippingOptions: ShippingOption[] | undefined
+): { methods: any[] } | undefined {
+  const items: any[] = cart.items || []
+  if (items.length === 0) return undefined
+
+  const lineItemIds: string[] = items.map((i: any) => i.id)
+
+  const destinations: any[] = []
+  let selectedDestinationId: string | null = null
+  if (cart.shipping_address) {
+    const addr = medusaToUcpAddress(cart.shipping_address)
+    const destId = cart.shipping_address.id || "cart_shipping_address"
+    destinations.push({ id: destId, ...addr })
+    selectedDestinationId = destId
+  }
+
+  const options: any[] = (shippingOptions || []).map((opt) => {
+    const amount = opt.amount ?? 0
+    const title = opt.name || "Shipping"
+    const result: Record<string, unknown> = {
+      id: opt.id,
+      title,
+      totals: [{ type: "fulfillment", display_text: title, amount }],
+    }
+    if (opt.provider_id) result.carrier = opt.provider_id
+    return result
+  })
+
+  const selectedMethod: ShippingMethod | undefined = (cart.shipping_methods || [])[0]
+  const selectedOptionId: string | null = selectedMethod?.shipping_option_id || null
+
+  const group: Record<string, unknown> = {
+    id: UCP_FULFILLMENT_GROUP_DEFAULT_ID,
+    line_item_ids: lineItemIds,
+    options,
+    selected_option_id: selectedOptionId,
+  }
+
+  const method: Record<string, unknown> = {
+    id: UCP_FULFILLMENT_METHOD_SHIPPING_ID,
+    type: "shipping",
+    line_item_ids: lineItemIds,
+    destinations,
+    selected_destination_id: selectedDestinationId,
+    groups: [group],
+  }
+
+  return { methods: [method] }
+}
+
+/**
+ * Parse a UCP fulfillment update payload and extract the selected shipping
+ * option id that should be applied to the cart.
+ */
+export function extractSelectedFulfillmentOptionId(
+  fulfillment: unknown
+): string | undefined {
+  if (!fulfillment || typeof fulfillment !== "object") return undefined
+  const f = fulfillment as any
+  const methods: any[] = Array.isArray(f.methods) ? f.methods : []
+  for (const method of methods) {
+    const groups: any[] = Array.isArray(method?.groups) ? method.groups : []
+    for (const group of groups) {
+      if (typeof group?.selected_option_id === "string" && group.selected_option_id) {
+        return group.selected_option_id
+      }
+    }
+  }
+  return undefined
+}

--- a/apps/backend/src/api/ucp/lib/payment-next-action.ts
+++ b/apps/backend/src/api/ucp/lib/payment-next-action.ts
@@ -1,0 +1,65 @@
+/**
+ * Normalize an initialized payment session into the concrete next step
+ * the client must take, per provider.
+ *
+ * Reused from the MCP registry — kept here as a standalone so UCP routes
+ * can call it without importing the full MCP registry.
+ */
+export function paymentNextAction(session: any): Record<string, any> {
+  const providerId: string = session?.provider_id || ""
+  const d: Record<string, any> = session?.data || {}
+
+  if (providerId.includes("payu")) {
+    return {
+      type: "redirect_form",
+      provider: "payu",
+      provider_id: providerId,
+      description:
+        "POST these fields as application/x-www-form-urlencoded to `url` to open PayU's hosted checkout. Finish with the PayU webhook / payu_complete_payment.",
+      method: "POST",
+      url: d.payment_url ?? null,
+      fields: {
+        key: d.key ?? null,
+        txnid: d.txnid ?? null,
+        amount: d.amount ?? null,
+        productinfo: d.productinfo ?? null,
+        firstname: d.firstname ?? null,
+        email: d.email ?? null,
+        phone: d.phone ?? null,
+        udf1: d.udf1 ?? null,
+        hash: d.hash ?? null,
+      },
+      txnid: d.txnid ?? null,
+      upi_link: d.upi_intent_uri ?? null,
+    }
+  }
+
+  if (providerId.includes("stripe")) {
+    return {
+      type: "client_secret",
+      provider: "stripe",
+      provider_id: providerId,
+      description:
+        "Stripe checkout. Use create_stripe_payment_page for a hosted card page, or hand this client_secret to Stripe.js.",
+      client_secret: d.client_secret ?? null,
+    }
+  }
+
+  return {
+    type: "session_ready",
+    provider_id: providerId || null,
+    description: "Payment session initialized. Once authorized, the cart completes via webhook.",
+  }
+}
+
+/** Find the just-initialized session (by provider_id) on a payment collection. */
+export function pickSession(data: any, providerId: unknown): any {
+  const sessions = data?.payment_collection?.payment_sessions || []
+  const pid = typeof providerId === "string" ? providerId : ""
+  return (
+    sessions.find((s: any) => s?.provider_id === pid) ||
+    sessions.find((s: any) => pid && String(s?.provider_id || "").includes(pid)) ||
+    sessions[sessions.length - 1] ||
+    null
+  )
+}

--- a/apps/backend/src/api/ucp/lib/shipping-options.ts
+++ b/apps/backend/src/api/ucp/lib/shipping-options.ts
@@ -1,0 +1,20 @@
+import { listShippingOptionsForCartWorkflow } from "@medusajs/medusa/core-flows"
+
+/**
+ * List shipping options available for a cart.
+ * Returns an empty array if the cart has no shippable address yet,
+ * if the region has no shipping profiles, or if the workflow fails.
+ */
+export async function listShippingOptionsSafe(
+  container: any,
+  cart_id: string
+): Promise<any[]> {
+  try {
+    const { result } = await listShippingOptionsForCartWorkflow(container).run({
+      input: { cart_id, is_return: false },
+    })
+    return Array.isArray(result) ? result : []
+  } catch {
+    return []
+  }
+}

--- a/apps/backend/src/api/ucp/lib/status-maps.ts
+++ b/apps/backend/src/api/ucp/lib/status-maps.ts
@@ -1,0 +1,32 @@
+/**
+ * UCP status mapping — maps Medusa cart state to UCP spec status values.
+ *
+ * Spec values: incomplete, requires_escalation, ready_for_complete,
+ *              complete_in_progress, completed, canceled
+ */
+
+export type UcpStatus =
+  | "incomplete"
+  | "requires_escalation"
+  | "ready_for_complete"
+  | "complete_in_progress"
+  | "completed"
+  | "canceled"
+
+export function resolveUcpStatus(cart: any): UcpStatus {
+  if (cart.metadata?.checkout_session_canceled) return "canceled"
+  if (cart.completed_at) return "completed"
+  if (cart.payment_collection?.status === "authorized") return "ready_for_complete"
+  if (cart.items?.length > 0 && cart.email && cart.shipping_address?.address_1) return "ready_for_complete"
+  return "incomplete"
+}
+
+export type MissingRequirement = "items" | "email" | "shipping_address"
+
+export function resolveMissingRequirements(cart: any): MissingRequirement[] {
+  const missing: MissingRequirement[] = []
+  if (!cart.items || cart.items.length === 0) missing.push("items")
+  if (!cart.email) missing.push("email")
+  if (!cart.shipping_address?.address_1) missing.push("shipping_address")
+  return missing
+}

--- a/apps/backend/src/api/ucp/orders/[id]/route.ts
+++ b/apps/backend/src/api/ucp/orders/[id]/route.ts
@@ -1,0 +1,56 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { buildUcpContext } from "../../lib/context"
+import { formatUcpOrder, UCP_VERSION } from "../../lib/formatter"
+import { formatUcpError } from "../../lib/error-formatter"
+import { callStoreRoute } from "../../../mcp/lib/proxy"
+
+/**
+ * GET /ucp/orders/:id
+ *
+ * Retrieve an order by id.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const { id } = req.params
+  const ctx = await buildUcpContext(req)
+
+  try {
+    const data = await callStoreRoute({
+      baseUrl: ctx.baseUrl,
+      method: "GET",
+      path: `/store/orders/${id}`,
+      publishableKey: ctx.publishableKey,
+    }) as any
+
+    const order = data?.order || data
+
+    if (!order || !order.id) {
+      res.status(404).json(formatUcpError({
+        ucpVersion: UCP_VERSION,
+        code: "not_found",
+        content: "Order not found",
+      }))
+      return
+    }
+
+    const formatted = formatUcpOrder(
+      { storeName: ctx.storeName, storefrontUrl: ctx.storefrontUrl, baseUrl: ctx.baseUrl },
+      order
+    )
+
+    res.json(formatted)
+  } catch (error: any) {
+    if (error?.status === 404) {
+      res.status(404).json(formatUcpError({
+        ucpVersion: UCP_VERSION,
+        code: "not_found",
+        content: "Order not found",
+      }))
+      return
+    }
+    res.status(500).json(formatUcpError({
+      ucpVersion: UCP_VERSION,
+      code: "internal_error",
+      content: error.message,
+    }))
+  }
+}

--- a/apps/backend/src/api/ucp/validators.ts
+++ b/apps/backend/src/api/ucp/validators.ts
@@ -1,0 +1,111 @@
+import { z } from "@medusajs/framework/zod"
+
+// UCP address format — per spec postal_address.json.
+const UcpAddressSchema = z.object({
+  first_name: z.string().optional(),
+  last_name: z.string().optional(),
+  street_address: z.string(),
+  extended_address: z.string().optional(),
+  address_locality: z.string(),
+  address_region: z.string().optional(),
+  address_country: z.string().min(2),
+  postal_code: z.string(),
+  phone_number: z.string().optional(),
+})
+
+const UcpBuyerSchema = z.object({
+  first_name: z.string().optional(),
+  last_name: z.string().optional(),
+  email: z.string().email().optional(),
+  phone_number: z.string().optional(),
+  full_name: z.string().optional(),
+})
+
+export const CreateUcpCheckoutSessionSchema = z.object({
+  line_items: z.array(z.object({
+    item: z.object({ id: z.string(), title: z.string().optional() }),
+    quantity: z.number().int().positive(),
+  })).min(1),
+  context: z.object({
+    address_country: z.string().optional(),
+    address_region: z.string().optional(),
+    postal_code: z.string().optional(),
+    currency: z.string().optional(),
+    region_id: z.string().optional(),
+    language: z.string().optional(),
+  }).optional(),
+  buyer: UcpBuyerSchema.optional(),
+  shipping_address: UcpAddressSchema.optional(),
+  payment: z.object({
+    instruments: z.array(z.any()).optional(),
+    handlers: z.array(z.any()).optional(),
+  }).optional(),
+  discounts: z.object({
+    codes: z.array(z.string()).optional(),
+  }).optional(),
+})
+
+const UcpFulfillmentGroupUpdateSchema = z.object({
+  id: z.string().optional(),
+  selected_option_id: z.string().nullable().optional(),
+}).passthrough()
+
+const UcpFulfillmentMethodUpdateSchema = z.object({
+  id: z.string().optional(),
+  type: z.enum(["shipping", "pickup"]).optional(),
+  selected_destination_id: z.string().nullable().optional(),
+  groups: z.array(UcpFulfillmentGroupUpdateSchema).optional(),
+}).passthrough()
+
+const UcpFulfillmentUpdateSchema = z.object({
+  methods: z.array(UcpFulfillmentMethodUpdateSchema).optional(),
+}).passthrough()
+
+export const UpdateUcpCheckoutSessionSchema = z.object({
+  line_items: z.array(z.object({
+    item: z.object({ id: z.string() }).optional(),
+    line_item_id: z.string().optional(),
+    quantity: z.number().int().min(0),
+  })).optional(),
+  buyer: UcpBuyerSchema.optional(),
+  shipping_address: UcpAddressSchema.optional(),
+  fulfillment: UcpFulfillmentUpdateSchema.optional(),
+  discounts: z.object({
+    codes: z.array(z.string()).optional(),
+  }).optional(),
+  context: z.object({
+    currency: z.string().optional(),
+    region_id: z.string().optional(),
+  }).optional(),
+})
+
+export const CompleteUcpCheckoutSessionSchema = z.object({
+  payment: z.object({
+    instruments: z.array(z.object({
+      id: z.string().optional(),
+      handler_id: z.string().optional(),
+      type: z.string().optional(),
+      credential: z.record(z.string(), z.unknown()).optional(),
+    })).optional(),
+    handlers: z.array(z.any()).optional(),
+  }).optional(),
+  buyer: UcpBuyerSchema.optional(),
+})
+
+export const CatalogSearchSchema = z.object({
+  query: z.string().optional(),
+  filters: z.object({
+    category: z.string().optional(),
+    collection: z.string().optional(),
+    min_price: z.number().optional(),
+    max_price: z.number().optional(),
+  }).optional(),
+  pagination: z.object({
+    limit: z.number().int().positive().max(100).optional().default(20),
+    offset: z.number().int().min(0).optional().default(0),
+  }).optional(),
+})
+
+export const CatalogLookupSchema = z.object({
+  ids: z.array(z.string()).min(1),
+})

--- a/apps/backend/src/api/well-known/ucp/route.ts
+++ b/apps/backend/src/api/well-known/ucp/route.ts
@@ -1,0 +1,78 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { resolveBaseUrl, resolvePublicUrl } from "../../ucp/lib/context"
+import { UCP_VERSION } from "../../ucp/lib/formatter"
+
+/**
+ * GET /.well-known/ucp
+ *
+ * UCP discovery manifest. Tells agents what services and capabilities
+ * this business supports, and where the API lives.
+ *
+ * NOTE: Medusa's file-based router ignores directories starting with ".",
+ * so this file exists for reference but the actual route is registered
+ * via defineMiddlewares in src/api/middlewares.ts.
+ */
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const baseUrl = resolveBaseUrl(req)
+  const storefrontUrl = resolvePublicUrl(req)
+
+  const paymentHandlers = [
+    {
+      id: "payu",
+      name: "dev.jyt.payu",
+      version: UCP_VERSION,
+      spec: "https://ucp.dev/specs/mock",
+      config_schema: "https://ucp.dev/schemas/mock.json",
+      instrument_schemas: [
+        "https://ucp.dev/schemas/shopping/types/card_payment_instrument.json",
+      ],
+      config: {
+        description: "PayU — INR payments (cards, UPI, netbanking). Redirect-flow gateway.",
+        currencies: ["inr"],
+      },
+    },
+    {
+      id: "stripe",
+      name: "dev.jyt.stripe",
+      version: UCP_VERSION,
+      spec: "https://ucp.dev/specs/mock",
+      config_schema: "https://ucp.dev/schemas/mock.json",
+      instrument_schemas: [
+        "https://ucp.dev/schemas/shopping/types/card_payment_instrument.json",
+      ],
+      config: {
+        description: "Stripe — non-INR payments (cards, Apple/Google Pay). Hosted page or client_secret.",
+        currencies: ["usd", "eur", "gbp", "aud", "cad", "sgd", "aed"],
+      },
+    },
+  ]
+
+  res.json({
+    ucp: {
+      version: UCP_VERSION,
+      services: {
+        "dev.ucp.shopping": [
+          {
+            version: UCP_VERSION,
+            transport: "rest",
+            endpoint: `${baseUrl}/ucp`,
+          },
+        ],
+      },
+      capabilities: {
+        "dev.ucp.shopping.catalog.search": [{ version: UCP_VERSION }],
+        "dev.ucp.shopping.catalog.lookup": [{ version: UCP_VERSION }],
+        "dev.ucp.shopping.checkout": [{ version: UCP_VERSION }],
+        "dev.ucp.shopping.cart": [{ version: UCP_VERSION }],
+        "dev.ucp.shopping.order": [{ version: UCP_VERSION }],
+        "dev.ucp.shopping.fulfillment": [{ version: UCP_VERSION }],
+        "dev.ucp.shopping.discount": [{ version: UCP_VERSION }],
+      },
+      payment_handlers: paymentHandlers,
+    },
+    store: {
+      name: process.env.STORE_NAME || "JYT Store",
+      url: storefrontUrl,
+    },
+  })
+}


### PR DESCRIPTION
## Summary

Ports the existing MCP store API to the [Universal Commerce Protocol (UCP)](https://github.com/Universal-Commerce-Protocol/ucp) spec, enabling AI agents to discover and interact with the store via a standardized protocol.

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | `/.well-known/ucp` | Discovery manifest (services, capabilities, payment handlers) |
| POST | `/ucp/checkout-sessions` | Create cart with line items, buyer, shipping address |
| GET | `/ucp/checkout-sessions/:id` | Retrieve cart |
| PUT | `/ucp/checkout-sessions/:id` | Update line items, email, address, discounts |
| POST | `/ucp/checkout-sessions/:id/complete` | Initialize payment (PayU/Stripe), return `next_action` |
| POST | `/ucp/catalog/search` | Full-text product search |
| POST | `/ucp/catalog/lookup` | Product lookup by id |
| GET | `/ucp/orders/:id` | Order details with fulfillment events |

## Key Design Decisions

- **UCP checkout session = Medusa cart**, formatted via `formatUcpCheckoutSession()`
- **Async payment flow**: Complete returns `status: complete_in_progress` with `next_action` (PayU redirect URL or Stripe hosted page); agent polls GET until `status: completed`
- **Payment provider selection**: INR → PayU, non-INR → Stripe
- **Reuses MCP infrastructure**: `callStoreRoute` loopback proxy and `resolveStorefront` for multi-tenancy
- **`.well-known/ucp`** registered via middleware (Medusa ignores dot directories in file scanner)

## Bug Fixes (found during testing)

- `shipping_address` check uses `address_1` instead of `id` — Medusa auto-creates empty address records on cart creation
- Orders route returns 404 (not 500) for non-existent orders via `error.status` check

## Test Coverage

19 integration tests covering all endpoints — all passing:
- Discovery manifest
- Header validation (UCP-Agent, Request-Id)
- Checkout session CRUD (create, retrieve, update)
- Checkout complete validation (missing email, missing address)
- Catalog search + lookup
- Order retrieval + 404
- UCP error envelope format