### PR TITLE
feat(investor): CCPS/iSAFE instrument + convertible→equity/CCPS conversion

### DIFF
--- a/apps/backend/src/admin/components/companies/cap-table-section.tsx
+++ b/apps/backend/src/admin/components/companies/cap-table-section.tsx
@@ -9,7 +9,7 @@ import {
   toast,
   useDataTable,
 } from "@medusajs/ui"
-import { CurrencyDollar, DocumentText, Plus, RocketLaunch, Users } from "@medusajs/icons"
+import { ArrowPath, CurrencyDollar, DocumentText, Plus, RocketLaunch, Users } from "@medusajs/icons"
 import { useMemo } from "react"
 import { Link } from "react-router-dom"
 import { ActionMenu } from "../common/action-menu"
@@ -231,9 +231,13 @@ const FundingRoundsTable = ({ capTable }: { capTable: AdminCapTable }) => {
         header: "Type",
         accessorKey: "round_type",
         cell: ({ row }: any) => {
+          const it = row.original.instrument_type
+          if (it === "ccps" || row.original.round_type === "ccps") {
+            return <Badge size="2xsmall" color="blue">CCPS</Badge>
+          }
           const isSafe =
-            row.original.instrument_type === "safe" ||
-            row.original.instrument_type === "convertible_note" ||
+            it === "safe" ||
+            it === "convertible_note" ||
             row.original.round_type === "safe"
           return isSafe ? (
             <Badge size="2xsmall" color="purple">SAFE</Badge>
@@ -313,11 +317,15 @@ const ConvertiblesTable = ({ capTable }: { capTable: AdminCapTable }) => {
       {
         header: "Instrument",
         accessorKey: "instrument_type",
-        cell: ({ row }: any) => (
-          <Badge size="2xsmall" color="purple">
-            {row.original.instrument_type === "convertible_note" ? "Note" : "SAFE"}
-          </Badge>
-        ),
+        cell: ({ row }: any) => {
+          const it = row.original.instrument_type
+          if (it === "ccps") return <Badge size="2xsmall" color="blue">CCPS</Badge>
+          return (
+            <Badge size="2xsmall" color="purple">
+              {it === "convertible_note" ? "Loan" : "SAFE"}
+            </Badge>
+          )
+        },
       },
       {
         header: "Principal",
@@ -354,6 +362,7 @@ const ConvertiblesTable = ({ capTable }: { capTable: AdminCapTable }) => {
         cell: ({ row }: any) => {
           const c = row.original as AdminConvertible
           const approved = !!c.metadata?.approved
+          const isOutstanding = (c.status ?? "outstanding") === "outstanding"
           return (
             <div className="flex justify-end">
               <ActionMenu
@@ -365,6 +374,15 @@ const ConvertiblesTable = ({ capTable }: { capTable: AdminCapTable }) => {
                         label: "Approve (generate pay link)",
                         disabled: approved,
                         onClick: () => approve(c.id),
+                      },
+                      {
+                        icon: <ArrowPath />,
+                        label:
+                          c.instrument_type === "convertible_note"
+                            ? "Convert (loan → CCPS/equity)"
+                            : "Convert to equity/CCPS",
+                        disabled: !isOutstanding,
+                        to: `convert-convertible?convertible_id=${c.id}`,
                       },
                     ],
                   },

--- a/apps/backend/src/admin/hooks/api/cap-tables-admin.ts
+++ b/apps/backend/src/admin/hooks/api/cap-tables-admin.ts
@@ -23,7 +23,7 @@ export type AdminFundingRound = {
   id: string
   name: string
   round_type?: string
-  instrument_type?: "equity" | "safe" | "convertible_note"
+  instrument_type?: "equity" | "safe" | "convertible_note" | "ccps"
   status?: string
   target_amount?: number | null
   raised_amount?: number | null
@@ -88,7 +88,7 @@ export type CreateShareClassPayload = {
 export type CreateFundingRoundPayload = {
   name: string
   round_type?: string
-  instrument_type?: "equity" | "safe" | "convertible_note"
+  instrument_type?: "equity" | "safe" | "convertible_note" | "ccps"
   status?: string
   target_amount?: number | null
   pre_money_valuation?: number | null
@@ -261,17 +261,29 @@ export type AdminParticipation = {
   payments?: Array<{ id: string; amount?: number | null; status?: string; metadata?: Record<string, any> | null }>
 }
 
+export type ConvertibleInstrument = "safe" | "convertible_note" | "ccps"
+
 export type AdminConvertible = {
   id: string
   investor_id?: string | null
-  instrument_type?: "safe" | "convertible_note"
+  instrument_type?: ConvertibleInstrument
   principal_amount?: number | null
   currency_code?: string | null
   valuation_cap?: number | null
   discount_rate?: number | null
   safe_type?: "post_money" | "pre_money"
+  // CCPS-only preference terms.
+  num_shares?: number | null
+  liquidation_preference_multiple?: number | null
+  dividend_rate?: number | null
+  conversion_ratio?: number | null
+  // Convertible-note-only.
+  interest_rate?: number | null
+  maturity_date?: string | null
   status?: string
   investment_date?: string | null
+  conversion_shares?: number | null
+  conversion_price_per_share?: number | null
   metadata?: Record<string, any> | null
   investor?: { id: string; name?: string; email?: string } | null
   payments?: Array<{ id: string; amount?: number | null; status?: string }>
@@ -287,14 +299,34 @@ export type AdminConvertible = {
 export type ProvisionConvertiblePayload = {
   investor_id?: string
   investor?: { name: string; email?: string; investor_type?: "individual" | "entity" | "fund" }
-  instrument_type?: "safe" | "convertible_note"
+  instrument_type?: ConvertibleInstrument
   principal_amount: number
   valuation_cap?: number | null
   discount_rate?: number | null
   safe_type?: "post_money" | "pre_money"
+  num_shares?: number | null
+  liquidation_preference_multiple?: number | null
+  dividend_rate?: number | null
+  conversion_ratio?: number | null
+  interest_rate?: number | null
+  maturity_date?: string | null
   investment_date?: string | null
   status?: "outstanding" | "converted" | "redeemed" | "cancelled" | "expired"
   notes?: string | null
+}
+
+export type ConvertConvertiblePayload = {
+  target?: "equity" | "ccps"
+  round_price_per_share?: number | null
+  fully_diluted_shares?: number | null
+  funding_round_id?: string | null
+  share_class_id?: string | null
+  shares?: number | null
+  price_per_share?: number | null
+  conversion_date?: string | null
+  liquidation_preference_multiple?: number | null
+  dividend_rate?: number | null
+  conversion_ratio?: number | null
 }
 
 export const convertiblesQueryKey = (capTableId: string) =>
@@ -354,6 +386,32 @@ export const useApproveConvertible = (
     onSuccess: (...args: any[]) => {
       queryClient.invalidateQueries({ queryKey: convertiblesQueryKey(capTableId) })
       queryClient.invalidateQueries({ queryKey: ["admin-round-participations"] })
+      ;(options?.onSuccess as any)?.(...args)
+    },
+  })
+}
+
+// Convert an outstanding convertible into equity (a stake) or CCPS shares.
+export const useConvertConvertible = (
+  capTableId: string,
+  options?: UseMutationOptions<
+    { target: "equity" | "ccps"; stake?: AdminStake; convertible?: AdminConvertible },
+    FetchError,
+    { convertibleId: string; payload: ConvertConvertiblePayload }
+  >
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    ...options,
+    mutationFn: ({ convertibleId, payload }) =>
+      sdk.client.fetch(`/admin/convertibles/${convertibleId}/convert`, {
+        method: "POST",
+        body: payload,
+      }),
+    onSuccess: (...args: any[]) => {
+      queryClient.invalidateQueries({ queryKey: convertiblesQueryKey(capTableId) })
+      queryClient.invalidateQueries({ queryKey: capTablesQueryKeys.detail(capTableId) })
+      queryClient.invalidateQueries({ queryKey: ["admin-company-cap-tables"] })
       ;(options?.onSuccess as any)?.(...args)
     },
   })

--- a/apps/backend/src/admin/routes/companies/[id]/@add-round/page.tsx
+++ b/apps/backend/src/admin/routes/companies/[id]/@add-round/page.tsx
@@ -31,7 +31,8 @@ const ROUND_TYPES = [
 const INSTRUMENTS = [
   { value: "equity", label: "Priced equity (shares)" },
   { value: "safe", label: "SAFE (converts later)" },
-  { value: "convertible_note", label: "Convertible note" },
+  { value: "convertible_note", label: "Convertible note / loan" },
+  { value: "ccps", label: "CCPS (iSAFE — preference shares)" },
 ] as const
 
 const AddRoundForm = ({ companyId }: { companyId: string }) => {
@@ -41,7 +42,7 @@ const AddRoundForm = ({ companyId }: { companyId: string }) => {
   const form = useForm({
     defaultValues: {
       name: "",
-      instrument_type: "equity" as "equity" | "safe" | "convertible_note",
+      instrument_type: "equity" as "equity" | "safe" | "convertible_note" | "ccps",
       round_type: "seed",
       target_amount: "",
       pre_money_valuation: "",
@@ -52,7 +53,11 @@ const AddRoundForm = ({ companyId }: { companyId: string }) => {
     },
   })
   const instrument = form.watch("instrument_type")
-  const isSafe = instrument === "safe" || instrument === "convertible_note"
+  // SAFE, note and CCPS all use the cap/discount economics and convert later.
+  const isSafe =
+    instrument === "safe" ||
+    instrument === "convertible_note" ||
+    instrument === "ccps"
   const { mutateAsync, isPending } = useCreateFundingRound(capTable?.id ?? "", {
     onSuccess: () => {
       toast.success("Funding round created")
@@ -65,13 +70,17 @@ const AddRoundForm = ({ companyId }: { companyId: string }) => {
       toast.error("Create a cap table first")
       return
     }
-    const safe = v.instrument_type === "safe" || v.instrument_type === "convertible_note"
+    const safe =
+      v.instrument_type === "safe" ||
+      v.instrument_type === "convertible_note" ||
+      v.instrument_type === "ccps"
     return mutateAsync({
       name: v.name,
       instrument_type: v.instrument_type,
-      // A SAFE/convertible round is tagged round_type "safe" so it reads clearly
-      // in the cap table; equity rounds keep the chosen stage.
-      round_type: safe ? "safe" : v.round_type,
+      // A SAFE/convertible/CCPS round is tagged by its instrument so it reads
+      // clearly in the cap table; equity rounds keep the chosen stage.
+      round_type:
+        v.instrument_type === "ccps" ? "ccps" : safe ? "safe" : v.round_type,
       status: "planned",
       target_amount: v.target_amount ? Number(v.target_amount) : null,
       pre_money_valuation:
@@ -115,8 +124,10 @@ const AddRoundForm = ({ companyId }: { companyId: string }) => {
             )}
           />
           <Text size="xsmall" className="text-ui-fg-muted">
-            {isSafe
-              ? "Participants invest now and receive a SAFE — equity is issued when it converts at a priced round."
+            {instrument === "ccps"
+              ? "Participants invest now and are allotted preference shares (CCPS) that mandatorily convert to equity at a priced round."
+              : isSafe
+              ? "Participants invest now and receive a SAFE/note — equity is issued when it converts at a priced round."
               : "Participants are allocated shares at the round price."}
           </Text>
         </div>

--- a/apps/backend/src/admin/routes/companies/[id]/@add-safe/page.tsx
+++ b/apps/backend/src/admin/routes/companies/[id]/@add-safe/page.tsx
@@ -23,7 +23,7 @@ type FormValues = {
   new_name: string
   new_email: string
   new_type: "individual" | "entity" | "fund"
-  instrument_type: "safe" | "convertible_note"
+  instrument_type: "safe" | "convertible_note" | "ccps"
   principal_amount: string
   valuation_cap: string
   discount_rate: string
@@ -31,6 +31,14 @@ type FormValues = {
   investment_date: string
   status: "outstanding" | "converted" | "redeemed" | "cancelled" | "expired"
   notes: string
+  // CCPS-only preference terms.
+  num_shares: string
+  liquidation_preference_multiple: string
+  dividend_rate: string
+  conversion_ratio: string
+  // Convertible-note (loan) terms.
+  interest_rate: string
+  maturity_date: string
 }
 
 // Record a (possibly historical) SAFE / convertible for an existing investor —
@@ -56,10 +64,19 @@ const AddSafeForm = ({ companyId }: { companyId: string }) => {
       safe_type: "post_money",
       investment_date: "",
       status: "outstanding",
+      num_shares: "",
+      liquidation_preference_multiple: "1",
+      dividend_rate: "",
+      conversion_ratio: "1",
+      interest_rate: "",
+      maturity_date: "",
     },
   })
 
   const mode = form.watch("mode")
+  const instrument = form.watch("instrument_type")
+  const isCcps = instrument === "ccps"
+  const isNote = instrument === "convertible_note"
   const ccy = capTable?.currency_code
 
   const { mutateAsync, isPending } = useProvisionConvertible(capTable?.id ?? "", {
@@ -94,6 +111,26 @@ const AddSafeForm = ({ companyId }: { companyId: string }) => {
         : null,
       status: v.status,
       notes: v.notes || null,
+      // CCPS preference terms (only sent for a CCPS instrument).
+      ...(v.instrument_type === "ccps"
+        ? {
+            num_shares: v.num_shares ? Number(v.num_shares) : null,
+            liquidation_preference_multiple: v.liquidation_preference_multiple
+              ? Number(v.liquidation_preference_multiple)
+              : null,
+            dividend_rate: v.dividend_rate ? Number(v.dividend_rate) / 100 : null,
+            conversion_ratio: v.conversion_ratio ? Number(v.conversion_ratio) : null,
+          }
+        : {}),
+      // Loan/note terms.
+      ...(v.instrument_type === "convertible_note"
+        ? {
+            interest_rate: v.interest_rate ? Number(v.interest_rate) / 100 : null,
+            maturity_date: v.maturity_date
+              ? new Date(v.maturity_date).toISOString()
+              : null,
+          }
+        : {}),
     })
   })
 
@@ -111,9 +148,10 @@ const AddSafeForm = ({ companyId }: { companyId: string }) => {
           </Text>
         )}
         <Text size="small" className="text-ui-fg-subtle">
-          Record a SAFE or convertible note directly — no shares are issued. Use
-          for an investor who already invested via SAFE. Value (implied ownership
-          + current value) is derived against the cap table valuation.
+          Record a SAFE, convertible note/loan, or CCPS directly. A SAFE/note
+          issues no shares yet; a CCPS allots preference shares now. Value
+          (implied ownership + current value) is derived against the cap table
+          valuation.
         </Text>
 
         {/* Investor: existing or new */}
@@ -199,7 +237,8 @@ const AddSafeForm = ({ companyId }: { companyId: string }) => {
                   <Select.Trigger><Select.Value /></Select.Trigger>
                   <Select.Content>
                     <Select.Item value="safe">SAFE</Select.Item>
-                    <Select.Item value="convertible_note">Convertible note</Select.Item>
+                    <Select.Item value="convertible_note">Convertible note / loan</Select.Item>
+                    <Select.Item value="ccps">CCPS (iSAFE — preference shares)</Select.Item>
                   </Select.Content>
                 </Select>
               )}
@@ -241,6 +280,51 @@ const AddSafeForm = ({ companyId }: { companyId: string }) => {
             <Input type="date" {...form.register("investment_date")} />
           </div>
         </div>
+
+        {isCcps && (
+          <div className="grid grid-cols-2 gap-4 rounded-lg border border-ui-border-strong p-3">
+            <div className="col-span-2">
+              <Text size="xsmall" className="text-ui-fg-muted">
+                CCPS (India iSAFE) — preference shares are allotted now, with a
+                liquidation-preference floor and a mandatory conversion to equity later.
+              </Text>
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label size="small" weight="plus">Shares allotted</Label>
+              <Input type="number" min="0" step="1" placeholder="1000" {...form.register("num_shares")} />
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label size="small" weight="plus">Liq. preference (x)</Label>
+              <Input type="number" min="0" step="any" placeholder="1" {...form.register("liquidation_preference_multiple")} />
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label size="small" weight="plus">Dividend (%)</Label>
+              <Input type="number" min="0" max="100" placeholder="0" {...form.register("dividend_rate")} />
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label size="small" weight="plus">Conversion ratio</Label>
+              <Input type="number" min="0" step="any" placeholder="1" {...form.register("conversion_ratio")} />
+            </div>
+          </div>
+        )}
+
+        {isNote && (
+          <div className="grid grid-cols-2 gap-4 rounded-lg border border-ui-border-strong p-3">
+            <div className="col-span-2">
+              <Text size="xsmall" className="text-ui-fg-muted">
+                Loan / convertible note — accrues interest until it converts or matures.
+              </Text>
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label size="small" weight="plus">Interest (% p.a.)</Label>
+              <Input type="number" min="0" max="100" step="any" placeholder="8" {...form.register("interest_rate")} />
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <Label size="small" weight="plus">Maturity date</Label>
+              <Input type="date" {...form.register("maturity_date")} />
+            </div>
+          </div>
+        )}
 
         <div className="flex flex-col gap-y-2">
           <Label size="small" weight="plus">Status</Label>

--- a/apps/backend/src/admin/routes/companies/[id]/@convert-convertible/page.tsx
+++ b/apps/backend/src/admin/routes/companies/[id]/@convert-convertible/page.tsx
@@ -1,0 +1,307 @@
+import {
+  Badge,
+  Button,
+  Heading,
+  Input,
+  Label,
+  Select,
+  Text,
+  toast,
+} from "@medusajs/ui"
+import { useMemo } from "react"
+import { Controller, useForm } from "react-hook-form"
+import { useParams, useSearchParams } from "react-router-dom"
+import { RouteDrawer } from "../../../../components/modal/route-drawer/route-drawer"
+import { useRouteModal } from "../../../../components/modal/use-route-modal"
+import {
+  useCompanyCapTables,
+  useCapTableConvertibles,
+  useConvertConvertible,
+  type AdminConvertible,
+} from "../../../../hooks/api/cap-tables-admin"
+
+const money = (v?: number | null, ccy?: string | null) =>
+  v == null ? "—" : `${ccy ? ccy + " " : ""}${new Intl.NumberFormat().format(Number(v))}`
+
+const INSTRUMENT_LABEL: Record<string, string> = {
+  safe: "SAFE",
+  convertible_note: "Loan / note",
+  ccps: "CCPS",
+}
+
+// Roughly how long ago the money went in — grounds the "a loan from 2 years ago"
+// story. Kept approximate on purpose (no exact-day precision needed).
+const agoLabel = (iso?: string | null): string | null => {
+  if (!iso) return null
+  const then = new Date(iso).getTime()
+  if (!Number.isFinite(then)) return null
+  const years = (Date.now() - then) / (365.25 * 24 * 3600 * 1000)
+  if (years < 0.08) return "recently"
+  if (years < 1) return `${Math.round(years * 12)} months ago`
+  return `${years.toFixed(years < 2 ? 1 : 0)} years ago`
+}
+
+type FormValues = {
+  target: "equity" | "ccps"
+  round_price_per_share: string
+  fully_diluted_shares: string
+  share_class_id: string
+  liquidation_preference_multiple: string
+  conversion_ratio: string
+}
+
+// Mirror of the server-side computeConversion, just for the live preview.
+const previewShares = (
+  c: AdminConvertible | undefined,
+  roundPrice: number,
+  fds: number
+): { price: number | null; shares: number | null; basis: string } => {
+  if (!c) return { price: null, shares: null, basis: "unknown" }
+  const principal = Number(c.principal_amount ?? 0)
+  const cap = Number(c.valuation_cap ?? 0)
+  const discount = Number(c.discount_rate ?? 0)
+  const capPrice = cap > 0 && fds > 0 ? cap / fds : null
+  const discountPrice =
+    roundPrice > 0 && discount > 0 && discount < 1 ? roundPrice * (1 - discount) : null
+  const candidates = [capPrice, discountPrice, roundPrice > 0 ? roundPrice : null].filter(
+    (v): v is number => v != null && v > 0
+  )
+  if (candidates.length) {
+    const price = Math.min(...candidates)
+    const basis =
+      price === capPrice ? "cap" : price === discountPrice ? "discount" : "round price"
+    return { price, shares: principal > 0 ? Math.round(principal / price) : null, basis }
+  }
+  if (c.num_shares && Number(c.num_shares) > 0) {
+    const ratio = Number(c.conversion_ratio ?? 1)
+    return {
+      price: null,
+      shares: Math.round(Number(c.num_shares) * ratio),
+      basis: "ratio",
+    }
+  }
+  return { price: null, shares: null, basis: "unknown" }
+}
+
+const ConvertForm = ({ companyId }: { companyId: string }) => {
+  const [params] = useSearchParams()
+  const convertibleId = params.get("convertible_id") || ""
+  const { cap_tables = [] } = useCompanyCapTables(companyId)
+  const capTable = cap_tables[0]
+  const { convertibles = [] } = useCapTableConvertibles(capTable?.id ?? "")
+  const convertible = convertibles.find((c) => c.id === convertibleId)
+  const { handleSuccess } = useRouteModal()
+  const ccy = capTable?.currency_code
+
+  const form = useForm<FormValues>({
+    defaultValues: {
+      target: "ccps",
+      round_price_per_share: "",
+      fully_diluted_shares: capTable?.fully_diluted_shares
+        ? String(capTable.fully_diluted_shares)
+        : "",
+      share_class_id: "",
+      liquidation_preference_multiple: "1",
+      conversion_ratio: "1",
+    },
+  })
+
+  const target = form.watch("target")
+  const roundPrice = Number(form.watch("round_price_per_share") || 0)
+  const fds = Number(form.watch("fully_diluted_shares") || 0)
+  const preview = useMemo(
+    () => previewShares(convertible, roundPrice, fds),
+    [convertible, roundPrice, fds]
+  )
+
+  const { mutateAsync, isPending } = useConvertConvertible(capTable?.id ?? "", {
+    onSuccess: (r) =>
+      toast.success(
+        r.target === "ccps" ? "Converted to CCPS shares" : "Converted to equity"
+      ),
+    onError: (e) => toast.error(e?.message || "Conversion failed"),
+  })
+
+  const shareClasses = capTable?.share_classes ?? []
+
+  const onSubmit = form.handleSubmit(async (v) => {
+    if (!convertible) {
+      toast.error("Instrument not found")
+      return
+    }
+    await mutateAsync({
+      convertibleId: convertible.id,
+      payload: {
+        target: v.target,
+        round_price_per_share: v.round_price_per_share
+          ? Number(v.round_price_per_share)
+          : null,
+        fully_diluted_shares: v.fully_diluted_shares
+          ? Number(v.fully_diluted_shares)
+          : null,
+        share_class_id: v.target === "equity" && v.share_class_id ? v.share_class_id : null,
+        liquidation_preference_multiple:
+          v.target === "ccps" && v.liquidation_preference_multiple
+            ? Number(v.liquidation_preference_multiple)
+            : null,
+        conversion_ratio:
+          v.target === "ccps" && v.conversion_ratio ? Number(v.conversion_ratio) : null,
+      },
+    })
+    handleSuccess()
+  })
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-1 flex-col">
+      <RouteDrawer.Header>
+        <RouteDrawer.Title asChild>
+          <Heading>Convert instrument</Heading>
+        </RouteDrawer.Title>
+      </RouteDrawer.Header>
+      <RouteDrawer.Body className="flex flex-1 flex-col gap-y-6 overflow-auto">
+        {!convertible ? (
+          <Text size="small" className="text-ui-fg-error">
+            Instrument not found on this cap table.
+          </Text>
+        ) : (
+          <>
+            {/* The instrument being converted — the "loan from 2 years ago" story. */}
+            <div className="rounded-lg border p-3">
+              <div className="mb-2 flex items-center gap-x-2">
+                <Badge size="2xsmall" color="purple">
+                  {INSTRUMENT_LABEL[convertible.instrument_type ?? "safe"] ?? "SAFE"}
+                </Badge>
+                <Text weight="plus">
+                  {convertible.investor?.name ?? convertible.investor_id ?? "Investor"}
+                </Text>
+              </div>
+              <Text size="small" className="text-ui-fg-subtle">
+                {money(convertible.principal_amount, ccy)} invested
+                {agoLabel(convertible.investment_date)
+                  ? ` · ${agoLabel(convertible.investment_date)}`
+                  : ""}
+                {convertible.valuation_cap
+                  ? ` · cap ${money(convertible.valuation_cap, ccy)}`
+                  : ""}
+                {convertible.discount_rate
+                  ? ` · ${(Number(convertible.discount_rate) * 100).toFixed(0)}% discount`
+                  : ""}
+              </Text>
+              {convertible.instrument_type === "convertible_note" && (
+                <Text size="xsmall" className="mt-1 text-ui-fg-muted">
+                  This loan will be turned into CCPS preference shares.
+                </Text>
+              )}
+            </div>
+
+            <div className="flex flex-col gap-y-2">
+              <Label size="small" weight="plus">Convert into</Label>
+              <Controller
+                control={form.control}
+                name="target"
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <Select.Trigger><Select.Value /></Select.Trigger>
+                    <Select.Content>
+                      <Select.Item value="ccps">CCPS (preference shares)</Select.Item>
+                      <Select.Item value="equity">Equity (common/preferred stake)</Select.Item>
+                    </Select.Content>
+                  </Select>
+                )}
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="flex flex-col gap-y-2">
+                <Label size="small" weight="plus">Round price / share {ccy ? `(${ccy})` : ""}</Label>
+                <Input type="number" min="0" step="any" placeholder="10" {...form.register("round_price_per_share")} />
+              </div>
+              <div className="flex flex-col gap-y-2">
+                <Label size="small" weight="plus">Fully-diluted shares</Label>
+                <Input type="number" min="0" step="1" placeholder="1000000" {...form.register("fully_diluted_shares")} />
+              </div>
+            </div>
+
+            {target === "equity" && shareClasses.length > 0 && (
+              <div className="flex flex-col gap-y-2">
+                <Label size="small" weight="plus">Target share class (optional)</Label>
+                <Controller
+                  control={form.control}
+                  name="share_class_id"
+                  render={({ field }) => (
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <Select.Trigger><Select.Value placeholder="Unassigned" /></Select.Trigger>
+                      <Select.Content>
+                        {shareClasses.map((sc) => (
+                          <Select.Item key={sc.id} value={sc.id}>
+                            {sc.name} ({sc.class_type ?? "common"})
+                          </Select.Item>
+                        ))}
+                      </Select.Content>
+                    </Select>
+                  )}
+                />
+              </div>
+            )}
+
+            {target === "ccps" && (
+              <div className="grid grid-cols-2 gap-4">
+                <div className="flex flex-col gap-y-2">
+                  <Label size="small" weight="plus">Liq. preference (x)</Label>
+                  <Input type="number" min="0" step="any" {...form.register("liquidation_preference_multiple")} />
+                </div>
+                <div className="flex flex-col gap-y-2">
+                  <Label size="small" weight="plus">Conversion ratio</Label>
+                  <Input type="number" min="0" step="any" {...form.register("conversion_ratio")} />
+                </div>
+              </div>
+            )}
+
+            {/* Live preview of the conversion outcome. */}
+            <div className="rounded-lg border border-ui-border-strong bg-ui-bg-subtle p-3">
+              <Text size="small" weight="plus">Preview</Text>
+              {preview.shares != null ? (
+                <Text size="small" className="mt-1 text-ui-fg-subtle">
+                  ≈ <span className="text-ui-fg-base">{new Intl.NumberFormat().format(preview.shares)}</span>{" "}
+                  {target === "ccps" ? "CCPS" : "equity"} shares
+                  {preview.price != null ? ` @ ${money(preview.price, ccy)}/share` : ""}
+                  {" "}<span className="text-ui-fg-muted">({preview.basis})</span>
+                </Text>
+              ) : (
+                <Text size="small" className="mt-1 text-ui-fg-muted">
+                  Enter a round price per share (and fully-diluted shares) to preview.
+                </Text>
+              )}
+            </div>
+          </>
+        )}
+      </RouteDrawer.Body>
+      <RouteDrawer.Footer>
+        <div className="flex items-center justify-end gap-x-2">
+          <RouteDrawer.Close asChild>
+            <Button size="small" variant="secondary">Cancel</Button>
+          </RouteDrawer.Close>
+          <Button
+            size="small"
+            type="submit"
+            isLoading={isPending}
+            disabled={!convertible || preview.shares == null}
+          >
+            Convert
+          </Button>
+        </div>
+      </RouteDrawer.Footer>
+    </form>
+  )
+}
+
+const ConvertConvertiblePage = () => {
+  const { id } = useParams()
+  return (
+    <RouteDrawer>
+      <ConvertForm companyId={id!} />
+    </RouteDrawer>
+  )
+}
+
+export default ConvertConvertiblePage

--- a/apps/backend/src/api/admin/convertibles/[id]/convert/route.ts
+++ b/apps/backend/src/api/admin/convertibles/[id]/convert/route.ts
@@ -1,0 +1,133 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { INVESTOR_MODULE } from "../../../../../modules/investor"
+import type InvestorService from "../../../../../modules/investor/service"
+import { convertConvertibleSchema } from "../../../../investors/validators"
+import { computeConversion } from "../../../../../modules/investor/lib/convertible-conversion"
+
+// POST /admin/convertibles/:id/convert — execute the conversion of an
+// outstanding convertible (SAFE / note / loan) into real equity.
+//
+//  - target=equity → mints a Stake (shares) against the chosen share class and
+//    records converted_stake_id on the convertible.
+//  - target=ccps   → mints a NEW convertible tagged `ccps` with the computed
+//    share count + preference terms (e.g. a 2-year-old loan becoming CCPS). The
+//    original is marked converted and linked via metadata.converted_to.
+//
+// Conversion price/shares are derived from the cap/discount vs the priced round
+// (see computeConversion). Idempotent-guarded: only `outstanding` can convert.
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const body = convertConvertibleSchema.parse(req.body ?? {})
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+  const service: InvestorService = req.scope.resolve(INVESTOR_MODULE)
+
+  const { data } = await query.graph({
+    entity: "convertible",
+    filters: { id: req.params.id },
+    fields: [
+      "*",
+      "cap_table.id",
+      "cap_table.fully_diluted_shares",
+      "cap_table.currency_code",
+    ],
+  })
+  const convertible = data?.[0] as any
+  if (!convertible) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Convertible not found")
+  }
+  if (convertible.status !== "outstanding") {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      `Only an outstanding instrument can be converted (this one is ${convertible.status})`
+    )
+  }
+
+  const conversion = computeConversion(convertible, {
+    round_price_per_share: body.round_price_per_share,
+    fully_diluted_shares:
+      body.fully_diluted_shares ?? convertible.cap_table?.fully_diluted_shares,
+    shares: body.shares,
+    price_per_share: body.price_per_share,
+  })
+  if (conversion.conversion_shares == null || conversion.conversion_shares <= 0) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "Cannot derive a share count — supply a round price per share (and fully-diluted shares) or an explicit share count."
+    )
+  }
+
+  const when = body.conversion_date ? new Date(body.conversion_date) : new Date()
+  const currency =
+    convertible.currency_code || convertible.cap_table?.currency_code || null
+  const principal = Number(convertible.principal_amount ?? 0)
+
+  if (body.target === "ccps") {
+    // Loan/SAFE → CCPS: issue preference shares now (a new ccps convertible),
+    // carrying the computed share count + preference terms.
+    const ccps: any = await service.createConvertibles({
+      investor_id: convertible.investor_id,
+      cap_table_id: convertible.cap_table_id,
+      funding_round_id: body.funding_round_id ?? null,
+      instrument_type: "ccps",
+      principal_amount: principal,
+      currency_code: currency,
+      valuation_cap: convertible.valuation_cap ?? null,
+      discount_rate: convertible.discount_rate ?? null,
+      safe_type: convertible.safe_type ?? "post_money",
+      num_shares: conversion.conversion_shares,
+      liquidation_preference_multiple: body.liquidation_preference_multiple ?? 1,
+      dividend_rate: body.dividend_rate ?? null,
+      conversion_ratio: body.conversion_ratio ?? 1,
+      investment_date: convertible.investment_date ?? when,
+      status: "outstanding",
+      notes: `Converted from ${convertible.instrument_type} ${convertible.id}`,
+      metadata: { converted_from: convertible.id },
+    } as any)
+
+    await service.updateConvertibles({
+      id: convertible.id,
+      status: "converted",
+      conversion_date: when,
+      conversion_shares: conversion.conversion_shares,
+      conversion_price_per_share: conversion.conversion_price_per_share,
+      metadata: {
+        ...(convertible.metadata || {}),
+        converted_to: ccps.id,
+        conversion_target: "ccps",
+        conversion_basis: conversion.basis,
+      },
+    } as any)
+
+    return res.status(201).json({ target: "ccps", convertible: ccps, conversion })
+  }
+
+  // SAFE / note / loan → priced equity: mint a Stake.
+  const stake: any = await service.createStakes({
+    investor_id: convertible.investor_id,
+    cap_table_id: convertible.cap_table_id,
+    share_class_id: body.share_class_id ?? null,
+    funding_round_id: body.funding_round_id ?? null,
+    number_of_shares: conversion.conversion_shares,
+    share_price: conversion.conversion_price_per_share,
+    total_invested: principal,
+    issue_date: when,
+    status: "active",
+    metadata: { converted_from: convertible.id },
+  } as any)
+
+  await service.updateConvertibles({
+    id: convertible.id,
+    status: "converted",
+    converted_stake_id: stake.id,
+    conversion_date: when,
+    conversion_shares: conversion.conversion_shares,
+    conversion_price_per_share: conversion.conversion_price_per_share,
+    metadata: {
+      ...(convertible.metadata || {}),
+      conversion_target: "equity",
+      conversion_basis: conversion.basis,
+    },
+  } as any)
+
+  res.status(201).json({ target: "equity", stake, conversion })
+}

--- a/apps/backend/src/api/investors/deals/[id]/participate/route.ts
+++ b/apps/backend/src/api/investors/deals/[id]/participate/route.ts
@@ -29,6 +29,7 @@ export const POST = async (
       "discount_rate",
       "safe_type",
       "cap_table.currency_code",
+      "metadata",
     ],
   })
   const round = data?.[0] as any
@@ -44,18 +45,39 @@ export const POST = async (
     throw new MedusaError(MedusaError.Types.INVALID_DATA, "A positive amount is required")
   }
 
-  // SAFE / convertible round → issue a Convertible (no shares yet), not a Stake.
+  // SAFE / convertible / CCPS round → issue a Convertible instrument, not a
+  // Stake. A CCPS (iSAFE) additionally allots preference shares up front, so we
+  // record `num_shares` + a default 1x liquidation preference; the cap/discount
+  // conversion economics are shared with the SAFE path.
+  const isCcps = round.instrument_type === "ccps"
   const isConvertible =
+    isCcps ||
     round.instrument_type === "safe" ||
     round.instrument_type === "convertible_note" ||
-    round.round_type === "safe"
+    round.round_type === "safe" ||
+    round.round_type === "ccps"
   if (isConvertible) {
+    const instrument_type = isCcps
+      ? "ccps"
+      : round.instrument_type === "convertible_note"
+      ? "convertible_note"
+      : "safe"
+
+    const pps = Number(round.price_per_share ?? 0)
+    const ccpsExtras = isCcps
+      ? {
+          num_shares: pps > 0 ? Math.round(amount / pps) : null,
+          liquidation_preference_multiple:
+            Number(round.metadata?.liquidation_preference_multiple ?? 1),
+          conversion_ratio: Number(round.metadata?.conversion_ratio ?? 1),
+        }
+      : {}
+
     const created = await service.createConvertibles({
       investor_id: investor.id,
       cap_table_id: round.cap_table_id,
       funding_round_id: round.id,
-      instrument_type:
-        round.instrument_type === "convertible_note" ? "convertible_note" : "safe",
+      instrument_type,
       principal_amount: amount,
       currency_code: round.cap_table?.currency_code ?? null,
       valuation_cap: round.valuation_cap ?? null,
@@ -63,6 +85,7 @@ export const POST = async (
       safe_type: round.safe_type ?? "post_money",
       investment_date: new Date(),
       status: "outstanding",
+      ...ccpsExtras,
     } as any)
 
     return res.status(201).json({ convertible: created })

--- a/apps/backend/src/api/investors/validators.ts
+++ b/apps/backend/src/api/investors/validators.ts
@@ -75,7 +75,7 @@ export const shareClassSchema = z.object({
   cap_table_id: z.string().optional(),
   name: z.string(),
   class_type: z.enum([
-    "common", "preferred", "convertible_note", "safe", "warrant", "option",
+    "common", "preferred", "convertible_note", "safe", "ccps", "warrant", "option",
   ]).optional(),
   authorized_shares: z.number().nullable().optional(),
   issued_shares: z.number().nullable().optional(),
@@ -112,7 +112,7 @@ export const convertibleSchema = z.object({
   investor_id: z.string().optional(),
   cap_table_id: z.string().optional(),
   funding_round_id: z.string().nullable().optional(),
-  instrument_type: z.enum(["safe", "convertible_note"]).optional(),
+  instrument_type: z.enum(["safe", "convertible_note", "ccps"]).optional(),
   principal_amount: z.number().positive(),
   currency_code: z.string().nullable().optional(),
   valuation_cap: z.number().positive().nullable().optional(),
@@ -120,6 +120,11 @@ export const convertibleSchema = z.object({
   safe_type: z.enum(["post_money", "pre_money"]).optional(),
   mfn: z.boolean().optional(),
   pro_rata: z.boolean().optional(),
+  // CCPS (iSAFE) preference terms.
+  num_shares: z.number().nonnegative().nullable().optional(),
+  liquidation_preference_multiple: z.number().min(0).nullable().optional(),
+  dividend_rate: z.number().min(0).max(1).nullable().optional(),
+  conversion_ratio: z.number().positive().nullable().optional(),
   interest_rate: z.number().min(0).max(1).nullable().optional(),
   maturity_date: z.string().datetime().nullable().optional(),
   investment_date: z.string().datetime().nullable().optional(),
@@ -130,6 +135,25 @@ export const convertibleSchema = z.object({
 })
 
 export const convertibleUpdateSchema = convertibleSchema.partial()
+
+// Convert an outstanding convertible into equity (a stake) or CCPS preference
+// shares. All pricing inputs optional — the engine derives from cap/discount.
+export const convertConvertibleSchema = z.object({
+  target: z.enum(["equity", "ccps"]).optional().default("equity"),
+  // The priced round the convertible converts at.
+  round_price_per_share: z.number().positive().nullable().optional(),
+  fully_diluted_shares: z.number().positive().nullable().optional(),
+  funding_round_id: z.string().nullable().optional(),
+  share_class_id: z.string().nullable().optional(),
+  // Explicit overrides.
+  shares: z.number().positive().nullable().optional(),
+  price_per_share: z.number().positive().nullable().optional(),
+  conversion_date: z.string().datetime().nullable().optional(),
+  // CCPS target preference terms.
+  liquidation_preference_multiple: z.number().min(0).nullable().optional(),
+  dividend_rate: z.number().min(0).max(1).nullable().optional(),
+  conversion_ratio: z.number().positive().nullable().optional(),
+})
 
 export const companyExpenseSchema = z.object({
   company_id: z.string().nullable().optional(),
@@ -152,9 +176,9 @@ export const fundingRoundSchema = z.object({
   name: z.string(),
   round_type: z.enum([
     "pre_seed", "seed", "series_a", "series_b", "series_c",
-    "series_d_plus", "bridge", "debt", "grant", "safe",
+    "series_d_plus", "bridge", "debt", "grant", "safe", "ccps",
   ]).optional(),
-  instrument_type: z.enum(["equity", "safe", "convertible_note"]).optional(),
+  instrument_type: z.enum(["equity", "safe", "convertible_note", "ccps"]).optional(),
   status: z.enum([
     "planned", "open", "closing", "closed", "cancelled",
   ]).optional(),

--- a/apps/backend/src/modules/investor/lib/__tests__/ccps.unit.spec.ts
+++ b/apps/backend/src/modules/investor/lib/__tests__/ccps.unit.spec.ts
@@ -1,0 +1,116 @@
+import { computeConvertibleValue } from "../convertible-value"
+import { computeConversion } from "../convertible-conversion"
+
+describe("computeConvertibleValue — CCPS liquidation-preference floor", () => {
+  it("floors a CCPS implied value at principal × multiple on a down round", () => {
+    // principal 1,000,000; cap 10,000,000 → 10% ownership. Reference valuation
+    // 5,000,000 (down round) would imply 500,000 — but the 1x preference floors
+    // it at the principal.
+    const v = computeConvertibleValue(
+      {
+        principal_amount: 1_000_000,
+        valuation_cap: 10_000_000,
+        safe_type: "post_money",
+        instrument_type: "ccps",
+        liquidation_preference_multiple: 1,
+      },
+      { referenceValuation: 5_000_000 }
+    )
+    expect(v.implied_value).toBe(1_000_000)
+    expect(v.multiple).toBe(1)
+  })
+
+  it("applies a 2x preference floor", () => {
+    const v = computeConvertibleValue(
+      {
+        principal_amount: 1_000_000,
+        valuation_cap: 10_000_000,
+        safe_type: "post_money",
+        instrument_type: "ccps",
+        liquidation_preference_multiple: 2,
+      },
+      { referenceValuation: 5_000_000 }
+    )
+    expect(v.implied_value).toBe(2_000_000)
+    expect(v.multiple).toBe(2)
+  })
+
+  it("does NOT floor when the implied value already exceeds the preference", () => {
+    // Up round: reference 20,000,000 → 10% = 2,000,000, well above the 1x floor.
+    const v = computeConvertibleValue(
+      {
+        principal_amount: 1_000_000,
+        valuation_cap: 10_000_000,
+        safe_type: "post_money",
+        instrument_type: "ccps",
+        liquidation_preference_multiple: 1,
+      },
+      { referenceValuation: 20_000_000 }
+    )
+    expect(v.implied_value).toBe(2_000_000)
+  })
+
+  it("does NOT apply the floor to a plain SAFE (non-CCPS)", () => {
+    const v = computeConvertibleValue(
+      {
+        principal_amount: 1_000_000,
+        valuation_cap: 10_000_000,
+        safe_type: "post_money",
+        instrument_type: "safe",
+        liquidation_preference_multiple: 1,
+      },
+      { referenceValuation: 5_000_000 }
+    )
+    expect(v.implied_value).toBe(500_000)
+  })
+})
+
+describe("computeConversion — SAFE/note/loan → equity or CCPS shares", () => {
+  it("uses the valuation cap price when it beats the round price", () => {
+    // cap 10,000,000 / 1,000,000 FDS = 10/share cap price vs 20 round price.
+    const r = computeConversion(
+      { principal_amount: 1_000_000, valuation_cap: 10_000_000 },
+      { round_price_per_share: 20, fully_diluted_shares: 1_000_000 }
+    )
+    expect(r.basis).toBe("cap")
+    expect(r.conversion_price_per_share).toBe(10)
+    expect(r.conversion_shares).toBe(100_000)
+  })
+
+  it("uses the discount price when there is no cap", () => {
+    // 20% discount off a 10 round price = 8/share.
+    const r = computeConversion(
+      { principal_amount: 800_000, discount_rate: 0.2 },
+      { round_price_per_share: 10 }
+    )
+    expect(r.basis).toBe("discount")
+    expect(r.conversion_price_per_share).toBe(8)
+    expect(r.conversion_shares).toBe(100_000)
+  })
+
+  it("honours an explicit share override", () => {
+    const r = computeConversion(
+      { principal_amount: 500_000 },
+      { shares: 5_000 }
+    )
+    expect(r.basis).toBe("explicit")
+    expect(r.conversion_shares).toBe(5_000)
+    expect(r.conversion_price_per_share).toBe(100)
+  })
+
+  it("converts a loan by ratio off pre-issued shares when no priced round is given", () => {
+    // A 2-year-old loan already carrying 1,000 pre-shares, 1:1 ratio.
+    const r = computeConversion(
+      { principal_amount: 1_000_000, num_shares: 1_000, conversion_ratio: 1 },
+      {}
+    )
+    expect(r.basis).toBe("ratio")
+    expect(r.conversion_shares).toBe(1_000)
+  })
+
+  it("returns nulls when nothing can be derived", () => {
+    const r = computeConversion({ principal_amount: 1_000_000 }, {})
+    expect(r.conversion_shares).toBeNull()
+    expect(r.basis).toBe("unknown")
+  })
+})

--- a/apps/backend/src/modules/investor/lib/convertible-conversion.ts
+++ b/apps/backend/src/modules/investor/lib/convertible-conversion.ts
@@ -1,0 +1,107 @@
+/**
+ * Compute the conversion of an outstanding convertible (SAFE / note / loan) into
+ * equity or CCPS shares (#969 follow-up). Pure — no I/O — so it's unit-testable
+ * and shared by the admin convert route.
+ *
+ * The conversion price is the price PER SHARE at which the invested principal
+ * buys shares. A SAFE/note holder gets the most favourable of:
+ *   - cap price      = valuation_cap / fully_diluted_shares  (the cap protects them)
+ *   - discount price = round_price × (1 − discount_rate)     (the discount rewards them)
+ * whichever is LOWER (more shares for the money). Falls back to the round price,
+ * then to any explicitly supplied price.
+ *
+ * Share count = principal / conversion_price. Callers may override with an
+ * explicit `shares` (e.g. a CCPS that converts by a fixed ratio, not by price).
+ */
+export type ConversionInput = {
+  principal_amount?: number | string | null
+  valuation_cap?: number | string | null
+  discount_rate?: number | null
+  // The CCPS-only path can convert by ratio off pre-issued shares instead of price.
+  num_shares?: number | string | null
+  conversion_ratio?: number | null
+}
+
+export type ConversionTerms = {
+  // The priced round the convertible converts at.
+  round_price_per_share?: number | string | null
+  fully_diluted_shares?: number | string | null
+  // Explicit overrides (win over the derived values when provided).
+  shares?: number | string | null
+  price_per_share?: number | string | null
+}
+
+export type ConversionResult = {
+  conversion_price_per_share: number | null
+  conversion_shares: number | null
+  basis: "cap" | "discount" | "round_price" | "ratio" | "explicit" | "unknown"
+}
+
+const num = (v: unknown): number | null => {
+  if (v === null || v === undefined || v === "") return null
+  const n = typeof v === "string" ? parseFloat(v) : (v as number)
+  return Number.isFinite(n) ? n : null
+}
+
+export function computeConversion(
+  c: ConversionInput,
+  terms: ConversionTerms = {}
+): ConversionResult {
+  const principal = num(c.principal_amount) ?? 0
+  const cap = num(c.valuation_cap)
+  const discount = num(c.discount_rate)
+  const roundPrice = num(terms.round_price_per_share)
+  const fds = num(terms.fully_diluted_shares)
+
+  // Explicit overrides win outright.
+  const explicitPrice = num(terms.price_per_share)
+  const explicitShares = num(terms.shares)
+  if (explicitShares != null && explicitShares > 0) {
+    const price =
+      explicitPrice ?? (principal > 0 ? principal / explicitShares : null)
+    return {
+      conversion_price_per_share: price,
+      conversion_shares: explicitShares,
+      basis: "explicit",
+    }
+  }
+
+  // Candidate per-share prices, cheapest first (cheaper → more shares → better
+  // for the holder). A CCPS/note that only carries a ratio and pre-issued shares
+  // converts by ratio when no priced round is supplied.
+  const capPrice = cap && cap > 0 && fds && fds > 0 ? cap / fds : null
+  const discountPrice =
+    roundPrice && roundPrice > 0 && discount && discount > 0 && discount < 1
+      ? roundPrice * (1 - discount)
+      : null
+
+  const candidates: Array<{ price: number; basis: ConversionResult["basis"] }> = []
+  if (capPrice != null) candidates.push({ price: capPrice, basis: "cap" })
+  if (discountPrice != null) candidates.push({ price: discountPrice, basis: "discount" })
+  if (roundPrice != null && roundPrice > 0)
+    candidates.push({ price: roundPrice, basis: "round_price" })
+
+  if (candidates.length) {
+    const best = candidates.reduce((a, b) => (b.price < a.price ? b : a))
+    const shares = best.price > 0 && principal > 0 ? principal / best.price : null
+    return {
+      conversion_price_per_share: best.price,
+      conversion_shares: shares != null ? Math.round(shares) : null,
+      basis: best.basis,
+    }
+  }
+
+  // No priced round → convert pre-issued shares by ratio (CCPS end-state → common).
+  const preShares = num(c.num_shares)
+  if (preShares != null && preShares > 0) {
+    const ratio = num(c.conversion_ratio) ?? 1
+    const shares = Math.round(preShares * ratio)
+    return {
+      conversion_price_per_share: shares > 0 && principal > 0 ? principal / shares : null,
+      conversion_shares: shares,
+      basis: "ratio",
+    }
+  }
+
+  return { conversion_price_per_share: null, conversion_shares: null, basis: "unknown" }
+}

--- a/apps/backend/src/modules/investor/lib/convertible-value.ts
+++ b/apps/backend/src/modules/investor/lib/convertible-value.ts
@@ -23,6 +23,12 @@ export type ConvertibleValueInput = {
   status?: string | null
   conversion_shares?: number | string | null
   conversion_price_per_share?: number | string | null
+  // CCPS (iSAFE) extras. A preference share carries a liquidation-preference
+  // floor: on a downside the holder gets back at least `principal × multiple`
+  // before common. Economically that's the only difference from a plain SAFE —
+  // cap/discount conversion math is otherwise identical.
+  instrument_type?: "safe" | "convertible_note" | "ccps" | null
+  liquidation_preference_multiple?: number | null
 }
 
 export type ConvertibleValue = {
@@ -50,6 +56,24 @@ export function computeConvertibleValue(
   const ref = num(opts.referenceValuation)
   const isPostMoney = (c.safe_type ?? "post_money") === "post_money"
 
+  // CCPS liquidation-preference floor: a preference holder can't be worth less
+  // than their guaranteed return, so no implied value should print below it.
+  const prefMultiple = num(c.liquidation_preference_multiple)
+  const prefFloor =
+    c.instrument_type === "ccps" && prefMultiple && prefMultiple > 0
+      ? principal * prefMultiple
+      : null
+  const applyFloor = (r: ConvertibleValue): ConvertibleValue => {
+    if (prefFloor == null || r.implied_value == null || r.implied_value >= prefFloor) {
+      return r
+    }
+    return {
+      ...r,
+      implied_value: prefFloor,
+      multiple: principal > 0 ? prefFloor / principal : r.multiple,
+    }
+  }
+
   // Already converted → value rides the resulting shares (caller can price the
   // linked stake); we surface the recorded conversion if present.
   if (c.status === "converted") {
@@ -70,13 +94,13 @@ export function computeConvertibleValue(
     const ownership = principal / cap
     const valuation = ref && ref > 0 ? ref : cap
     const value = ownership * valuation
-    return {
+    return applyFloor({
       principal,
       implied_ownership_pct: ownership,
       implied_value: value,
       multiple: principal > 0 ? value / principal : null,
       basis: ref && ref > 0 ? "reference_valuation" : "cap",
-    }
+    })
   }
 
   // Pre-money cap → approximate post-money as cap + this money in.
@@ -85,34 +109,34 @@ export function computeConvertibleValue(
     const ownership = principal / postMoney
     const valuation = ref && ref > 0 ? ref : postMoney
     const value = ownership * valuation
-    return {
+    return applyFloor({
       principal,
       implied_ownership_pct: ownership,
       implied_value: value,
       multiple: principal > 0 ? value / principal : null,
       basis: ref && ref > 0 ? "reference_valuation" : "cap",
-    }
+    })
   }
 
   // Discount-only (no cap): can't imply ownership without a round price; the
   // honest floor is the principal (optionally uplifted by the discount).
   if (discount && discount > 0 && discount < 1) {
     const value = principal / (1 - discount)
-    return {
+    return applyFloor({
       principal,
       implied_ownership_pct: null,
       implied_value: value,
       multiple: principal > 0 ? value / principal : null,
       basis: "principal",
-    }
+    })
   }
 
   // Nothing to imply from — show cost basis only.
-  return {
+  return applyFloor({
     principal,
     implied_ownership_pct: null,
     implied_value: principal || null,
     multiple: principal > 0 ? 1 : null,
     basis: principal > 0 ? "principal" : "unknown",
-  }
+  })
 }

--- a/apps/backend/src/modules/investor/migrations/Migration20260711220000.ts
+++ b/apps/backend/src/modules/investor/migrations/Migration20260711220000.ts
@@ -1,0 +1,58 @@
+import { Migration } from '@mikro-orm/migrations';
+
+// CCPS (Compulsorily Convertible Preference Shares — the Indian iSAFE legal
+// wrapper) — #969 follow-up.
+//
+// Rides the existing `convertible` instrument: same cap/discount conversion
+// economics as a SAFE, but shares are allotted up front (`num_shares`) and the
+// holder carries preference terms. This migration:
+//  - adds the CCPS columns to `convertible` (incl. the raw_ jsonb the bignumber
+//    `num_shares` needs — see the raw-column gotcha),
+//  - extends the instrument_type / class_type / round_type enum CHECKs to admit
+//    'ccps' on convertible, share_class and funding_round.
+// Idempotent (IF [NOT] EXISTS / drop-if-exists) so it's safe to re-run on boot.
+export class Migration20260711220000 extends Migration {
+
+  async up(): Promise<void> {
+    // --- convertible: CCPS columns ---
+    this.addSql(`alter table if exists "convertible" add column if not exists "num_shares" numeric null;`);
+    this.addSql(`alter table if exists "convertible" add column if not exists "raw_num_shares" jsonb null;`);
+    this.addSql(`alter table if exists "convertible" add column if not exists "liquidation_preference_multiple" real null;`);
+    this.addSql(`alter table if exists "convertible" add column if not exists "dividend_rate" real null;`);
+    this.addSql(`alter table if exists "convertible" add column if not exists "conversion_ratio" real null;`);
+
+    // --- convertible.instrument_type: allow 'ccps' ---
+    this.addSql(`alter table if exists "convertible" drop constraint if exists "convertible_instrument_type_check";`);
+    this.addSql(`alter table if exists "convertible" add constraint "convertible_instrument_type_check" check ("instrument_type" in ('safe', 'convertible_note', 'ccps'));`);
+
+    // --- share_class.class_type: allow 'ccps' ---
+    this.addSql(`alter table if exists "share_class" drop constraint if exists "share_class_class_type_check";`);
+    this.addSql(`alter table if exists "share_class" add constraint "share_class_class_type_check" check ("class_type" in ('common', 'preferred', 'convertible_note', 'safe', 'ccps', 'warrant', 'option'));`);
+
+    // --- funding_round.instrument_type + round_type: allow 'ccps' ---
+    this.addSql(`alter table if exists "funding_round" drop constraint if exists "funding_round_instrument_type_check";`);
+    this.addSql(`alter table if exists "funding_round" add constraint "funding_round_instrument_type_check" check ("instrument_type" in ('equity', 'safe', 'convertible_note', 'ccps'));`);
+    this.addSql(`alter table if exists "funding_round" drop constraint if exists "funding_round_round_type_check";`);
+    this.addSql(`alter table if exists "funding_round" add constraint "funding_round_round_type_check" check ("round_type" in ('pre_seed', 'seed', 'series_a', 'series_b', 'series_c', 'series_d_plus', 'bridge', 'debt', 'grant', 'safe', 'ccps'));`);
+  }
+
+  async down(): Promise<void> {
+    this.addSql(`alter table if exists "funding_round" drop constraint if exists "funding_round_round_type_check";`);
+    this.addSql(`alter table if exists "funding_round" add constraint "funding_round_round_type_check" check ("round_type" in ('pre_seed', 'seed', 'series_a', 'series_b', 'series_c', 'series_d_plus', 'bridge', 'debt', 'grant', 'safe'));`);
+    this.addSql(`alter table if exists "funding_round" drop constraint if exists "funding_round_instrument_type_check";`);
+    this.addSql(`alter table if exists "funding_round" add constraint "funding_round_instrument_type_check" check ("instrument_type" in ('equity', 'safe', 'convertible_note'));`);
+
+    this.addSql(`alter table if exists "share_class" drop constraint if exists "share_class_class_type_check";`);
+    this.addSql(`alter table if exists "share_class" add constraint "share_class_class_type_check" check ("class_type" in ('common', 'preferred', 'convertible_note', 'safe', 'warrant', 'option'));`);
+
+    this.addSql(`alter table if exists "convertible" drop constraint if exists "convertible_instrument_type_check";`);
+    this.addSql(`alter table if exists "convertible" add constraint "convertible_instrument_type_check" check ("instrument_type" in ('safe', 'convertible_note'));`);
+
+    this.addSql(`alter table if exists "convertible" drop column if exists "conversion_ratio";`);
+    this.addSql(`alter table if exists "convertible" drop column if exists "dividend_rate";`);
+    this.addSql(`alter table if exists "convertible" drop column if exists "liquidation_preference_multiple";`);
+    this.addSql(`alter table if exists "convertible" drop column if exists "raw_num_shares";`);
+    this.addSql(`alter table if exists "convertible" drop column if exists "num_shares";`);
+  }
+
+}

--- a/apps/backend/src/modules/investor/models/convertible.ts
+++ b/apps/backend/src/modules/investor/models/convertible.ts
@@ -31,7 +31,12 @@ const Convertible = model.define("convertible", {
   // stake models; resolve separately when needed.
   funding_round_id: model.text().nullable(),
 
-  instrument_type: model.enum(["safe", "convertible_note"]).default("safe"),
+  // `ccps` = Compulsorily Convertible Preference Shares (the Indian iSAFE legal
+  // wrapper): unlike a US SAFE, shares ARE issued now (`num_shares`) and the
+  // holder gets preference terms, but the SAFE-style cap/discount economics and
+  // the "converts to equity later" lifecycle are identical — so it rides the
+  // same instrument rather than a separate model.
+  instrument_type: model.enum(["safe", "convertible_note", "ccps"]).default("safe"),
 
   // The cash invested — the one certain number.
   principal_amount: model.bigNumber(),
@@ -43,6 +48,13 @@ const Convertible = model.define("convertible", {
   safe_type: model.enum(["post_money", "pre_money"]).default("post_money"),
   mfn: model.boolean().default(false),
   pro_rata: model.boolean().default(false),
+
+  // CCPS-only terms (null for a plain SAFE / note). Preference shares are
+  // allotted at investment, so they carry a share count + preference economics.
+  num_shares: model.bigNumber().nullable(),
+  liquidation_preference_multiple: model.number().nullable(), // e.g. 1 = 1x
+  dividend_rate: model.number().nullable(), // 0..1 annual (often nil for iSAFE)
+  conversion_ratio: model.number().nullable(), // e.g. 1 = 1:1 mandatory
 
   // Convertible-note-only terms.
   interest_rate: model.number().nullable(), // 0..1 annual

--- a/apps/backend/src/modules/investor/models/funding-round.ts
+++ b/apps/backend/src/modules/investor/models/funding-round.ts
@@ -21,11 +21,13 @@ const FundingRound = model.define("funding_round", {
     "debt",
     "grant",
     "safe",
+    "ccps",
   ]).default("seed"),
 
   // What participating in this round issues. `equity` → a Stake (shares);
-  // `safe` / `convertible_note` → a Convertible (money now, equity later).
-  instrument_type: model.enum(["equity", "safe", "convertible_note"]).default("equity"),
+  // `safe` / `convertible_note` / `ccps` → a Convertible (money now, equity
+  // later; `ccps` also allots preference shares up front).
+  instrument_type: model.enum(["equity", "safe", "convertible_note", "ccps"]).default("equity"),
 
   status: model.enum(["planned", "open", "closing", "closed", "cancelled"]).default("planned"),
 

--- a/apps/backend/src/modules/investor/models/share-class.ts
+++ b/apps/backend/src/modules/investor/models/share-class.ts
@@ -15,6 +15,7 @@ const ShareClass = model.define("share_class", {
     "preferred",
     "convertible_note",
     "safe",
+    "ccps", // Compulsorily Convertible Preference Shares (India / iSAFE)
     "warrant",
     "option",
   ]).default("common"),

--- a/apps/investor-ui/src/hooks/api/investments.tsx
+++ b/apps/investor-ui/src/hooks/api/investments.tsx
@@ -113,12 +113,15 @@ export type ConvertibleValue = {
 
 export type MyConvertible = {
   id: string
-  instrument_type?: "safe" | "convertible_note"
+  instrument_type?: "safe" | "convertible_note" | "ccps"
   principal_amount?: number | null
   currency_code?: string | null
   valuation_cap?: number | null
   discount_rate?: number | null
   safe_type?: "post_money" | "pre_money"
+  // CCPS-only preference terms.
+  num_shares?: number | null
+  liquidation_preference_multiple?: number | null
   status?: string
   investment_date?: string | null
   conversion_date?: string | null

--- a/apps/investor-ui/src/routes/cap-table/index.tsx
+++ b/apps/investor-ui/src/routes/cap-table/index.tsx
@@ -206,16 +206,32 @@ const SafesSection = ({
       {
         header: "Instrument",
         accessorKey: "instrument_type",
-        cell: ({ row }: any) => (
-          <span className="flex items-center gap-x-2">
-            {row.original.instrument_type === "convertible_note" ? "Convertible note" : "SAFE"}
-            {row.original.safe_type === "pre_money" ? (
-              <Badge size="2xsmall" color="grey">pre-money</Badge>
-            ) : (
-              <Badge size="2xsmall" color="grey">post-money</Badge>
-            )}
-          </span>
-        ),
+        cell: ({ row }: any) => {
+          const it = row.original.instrument_type
+          const label =
+            it === "ccps" ? "CCPS" : it === "convertible_note" ? "Loan / note" : "SAFE"
+          return (
+            <span className="flex items-center gap-x-2">
+              {it === "ccps" && (
+                <Badge size="2xsmall" color="blue">CCPS</Badge>
+              )}
+              {label}
+              {row.original.safe_type === "pre_money" ? (
+                <Badge size="2xsmall" color="grey">pre-money</Badge>
+              ) : (
+                <Badge size="2xsmall" color="grey">post-money</Badge>
+              )}
+            </span>
+          )
+        },
+      },
+      {
+        header: "Shares",
+        accessorKey: "num_shares",
+        cell: ({ row }: any) =>
+          row.original.instrument_type === "ccps"
+            ? num(row.original.num_shares)
+            : "—",
       },
       {
         header: "Company",
@@ -262,9 +278,9 @@ const SafesSection = ({
   return (
     <Container className="divide-y p-0">
       <div className="px-6 py-4">
-        <Heading level="h2">SAFEs &amp; Convertibles</Heading>
+        <Heading level="h2">SAFEs, Convertibles &amp; CCPS</Heading>
         <Text size="small" className="text-ui-fg-subtle mt-1">
-          Money invested now that converts to equity later — no shares are issued yet, so value is implied against the company valuation.
+          Money invested now that converts to equity later. A SAFE/note issues no shares yet; a CCPS allots preference shares up front (with a liquidation-preference floor). Value is implied against the company valuation.
         </Text>
       </div>
 


### PR DESCRIPTION
## What & why
Extends the SAFE/convertible instrument (#969) to accommodate **CCPS** (Compulsorily Convertible Preference Shares — the Indian **iSAFE** legal wrapper) with minimal, additive changes, and builds the previously-missing **conversion-execution engine** so an outstanding SAFE / note / loan can be turned into real equity or CCPS.

Answers the product question: an iSAFE fits the same `convertible` model (post-money cap + discount economics), with a preference-share **liquidation floor** as the only economic difference. Also supports the concrete case of *a loan given ~2 years ago now being turned into CCPS*.

## Backend
- **Models:** `convertible.instrument_type += "ccps"` + nullable preference fields (`num_shares`, `liquidation_preference_multiple`, `dividend_rate`, `conversion_ratio`); `share_class.class_type` / `funding_round.instrument_type` + `round_type` gain `"ccps"`.
- **Value engine:** CCPS liquidation-preference floor — implied value never prints below `principal × multiple` (only for `ccps`; plain SAFEs unaffected).
- **Conversion engine (new):** pure `convertible-conversion.ts` + `POST /admin/convertibles/:id/convert`. Derives price/shares from cap vs discount vs round price; mints a `Stake` (`target=equity`) or a new `ccps` convertible (`target=ccps`); records `converted_stake_id`/`conversion_*` and flips status to `converted`. Guarded to `outstanding` only.
- **Participate route:** `ccps` rounds route through the convertible rail, allotting shares up front.
- **Migration `Migration20260711220000`:** adds the 4 columns (incl. **`raw_num_shares` jsonb** for the bignumber — the raw-col gotcha that broke #999) and extends the instrument/class/round enum CHECKs. Idempotent; applies + `query.graph`-reads verified locally.

## Admin UI
- `@add-safe`: CCPS + loan instrument options with conditional preference / loan-term fields; `@add-round`: CCPS option.
- `cap-table-section`: CCPS badges + **Convert (loan → CCPS/equity)** action.
- `@convert-convertible`: new drawer showing the instrument (e.g. a loan from ~2 years ago), a **live share-count preview**, and equity/CCPS conversion.

## Investor UI
- "SAFEs, Convertibles & CCPS" section: CCPS badge, shares column, updated copy.

## Tests
- 9 unit specs (`ccps.unit.spec.ts`) for the preference floor + conversion math — all green.

## Deploy tail
- Migration runs on boot (`predeploy:force`). No seed required. Redeploy backend + investor-ui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)