### PR TITLE
feat(partner): auto-bypass email verification on partner creation

### DIFF
--- a/apps/backend/src/admin/components/partners/partner-email-verification-section.tsx
+++ b/apps/backend/src/admin/components/partners/partner-email-verification-section.tsx
@@ -1,0 +1,89 @@
+import { Badge, Button, Container, Heading, Text, toast } from "@medusajs/ui"
+import { useState } from "react"
+import { sdk } from "../../lib/config"
+import { useQueryClient } from "@tanstack/react-query"
+
+interface PartnerEmailVerificationSectionProps {
+  partnerId: string
+  partnerName: string
+}
+
+export const PartnerEmailVerificationSection = ({
+  partnerId,
+  partnerName,
+}: PartnerEmailVerificationSectionProps) => {
+  const queryClient = useQueryClient()
+  const [bypassing, setBypassing] = useState(false)
+  const [result, setResult] = useState<{
+    verified: boolean
+    already_verified: boolean
+    email?: string
+  } | null>(null)
+
+  const handleBypass = async () => {
+    setBypassing(true)
+    try {
+      const resp: any = await sdk.client.fetch(
+        `/admin/partners/${partnerId}/bypass-email-verification`,
+        { method: "POST" }
+      )
+      setResult(resp)
+      if (resp.already_verified) {
+        toast.success("Email already verified")
+      } else {
+        toast.success(`Email verification bypassed for ${resp.email}`)
+      }
+      queryClient.invalidateQueries({ queryKey: ["partner", partnerId] })
+    } catch (e: any) {
+      toast.error(e.message || "Failed to bypass email verification")
+    } finally {
+      setBypassing(false)
+    }
+  }
+
+  const isVerified = result?.verified
+
+  return (
+    <Container className="p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div>
+          <Heading level="h2">Email Verification</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            {isVerified
+              ? "Email is verified — partner can log in without verification"
+              : "Not verified — partner login may require email verification"}
+          </Text>
+        </div>
+        {isVerified && (
+          <Badge color="green" size="small">Verified</Badge>
+        )}
+      </div>
+
+      <div className="border-t border-ui-border-base px-6 py-4">
+        <div className="space-y-3">
+          {result?.email && (
+            <div className="flex items-center justify-between">
+              <div>
+                <Text size="small" className="text-ui-fg-muted font-medium">Email</Text>
+                <Text className="font-mono">{result.email}</Text>
+              </div>
+            </div>
+          )}
+          <Text size="xsmall" className="text-ui-fg-disabled">
+            Bypasses the email verification gate for {partnerName}, allowing
+            them to log in without confirming their email. Idempotent — safe
+            to apply even if already verified.
+          </Text>
+          <Button
+            size="small"
+            variant="primary"
+            onClick={handleBypass}
+            isLoading={bypassing}
+          >
+            {result?.already_verified ? "Re-verify" : "Bypass Email Verification"}
+          </Button>
+        </div>
+      </div>
+    </Container>
+  )
+}

--- a/apps/backend/src/admin/routes/partners/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/partners/[id]/page.tsx
@@ -12,6 +12,7 @@ import { PartnerStorefrontSection } from "../../../components/partners/partner-s
 import { PartnerSubscriptionSection } from "../../../components/partners/partner-subscription-section"
 import { PartnerPeopleSection } from "../../../components/partners/partner-people-section"
 import { PartnerWhatsAppSection } from "../../../components/partners/partner-whatsapp-section"
+import { PartnerEmailVerificationSection } from "../../../components/partners/partner-email-verification-section"
 import { PartnerTransactionFeesSection } from "../../../components/partners/partner-transaction-fees-section"
 import type { AdminPartner } from "../../../hooks/api/partners-admin"
 import { partnerLoader } from "./loader"
@@ -50,6 +51,10 @@ const PartnerDetailPage = () => {
             partnerName={partner.name}
             whatsappNumber={partner.whatsapp_number}
             whatsappVerified={partner.whatsapp_verified}
+          />
+          <PartnerEmailVerificationSection
+            partnerId={partner.id}
+            partnerName={partner.name}
           />
           <PartnerSubscriptionSection partnerId={partner.id} />
           <PartnerPeopleSection partnerId={partner.id} />

--- a/apps/backend/src/api/admin/partners/[id]/bypass-email-verification/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/bypass-email-verification/route.ts
@@ -1,0 +1,106 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
+import { PARTNER_MODULE } from "../../../../../modules/partner"
+
+/**
+ * POST /admin/partners/:id/bypass-email-verification
+ *
+ * Marks the partner admin's email as verified in the auth_verification
+ * system, bypassing the login gate. Uses the same auth_verification
+ * upsert logic as backfillPartnerEmailVerifiedJob.
+ *
+ * Idempotent — if the email is already verified the call is a no-op.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const { id: partnerId } = req.params
+
+  const partnerService = req.scope.resolve(PARTNER_MODULE) as any
+  const partner = await partnerService.retrievePartner(partnerId).catch(() => null)
+  if (!partner) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Partner not found")
+  }
+
+  const authModule: any = req.scope.resolve(Modules.AUTH)
+
+  // Determine entity type from config (same as backfill job)
+  let entityType = "email"
+  try {
+    const config = req.scope.resolve(ContainerRegistrationKeys.CONFIG_MODULE)
+    const forPartner =
+      config?.projectConfig?.http?.authVerificationsPerActor?.partner
+    const emailpass = (forPartner || []).find(
+      (v: any) => v?.auth_provider === "emailpass"
+    )
+    if (emailpass?.entity_type) entityType = emailpass.entity_type
+  } catch { /* default to "email" */ }
+
+  // Find auth identities linked to this partner via app_metadata
+  const identities = await authModule.listAuthIdentities(
+    {},
+    { relations: ["provider_identities"] }
+  )
+
+  const partnerIdentity = (identities || []).find(
+    (ai: any) => ai?.app_metadata?.partner_id === partnerId
+  )
+
+  if (!partnerIdentity) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      "No auth identity found for this partner"
+    )
+  }
+
+  const emailpass = (partnerIdentity.provider_identities || []).find(
+    (p: any) => p?.provider === "emailpass"
+  )
+
+  if (!emailpass?.entity_id) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      "No emailpass identity found for this partner"
+    )
+  }
+
+  const email = emailpass.entity_id
+  const now = new Date()
+
+  // Upsert verified auth_verification row (same logic as backfill job)
+  const existing = await authModule.listAuthVerifications({
+    auth_identity_id: partnerIdentity.id,
+    entity_id: email,
+    entity_type: entityType,
+  })
+
+  const row = existing?.[0]
+  if (row) {
+    if (row.verified_at) {
+      return res.json({
+        partner_id: partnerId,
+        email,
+        verified: true,
+        already_verified: true,
+      })
+    }
+    await authModule.updateAuthVerifications({
+      id: row.id,
+      verified_at: now,
+    })
+  } else {
+    await authModule.createAuthVerifications([{
+      auth_identity_id: partnerIdentity.id,
+      entity_id: email,
+      entity_type: entityType,
+      code_provider: "emailpass",
+      requested_at: now,
+      verified_at: now,
+    }])
+  }
+
+  return res.json({
+    partner_id: partnerId,
+    email,
+    verified: true,
+    already_verified: false,
+  })
+}

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -3350,6 +3350,11 @@ export default defineMiddlewares({
       matcher: "/admin/partners/:id/whatsapp-verify",
       method: "DELETE",
     },
+    // Admin partner email verification bypass
+    {
+      matcher: "/admin/partners/:id/bypass-email-verification",
+      method: "POST",
+    },
     {
       matcher: "/admin/persons/partner",
       method: "GET",

--- a/apps/backend/src/workflows/partner/create-partner-admin.ts
+++ b/apps/backend/src/workflows/partner/create-partner-admin.ts
@@ -9,7 +9,7 @@ import {
 } from "@medusajs/medusa/core-flows"
 import { PARTNER_MODULE } from "../../modules/partner"
 import PartnerService from "../../modules/partner/service"
-import { MedusaError, Modules } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
 import { randomBytes } from "crypto"
 import type { IAuthModuleService } from "@medusajs/types"
 
@@ -79,6 +79,65 @@ const createPartnerAndAdminStep = createStep(
     }
 )
 
+/**
+ * Bypass email verification for a partner's auth identity by upserting a
+ * verified auth_verification row. Uses the same logic as
+ * backfillPartnerEmailVerifiedJob so login does not return
+ * verification_required.
+ */
+const verifyPartnerAuthEmailStep = createStep(
+    "verify-partner-auth-email",
+    async (
+        input: { authIdentityId: string; email: string },
+        { container }
+    ) => {
+        const authModule = container.resolve(Modules.AUTH) as any
+
+        // Determine entity type from config (same as backfill job)
+        let entityType = "email"
+        try {
+            const config = container.resolve(ContainerRegistrationKeys.CONFIG_MODULE)
+            const forPartner =
+                config?.projectConfig?.http?.authVerificationsPerActor?.partner
+            const emailpass = (forPartner || []).find(
+                (v: any) => v?.auth_provider === "emailpass"
+            )
+            if (emailpass?.entity_type) entityType = emailpass.entity_type
+        } catch { /* default to "email" */ }
+
+        const existing = await authModule.listAuthVerifications({
+            auth_identity_id: input.authIdentityId,
+            entity_id: input.email,
+            entity_type: entityType,
+        } as any)
+
+        const row = existing?.[0] as any
+        const now = new Date()
+
+        if (row) {
+            if (row.verified_at) {
+                return new StepResponse(null) // already verified
+            }
+            await authModule.updateAuthVerifications({
+                id: row.id,
+                verified_at: now,
+            } as any)
+            return new StepResponse(null)
+        }
+
+        await authModule.createAuthVerifications([{
+            auth_identity_id: input.authIdentityId,
+            entity_id: input.email,
+            entity_type: entityType,
+            code_provider: "emailpass",
+            requested_at: now,
+            verified_at: now,
+        }] as any)
+
+        return new StepResponse(null)
+    }
+)
+
 // External workflow: requires authIdentityId
 const createPartnerAdminWorkflow = createWorkflow(
     "create-partner-admin",
@@ -92,6 +151,11 @@ const createPartnerAdminWorkflow = createWorkflow(
             authIdentityId: input.authIdentityId,
             actorType: "partner",
             value: partnerWithAdmin.createdPartner.id,  // Use partner ID, not admin ID
+        })
+
+        verifyPartnerAuthEmailStep({
+            authIdentityId: input.authIdentityId,
+            email: input.admin.email,
         })
 
         return new WorkflowResponse(
@@ -149,6 +213,11 @@ export const createPartnerAdminWithRegistrationWorkflow = createWorkflow(
             authIdentityId: registered.authIdentityId,
             actorType: "partner",
             value: partnerWithAdmin.createdPartner.id,  // Use partner ID, not admin ID
+        })
+
+        verifyPartnerAuthEmailStep({
+            authIdentityId: registered.authIdentityId,
+            email: input.admin.email,
         })
 
         return new WorkflowResponse({


### PR DESCRIPTION

## Changes

When partners are created via `POST /partners` or `POST /admin/partners`, their email is now automatically marked as verified in the auth_verification system, bypassing the login email verification gate.

Uses the same auth_verification upsert logic as the `backfillPartnerEmailVerifiedJob` data plumbing job.

### Backend
- **`create-partner-admin.ts`**: Added `verifyPartnerAuthEmailStep` — upserts an `auth_verification` row with `verified_at` set, using the entity type from config (same logic as backfill job). Added to both `createPartnerAdminWorkflow` (POST /partners) and `createPartnerAdminWithRegistrationWorkflow` (POST /admin/partners).
- **New `POST /admin/partners/:id/bypass-email-verification`**: Admin API endpoint for manually bypassing email verification on existing partners. Idempotent.

### Admin UI
- **New `PartnerEmailVerificationSection`** component using Medusa UI primitives (`Container`, `Heading`, `Text`, `Badge`, `Button`). Shows current email verification status with a "Bypass Email Verification" button.
- Added to partner detail page sidebar (between WhatsApp and Subscription sections).

### Verification
- TypeScript check passes with no errors in changed files.
- Pre-push hooks passed (lockfile sync, config parity).
