### PR TITLE
fix(faire): send unit_multiplier on product create; decouple prod migrations

### DIFF
--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -6,8 +6,9 @@ name: Deploy to AWS ECS
 # Sequence per run:
 #   1. Build a Docker image, push to GHCR (sha-<hash> + :latest)
 #   2. Mirror the same image to ECR
-#   3. `copilot svc deploy` for medusa-server + medusa-worker (parallel)
-#   4. Poll /health on the public ALB until green (or fail)
+#   3. Run DB migrations as a gated one-off ECS task (fails the deploy on error)
+#   4. `copilot svc deploy` for medusa-server + medusa-worker (parallel)
+#   5. Poll /health on the public ALB until green (or fail)
 
 on:
   push:
@@ -207,13 +208,42 @@ jobs:
           echo "ecr_image=${DST_SHA}" >> "$GITHUB_OUTPUT"
 
   # ─────────────────────────────────────────────────────────────────────────
-  # 3. Deploy server + worker in parallel via Copilot. Each deploy is its
+  # 3. Run DB migrations as a gated one-off ECS task on the freshly-built
+  #    image, BEFORE rolling the services. The server/worker containers no
+  #    longer migrate on boot (see apps/backend/Dockerfile), so this step owns
+  #    the schema. A migration failure fails the deploy here — the old tasks
+  #    keep serving and the services are never rolled onto un-migrated schema.
+  # ─────────────────────────────────────────────────────────────────────────
+  migrate:
+    name: Migrate DB
+    runs-on: ubuntu-latest
+    needs: [build-and-push, mirror-to-ecr]
+    # Same gate as the deploy jobs: only migrate when we're actually deploying
+    # services (push to main, or an explicit deploy_services dispatch).
+    if: github.event_name == 'push' || inputs.deploy_services == true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/jyt-github-actions
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Run migrations (gated one-off task)
+        env:
+          IMAGE_TAG: ${{ needs.build-and-push.outputs.image_tag }}
+        run: ./deploy/aws/scripts/run-migrations.sh
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # 4. Deploy server + worker in parallel via Copilot. Each deploy is its
   #    own job so a worker-only or server-only failure is visible separately.
+  #    Both wait on `migrate` so services never roll onto un-migrated schema.
   # ─────────────────────────────────────────────────────────────────────────
   deploy-server:
     name: Deploy medusa-server
     runs-on: ubuntu-latest
-    needs: [build-and-push, mirror-to-ecr]
+    needs: [build-and-push, mirror-to-ecr, migrate]
     # Push to main always deploys. Manual dispatch only deploys when
     # the operator explicitly checked `deploy_services`. Branch
     # dispatches default to build-only so they don't roll the prod
@@ -251,7 +281,7 @@ jobs:
   deploy-worker:
     name: Deploy medusa-worker
     runs-on: ubuntu-latest
-    needs: [build-and-push, mirror-to-ecr]
+    needs: [build-and-push, mirror-to-ecr, migrate]
     # See deploy-server above for the rationale.
     if: github.event_name == 'push' || inputs.deploy_services == true
     steps:
@@ -278,7 +308,7 @@ jobs:
             --tag "${{ needs.build-and-push.outputs.image_tag }}"
 
   # ─────────────────────────────────────────────────────────────────────────
-  # 4. Health-check the public endpoint after both deploys are done.
+  # 5. Health-check the public endpoint after both deploys are done.
   # ─────────────────────────────────────────────────────────────────────────
   health-check:
     name: Health Check — v3.jaalyantra.com

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -75,6 +75,11 @@ RUN pnpm install --prod --ignore-workspace --ignore-scripts
 
 EXPOSE 9000
 
-# Server runs predeploy:force (db:migrate --execute-all-links) before starting.
-# Worker skips migrations — the server owns the schema.
-CMD ["sh", "-c", "if [ \"${MEDUSA_WORKER_MODE}\" = \"worker\" ]; then pnpm run start; else pnpm predeploy:force && pnpm run start; fi"]
+# Both roles just start — neither migrates inline. Migrations are run as a
+# separate, gated one-off ECS task by the deploy workflow
+# (deploy/aws/scripts/run-migrations.sh) BEFORE the services roll, so a slow
+# migration no longer blocks server boot / the /health check.
+#
+# Escape hatch: set RUN_MIGRATIONS_ON_BOOT=1 to restore the old inline behavior
+# (e.g. for a local/standalone run with no separate migration step).
+CMD ["sh", "-c", "if [ \"${RUN_MIGRATIONS_ON_BOOT}\" = \"1\" ] && [ \"${MEDUSA_WORKER_MODE}\" != \"worker\" ]; then pnpm predeploy:force; fi; pnpm run start"]

--- a/deploy/aws/scripts/run-migrations.sh
+++ b/deploy/aws/scripts/run-migrations.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Run Medusa DB migrations as a ONE-OFF Fargate task, decoupled from the
+# server/worker boot.
+#
+# Why this exists
+#   The server container used to run `predeploy:force` (medusa db:migrate
+#   --execute-all-links) inline before starting the HTTP server, so every
+#   rolling deploy had to finish all migrations before the new task could pass
+#   /health — stretching the deploy and coupling schema changes to boot.
+#   Instead, the deploy workflow now runs THIS script off the freshly-built
+#   image, waits for it to finish, and only then rolls the services (which now
+#   just `start`). Migrations get their own task, their own logs, and their own
+#   pass/fail exit code.
+#
+# Mechanism (mirrors run-backfill.sh)
+#   - Register a one-off task-def revision off jyt-prod-medusa-server with the
+#     supplied image tag (so migrations run the NEW image, not :latest).
+#   - Override the container command to `pnpm predeploy:force`.
+#   - run-task, then BLOCK until the task stops and propagate its exit code.
+#
+# Usage
+#   IMAGE_TAG=sha-<hash> ./deploy/aws/scripts/run-migrations.sh
+#
+# Optional env
+#   TIMEOUT_SECONDS=1200  -> how long to wait for the task to stop (default 1200)
+#   ECR_REGISTRY=...      -> override the ECR account ref (auto-detected)
+
+set -euo pipefail
+
+: "${AWS_REGION:=us-east-1}"
+: "${ECS_CLUSTER:=jyt-prod-Cluster-JOcsxaMtDKJ3}"
+: "${TASK_FAMILY:=jyt-prod-medusa-server}"
+: "${CONTAINER_NAME:=medusa-server}"
+: "${SUBNETS:=subnet-0fbeafa1ebdf9026a,subnet-05ebe6f3b9fb25673}"
+: "${SECURITY_GROUP:=sg-0c3685e1a91b5d60e}"
+: "${LOG_GROUP:=/copilot/jyt-prod-medusa-server}"
+: "${ECR_REPOSITORY:=jyt-medusa}"
+: "${TIMEOUT_SECONDS:=1200}"
+
+if [ -z "${IMAGE_TAG:-}" ]; then
+  echo "❌ IMAGE_TAG is required (e.g. sha-<hash>)." >&2
+  echo "   The migration must run the exact image being deployed." >&2
+  exit 2
+fi
+
+echo "== Region:        $AWS_REGION"
+echo "== Cluster:       $ECS_CLUSTER"
+echo "== Task family:   $TASK_FAMILY"
+echo "== Image tag:     $IMAGE_TAG"
+echo "== Timeout:       ${TIMEOUT_SECONDS}s"
+echo
+
+# ── Register a one-off task-def revision pinned to IMAGE_TAG ────────────────
+CURRENT_DEF_FILE=$(mktemp -t run-migrations-current-td.XXXXXX.json)
+aws ecs describe-task-definition \
+  --task-definition "$TASK_FAMILY" \
+  --region "$AWS_REGION" \
+  --output json > "$CURRENT_DEF_FILE"
+
+if [ -z "${ECR_REGISTRY:-}" ]; then
+  CURRENT_IMAGE=$(python3 -c "
+import json, sys
+td = json.load(open(sys.argv[1]))['taskDefinition']
+for c in td['containerDefinitions']:
+    if c['name'] == sys.argv[2]:
+        print(c['image']); break
+" "$CURRENT_DEF_FILE" "$CONTAINER_NAME")
+  ECR_REGISTRY="${CURRENT_IMAGE%/*}"
+fi
+NEW_IMAGE="${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}"
+echo "Registering one-off migration task def with image: ${NEW_IMAGE}"
+
+NEW_DEF_FILE=$(mktemp -t run-migrations-taskdef.XXXXXX.json)
+python3 - "$CURRENT_DEF_FILE" "$CONTAINER_NAME" "$NEW_IMAGE" "$NEW_DEF_FILE" <<'PY'
+import json, sys
+in_path, container_name, new_image, out_path = sys.argv[1:]
+td = json.load(open(in_path))['taskDefinition']
+allowed_keys = {
+  'family', 'taskRoleArn', 'executionRoleArn', 'networkMode',
+  'containerDefinitions', 'volumes', 'placementConstraints',
+  'requiresCompatibilities', 'cpu', 'memory', 'tags',
+  'pidMode', 'ipcMode', 'proxyConfiguration', 'inferenceAccelerators',
+  'ephemeralStorage', 'runtimePlatform',
+}
+filtered = {k: v for k, v in td.items() if k in allowed_keys and v is not None}
+for c in filtered.get('containerDefinitions', []):
+    if c.get('name') == container_name:
+        c['image'] = new_image
+with open(out_path, 'w') as f:
+    json.dump(filtered, f)
+PY
+
+TASK_DEF_ARN=$(aws ecs register-task-definition \
+  --region "$AWS_REGION" \
+  --cli-input-json "file://${NEW_DEF_FILE}" \
+  --query "taskDefinition.taskDefinitionArn" \
+  --output text)
+echo "Registered: ${TASK_DEF_ARN}"
+
+# ── Command override: run migrations only (no server boot) ─────────────────
+OVERRIDES_FILE=$(mktemp -t run-migrations-overrides.XXXXXX.json)
+trap 'rm -f "$OVERRIDES_FILE" "${NEW_DEF_FILE:-}" "${CURRENT_DEF_FILE:-}"' EXIT
+python3 - "$CONTAINER_NAME" "$OVERRIDES_FILE" <<'PY'
+import json, sys
+container, out_path = sys.argv[1:]
+override = {"name": container, "command": ["sh", "-c", "pnpm predeploy:force"]}
+with open(out_path, "w") as f:
+    json.dump({"containerOverrides": [override]}, f)
+PY
+
+RUN_OUT=$(aws ecs run-task \
+  --cluster "$ECS_CLUSTER" \
+  --task-definition "$TASK_DEF_ARN" \
+  --launch-type FARGATE \
+  --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SECURITY_GROUP],assignPublicIp=ENABLED}" \
+  --overrides "file://$OVERRIDES_FILE" \
+  --started-by "migrate:${IMAGE_TAG}" \
+  --region "$AWS_REGION" \
+  --output json)
+
+TASK_ARN=$(echo "$RUN_OUT" | python3 -c "import json,sys; print(json.load(sys.stdin)['tasks'][0]['taskArn'])")
+TASK_ID="${TASK_ARN##*/}"
+echo
+echo "✅ Migration task started: $TASK_ID"
+echo "   Console: https://${AWS_REGION}.console.aws.amazon.com/ecs/v2/clusters/${ECS_CLUSTER}/tasks/${TASK_ID}?region=${AWS_REGION}"
+echo
+
+# ── Block until the task stops, polling lastStatus ─────────────────────────
+DEADLINE=$(( $(date +%s) + TIMEOUT_SECONDS ))
+LAST_STATUS=""
+while true; do
+  DESC=$(aws ecs describe-tasks --cluster "$ECS_CLUSTER" --tasks "$TASK_ARN" \
+    --region "$AWS_REGION" --output json)
+  LAST_STATUS=$(echo "$DESC" | python3 -c "import json,sys; print(json.load(sys.stdin)['tasks'][0].get('lastStatus',''))")
+  if [ "$LAST_STATUS" = "STOPPED" ]; then
+    break
+  fi
+  if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+    echo "❌ Migration task did not stop within ${TIMEOUT_SECONDS}s (last status: ${LAST_STATUS})." >&2
+    echo "   Stopping the task to avoid a dangling migration." >&2
+    aws ecs stop-task --cluster "$ECS_CLUSTER" --task "$TASK_ARN" \
+      --reason "migration timeout" --region "$AWS_REGION" >/dev/null || true
+    exit 1
+  fi
+  echo "⏳ task ${LAST_STATUS:-PENDING}…"
+  sleep 10
+done
+
+# ── Print the migration logs, then propagate the container exit code ───────
+STREAM="copilot/${CONTAINER_NAME}/${TASK_ID}"
+echo
+echo "── Migration logs ──────────────────────────────────────────────"
+aws logs tail "$LOG_GROUP" --log-stream-name-prefix "$STREAM" \
+  --since 1h --region "$AWS_REGION" 2>/dev/null || echo "(logs unavailable)"
+echo "────────────────────────────────────────────────────────────────"
+echo
+
+# exitCode is null when the container never ran (image-pull failure, OOM kill,
+# …) — treat that as a failure too. stoppedReason/container reason go to stderr
+# for the CI log; only the numeric code lands on stdout for the gate.
+EXIT_CODE=$(echo "$DESC" | python3 -c "
+import json, sys
+t = json.load(sys.stdin)['tasks'][0]
+c = next((c for c in t.get('containers', []) if c.get('name') == '${CONTAINER_NAME}'), {})
+code = c.get('exitCode')
+print('reason:', t.get('stoppedReason', ''), '| container:', c.get('reason', ''), file=sys.stderr)
+print(code if code is not None else 'null')
+")
+
+if [ "$EXIT_CODE" = "0" ]; then
+  echo "✅ Migrations completed (exit 0)."
+  exit 0
+fi
+echo "❌ Migrations failed — exit code: ${EXIT_CODE}" >&2
+exit 1

--- a/deploy/aws/scripts/run-migrations.sh
+++ b/deploy/aws/scripts/run-migrations.sh
@@ -147,11 +147,33 @@ while true; do
 done
 
 # ── Print the migration logs, then propagate the container exit code ───────
+# CloudWatch creates/flushes the stream a few seconds after the task stops, so
+# poll for it before reading (get-log-events is reliable for a finished stream;
+# `logs tail` raced and returned nothing when queried immediately after STOP).
 STREAM="copilot/${CONTAINER_NAME}/${TASK_ID}"
 echo
 echo "── Migration logs ──────────────────────────────────────────────"
-aws logs tail "$LOG_GROUP" --log-stream-name-prefix "$STREAM" \
-  --since 1h --region "$AWS_REGION" 2>/dev/null || echo "(logs unavailable)"
+LOGS_PRINTED=0
+for _ in $(seq 1 15); do
+  if aws logs describe-log-streams \
+      --log-group-name "$LOG_GROUP" \
+      --log-stream-name-prefix "$STREAM" \
+      --region "$AWS_REGION" \
+      --query "logStreams[?logStreamName=='$STREAM'] | length(@)" \
+      --output text 2>/dev/null | grep -q "^1$"; then
+    aws logs get-log-events \
+      --log-group-name "$LOG_GROUP" \
+      --log-stream-name "$STREAM" \
+      --region "$AWS_REGION" \
+      --start-from-head --limit 500 \
+      --query 'events[*].message' --output text 2>/dev/null \
+      | tr '\t' '\n'
+    LOGS_PRINTED=1
+    break
+  fi
+  sleep 3
+done
+[ "$LOGS_PRINTED" = "1" ] || echo "(logs stream not available yet — see the console link above)"
 echo "────────────────────────────────────────────────────────────────"
 echo
 

--- a/packages/medusa-plugin-faire-store-sync/package.json
+++ b/packages/medusa-plugin-faire-store-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jytextiles/medusa-plugin-faire-store-sync",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/packages/medusa-plugin-faire-store-sync/src/admin/lib/api.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/admin/lib/api.ts
@@ -84,10 +84,17 @@ export const faireApi = {
   retrySync: (id: string) =>
     sdk.client.fetch(`/admin/faire/syncs/${id}`, { method: "POST" }),
   brand: () => sdk.client.fetch("/admin/faire/brand"),
-  taxonomy: () =>
-    sdk.client.fetch<{ taxonomy: Array<{ id: string; name: string }> }>(
-      "/admin/faire/taxonomy"
-    ),
+  taxonomy: (opts: { q?: string; limit?: number; ids?: string[] } = {}) => {
+    const query: Record<string, string> = {}
+    if (opts.q) query.q = opts.q
+    if (opts.limit !== undefined) query.limit = String(opts.limit)
+    if (opts.ids?.length) query.ids = opts.ids.join(",")
+    return sdk.client.fetch<{
+      taxonomy: Array<{ id: string; name: string }>
+      count: number
+      total: number
+    }>("/admin/faire/taxonomy", { query })
+  },
   products: (opts: { limit?: number; page?: string; updated_at_min?: string } = {}) => {
     const query: Record<string, string> = {}
     if (opts.limit !== undefined) query.limit = String(opts.limit)

--- a/packages/medusa-plugin-faire-store-sync/src/admin/routes/settings/faire/page.tsx
+++ b/packages/medusa-plugin-faire-store-sync/src/admin/routes/settings/faire/page.tsx
@@ -209,20 +209,26 @@ const FaireSettingsPage = () => {
           {connected ? (
             <div className="flex items-center gap-3">
               <StatusBadge color="green">Connected</StatusBadge>
-              <Button
-                size="small"
-                variant="secondary"
-                onClick={() => navigate("/settings/faire/bulk")}
-              >
-                Bulk sync
-              </Button>
-              <Button
-                size="small"
-                variant="secondary"
-                onClick={() => navigate("/settings/faire/settings")}
-              >
-                Sync settings
-              </Button>
+              <DropdownMenu>
+                <DropdownMenu.Trigger asChild>
+                  <Button size="small" variant="secondary">
+                    Sync
+                    <ChevronDownMini />
+                  </Button>
+                </DropdownMenu.Trigger>
+                <DropdownMenu.Content>
+                  <DropdownMenu.Item
+                    onClick={() => navigate("/settings/faire/bulk")}
+                  >
+                    Bulk sync
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Item
+                    onClick={() => navigate("/settings/faire/settings")}
+                  >
+                    Sync settings
+                  </DropdownMenu.Item>
+                </DropdownMenu.Content>
+              </DropdownMenu>
               <Button
                 size="small"
                 variant="danger"

--- a/packages/medusa-plugin-faire-store-sync/src/admin/widgets/faire-product-widget.tsx
+++ b/packages/medusa-plugin-faire-store-sync/src/admin/widgets/faire-product-widget.tsx
@@ -15,11 +15,16 @@ import {
   toast,
 } from "@medusajs/ui"
 import { DetailWidgetProps, AdminProduct } from "@medusajs/framework/types"
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { useMemo, useState } from "react"
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
+import { useEffect, useState } from "react"
 import { faireApi, sdk } from "../lib/api"
 
-const MAX_RENDERED = 60
+const PICKER_LIMIT = 50
 
 const badgeColor = (status?: string): "green" | "red" | "orange" | "grey" => {
   switch (status) {
@@ -102,28 +107,60 @@ const FaireProductWidget = ({ data }: DetailWidgetProps<AdminProduct>) => {
 
   const [pickerOpen, setPickerOpen] = useState(false)
   const [pickerSearch, setPickerSearch] = useState("")
+  // Debounce the typed query so each keystroke doesn't fire a request; the
+  // backend searches its cached taxonomy and returns only matches.
+  const [debouncedSearch, setDebouncedSearch] = useState("")
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(pickerSearch.trim()), 250)
+    return () => clearTimeout(t)
+  }, [pickerSearch])
+
   // Local echo of the saved pin so the panel updates instantly (the parent
   // product page's `data.metadata` only refreshes on its own refetch).
-  const [pinnedOverride, setPinnedOverride] = useState<string | null | undefined>(
-    undefined
-  )
+  const [pinnedOverride, setPinnedOverride] = useState<
+    { id: string | null; name: string | null } | undefined
+  >(undefined)
 
+  // Search results — server-side filtered + sliced (Faire has no search API, so
+  // the backend caches the full ~3k list and filters there). keepPreviousData
+  // avoids a flash of "loading" between keystrokes.
   const taxonomyQuery = useQuery({
-    queryKey: ["faire", "taxonomy"],
+    queryKey: ["faire", "taxonomy", "search", debouncedSearch],
     enabled: pickerOpen,
-    queryFn: async () => (await faireApi.taxonomy()).taxonomy ?? [],
+    placeholderData: keepPreviousData,
+    queryFn: async () =>
+      faireApi.taxonomy({
+        q: debouncedSearch || undefined,
+        limit: PICKER_LIMIT,
+      }),
   })
-  const taxonomy = taxonomyQuery.data ?? []
+  const results = taxonomyQuery.data?.taxonomy ?? []
+  const matchCount = taxonomyQuery.data?.count ?? 0
 
   const pinnedId: string | undefined =
     pinnedOverride !== undefined
-      ? pinnedOverride ?? undefined
+      ? pinnedOverride.id ?? undefined
       : metadata.faire_taxonomy_type_id
-  const pinnedName = useMemo(() => {
-    if (!pinnedId) return undefined
-    if (!/^tt_/.test(String(pinnedId))) return String(pinnedId)
-    return taxonomy.find((t: any) => t.id === pinnedId)?.name
-  }, [pinnedId, taxonomy])
+  const pinnedNameFromMeta: string | undefined =
+    pinnedOverride !== undefined
+      ? pinnedOverride.name ?? undefined
+      : metadata.faire_taxonomy_type_name
+
+  // Resolve the name of an already-pinned `tt_…` id when it wasn't stored
+  // alongside (legacy pins) — a targeted `ids` lookup, not the whole list.
+  const pinnedResolveQuery = useQuery({
+    queryKey: ["faire", "taxonomy", "resolve", pinnedId],
+    enabled: !!pinnedId && !pinnedNameFromMeta && /^tt_/.test(String(pinnedId)),
+    queryFn: async () =>
+      (await faireApi.taxonomy({ ids: [pinnedId!] })).taxonomy,
+  })
+  const pinnedName =
+    pinnedNameFromMeta ??
+    (pinnedId && /^tt_/.test(String(pinnedId))
+      ? pinnedResolveQuery.data?.[0]?.name
+      : pinnedId
+        ? String(pinnedId)
+        : undefined)
 
   // What the sync will actually use as the category source, for display.
   const resolvedSource = pinnedId
@@ -134,25 +171,21 @@ const FaireProductWidget = ({ data }: DetailWidgetProps<AdminProduct>) => {
         ? { label: productType, from: "type" as const }
         : { label: "Account fallback", from: "fallback" as const }
 
-  const filteredTaxonomy = useMemo(() => {
-    const q = pickerSearch.trim().toLowerCase()
-    const list = q
-      ? taxonomy.filter((t: any) => t.name.toLowerCase().includes(q))
-      : taxonomy
-    return list.slice(0, MAX_RENDERED)
-  }, [taxonomy, pickerSearch])
-
   const saveCategory = useMutation({
-    mutationFn: (value: string | null) =>
+    mutationFn: (choice: { id: string; name: string } | null) =>
       sdk.admin.product.update(data.id, {
-        metadata: { ...metadata, faire_taxonomy_type_id: value },
+        metadata: {
+          ...metadata,
+          faire_taxonomy_type_id: choice?.id ?? null,
+          faire_taxonomy_type_name: choice?.name ?? null,
+        },
       }),
-    onSuccess: (_res, value) => {
-      setPinnedOverride(value)
+    onSuccess: (_res, choice) => {
+      setPinnedOverride({ id: choice?.id ?? null, name: choice?.name ?? null })
       queryClient.invalidateQueries({ queryKey: ["product", data.id] })
       setPickerOpen(false)
       setPickerSearch("")
-      toast.success(value ? "Faire category set" : "Faire category cleared")
+      toast.success(choice ? "Faire category set" : "Faire category cleared")
     },
     onError: (err: any) =>
       toast.error("Failed to save category", { description: err?.message }),
@@ -299,16 +332,18 @@ const FaireProductWidget = ({ data }: DetailWidgetProps<AdminProduct>) => {
                 <Text size="small" className="text-ui-fg-subtle px-1 py-2">
                   Loading categories…
                 </Text>
-              ) : filteredTaxonomy.length === 0 ? (
+              ) : results.length === 0 ? (
                 <Text size="small" className="text-ui-fg-subtle px-1 py-2">
-                  No categories match “{pickerSearch}”.
+                  {debouncedSearch
+                    ? `No categories match “${debouncedSearch}”.`
+                    : "No categories available."}
                 </Text>
               ) : (
-                filteredTaxonomy.map((t: any) => (
+                results.map((t) => (
                   <button
                     key={t.id}
                     type="button"
-                    onClick={() => saveCategory.mutate(t.id)}
+                    onClick={() => saveCategory.mutate(t)}
                     disabled={saveCategory.isPending}
                     className={clx(
                       "flex items-center justify-between rounded-md px-3 py-2 text-left text-sm",
@@ -325,13 +360,12 @@ const FaireProductWidget = ({ data }: DetailWidgetProps<AdminProduct>) => {
                   </button>
                 ))
               )}
-              {!taxonomyQuery.isLoading &&
-                taxonomy.length > filteredTaxonomy.length && (
-                  <Text size="xsmall" className="text-ui-fg-muted px-1 py-1">
-                    Showing {filteredTaxonomy.length} of {taxonomy.length} — refine
-                    your search to narrow down.
-                  </Text>
-                )}
+              {!taxonomyQuery.isLoading && matchCount > results.length && (
+                <Text size="xsmall" className="text-ui-fg-muted px-1 py-1">
+                  Showing {results.length} of {matchCount} matches — refine your
+                  search to narrow down.
+                </Text>
+              )}
             </div>
           </Drawer.Body>
           <Drawer.Footer>

--- a/packages/medusa-plugin-faire-store-sync/src/api/admin/faire/taxonomy/route.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/api/admin/faire/taxonomy/route.ts
@@ -2,9 +2,37 @@ import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { FAIRE_SYNC_MODULE } from "../../../../modules/faire-sync"
 import FaireSyncService from "../../../../modules/faire-sync/service"
 
-// GET /admin/faire/taxonomy — taxonomy types from Faire's /products/types
+const DEFAULT_LIMIT = 50
+const MAX_LIMIT = 200
+
+// GET /admin/faire/taxonomy?q=&limit=&ids= — taxonomy types from Faire's
+// /products/types. Faire returns the full ~3k list unpaginated with no
+// server-side search, so the service caches the whole list and we filter/slice
+// HERE. The browser sends `q` and gets back only matches, instead of pulling
+// every row to filter client-side. `ids` resolves specific `tt_…` rows (used to
+// show the name of an already-pinned category without loading the whole list).
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const service: FaireSyncService = req.scope.resolve(FAIRE_SYNC_MODULE)
-  const types = await service.getTaxonomyTypes()
-  res.json({ taxonomy: types })
+  const q = String((req.query.q as string) ?? "").trim().toLowerCase()
+  const idsParam = String((req.query.ids as string) ?? "").trim()
+  const limit = Math.min(Number(req.query.limit) || DEFAULT_LIMIT, MAX_LIMIT)
+
+  const all = await service.getTaxonomyTypes()
+
+  if (idsParam) {
+    const ids = new Set(idsParam.split(",").map((s) => s.trim()).filter(Boolean))
+    const rows = all.filter((t) => ids.has(t.id))
+    res.json({ taxonomy: rows, count: rows.length, total: all.length })
+    return
+  }
+
+  const matched = q
+    ? all.filter((t) => t.name.toLowerCase().includes(q))
+    : all
+
+  res.json({
+    taxonomy: matched.slice(0, limit),
+    count: matched.length,
+    total: all.length,
+  })
 }

--- a/packages/medusa-plugin-faire-store-sync/src/jobs/refresh-faire-token.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/jobs/refresh-faire-token.ts
@@ -10,6 +10,11 @@ export default async function refreshFaireTokenJob(container: MedusaContainer) {
   if (!account) {
     return
   }
+  // API-key connections have no OAuth token to refresh — skip entirely so the
+  // cron never drives Faire's token endpoint (which 400s for non-OAuth creds).
+  if ((account as any).auth_mode === "apiKey") {
+    return
+  }
   try {
     await service.ensureFreshToken(account)
   } catch (err: any) {

--- a/packages/medusa-plugin-faire-store-sync/src/modules/faire-sync/service.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/modules/faire-sync/service.ts
@@ -208,6 +208,12 @@ class FaireSyncService extends MedusaService({
         "Faire account is not connected"
       )
     }
+    // API keys never expire and have no OAuth refresh flow — short-circuit
+    // before touching the refresh path. Without this, a stray token_expires_at
+    // on an apiKey account would drive the OAuth token endpoint and 400 hourly.
+    if (acct.auth_mode === "apiKey") {
+      return this.withDecryptedTokens(acct)
+    }
     if (!acct.token_expires_at) {
       return this.withDecryptedTokens(acct)
     }
@@ -225,7 +231,8 @@ class FaireSyncService extends MedusaService({
       )
     }
     try {
-      const client = this.getClient()
+      // OAuth-only path (apiKey accounts short-circuited above).
+      const client = this.getClient("oauth")
       const token = await client.refreshAccessToken(refreshToken)
       const updated = await this.updateFaireSyncAccounts({
         id: acct.id,

--- a/packages/medusa-plugin-faire-store-sync/src/workflows/sync-product-to-faire.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/workflows/sync-product-to-faire.ts
@@ -281,6 +281,20 @@ const prepareProductStep = createStep(
           }
     )
 
+    // Faire requires `unit_multiplier` — the number of individual units in one
+    // sellable unit (e.g. a case of 6) — as a positive integer, or it rejects
+    // the create with 400 "unit multiplier is mandatory…". Default to 1 (sold
+    // individually); allow a per-product override via metadata.
+    const toPositiveInt = (v: any): number | null => {
+      const n = Math.floor(Number(v))
+      return Number.isFinite(n) && n > 0 ? n : null
+    }
+    const unit_multiplier = toPositiveInt(metadata.faire_unit_multiplier) ?? 1
+    const minimum_order_quantity =
+      toPositiveInt(metadata.faire_min_order_quantity) ??
+      toPositiveInt(settings.default_min_order_quantity) ??
+      1
+
     const product_input: CreateProductInput = {
       name: (product.title || "Untitled Product").slice(0, 140),
       idempotence_token: product.id,
@@ -291,6 +305,8 @@ const prepareProductStep = createStep(
         typeof metadata.faire_short_description === "string"
           ? metadata.faire_short_description
           : undefined,
+      unit_multiplier,
+      minimum_order_quantity,
       images,
       variants: builtVariants,
     }


### PR DESCRIPTION
## Why

Two things, from a live prod investigation into Faire product-sync 400s.

### 1. Faire product creation was failing with a 400 (the real blocker)

Prod logs (`POST /admin/faire/sync/product/…`) showed:

```
FaireApiError: Faire API 400: unit multiplier is mandatory and should always be a positive integer
  at FaireClient.createProduct
```

Auth is fine — the request reached Faire and got a **validation** 400. `unit_multiplier` was declared on `CreateProductInput` but **never assigned** in the payload build, so every create was rejected.

**Fix:** always send `unit_multiplier` (default `1`, per-product override via `metadata.faire_unit_multiplier`) plus `minimum_order_quantity` (`metadata` → `settings.default_min_order_quantity` → `1`).

> The earlier hypothesis (expired OAuth refresh token) was a misdiagnosis. The active account is **API-key** (`token_expires_at: null`); the API-key reconnect overwrote the old OAuth row in place, so `ensureFreshToken` early-returns and never refreshes. The historical hourly `OAuth2 token refresh failed: 400` were pre-reconnect and are already dormant.

### 2. Prod migrations blocked server boot

The server container ran `predeploy:force && start` inline, so every rolling deploy had to finish all migrations before `/health` passed — slow, and coupled schema changes to boot.

## What changed

**Faire plugin (0.2.9 → 0.2.10):**
- ✅ Send `unit_multiplier` + `minimum_order_quantity` on create — `workflows/sync-product-to-faire.ts`
- 🛡️ Guard the OAuth refresh path so it can never fire for `auth_mode === "apiKey"` — `service.ts`, `jobs/refresh-faire-token.ts`
- 🔎 Taxonomy **search on demand**: Faire's `/products/types` has no server-side search (returns all ~3k), so the backend caches the full list and `/admin/faire/taxonomy` now accepts `?q=`/`?limit=`/`?ids=`; the widget debounces and stores the pinned category name for display
- 🎛️ Move "Bulk sync" + "Sync settings" into a **Sync ▾** dropdown

**Decouple migrations from boot:**
- New `deploy/aws/scripts/run-migrations.sh` — gated one-off ECS task on the freshly-built image; blocks on the task and propagates its exit code
- `deploy-to-aws.yml` gains a `migrate` job: `build → mirror → migrate → {server, worker} → health`. Deploy jobs `needs: migrate`, so services never roll onto un-migrated schema and a migration failure fails the deploy while old tasks keep serving
- `apps/backend/Dockerfile` CMD is `start`-only for both roles (escape hatch `RUN_MIGRATIONS_ON_BOOT=1`)

## Verification
- `tsc --noEmit` clean on the plugin; `deploy-to-aws.yml` YAML + job graph validated
- **Faire:** after the plugin republishes + deploys, re-sync `prod_01JPSVM8HNRF4VSK9DWYKB8TCQ` (Cici Label) — should publish instead of 400
- **Migrations:** first deploy on this branch's merge exercises the new `Migrate DB` job (tails the task's CloudWatch logs + prints exit code)

## Notes
- The plugin reaches prod via `publish-faire-plugin.yml` (version bump + merge → publish + lockfile refloat → deploy)
- Migrations must stay backward-compatible during the brief old-code/new-schema overlap — same constraint as the previous inline+rolling deploy, no new risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)