### PR TITLE
fix(storefront): raise filter Drawer z-index above navbar

### DIFF
--- a/apps/storefront/src/modules/store/components/refinement-list/index.tsx
+++ b/apps/storefront/src/modules/store/components/refinement-list/index.tsx
@@ -112,7 +112,10 @@ const RefinementList = ({ sortBy, collections, tags, 'data-testid': dataTestId }
           <Drawer.Trigger asChild>
             <Button variant="secondary" className="w-full">Filters</Button>
           </Drawer.Trigger>
-          <Drawer.Content className="max-h-[85vh] overflow-hidden">
+          <Drawer.Content
+            className="max-h-[85vh] overflow-hidden z-[100]"
+            overlayProps={{ className: "z-[100]" }}
+          >
             <Drawer.Header>
               <Drawer.Title>Filters</Drawer.Title>
             </Drawer.Header>


### PR DESCRIPTION
## What

The mobile filter Drawer on the /store page was appearing behind the navbar — the navbar's z-50 painted on top of the modal overlay.

## Root cause

The navbar wrapper (nav-scroll-header.tsx) uses sticky z-50. The @medusajs/ui Drawer component renders its overlay and content as position:fixed with no explicit z-index (z-index: auto). Since an explicit z-index: 50 beats auto, the navbar always painted on top of the filter modal.

## Fix

Added z-[100] to both the Drawer.Content and the overlay (via overlayProps) so the filter drawer sits above the navbar. This mirrors the pattern already used by the side-menu component (z-[51] above navbar z-50).

## File
- src/modules/store/components/refinement-list/index.tsx