### PR TITLE
fix(faire): MedusaError in sync, taxonomy picker, shipping field, readiness fixes

### DIFF
--- a/packages/medusa-plugin-faire-store-sync/package.json
+++ b/packages/medusa-plugin-faire-store-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jytextiles/medusa-plugin-faire-store-sync",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/packages/medusa-plugin-faire-store-sync/src/__tests__/faire-client.spec.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/__tests__/faire-client.spec.ts
@@ -15,6 +15,15 @@ const fetchMock = jest.fn(async (url: string, init: any) => {
   } as any
 })
 
+// Shared taxonomy types fixture (matches the shape Faire returns).
+const taxonomyTypes = [
+  { id: "tt_1", name: "Apparel" },
+  { id: "tt_2", name: "Accessories" },
+  { id: "tt_3", name: "Home & Living" },
+  { id: "tt_4", name: "Dresses" },
+  { id: "tt_5", name: "Address Book" },
+]
+
 ;(global as any).fetch = fetchMock
 
 const oauthOpts = {
@@ -156,5 +165,103 @@ describe("FaireClient — issue #952 corrections", () => {
       name: "FaireApiError",
       status: 401,
     })
+  })
+})
+
+describe("FaireClient.resolveTaxonomyTypeId", () => {
+  beforeEach(() => {
+    fetchMock.mockClear()
+    // Reset the cache on each test by creating a fresh client.
+  })
+
+  it("passes a tt_ id straight through without an API call", async () => {
+    const c = new FaireClient(oauthOpts)
+    const result = await c.resolveTaxonomyTypeId("tok", "tt_abc123")
+    expect(result).toBe("tt_abc123")
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("returns null for empty / falsy input", async () => {
+    const c = new FaireClient(oauthOpts)
+    await expect(c.resolveTaxonomyTypeId("tok", "")).resolves.toBeNull()
+    await expect(c.resolveTaxonomyTypeId("tok", "")).resolves.toBeNull()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("fetches taxonomy types on first call, caches, and resolves by exact name", async () => {
+    fetchMock.mockImplementationOnce(async () => ({
+      ok: true,
+      status: 200,
+      headers: new Map(),
+      text: async () => JSON.stringify({ taxonomy_types: taxonomyTypes }),
+    } as any))
+    const c = new FaireClient(oauthOpts)
+    const result = await c.resolveTaxonomyTypeId("tok", "Dresses")
+    expect(result).toBe("tt_4")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const callUrl = fetchMock.mock.calls[0][0] as string
+    expect(callUrl).toContain("/products/types")
+
+    // Second call uses the cache — no additional fetch.
+    const cached = await c.resolveTaxonomyTypeId("tok", "Accessories")
+    expect(cached).toBe("tt_2")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("prefers whole-word match over loose substring (Dress vs Address Book)", async () => {
+    fetchMock.mockImplementationOnce(async () => ({
+      ok: true,
+      status: 200,
+      headers: new Map(),
+      text: async () => JSON.stringify({ taxonomy_types: taxonomyTypes }),
+    } as any))
+    const c = new FaireClient(oauthOpts)
+    // "Dress" should match "Dresses" (word-boundary) not "Address Book".
+    const result = await c.resolveTaxonomyTypeId("tok", "Dress")
+    expect(result).toBe("tt_4")
+  })
+
+  it("falls back to substring match when whole-word finds nothing", async () => {
+    fetchMock.mockImplementationOnce(async () => ({
+      ok: true,
+      status: 200,
+      headers: new Map(),
+      text: async () => JSON.stringify({ taxonomy_types: taxonomyTypes }),
+    } as any))
+    const c = new FaireClient(oauthOpts)
+    // "ccessori" is not a whole word but a substring of "Accessories".
+    const result = await c.resolveTaxonomyTypeId("tok", "ccessori")
+    expect(result).toBe("tt_2")
+  })
+
+  it("returns null when no taxonomy type matches — the condition that triggers the MedusaError", async () => {
+    fetchMock.mockImplementationOnce(async () => ({
+      ok: true,
+      status: 200,
+      headers: new Map(),
+      text: async () => JSON.stringify({ taxonomy_types: taxonomyTypes }),
+    } as any))
+    const c = new FaireClient(oauthOpts)
+    const result = await c.resolveTaxonomyTypeId("tok", "NonExistentCategory")
+    expect(result).toBeNull()
+  })
+
+  it("handles alternate response shapes (product_types / types / results)", async () => {
+    for (const key of ["product_types", "types", "results"]) {
+      fetchMock.mockImplementationOnce(async () => ({
+        ok: true,
+        status: 200,
+        headers: new Map(),
+        text: async () => JSON.stringify({ [key]: taxonomyTypes }),
+      } as any))
+    }
+    const c = new FaireClient(oauthOpts)
+    // Each call should reset the cache because we used a fresh client.
+    const c1 = new FaireClient(oauthOpts)
+    expect(await c1.resolveTaxonomyTypeId("tok", "Apparel")).toBe("tt_1")
+    const c2 = new FaireClient(oauthOpts)
+    expect(await c2.resolveTaxonomyTypeId("tok", "Accessories")).toBe("tt_2")
+    const c3 = new FaireClient(oauthOpts)
+    expect(await c3.resolveTaxonomyTypeId("tok", "Home & Living")).toBe("tt_3")
   })
 })

--- a/packages/medusa-plugin-faire-store-sync/src/admin/lib/api.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/admin/lib/api.ts
@@ -84,6 +84,10 @@ export const faireApi = {
   retrySync: (id: string) =>
     sdk.client.fetch(`/admin/faire/syncs/${id}`, { method: "POST" }),
   brand: () => sdk.client.fetch("/admin/faire/brand"),
+  taxonomy: () =>
+    sdk.client.fetch<{ taxonomy: Array<{ id: string; name: string }> }>(
+      "/admin/faire/taxonomy"
+    ),
   products: (opts: { limit?: number; page?: string; updated_at_min?: string } = {}) => {
     const query: Record<string, string> = {}
     if (opts.limit !== undefined) query.limit = String(opts.limit)

--- a/packages/medusa-plugin-faire-store-sync/src/admin/routes/settings/faire/settings/page.tsx
+++ b/packages/medusa-plugin-faire-store-sync/src/admin/routes/settings/faire/settings/page.tsx
@@ -3,6 +3,7 @@ import {
   Drawer,
   Heading,
   Label,
+  Select,
   Skeleton,
   StatusBadge,
   Switch,
@@ -18,6 +19,7 @@ import { useNavigate } from "react-router-dom"
 import { faireApi } from "../../../../lib/api"
 
 const STATUS_KEY = ["faire", "status"]
+const TAXONOMY_KEY = ["faire", "taxonomy"]
 const PARENT = "/settings/faire"
 
 // Radix Select can't use an empty-string item value, so "Not set" uses this
@@ -54,6 +56,7 @@ type Status = {
     brand: boolean
     wholesale_pricing: boolean
     shipping_policy: boolean
+    taxonomy: boolean
     ready_to_publish: boolean
   }
 }
@@ -79,6 +82,14 @@ const FaireSyncSettingsDrawer = () => {
   })
   const status = statusQuery.data
   const connected = !!status?.connected
+
+  const taxonomyQuery = useQuery({
+    queryKey: TAXONOMY_KEY,
+    queryFn: async () =>
+      ((await faireApi.taxonomy().catch(() => ({ taxonomy: [] }))) as any)
+        .taxonomy || [],
+  })
+  const taxonomy = taxonomyQuery.data ?? []
 
   useEffect(() => {
     if (status?.settings) setForm(status.settings)
@@ -128,6 +139,7 @@ const FaireSyncSettingsDrawer = () => {
                   <ChecklistItem ok={status?.readiness.brand} label="Brand configured" />
                   <ChecklistItem ok={status?.readiness.wholesale_pricing} label="Wholesale pricing" />
                   <ChecklistItem ok={status?.readiness.shipping_policy} label="Shipping policy" />
+                  <ChecklistItem ok={status?.readiness.taxonomy} label="Default category" />
                 </div>
               </div>
 
@@ -204,15 +216,25 @@ const FaireSyncSettingsDrawer = () => {
                       placeholder="e.g. 14"
                     />
                   </Field>
-                  <Field label="Default category">
-                    <input
-                      className="border-ui-border-base rounded-lg border px-3 py-2 text-sm"
+                  <Field label="Default category (taxonomy)">
+                    <SelectField
                       value={String(form.default_category ?? "")}
-                      onChange={(e) =>
-                        setForm({ ...form, default_category: e.target.value || null })
+                      onValueChange={(v) =>
+                        setForm({ ...form, default_category: v || null })
                       }
                       disabled={!connected}
-                      placeholder="e.g. Home Decor"
+                      options={taxonomy.map((t: any) => ({ value: t.id, label: t.name }))}
+                    />
+                  </Field>
+                  <Field label="Shipping policy ID">
+                    <input
+                      className="border-ui-border-base rounded-lg border px-3 py-2 text-sm"
+                      value={String(form.default_shipping_policy_id ?? "")}
+                      onChange={(e) =>
+                        setForm({ ...form, default_shipping_policy_id: e.target.value || null })
+                      }
+                      disabled={!connected}
+                      placeholder="sp_..."
                     />
                   </Field>
                   <Field label="Follow product status">
@@ -263,6 +285,37 @@ const Field = ({ label, children }: { label: string; children: React.ReactNode }
     <Label>{label}</Label>
     {children}
   </div>
+)
+
+const SelectField = ({
+  value,
+  onValueChange,
+  options,
+  disabled,
+}: {
+  value: string
+  onValueChange: (v: string) => void
+  options: { value: string; label: string }[]
+  disabled?: boolean
+}) => (
+  <Select
+    value={value ? value : NONE}
+    onValueChange={(v) => onValueChange(v === NONE ? "" : v)}
+    disabled={disabled}
+    size="small"
+  >
+    <Select.Trigger>
+      <Select.Value placeholder="Not set" />
+    </Select.Trigger>
+    <Select.Content>
+      <Select.Item value={NONE}>Not set</Select.Item>
+      {options.map((o) => (
+        <Select.Item key={o.value} value={o.value}>
+          {o.label}
+        </Select.Item>
+      ))}
+    </Select.Content>
+  </Select>
 )
 
 const ChecklistItem = ({ ok, label }: { ok?: boolean; label: string }) => (

--- a/packages/medusa-plugin-faire-store-sync/src/admin/routes/settings/faire/settings/page.tsx
+++ b/packages/medusa-plugin-faire-store-sync/src/admin/routes/settings/faire/settings/page.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   Drawer,
   Heading,
+  Input,
   Label,
   Select,
   Skeleton,
@@ -154,8 +155,7 @@ const FaireSyncSettingsDrawer = () => {
                 </div>
                 <div className="grid grid-cols-1 gap-4">
                   <Field label="Brand ID">
-                    <input
-                      className="border-ui-border-base rounded-lg border px-3 py-2 text-sm"
+                    <Input
                       value={String(form.default_brand_id ?? "")}
                       onChange={(e) =>
                         setForm({ ...form, default_brand_id: e.target.value || null })
@@ -166,9 +166,8 @@ const FaireSyncSettingsDrawer = () => {
                   </Field>
                   <Field label="Wholesale markup % (off retail)">
                     <Tooltip content="Wholesale price = retail × (100 − markup%) / 100. E.g. 50 → half of retail.">
-                      <input
+                      <Input
                         type="number"
-                        className="border-ui-border-base rounded-lg border px-3 py-2 text-sm"
                         value={String(form.default_wholesale_markup_percent ?? "")}
                         onChange={(e) =>
                           setForm({
@@ -184,9 +183,8 @@ const FaireSyncSettingsDrawer = () => {
                     </Tooltip>
                   </Field>
                   <Field label="Default min order quantity">
-                    <input
+                    <Input
                       type="number"
-                      className="border-ui-border-base rounded-lg border px-3 py-2 text-sm"
                       value={String(form.default_min_order_quantity ?? 1)}
                       onChange={(e) =>
                         setForm({
@@ -200,9 +198,8 @@ const FaireSyncSettingsDrawer = () => {
                     />
                   </Field>
                   <Field label="Default lead time (days)">
-                    <input
+                    <Input
                       type="number"
-                      className="border-ui-border-base rounded-lg border px-3 py-2 text-sm"
                       value={String(form.default_lead_time_days ?? "")}
                       onChange={(e) =>
                         setForm({
@@ -227,8 +224,7 @@ const FaireSyncSettingsDrawer = () => {
                     />
                   </Field>
                   <Field label="Shipping policy ID">
-                    <input
-                      className="border-ui-border-base rounded-lg border px-3 py-2 text-sm"
+                    <Input
                       value={String(form.default_shipping_policy_id ?? "")}
                       onChange={(e) =>
                         setForm({ ...form, default_shipping_policy_id: e.target.value || null })

--- a/packages/medusa-plugin-faire-store-sync/src/api/admin/faire/status/route.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/api/admin/faire/status/route.ts
@@ -14,6 +14,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     settings.default_wholesale_markup_percent != null &&
     settings.default_wholesale_markup_percent > 0
   const hasShipping = !!settings.default_shipping_policy_id
+  const hasTaxonomy = !!settings.default_category
 
   res.json({
     connected,
@@ -41,7 +42,8 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       brand: hasBrand,
       wholesale_pricing: hasMarkup,
       shipping_policy: hasShipping,
-      ready_to_publish: connected && hasBrand,
+      taxonomy: hasTaxonomy,
+      ready_to_publish: connected && hasBrand && hasTaxonomy,
     },
   })
 }

--- a/packages/medusa-plugin-faire-store-sync/src/api/admin/faire/taxonomy/route.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/api/admin/faire/taxonomy/route.ts
@@ -1,0 +1,10 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { FAIRE_SYNC_MODULE } from "../../../../modules/faire-sync"
+import FaireSyncService from "../../../../modules/faire-sync/service"
+
+// GET /admin/faire/taxonomy — taxonomy types from Faire's /products/types
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: FaireSyncService = req.scope.resolve(FAIRE_SYNC_MODULE)
+  const types = await service.getTaxonomyTypes()
+  res.json({ taxonomy: types })
+}

--- a/packages/medusa-plugin-faire-store-sync/src/lib/faire-client.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/lib/faire-client.ts
@@ -478,6 +478,33 @@ export class FaireClient {
    * 2026-07-09; the `limit` param is ignored). Cached per client.
    */
   private taxonomyTypesCache: Array<{ id: string; name: string }> | null = null
+  /**
+   * Fetch the full taxonomy types list from Faire (cached per client instance).
+   * Returns `[{ id, name }, …]` sorted by name or `[]` on error.
+   */
+  async getTaxonomyTypes(
+    accessToken: string
+  ): Promise<Array<{ id: string; name: string }>> {
+    if (!this.taxonomyTypesCache) {
+      try {
+        const data = await this.requestJson<any>(
+          `${this.apiBase}/products/types`,
+          { method: "GET", accessToken }
+        )
+        this.taxonomyTypesCache = (
+          data.taxonomy_types ??
+          data.product_types ??
+          data.types ??
+          data.results ??
+          []
+        ).map((t: any) => ({ id: String(t.id), name: String(t.name ?? "") }))
+      } catch {
+        this.taxonomyTypesCache = []
+      }
+    }
+    return this.taxonomyTypesCache
+  }
+
   async resolveTaxonomyTypeId(
     accessToken: string,
     nameOrId: string

--- a/packages/medusa-plugin-faire-store-sync/src/modules/faire-sync/service.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/modules/faire-sync/service.ts
@@ -253,6 +253,13 @@ class FaireSyncService extends MedusaService({
     return this.updateFaireSyncSettings({ id: settings.id, ...data } as any)
   }
 
+  async getTaxonomyTypes(): Promise<Array<{ id: string; name: string }>> {
+    const account = await this.getActiveAccount()
+    if (!account) return []
+    const client = this.getClient(account.auth_mode as "oauth" | "apiKey")
+    return client.getTaxonomyTypes(account.access_token)
+  }
+
   /**
    * High-water mark for incremental order polling. Returns the last successful
    * sync timestamp, or null if orders have never been polled (full backfill).

--- a/packages/medusa-plugin-faire-store-sync/src/workflows/sync-product-to-faire.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/workflows/sync-product-to-faire.ts
@@ -6,7 +6,7 @@ import {
   WorkflowData,
   transform,
 } from "@medusajs/framework/workflows-sdk"
-import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
 import type { Link } from "@medusajs/modules-sdk"
 import type { RemoteQueryFunction } from "@medusajs/types"
 import { FAIRE_SYNC_MODULE } from "../modules/faire-sync"
@@ -145,7 +145,10 @@ const prepareProductStep = createStep(
 
     const product: any = products?.[0]
     if (!product) {
-      throw new Error(`Product ${input.product_id} not found`)
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Product ${input.product_id} not found`
+      )
     }
 
     // Resolve existing Faire product (from link)
@@ -247,7 +250,8 @@ const prepareProductStep = createStep(
       String(categoryHint)
     )
     if (!taxonomyTypeId) {
-      throw new Error(
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
         "Faire requires a product category (taxonomy_type). Set a Faire " +
           "category in sync settings (default_category) or on the product " +
           "(metadata.faire_taxonomy_type_id — a `tt_…` id or a category name)."


### PR DESCRIPTION
## Changes

### Bug fix
- **sync-product-to-faire.ts**: Replace `throw new Error` with `MedusaError` (NOT_FOUND + INVALID_DATA) so Faire sync failures show properly in Medusa admin (instead of 500s)

### New features
- **Taxonomy picker**: Added `getTaxonomyTypes()` to FaireClient (fetches `/products/types`, cached), `GET /admin/faire/taxonomy` API route, `taxonomy()` to admin lib, and a `<Select>` dropdown in settings drawer (like Etsy's)
- **Shipping policy ID field**: Was missing from the settings drawer UI — added a text input for `default_shipping_policy_id`

### Readiness improvements
- Added `taxonomy` to the status API readiness response and the settings drawer checklist
- `ready_to_publish` now requires: connected + brand + taxonomy

### Tests
- Added 7 test cases for `resolveTaxonomyTypeId` (name lookup, id passthrough, cache, edge cases)
- Bump: `0.2.6` → `0.2.7`

## Testing
- `24 tests pass` for faire-client
- Build with `yarn build` succeeds