### PR TITLE
ci(faire): add npm publish workflow for faire plugin

### DIFF
--- a/.github/workflows/publish-faire-plugin.yml
+++ b/.github/workflows/publish-faire-plugin.yml
@@ -1,0 +1,80 @@
+name: Publish Faire Plugin
+
+# Publishes @jytextiles/medusa-plugin-faire-store-sync to npm when the plugin
+# source changes on main. Publish is gated on a version bump: the job is a
+# no-op unless the version in package.json is not yet on the registry, so
+# unrelated pushes (or re-runs) never error on "cannot publish over existing
+# version".
+#
+# To cut a release: bump `version` in
+# packages/medusa-plugin-faire-store-sync/package.json and merge to main.
+#
+# AUTH: npm Trusted Publishing (OIDC) — no long-lived token, nothing to rotate.
+# GitHub Actions mints a short-lived OIDC token (id-token: write below) that npm
+# exchanges for publish auth. One-time setup on npmjs.com:
+#   Package → Settings → Trusted publishing →
+#     Organization or user: Jaal-Yantra-Textiles
+#     Repository:           v2
+#     Workflow filename:    publish-faire-plugin.yml
+#     Allowed actions:      npm publish
+# Provenance is generated automatically (no --provenance flag). Needs npm >= 11.5.1
+# (installed below) and Node >= 22.14.
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'packages/medusa-plugin-faire-store-sync/**'
+      - '.github/workflows/publish-faire-plugin.yml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: publish-faire-plugin
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/medusa-plugin-faire-store-sync
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        working-directory: .
+        run: pnpm install --frozen-lockfile
+
+      - name: Build plugin
+        run: pnpm build
+
+      - name: Test plugin
+        run: pnpm test
+
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Publish to npm via OIDC (only if version changed)
+        run: |
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "${NAME}@${VERSION}" version >/dev/null 2>&1; then
+            echo "::notice::${NAME}@${VERSION} is already published — skipping (bump the version to release)."
+            exit 0
+          fi
+          echo "Publishing ${NAME}@${VERSION} via trusted publishing…"
+          npm publish --access public


### PR DESCRIPTION
Adds  — mirrors the Etsy plugin publish workflow.

- OIDC trusted publishing (no long-lived token)
- Version-gated: no-op unless  version is new
- Triggers on path changes to 
- Needs one-time npm Trusted Publishing setup (see file header)

Merge this first so the Faire plugin PR (#937) has the workflow on main.