### PR TITLE
fix(#1031): census embedded P2P mode — restore prod /web/census/*, retire Render proxy

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -68,8 +68,16 @@ FROM node:22-slim AS runtime
 
 ENV NODE_ENV=production
 
+# libatomic1: the embedded census P2P stack (corestore -> rocksdb-native,
+# hyperswarm -> sodium-native/udx-native) ships prebuilt linux-x64 .node addons
+# that dynamically link libatomic.so.1, which node:22-slim does NOT include.
+# Without it the addon dlopen fails and require-addon reports a misleading
+# ADDON_NOT_FOUND — the reason embedded P2P read as "DOA" and census fell back to
+# proxy mode. Adding this one lib lets the native stack load in-image. Verified
+# in a linux/amd64 node:22-slim container: corestore.ready + hyperbee get +
+# hyperswarm keypair all succeed once libatomic1 is present.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates curl \
+      ca-certificates curl libatomic1 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN corepack enable && corepack prepare pnpm@10.30.2 --activate

--- a/deploy/aws/copilot/medusa-server/manifest.yml
+++ b/deploy/aws/copilot/medusa-server/manifest.yml
@@ -70,14 +70,16 @@ variables:
   # (the cross-list subscriber runs on the WORKER — set there too). Non-secret.
   # Unset → falls back to the nondeterministic is_default storefront pick.
   CORE_SALES_CHANNEL_ID: sc_01JNQG1YX5549246DFCKKFTE0W
-  # #1031 — serve /web/census/* by PROXYING to the standalone edge reader on
-  # Render (which holds the Hyperswarm peer and replicates the PUBLIC core by key,
-  # read-only/PII-free). Proxy mode keeps the native hypercore stack + swarm OUT
-  # of Fargate entirely — Medusa just fetches over HTTPS. The reader was verified
-  # to peer the OCI seeder from Render, so Fargate never needs to hole-punch.
-  # (Alternative: drop this and set CENSUS_P2P_ENABLED=true to peer in-process —
-  #  viable since these tasks run in PUBLIC subnets, but the proxy is simpler.)
-  CENSUS_READER_URL: https://handloom-census-reader.onrender.com
+  # #1031 — serve /web/census/* by peering the P2P PUBLIC core IN-PROCESS (no
+  # Render proxy). Verified end-to-end 2026-07-14: (1) the native hypercore stack
+  # loads in this image now that libatomic1 is installed (see apps/backend/
+  # Dockerfile); (2) a Fargate task in THIS exact placement (public subnets,
+  # assignPublicIp) hole-punched the OCI seeder and replicated 29,214 blocks in
+  # ~5s. So proxy mode is no longer needed — retire the Render reader
+  # (srv-d9b6t7nlk1mc73ciprv0) once this deploy is green. The loader is
+  # non-fatal: if peering ever fails it just 503s /web/census/*, never breaks boot.
+  # To revert to proxy: unset CENSUS_P2P_ENABLED and set CENSUS_READER_URL back.
+  CENSUS_P2P_ENABLED: "true"
 
 # Secrets: rotating values come from Secrets Manager.
 # Non-rotating config (CORS, URLs, etc.) comes from SSM Parameter Store — listed


### PR DESCRIPTION
## Why
Prod `GET /web/census/stats` is **500-ing**. main serves census in **proxy mode** (`CENSUS_READER_URL` → Render reader `handloom-census-reader.onrender.com`), and that reader is now **404-ing on every path** — the proxy has no upstream.

## What
Switch to **in-process P2P peering**. The embedded reader (`p2p-reader.ts`) is already on main (#1037); this only flips it on:

- **Dockerfile**: add `libatomic1` so the prebuilt native addons (`rocksdb-native`, `sodium-native`/`udx-native`) `dlopen` in `node:22-slim`. Its absence was the real cause of the earlier misleading `ADDON_NOT_FOUND` ("embedded is DOA").
- **manifest**: `CENSUS_P2P_ENABLED=true`, drop `CENSUS_READER_URL`.

## Proven (2026-07-14)
- Loads inside the built image (pulled from ECR, `docker run --platform linux/amd64`).
- A Fargate task in **this exact placement** (public subnets, `assignPublicIp`) hole-punched the OCI seeder and **replicated 29,214 blocks in ~5s** (`verdict=PEERED_AND_REPLICATED`).
- Loader is **non-fatal**: peering failure → 503 on `/web/census/*`, never breaks boot. Core needs ~10–30s to replicate after boot.

## Verify after deploy
- `curl https://v3.jaalyantra.com/web/census/stats`  → real k-anon aggregates
- `curl 'https://v3.jaalyantra.com/web/census/weavers?state=UTTAR%20PRADESH'` → masked, PII-free

## Ops tail
Once green: `render services delete srv-d9b6t7nlk1mc73ciprv0` (~$7/mo, the only census cost).

## Scope note
Census-only, deliberately off main (mirrors #1037) — does **not** carry the `person_property` migration (#1045) or the MikroHyperbee DAL (#1046).

🤖 Generated with [Claude Code](https://claude.com/claude-code)