### PR TITLE
fix(faire): add null fallback for taxonomyTypesCache return

### DIFF
--- a/packages/medusa-plugin-faire-store-sync/src/lib/faire-client.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/lib/faire-client.ts
@@ -502,7 +502,7 @@ export class FaireClient {
         this.taxonomyTypesCache = []
       }
     }
-    return this.taxonomyTypesCache
+    return this.taxonomyTypesCache ?? []
   }
 
   async resolveTaxonomyTypeId(


### PR DESCRIPTION
The `getTaxonomyTypes` method returns `Promise<Array<{id;name}>>` (non-nullable) but `taxonomyTypesCache` field is declared as `| null`. After the if-block the cache is guaranteed to be set, but TypeScript doesn't narrow it. Adding `?? []` fallback to satisfy the type checker.

```
packages/medusa-plugin-faire-store-sync/src/lib/faire-client.ts:505:5 - error TS2322
Type '{ id: string; name: string; }[] | null' is not assignable to type '{ id: string; name: string; }[]'
```