### PR TITLE
feat(partner-ui): mobile-responsive section headers, rows & table toolbar

### DIFF
--- a/apps/partner-ui/src/components/common/activities-section/activities-section.tsx
+++ b/apps/partner-ui/src/components/common/activities-section/activities-section.tsx
@@ -23,7 +23,7 @@ export const ActivitiesSection = ({
 }: ActivitiesSectionProps) => {
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{title}</Heading>
         {actions}
       </div>

--- a/apps/partner-ui/src/components/common/json-view-section/json-view-section.tsx
+++ b/apps/partner-ui/src/components/common/json-view-section/json-view-section.tsx
@@ -27,7 +27,7 @@ export const JsonViewSection = ({ data }: JsonViewSectionProps) => {
   const numberOfKeys = Object.keys(data).length
 
   return (
-    <Container className="flex items-center justify-between px-6 py-4">
+    <Container className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
       <div className="flex items-center gap-x-4">
         <Heading level="h2">{t("json.header")}</Heading>
         <Badge size="2xsmall" rounded="full">
@@ -50,7 +50,7 @@ export const JsonViewSection = ({ data }: JsonViewSectionProps) => {
           dir="ltr"
           className="bg-ui-contrast-bg-base text-ui-code-fg-subtle !shadow-elevation-commandbar overflow-hidden border border-none max-md:inset-x-2 max-md:max-w-[calc(100%-16px)]"
         >
-          <div className="bg-ui-code-bg-base flex items-center justify-between px-6 py-4">
+          <div className="bg-ui-code-bg-base flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-center gap-x-4">
               <Drawer.Title asChild>
                 <Heading className="text-ui-contrast-fg-primary">

--- a/apps/partner-ui/src/components/common/section/section-row.tsx
+++ b/apps/partner-ui/src/components/common/section/section-row.tsx
@@ -13,9 +13,10 @@ export const SectionRow = ({ title, value, actions }: SectionRowProps) => {
   return (
     <div
       className={clx(
-        `text-ui-fg-subtle grid w-full grid-cols-2 items-center gap-4 px-6 py-4`,
+        // Stack title over value on mobile; restore the 2-col key/value grid at sm+.
+        `text-ui-fg-subtle grid w-full grid-cols-1 items-start gap-1 px-6 py-4 sm:grid-cols-2 sm:items-center sm:gap-4`,
         {
-          "grid-cols-[1fr_1fr_28px]": !!actions,
+          "sm:grid-cols-[1fr_1fr_28px]": !!actions,
         }
       )}
     >

--- a/apps/partner-ui/src/components/common/skeleton/skeleton.tsx
+++ b/apps/partner-ui/src/components/common/skeleton/skeleton.tsx
@@ -118,7 +118,7 @@ export const GeneralSectionSkeleton = ({
 
   return (
     <Container className="divide-y p-0" aria-hidden>
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <HeadingSkeleton characters={16} />
         <IconButtonSkeleton />
       </div>
@@ -184,7 +184,7 @@ export const TableSkeleton = ({
       })}
     >
       {hasToolbar && (
-        <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
           {filters && <Skeleton className="h-7 w-full max-w-[135px]" />}
           {(search || orderBy) && (
             <div className="flex items-center gap-x-2">
@@ -207,7 +207,7 @@ export const TableSkeleton = ({
 export const TableSectionSkeleton = (props: TableSkeletonProps) => {
   return (
     <Container className="divide-y p-0" aria-hidden>
-      <div className="flex items-center justify-between px-6 py-4" aria-hidden>
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between" aria-hidden>
         <HeadingSkeleton level="h2" characters={16} />
         <IconButtonSkeleton />
       </div>
@@ -219,7 +219,7 @@ export const TableSectionSkeleton = (props: TableSkeletonProps) => {
 export const JsonViewSectionSkeleton = () => {
   return (
     <Container className="divide-y p-0" aria-hidden>
-      <div className="flex items-center justify-between px-6 py-4" aria-hidden>
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between" aria-hidden>
         <div aria-hidden className="flex items-center gap-x-4">
           <HeadingSkeleton level="h2" characters={16} />
           <Skeleton className="h-5 w-12 rounded-md" />

--- a/apps/partner-ui/src/components/data-table/data-table.tsx
+++ b/apps/partner-ui/src/components/data-table/data-table.tsx
@@ -382,7 +382,7 @@ export const DataTable = <TData,>({
         translations={toolbarTranslations}
         filterBarContent={filterBarContent}
       >
-        <div className="flex w-full items-center justify-between gap-2">
+        <div className="flex w-full flex-wrap items-center justify-between gap-2">
           <div className="flex items-center gap-x-4">
             {shouldRenderHeading && (
               <div>
@@ -402,7 +402,7 @@ export const DataTable = <TData,>({
               />
             )}
           </div>
-          <div className="flex items-center gap-x-2">
+          <div className="flex flex-wrap items-center justify-end gap-2">
             {showFilterMenu && <UiDataTable.FilterMenu />}
             {enableSorting && <UiDataTable.SortingMenu />}
             {enableSearch && (

--- a/apps/partner-ui/src/components/work-orders/collated-design-detail.tsx
+++ b/apps/partner-ui/src/components/work-orders/collated-design-detail.tsx
@@ -73,7 +73,7 @@ export const DesignSpecs = ({ design }: { design: any }) => {
   return (
     <>
       <Container className="divide-y p-0">
-        <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
           <Heading level="h2">{t("partner.workOrders.summary")}</Heading>
           {/* Escape hatch to the full design-management surface. */}
           <Button size="small" variant="secondary" asChild>

--- a/apps/partner-ui/src/components/work-orders/inventory-order-sections.tsx
+++ b/apps/partner-ui/src/components/work-orders/inventory-order-sections.tsx
@@ -58,7 +58,7 @@ export const InventoryFulfillmentsSection = ({
         </div>
       ) : (
         events.map((e) => (
-          <div key={e.id} className="flex items-center justify-between px-6 py-4">
+          <div key={e.id} className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
             <div className="min-w-0">
               <Text size="small" weight="plus" className="truncate">
                 {e.title}
@@ -108,7 +108,7 @@ export const InventoryPaymentsSection = ({
         </div>
       ) : (
         payments.map((p, idx) => (
-          <div key={String(p.id ?? idx)} className="flex items-center justify-between px-6 py-4">
+          <div key={String(p.id ?? idx)} className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
             <div className="min-w-0">
               <Text size="small" weight="plus">
                 {money(Number(p.amount) || 0)}
@@ -161,7 +161,7 @@ export const InventoryUpcomingPickupCard = ({
         return (
           <div
             key={String(s.id ?? idx)}
-            className="flex items-center justify-between px-6 py-4"
+            className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between"
           >
             <div className="min-w-0">
               <Text size="small" weight="plus">
@@ -272,7 +272,7 @@ export const InventoryShipmentsSection = ({
         shipments.map((s, idx) => {
           const awb = s.awb || s.tracking_number
           return (
-            <div key={String(s.id ?? idx)} className="flex items-center justify-between px-6 py-4">
+            <div key={String(s.id ?? idx)} className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
               <div className="min-w-0">
                 {awb &&
                   (s.tracking_url ? (

--- a/apps/partner-ui/src/components/work-orders/production-run-card.tsx
+++ b/apps/partner-ui/src/components/work-orders/production-run-card.tsx
@@ -466,7 +466,7 @@ export const ProductionRunCard = ({
   return (
     <Container className={clx("divide-y p-0", { "opacity-60": isCancelled })}>
       {/* Header */}
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <div className="flex items-center gap-2">
             <Heading level="h2">Production</Heading>

--- a/apps/partner-ui/src/routes/api-key-management/api-key-management-detail/components/api-key-general-section/api-key-general-section.tsx
+++ b/apps/partner-ui/src/routes/api-key-management/api-key-management-detail/components/api-key-general-section/api-key-general-section.tsx
@@ -123,7 +123,7 @@ export const ApiKeyGeneralSection = ({ apiKey }: ApiKeyGeneralSectionProps) => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading>{apiKey.title}</Heading>
         <div className="flex items-center gap-x-4">
           <div className="flex items-center gap-x-2">

--- a/apps/partner-ui/src/routes/api-key-management/api-key-management-list/components/api-key-management-list-table/api-key-management-list-table.tsx
+++ b/apps/partner-ui/src/routes/api-key-management/api-key-management-list/components/api-key-management-list-table/api-key-management-list-table.tsx
@@ -51,7 +51,7 @@ export const ApiKeyManagementListTable = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <Heading level="h1">
             {keyType === "publishable"

--- a/apps/partner-ui/src/routes/campaigns/campaign-detail/components/campaign-general-section/campaign-general-section.tsx
+++ b/apps/partner-ui/src/routes/campaigns/campaign-detail/components/campaign-general-section/campaign-general-section.tsx
@@ -65,7 +65,7 @@ export const CampaignGeneralSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading>{campaign.name}</Heading>
 
         <div className="flex items-center gap-x-4">

--- a/apps/partner-ui/src/routes/campaigns/campaign-detail/components/campaign-promotion-section/campaign-promotion-section.tsx
+++ b/apps/partner-ui/src/routes/campaigns/campaign-detail/components/campaign-promotion-section/campaign-promotion-section.tsx
@@ -80,7 +80,7 @@ export const CampaignPromotionSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("promotions.domain")}</Heading>
         <Link to={`/campaigns/${campaign.id}/add-promotions`}>
           <Button variant="secondary" size="small">

--- a/apps/partner-ui/src/routes/campaigns/campaign-list/components/campaign-list-table.tsx
+++ b/apps/partner-ui/src/routes/campaigns/campaign-list/components/campaign-list-table.tsx
@@ -49,7 +49,7 @@ export const CampaignListTable = () => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h1">{t("campaigns.domain")}</Heading>
         <Link to="/campaigns/create">
           <Button size="small" variant="secondary">

--- a/apps/partner-ui/src/routes/categories/category-detail/components/category-general-section/category-general-section.tsx
+++ b/apps/partner-ui/src/routes/categories/category-detail/components/category-general-section/category-general-section.tsx
@@ -22,7 +22,7 @@ export const CategoryGeneralSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading>{category.name}</Heading>
         <div className="flex items-center gap-x-4">
           <div className="flex items-center gap-x-2">

--- a/apps/partner-ui/src/routes/categories/category-detail/components/category-organize-section/category-organize-section.tsx
+++ b/apps/partner-ui/src/routes/categories/category-detail/components/category-organize-section/category-organize-section.tsx
@@ -25,7 +25,7 @@ export const CategoryOrganizeSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("categories.organize.header")}</Heading>
         <ActionMenu
           groups={[

--- a/apps/partner-ui/src/routes/categories/category-detail/components/category-product-section/category-product-section.tsx
+++ b/apps/partner-ui/src/routes/categories/category-detail/components/category-product-section/category-product-section.tsx
@@ -109,7 +109,7 @@ export const CategoryProductSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("products.domain")}</Heading>
         <ActionMenu
           groups={[

--- a/apps/partner-ui/src/routes/categories/category-list/components/category-list-table/category-list-table.tsx
+++ b/apps/partner-ui/src/routes/categories/category-list/components/category-list-table/category-list-table.tsx
@@ -69,7 +69,7 @@ export const CategoryListTable = () => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <Heading>{t("categories.domain")}</Heading>
           <Text className="text-ui-fg-subtle" size="small">

--- a/apps/partner-ui/src/routes/collections/collection-detail/components/collection-general-section/collection-general-section.tsx
+++ b/apps/partner-ui/src/routes/collections/collection-detail/components/collection-general-section/collection-general-section.tsx
@@ -38,7 +38,7 @@ export const CollectionGeneralSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading>{collection.title}</Heading>
         <ActionMenu
           groups={[

--- a/apps/partner-ui/src/routes/collections/collection-detail/components/collection-product-section/collection-product-section.tsx
+++ b/apps/partner-ui/src/routes/collections/collection-detail/components/collection-product-section/collection-product-section.tsx
@@ -98,7 +98,7 @@ export const CollectionProductSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("products.domain")}</Heading>
         <ActionMenu
           groups={[

--- a/apps/partner-ui/src/routes/collections/collection-list/components/collection-list-table/collection-list-table.tsx
+++ b/apps/partner-ui/src/routes/collections/collection-list/components/collection-list-table/collection-list-table.tsx
@@ -50,7 +50,7 @@ export const CollectionListTable = () => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <Heading>{t("collections.domain")}</Heading>
           <Text className="text-ui-fg-subtle" size="small">

--- a/apps/partner-ui/src/routes/content/content-list/content-list.tsx
+++ b/apps/partner-ui/src/routes/content/content-list/content-list.tsx
@@ -240,7 +240,7 @@ export const ContentList = () => {
       hasOutlet={true}
     >
       <Container className="divide-y p-0">
-        <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <Heading>{t("partner.content.heading")}</Heading>
             {storefrontDomain && (

--- a/apps/partner-ui/src/routes/customer-groups/customer-group-detail/components/customer-group-customer-section/customer-group-customer-section.tsx
+++ b/apps/partner-ui/src/routes/customer-groups/customer-group-detail/components/customer-group-customer-section/customer-group-customer-section.tsx
@@ -87,7 +87,7 @@ export const CustomerGroupCustomerSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("customers.domain")}</Heading>
         <Link to={`/customer-groups/${group.id}/add-customers`}>
           <Button variant="secondary" size="small">

--- a/apps/partner-ui/src/routes/customer-groups/customer-group-detail/components/customer-group-general-section/customer-group-general-section.tsx
+++ b/apps/partner-ui/src/routes/customer-groups/customer-group-detail/components/customer-group-general-section/customer-group-general-section.tsx
@@ -53,7 +53,7 @@ export const CustomerGroupGeneralSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading>{group.name}</Heading>
         <ActionMenu
           groups={[

--- a/apps/partner-ui/src/routes/customers/customer-detail/components/customer-address-section/customer-address-section.tsx
+++ b/apps/partner-ui/src/routes/customers/customer-detail/components/customer-address-section/customer-address-section.tsx
@@ -56,7 +56,7 @@ export const CustomerAddressSection = ({
 
   return (
     <Container className="p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("addresses.title")}</Heading>
         <Link to={`create-address`} className="text-ui-fg-muted text-xs">
           Add

--- a/apps/partner-ui/src/routes/customers/customer-detail/components/customer-general-section/customer-general-section.tsx
+++ b/apps/partner-ui/src/routes/customers/customer-detail/components/customer-general-section/customer-general-section.tsx
@@ -70,7 +70,7 @@ export const CustomerGeneralSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading>{customer.email}</Heading>
         <div className="flex items-center gap-x-2">
           <StatusBadge color={statusColor}>{statusText}</StatusBadge>

--- a/apps/partner-ui/src/routes/customers/customer-detail/components/customer-group-section/customer-group-section.tsx
+++ b/apps/partner-ui/src/routes/customers/customer-detail/components/customer-group-section/customer-group-section.tsx
@@ -123,7 +123,7 @@ export const CustomerGroupSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("customerGroups.domain")}</Heading>
         <Link to={`/customers/${customer.id}/add-customer-groups`}>
           <Button variant="secondary" size="small">

--- a/apps/partner-ui/src/routes/customers/customer-detail/components/customer-order-section/customer-order-section.tsx
+++ b/apps/partner-ui/src/routes/customers/customer-detail/components/customer-order-section/customer-order-section.tsx
@@ -61,7 +61,7 @@ export const CustomerOrderSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("orders.domain")}</Heading>
         {/*TODO: ENABLE WHEN DRAFT ORDERS ARE DONE*/}
         {/*<div className="flex items-center gap-x-2">*/}

--- a/apps/partner-ui/src/routes/customers/customer-list/components/customer-list-table/customer-list-table.tsx
+++ b/apps/partner-ui/src/routes/customers/customer-list/components/customer-list-table/customer-list-table.tsx
@@ -51,7 +51,7 @@ export const CustomerListTable = () => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading>{t("customers.domain")}</Heading>
         {hasStore ? (
           <Link to="/customers/create">

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-consumption-logs-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-consumption-logs-section.tsx
@@ -128,7 +128,7 @@ export const DesignConsumptionLogsSection = ({ design }: DesignConsumptionLogsSe
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <div className="flex items-center gap-x-2">
             <Heading level="h2">Material Usage</Heading>

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-cost-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-cost-section.tsx
@@ -82,7 +82,7 @@ export const DesignCostSection = ({ design }: Props) => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <Heading level="h2">Cost estimate</Heading>
           <Text size="small" className="text-ui-fg-subtle">
@@ -108,7 +108,7 @@ export const DesignCostSection = ({ design }: Props) => {
           {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
-              className="flex items-center justify-between px-6 py-4"
+              className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between"
             >
               <Skeleton className="h-4 w-28" />
               <Skeleton className="h-4 w-20" />

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-inventory-bom-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-inventory-bom-section.tsx
@@ -76,7 +76,7 @@ export const DesignInventoryBomSection = ({ design }: Props) => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <Heading level="h2">Materials (BOM)</Heading>
           <Text size="small" className="text-ui-fg-subtle">

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-media-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-media-section.tsx
@@ -14,7 +14,7 @@ export const DesignMediaSection = ({ design }: DesignMediaSectionProps) => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">Media</Heading>
         <Button size="small" variant="secondary" asChild>
           <Link to="media">Manage</Link>

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-moodboard-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-moodboard-section.tsx
@@ -10,7 +10,7 @@ type DesignMoodboardSectionProps = {
 export const DesignMoodboardSection = ({ design: _design }: DesignMoodboardSectionProps) => {
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">Moodboard</Heading>
       </div>
       <div className="px-6 py-4">

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-production-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-production-section.tsx
@@ -106,7 +106,7 @@ const DesignOrderRow = ({ run, muted }: { run: any; muted?: boolean }) => {
     <Link
       to={to}
       className={clx(
-        "flex items-center justify-between px-6 py-4 transition-colors hover:bg-ui-bg-base-hover",
+        "flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between transition-colors hover:bg-ui-bg-base-hover",
         { "opacity-75": muted }
       )}
     >

--- a/apps/partner-ui/src/routes/designs/design-list/design-list.tsx
+++ b/apps/partner-ui/src/routes/designs/design-list/design-list.tsx
@@ -367,7 +367,7 @@ export const DesignList = () => {
       hasOutlet={true}
     >
       <Container className="divide-y p-0">
-        <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <Heading>Designs</Heading>
             <span className="text-ui-fg-subtle text-xs">

--- a/apps/partner-ui/src/routes/inventory/inventory-detail/components/inventory-item-attributes/attributes-section.tsx
+++ b/apps/partner-ui/src/routes/inventory/inventory-detail/components/inventory-item-attributes/attributes-section.tsx
@@ -18,7 +18,7 @@ export const InventoryItemAttributeSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("products.attributes")}</Heading>
         <ActionMenu
           groups={[

--- a/apps/partner-ui/src/routes/inventory/inventory-detail/components/inventory-item-general-section.tsx
+++ b/apps/partner-ui/src/routes/inventory/inventory-detail/components/inventory-item-general-section.tsx
@@ -26,7 +26,7 @@ export const InventoryItemGeneralSection = ({
   }
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading>
           {inventoryItem.title ?? inventoryItem.sku} {t("fields.details")}
         </Heading>

--- a/apps/partner-ui/src/routes/inventory/inventory-detail/components/inventory-item-location-levels.tsx
+++ b/apps/partner-ui/src/routes/inventory/inventory-detail/components/inventory-item-location-levels.tsx
@@ -14,7 +14,7 @@ export const InventoryItemLocationLevelsSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("inventory.locationLevels")}</Heading>
         <Button size="small" variant="secondary" asChild>
           <Link to="locations">{t("inventory.manageLocations")}</Link>

--- a/apps/partner-ui/src/routes/inventory/inventory-detail/components/inventory-item-reservations.tsx
+++ b/apps/partner-ui/src/routes/inventory/inventory-detail/components/inventory-item-reservations.tsx
@@ -14,7 +14,7 @@ export const InventoryItemReservationsSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("reservations.domain")}</Heading>
         <Button size="small" variant="secondary" asChild>
           <Link to={`/reservations/create?item_id=${inventoryItem.id}`}>

--- a/apps/partner-ui/src/routes/inventory/inventory-detail/components/inventory-item-variants/variants-section.tsx
+++ b/apps/partner-ui/src/routes/inventory/inventory-detail/components/inventory-item-variants/variants-section.tsx
@@ -21,7 +21,7 @@ export const InventoryItemVariantsSection = ({
 
   return (
     <Container className="p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("inventory.associatedVariants")}</Heading>
       </div>
 

--- a/apps/partner-ui/src/routes/inventory/inventory-list/components/inventory-list-table.tsx
+++ b/apps/partner-ui/src/routes/inventory/inventory-list/components/inventory-list-table.tsx
@@ -61,7 +61,7 @@ export const InventoryListTable = () => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <Heading>{t("inventory.domain")}</Heading>
           <Text className="text-ui-fg-subtle" size="small">

--- a/apps/partner-ui/src/routes/locations/location-detail/components/location-general-section/location-general-section.tsx
+++ b/apps/partner-ui/src/routes/locations/location-detail/components/location-general-section/location-general-section.tsx
@@ -63,7 +63,7 @@ export const LocationGeneralSection = ({
   return (
     <>
       <Container className="p-0">
-        <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <Heading>{location.name}</Heading>
             <Text className="text-ui-fg-subtle txt-small">
@@ -547,7 +547,7 @@ function FulfillmentSet(props: FulfillmentSetProps) {
   return (
     <Container className="p-0">
       <div className="flex flex-col divide-y">
-        <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
           <Heading level="h2">
             {t(`stockLocations.fulfillmentSets.${type}.header`)}
           </Heading>

--- a/apps/partner-ui/src/routes/locations/location-list/location-list.tsx
+++ b/apps/partner-ui/src/routes/locations/location-list/location-list.tsx
@@ -106,7 +106,7 @@ const LinksSection = () => {
 
   return (
     <Container className="p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("stockLocations.sidebar.header")}</Heading>
       </div>
 

--- a/apps/partner-ui/src/routes/orders/order-design-details/order-design-details.tsx
+++ b/apps/partner-ui/src/routes/orders/order-design-details/order-design-details.tsx
@@ -73,7 +73,7 @@ export const OrderDesignDetails = () => {
       <TwoColumnPage.Main>
         {/* General + link to the full design-management surface */}
         <Container className="divide-y p-0">
-          <div className="flex items-center justify-between px-6 py-4">
+          <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
             <Heading level="h2">{design.name || t("partner.workOrders.designDetails")}</Heading>
             <Button size="small" variant="secondary" asChild>
               <Link to={`/designs/${design.id}`}>

--- a/apps/partner-ui/src/routes/orders/order-detail/components/order-customer-section/order-customer-section.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/components/order-customer-section/order-customer-section.tsx
@@ -25,7 +25,7 @@ const Header = () => {
   const { t } = useTranslation()
 
   return (
-    <div className="flex items-center justify-between px-6 py-4">
+    <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
       <Heading level="h2">{t("fields.customer")}</Heading>
       <ActionMenu
         groups={[

--- a/apps/partner-ui/src/routes/orders/order-detail/components/order-fulfillment-section/order-fulfillment-section.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/components/order-fulfillment-section/order-fulfillment-section.tsx
@@ -177,7 +177,7 @@ const UnfulfilledItemDisplay = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("orders.fulfillment.unfulfilledItems")}</Heading>
 
         <div className="flex items-center gap-x-4">
@@ -466,7 +466,7 @@ const Fulfillment = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">
           {t("orders.fulfillment.number", {
             number: index + 1,

--- a/apps/partner-ui/src/routes/orders/order-detail/components/order-general-section/order-general-section.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/components/order-general-section/order-general-section.tsx
@@ -55,7 +55,7 @@ export const OrderGeneralSection = ({ order }: OrderGeneralSectionProps) => {
   }
 
   return (
-    <Container className="flex items-center justify-between px-6 py-4">
+    <Container className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
       <div>
         <div className="flex items-center gap-x-1">
           <Heading>#{order.display_id}</Heading>

--- a/apps/partner-ui/src/routes/orders/order-detail/components/order-partner-fee-section.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/components/order-partner-fee-section.tsx
@@ -43,7 +43,7 @@ export const OrderPartnerFeeSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <Heading level="h2">Platform commission</Heading>
           <Text size="small" leading="compact" className="text-ui-fg-subtle">

--- a/apps/partner-ui/src/routes/orders/order-detail/components/order-payment-section/order-payment-section.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/components/order-payment-section/order-payment-section.tsx
@@ -65,7 +65,7 @@ const Header = ({ order }: { order: HttpTypes.AdminOrder }) => {
   const { label, color } = getOrderPaymentStatus(t, order.payment_status)
 
   return (
-    <div className="flex items-center justify-between px-6 py-4">
+    <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
       <Heading level="h2">{t("orders.payment.title")}</Heading>
 
       <StatusBadge color={color} className="text-nowrap">
@@ -247,7 +247,7 @@ const Payment = ({
         />
       </div>
       {showCapture && (
-        <div className="bg-ui-bg-subtle flex items-center justify-between px-6 py-4">
+        <div className="bg-ui-bg-subtle flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-x-2">
             <ArrowDownRightMini className="text-ui-fg-muted shrink-0" />
             <Text size="small" leading="compact">

--- a/apps/partner-ui/src/routes/orders/order-detail/components/order-summary-section/order-summary-section.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/components/order-summary-section/order-summary-section.tsx
@@ -306,7 +306,7 @@ const Header = ({
     orderPreview?.order_change?.status === "pending"
 
   return (
-    <div className="flex items-center justify-between px-6 py-4">
+    <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
       <Heading level="h2">{t("fields.summary")}</Heading>
       <ActionMenu
         groups={[

--- a/apps/partner-ui/src/routes/orders/order-detail/components/work-order-status-section/work-order-status-section.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/components/work-order-status-section/work-order-status-section.tsx
@@ -122,7 +122,7 @@ export const WorkOrderStatusSection = ({
   }
 
   return (
-    <Container className="flex items-center justify-between px-6 py-4">
+    <Container className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
       <div>
         <div className="flex items-center gap-x-1">
           <Heading>#{order.display_id}</Heading>

--- a/apps/partner-ui/src/routes/orders/order-list/components/order-list-table/order-list-table.tsx
+++ b/apps/partner-ui/src/routes/orders/order-list/components/order-list-table/order-list-table.tsx
@@ -113,7 +113,7 @@ export const OrderListTable = () => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading>{kind === "retail" ? t("orders.domain") : KIND_HEADINGS[kind]}</Heading>
       </div>
       <_DataTable

--- a/apps/partner-ui/src/routes/payment-submissions/payment-submission-detail/payment-submission-detail.tsx
+++ b/apps/partner-ui/src/routes/payment-submissions/payment-submission-detail/payment-submission-detail.tsx
@@ -57,7 +57,7 @@ export const PaymentSubmissionDetail = () => {
       <div className="flex flex-col gap-y-4">
         {/* Header */}
         <Container className="divide-y p-0">
-          <div className="flex items-center justify-between px-6 py-4">
+          <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-center gap-3">
               <Heading>
                 Submission {submission.id.slice(0, 8)}...

--- a/apps/partner-ui/src/routes/payment-submissions/payment-submission-list/payment-submission-list.tsx
+++ b/apps/partner-ui/src/routes/payment-submissions/payment-submission-list/payment-submission-list.tsx
@@ -147,7 +147,7 @@ export const PaymentSubmissionList = () => {
       hasOutlet={true}
     >
       <Container className="divide-y p-0">
-        <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <Heading>{t("partner.paymentSubmissions.heading")}</Heading>
             <Text className="text-ui-fg-subtle" size="small">

--- a/apps/partner-ui/src/routes/price-lists/price-list-detail/components/price-list-general-section/price-list-general-section.tsx
+++ b/apps/partner-ui/src/routes/price-lists/price-list-detail/components/price-list-general-section/price-list-general-section.tsx
@@ -29,7 +29,7 @@ export const PriceListGeneralSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading>{priceList.title}</Heading>
         <div className="flex items-center gap-x-4">
           <StatusBadge color={color}>{text}</StatusBadge>

--- a/apps/partner-ui/src/routes/price-lists/price-list-detail/components/price-list-product-section/price-list-product-section.tsx
+++ b/apps/partner-ui/src/routes/price-lists/price-list-detail/components/price-list-product-section/price-list-product-section.tsx
@@ -112,7 +112,7 @@ export const PriceListProductSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("priceLists.products.header")}</Heading>
         <ActionMenu
           groups={[

--- a/apps/partner-ui/src/routes/price-lists/price-list-list/components/price-list-list-table/price-list-list-table.tsx
+++ b/apps/partner-ui/src/routes/price-lists/price-list-list/components/price-list-list-table/price-list-list-table.tsx
@@ -42,7 +42,7 @@ export const PriceListListTable = () => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <Heading>{t("priceLists.domain")}</Heading>
           <Text className="text-ui-fg-subtle" size="small">

--- a/apps/partner-ui/src/routes/product-tags/product-tag-list/components/product-tag-list-table/product-tag-list-table.tsx
+++ b/apps/partner-ui/src/routes/product-tags/product-tag-list/components/product-tag-list-table/product-tag-list-table.tsx
@@ -54,7 +54,7 @@ export const ProductTagListTable = () => {
 
   return (
     <Container className="divide-y px-0 py-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading>{t("productTags.domain")}</Heading>
         <Button variant="secondary" size="small" asChild>
           <Link to="create">{t("actions.create")}</Link>

--- a/apps/partner-ui/src/routes/product-types/product-type-list/components/product-type-list-table/product-type-list-table.tsx
+++ b/apps/partner-ui/src/routes/product-types/product-type-list/components/product-type-list-table/product-type-list-table.tsx
@@ -46,7 +46,7 @@ export const ProductTypeListTable = () => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <Heading>{t("productTypes.domain")}</Heading>
           <Text className="text-ui-fg-subtle" size="small">

--- a/apps/partner-ui/src/routes/product-variants/product-variant-detail/components/variant-general-section/variant-general-section.tsx
+++ b/apps/partner-ui/src/routes/product-variants/product-variant-detail/components/variant-general-section/variant-general-section.tsx
@@ -44,7 +44,7 @@ export function VariantGeneralSection({ variant }: VariantGeneralSectionProps) {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <div className="flex items-center gap-2">
             <Heading>{variant.title}</Heading>

--- a/apps/partner-ui/src/routes/product-variants/product-variant-detail/components/variant-inventory-section/variant-inventory-section.tsx
+++ b/apps/partner-ui/src/routes/product-variants/product-variant-detail/components/variant-inventory-section/variant-inventory-section.tsx
@@ -37,7 +37,7 @@ export function VariantInventorySection({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-2">
           <Heading level="h2">{t("fields.inventoryItems")}</Heading>
         </div>
@@ -78,7 +78,7 @@ export function InventorySectionPlaceholder() {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex flex-col gap-1">
           <Heading level="h2">{t("fields.inventoryItems")}</Heading>
           <span className="txt-small text-ui-fg-subtle">

--- a/apps/partner-ui/src/routes/product-variants/product-variant-detail/components/variant-media-section/variant-media-section.tsx
+++ b/apps/partner-ui/src/routes/product-variants/product-variant-detail/components/variant-media-section/variant-media-section.tsx
@@ -19,7 +19,7 @@ export const VariantMediaSection = ({ variant }: VariantMediaSectionProps) => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("products.media.label")}</Heading>
         <ActionMenu
           groups={[

--- a/apps/partner-ui/src/routes/product-variants/product-variant-detail/components/variant-prices-section/variant-prices-section.tsx
+++ b/apps/partner-ui/src/routes/product-variants/product-variant-detail/components/variant-prices-section/variant-prices-section.tsx
@@ -29,7 +29,7 @@ export function VariantPricesSection({ variant }: VariantPricesSectionProps) {
 
   return (
     <Container className="flex flex-col divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("labels.prices")}</Heading>
         <ActionMenu
           groups={[
@@ -60,7 +60,7 @@ export function VariantPricesSection({ variant }: VariantPricesSectionProps) {
         )
       })}
       {hasPrices && (
-        <div className="txt-small text-ui-fg-subtle flex items-center justify-between px-6 py-4">
+        <div className="txt-small text-ui-fg-subtle flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
           <span className="font-medium">
             {t("products.variant.pricesPagination", {
               total: prices.length,

--- a/apps/partner-ui/src/routes/products/product-detail/components/product-attribute-section/product-attribute-section.tsx
+++ b/apps/partner-ui/src/routes/products/product-detail/components/product-attribute-section/product-attribute-section.tsx
@@ -19,7 +19,7 @@ export const ProductAttributeSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("products.attributes")}</Heading>
         <ActionMenu
           groups={[

--- a/apps/partner-ui/src/routes/products/product-detail/components/product-general-section/product-general-section.tsx
+++ b/apps/partner-ui/src/routes/products/product-detail/components/product-general-section/product-general-section.tsx
@@ -68,7 +68,7 @@ export const ProductGeneralSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading>{product.title}</Heading>
         <div className="flex items-center gap-x-4">
           <StatusBadge color={productStatusColor(product.status)}>

--- a/apps/partner-ui/src/routes/products/product-detail/components/product-media-section/product-media-section.tsx
+++ b/apps/partner-ui/src/routes/products/product-detail/components/product-media-section/product-media-section.tsx
@@ -85,7 +85,7 @@ export const ProductMediaSection = ({ product }: ProductMedisaSectionProps) => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("products.media.label")}</Heading>
         <ActionMenu
           groups={[

--- a/apps/partner-ui/src/routes/products/product-detail/components/product-option-section/product-option-section.tsx
+++ b/apps/partner-ui/src/routes/products/product-detail/components/product-option-section/product-option-section.tsx
@@ -71,7 +71,7 @@ export const ProductOptionSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("products.options.header")}</Heading>
         <ActionMenu
           groups={[

--- a/apps/partner-ui/src/routes/products/product-detail/components/product-organization-section/product-organization-section.tsx
+++ b/apps/partner-ui/src/routes/products/product-detail/components/product-organization-section/product-organization-section.tsx
@@ -19,7 +19,7 @@ export const ProductOrganizationSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("products.organization.header")}</Heading>
         <ActionMenu
           groups={[

--- a/apps/partner-ui/src/routes/products/product-detail/components/product-shipping-profile-section/product-shipping-profile-section.tsx
+++ b/apps/partner-ui/src/routes/products/product-detail/components/product-shipping-profile-section/product-shipping-profile-section.tsx
@@ -21,7 +21,7 @@ export const ProductShippingProfileSection = ({
 
   return (
     <Container className="p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("products.shippingProfile.header")}</Heading>
         <ActionMenu
           groups={[

--- a/apps/partner-ui/src/routes/products/product-list/components/product-list-table/product-list-table.tsx
+++ b/apps/partner-ui/src/routes/products/product-list/components/product-list-table/product-list-table.tsx
@@ -70,7 +70,7 @@ export const ProductListTable = () => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h1">{t("products.domain")}</Heading>
         <div className="flex items-center justify-center gap-x-2">
           <Button size="small" variant="secondary" asChild>

--- a/apps/partner-ui/src/routes/profile/profile-detail/components/profile-general-section/profile-general-section.tsx
+++ b/apps/partner-ui/src/routes/profile/profile-detail/components/profile-general-section/profile-general-section.tsx
@@ -39,7 +39,7 @@ export const ProfileGeneralSection = ({ user }: ProfileGeneralSectionProps) => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <Heading>{t("profile.domain")}</Heading>
           <Text className="text-ui-fg-subtle" size="small">

--- a/apps/partner-ui/src/routes/promotions/promotion-detail/components/promotion-conditions-section/promotion-conditions-section.tsx
+++ b/apps/partner-ui/src/routes/promotions/promotion-detail/components/promotion-conditions-section/promotion-conditions-section.tsx
@@ -56,7 +56,7 @@ export const PromotionConditionsSection = ({
 
   return (
     <Container className="p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex flex-col">
           <Heading level="h2">
             {t(

--- a/apps/partner-ui/src/routes/promotions/promotion-detail/components/promotion-general-section/promotion-general-section.tsx
+++ b/apps/partner-ui/src/routes/promotions/promotion-detail/components/promotion-general-section/promotion-general-section.tsx
@@ -80,7 +80,7 @@ export const PromotionGeneralSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex flex-col">
           <Heading>{promotion.code}</Heading>
         </div>

--- a/apps/partner-ui/src/routes/promotions/promotion-list/components/promotion-list-table/promotion-list-table.tsx
+++ b/apps/partner-ui/src/routes/promotions/promotion-list/components/promotion-list-table/promotion-list-table.tsx
@@ -54,7 +54,7 @@ export const PromotionListTable = () => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h1">{t("promotions.domain")}</Heading>
 
         <Button size="small" variant="secondary" asChild>

--- a/apps/partner-ui/src/routes/regions/region-detail/components/region-country-section/region-country-section.tsx
+++ b/apps/partner-ui/src/routes/regions/region-detail/components/region-country-section/region-country-section.tsx
@@ -99,7 +99,7 @@ export const RegionCountrySection = ({ region }: RegionCountrySectionProps) => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("fields.countries")}</Heading>
         <ActionMenu
           groups={[

--- a/apps/partner-ui/src/routes/regions/region-detail/components/region-general-section/region-general-section.tsx
+++ b/apps/partner-ui/src/routes/regions/region-detail/components/region-general-section/region-general-section.tsx
@@ -28,7 +28,7 @@ export const RegionGeneralSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading>{region.name}</Heading>
         <RegionActions region={region} />
       </div>

--- a/apps/partner-ui/src/routes/regions/region-list/components/region-list-table/region-list-table.tsx
+++ b/apps/partner-ui/src/routes/regions/region-list/components/region-list-table/region-list-table.tsx
@@ -62,7 +62,7 @@ export const RegionListTable = () => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <Heading>{t("regions.domain")}</Heading>
           <Text className="text-ui-fg-subtle" size="small">

--- a/apps/partner-ui/src/routes/reservations/reservation-detail/components/reservation-general-section/reservation-general-section.tsx
+++ b/apps/partner-ui/src/routes/reservations/reservation-detail/components/reservation-general-section/reservation-general-section.tsx
@@ -41,7 +41,7 @@ export const ReservationGeneralSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading>
           {t("inventory.reservation.header", {
             itemName: inventoryItem.title ?? inventoryItem.sku,

--- a/apps/partner-ui/src/routes/reservations/reservation-list/components/reservation-list-table/reservation-list-table.tsx
+++ b/apps/partner-ui/src/routes/reservations/reservation-list/components/reservation-list-table/reservation-list-table.tsx
@@ -40,7 +40,7 @@ export const ReservationListTable = () => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <Heading>{t("reservations.domain")}</Heading>
           <Text className="text-ui-fg-subtle" size="small">

--- a/apps/partner-ui/src/routes/return-reasons/return-reason-list/components/return-reason-list-table/return-reason-list-table.tsx
+++ b/apps/partner-ui/src/routes/return-reasons/return-reason-list/components/return-reason-list-table/return-reason-list-table.tsx
@@ -46,7 +46,7 @@ export const ReturnReasonListTable = () => {
 
   return (
     <Container className="divide-y px-0 py-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <Heading>{t("returnReasons.domain")}</Heading>
           <Text className="text-ui-fg-subtle" size="small">

--- a/apps/partner-ui/src/routes/sales-channels/sales-channel-detail/components/sales-channel-general-section/sales-channel-general-section.tsx
+++ b/apps/partner-ui/src/routes/sales-channels/sales-channel-detail/components/sales-channel-general-section/sales-channel-general-section.tsx
@@ -56,7 +56,7 @@ export const SalesChannelGeneralSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading>{salesChannel.name}</Heading>
         <div className="flex items-center gap-x-2">
           <StatusBadge color={salesChannel.is_disabled ? "red" : "green"}>

--- a/apps/partner-ui/src/routes/sales-channels/sales-channel-detail/components/sales-channel-product-section/sales-channel-product-section.tsx
+++ b/apps/partner-ui/src/routes/sales-channels/sales-channel-detail/components/sales-channel-product-section/sales-channel-product-section.tsx
@@ -110,7 +110,7 @@ export const SalesChannelProductSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("products.domain")}</Heading>
         <Link to={`/settings/sales-channels/${salesChannel.id}/add-products`}>
           <Button size="small" variant="secondary">

--- a/apps/partner-ui/src/routes/settings/onboarding/onboarding.tsx
+++ b/apps/partner-ui/src/routes/settings/onboarding/onboarding.tsx
@@ -141,7 +141,7 @@ export const SettingsOnboarding = () => {
           </Text>
         </div>
 
-        <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <Text size="small" weight="plus">
               {t("partner.onboardingSettings.status.label")}

--- a/apps/partner-ui/src/routes/settings/payments/payments.tsx
+++ b/apps/partner-ui/src/routes/settings/payments/payments.tsx
@@ -205,7 +205,7 @@ export const SettingsPayments = () => {
     <SingleColumnPage widgets={{ before: [], after: [] }}>
       <div className="flex flex-col gap-y-3">
         <Container className="divide-y p-0">
-          <div className="flex items-center justify-between px-6 py-4">
+          <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <Heading>{t("partner.payments.heading")}</Heading>
               <Text size="small" className="text-ui-fg-subtle">

--- a/apps/partner-ui/src/routes/settings/people/people.tsx
+++ b/apps/partner-ui/src/routes/settings/people/people.tsx
@@ -268,7 +268,7 @@ export const SettingsPeople = () => {
   return (
     <SingleColumnPage widgets={{ before: [], after: [] }}>
       <Container className="divide-y p-0">
-        <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <Heading>{t("partner.people.heading")}</Heading>
             <Text size="small" className="text-ui-fg-subtle">

--- a/apps/partner-ui/src/routes/settings/stores/stores.tsx
+++ b/apps/partner-ui/src/routes/settings/stores/stores.tsx
@@ -152,7 +152,7 @@ const StorefrontSection = () => {
   if (!status.provisioned) {
     return (
       <Container className="divide-y p-0">
-        <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <Heading level="h2">Storefront</Heading>
             <Text size="small" className="text-ui-fg-subtle">
@@ -190,7 +190,7 @@ const StorefrontSection = () => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-x-2">
           <Heading level="h2">Storefront</Heading>
           {hasError ? (
@@ -439,7 +439,7 @@ const CustomDomainSection = () => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <Heading level="h2">Custom Domain</Heading>
           <Text size="small" className="text-ui-fg-subtle">
@@ -640,7 +640,7 @@ export const SettingsStores = () => {
     <SingleColumnPage widgets={{ before: [], after: [] }} hasOutlet>
       {/* Store General Section */}
       <Container className="divide-y p-0">
-        <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <Heading>Store</Heading>
             <Text className="text-ui-fg-subtle" size="small">
@@ -768,7 +768,7 @@ export const SettingsStores = () => {
       {/* Currencies Section */}
       {store && currencies.length > 0 && (
         <Container className="divide-y p-0">
-          <div className="flex items-center justify-between px-6 py-4">
+          <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <Heading level="h2">Currencies</Heading>
               <Text className="text-ui-fg-subtle" size="small">

--- a/apps/partner-ui/src/routes/shared-folders/shared-folder-detail/shared-folder-detail.tsx
+++ b/apps/partner-ui/src/routes/shared-folders/shared-folder-detail/shared-folder-detail.tsx
@@ -237,7 +237,7 @@ export const SharedFolderDetail = () => {
       <div className="flex flex-col gap-y-4">
         {/* Header */}
         <Container className="divide-y p-0">
-          <div className="flex items-center justify-between px-6 py-4">
+          <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <Heading>{folder.name}</Heading>
               {folder.description && (
@@ -312,7 +312,7 @@ export const SharedFolderDetail = () => {
 
         {/* Media Grid */}
         <Container className="divide-y p-0">
-          <div className="flex items-center justify-between px-6 py-4">
+          <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
             <Heading level="h2">Files</Heading>
             {mediaFiles.length > 0 && (
               <Text size="small" className="text-ui-fg-muted">

--- a/apps/partner-ui/src/routes/shared-folders/shared-folder-list/shared-folder-list.tsx
+++ b/apps/partner-ui/src/routes/shared-folders/shared-folder-list/shared-folder-list.tsx
@@ -99,7 +99,7 @@ export const SharedFolderList = () => {
   return (
     <SingleColumnPage widgets={{ before: [], after: [] }} hasOutlet={true}>
       <Container className="divide-y p-0">
-        <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <Heading>{t("partner.sharedFolders.heading")}</Heading>
             <Text className="text-ui-fg-subtle" size="small">

--- a/apps/partner-ui/src/routes/shipping-option-types/shipping-option-type-list/components/shipping-option-type-list-table/shipping-option-type-list-table.tsx
+++ b/apps/partner-ui/src/routes/shipping-option-types/shipping-option-type-list/components/shipping-option-type-list-table/shipping-option-type-list-table.tsx
@@ -43,7 +43,7 @@ export const ShippingOptionTypeListTable = () => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <Heading>{t("shippingOptionTypes.domain")}</Heading>
           <Text className="text-ui-fg-subtle" size="small">

--- a/apps/partner-ui/src/routes/shipping-profiles/shipping-profile-detail/components/shipping-profile-general-section/shipping-profile-general-section.tsx
+++ b/apps/partner-ui/src/routes/shipping-profiles/shipping-profile-detail/components/shipping-profile-general-section/shipping-profile-general-section.tsx
@@ -55,7 +55,7 @@ export const ShippingProfileGeneralSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading>{profile.name}</Heading>
         <ActionMenu
           groups={[

--- a/apps/partner-ui/src/routes/shipping-profiles/shipping-profiles-list/components/shipping-profile-list-table/shipping-profile-list-table.tsx
+++ b/apps/partner-ui/src/routes/shipping-profiles/shipping-profiles-list/components/shipping-profile-list-table/shipping-profile-list-table.tsx
@@ -42,7 +42,7 @@ export const ShippingProfileListTable = () => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <Heading>{t("shippingProfile.domain")}</Heading>
           <Text className="text-ui-fg-subtle" size="small">

--- a/apps/partner-ui/src/routes/store/store-detail/components/store-currency-section/store-currency-section.tsx
+++ b/apps/partner-ui/src/routes/store/store-detail/components/store-currency-section/store-currency-section.tsx
@@ -149,7 +149,7 @@ export const StoreCurrencySection = ({ store }: StoreCurrencySectionProps) => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("store.currencies")}</Heading>
         <ActionMenu
           groups={[

--- a/apps/partner-ui/src/routes/store/store-detail/components/store-fx-section/store-fx-section.tsx
+++ b/apps/partner-ui/src/routes/store/store-detail/components/store-fx-section/store-fx-section.tsx
@@ -65,7 +65,7 @@ export const StoreFxSection = ({ store }: StoreFxSectionProps) => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <Heading>
             {t("store.fxAutoConvertTitle", "Auto-convert prices across regions")}

--- a/apps/partner-ui/src/routes/store/store-detail/components/store-general-section/store-general-section.tsx
+++ b/apps/partner-ui/src/routes/store/store-detail/components/store-general-section/store-general-section.tsx
@@ -40,7 +40,7 @@ export const StoreGeneralSection = ({ store }: StoreGeneralSectionProps) => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <Heading>{t("store.domain")}</Heading>
           <Text className="text-ui-fg-subtle" size="small">

--- a/apps/partner-ui/src/routes/store/store-detail/components/store-locale-section/store-locale-section.tsx
+++ b/apps/partner-ui/src/routes/store/store-detail/components/store-locale-section/store-locale-section.tsx
@@ -113,7 +113,7 @@ export const StoreLocaleSection = ({ store }: StoreLocaleSectionProps) => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("store.locales")}</Heading>
         <ActionMenu
           groups={[

--- a/apps/partner-ui/src/routes/tasks/task-detail/components/task-actions-section.tsx
+++ b/apps/partner-ui/src/routes/tasks/task-detail/components/task-actions-section.tsx
@@ -19,7 +19,7 @@ export const TaskActionsSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">Actions</Heading>
       </div>
       <div className="flex flex-col gap-y-2 px-6 py-4">

--- a/apps/partner-ui/src/routes/tasks/task-detail/task-detail.tsx
+++ b/apps/partner-ui/src/routes/tasks/task-detail/task-detail.tsx
@@ -113,7 +113,7 @@ export const TaskDetail = () => {
     >
       <TwoColumnPage.Main>
         <Container className="divide-y p-0">
-          <div className="flex items-center justify-between px-6 py-4">
+          <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <Heading>{task?.title || "Task"}</Heading>
               <div className="mt-2 flex items-center gap-2">

--- a/apps/partner-ui/src/routes/tasks/task-list/task-list.tsx
+++ b/apps/partner-ui/src/routes/tasks/task-list/task-list.tsx
@@ -159,7 +159,7 @@ export const TaskList = () => {
   return (
     <SingleColumnPage widgets={{ before: [], after: [] }} hasOutlet={false}>
       <Container className="divide-y p-0">
-        <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
           <Heading>Tasks</Heading>
         </div>
         <_DataTable

--- a/apps/partner-ui/src/routes/users/user-detail/components/user-general-section/user-general-section.tsx
+++ b/apps/partner-ui/src/routes/users/user-detail/components/user-general-section/user-general-section.tsx
@@ -49,7 +49,7 @@ export const UserGeneralSection = ({ user }: UserGeneralSectionProps) => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading>{user.email}</Heading>
         <ActionMenu
           groups={[

--- a/apps/partner-ui/src/routes/workflow-executions/workflow-execution-detail/components/workflow-execution-general-section/workflow-execution-general-section.tsx
+++ b/apps/partner-ui/src/routes/workflow-executions/workflow-execution-detail/components/workflow-execution-general-section/workflow-execution-general-section.tsx
@@ -32,7 +32,7 @@ export const WorkflowExecutionGeneralSection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-x-0.5">
           <Heading>{cleanId}</Heading>
           <Copy content={cleanId} className="text-ui-fg-muted" />

--- a/apps/partner-ui/src/routes/workflow-executions/workflow-execution-detail/components/workflow-execution-history-section/workflow-execution-history-section.tsx
+++ b/apps/partner-ui/src/routes/workflow-executions/workflow-execution-detail/components/workflow-execution-history-section/workflow-execution-history-section.tsx
@@ -51,7 +51,7 @@ export const WorkflowExecutionHistorySection = ({
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">
           {t("workflowExecutions.history.sectionTitle")}
         </Heading>

--- a/apps/partner-ui/src/routes/workflow-executions/workflow-execution-detail/components/workflow-execution-timeline-section/workflow-execution-timeline-section.tsx
+++ b/apps/partner-ui/src/routes/workflow-executions/workflow-execution-detail/components/workflow-execution-timeline-section/workflow-execution-timeline-section.tsx
@@ -31,7 +31,7 @@ export const WorkflowExecutionTimelineSection = ({
 
   return (
     <Container className="overflow-hidden px-0 pb-8 pt-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <Heading level="h2">{t("general.timeline")}</Heading>
       </div>
       <div className="w-full overflow-hidden border-y">

--- a/apps/partner-ui/src/routes/workflow-executions/workflow-execution-list/components/workflow-execution-list-table/workflow-execution-list-table.tsx
+++ b/apps/partner-ui/src/routes/workflow-executions/workflow-execution-list/components/workflow-execution-list-table/workflow-execution-list-table.tsx
@@ -42,7 +42,7 @@ export const WorkflowExecutionListTable = () => {
 
   return (
     <Container className="divide-y p-0">
-      <div className="flex items-center justify-between px-6 py-4">
+      <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <Heading>{t("workflowExecutions.domain")}</Heading>
           <Text className="text-ui-fg-subtle" size="small">


### PR DESCRIPTION
## Mobile-responsive sweep — buttons & layouts

Audited partner-ui: the **shell** (sidebar → mobile drawer + hamburger), **page wrappers** (`TwoColumnPage` stacks below `xl`), and **DataTable toolbar** were already responsive. The concrete mobile breakage was concentrated in two copy-pasted, fixed-desktop patterns where **buttons/badges overflowed the header**.

### 1. Section-header rows (~120 occurrences, 101 files)
The pasted `flex items-center justify-between px-6 py-4` (title on the left, buttons/badges/ActionMenu on the right) had no wrap or breakpoint — the right cluster crushed the title on phones. Now:
`flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between` — stacks on mobile, restores the exact horizontal row at `sm+`. Covers order-detail, design-detail, home dashboard, workflow-execution, etc.

### 2. `SectionRow` (shared key/value row, used across every detail page)
Fixed `grid-cols-2` (and the `grid-cols-[1fr_1fr_28px]` actions variant) → `grid-cols-1` stacking title over value on mobile, restoring the 2-col grid at `sm+`.

### 3. DataTable toolbar
Inner heading/controls row now `flex-wrap`; the control cluster (filter/sort/search/action) wraps and right-aligns, so the full-width mobile search no longer collides with the sort/filter menus.

## Convention
Matches what the shell + DataTable already use — Tailwind default breakpoints, `flex-col` → `sm:/md:flex-row`. **className-only changes**; no logic touched.

## Verify
- Partner-ui typechecks clean (the 4 pre-existing `order-create-claim`/`order-create-exchange` parse errors are untouched).
- Open any order-detail / design-detail page at ≤640px: section headers stack, buttons drop to their own line instead of overflowing; key/value rows stack; list toolbars wrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)