### PR TITLE
feat(artisan): S3 made-to-order & maker-story product detail (#859/#862)

### DIFF
--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -504,6 +504,9 @@ module.exports = defineConfig({
       resolve: "./src/modules/partner-onboarding-profile",
     },
     {
+      resolve: "./src/modules/artisan-product-detail",
+    },
+    {
       resolve: "./src/modules/partner_billing",
     },
     {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -172,6 +172,9 @@ module.exports = defineConfig({
       resolve: "./src/modules/partner-onboarding-profile",
     },
     {
+      resolve: "./src/modules/artisan-product-detail",
+    },
+    {
       resolve: "./src/modules/partner_billing",
     },
     {

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -207,7 +207,7 @@ import { ListIdentitiesQuerySchema } from "./admin/users/identities/validators";
 import { ListInventoryItemRawMaterialsQuerySchema } from "./admin/inventory-items/raw-materials/validators";
 import { BulkImportSchema } from "./admin/inventory-items/bulk-import/validators";
 import { PartnerCreateStoreReq } from "./partners/stores/validators";
-import { PartnerCreateProductReq } from "./partners/products/validators";
+import { PartnerCreateProductReq, PartnerArtisanProductDetailReq } from "./partners/products/validators";
 import {
   PartnerCreateRegionReq,
   PartnerUpdateRegionReq,
@@ -1175,6 +1175,25 @@ export default defineMiddlewares({
       middlewares: [
         createCorsPartnerMiddleware(),
         authenticate("partner", ["session", "bearer"]),
+      ],
+    },
+    {
+      // #859 S3 (#862): read the artisan made-to-order/maker-story detail.
+      matcher: "/partners/products/:id/artisan-detail",
+      method: "GET",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
+    {
+      // #859 S3 (#862): upsert the artisan made-to-order/maker-story detail.
+      matcher: "/partners/products/:id/artisan-detail",
+      method: "POST",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+        validateAndTransformBody(wrapSchema(PartnerArtisanProductDetailReq)),
       ],
     },
 

--- a/apps/backend/src/api/partners/products/[id]/artisan-detail/route.ts
+++ b/apps/backend/src/api/partners/products/[id]/artisan-detail/route.ts
@@ -1,0 +1,111 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { tryGetPartnerSalesChannelId } from "../../../helpers"
+import partnerProductLink from "../../../../../links/partner-product"
+import { upsertArtisanProductDetailWorkflow } from "../../../../../workflows/products/upsert-artisan-product-detail"
+import { ARTISAN_PRODUCT_DETAIL_MODULE } from "../../../../../modules/artisan-product-detail"
+import type { PartnerArtisanProductDetailReqType } from "../../validators"
+
+const LINK_ENTRY = partnerProductLink.entryPoint
+
+/**
+ * Assert the authenticated partner owns the product, returning the partner.
+ *
+ * Ownership is primarily the product being in the partner's store sales
+ * channel — every partner product (dedicated or core-channel listing) is bound
+ * to `store.default_sales_channel_id` on create. We also accept the
+ * product → owning-partner link (recorded for artisan proposals) as a fallback.
+ * Non-owners get a 404 (hide existence), mirroring the resubmit route.
+ */
+const assertOwnership = async (
+  req: AuthenticatedMedusaRequest,
+  productId: string
+) => {
+  if (!req.auth_context?.actor_id) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "Partner authentication required"
+    )
+  }
+  const { partner, salesChannelId } = await tryGetPartnerSalesChannelId(
+    req.auth_context,
+    req.scope
+  )
+  if (!partner) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "No partner associated with this account"
+    )
+  }
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY) as any
+
+  const { data: products = [] } = await query.graph({
+    entity: "product",
+    fields: ["id", "sales_channels.id"],
+    filters: { id: productId },
+  })
+  const product = products[0]
+
+  const inPartnerChannel =
+    !!salesChannelId &&
+    ((product?.sales_channels as any[]) || []).some(
+      (sc: any) => sc?.id === salesChannelId
+    )
+
+  let ownedViaLink = false
+  if (product && !inPartnerChannel) {
+    const { data: ownerLinks = [] } = await query.graph({
+      entity: LINK_ENTRY,
+      fields: ["partner_id", "product_id"],
+      filters: { product_id: productId },
+    })
+    ownedViaLink = ownerLinks.some((l: any) => l.partner_id === partner.id)
+  }
+
+  if (!product || (!inPartnerChannel && !ownedViaLink)) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      `Product ${productId} not found`
+    )
+  }
+  return partner
+}
+
+/**
+ * Read the artisan detail for one of the partner's own products (#859 S3).
+ *
+ * @route GET /partners/products/:id/artisan-detail
+ */
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const productId = req.params.id
+  await assertOwnership(req, productId)
+
+  const service: any = req.scope.resolve(ARTISAN_PRODUCT_DETAIL_MODULE)
+  const detail = await service.findByProduct(productId)
+
+  return res.json({ artisan_detail: detail })
+}
+
+/**
+ * Create or update the artisan "made-to-order & maker story" detail for one of
+ * the partner's own products (#859 S3 / #862).
+ *
+ * @route POST /partners/products/:id/artisan-detail
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest<PartnerArtisanProductDetailReqType>,
+  res: MedusaResponse
+) => {
+  const productId = req.params.id
+  await assertOwnership(req, productId)
+
+  const { result } = await upsertArtisanProductDetailWorkflow(req.scope).run({
+    input: { product_id: productId, data: req.validatedBody },
+  })
+
+  return res.json({ artisan_detail: result })
+}

--- a/apps/backend/src/api/partners/products/validators.ts
+++ b/apps/backend/src/api/partners/products/validators.ts
@@ -10,3 +10,20 @@ export const PartnerCreateProductReq = z
   .strict()
 
 export type PartnerCreateProductReqType = z.infer<typeof PartnerCreateProductReq>
+
+// #859 S3 (#862): the partner-editable "made-to-order & maker story" fields for
+// an artisan product. All optional — a partner may set only a maker story, or
+// only flip made-to-order, etc. `null` explicitly clears a field.
+export const PartnerArtisanProductDetailReq = z
+  .object({
+    made_to_order: z.boolean().optional(),
+    lead_time_days: z.number().int().min(0).max(3650).nullable().optional(),
+    lead_time_label: z.string().trim().max(120).nullable().optional(),
+    min_order_quantity: z.number().int().min(1).max(100000).nullable().optional(),
+    maker_story: z.string().trim().max(5000).nullable().optional(),
+  })
+  .strict()
+
+export type PartnerArtisanProductDetailReqType = z.infer<
+  typeof PartnerArtisanProductDetailReq
+>

--- a/apps/backend/src/links/product-artisan-detail.ts
+++ b/apps/backend/src/links/product-artisan-detail.ts
@@ -1,0 +1,15 @@
+import { defineLink } from "@medusajs/framework/utils"
+import ProductModule from "@medusajs/medusa/product"
+import ArtisanProductDetailModule from "../modules/artisan-product-detail"
+
+// #859 S3 (#862): product ↔ artisan_product_detail link. A product has at most
+// one artisan detail row (made-to-order flag, lead time, min order qty, maker
+// story). Exposed on the storefront by requesting `+artisan_detail.*` on the
+// store product query.
+export default defineLink(
+  ProductModule.linkable.product,
+  {
+    linkable: ArtisanProductDetailModule.linkable.artisanProductDetail,
+    field: "artisan_detail",
+  }
+)

--- a/apps/backend/src/modules/artisan-product-detail/index.ts
+++ b/apps/backend/src/modules/artisan-product-detail/index.ts
@@ -1,0 +1,8 @@
+import { Module } from "@medusajs/framework/utils"
+import ArtisanProductDetailService from "./service"
+
+export const ARTISAN_PRODUCT_DETAIL_MODULE = "artisanProductDetail"
+
+export default Module(ARTISAN_PRODUCT_DETAIL_MODULE, {
+  service: ArtisanProductDetailService,
+})

--- a/apps/backend/src/modules/artisan-product-detail/migrations/Migration20260711170000.ts
+++ b/apps/backend/src/modules/artisan-product-detail/migrations/Migration20260711170000.ts
@@ -1,0 +1,22 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Creates the artisan_product_detail table (issue #859 S3 / #862).
+ *
+ * Hand-written (Claude-owned) create migration. Mirrors what DML would
+ * generate for the model: the unique product_id gets a partial unique index,
+ * plus the standard deleted_at index.
+ */
+export class Migration20260711170000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table if not exists "artisan_product_detail" ("id" text not null, "product_id" text not null, "made_to_order" boolean not null default false, "lead_time_days" integer null, "lead_time_label" text null, "min_order_quantity" integer null, "maker_story" text null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "artisan_product_detail_pkey" primary key ("id"));`);
+    this.addSql(`CREATE UNIQUE INDEX IF NOT EXISTS "IDX_artisan_product_detail_product_id_unique" ON "artisan_product_detail" ("product_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_artisan_product_detail_deleted_at" ON "artisan_product_detail" ("deleted_at") WHERE deleted_at IS NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "artisan_product_detail" cascade;`);
+  }
+
+}

--- a/apps/backend/src/modules/artisan-product-detail/models/artisan-product-detail.ts
+++ b/apps/backend/src/modules/artisan-product-detail/models/artisan-product-detail.ts
@@ -1,0 +1,41 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * Artisan product detail (issue #859 S3 / #862).
+ *
+ * Partner-editable, per-product "made-to-order & maker story" attributes for
+ * the Airbnb-style artisan flow. One row per product (`product_id` unique).
+ * Typed columns — NOT a metadata blob — because these fields are surfaced on
+ * the storefront and enforced at checkout (min order quantity), so they must
+ * survive Medusa's whole-blob metadata overwrites
+ * (see feedback_no_critical_data_in_metadata).
+ *
+ * Linked to the core Product via `links/product-artisan-detail.ts`.
+ */
+const ArtisanProductDetail = model.define("artisan_product_detail", {
+  id: model.id().primaryKey(),
+
+  // The product this detail belongs to. Unique — one detail row per product.
+  product_id: model.text().unique(),
+
+  // When true the storefront shows the made-to-order treatment (no live
+  // stock gate — the item is produced on demand once ordered).
+  made_to_order: model.boolean().default(false),
+
+  // Expected preparation time in days. Rendered on the storefront as an
+  // approximate "~X weeks to prepare" when `lead_time_label` is not set.
+  lead_time_days: model.number().nullable(),
+
+  // Free-form lead-time copy that, when present, overrides the derived
+  // "~X weeks" phrasing (e.g. "takes a few weeks", "made to your measurements").
+  lead_time_label: model.text().nullable(),
+
+  // Minimum quantity the customer must order. Enforced in add-to-cart.
+  min_order_quantity: model.number().nullable(),
+
+  // The maker / provenance prose shown on the product page (who made it,
+  // where, and how). Free-form partner-authored text.
+  maker_story: model.text().nullable(),
+})
+
+export default ArtisanProductDetail

--- a/apps/backend/src/modules/artisan-product-detail/service.ts
+++ b/apps/backend/src/modules/artisan-product-detail/service.ts
@@ -1,0 +1,18 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import ArtisanProductDetail from "./models/artisan-product-detail"
+
+class ArtisanProductDetailService extends MedusaService({
+  ArtisanProductDetail,
+}) {
+  /**
+   * Fetch the artisan detail for a product, or null if none exists yet.
+   */
+  async findByProduct(productId: string) {
+    const details = await this.listArtisanProductDetails({
+      product_id: productId,
+    })
+    return details?.[0] || null
+  }
+}
+
+export default ArtisanProductDetailService

--- a/apps/backend/src/workflows/products/upsert-artisan-product-detail.ts
+++ b/apps/backend/src/workflows/products/upsert-artisan-product-detail.ts
@@ -1,0 +1,113 @@
+import {
+  createWorkflow,
+  createStep,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { ARTISAN_PRODUCT_DETAIL_MODULE } from "../../modules/artisan-product-detail"
+
+export type ArtisanProductDetailInput = {
+  made_to_order?: boolean
+  lead_time_days?: number | null
+  lead_time_label?: string | null
+  min_order_quantity?: number | null
+  maker_story?: string | null
+}
+
+export type UpsertArtisanProductDetailInput = {
+  product_id: string
+  data: ArtisanProductDetailInput
+}
+
+/**
+ * Upsert the artisan detail row for a product and ensure the product ↔ detail
+ * module link exists (issue #859 S3 / #862). Idempotent: re-running updates the
+ * existing row rather than creating a duplicate (product_id is unique).
+ */
+type UpsertCompensation = {
+  created: boolean
+  id: string
+  product_id?: string
+  prev?: ArtisanProductDetailInput
+}
+
+const upsertArtisanProductDetailStep = createStep(
+  "upsert-artisan-product-detail",
+  async (input: UpsertArtisanProductDetailInput, { container }) => {
+    const service: any = container.resolve(ARTISAN_PRODUCT_DETAIL_MODULE)
+    const link: any = container.resolve(ContainerRegistrationKeys.LINK)
+
+    const existing = await service.findByProduct(input.product_id)
+
+    if (existing) {
+      const updated = await service.updateArtisanProductDetails({
+        id: existing.id,
+        ...input.data,
+      })
+      // Return the prior values so a failed downstream step can restore them.
+      const compensation: UpsertCompensation = {
+        created: false,
+        id: existing.id,
+        prev: {
+          made_to_order: existing.made_to_order,
+          lead_time_days: existing.lead_time_days,
+          lead_time_label: existing.lead_time_label,
+          min_order_quantity: existing.min_order_quantity,
+          maker_story: existing.maker_story,
+        },
+      }
+      return new StepResponse(updated, compensation)
+    }
+
+    const created = await service.createArtisanProductDetails({
+      product_id: input.product_id,
+      ...input.data,
+    })
+
+    await link.create({
+      [Modules.PRODUCT]: { product_id: input.product_id },
+      [ARTISAN_PRODUCT_DETAIL_MODULE]: {
+        artisan_product_detail_id: created.id,
+      },
+    })
+
+    const compensation: UpsertCompensation = {
+      created: true,
+      id: created.id,
+      product_id: input.product_id,
+    }
+    return new StepResponse(created, compensation)
+  },
+  async (compensation: UpsertCompensation | undefined, { container }) => {
+    if (!compensation) return
+    const service: any = container.resolve(ARTISAN_PRODUCT_DETAIL_MODULE)
+    const link: any = container.resolve(ContainerRegistrationKeys.LINK)
+
+    if (compensation.created) {
+      await link
+        .dismiss({
+          [Modules.PRODUCT]: { product_id: compensation.product_id },
+          [ARTISAN_PRODUCT_DETAIL_MODULE]: {
+            artisan_product_detail_id: compensation.id,
+          },
+        })
+        .catch(() => {})
+      await service.deleteArtisanProductDetails(compensation.id)
+      return
+    }
+
+    await service.updateArtisanProductDetails({
+      id: compensation.id,
+      ...compensation.prev,
+    })
+  }
+)
+
+export const upsertArtisanProductDetailWorkflow = createWorkflow(
+  "upsert-artisan-product-detail",
+  (input: UpsertArtisanProductDetailInput) => {
+    const detail = upsertArtisanProductDetailStep(input)
+    return new WorkflowResponse(detail)
+  }
+)

--- a/apps/partner-ui/src/hooks/api/onboarding-profile.tsx
+++ b/apps/partner-ui/src/hooks/api/onboarding-profile.tsx
@@ -1,0 +1,45 @@
+import { FetchError } from "@medusajs/js-sdk"
+import { QueryKey, UseQueryOptions, useQuery } from "@tanstack/react-query"
+
+import { sdk } from "../../lib/client"
+import { queryKeysFactory } from "../../lib/query-key-factory"
+
+const ONBOARDING_PROFILE_QUERY_KEY = "onboarding_profile" as const
+export const onboardingProfileQueryKeys = queryKeysFactory(
+  ONBOARDING_PROFILE_QUERY_KEY
+)
+
+export type PartnerOnboardingProfile = {
+  id?: string
+  partner_id?: string
+  selling_mode?: "dedicated_storefront" | "core_channel_listing" | null
+  commission_bps?: number | null
+  supplies_to_platform?: boolean | null
+  [key: string]: any
+} | null
+
+// #859 S3 (#862): read the partner's onboarding profile — used to gate the
+// artisan (made-to-order) UI to `core_channel_listing` sellers.
+export const usePartnerOnboardingProfile = (
+  options?: Omit<
+    UseQueryOptions<
+      { onboarding_profile: PartnerOnboardingProfile },
+      FetchError,
+      { onboarding_profile: PartnerOnboardingProfile },
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: onboardingProfileQueryKeys.details(),
+    queryFn: () =>
+      sdk.client.fetch<{ onboarding_profile: PartnerOnboardingProfile }>(
+        "/partners/onboarding-profile",
+        { method: "GET" }
+      ),
+    ...options,
+  })
+
+  return { ...data, ...rest }
+}

--- a/apps/partner-ui/src/hooks/api/products.tsx
+++ b/apps/partner-ui/src/hooks/api/products.tsx
@@ -22,6 +22,20 @@ export const variantsQueryKeys = queryKeysFactory(VARIANTS_QUERY_KEY)
 const OPTIONS_QUERY_KEY = "product_options" as const
 export const optionsQueryKeys = queryKeysFactory(OPTIONS_QUERY_KEY)
 
+const ARTISAN_DETAIL_QUERY_KEY = "artisan_product_detail" as const
+export const artisanDetailQueryKeys = queryKeysFactory(ARTISAN_DETAIL_QUERY_KEY)
+
+// #859 S3 (#862): the partner-editable made-to-order / maker-story detail.
+export type ArtisanProductDetail = {
+  id?: string
+  product_id?: string
+  made_to_order?: boolean | null
+  lead_time_days?: number | null
+  lead_time_label?: string | null
+  min_order_quantity?: number | null
+  maker_story?: string | null
+} | null
+
 export const useCreateProductOption = (
   productId: string,
   options?: UseMutationOptions<any, FetchError, any>
@@ -645,6 +659,61 @@ export const useBatchVariantImages = (
         queryKey: variantsQueryKeys.detail(variantId),
       })
 
+      options?.onSuccess?.(data, variables, context)
+    },
+    ...options,
+  })
+}
+
+// #859 S3 (#862): read the artisan made-to-order / maker-story detail for one
+// of the partner's own products.
+export const useArtisanProductDetail = (
+  productId: string,
+  options?: Omit<
+    UseQueryOptions<
+      { artisan_detail: ArtisanProductDetail },
+      FetchError,
+      { artisan_detail: ArtisanProductDetail },
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: artisanDetailQueryKeys.detail(productId),
+    queryFn: () =>
+      sdk.client.fetch<{ artisan_detail: ArtisanProductDetail }>(
+        `/partners/products/${productId}/artisan-detail`,
+        { method: "GET" }
+      ),
+    ...options,
+  })
+
+  return { ...data, ...rest }
+}
+
+// #859 S3 (#862): upsert the artisan made-to-order / maker-story detail.
+export const useUpsertArtisanProductDetail = (
+  productId: string,
+  options?: UseMutationOptions<
+    { artisan_detail: ArtisanProductDetail },
+    FetchError,
+    NonNullable<ArtisanProductDetail>
+  >
+) => {
+  return useMutation({
+    mutationFn: (payload) =>
+      sdk.client.fetch<{ artisan_detail: ArtisanProductDetail }>(
+        `/partners/products/${productId}/artisan-detail`,
+        { method: "POST", body: payload }
+      ),
+    onSuccess: async (data, variables, context) => {
+      await queryClient.invalidateQueries({
+        queryKey: artisanDetailQueryKeys.detail(productId),
+      })
+      await queryClient.invalidateQueries({
+        queryKey: productsQueryKeys.detail(productId),
+      })
       options?.onSuccess?.(data, variables, context)
     },
     ...options,

--- a/apps/partner-ui/src/lib/format-provider.ts
+++ b/apps/partner-ui/src/lib/format-provider.ts
@@ -8,14 +8,16 @@
  * @returns A formatted string
  */
 export const formatProvider = (id: string) => {
-  // Both Stripe providers surface to buyers/partners as a single "Stripe".
-  // `pp_stripe_stripe` (standard) and `pp_stripe-connect_stripe-connect`
-  // (Connect) are one payment method chosen by the partner's onboarding status
-  // (#985) — the Connect-vs-standard split is an implementation detail nobody
-  // configuring a region should have to reason about. Targeted so payu /
-  // fulfillment / tax providers keep their "Name (TYPE)" format.
-  if (id === "pp_stripe_stripe" || id === "pp_stripe-connect_stripe-connect") {
+  // Buyers see a single "Stripe" at checkout (#985), but operators configuring
+  // regions/payment-configs need to tell the two apart: `pp_stripe_stripe` is
+  // the platform-owned standard Stripe, `pp_stripe-connect_stripe-connect` is
+  // the merchant's connected account (Connect). So in the admin/partner-ui we
+  // label them distinctly to avoid the "two identical Stripe rows" confusion.
+  if (id === "pp_stripe_stripe") {
     return "Stripe"
+  }
+  if (id === "pp_stripe-connect_stripe-connect") {
+    return "Stripe Connect"
   }
 
   const [_, name, type] = id.split("_")

--- a/apps/partner-ui/src/routes/products/product-detail/components/product-artisan-section/index.ts
+++ b/apps/partner-ui/src/routes/products/product-detail/components/product-artisan-section/index.ts
@@ -1,0 +1,1 @@
+export { ProductArtisanSection } from "./product-artisan-section"

--- a/apps/partner-ui/src/routes/products/product-detail/components/product-artisan-section/product-artisan-section.tsx
+++ b/apps/partner-ui/src/routes/products/product-detail/components/product-artisan-section/product-artisan-section.tsx
@@ -1,0 +1,209 @@
+import { HttpTypes } from "@medusajs/types"
+import {
+  Button,
+  Container,
+  Heading,
+  Input,
+  Label,
+  Switch,
+  Text,
+  Textarea,
+  toast,
+} from "@medusajs/ui"
+import { useEffect, useState } from "react"
+
+import {
+  useArtisanProductDetail,
+  useUpsertArtisanProductDetail,
+} from "../../../../../hooks/api/products"
+import { usePartnerOnboardingProfile } from "../../../../../hooks/api/onboarding-profile"
+
+type Props = {
+  product: HttpTypes.AdminProduct
+}
+
+/**
+ * #859 S3 (#862) — the partner-editable "Made-to-order & maker story" panel.
+ *
+ * These fields are stored on the linked `artisan_product_detail` module (not
+ * product metadata) and surfaced on the storefront: a made-to-order notice with
+ * lead time, a minimum order quantity enforced at add-to-cart, and the maker /
+ * provenance prose shown on the product page.
+ */
+export const ProductArtisanSection = ({ product }: Props) => {
+  // #859 S3 — this panel only applies to artisans selling on the core channel.
+  const { onboarding_profile } = usePartnerOnboardingProfile()
+  const isCoreListing =
+    onboarding_profile?.selling_mode === "core_channel_listing"
+
+  const { artisan_detail, isLoading } = useArtisanProductDetail(product.id, {
+    enabled: isCoreListing,
+  })
+  const { mutateAsync, isPending } = useUpsertArtisanProductDetail(product.id)
+
+  const [madeToOrder, setMadeToOrder] = useState(false)
+  const [leadTimeDays, setLeadTimeDays] = useState<string>("")
+  const [leadTimeLabel, setLeadTimeLabel] = useState<string>("")
+  const [minOrderQty, setMinOrderQty] = useState<string>("")
+  const [makerStory, setMakerStory] = useState<string>("")
+
+  // Hydrate once the saved detail loads.
+  useEffect(() => {
+    if (!artisan_detail) return
+    setMadeToOrder(!!artisan_detail.made_to_order)
+    setLeadTimeDays(
+      artisan_detail.lead_time_days != null
+        ? String(artisan_detail.lead_time_days)
+        : ""
+    )
+    setLeadTimeLabel(artisan_detail.lead_time_label ?? "")
+    setMinOrderQty(
+      artisan_detail.min_order_quantity != null
+        ? String(artisan_detail.min_order_quantity)
+        : ""
+    )
+    setMakerStory(artisan_detail.maker_story ?? "")
+  }, [artisan_detail])
+
+  const handleSave = async () => {
+    // Empty numeric/text inputs clear the field (null); otherwise parse/trim.
+    const payload = {
+      made_to_order: madeToOrder,
+      lead_time_days: leadTimeDays.trim() === "" ? null : Number(leadTimeDays),
+      lead_time_label: leadTimeLabel.trim() === "" ? null : leadTimeLabel.trim(),
+      min_order_quantity:
+        minOrderQty.trim() === "" ? null : Number(minOrderQty),
+      maker_story: makerStory.trim() === "" ? null : makerStory.trim(),
+    }
+
+    if (
+      payload.lead_time_days != null &&
+      (!Number.isFinite(payload.lead_time_days) || payload.lead_time_days < 0)
+    ) {
+      toast.error("Lead time must be a positive number of days")
+      return
+    }
+    if (
+      payload.min_order_quantity != null &&
+      (!Number.isFinite(payload.min_order_quantity) ||
+        payload.min_order_quantity < 1)
+    ) {
+      toast.error("Minimum order quantity must be at least 1")
+      return
+    }
+
+    await mutateAsync(payload, {
+      onSuccess: () => toast.success("Made-to-order details saved"),
+      onError: (e) => toast.error(e.message),
+    })
+  }
+
+  // Hidden for dedicated-storefront partners — the made-to-order / maker-story
+  // fields only surface on the core-channel (Airbnb-style) listings.
+  if (!isCoreListing) {
+    return null
+  }
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <Heading level="h2">Made-to-order & maker story</Heading>
+      </div>
+
+      <div className="flex flex-col gap-y-4 px-6 py-4">
+        <div className="flex items-center justify-between">
+          <div className="flex flex-col">
+            <Label htmlFor="made_to_order" weight="plus">
+              Made to order
+            </Label>
+            <Text size="small" className="text-ui-fg-subtle">
+              Crafted on demand after the customer orders.
+            </Text>
+          </div>
+          <Switch
+            id="made_to_order"
+            checked={madeToOrder}
+            onCheckedChange={setMadeToOrder}
+            disabled={isLoading}
+          />
+        </div>
+
+        <div className="flex flex-col gap-y-2">
+          <Label htmlFor="lead_time_label" weight="plus">
+            Lead time note
+          </Label>
+          <Input
+            id="lead_time_label"
+            placeholder="e.g. takes a few weeks"
+            value={leadTimeLabel}
+            onChange={(e) => setLeadTimeLabel(e.target.value)}
+            disabled={isLoading}
+          />
+          <Text size="small" className="text-ui-fg-subtle">
+            Shown to shoppers as-is. Leave empty to derive it from the days
+            below.
+          </Text>
+        </div>
+
+        <div className="flex flex-col gap-y-2">
+          <Label htmlFor="lead_time_days" weight="plus">
+            Lead time (days)
+          </Label>
+          <Input
+            id="lead_time_days"
+            type="number"
+            min={0}
+            placeholder="e.g. 21"
+            value={leadTimeDays}
+            onChange={(e) => setLeadTimeDays(e.target.value)}
+            disabled={isLoading}
+          />
+          <Text size="small" className="text-ui-fg-subtle">
+            Rendered as an approximate "~N weeks to prepare" when no note is set.
+          </Text>
+        </div>
+
+        <div className="flex flex-col gap-y-2">
+          <Label htmlFor="min_order_quantity" weight="plus">
+            Minimum order quantity
+          </Label>
+          <Input
+            id="min_order_quantity"
+            type="number"
+            min={1}
+            placeholder="e.g. 1"
+            value={minOrderQty}
+            onChange={(e) => setMinOrderQty(e.target.value)}
+            disabled={isLoading}
+          />
+        </div>
+
+        <div className="flex flex-col gap-y-2">
+          <Label htmlFor="maker_story" weight="plus">
+            Maker's story
+          </Label>
+          <Textarea
+            id="maker_story"
+            rows={5}
+            placeholder="Who makes this, where, and how it's crafted…"
+            value={makerStory}
+            onChange={(e) => setMakerStory(e.target.value)}
+            disabled={isLoading}
+          />
+        </div>
+
+        <div className="flex justify-end">
+          <Button
+            variant="primary"
+            size="small"
+            onClick={handleSave}
+            isLoading={isPending}
+            disabled={isLoading}
+          >
+            Save
+          </Button>
+        </div>
+      </div>
+    </Container>
+  )
+}

--- a/apps/partner-ui/src/routes/products/product-detail/product-detail.tsx
+++ b/apps/partner-ui/src/routes/products/product-detail/product-detail.tsx
@@ -3,6 +3,7 @@ import { useLoaderData, useParams } from "react-router-dom"
 import { TwoColumnPageSkeleton } from "../../../components/common/skeleton"
 import { TwoColumnPage } from "../../../components/layout/pages"
 import { useProduct } from "../../../hooks/api/products"
+import { ProductArtisanSection } from "./components/product-artisan-section"
 import { ProductAttributeSection } from "./components/product-attribute-section"
 import { ProductGeneralSection } from "./components/product-general-section"
 import { ProductReviewBanner } from "./components/product-review-banner/product-review-banner"
@@ -71,6 +72,7 @@ export const ProductDetail = () => {
         <ProductMediaSection product={product} />
         <ProductOptionSection product={product} />
         <ProductVariantSection product={product} />
+        <ProductArtisanSection product={product} />
       </TwoColumnPage.Main>
       <TwoColumnPage.Sidebar>
         <ProductSalesChannelSection product={product} />


### PR DESCRIPTION
## Summary
Ships **#859 S3 (#862)** — the artisan made-to-order & maker-story product detail — plus a small partner-ui Stripe-label clarity fix.

### Backend
- New **`artisanProductDetail`** module: `made_to_order`, `lead_time_days`, `lead_time_label`, `min_order_quantity`, `maker_story` (typed cols, one row per product — not metadata). Hand-written create migration `Migration20260711170000`.
- `product ↔ artisanProductDetail` link; idempotent upsert workflow (creates link + compensation).
- Partner routes `GET|POST /partners/products/:id/artisan-detail`, ownership via the partner's store sales channel (proposal link as fallback).

### Partner-ui
- "Made-to-order & maker story" editing section on the product detail page, **gated to `core_channel_listing`** artisans.
- `format-provider`: distinguishes **"Stripe"** (`pp_stripe_stripe`) vs **"Stripe Connect"** (`pp_stripe-connect_stripe-connect`) so operators no longer see two identical "Stripe" rows (buyers still see one, per #985).

### Storefront
- The starter storefront half (reads `+artisan_detail.*`, renders the made-to-order notice + maker story) shipped separately on `nextjs-starter-medusa` `main`.

## Deploy tail
- Backend auto-deploy runs the new migration (creates `artisan_product_detail`).
- Store field `artisan_detail` surfaces on `/store/products` — verify it returns; add a store field allow-list middleware if not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)