### PR TITLE
fix(storefront): force corepack (pnpm 10) on Vercel

### DIFF
--- a/apps/storefront/vercel.json
+++ b/apps/storefront/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "corepack enable && pnpm install --frozen-lockfile"
+}


### PR DESCRIPTION
Fixes the Vercel storefront build failing with:

```
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  ... "packageExtensionsChecksum" ... doesn't match
```

**Cause:** Vercel defaulted to `pnpm@9.x` ("based on project creation date") while the lockfile's `packageExtensionsChecksum` (from `pnpm.packageExtensions`) was written by `pnpm@10.30.2`. The checksum is pnpm-version-sensitive, so the frozen install fails under pnpm 9.

**Fix:** `apps/storefront/vercel.json` overrides `installCommand` to `corepack enable && pnpm install --frozen-lockfile`, activating the root `packageManager: pnpm@10.30.2` so Vercel installs with pnpm 10 and the checksum matches.

If Vercel's build image blocks `corepack enable`, the equivalent alternative is setting the project env var `ENABLE_EXPERIMENTAL_COREPACK=1` in Vercel settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)