### PR TITLE
fix(social-posts): prevent unrecognized fields error by whitelisting payload

### DIFF
--- a/apps/backend/integration-tests/http/socials/social-post-api.spec.ts
+++ b/apps/backend/integration-tests/http/socials/social-post-api.spec.ts
@@ -15,6 +15,73 @@ describe("Social Post API", () => {
       });
 
       describe("Social Post API", () => {
+        it("should reject unrecognized top-level metadata fields", async () => {
+          const platformResponse = await api.post(
+            '/admin/social-platforms',
+            { name: 'Test SocialPlatform' },
+            adminHeaders
+          );
+          const platformId = platformResponse.data.socialPlatform.id;
+
+          const payload = {
+            name: "Test Post",
+            platform_id: platformId,
+            page_id: "fb_page_123",
+            ig_user_id: "ig_acct_456",
+            publish_target: "both",
+            auto_publish: true,
+            is_campaign: false,
+            product_ids: ["prod_1", "prod_2"],
+            interval_hours: 24,
+          };
+
+          try {
+            await api.post("/admin/social-posts", payload, adminHeaders);
+            fail("Should have rejected unrecognized top-level fields");
+          } catch (err: any) {
+            expect(err.response.status).toBe(400);
+            expect(err.response.data.message).toContain("Unrecognized fields");
+            expect(err.response.data.message).toContain("page_id");
+            expect(err.response.data.message).toContain("ig_user_id");
+            expect(err.response.data.message).toContain("publish_target");
+            expect(err.response.data.message).toContain("auto_publish");
+            expect(err.response.data.message).toContain("is_campaign");
+            expect(err.response.data.message).toContain("product_ids");
+            expect(err.response.data.message).toContain("interval_hours");
+          }
+        });
+
+        it("should accept metadata fields nested inside metadata object", async () => {
+          const platformResponse = await api.post(
+            '/admin/social-platforms',
+            { name: 'Test SocialPlatform' },
+            adminHeaders
+          );
+          const platformId = platformResponse.data.socialPlatform.id;
+
+          const payload = {
+            name: "Test Post with Metadata",
+            platform_id: platformId,
+            message: "Check out our new collection!",
+            media_urls: ["https://example.com/image.jpg"],
+            metadata: {
+              page_id: "fb_page_123",
+              ig_user_id: "ig_acct_456",
+              publish_target: "both",
+              auto_publish: true,
+            },
+          };
+
+          const response = await api.post("/admin/social-posts", payload, adminHeaders);
+          expect(response.status).toBe(201);
+          expect(response.data.socialPost).toBeDefined();
+          expect(response.data.socialPost.metadata).toBeDefined();
+          expect(response.data.socialPost.metadata.page_id).toBe("fb_page_123");
+          expect(response.data.socialPost.metadata.ig_user_id).toBe("ig_acct_456");
+          expect(response.data.socialPost.metadata.publish_target).toBe("both");
+          expect(response.data.socialPost.metadata.auto_publish).toBe(true);
+        });
+
         it("should perform full CRUD for a social post", async () => {
           console.log("Starting social post CRUD test");
 

--- a/apps/backend/src/admin/components/creates/create-social-post-steps.tsx
+++ b/apps/backend/src/admin/components/creates/create-social-post-steps.tsx
@@ -186,9 +186,15 @@ export const CreateSocialPostSteps = () => {
 
     // Single post mode submission
     const payload: any = {
-      ...data,
-      caption: data.message,
+      name: data.name,
+      platform_id: data.platform_id,
+      platform_name: data.platform_name,
+      message: data.message,
+      link: data.link,
       media_urls: data.media_urls,
+      post_type: data.post_type,
+      caption: data.message,
+      scheduled_at: data.scheduled_at,
       metadata: {
         ...(data.page_id ? { page_id: data.page_id } : {}),
         ...(data.ig_user_id ? { ig_user_id: data.ig_user_id } : {}),


### PR DESCRIPTION
## What

The create-social-post-steps form was spreading all form fields (`...data`) into the API payload, causing the backend to reject unrecognized top-level fields like `page_id`, `ig_user_id`, `publish_target`, `auto_publish`, `is_campaign`, `product_ids`, and `interval_hours`. These fields belong inside the `metadata` object.

## Fix

Replaced `...data` with an explicit whitelist of only the fields that `SocialPostSchema` accepts. Platform-specific fields are nested inside `metadata` where the workflow expects them.

## Tests

Added integration tests verifying:
1. Unrecognized top-level fields are rejected with 400
2. Fields nested inside `metadata` are accepted and persisted correctly