### PR TITLE
[#938] MikroHyperbee timestamps + query.graph-across-link (verified live)

### DIFF
--- a/apps/backend/src/api/admin/person-properties/verify-link/route.ts
+++ b/apps/backend/src/api/admin/person-properties/verify-link/route.ts
@@ -1,0 +1,140 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils";
+import type { Link } from "@medusajs/modules-sdk";
+
+import { PERSON_MODULE } from "../../../../modules/person";
+import { PERSON_PROPERTY_MODULE } from "../../../../modules/personproperty";
+
+/**
+ * STEP-2 verify — query.graph across the person <-> person_property module link,
+ * on a REAL boot, with the person_property DAL swappable.
+ *
+ * The unit tests prove the repository in isolation; the boot-verify proves the
+ * loader override wins. Neither exercises Query traversing the module link into
+ * a Hyperbee-backed module. This route does exactly that against the running
+ * server: person (Postgres) --link--> person_property (Hyperbee when
+ * PERSON_PROPERTY_HYPERBEE=true, else Postgres), both directions.
+ *
+ * It is backend-agnostic on purpose: same assertions pass with the flag on or
+ * off, so a green run with the flag ON is the proof that Query loads records
+ * from the Hyperbee DAL across a link. Self-contained + self-cleaning.
+ *
+ * Note: Query hydrates linked records with `{ id: [ids] }` filters and
+ * `config.take = null` (no limit). The DAL must honour both shapes — this route
+ * is what surfaced that (see @jytextiles/mikrohyperbee list()).
+ *
+ *   GET /admin/person-properties/verify-link   (admin auth)
+ *   -> { ok: true, checks: [...], backend: "hyperbee" | "postgres" }
+ */
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY);
+  const remoteLink = req.scope.resolve(ContainerRegistrationKeys.LINK) as Link;
+  const personService: any = req.scope.resolve(PERSON_MODULE);
+  const propertyService: any = req.scope.resolve(PERSON_PROPERTY_MODULE);
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER);
+
+  // Which DAL is actually serving person_property right now.
+  const internal =
+    propertyService?.__container__?.personPropertyService ??
+    (propertyService as any)?.personPropertyService_;
+  const backend =
+    internal?.constructor?.name === "HyperbeeBaseRepository" ? "hyperbee" : "postgres";
+
+  const checks: { name: string; ok: boolean; detail?: string }[] = [];
+  const assert = (name: string, ok: boolean, detail?: string) =>
+    checks.push({ name, ok, ...(detail ? { detail } : {}) });
+
+  // Unique per-run person so repeated calls never collide on the unique email.
+  const email = `hyperbee-verify-${Date.now()}@jyt.local`;
+  let personId: string | undefined;
+  let propertyId: string | undefined;
+
+  try {
+    const person = await personService.createPeople({
+      first_name: "Hyperbee",
+      last_name: "Verify",
+      email,
+    });
+    personId = person.id;
+
+    const created = await propertyService.createPersonProperties({
+      profile_type: "weaver",
+      district: "AMBALA",
+      region_state: "HARYANA",
+      total_looms_owned: 3,
+    });
+    const property = Array.isArray(created) ? created[0] : created;
+    propertyId = property.id;
+
+    assert("person_property carries created_at/updated_at (task 1)",
+      !!property.created_at && !!property.updated_at,
+      `created_at=${property.created_at} updated_at=${property.updated_at}`);
+
+    await remoteLink.create([
+      {
+        [PERSON_MODULE]: { person_id: personId },
+        [PERSON_PROPERTY_MODULE]: { person_property_id: propertyId },
+      },
+    ]);
+
+    // ── Forward: person -> person_property. NOTE: the query.graph alias is the
+    // linked MODEL name (`person_property`), NOT the defineLink `field`
+    // ("properties") — the field is misleading for Query traversal. isList is
+    // unset on the link, so the relation resolves as a list.
+    const { data: persons } = await query.graph({
+      entity: "person",
+      fields: [
+        "id",
+        "email",
+        "person_property.id",
+        "person_property.district",
+        "person_property.created_at",
+        "person_property.updated_at",
+      ],
+      filters: { id: personId },
+    });
+    const rawProps = persons?.[0]?.person_property;
+    const props = Array.isArray(rawProps) ? rawProps[0] : rawProps;
+    assert("query.graph person.person_property resolves the linked record",
+      !!props && props.id === propertyId,
+      `got ${JSON.stringify(props?.id)}`);
+    assert("linked property data loads across the link (district)",
+      props?.district === "AMBALA",
+      `district=${props?.district}`);
+    assert("timestamps survive query.graph traversal (task 1 x task 2)",
+      !!props?.created_at && !!props?.updated_at);
+
+    // ── Reverse: person_property -> person ──
+    const { data: properties } = await query.graph({
+      entity: "person_property",
+      fields: ["id", "district", "person.id", "person.email"],
+      filters: { id: propertyId },
+    });
+    const back = properties?.[0];
+    assert("query.graph person_property.person resolves back to the person",
+      back?.person?.id === personId,
+      `got ${JSON.stringify(back?.person?.id)}`);
+  } catch (e: any) {
+    assert("verify ran without throwing", false, e?.message || String(e));
+    logger?.error(`[person-properties/verify-link] ${e?.stack || e}`);
+  } finally {
+    // Best-effort cleanup: drop the link + the throwaway person. The Hyperbee
+    // property record is a local KV entry; leave it (harmless, no unique email).
+    try {
+      if (personId && propertyId) {
+        await remoteLink.dismiss([
+          {
+            [PERSON_MODULE]: { person_id: personId },
+            [PERSON_PROPERTY_MODULE]: { person_property_id: propertyId },
+          },
+        ]);
+      }
+      if (personId) await personService.deletePeople(personId);
+    } catch (e: any) {
+      logger?.error(`[person-properties/verify-link] cleanup: ${e?.message || e}`);
+    }
+  }
+
+  const ok = checks.every((c) => c.ok);
+  res.status(ok ? 200 : 500).json({ ok, backend, checks });
+};

--- a/apps/backend/src/modules/personproperty/__tests__/workflow-engine-hyperbee.script.ts
+++ b/apps/backend/src/modules/personproperty/__tests__/workflow-engine-hyperbee.script.ts
@@ -122,9 +122,12 @@ async function main() {
   {
     const { store, repo } = openRepo();
     const storage: any = new InMemoryDistributedTransactionStorage({
+      // proof harness: the Hyperbee repo + noop logger stand in for the
+      // MedusaInternalService/Logger the engine expects — cast past the
+      // structural gap (this file runs via tsx, not the app).
       workflowExecutionService: repo,
       logger: noopLogger,
-    });
+    } as any);
     // NOT_STARTED is a persisted, resumable state (get() deliberately refuses to
     // return DONE/failed/reverted — a finished txn is never resumed).
     await storage.save(KEY, checkpoint(TransactionState.NOT_STARTED), 0, {});
@@ -138,9 +141,12 @@ async function main() {
   {
     const { store, repo } = openRepo();
     const storage: any = new InMemoryDistributedTransactionStorage({
+      // proof harness: the Hyperbee repo + noop logger stand in for the
+      // MedusaInternalService/Logger the engine expects — cast past the
+      // structural gap (this file runs via tsx, not the app).
       workflowExecutionService: repo,
       logger: noopLogger,
-    });
+    } as any);
     const resumed = await storage.get(KEY);
     ok(!!resumed, "checkpoint SURVIVES process death — a fresh engine instance reads it from Hyperbee");
     ok(resumed?.flow?.state === TransactionState.NOT_STARTED, "resumed flow has the persisted state");
@@ -159,9 +165,12 @@ async function main() {
   {
     const { store, repo } = openRepo();
     const storage: any = new InMemoryDistributedTransactionStorage({
+      // proof harness: the Hyperbee repo + noop logger stand in for the
+      // MedusaInternalService/Logger the engine expects — cast past the
+      // structural gap (this file runs via tsx, not the app).
       workflowExecutionService: repo,
       logger: noopLogger,
-    });
+    } as any);
     // a second transaction that finishes with no retention
     const K2 = "dtx:create-weaver:tx_2";
     await storage.save(K2, checkpoint(TransactionState.NOT_STARTED, { transactionId: "tx_2", runId: "run_2" }), 0, {});

--- a/packages/mikrohyperbee/src/repository.ts
+++ b/packages/mikrohyperbee/src/repository.ts
@@ -35,6 +35,9 @@ const isPlainObject = (v: unknown): v is Record<string, any> =>
 const matches = (row: Record<string, any>, where: Where = {}): boolean =>
   Object.entries(where).every(([k, cond]) => {
     const v = row[k];
+    // A bare array is IN-membership — this is the shape query.graph uses to load
+    // linked records (`{ id: [id1, id2] }`), so it must resolve, not fall through.
+    if (Array.isArray(cond)) return cond.includes(v);
     if (cond && typeof cond === "object") {
       const c = cond as Record<string, any>;
       // Unknown/opaque operator values (e.g. a Postgres raw() predicate) never
@@ -110,6 +113,25 @@ export class HyperbeeBaseRepository implements ModelRepository {
       return this.pk.map((k) => String(row[k])).join(":");
     }
     return String(row.id);
+  }
+  /**
+   * Stamp created_at/updated_at the way every Medusa DML model does, so records
+   * served through the generated service + query.graph carry the timestamps
+   * downstream code (and `order: {updated_at}`) expects. Opt out with
+   * `timestamps: false`. Mutates and returns `row`.
+   */
+  private stamp(row: Record<string, any>, existing: any | null): Record<string, any> {
+    if (this.contract.timestamps === false) return row;
+    const now = new Date().toISOString();
+    if (existing) {
+      row.created_at = existing.created_at ?? row.created_at ?? now;
+      row.updated_at = now;
+    } else {
+      row.created_at = row.created_at ?? now;
+      row.updated_at = row.updated_at ?? now;
+    }
+    if (row.deleted_at === undefined) row.deleted_at = null;
+    return row;
   }
   private async ensureSeq(): Promise<void> {
     if (this.seq !== null) return;
@@ -212,6 +234,7 @@ export class HyperbeeBaseRepository implements ModelRepository {
     }
     const key = this.keyOf(row);
     if (this.pk && row.id === undefined) row.id = key;
+    this.stamp(row, existing);
 
     await this.assertUnique(row, key);
     await this.assertReferential(row);
@@ -276,6 +299,24 @@ export class HyperbeeBaseRepository implements ModelRepository {
   }
 
   private async candidateKeys(where: Where = {}): Promise<string[]> {
+    // Fast path: filtering by the record key itself. `id` always equals the
+    // storage key (generated id, or the composite PK we mirror onto row.id), so
+    // an id / [ids] / {$in:[ids]} filter resolves to those keys directly — this
+    // is exactly how query.graph loads linked records. resolve() re-applies the
+    // full `where` (incl. any other predicates) via matches(), so returning the
+    // id set as candidates is a correct superset.
+    const idc: any = (where as any).id;
+    if (idc !== undefined) {
+      const ids =
+        typeof idc === "string"
+          ? [idc]
+          : Array.isArray(idc)
+          ? idc.map(String)
+          : idc && typeof idc === "object" && Array.isArray(idc.$in)
+          ? idc.$in.map(String)
+          : null;
+      if (ids && ids.length) return ids;
+    }
     const eqIndexed = Object.entries(where).filter(
       ([k, v]) => this.indexed.includes(k) && (typeof v !== "object" || v === null)
     );
@@ -309,7 +350,13 @@ export class HyperbeeBaseRepository implements ModelRepository {
 
   async list(filters: Where = {}, config: ListConfig = {}): Promise<any[]> {
     const rows = await this.resolve(filters);
-    const { take = 15, skip = 0, order } = config || {};
+    const cfg = config || {};
+    const skip = cfg.skip ?? 0;
+    // take: undefined → default page size (15); null → no limit. Query hydrates
+    // linked records with `take: null`, and `= 15` default only fires for
+    // undefined — a null `take` must mean "all", never slice(skip, skip+null)=[].
+    const take = cfg.take === undefined ? 15 : cfg.take;
+    const order = cfg.order;
     if (order) {
       const [f, dir] = Object.entries(order)[0] as [string, string];
       const sign = String(dir).toUpperCase() === "DESC" ? -1 : 1;
@@ -317,7 +364,7 @@ export class HyperbeeBaseRepository implements ModelRepository {
     } else {
       rows.sort((a, b) => (a.id > b.id ? 1 : -1));
     }
-    return rows.slice(skip, skip + take);
+    return take === null ? rows.slice(skip) : rows.slice(skip, skip + take);
   }
 
   async listAndCount(filters: Where = {}, config: ListConfig = {}): Promise<[any[], number]> {

--- a/packages/mikrohyperbee/src/types.ts
+++ b/packages/mikrohyperbee/src/types.ts
@@ -66,6 +66,14 @@ export interface Contract {
   idempotencyKey?: (row: Record<string, any>) => string | undefined;
   /** strict = enforce required/enum/unique hard; lax = warn-and-allow shape, keep uniqueness. */
   mode?: "strict" | "lax";
+  /**
+   * Stamp Medusa-style `created_at`/`updated_at` (and a null `deleted_at`) on
+   * write, the way every DML model does. Default true — set false only for a
+   * model that manages its own timestamps. On create both default to now (a
+   * caller-supplied value, e.g. a backfill preserving origin times, is kept); on
+   * update `created_at` is preserved and `updated_at` is always bumped.
+   */
+  timestamps?: boolean;
 }
 
 /** Query operators supported by the resolver (mirrors the proven DAL). */
@@ -81,7 +89,8 @@ export type WhereCond =
     };
 export type Where = Record<string, WhereCond>;
 export interface ListConfig {
-  take?: number;
+  /** undefined → default page size; null → no limit (Query passes null to mean "all"). */
+  take?: number | null;
   skip?: number;
   order?: Record<string, string>;
 }

--- a/packages/mikrohyperbee/test/repository.e2e.ts
+++ b/packages/mikrohyperbee/test/repository.e2e.ts
@@ -112,9 +112,29 @@ async function main() {
   const gte = await repo.list({ total_looms_owned: { $gte: 3 } });
   ok(gte.length === 1 && gte[0].person_id === "pers_1", "$gte operator filter works");
 
+  // id / bare-array IN — the exact shape query.graph uses to load linked records.
+  const byId = await repo.list({ id: a.id });
+  ok(byId.length === 1 && byId[0].id === a.id, "filter by id resolves the record (link load)");
+  const byIds = await repo.list({ id: [a.id, c1.id] });
+  ok(byIds.length === 2, `bare-array id IN resolves multiple (got ${byIds.length})`);
+  const byIn = await repo.list({ district: ["PANIPAT", "NOWHERE"] });
+  ok(byIn.every((r) => r.district === "PANIPAT"), "bare-array field IN filters correctly");
+
+  // take: null means "no limit" (the shape query.graph passes when hydrating
+  // linked records) — must NOT collapse to slice(skip, skip+null) = [].
+  const nullTake = await repo.list({ id: [a.id] }, { take: null } as any);
+  ok(nullTake.length === 1, `take:null returns all matches, not [] (got ${nullTake.length})`);
+
+  // ── Timestamps ──
+  const ISO = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+  ok(ISO.test(a.created_at) && ISO.test(a.updated_at), "create stamps ISO created_at + updated_at");
+  ok(a.deleted_at === null, "create stamps deleted_at=null (Medusa-compatible)");
+
   // ── Update reindex ──
   const upd = await repo.update({ id: a.id, district: "PANIPAT" });
   ok(upd.district === "PANIPAT", "update applied");
+  ok(upd.created_at === a.created_at, "update preserves created_at");
+  ok(upd.updated_at >= a.updated_at && ISO.test(upd.updated_at), "update bumps updated_at (>= original)");
   const [, ambCount] = await repo.listAndCount({ district: "AMBALA" });
   ok(ambCount === 2, `old index entry removed on update (AMBALA now 2, got ${ambCount})`);
 


### PR DESCRIPTION
Follow-ups to the merged #1046 MikroHyperbee DAL foundation (stacked on `feat/1030-personproperty-migration`). Both tasks **verified end-to-end on a live MedusaApp boot** with `person_property` served from Hyperbee (`backend:"hyperbee"`, 5/5 checks green).

## Task 1 — timestamps
`HyperbeeBaseRepository.stamp()` sets `created_at`/`updated_at` (+ `deleted_at:null`) on every write, the way DML models do. Create defaults both to now (caller value honored, e.g. backfills); update preserves `created_at` and always bumps `updated_at`. Opt out via `Contract.timestamps=false`.

## Task 2 — query.graph across the person ↔ person_property link
Proven both directions via a self-cleaning verify route (`GET /admin/person-properties/verify-link`). The live boot surfaced **3 real DAL bugs** the package/boot tests missed (all fixed + regression-tested — package now **26/26 + 9/9**):

1. **Bare-array id filter** — query.graph loads linked records with `{ id: [ids] }` (not `{$in}`); the matcher treated a bare array as unevaluable → nothing matched. Fixed + id fast-path.
2. **`take: null`** — query.graph passes no-limit as `null` when hydrating links; the `=15` default only fires for `undefined`, so `null` → `slice(skip, skip+null)` → `[]` broke every linked read. `take:undefined→15`, `take:null→no limit`.
3. **Alias gotcha** — the forward link alias is the linked **model name** `person_property`, NOT the `defineLink` `field:"properties"` (misleading for Query traversal). Reverse is auto `person_property.person`.

## Verify
Start the server with the flag on, then `GET /admin/person-properties/verify-link` → `{ ok: true, backend: "hyperbee" }`.
```bash
cd apps/backend && PERSON_PROPERTY_HYPERBEE=true \
  PERSON_PROPERTY_HYPERBEE_STORE=./.person-property-store yarn dev
```
Package tests: `pnpm --filter @jytextiles/mikrohyperbee test` (26/26 + 9/9).

## Note
The backend imports the package's compiled `dist/`, so package changes need `pnpm --filter @jytextiles/mikrohyperbee build` + a server restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)