### PR TITLE
fix(investor): unblock prod build — type register-auth step compensation

### DIFF
--- a/apps/backend/src/workflows/investor/create-investor-admin.ts
+++ b/apps/backend/src/workflows/investor/create-investor-admin.ts
@@ -124,6 +124,26 @@ const findEmailpassIdentity = async (
   return (identities || []).find((pi: any) => pi.provider === "emailpass")
 }
 
+// The register step either resets an existing emailpass identity or creates a
+// new one; each path compensates differently, so its compensation payload is a
+// discriminated union. Pin both StepResponse generics to these explicit types
+// so TS unifies the two return branches (otherwise the invoke fn's inferred
+// type collapses and every downstream `.authIdentityId` reference breaks).
+type RegisterAuthOutput = {
+  // Always resolved: `reg.id` on create, the existing identity's
+  // `auth_identity_id` on reset (a provider identity always has one).
+  authIdentityId: string
+  tempPassword: string
+  reused: boolean
+}
+type RegisterAuthCompensate =
+  | {
+      mode: "reset"
+      providerIdentityId: string
+      previousProviderMetadata: Record<string, unknown>
+    }
+  | { mode: "create"; authIdentityId: string }
+
 const registerInvestorAdminAuthStep = createStep(
   "register-investor-admin-auth-step",
   async (input: { email: string; tempPassword?: string }, { container }) => {
@@ -144,10 +164,10 @@ const registerInvestorAdminAuthStep = createStep(
         id: existing.id,
         provider_metadata: { ...previousProviderMetadata, password: passwordHash },
       } as any)
-      return new StepResponse(
+      return new StepResponse<RegisterAuthOutput, RegisterAuthCompensate>(
         { authIdentityId: existing.auth_identity_id, tempPassword: plainPassword, reused: true },
         {
-          mode: "reset" as const,
+          mode: "reset",
           providerIdentityId: existing.id,
           previousProviderMetadata,
         }
@@ -163,12 +183,12 @@ const registerInvestorAdminAuthStep = createStep(
         },
       ],
     })
-    return new StepResponse(
+    return new StepResponse<RegisterAuthOutput, RegisterAuthCompensate>(
       { authIdentityId: reg.id, tempPassword: plainPassword, reused: false },
-      { mode: "create" as const, authIdentityId: reg.id }
+      { mode: "create", authIdentityId: reg.id }
     )
   },
-  async (rollback, { container }) => {
+  async (rollback: RegisterAuthCompensate | undefined, { container }) => {
     if (!rollback) return
     const authModule = container.resolve(Modules.AUTH) as IAuthModuleService
     if (rollback.mode === "reset" && rollback.providerIdentityId) {


### PR DESCRIPTION
## Problem
The **Deploy to AWS ECS → Build & Push Image** job is red on `main`. The prod `medusa build` fails with TS errors in `src/workflows/investor/create-investor-admin.ts` (from the CCPS/investor merge #1005):

```
create-investor-admin.ts:129  TS2345  invoke fn not assignable to InvokeFn (compensation shape mismatch)
create-investor-admin.ts:180  TS2367  '"reset"' vs '"create"' have no overlap
create-investor-admin.ts:181  TS2339  authIdentityId does not exist on the reset payload
create-investor-admin.ts:240  TS2554  Expected 0 arguments, but got 1
create-investor-admin.ts:246  TS2339  authIdentityId does not exist on step result
```

`register-investor-admin-auth-step` returns two different `StepResponse` shapes — create (`{mode:"create", authIdentityId}`) vs reset (`{mode:"reset", providerIdentityId, previousProviderMetadata}`). TS couldn't unify the two compensation payloads, so the invoke fn's inferred type collapsed and every downstream `registered.authIdentityId` reference broke.

## Fix
- Pin both `StepResponse` generics to explicit `RegisterAuthOutput` + `RegisterAuthCompensate` (a discriminated union on `mode`), and type the compensation callback arg. This makes the two branches unify and the compensation `mode` checks type-safe.
- `authIdentityId` is always resolved (`reg.id` on create, the existing identity's `auth_identity_id` on reset), so the output type drops the optional to satisfy `setAuthAppMetadataStep` (which requires a `string`).

No behavioural change — types only.

## Verify
- `tsc` errors in `create-investor-admin.ts` are gone (the 6 flagged above).
- Prod `medusa build` (`check:prod-build`) no longer fails on this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)