### PR TITLE
fix(investor-ui): prevent onboarding redirect loop — child route + localStorage skip

### DIFF
--- a/apps/investor-ui/src/dashboard-app/routes/get-route.map.tsx
+++ b/apps/investor-ui/src/dashboard-app/routes/get-route.map.tsx
@@ -29,11 +29,13 @@ export function getRouteMap({
               path: "/",
               errorElement: <ErrorBoundary />,
               lazy: () => import("../../routes/home"),
-            },
-            {
-              path: "/onboarding",
-              errorElement: <ErrorBoundary />,
-              lazy: () => import("../../routes/onboarding"),
+              children: [
+                {
+                  path: "onboarding",
+                  errorElement: <ErrorBoundary />,
+                  lazy: () => import("../../routes/onboarding"),
+                },
+              ],
             },
             {
               path: "/cap-table",

--- a/apps/investor-ui/src/routes/home/home.tsx
+++ b/apps/investor-ui/src/routes/home/home.tsx
@@ -1,6 +1,6 @@
 import { Badge, Container, Heading, Skeleton, Text } from "@medusajs/ui"
-import { useEffect } from "react"
-import { useNavigate } from "react-router-dom"
+import { useMemo, useEffect } from "react"
+import { Outlet, useNavigate } from "react-router-dom"
 import { useMe } from "../../hooks/api/users"
 import type { InvestorOnboarding } from "../onboarding/onboarding"
 
@@ -90,7 +90,25 @@ export const Home = () => {
 
   const investor = (user ?? {}) as Record<string, any>
   const onboarding: InvestorOnboarding = investor?.metadata?.onboarding ?? {}
-  const needsOnboarding = !isPending && !!user && !onboarding.completed
+
+  const userId = (user as any)?.id
+  const storageKey = useMemo(
+    () => (userId ? `investor_onboarding_${userId}` : null),
+    [userId]
+  )
+
+  const onboardingSkipped = useMemo(() => {
+    if (!storageKey) return false
+    try {
+      const raw = localStorage.getItem(storageKey)
+      return raw ? JSON.parse(raw)?.skipped === true : false
+    } catch {
+      return false
+    }
+  }, [storageKey])
+
+  const needsOnboarding =
+    !isPending && !!user && !onboarding.completed && !onboardingSkipped
 
   // First-run: open the onboarding focus-modal over the dashboard.
   useEffect(() => {
@@ -103,5 +121,10 @@ export const Home = () => {
     return <HomeSkeleton />
   }
 
-  return <DashboardHome investor={investor} />
+  return (
+    <>
+      <DashboardHome investor={investor} />
+      <Outlet />
+    </>
+  )
 }

--- a/apps/investor-ui/src/routes/onboarding/onboarding.tsx
+++ b/apps/investor-ui/src/routes/onboarding/onboarding.tsx
@@ -8,8 +8,7 @@ import {
   toast,
 } from "@medusajs/ui"
 import { useState } from "react"
-import { useNavigate } from "react-router-dom"
-import { RouteFocusModal } from "../../components/modals"
+import { RouteFocusModal, useRouteModal } from "../../components/modals"
 import { useMe, useUpdateMe } from "../../hooks/api/users"
 
 export type InvestorOnboarding = {
@@ -39,12 +38,16 @@ const INTERESTS = [
   "Growth Stage",
 ]
 
+const getUserId = (user: any): string | null => user?.id ?? null
+
 const OnboardingInner = ({
   metadata,
+  userId,
 }: {
   metadata?: Record<string, any> | null
+  userId: string | null
 }) => {
-  const navigate = useNavigate()
+  const { handleSuccess } = useRouteModal()
   const existing: InvestorOnboarding = metadata?.onboarding ?? {}
 
   const [ticketSize, setTicketSize] = useState<string>(existing.ticket_size ?? "")
@@ -56,7 +59,7 @@ const OnboardingInner = ({
   const { mutateAsync, isPending } = useUpdateMe({
     onSuccess: () => {
       toast.success("Welcome aboard — your preferences are saved.")
-      navigate("/", { replace: true })
+      handleSuccess("/")
     },
     onError: (err: any) => {
       toast.error(err?.message || "Could not save your preferences")
@@ -69,6 +72,20 @@ const OnboardingInner = ({
         ? prev.filter((i) => i !== interest)
         : [...prev, interest]
     )
+  }
+
+  const handleSkip = () => {
+    if (userId) {
+      try {
+        localStorage.setItem(
+          `investor_onboarding_${userId}`,
+          JSON.stringify({ skipped: true, skipped_at: new Date().toISOString() })
+        )
+      } catch {
+        // non-blocking
+      }
+    }
+    handleSuccess("/")
   }
 
   const canSubmit = ticketSize !== "" && interests.length > 0 && !isPending
@@ -168,7 +185,10 @@ const OnboardingInner = ({
             <Switch checked={newsletter} onCheckedChange={setNewsletter} />
           </div>
 
-          <div className="flex items-center justify-end gap-x-3">
+          <div className="flex items-center justify-between gap-x-3">
+            <Button variant="secondary" onClick={handleSkip}>
+              Skip for now
+            </Button>
             <Button
               variant="primary"
               onClick={handleSubmit}
@@ -187,10 +207,11 @@ const OnboardingInner = ({
 export const Onboarding = () => {
   const { user, isPending } = useMe()
   const metadata = (user as any)?.metadata ?? null
+  const userId = getUserId(user)
 
   return (
-    <RouteFocusModal prev="/">
-      {!isPending && <OnboardingInner metadata={metadata} />}
+    <RouteFocusModal>
+      {!isPending && <OnboardingInner metadata={metadata} userId={userId} />}
     </RouteFocusModal>
   )
 }


### PR DESCRIPTION
## Problem

PR #991 removed `setCloseOnEscape(false)` so pressing Escape would close the onboarding modal. But once closed, the home page would see `onboarding.completed === false` and immediately redirect right back to `/onboarding` — an endless loop.

## Root Cause

`/` and `/onboarding` were sibling routes — navigating between them unmounted/remounted the Home component. There was no way to signal "user dismissed the modal, don't redirect again."

## Fix (mimics partner-ui pattern)

1. **`get-route.map.tsx`** — Made `/onboarding` a **child route** of `/` (so Home stays mounted when onboarding opens/closes).

2. **`home.tsx`** — Added `<Outlet />` and a `localStorage` check (`investor_onboarding_${userId}`). Before redirecting, Home checks if the user has skipped. If so, `needsOnboarding = false`.

3. **`onboarding.tsx`** — Added "Skip for now" button that writes `{ skipped: true }` to localStorage then calls `handleSuccess` to navigate back to `/`.

## Behavior

| Action | Result |
|--------|--------|
| Complete onboarding | Writes `completed: true` to metadata → Home sees it's done → no redirect |
| Click "Skip for now" | Writes `skipped: true` to localStorage → Home sees skip flag → no redirect |
| Press Escape | Modal closes → Home re-evaluates → if not completed/skipped, re-opens (intentional — same as partner-ui)