### PR TITLE
fix(#969): settle convertible payments, paid-gate + agreement backfill

### DIFF
--- a/apps/backend/src/admin/components/companies/cap-table-section.tsx
+++ b/apps/backend/src/admin/components/companies/cap-table-section.tsx
@@ -323,6 +323,12 @@ const convertibleStatusColor = (s?: string): "green" | "orange" | "red" | "grey"
   }
 }
 
+// A convertible has no `fully_paid` instrument state — settlement lives on its
+// payment. Only count it as paid once a payment is `completed`; an approved-but-
+// unpaid convertible is surfaced as "Awaiting payment", not silently invested.
+const convertibleIsPaid = (c: AdminConvertible) =>
+  !!c.payments?.some((pm) => pm.status === "completed")
+
 const ConvertiblesTable = ({ capTable }: { capTable: AdminCapTable }) => {
   const ccy = capTable.currency_code
   const { convertibles = [], isPending } = useCapTableConvertibles(capTable.id)
@@ -378,11 +384,21 @@ const ConvertiblesTable = ({ capTable }: { capTable: AdminCapTable }) => {
       {
         header: "Status",
         accessorKey: "status",
-        cell: ({ row }: any) => (
-          <Badge color={convertibleStatusColor(row.original.status)}>
-            {row.original.status ?? "outstanding"}
-          </Badge>
-        ),
+        cell: ({ row }: any) => {
+          const c = row.original as AdminConvertible
+          const status = c.status ?? "outstanding"
+          const showPayment = status === "outstanding" && !convertibleIsPaid(c)
+          return (
+            <div className="flex items-center gap-x-1">
+              <Badge color={convertibleStatusColor(status)}>{status}</Badge>
+              {showPayment && (
+                <Badge size="2xsmall" color="orange">
+                  Awaiting payment
+                </Badge>
+              )}
+            </div>
+          )
+        },
       },
       {
         id: "actions",

--- a/apps/backend/src/admin/hooks/api/cap-tables-admin.ts
+++ b/apps/backend/src/admin/hooks/api/cap-tables-admin.ts
@@ -259,6 +259,15 @@ export type AdminParticipation = {
   metadata?: Record<string, any> | null
   investor?: { id: string; name?: string; email?: string } | null
   payments?: Array<{ id: string; amount?: number | null; status?: string; metadata?: Record<string, any> | null }>
+  // The issued subscription agreement, if any (null = never issued). `status`
+  // is the agreement_response status: sent | viewed | agreed | disagreed | expired.
+  agreement?: {
+    id: string
+    status?: string
+    agreed?: boolean
+    responded_at?: string | null
+    signed_by_admin?: boolean
+  } | null
 }
 
 export type ConvertibleInstrument = "safe" | "convertible_note" | "ccps"
@@ -513,6 +522,86 @@ export const useMarkParticipationPaid = (
       queryClient.invalidateQueries({ queryKey: roundParticipationsQueryKey(roundId) })
       queryClient.invalidateQueries({ queryKey: ["admin-cap-table"] })
       queryClient.invalidateQueries({ queryKey: ["admin-company-cap-tables"] })
+      ;(options?.onSuccess as any)?.(...args)
+    },
+  })
+}
+
+// Settle a SAFE / convertible / CCPS participation manually — completes its
+// payment(s). Counterpart to the PayU webhook for the convertible rail (which,
+// unlike stakes, has no `fully_paid` instrument state — "paid" lives on the
+// Payment). Mirrors useMarkParticipationPaid but hits the convertible route.
+export const useMarkConvertiblePaid = (
+  roundId: string,
+  options?: UseMutationOptions<{ ok: boolean }, FetchError, string>
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    ...options,
+    mutationFn: (convertibleId: string) =>
+      sdk.client.fetch(`/admin/convertibles/${convertibleId}/mark-paid`, {
+        method: "POST",
+      }),
+    onSuccess: (...args: any[]) => {
+      queryClient.invalidateQueries({ queryKey: roundParticipationsQueryKey(roundId) })
+      queryClient.invalidateQueries({ queryKey: ["admin-cap-table"] })
+      queryClient.invalidateQueries({ queryKey: ["admin-cap-table-convertibles"] })
+      queryClient.invalidateQueries({ queryKey: ["admin-company-cap-tables"] })
+      ;(options?.onSuccess as any)?.(...args)
+    },
+  })
+}
+
+// Issue (or re-fetch) the subscription agreement for a participation — the
+// admin counterpart to participate-time issuance, used to backfill agreements
+// for participations created before the templates existed. Routes by type
+// (stake vs convertible). Idempotent server-side (returns reused: true).
+export const useIssueParticipationAgreement = (
+  roundId: string,
+  options?: UseMutationOptions<
+    { response_id: string | null; agreement_url: string | null; reused: boolean },
+    FetchError,
+    { id: string; type?: "stake" | "convertible" }
+  >
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    ...options,
+    mutationFn: ({ id, type }) =>
+      sdk.client.fetch(
+        type === "convertible"
+          ? `/admin/convertibles/${id}/issue-agreement`
+          : `/admin/stakes/${id}/issue-agreement`,
+        { method: "POST" }
+      ),
+    onSuccess: (...args: any[]) => {
+      queryClient.invalidateQueries({ queryKey: roundParticipationsQueryKey(roundId) })
+      ;(options?.onSuccess as any)?.(...args)
+    },
+  })
+}
+
+// Record an out-of-band signature on an agreement (admin marks it signed /
+// declined on the investor's behalf — paper/e-sign done elsewhere). Flagged
+// signed_by_admin server-side for the audit trail.
+export const useMarkAgreementSigned = (
+  roundId: string,
+  options?: UseMutationOptions<
+    { agreement: { id: string; status: string; agreed: boolean } },
+    FetchError,
+    { responseId: string; agreed?: boolean; notes?: string; signer_name?: string }
+  >
+) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    ...options,
+    mutationFn: ({ responseId, ...body }) =>
+      sdk.client.fetch(
+        `/admin/agreement-responses/${responseId}/mark-signed`,
+        { method: "POST", body }
+      ),
+    onSuccess: (...args: any[]) => {
+      queryClient.invalidateQueries({ queryKey: roundParticipationsQueryKey(roundId) })
       ;(options?.onSuccess as any)?.(...args)
     },
   })

--- a/apps/backend/src/admin/routes/companies/[id]/@participations/page.tsx
+++ b/apps/backend/src/admin/routes/companies/[id]/@participations/page.tsx
@@ -7,7 +7,15 @@ import {
   toast,
   useDataTable,
 } from "@medusajs/ui"
-import { ArrowPath, Check, Clock, CurrencyDollar, XMark } from "@medusajs/icons"
+import {
+  ArrowPath,
+  Check,
+  Clock,
+  CurrencyDollar,
+  DocumentText,
+  PencilSquare,
+  XMark,
+} from "@medusajs/icons"
 import { useSearchParams } from "react-router-dom"
 import { RouteFocusModal } from "../../../../components/modal/route-focus-modal"
 import { ActionMenu } from "../../../../components/common/action-menu"
@@ -15,6 +23,9 @@ import {
   useApproveParticipation,
   useApproveConvertible,
   useMarkParticipationPaid,
+  useMarkConvertiblePaid,
+  useIssueParticipationAgreement,
+  useMarkAgreementSigned,
   useRoundParticipations,
   useSetParticipationStatus,
   type AdminParticipation,
@@ -26,8 +37,10 @@ const num = (v?: number | null) =>
 const statusColor = (s?: string): "green" | "orange" | "red" | "grey" => {
   switch (s) {
     case "fully_paid":
+    case "paid":
     case "active":
       return "green"
+    case "awaiting payment":
     case "partially_paid":
     case "unpaid":
       return "orange"
@@ -42,6 +55,36 @@ const statusColor = (s?: string): "green" | "orange" | "red" | "grey" => {
 }
 
 const statusLabel = (s?: string) => (s ? s.replace(/_/g, " ") : "unpaid")
+
+// A convertible has no `fully_paid` instrument state — "paid" lives on its
+// payment. Consider a participation paid once any payment is `completed`.
+const isPaid = (p: AdminParticipation) =>
+  p.type === "convertible"
+    ? !!p.payments?.some((pm) => pm.status === "completed")
+    : p.status === "fully_paid"
+
+// Payment-aware status for the badge: convertibles show payment reality
+// (paid / awaiting payment) rather than the raw "outstanding" instrument state.
+const displayStatus = (p: AdminParticipation): string => {
+  if (p.type !== "convertible") return p.status ?? "unpaid"
+  if (isPaid(p)) return "paid"
+  return p.metadata?.approved ? "awaiting payment" : "outstanding"
+}
+
+const agreementColor = (s?: string): "green" | "orange" | "red" | "grey" => {
+  switch (s) {
+    case "agreed":
+      return "green"
+    case "sent":
+    case "viewed":
+      return "orange"
+    case "disagreed":
+    case "expired":
+      return "red"
+    default:
+      return "grey"
+  }
+}
 
 const ParticipationsTable = ({
   roundId,
@@ -68,6 +111,21 @@ const ParticipationsTable = ({
   })
   const { mutateAsync: markPaid } = useMarkParticipationPaid(roundId, {
     onSuccess: () => toast.success("Marked as paid"),
+    onError: (e) => toast.error(e?.message || "Failed"),
+  })
+  const { mutateAsync: markConvertiblePaid } = useMarkConvertiblePaid(roundId, {
+    onSuccess: () => toast.success("Marked as paid"),
+    onError: (e) => toast.error(e?.message || "Failed"),
+  })
+  const { mutateAsync: issueAgreement } = useIssueParticipationAgreement(roundId, {
+    onSuccess: (r) =>
+      toast.success(
+        r?.reused ? "Agreement already issued" : "Agreement issued & emailed"
+      ),
+    onError: (e) => toast.error(e?.message || "Issue failed"),
+  })
+  const { mutateAsync: markSigned } = useMarkAgreementSigned(roundId, {
+    onSuccess: () => toast.success("Recorded as signed"),
     onError: (e) => toast.error(e?.message || "Failed"),
   })
   const { mutateAsync: setStatus } = useSetParticipationStatus(roundId, {
@@ -102,11 +160,10 @@ const ParticipationsTable = ({
       {
         header: "Status",
         accessorKey: "status",
-        cell: ({ row }: any) => (
-          <Badge color={statusColor(row.original.status)}>
-            {statusLabel(row.original.status)}
-          </Badge>
-        ),
+        cell: ({ row }: any) => {
+          const s = displayStatus(row.original as AdminParticipation)
+          return <Badge color={statusColor(s)}>{statusLabel(s)}</Badge>
+        },
       },
       {
         header: "Pay link",
@@ -125,12 +182,34 @@ const ParticipationsTable = ({
         },
       },
       {
+        header: "Agreement",
+        id: "agreement",
+        cell: ({ row }: any) => {
+          const a = (row.original as AdminParticipation).agreement
+          if (!a) return <Badge size="2xsmall" color="grey">Not issued</Badge>
+          return (
+            <div className="flex items-center gap-x-1">
+              <Badge size="2xsmall" color={agreementColor(a.status)}>
+                {a.status === "agreed" ? "signed" : a.status}
+              </Badge>
+              {a.signed_by_admin && (
+                <Text size="xsmall" className="text-ui-fg-muted">
+                  (admin)
+                </Text>
+              )}
+            </div>
+          )
+        },
+      },
+      {
         id: "actions",
         header: "",
         cell: ({ row }: any) => {
           const p = row.original as AdminParticipation
           const approved = !!p.metadata?.approved
           const isConvertible = p.type === "convertible"
+          const agreement = p.agreement
+          const agreementSigned = agreement?.status === "agreed"
           const isParked =
             p.status === "rejected" || p.status === "not_followed_up"
           return (
@@ -146,13 +225,42 @@ const ParticipationsTable = ({
                         onClick: () =>
                           isConvertible ? approveConvertible(p.id) : approve(p.id),
                       },
-                      // Mark-paid uses the stake ledger; only equity stakes support it.
+                      // Mark-paid settles the payment ledger: stakes flip to
+                      // fully_paid, convertibles complete their payment (and
+                      // stay outstanding). Both rails are supported.
                       {
                         icon: <CurrencyDollar />,
                         label: "Mark paid",
-                        disabled:
-                          isConvertible || isParked || p.status === "fully_paid",
-                        onClick: () => markPaid(p.id),
+                        disabled: isParked || isPaid(p),
+                        onClick: () =>
+                          isConvertible
+                            ? markConvertiblePaid(p.id)
+                            : markPaid(p.id),
+                      },
+                    ],
+                  },
+                  // Subscription agreement: issue (or re-issue) it, and record
+                  // an out-of-band signature. Issue is disabled once one exists;
+                  // Mark signed once it's already signed.
+                  {
+                    actions: [
+                      {
+                        icon: <DocumentText />,
+                        label: agreement ? "Agreement issued" : "Issue agreement",
+                        disabled: isParked || !!agreement,
+                        onClick: () =>
+                          issueAgreement({ id: p.id, type: p.type }),
+                      },
+                      {
+                        icon: <PencilSquare />,
+                        label: "Mark signed",
+                        disabled: !agreement || agreementSigned,
+                        onClick: () =>
+                          agreement &&
+                          markSigned({
+                            responseId: agreement.id,
+                            agreed: true,
+                          }),
                       },
                     ],
                   },

--- a/apps/backend/src/api/admin/agreement-responses/[id]/mark-signed/route.ts
+++ b/apps/backend/src/api/admin/agreement-responses/[id]/mark-signed/route.ts
@@ -1,0 +1,91 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { AGREEMENT_RESPONSE_MODULE } from "../../../../../modules/agreement-responses"
+import { AGREEMENTS_MODULE } from "../../../../../modules/agreements"
+
+// POST /admin/agreement-responses/:id/mark-signed — an admin records that an
+// agreement was signed (or declined) out-of-band: paper/e-sign done elsewhere,
+// or verbal/confirmed acceptance the team is logging on the investor's behalf.
+// Counterpart to the investor portal `/investors/me/agreements/:id/sign` and the
+// token `/web/agreement/:id/respond` — same status transition + counter bump,
+// but flagged in metadata as admin-recorded for an audit trail.
+//
+// Body: { agreed?: boolean (default true), notes?: string, signer_name?: string }
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const responseSvc: any = req.scope.resolve(AGREEMENT_RESPONSE_MODULE)
+  const agreementsSvc: any = req.scope.resolve(AGREEMENTS_MODULE)
+
+  const body = (req.body as any) || {}
+  const agreed = body.agreed !== false // default to accept
+  const notes = typeof body.notes === "string" ? body.notes : null
+  const signerName =
+    typeof body.signer_name === "string" ? body.signer_name : null
+
+  const response = await responseSvc
+    .retrieveAgreementResponse(req.params.id)
+    .catch(() => null)
+  if (!response) {
+    throw new MedusaError(MedusaError.Types.NOT_FOUND, "Agreement not found")
+  }
+  if (response.status === "agreed" || response.status === "disagreed") {
+    throw new MedusaError(
+      MedusaError.Types.NOT_ALLOWED,
+      "This agreement has already been responded to"
+    )
+  }
+
+  const adminEmail =
+    (req as any).auth_context?.actor_id ||
+    (req as any).user?.email ||
+    "admin"
+  const ip =
+    (req.headers["x-forwarded-for"] as string)?.split(",")[0]?.trim() ||
+    (req.socket as any)?.remoteAddress ||
+    null
+
+  const [updated] = await responseSvc.updateAgreementResponses({
+    selector: { id: response.id },
+    data: {
+      status: agreed ? "agreed" : "disagreed",
+      agreed,
+      responded_at: new Date(),
+      response_notes: notes,
+      response_ip: ip,
+      response_user_agent: "admin-dashboard",
+      metadata: {
+        ...(response.metadata || {}),
+        signed_by_admin: true,
+        signed_by_admin_email: adminEmail,
+        signed_by_admin_at: new Date().toISOString(),
+        signer_name: signerName || response.metadata?.signer_name || null,
+      },
+    },
+  })
+
+  // Bump agreement counters (best-effort).
+  try {
+    const [agreement] = await agreementsSvc.listAgreements({
+      id: response.agreement_id,
+    })
+    if (agreement) {
+      await agreementsSvc.updateAgreements({
+        selector: { id: agreement.id },
+        data: {
+          response_count: (agreement.response_count || 0) + 1,
+          agreed_count: (agreement.agreed_count || 0) + (agreed ? 1 : 0),
+        },
+      })
+    }
+  } catch {
+    /* non-fatal */
+  }
+
+  res.json({
+    agreement: {
+      id: updated.id,
+      status: updated.status,
+      agreed: updated.agreed,
+      responded_at: updated.responded_at,
+    },
+  })
+}

--- a/apps/backend/src/api/admin/convertibles/[id]/issue-agreement/route.ts
+++ b/apps/backend/src/api/admin/convertibles/[id]/issue-agreement/route.ts
@@ -1,0 +1,12 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { issueAgreementForConvertible } from "../../../lib/issue-investor-agreement"
+
+// POST /admin/convertibles/:id/issue-agreement — issue (or return the
+// already-issued) subscription agreement for a SAFE / note / CCPS participation.
+// Admin counterpart to participate-time issuance; idempotent (see the stake
+// twin). Used to backfill convertibles created before the agreement templates
+// existed — e.g. an already-paid CCPS that never received its agreement.
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const result = await issueAgreementForConvertible(req.scope, req.params.id)
+  res.json(result)
+}

--- a/apps/backend/src/api/admin/convertibles/[id]/mark-paid/route.ts
+++ b/apps/backend/src/api/admin/convertibles/[id]/mark-paid/route.ts
@@ -1,0 +1,29 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { INVESTOR_MODULE } from "../../../../../modules/investor"
+import type InvestorService from "../../../../../modules/investor/service"
+
+// POST /admin/convertibles/:id/mark-paid — settle a SAFE / convertible / CCPS
+// participation manually: mark its payment(s) completed. The convertible's own
+// status stays "outstanding" (a paid convertible is an active/outstanding
+// instrument until it converts or is redeemed). This is the manual counterpart
+// to the PayU webhook for the convertible rail, mirroring stakes' mark-paid —
+// unlike stakes there is no `fully_paid` instrument state, so "paid" lives on
+// the Payment and is what the cap table / portfolio gate on.
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: InvestorService = req.scope.resolve(INVESTOR_MODULE)
+
+  const payments: any[] = await service.listPayments({
+    convertible_id: req.params.id,
+  } as any)
+  for (const p of payments) {
+    if (p.status !== "completed") {
+      await service.updatePayments({
+        id: p.id,
+        status: "completed",
+        paid_date: new Date(),
+      } as any)
+    }
+  }
+
+  res.json({ ok: true })
+}

--- a/apps/backend/src/api/admin/funding-rounds/[id]/participations/route.ts
+++ b/apps/backend/src/api/admin/funding-rounds/[id]/participations/route.ts
@@ -1,10 +1,13 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { AGREEMENT_RESPONSE_MODULE } from "../../../../../modules/agreement-responses"
 
 // GET /admin/funding-rounds/:id/participations — investor participations on this
-// round, with investor + any payment (to show status / PayU link). Equity rounds
-// yield `stake` participations; SAFE / convertible rounds yield `convertible`
-// ones — both are returned with a `type` discriminator so one screen handles both.
+// round, with investor + any payment (to show status / PayU link) + the issued
+// subscription agreement (to issue / mark-signed from the dashboard). Equity
+// rounds yield `stake` participations; SAFE / convertible rounds yield
+// `convertible` ones — both are returned with a `type` discriminator so one
+// screen handles both.
 export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
@@ -49,5 +52,45 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     })),
   ]
 
-  res.json({ participations, count: participations.length })
+  // Attach the issued subscription agreement (if any) per participation. The
+  // generate workflow stamps `metadata.stake_id` / `metadata.convertible_id` on
+  // the agreement_response, so match on that — scoped to the participants'
+  // emails to keep the scan tight. Lets the dashboard show issue / mark-signed.
+  const emails = Array.from(
+    new Set(
+      participations.map((p: any) => p.investor?.email).filter(Boolean)
+    )
+  )
+  let responses: any[] = []
+  if (emails.length) {
+    try {
+      const responseSvc: any = req.scope.resolve(AGREEMENT_RESPONSE_MODULE)
+      responses = await responseSvc.listAgreementResponses({
+        email_sent_to: emails,
+      })
+    } catch {
+      responses = []
+    }
+  }
+  const withAgreements = participations.map((p: any) => {
+    const r = responses.find(
+      (x) =>
+        (p.type === "stake" && x.metadata?.stake_id === p.id) ||
+        (p.type === "convertible" && x.metadata?.convertible_id === p.id)
+    )
+    return {
+      ...p,
+      agreement: r
+        ? {
+            id: r.id,
+            status: r.status,
+            agreed: r.agreed,
+            responded_at: r.responded_at,
+            signed_by_admin: !!r.metadata?.signed_by_admin,
+          }
+        : null,
+    }
+  })
+
+  res.json({ participations: withAgreements, count: withAgreements.length })
 }

--- a/apps/backend/src/api/admin/lib/issue-investor-agreement.ts
+++ b/apps/backend/src/api/admin/lib/issue-investor-agreement.ts
@@ -1,0 +1,165 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import {
+  generateInvestorAgreementWorkflow,
+  type GenerateInvestorAgreementInput,
+} from "../../../workflows/investor/generate-investor-agreement"
+import { AGREEMENT_RESPONSE_MODULE } from "../../../modules/agreement-responses"
+
+export type IssueAgreementResult = {
+  response_id: string | null
+  agreement_url: string | null
+  reused: boolean
+}
+
+// Has an agreement already been issued for this instrument? The generate
+// workflow stamps `metadata.stake_id` / `metadata.convertible_id` on the
+// agreement_response, so we match on that (scoped to the investor's email to
+// keep the scan small). Prevents an admin double-issuing (and double-emailing).
+async function findExistingResponse(
+  scope: any,
+  opts: { email?: string | null; stakeId?: string; convertibleId?: string }
+): Promise<any | null> {
+  if (!opts.email) return null
+  const responseSvc: any = scope.resolve(AGREEMENT_RESPONSE_MODULE)
+  const responses: any[] = await responseSvc.listAgreementResponses({
+    email_sent_to: opts.email,
+  })
+  return (
+    responses?.find(
+      (r) =>
+        (opts.stakeId && r.metadata?.stake_id === opts.stakeId) ||
+        (opts.convertibleId && r.metadata?.convertible_id === opts.convertibleId)
+    ) ?? null
+  )
+}
+
+async function run(
+  scope: any,
+  input: GenerateInvestorAgreementInput
+): Promise<IssueAgreementResult> {
+  const { result } = await generateInvestorAgreementWorkflow(scope).run({ input })
+  return {
+    response_id: (result as any)?.response_id ?? null,
+    agreement_url: (result as any)?.agreement_url ?? null,
+    reused: false,
+  }
+}
+
+// Issue (or return the already-issued) subscription agreement for an existing
+// equity Stake. Reconstructs the workflow input from the persisted stake + its
+// round + cap table + investor — the admin counterpart to the participate-time
+// issuance, used to backfill participations created before the agreement
+// templates existed (or that skipped issuance).
+export async function issueAgreementForStake(
+  scope: any,
+  stakeId: string
+): Promise<IssueAgreementResult> {
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data } = await query.graph({
+    entity: "stake",
+    filters: { id: stakeId },
+    fields: [
+      "id",
+      "investor_id",
+      "number_of_shares",
+      "share_price",
+      "total_invested",
+      "funding_round_id",
+      "cap_table_id",
+      "investor.email",
+      "funding_round.name",
+      "cap_table.currency_code",
+    ],
+  })
+  const stake = data?.[0]
+  if (!stake) throw new Error(`Stake ${stakeId} not found`)
+
+  const existing = await findExistingResponse(scope, {
+    email: stake.investor?.email,
+    stakeId,
+  })
+  if (existing) {
+    return {
+      response_id: existing.id,
+      agreement_url: existing.metadata?.agreement_url ?? null,
+      reused: true,
+    }
+  }
+
+  return run(scope, {
+    investor_id: stake.investor_id,
+    funding_round_id: stake.funding_round_id ?? "",
+    cap_table_id: stake.cap_table_id,
+    instrument_group: "equity",
+    instrument_label: "Equity Subscription Agreement",
+    amount: Number(stake.total_invested ?? 0),
+    currency_code: stake.cap_table?.currency_code ?? null,
+    number_of_shares: stake.number_of_shares ?? null,
+    share_price: stake.share_price ?? null,
+    stake_id: stakeId,
+  })
+}
+
+// Issue (or return the already-issued) subscription agreement for an existing
+// convertible (SAFE / note / CCPS).
+export async function issueAgreementForConvertible(
+  scope: any,
+  convertibleId: string
+): Promise<IssueAgreementResult> {
+  const query = scope.resolve(ContainerRegistrationKeys.QUERY)
+  const { data } = await query.graph({
+    entity: "convertible",
+    filters: { id: convertibleId },
+    fields: [
+      "id",
+      "investor_id",
+      "instrument_type",
+      "principal_amount",
+      "valuation_cap",
+      "discount_rate",
+      "safe_type",
+      "num_shares",
+      "funding_round_id",
+      "cap_table_id",
+      "investor.email",
+      "cap_table.currency_code",
+    ],
+  })
+  const c = data?.[0]
+  if (!c) throw new Error(`Convertible ${convertibleId} not found`)
+
+  const existing = await findExistingResponse(scope, {
+    email: c.investor?.email,
+    convertibleId,
+  })
+  if (existing) {
+    return {
+      response_id: existing.id,
+      agreement_url: existing.metadata?.agreement_url ?? null,
+      reused: true,
+    }
+  }
+
+  const isCcps = c.instrument_type === "ccps"
+  const label = isCcps
+    ? "CCPS Subscription Agreement"
+    : c.instrument_type === "convertible_note"
+    ? "Convertible Note Agreement"
+    : "SAFE Agreement"
+
+  return run(scope, {
+    investor_id: c.investor_id,
+    funding_round_id: c.funding_round_id ?? "",
+    cap_table_id: c.cap_table_id,
+    instrument_group: isCcps ? "ccps" : "safe",
+    instrument_label: label,
+    amount: Number(c.principal_amount ?? 0),
+    currency_code: c.cap_table?.currency_code ?? null,
+    number_of_shares: isCcps ? c.num_shares ?? null : null,
+    principal: Number(c.principal_amount ?? 0),
+    valuation_cap: c.valuation_cap ?? null,
+    discount_rate: c.discount_rate ?? null,
+    safe_type: c.safe_type ?? "post_money",
+    convertible_id: convertibleId,
+  })
+}

--- a/apps/backend/src/api/admin/stakes/[id]/issue-agreement/route.ts
+++ b/apps/backend/src/api/admin/stakes/[id]/issue-agreement/route.ts
@@ -1,0 +1,12 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { issueAgreementForStake } from "../../../lib/issue-investor-agreement"
+
+// POST /admin/stakes/:id/issue-agreement — issue (or return the already-issued)
+// subscription agreement for an equity participation. Admin counterpart to
+// participate-time issuance: used to backfill stakes created before the
+// agreement templates existed. Idempotent — returns the existing response with
+// `reused: true` rather than issuing (and re-emailing) a duplicate.
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const result = await issueAgreementForStake(req.scope, req.params.id)
+  res.json(result)
+}

--- a/apps/backend/src/api/investors/me/participations/route.ts
+++ b/apps/backend/src/api/investors/me/participations/route.ts
@@ -2,8 +2,14 @@ import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { requireInvestor } from "../../helpers"
 
-// GET /investors/me/participations — the investor's stakes (participations),
-// with the round + any payment (so the portal can surface a PayU pay link).
+// GET /investors/me/participations — the investor's participations, with the
+// round + any payment (so the portal can surface a PayU pay link and reflect
+// settlement). Equity rounds yield `stake` participations; SAFE / convertible /
+// CCPS rounds yield `convertible` ones — both are returned with a `type`
+// discriminator and a normalised `total_invested` so one table renders both.
+// Whether a participation counts as *paid* is derived from its payments (a
+// `completed` payment), not the instrument status — a convertible stays
+// "outstanding" once paid.
 export const GET = async (
   req: AuthenticatedMedusaRequest,
   res: MedusaResponse
@@ -11,20 +17,50 @@ export const GET = async (
   const investor = await requireInvestor(req.auth_context, req.scope)
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
-  const { data } = await query.graph({
-    entity: "stake",
-    filters: { investor_id: investor.id },
-    fields: [
-      "*",
-      "funding_round.name",
-      "funding_round.round_type",
-      "cap_table.company_id",
-      "cap_table.name",
-      "payments.id",
-      "payments.amount",
-      "payments.status",
-      "payments.metadata",
-    ],
-  })
-  res.json({ participations: data || [], count: (data || []).length })
+  const [{ data: stakes }, { data: convertibles }] = await Promise.all([
+    query.graph({
+      entity: "stake",
+      filters: { investor_id: investor.id },
+      fields: [
+        "*",
+        "funding_round.name",
+        "funding_round.round_type",
+        "cap_table.company_id",
+        "cap_table.name",
+        "payments.id",
+        "payments.amount",
+        "payments.status",
+        "payments.metadata",
+      ],
+    }),
+    query
+      .graph({
+        entity: "convertible",
+        filters: { investor_id: investor.id },
+        fields: [
+          "*",
+          "funding_round.name",
+          "funding_round.round_type",
+          "cap_table.company_id",
+          "cap_table.name",
+          "payments.id",
+          "payments.amount",
+          "payments.status",
+          "payments.metadata",
+        ],
+      })
+      .catch(() => ({ data: [] as any[] })),
+  ])
+
+  const participations = [
+    ...(stakes || []).map((s: any) => ({ ...s, type: "stake" })),
+    ...(convertibles || []).map((c: any) => ({
+      ...c,
+      type: "convertible",
+      // Normalise so the UI renders one "Amount" column: SAFEs carry `principal_amount`.
+      total_invested: c.principal_amount,
+    })),
+  ]
+
+  res.json({ participations, count: participations.length })
 }

--- a/apps/backend/src/api/investors/me/referrals/route.ts
+++ b/apps/backend/src/api/investors/me/referrals/route.ts
@@ -67,6 +67,7 @@ export const POST = async (
           invitee_email: data.email,
           access_level: accessLabel,
           note: data.note ?? "",
+          current_year: String(new Date().getFullYear()),
         },
       },
     })
@@ -86,6 +87,7 @@ export const POST = async (
           access_level: accessLabel,
           note: data.note ?? "",
           portal_url: PORTAL_URL,
+          current_year: String(new Date().getFullYear()),
         },
       },
     })

--- a/apps/backend/src/scripts/seed-investor-email-templates.ts
+++ b/apps/backend/src/scripts/seed-investor-email-templates.ts
@@ -54,7 +54,7 @@ export const investorEmailTemplates = [
       note: "Optional message from the referrer",
       current_year: "Year",
     },
-    html_content: `<div style="font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;max-width:560px;margin:0 auto;color:#18181b"><h1 style="font-size:18px;margin:0 0 12px">New investor referral</h1><p style="font-size:14px;line-height:1.6;color:#3f3f46"><strong>{{referrer_name}}</strong> ({{referrer_email}}) has invited someone to the investor portal. Follow up to onboard them.</p><table style="width:100%;border-collapse:collapse;font-size:14px;margin:16px 0"><tr><td style="padding:8px 12px;border:1px solid #e4e4e7;color:#71717a;background:#f4f4f5">Name</td><td style="padding:8px 12px;border:1px solid #e4e4e7;border-left:0;text-align:right;font-weight:600">{{invitee_name}}</td></tr><tr><td style="padding:8px 12px;border:1px solid #e4e4e7;border-top:0;color:#71717a;background:#f4f4f5">Email</td><td style="padding:8px 12px;border:1px solid #e4e4e7;border-left:0;border-top:0;text-align:right">{{invitee_email}}</td></tr><tr><td style="padding:8px 12px;border:1px solid #e4e4e7;border-top:0;color:#71717a;background:#f4f4f5">Access level</td><td style="padding:8px 12px;border:1px solid #e4e4e7;border-left:0;border-top:0;text-align:right">{{access_level}}</td></tr></table><p style="font-size:13px;line-height:1.6;color:#71717a">Note from referrer: {{note}}</p><p style="font-size:12px;color:#a1a1aa;margin-top:24px">Jaal Yantra Textiles · {{current_year}}</p></div>`,
+    html_content: `<div style="font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;max-width:560px;margin:0 auto;color:#18181b"><h1 style="font-size:18px;margin:0 0 12px">New investor referral</h1><p style="font-size:14px;line-height:1.6;color:#3f3f46"><strong>{{referrer_name}}</strong> ({{referrer_email}}) has invited someone to the investor portal. Follow up to onboard them.</p><table style="width:100%;border-collapse:collapse;font-size:14px;margin:16px 0"><tr><td style="padding:8px 12px;border:1px solid #e4e4e7;color:#71717a;background:#f4f4f5">Name</td><td style="padding:8px 12px;border:1px solid #e4e4e7;border-left:0;text-align:right;font-weight:600">{{invitee_name}}</td></tr><tr><td style="padding:8px 12px;border:1px solid #e4e4e7;border-top:0;color:#71717a;background:#f4f4f5">Email</td><td style="padding:8px 12px;border:1px solid #e4e4e7;border-left:0;border-top:0;text-align:right">{{invitee_email}}</td></tr><tr><td style="padding:8px 12px;border:1px solid #e4e4e7;border-top:0;color:#71717a;background:#f4f4f5">Access level</td><td style="padding:8px 12px;border:1px solid #e4e4e7;border-left:0;border-top:0;text-align:right">{{access_level}}</td></tr></table>{{#if note}}<p style="font-size:13px;line-height:1.6;color:#71717a">Note from referrer: {{note}}</p>{{/if}}<p style="font-size:12px;color:#a1a1aa;margin-top:24px">Jaal Yantra Textiles · {{current_year}}</p></div>`,
   },
   {
     template_key: "investor-referral-friend",
@@ -71,7 +71,7 @@ export const investorEmailTemplates = [
       portal_url: "Investor portal URL",
       current_year: "Year",
     },
-    html_content: `<div style="font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;max-width:560px;margin:0 auto;color:#18181b"><h1 style="font-size:18px;margin:0 0 12px">Hi {{invitee_name}},</h1><p style="font-size:14px;line-height:1.6;color:#3f3f46"><strong>{{referrer_name}}</strong> thought you'd be interested in <strong>Jaal Yantra Textiles</strong> and invited you to our investor portal as a <strong>{{access_level}}</strong>.</p><p style="font-size:14px;line-height:1.6;color:#3f3f46;font-style:italic">"{{note}}"</p><p style="font-size:14px;line-height:1.6;color:#3f3f46">Our team will reach out shortly to set up your access. No action is needed right now — this is just a heads-up.</p><p style="font-size:13px;line-height:1.6;color:#71717a">Learn more about the portal: <a href="{{portal_url}}" style="color:#3f3f46">{{portal_url}}</a></p><p style="font-size:12px;color:#a1a1aa;margin-top:24px">If this wasn't expected, you can safely ignore this email.</p><p style="font-size:12px;color:#a1a1aa;margin-top:12px">Jaal Yantra Textiles · {{current_year}}</p></div>`,
+    html_content: `<div style="font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;max-width:560px;margin:0 auto;color:#18181b"><h1 style="font-size:18px;margin:0 0 12px">Hi {{invitee_name}},</h1><p style="font-size:14px;line-height:1.6;color:#3f3f46"><strong>{{referrer_name}}</strong> thought you'd be interested in <strong>Jaal Yantra Textiles</strong> and invited you to our investor portal as a <strong>{{access_level}}</strong>.</p>{{#if note}}<p style="font-size:14px;line-height:1.6;color:#3f3f46;font-style:italic">"{{note}}"</p>{{/if}}<p style="font-size:14px;line-height:1.6;color:#3f3f46">Our team will reach out shortly to set up your access. No action is needed right now — this is just a heads-up.</p>{{#if portal_url}}<p style="font-size:13px;line-height:1.6;color:#71717a">Learn more about the portal: <a href="{{portal_url}}" style="color:#3f3f46">{{portal_url}}</a></p>{{/if}}<p style="font-size:12px;color:#a1a1aa;margin-top:24px">If this wasn't expected, you can safely ignore this email.</p><p style="font-size:12px;color:#a1a1aa;margin-top:12px">Jaal Yantra Textiles · {{current_year}}</p></div>`,
   },
 ]
 
@@ -80,18 +80,21 @@ export default async function seedInvestorEmailTemplates({ container }: { contai
   const svc: any = container.resolve(EMAIL_TEMPLATES_MODULE)
 
   let created = 0
-  let skipped = 0
+  let updated = 0
   for (const t of investorEmailTemplates) {
-    let exists = false
+    let existing: any = null
     try {
-      await svc.getTemplateByKey(t.template_key)
-      exists = true
+      existing = await svc.getTemplateByKey(t.template_key)
     } catch {
-      exists = false
+      existing = null
     }
-    if (exists) {
-      skipped++
-      logger.info(`[seed-investor-email-templates] ⏭ ${t.template_key} exists — skip`)
+    // Upsert: the template body lives in the DB, so shipping a fix to the HTML
+    // (e.g. the Handlebars note/portal guards) must refresh the existing row —
+    // a create-only seed would leave prod on the stale copy.
+    if (existing?.id) {
+      await svc.updateEmailTemplates({ id: existing.id, ...t })
+      updated++
+      logger.info(`[seed-investor-email-templates] ♻ updated ${t.template_key}`)
       continue
     }
     await svc.createEmailTemplates([t])
@@ -99,6 +102,6 @@ export default async function seedInvestorEmailTemplates({ container }: { contai
     logger.info(`[seed-investor-email-templates] ✅ created ${t.template_key}`)
   }
   logger.info(
-    `[seed-investor-email-templates] done — created=${created} skipped=${skipped}`
+    `[seed-investor-email-templates] done — created=${created} updated=${updated}`
   )
 }

--- a/apps/investor-ui/src/hooks/api/investments.tsx
+++ b/apps/investor-ui/src/hooks/api/investments.tsx
@@ -33,8 +33,13 @@ export const isSafeDeal = (d: Deal) =>
 
 export type Participation = {
   id: string
+  // "stake" (equity) or "convertible" (SAFE / note / CCPS) — set by the route.
+  type?: "stake" | "convertible"
   number_of_shares?: number | null
   total_invested?: number | null
+  // Equity-stake instrument status (unpaid / fully_paid / …); convertibles carry
+  // their own outstanding/converted status. Use isPaid()/displayStatus() for
+  // payment-aware rendering rather than this raw value.
   status?: string
   funding_round?: { name?: string; round_type?: string } | null
   cap_table?: { name?: string; company_id?: string } | null

--- a/apps/investor-ui/src/routes/finances/finances.tsx
+++ b/apps/investor-ui/src/routes/finances/finances.tsx
@@ -7,8 +7,9 @@ import {
   Text,
   useDataTable,
 } from "@medusajs/ui"
-import { CreditCard, CurrencyDollar } from "@medusajs/icons"
-import { Outlet } from "react-router-dom"
+import { CheckCircleSolid, CreditCard, CurrencyDollar, XCircleSolid } from "@medusajs/icons"
+import { Outlet, useSearchParams } from "react-router-dom"
+import { useState } from "react"
 import { ActionMenu } from "../../components/common/action-menu/action-menu"
 import { useIsViewOnly } from "../../hooks/api/companies"
 import {
@@ -23,7 +24,9 @@ const money = (v?: number | null, ccy?: string | null) =>
 const statusColor = (s?: string): "green" | "orange" | "red" | "grey" => {
   switch (s) {
     case "fully_paid":
+    case "paid":
       return "green"
+    case "awaiting payment":
     case "unpaid":
     case "partially_paid":
       return "orange"
@@ -35,6 +38,22 @@ const statusColor = (s?: string): "green" | "orange" | "red" | "grey" => {
     default:
       return "grey"
   }
+}
+
+// A convertible (SAFE / CCPS) has no `fully_paid` instrument state — settlement
+// lives on its payment. Treat a participation as paid once any payment is
+// `completed` (or a stake reaches fully_paid). This keeps an approved-but-unpaid
+// convertible from reading as already invested.
+const isPaid = (p: Participation) =>
+  p.status === "fully_paid" ||
+  !!p.payments?.some((pm) => pm.status === "completed")
+
+// Payment-aware badge label. Convertibles show payment reality rather than the
+// raw "outstanding" instrument status.
+const displayStatus = (p: Participation): string => {
+  if (isPaid(p)) return "paid"
+  if (p.type === "convertible") return "awaiting payment"
+  return p.status ?? "unpaid"
 }
 
 const DealsTable = () => {
@@ -167,11 +186,10 @@ const MyParticipationsTable = () => {
       {
         header: "Status",
         accessorKey: "status",
-        cell: ({ row }: any) => (
-          <Badge color={statusColor(row.original.status)}>
-            {row.original.status ?? "unpaid"}
-          </Badge>
-        ),
+        cell: ({ row }: any) => {
+          const s = displayStatus(row.original as Participation)
+          return <Badge color={statusColor(s)}>{s}</Badge>
+        },
       },
       {
         id: "actions",
@@ -179,7 +197,7 @@ const MyParticipationsTable = () => {
         cell: ({ row }: any) => {
           const p = row.original as Participation
           const link = payLink(p)
-          if (p.status === "fully_paid") {
+          if (isPaid(p)) {
             return (
               <div className="flex justify-end">
                 <Text size="small" className="text-ui-fg-subtle">Paid</Text>
@@ -249,6 +267,60 @@ const MyParticipationsTable = () => {
   )
 }
 
+// Confirmation banner shown when PayU redirects back to /finances?paid=1 (or
+// ?paid=0 on failure). Settlement itself is server-side via the PayU webhook and
+// can lag the redirect by a few seconds, so the success copy sets that
+// expectation rather than asserting the row is already updated.
+const PaymentReturnBanner = () => {
+  const [params, setParams] = useSearchParams()
+  const paid = params.get("paid")
+  const [dismissed, setDismissed] = useState(false)
+
+  if (dismissed || (paid !== "1" && paid !== "0")) return null
+
+  const success = paid === "1"
+
+  const clear = () => {
+    setDismissed(true)
+    params.delete("paid")
+    setParams(params, { replace: true })
+  }
+
+  return (
+    <div
+      className={`flex items-start gap-x-3 rounded-lg border px-4 py-3 ${
+        success
+          ? "border-ui-tag-green-border bg-ui-tag-green-bg"
+          : "border-ui-tag-red-border bg-ui-tag-red-bg"
+      }`}
+      role="status"
+    >
+      {success ? (
+        <CheckCircleSolid className="text-ui-tag-green-icon mt-0.5 shrink-0" />
+      ) : (
+        <XCircleSolid className="text-ui-tag-red-icon mt-0.5 shrink-0" />
+      )}
+      <div className="flex-1">
+        <Text size="small" weight="plus">
+          {success ? "Payment received — thank you." : "Payment not completed"}
+        </Text>
+        <Text size="small" className="text-ui-fg-subtle mt-0.5">
+          {success
+            ? "We're confirming it with the payment provider. Your participation below will update to “Paid” within a few moments."
+            : "The payment wasn't completed. You can retry from “My participations” below, or reach out if you were charged."}
+        </Text>
+      </div>
+      <button
+        onClick={clear}
+        className="text-ui-fg-muted hover:text-ui-fg-subtle text-sm"
+        aria-label="Dismiss"
+      >
+        Dismiss
+      </button>
+    </div>
+  )
+}
+
 export const Finances = () => {
   return (
     <div className="flex flex-col gap-y-3">
@@ -259,6 +331,7 @@ export const Finances = () => {
         </Text>
       </div>
 
+      <PaymentReturnBanner />
       <DealsTable />
       <MyParticipationsTable />
       <Outlet />


### PR DESCRIPTION
## Context
Surfaced by a real prod incident: Chirag's **₹96k CCPS payment** (company `01KX81MBKSWYB1Z62F21848FA1`) that PayU had received but stayed `pending`, plus investor **agreement signing that never fired in prod**.

Prod incident already resolved out-of-band (webhook replay → payment `completed`; agreement templates seeded via ECS run-task). This PR fixes the **root causes** so it can't recur.

## Payments
- **`POST /admin/convertibles/:id/mark-paid`** — the convertible rail has no `fully_paid` state and the PayU webhook only settles stakes (via `stake_id`), so convertible/SAFE/CCPS payments stranded with **no manual recovery**. Wired into the Participations "Mark paid" action.
- **`/investors/me/participations` now returns convertibles** (was stakes-only) — a paid CCPS didn't show on the portal at all.
- **Payment-aware status everywhere** — "paid" now derives from a `completed` payment, not the instrument status, so an approved-but-unpaid convertible no longer reads as **invested** (admin participations + cap-table table + investor-ui).

## Confirmation + email
- investor-ui `/finances` shows a **Payment received / not-completed banner** on the PayU return (`?paid=1` / `?paid=0`) — previously silent.
- Referral email: guard empty `{{note}}`/`{{portal_url}}` with Handlebars `{{#if}}` (empty note rendered a literal `""`), pass `current_year` (footer showed a bare `· `), and make the template seed **UPSERT** so prod refreshes stale DB rows.

## Agreement signing — dashboard manual flow
Root cause of "signing doesn't work": the workflow throws when no tagged template exists and `issueAgreement()` swallows it → no `agreement_response` → nothing to sign. Templates are now seeded in prod; this adds the admin flow to **issue + backfill**:
- **`POST /admin/stakes|convertibles/:id/issue-agreement`** (shared lib, idempotent via `metadata.stake_id/convertible_id`)
- **`POST /admin/agreement-responses/:id/mark-signed`** (out-of-band signature, flagged `signed_by_admin`)
- Participations route attaches per-row agreement status; page gains an **Agreement** column + **Issue / Mark signed** actions.

## Post-merge
- Deploy → then backfill **Chirag's paid CCPS** (and other pre-template participations) via the dashboard: *Issue agreement → Mark signed*.
- Known follow-ups (not in scope): stored `investor_document` artifact isn't stamped with the signature (no signed record-of-record), `viewed_at` untracked in portal flow, no test on the investor sign path.

## Verify
- `POST /admin/convertibles/<id>/mark-paid` flips a pending convertible payment to `completed`.
- Participate on a live round → agreement issued + emailed; `/investors/me/agreements` lists it; sign from the portal.
- Admin: Participations → Issue agreement → Mark signed on an existing paid participation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)