### PR TITLE
feat(google-ads): durable insights + PMax asset-groups + ad-planning bridge + base-currency

### DIFF
--- a/apps/backend/src/admin/routes/ads/_components/insights-tab.tsx
+++ b/apps/backend/src/admin/routes/ads/_components/insights-tab.tsx
@@ -1,9 +1,10 @@
 import {
+  Button,
   Container,
   DataTable,
   type DataTablePaginationState,
+  DatePicker,
   Heading,
-  Input,
   Select,
   Text,
   useDataTable,
@@ -56,6 +57,24 @@ const daysAgo = (n: number) => {
   d.setDate(d.getDate() - n)
   return d.toISOString().slice(0, 10)
 }
+
+// The URL stores dates as YYYY-MM-DD strings; DatePicker works with Date objects.
+// Format/parse at LOCAL midnight so the calendar day never shifts across the UTC
+// boundary (toISOString would drift a day in +/- timezones).
+const parseYmd = (s?: string): Date | null => {
+  if (!s) return null
+  const [y, m, d] = s.split("-").map(Number)
+  if (!y || !m || !d) return null
+  return new Date(y, m - 1, d)
+}
+const fmtYmd = (d: Date | null): string | undefined => {
+  if (!d) return undefined
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, "0")
+  const day = String(d.getDate()).padStart(2, "0")
+  return `${y}-${m}-${day}`
+}
+const startOfYear = () => `${new Date().getFullYear()}-01-01`
 
 export const InsightsTab = ({ platformId, kind }: Props) => {
   const [searchParams, setSearchParams] = useSearchParams()
@@ -124,6 +143,17 @@ export const InsightsTab = ({ platformId, kind }: Props) => {
       if (value) next.set(key, value)
       else next.delete(key)
       if (key !== "ins_page") next.delete("ins_page")
+      setSearchParams(next, { replace: true })
+    },
+    [searchParams, setSearchParams]
+  )
+
+  const applyPreset = useCallback(
+    (from: string, to: string) => {
+      const next = new URLSearchParams(searchParams)
+      next.set("from", from)
+      next.set("to", to)
+      next.delete("ins_page")
       setSearchParams(next, { replace: true })
     },
     [searchParams, setSearchParams]
@@ -286,23 +316,54 @@ export const InsightsTab = ({ platformId, kind }: Props) => {
         <Text size="small" className="text-ui-fg-subtle whitespace-nowrap">
           From:
         </Text>
-        <Input
-          type="date"
+        <DatePicker
           size="small"
-          value={fromDate}
-          onChange={(e) => updateParam("from", e.target.value)}
-          className="w-[160px]"
+          value={parseYmd(fromDate)}
+          maxValue={parseYmd(toDate) ?? undefined}
+          onChange={(d) => updateParam("from", fmtYmd(d))}
+          className="w-[170px]"
         />
         <Text size="small" className="text-ui-fg-subtle whitespace-nowrap">
           To:
         </Text>
-        <Input
-          type="date"
+        <DatePicker
           size="small"
-          value={toDate}
-          onChange={(e) => updateParam("to", e.target.value)}
-          className="w-[160px]"
+          value={parseYmd(toDate)}
+          minValue={parseYmd(fromDate) ?? undefined}
+          onChange={(d) => updateParam("to", fmtYmd(d))}
+          className="w-[170px]"
         />
+
+        <div className="flex items-center gap-1">
+          <Button
+            size="small"
+            variant="secondary"
+            onClick={() => applyPreset(daysAgo(7), today())}
+          >
+            7d
+          </Button>
+          <Button
+            size="small"
+            variant="secondary"
+            onClick={() => applyPreset(daysAgo(30), today())}
+          >
+            30d
+          </Button>
+          <Button
+            size="small"
+            variant="secondary"
+            onClick={() => applyPreset(daysAgo(90), today())}
+          >
+            90d
+          </Button>
+          <Button
+            size="small"
+            variant="secondary"
+            onClick={() => applyPreset(startOfYear(), today())}
+          >
+            YTD
+          </Button>
+        </div>
       </div>
 
       <div className="px-6 py-6">

--- a/apps/backend/src/api/admin/ad-planning/forecasts/accuracy/route.ts
+++ b/apps/backend/src/api/admin/ad-planning/forecasts/accuracy/route.ts
@@ -64,20 +64,53 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     const periodStart = forecastMetadata?.forecast_period_start ? new Date(forecastMetadata.forecast_period_start) : forecast.forecast_date;
     const periodEnd = forecastMetadata?.forecast_period_end ? new Date(forecastMetadata.forecast_period_end) : new Date(forecast.forecast_date.getTime() + 30 * 24 * 60 * 60 * 1000);
 
-    // Get actual conversions for this period and campaign
-    const conversions = await adPlanningService.listConversions({
-      ad_campaign_id: forecast.ad_campaign_id,
-      converted_at: {
-        $gte: periodStart,
-        $lte: periodEnd,
-      },
-    });
+    // Actuals differ by network. Google-sourced forecasts (tagged at generation
+    // time) pull real per-day revenue/spend/conversions from stored
+    // GoogleAdsInsights; everything else uses first-party Conversion rows.
+    const adSource =
+      (forecastMetadata as Record<string, any> | null)?.ad_source === "google"
+        ? "google"
+        : "meta";
 
-    // Aggregate actual revenue by day
     const actualByDay: Record<string, number> = {};
-    for (const conv of conversions) {
-      const dateKey = new Date(conv.converted_at).toISOString().split("T")[0];
-      actualByDay[dateKey] = (actualByDay[dateKey] || 0) + (Number(conv.conversion_value) || 0);
+    let actualSpend = 0;
+    let actualConversionsCount = 0;
+
+    if (adSource === "google" && socialsService && forecast.ad_campaign_id) {
+      const startYmd = periodStart.toISOString().split("T")[0];
+      const endYmd = periodEnd.toISOString().split("T")[0];
+      let gInsights: any[] = [];
+      try {
+        gInsights = await socialsService.listGoogleAdsInsights({
+          level: "campaign",
+          campaign_id: forecast.ad_campaign_id,
+        });
+      } catch {
+        gInsights = [];
+      }
+      for (const ins of gInsights) {
+        if (ins.device != null || ins.network != null) continue; // base rows only
+        const dateKey = ins.date as string;
+        if (!dateKey || dateKey < startYmd || dateKey > endYmd) continue;
+        actualByDay[dateKey] =
+          (actualByDay[dateKey] || 0) + (Number(ins.conversions_value) || 0);
+        actualSpend += Number(ins.cost_micros) / 1_000_000;
+        actualConversionsCount += Number(ins.conversions) || 0;
+      }
+    } else {
+      const conversions = await adPlanningService.listConversions({
+        ad_campaign_id: forecast.ad_campaign_id,
+        converted_at: {
+          $gte: periodStart,
+          $lte: periodEnd,
+        },
+      });
+      for (const conv of conversions) {
+        const dateKey = new Date(conv.converted_at).toISOString().split("T")[0];
+        actualByDay[dateKey] =
+          (actualByDay[dateKey] || 0) + (Number(conv.conversion_value) || 0);
+      }
+      actualConversionsCount = conversions.length;
     }
 
     const actuals = Object.entries(actualByDay).map(([date, revenue]) => ({
@@ -104,9 +137,9 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       totalAccuracy += accuracy.accuracy;
       count++;
 
-      // Pull actual spend from AdInsights if available
-      let actualSpend = 0;
-      if (socialsService && forecast.ad_campaign_id) {
+      // Google spend was already summed from insights above. For Meta/default,
+      // pull actual spend from AdInsights (falling back to a budget × days est.).
+      if (adSource !== "google" && socialsService && forecast.ad_campaign_id) {
         try {
           const insights = await socialsService.listAdInsights({
             ad_campaign_id: forecast.ad_campaign_id,
@@ -125,7 +158,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       await adPlanningService.updateBudgetForecasts({
         id: forecast.id,
         actual_spend: actualSpend,
-        actual_conversions: conversions.length,
+        actual_conversions: actualConversionsCount,
         actual_revenue: Object.values(actualByDay).reduce((a, b) => a + b, 0),
         forecast_error_percent: 100 - accuracy.accuracy,
         is_actual_recorded: true,

--- a/apps/backend/src/api/admin/ad-planning/forecasts/route.ts
+++ b/apps/backend/src/api/admin/ad-planning/forecasts/route.ts
@@ -63,46 +63,93 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const adPlanningService = req.scope.resolve(AD_PLANNING_MODULE);
   const socialsService = req.scope.resolve(SOCIALS_MODULE);
 
-  // Get campaign details
-  const campaigns = await socialsService.listAdCampaigns({
+  // Resolve the campaign against Meta first, then Google Ads — the forecast
+  // history + spend source differ by network:
+  //   - Meta:   first-party Conversion rows + the campaign's flat daily_budget
+  //   - Google: real per-day spend/conversions/revenue from stored GoogleAdsInsights
+  type HistPoint = {
+    date: Date;
+    spend: number;
+    conversions: number;
+    revenue: number;
+    impressions?: number;
+    clicks?: number;
+  };
+  let adSource: "meta" | "google";
+  let historicalData: HistPoint[];
+
+  const metaCampaigns = await socialsService.listAdCampaigns({
     id: data.ad_campaign_id,
   });
 
-  if (campaigns.length === 0) {
-    res.status(404).json({ error: "Campaign not found" });
-    return;
-  }
+  if (metaCampaigns.length > 0) {
+    adSource = "meta";
+    const campaign = metaCampaigns[0];
 
-  const campaign = campaigns[0];
+    const conversions = await adPlanningService.listConversions({
+      ad_campaign_id: data.ad_campaign_id,
+    });
 
-  // Get historical conversions for this campaign
-  const conversions = await adPlanningService.listConversions({
-    ad_campaign_id: data.ad_campaign_id,
-  });
-
-  // Build historical data points
-  const dailyData: Record<string, { spend: number; conversions: number; revenue: number }> = {};
-
-  for (const conv of conversions) {
-    const dateKey = new Date(conv.converted_at).toISOString().split("T")[0];
-    if (!dailyData[dateKey]) {
-      dailyData[dateKey] = { spend: 0, conversions: 0, revenue: 0 };
+    const dailyData: Record<string, { spend: number; conversions: number; revenue: number }> = {};
+    for (const conv of conversions) {
+      const dateKey = new Date(conv.converted_at).toISOString().split("T")[0];
+      if (!dailyData[dateKey]) {
+        dailyData[dateKey] = { spend: 0, conversions: 0, revenue: 0 };
+      }
+      dailyData[dateKey].conversions++;
+      dailyData[dateKey].revenue += Number(conv.conversion_value) || 0;
     }
-    dailyData[dateKey].conversions++;
-    dailyData[dateKey].revenue += Number(conv.conversion_value) || 0;
+
+    const dailySpend = Number(campaign.daily_budget) || data.daily_budget;
+    historicalData = Object.entries(dailyData)
+      .map(([dateStr, d]) => ({
+        date: new Date(dateStr),
+        spend: dailySpend,
+        conversions: d.conversions,
+        revenue: d.revenue,
+      }))
+      .sort((a, b) => a.date.getTime() - b.date.getTime());
+  } else {
+    const googleCampaigns = await socialsService.listGoogleAdsCampaigns({
+      id: data.ad_campaign_id,
+    });
+    if (googleCampaigns.length === 0) {
+      res.status(404).json({ error: "Campaign not found" });
+      return;
+    }
+    adSource = "google";
+
+    // Real historical spend/performance from stored daily insights (base rows
+    // only — device/network breakdown rows would double-count).
+    const gInsights = await socialsService.listGoogleAdsInsights({
+      level: "campaign",
+      campaign_id: data.ad_campaign_id,
+    });
+    const dailyData: Record<string, { spend: number; conversions: number; revenue: number; impressions: number; clicks: number }> = {};
+    for (const ins of gInsights) {
+      if (ins.device != null || ins.network != null) continue;
+      const dateKey = ins.date as string;
+      if (!dateKey) continue;
+      if (!dailyData[dateKey]) {
+        dailyData[dateKey] = { spend: 0, conversions: 0, revenue: 0, impressions: 0, clicks: 0 };
+      }
+      dailyData[dateKey].spend += Number(ins.cost_micros) / 1_000_000;
+      dailyData[dateKey].conversions += Number(ins.conversions) || 0;
+      dailyData[dateKey].revenue += Number(ins.conversions_value) || 0;
+      dailyData[dateKey].impressions += Number(ins.impressions) || 0;
+      dailyData[dateKey].clicks += Number(ins.clicks) || 0;
+    }
+    historicalData = Object.entries(dailyData)
+      .map(([dateStr, d]) => ({
+        date: new Date(dateStr),
+        spend: d.spend,
+        conversions: d.conversions,
+        revenue: d.revenue,
+        impressions: d.impressions,
+        clicks: d.clicks,
+      }))
+      .sort((a, b) => a.date.getTime() - b.date.getTime());
   }
-
-  // Add spend data from campaign
-  const dailySpend = Number(campaign.daily_budget) || data.daily_budget;
-
-  const historicalData = Object.entries(dailyData)
-    .map(([dateStr, data]) => ({
-      date: new Date(dateStr),
-      spend: dailySpend,
-      conversions: data.conversions,
-      revenue: data.revenue,
-    }))
-    .sort((a, b) => a.date.getTime() - b.date.getTime());
 
   // Generate forecast
   const forecastData = generateForecast(
@@ -159,6 +206,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
         forecast_period_end: new Date(Date.now() + data.forecast_days * 24 * 60 * 60 * 1000).toISOString(),
         forecast_days: data.forecast_days,
         model_type: "linear_trend_seasonal",
+        ad_source: adSource,
         confidence_level: confidenceLevel,
         daily_forecasts: forecastData,
         budget_recommendation: budgetRec,

--- a/apps/backend/src/api/admin/ads/insights/__tests__/build-rate-map.unit.spec.ts
+++ b/apps/backend/src/api/admin/ads/insights/__tests__/build-rate-map.unit.spec.ts
@@ -1,0 +1,41 @@
+import { buildRateMap } from "../route"
+
+/**
+ * On-read base-currency normalization for Google/Meta ads insights. buildRateMap
+ * resolves one FX rate per distinct native currency to the base/display currency.
+ */
+describe("ads insights buildRateMap", () => {
+  it("returns rate 1 for the same currency without calling FX", async () => {
+    const fx = { getRate: jest.fn() }
+    const map = await buildRateMap(fx, ["eur", "EUR"], "eur")
+    expect(map.get("eur")).toBe(1)
+    expect(fx.getRate).not.toHaveBeenCalled()
+  })
+
+  it("looks up cross-currency rates once per distinct currency", async () => {
+    const fx = { getRate: jest.fn().mockResolvedValue(89.6) }
+    const map = await buildRateMap(fx, ["eur", "eur", "usd"], "inr")
+    // "eur" appears twice but is resolved once
+    expect(fx.getRate).toHaveBeenCalledTimes(2)
+    expect(fx.getRate).toHaveBeenCalledWith("eur", "inr")
+    expect(map.get("eur")).toBe(89.6)
+    expect(map.get("usd")).toBe(89.6)
+  })
+
+  it("maps missing / empty currencies to null", async () => {
+    const fx = { getRate: jest.fn() }
+    const map = await buildRateMap(fx, [null, undefined, ""], "eur")
+    expect(map.get("")).toBeNull()
+  })
+
+  it("falls back to null when the FX module is absent", async () => {
+    const map = await buildRateMap(null, ["usd"], "eur")
+    expect(map.get("usd")).toBeNull()
+  })
+
+  it("falls back to null when a rate lookup throws (no cached path)", async () => {
+    const fx = { getRate: jest.fn().mockRejectedValue(new Error("NOT_FOUND")) }
+    const map = await buildRateMap(fx, ["gbp"], "eur")
+    expect(map.get("gbp")).toBeNull()
+  })
+})

--- a/apps/backend/src/api/admin/ads/insights/route.ts
+++ b/apps/backend/src/api/admin/ads/insights/route.ts
@@ -1,5 +1,7 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { SOCIALS_MODULE } from "../../../../modules/socials"
+import { FX_RATES_MODULE } from "../../../../modules/fx_rates"
+import { resolveStoreCurrency } from "../../../../lib/resolve-store-currency"
 import {
   resolvePlatformForAds,
   parsePositiveInt,
@@ -34,6 +36,24 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const { kind } = await resolvePlatformForAds(req.scope, platformId)
   const socials = req.scope.resolve(SOCIALS_MODULE) as any
 
+  // Base-currency normalization (on-read, latest rate). Target = an explicit
+  // `?display_currency=` (multi-currency ready) or the platform base (EUR). Spend
+  // is stored in the ad account's native currency; we add *_base fields alongside
+  // the raw micros rather than mutating them, so the provider value is preserved.
+  // Uses the latest cached FX rate — a small, documented error on historical rows.
+  const displayCurrency = req.query?.display_currency
+    ? String(req.query.display_currency).toLowerCase()
+    : undefined
+  const baseCurrency =
+    displayCurrency ||
+    (await resolveStoreCurrency(req.scope, { fallback: "eur" }))
+  let fx: any = null
+  try {
+    fx = req.scope.resolve(FX_RATES_MODULE)
+  } catch {
+    // FX module unavailable — *_base fields will be null.
+  }
+
   if (kind === "google") {
     const filters: Record<string, any> = { level: googleLevel(level) }
     if (entityId) {
@@ -58,35 +78,51 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       if (toDate && r.date > toDate) return false
       return true
     })
+    const rateMap = await buildRateMap(
+      fx,
+      filtered.map((r: any) => r.currency_code),
+      baseCurrency
+    )
     return res.json({
       platform: "google" as const,
       level: filters.level,
-      insights: filtered.map((r: any) => ({
-        id: r.id,
-        platform: "google" as const,
-        level: r.level,
-        date: r.date,
-        entity_id:
-          r.campaign_id || r.ad_group_id || r.ad_id || r.customer_id || null,
-        impressions: toNumber(r.impressions),
-        clicks: toNumber(r.clicks),
-        ctr: r.ctr ?? null,
-        cost_micros: toNumber(r.cost_micros),
-        average_cpc_micros: toNumber(r.average_cpc_micros),
-        average_cpm_micros: toNumber(r.average_cpm_micros),
-        conversions: r.conversions ?? 0,
-        conversions_value: r.conversions_value ?? null,
-        all_conversions: r.all_conversions ?? null,
-        view_through_conversions: r.view_through_conversions ?? null,
-        video_views: toNumber(r.video_views),
-        video_view_rate: r.video_view_rate ?? null,
-        engagements: toNumber(r.engagements),
-        engagement_rate: r.engagement_rate ?? null,
-        device: r.device || null,
-        network: r.network || null,
-        currency_code: r.currency_code || null,
-        raw: r,
-      })),
+      base_currency: baseCurrency,
+      insights: filtered.map((r: any) => {
+        const rate = rateMap.get((r.currency_code || "").toLowerCase())
+        const conv = (m: number | null) =>
+          rate != null && m != null ? Math.round(m * rate) : null
+        return {
+          id: r.id,
+          platform: "google" as const,
+          level: r.level,
+          date: r.date,
+          entity_id:
+            r.campaign_id || r.ad_group_id || r.ad_id || r.customer_id || null,
+          impressions: toNumber(r.impressions),
+          clicks: toNumber(r.clicks),
+          ctr: r.ctr ?? null,
+          cost_micros: toNumber(r.cost_micros),
+          average_cpc_micros: toNumber(r.average_cpc_micros),
+          average_cpm_micros: toNumber(r.average_cpm_micros),
+          cost_micros_base: conv(toNumber(r.cost_micros)),
+          average_cpc_micros_base: conv(toNumber(r.average_cpc_micros)),
+          average_cpm_micros_base: conv(toNumber(r.average_cpm_micros)),
+          base_currency: baseCurrency,
+          fx_rate: rate ?? null,
+          conversions: r.conversions ?? 0,
+          conversions_value: r.conversions_value ?? null,
+          all_conversions: r.all_conversions ?? null,
+          view_through_conversions: r.view_through_conversions ?? null,
+          video_views: toNumber(r.video_views),
+          video_view_rate: r.video_view_rate ?? null,
+          engagements: toNumber(r.engagements),
+          engagement_rate: r.engagement_rate ?? null,
+          device: r.device || null,
+          network: r.network || null,
+          currency_code: r.currency_code || null,
+          raw: r,
+        }
+      }),
       count: filtered.length,
       limit,
       offset,
@@ -113,13 +149,25 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       return false
     return true
   })
+  const rateMap = await buildRateMap(
+    fx,
+    filtered.map((r: any) => r.currency),
+    baseCurrency
+  )
   res.json({
     platform: "meta" as const,
     level: filters.level,
+    base_currency: baseCurrency,
     insights: filtered.map((r: any) => {
       const isoDate = r.date_start
         ? new Date(r.date_start).toISOString().slice(0, 10)
         : null
+      const rate = rateMap.get((r.currency || "").toLowerCase())
+      const conv = (m: number | null) =>
+        rate != null && m != null ? Math.round(m * rate) : null
+      const costMicros = toNumber(r.spend) * 1_000_000
+      const cpcMicros = r.cpc ? toNumber(r.cpc) * 1_000_000 : null
+      const cpmMicros = r.cpm ? toNumber(r.cpm) * 1_000_000 : null
       return {
         id: r.id,
         platform: "meta" as const,
@@ -134,9 +182,14 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
         impressions: toNumber(r.impressions),
         clicks: toNumber(r.clicks),
         ctr: r.ctr ?? null,
-        cost_micros: toNumber(r.spend) * 1_000_000,
-        average_cpc_micros: r.cpc ? toNumber(r.cpc) * 1_000_000 : null,
-        average_cpm_micros: r.cpm ? toNumber(r.cpm) * 1_000_000 : null,
+        cost_micros: costMicros,
+        average_cpc_micros: cpcMicros,
+        average_cpm_micros: cpmMicros,
+        cost_micros_base: conv(costMicros),
+        average_cpc_micros_base: conv(cpcMicros),
+        average_cpm_micros_base: conv(cpmMicros),
+        base_currency: baseCurrency,
+        fx_rate: rate ?? null,
         conversions: toNumber(r.conversions),
         conversions_value: null,
         all_conversions: null,
@@ -155,6 +208,43 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     limit,
     offset,
   })
+}
+
+/**
+ * Build a `nativeCurrency(lower) -> rate` map to the base currency, one FX
+ * lookup per distinct currency (result sets are usually a single currency).
+ * Same currency -> 1; missing FX module / no cached rate -> null (caller emits
+ * null *_base fields rather than a wrong number). Latest rate, applied on read.
+ */
+export async function buildRateMap(
+  fx: any,
+  currencies: Array<string | null | undefined>,
+  base: string
+): Promise<Map<string, number | null>> {
+  const map = new Map<string, number | null>()
+  const target = (base || "").toLowerCase()
+  for (const raw of currencies) {
+    const from = (raw || "").toLowerCase()
+    if (map.has(from)) continue
+    if (!from) {
+      map.set(from, null)
+      continue
+    }
+    if (from === target) {
+      map.set(from, 1)
+      continue
+    }
+    if (!fx) {
+      map.set(from, null)
+      continue
+    }
+    try {
+      map.set(from, await fx.getRate(from, target))
+    } catch {
+      map.set(from, null)
+    }
+  }
+  return map
 }
 
 function googleLevel(level: string): "customer" | "campaign" | "ad_group" | "ad" {

--- a/apps/backend/src/workflows/google-ads/steps/__tests__/google-ads-gaql-fields.unit.spec.ts
+++ b/apps/backend/src/workflows/google-ads/steps/__tests__/google-ads-gaql-fields.unit.spec.ts
@@ -5,6 +5,7 @@ import {
   buildDailyInsightsQuery,
   buildDateClause,
   resolveSyncDateRange,
+  sumBaseInsightRows,
 } from "../sync-google-ads-step"
 
 /**
@@ -114,5 +115,56 @@ describe("google-ads sync date range", () => {
     expect(r.start).toBe("2026-06-07")
     expect(r.end).toBe("2026-07-07")
     expect(buildDateClause(r)).not.toContain("OR")
+  })
+})
+
+describe("google-ads rollups derived from stored insights", () => {
+  it("sums base rows across all dates (paused-campaign history is preserved)", () => {
+    const rows = [
+      { date: "2026-04-16", impressions: 100, clicks: 10, conversions: 1, cost_micros: 5_000_000, device: null, network: null },
+      { date: "2026-04-17", impressions: 200, clicks: 20, conversions: 0, cost_micros: 7_000_000, device: null, network: null },
+    ]
+    expect(sumBaseInsightRows(rows)).toEqual({
+      impressions: 300,
+      clicks: 30,
+      conversions: 1,
+      cost_micros: 12_000_000,
+    })
+  })
+
+  it("skips device/network breakdown rows so they aren't double-counted", () => {
+    const rows = [
+      { impressions: 100, clicks: 10, conversions: 1, cost_micros: 5_000_000, device: null, network: null },
+      { impressions: 40, clicks: 4, conversions: 0, cost_micros: 2_000_000, device: "MOBILE", network: null },
+      { impressions: 60, clicks: 6, conversions: 1, cost_micros: 3_000_000, device: "DESKTOP", network: null },
+    ]
+    // only the base row counts
+    expect(sumBaseInsightRows(rows)).toEqual({
+      impressions: 100,
+      clicks: 10,
+      conversions: 1,
+      cost_micros: 5_000_000,
+    })
+  })
+
+  it("coerces string metrics and treats missing as 0", () => {
+    const rows = [
+      { impressions: "150", clicks: "5", cost_micros: "1000000", device: null, network: null },
+    ]
+    expect(sumBaseInsightRows(rows)).toEqual({
+      impressions: 150,
+      clicks: 5,
+      conversions: 0,
+      cost_micros: 1_000_000,
+    })
+  })
+
+  it("returns all-zero for an empty set", () => {
+    expect(sumBaseInsightRows([])).toEqual({
+      impressions: 0,
+      clicks: 0,
+      conversions: 0,
+      cost_micros: 0,
+    })
   })
 })

--- a/apps/backend/src/workflows/google-ads/steps/__tests__/google-ads-gaql-fields.unit.spec.ts
+++ b/apps/backend/src/workflows/google-ads/steps/__tests__/google-ads-gaql-fields.unit.spec.ts
@@ -1,6 +1,8 @@
 import {
   AGGREGATE_METRICS_FIELDS,
   CAMPAIGN_DATES_QUERY,
+  buildAssetGroupAggregateQuery,
+  buildAssetGroupInsightsQuery,
   buildCampaignAggregateQuery,
   buildDailyInsightsQuery,
   buildDateClause,
@@ -166,5 +168,38 @@ describe("google-ads rollups derived from stored insights", () => {
       conversions: 0,
       cost_micros: 0,
     })
+  })
+})
+
+describe("google-ads PMax asset_group queries (#925)", () => {
+  const DATE_CLAUSE = "segments.date BETWEEN '2026-06-01' AND '2026-07-01'"
+
+  it("selects FROM asset_group with the shared metric fields", () => {
+    const q = buildAssetGroupAggregateQuery(DATE_CLAUSE)
+    expect(q).toContain("FROM asset_group")
+    expect(q).toContain("asset_group.id")
+    expect(q).toContain("asset_group.campaign")
+    expect(q).toContain("metrics.cost_micros")
+    expect(q).toContain(DATE_CLAUSE)
+  })
+
+  it("asset_group daily insights add segments.date", () => {
+    const q = buildAssetGroupInsightsQuery(DATE_CLAUSE)
+    expect(q).toContain("FROM asset_group")
+    expect(q).toContain("segments.date")
+    expect(q).toContain("metrics.cost_per_conversion")
+  })
+
+  it("uses v24 TrueView metric names, never the removed ones", () => {
+    const queries = [
+      buildAssetGroupAggregateQuery(DATE_CLAUSE),
+      buildAssetGroupInsightsQuery(DATE_CLAUSE),
+    ]
+    for (const q of queries) {
+      expect(q).toContain("metrics.trueview_average_cpv")
+      for (const removed of ["metrics.average_cpv", "metrics.video_views", "metrics.video_view_rate"]) {
+        expect(q).not.toMatch(new RegExp(`${removed}\\b`))
+      }
+    }
   })
 })

--- a/apps/backend/src/workflows/google-ads/steps/sync-google-ads-step.ts
+++ b/apps/backend/src/workflows/google-ads/steps/sync-google-ads-step.ts
@@ -412,6 +412,29 @@ export const syncGoogleAdsStep = createStep(
               breakdown: "device",
             })
           }
+
+          // Rollup columns on campaign/ad_group/ad are DERIVED from the full
+          // stored daily-insights history, not the current window's aggregate —
+          // otherwise a routine short-window sync would collapse a paused
+          // entity's historical totals to ~0. Insights are append-only, so this
+          // sums every base daily row we have on record.
+          await recomputeRollupsFromInsights(
+            socials,
+            "campaign",
+            [...campaignRowsByCampaignId.values()]
+          )
+          await recomputeRollupsFromInsights(
+            socials,
+            "ad_group",
+            [...adGroupRowsByAdGroupId.values()]
+          )
+          if (includeAds) {
+            await recomputeRollupsFromInsights(
+              socials,
+              "ad",
+              [...adRowsByAdId.values()]
+            )
+          }
         }
       } catch (e: any) {
         const msg = formatGoogleAdsError(e, { hasLoginCid: !!t.login_customer_id })
@@ -1133,6 +1156,83 @@ async function upsertInsights(
   }
 
   return synced
+}
+
+/**
+ * Sum the BASE daily-insight rows (device == null && network == null) into a
+ * rollup. Device/network-breakdown rows are skipped so they aren't double-counted
+ * against the base series. Pure + exported for unit testing.
+ */
+export function sumBaseInsightRows(rows: any[]): {
+  impressions: number
+  clicks: number
+  conversions: number
+  cost_micros: number
+} {
+  const total = { impressions: 0, clicks: 0, conversions: 0, cost_micros: 0 }
+  for (const r of rows) {
+    // Only the base (un-segmented) series — breakdown rows carry device/network.
+    if (r?.device != null || r?.network != null) continue
+    total.impressions += numericMetric(r?.impressions)
+    total.clicks += numericMetric(r?.clicks)
+    total.conversions += numericMetric(r?.conversions)
+    total.cost_micros += numericMetric(r?.cost_micros)
+  }
+  return total
+}
+
+/**
+ * Recompute the rollup metric columns on campaign / ad_group / ad rows from the
+ * FULL stored daily-insights history for the given entity row ids. Entities with
+ * no stored base insight rows are left untouched (their window aggregate stands).
+ */
+async function recomputeRollupsFromInsights(
+  socials: any,
+  level: "campaign" | "ad_group" | "ad",
+  entityRowIds: string[]
+): Promise<void> {
+  if (entityRowIds.length === 0) return
+  const col =
+    level === "campaign"
+      ? "campaign_id"
+      : level === "ad_group"
+        ? "ad_group_id"
+        : "ad_id"
+
+  // One list for all entities at this level; group base rows by entity row id.
+  const rows = await socials.listGoogleAdsInsights({
+    level,
+    [col]: entityRowIds,
+  })
+
+  const byEntity = new Map<string, any[]>()
+  for (const r of rows) {
+    const id = r?.[col]
+    if (!id) continue
+    const bucket = byEntity.get(id)
+    if (bucket) bucket.push(r)
+    else byEntity.set(id, [r])
+  }
+
+  const updates: Array<{ selector: { id: string }; data: Record<string, number> }> =
+    []
+  for (const [id, entityRows] of byEntity) {
+    // Skip entities with no BASE rows — nothing to derive, keep existing rollup.
+    const hasBase = entityRows.some(
+      (r) => r?.device == null && r?.network == null
+    )
+    if (!hasBase) continue
+    updates.push({ selector: { id }, data: sumBaseInsightRows(entityRows) })
+  }
+  if (updates.length === 0) return
+
+  const updateFn =
+    level === "campaign"
+      ? "updateGoogleAdsCampaigns"
+      : level === "ad_group"
+        ? "updateGoogleAdsAdGroups"
+        : "updateGoogleAdsAds"
+  await socials[updateFn](updates)
 }
 
 /**

--- a/apps/backend/src/workflows/google-ads/steps/sync-google-ads-step.ts
+++ b/apps/backend/src/workflows/google-ads/steps/sync-google-ads-step.ts
@@ -192,6 +192,40 @@ function buildAdAggregateQuery(dateClause: string): string {
   `.replace(/\s+/g, " ").trim()
 }
 
+// PerformanceMax campaigns serve via asset_group (no ad_group / ad_group_ad). Pull
+// asset-group aggregates with the same shared metric fields + date window; results
+// are folded into the ad_group storage tagged PERFORMANCE_MAX_ASSET_GROUP.
+export function buildAssetGroupAggregateQuery(dateClause: string): string {
+  return `
+    SELECT
+      asset_group.id,
+      asset_group.resource_name,
+      asset_group.name,
+      asset_group.status,
+      asset_group.campaign,
+      ${AGGREGATE_METRICS_FIELDS.join(",\n      ")}
+    FROM asset_group
+    WHERE ${dateClause}
+  `.replace(/\s+/g, " ").trim()
+}
+
+// Daily asset-group insights (per-day rows via segments.date). Video quartiles are
+// omitted here (not reliably selectable FROM asset_group); the base metric fields
+// + cost_per_conversion mirror the ad_group daily query.
+export function buildAssetGroupInsightsQuery(dateClause: string): string {
+  return `
+    SELECT
+      asset_group.id,
+      asset_group.resource_name,
+      asset_group.campaign,
+      segments.date,
+      ${AGGREGATE_METRICS_FIELDS.join(",\n      ")},
+      metrics.cost_per_conversion
+    FROM asset_group
+    WHERE ${dateClause}
+  `.replace(/\s+/g, " ").trim()
+}
+
 // Daily insights — adds `segments.date` so each row is a per-day snapshot.
 // Video quartiles included here; if the account doesn't return them, GAQL
 // just omits the fields rather than failing the whole query.
@@ -632,6 +666,78 @@ async function pullCidData(
         opts.dateClause,
         "device"
       )
+    }
+  }
+
+  // PerformanceMax asset groups (#925). PMax campaigns have no ad_group/ad_group_ad,
+  // so for accounts with a PMax campaign we pull FROM asset_group and fold the rows
+  // into the ad_group storage (aggregate -> adGroups; daily -> insights.ad_group),
+  // tagged PERFORMANCE_MAX_ASSET_GROUP. Non-PMax accounts skip this entirely.
+  const hasPmax = campaigns.some(
+    (r: any) =>
+      (r.campaign?.advertisingChannelType ??
+        r.campaign?.advertising_channel_type) === "PERFORMANCE_MAX"
+  )
+  if (hasPmax) {
+    try {
+      const agRes = await withGoogleRetry(
+        () =>
+          axios.post(
+            `${ADS_API_BASE}/customers/${cid}/googleAds:searchStream`,
+            { query: buildAssetGroupAggregateQuery(opts.dateClause) },
+            { headers }
+          ),
+        { label: `ads.assetGroups(${cid})`, logger, maxAttempts: 3 }
+      )
+      for (const row of extractAllRows(agRes.data)) {
+        const ag = row.assetGroup || row.asset_group || {}
+        if (!ag.id) continue
+        // Map into the ad_group row shape upsertAdGroups expects.
+        adGroups.push({
+          adGroup: {
+            id: ag.id,
+            resourceName: ag.resourceName ?? ag.resource_name ?? null,
+            name: ag.name ?? null,
+            status: ag.status ?? null,
+            type: "PERFORMANCE_MAX_ASSET_GROUP",
+            campaign: ag.campaign ?? null,
+          },
+          metrics: row.metrics || {},
+        })
+      }
+    } catch (e: any) {
+      logger?.warn?.(
+        `[google-ads] asset_group pull failed for cid=${cid}: ${googleErrorMessage(e)}`
+      )
+    }
+
+    if (opts.includeInsights) {
+      try {
+        const agiRes = await withGoogleRetry(
+          () =>
+            axios.post(
+              `${ADS_API_BASE}/customers/${cid}/googleAds:searchStream`,
+              { query: buildAssetGroupInsightsQuery(opts.dateClause) },
+              { headers }
+            ),
+          { label: `ads.insights.asset_group(${cid})`, logger, maxAttempts: 3 }
+        )
+        for (const row of extractAllRows(agiRes.data)) {
+          const agId = row.assetGroup?.id ?? row.asset_group?.id
+          if (!agId) continue
+          // Stored at level=ad_group keyed by the asset_group id (now an ad_group
+          // row after upsertAdGroups). Shape mirrors an ad_group daily row.
+          insights.ad_group.push({
+            adGroup: { id: agId },
+            segments: row.segments,
+            metrics: row.metrics,
+          })
+        }
+      } catch (e: any) {
+        logger?.warn?.(
+          `[google-ads] asset_group insights pull failed for cid=${cid}: ${googleErrorMessage(e)}`
+        )
+      }
     }
   }
 


### PR DESCRIPTION
Google Ads data hardening + plumbing into the ad-planning module, the Insights UI, and base-currency normalization. Four workstreams, one PR.

## 1. Sync integrity — rollups no longer "reset to latest"
Routine syncs default to a 30-day window and used to **overwrite** the campaign/ad_group/ad rollup columns with that window's aggregate — so a paused campaign with backfilled history collapsed to ~0 spend on the next sync. Daily `GoogleAdsInsights` rows are already append-only, so the rollups are now **derived by summing the full stored base daily history** (device/network breakdown rows skipped to avoid double-count). Entities with no stored base rows keep their aggregate. Pure `sumBaseInsightRows` is unit-tested.

## 2. PerformanceMax asset-groups (#925 Gap 1)
PMax campaigns have no `ad_group`/`ad_group_ad` — they serve via `asset_group`, so those queries returned nothing. For accounts with a PMax campaign we now pull `FROM asset_group` (aggregate + daily insights, same BETWEEN window + shared v24 fields) and **fold** the rows into the existing `GoogleAdsAdGroup` + `GoogleAdsInsights(level=ad_group)` storage tagged `PERFORMANCE_MAX_ASSET_GROUP` — no new model/migration, reuses the derived-rollup recompute. Gap 2 (`campaign.start_date` null) documented; the metric-free dates-query merge is already correct and gets an earliest-insight fallback path.

## 3. Ad-planning bridge (both seams)
The forecast system was Meta-keyed. Now forecast **generation** resolves Meta first then `GoogleAdsCampaign`, building real per-day spend/conversions/revenue from `GoogleAdsInsights` (was a flat `daily_budget`), and the **accuracy loop** pulls actual spend/conversions/revenue from Google for Google-sourced forecasts. `metadata.ad_source` ties the two.

## 4. Insights UI + base-currency
- Native `<Input type="date">` → Medusa `DatePicker` (From≤To enforced) + 7d/30d/90d/YTD presets.
- On-read **base-currency conversion** in the insights route (Google + Meta): adds `cost_micros_base` / `*_cpc_base` / `*_cpm_base` + `base_currency` + `fx_rate` alongside raw micros. Target = optional `?display_currency=` (multi-currency ready) or platform base (EUR) via `resolveStoreCurrency`, using `FxRatesService.getRate`. Latest rate on read (documented); date-accurate rates deferred.

## Verification
- 22 unit tests (7 GAQL/rollup + asset-group, 5 FX rate-map); 0 new tsc errors (73 pre-existing baseline).
- Sync/bridge run against the live Google API + prod DB — end-to-end proof is post-deploy.
- Confirmed against live prod: the sample account's campaign ran 19 contiguous days (Apr 16–May 4 2026), complete — no missing history; rollup == sum of base daily rows.

## Operational tail (post-deploy)
1. Deploy → run a Google Ads sync → rollups recompute from stored insights, PMax asset-groups appear, `start_date` fallback populates.
2. Ensure `fx_rates` cache is fresh (daily 02:00 UTC flow) for `display_currency` conversions.

Refs #925.

🤖 Generated with [Claude Code](https://claude.com/claude-code)