### PR TITLE
fix(google-ads): surface searchStream 400 reason + skip metrics for manager accounts

### DIFF
--- a/apps/backend/src/workflows/google-ads/steps/__tests__/format-google-ads-error.unit.spec.ts
+++ b/apps/backend/src/workflows/google-ads/steps/__tests__/format-google-ads-error.unit.spec.ts
@@ -1,0 +1,67 @@
+import { formatGoogleAdsError, googleErrorRoot } from "../sync-google-ads-step"
+
+/** Build an axios-like error with a given response body + status. */
+const axiosErr = (status: number, data: any) => ({
+  message: `Request failed with status code ${status}`,
+  response: { status, data },
+})
+
+/** searchStream error body: an ARRAY wrapping the error object. */
+const streamError = (code: Record<string, string>, message: string) => [
+  { error: { message, details: [{ errors: [{ errorCode: code, message }] }] } },
+]
+
+describe("googleErrorRoot", () => {
+  it("unwraps the array-shaped searchStream error body", () => {
+    expect(googleErrorRoot([{ error: { message: "x" } }])).toEqual({ error: { message: "x" } })
+  })
+  it("passes through the plain object shape (unary endpoints)", () => {
+    expect(googleErrorRoot({ error: { message: "y" } })).toEqual({ error: { message: "y" } })
+  })
+  it("tolerates null/empty", () => {
+    expect(googleErrorRoot(null)).toBeNull()
+    expect(googleErrorRoot([])).toBeNull()
+  })
+})
+
+describe("formatGoogleAdsError — array-shaped searchStream 400", () => {
+  it("decodes a manager-metrics 400 and appends the MCC hint (previously a bare message)", () => {
+    const e = axiosErr(
+      400,
+      streamError(
+        { queryError: "REQUESTED_METRICS_FOR_MANAGER" },
+        "Metrics cannot be requested for a manager account."
+      )
+    )
+    const msg = formatGoogleAdsError(e, { hasLoginCid: true })
+    expect(msg).toContain("Metrics cannot be requested for a manager account")
+    expect(msg).toContain("[queryError:REQUESTED_METRICS_FOR_MANAGER]")
+    expect(msg).toContain("manager (MCC) account")
+  })
+
+  it("decodes a generic GAQL 400 (bad field) with a query hint", () => {
+    const e = axiosErr(
+      400,
+      streamError({ queryError: "BAD_FIELD_NAME" }, "Unrecognized field: metrics.foo")
+    )
+    const msg = formatGoogleAdsError(e, { hasLoginCid: false })
+    expect(msg).toContain("Unrecognized field: metrics.foo")
+    expect(msg).toContain("GAQL query rejected (400)")
+  })
+
+  it("still surfaces a bare axios message when Google gives no parseable body", () => {
+    const msg = formatGoogleAdsError(axiosErr(400, undefined), { hasLoginCid: true })
+    expect(msg).toContain("Request failed with status code 400")
+  })
+
+  it("regression: plain-object 403 developer-token error still hinted", () => {
+    const e = axiosErr(403, {
+      error: {
+        message: "The developer token is not approved.",
+        details: [{ errors: [{ errorCode: { authorizationError: "DEVELOPER_TOKEN_NOT_APPROVED" }, message: "not approved" }] }],
+      },
+    })
+    const msg = formatGoogleAdsError(e, { hasLoginCid: true })
+    expect(msg).toContain("Test access")
+  })
+})

--- a/apps/backend/src/workflows/google-ads/steps/sync-google-ads-step.ts
+++ b/apps/backend/src/workflows/google-ads/steps/sync-google-ads-step.ts
@@ -406,6 +406,37 @@ async function pullCidData(
   )
   const customerRow = extractFirstRow(customerRes.data)?.customer ?? {}
 
+  // Manager (MCC) accounts have NO campaigns/metrics — every metric query against
+  // one returns 400 (QueryError.REQUESTED_METRICS_FOR_MANAGER). Detect it from the
+  // (metric-free) customer query and skip the metric pulls entirely, so binding an
+  // MCC records the account cleanly instead of 400-looping. Bind a child client
+  // CID to get campaign data.
+  const isManager = customerRow.manager === true || customerRow.manager === "true"
+  if (isManager) {
+    logger?.info?.(
+      `[google-ads] cid=${cid} is a manager (MCC) account — skipping campaign/metric pulls (managers have no metrics; bind a child CID for campaign data)`
+    )
+    return {
+      customer: {
+        resource_name: `customers/${cid}`,
+        descriptive_name: customerRow.descriptiveName ?? null,
+        currency_code: customerRow.currencyCode ?? null,
+        time_zone: customerRow.timeZone ?? null,
+        manager: true,
+        test_account: customerRow.testAccount ?? false,
+      },
+      campaigns: [],
+      adGroups: [],
+      ads: [],
+      insights: {
+        campaign: [],
+        ad_group: [],
+        campaign_by_device: [],
+        ad_group_by_device: [],
+      },
+    }
+  }
+
   const campaignsRes = await withGoogleRetry(
     () =>
       axios.post(
@@ -444,9 +475,7 @@ async function pullCidData(
     } catch (e: any) {
       // Don't fail the whole sync over creative pull — log + continue.
       logger?.warn?.(
-        `[google-ads] ad_group_ad pull failed for cid=${cid}: ${
-          e.response?.data?.error?.message || e.message
-        }`
+        `[google-ads] ad_group_ad pull failed for cid=${cid}: ${googleErrorMessage(e)}`
       )
     }
   }
@@ -531,7 +560,7 @@ async function pullDailyInsights(
     logger?.warn?.(
       `[google-ads] daily insights pull failed for cid=${cid} level=${level}${
         breakdown ? " breakdown=" + breakdown : ""
-      }: ${e.response?.data?.error?.message || e.message}`
+      }: ${googleErrorMessage(e)}`
     )
     return []
   }
@@ -549,6 +578,24 @@ function extractAllRows(data: any): any[] {
 
 function extractFirstRow(data: any): any {
   return extractAllRows(data)[0] ?? null
+}
+
+/**
+ * Unwrap a Google Ads error body to the `{ error: { message, details } }` object.
+ * `googleAds:searchStream` returns its ERROR body as an ARRAY (`[{ error: … }]`),
+ * not the plain object the unary endpoints return — so `data.error` is undefined
+ * for exactly the streaming calls this step makes, and every 400/403 reason gets
+ * silently dropped. Handle both shapes.
+ */
+export function googleErrorRoot(raw: any): any {
+  if (Array.isArray(raw)) return raw.find((c: any) => c?.error) ?? raw[0] ?? null
+  return raw ?? null
+}
+
+/** Best-effort human message from a Google Ads axios error (array-shape aware). */
+function googleErrorMessage(e: any): string {
+  const root = googleErrorRoot(e?.response?.data)
+  return root?.error?.message || e?.message || "Unknown Google Ads error"
 }
 
 async function upsertCustomer(
@@ -1010,12 +1057,14 @@ async function upsertInsights(
  * Test-access dev tokens (the latter looks IDENTICAL to a missing-cid
  * error unless we explicitly call it out).
  */
-function formatGoogleAdsError(
+export function formatGoogleAdsError(
   e: any,
   ctx: { hasLoginCid: boolean }
 ): string {
   const status: number | undefined = e?.response?.status
-  const data: any = e?.response?.data
+  // searchStream returns its error body as an array (`[{ error: … }]`) — unwrap
+  // to the error object so 400/403 reasons aren't silently dropped.
+  const data: any = googleErrorRoot(e?.response?.data)
 
   // Google's normal failure shape — extract the first specific error code.
   let specificCode: string | null = null
@@ -1050,7 +1099,13 @@ function formatGoogleAdsError(
   const code = specificCode || ""
   let hint: string | null = null
 
-  if (
+  if (code.includes("REQUESTED_METRICS_FOR_MANAGER")) {
+    hint =
+      "this CID is a manager (MCC) account — manager accounts have no campaign metrics, so metric queries always 400. Bind a child client-account CID instead of the manager. (The sync now auto-skips metric pulls for manager accounts, so this should not recur.)"
+  } else if (status === 400 && code.startsWith("queryError")) {
+    hint =
+      "GAQL query rejected (400) — a requested field/metric is invalid for this account or Google Ads API v24. See the error message above for the offending field."
+  } else if (
     code.includes("DEVELOPER_TOKEN_NOT_APPROVED") ||
     code.includes("DEVELOPER_TOKEN_PROHIBITED") ||
     code.includes("DEVELOPER_TOKEN_NEEDS_APPROVAL")


### PR DESCRIPTION
## Symptom
After setting the Google Ads developer token, the sync 400'd repeatedly. Prod logs (`/copilot/jyt-prod-medusa-server`):
```
[google-ads] sync failed for cid=2827746221: Request failed with status code 400
```

## Root cause (two bugs)
1. **We were blind to the reason.** `googleAds:searchStream` returns its **error** body as an **array** `[{ error: … }]`, not the `{ error: … }` object the unary endpoints use. `formatGoogleAdsError` read `data.error` (undefined for the streaming calls this step makes) and fell back to axios's bare `Request failed with status code 400`. Every 400/403 detail was dropped.
2. **The actual 400:** the customer query (no metrics) succeeds, then the campaigns query (with metrics) runs against a **manager (MCC) account** — Google *always* 400s metric queries against a manager (`QueryError.REQUESTED_METRICS_FOR_MANAGER`). cid `2827746221` is a manager.

## Fix
- `googleErrorRoot()` unwraps both the array and object error shapes; wired into `formatGoogleAdsError` + the two inline catch logs — real reasons now surface in logs and the sync `errors[]`.
- After the (metric-free) customer query, detect `customer.manager` and **skip the metric pulls** for manager accounts — records the account cleanly instead of 400-looping. Bind a child client CID for campaign data.
- Added operator hints for the MCC-metrics case and generic GAQL 400s.

## Testing
- **7 unit tests** (array-shape decode, manager hint, GAQL-400 hint, bare-body fallback, 403 regression). 0 new TS errors.
- Diagnosed from prod CloudWatch logs (read-only).

## Note
This is why syncing the MCC returned no campaigns — managers have none. To pull campaign/metric data, bind a **child client account** CID on the platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)