### PR TITLE
feat(#859): artisan proposal gate on store route + private preview page

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/normalize-artisan-products-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/normalize-artisan-products-job.ts
@@ -1,0 +1,211 @@
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+import { updateProductsWorkflow } from "@medusajs/medusa/core-flows"
+
+import { PARTNER_MODULE } from "../../../../modules/partner"
+import { PARTNER_ONBOARDING_PROFILE_MODULE } from "../../../../modules/partner-onboarding-profile"
+import partnerProductLink from "../../../../links/partner-product"
+import type {
+  MaintenanceChange,
+  MaintenanceJob,
+  MaintenanceJobResult,
+} from "./registry"
+
+/**
+ * #859 Data Plumbing — normalise artisan products that were published directly
+ * before the proposal gate was wired into `POST /partners/stores/:id/products`.
+ *
+ * A `core_channel_listing` (Airbnb-style) partner's products should enter as
+ * `proposed` and be admin-approved before publish. Products created via the
+ * pre-fix path are `published`, bound only to the partner's own (storefront-
+ * less) sales channel, and carry NO partner→product ownership link.
+ *
+ * For each such product this: (1) flips status → `proposed`, (2) creates the
+ * ownership link, (3) emits `partner_product.proposed` so it enters the admin
+ * review queue + notifications/flows. Idempotent — a product that already has
+ * an ownership link is skipped (it went through the real flow). Dry-run lists
+ * what WOULD change without writing.
+ */
+
+/** Hard cap on products scanned in one call — bounds per-request blast radius. */
+export const MAX_ARTISAN_NORMALIZE_SCAN = 5000
+
+const paramsSchema = z.object({
+  /** Restrict to a single partner. */
+  partner_id: z.string().min(1).optional(),
+  /** Max products to scan in one call. */
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_ARTISAN_NORMALIZE_SCAN)
+    .optional()
+    .default(1000),
+})
+
+export const normalizeArtisanProductsJob: MaintenanceJob = {
+  id: "normalize-artisan-published-products",
+  label: "Normalize artisan products (published → in review)",
+  description:
+    `Move core_channel_listing (Airbnb-style) partners' products that were published directly — before the proposal gate shipped — back to 'proposed' so they enter the admin review queue. Targets ONLY published products in an artisan partner's own sales channel that have no partner→product ownership link (i.e. created via the pre-fix path); already-linked/approved products are skipped. Apply flips status → proposed, creates the ownership link, and emits partner_product.proposed (review widget + email/flows). Dry-run lists what would change. Optionally scope to one partner_id. Scans up to 'limit' products (default 1000, max ${MAX_ARTISAN_NORMALIZE_SCAN}).`,
+  params: [
+    {
+      name: "partner_id",
+      type: "string",
+      required: false,
+      description: "Restrict to a single artisan partner (default: all core_channel_listing partners)",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max products to scan in one call (default 1000, max ${MAX_ARTISAN_NORMALIZE_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const parsed = paramsSchema.safeParse(params)
+    if (!parsed.success) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        parsed.error.issues.map((i) => i.message).join("; ")
+      )
+    }
+    const { partner_id, limit } = parsed.data
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+    const link: any = container.resolve(ContainerRegistrationKeys.LINK)
+    const eventBus: any = container.resolve(Modules.EVENT_BUS)
+    const onboarding: any = container.resolve(PARTNER_ONBOARDING_PROFILE_MODULE)
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+
+    // 1. Core-channel-listing partners (optionally scoped to one).
+    const profileFilter: Record<string, unknown> = {
+      selling_mode: "core_channel_listing",
+    }
+    if (partner_id) profileFilter.partner_id = partner_id
+    const profiles = await onboarding.listPartnerOnboardingProfiles(profileFilter)
+    const partnerIds: string[] = (profiles ?? [])
+      .map((p: any) => p.partner_id)
+      .filter(Boolean)
+
+    if (!partnerIds.length) {
+      return {
+        job_id: normalizeArtisanProductsJob.id,
+        dry_run,
+        applied: false,
+        summary: "No core_channel_listing partners found — nothing to normalize",
+        changes,
+      }
+    }
+
+    // 2. Their stores' default sales channels → owning partner.
+    const { data: partners = [] } = await query.graph({
+      entity: "partners",
+      fields: ["id", "stores.default_sales_channel_id"],
+      filters: { id: partnerIds },
+    })
+    const channelToPartner = new Map<string, string>()
+    for (const p of partners as any[]) {
+      for (const s of p.stores || []) {
+        if (s?.default_sales_channel_id) {
+          channelToPartner.set(s.default_sales_channel_id, p.id)
+        }
+      }
+    }
+    const channelIds = [...channelToPartner.keys()]
+    if (!channelIds.length) {
+      return {
+        job_id: normalizeArtisanProductsJob.id,
+        dry_run,
+        applied: false,
+        summary: "No partner sales channels found — nothing to normalize",
+        changes,
+      }
+    }
+
+    // 3. Products in those channels (+ status).
+    const { data: products = [] } = await query.graph({
+      entity: "product",
+      fields: ["id", "title", "status", "sales_channels.id"],
+      filters: { sales_channels: { id: channelIds } } as any,
+      pagination: { take: limit },
+    })
+
+    // 4. Existing ownership links → already went through the real flow.
+    const { data: existingLinks = [] } = await query.graph({
+      entity: partnerProductLink.entryPoint,
+      fields: ["product_id", "partner_id"],
+    })
+    const linkedProductIds = new Set(
+      (existingLinks as any[]).map((l) => l.product_id)
+    )
+
+    for (const prod of products as any[]) {
+      if (prod.status !== "published") continue
+      if (linkedProductIds.has(prod.id)) continue
+
+      const channelId = (prod.sales_channels || [])
+        .map((c: any) => c.id)
+        .find((id: string) => channelToPartner.has(id))
+      const partnerId = channelId ? channelToPartner.get(channelId) : undefined
+      if (!partnerId) continue
+
+      const change: MaintenanceChange = {
+        entity: "product",
+        id: prod.id,
+        field: "status",
+        before: "published",
+        after: "proposed",
+      }
+
+      if (!dry_run) {
+        try {
+          await updateProductsWorkflow(container).run({
+            input: { products: [{ id: prod.id, status: "proposed" }] },
+          })
+          await link
+            .create({
+              [PARTNER_MODULE]: { partner_id: partnerId },
+              [Modules.PRODUCT]: { product_id: prod.id },
+            })
+            .catch(() => {})
+          await eventBus
+            .emit({
+              name: "partner_product.proposed",
+              data: { id: prod.id, partner_id: partnerId },
+            })
+            .catch(() => {})
+        } catch (e: any) {
+          errors.push({ id: prod.id, message: e?.message ?? String(e) })
+          continue
+        }
+      }
+
+      changes.push(change)
+    }
+
+    const verb = dry_run ? "Would move" : "Moved"
+    const summary =
+      changes.length === 0
+        ? "No changes — no published artisan products need normalizing"
+        : `${verb} ${changes.length} artisan product(s) published → proposed (into review)` +
+          (errors.length ? `; ${errors.length} error(s)` : "")
+
+    return {
+      job_id: normalizeArtisanProductsJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary,
+      changes,
+      ...(errors.length ? { errors } : {}),
+    }
+  },
+}
+
+export default normalizeArtisanProductsJob

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -88,6 +88,7 @@ import { backfillGoogleAdsHistoryJob } from "./backfill-google-ads-history-job"
 import { backfillDesignSizeSetsJob } from "./backfill-design-size-sets-job"
 import { backfillPartnerShippingOptionsJob } from "./backfill-partner-shipping-options-job"
 import { repairShippingOptionStoreVisibilityJob } from "./repair-shipping-option-store-visibility-job"
+import { normalizeArtisanProductsJob } from "./normalize-artisan-products-job"
 import {
   sweepAiPlatformsByCategory,
   AI_ROLES,
@@ -5496,6 +5497,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   backfillDesignSizeSetsJob,
   backfillPartnerShippingOptionsJob,
   repairShippingOptionStoreVisibilityJob,
+  normalizeArtisanProductsJob,
   seedInvestorPanelsJob,
 ]
 

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -1188,6 +1188,15 @@ export default defineMiddlewares({
       ],
     },
     {
+      // #859: private shareable review link for an artisan's unpublished product.
+      matcher: "/partners/products/:id/preview-link",
+      method: "GET",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
+    {
       // #859 S3 (#862): read the artisan made-to-order/maker-story detail.
       matcher: "/partners/products/:id/artisan-detail",
       method: "GET",

--- a/apps/backend/src/api/partners/products/[id]/preview-link/route.ts
+++ b/apps/backend/src/api/partners/products/[id]/preview-link/route.ts
@@ -1,0 +1,95 @@
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+} from "@medusajs/framework/utils"
+import { getPartnerFromAuthContext } from "../../../helpers"
+import partnerProductLink from "../../../../../links/partner-product"
+import { signPreviewToken } from "../../../../store/products/preview/lib/token"
+
+const LINK_ENTRY = partnerProductLink.entryPoint
+
+/**
+ * Return a private, shareable review link for an artisan's (unpublished)
+ * product (#859). The product lists on the core cicilabel.com channel, so the
+ * preview lives on the core storefront (`FRONTEND_URL`) under the token-gated
+ * `/products/preview/:token` route — not discoverable in any listing/sitemap.
+ *
+ * @route GET /partners/products/:id/preview-link
+ */
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  if (!req.auth_context?.actor_id) {
+    throw new MedusaError(MedusaError.Types.UNAUTHORIZED, "Partner authentication required")
+  }
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
+  if (!partner) {
+    throw new MedusaError(MedusaError.Types.UNAUTHORIZED, "No partner associated with this account")
+  }
+
+  const productId = req.params.id
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY) as any
+
+  // Ownership gate — only the owning partner gets a share link.
+  const { data: ownerLinks = [] } = await query.graph({
+    entity: LINK_ENTRY,
+    fields: ["partner_id", "product_id"],
+    filters: { product_id: productId },
+  })
+  const ownedByPartner = ownerLinks.some(
+    (l: any) => l.partner_id === partner.id
+  )
+  if (!ownedByPartner) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, `Product ${productId} not found`)
+  }
+
+  const { data: products = [] } = await query.graph({
+    entity: "product",
+    fields: ["id", "status"],
+    filters: { id: productId },
+  })
+  const product = products[0]
+  if (!product) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, `Product ${productId} not found`)
+  }
+
+  // Resolve a country code for the region-prefixed storefront URL from the
+  // partner's store region (falls back to a sensible default).
+  let countryCode = "de"
+  try {
+    const { data: partners = [] } = await query.graph({
+      entity: "partners",
+      fields: ["id", "stores.default_region_id"],
+      filters: { id: partner.id },
+    })
+    const regionId = partners?.[0]?.stores?.find(
+      (s: any) => s?.default_region_id
+    )?.default_region_id
+    if (regionId) {
+      const { data: regions = [] } = await query.graph({
+        entity: "region",
+        fields: ["id", "countries.iso_2"],
+        filters: { id: regionId },
+      })
+      const iso = regions?.[0]?.countries?.[0]?.iso_2
+      if (iso) {
+        countryCode = iso
+      }
+    }
+  } catch {
+    // keep the default country code
+  }
+
+  const token = signPreviewToken(productId)
+  const base = (process.env.FRONTEND_URL || "").replace(/\/$/, "")
+  const path = `/${countryCode}/products/preview/${token}`
+
+  res.json({
+    token,
+    path,
+    url: base ? `${base}${path}` : path,
+    status: product.status,
+  })
+}

--- a/apps/backend/src/api/partners/products/lib/artisan-proposal.ts
+++ b/apps/backend/src/api/partners/products/lib/artisan-proposal.ts
@@ -1,0 +1,67 @@
+import {
+  ContainerRegistrationKeys,
+  Modules,
+} from "@medusajs/framework/utils"
+import { PARTNER_MODULE } from "../../../../modules/partner"
+import { PARTNER_ONBOARDING_PROFILE_MODULE } from "../../../../modules/partner-onboarding-profile"
+
+/**
+ * Artisan quasi-partner proposal helpers (#859 S2 / #861).
+ *
+ * A `core_channel_listing` partner (the "Airbnb-style" seller who lists on the
+ * core cicilabel.com channel instead of running their own storefront) does NOT
+ * publish directly: their products enter as `proposed` (native ProductStatus),
+ * an admin verifies/approves, and only then are they published + cross-listed.
+ *
+ * This lives in a shared lib because BOTH product-create routes must apply the
+ * gate identically — the legacy `POST /partners/products` and the store-scoped
+ * `POST /partners/stores/:id/products` that the partner-ui actually calls.
+ */
+
+/**
+ * Is this partner an artisan who lists on the core channel (and therefore whose
+ * products must enter the proposal queue)? Never throws — a missing profile or
+ * lookup error is treated as "not core-channel" so the normal publish path is
+ * preserved.
+ */
+export const isCoreChannelListingPartner = async (
+  scope: any,
+  partnerId: string
+): Promise<boolean> => {
+  const onboardingService: any = scope.resolve(
+    PARTNER_ONBOARDING_PROFILE_MODULE
+  )
+  const profile = await onboardingService
+    .findByPartner(partnerId)
+    .catch(() => null)
+  return profile?.selling_mode === "core_channel_listing"
+}
+
+/**
+ * Record product → owning-partner ownership link and emit the dedicated
+ * `partner_product.proposed` event (the seam for admin-review notifications and
+ * visual flows — registered in visual-flow-event-trigger.ts). Kept off the
+ * generic product firehose so flows only wake on real artisan proposals.
+ * Never throws.
+ */
+export const recordArtisanProposal = async (
+  scope: any,
+  partnerId: string,
+  productId: string
+): Promise<void> => {
+  const remoteLink = scope.resolve(ContainerRegistrationKeys.LINK) as any
+  await remoteLink
+    .create({
+      [PARTNER_MODULE]: { partner_id: partnerId },
+      [Modules.PRODUCT]: { product_id: productId },
+    })
+    .catch(() => {})
+
+  const eventBus = scope.resolve(Modules.EVENT_BUS) as any
+  await eventBus
+    .emit({
+      name: "partner_product.proposed",
+      data: { id: productId, partner_id: partnerId },
+    })
+    .catch(() => {})
+}

--- a/apps/backend/src/api/partners/stores/[id]/products/route.ts
+++ b/apps/backend/src/api/partners/stores/[id]/products/route.ts
@@ -6,6 +6,10 @@ import {
 } from "../../../helpers"
 import listStoreProductsWorkflow from "../../../../../workflows/partner/list-store-products"
 import { fanoutVariantPrices } from "../../../../../workflows/fx/fanout-variant-prices"
+import {
+  isCoreChannelListingPartner,
+  recordArtisanProposal,
+} from "../../../products/lib/artisan-proposal"
 
 export const GET = async (
   req: AuthenticatedMedusaRequest,
@@ -40,7 +44,7 @@ export const POST = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
 ) => {
-  const { store } = await validatePartnerStoreAccess(
+  const { partner, store } = await validatePartnerStoreAccess(
     req.auth_context,
     req.params.id,
     req.scope
@@ -53,6 +57,20 @@ export const POST = async (
     body.sales_channels = [{ id: store.default_sales_channel_id }]
   }
 
+  // #859 S2 (#861) — artisan proposal gate. A `core_channel_listing` partner
+  // (Airbnb-style seller) never publishes directly: their products enter as
+  // `proposed` and an admin verifies/approves before publish + cross-list.
+  // This is the route the partner-ui actually calls, so the gate must live
+  // here (not only on the legacy `POST /partners/products`).
+  const isCoreChannelListing = await isCoreChannelListingPartner(
+    req.scope,
+    partner.id
+  )
+  if (isCoreChannelListing) {
+    // Proposal override wins over any client-supplied status.
+    body.status = "proposed"
+  }
+
   const { result } = await createProductsWorkflow(req.scope).run({
     input: {
       products: [body] as any,
@@ -60,6 +78,12 @@ export const POST = async (
   })
 
   const product = result[0]
+
+  // Record ownership link + emit `partner_product.proposed` so the admin-review
+  // widget, notifications and visual flows can resolve the owning partner.
+  if (isCoreChannelListing && product?.id) {
+    await recordArtisanProposal(req.scope, partner.id, product.id)
+  }
 
   // Auto-seed inventory_level rows at the partner's stock location(s) for
   // any managed-inventory variants on the new product. Without this, the

--- a/apps/backend/src/api/store/products/preview/[token]/route.ts
+++ b/apps/backend/src/api/store/products/preview/[token]/route.ts
@@ -1,0 +1,94 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+  QueryContext,
+  isPresent,
+} from "@medusajs/framework/utils"
+import { verifyPreviewToken } from "../lib/token"
+
+// Field set mirrors the storefront's listProducts() so ProductTemplate renders
+// identically — minus anything published-only. Prices are resolved via the
+// pricing QueryContext below.
+const PREVIEW_FIELDS = [
+  "*",
+  "status",
+  "*variants",
+  "*variants.calculated_price",
+  "*variants.options",
+  "*variants.images",
+  "*options",
+  "*options.values",
+  "*images",
+  "*tags",
+  "*categories",
+  "*collection",
+  "*type",
+  "+metadata",
+  "*artisan_detail",
+]
+
+/**
+ * Token-gated preview of an unpublished (proposed/draft) artisan product (#859).
+ *
+ * @route GET /store/products/preview/:token?region_id=...
+ *
+ * Deliberately NOT a public listing: this fetches ONE product by the id encoded
+ * in a signed share token, regardless of `status`, so an artisan can share a
+ * private review link before an admin publishes. It is excluded from
+ * `/store/products`, the sitemap, and search — the only way in is a valid
+ * signed token. Requires the storefront publishable key (the storefront's
+ * server fetch supplies it), same as every other `/store` route.
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const productId = verifyPreviewToken(req.params.token)
+  if (!productId) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "Invalid or expired preview link"
+    )
+  }
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  // Resolve a pricing context from the caller's region so calculated_price is
+  // populated (unpublished products still price normally).
+  const regionId =
+    (req.query.region_id as string) || (req.query.regionId as string) || ""
+  let currencyCode = (req.query.currency_code as string) || ""
+  if (regionId && !currencyCode) {
+    const { data: regions = [] } = await query.graph({
+      entity: "region",
+      fields: ["id", "currency_code"],
+      filters: { id: regionId },
+    })
+    currencyCode = regions?.[0]?.currency_code || ""
+  }
+
+  const context: Record<string, any> = {}
+  if (regionId || currencyCode) {
+    context["variants"] = {
+      calculated_price: QueryContext({
+        ...(regionId ? { region_id: regionId } : {}),
+        ...(currencyCode ? { currency_code: currencyCode } : {}),
+      }),
+    }
+  }
+
+  const { data: products = [] } = await query.graph({
+    entity: "product",
+    fields: PREVIEW_FIELDS,
+    filters: { id: productId },
+    ...(isPresent(context) ? { context } : {}),
+  })
+
+  const product = products?.[0]
+  if (!product) {
+    throw new MedusaError(
+      MedusaError.Types.NOT_FOUND,
+      "Product not found"
+    )
+  }
+
+  res.json({ product })
+}

--- a/apps/backend/src/api/store/products/preview/lib/token.ts
+++ b/apps/backend/src/api/store/products/preview/lib/token.ts
@@ -1,0 +1,53 @@
+import crypto from "crypto"
+
+/**
+ * Share-token signing for artisan product previews (#859).
+ *
+ * A `core_channel_listing` partner's product enters as `proposed` and is NOT
+ * returned by `/store/products` (published-only) nor listed anywhere public.
+ * To let the partner share a private "review this before it goes live" link, we
+ * mint a stateless signed token — `<productId>.<hmac>` — that a dedicated
+ * preview endpoint verifies. No schema change, no DB lookup: possession of the
+ * signed link is the capability. Anyone without the signature cannot guess it
+ * even if they know the product id.
+ */
+
+const secret = (): string =>
+  process.env.PRODUCT_PREVIEW_SECRET ||
+  process.env.JWT_SECRET ||
+  process.env.COOKIE_SECRET ||
+  "insecure-preview-secret-change-me"
+
+const sign = (productId: string): string =>
+  crypto
+    .createHmac("sha256", secret())
+    .update(productId)
+    .digest("base64url")
+
+/** Build the `<productId>.<sig>` share token for a product. */
+export const signPreviewToken = (productId: string): string =>
+  `${productId}.${sign(productId)}`
+
+/**
+ * Verify a share token and return its product id, or null if malformed /
+ * tampered. Uses a constant-time comparison to avoid signature-timing leaks.
+ */
+export const verifyPreviewToken = (token: string): string | null => {
+  if (!token || typeof token !== "string") {
+    return null
+  }
+  const idx = token.lastIndexOf(".")
+  if (idx <= 0) {
+    return null
+  }
+  const productId = token.slice(0, idx)
+  const provided = token.slice(idx + 1)
+  const expected = sign(productId)
+
+  const a = Buffer.from(provided)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length) {
+    return null
+  }
+  return crypto.timingSafeEqual(a, b) ? productId : null
+}

--- a/apps/storefront/src/app/[countryCode]/(main)/products/preview/[token]/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/products/preview/[token]/page.tsx
@@ -1,0 +1,71 @@
+import { Metadata } from "next"
+import { notFound } from "next/navigation"
+import { retrievePreviewProduct } from "@lib/data/products"
+import { getRegion } from "@lib/data/regions"
+import ProductTemplate from "@modules/products/templates"
+import { HttpTypes } from "@medusajs/types"
+
+// #859 — private artisan product review page.
+//
+// Fully dynamic (no generateStaticParams), never cached, and NOINDEX. The only
+// way in is a valid signed share token; the product is unpublished so it appears
+// in no listing, sitemap or search. Lets an artisan share a "review before it
+// goes live" link on the core cicilabel.com storefront.
+export const dynamic = "force-dynamic"
+
+type Props = {
+  params: Promise<{ countryCode: string; token: string }>
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: "Product preview",
+    robots: { index: false, follow: false },
+  }
+}
+
+export default async function ProductPreviewPage(props: Props) {
+  const { countryCode, token } = await props.params
+
+  const region = await getRegion(countryCode)
+  if (!region) {
+    notFound()
+  }
+
+  const product = await retrievePreviewProduct({ token, countryCode })
+  if (!product) {
+    notFound()
+  }
+
+  const images: HttpTypes.StoreProductImage[] = product.images ?? []
+
+  return (
+    <>
+      <PreviewBanner status={(product as any).status} />
+      <ProductTemplate
+        product={product}
+        region={region}
+        countryCode={countryCode}
+        images={images}
+      />
+    </>
+  )
+}
+
+function PreviewBanner({ status }: { status?: string }) {
+  const isPending = status === "proposed"
+  return (
+    <div className="w-full bg-ui-bg-highlight border-b border-ui-border-base">
+      <div className="content-container flex flex-col gap-y-0.5 py-3">
+        <p className="text-small-semi text-ui-fg-base">
+          Private preview — not yet live
+        </p>
+        <p className="text-small-regular text-ui-fg-subtle">
+          {isPending
+            ? "This product is awaiting review. Only people with this link can see it, and it won't appear in the store until it's approved and published."
+            : "This is a private preview link. This product isn't published, so it won't appear in the store or search."}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/apps/storefront/src/app/robots.ts
+++ b/apps/storefront/src/app/robots.ts
@@ -16,6 +16,8 @@ export default function robots(): MetadataRoute.Robots {
           "/*/account",
           "/*/account/*",
           "/*/order/*",
+          // #859 — private artisan product review links (unpublished, noindex).
+          "/*/products/preview/*",
         ],
       },
     ],

--- a/apps/storefront/src/lib/data/products.ts
+++ b/apps/storefront/src/lib/data/products.ts
@@ -71,7 +71,7 @@ export const listProducts = async ({
           // relations on Design, so populating them here throws
           // "Entity 'Design' does not have property 'persons'".
           fields:
-            "*variants.calculated_price,+variants.inventory_quantity,*variants.images,+metadata,+tags,+designs.*, +designs.partners.*, +designs.tasks.*, +designs.inventory_items.raw_materials.*, +designs.inventory_items.raw_materials.material_type.*",
+            "*variants.calculated_price,+variants.inventory_quantity,*variants.images,+metadata,+tags,+artisan_detail.*,+designs.*, +designs.partners.*, +designs.tasks.*, +designs.inventory_items.raw_materials.*, +designs.inventory_items.raw_materials.material_type.*",
           ...queryParams,
         },
         headers,
@@ -91,6 +91,37 @@ export const listProducts = async ({
         queryParams,
       }
     })
+}
+
+/**
+ * #859 — fetch a single UNPUBLISHED artisan product for a private review page
+ * via a signed share token. Hits the token-gated backend preview endpoint
+ * (NOT `/store/products`, which is published-only). Returns null on an invalid
+ * token or missing product so the caller can `notFound()`.
+ */
+export const retrievePreviewProduct = async ({
+  token,
+  countryCode,
+}: {
+  token: string
+  countryCode: string
+}): Promise<HttpTypes.StoreProduct | null> => {
+  const region = await getRegion(countryCode)
+  const headers = { ...(await getAuthHeaders()) }
+
+  return sdk.client
+    .fetch<{ product: HttpTypes.StoreProduct }>(
+      `/store/products/preview/${encodeURIComponent(token)}`,
+      {
+        method: "GET",
+        query: { region_id: region?.id },
+        headers,
+        // Never cache a preview — the artisan is actively editing it.
+        cache: "no-store",
+      }
+    )
+    .then(({ product }) => product ?? null)
+    .catch(() => null)
 }
 
 /**

--- a/apps/storefront/src/modules/products/components/artisan-detail/index.ts
+++ b/apps/storefront/src/modules/products/components/artisan-detail/index.ts
@@ -1,0 +1,40 @@
+import { HttpTypes } from "@medusajs/types"
+
+// #859 S3 (#862): the artisan "made-to-order & maker story" detail, linked to a
+// product on the backend and hydrated onto the store product via
+// `fields=+artisan_detail.*`. Not part of the core StoreProduct type, so we
+// read it defensively.
+export type ArtisanDetail = {
+  made_to_order?: boolean | null
+  lead_time_days?: number | null
+  lead_time_label?: string | null
+  min_order_quantity?: number | null
+  maker_story?: string | null
+}
+
+export function getArtisanDetail(
+  product?: HttpTypes.StoreProduct | null
+): ArtisanDetail | null {
+  const detail = (product as any)?.artisan_detail
+  if (!detail || typeof detail !== "object") return null
+  return detail as ArtisanDetail
+}
+
+/**
+ * Human-friendly preparation time. Prefers the partner's free-form label; else
+ * derives an approximate "~N week(s)/day(s)" from lead_time_days. Returns null
+ * when there's nothing to say.
+ */
+export function formatLeadTime(detail: ArtisanDetail | null): string | null {
+  if (!detail) return null
+  if (detail.lead_time_label && detail.lead_time_label.trim()) {
+    return detail.lead_time_label.trim()
+  }
+  const days = detail.lead_time_days
+  if (!days || days <= 0) return null
+  if (days < 7) {
+    return `~${days} day${days === 1 ? "" : "s"} to prepare`
+  }
+  const weeks = Math.round(days / 7)
+  return `~${weeks} week${weeks === 1 ? "" : "s"} to prepare`
+}

--- a/apps/storefront/src/modules/products/components/artisan-detail/made-to-order-notice.tsx
+++ b/apps/storefront/src/modules/products/components/artisan-detail/made-to-order-notice.tsx
@@ -1,0 +1,61 @@
+import { clx } from "@medusajs/ui"
+import { Clock, Sparkles } from "@medusajs/icons"
+import { ArtisanDetail, formatLeadTime } from "./index"
+
+/**
+ * Made-to-order reassurance for the buy box (#859 S3 / #862).
+ *
+ * Styled after the "Fast delivery / Easy returns" inline shipping blocks
+ * (icon + bold label + subtle copy) so it reads as a native trust signal.
+ * Rendered only when the partner marked the product made-to-order.
+ */
+export default function MadeToOrderNotice({
+  detail,
+  className,
+}: {
+  detail: ArtisanDetail | null
+  className?: string
+}) {
+  if (!detail?.made_to_order) return null
+
+  const leadTime = formatLeadTime(detail)
+  const minQty =
+    detail.min_order_quantity && detail.min_order_quantity > 1
+      ? detail.min_order_quantity
+      : null
+
+  return (
+    <div
+      data-testid="made-to-order-notice"
+      className={clx(
+        "text-small-regular flex flex-col gap-y-4 rounded-lg border border-ui-border-base bg-ui-bg-subtle p-4",
+        className
+      )}
+    >
+      <div className="flex items-start gap-x-2">
+        <Sparkles className="mt-0.5 flex-shrink-0 text-ui-fg-subtle" />
+        <div>
+          <span className="font-semibold">Made to order</span>
+          <p className="max-w-sm text-ui-fg-subtle">
+            This piece is crafted for you once you order — not held in stock, so
+            each one is made just for you.
+          </p>
+        </div>
+      </div>
+      {leadTime && (
+        <div className="flex items-start gap-x-2">
+          <Clock className="mt-0.5 flex-shrink-0 text-ui-fg-subtle" />
+          <div>
+            <span className="font-semibold">Preparation time</span>
+            <p className="max-w-sm text-ui-fg-subtle">
+              {leadTime}. We&apos;ll keep you posted as your piece comes together.
+            </p>
+          </div>
+        </div>
+      )}
+      {minQty && (
+        <p className="text-ui-fg-subtle">Minimum order: {minQty}</p>
+      )}
+    </div>
+  )
+}

--- a/apps/storefront/src/modules/products/components/artisan-detail/maker-story.tsx
+++ b/apps/storefront/src/modules/products/components/artisan-detail/maker-story.tsx
@@ -1,0 +1,40 @@
+import { Heading, Text } from "@medusajs/ui"
+import { HttpTypes } from "@medusajs/types"
+import { getArtisanDetail } from "./index"
+
+/**
+ * The maker / provenance prose for an artisan product (#859 S3 / #862).
+ *
+ * Partner-authored free text describing who made the piece, where, and how.
+ * Rendered on the product page under the product info. Renders nothing when
+ * the product has no maker story.
+ */
+export default function MakerStory({
+  product,
+}: {
+  product: HttpTypes.StoreProduct
+}) {
+  const detail = getArtisanDetail(product)
+  const story = detail?.maker_story?.trim()
+  if (!story) return null
+
+  return (
+    <div
+      data-testid="maker-story"
+      className="flex flex-col gap-y-2 border-t border-ui-border-base pt-6"
+    >
+      <Heading level="h3" className="text-base-semi">
+        The maker&apos;s story
+      </Heading>
+      {story.split(/\n{2,}/).map((paragraph, i) => (
+        <Text
+          key={i}
+          size="small"
+          className="text-ui-fg-subtle whitespace-pre-line"
+        >
+          {paragraph}
+        </Text>
+      ))}
+    </div>
+  )
+}

--- a/apps/storefront/src/modules/products/templates/index.tsx
+++ b/apps/storefront/src/modules/products/templates/index.tsx
@@ -12,6 +12,9 @@ import SkeletonRelatedProducts from "@modules/skeletons/templates/skeleton-relat
 import { notFound } from "next/navigation"
 import ProductActionsWrapper from "./product-actions-wrapper"
 import SizeGuide from "@modules/products/components/size-guide"
+import MakerStory from "@modules/products/components/artisan-detail/maker-story"
+import MadeToOrderNotice from "@modules/products/components/artisan-detail/made-to-order-notice"
+import { getArtisanDetail } from "@modules/products/components/artisan-detail"
 import { HttpTypes } from "@medusajs/types"
 import { Text } from "@medusajs/ui"
 import { StoreDesign } from "../../../types/product-design"
@@ -100,6 +103,7 @@ const ProductTemplate = async ({
       >
         <div className="flex flex-col small:sticky small:top-48 small:py-0 small:max-w-[300px] w-full py-8 gap-y-6">
           <ProductInfo product={product} />
+          <MakerStory product={product} />
           <div className="hidden small:block">
             <DesignInfo
               design={design}
@@ -135,6 +139,7 @@ const ProductTemplate = async ({
           >
 
             <ProductActionsWrapper id={product.id} region={region} />
+            <MadeToOrderNotice detail={getArtisanDetail(product)} className="mt-4" />
             <div className="mt-4 flex items-center gap-x-2">
               <Text className="txt-medium">Size Guide</Text>
               <SizeGuide />


### PR DESCRIPTION
## Why

Diagnosing a report that an "Airbnb-style" (core_channel_listing) partner's product **published** instead of entering review, I traced it to the wrong route carrying the gate:

- The proposal lifecycle (`status → proposed` for `core_channel_listing` partners, ownership link, `partner_product.proposed` event) was built into `POST /partners/products` — but **the partner-ui never calls that route.** Product creation goes through `POST /partners/stores/:id/products`, which published directly with no gate. So every artisan product skipped review.

Verified live: partner Le Ciricotte has `selling_mode=core_channel_listing` (20% commission) yet `A Hand-Woven Poncho-Top` came back `published`.

## What

**1. Status fix (root cause)**
- Port the proposal gate into `partners/stores/[id]/products/route.ts` (the route the partner-ui uses).
- Extract shared `partners/products/lib/artisan-proposal.ts` (`isCoreChannelListingPartner`, `recordArtisanProposal`) so both create routes stay consistent.

**2. Private, shareable review page** (unpublished products aren't in `/store/products`)
- Backend: `GET /store/products/preview/:token` — stateless HMAC token (`<productId>.<sig>`, no schema change), returns product at any status; `GET /partners/products/:id/preview-link` mints the signed link on the core storefront.
- Storefront: `products/preview/[token]` page — `force-dynamic`, `robots: noindex/nofollow`, no `generateStaticParams`, not in listings/sitemap; `robots.ts` disallow added. Renders normal `ProductTemplate` behind a "Private preview — not yet live" banner.

**3. Maker story + made-to-order on the core storefront**
- Ported `artisan-detail` components (`MadeToOrderNotice`, `MakerStory`) into `apps/storefront`, styled like the inline "Fast delivery / Easy returns" shipping blocks.
- Added `+artisan_detail.*` to the product fetch.

**4. Data Plumbing job** — "Normalize artisan products (published → in review)": idempotent backfill that moves products published via the pre-fix path back to `proposed` (+ link + event). Dry-run by default. Targets only artisan-channel published products with no ownership link (skips genuinely-approved ones).

## Verification
- `tsc --noEmit` clean (backend).
- Confirmed `CORE_SALES_CHANNEL_ID` (needed for the cross-list-on-approval chain) is live in both running prod task defs (medusa-server:36, medusa-worker:12).

## Post-merge tail
- Run the DP job (dry-run → apply) to normalize the existing published `A Hand-Woven Poncho-Top`.

Refs #859 / #861 / #862.

🤖 Generated with [Claude Code](https://claude.com/claude-code)