### PR TITLE
feat(shipping): Carrier Select for Shiprocket/Delhivery across admin, partner, inventory-orders, order-fulfillment

### DIFF
--- a/apps/backend/integration-tests/http/inventory-order-shiprocket-shipment.spec.ts
+++ b/apps/backend/integration-tests/http/inventory-order-shiprocket-shipment.spec.ts
@@ -16,7 +16,7 @@ jest.setTimeout(60000);
  * body, so we can assert the exact payload the client would send.
  */
 setupSharedTestSuite(() => {
-  const { api, getContainer } = getSharedTestEnv();
+  const { api, getContainer, dbUtils } = getSharedTestEnv();
 
   let headers: any;
   let inventoryItemId: string;
@@ -26,6 +26,7 @@ setupSharedTestSuite(() => {
   let prevEmail: string | undefined;
   let prevPassword: string | undefined;
   let prevStub: string | undefined;
+  let prevDelhiveryToken: string | undefined;
 
   const TO_ADDRESS = {
     address_1: "9 Mill Rd",
@@ -40,9 +41,11 @@ setupSharedTestSuite(() => {
     prevEmail = process.env.SHIPROCKET_EMAIL;
     prevPassword = process.env.SHIPROCKET_PASSWORD;
     prevStub = process.env.SHIPROCKET_STUB;
+    prevDelhiveryToken = process.env.DELHIVERY_API_TOKEN;
     process.env.SHIPROCKET_EMAIL = "test@shiprocket.example";
     process.env.SHIPROCKET_PASSWORD = "secret";
     process.env.SHIPROCKET_STUB = "1";
+    process.env.DELHIVERY_API_TOKEN = "test-delhivery-token";
   });
 
   afterAll(() => {
@@ -52,6 +55,8 @@ setupSharedTestSuite(() => {
     else process.env.SHIPROCKET_PASSWORD = prevPassword;
     if (prevStub === undefined) delete process.env.SHIPROCKET_STUB;
     else process.env.SHIPROCKET_STUB = prevStub;
+    if (prevDelhiveryToken === undefined) delete process.env.DELHIVERY_API_TOKEN;
+    else process.env.DELHIVERY_API_TOKEN = prevDelhiveryToken;
   });
 
   beforeEach(async () => {
@@ -352,6 +357,56 @@ setupSharedTestSuite(() => {
         .catch((e: any) => e.response);
       expect(res.status).toBe(400);
       expect(res.data.message).toMatch(/has no pincode to quote pickup rates from/);
+    });
+
+    it("accepts ?carrier=shiprocket query param", async () => {
+      const id = await createShippableOrder();
+      const res = await api.get(
+        `/admin/inventory-orders/${id}/shiprocket-rates?carrier=shiprocket`,
+        headers
+      );
+      expect(res.status).toBe(200);
+      expect(res.data.origin_pincode).toBe("302001");
+      expect(Array.isArray(res.data.rates)).toBe(true);
+    });
+
+    it("rejects ?carrier=delhivery (no courier picker for Delhivery)", async () => {
+      const id = await createShippableOrder();
+      const res = await api.get(
+        `/admin/inventory-orders/${id}/shiprocket-rates?carrier=delhivery`,
+        { ...headers, validateStatus: () => true }
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("responds on the carrier-neutral fulfillment-rates alias route (#835)", async () => {
+      const id = await createShippableOrder();
+      const res = await api.get(
+        `/admin/inventory-orders/${id}/fulfillment-rates`,
+        headers
+      );
+      expect(res.status).toBe(200);
+      expect(res.data.origin_pincode).toBe("302001");
+      expect(Array.isArray(res.data.rates)).toBe(true);
+    });
+
+    it("fulfillment-rates alias honours ?carrier=shiprocket", async () => {
+      const id = await createShippableOrder();
+      const res = await api.get(
+        `/admin/inventory-orders/${id}/fulfillment-rates?carrier=shiprocket`,
+        headers
+      );
+      expect(res.status).toBe(200);
+      expect(res.data.rates.length).toBeGreaterThan(0);
+    });
+
+    it("fulfillment-rates alias rejects ?carrier=delhivery (no courier picker)", async () => {
+      const id = await createShippableOrder();
+      const res = await api.get(
+        `/admin/inventory-orders/${id}/fulfillment-rates?carrier=delhivery`,
+        { ...headers, validateStatus: () => true }
+      );
+      expect(res.status).toBe(400);
     });
   });
 

--- a/apps/backend/integration-tests/http/partner-order-shiprocket-label.spec.ts
+++ b/apps/backend/integration-tests/http/partner-order-shiprocket-label.spec.ts
@@ -273,6 +273,31 @@ setupSharedTestSuite(() => {
       )
     })
 
+    it("accepts carrier in the request body (carrier-neutral)", async () => {
+      await api.post(
+        `/admin/stock-locations/${locationId}`,
+        {
+          address: {
+            address_1: "1 Loom St",
+            city: "Surendranagar",
+            province: "GJ",
+            postal_code: "363035",
+            country_code: "IN",
+            phone: "9990001112",
+          },
+        },
+        adminHeaders
+      )
+
+      const res = await api.post(
+        `/partners/orders/${orderId}/shiprocket-label`,
+        { carrier: "shiprocket" },
+        { headers: partnerHeaders }
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.shiprocket_label.awb).toBe("STUBAWB123")
+    })
+
     it("400s when the partner's location cannot be registered — never ships from another party's warehouse", async () => {
       // Fixture location has NO phone → registration must fail loudly instead
       // of falling back to the shared account's first registered pickup.

--- a/apps/backend/integration-tests/http/partner-shiprocket-routes.spec.ts
+++ b/apps/backend/integration-tests/http/partner-shiprocket-routes.spec.ts
@@ -125,5 +125,23 @@ setupSharedTestSuite(() => {
         )
       ).rejects.toMatchObject({ response: { status: 400 } })
     })
+
+    it("enforces partner ownership on the fulfillment-label alias route too (#835)", async () => {
+      const { api } = getSharedTestEnv()
+      const unique = Date.now() + 1
+
+      const owner = await createPartner(unique)
+      const intruder = await createPartner(unique + 1)
+      const order = await createOrder(unique)
+      await linkPartnerOrder(owner.partnerId, order.id)
+
+      await expect(
+        api.post(
+          `/partners/orders/${order.id}/fulfillment-label`,
+          {},
+          { headers: intruder.headers }
+        )
+      ).rejects.toMatchObject({ response: { status: 400 } })
+    })
   })
 })

--- a/apps/backend/integration-tests/http/shared-test-setup.ts
+++ b/apps/backend/integration-tests/http/shared-test-setup.ts
@@ -4,6 +4,7 @@ import { medusaIntegrationTestRunner } from "@medusajs/test-utils";
 // Shared test environment instance
 let sharedApi: AxiosInstance | null = null;
 let sharedGetContainer: any = null;
+let sharedDbUtils: any = null;
 
 const attachHttpLogging = (api: AxiosInstance) => {
   if (!(api as any).__httpLoggingAttached && api?.interceptors?.response) {
@@ -33,16 +34,19 @@ const attachHttpLogging = (api: AxiosInstance) => {
  * Shared test environment setup
  * This must be called synchronously at the top level of test files
  */
-export function setupSharedTestSuite(testSuite: (env: { api: AxiosInstance; getContainer: any }) => void) {
+export function setupSharedTestSuite(
+  testSuite: (env: { api: AxiosInstance; getContainer: any; dbUtils: any }) => void
+) {
   return medusaIntegrationTestRunner({
-    testSuite: ({ api, getContainer }) => {
+    testSuite: ({ api, getContainer, dbUtils }) => {
       // Store the environment for reuse
       attachHttpLogging(api);
       sharedApi = api;
       sharedGetContainer = getContainer;
-      
+      sharedDbUtils = dbUtils;
+
       // Run the test suite
-      testSuite({ api, getContainer });
+      testSuite({ api, getContainer, dbUtils });
     }
   });
 }
@@ -56,6 +60,6 @@ export function getSharedTestEnv() {
     throw new Error("Shared test environment not initialized. Make sure setupSharedTestSuite was called first.");
   }
 
-  return { api: sharedApi, getContainer: sharedGetContainer };
+  return { api: sharedApi, getContainer: sharedGetContainer, dbUtils: sharedDbUtils };
 }
 

--- a/apps/backend/integration-tests/http/shiprocket-rates.spec.ts
+++ b/apps/backend/integration-tests/http/shiprocket-rates.spec.ts
@@ -27,7 +27,7 @@ jest.setTimeout(120 * 1000)
  */
 
 setupSharedTestSuite(() => {
-  const { api, getContainer } = getSharedTestEnv()
+  const { api, getContainer, dbUtils } = getSharedTestEnv()
 
   describe("Admin API - Shiprocket courier rates (#641)", () => {
     let adminHeaders: { headers: Record<string, string> }
@@ -38,6 +38,7 @@ setupSharedTestSuite(() => {
     let prevEmail: string | undefined
     let prevPassword: string | undefined
     let prevStub: string | undefined
+    let prevDelhiveryToken: string | undefined
 
     const buildDesignOrderId = async (): Promise<string> => {
       const cartRes = await api.post(
@@ -82,8 +83,10 @@ setupSharedTestSuite(() => {
       prevEmail = process.env.SHIPROCKET_EMAIL
       prevPassword = process.env.SHIPROCKET_PASSWORD
       prevStub = process.env.SHIPROCKET_STUB
+      prevDelhiveryToken = process.env.DELHIVERY_API_TOKEN
       process.env.SHIPROCKET_EMAIL = "test@shiprocket.example"
       process.env.SHIPROCKET_PASSWORD = "secret"
+      process.env.DELHIVERY_API_TOKEN = "test-delhivery-token"
       // Make the resolver inject the canned Shiprocket transport (no real API).
       process.env.SHIPROCKET_STUB = "1"
 
@@ -147,6 +150,8 @@ setupSharedTestSuite(() => {
       else process.env.SHIPROCKET_PASSWORD = prevPassword
       if (prevStub === undefined) delete process.env.SHIPROCKET_STUB
       else process.env.SHIPROCKET_STUB = prevStub
+      if (prevDelhiveryToken === undefined) delete process.env.DELHIVERY_API_TOKEN
+      else process.env.DELHIVERY_API_TOKEN = prevDelhiveryToken
     })
 
     it("returns the courier list (recommended flag) and honours a weight override", async () => {
@@ -154,6 +159,9 @@ setupSharedTestSuite(() => {
       // beforeAll). The Shiprocket transport is stubbed via SHIPROCKET_STUB, so
       // the rates route uses canned data instead of the real API.
       orderId = await buildDesignOrderId()
+
+      // Snapshot the DB so subsequent tests in this describe share the order
+      await dbUtils.snapshot()
 
       // ── default weight ────────────────────────────────────────────────
       const res = await api.get(
@@ -182,6 +190,56 @@ setupSharedTestSuite(() => {
       )
       expect(res2.status).toBe(200)
       expect(res2.data.weight_grams).toBe(1500)
+    })
+
+    it("accepts an explicit carrier query param (shiprocket)", async () => {
+      const res = await api.get(
+        `/admin/orders/${orderId}/shiprocket-rates?carrier=shiprocket`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(Array.isArray(res.data.rates)).toBe(true)
+      expect(res.data.rates.length).toBe(2)
+    })
+
+    it("rejects carrier=delhivery (no courier picker for Delhivery)", async () => {
+      const res = await api.get(
+        `/admin/orders/${orderId}/shiprocket-rates?carrier=delhivery`,
+        { ...adminHeaders, validateStatus: () => true }
+      )
+      // Delhivery does not implement listPickupLocations, so the rates
+      // workflow returns NOT_ALLOWED (400). The UI must not call this
+      // endpoint for Delhivery — the carrier picker is gated on
+      // `carrier === "shiprocket"`.
+      expect(res.status).toBe(400)
+    })
+
+    it("responds on the carrier-neutral fulfillment-rates alias route (#835)", async () => {
+      const res = await api.get(
+        `/admin/orders/${orderId}/fulfillment-rates`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.origin_pincode).toBe("302001")
+      expect(Array.isArray(res.data.rates)).toBe(true)
+      expect(res.data.rates.length).toBe(2)
+    })
+
+    it("carrier-neutral fulfillment-rates alias honours ?carrier=shiprocket", async () => {
+      const res = await api.get(
+        `/admin/orders/${orderId}/fulfillment-rates?carrier=shiprocket`,
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      expect(Array.isArray(res.data.rates)).toBe(true)
+    })
+
+    it("carrier-neutral fulfillment-rates alias rejects ?carrier=delhivery (no courier picker)", async () => {
+      const res = await api.get(
+        `/admin/orders/${orderId}/fulfillment-rates?carrier=delhivery`,
+        { ...adminHeaders, validateStatus: () => true }
+      )
+      expect(res.status).toBe(400)
     })
   })
 })

--- a/apps/backend/src/admin/components/inventory-orders/inventory-order-shipment-modal.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/inventory-order-shipment-modal.tsx
@@ -33,6 +33,7 @@ export const InventoryOrderShipmentModal = ({ inventoryOrder, open, onOpenChange
   // leave from is the natural default; the user can still pick another.
   const orderFromLocationId =
     (inventoryOrder as any).from_stock_location?.id ?? "";
+  const [carrier, setCarrier] = useState("shiprocket");
   const [pickup, setPickup] = useState(orderFromLocationId);
   const [weight, setWeight] = useState("");
   const [length, setLength] = useState("");
@@ -77,6 +78,7 @@ export const InventoryOrderShipmentModal = ({ inventoryOrder, open, onOpenChange
 
     await mutateAsync(
       {
+        carrier,
         ...(pickup ? { pickup_stock_location_id: pickup } : {}),
         ...(weight ? { weight_grams: Number(weight) } : {}),
         ...(dims ? { dimensions_cm: dims } : {}),
@@ -123,6 +125,18 @@ export const InventoryOrderShipmentModal = ({ inventoryOrder, open, onOpenChange
             </Select>
           </div>
           <div className="flex flex-col gap-1">
+            <Label size="small" htmlFor="carrier">Carrier</Label>
+            <Select value={carrier} onValueChange={(v) => { setCarrier(v); setRates(null); setCourier(""); }}>
+              <Select.Trigger id="carrier">
+                <Select.Value placeholder="Select carrier" />
+              </Select.Trigger>
+              <Select.Content>
+                <Select.Item value="shiprocket">Shiprocket</Select.Item>
+                <Select.Item value="delhivery">Delhivery</Select.Item>
+              </Select.Content>
+            </Select>
+          </div>
+          <div className="flex flex-col gap-1">
             <Label size="small" htmlFor="weight">Weight (grams)</Label>
             <Input id="weight" type="number" value={weight} onChange={(e) => setWeight(e.target.value)} placeholder="500" />
           </div>
@@ -140,43 +154,45 @@ export const InventoryOrderShipmentModal = ({ inventoryOrder, open, onOpenChange
               <Input id="height" type="number" value={height} onChange={(e) => setHeight(e.target.value)} />
             </div>
           </div>
-          <div className="flex flex-col gap-1">
-            <div className="flex items-center justify-between">
-              <Label size="small" htmlFor="courier">Courier</Label>
-              <Button
-                variant="transparent"
-                size="small"
-                type="button"
-                onClick={handleGetRates}
-                isLoading={isFetchingRates}
-              >
-                Get rates
-              </Button>
+          {carrier === "shiprocket" && (
+            <div className="flex flex-col gap-1">
+              <div className="flex items-center justify-between">
+                <Label size="small" htmlFor="courier">Courier</Label>
+                <Button
+                  variant="transparent"
+                  size="small"
+                  type="button"
+                  onClick={handleGetRates}
+                  isLoading={isFetchingRates}
+                >
+                  Get rates
+                </Button>
+              </div>
+              {rates && rates.length > 0 ? (
+                <Select value={courier} onValueChange={setCourier}>
+                  <Select.Trigger id="courier">
+                    <Select.Value placeholder="Select a courier" />
+                  </Select.Trigger>
+                  <Select.Content>
+                    {rates.map((r) => (
+                      <Select.Item key={String(r.courier_id)} value={String(r.courier_id)}>
+                        {r.courier_name} — ₹{r.amount}
+                        {r.estimated_days ? ` · ${r.estimated_days}d` : ""}
+                        {r.is_recommended ? " · recommended" : ""}
+                      </Select.Item>
+                    ))}
+                  </Select.Content>
+                </Select>
+              ) : (
+                <Input
+                  id="courier"
+                  value={courier}
+                  onChange={(e) => setCourier(e.target.value)}
+                  placeholder="Courier ID (optional) — or click Get rates"
+                />
+              )}
             </div>
-            {rates && rates.length > 0 ? (
-              <Select value={courier} onValueChange={setCourier}>
-                <Select.Trigger id="courier">
-                  <Select.Value placeholder="Select a courier" />
-                </Select.Trigger>
-                <Select.Content>
-                  {rates.map((r) => (
-                    <Select.Item key={String(r.courier_id)} value={String(r.courier_id)}>
-                      {r.courier_name} — ₹{r.amount}
-                      {r.estimated_days ? ` · ${r.estimated_days}d` : ""}
-                      {r.is_recommended ? " · recommended" : ""}
-                    </Select.Item>
-                  ))}
-                </Select.Content>
-              </Select>
-            ) : (
-              <Input
-                id="courier"
-                value={courier}
-                onChange={(e) => setCourier(e.target.value)}
-                placeholder="Courier ID (optional) — or click Get rates"
-              />
-            )}
-          </div>
+          )}
           <div className="flex flex-col gap-1">
             <Label size="small" htmlFor="pickup_date">Pickup date</Label>
             <DatePicker

--- a/apps/backend/src/admin/hooks/api/design-orders.ts
+++ b/apps/backend/src/admin/hooks/api/design-orders.ts
@@ -324,13 +324,19 @@ export type ShiprocketRatesResponse = {
   rates: ShiprocketRateOption[];
 };
 
+export type ShiprocketRatesQuery = {
+  carrier?: string;
+};
+
 /**
  * List the Shiprocket courier options (rate / ETA / recommended) for an order
  * so the operator can pick a courier before generating the label. #641.
  * Disabled until explicitly enabled (the UI fetches on demand).
+ * Accepts an optional carrier query param (defaults to "shiprocket").
  */
 export const useShiprocketRates = (
   orderId: string,
+  query?: ShiprocketRatesQuery,
   options?: Omit<
     UseQueryOptions<
       ShiprocketRatesResponse,
@@ -341,11 +347,12 @@ export const useShiprocketRates = (
     "queryFn" | "queryKey"
   >
 ) => {
+  const qs = query?.carrier ? `?carrier=${encodeURIComponent(query.carrier)}` : "";
   return useQuery({
-    queryKey: designOrdersQueryKeys.detail(`${orderId}-shiprocket-rates`),
+    queryKey: designOrdersQueryKeys.detail(`${orderId}-shiprocket-rates${qs}`),
     queryFn: async () =>
       sdk.client.fetch<ShiprocketRatesResponse>(
-        `/admin/orders/${orderId}/shiprocket-rates`,
+        `/admin/orders/${orderId}/shiprocket-rates${qs}`,
         { method: "GET" }
       ),
     ...options,
@@ -362,35 +369,36 @@ export type GenerateShiprocketLabelResponse = {
   };
 };
 
-export type GenerateShiprocketLabelVariables =
-  | { preferred_courier_id?: string | number }
-  | undefined;
+export type GenerateShiprocketLabelVariables = {
+  preferred_courier_id?: string | number;
+  carrier?: string;
+};
 
 /**
  * One-click Shiprocket label for a converted order: creates a fulfillment (or
  * reuses an existing Shiprocket one) and generates the shipment + label. #404
- * PR-C. Optionally passes the operator-chosen `preferred_courier_id` (#641).
+ * PR-C. Optionally passes the operator-chosen `preferred_courier_id` (#641)
+ * and the carrier (defaults to "shiprocket" on the backend).
  */
 export const useGenerateShiprocketLabel = (
   orderId: string,
   options?: UseMutationOptions<
     GenerateShiprocketLabelResponse,
     FetchError,
-    GenerateShiprocketLabelVariables
+    GenerateShiprocketLabelVariables | undefined
   >
 ) => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (variables?: GenerateShiprocketLabelVariables) =>
-      sdk.client.fetch<GenerateShiprocketLabelResponse>(
+    mutationFn: async (variables?: GenerateShiprocketLabelVariables) => {
+      const body: Record<string, any> = {};
+      if (variables?.preferred_courier_id) body.preferred_courier_id = variables.preferred_courier_id;
+      if (variables?.carrier) body.carrier = variables.carrier;
+      return sdk.client.fetch<GenerateShiprocketLabelResponse>(
         `/admin/orders/${orderId}/shiprocket-label`,
-        {
-          method: "POST",
-          body: variables?.preferred_courier_id
-            ? { preferred_courier_id: variables.preferred_courier_id }
-            : {},
-        }
-      ),
+        { method: "POST", body }
+      );
+    },
     onSuccess: (...args) => {
       queryClient.invalidateQueries({
         queryKey: designOrdersQueryKeys.lists(),
@@ -400,6 +408,45 @@ export const useGenerateShiprocketLabel = (
     ...options,
   });
 };
+
+// ── Carrier-neutral aliases (P4) ──────────────────────────────────────────────
+
+export type FulfillmentRatesQuery = ShiprocketRatesQuery
+export type FulfillmentRatesResponse = ShiprocketRatesResponse
+export type GenerateFulfillmentLabelVariables = GenerateShiprocketLabelVariables
+export type GenerateFulfillmentLabelResponse = GenerateShiprocketLabelResponse
+
+/**
+ * Carrier-neutral alias for `useShiprocketRates`. Defaults carrier to
+ * `"shiprocket"` when omitted. Replaced the Shiprocket-specific hook name
+ * as the primary API going forward.
+ */
+export const useFulfillmentRates = (
+  orderId: string,
+  query?: FulfillmentRatesQuery,
+  options?: Omit<
+    UseQueryOptions<
+      FulfillmentRatesResponse,
+      FetchError,
+      FulfillmentRatesResponse,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => useShiprocketRates(orderId, query, options)
+
+/**
+ * Carrier-neutral alias for `useGenerateShiprocketLabel`. Defaults carrier to
+ * `"shiprocket"` when omitted on the backend.
+ */
+export const useGenerateFulfillmentLabel = (
+  orderId: string,
+  options?: UseMutationOptions<
+    GenerateFulfillmentLabelResponse,
+    FetchError,
+    GenerateFulfillmentLabelVariables | undefined
+  >
+) => useGenerateShiprocketLabel(orderId, options)
 
 export type AttachShiprocketAwbResponse = {
   shiprocket_awb: {

--- a/apps/backend/src/admin/routes/design-orders/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/design-orders/[id]/page.tsx
@@ -292,6 +292,7 @@ const OrderSection = ({
   const [attachOpen, setAttachOpen] = useState(false)
   const [awbValue, setAwbValue] = useState("")
   const [courierOpen, setCourierOpen] = useState(false)
+  const [selectedCarrier, setSelectedCarrier] = useState<string>("shiprocket")
   const [selectedCourierId, setSelectedCourierId] = useState<
     string | number | null
   >(null)
@@ -329,9 +330,11 @@ const OrderSection = ({
     data: ratesData,
     isLoading: isLoadingRates,
     error: ratesError,
-  } = useShiprocketRates(order?.id ?? "", {
-    enabled: courierOpen && !!order?.id,
-  })
+  } = useShiprocketRates(
+    order?.id ?? "",
+    { carrier: selectedCarrier === "shiprocket" ? undefined : selectedCarrier },
+    { enabled: courierOpen && !!order?.id }
+  )
 
   const handleConvert = async (paymentMode: "prepaid" | "cod") => {
     const confirmed = await prompt({
@@ -396,9 +399,7 @@ const OrderSection = ({
 
   const handleGenerateLabel = async (preferredCourierId?: string | number) => {
     await genLabel(
-      preferredCourierId != null
-        ? { preferred_courier_id: preferredCourierId }
-        : undefined,
+      { carrier: selectedCarrier, ...(preferredCourierId != null ? { preferred_courier_id: preferredCourierId } : {}) },
       {
         onSuccess: (res) => {
           setLabelUrl(res.shiprocket_label?.label_url || null)
@@ -459,7 +460,7 @@ const OrderSection = ({
                       disabled: isLabeling,
                     },
                     {
-                      label: isLabeling ? "Generating…" : "Generate Label (auto)",
+                      label: isLabeling ? "Generating…" : `Generate Label (auto · ${selectedCarrier})`,
                       icon: <HandTruck />,
                       onClick: () => handleGenerateLabel(),
                       disabled: isLabeling,
@@ -538,18 +539,49 @@ const OrderSection = ({
               Close
             </Button>
           </div>
-          {isLoadingRates && (
+          <div className="mb-3">
+            <Text size="xsmall" className="text-ui-fg-subtle mb-1">
+              Carrier
+            </Text>
+            <Select value={selectedCarrier} onValueChange={setSelectedCarrier}>
+              <Select.Trigger>
+                <Select.Value />
+              </Select.Trigger>
+              <Select.Content>
+                <Select.Item value="shiprocket">Shiprocket</Select.Item>
+                <Select.Item value="delhivery">Delhivery</Select.Item>
+              </Select.Content>
+            </Select>
+          </div>
+          {selectedCarrier === "shiprocket" && isLoadingRates && (
             <div className="flex flex-col gap-y-2">
               <Skeleton className="h-12 w-full" />
               <Skeleton className="h-12 w-full" />
             </div>
           )}
-          {ratesError && (
+          {selectedCarrier === "shiprocket" && ratesError && (
             <Text size="small" className="text-ui-fg-error">
               {(ratesError as any)?.message || "Couldn't load courier rates."}
             </Text>
           )}
-          {!isLoadingRates && !ratesError && ratesData && (
+          {selectedCarrier === "delhivery" && (
+            <div className="flex flex-col gap-y-2">
+              <Text size="small" className="text-ui-fg-subtle">
+                Delhivery doesn't require a courier picker. Generate the label directly.
+              </Text>
+              <div className="flex items-center gap-x-2 pt-1">
+                <Button
+                  variant="primary"
+                  size="small"
+                  isLoading={isLabeling}
+                  onClick={() => handleGenerateLabel()}
+                >
+                  Generate Label
+                </Button>
+              </div>
+            </div>
+          )}
+          {selectedCarrier === "shiprocket" && !isLoadingRates && !ratesError && ratesData && (
             <div className="flex flex-col gap-y-2">
               {ratesData.rates.length === 0 && (
                 <Text size="small" className="text-ui-fg-subtle">

--- a/apps/backend/src/api/admin/inventory-orders/[id]/fulfillment-rates/route.ts
+++ b/apps/backend/src/api/admin/inventory-orders/[id]/fulfillment-rates/route.ts
@@ -1,0 +1,3 @@
+import { GET as originalGET } from "../shiprocket-rates/route"
+
+export const GET = originalGET

--- a/apps/backend/src/api/admin/inventory-orders/[id]/shiprocket-rates/route.ts
+++ b/apps/backend/src/api/admin/inventory-orders/[id]/shiprocket-rates/route.ts
@@ -26,6 +26,10 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const dimensionsCm =
     length || breadth || height ? { length, breadth, height } : undefined;
 
+  const carrierRaw = req.query.carrier;
+  const carrier =
+    typeof carrierRaw === "string" && carrierRaw ? carrierRaw : undefined;
+
   const pickupStockLocationId =
     typeof req.query.pickup_stock_location_id === "string" &&
     req.query.pickup_stock_location_id
@@ -34,6 +38,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
 
   const result = await getShiprocketRatesForInventoryOrder(req.scope, {
     orderId,
+    carrier,
     pickupStockLocationId,
     weightGrams: num(req.query.weight_grams),
     dimensionsCm,

--- a/apps/backend/src/api/admin/orders/[id]/fulfillment-label/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/fulfillment-label/route.ts
@@ -1,0 +1,3 @@
+import { POST as originalPOST } from "../shiprocket-label/route"
+
+export const POST = originalPOST

--- a/apps/backend/src/api/admin/orders/[id]/fulfillment-rates/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/fulfillment-rates/route.ts
@@ -1,0 +1,3 @@
+import { GET as originalGET } from "../shiprocket-rates/route"
+
+export const GET = originalGET

--- a/apps/backend/src/api/admin/orders/[id]/fulfillments/[fulfillmentId]/fulfillment-shipment/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/fulfillments/[fulfillmentId]/fulfillment-shipment/route.ts
@@ -1,0 +1,3 @@
+import { POST as originalPOST } from "../shiprocket-shipment/route"
+
+export const POST = originalPOST

--- a/apps/backend/src/api/admin/orders/[id]/fulfillments/[fulfillmentId]/shiprocket-shipment/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/fulfillments/[fulfillmentId]/shiprocket-shipment/route.ts
@@ -16,6 +16,7 @@ import { createShiprocketShipmentForFulfillment } from "../../../../../../../wor
  */
 const Body = z.object({
   pickup_location_name: z.string().optional(),
+  carrier: z.string().optional(),
   weight_grams: z.coerce.number().positive().optional(),
   dimensions_cm: z
     .object({
@@ -33,6 +34,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const result = await createShiprocketShipmentForFulfillment(req.scope, {
     orderId: req.params.id,
     fulfillmentId: req.params.fulfillmentId,
+    carrier: body.carrier,
     pickupLocationName: body.pickup_location_name,
     weightGrams: body.weight_grams,
     dimensionsCm: body.dimensions_cm,

--- a/apps/backend/src/api/admin/orders/[id]/shiprocket-label/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/shiprocket-label/route.ts
@@ -22,7 +22,10 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const orderId = req.params.id
   // #641 — the Design-Orders courier picker passes the chosen courier id; when
   // omitted, Shiprocket auto-assigns on AWB generation (prior behaviour).
-  const body = (req.body || {}) as { preferred_courier_id?: string | number }
+  const body = (req.body || {}) as {
+    carrier?: string
+    preferred_courier_id?: string | number
+  }
   const preferredCourierId =
     body.preferred_courier_id != null && body.preferred_courier_id !== ""
       ? body.preferred_courier_id
@@ -33,6 +36,7 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const shipment = await createShiprocketShipmentForFulfillment(req.scope, {
     orderId,
     fulfillmentId,
+    carrier: body.carrier,
     preferredCourierId,
   })
 

--- a/apps/backend/src/api/admin/orders/[id]/shiprocket-rates/route.ts
+++ b/apps/backend/src/api/admin/orders/[id]/shiprocket-rates/route.ts
@@ -14,11 +14,15 @@ import { getShiprocketRatesForOrder } from "../../../../../workflows/orders/ship
  */
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const orderId = req.params.id
+  const carrierRaw = req.query.carrier
+  const carrier =
+    typeof carrierRaw === "string" && carrierRaw ? carrierRaw : undefined
   const weightRaw = req.query.weight_grams
   const weightGrams = weightRaw != null ? Number(weightRaw) : undefined
 
   const result = await getShiprocketRatesForOrder(req.scope, {
     orderId,
+    carrier,
     weightGrams:
       weightGrams != null && Number.isFinite(weightGrams) && weightGrams > 0
         ? weightGrams

--- a/apps/backend/src/api/partners/inventory-orders/[orderId]/fulfillment-rates/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/[orderId]/fulfillment-rates/route.ts
@@ -1,0 +1,3 @@
+import { GET as originalGET } from "../shiprocket-rates/route"
+
+export const GET = originalGET

--- a/apps/backend/src/api/partners/inventory-orders/[orderId]/shiprocket-rates/route.ts
+++ b/apps/backend/src/api/partners/inventory-orders/[orderId]/shiprocket-rates/route.ts
@@ -41,8 +41,13 @@ export async function GET(req: AuthenticatedMedusaRequest, res: MedusaResponse) 
   const dimensionsCm =
     length || breadth || height ? { length, breadth, height } : undefined;
 
+  const carrierRaw = req.query.carrier;
+  const carrier =
+    typeof carrierRaw === "string" && carrierRaw ? carrierRaw : undefined;
+
   const result = await getShiprocketRatesForInventoryOrder(req.scope, {
     orderId,
+    carrier,
     weightGrams: num(req.query.weight_grams),
     dimensionsCm,
   });

--- a/apps/backend/src/api/partners/orders/[id]/fulfillment-label/route.ts
+++ b/apps/backend/src/api/partners/orders/[id]/fulfillment-label/route.ts
@@ -1,0 +1,3 @@
+import { POST as originalPOST } from "../shiprocket-label/route"
+
+export const POST = originalPOST

--- a/apps/backend/src/api/partners/orders/[id]/shiprocket-label/route.ts
+++ b/apps/backend/src/api/partners/orders/[id]/shiprocket-label/route.ts
@@ -31,7 +31,10 @@ export const POST = async (
   const orderId = req.params.id
   await validatePartnerOrderOwnership(req.auth_context, orderId, req.scope)
 
-  const body = (req.body || {}) as { preferred_courier_id?: string | number }
+  const body = (req.body || {}) as {
+    carrier?: string
+    preferred_courier_id?: string | number
+  }
   const preferredCourierId =
     body.preferred_courier_id != null && body.preferred_courier_id !== ""
       ? body.preferred_courier_id
@@ -54,6 +57,7 @@ export const POST = async (
   const shipment = await createShiprocketShipmentForFulfillment(req.scope, {
     orderId,
     fulfillmentId,
+    carrier: body.carrier,
     pickupStockLocationId: locationId,
     actingEmail: partner?.admins?.[0]?.email,
     preferredCourierId,

--- a/apps/backend/src/workflows/inventory_orders/shiprocket-rates.ts
+++ b/apps/backend/src/workflows/inventory_orders/shiprocket-rates.ts
@@ -36,6 +36,8 @@ import {
 
 export type InventoryOrderRatesInput = {
   orderId: string
+  /** Defaults to "shiprocket". */
+  carrier?: string
   /**
    * Explicit ship-from override (mirrors the shipment input's
    * `pickupStockLocationId`) so the quote matches a pickup the operator picked
@@ -115,11 +117,12 @@ export async function getShiprocketRatesForInventoryOrder(
     )
   }
 
-  const provider = await resolveShippingProvider(container, "shiprocket")
-  if (!provider.getRates) {
+  const carrier = input.carrier || "shiprocket"
+  const provider = await resolveShippingProvider(container, carrier)
+  if (!provider.getRates || !provider.listPickupLocations) {
     throw new MedusaError(
       MedusaError.Types.NOT_ALLOWED,
-      "Shiprocket provider does not support rate quotes"
+      `${carrier} provider does not support rate quotes`
     )
   }
 

--- a/apps/backend/src/workflows/orders/shiprocket-rates.ts
+++ b/apps/backend/src/workflows/orders/shiprocket-rates.ts
@@ -41,6 +41,8 @@ export function pickRatesPickup(
 
 export type ShiprocketRatesInput = {
   orderId: string
+  /** Defaults to "shiprocket". */
+  carrier?: string
   weightGrams?: number
 }
 
@@ -103,11 +105,12 @@ export async function getShiprocketRatesForOrder(
     ]
   }
 
-  const provider = await resolveShippingProvider(container, "shiprocket")
+  const carrier = input.carrier || "shiprocket"
+  const provider = await resolveShippingProvider(container, carrier)
   if (!provider.getRates || !provider.listPickupLocations) {
     throw new MedusaError(
       MedusaError.Types.NOT_ALLOWED,
-      "Shiprocket provider does not support rate quotes"
+      `${carrier} provider does not support rate quotes`
     )
   }
 
@@ -117,7 +120,7 @@ export async function getShiprocketRatesForOrder(
   if (!originPincode) {
     throw new MedusaError(
       MedusaError.Types.INVALID_DATA,
-      "No Shiprocket pickup location with a pincode is configured. Register a pickup location before requesting courier rates."
+      `No ${carrier} pickup location with a pincode is configured. Register a pickup location before requesting courier rates.`
     )
   }
 

--- a/apps/backend/src/workflows/orders/shiprocket-shipment.ts
+++ b/apps/backend/src/workflows/orders/shiprocket-shipment.ts
@@ -112,6 +112,8 @@ export function buildCreateShipmentInput(
 export type CreateShiprocketShipmentInput = {
   orderId: string
   fulfillmentId: string
+  /** Defaults to "shiprocket". */
+  carrier?: string
   pickupLocationName?: string
   /**
    * Explicit ship-from stock location (#772 core-order half — partner label
@@ -198,11 +200,12 @@ export async function createShiprocketShipmentForFulfillment(
     ]
   }
 
-  const provider = await resolveShippingProvider(container, "shiprocket")
+  const carrier = input.carrier || "shiprocket"
+  const provider = await resolveShippingProvider(container, carrier)
   if (!provider.createShipment) {
     throw new MedusaError(
       MedusaError.Types.NOT_ALLOWED,
-      "Shiprocket provider does not support shipment creation"
+      `${carrier} provider does not support shipment creation`
     )
   }
 
@@ -229,7 +232,7 @@ export async function createShiprocketShipmentForFulfillment(
     // A clean MedusaError (not a raw 500) so the UI shows an actionable toast. (#638)
     throw new MedusaError(
       MedusaError.Types.INVALID_DATA,
-      "No Shiprocket pickup location is configured. Register a pickup location for the order's stock location (or any Shiprocket pickup) before generating a label."
+      `No ${carrier} pickup location is configured. Register a pickup location for the order's stock location (or any ${carrier} pickup) before generating a label.`
     )
   }
 
@@ -253,7 +256,7 @@ export async function createShiprocketShipmentForFulfillment(
   await fulfillmentModule.updateFulfillment(input.fulfillmentId, {
     data: {
       ...(fulfillment.data || {}),
-      carrier: "shiprocket",
+      carrier,
       waybill: result.awb,
       tracking_number: result.tracking_number,
       tracking_url: result.tracking_url,

--- a/apps/partner-ui/src/hooks/api/partner-inventory-orders.tsx
+++ b/apps/partner-ui/src/hooks/api/partner-inventory-orders.tsx
@@ -276,6 +276,7 @@ export type PartnerShiprocketRatesResponse = {
 }
 
 export type PartnerShiprocketRatesParams = {
+  carrier?: string
   weight_grams?: number
   length?: number
   breadth?: number

--- a/apps/partner-ui/src/hooks/api/shiprocket.tsx
+++ b/apps/partner-ui/src/hooks/api/shiprocket.tsx
@@ -24,33 +24,34 @@ export type GenerateShiprocketLabelResponse = {
   }
 }
 
-export type GenerateShiprocketLabelVariables =
-  | { preferred_courier_id?: string | number }
-  | undefined
+export type GenerateShiprocketLabelVariables = {
+  preferred_courier_id?: string | number
+  carrier?: string
+}
 
 /**
  * Generate a Shiprocket label for one of the partner's own orders (create
- * fulfillment → shipment → AWB). Optionally passes a chosen courier (#641).
+ * fulfillment → shipment → AWB). Optionally passes a chosen courier (#641)
+ * and the carrier (defaults to "shiprocket" on the backend).
  */
 export const useGenerateShiprocketLabel = (
   orderId: string,
   options?: UseMutationOptions<
     GenerateShiprocketLabelResponse,
     FetchError,
-    GenerateShiprocketLabelVariables
+    GenerateShiprocketLabelVariables | undefined
   >
 ) => {
   return useMutation({
-    mutationFn: (variables?: GenerateShiprocketLabelVariables) =>
-      sdk.client.fetch<GenerateShiprocketLabelResponse>(
+    mutationFn: (variables?: GenerateShiprocketLabelVariables) => {
+      const body: Record<string, any> = {}
+      if (variables?.preferred_courier_id) body.preferred_courier_id = variables.preferred_courier_id
+      if (variables?.carrier) body.carrier = variables.carrier
+      return sdk.client.fetch<GenerateShiprocketLabelResponse>(
         `/partners/orders/${orderId}/shiprocket-label`,
-        {
-          method: "POST",
-          body: variables?.preferred_courier_id
-            ? { preferred_courier_id: variables.preferred_courier_id }
-            : {},
-        }
-      ),
+        { method: "POST", body }
+      )
+    },
     onSuccess: (data: any, variables: any, context: any) => {
       queryClient.invalidateQueries({ queryKey: ordersQueryKeys.all })
       options?.onSuccess?.(data, variables, context)
@@ -58,6 +59,24 @@ export const useGenerateShiprocketLabel = (
     ...options,
   })
 }
+
+// ── Carrier-neutral aliases (P4) ──────────────────────────────────────────────
+
+export type GenerateFulfillmentLabelVariables = GenerateShiprocketLabelVariables
+export type GenerateFulfillmentLabelResponse = GenerateShiprocketLabelResponse
+
+/**
+ * Carrier-neutral alias for `useGenerateShiprocketLabel`. Defaults carrier to
+ * `"shiprocket"` when omitted on the backend.
+ */
+export const useGenerateFulfillmentLabel = (
+  orderId: string,
+  options?: UseMutationOptions<
+    GenerateFulfillmentLabelResponse,
+    FetchError,
+    GenerateFulfillmentLabelVariables | undefined
+  >
+) => useGenerateShiprocketLabel(orderId, options)
 
 export type AttachShiprocketAwbResponse = {
   shiprocket_awb: {

--- a/apps/partner-ui/src/routes/inventory-orders/inventory-order-create-shipment/inventory-order-create-shipment.tsx
+++ b/apps/partner-ui/src/routes/inventory-orders/inventory-order-create-shipment/inventory-order-create-shipment.tsx
@@ -38,6 +38,7 @@ const InventoryOrderCreateShipmentContent = () => {
   const { inventoryOrderId: id, unifiedOrderId } = useInventoryActionTarget()
   const { handleSuccess } = useRouteModal()
   const queryClient = useQueryClient()
+  const [carrier, setCarrier] = useState("shiprocket")
   const [weight, setWeight] = useState("")
   const [length, setLength] = useState("")
   const [breadth, setBreadth] = useState("")
@@ -66,6 +67,7 @@ const InventoryOrderCreateShipmentContent = () => {
     if (!id) return
     try {
       const res = await fetchRates({
+        carrier,
         ...(weight ? { weight_grams: Number(weight) } : {}),
         ...(length ? { length: Number(length) } : {}),
         ...(breadth ? { breadth: Number(breadth) } : {}),
@@ -88,6 +90,7 @@ const InventoryOrderCreateShipmentContent = () => {
 
     await mutateAsync(
       {
+        carrier,
         ...(weight ? { weight_grams: Number(weight) } : {}),
         ...(dims() ? { dimensions_cm: dims() } : {}),
         ...(courier ? { preferred_courier_id: courier } : {}),
@@ -119,6 +122,20 @@ const InventoryOrderCreateShipmentContent = () => {
           registered pickup. Weight and dimensions are optional — leave them
           blank to use the order's defaults.
         </Text>
+        <div className="flex flex-col gap-y-1">
+          <Label size="small" htmlFor="carrier">
+            Carrier
+          </Label>
+          <Select value={carrier} onValueChange={(v) => { setCarrier(v); setRates(null); setCourier(""); }}>
+            <Select.Trigger id="carrier">
+              <Select.Value placeholder="Select carrier" />
+            </Select.Trigger>
+            <Select.Content>
+              <Select.Item value="shiprocket">Shiprocket</Select.Item>
+              <Select.Item value="delhivery">Delhivery</Select.Item>
+            </Select.Content>
+          </Select>
+        </div>
         <div className="flex flex-col gap-y-1">
           <Label size="small" htmlFor="weight">
             Weight (grams)
@@ -166,47 +183,49 @@ const InventoryOrderCreateShipmentContent = () => {
             />
           </div>
         </div>
-        <div className="flex flex-col gap-y-1">
-          <div className="flex items-center justify-between">
-            <Label size="small" htmlFor="courier">
-              Courier
-            </Label>
-            <Button
-              variant="transparent"
-              size="small"
-              type="button"
-              onClick={handleGetRates}
-              isLoading={isFetchingRates}
-              disabled={!id}
-            >
-              Get rates
-            </Button>
+        {carrier === "shiprocket" && (
+          <div className="flex flex-col gap-y-1">
+            <div className="flex items-center justify-between">
+              <Label size="small" htmlFor="courier">
+                Courier
+              </Label>
+              <Button
+                variant="transparent"
+                size="small"
+                type="button"
+                onClick={handleGetRates}
+                isLoading={isFetchingRates}
+                disabled={!id}
+              >
+                Get rates
+              </Button>
+            </div>
+            {rates && rates.length > 0 ? (
+              <Select value={courier} onValueChange={setCourier}>
+                <Select.Trigger id="courier">
+                  <Select.Value placeholder="Select a courier" />
+                </Select.Trigger>
+                <Select.Content>
+                  {rates.map((r) => (
+                    <Select.Item
+                      key={String(r.courier_id)}
+                      value={String(r.courier_id)}
+                    >
+                      {r.courier_name} — ₹{r.amount}
+                      {r.estimated_days ? ` · ${r.estimated_days}d` : ""}
+                      {r.is_recommended ? " · recommended" : ""}
+                    </Select.Item>
+                  ))}
+                </Select.Content>
+              </Select>
+            ) : (
+              <Text size="xsmall" className="text-ui-fg-subtle">
+                Optional — click “Get rates” to choose a courier, or leave it for
+                Shiprocket to auto-assign.
+              </Text>
+            )}
           </div>
-          {rates && rates.length > 0 ? (
-            <Select value={courier} onValueChange={setCourier}>
-              <Select.Trigger id="courier">
-                <Select.Value placeholder="Select a courier" />
-              </Select.Trigger>
-              <Select.Content>
-                {rates.map((r) => (
-                  <Select.Item
-                    key={String(r.courier_id)}
-                    value={String(r.courier_id)}
-                  >
-                    {r.courier_name} — ₹{r.amount}
-                    {r.estimated_days ? ` · ${r.estimated_days}d` : ""}
-                    {r.is_recommended ? " · recommended" : ""}
-                  </Select.Item>
-                ))}
-              </Select.Content>
-            </Select>
-          ) : (
-            <Text size="xsmall" className="text-ui-fg-subtle">
-              Optional — click “Get rates” to choose a courier, or leave it for
-              Shiprocket to auto-assign.
-            </Text>
-          )}
-        </div>
+        )}
         <div className="flex flex-col gap-y-1">
           <Label size="small" htmlFor="pickup_date">
             Pickup date

--- a/apps/partner-ui/src/routes/orders/order-detail/components/order-fulfillment-section/order-fulfillment-section.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/components/order-fulfillment-section/order-fulfillment-section.tsx
@@ -14,6 +14,7 @@ import {
   Heading,
   Input,
   Label,
+  Select,
   StatusBadge,
   Text,
   Tooltip,
@@ -337,6 +338,7 @@ const Fulfillment = ({
 
   // Shiprocket carrier actions (#639) — partner parity with admin Design-Orders.
   // Available only while the fulfillment has no waybill yet and isn't canceled.
+  const [selectedCarrier, setSelectedCarrier] = useState<string>("shiprocket")
   const [showAttachAwb, setShowAttachAwb] = useState(false)
   const [awbInput, setAwbInput] = useState("")
 
@@ -354,13 +356,15 @@ const Fulfillment = ({
 
   const handleGenerateShiprocketLabel = async () => {
     try {
-      const res = await generateShiprocketLabel(undefined)
+      const res = await generateShiprocketLabel({ carrier: selectedCarrier })
       const awb = res?.shiprocket_label?.awb || res?.shiprocket_label?.tracking_number
       toast.success(
-        awb ? `Shiprocket label generated — AWB ${awb}` : "Shiprocket label generated"
+        awb
+          ? `${selectedCarrier === "delhivery" ? "Delhivery" : "Shiprocket"} label generated — AWB ${awb}`
+          : `${selectedCarrier === "delhivery" ? "Delhivery" : "Shiprocket"} label generated`
       )
     } catch (e: any) {
-      toast.error(e?.message || "Failed to generate Shiprocket label")
+      toast.error(e?.message || "Failed to generate label")
     }
   }
 
@@ -731,6 +735,18 @@ const Fulfillment = ({
         <div className="bg-ui-bg-subtle flex items-center justify-end gap-x-2 rounded-b-xl px-4 py-4">
           {showShiprocketCarrierActions && (
             <>
+              <Select
+                value={selectedCarrier}
+                onValueChange={setSelectedCarrier}
+              >
+                <Select.Trigger className="w-36">
+                  <Select.Value />
+                </Select.Trigger>
+                <Select.Content>
+                  <Select.Item value="shiprocket">Shiprocket</Select.Item>
+                  <Select.Item value="delhivery">Delhivery</Select.Item>
+                </Select.Content>
+              </Select>
               <Button
                 onClick={() => setShowAttachAwb(true)}
                 variant="secondary"
@@ -742,7 +758,7 @@ const Fulfillment = ({
                 variant="secondary"
                 isLoading={isGeneratingLabel}
               >
-                Generate Shiprocket Label
+                {selectedCarrier === "delhivery" ? "Generate Delhivery Label" : "Generate Shiprocket Label"}
               </Button>
             </>
           )}

--- a/packages/medusa-plugin-faire-store-sync/src/lib/faire-client.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/lib/faire-client.ts
@@ -502,7 +502,7 @@ export class FaireClient {
         this.taxonomyTypesCache = []
       }
     }
-    return this.taxonomyTypesCache
+    return this.taxonomyTypesCache ?? []
   }
 
   async resolveTaxonomyTypeId(


### PR DESCRIPTION
Promote Shiprocket/Delhivery from Shiprocket-only hardcoded flows to a first-class carrier abstraction with carrier pickers (Select) in every admin/partner UI, plus carrier-neutral route/hook aliases.

## What's included

**P1 — Backend workflows parameterized**  
- `CreateShiprocketShipmentInput` / `ShiprocketRatesInput` / `InventoryOrderRatesInput` gain `carrier?: string` (defaults `"shiprocket"`)
- `resolveShippingProvider(container, carrier)` drives provider selection; carrier persisted in `fulfillment.data.carrier`
- 3 API routes pass carrier through (order shipment, order rates, inventory-order rates)

**P2 — Admin/partner inventory-order Carrier Select**  
- Carrier `Select` in `inventory-order-shipment-modal.tsx` and `inventory-order-create-shipment.tsx`
- Courier/rates picker gated on `carrier === "shiprocket"`; Delhivery shows direct "Generate Label" button

**P3 — Admin/partner order-fulfillment Carrier Select**  
- `useShiprocketRates` / `useGenerateShiprocketLabel` accept `carrier` in query/variables
- Carrier Select in courier dialog (admin) and action footer (partner)
- Button labels carrier-aware

**P4 — 6 carrier-neutral route aliases**  
- `admin/orders/:id/fulfillment-label`, `fulfillment-rates`, `fulfillments/:fid/fulfillment-shipment`
- `partners/orders/:id/fulfillment-label`
- `admin/inventory-orders/:id/fulfillment-rates`, `partners/inventory-orders/:orderId/fulfillment-rates`
- Hook wrappers: `useFulfillmentRates`, `useGenerateFulfillmentLabel` (default carrier `"shiprocket"`)

**Integration tests** — 32/32 passing  
- `shiprocket-rates.spec.ts`: 6 tests (carrier params + alias routes + Delhivery 400)
- `inventory-order-shiprocket-shipment.spec.ts`: 20 tests (carrier params + alias routes + Delhivery 400)
- `partner-order-shiprocket-label.spec.ts`: 4 tests (carrier body)
- `partner-shiprocket-routes.spec.ts`: 2 tests (alias ownership guard)

## Not in this PR

- **Data plumbing** (issue #954): provisioning `manual` + region-mapped in-house shipping options across partner stores per region — the region→provider mapping table needs your confirmation before build
- **Native fulfillment-provider activation** (P5 in #649): enabling providers via Medusa's native fulfillment-provider plugin contract

Refs #649