### PR TITLE
feat(hosting): multi-provider storefront provisioning with account rotation (#884)

### DIFF
--- a/apps/backend/src/admin/hooks/api/deployment-accounts.ts
+++ b/apps/backend/src/admin/hooks/api/deployment-accounts.ts
@@ -1,0 +1,149 @@
+import { toast } from "@medusajs/ui"
+import {
+  QueryKey,
+  UseMutationResult,
+  UseQueryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
+import { FetchError } from "@medusajs/js-sdk"
+
+import { sdk } from "../../lib/config"
+import { queryKeysFactory } from "../../lib/query-key-factory"
+
+export type DeploymentProvider = "vercel" | "cloudflare" | "render" | "netlify"
+export type DeploymentAccountStatus = "active" | "full" | "inactive"
+
+export type AdminDeploymentAccount = {
+  id: string
+  provider: DeploymentProvider
+  role: string
+  label: string
+  api_config: Record<string, any> & { token_present?: boolean }
+  cutoff_max: number | null
+  project_count: number
+  priority: number
+  status: DeploymentAccountStatus
+  remaining_capacity: number | null
+  created_at?: string
+  updated_at?: string
+}
+
+export type AdminDeploymentAccountListResponse = {
+  deployment_accounts: AdminDeploymentAccount[]
+  count: number
+  offset: number
+  limit: number
+}
+
+export type AdminDeploymentAccountResponse = {
+  deployment_account: AdminDeploymentAccount
+}
+
+export type CreateDeploymentAccountPayload = {
+  provider: DeploymentProvider
+  label: string
+  token: string
+  role?: string
+  cutoff_max?: number | null
+  priority?: number
+  status?: DeploymentAccountStatus
+  team_id?: string
+  account_id?: string
+  zone_id?: string
+  github_installation_id?: string
+  github_repo_id?: string
+  owner_id?: string
+  region?: string
+  plan?: string
+}
+
+export type UpdateDeploymentAccountPayload = Partial<
+  Omit<CreateDeploymentAccountPayload, "provider">
+>
+
+export const deploymentAccountsQueryKeys = queryKeysFactory<
+  "deployment_accounts",
+  CreateDeploymentAccountPayload | UpdateDeploymentAccountPayload
+>("deployment_accounts")
+
+export const useDeploymentAccounts = (
+  query?: Record<string, any>,
+  options?: Omit<
+    UseQueryOptions<
+      AdminDeploymentAccountListResponse,
+      FetchError,
+      AdminDeploymentAccountListResponse,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: deploymentAccountsQueryKeys.list(query),
+    queryFn: async () =>
+      sdk.client.fetch<AdminDeploymentAccountListResponse>(
+        `/admin/deployment-accounts`,
+        { method: "GET", query }
+      ),
+    ...options,
+  })
+  return { ...data, ...rest }
+}
+
+export const useCreateDeploymentAccount = (): UseMutationResult<
+  AdminDeploymentAccountResponse,
+  Error,
+  CreateDeploymentAccountPayload
+> => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (payload) =>
+      sdk.client.fetch(`/admin/deployment-accounts`, {
+        method: "POST",
+        body: payload,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: deploymentAccountsQueryKeys.lists() })
+    },
+    onError: (e: any) => {
+      toast.error(e?.message || "Failed to create hosting account")
+    },
+  })
+}
+
+export const useUpdateDeploymentAccount = (
+  id: string
+): UseMutationResult<AdminDeploymentAccountResponse, Error, UpdateDeploymentAccountPayload> => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (payload) =>
+      sdk.client.fetch(`/admin/deployment-accounts/${id}`, {
+        method: "POST",
+        body: payload,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: deploymentAccountsQueryKeys.all })
+    },
+    onError: (e: any) => {
+      toast.error(e?.message || "Failed to update hosting account")
+    },
+  })
+}
+
+export const useDeleteDeploymentAccount = (
+  id: string
+): UseMutationResult<{ id: string; deleted: boolean }, Error, void> => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async () =>
+      sdk.client.fetch(`/admin/deployment-accounts/${id}`, { method: "DELETE" }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: deploymentAccountsQueryKeys.all })
+    },
+    onError: (e: any) => {
+      toast.error(e?.message || "Failed to delete hosting account")
+    },
+  })
+}

--- a/apps/backend/src/admin/routes/settings/deployment-accounts/page.tsx
+++ b/apps/backend/src/admin/routes/settings/deployment-accounts/page.tsx
@@ -1,0 +1,495 @@
+import { defineRouteConfig } from "@medusajs/admin-sdk"
+import { RocketLaunch } from "@medusajs/icons"
+import {
+  Badge,
+  Button,
+  Container,
+  Drawer,
+  DropdownMenu,
+  FocusModal,
+  Heading,
+  IconButton,
+  Input,
+  Label,
+  Select,
+  StatusBadge,
+  Table,
+  Text,
+  toast,
+} from "@medusajs/ui"
+import { EllipsisHorizontal, PencilSquare, Trash } from "@medusajs/icons"
+import { useMemo, useState } from "react"
+import {
+  AdminDeploymentAccount,
+  DeploymentAccountStatus,
+  DeploymentProvider,
+  useCreateDeploymentAccount,
+  useDeleteDeploymentAccount,
+  useDeploymentAccounts,
+  useUpdateDeploymentAccount,
+} from "../../../hooks/api/deployment-accounts"
+
+const PROVIDERS: { value: DeploymentProvider; label: string }[] = [
+  { value: "cloudflare", label: "Cloudflare Pages" },
+  { value: "netlify", label: "Netlify" },
+  { value: "render", label: "Render" },
+  { value: "vercel", label: "Vercel" },
+]
+
+const STATUSES: { value: DeploymentAccountStatus; label: string }[] = [
+  { value: "active", label: "Active" },
+  { value: "full", label: "Full (cutoff)" },
+  { value: "inactive", label: "Inactive" },
+]
+
+function providerLabel(p: string): string {
+  return PROVIDERS.find((x) => x.value === p)?.label ?? p
+}
+
+function statusColor(s: string): "green" | "orange" | "grey" | "red" {
+  switch (s) {
+    case "active":
+      return "green"
+    case "full":
+      return "orange"
+    case "inactive":
+      return "grey"
+    default:
+      return "grey"
+  }
+}
+
+// Provider-specific config fields (mirrors HostingCredentials.extra + ids).
+type FieldDef = { key: string; label: string; required?: boolean; help?: string }
+
+function providerConfigFields(provider: DeploymentProvider): FieldDef[] {
+  switch (provider) {
+    case "cloudflare":
+      return [
+        { key: "account_id", label: "Cloudflare Account ID", required: true },
+        { key: "zone_id", label: "DNS Zone ID", help: "Optional — for the platform DNS zone." },
+      ]
+    case "netlify":
+      return [
+        { key: "account_id", label: "Netlify Team/Account ID", required: true, help: "Used for the env-vars API." },
+        { key: "github_installation_id", label: "GitHub App Installation ID", required: true, help: "Install the Netlify GitHub App once, then paste its installation id." },
+        { key: "github_repo_id", label: "GitHub Repo ID", help: "Optional numeric id; Netlify resolves it when omitted." },
+      ]
+    case "render":
+      return [
+        { key: "owner_id", label: "Render Owner ID", required: true, help: "From GET /v1/owners." },
+        { key: "region", label: "Region", help: "Default: oregon." },
+        { key: "plan", label: "Plan", help: "Default: starter." },
+      ]
+    case "vercel":
+      return [{ key: "team_id", label: "Vercel Team ID", help: "Optional — personal accounts omit it." }]
+    default:
+      return []
+  }
+}
+
+// ── Shared form fields (create + edit) ──────────────────────────────────────
+type FormState = Record<string, string> & {
+  label: string
+  token: string
+  cutoff_max: string
+  priority: string
+  status: DeploymentAccountStatus
+}
+
+function AccountFields({
+  provider,
+  form,
+  set,
+  isEdit,
+}: {
+  provider: DeploymentProvider
+  form: FormState
+  set: (key: string, value: string) => void
+  isEdit?: boolean
+}) {
+  return (
+    <div className="flex flex-col gap-y-4">
+      <div className="flex flex-col gap-y-2">
+        <Label size="small" weight="plus">Label</Label>
+        <Input
+          placeholder="e.g. cf-pages-free-1"
+          value={form.label}
+          onChange={(e) => set("label", e.target.value)}
+        />
+      </div>
+
+      <div className="flex flex-col gap-y-2">
+        <Label size="small" weight="plus">
+          API Token{isEdit ? "" : " *"}
+        </Label>
+        <Input
+          type="password"
+          placeholder={isEdit ? "Leave blank to keep the current token" : "Provider API token / key"}
+          value={form.token}
+          onChange={(e) => set("token", e.target.value)}
+        />
+        <Text size="small" className="text-ui-fg-subtle">
+          Encrypted at rest. {isEdit ? "Only enter a value to rotate it." : ""}
+        </Text>
+      </div>
+
+      {providerConfigFields(provider).map((f) => (
+        <div key={f.key} className="flex flex-col gap-y-2">
+          <Label size="small" weight="plus">
+            {f.label}{f.required ? " *" : ""}
+          </Label>
+          <Input value={form[f.key] || ""} onChange={(e) => set(f.key, e.target.value)} />
+          {f.help && (
+            <Text size="small" className="text-ui-fg-subtle">{f.help}</Text>
+          )}
+        </div>
+      ))}
+
+      <div className="grid grid-cols-2 gap-x-3">
+        <div className="flex flex-col gap-y-2">
+          <Label size="small" weight="plus">Cutoff max</Label>
+          <Input
+            type="number"
+            placeholder="Free-tier ceiling (blank = unlimited)"
+            value={form.cutoff_max}
+            onChange={(e) => set("cutoff_max", e.target.value)}
+          />
+        </div>
+        <div className="flex flex-col gap-y-2">
+          <Label size="small" weight="plus">Priority</Label>
+          <Input
+            type="number"
+            placeholder="0"
+            value={form.priority}
+            onChange={(e) => set("priority", e.target.value)}
+          />
+        </div>
+      </div>
+
+      {isEdit && (
+        <div className="flex flex-col gap-y-2">
+          <Label size="small" weight="plus">Status</Label>
+          <Select value={form.status} onValueChange={(v) => set("status", v)}>
+            <Select.Trigger>
+              <Select.Value />
+            </Select.Trigger>
+            <Select.Content>
+              {STATUSES.map((s) => (
+                <Select.Item key={s.value} value={s.value}>{s.label}</Select.Item>
+              ))}
+            </Select.Content>
+          </Select>
+          <Text size="small" className="text-ui-fg-subtle">
+            Set “Full” to cut off new provisions; raise Cutoff max to round up on upgrade.
+          </Text>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function buildPayload(form: FormState, provider: DeploymentProvider, isEdit: boolean) {
+  const payload: Record<string, any> = {
+    label: form.label.trim(),
+    priority: form.priority ? Number(form.priority) : 0,
+  }
+  if (!isEdit) payload.provider = provider
+  if (form.token) payload.token = form.token
+  payload.cutoff_max = form.cutoff_max ? Number(form.cutoff_max) : null
+  if (isEdit) payload.status = form.status
+  for (const f of providerConfigFields(provider)) {
+    if (form[f.key]) payload[f.key] = form[f.key]
+  }
+  return payload
+}
+
+const emptyForm = (): FormState => ({
+  label: "",
+  token: "",
+  cutoff_max: "",
+  priority: "",
+  status: "active",
+})
+
+// ── Create (FocusModal) ─────────────────────────────────────────────────────
+function CreateAccountModal() {
+  const [open, setOpen] = useState(false)
+  const [provider, setProvider] = useState<DeploymentProvider>("cloudflare")
+  const [form, setForm] = useState<FormState>(emptyForm())
+  const create = useCreateDeploymentAccount()
+  const set = (key: string, value: string) => setForm((f) => ({ ...f, [key]: value }))
+
+  const reset = () => {
+    setForm(emptyForm())
+    setProvider("cloudflare")
+  }
+
+  const handleSubmit = () => {
+    if (!form.label.trim()) return toast.error("Label is required")
+    if (!form.token) return toast.error("API token is required")
+    for (const f of providerConfigFields(provider)) {
+      if (f.required && !form[f.key]) return toast.error(`${f.label} is required`)
+    }
+    create.mutate(buildPayload(form, provider, false) as any, {
+      onSuccess: () => {
+        toast.success("Hosting account added")
+        setOpen(false)
+        reset()
+      },
+    })
+  }
+
+  return (
+    <FocusModal open={open} onOpenChange={(o) => { setOpen(o); if (!o) reset() }}>
+      <FocusModal.Trigger asChild>
+        <Button size="small" variant="secondary">Add account</Button>
+      </FocusModal.Trigger>
+      <FocusModal.Content>
+        <div className="flex h-full flex-col overflow-hidden">
+          <FocusModal.Header>
+            <div className="flex items-center justify-end gap-x-2">
+              <FocusModal.Close asChild>
+                <Button size="small" variant="secondary" disabled={create.isPending}>Cancel</Button>
+              </FocusModal.Close>
+              <Button size="small" onClick={handleSubmit} isLoading={create.isPending}>Add account</Button>
+            </div>
+          </FocusModal.Header>
+          <FocusModal.Body className="flex-1 overflow-auto">
+            <div className="mx-auto flex w-full max-w-lg flex-col gap-y-6 py-8">
+              <div className="flex flex-col gap-y-1">
+                <Heading level="h2">New hosting account</Heading>
+                <Text size="small" className="text-ui-fg-subtle">
+                  A rotatable provider account. New storefronts provision onto the least-loaded active account under its cutoff.
+                </Text>
+              </div>
+
+              <div className="flex flex-col gap-y-2">
+                <Label size="small" weight="plus">Provider</Label>
+                <Select value={provider} onValueChange={(v) => setProvider(v as DeploymentProvider)}>
+                  <Select.Trigger>
+                    <Select.Value />
+                  </Select.Trigger>
+                  <Select.Content>
+                    {PROVIDERS.map((p) => (
+                      <Select.Item key={p.value} value={p.value}>{p.label}</Select.Item>
+                    ))}
+                  </Select.Content>
+                </Select>
+              </div>
+
+              <AccountFields provider={provider} form={form} set={set} />
+            </div>
+          </FocusModal.Body>
+        </div>
+      </FocusModal.Content>
+    </FocusModal>
+  )
+}
+
+// ── Edit (Drawer) ───────────────────────────────────────────────────────────
+function EditAccountDrawer({
+  account,
+  open,
+  onOpenChange,
+}: {
+  account: AdminDeploymentAccount
+  open: boolean
+  onOpenChange: (o: boolean) => void
+}) {
+  const update = useUpdateDeploymentAccount(account.id)
+  const [form, setForm] = useState<FormState>(() => ({
+    label: account.label || "",
+    token: "",
+    cutoff_max: account.cutoff_max != null ? String(account.cutoff_max) : "",
+    priority: account.priority != null ? String(account.priority) : "",
+    status: account.status,
+    ...Object.fromEntries(
+      providerConfigFields(account.provider).map((f) => [f.key, account.api_config?.[f.key] ?? ""])
+    ),
+  }))
+  const set = (key: string, value: string) => setForm((f) => ({ ...f, [key]: value }))
+
+  const handleSubmit = () => {
+    if (!form.label.trim()) return toast.error("Label is required")
+    update.mutate(buildPayload(form, account.provider, true) as any, {
+      onSuccess: () => {
+        toast.success("Hosting account updated")
+        onOpenChange(false)
+      },
+    })
+  }
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <Drawer.Content>
+        <Drawer.Header>
+          <Drawer.Title>{providerLabel(account.provider)} · {account.label}</Drawer.Title>
+        </Drawer.Header>
+        <Drawer.Body className="flex flex-1 flex-col overflow-y-auto">
+          <AccountFields provider={account.provider} form={form} set={set} isEdit />
+        </Drawer.Body>
+        <Drawer.Footer>
+          <Drawer.Close asChild>
+            <Button size="small" variant="secondary" disabled={update.isPending}>Cancel</Button>
+          </Drawer.Close>
+          <Button size="small" onClick={handleSubmit} isLoading={update.isPending}>Save</Button>
+        </Drawer.Footer>
+      </Drawer.Content>
+    </Drawer>
+  )
+}
+
+// ── Row actions ─────────────────────────────────────────────────────────────
+function RowActions({ account }: { account: AdminDeploymentAccount }) {
+  const [editOpen, setEditOpen] = useState(false)
+  const update = useUpdateDeploymentAccount(account.id)
+  const del = useDeleteDeploymentAccount(account.id)
+
+  const toggleCutoff = () => {
+    const next = account.status === "full" ? "active" : "full"
+    update.mutate({ status: next }, {
+      onSuccess: () => toast.success(next === "full" ? "Account cut off" : "Account reactivated"),
+    })
+  }
+
+  const handleDelete = () => {
+    if (!confirm(`Delete hosting account “${account.label}”? This does not delete already-provisioned storefronts.`)) return
+    del.mutate(undefined, { onSuccess: () => toast.success("Hosting account deleted") })
+  }
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenu.Trigger asChild>
+          <IconButton size="small" variant="transparent">
+            <EllipsisHorizontal />
+          </IconButton>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <DropdownMenu.Item className="gap-x-2" onClick={() => setEditOpen(true)}>
+            <PencilSquare className="text-ui-fg-subtle" />
+            Edit
+          </DropdownMenu.Item>
+          <DropdownMenu.Item className="gap-x-2" onClick={toggleCutoff}>
+            <RocketLaunch className="text-ui-fg-subtle" />
+            {account.status === "full" ? "Reactivate" : "Cut off (mark full)"}
+          </DropdownMenu.Item>
+          <DropdownMenu.Separator />
+          <DropdownMenu.Item className="gap-x-2" onClick={handleDelete}>
+            <Trash className="text-ui-fg-subtle" />
+            Delete
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu>
+      {editOpen && (
+        <EditAccountDrawer account={account} open={editOpen} onOpenChange={setEditOpen} />
+      )}
+    </>
+  )
+}
+
+// ── Page ────────────────────────────────────────────────────────────────────
+const DeploymentAccountsPage = () => {
+  const { deployment_accounts, isLoading, isError } = useDeploymentAccounts({ limit: 200 })
+
+  const accounts = useMemo(
+    () => (deployment_accounts || []) as AdminDeploymentAccount[],
+    [deployment_accounts]
+  )
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex flex-col gap-y-1">
+          <Heading level="h2">Storefront hosting</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            Rotatable provider accounts. New partner storefronts provision onto the least-loaded active account under its cutoff.
+          </Text>
+        </div>
+        <CreateAccountModal />
+      </div>
+
+      {isLoading ? (
+        <div className="px-6 py-8">
+          <Text size="small" className="text-ui-fg-subtle">Loading…</Text>
+        </div>
+      ) : isError ? (
+        <div className="px-6 py-8">
+          <Text size="small" className="text-ui-fg-error">Failed to load hosting accounts.</Text>
+        </div>
+      ) : accounts.length === 0 ? (
+        <div className="px-6 py-8">
+          <Text size="small" className="text-ui-fg-subtle">
+            No hosting accounts yet. Add one to start rotating storefront provisioning across free tiers.
+          </Text>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <Table>
+            <Table.Header>
+              <Table.Row>
+                <Table.HeaderCell>Provider</Table.HeaderCell>
+                <Table.HeaderCell>Label</Table.HeaderCell>
+                <Table.HeaderCell>Status</Table.HeaderCell>
+                <Table.HeaderCell>Load</Table.HeaderCell>
+                <Table.HeaderCell>Priority</Table.HeaderCell>
+                <Table.HeaderCell>Token</Table.HeaderCell>
+                <Table.HeaderCell />
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {accounts.map((a) => {
+                const load =
+                  a.cutoff_max != null
+                    ? `${a.project_count} / ${a.cutoff_max}`
+                    : `${a.project_count}`
+                return (
+                  <Table.Row key={a.id}>
+                    <Table.Cell>{providerLabel(a.provider)}</Table.Cell>
+                    <Table.Cell>
+                      <Text size="small" className="font-medium">{a.label}</Text>
+                    </Table.Cell>
+                    <Table.Cell>
+                      <StatusBadge color={statusColor(a.status)}>{a.status}</StatusBadge>
+                    </Table.Cell>
+                    <Table.Cell>
+                      <div className="flex items-center gap-x-2">
+                        <Text size="small">{load}</Text>
+                        {a.remaining_capacity === 0 && (
+                          <Badge color="orange" size="2xsmall">at cap</Badge>
+                        )}
+                      </div>
+                    </Table.Cell>
+                    <Table.Cell>{a.priority ?? 0}</Table.Cell>
+                    <Table.Cell>
+                      {a.api_config?.token_present ? (
+                        <Badge color="green" size="2xsmall">set</Badge>
+                      ) : (
+                        <Badge color="red" size="2xsmall">missing</Badge>
+                      )}
+                    </Table.Cell>
+                    <Table.Cell className="text-right">
+                      <RowActions account={a} />
+                    </Table.Cell>
+                  </Table.Row>
+                )
+              })}
+            </Table.Body>
+          </Table>
+        </div>
+      )}
+    </Container>
+  )
+}
+
+export const config = defineRouteConfig({
+  label: "Storefront Hosting",
+  icon: RocketLaunch,
+})
+
+export const handle = {
+  breadcrumb: () => "Storefront Hosting",
+}
+
+export default DeploymentAccountsPage

--- a/apps/backend/src/api/admin/deployment-accounts/[id]/route.ts
+++ b/apps/backend/src/api/admin/deployment-accounts/[id]/route.ts
@@ -1,0 +1,59 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { DEPLOYMENT_MODULE } from "../../../../modules/deployment"
+import type DeploymentService from "../../../../modules/deployment/service"
+import { buildApiConfig, redactDeploymentAccount } from "../helpers"
+import type { UpdateDeploymentAccountBody } from "../validators"
+
+async function retrieveOr404(
+  deployment: DeploymentService,
+  id: string
+): Promise<any> {
+  try {
+    return await deployment.retrieveDeploymentAccount(id)
+  } catch {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, `Deployment account ${id} not found`)
+  }
+}
+
+/** GET /admin/deployment-accounts/:id — retrieve (redacted). */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const deployment: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
+  const account = await retrieveOr404(deployment, req.params.id)
+  res.json({ deployment_account: redactDeploymentAccount(account) })
+}
+
+/**
+ * POST/PUT /admin/deployment-accounts/:id — update. Token is only re-encrypted
+ * when a non-empty `token` is supplied; other api_config fields merge onto the
+ * existing config. `status: "full"` is the manual cutoff; raising `cutoff_max`
+ * is the "round-up" on upgrade.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const body = (req.validatedBody || req.body) as UpdateDeploymentAccountBody
+  const deployment: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
+  const existing = await retrieveOr404(deployment, req.params.id)
+
+  const api_config = buildApiConfig(body, req.scope, existing.api_config)
+
+  const update: Record<string, any> = { id: req.params.id, api_config }
+  if (body.label !== undefined) update.label = body.label
+  if (body.role !== undefined) update.role = body.role
+  if (body.cutoff_max !== undefined) update.cutoff_max = body.cutoff_max
+  if (body.priority !== undefined) update.priority = body.priority
+  if (body.status !== undefined) update.status = body.status
+
+  await deployment.updateDeploymentAccounts(update)
+  const updated = await deployment.retrieveDeploymentAccount(req.params.id)
+  res.json({ deployment_account: redactDeploymentAccount(updated) })
+}
+
+export const PUT = POST
+
+/** DELETE /admin/deployment-accounts/:id. */
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const deployment: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
+  await retrieveOr404(deployment, req.params.id)
+  await deployment.deleteDeploymentAccounts(req.params.id)
+  res.json({ id: req.params.id, object: "deployment_account", deleted: true })
+}

--- a/apps/backend/src/api/admin/deployment-accounts/helpers.ts
+++ b/apps/backend/src/api/admin/deployment-accounts/helpers.ts
@@ -1,0 +1,64 @@
+import type { MedusaContainer } from "@medusajs/framework"
+import { ENCRYPTION_MODULE } from "../../../modules/encryption"
+import type EncryptionService from "../../../modules/encryption/service"
+import { remainingCapacity, type DeploymentAccountRow } from "../../../modules/deployment/account-selector"
+import { API_CONFIG_KEYS } from "./validators"
+
+/**
+ * Build the stored `api_config` for a deployment_account:
+ *   - token → token_encrypted (AES-256-GCM via the encryption module)
+ *   - every non-secret provider field stored plainly
+ * On update, `existing` is merged so unspecified fields (and the token when
+ * omitted) survive.
+ */
+export function buildApiConfig(
+  input: Record<string, any>,
+  container: MedusaContainer,
+  existing?: Record<string, any> | null
+): Record<string, any> {
+  const cfg: Record<string, any> = { ...(existing || {}) }
+
+  // Non-secret provider fields (undefined = leave as-is; null/"" would blank).
+  for (const key of API_CONFIG_KEYS) {
+    if (input[key] !== undefined) cfg[key] = input[key]
+  }
+
+  // Token: only (re)encrypt when a non-empty value is supplied.
+  if (typeof input.token === "string" && input.token.length > 0) {
+    const encryption = container.resolve(ENCRYPTION_MODULE) as EncryptionService
+    cfg.token_encrypted = encryption.encrypt(input.token)
+    // Never keep a plaintext token in the stored config.
+    delete cfg.token
+  }
+
+  return cfg
+}
+
+/**
+ * Redact a deployment_account row for API responses: strip the encrypted token
+ * blob, expose a `token_present` boolean instead, and surface live capacity.
+ */
+export function redactDeploymentAccount(account: any): any {
+  const api_config = (account?.api_config || {}) as Record<string, any>
+  const { token_encrypted, token, ...safeConfig } = api_config
+
+  const row: DeploymentAccountRow = {
+    id: account.id,
+    provider: account.provider,
+    label: account.label,
+    cutoff_max: account.cutoff_max,
+    project_count: account.project_count,
+    priority: account.priority,
+    status: account.status,
+  }
+  const cap = remainingCapacity(row)
+
+  return {
+    ...account,
+    api_config: {
+      ...safeConfig,
+      token_present: !!(token_encrypted || token),
+    },
+    remaining_capacity: Number.isFinite(cap) ? cap : null, // null = uncapped
+  }
+}

--- a/apps/backend/src/api/admin/deployment-accounts/route.ts
+++ b/apps/backend/src/api/admin/deployment-accounts/route.ts
@@ -1,0 +1,65 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { DEPLOYMENT_MODULE } from "../../../modules/deployment"
+import type DeploymentService from "../../../modules/deployment/service"
+import { buildApiConfig, redactDeploymentAccount } from "./helpers"
+import type { CreateDeploymentAccountBody } from "./validators"
+
+/**
+ * GET /admin/deployment-accounts — list rotatable hosting accounts (redacted).
+ * Filters: q (label), provider, status. Ordered by provider, then priority desc.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const deployment: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
+  const query = (req.validatedQuery || req.query) as Record<string, any>
+
+  const filters: Record<string, any> = {}
+  if (query.provider) filters.provider = query.provider
+  if (query.status) filters.status = query.status
+
+  const [accounts, count] = await deployment.listAndCountDeploymentAccounts(filters, {
+    take: query.limit ? Number(query.limit) : 100,
+    skip: query.offset ? Number(query.offset) : 0,
+    order: { provider: "ASC", priority: "DESC" },
+  })
+
+  const q = (query.q as string | undefined)?.toLowerCase()
+  const filtered = q
+    ? accounts.filter((a: any) => (a.label || "").toLowerCase().includes(q))
+    : accounts
+
+  res.json({
+    deployment_accounts: filtered.map(redactDeploymentAccount),
+    count,
+    offset: query.offset ? Number(query.offset) : 0,
+    limit: query.limit ? Number(query.limit) : 100,
+  })
+}
+
+/**
+ * POST /admin/deployment-accounts — register a new hosting account. The token
+ * is encrypted at rest; other provider ids are stored in api_config.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const body = (req.validatedBody || req.body) as CreateDeploymentAccountBody
+  const deployment: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
+
+  const api_config = buildApiConfig(body, req.scope)
+
+  const created = await deployment.createDeploymentAccounts({
+    provider: body.provider,
+    role: body.role || "hosting",
+    label: body.label,
+    api_config,
+    cutoff_max: body.cutoff_max ?? null,
+    priority: body.priority ?? 0,
+    status: body.status ?? "active",
+  })
+
+  const account = Array.isArray(created) ? created[0] : created
+  if (!account) {
+    throw new MedusaError(MedusaError.Types.UNEXPECTED_STATE, "Failed to create deployment account")
+  }
+
+  res.status(201).json({ deployment_account: redactDeploymentAccount(account) })
+}

--- a/apps/backend/src/api/admin/deployment-accounts/validators.ts
+++ b/apps/backend/src/api/admin/deployment-accounts/validators.ts
@@ -1,0 +1,84 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * Deployment-account admin validators (#884 S4).
+ *
+ * A deployment_account is a rotatable hosting-provider account. The `token` is
+ * the only secret — it is encrypted at rest into `api_config.token_encrypted`;
+ * every other field is non-secret provider config stored plainly in api_config
+ * (or as a typed column: provider/label/cutoff_max/priority/status).
+ */
+
+export const DeploymentProviderSchema = z.enum([
+  "vercel",
+  "cloudflare",
+  "render",
+  "netlify",
+])
+
+export const DeploymentAccountStatusSchema = z.enum(["active", "full", "inactive"])
+
+// Non-secret provider config fields (mirrors HostingCredentials.extra + ids).
+const providerConfigFields = {
+  team_id: z.string().optional(),
+  account_id: z.string().optional(),
+  zone_id: z.string().optional(),
+  github_installation_id: z.string().optional(),
+  github_repo_id: z.string().optional(),
+  owner_id: z.string().optional(),
+  region: z.string().optional(),
+  plan: z.string().optional(),
+}
+
+export const CreateDeploymentAccountSchema = z
+  .object({
+    provider: DeploymentProviderSchema,
+    label: z.string().min(1),
+    role: z.string().optional(),
+    /** The API token/PAT/key — required on create; encrypted at rest. */
+    token: z.string().min(1),
+    cutoff_max: z.number().int().positive().nullable().optional(),
+    priority: z.number().int().optional(),
+    status: DeploymentAccountStatusSchema.optional(),
+    ...providerConfigFields,
+  })
+  .strict()
+
+export const UpdateDeploymentAccountSchema = z
+  .object({
+    label: z.string().min(1).optional(),
+    role: z.string().optional(),
+    /** Provide only to rotate the token; omit/blank keeps the stored one. */
+    token: z.string().optional(),
+    cutoff_max: z.number().int().positive().nullable().optional(),
+    priority: z.number().int().optional(),
+    status: DeploymentAccountStatusSchema.optional(),
+    ...providerConfigFields,
+  })
+  .strict()
+
+export const ListDeploymentAccountsQuerySchema = z
+  .object({
+    q: z.string().optional(),
+    provider: DeploymentProviderSchema.optional(),
+    status: DeploymentAccountStatusSchema.optional(),
+    limit: z.coerce.number().int().positive().max(200).optional(),
+    offset: z.coerce.number().int().min(0).optional(),
+    order: z.string().optional(),
+  })
+  .strict()
+
+export type CreateDeploymentAccountBody = z.infer<typeof CreateDeploymentAccountSchema>
+export type UpdateDeploymentAccountBody = z.infer<typeof UpdateDeploymentAccountSchema>
+
+/** The non-secret config keys that live in api_config alongside token_encrypted. */
+export const API_CONFIG_KEYS = [
+  "team_id",
+  "account_id",
+  "zone_id",
+  "github_installation_id",
+  "github_repo_id",
+  "owner_id",
+  "region",
+  "plan",
+] as const

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-partner-hosting-provider.unit.spec.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/__tests__/backfill-partner-hosting-provider.unit.spec.ts
@@ -1,0 +1,66 @@
+import { decideHostingBackfillAction } from "../backfill-partner-hosting-provider-job"
+
+describe("decideHostingBackfillAction", () => {
+  it("skips partners with no vercel project (never provisioned)", () => {
+    expect(decideHostingBackfillAction({ vercel_project_id: null })).toBe("not_provisioned")
+    expect(decideHostingBackfillAction({})).toBe("not_provisioned")
+  })
+
+  it("stamps a pre-#884 vercel partner (vercel_* set, generic cols null)", () => {
+    expect(
+      decideHostingBackfillAction({
+        vercel_project_id: "prj_1",
+        hosting_provider: null,
+        deployment_project_id: null,
+      })
+    ).toBe("stamp")
+  })
+
+  it("treats a fully-stamped partner as already backfilled (no account asked)", () => {
+    expect(
+      decideHostingBackfillAction({
+        vercel_project_id: "prj_1",
+        hosting_provider: "vercel",
+        deployment_project_id: "prj_1",
+      })
+    ).toBe("already_backfilled")
+  })
+
+  it("re-stamps when an account is requested but not yet attached", () => {
+    expect(
+      decideHostingBackfillAction(
+        {
+          vercel_project_id: "prj_1",
+          hosting_provider: "vercel",
+          deployment_project_id: "prj_1",
+          deployment_account_id: null,
+        },
+        { accountId: "dep_acct_9" }
+      )
+    ).toBe("stamp")
+  })
+
+  it("is idempotent once the requested account is attached", () => {
+    expect(
+      decideHostingBackfillAction(
+        {
+          vercel_project_id: "prj_1",
+          hosting_provider: "vercel",
+          deployment_project_id: "prj_1",
+          deployment_account_id: "dep_acct_9",
+        },
+        { accountId: "dep_acct_9" }
+      )
+    ).toBe("already_backfilled")
+  })
+
+  it("stamps when provider set but generic project id missing (partial legacy)", () => {
+    expect(
+      decideHostingBackfillAction({
+        vercel_project_id: "prj_1",
+        hosting_provider: "vercel",
+        deployment_project_id: null,
+      })
+    ).toBe("stamp")
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-partner-hosting-provider-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-partner-hosting-provider-job.ts
@@ -1,0 +1,238 @@
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+} from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import { PARTNER_MODULE } from "../../../../modules/partner"
+import { DEPLOYMENT_MODULE } from "../../../../modules/deployment"
+import type {
+  MaintenanceChange,
+  MaintenanceJob,
+  MaintenanceJobResult,
+} from "./registry"
+
+/**
+ * #884 S3 tail — backfill the provider-agnostic hosting columns for partners
+ * provisioned BEFORE the multi-provider rotation shipped.
+ *
+ * Pre-#884 partners have `vercel_project_id`/`vercel_project_name`/
+ * `vercel_linked` set but a NULL `hosting_provider` / `deployment_project_id` /
+ * `deployment_account_id`. The new resolver tolerates that (infers "vercel" +
+ * reads vercel_* as a fallback), but rotation load-accounting and the admin/
+ * partner "which provider" reads only line up once the generic columns are
+ * stamped. This job stamps them:
+ *   - hosting_provider          → "vercel"
+ *   - deployment_project_id     ← vercel_project_id
+ *   - deployment_project_name   ← vercel_project_name
+ *   - deployment_account_id     ← the `account_id` param (a Vercel
+ *                                 deployment_account created in Settings →
+ *                                 Storefront Hosting), when provided
+ *
+ * When `account_id` is given, the job ALSO bumps that account's `project_count`
+ * by the number of partners newly attached to it, so the rotation selector sees
+ * the real load. Idempotent: an already-stamped partner (and, when an account is
+ * requested, one already attached to it) is skipped. Dry-run lists who WOULD be
+ * stamped without persisting.
+ */
+
+/** Hard cap on partners processed in one call. */
+export const MAX_HOSTING_BACKFILL_SCAN = 5000
+
+const paramsSchema = z.object({
+  /**
+   * The Vercel `deployment_account` id to attach these partners to (create it
+   * first in Settings → Storefront Hosting). Omit to only stamp
+   * hosting_provider + deployment_project_* without linking an account.
+   */
+  account_id: z.string().min(1).optional(),
+  /** Restrict to a single partner. */
+  partner_id: z.string().min(1).optional(),
+  /** Max partners to process in one call. */
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_HOSTING_BACKFILL_SCAN)
+    .optional()
+    .default(1000),
+})
+
+export type HostingBackfillAction = "already_backfilled" | "not_provisioned" | "stamp"
+
+/**
+ * PURE: decide what to do for one partner. Exported for unit testing.
+ *   - no vercel project ref at all                        → not_provisioned (skip)
+ *   - hosting_provider already set AND (no account asked
+ *     OR the requested account already attached)          → already_backfilled
+ *   - otherwise                                            → stamp
+ */
+export function decideHostingBackfillAction(
+  partner: {
+    vercel_project_id?: string | null
+    hosting_provider?: string | null
+    deployment_account_id?: string | null
+    deployment_project_id?: string | null
+  },
+  opts: { accountId?: string } = {}
+): HostingBackfillAction {
+  const hasVercelProject = !!partner?.vercel_project_id
+  if (!hasVercelProject) return "not_provisioned"
+
+  const providerStamped =
+    !!partner?.hosting_provider && !!partner?.deployment_project_id
+  const accountSatisfied = !opts.accountId
+    ? true
+    : partner?.deployment_account_id === opts.accountId
+
+  if (providerStamped && accountSatisfied) return "already_backfilled"
+  return "stamp"
+}
+
+export const backfillPartnerHostingProviderJob: MaintenanceJob = {
+  id: "backfill-partner-hosting-provider",
+  label: "Backfill partner hosting provider (Vercel)",
+  description:
+    `Stamp the provider-agnostic hosting columns (hosting_provider, deployment_project_id/name, deployment_account_id) on partners provisioned before multi-provider rotation shipped. Pre-#884 partners only have vercel_* columns; this sets hosting_provider="vercel" and copies vercel_project_id/name into the generic columns. Pass account_id (a Vercel deployment_account from Settings → Storefront Hosting) to also LINK partners to it and bump that account's project_count by the number newly attached. Idempotent — already-stamped/attached partners are skipped. Dry-run lists who WOULD be stamped. Optionally scope to one partner_id. Processes up to 'limit' partners per call (default 1000, max ${MAX_HOSTING_BACKFILL_SCAN}).`,
+  params: [
+    {
+      name: "account_id",
+      type: "string",
+      required: false,
+      description:
+        "Vercel deployment_account id to attach partners to (create it in Settings → Storefront Hosting first). Omit to stamp columns without linking an account.",
+    },
+    {
+      name: "partner_id",
+      type: "string",
+      required: false,
+      description: "Restrict to a single partner (default: all provisioned partners)",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max partners to process per call (default 1000, max ${MAX_HOSTING_BACKFILL_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { account_id, partner_id, limit } = parsed.data
+
+    const query = container.resolve(ContainerRegistrationKeys.QUERY)
+    const partnerService: any = container.resolve(PARTNER_MODULE)
+    const deployment: any = container.resolve(DEPLOYMENT_MODULE)
+
+    // Validate the target account up front (fail fast, in both dry-run + apply).
+    if (account_id) {
+      try {
+        const acct = await deployment.retrieveDeploymentAccount(account_id)
+        if (acct?.provider !== "vercel") {
+          throw new MedusaError(
+            MedusaError.Types.INVALID_DATA,
+            `Deployment account ${account_id} is provider "${acct?.provider}", not "vercel" — this backfill only attaches Vercel partners.`
+          )
+        }
+      } catch (e: any) {
+        if (e instanceof MedusaError) throw e
+        throw new MedusaError(
+          MedusaError.Types.NOT_FOUND,
+          `Deployment account ${account_id} not found`
+        )
+      }
+    }
+
+    const filters: Record<string, any> = {}
+    if (partner_id) filters.id = partner_id
+
+    const { data: partners } = await query.graph({
+      entity: "partners",
+      fields: [
+        "id",
+        "name",
+        "hosting_provider",
+        "deployment_account_id",
+        "deployment_project_id",
+        "deployment_project_name",
+        "vercel_project_id",
+        "vercel_project_name",
+      ],
+      filters,
+    })
+
+    const candidates = (partners || []).filter(
+      (p: any) =>
+        decideHostingBackfillAction(p, { accountId: account_id }) === "stamp"
+    )
+    const total = candidates.length
+    const batch = candidates.slice(0, limit)
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    let stamped = 0
+
+    for (const p of batch) {
+      changes.push({
+        entity: "partner",
+        id: p.id,
+        field: "hosting_provider",
+        before: p.hosting_provider ?? "(null)",
+        after: account_id ? `vercel → account ${account_id}` : "vercel",
+      })
+
+      if (dry_run) {
+        stamped++
+        continue
+      }
+
+      try {
+        await partnerService.updatePartners({
+          id: p.id,
+          hosting_provider: "vercel",
+          deployment_project_id: p.vercel_project_id,
+          deployment_project_name: p.vercel_project_name ?? null,
+          ...(account_id ? { deployment_account_id: account_id } : {}),
+        })
+        stamped++
+      } catch (e: any) {
+        errors.push({ id: p.id, message: e?.message ?? String(e) })
+      }
+    }
+
+    // Bump the target account's live project_count by however many we attached.
+    if (!dry_run && account_id && stamped > 0) {
+      try {
+        const acct = await deployment.retrieveDeploymentAccount(account_id)
+        const next = ((acct as any)?.project_count ?? 0) + stamped
+        await deployment.updateDeploymentAccounts({ id: account_id, project_count: next })
+      } catch (e: any) {
+        errors.push({ id: account_id, message: `project_count bump failed: ${e?.message ?? e}` })
+      }
+    }
+
+    const verb = dry_run ? "Would stamp" : "Stamped"
+    const capped =
+      total > batch.length ? ` (capped at ${limit} of ${total} — re-run to continue)` : ""
+    const link = account_id ? ` and linked to account ${account_id}` : ""
+    const summary = `${verb} ${stamped} partner(s) as vercel${link}${
+      errors.length ? `, ${errors.length} error(s)` : ""
+    }${capped}.`
+
+    return {
+      job_id: backfillPartnerHostingProviderJob.id,
+      dry_run,
+      applied: !dry_run && stamped > 0,
+      summary,
+      changes,
+      errors,
+    }
+  },
+}
+
+export default backfillPartnerHostingProviderJob

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -77,6 +77,7 @@ import { seedInvestorPanelsJob } from "./seed-investor-panels-job"
 import { replayFxFanoutJob } from "./fanout-fx-job"
 import { backfillStoreCurrenciesJob } from "./backfill-store-currencies-job"
 import { backfillPartnerEmailVerifiedJob } from "./backfill-partner-email-verified-job"
+import { backfillPartnerHostingProviderJob } from "./backfill-partner-hosting-provider-job"
 import { enableStripeConnectEurRegionsJob } from "./enable-stripe-connect-eur-regions-job"
 import { suppressBouncedSubscribersJob } from "./suppress-bounced-subscribers-job"
 import { backfillAudienceEntriesJob } from "./backfill-audience-entries-job"
@@ -5484,6 +5485,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   replayFxFanoutJob,
   backfillStoreCurrenciesJob,
   backfillPartnerEmailVerifiedJob,
+  backfillPartnerHostingProviderJob,
   enableStripeConnectEurRegionsJob,
   suppressBouncedSubscribersJob,
   backfillAudienceEntriesJob,

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -125,6 +125,7 @@ import { createStoreSchema } from "./admin/stores/validators";
 import { UpdateInventoryOrderTask } from "./admin/inventory-orders/[id]/tasks/[taskId]/validators";
 import { TestBlogEmailSchema } from "./admin/websites/[id]/pages/[pageId]/subs/test/route";
 import { listSocialPlatformsQuerySchema, SocialPlatformSchema, UpdateSocialPlatformSchema, ConnectWhatsAppSchema } from "./admin/social-platforms/validators";
+import { CreateDeploymentAccountSchema, UpdateDeploymentAccountSchema, ListDeploymentAccountsQuerySchema } from "./admin/deployment-accounts/validators";
 import { StoreAiSearchSchema } from "./store/ai/search/validators";
 import { StoreAiChatSchema } from "./store/ai/chat/validators";
 import { StoreGenerateAiImageReqSchema } from "./store/ai/imagegen/validators";
@@ -3950,6 +3951,23 @@ export default defineMiddlewares({
       matcher: "/admin/social-platforms",
       method: "GET",
       middlewares: [validateAndTransformQuery(wrapSchema(listSocialPlatformsQuerySchema), {})],
+    },
+
+    // ── Deployment accounts (rotatable storefront hosting accounts, #884 S4) ──
+    {
+      matcher: "/admin/deployment-accounts",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(CreateDeploymentAccountSchema))],
+    },
+    {
+      matcher: "/admin/deployment-accounts",
+      method: "GET",
+      middlewares: [validateAndTransformQuery(wrapSchema(ListDeploymentAccountsQuerySchema), {})],
+    },
+    {
+      matcher: "/admin/deployment-accounts/:id",
+      method: ["POST", "PUT"],
+      middlewares: [validateAndTransformBody(wrapSchema(UpdateDeploymentAccountSchema))],
     },
     {
       matcher: "/admin/social-posts",

--- a/apps/backend/src/api/partners/storefront/helpers.ts
+++ b/apps/backend/src/api/partners/storefront/helpers.ts
@@ -3,6 +3,10 @@ import { MedusaError } from "@medusajs/framework/utils"
 import { getPartnerFromAuthContext } from "../helpers"
 import { WEBSITE_MODULE } from "../../../modules/website"
 import WebsiteService from "../../../modules/website/service"
+import {
+  partnerHostingProviderName,
+  partnerProjectRef,
+} from "../../../modules/deployment/providers/resolve-partner-provider"
 
 /**
  * Storefront identifiers live on dedicated partner columns now
@@ -18,25 +22,33 @@ export type StorefrontRefs = {
   storefrontDomain: string | null
   vercelLastDeploymentId: string | null
   storefrontProvisionedAt: string | null
+  // Provider-agnostic (#884 S3): which provider + the ref to address it by.
+  providerName: "vercel" | "cloudflare" | "render" | "netlify"
+  projectRef: string | null
 }
 
-export const getStorefrontRefs = (partner: any): StorefrontRefs => ({
-  vercelProjectId:
-    partner?.vercel_project_id ?? partner?.metadata?.vercel_project_id ?? null,
-  vercelProjectName:
-    partner?.vercel_project_name ??
-    partner?.metadata?.vercel_project_name ??
-    null,
-  storefrontDomain:
-    partner?.storefront_domain ?? partner?.metadata?.storefront_domain ?? null,
-  vercelLastDeploymentId:
-    partner?.vercel_last_deployment_id ??
-    partner?.metadata?.vercel_last_deployment_id ??
-    null,
-  // No column for this one — stays metadata-only.
-  storefrontProvisionedAt:
-    partner?.metadata?.storefront_provisioned_at ?? null,
-})
+export const getStorefrontRefs = (partner: any): StorefrontRefs => {
+  const providerName = partnerHostingProviderName(partner)
+  return {
+    vercelProjectId:
+      partner?.vercel_project_id ?? partner?.metadata?.vercel_project_id ?? null,
+    vercelProjectName:
+      partner?.vercel_project_name ??
+      partner?.metadata?.vercel_project_name ??
+      null,
+    storefrontDomain:
+      partner?.storefront_domain ?? partner?.metadata?.storefront_domain ?? null,
+    vercelLastDeploymentId:
+      partner?.vercel_last_deployment_id ??
+      partner?.metadata?.vercel_last_deployment_id ??
+      null,
+    // No column for this one — stays metadata-only.
+    storefrontProvisionedAt:
+      partner?.metadata?.storefront_provisioned_at ?? null,
+    providerName,
+    projectRef: partnerProjectRef(partner, providerName),
+  }
+}
 
 /**
  * Gets the partner's website.

--- a/apps/backend/src/api/partners/storefront/provision/route.ts
+++ b/apps/backend/src/api/partners/storefront/provision/route.ts
@@ -5,8 +5,7 @@ import {
 import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
 import { getPartnerFromAuthContext } from "../../helpers"
 import { provisionStorefrontWorkflow } from "../../../../workflows/stores/provision-storefront"
-import { DEPLOYMENT_MODULE } from "../../../../modules/deployment"
-import type DeploymentService from "../../../../modules/deployment/service"
+import { resolveHostingProviderForPartner } from "../../../../modules/deployment/providers/resolve-partner-provider"
 import updatePartnerWorkflow from "../../../../workflows/partners/update-partner"
 
 const ROOT_DOMAIN = process.env.ROOT_DOMAIN || "cicilabel.com"
@@ -84,20 +83,28 @@ export const POST = async (
     )
   }
 
-  // Check if already provisioned — verify the project actually exists on Vercel
-  const existingProjectId =
-    partnerData.vercel_project_id || partnerData.metadata?.vercel_project_id
-  if (existingProjectId) {
+  // Check if already provisioned — verify the project actually exists on the
+  // partner's current hosting provider (provider-agnostic; #884 S3).
+  const existingProjectRef =
+    partnerData.deployment_project_id ||
+    partnerData.deployment_project_name ||
+    partnerData.vercel_project_id ||
+    partnerData.metadata?.vercel_project_id
+  if (existingProjectRef) {
     let projectExists = false
-    const deploymentSvc: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
-    if (deploymentSvc.isVercelConfigured()) {
-      try {
-        await deploymentSvc.getProject(existingProjectId)
+    try {
+      const { provider, projectRef } = await resolveHostingProviderForPartner(
+        partnerData,
+        req.scope
+      )
+      if (projectRef) {
+        await provider.getProject(projectRef)
         projectExists = true
-      } catch {
-        // Project doesn't exist on Vercel (404) — clear stale refs and allow re-provisioning
-        projectExists = false
       }
+    } catch {
+      // Project doesn't exist on the provider (404) or creds missing —
+      // clear stale refs and allow re-provisioning.
+      projectExists = false
     }
 
     if (projectExists) {
@@ -119,6 +126,10 @@ export const POST = async (
       input: {
         id: partner.id,
         data: {
+          hosting_provider: null,
+          deployment_account_id: null,
+          deployment_project_id: null,
+          deployment_project_name: null,
           vercel_project_id: null,
           vercel_project_name: null,
           vercel_last_deployment_id: null,
@@ -128,6 +139,8 @@ export const POST = async (
       },
     })
     partnerData.metadata = cleanMeta
+    partnerData.deployment_project_id = null
+    partnerData.deployment_project_name = null
     partnerData.vercel_project_id = null
     partnerData.vercel_project_name = null
   }
@@ -191,6 +204,9 @@ export const POST = async (
       stripe_publishable_key: STRIPE_PUBLISHABLE_KEY,
       s3_hostname: s3Config.hostname,
       s3_pathname: s3Config.pathname,
+      // Partner-pinned provider wins; else the workflow rotates from the default
+      // (DEFAULT_HOSTING_PROVIDER env, or Cloudflare Pages).
+      preferred_provider: partnerData.hosting_provider || undefined,
     },
   })
 

--- a/apps/backend/src/api/partners/storefront/route.ts
+++ b/apps/backend/src/api/partners/storefront/route.ts
@@ -6,6 +6,7 @@ import { MedusaError } from "@medusajs/framework/utils"
 import { getPartnerFromAuthContext } from "../helpers"
 import { DEPLOYMENT_MODULE } from "../../../modules/deployment"
 import type DeploymentService from "../../../modules/deployment/service"
+import { resolveHostingProviderForPartner } from "../../../modules/deployment/providers/resolve-partner-provider"
 import updatePartnerWorkflow from "../../../workflows/partners/update-partner"
 import { getStorefrontRefs } from "./helpers"
 
@@ -42,18 +43,37 @@ export const GET = async (
   const deployment: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
   const refs = getStorefrontRefs(partner)
 
-  if (!refs.vercelProjectId) {
+  if (!refs.projectRef) {
     return res.json({
       provisioned: false,
+      provider: refs.providerName,
       message: "Storefront has not been provisioned yet",
       vercel_configured: deployment.isVercelConfigured(),
       cloudflare_configured: deployment.isCloudflareConfigured(),
     })
   }
 
+  // Resolve the partner's provider (Vercel/Cloudflare Pages/Netlify/Render) and
+  // confirm the project still exists. Vercel keeps its richer latest-deployment
+  // detail; other providers report existence + the stored deployment id.
+  let provider: Awaited<ReturnType<typeof resolveHostingProviderForPartner>>
   try {
-    const project = await deployment.getProject(refs.vercelProjectId)
-    const latestDeployment = project.latestDeployments?.[0]
+    provider = await resolveHostingProviderForPartner(partner, req.scope)
+  } catch (e: any) {
+    return res.json({
+      provisioned: true,
+      provider: refs.providerName,
+      project: { id: refs.projectRef, name: refs.vercelProjectName },
+      domain: refs.storefrontDomain,
+      storefront_url: refs.storefrontDomain ? `https://${refs.storefrontDomain}` : null,
+      provisioned_at: refs.storefrontProvisionedAt,
+      latest_deployment: null,
+      error: `Hosting provider not resolvable: ${e.message}`,
+    })
+  }
+
+  try {
+    const project = await provider.provider.getProject(refs.projectRef)
 
     let deploymentInfo: {
       id: string
@@ -62,31 +82,38 @@ export const GET = async (
       created_at: number
     } | null = null
 
-    if (latestDeployment) {
+    // Vercel exposes latest-deployment detail via the legacy service client.
+    if (refs.providerName === "vercel") {
       try {
-        const details = await deployment.getDeployment(latestDeployment.id)
-        deploymentInfo = {
-          id: details.id,
-          url: details.url,
-          status: details.readyState,
-          created_at: details.createdAt,
+        const vProject = await deployment.getProject(refs.projectRef)
+        const latest = vProject.latestDeployments?.[0]
+        if (latest) {
+          try {
+            const details = await deployment.getDeployment(latest.id)
+            deploymentInfo = {
+              id: details.id,
+              url: details.url,
+              status: details.readyState,
+              created_at: details.createdAt,
+            }
+          } catch {
+            deploymentInfo = {
+              id: latest.id,
+              url: latest.url,
+              status: latest.readyState,
+              created_at: latest.createdAt,
+            }
+          }
         }
       } catch {
-        deploymentInfo = {
-          id: latestDeployment.id,
-          url: latestDeployment.url,
-          status: latestDeployment.readyState,
-          created_at: latestDeployment.createdAt,
-        }
+        // non-fatal — status still returns
       }
     }
 
     res.json({
       provisioned: true,
-      project: {
-        id: project.id,
-        name: project.name,
-      },
+      provider: refs.providerName,
+      project: { id: project.id, name: project.name },
       domain: refs.storefrontDomain,
       storefront_url: refs.storefrontDomain
         ? `https://${refs.storefrontDomain}`
@@ -97,16 +124,20 @@ export const GET = async (
       cloudflare_configured: deployment.isCloudflareConfigured(),
     })
   } catch (e: any) {
-    // If Vercel returns 404, the project was deleted — treat as not provisioned
+    // Project no longer exists on the provider (404) — treat as unprovisioned
+    // and clear stale references.
     const is404 = e.message?.includes("(404)") || e.message?.includes("NOT_FOUND")
     if (is404) {
-      // Clean up stale references via workflow — clear both columns and legacy metadata.
       try {
         await updatePartnerWorkflow(req.scope).run({
           input: {
             id: partner.id,
             data: {
               metadata: stripStorefrontKeys(partner.metadata),
+              hosting_provider: null,
+              deployment_account_id: null,
+              deployment_project_id: null,
+              deployment_project_name: null,
               vercel_project_id: null,
               vercel_project_name: null,
               vercel_last_deployment_id: null,
@@ -121,27 +152,22 @@ export const GET = async (
 
       return res.json({
         provisioned: false,
+        provider: refs.providerName,
         message: "Storefront project no longer exists",
-        vercel_configured: deployment.isVercelConfigured(),
-        cloudflare_configured: deployment.isCloudflareConfigured(),
       })
     }
 
     res.json({
       provisioned: true,
-      project: {
-        id: refs.vercelProjectId,
-        name: refs.vercelProjectName,
-      },
+      provider: refs.providerName,
+      project: { id: refs.projectRef, name: refs.vercelProjectName },
       domain: refs.storefrontDomain,
       storefront_url: refs.storefrontDomain
         ? `https://${refs.storefrontDomain}`
         : null,
       provisioned_at: refs.storefrontProvisionedAt,
       latest_deployment: null,
-      error: `Could not fetch Vercel status: ${e.message}`,
-      vercel_configured: deployment.isVercelConfigured(),
-      cloudflare_configured: deployment.isCloudflareConfigured(),
+      error: `Could not fetch status: ${e.message}`,
     })
   }
 }
@@ -164,10 +190,10 @@ export const DELETE = async (
 
   const deployment: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
   const refs = getStorefrontRefs(partner)
-  const vercelProjectId = refs.vercelProjectId
+  const projectRef = refs.projectRef
   const storefrontDomain = refs.storefrontDomain
 
-  if (!vercelProjectId) {
+  if (!projectRef) {
     throw new MedusaError(
       MedusaError.Types.NOT_FOUND,
       "Storefront has not been provisioned"
@@ -176,46 +202,72 @@ export const DELETE = async (
 
   const results: Record<string, any> = {}
 
-  // Remove Vercel project
-  if (deployment.isVercelConfigured()) {
-    try {
-      if (storefrontDomain) {
-        try {
-          await deployment.removeDomain(vercelProjectId, storefrontDomain)
-          results.vercel_domain = { action: "removed" }
-        } catch (e: any) {
-          results.vercel_domain = { action: "failed", error: e.message }
-        }
+  // Remove the project on whatever provider the partner is on.
+  try {
+    const { provider } = await resolveHostingProviderForPartner(partner, req.scope)
+    if (storefrontDomain) {
+      try {
+        await provider.removeDomain(projectRef, storefrontDomain)
+        results.domain = { action: "removed" }
+      } catch (e: any) {
+        results.domain = { action: "failed", error: e.message }
       }
-
-      await deployment.deleteProject(vercelProjectId)
-      results.vercel_project = { action: "deleted" }
-    } catch (e: any) {
-      results.vercel_project = { action: "failed", error: e.message }
     }
-  } else {
-    results.vercel_project = { action: "skipped", reason: "Vercel not configured" }
+    // deleteProject isn't on the HostingProvider interface (Vercel service has
+    // it); guard for providers that expose it.
+    const anyProvider = provider as any
+    if (typeof anyProvider.deleteProject === "function") {
+      await anyProvider.deleteProject(projectRef)
+      results.project = { action: "deleted" }
+    } else if (refs.providerName === "vercel" && deployment.isVercelConfigured()) {
+      await deployment.deleteProject(projectRef)
+      results.project = { action: "deleted" }
+    } else {
+      results.project = {
+        action: "skipped",
+        reason: `Provider "${refs.providerName}" has no API delete — remove it in the provider dashboard`,
+      }
+    }
+  } catch (e: any) {
+    results.project = { action: "failed", error: e.message }
   }
 
-  // Remove Cloudflare DNS record
+  // Remove the Cloudflare DNS record (our zone) for the subdomain.
   if (storefrontDomain) {
     results.dns = await deployment.removeStorefrontDns(storefrontDomain)
   } else {
     results.dns = { action: "skipped", reason: "No domain" }
   }
 
-  // Clear storefront metadata via the update workflow (ensures proper DB write)
-  const cleanMetadata = stripStorefrontKeys(partner.metadata)
+  // Decrement the account's project_count (best-effort) so freed capacity is
+  // reflected in future rotation.
+  const accountId = partner?.deployment_account_id
+  if (accountId) {
+    try {
+      const acct = await deployment.retrieveDeploymentAccount(accountId)
+      const next = Math.max(0, ((acct as any)?.project_count ?? 1) - 1)
+      await deployment.updateDeploymentAccounts({ id: accountId, project_count: next })
+      results.account = { action: "decremented" }
+    } catch (e: any) {
+      results.account = { action: "failed", error: e.message }
+    }
+  }
 
+  // Clear storefront state via the update workflow (proper DB write).
   await updatePartnerWorkflow(req.scope).run({
     input: {
       id: partner.id,
       data: {
-        metadata: cleanMetadata,
+        metadata: stripStorefrontKeys(partner.metadata),
+        hosting_provider: null,
+        deployment_account_id: null,
+        deployment_project_id: null,
+        deployment_project_name: null,
         vercel_project_id: null,
         vercel_project_name: null,
         vercel_last_deployment_id: null,
         vercel_linked: false,
+        storefront_domain: null,
       },
     },
   })

--- a/apps/backend/src/modules/deployment/__tests__/account-selector.unit.spec.ts
+++ b/apps/backend/src/modules/deployment/__tests__/account-selector.unit.spec.ts
@@ -3,6 +3,7 @@ import {
   isFull,
   isEligible,
   selectDeploymentAccount,
+  decideProvisionTarget,
   type DeploymentAccountRow,
 } from "../account-selector"
 
@@ -70,5 +71,55 @@ describe("deployment account-selector — selection", () => {
       acct({ id: "hi", project_count: 2, cutoff_max: 20, priority: 5 }),
     ])
     expect(pick?.id).toBe("hi")
+  })
+})
+
+describe("decideProvisionTarget — rotation + env fallback", () => {
+  it("prefers a least-loaded account of the preferred provider", () => {
+    const t = decideProvisionTarget(
+      [
+        acct({ id: "cf1", provider: "cloudflare", project_count: 4, cutoff_max: 10 }),
+        acct({ id: "cf2", provider: "cloudflare", project_count: 1, cutoff_max: 10 }),
+        acct({ id: "v1", provider: "vercel", project_count: 0, cutoff_max: 10 }),
+      ],
+      { preferredProvider: "cloudflare", envProviders: ["vercel"] }
+    )
+    expect(t).toEqual({ kind: "account", accountId: "cf2", provider: "cloudflare" })
+  })
+
+  it("spills to another provider's account when the preferred pool is full", () => {
+    const t = decideProvisionTarget(
+      [
+        acct({ id: "cf1", provider: "cloudflare", project_count: 10, cutoff_max: 10 }),
+        acct({ id: "nl1", provider: "netlify", project_count: 2, cutoff_max: 10 }),
+      ],
+      { preferredProvider: "cloudflare", envProviders: [] }
+    )
+    expect(t).toEqual({ kind: "account", accountId: "nl1", provider: "netlify" })
+  })
+
+  it("falls back to the preferred env provider when no accounts exist", () => {
+    const t = decideProvisionTarget([], {
+      preferredProvider: "cloudflare",
+      envProviders: ["vercel", "cloudflare"],
+    })
+    expect(t).toEqual({ kind: "env", provider: "cloudflare" })
+  })
+
+  it("falls back to the first env provider when preferred has no env creds", () => {
+    const t = decideProvisionTarget([], {
+      preferredProvider: "cloudflare",
+      envProviders: ["vercel"],
+    })
+    expect(t).toEqual({ kind: "env", provider: "vercel" })
+  })
+
+  it("returns null when no accounts and no env providers (capacity exhausted)", () => {
+    expect(
+      decideProvisionTarget(
+        [acct({ id: "cf1", provider: "cloudflare", project_count: 10, cutoff_max: 10 })],
+        { preferredProvider: "cloudflare", envProviders: [] }
+      )
+    ).toBeNull()
   })
 })

--- a/apps/backend/src/modules/deployment/__tests__/hosting-providers.unit.spec.ts
+++ b/apps/backend/src/modules/deployment/__tests__/hosting-providers.unit.spec.ts
@@ -67,9 +67,17 @@ describe("createHostingProvider", () => {
     expect(p).toBeInstanceOf(CloudflarePagesProvider)
     expect(p.provider).toBe("cloudflare")
   })
-  it("throws for not-yet-implemented providers (S5)", () => {
-    expect(() => createHostingProvider("render", { token: "t" })).toThrow(/not implemented/)
-    expect(() => createHostingProvider("netlify", { token: "t" })).toThrow(/not implemented/)
+  it("builds Netlify + Render providers (S5)", () => {
+    expect(
+      createHostingProvider("netlify", { token: "t", accountId: "a", extra: { github_installation_id: "1" } })
+        .provider
+    ).toBe("netlify")
+    expect(
+      createHostingProvider("render", { token: "t", extra: { owner_id: "tea_1" } }).provider
+    ).toBe("render")
+  })
+  it("throws for an unknown provider", () => {
+    expect(() => createHostingProvider("fly" as any, { token: "t" })).toThrow(/Unknown hosting provider/)
   })
 })
 
@@ -147,5 +155,79 @@ describe("hostingProviderForAccount", () => {
       decryptor
     )
     expect(p).toBeInstanceOf(CloudflarePagesProvider)
+  })
+})
+
+// ─── S5 providers: Netlify + Render ──────────────────────────────────────────
+
+import { NetlifyProvider } from "../providers/netlify-provider"
+import { RenderProvider } from "../providers/render-provider"
+
+describe("resolveAccountCredentials — extra passthrough (S5)", () => {
+  it("carries provider-specific non-secret config into `extra`", () => {
+    const creds = resolveAccountCredentials(
+      {
+        token_encrypted: enc("nf-tok"),
+        account_id: "acct_1",
+        github_installation_id: "999",
+        github_repo_id: 12345,
+        region: "oregon",
+      } as DeploymentApiConfig,
+      decryptor
+    )
+    expect(creds.token).toBe("nf-tok")
+    expect(creds.accountId).toBe("acct_1")
+    expect(creds.extra).toEqual({
+      github_installation_id: "999",
+      github_repo_id: "12345",
+      region: "oregon",
+    })
+  })
+})
+
+describe("NetlifyProvider", () => {
+  const p = new NetlifyProvider({
+    token: "nf",
+    accountId: "acct_1",
+    extra: { github_installation_id: "42" },
+  })
+  it("has provider name netlify", () => expect(p.provider).toBe("netlify"))
+  it("dnsTarget prefers originHost, else <name>.netlify.app", () => {
+    expect(p.dnsTarget({ id: "s1", name: "Storefront ACME" })).toBe("storefront-acme.netlify.app")
+    expect(p.dnsTarget({ id: "s1", name: "x", originHost: "custom.netlify.app" })).toBe(
+      "custom.netlify.app"
+    )
+  })
+  it("requires a token", () => {
+    expect(() => new NetlifyProvider({ token: "" } as any)).toThrow(/requires a token/)
+  })
+  it("createProject requires github_installation_id", async () => {
+    const noInstall = new NetlifyProvider({ token: "nf", accountId: "a" })
+    await expect(
+      noInstall.createProject({ name: "s", gitRepo: "o/r" })
+    ).rejects.toThrow(/github_installation_id/)
+  })
+  it("is built by createHostingProvider('netlify')", () => {
+    expect(createHostingProvider("netlify", { token: "t", accountId: "a", extra: { github_installation_id: "1" } }))
+      .toBeInstanceOf(NetlifyProvider)
+  })
+})
+
+describe("RenderProvider", () => {
+  const p = new RenderProvider({ token: "rd", extra: { owner_id: "tea_1" } })
+  it("has provider name render", () => expect(p.provider).toBe("render"))
+  it("dnsTarget prefers originHost, else <name>.onrender.com", () => {
+    expect(p.dnsTarget({ id: "s1", name: "Shop One" })).toBe("shop-one.onrender.com")
+    expect(p.dnsTarget({ id: "s1", name: "x", originHost: "svc.onrender.com" })).toBe(
+      "svc.onrender.com"
+    )
+  })
+  it("createProject requires owner_id", async () => {
+    const noOwner = new RenderProvider({ token: "rd" })
+    await expect(noOwner.createProject({ name: "s", gitRepo: "o/r" })).rejects.toThrow(/owner_id/)
+  })
+  it("is built by createHostingProvider('render')", () => {
+    expect(createHostingProvider("render", { token: "t", extra: { owner_id: "tea_1" } }))
+      .toBeInstanceOf(RenderProvider)
   })
 })

--- a/apps/backend/src/modules/deployment/account-selector.ts
+++ b/apps/backend/src/modules/deployment/account-selector.ts
@@ -71,3 +71,58 @@ export function selectDeploymentAccount(
 
   return pool[0]
 }
+
+/**
+ * The provisioning target for a NEW storefront: which account (multi-account
+ * rotation) or which env-single-account provider (legacy fallback) to place it
+ * on. PURE — the workflow feeds it the DB accounts + which providers have env
+ * creds configured, and gets back a decision (or null → capacity exhausted).
+ */
+export type ProvisionTarget =
+  | { kind: "account"; accountId: string; provider: DeploymentProvider }
+  | { kind: "env"; provider: DeploymentProvider }
+
+export type DecideProvisionOptions = {
+  /** Provider to prefer for new partners (default target, e.g. "cloudflare"). */
+  preferredProvider?: DeploymentProvider
+  /** Providers that have legacy env-single-account creds configured. */
+  envProviders?: DeploymentProvider[]
+}
+
+/**
+ * Decide where a new storefront provisions:
+ *   1. A rotatable account of the PREFERRED provider (least-loaded under cap).
+ *   2. Else any rotatable account of ANY provider (cross-provider fallback so a
+ *      full Cloudflare pool spills onto Netlify/Render, etc.).
+ *   3. Else the legacy env account — preferred provider if it has env creds,
+ *      otherwise the first configured env provider (keeps pre-#884 deploys
+ *      working with zero accounts configured).
+ * Returns null when nothing is eligible (caller alerts: add / round-up an account).
+ */
+export function decideProvisionTarget(
+  accounts: DeploymentAccountRow[],
+  opts: DecideProvisionOptions = {}
+): ProvisionTarget | null {
+  const preferred = opts.preferredProvider
+  const envProviders = opts.envProviders ?? []
+
+  // 1. preferred-provider account
+  if (preferred) {
+    const acct = selectDeploymentAccount(accounts, { provider: preferred })
+    if (acct) return { kind: "account", accountId: acct.id, provider: acct.provider }
+  }
+
+  // 2. any-provider account (cross-provider spillover)
+  const anyAcct = selectDeploymentAccount(accounts)
+  if (anyAcct) return { kind: "account", accountId: anyAcct.id, provider: anyAcct.provider }
+
+  // 3. legacy env fallback
+  if (preferred && envProviders.includes(preferred)) {
+    return { kind: "env", provider: preferred }
+  }
+  if (envProviders.length) {
+    return { kind: "env", provider: envProviders[0] }
+  }
+
+  return null
+}

--- a/apps/backend/src/modules/deployment/providers/netlify-provider.ts
+++ b/apps/backend/src/modules/deployment/providers/netlify-provider.ts
@@ -1,0 +1,225 @@
+/**
+ * NetlifyProvider — Netlify as a storefront hosting target (#884 S5).
+ *
+ * Netlify REST API v1 (https://api.netlify.com/api/v1), Bearer PAT. A site is
+ * linked to a GitHub repo at create time; Netlify auto-detects Next.js and
+ * applies @netlify/plugin-nextjs so SSR "just works" (no separate service type).
+ *
+ * Projects are addressed by the opaque `site_id`, so `HostingProject.id` is the
+ * site id here (like Vercel), while `name`/`originHost` carry the
+ * `<name>.netlify.app` subdomain used as the CNAME target.
+ *
+ * Credentials (decrypted from `deployment_account.api_config`):
+ *   - token       Netlify personal access token
+ *   - accountId   Netlify team/account id (for the env-vars API + team-scoped create)
+ *   - extra.github_installation_id   the Netlify GitHub App installation id (required to link a repo)
+ *   - extra.github_repo_id           numeric GitHub repo id (optional; Netlify resolves it when omitted)
+ */
+
+import type {
+  AddDomainOptions,
+  CreateProjectInput,
+  HostingCredentials,
+  HostingDeployment,
+  HostingDomain,
+  HostingDomainStatus,
+  HostingEnvVar,
+  HostingProject,
+  HostingProvider,
+  TriggerDeploymentInput,
+} from "./types"
+import { cnameInstruction, isApexDomain, sanitizeProjectName } from "./types"
+
+const NETLIFY_API = "https://api.netlify.com/api/v1"
+
+type NetlifySite = {
+  id: string
+  name: string
+  url?: string
+  ssl_url?: string
+  admin_url?: string
+  custom_domain?: string | null
+  default_domain?: string
+}
+
+export class NetlifyProvider implements HostingProvider {
+  readonly provider = "netlify" as const
+  private readonly token: string
+  private readonly accountId?: string
+  private readonly installationId?: string
+  private readonly repoId?: string
+
+  constructor(creds: HostingCredentials) {
+    if (!creds?.token) throw new Error("NetlifyProvider requires a token")
+    this.token = creds.token
+    this.accountId = creds.accountId
+    this.installationId = creds.extra?.github_installation_id
+    this.repoId = creds.extra?.github_repo_id
+  }
+
+  private headers(): Record<string, string> {
+    return { Authorization: `Bearer ${this.token}`, "Content-Type": "application/json" }
+  }
+
+  private async nf<T>(url: string, init: RequestInit, op: string): Promise<T> {
+    const res = await fetch(url, { ...init, headers: this.headers() })
+    if (!res.ok) {
+      const body = await res.text().catch(() => "")
+      throw new Error(`Netlify ${op} failed (${res.status}): ${body || res.statusText}`)
+    }
+    return (await res.json().catch(() => ({}))) as T
+  }
+
+  /** The `<name>.netlify.app` origin a subdomain should CNAME to. */
+  dnsTarget(project: HostingProject): string {
+    if (project.originHost) return project.originHost
+    return `${sanitizeProjectName(project.name)}.netlify.app`
+  }
+
+  private originFromSite(site: NetlifySite): string {
+    // Prefer the exact host Netlify returns; fall back to the convention.
+    const raw = site.ssl_url || site.url || (site.default_domain ? `https://${site.default_domain}` : "")
+    if (raw) {
+      try {
+        return new URL(raw).hostname
+      } catch {
+        // fall through
+      }
+    }
+    return `${site.name}.netlify.app`
+  }
+
+  async createProject(input: CreateProjectInput): Promise<HostingProject> {
+    if (!this.installationId) {
+      throw new Error(
+        "NetlifyProvider.createProject requires api_config.github_installation_id " +
+          "(install the Netlify GitHub App on the account once, then store its installation id)"
+      )
+    }
+    const name = sanitizeProjectName(input.name)
+    const branch = input.productionBranch || "main"
+
+    const repo: Record<string, any> = {
+      provider: "github",
+      repo: input.gitRepo,
+      private: false,
+      branch,
+      cmd: input.buildCommand || "npm run build",
+      installation_id: this.installationId,
+    }
+    if (this.repoId) repo.repo_id = Number(this.repoId)
+    if (input.rootDirectory) repo.base = input.rootDirectory
+
+    // Team-scoped create when we know the account slug/id, else the default team.
+    const createUrl = this.accountId
+      ? `${NETLIFY_API}/${this.accountId}/sites`
+      : `${NETLIFY_API}/sites`
+
+    const site = await this.nf<NetlifySite>(
+      createUrl,
+      { method: "POST", body: JSON.stringify({ name, repo }) },
+      "createProject"
+    )
+    return { id: site.id, name: site.name, originHost: this.originFromSite(site) }
+  }
+
+  async setEnvVars(siteId: string, envVars: HostingEnvVar[]): Promise<void> {
+    if (!this.accountId) {
+      throw new Error(
+        "NetlifyProvider.setEnvVars requires api_config.account_id (Netlify team/account id) for the env-vars API"
+      )
+    }
+    const payload = envVars.map((v) => ({
+      key: v.key,
+      scopes: ["builds", "functions", "runtime"],
+      values: [{ value: v.value, context: "all" }],
+    }))
+    await this.nf(
+      `${NETLIFY_API}/accounts/${this.accountId}/env?site_id=${encodeURIComponent(siteId)}`,
+      { method: "POST", body: JSON.stringify(payload) },
+      "setEnvVars"
+    )
+  }
+
+  async addDomain(
+    siteId: string,
+    domain: string,
+    _opts?: AddDomainOptions
+  ): Promise<HostingDomain> {
+    // Netlify sets the primary custom domain on the site record; it verifies
+    // automatically once the CNAME resolves (no TXT records to publish).
+    try {
+      const site = await this.nf<NetlifySite>(
+        `${NETLIFY_API}/sites/${siteId}`,
+        { method: "PATCH", body: JSON.stringify({ custom_domain: domain }) },
+        "addDomain"
+      )
+      return { name: site.custom_domain || domain, verified: false, verification: [] }
+    } catch (e: any) {
+      return { name: domain, verified: false, verification: [], error: e.message }
+    }
+  }
+
+  async removeDomain(siteId: string, _domain: string): Promise<void> {
+    // Clear the primary custom domain.
+    const res = await fetch(`${NETLIFY_API}/sites/${siteId}`, {
+      method: "PATCH",
+      headers: this.headers(),
+      body: JSON.stringify({ custom_domain: null }),
+    })
+    if (!res.ok && res.status !== 404) {
+      throw new Error(`Netlify removeDomain failed (${res.status}): ${await res.text()}`)
+    }
+  }
+
+  async verifyDomain(siteId: string, domain: string): Promise<HostingDomain> {
+    const site = await this.nf<NetlifySite>(
+      `${NETLIFY_API}/sites/${siteId}`,
+      { method: "GET" },
+      "verifyDomain"
+    )
+    // Verified once the custom domain is set AND TLS is provisioned (ssl_url present for it).
+    const verified = site.custom_domain === domain && !!site.ssl_url
+    return { name: domain, verified, verification: [] }
+  }
+
+  async describeDomain(siteId: string, domain: string): Promise<HostingDomainStatus> {
+    let site: NetlifySite | null = null
+    try {
+      site = await this.nf<NetlifySite>(`${NETLIFY_API}/sites/${siteId}`, { method: "GET" }, "describeDomain")
+    } catch {
+      // fall through with defaults
+    }
+    const target = site ? this.originFromSite(site) : `${sanitizeProjectName(domain)}.netlify.app`
+    const active = !!site && site.custom_domain === domain && !!site.ssl_url
+    const dnsRecords = isApexDomain(domain)
+      ? [{ type: "ALIAS", host: "@", value: target }] // apex → Netlify ALIAS/ANAME
+      : [cnameInstruction(domain, target)]
+    return {
+      name: domain,
+      verified: active,
+      misconfigured: !active,
+      configuredBy: active ? "CNAME" : null,
+      dnsRecords,
+    }
+  }
+
+  async triggerDeployment(input: TriggerDeploymentInput): Promise<HostingDeployment> {
+    const siteId = input.projectId || input.projectName
+    const build = await this.nf<{ id: string; deploy_id?: string; deploy_ssl_url?: string }>(
+      `${NETLIFY_API}/sites/${siteId}/builds`,
+      { method: "POST", body: JSON.stringify({ clear_cache: false }) },
+      "triggerDeployment"
+    )
+    return {
+      id: build.deploy_id || build.id,
+      url: build.deploy_ssl_url || "",
+      status: "building",
+    }
+  }
+
+  async getProject(siteId: string): Promise<HostingProject> {
+    const site = await this.nf<NetlifySite>(`${NETLIFY_API}/sites/${siteId}`, { method: "GET" }, "getProject")
+    return { id: site.id, name: site.name, originHost: this.originFromSite(site) }
+  }
+}

--- a/apps/backend/src/modules/deployment/providers/registry.ts
+++ b/apps/backend/src/modules/deployment/providers/registry.ts
@@ -9,6 +9,8 @@
 
 import type { EncryptedData } from "../../encryption/service"
 import { CloudflarePagesProvider } from "./cloudflare-pages-provider"
+import { NetlifyProvider } from "./netlify-provider"
+import { RenderProvider } from "./render-provider"
 import type { HostingCredentials, HostingProvider, HostingProviderName } from "./types"
 import { VercelHostingProvider } from "./vercel-provider"
 
@@ -30,13 +32,13 @@ export type {
  * (EncryptedData) — same convention as SocialPlatform. A plaintext `token`
  * fallback is tolerated for local/dev seeds.
  */
-export type DeploymentApiConfig = {
+export type DeploymentApiConfig = ({
   token_encrypted?: EncryptedData
   token?: string
   team_id?: string
   account_id?: string
   zone_id?: string
-} | null | undefined
+} & Record<string, any>) | null | undefined
 
 /** Minimal decryptor surface — the encryption module's service satisfies this. */
 export type Decryptor = { decrypt(data: EncryptedData): string }
@@ -63,10 +65,27 @@ export function resolveAccountCredentials(
     throw new Error("resolveAccountCredentials: deployment account has no token")
   }
 
+  // Pass through every remaining non-secret config field so provider adapters
+  // can read provider-specific ids (netlify installation_id, render owner_id…).
+  const RESERVED = new Set([
+    "token",
+    "token_encrypted",
+    "team_id",
+    "account_id",
+  ])
+  const extra: Record<string, string> = {}
+  for (const [k, v] of Object.entries(cfg)) {
+    if (RESERVED.has(k)) continue
+    if (v == null) continue
+    if (typeof v === "string") extra[k] = v
+    else if (typeof v === "number" || typeof v === "boolean") extra[k] = String(v)
+  }
+
   return {
     token,
     teamId: cfg.team_id || undefined,
     accountId: cfg.account_id || undefined,
+    extra: Object.keys(extra).length ? extra : undefined,
   }
 }
 
@@ -80,9 +99,10 @@ export function createHostingProvider(
       return new VercelHostingProvider(creds)
     case "cloudflare":
       return new CloudflarePagesProvider(creds)
-    case "render":
     case "netlify":
-      throw new Error(`Hosting provider "${provider}" not implemented yet (S5)`)
+      return new NetlifyProvider(creds)
+    case "render":
+      return new RenderProvider(creds)
     default:
       throw new Error(`Unknown hosting provider: ${provider}`)
   }

--- a/apps/backend/src/modules/deployment/providers/render-provider.ts
+++ b/apps/backend/src/modules/deployment/providers/render-provider.ts
@@ -1,0 +1,255 @@
+/**
+ * RenderProvider — Render as a storefront hosting target (#884 S5).
+ *
+ * Render REST API v1 (https://api.render.com/v1), Bearer API key. A Next.js
+ * storefront runs as a `web_service` (a long-running Node process serving
+ * `next start`) linked to a GitHub repo. Projects are addressed by the opaque
+ * `service id`, so `HostingProject.id` is the service id; `originHost` carries
+ * the `<slug>.onrender.com` host used as the CNAME target.
+ *
+ * Credentials (decrypted from `deployment_account.api_config`):
+ *   - token          Render API key
+ *   - extra.owner_id Render workspace/owner id (from GET /v1/owners) — required to create
+ *   - extra.region   optional Render region (default "oregon")
+ *   - extra.plan     optional Render plan (default "starter")
+ *
+ * Prerequisite: the Render GitHub App must be installed on the account so the
+ * repo is connectable (done once via the dashboard).
+ */
+
+import type {
+  AddDomainOptions,
+  CreateProjectInput,
+  HostingCredentials,
+  HostingDeployment,
+  HostingDomain,
+  HostingDomainStatus,
+  HostingEnvVar,
+  HostingProject,
+  HostingProvider,
+  TriggerDeploymentInput,
+} from "./types"
+import { cnameInstruction, isApexDomain, sanitizeProjectName } from "./types"
+
+const RENDER_API = "https://api.render.com/v1"
+
+type RenderService = {
+  id: string
+  name: string
+  slug?: string
+  serviceDetails?: { url?: string }
+}
+
+type RenderCustomDomain = { id: string; name: string; verificationStatus?: string }
+
+export class RenderProvider implements HostingProvider {
+  readonly provider = "render" as const
+  private readonly token: string
+  private readonly ownerId?: string
+  private readonly region: string
+  private readonly plan: string
+
+  constructor(creds: HostingCredentials) {
+    if (!creds?.token) throw new Error("RenderProvider requires a token")
+    this.token = creds.token
+    this.ownerId = creds.extra?.owner_id
+    this.region = creds.extra?.region || "oregon"
+    this.plan = creds.extra?.plan || "starter"
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.token}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    }
+  }
+
+  private async rd<T>(url: string, init: RequestInit, op: string): Promise<T> {
+    const res = await fetch(url, { ...init, headers: this.headers() })
+    if (!res.ok) {
+      const body = await res.text().catch(() => "")
+      throw new Error(`Render ${op} failed (${res.status}): ${body || res.statusText}`)
+    }
+    return (await res.json().catch(() => ({}))) as T
+  }
+
+  /** `<slug>.onrender.com` — the origin a subdomain should CNAME to. */
+  dnsTarget(project: HostingProject): string {
+    if (project.originHost) return project.originHost
+    return `${sanitizeProjectName(project.name)}.onrender.com`
+  }
+
+  private originFromService(svc: RenderService): string {
+    const url = svc.serviceDetails?.url
+    if (url) {
+      try {
+        return new URL(url).hostname
+      } catch {
+        // fall through
+      }
+    }
+    return `${svc.slug || sanitizeProjectName(svc.name)}.onrender.com`
+  }
+
+  async createProject(input: CreateProjectInput): Promise<HostingProject> {
+    if (!this.ownerId) {
+      throw new Error(
+        "RenderProvider.createProject requires api_config.owner_id (Render workspace/owner id from GET /v1/owners)"
+      )
+    }
+    const name = sanitizeProjectName(input.name)
+    const gitUrl = input.gitRepo.startsWith("http")
+      ? input.gitRepo
+      : `https://github.com/${input.gitRepo}`
+
+    const payload: Record<string, any> = {
+      type: "web_service",
+      name,
+      ownerId: this.ownerId,
+      repo: gitUrl,
+      branch: input.productionBranch || "main",
+      autoDeploy: "yes",
+      rootDir: input.rootDirectory || "",
+      serviceDetails: {
+        env: "node",
+        region: this.region,
+        plan: this.plan,
+        envSpecificDetails: {
+          buildCommand: input.buildCommand || "npm install && npm run build",
+          startCommand: "npm run start",
+        },
+      },
+    }
+
+    // Render wraps the created service under `.service` in the create response.
+    const created = await this.rd<{ service: RenderService } | RenderService>(
+      `${RENDER_API}/services`,
+      { method: "POST", body: JSON.stringify(payload) },
+      "createProject"
+    )
+    const svc = (created as any).service ?? (created as RenderService)
+    return { id: svc.id, name: svc.name, originHost: this.originFromService(svc) }
+  }
+
+  async setEnvVars(serviceId: string, envVars: HostingEnvVar[]): Promise<void> {
+    // PUT is a full replace of the service's env vars.
+    const payload = envVars.map((v) => ({ key: v.key, value: v.value }))
+    await this.rd(
+      `${RENDER_API}/services/${serviceId}/env-vars`,
+      { method: "PUT", body: JSON.stringify(payload) },
+      "setEnvVars"
+    )
+  }
+
+  async addDomain(
+    serviceId: string,
+    domain: string,
+    _opts?: AddDomainOptions
+  ): Promise<HostingDomain> {
+    try {
+      const d = await this.rd<RenderCustomDomain>(
+        `${RENDER_API}/services/${serviceId}/custom-domains`,
+        { method: "POST", body: JSON.stringify({ name: domain }) },
+        "addDomain"
+      )
+      return {
+        name: d.name || domain,
+        verified: d.verificationStatus === "verified",
+        verification: [],
+      }
+    } catch (e: any) {
+      return { name: domain, verified: false, verification: [], error: e.message }
+    }
+  }
+
+  async removeDomain(serviceId: string, domain: string): Promise<void> {
+    // Render deletes custom domains by their id — look it up by name first.
+    const domains = await this.rd<Array<{ customDomain: RenderCustomDomain }> | RenderCustomDomain[]>(
+      `${RENDER_API}/services/${serviceId}/custom-domains`,
+      { method: "GET" },
+      "listCustomDomains"
+    ).catch(() => [] as any)
+    const match = (domains as any[])
+      .map((x) => x.customDomain ?? x)
+      .find((d: RenderCustomDomain) => d.name === domain)
+    if (!match) return
+    const res = await fetch(`${RENDER_API}/services/${serviceId}/custom-domains/${match.id}`, {
+      method: "DELETE",
+      headers: this.headers(),
+    })
+    if (!res.ok && res.status !== 404) {
+      throw new Error(`Render removeDomain failed (${res.status}): ${await res.text()}`)
+    }
+  }
+
+  private async findCustomDomain(
+    serviceId: string,
+    domain: string
+  ): Promise<RenderCustomDomain | null> {
+    try {
+      const domains = await this.rd<Array<{ customDomain: RenderCustomDomain }> | RenderCustomDomain[]>(
+        `${RENDER_API}/services/${serviceId}/custom-domains`,
+        { method: "GET" },
+        "listCustomDomains"
+      )
+      return (
+        (domains as any[]).map((x) => x.customDomain ?? x).find((d) => d.name === domain) ?? null
+      )
+    } catch {
+      return null
+    }
+  }
+
+  async verifyDomain(serviceId: string, domain: string): Promise<HostingDomain> {
+    // POST verify triggers Render's DNS check; fall back to reading status.
+    try {
+      const d = await this.rd<RenderCustomDomain>(
+        `${RENDER_API}/services/${serviceId}/custom-domains/${encodeURIComponent(domain)}/verify`,
+        { method: "POST", body: JSON.stringify({}) },
+        "verifyDomain"
+      )
+      return { name: domain, verified: d.verificationStatus === "verified", verification: [] }
+    } catch {
+      const found = await this.findCustomDomain(serviceId, domain)
+      return { name: domain, verified: found?.verificationStatus === "verified", verification: [] }
+    }
+  }
+
+  async describeDomain(serviceId: string, domain: string): Promise<HostingDomainStatus> {
+    const found = await this.findCustomDomain(serviceId, domain)
+    let target = `${sanitizeProjectName(domain)}.onrender.com`
+    try {
+      const svc = await this.rd<RenderService>(`${RENDER_API}/services/${serviceId}`, { method: "GET" }, "getService")
+      target = this.originFromService(svc)
+    } catch {
+      // keep fallback target
+    }
+    const verified = found?.verificationStatus === "verified"
+    const dnsRecords = isApexDomain(domain)
+      ? [{ type: "A", host: "@", value: "216.24.57.1" }] // Render apex A record
+      : [cnameInstruction(domain, target)]
+    return {
+      name: domain,
+      verified,
+      misconfigured: !verified,
+      configuredBy: verified ? "CNAME" : null,
+      dnsRecords,
+    }
+  }
+
+  async triggerDeployment(input: TriggerDeploymentInput): Promise<HostingDeployment> {
+    const serviceId = input.projectId || input.projectName
+    const d = await this.rd<{ id: string; status?: string }>(
+      `${RENDER_API}/services/${serviceId}/deploys`,
+      { method: "POST", body: JSON.stringify({ clearCache: "do_not_clear" }) },
+      "triggerDeployment"
+    )
+    return { id: d.id, url: "", status: d.status || "created" }
+  }
+
+  async getProject(serviceId: string): Promise<HostingProject> {
+    const svc = await this.rd<RenderService>(`${RENDER_API}/services/${serviceId}`, { method: "GET" }, "getProject")
+    return { id: svc.id, name: svc.name, originHost: this.originFromService(svc) }
+  }
+}

--- a/apps/backend/src/modules/deployment/providers/resolve-partner-provider.ts
+++ b/apps/backend/src/modules/deployment/providers/resolve-partner-provider.ts
@@ -93,11 +93,37 @@ function envCredentials(providerName: HostingProviderName): HostingCredentials {
       return { token, accountId }
     }
     default:
+      // Netlify/Render have no legacy env-single-account path — they always run
+      // via a deployment_account. Reaching here means the partner has no account.
       throw new MedusaError(
         MedusaError.Types.NOT_ALLOWED,
-        `Hosting provider "${providerName}" has no env credentials (not implemented until S5)`
+        `Hosting provider "${providerName}" requires a deployment account (no env-single-account fallback)`
       )
   }
+}
+
+/**
+ * Build a HostingProvider for a provider name + (optional) deployment_account.
+ * The single credential-resolution seam used by both the per-partner resolver
+ * and the provision workflow (S3):
+ *   - accountId set → decrypt that account's token (multi-account rotation path)
+ *   - accountId null → legacy env-single-account creds (pre-#884 behaviour)
+ */
+export async function buildHostingProvider(
+  providerName: HostingProviderName,
+  accountId: string | null,
+  container: MedusaContainer
+): Promise<HostingProvider> {
+  let creds: HostingCredentials
+  if (accountId) {
+    const deployment = container.resolve(DEPLOYMENT_MODULE) as DeploymentService
+    const account = await deployment.retrieveDeploymentAccount(accountId)
+    const encryption = container.resolve(ENCRYPTION_MODULE) as EncryptionService
+    creds = resolveAccountCredentials((account as any)?.api_config, encryption)
+  } else {
+    creds = envCredentials(providerName)
+  }
+  return createHostingProvider(providerName, creds)
 }
 
 export async function resolveHostingProviderForPartner(
@@ -111,16 +137,6 @@ export async function resolveHostingProviderForPartner(
     partner?.metadata?.deployment_account_id ??
     null) as string | null
 
-  let creds: HostingCredentials
-  if (accountId) {
-    const deployment = container.resolve(DEPLOYMENT_MODULE) as DeploymentService
-    const account = await deployment.retrieveDeploymentAccount(accountId)
-    const encryption = container.resolve(ENCRYPTION_MODULE) as EncryptionService
-    creds = resolveAccountCredentials((account as any)?.api_config, encryption)
-  } else {
-    creds = envCredentials(providerName)
-  }
-
-  const provider = createHostingProvider(providerName, creds)
+  const provider = await buildHostingProvider(providerName, accountId, container)
   return { providerName, provider, projectRef, accountId }
 }

--- a/apps/backend/src/modules/deployment/providers/types.ts
+++ b/apps/backend/src/modules/deployment/providers/types.ts
@@ -17,12 +17,21 @@ export type HostingProviderName = "vercel" | "cloudflare" | "render" | "netlify"
 
 /** Per-account credentials, decrypted at runtime from `deployment_account.api_config`. */
 export type HostingCredentials = {
-  /** API token (Vercel token / Cloudflare API token). */
+  /** API token (Vercel token / Cloudflare API token / Netlify PAT / Render key). */
   token: string
   /** Vercel team id (optional — personal accounts omit it). */
   teamId?: string
   /** Cloudflare/Render account id (the URL-scoping id). */
   accountId?: string
+  /**
+   * Provider-specific non-secret config carried through from api_config so each
+   * adapter can read what it needs without widening the core shape:
+   *   - Netlify: `account_slug`, `github_installation_id`
+   *   - Render:  `owner_id`
+   *   - Cloudflare (Pages/Workers): `zone_id`
+   * Populated from every api_config key that isn't a token/team/account field.
+   */
+  extra?: Record<string, string>
 }
 
 export type CreateProjectInput = {
@@ -96,6 +105,10 @@ export type HostingDomainStatus = {
 
 export type TriggerDeploymentInput = {
   projectName: string
+  /** The provider project id (Netlify site id / Render service id). Providers
+   * that address deploys by id use this; name-addressed providers (Vercel,
+   * Cloudflare Pages) use `projectName`. */
+  projectId?: string
   gitRepo: string
   ref?: string
 }

--- a/apps/backend/src/modules/partner/migrations/Migration20260712150000.ts
+++ b/apps/backend/src/modules/partner/migrations/Migration20260712150000.ts
@@ -1,0 +1,33 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Multi-provider hosting columns (#884 S3) — add the provider-agnostic
+ * storefront hosting fields to `partner`:
+ *   - hosting_provider          which provider the storefront lives on
+ *   - deployment_account_id     the rotated deployment_account it was placed on
+ *   - deployment_project_id     provider project id (Vercel id / Render service id)
+ *   - deployment_project_name   provider project name (Cloudflare Pages / Netlify site)
+ *
+ * These supersede the vercel_* columns; the vercel_* columns remain for
+ * backwards-compat reads of pre-#884 partners (see resolve-partner-provider.ts).
+ *
+ * Hand-written idempotent ALTER (add-column-if-not-exists) because `partner`
+ * already exists on live DBs (the create-if-not-exists migration hazard).
+ */
+export class Migration20260712150000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table if exists "partner" add column if not exists "hosting_provider" text null;`);
+    this.addSql(`alter table if exists "partner" add column if not exists "deployment_account_id" text null;`);
+    this.addSql(`alter table if exists "partner" add column if not exists "deployment_project_id" text null;`);
+    this.addSql(`alter table if exists "partner" add column if not exists "deployment_project_name" text null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table if exists "partner" drop column if exists "hosting_provider";`);
+    this.addSql(`alter table if exists "partner" drop column if exists "deployment_account_id";`);
+    this.addSql(`alter table if exists "partner" drop column if exists "deployment_project_id";`);
+    this.addSql(`alter table if exists "partner" drop column if exists "deployment_project_name";`);
+  }
+
+}

--- a/apps/backend/src/modules/partner/models/partner.ts
+++ b/apps/backend/src/modules/partner/models/partner.ts
@@ -47,6 +47,17 @@ const Partner = model.define("partner", {
     storefront_root_dir: model.text().nullable(),
     storefront_branch: model.text().nullable(),
 
+    // Multi-provider hosting (#884 S3). Which provider/account a partner's
+    // storefront was provisioned onto, and the provider-agnostic project ref.
+    // `hosting_provider` null → treat as legacy "vercel" (see resolve-partner-
+    // provider.ts). `deployment_account_id` null → legacy env-single-account
+    // path. `deployment_project_id/name` supersede the vercel_* columns; the
+    // vercel_* columns are kept for backwards-compat reads of pre-#884 records.
+    hosting_provider: model.text().nullable(),
+    deployment_account_id: model.text().nullable(),
+    deployment_project_id: model.text().nullable(),
+    deployment_project_name: model.text().nullable(),
+
     // Relationships
     admins: model.hasMany(() => PartnerAdmin),
 

--- a/apps/backend/src/workflows/partners/update-partner.ts
+++ b/apps/backend/src/workflows/partners/update-partner.ts
@@ -27,6 +27,10 @@ export type UpdatePartnerInput = {
     storefront_repo: string | null
     storefront_root_dir: string | null
     storefront_branch: string | null
+    hosting_provider: string | null
+    deployment_account_id: string | null
+    deployment_project_id: string | null
+    deployment_project_name: string | null
   }>
 }
 

--- a/apps/backend/src/workflows/stores/provision-storefront.ts
+++ b/apps/backend/src/workflows/stores/provision-storefront.ts
@@ -4,8 +4,16 @@ import {
   StepResponse,
   WorkflowResponse,
 } from "@medusajs/workflows-sdk"
+import { MedusaError } from "@medusajs/framework/utils"
 import { DEPLOYMENT_MODULE } from "../../modules/deployment"
 import type DeploymentService from "../../modules/deployment/service"
+import {
+  decideProvisionTarget,
+  type DeploymentAccountRow,
+  type DeploymentProvider,
+} from "../../modules/deployment/account-selector"
+import { buildHostingProvider } from "../../modules/deployment/providers/resolve-partner-provider"
+import type { HostingProviderName } from "../../modules/deployment/providers/types"
 import PartnerService from "../../modules/partner/service"
 import { WEBSITE_MODULE } from "../../modules/website"
 import type WebsiteService from "../../modules/website/service"
@@ -24,9 +32,18 @@ export type ProvisionStorefrontInput = {
   stripe_publishable_key: string
   s3_hostname: string
   s3_pathname: string
+  /**
+   * Preferred hosting provider for this NEW storefront. Defaults to
+   * DEFAULT_HOSTING_PROVIDER env (or "cloudflare"). The selector rotates across
+   * that provider's accounts, spills to other providers, then falls back to the
+   * legacy env-single-account path.
+   */
+  preferred_provider?: DeploymentProvider
 }
 
 export type ProvisionStorefrontResult = {
+  provider: HostingProviderName
+  account_id: string | null
   project: { id: string; name: string }
   domain: any
   dns: any
@@ -35,44 +52,138 @@ export type ProvisionStorefrontResult = {
   storefront_url: string
 }
 
-// Step 1: Create Vercel project
-const createVercelProjectStep = createStep(
-  "create-vercel-project",
+// ── Which providers have legacy env-single-account creds configured? ─────────
+function envConfiguredProviders(): DeploymentProvider[] {
+  const out: DeploymentProvider[] = []
+  if (process.env.VERCEL_TOKEN) out.push("vercel")
+  if (process.env.CLOUDFLARE_API_TOKEN && process.env.CLOUDFLARE_ACCOUNT_ID) {
+    out.push("cloudflare")
+  }
+  return out
+}
+
+// Step 1 (hosting): pick the account/provider this storefront provisions onto.
+const selectHostingTargetStep = createStep(
+  "select-hosting-target",
   async (
-    input: { handle: string; storefrontRepo: string; rootDirectory?: string },
+    input: { preferredProvider?: DeploymentProvider },
     { container }
   ) => {
     const deployment: DeploymentService = container.resolve(DEPLOYMENT_MODULE)
+
+    const accounts = (await deployment.listDeploymentAccounts(
+      {},
+      { take: 1000 }
+    )) as unknown as DeploymentAccountRow[]
+
+    const preferred =
+      input.preferredProvider ||
+      (process.env.DEFAULT_HOSTING_PROVIDER as DeploymentProvider | undefined) ||
+      "cloudflare"
+
+    const target = decideProvisionTarget(accounts || [], {
+      preferredProvider: preferred,
+      envProviders: envConfiguredProviders(),
+    })
+
+    if (!target) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_ALLOWED,
+        "No hosting capacity available — every deployment account is full/inactive and no legacy env provider is configured. Add or round-up an account."
+      )
+    }
+
+    const accountId = target.kind === "account" ? target.accountId : null
+    return new StepResponse({ providerName: target.provider, accountId })
+  }
+)
+
+// Step 2 (hosting): create the provider project (linked to the storefront repo).
+const createProjectStep = createStep(
+  "create-hosting-project",
+  async (
+    input: {
+      providerName: HostingProviderName
+      accountId: string | null
+      handle: string
+      storefrontRepo: string
+      rootDirectory?: string
+      branch?: string
+    },
+    { container }
+  ) => {
+    const provider = await buildHostingProvider(
+      input.providerName,
+      input.accountId,
+      container
+    )
     const projectName = `storefront-${input.handle}`
-    const project = await deployment.createProject({
+    const project = await provider.createProject({
       name: projectName,
       gitRepo: input.storefrontRepo,
       framework: "nextjs",
       rootDirectory: input.rootDirectory,
+      productionBranch: input.branch || "main",
       installCommand: "pnpm install --no-frozen-lockfile",
     })
 
     return new StepResponse(
-      { id: project.id, name: project.name },
-      { projectId: project.id }
+      { id: project.id, name: project.name, originHost: project.originHost ?? null },
+      {
+        projectId: project.id,
+        providerName: input.providerName,
+        accountId: input.accountId,
+      }
     )
+  },
+  // Compensation: best-effort remove the project if a later step fails.
+  async (state, { container }) => {
+    if (!state?.projectId) return
+    try {
+      const provider = await buildHostingProvider(
+        state.providerName,
+        state.accountId,
+        container
+      )
+      // Not all providers expose delete on the interface yet; guard.
+      const anyProvider = provider as any
+      if (typeof anyProvider.deleteProject === "function") {
+        await anyProvider.deleteProject(state.projectId)
+      }
+    } catch {
+      // best-effort
+    }
   }
 )
 
-// Step 2: Set environment variables on Vercel project
-const setVercelEnvVarsStep = createStep(
-  "set-vercel-env-vars",
-  async (input: {
-    projectId: string
-    publishableKey: string
-    medusaBackendUrl: string
-    stripeKey: string
-    s3Hostname: string
-    s3Pathname: string
-  }, { container }) => {
-    const deployment: DeploymentService = container.resolve(DEPLOYMENT_MODULE)
+// Step 3 (hosting): set env vars on the project.
+const setEnvVarsStep = createStep(
+  "set-hosting-env-vars",
+  async (
+    input: {
+      providerName: HostingProviderName
+      accountId: string | null
+      projectId: string
+      publishableKey: string
+      medusaBackendUrl: string
+      stripeKey: string
+      s3Hostname: string
+      s3Pathname: string
+    },
+    { container }
+  ) => {
+    const provider = await buildHostingProvider(
+      input.providerName,
+      input.accountId,
+      container
+    )
 
-    const envVars: Array<{ key: string; value: string; type: "plain"; target: string[] }> = [
+    const envVars: Array<{
+      key: string
+      value: string
+      type: "plain"
+      target: string[]
+    }> = [
       {
         key: "NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY",
         value: input.publishableKey,
@@ -116,54 +227,93 @@ const setVercelEnvVarsStep = createStep(
       })
     }
 
-    await deployment.setEnvironmentVariables(input.projectId, envVars)
-
+    await provider.setEnvVars(input.projectId, envVars)
     return new StepResponse({ success: true })
   }
 )
 
-// Step 3: Add custom domain to Vercel project
-const addVercelDomainStep = createStep(
-  "add-vercel-domain",
-  async (input: { projectId: string; handle: string; rootDomain: string }, { container }) => {
-    const deployment: DeploymentService = container.resolve(DEPLOYMENT_MODULE)
+// Step 4 (hosting): add the storefront subdomain as a custom domain.
+const addDomainStep = createStep(
+  "add-hosting-domain",
+  async (
+    input: {
+      providerName: HostingProviderName
+      accountId: string | null
+      projectId: string
+      handle: string
+      rootDomain: string
+    },
+    { container }
+  ) => {
+    const provider = await buildHostingProvider(
+      input.providerName,
+      input.accountId,
+      container
+    )
     const domain = `${input.handle}.${input.rootDomain}`
     try {
-      const result = await deployment.addDomain(input.projectId, domain)
+      const result = await provider.addDomain(input.projectId, domain)
       return new StepResponse(result)
     } catch (e: any) {
-      return new StepResponse({
-        name: domain,
-        verified: false,
-        error: e.message,
-      })
+      return new StepResponse({ name: domain, verified: false, error: e.message })
     }
   }
 )
 
-// Step 4a: Create Cloudflare DNS record using Vercel's recommended target
-// for this specific project. The recommendation is fetched at runtime so
-// per-project CNAMEs (e.g. dc034fcb6b63fdce.vercel-dns-017.com) are applied
-// directly rather than the generic cname.vercel-dns.com fallback.
-const createCloudflareCnameStep = createStep(
-  "create-cloudflare-cname",
-  async (input: { subdomain: string; rootDomain: string }, { container }) => {
+// Step 5a: Create the Cloudflare DNS record (our platform zone) pointing the
+// subdomain at the provider origin. Vercel uses the per-project recommendation;
+// other providers CNAME to their fixed origin host (provider.dnsTarget).
+const createCnameStep = createStep(
+  "create-storefront-cname",
+  async (
+    input: {
+      providerName: HostingProviderName
+      accountId: string | null
+      subdomain: string
+      rootDomain: string
+      projectId: string
+      projectName: string
+      originHost: string | null
+    },
+    { container }
+  ) => {
     const deployment: DeploymentService = container.resolve(DEPLOYMENT_MODULE)
     const fullDomain = `${input.subdomain}.${input.rootDomain}`
     try {
-      const result = await deployment.applyRecommendedDns(fullDomain)
-      console.log("[provision-storefront] Cloudflare DNS result:", JSON.stringify(result))
+      if (input.providerName === "vercel") {
+        // Vercel's per-project CNAME recommendation (e.g. <hash>.vercel-dns-017.com).
+        const result = await deployment.applyRecommendedDns(fullDomain)
+        console.log("[provision-storefront] DNS (vercel recommended):", JSON.stringify(result))
+        return new StepResponse(result as any)
+      }
+      const provider = await buildHostingProvider(
+        input.providerName,
+        input.accountId,
+        container
+      )
+      const target = provider.dnsTarget({
+        id: input.projectId,
+        name: input.projectName,
+        originHost: input.originHost ?? undefined,
+      })
+      const result = await deployment.ensureCname(fullDomain, target)
+      console.log(
+        `[provision-storefront] DNS (${input.providerName} CNAME → ${target}):`,
+        JSON.stringify(result)
+      )
       return new StepResponse(result as any)
     } catch (e: any) {
-      console.error("[provision-storefront] Cloudflare DNS error:", e.message)
+      console.error("[provision-storefront] DNS error:", e.message)
       return new StepResponse({ action: "failed", error: e.message } as any)
     }
   }
 )
 
-// Step 4b: Create Vercel domain verification DNS records (TXT etc.)
-const createVercelVerificationRecordsStep = createStep(
-  "create-vercel-verification-records",
+// Step 5b: Create provider domain-verification DNS records (Vercel TXT etc.).
+// No-op when the provider returned no verification records (Cloudflare/Netlify/
+// Render verify via the CNAME resolving).
+const createVerificationRecordsStep = createStep(
+  "create-verification-records",
   async (
     input: { verification: Array<{ type: string; domain: string; value: string }> | null },
     { container }
@@ -173,26 +323,35 @@ const createVercelVerificationRecordsStep = createStep(
       const results = await deployment.createVercelVerificationRecords(
         input.verification || undefined
       )
-      console.log("[provision-storefront] Verification records result:", JSON.stringify(results))
       return new StepResponse(results)
     } catch (e: any) {
-      console.error("[provision-storefront] Verification records error:", e.message)
       return new StepResponse([{ domain: "unknown", action: "failed", error: e.message }])
     }
   }
 )
 
-// Step 5: Trigger Vercel production deployment
-const triggerVercelDeploymentStep = createStep(
-  "trigger-vercel-deployment",
+// Step 6 (hosting): trigger a production deployment.
+const triggerDeploymentStep = createStep(
+  "trigger-hosting-deployment",
   async (
-    input: { handle: string; storefrontRepo: string; branch?: string },
+    input: {
+      providerName: HostingProviderName
+      accountId: string | null
+      projectId: string
+      projectName: string
+      storefrontRepo: string
+      branch?: string
+    },
     { container }
   ) => {
-    const deployment: DeploymentService = container.resolve(DEPLOYMENT_MODULE)
-    const projectName = `storefront-${input.handle}`
-    const result = await deployment.triggerDeployment({
-      projectName,
+    const provider = await buildHostingProvider(
+      input.providerName,
+      input.accountId,
+      container
+    )
+    const result = await provider.triggerDeployment({
+      projectName: input.projectName,
+      projectId: input.projectId,
       gitRepo: input.storefrontRepo,
       ref: input.branch || "main",
     })
@@ -200,16 +359,14 @@ const triggerVercelDeploymentStep = createStep(
     return new StepResponse({
       id: result.id,
       url: result.url,
-      status: result.readyState,
+      status: result.status,
     })
   }
 )
 
-// Step 6: Save Vercel metadata to partner.
-// Columns are the source of truth. After writing them we strip legacy keys
-// from partner.metadata so we don't keep stale dual state — every read
-// helper falls back to metadata for older partners, and this is the
-// migration step for any partner that gets re-provisioned.
+// Step 7: Save storefront state to the partner (source of truth = columns).
+// Stamps the provider-agnostic columns + keeps vercel_* in sync for Vercel so
+// pre-#884 read helpers keep working. Strips legacy metadata keys.
 const LEGACY_STOREFRONT_METADATA_KEYS = [
   "vercel_project_id",
   "vercel_project_name",
@@ -223,6 +380,8 @@ const saveStorefrontMetadataStep = createStep(
   async (
     input: {
       partnerId: string
+      providerName: HostingProviderName
+      accountId: string | null
       projectId: string
       projectName: string
       handle: string
@@ -237,7 +396,6 @@ const saveStorefrontMetadataStep = createStep(
     const domain = `${input.handle}.${input.rootDomain}`
     const partnerService: PartnerService = container.resolve("partner")
 
-    // Read current metadata so we can strip the legacy keys in the same write.
     const existing = await partnerService.retrievePartner(input.partnerId)
     const currentMeta = (existing?.metadata || {}) as Record<string, any>
     const cleanedMeta: Record<string, any> = {}
@@ -247,13 +405,21 @@ const saveStorefrontMetadataStep = createStep(
       }
     }
 
+    const isVercel = input.providerName === "vercel"
+
     await partnerService.updatePartners({
       id: input.partnerId,
       storefront_domain: domain,
-      vercel_project_id: input.projectId,
-      vercel_project_name: input.projectName,
-      vercel_last_deployment_id: input.lastDeploymentId ?? null,
-      vercel_linked: true,
+      // Provider-agnostic source of truth (S3):
+      hosting_provider: input.providerName,
+      deployment_account_id: input.accountId ?? null,
+      deployment_project_id: input.projectId,
+      deployment_project_name: input.projectName,
+      // Keep vercel_* in sync for Vercel partners so legacy reads still resolve.
+      vercel_project_id: isVercel ? input.projectId : null,
+      vercel_project_name: isVercel ? input.projectName : null,
+      vercel_last_deployment_id: isVercel ? input.lastDeploymentId ?? null : null,
+      vercel_linked: isVercel,
       storefront_repo: input.storefrontRepo,
       storefront_root_dir: input.storefrontRootDir ?? null,
       storefront_branch: input.storefrontBranch ?? "main",
@@ -264,7 +430,36 @@ const saveStorefrontMetadataStep = createStep(
   }
 )
 
-// Step 7: Create website record for the storefront domain
+// Step 8: Increment the chosen account's live project_count (rotation load).
+// Only when we provisioned onto a real deployment_account (not the env path).
+const incrementAccountCountStep = createStep(
+  "increment-account-count",
+  async (
+    input: { accountId: string | null },
+    { container }
+  ) => {
+    if (!input.accountId) return new StepResponse({ incremented: false }, null)
+    const deployment: DeploymentService = container.resolve(DEPLOYMENT_MODULE)
+    const account = await deployment.retrieveDeploymentAccount(input.accountId)
+    const next = ((account as any)?.project_count ?? 0) + 1
+    await deployment.updateDeploymentAccounts({ id: input.accountId, project_count: next })
+    return new StepResponse({ incremented: true }, input.accountId)
+  },
+  // Compensation: roll the count back down.
+  async (accountId, { container }) => {
+    if (!accountId) return
+    try {
+      const deployment: DeploymentService = container.resolve(DEPLOYMENT_MODULE)
+      const account = await deployment.retrieveDeploymentAccount(accountId)
+      const next = Math.max(0, ((account as any)?.project_count ?? 1) - 1)
+      await deployment.updateDeploymentAccounts({ id: accountId, project_count: next })
+    } catch {
+      // best-effort
+    }
+  }
+)
+
+// Step: Create website record for the storefront domain (provider-neutral).
 const createWebsiteRecordStep = createStep(
   "create-website-record",
   async (
@@ -279,16 +474,9 @@ const createWebsiteRecordStep = createStep(
     const websiteService: WebsiteService = container.resolve(WEBSITE_MODULE)
     const domain = `${input.handle}.${input.rootDomain}`
 
-    // Check if a website already exists for this domain
-    const [existing] = await websiteService.listAndCountWebsites(
-      { domain },
-      { take: 1 }
-    )
+    const [existing] = await websiteService.listAndCountWebsites({ domain }, { take: 1 })
     if (existing.length) {
-      return new StepResponse(
-        { website: existing[0], created: false },
-        null
-      )
+      return new StepResponse({ website: existing[0], created: false }, null)
     }
 
     const website = await websiteService.createWebsites({
@@ -299,17 +487,10 @@ const createWebsiteRecordStep = createStep(
 
     await websiteService.ensurePrimaryWebsiteDomain(website.id, domain)
 
-    // Save website_id on partner record
     const partnerService: PartnerService = container.resolve("partner")
-    await partnerService.updatePartners({
-      id: input.partnerId,
-      website_id: website.id,
-    })
+    await partnerService.updatePartners({ id: input.partnerId, website_id: website.id })
 
-    return new StepResponse(
-      { website, created: true },
-      website.id
-    )
+    return new StepResponse({ website, created: true }, website.id)
   },
   async (websiteId, { container }) => {
     if (!websiteId) return
@@ -322,24 +503,16 @@ const createWebsiteRecordStep = createStep(
   }
 )
 
-// Step 8: Seed default pages for the website. Always runs — the seed
-// workflow itself is idempotent (it skips slugs that already exist), so
-// re-provisions and previously-created-but-unseeded websites self-heal.
+// Step: Seed default pages for the website (idempotent, non-fatal).
 const seedDefaultWebsitePagesStep = createStep(
   "seed-default-website-pages",
-  async (
-    input: { websiteId: string },
-    { container }
-  ) => {
+  async (input: { websiteId: string }, { container }) => {
     try {
       const { result } = await seedDefaultPagesWorkflow(container).run({
         input: { website_id: input.websiteId },
       })
       return new StepResponse({ pages: result?.pages, skipped_slugs: result?.skipped })
     } catch (e: any) {
-      // Non-fatal — provisioning should succeed even if page seeding fails.
-      // Return the same shape as the success path so the step's inferred
-      // output type stays unified.
       console.error("[provision-storefront] Page seeding failed:", e.message)
       return new StepResponse({
         pages: [] as { id: string; title: string; slug: string; blocks_created: number }[],
@@ -352,8 +525,7 @@ const seedDefaultWebsitePagesStep = createStep(
 export const provisionStorefrontWorkflow = createWorkflow(
   "provision-storefront",
   (input: ProvisionStorefrontInput) => {
-    // Step 1: Create website row FIRST so /web/website/{domain}/* never
-    // races a missing row on the very first Vercel build.
+    // Website row first so /web/website/{domain}/* never races a missing row.
     const websiteResult = createWebsiteRecordStep({
       handle: input.handle,
       rootDomain: input.root_domain,
@@ -361,20 +533,29 @@ export const provisionStorefrontWorkflow = createWorkflow(
       partnerId: input.partner_id,
     })
 
-    // Step 2: Seed default pages for the website
     seedDefaultWebsitePagesStep({
       websiteId: websiteResult.website.id as unknown as string,
     })
 
-    // Step 3: Create Vercel project (linked directly to the storefront repo)
-    const project = createVercelProjectStep({
+    // Pick provider/account (rotation; default Cloudflare Pages; env fallback).
+    const target = selectHostingTargetStep({
+      preferredProvider: input.preferred_provider,
+    })
+
+    // Create the provider project (linked to the storefront repo).
+    const project = createProjectStep({
+      providerName: target.providerName,
+      accountId: target.accountId,
       handle: input.handle,
       storefrontRepo: input.storefront_repo,
       rootDirectory: input.storefront_root_dir,
+      branch: input.storefront_branch,
     })
 
-    // Step 4: Set env vars
-    setVercelEnvVarsStep({
+    // Env vars.
+    setEnvVarsStep({
+      providerName: target.providerName,
+      accountId: target.accountId,
       projectId: project.id,
       publishableKey: input.publishable_key,
       medusaBackendUrl: input.medusa_backend_url,
@@ -383,34 +564,46 @@ export const provisionStorefrontWorkflow = createWorkflow(
       s3Pathname: input.s3_pathname,
     })
 
-    // Step 5: Add custom domain to Vercel
-    const domainResult = addVercelDomainStep({
+    // Custom domain.
+    const domainResult = addDomainStep({
+      providerName: target.providerName,
+      accountId: target.accountId,
       projectId: project.id,
       handle: input.handle,
       rootDomain: input.root_domain,
     })
 
-    // Step 6a: Create Cloudflare CNAME
-    const dnsResult = createCloudflareCnameStep({
+    // DNS: CNAME (our zone) → provider origin.
+    const dnsResult = createCnameStep({
+      providerName: target.providerName,
+      accountId: target.accountId,
       subdomain: input.handle,
       rootDomain: input.root_domain,
+      projectId: project.id,
+      projectName: project.name,
+      originHost: project.originHost,
     })
 
-    // Step 6b: Create verification DNS records (depends on step 5 domain result)
-    const verificationResult = createVercelVerificationRecordsStep({
+    // Verification DNS records (Vercel TXT; no-op otherwise).
+    const verificationResult = createVerificationRecordsStep({
       verification: domainResult.verification as any,
     })
 
-    // Step 7: Trigger deployment
-    const deployment = triggerVercelDeploymentStep({
-      handle: input.handle,
+    // Trigger production deployment.
+    const deployment = triggerDeploymentStep({
+      providerName: target.providerName,
+      accountId: target.accountId,
+      projectId: project.id,
+      projectName: project.name,
       storefrontRepo: input.storefront_repo,
       branch: input.storefront_branch,
     })
 
-    // Step 8: Save partner storefront state (source of truth = table columns)
+    // Save partner storefront state (source of truth = columns).
     saveStorefrontMetadataStep({
       partnerId: input.partner_id,
+      providerName: target.providerName,
+      accountId: target.accountId,
       projectId: project.id,
       projectName: project.name,
       handle: input.handle,
@@ -421,7 +614,12 @@ export const provisionStorefrontWorkflow = createWorkflow(
       lastDeploymentId: deployment.id as unknown as string,
     })
 
+    // Bump the account's rotation load.
+    incrementAccountCountStep({ accountId: target.accountId })
+
     return new WorkflowResponse({
+      provider: target.providerName,
+      account_id: target.accountId,
       project,
       domain: domainResult,
       dns: dnsResult,

--- a/apps/docs/notes/MULTI_ACCOUNT_HOSTING_PROVISIONING.md
+++ b/apps/docs/notes/MULTI_ACCOUNT_HOSTING_PROVISIONING.md
@@ -1,6 +1,54 @@
 # Multi-account storefront hosting provisioning (Vercel / Cloudflare Pages / Render / Netlify)
 
-Status: **in progress** — slice 1 built (2026-07-04). Branch `feat/839-unsubscribe-bounce-webhooks`.
+Status: **S1–S3 + S5(Netlify/Render) + admin CRUD + partner-agnostic routes done**
+(2026-07-12, branch `feat/storefront-hosting-rotation-s3`). S1/S2 previously merged.
+
+## What shipped 2026-07-12 (this branch)
+
+- **S3 rotation wiring** — `provisionStorefrontWorkflow` is now provider-agnostic:
+  it selects a `deployment_account` via `decideProvisionTarget` (least-loaded of
+  the preferred provider → spill to any provider → legacy env fallback), runs
+  create/env/domain/DNS/deploy through the resolved `HostingProvider`, stamps the
+  new partner columns, and increments `project_count` (with compensating
+  rollback). **Default provider for new partners = Cloudflare Pages** (override
+  via `DEFAULT_HOSTING_PROVIDER` or `partner.hosting_provider`).
+- **New partner columns** (`Migration20260712150000`): `hosting_provider`,
+  `deployment_account_id`, `deployment_project_id`, `deployment_project_name`.
+  Applied locally. vercel_* columns kept in sync for Vercel partners.
+- **S5 adapters**: `netlify-provider.ts` + `render-provider.ts` implement
+  `HostingProvider` (repo-linked create, env, custom domain, deploy, dnsTarget →
+  `*.netlify.app` / `*.onrender.com`). Registered in `registry.ts`.
+  `HostingCredentials.extra` carries provider-specific ids (Netlify
+  `github_installation_id`/`account_id`, Render `owner_id`, …) decrypted from
+  api_config.
+- **Cloudflare Workers: NOT built (decision).** Repo→Worker linking is
+  dashboard-only in CF's API (open gap, workers-sdk#12058); only build-trigger/
+  env/deploy/custom-domain are API-driven. **Cloudflare Pages** (already built,
+  `POST /accounts/{id}/pages/projects`) is the Cloudflare hosting path.
+- **S4 admin CRUD**: `/admin/deployment-accounts` (+ `/:id`) — create (token
+  AES-encrypted at rest via encryption module → `api_config.token_encrypted`,
+  redacted with `token_present`), list (capacity surfaced), update (cutoff via
+  `status:"full"`, round-up via `cutoff_max`), delete. Validators + middleware
+  wired. **Admin React UI DONE**: `src/admin/routes/settings/deployment-accounts/
+  page.tsx` (Settings → "Storefront Hosting") — list Table + create FocusModal +
+  edit Drawer + row actions (cutoff toggle / delete), provider-specific config
+  fields, token `_present` badge, capacity/at-cap display. Hooks in
+  `src/admin/hooks/api/deployment-accounts.ts`.
+- **Provider-agnostic partner routes**: `GET/DELETE /partners/storefront` and the
+  provision dup-check now dispatch through `resolveHostingProviderForPartner`
+  (status/teardown work for CF/Netlify/Render partners, not just Vercel). DELETE
+  decrements the account's `project_count`.
+- **partner-ui**: `settings/stores` surfaces the hosting provider; provision/
+  status/custom-domain + DNS-records/verify flow already existed.
+- Tests: `account-selector` (12) + `hosting-providers` (43 total) green.
+
+**Next**: admin React UI for deployment-accounts; backfill existing Vercel
+partners to a Vercel env-account row; configure a Cloudflare Pages + Netlify
+`deployment_account` with real `cutoff_max`; live provision smoke-test.
+
+---
+
+Status (historical): **in progress** — slice 1 built (2026-07-04).
 
 ## Goal
 

--- a/apps/partner-ui/src/hooks/api/storefront.ts
+++ b/apps/partner-ui/src/hooks/api/storefront.ts
@@ -12,9 +12,13 @@ import { queryKeysFactory } from "../../lib/query-key-factory"
 const STOREFRONT_QUERY_KEY = "partner_storefront" as const
 export const storefrontQueryKeys = queryKeysFactory(STOREFRONT_QUERY_KEY)
 
+export type HostingProvider = "vercel" | "cloudflare" | "render" | "netlify"
+
 export interface StorefrontStatus {
   provisioned: boolean
   message?: string
+  /** Which hosting provider the storefront lives on (#884). */
+  provider?: HostingProvider
   project?: {
     id: string
     name: string

--- a/apps/partner-ui/src/routes/settings/stores/stores.tsx
+++ b/apps/partner-ui/src/routes/settings/stores/stores.tsx
@@ -41,6 +41,21 @@ function formatDate(dateStr: string | number | null | undefined): string {
   })
 }
 
+function hostingProviderLabel(provider: string | undefined): string {
+  switch (provider) {
+    case "vercel":
+      return "Vercel"
+    case "cloudflare":
+      return "Cloudflare Pages"
+    case "netlify":
+      return "Netlify"
+    case "render":
+      return "Render"
+    default:
+      return "—"
+  }
+}
+
 function statusColor(
   status: string | undefined
 ): "green" | "orange" | "grey" | "red" {
@@ -279,6 +294,11 @@ const StorefrontSection = () => {
               <Text size="small">—</Text>
             )}
           </div>
+
+          <Text size="small" className="text-ui-fg-subtle">
+            Hosting
+          </Text>
+          <Text size="small">{hostingProviderLabel(status.provider)}</Text>
 
           <Text size="small" className="text-ui-fg-subtle">
             Enabled


### PR DESCRIPTION
Provisions partner storefronts across **Vercel, Cloudflare Pages, Netlify, and Render**, rotating across free-tier deployment accounts so a new storefront lands on the least-loaded active account under its cutoff. Continues #884 (S1/S2 previously merged).

## Backend
- **Rotation**: `provisionStorefrontWorkflow` is now provider-agnostic — selects a `deployment_account` via `decideProvisionTarget` (preferred provider → spill to any provider → legacy env fallback), runs create/env/domain/DNS/deploy through the resolved `HostingProvider`, stamps partner columns, `project_count++` (compensating). **Default = Cloudflare Pages** (`DEFAULT_HOSTING_PROVIDER` / `partner.hosting_provider` override).
- **Columns**: `hosting_provider`, `deployment_account_id`, `deployment_project_id`, `deployment_project_name` (+ `Migration20260712150000`); `vercel_*` kept in sync for Vercel partners.
- **Adapters**: Netlify + Render `HostingProvider`s (repo-linked create, env, custom domain, deploy, `dnsTarget`). `HostingCredentials.extra` passthrough for provider-specific ids.
- **Cloudflare Workers not built** — repo→Worker linking is dashboard-only in CF's API; **Cloudflare Pages** is the Cloudflare path.
- **Admin CRUD** `/admin/deployment-accounts` (token AES-encrypted at rest, redacted with `token_present`, cutoff via `status:"full"`, round-up via `cutoff_max`) + **admin UI** (Settings → Storefront Hosting).
- Partner storefront GET/DELETE + provision dup-check made provider-agnostic.
- **Data Plumbing job** `backfill-partner-hosting-provider` — stamp/attach pre-#884 Vercel partners to a Vercel deployment account (dry-run → apply, audited).

## partner-ui
- `settings/stores` surfaces the hosting provider.

## Tests
- `account-selector` (rotation + env fallback), Netlify/Render adapters, backfill decision helper — all green. Backend + admin + partner-ui typecheck clean.

## Ops tail (post-merge)
1. Create a Vercel + a Cloudflare Pages `deployment_account` in Settings → Storefront Hosting.
2. Run the `backfill-partner-hosting-provider` DP job (dry-run, then apply with the Vercel account id).
3. Live provision smoke-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)