### PR TITLE
feat(investor): SAFE instruments, publishable SAFE rounds, expense & commission panels

### DIFF
--- a/apps/backend/src/admin/components/companies/cap-table-section.tsx
+++ b/apps/backend/src/admin/components/companies/cap-table-section.tsx
@@ -16,8 +16,11 @@ import { ActionMenu } from "../common/action-menu"
 import { OwnershipDonut, type DonutSegment } from "./ownership-donut"
 import {
   useCompanyCapTables,
+  useCapTableConvertibles,
+  useApproveConvertible,
   usePublishRound,
   type AdminCapTable,
+  type AdminConvertible,
   type AdminFundingRound,
   type AdminStake,
 } from "../../hooks/api/cap-tables-admin"
@@ -227,7 +230,17 @@ const FundingRoundsTable = ({ capTable }: { capTable: AdminCapTable }) => {
       {
         header: "Type",
         accessorKey: "round_type",
-        cell: ({ row }: any) => row.original.round_type ?? "—",
+        cell: ({ row }: any) => {
+          const isSafe =
+            row.original.instrument_type === "safe" ||
+            row.original.instrument_type === "convertible_note" ||
+            row.original.round_type === "safe"
+          return isSafe ? (
+            <Badge size="2xsmall" color="purple">SAFE</Badge>
+          ) : (
+            row.original.round_type ?? "—"
+          )
+        },
       },
       {
         header: "Status",
@@ -252,6 +265,119 @@ const FundingRoundsTable = ({ capTable }: { capTable: AdminCapTable }) => {
       },
     ],
   })
+  return (
+    <DataTable instance={table}>
+      <DataTable.Table />
+    </DataTable>
+  )
+}
+
+const pct = (v?: number | null) =>
+  v == null ? "—" : `${(Number(v) * 100).toFixed(2)}%`
+
+const convertibleStatusColor = (s?: string): "green" | "orange" | "red" | "grey" => {
+  switch (s) {
+    case "outstanding":
+      return "green"
+    case "converted":
+      return "grey"
+    case "redeemed":
+      return "orange"
+    case "cancelled":
+    case "expired":
+      return "red"
+    default:
+      return "grey"
+  }
+}
+
+const ConvertiblesTable = ({ capTable }: { capTable: AdminCapTable }) => {
+  const ccy = capTable.currency_code
+  const { convertibles = [], isPending } = useCapTableConvertibles(capTable.id)
+  const { mutate: approve } = useApproveConvertible(capTable.id, {
+    onSuccess: (r) =>
+      toast.success(
+        r?.payment_link ? "Approved — PayU link generated" : "Approved — pending payment"
+      ),
+    onError: (e) => toast.error(e?.message || "Approve failed"),
+  })
+
+  const table = useDataTable({
+    data: convertibles,
+    columns: [
+      {
+        header: "Investor",
+        accessorKey: "investor",
+        cell: ({ row }: any) => row.original.investor?.name ?? row.original.investor_id ?? "—",
+      },
+      {
+        header: "Instrument",
+        accessorKey: "instrument_type",
+        cell: ({ row }: any) => (
+          <Badge size="2xsmall" color="purple">
+            {row.original.instrument_type === "convertible_note" ? "Note" : "SAFE"}
+          </Badge>
+        ),
+      },
+      {
+        header: "Principal",
+        accessorKey: "principal_amount",
+        cell: ({ row }: any) => money(row.original.value?.principal ?? row.original.principal_amount, ccy),
+      },
+      {
+        header: "Cap",
+        accessorKey: "valuation_cap",
+        cell: ({ row }: any) => money(row.original.valuation_cap, ccy),
+      },
+      {
+        header: "Implied own.",
+        id: "implied_own",
+        cell: ({ row }: any) => pct(row.original.value?.implied_ownership_pct),
+      },
+      {
+        header: "Implied value",
+        id: "implied_value",
+        cell: ({ row }: any) => money(row.original.value?.implied_value, ccy),
+      },
+      {
+        header: "Status",
+        accessorKey: "status",
+        cell: ({ row }: any) => (
+          <Badge color={convertibleStatusColor(row.original.status)}>
+            {row.original.status ?? "outstanding"}
+          </Badge>
+        ),
+      },
+      {
+        id: "actions",
+        header: "",
+        cell: ({ row }: any) => {
+          const c = row.original as AdminConvertible
+          const approved = !!c.metadata?.approved
+          return (
+            <div className="flex justify-end">
+              <ActionMenu
+                groups={[
+                  {
+                    actions: [
+                      {
+                        icon: <CurrencyDollar />,
+                        label: "Approve (generate pay link)",
+                        disabled: approved,
+                        onClick: () => approve(c.id),
+                      },
+                    ],
+                  },
+                ]}
+              />
+            </div>
+          )
+        },
+      },
+    ],
+  })
+
+  if (isPending) return <Skeleton className="mx-6 mb-5 h-16" />
   return (
     <DataTable instance={table}>
       <DataTable.Table />
@@ -301,6 +427,7 @@ export const CapTableSection = ({ companyId }: { companyId: string }) => {
                 {
                   actions: [
                     { icon: <Users />, label: "Provision shares (manual)", to: "provision-stake" },
+                    { icon: <DocumentText />, label: "Record SAFE (manual)", to: "add-safe" },
                     { icon: <Plus />, label: "Add share class", to: "add-share-class" },
                     { icon: <Plus />, label: "Add funding round", to: "add-round" },
                     { icon: <DocumentText />, label: "Add document", to: "add-document" },
@@ -352,6 +479,12 @@ export const CapTableSection = ({ companyId }: { companyId: string }) => {
           >
             <FundingRoundsTable capTable={capTable} />
           </FullWidthBlock>
+          <div>
+            <div className="px-6 pb-3 pt-5">
+              <Text weight="plus">SAFEs &amp; convertibles</Text>
+            </div>
+            <ConvertiblesTable capTable={capTable} />
+          </div>
         </>
       )}
     </Container>

--- a/apps/backend/src/admin/hooks/api/cap-tables-admin.ts
+++ b/apps/backend/src/admin/hooks/api/cap-tables-admin.ts
@@ -23,12 +23,16 @@ export type AdminFundingRound = {
   id: string
   name: string
   round_type?: string
+  instrument_type?: "equity" | "safe" | "convertible_note"
   status?: string
   target_amount?: number | null
   raised_amount?: number | null
   pre_money_valuation?: number | null
   post_money_valuation?: number | null
   price_per_share?: number | null
+  valuation_cap?: number | null
+  discount_rate?: number | null
+  safe_type?: "post_money" | "pre_money" | null
   open_date?: string | null
   close_date?: string | null
 }
@@ -84,10 +88,14 @@ export type CreateShareClassPayload = {
 export type CreateFundingRoundPayload = {
   name: string
   round_type?: string
+  instrument_type?: "equity" | "safe" | "convertible_note"
   status?: string
   target_amount?: number | null
   pre_money_valuation?: number | null
   price_per_share?: number | null
+  valuation_cap?: number | null
+  discount_rate?: number | null
+  safe_type?: "post_money" | "pre_money" | null
 }
 
 // ---- Query keys ------------------------------------------------------------
@@ -174,6 +182,9 @@ export const useCreateShareClass = (
       }),
     onSuccess: (...args: any[]) => {
       queryClient.invalidateQueries({ queryKey: capTablesQueryKeys.detail(capTableId) })
+      // The company-page section renders from the companyList query, not detail —
+      // invalidate the whole family so it re-fetches too.
+      queryClient.invalidateQueries({ queryKey: ["admin-company-cap-tables"] })
       ;(options?.onSuccess as any)?.(...args)
     },
   })
@@ -193,6 +204,7 @@ export const useCreateFundingRound = (
       }),
     onSuccess: (...args: any[]) => {
       queryClient.invalidateQueries({ queryKey: capTablesQueryKeys.detail(capTableId) })
+      queryClient.invalidateQueries({ queryKey: ["admin-company-cap-tables"] })
       ;(options?.onSuccess as any)?.(...args)
     },
   })
@@ -238,6 +250,8 @@ export const useProvisionStake = (
 
 export type AdminParticipation = {
   id: string
+  // "stake" (equity) or "convertible" (SAFE / note) — set by the participations route.
+  type?: "stake" | "convertible"
   investor_id?: string | null
   number_of_shares?: number | null
   total_invested?: number | null
@@ -245,6 +259,104 @@ export type AdminParticipation = {
   metadata?: Record<string, any> | null
   investor?: { id: string; name?: string; email?: string } | null
   payments?: Array<{ id: string; amount?: number | null; status?: string; metadata?: Record<string, any> | null }>
+}
+
+export type AdminConvertible = {
+  id: string
+  investor_id?: string | null
+  instrument_type?: "safe" | "convertible_note"
+  principal_amount?: number | null
+  currency_code?: string | null
+  valuation_cap?: number | null
+  discount_rate?: number | null
+  safe_type?: "post_money" | "pre_money"
+  status?: string
+  investment_date?: string | null
+  metadata?: Record<string, any> | null
+  investor?: { id: string; name?: string; email?: string } | null
+  payments?: Array<{ id: string; amount?: number | null; status?: string }>
+  value?: {
+    principal: number
+    implied_ownership_pct: number | null
+    implied_value: number | null
+    multiple: number | null
+    basis: string
+  }
+}
+
+export type ProvisionConvertiblePayload = {
+  investor_id?: string
+  investor?: { name: string; email?: string; investor_type?: "individual" | "entity" | "fund" }
+  instrument_type?: "safe" | "convertible_note"
+  principal_amount: number
+  valuation_cap?: number | null
+  discount_rate?: number | null
+  safe_type?: "post_money" | "pre_money"
+  investment_date?: string | null
+  status?: "outstanding" | "converted" | "redeemed" | "cancelled" | "expired"
+  notes?: string | null
+}
+
+export const convertiblesQueryKey = (capTableId: string) =>
+  ["admin-cap-table-convertibles", capTableId] as const
+
+export const useCapTableConvertibles = (
+  capTableId: string,
+  options?: Omit<
+    UseQueryOptions<{ convertibles: AdminConvertible[]; count: number }, FetchError, { convertibles: AdminConvertible[]; count: number }, QueryKey>,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryFn: () =>
+      sdk.client.fetch<{ convertibles: AdminConvertible[]; count: number }>(
+        `/admin/cap-tables/${capTableId}/convertibles`,
+        { method: "GET" }
+      ),
+    queryKey: convertiblesQueryKey(capTableId),
+    ...options,
+  })
+  return { ...data, ...rest }
+}
+
+// Manual SAFE provision — record a (possibly historical) SAFE for an existing
+// investor (or a new individual inline). Mirrors useProvisionStake.
+export const useProvisionConvertible = (
+  capTableId: string,
+  options?: UseMutationOptions<{ convertible: AdminConvertible }, FetchError, ProvisionConvertiblePayload>
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    ...options,
+    mutationFn: (payload) =>
+      sdk.client.fetch(`/admin/cap-tables/${capTableId}/convertibles`, {
+        method: "POST",
+        body: payload,
+      }),
+    onSuccess: (...args: any[]) => {
+      queryClient.invalidateQueries({ queryKey: convertiblesQueryKey(capTableId) })
+      queryClient.invalidateQueries({ queryKey: capTablesQueryKeys.detail(capTableId) })
+      queryClient.invalidateQueries({ queryKey: ["admin-company-cap-tables"] })
+      ;(options?.onSuccess as any)?.(...args)
+    },
+  })
+}
+
+export const useApproveConvertible = (
+  capTableId: string,
+  options?: UseMutationOptions<{ payment_id: string; payment_link: string | null }, FetchError, string>
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    ...options,
+    mutationFn: (convertibleId: string) =>
+      sdk.client.fetch(`/admin/convertibles/${convertibleId}/approve`, { method: "POST" }),
+    onSuccess: (...args: any[]) => {
+      queryClient.invalidateQueries({ queryKey: convertiblesQueryKey(capTableId) })
+      queryClient.invalidateQueries({ queryKey: ["admin-round-participations"] })
+      ;(options?.onSuccess as any)?.(...args)
+    },
+  })
 }
 
 export const roundParticipationsQueryKey = (roundId: string) =>
@@ -261,6 +373,7 @@ export const usePublishRound = (
       sdk.client.fetch(`/admin/funding-rounds/${roundId}/publish`, { method: "POST" }),
     onSuccess: (...args: any[]) => {
       queryClient.invalidateQueries({ queryKey: capTablesQueryKeys.detail(capTableId) })
+      queryClient.invalidateQueries({ queryKey: ["admin-company-cap-tables"] })
       ;(options?.onSuccess as any)?.(...args)
     },
   })

--- a/apps/backend/src/admin/routes/companies/[id]/@add-round/page.tsx
+++ b/apps/backend/src/admin/routes/companies/[id]/@add-round/page.tsx
@@ -28,6 +28,12 @@ const ROUND_TYPES = [
   "grant",
 ] as const
 
+const INSTRUMENTS = [
+  { value: "equity", label: "Priced equity (shares)" },
+  { value: "safe", label: "SAFE (converts later)" },
+  { value: "convertible_note", label: "Convertible note" },
+] as const
+
 const AddRoundForm = ({ companyId }: { companyId: string }) => {
   const { cap_tables = [] } = useCompanyCapTables(companyId)
   const capTable = cap_tables[0]
@@ -35,12 +41,18 @@ const AddRoundForm = ({ companyId }: { companyId: string }) => {
   const form = useForm({
     defaultValues: {
       name: "",
+      instrument_type: "equity" as "equity" | "safe" | "convertible_note",
       round_type: "seed",
       target_amount: "",
       pre_money_valuation: "",
       price_per_share: "",
+      valuation_cap: "",
+      discount_rate: "",
+      safe_type: "post_money" as "post_money" | "pre_money",
     },
   })
+  const instrument = form.watch("instrument_type")
+  const isSafe = instrument === "safe" || instrument === "convertible_note"
   const { mutateAsync, isPending } = useCreateFundingRound(capTable?.id ?? "", {
     onSuccess: () => {
       toast.success("Funding round created")
@@ -53,13 +65,21 @@ const AddRoundForm = ({ companyId }: { companyId: string }) => {
       toast.error("Create a cap table first")
       return
     }
+    const safe = v.instrument_type === "safe" || v.instrument_type === "convertible_note"
     return mutateAsync({
       name: v.name,
-      round_type: v.round_type,
+      instrument_type: v.instrument_type,
+      // A SAFE/convertible round is tagged round_type "safe" so it reads clearly
+      // in the cap table; equity rounds keep the chosen stage.
+      round_type: safe ? "safe" : v.round_type,
       status: "planned",
       target_amount: v.target_amount ? Number(v.target_amount) : null,
-      pre_money_valuation: v.pre_money_valuation ? Number(v.pre_money_valuation) : null,
-      price_per_share: v.price_per_share ? Number(v.price_per_share) : null,
+      pre_money_valuation:
+        !safe && v.pre_money_valuation ? Number(v.pre_money_valuation) : null,
+      price_per_share: !safe && v.price_per_share ? Number(v.price_per_share) : null,
+      valuation_cap: safe && v.valuation_cap ? Number(v.valuation_cap) : null,
+      discount_rate: safe && v.discount_rate ? Number(v.discount_rate) / 100 : null,
+      safe_type: safe ? v.safe_type : null,
     })
   })
 
@@ -79,36 +99,92 @@ const AddRoundForm = ({ companyId }: { companyId: string }) => {
           <Input placeholder="Seed round 2026" {...form.register("name", { required: true })} />
         </div>
         <div className="flex flex-col gap-y-2">
-          <Label size="small" weight="plus">Round type</Label>
+          <Label size="small" weight="plus">Instrument</Label>
           <Controller
             control={form.control}
-            name="round_type"
+            name="instrument_type"
             render={({ field }) => (
               <Select value={field.value} onValueChange={field.onChange}>
                 <Select.Trigger><Select.Value /></Select.Trigger>
                 <Select.Content>
-                  {ROUND_TYPES.map((t) => (
-                    <Select.Item key={t} value={t}>{t}</Select.Item>
+                  {INSTRUMENTS.map((t) => (
+                    <Select.Item key={t.value} value={t.value}>{t.label}</Select.Item>
                   ))}
                 </Select.Content>
               </Select>
             )}
           />
+          <Text size="xsmall" className="text-ui-fg-muted">
+            {isSafe
+              ? "Participants invest now and receive a SAFE — equity is issued when it converts at a priced round."
+              : "Participants are allocated shares at the round price."}
+          </Text>
         </div>
-        <div className="grid grid-cols-2 gap-x-3">
+
+        {!isSafe && (
           <div className="flex flex-col gap-y-2">
-            <Label size="small" weight="plus">Target amount</Label>
-            <Input type="number" {...form.register("target_amount")} />
+            <Label size="small" weight="plus">Round type</Label>
+            <Controller
+              control={form.control}
+              name="round_type"
+              render={({ field }) => (
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <Select.Trigger><Select.Value /></Select.Trigger>
+                  <Select.Content>
+                    {ROUND_TYPES.map((t) => (
+                      <Select.Item key={t} value={t}>{t}</Select.Item>
+                    ))}
+                  </Select.Content>
+                </Select>
+              )}
+            />
           </div>
-          <div className="flex flex-col gap-y-2">
-            <Label size="small" weight="plus">Pre-money valuation</Label>
-            <Input type="number" {...form.register("pre_money_valuation")} />
-          </div>
-          <div className="flex flex-col gap-y-2">
-            <Label size="small" weight="plus">Price / share</Label>
-            <Input type="number" {...form.register("price_per_share")} />
-          </div>
+        )}
+
+        <div className="flex flex-col gap-y-2">
+          <Label size="small" weight="plus">Target amount</Label>
+          <Input type="number" {...form.register("target_amount")} />
         </div>
+
+        {isSafe ? (
+          <div className="grid grid-cols-2 gap-x-3 gap-y-4">
+            <div className="flex flex-col gap-y-2">
+              <Label size="small" weight="plus">Valuation cap</Label>
+              <Input type="number" placeholder="5000000" {...form.register("valuation_cap")} />
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label size="small" weight="plus">Discount (%)</Label>
+              <Input type="number" placeholder="20" {...form.register("discount_rate")} />
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label size="small" weight="plus">SAFE type</Label>
+              <Controller
+                control={form.control}
+                name="safe_type"
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <Select.Trigger><Select.Value /></Select.Trigger>
+                    <Select.Content>
+                      <Select.Item value="post_money">Post-money</Select.Item>
+                      <Select.Item value="pre_money">Pre-money</Select.Item>
+                    </Select.Content>
+                  </Select>
+                )}
+              />
+            </div>
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-x-3 gap-y-4">
+            <div className="flex flex-col gap-y-2">
+              <Label size="small" weight="plus">Pre-money valuation</Label>
+              <Input type="number" {...form.register("pre_money_valuation")} />
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label size="small" weight="plus">Price / share</Label>
+              <Input type="number" {...form.register("price_per_share")} />
+            </div>
+          </div>
+        )}
       </RouteDrawer.Body>
       <RouteDrawer.Footer>
         <div className="flex items-center justify-end gap-x-2">

--- a/apps/backend/src/admin/routes/companies/[id]/@add-safe/page.tsx
+++ b/apps/backend/src/admin/routes/companies/[id]/@add-safe/page.tsx
@@ -1,0 +1,293 @@
+import {
+  Button,
+  Heading,
+  Input,
+  Label,
+  Select,
+  Text,
+  toast,
+} from "@medusajs/ui"
+import { Controller, useForm } from "react-hook-form"
+import { useParams } from "react-router-dom"
+import { RouteDrawer } from "../../../../components/modal/route-drawer/route-drawer"
+import { useRouteModal } from "../../../../components/modal/use-route-modal"
+import {
+  useCompanyCapTables,
+  useProvisionConvertible,
+} from "../../../../hooks/api/cap-tables-admin"
+import { useCompanyInvestors } from "../../../../hooks/api/companies-admin"
+
+type FormValues = {
+  mode: "existing" | "new"
+  investor_id: string
+  new_name: string
+  new_email: string
+  new_type: "individual" | "entity" | "fund"
+  instrument_type: "safe" | "convertible_note"
+  principal_amount: string
+  valuation_cap: string
+  discount_rate: string
+  safe_type: "post_money" | "pre_money"
+  investment_date: string
+  status: "outstanding" | "converted" | "redeemed" | "cancelled" | "expired"
+  notes: string
+}
+
+// Record a (possibly historical) SAFE / convertible for an existing investor —
+// e.g. someone who invested via SAFE before this system existed and holds no
+// shares yet. Mirrors the manual share-provision form.
+const AddSafeForm = ({ companyId }: { companyId: string }) => {
+  const { cap_tables = [] } = useCompanyCapTables(companyId)
+  const capTable = cap_tables[0]
+  const { investors = [] } = useCompanyInvestors(companyId)
+  const { handleSuccess } = useRouteModal()
+
+  const form = useForm<FormValues>({
+    defaultValues: {
+      mode: investors.length ? "existing" : "new",
+      investor_id: "",
+      new_name: "",
+      new_email: "",
+      new_type: "individual",
+      instrument_type: "safe",
+      principal_amount: "",
+      valuation_cap: "",
+      discount_rate: "",
+      safe_type: "post_money",
+      investment_date: "",
+      status: "outstanding",
+    },
+  })
+
+  const mode = form.watch("mode")
+  const ccy = capTable?.currency_code
+
+  const { mutateAsync, isPending } = useProvisionConvertible(capTable?.id ?? "", {
+    onSuccess: () => {
+      toast.success("SAFE recorded")
+      handleSuccess()
+    },
+    onError: (e) => toast.error(e?.message || "Failed to record SAFE"),
+  })
+
+  const onSubmit = form.handleSubmit(async (v) => {
+    if (!capTable) {
+      toast.error("Create a cap table first")
+      return
+    }
+    const principal = Number(v.principal_amount)
+    if (!principal || principal <= 0) {
+      toast.error("Enter a positive principal amount")
+      return
+    }
+    return mutateAsync({
+      ...(v.mode === "existing"
+        ? { investor_id: v.investor_id }
+        : { investor: { name: v.new_name, email: v.new_email || undefined, investor_type: v.new_type } }),
+      instrument_type: v.instrument_type,
+      principal_amount: principal,
+      valuation_cap: v.valuation_cap ? Number(v.valuation_cap) : null,
+      discount_rate: v.discount_rate ? Number(v.discount_rate) / 100 : null,
+      safe_type: v.safe_type,
+      investment_date: v.investment_date
+        ? new Date(v.investment_date).toISOString()
+        : null,
+      status: v.status,
+      notes: v.notes || null,
+    })
+  })
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-1 flex-col">
+      <RouteDrawer.Header>
+        <RouteDrawer.Title asChild>
+          <Heading>Record SAFE (manual)</Heading>
+        </RouteDrawer.Title>
+      </RouteDrawer.Header>
+      <RouteDrawer.Body className="flex flex-1 flex-col gap-y-6 overflow-auto">
+        {!capTable && (
+          <Text size="small" className="text-ui-fg-error">
+            This company has no cap table yet — create one first.
+          </Text>
+        )}
+        <Text size="small" className="text-ui-fg-subtle">
+          Record a SAFE or convertible note directly — no shares are issued. Use
+          for an investor who already invested via SAFE. Value (implied ownership
+          + current value) is derived against the cap table valuation.
+        </Text>
+
+        {/* Investor: existing or new */}
+        <div className="flex flex-col gap-y-2">
+          <Label size="small" weight="plus">Investor</Label>
+          <Controller
+            control={form.control}
+            name="mode"
+            render={({ field }) => (
+              <Select value={field.value} onValueChange={field.onChange}>
+                <Select.Trigger><Select.Value /></Select.Trigger>
+                <Select.Content>
+                  <Select.Item value="existing" disabled={!investors.length}>
+                    Existing investor
+                  </Select.Item>
+                  <Select.Item value="new">New individual</Select.Item>
+                </Select.Content>
+              </Select>
+            )}
+          />
+        </div>
+
+        {mode === "existing" ? (
+          <div className="flex flex-col gap-y-2">
+            <Label size="small" weight="plus">Select investor</Label>
+            <Controller
+              control={form.control}
+              name="investor_id"
+              rules={{ required: mode === "existing" }}
+              render={({ field }) => (
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <Select.Trigger><Select.Value placeholder="Pick an investor" /></Select.Trigger>
+                  <Select.Content>
+                    {investors.map((inv) => (
+                      <Select.Item key={inv.id} value={inv.id}>
+                        {inv.name}{inv.email ? ` · ${inv.email}` : ""}
+                      </Select.Item>
+                    ))}
+                  </Select.Content>
+                </Select>
+              )}
+            />
+          </div>
+        ) : (
+          <>
+            <div className="flex flex-col gap-y-2">
+              <Label size="small" weight="plus">Name</Label>
+              <Input placeholder="Jane Doe" {...form.register("new_name", { required: mode === "new" })} />
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label size="small" weight="plus">Email (optional)</Label>
+              <Input type="email" placeholder="jane@example.com" {...form.register("new_email")} />
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label size="small" weight="plus">Type</Label>
+              <Controller
+                control={form.control}
+                name="new_type"
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <Select.Trigger><Select.Value /></Select.Trigger>
+                    <Select.Content>
+                      <Select.Item value="individual">Individual</Select.Item>
+                      <Select.Item value="entity">Entity</Select.Item>
+                      <Select.Item value="fund">Fund</Select.Item>
+                    </Select.Content>
+                  </Select>
+                )}
+              />
+            </div>
+          </>
+        )}
+
+        {/* Instrument + economics */}
+        <div className="grid grid-cols-2 gap-4">
+          <div className="flex flex-col gap-y-2">
+            <Label size="small" weight="plus">Instrument</Label>
+            <Controller
+              control={form.control}
+              name="instrument_type"
+              render={({ field }) => (
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <Select.Trigger><Select.Value /></Select.Trigger>
+                  <Select.Content>
+                    <Select.Item value="safe">SAFE</Select.Item>
+                    <Select.Item value="convertible_note">Convertible note</Select.Item>
+                  </Select.Content>
+                </Select>
+              )}
+            />
+          </div>
+          <div className="flex flex-col gap-y-2">
+            <Label size="small" weight="plus">Principal {ccy ? `(${ccy})` : ""}</Label>
+            <Input type="number" min="0" step="any" {...form.register("principal_amount", { required: true })} />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div className="flex flex-col gap-y-2">
+            <Label size="small" weight="plus">Valuation cap {ccy ? `(${ccy})` : ""}</Label>
+            <Input type="number" min="0" step="any" placeholder="5000000" {...form.register("valuation_cap")} />
+          </div>
+          <div className="flex flex-col gap-y-2">
+            <Label size="small" weight="plus">Discount (%)</Label>
+            <Input type="number" min="0" max="100" placeholder="20" {...form.register("discount_rate")} />
+          </div>
+          <div className="flex flex-col gap-y-2">
+            <Label size="small" weight="plus">SAFE type</Label>
+            <Controller
+              control={form.control}
+              name="safe_type"
+              render={({ field }) => (
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <Select.Trigger><Select.Value /></Select.Trigger>
+                  <Select.Content>
+                    <Select.Item value="post_money">Post-money</Select.Item>
+                    <Select.Item value="pre_money">Pre-money</Select.Item>
+                  </Select.Content>
+                </Select>
+              )}
+            />
+          </div>
+          <div className="flex flex-col gap-y-2">
+            <Label size="small" weight="plus">Investment date</Label>
+            <Input type="date" {...form.register("investment_date")} />
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-y-2">
+          <Label size="small" weight="plus">Status</Label>
+          <Controller
+            control={form.control}
+            name="status"
+            render={({ field }) => (
+              <Select value={field.value} onValueChange={field.onChange}>
+                <Select.Trigger><Select.Value /></Select.Trigger>
+                <Select.Content>
+                  <Select.Item value="outstanding">Outstanding</Select.Item>
+                  <Select.Item value="converted">Converted</Select.Item>
+                  <Select.Item value="redeemed">Redeemed</Select.Item>
+                  <Select.Item value="cancelled">Cancelled</Select.Item>
+                  <Select.Item value="expired">Expired</Select.Item>
+                </Select.Content>
+              </Select>
+            )}
+          />
+        </div>
+
+        <div className="flex flex-col gap-y-2">
+          <Label size="small" weight="plus">Notes (optional)</Label>
+          <Input placeholder="Original SAFE signed 2024…" {...form.register("notes")} />
+        </div>
+      </RouteDrawer.Body>
+      <RouteDrawer.Footer>
+        <div className="flex items-center justify-end gap-x-2">
+          <RouteDrawer.Close asChild>
+            <Button size="small" variant="secondary">Cancel</Button>
+          </RouteDrawer.Close>
+          <Button size="small" type="submit" isLoading={isPending} disabled={!capTable}>
+            Record SAFE
+          </Button>
+        </div>
+      </RouteDrawer.Footer>
+    </form>
+  )
+}
+
+const AddSafePage = () => {
+  const { id } = useParams()
+  return (
+    <RouteDrawer>
+      <AddSafeForm companyId={id!} />
+    </RouteDrawer>
+  )
+}
+
+export default AddSafePage

--- a/apps/backend/src/admin/routes/companies/[id]/@participations/page.tsx
+++ b/apps/backend/src/admin/routes/companies/[id]/@participations/page.tsx
@@ -13,6 +13,7 @@ import { RouteFocusModal } from "../../../../components/modal/route-focus-modal"
 import { ActionMenu } from "../../../../components/common/action-menu"
 import {
   useApproveParticipation,
+  useApproveConvertible,
   useMarkParticipationPaid,
   useRoundParticipations,
   type AdminParticipation,
@@ -43,14 +44,21 @@ const ParticipationsTable = ({
   roundId: string
   participations: AdminParticipation[]
 }) => {
+  const approveToast = (r: any) =>
+    toast.success(
+      r?.payment_link
+        ? "Approved — PayU link generated"
+        : "Approved — pending payment (PayU not configured)"
+    )
+  const approveErr = (e: any) => toast.error(e?.message || "Approve failed")
   const { mutateAsync: approve } = useApproveParticipation(roundId, {
-    onSuccess: (r) =>
-      toast.success(
-        r?.payment_link
-          ? "Approved — PayU link generated"
-          : "Approved — pending payment (PayU not configured)"
-      ),
-    onError: (e) => toast.error(e?.message || "Approve failed"),
+    onSuccess: approveToast,
+    onError: approveErr,
+  })
+  // SAFE participants approve through the convertible route (same PayU rail).
+  const { mutateAsync: approveConvertible } = useApproveConvertible("", {
+    onSuccess: approveToast,
+    onError: approveErr,
   })
   const { mutateAsync: markPaid } = useMarkParticipationPaid(roundId, {
     onSuccess: () => toast.success("Marked as paid"),
@@ -65,6 +73,16 @@ const ParticipationsTable = ({
         accessorKey: "investor",
         cell: ({ row }: any) =>
           row.original.investor?.name ?? row.original.investor_id ?? "—",
+      },
+      {
+        header: "Type",
+        id: "type",
+        cell: ({ row }: any) =>
+          row.original.type === "convertible" ? (
+            <Badge size="2xsmall" color="purple">SAFE</Badge>
+          ) : (
+            <Badge size="2xsmall" color="grey">Equity</Badge>
+          ),
       },
       {
         header: "Amount",
@@ -102,6 +120,7 @@ const ParticipationsTable = ({
         cell: ({ row }: any) => {
           const p = row.original as AdminParticipation
           const approved = !!p.metadata?.approved
+          const isConvertible = p.type === "convertible"
           return (
             <div className="flex justify-end">
               <ActionMenu
@@ -112,12 +131,14 @@ const ParticipationsTable = ({
                         icon: <Check />,
                         label: "Approve (generate pay link)",
                         disabled: approved,
-                        onClick: () => approve(p.id),
+                        onClick: () =>
+                          isConvertible ? approveConvertible(p.id) : approve(p.id),
                       },
+                      // Mark-paid uses the stake ledger; only equity stakes support it.
                       {
                         icon: <CurrencyDollar />,
                         label: "Mark paid",
-                        disabled: p.status === "fully_paid",
+                        disabled: isConvertible || p.status === "fully_paid",
                         onClick: () => markPaid(p.id),
                       },
                     ],

--- a/apps/backend/src/api/admin/cap-tables/[id]/convertibles/route.ts
+++ b/apps/backend/src/api/admin/cap-tables/[id]/convertibles/route.ts
@@ -1,0 +1,129 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+import { INVESTOR_MODULE } from "../../../../../modules/investor"
+import type InvestorService from "../../../../../modules/investor/service"
+import { convertibleSchema } from "../../../../investors/validators"
+import { computeConvertibleValue } from "../../../../../modules/investor/lib/convertible-value"
+
+// GET /admin/cap-tables/:id/convertibles — SAFEs/notes on this cap table, with
+// the owning investor and a derived value (implied ownership + implied value
+// against the cap table's current post-money valuation).
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: capTables } = await query.graph({
+    entity: "cap_table",
+    fields: ["id", "post_money_valuation", "currency_code"],
+    filters: { id: req.params.id },
+  })
+  const capTable = capTables?.[0]
+  if (!capTable) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Cap table not found")
+  }
+
+  const { data } = await query.graph({
+    entity: "convertible",
+    filters: { cap_table_id: req.params.id },
+    fields: [
+      "*",
+      "investor.id",
+      "investor.name",
+      "investor.email",
+      "payments.id",
+      "payments.amount",
+      "payments.status",
+    ],
+  })
+
+  const convertibles = (data || []).map((c: any) => ({
+    ...c,
+    value: computeConvertibleValue(c, {
+      referenceValuation: capTable.post_money_valuation,
+    }),
+  }))
+
+  res.json({ convertibles, count: convertibles.length })
+}
+
+// Manual provision — mirror of the stake provision: allocate a convertible to an
+// EXISTING investor (investor_id) OR a NEW individual added inline. Records a
+// retroactive SAFE/note for someone who already invested.
+const provisionInlineInvestorSchema = z.object({
+  name: z.string().min(1, "investor name is required"),
+  email: z.string().email().optional(),
+  investor_type: z.enum(["individual", "entity", "fund"]).optional().default("individual"),
+})
+
+const provisionConvertibleSchema = convertibleSchema
+  .extend({
+    investor: provisionInlineInvestorSchema.optional(),
+  })
+  .refine((v) => !!v.investor_id || !!v.investor, {
+    message: "Provide either investor_id (existing) or investor { name } (new)",
+  })
+
+// POST /admin/cap-tables/:id/convertibles
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const capTableId = req.params.id
+  const parsed = provisionConvertibleSchema.parse({
+    ...(req.body as Record<string, any>),
+    cap_table_id: capTableId,
+  })
+  const { investor: inlineInvestor, ...convertibleData } = parsed
+
+  const service: InvestorService = req.scope.resolve(INVESTOR_MODULE)
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: capTables } = await query.graph({
+    entity: "cap_table",
+    fields: ["id", "company_id", "currency_code"],
+    filters: { id: capTableId },
+  })
+  const capTable = capTables?.[0]
+  if (!capTable) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Cap table not found")
+  }
+
+  // Resolve investor_id: existing, or create a bare inline investor + pipeline.
+  let investorId = convertibleData.investor_id
+  if (!investorId && inlineInvestor) {
+    const rand = Math.random().toString(36).slice(2, 8)
+    const created = await service.createInvestors({
+      name: inlineInvestor.name,
+      handle: `inv-${Date.now()}-${rand}`,
+      email: inlineInvestor.email || `manual-${Date.now()}-${rand}@captable.local`,
+      investor_type: inlineInvestor.investor_type,
+      status: "active",
+      is_verified: true,
+      currency_code: capTable.currency_code ?? null,
+    } as any)
+    investorId = created.id
+
+    if (capTable.company_id) {
+      await service.createPipelines({
+        investor_id: investorId,
+        company_id: capTable.company_id,
+        stage: "closed",
+        status: "won",
+        source: "manual_provision",
+      } as any)
+    }
+  }
+
+  if (!investorId) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "Provide either investor_id (existing) or investor { name } (new)"
+    )
+  }
+
+  const created = await service.createConvertibles({
+    funding_round_id: null,
+    currency_code: capTable.currency_code ?? null,
+    ...convertibleData,
+    investor_id: investorId,
+  } as any)
+
+  res.status(201).json({ convertible: created })
+}

--- a/apps/backend/src/api/admin/company-expenses/[id]/route.ts
+++ b/apps/backend/src/api/admin/company-expenses/[id]/route.ts
@@ -1,0 +1,19 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { INVESTOR_MODULE } from "../../../../modules/investor"
+import type InvestorService from "../../../../modules/investor/service"
+import { companyExpenseUpdateSchema } from "../../../investors/validators"
+
+// POST /admin/company-expenses/:id — update an expense.
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const data = companyExpenseUpdateSchema.parse(req.body)
+  const service: InvestorService = req.scope.resolve(INVESTOR_MODULE)
+  const updated = await service.updateCompanyExpenses({ id: req.params.id, ...data } as any)
+  res.json({ company_expense: updated })
+}
+
+// DELETE /admin/company-expenses/:id
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: InvestorService = req.scope.resolve(INVESTOR_MODULE)
+  await service.deleteCompanyExpenses(req.params.id)
+  res.json({ id: req.params.id, object: "company_expense", deleted: true })
+}

--- a/apps/backend/src/api/admin/company-expenses/route.ts
+++ b/apps/backend/src/api/admin/company-expenses/route.ts
@@ -1,0 +1,29 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { INVESTOR_MODULE } from "../../../modules/investor"
+import type InvestorService from "../../../modules/investor/service"
+import { companyExpenseSchema } from "../../investors/validators"
+
+// GET /admin/company-expenses — list company operating expenses (optionally
+// filtered by ?company_id / ?category / ?status).
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: InvestorService = req.scope.resolve(INVESTOR_MODULE)
+  const { company_id, category, status } = req.query as Record<string, string>
+  const filters: Record<string, any> = {}
+  if (company_id) filters.company_id = company_id
+  if (category) filters.category = category
+  if (status) filters.status = status
+
+  const [items, count] = await service.listAndCountCompanyExpenses(filters, {
+    take: 500,
+    order: { created_at: "DESC" },
+  } as any)
+  res.json({ company_expenses: items, count })
+}
+
+// POST /admin/company-expenses — record an expense (partnership cost, tech stack, …).
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const data = companyExpenseSchema.parse(req.body)
+  const service: InvestorService = req.scope.resolve(INVESTOR_MODULE)
+  const created = await service.createCompanyExpenses(data as any)
+  res.status(201).json({ company_expense: created })
+}

--- a/apps/backend/src/api/admin/convertibles/[id]/approve/route.ts
+++ b/apps/backend/src/api/admin/convertibles/[id]/approve/route.ts
@@ -1,0 +1,98 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { INVESTOR_MODULE } from "../../../../../modules/investor"
+import type InvestorService from "../../../../../modules/investor/service"
+import { createPayuLink } from "../../../lib/create-payu-link"
+
+// POST /admin/convertibles/:id/approve — approve a SAFE / convertible
+// commitment: create a pending Payment for the principal and generate a PayU
+// link. Mirrors the stake approve flow (reuses createPayuLink) so SAFE holders
+// pay through the same rail; settlement is reconciled by the PayU webhook.
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const service: InvestorService = req.scope.resolve(INVESTOR_MODULE)
+
+  const { data } = await query.graph({
+    entity: "convertible",
+    filters: { id: req.params.id },
+    fields: [
+      "id",
+      "investor_id",
+      "principal_amount",
+      "currency_code",
+      "metadata",
+      "investor.name",
+      "investor.email",
+      "cap_table.company_id",
+      "cap_table.currency_code",
+    ],
+  })
+  const convertible = data?.[0] as any
+  if (!convertible) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Convertible not found")
+  }
+  const amount = Number(convertible.principal_amount ?? 0)
+  if (amount <= 0) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "This SAFE has no principal amount to collect"
+    )
+  }
+
+  const companyId = convertible.cap_table?.company_id
+  const currency =
+    convertible.currency_code || convertible.cap_table?.currency_code || "INR"
+
+  // 1) pending Payment (typed as a convertible payment)
+  const payment: any = await service.createPayments({
+    convertible_id: convertible.id,
+    investor_id: convertible.investor_id,
+    company_id: companyId,
+    amount,
+    currency_code: currency,
+    payment_type: "convertible",
+    status: "pending",
+  } as any)
+
+  // 2) PayU link — same helper the stake flow uses.
+  const portal = process.env.INVESTOR_UI_URL || "https://investor.jaalyantra.com"
+  const link = await createPayuLink(
+    {
+      amount,
+      description: `SAFE investment — ${convertible.id}`,
+      customer: {
+        name: convertible.investor?.name,
+        email: convertible.investor?.email,
+      },
+      successURL: `${portal}/finances?paid=1`,
+      failureURL: `${portal}/finances?paid=0`,
+      reference: payment.id,
+    },
+    logger
+  )
+
+  // 3) persist link on the payment + mark the convertible approved
+  await service.updatePayments({
+    id: payment.id,
+    reference_number: link.invoice_number ?? undefined,
+    metadata: {
+      payu_payment_link: link.payment_link,
+      payu_invoice_number: link.invoice_number,
+    },
+  } as any)
+  await service.updateConvertibles({
+    id: convertible.id,
+    metadata: {
+      ...(convertible.metadata || {}),
+      approved: true,
+      approved_at: new Date().toISOString(),
+    },
+  } as any)
+
+  res.json({
+    payment_id: payment.id,
+    payment_link: link.payment_link,
+    payu_error: link.error ?? null,
+  })
+}

--- a/apps/backend/src/api/admin/convertibles/[id]/payments/route.ts
+++ b/apps/backend/src/api/admin/convertibles/[id]/payments/route.ts
@@ -1,0 +1,42 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { INVESTOR_MODULE } from "../../../../../modules/investor"
+import type InvestorService from "../../../../../modules/investor/service"
+import { paymentSchema } from "../../../../investors/validators"
+
+// GET /admin/convertibles/:id/payments
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: InvestorService = req.scope.resolve(INVESTOR_MODULE)
+  const items = await service.listPayments({ convertible_id: req.params.id } as any)
+  res.json({ payments: items, count: items.length })
+}
+
+// POST /admin/convertibles/:id/payments — record a payment against a convertible
+// (e.g. the SAFE principal wired in). Derives investor/company from the
+// convertible when not supplied so the admin only needs amount + method.
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: InvestorService = req.scope.resolve(INVESTOR_MODULE)
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data } = await query.graph({
+    entity: "convertible",
+    filters: { id: req.params.id },
+    fields: ["id", "investor_id", "currency_code", "cap_table.company_id"],
+  })
+  const convertible = data?.[0]
+  if (!convertible) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Convertible not found")
+  }
+
+  const parsed = paymentSchema.parse({
+    payment_type: "convertible",
+    ...(req.body as Record<string, any>),
+    convertible_id: req.params.id,
+    investor_id: (req.body as any)?.investor_id ?? convertible.investor_id,
+    company_id: (req.body as any)?.company_id ?? convertible.cap_table?.company_id,
+    currency_code: (req.body as any)?.currency_code ?? convertible.currency_code ?? undefined,
+  })
+
+  const created = await service.createPayments(parsed as any)
+  res.status(201).json({ payment: created })
+}

--- a/apps/backend/src/api/admin/convertibles/[id]/route.ts
+++ b/apps/backend/src/api/admin/convertibles/[id]/route.ts
@@ -1,0 +1,48 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { INVESTOR_MODULE } from "../../../../modules/investor"
+import type InvestorService from "../../../../modules/investor/service"
+import { convertibleUpdateSchema } from "../../../investors/validators"
+import { computeConvertibleValue } from "../../../../modules/investor/lib/convertible-value"
+
+// GET /admin/convertibles/:id — one convertible with its payments and derived value.
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data } = await query.graph({
+    entity: "convertible",
+    filters: { id: req.params.id },
+    fields: [
+      "*",
+      "investor.id",
+      "investor.name",
+      "investor.email",
+      "cap_table.id",
+      "cap_table.post_money_valuation",
+      "cap_table.currency_code",
+      "payments.*",
+    ],
+  })
+  const convertible = data?.[0]
+  if (!convertible) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Convertible not found")
+  }
+  const value = computeConvertibleValue(convertible, {
+    referenceValuation: convertible.cap_table?.post_money_valuation,
+  })
+  res.json({ convertible: { ...convertible, value } })
+}
+
+// POST /admin/convertibles/:id — update terms/status.
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const data = convertibleUpdateSchema.parse(req.body)
+  const service: InvestorService = req.scope.resolve(INVESTOR_MODULE)
+  const updated = await service.updateConvertibles({ id: req.params.id, ...data } as any)
+  res.json({ convertible: updated })
+}
+
+// DELETE /admin/convertibles/:id
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: InvestorService = req.scope.resolve(INVESTOR_MODULE)
+  await service.deleteConvertibles(req.params.id)
+  res.json({ id: req.params.id, object: "convertible", deleted: true })
+}

--- a/apps/backend/src/api/admin/funding-rounds/[id]/participations/route.ts
+++ b/apps/backend/src/api/admin/funding-rounds/[id]/participations/route.ts
@@ -1,23 +1,53 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
-// GET /admin/funding-rounds/:id/participations — investor participations (stakes)
-// on this round, with investor + any payment (to show status / PayU link).
+// GET /admin/funding-rounds/:id/participations — investor participations on this
+// round, with investor + any payment (to show status / PayU link). Equity rounds
+// yield `stake` participations; SAFE / convertible rounds yield `convertible`
+// ones — both are returned with a `type` discriminator so one screen handles both.
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
-  const { data } = await query.graph({
-    entity: "stake",
-    filters: { funding_round_id: req.params.id },
-    fields: [
-      "*",
-      "investor.id",
-      "investor.name",
-      "investor.email",
-      "payments.id",
-      "payments.amount",
-      "payments.status",
-      "payments.metadata",
-    ],
-  })
-  res.json({ participations: data || [], count: (data || []).length })
+
+  const [{ data: stakes }, { data: convertibles }] = await Promise.all([
+    query.graph({
+      entity: "stake",
+      filters: { funding_round_id: req.params.id },
+      fields: [
+        "*",
+        "investor.id",
+        "investor.name",
+        "investor.email",
+        "payments.id",
+        "payments.amount",
+        "payments.status",
+        "payments.metadata",
+      ],
+    }),
+    query.graph({
+      entity: "convertible",
+      filters: { funding_round_id: req.params.id },
+      fields: [
+        "*",
+        "investor.id",
+        "investor.name",
+        "investor.email",
+        "payments.id",
+        "payments.amount",
+        "payments.status",
+        "payments.metadata",
+      ],
+    }).catch(() => ({ data: [] as any[] })),
+  ])
+
+  const participations = [
+    ...(stakes || []).map((s: any) => ({ ...s, type: "stake" })),
+    ...(convertibles || []).map((c: any) => ({
+      ...c,
+      type: "convertible",
+      // Normalise so the UI can render one column: SAFEs carry `principal_amount`.
+      total_invested: c.principal_amount,
+    })),
+  ]
+
+  res.json({ participations, count: participations.length })
 }

--- a/apps/backend/src/api/investors/deals/[id]/participate/route.ts
+++ b/apps/backend/src/api/investors/deals/[id]/participate/route.ts
@@ -18,7 +18,18 @@ export const POST = async (
   const { data } = await query.graph({
     entity: "funding_round",
     filters: { id: req.params.id },
-    fields: ["id", "cap_table_id", "price_per_share", "status"],
+    fields: [
+      "id",
+      "cap_table_id",
+      "price_per_share",
+      "status",
+      "round_type",
+      "instrument_type",
+      "valuation_cap",
+      "discount_rate",
+      "safe_type",
+      "cap_table.currency_code",
+    ],
   })
   const round = data?.[0] as any
   if (!round) {
@@ -31,6 +42,30 @@ export const POST = async (
   const amount = Number((req.body as any)?.amount ?? 0)
   if (!amount || amount <= 0) {
     throw new MedusaError(MedusaError.Types.INVALID_DATA, "A positive amount is required")
+  }
+
+  // SAFE / convertible round → issue a Convertible (no shares yet), not a Stake.
+  const isConvertible =
+    round.instrument_type === "safe" ||
+    round.instrument_type === "convertible_note" ||
+    round.round_type === "safe"
+  if (isConvertible) {
+    const created = await service.createConvertibles({
+      investor_id: investor.id,
+      cap_table_id: round.cap_table_id,
+      funding_round_id: round.id,
+      instrument_type:
+        round.instrument_type === "convertible_note" ? "convertible_note" : "safe",
+      principal_amount: amount,
+      currency_code: round.cap_table?.currency_code ?? null,
+      valuation_cap: round.valuation_cap ?? null,
+      discount_rate: round.discount_rate ?? null,
+      safe_type: round.safe_type ?? "post_money",
+      investment_date: new Date(),
+      status: "outstanding",
+    } as any)
+
+    return res.status(201).json({ convertible: created })
   }
 
   const pricePerShare = Number(round.price_per_share ?? 0)

--- a/apps/backend/src/api/investors/me/convertibles/route.ts
+++ b/apps/backend/src/api/investors/me/convertibles/route.ts
@@ -1,0 +1,54 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { requireInvestor } from "../../helpers"
+import { computeConvertibleValue } from "../../../../modules/investor/lib/convertible-value"
+
+// GET /investors/me/convertibles — the SAFEs / convertible notes held by the
+// authenticated investor, each with a derived value (principal, implied
+// ownership, implied current value) against the company's post-money valuation.
+// Powers the investor-ui "My SAFEs" view — how a SAFE holder with no shares
+// still sees what their investment is worth, current and past.
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const investor = await requireInvestor(req.auth_context, req.scope)
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data } = await query.graph({
+    entity: "convertible",
+    filters: { investor_id: investor.id },
+    fields: [
+      "*",
+      "cap_table.id",
+      "cap_table.name",
+      "cap_table.company_id",
+      "cap_table.post_money_valuation",
+      "cap_table.currency_code",
+      "payments.id",
+      "payments.amount",
+      "payments.status",
+      "payments.paid_date",
+    ],
+  })
+
+  const convertibles = (data || []).map((c: any) => ({
+    ...c,
+    value: computeConvertibleValue(c, {
+      referenceValuation: c.cap_table?.post_money_valuation,
+    }),
+  }))
+
+  // Portfolio roll-up so the UI can show a headline number.
+  const summary = convertibles.reduce(
+    (acc: any, c: any) => {
+      acc.total_principal += c.value.principal || 0
+      acc.total_implied_value += c.value.implied_value || 0
+      if (c.status === "outstanding") acc.outstanding_count += 1
+      return acc
+    },
+    { total_principal: 0, total_implied_value: 0, outstanding_count: 0 }
+  )
+
+  res.json({ convertibles, count: convertibles.length, summary })
+}

--- a/apps/backend/src/api/investors/validators.ts
+++ b/apps/backend/src/api/investors/validators.ts
@@ -107,13 +107,54 @@ export const stakeSchema = z.object({
   ]).optional(),
 })
 
+// Convertible instrument (SAFE / note) — #969 follow-up.
+export const convertibleSchema = z.object({
+  investor_id: z.string().optional(),
+  cap_table_id: z.string().optional(),
+  funding_round_id: z.string().nullable().optional(),
+  instrument_type: z.enum(["safe", "convertible_note"]).optional(),
+  principal_amount: z.number().positive(),
+  currency_code: z.string().nullable().optional(),
+  valuation_cap: z.number().positive().nullable().optional(),
+  discount_rate: z.number().min(0).max(1).nullable().optional(),
+  safe_type: z.enum(["post_money", "pre_money"]).optional(),
+  mfn: z.boolean().optional(),
+  pro_rata: z.boolean().optional(),
+  interest_rate: z.number().min(0).max(1).nullable().optional(),
+  maturity_date: z.string().datetime().nullable().optional(),
+  investment_date: z.string().datetime().nullable().optional(),
+  status: z
+    .enum(["outstanding", "converted", "redeemed", "cancelled", "expired"])
+    .optional(),
+  notes: z.string().nullable().optional(),
+})
+
+export const convertibleUpdateSchema = convertibleSchema.partial()
+
+export const companyExpenseSchema = z.object({
+  company_id: z.string().nullable().optional(),
+  category: z
+    .enum(["partnership", "tech_stack", "marketing", "operations", "salaries", "other"])
+    .optional(),
+  name: z.string().min(1),
+  amount: z.number().nonnegative(),
+  currency_code: z.string().optional(),
+  recurrence: z.enum(["one_time", "monthly", "annual"]).optional(),
+  incurred_date: z.string().datetime().nullable().optional(),
+  status: z.enum(["active", "ended"]).optional(),
+  notes: z.string().nullable().optional(),
+})
+
+export const companyExpenseUpdateSchema = companyExpenseSchema.partial()
+
 export const fundingRoundSchema = z.object({
   cap_table_id: z.string().optional(),
   name: z.string(),
   round_type: z.enum([
     "pre_seed", "seed", "series_a", "series_b", "series_c",
-    "series_d_plus", "bridge", "debt", "grant",
+    "series_d_plus", "bridge", "debt", "grant", "safe",
   ]).optional(),
+  instrument_type: z.enum(["equity", "safe", "convertible_note"]).optional(),
   status: z.enum([
     "planned", "open", "closing", "closed", "cancelled",
   ]).optional(),
@@ -123,6 +164,9 @@ export const fundingRoundSchema = z.object({
   post_money_valuation: z.number().nullable().optional(),
   price_per_share: z.number().nullable().optional(),
   shares_offered: z.number().nullable().optional(),
+  valuation_cap: z.number().nullable().optional(),
+  discount_rate: z.number().min(0).max(1).nullable().optional(),
+  safe_type: z.enum(["post_money", "pre_money"]).nullable().optional(),
   open_date: z.string().datetime().nullable().optional(),
   close_date: z.string().datetime().nullable().optional(),
   lead_investor: z.string().nullable().optional(),
@@ -166,12 +210,13 @@ export const callForSharesSchema = z.object({
 export const paymentSchema = z.object({
   stake_id: z.string().optional(),
   call_for_shares_id: z.string().optional(),
+  convertible_id: z.string().optional(),
   investor_id: z.string().optional(),
-  company_id: z.string(),
+  company_id: z.string().optional(),
   amount: z.number(),
   currency_code: z.string().min(3).max(3).optional(),
   payment_type: z.enum([
-    "subscription", "capital_call", "top_up", "transfer_fee", "other",
+    "subscription", "capital_call", "top_up", "transfer_fee", "convertible", "other",
   ]).optional(),
   status: z.enum([
     "pending", "in_progress", "completed", "failed", "refunded", "cancelled",

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -885,6 +885,15 @@ export default defineMiddlewares({
       ],
     },
     {
+      // #969 follow-up — the investor's SAFEs / convertible notes with value.
+      matcher: "/investors/me/convertibles",
+      method: "GET",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("investor", ["session", "bearer"]),
+      ],
+    },
+    {
       matcher: "/investors/cap-tables",
       method: "POST",
       middlewares: [

--- a/apps/backend/src/modules/investor/lib/convertible-value.ts
+++ b/apps/backend/src/modules/investor/lib/convertible-value.ts
@@ -1,0 +1,118 @@
+/**
+ * Derive the "value" of a convertible instrument (SAFE / note) for display
+ * (#969 follow-up). Pure — no I/O — so it's unit-testable and reused by both
+ * the admin and investor routes.
+ *
+ * A convertible holder has no shares until conversion, so value is *implied*:
+ *  - principal            → the cash invested (cost basis; always known)
+ *  - implied_ownership_pct → for a post-money SAFE this is simply
+ *                            principal / valuation_cap (the investor's floor)
+ *  - implied_value        → implied_ownership_pct × a reference valuation
+ *                            (the company's current/post-money valuation, or the
+ *                            cap when no fresher valuation is available)
+ *  - multiple             → implied_value / principal (MOIC estimate)
+ *
+ * Everything is best-effort: fields that can't be derived come back null so the
+ * UI can show "—" rather than a fabricated number.
+ */
+export type ConvertibleValueInput = {
+  principal_amount?: number | string | null
+  valuation_cap?: number | string | null
+  discount_rate?: number | null
+  safe_type?: "post_money" | "pre_money" | null
+  status?: string | null
+  conversion_shares?: number | string | null
+  conversion_price_per_share?: number | string | null
+}
+
+export type ConvertibleValue = {
+  principal: number
+  implied_ownership_pct: number | null
+  implied_value: number | null
+  multiple: number | null
+  // How implied_value was derived, so the UI can label it honestly.
+  basis: "converted" | "reference_valuation" | "cap" | "principal" | "unknown"
+}
+
+const num = (v: unknown): number | null => {
+  if (v === null || v === undefined || v === "") return null
+  const n = typeof v === "string" ? parseFloat(v) : (v as number)
+  return Number.isFinite(n) ? n : null
+}
+
+export function computeConvertibleValue(
+  c: ConvertibleValueInput,
+  opts: { referenceValuation?: number | string | null } = {}
+): ConvertibleValue {
+  const principal = num(c.principal_amount) ?? 0
+  const cap = num(c.valuation_cap)
+  const discount = num(c.discount_rate)
+  const ref = num(opts.referenceValuation)
+  const isPostMoney = (c.safe_type ?? "post_money") === "post_money"
+
+  // Already converted → value rides the resulting shares (caller can price the
+  // linked stake); we surface the recorded conversion if present.
+  if (c.status === "converted") {
+    const shares = num(c.conversion_shares)
+    const price = num(c.conversion_price_per_share)
+    const value = shares != null && price != null ? shares * price : null
+    return {
+      principal,
+      implied_ownership_pct: null,
+      implied_value: value,
+      multiple: value != null && principal > 0 ? value / principal : null,
+      basis: "converted",
+    }
+  }
+
+  // Post-money SAFE with a cap → clean floor ownership = principal / cap.
+  if (cap && cap > 0 && isPostMoney) {
+    const ownership = principal / cap
+    const valuation = ref && ref > 0 ? ref : cap
+    const value = ownership * valuation
+    return {
+      principal,
+      implied_ownership_pct: ownership,
+      implied_value: value,
+      multiple: principal > 0 ? value / principal : null,
+      basis: ref && ref > 0 ? "reference_valuation" : "cap",
+    }
+  }
+
+  // Pre-money cap → approximate post-money as cap + this money in.
+  if (cap && cap > 0) {
+    const postMoney = cap + principal
+    const ownership = principal / postMoney
+    const valuation = ref && ref > 0 ? ref : postMoney
+    const value = ownership * valuation
+    return {
+      principal,
+      implied_ownership_pct: ownership,
+      implied_value: value,
+      multiple: principal > 0 ? value / principal : null,
+      basis: ref && ref > 0 ? "reference_valuation" : "cap",
+    }
+  }
+
+  // Discount-only (no cap): can't imply ownership without a round price; the
+  // honest floor is the principal (optionally uplifted by the discount).
+  if (discount && discount > 0 && discount < 1) {
+    const value = principal / (1 - discount)
+    return {
+      principal,
+      implied_ownership_pct: null,
+      implied_value: value,
+      multiple: principal > 0 ? value / principal : null,
+      basis: "principal",
+    }
+  }
+
+  // Nothing to imply from — show cost basis only.
+  return {
+    principal,
+    implied_ownership_pct: null,
+    implied_value: principal || null,
+    multiple: principal > 0 ? 1 : null,
+    basis: principal > 0 ? "principal" : "unknown",
+  }
+}

--- a/apps/backend/src/modules/investor/migrations/Migration20260711180000.ts
+++ b/apps/backend/src/modules/investor/migrations/Migration20260711180000.ts
@@ -1,0 +1,57 @@
+import { Migration } from '@mikro-orm/migrations';
+
+// Convertible instruments (SAFE / convertible note) — #969 follow-up.
+// Creates the `convertible` table, adds the payment → convertible FK column,
+// and extends the investor_payment.payment_type check to include 'convertible'.
+export class Migration20260711180000 extends Migration {
+
+  async up(): Promise<void> {
+    this.addSql(`create table if not exists "convertible" (
+      "id" text not null,
+      "investor_id" text not null,
+      "cap_table_id" text not null,
+      "funding_round_id" text null,
+      "instrument_type" text check ("instrument_type" in ('safe', 'convertible_note')) not null default 'safe',
+      "principal_amount" numeric not null,
+      "currency_code" text null,
+      "valuation_cap" numeric null,
+      "discount_rate" real null,
+      "safe_type" text check ("safe_type" in ('post_money', 'pre_money')) not null default 'post_money',
+      "mfn" boolean not null default false,
+      "pro_rata" boolean not null default false,
+      "interest_rate" real null,
+      "maturity_date" timestamptz null,
+      "investment_date" timestamptz null,
+      "status" text check ("status" in ('outstanding', 'converted', 'redeemed', 'cancelled', 'expired')) not null default 'outstanding',
+      "converted_stake_id" text null,
+      "conversion_date" timestamptz null,
+      "conversion_price_per_share" numeric null,
+      "conversion_shares" numeric null,
+      "notes" text null,
+      "metadata" jsonb null,
+      "created_at" timestamptz not null default now(),
+      "updated_at" timestamptz not null default now(),
+      "deleted_at" timestamptz null,
+      constraint "convertible_pkey" primary key ("id")
+    );`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_convertible_investor_id" ON "convertible" ("investor_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_convertible_cap_table_id" ON "convertible" ("cap_table_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_convertible_deleted_at" ON "convertible" ("deleted_at") WHERE deleted_at IS NULL;`);
+
+    // payment → convertible link (nullable, mirrors the stake/call_for_shares FKs).
+    this.addSql(`alter table if exists "investor_payment" add column if not exists "convertible_id" text null;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_investor_payment_convertible_id" ON "investor_payment" ("convertible_id") WHERE deleted_at IS NULL;`);
+
+    // Extend payment_type check to include 'convertible'.
+    this.addSql(`alter table if exists "investor_payment" drop constraint if exists "investor_payment_payment_type_check";`);
+    this.addSql(`alter table if exists "investor_payment" add constraint "investor_payment_payment_type_check" check ("payment_type" in ('subscription', 'capital_call', 'top_up', 'transfer_fee', 'convertible', 'other'));`);
+  }
+
+  async down(): Promise<void> {
+    this.addSql(`alter table if exists "investor_payment" drop constraint if exists "investor_payment_payment_type_check";`);
+    this.addSql(`alter table if exists "investor_payment" add constraint "investor_payment_payment_type_check" check ("payment_type" in ('subscription', 'capital_call', 'top_up', 'transfer_fee', 'other'));`);
+    this.addSql(`alter table if exists "investor_payment" drop column if exists "convertible_id";`);
+    this.addSql(`drop table if exists "convertible" cascade;`);
+  }
+
+}

--- a/apps/backend/src/modules/investor/migrations/Migration20260711190000.ts
+++ b/apps/backend/src/modules/investor/migrations/Migration20260711190000.ts
@@ -1,0 +1,34 @@
+import { Migration } from '@mikro-orm/migrations';
+
+// Company operating expenses (partnership cost, tech stack, etc.) — #969 follow-up.
+// Creates the `company_expense` table that panels roll up as company expenses.
+export class Migration20260711190000 extends Migration {
+
+  async up(): Promise<void> {
+    this.addSql(`create table if not exists "company_expense" (
+      "id" text not null,
+      "company_id" text null,
+      "category" text check ("category" in ('partnership', 'tech_stack', 'marketing', 'operations', 'salaries', 'other')) not null default 'other',
+      "name" text not null,
+      "amount" numeric not null,
+      "currency_code" text not null default 'INR',
+      "recurrence" text check ("recurrence" in ('one_time', 'monthly', 'annual')) not null default 'monthly',
+      "incurred_date" timestamptz null,
+      "status" text check ("status" in ('active', 'ended')) not null default 'active',
+      "notes" text null,
+      "metadata" jsonb null,
+      "created_at" timestamptz not null default now(),
+      "updated_at" timestamptz not null default now(),
+      "deleted_at" timestamptz null,
+      constraint "company_expense_pkey" primary key ("id")
+    );`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_company_expense_company_id" ON "company_expense" ("company_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_company_expense_category" ON "company_expense" ("category") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_company_expense_deleted_at" ON "company_expense" ("deleted_at") WHERE deleted_at IS NULL;`);
+  }
+
+  async down(): Promise<void> {
+    this.addSql(`drop table if exists "company_expense" cascade;`);
+  }
+
+}

--- a/apps/backend/src/modules/investor/migrations/Migration20260711200000.ts
+++ b/apps/backend/src/modules/investor/migrations/Migration20260711200000.ts
@@ -1,0 +1,28 @@
+import { Migration } from '@mikro-orm/migrations';
+
+// SAFE / convertible funding rounds — #969 follow-up.
+// Adds instrument_type + SAFE terms to funding_round and extends round_type to
+// allow 'safe', so a round can be published as a SAFE that investors join
+// (participating issues a Convertible instead of a Stake).
+export class Migration20260711200000 extends Migration {
+
+  async up(): Promise<void> {
+    this.addSql(`alter table if exists "funding_round" add column if not exists "instrument_type" text check ("instrument_type" in ('equity', 'safe', 'convertible_note')) not null default 'equity';`);
+    this.addSql(`alter table if exists "funding_round" add column if not exists "valuation_cap" numeric null;`);
+    this.addSql(`alter table if exists "funding_round" add column if not exists "discount_rate" real null;`);
+    this.addSql(`alter table if exists "funding_round" add column if not exists "safe_type" text check ("safe_type" in ('post_money', 'pre_money')) null;`);
+
+    this.addSql(`alter table if exists "funding_round" drop constraint if exists "funding_round_round_type_check";`);
+    this.addSql(`alter table if exists "funding_round" add constraint "funding_round_round_type_check" check ("round_type" in ('pre_seed', 'seed', 'series_a', 'series_b', 'series_c', 'series_d_plus', 'bridge', 'debt', 'grant', 'safe'));`);
+  }
+
+  async down(): Promise<void> {
+    this.addSql(`alter table if exists "funding_round" drop constraint if exists "funding_round_round_type_check";`);
+    this.addSql(`alter table if exists "funding_round" add constraint "funding_round_round_type_check" check ("round_type" in ('pre_seed', 'seed', 'series_a', 'series_b', 'series_c', 'series_d_plus', 'bridge', 'debt', 'grant'));`);
+    this.addSql(`alter table if exists "funding_round" drop column if exists "safe_type";`);
+    this.addSql(`alter table if exists "funding_round" drop column if exists "discount_rate";`);
+    this.addSql(`alter table if exists "funding_round" drop column if exists "valuation_cap";`);
+    this.addSql(`alter table if exists "funding_round" drop column if exists "instrument_type";`);
+  }
+
+}

--- a/apps/backend/src/modules/investor/models/cap-table.ts
+++ b/apps/backend/src/modules/investor/models/cap-table.ts
@@ -1,6 +1,7 @@
 import { model } from "@medusajs/framework/utils"
 import ShareClass from "./share-class"
 import Stake from "./stake"
+import Convertible from "./convertible"
 import FundingRound from "./funding-round"
 import CallForShares from "./call-for-shares"
 import Document from "./document"
@@ -25,6 +26,7 @@ const CapTable = model.define("cap_table", {
 
   share_classes: model.hasMany(() => ShareClass),
   stakes: model.hasMany(() => Stake),
+  convertibles: model.hasMany(() => Convertible),
   funding_rounds: model.hasMany(() => FundingRound),
   calls_for_shares: model.hasMany(() => CallForShares),
   documents: model.hasMany(() => Document),

--- a/apps/backend/src/modules/investor/models/company-expense.ts
+++ b/apps/backend/src/modules/investor/models/company-expense.ts
@@ -1,0 +1,38 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * A recurring or one-off company operating expense (#969 follow-up).
+ *
+ * Records the cost side of the business shown to investors — partnership cost,
+ * tech stack, etc. Kept as typed columns (not metadata) per the repo rule.
+ * `company_id` is a plain text ref, matching how `cap_table.company_id` points
+ * at the company without widening a cross-module relation.
+ *
+ * Panels roll these up (e.g. "Partnership cost / mo" = sum(amount) where
+ * category = partnership & recurrence = monthly & status = active).
+ */
+const CompanyExpense = model.define("company_expense", {
+  id: model.id().primaryKey(),
+
+  company_id: model.text().nullable(),
+
+  category: model
+    .enum(["partnership", "tech_stack", "marketing", "operations", "salaries", "other"])
+    .default("other"),
+
+  name: model.text(),
+  amount: model.bigNumber(),
+  currency_code: model.text().default("INR"),
+
+  // How the amount recurs. `monthly` is the run-rate a projection sums directly.
+  recurrence: model.enum(["one_time", "monthly", "annual"]).default("monthly"),
+
+  incurred_date: model.dateTime().nullable(),
+
+  status: model.enum(["active", "ended"]).default("active"),
+
+  notes: model.text().nullable(),
+  metadata: model.json().nullable(),
+})
+
+export default CompanyExpense

--- a/apps/backend/src/modules/investor/models/convertible.ts
+++ b/apps/backend/src/modules/investor/models/convertible.ts
@@ -1,0 +1,69 @@
+import { model } from "@medusajs/framework/utils"
+import Investor from "./investor"
+import CapTable from "./cap-table"
+import Payment from "./payment"
+
+/**
+ * A convertible instrument — a SAFE or convertible note (#969 follow-up).
+ *
+ * Money invested NOW that converts to equity LATER (at the next priced round or
+ * a liquidity event). Unlike a `stake`, the holder has **no shares yet** — they
+ * hold a contractual right to future equity — so this is modelled as its own
+ * instrument rather than shoehorned into the share-centric `stake`.
+ *
+ * "Value" reflected to the investor is derived, not stored as shares:
+ *  - principal_amount           → cost basis (certain)
+ *  - implied ownership          → post-money SAFE: principal / valuation_cap
+ *  - implied current value      → implied ownership × current company valuation
+ * On a priced round the instrument CONVERTS: a real `stake` is created, its id
+ * recorded in `converted_stake_id`, and status flips to `converted`.
+ */
+const Convertible = model.define("convertible", {
+  id: model.id().primaryKey(),
+
+  investor: model.belongsTo(() => Investor, {
+    mappedBy: "convertibles",
+  }),
+  cap_table: model.belongsTo(() => CapTable, {
+    mappedBy: "convertibles",
+  }),
+  // Kept as a plain id (not a relation) to avoid widening the funding_round /
+  // stake models; resolve separately when needed.
+  funding_round_id: model.text().nullable(),
+
+  instrument_type: model.enum(["safe", "convertible_note"]).default("safe"),
+
+  // The cash invested — the one certain number.
+  principal_amount: model.bigNumber(),
+  currency_code: model.text().nullable(),
+
+  // Conversion economics.
+  valuation_cap: model.bigNumber().nullable(),
+  discount_rate: model.number().nullable(), // 0..1 (e.g. 0.20 = 20%)
+  safe_type: model.enum(["post_money", "pre_money"]).default("post_money"),
+  mfn: model.boolean().default(false),
+  pro_rata: model.boolean().default(false),
+
+  // Convertible-note-only terms.
+  interest_rate: model.number().nullable(), // 0..1 annual
+  maturity_date: model.dateTime().nullable(),
+
+  investment_date: model.dateTime().nullable(),
+
+  status: model
+    .enum(["outstanding", "converted", "redeemed", "cancelled", "expired"])
+    .default("outstanding"),
+
+  // Populated on conversion into equity.
+  converted_stake_id: model.text().nullable(),
+  conversion_date: model.dateTime().nullable(),
+  conversion_price_per_share: model.bigNumber().nullable(),
+  conversion_shares: model.bigNumber().nullable(),
+
+  payments: model.hasMany(() => Payment),
+
+  notes: model.text().nullable(),
+  metadata: model.json().nullable(),
+})
+
+export default Convertible

--- a/apps/backend/src/modules/investor/models/funding-round.ts
+++ b/apps/backend/src/modules/investor/models/funding-round.ts
@@ -20,7 +20,12 @@ const FundingRound = model.define("funding_round", {
     "bridge",
     "debt",
     "grant",
+    "safe",
   ]).default("seed"),
+
+  // What participating in this round issues. `equity` → a Stake (shares);
+  // `safe` / `convertible_note` → a Convertible (money now, equity later).
+  instrument_type: model.enum(["equity", "safe", "convertible_note"]).default("equity"),
 
   status: model.enum(["planned", "open", "closing", "closed", "cancelled"]).default("planned"),
 
@@ -31,6 +36,11 @@ const FundingRound = model.define("funding_round", {
 
   price_per_share: model.bigNumber().nullable(),
   shares_offered: model.bigNumber().nullable(),
+
+  // SAFE / convertible round terms (applied to Convertibles created on participate).
+  valuation_cap: model.bigNumber().nullable(),
+  discount_rate: model.number().nullable(),
+  safe_type: model.enum(["post_money", "pre_money"]).nullable(),
 
   open_date: model.dateTime().nullable(),
   close_date: model.dateTime().nullable(),

--- a/apps/backend/src/modules/investor/models/investor.ts
+++ b/apps/backend/src/modules/investor/models/investor.ts
@@ -1,6 +1,7 @@
 import { model } from "@medusajs/framework/utils"
 import InvestorAdmin from "./investor-admin"
 import Stake from "./stake"
+import Convertible from "./convertible"
 import Pipeline from "./pipeline"
 
 const Investor = model.define("investor", {
@@ -30,6 +31,7 @@ const Investor = model.define("investor", {
 
   admins: model.hasMany(() => InvestorAdmin),
   stakes: model.hasMany(() => Stake),
+  convertibles: model.hasMany(() => Convertible),
   pipeline: model.hasMany(() => Pipeline),
 
   metadata: model.json().nullable(),

--- a/apps/backend/src/modules/investor/models/payment.ts
+++ b/apps/backend/src/modules/investor/models/payment.ts
@@ -1,6 +1,7 @@
 import { model } from "@medusajs/framework/utils"
 import Stake from "./stake"
 import CallForShares from "./call-for-shares"
+import Convertible from "./convertible"
 
 const Payment = model.define("investor_payment", {
   id: model.id().primaryKey(),
@@ -9,6 +10,9 @@ const Payment = model.define("investor_payment", {
     mappedBy: "payments",
   }).nullable(),
   call_for_shares: model.belongsTo(() => CallForShares, {
+    mappedBy: "payments",
+  }).nullable(),
+  convertible: model.belongsTo(() => Convertible, {
     mappedBy: "payments",
   }).nullable(),
 
@@ -23,6 +27,7 @@ const Payment = model.define("investor_payment", {
     "capital_call",
     "top_up",
     "transfer_fee",
+    "convertible",
     "other",
   ]).default("subscription"),
 

--- a/apps/backend/src/modules/investor/service.ts
+++ b/apps/backend/src/modules/investor/service.ts
@@ -4,6 +4,8 @@ import InvestorAdmin from "./models/investor-admin"
 import CapTable from "./models/cap-table"
 import ShareClass from "./models/share-class"
 import Stake from "./models/stake"
+import Convertible from "./models/convertible"
+import CompanyExpense from "./models/company-expense"
 import FundingRound from "./models/funding-round"
 import Pipeline from "./models/pipeline"
 import CallForShares from "./models/call-for-shares"
@@ -16,6 +18,8 @@ class InvestorService extends MedusaService({
   CapTable,
   ShareClass,
   Stake,
+  Convertible,
+  CompanyExpense,
   FundingRound,
   Pipeline,
   CallForShares,

--- a/apps/backend/src/modules/visual_flows/operations/commission-projection.ts
+++ b/apps/backend/src/modules/visual_flows/operations/commission-projection.ts
@@ -1,0 +1,130 @@
+import { z } from "@medusajs/framework/zod"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { OperationDefinition, OperationContext, OperationResult } from "./types"
+
+// Forward per-order commission run-rate. The platform earns a commission on
+// every partner sale, so the projection is derived — not assumed — from the
+// live catalogue:
+//   commission_per_order = avg_partner_product_price × commission_rate
+//   projected            = commission_per_order × orders_per_month × months
+// `orders_per_month` defaults to the actual last-30-day order count (the real
+// run-rate) unless the caller pins it. Keeps the investor number honest: it
+// moves with the catalogue's prices and the store's real order velocity.
+const DEFAULT_COMMISSION_BPS = 200 // 2% — PLATFORM_DEFAULT_FEE_BPS
+
+const commissionProjectionOptionsSchema = z.object({
+  currency: z
+    .string()
+    .default("INR")
+    .describe("Currency the average price + projection are expressed in."),
+  commission_bps: z
+    .number()
+    .int()
+    .positive()
+    .max(10000)
+    .default(DEFAULT_COMMISSION_BPS)
+    .describe("Platform commission in basis points (200 = 2%)."),
+  orders_per_month: z
+    .number()
+    .nonnegative()
+    .optional()
+    .describe("Override projected orders/month. Omit to use the real last-30d run-rate."),
+  window_days: z
+    .number()
+    .int()
+    .positive()
+    .max(3650)
+    .default(90)
+    .describe("Projection horizon in days. Monthly run-rate × (window_days / 30)."),
+})
+
+export const commissionProjectionOperation: OperationDefinition = {
+  type: "commission_projection",
+  name: "Commission Projection",
+  description:
+    "Forward per-order commission run-rate, derived from average partner product price × platform commission × order velocity.",
+  icon: "receipt-percent",
+  category: "data",
+
+  optionsSchema: commissionProjectionOptionsSchema,
+
+  defaultOptions: {
+    currency: "INR",
+    commission_bps: DEFAULT_COMMISSION_BPS,
+    window_days: 90,
+  },
+
+  execute: async (options: any, context: OperationContext): Promise<OperationResult> => {
+    try {
+      const parsed = commissionProjectionOptionsSchema.parse(options ?? {})
+      const currency = parsed.currency.toUpperCase()
+      const query = context.container.resolve(ContainerRegistrationKeys.QUERY)
+
+      // --- Average partner product price (from the live catalogue's variant prices) ---
+      const { data: products } = await query.graph({
+        entity: "product",
+        fields: ["id", "variants.prices.amount", "variants.prices.currency_code"],
+        filters: { status: "published" },
+        pagination: { take: 5000 },
+      }).catch(() => ({ data: [] as any[] }))
+
+      const prices: number[] = []
+      for (const p of (products || []) as any[]) {
+        for (const v of p.variants || []) {
+          for (const pr of v.prices || []) {
+            if (
+              String(pr.currency_code || "").toUpperCase() === currency &&
+              typeof pr.amount === "number" &&
+              pr.amount > 0
+            ) {
+              prices.push(pr.amount)
+            }
+          }
+        }
+      }
+      const avgPrice = prices.length
+        ? prices.reduce((a, b) => a + b, 0) / prices.length
+        : 0
+
+      // --- Orders per month: real last-30d run-rate unless pinned ---
+      let ordersPerMonth = parsed.orders_per_month
+      if (ordersPerMonth == null) {
+        const since = new Date()
+        since.setDate(since.getDate() - 30)
+        const res = await query.graph({
+          entity: "order",
+          fields: ["id"],
+          filters: { created_at: { $gte: since } as any },
+          pagination: { take: 1 },
+        }).catch(() => ({ data: [] as any[], metadata: { count: 0 } }))
+        ordersPerMonth = (res as any)?.metadata?.count ?? res.data?.length ?? 0
+      }
+
+      const ordersRunRate = ordersPerMonth ?? 0
+      const commissionRate = parsed.commission_bps / 10000
+      const commissionPerOrder = avgPrice * commissionRate
+      const months = parsed.window_days / 30
+      const amount = Math.round(commissionPerOrder * ordersRunRate * months)
+
+      return {
+        success: true,
+        data: {
+          amount,
+          currency,
+          window_days: parsed.window_days,
+          source: "projected",
+          avg_product_price: Math.round(avgPrice),
+          commission_bps: parsed.commission_bps,
+          orders_per_month: ordersRunRate,
+          formula: {
+            commission_per_order: Math.round(commissionPerOrder),
+            commission_rate: commissionRate,
+            months,
+          },
+        },
+      }
+    } catch (error: any) {
+      return { success: false, error: error.message, errorStack: error.stack }
+    }
+  },
+}

--- a/apps/backend/src/modules/visual_flows/operations/gmv-projection.ts
+++ b/apps/backend/src/modules/visual_flows/operations/gmv-projection.ts
@@ -9,14 +9,14 @@ import { OperationDefinition, OperationContext, OperationResult } from "./types"
 //             + artisans   × per_artisan_monthly × months
 // Conservative, defensible run-rate framing — not an aspirational ceiling.
 const PROJECTION_PER_BRAND_MONTHLY: Record<string, number> = {
-  INR: 100_000,
-  USD: 1_200,
-  EUR: 1_100,
+  INR: 2_000,
+  USD: 24,
+  EUR: 22,
 }
 const PROJECTION_PER_ARTISAN_MONTHLY: Record<string, number> = {
-  INR: 5_000,
-  USD: 60,
-  EUR: 55,
+  INR: 100,
+  USD: 1,
+  EUR: 1,
 }
 
 // Platform's own marketing hosts — excluded from brands_live so the number

--- a/apps/backend/src/modules/visual_flows/operations/index.ts
+++ b/apps/backend/src/modules/visual_flows/operations/index.ts
@@ -35,6 +35,7 @@ export { partnerAnalyticsDigestOperation } from "./partner-analytics-digest"
 export { marketingDailyIdeasEmailOperation } from "./marketing-daily-ideas-email"
 export { waitForEventOperation } from "./wait-for-event"
 export { gmvProjectionOperation } from "./gmv-projection"
+export { commissionProjectionOperation } from "./commission-projection"
 export { adsEfficiencyOperation } from "./ads-efficiency"
 
 // Import all operations and register them
@@ -71,6 +72,7 @@ import { partnerAnalyticsDigestOperation } from "./partner-analytics-digest"
 import { marketingDailyIdeasEmailOperation } from "./marketing-daily-ideas-email"
 import { waitForEventOperation } from "./wait-for-event"
 import { gmvProjectionOperation } from "./gmv-projection"
+import { commissionProjectionOperation } from "./commission-projection"
 import { adsEfficiencyOperation } from "./ads-efficiency"
 
 // Register all built-in operations
@@ -118,6 +120,7 @@ export function registerBuiltInOperations(): void {
   operationRegistry.register(resolveCartRecoveryUrlsOperation)
   operationRegistry.register(partnerAnalyticsDigestOperation)
   operationRegistry.register(gmvProjectionOperation)
+  operationRegistry.register(commissionProjectionOperation)
   operationRegistry.register(adsEfficiencyOperation)
 }
 

--- a/apps/backend/src/scripts/seed-company-expenses.ts
+++ b/apps/backend/src/scripts/seed-company-expenses.ts
@@ -1,0 +1,39 @@
+import { ExecArgs } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { INVESTOR_MODULE } from "../modules/investor"
+
+/**
+ * Seeds the two headline company expenses shown to investors — partnership cost
+ * and tech stack — as editable monthly rows. Amounts are placeholders: adjust
+ * them to the real figures in the admin (POST /admin/company-expenses/:id) — the
+ * "Partnership cost / mo" and "Tech stack / mo" panels sum these live.
+ *
+ * Idempotent: matched by (category, name); re-running leaves existing rows alone.
+ *
+ * Usage:
+ *   npx medusa exec ./src/scripts/seed-company-expenses.ts
+ */
+const EXPENSES = [
+  { category: "partnership", name: "Partner network & onboarding", amount: 2_000, currency_code: "INR" },
+  { category: "tech_stack", name: "Cloud, AI & tooling", amount: 5_000, currency_code: "INR" },
+]
+
+export default async function seedCompanyExpenses({ container }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const service: any = container.resolve(INVESTOR_MODULE)
+
+  for (const spec of EXPENSES) {
+    const existing = await service.listCompanyExpenses(
+      { category: spec.category, name: spec.name },
+      { take: 1 }
+    )
+    if ((existing || []).length) {
+      logger.info(`Expense "${spec.name}" already exists — leaving as-is`)
+      continue
+    }
+    const [created] = await service.createCompanyExpenses([
+      { ...spec, recurrence: "monthly", status: "active" },
+    ])
+    logger.info(`Created expense "${spec.name}" (${created.id}) — edit amount to the real value`)
+  }
+}

--- a/apps/backend/src/scripts/seed-investor-projection-panels.ts
+++ b/apps/backend/src/scripts/seed-investor-projection-panels.ts
@@ -70,6 +70,87 @@ const PANELS = [
     operation_type: "ads_efficiency",
     operation_options: { last_days: 30, base_currency: "INR" },
   },
+
+  // --- Traction / financial roll-ups (all-time; DB-backed via aggregate_data) ---
+  {
+    name: "Total products",
+    type: "metric",
+    x: 0, y: 6, width: 3, height: 2,
+    operation_type: "aggregate_data",
+    operation_options: { entity: "product", fields: ["id"], aggregate: { fn: "count" } },
+  },
+  {
+    name: "Total orders",
+    type: "metric",
+    x: 3, y: 6, width: 3, height: 2,
+    operation_type: "aggregate_data",
+    operation_options: { entity: "order", fields: ["id"], aggregate: { fn: "count" } },
+  },
+  {
+    name: "Partner production runs",
+    type: "metric",
+    x: 6, y: 6, width: 3, height: 2,
+    operation_type: "aggregate_data",
+    operation_options: { entity: "production_runs", fields: ["id"], aggregate: { fn: "count" } },
+  },
+  {
+    name: "Inventory orders value",
+    type: "metric",
+    x: 9, y: 6, width: 3, height: 2,
+    operation_type: "aggregate_data",
+    operation_options: {
+      entity: "inventory_orders",
+      fields: ["total_price"],
+      aggregate: { fn: "sum", field: "total_price" },
+    },
+  },
+  {
+    name: "Commissions accrued",
+    type: "metric",
+    x: 0, y: 8, width: 6, height: 2,
+    operation_type: "aggregate_data",
+    operation_options: {
+      entity: "partner_fee",
+      fields: ["fee_amount"],
+      filters: { status: "accrued" },
+      aggregate: { fn: "sum", field: "fee_amount" },
+    },
+  },
+
+  // --- Forward projections (derived run-rates, not stored) ---
+  {
+    name: "Commission projection",
+    type: "metric",
+    x: 6, y: 8, width: 6, height: 2,
+    operation_type: "commission_projection",
+    operation_options: { currency: "INR", commission_bps: 200, window_days: 90 },
+  },
+
+  // --- Company expenses (cost side shown to investors) ---
+  {
+    name: "Partnership cost / mo",
+    type: "metric",
+    x: 0, y: 10, width: 6, height: 2,
+    operation_type: "aggregate_data",
+    operation_options: {
+      entity: "company_expense",
+      fields: ["amount"],
+      filters: { category: "partnership", recurrence: "monthly", status: "active" },
+      aggregate: { fn: "sum", field: "amount" },
+    },
+  },
+  {
+    name: "Tech stack / mo",
+    type: "metric",
+    x: 6, y: 10, width: 6, height: 2,
+    operation_type: "aggregate_data",
+    operation_options: {
+      entity: "company_expense",
+      fields: ["amount"],
+      filters: { category: "tech_stack", recurrence: "monthly", status: "active" },
+      aggregate: { fn: "sum", field: "amount" },
+    },
+  },
 ]
 
 export default async function seedInvestorProjectionPanels({ container }: ExecArgs) {

--- a/apps/investor-ui/src/dashboard-app/routes/get-route.map.tsx
+++ b/apps/investor-ui/src/dashboard-app/routes/get-route.map.tsx
@@ -29,11 +29,13 @@ export function getRouteMap({
               path: "/",
               errorElement: <ErrorBoundary />,
               lazy: () => import("../../routes/home"),
-            },
-            {
-              path: "/onboarding",
-              errorElement: <ErrorBoundary />,
-              lazy: () => import("../../routes/onboarding"),
+              children: [
+                {
+                  path: "onboarding",
+                  errorElement: <ErrorBoundary />,
+                  lazy: () => import("../../routes/onboarding"),
+                },
+              ],
             },
             {
               path: "/cap-table",

--- a/apps/investor-ui/src/hooks/api/investments.tsx
+++ b/apps/investor-ui/src/hooks/api/investments.tsx
@@ -13,14 +13,23 @@ export type Deal = {
   id: string
   name: string
   round_type?: string
+  instrument_type?: "equity" | "safe" | "convertible_note"
   status?: string
   target_amount?: number | null
   raised_amount?: number | null
   price_per_share?: number | null
   pre_money_valuation?: number | null
+  valuation_cap?: number | null
+  discount_rate?: number | null
+  safe_type?: "post_money" | "pre_money" | null
   close_date?: string | null
   cap_table?: { company_id?: string; name?: string; currency_code?: string | null } | null
 }
+
+export const isSafeDeal = (d: Deal) =>
+  d.instrument_type === "safe" ||
+  d.instrument_type === "convertible_note" ||
+  d.round_type === "safe"
 
 export type Participation = {
   id: string
@@ -92,6 +101,66 @@ export const useMyDocuments = () => {
   return { documents: data?.documents ?? [], count: data?.count ?? 0, ...rest }
 }
 
+// --- SAFEs / convertibles (money in now, equity later — no shares yet) --------
+
+export type ConvertibleValue = {
+  principal: number
+  implied_ownership_pct: number | null
+  implied_value: number | null
+  multiple: number | null
+  basis: string
+}
+
+export type MyConvertible = {
+  id: string
+  instrument_type?: "safe" | "convertible_note"
+  principal_amount?: number | null
+  currency_code?: string | null
+  valuation_cap?: number | null
+  discount_rate?: number | null
+  safe_type?: "post_money" | "pre_money"
+  status?: string
+  investment_date?: string | null
+  conversion_date?: string | null
+  cap_table?: {
+    id?: string
+    name?: string
+    company_id?: string
+    post_money_valuation?: number | null
+    currency_code?: string | null
+  } | null
+  payments?: Array<{ id: string; amount?: number | null; status?: string; paid_date?: string | null }>
+  value: ConvertibleValue
+}
+
+export type ConvertibleSummary = {
+  total_principal: number
+  total_implied_value: number
+  outstanding_count: number
+}
+
+export const useMyConvertibles = () => {
+  const { data, ...rest } = useQuery({
+    queryFn: () =>
+      sdk.client.fetch<{
+        convertibles: MyConvertible[]
+        count: number
+        summary: ConvertibleSummary
+      }>("/investors/me/convertibles", { method: "GET" }),
+    queryKey: ["investor-convertibles"] as const,
+  })
+  return {
+    convertibles: data?.convertibles ?? [],
+    count: data?.count ?? 0,
+    summary: data?.summary ?? {
+      total_principal: 0,
+      total_implied_value: 0,
+      outstanding_count: 0,
+    },
+    ...rest,
+  }
+}
+
 export const useMyCapTable = () => {
   const { data, ...rest } = useQuery({
     queryFn: () =>
@@ -129,18 +198,27 @@ export const useMyParticipations = () => {
 
 export const useParticipate = (
   dealId: string,
-  options?: UseMutationOptions<{ stake: any }, FetchError, { amount: number }>
+  options?: UseMutationOptions<
+    { stake?: any; convertible?: any },
+    FetchError,
+    { amount: number }
+  >
 ) => {
   return useMutation({
     mutationFn: (payload) =>
-      sdk.client.fetch<{ stake: any }>(`/investors/deals/${dealId}/participate`, {
-        method: "POST",
-        body: payload,
-      }),
+      sdk.client.fetch<{ stake?: any; convertible?: any }>(
+        `/investors/deals/${dealId}/participate`,
+        {
+          method: "POST",
+          body: payload,
+        }
+      ),
     onSuccess: (data, variables, context) => {
       queryClient.invalidateQueries({ queryKey: investmentsQueryKeys.deals })
       queryClient.invalidateQueries({ queryKey: investmentsQueryKeys.participations })
-      options?.onSuccess?.(data, variables, context)
+      queryClient.invalidateQueries({ queryKey: investmentsQueryKeys.capTable })
+      queryClient.invalidateQueries({ queryKey: ["investor-convertibles"] })
+      ;(options?.onSuccess as any)?.(data, variables, context)
     },
     ...options,
   })

--- a/apps/investor-ui/src/routes/cap-table/index.tsx
+++ b/apps/investor-ui/src/routes/cap-table/index.tsx
@@ -14,8 +14,11 @@ import {
 } from "../../components/common/ownership-donut"
 import {
   useMyCapTable,
+  useMyConvertibles,
   type CapTableStake,
   type InvestorCapTable,
+  type MyConvertible,
+  type ConvertibleSummary,
 } from "../../hooks/api/investments"
 
 const money = (v?: number | null, ccy?: string | null) =>
@@ -23,6 +26,9 @@ const money = (v?: number | null, ccy?: string | null) =>
 
 const num = (v?: number | null) =>
   v == null ? "—" : new Intl.NumberFormat().format(Number(v))
+
+const pct = (v?: number | null) =>
+  v == null ? "—" : `${(Number(v) * 100).toFixed(2)}%`
 
 const stakeValue = (s: CapTableStake) =>
   Number(s.total_invested ?? 0) || Number(s.number_of_shares ?? 0) || 0
@@ -166,8 +172,131 @@ const CapTableSection = ({ capTable }: { capTable: InvestorCapTable }) => {
   )
 }
 
+const safeStatusColor = (s?: string): "green" | "orange" | "red" | "grey" => {
+  switch (s) {
+    case "outstanding":
+      return "green"
+    case "converted":
+      return "blue" as any
+    case "redeemed":
+      return "orange"
+    case "cancelled":
+    case "expired":
+      return "red"
+    default:
+      return "grey"
+  }
+}
+
+// SAFEs / convertibles — kept as a SEPARATE section from common shares because a
+// SAFE holder has no shares yet; their value is *implied* (principal, implied
+// ownership floor, implied current value against the company valuation).
+const SafesSection = ({
+  convertibles,
+  summary,
+}: {
+  convertibles: MyConvertible[]
+  summary: ConvertibleSummary
+}) => {
+  const ccy = convertibles[0]?.currency_code ?? convertibles[0]?.cap_table?.currency_code
+
+  const table = useDataTable({
+    data: convertibles,
+    columns: [
+      {
+        header: "Instrument",
+        accessorKey: "instrument_type",
+        cell: ({ row }: any) => (
+          <span className="flex items-center gap-x-2">
+            {row.original.instrument_type === "convertible_note" ? "Convertible note" : "SAFE"}
+            {row.original.safe_type === "pre_money" ? (
+              <Badge size="2xsmall" color="grey">pre-money</Badge>
+            ) : (
+              <Badge size="2xsmall" color="grey">post-money</Badge>
+            )}
+          </span>
+        ),
+      },
+      {
+        header: "Company",
+        accessorKey: "cap_table",
+        cell: ({ row }: any) => row.original.cap_table?.name ?? "—",
+      },
+      {
+        header: "Principal",
+        accessorKey: "principal_amount",
+        cell: ({ row }: any) => money(row.original.value?.principal, row.original.currency_code ?? ccy),
+      },
+      {
+        header: "Cap",
+        accessorKey: "valuation_cap",
+        cell: ({ row }: any) => money(row.original.valuation_cap, row.original.currency_code ?? ccy),
+      },
+      {
+        header: "Implied own.",
+        accessorKey: "implied_ownership",
+        cell: ({ row }: any) => pct(row.original.value?.implied_ownership_pct),
+      },
+      {
+        header: "Implied value",
+        accessorKey: "implied_value",
+        cell: ({ row }: any) => money(row.original.value?.implied_value, row.original.currency_code ?? ccy),
+      },
+      {
+        header: "Status",
+        accessorKey: "status",
+        cell: ({ row }: any) => (
+          <Badge color={safeStatusColor(row.original.status)}>
+            {row.original.status ?? "outstanding"}
+          </Badge>
+        ),
+      },
+    ],
+  })
+
+  const multiple =
+    summary.total_principal > 0
+      ? summary.total_implied_value / summary.total_principal
+      : null
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="px-6 py-4">
+        <Heading level="h2">SAFEs &amp; Convertibles</Heading>
+        <Text size="small" className="text-ui-fg-subtle mt-1">
+          Money invested now that converts to equity later — no shares are issued yet, so value is implied against the company valuation.
+        </Text>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 px-6 py-5 md:grid-cols-4">
+        <div className="rounded-lg border p-3">
+          <Text size="small" className="text-ui-fg-subtle">Total invested</Text>
+          <Text weight="plus" className="mt-1">{money(summary.total_principal, ccy)}</Text>
+        </div>
+        <div className="rounded-lg border p-3">
+          <Text size="small" className="text-ui-fg-subtle">Implied value</Text>
+          <Text weight="plus" className="mt-1">{money(summary.total_implied_value, ccy)}</Text>
+        </div>
+        <div className="rounded-lg border p-3">
+          <Text size="small" className="text-ui-fg-subtle">Est. multiple</Text>
+          <Text weight="plus" className="mt-1">{multiple == null ? "—" : `${multiple.toFixed(2)}×`}</Text>
+        </div>
+        <div className="rounded-lg border p-3">
+          <Text size="small" className="text-ui-fg-subtle">Outstanding</Text>
+          <Text weight="plus" className="mt-1">{summary.outstanding_count}</Text>
+        </div>
+      </div>
+
+      <DataTable instance={table}>
+        <DataTable.Table />
+      </DataTable>
+    </Container>
+  )
+}
+
 export const Component = () => {
   const { capTables, isPending } = useMyCapTable()
+  const { convertibles, summary, isPending: safesPending } = useMyConvertibles()
 
   if (isPending) {
     return (
@@ -206,9 +335,13 @@ export const Component = () => {
 
       {capTables.length > 0 && capTables.some((ct) => (ct.stakes ?? []).length > 0) && (
         <div className="flex flex-col gap-y-3">
-          <Heading level="h2">All Stakes</Heading>
+          <Heading level="h2">Common Shares</Heading>
           <CapTableList capTables={capTables} />
         </div>
+      )}
+
+      {!safesPending && convertibles.length > 0 && (
+        <SafesSection convertibles={convertibles} summary={summary} />
       )}
     </div>
   )

--- a/apps/investor-ui/src/routes/finances/participate/participate.tsx
+++ b/apps/investor-ui/src/routes/finances/participate/participate.tsx
@@ -2,7 +2,7 @@ import { Button, Heading, Input, Label, Text, toast } from "@medusajs/ui"
 import { useForm } from "react-hook-form"
 import { useParams } from "react-router-dom"
 import { RouteFocusModal, useRouteModal } from "../../../components/modals"
-import { useDeals, useParticipate, type Deal } from "../../../hooks/api/investments"
+import { useDeals, useParticipate, isSafeDeal, type Deal } from "../../../hooks/api/investments"
 
 const money = (v?: number | null, ccy?: string | null) =>
   v == null ? "—" : `${ccy ? ccy + " " : ""}${new Intl.NumberFormat().format(Number(v))}`
@@ -11,9 +11,14 @@ const ParticipateForm = ({ deal }: { deal: Deal }) => {
   const { handleSuccess } = useRouteModal()
   const form = useForm({ defaultValues: { amount: "" } })
   const ccy = deal.cap_table?.currency_code
+  const isSafe = isSafeDeal(deal)
   const { mutateAsync, isPending } = useParticipate(deal.id, {
     onSuccess: () => {
-      toast.success("Participation submitted — awaiting approval")
+      toast.success(
+        isSafe
+          ? "SAFE commitment submitted — awaiting approval"
+          : "Participation submitted — awaiting approval"
+      )
       handleSuccess()
     },
     onError: (e: any) => toast.error(e?.message || "Failed to participate"),
@@ -40,17 +45,44 @@ const ParticipateForm = ({ deal }: { deal: Deal }) => {
       <RouteFocusModal.Body className="flex flex-1 flex-col items-center overflow-auto py-8">
         <div className="flex w-full max-w-md flex-col gap-y-6">
           <div className="flex flex-col gap-y-1">
-            <Heading level="h2">Participate in {deal.name}</Heading>
+            <Heading level="h2">
+              {isSafe ? "Invest via SAFE" : "Participate"} in {deal.name}
+            </Heading>
             <Text size="small" className="text-ui-fg-subtle">
               {deal.cap_table?.name}
-              {deal.price_per_share ? ` · ${money(deal.price_per_share, ccy)} / share` : ""}
+              {!isSafe && deal.price_per_share
+                ? ` · ${money(deal.price_per_share, ccy)} / share`
+                : ""}
             </Text>
           </div>
+
+          {isSafe && (
+            <div className="rounded-lg border bg-ui-bg-subtle p-4">
+              <Text size="small" weight="plus" className="mb-2">
+                SAFE terms {deal.safe_type === "pre_money" ? "(pre-money)" : "(post-money)"}
+              </Text>
+              <div className="grid grid-cols-2 gap-y-1.5 gap-x-4">
+                <Text size="small" className="text-ui-fg-subtle">Valuation cap</Text>
+                <Text size="small">{money(deal.valuation_cap, ccy)}</Text>
+                <Text size="small" className="text-ui-fg-subtle">Discount</Text>
+                <Text size="small">
+                  {deal.discount_rate ? `${(Number(deal.discount_rate) * 100).toFixed(0)}%` : "—"}
+                </Text>
+              </div>
+              <Text size="xsmall" className="text-ui-fg-muted mt-2">
+                No shares are issued now — your SAFE converts to equity at the next
+                priced round or a liquidity event.
+              </Text>
+            </div>
+          )}
+
           <div className="flex flex-col gap-y-2">
-            <Label size="small" weight="plus">Amount {ccy ? `(${ccy})` : ""}</Label>
+            <Label size="small" weight="plus">
+              {isSafe ? "Investment amount" : "Amount"} {ccy ? `(${ccy})` : ""}
+            </Label>
             <Input type="number" placeholder="50000" {...form.register("amount", { required: true })} />
             <Text size="small" className="text-ui-fg-subtle">
-              We'll confirm your allocation and send a payment link.
+              We'll confirm your {isSafe ? "SAFE" : "allocation"} and send a payment link.
             </Text>
           </div>
         </div>

--- a/apps/investor-ui/src/routes/home/home.tsx
+++ b/apps/investor-ui/src/routes/home/home.tsx
@@ -1,6 +1,6 @@
 import { Badge, Container, Heading, Skeleton, Text } from "@medusajs/ui"
-import { useEffect } from "react"
-import { useNavigate } from "react-router-dom"
+import { useMemo, useEffect } from "react"
+import { Outlet, useNavigate } from "react-router-dom"
 import { useMe } from "../../hooks/api/users"
 import type { InvestorOnboarding } from "../onboarding/onboarding"
 
@@ -90,7 +90,25 @@ export const Home = () => {
 
   const investor = (user ?? {}) as Record<string, any>
   const onboarding: InvestorOnboarding = investor?.metadata?.onboarding ?? {}
-  const needsOnboarding = !isPending && !!user && !onboarding.completed
+
+  const userId = (user as any)?.id
+  const storageKey = useMemo(
+    () => (userId ? `investor_onboarding_${userId}` : null),
+    [userId]
+  )
+
+  const onboardingSkipped = useMemo(() => {
+    if (!storageKey) return false
+    try {
+      const raw = localStorage.getItem(storageKey)
+      return raw ? JSON.parse(raw)?.skipped === true : false
+    } catch {
+      return false
+    }
+  }, [storageKey])
+
+  const needsOnboarding =
+    !isPending && !!user && !onboarding.completed && !onboardingSkipped
 
   // First-run: open the onboarding focus-modal over the dashboard.
   useEffect(() => {
@@ -103,5 +121,10 @@ export const Home = () => {
     return <HomeSkeleton />
   }
 
-  return <DashboardHome investor={investor} />
+  return (
+    <>
+      <DashboardHome investor={investor} />
+      <Outlet />
+    </>
+  )
 }

--- a/apps/investor-ui/src/routes/home/home.tsx
+++ b/apps/investor-ui/src/routes/home/home.tsx
@@ -5,11 +5,11 @@ import {
   Skeleton,
   Text,
 } from "@medusajs/ui"
-import { Buildings, CurrencyDollar, RocketLaunch, PencilSquare } from "@medusajs/icons"
+import { Buildings, CurrencyDollar, RocketLaunch, PencilSquare, DocumentText } from "@medusajs/icons"
 import { useMemo, useEffect } from "react"
 import { Outlet, useNavigate, Link } from "react-router-dom"
 import { useMe } from "../../hooks/api/users"
-import { useMyCapTable, useDeals } from "../../hooks/api/investments"
+import { useMyCapTable, useDeals, useMyConvertibles, isSafeDeal } from "../../hooks/api/investments"
 import { useMyProjections } from "../../hooks/api/projections"
 import { SingleColumnPage } from "../../components/layout/pages"
 import type { InvestorOnboarding } from "../onboarding/onboarding"
@@ -88,6 +88,7 @@ const DashboardHome = ({ investor }: { investor: Record<string, any> }) => {
   const { capTables, isPending: ctPending } = useMyCapTable()
   const { deals, isPending: dealsPending } = useDeals()
   const { portfolio, isPending: posPending } = useMyProjections()
+  const { summary: safeSummary, count: safeCount, isPending: safesPending } = useMyConvertibles()
 
   const companies = useMemo(() => {
     const seen = new Map<string, CompanySummary>()
@@ -122,10 +123,11 @@ const DashboardHome = ({ investor }: { investor: Record<string, any> }) => {
     return Array.from(seen.values())
   }, [capTables, deals])
 
-  const pending = ctPending || dealsPending || posPending
+  const pending = ctPending || dealsPending || posPending || safesPending
 
   const openDeals = deals.filter((d) => d.status !== "closed" && d.status !== "cancelled")
   const totalInvested = portfolio?.total_invested ?? 0
+  const hasSafes = safeCount > 0
 
   return (
     <>
@@ -157,10 +159,19 @@ const DashboardHome = ({ investor }: { investor: Record<string, any> }) => {
           <Skeleton className="h-20 rounded-lg" />
         </div>
       ) : (
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <div className={`grid grid-cols-1 gap-3 ${hasSafes ? "sm:grid-cols-4" : "sm:grid-cols-3"}`}>
           <StatCard icon={<CurrencyDollar />} label="Total invested" value={money(totalInvested)} />
           <StatCard icon={<Buildings />} label="Companies" value={num(companies.length)} />
           <StatCard icon={<RocketLaunch />} label="Open deals" value={num(openDeals.length)} />
+          {hasSafes && (
+            <Link to="/cap-table" className="block">
+              <StatCard
+                icon={<DocumentText />}
+                label={`SAFEs (${safeCount})`}
+                value={money(safeSummary.total_implied_value)}
+              />
+            </Link>
+          )}
         </div>
       )}
 
@@ -236,7 +247,10 @@ const DashboardHome = ({ investor }: { investor: Record<string, any> }) => {
                 className="flex items-center justify-between rounded-lg border px-4 py-3 transition-colors hover:bg-ui-bg-base-hover"
               >
                 <div>
-                  <Text weight="plus">{d.name}</Text>
+                  <Text weight="plus" className="flex items-center gap-x-2">
+                    {d.name}
+                    {isSafeDeal(d) && <Badge size="2xsmall" color="purple">SAFE</Badge>}
+                  </Text>
                   <Text size="small" className="text-ui-fg-subtle">
                     {d.cap_table?.name ?? d.round_type ?? "Round"} · {money(d.target_amount)} target
                   </Text>

--- a/apps/investor-ui/src/routes/onboarding/onboarding.tsx
+++ b/apps/investor-ui/src/routes/onboarding/onboarding.tsx
@@ -8,8 +8,7 @@ import {
   toast,
 } from "@medusajs/ui"
 import { useState } from "react"
-import { useNavigate } from "react-router-dom"
-import { RouteFocusModal } from "../../components/modals"
+import { RouteFocusModal, useRouteModal } from "../../components/modals"
 import { useMe, useUpdateMe } from "../../hooks/api/users"
 
 export type InvestorOnboarding = {
@@ -39,12 +38,16 @@ const INTERESTS = [
   "Growth Stage",
 ]
 
+const getUserId = (user: any): string | null => user?.id ?? null
+
 const OnboardingInner = ({
   metadata,
+  userId,
 }: {
   metadata?: Record<string, any> | null
+  userId: string | null
 }) => {
-  const navigate = useNavigate()
+  const { handleSuccess } = useRouteModal()
   const existing: InvestorOnboarding = metadata?.onboarding ?? {}
 
   const [ticketSize, setTicketSize] = useState<string>(existing.ticket_size ?? "")
@@ -56,7 +59,7 @@ const OnboardingInner = ({
   const { mutateAsync, isPending } = useUpdateMe({
     onSuccess: () => {
       toast.success("Welcome aboard — your preferences are saved.")
-      navigate("/", { replace: true })
+      handleSuccess("/")
     },
     onError: (err: any) => {
       toast.error(err?.message || "Could not save your preferences")
@@ -69,6 +72,20 @@ const OnboardingInner = ({
         ? prev.filter((i) => i !== interest)
         : [...prev, interest]
     )
+  }
+
+  const handleSkip = () => {
+    if (userId) {
+      try {
+        localStorage.setItem(
+          `investor_onboarding_${userId}`,
+          JSON.stringify({ skipped: true, skipped_at: new Date().toISOString() })
+        )
+      } catch {
+        // non-blocking
+      }
+    }
+    handleSuccess("/")
   }
 
   const canSubmit = ticketSize !== "" && interests.length > 0 && !isPending
@@ -168,7 +185,10 @@ const OnboardingInner = ({
             <Switch checked={newsletter} onCheckedChange={setNewsletter} />
           </div>
 
-          <div className="flex items-center justify-end gap-x-3">
+          <div className="flex items-center justify-between gap-x-3">
+            <Button variant="secondary" onClick={handleSkip}>
+              Skip for now
+            </Button>
             <Button
               variant="primary"
               onClick={handleSubmit}
@@ -187,10 +207,11 @@ const OnboardingInner = ({
 export const Onboarding = () => {
   const { user, isPending } = useMe()
   const metadata = (user as any)?.metadata ?? null
+  const userId = getUserId(user)
 
   return (
-    <RouteFocusModal prev="/">
-      {!isPending && <OnboardingInner metadata={metadata} />}
+    <RouteFocusModal>
+      {!isPending && <OnboardingInner metadata={metadata} userId={userId} />}
     </RouteFocusModal>
   )
 }


### PR DESCRIPTION
## What

End-to-end **SAFE / convertible** support for the investor module, plus projection-panel fixes the user requested.

### SAFEs (money now, equity later — no shares issued yet)
- **Model**: new `convertible` (SAFE / note) with `computeConvertibleValue` — derives implied ownership (`principal / cap`) and implied current value against the company valuation. Reverse relations added to investor / cap_table / payment.
- **Record a historical SAFE** for an existing investor from the admin cap-table section (`@add-safe`) — mirrors manual share provisioning.
- **Publishable SAFE rounds**: `funding_round` gains `instrument_type` + SAFE terms (valuation_cap / discount / safe_type). The add-round form lets you pick *SAFE*; participating in a SAFE round creates a **Convertible** instead of a Stake.
- **Investor-ui**: a **separate "SAFEs & Convertibles" section** (distinct from common shares) + a home summary tile; the participate form shows SAFE terms.
- **Payments reuse the PayU rail**: convertible approve → `createPayuLink` (same helper as stakes). The PayU webhook already no-ops the stake update when a payment has no `stake_id`, so a paid SAFE stays `outstanding` (correct — it converts later).
- SAFE participants surface in the round **participations** screen (approve via the convertible route).

### Projections / panels
- **Per-brand monthly** corrected to the real run-rate (INR 2,000; USD/EUR FX-equiv) — fixes the "100,000" tile; artisan per-month dropped proportionally (INR 100).
- New **`commission_projection`** operation: avg partner product price × 2% (`PLATFORM_DEFAULT_FEE_BPS`) × real last-30d orders/month.
- New **`company_expense`** model + admin routes; **"Partnership cost /mo"** and **"Tech stack /mo"** panels roll them up as company expenses.
- Seed adds: Total products/orders, partner production runs, inventory-order value, commissions accrued, commission projection, and the two expense panels.

### Fixes
- Admin **query-invalidation**: share-class / funding-round / publish-round mutations now also invalidate the company cap-tables list, so the section refreshes immediately (bug the user flagged).

## Deploy tail (post-merge)
1. Run migrations `Migration20260711180000/190000/200000` (convertible, company_expense, funding_round SAFE terms).
2. Run `seed-investor-projection-panels.ts` (new panels) + optionally `seed-company-expenses.ts` (placeholder partnership/tech-stack rows — edit amounts to real values).
3. Redeploy backend + investor-ui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)