### PR TITLE
fix(investor-ui): restructure OnboardingInner to match RouteFocusModal pattern

### DIFF
--- a/apps/investor-ui/src/routes/onboarding/onboarding.tsx
+++ b/apps/investor-ui/src/routes/onboarding/onboarding.tsx
@@ -100,90 +100,93 @@ const OnboardingInner = ({
   }
 
   return (
-    <RouteFocusModal.Body className="flex flex-1 flex-col items-center overflow-y-auto py-10">
-      <div className="flex w-full max-w-xl flex-col gap-y-8">
-        <div className="flex flex-col gap-y-2">
-          <Heading level="h1">Welcome to your investor portal</Heading>
-          <Text className="text-ui-fg-subtle">
-            A few quick questions so we can tailor what you see and hear from us.
-          </Text>
-        </div>
-
-        {/* Ticket size */}
-        <div className="flex flex-col gap-y-3 rounded-lg border bg-ui-bg-base p-5">
-          <div className="flex flex-col gap-y-1">
-            <Text weight="plus">Typical ticket size</Text>
-            <Text size="small" className="text-ui-fg-subtle">
-              How much do you usually invest per opportunity?
+    <>
+      <RouteFocusModal.Header />
+      <RouteFocusModal.Body className="flex flex-1 flex-col items-center overflow-y-auto py-10">
+        <div className="flex w-full max-w-xl flex-col gap-y-8">
+          <div className="flex flex-col gap-y-2">
+            <Heading level="h1">Welcome to your investor portal</Heading>
+            <Text className="text-ui-fg-subtle">
+              A few quick questions so we can tailor what you see and hear from us.
             </Text>
           </div>
-          <Select value={ticketSize} onValueChange={setTicketSize}>
-            <Select.Trigger>
-              <Select.Value placeholder="Select a range" />
-            </Select.Trigger>
-            <Select.Content>
-              {TICKET_SIZES.map((t) => (
-                <Select.Item key={t.value} value={t.value}>
-                  {t.label}
-                </Select.Item>
-              ))}
-            </Select.Content>
-          </Select>
-        </div>
 
-        {/* Interests */}
-        <div className="flex flex-col gap-y-3 rounded-lg border bg-ui-bg-base p-5">
-          <div className="flex flex-col gap-y-1">
-            <Text weight="plus">Interests</Text>
-            <Text size="small" className="text-ui-fg-subtle">
-              Pick the areas you'd like to hear about (choose one or more).
-            </Text>
+          {/* Ticket size */}
+          <div className="flex flex-col gap-y-3 rounded-lg border bg-ui-bg-base p-5">
+            <div className="flex flex-col gap-y-1">
+              <Text weight="plus">Typical ticket size</Text>
+              <Text size="small" className="text-ui-fg-subtle">
+                How much do you usually invest per opportunity?
+              </Text>
+            </div>
+            <Select value={ticketSize} onValueChange={setTicketSize}>
+              <Select.Trigger>
+                <Select.Value placeholder="Select a range" />
+              </Select.Trigger>
+              <Select.Content>
+                {TICKET_SIZES.map((t) => (
+                  <Select.Item key={t.value} value={t.value}>
+                    {t.label}
+                  </Select.Item>
+                ))}
+              </Select.Content>
+            </Select>
           </div>
-          <div className="flex flex-wrap gap-2">
-            {INTERESTS.map((interest) => {
-              const active = interests.includes(interest)
-              return (
-                <button
-                  key={interest}
-                  type="button"
-                  onClick={() => toggleInterest(interest)}
-                  className={clx(
-                    "txt-compact-small rounded-full border px-3 py-1.5 transition-colors",
-                    active
-                      ? "border-ui-border-interactive bg-ui-bg-interactive text-ui-fg-on-color"
-                      : "border-ui-border-base bg-ui-bg-base text-ui-fg-subtle hover:bg-ui-bg-base-hover"
-                  )}
-                >
-                  {interest}
-                </button>
-              )
-            })}
-          </div>
-        </div>
 
-        {/* Newsletter */}
-        <div className="flex items-center justify-between rounded-lg border bg-ui-bg-base p-5">
-          <div className="flex flex-col gap-y-1 pr-4">
-            <Text weight="plus">Quarterly investor letters</Text>
-            <Text size="small" className="text-ui-fg-subtle">
-              Receive our portfolio & company update email every quarter.
-            </Text>
+          {/* Interests */}
+          <div className="flex flex-col gap-y-3 rounded-lg border bg-ui-bg-base p-5">
+            <div className="flex flex-col gap-y-1">
+              <Text weight="plus">Interests</Text>
+              <Text size="small" className="text-ui-fg-subtle">
+                Pick the areas you'd like to hear about (choose one or more).
+              </Text>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {INTERESTS.map((interest) => {
+                const active = interests.includes(interest)
+                return (
+                  <button
+                    key={interest}
+                    type="button"
+                    onClick={() => toggleInterest(interest)}
+                    className={clx(
+                      "txt-compact-small rounded-full border px-3 py-1.5 transition-colors",
+                      active
+                        ? "border-ui-border-interactive bg-ui-bg-interactive text-ui-fg-on-color"
+                        : "border-ui-border-base bg-ui-bg-base text-ui-fg-subtle hover:bg-ui-bg-base-hover"
+                    )}
+                  >
+                    {interest}
+                  </button>
+                )
+              })}
+            </div>
           </div>
-          <Switch checked={newsletter} onCheckedChange={setNewsletter} />
-        </div>
 
-        <div className="flex items-center justify-end gap-x-3">
-          <Button
-            variant="primary"
-            onClick={handleSubmit}
-            isLoading={isPending}
-            disabled={!canSubmit}
-          >
-            Finish setup
-          </Button>
+          {/* Newsletter */}
+          <div className="flex items-center justify-between rounded-lg border bg-ui-bg-base p-5">
+            <div className="flex flex-col gap-y-1 pr-4">
+              <Text weight="plus">Quarterly investor letters</Text>
+              <Text size="small" className="text-ui-fg-subtle">
+                Receive our portfolio & company update email every quarter.
+              </Text>
+            </div>
+            <Switch checked={newsletter} onCheckedChange={setNewsletter} />
+          </div>
+
+          <div className="flex items-center justify-end gap-x-3">
+            <Button
+              variant="primary"
+              onClick={handleSubmit}
+              isLoading={isPending}
+              disabled={!canSubmit}
+            >
+              Finish setup
+            </Button>
+          </div>
         </div>
-      </div>
-    </RouteFocusModal.Body>
+      </RouteFocusModal.Body>
+    </>
   )
 }
 
@@ -198,7 +201,6 @@ export const Onboarding = () => {
 
   return (
     <RouteFocusModal prev="/">
-      <RouteFocusModal.Header />
       {!isPending && <OnboardingInner metadata={metadata} />}
     </RouteFocusModal>
   )


### PR DESCRIPTION
Fixes `useRouteModal must be used within a RouteModalProvider` error on the onboarding page.

## Problem

After the previous PR (#988) merged the `closeOnEscape` lift and context ordering fix, the error persisted. The structure didn't match the established pattern used in other routes like `ParticipateRoute`.

## Fix

Re-structured `OnboardingInner` to render both `RouteFocusModal.Header` and `RouteFocusModal.Body` inside itself (wrapped in a fragment), matching the exact pattern used by `ParticipateForm` in `participate.tsx`.

### Before (broken)
```tsx
<RouteFocusModal prev="/">
  <RouteFocusModal.Header />
  {!isPending && <OnboardingInner metadata={metadata} />}
</RouteFocusModal>
```

### After (matches participate pattern)
```tsx
<RouteFocusModal prev="/">
  {!isPending && <OnboardingInner metadata={metadata} />}
</RouteFocusModal>
```
`OnboardingInner` now renders both `Header` + `Body` in a fragment.