### PR TITLE
fix(investor-ui): onboarding close loop — await cache refetch before navigating home

### DIFF
--- a/apps/investor-ui/src/hooks/api/users.tsx
+++ b/apps/investor-ui/src/hooks/api/users.tsx
@@ -65,8 +65,8 @@ export const useUpdateMe = (
         method: "POST",
         body: payload,
       }),
-    onSuccess: (data, variables, context) => {
-      queryClient.invalidateQueries({ queryKey: usersQueryKeys.me() })
+    onSuccess: async (data, variables, context) => {
+      await queryClient.refetchQueries({ queryKey: usersQueryKeys.me() })
       options?.onSuccess?.(data, variables, context)
     },
     ...options,


### PR DESCRIPTION
## Bug

After completing the onboarding form and clicking "Finish setup", the modal immediately reopens instead of closing to the dashboard.

## Root Cause

`useUpdateMe` called `queryClient.invalidateQueries` without awaiting it. The internal `onSuccess` then fires `options.onSuccess` which navigates to `/`. But the `Home` component renders while the `me` query cache is still stale — it still sees `onboarding.completed === false` and immediately redirects back to `/onboarding`.

## Fix

Changed to `await queryClient.refetchQueries(...)` so the cache is fully up-to-date before the navigation fires.

## Files Changed

- `apps/investor-ui/src/hooks/api/users.tsx` — await refetchQueries in onSuccess