### PR TITLE
chore(etsy): bump backend to medusa-plugin-etsy-sync 0.1.2

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -68,7 +68,7 @@
     "@freesewing/titan": "4.10.0",
     "@hookform/error-message": "^2.0.1",
     "@hookform/resolvers": "^5.0.1",
-    "@jytextiles/medusa-plugin-etsy-sync": "0.1.0",
+    "@jytextiles/medusa-plugin-etsy-sync": "0.1.2",
     "@mastra/core": "latest",
     "@mastra/evals": "latest",
     "@mastra/loggers": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,8 +150,8 @@ importers:
         specifier: ^5.0.1
         version: 5.2.2(react-hook-form@7.71.2(react@18.3.1))
       '@jytextiles/medusa-plugin-etsy-sync':
-        specifier: 0.1.0
-        version: 0.1.0(@medusajs/admin-sdk@2.17.2)(@medusajs/cli@2.17.2(@types/node@20.19.34))(@medusajs/dashboard@2.17.2(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(typescript@5.9.3))(@medusajs/framework@2.17.2(@medusajs/cli@2.17.2(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))(zod@4.3.6))(@medusajs/icons@2.17.2(react@18.3.1))(@medusajs/medusa@2.17.2)(@medusajs/test-utils@2.17.2)(@medusajs/types@2.17.2(ioredis@5.9.3)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)))(@medusajs/ui@4.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        specifier: 0.1.2
+        version: 0.1.2(@medusajs/admin-sdk@2.17.2)(@medusajs/cli@2.17.2(@types/node@20.19.34))(@medusajs/dashboard@2.17.2(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(typescript@5.9.3))(@medusajs/framework@2.17.2(@medusajs/cli@2.17.2(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))(zod@4.3.6))(@medusajs/icons@2.17.2(react@18.3.1))(@medusajs/medusa@2.17.2)(@medusajs/test-utils@2.17.2)(@medusajs/types@2.17.2(ioredis@5.9.3)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)))(@medusajs/ui@4.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@mastra/core':
         specifier: latest
         version: 1.28.0(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.19.19)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(effect@3.19.19)(quansync@0.2.11)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(effect@3.19.19)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6)
@@ -4228,18 +4228,18 @@ packages:
     peerDependencies:
       tslib: '2'
 
-  '@jytextiles/medusa-plugin-etsy-sync@0.1.0':
-    resolution: {integrity: sha512-qD6VlZCWYIMXm/UA1FstebcY+19r/WIU4MKsA7HLNgznHvdGQJ5W7ReDpSBHMpThMnI4xLuwN+7MzNqBkN88yg==}
+  '@jytextiles/medusa-plugin-etsy-sync@0.1.2':
+    resolution: {integrity: sha512-JxPmD8oqHs8zV9+wW/gmi7adxZczeqboKS1FF9Naf6TEWh8uGm6kMBPSLA/W40QOTZstiJR+WS9xW75DhM4HVQ==}
     peerDependencies:
-      '@medusajs/admin-sdk': 2.17.1
-      '@medusajs/cli': 2.17.1
-      '@medusajs/dashboard': 2.17.1
-      '@medusajs/framework': 2.17.1
-      '@medusajs/icons': 2.17.1
-      '@medusajs/medusa': 2.17.1
-      '@medusajs/test-utils': 2.17.1
-      '@medusajs/types': 2.17.1
-      '@medusajs/ui': 4.1.18
+      '@medusajs/admin-sdk': 2.17.2
+      '@medusajs/cli': 2.17.2
+      '@medusajs/dashboard': 2.17.2
+      '@medusajs/framework': 2.17.2
+      '@medusajs/icons': 2.17.2
+      '@medusajs/medusa': 2.17.2
+      '@medusajs/test-utils': 2.17.2
+      '@medusajs/types': 2.17.2
+      '@medusajs/ui': 4.1.19
       react: ^18.3.1
       react-dom: ^18.3.1
       react-router-dom: 6.30.3
@@ -23669,7 +23669,7 @@ snapshots:
       '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@jytextiles/medusa-plugin-etsy-sync@0.1.0(@medusajs/admin-sdk@2.17.2)(@medusajs/cli@2.17.2(@types/node@20.19.34))(@medusajs/dashboard@2.17.2(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(typescript@5.9.3))(@medusajs/framework@2.17.2(@medusajs/cli@2.17.2(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))(zod@4.3.6))(@medusajs/icons@2.17.2(react@18.3.1))(@medusajs/medusa@2.17.2)(@medusajs/test-utils@2.17.2)(@medusajs/types@2.17.2(ioredis@5.9.3)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)))(@medusajs/ui@4.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@jytextiles/medusa-plugin-etsy-sync@0.1.2(@medusajs/admin-sdk@2.17.2)(@medusajs/cli@2.17.2(@types/node@20.19.34))(@medusajs/dashboard@2.17.2(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(typescript@5.9.3))(@medusajs/framework@2.17.2(@medusajs/cli@2.17.2(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))(zod@4.3.6))(@medusajs/icons@2.17.2(react@18.3.1))(@medusajs/medusa@2.17.2)(@medusajs/test-utils@2.17.2)(@medusajs/types@2.17.2(ioredis@5.9.3)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)))(@medusajs/ui@4.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@medusajs/admin-sdk': 2.17.2
       '@medusajs/cli': 2.17.2(@types/node@20.19.34)


### PR DESCRIPTION
## Why

The etsy plugin (`@jytextiles/medusa-plugin-etsy-sync`) is published to npm and consumed by `apps/backend` as a **pinned version** — not `workspace:*`. Deploying the backend runs `pnpm install` against that pin; it does **not** publish or auto-update the npm package. Those are two separate lifecycles.

The recent fixes **#908 / #796** (pricing/currency, batch, webhooks, order ingest & lifecycle) were published to npm as **0.1.2**, but `apps/backend` was still pinned to **0.1.0** — so every deploy shipped the old plugin without those fixes.

## Change
- `apps/backend/package.json`: `@jytextiles/medusa-plugin-etsy-sync` `0.1.0` → `0.1.2`
- `pnpm-lock.yaml` refreshed (`--lockfile-only`); zero `0.1.0` refs remain

## Verification
- npm `0.1.2` published `2026-07-06T15:43Z` — 3 min after the #908 merge (15:40Z)
- Confirmed the published 0.1.2 tarball contains the #908 files: `lib/webhook`, `workflows/ingest-etsy-order-support`, `api/admin/etsy/status/product/[id]/route`
- peer deps satisfied (plugin 0.1.2 targets Medusa 2.17.2, matching the backend)

After merge + deploy, the prod backend will run the #908 etsy fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)