### PR TITLE
feat(investor): projections tab (marketing + own position) + SAFE stake tagging + CORS fix

### DIFF
--- a/apps/backend/src/admin/hooks/api/cap-tables-admin.ts
+++ b/apps/backend/src/admin/hooks/api/cap-tables-admin.ts
@@ -206,6 +206,7 @@ export type ProvisionStakePayload = {
   share_price?: number | null
   total_invested?: number | null
   share_class_id?: string
+  funding_round_id?: string
   status?: "active" | "fully_paid" | "partially_paid" | "unpaid" | "cancelled"
   certificate_number?: string
 }

--- a/apps/backend/src/admin/routes/companies/[id]/@provision-stake/page.tsx
+++ b/apps/backend/src/admin/routes/companies/[id]/@provision-stake/page.tsx
@@ -30,9 +30,14 @@ type FormValues = {
   number_of_shares: string
   share_price: string
   total_invested: string
+  share_class_id: string
+  funding_round_id: string
   status: (typeof STATUSES)[number]
   certificate_number: string
 }
+
+// Sentinel for "no share class / round" — Select can't hold an empty string value.
+const NONE = "__none__"
 
 const ProvisionStakeForm = ({ companyId }: { companyId: string }) => {
   const { cap_tables = [] } = useCompanyCapTables(companyId)
@@ -51,10 +56,15 @@ const ProvisionStakeForm = ({ companyId }: { companyId: string }) => {
       number_of_shares: "",
       share_price: "",
       total_invested: "",
+      share_class_id: NONE,
+      funding_round_id: NONE,
       status: "fully_paid",
       certificate_number: "",
     },
   })
+
+  const shareClasses = capTable?.share_classes ?? []
+  const fundingRounds = capTable?.funding_rounds ?? []
 
   const mode = form.watch("mode")
   const shares = form.watch("number_of_shares")
@@ -100,6 +110,8 @@ const ProvisionStakeForm = ({ companyId }: { companyId: string }) => {
       number_of_shares: numShares,
       share_price: v.share_price ? Number(v.share_price) : undefined,
       total_invested: totalInvested,
+      share_class_id: v.share_class_id !== NONE ? v.share_class_id : undefined,
+      funding_round_id: v.funding_round_id !== NONE ? v.funding_round_id : undefined,
       status: v.status,
       certificate_number: v.certificate_number || undefined,
     })
@@ -225,6 +237,58 @@ const ProvisionStakeForm = ({ companyId }: { companyId: string }) => {
             {...(autoInvested ? {} : form.register("total_invested"))}
           />
         </div>
+
+        {/* Classify the holding: which share class (e.g. a SAFE) and which
+            round it came from. Optional — leave as "None" for an untagged
+            provision. Only render when the cap table actually has classes/rounds. */}
+        {(shareClasses.length > 0 || fundingRounds.length > 0) && (
+          <div className="grid grid-cols-2 gap-4">
+            {shareClasses.length > 0 && (
+              <div className="flex flex-col gap-y-2">
+                <Label size="small" weight="plus">Share class</Label>
+                <Controller
+                  control={form.control}
+                  name="share_class_id"
+                  render={({ field }) => (
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <Select.Trigger><Select.Value /></Select.Trigger>
+                      <Select.Content>
+                        <Select.Item value={NONE}>None</Select.Item>
+                        {shareClasses.map((sc) => (
+                          <Select.Item key={sc.id} value={sc.id}>
+                            {sc.name}{sc.class_type ? ` · ${sc.class_type}` : ""}
+                          </Select.Item>
+                        ))}
+                      </Select.Content>
+                    </Select>
+                  )}
+                />
+              </div>
+            )}
+            {fundingRounds.length > 0 && (
+              <div className="flex flex-col gap-y-2">
+                <Label size="small" weight="plus">Funding round</Label>
+                <Controller
+                  control={form.control}
+                  name="funding_round_id"
+                  render={({ field }) => (
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <Select.Trigger><Select.Value /></Select.Trigger>
+                      <Select.Content>
+                        <Select.Item value={NONE}>None</Select.Item>
+                        {fundingRounds.map((fr) => (
+                          <Select.Item key={fr.id} value={fr.id}>
+                            {fr.name}{fr.round_type ? ` · ${fr.round_type}` : ""}
+                          </Select.Item>
+                        ))}
+                      </Select.Content>
+                    </Select>
+                  )}
+                />
+              </div>
+            )}
+          </div>
+        )}
 
         <div className="grid grid-cols-2 gap-4">
           <div className="flex flex-col gap-y-2">

--- a/apps/backend/src/api/investors/me/projections/route.ts
+++ b/apps/backend/src/api/investors/me/projections/route.ts
@@ -1,0 +1,117 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { requireInvestor } from "../../helpers"
+
+// GET /investors/me/projections — the investor's OWN position, per cap table and
+// as a portfolio total. This is deliberately bespoke (not a shared stats panel)
+// because every figure is scoped to the authenticated investor:
+//   ownership_pct = my_shares / shares_outstanding
+//   implied_value = ownership_pct × post_money_valuation
+//   multiple      = implied_value / my_invested   (paper MOIC)
+// Companies are resolved through the investor pipeline, exactly like
+// /investors/me/cap-table.
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const investor = await requireInvestor(req.auth_context, req.scope)
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: pipelines } = await query.graph({
+    entity: "investor_pipeline",
+    filters: { investor_id: investor.id },
+    fields: ["company_id"],
+  })
+  const companyIds = [
+    ...new Set((pipelines || []).map((p: any) => p.company_id).filter(Boolean)),
+  ]
+  if (!companyIds.length) {
+    return res.json({ positions: [], portfolio: emptyPortfolio(), count: 0 })
+  }
+
+  const { data: capTables } = await query.graph({
+    entity: "cap_tables",
+    filters: { company_id: companyIds },
+    fields: [
+      "id",
+      "name",
+      "company_id",
+      "currency_code",
+      "total_shares_outstanding",
+      "fully_diluted_shares",
+      "post_money_valuation",
+      "stakes.*",
+      "stakes.investor.id",
+    ],
+  })
+
+  const positions = (capTables || []).map((ct: any) => {
+    const stakes = (ct.stakes || []) as any[]
+    const mine = stakes.filter(
+      (s) => s.investor?.id === investor.id || s.investor_id === investor.id
+    )
+
+    const myShares = mine.reduce((sum, s) => sum + (Number(s.number_of_shares) || 0), 0)
+    const myInvested = mine.reduce((sum, s) => sum + (Number(s.total_invested) || 0), 0)
+
+    // Prefer the recorded outstanding total; fall back to the sum of every
+    // stake's shares so ownership is still meaningful on a lightly-maintained
+    // cap table.
+    const outstanding =
+      Number(ct.total_shares_outstanding) ||
+      Number(ct.fully_diluted_shares) ||
+      stakes.reduce((sum, s) => sum + (Number(s.number_of_shares) || 0), 0)
+
+    const ownershipPct =
+      outstanding > 0 ? (myShares / outstanding) * 100 : null
+    const postMoney = Number(ct.post_money_valuation) || null
+    const impliedValue =
+      ownershipPct != null && postMoney != null
+        ? Math.round((postMoney * ownershipPct) / 100)
+        : null
+    const multiple =
+      impliedValue != null && myInvested > 0
+        ? Math.round((impliedValue / myInvested) * 100) / 100
+        : null
+
+    return {
+      cap_table_id: ct.id,
+      cap_table_name: ct.name,
+      company_id: ct.company_id,
+      currency_code: ct.currency_code ?? null,
+      my_shares: myShares,
+      my_invested: myInvested,
+      shares_outstanding: outstanding || null,
+      ownership_pct: ownershipPct == null ? null : Math.round(ownershipPct * 100) / 100,
+      post_money_valuation: postMoney,
+      implied_value: impliedValue,
+      multiple,
+      stake_count: mine.length,
+    }
+  })
+
+  const portfolio = positions.reduce(
+    (acc, p) => {
+      acc.total_invested += p.my_invested
+      acc.total_implied_value += p.implied_value ?? 0
+      acc.cap_tables += 1
+      return acc
+    },
+    emptyPortfolio()
+  )
+  portfolio.blended_multiple =
+    portfolio.total_invested > 0
+      ? Math.round((portfolio.total_implied_value / portfolio.total_invested) * 100) / 100
+      : null
+
+  res.json({ positions, portfolio, count: positions.length })
+}
+
+function emptyPortfolio() {
+  return {
+    total_invested: 0,
+    total_implied_value: 0,
+    blended_multiple: null as number | null,
+    cap_tables: 0,
+  }
+}

--- a/apps/backend/src/api/investors/stats/panels/[id]/data/route.ts
+++ b/apps/backend/src/api/investors/stats/panels/[id]/data/route.ts
@@ -1,0 +1,51 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { STATS_MODULE } from "../../../../../../modules/stats"
+import StatsService from "../../../../../../modules/stats/service"
+import { resolvePanel } from "../../../../../../modules/stats/resolver"
+import { requireInvestor } from "../../../../helpers"
+
+// GET /investors/stats/panels/:id/data — resolve a single investor-visible panel.
+// 404s unless the panel is explicitly flagged `metadata.investor === true`, so
+// investor auth can never be used to read an arbitrary internal dashboard panel.
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  try {
+    await requireInvestor(req.auth_context, req.scope)
+
+    const service: StatsService = req.scope.resolve(STATS_MODULE)
+    const { id } = req.params
+    const skipCache = req.query?.skip_cache === "true"
+
+    const panel = await service.retrieveStatsPanel(id)
+    if (((panel as any).metadata ?? {})?.investor !== true) {
+      throw new MedusaError(MedusaError.Types.NOT_FOUND, "Panel not found")
+    }
+
+    const result = await resolvePanel(
+      req.scope,
+      {
+        id: panel.id,
+        dashboard_id: (panel as any).dashboard_id,
+        operation_type: panel.operation_type,
+        operation_options: (panel.operation_options ?? {}) as Record<string, any>,
+        display: (panel.display ?? {}) as Record<string, any>,
+        cache_ttl_seconds: panel.cache_ttl_seconds,
+      },
+      { skipCache }
+    )
+
+    res.json({
+      panel_id: panel.id,
+      name: panel.name,
+      type: panel.type,
+      ...result,
+      display: panel.display ?? {},
+    })
+  } catch (error: any) {
+    const notFound = error.type === "not_found" || error.type === MedusaError.Types.NOT_FOUND
+    res.status(notFound ? 404 : 400).json({ error: error.message })
+  }
+}

--- a/apps/backend/src/api/investors/stats/panels/route.ts
+++ b/apps/backend/src/api/investors/stats/panels/route.ts
@@ -1,0 +1,45 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { STATS_MODULE } from "../../../../modules/stats"
+import StatsService from "../../../../modules/stats/service"
+import { requireInvestor } from "../../helpers"
+
+// GET /investors/stats/panels — the stats panels an investor is allowed to see.
+// A panel opts in to the investor portal by setting `metadata.investor === true`
+// (mirrors the `metadata.public === true` gate the /web embed uses). Returns the
+// panel shells (no resolved data) so the Projections tab can lay out its grid;
+// data is fetched per-panel from `./[id]/data`.
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  await requireInvestor(req.auth_context, req.scope)
+
+  const service: StatsService = req.scope.resolve(STATS_MODULE)
+  const panels = await service.listStatsPanels(
+    {},
+    {
+      take: 500,
+      order: { y: "ASC", x: "ASC" },
+    }
+  )
+
+  const investorPanels = (panels || []).filter(
+    (p: any) => (p.metadata ?? {})?.investor === true
+  )
+
+  res.json({
+    panels: investorPanels.map((p: any) => ({
+      id: p.id,
+      dashboard_id: p.dashboard_id,
+      name: p.name,
+      type: p.type,
+      x: p.x,
+      y: p.y,
+      width: p.width,
+      height: p.height,
+      display: p.display ?? {},
+      operation_type: p.operation_type,
+    })),
+    count: investorPanels.length,
+  })
+}

--- a/apps/backend/src/modules/visual_flows/operations/ads-efficiency.ts
+++ b/apps/backend/src/modules/visual_flows/operations/ads-efficiency.ts
@@ -1,0 +1,157 @@
+import { z } from "@medusajs/framework/zod"
+import { OperationDefinition, OperationContext, OperationResult } from "./types"
+import { SOCIALS_MODULE } from "../../socials"
+import { FX_RATES_MODULE } from "../../fx_rates"
+
+// Paid-marketing efficiency across Meta + Google, normalized to one currency.
+// Reads account-level insight rows only (level = account/customer) so we don't
+// double-count campaign/adset/ad breakdowns of the same spend. Spend is stored
+// in each ad account's native currency; we convert to `base_currency` via the
+// latest cached FX rate (a small, documented error on historical rows — same
+// tradeoff the /admin/ads/insights route makes).
+//
+//   CAC  = spend / conversions
+//   ROAS = conversions_value / spend   (Google only reports conversions_value;
+//          Meta insight rows have no revenue field, so ROAS is Google-weighted)
+const adsEfficiencyOptionsSchema = z.object({
+  last_days: z
+    .number()
+    .int()
+    .positive()
+    .max(3650)
+    .default(30)
+    .describe("Rolling window (days) over the insight date."),
+  base_currency: z
+    .string()
+    .default("INR")
+    .describe("Currency to normalize spend/revenue into."),
+})
+
+function windowStartISO(lastDays: number): string {
+  const to = new Date()
+  to.setUTCHours(0, 0, 0, 0)
+  const from = new Date(to)
+  from.setUTCDate(from.getUTCDate() - lastDays)
+  return from.toISOString().slice(0, 10)
+}
+
+export const adsEfficiencyOperation: OperationDefinition = {
+  type: "ads_efficiency",
+  name: "Ads Efficiency (spend / CAC / ROAS)",
+  description:
+    "Roll up Meta + Google ad spend, conversions and revenue over a window, FX-normalized to one currency, with CAC and ROAS.",
+  icon: "currency-dollar",
+  category: "data",
+
+  optionsSchema: adsEfficiencyOptionsSchema,
+
+  defaultOptions: {
+    last_days: 30,
+    base_currency: "INR",
+  },
+
+  execute: async (options: any, context: OperationContext): Promise<OperationResult> => {
+    try {
+      const parsed = adsEfficiencyOptionsSchema.parse(options ?? {})
+      const base = parsed.base_currency.toUpperCase()
+      const fromDate = windowStartISO(parsed.last_days)
+
+      const socials = context.container.resolve(SOCIALS_MODULE) as any
+      let fx: any = null
+      try {
+        fx = context.container.resolve(FX_RATES_MODULE)
+      } catch {
+        // FX module unavailable — conversions marked incomplete below.
+      }
+
+      let fxIncomplete = false
+      const rateCache = new Map<string, number>()
+      const toBase = async (amount: number, ccy?: string | null): Promise<number> => {
+        const from = String(ccy || base).toUpperCase()
+        if (!Number.isFinite(amount) || amount === 0) return 0
+        if (from === base) return amount
+        if (!fx) {
+          fxIncomplete = true
+          return amount
+        }
+        try {
+          if (!rateCache.has(from)) {
+            rateCache.set(from, await fx.getRate(from, base))
+          }
+          return amount * (rateCache.get(from) as number)
+        } catch {
+          fxIncomplete = true
+          return amount
+        }
+      }
+
+      // ── Meta (account level, native `spend` in `currency`) ──────────────
+      let metaSpend = 0
+      let metaConversions = 0
+      try {
+        const [metaRows] = await socials.listAndCountAdInsights(
+          { level: "account", date_start: { $gte: fromDate } },
+          { take: 20_000, order: { date_start: "DESC" } }
+        )
+        for (const r of metaRows as any[]) {
+          metaSpend += await toBase(Number(r.spend) || 0, r.currency)
+          metaConversions += Number(r.conversions) || 0
+        }
+      } catch {
+        // Meta insights absent in this env — leave meta totals at zero.
+      }
+
+      // ── Google (customer level, `cost_micros` in `currency_code`) ───────
+      let googleSpend = 0
+      let googleConversions = 0
+      let googleRevenue = 0
+      try {
+        const [gRows] = await socials.listAndCountGoogleAdsInsights(
+          { level: "customer", date: { $gte: fromDate } },
+          { take: 20_000, order: { date: "DESC" } }
+        )
+        for (const r of gRows as any[]) {
+          const spend = (Number(r.cost_micros) || 0) / 1_000_000
+          googleSpend += await toBase(spend, r.currency_code)
+          googleConversions += Number(r.conversions) || 0
+          googleRevenue += await toBase(
+            Number(r.conversions_value) || 0,
+            r.currency_code
+          )
+        }
+      } catch {
+        // Google insights absent in this env — leave google totals at zero.
+      }
+
+      const spend = metaSpend + googleSpend
+      const conversions = metaConversions + googleConversions
+      const conversionsValue = googleRevenue // only Google reports revenue
+      const cac = conversions > 0 ? spend / conversions : null
+      const roas = spend > 0 ? conversionsValue / spend : null
+
+      return {
+        success: true,
+        data: {
+          currency: base,
+          window_days: parsed.last_days,
+          spend: Math.round(spend),
+          conversions: Math.round(conversions),
+          conversions_value: Math.round(conversionsValue),
+          cac: cac == null ? null : Math.round(cac),
+          roas: roas == null ? null : Math.round(roas * 100) / 100,
+          by_platform: {
+            meta: { spend: Math.round(metaSpend), conversions: Math.round(metaConversions) },
+            google: {
+              spend: Math.round(googleSpend),
+              conversions: Math.round(googleConversions),
+              conversions_value: Math.round(googleRevenue),
+            },
+          },
+          fx_incomplete: fxIncomplete,
+        },
+      }
+    } catch (error: any) {
+      return { success: false, error: error.message, errorStack: error.stack }
+    }
+  },
+}

--- a/apps/backend/src/modules/visual_flows/operations/gmv-projection.ts
+++ b/apps/backend/src/modules/visual_flows/operations/gmv-projection.ts
@@ -1,0 +1,124 @@
+import { z } from "@medusajs/framework/zod"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { OperationDefinition, OperationContext, OperationResult } from "./types"
+
+// Forward GMV run-rate projection. Mirrors the marketing-site metrics endpoint
+// (src/api/web/website/[domain]/marketing/metrics/route.ts) so the investor
+// Projections tab and the public marketing strip tell the same story:
+//   projected = brands_live × per_brand_monthly × months
+//             + artisans   × per_artisan_monthly × months
+// Conservative, defensible run-rate framing — not an aspirational ceiling.
+const PROJECTION_PER_BRAND_MONTHLY: Record<string, number> = {
+  INR: 100_000,
+  USD: 1_200,
+  EUR: 1_100,
+}
+const PROJECTION_PER_ARTISAN_MONTHLY: Record<string, number> = {
+  INR: 5_000,
+  USD: 60,
+  EUR: 55,
+}
+
+// Platform's own marketing hosts — excluded from brands_live so the number
+// reflects ateliers, not us. Same set the marketing-metrics route excludes.
+const PLATFORM_HOSTS = new Set<string>([
+  "jaalyantra.com",
+  "www.jaalyantra.com",
+  "kindhealth.com",
+  "www.kindhealth.com",
+])
+
+const gmvProjectionOptionsSchema = z.object({
+  currency: z
+    .string()
+    .default("INR")
+    .describe("Currency the projection is expressed in (INR | USD | EUR)."),
+  window_days: z
+    .number()
+    .int()
+    .positive()
+    .max(3650)
+    .default(90)
+    .describe("Projection horizon in days. Monthly run-rate × (window_days / 30)."),
+})
+
+export const gmvProjectionOperation: OperationDefinition = {
+  type: "gmv_projection",
+  name: "GMV Projection",
+  description:
+    "Forward GMV run-rate from live brands + artisans over a horizon. Mirrors the marketing-site projection formula.",
+  icon: "arrow-trending-up",
+  category: "data",
+
+  optionsSchema: gmvProjectionOptionsSchema,
+
+  defaultOptions: {
+    currency: "INR",
+    window_days: 90,
+  },
+
+  execute: async (options: any, context: OperationContext): Promise<OperationResult> => {
+    try {
+      const parsed = gmvProjectionOptionsSchema.parse(options ?? {})
+      const currency = parsed.currency.toUpperCase()
+      const query = context.container.resolve(ContainerRegistrationKeys.QUERY)
+
+      const [partnersRes, websitesRes] = await Promise.all([
+        query.graph({
+          entity: "partners",
+          fields: ["vercel_linked", "storefront_domain"],
+          filters: { status: "active" },
+          pagination: { take: 1000 },
+        }).catch(() => ({ data: [] })),
+        query.graph({
+          entity: "websites",
+          fields: ["id", "domain", "status"],
+          filters: { status: "Active" },
+          pagination: { take: 200 },
+        }).catch(() => ({ data: [] })),
+      ])
+
+      // Anyone without a provisioned storefront counts as an artisan — aligned
+      // with the partners route: workspace_type is a sidebar concept, not a
+      // marketing classifier.
+      let artisans = 0
+      for (const p of (partnersRes.data || []) as any[]) {
+        const isLiveBrand = p.vercel_linked === true && !!p.storefront_domain
+        if (!isLiveBrand) artisans++
+      }
+
+      const sites = (websitesRes.data || []) as Array<{ domain: string }>
+      const brandsLive = sites.filter(
+        (w) => !PLATFORM_HOSTS.has(String(w.domain || "").toLowerCase())
+      ).length
+
+      const perBrand =
+        PROJECTION_PER_BRAND_MONTHLY[currency] ?? PROJECTION_PER_BRAND_MONTHLY.USD
+      const perArtisan =
+        PROJECTION_PER_ARTISAN_MONTHLY[currency] ?? PROJECTION_PER_ARTISAN_MONTHLY.USD
+      const months = parsed.window_days / 30
+      const amount = Math.round(
+        brandsLive * perBrand * months + artisans * perArtisan * months
+      )
+
+      return {
+        success: true,
+        data: {
+          amount,
+          currency,
+          window_days: parsed.window_days,
+          source: "projected",
+          brands_live: brandsLive,
+          artisans,
+          formula: {
+            per_brand_monthly: perBrand,
+            per_artisan_monthly: perArtisan,
+            months,
+          },
+        },
+      }
+    } catch (error: any) {
+      return { success: false, error: error.message, errorStack: error.stack }
+    }
+  },
+}

--- a/apps/backend/src/modules/visual_flows/operations/index.ts
+++ b/apps/backend/src/modules/visual_flows/operations/index.ts
@@ -34,6 +34,8 @@ export { generatePartnerDeeplinkOperation } from "./generate-partner-deeplink"
 export { partnerAnalyticsDigestOperation } from "./partner-analytics-digest"
 export { marketingDailyIdeasEmailOperation } from "./marketing-daily-ideas-email"
 export { waitForEventOperation } from "./wait-for-event"
+export { gmvProjectionOperation } from "./gmv-projection"
+export { adsEfficiencyOperation } from "./ads-efficiency"
 
 // Import all operations and register them
 import { operationRegistry } from "./types"
@@ -68,6 +70,8 @@ import { generatePartnerDeeplinkOperation } from "./generate-partner-deeplink"
 import { partnerAnalyticsDigestOperation } from "./partner-analytics-digest"
 import { marketingDailyIdeasEmailOperation } from "./marketing-daily-ideas-email"
 import { waitForEventOperation } from "./wait-for-event"
+import { gmvProjectionOperation } from "./gmv-projection"
+import { adsEfficiencyOperation } from "./ads-efficiency"
 
 // Register all built-in operations
 export function registerBuiltInOperations(): void {
@@ -113,6 +117,8 @@ export function registerBuiltInOperations(): void {
   operationRegistry.register(cartRecoveryStatsOperation)
   operationRegistry.register(resolveCartRecoveryUrlsOperation)
   operationRegistry.register(partnerAnalyticsDigestOperation)
+  operationRegistry.register(gmvProjectionOperation)
+  operationRegistry.register(adsEfficiencyOperation)
 }
 
 // Auto-register on import

--- a/apps/backend/src/scripts/seed-investor-projection-panels.ts
+++ b/apps/backend/src/scripts/seed-investor-projection-panels.ts
@@ -1,0 +1,134 @@
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { STATS_MODULE } from "../modules/stats"
+
+/**
+ * Seeds the "Investor Projections" stats dashboard + its panels, each flagged
+ * `metadata.investor === true` so the investor-ui Projections tab can read them
+ * through the investor-scoped resolver (`GET /investors/stats/panels`).
+ *
+ * Idempotent: re-running updates the existing dashboard's panels in place
+ * (matched by name) rather than duplicating them.
+ *
+ * Usage:
+ *   npx medusa exec ./src/scripts/seed-investor-projection-panels.ts
+ */
+const DASHBOARD_NAME = "Investor Projections"
+
+const PANELS = [
+  {
+    name: "GMV projection",
+    type: "metric",
+    x: 0, y: 0, width: 6, height: 2,
+    operation_type: "gmv_projection",
+    operation_options: { currency: "INR", window_days: 90 },
+  },
+  {
+    name: "GMV trend",
+    type: "area",
+    x: 6, y: 0, width: 6, height: 2,
+    operation_type: "time_series",
+    operation_options: {
+      entity: "marketing_metric_snapshot",
+      dateField: "captured_for_date",
+      filters: { metric_key: "platform_net_gmv" },
+      aggregate: { fn: "sum", field: "value" },
+      precision: "week",
+      range: { last_days: 90 },
+    },
+  },
+  {
+    name: "Unique visitors (30d)",
+    type: "line",
+    x: 0, y: 2, width: 6, height: 2,
+    operation_type: "time_series",
+    operation_options: {
+      entity: "analytics_daily_stats",
+      dateField: "date",
+      aggregate: { fn: "sum", field: "unique_visitors" },
+      precision: "day",
+      range: { last_days: 30 },
+    },
+  },
+  {
+    name: "Conversion rate (30d avg)",
+    type: "metric",
+    x: 6, y: 2, width: 6, height: 2,
+    operation_type: "aggregate_data",
+    operation_options: {
+      entity: "marketing_metric_snapshot",
+      dateField: "captured_for_date",
+      filters: { metric_key: "storefront_conversion_rate" },
+      aggregate: { fn: "avg", field: "value" },
+      range: { last_days: 30 },
+    },
+  },
+  {
+    name: "Ads efficiency (30d)",
+    type: "metric",
+    x: 0, y: 4, width: 12, height: 2,
+    operation_type: "ads_efficiency",
+    operation_options: { last_days: 30, base_currency: "INR" },
+  },
+]
+
+export default async function seedInvestorProjectionPanels({ container }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const stats: any = container.resolve(STATS_MODULE)
+
+  // Find or create the dashboard.
+  const existing = await stats.listStatsDashboards({ name: DASHBOARD_NAME }, { take: 1 })
+  let dashboard = (existing || [])[0]
+  if (!dashboard) {
+    ;[dashboard] = await stats.createStatsDashboards([
+      {
+        name: DASHBOARD_NAME,
+        description: "Growth, marketing efficiency and valuation metrics shown to investors.",
+        icon: "arrow-trending-up",
+        color: "#3b82f6",
+        metadata: { investor: true },
+      },
+    ])
+    logger.info(`Created dashboard ${dashboard.id} (${DASHBOARD_NAME})`)
+  } else {
+    logger.info(`Reusing dashboard ${dashboard.id} (${DASHBOARD_NAME})`)
+  }
+
+  const currentPanels = await stats.listStatsPanels(
+    { dashboard_id: dashboard.id },
+    { take: 500 }
+  )
+  const byName = new Map<string, any>()
+  for (const p of currentPanels || []) byName.set(p.name, p)
+
+  for (const spec of PANELS) {
+    const payload = {
+      dashboard_id: dashboard.id,
+      name: spec.name,
+      type: spec.type,
+      x: spec.x,
+      y: spec.y,
+      width: spec.width,
+      height: spec.height,
+      operation_type: spec.operation_type,
+      operation_options: spec.operation_options,
+      display: {},
+      cache_ttl_seconds: 300,
+      metadata: { investor: true },
+    }
+
+    const found = byName.get(spec.name)
+    if (found) {
+      await stats.updateStatsPanels({ id: found.id, ...payload })
+      logger.info(`Updated panel "${spec.name}" (${found.id})`)
+    } else {
+      const [created] = await stats.createStatsPanels([payload])
+      logger.info(`Created panel "${spec.name}" (${created.id})`)
+    }
+  }
+
+  logger.info(
+    `Investor projection panels seeded on dashboard ${dashboard.id}. ` +
+      `They are visible at GET /investors/stats/panels.`
+  )
+}

--- a/apps/investor-ui/src/hooks/api/projections.tsx
+++ b/apps/investor-ui/src/hooks/api/projections.tsx
@@ -1,0 +1,101 @@
+import { useQuery } from "@tanstack/react-query"
+import { sdk } from "../../lib/client"
+
+// Investor Projections tab data. Two sources:
+//  1. Admin-authored stats panels flagged `metadata.investor === true`, resolved
+//     through the investor-scoped resolver (marketing/growth/ads metrics).
+//  2. The investor's own position (bespoke, per-investor).
+
+export type InvestorPanel = {
+  id: string
+  dashboard_id?: string
+  name: string
+  type: string
+  x?: number
+  y?: number
+  width?: number
+  height?: number
+  display?: Record<string, any>
+  operation_type: string
+}
+
+export type PanelData = {
+  panel_id: string
+  name?: string
+  type?: string
+  data: any
+  error?: string
+  operation_type: string
+  resolved_at: string
+  display?: Record<string, any>
+}
+
+export type ProjectionPosition = {
+  cap_table_id: string
+  cap_table_name: string
+  company_id?: string
+  currency_code?: string | null
+  my_shares: number
+  my_invested: number
+  shares_outstanding?: number | null
+  ownership_pct?: number | null
+  post_money_valuation?: number | null
+  implied_value?: number | null
+  multiple?: number | null
+  stake_count: number
+}
+
+export type ProjectionPortfolio = {
+  total_invested: number
+  total_implied_value: number
+  blended_multiple: number | null
+  cap_tables: number
+}
+
+export const projectionsQueryKeys = {
+  panels: ["investor-panels"] as const,
+  panelData: (id: string) => ["investor-panel-data", id] as const,
+  myProjections: ["investor-my-projections"] as const,
+}
+
+export const useInvestorPanels = () => {
+  const { data, ...rest } = useQuery({
+    queryFn: () =>
+      sdk.client.fetch<{ panels: InvestorPanel[]; count: number }>(
+        "/investors/stats/panels",
+        { method: "GET" }
+      ),
+    queryKey: projectionsQueryKeys.panels,
+  })
+  return { panels: data?.panels ?? [], count: data?.count ?? 0, ...rest }
+}
+
+export const useInvestorPanelData = (id: string, enabled = true) => {
+  const { data, ...rest } = useQuery({
+    queryFn: () =>
+      sdk.client.fetch<PanelData>(`/investors/stats/panels/${id}/data`, {
+        method: "GET",
+      }),
+    queryKey: projectionsQueryKeys.panelData(id),
+    enabled: enabled && !!id,
+  })
+  return { panel: data, ...rest }
+}
+
+export const useMyProjections = () => {
+  const { data, ...rest } = useQuery({
+    queryFn: () =>
+      sdk.client.fetch<{
+        positions: ProjectionPosition[]
+        portfolio: ProjectionPortfolio
+        count: number
+      }>("/investors/me/projections", { method: "GET" }),
+    queryKey: projectionsQueryKeys.myProjections,
+  })
+  return {
+    positions: data?.positions ?? [],
+    portfolio: data?.portfolio,
+    count: data?.count ?? 0,
+    ...rest,
+  }
+}

--- a/apps/investor-ui/src/routes/projections/index.tsx
+++ b/apps/investor-ui/src/routes/projections/index.tsx
@@ -1,8 +1,266 @@
-import { ComingSoon } from "../_placeholder/coming-soon"
+import { Badge, Container, Heading, Skeleton, Text } from "@medusajs/ui"
+import type { ReactNode } from "react"
+import {
+  InvestorPanel,
+  useInvestorPanelData,
+  useInvestorPanels,
+  useMyProjections,
+  type ProjectionPortfolio,
+} from "../../hooks/api/projections"
 
-export const Component = () => (
-  <ComingSoon
-    title="Projections"
-    description="Valuation and return projections will appear here."
-  />
+const nf = new Intl.NumberFormat()
+const money = (v?: number | null, ccy?: string | null) =>
+  v == null ? "—" : `${ccy ? ccy + " " : ""}${nf.format(Math.round(Number(v)))}`
+const num = (v?: number | null) => (v == null ? "—" : nf.format(Number(v)))
+const pct = (v?: number | null) => (v == null ? "—" : `${nf.format(Number(v))}%`)
+
+// ── Tiny inline sparkline (no chart dependency; matches OwnershipDonut's
+//    hand-rolled SVG approach). ──────────────────────────────────────────
+const Sparkline = ({
+  points,
+  height = 48,
+  width = 220,
+}: {
+  points: number[]
+  height?: number
+  width?: number
+}) => {
+  if (!points.length) return null
+  const max = Math.max(...points, 1)
+  const min = Math.min(...points, 0)
+  const span = max - min || 1
+  const step = points.length > 1 ? width / (points.length - 1) : width
+  const path = points
+    .map((p, i) => {
+      const x = i * step
+      const y = height - ((p - min) / span) * height
+      return `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`
+    })
+    .join(" ")
+  const area = `${path} L${width},${height} L0,${height} Z`
+  return (
+    <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`} className="overflow-visible">
+      <path d={area} fill="rgba(59,130,246,0.12)" />
+      <path d={path} fill="none" stroke="#3b82f6" strokeWidth={2} strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+const Tile = ({
+  label,
+  value,
+  hint,
+}: {
+  label: string
+  value: ReactNode
+  hint?: string
+}) => (
+  <div className="rounded-lg border p-3">
+    <Text size="small" className="text-ui-fg-subtle">
+      {label}
+    </Text>
+    <Text weight="plus" className="mt-1">
+      {value}
+    </Text>
+    {hint && (
+      <Text size="xsmall" className="text-ui-fg-muted mt-0.5">
+        {hint}
+      </Text>
+    )}
+  </div>
 )
+
+// Renders a resolved panel by the shape its operation produced. Known shapes
+// are formatted; anything else falls back to a raw value so a newly-authored
+// panel still shows *something* rather than breaking the tab.
+const PanelBody = ({ data, operationType }: { data: any; operationType: string }) => {
+  if (data == null) return <Text className="text-ui-fg-muted">No data</Text>
+
+  // gmv_projection → headline amount + inputs
+  if (operationType === "gmv_projection") {
+    return (
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Tile
+          label={`Projected GMV (${data.window_days ?? 90}d)`}
+          value={money(data.amount, data.currency)}
+          hint="run-rate"
+        />
+        <Tile label="Live brands" value={num(data.brands_live)} />
+        <Tile label="Artisans" value={num(data.artisans)} />
+        <Tile
+          label="Per-brand / mo"
+          value={money(data.formula?.per_brand_monthly, data.currency)}
+        />
+      </div>
+    )
+  }
+
+  // ads_efficiency → spend / CAC / ROAS
+  if (operationType === "ads_efficiency") {
+    return (
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Tile label={`Spend (${data.window_days ?? 30}d)`} value={money(data.spend, data.currency)} />
+        <Tile label="Conversions" value={num(data.conversions)} />
+        <Tile label="CAC" value={money(data.cac, data.currency)} />
+        <Tile label="ROAS" value={data.roas == null ? "—" : `${data.roas}×`} />
+        {data.fx_incomplete && (
+          <div className="col-span-2 sm:col-span-4">
+            <Badge size="2xsmall" color="orange">
+              FX incomplete — some spend not converted
+            </Badge>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  // time_series → sparkline + latest
+  if (Array.isArray(data.buckets)) {
+    const points = data.buckets.map((b: any) => Number(b.value) || 0)
+    const latest = points.length ? points[points.length - 1] : null
+    return (
+      <div className="flex items-end justify-between gap-4">
+        <div>
+          <Text weight="plus">{num(latest)}</Text>
+          <Text size="xsmall" className="text-ui-fg-muted">
+            latest · {data.precision ?? "day"}
+          </Text>
+        </div>
+        <Sparkline points={points} />
+      </div>
+    )
+  }
+
+  // aggregate_data → single value
+  if (typeof data.value === "number" || data.value === null) {
+    return <Text weight="plus">{num(data.value)}</Text>
+  }
+
+  // Fallback
+  return (
+    <Text size="small" className="text-ui-fg-muted">
+      {JSON.stringify(data).slice(0, 120)}
+    </Text>
+  )
+}
+
+const PanelCard = ({ panel }: { panel: InvestorPanel }) => {
+  const { panel: resolved, isPending } = useInvestorPanelData(panel.id)
+  return (
+    <Container className="p-0">
+      <div className="px-6 py-4">
+        <Heading level="h3">{panel.name}</Heading>
+      </div>
+      <div className="px-6 pb-5">
+        {isPending ? (
+          <Skeleton className="h-16 w-full" />
+        ) : resolved?.error ? (
+          <Text size="small" className="text-ui-fg-muted">
+            {resolved.error}
+          </Text>
+        ) : (
+          <PanelBody data={resolved?.data} operationType={panel.operation_type} />
+        )}
+      </div>
+    </Container>
+  )
+}
+
+const PortfolioSection = ({
+  portfolio,
+  positions,
+}: {
+  portfolio?: ProjectionPortfolio
+  positions: ReturnType<typeof useMyProjections>["positions"]
+}) => {
+  const ccy = positions[0]?.currency_code
+  return (
+    <Container className="divide-y p-0">
+      <div className="px-6 py-4">
+        <Heading level="h2">Your position</Heading>
+        <Text size="small" className="text-ui-fg-subtle mt-1">
+          Implied value uses each cap table's post-money valuation.
+        </Text>
+      </div>
+      <div className="grid grid-cols-2 gap-3 px-6 py-5 sm:grid-cols-4">
+        <Tile label="Total invested" value={money(portfolio?.total_invested, ccy)} />
+        <Tile label="Implied value" value={money(portfolio?.total_implied_value, ccy)} />
+        <Tile
+          label="Blended multiple"
+          value={portfolio?.blended_multiple == null ? "—" : `${portfolio.blended_multiple}×`}
+          hint="paper MOIC"
+        />
+        <Tile label="Cap tables" value={num(portfolio?.cap_tables)} />
+      </div>
+      {positions.length > 0 && (
+        <div className="flex flex-col gap-y-2 px-6 py-5">
+          {positions.map((p) => (
+            <div
+              key={p.cap_table_id}
+              className="flex items-center justify-between rounded-lg border px-3 py-2"
+            >
+              <div>
+                <Text weight="plus" size="small">
+                  {p.cap_table_name}
+                </Text>
+                <Text size="xsmall" className="text-ui-fg-muted">
+                  {num(p.my_shares)} shares · {pct(p.ownership_pct)}
+                </Text>
+              </div>
+              <div className="text-right">
+                <Text weight="plus" size="small">
+                  {money(p.implied_value, p.currency_code)}
+                </Text>
+                <Text size="xsmall" className="text-ui-fg-muted">
+                  {p.multiple == null ? "—" : `${p.multiple}×`} on {money(p.my_invested, p.currency_code)}
+                </Text>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </Container>
+  )
+}
+
+export const Component = () => {
+  const { panels, isPending: panelsPending } = useInvestorPanels()
+  const { positions, portfolio, isPending: posPending } = useMyProjections()
+
+  return (
+    <div className="flex w-full flex-col gap-y-4 px-4 py-6 md:px-6">
+      <div>
+        <Heading level="h1">Projections</Heading>
+        <Text size="small" className="text-ui-fg-subtle mt-1">
+          Growth, marketing efficiency and your projected position.
+        </Text>
+      </div>
+
+      {posPending ? (
+        <Container className="p-6">
+          <Skeleton className="h-32 w-full" />
+        </Container>
+      ) : (
+        <PortfolioSection portfolio={portfolio} positions={positions} />
+      )}
+
+      {panelsPending ? (
+        <Container className="p-6">
+          <Skeleton className="h-24 w-full" />
+        </Container>
+      ) : panels.length === 0 ? (
+        <Container className="p-6">
+          <Text size="small" className="text-ui-fg-subtle">
+            Growth and marketing metrics will appear here once published.
+          </Text>
+        </Container>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          {panels.map((p) => (
+            <PanelCard key={p.id} panel={p} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
Builds the investor-ui **Projections** tab (was a `ComingSoon` stub) as a hybrid of admin-authored stats panels + a per-investor position view, closes the manual-provision share-class tagging gap, and documents the already-shipped prod CORS fix for `invest.jaalyantra.com`.

Relates to #969.

## CORS fix (already LIVE in prod, no code in this PR)
`/investors/*` routes use `createCorsPartnerMiddleware()` whose allowlist is `PARTNER_CORS || AUTH_CORS || ...` (first-defined wins). `PARTNER_CORS` was set, so `AUTH_CORS` (where the invest origin was added) was never consulted, and `ROOT_DOMAIN=cicilabel.com` so the wildcard regex didn't cover it either. **Fix:** appended `https://invest.jaalyantra.com` to `/jyt/prod/PARTNER_CORS` (SSM) + forced an ECS redeploy. Verified: preflight returns 204 + correct `Access-Control-Allow-Origin`.

## Backend
- **New stats ops:** `gmv_projection` (forward GMV run-rate, mirrors the marketing-site formula) and `ads_efficiency` (Meta+Google spend/CAC/ROAS, FX-normalized). Registered in the operation registry.
- **Investor-scoped panel resolver:** `GET /investors/stats/panels` + `/:id/data`, gated on `metadata.investor === true`, reusing `resolvePanel()`.
- **`GET /investors/me/projections`** — the investor's own position (ownership %, implied value vs post-money, paper MOIC), per cap table + portfolio total.
- **Seed script** for the "Investor Projections" dashboard + 5 panels (idempotent).

## Admin
- "Provision shares (manual)" drawer now has optional **Share class** + **Funding round** pickers, so a manually-provisioned stake (e.g. a SAFE) is tagged. Added `funding_round_id` to the payload type.

## investor-ui
- Projections tab: position tiles + dynamic panel grid with inline SVG sparklines (no chart dependency). New data hooks.

## Verification
- Backend + investor-ui typecheck clean (no new errors).
- Seed + a resolver-path smoke run against the local DB return real data for all 5 panels (GMV projection ₹1.53M, trend/visitors/conversion real, ads 0 locally).

## Deploy tail
1. Backend prod-deploy → ships routes/ops (Projections 404s until then).
2. Run seed in prod: `npx medusa exec ./src/scripts/seed-investor-projection-panels.ts`.
3. Rebuild/redeploy investor-ui (CF Workers).

## Note
SAFE is a `share_class` label only — there is **no conversion engine** (no valuation-cap/discount fields). This PR records SAFE money and tags it; SAFE→equity conversion at a priced round remains net-new work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)