### PR TITLE
docs(ucp): add UCP API reference and developer guide

### DIFF
--- a/apps/docs/docs/reference/intro.md
+++ b/apps/docs/docs/reference/intro.md
@@ -17,3 +17,4 @@ API references, platform-specific details, status reports, and troubleshooting g
 - **[X / Twitter](/docs/reference/x-twitter/implementation-status)** - Implementation status, integration analysis, hashtags
 - **[UI Components](/docs/reference/ui-components/file-modal-enhancement)** - File modal, partner filter views
 - **[Status & Phases](/docs/reference/status/production-status)** - Production status, phase completions, unified workflow
+- **[UCP](/docs/reference/ucp/overview)** - Universal Commerce Protocol API for AI agent integration

--- a/apps/docs/docs/reference/ucp/_category_.json
+++ b/apps/docs/docs/reference/ucp/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "UCP",
+  "position": 8
+}

--- a/apps/docs/docs/reference/ucp/developer-guide.md
+++ b/apps/docs/docs/reference/ucp/developer-guide.md
@@ -1,0 +1,313 @@
+---
+title: "UCP Developer Guide"
+sidebar_label: "Developer Guide"
+sidebar_position: 2
+---
+
+# UCP Developer Guide
+
+A step-by-step guide for integrating an AI agent with the JYT store via UCP.
+
+## Quick Start
+
+### 1. Discover the store
+
+```bash
+curl https://api.jyt.com/.well-known/ucp
+```
+
+The response tells you what services and payment handlers are available. No headers required.
+
+### 2. Search the catalog
+
+```bash
+curl -X POST https://api.jyt.com/ucp/catalog/search \
+  -H "Content-Type: application/json" \
+  -H "UCP-Agent: profile=\"https://my-agent.example/profile\"" \
+  -H "Request-Id: req-$(uuidgen)" \
+  -H "x-publishable-api-key: pk_..." \
+  -d '{ "query": "cotton shirt", "pagination": { "limit": 5 } }'
+```
+
+### 3. Create a checkout session
+
+```bash
+curl -X POST https://api.jyt.com/ucp/checkout-sessions \
+  -H "Content-Type: application/json" \
+  -H "UCP-Agent: profile=\"https://my-agent.example/profile\"" \
+  -H "Request-Id: req-$(uuidgen)" \
+  -H "x-publishable-api-key: pk_..." \
+  -d '{
+    "line_items": [{ "item": { "id": "variant_01JXY..." }, "quantity": 1 }],
+    "buyer": { "email": "customer@example.com" },
+    "context": { "currency": "usd" }
+  }'
+```
+
+The response includes:
+- `id` — the session ID (use for all subsequent calls)
+- `status` — `incomplete` (items + email, no address yet)
+- `messages` — guidance on what's missing
+
+### 4. Add a shipping address
+
+```bash
+curl -X PUT https://api.jyt.com/ucp/checkout-sessions/sess_01JXY... \
+  -H "Content-Type: application/json" \
+  -H "UCP-Agent: profile=\"https://my-agent.example/profile\"" \
+  -H "Request-Id: req-$(uuidgen)" \
+  -H "x-publishable-api-key: pk_..." \
+  -d '{
+    "shipping_address": {
+      "first_name": "Asha",
+      "last_name": "Patel",
+      "street_address": "123 Hill Rd",
+      "address_locality": "Mumbai",
+      "address_region": "MH",
+      "address_country": "in",
+      "postal_code": "400001",
+      "phone_number": "+919876543210"
+    }
+  }'
+```
+
+After this, `status` becomes `ready_for_complete`.
+
+### 5. Complete checkout
+
+```bash
+curl -X POST https://api.jyt.com/ucp/checkout-sessions/sess_01JXY.../complete \
+  -H "Content-Type: application/json" \
+  -H "UCP-Agent: profile=\"https://my-agent.example/profile\"" \
+  -H "Request-Id: req-$(uuidgen)" \
+  -H "x-publishable-api-key: pk_..." \
+  -d '{ "payment": { "instruments": [{ "handler_id": "payu" }] } }'
+```
+
+The response includes a `payment.next_action`:
+
+```json
+{
+  "status": "complete_in_progress",
+  "payment": {
+    "handler_id": "payu",
+    "next_action": {
+      "type": "redirect",
+      "url": "https://secure.payu.in/_payment",
+      "description": "PayU hosted payment page..."
+    }
+  }
+}
+```
+
+### 6. Poll for completion
+
+```bash
+# Poll every 2-5 seconds
+curl https://api.jyt.com/ucp/checkout-sessions/sess_01JXY... \
+  -H "UCP-Agent: profile=\"https://my-agent.example/profile\"" \
+  -H "Request-Id: req-$(uuidgen)" \
+  -H "x-publishable-api-key: pk_..."
+```
+
+When `status` becomes `"completed"`, the response includes an order link.
+
+### 7. Retrieve the order
+
+```bash
+curl https://api.jyt.com/ucp/orders/order_01JXY... \
+  -H "UCP-Agent: profile=\"https://my-agent.example/profile\"" \
+  -H "Request-Id: req-$(uuidgen)" \
+  -H "x-publishable-api-key: pk_..."
+```
+
+---
+
+## Session Status Lifecycle
+
+```
+                    ┌─────────────┐
+         create ──▶ │  incomplete  │
+                    └──────┬──────┘
+                           │
+                    add items + email + address
+                           │
+                    ┌──────▼──────────────┐
+                    │  ready_for_complete  │
+                    └──────┬──────────────┘
+                           │
+                    POST /complete
+                           │
+                    ┌──────▼───────────────────┐
+                    │  complete_in_progress     │
+                    │  (payment pending)        │
+                    └──────┬─────────┬──────────┘
+                           │         │
+                     payment        payment
+                     succeeds       fails/expires
+                           │         │
+                    ┌──────▼──┐  ┌──▼──────────┐
+                    │ completed│  │  incomplete  │
+                    └─────────┘  └──────────────┘
+```
+
+| Status | Meaning | Agent action |
+|--------|---------|-------------|
+| `incomplete` | Missing items, email, or address | Add via PUT |
+| `ready_for_complete` | All prerequisites met | POST /complete |
+| `complete_in_progress` | Payment initialized, waiting | Poll GET until terminal |
+| `completed` | Order created | Retrieve order via GET /ucp/orders/:id |
+| `canceled` | Session canceled | No further action |
+
+---
+
+## Region Resolution
+
+The UCP API automatically resolves regions based on the shipping address country:
+
+1. If `context.region_id` is provided, it's used directly
+2. If only a shipping address is provided, the system searches for a region whose country list includes `address_country`
+3. Country codes are normalized — accepts alpha-2 (`us`), alpha-3 (`usa`), and full names (`United States`)
+4. If no matching region exists, returns a `country_not_supported` error listing supported countries
+
+---
+
+## Address Translation
+
+UCP uses schema.org-style address fields. These are translated to/from Medusa's internal format:
+
+| UCP field | Medusa field |
+|-----------|-------------|
+| `street_address` | `address_1` |
+| `address_locality` | `city` |
+| `address_region` | `province` |
+| `address_country` | `country_code` |
+| `postal_code` | `postal_code` |
+| `phone_number` | `phone` |
+
+---
+
+## Payment Flows
+
+### PayU (INR)
+
+1. Agent calls `POST /complete` with `handler_id: "payu"`
+2. Backend creates a payment collection and initializes a PayU session
+3. Response includes `next_action.type: "redirect"` with a PayU payment URL
+4. Shopper pays on PayU's hosted page (cards, UPI, netbanking)
+5. PayU webhook completes the cart → order is created
+6. Agent polls GET until `status: "completed"`
+
+### Stripe (non-INR)
+
+1. Agent calls `POST /complete` with `handler_id: "stripe"`
+2. Backend creates a payment collection and initializes a Stripe session
+3. Response includes either:
+   - `next_action.type: "redirect"` with a Stripe hosted card page URL (preferred)
+   - `next_action.type: "client_secret"` with a Stripe client secret (fallback)
+4. Shopper pays on Stripe's hosted page
+5. Stripe webhook completes the cart → order is created
+6. Agent polls GET until `status: "completed"`
+
+---
+
+## TypeScript Integration
+
+### Types
+
+```typescript
+interface UcpCheckoutSession {
+  ucp: { version: string; status: "success" }
+  id: string
+  status: "incomplete" | "ready_for_complete" | "complete_in_progress" | "completed" | "canceled"
+  currency: string
+  line_items: UcpLineItem[]
+  totals: UcpTotal[]
+  buyer?: { email?: string; first_name?: string; last_name?: string; phone_number?: string }
+  shipping_address?: UcpAddress
+  fulfillment?: UcpFulfillment
+  messages: UcpMessage[]
+  links: UcpLink[]
+}
+
+interface UcpError {
+  ucp: { version: string; status: "error" }
+  messages: Array<{
+    type: "error"
+    code: string
+    content: string
+    severity: "recoverable" | "fatal"
+    path?: string
+  }>
+}
+```
+
+### Minimal client
+
+```typescript
+const UCP_BASE = "https://api.jyt.com"
+const HEADERS = {
+  "Content-Type": "application/json",
+  "UCP-Agent": 'profile="https://my-agent.example/profile"',
+  "x-publishable-api-key": process.env.JYT_PUBLISHABLE_KEY!,
+}
+
+async function ucpRequest(path: string, body?: unknown) {
+  const res = await fetch(`${UCP_BASE}${path}`, {
+    method: body ? "POST" : "GET",
+    headers: { ...HEADERS, "Request-Id": crypto.randomUUID() },
+    body: body ? JSON.stringify(body) : undefined,
+  })
+  return res.json()
+}
+
+// Create session
+const session = await ucpRequest("/ucp/checkout-sessions", {
+  line_items: [{ item: { id: variantId }, quantity: 1 }],
+  buyer: { email: "customer@example.com" },
+})
+
+// Add address
+await ucpRequest(`/ucp/checkout-sessions/${session.id}`, {
+  shipping_address: {
+    street_address: "123 Main St",
+    address_locality: "New York",
+    address_country: "us",
+    postal_code: "10001",
+  },
+})
+
+// Complete
+const completed = await ucpRequest(`/ucp/checkout-sessions/${session.id}/complete`, {
+  payment: { instruments: [{ handler_id: "stripe" }] },
+})
+
+// Redirect shopper to completed.payment.next_action.url
+// Then poll:
+const poll = await ucpRequest(`/ucp/checkout-sessions/${session.id}`)
+if (poll.status === "completed") {
+  const order = await ucpRequest(`/ucp/orders/${poll.order_id}`)
+  console.log("Order created:", order.display_id)
+}
+```
+
+---
+
+## Testing
+
+Integration tests are at `integration-tests/http/ucp/ucp-checkout.spec.ts` (19 tests, all passing).
+
+```bash
+# Run UCP tests
+TEST_TYPE=integration:http NODE_OPTIONS="--experimental-vm-modules" \
+  npx jest --testPathPattern="ucp/ucp-checkout" --runInBand
+```
+
+The test suite covers:
+- Discovery manifest
+- Header validation (missing UCP-Agent / Request-Id)
+- Checkout session CRUD (create, retrieve, update)
+- Checkout complete validation (missing email, missing address)
+- Catalog search + lookup
+- Order retrieval + 404 handling
+- UCP error envelope format

--- a/apps/docs/docs/reference/ucp/endpoints.md
+++ b/apps/docs/docs/reference/ucp/endpoints.md
@@ -1,0 +1,444 @@
+---
+title: "UCP Endpoints"
+sidebar_label: "Endpoints"
+sidebar_position: 1
+---
+
+# UCP Endpoint Reference
+
+## Discovery
+
+### `GET /.well-known/ucp`
+
+Returns the UCP discovery manifest describing the store's services, capabilities, and supported payment handlers.
+
+**Headers:** None required.
+
+**Response:**
+
+```json
+{
+  "ucp": {
+    "version": "2026-01-11",
+    "status": "success",
+    "services": {
+      "dev.ucp.shopping": [
+        {
+          "transport": "rest",
+          "endpoint": "https://api.jyt.com/ucp"
+        }
+      ]
+    },
+    "capabilities": {
+      "dev.ucp.shopping.checkout": [{ "version": "2026-01-11" }],
+      "dev.ucp.shopping.cart": [{ "version": "2026-01-11" }],
+      "dev.ucp.shopping.order": [{ "version": "2026-01-11" }],
+      "dev.ucp.shopping.fulfillment": [{ "version": "2026-01-11" }]
+    },
+    "payment_handlers": [
+      { "id": "payu", "name": "PayU", "currencies": ["inr"] },
+      { "id": "stripe", "name": "Stripe", "currencies": ["usd", "eur", "gbp"] }
+    ]
+  }
+}
+```
+
+---
+
+## Checkout Sessions
+
+### `POST /ucp/checkout-sessions`
+
+Creates a new checkout session (Medusa cart) with line items, buyer info, and optional shipping address.
+
+**Request body:**
+
+```typescript
+{
+  line_items: Array<{
+    item: { id: string }       // variant ID
+    quantity: number
+  }>
+  buyer?: {
+    email?: string
+    first_name?: string
+    last_name?: string
+    full_name?: string
+    phone_number?: string
+  }
+  shipping_address?: UcpAddress
+  context?: {
+    region_id?: string
+    currency?: string          // ISO 4217 code, e.g. "usd", "inr"
+  }
+  discounts?: {
+    codes?: string[]
+  }
+}
+```
+
+**Response (201):**
+
+```typescript
+{
+  ucp: { version: "2026-01-11", status: "success" }
+  id: string                    // cart ID
+  status: "incomplete" | "ready_for_complete"
+  currency: string              // e.g. "USD"
+  line_items: UcpLineItem[]
+  totals: UcpTotal[]
+  buyer?: { email?: string, first_name?: string, ... }
+  shipping_address?: UcpAddress
+  fulfillment?: UcpFulfillment
+  messages: UcpMessage[]
+  links: UcpLink[]
+}
+```
+
+**Example:**
+
+```bash
+curl -X POST https://api.jyt.com/ucp/checkout-sessions \
+  -H "Content-Type: application/json" \
+  -H "UCP-Agent: profile=\"https://agent.example/profile\"" \
+  -H "Request-Id: req-001" \
+  -H "x-publishable-api-key: pk_..." \
+  -d '{
+    "line_items": [{ "item": { "id": "variant_01..." }, "quantity": 2 }],
+    "buyer": { "email": "buyer@example.com" },
+    "context": { "region_id": "reg_01..." }
+  }'
+```
+
+---
+
+### `GET /ucp/checkout-sessions/:id`
+
+Retrieves a checkout session by ID.
+
+**Response (200):** Same shape as POST response.
+
+**Errors:**
+
+| Status | Code | Description |
+|--------|------|-------------|
+| 404 | `not_found` | Session does not exist |
+
+---
+
+### `PUT /ucp/checkout-sessions/:id`
+
+Updates an existing checkout session. Supports partial updates — only provided fields are modified.
+
+**Request body (all optional):**
+
+```typescript
+{
+  buyer?: { email?: string, first_name?: string, last_name?: string, ... }
+  shipping_address?: UcpAddress
+  line_items?: Array<{
+    line_item_id?: string       // existing item to update
+    item?: { id: string }       // new item to add
+    quantity: number
+  }>
+  fulfillment_option_id?: string
+  discounts?: { codes?: string[] }
+}
+```
+
+**Response (200):** Updated session.
+
+**Notes:**
+- If `shipping_address` changes the country, the cart's region is automatically switched to a matching region.
+- Providing `line_item_id` updates an existing line item's quantity; providing `item.id` adds a new line item.
+
+---
+
+### `POST /ucp/checkout-sessions/:id/complete`
+
+Initiates payment for a checkout session. Returns a `next_action` the agent/shopper must take to complete payment.
+
+**Prerequisites:**
+- At least one line item
+- Buyer email set
+- Shipping address with `address_1` (not just an auto-created empty record)
+
+**Request body:**
+
+```typescript
+{
+  payment: {
+    instruments: Array<{
+      handler_id: string        // "payu" or "stripe"
+      instrument?: {
+        token?: string          // optional payment instrument token
+      }
+    }>
+  }
+}
+```
+
+**Response (200):**
+
+```typescript
+{
+  ucp: { version: "2026-01-11", status: "success" }
+  id: string
+  status: "complete_in_progress"
+  payment: {
+    handler_id: "payu" | "stripe"
+    provider_id: string         // e.g. "pp_payu_payu"
+    next_action: {
+      type: "redirect" | "client_secret"
+      url?: string              // for redirect type
+      client_secret?: string    // for client_secret type
+      description: string
+    }
+    description: string
+  }
+  ...
+}
+```
+
+**Payment provider selection:**
+
+| Cart currency | Provider | Handler ID | Next action |
+|---------------|----------|------------|-------------|
+| INR | PayU | `payu` | Redirect to PayU hosted page |
+| Non-INR | Stripe | `stripe` | Redirect to Stripe hosted card page (falls back to `client_secret`) |
+
+**After completion:** Poll `GET /ucp/checkout-sessions/:id` until `status` changes to `"completed"`. The response will include an `order` link.
+
+**Errors:**
+
+| Status | Code | Description |
+|--------|------|-------------|
+| 400 | `missing_items` | No line items in cart |
+| 400 | `missing_email` | Buyer email not set |
+| 400 | `missing_shipping_address` | No shipping address with street |
+| 404 | `not_found` | Session does not exist |
+| 500 | `payment_setup_failed` | Could not create payment collection |
+| 500 | `payment_session_failed` | Payment provider rejected session init |
+
+---
+
+## Catalog
+
+### `POST /ucp/catalog/search`
+
+Full-text search of the storefront catalog.
+
+**Request body:**
+
+```typescript
+{
+  query?: string                // full-text search
+  filters?: {
+    category?: string           // category ID
+    collection?: string         // collection ID
+  }
+  pagination?: {
+    limit?: number              // default 20
+    offset?: number             // default 0
+  }
+}
+```
+
+**Response (200):**
+
+```typescript
+{
+  ucp: { version: "2026-01-11", status: "success" }
+  products: UcpProduct[]
+  count: number
+  offset: number
+  limit: number
+}
+```
+
+---
+
+### `POST /ucp/catalog/lookup`
+
+Retrieve specific products by ID.
+
+**Request body:**
+
+```typescript
+{
+  ids: string[]                 // product IDs
+}
+```
+
+**Response (200):** Same as search, but filtered to requested IDs.
+
+---
+
+## Orders
+
+### `GET /ucp/orders/:id`
+
+Retrieve an order by ID. Includes fulfillment events and tracking info.
+
+**Response (200):**
+
+```typescript
+{
+  ucp: { version: "2026-01-11", status: "success" }
+  id: string
+  display_id: string | null
+  checkout_id: string | null     // original cart ID
+  status: string                 // e.g. "completed", "pending"
+  currency: string
+  line_items: UcpLineItem[]
+  totals: UcpTotal[]
+  fulfillment_status: string
+  fulfillment_events: Array<{
+    type: "shipped" | "created"
+    timestamp: string
+    tracking_number: string | null
+    carrier: string | null
+    items: Array<{ product_id: string, quantity: number }>
+  }>
+  buyer?: { email: string }
+  shipping_address?: UcpAddress
+  links: UcpLink[]
+}
+```
+
+**Errors:**
+
+| Status | Code | Description |
+|--------|------|-------------|
+| 404 | `not_found` | Order does not exist |
+
+---
+
+## Types
+
+### UcpAddress
+
+```typescript
+{
+  first_name?: string
+  last_name?: string
+  street_address: string          // maps to Medusa address_1
+  address_locality: string        // maps to Medusa city
+  address_region?: string         // maps to Medusa province
+  address_country: string         // ISO 3166 alpha-2/alpha-3/full name
+  postal_code?: string
+  phone_number?: string
+}
+```
+
+Country code normalization handles:
+- Alpha-2: `us`, `in`, `gb`
+- Alpha-3: `usa`, `ind`, `gbr`
+- Full names: `United States`, `India`, `United Kingdom`
+
+### UcpLineItem
+
+```typescript
+{
+  id: string
+  item: {
+    id: string                    // variant ID
+    title: string
+    price: number
+  }
+  quantity: number
+  totals: Array<{ type: "line_total", display_text: string, amount: number }>
+}
+```
+
+### UcpTotal
+
+```typescript
+{
+  type: "subtotal" | "fulfillment" | "tax" | "discount" | "total"
+  display_text: string
+  amount: number
+}
+```
+
+### UcpMessage
+
+```typescript
+// Error message
+{
+  type: "error"
+  code: string                    // e.g. "missing_email", "missing_shipping_address"
+  content: string
+  severity: "recoverable" | "fatal"
+  path?: string                   // JSON pointer, e.g. "$.buyer.email"
+}
+
+// Info message
+{
+  type: "info"
+  code?: string
+  content: string
+}
+```
+
+### UcpProduct
+
+```typescript
+{
+  id: string
+  title: string
+  description: string
+  handle: string
+  categories: string[]
+  price_range: {
+    min: { amount: number, currency: string }
+    max: { amount: number, currency: string }
+  } | null
+  variants: Array<{
+    id: string
+    title: string
+    sku: string | null
+    price: { amount: number, currency: string } | null
+    availability: {
+      available: boolean
+      status: "in_stock" | "out_of_stock"
+    }
+  }>
+  media: Array<{ url: string, type: "image" }>
+}
+```
+
+---
+
+## Error Envelope
+
+All errors follow a consistent shape:
+
+```json
+{
+  "ucp": {
+    "version": "2026-01-11",
+    "status": "error"
+  },
+  "messages": [
+    {
+      "type": "error",
+      "code": "not_found",
+      "content": "Checkout session not found",
+      "severity": "fatal"
+    }
+  ]
+}
+```
+
+| Code | HTTP Status | Severity | Description |
+|------|-------------|----------|-------------|
+| `not_found` | 404 | fatal | Resource does not exist |
+| `missing_items` | 400 | recoverable | Cart has no line items |
+| `missing_email` | 400 | recoverable | Buyer email not set |
+| `missing_shipping_address` | 400 | recoverable | No shipping address |
+| `country_not_supported` | 400 | recoverable | Country not in any region |
+| `payment_setup_failed` | 500 | fatal | Payment collection creation failed |
+| `payment_session_failed` | 500 | fatal | Payment session init failed |
+| `checkout_failed` | 500 | fatal | General checkout error |
+| `internal_error` | 500 | fatal | Unhandled error |

--- a/apps/docs/docs/reference/ucp/overview.md
+++ b/apps/docs/docs/reference/ucp/overview.md
@@ -1,0 +1,96 @@
+---
+title: "Universal Commerce Protocol (UCP)"
+sidebar_label: "Overview"
+sidebar_position: 0
+---
+
+# Universal Commerce Protocol (UCP)
+
+The JYT Commerce API exposes a **Universal Commerce Protocol (UCP)** surface that lets AI agents discover and interact with the store through a standardized, spec-compliant REST API. UCP abstracts away Medusa-specific cart semantics and gives agents a uniform checkout flow: discover → search → create session → update → complete → poll.
+
+## Why UCP?
+
+Traditional store APIs are designed for human-operated frontends. AI agents need:
+
+- **Self-discovery** — a well-known endpoint that describes what the store can do
+- **Standardized error envelopes** — structured `{ ucp, messages }` format, not raw HTTP errors
+- **Status-driven sessions** — explicit `incomplete → ready_for_complete → complete_in_progress → completed` lifecycle
+- **Payment next-actions** — agents receive a `next_action` (redirect URL or client secret) instead of having to reverse-engineer provider flows
+
+## Architecture
+
+```
+AI Agent
+  │
+  ▼
+GET /.well-known/ucp          ← Discovery manifest
+  │
+  ▼
+POST /ucp/catalog/search      ← Find products
+POST /ucp/catalog/lookup      ← Get product details
+  │
+  ▼
+POST /ucp/checkout-sessions   ← Create cart (session)
+GET  /ucp/checkout-sessions/:id
+PUT  /ucp/checkout-sessions/:id
+  │
+  ▼
+POST /ucp/checkout-sessions/:id/complete  ← Initialize payment
+  │                                            Returns next_action
+  ▼
+GET /ucp/checkout-sessions/:id  ← Poll until status = "completed"
+  │
+  ▼
+GET /ucp/orders/:id            ← Retrieve order
+```
+
+## Key Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| UCP checkout session = Medusa cart | No duplicate state; leverages Medusa's cart engine |
+| Async payment flow | PayU/Stripe payments are redirect-based; agent polls until completion |
+| Reuses MCP loopback proxy | `callStoreRoute` forwards to `/store/*` routes, inheriting all middleware (publishable-key scoping, pricing, tax) |
+| `.well-known/ucp` via middleware | Medusa's file scanner ignores dot-directories; registered as inline handler in `defineMiddlewares` |
+| INR → PayU, non-INR → Stripe | Currency-based provider selection |
+
+## Protocol Version
+
+Current UCP version: **`2026-01-11`**
+
+All responses include a `ucp` envelope:
+
+```json
+{
+  "ucp": {
+    "version": "2026-01-11",
+    "status": "success"
+  },
+  ...
+}
+```
+
+## Required Headers
+
+All `/ucp/*` routes (except `/.well-known/ucp`) require:
+
+| Header | Description |
+|--------|-------------|
+| `UCP-Agent` | Agent identifier, e.g. `profile="https://agent.example/profile"` |
+| `Request-Id` | Unique request ID for tracing |
+| `x-publishable-api-key` | Medusa publishable API key for sales-channel scoping |
+
+## Source Files
+
+| File | Purpose |
+|------|---------|
+| `src/api/ucp/lib/context.ts` | Publishable key resolution, region matching, loopback URL |
+| `src/api/ucp/lib/formatter.ts` | Medusa cart → UCP checkout session transformation |
+| `src/api/ucp/lib/status-maps.ts` | Cart state → UCP status mapping |
+| `src/api/ucp/lib/address-translator.ts` | UCP ↔ Medusa address translation + country code normalization |
+| `src/api/ucp/lib/error-formatter.ts` | UCP spec-compliant error envelope |
+| `src/api/ucp/lib/fulfillment.ts` | Fulfillment methods, groups, and shipping options |
+| `src/api/ucp/lib/payment-next-action.ts` | Payment session → next action (redirect URL / client secret) |
+| `src/api/ucp/lib/cart-fields.ts` | Cart field constants for `query.graph` |
+| `src/api/ucp/lib/shipping-options.ts` | Safe wrapper around `listShippingOptionsForCartWorkflow` |
+| `src/api/ucp/validators.ts` | Zod schemas for all UCP request bodies |


### PR DESCRIPTION
## Summary

Adds Docusaurus documentation for the UCP (Universal Commerce Protocol) API shipped in #905.

## Pages

| Page | Content |
|------|---------|
| **[Overview](/docs/reference/ucp/overview)** | Architecture diagram, design decisions, protocol version, required headers, source file map |
| **[Endpoints](/docs/reference/ucp/endpoints)** | Full reference for all 8 UCP endpoints — request/response schemas, error codes, TypeScript types |
| **[Developer Guide](/docs/reference/ucp/developer-guide)** | Quick start with curl examples, session status lifecycle diagram, PayU/Stripe payment flow walkthroughs, minimal TypeScript client |

## Changes

- New  directory with , 3 markdown files
- Added UCP entry to  category list
- Docusaurus build passes (no new broken links/anchors)

## Sidebar

Auto-appears under the **Reference** sidebar (autogenerated) — no  changes needed.