### PR TITLE
feat(email): engagement-based soft-suppression — capture opens/clicks, drop dormant from bulk, queue win-back (#916)

### DIFF
--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -482,6 +482,9 @@ module.exports = defineConfig({
     resolve: "./src/modules/email_suppression",
   },
   {
+    resolve: "./src/modules/email_engagement",
+  },
+  {
     resolve: "./src/modules/audience",
   },
   {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -528,6 +528,9 @@ module.exports = defineConfig({
     resolve: "./src/modules/email_suppression",
   },
   {
+    resolve: "./src/modules/email_engagement",
+  },
+  {
     resolve: "./src/modules/audience",
   },
   {

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/generate-newsletter-winback-targets-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/generate-newsletter-winback-targets-job.ts
@@ -1,0 +1,159 @@
+import { EMAIL_ENGAGEMENT_MODULE } from "../../../../modules/email_engagement"
+import { MARKETING_MODULE } from "../../../../modules/marketing"
+import {
+  DEFAULT_ENGAGEMENT_THRESHOLDS,
+  type EngagementThresholds,
+} from "../../../../modules/email_engagement/classifier"
+import {
+  selectNewsletterWinbackTargets,
+  DEFAULT_WINBACK_CAP,
+} from "../../../../modules/email_engagement/winback-select"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+const CAMPAIGN = "newsletter-winback"
+
+/** Hard cap on how many engagement rows one run scans. */
+const MAX_SCAN = 5000
+
+function numParam(raw: unknown, fallback: number): number {
+  const n = Number(raw)
+  return Number.isFinite(n) ? n : fallback
+}
+
+/**
+ * #881 Slice 3 — queue newsletter win-back targets from the engagement ledger.
+ *
+ * Selects `cooling` contacts (engaged before, now on a cold streak but not yet
+ * dormant — the pre-dormant nudge window) and creates `marketing_outreach` rows
+ * (campaign="newsletter-winback", channel=email, status=queued). Mirrors the
+ * churn `generate-winback-targets` job: read-only over engagement, presence-based
+ * idempotency (an email already in this campaign is never re-created), dry-run
+ * previews without writing. It does NOT send — the existing outreach flow does,
+ * and the opens/clicks flow back through the Slice-1 bridge.
+ */
+export const generateNewsletterWinbackTargetsJob: MaintenanceJob = {
+  id: "generate-newsletter-winback-targets",
+  label: "Generate newsletter winback targets",
+  description:
+    "Queue newsletter win-back targets from the email_engagement ledger: select `cooling` contacts (pre-dormant) and create marketing_outreach rows (campaign=newsletter-winback, channel=email, status=queued). Read-only over engagement, idempotent (email already in the campaign is skipped), dry-run previews without writing. Does not send — the outreach flow handles that; opens/clicks reconcile back via the engagement bridge.",
+  params: [
+    {
+      name: "max_targets",
+      type: "number",
+      required: false,
+      description: "Max win-back rows to create per run (coldest first). Default 100.",
+    },
+    {
+      name: "cooling_cold_streak",
+      type: "number",
+      required: false,
+      description: "Cold streak to qualify as `cooling`. Default 3 (must match the recompute policy).",
+    },
+    {
+      name: "dormant_cold_streak",
+      type: "number",
+      required: false,
+      description: "Upper bound — at/above this a contact is `dormant`, not `cooling`. Default 5.",
+    },
+    {
+      name: "dormant_min_span_days",
+      type: "number",
+      required: false,
+      description: "Min first-delivery age (days) before `dormant` applies. Default 30.",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const engagement: any = container.resolve(EMAIL_ENGAGEMENT_MODULE)
+    const marketing: any = container.resolve(MARKETING_MODULE)
+
+    const cap = numParam(params.max_targets, DEFAULT_WINBACK_CAP)
+    const thresholds: Partial<EngagementThresholds> = {
+      coolingColdStreak: numParam(params.cooling_cold_streak, DEFAULT_ENGAGEMENT_THRESHOLDS.coolingColdStreak),
+      dormantColdStreak: numParam(params.dormant_cold_streak, DEFAULT_ENGAGEMENT_THRESHOLDS.dormantColdStreak),
+      dormantMinSpanDays: numParam(params.dormant_min_span_days, DEFAULT_ENGAGEMENT_THRESHOLDS.dormantMinSpanDays),
+    }
+
+    // Engagement rows (read-only), classified live so a stale stored status
+    // never mis-targets.
+    const rows: any[] = await engagement
+      .listEmailEngagements(
+        {},
+        {
+          select: [
+            "email",
+            "delivered_count",
+            "opens_count",
+            "clicks_count",
+            "delivered_since_last_open",
+            "first_delivered_at",
+            "last_open_at",
+            "last_delivered_at",
+          ],
+          take: MAX_SCAN,
+        }
+      )
+      .catch(() => [])
+
+    // Idempotency — emails already in this campaign.
+    const existing: any[] = await marketing
+      .listMarketingOutreaches({ campaign: CAMPAIGN })
+      .catch(() => [])
+    const alreadyTargeted = new Set<string>(
+      (existing ?? [])
+        .map((o) => (o.recipient_email || "").trim().toLowerCase())
+        .filter(Boolean)
+    )
+
+    const selection = selectNewsletterWinbackTargets(rows, alreadyTargeted, {
+      thresholds,
+      cap,
+    })
+
+    let createdCount = 0
+    if (!dry_run && selection.targets.length) {
+      const created = await marketing.createMarketingOutreaches(
+        selection.targets.map((t) => ({
+          recipient_email: t.email,
+          campaign: CAMPAIGN,
+          channel: "email",
+          status: "queued",
+          notes: `newsletter winback — cold_streak=${t.cold_streak}${
+            t.last_open_at ? `, last_open=${t.last_open_at}` : ", never opened"
+          }`,
+        }))
+      )
+      createdCount = Array.isArray(created) ? created.length : created ? 1 : 0
+    }
+
+    const { targets, stats } = selection
+    const changes: MaintenanceChange[] = targets.map((t) => ({
+      entity: "marketing_outreach",
+      id: t.email,
+      field: "created",
+      after: {
+        campaign: CAMPAIGN,
+        recipient_email: t.email,
+        cold_streak: t.cold_streak,
+        status: dry_run ? "(would create)" : "queued",
+      },
+    }))
+
+    const cappedNote = stats.capped > 0 ? ` (${stats.capped} over the cap not selected)` : ""
+    const skipNote =
+      stats.skipped_already || stats.skipped_no_email
+        ? ` Skipped ${stats.skipped_already} already-targeted, ${stats.skipped_no_email} no-email.`
+        : ""
+    const verb = dry_run ? "Would create" : "Created"
+    return {
+      job_id: generateNewsletterWinbackTargetsJob.id,
+      dry_run,
+      applied: !dry_run && createdCount > 0,
+      summary:
+        `${verb} ${dry_run ? stats.targeted : createdCount} newsletter-winback target(s) ` +
+        `from ${stats.cooling} cooling contact(s) (scanned ${stats.scanned})${cappedNote}.${skipNote}`,
+      changes,
+    }
+  },
+}
+
+export default generateNewsletterWinbackTargetsJob

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/recompute-email-engagement-status-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/recompute-email-engagement-status-job.ts
@@ -1,0 +1,143 @@
+import { EMAIL_ENGAGEMENT_MODULE } from "../../../../modules/email_engagement"
+import {
+  classifyEngagement,
+  DEFAULT_ENGAGEMENT_THRESHOLDS,
+  type EngagementStatus,
+  type EngagementThresholds,
+} from "../../../../modules/email_engagement/classifier"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/** Split into fixed-size batches so a large ledger never becomes one unbounded UPDATE. */
+function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = []
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size))
+  return out
+}
+
+const WRITE_BATCH = 500
+
+const ALL_STATUSES: EngagementStatus[] = [
+  "engaged",
+  "cooling",
+  "dormant",
+  "never_opened",
+  "unknown",
+]
+
+function numParam(raw: unknown, fallback: number): number {
+  const n = Number(raw)
+  return Number.isFinite(n) ? n : fallback
+}
+
+/**
+ * Recompute the persisted `engagement_status` on every `email_engagement` row
+ * from its live counters (#881 engagement scoring). This is the visibility +
+ * win-back feed; the send-path gate recomputes live, so this never has to be
+ * fresh for correctness — it just keeps the queryable status current.
+ *
+ * Dry-run reports the status distribution + how many rows would change without
+ * writing; apply persists only the rows whose status actually changed
+ * (change-detected + batched, so a settled ledger re-run is a near no-op).
+ * Thresholds are overridable per run so the operator can tune the policy from
+ * the ops UI without a deploy.
+ */
+export const recomputeEmailEngagementStatusJob: MaintenanceJob = {
+  id: "recompute-email-engagement-status",
+  label: "Recompute email engagement status",
+  description:
+    "Classify every email_engagement row (engaged / cooling / dormant / never_opened / unknown) from its delivery/open/click counters and persist engagement_status. Dry-run reports the distribution + change count without writing; apply updates only changed rows. Only `dormant` is excluded from bulk sends (soft exclusion — rows stay visible). Thresholds tunable per run.",
+  params: [
+    {
+      name: "dormant_cold_streak",
+      type: "number",
+      required: false,
+      description: "Deliveries-since-last-open (or deliveries if never opened) to reach `dormant`. Default 5.",
+    },
+    {
+      name: "dormant_min_span_days",
+      type: "number",
+      required: false,
+      description: "Min age (days) of the first delivery before `dormant` can apply. Default 30.",
+    },
+    {
+      name: "cooling_cold_streak",
+      type: "number",
+      required: false,
+      description: "Cold streak that flags an ever-engaged contact as `cooling` (win-back). Default 3.",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const service: any = container.resolve(EMAIL_ENGAGEMENT_MODULE)
+
+    const thresholds: Partial<EngagementThresholds> = {
+      dormantColdStreak: numParam(params.dormant_cold_streak, DEFAULT_ENGAGEMENT_THRESHOLDS.dormantColdStreak),
+      dormantMinSpanDays: numParam(params.dormant_min_span_days, DEFAULT_ENGAGEMENT_THRESHOLDS.dormantMinSpanDays),
+      coolingColdStreak: numParam(params.cooling_cold_streak, DEFAULT_ENGAGEMENT_THRESHOLDS.coolingColdStreak),
+    }
+
+    const rows: any[] = await service
+      .listEmailEngagements(
+        {},
+        {
+          select: [
+            "id",
+            "email",
+            "delivered_count",
+            "opens_count",
+            "clicks_count",
+            "delivered_since_last_open",
+            "first_delivered_at",
+            "engagement_status",
+          ],
+          take: null,
+        }
+      )
+      .catch(() => [])
+
+    const now = new Date()
+    const nowIso = now.toISOString()
+    const dist: Record<EngagementStatus, number> = {
+      engaged: 0,
+      cooling: 0,
+      dormant: 0,
+      never_opened: 0,
+      unknown: 0,
+    }
+    const toUpdate: Array<{ id: string; engagement_status: EngagementStatus; status_computed_at: string }> = []
+
+    for (const r of rows) {
+      const { status } = classifyEngagement(r, { now, thresholds })
+      dist[status]++
+      if (r.engagement_status !== status) {
+        toUpdate.push({ id: r.id, engagement_status: status, status_computed_at: nowIso })
+      }
+    }
+
+    if (!dry_run && toUpdate.length) {
+      for (const batch of chunk(toUpdate, WRITE_BATCH)) {
+        await service.updateEmailEngagements(batch)
+      }
+    }
+
+    const changes: MaintenanceChange[] = [
+      { entity: "email_engagement", id: "changed", field: "count", after: toUpdate.length },
+      ...ALL_STATUSES.map(
+        (s): MaintenanceChange => ({ entity: "email_engagement", id: `status:${s}`, field: "count", after: dist[s] })
+      ),
+    ]
+
+    const verb = dry_run ? "Would reclassify" : "Reclassified"
+    return {
+      job_id: recomputeEmailEngagementStatusJob.id,
+      dry_run,
+      applied: !dry_run && toUpdate.length > 0,
+      summary:
+        `${verb} ${rows.length} engagement row(s) — ${toUpdate.length} changed. ` +
+        `Distribution: ${ALL_STATUSES.map((s) => `${s}=${dist[s]}`).join(", ")}` +
+        ` (dormant ${dist.dormant} dropped from bulk).`,
+      changes,
+    }
+  },
+}
+
+export default recomputeEmailEngagementStatusJob

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -78,6 +78,8 @@ import { backfillPartnerEmailVerifiedJob } from "./backfill-partner-email-verifi
 import { enableStripeConnectEurRegionsJob } from "./enable-stripe-connect-eur-regions-job"
 import { suppressBouncedSubscribersJob } from "./suppress-bounced-subscribers-job"
 import { backfillAudienceEntriesJob } from "./backfill-audience-entries-job"
+import { recomputeEmailEngagementStatusJob } from "./recompute-email-engagement-status-job"
+import { generateNewsletterWinbackTargetsJob } from "./generate-newsletter-winback-targets-job"
 import { repairInventoryOrderSourceJob } from "./repair-inventory-order-source-job"
 import {
   sweepAiPlatformsByCategory,
@@ -5414,6 +5416,8 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   enableStripeConnectEurRegionsJob,
   suppressBouncedSubscribersJob,
   backfillAudienceEntriesJob,
+  recomputeEmailEngagementStatusJob,
+  generateNewsletterWinbackTargetsJob,
   repairInventoryOrderSourceJob,
 ]
 

--- a/apps/backend/src/api/webhooks/mailjet/events/route.ts
+++ b/apps/backend/src/api/webhooks/mailjet/events/route.ts
@@ -3,6 +3,9 @@ import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
 import { parseMailjetEvents } from "../../../../modules/email_suppression/provider-parsers"
 import { suppressEmail } from "../../../../modules/email_suppression/suppress-core"
+import { parseMailjetEngagement } from "../../../../modules/email_engagement/provider-parsers"
+import { recordEngagement } from "../../../../modules/email_engagement/engagement-core"
+import { bridgeOutreachEngagement } from "../../../../modules/marketing/bridge-engagement"
 
 /**
  * POST /webhooks/mailjet/events
@@ -33,21 +36,28 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
 
   const body = req.body as any
   const items = parseMailjetEvents(body)
+  const engagement = parseMailjetEngagement(body)
 
   // Ack immediately; process async (Mailjet retries on non-2xx).
   res.status(200).send("OK")
 
-  processMailjetEvents(req.scope, body, items).catch((error) => {
+  processMailjetEvents(req.scope, body, items, engagement).catch((error) => {
     logger.error("[Mailjet Events] Failed to process events:", error as Error)
   })
 }
 
-async function processMailjetEvents(scope: any, body: any, items: any[]): Promise<void> {
+async function processMailjetEvents(
+  scope: any,
+  body: any,
+  items: any[],
+  engagement: any[]
+): Promise<void> {
   const logger: any = scope.resolve(ContainerRegistrationKeys.LOGGER)
-  if (!items.length) {
+  if (!items.length && !engagement.length) {
     logger.info("[Mailjet Events] No actionable events in payload")
     return
   }
+  // Suppression events (bounce/blocked/spam/unsub) — take the recipient off the list.
   for (const item of items) {
     const outcome = await suppressEmail(scope, {
       email: item.email,
@@ -59,6 +69,27 @@ async function processMailjetEvents(scope: any, body: any, items: any[]): Promis
     })
     logger.info(
       `[Mailjet Events] ${item.reason} ${item.email} → suppressed=${outcome.suppressed} (p:${outcome.persons} c:${outcome.customers} l:${outcome.leads})${outcome.duplicate ? " [dup]" : ""}`
+    )
+  }
+  // Engagement events (sent→delivered / open / click) — fold into the ledger
+  // and (Option C) feed any matching marketing_outreach campaign row.
+  for (const ev of engagement) {
+    const outcome = await recordEngagement(scope, {
+      email: ev.email,
+      type: ev.type,
+      provider: "mailjet",
+      event_id: ev.event_id,
+      event_at: ev.event_at,
+      message_id: ev.message_id,
+      raw: ev,
+    })
+    const bridged = await bridgeOutreachEngagement(scope, {
+      type: ev.type,
+      message_id: ev.message_id,
+      event_at: ev.event_at,
+    }).catch(() => ({ matched: 0, changed: 0 }))
+    logger.info(
+      `[Mailjet Events] engagement ${ev.type} ${ev.email} → recorded=${outcome.recorded}${outcome.duplicate ? " [dup]" : ""}${bridged.changed ? ` [outreach:${bridged.changed}]` : ""}`
     )
   }
 }

--- a/apps/backend/src/api/webhooks/resend/email-events/route.ts
+++ b/apps/backend/src/api/webhooks/resend/email-events/route.ts
@@ -8,6 +8,9 @@ import type EncryptionService from "../../../../modules/encryption/service"
 import type { EncryptedData } from "../../../../modules/encryption"
 import { parseResendEvent } from "../../../../modules/email_suppression/provider-parsers"
 import { suppressEmail } from "../../../../modules/email_suppression/suppress-core"
+import { parseResendEngagement } from "../../../../modules/email_engagement/provider-parsers"
+import { recordEngagement } from "../../../../modules/email_engagement/engagement-core"
+import { bridgeOutreachEngagement } from "../../../../modules/marketing/bridge-engagement"
 
 /**
  * POST /webhooks/resend/email-events
@@ -92,10 +95,12 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
 async function processResendDeliveryEvent(scope: any, payload: any): Promise<void> {
   const logger: any = scope.resolve(ContainerRegistrationKeys.LOGGER)
   const items = parseResendEvent(payload)
-  if (!items.length) {
+  const engagement = parseResendEngagement(payload)
+  if (!items.length && !engagement.length) {
     logger.info(`[Resend Events] Ignoring event type: ${payload?.type}`)
     return
   }
+  // Suppression events (email.bounced / email.complained).
   for (const item of items) {
     const outcome = await suppressEmail(scope, {
       email: item.email,
@@ -107,6 +112,27 @@ async function processResendDeliveryEvent(scope: any, payload: any): Promise<voi
     })
     logger.info(
       `[Resend Events] ${item.reason} ${item.email} → suppressed=${outcome.suppressed} (p:${outcome.persons} c:${outcome.customers} l:${outcome.leads})${outcome.duplicate ? " [dup]" : ""}`
+    )
+  }
+  // Engagement events (email.delivered / email.opened / email.clicked) — fold
+  // into the ledger and (Option C) feed any matching marketing_outreach row.
+  for (const ev of engagement) {
+    const outcome = await recordEngagement(scope, {
+      email: ev.email,
+      type: ev.type,
+      provider: "resend",
+      event_id: ev.event_id,
+      event_at: ev.event_at,
+      message_id: ev.message_id,
+      raw: payload,
+    })
+    const bridged = await bridgeOutreachEngagement(scope, {
+      type: ev.type,
+      message_id: ev.message_id,
+      event_at: ev.event_at,
+    }).catch(() => ({ matched: 0, changed: 0 }))
+    logger.info(
+      `[Resend Events] engagement ${ev.type} ${ev.email} → recorded=${outcome.recorded}${outcome.duplicate ? " [dup]" : ""}${bridged.changed ? ` [outreach:${bridged.changed}]` : ""}`
     )
   }
 }

--- a/apps/backend/src/modules/email_engagement/__tests__/classifier.unit.spec.ts
+++ b/apps/backend/src/modules/email_engagement/__tests__/classifier.unit.spec.ts
@@ -1,0 +1,115 @@
+import {
+  classifyEngagement,
+  isBulkSuppressed,
+} from "../classifier"
+import { selectNewsletterWinbackTargets } from "../winback-select"
+
+const NOW = new Date("2026-07-06T00:00:00.000Z")
+const daysAgo = (d: number) =>
+  new Date(NOW.getTime() - d * 24 * 60 * 60 * 1000).toISOString()
+
+describe("classifier — classifyEngagement", () => {
+  it("unknown when too little data (< minDataDelivered)", () => {
+    expect(classifyEngagement({ delivered_count: 2, opens_count: 0 }, { now: NOW }).status).toBe("unknown")
+  })
+
+  it("engaged when recently opened (short cold streak)", () => {
+    const c = classifyEngagement(
+      { delivered_count: 10, opens_count: 4, delivered_since_last_open: 1, first_delivered_at: daysAgo(120) },
+      { now: NOW }
+    )
+    expect(c.status).toBe("engaged")
+    expect(c.bulk_suppressed).toBe(false)
+  })
+
+  it("cooling when an ever-engaged contact hits the cooling streak but not dormant", () => {
+    const c = classifyEngagement(
+      { delivered_count: 10, opens_count: 2, delivered_since_last_open: 3, first_delivered_at: daysAgo(120) },
+      { now: NOW }
+    )
+    expect(c.status).toBe("cooling")
+    expect(c.bulk_suppressed).toBe(false)
+  })
+
+  it("dormant when an ever-engaged contact goes cold past the streak over enough time", () => {
+    const c = classifyEngagement(
+      { delivered_count: 12, opens_count: 2, delivered_since_last_open: 5, first_delivered_at: daysAgo(120) },
+      { now: NOW }
+    )
+    expect(c.status).toBe("dormant")
+    expect(c.bulk_suppressed).toBe(true)
+  })
+
+  it("NOT dormant if the cold streak is old enough but the account is too young (span < 30d)", () => {
+    const c = classifyEngagement(
+      { delivered_count: 12, opens_count: 2, delivered_since_last_open: 6, first_delivered_at: daysAgo(10) },
+      { now: NOW }
+    )
+    expect(c.status).toBe("cooling") // flagged, but not suppressed
+    expect(c.bulk_suppressed).toBe(false)
+  })
+
+  it("never_opened when opens=0 but not yet enough deliveries/time for dormant", () => {
+    const c = classifyEngagement(
+      { delivered_count: 4, opens_count: 0, delivered_since_last_open: 4, first_delivered_at: daysAgo(120) },
+      { now: NOW }
+    )
+    expect(c.status).toBe("never_opened")
+    expect(c.bulk_suppressed).toBe(false)
+  })
+
+  it("dormant when opens=0 with enough deliveries over enough time", () => {
+    const c = classifyEngagement(
+      { delivered_count: 6, opens_count: 0, delivered_since_last_open: 6, first_delivered_at: daysAgo(120) },
+      { now: NOW }
+    )
+    expect(c.status).toBe("dormant")
+  })
+
+  it("only dormant is bulk-suppressed", () => {
+    expect(isBulkSuppressed("dormant")).toBe(true)
+    expect(isBulkSuppressed("cooling")).toBe(false)
+    expect(isBulkSuppressed("never_opened")).toBe(false)
+    expect(isBulkSuppressed("engaged")).toBe(false)
+    expect(isBulkSuppressed("unknown")).toBe(false)
+  })
+})
+
+describe("winback-select — selectNewsletterWinbackTargets", () => {
+  const cooling = (email: string, cold: number) => ({
+    email,
+    delivered_count: 10,
+    opens_count: 2,
+    delivered_since_last_open: cold,
+    first_delivered_at: daysAgo(120),
+    last_open_at: daysAgo(60),
+    last_delivered_at: daysAgo(1),
+  })
+
+  it("selects only cooling contacts, coldest first, and skips already-targeted", () => {
+    const rows = [
+      cooling("a@x.com", 3),
+      cooling("b@x.com", 4),
+      { ...cooling("c@x.com", 5) }, // dormant (streak 5) — excluded
+      { email: "d@x.com", delivered_count: 10, opens_count: 5, delivered_since_last_open: 1, first_delivered_at: daysAgo(120) }, // engaged
+    ]
+    const sel = selectNewsletterWinbackTargets(rows, new Set(["a@x.com"]), { now: NOW })
+    expect(sel.targets.map((t) => t.email)).toEqual(["b@x.com"]) // a skipped (already), coldest-first
+    expect(sel.stats.cooling).toBe(2) // a + b classified cooling
+    expect(sel.stats.skipped_already).toBe(1)
+  })
+
+  it("caps the target list and reports the overflow", () => {
+    const rows = [cooling("a@x.com", 4), cooling("b@x.com", 3), cooling("c@x.com", 3)]
+    const sel = selectNewsletterWinbackTargets(rows, new Set(), { now: NOW, cap: 2 })
+    expect(sel.targets).toHaveLength(2)
+    expect(sel.stats.capped).toBe(1)
+    expect(sel.targets[0].email).toBe("a@x.com") // coldest first
+  })
+
+  it("skips cooling rows with no email", () => {
+    const sel = selectNewsletterWinbackTargets([cooling("", 4)], new Set(), { now: NOW })
+    expect(sel.targets).toHaveLength(0)
+    expect(sel.stats.skipped_no_email).toBe(1)
+  })
+})

--- a/apps/backend/src/modules/email_engagement/__tests__/engagement.unit.spec.ts
+++ b/apps/backend/src/modules/email_engagement/__tests__/engagement.unit.spec.ts
@@ -1,0 +1,116 @@
+import {
+  parseMailjetEngagement,
+  parseResendEngagement,
+} from "../provider-parsers"
+import { applyEngagement } from "../engagement-core"
+
+describe("provider-parsers — parseMailjetEngagement", () => {
+  it("maps sent→delivered / open / click with per-message+type event ids", () => {
+    expect(
+      parseMailjetEngagement({ event: "sent", email: "A@X.com", MessageID: 42, time: 1_700_000_000 })
+    ).toEqual([
+      {
+        email: "a@x.com",
+        type: "delivered",
+        event_id: "mje:delivered:42",
+        event_at: new Date(1_700_000_000_000).toISOString(),
+        message_id: "42",
+      },
+    ])
+    expect(parseMailjetEngagement({ event: "open", email: "a@x.com", MessageID: 42 })[0]).toMatchObject({ type: "open", event_id: "mje:open:42" })
+    expect(parseMailjetEngagement({ event: "click", email: "a@x.com", MessageID: 42 })[0]).toMatchObject({ type: "click", event_id: "mje:click:42" })
+  })
+  it("ignores suppression + unknown events, accepts arrays", () => {
+    const out = parseMailjetEngagement([
+      { event: "bounce", email: "a@x.com" },
+      { event: "spam", email: "a@x.com" },
+      { event: "open", email: "b@y.com", MessageID: 7 },
+    ])
+    expect(out).toHaveLength(1)
+    expect(out[0]).toMatchObject({ email: "b@y.com", type: "open" })
+  })
+  it("skips no-email + tolerates junk; null event_id when no message id", () => {
+    expect(parseMailjetEngagement({ event: "open" })).toEqual([])
+    expect(parseMailjetEngagement(null)).toEqual([])
+    expect(parseMailjetEngagement({ event: "open", email: "a@x.com" })[0].event_id).toBeNull()
+  })
+})
+
+describe("provider-parsers — parseResendEngagement", () => {
+  it("maps delivered/opened/clicked across all recipients", () => {
+    const out = parseResendEngagement({
+      type: "email.delivered",
+      created_at: "2026-07-06T00:00:00.000Z",
+      data: { email_id: "e1", to: ["A@X.com", "b@y.com"] },
+    })
+    expect(out).toHaveLength(2)
+    expect(out[0]).toEqual({
+      email: "a@x.com",
+      type: "delivered",
+      event_id: "rse:delivered:e1:a@x.com",
+      event_at: "2026-07-06T00:00:00.000Z",
+      message_id: "e1",
+    })
+    expect(parseResendEngagement({ type: "email.opened", data: { email_id: "e1", to: "a@x.com" } })[0].type).toBe("open")
+    expect(parseResendEngagement({ type: "email.clicked", data: { email_id: "e1", to: "a@x.com" } })[0].type).toBe("click")
+  })
+  it("does NOT count email.sent (pre-delivery) and ignores bounces + empty recipients", () => {
+    expect(parseResendEngagement({ type: "email.sent", data: { to: ["a@x.com"] } })).toEqual([])
+    expect(parseResendEngagement({ type: "email.bounced", data: { to: ["a@x.com"] } })).toEqual([])
+    expect(parseResendEngagement({ type: "email.opened", data: { to: [] } })).toEqual([])
+  })
+})
+
+describe("engagement-core — applyEngagement", () => {
+  const t0 = "2026-06-01T00:00:00.000Z"
+  const t1 = "2026-06-08T00:00:00.000Z"
+  const t2 = "2026-06-15T00:00:00.000Z"
+
+  it("folds a first delivery into an empty aggregate", () => {
+    expect(applyEngagement(null, "delivered", t0)).toEqual({
+      delivered_count: 1,
+      opens_count: 0,
+      clicks_count: 0,
+      delivered_since_last_open: 1,
+      first_delivered_at: t0,
+      last_delivered_at: t0,
+      last_open_at: null,
+      last_click_at: null,
+      last_event_at: t0,
+    })
+  })
+
+  it("builds a cold streak across deliveries, then an open resets it", () => {
+    let agg = applyEngagement(null, "delivered", t0)
+    agg = applyEngagement(agg, "delivered", t1)
+    expect(agg.delivered_since_last_open).toBe(2)
+    agg = applyEngagement(agg, "open", t2)
+    expect(agg).toMatchObject({
+      delivered_count: 2,
+      opens_count: 1,
+      delivered_since_last_open: 0,
+      first_delivered_at: t0,
+      last_delivered_at: t1,
+      last_open_at: t2,
+    })
+  })
+
+  it("treats a click as engagement: resets streak and implies an open", () => {
+    let agg = applyEngagement(null, "delivered", t0)
+    agg = applyEngagement(agg, "click", t1)
+    expect(agg).toMatchObject({
+      clicks_count: 1,
+      delivered_since_last_open: 0,
+      last_click_at: t1,
+      last_open_at: t1,
+    })
+  })
+
+  it("folds timestamps order-independently (out-of-order webhooks safe)", () => {
+    // Later delivery folded first, earlier delivery second.
+    let agg = applyEngagement(null, "delivered", t2)
+    agg = applyEngagement(agg, "delivered", t0)
+    expect(agg.first_delivered_at).toBe(t0)
+    expect(agg.last_delivered_at).toBe(t2)
+  })
+})

--- a/apps/backend/src/modules/email_engagement/classifier.ts
+++ b/apps/backend/src/modules/email_engagement/classifier.ts
@@ -1,0 +1,122 @@
+/**
+ * PURE engagement classifier — the single policy that turns an `email_engagement`
+ * aggregate into a status. Read by BOTH the recompute job (persists the status
+ * for visibility + win-back selection) and the send path (live gate: `dormant`
+ * drops from BULK sends). No IO — fully unit-testable.
+ *
+ * Policy (soft exclusion — see #3): only `dormant` is bulk-suppressed. `cooling`
+ * is the pre-dormant win-back target; `never_opened` / `engaged` / `unknown`
+ * still get mailed. Deliberately conservative: too little data → `unknown`, and
+ * any open/click keeps someone out of `dormant`.
+ */
+
+export type EngagementStatus =
+  | "engaged"
+  | "cooling"
+  | "dormant"
+  | "never_opened"
+  | "unknown"
+
+export type EngagementThresholds = {
+  /** Below this many deliveries we can't judge → `unknown`. */
+  minDataDelivered: number
+  /** Cold streak (deliveries since last open) that tips an ever-engaged contact
+   * to `dormant` — and, for a never-opened contact, the delivery count. */
+  dormantColdStreak: number
+  /** …but only once the first delivery is at least this many days old (so a
+   * fresh burst of sends can't dormant someone overnight). */
+  dormantMinSpanDays: number
+  /** Cold streak that flags an ever-engaged contact as `cooling` (win-back). */
+  coolingColdStreak: number
+}
+
+export const DEFAULT_ENGAGEMENT_THRESHOLDS: EngagementThresholds = {
+  minDataDelivered: 3,
+  dormantColdStreak: 5,
+  dormantMinSpanDays: 30,
+  coolingColdStreak: 3,
+}
+
+/** The aggregate columns the classifier reads (subset of `email_engagement`). */
+export type EngagementRow = {
+  delivered_count?: number | null
+  opens_count?: number | null
+  clicks_count?: number | null
+  delivered_since_last_open?: number | null
+  first_delivered_at?: Date | string | null
+}
+
+export type EngagementClassification = {
+  status: EngagementStatus
+  /** true when this status is excluded from BULK sends (only `dormant`). */
+  bulk_suppressed: boolean
+  /** short human reason, for the recompute audit + UI. */
+  reason: string
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+function n(v: unknown): number {
+  return typeof v === "number" && Number.isFinite(v) ? v : 0
+}
+
+function spanDays(first: Date | string | null | undefined, now: Date): number {
+  if (!first) return 0
+  const t = new Date(first).getTime()
+  if (Number.isNaN(t)) return 0
+  return (now.getTime() - t) / MS_PER_DAY
+}
+
+/** Which statuses are dropped from bulk sends. Single source of the gate. */
+export function isBulkSuppressed(status: EngagementStatus): boolean {
+  return status === "dormant"
+}
+
+/**
+ * Classify one aggregate. `now` is injected (defaults to a fresh Date) so the
+ * recompute + tests are deterministic.
+ */
+export function classifyEngagement(
+  row: EngagementRow,
+  opts: { now?: Date; thresholds?: Partial<EngagementThresholds> } = {}
+): EngagementClassification {
+  const now = opts.now ?? new Date()
+  const th = { ...DEFAULT_ENGAGEMENT_THRESHOLDS, ...(opts.thresholds ?? {}) }
+
+  const delivered = n(row.delivered_count)
+  const opens = n(row.opens_count)
+  const clicks = n(row.clicks_count)
+  const cold = n(row.delivered_since_last_open)
+  const span = spanDays(row.first_delivered_at, now)
+
+  const wrap = (status: EngagementStatus, reason: string): EngagementClassification => ({
+    status,
+    bulk_suppressed: isBulkSuppressed(status),
+    reason,
+  })
+
+  // Too little signal to judge — never suppress on thin data.
+  if (delivered < th.minDataDelivered) {
+    return wrap("unknown", `only ${delivered} delivered (< ${th.minDataDelivered})`)
+  }
+
+  const everEngaged = opens > 0 || clicks > 0
+  const oldEnough = span >= th.dormantMinSpanDays
+
+  if (!everEngaged) {
+    // Never opened anything.
+    if (delivered >= th.dormantColdStreak && oldEnough) {
+      return wrap("dormant", `never opened in ${delivered} deliveries over ${Math.round(span)}d`)
+    }
+    return wrap("never_opened", `opens=0 after ${delivered} deliveries (${Math.round(span)}d)`)
+  }
+
+  // Engaged at some point — judge on the cold streak since last open.
+  if (cold >= th.dormantColdStreak && oldEnough) {
+    return wrap("dormant", `${cold} deliveries since last open over ${Math.round(span)}d`)
+  }
+  if (cold >= th.coolingColdStreak) {
+    return wrap("cooling", `${cold} deliveries since last open`)
+  }
+  return wrap("engaged", `recent open/click (cold streak ${cold})`)
+}

--- a/apps/backend/src/modules/email_engagement/engagement-core.ts
+++ b/apps/backend/src/modules/email_engagement/engagement-core.ts
@@ -1,0 +1,188 @@
+import { normalizeEmail } from "../email_suppression/suppress-core"
+import { EMAIL_ENGAGEMENT_MODULE } from "./index"
+import type { EngagementType } from "./provider-parsers"
+
+/**
+ * Shared engagement core — the ONE place a delivery/open/click event updates a
+ * recipient's engagement rollup, called from the Mailjet + Resend delivery-event
+ * webhooks. Writes a raw `email_engagement_event` row (idempotent on `event_id`)
+ * and folds it into the `email_engagement` aggregate. Never suppresses anything
+ * itself — the aggregate is read later by the engagement recompute, which does
+ * the soft-exclusion. Sibling of `suppress-core`.
+ */
+
+export type EngagementProvider = "mailjet" | "resend" | "other"
+
+export type EngagementInput = {
+  email: string
+  type: EngagementType
+  provider: EngagementProvider
+  event_id?: string | null
+  event_at?: string | null
+  message_id?: string | null
+  raw?: any
+}
+
+export type EngagementOutcome = {
+  email: string
+  type: EngagementType
+  /** true when the aggregate was updated (first time we saw this event). */
+  recorded: boolean
+  /** true when skipped because the same event_id was already processed. */
+  duplicate: boolean
+}
+
+/** The mutable counters `applyEngagement` returns (a partial aggregate row). */
+export type EngagementAggregate = {
+  delivered_count: number
+  opens_count: number
+  clicks_count: number
+  delivered_since_last_open: number
+  first_delivered_at: string | null
+  last_delivered_at: string | null
+  last_open_at: string | null
+  last_click_at: string | null
+  last_event_at: string | null
+}
+
+/** PURE: later of two ISO instants (either may be null/undefined). */
+function laterIso(a: string | null | undefined, b: string): string {
+  return !a || b > a ? b : a
+}
+
+/** PURE: earlier of two ISO instants (either may be null/undefined). */
+function earlierIso(a: string | null | undefined, b: string): string {
+  return !a || b < a ? b : a
+}
+
+function num(v: unknown): number {
+  return typeof v === "number" && Number.isFinite(v) ? v : 0
+}
+
+function iso(v: unknown): string | null {
+  if (!v) return null
+  if (v instanceof Date) return v.toISOString()
+  return String(v)
+}
+
+/**
+ * PURE: fold one engagement event into the aggregate. `existing` is the current
+ * row (or null/undefined for a brand-new email). Returns the next counter set.
+ *
+ *  - delivered → delivered_count++, extend the delivered-since-open cold streak
+ *  - open      → opens_count++, reset the cold streak (they're alive)
+ *  - click     → clicks_count++, reset the cold streak, and imply an open if we
+ *                haven't recorded one (a click is a strictly stronger signal)
+ *
+ * Timestamps are folded order-independently (min for first_*, max for last_*),
+ * so out-of-order webhook delivery can't corrupt them. The cold streak resets on
+ * ANY open/click, so races only ever LOSE cold deliveries → we err toward
+ * keeping people on the list, never toward wrongly marking them dormant.
+ */
+export function applyEngagement(
+  existing: Partial<EngagementAggregate> | null | undefined,
+  type: EngagementType,
+  at: string
+): EngagementAggregate {
+  const e = existing || {}
+  const next: EngagementAggregate = {
+    delivered_count: num(e.delivered_count),
+    opens_count: num(e.opens_count),
+    clicks_count: num(e.clicks_count),
+    delivered_since_last_open: num(e.delivered_since_last_open),
+    first_delivered_at: iso(e.first_delivered_at),
+    last_delivered_at: iso(e.last_delivered_at),
+    last_open_at: iso(e.last_open_at),
+    last_click_at: iso(e.last_click_at),
+    last_event_at: iso(e.last_event_at),
+  }
+
+  if (type === "delivered") {
+    next.delivered_count += 1
+    next.delivered_since_last_open += 1
+    next.last_delivered_at = laterIso(next.last_delivered_at, at)
+    next.first_delivered_at = earlierIso(next.first_delivered_at, at)
+  } else if (type === "open") {
+    next.opens_count += 1
+    next.delivered_since_last_open = 0
+    next.last_open_at = laterIso(next.last_open_at, at)
+  } else if (type === "click") {
+    next.clicks_count += 1
+    next.delivered_since_last_open = 0
+    next.last_click_at = laterIso(next.last_click_at, at)
+    // A click implies engagement even if the open event never reached us.
+    next.last_open_at = laterIso(next.last_open_at, at)
+  }
+
+  next.last_event_at = laterIso(next.last_event_at, at)
+  return next
+}
+
+/**
+ * Record one engagement event: idempotent raw-row insert + aggregate fold.
+ * Container-driven (resolves the email_engagement service).
+ */
+export async function recordEngagement(
+  container: any,
+  input: EngagementInput
+): Promise<EngagementOutcome> {
+  const email = normalizeEmail(input.email)
+  const type = input.type
+  const at = input.event_at || new Date().toISOString()
+
+  const base: EngagementOutcome = { email, type, recorded: false, duplicate: false }
+  if (!email) return base
+
+  const service: any = container.resolve(EMAIL_ENGAGEMENT_MODULE)
+
+  // Idempotency: same provider event already folded in → no-op.
+  if (input.event_id) {
+    const seen = await service
+      .listEmailEngagementEvents({ event_id: input.event_id }, { take: 1 })
+      .catch(() => [])
+    if (seen?.length) return { ...base, duplicate: true }
+  }
+
+  // Raw audit row (best-effort — a logging failure never fails the caller, but
+  // we still fold the aggregate since the dedup guard already passed).
+  try {
+    await service.createEmailEngagementEvents({
+      email,
+      type,
+      provider: input.provider,
+      event_id: input.event_id ?? null,
+      event_at: at,
+      message_id: input.message_id ?? null,
+      raw: input.raw ?? null,
+    })
+  } catch {
+    // swallow — aggregate still updates below
+  }
+
+  // Fold into the aggregate (read-modify-write; volume is low).
+  const existing = (
+    await service.listEmailEngagements({ email }, { take: 1 }).catch(() => [])
+  )?.[0]
+  const folded = applyEngagement(existing, type, at)
+  if (existing) {
+    await service.updateEmailEngagements({ id: existing.id, ...folded })
+  } else {
+    try {
+      await service.createEmailEngagements({ email, ...folded })
+    } catch {
+      // A concurrent event for this same new email may have created the row
+      // first (UNIQUE(email)). Re-read and fold into what's now there.
+      const now = (
+        await service.listEmailEngagements({ email }, { take: 1 }).catch(() => [])
+      )?.[0]
+      if (now) {
+        await service.updateEmailEngagements({
+          id: now.id,
+          ...applyEngagement(now, type, at),
+        })
+      }
+    }
+  }
+
+  return { ...base, recorded: true }
+}

--- a/apps/backend/src/modules/email_engagement/index.ts
+++ b/apps/backend/src/modules/email_engagement/index.ts
@@ -1,0 +1,13 @@
+import { Module } from "@medusajs/framework/utils"
+
+import EmailEngagementService from "./service"
+
+export const EMAIL_ENGAGEMENT_MODULE = "email_engagement"
+
+const EmailEngagementModule = Module(EMAIL_ENGAGEMENT_MODULE, {
+  service: EmailEngagementService,
+})
+
+export { EmailEngagementModule }
+
+export default EmailEngagementModule

--- a/apps/backend/src/modules/email_engagement/migrations/Migration20260706120000.ts
+++ b/apps/backend/src/modules/email_engagement/migrations/Migration20260706120000.ts
@@ -1,0 +1,21 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+export class Migration20260706120000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table if not exists "email_engagement" ("id" text not null, "email" text not null, "delivered_count" integer not null default 0, "opens_count" integer not null default 0, "clicks_count" integer not null default 0, "delivered_since_last_open" integer not null default 0, "first_delivered_at" timestamptz null, "last_delivered_at" timestamptz null, "last_open_at" timestamptz null, "last_click_at" timestamptz null, "last_event_at" timestamptz null, "engagement_status" text check ("engagement_status" in ('engaged', 'cooling', 'dormant', 'never_opened', 'unknown')) not null default 'unknown', "status_computed_at" timestamptz null, "metadata" jsonb null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "email_engagement_pkey" primary key ("id"));`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_email_engagement_deleted_at" ON "email_engagement" ("deleted_at") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE UNIQUE INDEX IF NOT EXISTS "UQ_email_engagement_email" ON "email_engagement" ("email") WHERE deleted_at IS NULL;`);
+
+    this.addSql(`create table if not exists "email_engagement_event" ("id" text not null, "email" text not null, "type" text check ("type" in ('delivered', 'open', 'click')) not null default 'delivered', "provider" text check ("provider" in ('mailjet', 'resend', 'other')) not null default 'other', "event_id" text null, "event_at" timestamptz null, "message_id" text null, "raw" jsonb null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "email_engagement_event_pkey" primary key ("id"));`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_email_engagement_event_deleted_at" ON "email_engagement_event" ("deleted_at") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_email_engagement_event_email" ON "email_engagement_event" ("email") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_email_engagement_event_event_id" ON "email_engagement_event" ("event_id") WHERE deleted_at IS NULL AND event_id IS NOT NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "email_engagement" cascade;`);
+    this.addSql(`drop table if exists "email_engagement_event" cascade;`);
+  }
+
+}

--- a/apps/backend/src/modules/email_engagement/models/email-engagement-event.ts
+++ b/apps/backend/src/modules/email_engagement/models/email-engagement-event.ts
@@ -1,0 +1,25 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * Raw per-event ledger — one row per delivery/open/click webhook event. Serves
+ * two jobs: (1) idempotency, so a re-delivered webhook doesn't double-count the
+ * aggregate (dedup on `event_id`); (2) a debuggable audit trail of exactly what
+ * each ESP told us. The aggregate `email_engagement` is the denormalized rollup
+ * of these rows — same pattern as `email_suppression`.
+ */
+const EmailEngagementEvent = model.define("email_engagement_event", {
+  id: model.id({ prefix: "email_enge" }).primaryKey(),
+  email: model.text().searchable(),
+  // Normalized event type. `delivered` = Mailjet `sent` / Resend `email.delivered`.
+  type: model.enum(["delivered", "open", "click"]).default("delivered"),
+  provider: model.enum(["mailjet", "resend", "other"]).default("other"),
+  // Provider-side idempotency key (per message + type) — nullable when the ESP
+  // gave us no message id.
+  event_id: model.text().nullable(),
+  event_at: model.dateTime().nullable(),
+  // The ESP message id this event belongs to (Mailjet MessageID / Resend email_id).
+  message_id: model.text().nullable(),
+  raw: model.json().nullable(),
+})
+
+export default EmailEngagementEvent

--- a/apps/backend/src/modules/email_engagement/models/email-engagement.ts
+++ b/apps/backend/src/modules/email_engagement/models/email-engagement.ts
@@ -1,0 +1,45 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * One aggregate row per email — the durable engagement ledger that answers
+ * "is this address still reading our mail?". Fed by the Mailjet + Resend
+ * delivery/open/click webhooks (the events those routes used to drop), it is the
+ * denominator+numerator the engagement recompute reads to classify a contact as
+ * engaged / cooling / dormant / never_opened and, in soft-exclusion, drop the
+ * dormant ones from BULK sends without hiding them (they stay visible). Sibling
+ * of `email_suppression` (hard bounce/complaint/unsub) — this is the softer,
+ * behavioural signal. (#881 / #839)
+ */
+const EmailEngagement = model.define("email_engagement", {
+  id: model.id({ prefix: "email_eng" }).primaryKey(),
+  // Join key — sends dedupe recipients by email across person/customer/lead, so
+  // engagement is tracked per email just like suppression.
+  email: model.text().searchable(),
+  // Denominator (deliveries) + engagement signals. A delivered event is the
+  // closest per-recipient "campaign reached them" marker both ESPs give us
+  // (Mailjet `sent`, Resend `email.delivered`).
+  delivered_count: model.number().default(0),
+  opens_count: model.number().default(0),
+  clicks_count: model.number().default(0),
+  // The cold-streak signal: deliveries since we last saw ANY open/click. Reset to
+  // 0 on any engagement. Drives the dormancy threshold. Approximate under
+  // out-of-order webhooks — but an open always zeroes it, so it errs toward
+  // KEEPING people (conservative, never over-suppresses).
+  delivered_since_last_open: model.number().default(0),
+  first_delivered_at: model.dateTime().nullable(),
+  last_delivered_at: model.dateTime().nullable(),
+  last_open_at: model.dateTime().nullable(),
+  last_click_at: model.dateTime().nullable(),
+  // Latest of any engagement/delivery event we've seen for this address.
+  last_event_at: model.dateTime().nullable(),
+  // Persisted classification (written by the recompute job) — for visibility +
+  // win-back selection. The send-path gate recomputes live from the counters
+  // above, so a stale status here never causes a wrong exclusion.
+  engagement_status: model
+    .enum(["engaged", "cooling", "dormant", "never_opened", "unknown"])
+    .default("unknown"),
+  status_computed_at: model.dateTime().nullable(),
+  metadata: model.json().nullable(),
+})
+
+export default EmailEngagement

--- a/apps/backend/src/modules/email_engagement/provider-parsers.ts
+++ b/apps/backend/src/modules/email_engagement/provider-parsers.ts
@@ -1,0 +1,87 @@
+/**
+ * PURE provider→normalized-engagement parsers. Sibling of the suppression
+ * parsers, but for the events those DROP: delivery, open, click. Both ESPs post
+ * different shapes; both reduce to a flat list of `EngagementItem` the webhook
+ * routes feed to `recordEngagement`. No IO here — fully unit-testable.
+ */
+
+export type EngagementType = "delivered" | "open" | "click"
+
+export type EngagementItem = {
+  email: string
+  type: EngagementType
+  event_id: string | null
+  event_at: string | null
+  message_id: string | null
+}
+
+/**
+ * Mailjet Event API. Single event object OR an array. We care about:
+ *   sent  → delivered (Mailjet has no separate "delivered"; `sent` = accepted by
+ *           the remote MX, which is our per-recipient reached signal)
+ *   open  → open
+ *   click → click
+ * Everything else (bounce/spam/unsub/…) is handled by the suppression parser.
+ * The idempotency key is per message + type, so N opens of ONE message collapse
+ * to a single "they opened this campaign" — the unit we actually want to count.
+ */
+export function parseMailjetEngagement(body: any): EngagementItem[] {
+  const events = Array.isArray(body) ? body : body ? [body] : []
+  const out: EngagementItem[] = []
+  for (const e of events) {
+    if (!e || typeof e !== "object") continue
+    const email = String(e.email || "").trim().toLowerCase()
+    if (!email) continue
+    const raw = String(e.event || "").toLowerCase()
+    let type: EngagementType | null = null
+    if (raw === "sent") type = "delivered"
+    else if (raw === "open") type = "open"
+    else if (raw === "click") type = "click"
+    if (!type) continue
+    const mid = e.MessageID ?? e.MessageGUID ?? e.mid ?? ""
+    const message_id = mid ? String(mid) : null
+    const event_id = message_id ? `mje:${type}:${message_id}` : null
+    const at =
+      typeof e.time === "number" ? new Date(e.time * 1000).toISOString() : null
+    out.push({ email, type, event_id, event_at: at, message_id })
+  }
+  return out
+}
+
+/**
+ * Resend webhook event. Single object: { type, created_at, data:{ email_id, to[] } }.
+ * We care about email.delivered / email.opened / email.clicked. (email.sent is
+ * pre-delivery, so it is NOT counted as a delivery to keep the denominator honest.)
+ * Docs: https://resend.com/docs/dashboard/webhooks/event-types
+ */
+export function parseResendEngagement(body: any): EngagementItem[] {
+  if (!body || typeof body !== "object") return []
+  const t = String(body.type || "").toLowerCase()
+  let type: EngagementType | null = null
+  if (t === "email.delivered") type = "delivered"
+  else if (t === "email.opened") type = "open"
+  else if (t === "email.clicked") type = "click"
+  if (!type) return []
+
+  const data = body.data || {}
+  const recipients: string[] = Array.isArray(data.to)
+    ? data.to
+    : data.to
+    ? [data.to]
+    : []
+  const emails = recipients
+    .map((r) => String(r || "").trim().toLowerCase())
+    .filter(Boolean)
+  if (!emails.length) return []
+
+  const at = body.created_at ? new Date(body.created_at).toISOString() : null
+  const mid = data.email_id || body.id || ""
+  const message_id = mid ? String(mid) : null
+  return emails.map((email) => ({
+    email,
+    type: type as EngagementType,
+    event_id: message_id ? `rse:${type}:${message_id}:${email}` : null,
+    event_at: at,
+    message_id,
+  }))
+}

--- a/apps/backend/src/modules/email_engagement/service.ts
+++ b/apps/backend/src/modules/email_engagement/service.ts
@@ -1,0 +1,11 @@
+import { MedusaService } from "@medusajs/framework/utils"
+
+import EmailEngagement from "./models/email-engagement"
+import EmailEngagementEvent from "./models/email-engagement-event"
+
+class EmailEngagementService extends MedusaService({
+  EmailEngagement,
+  EmailEngagementEvent,
+}) {}
+
+export default EmailEngagementService

--- a/apps/backend/src/modules/email_engagement/winback-select.ts
+++ b/apps/backend/src/modules/email_engagement/winback-select.ts
@@ -1,0 +1,110 @@
+import {
+  classifyEngagement,
+  type EngagementRow,
+  type EngagementThresholds,
+} from "./classifier"
+
+/**
+ * PURE newsletter win-back selection (Slice 3). Picks `cooling` contacts — the
+ * pre-dormant nudge window: engaged before, now on a cold streak but not yet
+ * `dormant`. Mirrors the marketing `selectWinbackTargets` shape so the job stays
+ * thin + unit-testable. Idempotency is presence-based (skip anyone already in
+ * the `newsletter-winback` campaign), matching `generate-winback-targets`.
+ *
+ * Targets become `marketing_outreach` rows (Option C) — we do NOT auto-blast;
+ * the existing outreach flow handles sending, and the opens/clicks that flow
+ * back are reconciled by the bridge we wired in Slice 1.
+ */
+
+export type WinbackEngagementRow = EngagementRow & {
+  email?: string | null
+  last_open_at?: Date | string | null
+  last_delivered_at?: Date | string | null
+}
+
+export type NewsletterWinbackTarget = {
+  email: string
+  cold_streak: number
+  last_open_at: string | null
+  last_delivered_at: string | null
+}
+
+export type NewsletterWinbackSelection = {
+  targets: NewsletterWinbackTarget[]
+  stats: {
+    scanned: number
+    cooling: number
+    targeted: number
+    capped: number
+    skipped_no_email: number
+    skipped_already: number
+  }
+}
+
+export type SelectNewsletterWinbackOptions = {
+  now?: Date
+  thresholds?: Partial<EngagementThresholds>
+  cap?: number
+}
+
+export const DEFAULT_WINBACK_CAP = 100
+
+function iso(v: Date | string | null | undefined): string | null {
+  if (!v) return null
+  return v instanceof Date ? v.toISOString() : String(v)
+}
+
+function normEmail(v: unknown): string {
+  return String(v ?? "").trim().toLowerCase()
+}
+
+export function selectNewsletterWinbackTargets(
+  rows: WinbackEngagementRow[] | null | undefined,
+  alreadyTargeted: Set<string>,
+  options: SelectNewsletterWinbackOptions = {}
+): NewsletterWinbackSelection {
+  const now = options.now ?? new Date()
+  const cap = options.cap ?? DEFAULT_WINBACK_CAP
+  const list = Array.isArray(rows) ? rows : []
+
+  const stats = {
+    scanned: list.length,
+    cooling: 0,
+    targeted: 0,
+    capped: 0,
+    skipped_no_email: 0,
+    skipped_already: 0,
+  }
+
+  const candidates: NewsletterWinbackTarget[] = []
+  for (const r of list) {
+    const { status } = classifyEngagement(r, { now, thresholds: options.thresholds })
+    if (status !== "cooling") continue
+    stats.cooling++
+
+    const email = normEmail(r.email)
+    if (!email) {
+      stats.skipped_no_email++
+      continue
+    }
+    if (alreadyTargeted.has(email)) {
+      stats.skipped_already++
+      continue
+    }
+    candidates.push({
+      email,
+      cold_streak: Number(r.delivered_since_last_open ?? 0),
+      last_open_at: iso(r.last_open_at),
+      last_delivered_at: iso(r.last_delivered_at),
+    })
+  }
+
+  // Coldest first — the ones closest to tipping dormant get nudged first.
+  candidates.sort((a, b) => b.cold_streak - a.cold_streak)
+
+  const targets = candidates.slice(0, Math.max(0, cap))
+  stats.targeted = targets.length
+  stats.capped = Math.max(0, candidates.length - targets.length)
+
+  return { targets, stats }
+}

--- a/apps/backend/src/modules/marketing/__tests__/bridge-engagement.unit.spec.ts
+++ b/apps/backend/src/modules/marketing/__tests__/bridge-engagement.unit.spec.ts
@@ -1,0 +1,29 @@
+import { engagementToOutreachEvent } from "../bridge-engagement"
+
+describe("bridge-engagement — engagementToOutreachEvent", () => {
+  const at = "2026-07-06T00:00:00.000Z"
+
+  it("maps delivered → sent_at on the addressed row", () => {
+    expect(engagementToOutreachEvent({ type: "delivered", message_id: "m1", at })).toEqual({
+      external_id: "m1",
+      sent_at: at,
+    })
+  })
+
+  it("maps open AND click → opened_at (outreach has no clicked state)", () => {
+    expect(engagementToOutreachEvent({ type: "open", message_id: "m1", at })).toEqual({
+      external_id: "m1",
+      opened_at: at,
+    })
+    expect(engagementToOutreachEvent({ type: "click", message_id: "m1", at })).toEqual({
+      external_id: "m1",
+      opened_at: at,
+    })
+  })
+
+  it("returns null when it can't address a row or has no timestamp", () => {
+    expect(engagementToOutreachEvent({ type: "open", message_id: null, at })).toBeNull()
+    expect(engagementToOutreachEvent({ type: "open", message_id: "  ", at })).toBeNull()
+    expect(engagementToOutreachEvent({ type: "open", message_id: "m1", at: "" })).toBeNull()
+  })
+})

--- a/apps/backend/src/modules/marketing/bridge-engagement.ts
+++ b/apps/backend/src/modules/marketing/bridge-engagement.ts
@@ -1,0 +1,82 @@
+import { MARKETING_MODULE } from "./index"
+import {
+  reconcileOutreachBatch,
+  type OutreachSyncEvent,
+  type OutreachSyncRow,
+} from "./outreach-sync-lib"
+import type { EngagementType } from "../email_engagement/provider-parsers"
+
+/**
+ * Bridge (Option C) — feed live ESP delivery/open/click events from the
+ * `email_engagement` webhooks into the marketing `marketing_outreach`
+ * reconciliation layer, which was BUILT but STARVED (no relay/adapter wired).
+ *
+ * Matches an outreach row by `external_id` = the provider message id. A no-op
+ * when the message isn't a marketing campaign send (the vast majority of
+ * newsletter/blog opens), so it's safe to call on every engagement event. The
+ * reconciliation is forward-only + idempotent (`diffOutreachEngagement`), so a
+ * re-delivered webhook can't downgrade or double-write a row.
+ *
+ * Signal mapping (our types → outreach state machine):
+ *   delivered → sent_at    (outreach "sent" = reached the recipient)
+ *   open      → opened_at
+ *   click     → opened_at   (outreach has no `clicked` state; a click implies open)
+ */
+
+export type EngagementToOutreachInput = {
+  type: EngagementType
+  message_id: string | null | undefined
+  /** Resolved ISO instant (caller defaults null → now). */
+  at: string
+}
+
+export type BridgeOutcome = { matched: number; changed: number }
+
+/**
+ * PURE: map one engagement event to a normalized outreach sync event, or null
+ * when it can't address a row (no message id) or carries no usable signal.
+ */
+export function engagementToOutreachEvent(
+  input: EngagementToOutreachInput
+): OutreachSyncEvent | null {
+  const message_id =
+    typeof input.message_id === "string" ? input.message_id.trim() : ""
+  if (!message_id || !input.at) return null
+
+  const event: OutreachSyncEvent = { external_id: message_id }
+  if (input.type === "delivered") event.sent_at = input.at
+  else if (input.type === "open" || input.type === "click")
+    event.opened_at = input.at
+  else return null
+  return event
+}
+
+/**
+ * Reconcile one engagement event onto any matching `marketing_outreach` row.
+ * Container-driven; best-effort by design — the caller's own ledger write is the
+ * source of truth, this is the secondary feed.
+ */
+export async function bridgeOutreachEngagement(
+  container: any,
+  input: { type: EngagementType; message_id: string | null | undefined; event_at: string | null }
+): Promise<BridgeOutcome> {
+  const at = input.event_at || new Date().toISOString()
+  const event = engagementToOutreachEvent({
+    type: input.type,
+    message_id: input.message_id,
+    at,
+  })
+  if (!event) return { matched: 0, changed: 0 }
+
+  const service: any = container.resolve(MARKETING_MODULE)
+  const rows: OutreachSyncRow[] = await service
+    .listMarketingOutreaches({ external_id: [event.external_id] })
+    .catch(() => [])
+  if (!rows?.length) return { matched: 0, changed: 0 }
+
+  const result = reconcileOutreachBatch(rows, [event])
+  for (const item of result.items) {
+    await service.updateMarketingOutreaches({ id: item.id, ...item.patch })
+  }
+  return { matched: result.matchedRowIds.length, changed: result.items.length }
+}

--- a/apps/backend/src/workflows/blogs/send-blog-subscribers/steps/get-subscribers.ts
+++ b/apps/backend/src/workflows/blogs/send-blog-subscribers/steps/get-subscribers.ts
@@ -5,6 +5,8 @@ import { PERSON_MODULE } from "../../../../modules/person"
 import PersonService from "../../../../modules/person/service"
 import { SOCIALS_MODULE } from "../../../../modules/socials"
 import SocialsService from "../../../../modules/socials/service"
+import { EMAIL_ENGAGEMENT_MODULE } from "../../../../modules/email_engagement"
+import { classifyEngagement } from "../../../../modules/email_engagement/classifier"
 import { ICustomerModuleService } from "@medusajs/framework/types"
 
 export const getSubscribersStepId = "get-subscribers"
@@ -115,6 +117,31 @@ export const getSubscribersStep = createStep(
               last_name: lead.last_name || lead.full_name?.split(" ").slice(1).join(" ") || "",
             })
           }
+        }
+      }
+
+      // Soft engagement exclusion (#881): drop `dormant` addresses from BULK
+      // sends — computed LIVE from the engagement ledger so a freshly-cold
+      // contact is honored without waiting on the recompute job. The
+      // person/customer/lead rows are untouched (they stay in the audience +
+      // still get transactional / win-back mail), so we never lose sight of
+      // who's dormant vs active.
+      const emails = Array.from(uniqueSubscribers.keys())
+      if (emails.length) {
+        const engagementService: any = container.resolve(EMAIL_ENGAGEMENT_MODULE)
+        const engagementRows: any[] = await engagementService
+          .listEmailEngagements({ email: emails }, { take: null })
+          .catch(() => [])
+        const now = new Date()
+        let dropped = 0
+        for (const row of engagementRows) {
+          if (classifyEngagement(row, { now }).bulk_suppressed) {
+            if (uniqueSubscribers.delete(String(row.email).toLowerCase())) dropped++
+          }
+        }
+        if (dropped) {
+          const logger: any = container.resolve("logger")
+          logger?.info?.(`[get-subscribers] dropped ${dropped} dormant address(es) from bulk send`)
         }
       }
 


### PR DESCRIPTION
Closes #916. Sibling of #839 (hard bounce/complaint suppression) and #881 (audience grouping).

## Problem
Bounce suppression (#839) is live, but **email engagement was captured by nothing** — both the Mailjet and Resend webhook parsers dropped `open`/`click`/`delivered`. We want non-openers marked low-potential and dropped from future **bulk** sends, without losing sight of who's dormant vs active.

## What this does (3 slices, all in one PR)

**S1 — Ingestion.** New `email_engagement` module: a per-email aggregate (`delivered/opens/clicks` counts, `delivered_since_last_open` cold-streak, first/last timestamps) + a raw idempotent event ledger. Pure parsers turn Mailjet `sent/open/click` and Resend `email.delivered/opened/clicked` into normalized events; `recordEngagement` folds them **order-independently** (any open/click resets the cold streak → out-of-order webhooks only ever *keep* people on the list, never wrongly drop them). Both webhook routes wired, and no longer early-return on opens-only payloads.
- **Option C bridge:** matching opens/clicks now also feed the previously built-but-starved marketing `marketing_outreach` reconciliation (`bridge-engagement.ts`), matched by `external_id`. No relay/adapter needed anymore.

**S2 — Score + gate.** Pure `classifyEngagement` → `engaged | cooling | dormant | never_opened | unknown`. **Only `dormant` is bulk-suppressed**, and it's deliberately conservative (thin data → `unknown`; any open keeps you out of `dormant`; needs ≥30d span). The bulk send path (`get-subscribers`) drops `dormant` **live from the ledger** — person/customer/lead rows are untouched, so dormant-vs-active stays visible (soft exclusion). `recompute-email-engagement-status` ops job persists status for visibility/win-back (dry-run/apply, tunable thresholds).

**S3 — Win-back.** Pure `selectNewsletterWinbackTargets` (cooling contacts, coldest-first) + `generate-newsletter-winback-targets` ops job that **queues** `marketing_outreach` rows (`campaign=newsletter-winback`). Reuses the existing outreach model + WinbacksView + reconciliation — no third win-back engine, no auto-blast.

## Design notes
- `engagement_status` lives on `email_engagement`, **not** `audience_entry` — the audience backfill rebuilds those rows and would clobber live counters. The send-path gate recomputes live, so a stale stored status can never wrongly exclude anyone.
- Win-back queues targets (mirrors #659 `generate-winback-targets`) rather than auto-sending — outward action stays operator-reviewed.

## Testing
- **23 unit tests** green (parsers, `applyEngagement` fold, classifier, win-back selector, bridge mapping). 0 new TS errors (baseline unchanged).
- **Migration applied + verified on dev** (tables + enum CHECK constraint).
- **Live smoke test on dev:** POST synthetic Mailjet `sent`+`open` → aggregate folded to `delivered=1/opens=1/streak=0`, 2 raw ledger rows; replay is idempotent (no double-count). Test data cleaned up.

## Deploy tail
1. Run prod migration.
2. Enable `delivered`/`opened`/`clicked` event types in Resend + Mailjet dashboards ✅ (done on the webhook side).
3. Run `recompute-email-engagement-status` then `generate-newsletter-winback-targets` (dry-run → apply).

## Follow-ons
- Admin visibility view (join `engagement_status` onto audience).
- Operator-tunable win-back as a visual flow once send-side is wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)