### PR TITLE
fix(inventory-orders): fetch-all picker catalog to remove limit truncation

### DIFF
--- a/apps/backend/src/admin/components/creates/create-inventory-order.tsx
+++ b/apps/backend/src/admin/components/creates/create-inventory-order.tsx
@@ -9,7 +9,7 @@ import { KeyboundForm } from "../utilitites/key-bound-form";
 import { Form } from "../common/form";
 import { useState, useEffect } from "react";
 import { useStockLocations } from "../../hooks/api/stock_location";
-import { useInventoryWithRawMaterials } from "../../hooks/api/raw-materials";
+import { useAllInventoryWithRawMaterials } from "../../hooks/api/raw-materials";
 import { InventoryOrderLinesGrid } from "./inventory-order-lines-grid";
 import { AddMaterialGroupControl } from "../inventory-orders/add-material-group-control";
 
@@ -110,16 +110,17 @@ export const CreateInventoryOrderComponent = () => {
   }, [tab]);
 
   const { stock_locations = [] } = useStockLocations();
-  // Load a generous page of the catalog once and filter the item picker purely
-  // client-side (see inventory-order-lines-grid). Server-side `q` search was
-  // dropped on purpose: changing the query key on every keystroke re-fetched,
-  // churned the grid's option/column state and REMOUNTED the picker cell mid-
-  // type — which blurred the input, closed the dropdown and wiped the query
-  // (the "search flickers / closes on the earlier value" flakiness). A single
-  // large fetch + local narrowing is stable and covers our catalog size.
-  const { inventory_items = [], isLoading } = useInventoryWithRawMaterials({
-    limit: 1000,
-  });
+  // Load the full catalog once (paginated to the true `count`) and filter the
+  // item picker purely client-side (see inventory-order-lines-grid). A single
+  // fixed-limit page used to silently truncate once the catalog grew past it
+  // (#947); the fetch-all hook pages until the endpoint's true count is
+  // reached. Server-side `q` search remains dropped on purpose: changing the
+  // query key on every keystroke re-fetched, churned the grid's option/column
+  // state and REMOUNTED the picker cell mid-type — which blurred the input,
+  // closed the dropdown and wiped the query (the "search flickers / closes on
+  // the earlier value" flakiness). A single large fetch + local narrowing is
+  // stable and covers our catalog size.
+  const { inventory_items = [], isLoading } = useAllInventoryWithRawMaterials();
 
   // Use Field Array for order lines
   const { fields, append, remove } = useFieldArray({

--- a/apps/backend/src/admin/components/inventory-orders/add-material-group-control.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/add-material-group-control.tsx
@@ -10,7 +10,7 @@ import {
   toast,
 } from "@medusajs/ui"
 import { sdk } from "../../lib/config"
-import { useRawMaterialGroups } from "../../hooks/api/raw-material-groups"
+import { useAllRawMaterialGroups } from "../../hooks/api/raw-material-groups"
 import type { RawMaterialGroup } from "../../hooks/api/raw-material-groups"
 import {
   expandGroupsToBatchLines,
@@ -51,7 +51,9 @@ export const AddMaterialGroupControl = ({
   onAdd,
   disabled,
 }: AddMaterialGroupControlProps) => {
-  const { data, isLoading } = useRawMaterialGroups({ limit: 100 })
+  // Fetch every group (paginated to the true `count`) so the picker never
+  // silently drops groups beyond a flat limit (#947).
+  const { data, isLoading } = useAllRawMaterialGroups()
   const groups = data?.raw_material_groups ?? []
 
   const [open, setOpen] = useState(false)

--- a/apps/backend/src/admin/components/inventory-orders/edit-order-lines.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/edit-order-lines.tsx
@@ -5,7 +5,7 @@ import { Button, Heading, Text, toast } from "@medusajs/ui";
 import { useRouteModal } from "../modal/use-route-modal";
 import { RouteFocusModal } from "../modal/route-focus-modal";
 import { KeyboundForm } from "../utilitites/key-bound-form";
-import { useInventoryWithRawMaterials } from "../../hooks/api/raw-materials";
+import { useAllInventoryWithRawMaterials } from "../../hooks/api/raw-materials";
 import { InventoryOrderLinesGrid } from "../creates/inventory-order-lines-grid";
 import { AddMaterialGroupControl } from "./add-material-group-control";
 import { AdminInventoryOrder } from "../../hooks/api/inventory-orders";
@@ -71,12 +71,12 @@ export const EditOrderLines = ({ inventoryOrder }: EditOrderLinesProps) => {
     resolver: zodResolver(editOrderLinesSchema),
   });
 
-  // Single large fetch + client-side narrowing in the picker (see
-  // create-inventory-order for why server-side `q` search was dropped: the
-  // per-keystroke refetch remounted the picker cell and made search flaky).
-  const { inventory_items = [], isLoading } = useInventoryWithRawMaterials({
-    limit: 1000,
-  });
+  // Full-catalog fetch (paginated to the true `count`) + client-side narrowing
+  // in the picker (see create-inventory-order for why server-side `q` search
+  // was dropped: the per-keystroke refetch remounted the picker cell and made
+  // search flaky). The fetch-all hook pages until the endpoint's true count is
+  // reached so a large catalog no longer silently truncates (#947).
+  const { inventory_items = [], isLoading } = useAllInventoryWithRawMaterials();
 
   // Use Field Array for order lines.
   // keyName MUST NOT be the default "id": react-hook-form overwrites the row's

--- a/apps/backend/src/admin/hooks/api/raw-material-groups.ts
+++ b/apps/backend/src/admin/hooks/api/raw-material-groups.ts
@@ -71,6 +71,56 @@ export const useRawMaterialGroups = (query?: {
       }>("/admin/raw-material-groups", { query: query as any }),
   })
 
+// Page size for auto-paginating the groups list. Groups are far fewer than
+// inventory items, but raising a flat limit only defers the truncation —
+// paging to the true `count` removes it entirely. #947
+const RAW_MATERIAL_GROUPS_FETCH_ALL_PAGE_SIZE = 100
+
+// Fetch-all variant: pages through /admin/raw-material-groups until the true
+// `count` is reached, so the order-lines "Add material groups" picker never
+// silently drops groups beyond a flat limit. Returns the same `{ data, ... }`
+// shape as useRawMaterialGroups for a drop-in swap. #947
+export const useAllRawMaterialGroups = (query?: {
+  q?: string
+  status?: string
+}) =>
+  useQuery({
+    queryKey: groupKeys.list({ ...query, all: true }),
+    queryFn: async () => {
+      const baseQuery: Record<string, any> = { ...(query ?? {}) }
+      const accumulated: RawMaterialGroup[] = []
+      let offset = 0
+      const maxPages = 100
+      for (let page = 0; page < maxPages; page++) {
+        const res = await sdk.client.fetch<{
+          raw_material_groups: RawMaterialGroup[]
+          count: number
+          offset: number
+          limit: number
+        }>("/admin/raw-material-groups", {
+          query: {
+            ...baseQuery,
+            limit: RAW_MATERIAL_GROUPS_FETCH_ALL_PAGE_SIZE,
+            offset,
+          } as any,
+        })
+        const batch = res.raw_material_groups ?? []
+        accumulated.push(...batch)
+        const total = res.count ?? accumulated.length
+        offset += batch.length
+        if (batch.length === 0 || offset >= total) {
+          break
+        }
+      }
+      return {
+        raw_material_groups: accumulated,
+        count: accumulated.length,
+        offset: 0,
+        limit: accumulated.length,
+      }
+    },
+  })
+
 export const useRawMaterialGroup = (id?: string) =>
   useQuery({
     queryKey: groupKeys.detail(id!),

--- a/apps/backend/src/admin/hooks/api/raw-materials.ts
+++ b/apps/backend/src/admin/hooks/api/raw-materials.ts
@@ -423,3 +423,79 @@ export const useInventoryWithRawMaterials = (
   
   return { ...data, ...rest };
 };
+
+// Page size used when auto-paginating the raw-materials catalog. The endpoint
+// loads the full set server-side then slices, so this only bounds the number
+// of round-trips — 200 keeps payload sizes modest while capping fetches at
+// ~ceil(count/200) for very large catalogs.
+const RAW_MATERIALS_FETCH_ALL_PAGE_SIZE = 200
+
+// Fetch-all variant: pages through /admin/inventory-items/raw-materials until
+// the true `count` is reached, eliminating the silent truncation a single
+// `limit:1000` page introduced once the catalog grows past it. Returns a shape
+// matching the single-page hook so callers (order-lines pickers) can swap in
+// unchanged. #947
+export const useAllInventoryWithRawMaterials = (
+  baseQuery?: Record<string, any>,
+  options?: Omit<
+    UseQueryOptions<
+      InventoryWithRawMaterialsResponse,
+      FetchError,
+      InventoryWithRawMaterialsResponse,
+      QueryKey
+    >,
+    "queryKey" | "queryFn"
+  >
+) => {
+  const query = { ...(baseQuery ?? {}) }
+  delete query.limit
+  delete query.offset
+
+  const { data, ...rest } = useQuery<
+    InventoryWithRawMaterialsResponse,
+    FetchError,
+    InventoryWithRawMaterialsResponse,
+    QueryKey
+  >({
+    queryKey: [
+      ...inventoryItemsRawMaterialQueryKeys.lists(),
+      "all",
+      query,
+    ],
+    queryFn: async () => {
+      const accumulated: InventoryItem[] = []
+      let offset = 0
+      // Upper bound on iterations to guard against a misbehaving endpoint.
+      const maxPages = 500
+      for (let page = 0; page < maxPages; page++) {
+        const res = await sdk.client.fetch<InventoryWithRawMaterialsResponse>(
+          `/admin/inventory-items/raw-materials`,
+          {
+            method: "GET",
+            query: {
+              ...query,
+              limit: RAW_MATERIALS_FETCH_ALL_PAGE_SIZE,
+              offset,
+            },
+          }
+        )
+        const batch = res.inventory_items ?? []
+        accumulated.push(...batch)
+        const total = res.count ?? accumulated.length
+        offset += batch.length
+        if (batch.length === 0 || offset >= total) {
+          break
+        }
+      }
+      return {
+        inventory_items: accumulated,
+        count: accumulated.length,
+        offset: 0,
+        limit: accumulated.length,
+      }
+    },
+    ...options,
+  })
+
+  return { ...data, ...rest }
+};


### PR DESCRIPTION
## What

Order-lines pickers requested a single fixed-limit page and could silently truncate a large catalog. **#947** (follow-up to #846).

- `useInventoryWithRawMaterials({ limit: 1000 })` in `create-inventory-order.tsx` and `edit-order-lines.tsx` — overflow invisible in the picker (client-side narrowing only).
- `useRawMaterialGroups({ limit: 100 })` in `add-material-group-control.tsx` — groups beyond 100 never appeared.

## Change

Frontend-only. Added two fetch-all hooks that page through the endpoint's true `count` until everything is loaded, and swapped the three picker call sites:

| Hook | Page size | Safety cap |
|------|-----------|------------|
| `useAllInventoryWithRawMaterials` | 200 | 500 pages |
| `useAllRawMaterialGroups` | 100 | 100 pages |

The original single-page hooks are retained — still used by the raw-material-groups management page and other components that paginate on their own.

## Notes

- Defensive, not urgent — prod catalog is currently <1000.
- Server already loads the full set in memory then slices, so this only bounds round-trips; no backend change needed.
- No new typecheck errors introduced (remaining are pre-existing Medusa UI JSX-prop issues across the codebase).

Closes #947