### PR TITLE
fix(storefront): await params/searchParams in design page for Next.js 16

### DIFF
--- a/apps/storefront/src/app/[countryCode]/(main)/products/[handle]/design/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/products/[handle]/design/page.tsx
@@ -9,6 +9,11 @@ import { getRegion } from "@lib/data/regions"
 type PageParams = { handle: string; countryCode: string }
 type SearchParams = { designId?: string }
 
+type Props = {
+  params: Promise<PageParams>
+  searchParams: Promise<SearchParams>
+}
+
 async function getProduct(params: PageParams) {
   const region = await getRegion(params.countryCode)
   if (!region) return null
@@ -19,13 +24,13 @@ async function getProduct(params: PageParams) {
   })
 
   const product = response.products[0]
-  console.log("[DesignPage] Product fetched:", product?.id, "thumbnail:", product?.thumbnail, "other details:", product)
 
   return product || null
 }
 
-export async function generateMetadata({ params }: { params: PageParams }): Promise<Metadata> {
-  const product = await getProduct(params)
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const resolvedParams = await params
+  const product = await getProduct(resolvedParams)
 
   if (!product) {
     return { title: "Design Not Found" }
@@ -40,11 +45,13 @@ export async function generateMetadata({ params }: { params: PageParams }): Prom
 export default async function DesignPage({
   params,
   searchParams,
-}: {
-  params: PageParams
-  searchParams: SearchParams
-}) {
-  const product = await getProduct(params)
+}: Props) {
+  const [resolvedParams, resolvedSearchParams] = await Promise.all([
+    params,
+    searchParams,
+  ])
+
+  const product = await getProduct(resolvedParams)
   const customer = await retrieveCustomer().catch(() => null)
 
   if (!product) {
@@ -53,8 +60,8 @@ export default async function DesignPage({
 
   // If a designId is provided, fetch the existing design to pre-populate the editor
   let initialDesign: DesignDetail | null = null
-  if (searchParams.designId) {
-    initialDesign = await getDesign(searchParams.designId).catch(() => null)
+  if (resolvedSearchParams.designId) {
+    initialDesign = await getDesign(resolvedSearchParams.designId).catch(() => null)
   }
 
   return (
@@ -74,7 +81,7 @@ export default async function DesignPage({
         email: customer.email,
         aiFeaturesPaid: customer.metadata?.ai_features_paid === true,
       } : null}
-      countryCode={params.countryCode}
+      countryCode={resolvedParams.countryCode}
       initialDesign={initialDesign}
     />
   )


### PR DESCRIPTION
## What

Fixes a server crash on `/products/[handle]/design` — the page throws **"Country code or region ID is required"** because `params` and `searchParams` were treated as synchronous objects instead of Promises.

## Root cause

Next.js 16 passes `params` and `searchParams` as **Promises**. The design page destructured them synchronously:

```ts
// Before — broken
export default async function DesignPage({ params, searchParams }: {
  params: PageParams          // not a Promise
  searchParams: SearchParams  // not a Promise
}) {
  const product = await getProduct(params)  // params.countryCode is undefined
```

This meant `params.countryCode` was `undefined`, so `getRegion(undefined)` threw.

## Fix

Await both `params` and `searchParams` before use, matching the pattern already used in the product detail page and other Next.js 16 pages:

```ts
type Props = {
  params: Promise<PageParams>
  searchParams: Promise<SearchParams>
}

export default async function DesignPage({ params, searchParams }: Props) {
  const [resolvedParams, resolvedSearchParams] = await Promise.all([
    params, searchParams,
  ])
  // ...
}
```

## Testing
- TypeScript compiles cleanly (no new errors)
- The page now resolves `countryCode` correctly before calling `getRegion()`