### PR TITLE
fix(etsy): return-policy label + settings as its own route; consume plugin @latest

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -68,7 +68,7 @@
     "@freesewing/titan": "4.10.0",
     "@hookform/error-message": "^2.0.1",
     "@hookform/resolvers": "^5.0.1",
-    "@jytextiles/medusa-plugin-etsy-sync": "0.1.2",
+    "@jytextiles/medusa-plugin-etsy-sync": "latest",
     "@mastra/core": "latest",
     "@mastra/evals": "latest",
     "@mastra/loggers": "latest",

--- a/packages/medusa-plugin-etsy-sync/package.json
+++ b/packages/medusa-plugin-etsy-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jytextiles/medusa-plugin-etsy-sync",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/packages/medusa-plugin-etsy-sync/src/admin/routes/settings/etsy/[id]/page.tsx
+++ b/packages/medusa-plugin-etsy-sync/src/admin/routes/settings/etsy/[id]/page.tsx
@@ -5,6 +5,7 @@ import {
   Heading,
   IconButton,
   Label,
+  Skeleton,
   StatusBadge,
   Text,
   Toaster,
@@ -63,7 +64,7 @@ const EtsySyncDetailPage = () => {
   if (loading) {
     return (
       <Container className="p-6">
-        <Text>Loading…</Text>
+        <Skeleton className="h-7 w-12 rounded-md" />
       </Container>
     )
   }

--- a/packages/medusa-plugin-etsy-sync/src/admin/routes/settings/etsy/page.tsx
+++ b/packages/medusa-plugin-etsy-sync/src/admin/routes/settings/etsy/page.tsx
@@ -7,18 +7,13 @@ import {
   DataTable,
   DataTableFilteringState,
   DataTablePaginationState,
-  Drawer,
   Heading,
   Label,
-  Select,
   Skeleton,
   StatusBadge,
-  Switch,
   Text,
   Toaster,
-  Tooltip,
   toast,
-  clx,
   createDataTableFilterHelper,
   useDataTable,
 } from "@medusajs/ui"
@@ -28,7 +23,7 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { useNavigate } from "react-router-dom"
 import { etsyApi } from "../../../lib/api"
 import { useEtsySyncColumns, EtsySyncRecord } from "./hooks/use-etsy-sync-columns"
@@ -36,26 +31,6 @@ import { useEtsySyncColumns, EtsySyncRecord } from "./hooks/use-etsy-sync-column
 const PAGE_SIZE = 10
 const STATUS_KEY = ["etsy", "status"]
 const OPTIONS_KEY = ["etsy", "options"]
-const TAXONOMY_KEY = ["etsy", "taxonomy"]
-
-// Radix Select can't use an empty-string item value, so "Not set" uses this
-// sentinel. It must never be persisted — map it back to null on save.
-const NONE = "__none__"
-
-const cleanSettings = (form: any) => {
-  const out: any = { ...form }
-  for (const key of [
-    "default_shipping_profile_id",
-    "default_return_policy_id",
-    "default_readiness_state_id",
-  ]) {
-    if (!out[key] || out[key] === NONE) out[key] = null
-  }
-  if (!out.default_taxonomy_id || Number.isNaN(Number(out.default_taxonomy_id))) {
-    out.default_taxonomy_id = null
-  }
-  return out
-}
 
 type Status = {
   connected: boolean
@@ -75,9 +50,6 @@ const EtsySettingsPage = () => {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
 
-  const [settingsOpen, setSettingsOpen] = useState(false)
-  const [form, setForm] = useState<any>({})
-
   // DataTable state
   const [pagination, setPagination] = useState<DataTablePaginationState>({
     pageIndex: 0,
@@ -92,41 +64,6 @@ const EtsySettingsPage = () => {
   })
   const status = statusQuery.data
   const connected = !!status?.connected
-
-  // Keep the editable form in sync with the persisted settings.
-  useEffect(() => {
-    if (status?.settings) {
-      setForm(status.settings)
-    }
-  }, [status?.settings])
-
-  const optionsQuery = useQuery({
-    queryKey: OPTIONS_KEY,
-    enabled: connected,
-    queryFn: async () => {
-      const [sp, rp, rs] = await Promise.all([
-        etsyApi.shippingProfiles().catch(() => ({ shipping_profiles: [] })),
-        etsyApi.returnPolicies().catch(() => ({ return_policies: [] })),
-        etsyApi.readinessStates().catch(() => ({ readiness_states: [] })),
-      ])
-      return {
-        shippingProfiles: (sp as any).shipping_profiles || [],
-        returnPolicies: (rp as any).return_policies || [],
-        readinessStates: (rs as any).readiness_states || [],
-      }
-    },
-  })
-  const shippingProfiles = optionsQuery.data?.shippingProfiles ?? []
-  const returnPolicies = optionsQuery.data?.returnPolicies ?? []
-  const readinessStates = optionsQuery.data?.readinessStates ?? []
-
-  const taxonomyQuery = useQuery({
-    queryKey: TAXONOMY_KEY,
-    queryFn: async () =>
-      ((await etsyApi.taxonomy().catch(() => ({ taxonomy: [] }))) as any)
-        .taxonomy || [],
-  })
-  const taxonomy = taxonomyQuery.data ?? []
 
   const syncsQuery = useQuery({
     queryKey: ["etsy", "syncs", pagination, filtering],
@@ -166,17 +103,6 @@ const EtsySettingsPage = () => {
     },
     onError: (err: any) =>
       toast.error("Failed to disconnect", { description: err.message }),
-  })
-
-  const saveMutation = useMutation({
-    mutationFn: (payload: any) => etsyApi.saveSettings(payload),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: STATUS_KEY })
-      toast.success("Sync settings saved")
-      setSettingsOpen(false)
-    },
-    onError: (err: any) =>
-      toast.error("Failed to save settings", { description: err.message }),
   })
 
   // ── DataTable ───────────────────────────────────────────────────────────────
@@ -274,7 +200,7 @@ const EtsySettingsPage = () => {
               <Button
                 size="small"
                 variant="secondary"
-                onClick={() => setSettingsOpen(true)}
+                onClick={() => navigate("/settings/etsy/settings")}
               >
                 Sync settings
               </Button>
@@ -341,145 +267,6 @@ const EtsySettingsPage = () => {
         </DataTable>
       </Container>
 
-      {/* Publish readiness + Sync defaults — in a drawer */}
-      <Drawer open={settingsOpen} onOpenChange={setSettingsOpen}>
-        <Drawer.Content>
-          <Drawer.Header>
-            <Drawer.Title>Sync settings</Drawer.Title>
-            <Drawer.Description>
-              Publish readiness and the defaults applied to every product.
-            </Drawer.Description>
-          </Drawer.Header>
-          <Drawer.Body className="flex flex-col gap-6 overflow-y-auto">
-            {/* Readiness checklist */}
-            <div className="flex flex-col gap-3">
-              <div className="flex flex-col gap-1">
-                <Heading level="h2">Publish readiness</Heading>
-                <Text className="text-ui-fg-subtle" size="small">
-                  Etsy requires these to publish listings as active. Missing
-                  fields sync products as drafts.
-                </Text>
-              </div>
-              <div className="flex flex-col gap-2">
-                <ChecklistItem ok={status?.readiness.connected} label="Etsy connected" />
-                <ChecklistItem ok={status?.readiness.taxonomy} label="Default category" />
-                <ChecklistItem ok={status?.readiness.shipping_profile} label="Shipping profile" />
-                <ChecklistItem ok={status?.readiness.return_policy} label="Return policy" />
-                <ChecklistItem ok={status?.readiness.readiness_state} label="Processing profile" />
-              </div>
-            </div>
-
-            {/* Defaults */}
-            <div className="flex flex-col gap-3">
-              <div className="flex flex-col gap-1">
-                <Heading level="h2">Sync defaults</Heading>
-                <Text className="text-ui-fg-subtle" size="small">
-                  Applied to every product unless overridden in product metadata.
-                </Text>
-              </div>
-              <div className="grid grid-cols-1 gap-4">
-                <Field label="Default category (taxonomy)">
-                  <SelectField
-                    value={String(form.default_taxonomy_id ?? "")}
-                    onValueChange={(v) =>
-                      setForm({ ...form, default_taxonomy_id: v ? Number(v) : null })
-                    }
-                    disabled={!connected}
-                    options={taxonomy.map((t: any) => ({ value: String(t.id), label: t.name }))}
-                  />
-                </Field>
-                <Field label="Shipping profile">
-                  <SelectField
-                    value={form.default_shipping_profile_id ?? ""}
-                    onValueChange={(v) => setForm({ ...form, default_shipping_profile_id: v })}
-                    disabled={!connected}
-                    options={shippingProfiles.map((p: any) => ({ value: p.shipping_profile_id, label: p.title }))}
-                  />
-                </Field>
-                <Field label="Return policy">
-                  <SelectField
-                    value={form.default_return_policy_id ?? ""}
-                    onValueChange={(v) => setForm({ ...form, default_return_policy_id: v })}
-                    disabled={!connected}
-                    options={returnPolicies.map((p: any) => ({ value: p.return_policy_id, label: p.name }))}
-                  />
-                </Field>
-                <Field label="Processing profile">
-                  <SelectField
-                    value={form.default_readiness_state_id ?? ""}
-                    onValueChange={(v) => setForm({ ...form, default_readiness_state_id: v })}
-                    disabled={!connected}
-                    options={readinessStates.map((r: any) => ({ value: r.id, label: r.label }))}
-                  />
-                </Field>
-                <Field label="Who made">
-                  <SelectField
-                    value={form.default_who_made ?? "i_did"}
-                    onValueChange={(v) => setForm({ ...form, default_who_made: v })}
-                    options={[
-                      { value: "i_did", label: "I did" },
-                      { value: "someone_else", label: "Someone else" },
-                      { value: "collective", label: "Collective" },
-                    ]}
-                  />
-                </Field>
-                <Field label="When made">
-                  <SelectField
-                    value={form.default_when_made ?? "made_to_order"}
-                    onValueChange={(v) => setForm({ ...form, default_when_made: v })}
-                    options={[
-                      { value: "made_to_order", label: "Made to order" },
-                      { value: "2020_2026", label: "2020–2026" },
-                      { value: "2010_2019", label: "2010–2019" },
-                      { value: "2000_2006", label: "2000–2006" },
-                      { value: "1990s", label: "1990s" },
-                      { value: "1980s", label: "1980s" },
-                      { value: "1970s", label: "1970s" },
-                    ]}
-                  />
-                </Field>
-                <Field label="Listing type">
-                  <SelectField
-                    value={form.default_type ?? "physical"}
-                    onValueChange={(v) => setForm({ ...form, default_type: v })}
-                    options={[
-                      { value: "physical", label: "Physical" },
-                      { value: "download", label: "Digital" },
-                      { value: "both", label: "Both" },
-                    ]}
-                  />
-                </Field>
-                <Field label="Is supply">
-                  <Switch
-                    checked={!!form.default_is_supply}
-                    onCheckedChange={(v: boolean) => setForm({ ...form, default_is_supply: v })}
-                  />
-                </Field>
-                <Field label="Follow product status">
-                  <Tooltip content="If on, published Medusa products are published on Etsy; draft products sync as drafts.">
-                    <Switch
-                      checked={form.follow_product_status !== false}
-                      onCheckedChange={(v: boolean) => setForm({ ...form, follow_product_status: v })}
-                    />
-                  </Tooltip>
-                </Field>
-              </div>
-            </div>
-          </Drawer.Body>
-          <Drawer.Footer>
-            <Drawer.Close asChild>
-              <Button variant="secondary">Cancel</Button>
-            </Drawer.Close>
-            <Button
-              onClick={() => saveMutation.mutate(cleanSettings(form))}
-              isLoading={saveMutation.isPending}
-            >
-              Save settings
-            </Button>
-          </Drawer.Footer>
-        </Drawer.Content>
-      </Drawer>
-
       <Toaster />
     </div>
   )
@@ -489,58 +276,6 @@ const InfoField = ({ label, value }: { label: string; value: string }) => (
   <div className="flex flex-col gap-1">
     <Label>{label}</Label>
     <Text>{value}</Text>
-  </div>
-)
-
-const Field = ({ label, children }: { label: string; children: React.ReactNode }) => (
-  <div className="flex flex-col gap-1.5">
-    <Label>{label}</Label>
-    {children}
-  </div>
-)
-
-const SelectField = ({
-  value,
-  onValueChange,
-  options,
-  disabled,
-}: {
-  value: string
-  onValueChange: (v: string) => void
-  options: { value: string; label: string }[]
-  disabled?: boolean
-}) => (
-  <Select
-    value={value ? value : NONE}
-    onValueChange={(v) => onValueChange(v === NONE ? "" : v)}
-    disabled={disabled}
-    size="small"
-  >
-    <Select.Trigger>
-      <Select.Value placeholder="Not set" />
-    </Select.Trigger>
-    <Select.Content>
-      <Select.Item value={NONE}>Not set</Select.Item>
-      {options.map((o) => (
-        <Select.Item key={o.value} value={o.value}>
-          {o.label}
-        </Select.Item>
-      ))}
-    </Select.Content>
-  </Select>
-)
-
-const ChecklistItem = ({ ok, label }: { ok?: boolean; label: string }) => (
-  <div
-    className={clx(
-      "flex items-center gap-2 rounded-lg border px-3 py-2",
-      ok
-        ? "border-ui-tag-green-border bg-ui-tag-green-bg"
-        : "border-ui-tag-red-border bg-ui-tag-red-bg"
-    )}
-  >
-    <StatusBadge color={ok ? "green" : "red"}>{ok ? "Ready" : "Missing"}</StatusBadge>
-    <Text>{label}</Text>
   </div>
 )
 

--- a/packages/medusa-plugin-etsy-sync/src/admin/routes/settings/etsy/settings/page.tsx
+++ b/packages/medusa-plugin-etsy-sync/src/admin/routes/settings/etsy/settings/page.tsx
@@ -1,0 +1,344 @@
+import {
+  Button,
+  Drawer,
+  Heading,
+  Label,
+  Select,
+  Skeleton,
+  StatusBadge,
+  Switch,
+  Text,
+  Toaster,
+  Tooltip,
+  clx,
+  toast,
+} from "@medusajs/ui"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useEffect, useState } from "react"
+import { useNavigate } from "react-router-dom"
+import { etsyApi } from "../../../../lib/api"
+
+const STATUS_KEY = ["etsy", "status"]
+const OPTIONS_KEY = ["etsy", "options"]
+const TAXONOMY_KEY = ["etsy", "taxonomy"]
+const PARENT = "/settings/etsy"
+
+// Radix Select can't use an empty-string item value, so "Not set" uses this
+// sentinel. It must never be persisted — map it back to null on save.
+const NONE = "__none__"
+
+const cleanSettings = (form: any) => {
+  const out: any = { ...form }
+  for (const key of [
+    "default_shipping_profile_id",
+    "default_return_policy_id",
+    "default_readiness_state_id",
+  ]) {
+    if (!out[key] || out[key] === NONE) out[key] = null
+  }
+  if (!out.default_taxonomy_id || Number.isNaN(Number(out.default_taxonomy_id))) {
+    out.default_taxonomy_id = null
+  }
+  return out
+}
+
+type Status = {
+  connected: boolean
+  account: any | null
+  settings: any
+  readiness: {
+    connected: boolean
+    shipping_profile: boolean
+    return_policy: boolean
+    readiness_state: boolean
+    taxonomy: boolean
+    ready_to_publish: boolean
+  }
+}
+
+/**
+ * Routed Sync-settings drawer. Lives at /settings/etsy/settings so it's its own
+ * route (linkable, back-button friendly) rather than an inline <Drawer> in the
+ * list page. Closing the drawer navigates back to the Etsy settings list.
+ */
+const EtsySyncSettingsDrawer = () => {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [open, setOpen] = useState(true)
+  const [form, setForm] = useState<any>({})
+
+  const close = () => {
+    setOpen(false)
+    navigate(PARENT)
+  }
+
+  const statusQuery = useQuery({
+    queryKey: STATUS_KEY,
+    queryFn: () => etsyApi.status() as Promise<Status>,
+  })
+  const status = statusQuery.data
+  const connected = !!status?.connected
+
+  useEffect(() => {
+    if (status?.settings) setForm(status.settings)
+  }, [status?.settings])
+
+  const optionsQuery = useQuery({
+    queryKey: OPTIONS_KEY,
+    enabled: connected,
+    queryFn: async () => {
+      const [sp, rp, rs] = await Promise.all([
+        etsyApi.shippingProfiles().catch(() => ({ shipping_profiles: [] })),
+        etsyApi.returnPolicies().catch(() => ({ return_policies: [] })),
+        etsyApi.readinessStates().catch(() => ({ readiness_states: [] })),
+      ])
+      return {
+        shippingProfiles: (sp as any).shipping_profiles || [],
+        returnPolicies: (rp as any).return_policies || [],
+        readinessStates: (rs as any).readiness_states || [],
+      }
+    },
+  })
+  const shippingProfiles = optionsQuery.data?.shippingProfiles ?? []
+  const returnPolicies = optionsQuery.data?.returnPolicies ?? []
+  const readinessStates = optionsQuery.data?.readinessStates ?? []
+
+  const taxonomyQuery = useQuery({
+    queryKey: TAXONOMY_KEY,
+    queryFn: async () =>
+      ((await etsyApi.taxonomy().catch(() => ({ taxonomy: [] }))) as any)
+        .taxonomy || [],
+  })
+  const taxonomy = taxonomyQuery.data ?? []
+
+  const saveMutation = useMutation({
+    mutationFn: (payload: any) => etsyApi.saveSettings(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: STATUS_KEY })
+      toast.success("Sync settings saved")
+      close()
+    },
+    onError: (err: any) =>
+      toast.error("Failed to save settings", { description: err.message }),
+  })
+
+  return (
+    <Drawer open={open} onOpenChange={(o) => (o ? setOpen(true) : close())}>
+      <Drawer.Content>
+        <Drawer.Header>
+          <Drawer.Title>Sync settings</Drawer.Title>
+          <Drawer.Description>
+            Publish readiness and the defaults applied to every product.
+          </Drawer.Description>
+        </Drawer.Header>
+        <Drawer.Body className="flex flex-col gap-6 overflow-y-auto">
+          {statusQuery.isLoading ? (
+            <div className="flex flex-col gap-3">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <Skeleton key={i} className="h-10 w-full" />
+              ))}
+            </div>
+          ) : (
+            <>
+              {/* Readiness checklist */}
+              <div className="flex flex-col gap-3">
+                <div className="flex flex-col gap-1">
+                  <Heading level="h2">Publish readiness</Heading>
+                  <Text className="text-ui-fg-subtle" size="small">
+                    Etsy requires these to publish listings as active. Missing
+                    fields sync products as drafts.
+                  </Text>
+                </div>
+                <div className="flex flex-col gap-2">
+                  <ChecklistItem ok={status?.readiness.connected} label="Etsy connected" />
+                  <ChecklistItem ok={status?.readiness.taxonomy} label="Default category" />
+                  <ChecklistItem ok={status?.readiness.shipping_profile} label="Shipping profile" />
+                  <ChecklistItem ok={status?.readiness.return_policy} label="Return policy" />
+                  <ChecklistItem ok={status?.readiness.readiness_state} label="Processing profile" />
+                </div>
+              </div>
+
+              {/* Defaults */}
+              <div className="flex flex-col gap-3">
+                <div className="flex flex-col gap-1">
+                  <Heading level="h2">Sync defaults</Heading>
+                  <Text className="text-ui-fg-subtle" size="small">
+                    Applied to every product unless overridden in product metadata.
+                  </Text>
+                </div>
+                <div className="grid grid-cols-1 gap-4">
+                  <Field label="Default category (taxonomy)">
+                    <SelectField
+                      value={String(form.default_taxonomy_id ?? "")}
+                      onValueChange={(v) =>
+                        setForm({ ...form, default_taxonomy_id: v ? Number(v) : null })
+                      }
+                      disabled={!connected}
+                      options={taxonomy.map((t: any) => ({ value: String(t.id), label: t.name }))}
+                    />
+                  </Field>
+                  <Field label="Shipping profile">
+                    <SelectField
+                      value={form.default_shipping_profile_id ?? ""}
+                      onValueChange={(v) => setForm({ ...form, default_shipping_profile_id: v })}
+                      disabled={!connected}
+                      options={shippingProfiles.map((p: any) => ({
+                        value: p.shipping_profile_id,
+                        label: p.title,
+                      }))}
+                    />
+                  </Field>
+                  <Field label="Return policy">
+                    <SelectField
+                      value={form.default_return_policy_id ?? ""}
+                      onValueChange={(v) => setForm({ ...form, default_return_policy_id: v })}
+                      disabled={!connected}
+                      options={returnPolicies.map((p: any) => ({
+                        value: p.return_policy_id,
+                        // Etsy return policies carry no name — the client derives one;
+                        // fall back to the id here so it never renders blank.
+                        label: p.name || p.return_policy_id,
+                      }))}
+                    />
+                  </Field>
+                  <Field label="Processing profile">
+                    <SelectField
+                      value={form.default_readiness_state_id ?? ""}
+                      onValueChange={(v) => setForm({ ...form, default_readiness_state_id: v })}
+                      disabled={!connected}
+                      options={readinessStates.map((r: any) => ({ value: r.id, label: r.label }))}
+                    />
+                  </Field>
+                  <Field label="Who made">
+                    <SelectField
+                      value={form.default_who_made ?? "i_did"}
+                      onValueChange={(v) => setForm({ ...form, default_who_made: v })}
+                      options={[
+                        { value: "i_did", label: "I did" },
+                        { value: "someone_else", label: "Someone else" },
+                        { value: "collective", label: "Collective" },
+                      ]}
+                    />
+                  </Field>
+                  <Field label="When made">
+                    <SelectField
+                      value={form.default_when_made ?? "made_to_order"}
+                      onValueChange={(v) => setForm({ ...form, default_when_made: v })}
+                      options={[
+                        { value: "made_to_order", label: "Made to order" },
+                        { value: "2020_2026", label: "2020–2026" },
+                        { value: "2010_2019", label: "2010–2019" },
+                        { value: "2000_2006", label: "2000–2006" },
+                        { value: "1990s", label: "1990s" },
+                        { value: "1980s", label: "1980s" },
+                        { value: "1970s", label: "1970s" },
+                      ]}
+                    />
+                  </Field>
+                  <Field label="Listing type">
+                    <SelectField
+                      value={form.default_type ?? "physical"}
+                      onValueChange={(v) => setForm({ ...form, default_type: v })}
+                      options={[
+                        { value: "physical", label: "Physical" },
+                        { value: "download", label: "Digital" },
+                        { value: "both", label: "Both" },
+                      ]}
+                    />
+                  </Field>
+                  <Field label="Is supply">
+                    <Switch
+                      checked={!!form.default_is_supply}
+                      onCheckedChange={(v: boolean) => setForm({ ...form, default_is_supply: v })}
+                    />
+                  </Field>
+                  <Field label="Follow product status">
+                    <Tooltip content="If on, published Medusa products are published on Etsy; draft products sync as drafts.">
+                      <Switch
+                        checked={form.follow_product_status !== false}
+                        onCheckedChange={(v: boolean) =>
+                          setForm({ ...form, follow_product_status: v })
+                        }
+                      />
+                    </Tooltip>
+                  </Field>
+                </div>
+              </div>
+            </>
+          )}
+        </Drawer.Body>
+        <Drawer.Footer>
+          <Button variant="secondary" onClick={close}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() => saveMutation.mutate(cleanSettings(form))}
+            isLoading={saveMutation.isPending}
+            disabled={!connected}
+          >
+            Save settings
+          </Button>
+        </Drawer.Footer>
+      </Drawer.Content>
+      <Toaster />
+    </Drawer>
+  )
+}
+
+const Field = ({ label, children }: { label: string; children: React.ReactNode }) => (
+  <div className="flex flex-col gap-1.5">
+    <Label>{label}</Label>
+    {children}
+  </div>
+)
+
+const SelectField = ({
+  value,
+  onValueChange,
+  options,
+  disabled,
+}: {
+  value: string
+  onValueChange: (v: string) => void
+  options: { value: string; label: string }[]
+  disabled?: boolean
+}) => (
+  <Select
+    value={value ? value : NONE}
+    onValueChange={(v) => onValueChange(v === NONE ? "" : v)}
+    disabled={disabled}
+    size="small"
+  >
+    <Select.Trigger>
+      <Select.Value placeholder="Not set" />
+    </Select.Trigger>
+    <Select.Content>
+      <Select.Item value={NONE}>Not set</Select.Item>
+      {options.map((o) => (
+        <Select.Item key={o.value} value={o.value}>
+          {o.label}
+        </Select.Item>
+      ))}
+    </Select.Content>
+  </Select>
+)
+
+const ChecklistItem = ({ ok, label }: { ok?: boolean; label: string }) => (
+  <div
+    className={clx(
+      "flex items-center gap-2 rounded-lg border px-3 py-2",
+      ok
+        ? "border-ui-tag-green-border bg-ui-tag-green-bg"
+        : "border-ui-tag-red-border bg-ui-tag-red-bg"
+    )}
+  >
+    <StatusBadge color={ok ? "green" : "red"}>{ok ? "Ready" : "Missing"}</StatusBadge>
+    <Text>{label}</Text>
+  </div>
+)
+
+export const handle = {
+  breadcrumb: () => "Sync settings",
+}
+
+export default EtsySyncSettingsDrawer

--- a/packages/medusa-plugin-etsy-sync/src/lib/etsy-client.ts
+++ b/packages/medusa-plugin-etsy-sync/src/lib/etsy-client.ts
@@ -19,6 +19,22 @@ const API_BASE = "https://api.etsy.com/v3"
 const AUTH_URL = "https://www.etsy.com/oauth/connect"
 const TOKEN_URL = "https://api.etsy.com/v3/public/oauth/token"
 
+/**
+ * Etsy's return-policy resource has no name — only accepts_returns /
+ * accepts_exchanges / return_deadline. Build a readable label from those terms
+ * so a policy renders as e.g. "Returns in 30 days + exchanges" instead of blank.
+ */
+export function describeReturnPolicy(p: any): string {
+  const parts: string[] = []
+  if (p?.accepts_returns) {
+    parts.push(p.return_deadline ? `Returns in ${p.return_deadline} days` : "Returns")
+  }
+  if (p?.accepts_exchanges) {
+    parts.push("exchanges")
+  }
+  return parts.length ? parts.join(" + ") : "No returns or exchanges"
+}
+
 export class EtsyApiError extends Error {
   status: number
   body: any
@@ -389,7 +405,10 @@ export class EtsyClient {
     )
     return (data.results ?? []).map((p: any) => ({
       return_policy_id: String(p.return_policy_id),
-      name: p.name,
+      // Etsy return policies have NO name field — only accepts_returns /
+      // accepts_exchanges / return_deadline. Derive a human label so the
+      // Sync-defaults select doesn't render blank (→ "Not set").
+      name: p.name ?? describeReturnPolicy(p),
       raw: p,
     }))
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,7 +150,7 @@ importers:
         specifier: ^5.0.1
         version: 5.2.2(react-hook-form@7.71.2(react@18.3.1))
       '@jytextiles/medusa-plugin-etsy-sync':
-        specifier: 0.1.2
+        specifier: latest
         version: 0.1.2(@medusajs/admin-sdk@2.17.2)(@medusajs/cli@2.17.2(@types/node@20.19.34))(@medusajs/dashboard@2.17.2(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(typescript@5.9.3))(@medusajs/framework@2.17.2(@medusajs/cli@2.17.2(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))(zod@4.3.6))(@medusajs/icons@2.17.2(react@18.3.1))(@medusajs/medusa@2.17.2)(@medusajs/test-utils@2.17.2)(@medusajs/types@2.17.2(ioredis@5.9.3)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)))(@medusajs/ui@4.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@mastra/core':
         specifier: latest


### PR DESCRIPTION
## 1. Return policy showed "Not set" despite a policy existing
The API returns `return_policies: [{ return_policy_id, raw: { accepts_returns, accepts_exchanges, return_deadline, … } }]` — **no `name` field** (Etsy return policies don't have one). The client mapped `name: p.name` → `undefined`, so the Sync-defaults `<Select>` item rendered blank and Radix fell back to the **"Not set"** placeholder.

**Fix:** `getShopReturnPolicies` derives a readable label via `describeReturnPolicy` → e.g. `"Returns in 30 days + exchanges"` / `"No returns or exchanges"`. The select also falls back to the id so it can never render blank.

## 2. Settings drawer → its own route
The "Sync settings" drawer lived inline in the Etsy list page. Extracted it to **`settings/etsy/settings`** — a routed drawer (`open` by default; closing navigates back to `/settings/etsy`). The list page is trimmed to connection + recent-syncs; the button now navigates to the route. Static `settings` ranks above the `:id` detail route, so no collision.

## 3. Consume the plugin `@latest`
`apps/backend` pinned `@jytextiles/medusa-plugin-etsy-sync": "0.1.2"`. Switched to **`"latest"`** so it tracks the newest publish instead of a hand-incremented pin. Plugin bumped to **0.1.3**; lockfile specifier reconciled (`--lockfile-only`, resolves to 0.1.2 until 0.1.3 is published — CI frozen install stays green).

## ⚠️ Operational note
The return-policy + route fixes reach the backend only after **`npm publish` of 0.1.3** (the backend consumes the published package, not the workspace source). Until then `latest` resolves to 0.1.2. Publish is a manual step — I did not run it.

## Testing
- Plugin `tsc --noEmit`: **0 errors**. Skeletons preserved for loading states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)