### PR TITLE
feat(faire): per-account auth mode + API-key connect UI — 0.2.5 (#937)

### DIFF
--- a/packages/medusa-plugin-faire-store-sync/package.json
+++ b/packages/medusa-plugin-faire-store-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jytextiles/medusa-plugin-faire-store-sync",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/packages/medusa-plugin-faire-store-sync/src/admin/routes/settings/faire/page.tsx
+++ b/packages/medusa-plugin-faire-store-sync/src/admin/routes/settings/faire/page.tsx
@@ -1,5 +1,5 @@
 import { defineRouteConfig } from "@medusajs/admin-sdk"
-import { BuildingStorefront } from "@medusajs/icons"
+import { BuildingStorefront, ChevronDownMini } from "@medusajs/icons"
 import {
   Alert,
   Button,
@@ -7,7 +7,10 @@ import {
   DataTable,
   DataTableFilteringState,
   DataTablePaginationState,
+  Drawer,
+  DropdownMenu,
   Heading,
+  Input,
   Label,
   Skeleton,
   StatusBadge,
@@ -53,6 +56,8 @@ const FaireSettingsPage = () => {
     pageSize: PAGE_SIZE,
   })
   const [filtering, setFiltering] = useState<DataTableFilteringState>({})
+  const [apiKeyOpen, setApiKeyOpen] = useState(false)
+  const [apiKey, setApiKey] = useState("")
 
   // ── Queries ───────────────────────────────────────────────────────────────
   const statusQuery = useQuery({
@@ -87,6 +92,20 @@ const FaireSettingsPage = () => {
     },
     onError: (err: any) =>
       toast.error("Failed to start Faire authorization", {
+        description: err.message,
+      }),
+  })
+
+  const apiKeyMutation = useMutation({
+    mutationFn: () => faireApi.connectApiKey(apiKey.trim()),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: STATUS_KEY })
+      setApiKeyOpen(false)
+      setApiKey("")
+      toast.success("Connected to Faire with API key")
+    },
+    onError: (err: any) =>
+      toast.error("Failed to connect with API key", {
         description: err.message,
       }),
   })
@@ -211,13 +230,22 @@ const FaireSettingsPage = () => {
               </Button>
             </div>
           ) : (
-            <Button
-              size="small"
-              onClick={() => connectMutation.mutate()}
-              isLoading={connectMutation.isPending}
-            >
-              Connect Faire
-            </Button>
+            <DropdownMenu>
+              <DropdownMenu.Trigger asChild>
+                <Button size="small" isLoading={connectMutation.isPending}>
+                  Connect Faire
+                  <ChevronDownMini />
+                </Button>
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Content>
+                <DropdownMenu.Item onClick={() => connectMutation.mutate()}>
+                  Connect with OAuth
+                </DropdownMenu.Item>
+                <DropdownMenu.Item onClick={() => setApiKeyOpen(true)}>
+                  Connect with API key (private)
+                </DropdownMenu.Item>
+              </DropdownMenu.Content>
+            </DropdownMenu>
           )}
         </div>
         {connected && status?.account && (
@@ -263,6 +291,48 @@ const FaireSettingsPage = () => {
           <DataTable.Pagination />
         </DataTable>
       </Container>
+
+      {/* API-key connect (private integrations) */}
+      <Drawer open={apiKeyOpen} onOpenChange={setApiKeyOpen}>
+        <Drawer.Content>
+          <Drawer.Header>
+            <Drawer.Title>Connect with API key</Drawer.Title>
+          </Drawer.Header>
+          <Drawer.Body className="flex flex-col gap-y-3">
+            <Text className="text-ui-fg-subtle" size="small">
+              For private / unpublished Faire integrations, paste the API key
+              your Faire brand issued for this app. This connects without OAuth.
+            </Text>
+            <div className="flex flex-col gap-y-1">
+              <Label size="small">Faire API key</Label>
+              <Input
+                type="password"
+                placeholder="Paste the Faire API key…"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                autoComplete="off"
+              />
+            </div>
+          </Drawer.Body>
+          <Drawer.Footer>
+            <Button
+              variant="secondary"
+              size="small"
+              onClick={() => setApiKeyOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="small"
+              onClick={() => apiKeyMutation.mutate()}
+              isLoading={apiKeyMutation.isPending}
+              disabled={!apiKey.trim()}
+            >
+              Connect
+            </Button>
+          </Drawer.Footer>
+        </Drawer.Content>
+      </Drawer>
 
       <Toaster />
     </div>

--- a/packages/medusa-plugin-faire-store-sync/src/modules/faire-sync/migrations/.snapshot-medusa-faire-sync.json
+++ b/packages/medusa-plugin-faire-store-sync/src/modules/faire-sync/migrations/.snapshot-medusa-faire-sync.json
@@ -301,6 +301,25 @@
           "enumItems": [],
           "mappedType": "text"
         },
+        "auth_mode": {
+          "name": "auth_mode",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "'oauth'",
+          "comment": null,
+          "enumItems": [
+            "oauth",
+            "apiKey"
+          ],
+          "mappedType": "enum"
+        },
         "access_token": {
           "name": "access_token",
           "type": "text",

--- a/packages/medusa-plugin-faire-store-sync/src/modules/faire-sync/migrations/Migration20260709161201.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/modules/faire-sync/migrations/Migration20260709161201.ts
@@ -1,0 +1,13 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+export class Migration20260709161201 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "faire_sync_account" add column if not exists "auth_mode" text check ("auth_mode" in ('oauth', 'apiKey')) not null default 'oauth';`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "faire_sync_account" drop column if exists "auth_mode";`);
+  }
+
+}

--- a/packages/medusa-plugin-faire-store-sync/src/modules/faire-sync/models/faire-sync-account.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/modules/faire-sync/models/faire-sync-account.ts
@@ -6,6 +6,10 @@ const FaireSyncAccount = model.define("faire_sync_account", {
   brand_name: model.text(),
   currency: model.text().nullable(),
   country: model.text().nullable(),
+  // How this account authenticates to Faire: OAuth (published apps) or a
+  // brand-issued API key (private/single-merchant integrations). Drives which
+  // auth header the client sends, so both connection types can coexist.
+  auth_mode: model.enum(["oauth", "apiKey"]).default("oauth"),
   access_token: model.text(),
   refresh_token: model.text().nullable(),
   token_expires_at: model.dateTime().nullable(),

--- a/packages/medusa-plugin-faire-store-sync/src/modules/faire-sync/service.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/modules/faire-sync/service.ts
@@ -92,7 +92,15 @@ class FaireSyncService extends MedusaService({
     this.options_ = resolveFaireOptions(options)
   }
 
-  getClient(): FaireClient {
+  /**
+   * Build a Faire client. Pass `authModeOverride` (e.g. an account's `auth_mode`)
+   * to force the auth header for that connection type; without it, the plugin's
+   * configured default is used (cached).
+   */
+  getClient(authModeOverride?: "oauth" | "apiKey"): FaireClient {
+    if (authModeOverride) {
+      return new FaireClient({ ...this.options_, authMode: authModeOverride })
+    }
     if (!this.client_) {
       this.client_ = new FaireClient(this.options_)
     }
@@ -128,7 +136,11 @@ class FaireSyncService extends MedusaService({
     }
   }
 
-  async saveAccount(token: TokenData, brand: BrandInfo) {
+  async saveAccount(
+    token: TokenData,
+    brand: BrandInfo,
+    authMode: "oauth" | "apiKey" = "oauth"
+  ) {
     const existing = await this.getActiveAccount()
     const expiresAt =
       token.expires_in != null
@@ -139,6 +151,7 @@ class FaireSyncService extends MedusaService({
       brand_name: brand.brand_name,
       currency: brand.currency ?? null,
       country: brand.country ?? null,
+      auth_mode: authMode,
       access_token: encryptSecret(token.access_token),
       refresh_token: encryptSecret(token.refresh_token ?? null),
       token_expires_at: expiresAt,
@@ -163,8 +176,9 @@ class FaireSyncService extends MedusaService({
     // Best-effort: a failed revoke must not block local disconnect.
     try {
       const accessToken = decryptSecret((account as any).access_token)
-      if (accessToken && this.options_.authMode !== "apiKey") {
-        await this.getClient().revokeToken(accessToken)
+      // Only OAuth tokens are revocable; a brand-issued API key is not.
+      if (accessToken && (account as any).auth_mode !== "apiKey") {
+        await this.getClient("oauth").revokeToken(accessToken)
       }
     } catch (err: any) {
       // eslint-disable-next-line no-console
@@ -254,12 +268,8 @@ class FaireSyncService extends MedusaService({
   }
 
   async startOAuth(): Promise<{ authorization_url: string; state: string }> {
-    if (this.options_.authMode === "apiKey") {
-      throw new MedusaError(
-        MedusaError.Types.INVALID_DATA,
-        "Faire is configured in API-key mode — use /admin/faire/auth/api-key to connect, not OAuth."
-      )
-    }
+    // Both connection types are available per-account, so OAuth is always
+    // offered here; the API-key path is a separate entry point.
     try {
       const state = crypto.randomUUID()
       await this.updateSettings({
@@ -268,7 +278,7 @@ class FaireSyncService extends MedusaService({
           created_at: Date.now(),
         },
       })
-      const client = this.getClient()
+      const client = this.getClient("oauth")
       return {
         authorization_url: client.getAuthorizationUrl(state),
         state,
@@ -290,14 +300,16 @@ class FaireSyncService extends MedusaService({
       )
     }
     try {
-      const client = this.getClient()
+      // Force API-key auth (X-FAIRE-ACCESS-TOKEN) for this connection regardless
+      // of the plugin's default mode, and persist it so later API calls use it.
+      const client = this.getClient("apiKey")
       const brand = await client.getBrand(accessToken)
       const token: TokenData = {
         access_token: accessToken,
         token_type: "Bearer",
         retrieved_at: Date.now(),
       }
-      const account = await this.saveAccount(token, brand)
+      const account = await this.saveAccount(token, brand, "apiKey")
       await this.updateSettings({
         account_id: account.id,
         default_brand_id: brand.brand_id,
@@ -323,7 +335,7 @@ class FaireSyncService extends MedusaService({
       const client = this.getClient()
       token = await client.exchangeCodeForToken(code)
       const brand = await client.getBrand(token.access_token)
-      const account = await this.saveAccount(token, brand)
+      const account = await this.saveAccount(token, brand, "oauth")
       await this.updateSettings({
         account_id: account.id,
         default_brand_id: brand.brand_id,

--- a/packages/medusa-plugin-faire-store-sync/src/workflows/ingest-faire-orders-bulk.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/workflows/ingest-faire-orders-bulk.ts
@@ -70,7 +70,7 @@ const processBatchStep = createStep(
   ): Promise<StepResponse<{ synced: number; failed: number }>> => {
     const service: FaireSyncService = container.resolve(FAIRE_SYNC_MODULE)
     const account = await service.ensureFreshToken()
-    const client = service.getClient()
+    const client = service.getClient((account as any).auth_mode)
 
     // Resolve the incremental window. Precedence:
     //   explicit input > persisted high-water mark > full backfill (undefined).

--- a/packages/medusa-plugin-faire-store-sync/src/workflows/sync-product-to-faire.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/workflows/sync-product-to-faire.ts
@@ -26,6 +26,7 @@ type ResolvedConfig = {
   account_id: string
   brand_id: string
   access_token: string
+  auth_mode: "oauth" | "apiKey"
   currency: string | null
   settings: any
 }
@@ -66,6 +67,7 @@ const resolveFaireConfigStep = createStep(
       account_id: account.id,
       brand_id: account.brand_id,
       access_token: account.access_token,
+      auth_mode: (account.auth_mode as "oauth" | "apiKey") ?? "oauth",
       currency: account.currency ?? null,
       settings,
     })
@@ -211,7 +213,7 @@ const syncProductStep = createStep(
     { container }
   ): Promise<StepResponse<SyncResult>> => {
     const service: FaireSyncService = container.resolve(FAIRE_SYNC_MODULE)
-    const client = service.getClient()
+    const client = service.getClient(input.config.auth_mode)
     const { access_token, settings } = input.config
     const { product_input, existing_product_token, product_status } =
       input.prepared


### PR DESCRIPTION
Adds a **Connect** dropdown offering **OAuth** (published apps) or **API key** (private/unpublished integrations), and makes the auth mode **per-account** so both coexist and you can switch later (e.g. API-key now → OAuth once the app is published) without breaking a stored connection. Bumps to **0.2.5** → CI publishes on merge.

### Why
An unpublished Faire app isn't in the brand portal's Integrations list and uses Faire's **API-key** path (not OAuth) — so OAuth returns "Application is already installed" and there's nothing to disconnect. API-key connect sidesteps that entirely.

### Changes
- **Model:** `auth_mode` (`'oauth' | 'apiKey'`, default `oauth`) on `faire_sync_account` + migration. The client's auth header is now driven per-account, not by a global `FAIRE_AUTH_MODE`.
- **Service:** `getClient(authModeOverride?)`; `saveAccount` persists the mode; `connectWithApiKey` forces `apiKey` and stores it; `completeOAuth` stores `oauth`; `disconnect` only revokes OAuth tokens (API keys aren't revocable); `startOAuth` no longer gated on a global mode.
- **Workflows:** product-sync + bulk-order-pull build the client from the account's `auth_mode`.
- **Admin UI:** Connect → `DropdownMenu` with "Connect with OAuth" / "Connect with API key (private)"; the API-key item opens a `Drawer` to paste the key (wired to the existing `/admin/faire/auth/api-key`).

15/15 tests pass; full build (incl. admin) clean.

> After merge + CI publish: `cd apps/backend && pnpm update @jytextiles/medusa-plugin-faire-store-sync --latest && medusa db:migrate`, then use **Connect → Connect with API key**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)