### PR TITLE
feat(partner-ui): production-cost input + platform-fee line on design cost panel

### DIFF
--- a/apps/partner-ui/src/hooks/api/partner-design-cost.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-design-cost.tsx
@@ -20,10 +20,16 @@ export type PartnerDesignCost = {
   estimated_cost?: number | null
   material_cost?: number | null
   production_cost?: number | null
+  /** JYT platform commission (10% of material). */
+  platform_fee?: number | null
   cost_currency?: string | null
   cost_breakdown?: {
     items?: Array<Record<string, any>>
     production_percent?: number
+    platform_fee?: number
+    platform_fee_percent?: number
+    /** "partner_entered" when the owner typed the production cost, else "estimated". */
+    production_cost_source?: string
     confidence?: string
     calculated_at?: string
     source?: string
@@ -34,15 +40,20 @@ export type PartnerDesignCostEstimate = {
   cost_estimate: {
     material_cost: number
     production_cost: number
+    platform_fee: number
     total_estimated: number
     confidence: string
     breakdown?: {
       materials?: Array<Record<string, any>>
       production_percent?: number
+      platform_fee_percent?: number
     }
   }
   message: string
 }
+
+/** Optional per-unit production cost the partner types; overrides the estimate. */
+export type RecalcPartnerCostVars = { production_cost?: number } | void
 
 const costKey = (designId: string) => ["partner-design-cost", designId]
 
@@ -67,14 +78,23 @@ export const usePartnerDesignCost = (
 
 export const useRecalculatePartnerDesignCost = (
   designId: string,
-  options?: UseMutationOptions<PartnerDesignCostEstimate, FetchError, void>
+  options?: UseMutationOptions<
+    PartnerDesignCostEstimate,
+    FetchError,
+    RecalcPartnerCostVars
+  >
 ) => {
   return useMutation({
-    mutationFn: async () =>
-      sdk.client.fetch<PartnerDesignCostEstimate>(
+    mutationFn: async (vars?: RecalcPartnerCostVars) => {
+      const body =
+        vars && "production_cost" in vars && vars.production_cost != null
+          ? { production_cost: vars.production_cost }
+          : {}
+      return sdk.client.fetch<PartnerDesignCostEstimate>(
         `/partners/designs/${designId}/recalculate-cost`,
-        { method: "POST", body: {} }
-      ),
+        { method: "POST", body }
+      )
+    },
     onSuccess: async (data, variables, context) => {
       await queryClient.invalidateQueries({ queryKey: costKey(designId) })
       options?.onSuccess?.(data, variables, context)

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-cost-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-cost-section.tsx
@@ -1,9 +1,12 @@
+import { useEffect, useRef, useState } from "react"
 import { ArrowPath } from "@medusajs/icons"
 import {
   Badge,
   Button,
   Container,
   Heading,
+  Input,
+  Label,
   Text,
   toast,
 } from "@medusajs/ui"
@@ -24,9 +27,10 @@ const fmt = (v?: number | null, currency?: string | null) =>
     : `${currency ? currency.toUpperCase() + " " : ""}${Number(v).toLocaleString(undefined, { maximumFractionDigits: 2 })}`
 
 /**
- * Roadmap #6 Phase 3 — cost panel. Shows the design's estimated /
- * material / production cost + breakdown, with a Recalculate action
- * (owner only) that re-runs the estimate over the linked BOM.
+ * Roadmap #6 Phase 3 — cost panel. Shows the design's estimated / material /
+ * production cost + the 10% JYT platform fee, with a Recalculate action (owner
+ * only) that re-runs the estimate over the linked BOM. The owner can also type
+ * their own production cost, which overrides the auto estimate.
  */
 export const DesignCostSection = ({ design }: Props) => {
   const isOwner = !!(design as any).owner_partner_id
@@ -35,18 +39,46 @@ export const DesignCostSection = ({ design }: Props) => {
     design.id
   )
 
+  // Partner-entered production cost per unit. Seed from the persisted value once
+  // it loads; `touched` keeps a later refetch from clobbering the owner's typing.
+  const [prodInput, setProdInput] = useState("")
+  const touched = useRef(false)
+  useEffect(() => {
+    if (!touched.current && cost?.production_cost != null) {
+      setProdInput(String(cost.production_cost))
+    }
+  }, [cost?.production_cost])
+
   const handleRecalc = async () => {
-    await recalc(undefined, {
-      onSuccess: (d) =>
-        toast.success(
-          `Cost recalculated: ${fmt(d.cost_estimate.total_estimated)} (${d.cost_estimate.confidence})`
-        ),
-      onError: (e) => toast.error(e.message),
-    })
+    const trimmed = prodInput.trim()
+    let production_cost: number | undefined
+    if (trimmed !== "") {
+      const n = Number(trimmed)
+      if (!Number.isFinite(n) || n < 0) {
+        toast.error("Enter a valid production cost (0 or more)")
+        return
+      }
+      production_cost = n
+    }
+    await recalc(
+      { production_cost },
+      {
+        onSuccess: (d) => {
+          touched.current = false
+          toast.success(
+            `Cost recalculated: ${fmt(d.cost_estimate.total_estimated)} (${d.cost_estimate.confidence})`
+          )
+        },
+        onError: (e) => toast.error(e.message),
+      }
+    )
   }
 
   const currency = cost?.cost_currency
   const confidence = cost?.cost_breakdown?.confidence
+  const feePercent = cost?.cost_breakdown?.platform_fee_percent ?? 10
+  const prodIsPartnerEntered =
+    cost?.cost_breakdown?.production_cost_source === "partner_entered"
 
   return (
     <Container className="divide-y p-0">
@@ -54,7 +86,8 @@ export const DesignCostSection = ({ design }: Props) => {
         <div>
           <Heading level="h2">Cost estimate</Heading>
           <Text size="small" className="text-ui-fg-subtle">
-            Material + production cost from the linked BOM.
+            Material + production cost from the linked BOM, plus the JYT platform
+            fee.
           </Text>
         </div>
         {isOwner && (
@@ -72,7 +105,7 @@ export const DesignCostSection = ({ design }: Props) => {
 
       {isLoading ? (
         <div className="flex flex-col divide-y">
-          {Array.from({ length: 3 }).map((_, i) => (
+          {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
               className="flex items-center justify-between px-6 py-4"
@@ -114,7 +147,18 @@ export const DesignCostSection = ({ design }: Props) => {
           />
           <SectionRow
             title="Production cost"
-            value={fmt(cost?.production_cost, currency)}
+            value={
+              <div className="flex items-center gap-x-2">
+                <Text size="small">{fmt(cost?.production_cost, currency)}</Text>
+                <Badge size="2xsmall" color={prodIsPartnerEntered ? "green" : "grey"}>
+                  {prodIsPartnerEntered ? "your input" : "estimated"}
+                </Badge>
+              </div>
+            }
+          />
+          <SectionRow
+            title={`Platform fee (${feePercent}%)`}
+            value={fmt(cost?.platform_fee, currency)}
           />
           {cost?.cost_breakdown?.calculated_at && (
             <SectionRow
@@ -122,6 +166,52 @@ export const DesignCostSection = ({ design }: Props) => {
               value={new Date(cost.cost_breakdown.calculated_at).toLocaleString()}
             />
           )}
+
+          {isOwner && (
+            <div className="flex flex-col gap-y-2 px-6 py-4">
+              <Label size="small" weight="plus" htmlFor="partner-production-cost">
+                Your production cost (per unit)
+              </Label>
+              <div className="flex items-center gap-x-2">
+                <Input
+                  id="partner-production-cost"
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  inputMode="decimal"
+                  placeholder="Auto-estimate"
+                  value={prodInput}
+                  onChange={(e) => {
+                    touched.current = true
+                    setProdInput(e.target.value)
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleRecalc()
+                  }}
+                  className="max-w-[220px]"
+                />
+                {prodInput.trim() !== "" && (
+                  <Button
+                    size="small"
+                    variant="transparent"
+                    type="button"
+                    onClick={() => {
+                      touched.current = true
+                      setProdInput("")
+                    }}
+                  >
+                    Clear
+                  </Button>
+                )}
+              </div>
+              <Text size="xsmall" className="text-ui-fg-subtle">
+                Overrides the auto estimate — leave blank to estimate from
+                history. A {feePercent}% platform fee applies on material cost.
+                Press Recalculate to apply.
+              </Text>
+            </div>
+          )}
+
           {!cost?.estimated_cost && isOwner && (
             <div className="px-6 py-4">
               <Text size="small" className="text-ui-fg-subtle">


### PR DESCRIPTION
Surfaces the backend from #922 (merged) in the partner design **cost panel**.

## Changes
- **"Your production cost (per unit)"** input (owner only), seeded from the persisted value. **Recalculate** now posts `{ production_cost }` so a typed value overrides the 30% auto-estimate; blank = estimate from history.
- **"Platform fee (10%)"** row (JYT platform commission on material cost).
- Production-cost row shows a **"your input" / "estimated"** badge from `cost_breakdown.production_cost_source`.
- Hook: `PartnerDesignCost` gains `platform_fee` + breakdown fields; recalc mutation takes optional `{ production_cost }`.

## Panel now reads
```
Estimated total     ...   [confidence]
Material cost       ...
Production cost     ...   [your input | estimated]
Platform fee (10%)  ...
Your production cost (per unit)  [ input ]  Recalculate
```

## Testing
- `tsc` clean on the two touched files (4 pre-existing errors elsewhere, unrelated). Skeletons preserved for the loading state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)