### PR TITLE
fix(investor-ui): move useRouteModal into OnboardingInner, restructure to match RouteFocusModal pattern

### DIFF
--- a/apps/investor-ui/src/routes/onboarding/onboarding.tsx
+++ b/apps/investor-ui/src/routes/onboarding/onboarding.tsx
@@ -193,11 +193,6 @@ const OnboardingInner = ({
 export const Onboarding = () => {
   const { user, isPending } = useMe()
   const metadata = (user as any)?.metadata ?? null
-  const { setCloseOnEscape } = useRouteModal()
-
-  useEffect(() => {
-    setCloseOnEscape(false)
-  }, [setCloseOnEscape])
 
   return (
     <RouteFocusModal prev="/">


### PR DESCRIPTION
Fixes `useRouteModal must be used within a RouteModalProvider` error on the onboarding page.

## Changes

### `onboarding.tsx`
- Moved `useRouteModal()` + `useEffect(setCloseOnEscape)` from `Onboarding` (outside provider) into `OnboardingInner` (inside provider)
- Restructured `OnboardingInner` to render both `RouteFocusModal.Header` and `RouteFocusModal.Body` in a fragment, matching the pattern used by `ParticipateForm` in `participate.tsx`

### `route-focus-modal.tsx`
- Lifted `closeOnEscape` state to `Root` so children can control it via context
- Gate `handleOpenChange` with `closeOnEscape`
- Pass `__closeOnEscape` / `__setCloseOnEscape` to `RouteModalProvider`

### `route-provider.tsx`
- Accept optional `__closeOnEscape` / `__setCloseOnEscape` props (backward-compatible with local state fallback)