### PR TITLE
feat(partner-ui): full design manager nested inside the order (#2)

### DIFF
--- a/apps/partner-ui/src/components/work-orders/collated-design-detail.tsx
+++ b/apps/partner-ui/src/components/work-orders/collated-design-detail.tsx
@@ -75,9 +75,11 @@ export const DesignSpecs = ({ design }: { design: any }) => {
       <Container className="divide-y p-0">
         <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
           <Heading level="h2">{t("partner.workOrders.summary")}</Heading>
-          {/* Escape hatch to the full design-management surface. */}
+          {/* Open the FULL design manager nested in this order (relative →
+              /orders/:id/design-details/:designId), keeping the partner in the
+              Orders context instead of jumping to /designs/:id. */}
           <Button size="small" variant="secondary" asChild>
-            <Link to={`/designs/${design.id}`}>
+            <Link to={`design-details/${design.id}`}>
               {t("partner.workOrders.openDesignManager")}
               <ArrowUpRightOnBox />
             </Link>

--- a/apps/partner-ui/src/i18n/translations/en.json
+++ b/apps/partner-ui/src/i18n/translations/en.json
@@ -3462,6 +3462,7 @@
       "stockLocation": "Stock location",
       "designDetails": "Design details",
       "openDesignManager": "Open design manager",
+      "backToOrder": "Back to order",
       "noDesign": "No design linked to this order.",
       "activity": {
         "title": "Activity",

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-inventory-bom-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-inventory-bom-section.tsx
@@ -84,7 +84,9 @@ export const DesignInventoryBomSection = ({ design }: Props) => {
           </Text>
         </div>
         {isOwner && (
-          <Link to="add-inventory">
+          // Absolute so "Add material" works from the nested in-order manager
+          // too (the nested route has no add-inventory child).
+          <Link to={`/designs/${design.id}/add-inventory`}>
             <Button size="small" variant="secondary">
               <Plus />
               Add material

--- a/apps/partner-ui/src/routes/designs/design-detail/components/design-owner-actions-section.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/components/design-owner-actions-section.tsx
@@ -70,7 +70,10 @@ export const DesignOwnerActionsSection = ({ design }: Props) => {
         </Text>
       </div>
       <div className="flex items-center gap-x-2">
-        <Link to="production-run-create">
+        {/* Absolute so this owner-mutation flow works whether the manager is
+            standalone (/designs/:id) or nested under an order — the nested route
+            has no production-run-create child. */}
+        <Link to={`/designs/${design.id}/production-run-create`}>
           <Button
             size="small"
             variant={hasActiveRun ? "secondary" : "primary"}

--- a/apps/partner-ui/src/routes/designs/design-detail/design-detail.tsx
+++ b/apps/partner-ui/src/routes/designs/design-detail/design-detail.tsx
@@ -1,5 +1,6 @@
 import React from "react"
-import { Badge, Container, Heading, Text } from "@medusajs/ui"
+import { ArrowLeft } from "@medusajs/icons"
+import { Badge, Button, Container, Heading, Text } from "@medusajs/ui"
 import { useMemo } from "react"
 import { Link, useParams } from "react-router-dom"
 
@@ -204,8 +205,24 @@ function getTipTapBlocks(input: unknown): BlockNode[] {
   return Array.isArray(doc.content) ? (doc.content as BlockNode[]) : []
 }
 
-export const DesignDetail = () => {
-  const { id } = useParams()
+/**
+ * The full design manager. Standalone it reads the design id from the route
+ * param (`/designs/:id`). Nested under an order (`/orders/:id/design-details`)
+ * the resolver passes the design id + a `backTo` link explicitly, so the SAME
+ * manager renders inside the order instead of jumping the partner to a new
+ * top-level route. `backTo` swaps the standalone breadcrumb for a "Back to
+ * order" affordance.
+ */
+export type DesignDetailProps = {
+  /** Explicit design id (nested/in-order use). Falls back to the route param. */
+  designId?: string
+  /** When set, renders a back link at the top (in-order use). */
+  backTo?: { to: string; label: string }
+}
+
+export const DesignDetail = ({ designId, backTo }: DesignDetailProps = {}) => {
+  const { id: idParam } = useParams()
+  const id = designId ?? idParam
 
   if (!id) {
     return (
@@ -301,6 +318,16 @@ export const DesignDetail = () => {
   return (
     <TwoColumnPage widgets={{ before: [], after: [], sideBefore: [], sideAfter: [] }} hasOutlet>
       <TwoColumnPage.Main>
+        {backTo && (
+          <div>
+            <Button size="small" variant="transparent" asChild>
+              <Link to={backTo.to}>
+                <ArrowLeft />
+                {backTo.label}
+              </Link>
+            </Button>
+          </div>
+        )}
         {design && <DesignOwnerActionsSection design={design} />}
         <Container className="divide-y p-0">
           <div className="px-6 py-4">

--- a/apps/partner-ui/src/routes/orders/order-design-details/order-design-details.tsx
+++ b/apps/partner-ui/src/routes/orders/order-design-details/order-design-details.tsx
@@ -1,55 +1,47 @@
-import { ArrowUpRightOnBox } from "@medusajs/icons"
-import { Badge, Button, Container, Heading, Text } from "@medusajs/ui"
-import { Link, useParams } from "react-router-dom"
+import { Container, Heading, Text } from "@medusajs/ui"
+import { useParams } from "react-router-dom"
 import { useTranslation } from "react-i18next"
 
-import { SectionRow } from "../../../components/common/section"
 import { TwoColumnPageSkeleton } from "../../../components/common/skeleton"
-import { SingleColumnPage, TwoColumnPage } from "../../../components/layout/pages"
-import { getStatusBadgeColor } from "../../../lib/status-badge"
+import { SingleColumnPage } from "../../../components/layout/pages"
 import { useOrder } from "../../../hooks/api/orders"
-import { usePartnerDesign } from "../../../hooks/api/partner-designs"
 import { usePartnerProductionRun } from "../../../hooks/api/partner-production-runs"
-import { DesignCostSection } from "../../designs/design-detail/components/design-cost-section"
-import { DesignConsumptionLogsSection } from "../../designs/design-detail/components/design-consumption-logs-section"
-import { DesignMediaSection } from "../../designs/design-detail/components/design-media-section"
-import { DesignMoodboardSection } from "../../designs/design-detail/components/design-moodboard-section"
+import { DesignDetail } from "../../designs/design-detail/design-detail"
 
 /**
- * #342 — design details as a sub-route of the unified order
- * (`/orders/:id/design-details`, breadcrumb "Orders › <id> › Design details").
- * Resolves the design from the order's production run and renders the read-only
- * design context (general, materials, cost, consumption) inline — keeping the
- * partner in the Orders context. Editing / media / moodboard stay on the full
- * design-management surface, reachable via the header link.
+ * #342 / #2 — the design manager as a sub-route of the unified order
+ * (`/orders/:id/design-details[/:designId]`). Instead of a reduced read-only
+ * view with an "Open design manager" button that jumped to `/designs/:id`
+ * (leaving the Orders context), this resolves the design id and renders the
+ * FULL design manager INLINE, with a "Back to order" link — so the partner
+ * drives the whole design from within the order and can return with one click.
+ *
+ * Resolution: a collated order's per-design route names the design directly via
+ * `:designId`; a legacy single-design order resolves it from the order's
+ * `metadata.legacy_id` production run. The full manager renders its own loading
+ * skeleton + not-found once the id is known.
  */
 export const OrderDesignDetails = () => {
   const { t } = useTranslation()
   const { id, designId: designIdParam } = useParams()
 
   const { order } = useOrder(id!, { fields: "id,metadata" })
-  // #826 — a collated order links each card to `/design-details/:designId`, so
-  // the param names the design directly. Only fall back to the order's single
-  // legacy_id run pointer (legacy single-design orders) when no param is given.
   const runId = order?.metadata?.legacy_id as string | undefined
   const { production_run } = usePartnerProductionRun(runId ?? "", {
     enabled: !designIdParam && !!runId,
   })
   const designId =
     designIdParam ?? ((production_run as any)?.design_id as string | undefined)
-  const { design, isPending } = usePartnerDesign(designId ?? "", {
-    enabled: !!designId,
-  })
 
-  if (
-    !order ||
-    (!designIdParam && runId && !production_run) ||
-    (designId && isPending)
-  ) {
-    return <TwoColumnPageSkeleton mainSections={3} sidebarSections={1} showJSON={false} />
+  // Wait for the order (and, for legacy single-design orders, the run) before
+  // we can name the design — the manager itself skeletons the design fetch.
+  if (!order || (!designIdParam && runId && !production_run)) {
+    return (
+      <TwoColumnPageSkeleton mainSections={5} sidebarSections={3} showJSON={false} />
+    )
   }
 
-  if (!design) {
+  if (!designId) {
     return (
       <SingleColumnPage widgets={{ before: [], after: [] }} hasOutlet={false}>
         <Container className="p-6">
@@ -62,88 +54,13 @@ export const OrderDesignDetails = () => {
     )
   }
 
-  const materials = (design.inventory_items || []) as Array<Record<string, any>>
-
   return (
-    // hasOutlet renders the nested media / moodboard upload modals.
-    <TwoColumnPage
-      widgets={{ before: [], after: [], sideBefore: [], sideAfter: [] }}
-      hasOutlet
-    >
-      <TwoColumnPage.Main>
-        {/* General + link to the full design-management surface */}
-        <Container className="divide-y p-0">
-          <div className="flex flex-col gap-y-3 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
-            <Heading level="h2">{design.name || t("partner.workOrders.designDetails")}</Heading>
-            <Button size="small" variant="secondary" asChild>
-              <Link to={`/designs/${design.id}`}>
-                {t("partner.workOrders.openDesignManager")}
-                <ArrowUpRightOnBox />
-              </Link>
-            </Button>
-          </div>
-          {(design as any).design_type && (
-            <SectionRow
-              title={t("partner.workOrders.type")}
-              value={<Badge size="2xsmall" color="blue">{String((design as any).design_type)}</Badge>}
-            />
-          )}
-          {design.status && (
-            <SectionRow
-              title={t("partner.workOrders.designStatus")}
-              value={
-                <Badge size="2xsmall" color={getStatusBadgeColor(design.status)}>
-                  {String(design.status)}
-                </Badge>
-              }
-            />
-          )}
-          {(design as any).description && (
-            <div className="px-6 py-4">
-              <Text size="small" className="text-ui-fg-subtle whitespace-pre-line">
-                {String((design as any).description)}
-              </Text>
-            </div>
-          )}
-        </Container>
-
-        <DesignCostSection design={design} />
-        <DesignConsumptionLogsSection design={design} />
-      </TwoColumnPage.Main>
-
-      <TwoColumnPage.Sidebar>
-        {/* Media + moodboard upload — links resolve to the nested
-            /orders/:id/design-details/{media,moodboard} routes. */}
-        <DesignMediaSection design={design} />
-        <DesignMoodboardSection design={design} />
-
-        {/* Read-only materials list (link-free; full BOM editing is on the design manager). */}
-        <Container className="divide-y p-0">
-          <div className="px-6 py-4">
-            <Heading level="h2">{t("partner.workOrders.materials")}</Heading>
-          </div>
-          {materials.length === 0 ? (
-            <div className="px-6 py-4">
-              <Text size="small" className="text-ui-fg-subtle">
-                {t("partner.inventoryOrders.detail.noLines")}
-              </Text>
-            </div>
-          ) : (
-            <div className="flex flex-col gap-2 px-2 py-2">
-              {materials.map((it) => (
-                <div
-                  key={String(it.id)}
-                  className="shadow-elevation-card-rest bg-ui-bg-component rounded-md px-4 py-2"
-                >
-                  <Text size="small" weight="plus" className="truncate">
-                    {String(it.title || it.name || it.sku || it.id)}
-                  </Text>
-                </div>
-              ))}
-            </div>
-          )}
-        </Container>
-      </TwoColumnPage.Sidebar>
-    </TwoColumnPage>
+    <DesignDetail
+      designId={designId}
+      backTo={{
+        to: `/orders/${id}`,
+        label: t("partner.workOrders.backToOrder", "Back to order"),
+      }}
+    />
   )
 }


### PR DESCRIPTION
## What
The in-order design sub-route now renders the **full design manager** inline, instead of a reduced read-only view with an *Open design manager* button that jumped to `/designs/:id` and pulled the partner out of the Orders context.

**Order › :id › design-details[/:designId]** now shows the same manager the standalone `/designs/:id` page uses — general, sizes, colors, notes, BOM, cost, production, consumption, media, moodboard — with a **← Back to order** link.

## How
- **`DesignDetail`** gained optional `{ designId, backTo }`. Standalone it reads the route param as before (no props → byte-identical behavior); nested, the resolver passes the design id + a back link. `backTo` renders the "Back to order" affordance.
- **`OrderDesignDetails`** is now a thin resolver: order → `metadata.legacy_id` run → `design_id` (or the `:designId` param for collated orders), then mounts `<DesignDetail>` with the back link. Loading skeleton while resolving; the manager skeletons its own fetch.
- **Entry links stay in-order**: `Open design manager` now uses the relative `design-details/:designId` (→ `/orders/:id/design-details/:designId`) instead of `/designs/:id`. The partner never leaves Orders, so the **Orders nav tab stays active** the whole time (the "keep the design/inventory tab active" ask).
- **No broken links when nested**: owner-mutation flows without a nested child (`production-run-create`, `add-inventory`) are now absolute to `/designs/:id/...` (behavior-identical standalone). Media/moodboard stay relative — they ARE registered nested children and render in the manager's outlet.

## Verify
1. Open a design order → **Open design manager** → the full manager renders *inside* the order (URL stays under `/orders/:id/…`), Orders nav still highlighted.
2. **← Back to order** returns to the order detail (skeleton on the way).
3. Collated order: each design card opens its own nested manager via `:designId`.
4. Standalone `/designs/:id` is unchanged.
5. Media / moodboard modals still open (nested outlet); `add material` / `create order` (owner) open the standalone flow.

Partner-ui typechecks clean (pre-existing claim/exchange parse errors untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)