### PR TITLE
fix(migrations): unique names for the two colliding 20260712150000 migrations

### DIFF
--- a/apps/backend/src/modules/investor/migrations/Migration20260712150001.ts
+++ b/apps/backend/src/modules/investor/migrations/Migration20260712150001.ts
@@ -3,7 +3,7 @@ import { Migration } from '@mikro-orm/migrations';
 // Investor referrals — #969 follow-up. Lets an investor invite a friend / other
 // investor into the portal. Onboarding stays invite-only, so a referral is a
 // lead the team follows up on. Idempotent create-table (safe to re-run on boot).
-export class Migration20260712150000 extends Migration {
+export class Migration20260712150001 extends Migration {
 
   async up(): Promise<void> {
     this.addSql(`

--- a/apps/backend/src/modules/partner/migrations/Migration20260712150002.ts
+++ b/apps/backend/src/modules/partner/migrations/Migration20260712150002.ts
@@ -14,7 +14,7 @@ import { Migration } from "@medusajs/framework/mikro-orm/migrations";
  * Hand-written idempotent ALTER (add-column-if-not-exists) because `partner`
  * already exists on live DBs (the create-if-not-exists migration hazard).
  */
-export class Migration20260712150000 extends Migration {
+export class Migration20260712150002 extends Migration {
 
   override async up(): Promise<void> {
     this.addSql(`alter table if exists "partner" add column if not exists "hosting_provider" text null;`);


### PR DESCRIPTION
## The bug — `column p.hosting_provider does not exist` in prod
The hosting PR (6ce6cc9 / #1019) added `partner.hosting_provider` + `deployment_*` via a hand-rolled migration named **`Migration20260712150000`**. The investor referrals work added `investor_referral` via a migration **also named `Migration20260712150000`** (different module).

Medusa/MikroORM records executed migrations by **bare class name in a single shared `mikro_orm_migrations` table**. So on any database, only **one** of the two ever runs — the second is seen as already-applied and **silently skipped**. Which one wins depends on module run order, which differs per environment:
- locally / fresh DB → the **partner** one wins (I reproduced: `hosting_provider` present, `investor_referral` missing)
- in **prod** → the **investor** one won → `partner.hosting_provider` never created → the error.

## Fix
Rename each to a unique class + filename — investor → `Migration20260712150001`, partner → `Migration20260712150002` — so both are pending on every DB and both run. Both were already idempotent (`create table` / `add column` **IF NOT EXISTS**), so re-running the one that already applied is a safe no-op; the previously-skipped one now applies. (The orphaned `Migration20260712150000` row left in existing DBs is harmless — `db:migrate` only runs *pending* ups.)

## Verified locally (`medusa db:migrate`)
- **prod-like DB** (had partner columns, missing `investor_referral`) → after rename, both present ✅
- **fully fresh empty DB** → both `investor_referral` and `partner.hosting_provider` present ✅

## Why not `medusa db:generate` (asked during review)
Ran it as an experiment. Two findings:
1. It auto-names by timestamp-to-the-second (`…174947`/`…174948`), so it would have **avoided the name collision** — the collision only happened because both were hand-stamped at a fixed `…150000`.
2. **But it's the wrong tool for adding a column to an existing table.** It emits `create table if not exists "partner" (…hosting_provider…)`, which on a live DB (partner already exists) is a **no-op** — proven locally: the column was **not** added. Only the hand-rolled `alter table add column if not exists` adds it.

So the takeaway is **keep hand-rolling idempotent ALTERs for existing tables — just give them unique names** (or generate to get unique names, then hand-edit for the ALTER). This PR is the minimal correct fix; a follow-up could add a CI guard that rejects duplicate migration class names.

Merging redeploys prod and the corrected partner migration finally adds `hosting_provider`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)