### PR TITLE
fix(faire): robust OAuth code exchange on login callback (#937)

### DIFF
--- a/packages/medusa-plugin-faire-store-sync/src/admin/routes/settings/oauth/faire/callback/page.tsx
+++ b/packages/medusa-plugin-faire-store-sync/src/admin/routes/settings/oauth/faire/callback/page.tsx
@@ -1,44 +1,87 @@
 import { Container, Heading, Text, Alert, Button } from "@medusajs/ui"
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import { useNavigate, useSearchParams } from "react-router-dom"
 import { faireApi } from "../../../../../lib/api"
+
+/**
+ * Faire redirects here with `?code=...&state=...`. Faire OAuth codes are
+ * single-use: exchanging the same code twice yields `invalid_grant`.
+ *
+ * A `useRef` guard is not sufficient — React StrictMode (dev) simulates an
+ * unmount/remount which resets the ref, and any real remount (e.g. a parent
+ * re-render, route transition, or HMR) would too. We therefore persist the
+ * "already exchanged" flag in `sessionStorage` keyed by the code itself, which
+ * survives remounts. We also short-circuit if Faire is already connected.
+ */
+const EXCHANGED_PREFIX = "faire:oauth:exchanged:"
 
 const FaireOauthCallback = () => {
   const [params] = useSearchParams()
   const navigate = useNavigate()
   const [error, setError] = useState<string | null>(null)
-  // OAuth codes are single-use. React StrictMode (dev) double-invokes effects,
-  // and any re-render would re-run this — exchanging the same code twice yields
-  // an invalid_grant error. Guard so it runs once.
-  const exchangedRef = useRef(false)
+  const [exchanging, setExchanging] = useState(true)
 
   useEffect(() => {
-    if (exchangedRef.current) return
-    exchangedRef.current = true
-
-    const code = params.get("code")
-    const state = params.get("state")
     const errParam = params.get("error")
-
     if (errParam) {
       setError(
         `Faire authorization failed: ${params.get("error_description") || errParam}`
       )
-      return
-    }
-    if (!code || !state) {
-      setError("Missing code or state in Faire callback.")
+      setExchanging(false)
       return
     }
 
-    faireApi
-      .callback(code, state)
-      .then(() => {
-        navigate("/settings/faire", { replace: true })
-      })
-      .catch((err: any) => {
-        setError(err.message || "Failed to complete Faire authorization.")
-      })
+    // Faire returns the authorization code as `authorization_code`
+    // (some flows use `code`). Accept either.
+    const code = params.get("authorization_code") || params.get("code")
+    const state = params.get("state")
+    if (!code || !state) {
+      setError("Missing code or state in Faire callback.")
+      setExchanging(false)
+      return
+    }
+
+    // Already exchanged this exact code in this browser session — don't retry.
+    // This guard is checked AND set synchronously, before any async work, so
+    // that React StrictMode's double effect invocation (or any concurrent
+    // remount) cannot race past it and exchange the single-use code twice.
+    if (sessionStorage.getItem(EXCHANGED_PREFIX + code)) {
+      navigate("/settings/faire", { replace: true })
+      return
+    }
+    // Claim the code synchronously — any subsequent effect run will see this.
+    sessionStorage.setItem(EXCHANGED_PREFIX + code, "1")
+
+    let cancelled = false
+
+    const run = async () => {
+      try {
+        await faireApi.callback(code, state)
+        if (!cancelled) navigate("/settings/faire", { replace: true })
+      } catch (err: any) {
+        if (!cancelled) {
+          // "code already used" can happen if a prior exchange succeeded but
+          // the response was lost. If we are in fact connected, treat as success.
+          try {
+            const status: any = await faireApi.status()
+            if (status?.connected) {
+              navigate("/settings/faire", { replace: true })
+              return
+            }
+          } catch {
+            /* ignore */
+          }
+          setError(err.message || "Failed to complete Faire authorization.")
+          setExchanging(false)
+        }
+      }
+    }
+
+    run()
+
+    return () => {
+      cancelled = true
+    }
   }, [params, navigate])
 
   return (
@@ -49,7 +92,7 @@ const FaireOauthCallback = () => {
           <Text>{error}</Text>
         </Alert>
       ) : (
-        <Text>Completing authorization, please wait…</Text>
+        <Text>{exchanging ? "Completing authorization, please wait…" : "Redirecting…"}</Text>
       )}
       {error && (
         <Button


### PR DESCRIPTION
## Problem
The Faire login authorization callback intermittently fails with `invalid_grant` / "Missing code or state" when authorising.

Two root causes:
1. **Wrong param name** — Faire returns the authorization code as `authorization_code`, but the callback only read `code`, so on those flows the code was seen as missing.
2. **Double exchange of a single-use code** — OAuth codes are single-use. The old `useRef` guard resets on any remount (React StrictMode double-invoke in dev, HMR, parent/route re-render), so the same code could be exchanged twice → `invalid_grant`.

## Fix
- Accept `authorization_code` **or** `code`.
- Guard the exchange with a **`sessionStorage`** flag keyed by the code (survives remounts), claimed **synchronously** before any async work so a concurrent effect run can't race past it.
- On exchange error, check `faireApi.status()` — if we're already connected (a prior exchange succeeded but the response was lost), treat it as success instead of showing an error.

## Scope / safety
- **Plugin source only** (`packages/medusa-plugin-faire-store-sync/src/admin/routes/settings/oauth/faire/callback/page.tsx`).
- **No version bump** → the `publish-faire-plugin` workflow is a no-op; merging does **not** publish to npm or trigger an AWS deploy.
- To ship to prod, cut a plugin release separately (bump version → npm publish → bump backend dep → redeploy).

Separated from the DHL/international-shipping work and the Faire bulk-products feature (each its own PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)