### PR TITLE
fix(deployment): use File instead of Blob for Workers multipart upload

### DIFF
--- a/apps/backend/src/modules/deployment/providers/cloudflare-workers-provider.ts
+++ b/apps/backend/src/modules/deployment/providers/cloudflare-workers-provider.ts
@@ -192,7 +192,7 @@ export class CloudflareWorkersProvider implements HostingProvider {
     formData.append("metadata", new Blob([metadata], { type: "application/json" }))
     formData.append(
       "worker.js",
-      new Blob([PLACEHOLDER_SCRIPT], {
+      new File([PLACEHOLDER_SCRIPT], "worker.js", {
         type: "application/javascript+module",
       })
     )


### PR DESCRIPTION
## Fix

`POST /partners/storefront/provision` was failing with:
```
Cloudflare Workers uploadWorker failed (400): Uncaught Error: No such module: worker.js
```

**Root cause:** Node.js `FormData.append(name, blob)` does not set a `filename` in the multipart Content-Disposition header. The Cloudflare Workers Upload API requires `filename="worker.js"` to match `main_module: "worker.js"` in the metadata.

**Fix:** Use `new File([...], "worker.js", ...)` instead of `new Blob([...])` — `File` includes the filename in the multipart part, which Cloudflare API requires.