### PR TITLE
fix(#881): winback campaign toggle + open/click implies engaged

### DIFF
--- a/apps/backend/src/admin/routes/marketing/winbacks/page.tsx
+++ b/apps/backend/src/admin/routes/marketing/winbacks/page.tsx
@@ -1,12 +1,14 @@
 import { defineRouteConfig } from "@medusajs/admin-sdk"
 import {
   Badge,
+  Button,
   Container,
   DataTable,
   type DataTablePaginationState,
   Heading,
   StatusBadge,
   Text,
+  clx,
   useDataTable,
 } from "@medusajs/ui"
 import { createColumnHelper } from "@tanstack/react-table"
@@ -70,9 +72,22 @@ const formatDateTime = (iso: string | null): string => {
   }
 }
 
+// The two win-back campaigns land under distinct `campaign` values:
+//   churn re-engagement → "winback"  (generate-winback-targets)
+//   newsletter engagement → "newsletter-winback" (generate-newsletter-winback-targets, #881)
+// The outreach list filters campaign by exact match, so the UI has to pick one.
+const CAMPAIGNS = [
+  { value: "winback", label: "Churn" },
+  { value: "newsletter-winback", label: "Newsletter" },
+] as const
+
 const WinbacksView = () => {
   const [searchParams, setSearchParams] = useSearchParams()
   const pageFromUrl = parseInt(searchParams.get("w_page") || "1", 10)
+  const campaignParam = searchParams.get("w_camp") || "winback"
+  const campaign = CAMPAIGNS.some((c) => c.value === campaignParam)
+    ? campaignParam
+    : "winback"
 
   const pagination: DataTablePaginationState = {
     pageIndex: Math.max(0, pageFromUrl - 1),
@@ -82,7 +97,7 @@ const WinbacksView = () => {
   const offset = pagination.pageIndex * pagination.pageSize
 
   const { data, isLoading, isError, error } = useQuery({
-    queryKey: ["marketing", "winbacks", pagination],
+    queryKey: ["marketing", "winbacks", campaign, pagination],
     queryFn: async () => {
       const res = await sdk.client.fetch<{
         outreach: MarketingOutreach[]
@@ -91,7 +106,7 @@ const WinbacksView = () => {
         limit: number
       }>("/admin/marketing/outreach", {
         query: {
-          campaign: "winback",
+          campaign,
           limit: pagination.pageSize,
           offset,
         },
@@ -100,6 +115,18 @@ const WinbacksView = () => {
     },
     placeholderData: (prev) => prev,
   })
+
+  const handleCampaignChange = useCallback(
+    (next: string) => {
+      const params = new URLSearchParams(searchParams)
+      if (next !== "winback") params.set("w_camp", next)
+      else params.delete("w_camp")
+      // Switching campaigns resets pagination.
+      params.delete("w_page")
+      setSearchParams(params, { replace: true })
+    },
+    [searchParams, setSearchParams]
+  )
 
   const handlePaginationChange = useCallback(
     (newPagination: DataTablePaginationState) => {
@@ -179,7 +206,7 @@ const WinbacksView = () => {
   return (
     <Container className="divide-y p-0">
       <DataTable instance={table}>
-        <DataTable.Toolbar className="flex flex-col md:flex-row justify-between gap-y-4 w-full px-6 py-4">
+        <DataTable.Toolbar className="flex flex-col md:flex-row md:items-center justify-between gap-y-4 w-full px-6 py-4">
           <div>
             <Heading>Winbacks</Heading>
             <Text className="text-ui-fg-subtle" size="small">
@@ -191,6 +218,21 @@ const WinbacksView = () => {
                 = provider bounce flags are unreliable — verify manually.
               </span>
             </Text>
+          </div>
+          <div className="flex items-center gap-x-1 rounded-lg bg-ui-bg-subtle p-1">
+            {CAMPAIGNS.map((c) => (
+              <Button
+                key={c.value}
+                size="small"
+                variant="transparent"
+                onClick={() => handleCampaignChange(c.value)}
+                className={clx(
+                  campaign === c.value && "bg-ui-bg-base shadow-borders-base"
+                )}
+              >
+                {c.label}
+              </Button>
+            ))}
           </div>
         </DataTable.Toolbar>
         <DataTable.Table />

--- a/apps/backend/src/modules/email_engagement/__tests__/classifier.unit.spec.ts
+++ b/apps/backend/src/modules/email_engagement/__tests__/classifier.unit.spec.ts
@@ -9,8 +9,19 @@ const daysAgo = (d: number) =>
   new Date(NOW.getTime() - d * 24 * 60 * 60 * 1000).toISOString()
 
 describe("classifier — classifyEngagement", () => {
-  it("unknown when too little data (< minDataDelivered)", () => {
+  it("unknown when too little data (< minDataDelivered) AND no opens", () => {
     expect(classifyEngagement({ delivered_count: 2, opens_count: 0 }, { now: NOW }).status).toBe("unknown")
+  })
+
+  it("engaged (not unknown) when opened, even with thin/zero delivered count", () => {
+    // An open proves delivery + interest — e.g. Mailjet reports opens but no
+    // `sent` events, so delivered_count stays low. Must not fall to `unknown`.
+    const c = classifyEngagement(
+      { delivered_count: 0, opens_count: 1, delivered_since_last_open: 0 },
+      { now: NOW }
+    )
+    expect(c.status).toBe("engaged")
+    expect(c.bulk_suppressed).toBe(false)
   })
 
   it("engaged when recently opened (short cold streak)", () => {

--- a/apps/backend/src/modules/email_engagement/classifier.ts
+++ b/apps/backend/src/modules/email_engagement/classifier.ts
@@ -6,8 +6,10 @@
  *
  * Policy (soft exclusion — see #3): only `dormant` is bulk-suppressed. `cooling`
  * is the pre-dormant win-back target; `never_opened` / `engaged` / `unknown`
- * still get mailed. Deliberately conservative: too little data → `unknown`, and
- * any open/click keeps someone out of `dormant`.
+ * still get mailed. Any open/click proves delivery + interest, so an engaged
+ * contact is judged on their cold streak regardless of how many `delivered`
+ * events we recorded (a provider may report opens but not deliveries). Only a
+ * contact with NO opens AND too few deliveries to judge is `unknown`.
  */
 
 export type EngagementStatus =
@@ -95,28 +97,32 @@ export function classifyEngagement(
     reason,
   })
 
-  // Too little signal to judge — never suppress on thin data.
-  if (delivered < th.minDataDelivered) {
-    return wrap("unknown", `only ${delivered} delivered (< ${th.minDataDelivered})`)
-  }
-
   const everEngaged = opens > 0 || clicks > 0
   const oldEnough = span >= th.dormantMinSpanDays
 
-  if (!everEngaged) {
-    // Never opened anything.
-    if (delivered >= th.dormantColdStreak && oldEnough) {
-      return wrap("dormant", `never opened in ${delivered} deliveries over ${Math.round(span)}d`)
+  // An open or click PROVES the message was delivered and the contact is real —
+  // so we always have enough signal to judge them, regardless of how many
+  // `delivered` webhooks we happened to record. This matters when a provider
+  // (e.g. Mailjet without its `sent` trigger) reports opens but not deliveries:
+  // without this, an engaged opener would fall through to `unknown`. Judge on
+  // the cold streak since their last open.
+  if (everEngaged) {
+    if (cold >= th.dormantColdStreak && oldEnough) {
+      return wrap("dormant", `${cold} deliveries since last open over ${Math.round(span)}d`)
     }
-    return wrap("never_opened", `opens=0 after ${delivered} deliveries (${Math.round(span)}d)`)
+    if (cold >= th.coolingColdStreak) {
+      return wrap("cooling", `${cold} deliveries since last open`)
+    }
+    return wrap("engaged", `recent open/click (cold streak ${cold})`)
   }
 
-  // Engaged at some point — judge on the cold streak since last open.
-  if (cold >= th.dormantColdStreak && oldEnough) {
-    return wrap("dormant", `${cold} deliveries since last open over ${Math.round(span)}d`)
+  // Never opened/clicked — now we DO need enough delivery signal to judge,
+  // otherwise there's nothing to go on. Thin data → unknown (never suppressed).
+  if (delivered < th.minDataDelivered) {
+    return wrap("unknown", `only ${delivered} delivered (< ${th.minDataDelivered}), no opens`)
   }
-  if (cold >= th.coolingColdStreak) {
-    return wrap("cooling", `${cold} deliveries since last open`)
+  if (delivered >= th.dormantColdStreak && oldEnough) {
+    return wrap("dormant", `never opened in ${delivered} deliveries over ${Math.round(span)}d`)
   }
-  return wrap("engaged", `recent open/click (cold streak ${cold})`)
+  return wrap("never_opened", `opens=0 after ${delivered} deliveries (${Math.round(span)}d)`)
 }


### PR DESCRIPTION
Relates to #881 (email engagement scoring / win-backs).

While triaging why the **recompute-email-engagement-status** job reported **116/118 rows as `unknown`** and the newsletter win-backs weren't showing in the UI, two real gaps surfaced (both confirmed against today's prod CloudWatch logs for the blog send: Resend 99 delivered + opens; **Mailjet 0 `sent`/delivered but 29 opens** — its `sent` trigger isn't enabled).

### 1. Winbacks UI campaign mismatch
The Winbacks view filtered `campaign="winback"` (churn) with an **exact match**, but the #881 newsletter job writes `campaign="newsletter-winback"`. So generated newsletter win-back targets were invisible in the UI.
→ Added a **Churn / Newsletter toggle** (URL-persisted via `?w_camp`, resets pagination on switch) so both campaigns are viewable.

### 2. `unknown` swallowed engaged openers
`classifyEngagement` returned `unknown` whenever `delivered_count < 3` **before** checking opens. A contact who opened but whose deliveries we didn't record (Mailjet-without-`sent`) fell to `unknown`.
→ An open/click **proves** delivery + interest, so `everEngaged` is now evaluated first: openers are judged on their cold streak (engaged/cooling/dormant); only **no-open + thin-data** contacts remain `unknown`. Added a unit test; existing 42 unit tests green.

> Note: the remaining `unknown` for never-opened, freshly-delivered contacts is expected (needs ≥3 deliveries) and self-heals with volume. Enabling Mailjet's `sent` event trigger (dashboard, → `/webhooks/mailjet/events`) is the ops-side complement so Mailjet deliveries are counted.

## Verify
- `jest classifier.unit|winback` → 42 passed.
- Winbacks UI: toggle switches the list between churn and newsletter campaigns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)