### PR TITLE
feat(partner-ui): design sizes + BOM on order page, cost gated to owner

### DIFF
--- a/apps/partner-ui/src/components/work-orders/collated-design-detail.tsx
+++ b/apps/partner-ui/src/components/work-orders/collated-design-detail.tsx
@@ -11,6 +11,7 @@ import { usePartnerDesign } from "../../hooks/api/partner-designs"
 import { usePartnerProductionRun } from "../../hooks/api/partner-production-runs"
 import { DesignCostSection } from "../../routes/designs/design-detail/components/design-cost-section"
 import { DesignInventoryBomSection } from "../../routes/designs/design-detail/components/design-inventory-bom-section"
+import { DesignSizeSetsSection } from "../../routes/designs/design-detail/components/design-size-sets-section"
 import { ProductionRunCard } from "./production-run-card"
 
 /**
@@ -155,10 +156,13 @@ export const DesignSpecs = ({ design }: { design: any }) => {
         )}
       </Container>
 
-      {/* Full BOM + cost breakdown — the design "specs" the operator asked to
-          keep under the order form. Each self-fetches off the design id. */}
+      {/* Sizes (size_sets or legacy custom_sizes) + full BOM. The design
+          "specs" the operator asked to keep under the order form. */}
+      <DesignSizeSetsSection design={design} />
       <DesignInventoryBomSection design={design} />
-      <DesignCostSection design={design} />
+      {/* Cost estimate only matters for partner-owned designs — hide it for
+          JYT-owned work-orders (#5). */}
+      {!!design?.owner_partner_id && <DesignCostSection design={design} />}
     </>
   )
 }

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-size-sets-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-size-sets-section.tsx
@@ -1,0 +1,82 @@
+import { Badge, Container, Heading, Text } from "@medusajs/ui"
+import { useMemo } from "react"
+import { useTranslation } from "react-i18next"
+
+/**
+ * #3 — read-only sizes panel for a design, shared by the standalone design page
+ * and the order → production-run design manager (single + collated).
+ *
+ * Sizes reach a design in one of two shapes:
+ *   - `size_sets`  — the normalized relation `[{ size_label, measurements }]`
+ *                    (the current format; produced by `convertCustomSizesToSizeSets`).
+ *   - `custom_sizes` — a legacy JSON map `{ "S": { chest, length }, ... }`.
+ *
+ * Most existing designs still carry their sizes on `custom_sizes`, so we prefer
+ * `size_sets` but fall back to `custom_sizes` — otherwise the partner sees no
+ * sizes at all on the order. Mirrors the admin `design-sizes-section`.
+ */
+export const DesignSizeSetsSection = ({ design }: { design: any }) => {
+  const { t } = useTranslation()
+
+  const sizeSets = design?.size_sets as
+    | Array<{ size_label?: string; measurements?: any }>
+    | undefined
+  const customSizes = design?.custom_sizes as Record<string, any> | undefined
+
+  const sizes = useMemo<Array<{ label: string; measurements: any }>>(() => {
+    if (Array.isArray(sizeSets) && sizeSets.length > 0) {
+      return sizeSets
+        .filter((s) => s?.size_label)
+        .map((s) => ({ label: String(s.size_label), measurements: s?.measurements }))
+    }
+    if (customSizes && typeof customSizes === "object") {
+      return Object.entries(customSizes).map(([label, measurements]) => ({
+        label,
+        measurements,
+      }))
+    }
+    return []
+  }, [sizeSets, customSizes])
+
+  if (sizes.length === 0) {
+    return null
+  }
+
+  return (
+    <Container className="p-0">
+      <div className="flex items-center gap-x-2 px-6 py-4">
+        <Heading level="h2">{t("partner.workOrders.sizes", "Sizes")}</Heading>
+        <Badge size="2xsmall" color="blue">
+          {sizes.length}
+        </Badge>
+      </div>
+      <div className="flex flex-col gap-y-2 px-6 pb-6">
+        {sizes.map(({ label, measurements }) => (
+          <div
+            key={label}
+            className="flex items-start gap-x-3 rounded-lg bg-ui-bg-subtle p-3"
+          >
+            <Badge size="2xsmall" color="blue" className="mt-0.5 shrink-0">
+              {label}
+            </Badge>
+            {measurements && typeof measurements === "object" ? (
+              <div className="flex flex-wrap gap-x-3 gap-y-1">
+                {Object.entries(measurements as Record<string, any>).map(
+                  ([key, val]) => (
+                    <Text key={key} size="xsmall" className="text-ui-fg-subtle">
+                      {key}: {val != null ? String(val) : "-"}
+                    </Text>
+                  )
+                )}
+              </div>
+            ) : measurements != null ? (
+              <Text size="xsmall" className="text-ui-fg-subtle">
+                {String(measurements)}
+              </Text>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </Container>
+  )
+}

--- a/apps/partner-ui/src/routes/orders/order-detail/order-detail.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/order-detail.tsx
@@ -15,6 +15,9 @@ import {
 import { ProductionRunCard } from "../../../components/work-orders/production-run-card"
 import { WorkOrderActivitySection } from "../../../components/work-orders/work-order-activity-section"
 import { WorkOrderSummarySection } from "../../../components/work-orders/work-order-summary-section"
+import { DesignInventoryBomSection } from "../../designs/design-detail/components/design-inventory-bom-section"
+import { DesignSizeSetsSection } from "../../designs/design-detail/components/design-size-sets-section"
+import { DesignCostSection } from "../../designs/design-detail/components/design-cost-section"
 import { ordersQueryKeys, useOrder, useOrderPreview } from "../../../hooks/api/orders"
 import { usePartnerConsumptionLogs } from "../../../hooks/api/partner-consumption-logs"
 import { usePartnerDesign } from "../../../hooks/api/partner-designs"
@@ -185,7 +188,17 @@ export const OrderDetail = () => {
             {kind === "design" &&
               !(order as any)?.metadata?.collated_design_order &&
               design && (
-                <WorkOrderSummarySection kind="design" design={design} designId={designId} />
+                <>
+                  <WorkOrderSummarySection kind="design" design={design} designId={designId} />
+                  {/* Sizes (size_sets or legacy custom_sizes) + BOM inventory
+                      with thumbnails — parity with the collated design view (#1, #3). */}
+                  <DesignSizeSetsSection design={design} />
+                  <DesignInventoryBomSection design={design} />
+                  {/* Cost estimate only for partner-owned designs (#5). */}
+                  {!!(design as any)?.owner_partner_id && (
+                    <DesignCostSection design={design} />
+                  )}
+                </>
               )}
             {kind === "design" &&
               !(order as any)?.metadata?.collated_design_order &&


### PR DESCRIPTION
## Group A — partner order design specs (#1, #3, #5)

Brings the design manager's key specs onto the **partner order → production-run** view so the partner doesn't have to open the standalone design page.

### #3 — Sizes (with a real-data fix)
New \`DesignSizeSetsSection\` renders design sizes on the order. It reads the normalized \`size_sets\` relation first and **falls back to the legacy \`custom_sizes\` map**.

**Why the fallback matters — confirmed via prod API:**

| | Count (100 most-recent designs) |
|---|---|
| \`size_sets\` (new relation) | **0** |
| \`custom_sizes\` (legacy map) | **21** |
| neither | 79 |

Every design on prod that has sizes stores them in \`custom_sizes\` — the \`size_sets\` relation is empty. A \`size_sets\`-only read would have shown the partner nothing. The partner design route already returns both (\`["*", ..., "size_sets.*"]\`), so the object carries the data.

### #1 — BOM inventory with thumbnails
The single-design order branch now renders \`DesignInventoryBomSection\` (thumbnails), matching what the collated design view already showed.

### #5 — Cost gated to owner
The cost estimate is now shown **only for partner-owned designs** (\`owner_partner_id\`) in both the single and collated paths — hidden for JYT-owned work-orders.

## Verify
- Open a design order as a partner → Sizes + BOM (with thumbnails) render under the summary.
- Legacy \`custom_sizes\` designs (e.g. "Butterfly in muslin") show their sizes.
- Cost panel appears only when the design is partner-owned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)