### PR TITLE
fix(designs): populate size_sets on AI-created designs + backfill legacy custom_sizes

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-design-size-sets.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-design-size-sets.unit.spec.ts
@@ -1,0 +1,79 @@
+import {
+  decideDesignSizeSetBackfill,
+  summarizeSizeSetBackfill,
+} from "../backfill-design-size-sets-job"
+
+/**
+ * Pure planner for the custom_sizes → size_sets backfill. No container/DB.
+ * The scenario: AI-generated designs stored `custom_sizes` (e.g. the prod
+ * "Butterfly in muslin" with { L, S }) but never populated `size_sets`, so the
+ * design manager's Sizes section showed nothing.
+ */
+describe("decideDesignSizeSetBackfill", () => {
+  it("skips a design that already has size_sets (idempotent)", () => {
+    expect(
+      decideDesignSizeSetBackfill(true, { L: { chest: 50 } })
+    ).toEqual({ action: "skip_has_size_sets" })
+  })
+
+  it("ports a legacy custom_sizes map (the Butterfly-in-muslin shape)", () => {
+    const decision = decideDesignSizeSetBackfill(false, {
+      L: { chest: 0, length: 0 },
+      S: { chest: 0, length: 0 },
+    })
+    expect(decision.action).toBe("port")
+    if (decision.action === "port") {
+      expect(decision.sizeSets).toEqual([
+        { size_label: "L", measurements: { chest: 0, length: 0 } },
+        { size_label: "S", measurements: { chest: 0, length: 0 } },
+      ])
+    }
+  })
+
+  it("coerces numeric-string measurements", () => {
+    const decision = decideDesignSizeSetBackfill(false, {
+      M: { chest: "48", length: "60" },
+    })
+    expect(decision.action).toBe("port")
+    if (decision.action === "port") {
+      expect(decision.sizeSets).toEqual([
+        { size_label: "M", measurements: { chest: 48, length: 60 } },
+      ])
+    }
+  })
+
+  it("skips when custom_sizes is empty / null", () => {
+    expect(decideDesignSizeSetBackfill(false, null).action).toBe(
+      "skip_no_convertible"
+    )
+    expect(decideDesignSizeSetBackfill(false, {}).action).toBe(
+      "skip_no_convertible"
+    )
+  })
+
+  it("skips when a label has no numeric measurements", () => {
+    expect(
+      decideDesignSizeSetBackfill(false, { S: { note: "loose" } }).action
+    ).toBe("skip_no_convertible")
+  })
+})
+
+describe("summarizeSizeSetBackfill", () => {
+  it("reports a dry-run port with skips", () => {
+    expect(summarizeSizeSetBackfill(true, 100, 21, 0, 79, 0)).toBe(
+      "Would port custom_sizes → size_sets on 21 design(s) (scanned 100); 79 no convertible custom_sizes"
+    )
+  })
+
+  it("reports a no-op sweep", () => {
+    expect(summarizeSizeSetBackfill(false, 50, 0, 50, 0, 0)).toBe(
+      "No changes — scanned 50 design(s), none needed a size_sets backfill; 50 already had size_sets"
+    )
+  })
+
+  it("appends an error count", () => {
+    expect(summarizeSizeSetBackfill(false, 10, 3, 5, 2, 1)).toContain(
+      "1 error(s)"
+    )
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-design-size-sets-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-design-size-sets-job.ts
@@ -1,0 +1,202 @@
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import type {
+  MaintenanceChange,
+  MaintenanceJob,
+  MaintenanceJobResult,
+} from "./registry"
+import { DESIGN_MODULE } from "../../../../modules/designs"
+import {
+  convertCustomSizesToSizeSets,
+  type NormalizedSizeSet,
+} from "../../../../workflows/designs/helpers/size-set-utils"
+
+/**
+ * Backfill design `size_sets` from the legacy `custom_sizes` map.
+ *
+ * Sizes reach a design in two shapes: the normalized `size_sets` relation
+ * (`[{ size_label, measurements }]`) and the legacy `custom_sizes` JSON map
+ * (`{ "S": { chest, length }, ... }`). The manual create/update workflows
+ * convert one to the other, but the **AI/LLM creation path**
+ * (`create-design-from-llm`) historically stored `custom_sizes` directly and
+ * never populated `size_sets` — so on prod every design carries its sizes on
+ * `custom_sizes` and the design manager's Sizes section (which reads
+ * `size_sets`) shows nothing.
+ *
+ * This ports each such design: convert `custom_sizes` → `size_sets`, create the
+ * rows, and null out `custom_sizes` (mirroring the create/update workflows'
+ * "size_sets wins" rule). Dry-run (default) previews every design that WOULD be
+ * ported without writing; apply persists.
+ *
+ * Idempotent — a design that already has `size_sets` is skipped, and a
+ * `custom_sizes` that yields no convertible set (empty / all-non-numeric) is
+ * counted, not treated as an error. A genuine per-design failure is recorded in
+ * `errors` instead of aborting the sweep.
+ */
+
+/** Hard cap on designs scanned in one call. */
+export const MAX_DESIGN_SIZE_SET_SCAN = 5000
+
+const paramsSchema = z.object({
+  /** Process a single design instead of sweeping all designs. */
+  design_id: z.string().min(1).optional(),
+  /** Max designs to scan in one call (1..MAX_DESIGN_SIZE_SET_SCAN). */
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_DESIGN_SIZE_SET_SCAN)
+    .optional()
+    .default(1000),
+})
+
+export type DesignSizeSetDecision =
+  | { action: "skip_has_size_sets" }
+  | { action: "skip_no_convertible" }
+  | { action: "port"; sizeSets: NormalizedSizeSet[] }
+
+/**
+ * PURE: decide what to do for one design given whether it already has size_sets
+ * and its legacy custom_sizes. Exported for unit testing.
+ *   - already has size_sets            → skip (idempotent)
+ *   - custom_sizes yields size sets    → port them
+ *   - otherwise (empty/unconvertible)  → skip
+ */
+export function decideDesignSizeSetBackfill(
+  hasSizeSets: boolean,
+  customSizes: Record<string, any> | null | undefined
+): DesignSizeSetDecision {
+  if (hasSizeSets) return { action: "skip_has_size_sets" }
+  const sizeSets = convertCustomSizesToSizeSets(customSizes)
+  if (!sizeSets?.length) return { action: "skip_no_convertible" }
+  return { action: "port", sizeSets }
+}
+
+/** Pure summary builder — verifiable without booting the DB. */
+export function summarizeSizeSetBackfill(
+  dryRun: boolean,
+  scanned: number,
+  portedCount: number,
+  alreadyHadCount: number,
+  noConvertibleCount: number,
+  errorCount: number
+): string {
+  const verb = dryRun ? "Would port" : "Ported"
+  const head =
+    portedCount === 0
+      ? `No changes — scanned ${scanned} design(s), none needed a size_sets backfill`
+      : `${verb} custom_sizes → size_sets on ${portedCount} design(s) (scanned ${scanned})`
+  const skips: string[] = []
+  if (alreadyHadCount > 0) skips.push(`${alreadyHadCount} already had size_sets`)
+  if (noConvertibleCount > 0)
+    skips.push(`${noConvertibleCount} no convertible custom_sizes`)
+  const tail = skips.length ? `; ${skips.join(", ")}` : ""
+  return errorCount > 0 ? `${head}${tail}; ${errorCount} error(s)` : `${head}${tail}`
+}
+
+export const backfillDesignSizeSetsJob: MaintenanceJob = {
+  id: "backfill-design-size-sets",
+  label: "Backfill design size sets from custom_sizes",
+  description:
+    `Port each design's legacy custom_sizes map into the normalized size_sets relation so the design manager's Sizes section renders. AI-generated designs stored custom_sizes but never populated size_sets. Dry-run previews every design that WOULD be ported without persisting; apply creates the size_sets rows and nulls custom_sizes (size_sets wins). Idempotent — designs that already have size_sets are skipped. Pass design_id to target one design, or sweep up to 'limit' designs (default 1000, max ${MAX_DESIGN_SIZE_SET_SCAN}).`,
+  params: [
+    {
+      name: "design_id",
+      type: "string",
+      required: false,
+      description: "Process a single design instead of sweeping all designs",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max designs to scan in one call (default 1000, max ${MAX_DESIGN_SIZE_SET_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { design_id, limit } = parsed.data
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const designService: any = container.resolve(DESIGN_MODULE)
+
+    const { data: designs } = await query.graph({
+      entity: "design",
+      filters: design_id ? { id: design_id } : {},
+      fields: ["id", "name", "custom_sizes", "size_sets.id"],
+      pagination: { skip: 0, take: limit },
+    })
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    let ported = 0
+    let alreadyHad = 0
+    let noConvertible = 0
+
+    for (const design of (designs || []) as any[]) {
+      try {
+        const hasSizeSets =
+          Array.isArray(design.size_sets) && design.size_sets.length > 0
+        const decision = decideDesignSizeSetBackfill(
+          hasSizeSets,
+          design.custom_sizes
+        )
+
+        if (decision.action === "skip_has_size_sets") {
+          alreadyHad++
+          continue
+        }
+        if (decision.action === "skip_no_convertible") {
+          noConvertible++
+          continue
+        }
+
+        changes.push({
+          entity: "design",
+          id: design.id,
+          field: "size_sets",
+          before: `custom_sizes (${Object.keys(design.custom_sizes || {}).length} label(s))`,
+          after: decision.sizeSets.map((s) => s.size_label).join(", "),
+        })
+        ported++
+
+        if (!dry_run) {
+          await designService.createDesignSizeSets(
+            decision.sizeSets.map((s) => ({ design_id: design.id, ...s }))
+          )
+          await designService.updateDesigns({
+            id: design.id,
+            custom_sizes: null,
+          })
+        }
+      } catch (e: any) {
+        errors.push({ id: design.id, message: e?.message ?? String(e) })
+      }
+    }
+
+    return {
+      job_id: backfillDesignSizeSetsJob.id,
+      dry_run,
+      applied: !dry_run && ported > 0,
+      summary: summarizeSizeSetBackfill(
+        dry_run,
+        (designs || []).length,
+        ported,
+        alreadyHad,
+        noConvertible,
+        errors.length
+      ),
+      changes,
+      errors,
+    }
+  },
+}
+
+export default backfillDesignSizeSetsJob

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -82,6 +82,7 @@ import { recomputeEmailEngagementStatusJob } from "./recompute-email-engagement-
 import { generateNewsletterWinbackTargetsJob } from "./generate-newsletter-winback-targets-job"
 import { repairInventoryOrderSourceJob } from "./repair-inventory-order-source-job"
 import { backfillGoogleAdsHistoryJob } from "./backfill-google-ads-history-job"
+import { backfillDesignSizeSetsJob } from "./backfill-design-size-sets-job"
 import {
   sweepAiPlatformsByCategory,
   AI_ROLES,
@@ -5421,6 +5422,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   generateNewsletterWinbackTargetsJob,
   repairInventoryOrderSourceJob,
   backfillGoogleAdsHistoryJob,
+  backfillDesignSizeSetsJob,
 ]
 
 export const getMaintenanceJob = (id: string): MaintenanceJob | undefined =>

--- a/apps/backend/src/workflows/designs/create-design-from-llm.ts
+++ b/apps/backend/src/workflows/designs/create-design-from-llm.ts
@@ -10,6 +10,10 @@ import DesignService from "../../modules/designs/service";
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
 import { sendNotificationsStep } from "@medusajs/medusa/core-flows";
 import { mastra } from "../../mastra";
+import {
+  convertColorPaletteToColors,
+  convertCustomSizesToSizeSets,
+} from "./helpers/size-set-utils";
 
 // Input type for the generate design step
 export type GenerateDesignFromLLMInput = {
@@ -98,7 +102,15 @@ export const createDesignFromDataStep = createStep(
   "create-design-from-data-step",
   async (input: Record<string, any>, { container }) => {
     const designService: DesignService = container.resolve(DESIGN_MODULE);
-    
+
+    // Normalize the LLM's loose `custom_sizes` / `color_palette` into the
+    // structured `size_sets` / `colors` relations — same as the manual
+    // `create-design` path. Without this, AI-generated designs only ever
+    // carried `custom_sizes` and their `size_sets` relation stayed empty, so
+    // the design manager's Sizes section had nothing to show.
+    const normalizedSizeSets = convertCustomSizesToSizeSets(input.custom_sizes);
+    const normalizedColors = convertColorPaletteToColors(input.color_palette);
+
     // Process the input data to match the design model
     const designData = {
       name: input.name,
@@ -108,15 +120,27 @@ export const createDesignFromDataStep = createStep(
       status: input.status,
       priority: input.priority,
       target_completion_date: input.target_completion_date ? new Date(input.target_completion_date) : null,
-      custom_sizes: input.custom_sizes,
-      color_palette: input.color_palette,
+      custom_sizes: normalizedSizeSets ? null : input.custom_sizes,
+      color_palette: normalizedColors ? null : input.color_palette,
       tags: input.tags,
       estimated_cost: input.estimated_cost,
       designer_notes: input.designer_notes,
       metadata: input.metadata
     };
-    
+
     const design = await designService.createDesigns(designData);
+
+    if (normalizedColors?.length) {
+      await designService.createDesignColors(
+        normalizedColors.map((c) => ({ design_id: design.id, ...c }))
+      );
+    }
+    if (normalizedSizeSets?.length) {
+      await designService.createDesignSizeSets(
+        normalizedSizeSets.map((s) => ({ design_id: design.id, ...s }))
+      );
+    }
+
     return new StepResponse(design, design.id);
   },
   // Compensation function to handle rollback


### PR DESCRIPTION
## The bug you spotted

The design manager's **Sizes** section reads the `size_sets` relation, but on prod it's empty everywhere.

**Root cause:** the **AI/LLM design-creation path** (`create-design-from-llm`) stored the LLM's loose `custom_sizes` map directly and **never converted it to `size_sets`** — unlike the manual `create-design` path, which calls `convertCustomSizesToSizeSets`. Since designs are generated via the AI flow, they all end up with sizes trapped in `custom_sizes` and an empty `size_sets`.

**Confirmed via prod API (100 most-recent designs):**

| storage | count |
|---|---|
| `size_sets` (new relation) | **0** |
| `custom_sizes` (legacy map) | **21** |
| neither | 79 |

e.g. "Butterfly in muslin" → `size_sets: []`, `custom_sizes: {"L":{chest,length}, "S":{chest,length}}`.

## Fixes

### 1. Stop creating the bad state
`create-design-from-llm` now normalizes `custom_sizes` → `size_sets` (and `color_palette` → `colors`), persists the rows, and nulls the legacy maps — the exact contract `create-design` already follows. New AI-generated designs will carry `size_sets` going forward.

### 2. Backfill existing designs (data plumbing)
New DP maintenance job **`backfill-design-size-sets`**:
- Sweeps designs (or one `design_id`), converts `custom_sizes` → `size_sets`, creates the rows, nulls `custom_sizes`.
- **Dry-run by default** (preview every design that would be ported); apply persists.
- **Idempotent** — skips designs that already have `size_sets` or whose `custom_sizes` yields no numeric set.
- Registered in `MAINTENANCE_JOBS`; runnable from the Ops console.

Pure planner (`decideDesignSizeSetBackfill`) + summary builder are unit-tested (8 passing).

## Verify
- Dry run: `POST /admin/ops/maintenance-jobs/backfill-design-size-sets/run` with `{ dry_run: true }` → lists the ~21 designs it would port.
- Apply: same with `dry_run: false` → sizes then render in the design manager (paired with partner-UI #928 for the order view).

Pairs with #928 (partner order Sizes/BOM UI, which already reads `custom_sizes` as a fallback so it works even before this backfill runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)