### PR TITLE
fix(ucp): catalog pricing, dynamic multi-currency & spec conformance

### DIFF
--- a/apps/backend/integration-tests/http/ucp/ucp-checkout.spec.ts
+++ b/apps/backend/integration-tests/http/ucp/ucp-checkout.spec.ts
@@ -21,6 +21,7 @@ setupSharedTestSuite(() => {
     let regionId: string
     let variantId: string
     let productId: string
+    let salesChannelId: string
 
     beforeEach(async () => {
       const container = getContainer()
@@ -43,7 +44,7 @@ setupSharedTestSuite(() => {
       // Link stock location to the default sales channel
       const storeService: any = container.resolve(Modules.STORE)
       const store = (await storeService.listStores({}))?.[0]
-      const salesChannelId = store?.default_sales_channel_id
+      salesChannelId = store?.default_sales_channel_id
 
       try {
         const remoteLink: any = container.resolve("link")
@@ -95,7 +96,7 @@ setupSharedTestSuite(() => {
 
         expect(res.status).toBe(200)
         expect(res.data.ucp).toBeDefined()
-        expect(res.data.ucp.version).toBe("2026-01-11")
+        expect(res.data.ucp.version).toBe("2026-04-08")
         expect(res.data.ucp.services["dev.ucp.shopping"]).toBeDefined()
         expect(res.data.ucp.services["dev.ucp.shopping"][0].transport).toBe("rest")
         expect(res.data.ucp.services["dev.ucp.shopping"][0].endpoint).toContain("/ucp")
@@ -140,22 +141,21 @@ setupSharedTestSuite(() => {
         expect(status).toBe(400)
       })
 
-      it("rejects POST /ucp/checkout-sessions without Request-Id header", async () => {
-        let status = 0
-        try {
-          await api.post("/ucp/checkout-sessions", {
-            line_items: [{ item: { id: variantId }, quantity: 1 }],
-          }, {
-            headers: {
-              "Content-Type": "application/json",
-              "UCP-Agent": "profile=\"https://agent.example/profile\"",
-              "x-publishable-api-key": publishableKey,
-            },
-          })
-        } catch (e: any) {
-          status = e?.response?.status ?? 0
-        }
-        expect(status).toBe(400)
+      it("accepts requests without a Request-Id header (spec does not mandate it)", async () => {
+        // UCP treats Request-Id as correlation, not authorization. When the caller
+        // omits it, the server mints one and echoes it back rather than rejecting.
+        const res = await api.post("/ucp/checkout-sessions", {
+          line_items: [{ item: { id: variantId }, quantity: 1 }],
+          context: { region_id: regionId },
+        }, {
+          headers: {
+            "Content-Type": "application/json",
+            "UCP-Agent": "profile=\"https://agent.example/profile\"",
+            "x-publishable-api-key": publishableKey,
+          },
+        })
+        expect(res.status).toBe(201)
+        expect(res.headers["request-id"]).toBeDefined()
       })
     })
 
@@ -174,7 +174,7 @@ setupSharedTestSuite(() => {
         expect(res.status).toBe(201)
         expect(res.data.id).toBeDefined()
         expect(res.data.ucp).toBeDefined()
-        expect(res.data.ucp.version).toBe("2026-01-11")
+        expect(res.data.ucp.version).toBe("2026-04-08")
         expect(res.data.status).toBe("incomplete")
         expect(res.data.line_items).toHaveLength(1)
         expect(res.data.line_items[0].quantity).toBe(2)
@@ -398,6 +398,12 @@ setupSharedTestSuite(() => {
         expect(p.title).toBeDefined()
         expect(p.handle).toBeDefined()
         expect(Array.isArray(p.variants)).toBe(true)
+        // Spec: description is a Description object, categories are {value} objects.
+        expect(typeof p.description).toBe("object")
+        expect(p.description.plain).toBeDefined()
+        expect(Array.isArray(p.categories)).toBe(true)
+        // Spec: pagination envelope.
+        expect(typeof res.data.pagination?.has_next_page).toBe("boolean")
       })
     })
 
@@ -414,6 +420,59 @@ setupSharedTestSuite(() => {
         expect(res.status).toBe(200)
         expect(res.data.products).toHaveLength(1)
         expect(res.data.products[0].id).toBe(productId)
+      })
+
+      it("prices in minor units, uppercase currency, with a region context", async () => {
+        // Seeded product is USD 499 (major). UCP wants integer minor units → 49900.
+        const res = await api.post("/ucp/catalog/lookup", {
+          ids: [productId],
+          context: { region_id: regionId },
+        }, ucpHeaders())
+
+        expect(res.status).toBe(200)
+        const v = res.data.products[0].variants[0]
+        expect(v.price).toEqual({ amount: 49900, currency: "USD" })
+        expect(v.description.plain).toBeDefined()
+        expect(res.data.products[0].price_range.min.currency).toBe("USD")
+      })
+
+      it("exposes every merchant currency with dynamic exponents (USD×100, JPY×1)", async () => {
+        // JPY has 0 minor-unit digits, so 500 JPY stays 500 (not ×100) — proves the
+        // exponent is resolved per-currency, not hardcoded.
+        const product = await api.post(
+          "/admin/products",
+          {
+            title: `UCP MultiCcy ${Date.now()}`,
+            status: "published",
+            sales_channels: [{ id: salesChannelId }],
+            options: [{ title: "Size", values: ["M"] }],
+            variants: [
+              {
+                title: "M",
+                options: { Size: "M" },
+                prices: [
+                  { amount: 499, currency_code: "usd" },
+                  { amount: 500, currency_code: "jpy" },
+                ],
+                manage_inventory: false,
+              },
+            ],
+          },
+          adminHeaders
+        )
+
+        const res = await api.post("/ucp/catalog/lookup", {
+          ids: [product.data.product.id],
+        }, ucpHeaders())
+
+        expect(res.status).toBe(200)
+        const prices = res.data.products[0].variants[0].prices
+        expect(prices).toEqual(
+          expect.arrayContaining([
+            { amount: 49900, currency: "USD" },
+            { amount: 500, currency: "JPY" },
+          ])
+        )
       })
     })
 

--- a/apps/backend/src/api/mcp/lib/store-resolver.ts
+++ b/apps/backend/src/api/mcp/lib/store-resolver.ts
@@ -181,6 +181,22 @@ export async function findStorefrontBySalesChannel(
 }
 
 /**
+ * Resolve the storefront that owns a given publishable key token. Maps a
+ * caller-supplied `x-publishable-api-key` back to its partner/core store so
+ * requests can be scoped dynamically (name, domain, region) to that storefront.
+ */
+export async function findStorefrontByKey(
+  container: any,
+  token: string | null | undefined
+): Promise<StorefrontInfo | null> {
+  if (!token) {
+    return null
+  }
+  const all = await listStorefronts(container)
+  return all.find((s) => s.publishable_key === token) ?? null
+}
+
+/**
  * Resolve a single storefront. Matches (in order): partner handle, exact domain,
  * store id, default sales-channel id, store name, the first domain label as a
  * handle, then the platform core store via "default"/"main" or the apex domain.

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import {
   defineMiddlewares,
   MedusaErrorHandlerFunction,
@@ -28,6 +29,7 @@ import {
   CatalogSearchSchema,
   CatalogLookupSchema,
 } from "./ucp/validators";
+import { resolveStorefrontUrl } from "./ucp/lib/context";
 
 // Helper function to wrap Zod schemas for compatibility with validateAndTransformBody.
 // Historically this wrapped with z.preprocess((obj) => obj, schema) — under Zod v3
@@ -5206,12 +5208,16 @@ export default defineMiddlewares({
       matcher: "/.well-known/ucp",
       method: "GET",
       middlewares: [
-        (req: MedusaRequest, res: MedusaResponse) => {
+        async (req: MedusaRequest, res: MedusaResponse) => {
           const proto = (req.protocol || "http").split(",")[0].trim()
           const host = req.get("host")
           const baseUrl = process.env.STORE_MCP_LOOPBACK_URL?.replace(/\/$/, "") || `${proto}://${host}`
-          const storefrontUrl = process.env.STOREFRONT_URL || baseUrl
-          const UCP_VERSION = "2026-01-11"
+          // Buyer-facing store URL is the storefront's own domain (a partner
+          // domain when scoped by publishable key, else the core store's
+          // cicilabel.com) — not the API host. Env/host fallback.
+          const callerKey = (req.headers["x-publishable-api-key"] as string) || undefined
+          const storefrontUrl = await resolveStorefrontUrl(req.scope, req, callerKey)
+          const UCP_VERSION = "2026-04-08"
           res.json({
             ucp: {
               version: UCP_VERSION,
@@ -5257,20 +5263,17 @@ export default defineMiddlewares({
           const ucpAgent = req.headers["ucp-agent"]
           if (!ucpAgent) {
             res.status(400).json({
-              ucp: { version: "2026-01-11", status: "error" },
+              ucp: { version: "2026-04-08", status: "error" },
               messages: [{ type: "error", code: "missing_ucp_agent", content: "Missing UCP-Agent header for platform identification", severity: "unrecoverable" }],
             })
             return
           }
-          const requestId = req.headers["request-id"]
-          if (!requestId) {
-            res.status(400).json({
-              ucp: { version: "2026-01-11", status: "error" },
-              messages: [{ type: "error", code: "missing_request_id", content: "Request-Id header is required for UCP requests", severity: "unrecoverable" }],
-            })
-            return
-          }
-          res.set("Request-Id", requestId as string)
+          // Request-Id is for correlation, not authorization — the UCP spec does
+          // not mandate it. Echo the caller's when present, else mint one, so
+          // conformant agents that omit it aren't rejected.
+          const requestId =
+            (req.headers["request-id"] as string) || randomUUID()
+          res.set("Request-Id", requestId)
           next()
         },
       ],

--- a/apps/backend/src/api/ucp/catalog/lookup/route.ts
+++ b/apps/backend/src/api/ucp/catalog/lookup/route.ts
@@ -1,12 +1,21 @@
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { buildUcpContext } from "../../lib/context"
-import { formatUcpProduct, UCP_VERSION } from "../../lib/formatter"
+import qs from "qs"
+import { buildUcpContext, resolveCatalogPriceContext } from "../../lib/context"
+import { formatUcpProduct, catalogEnvelope, UCP_VERSION } from "../../lib/formatter"
 import { formatUcpError } from "../../lib/error-formatter"
+
+// Base prices are always safe; calculated_price needs a region/country context.
+function productFields(hasRegion: boolean): string {
+  return hasRegion
+    ? "*variants.calculated_price,*variants.prices"
+    : "*variants.prices"
+}
 
 /**
  * POST /ucp/catalog/lookup
  *
- * Look up products by id. Returns full product details including variants.
+ * Look up products by id. Returns full product details including variants,
+ * priced in the buyer's context currency plus every currency the merchant sets.
  */
 export async function POST(req: MedusaRequest, res: MedusaResponse) {
   const ctx = await buildUcpContext(req)
@@ -16,9 +25,18 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     const ids: string[] = body.ids || []
     const products: any[] = []
 
+    // Pricing context — required for Medusa to compute calculated_price;
+    // otherwise every variant price is null. Also yields the presentment currency.
+    const priceCtx = await resolveCatalogPriceContext(ctx.container, ctx, body.context)
+    const hasRegion = !!(priceCtx.query.region_id || priceCtx.query.country_code)
+    const qstr = qs.stringify(
+      { fields: productFields(hasRegion), ...priceCtx.query },
+      { skipNulls: true }
+    )
+
     for (const id of ids) {
       try {
-        const url = `${ctx.baseUrl}/store/products/${id}`
+        const url = `${ctx.baseUrl}/store/products/${id}${qstr ? `?${qstr}` : ""}`
         const headers: Record<string, string> = { accept: "application/json" }
         if (ctx.publishableKey) headers["x-publishable-api-key"] = ctx.publishableKey
 
@@ -26,7 +44,12 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
         if (resp.ok) {
           const data = await resp.json() as any
           const product = data.product || data
-          products.push(formatUcpProduct(product))
+          products.push(
+            formatUcpProduct(product, {
+              storefrontUrl: ctx.storefrontUrl,
+              currency: priceCtx.currency,
+            })
+          )
         }
       } catch {
         // Skip not found
@@ -34,7 +57,7 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     }
 
     res.json({
-      ucp: { version: UCP_VERSION, status: "success" },
+      ucp: catalogEnvelope(),
       products,
       count: products.length,
     })

--- a/apps/backend/src/api/ucp/catalog/search/route.ts
+++ b/apps/backend/src/api/ucp/catalog/search/route.ts
@@ -1,26 +1,58 @@
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { buildUcpContext } from "../../lib/context"
-import { formatUcpProduct, UCP_VERSION } from "../../lib/formatter"
-import { formatUcpError } from "../../lib/error-formatter"
-import { callStoreRoute } from "../../../mcp/lib/proxy"
 import qs from "qs"
+import {
+  buildUcpContext,
+  resolveCatalogPriceContext,
+  resolveCategoryIds,
+} from "../../lib/context"
+import { formatUcpProduct, catalogEnvelope, UCP_VERSION } from "../../lib/formatter"
+import { formatUcpError } from "../../lib/error-formatter"
+
+/**
+ * Fields selector. Base prices (`*variants.prices`) never need a pricing context,
+ * so they're always safe. `calculated_price` REQUIRES a region/country — request
+ * it only when we have one, otherwise Medusa errors the whole call.
+ */
+function productFields(hasRegion: boolean): string {
+  return hasRegion
+    ? "*variants.calculated_price,*variants.prices"
+    : "*variants.prices"
+}
 
 /**
  * POST /ucp/catalog/search
  *
- * Search the storefront catalog. Supports full-text query and filters.
+ * Search the storefront catalog. Full-text query + spec filters (categories,
+ * price) and buyer context (country/currency) for localized pricing.
  */
 export async function POST(req: MedusaRequest, res: MedusaResponse) {
   const ctx = await buildUcpContext(req)
   const body = req.validatedBody as any
+  const messages: { type: string; code: string; content: string }[] = []
 
   try {
     const query: Record<string, unknown> = {}
     if (body.query) query.q = body.query
-    if (body.filters?.category) query.category_id = body.filters.category
     if (body.filters?.collection) query.collection_id = body.filters.collection
+
+    // Categories: spec `categories` (values/ids) or legacy `category`.
+    const catValues: string[] = body.filters?.categories
+      ? body.filters.categories
+      : body.filters?.category
+        ? [body.filters.category]
+        : []
+    if (catValues.length) {
+      const ids = await resolveCategoryIds(ctx.container, catValues)
+      if (ids.length) query.category_id = ids
+    }
+
     query.limit = body.pagination?.limit ?? 20
     query.offset = body.pagination?.offset ?? 0
+
+    // Pricing context → Medusa region/country params + presentment currency.
+    const priceCtx = await resolveCatalogPriceContext(ctx.container, ctx, body.context)
+    Object.assign(query, priceCtx.query)
+    query.fields = productFields(!!(priceCtx.query.region_id || priceCtx.query.country_code))
 
     const qstr = qs.stringify(query, { arrayFormat: "brackets", skipNulls: true })
     const url = `${ctx.baseUrl}/store/products?${qstr}`
@@ -31,14 +63,49 @@ export async function POST(req: MedusaRequest, res: MedusaResponse) {
     const resp = await fetch(url, { headers })
     const data = await resp.json() as any
 
-    const products = (data.products || []).map(formatUcpProduct)
+    let products = (data.products || []).map((p: any) =>
+      formatUcpProduct(p, { storefrontUrl: ctx.storefrontUrl, currency: priceCtx.currency })
+    )
+
+    // Price filter (minor units, denominated in the presentment currency).
+    // Medusa's store list doesn't filter on calculated price, so apply it to the
+    // returned page and tell the caller — per spec, prices are already minor units.
+    const pf = body.filters?.price
+    if (pf && (pf.min != null || pf.max != null)) {
+      const before = products.length
+      products = products.filter((p: any) => {
+        const amt = p.price_range?.min?.amount
+        if (amt == null) return false
+        if (pf.min != null && amt < pf.min) return false
+        if (pf.max != null && p.price_range.max.amount > pf.max) return false
+        return true
+      })
+      if (products.length !== before) {
+        messages.push({
+          type: "info",
+          code: "price_filter_applied",
+          content: "Price filter applied to the current page of results.",
+        })
+      }
+    }
+
+    const limit = query.limit as number
+    const offset = query.offset as number
+    const total = typeof data.count === "number" ? data.count : undefined
+    const hasNext = total != null ? offset + limit < total : (data.products || []).length === limit
 
     res.json({
-      ucp: { version: UCP_VERSION, status: "success" },
+      ucp: catalogEnvelope(),
       products,
+      pagination: {
+        has_next_page: hasNext,
+        ...(total != null ? { total_count: total } : {}),
+      },
+      ...(messages.length ? { messages } : {}),
+      // Legacy fields (back-compat with the first cut of this API).
       count: products.length,
-      offset: query.offset,
-      limit: query.limit,
+      offset,
+      limit,
     })
   } catch (error: any) {
     res.status(500).json(formatUcpError({

--- a/apps/backend/src/api/ucp/lib/context.ts
+++ b/apps/backend/src/api/ucp/lib/context.ts
@@ -4,7 +4,29 @@
  */
 
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
-import { resolveStorefront, type StorefrontInfo } from "../../mcp/lib/store-resolver"
+import {
+  resolveStorefront,
+  findStorefrontByKey,
+  type StorefrontInfo,
+} from "../../mcp/lib/store-resolver"
+
+/**
+ * Resolve the storefront a UCP request is scoped to. A caller-supplied
+ * publishable key pins the request to that partner (or core) storefront; with no
+ * key we fall back to the platform core store. Returns null only if resolution
+ * fails entirely (callers then fall back to env/host defaults).
+ */
+async function resolveScopedStorefront(
+  container: any,
+  callerKey: string | undefined
+): Promise<StorefrontInfo | null> {
+  try {
+    const byKey = callerKey ? await findStorefrontByKey(container, callerKey) : null
+    return byKey || (await resolveStorefront(container, "default"))
+  } catch {
+    return null
+  }
+}
 
 export type UcpContext = {
   baseUrl: string
@@ -12,6 +34,10 @@ export type UcpContext = {
   container: any
   storeName: string
   storefrontUrl: string
+  /** Store's default region — used for price/tax context when caller omits one. */
+  defaultRegionId: string | undefined
+  /** Store's default currency code (lowercase, e.g. "eur"). */
+  storeCurrency: string | undefined
 }
 
 const PUBLISHABLE_HEADER = "x-publishable-api-key"
@@ -30,6 +56,22 @@ export function resolvePublicUrl(req: any): string {
   return process.env.STOREFRONT_URL || `${req.protocol}://${req.get("host")}`
 }
 
+/**
+ * Canonical storefront URL for buyer-facing links (product pages, terms, order
+ * permalinks). Prefers the resolved core store's own domain (e.g.
+ * https://cicilabel.com) over the API host or STOREFRONT_URL env, so links point
+ * at the shopper's storefront and never at the backend/API origin.
+ */
+export async function resolveStorefrontUrl(
+  container: any,
+  req: any,
+  callerKey?: string
+): Promise<string> {
+  const info = await resolveScopedStorefront(container, callerKey)
+  if (info?.domain) return `https://${info.domain}`
+  return resolvePublicUrl(req)
+}
+
 export async function buildUcpContext(req: any): Promise<UcpContext> {
   const container = req.scope
   const baseUrl = resolveBaseUrl(req)
@@ -39,23 +81,23 @@ export async function buildUcpContext(req: any): Promise<UcpContext> {
     req.get(PUBLISHABLE_HEADER) ||
     (req as any).publishable_key_context?.key ||
     undefined
-  const publishableKey = callerKey || process.env.STORE_MCP_DEFAULT_PUBLISHABLE_KEY
 
-  let storeName = process.env.STORE_NAME || "JYT Store"
-  let resolvedStorefrontUrl = storefrontUrl
+  // Resolve the storefront this request is scoped to: the caller's publishable
+  // key pins it to that partner (via sales-channel → store → partner link), else
+  // the platform core store. Name, URL, region, currency and the fallback key all
+  // come from this single storefront so a partner request stays fully consistent.
+  const info = await resolveScopedStorefront(container, callerKey)
 
-  // Try to resolve store info for the name/URL
-  try {
-    const info: StorefrontInfo | null = await resolveStorefront(container, "default")
-    if (info) {
-      storeName = info.name || info.store_name || storeName
-      if (info.domain) {
-        resolvedStorefrontUrl = `https://${info.domain}`
-      }
-    }
-  } catch {
-    // Fall back to env defaults
-  }
+  const storeName = info?.name || info?.store_name || process.env.STORE_NAME || "JYT Store"
+  const resolvedStorefrontUrl = info?.domain ? `https://${info.domain}` : storefrontUrl
+  const defaultRegionId = info?.default_region_id || undefined
+  const storeCurrency = info?.currency_code || undefined
+
+  // Precedence: caller-supplied key > explicit env override > resolved store key.
+  // Without this, an unkeyed catalog request returns zero products because
+  // /store/* requires a publishable key for sales-channel scoping.
+  const publishableKey =
+    callerKey || process.env.STORE_MCP_DEFAULT_PUBLISHABLE_KEY || info?.publishable_key || undefined
 
   return {
     baseUrl,
@@ -63,6 +105,8 @@ export async function buildUcpContext(req: any): Promise<UcpContext> {
     container,
     storeName,
     storefrontUrl: resolvedStorefrontUrl,
+    defaultRegionId,
+    storeCurrency,
   }
 }
 
@@ -86,6 +130,98 @@ export async function findRegionForCountry(
     }
   }
   return null
+}
+
+/** Find a region by its currency code (first match). */
+export async function findRegionForCurrency(
+  scope: any,
+  currency: string
+): Promise<{ id: string; currency_code: string } | null> {
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data: regions } = await query.graph({
+    entity: "region",
+    fields: ["id", "currency_code"],
+    filters: { currency_code: currency.toLowerCase() },
+  })
+  const r = (regions || [])[0]
+  return r ? { id: r.id, currency_code: r.currency_code } : null
+}
+
+export type CatalogPriceContext = {
+  /** Query params to forward to /store/products for price/tax context. */
+  query: Record<string, string>
+  /** Resolved presentment currency (uppercase ISO 4217), for the formatter. */
+  currency: string | undefined
+}
+
+/**
+ * Resolve the pricing context for a catalog request into (a) the Medusa query
+ * params that make /store/products compute calculated prices and (b) the
+ * presentment currency the response should be denominated in. Honors, in order:
+ * country → currency → explicit region_id → the store's default region.
+ */
+export async function resolveCatalogPriceContext(
+  scope: any,
+  ctx: UcpContext,
+  reqCtx: any
+): Promise<CatalogPriceContext> {
+  const country = reqCtx?.address_country || reqCtx?.country_code
+  const currency = reqCtx?.currency
+  const regionId = reqCtx?.region_id
+
+  // 1. Country hint — resolve to a region so we also learn its currency.
+  if (country) {
+    const region = await findRegionForCountry(scope, country)
+    if (region) {
+      return { query: { region_id: region.id }, currency: region.currency_code?.toUpperCase() }
+    }
+    // Unknown country — let Medusa try to resolve it, currency unknown.
+    return { query: { country_code: String(country).toLowerCase() }, currency: currency?.toUpperCase() }
+  }
+
+  // 2. Explicit currency hint — map to a region carrying that currency.
+  if (currency) {
+    const region = await findRegionForCurrency(scope, currency)
+    if (region) {
+      return { query: { region_id: region.id }, currency: region.currency_code.toUpperCase() }
+    }
+    // No region for that currency; still surface the requested currency.
+    return { query: {}, currency: currency.toUpperCase() }
+  }
+
+  // 3. Explicit region id.
+  if (regionId) {
+    return { query: { region_id: regionId }, currency: ctx.storeCurrency?.toUpperCase() }
+  }
+
+  // 4. Store default region.
+  return {
+    query: ctx.defaultRegionId ? { region_id: ctx.defaultRegionId } : {},
+    currency: ctx.storeCurrency?.toUpperCase(),
+  }
+}
+
+/**
+ * Resolve UCP category filter values (category `value`s = names, or raw pcat_
+ * ids) into Medusa category ids for the /store/products `category_id` filter.
+ * Unresolvable names are dropped.
+ */
+export async function resolveCategoryIds(
+  scope: any,
+  values: string[]
+): Promise<string[]> {
+  const ids = values.filter((v) => v.startsWith("pcat_"))
+  const names = values.filter((v) => !v.startsWith("pcat_"))
+  if (names.length) {
+    const query = scope.resolve(ContainerRegistrationKeys.QUERY)
+    const { data: cats } = await query.graph({
+      entity: "product_category",
+      fields: ["id"],
+      filters: { name: names },
+    })
+    for (const c of cats || []) ids.push(c.id)
+  }
+  return Array.from(new Set(ids))
 }
 
 export async function getSupportedCountries(scope: any): Promise<string[]> {

--- a/apps/backend/src/api/ucp/lib/formatter.ts
+++ b/apps/backend/src/api/ucp/lib/formatter.ts
@@ -11,7 +11,7 @@ import { buildUcpFulfillment } from "./fulfillment"
 import { listShippingOptionsSafe } from "./shipping-options"
 import { paymentNextAction } from "./payment-next-action"
 
-export const UCP_VERSION = "2026-01-11"
+export const UCP_VERSION = "2026-04-08"
 
 export type UcpFormatterContext = {
   storeName: string
@@ -35,6 +35,21 @@ function ucpEnvelope(ctx: UcpFormatterContext, cartMetadata?: Record<string, unk
       "dev.ucp.shopping.order": [{ version: UCP_VERSION }],
       "dev.ucp.shopping.fulfillment": [{ version: UCP_VERSION }],
       "dev.ucp.shopping.discount": [{ version: UCP_VERSION }],
+    },
+  }
+}
+
+/**
+ * Response envelope for stateless catalog endpoints (no cart context). Per the
+ * UCP REST binding, the envelope carries `version` + advertised `capabilities`.
+ */
+export function catalogEnvelope() {
+  return {
+    version: UCP_VERSION,
+    status: "success" as const,
+    capabilities: {
+      "dev.ucp.shopping.catalog.search": [{ version: UCP_VERSION }],
+      "dev.ucp.shopping.catalog.lookup": [{ version: UCP_VERSION }],
     },
   }
 }
@@ -218,19 +233,94 @@ export async function formatUcpCheckoutSession(
 // Product
 // =====================================================
 
-export function formatUcpProduct(product: any) {
+/**
+ * ISO 4217 minor-unit exponent for a currency, resolved dynamically via Intl
+ * (no hardcoded table): USD→2, JPY→0, KWD→3, etc. Falls back to 2 for unknown
+ * codes. Medusa stores amounts in MAJOR units (e.g. 100.00), UCP wants integer
+ * minor units, so every amount is scaled by 10^exponent.
+ */
+function currencyExponent(currency: string): number {
+  try {
+    return (
+      new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: currency.toUpperCase(),
+      }).resolvedOptions().maximumFractionDigits ?? 2
+    )
+  } catch {
+    return 2
+  }
+}
+
+/** UCP Price: integer minor units + uppercase ISO 4217 currency (^[A-Z]{3}$). */
+function ucpPrice(majorAmount: number | string, currency: string | undefined) {
+  const cur = currency || "usd"
+  const major = Number(majorAmount) || 0
+  return {
+    amount: Math.round(major * Math.pow(10, currencyExponent(cur))),
+    currency: cur.toUpperCase(),
+  }
+}
+
+/**
+ * All non-price-list money amounts on a Medusa variant, one per currency,
+ * deduped and converted to UCP minor-unit prices. This is the dynamic
+ * multi-currency view — whatever currencies the merchant has priced in Medusa.
+ */
+function variantPrices(v: any): { amount: number; currency: string }[] {
+  const seen = new Set<string>()
+  const out: { amount: number; currency: string }[] = []
+  for (const p of v.prices || []) {
+    // Skip price-list (sale/override) rows — base prices only for the catalog.
+    if (p.price_list_id) continue
+    const code = p.currency_code
+    if (!code || seen.has(code)) continue
+    seen.add(code)
+    out.push(ucpPrice(p.amount ?? p.raw_amount?.value ?? 0, code))
+  }
+  return out
+}
+
+export type ProductFormatOptions = {
+  storefrontUrl?: string
+  /** Presentment currency (uppercase ISO 4217) to select variant.price from. */
+  currency?: string
+}
+
+export function formatUcpProduct(product: any, opts: ProductFormatOptions = {}) {
+  const { storefrontUrl, currency: wanted } = opts
+  const wantedUpper = wanted?.toUpperCase()
+
   const variants = (product.variants || []).map((v: any) => {
-    const price = v.prices?.[0] || v.calculated_price || null
-    const priceAmount = price ? (price.amount ?? price.calculated_amount ?? 0) : null
-    const priceCurrency = price?.currency_code || "usd"
+    const prices = variantPrices(v)
+
+    // Selling price: region-calculated price wins (tax/price-list aware), else
+    // the priced entry in the requested/presentment currency, else first.
+    const calc = v.calculated_price
+    const calculated = calc?.calculated_amount != null
+      ? ucpPrice(calc.calculated_amount, calc.currency_code)
+      : null
+    const byCurrency = wantedUpper
+      ? prices.find((p) => p.currency === wantedUpper)
+      : undefined
+    const price = calculated || byCurrency || prices[0] || null
+
+    // Strikethrough / list price when the calculated original differs.
+    const listPrice = calc?.original_amount != null && calc.original_amount !== calc.calculated_amount
+      ? ucpPrice(calc.original_amount, calc.currency_code)
+      : undefined
 
     return {
       id: v.id,
       title: v.title || "",
+      // Spec: variant.description is required and MUST be an object with ≥1
+      // format. Medusa variants carry none, so mirror the title.
+      description: { plain: v.title || product.title || "" },
       sku: v.sku || null,
-      price: priceAmount != null
-        ? { amount: priceAmount, currency: priceCurrency }
-        : null,
+      price,
+      ...(listPrice ? { list_price: listPrice } : {}),
+      // Extension: every currency the merchant prices this variant in.
+      ...(prices.length ? { prices } : {}),
       availability: {
         available: v.inventory_quantity != null ? v.inventory_quantity > 0 : true,
         status: v.inventory_quantity != null
@@ -240,23 +330,43 @@ export function formatUcpProduct(product: any) {
     }
   })
 
-  const variantPrices = variants.map((v: any) => v.price?.amount).filter((p: any) => p != null)
-  const priceRange = variantPrices.length > 0
+  // Price range in the presentment currency (fall back to whatever price[0] is).
+  const priced = variants.filter((v: any) => v.price != null)
+  const rangeCurrency = wantedUpper && priced.some((v: any) => v.price.currency === wantedUpper)
+    ? wantedUpper
+    : priced[0]?.price?.currency
+  const inRange = priced
+    .map((v: any) =>
+      v.price.currency === rangeCurrency
+        ? v.price.amount
+        : v.prices?.find((p: any) => p.currency === rangeCurrency)?.amount
+    )
+    .filter((a: any) => a != null) as number[]
+  const priceRange = inRange.length > 0
     ? {
-        min: { amount: Math.min(...variantPrices), currency: variants[0]?.price?.currency || "usd" },
-        max: { amount: Math.max(...variantPrices), currency: variants[0]?.price?.currency || "usd" },
+        min: { amount: Math.min(...inRange), currency: rangeCurrency },
+        max: { amount: Math.max(...inRange), currency: rangeCurrency },
       }
     : null
 
   const media = (product.images || []).map((img: any) => ({ url: img.url, type: "image" as const }))
-  if (product.thumbnail) media.unshift({ url: product.thumbnail, type: "image" as const })
+  if (product.thumbnail && !media.some((m: any) => m.url === product.thumbnail)) {
+    media.unshift({ url: product.thumbnail, type: "image" as const })
+  }
+
+  const handle = product.handle || ""
 
   return {
     id: product.id,
     title: product.title || "",
-    description: product.description || "",
-    handle: product.handle || "",
-    categories: (product.categories || []).map((c: any) => c.name),
+    // Spec: description is a Description object ({ plain|html|markdown }), not a string.
+    description: { plain: product.description || "" },
+    handle,
+    ...(storefrontUrl && handle ? { url: `${storefrontUrl}/products/${handle}` } : {}),
+    // Spec: categories are Category objects keyed by `value`, not bare strings.
+    categories: (product.categories || [])
+      .map((c: any) => (c?.name ? { value: c.name } : null))
+      .filter(Boolean),
     price_range: priceRange,
     variants,
     media,

--- a/apps/backend/src/api/ucp/validators.ts
+++ b/apps/backend/src/api/ucp/validators.ts
@@ -92,20 +92,44 @@ export const CompleteUcpCheckoutSessionSchema = z.object({
   buyer: UcpBuyerSchema.optional(),
 })
 
+// UCP catalog context — buyer signals for localization/pricing (spec
+// types/context.json). `passthrough` keeps forward-compat with signals the spec
+// may add; the extra region_id/country_code are direct Medusa hints we accept.
+const UcpCatalogContextSchema = z.object({
+  address_country: z.string().optional(),
+  address_region: z.string().optional(),
+  postal_code: z.string().optional(),
+  currency: z.string().optional(),
+  language: z.string().optional(),
+  intent: z.string().optional(),
+  region_id: z.string().optional(),
+  country_code: z.string().min(2).optional(),
+}).passthrough().optional()
+
 export const CatalogSearchSchema = z.object({
   query: z.string().optional(),
   filters: z.object({
+    // Spec: categories (array of category `value`s, OR logic) + price (minor units).
+    categories: z.array(z.string()).optional(),
+    price: z.object({
+      min: z.number().int().min(0).optional(),
+      max: z.number().int().min(0).optional(),
+    }).optional(),
+    // Legacy / direct hints (back-compat).
     category: z.string().optional(),
     collection: z.string().optional(),
     min_price: z.number().optional(),
     max_price: z.number().optional(),
-  }).optional(),
+  }).passthrough().optional(),
+  context: UcpCatalogContextSchema,
   pagination: z.object({
     limit: z.number().int().positive().max(100).optional().default(20),
     offset: z.number().int().min(0).optional().default(0),
+    cursor: z.string().optional(),
   }).optional(),
 })
 
 export const CatalogLookupSchema = z.object({
   ids: z.array(z.string()).min(1),
+  context: UcpCatalogContextSchema,
 })

--- a/apps/backend/src/api/well-known/ucp/route.ts
+++ b/apps/backend/src/api/well-known/ucp/route.ts
@@ -1,5 +1,5 @@
 import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { resolveBaseUrl, resolvePublicUrl } from "../../ucp/lib/context"
+import { resolveBaseUrl, resolveStorefrontUrl } from "../../ucp/lib/context"
 import { UCP_VERSION } from "../../ucp/lib/formatter"
 
 /**
@@ -14,7 +14,8 @@ import { UCP_VERSION } from "../../ucp/lib/formatter"
  */
 export async function GET(req: MedusaRequest, res: MedusaResponse) {
   const baseUrl = resolveBaseUrl(req)
-  const storefrontUrl = resolvePublicUrl(req)
+  const callerKey = (req.headers["x-publishable-api-key"] as string) || undefined
+  const storefrontUrl = await resolveStorefrontUrl(req.scope, req, callerKey)
 
   const paymentHandlers = [
     {


### PR DESCRIPTION
## Problem

The UCP catalog API (ported from the MCP store server in #905) returned **null prices**. Reproduced on prod (`v3.jaalyantra.com`):

| Call | Before |
|---|---|
| `POST /ucp/catalog/search` (no key) | `count: 0` — empty catalog |
| `POST /ucp/catalog/search` (with key, no region) | products returned, **every `price` + `price_range` = null** |

Root cause: the loopback to `/store/products` dropped the resolved publishable key and never passed a region, so Medusa computed no `calculated_price`. `buildUcpContext` was resolving the storefront but discarding its `publishable_key` and `default_region_id`.

## What changed

**Pricing / key resolution**
- Resolve **one** storefront per request — the caller's publishable key pins it to that partner (via sales-channel → store → partner link), else the platform core store — and derive name, URL, region, currency and the fallback key from it. Agents need no key; a partner key scopes the whole request.
- Pass region/country context so `calculated_price` is computed. Request `calculated_price` **only when a region resolves** (otherwise the store call errors → 0 products); base prices are always requested.

**Dynamic multi-currency** (Medusa exposes `*variants.prices`)
- Each variant carries `prices: [{amount, currency}]` for **every currency the merchant prices in** — fully dynamic.
- Spec `price` = calculated (context) → requested currency → first available.

**Minor units**
- Medusa stores major units; UCP wants integer ISO-4217 minor units. Converted via per-currency exponents resolved dynamically through `Intl` (no hardcoded table): USD ×100, JPY ×1, KWD ×1000.

**Spec conformance (ucp.dev `2026-04-08`)**
- Version bump; `description` as objects; `categories` as `{value}`; uppercase currency (`^[A-Z]{3}$`); canonical `url`; capabilities envelope.
- Spec request shapes: `filters.categories` / `filters.price`, `context.{address_country,currency,language,intent,…}` (with back-compat for the first-cut fields).
- `pagination: {has_next_page, total_count}`.
- `Request-Id` is now optional (minted + echoed, not rejected) — the spec treats it as correlation, not authorization.

**Storefront URL**
- Resolve the store's own domain (**cicilabel.com** / a partner domain) instead of the API host.

## Testing

`pnpm test:integration:http:shared ./integration-tests/http/ucp` → **21/21 pass**, including new coverage:
- Minor units: USD 499 → `{amount: 49900, currency: "USD"}`
- Dynamic exponents: a USD 499 + JPY 500 product returns `[{49900,"USD"},{500,"JPY"}]` — JPY stays 500 (0 decimals), proving per-currency resolution.

The catalog-returns-0 bug was **caught by these tests** (test store has no default region) and fixed before shipping.

`tsc --noEmit` clean (73 pre-existing errors repo-wide, none in touched files).

## Follow-ups (not in this PR)
- Cursor-based pagination (offset kept as an extension for now).
- Prod AI/pricing verification after deploy.

Context: #905 (original UCP port).

🤖 Generated with [Claude Code](https://claude.com/claude-code)