### PR TITLE
feat(partner-ui): surface + highlight design sizes in the design manager

### DIFF
--- a/apps/backend/src/api/partners/designs/[designId]/route.ts
+++ b/apps/backend/src/api/partners/designs/[designId]/route.ts
@@ -162,9 +162,12 @@ export const GET = async (
     return res.status(404).json({ error: "Design not found for this partner" })
   }
 
-  // Use admin single-design workflow to fetch the full design shape
+  // Use admin single-design workflow to fetch the full design shape.
+  // Expand the `size_sets` (and `colors`) relations — a bare `["*"]` returns only
+  // scalar columns, so the design manager never saw the design's sizes. Mirrors
+  // the list + PUT routes, which already request these.
   const { result: workflowDesign } = await listSingleDesignsWorkflow(req.scope).run({
-    input: { id: designId, fields: ["*"] },
+    input: { id: designId, fields: ["*", "colors.*", "size_sets.*"] },
   })
 
   const partner_phase: "redo" | null = null

--- a/apps/partner-ui/src/routes/designs/design-detail/design-detail.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/design-detail.tsx
@@ -240,8 +240,28 @@ export const DesignDetail = () => {
   const notesValue = (design as any)?.designer_notes || metadata?.notes
   // Specs — can be in metadata.specs or as a top-level field
   const specsValue = metadata?.specs
-  // Sizes — stored as `custom_sizes` column (e.g. { "S": { chest: 0, length: 0 }, "M": { ... } })
+  // Sizes — prefer the normalized `size_sets` relation
+  // ({ size_label, measurements }); fall back to the legacy `custom_sizes` map
+  // ({ "S": { chest, length }, ... }). The design that comes with an order carries
+  // its sizes on `size_sets`, so this is what the partner needs to see.
+  const sizeSets = (design as any)?.size_sets as
+    | Array<{ size_label?: string; measurements?: any }>
+    | undefined
   const customSizes = (design as any)?.custom_sizes as Record<string, any> | undefined
+  const sizes = useMemo<Array<{ label: string; measurements: any }>>(() => {
+    if (Array.isArray(sizeSets) && sizeSets.length > 0) {
+      return sizeSets
+        .filter((s) => s?.size_label)
+        .map((s) => ({ label: String(s.size_label), measurements: s?.measurements }))
+    }
+    if (customSizes && typeof customSizes === "object") {
+      return Object.entries(customSizes).map(([label, measurements]) => ({
+        label,
+        measurements,
+      }))
+    }
+    return []
+  }, [sizeSets, customSizes])
   // Color palette
   const colorPalette = (design as any)?.color_palette as any[] | Record<string, any> | undefined
   // Description
@@ -393,14 +413,18 @@ export const DesignDetail = () => {
                 </div>
               </div>
             )}
-            {customSizes && typeof customSizes === "object" && Object.keys(customSizes).length > 0 && (
+            {sizes.length > 0 && (
               <div className="px-6 py-4">
-                <Text size="xsmall" weight="plus" className="text-ui-fg-subtle mb-2">Sizes</Text>
-                <div className="flex flex-col gap-y-2">
-                  {Object.entries(customSizes).map(([sizeName, measurements]) => (
-                    <div key={sizeName} className="flex items-start gap-x-3">
+                <div className="flex items-center gap-x-2 mb-2">
+                  <Text size="xsmall" weight="plus" className="text-ui-fg-base">Sizes</Text>
+                  <Badge size="2xsmall" color="blue">{sizes.length}</Badge>
+                </div>
+                {/* Highlighted so the sizes that come with this design stand out to the partner. */}
+                <div className="flex flex-col gap-y-2 rounded-lg bg-ui-bg-highlight p-3">
+                  {sizes.map(({ label, measurements }) => (
+                    <div key={label} className="flex items-start gap-x-3">
                       <Badge size="2xsmall" color="blue" className="mt-0.5 shrink-0">
-                        {sizeName}
+                        {label}
                       </Badge>
                       {measurements && typeof measurements === "object" ? (
                         <div className="flex flex-wrap gap-x-3 gap-y-1">
@@ -410,11 +434,11 @@ export const DesignDetail = () => {
                             </Text>
                           ))}
                         </div>
-                      ) : (
+                      ) : measurements != null ? (
                         <Text size="xsmall" className="text-ui-fg-subtle">
                           {String(measurements)}
                         </Text>
-                      )}
+                      ) : null}
                     </div>
                   ))}
                 </div>


### PR DESCRIPTION
## What
When a partner opens the **design manager** (`/designs/:id`) from an order, the design's sizes now show — highlighted.

## Why it was missing (two gaps)
1. **Backend:** the partner single-design GET (`/partners/designs/:id`) fetched `["*"]`, which returns only scalar columns — **not** the `size_sets` relation. The list route, PUT, and the production-run snapshot all already expand `size_sets.*`; only the GET didn't, so the design manager never received the sizes. → Expanded the GET to `["*", "colors.*", "size_sets.*"]`.
2. **Frontend:** the design manager rendered only the legacy `custom_sizes` map, which is empty for designs that carry sizes on the normalized `size_sets` relation. → Now prefers `size_sets` (`{ size_label, measurements }`) with a `custom_sizes` fallback, in a **highlighted block** (`bg-ui-bg-highlight` + a count badge) so the sizes stand out.

## Testing
- Backend typecheck: 0 new errors (baseline unchanged).
- `design-detail.tsx` typechecks clean (pre-existing tsc errors elsewhere are unrelated claim/exchange files; app builds via `tsup`).
- Display-only change feeding an existing render pattern from the now-expanded API field.

## Note / possible follow-up
This surfaces sizes on the **design manager** page (the "Open design manager" target). If you also want the sizes shown *inline in the in-order/production-run view* (`order-design-details.tsx`, which currently shows no sizes), that's a small fast-follow — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)