### PR TITLE
feat: customer-design unlink + moodboard polish (redesign role, fashion-lib cleanup, construction presets)

### DIFF
--- a/apps/backend/.env.template
+++ b/apps/backend/.env.template
@@ -63,6 +63,27 @@ SHIPROCKET_API_PASSWORD=your_shiprocket_password
 # MASTRA_STEP_TIMEOUT_MS=60000
 # VFLOW_FETCH_TIMEOUT_MS=30000
 
+# ─── AI providers ───────────────────────────────────────────────────────────
+# All AI features (moodboard "Redesign", tech-pack text/vision roles) resolve a
+# provider DB-first (Settings → External Platforms, category="ai", tagged by
+# role) and fall back to these env vars when no platform is configured — the
+# local-dev path. See src/mastra/services/ai-platforms.ts and
+# src/mastra/services/redesign-credentials.ts.
+#
+# Redesign (#892) uses Nano-Banana (gemini-2.5-flash-image), reachable via either
+# provider below. The first key present wins (OpenRouter preferred):
+#   OPENROUTER_API_KEY            → OpenRouter engine (google/gemini-2.5-flash-image)
+#   GOOGLE_GENERATIVE_AI_API_KEY  → direct Google engine (gemini-2.5-flash-image)
+# OPENROUTER_API_KEY also backs the free text/vision model rotator when no
+# platform is set for a text/vision role.
+OPENROUTER_API_KEY=your_openrouter_api_key
+GOOGLE_GENERATIVE_AI_API_KEY=your_google_generative_ai_key
+# Optional — used by other AI roles when present:
+# OPENAI_API_KEY=your_openai_api_key
+# AI_GATEWAY_API_KEY=your_vercel_ai_gateway_key
+# CLOUDFLARE_AI_ACCOUNT_ID=your_cloudflare_account_id
+# CLOUDFLARE_AI_TOKEN=your_cloudflare_ai_token
+
 # Artisan quasi-partner cross-listing (#859 / #861). The sales-channel id of the
 # core storefront ("JYT Medu Store") that approved artisan products get listed
 # onto. There is no "core store" entity — the channel id IS the identity. When

--- a/apps/backend/src/admin/components/designs/design-construction-section.tsx
+++ b/apps/backend/src/admin/components/designs/design-construction-section.tsx
@@ -35,6 +35,111 @@ const TECHNIQUES: { value: string; label: string; paramHint: string }[] = [
   { value: "embroidery", label: "Embroidery", paramHint: "motif = 6" },
 ]
 
+// Ready-made construction details for common garment features. Selecting one
+// pre-fills the form so the same detail isn't re-authored from scratch each time.
+// All techniques below must exist in TECHNIQUES / the backend SUPPORTED_TECHNIQUES.
+type ConstructionSample = {
+  value: string
+  label: string
+  technique: string
+  detailLabel: string
+  params?: Record<string, number>
+  fabricRules?: string[]
+  note?: string
+}
+
+const SAMPLES: ConstructionSample[] = [
+  {
+    value: "waist-dart",
+    label: "Waist dart",
+    technique: "dart",
+    detailLabel: "Waist dart",
+    params: { intake: 0.6 },
+    fabricRules: ["press toward centre front", "taper to nothing at apex"],
+    note: "Backstitch at waist seam, leave apex un-backstitched",
+  },
+  {
+    value: "bust-dart",
+    label: "Bust dart",
+    technique: "dart",
+    detailLabel: "Bust dart",
+    params: { intake: 0.5 },
+    fabricRules: ["press downward", "end 2.5 cm short of apex"],
+  },
+  {
+    value: "knife-pleat-skirt",
+    label: "Knife pleats (skirt)",
+    technique: "knife-pleat",
+    detailLabel: "Knife pleats",
+    params: { count: 6 },
+    fabricRules: ["all pleats face one direction", "press sharp, edge-stitch top 8 cm"],
+  },
+  {
+    value: "box-pleat-center",
+    label: "Centre box pleat",
+    technique: "box-pleat",
+    detailLabel: "Centre box pleat",
+    params: { count: 1 },
+    fabricRules: ["centre on CF", "tack at waist"],
+  },
+  {
+    value: "gathered-sleeve-head",
+    label: "Gathered sleeve head",
+    technique: "gathers",
+    detailLabel: "Sleeve-head gathers",
+    params: { ratio: 1.4 },
+    fabricRules: ["two rows of ease stitching", "distribute fullness between notches"],
+  },
+  {
+    value: "gathered-skirt-waist",
+    label: "Gathered skirt waist",
+    technique: "gathers",
+    detailLabel: "Waist gathers",
+    params: { ratio: 2 },
+    fabricRules: ["gather evenly to waistband length"],
+  },
+  {
+    value: "pin-tucks-bodice",
+    label: "Pin tucks (bodice)",
+    technique: "tucks",
+    detailLabel: "Pin tucks",
+    params: { count: 5 },
+    fabricRules: ["6 mm spacing", "press to one side"],
+  },
+  {
+    value: "double-topstitch-hem",
+    label: "Double topstitch hem",
+    technique: "topstitch",
+    detailLabel: "Double topstitch",
+    params: { rows: 2 },
+    fabricRules: ["6 mm row spacing", "matching thread"],
+  },
+  {
+    value: "edge-topstitch",
+    label: "Edge topstitch",
+    technique: "topstitch",
+    detailLabel: "Edge topstitch",
+    params: { rows: 1 },
+    fabricRules: ["1.5 mm from edge"],
+  },
+  {
+    value: "back-yoke",
+    label: "Back yoke",
+    technique: "yoke",
+    detailLabel: "Back yoke",
+    params: { drop: 0.4 },
+    fabricRules: ["burrito method", "understitch yoke seam"],
+  },
+  {
+    value: "chain-embroidery",
+    label: "Chain-stitch embroidery",
+    technique: "embroidery",
+    detailLabel: "Chain-stitch motif",
+    params: { motif: 6 },
+    fabricRules: ["stabilise reverse before stitching"],
+  },
+]
+
 /** Parse a textarea of `key = value` lines into a numeric param map (non-numeric dropped). */
 function parseParams(text: string): Record<string, number> {
   const out: Record<string, number> = {}
@@ -121,14 +226,32 @@ const AddDetailModal = ({ designId }: { designId: string }) => {
   const [rulesText, setRulesText] = useState("")
   const [note, setNote] = useState("")
 
+  const [sample, setSample] = useState<string>("")
+
   const { mutateAsync: create, isPending } = useCreateConstructionDetail(designId)
 
   const reset = () => {
+    setSample("")
     setTechnique("")
     setLabel("")
     setParamsText("")
     setRulesText("")
     setNote("")
+  }
+
+  const applySample = (value: string) => {
+    setSample(value)
+    const s = SAMPLES.find((x) => x.value === value)
+    if (!s) return
+    setTechnique(s.technique)
+    setLabel(s.detailLabel)
+    setParamsText(
+      s.params
+        ? Object.entries(s.params).map(([k, v]) => `${k} = ${v}`).join("\n")
+        : ""
+    )
+    setRulesText((s.fabricRules ?? []).join("\n"))
+    setNote(s.note ?? "")
   }
 
   const handleSubmit = async () => {
@@ -182,6 +305,25 @@ const AddDetailModal = ({ designId }: { designId: string }) => {
                 <Heading level="h2">Add construction detail</Heading>
                 <Text size="small" className="text-ui-fg-subtle">
                   Feeds the tech-pack's construction-details frame.
+                </Text>
+              </div>
+
+              <div className="flex flex-col gap-y-2">
+                <Label>Start from a sample <span className="text-ui-fg-muted">(optional)</span></Label>
+                <Select value={sample} onValueChange={applySample}>
+                  <Select.Trigger>
+                    <Select.Value placeholder="Pick a common detail to pre-fill" />
+                  </Select.Trigger>
+                  <Select.Content>
+                    {SAMPLES.map((s) => (
+                      <Select.Item key={s.value} value={s.value}>
+                        {s.label}
+                      </Select.Item>
+                    ))}
+                  </Select.Content>
+                </Select>
+                <Text size="xsmall" className="text-ui-fg-muted">
+                  Fills the fields below — tweak anything before adding.
                 </Text>
               </div>
 

--- a/apps/backend/src/admin/components/designs/fashion-panel.tsx
+++ b/apps/backend/src/admin/components/designs/fashion-panel.tsx
@@ -1,15 +1,4 @@
-import { useState, useMemo, useCallback } from "react"
-import {
-  FASHION_SHAPES,
-  FashionShape,
-  createShapeElements,
-  perspectiveTransformPoints,
-} from "./fashion-shapes"
-import {
-  PatternPiece,
-  PATTERN_PIECES,
-  createPatternPieceElement,
-} from "./fashion-croquis"
+import { useState, useCallback } from "react"
 import { sdk } from "../../lib/config"
 import { FabricPreviewTab } from "./fabric-preview-tab"
 import { RedesignTab } from "./redesign-tab"
@@ -22,7 +11,7 @@ interface FashionPanelProps {
   initialTab?: string
 }
 
-type Tab = "garments" | "patterns" | "pinterest" | "fabric" | "redesign" | "outline"
+type Tab = "pinterest" | "fabric" | "redesign" | "outline"
 
 type PinterestPin = {
   id: string
@@ -58,120 +47,10 @@ function addImageToCanvas(
 }
 
 // ---------------------------------------------------------------------------
-// Shape thumbnail (Garments tab)
-// ---------------------------------------------------------------------------
-function ShapeThumbnail({
-  shape,
-  selected,
-  perspective,
-  onClick,
-}: {
-  shape: FashionShape
-  selected: boolean
-  perspective: "flat" | "three-quarter"
-  onClick: () => void
-}) {
-  const vbW = shape.width
-  const vbH = shape.height
-  const aspect = vbW / vbH
-  const thumbW = aspect >= 1 ? 56 : Math.round(56 * aspect)
-  const thumbH = aspect >= 1 ? Math.round(56 / aspect) : 56
-
-  return (
-    <button
-      onClick={onClick}
-      title={shape.name}
-      className={`flex flex-col items-center gap-1 p-1 rounded border transition-all ${
-        selected
-          ? "border-ui-fg-interactive bg-ui-bg-highlight"
-          : "border-ui-border-base hover:border-ui-border-strong hover:bg-ui-bg-subtle"
-      }`}
-    >
-      <svg width={thumbW} height={thumbH} viewBox={`0 0 ${vbW} ${vbH}`}>
-        {shape.regions.map((region, i) => {
-          let pts: [number, number][] = region.points.map(
-            ([px, py]) => [px * vbW, py * vbH]
-          )
-          if (perspective === "three-quarter") {
-            pts = perspectiveTransformPoints(pts, vbW, vbH)
-          }
-          return (
-            <polygon
-              key={i}
-              points={pts.map(([x, y]) => `${x},${y}`).join(" ")}
-              fill={region.defaultColor}
-              stroke="#1a1a1a"
-              strokeWidth={vbW * 0.012}
-            />
-          )
-        })}
-      </svg>
-      <span className="text-xs text-ui-fg-subtle truncate w-full text-center leading-tight">
-        {shape.name}
-      </span>
-    </button>
-  )
-}
-
-// ---------------------------------------------------------------------------
-// Pattern piece thumbnail (Cut Patterns tab)
-// ---------------------------------------------------------------------------
-function PatternCard({
-  piece,
-  selected,
-  onClick,
-}: {
-  piece: PatternPiece
-  selected: boolean
-  onClick: () => void
-}) {
-  const aspect = piece.width / piece.height
-  const thumbW = aspect >= 1 ? 56 : Math.round(56 * aspect)
-  const thumbH = aspect >= 1 ? Math.round(56 / aspect) : 56
-
-  // Render the piece SVG inline as a small preview via data URL
-  const src = useMemo(
-    () => `data:image/svg+xml;base64,${btoa(piece.svg)}`,
-    [piece.svg]
-  )
-
-  return (
-    <button
-      onClick={onClick}
-      title={piece.name}
-      className={`flex flex-col items-center gap-1 p-1 rounded border transition-all ${
-        selected
-          ? "border-ui-fg-interactive bg-ui-bg-highlight"
-          : "border-ui-border-base hover:border-ui-border-strong hover:bg-ui-bg-subtle"
-      }`}
-    >
-      <img
-        src={src}
-        alt={piece.name}
-        width={thumbW}
-        height={thumbH}
-        style={{ objectFit: "contain" }}
-      />
-      <span className="text-xs text-ui-fg-subtle truncate w-full text-center leading-tight">
-        {piece.name}
-      </span>
-    </button>
-  )
-}
-
-// ---------------------------------------------------------------------------
 // Main panel
 // ---------------------------------------------------------------------------
 export function FashionPanel({ excalidrawAPI, getCanvasCenter, onClose, initialTab }: FashionPanelProps) {
-  const [tab, setTab] = useState<Tab>((initialTab as Tab) || "garments")
-
-  // Garments tab state
-  const [garmentCategory, setGarmentCategory] = useState<"body" | "garment">("garment")
-  const [selectedShape, setSelectedShape] = useState<FashionShape | null>(null)
-  const [perspective, setPerspective] = useState<"flat" | "three-quarter">("flat")
-
-  // Cut Patterns tab state
-  const [selectedPattern, setSelectedPattern] = useState<PatternPiece | null>(null)
+  const [tab, setTab] = useState<Tab>((initialTab as Tab) || "pinterest")
 
   // Pinterest tab state
   const [pinterestQuery, setPinterestQuery] = useState("")
@@ -179,31 +58,6 @@ export function FashionPanel({ excalidrawAPI, getCanvasCenter, onClose, initialT
   const [pinterestBookmark, setPinterestBookmark] = useState<string | null>(null)
   const [pinterestLoading, setPinterestLoading] = useState(false)
   const [pinterestError, setPinterestError] = useState<string | null>(null)
-
-  const filteredShapes = FASHION_SHAPES.filter(s => s.category === garmentCategory)
-
-  // ── Insert handlers ──────────────────────────────────────────────────────
-
-  function handleInsertShape() {
-    if (!excalidrawAPI || !selectedShape) return
-    const center = getCanvasCenter()
-    const elements = createShapeElements(selectedShape, center.x, center.y, 1, perspective)
-    excalidrawAPI.updateScene({
-      elements: [...excalidrawAPI.getSceneElements(), ...elements],
-    })
-  }
-
-  function handleInsertPattern() {
-    if (!excalidrawAPI || !selectedPattern) return
-    const center = getCanvasCenter()
-    const { fileId, dataUrl, element } = createPatternPieceElement(
-      selectedPattern,
-      center.x,
-      center.y,
-      1
-    )
-    addImageToCanvas(excalidrawAPI, fileId, dataUrl, element)
-  }
 
   // Pinterest handlers
   const handlePinterestSearch = useCallback(async (loadMore = false) => {
@@ -304,8 +158,6 @@ export function FashionPanel({ excalidrawAPI, getCanvasCenter, onClose, initialT
   // ── Render ───────────────────────────────────────────────────────────────
 
   const tabLabels: { key: Tab; label: string }[] = [
-    { key: "garments", label: "Garments" },
-    { key: "patterns", label: "Patterns" },
     { key: "pinterest", label: "Pinterest" },
     { key: "fabric",   label: "Fabric" },
     { key: "redesign", label: "Redesign" },
@@ -345,104 +197,6 @@ export function FashionPanel({ excalidrawAPI, getCanvasCenter, onClose, initialT
 
       {/* Body */}
       <div className="p-3 flex flex-col gap-3 overflow-y-auto" style={{ maxHeight: 440 }}>
-
-        {/* ── GARMENTS TAB ─────────────────────────────────────────────── */}
-        {tab === "garments" && (
-          <>
-            {/* Category toggle */}
-            <div className="flex gap-1">
-              {(["garment", "body"] as const).map(cat => (
-                <button
-                  key={cat}
-                  onClick={() => { setGarmentCategory(cat); setSelectedShape(null) }}
-                  className={`flex-1 py-1 text-xs rounded border transition-colors capitalize ${
-                    garmentCategory === cat
-                      ? "bg-ui-bg-interactive text-ui-fg-on-inverted border-ui-bg-interactive"
-                      : "border-ui-border-base text-ui-fg-subtle hover:bg-ui-bg-subtle"
-                  }`}
-                >
-                  {cat === "garment" ? "Garments" : "Body Shapes"}
-                </button>
-              ))}
-            </div>
-
-            {/* Perspective toggle */}
-            <div className="flex gap-1 items-center">
-              <span className="text-xs text-ui-fg-subtle mr-1 shrink-0">View</span>
-              {(["flat", "three-quarter"] as const).map(v => (
-                <button
-                  key={v}
-                  onClick={() => setPerspective(v)}
-                  className={`flex-1 py-1 text-xs rounded border transition-colors ${
-                    perspective === v
-                      ? "bg-ui-bg-interactive text-ui-fg-on-inverted border-ui-bg-interactive"
-                      : "border-ui-border-base text-ui-fg-subtle hover:bg-ui-bg-subtle"
-                  }`}
-                >
-                  {v === "flat" ? "Flat-lay" : "3/4 View"}
-                </button>
-              ))}
-            </div>
-
-            {/* Shape grid */}
-            <div className="grid grid-cols-3 gap-2">
-              {filteredShapes.map(shape => (
-                <ShapeThumbnail
-                  key={shape.id}
-                  shape={shape}
-                  selected={selectedShape?.id === shape.id}
-                  perspective={perspective}
-                  onClick={() => setSelectedShape(shape)}
-                />
-              ))}
-            </div>
-
-            <button
-              onClick={handleInsertShape}
-              disabled={!selectedShape}
-              className={`w-full py-2 text-sm font-medium rounded transition-colors ${
-                selectedShape
-                  ? "bg-ui-bg-interactive text-ui-fg-on-inverted hover:opacity-90"
-                  : "bg-ui-bg-disabled text-ui-fg-disabled cursor-not-allowed"
-              }`}
-            >
-              {selectedShape ? `Insert ${selectedShape.name}` : "Select a Garment"}
-            </button>
-          </>
-        )}
-
-        {/* ── CUT PATTERNS TAB ─────────────────────────────────────────── */}
-        {tab === "patterns" && (
-          <>
-            <p className="text-xs text-ui-fg-subtle leading-snug">
-              Sewing pattern blocks with grain lines and notch marks. Use these as construction references on your moodboard.
-            </p>
-
-            {/* Pattern grid */}
-            <div className="grid grid-cols-3 gap-2">
-              {PATTERN_PIECES.map(piece => (
-                <PatternCard
-                  key={piece.id}
-                  piece={piece}
-                  selected={selectedPattern?.id === piece.id}
-                  onClick={() => setSelectedPattern(piece)}
-                />
-              ))}
-            </div>
-
-            <button
-              onClick={handleInsertPattern}
-              disabled={!selectedPattern}
-              className={`w-full py-2 text-sm font-medium rounded transition-colors ${
-                selectedPattern
-                  ? "bg-ui-bg-interactive text-ui-fg-on-inverted hover:opacity-90"
-                  : "bg-ui-bg-disabled text-ui-fg-disabled cursor-not-allowed"
-              }`}
-            >
-              {selectedPattern ? `Insert ${selectedPattern.name}` : "Select a Pattern Piece"}
-            </button>
-          </>
-        )}
 
         {/* ── PINTEREST TAB ──────────────────────────────────────────── */}
         {tab === "pinterest" && (

--- a/apps/backend/src/admin/components/designs/link-design-to-customer-drawer.tsx
+++ b/apps/backend/src/admin/components/designs/link-design-to-customer-drawer.tsx
@@ -7,6 +7,7 @@ import {
   Checkbox,
   Badge,
   StatusBadge,
+  Skeleton,
   toast,
 } from "@medusajs/ui"
 import { useDesigns, useLinkDesignsToCustomer } from "../../hooks/api/designs"
@@ -111,7 +112,17 @@ export const LinkDesignToCustomerDrawer = ({
           </div>
 
           {isLoading ? (
-            <Text className="text-ui-fg-subtle">Loading designs...</Text>
+            <div className="divide-y">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <div key={i} className="flex items-center gap-x-3 py-3 px-2">
+                  <Skeleton className="h-4 w-4 rounded" />
+                  <div className="flex-1">
+                    <Skeleton className="h-4 w-2/3" />
+                    <Skeleton className="h-3 w-1/3 mt-2" />
+                  </div>
+                </div>
+              ))}
+            </div>
           ) : availableDesigns.length === 0 ? (
             <Text className="text-ui-fg-subtle">No unlinked designs found.</Text>
           ) : (

--- a/apps/backend/src/admin/components/social-platforms/ai-roles.ts
+++ b/apps/backend/src/admin/components/social-platforms/ai-roles.ts
@@ -41,6 +41,10 @@ export const KNOWN_AI_ROLES: KnownAiRole[] = [
     value: "ai_image_extraction",
     label: "Inventory image → items (vision extraction)",
   },
+  {
+    value: "ai_redesign",
+    label: "Moodboard Redesign — Nano-Banana (gemini-2.5-flash-image)",
+  },
 ]
 
 /** Sentinel form value selected when the operator wants a free-form role. */

--- a/apps/backend/src/admin/hooks/api/designs.ts
+++ b/apps/backend/src/admin/hooks/api/designs.ts
@@ -964,6 +964,34 @@ export const useLinkDesignsToCustomer = (
   })
 }
 
+export interface UnlinkDesignsFromCustomerResponse {
+  unlinked: number
+}
+
+export const useUnlinkDesignsFromCustomer = (
+  customerId: string,
+  options?: UseMutationOptions<
+    UnlinkDesignsFromCustomerResponse,
+    FetchError,
+    LinkDesignsToCustomerPayload
+  >
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    ...options,
+    mutationFn: async (payload: LinkDesignsToCustomerPayload) =>
+      sdk.client.fetch<UnlinkDesignsFromCustomerResponse>(
+        `/admin/customers/${customerId}/designs`,
+        { method: "DELETE", body: payload }
+      ),
+    onSuccess: (data, variables, _mutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: designQueryKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: ["customer-ordered-designs", customerId] })
+      options?.onSuccess?.(data, variables, _mutateResult, context)
+    },
+  })
+}
+
 // ─── Create Draft Order from Designs ────────────────────────────────────────
 
 export interface CreateDesignOrderPayload {

--- a/apps/backend/src/admin/widgets/customer-designs.tsx
+++ b/apps/backend/src/admin/widgets/customer-designs.tsx
@@ -1,16 +1,17 @@
 import { defineWidgetConfig } from "@medusajs/admin-sdk"
-import { Container, Text, Badge, StatusBadge, Skeleton, Heading, toast, Checkbox, CommandBar, Button } from "@medusajs/ui"
+import { Container, Text, Badge, StatusBadge, Skeleton, Heading, toast, Checkbox, CommandBar, Button, usePrompt } from "@medusajs/ui"
 import { DetailWidgetProps } from "@medusajs/framework/types"
 import { useState, useMemo, useCallback } from "react"
 import { useNavigate } from "react-router-dom"
 import { ActionMenu } from "../components/common/action-menu"
-import { BellAlert, PencilSquare, Plus, Link as LinkIcon, ShoppingBag, SquareTwoStack } from "@medusajs/icons"
+import { BellAlert, PencilSquare, Plus, Link as LinkIcon, ShoppingBag, SquareTwoStack, XMarkMini } from "@medusajs/icons"
 import {
   useDesigns,
   useNotifyDesignCustomer,
   usePreviewDesignOrder,
   useCreateDesignOrder,
   useCustomerOrderedDesigns,
+  useUnlinkDesignsFromCustomer,
   DesignEstimatePreview,
 } from "../hooks/api/designs"
 import { LinkDesignToCustomerDrawer } from "../components/designs/link-design-to-customer-drawer"
@@ -32,13 +33,17 @@ type Customer = { id: string }
 
 const DesignRow = ({
   design,
+  customerId,
   selected,
   onToggle,
 }: {
   design: any
+  customerId: string
   selected: boolean
   onToggle: (id: string) => void
 }) => {
+  const prompt = usePrompt()
+
   const { mutate: notifyCustomer, isPending: isNotifying } = useNotifyDesignCustomer(design.id, {
     onSuccess: () => {
       toast.success("Notification sent", {
@@ -51,6 +56,30 @@ const DesignRow = ({
       })
     },
   })
+
+  const { mutate: unlinkDesign, isPending: isUnlinking } = useUnlinkDesignsFromCustomer(customerId, {
+    onSuccess: () => {
+      toast.success("Design unlinked", {
+        description: `"${design.name}" is no longer linked to this customer.`,
+      })
+    },
+    onError: (err: any) => {
+      toast.error("Failed to unlink design", {
+        description: err?.message || "An unexpected error occurred.",
+      })
+    },
+  })
+
+  const handleUnlink = async () => {
+    const confirmed = await prompt({
+      title: "Unlink design",
+      description: `Remove the link between "${design.name}" and this customer? The design itself will not be deleted.`,
+      confirmText: "Unlink",
+      cancelText: "Cancel",
+    })
+    if (!confirmed) return
+    unlinkDesign({ design_ids: [design.id] })
+  }
 
   const actionGroups = [
     {
@@ -70,6 +99,16 @@ const DesignRow = ({
           icon: <BellAlert />,
           onClick: () => notifyCustomer(),
           disabled: isNotifying,
+        },
+      ],
+    },
+    {
+      actions: [
+        {
+          label: isUnlinking ? "Unlinking…" : "Unlink from Customer",
+          icon: <XMarkMini />,
+          onClick: handleUnlink,
+          disabled: isUnlinking,
         },
       ],
     },
@@ -386,6 +425,7 @@ const CustomerDesignsWidget = ({ data }: DetailWidgetProps<Customer>) => {
                 <DesignRow
                   key={design.id}
                   design={design}
+                  customerId={data.id}
                   selected={!!selectedRows[design.id]}
                   onToggle={toggleRow}
                 />

--- a/apps/backend/src/api/admin/customers/[id]/designs/route.ts
+++ b/apps/backend/src/api/admin/customers/[id]/designs/route.ts
@@ -24,3 +24,22 @@ export const POST = async (
 
   res.json({ linked: design_ids.length })
 }
+
+export const DELETE = async (
+  req: MedusaRequest<LinkDesignsBody>,
+  res: MedusaResponse
+) => {
+  const { id: customer_id } = req.params
+  const { design_ids } = req.validatedBody as LinkDesignsBody
+
+  const remoteLink = req.scope.resolve(ContainerRegistrationKeys.LINK) as any
+
+  const links = design_ids.map((design_id) => ({
+    [DESIGN_MODULE]: { design_id },
+    [Modules.CUSTOMER]: { customer_id },
+  }))
+
+  await remoteLink.dismiss(links)
+
+  res.json({ unlinked: design_ids.length })
+}

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -3346,6 +3346,13 @@ export default defineMiddlewares({
       ],
     },
     {
+      matcher: "/admin/customers/:id/designs",
+      method: "DELETE",
+      middlewares: [
+        validateAndTransformBody(wrapSchema(LinkDesignsToCustomerSchema)),
+      ],
+    },
+    {
       matcher: "/admin/customers/:id/design-order",
       method: "POST",
       middlewares: [

--- a/apps/backend/src/mastra/services/ai-platforms.ts
+++ b/apps/backend/src/mastra/services/ai-platforms.ts
@@ -64,6 +64,11 @@ export type AiRole =
   // falls back to the auto-rotating OpenRouter free vision model. Previously
   // hardcoded to OPENROUTER_API_KEY which made the feature go dark when unset.
   | "ai_image_extraction"
+  // Moodboard "Redesign" — Nano-Banana (gemini-2.5-flash-image) (#892).
+  // Resolved by resolveRedesignCredentials: honours provider_type=openrouter
+  // (google/gemini-2.5-flash-image) or a hand-tagged google platform; falls
+  // back to OPENROUTER_API_KEY / GOOGLE_GENERATIVE_AI_API_KEY env vars.
+  | "ai_redesign"
   // String escape hatch so callers can use ad-hoc roles without
   // bumping this union every time.
   | (string & {})
@@ -703,4 +708,5 @@ export const AI_ROLES: AiRole[] = [
   "ai_digest_summary",
   "ai_newsletter_drafter",
   "ai_image_extraction",
+  "ai_redesign",
 ]


### PR DESCRIPTION
Bug-fix / polish pass across the Customer Designs widget and the #892 moodboard suite. Four independent commits.

## Customer Designs widget
- **Unlink designs from a customer** — new `DELETE /admin/customers/:id/designs` (dismisses the remote link; the design itself is not deleted) + middleware validation + `useUnlinkDesignsFromCustomer` hook. Each active design row gets an **Unlink from Customer** action behind a confirm prompt. Previously only partner/inventory relations had an unlink path.
- **Skeleton loading** — the link-existing drawer's `Loading designs...` text is replaced with skeleton rows.

## AI provider role (#892)
- `ai_redesign` is now a **first-class selectable role** (added to the `AiRole` union, `AI_ROLES`, and the `KNOWN_AI_ROLES` admin dropdown, label *"Moodboard Redesign — Nano-Banana"*). It was resolvable before but only via the free-text *Custom role* entry.
- To create manually: **Settings → External Platforms → Create AI provider** → provider_type `openrouter`, role *Moodboard Redesign*, paste OpenRouter key (default model `google/gemini-2.5-flash-image` applied automatically).
- `.env.template` gains a documented **AI providers** section (it had none).

## Fashion Library cleanup
- Removed the unused **Garments** and **Patterns** tabs from the moodboard Fashion Library panel; default tab is now Pinterest.

## Construction detail presets
- **Start from a sample** picklist (11 common details) in the Add-detail modal, pre-filling technique/label/params/rules/note. Reuses the existing 8 techniques — no backend change.

## Verification
- `tsc --noEmit` clean on all touched files (pre-existing tree errors unrelated).
- Not yet driven in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)