### PR TITLE
fix(faire): revoke on disconnect, encrypt tokens at rest, bulk ops in modal — 0.2.3 (#937)

### DIFF
--- a/packages/medusa-plugin-faire-store-sync/package.json
+++ b/packages/medusa-plugin-faire-store-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jytextiles/medusa-plugin-faire-store-sync",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/packages/medusa-plugin-faire-store-sync/src/admin/routes/settings/faire/bulk/page.tsx
+++ b/packages/medusa-plugin-faire-store-sync/src/admin/routes/settings/faire/bulk/page.tsx
@@ -8,6 +8,7 @@ import {
   Heading,
   Input,
   Skeleton,
+  StatusBadge,
   Text,
   Toaster,
   toast,
@@ -131,6 +132,28 @@ const FaireBulkPage = () => {
       toast.error("Failed to start bulk sync", { description: err.message }),
   })
 
+  // ── Pull Faire orders into Medusa (the other bulk operation) ───────────────
+  const [pullBatch, setPullBatch] = useState<string | null>(null)
+  const pullMutation = useMutation({
+    mutationFn: () => faireApi.ingestOrders(),
+    onSuccess: (res: any) => {
+      setPullBatch(res.batch_id)
+      toast.success("Faire order pull started", {
+        description: "Running in the background. Polling progress…",
+      })
+    },
+    onError: (err: any) =>
+      toast.error("Failed to start order pull", { description: err.message }),
+  })
+  const pullStatus = useQuery({
+    queryKey: ["faire", "ingest", pullBatch],
+    enabled: !!pullBatch,
+    refetchInterval: (q) =>
+      (q.state.data as any)?.progress?.finished ? false : 3000,
+    queryFn: () => faireApi.ingestStatus(pullBatch!),
+  })
+  const pullProgress = (pullStatus.data as any)?.progress
+
   const columns = useBulkProductColumns()
 
   const commands = useMemo(
@@ -251,6 +274,38 @@ const FaireBulkPage = () => {
           <DataTable.Pagination />
         </DataTable>
       </RouteFocusModal.Body>
+      <RouteFocusModal.Footer>
+        <div className="flex w-full items-center justify-between gap-x-3">
+          <div className="flex items-center gap-x-3">
+            <Text size="small" className="text-ui-fg-subtle">
+              Pull Faire orders into Medusa (idempotent)
+            </Text>
+            {pullBatch && pullProgress && (
+              <StatusBadge
+                color={
+                  pullProgress.finished
+                    ? (pullStatus.data as any)?.batch?.status === "failed"
+                      ? "red"
+                      : "green"
+                    : "orange"
+                }
+              >
+                Pull: {pullProgress.done}/{pullProgress.total || "?"} (
+                {pullProgress.pct}%)
+              </StatusBadge>
+            )}
+          </div>
+          <Button
+            size="small"
+            variant="secondary"
+            onClick={() => pullMutation.mutate()}
+            disabled={!connected || pullMutation.isPending}
+            isLoading={pullMutation.isPending}
+          >
+            Pull orders
+          </Button>
+        </div>
+      </RouteFocusModal.Footer>
       <Toaster />
     </RouteFocusModal>
   )

--- a/packages/medusa-plugin-faire-store-sync/src/admin/routes/settings/faire/page.tsx
+++ b/packages/medusa-plugin-faire-store-sync/src/admin/routes/settings/faire/page.tsx
@@ -190,6 +190,13 @@ const FaireSettingsPage = () => {
               <Button
                 size="small"
                 variant="secondary"
+                onClick={() => navigate("/settings/faire/bulk")}
+              >
+                Bulk sync
+              </Button>
+              <Button
+                size="small"
+                variant="secondary"
                 onClick={() => navigate("/settings/faire/settings")}
               >
                 Sync settings
@@ -230,9 +237,6 @@ const FaireSettingsPage = () => {
         )}
       </Container>
 
-      {/* Bulk operations */}
-      <BulkOperations connected={connected} />
-
       {/* Recent syncs */}
       <Container className="divide-y p-0">
         <DataTable instance={table}>
@@ -269,175 +273,6 @@ const InfoField = ({ label, value }: { label: string; value: string }) => (
   <div className="flex flex-col gap-1">
     <Label>{label}</Label>
     <Text>{value}</Text>
-  </div>
-)
-
-/**
- * Bulk operations card: push many products to Faire, and pull Faire orders into
- * Medusa. Both run as long-running background workflows; progress is polled.
- */
-const BulkOperations = ({ connected }: { connected: boolean }) => {
-  const [productIds, setProductIds] = useState("")
-  const [pushBatch, setPushBatch] = useState<string | null>(null)
-  const [pullBatch, setPullBatch] = useState<string | null>(null)
-
-  const pushMutation = useMutation({
-    mutationFn: (ids: string[]) => faireApi.syncBulk(ids),
-    onSuccess: (res: any) => {
-      setPushBatch(res.batch_id)
-      toast.success("Bulk product sync started", {
-        description: "Running in the background. Polling progress…",
-      })
-    },
-    onError: (err: any) =>
-      toast.error("Failed to start bulk sync", { description: err.message }),
-  })
-
-  const pullMutation = useMutation({
-    mutationFn: () => faireApi.ingestOrders(),
-    onSuccess: (res: any) => {
-      setPullBatch(res.batch_id)
-      toast.success("Faire order pull started", {
-        description: "Running in the background. Polling progress…",
-      })
-    },
-    onError: (err: any) =>
-      toast.error("Failed to start order pull", { description: err.message }),
-  })
-
-  // Poll both batches until finished.
-  const pushStatus = useQuery({
-    queryKey: ["faire", "bulk", pushBatch],
-    enabled: !!pushBatch,
-    refetchInterval: (q) =>
-      (q.state.data as any)?.progress?.finished ? false : 3000,
-    queryFn: () => faireApi.bulkStatus(pushBatch!),
-  })
-  const pullStatus = useQuery({
-    queryKey: ["faire", "ingest", pullBatch],
-    enabled: !!pullBatch,
-    refetchInterval: (q) =>
-      (q.state.data as any)?.progress?.finished ? false : 3000,
-    queryFn: () => faireApi.ingestStatus(pullBatch!),
-  })
-
-  const pushProgress = (pushStatus.data as any)?.progress
-  const pullProgress = (pullStatus.data as any)?.progress
-
-  const handlePush = () => {
-    const ids = productIds
-      .split(/[\s,]+/)
-      .map((s) => s.trim())
-      .filter(Boolean)
-    if (!ids.length) {
-      toast.error("Enter at least one product id")
-      return
-    }
-    pushMutation.mutate(ids)
-  }
-
-  return (
-    <Container className="divide-y p-0">
-      <div className="px-6 py-4">
-        <Heading>Bulk operations</Heading>
-        <Text className="text-ui-fg-subtle" size="small">
-          Push many products to Faire, or pull wholesale orders from Faire into
-          Medusa. Both run as long-running background workflows.
-        </Text>
-      </div>
-      <div className="px-6 py-4 flex flex-col gap-6">
-        {/* Push products */}
-        <div className="flex flex-col gap-3">
-          <div className="flex flex-col gap-1">
-            <Label>Push products to Faire</Label>
-            <Text className="text-ui-fg-subtle" size="small">
-              Comma- or line-separated Medusa product IDs.
-            </Text>
-          </div>
-          <textarea
-            className="border-ui-border-base rounded-lg border px-3 py-2 text-sm min-h-[72px]"
-            placeholder="prod_01..., prod_02..."
-            value={productIds}
-            onChange={(e) => setProductIds(e.target.value)}
-            disabled={!connected || pushMutation.isPending}
-          />
-          <div className="flex flex-wrap items-center gap-3">
-            <Button
-              size="small"
-              variant="secondary"
-              disabled={!connected}
-              onClick={() => navigate("/settings/faire/bulk")}
-            >
-              Select products
-            </Button>
-            <Button
-              size="small"
-              onClick={handlePush}
-              disabled={!connected || pushMutation.isPending}
-              isLoading={pushMutation.isPending}
-            >
-              Start bulk push
-            </Button>
-            {pushBatch && pushProgress && (
-              <BulkProgress
-                label="Push"
-                progress={pushProgress}
-                status={(pushStatus.data as any)?.batch?.status}
-              />
-            )}
-          </div>
-        </div>
-
-        {/* Pull orders */}
-        <div className="flex flex-col gap-3">
-          <div className="flex flex-col gap-1">
-            <Label>Pull Faire orders into Medusa</Label>
-            <Text className="text-ui-fg-subtle" size="small">
-              Ingests all available Faire orders as Medusa orders (idempotent).
-            </Text>
-          </div>
-          <div className="flex items-center gap-3">
-            <Button
-              size="small"
-              variant="secondary"
-              onClick={() => pullMutation.mutate()}
-              disabled={!connected || pullMutation.isPending}
-              isLoading={pullMutation.isPending}
-            >
-              Start order pull
-            </Button>
-            {pullBatch && pullProgress && (
-              <BulkProgress
-                label="Pull"
-                progress={pullProgress}
-                status={(pullStatus.data as any)?.batch?.status}
-              />
-            )}
-          </div>
-        </div>
-      </div>
-    </Container>
-  )
-}
-
-const BulkProgress = ({
-  label,
-  progress,
-  status,
-}: {
-  label: string
-  progress: { total: number; done: number; pct: number; finished: boolean }
-  status?: string
-}) => (
-  <div className="flex items-center gap-3">
-    <StatusBadge color={progress.finished ? (status === "failed" ? "red" : "green") : "orange"}>
-      {label}: {progress.done}/{progress.total || "?"} ({progress.pct}%)
-    </StatusBadge>
-    {progress.finished && (
-      <Text className="text-ui-fg-subtle" size="small">
-        {status === "failed" ? "Completed with errors" : "Done"}
-      </Text>
-    )}
   </div>
 )
 

--- a/packages/medusa-plugin-faire-store-sync/src/lib/crypto.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/lib/crypto.ts
@@ -1,0 +1,84 @@
+import crypto from "crypto"
+
+/**
+ * Symmetric encryption for secrets at rest (Faire OAuth access/refresh tokens).
+ *
+ * AES-256-GCM, mirroring the host app's `encryption` module so the same
+ * `ENCRYPTION_KEY` protects Faire tokens the same way it protects social
+ * platform tokens. A dedicated `FAIRE_TOKEN_ENCRYPTION_KEY` takes precedence
+ * if set.
+ *
+ * Stored format (single self-describing string, fits the existing text column):
+ *   fenc1:<iv_b64>.<authTag_b64>.<ciphertext_b64>
+ *
+ * Backward/forward compatible:
+ *   - `encryptSecret`  of an empty/nullish value returns it unchanged.
+ *   - `decryptSecret`  of a value WITHOUT the `fenc1:` prefix is returned as-is,
+ *     so legacy plaintext rows keep working and a missing key degrades to
+ *     plaintext (with a one-time warning) rather than crashing.
+ */
+
+const PREFIX = "fenc1:"
+const ALGORITHM = "aes-256-gcm"
+
+let warnedNoKey = false
+
+/** Resolve a 32-byte key from whatever secret is configured (any length). */
+function resolveKey(): Buffer | null {
+  const keyString =
+    process.env.FAIRE_TOKEN_ENCRYPTION_KEY ||
+    process.env.ENCRYPTION_KEY ||
+    process.env.ENCRYPTION_KEY_V1
+  if (!keyString) return null
+
+  // Prefer a base64 32-byte key (matches the host encryption module); otherwise
+  // derive a stable 32-byte key from the secret so any value works.
+  const asBase64 = Buffer.from(keyString, "base64")
+  if (asBase64.length === 32) return asBase64
+  return crypto.createHash("sha256").update(keyString, "utf8").digest()
+}
+
+export function encryptSecret(plaintext: string | null | undefined): string | null {
+  if (plaintext == null || plaintext === "") {
+    return plaintext ?? null
+  }
+  const key = resolveKey()
+  if (!key) {
+    if (!warnedNoKey) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[faire-sync] No ENCRYPTION_KEY/FAIRE_TOKEN_ENCRYPTION_KEY set — Faire tokens are stored in plaintext. Set one to encrypt at rest."
+      )
+      warnedNoKey = true
+    }
+    return plaintext
+  }
+  const iv = crypto.randomBytes(12)
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv)
+  const ct = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()])
+  const tag = cipher.getAuthTag()
+  return `${PREFIX}${iv.toString("base64")}.${tag.toString("base64")}.${ct.toString("base64")}`
+}
+
+export function decryptSecret(stored: string | null | undefined): string {
+  if (stored == null || stored === "") return ""
+  if (!stored.startsWith(PREFIX)) return stored // legacy plaintext / unencrypted
+  const key = resolveKey()
+  if (!key) {
+    throw new Error(
+      "[faire-sync] Encrypted Faire token found but no ENCRYPTION_KEY/FAIRE_TOKEN_ENCRYPTION_KEY is set to decrypt it."
+    )
+  }
+  const [ivB64, tagB64, ctB64] = stored.slice(PREFIX.length).split(".")
+  const iv = Buffer.from(ivB64, "base64")
+  const tag = Buffer.from(tagB64, "base64")
+  const ct = Buffer.from(ctB64, "base64")
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv)
+  decipher.setAuthTag(tag)
+  return Buffer.concat([decipher.update(ct), decipher.final()]).toString("utf8")
+}
+
+/** True if the stored value is in the encrypted envelope format. */
+export function isEncrypted(stored: string | null | undefined): boolean {
+  return typeof stored === "string" && stored.startsWith(PREFIX)
+}

--- a/packages/medusa-plugin-faire-store-sync/src/lib/faire-client.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/lib/faire-client.ts
@@ -130,6 +130,30 @@ export class FaireClient {
     }
   }
 
+  /**
+   * Revoke an OAuth access token on Faire's side.
+   *
+   * Faire allows only ONE active OAuth token per (app, brand); without revoking,
+   * a reconnect fails with 400 "Application is already installed via an active
+   * OAuth access token". Non-RFC-6749 body (matches the token endpoint), posted
+   * to `/api/external-api-oauth2/revoke`, no auth header.
+   */
+  async revokeToken(accessToken: string): Promise<void> {
+    if (!accessToken) return
+    const revokeUrl = this.tokenUrl.replace(/\/token$/, "/revoke")
+    const body = {
+      application_token: this.clientId,
+      application_secret: this.clientSecret,
+      access_token_o_auth: accessToken,
+    }
+    await this.requestJson<any>(revokeUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      auth: false,
+    })
+  }
+
   async refreshAccessToken(refresh_token: string): Promise<TokenData> {
     const body = {
       application_token: this.clientId,

--- a/packages/medusa-plugin-faire-store-sync/src/modules/faire-sync/service.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/modules/faire-sync/service.ts
@@ -6,6 +6,7 @@ import FaireSyncBatch from "./models/faire-sync-batch"
 import FaireWebhookEvent from "./models/faire-webhook-event"
 import FaireOrder from "./models/faire-order"
 import { FaireClient } from "../../lib/faire-client"
+import { encryptSecret, decryptSecret } from "../../lib/crypto"
 import { FairePluginOptions, BrandInfo, TokenData } from "../../lib/types"
 
 type ModuleOptions = FairePluginOptions & Record<string, any>
@@ -31,6 +32,12 @@ function toMedusaError(err: any): MedusaError {
     return new MedusaError(
       MedusaError.Types.INVALID_DATA,
       "Faire authorization expired or was already used. Please reconnect."
+    )
+  }
+  if (/already installed/i.test(message)) {
+    return new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "This Faire app already has an active connection. Disconnect it here first, or uninstall the app from your Faire account (Settings → Apps), then connect again."
     )
   }
   if (/brand/i.test(message) && /(no|not|own)/i.test(message)) {
@@ -105,6 +112,24 @@ class FaireSyncService extends MedusaService({
     return account ?? null
   }
 
+  /**
+   * Return a shallow copy of an account with its at-rest secrets decrypted, for
+   * use when calling the Faire API. Tokens are stored encrypted (AES-256-GCM);
+   * callers that make API requests must go through this / `ensureFreshToken`.
+   */
+  private withDecryptedTokens<T extends { access_token?: any; refresh_token?: any }>(
+    account: T | null
+  ): T | null {
+    if (!account) return account
+    return {
+      ...account,
+      access_token: decryptSecret(account.access_token),
+      refresh_token: account.refresh_token
+        ? decryptSecret(account.refresh_token)
+        : account.refresh_token,
+    }
+  }
+
   async saveAccount(token: TokenData, brand: BrandInfo) {
     const existing = await this.getActiveAccount()
     const expiresAt =
@@ -116,8 +141,8 @@ class FaireSyncService extends MedusaService({
       brand_name: brand.brand_name,
       currency: brand.currency ?? null,
       country: brand.country ?? null,
-      access_token: token.access_token,
-      refresh_token: token.refresh_token ?? null,
+      access_token: encryptSecret(token.access_token),
+      refresh_token: encryptSecret(token.refresh_token ?? null),
       token_expires_at: expiresAt,
       brand_info: brand.raw,
       is_active: true,
@@ -134,6 +159,22 @@ class FaireSyncService extends MedusaService({
   async disconnect() {
     const account = await this.getActiveAccount()
     if (!account) return
+    // Revoke on Faire's side FIRST. Faire allows only one active OAuth token per
+    // (app, brand); if we only clear locally, a later reconnect fails with 400
+    // "Application is already installed via an active OAuth access token".
+    // Best-effort: a failed revoke must not block local disconnect.
+    try {
+      const accessToken = decryptSecret((account as any).access_token)
+      if (accessToken && this.options_.authMode !== "apiKey") {
+        await this.getClient().revokeToken(accessToken)
+      }
+    } catch (err: any) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[faire-sync] Faire token revoke failed on disconnect (clearing locally anyway):",
+        err?.message
+      )
+    }
     await this.updateFaireSyncAccounts({
       id: account.id,
       is_active: false,
@@ -142,6 +183,11 @@ class FaireSyncService extends MedusaService({
     } as any)
   }
 
+  /**
+   * Resolve an account whose access/refresh tokens are DECRYPTED and non-expired,
+   * refreshing against Faire if needed. All Faire API callers must use this — the
+   * tokens are stored encrypted at rest, so a raw account row is unusable.
+   */
   async ensureFreshToken(account?: any) {
     const acct = account ?? (await this.getActiveAccount())
     if (!acct) {
@@ -151,15 +197,16 @@ class FaireSyncService extends MedusaService({
       )
     }
     if (!acct.token_expires_at) {
-      return acct
+      return this.withDecryptedTokens(acct)
     }
     const now = Date.now()
     const expiresAt = new Date(acct.token_expires_at).getTime()
     const fiveMinutes = 5 * 60 * 1000
     if (expiresAt - now > fiveMinutes) {
-      return acct
+      return this.withDecryptedTokens(acct)
     }
-    if (!acct.refresh_token) {
+    const refreshToken = acct.refresh_token ? decryptSecret(acct.refresh_token) : ""
+    if (!refreshToken) {
       throw new MedusaError(
         MedusaError.Types.NOT_ALLOWED,
         "Faire access token has expired. Please reconnect your Faire account."
@@ -167,16 +214,17 @@ class FaireSyncService extends MedusaService({
     }
     try {
       const client = this.getClient()
-      const token = await client.refreshAccessToken(acct.refresh_token)
-      return this.updateFaireSyncAccounts({
+      const token = await client.refreshAccessToken(refreshToken)
+      const updated = await this.updateFaireSyncAccounts({
         id: acct.id,
-        access_token: token.access_token,
-        refresh_token: token.refresh_token ?? acct.refresh_token,
+        access_token: encryptSecret(token.access_token),
+        refresh_token: encryptSecret(token.refresh_token ?? refreshToken),
         token_expires_at:
           token.expires_in != null
             ? new Date(token.retrieved_at + token.expires_in * 1000)
             : null,
       } as any)
+      return this.withDecryptedTokens(updated)
     } catch (err) {
       throw toMedusaError(err)
     }


### PR DESCRIPTION
Three fixes surfaced during local OAuth testing. Bumps the plugin to **0.2.3** → merges to `main` publish it to npm via `publish-faire-plugin.yml`.

### 1. Revoke on disconnect (the "already installed" trap)
Faire allows only **one active OAuth token per (app, brand)**. `disconnect()` cleared the token *locally only*, stranding it on Faire's side → reconnect failed with `400 "Application is already installed via an active OAuth access token"`.
- New `FaireClient.revokeToken()` → `POST /api/external-api-oauth2/revoke` (verified body shape), called from `disconnect()` **before** clearing locally (best-effort).
- That 400 now maps to a clear message: *"Disconnect here first, or uninstall the app from your Faire account (Settings → Apps), then connect again."*

### 2. Encrypt tokens at rest
- New `src/lib/crypto.ts` — AES-256-GCM, mirroring the host app's `encryption` module, reusing `ENCRYPTION_KEY` (or `FAIRE_TOKEN_ENCRYPTION_KEY`).
- Encrypted in `saveAccount` + refresh path; decrypted only at the `ensureFreshToken` seam.
- Self-describing `fenc1:` envelope in the existing text column — **no migration**, legacy plaintext rows still read, degrades to plaintext-with-warning if no key set.

### 3. Bulk ops moved into the RouteFocusModal
- Removed the inline "Bulk operations" card from the settings page (also fixed a latent crash — it referenced `navigate` out of scope).
- Settings header gets a **"Bulk sync"** button → opens `/settings/faire/bulk`.
- Order-pull moved into that modal's footer, so product-push + order-pull both live in the modal.

15/15 unit tests pass; full plugin build (incl. admin) compiles clean.

> Note: switched off local yalc back to npm consumption — the pnpm+yalc flat-copy conflict wasn't worth fighting. After 0.2.3 lands, `apps/backend` picks it up via `pnpm update @jytextiles/medusa-plugin-faire-store-sync --latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)