### PR TITLE
fix: country_code case mismatch (lowercase from CountrySelect vs uppercase comparison)

### DIFF
--- a/apps/investor-ui/src/routes/profile/profile-edit/components/edit-profile-form/edit-profile-form.tsx
+++ b/apps/investor-ui/src/routes/profile/profile-edit/components/edit-profile-form/edit-profile-form.tsx
@@ -63,7 +63,7 @@ export const EditProfileForm = ({ user }: EditProfileProps) => {
       .trim()
     const payload: Record<string, any> = { name: name || undefined }
     if (values.country_code) {
-      payload.country_code = values.country_code
+      payload.country_code = values.country_code.toUpperCase()
     }
 
     await mutateAsync(payload, {

--- a/apps/investor-ui/src/routes/settings/verification/components/edit-verification-section/edit-verification-section.tsx
+++ b/apps/investor-ui/src/routes/settings/verification/components/edit-verification-section/edit-verification-section.tsx
@@ -31,7 +31,7 @@ export const EditVerificationSection = ({
   const { t } = useTranslation()
   const { handleSuccess } = useRouteModal()
 
-  const isIndia = investor.country_code === "IN"
+  const isIndia = investor.country_code?.toUpperCase() === "IN"
 
   const EditVerificationSchema = zod.object({
     pan_number: isIndia

--- a/apps/investor-ui/src/routes/settings/verification/components/verification-section/verification-section.tsx
+++ b/apps/investor-ui/src/routes/settings/verification/components/verification-section/verification-section.tsx
@@ -26,7 +26,7 @@ const maskId = (value: string | null | undefined): string => {
 export const VerificationSection = ({ investor }: VerificationSectionProps) => {
   const { t } = useTranslation()
 
-  const isIndia = investor.country_code === "IN"
+  const isIndia = investor.country_code?.toUpperCase() === "IN"
   const hasPan = !!investor.pan_number
   const hasAadhar = !!investor.aadhar_number
   const hasInternational = !!investor.international_id_number


### PR DESCRIPTION
## Bug

 sends ISO codes in lowercase (e.g. `"in"`), but the verification section compared with uppercase `"IN"`. This meant setting your country to India in Profile still showed International ID / Passport instead of PAN + Aadhar in the Verification section.

## Fix

1. **Profile edit form** — uppercases `country_code` before sending to the API
2. **VerificationSection** — uses `.toUpperCase()` on comparison (belt-and-suspenders)
3. **EditVerificationSection** — same case-insensitive comparison