### PR TITLE
feat(etsy,faire): delete/remove a synced listing from the sync detail page

### DIFF
--- a/packages/medusa-plugin-etsy-sync/package.json
+++ b/packages/medusa-plugin-etsy-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jytextiles/medusa-plugin-etsy-sync",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/packages/medusa-plugin-etsy-sync/src/admin/lib/api.ts
+++ b/packages/medusa-plugin-etsy-sync/src/admin/lib/api.ts
@@ -61,6 +61,8 @@ export const etsyApi = {
     sdk.client.fetch(`/admin/etsy/syncs/${id}`),
   retrySync: (id: string) =>
     sdk.client.fetch(`/admin/etsy/syncs/${id}`, { method: "POST" }),
+  deleteSync: (id: string) =>
+    sdk.client.fetch(`/admin/etsy/syncs/${id}`, { method: "DELETE" }),
   shippingProfiles: () =>
     sdk.client.fetch("/admin/etsy/shipping-profiles"),
   returnPolicies: () =>

--- a/packages/medusa-plugin-etsy-sync/src/admin/routes/settings/etsy/[id]/page.tsx
+++ b/packages/medusa-plugin-etsy-sync/src/admin/routes/settings/etsy/[id]/page.tsx
@@ -9,8 +9,9 @@ import {
   StatusBadge,
   Text,
   Toaster,
+  usePrompt,
 } from "@medusajs/ui"
-import { EllipsisHorizontal, ArrowPath, ArrowUpRightOnBox } from "@medusajs/icons"
+import { EllipsisHorizontal, ArrowPath, ArrowUpRightOnBox, Trash } from "@medusajs/icons"
 import { useEffect, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { etsyApi } from "../../../../lib/api"
@@ -27,9 +28,11 @@ const STATUS_COLORS: Record<string, "green" | "red" | "orange" | "grey"> = {
 const EtsySyncDetailPage = () => {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
+  const prompt = usePrompt()
   const [record, setRecord] = useState<EtsySyncRecord | null>(null)
   const [loading, setLoading] = useState(true)
   const [retrying, setRetrying] = useState(false)
+  const [deleting, setDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
@@ -58,6 +61,31 @@ const EtsySyncDetailPage = () => {
       setError(err.message || "Retry failed")
     } finally {
       setRetrying(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!record) return
+    const confirmed = await prompt({
+      title: "Delete from Etsy?",
+      description:
+        "This removes the listing from Etsy and unlinks it from the product. This can't be undone — you'd have to re-sync to recreate it.",
+      confirmText: "Delete",
+      cancelText: "Cancel",
+    })
+    if (!confirmed) return
+    setDeleting(true)
+    setError(null)
+    try {
+      await etsyApi.deleteSync(record.id)
+      // Reflect the removal in place, then return to the list.
+      const updated = await etsyApi.getSync(record.id).catch(() => null)
+      if (updated) setRecord((updated as any).sync || updated)
+      navigate("/settings/etsy")
+    } catch (err: any) {
+      setError(err.message || "Delete failed")
+    } finally {
+      setDeleting(false)
     }
   }
 
@@ -104,7 +132,7 @@ const EtsySyncDetailPage = () => {
             </StatusBadge>
             <DropdownMenu>
               <DropdownMenu.Trigger asChild>
-                <IconButton size="small" variant="transparent" disabled={retrying}>
+                <IconButton size="small" variant="transparent" disabled={retrying || deleting}>
                   <EllipsisHorizontal />
                 </IconButton>
               </DropdownMenu.Trigger>
@@ -126,6 +154,15 @@ const EtsySyncDetailPage = () => {
                     Open on Etsy
                   </DropdownMenu.Item>
                 )}
+                <DropdownMenu.Separator />
+                <DropdownMenu.Item
+                  className="gap-x-2 text-ui-fg-error"
+                  onClick={handleDelete}
+                  disabled={deleting}
+                >
+                  <Trash className="text-ui-fg-error" />
+                  {deleting ? "Deleting…" : "Delete from Etsy"}
+                </DropdownMenu.Item>
               </DropdownMenu.Content>
             </DropdownMenu>
           </div>

--- a/packages/medusa-plugin-etsy-sync/src/api/admin/etsy/syncs/[id]/route.ts
+++ b/packages/medusa-plugin-etsy-sync/src/api/admin/etsy/syncs/[id]/route.ts
@@ -3,6 +3,7 @@ import { MedusaError } from "@medusajs/framework/utils"
 import { ETSY_SYNC_MODULE } from "../../../../../modules/etsy-sync"
 import EtsySyncService from "../../../../../modules/etsy-sync/service"
 import { syncProductToEtsyWorkflow } from "../../../../../workflows/sync-product-to-etsy"
+import { deleteListingFromEtsyWorkflow } from "../../../../../workflows/delete-listing-from-etsy"
 
 // GET /admin/etsy/syncs/:id — fetch a single sync record
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
@@ -25,6 +26,24 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   }
 
   const { result } = await syncProductToEtsyWorkflow(req.scope).run({
+    input: { product_id: (record as any).product_id },
+  })
+
+  res.json({ result })
+}
+
+// DELETE /admin/etsy/syncs/:id — remove the Etsy listing for this record's
+// product and clear the local link. Idempotent: a listing already gone on Etsy
+// still cleans up our side.
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: EtsySyncService = req.scope.resolve(ETSY_SYNC_MODULE)
+  const { id } = req.params
+  const [record] = await service.listEtsySyncRecords({ id } as any, { take: 1 } as any)
+  if (!record) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Sync record not found")
+  }
+
+  const { result } = await deleteListingFromEtsyWorkflow(req.scope).run({
     input: { product_id: (record as any).product_id },
   })
 

--- a/packages/medusa-plugin-etsy-sync/src/workflows/delete-listing-from-etsy.ts
+++ b/packages/medusa-plugin-etsy-sync/src/workflows/delete-listing-from-etsy.ts
@@ -1,0 +1,117 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+  WorkflowData,
+} from "@medusajs/framework/workflows-sdk"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { Link } from "@medusajs/modules-sdk"
+import { ETSY_SYNC_MODULE } from "../modules/etsy-sync"
+import EtsySyncService from "../modules/etsy-sync/service"
+
+export const DELETE_LISTING_FROM_ETSY = "etsy-delete-listing"
+
+export type DeleteListingFromEtsyInput = {
+  product_id: string
+}
+
+type DeleteResult = {
+  product_id: string
+  listing_id: string | null
+  deleted: boolean
+  warnings: string[]
+}
+
+// ── Step: delete the Etsy listing + clean up the local link/record ─────────
+
+const deleteEtsyListingStep = createStep(
+  "etsy-delete-listing-step",
+  async (
+    input: { product_id: string },
+    { container }
+  ): Promise<StepResponse<DeleteResult>> => {
+    const service: EtsySyncService = container.resolve(ETSY_SYNC_MODULE)
+    const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+    const client = service.getClient()
+
+    const account = await service.ensureFreshToken()
+    const warnings: string[] = []
+
+    // Find the linked Etsy listing for this product.
+    let listing_id: string | null = null
+    try {
+      const linkRows = await remoteLink.list({
+        [Modules.PRODUCT]: { product_id: input.product_id },
+        [ETSY_SYNC_MODULE]: { etsy_sync_account_id: account.id },
+      })
+      const row: any = (linkRows as any[])?.[0]
+      listing_id = row?.etsy_listing_id ?? null
+    } catch {
+      // no link
+    }
+
+    // Delete the remote listing. A 404 means it's already gone on Etsy — treat
+    // that as success so re-deleting (or deleting an already-removed listing)
+    // still cleans up our side.
+    if (listing_id) {
+      try {
+        await client.deleteListing(account.access_token, listing_id)
+      } catch (err: any) {
+        const msg = String(err?.message || err)
+        if (/404|not found/i.test(msg)) {
+          warnings.push("Listing was already removed on Etsy.")
+        } else {
+          // Surface the error but still clear our link so the product isn't stuck
+          // pointing at a listing we can't manage.
+          warnings.push(`Etsy delete failed: ${msg}`)
+        }
+      }
+    } else {
+      warnings.push("No linked Etsy listing found for this product.")
+    }
+
+    // Drop the product↔account link so the product reads as un-synced.
+    try {
+      await remoteLink.dismiss([
+        {
+          [Modules.PRODUCT]: { product_id: input.product_id },
+          [ETSY_SYNC_MODULE]: { etsy_sync_account_id: account.id },
+        },
+      ])
+    } catch {
+      // ignore dismiss errors
+    }
+
+    // Historical record of the removal.
+    await service.createSyncRecord({
+      product_id: input.product_id,
+      account_id: account.id,
+      listing_id,
+      listing_url: null,
+      listing_state: "deleted",
+      action: "delete",
+      status: "success",
+      published: false,
+      error_message: warnings.length ? warnings.join(" | ") : null,
+      warnings,
+      metadata: {},
+      synced_at: new Date(),
+    } as any)
+
+    return new StepResponse({
+      product_id: input.product_id,
+      listing_id,
+      deleted: Boolean(listing_id),
+      warnings,
+    })
+  }
+)
+
+export const deleteListingFromEtsyWorkflow = createWorkflow(
+  DELETE_LISTING_FROM_ETSY,
+  (input: WorkflowData<DeleteListingFromEtsyInput>) => {
+    const result = deleteEtsyListingStep(input)
+    return new WorkflowResponse(result)
+  }
+)

--- a/packages/medusa-plugin-faire-store-sync/package.json
+++ b/packages/medusa-plugin-faire-store-sync/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jytextiles/medusa-plugin-faire-store-sync",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"

--- a/packages/medusa-plugin-faire-store-sync/src/admin/lib/api.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/admin/lib/api.ts
@@ -83,6 +83,8 @@ export const faireApi = {
   getSync: (id: string) => sdk.client.fetch(`/admin/faire/syncs/${id}`),
   retrySync: (id: string) =>
     sdk.client.fetch(`/admin/faire/syncs/${id}`, { method: "POST" }),
+  deleteSync: (id: string) =>
+    sdk.client.fetch(`/admin/faire/syncs/${id}`, { method: "DELETE" }),
   brand: () => sdk.client.fetch("/admin/faire/brand"),
   taxonomy: (opts: { q?: string; limit?: number; ids?: string[] } = {}) => {
     const query: Record<string, string> = {}

--- a/packages/medusa-plugin-faire-store-sync/src/admin/routes/settings/faire/[id]/page.tsx
+++ b/packages/medusa-plugin-faire-store-sync/src/admin/routes/settings/faire/[id]/page.tsx
@@ -8,8 +8,9 @@ import {
   StatusBadge,
   Text,
   Toaster,
+  usePrompt,
 } from "@medusajs/ui"
-import { EllipsisHorizontal, ArrowPath, ArrowUpRightOnBox } from "@medusajs/icons"
+import { EllipsisHorizontal, ArrowPath, ArrowUpRightOnBox, Trash } from "@medusajs/icons"
 import { useEffect, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { faireApi } from "../../../../lib/api"
@@ -29,9 +30,11 @@ const STATUS_COLORS: Record<string, "green" | "red" | "orange" | "grey"> = {
 const FaireSyncDetailPage = () => {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
+  const prompt = usePrompt()
   const [record, setRecord] = useState<FaireSyncRecord | null>(null)
   const [loading, setLoading] = useState(true)
   const [retrying, setRetrying] = useState(false)
+  const [deleting, setDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
@@ -61,6 +64,30 @@ const FaireSyncDetailPage = () => {
     }
   }
 
+  const handleDelete = async () => {
+    if (!record) return
+    const confirmed = await prompt({
+      title: "Remove from Faire?",
+      description:
+        "Faire has no hard-delete API, so this unpublishes the product (sets it back to draft, hidden from buyers) and unlinks it from the product. Re-sync to publish it again, or delete it permanently from the Faire brand portal.",
+      confirmText: "Remove",
+      cancelText: "Cancel",
+    })
+    if (!confirmed) return
+    setDeleting(true)
+    setError(null)
+    try {
+      await faireApi.deleteSync(record.id)
+      const updated = await faireApi.getSync(record.id).catch(() => null)
+      if (updated) setRecord((updated as any).sync || updated)
+      navigate(PARENT)
+    } catch (err: any) {
+      setError(err.message || "Remove failed")
+    } finally {
+      setDeleting(false)
+    }
+  }
+
   const warnings: string[] = record?.error_message
     ? record.error_message.split(" | ")
     : []
@@ -80,7 +107,7 @@ const FaireSyncDetailPage = () => {
           <div className="flex items-center gap-2">
             <DropdownMenu>
               <DropdownMenu.Trigger asChild>
-                <IconButton size="small" variant="transparent" disabled={retrying}>
+                <IconButton size="small" variant="transparent" disabled={retrying || deleting}>
                   <EllipsisHorizontal />
                 </IconButton>
               </DropdownMenu.Trigger>
@@ -102,6 +129,15 @@ const FaireSyncDetailPage = () => {
                     Open on Faire
                   </DropdownMenu.Item>
                 )}
+                <DropdownMenu.Separator />
+                <DropdownMenu.Item
+                  className="gap-x-2 text-ui-fg-error"
+                  onClick={handleDelete}
+                  disabled={deleting}
+                >
+                  <Trash className="text-ui-fg-error" />
+                  {deleting ? "Removing…" : "Remove from Faire"}
+                </DropdownMenu.Item>
               </DropdownMenu.Content>
             </DropdownMenu>
           </div>

--- a/packages/medusa-plugin-faire-store-sync/src/api/admin/faire/syncs/[id]/route.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/api/admin/faire/syncs/[id]/route.ts
@@ -3,6 +3,7 @@ import { MedusaError } from "@medusajs/framework/utils"
 import { FAIRE_SYNC_MODULE } from "../../../../../modules/faire-sync"
 import FaireSyncService from "../../../../../modules/faire-sync/service"
 import { syncProductToFaireWorkflow } from "../../../../../workflows/sync-product-to-faire"
+import { removeProductFromFaireWorkflow } from "../../../../../workflows/remove-product-from-faire"
 
 // GET /admin/faire/syncs/:id — fetch a single sync record
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
@@ -25,6 +26,24 @@ export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
   }
 
   const { result } = await syncProductToFaireWorkflow(req.scope).run({
+    input: { product_id: (record as any).product_id },
+  })
+
+  res.json({ result })
+}
+
+// DELETE /admin/faire/syncs/:id — remove (unpublish) the Faire product for this
+// record's product and clear the local link. Faire has no hard-delete API, so
+// this sets the product back to DRAFT (hidden from buyers).
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: FaireSyncService = req.scope.resolve(FAIRE_SYNC_MODULE)
+  const { id } = req.params
+  const [record] = await service.listFaireSyncRecords({ id } as any, { take: 1 } as any)
+  if (!record) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Sync record not found")
+  }
+
+  const { result } = await removeProductFromFaireWorkflow(req.scope).run({
     input: { product_id: (record as any).product_id },
   })
 

--- a/packages/medusa-plugin-faire-store-sync/src/workflows/remove-product-from-faire.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/workflows/remove-product-from-faire.ts
@@ -1,0 +1,121 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+  WorkflowData,
+} from "@medusajs/framework/workflows-sdk"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { Link } from "@medusajs/modules-sdk"
+import { FAIRE_SYNC_MODULE } from "../modules/faire-sync"
+import FaireSyncService from "../modules/faire-sync/service"
+
+export const REMOVE_PRODUCT_FROM_FAIRE = "faire-remove-product"
+
+export type RemoveProductFromFaireInput = {
+  product_id: string
+}
+
+type RemoveResult = {
+  product_id: string
+  product_token: string | null
+  removed: boolean
+  warnings: string[]
+}
+
+// ── Step: unpublish the Faire product + clean up the local link/record ─────
+//
+// Faire's public Brand API exposes no hard-delete for products (only
+// POST/PUT/GET on /products), so "remove" means unpublish: set the product's
+// lifecycle_state back to DRAFT via the update endpoint, which pulls it from
+// buyers' view. A true hard-delete has to be done in the Faire brand portal.
+
+const removeFaireProductStep = createStep(
+  "faire-remove-product-step",
+  async (
+    input: { product_id: string },
+    { container }
+  ): Promise<StepResponse<RemoveResult>> => {
+    const service: FaireSyncService = container.resolve(FAIRE_SYNC_MODULE)
+    const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+
+    const account = await service.ensureFreshToken()
+    const client = service.getClient((account.auth_mode as "oauth" | "apiKey") ?? "oauth")
+    const warnings: string[] = []
+
+    // Find the linked Faire product for this product.
+    let product_token: string | null = null
+    try {
+      const linkRows = await remoteLink.list({
+        [Modules.PRODUCT]: { product_id: input.product_id },
+        [FAIRE_SYNC_MODULE]: { faire_sync_account_id: account.id },
+      })
+      const row: any = (linkRows as any[])?.[0]
+      product_token = row?.faire_product_token ?? null
+    } catch {
+      // no link
+    }
+
+    // Unpublish (DRAFT) so it disappears from the Faire storefront. Tolerate a
+    // 404 — a product already gone on Faire still cleans up our side.
+    if (product_token) {
+      try {
+        await client.updateProduct(account.access_token, product_token, {
+          lifecycle_state: "DRAFT",
+        })
+      } catch (err: any) {
+        const msg = String(err?.message || err)
+        if (/404|not found/i.test(msg)) {
+          warnings.push("Product was already removed on Faire.")
+        } else {
+          warnings.push(`Faire unpublish failed: ${msg}`)
+        }
+      }
+    } else {
+      warnings.push("No linked Faire product found for this product.")
+    }
+
+    // Drop the product↔account link so the product reads as un-synced.
+    try {
+      await remoteLink.dismiss([
+        {
+          [Modules.PRODUCT]: { product_id: input.product_id },
+          [FAIRE_SYNC_MODULE]: { faire_sync_account_id: account.id },
+        },
+      ])
+    } catch {
+      // ignore dismiss errors
+    }
+
+    // Historical record of the removal.
+    await service.createSyncRecord({
+      product_id: input.product_id,
+      account_id: account.id,
+      product_token,
+      product_url: null,
+      product_state: "draft",
+      action: "delete",
+      status: "success",
+      published: false,
+      error_message: warnings.length ? warnings.join(" | ") : null,
+      warnings,
+      metadata: {},
+      synced_at: new Date(),
+    } as any)
+
+    return new StepResponse({
+      product_id: input.product_id,
+      product_token,
+      removed: Boolean(product_token),
+      warnings,
+    })
+  }
+)
+
+export const removeProductFromFaireWorkflow = createWorkflow(
+  REMOVE_PRODUCT_FROM_FAIRE,
+  (input: WorkflowData<RemoveProductFromFaireInput>) => {
+    const result = removeFaireProductStep(input)
+    return new WorkflowResponse(result)
+  }
+)


### PR DESCRIPTION
## What
Adds a destructive action to the Etsy and Faire **sync-record detail pages** (the `…` menu) so an operator can pull a product back off the marketplace from inside Medusa. Both go through our own admin API → workflow (not the marketplace API directly), and both are idempotent — a listing already gone still cleans up our side (link + record).

## Etsy (`@jytextiles/medusa-plugin-etsy-sync` → 0.1.6) — true delete
- `deleteListingFromEtsyWorkflow`: finds the linked listing → `EtsyClient.deleteListing` (404 treated as already-gone) → dismisses the product↔account link → writes a `delete` sync record.
- `DELETE /admin/etsy/syncs/:id`; UI adds **"Delete from Etsy"** with a confirm prompt.

## Faire (`@jytextiles/medusa-plugin-faire-store-sync` → 0.2.14) — unpublish
Faire's public Brand API exposes **no hard-delete** for products (verified: the client only does POST/PUT/GET on `/products`, and only `DRAFT`/`PUBLISHED` lifecycle states are known). So "remove" = **unpublish**: set `lifecycle_state → DRAFT` via the update endpoint (hidden from buyers), dismiss the link, write a `delete` record. The confirm copy tells the operator a permanent delete must be done in the Faire brand portal.
- `removeProductFromFaireWorkflow`; `DELETE /admin/faire/syncs/:id`; UI adds **"Remove from Faire"**.

## Verify
- Etsy: open a sync record → `…` → Delete from Etsy → listing gone on Etsy, product unlinked, a `delete` record appears.
- Faire: same flow → product flips to draft on Faire (off the storefront), unlinked.
- `npx tsc --noEmit` green in both plugins.

Merging publishes both plugins (OIDC) + refloats the backend lockfile → prod deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)