### PR TITLE
feat(investor): add country/region selector to profile settings

### DIFF
--- a/apps/investor-ui/src/i18n/translations/en.json
+++ b/apps/investor-ui/src/i18n/translations/en.json
@@ -2626,6 +2626,7 @@
     "manageYourProfileDetails": "Manage your profile details.",
     "fields": {
       "languageLabel": "Language",
+      "country": "Country / Region",
       "usageInsightsLabel": "Usage insights"
     },
     "mfa": {
@@ -2657,6 +2658,7 @@
       "header": "Edit Profile",
       "languageHint": "The language you want to use in the admin dashboard. This doesn't change the language of your store.",
       "languagePlaceholder": "Select language",
+      "countryHint": "Select your country of residence. This determines the verification fields shown.",
       "usageInsightsHint": "Share usage insights and help us improve Medusa. You can read more about what we collect and how we use it in our <0>documentation</0>."
     },
     "toast": {

--- a/apps/investor-ui/src/routes/profile/profile-detail/components/profile-general-section/profile-general-section.tsx
+++ b/apps/investor-ui/src/routes/profile/profile-detail/components/profile-general-section/profile-general-section.tsx
@@ -3,6 +3,7 @@ import { HttpTypes } from "@medusajs/types"
 import { Container, Heading, Text } from "@medusajs/ui"
 import { useTranslation } from "react-i18next"
 import { ActionMenu } from "../../../../../components/common/action-menu"
+import { getFormattedCountry } from "../../../../../lib/addresses"
 import { languages } from "../../../../../i18n/languages"
 
 type ProfileGeneralSectionProps = {
@@ -62,6 +63,16 @@ export const ProfileGeneralSection = ({ user }: ProfileGeneralSectionProps) => {
             ?.display_name || "-"}
         </Text>
       </div>
+      {(user as any).country_code && (
+        <div className="text-ui-fg-subtle grid grid-cols-2 items-center px-6 py-4">
+          <Text size="small" leading="compact" weight="plus">
+            {t("profile.fields.country")}
+          </Text>
+          <Text size="small" leading="compact">
+            {getFormattedCountry((user as any).country_code)}
+          </Text>
+        </div>
+      )}
       {/* TODO: Do we want to implement usage insights in V2? */}
       {/* <div className="grid grid-cols-2 items-center px-6 py-4">
         <Text size="small" leading="compact" weight="plus">

--- a/apps/investor-ui/src/routes/profile/profile-edit/components/edit-profile-form/edit-profile-form.tsx
+++ b/apps/investor-ui/src/routes/profile/profile-edit/components/edit-profile-form/edit-profile-form.tsx
@@ -6,6 +6,7 @@ import * as zod from "zod"
 
 import { HttpTypes } from "@medusajs/types"
 import { Form } from "../../../../../components/common/form"
+import { CountrySelect } from "../../../../../components/inputs/country-select"
 import { RouteDrawer, useRouteModal } from "../../../../../components/modals"
 import { KeyboundForm } from "../../../../../components/utilities/keybound-form"
 import { useUpdateMe } from "../../../../../hooks/api/users"
@@ -21,6 +22,7 @@ const EditProfileSchema = zod.object({
   first_name: zod.string().optional(),
   last_name: zod.string().optional(),
   language: zod.string(),
+  country_code: zod.string().optional(),
   // usage_insights: zod.boolean(),
 })
 
@@ -38,6 +40,7 @@ export const EditProfileForm = ({ user }: EditProfileProps) => {
       first_name: user.first_name ?? initialFirst ?? "",
       last_name: user.last_name ?? initialRest.join(" ") ?? "",
       language: i18n.language,
+      country_code: (user as any).country_code ?? "",
       // usage_insights: usageInsights,
     },
     resolver: zodResolver(EditProfileSchema),
@@ -58,15 +61,17 @@ export const EditProfileForm = ({ user }: EditProfileProps) => {
       .filter(Boolean)
       .join(" ")
       .trim()
-    await mutateAsync(
-      { name: name || undefined },
-      {
-        onError: (error) => {
-          toast.error(error.message)
-          return
-        },
-      }
-    )
+    const payload: Record<string, any> = { name: name || undefined }
+    if (values.country_code) {
+      payload.country_code = values.country_code
+    }
+
+    await mutateAsync(payload, {
+      onError: (error) => {
+        toast.error(error.message)
+        return
+      },
+    })
 
     await changeLanguage(values.language)
 
@@ -107,6 +112,27 @@ export const EditProfileForm = ({ user }: EditProfileProps) => {
                 )}
               />
             </div>
+            <Form.Field
+              control={form.control}
+              name="country_code"
+              render={({ field: { ref, ...field } }) => (
+                <Form.Item>
+                  <div>
+                    <Form.Label>{t("profile.fields.country")}</Form.Label>
+                    <Form.Hint>{t("profile.edit.countryHint")}</Form.Hint>
+                  </div>
+                  <Form.Control>
+                    <CountrySelect
+                      {...field}
+                      ref={ref}
+                      value={field.value ?? ""}
+                      onChange={(val) => field.onChange(val || "")}
+                    />
+                  </Form.Control>
+                  <Form.ErrorMessage />
+                </Form.Item>
+              )}
+            />
             <Form.Field
               control={form.control}
               name="language"


### PR DESCRIPTION
## Summary

Adds a **Country / Region** dropdown to Settings → Profile so investors can set their country of residence. This drives the conditional verification fields (PAN/Aadhar for India, International ID for others).

## Changes

- **Edit Profile form** — added `CountrySelect` combobox (searchable) for `country_code` field
- **Profile detail** — displays the selected country name when set
- **Mutation** — `country_code` is sent to `POST /investors/me` on save
- **Translations** — added `profile.fields.country` and `profile.edit.countryHint`

The backend already accepts `country_code` on the investor model and validator — no backend changes needed.