### PR TITLE
fix(config): register investor module in prod config — fixes 'companies.industry does not exist' crash

### DIFF
--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -545,5 +545,8 @@ module.exports = defineConfig({
   {
     resolve: "./src/modules/platform-tax-identity",
   },
+  {
+    resolve: "./src/modules/investor",
+  },
 ],
 });


### PR DESCRIPTION
## Why prod crashed with `column "industry" of relation "companies" does not exist`
- The **`company` module model** declares `industry`, `cap_table_id`, `investor_dashboard_enabled`, `description` (`company/models/company.ts:26-29`).
- The company module has **no migration** for those columns — the only migration adding them is **hand-rolled inside the `investor` module** (`investor/migrations/Migration20260709120000.ts`, the `alter table companies …` block).
- Medusa runs a module's migrations **only when the module is registered**. `medusa-config.prod.ts` was **missing `./src/modules/investor`**, so in prod that migration never ran → the columns were never created → the registered company module's queries fail.
- Dev works because `medusa-config.ts` registers investor.

## Fix
Register `./src/modules/investor` in `medusa-config.prod.ts` (parity with base). The investor migration was never applied in prod (module never loaded), so it's **pending** — `predeploy:force` (`db:migrate`) runs it on deploy and adds the columns (idempotent `add column if not exists`; `companies` already exists) **before** the server starts. No manual SQL/ECS task needed.

> Note: a prior identical fix (`c687fdb6a`) was stranded on the DP-job branch — #978 auto-merged on its required `test` check before that commit landed, and `check:prod-config` isn't a merge-blocking check. Worth making it required to prevent recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)