### PR TITLE
feat(storefront): first-touch UTM/referrer cookie capture + cart metadata stamping

### DIFF
--- a/apps/storefront/src/app/[countryCode]/(main)/layout.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/layout.tsx
@@ -10,6 +10,7 @@ import Footer from "@modules/layout/templates/footer"
 import Nav from "@modules/layout/templates/nav"
 import FreeShippingPriceNudge from "@modules/shipping/components/free-shipping-price-nudge"
 import { Toaster } from "@medusajs/ui"
+import PresenceMarker from "@modules/layout/components/presence-marker"
 
 export const metadata: Metadata = {
   metadataBase: new URL(getBaseURL()),
@@ -28,6 +29,7 @@ export default async function PageLayout(props: { children: React.ReactNode }) {
 
   return (
     <>
+      <PresenceMarker />
       <Nav />
       {customer && cart && (
         <CartMismatchBanner customer={customer} cart={cart} />

--- a/apps/storefront/src/lib/data/cart.ts
+++ b/apps/storefront/src/lib/data/cart.ts
@@ -10,6 +10,7 @@ import {
   getCacheOptions,
   getCacheTag,
   getCartId,
+  getTrackingCookies,
   removeCartId,
   setCartId,
 } from "./cookies"
@@ -141,21 +142,36 @@ export async function addToCart({
     ...(await getAuthHeaders()),
   }
 
-  // Stamp visitor_id on cart metadata exactly once, before adding the
-  // line item. We only write when the cart doesn't already carry one
-  // so a returning visitor on a different device doesn't clobber the
-  // original signal source. Failure is non-fatal — never block the
-  // add-to-cart on this best-effort enrichment.
-  if (visitorId && !(cart.metadata as Record<string, unknown> | null)?.visitor_id) {
+  // Stamp visitor_id + first-touch attribution on cart metadata exactly
+  // once, before adding the line item. We only write when the cart doesn't
+  // already carry one so a returning visitor on a different device doesn't
+  // clobber the original signal source. Failure is non-fatal — never
+  // block the add-to-cart on this best-effort enrichment.
+  const existingMeta = (cart.metadata ?? {}) as Record<string, unknown>
+  const hasVisitorId = !!existingMeta.visitor_id
+  const tracking = await getTrackingCookies()
+  const trackingKeys = Object.keys(tracking)
+  const hasTracking = trackingKeys.some((k) => !existingMeta[k])
+
+  if ((visitorId && !hasVisitorId) || (hasTracking && trackingKeys.length > 0)) {
     try {
+      const enriched: Record<string, unknown> = { ...existingMeta }
+      if (visitorId && !hasVisitorId) {
+        enriched.visitor_id = visitorId
+      }
+      for (const [key, value] of Object.entries(tracking)) {
+        if (existingMeta[key] === undefined) {
+          enriched[key] = value
+        }
+      }
       await sdk.store.cart.update(
         cart.id,
-        { metadata: { ...(cart.metadata ?? {}), visitor_id: visitorId } },
+        { metadata: enriched },
         {},
         headers,
       )
     } catch (e) {
-      console.warn("[addToCart] visitor_id stamp failed", e)
+      console.warn("[addToCart] metadata stamp failed", e)
     }
   }
 

--- a/apps/storefront/src/lib/data/cookies.ts
+++ b/apps/storefront/src/lib/data/cookies.ts
@@ -87,3 +87,41 @@ export const removeCartId = async () => {
     maxAge: -1,
   })
 }
+
+/**
+ * Reads first-touch tracking cookies set by the middleware. Returns an
+ * object with all available attribution fields — any field not yet
+ * captured is omitted from the result.
+ *
+ * Used by cart stamping (addToCart) so the backend can join carts →
+ * campaigns → orders for ad-planning attribution.
+ */
+export const getTrackingCookies = async (): Promise<
+  Record<string, string>
+> => {
+  try {
+    const cookies = await nextCookies()
+    const keys = [
+      "jyt_utm_source",
+      "jyt_utm_medium",
+      "jyt_utm_campaign",
+      "jyt_utm_term",
+      "jyt_utm_content",
+      "jyt_gclid",
+      "jyt_fbclid",
+      "jyt_ref",
+      "jyt_referrer",
+      "jyt_landing_page",
+    ]
+    const result: Record<string, string> = {}
+    for (const key of keys) {
+      const value = cookies.get(key)?.value
+      if (value) {
+        result[key.replace("jyt_", "")] = value
+      }
+    }
+    return result
+  } catch {
+    return {}
+  }
+}

--- a/apps/storefront/src/middleware.ts
+++ b/apps/storefront/src/middleware.ts
@@ -5,6 +5,85 @@ const BACKEND_URL = process.env.MEDUSA_BACKEND_URL
 const PUBLISHABLE_API_KEY = process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY
 const DEFAULT_REGION = process.env.NEXT_PUBLIC_DEFAULT_REGION || "us"
 
+/**
+ * Tracking params to capture from the URL query string. Stored as
+ * first-party cookies with a `jyt_` prefix so server-side code (cart
+ * stamping, server actions) can read them via `next/headers`.
+ *
+ * First-touch model: cookies are only written when they don't already
+ * exist — the initial ad click / UTM link that brought the visitor in
+ * is preserved even if they navigate to other pages.
+ */
+const TRACKING_PARAMS = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+  "gclid",
+  "fbclid",
+  "ref",
+] as const
+
+const TRACKING_COOKIE_MAX_AGE = 60 * 60 * 24 * 30 // 30 days
+
+/**
+ * Captures first-touch attribution params from the URL query string and
+ * the `Referer` header, setting them as cookies on the response if they
+ * aren't already present. Runs on every request that passes the matcher.
+ *
+ * Mutates the response's cookie set in-place — returns nothing.
+ */
+function captureTrackingParams(
+  request: NextRequest,
+  response: NextResponse,
+) {
+  const searchParams = request.nextUrl.searchParams
+  const existingCookies = request.cookies
+
+  for (const param of TRACKING_PARAMS) {
+    const cookieName = `jyt_${param}`
+    const value = searchParams.get(param)
+
+    if (value && !existingCookies.get(cookieName)) {
+      response.cookies.set(cookieName, value, {
+        maxAge: TRACKING_COOKIE_MAX_AGE,
+        path: "/",
+        sameSite: "lax",
+      })
+    }
+  }
+
+  // HTTP referrer — only set if we don't already have one captured.
+  // The `Referer` header is more reliable than `document.referrer` for
+  // server-side attribution (it's set by the browser, not spoofable by
+  // client JS) and survives ad-blockers that block the analytics script.
+  const httpReferrer = request.headers.get("referer")
+  if (
+    httpReferrer &&
+    !existingCookies.get("jyt_referrer")
+  ) {
+    response.cookies.set("jyt_referrer", httpReferrer, {
+      maxAge: TRACKING_COOKIE_MAX_AGE,
+      path: "/",
+      sameSite: "lax",
+    })
+  }
+
+  // Landing page — the first page the visitor landed on. Only set once
+  // per cookie lifetime so it always reflects the entry point, not
+  // subsequent navigations.
+  if (!existingCookies.get("jyt_landing_page")) {
+    const landingPath =
+      request.nextUrl.pathname + (request.nextUrl.search || "")
+    response.cookies.set("jyt_landing_page", landingPath, {
+      maxAge: TRACKING_COOKIE_MAX_AGE,
+      path: "/",
+      sameSite: "lax",
+    })
+  }
+}
+
 const regionMapCache = {
   regionMap: new Map<string, HttpTypes.StoreRegion>(),
   regionMapUpdated: Date.now(),
@@ -161,6 +240,10 @@ export async function middleware(request: NextRequest) {
     } else {
       console.log(`[Middleware] → NextResponse.next() (cache id already set)`)
     }
+
+    // Capture first-touch UTM / referrer / landing-page cookies.
+    captureTrackingParams(request, next)
+
     return next
   }
 
@@ -188,6 +271,10 @@ export async function middleware(request: NextRequest) {
     redirectUrl = `${request.nextUrl.origin}/${countryCode}${redirectPath}${queryString}`
     response = NextResponse.redirect(`${redirectUrl}`, 307)
     console.log(`[Middleware] → Redirecting to ${redirectUrl}`)
+
+    // Capture first-touch UTM / referrer / landing-page cookies on the
+    // redirect response so they're set before the page even renders.
+    captureTrackingParams(request, response)
   } else if (!urlHasCountryCode && !countryCode) {
     console.log(`[Middleware] → 500: No valid regions`)
     // Handle case where no valid country code exists (empty regions)

--- a/apps/storefront/src/modules/layout/components/presence-marker.tsx
+++ b/apps/storefront/src/modules/layout/components/presence-marker.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { useEffect } from "react"
+
+/**
+ * Ensures the `jyt_visitor_id` exists in localStorage before any
+ * user interaction. The analytics script (analytics.min.js) also
+ * writes this key, but it may be blocked by ad-blockers or load
+ * late — this guarantees the id is available for cart stamping
+ * and chat from the very first render.
+ *
+ * Also syncs any UTM params present in the current URL to
+ * sessionStorage so the `window.jytAnalytics` global (if loaded)
+ * picks them up even if the analytics script's own capture runs
+ * after this component.
+ *
+ * Pure side-effect — renders null.
+ */
+export default function PresenceMarker() {
+  useEffect(() => {
+    try {
+      const STORAGE_KEY = "jyt_visitor_id"
+      if (!localStorage.getItem(STORAGE_KEY)) {
+        const id = crypto.randomUUID()
+        localStorage.setItem(STORAGE_KEY, id)
+      }
+    } catch {
+      // localStorage unavailable (private mode, quota) — non-fatal
+    }
+
+    // Best-effort: if analytics.js hasn't captured UTMs from the URL
+    // yet (script blocked or still loading), stash them in
+    // sessionStorage["jyt_utm"] so the conversion/journey calls can
+    // still read them.
+    try {
+      const utmKeys = [
+        "utm_source",
+        "utm_medium",
+        "utm_campaign",
+        "utm_term",
+        "utm_content",
+      ]
+      const params = new URLSearchParams(window.location.search)
+      const captured: Record<string, string> = {}
+      for (const key of utmKeys) {
+        const val = params.get(key)
+        if (val) captured[key] = val
+      }
+
+      if (Object.keys(captured).length > 0) {
+        const existing = sessionStorage.getItem("jyt_utm")
+        if (!existing) {
+          sessionStorage.setItem("jyt_utm", JSON.stringify(captured))
+        }
+      }
+    } catch {
+      // sessionStorage unavailable — non-fatal
+    }
+  }, [])
+
+  return null
+}


### PR DESCRIPTION
## What

Adds first-touch attribution tracking to the storefront so user presence (UTM params, ad IDs, referrer, landing page) is captured on every page load and joined to cart metadata.

## Why

The existing `analytics.min.js` script captures UTMs client-side, but:
1. **Ad-blockers** block the script entirely — no tracking data is captured
2. UTM params are **session-scoped** (sessionStorage) — lost when the session ends
3. **No backend join** — carts can't be linked to campaigns for ad-planning attribution
4. **Ad IDs** (gclid, fbclid) are not captured at all

This PR fills those gaps with middleware-level cookie capture (survives ad-blockers, persists 30 days), cart metadata stamping (enables backend attribution), and a client-side presence marker (ensures visitor_id is always available).

## Changes

### 1. Middleware — `src/middleware.ts`
- New `captureTrackingParams()` runs on every request
- Captures from URL query: `utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content`, `gclid`, `fbclid`, `ref`
- Captures from HTTP headers: `Referer` → `jyt_referrer`
- Captures landing page path → `jyt_landing_page`
- All stored as `jyt_*` first-party cookies (30-day, SameSite=Lax)
- **First-touch model**: only writes if the cookie doesn't already exist

### 2. Cookie helper — `src/lib/data/cookies.ts`
- New `getTrackingCookies()` reads all `jyt_*` cookies server-side via `next/headers`

### 3. Cart metadata stamping — `src/lib/data/cart.ts`
- `addToCart` now reads tracking cookies and stamps `utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content`, `gclid`, `fbclid`, `ref`, `referrer`, `landing_page` onto `cart.metadata`
- Same write-once pattern as the existing `visitor_id` stamp — only writes fields not already present

### 4. PresenceMarker — `src/modules/layout/components/presence-marker.tsx`
- New client component (renders null) mounted in the `(main)` layout
- Ensures `jyt_visitor_id` exists in localStorage (survives ad-blocker scenarios)
- Syncs UTM params from URL to `sessionStorage["jyt_utm"]` if analytics.js hasn't captured them yet

### 5. Layout — `src/app/[countryCode]/(main)/layout.tsx`
- Mounted `<PresenceMarker />` as the first element

## Testing
- Build compiles successfully (verified with `pnpm build` — compiled in 4.7s, no code errors)
- Full static generation requires a live Medusa backend + valid publishable key (environment dependency)
- TypeScript: no new errors introduced (pre-existing React 19 type compat errors unchanged)