### PR TITLE
fix(investor-ui): block onboarding modal dismissal when form is not completed

### DIFF
--- a/apps/investor-ui/src/components/modals/route-focus-modal/route-focus-modal.tsx
+++ b/apps/investor-ui/src/components/modals/route-focus-modal/route-focus-modal.tsx
@@ -14,6 +14,7 @@ type RouteFocusModalProps = PropsWithChildren<{
 const Root = ({ prev = "..", children }: RouteFocusModalProps) => {
   const navigate = useNavigate()
   const [open, setOpen] = useState(false)
+  const [closeOnEscape, setCloseOnEscape] = useState(true)
   const [stackedModalOpen, onStackedModalOpen] = useState(false)
 
   const to: string | Partial<Path> | number =
@@ -35,6 +36,7 @@ const Root = ({ prev = "..", children }: RouteFocusModalProps) => {
 
   const handleOpenChange = (open: boolean) => {
     if (!open) {
+      if (!closeOnEscape) return
       document.body.style.pointerEvents = "auto"
       if (typeof to === "number") {
         navigate(to)
@@ -49,7 +51,7 @@ const Root = ({ prev = "..", children }: RouteFocusModalProps) => {
 
   return (
     <FocusModal open={open} onOpenChange={handleOpenChange}>
-      <RouteModalProvider prev={to}>
+      <RouteModalProvider prev={to} __closeOnEscape={closeOnEscape} __setCloseOnEscape={setCloseOnEscape}>
         <StackedModalProvider onOpenChange={onStackedModalOpen}>
           <Content stackedModalOpen={stackedModalOpen}>{children}</Content>
         </StackedModalProvider>

--- a/apps/investor-ui/src/components/modals/route-modal-provider/route-provider.tsx
+++ b/apps/investor-ui/src/components/modals/route-modal-provider/route-provider.tsx
@@ -4,16 +4,22 @@ import { RouteModalProviderContext } from "./route-modal-context"
 
 type RouteModalProviderProps = PropsWithChildren<{
   prev: string | Partial<Path> | number
+  __closeOnEscape?: boolean
+  __setCloseOnEscape?: React.Dispatch<React.SetStateAction<boolean>>
 }>
 
 export const RouteModalProvider = ({
   prev,
+  __closeOnEscape,
+  __setCloseOnEscape,
   children,
 }: RouteModalProviderProps) => {
   const navigate = useNavigate()
   const location = useLocation()
 
-  const [closeOnEscape, setCloseOnEscape] = useState(true)
+  const [localCloseOnEscape, localSetCloseOnEscape] = useState(true)
+  const closeOnEscape = __closeOnEscape ?? localCloseOnEscape
+  const setCloseOnEscape = __setCloseOnEscape ?? localSetCloseOnEscape
 
   const handleSuccess = useCallback(
     (path?: string) => {

--- a/apps/investor-ui/src/routes/onboarding/onboarding.tsx
+++ b/apps/investor-ui/src/routes/onboarding/onboarding.tsx
@@ -7,9 +7,10 @@ import {
   clx,
   toast,
 } from "@medusajs/ui"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useNavigate } from "react-router-dom"
 import { RouteFocusModal } from "../../components/modals"
+import { useRouteModal } from "../../components/modals/route-modal-provider/use-route-modal"
 import { useMe, useUpdateMe } from "../../hooks/api/users"
 
 export type InvestorOnboarding = {
@@ -184,6 +185,11 @@ const OnboardingInner = ({
 export const Onboarding = () => {
   const { user, isPending } = useMe()
   const metadata = (user as any)?.metadata ?? null
+  const { setCloseOnEscape } = useRouteModal()
+
+  useEffect(() => {
+    setCloseOnEscape(false)
+  }, [setCloseOnEscape])
 
   return (
     <RouteFocusModal prev="/">


### PR DESCRIPTION
## Bug

Pressing Escape or clicking outside the onboarding modal navigates to the dashboard, but `Home` immediately redirects back to `/onboarding` because `onboarding.completed` is still `false`. This creates an infinite reopen loop.

## Fix

- Lifted `closeOnEscape` state from `RouteModalProvider` up to `RouteFocusModal.Root` so the root's `handleOpenChange` can read it
- `Onboarding` component calls `setCloseOnEscape(false)` on mount, which both:
  - Prevents Escape key dismissal (already handled in `Content`)
  - Blocks the `handleOpenChange → navigate()` path for outside-click dismissal

The only way out of the onboarding modal is to complete the form and click "Finish setup".

## Files

- `apps/investor-ui/src/components/modals/route-focus-modal/route-focus-modal.tsx` — lift closeOnEscape into Root, gate handleOpenChange
- `apps/investor-ui/src/components/modals/route-modal-provider/route-provider.tsx` — accept lifted state via props
- `apps/investor-ui/src/routes/onboarding/onboarding.tsx` — setCloseOnEscape(false) on mount