### PR TITLE
fix(investor-ui): restore settings dropdown link to /settings/profile

### DIFF
--- a/apps/investor-ui/src/components/layout/main-layout/main-layout.tsx
+++ b/apps/investor-ui/src/components/layout/main-layout/main-layout.tsx
@@ -155,8 +155,8 @@ const Header = () => {
             </div>
             <DropdownMenu.Separator />
             <DropdownMenu.Item className="gap-x-2" asChild>
-              <Link to="/">
-                <ChartPie className="text-ui-fg-subtle" />
+              <Link to="/settings/profile">
+                <CogSixTooth className="text-ui-fg-subtle" />
                 {t("app.nav.settings.header")}
               </Link>
             </DropdownMenu.Item>


### PR DESCRIPTION
The header popup dropdown's Settings link was incorrectly changed to `/` in #1000. Restored it to `/settings/profile` and changed the icon from `ChartPie` to `CogSixTooth` for correctness.