### PR TITLE
fix(investor-ui): Settings back nav → /, remove Store refs from header popup

### DIFF
--- a/apps/investor-ui/src/components/layout/main-layout/main-layout.tsx
+++ b/apps/investor-ui/src/components/layout/main-layout/main-layout.tsx
@@ -1,5 +1,4 @@
 import {
-  BuildingStorefront,
   ChartBar,
   ChartPie,
   CogSixTooth,
@@ -151,19 +150,13 @@ const Header = () => {
                 >
                   {name}
                 </Text>
-                <Text
-                  size="xsmall"
-                  leading="compact"
-                  className="text-ui-fg-subtle"
-                >
-                  {t("app.nav.main.store")}
-                </Text>
+
               </div>
             </div>
             <DropdownMenu.Separator />
             <DropdownMenu.Item className="gap-x-2" asChild>
-              <Link to="/settings/profile">
-                <BuildingStorefront className="text-ui-fg-subtle" />
+              <Link to="/">
+                <ChartPie className="text-ui-fg-subtle" />
                 {t("app.nav.settings.header")}
               </Link>
             </DropdownMenu.Item>

--- a/apps/investor-ui/src/components/layout/settings-layout/settings-layout.tsx
+++ b/apps/investor-ui/src/components/layout/settings-layout/settings-layout.tsx
@@ -51,7 +51,7 @@ const useMyAccountRoutes = (): INavItem[] => {
  */
 const getSafeFromValue = (from: string) => {
   if (from.startsWith("/settings")) {
-    return "/orders"
+    return "/"
   }
 
   return from
@@ -106,7 +106,7 @@ const SettingsSidebar = () => {
 }
 
 const Header = () => {
-  const [from, setFrom] = useState("/orders")
+  const [from, setFrom] = useState("/")
 
   const { t } = useTranslation()
   const location = useLocation()


### PR DESCRIPTION
**Changes:**
1. **Settings back button** — changed fallback from `/orders` to `/` in `settings-layout.tsx` (`getSafeFromValue` and `useState` default) since the investor UI has no orders route.
2. **Header popup Store references** — removed the `Store` subtitle text and changed the dropdown link from `/settings/profile` (with `BuildingStorefront` icon) to `/` (with `ChartPie` icon). Cleaned up unused `BuildingStorefront` import.