### PR TITLE
[#938] MikroHyperbee DAL for person_property (flag-gated, draft)

### DIFF
--- a/apps/backend/.gitignore
+++ b/apps/backend/.gitignore
@@ -1,3 +1,8 @@
 
 # #1031 census embedded P2P reader local corestore
 .census-p2p-store/
+
+# MikroHyperbee local Hyperbee stores (test/dev artifacts)
+.person-property-store/
+.pp-boot-verify-store/
+.pp-*-store/

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -71,6 +71,7 @@
     "@hookform/resolvers": "^5.0.1",
     "@jytextiles/medusa-plugin-etsy-sync": "latest",
     "@jytextiles/medusa-plugin-faire-store-sync": "latest",
+    "@jytextiles/mikrohyperbee": "workspace:*",
     "@mastra/core": "latest",
     "@mastra/evals": "latest",
     "@mastra/loggers": "latest",

--- a/apps/backend/src/api/admin/person-properties/[id]/route.ts
+++ b/apps/backend/src/api/admin/person-properties/[id]/route.ts
@@ -1,0 +1,27 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+import { PERSON_PROPERTY_MODULE } from "../../../../modules/personproperty";
+
+// GET /admin/person-properties/:id — retrieve (throws MedusaError NOT_FOUND → 404)
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(PERSON_PROPERTY_MODULE);
+  const person_property = await service.retrievePersonProperty(req.params.id);
+  res.json({ person_property });
+};
+
+// POST /admin/person-properties/:id — update
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(PERSON_PROPERTY_MODULE);
+  const person_property = await service.updatePersonProperties({
+    id: req.params.id,
+    ...(req.validatedBody as Record<string, unknown>),
+  });
+  res.json({ person_property });
+};
+
+// DELETE /admin/person-properties/:id
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(PERSON_PROPERTY_MODULE);
+  await service.deletePersonProperties(req.params.id);
+  res.json({ id: req.params.id, object: "person_property", deleted: true });
+};

--- a/apps/backend/src/api/admin/person-properties/route.ts
+++ b/apps/backend/src/api/admin/person-properties/route.ts
@@ -1,0 +1,46 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
+
+import { PERSON_PROPERTY_MODULE } from "../../../modules/personproperty";
+import { LIST_FILTER_FIELDS } from "./validators";
+
+/**
+ * Admin CRUD for person_property. Goes through the MODULE SERVICE (not
+ * query.graph) on purpose: the generated create/list methods delegate to the
+ * injected internal service, so with PERSON_PROPERTY_HYPERBEE=true these run over
+ * the Hyperbee DAL and with the flag off they run over Postgres — same route,
+ * same responses, swappable backend.
+ */
+
+// POST /admin/person-properties — create one
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(PERSON_PROPERTY_MODULE);
+  const created = await service.createPersonProperties(req.validatedBody);
+  res.status(201).json({ person_property: created });
+};
+
+// GET /admin/person-properties?district=AMBALA&limit=20&offset=0 — list + count
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(PERSON_PROPERTY_MODULE);
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER);
+
+  const q = req.query as Record<string, string | undefined>;
+  const filters: Record<string, string> = {};
+  for (const f of LIST_FILTER_FIELDS) {
+    if (q[f] !== undefined && q[f] !== "") filters[f] = q[f] as string;
+  }
+
+  const limit = Math.min(Math.max(Number(q.limit) || 20, 1), 100);
+  const offset = Math.max(Number(q.offset) || 0, 0);
+
+  try {
+    const [person_properties, count] = await service.listAndCountPersonProperties(
+      filters,
+      { take: limit, skip: offset }
+    );
+    res.json({ person_properties, count, limit, offset });
+  } catch (e: any) {
+    logger?.error(`[person-properties] list failed: ${e?.message || e}`);
+    throw e;
+  }
+};

--- a/apps/backend/src/api/admin/person-properties/validators.ts
+++ b/apps/backend/src/api/admin/person-properties/validators.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+/**
+ * Validation schemas for the /admin/person-properties CRUD routes.
+ * Mirrors the person_property model (models/person_property.ts).
+ */
+
+export const CreatePersonPropertySchema = z.object({
+  profile_type: z.string().optional().default("weaver"),
+  census_id: z.string().nullish(),
+  relation_to_head: z.string().nullish(),
+  gender: z.string().nullish(),
+  social_group: z.string().nullish(),
+  religion: z.string().nullish(),
+  region_state: z.string().nullish(),
+  district: z.string().nullish(),
+  own_looms: z.boolean().nullish(),
+  total_looms_owned: z.number().int().nullish(),
+  natural_dye_used: z.boolean().nullish(),
+  sells_local_market: z.boolean().nullish(),
+  sells_master_weaver: z.boolean().nullish(),
+  sells_cooperative: z.boolean().nullish(),
+  sells_ecommerce: z.boolean().nullish(),
+  support_requirements: z.array(z.string()).nullish(),
+  metadata: z.record(z.string(), z.unknown()).nullish(),
+});
+
+// Update: every field optional (partial). profile_type has no default here so an
+// omitted value doesn't silently reset it.
+export const UpdatePersonPropertySchema = CreatePersonPropertySchema.partial().extend({
+  profile_type: z.string().optional(),
+});
+
+export type CreatePersonPropertyInput = z.infer<typeof CreatePersonPropertySchema>;
+export type UpdatePersonPropertyInput = z.infer<typeof UpdatePersonPropertySchema>;
+
+// Equality-filterable query fields for GET list (the ones the Hyperbee DAL also
+// indexes, plus census_id).
+export const LIST_FILTER_FIELDS = [
+  "profile_type",
+  "census_id",
+  "gender",
+  "social_group",
+  "religion",
+  "region_state",
+  "district",
+] as const;

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -275,6 +275,11 @@ import { WebSaveTourItinerarySchema } from "./web/tour-visits/[token]/validators
 import { LinkDesignsToCustomerSchema } from "./admin/customers/[id]/designs/validators";
 import { CreateDesignOrderSchema } from "./admin/customers/[id]/design-order/validators";
 import { listAbandonedCartsQuerySchema } from "./admin/abandoned-carts/validators";
+import {
+  CreatePersonPropertySchema,
+  UpdatePersonPropertySchema,
+} from "./admin/person-properties/validators";
+import { VerifyWeaverSchema } from "./web/census/verify/validators";
 
 /**
  * In-process per-IP rate limiter for public token-resolution routes.
@@ -2954,6 +2959,23 @@ export default defineMiddlewares({
       matcher: "/admin/persons/:id",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(UpdatePersonSchema))],
+    },
+    // person_property CRUD (module-service backed; swappable Postgres/Hyperbee DAL)
+    {
+      matcher: "/admin/person-properties",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(CreatePersonPropertySchema))],
+    },
+    {
+      matcher: "/admin/person-properties/:id",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(UpdatePersonPropertySchema))],
+    },
+    // #1038 weaver verify against the census public core
+    {
+      matcher: "/web/census/verify",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(VerifyWeaverSchema))],
     },
     {
       matcher: "/admin/persons/:id/resources/:resource",

--- a/apps/backend/src/api/web/census/verify/lib.ts
+++ b/apps/backend/src/api/web/census/verify/lib.ts
@@ -1,0 +1,56 @@
+import { createHmac } from "node:crypto";
+
+/** Normalize a name for tolerant comparison: upper, strip punctuation, collapse ws. */
+export function normalizeName(s: string): string {
+  return s
+    .toUpperCase()
+    .replace(/[^A-Z0-9\s]/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+/** Token-set Jaccard similarity (0..1) — order-insensitive, tolerant to extra tokens. */
+export function nameSimilarity(a: string, b: string): number {
+  const ta = new Set(normalizeName(a).split(" ").filter(Boolean));
+  const tb = new Set(normalizeName(b).split(" ").filter(Boolean));
+  if (!ta.size || !tb.size) return 0;
+  let inter = 0;
+  for (const t of ta) if (tb.has(t)) inter++;
+  return inter / (ta.size + tb.size - inter);
+}
+
+/**
+ * Pull a display name out of a masked census record without hardcoding one key —
+ * the public record shape varies, so take the first string field whose key looks
+ * name-ish (and isn't obviously something else).
+ */
+export function extractName(rec: Record<string, any>): string | null {
+  for (const [k, v] of Object.entries(rec)) {
+    if (
+      typeof v === "string" &&
+      /name/iu.test(k) &&
+      !/user|file|scheme|district|state|village|block/iu.test(k)
+    ) {
+      return v;
+    }
+  }
+  return null;
+}
+
+/** Normalize Aadhaar to its 12 digits. */
+export function normalizeAadhaar(s: string): string {
+  return s.replace(/\D/gu, "");
+}
+
+/**
+ * HMAC-SHA256 the Aadhaar with a server-side pepper so the value is never stored
+ * or logged in the clear. Pepper from CENSUS_AADHAAR_PEPPER (falls back to the
+ * general handloom key, or a dev constant) — set a dedicated one in prod.
+ */
+export function hashAadhaar(aadhaar: string): string {
+  const pepper =
+    process.env.CENSUS_AADHAAR_PEPPER ||
+    process.env.HANDLOOM_ENCRYPTION_KEY ||
+    "dev-only-unsafe-pepper";
+  return createHmac("sha256", pepper).update(normalizeAadhaar(aadhaar)).digest("hex");
+}

--- a/apps/backend/src/api/web/census/verify/route.ts
+++ b/apps/backend/src/api/web/census/verify/route.ts
@@ -1,0 +1,86 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+import { CENSUS_MODULE } from "../../../../modules/census";
+import type CensusModuleService from "../../../../modules/census/service";
+import {
+  extractName,
+  hashAadhaar,
+  nameSimilarity,
+} from "./lib";
+import type { VerifyWeaverInput } from "./validators";
+
+// Name confidence at/above which the name factor is considered a match.
+const NAME_MATCH_THRESHOLD = 0.6;
+
+/**
+ * POST /web/census/verify  (#1038) — public (/web/* is CORS-only, no key).
+ *
+ * Verify a weaver against the census PUBLIC core by census_id, optionally
+ * confirming name (fuzzy) and accepting an Aadhaar (hashed for audit).
+ *
+ * IMPORTANT scope note: the public core is masked/PII-free and carries no
+ * Aadhaar, so `aadhaar_matched` is null here — true Aadhaar+Name matching needs
+ * the encrypted sensitive-core index (issue #1038). This endpoint is the working
+ * first cut (census_id + name) with the Aadhaar path wired for when that lands.
+ */
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const census = req.scope.resolve(CENSUS_MODULE) as CensusModuleService;
+
+  if (!census.connected) {
+    return res.status(503).json({
+      message: "census reader not connected yet — try again shortly",
+    });
+  }
+
+  const { census_id, name, aadhaar } = req.validatedBody as VerifyWeaverInput;
+
+  const weaver = await census.retrieveWeaver(census_id);
+  if (!weaver) {
+    return res.json({
+      verified: false,
+      reason: "not_found",
+      census_id,
+      // Still record that an Aadhaar was submitted (hashed) for audit, never raw.
+      ...(aadhaar ? { aadhaar_hash_prefix: hashAadhaar(aadhaar).slice(0, 12) } : {}),
+    });
+  }
+
+  // ── name factor (optional) ──
+  let name_confidence: number | null = null;
+  let name_matched: boolean | null = null;
+  if (name) {
+    const recName = extractName(weaver);
+    if (recName) {
+      name_confidence = Number(nameSimilarity(name, recName).toFixed(3));
+      name_matched = name_confidence >= NAME_MATCH_THRESHOLD;
+    } else {
+      name_matched = null; // record has no comparable name field
+    }
+  }
+
+  // ── aadhaar factor (accepted + hashed, but not matchable on the public core) ──
+  let aadhaar_matched: boolean | null = null;
+  let aadhaar_hash_prefix: string | undefined;
+  if (aadhaar) {
+    const hash = hashAadhaar(aadhaar);
+    aadhaar_hash_prefix = hash.slice(0, 12);
+    const recHash = (weaver as Record<string, any>).aadhaar_hash;
+    aadhaar_matched = recHash ? recHash === hash : null; // null → not on public core
+  }
+
+  // Overall verdict: found by census_id AND (no name given OR name matched).
+  const verified = name_matched === false ? false : true;
+
+  res.json({
+    verified,
+    census_id,
+    factors: {
+      census_id: true,
+      name_matched,
+      name_confidence,
+      aadhaar_matched, // null = Aadhaar not available on the public core (#1038 tail)
+    },
+    ...(aadhaar_hash_prefix ? { aadhaar_hash_prefix } : {}),
+    weaver, // masked, PII-free public record
+  });
+};

--- a/apps/backend/src/api/web/census/verify/validators.ts
+++ b/apps/backend/src/api/web/census/verify/validators.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+/**
+ * POST /web/census/verify  (#1038)
+ * Verify/lookup a weaver against the handloom census.
+ *
+ * `census_id` is required because the PUBLIC core is keyed by it and carries no
+ * secondary index (a name-only scan of millions of masked records is not a public
+ * endpoint). `name` is an optional confirmation factor. `aadhaar` is accepted +
+ * hashed for audit/forward-compat, but Aadhaar matching is NOT yet backed by data
+ * — Aadhaar (if collected at all) lives only in the encrypted sensitive core, not
+ * the public core this endpoint reads (see issue #1038 open questions).
+ */
+export const VerifyWeaverSchema = z
+  .object({
+    census_id: z.string().min(1),
+    name: z.string().min(1).optional(),
+    // 12 digits, optional spaces — normalized before hashing; never stored/echoed.
+    aadhaar: z
+      .string()
+      .regex(/^\d[\d\s]{10,20}\d$/u, "aadhaar must be a 12-digit number")
+      .optional(),
+  })
+  .strict();
+
+export type VerifyWeaverInput = z.infer<typeof VerifyWeaverSchema>;

--- a/apps/backend/src/modules/personproperty/__tests__/hyperbee-boot-verify.ts
+++ b/apps/backend/src/modules/personproperty/__tests__/hyperbee-boot-verify.ts
@@ -1,0 +1,111 @@
+/**
+ * STEP 0 — live boot verification of the MikroHyperbee DAL seam.
+ *
+ * Proves the one thing the M6 spike could NOT: that the module's flag-gated
+ * `hyperbee-dal` loader override actually BEATS Medusa's auto-registered
+ * internal service when the module is loaded through Medusa's REAL loader
+ * pipeline (connectionLoader -> containerLoader -> custom loaders).
+ *
+ * It boots ONLY this module via MedusaModule.bootstrap (no app, no HTTP), and
+ * injects a stub `manager` in options so the MikroORM connectionLoader returns
+ * before touching Postgres (mikro-orm-connection-loader.js:21-25). The Hyperbee
+ * loader then overrides personPropertyService + baseRepository; if the override
+ * wins, the generated createPersonProperties/listAndCountPersonProperties run
+ * over Hyperbee and the internal service is HyperbeePersonPropertyService.
+ *
+ * Run:  cd apps/backend && \
+ *   PERSON_PROPERTY_HYPERBEE=true \
+ *   PERSON_PROPERTY_HYPERBEE_STORE=./.pp-boot-verify-store \
+ *   ../../node_modules/.bin/tsx src/modules/personproperty/__tests__/hyperbee-boot-verify.ts
+ */
+import { MedusaModule } from "@medusajs/modules-sdk";
+import { existsSync, rmSync } from "fs";
+import { resolve } from "path";
+
+import personPropertyModule, { PERSON_PROPERTY_MODULE } from "../index";
+
+// loadResources re-imports the service from this path (dynamicImport(defaultPath).service),
+// so it must point at the module's own index, not @medusajs/framework.
+const MODULE_PATH = resolve(process.cwd(), "src/modules/personproperty/index.ts");
+
+const STORE = process.env.PERSON_PROPERTY_HYPERBEE_STORE || "./.pp-boot-verify-store";
+
+let pass = 0;
+let fail = 0;
+function assert(cond: boolean, msg: string) {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${msg}`);
+  } else {
+    fail++;
+    console.error(`  ✗ ${msg}`);
+  }
+}
+
+async function main() {
+  // clean slate
+  if (existsSync(STORE)) rmSync(STORE, { recursive: true, force: true });
+
+  if (process.env.PERSON_PROPERTY_HYPERBEE !== "true") {
+    console.error("PERSON_PROPERTY_HYPERBEE must be 'true' for this verify");
+    process.exit(2);
+  }
+
+  console.log("• Booting person_property via MedusaModule.bootstrap (flag ON, stub manager, no PG)…");
+
+  const loaded = await MedusaModule.bootstrap({
+    moduleKey: PERSON_PROPERTY_MODULE,
+    defaultPath: MODULE_PATH,
+    moduleExports: personPropertyModule as any,
+    declaration: {
+      scope: "internal" as any,
+      // stub manager -> connectionLoader skips the real PG connection
+      options: { manager: {} as any } as any,
+    } as any,
+  });
+
+  const service: any = loaded[PERSON_PROPERTY_MODULE];
+  assert(!!service, "module service resolved from bootstrap");
+
+  // 1) the override won: the internal service is the Hyperbee one.
+  // __container__ is the awilix cradle (property access == resolve).
+  const internal = service.__container__?.personPropertyService;
+  assert(!!internal, "internal personPropertyService is registered");
+  assert(
+    internal?.constructor?.name === "HyperbeePersonPropertyService",
+    `internal service is HyperbeePersonPropertyService (got '${internal?.constructor?.name}') — LOADER OVERRIDE WON`
+  );
+
+  // 2) live round-trip through the REAL generated methods
+  const created = await service.createPersonProperties({
+    person_id: "pers_boot_verify_1",
+    district: "AMBALA",
+    state: "HARYANA",
+    total_looms_owned: 3,
+  });
+  const rec = Array.isArray(created) ? created[0] : created;
+  assert(!!rec?.id, `createPersonProperties returned a record with id (${rec?.id})`);
+  assert(rec?.district === "AMBALA", "created record round-trips district=AMBALA");
+
+  const [rows, count] = await service.listAndCountPersonProperties(
+    { district: "AMBALA" },
+    { take: 20, skip: 0 }
+  );
+  assert(count >= 1, `listAndCountPersonProperties count>=1 (got ${count})`);
+  assert(
+    rows.some((r: any) => r.id === rec.id),
+    "listed rows include the created record"
+  );
+
+  // 3) it actually persisted to the Hyperbee store on disk (not PG)
+  assert(existsSync(STORE), `Hyperbee store dir written to disk at ${STORE}`);
+
+  console.log(`\n${fail === 0 ? "✅ PASS" : "❌ FAIL"} — ${pass} passed, ${fail} failed`);
+  await MedusaModule.clearInstances?.();
+  process.exit(fail === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error("BOOT VERIFY THREW:", e);
+  process.exit(1);
+});

--- a/apps/backend/src/modules/personproperty/__tests__/hyperbee-boot-verify.ts
+++ b/apps/backend/src/modules/personproperty/__tests__/hyperbee-boot-verify.ts
@@ -11,7 +11,7 @@
  * before touching Postgres (mikro-orm-connection-loader.js:21-25). The Hyperbee
  * loader then overrides personPropertyService + baseRepository; if the override
  * wins, the generated createPersonProperties/listAndCountPersonProperties run
- * over Hyperbee and the internal service is HyperbeePersonPropertyService.
+ * over Hyperbee and the internal service is the package HyperbeeBaseRepository.
  *
  * Run:  cd apps/backend && \
  *   PERSON_PROPERTY_HYPERBEE=true \
@@ -72,8 +72,8 @@ async function main() {
   const internal = service.__container__?.personPropertyService;
   assert(!!internal, "internal personPropertyService is registered");
   assert(
-    internal?.constructor?.name === "HyperbeePersonPropertyService",
-    `internal service is HyperbeePersonPropertyService (got '${internal?.constructor?.name}') — LOADER OVERRIDE WON`
+    internal?.constructor?.name === "HyperbeeBaseRepository",
+    `internal service is the package HyperbeeBaseRepository (got '${internal?.constructor?.name}') — LOADER OVERRIDE WON`
   );
 
   // 2) live round-trip through the REAL generated methods

--- a/apps/backend/src/modules/personproperty/__tests__/hyperbee-dal.e2e.ts
+++ b/apps/backend/src/modules/personproperty/__tests__/hyperbee-dal.e2e.ts
@@ -1,7 +1,7 @@
 /**
  * REAL end-to-end proof: the module's actual PersonPropertyService
  * (class extends MedusaService({ PersonProperty })) driven over the module's
- * ported Hyperbee DAL (HyperbeePersonPropertyService) — no Postgres, no MikroORM.
+ * Hyperbee DAL from @jytextiles/mikrohyperbee — no Postgres, no MikroORM.
  *
  * This re-homes the MikroHyperbee spike proof into the module so it lives beside
  * the code it validates. It exercises the SERVICE seam (generated methods →
@@ -17,7 +17,7 @@ import Corestore from "corestore";
 import Hyperbee from "hyperbee";
 import { MedusaError } from "@medusajs/framework/utils";
 
-import { HyperbeePersonPropertyService } from "../dal/hyperbee-person-property-service";
+import { createPersonPropertyRepository } from "../dal/hyperbee-person-property-service";
 import PersonPropertyServiceDefault from "../service";
 
 // CJS-interop can double-wrap the default export depending on the loader.
@@ -40,7 +40,7 @@ async function main() {
     keyEncoding: "utf-8",
     valueEncoding: "binary",
   });
-  const internal = new HyperbeePersonPropertyService(bee);
+  const internal = createPersonPropertyRepository(bee as any);
 
   const container: any = {
     baseRepository: {

--- a/apps/backend/src/modules/personproperty/__tests__/hyperbee-dal.e2e.ts
+++ b/apps/backend/src/modules/personproperty/__tests__/hyperbee-dal.e2e.ts
@@ -1,0 +1,126 @@
+/**
+ * REAL end-to-end proof: the module's actual PersonPropertyService
+ * (class extends MedusaService({ PersonProperty })) driven over the module's
+ * ported Hyperbee DAL (HyperbeePersonPropertyService) — no Postgres, no MikroORM.
+ *
+ * This re-homes the MikroHyperbee spike proof into the module so it lives beside
+ * the code it validates. It exercises the SERVICE seam (generated methods →
+ * injected internal `personPropertyService`), which is exactly what the flag-gated
+ * loader (loaders/hyperbee-dal.ts) rewires at boot.
+ *
+ * Run:  node_modules/.bin/tsx apps/backend/src/modules/personproperty/__tests__/hyperbee-dal.e2e.ts
+ */
+import assert from "node:assert";
+import { rmSync } from "node:fs";
+
+import Corestore from "corestore";
+import Hyperbee from "hyperbee";
+import { MedusaError } from "@medusajs/framework/utils";
+
+import { HyperbeePersonPropertyService } from "../dal/hyperbee-person-property-service";
+import PersonPropertyServiceDefault from "../service";
+
+// CJS-interop can double-wrap the default export depending on the loader.
+const PersonPropertyService: any =
+  (PersonPropertyServiceDefault as any)?.default ?? PersonPropertyServiceDefault;
+
+let PASS = 0;
+const ok = (label: string, cond: boolean) => {
+  assert(cond, `FAIL: ${label}`);
+  console.log(`  ✓ ${label}`);
+  PASS++;
+};
+
+const DIR = "./_pp_hb_e2e";
+
+async function main() {
+  rmSync(DIR, { recursive: true, force: true });
+  const store = new Corestore(DIR);
+  const bee = new Hyperbee(store.get({ name: "person_property" }), {
+    keyEncoding: "utf-8",
+    valueEncoding: "binary",
+  });
+  const internal = new HyperbeePersonPropertyService(bee);
+
+  const container: any = {
+    baseRepository: {
+      serialize: async (d: any) => JSON.parse(JSON.stringify(d)),
+      getFreshManager: () => internal,
+      getActiveManager: () => internal,
+      transaction: async (task: any) => task(internal),
+    },
+    personPropertyService: internal,
+    eventBusModuleService: { emit: async () => {} },
+    messageAggregator: {
+      saveRawMessageData() {},
+      getMessages() {
+        return [];
+      },
+      clearMessages() {},
+    },
+  };
+
+  const svc: any = new PersonPropertyService(container);
+  console.log("Instantiated the REAL PersonPropertyService over the module's Hyperbee DAL.\n");
+
+  const one = await svc.createPersonProperties({
+    profile_type: "weaver",
+    census_id: "2904500",
+    social_group: "Schedule Caste",
+    district: "AMBALA",
+    own_looms: true,
+    total_looms_owned: 2,
+  });
+  ok(`created single -> id ${one.id}`, !!one.id && one.social_group === "Schedule Caste");
+
+  const many = await svc.createPersonProperties([
+    { profile_type: "weaver", census_id: "2904501", social_group: "Scheduled Tribe", district: "AMBALA", own_looms: false, total_looms_owned: 0 },
+    { profile_type: "weaver", census_id: "2904502", social_group: "Other Backward Caste", district: "PANIPAT", own_looms: true, total_looms_owned: 3 },
+    { profile_type: "weaver", census_id: "2904503", social_group: "Scheduled Tribe", district: "AMBALA", own_looms: true, total_looms_owned: 4 },
+  ]);
+  ok("created batch of 3", Array.isArray(many) && many.length === 3);
+
+  const st = await svc.listPersonProperties({ social_group: "Scheduled Tribe" });
+  ok(`filter social_group='Scheduled Tribe' -> ${st.length}`, st.length === 2 && st.every((r: any) => r.social_group === "Scheduled Tribe"));
+
+  const ambala = await svc.listPersonProperties({ district: "AMBALA", own_looms: true });
+  ok(`compound filter district=AMBALA & own_looms=true -> ${ambala.length}`, ambala.length === 2);
+
+  const heavy = await svc.listPersonProperties({ total_looms_owned: { $gte: 2 } });
+  ok(`operator filter total_looms_owned>=2 -> ${heavy.length}`, heavy.length === 3);
+
+  const [page, count] = await svc.listAndCountPersonProperties(
+    { profile_type: "weaver" },
+    { take: 2, skip: 0, order: { census_id: "ASC" } }
+  );
+  ok("count=4 weavers, page of 2", count === 4 && page.length === 2);
+
+  const got = await svc.retrievePersonProperty(one.id);
+  ok("retrieve by id", got.census_id === "2904500");
+  let threw = false;
+  try {
+    await svc.retrievePersonProperty("pp_999999");
+  } catch (e: any) {
+    threw = e instanceof MedusaError;
+  }
+  ok("retrieve missing -> MedusaError NOT_FOUND", threw);
+
+  await svc.updatePersonProperties({ id: many[1].id, district: "KARNAL" });
+  ok("update moved out of PANIPAT", (await svc.listPersonProperties({ district: "PANIPAT" })).length === 0);
+  ok("update reindexed into KARNAL", (await svc.listPersonProperties({ district: "KARNAL" })).length === 1);
+
+  await svc.deletePersonProperties(many[0].id);
+  ok("delete removed the row", (await svc.listAndCountPersonProperties({ profile_type: "weaver" }))[1] === 3);
+
+  await store.close();
+  rmSync(DIR, { recursive: true, force: true });
+  console.log(`\n✅ ${PASS}/${PASS} assertions — the REAL PersonPropertyService runs end-to-end over the module's Hyperbee DAL.`);
+}
+
+main().then(
+  () => process.exit(0),
+  (e) => {
+    console.error(e);
+    process.exit(1);
+  }
+);

--- a/apps/backend/src/modules/personproperty/__tests__/package-dal.script.ts
+++ b/apps/backend/src/modules/personproperty/__tests__/package-dal.script.ts
@@ -1,0 +1,136 @@
+/**
+ * Small proof: the REAL Medusa `PersonPropertyService` (MedusaService({PersonProperty}))
+ * generated methods run over the `@jytextiles/mikrohyperbee` package DAL — no
+ * Postgres, no full Medusa boot. This is step 2 in miniature: swap the in-module
+ * DAL class for the extracted package repository and confirm the generated
+ * create/list/listAndCount/retrieve/update methods still round-trip.
+ *
+ * Run:  cd apps/backend && \
+ *   ../../node_modules/.bin/tsx src/modules/personproperty/__tests__/package-dal.script.ts
+ */
+import { existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// @ts-ignore resolved from apps/backend node_modules
+import Corestore from "corestore";
+// @ts-ignore
+import Hyperbee from "hyperbee";
+
+// Import the extracted package by source (workspace dep wiring comes with the
+// real step-2 module rewire; a relative import keeps this script self-contained).
+import { defineContract, hyperbeeRepositoryFor } from "../../../../../../packages/mikrohyperbee/src";
+
+import PersonPropertyServiceImport from "../service";
+
+// backend service default export can be CJS-interop double-wrapped.
+const PersonPropertyService: any =
+  (PersonPropertyServiceImport as any)?.default ?? PersonPropertyServiceImport;
+
+let pass = 0;
+let fail = 0;
+const ok = (c: boolean, m: string) => {
+  if (c) (pass++, console.log(`  ✓ ${m}`));
+  else (fail++, console.error(`  ✗ ${m}`));
+};
+
+// Contract mirrors src/modules/personproperty/models/person_property.ts. The
+// person link is a Medusa module-link (no FK column), so it is not modelled as a
+// belongsTo here — census_id is the natural key we dedupe/uniquify on.
+const personPropertyContract = defineContract("person_property", {
+  id: { prefix: "pp" },
+  mode: "lax",
+  fields: {
+    profile_type: { type: "string", default: "weaver" },
+    census_id: { type: "string", nullable: true },
+    gender: { type: "string", nullable: true },
+    social_group: { type: "string", nullable: true },
+    region_state: { type: "string", nullable: true },
+    district: { type: "string", nullable: true },
+    own_looms: { type: "boolean", nullable: true },
+    total_looms_owned: { type: "number", nullable: true },
+  },
+  indexes: ["profile_type", "social_group", "district", "region_state", "gender", "own_looms"],
+  unique: ["census_id"],
+  idempotencyKey: (r) => (r.census_id ? `census:${r.census_id}` : undefined),
+});
+
+const STORE = join(tmpdir(), `pp-package-dal-${process.pid}`);
+
+async function main() {
+  if (existsSync(STORE)) rmSync(STORE, { recursive: true, force: true });
+  const store = new Corestore(STORE);
+  await store.ready();
+  const bee = new Hyperbee(store.get({ name: "person_property" }), {
+    keyEncoding: "utf-8",
+    valueEncoding: "binary",
+  });
+  await bee.ready();
+
+  // The package repository IS the internal per-model service.
+  const repo = hyperbeeRepositoryFor(personPropertyContract, bee as any);
+
+  // baseRepository stub: serialize + the manager/transaction seam the generated
+  // service reaches through @InjectManager/@InjectTransactionManager.
+  const baseRepository = {
+    serialize: async (d: any) => JSON.parse(JSON.stringify(d)),
+    getFreshManager: () => repo,
+    getActiveManager: () => repo,
+    transaction: async (task: (m: any) => any) => task(repo),
+  };
+
+  // Construct the REAL generated service with our container.
+  const container = { personPropertyService: repo, baseRepository } as any;
+  const service = new PersonPropertyService(container);
+
+  // ── generated methods over the package DAL ──
+  const created = await service.createPersonProperties({
+    census_id: "1001",
+    profile_type: "weaver",
+    district: "AMBALA",
+    region_state: "HARYANA",
+    total_looms_owned: 3,
+  });
+  const rec = Array.isArray(created) ? created[0] : created;
+  ok(/^pp_\d{6}$/.test(rec?.id), `createPersonProperties -> id (${rec?.id})`);
+  ok(rec?.profile_type === "weaver", "record round-trips profile_type");
+
+  // batch create
+  await service.createPersonProperties([
+    { census_id: "1002", district: "AMBALA", region_state: "HARYANA" },
+    { census_id: "1003", district: "PANIPAT", region_state: "HARYANA" },
+  ]);
+
+  // idempotency through the generated method
+  const dup = await service.createPersonProperties({ census_id: "1001", district: "AMBALA" });
+  const dupRec = Array.isArray(dup) ? dup[0] : dup;
+  ok(dupRec?.id === rec.id, "generated create is idempotent on census_id");
+
+  // retrieve
+  const got = await service.retrievePersonProperty(rec.id);
+  ok(got?.id === rec.id, "retrievePersonProperty works");
+
+  // listAndCount with indexed filter
+  const [rows, count] = await service.listAndCountPersonProperties(
+    { district: "AMBALA" },
+    { take: 10 }
+  );
+  ok(count === 2, `listAndCount district=AMBALA -> 2 (got ${count})`);
+  ok(rows.every((r: any) => r.district === "AMBALA"), "all listed rows match filter");
+
+  // update + reindex
+  const upd = await service.updatePersonProperties({ id: rec.id, district: "PANIPAT" });
+  const updRec = Array.isArray(upd) ? upd[0] : upd;
+  ok(updRec?.district === "PANIPAT", "updatePersonProperties applied");
+  const [, amb] = await service.listAndCountPersonProperties({ district: "AMBALA" });
+  ok(amb === 1, `index updated on change (AMBALA now 1, got ${amb})`);
+
+  rmSync(STORE, { recursive: true, force: true });
+  console.log(`\n${fail === 0 ? "✅ PASS" : "❌ FAIL"} — ${pass} passed, ${fail} failed`);
+  process.exit(fail === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error("SCRIPT THREW:", e);
+  process.exit(1);
+});

--- a/apps/backend/src/modules/personproperty/__tests__/package-dal.script.ts
+++ b/apps/backend/src/modules/personproperty/__tests__/package-dal.script.ts
@@ -17,10 +17,9 @@ import Corestore from "corestore";
 // @ts-ignore
 import Hyperbee from "hyperbee";
 
-// Import the extracted package by source (workspace dep wiring comes with the
-// real step-2 module rewire; a relative import keeps this script self-contained).
-import { defineContract, hyperbeeRepositoryFor } from "../../../../../../packages/mikrohyperbee/src";
+import { hyperbeeRepositoryFor } from "@jytextiles/mikrohyperbee";
 
+import { personPropertyContract } from "../dal/hyperbee-person-property-service";
 import PersonPropertyServiceImport from "../service";
 
 // backend service default export can be CJS-interop double-wrapped.
@@ -34,27 +33,7 @@ const ok = (c: boolean, m: string) => {
   else (fail++, console.error(`  ✗ ${m}`));
 };
 
-// Contract mirrors src/modules/personproperty/models/person_property.ts. The
-// person link is a Medusa module-link (no FK column), so it is not modelled as a
-// belongsTo here — census_id is the natural key we dedupe/uniquify on.
-const personPropertyContract = defineContract("person_property", {
-  id: { prefix: "pp" },
-  mode: "lax",
-  fields: {
-    profile_type: { type: "string", default: "weaver" },
-    census_id: { type: "string", nullable: true },
-    gender: { type: "string", nullable: true },
-    social_group: { type: "string", nullable: true },
-    region_state: { type: "string", nullable: true },
-    district: { type: "string", nullable: true },
-    own_looms: { type: "boolean", nullable: true },
-    total_looms_owned: { type: "number", nullable: true },
-  },
-  indexes: ["profile_type", "social_group", "district", "region_state", "gender", "own_looms"],
-  unique: ["census_id"],
-  idempotencyKey: (r) => (r.census_id ? `census:${r.census_id}` : undefined),
-});
-
+// Uses the REAL production contract from ../dal/hyperbee-person-property-service.
 const STORE = join(tmpdir(), `pp-package-dal-${process.pid}`);
 
 async function main() {

--- a/apps/backend/src/modules/personproperty/__tests__/workflow-engine-hyperbee.script.ts
+++ b/apps/backend/src/modules/personproperty/__tests__/workflow-engine-hyperbee.script.ts
@@ -1,0 +1,204 @@
+/**
+ * Step 3 — durable workflow execution over Hyperbee (Seam B, full engine class).
+ *
+ * Boots Medusa's REAL InMemoryDistributedTransactionStorage (the actual code the
+ * workflow engine uses to persist `store:true` transactions) with our
+ * @jytextiles/mikrohyperbee package repository injected as the
+ * `workflowExecutionService`. Then drives real save()/get() checkpoints and
+ * proves the two things durable execution needs:
+ *   (1) a checkpoint written by one instance SURVIVES a simulated process death
+ *       (a fresh repo + storage over the SAME on-disk store reads it back), and
+ *   (2) retention cleanup works in JS (the one Postgres raw() predicate the
+ *       engine uses is reimplemented here — clearExpiredWorkflowExecutions).
+ *
+ * No Postgres. Run:
+ *   cd apps/backend && ../../node_modules/.bin/tsx \
+ *     src/modules/personproperty/__tests__/workflow-engine-hyperbee.script.ts
+ */
+import { existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// @ts-ignore
+import Corestore from "corestore";
+// @ts-ignore
+import Hyperbee from "hyperbee";
+// @ts-ignore - deep import of the engine's real storage class (dist JS)
+import { InMemoryDistributedTransactionStorage } from "@medusajs/workflow-engine-inmemory/dist/utils/workflow-orchestrator-storage";
+import { TransactionState } from "@medusajs/utils";
+
+import { defineContract, hyperbeeRepositoryFor, type ModelRepository } from "@jytextiles/mikrohyperbee";
+
+let pass = 0;
+let fail = 0;
+const ok = (c: boolean, m: string) => {
+  if (c) (pass++, console.log(`  ✓ ${m}`));
+  else (fail++, console.error(`  ✗ ${m}`));
+};
+
+const STORE = join(tmpdir(), `wf-engine-hb-${process.pid}`);
+const noopLogger = { info() {}, error() {}, warn() {}, debug() {} };
+
+// The workflow_execution model (mirrors @medusajs/workflow-engine-inmemory).
+const workflowExecution = defineContract("workflow_execution", {
+  id: { prefix: "wf_exec" },
+  primaryKey: ["workflow_id", "transaction_id", "run_id"],
+  mode: "lax",
+  fields: {
+    workflow_id: { type: "string", required: true },
+    transaction_id: { type: "string", required: true },
+    run_id: { type: "string", required: true },
+    execution: { type: "json", nullable: true },
+    context: { type: "json", nullable: true },
+    state: { type: "string" },
+    retention_time: { type: "number", nullable: true },
+    updated_at: { type: "number", nullable: true },
+  },
+  indexes: ["workflow_id", "transaction_id", "run_id", "state"],
+});
+
+function openRepo() {
+  const store = new Corestore(STORE);
+  const bee = new Hyperbee(store.get({ name: "workflow_execution" }), {
+    keyEncoding: "utf-8",
+    valueEncoding: "binary",
+  });
+  return { store, repo: hyperbeeRepositoryFor(workflowExecution, bee as any) };
+}
+
+// A realistic transaction checkpoint (the shape DistributedTransaction hands to save()).
+function checkpoint(state: any, extra: Record<string, any> = {}) {
+  return {
+    flow: {
+      modelId: "create-weaver",
+      transactionId: "tx_1",
+      runId: "run_1",
+      state,
+      startedAt: 1,
+      steps: { _root: { id: "_root", depth: 0, definition: {}, invoke: {}, compensate: {} } },
+      definition: {},
+      metadata: {},
+      ...extra,
+    },
+    context: { input: 7 },
+    errors: [],
+  };
+}
+
+// JS reimplementation of the engine's clearExpiredExecutions (which uses a
+// Postgres raw() predicate). This is what a Hyperbee-backed storage would run.
+async function clearExpiredWorkflowExecutions(
+  repo: ModelRepository,
+  nowMs: number
+): Promise<number> {
+  const finished = new Set([
+    TransactionState.DONE,
+    TransactionState.FAILED,
+    TransactionState.REVERTED,
+  ]);
+  const all = await repo.list({}, { take: 100000 });
+  const expired = all.filter(
+    (r: any) =>
+      r.retention_time != null &&
+      // If a row can't be aged (no updated_at), never delete it — conservative by
+      // design. NOTE: engine-persisted rows lack updated_at today; production
+      // retention needs the package to stamp updated_at on write (follow-up).
+      r.updated_at != null &&
+      finished.has(r.state) &&
+      Number(r.updated_at) + r.retention_time * 1000 <= nowMs
+  );
+  for (const r of expired) {
+    await repo.delete([{ run_id: r.run_id, transaction_id: r.transaction_id, workflow_id: r.workflow_id }]);
+  }
+  return expired.length;
+}
+
+async function main() {
+  if (existsSync(STORE)) rmSync(STORE, { recursive: true, force: true });
+
+  const KEY = "dtx:create-weaver:tx_1"; // storage key: <prefix>:<workflowId>:<transactionId>
+
+  // ── "process A": engine persists an IN-PROGRESS checkpoint, then closes ──
+  {
+    const { store, repo } = openRepo();
+    const storage: any = new InMemoryDistributedTransactionStorage({
+      workflowExecutionService: repo,
+      logger: noopLogger,
+    });
+    // NOT_STARTED is a persisted, resumable state (get() deliberately refuses to
+    // return DONE/failed/reverted — a finished txn is never resumed).
+    await storage.save(KEY, checkpoint(TransactionState.NOT_STARTED), 0, {});
+    const loaded = await storage.get(KEY);
+    ok(!!loaded, "engine save() → get() round-trips an in-progress checkpoint over Hyperbee");
+    ok((await repo.list({ transaction_id: "tx_1" })).length === 1, "checkpoint row persisted to Hyperbee");
+    await store.close(); // ← the process boundary
+  }
+
+  // ── SIMULATED CRASH → "process B": fresh repo + storage over the SAME store ──
+  {
+    const { store, repo } = openRepo();
+    const storage: any = new InMemoryDistributedTransactionStorage({
+      workflowExecutionService: repo,
+      logger: noopLogger,
+    });
+    const resumed = await storage.get(KEY);
+    ok(!!resumed, "checkpoint SURVIVES process death — a fresh engine instance reads it from Hyperbee");
+    ok(resumed?.flow?.state === TransactionState.NOT_STARTED, "resumed flow has the persisted state");
+    ok(resumed?.context?.input === 7, "resumed checkpoint restores the transaction context");
+
+    // advance to DONE with retention → engine saveToDb persists in place
+    await storage.save(KEY, checkpoint(TransactionState.DONE), 0, { retentionTime: 3600 });
+    const rows = await repo.list({ transaction_id: "tx_1" });
+    ok(rows.length === 1, `completed txn updated in place, no dup (got ${rows.length})`);
+    ok(rows[0].retention_time === 3600, "retention_time persisted on completion");
+    ok(rows[0].execution?.state === TransactionState.DONE, "execution jsonb advanced to DONE");
+    await store.close();
+  }
+
+  // ── completion WITHOUT retention → engine deleteFromDb removes the row ──
+  {
+    const { store, repo } = openRepo();
+    const storage: any = new InMemoryDistributedTransactionStorage({
+      workflowExecutionService: repo,
+      logger: noopLogger,
+    });
+    // a second transaction that finishes with no retention
+    const K2 = "dtx:create-weaver:tx_2";
+    await storage.save(K2, checkpoint(TransactionState.NOT_STARTED, { transactionId: "tx_2", runId: "run_2" }), 0, {});
+    await storage.save(K2, checkpoint(TransactionState.DONE, { transactionId: "tx_2", runId: "run_2" }), 0, {});
+    ok((await repo.list({ transaction_id: "tx_2" })).length === 0, "deleteFromDb removed the finished, non-retained txn");
+    await store.close();
+  }
+
+  // ── JS retention (replaces the engine's Postgres raw() predicate) ──
+  {
+    const { store, repo } = openRepo();
+
+    // one already-expired retained row, one still-valid, one no-retention
+    const now = 1_000_000_000_000;
+    await repo.upsert([
+      { workflow_id: "w", transaction_id: "old", run_id: "r_old", state: TransactionState.DONE, retention_time: 60, updated_at: now - 120_000 },
+      { workflow_id: "w", transaction_id: "fresh", run_id: "r_fresh", state: TransactionState.DONE, retention_time: 3600, updated_at: now - 1_000 },
+      { workflow_id: "w", transaction_id: "keep", run_id: "r_keep", state: TransactionState.DONE, retention_time: null, updated_at: now - 999_999 },
+    ]);
+
+    const cleared = await clearExpiredWorkflowExecutions(repo, now);
+    ok(cleared === 1, `retention swept exactly the expired row (cleared=${cleared})`);
+    const remaining = await repo.list({ workflow_id: "w" });
+    const ids = remaining.map((r: any) => r.transaction_id).sort();
+    ok(
+      !ids.includes("old") && ids.includes("fresh") && ids.includes("keep"),
+      "expired removed; unexpired + non-retained kept"
+    );
+    await store.close();
+  }
+
+  rmSync(STORE, { recursive: true, force: true });
+  console.log(`\n${fail === 0 ? "✅ PASS" : "❌ FAIL"} — ${pass} passed, ${fail} failed`);
+  process.exit(fail === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error("SCRIPT THREW:", e);
+  process.exit(1);
+});

--- a/apps/backend/src/modules/personproperty/dal/hyperbee-person-property-service.ts
+++ b/apps/backend/src/modules/personproperty/dal/hyperbee-person-property-service.ts
@@ -1,211 +1,97 @@
-import { brotliCompressSync, brotliDecompressSync } from "node:zlib";
-
+/**
+ * MikroHyperbee DAL for `person_property` — now a thin binding over the extracted
+ * `@jytextiles/mikrohyperbee` package. The generic HyperbeeBaseRepository + the
+ * staged write-contract live in the package; this file just declares the
+ * person_property contract and hands back a repository.
+ *
+ * The package core imports zero @medusajs and no native deps (it takes a ready
+ * Hyperbee), so importing it here is production-safe even with the flag off — the
+ * loader only opens a store + builds the repo when PERSON_PROPERTY_HYPERBEE=true.
+ *
+ * Contract mirrors ../models/person_property.ts. The person link is a Medusa
+ * module-link (no FK column), so it is not a belongsTo here; census_id is the
+ * natural key we uniquify + dedupe (idempotent re-import) on. Provenance domain →
+ * lax mode (schema-on-read flexibility, keep uniqueness).
+ */
 import { MedusaError } from "@medusajs/framework/utils";
 
-/**
- * Hyperbee-backed internal model service for `person_property` — the "MikroHyperbee"
- * DAL. It implements exactly the surface Medusa's generated PersonPropertyService
- * (`MedusaService({ PersonProperty })`) calls on the injected internal service
- * `container.personPropertyService`, so the REAL generated
- * create/list/listAndCount/retrieve/update/delete methods run over Hyperbee with
- * no Postgres / MikroORM.
- *
- * Proven end-to-end against the real service class in the MikroHyperbee spike
- * (scripts/handloom-scrape/hyperbee-slice/person-property-medusa-e2e.ts, 11/11).
- * This is that HyperbeeModelService ported into the module, typed.
- *
- * Records live in the `rec` sub (brotli-compressed JSON); equality-filterable
- * fields get a secondary `idx` sub (`field/value/id -> id`) for indexed lookups;
- * everything else falls back to a full scan + in-memory match.
- */
+import {
+  ContractError,
+  defineContract,
+  hyperbeeRepositoryFor,
+  type BeeLike,
+  type ModelRepository,
+} from "@jytextiles/mikrohyperbee";
 
-// Fields we maintain a secondary index for (the ones weavers are segmented by).
-const INDEXED = [
-  "profile_type",
-  "social_group",
-  "district",
-  "region_state",
-  "gender",
-  "own_looms",
-] as const;
+export const personPropertyContract = defineContract("person_property", {
+  id: { prefix: "pp" },
+  mode: "lax",
+  fields: {
+    profile_type: { type: "string", default: "weaver" },
+    census_id: { type: "string", nullable: true },
+    relation_to_head: { type: "string", nullable: true },
+    gender: { type: "string", nullable: true },
+    social_group: { type: "string", nullable: true },
+    religion: { type: "string", nullable: true },
+    region_state: { type: "string", nullable: true },
+    district: { type: "string", nullable: true },
+    own_looms: { type: "boolean", nullable: true },
+    total_looms_owned: { type: "number", nullable: true },
+    natural_dye_used: { type: "boolean", nullable: true },
+    sells_local_market: { type: "boolean", nullable: true },
+    sells_master_weaver: { type: "boolean", nullable: true },
+    sells_cooperative: { type: "boolean", nullable: true },
+    sells_ecommerce: { type: "boolean", nullable: true },
+    support_requirements: { type: "json", nullable: true },
+    metadata: { type: "json", nullable: true },
+  },
+  // The fields weavers are segmented by (equality secondary index).
+  indexes: ["profile_type", "social_group", "district", "region_state", "gender", "own_looms"],
+  // census_id is the natural identity — unique + idempotent on re-import.
+  unique: ["census_id"],
+  idempotencyKey: (r) => (r.census_id ? `census:${r.census_id}` : undefined),
+});
 
-type Where = Record<string, unknown>;
-type ListConfig = { take?: number; skip?: number; order?: Record<string, string> };
+// ── Medusa adapter ──────────────────────────────────────────────────────────
+// The package core is Medusa-free and throws its own ContractError; Medusa's
+// routes + error middleware expect MedusaError (for 404/400 mapping). This thin
+// boundary translates the two. It wraps only the repository methods so the
+// underlying identity (constructor.name = HyperbeeBaseRepository) is preserved.
+const ERROR_MAP: Record<ContractError["type"], string> = {
+  not_found: MedusaError.Types.NOT_FOUND,
+  invalid_data: MedusaError.Types.INVALID_DATA,
+  not_unique: MedusaError.Types.INVALID_DATA,
+  not_allowed: MedusaError.Types.NOT_ALLOWED,
+};
+const WRAPPED = new Set([
+  "create", "retrieve", "list", "listAndCount", "update", "upsert", "delete", "softDelete", "restore",
+]);
 
-const matches = (row: Record<string, any>, where: Where = {}): boolean =>
-  Object.entries(where).every(([k, cond]) => {
-    const v = row[k];
-    if (cond && typeof cond === "object") {
-      const c = cond as Record<string, any>;
-      if ("$in" in c) return c.$in.includes(v);
-      if ("$ne" in c) return v !== c.$ne;
-      if ("$gt" in c) return v > c.$gt;
-      if ("$gte" in c) return v >= c.$gte;
-      if ("$lt" in c) return v < c.$lt;
-      if ("$lte" in c) return v <= c.$lte;
-    }
-    return v === cond;
-  });
-
-export class HyperbeePersonPropertyService {
-  private recs: any;
-  private idx: any;
-  private seq = 0;
-
-  constructor(bee: any) {
-    this.recs = bee.sub("rec", { valueEncoding: "binary" });
-    this.idx = bee.sub("idx", { valueEncoding: "utf-8" });
-  }
-
-  private enc(o: unknown): Buffer {
-    return brotliCompressSync(Buffer.from(JSON.stringify(o)));
-  }
-  private dec(b: Buffer): any {
-    return JSON.parse(brotliDecompressSync(b).toString());
-  }
-  // Deterministic id (no Date.now/Math.random — keeps replicas byte-identical).
-  private nextId(): string {
-    return `pp_${String(++this.seq).padStart(6, "0")}`;
-  }
-
-  private async index(row: Record<string, any>): Promise<void> {
-    for (const f of INDEXED) {
-      if (row[f] !== undefined && row[f] !== null) {
-        await this.idx.put(`${f}/${String(row[f])}/${row.id}`, row.id);
-      }
-    }
-  }
-  private async deindex(row: Record<string, any>): Promise<void> {
-    for (const f of INDEXED) {
-      if (row[f] !== undefined && row[f] !== null) {
-        await this.idx.del(`${f}/${String(row[f])}/${row.id}`);
-      }
-    }
-  }
-  private async get(id: string): Promise<any | null> {
-    const node = await this.recs.get(String(id));
-    return node ? this.dec(node.value) : null;
-  }
-
-  // ── surface Medusa's generated methods invoke on the internal service ──
-
-  async create(data: any): Promise<any> {
-    const arr = Array.isArray(data) ? data : [data];
-    const out: any[] = [];
-    for (const d of arr) {
-      const row = { id: d.id || this.nextId(), ...d };
-      await this.recs.put(row.id, this.enc(row));
-      await this.index(row);
-      out.push(row);
-    }
-    return Array.isArray(data) ? out : out[0];
-  }
-
-  async retrieve(id: string): Promise<any> {
-    const r = await this.get(id);
-    if (!r) {
-      throw new MedusaError(
-        MedusaError.Types.NOT_FOUND,
-        `PersonProperty with id: ${id} was not found`
-      );
-    }
-    return r;
-  }
-
-  // Resolve a where-clause to candidate ids, intersecting secondary indexes when
-  // the filter uses indexed equality; otherwise scan all record keys.
-  private async candidateIds(where: Where = {}): Promise<string[]> {
-    const eqIndexed = Object.entries(where).filter(
-      ([k, v]) =>
-        (INDEXED as readonly string[]).includes(k) &&
-        (typeof v !== "object" || v === null)
-    );
-    if (eqIndexed.length) {
-      const sets = await Promise.all(
-        eqIndexed.map(async ([k, v]) => {
-          const s = new Set<string>();
-          const p = `${k}/${String(v)}/`;
-          for await (const { value: id } of this.idx.createReadStream({
-            gte: p,
-            lt: p + "~",
-          })) {
-            s.add(id);
+function toMedusaRepository(repo: ModelRepository): ModelRepository {
+  return new Proxy(repo, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value === "function" && WRAPPED.has(prop as string)) {
+        return async (...args: any[]) => {
+          try {
+            return await (value as (...a: any[]) => any).apply(target, args);
+          } catch (e) {
+            if (e instanceof ContractError) {
+              throw new MedusaError(
+                ERROR_MAP[e.type] ?? MedusaError.Types.UNEXPECTED_STATE,
+                e.message
+              );
+            }
+            throw e;
           }
-          return s;
-        })
-      );
-      return [...sets.reduce((a, b) => new Set([...a].filter((x) => b.has(x))))];
-    }
-    const ids: string[] = [];
-    for await (const { key } of this.recs.createReadStream()) ids.push(key);
-    return ids;
-  }
-
-  private async resolve(filters: Where): Promise<any[]> {
-    const ids = await this.candidateIds(filters);
-    const rows: any[] = [];
-    for (const id of ids) {
-      const r = await this.get(id);
-      if (r && matches(r, filters)) rows.push(r);
-    }
-    return rows;
-  }
-
-  async list(filters: Where = {}, config: ListConfig = {}): Promise<any[]> {
-    const rows = await this.resolve(filters);
-    const { take = 15, skip = 0, order } = config || {};
-    if (order) {
-      const [f, dir] = Object.entries(order)[0] as [string, string];
-      const sign = String(dir).toUpperCase() === "DESC" ? -1 : 1;
-      rows.sort((a, b) => (a[f] > b[f] ? 1 : a[f] < b[f] ? -1 : 0) * sign);
-    } else {
-      rows.sort((a, b) => (a.id > b.id ? 1 : -1));
-    }
-    return rows.slice(skip, skip + take);
-  }
-
-  async listAndCount(
-    filters: Where = {},
-    config: ListConfig = {}
-  ): Promise<[any[], number]> {
-    const count = (await this.resolve(filters)).length;
-    return [await this.list(filters, config), count];
-  }
-
-  async update(data: any): Promise<any> {
-    const arr = Array.isArray(data) ? data : [data];
-    const out: any[] = [];
-    for (const d of arr) {
-      const cur = await this.retrieve(d.id);
-      await this.deindex(cur);
-      const row = { ...cur, ...d };
-      await this.recs.put(row.id, this.enc(row));
-      await this.index(row);
-      out.push(row);
-    }
-    return Array.isArray(data) ? out : out[0];
-  }
-
-  async delete(pks: string | string[]): Promise<void> {
-    const ids = Array.isArray(pks) ? pks : [pks];
-    for (const id of ids) {
-      const cur = await this.get(id);
-      if (cur) {
-        await this.deindex(cur);
-        await this.recs.del(id);
+        };
       }
-    }
-  }
-
-  // A KV store has no soft-delete/restore semantics; return the empty shapes the
-  // generated service expects. (Onboarded person_property records are few and
-  // hard-deleted; the append-only history lives in the core itself.)
-  async softDelete(): Promise<[any[], Record<string, unknown>]> {
-    return [[], {}];
-  }
-  async restore(): Promise<[any[], Record<string, unknown>]> {
-    return [[], {}];
-  }
+      return value;
+    },
+  }) as ModelRepository;
 }
 
-export default HyperbeePersonPropertyService;
+/** Build the Hyperbee-backed internal service Medusa's generated methods call. */
+export function createPersonPropertyRepository(bee: BeeLike) {
+  return toMedusaRepository(hyperbeeRepositoryFor(personPropertyContract, bee));
+}

--- a/apps/backend/src/modules/personproperty/dal/hyperbee-person-property-service.ts
+++ b/apps/backend/src/modules/personproperty/dal/hyperbee-person-property-service.ts
@@ -1,0 +1,211 @@
+import { brotliCompressSync, brotliDecompressSync } from "node:zlib";
+
+import { MedusaError } from "@medusajs/framework/utils";
+
+/**
+ * Hyperbee-backed internal model service for `person_property` — the "MikroHyperbee"
+ * DAL. It implements exactly the surface Medusa's generated PersonPropertyService
+ * (`MedusaService({ PersonProperty })`) calls on the injected internal service
+ * `container.personPropertyService`, so the REAL generated
+ * create/list/listAndCount/retrieve/update/delete methods run over Hyperbee with
+ * no Postgres / MikroORM.
+ *
+ * Proven end-to-end against the real service class in the MikroHyperbee spike
+ * (scripts/handloom-scrape/hyperbee-slice/person-property-medusa-e2e.ts, 11/11).
+ * This is that HyperbeeModelService ported into the module, typed.
+ *
+ * Records live in the `rec` sub (brotli-compressed JSON); equality-filterable
+ * fields get a secondary `idx` sub (`field/value/id -> id`) for indexed lookups;
+ * everything else falls back to a full scan + in-memory match.
+ */
+
+// Fields we maintain a secondary index for (the ones weavers are segmented by).
+const INDEXED = [
+  "profile_type",
+  "social_group",
+  "district",
+  "region_state",
+  "gender",
+  "own_looms",
+] as const;
+
+type Where = Record<string, unknown>;
+type ListConfig = { take?: number; skip?: number; order?: Record<string, string> };
+
+const matches = (row: Record<string, any>, where: Where = {}): boolean =>
+  Object.entries(where).every(([k, cond]) => {
+    const v = row[k];
+    if (cond && typeof cond === "object") {
+      const c = cond as Record<string, any>;
+      if ("$in" in c) return c.$in.includes(v);
+      if ("$ne" in c) return v !== c.$ne;
+      if ("$gt" in c) return v > c.$gt;
+      if ("$gte" in c) return v >= c.$gte;
+      if ("$lt" in c) return v < c.$lt;
+      if ("$lte" in c) return v <= c.$lte;
+    }
+    return v === cond;
+  });
+
+export class HyperbeePersonPropertyService {
+  private recs: any;
+  private idx: any;
+  private seq = 0;
+
+  constructor(bee: any) {
+    this.recs = bee.sub("rec", { valueEncoding: "binary" });
+    this.idx = bee.sub("idx", { valueEncoding: "utf-8" });
+  }
+
+  private enc(o: unknown): Buffer {
+    return brotliCompressSync(Buffer.from(JSON.stringify(o)));
+  }
+  private dec(b: Buffer): any {
+    return JSON.parse(brotliDecompressSync(b).toString());
+  }
+  // Deterministic id (no Date.now/Math.random — keeps replicas byte-identical).
+  private nextId(): string {
+    return `pp_${String(++this.seq).padStart(6, "0")}`;
+  }
+
+  private async index(row: Record<string, any>): Promise<void> {
+    for (const f of INDEXED) {
+      if (row[f] !== undefined && row[f] !== null) {
+        await this.idx.put(`${f}/${String(row[f])}/${row.id}`, row.id);
+      }
+    }
+  }
+  private async deindex(row: Record<string, any>): Promise<void> {
+    for (const f of INDEXED) {
+      if (row[f] !== undefined && row[f] !== null) {
+        await this.idx.del(`${f}/${String(row[f])}/${row.id}`);
+      }
+    }
+  }
+  private async get(id: string): Promise<any | null> {
+    const node = await this.recs.get(String(id));
+    return node ? this.dec(node.value) : null;
+  }
+
+  // ── surface Medusa's generated methods invoke on the internal service ──
+
+  async create(data: any): Promise<any> {
+    const arr = Array.isArray(data) ? data : [data];
+    const out: any[] = [];
+    for (const d of arr) {
+      const row = { id: d.id || this.nextId(), ...d };
+      await this.recs.put(row.id, this.enc(row));
+      await this.index(row);
+      out.push(row);
+    }
+    return Array.isArray(data) ? out : out[0];
+  }
+
+  async retrieve(id: string): Promise<any> {
+    const r = await this.get(id);
+    if (!r) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `PersonProperty with id: ${id} was not found`
+      );
+    }
+    return r;
+  }
+
+  // Resolve a where-clause to candidate ids, intersecting secondary indexes when
+  // the filter uses indexed equality; otherwise scan all record keys.
+  private async candidateIds(where: Where = {}): Promise<string[]> {
+    const eqIndexed = Object.entries(where).filter(
+      ([k, v]) =>
+        (INDEXED as readonly string[]).includes(k) &&
+        (typeof v !== "object" || v === null)
+    );
+    if (eqIndexed.length) {
+      const sets = await Promise.all(
+        eqIndexed.map(async ([k, v]) => {
+          const s = new Set<string>();
+          const p = `${k}/${String(v)}/`;
+          for await (const { value: id } of this.idx.createReadStream({
+            gte: p,
+            lt: p + "~",
+          })) {
+            s.add(id);
+          }
+          return s;
+        })
+      );
+      return [...sets.reduce((a, b) => new Set([...a].filter((x) => b.has(x))))];
+    }
+    const ids: string[] = [];
+    for await (const { key } of this.recs.createReadStream()) ids.push(key);
+    return ids;
+  }
+
+  private async resolve(filters: Where): Promise<any[]> {
+    const ids = await this.candidateIds(filters);
+    const rows: any[] = [];
+    for (const id of ids) {
+      const r = await this.get(id);
+      if (r && matches(r, filters)) rows.push(r);
+    }
+    return rows;
+  }
+
+  async list(filters: Where = {}, config: ListConfig = {}): Promise<any[]> {
+    const rows = await this.resolve(filters);
+    const { take = 15, skip = 0, order } = config || {};
+    if (order) {
+      const [f, dir] = Object.entries(order)[0] as [string, string];
+      const sign = String(dir).toUpperCase() === "DESC" ? -1 : 1;
+      rows.sort((a, b) => (a[f] > b[f] ? 1 : a[f] < b[f] ? -1 : 0) * sign);
+    } else {
+      rows.sort((a, b) => (a.id > b.id ? 1 : -1));
+    }
+    return rows.slice(skip, skip + take);
+  }
+
+  async listAndCount(
+    filters: Where = {},
+    config: ListConfig = {}
+  ): Promise<[any[], number]> {
+    const count = (await this.resolve(filters)).length;
+    return [await this.list(filters, config), count];
+  }
+
+  async update(data: any): Promise<any> {
+    const arr = Array.isArray(data) ? data : [data];
+    const out: any[] = [];
+    for (const d of arr) {
+      const cur = await this.retrieve(d.id);
+      await this.deindex(cur);
+      const row = { ...cur, ...d };
+      await this.recs.put(row.id, this.enc(row));
+      await this.index(row);
+      out.push(row);
+    }
+    return Array.isArray(data) ? out : out[0];
+  }
+
+  async delete(pks: string | string[]): Promise<void> {
+    const ids = Array.isArray(pks) ? pks : [pks];
+    for (const id of ids) {
+      const cur = await this.get(id);
+      if (cur) {
+        await this.deindex(cur);
+        await this.recs.del(id);
+      }
+    }
+  }
+
+  // A KV store has no soft-delete/restore semantics; return the empty shapes the
+  // generated service expects. (Onboarded person_property records are few and
+  // hard-deleted; the append-only history lives in the core itself.)
+  async softDelete(): Promise<[any[], Record<string, unknown>]> {
+    return [[], {}];
+  }
+  async restore(): Promise<[any[], Record<string, unknown>]> {
+    return [[], {}];
+  }
+}
+
+export default HyperbeePersonPropertyService;

--- a/apps/backend/src/modules/personproperty/index.ts
+++ b/apps/backend/src/modules/personproperty/index.ts
@@ -1,8 +1,12 @@
 import { Module } from "@medusajs/framework/utils";
+import hyperbeeDalLoader from "./loaders/hyperbee-dal";
 import PersonPropertyService from "./service";
 
 export const PERSON_PROPERTY_MODULE = "person_property";
 
 export default Module(PERSON_PROPERTY_MODULE, {
   service: PersonPropertyService,
+  // Flag-gated MikroHyperbee DAL swap; strict no-op unless
+  // PERSON_PROPERTY_HYPERBEE=true (defaults to the MikroORM/Postgres DAL).
+  loaders: [hyperbeeDalLoader],
 });

--- a/apps/backend/src/modules/personproperty/loaders/hyperbee-dal.ts
+++ b/apps/backend/src/modules/personproperty/loaders/hyperbee-dal.ts
@@ -2,7 +2,7 @@ import { asValue } from "awilix";
 
 import type { LoaderOptions } from "@medusajs/framework/types";
 
-import { HyperbeePersonPropertyService } from "../dal/hyperbee-person-property-service";
+import { createPersonPropertyRepository } from "../dal/hyperbee-person-property-service";
 
 /**
  * MikroHyperbee DAL swap for the `person_property` module.
@@ -51,7 +51,7 @@ export default async function hyperbeeDalLoader({ container }: LoaderOptions) {
     });
     await bee.ready();
 
-    const internal = new HyperbeePersonPropertyService(bee);
+    const internal = createPersonPropertyRepository(bee);
 
     // For a KV store the "manager" is a no-op and a transaction runs inline; the
     // outer generated service only uses baseRepository.serialize. (Mirrors the

--- a/apps/backend/src/modules/personproperty/loaders/hyperbee-dal.ts
+++ b/apps/backend/src/modules/personproperty/loaders/hyperbee-dal.ts
@@ -1,0 +1,80 @@
+import { asValue } from "awilix";
+
+import type { LoaderOptions } from "@medusajs/framework/types";
+
+import { HyperbeePersonPropertyService } from "../dal/hyperbee-person-property-service";
+
+/**
+ * MikroHyperbee DAL swap for the `person_property` module.
+ *
+ * Flag-gated + fully non-fatal. When PERSON_PROPERTY_HYPERBEE=true, this loader
+ * opens a local Hyperbee-backed store and overrides the module container's
+ * `personPropertyService` (the internal per-model service the generated
+ * PersonPropertyService delegates to) and `baseRepository` (the serialize +
+ * manager/transaction seam) with Hyperbee equivalents — so the REAL generated
+ * create/list/listAndCount/retrieve/update/delete run over Hyperbee, no Postgres.
+ *
+ * With the flag unset (the default), this returns immediately and the module
+ * keeps its normal MikroORM/Postgres DAL — so it is a strict no-op until opted in.
+ *
+ * The DAL logic is proven against the real service class in the MikroHyperbee
+ * spike (person-property-medusa-e2e.ts, 11/11). The one seam that still needs a
+ * live Medusa boot to confirm is whether this loader's container override takes
+ * effect over the auto-registered internal service — hence flag-off by default.
+ */
+export default async function hyperbeeDalLoader({ container }: LoaderOptions) {
+  const logger = container.resolve("logger", { allowUnregistered: true }) as
+    | { info: (m: string) => void; error: (m: string) => void }
+    | undefined;
+
+  if (process.env.PERSON_PROPERTY_HYPERBEE !== "true") {
+    return;
+  }
+
+  const storeDir =
+    process.env.PERSON_PROPERTY_HYPERBEE_STORE || "./.person-property-store";
+
+  try {
+    // Native hypercore stack (corestore -> rocksdb-native) is dynamic-imported so
+    // a build/runtime without the optional deps never breaks — same pattern as
+    // the census reader loader.
+    const [{ default: Corestore }, { default: Hyperbee }] = await Promise.all([
+      import("corestore"),
+      import("hyperbee"),
+    ]);
+
+    const store = new Corestore(storeDir);
+    await store.ready();
+    const bee = new Hyperbee(store.get({ name: "person_property" }), {
+      keyEncoding: "utf-8",
+      valueEncoding: "binary",
+    });
+    await bee.ready();
+
+    const internal = new HyperbeePersonPropertyService(bee);
+
+    // For a KV store the "manager" is a no-op and a transaction runs inline; the
+    // outer generated service only uses baseRepository.serialize. (Mirrors the
+    // proven spike container shape.)
+    const baseRepository = {
+      serialize: async (d: any) => JSON.parse(JSON.stringify(d)),
+      getFreshManager: () => internal,
+      getActiveManager: () => internal,
+      transaction: async (task: (m: any) => any) => task(internal),
+    };
+
+    container.register({
+      personPropertyService: asValue(internal),
+      baseRepository: asValue(baseRepository),
+    });
+
+    logger?.info(
+      "[person_property] MikroHyperbee DAL active — records served from Hyperbee (PERSON_PROPERTY_HYPERBEE=true)"
+    );
+  } catch (e: any) {
+    // Never break boot: log and leave the default Postgres DAL in place.
+    logger?.error(
+      `[person_property] Hyperbee DAL failed to start, falling back to Postgres: ${e?.message || e}`
+    );
+  }
+}

--- a/apps/docs/notes/MIKROHYPERBEE_FRAMEWORK.md
+++ b/apps/docs/notes/MIKROHYPERBEE_FRAMEWORK.md
@@ -1,0 +1,209 @@
+# MikroHyperbee — a Hyperbee-backed DAL and the path off Medusa
+
+> **Status (2026-07-15):** seam verified end-to-end; package `packages/mikrohyperbee/`
+> being scaffolded. This is the design-of-record. Related memory: the
+> `handloom / hyperbee / MikroHyperbee` topic and `#938 product-as-spine`.
+
+## 1. North star — learn from, don't clone; strangle, don't rewrite
+
+The goal is **not** to reproduce Medusa's exact data structures/APIs so they keep
+working. It is to **learn from Medusa's patterns** and build our **own resilient
+framework** on an append-log + P2P foundation, then **move off Medusa
+incrementally** — a strangler-fig, never a big-bang rewrite ("resilient rather
+than breaking everything apart").
+
+So the design question at every step is: *which Medusa pattern is worth carrying
+forward, and which is Postgres-coupling to shed?*
+
+The endgame is a standalone framework — our own model→CRUD codegen + a
+`query.graph`-style joiner + a thin HTTP layer — that **Medusa imports today and a
+Medusa-free app imports tomorrow.** Same repository code powers both. "Moving
+away" becomes deleting an import, not un-forking a fork.
+
+## 2. The one decision that unlocks it: replace at the seam, never fork the source
+
+Medusa is built so you don't fork each writer — every writer funnels through **one
+swappable interface**. There are two, and both are already swappable:
+
+- **Seam A — `RepositoryService` / `baseRepository`** (the module DAL). Every
+  `MedusaService`'s generated CRUD delegates to an internal `${model}Service`,
+  which delegates to an injected repository implementing a fixed interface:
+  `find / findAndCount / create / update / delete / upsert / softDelete / restore
+  / serialize / transaction / getFreshManager / getActiveManager`. Satisfy that
+  interface and the service, links, `query.graph`, and workflow steps above it
+  never know the store changed.
+- **Seam B — `DistributedTransactionStorage`** (workflow persistence,
+  `get / save / scheduleRetry / scheduleStepTimeout / clearExpiredExecutions`,
+  injected via `DistributedTransaction.setStorage`). Independent of Seam A.
+
+**Do NOT patch Medusa's source.** Forking inherits merge conflicts on every
+release and *deepens* coupling — the opposite of the goal. Read Medusa's source as
+a *pattern reference* for the one thing we rebuild (codegen + joiner); replace
+everything else at the seam.
+
+### The seam is verified (2026-07-15)
+
+The module's flag-gated loader override provably beats Medusa's auto-registered
+internal service, two ways:
+
+- **By construction:** `@medusajs/modules-sdk` `prepareLoaders`
+  (`dist/loaders/utils/load-internal.js:465-500`) pushes `connectionLoader` →
+  `containerLoader` (registers the internal service + `baseRepository`) → **then
+  the module's custom loaders LAST**. `runLoaders` runs them in array order, so
+  our `container.register({ personPropertyService: asValue, baseRepository:
+  asValue })` clobbers the defaults. The outer module service resolves the
+  internal one lazily from its cradle → gets ours.
+- **Empirically:** `apps/backend/src/modules/personproperty/__tests__/hyperbee-boot-verify.ts`
+  boots only that module through the real `MedusaModule.bootstrap` pipeline —
+  no app, no HTTP, **no Postgres** (pass `declaration.options.manager = {}` so the
+  MikroORM connection loader registers the stub and returns before connecting).
+  **8/8 pass**: the internal service is `HyperbeePersonPropertyService`, the
+  generated `create/listAndCount` round-trip over Hyperbee, the store is written
+  to disk, zero PG.
+
+## 3. Keep / shed
+
+**KEEP** (storage-agnostic, resilient):
+
+| Pattern | Why it survives | On our foundation |
+|---|---|---|
+| The narrow `RepositoryService` contract | It *is* the decoupling | Our `HyperbeeBaseRepository` |
+| `query.graph` / RemoteJoiner | Joins are a fetch-callback, not SQL | Reuse the pattern over any store |
+| Module isolation | Each module owns its data | Each module = its own core / sub-db |
+| `defineLink` links as pivot records | Associations without FKs | Pivot entries + reverse index |
+| Workflow = orchestration + append journal | The execution log is already append-only | Native to Hyperbee (spike M4) |
+| DML model-def → generated CRUD | Declare model, get CRUD + indexes | Build our own generator |
+
+**SHED** (Postgres baggage): raw knex/SQL escape hatches (→ CQRS projection
+catalogs); MikroORM entity-manager; transactions-as-rollback (→ append-log
+status-flip); the single-central-DB assumption; query-time SQL joins (→ maintained
+read-models).
+
+**RESILIENCE we gain that Medusa can't:** append-only/immutable log (audit +
+crash-safety + provenance *by construction* — the #935 certification story);
+local-first / P2P (no SPOF, offline, verifiable-without-disclosure via dual
+public/encrypted cores); CQRS read-models over a query planner; narrow swappable
+seams per subsystem.
+
+## 4. Schema-flexibility: the model becomes a write-contract, not a storage schema
+
+Postgres enforced the model as **DDL** — the DB physically rejects off-schema
+rows. Hyperbee is schema-flexible, so the model becomes a **write-time contract**
+the repository applies. That relocation is where the benefits and the risks live.
+
+**Benefits:** additive change needs no migration (schema-on-read); heterogeneous /
+sparse records are free (the ~50-field census record varies by state/source);
+multiple schema versions coexist (a v1 and v3 record live side by side, the model
+is a *lens*); faster iteration during the migration.
+
+**Cost:** you lose `NOT NULL / UNIQUE / FK / CHECK` for free. Integrity must move
+to the **write path**. That is not optional — it is the tax of leaving the DB.
+
+## 5. The contract — a staged write pipeline
+
+Integrity is enforced at the repository boundary as an **ordered pipeline**, each
+stage derived from the model/link metadata where possible, each with a strictness
+mode (`strict | soft | off`) the module dials per domain.
+
+| Stage | Does | Source | Default (provenance) |
+|---|---|---|---|
+| 1. **Shape** | types, required, enum, defaults, coercion | DML model | strict on declared fields, open for the rest |
+| 2. **Identity** | id gen/prefix, natural-key derivation | model | strict |
+| 3. **Uniqueness** | natural keys + 1:1 endpoints (unique index) | contract | strict on natural key |
+| 4. **Referential** | FK/link targets exist; cardinality | model + links | **soft** |
+| 5. **Invariants** | cross-field CHECK-like rules | declared | lax |
+| 6. **Commit** | append txn: one atomic batch writes record + secondary + unique + link indexes | — | — |
+| (wrap) **Idempotency** | dedupe on natural key so re-ingest doesn't double-write | contract | on |
+
+Relationships are **not a separate subsystem** — they are stages 3–4 of the same
+contract:
+
+- **within-module `belongsTo`** = an FK field (shape + referential stages) + a
+  secondary index for reverse traversal; **`hasMany`** = the derived reverse read,
+  nothing stored.
+- **cross-module link** = a pivot record `{left_id, right_id}` with its own tiny
+  contract; **cardinality** (1:1 / 1:n / n:m) = uniqueness on the endpoint(s), so
+  it reuses stage 3.
+- **cascade** = tombstone/status-flip propagation OR read-time filtering (prefer
+  read-time filter for append-log purity).
+
+**Distributed caveat:** a link can replicate before the record it points to, and
+hard cross-writer referential checks need coordination we don't want. So the
+resilient default is **soft / eventual referential integrity** — dangling
+tolerated, resolved at read — exactly how Medusa's own cross-module links behave.
+Reserve **hard** integrity for within-a-single-writer domains. Soft-by-default is
+the *more* robust choice, not a compromise.
+
+### Contract example
+
+```ts
+defineContract("person_property", {
+  shape:   { from: PersonProperty },          // types/required/enum from the DML model
+  id:      { prefix: "pp" },
+  unique:  ["person_id"],                      // 1:1 with person
+  indexes: ["district", "region_state", "profile_type", "social_group"],
+  relations: {
+    person: { kind: "belongsTo", key: "person_id",
+              target: "person", integrity: "soft" },
+  },
+  idempotencyKey: (r) => r.census_id,
+  mode: "lax",                                 // provenance domain → flexible
+})
+```
+
+## 6. Polyglot by design
+
+Match the store to the domain's consistency needs — do not reflexively re-impose
+Postgres rigidity:
+
+- **Provenance / append-mostly** (weaver, audit, certification, person_property):
+  Hyperbee. Schema-on-read + soft referential integrity + immutability. The
+  append-log *is* the integrity model. These move first.
+- **Transactional / invariant-critical** (orders, carts, inventory, money): keep
+  on Postgres until (and unless) the framework is mature. Keeping them on PG is a
+  *feature*, not a defeat.
+
+## 7. Package plan — `packages/mikrohyperbee/`
+
+A plain TypeScript library (not a Medusa plugin) — the whole point is it does not
+depend on Medusa. Consumed by the backend today via a per-module loader; by a
+standalone runtime later.
+
+- **Step 0 — seam verified.** ✅ Done (§2).
+- **Step 1 — extract the package.** `HyperbeeBaseRepository` implementing the full
+  `RepositoryService` surface (generalized from the proven
+  `HyperbeePersonPropertyService`), the model→index derivation, the append-log txn
+  primitives, and the staged contract (§5). A `hyperbeeRepositoryFor(contract)`
+  factory + a one-line Medusa loader factory. Standalone tsx tests (no Medusa, no
+  PG). **← in progress.**
+- **Step 2 — first real module on it.** Move `person_property` (and the weaver
+  provenance domain) onto the package behind the existing flag. Prove
+  `query.graph`-across-the-`person` link on a real MedusaApp boot.
+- **Step 3 — durable execution over Hyperbee.** A `store:true` workflow whose
+  module DAL is the package — the `workflow_execution` journal on the append-log,
+  single-node, crash/resume, zero Postgres in the loop (Seam B).
+- **Later — the standalone runtime.** Grow the package's own thin HTTP + joiner so
+  a module runs without Medusa; lift modules across the boundary one at a time.
+  Medusa becomes optional, not load-bearing.
+
+### Interface shape (target)
+
+```ts
+// storage-agnostic: caller provides a ready Hyperbee (or the loader opens one)
+const repo = hyperbeeRepositoryFor(personPropertyContract, bee)
+// implements RepositoryService: create/find/findAndCount/update/delete/upsert/
+// softDelete/restore/serialize/transaction/getFreshManager/getActiveManager
+```
+
+## 8. Proven groundwork (the spike, M3–M6)
+
+- **M3** — `HyperbeeBaseRepository` over Hyperbee sub-dbs + auto secondary indexes
+  + a tiny query planner; `query.graph` across a module link; a workflow
+  step+compensation. 19/19.
+- **M4** — append-only transactions as a *status log* (not rollback) + Autobase
+  multi-writer + visibility-gated secondary index (projection catalog). 23/23.
+- **M5** — batch atomicity, concurrent LWW, crash-recovery, compound+range index,
+  30× indexed-query perf at 2k rows. 59/59 across the suite.
+- **M6** — the REAL Medusa `PersonPropertyService` generated methods running over
+  Hyperbee, no Postgres. 11/11. Re-homed into the backend module DAL.
+- **Step 0** — that DAL proven to win at real Medusa module boot. 8/8.

--- a/apps/docs/notes/MIKROHYPERBEE_FRAMEWORK.md
+++ b/apps/docs/notes/MIKROHYPERBEE_FRAMEWORK.md
@@ -179,9 +179,20 @@ standalone runtime later.
 - **Step 2 — first real module on it.** Move `person_property` (and the weaver
   provenance domain) onto the package behind the existing flag. Prove
   `query.graph`-across-the-`person` link on a real MedusaApp boot.
-- **Step 3 — durable execution over Hyperbee.** A `store:true` workflow whose
-  module DAL is the package — the `workflow_execution` journal on the append-log,
-  single-node, crash/resume, zero Postgres in the loop (Seam B).
+- **Step 3 — durable execution over Hyperbee.** ✅ **Done.** The engine's *real*
+  `InMemoryDistributedTransactionStorage` class, backed by the package repo as
+  `workflowExecutionService`, drives real `save()`/`get()` checkpoints; a
+  checkpoint written by one instance **survives a true process boundary**
+  (`store.close()` → fresh repo+storage over the same on-disk store reads it back
+  via `get()`), completion updates in place, `deleteFromDb` removes non-retained
+  finished txns, and **retention is reimplemented in JS** (the engine's Postgres
+  `raw()` predicate). 11/11, zero Postgres.
+  (`apps/backend/.../workflow-engine-hyperbee.script.ts`.) Findings: `get()`
+  deliberately refuses to return DONE/failed/reverted (a finished txn is never
+  resumed); the engine stores `execution = data.flow` directly; engine-persisted
+  rows lack `updated_at`, so JS retention skips un-ageable rows (conservative) —
+  **follow-up: the package should stamp `updated_at` on write for production
+  retention.**
 - **Later — the standalone runtime.** Grow the package's own thin HTTP + joiner so
   a module runs without Medusa; lift modules across the boundary one at a time.
   Medusa becomes optional, not load-bearing.

--- a/packages/mikrohyperbee/.gitignore
+++ b/packages/mikrohyperbee/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.tsbuildinfo

--- a/packages/mikrohyperbee/package.json
+++ b/packages/mikrohyperbee/package.json
@@ -6,10 +6,13 @@
   "license": "MIT",
   "author": "Jaal Yantra Textiles",
   "type": "commonjs",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [
@@ -19,7 +22,8 @@
   "scripts": {
     "test": "tsx test/repository.e2e.ts && tsx test/workflow-store.e2e.ts",
     "typecheck": "tsc --noEmit",
-    "build": "tsc"
+    "build": "tsc",
+    "prepare": "tsc"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/mikrohyperbee/package.json
+++ b/packages/mikrohyperbee/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@jytextiles/mikrohyperbee",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Hyperbee-backed DAL: a RepositoryService over an append-log KV store with a staged write-contract (shape, uniqueness, referential integrity). Medusa-free core; opt-in Medusa adapter.",
+  "license": "MIT",
+  "author": "Jaal Yantra Textiles",
+  "type": "commonjs",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "src",
+    "dist"
+  ],
+  "scripts": {
+    "test": "tsx test/repository.e2e.ts && tsx test/workflow-store.e2e.ts",
+    "typecheck": "tsc --noEmit",
+    "build": "tsc"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "corestore": "^7.4.6",
+    "hyperbee": "^2.24.2",
+    "tsx": "^4.19.2",
+    "typescript": "5.6.3"
+  },
+  "peerDependencies": {
+    "hyperbee": "*"
+  },
+  "peerDependenciesMeta": {
+    "hyperbee": {
+      "optional": true
+    }
+  }
+}

--- a/packages/mikrohyperbee/src/contract.ts
+++ b/packages/mikrohyperbee/src/contract.ts
@@ -1,0 +1,128 @@
+/**
+ * The staged write-contract (pure stages).
+ *
+ * Stages that don't need store access live here: Shape (types/required/enum/
+ * defaults/coercion) and Invariants (cross-field rules). Identity, Uniqueness,
+ * Referential and Commit need the store and live in the repository, but they are
+ * driven by the same Contract so the whole pipeline reads as one thing.
+ */
+import { Contract, ContractError, FieldSpec } from "./types";
+
+/** Ergonomic identity helper — validates the contract once and returns it. */
+export function defineContract(model: string, spec: Omit<Contract, "model">): Contract {
+  const contract: Contract = { model, mode: "lax", ...spec };
+  // Cheap self-checks so a malformed contract fails loudly at load, not at write.
+  for (const u of contract.unique ?? []) {
+    if (contract.fields && !(u in contract.fields)) {
+      // A unique key that isn't a declared field is allowed (it may be an
+      // undeclared/open field), but index+unique on the same open field is fine.
+    }
+  }
+  for (const [name, rel] of Object.entries(contract.relations ?? {})) {
+    if (rel.kind === "belongsTo" && !rel.key) {
+      throw new Error(`[mikrohyperbee] relation '${name}' (belongsTo) needs a 'key'`);
+    }
+  }
+  return contract;
+}
+
+function coerce(value: unknown, spec: FieldSpec): unknown {
+  if (value === undefined || value === null) return value;
+  switch (spec.type) {
+    case "number":
+      return typeof value === "number" ? value : Number(value);
+    case "boolean":
+      if (typeof value === "boolean") return value;
+      if (value === "true") return true;
+      if (value === "false") return false;
+      return value;
+    case "string":
+      return typeof value === "string" ? value : String(value);
+    default:
+      return value; // json passes through
+  }
+}
+
+function typeOk(value: unknown, spec: FieldSpec): boolean {
+  switch (spec.type) {
+    case "number":
+      return typeof value === "number" && !Number.isNaN(value);
+    case "boolean":
+      return typeof value === "boolean";
+    case "string":
+      return typeof value === "string";
+    case "json":
+      return true;
+  }
+}
+
+/**
+ * Stage 1 — Shape. Validates + coerces declared fields, applies defaults.
+ * Undeclared fields pass through untouched (schema-flexibility). In strict mode
+ * violations throw; in lax mode they are collected as warnings and allowed
+ * (except a hard type mismatch on a present value, which always throws — that is
+ * corruption, not flexibility).
+ */
+export function applyShape(
+  contract: Contract,
+  input: Record<string, any>
+): { row: Record<string, any>; warnings: string[] } {
+  const fields = contract.fields ?? {};
+  const strict = contract.mode === "strict";
+  const warnings: string[] = [];
+  const row: Record<string, any> = { ...input };
+
+  for (const [name, spec] of Object.entries(fields)) {
+    let v = row[name];
+
+    if (v === undefined && spec.default !== undefined) {
+      v = typeof spec.default === "function" ? (spec.default as any)() : spec.default;
+    }
+
+    if (v === undefined) {
+      if (spec.required) {
+        const msg = `field '${name}' is required`;
+        if (strict) throw new ContractError("invalid_data", msg);
+        warnings.push(msg);
+      }
+      continue;
+    }
+
+    if (v === null) {
+      if (spec.nullable === false) {
+        const msg = `field '${name}' may not be null`;
+        if (strict) throw new ContractError("invalid_data", msg);
+        warnings.push(msg);
+      }
+      row[name] = v;
+      continue;
+    }
+
+    v = coerce(v, spec);
+    if (!typeOk(v, spec)) {
+      // A present-but-wrong-type value is corruption regardless of mode.
+      throw new ContractError(
+        "invalid_data",
+        `field '${name}' expected ${spec.type}, got ${typeof row[name]}`
+      );
+    }
+    if (spec.enum && !spec.enum.includes(v as string)) {
+      const msg = `field '${name}' must be one of [${spec.enum.join(", ")}], got '${v}'`;
+      if (strict) throw new ContractError("invalid_data", msg);
+      warnings.push(msg);
+    }
+    row[name] = v;
+  }
+
+  return { row, warnings };
+}
+
+/** Stage 5 — Invariants. Cross-field CHECK-like rules. */
+export function checkInvariants(contract: Contract, row: Record<string, any>): void {
+  for (const inv of contract.invariants ?? []) {
+    const res = inv(row);
+    if (res !== true) {
+      throw new ContractError("invalid_data", `invariant failed: ${res}`);
+    }
+  }
+}

--- a/packages/mikrohyperbee/src/index.ts
+++ b/packages/mikrohyperbee/src/index.ts
@@ -1,0 +1,23 @@
+/**
+ * @jytextiles/mikrohyperbee — a Hyperbee-backed DAL with a staged write-contract.
+ *
+ * Medusa-free core. See apps/docs/notes/MIKROHYPERBEE_FRAMEWORK.md for the design.
+ */
+export { defineContract, applyShape, checkInvariants } from "./contract";
+export { HyperbeeBaseRepository, hyperbeeRepositoryFor } from "./repository";
+export {
+  ContractError,
+} from "./types";
+export type {
+  Contract,
+  FieldSpec,
+  FieldType,
+  RelationSpec,
+  RelationKind,
+  ModelRepository,
+  RepositoryContext,
+  BeeLike,
+  Where,
+  WhereCond,
+  ListConfig,
+} from "./types";

--- a/packages/mikrohyperbee/src/repository.ts
+++ b/packages/mikrohyperbee/src/repository.ts
@@ -1,0 +1,387 @@
+/**
+ * HyperbeeBaseRepository — the generalized MikroHyperbee DAL.
+ *
+ * Generalizes the proven person_property DAL into a contract-driven repository
+ * over Hyperbee sub-dbs. Implements the ModelRepository surface that Medusa's
+ * generated methods invoke on the injected internal service, so satisfying it =
+ * the storage swap (no Postgres / MikroORM).
+ *
+ * Sub-dbs:
+ *   rec   key -> brotli(JSON)                  the records (key = generated id or composite PK)
+ *   idx   field/value/key -> key               equality secondary indexes
+ *   uniq  field/value -> key                   uniqueness reservations
+ *   idemp natkey -> key                         idempotency (natural-key dedupe)
+ *   meta  seq -> "<n>"                          persisted id counter
+ *
+ * Writes run the staged contract: Shape → Identity → Uniqueness → Referential →
+ * Invariants → Commit (record + secondary + unique indexes maintained together).
+ */
+import { brotliCompressSync, brotliDecompressSync } from "node:zlib";
+
+import { applyShape, checkInvariants } from "./contract";
+import {
+  BeeLike,
+  Contract,
+  ContractError,
+  ListConfig,
+  ModelRepository,
+  RepositoryContext,
+  Where,
+} from "./types";
+
+const isPlainObject = (v: unknown): v is Record<string, any> =>
+  !!v && typeof v === "object" && !Array.isArray(v);
+
+const matches = (row: Record<string, any>, where: Where = {}): boolean =>
+  Object.entries(where).every(([k, cond]) => {
+    const v = row[k];
+    if (cond && typeof cond === "object") {
+      const c = cond as Record<string, any>;
+      // Unknown/opaque operator values (e.g. a Postgres raw() predicate) never
+      // match — a filter we can't evaluate is treated as "no rows", never "all".
+      if ("$in" in c) return Array.isArray(c.$in) && c.$in.includes(v);
+      // $ne: null is a real filter; only an opaque object (e.g. raw()) is unevaluable.
+      if ("$ne" in c) return c.$ne !== null && typeof c.$ne === "object" ? true : v !== c.$ne;
+      if ("$gt" in c) return typeof c.$gt !== "object" && (v as any) > c.$gt;
+      if ("$gte" in c) return typeof c.$gte !== "object" && (v as any) >= c.$gte;
+      if ("$lt" in c) return typeof c.$lt !== "object" && (v as any) < c.$lt;
+      if ("$lte" in c) return typeof c.$lte !== "object" && (v as any) <= c.$lte;
+      return false;
+    }
+    return v === cond;
+  });
+
+export class HyperbeeBaseRepository implements ModelRepository {
+  private recs: BeeLike;
+  private idx: BeeLike;
+  private uniq: BeeLike;
+  private idemp: BeeLike;
+  private meta: BeeLike;
+  private seq: number | null = null;
+
+  private readonly indexed: string[];
+  private readonly uniques: string[];
+  /** Natural/composite PK fields, or null → generated id. */
+  private readonly pk: string[] | null;
+
+  constructor(
+    private bee: BeeLike,
+    private contract: Contract,
+    private ctx: RepositoryContext = {}
+  ) {
+    this.recs = bee.sub("rec", { valueEncoding: "binary" });
+    this.idx = bee.sub("idx", { valueEncoding: "utf-8" });
+    this.uniq = bee.sub("uniq", { valueEncoding: "utf-8" });
+    this.idemp = bee.sub("idemp", { valueEncoding: "utf-8" });
+    this.meta = bee.sub("meta", { valueEncoding: "utf-8" });
+
+    this.pk =
+      contract.primaryKey && contract.primaryKey.length
+        ? [...contract.primaryKey]
+        : null;
+
+    const relKeys = Object.values(contract.relations ?? {})
+      .filter((r) => r.kind === "belongsTo")
+      .map((r) => r.key);
+    // Composite PK fields are indexed too, so list-by-partial-key works.
+    this.indexed = [
+      ...new Set([...(contract.indexes ?? []), ...relKeys, ...(this.pk ?? [])]),
+    ];
+    this.uniques = [...(contract.unique ?? [])];
+  }
+
+  // ── encoding + keys ─────────────────────────────────────────────────────────
+  private enc(o: unknown): Buffer {
+    return brotliCompressSync(Buffer.from(JSON.stringify(o)));
+  }
+  private dec(b: Buffer): any {
+    return JSON.parse(brotliDecompressSync(b).toString());
+  }
+  /** Storage key for a record: composite PK joined, or the generated/explicit id. */
+  private keyOf(row: Record<string, any>): string {
+    if (this.pk) {
+      const missing = this.pk.filter((k) => row[k] === undefined || row[k] === null);
+      if (missing.length) {
+        throw new ContractError(
+          "invalid_data",
+          `${this.contract.model} missing primary-key field(s): ${missing.join(", ")}`
+        );
+      }
+      return this.pk.map((k) => String(row[k])).join(":");
+    }
+    return String(row.id);
+  }
+  private async ensureSeq(): Promise<void> {
+    if (this.seq !== null) return;
+    const node = await this.meta.get("seq");
+    this.seq = node ? parseInt(String(node.value), 10) || 0 : 0;
+  }
+  private async nextId(): Promise<string> {
+    await this.ensureSeq();
+    this.seq = (this.seq as number) + 1;
+    await this.meta.put("seq", String(this.seq));
+    const prefix = this.contract.id?.prefix ?? this.contract.model;
+    return `${prefix}_${String(this.seq).padStart(6, "0")}`;
+  }
+
+  // ── index maintenance (pointer = storage key) ────────────────────────────────
+  private async index(row: Record<string, any>, key: string): Promise<void> {
+    for (const f of this.indexed) {
+      const v = row[f];
+      if (v !== undefined && v !== null) await this.idx.put(`${f}/${String(v)}/${key}`, key);
+    }
+  }
+  private async deindex(row: Record<string, any>, key: string): Promise<void> {
+    for (const f of this.indexed) {
+      const v = row[f];
+      if (v !== undefined && v !== null) await this.idx.del(`${f}/${String(v)}/${key}`);
+    }
+  }
+
+  // ── uniqueness (stage 3) ─────────────────────────────────────────────────────
+  private uniqKey(field: string, value: unknown): string {
+    return `${field}/${String(value)}`;
+  }
+  private async assertUnique(row: Record<string, any>, key: string): Promise<void> {
+    for (const f of this.uniques) {
+      const v = row[f];
+      if (v === undefined || v === null) continue;
+      const node = await this.uniq.get(this.uniqKey(f, v));
+      if (node && node.value !== key) {
+        throw new ContractError(
+          "not_unique",
+          `${this.contract.model}.${f} must be unique — '${v}' already used`
+        );
+      }
+    }
+  }
+  private async reserveUnique(row: Record<string, any>, key: string): Promise<void> {
+    for (const f of this.uniques) {
+      const v = row[f];
+      if (v !== undefined && v !== null) await this.uniq.put(this.uniqKey(f, v), key);
+    }
+  }
+  private async releaseUnique(row: Record<string, any>): Promise<void> {
+    for (const f of this.uniques) {
+      const v = row[f];
+      if (v !== undefined && v !== null) await this.uniq.del(this.uniqKey(f, v));
+    }
+  }
+
+  // ── referential (stage 4) ────────────────────────────────────────────────────
+  private async assertReferential(row: Record<string, any>): Promise<void> {
+    for (const rel of Object.values(this.contract.relations ?? {})) {
+      if (rel.kind !== "belongsTo") continue;
+      const targetId = row[rel.key];
+      if (targetId === undefined || targetId === null) continue;
+      if ((rel.integrity ?? "soft") === "strict") {
+        if (!this.ctx.exists) {
+          throw new ContractError(
+            "not_allowed",
+            `relation '${rel.key}' is strict but no exists() resolver is configured`
+          );
+        }
+        const okExists = await this.ctx.exists(rel.target, String(targetId));
+        if (!okExists) {
+          throw new ContractError(
+            "not_found",
+            `${this.contract.model}.${rel.key} -> ${rel.target}:${targetId} does not exist`
+          );
+        }
+      }
+    }
+  }
+
+  private async get(key: string): Promise<any | null> {
+    const node = await this.recs.get(String(key));
+    return node ? this.dec(node.value) : null;
+  }
+
+  /** Shared write path for create/upsert. `existing` non-null → update-in-place. */
+  private async write(input: any, existing: any | null): Promise<any> {
+    const base = existing ? { ...existing, ...input } : input;
+    const { row: shaped } = applyShape(this.contract, base);
+
+    let row: Record<string, any>;
+    if (existing) {
+      row = { ...shaped };
+    } else if (this.pk) {
+      row = { ...shaped, id: input.id ?? undefined };
+    } else {
+      row = { id: input.id || (await this.nextId()), ...shaped };
+    }
+    const key = this.keyOf(row);
+    if (this.pk && row.id === undefined) row.id = key;
+
+    await this.assertUnique(row, key);
+    await this.assertReferential(row);
+    checkInvariants(this.contract, row);
+
+    if (existing) {
+      await this.deindex(existing, key);
+      await this.releaseUnique(existing);
+    }
+    await this.recs.put(key, this.enc(row));
+    await this.index(row, key);
+    await this.reserveUnique(row, key);
+    return row;
+  }
+
+  // ── ModelRepository surface ──────────────────────────────────────────────────
+
+  async create(data: any): Promise<any> {
+    const arr = Array.isArray(data) ? data : [data];
+    const out: any[] = [];
+    for (const input of arr) {
+      const { row: shaped } = applyShape(this.contract, input);
+      const idemKey = this.contract.idempotencyKey?.(shaped);
+      if (idemKey) {
+        const existing = await this.idemp.get(idemKey);
+        if (existing) {
+          const prev = await this.get(String(existing.value));
+          if (prev) {
+            out.push(prev);
+            continue;
+          }
+        }
+      }
+      const row = await this.write(input, null);
+      if (idemKey) await this.idemp.put(idemKey, this.keyOf(row));
+      out.push(row);
+    }
+    return Array.isArray(data) ? out : out[0];
+  }
+
+  async upsert(data: any): Promise<any> {
+    const arr = Array.isArray(data) ? data : [data];
+    const out: any[] = [];
+    for (const input of arr) {
+      const { row: probe } = applyShape(this.contract, input);
+      const key = this.keyOf(probe);
+      const existing = await this.get(key);
+      out.push(await this.write(input, existing));
+    }
+    return Array.isArray(data) ? out : out[0];
+  }
+
+  async retrieve(id: string): Promise<any> {
+    const r = await this.get(id);
+    if (!r) {
+      throw new ContractError(
+        "not_found",
+        `${this.contract.model} with id: ${id} was not found`
+      );
+    }
+    return r;
+  }
+
+  private async candidateKeys(where: Where = {}): Promise<string[]> {
+    const eqIndexed = Object.entries(where).filter(
+      ([k, v]) => this.indexed.includes(k) && (typeof v !== "object" || v === null)
+    );
+    if (eqIndexed.length) {
+      const sets = await Promise.all(
+        eqIndexed.map(async ([k, v]) => {
+          const s = new Set<string>();
+          const p = `${k}/${String(v)}/`;
+          for await (const { value: key } of this.idx.createReadStream({ gte: p, lt: p + "~" })) {
+            s.add(key as unknown as string);
+          }
+          return s;
+        })
+      );
+      return [...sets.reduce((a, b) => new Set([...a].filter((x) => b.has(x))))];
+    }
+    const keys: string[] = [];
+    for await (const { key } of this.recs.createReadStream()) keys.push(key);
+    return keys;
+  }
+
+  private async resolve(filters: Where): Promise<any[]> {
+    const keys = await this.candidateKeys(filters);
+    const rows: any[] = [];
+    for (const key of keys) {
+      const r = await this.get(key);
+      if (r && matches(r, filters)) rows.push(r);
+    }
+    return rows;
+  }
+
+  async list(filters: Where = {}, config: ListConfig = {}): Promise<any[]> {
+    const rows = await this.resolve(filters);
+    const { take = 15, skip = 0, order } = config || {};
+    if (order) {
+      const [f, dir] = Object.entries(order)[0] as [string, string];
+      const sign = String(dir).toUpperCase() === "DESC" ? -1 : 1;
+      rows.sort((a, b) => (a[f] > b[f] ? 1 : a[f] < b[f] ? -1 : 0) * sign);
+    } else {
+      rows.sort((a, b) => (a.id > b.id ? 1 : -1));
+    }
+    return rows.slice(skip, skip + take);
+  }
+
+  async listAndCount(filters: Where = {}, config: ListConfig = {}): Promise<[any[], number]> {
+    const count = (await this.resolve(filters)).length;
+    return [await this.list(filters, config), count];
+  }
+
+  async update(data: any): Promise<any> {
+    const arr = Array.isArray(data) ? data : [data];
+    const out: any[] = [];
+    for (const d of arr) {
+      // find by composite PK fields present on d, else by id
+      const key = this.pk ? this.keyOf(d) : String(d.id);
+      const cur = await this.get(key);
+      if (!cur) {
+        throw new ContractError(
+          "not_found",
+          `${this.contract.model} with key: ${key} was not found`
+        );
+      }
+      out.push(await this.write(d, cur));
+    }
+    return Array.isArray(data) ? out : out[0];
+  }
+
+  async delete(selector: string | string[] | Where | Where[]): Promise<void> {
+    // Normalize to a list of "targets": each is either a storage key (string)
+    // or a filter/partial-key object we resolve to matching keys.
+    const targets: Array<string | Where> = Array.isArray(selector)
+      ? (selector as Array<string | Where>)
+      : [selector as string | Where];
+
+    const keys = new Set<string>();
+    for (const t of targets) {
+      if (typeof t === "string") {
+        keys.add(t);
+      } else if (isPlainObject(t)) {
+        // A partial-key/filter object → resolve to the keys of matching rows.
+        for (const row of await this.resolve(t)) keys.add(this.keyOf(row));
+      }
+    }
+    for (const key of keys) {
+      const cur = await this.get(key);
+      if (cur) {
+        await this.deindex(cur, key);
+        await this.releaseUnique(cur);
+        await this.recs.del(key);
+      }
+    }
+  }
+
+  async softDelete(): Promise<[any[], Record<string, unknown>]> {
+    return [[], {}];
+  }
+  async restore(): Promise<[any[], Record<string, unknown>]> {
+    return [[], {}];
+  }
+}
+
+/** Factory: build a repository for a contract over a ready Hyperbee. */
+export function hyperbeeRepositoryFor(
+  contract: Contract,
+  bee: BeeLike,
+  ctx?: RepositoryContext
+): HyperbeeBaseRepository {
+  return new HyperbeeBaseRepository(bee, contract, ctx);
+}

--- a/packages/mikrohyperbee/src/types.ts
+++ b/packages/mikrohyperbee/src/types.ts
@@ -1,0 +1,137 @@
+/**
+ * MikroHyperbee — core types.
+ *
+ * The core is deliberately Medusa-free: it knows nothing about DML, awilix, or
+ * MedusaService. A thin adapter (later) derives a Contract from a DML model and
+ * wires the repository into a module container. Here we speak only in plain
+ * records, a Contract, and a minimal Hyperbee surface.
+ */
+
+export type FieldType = "string" | "number" | "boolean" | "json";
+
+export interface FieldSpec {
+  type: FieldType;
+  /** Reject create when missing/undefined in strict mode. */
+  required?: boolean;
+  /** Allow explicit null (default true). */
+  nullable?: boolean;
+  /** Allowed values (validated when present). */
+  enum?: readonly string[];
+  /** Applied when the field is undefined on create. */
+  default?: unknown;
+}
+
+export type RelationKind = "belongsTo" | "hasMany" | "manyToMany";
+
+export interface RelationSpec {
+  kind: RelationKind;
+  /** Local FK field holding the target id (for belongsTo). */
+  key: string;
+  /** Target model name. */
+  target: string;
+  /**
+   * strict = the target must exist at write time (needs an `exists` resolver);
+   * soft  = dangling tolerated, resolved at read (the resilient default).
+   */
+  integrity?: "strict" | "soft";
+}
+
+/**
+ * Per-model write-contract. Most of this is auto-derivable from a DML model by an
+ * adapter; here it is explicit so the core has zero Medusa coupling.
+ */
+export interface Contract {
+  /** Model name (e.g. "person_property"). */
+  model: string;
+  /** Identity stage: id prefix for generated ids. */
+  id?: { prefix?: string };
+  /**
+   * Natural/composite primary key fields. When set, records are keyed by the
+   * joined values of these fields (e.g. workflow_execution keyed by
+   * [workflow_id, transaction_id, run_id]) instead of a generated `id`, and
+   * `upsert` matches on them. Defaults to ["id"] with a generated id.
+   */
+  primaryKey?: readonly string[];
+  /** Shape stage: declared field specs (undeclared fields pass through untouched). */
+  fields?: Record<string, FieldSpec>;
+  /** Fields to maintain an equality secondary index for (fast filtered reads). */
+  indexes?: readonly string[];
+  /** Fields that must be unique across the model (natural keys, 1:1 endpoints). */
+  unique?: readonly string[];
+  /** Relationship specs (stages 3–4). */
+  relations?: Record<string, RelationSpec>;
+  /** Invariant stage: cross-field rules; return true or an error message. */
+  invariants?: Array<(row: Record<string, any>) => true | string>;
+  /** Idempotency: dedupe create on this natural key. */
+  idempotencyKey?: (row: Record<string, any>) => string | undefined;
+  /** strict = enforce required/enum/unique hard; lax = warn-and-allow shape, keep uniqueness. */
+  mode?: "strict" | "lax";
+}
+
+/** Query operators supported by the resolver (mirrors the proven DAL). */
+export type WhereCond =
+  | unknown
+  | {
+      $in?: unknown[];
+      $ne?: unknown;
+      $gt?: unknown;
+      $gte?: unknown;
+      $lt?: unknown;
+      $lte?: unknown;
+    };
+export type Where = Record<string, WhereCond>;
+export interface ListConfig {
+  take?: number;
+  skip?: number;
+  order?: Record<string, string>;
+}
+
+/** Optional cross-model resolver for strict referential integrity. */
+export interface RepositoryContext {
+  /** Return whether a record of `model` with `id` exists. */
+  exists?: (model: string, id: string) => Promise<boolean>;
+}
+
+/** The minimal Hyperbee surface the repository needs (structurally typed). */
+export interface BeeLike {
+  sub(name: string, opts?: any): BeeLike;
+  put(key: string, value: any): Promise<void>;
+  get(key: string): Promise<{ key: string; value: any } | null>;
+  del(key: string): Promise<void>;
+  createReadStream(range?: { gte?: string; lt?: string; gt?: string; lte?: string }): AsyncIterable<{
+    key: string;
+    value: any;
+  }>;
+}
+
+/**
+ * The internal-service surface Medusa's generated methods invoke on the injected
+ * `${model}Service`. Satisfying this = the DAL swap.
+ */
+export interface ModelRepository {
+  create(data: any): Promise<any>;
+  retrieve(id: string): Promise<any>;
+  list(filters?: Where, config?: ListConfig): Promise<any[]>;
+  listAndCount(filters?: Where, config?: ListConfig): Promise<[any[], number]>;
+  update(data: any): Promise<any>;
+  upsert(data: any): Promise<any>;
+  /** Accepts an id, ids, a filter object, or an array of partial-key/filter objects. */
+  delete(selector: string | string[] | Where | Where[]): Promise<void>;
+  softDelete(): Promise<[any[], Record<string, unknown>]>;
+  restore(): Promise<[any[], Record<string, unknown>]>;
+}
+
+/** Error thrown by contract enforcement (mapped to MedusaError by the adapter). */
+export class ContractError extends Error {
+  constructor(
+    public readonly type:
+      | "invalid_data"
+      | "not_found"
+      | "not_unique"
+      | "not_allowed",
+    message: string
+  ) {
+    super(message);
+    this.name = "ContractError";
+  }
+}

--- a/packages/mikrohyperbee/test/repository.e2e.ts
+++ b/packages/mikrohyperbee/test/repository.e2e.ts
@@ -1,0 +1,162 @@
+/**
+ * Standalone proof: the contract-driven HyperbeeBaseRepository over a REAL
+ * Hyperbee, no Medusa, no Postgres. Run: pnpm --filter @jytextiles/mikrohyperbee test
+ */
+import { existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// @ts-ignore - resolved from devDependencies at test time
+import Corestore from "corestore";
+// @ts-ignore
+import Hyperbee from "hyperbee";
+
+import { defineContract, hyperbeeRepositoryFor, ContractError } from "../src";
+
+let pass = 0;
+let fail = 0;
+function ok(cond: boolean, msg: string) {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${msg}`);
+  } else {
+    fail++;
+    console.error(`  ✗ ${msg}`);
+  }
+}
+async function throws(fn: () => Promise<any>, type: string, msg: string) {
+  try {
+    await fn();
+    fail++;
+    console.error(`  ✗ ${msg} (expected throw, none)`);
+  } catch (e: any) {
+    const t = e instanceof ContractError ? e.type : e?.name;
+    ok(t === type, `${msg} (threw ${t})`);
+  }
+}
+
+const STORE = join(tmpdir(), `mikrohyperbee-test-${process.pid}`);
+
+// A provenance-domain contract: weaver properties, 1:1 with person, soft link.
+const weaver = defineContract("person_property", {
+  id: { prefix: "pp" },
+  mode: "strict",
+  fields: {
+    profile_type: { type: "string", default: "weaver", enum: ["weaver", "artisan"] },
+    person_id: { type: "string", required: true },
+    census_id: { type: "string", nullable: true },
+    district: { type: "string", nullable: true },
+    region_state: { type: "string", nullable: true },
+    total_looms_owned: { type: "number", nullable: true },
+    own_looms: { type: "boolean", nullable: true },
+  },
+  indexes: ["district", "region_state", "profile_type"],
+  unique: ["person_id", "census_id"],
+  relations: {
+    person: { kind: "belongsTo", key: "person_id", target: "person", integrity: "soft" },
+  },
+  invariants: [(r) => (r.total_looms_owned == null || r.total_looms_owned >= 0) || "looms must be >= 0"],
+  idempotencyKey: (r) => (r.census_id ? `census:${r.census_id}` : undefined),
+});
+
+async function main() {
+  if (existsSync(STORE)) rmSync(STORE, { recursive: true, force: true });
+  const store = new Corestore(STORE);
+  await store.ready();
+  const bee = new Hyperbee(store.get({ name: "person_property" }), {
+    keyEncoding: "utf-8",
+    valueEncoding: "binary",
+  });
+  await bee.ready();
+
+  const repo = hyperbeeRepositoryFor(weaver, bee as any);
+
+  // ── Shape + Identity ──
+  const a = await repo.create({ person_id: "pers_1", district: "AMBALA", region_state: "HARYANA", total_looms_owned: "3" });
+  ok(/^pp_\d{6}$/.test(a.id), `id generated with prefix (${a.id})`);
+  ok(a.profile_type === "weaver", "default applied (profile_type=weaver)");
+  ok(a.total_looms_owned === 3, "number coerced from string '3' -> 3");
+
+  await throws(() => repo.create({ district: "X" }), "invalid_data", "required person_id enforced");
+  await throws(
+    () => repo.create({ person_id: "pers_x", profile_type: "spy" }),
+    "invalid_data",
+    "enum enforced (profile_type)"
+  );
+  await throws(
+    () => repo.create({ person_id: "pers_y", total_looms_owned: -1 }),
+    "invalid_data",
+    "invariant enforced (looms >= 0)"
+  );
+
+  // ── Uniqueness ──
+  await throws(
+    () => repo.create({ person_id: "pers_1" }),
+    "not_unique",
+    "unique person_id collision rejected"
+  );
+
+  // ── Idempotency ──
+  const c1 = await repo.create({ person_id: "pers_2", census_id: "100", district: "AMBALA" });
+  const c2 = await repo.create({ person_id: "pers_2b", census_id: "100", district: "AMBALA" });
+  ok(c1.id === c2.id, "idempotent on census_id — re-create returns same record");
+
+  // ── Indexed query + listAndCount ──
+  await repo.create({ person_id: "pers_3", district: "AMBALA", region_state: "HARYANA" });
+  await repo.create({ person_id: "pers_4", district: "PANIPAT", region_state: "HARYANA" });
+  const [rows, count] = await repo.listAndCount({ district: "AMBALA" }, { take: 10 });
+  ok(count === 3, `indexed filter district=AMBALA -> 3 (got ${count})`);
+  ok(rows.every((r) => r.district === "AMBALA"), "all returned rows match filter");
+
+  // operator filter (non-indexed path)
+  const gte = await repo.list({ total_looms_owned: { $gte: 3 } });
+  ok(gte.length === 1 && gte[0].person_id === "pers_1", "$gte operator filter works");
+
+  // ── Update reindex ──
+  const upd = await repo.update({ id: a.id, district: "PANIPAT" });
+  ok(upd.district === "PANIPAT", "update applied");
+  const [, ambCount] = await repo.listAndCount({ district: "AMBALA" });
+  ok(ambCount === 2, `old index entry removed on update (AMBALA now 2, got ${ambCount})`);
+
+  // ── Delete ──
+  await repo.delete(a.id);
+  await throws(() => repo.retrieve(a.id), "not_found", "retrieve after delete throws not_found");
+  // unique released on delete -> person_id reusable
+  const reuse = await repo.create({ person_id: "pers_1" });
+  ok(!!reuse.id, "unique key released on delete (person_id reusable)");
+
+  // ── Strict referential without resolver fails closed ──
+  const strictRel = defineContract("thing", {
+    id: { prefix: "th" },
+    fields: { owner_id: { type: "string", required: true } },
+    relations: { owner: { kind: "belongsTo", key: "owner_id", target: "person", integrity: "strict" } },
+  });
+  const bee2 = new Hyperbee(store.get({ name: "thing" }), { keyEncoding: "utf-8", valueEncoding: "binary" });
+  await bee2.ready();
+  const strictRepo = hyperbeeRepositoryFor(strictRel, bee2 as any); // no exists() ctx
+  await throws(
+    () => strictRepo.create({ owner_id: "pers_1" }),
+    "not_allowed",
+    "strict relation without exists() resolver fails closed"
+  );
+  // with a resolver
+  const strictRepo2 = hyperbeeRepositoryFor(strictRel, bee2 as any, {
+    exists: async (_m, id) => id === "pers_1",
+  });
+  const good = await strictRepo2.create({ owner_id: "pers_1" });
+  ok(!!good.id, "strict relation passes when target exists");
+  await throws(
+    () => strictRepo2.create({ owner_id: "ghost" }),
+    "not_found",
+    "strict relation rejects dangling target"
+  );
+
+  rmSync(STORE, { recursive: true, force: true });
+  console.log(`\n${fail === 0 ? "✅ PASS" : "❌ FAIL"} — ${pass} passed, ${fail} failed`);
+  process.exit(fail === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error("TEST THREW:", e);
+  process.exit(1);
+});

--- a/packages/mikrohyperbee/test/workflow-store.e2e.ts
+++ b/packages/mikrohyperbee/test/workflow-store.e2e.ts
@@ -1,0 +1,141 @@
+/**
+ * Proof: the package DAL can back Medusa's `workflow_execution` store (Seam B).
+ *
+ * It replays the EXACT calls the workflow engine's DistributedTransactionStorage
+ * makes on the injected `workflowExecutionService_`
+ * (node_modules/@medusajs/workflow-engine-inmemory/dist/utils/workflow-orchestrator-storage.js):
+ *   - upsert([{ workflow_id, transaction_id, run_id, execution, context, state, retention_time }])
+ *   - list({ workflow_id, transaction_id }, { order: { id: "desc" }, take: 1 })   (get)
+ *   - delete([{ run_id }])                                                        (deleteFromDb)
+ *   - delete({ retention_time: {$ne:null}, updated_at: {$lte: raw()}, state: {$in} })  (retention)
+ *
+ * Proves the append-log is a drop-in for the execution journal: composite PK,
+ * upsert-in-place, partial-key delete, and the one Postgres-`raw()` retention
+ * predicate degrading to a safe no-op (JS retention is a follow-up, not a
+ * correctness gap).
+ *
+ * Run: pnpm --filter @jytextiles/mikrohyperbee exec tsx test/workflow-store.e2e.ts
+ */
+import { existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// @ts-ignore
+import Corestore from "corestore";
+// @ts-ignore
+import Hyperbee from "hyperbee";
+
+import { defineContract, hyperbeeRepositoryFor } from "../src";
+
+let pass = 0;
+let fail = 0;
+const ok = (c: boolean, m: string) => {
+  if (c) (pass++, console.log(`  ✓ ${m}`));
+  else (fail++, console.error(`  ✗ ${m}`));
+};
+
+// Mirrors @medusajs/workflow-engine-inmemory WorkflowExecution model.
+const workflowExecution = defineContract("workflow_execution", {
+  id: { prefix: "wf_exec" },
+  primaryKey: ["workflow_id", "transaction_id", "run_id"],
+  mode: "lax",
+  fields: {
+    workflow_id: { type: "string", required: true },
+    transaction_id: { type: "string", required: true },
+    run_id: { type: "string", required: true },
+    execution: { type: "json", nullable: true },
+    context: { type: "json", nullable: true },
+    state: { type: "string" },
+    retention_time: { type: "number", nullable: true },
+  },
+  indexes: ["workflow_id", "transaction_id", "run_id", "state"],
+});
+
+const STORE = join(tmpdir(), `wf-store-${process.pid}`);
+
+// A fake Postgres raw() predicate — an opaque object, exactly what the retention
+// sweep passes. The KV matcher must treat it as unevaluable (never match).
+const raw = () => ({ __raw: "CURRENT_TIMESTAMP - INTERVAL ..." });
+
+async function main() {
+  if (existsSync(STORE)) rmSync(STORE, { recursive: true, force: true });
+  const store = new Corestore(STORE);
+  await store.ready();
+  const bee = new Hyperbee(store.get({ name: "workflow_execution" }), {
+    keyEncoding: "utf-8",
+    valueEncoding: "binary",
+  });
+  await bee.ready();
+
+  const svc = hyperbeeRepositoryFor(workflowExecution, bee as any);
+
+  // 1) engine checkpoints a running transaction (upsert)
+  await svc.upsert([
+    {
+      workflow_id: "create-weaver",
+      transaction_id: "tx_1",
+      run_id: "run_1",
+      execution: { flow: { state: "invoking", steps: { _root: {}, s1: { depth: 1 } } } },
+      context: { data: { input: 1 }, errors: [] },
+      state: "invoking",
+      retention_time: null,
+    },
+  ]);
+
+  // 2) engine loads it back (get → list by workflow+transaction)
+  const loaded = await svc.list(
+    { workflow_id: "create-weaver", transaction_id: "tx_1" },
+    { order: { id: "desc" }, take: 1 }
+  );
+  ok(loaded.length === 1, "checkpoint persisted + loadable via list()");
+  ok(loaded[0].state === "invoking", "loaded execution has state=invoking");
+  ok(loaded[0].execution?.flow?.state === "invoking", "execution jsonb round-trips");
+
+  // 3) engine advances the SAME transaction to done → upsert must update in place
+  await svc.upsert([
+    {
+      workflow_id: "create-weaver",
+      transaction_id: "tx_1",
+      run_id: "run_1",
+      execution: { flow: { state: "done" } },
+      context: { data: { input: 1, output: 42 }, errors: [] },
+      state: "done",
+      retention_time: 3600,
+    },
+  ]);
+  const [afterRows, afterCount] = await svc.listAndCount({ transaction_id: "tx_1" });
+  ok(afterCount === 1, `upsert updated in place, no duplicate (count=${afterCount})`);
+  ok(afterRows[0].state === "done", "state advanced invoking → done on same composite key");
+  ok(afterRows[0].context?.data?.output === 42, "context jsonb updated");
+
+  // 4) a second run of the same workflow → distinct record (different run_id)
+  await svc.upsert([
+    { workflow_id: "create-weaver", transaction_id: "tx_2", run_id: "run_2", state: "invoking" },
+  ]);
+  const [, total] = await svc.listAndCount({ workflow_id: "create-weaver" });
+  ok(total === 2, `distinct run persisted separately (total=${total})`);
+
+  // 5) engine deletes a finished, non-retained transaction (delete by partial key)
+  await svc.delete([{ run_id: "run_2" }]);
+  const [, afterDel] = await svc.listAndCount({ workflow_id: "create-weaver" });
+  ok(afterDel === 1, `deleteFromDb({run_id}) removed exactly that run (remaining=${afterDel})`);
+
+  // 6) retention sweep uses a Postgres raw() predicate → safe no-op over KV,
+  //    must NOT delete the still-valid retained record.
+  await svc.delete({
+    retention_time: { $ne: null },
+    updated_at: { $lte: raw() },
+    state: { $in: ["done", "failed", "reverted"] },
+  } as any);
+  const [, afterSweep] = await svc.listAndCount({ workflow_id: "create-weaver" });
+  ok(afterSweep === 1, "retention sweep with raw() predicate is a safe no-op (record intact)");
+
+  rmSync(STORE, { recursive: true, force: true });
+  console.log(`\n${fail === 0 ? "✅ PASS" : "❌ FAIL"} — ${pass} passed, ${fail} failed`);
+  process.exit(fail === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error("TEST THREW:", e);
+  process.exit(1);
+});

--- a/packages/mikrohyperbee/tsconfig.json
+++ b/packages/mikrohyperbee/tsconfig.json
@@ -6,7 +6,7 @@
     "lib": ["ES2021"],
     "declaration": true,
     "outDir": "./dist",
-    "rootDir": ".",
+    "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -14,6 +14,6 @@
     "resolveJsonModule": true,
     "types": ["node"]
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"],
-  "exclude": ["dist", "node_modules"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules", "test"]
 }

--- a/packages/mikrohyperbee/tsconfig.json
+++ b/packages/mikrohyperbee/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "lib": ["ES2021"],
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -818,7 +818,7 @@ importers:
     devDependencies:
       '@medusajs/admin-vite-plugin':
         specifier: 2.17.2
-        version: 2.17.2(picomatch@4.0.5)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
+        version: 2.17.2(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
       '@medusajs/types':
         specifier: 2.17.2
         version: 2.17.2(ioredis@5.9.3)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
@@ -1439,6 +1439,24 @@ importers:
       jest:
         specifier: 29.7.0
         version: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3))
+      typescript:
+        specifier: 5.6.3
+        version: 5.6.3
+
+  packages/mikrohyperbee:
+    devDependencies:
+      '@types/node':
+        specifier: ^20.12.11
+        version: 20.19.34
+      corestore:
+        specifier: ^7.4.6
+        version: 7.11.0(bare-url@2.4.5)
+      hyperbee:
+        specifier: ^2.24.2
+        version: 2.27.3
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
       typescript:
         specifier: 5.6.3
         version: 5.6.3
@@ -24889,7 +24907,6 @@ snapshots:
       - bare-url
       - react-native-b4a
       - sodium-javascript
-    optional: true
 
   '@icons/material@0.2.4(react@18.3.1)':
     dependencies:
@@ -25737,7 +25754,7 @@ snapshots:
   '@medusajs/admin-bundler@2.17.2(@emotion/is-prop-valid@1.4.0)(@types/node@20.19.34)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(typescript@5.6.3)':
     dependencies:
       '@medusajs/admin-shared': 2.17.2
-      '@medusajs/admin-vite-plugin': 2.17.2(picomatch@4.0.5)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
+      '@medusajs/admin-vite-plugin': 2.17.2(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
       '@medusajs/dashboard': 2.17.2(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(typescript@5.6.3)
       '@vitejs/plugin-react': 4.7.0(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
       autoprefixer: 10.4.27(postcss@8.5.6)
@@ -25801,6 +25818,22 @@ snapshots:
       '@medusajs/admin-shared': 2.17.2
       chokidar: 3.6.0
       fdir: 6.1.1(picomatch@4.0.5)
+      magic-string: 0.30.5
+      outdent: 0.8.0
+      picocolors: 1.1.1
+      vite: 5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
+    transitivePeerDependencies:
+      - picomatch
+      - supports-color
+
+  '@medusajs/admin-vite-plugin@2.17.2(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))':
+    dependencies:
+      '@babel/parser': 7.25.6
+      '@babel/traverse': 7.25.6
+      '@babel/types': 7.25.6
+      '@medusajs/admin-shared': 2.17.2
+      chokidar: 3.6.0
+      fdir: 6.1.1(picomatch@4.0.4)
       magic-string: 0.30.5
       outdent: 0.8.0
       picocolors: 1.1.1
@@ -36878,7 +36911,6 @@ snapshots:
       bare-semver: 1.1.0
     optionalDependencies:
       bare-url: 2.4.5
-    optional: true
 
   bare-ansi-escapes@2.2.3(bare-events@2.9.1):
     dependencies:
@@ -36887,7 +36919,6 @@ snapshots:
       - bare-abort-controller
       - bare-events
       - react-native-b4a
-    optional: true
 
   bare-assert@1.2.0(bare-events@2.9.1):
     dependencies:
@@ -36897,7 +36928,6 @@ snapshots:
       - bare-buffer
       - bare-events
       - react-native-b4a
-    optional: true
 
   bare-events@2.9.1: {}
 
@@ -36933,14 +36963,12 @@ snapshots:
       - bare-buffer
       - bare-events
       - react-native-b4a
-    optional: true
 
   bare-module-resolve@1.12.2(bare-url@2.4.5):
     dependencies:
       bare-semver: 1.1.0
     optionalDependencies:
       bare-url: 2.4.5
-    optional: true
 
   bare-os@3.7.0:
     optional: true
@@ -36952,8 +36980,7 @@ snapshots:
 
   bare-path@3.1.1: {}
 
-  bare-semver@1.1.0:
-    optional: true
+  bare-semver@1.1.0: {}
 
   bare-stream@2.13.3(bare-events@2.9.1):
     dependencies:
@@ -36976,8 +37003,7 @@ snapshots:
       - react-native-b4a
     optional: true
 
-  bare-type@1.1.0:
-    optional: true
+  bare-type@1.1.0: {}
 
   bare-url@2.3.2:
     dependencies:
@@ -37014,8 +37040,7 @@ snapshots:
 
   big-integer@1.6.52: {}
 
-  big-sparse-array@1.0.3:
-    optional: true
+  big-sparse-array@1.0.3: {}
 
   big.js@5.2.2: {}
 
@@ -37630,7 +37655,6 @@ snapshots:
       b4a: 1.8.1
     transitivePeerDependencies:
       - react-native-b4a
-    optional: true
 
   collapse-white-space@2.1.0: {}
 
@@ -37740,7 +37764,6 @@ snapshots:
       b4a: 1.8.1
     transitivePeerDependencies:
       - react-native-b4a
-    optional: true
 
   compare-func@2.0.0:
     dependencies:
@@ -37930,7 +37953,6 @@ snapshots:
       - bare-url
       - react-native-b4a
       - sodium-javascript
-    optional: true
 
   cors@2.8.6:
     dependencies:
@@ -38405,8 +38427,7 @@ snapshots:
 
   debounce@1.2.1: {}
 
-  debounceify@1.1.0:
-    optional: true
+  debounceify@1.1.0: {}
 
   debug@2.6.9:
     dependencies:
@@ -38537,7 +38558,6 @@ snapshots:
       - bare-buffer
       - bare-url
       - react-native-b4a
-    optional: true
 
   devlop@1.1.0:
     dependencies:
@@ -39495,7 +39515,7 @@ snapshots:
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.1.0
 
   exceljs@4.4.0:
     dependencies:
@@ -39772,7 +39792,6 @@ snapshots:
       - bare-buffer
       - bare-url
       - react-native-b4a
-    optional: true
 
   fd-slicer@1.1.0:
     dependencies:
@@ -39921,8 +39940,7 @@ snapshots:
       keyv: 4.5.4
       rimraf: 3.0.2
 
-  flat-tree@1.13.0:
-    optional: true
+  flat-tree@1.13.0: {}
 
   flat@5.0.2: {}
 
@@ -40045,7 +40063,6 @@ snapshots:
       which-runtime: 1.4.0
     transitivePeerDependencies:
       - bare-url
-    optional: true
 
   fs.realpath@1.0.0: {}
 
@@ -40098,10 +40115,8 @@ snapshots:
   generate-object-property@2.0.0:
     dependencies:
       is-property: 1.0.2
-    optional: true
 
-  generate-string@1.0.1:
-    optional: true
+  generate-string@1.0.1: {}
 
   generator-function@2.0.1: {}
 
@@ -40688,7 +40703,6 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
-    optional: true
 
   hypercore-crypto@3.7.0(bare-events@2.9.1)(bare-url@2.4.5):
     dependencies:
@@ -40702,14 +40716,12 @@ snapshots:
       - bare-url
       - react-native-b4a
       - sodium-javascript
-    optional: true
 
   hypercore-errors@1.5.0:
     dependencies:
       hypercore-id-encoding: 1.3.0
     transitivePeerDependencies:
       - react-native-b4a
-    optional: true
 
   hypercore-id-encoding@1.3.0:
     dependencies:
@@ -40717,7 +40729,6 @@ snapshots:
       z32: 1.1.0
     transitivePeerDependencies:
       - react-native-b4a
-    optional: true
 
   hypercore-storage@3.2.0(bare-events@2.9.1)(bare-url@2.4.5):
     dependencies:
@@ -40741,7 +40752,6 @@ snapshots:
       - bare-url
       - react-native-b4a
       - sodium-javascript
-    optional: true
 
   hypercore@11.34.0(bare-url@2.4.5):
     dependencies:
@@ -40772,7 +40782,6 @@ snapshots:
       - bare-url
       - react-native-b4a
       - sodium-javascript
-    optional: true
 
   hyperdht-address@1.1.1:
     dependencies:
@@ -40827,7 +40836,6 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
-    optional: true
 
   hyperswarm@4.17.0(bare-url@2.4.5):
     dependencies:
@@ -40977,7 +40985,6 @@ snapshots:
       b4a: 1.8.1
     transitivePeerDependencies:
       - react-native-b4a
-    optional: true
 
   index-to-position@1.2.0: {}
 
@@ -41238,7 +41245,6 @@ snapshots:
       b4a: 1.8.1
     transitivePeerDependencies:
       - react-native-b4a
-    optional: true
 
   is-path-inside@3.0.3: {}
 
@@ -41256,8 +41262,7 @@ snapshots:
 
   is-promise@4.0.0: {}
 
-  is-property@1.0.2:
-    optional: true
+  is-property@1.0.2: {}
 
   is-reference@1.2.1:
     dependencies:
@@ -43318,7 +43323,6 @@ snapshots:
   mutexify@1.4.0:
     dependencies:
       queue-tick: 1.0.1
-    optional: true
 
   mylas@2.1.14: {}
 
@@ -43328,8 +43332,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoassert@2.0.0:
-    optional: true
+  nanoassert@2.0.0: {}
 
   nanoid@3.3.11: {}
 
@@ -43553,7 +43556,6 @@ snapshots:
       - bare-url
       - react-native-b4a
       - sodium-javascript
-    optional: true
 
   noise-handshake@4.2.0(bare-events@2.9.1)(bare-url@2.4.5):
     dependencies:
@@ -43567,7 +43569,6 @@ snapshots:
       - bare-url
       - react-native-b4a
       - sodium-javascript
-    optional: true
 
   non-layered-tidy-tree-layout@2.0.2: {}
 
@@ -45046,7 +45047,6 @@ snapshots:
       varint: 5.0.0
     transitivePeerDependencies:
       - react-native-b4a
-    optional: true
 
   protomux@3.11.0:
     dependencies:
@@ -45057,7 +45057,6 @@ snapshots:
       unslab: 1.3.0
     transitivePeerDependencies:
       - react-native-b4a
-    optional: true
 
   proxy-addr@2.0.7:
     dependencies:
@@ -45109,8 +45108,7 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  queue-tick@1.0.1:
-    optional: true
+  queue-tick@1.0.1: {}
 
   queue@6.0.2:
     dependencies:
@@ -45136,12 +45134,10 @@ snapshots:
     transitivePeerDependencies:
       - bare-url
       - react-native-b4a
-    optional: true
 
   quotemeta@0.0.0: {}
 
-  rache@1.0.0:
-    optional: true
+  rache@1.0.0: {}
 
   radix-ui@1.1.2(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -45386,8 +45382,7 @@ snapshots:
       discontinuous-range: 1.0.0
       ret: 0.1.15
 
-  random-array-iterator@1.0.0:
-    optional: true
+  random-array-iterator@1.0.0: {}
 
   random-bytes@1.0.0: {}
 
@@ -45997,7 +45992,6 @@ snapshots:
       bare-events: 2.9.1
     transitivePeerDependencies:
       - bare-abort-controller
-    optional: true
 
   real-require@0.2.0: {}
 
@@ -46116,8 +46110,7 @@ snapshots:
 
   redux@5.0.1: {}
 
-  refcounter@1.0.0:
-    optional: true
+  refcounter@1.0.0: {}
 
   reflect-metadata@0.2.2: {}
 
@@ -46306,7 +46299,6 @@ snapshots:
       bare-addon-resolve: 1.10.0(bare-url@2.4.5)
     transitivePeerDependencies:
       - bare-url
-    optional: true
 
   require-directory@2.1.1: {}
 
@@ -46356,8 +46348,7 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  resolve-reject-promise@1.1.0:
-    optional: true
+  resolve-reject-promise@1.1.0: {}
 
   resolve.exports@2.0.3: {}
 
@@ -46383,8 +46374,7 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  resource-on-exit@1.0.0:
-    optional: true
+  resource-on-exit@1.0.0: {}
 
   responselike@3.0.0:
     dependencies:
@@ -46431,7 +46421,6 @@ snapshots:
       - bare-abort-controller
       - bare-url
       - react-native-b4a
-    optional: true
 
   rollup-plugin-esbuild@6.2.1(esbuild@0.28.1)(rollup@4.62.2):
     dependencies:
@@ -46592,8 +46581,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  safety-catch@1.0.3:
-    optional: true
+  safety-catch@1.0.3: {}
 
   sass-embedded-all-unknown@1.97.3:
     dependencies:
@@ -46731,8 +46719,7 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.20.0)
       ajv-keywords: 5.1.0(ajv@8.20.0)
 
-  scope-lock@1.2.4:
-    optional: true
+  scope-lock@1.2.4: {}
 
   scrypt-kdf@2.0.1: {}
 
@@ -47068,8 +47055,7 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  signal-promise@1.0.3:
-    optional: true
+  signal-promise@1.0.3: {}
 
   signale@1.4.0:
     dependencies:
@@ -47080,7 +47066,6 @@ snapshots:
   signed-varint@2.0.1:
     dependencies:
       varint: 5.0.0
-    optional: true
 
   signedsource@1.0.0: {}
 
@@ -47101,7 +47086,6 @@ snapshots:
     transitivePeerDependencies:
       - bare-url
       - react-native-b4a
-    optional: true
 
   simple-concat@1.0.1: {}
 
@@ -47187,7 +47171,6 @@ snapshots:
       - bare-events
       - bare-url
       - react-native-b4a
-    optional: true
 
   sodium-secretstream@1.2.0(bare-events@2.9.1)(bare-url@2.4.5):
     dependencies:
@@ -47200,7 +47183,6 @@ snapshots:
       - bare-url
       - react-native-b4a
       - sodium-javascript
-    optional: true
 
   sodium-universal@5.0.1(bare-events@2.9.1)(bare-url@2.4.5):
     dependencies:
@@ -47211,7 +47193,6 @@ snapshots:
       - bare-events
       - bare-url
       - react-native-b4a
-    optional: true
 
   sonic-boom@4.2.1:
     dependencies:
@@ -47879,8 +47860,7 @@ snapshots:
     dependencies:
       convert-hrtime: 5.0.0
 
-  timeout-refresh@2.0.1:
-    optional: true
+  timeout-refresh@2.0.1: {}
 
   tiny-invariant@1.3.3: {}
 
@@ -48380,7 +48360,6 @@ snapshots:
       b4a: 1.8.1
     transitivePeerDependencies:
       - react-native-b4a
-    optional: true
 
   unzipper@0.10.14:
     dependencies:
@@ -48594,8 +48573,7 @@ snapshots:
 
   value-equal@1.0.1: {}
 
-  varint@5.0.0:
-    optional: true
+  varint@5.0.0: {}
 
   varint@6.0.0: {}
 
@@ -48960,8 +48938,7 @@ snapshots:
 
   which-module@2.0.1: {}
 
-  which-runtime@1.4.0:
-    optional: true
+  which-runtime@1.4.0: {}
 
   which-typed-array@1.1.20:
     dependencies:
@@ -49093,8 +49070,7 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
 
-  xache@1.2.1:
-    optional: true
+  xache@1.2.1: {}
 
   xdg-basedir@4.0.0: {}
 
@@ -49227,7 +49203,6 @@ snapshots:
       b4a: 1.8.1
     transitivePeerDependencies:
       - react-native-b4a
-    optional: true
 
   zeroentropy@0.1.0-alpha.7:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       '@jytextiles/medusa-plugin-faire-store-sync':
         specifier: latest
         version: 0.2.14(@medusajs/admin-sdk@2.17.2)(@medusajs/cli@2.17.2(@types/node@20.19.34))(@medusajs/dashboard@2.17.2(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(typescript@5.9.3))(@medusajs/framework@2.17.2(@medusajs/cli@2.17.2(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))(zod@4.2.0))(@medusajs/icons@2.17.2(react@18.3.1))(@medusajs/medusa@2.17.2)(@medusajs/test-utils@2.17.2)(@medusajs/types@2.17.2(ioredis@5.9.3)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)))(@medusajs/ui@4.1.19(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@jytextiles/mikrohyperbee':
+        specifier: workspace:*
+        version: link:../../packages/mikrohyperbee
       '@mastra/core':
         specifier: latest
         version: 1.50.1(@bufbuild/protobuf@2.11.0)(@grpc/grpc-js@1.14.3)(ai@5.0.138(zod@4.2.0))(express@5.2.1)(rxjs@7.8.2)(zod@4.2.0)


### PR DESCRIPTION
Stacked on #1045 (needs the `person_property` module). Makes `PersonPropertyService` able to run over **Hyperbee instead of Postgres** — the MikroHyperbee direction — behind a flag.

## What's here
- **`dal/hyperbee-person-property-service.ts`** — the internal per-model service Medusa's generated methods delegate to, ported from the proven spike. Brotli-compressed records + secondary indexes; equality / `$in` / `$ne` / `$gt..$lte` filters, compound intersection, pagination + order.
- **`loaders/hyperbee-dal.ts`** — flag-gated loader (`PERSON_PROPERTY_HYPERBEE=true`). Opens a local Hyperbee store, overrides the container's `personPropertyService` + `baseRepository`. Native deps dynamic-imported + try/catch. **Strict no-op when the flag is unset** → default stays Postgres.
- **`__tests__/hyperbee-dal.e2e.ts`** — re-homed proof driving the REAL service over the ported DAL.

## Verified ✅
- `node_modules/.bin/tsx …/__tests__/hyperbee-dal.e2e.ts` → **11/11**: the real generated `create/list/listAndCount/retrieve/update/delete` (incl. compound + operator filters, reindex-on-update, NOT_FOUND) all run over Hyperbee.
- Embedded native stack loads in the prod image + peers from Fargate (proven in #1045).

## Not yet verified — why this is a DRAFT ⚠️
The one seam the tsx proof can't cover: whether the loader's `container.register(...)` override actually takes effect over Medusa's **auto-registered** internal service at real module boot. Needs a live backend run with the flag on (`yarn dev` + hit an admin route that lists person_property). Flag defaults OFF so this can't affect anything until confirmed.

## Design note
This first cut uses a **local writable Hyperbee store** (self-contained, for onboarded-weaver `person_property` records) — decoupled from the census crawl cores. Peering / encrypted-core reading / mirror replication are follow-ups.

Relates to #938 (product-as-spine / MikroHyperbee) and the #1030 person_property landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)