### PR TITLE
fix(faire): unblock 0.2.7 publish — getTaxonomyTypes nullable-cache type error

### DIFF
--- a/packages/medusa-plugin-faire-store-sync/src/lib/faire-client.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/lib/faire-client.ts
@@ -502,7 +502,7 @@ export class FaireClient {
         this.taxonomyTypesCache = []
       }
     }
-    return this.taxonomyTypesCache
+    return this.taxonomyTypesCache ?? []
   }
 
   async resolveTaxonomyTypeId(


### PR DESCRIPTION
## Why prod's Faire plugin is stale
The backend consumes `@jytextiles/medusa-plugin-faire-store-sync: "latest"` from npm. The local plugin is at **0.2.7** (#972), but its **npm publish failed** ([run 29099986962](https://github.com/Jaal-Yantra-Textiles/v2/actions/runs/29099986962)) at the `medusa plugin:build` step:

```
src/lib/faire-client.ts:505 - error TS2322:
  Type '{ id: string; name: string; }[] | null' is not assignable to type '{ id: string; name: string; }[]'.
```

So 0.2.7 never reached npm — npm's latest is still 0.2.6, which is exactly what prod runs (prod *did* successfully deploy 0.2.6 at 07:04 today). This is a plugin-release bug, not a prod-deploy problem.

## Fix
`taxonomyTypesCache` is a mutable class property (`Array | null`), so TS won't narrow it to non-null after the if/try-catch block. Coalesce the return with `?? []`. Verified: `pnpm run build` (== `medusa plugin:build`) now completes successfully.

## After merge
The publish workflow republishes 0.2.7 (never hit npm, so the version is free). Then bump the backend lockfile to 0.2.7 (`pnpm update @jytextiles/medusa-plugin-faire-store-sync --latest`) + deploy so prod picks it up — `"latest"` + `--frozen-lockfile` won't auto-pull it otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)