### PR TITLE
fix(storefront): scope Vercel install to @jyt/storefront + drop frozen check

### DIFF
--- a/apps/storefront/vercel.json
+++ b/apps/storefront/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "installCommand": "corepack enable && pnpm install --frozen-lockfile"
+  "installCommand": "pnpm install --no-frozen-lockfile --filter @jyt/storefront..."
 }


### PR DESCRIPTION
Supersedes the corepack attempt (#910) which didn't work — Vercel kept resolving `pnpm@9.x` for the frozen install, so the `pnpm@10`-written `packageExtensionsChecksum` still failed.

**Fix:** `apps/storefront/vercel.json` install command →
`pnpm install --no-frozen-lockfile --filter @jyt/storefront...`

- `@jyt/storefront` has **no workspace deps**, so `--filter …` installs only its subtree → no more "Scope: all 9 workspace projects" (answers the "focus on just apps/storefront" ask).
- `--no-frozen-lockfile` sidesteps `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` (the freesewing `packageExtensions` are backend-only; the storefront never uses them). This is exactly what the pnpm error message recommends.

**Stricter alternative** (if you'd rather keep frozen installs): set `ENABLE_EXPERIMENTAL_COREPACK=1` in the Vercel project env so it honors root `packageManager: pnpm@10.30.2`. Also worth setting **Root Directory = `apps/storefront`** in the Vercel project to fully scope build/output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)