### PR TITLE
fix(google-ads): correct v24 GAQL field names (UNRECOGNIZED_FIELD)

### DIFF
--- a/apps/backend/src/workflows/google-ads/steps/__tests__/google-ads-gaql-fields.unit.spec.ts
+++ b/apps/backend/src/workflows/google-ads/steps/__tests__/google-ads-gaql-fields.unit.spec.ts
@@ -1,0 +1,60 @@
+import {
+  AGGREGATE_METRICS_FIELDS,
+  CAMPAIGN_DATES_QUERY,
+  buildCampaignAggregateQuery,
+  buildDailyInsightsQuery,
+} from "../sync-google-ads-step"
+
+/**
+ * Regression guard for the v24 GAQL field-name drift (queryError:UNRECOGNIZED_FIELD).
+ * Google renamed the video CPV/view metrics to the TrueView namespace and rejects
+ * campaign.start_date/end_date when selected alongside segments.date + metrics.
+ */
+describe("google-ads GAQL field selection (v24)", () => {
+  // Removed/renamed in v24 — selecting any of these 400s the whole query.
+  const REMOVED_METRICS = [
+    "metrics.average_cpv",
+    "metrics.video_views",
+    "metrics.video_view_rate",
+  ]
+
+  it("uses the v24 TrueView metric names, not the removed ones", () => {
+    expect(AGGREGATE_METRICS_FIELDS).toContain("metrics.trueview_average_cpv")
+    expect(AGGREGATE_METRICS_FIELDS).toContain("metrics.video_trueview_views")
+    expect(AGGREGATE_METRICS_FIELDS).toContain(
+      "metrics.video_trueview_view_rate"
+    )
+    for (const removed of REMOVED_METRICS) {
+      expect(AGGREGATE_METRICS_FIELDS).not.toContain(removed)
+    }
+  })
+
+  it("never selects a removed metric in any metric-bearing query", () => {
+    const queries = [
+      buildCampaignAggregateQuery(30),
+      buildDailyInsightsQuery("campaign", 30),
+      buildDailyInsightsQuery("ad_group", 30),
+      buildDailyInsightsQuery("ad", 30),
+    ]
+    for (const q of queries) {
+      for (const removed of REMOVED_METRICS) {
+        // word-boundary so trueview_average_cpv isn't caught by average_cpv
+        expect(q).not.toMatch(new RegExp(`${removed}\\b`))
+      }
+    }
+  })
+
+  it("does NOT select campaign date attributes in the segmented aggregate query", () => {
+    const q = buildCampaignAggregateQuery(30)
+    expect(q).toContain("segments.date")
+    expect(q).not.toContain("campaign.start_date")
+    expect(q).not.toContain("campaign.end_date")
+  })
+
+  it("pulls campaign start/end dates in a separate metric-free query", () => {
+    expect(CAMPAIGN_DATES_QUERY).toContain("campaign.start_date")
+    expect(CAMPAIGN_DATES_QUERY).toContain("campaign.end_date")
+    expect(CAMPAIGN_DATES_QUERY).not.toContain("segments.date")
+    expect(CAMPAIGN_DATES_QUERY).not.toContain("metrics.")
+  })
+})

--- a/apps/backend/src/workflows/google-ads/steps/sync-google-ads-step.ts
+++ b/apps/backend/src/workflows/google-ads/steps/sync-google-ads-step.ts
@@ -45,21 +45,25 @@ const CUSTOMER_QUERY =
 // GAQL won't let us combine `LIMIT` with `WHERE segments.date BETWEEN` for
 // metric queries, so we use `DURING LAST_N_DAYS`-style constants computed from
 // the runtime window.
-const AGGREGATE_METRICS_FIELDS = [
+export const AGGREGATE_METRICS_FIELDS = [
   "metrics.impressions",
   "metrics.clicks",
   "metrics.ctr",
   "metrics.average_cpc",
   "metrics.average_cpm",
-  "metrics.average_cpv",
+  // v24 renamed the video CPV/view metrics to the TrueView-namespaced fields;
+  // the old metrics.average_cpv / video_views / video_view_rate now 400 with
+  // queryError:UNRECOGNIZED_FIELD. DB columns keep their old names — only the
+  // GAQL selectors and the response keys read in the mappers change.
+  "metrics.trueview_average_cpv",
   "metrics.cost_micros",
   "metrics.conversions",
   "metrics.conversions_value",
   "metrics.all_conversions",
   "metrics.all_conversions_value",
   "metrics.view_through_conversions",
-  "metrics.video_views",
-  "metrics.video_view_rate",
+  "metrics.video_trueview_views",
+  "metrics.video_trueview_view_rate",
   "metrics.engagements",
   "metrics.engagement_rate",
   "metrics.interactions",
@@ -76,7 +80,7 @@ const VIDEO_QUARTILE_FIELDS = [
   "metrics.video_quartile_p100_rate",
 ]
 
-function buildCampaignAggregateQuery(windowDays: number): string {
+export function buildCampaignAggregateQuery(windowDays: number): string {
   return `
     SELECT
       campaign.id,
@@ -86,14 +90,19 @@ function buildCampaignAggregateQuery(windowDays: number): string {
       campaign.serving_status,
       campaign.advertising_channel_type,
       campaign.bidding_strategy_type,
-      campaign.start_date,
-      campaign.end_date,
       campaign_budget.amount_micros,
       ${AGGREGATE_METRICS_FIELDS.join(",\n      ")}
     FROM campaign
     WHERE segments.date DURING LAST_${windowDays}_DAYS
   `.replace(/\s+/g, " ").trim()
 }
+
+// campaign.start_date / end_date are resource attributes that are NOT selectable
+// together with segments.date (the metric/date-segmented query above 400s with
+// UNRECOGNIZED_FIELD). Pull them in a separate metric-free query and merge onto
+// the aggregate rows by campaign id.
+export const CAMPAIGN_DATES_QUERY =
+  "SELECT campaign.id, campaign.start_date, campaign.end_date FROM campaign"
 
 function buildAdGroupAggregateQuery(windowDays: number): string {
   return `
@@ -141,7 +150,7 @@ function buildAdAggregateQuery(windowDays: number): string {
 // Daily insights — adds `segments.date` so each row is a per-day snapshot.
 // Video quartiles included here; if the account doesn't return them, GAQL
 // just omits the fields rather than failing the whole query.
-function buildDailyInsightsQuery(
+export function buildDailyInsightsQuery(
   level: "campaign" | "ad_group" | "ad",
   windowDays: number,
   breakdown?: "device" | "network"
@@ -416,6 +425,38 @@ async function pullCidData(
     { label: `ads.campaigns(${cid})`, logger, maxAttempts: 3 }
   )
   const campaigns = extractAllRows(campaignsRes.data)
+
+  // Merge campaign start/end dates (fetched metric-free — see CAMPAIGN_DATES_QUERY).
+  try {
+    const datesRes = await withGoogleRetry(
+      () =>
+        axios.post(
+          `${ADS_API_BASE}/customers/${cid}/googleAds:searchStream`,
+          { query: CAMPAIGN_DATES_QUERY },
+          { headers }
+        ),
+      { label: `ads.campaignDates(${cid})`, logger, maxAttempts: 3 }
+    )
+    const datesById = new Map<string, any>()
+    for (const row of extractAllRows(datesRes.data)) {
+      const id = String(row.campaign?.id ?? "")
+      if (id) datesById.set(id, row.campaign)
+    }
+    for (const row of campaigns) {
+      const dates = datesById.get(String(row.campaign?.id ?? ""))
+      if (dates && row.campaign) {
+        row.campaign.startDate = dates.startDate ?? dates.start_date ?? null
+        row.campaign.endDate = dates.endDate ?? dates.end_date ?? null
+      }
+    }
+  } catch (e: any) {
+    // Non-fatal — dates are nice-to-have; keep the metrics we already pulled.
+    logger?.warn?.(
+      `[google-ads] campaign dates pull failed for cid=${cid}: ${
+        e.response?.data?.error?.message || e.message
+      }`
+    )
+  }
 
   const adGroupsRes = await withGoogleRetry(
     () =>
@@ -915,7 +956,7 @@ async function upsertInsights(
         metrics.averageCpm ?? metrics.average_cpm
       ),
       average_cpv_micros: numericMetric(
-        metrics.averageCpv ?? metrics.average_cpv
+        metrics.trueviewAverageCpv ?? metrics.trueview_average_cpv
       ),
       conversions: floatMetric(metrics.conversions) ?? 0,
       conversions_value: floatMetric(
@@ -934,10 +975,10 @@ async function upsertInsights(
         metrics.costPerConversion ?? metrics.cost_per_conversion
       ),
       video_views: numericMetric(
-        metrics.videoViews ?? metrics.video_views
+        metrics.videoTrueviewViews ?? metrics.video_trueview_views
       ),
       video_view_rate: floatMetric(
-        metrics.videoViewRate ?? metrics.video_view_rate
+        metrics.videoTrueviewViewRate ?? metrics.video_trueview_view_rate
       ),
       video_quartile_p25_rate: floatMetric(
         metrics.videoQuartileP25Rate ?? metrics.video_quartile_p25_rate


### PR DESCRIPTION
## Symptom
Google Ads sync returned all-zeros with `errors[]` on cid `2827746221`:
```
Unrecognized fields: metrics.video_views, metrics.video_view_rate,
metrics.average_cpv, campaign.start_date, campaign.end_date
[queryError:UNRECOGNIZED_FIELD]
```
This is the open tail from #918 — its error-body decoding is what surfaced the real reason instead of a bare "status code 400".

## Root cause — v24 GAQL field drift (not account/manager)
All five rejected fields live in `buildCampaignAggregateQuery`, so it hard-fails → `campaigns_synced=0` cascades everything to zero.

1. **v24 renamed the video metrics** (old names now 400):
   - `metrics.average_cpv` → `metrics.trueview_average_cpv`
   - `metrics.video_views` → `metrics.video_trueview_views`
   - `metrics.video_view_rate` → `metrics.video_trueview_view_rate`
2. **`campaign.start_date` / `end_date` aren't selectable alongside `segments.date`** in a metric query.

## Fix
- Renamed the three metrics in the shared `AGGREGATE_METRICS_FIELDS` (it feeds every aggregate + daily-insights query); mappers read the new camelCase response keys. **DB columns unchanged** → no migration, downstream admin routes untouched.
- Dropped the date attributes from the segmented aggregate query; pull them via a separate metric-free `CAMPAIGN_DATES_QUERY` and merge onto rows by campaign id (non-fatal).
- Verified each replacement against the live v24 metrics reference (selectable-with campaign / ad_group / ad_group_ad).

## Testing
- New `google-ads-gaql-fields.unit.spec.ts` — 4 tests, pass. 0 new TS errors.
- Post-deploy: re-sync `2827746221`, confirm `campaigns_synced > 0` in CloudWatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)