### PR TITLE
feat(investor): re-invite existing investors instead of failing on existing auth

### DIFF
--- a/apps/backend/src/admin/routes/companies/[id]/@invite-investor/page.tsx
+++ b/apps/backend/src/admin/routes/companies/[id]/@invite-investor/page.tsx
@@ -29,8 +29,12 @@ const InviteInvestorForm = ({ companyId }: { companyId: string }) => {
     },
   })
   const { mutateAsync, isPending } = useInviteInvestorToCompany(companyId, {
-    onSuccess: () => {
-      toast.success("Investor invited")
+    onSuccess: (data: any) => {
+      toast.success(
+        data?.reinvited
+          ? "Investor already existed — password reset and invite re-sent"
+          : "Investor invited"
+      )
       handleSuccess()
     },
     onError: (err) => toast.error(err?.message || "Failed to invite investor"),

--- a/apps/backend/src/api/admin/companies/[id]/investors/route.ts
+++ b/apps/backend/src/api/admin/companies/[id]/investors/route.ts
@@ -4,7 +4,10 @@ import {
   MedusaError,
   Modules,
 } from "@medusajs/framework/utils"
-import { createInvestorAdminWithRegistrationWorkflow } from "../../../../../workflows/investor/create-investor-admin"
+import {
+  createInvestorAdminWithRegistrationWorkflow,
+  resetInvestorAdminPasswordWorkflow,
+} from "../../../../../workflows/investor/create-investor-admin"
 import { INVESTOR_MODULE } from "../../../../../modules/investor"
 import type InvestorService from "../../../../../modules/investor/service"
 
@@ -37,6 +40,69 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const companyId = req.params.id
   const { admin, ...investorData } = req.validatedBody as any
 
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const investorService: InvestorService = req.scope.resolve(INVESTOR_MODULE)
+  const eventService = req.scope.resolve(Modules.EVENT_BUS)
+
+  // Re-invite path: if an investor admin already exists for this email, don't try
+  // to create a duplicate (which would fail with "auth already exists"). Instead
+  // regenerate the password, ensure the pipeline link to THIS company exists, and
+  // re-send the onboarding email with the fresh temp password.
+  const { data: existingAdmins } = await query.graph({
+    entity: "investor_admin",
+    fields: ["id", "email", "investor_id", "investor.*"],
+    filters: { email: admin.email },
+  })
+  const existingAdmin = existingAdmins?.[0]
+
+  if (existingAdmin?.investor_id) {
+    const { result: reset, errors: resetErrors } =
+      await resetInvestorAdminPasswordWorkflow(req.scope).run({
+        input: { email: admin.email },
+      })
+    if (resetErrors?.length) {
+      throw (
+        resetErrors[0].error ||
+        new MedusaError(
+          MedusaError.Types.UNEXPECTED_STATE,
+          "Failed to reset investor password"
+        )
+      )
+    }
+
+    // Ensure a pipeline row links this existing investor to this company.
+    const { data: pipelines } = await query.graph({
+      entity: "investor_pipeline",
+      fields: ["id"],
+      filters: { investor_id: existingAdmin.investor_id, company_id: companyId },
+    })
+    if (!pipelines?.length) {
+      await investorService.createPipelines({
+        investor_id: existingAdmin.investor_id,
+        company_id: companyId,
+        stage: "lead",
+        status: "active",
+      } as any)
+    }
+
+    eventService.emit({
+      name: "investor.created.fromAdmin",
+      data: {
+        investor_id: existingAdmin.investor_id,
+        investor_admin_id: existingAdmin.id,
+        email: admin.email,
+        temp_password: (reset as any).tempPassword,
+        company_id: companyId,
+      },
+    })
+
+    return res.status(200).json({
+      investor: (existingAdmin as any).investor,
+      investor_admin: existingAdmin,
+      reinvited: true,
+    })
+  }
+
   if (!investorData.handle) {
     investorData.handle = `inv-${Date.now()}-${Math.random()
       .toString(36)
@@ -63,7 +129,6 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   const investorId = payload.investorWithAdmin.createdInvestor.id
 
   // Link the new investor to this company via a pipeline row.
-  const investorService: InvestorService = req.scope.resolve(INVESTOR_MODULE)
   await investorService.createPipelines({
     investor_id: investorId,
     company_id: companyId,
@@ -71,7 +136,6 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
     status: "active",
   } as any)
 
-  const eventService = req.scope.resolve(Modules.EVENT_BUS)
   eventService.emit({
     name: "investor.created.fromAdmin",
     data: {

--- a/apps/backend/src/workflows/investor/create-investor-admin.ts
+++ b/apps/backend/src/workflows/investor/create-investor-admin.ts
@@ -106,26 +106,126 @@ export type CreateInvestorAdminWithRegistrationInput = Omit<
   "authIdentityId"
 >
 
+const hashPassword = async (plain: string) => {
+  const hashConfig = { logN: 15, r: 8, p: 1 }
+  const hashed = await Scrypt.kdf(Buffer.from(plain), hashConfig)
+  return hashed.toString("base64")
+}
+
+// Find the existing emailpass provider identity for an email (Medusa v2 keys it by
+// entity_id = email). Returns undefined if this email has never authenticated.
+const findEmailpassIdentity = async (
+  authModule: IAuthModuleService,
+  email: string
+) => {
+  const identities = await authModule.listProviderIdentities({
+    entity_id: email,
+  } as any)
+  return (identities || []).find((pi: any) => pi.provider === "emailpass")
+}
+
 const registerInvestorAdminAuthStep = createStep(
   "register-investor-admin-auth-step",
   async (input: { email: string; tempPassword?: string }, { container }) => {
-    const hashConfig = { logN: 15, r: 8, p: 1 }
     const plainPassword = input.tempPassword || randomBytes(12).toString("base64")
-    const hashed = await Scrypt.kdf(Buffer.from(plainPassword), hashConfig)
+    const passwordHash = await hashPassword(plainPassword)
 
     const authModule = container.resolve(Modules.AUTH) as IAuthModuleService
+
+    // If an emailpass identity already exists for this email (e.g. the person is
+    // already a partner/user, or a prior invite half-completed), don't fail with
+    // "auth already exists" — regenerate its password so this invite doubles as a
+    // password reset. setAuthAppMetadataStep then adds the investor actor mapping
+    // (it's keyed per actor type, so any existing partner/user mapping is kept).
+    const existing = await findEmailpassIdentity(authModule, input.email)
+    if (existing) {
+      const previousProviderMetadata = existing.provider_metadata || {}
+      await authModule.updateProviderIdentities({
+        id: existing.id,
+        provider_metadata: { ...previousProviderMetadata, password: passwordHash },
+      } as any)
+      return new StepResponse(
+        { authIdentityId: existing.auth_identity_id, tempPassword: plainPassword, reused: true },
+        {
+          mode: "reset" as const,
+          providerIdentityId: existing.id,
+          previousProviderMetadata,
+        }
+      )
+    }
+
     const reg = await authModule.createAuthIdentities({
       provider_identities: [
         {
           provider: "emailpass",
           entity_id: input.email,
-          provider_metadata: {
-            password: hashed.toString("base64"),
-          },
+          provider_metadata: { password: passwordHash },
         },
       ],
     })
-    return new StepResponse({ authIdentityId: reg.id, tempPassword: plainPassword })
+    return new StepResponse(
+      { authIdentityId: reg.id, tempPassword: plainPassword, reused: false },
+      { mode: "create" as const, authIdentityId: reg.id }
+    )
+  },
+  async (rollback, { container }) => {
+    if (!rollback) return
+    const authModule = container.resolve(Modules.AUTH) as IAuthModuleService
+    if (rollback.mode === "reset" && rollback.providerIdentityId) {
+      // Restore the previous password (don't delete an identity we didn't create).
+      await authModule.updateProviderIdentities({
+        id: rollback.providerIdentityId,
+        provider_metadata: rollback.previousProviderMetadata,
+      } as any)
+    } else if (rollback.mode === "create" && rollback.authIdentityId) {
+      await authModule.deleteAuthIdentities([rollback.authIdentityId])
+    }
+  }
+)
+
+// Reset (regenerate) an existing investor's emailpass password — used by the
+// admin re-invite path when the investor already exists in the system.
+export const resetInvestorAdminAuthStep = createStep(
+  "reset-investor-admin-auth-step",
+  async (input: { email: string; tempPassword?: string }, { container }) => {
+    const authModule = container.resolve(Modules.AUTH) as IAuthModuleService
+    const existing = await findEmailpassIdentity(authModule, input.email)
+    if (!existing) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `No emailpass auth identity found for ${input.email}`
+      )
+    }
+
+    const plainPassword = input.tempPassword || randomBytes(12).toString("base64")
+    const passwordHash = await hashPassword(plainPassword)
+    const previousProviderMetadata = existing.provider_metadata || {}
+
+    await authModule.updateProviderIdentities({
+      id: existing.id,
+      provider_metadata: { ...previousProviderMetadata, password: passwordHash },
+    } as any)
+
+    return new StepResponse(
+      { authIdentityId: existing.auth_identity_id, tempPassword: plainPassword },
+      { providerIdentityId: existing.id, previousProviderMetadata }
+    )
+  },
+  async (rollback, { container }) => {
+    if (!rollback?.providerIdentityId) return
+    const authModule = container.resolve(Modules.AUTH) as IAuthModuleService
+    await authModule.updateProviderIdentities({
+      id: rollback.providerIdentityId,
+      provider_metadata: rollback.previousProviderMetadata,
+    } as any)
+  }
+)
+
+export const resetInvestorAdminPasswordWorkflow = createWorkflow(
+  "reset-investor-admin-password",
+  (input: { email: string; tempPassword?: string }) => {
+    const reset = resetInvestorAdminAuthStep(input)
+    return new WorkflowResponse(reset)
   }
 )
 


### PR DESCRIPTION
## Problem

Inviting an investor whose email already has an auth identity dead-ended:
`authModule.createAuthIdentities` throws **"auth already exists"**, and because the
`investor.email` unique index also blocks a second investor, the invite could never
succeed — there was no way to re-provision / reset a stuck investor from the admin.

## Fix — the invite now doubles as a re-invite / password reset

- **Route** (`admin/companies/:id/investors` POST): if an `investor_admin` already
  exists for the email, **reuse that investor** — regenerate its emailpass password
  (`resetInvestorAdminPasswordWorkflow`), ensure a pipeline row links it to *this*
  company (idempotent), and re-emit `investor.created.fromAdmin` so the onboarding
  email is re-sent with the fresh temp password. Returns `{ reinvited: true }` (200).
- **Workflow safety net**: `registerInvestorAdminAuthStep` now regenerates the
  password when an emailpass identity already exists (covers "email is a partner/user
  but not yet an investor") instead of throwing. `setAuthAppMetadataStep` then adds
  the investor actor mapping — app_metadata is per-actor-type, so any existing
  partner/user mapping is preserved. Added proper compensation (restore the previous
  password on a reset; only delete auth identities we actually created).
- **Admin UI**: invite success toast reflects the re-invite/reset case.

## Verification

`medusa exec` throwaway covering both paths:
- **A)** existing-investor re-invite → password reset, **single** investor record (no duplicate).
- **B)** auth exists but no investor → no throw, password reset (`reused=true`).

Both passed. No schema/migration changes.