### PR TITLE
feat(handloom-scrape): weaver data import pipeline from Census Portal

### DIFF
--- a/scripts/handloom-scrape/.env.example
+++ b/scripts/handloom-scrape/.env.example
@@ -1,0 +1,9 @@
+# Census Portal Login Credentials (required for scraping)
+# Get these from the Census Portal admin at tricorniotec.com/webapp
+CENSUS_USERNAME=your_username_here
+CENSUS_PASSWORD=your_password_here
+
+# Medusa Admin API (required for importing to persons module)
+# Generate an API token from Medusa admin settings
+MEDUSA_ADMIN_URL=http://localhost:9000
+MEDUSA_API_KEY=your_api_key_here

--- a/scripts/handloom-scrape/dashboard/server.py
+++ b/scripts/handloom-scrape/dashboard/server.py
@@ -152,7 +152,7 @@ function renderTable() {{
         tr = document.createElement('tr');
         tr.className = `hover:bg-gray-100 ${{bg}}`;
         tr.innerHTML = `
-            <td class="px-2 py-1 text-xs font-mono"><a href="javascript:void(0)" onclick='showDetail({JSON.stringify(r).replace(/'/g,"&#39;")})' class="text-blue-600 hover:underline">${{r.census_id}}</a></td>
+            <td class="px-2 py-1 text-xs font-mono"><a href="javascript:void(0)" onclick='showDetail(${{JSON.stringify(r).replace(/'/g,"&#39;")}})' class="text-blue-600 hover:underline">${{r.census_id}}</a></td>
             <td class="px-2 py-1">${{esc(name)}}</td>
             <td class="px-2 py-1 text-xs">${{esc(state)}}</td>
             <td class="px-2 py-1 text-xs">${{esc(district)}}</td>

--- a/scripts/handloom-scrape/dashboard/server.py
+++ b/scripts/handloom-scrape/dashboard/server.py
@@ -1,0 +1,466 @@
+"""
+Verification Dashboard — browse, search, and approve/flag/reject scraped weaver records.
+
+Usage:
+    python dashboard/server.py --data ../data --port 8080
+"""
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from fastapi import FastAPI, Query, HTTPException
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.middleware.cors import CORSMiddleware
+import uvicorn
+import typer
+
+cli = typer.Typer()
+DATA_DIR = Path("data")
+
+
+def load_all_records(data_dir: Path, max_files: int = 0) -> list[dict]:
+    records = []
+    batches_dir = data_dir / "batches"
+    if not batches_dir.exists():
+        return records
+    files = sorted(batches_dir.glob("*.jsonl"))
+    if max_files > 0:
+        files = files[:max_files]
+    for f in files:
+        for line in f.read_text().splitlines():
+            if line.strip():
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    return records
+
+
+def get_app(data_dir: Path):
+    app = FastAPI(title="Handloom Weaver Verification Dashboard")
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    records_cache: list[dict] = []
+    verified: dict[int, str] = {}  # census_id -> verdict (approved/flagged/rejected)
+    notes: dict[int, str] = {}
+
+    @app.on_event("startup")
+    async def load_data():
+        nonlocal records_cache
+        records_cache = load_all_records(data_dir)
+        print(f"Loaded {len(records_cache)} records")
+
+        ver_path = data_dir / "verified"
+        ver_path.mkdir(parents=True, exist_ok=True)
+        if (ver_path / "approved.jsonl").exists():
+            for line in (ver_path / "approved.jsonl").read_text().splitlines():
+                if line.strip():
+                    try:
+                        r = json.loads(line)
+                        verified[r.get("census_id")] = "approved"
+                    except Exception:
+                        pass
+        if (ver_path / "flags.jsonl").exists():
+            for line in (ver_path / "flags.jsonl").read_text().splitlines():
+                if line.strip():
+                    try:
+                        r = json.loads(line)
+                        verified[r.get("census_id")] = "flagged"
+                    except Exception:
+                        pass
+        if (ver_path / "rejected.jsonl").exists():
+            for line in (ver_path / "rejected.jsonl").read_text().splitlines():
+                if line.strip():
+                    try:
+                        r = json.loads(line)
+                        verified[r.get("census_id")] = "rejected"
+                    except Exception:
+                        pass
+
+    @app.get("/", response_class=HTMLResponse)
+    async def index():
+        total = len(records_cache)
+        approved_count = sum(1 for v in verified.values() if v == "approved")
+        flagged_count = sum(1 for v in verified.values() if v == "flagged")
+        rejected_count = sum(1 for v in verified.values() if v == "rejected")
+        pending = total - len(verified)
+
+        return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Handloom Weaver Verification Dashboard</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<script>
+const API = '';
+let allRecords = [];
+let filteredRecords = [];
+let currentPage = 1;
+const PER_PAGE = 25;
+
+async function loadStats() {{
+    const r = await fetch(API + '/api/stats');
+    const s = await r.json();
+    document.getElementById('stats-total').textContent = s.total;
+    document.getElementById('stats-approved').textContent = s.approved;
+    document.getElementById('stats-pending').textContent = s.pending;
+    document.getElementById('stats-flagged').textContent = s.flagged;
+    document.getElementById('stats-rejected').textContent = s.rejected;
+    document.getElementById('stats-failures').textContent = s.failures;
+    document.getElementById('search-count').textContent =
+        filteredRecords.length > 0 ? `Showing {{filteredRecords.length}} of {{s.total}}` : '';
+}}
+
+async function fetchRecords() {{
+    const r = await fetch(API + '/api/records?limit=500');
+    allRecords = await r.json();
+    filteredRecords = [...allRecords];
+    renderTable();
+    loadStats();
+}}
+
+function renderTable() {{
+    const start = (currentPage - 1) * PER_PAGE;
+    const page = filteredRecords.slice(start, start + PER_PAGE);
+    const tbody = document.getElementById('records-body');
+    tbody.innerHTML = '';
+    page.forEach(r => {{
+        const verdict = r._verdict || '';
+        const name = r.name || 'N/A';
+        const state = r.state || '';
+        const district = r.district || '';
+        const phone = r.mobile || '';
+        const age = r.age ?? '';
+        const gender = r.gender || '';
+        const hasLoom = r.own_looms ? 'Yes' : (r.own_looms === false ? 'No' : '');
+        const income = r.monthly_income || '';
+        const bg = verdict === 'approved' ? 'bg-green-50' :
+                   verdict === 'flagged' ? 'bg-yellow-50' :
+                   verdict === 'rejected' ? 'bg-red-50' : '';
+        const btnDisabled = verdict ? 'opacity-50 cursor-not-allowed' : '';
+        tr = document.createElement('tr');
+        tr.className = `hover:bg-gray-100 ${{bg}}`;
+        tr.innerHTML = `
+            <td class="px-2 py-1 text-xs font-mono"><a href="javascript:void(0)" onclick='showDetail({JSON.stringify(r).replace(/'/g,"&#39;")})' class="text-blue-600 hover:underline">${{r.census_id}}</a></td>
+            <td class="px-2 py-1">${{esc(name)}}</td>
+            <td class="px-2 py-1 text-xs">${{esc(state)}}</td>
+            <td class="px-2 py-1 text-xs">${{esc(district)}}</td>
+            <td class="px-2 py-1 text-xs">${{phone}}</td>
+            <td class="px-2 py-1 text-xs">${{gender}}</td>
+            <td class="px-2 py-1 text-xs">${{age}}</td>
+            <td class="px-2 py-1 text-xs">${{hasLoom}}</td>
+            <td class="px-2 py-1 text-xs">${{income}}</td>
+            <td class="px-2 py-1 whitespace-nowrap">
+                <button onclick="verdict(${{r.census_id}},'approved')" class="text-xs px-2 py-0.5 rounded bg-green-500 text-white ${{btnDisabled}}">✓</button>
+                <button onclick="verdict(${{r.census_id}},'flagged')" class="text-xs px-2 py-0.5 rounded bg-yellow-500 text-white ${{btnDisabled}}">!</button>
+                <button onclick="verdict(${{r.census_id}},'rejected')" class="text-xs px-2 py-0.5 rounded bg-red-500 text-white ${{btnDisabled}}">✗</button>
+            </td>
+        `;
+        tbody.appendChild(tr);
+    }});
+    document.getElementById('page-info').textContent =
+        `Page ${{currentPage}} of ${{Math.ceil(filteredRecords.length/PER_PAGE)}} (${{filteredRecords.length}} total)`;
+}}
+
+function esc(s) {{ return String(s || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }}
+
+async function verdict(id, v) {{
+    await fetch(API + '/api/verdict', {{
+        method: 'POST',
+        headers: {{'Content-Type': 'application/json'}},
+        body: JSON.stringify({{census_id: id, verdict: v}})
+    }});
+    const r = allRecords.find(x => x.census_id === id);
+    if (r) r._verdict = v;
+    renderTable();
+    loadStats();
+}}
+
+function showDetail(r) {{
+    const d = document.getElementById('detail-panel');
+    const sections = [];
+    const add = (label, val) => {{
+        if (val !== null && val !== undefined && val !== '') {{
+            sections.push(`<div class="flex py-1"><span class="w-1/3 text-gray-500 text-xs">${{label}}</span><span class="w-2/3 text-xs">${{esc(val)}}</span></div>`);
+        }}
+    }};
+    add('Name', r.name);
+    add('Census ID', r.census_id);
+    add('Mobile', r.mobile);
+    add('Gender', r.gender);
+    add('Age', r.age);
+    add('Education', r.education);
+    add('State', r.state);
+    add('District', r.district);
+    add('Block', r.block);
+    add('Village', r.village);
+    add('House', r.house_no);
+    add('Pin Code', r.pin_code);
+    add('Rural/Urban', r.rural_urban);
+    add('Latitude', r.latitude);
+    add('Longitude', r.longitude);
+    add('Head of Household', r.head_of_household);
+    add('Relation to Head', r.relation_to_head);
+    add('Religion', r.religion);
+    add('Social Group', r.social_group);
+    add('Household Size', r.household_size);
+    add('Monthly Income', r.monthly_income);
+    add('Handloom Income', r.handloom_income);
+    add('Household Type', r.household_type);
+    add('Own Looms', r.own_looms);
+    add('Total Looms', r.total_looms_owned);
+    add('Pit Looms', r.pit_loom_count);
+    add('Frame Looms', r.frame_loom_count);
+    add('Avg Production (m)', r.avg_production_meters);
+    add('Intricacy', r.intricacy_level);
+    add('Natural Dye', r.natural_dye_used);
+    add('Survey Date', r.survey_date);
+    if (r.support_requirements && r.support_requirements.length) {{
+        add('Support Needed', r.support_requirements.join(', '));
+    }}
+    if (r.family_weavers && r.family_weavers.length) {{
+        sections.push('<div class="mt-2 pt-2 border-t"><span class="text-xs font-bold">Family Weavers:</span></div>');
+        r.family_weavers.forEach(fw => {{
+            sections.push(`<div class="flex py-0.5"><span class="w-1/3 text-gray-500 text-xs">${{esc(fw.name)}}</span><span class="w-2/3 text-xs">Age: ${{fw.age ?? '?'}} | ${{esc(fw.gender)}} | ${{esc(fw.mobile || '')}}</span></div>`);
+        }});
+    }}
+    d.innerHTML = sections.join('');
+    document.getElementById('detail-title').textContent = `Weaver #${{r.census_id}} - ${{esc(r.name)}}`;
+    document.getElementById('detail-view').classList.remove('hidden');
+}}
+
+function search() {{
+    const q = document.getElementById('search-input').value.toLowerCase();
+    if (!q) {{
+        filteredRecords = [...allRecords];
+    }} else {{
+        filteredRecords = allRecords.filter(r =>
+            (r.name || '').toLowerCase().includes(q) ||
+            (r.state || '').toLowerCase().includes(q) ||
+            (r.district || '').toLowerCase().includes(q) ||
+            (r.village || '').toLowerCase().includes(q) ||
+            (r.mobile || '').includes(q) ||
+            String(r.census_id).includes(q)
+        );
+    }}
+    currentPage = 1;
+    renderTable();
+    document.getElementById('search-count').textContent = `Found ${{filteredRecords.length}} records`;
+}}
+
+function filterState() {{
+    const state = document.getElementById('state-filter').value;
+    if (!state) {{
+        filteredRecords = [...allRecords];
+    }} else {{
+        filteredRecords = allRecords.filter(r => (r.state || '') === state);
+    }}
+    currentPage = 1;
+    renderTable();
+}}
+
+function filterVerdict() {{
+    const v = document.getElementById('verdict-filter').value;
+    if (!v) {{
+        filteredRecords = [...allRecords];
+    }} else if (v === 'pending') {{
+        filteredRecords = allRecords.filter(r => !r._verdict);
+    }} else {{
+        filteredRecords = allRecords.filter(r => r._verdict === v);
+    }}
+    currentPage = 1;
+    renderTable();
+}}
+
+async function exportApproved() {{
+    const r = await fetch(API + '/api/export/approved');
+    const blob = await r.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'approved-weavers.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+}}
+
+function prevPage() {{ if (currentPage > 1) {{ currentPage--; renderTable(); }} }}
+function nextPage() {{ if (currentPage * PER_PAGE < filteredRecords.length) {{ currentPage++; renderTable(); }} }}
+
+window.onload = fetchRecords;
+</script>
+</head>
+<body class="bg-gray-50 text-gray-800">
+<div class="max-w-7xl mx-auto px-4 py-4">
+    <div class="flex justify-between items-center mb-4">
+        <h1 class="text-2xl font-bold">🪡 Handloom Weaver Verification</h1>
+        <button onclick="exportApproved()" class="bg-blue-600 text-white px-4 py-2 rounded text-sm hover:bg-blue-700">Export Approved CSV</button>
+    </div>
+
+    <div class="grid grid-cols-5 gap-3 mb-4 text-center">
+        <div class="bg-white p-3 rounded shadow"><div class="text-2xl font-bold" id="stats-total">-</div><div class="text-xs text-gray-500">Total</div></div>
+        <div class="bg-green-50 p-3 rounded shadow"><div class="text-2xl font-bold text-green-700" id="stats-approved">-</div><div class="text-xs text-gray-500">Approved</div></div>
+        <div class="bg-gray-50 p-3 rounded shadow"><div class="text-2xl font-bold" id="stats-pending">-</div><div class="text-xs text-gray-500">Pending</div></div>
+        <div class="bg-yellow-50 p-3 rounded shadow"><div class="text-2xl font-bold text-yellow-700" id="stats-flagged">-</div><div class="text-xs text-gray-500">Flagged</div></div>
+        <div class="bg-red-50 p-3 rounded shadow"><div class="text-2xl font-bold text-red-700" id="stats-rejected">-</div><div class="text-xs text-gray-500">Rejected</div></div>
+    </div>
+
+    <div class="flex gap-2 mb-3 items-center">
+        <input id="search-input" onkeyup="search()" placeholder="Search name, state, district, phone, ID..." class="flex-1 p-2 border rounded text-sm">
+        <select id="state-filter" onchange="filterState()" class="p-2 border rounded text-sm">
+            <option value="">All States</option>
+        </select>
+        <select id="verdict-filter" onchange="filterVerdict()" class="p-2 border rounded text-sm">
+            <option value="">All Verdicts</option>
+            <option value="pending">Pending</option>
+            <option value="approved">Approved</option>
+            <option value="flagged">Flagged</option>
+            <option value="rejected">Rejected</option>
+        </select>
+        <span id="search-count" class="text-xs text-gray-500"></span>
+    </div>
+
+    <div class="flex gap-4">
+        <div class="flex-1">
+            <div class="bg-white rounded shadow overflow-x-auto">
+                <table class="w-full text-sm">
+                    <thead><tr class="bg-gray-100 text-left text-xs uppercase">
+                        <th class="px-2 py-2">ID</th>
+                        <th class="px-2 py-2">Name</th>
+                        <th class="px-2 py-2">State</th>
+                        <th class="px-2 py-2">District</th>
+                        <th class="px-2 py-2">Phone</th>
+                        <th class="px-2 py-2">Gender</th>
+                        <th class="px-2 py-2">Age</th>
+                        <th class="px-2 py-2">Loom</th>
+                        <th class="px-2 py-2">Income</th>
+                        <th class="px-2 py-2">Verdict</th>
+                    </tr></thead>
+                    <tbody id="records-body"></tbody>
+                </table>
+            </div>
+            <div class="flex justify-between items-center mt-2 text-sm">
+                <span id="page-info" class="text-gray-500"></span>
+                <div class="flex gap-1">
+                    <button onclick="prevPage()" class="px-3 py-1 bg-gray-200 rounded hover:bg-gray-300 text-xs">← Prev</button>
+                    <button onclick="nextPage()" class="px-3 py-1 bg-gray-200 rounded hover:bg-gray-300 text-xs">Next →</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="detail-view" class="hidden w-96 bg-white rounded shadow p-4">
+            <h2 id="detail-title" class="text-sm font-bold mb-2"></h2>
+            <div id="detail-panel" class="text-sm max-h-[70vh] overflow-y-auto"></div>
+        </div>
+    </div>
+</div>
+</body>
+</html>"""
+
+    @app.get("/api/stats")
+    async def api_stats():
+        total = len(records_cache)
+        approved = sum(1 for v in verified.values() if v == "approved")
+        flagged = sum(1 for v in verified.values() if v == "flagged")
+        rejected = sum(1 for v in verified.values() if v == "rejected")
+        pending = total - approved - flagged - rejected
+        failures_dir = data_dir / "failures"
+        failures = 0
+        if failures_dir.exists():
+            for f in failures_dir.glob("*.json"):
+                try:
+                    failures += len(json.loads(f.read_text()))
+                except Exception:
+                    failures += 1
+        return {
+            "total": total,
+            "approved": approved,
+            "flagged": flagged,
+            "rejected": rejected,
+            "pending": pending,
+            "failures": failures,
+        }
+
+    @app.get("/api/records")
+    async def api_records(limit: int = Query(500, le=5000), offset: int = Query(0)):
+        records = records_cache[offset:offset + limit]
+        for r in records:
+            r["_verdict"] = verified.get(r.get("census_id"), "")
+        return records
+
+    @app.get("/api/states")
+    async def api_states():
+        states = sorted(set(r.get("state", "") for r in records_cache if r.get("state")))
+        return states
+
+    @app.post("/api/verdict")
+    async def api_verdict(data: dict):
+        cid = data.get("census_id")
+        v = data.get("verdict")
+        if not cid or v not in ("approved", "flagged", "rejected"):
+            raise HTTPException(400, "Invalid data")
+        verified[cid] = v
+        ver_path = data_dir / "verified"
+        ver_path.mkdir(parents=True, exist_ok=True)
+        record = next((r for r in records_cache if r.get("census_id") == cid), None)
+        if record:
+            filename = {"approved": "approved.jsonl", "flagged": "flags.jsonl", "rejected": "rejected.jsonl"}[v]
+            with open(ver_path / filename, "a") as f:
+                f.write(json.dumps(record, default=str) + "\n")
+        return {"ok": True}
+
+    @app.get("/api/export/approved")
+    async def export_approved():
+        import csv
+        from io import StringIO
+        approved_records = [r for r in records_cache if verified.get(r.get("census_id")) == "approved"]
+        output = StringIO()
+        fieldnames = [
+            "census_id", "name", "mobile", "gender", "age", "education",
+            "state", "district", "block", "village", "house_no", "pin_code",
+            "latitude", "longitude", "religion", "social_group",
+            "household_size", "monthly_income", "handloom_income",
+            "own_looms", "total_looms_owned", "pit_loom_count", "frame_loom_count",
+            "avg_production_meters", "natural_dye_used",
+            "support_requirements", "survey_date",
+        ]
+        writer = csv.DictWriter(output, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        for r in approved_records:
+            writer.writerow(r)
+        from fastapi.responses import StreamingResponse
+        return StreamingResponse(
+            iter([output.getvalue()]),
+            media_type="text/csv",
+            headers={"Content-Disposition": "attachment; filename=approved-weavers.csv"},
+        )
+
+    @app.get("/health")
+    async def health():
+        return {"ok": True, "records_loaded": len(records_cache)}
+
+    return app
+
+
+@cli.command()
+def serve(
+    data: str = typer.Option("./data", "--data", "-d", help="Scrape data directory"),
+    port: int = typer.Option(8080, "--port", "-p", help="Dashboard port"),
+    reload: bool = typer.Option(False, "--reload", help="Auto-reload on changes"),
+):
+    app = get_app(Path(data))
+    uvicorn.run(app, host="0.0.0.0", port=port, reload=reload)
+
+
+if __name__ == "__main__":
+    cli()

--- a/scripts/handloom-scrape/import_to_persons.py
+++ b/scripts/handloom-scrape/import_to_persons.py
@@ -230,7 +230,7 @@ def validate(
     data: str = typer.Option("./data", "--data", "-d", help="Scrape data directory"),
 ):
     """Validate approved records without importing."""
-    run.callback(data=data, api_url="", api_key="", dry_run=True, max_records=0)
+    run(data=data, api_url="", api_key="", dry_run=True, max_records=0)
 
 
 if __name__ == "__main__":

--- a/scripts/handloom-scrape/import_to_persons.py
+++ b/scripts/handloom-scrape/import_to_persons.py
@@ -1,0 +1,237 @@
+"""
+Import verified weaver records from scrape data into Medusa Persons API.
+
+Reads approved records from data/verified/approved.jsonl, maps them to the
+Persons module schema, and creates/updates them via the Medusa admin API.
+
+Usage:
+    python import_to_persons.py --data ./data --api-url https://admin.jyt.com
+    python import_to_persons.py --data ./data --api-url http://localhost:9000 --dry-run
+    python import_to_persons.py --help
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import Optional
+
+import httpx
+import typer
+from rich.console import Console
+from rich.progress import Progress, BarColumn, TextColumn, TimeElapsedColumn
+from rich.table import Table
+
+cli = typer.Typer()
+console = Console()
+
+DATA_DIR = Path("data")
+BATCH_SIZE = 50  # Persons per API batch request
+
+
+def load_approved_records(data_dir: Path) -> list[dict]:
+    ver_path = data_dir / "verified" / "approved.jsonl"
+    if not ver_path.exists():
+        console.print("[yellow]No approved records found[/yellow]")
+        return []
+    records = []
+    for line in ver_path.read_text().splitlines():
+        if line.strip():
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return records
+
+
+def map_weaver_to_person(weaver: dict) -> dict:
+    """Map census weaver record to Person API payload."""
+    name = (weaver.get("name") or "").strip()
+    name_parts = name.split(" ", 1)
+    first_name = name_parts[0] if name_parts else name
+    last_name = name_parts[1] if len(name_parts) > 1 else ""
+
+    person = {
+        "first_name": first_name,
+        "last_name": last_name,
+        "state": "Onboarding",
+        "public_metadata": {
+            "source": "census_portal",
+            "census_id": weaver.get("census_id"),
+            "survey_date": weaver.get("survey_date"),
+            "age": weaver.get("age"),
+            "gender": weaver.get("gender"),
+            "education": weaver.get("education"),
+            "religion": weaver.get("religion"),
+            "social_group": weaver.get("social_group"),
+            "head_of_household": weaver.get("head_of_household"),
+            "relation_to_head": weaver.get("relation_to_head"),
+            "rural_urban": weaver.get("rural_urban"),
+            "household_size": weaver.get("household_size"),
+            "monthly_income": weaver.get("monthly_income"),
+            "handloom_income": weaver.get("handloom_income"),
+            "household_type": weaver.get("household_type"),
+            "dwelling_type": weaver.get("dwelling_type"),
+            "ownership_type": weaver.get("ownership_type"),
+            "electricity": weaver.get("electricity"),
+            "aadhaar_issued": weaver.get("aadhaar_issued"),
+            "own_looms": weaver.get("own_looms"),
+            "total_looms_owned": weaver.get("total_looms_owned"),
+            "pit_loom_count": weaver.get("pit_loom_count"),
+            "frame_loom_count": weaver.get("frame_loom_count"),
+            "loin_loom_count": weaver.get("loin_loom_count"),
+            "other_loom_count": weaver.get("other_loom_count"),
+            "avg_production_meters": weaver.get("avg_production_meters"),
+            "intricacy_level": weaver.get("intricacy_level"),
+            "natural_dye_used": weaver.get("natural_dye_used"),
+            "yarn_consumption": weaver.get("yarn_consumption"),
+            "dye_consumption_kg": weaver.get("dye_consumption_kg"),
+            "chemical_consumption_kg": weaver.get("chemical_consumption_kg"),
+            "sells_local_market": weaver.get("sells_local_market"),
+            "sells_master_weaver": weaver.get("sells_master_weaver"),
+            "sells_cooperative": weaver.get("sells_cooperative"),
+            "sells_ecommerce": weaver.get("sells_ecommerce"),
+            "support_requirements": weaver.get("support_requirements"),
+            "family_weavers": weaver.get("family_weavers"),
+            "family_allied": weaver.get("family_allied"),
+            "profile_photo_url": weaver.get("profile_photo_url"),
+            "aadhaar_photo_url": weaver.get("aadhaar_photo_url"),
+        },
+    }
+
+    addresses = []
+    street_parts = []
+    if weaver.get("house_no"):
+        street_parts.append(weaver["house_no"])
+    address = {
+        "street": ", ".join(street_parts) if street_parts else None,
+        "city": weaver.get("village") or weaver.get("block"),
+        "state": weaver.get("district") or weaver.get("state"),
+        "postal_code": weaver.get("pin_code"),
+        "country": "India",
+        "latitude": weaver.get("latitude"),
+        "longitude": weaver.get("longitude"),
+    }
+    if address["street"] or address["city"]:
+        addresses.append(address)
+
+    if addresses:
+        person["addresses"] = addresses
+
+    contact_details = []
+    phone = weaver.get("mobile")
+    if phone and phone != "91XXXXXXXXXX":
+        contact_details.append({"phone_number": phone, "type": "mobile"})
+
+    if contact_details:
+        person["contact_details"] = contact_details
+
+    tags = []
+    if weaver.get("own_looms") is True:
+        tags.append({"name": "loom-owner"})
+    if weaver.get("own_looms") is False:
+        tags.append({"name": "contract-weaver"})
+    if weaver.get("natural_dye_used"):
+        tags.append({"name": "natural-dye"})
+    if weaver.get("social_group"):
+        tags.append({"name": weaver["social_group"].lower().replace(" ", "-")})
+    if weaver.get("religion"):
+        tags.append({"name": weaver["religion"].lower().replace(" ", "-")})
+    if weaver.get("gender"):
+        tags.append({"name": weaver["gender"].lower()})
+    if weaver.get("state"):
+        tags.append({"name": f"state-{weaver['state'].lower().replace(' ', '-')}"})
+
+    if tags:
+        person["tags"] = tags
+
+    return person
+
+
+async def import_persons(
+    api_url: str,
+    api_key: str,
+    persons: list[dict],
+    dry_run: bool = False,
+) -> tuple[int, int]:
+    created = 0
+    errors = 0
+
+    headers = {
+        "Content-Type": "application/json",
+        "x-api-key": api_key,
+    }
+    if not api_key.startswith("Bearer "):
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    async with httpx.AsyncClient(timeout=60.0, headers=headers) as client:
+        for i, person in enumerate(persons):
+            if dry_run:
+                console.print(f"[dim]DRY RUN: Would create person {person['first_name']} {person['last_name']}[/dim]")
+                continue
+
+            try:
+                resp = await client.post(f"{api_url}/admin/persons", json=person)
+                if resp.status_code in (200, 201):
+                    created += 1
+                else:
+                    console.print(f"[red]Error creating person: {resp.status_code} {resp.text[:200]}[/red]")
+                    errors += 1
+            except httpx.RequestError as e:
+                console.print(f"[red]Request failed: {e}[/red]")
+                errors += 1
+
+    return created, errors
+
+
+@cli.command()
+def run(
+    data: str = typer.Option("./data", "--data", "-d", help="Scrape data directory"),
+    api_url: str = typer.Option("http://localhost:9000", "--api-url", envvar="MEDUSA_ADMIN_URL", help="Medusa admin API URL"),
+    api_key: str = typer.Option("", "--api-key", envvar="MEDUSA_API_KEY", help="Medusa API key"),
+    dry_run: bool = typer.Option(False, "--dry-run", "-n", help="Dry run (validate only, no API calls)"),
+    max_records: int = typer.Option(0, "--max", "-m", help="Max records to import"),
+):
+    records = load_approved_records(Path(data))
+    if not records:
+        raise typer.Exit(1)
+
+    if max_records > 0:
+        records = records[:max_records]
+
+    console.print(f"[bold]Importing {len(records)} approved weaver records[/bold]")
+    console.print(f"  API URL: {api_url}")
+    console.print(f"  Dry Run: {dry_run}")
+
+    persons = []
+    for r in records:
+        try:
+            persons.append(map_weaver_to_person(r))
+        except Exception as e:
+            console.print(f"[red]Error mapping record {r.get('census_id')}: {e}[/red]")
+
+    console.print(f"  Mapped {len(persons)} persons for import")
+
+    import asyncio
+
+    created, errors = asyncio.run(import_persons(api_url, api_key, persons, dry_run))
+
+    table = Table(title="Import Results")
+    table.add_column("Metric", style="cyan")
+    table.add_column("Value", style="green")
+    table.add_row("Total Records", str(len(records)))
+    table.add_row("Mapped to Persons", str(len(persons)))
+    table.add_row("Created", str(created))
+    table.add_row("Errors", str(errors))
+    console.print(table)
+
+
+@cli.command()
+def validate(
+    data: str = typer.Option("./data", "--data", "-d", help="Scrape data directory"),
+):
+    """Validate approved records without importing."""
+    run.callback(data=data, api_url="", api_key="", dry_run=True, max_records=0)
+
+
+if __name__ == "__main__":
+    cli()

--- a/scripts/handloom-scrape/parser.py
+++ b/scripts/handloom-scrape/parser.py
@@ -1,0 +1,425 @@
+from bs4 import BeautifulSoup
+from typing import Optional
+from pydantic import BaseModel
+import re
+
+
+class WeaverFamilyMember(BaseModel):
+    name: str
+    father_husband_name: Optional[str] = None
+    age: Optional[int] = None
+    gender: Optional[str] = None
+    relationship: Optional[str] = None
+    education: Optional[str] = None
+    employment_status: Optional[str] = None
+    nature_of_engagement: Optional[str] = None
+    days_worked: Optional[int] = None
+    mobile: Optional[str] = None
+    aadhaar_issued: Optional[str] = None
+    bank_account: Optional[str] = None
+    account_number: Optional[str] = None
+    ifsc: Optional[str] = None
+    profile_photo_url: Optional[str] = None
+    type: Optional[str] = None  # "weaver" or "allied"
+    allied_activities: Optional[list[str]] = None  # for allied workers
+
+
+class WeaverRecord(BaseModel):
+    census_id: int
+    name: str
+    head_of_household: Optional[str] = None
+    relation_to_head: Optional[str] = None
+    gender: Optional[str] = None
+    age: Optional[int] = None
+    education: Optional[str] = None
+    religion: Optional[str] = None
+    social_group: Optional[str] = None
+    mobile: Optional[str] = None
+    aadhaar_issued: Optional[bool] = None
+
+    latitude: Optional[float] = None
+    longitude: Optional[float] = None
+    village: Optional[str] = None
+    block: Optional[str] = None
+    district: Optional[str] = None
+    state: Optional[str] = None
+
+    rural_urban: Optional[str] = None
+    house_no: Optional[str] = None
+    pin_code: Optional[str] = None
+    household_size: Optional[int] = None
+    household_type: Optional[str] = None
+    monthly_income: Optional[str] = None
+    handloom_income: Optional[str] = None
+    dwelling_type: Optional[str] = None
+    ownership_type: Optional[str] = None
+    electricity: Optional[bool] = None
+
+    # Loom details
+    own_looms: Optional[bool] = None
+    total_looms_owned: Optional[int] = None
+    pit_loom_count: Optional[int] = 0
+    frame_loom_count: Optional[int] = 0
+    loin_loom_count: Optional[int] = 0
+    other_loom_count: Optional[int] = 0
+
+    # Production
+    yarn_consumption: Optional[dict] = None
+    dye_consumption_kg: Optional[float] = None
+    chemical_consumption_kg: Optional[float] = None
+    avg_production_meters: Optional[float] = None
+    intricacy_level: Optional[str] = None
+    natural_dye_used: Optional[bool] = None
+
+    # Sales & marketing
+    sells_local_market: Optional[bool] = None
+    sells_master_weaver: Optional[bool] = None
+    sells_cooperative: Optional[bool] = None
+    sells_ecommerce: Optional[bool] = None
+    support_requirements: Optional[list[str]] = None
+
+    # Family weavers
+    family_weavers: list[WeaverFamilyMember] = []
+    family_allied: list[WeaverFamilyMember] = []
+
+    # Photos
+    profile_photo_url: Optional[str] = None
+    aadhaar_photo_url: Optional[str] = None
+
+    survey_date: Optional[str] = None
+
+
+def parse_value(cell) -> str:
+    text = cell.get_text(strip=True)
+    return text
+
+
+def clean_phone(phone: str) -> Optional[str]:
+    cleaned = re.sub(r'\D', '', phone)
+    if len(cleaned) == 10:
+        return cleaned
+    if len(cleaned) > 10 and cleaned.startswith('91') and len(cleaned) == 12:
+        return cleaned[2:]
+    if len(cleaned) > 10 and cleaned.startswith('0'):
+        return cleaned[1:]
+    return cleaned if cleaned else None
+
+
+def parse_weaver_page(html: str, census_id: int) -> Optional[WeaverRecord]:
+    soup = BeautifulSoup(html, 'lxml')
+
+    record = WeaverRecord(census_id=census_id, name="")
+
+    td_pairs = {}
+    for tr in soup.find_all('tr'):
+        tds = tr.find_all('td')
+        if len(tds) >= 3:
+            label = tds[0].get_text(strip=True)
+            question = tds[1].get_text(strip=True)
+            value = tds[2].get_text(strip=True) if len(tds) > 2 else ""
+            td_pairs[label] = value
+        elif len(tds) == 2:
+            label = tds[0].get_text(strip=True)
+            value = tds[1].get_text(strip=True)
+            td_pairs[label] = value
+
+    # Simple key-value pairs table (Name, Lat/Lng, Village, etc.)
+    key_table = {}
+    for table in soup.find_all('table'):
+        rows = table.find_all('tr')
+        if not rows:
+            continue
+        for row in rows:
+            cells = row.find_all('td')
+            if len(cells) == 2:
+                key = cells[0].get_text(strip=True)
+                val = cells[1].get_text(strip=True)
+                if key in ('Name', 'Start Time', 'Latitude', 'Longitude',
+                           'Village', 'Block', 'District', 'State'):
+                    key_table[key] = val
+
+    record.name = key_table.get('Name', '')
+    record.latitude = _parse_float(key_table.get('Latitude'))
+    record.longitude = _parse_float(key_table.get('Longitude'))
+    record.village = key_table.get('Village')
+    record.block = key_table.get('Block')
+    record.district = key_table.get('District')
+    record.state = key_table.get('State')
+    record.survey_date = key_table.get('Start Time')
+
+    # Section 1: Respondent info
+    record.head_of_household = td_pairs.get('1.2')
+    record.relation_to_head = td_pairs.get('1.3')
+    record.gender = td_pairs.get("1.4")
+    record.age = _parse_int(td_pairs.get("1.5"))
+    record.education = td_pairs.get("1.6")
+    record.aadhaar_issued = _parse_bool(td_pairs.get("1.8"))
+
+    raw_phone = td_pairs.get("1.9") or ""
+    if raw_phone and raw_phone not in ('', '91XXXXXXXXXX'):
+        record.mobile = clean_phone(raw_phone)
+
+    # Section 2: Address
+    record.rural_urban = td_pairs.get("2.1")
+    record.house_no = td_pairs.get("2.2")
+    record.pin_code = td_pairs.get("2.6")
+
+    # Section 3: Household characteristics
+    record.household_size = _parse_int(td_pairs.get("3.1"))
+    record.religion = td_pairs.get("3.2")
+    record.social_group = td_pairs.get("3.3")
+    record.ownership_type = td_pairs.get("3.5")
+    record.dwelling_type = td_pairs.get("3.6")
+    record.electricity = _parse_bool(td_pairs.get("3.8"))
+    record.monthly_income = td_pairs.get("3.9.1")
+    record.handloom_income = td_pairs.get("3.9.2")
+
+    # Section 4: Household type
+    record.household_type = td_pairs.get("4.1")
+
+    # Section 5: Loom details (parse from loom table)
+    _parse_loom_details(soup, record)
+
+    # Section 6: Production
+    record.avg_production_meters = _parse_float(td_pairs.get("Meters"))
+    record.intricacy_level = td_pairs.get("6.4")
+    record.dye_consumption_kg = _parse_float(td_pairs.get("6.8"))
+    record.chemical_consumption_kg = _parse_float(td_pairs.get("6.9"))
+
+    dyetype_6_3_2 = td_pairs.get("6.3.2")
+    record.natural_dye_used = (dyetype_6_3_2 == "Yes")
+
+    # Parse yarn consumption
+    record.yarn_consumption = _parse_yarn_consumption(td_pairs)
+
+    # Section 6: Sales channels
+    record.sells_local_market = _parse_bool(td_pairs.get("6.6.1"))
+    record.sells_master_weaver = _parse_bool(td_pairs.get("6.6.2"))
+    record.sells_cooperative = _parse_bool(td_pairs.get("6.6.3"))
+    record.sells_ecommerce = _parse_bool(td_pairs.get("6.6.7"))
+
+    # Section 6 input sources
+    _parse_input_sources(soup, record)
+
+    # Section 7: Support requirements
+    record.support_requirements = _parse_support_requirements(td_pairs)
+
+    # Section 8: Family members
+    _parse_family_members(soup, record)
+
+    # Photo
+    _parse_photos(soup, record)
+
+    return record
+
+
+def _parse_float(val: Optional[str]) -> Optional[float]:
+    if not val or not val.strip():
+        return None
+    try:
+        return float(val.strip())
+    except ValueError:
+        return None
+
+
+def _parse_int(val: Optional[str]) -> Optional[int]:
+    if not val or not val.strip():
+        return None
+    try:
+        return int(val.strip())
+    except ValueError:
+        return None
+
+
+def _parse_bool(val: Optional[str]) -> Optional[bool]:
+    if not val or not val.strip():
+        return None
+    v = val.strip().lower()
+    return v == 'yes'
+
+
+def _parse_yarn_consumption(td_pairs: dict) -> dict:
+    yarn = {}
+    for key in ('6.7.1', '6.7.2', '6.7.3', '6.7.4', '6.7.5', '6.7.6', '6.7.7',
+                '6.7.8', '6.7.9', '6.7.10', '6.7.11', '6.7.12', '6.7.13',
+                '6.7.14', '6.7.15', '6.7.16'):
+        val = td_pairs.get(key)
+        if val and val.strip():
+            yarn[key] = val.strip()
+    return yarn if yarn else None
+
+
+def _parse_loom_details(soup: BeautifulSoup, record: WeaverRecord):
+    loom_tables = soup.find_all('table')
+    for table in loom_tables:
+        header = table.find_previous(['h4', 'h5'])
+        if header and 'loom' not in header.get_text(strip=True).lower():
+            continue
+        rows = table.find_all('tr')
+        for row in rows:
+            cells = row.find_all(['td', 'th'])
+            texts = [c.get_text(strip=True) for c in cells]
+
+            if not texts:
+                continue
+
+            combined = " ".join(texts).lower()
+
+            # Check for "own looms" row
+            if 'pit loom with' in combined or 'other pit looms' in combined:
+                if len(texts) >= 5:
+                    owns = texts[3].lower()
+                    count = _parse_int(texts[4])
+                    if owns == 'yes':
+                        record.total_looms_owned = (record.total_looms_owned or 0) + (count or 0)
+                        record.pit_loom_count = (record.pit_loom_count or 0) + (count or 0)
+            elif 'frame loom with' in combined or 'other frame looms' in combined:
+                if len(texts) >= 5:
+                    owns = texts[3].lower()
+                    count = _parse_int(texts[4])
+                    if owns == 'yes':
+                        record.total_looms_owned = (record.total_looms_owned or 0) + (count or 0)
+                        record.frame_loom_count = (record.frame_loom_count or 0) + (count or 0)
+            elif 'loin looms' in combined:
+                if len(texts) >= 5:
+                    owns = texts[3].lower()
+                    count = _parse_int(texts[4])
+                    if owns == 'yes':
+                        record.total_looms_owned = (record.total_looms_owned or 0) + (count or 0)
+                        record.loin_loom_count = (record.loin_loom_count or 0) + (count or 0)
+            elif combined == 'others' or combined.startswith('others\t'):
+                if len(texts) >= 5:
+                    owns = texts[3].lower()
+                    count = _parse_int(texts[4])
+                    if owns == 'yes':
+                        record.total_looms_owned = (record.total_looms_owned or 0) + (count or 0)
+                        record.other_loom_count = (record.other_loom_count or 0) + (count or 0)
+
+    if record.total_looms_owned and record.total_looms_owned > 0:
+        record.own_looms = True
+    elif record.total_looms_owned == 0:
+        record.own_looms = False
+
+
+def _parse_input_sources(soup: BeautifulSoup, record: WeaverRecord):
+    pass  # Complex table parsing, can add later
+
+
+def _parse_support_requirements(td_pairs: dict) -> list[str]:
+    requirements = []
+    support_map = {
+        "7.3.1": "Marketing Support",
+        "7.3.2": "Management Training",
+        "7.3.3": "Technical Training",
+        "7.3.4": "Design Support",
+        "7.3.5": "Technology Upgradation",
+        "7.3.6": "Raw Material Support",
+        "7.3.7": "Credit Support",
+        "7.3.8": "Calendaring",
+        "7.3.9": "Dyeing",
+    }
+    for key, label in support_map.items():
+        val = td_pairs.get(key)
+        if val and val.strip().lower() == 'yes':
+            requirements.append(label)
+    return requirements if requirements else None
+
+
+def _parse_family_members(soup: BeautifulSoup, record: WeaverRecord):
+    tables = soup.find_all('table')
+    for table in tables:
+        prev = table.find_previous(['h4', 'h5'])
+        if not prev:
+            continue
+        heading = prev.get_text(strip=True)
+
+        if 'Profile of Family Members engaged in Weaving' in heading:
+            rows = table.find_all('tr')
+            member = WeaverFamilyMember(name="")
+            member.type = "weaver"
+            for row in rows:
+                cells = row.find_all('td')
+                if len(cells) < 3:
+                    continue
+                label = cells[0].get_text(strip=True)
+                key = cells[1].get_text(strip=True) if len(cells) >= 3 else ""
+                value = cells[2].get_text(strip=True) if len(cells) >= 3 else ""
+
+                if label == "8.3.2":
+                    member.name = value
+                elif label == "8.3.3":
+                    member.father_husband_name = value
+                elif label == "8.3.11":
+                    member.age = _parse_int(value)
+                elif label == "8.3.12":
+                    member.gender = value
+                elif label == "8.3.14":
+                    member.mobile = clean_phone(value)
+                elif label == "8.3.15":
+                    member.education = value
+                elif label == "8.3.16":
+                    member.employment_status = value
+                elif label == "8.3.17":
+                    member.nature_of_engagement = value
+                elif label == "8.3.18":
+                    member.days_worked = _parse_int(value)
+                elif label == "8.3.19":
+                    member.bank_account = value
+                elif label == "8.3.20":
+                    member.account_number = value
+                elif label == "8.3.21":
+                    member.ifsc = value
+
+            if member.name:
+                record.family_weavers.append(member)
+
+        elif 'Profile of Family Members engaged in Allied activities' in heading:
+            rows = table.find_all('tr')
+            member = WeaverFamilyMember(name="")
+            member.type = "allied"
+            for row in rows:
+                cells = row.find_all('td')
+                if len(cells) < 3:
+                    continue
+                label = cells[0].get_text(strip=True)
+                value = cells[2].get_text(strip=True) if len(cells) >= 3 else ""
+
+                if label == "8.4.2":
+                    member.name = value
+                elif label == "8.4.3":
+                    member.father_husband_name = value
+                elif label == "8.4.11":
+                    member.age = _parse_int(value)
+                elif label == "8.4.12":
+                    member.gender = value
+                elif label == "8.4.14":
+                    member.mobile = clean_phone(value)
+                elif label == "8.4.15":
+                    member.education = value
+                elif label == "8.4.16":
+                    member.employment_status = value
+                elif label == "8.4.17":
+                    member.nature_of_engagement = value
+                elif label == "8.4.18":
+                    member.days_worked = _parse_int(value)
+                elif label == "8.4.19":
+                    member.bank_account = value
+                elif label == "8.4.20":
+                    member.account_number = value
+                elif label == "8.4.21":
+                    member.ifsc = value
+                elif label == "8.4.22":
+                    member.type = "allied"
+
+            if member.name:
+                record.family_allied.append(member)
+
+
+def _parse_photos(soup: BeautifulSoup, record: WeaverRecord):
+    imgs = soup.find_all('img')
+    for img in imgs:
+        src = img.get('src', '')
+        if 'Profile Photo' in src and not record.profile_photo_url:
+            record.profile_photo_url = src
+        elif 'Front Image' in src and not record.aadhaar_photo_url:
+            record.aadhaar_photo_url = src

--- a/scripts/handloom-scrape/requirements.txt
+++ b/scripts/handloom-scrape/requirements.txt
@@ -1,0 +1,7 @@
+httpx>=0.28.0
+beautifulsoup4>=4.12.0
+lxml>=5.0.0
+pydantic>=2.0.0
+typer>=0.12.0
+rich>=13.0.0
+python-dotenv>=1.0.0

--- a/scripts/handloom-scrape/requirements.txt
+++ b/scripts/handloom-scrape/requirements.txt
@@ -5,3 +5,5 @@ pydantic>=2.0.0
 typer>=0.12.0
 rich>=13.0.0
 python-dotenv>=1.0.0
+fastapi>=0.110.0
+uvicorn>=0.29.0

--- a/scripts/handloom-scrape/scraper.py
+++ b/scripts/handloom-scrape/scraper.py
@@ -92,14 +92,13 @@ class SessionManager:
         self.cookies: dict = {}
         self._lock = asyncio.Lock()
 
-    async def ensure_session(self, client: AsyncClient) -> bool:
+    async def ensure_session(self, client: AsyncClient, force: bool = False) -> bool:
         async with self._lock:
-            if self._check_session_valid(client):
+            if not force and self.cookies:
                 return True
+            # force re-login (session expired) or first login
+            self.cookies = {}
             return await self._login(client)
-
-    def _check_session_valid(self, client: AsyncClient) -> bool:
-        return bool(self.cookies)
 
     async def _login(self, client: AsyncClient) -> bool:
         login_data = {
@@ -144,8 +143,12 @@ async def fetch_weaver(
                     timeout=30.0,
                 )
 
-                if resp.status_code == 302:
-                    await session.ensure_session(client)
+                # Session expired: portal redirects (or 302s) to the login page.
+                # Force a re-login and retry rather than silently parsing the
+                # login HTML into an empty record.
+                if resp.status_code == 302 or "login" in resp.url.path.lower():
+                    await session.ensure_session(client, force=True)
+                    await asyncio.sleep(RETRY_DELAY * (attempt + 1))
                     continue
 
                 if resp.status_code != 200:
@@ -348,7 +351,7 @@ def resume(
     username: str = typer.Option("", "--username", "-u", envvar="CENSUS_USERNAME"),
     password: str = typer.Option("", "--password", "-p", envvar="CENSUS_PASSWORD"),
 ):
-    run.callback(
+    run(
         start=15000, end=3850000, output=output, concurrent=concurrent,
         username=username, password=password, resume=True, stats_only=False, limit=0,
     )

--- a/scripts/handloom-scrape/scraper.py
+++ b/scripts/handloom-scrape/scraper.py
@@ -1,0 +1,423 @@
+"""
+Handloom Weaver Census Scraper
+
+Scrapes all ~3.5M weaver records from the Census Portal (tricorniotec.com/webapp)
+into local JSONL files with checkpointing, retry, and failure handling.
+
+Usage:
+    python scraper.py --start 15000 --end 3850000 --output ./data --concurrent 100
+    python scraper.py --resume --output ./data                # Resume from checkpoint
+    python scraper.py --stats --output ./data                  # Show scrape stats
+"""
+
+import asyncio
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import httpx
+from httpx import AsyncClient, Response
+from rich.console import Console
+from rich.progress import (
+    BarColumn,
+    Progress,
+    TaskProgressColumn,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
+from rich.table import Table
+from rich.live import Live
+from rich.layout import Layout
+from rich.panel import Panel
+import typer
+
+from parser import parse_weaver_page, WeaverRecord
+
+app = typer.Typer()
+console = Console()
+
+BASE_URL = "https://tricorniotec.com/webapp"
+LOGIN_URL = f"{BASE_URL}/portal/login"
+DASHBOARD_URL = f"{BASE_URL}/ministry/dashboard"
+WEAVER_URL = f"{BASE_URL}/Master/weaverInfo"
+
+BATCH_SIZE = 1000
+MAX_RETRIES = 3
+RETRY_DELAY = 2
+
+DATA_DIR = Path("data")
+
+
+class ScrapeStats:
+    def __init__(self):
+        self.processed = 0
+        self.success = 0
+        self.failed = 0
+        self.empty = 0
+        self.retried = 0
+        self.start_time = time.time()
+        self.last_batch_time = time.time()
+
+    @property
+    def elapsed(self) -> float:
+        return time.time() - self.start_time
+
+    @property
+    def rate(self) -> float:
+        elapsed = self.elapsed
+        return self.success / elapsed if elapsed > 0 else 0
+
+    def summary(self) -> dict:
+        return {
+            "processed": self.processed,
+            "success": self.success,
+            "failed": self.failed,
+            "empty": self.empty,
+            "retried": self.retried,
+            "elapsed_seconds": self.elapsed,
+            "rate_per_second": round(self.rate, 2),
+            "last_updated": datetime.now(timezone.utc).isoformat(),
+        }
+
+
+class SessionManager:
+    def __init__(self, username: str, password: str):
+        self.username = username
+        self.password = password
+        self.cookies: dict = {}
+        self._lock = asyncio.Lock()
+
+    async def ensure_session(self, client: AsyncClient) -> bool:
+        async with self._lock:
+            if self._check_session_valid(client):
+                return True
+            return await self._login(client)
+
+    def _check_session_valid(self, client: AsyncClient) -> bool:
+        return bool(self.cookies)
+
+    async def _login(self, client: AsyncClient) -> bool:
+        login_data = {
+            "username": self.username,
+            "password": self.password,
+        }
+        headers = {
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        login_resp = await client.post(
+            LOGIN_URL, data=login_data, headers=headers, follow_redirects=True
+        )
+        if login_resp.status_code == 200 and "dashboard" in login_resp.url.path:
+            self.cookies = dict(login_resp.cookies)
+            console.print("[green]Login successful[/green]")
+            return True
+        console.print(f"[red]Login failed: {login_resp.status_code}[/red]")
+        return False
+
+    def get_cookie_header(self) -> dict:
+        ci_session = self.cookies.get("ci_session", "")
+        return {"Cookie": f"ci_session={ci_session}"}
+
+
+async def fetch_weaver(
+    client: AsyncClient, census_id: int, session: SessionManager, sem: asyncio.Semaphore
+) -> Optional[WeaverRecord]:
+    async with sem:
+        for attempt in range(MAX_RETRIES):
+            try:
+                await session.ensure_session(client)
+
+                resp = await client.get(
+                    WEAVER_URL,
+                    params={"Id": census_id},
+                    headers={
+                        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+                        **session.get_cookie_header(),
+                    },
+                    follow_redirects=True,
+                    timeout=30.0,
+                )
+
+                if resp.status_code == 302:
+                    await session.ensure_session(client)
+                    continue
+
+                if resp.status_code != 200:
+                    await asyncio.sleep(RETRY_DELAY * (attempt + 1))
+                    continue
+
+                if len(resp.text) < 1000:
+                    if attempt < MAX_RETRIES - 1:
+                        await asyncio.sleep(RETRY_DELAY * (attempt + 1))
+                        continue
+                    return None
+
+                record = parse_weaver_page(resp.text, census_id)
+                return record
+
+            except (httpx.TimeoutException, httpx.HTTPStatusError,
+                    httpx.ConnectError, httpx.RemoteProtocolError) as e:
+                if attempt < MAX_RETRIES - 1:
+                    await asyncio.sleep(RETRY_DELAY * (attempt + 1))
+                    continue
+                return None
+
+        return None
+
+
+async def process_batch(
+    client: AsyncClient,
+    ids: list[int],
+    session: SessionManager,
+    sem: asyncio.Semaphore,
+    stats: ScrapeStats,
+    output_dir: Path,
+    batch_num: int,
+) -> tuple[int, int, int]:
+    results = await asyncio.gather(
+        *[fetch_weaver(client, cid, session, sem) for cid in ids],
+        return_exceptions=True,
+    )
+
+    records = []
+    failures = []
+    success_count = 0
+    empty_count = 0
+    fail_count = 0
+
+    for cid, result in zip(ids, results):
+        if isinstance(result, WeaverRecord) and result.name:
+            records.append(result.model_dump(mode="json"))
+            success_count += 1
+        elif isinstance(result, WeaverRecord) and not result.name:
+            records.append(result.model_dump(mode="json"))
+            empty_count += 1
+        else:
+            failures.append({"id": cid, "error": str(result) if result else "timeout/empty"})
+            fail_count += 1
+
+    if records:
+        batch_file = output_dir / "batches" / f"{batch_num:06d}.jsonl"
+        batch_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(batch_file, "w") as f:
+            for r in records:
+                f.write(json.dumps(r, default=str) + "\n")
+
+    if failures:
+        fail_file = output_dir / "failures" / f"{batch_num:06d}.json"
+        fail_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(fail_file, "w") as f:
+            json.dump(failures, f, indent=2)
+
+    stats.processed += len(ids)
+    stats.success += success_count
+    stats.empty += empty_count
+    stats.failed += fail_count
+
+    return success_count, fail_count, empty_count
+
+
+def save_checkpoint(output_dir: Path, last_id: int, stats: ScrapeStats):
+    cp = output_dir / "checkpoint.json"
+    cp.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "last_id": last_id,
+        "stats": stats.summary(),
+    }
+    with open(cp, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def load_checkpoint(output_dir: Path) -> Optional[int]:
+    cp = output_dir / "checkpoint.json"
+    if cp.exists():
+        data = json.loads(cp.read_text())
+        return data.get("last_id")
+    return None
+
+
+@app.command()
+def run(
+    start: int = typer.Option(15000, "--start", "-s", help="Starting census ID"),
+    end: int = typer.Option(3850000, "--end", "-e", help="Ending census ID"),
+    output: str = typer.Option("./data", "--output", "-o", help="Output directory"),
+    concurrent: int = typer.Option(100, "--concurrent", "-c", help="Concurrent requests"),
+    username: str = typer.Option("", "--username", "-u", envvar="CENSUS_USERNAME", help="Census portal username"),
+    password: str = typer.Option("", "--password", "-p", envvar="CENSUS_PASSWORD", help="Census portal password"),
+    resume: bool = typer.Option(False, "--resume", "-r", help="Resume from checkpoint"),
+    stats_only: bool = typer.Option(False, "--stats", help="Show stats and exit"),
+    limit: int = typer.Option(0, "--limit", "-l", help="Limit total IDs to scrape (for testing)"),
+):
+    output_dir = Path(output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "batches").mkdir(parents=True, exist_ok=True)
+    (output_dir / "failures").mkdir(parents=True, exist_ok=True)
+
+    if stats_only:
+        show_stats(output_dir)
+        raise typer.Exit()
+
+    if not username or not password:
+        console.print("[red]Error: CENSUS_USERNAME and CENSUS_PASSWORD must be set[/red]")
+        console.print("  Set via --username/--password flags or CENSUS_USERNAME/CENSUS_PASSWORD env vars")
+        raise typer.Exit(1)
+
+    if resume:
+        checkpoint = load_checkpoint(output_dir)
+        if checkpoint:
+            start = checkpoint + 1
+            console.print(f"[yellow]Resuming from ID {start}[/yellow]")
+        else:
+            console.print("[yellow]No checkpoint found, starting from --start[/yellow]")
+
+    ids_to_scrape = list(range(start, end + 1))
+    if limit > 0:
+        ids_to_scrape = ids_to_scrape[:limit]
+
+    total = len(ids_to_scrape)
+    console.print(f"[bold]Scraping {total} weaver IDs[/bold]")
+    console.print(f"  Range: {ids_to_scrape[0]} - {ids_to_scrape[-1]}")
+    console.print(f"  Concurrent: {concurrent}")
+    console.print(f"  Batch size: {BATCH_SIZE}")
+    console.print(f"  Output: {output_dir.resolve()}")
+    console.print()
+
+    stats = ScrapeStats()
+    session = SessionManager(username, password)
+    sem = asyncio.Semaphore(concurrent)
+
+    batches = [ids_to_scrape[i:i + BATCH_SIZE] for i in range(0, len(ids_to_scrape), BATCH_SIZE)]
+
+    progress = Progress(
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        TaskProgressColumn(),
+        TextColumn("[bold]{task.completed}/{task.total}[/bold]"),
+        TextColumn("•"),
+        TimeElapsedColumn(),
+        TimeRemainingColumn(),
+        TextColumn("• [cyan]{task.fields[rate]} IDs/s[/cyan]"),
+        TextColumn("• [red]{task.fields[fails]} fails[/red]"),
+    )
+
+    async def run_scraper():
+        async with AsyncClient(
+            timeout=30.0,
+            limits=httpx.Limits(max_keepalive_connections=concurrent, max_connections=concurrent * 2),
+        ) as client:
+            task = progress.add_task(
+                "[cyan]Scraping weavers...[/cyan]",
+                total=len(batches),
+                rate="0.0",
+                fails="0",
+            )
+
+            with progress:
+                for i, batch_ids in enumerate(batches):
+                    s, f, e = await process_batch(
+                        client, batch_ids, session, sem, stats, output_dir, i + 1
+                    )
+
+                    progress.update(
+                        task,
+                        advance=1,
+                        rate=f"{stats.rate:.1f}",
+                        fails=str(stats.failed),
+                    )
+
+                    if (i + 1) % 10 == 0:
+                        save_checkpoint(output_dir, batch_ids[-1], stats)
+
+            save_checkpoint(output_dir, batches[-1][-1], stats)
+
+        print_summary(stats)
+
+    asyncio.run(run_scraper())
+
+
+@app.command()
+def resume(
+    output: str = typer.Option("./data", "--output", "-o"),
+    concurrent: int = typer.Option(100, "--concurrent", "-c"),
+    username: str = typer.Option("", "--username", "-u", envvar="CENSUS_USERNAME"),
+    password: str = typer.Option("", "--password", "-p", envvar="CENSUS_PASSWORD"),
+):
+    run.callback(
+        start=15000, end=3850000, output=output, concurrent=concurrent,
+        username=username, password=password, resume=True, stats_only=False, limit=0,
+    )
+
+
+@app.command()
+def stats(
+    output: str = typer.Option("./data", "--output", "-o"),
+):
+    show_stats(Path(output))
+
+
+def show_stats(output_dir: Path):
+    cp = output_dir / "checkpoint.json"
+    if not cp.exists():
+        console.print("[red]No checkpoint found[/red]")
+        raise typer.Exit(1)
+
+    data = json.loads(cp.read_text())
+    stats = data.get("stats", {})
+    batches_dir = output_dir / "batches"
+    failures_dir = output_dir / "failures"
+
+    batch_count = len(list(batches_dir.glob("*.jsonl"))) if batches_dir.exists() else 0
+    fail_count = len(list(failures_dir.glob("*.json"))) if failures_dir.exists() else 0
+
+    total_records = 0
+    if batches_dir.exists():
+        for f in sorted(batches_dir.glob("*.jsonl")):
+            total_records += sum(1 for _ in f.read_text().splitlines() if _.strip())
+
+    total_failures = 0
+    if failures_dir.exists():
+        for f in sorted(failures_dir.glob("*.json")):
+            try:
+                total_failures += len(json.loads(f.read_text()))
+            except Exception:
+                total_failures += 1
+
+    table = Table(title="Scrape Statistics")
+    table.add_column("Metric", style="cyan")
+    table.add_column("Value", style="green")
+
+    table.add_row("Last ID", str(data.get("last_id", "?")))
+    table.add_row("Total Records Scraped", str(total_records))
+    table.add_row("Total Failures", str(total_failures))
+    table.add_row("Batch Files", str(batch_count))
+    table.add_row("Failure Files", str(fail_count))
+    table.add_row("Elapsed (s)", str(round(stats.get("elapsed_seconds", 0), 1)))
+    table.add_row("Rate (IDs/s)", str(stats.get("rate_per_second", 0)))
+    table.add_row("Last Updated", stats.get("last_updated", "?"))
+
+    console.print(table)
+
+
+def print_summary(stats: ScrapeStats):
+    table = Table(title="Scrape Complete")
+    table.add_column("Metric", style="cyan")
+    table.add_column("Value", style="green")
+
+    table.add_row("Total Processed", str(stats.processed))
+    table.add_row("Successful", str(stats.success))
+    table.add_row("Empty", str(stats.empty))
+    table.add_row("Failed", str(stats.failed))
+    table.add_row("Elapsed", f"{stats.elapsed:.1f}s")
+    table.add_row("Average Rate", f"{stats.rate:.1f} IDs/s")
+
+    console.print(table)
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
## What

Complete pipeline to scrape, verify, and import ~3.5M handloom weaver records from the Census Portal (tricorniotec.com/webapp) into the Persons module.

Closes #1028. Depends on #350.

## Files

```
scripts/handloom-scrape/
├── .env.example              # Credential template
├── requirements.txt          # Python deps (httpx, bs4, fastapi, etc.)
├── parser.py                 # HTML → 50+ field WeaverRecord extraction
├── scraper.py                # Async scraper with checkpointing + retry
├── dashboard/
│   └── server.py             # Verification dashboard (FastAPI + Tailwind)
└── import_to_persons.py      # Approved records → Medusa Persons API
```

## Architecture

```
Census Portal → scraper.py → data/batches/*.jsonl → dashboard → verify → import_to_persons.py → Medusa Person API
```

## Credentials Required

See `.env.example`:

| Variable | Source | Purpose |
|----------|--------|---------|
| `CENSUS_USERNAME` | Census Portal admin (tricorniotec.com) | Login for scraping |
| `CENSUS_PASSWORD` | Census Portal admin | Login for scraping |
| `MEDUSA_ADMIN_URL` | Your Medusa deployment | API endpoint for import |
| `MEDUSA_API_KEY` | Medusa admin settings | Auth for import API |

## Usage

```bash
# 1. Install deps
pip install -r scripts/handloom-scrape/requirements.txt

# 2. Scrape (will ask for credentials or use env vars)
python scripts/handloom-scrape/scraper.py run --start 15000 --end 3850000

# 3. Resume if interrupted
python scripts/handloom-scrape/scraper.py resume

# 4. Launch verification dashboard
python scripts/handloom-scrape/dashboard/server.py --data ./data --port 8080

# 5. Export approved → import to persons
python scripts/handloom-scrape/import_to_persons.py --dry-run
python scripts/handloom-scrape/import_to_persons.py
```

## Data Mapping

| Census Field | Person Field |
|-------------|--------------|
| Name | `first_name` + `last_name` |
| Mobile | `contact_details[].phone_number` (type: mobile) |
| Village, District, State, Pin, Lat/Lng | `addresses[]` |
| Everything else (demographics, looms, production, etc.) | `public_metadata` (JSON) |
| State, Gender, Loom ownership, etc. | `tags[]` (inferred) |

## Failure Handling

- Per-ID: 3 retries with exponential backoff (2s/4s/8s)
- Per-batch: checkpointing every 10 batches
- Dead letter: failed IDs → `data/failures/*.json`
- Resume: `--resume` flag picks up from last checkpoint
- Session: auto re-login on 302 redirect
