### PR TITLE
fix(investor-ui): move useRouteModal into OnboardingInner to fix context ordering

### DIFF
--- a/apps/investor-ui/src/components/modals/route-focus-modal/route-focus-modal.tsx
+++ b/apps/investor-ui/src/components/modals/route-focus-modal/route-focus-modal.tsx
@@ -14,6 +14,7 @@ type RouteFocusModalProps = PropsWithChildren<{
 const Root = ({ prev = "..", children }: RouteFocusModalProps) => {
   const navigate = useNavigate()
   const [open, setOpen] = useState(false)
+  const [closeOnEscape, setCloseOnEscape] = useState(true)
   const [stackedModalOpen, onStackedModalOpen] = useState(false)
 
   const to: string | Partial<Path> | number =
@@ -35,6 +36,7 @@ const Root = ({ prev = "..", children }: RouteFocusModalProps) => {
 
   const handleOpenChange = (open: boolean) => {
     if (!open) {
+      if (!closeOnEscape) return
       document.body.style.pointerEvents = "auto"
       if (typeof to === "number") {
         navigate(to)
@@ -49,7 +51,7 @@ const Root = ({ prev = "..", children }: RouteFocusModalProps) => {
 
   return (
     <FocusModal open={open} onOpenChange={handleOpenChange}>
-      <RouteModalProvider prev={to}>
+      <RouteModalProvider prev={to} __closeOnEscape={closeOnEscape} __setCloseOnEscape={setCloseOnEscape}>
         <StackedModalProvider onOpenChange={onStackedModalOpen}>
           <Content stackedModalOpen={stackedModalOpen}>{children}</Content>
         </StackedModalProvider>

--- a/apps/investor-ui/src/components/modals/route-modal-provider/route-provider.tsx
+++ b/apps/investor-ui/src/components/modals/route-modal-provider/route-provider.tsx
@@ -4,16 +4,22 @@ import { RouteModalProviderContext } from "./route-modal-context"
 
 type RouteModalProviderProps = PropsWithChildren<{
   prev: string | Partial<Path> | number
+  __closeOnEscape?: boolean
+  __setCloseOnEscape?: React.Dispatch<React.SetStateAction<boolean>>
 }>
 
 export const RouteModalProvider = ({
   prev,
+  __closeOnEscape,
+  __setCloseOnEscape,
   children,
 }: RouteModalProviderProps) => {
   const navigate = useNavigate()
   const location = useLocation()
 
-  const [closeOnEscape, setCloseOnEscape] = useState(true)
+  const [localCloseOnEscape, localSetCloseOnEscape] = useState(true)
+  const closeOnEscape = __closeOnEscape ?? localCloseOnEscape
+  const setCloseOnEscape = __setCloseOnEscape ?? localSetCloseOnEscape
 
   const handleSuccess = useCallback(
     (path?: string) => {

--- a/apps/investor-ui/src/routes/onboarding/onboarding.tsx
+++ b/apps/investor-ui/src/routes/onboarding/onboarding.tsx
@@ -7,9 +7,10 @@ import {
   clx,
   toast,
 } from "@medusajs/ui"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useNavigate } from "react-router-dom"
 import { RouteFocusModal } from "../../components/modals"
+import { useRouteModal } from "../../components/modals/route-modal-provider/use-route-modal"
 import { useMe, useUpdateMe } from "../../hooks/api/users"
 
 export type InvestorOnboarding = {
@@ -45,7 +46,12 @@ const OnboardingInner = ({
   metadata?: Record<string, any> | null
 }) => {
   const navigate = useNavigate()
+  const { setCloseOnEscape } = useRouteModal()
   const existing: InvestorOnboarding = metadata?.onboarding ?? {}
+
+  useEffect(() => {
+    setCloseOnEscape(false)
+  }, [setCloseOnEscape])
 
   const [ticketSize, setTicketSize] = useState<string>(existing.ticket_size ?? "")
   const [interests, setInterests] = useState<string[]>(existing.interests ?? [])


### PR DESCRIPTION
Fixes a `useRouteModal must be used within a RouteModalProvider` error on the onboarding page.

## Problem

PR #987 lifted `closeOnEscape` state to `RouteFocusModal.Root` so the onboarding page could block modal dismissal while the form is dirty. However, `useRouteModal` was called at the `Onboarding` component level, which is a **direct child** of `RouteFocusModal.Root` — not inside `RouteModalProvider` (the provider lives inside `<FocusModal>`, deeper in the tree).

## Fix

- Move the `useRouteModal()` / `useEffect(setCloseOnEscape(false))` call into `OnboardingInner`, which renders inside `RouteModalProvider`.
- Clean carry-forward of the `closeOnEscape` state lift in `RouteFocusModal.Root` and `RouteModalProvider`.

## Context

This branch replaces the reverted PR #987 with the same intent but correct component hierarchy. The diff is identical to the working version that was force-pushed earlier.