### PR TITLE
fix(google-ads): date-range sync via BETWEEN — any window / full history

### DIFF
--- a/apps/backend/src/api/admin/ads/sync/route.ts
+++ b/apps/backend/src/api/admin/ads/sync/route.ts
@@ -12,6 +12,9 @@ type SyncBody = {
   include_insights?: boolean
   include_breakdowns?: boolean
   window_days?: number
+  /** Explicit range (YYYY-MM-DD). start_date overrides window_days — full backfill. */
+  start_date?: string
+  end_date?: string
 }
 
 /**
@@ -42,6 +45,8 @@ export const POST = async (req: MedusaRequest<SyncBody>, res: MedusaResponse) =>
         include_insights: body.include_insights,
         include_breakdowns: body.include_breakdowns,
         window_days: body.window_days,
+        start_date: body.start_date,
+        end_date: body.end_date,
       },
     })
     return res.status(200).json({ platform: "google" as const, result })

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-google-ads-history-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-google-ads-history-job.ts
@@ -1,0 +1,197 @@
+import { MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import { resolvePlatformForAds } from "../../../../lib/ads-router"
+import { syncGoogleAdsWorkflow } from "../../../../workflows/google-ads/sync-google-ads"
+import { resolveSyncDateRange } from "../../../../workflows/google-ads/steps/sync-google-ads-step"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+/**
+ * Data Plumbing — backfill Google Ads history for a SocialPlatform.
+ *
+ * The regular sync (`POST /admin/ads/sync`) defaults to a 30-day window. This
+ * job runs the SAME `syncGoogleAdsWorkflow` but over a WIDE range so all
+ * historical campaigns / ad-groups / ads / daily-insights get pulled and
+ * upserted (insights rows are keyed per (level, entity, date, device, network),
+ * so re-running just backfills older dates + updates in place — no duplicates).
+ *
+ * Window: pass `start_date` (YYYY-MM-DD) for a true full backfill; otherwise it
+ * defaults to a 2-year `window_days`. Dates go through `segments.date BETWEEN`
+ * (NOT the `LAST_N_DAYS` literal, which only allows 7/14/30) — see
+ * resolveSyncDateRange.
+ *
+ * Dry-run previews the resolved sync window WITHOUT calling Google or writing.
+ * Apply runs the workflow and reports how many rows synced; per-CID failures are
+ * recorded in `errors` (the workflow is best-effort per account).
+ */
+
+// Default lookback for a backfill when no explicit start_date is given (2y).
+export const DEFAULT_BACKFILL_WINDOW_DAYS = 730
+
+const backfillGoogleAdsHistoryParamsSchema = z.object({
+  platform_id: z.string().min(1, "platform_id is required"),
+  /** Scope to a single CID; defaults to all `ads` bindings on the platform. */
+  account_id: z.string().min(1).optional(),
+  /** Full-backfill range start (YYYY-MM-DD). Overrides window_days. */
+  start_date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "start_date must be YYYY-MM-DD")
+    .optional(),
+  /** Range end (YYYY-MM-DD). Defaults to today. */
+  end_date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "end_date must be YYYY-MM-DD")
+    .optional(),
+  /** Lookback in days when no start_date (default 2y). */
+  window_days: z.number().int().positive().optional(),
+  include_insights: z.boolean().optional().default(true),
+  include_ads: z.boolean().optional().default(true),
+  include_breakdowns: z.boolean().optional().default(false),
+})
+
+export const backfillGoogleAdsHistoryJob: MaintenanceJob = {
+  id: "backfill-google-ads-history",
+  label: "Backfill Google Ads history",
+  description:
+    `Pull ALL historical Google Ads data (campaigns, ad-groups, ads, daily insights) for a platform by running the sync over a wide date range instead of the default 30 days. Pass start_date (YYYY-MM-DD) for a full backfill, else it looks back ${DEFAULT_BACKFILL_WINDOW_DAYS} days. Idempotent — insights are keyed per (level, entity, date) so re-runs backfill older dates and update in place. Dry-run previews the resolved window WITHOUT calling Google or writing; apply runs the sync and reports rows synced (per-account failures are listed, not fatal).`,
+  params: [
+    {
+      name: "platform_id",
+      type: "string",
+      required: true,
+      description: "SocialPlatform id (Google Ads) to backfill",
+    },
+    {
+      name: "account_id",
+      type: "string",
+      required: false,
+      description: "Single CID to scope to (default: all bound accounts)",
+    },
+    {
+      name: "start_date",
+      type: "string",
+      required: false,
+      description: "Full-backfill range start (YYYY-MM-DD). Overrides window_days.",
+    },
+    {
+      name: "end_date",
+      type: "string",
+      required: false,
+      description: "Range end (YYYY-MM-DD). Defaults to today.",
+    },
+    {
+      name: "window_days",
+      type: "number",
+      required: false,
+      description: `Lookback in days when no start_date (default ${DEFAULT_BACKFILL_WINDOW_DAYS})`,
+    },
+    {
+      name: "include_insights",
+      type: "boolean",
+      required: false,
+      description: "Pull daily time-series insights (default true)",
+    },
+    {
+      name: "include_ads",
+      type: "boolean",
+      required: false,
+      description: "Pull ad-level rows + creative (default true)",
+    },
+    {
+      name: "include_breakdowns",
+      type: "boolean",
+      required: false,
+      description: "Also pull device-breakdown insights (default false)",
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = backfillGoogleAdsHistoryParamsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const {
+      platform_id,
+      account_id,
+      start_date,
+      end_date,
+      window_days,
+      include_insights,
+      include_ads,
+      include_breakdowns,
+    } = parsed.data
+
+    // Only Google platforms flow through this workflow — mirror the sync route.
+    const { kind } = await resolvePlatformForAds(container, platform_id)
+    if (kind !== "google") {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        `Platform ${platform_id} is not a Google Ads platform (kind=${kind}); this job backfills Google Ads only`
+      )
+    }
+
+    // No explicit start_date → default to a wide lookback so it's a real backfill.
+    const effectiveWindowDays =
+      start_date != null ? undefined : window_days ?? DEFAULT_BACKFILL_WINDOW_DAYS
+
+    const range = resolveSyncDateRange({
+      window_days: effectiveWindowDays,
+      start_date,
+      end_date,
+    })
+
+    const windowChange: MaintenanceChange = {
+      entity: "social_platform",
+      id: platform_id,
+      field: "sync_window",
+      before: null,
+      after: `${range.start} → ${range.end}${account_id ? ` (cid ${account_id})` : ""}`,
+    }
+
+    if (dry_run) {
+      return {
+        job_id: backfillGoogleAdsHistoryJob.id,
+        dry_run,
+        applied: false,
+        summary: `Would sync Google Ads for platform ${platform_id} over ${range.start} → ${range.end}${account_id ? ` (cid ${account_id})` : " (all bound accounts)"}`,
+        changes: [windowChange],
+      }
+    }
+
+    const { result } = await syncGoogleAdsWorkflow(container).run({
+      input: {
+        platform_id,
+        customer_id: account_id,
+        include_ads,
+        include_insights,
+        include_breakdowns,
+        start_date: range.start,
+        end_date: range.end,
+      },
+    })
+
+    const errors = (result.errors ?? []).map((e) => ({
+      id: e.customer_id,
+      message: e.message,
+    }))
+    const synced =
+      result.customers_synced +
+      result.campaigns_synced +
+      result.ad_groups_synced +
+      result.ads_synced +
+      result.insights_rows_synced
+
+    return {
+      job_id: backfillGoogleAdsHistoryJob.id,
+      dry_run,
+      applied: synced > 0,
+      summary: `Synced ${result.customers_synced} customer(s), ${result.campaigns_synced} campaign(s), ${result.ad_groups_synced} ad-group(s), ${result.ads_synced} ad(s), ${result.insights_rows_synced} insights row(s) over ${range.start} → ${range.end}${errors.length ? `; ${errors.length} account error(s)` : ""}`,
+      changes: [windowChange],
+      errors,
+    }
+  },
+}
+
+export default backfillGoogleAdsHistoryJob

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -81,6 +81,7 @@ import { backfillAudienceEntriesJob } from "./backfill-audience-entries-job"
 import { recomputeEmailEngagementStatusJob } from "./recompute-email-engagement-status-job"
 import { generateNewsletterWinbackTargetsJob } from "./generate-newsletter-winback-targets-job"
 import { repairInventoryOrderSourceJob } from "./repair-inventory-order-source-job"
+import { backfillGoogleAdsHistoryJob } from "./backfill-google-ads-history-job"
 import {
   sweepAiPlatformsByCategory,
   AI_ROLES,
@@ -5419,6 +5420,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   recomputeEmailEngagementStatusJob,
   generateNewsletterWinbackTargetsJob,
   repairInventoryOrderSourceJob,
+  backfillGoogleAdsHistoryJob,
 ]
 
 export const getMaintenanceJob = (id: string): MaintenanceJob | undefined =>

--- a/apps/backend/src/workflows/google-ads/steps/__tests__/google-ads-gaql-fields.unit.spec.ts
+++ b/apps/backend/src/workflows/google-ads/steps/__tests__/google-ads-gaql-fields.unit.spec.ts
@@ -3,6 +3,8 @@ import {
   CAMPAIGN_DATES_QUERY,
   buildCampaignAggregateQuery,
   buildDailyInsightsQuery,
+  buildDateClause,
+  resolveSyncDateRange,
 } from "../sync-google-ads-step"
 
 /**
@@ -11,6 +13,8 @@ import {
  * campaign.start_date/end_date when selected alongside segments.date + metrics.
  */
 describe("google-ads GAQL field selection (v24)", () => {
+  const DATE_CLAUSE = "segments.date BETWEEN '2026-06-01' AND '2026-07-01'"
+
   // Removed/renamed in v24 — selecting any of these 400s the whole query.
   const REMOVED_METRICS = [
     "metrics.average_cpv",
@@ -31,10 +35,10 @@ describe("google-ads GAQL field selection (v24)", () => {
 
   it("never selects a removed metric in any metric-bearing query", () => {
     const queries = [
-      buildCampaignAggregateQuery(30),
-      buildDailyInsightsQuery("campaign", 30),
-      buildDailyInsightsQuery("ad_group", 30),
-      buildDailyInsightsQuery("ad", 30),
+      buildCampaignAggregateQuery(DATE_CLAUSE),
+      buildDailyInsightsQuery("campaign", DATE_CLAUSE),
+      buildDailyInsightsQuery("ad_group", DATE_CLAUSE),
+      buildDailyInsightsQuery("ad", DATE_CLAUSE),
     ]
     for (const q of queries) {
       for (const removed of REMOVED_METRICS) {
@@ -45,7 +49,7 @@ describe("google-ads GAQL field selection (v24)", () => {
   })
 
   it("does NOT select campaign date attributes in the segmented aggregate query", () => {
-    const q = buildCampaignAggregateQuery(30)
+    const q = buildCampaignAggregateQuery(DATE_CLAUSE)
     expect(q).toContain("segments.date")
     expect(q).not.toContain("campaign.start_date")
     expect(q).not.toContain("campaign.end_date")
@@ -56,5 +60,59 @@ describe("google-ads GAQL field selection (v24)", () => {
     expect(CAMPAIGN_DATES_QUERY).toContain("campaign.end_date")
     expect(CAMPAIGN_DATES_QUERY).not.toContain("segments.date")
     expect(CAMPAIGN_DATES_QUERY).not.toContain("metrics.")
+  })
+})
+
+/**
+ * The date window must be an explicit `BETWEEN` range, never the `LAST_N_DAYS`
+ * literal — that literal only accepts 7/14/30, so any other window_days 400s
+ * and a full historical backfill is impossible.
+ */
+describe("google-ads sync date range", () => {
+  const NOW = new Date("2026-07-07T12:00:00Z")
+
+  it("never emits a LAST_N_DAYS literal", () => {
+    const q = buildCampaignAggregateQuery(
+      buildDateClause(resolveSyncDateRange({ window_days: 90 }, NOW))
+    )
+    expect(q).not.toMatch(/LAST_\d+_DAYS/)
+    expect(q).toContain("segments.date BETWEEN")
+  })
+
+  it("computes start = end − window_days (arbitrary N works)", () => {
+    const r = resolveSyncDateRange({ window_days: 90 }, NOW)
+    expect(r.end).toBe("2026-07-07")
+    expect(r.start).toBe("2026-04-08") // 90 days before
+  })
+
+  it("defaults to a 30-day window", () => {
+    const r = resolveSyncDateRange({}, NOW)
+    expect(r.start).toBe("2026-06-07")
+    expect(r.end).toBe("2026-07-07")
+  })
+
+  it("honours an explicit start_date (full backfill) over window_days", () => {
+    const r = resolveSyncDateRange(
+      { start_date: "2020-01-01", window_days: 30 },
+      NOW
+    )
+    expect(r.start).toBe("2020-01-01")
+    expect(r.end).toBe("2026-07-07")
+  })
+
+  it("caps the window at ~10y to avoid an unbounded query", () => {
+    const r = resolveSyncDateRange({ window_days: 999999 }, NOW)
+    expect(r.start).toBe("2016-07-09") // 3650 days before NOW
+  })
+
+  it("rejects a non-ISO / injection-y date and falls back", () => {
+    const r = resolveSyncDateRange(
+      { start_date: "2020-01-01' OR '1'='1", end_date: "garbage" },
+      NOW
+    )
+    // malformed start_date ignored → window fallback; malformed end_date → today
+    expect(r.start).toBe("2026-06-07")
+    expect(r.end).toBe("2026-07-07")
+    expect(buildDateClause(r)).not.toContain("OR")
   })
 })

--- a/apps/backend/src/workflows/google-ads/steps/sync-google-ads-step.ts
+++ b/apps/backend/src/workflows/google-ads/steps/sync-google-ads-step.ts
@@ -22,8 +22,16 @@ export type SyncGoogleAdsInput = {
   include_insights?: boolean
   /** Also pull device-breakdown insights at campaign + ad_group. Default false. */
   include_breakdowns?: boolean
-  /** Window for aggregate metrics + daily insights. Default 30. Min 1, max 365. */
+  /**
+   * Lookback window in days for aggregates + daily insights. Default 30, max
+   * ~10y. Ignored when `start_date` is given. Implemented as `segments.date
+   * BETWEEN` (NOT the `LAST_N_DAYS` literal, which only allows 7/14/30).
+   */
   window_days?: number
+  /** Explicit range start (YYYY-MM-DD). Overrides window_days — use for full backfill. */
+  start_date?: string
+  /** Explicit range end (YYYY-MM-DD). Defaults to today. */
+  end_date?: string
 }
 
 export type SyncGoogleAdsOutput = {
@@ -42,9 +50,9 @@ const CUSTOMER_QUERY =
   "SELECT customer.id, customer.descriptive_name, customer.currency_code, customer.time_zone, customer.manager, customer.test_account FROM customer LIMIT 1"
 
 // Enriched aggregate metrics for the rolled-up rows on campaign / ad_group / ad.
-// GAQL won't let us combine `LIMIT` with `WHERE segments.date BETWEEN` for
-// metric queries, so we use `DURING LAST_N_DAYS`-style constants computed from
-// the runtime window.
+// Date-scoped via an explicit `segments.date BETWEEN 'start' AND 'end'` clause
+// (see resolveSyncDateRange) so any lookback works — the `LAST_N_DAYS` literal
+// these once used only accepts 7/14/30.
 export const AGGREGATE_METRICS_FIELDS = [
   "metrics.impressions",
   "metrics.clicks",
@@ -80,7 +88,44 @@ const VIDEO_QUARTILE_FIELDS = [
   "metrics.video_quartile_p100_rate",
 ]
 
-export function buildCampaignAggregateQuery(windowDays: number): string {
+// GAQL's `LAST_N_DAYS` literal only accepts 7 / 14 / 30 — anything else 400s.
+// To support arbitrary lookbacks (incl. a full historical backfill) we build an
+// explicit `segments.date BETWEEN 'start' AND 'end'` clause. ~10y cap keeps a
+// stray window_days from producing an unbounded query; Google returns only the
+// dates it actually retains within the range.
+const MAX_WINDOW_DAYS = 3650
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
+// Only accept well-formed YYYY-MM-DD — these values are interpolated straight
+// into GAQL, so an unvalidated string would be an injection vector.
+function safeISODate(v: string | undefined | null): string | undefined {
+  return typeof v === "string" && ISO_DATE.test(v) ? v : undefined
+}
+
+function toISODate(d: Date): string {
+  return d.toISOString().slice(0, 10)
+}
+
+export function resolveSyncDateRange(
+  input: { window_days?: number; start_date?: string; end_date?: string },
+  now: Date = new Date()
+): { start: string; end: string } {
+  const end = safeISODate(input.end_date) ?? toISODate(now)
+  const explicitStart = safeISODate(input.start_date)
+  if (explicitStart) {
+    return { start: explicitStart, end }
+  }
+  const days = Math.min(Math.max(input.window_days ?? 30, 1), MAX_WINDOW_DAYS)
+  const startDate = new Date(now)
+  startDate.setUTCDate(startDate.getUTCDate() - days)
+  return { start: toISODate(startDate), end }
+}
+
+export function buildDateClause(range: { start: string; end: string }): string {
+  return `segments.date BETWEEN '${range.start}' AND '${range.end}'`
+}
+
+export function buildCampaignAggregateQuery(dateClause: string): string {
   return `
     SELECT
       campaign.id,
@@ -93,7 +138,7 @@ export function buildCampaignAggregateQuery(windowDays: number): string {
       campaign_budget.amount_micros,
       ${AGGREGATE_METRICS_FIELDS.join(",\n      ")}
     FROM campaign
-    WHERE segments.date DURING LAST_${windowDays}_DAYS
+    WHERE ${dateClause}
   `.replace(/\s+/g, " ").trim()
 }
 
@@ -104,7 +149,7 @@ export function buildCampaignAggregateQuery(windowDays: number): string {
 export const CAMPAIGN_DATES_QUERY =
   "SELECT campaign.id, campaign.start_date, campaign.end_date FROM campaign"
 
-function buildAdGroupAggregateQuery(windowDays: number): string {
+function buildAdGroupAggregateQuery(dateClause: string): string {
   return `
     SELECT
       ad_group.id,
@@ -115,14 +160,14 @@ function buildAdGroupAggregateQuery(windowDays: number): string {
       ad_group.campaign,
       ${AGGREGATE_METRICS_FIELDS.join(",\n      ")}
     FROM ad_group
-    WHERE segments.date DURING LAST_${windowDays}_DAYS
+    WHERE ${dateClause}
   `.replace(/\s+/g, " ").trim()
 }
 
 // ad_group_ad rolls the placement (status, resource_name) and the creative
 // (ad_group_ad.ad.*) together. We flatten the most-useful creative fields per
 // ad type — RSAs use the asset arrays, image/video ads use the static fields.
-function buildAdAggregateQuery(windowDays: number): string {
+function buildAdAggregateQuery(dateClause: string): string {
   return `
     SELECT
       ad_group_ad.ad.id,
@@ -143,7 +188,7 @@ function buildAdAggregateQuery(windowDays: number): string {
       ad_group_ad.ad_group,
       ${AGGREGATE_METRICS_FIELDS.join(",\n      ")}
     FROM ad_group_ad
-    WHERE segments.date DURING LAST_${windowDays}_DAYS
+    WHERE ${dateClause}
   `.replace(/\s+/g, " ").trim()
 }
 
@@ -152,7 +197,7 @@ function buildAdAggregateQuery(windowDays: number): string {
 // just omits the fields rather than failing the whole query.
 export function buildDailyInsightsQuery(
   level: "campaign" | "ad_group" | "ad",
-  windowDays: number,
+  dateClause: string,
   breakdown?: "device" | "network"
 ): string {
   const entityFields =
@@ -186,7 +231,7 @@ export function buildDailyInsightsQuery(
       ${VIDEO_QUARTILE_FIELDS.join(",\n      ")},
       metrics.cost_per_conversion
     FROM ${from}
-    WHERE segments.date DURING LAST_${windowDays}_DAYS
+    WHERE ${dateClause}
   `.replace(/\s+/g, " ").trim()
 }
 
@@ -216,7 +261,11 @@ export const syncGoogleAdsStep = createStep(
     const includeAds = input.include_ads !== false
     const includeInsights = input.include_insights !== false
     const includeBreakdowns = input.include_breakdowns === true
-    const windowDays = Math.min(Math.max(input.window_days ?? 30, 1), 365)
+    const dateRange = resolveSyncDateRange(input)
+    const dateClause = buildDateClause(dateRange)
+    logger?.info?.(
+      `[google-ads] sync window ${dateRange.start} → ${dateRange.end} for platform=${input.platform_id}`
+    )
 
     const developerToken = await readDeveloperToken(
       input.platform_id,
@@ -288,7 +337,7 @@ export const syncGoogleAdsStep = createStep(
           t.customer_id,
           headers,
           logger,
-          { includeAds, includeInsights, includeBreakdowns, windowDays }
+          { includeAds, includeInsights, includeBreakdowns, dateClause }
         )
 
         const customerRow = await upsertCustomer(socials, {
@@ -395,7 +444,8 @@ type PullOpts = {
   includeAds: boolean
   includeInsights: boolean
   includeBreakdowns: boolean
-  windowDays: number
+  /** Pre-built `segments.date BETWEEN …` clause shared by every metric query. */
+  dateClause: string
 }
 
 async function pullCidData(
@@ -450,7 +500,7 @@ async function pullCidData(
     () =>
       axios.post(
         `${ADS_API_BASE}/customers/${cid}/googleAds:searchStream`,
-        { query: buildCampaignAggregateQuery(opts.windowDays) },
+        { query: buildCampaignAggregateQuery(opts.dateClause) },
         { headers }
       ),
     { label: `ads.campaigns(${cid})`, logger, maxAttempts: 3 }
@@ -493,7 +543,7 @@ async function pullCidData(
     () =>
       axios.post(
         `${ADS_API_BASE}/customers/${cid}/googleAds:searchStream`,
-        { query: buildAdGroupAggregateQuery(opts.windowDays) },
+        { query: buildAdGroupAggregateQuery(opts.dateClause) },
         { headers }
       ),
     { label: `ads.adGroups(${cid})`, logger, maxAttempts: 3 }
@@ -507,7 +557,7 @@ async function pullCidData(
         () =>
           axios.post(
             `${ADS_API_BASE}/customers/${cid}/googleAds:searchStream`,
-            { query: buildAdAggregateQuery(opts.windowDays) },
+            { query: buildAdAggregateQuery(opts.dateClause) },
             { headers }
           ),
         { label: `ads.ads(${cid})`, logger, maxAttempts: 3 }
@@ -533,14 +583,14 @@ async function pullCidData(
       headers,
       logger,
       "campaign",
-      opts.windowDays
+      opts.dateClause
     )
     insights.ad_group = await pullDailyInsights(
       cid,
       headers,
       logger,
       "ad_group",
-      opts.windowDays
+      opts.dateClause
     )
     if (opts.includeBreakdowns) {
       insights.campaign_by_device = await pullDailyInsights(
@@ -548,7 +598,7 @@ async function pullCidData(
         headers,
         logger,
         "campaign",
-        opts.windowDays,
+        opts.dateClause,
         "device"
       )
       insights.ad_group_by_device = await pullDailyInsights(
@@ -556,7 +606,7 @@ async function pullCidData(
         headers,
         logger,
         "ad_group",
-        opts.windowDays,
+        opts.dateClause,
         "device"
       )
     }
@@ -583,7 +633,7 @@ async function pullDailyInsights(
   headers: Record<string, string>,
   logger: Logger | undefined,
   level: "campaign" | "ad_group" | "ad",
-  windowDays: number,
+  dateClause: string,
   breakdown?: "device" | "network"
 ): Promise<any[]> {
   try {
@@ -591,7 +641,7 @@ async function pullDailyInsights(
       () =>
         axios.post(
           `${ADS_API_BASE}/customers/${cid}/googleAds:searchStream`,
-          { query: buildDailyInsightsQuery(level, windowDays, breakdown) },
+          { query: buildDailyInsightsQuery(level, dateClause, breakdown) },
           { headers }
         ),
       { label: `ads.insights.${level}${breakdown ? "." + breakdown : ""}(${cid})`, logger, maxAttempts: 3 }

--- a/apps/backend/src/workflows/google-ads/sync-google-ads.ts
+++ b/apps/backend/src/workflows/google-ads/sync-google-ads.ts
@@ -20,8 +20,12 @@ export type SyncGoogleAdsWorkflowInput = {
   include_insights?: boolean
   /** Also pull device-breakdown insights. Default false. */
   include_breakdowns?: boolean
-  /** Window in days for aggregates + daily insights. Default 30. */
+  /** Window in days for aggregates + daily insights. Default 30, max ~10y. */
   window_days?: number
+  /** Explicit range start (YYYY-MM-DD). Overrides window_days — full backfill. */
+  start_date?: string
+  /** Explicit range end (YYYY-MM-DD). Defaults to today. */
+  end_date?: string
 }
 
 export const syncGoogleAdsWorkflowId = "sync-google-ads-workflow"
@@ -51,6 +55,8 @@ export const syncGoogleAdsWorkflow = createWorkflow(
         include_insights: input.include_insights,
         include_breakdowns: input.include_breakdowns,
         window_days: input.window_days,
+        start_date: input.start_date,
+        end_date: input.end_date,
       })
     )
 


### PR DESCRIPTION
## Why
Verifying the synced data for platform `01KRBE08414X7XK3YJ05ZAXWM3` (cid `2827746221`): the sync created the account + 1 campaign but **0 insights, 0 metrics**. Root cause of the "it doesn't sync all past information" report:

The sync scoped metrics + daily insights with `segments.date DURING LAST_${windowDays}_DAYS`. **GAQL's `LAST_N_DAYS` literal only accepts 7 / 14 / 30** — the default 30 is the only value that worked; `window_days=90`/`365` would 400 (`queryError`). A full historical backfill was impossible.

## Fix
- Replace the literal with an explicit **`segments.date BETWEEN 'start' AND 'end'`** clause (`resolveSyncDateRange` + `buildDateClause`, ~10y cap). Any lookback now works.
- New optional **`start_date` / `end_date`** (YYYY-MM-DD), threaded through the workflow + `POST /admin/ads/sync`. `start_date` overrides `window_days` → full backfill. ISO-validated before interpolation (closes a GAQL injection vector).

## Data Plumbing trigger (added)
New DP job **`backfill-google-ads-history`** (`backfill-google-ads-history-job.ts`) runs the sync over a wide range (default 2y, or explicit `start_date` for all history). Dry-run previews the resolved window without calling Google; apply runs it and reports rows synced. Registered in `MAINTENANCE_JOBS`. This is the intended way to trigger the full backfill (no manual curl).

## Testing
- 6 new unit tests for the date range (no `LAST_N_DAYS`, window math, explicit-start backfill, 10y cap, injection rejection) — 10/10 in the suite. 0 new TS errors.

## Follow-up
PerformanceMax asset-group coverage + campaign `start_date` null → tracked in a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)