### PR TITLE
fix(backend): resolve @jytextiles/mikrohyperbee in prod Docker runtime install

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -100,7 +100,22 @@ COPY --from=builder /app/.npmrc ./.npmrc
 # Medusa compiles into .medusa/server with its own package.json. Install prod
 # deps there. --ignore-scripts skips the patch-package postinstall (dev-only).
 WORKDIR /app/.medusa/server
+
+# The compiled server carries an internal workspace dependency
+# (@jytextiles/mikrohyperbee — the Hyperbee-backed DAL the personproperty module
+# uses) declared via the `workspace:*` protocol. The prod install below runs with
+# --ignore-workspace (there is no pnpm workspace in the runtime image), and pnpm
+# cannot resolve `workspace:*` without one → ERR_PNPM_WORKSPACE_PKG_NOT_FOUND.
+# So: (1) drop that entry from the generated package.json before installing,
+# (2) install the remaining prod deps (including hyperbee/corestore, which the
+# package declares only as an OPTIONAL peer), then (3) vendor the prebuilt
+# package straight into node_modules. The package is Medusa-free CommonJS with no
+# runtime deps of its own and its dist/ is built by the package's `prepare` (tsc)
+# during the builder install above, so this copy is self-contained.
+RUN node -e "const fs=require('fs');const p=require('./package.json');if(p.dependencies){delete p.dependencies['@jytextiles/mikrohyperbee'];}fs.writeFileSync('./package.json',JSON.stringify(p,null,2)+'\n');"
 RUN pnpm install --prod --ignore-workspace --ignore-scripts
+COPY --from=builder /app/packages/mikrohyperbee/package.json ./node_modules/@jytextiles/mikrohyperbee/package.json
+COPY --from=builder /app/packages/mikrohyperbee/dist ./node_modules/@jytextiles/mikrohyperbee/dist
 
 EXPOSE 9000
 


### PR DESCRIPTION
## Problem
The Deploy to AWS ECS run for the merged handloom PR failed at the Docker **runtime** stage:

```
ERR_PNPM_WORKSPACE_PKG_NOT_FOUND
"@jytextiles/mikrohyperbee@workspace:*" is in the dependencies but no package
named "@jytextiles/mikrohyperbee" is present in the workspace
```
(run [29418190718](https://github.com/Jaal-Yantra-Textiles/v2/actions/runs/29418190718))

The merged PR wired `@jytextiles/mikrohyperbee` (the Hyperbee-backed DAL the `personproperty` module uses) into the backend as a `workspace:*` dependency. The compiled `.medusa/server/package.json` carries that protocol through, and the runtime install runs with `pnpm install --prod --ignore-workspace` — pnpm cannot resolve `workspace:*` without a workspace, so the image build fails. The builder stage is fine (it has the full workspace + frozen lockfile).

## Fix
In the runtime stage, before the prod install:
1. Strip the `workspace:*` entry from the generated `.medusa/server/package.json`.
2. Run the prod install (otherwise unchanged) — installs the remaining deps.
3. Vendor the **prebuilt** package into `node_modules/@jytextiles/mikrohyperbee`.

The package is Medusa-free CommonJS with **no runtime deps of its own** (`hyperbee` is only an *optional* peer), and its `dist/` is built by the package's own `prepare` (tsc) during the builder install — so the vendored copy is self-contained and `require('@jytextiles/mikrohyperbee')` resolves at runtime.

## Verification
- Confirmed the exact `.medusa/server/package.json` rewrite one-liner strips only that dep and leaves valid JSON with all other deps intact.
- Builder already produces `packages/mikrohyperbee/dist/index.js`, so the vendor COPY has content.
- Branch is **Dockerfile-only** (no dependency/lockfile changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)