### PR TITLE
fix(etsy,faire): pre-flight listing image replace + Faire multi-geo prices

### DIFF
--- a/packages/medusa-plugin-etsy-sync/package.json
+++ b/packages/medusa-plugin-etsy-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jytextiles/medusa-plugin-etsy-sync",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/packages/medusa-plugin-etsy-sync/src/lib/etsy-client.ts
+++ b/packages/medusa-plugin-etsy-sync/src/lib/etsy-client.ts
@@ -322,6 +322,43 @@ export class EtsyClient {
 
   // ── Listing images (multipart binary upload) ───────────────────────────
 
+  /**
+   * List the images currently on a listing. Used as a pre-flight before a
+   * re-sync: Etsy *appends* on upload and caps a listing at 20 images, so we
+   * must know what's already there before pushing more.
+   */
+  async getListingImages(
+    accessToken: string,
+    shopId: string,
+    listingId: string
+  ): Promise<Array<{ listing_image_id: string; rank: number }>> {
+    const data = await this.requestJson<any>(
+      `${API_BASE}/application/shops/${shopId}/listings/${listingId}/images`,
+      { method: "GET", accessToken }
+    )
+    return (data.results ?? []).map((im: any) => ({
+      listing_image_id: String(im.listing_image_id),
+      rank: Number(im.rank ?? 0),
+    }))
+  }
+
+  /**
+   * Delete a single image from a listing. Used to clear a listing's photos on a
+   * re-sync before re-uploading, so images are replaced rather than appended
+   * (Etsy never overwrites on upload and caps a listing at 20 images).
+   */
+  async deleteListingImage(
+    accessToken: string,
+    shopId: string,
+    listingId: string,
+    listingImageId: string
+  ): Promise<void> {
+    await this.requestJson<any>(
+      `${API_BASE}/application/shops/${shopId}/listings/${listingId}/images/${listingImageId}`,
+      { method: "DELETE", accessToken }
+    )
+  }
+
   async uploadListingImage(
     accessToken: string,
     shopId: string,

--- a/packages/medusa-plugin-etsy-sync/src/workflows/sync-product-to-etsy.ts
+++ b/packages/medusa-plugin-etsy-sync/src/workflows/sync-product-to-etsy.ts
@@ -221,33 +221,102 @@ const syncListingStep = createStep(
     const warnings: string[] = []
     let listing: ListingResponse
 
+    // ── Pre-flight: inspect the live listing before mutating it ────────────
+    // On a re-sync the listing already exists on Etsy. Read its current state
+    // and image count FIRST so we don't blindly re-run work that would fail or
+    // duplicate — the classic symptom is re-uploading the same photos onto a
+    // listing that already has the max 20 images (Etsy appends, it never
+    // replaces on upload) and getting "Listings are only allowed 20 images".
+    const ETSY_MAX_IMAGES = 20
+    let existingImages: Array<{ listing_image_id: string; rank: number }> = []
+    let imagesUnreadable = false
+    let listingMissing = false
     if (existing_listing_id) {
+      try {
+        const current = await client.getListing(access_token, existing_listing_id)
+        if (current?.state) {
+          warnings.push(`Listing is currently "${current.state}" on Etsy before this update.`)
+        }
+      } catch (err: any) {
+        // 404 → the listing was deleted on Etsy; fall back to a fresh create.
+        listingMissing = true
+        warnings.push(`Existing listing not found on Etsy (${err?.message || "gone"}); creating a new one.`)
+      }
+      if (!listingMissing) {
+        try {
+          existingImages = await client.getListingImages(access_token, shop_id, existing_listing_id)
+        } catch {
+          // Can't read images — flag it so we don't risk busting the 20-image cap.
+          imagesUnreadable = true
+        }
+      }
+    }
+    let existingImageCount = existingImages.length
+
+    const isUpdate = Boolean(existing_listing_id) && !listingMissing
+    if (isUpdate) {
       listing = await client.updateListing(
         access_token,
         shop_id,
-        existing_listing_id,
+        existing_listing_id!,
         listing_input
       )
     } else {
       listing = await client.createDraftListing(access_token, shop_id, listing_input)
     }
 
-    // Upload images (Etsy requires >=1 image to publish)
+    // Upload images (Etsy requires >=1 image to publish). Etsy *appends* on
+    // upload — it never overwrites — and caps a listing at 20 images, so a naive
+    // re-sync duplicates photos and eventually trips "only allowed 20 images".
+    // Fix: on an update, remove the listing's current images FIRST, then upload
+    // the product's images fresh. Only clear when we actually have replacements
+    // to put back, so a product with no images never strips a live listing bare.
     const uploaded_images: UploadedImage[] = []
-    for (let i = 0; i < image_urls.length; i++) {
-      try {
-        const { buffer, filename } = await EtsyClient.fetchImageBuffer(image_urls[i])
-        const img = await client.uploadListingImage(
-          access_token,
-          shop_id,
-          listing.listing_id,
-          buffer,
-          filename,
-          { rank: i + 1 }
-        )
-        uploaded_images.push(img)
-      } catch (err: any) {
-        warnings.push(`Image ${i + 1} upload failed: ${err.message}`)
+    const toUpload = image_urls.slice(0, ETSY_MAX_IMAGES)
+
+    if (isUpdate && existingImages.length > 0 && toUpload.length > 0) {
+      for (const im of existingImages) {
+        try {
+          await client.deleteListingImage(
+            access_token,
+            shop_id,
+            listing.listing_id,
+            im.listing_image_id
+          )
+        } catch (err: any) {
+          warnings.push(`Could not remove old image ${im.listing_image_id}: ${err.message}`)
+        }
+      }
+      existingImageCount = 0
+    } else if (isUpdate && imagesUnreadable && toUpload.length > 0) {
+      // We couldn't read the listing's images, so we can't safely clear them.
+      // Skip upload rather than risk appending past the 20-image cap.
+      warnings.push(
+        "Skipped image upload: couldn't read the listing's current images to replace them safely."
+      )
+    }
+
+    const shouldUpload =
+      toUpload.length > 0 && !(isUpdate && imagesUnreadable)
+    if (shouldUpload) {
+      for (let i = 0; i < toUpload.length; i++) {
+        try {
+          const { buffer, filename } = await EtsyClient.fetchImageBuffer(toUpload[i])
+          const img = await client.uploadListingImage(
+            access_token,
+            shop_id,
+            listing.listing_id,
+            buffer,
+            filename,
+            { rank: i + 1 }
+          )
+          uploaded_images.push(img)
+        } catch (err: any) {
+          warnings.push(`Image ${i + 1} upload failed: ${err.message}`)
+        }
+      }
+      if (image_urls.length > ETSY_MAX_IMAGES) {
+        warnings.push(`Only the first ${ETSY_MAX_IMAGES} images were uploaded (Etsy limit).`)
       }
     }
 
@@ -255,9 +324,12 @@ const syncListingStep = createStep(
     const shouldPublish =
       settings.follow_product_status !== false && product_status === "published"
 
+    // A listing is publishable if it has images either freshly uploaded now or
+    // already living on Etsy from a prior sync.
+    const hasImages = uploaded_images.length > 0 || existingImageCount > 0
     const isPhysical = listing_input.type !== "download"
     const canPublish =
-      uploaded_images.length > 0 &&
+      hasImages &&
       (!isPhysical ||
         (listing_input.shipping_profile_id &&
           listing_input.return_policy_id &&

--- a/packages/medusa-plugin-faire-store-sync/package.json
+++ b/packages/medusa-plugin-faire-store-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jytextiles/medusa-plugin-faire-store-sync",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/packages/medusa-plugin-faire-store-sync/src/workflows/sync-product-to-faire.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/workflows/sync-product-to-faire.ts
@@ -72,6 +72,8 @@ const geoForCurrency = (
       return { country: "GB" }
     case "USD":
       return { country: "US" }
+    case "INR":
+      return { country: "IN" }
     case "CAD":
       return { country: "CA" }
     case "AUD":
@@ -234,13 +236,61 @@ const prepareProductStep = createStep(
       return Number.isFinite(available) ? Math.max(0, available) : 0
     }
 
+    const wholesaleFrom = (retailMinor: number): number =>
+      markupPercent > 0
+        ? Math.round((retailMinor * (100 - markupPercent)) / 100)
+        : retailMinor
+
+    // Faire prices are geo-scoped and a variant may carry several — one per
+    // currency the product is priced in. Emit a price for EVERY currency present
+    // (INR → India, USD → US, EUR → the EU group, etc.) so buyers in each region
+    // see their own currency, and fall back to the chosen/default currency +
+    // geo (EUR by default) when the product has no multi-currency prices.
+    const buildPrices = (variantPrices: any[]) => {
+      const byCurrency = new Map<string, any>()
+      for (const p of variantPrices || []) {
+        const c = String(p.currency_code || "").toUpperCase()
+        if (!c) continue
+        // First price row per currency wins (Medusa may hold several tiers).
+        if (!byCurrency.has(c)) byCurrency.set(c, p)
+      }
+
+      const rows: {
+        geo_constraint: { country?: string; country_group?: string }
+        wholesale_price: { amount_minor: number; currency: string }
+        retail_price: { amount_minor: number; currency: string }
+      }[] = []
+      for (const [c, p] of byCurrency) {
+        const retailMinor = toMinor(p.amount)
+        if (retailMinor <= 0) continue
+        // The explicit metadata override only applies to the brand's primary
+        // currency; every other currency is scoped by its natural geo.
+        const geo =
+          c === currency ? geoConstraint : geoForCurrency(c, input.country)
+        rows.push({
+          geo_constraint: geo,
+          wholesale_price: { amount_minor: wholesaleFrom(retailMinor), currency: c },
+          retail_price: { amount_minor: retailMinor, currency: c },
+        })
+      }
+
+      // Guarantee at least the chosen-currency price so a create never ships a
+      // variant with no price at all.
+      if (!rows.length) {
+        const retail = pickPrice(variantPrices || [])
+        const retailMinor = retail ? toMinor(retail.amount) : 0
+        if (retailMinor > 0) {
+          rows.push({
+            geo_constraint: geoConstraint,
+            wholesale_price: { amount_minor: wholesaleFrom(retailMinor), currency },
+            retail_price: { amount_minor: retailMinor, currency },
+          })
+        }
+      }
+      return rows.length ? rows : undefined
+    }
+
     const buildVariant = (v: any, idx: number) => {
-      const retail = pickPrice(v.prices || [])
-      const retailMinor = retail ? toMinor(retail.amount) : 0
-      const wholesaleMinor =
-        markupPercent > 0
-          ? Math.round((retailMinor * (100 - markupPercent)) / 100)
-          : retailMinor
       const sku = v.sku || v.id
       const options =
         (v.options || [])
@@ -255,16 +305,7 @@ const prepareProductStep = createStep(
         idempotence_token: `${product.id}:${v.id || sku}`,
         options: options.length ? options : undefined,
         available_quantity: variantQuantity(v),
-        prices:
-          retailMinor > 0
-            ? [
-                {
-                  geo_constraint: geoConstraint,
-                  wholesale_price: { amount_minor: wholesaleMinor, currency },
-                  retail_price: { amount_minor: retailMinor, currency },
-                },
-              ]
-            : undefined,
+        prices: buildPrices(v.prices || []),
       }
     }
 


### PR DESCRIPTION
## Why
Re-syncing an already-published Etsy listing was re-uploading the same photos and eventually failing with **"Listings are only allowed 20 images"** (seen on listing 4533544921). Etsy *appends* on image upload — it never overwrites — and caps a listing at 20 images, so every re-sync piled more photos on until the cap tripped. Separately, Faire only ever sent a single geo-scoped price.

## Etsy (`@jytextiles/medusa-plugin-etsy-sync` → 0.1.5)
The re-sync already delegates correctly (admin → `POST /admin/etsy/syncs/:id` → `syncProductToEtsyWorkflow`). The bug was in the workflow's image step. On the **update** path it now:
- reads the live listing + its current images **first** (pre-flight), warning with the listing's current state so the operator is informed;
- **removes the existing images before re-uploading** the product's images → photos are replaced, not appended (only clears when there are replacement images to put back, so a product with no images never strips a live listing bare);
- falls back to a fresh **create** if the listing was deleted on Etsy;
- caps uploads at 20, and if it can't read the current images it skips upload with a warning rather than risk busting the cap;
- publish gate now counts images already on Etsy, not just freshly-uploaded ones.

Adds `EtsyClient.getListingImages` + `deleteListingImage`.

## Faire (`@jytextiles/medusa-plugin-faire-store-sync` → 0.2.13)
Variants now emit **one geo-scoped price per currency** the product is priced in — INR → India, USD → US, EUR → EU group (plus GBP/CAD/AUD) — instead of a single price. Currencies with no specific geo fall back to EUR/EU. Adds the missing INR mapping.

> Note: the earlier prod 404 (`Inventory push failed: Faire API 404: variant_…`) was a **stale-deploy** artefact — 0.2.12 already skips synthetic `variant_`/`prod_` SKUs and rolled out at the 15:52 UTC deploy. This PR is unrelated to that.

## Verify
- Etsy: re-sync a product whose listing already has 20 images → succeeds, images replaced, no cap error.
- Faire: sync a product priced in INR+USD+EUR → variant carries three geo-scoped prices.
- `npx tsc --noEmit` green in both plugins; existing client tests pass.

Merging publishes both plugins (OIDC) and auto-refloats the backend lockfile → prod deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)