### PR TITLE
fix(ci): pin npm@11.18.0 for plugin publish (npm 12 breaks provenance)

### DIFF
--- a/.github/workflows/publish-etsy-plugin.yml
+++ b/.github/workflows/publish-etsy-plugin.yml
@@ -71,7 +71,10 @@ jobs:
 
       # Trusted Publishing (OIDC) requires npm >= 11.5.1; Node 22 ships npm 10.x.
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+        # Pinned: npm 12.0.0 (2026-07-08) broke provenance publishing with
+        # "Cannot find module 'sigstore'". 11.18.0 is the last known-good that
+        # bundles sigstore for OIDC trusted publishing. Revisit when 12.x fixes it.
+        run: npm install -g npm@11.18.0
 
       - name: Publish to npm via OIDC (only if version changed)
         run: |

--- a/.github/workflows/publish-faire-plugin.yml
+++ b/.github/workflows/publish-faire-plugin.yml
@@ -66,7 +66,10 @@ jobs:
         run: pnpm test
 
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+        # Pinned: npm 12.0.0 (2026-07-08) broke provenance publishing with
+        # "Cannot find module 'sigstore'". 11.18.0 is the last known-good that
+        # bundles sigstore for OIDC trusted publishing. Revisit when 12.x fixes it.
+        run: npm install -g npm@11.18.0
 
       - name: Publish to npm via OIDC (only if version changed)
         run: |


### PR DESCRIPTION
npm 12.0.0 (2026-07-08 21:06 UTC) broke OIDC trusted publishing with `Cannot find module 'sigstore'`. The Faire `0.2.0` publish failed twice on this; Etsy last published fine on 11.18.0 (2026-07-07). Pins both plugin publish workflows to `npm@11.18.0` until 12.x fixes it.

Merging re-triggers the Faire publish (workflow-path change) → publishes `0.2.0`. Etsy publish will no-op (0.1.3 already on registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)