### PR TITLE
feat(partner): designer persona + partner-scoped LayoutComposer & progressive onboarding (#338)

### DIFF
--- a/apps/backend/integration-tests/http/partner-layouts-api.spec.ts
+++ b/apps/backend/integration-tests/http/partner-layouts-api.spec.ts
@@ -1,0 +1,203 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+
+const TEST_PARTNER_PASSWORD = "supersecret"
+
+jest.setTimeout(90 * 1000)
+
+async function createPartner(api: any) {
+  const unique = Date.now() + Math.random().toString(36).slice(2, 6)
+  const email = `partner-layout-${unique}@medusa-test.com`
+
+  await api.post("/auth/partner/emailpass/register", {
+    email,
+    password: TEST_PARTNER_PASSWORD,
+  })
+  const login1 = await api.post("/auth/partner/emailpass", {
+    email,
+    password: TEST_PARTNER_PASSWORD,
+  })
+  let headers: Record<string, string> = {
+    Authorization: `Bearer ${login1.data.token}`,
+  }
+
+  const partnerRes = await api.post(
+    "/partners",
+    {
+      name: `LayoutTest ${unique}`,
+      handle: `layouttest-${unique}`,
+      admin: { email, first_name: "Admin", last_name: "Layout" },
+    },
+    { headers }
+  )
+  const partnerId = partnerRes.data.partner.id
+
+  // Re-login so the bearer token carries partner actor context.
+  const login2 = await api.post("/auth/partner/emailpass", {
+    email,
+    password: TEST_PARTNER_PASSWORD,
+  })
+  headers = { Authorization: `Bearer ${login2.data.token}` }
+
+  return { headers, partnerId }
+}
+
+const ZONE = "sidebar.main"
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Partner LayoutComposer configuration API (#338)", () => {
+    let partner: Awaited<ReturnType<typeof createPartner>>
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      await getAuthHeaders(api)
+      partner = await createPartner(api)
+    })
+
+    it("GET returns nulls before any configuration is saved", async () => {
+      const res = await api.get(
+        `/partners/layouts/${ZONE}/configuration`,
+        { headers: partner.headers }
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.personal_configuration).toBeNull()
+      expect(res.data.default_configuration).toBeNull()
+      expect(res.data.active_scope).toBe("personal")
+    })
+
+    it("POST creates a personal configuration then reads it back", async () => {
+      const configuration = {
+        widgets: {
+          "nav.customers": { hidden: true },
+          "nav.designs": { order: 0 },
+        },
+      }
+
+      const post = await api.post(
+        `/partners/layouts/${ZONE}/configuration`,
+        { configuration },
+        { headers: partner.headers }
+      )
+      expect(post.status).toBe(200)
+      expect(post.data.layout_configuration.partner_id).toBe(partner.partnerId)
+      expect(post.data.layout_configuration.is_default).toBe(false)
+      expect(post.data.layout_configuration.configuration).toEqual(configuration)
+
+      const get = await api.get(
+        `/partners/layouts/${ZONE}/configuration`,
+        { headers: partner.headers }
+      )
+      expect(get.data.personal_configuration.configuration).toEqual(configuration)
+      expect(get.data.active_scope).toBe("personal")
+    })
+
+    it("POST upserts the same scope (no duplicate row)", async () => {
+      const first = await api.post(
+        `/partners/layouts/${ZONE}/configuration`,
+        { configuration: { widgets: { a: { hidden: true } } } },
+        { headers: partner.headers }
+      )
+      const firstId = first.data.layout_configuration.id
+
+      const second = await api.post(
+        `/partners/layouts/${ZONE}/configuration`,
+        { configuration: { widgets: { a: { hidden: false }, b: { order: 2 } } } },
+        { headers: partner.headers }
+      )
+      expect(second.data.layout_configuration.id).toBe(firstId)
+      expect(second.data.layout_configuration.configuration.widgets.a.hidden).toBe(false)
+      expect(second.data.layout_configuration.configuration.widgets.b.order).toBe(2)
+    })
+
+    it("personal and default scopes coexist for the same zone", async () => {
+      await api.post(
+        `/partners/layouts/${ZONE}/configuration`,
+        { is_default: false, configuration: { widgets: { a: { hidden: true } } } },
+        { headers: partner.headers }
+      )
+      await api.post(
+        `/partners/layouts/${ZONE}/configuration`,
+        { is_default: true, configuration: { widgets: { a: { hidden: false } } } },
+        { headers: partner.headers }
+      )
+
+      const get = await api.get(
+        `/partners/layouts/${ZONE}/configuration`,
+        { headers: partner.headers }
+      )
+      expect(get.data.personal_configuration.configuration.widgets.a.hidden).toBe(true)
+      expect(get.data.default_configuration.configuration.widgets.a.hidden).toBe(false)
+      // Personal wins.
+      expect(get.data.active_scope).toBe("personal")
+    })
+
+    it("DELETE removes the personal override but leaves the default", async () => {
+      await api.post(
+        `/partners/layouts/${ZONE}/configuration`,
+        { is_default: false, configuration: { widgets: { a: { hidden: true } } } },
+        { headers: partner.headers }
+      )
+      await api.post(
+        `/partners/layouts/${ZONE}/configuration`,
+        { is_default: true, configuration: { widgets: { a: { hidden: false } } } },
+        { headers: partner.headers }
+      )
+
+      const del = await api.delete(
+        `/partners/layouts/${ZONE}/configuration`,
+        { headers: partner.headers }
+      )
+      expect(del.status).toBe(200)
+      expect(del.data.deleted).toBe(true)
+
+      const get = await api.get(
+        `/partners/layouts/${ZONE}/configuration`,
+        { headers: partner.headers }
+      )
+      expect(get.data.personal_configuration).toBeNull()
+      expect(get.data.default_configuration).not.toBeNull()
+      expect(get.data.active_scope).toBe("default")
+    })
+
+    it("configurations list returns the partner's saved configs with a count", async () => {
+      await api.post(
+        `/partners/layouts/${ZONE}/configuration`,
+        { configuration: { widgets: {} } },
+        { headers: partner.headers }
+      )
+      await api.post(
+        `/partners/layouts/home/configuration`,
+        { configuration: { widgets: {} } },
+        { headers: partner.headers }
+      )
+
+      const res = await api.get("/partners/layouts/configurations", {
+        headers: partner.headers,
+      })
+      expect(res.status).toBe(200)
+      expect(res.data.count).toBe(2)
+      expect(res.data.layout_configurations).toHaveLength(2)
+    })
+
+    it("POST rejects an unknown widget field with 400 (strict schema)", async () => {
+      const res = await api
+        .post(
+          `/partners/layouts/${ZONE}/configuration`,
+          { configuration: { widgets: { a: { bogus: true } } } },
+          { headers: partner.headers }
+        )
+        .catch((e: any) => e.response)
+      expect(res.status).toBe(400)
+    })
+
+    it("requires partner authentication", async () => {
+      const res = await api
+        .get(`/partners/layouts/${ZONE}/configuration`)
+        .catch((e: any) => e.response)
+      expect([401, 403]).toContain(res.status)
+    })
+  })
+})

--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -510,6 +510,9 @@ module.exports = defineConfig({
       resolve: "./src/modules/partner-onboarding-profile",
     },
     {
+      resolve: "./src/modules/partner-ui-prefs",
+    },
+    {
       resolve: "./src/modules/artisan-product-detail",
     },
     {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -178,6 +178,9 @@ module.exports = defineConfig({
       resolve: "./src/modules/partner-onboarding-profile",
     },
     {
+      resolve: "./src/modules/partner-ui-prefs",
+    },
+    {
       resolve: "./src/modules/artisan-product-detail",
     },
     {

--- a/apps/backend/src/admin/components/partners/partner-general-section.tsx
+++ b/apps/backend/src/admin/components/partners/partner-general-section.tsx
@@ -15,7 +15,7 @@ export type AdminPartner = {
   logo?: string | null
   status: "active" | "inactive" | "pending"
   is_verified: boolean
-  workspace_type?: "seller" | "manufacturer" | "individual"
+  workspace_type?: "seller" | "manufacturer" | "individual" | "designer"
   whatsapp_number?: string | null
   whatsapp_verified?: boolean
   metadata?: Record<string, any> | null
@@ -30,7 +30,7 @@ export const PartnerGeneralSection = ({ partner }: { partner: AdminPartner }) =>
   const [logo, setLogo] = useState(partner.logo || "")
   const [status, setStatus] = useState<"active" | "inactive" | "pending">(partner.status)
   const [isVerified, setIsVerified] = useState<boolean>(!!partner.is_verified)
-  const [workspaceType, setWorkspaceType] = useState<"seller" | "manufacturer" | "individual">(
+  const [workspaceType, setWorkspaceType] = useState<"seller" | "manufacturer" | "individual" | "designer">(
     partner.workspace_type || "manufacturer"
   )
   const [showEdit, setShowEdit] = useState(false)
@@ -261,6 +261,7 @@ export const PartnerGeneralSection = ({ partner }: { partner: AdminPartner }) =>
                     <Select.Item value="seller">Seller</Select.Item>
                     <Select.Item value="manufacturer">Manufacturer</Select.Item>
                     <Select.Item value="individual">Individual</Select.Item>
+                    <Select.Item value="designer">Designer</Select.Item>
                   </Select.Content>
                 </Select>
               </div>

--- a/apps/backend/src/admin/hooks/api/partners-admin.ts
+++ b/apps/backend/src/admin/hooks/api/partners-admin.ts
@@ -21,7 +21,7 @@ export interface AdminPartner {
   logo?: string | null
   status: "active" | "inactive" | "pending"
   is_verified: boolean
-  workspace_type?: "seller" | "manufacturer" | "individual"
+  workspace_type?: "seller" | "manufacturer" | "individual" | "designer"
   whatsapp_number?: string | null
   whatsapp_verified?: boolean
   metadata?: Record<string, any> | null

--- a/apps/backend/src/admin/routes/partners/create/page.tsx
+++ b/apps/backend/src/admin/routes/partners/create/page.tsx
@@ -13,7 +13,7 @@ import { usePersonTypes } from "../../../hooks/api/persontype"
 // Use literal tuples to avoid TS enum widening issues with z.enum
 const ROLE_ENUM = ["owner", "admin", "manager"] as const
 const STATUS_ENUM = ["active", "inactive", "pending"] as const
-const WORKSPACE_TYPE_ENUM = ["seller", "manufacturer", "individual"] as const
+const WORKSPACE_TYPE_ENUM = ["seller", "manufacturer", "individual", "designer"] as const
 
 const partnerAdminSchema = z.object({
   partner: z.object({
@@ -243,6 +243,7 @@ const CreatePartnerComponent = () => {
                           <Select.Item value="seller">Seller</Select.Item>
                           <Select.Item value="manufacturer">Manufacturer</Select.Item>
                           <Select.Item value="individual">Individual</Select.Item>
+                          <Select.Item value="designer">Designer</Select.Item>
                         </Select.Content>
                       </Select>
                     </Form.Control>

--- a/apps/backend/src/api/admin/partners/[id]/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/route.ts
@@ -174,7 +174,7 @@ export const PUT = async (
     logo?: string | null
     status?: "active" | "inactive" | "pending"
     is_verified?: boolean
-    workspace_type?: "seller" | "manufacturer" | "individual"
+    workspace_type?: "seller" | "manufacturer" | "individual" | "designer"
     metadata?: Record<string, any> | null
     admin_id?: string
     admin_password?: string

--- a/apps/backend/src/api/admin/partners/validators.ts
+++ b/apps/backend/src/api/admin/partners/validators.ts
@@ -7,7 +7,7 @@ export const PostPartnerSchema = z.object({
     logo: z.string().url().optional(),
     status: z.enum(["active", "inactive", "pending"]).optional().default("pending"),
     is_verified: z.boolean().optional().default(false),
-    workspace_type: z.enum(["seller", "manufacturer", "individual"]).optional().default("manufacturer"),
+    workspace_type: z.enum(["seller", "manufacturer", "individual", "designer"]).optional().default("manufacturer"),
   }),
   admin: z.object({
     email: z.string().email(),

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -109,6 +109,7 @@ import { investorSchema, investorUpdateSchema, capTableSchema, capTableUpdateSch
 import { partnerPeopleSchema } from "./partners/[id]/validators";
 import { updatePartnerMeSchema } from "./partners/me/validators";
 import { onboardingProfileUpdateSchema } from "./partners/onboarding-profile/validators";
+import { setLayoutConfigurationSchema } from "./partners/layouts/validators";
 import { AdminGetPartnersParamsSchema } from "./admin/persons/partner/validators";
 import { createInventoryOrdersSchema, listInventoryOrdersQuerySchema, ReadSingleInventoryOrderQuerySchema, updateInventoryOrdersSchema, updateInventoryOrderLinesSchema } from "./admin/inventory-orders/validators";
 import { createRawMaterialGroupSchema, updateRawMaterialGroupSchema, listRawMaterialGroupsQuerySchema, addGroupColorSchema, addGroupColorFullSchema, linkGroupColorsSchema, createGroupOrderSchema, readGroupQuerySchema } from "./admin/raw-material-groups/validators";
@@ -819,6 +820,43 @@ export default defineMiddlewares({
     {
       matcher: "/partners/onboarding-profile",
       method: "GET",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
+
+    // Partner LayoutComposer persistence (#338). List across zones, plus
+    // per-zone read / upsert / reset. The static `configurations` matcher must
+    // stay above the `:zone` one so it isn't shadowed by the dynamic param.
+    {
+      matcher: "/partners/layouts/configurations",
+      method: "GET",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
+    {
+      matcher: "/partners/layouts/:zone/configuration",
+      method: "GET",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+      ],
+    },
+    {
+      matcher: "/partners/layouts/:zone/configuration",
+      method: "POST",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+        validateAndTransformBody(wrapSchema(setLayoutConfigurationSchema)),
+      ],
+    },
+    {
+      matcher: "/partners/layouts/:zone/configuration",
+      method: "DELETE",
       middlewares: [
         createCorsPartnerMiddleware(),
         authenticate("partner", ["session", "bearer"]),

--- a/apps/backend/src/api/partners/layouts/[zone]/configuration/route.ts
+++ b/apps/backend/src/api/partners/layouts/[zone]/configuration/route.ts
@@ -1,0 +1,109 @@
+/**
+ * @file Partner LayoutComposer configuration API (#338)
+ * @description Per-zone read / upsert / reset of a partner's layout
+ *   personalization (sidebar & page widget placement/visibility). The
+ *   partner-scoped mirror of Medusa core's `/admin/layouts/:zone/configuration`,
+ *   backing the LayoutComposer ported into partner-ui.
+ * @module API/Partners/Layouts
+ */
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { getPartnerFromAuthContext } from "../../../helpers"
+import { PARTNER_UI_PREFS_MODULE } from "../../../../../modules/partner-ui-prefs"
+import type { SetLayoutConfigurationInput } from "../../validators"
+
+/**
+ * GET /partners/layouts/:zone/configuration
+ * Returns the partner's personal + default configurations for a zone (either
+ * may be null), plus which scope is active. Shape matches what the composer's
+ * `useLayoutConfiguration` hook reads.
+ */
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
+  if (!partner?.id) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "Partner authentication required"
+    )
+  }
+
+  const zone = req.params.zone
+  const service: any = req.scope.resolve(PARTNER_UI_PREFS_MODULE)
+  const { personal, default: defaultRow } = await service.getZoneConfigurations(
+    partner.id,
+    zone
+  )
+
+  // Personal wins over default for the current partner (matches the composer's
+  // definedScope precedence). Falls back to "default" when only a default row
+  // exists, and "personal" when neither does (the composer seeds from default).
+  const active_scope = personal ? "personal" : defaultRow ? "default" : "personal"
+
+  return res.status(200).json({
+    personal_configuration: personal,
+    default_configuration: defaultRow,
+    active_scope,
+  })
+}
+
+/**
+ * POST /partners/layouts/:zone/configuration
+ * Upserts the configuration for the given scope (`is_default` false → personal,
+ * true → the partner-wide default). Mirrors the composer's `setPreference`.
+ */
+export const POST = async (
+  req: AuthenticatedMedusaRequest<SetLayoutConfigurationInput>,
+  res: MedusaResponse
+) => {
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
+  if (!partner?.id) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "Partner authentication required"
+    )
+  }
+
+  const zone = req.params.zone
+  const { is_default = false, configuration } =
+    req.validatedBody as SetLayoutConfigurationInput
+
+  const service: any = req.scope.resolve(PARTNER_UI_PREFS_MODULE)
+  const saved = await service.setZoneConfiguration({
+    partner_id: partner.id,
+    zone,
+    is_default,
+    configuration,
+  })
+
+  return res.status(200).json({ layout_configuration: saved })
+}
+
+/**
+ * DELETE /partners/layouts/:zone/configuration
+ * Removes the partner's personal override for the zone (resets to default).
+ * The default row, if any, is left intact.
+ */
+export const DELETE = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
+  if (!partner?.id) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "Partner authentication required"
+    )
+  }
+
+  const zone = req.params.zone
+  const service: any = req.scope.resolve(PARTNER_UI_PREFS_MODULE)
+  const deleted = await service.deletePersonalZoneConfiguration(partner.id, zone)
+
+  return res.status(200).json({ id: zone, object: "layout_configuration", deleted })
+}

--- a/apps/backend/src/api/partners/layouts/configurations/route.ts
+++ b/apps/backend/src/api/partners/layouts/configurations/route.ts
@@ -1,0 +1,44 @@
+/**
+ * @file Partner layout configurations list API (#338)
+ * @description Lists the authenticated partner's layout configurations across
+ *   all zones (personal + default). Backs the composer's
+ *   `useLayoutConfigurations` / `useHasLayoutCustomizations` existence check.
+ *   Partner-scoped mirror of `/admin/layouts/configurations`.
+ * @module API/Partners/Layouts
+ */
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { getPartnerFromAuthContext } from "../../helpers"
+import { PARTNER_UI_PREFS_MODULE } from "../../../../modules/partner-ui-prefs"
+
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const partner = await getPartnerFromAuthContext(req.auth_context, req.scope)
+  if (!partner?.id) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "Partner authentication required"
+    )
+  }
+
+  const limit = Number.parseInt(String(req.query.limit ?? "100"), 10) || 100
+  const offset = Number.parseInt(String(req.query.offset ?? "0"), 10) || 0
+
+  const service: any = req.scope.resolve(PARTNER_UI_PREFS_MODULE)
+  const [rows, count] = await service.listAndCountPartnerUiLayoutConfigurations(
+    { partner_id: partner.id },
+    { skip: offset, take: limit }
+  )
+
+  return res.status(200).json({
+    layout_configurations: rows,
+    count,
+    offset,
+    limit,
+  })
+}

--- a/apps/backend/src/api/partners/layouts/validators.ts
+++ b/apps/backend/src/api/partners/layouts/validators.ts
@@ -1,0 +1,34 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * Validators for the partner LayoutComposer persistence routes (#338).
+ *
+ * The body shape mirrors the composer's `LayoutPreference` exactly (see
+ * apps/investor-ui/.../layout-composer/types.ts): a per-widget map of
+ * placement/visibility overrides under `configuration.widgets`, plus the
+ * `is_default` scope flag the composer sends from `setPreference`.
+ */
+
+// Per-widget override — matches WidgetPreference { hidden?, section?, order? }.
+const widgetPreferenceSchema = z
+  .object({
+    hidden: z.boolean().optional(),
+    section: z.string().optional(),
+    order: z.number().optional(),
+  })
+  .strict()
+
+export const setLayoutConfigurationSchema = z
+  .object({
+    // false → the partner's personal override; true → the partner-wide default
+    // ("save for everyone" within the partner). Defaults to personal.
+    is_default: z.boolean().optional().default(false),
+    configuration: z.object({
+      widgets: z.record(z.string(), widgetPreferenceSchema).default({}),
+    }),
+  })
+  .strict()
+
+export type SetLayoutConfigurationInput = z.infer<
+  typeof setLayoutConfigurationSchema
+>

--- a/apps/backend/src/api/partners/update/route.ts
+++ b/apps/backend/src/api/partners/update/route.ts
@@ -101,7 +101,7 @@ export const PUT = async (
     logo?: string | null
     status?: "active" | "inactive" | "pending"
     is_verified?: boolean
-    workspace_type?: "seller" | "manufacturer" | "individual"
+    workspace_type?: "seller" | "manufacturer" | "individual" | "designer"
     country_code?: string | null
     currency_code?: string | null
     metadata?: Record<string, any> | null

--- a/apps/backend/src/api/partners/validators.ts
+++ b/apps/backend/src/api/partners/validators.ts
@@ -6,7 +6,7 @@ export const partnerSchema = z.object({
     logo: z.string().optional(),
     status: z.enum(['active', 'inactive', 'pending']).optional(),
     is_verified: z.boolean().optional(),
-    workspace_type: z.enum(['seller', 'manufacturer', 'individual']).optional(),
+    workspace_type: z.enum(['seller', 'manufacturer', 'individual', 'designer']).optional(),
     whatsapp_number: z.string().optional(),
     admin: z.object({
         email: z.string(),
@@ -23,7 +23,7 @@ export const partnerUpdateSchema = z.object({
     logo: z.string().nullable().optional(),
     status: z.enum(['active', 'inactive', 'pending']).optional(),
     is_verified: z.boolean().optional(),
-    workspace_type: z.enum(['seller', 'manufacturer', 'individual']).optional(),
+    workspace_type: z.enum(['seller', 'manufacturer', 'individual', 'designer']).optional(),
     whatsapp_number: z.string().nullable().optional(),
     // Billing locale (drives subscription provider routing). Currency is
     // normalized to lower-case so the "inr" comparison in the subscription route

--- a/apps/backend/src/api/web/website/[domain]/marketing/partners/route.ts
+++ b/apps/backend/src/api/web/website/[domain]/marketing/partners/route.ts
@@ -6,7 +6,7 @@ type RawPartner = {
   name: string
   handle: string
   logo: string | null
-  workspace_type: "seller" | "manufacturer" | "individual"
+  workspace_type: "seller" | "manufacturer" | "individual" | "designer"
   storefront_domain: string | null
   vercel_linked: boolean
   metadata: Record<string, unknown> | null

--- a/apps/backend/src/modules/partner-ui-prefs/index.ts
+++ b/apps/backend/src/modules/partner-ui-prefs/index.ts
@@ -1,0 +1,8 @@
+import { Module } from "@medusajs/framework/utils"
+import PartnerUiPrefsService from "./service"
+
+export const PARTNER_UI_PREFS_MODULE = "partner_ui_prefs"
+
+export default Module(PARTNER_UI_PREFS_MODULE, {
+  service: PartnerUiPrefsService,
+})

--- a/apps/backend/src/modules/partner-ui-prefs/migrations/Migration20260715120100.ts
+++ b/apps/backend/src/modules/partner-ui-prefs/migrations/Migration20260715120100.ts
@@ -1,0 +1,26 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Creates the partner_ui_layout_configuration table (#338 — partner-ui
+ * personalization / LayoutComposer persistence).
+ *
+ * Hand-written (Claude-owned) create migration. Mirrors what DML would
+ * generate for the model: jsonb `configuration`/`metadata`, the compound
+ * unique index over (partner_id, zone, is_default) as a partial index
+ * (WHERE deleted_at IS NULL) so soft-deleted rows don't collide, a lookup
+ * index on partner_id, plus the standard deleted_at index.
+ */
+export class Migration20260715120100 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table if not exists "partner_ui_layout_configuration" ("id" text not null, "partner_id" text not null, "zone" text not null, "is_default" boolean not null default false, "configuration" jsonb not null, "metadata" jsonb null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "partner_ui_layout_configuration_pkey" primary key ("id"));`);
+    this.addSql(`CREATE UNIQUE INDEX IF NOT EXISTS "IDX_partner_ui_layout_configuration_partner_zone_scope_unique" ON "partner_ui_layout_configuration" ("partner_id", "zone", "is_default") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_partner_ui_layout_configuration_partner_id" ON "partner_ui_layout_configuration" ("partner_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_partner_ui_layout_configuration_deleted_at" ON "partner_ui_layout_configuration" ("deleted_at") WHERE deleted_at IS NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "partner_ui_layout_configuration" cascade;`);
+  }
+
+}

--- a/apps/backend/src/modules/partner-ui-prefs/models/partner-ui-layout-configuration.ts
+++ b/apps/backend/src/modules/partner-ui-prefs/models/partner-ui-layout-configuration.ts
@@ -1,0 +1,53 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * Partner UI layout configuration (#338 — menu/submenu personalization).
+ *
+ * The partner-scoped mirror of Medusa core's admin `layout_configuration`. It
+ * backs the LayoutComposer (ported from investor-ui, whose persistence was
+ * stubbed): per-zone widget placement/visibility so a partner can hide unused
+ * modules, reorder the sidebar, etc.
+ *
+ * Data contract matches the composer's `LayoutPreference`:
+ *   configuration = { widgets: Record<widgetId, { hidden?, order?, section? }> }
+ *
+ * Scope (mirrors the composer's personal/default split):
+ *   - is_default = false → the partner's personal override (what they edited).
+ *   - is_default = true  → the zone's default for the partner, seeded from the
+ *     persona template (designer/seller/…). Personal wins over default at read.
+ *
+ * NOTE: the partner IS the auth actor here (auth_context.actor_id = partner_id;
+ * there is no separate per-admin-user identity on partner auth), so scoping is
+ * per-partner, not per-user. The is_default axis is what distinguishes a
+ * partner's own edit from the persona-seeded default.
+ *
+ * One row per (partner_id, zone, is_default) — enforced by the compound unique
+ * index below.
+ */
+const PartnerUiLayoutConfiguration = model
+  .define("partner_ui_layout_configuration", {
+    id: model.id().primaryKey(),
+
+    // The partner this configuration belongs to.
+    partner_id: model.text().searchable(),
+
+    // The layout zone / widgets-zone-prefix this configures, e.g.
+    // "sidebar.main", "home", "product.list".
+    zone: model.text(),
+
+    // Scope discriminator — see the model doc-comment.
+    is_default: model.boolean().default(false),
+
+    // The composer's LayoutPreference blob: { widgets: { [id]: {...} } }.
+    configuration: model.json(),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["partner_id", "zone", "is_default"],
+      unique: true,
+    },
+  ])
+
+export default PartnerUiLayoutConfiguration

--- a/apps/backend/src/modules/partner-ui-prefs/service.ts
+++ b/apps/backend/src/modules/partner-ui-prefs/service.ts
@@ -1,0 +1,81 @@
+import { MedusaService } from "@medusajs/framework/utils"
+import PartnerUiLayoutConfiguration from "./models/partner-ui-layout-configuration"
+
+class PartnerUiPrefsService extends MedusaService({
+  PartnerUiLayoutConfiguration,
+}) {
+  /**
+   * Both scope rows for a (partner, zone): the partner's personal override and
+   * the zone default, either of which may be absent.
+   */
+  async getZoneConfigurations(partnerId: string, zone: string): Promise<{
+    personal: any | null
+    default: any | null
+  }> {
+    const rows = await this.listPartnerUiLayoutConfigurations({
+      partner_id: partnerId,
+      zone,
+    })
+    const personal = rows.find((r: any) => !r.is_default) || null
+    const defaultRow = rows.find((r: any) => r.is_default) || null
+    return { personal, default: defaultRow }
+  }
+
+  /**
+   * Upsert the single row for a (partner, zone, is_default) scope. Creates it on
+   * first save, replaces its `configuration` thereafter — so the composer's
+   * "save" is idempotent per scope.
+   */
+  async setZoneConfiguration(input: {
+    partner_id: string
+    zone: string
+    is_default: boolean
+    configuration: unknown
+  }): Promise<any> {
+    const existing = await this.listPartnerUiLayoutConfigurations({
+      partner_id: input.partner_id,
+      zone: input.zone,
+      is_default: input.is_default,
+    })
+
+    if (existing?.[0]) {
+      const [updated] = await this.updatePartnerUiLayoutConfigurations([
+        { id: existing[0].id, configuration: input.configuration },
+      ])
+      return updated
+    }
+
+    const [created] = await this.createPartnerUiLayoutConfigurations([
+      {
+        partner_id: input.partner_id,
+        zone: input.zone,
+        is_default: input.is_default,
+        configuration: input.configuration,
+      },
+    ])
+    return created
+  }
+
+  /**
+   * Remove the partner's PERSONAL override for a zone (leaves the default
+   * untouched), mirroring the composer's "reset to default". No-op when none
+   * exists. Returns whether a row was deleted.
+   */
+  async deletePersonalZoneConfiguration(
+    partnerId: string,
+    zone: string
+  ): Promise<boolean> {
+    const existing = await this.listPartnerUiLayoutConfigurations({
+      partner_id: partnerId,
+      zone,
+      is_default: false,
+    })
+    if (!existing?.[0]) {
+      return false
+    }
+    await this.deletePartnerUiLayoutConfigurations(existing[0].id)
+    return true
+  }
+}
+
+export default PartnerUiPrefsService

--- a/apps/backend/src/modules/partner/migrations/Migration20260715120000.ts
+++ b/apps/backend/src/modules/partner/migrations/Migration20260715120000.ts
@@ -1,0 +1,35 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Adds `designer` to the partner.workspace_type check constraint (#338 / #958).
+ *
+ * Hand-written (Claude-owned) migration. `workspace_type` is a `text` column
+ * with a CHECK constraint (see Migration20260411122856); MikroORM names it
+ * `partner_workspace_type_check`. To widen the allowed set we drop and re-add
+ * the constraint rather than editing the create migration (which would no-op on
+ * existing databases — see the repo "migration create-if-not-exists hazard").
+ *
+ * The new `designer` persona drives the lean designer sidebar and the persona
+ * layout default; no data backfill is needed (default stays 'manufacturer').
+ */
+export class Migration20260715120000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(
+      `alter table if exists "partner" drop constraint if exists "partner_workspace_type_check";`
+    );
+    this.addSql(
+      `alter table if exists "partner" add constraint "partner_workspace_type_check" check ("workspace_type" in ('seller', 'manufacturer', 'individual', 'designer'));`
+    );
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(
+      `alter table if exists "partner" drop constraint if exists "partner_workspace_type_check";`
+    );
+    this.addSql(
+      `alter table if exists "partner" add constraint "partner_workspace_type_check" check ("workspace_type" in ('seller', 'manufacturer', 'individual'));`
+    );
+  }
+
+}

--- a/apps/backend/src/modules/partner/models/partner.ts
+++ b/apps/backend/src/modules/partner/models/partner.ts
@@ -13,8 +13,12 @@ const Partner = model.define("partner", {
         .default('pending'),
     is_verified: model.boolean().default(false),
 
-    // Workspace type — controls sidebar navigation and available features
-    workspace_type: model.enum(['seller', 'manufacturer', 'individual'])
+    // Workspace type — controls sidebar navigation and available features.
+    // `designer` (#338/#958): a designer-persona partner who authors designs
+    // (sketches → moodboard → fabric spec) and routes them to a producing
+    // partner, rather than running the full commerce surface. Drives the lean
+    // designer sidebar + the persona layout default (see partner-ui-prefs).
+    workspace_type: model.enum(['seller', 'manufacturer', 'individual', 'designer'])
         .default('manufacturer'),
 
     // WhatsApp notifications

--- a/apps/partner-ui/src/components/layout/main-layout/layout-customizer.tsx
+++ b/apps/partner-ui/src/components/layout/main-layout/layout-customizer.tsx
@@ -1,0 +1,258 @@
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core"
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable"
+import { CSS } from "@dnd-kit/utilities"
+import { Check, DotsSix, Eye, EyeSlash } from "@medusajs/icons"
+import { Button, IconButton, Text, clx, toast } from "@medusajs/ui"
+import { useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import {
+  useResetPartnerLayoutConfiguration,
+  useSetPartnerLayoutConfiguration,
+  type LayoutPreference,
+  type SidebarPreset,
+} from "../../../hooks/api/layout-preferences"
+
+/** A composable item in any layout zone (a nav route, a page section, a tab…). */
+export type LayoutCustomizerItem = {
+  id: string
+  label: string
+  icon?: React.ReactNode
+}
+
+type LayoutCustomizerProps = {
+  /** The zone being edited, e.g. "sidebar.main" or "home". */
+  zone: string
+  /** All composable items for the zone (including currently-hidden ones). */
+  items: LayoutCustomizerItem[]
+  /** The partner's saved personal widget overrides for this zone. */
+  widgets: LayoutPreference["widgets"]
+  /** The preset — bootstrap order/visibility before personal edits. */
+  preset: SidebarPreset
+  /** Leave edit mode. */
+  onClose: () => void
+}
+
+/**
+ * #338 — the generic layout personalization editor: drag to reorder, click the
+ * eye to hide/show, for ANY zone (sidebar, home dashboard sections, tab strips…).
+ * Persists the arrangement as the partner's personal layout configuration
+ * (`/partners/layouts/:zone/configuration`) using the composer's
+ * `LayoutPreference { widgets: { id: { hidden, order } } }` contract.
+ *
+ * A flat vertical sortable, shared by the sidebar and every page surface.
+ */
+export const LayoutCustomizer = ({
+  zone,
+  items,
+  widgets,
+  preset,
+  onClose,
+}: LayoutCustomizerProps) => {
+  const { t } = useTranslation()
+
+  const itemById = useMemo(() => {
+    const m = new Map<string, LayoutCustomizerItem>()
+    for (const it of items) m.set(it.id, it)
+    return m
+  }, [items])
+
+  // Seed the draft with the same precedence as the surface:
+  // personal override → preset → natural (index/visible).
+  const [orderedIds, setOrderedIds] = useState<string[]>(() =>
+    items
+      .map((it, index) => ({
+        id: it.id,
+        order: widgets[it.id]?.order ?? preset[it.id]?.order ?? index,
+      }))
+      .sort((a, b) => a.order - b.order)
+      .map((x) => x.id)
+  )
+  const [hiddenSet, setHiddenSet] = useState<Set<string>>(
+    () =>
+      new Set(
+        items
+          .filter((it) => widgets[it.id]?.hidden ?? preset[it.id]?.hidden ?? false)
+          .map((it) => it.id)
+      )
+  )
+
+  const { mutate: saveLayout, isPending: isSaving } =
+    useSetPartnerLayoutConfiguration(zone, {
+      onSuccess: () => {
+        toast.success(t("app.nav.customize.saved"))
+        onClose()
+      },
+      onError: (e) => toast.error(e.message),
+    })
+  const { mutate: resetLayout, isPending: isResetting } =
+    useResetPartnerLayoutConfiguration(zone, {
+      onSuccess: () => {
+        toast.success(t("app.nav.customize.reset"))
+        onClose()
+      },
+      onError: (e) => toast.error(e.message),
+    })
+
+  const sensors = useSensors(
+    // Small activation distance so a click on the eye toggle isn't read as a drag.
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  )
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    setOrderedIds((ids) => {
+      const from = ids.indexOf(String(active.id))
+      const to = ids.indexOf(String(over.id))
+      if (from === -1 || to === -1) return ids
+      return arrayMove(ids, from, to)
+    })
+  }
+
+  const toggleHidden = (id: string) => {
+    setHiddenSet((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const handleSave = () => {
+    const nextWidgets: LayoutPreference["widgets"] = {}
+    orderedIds.forEach((id, index) => {
+      nextWidgets[id] = { order: index, hidden: hiddenSet.has(id) }
+    })
+    saveLayout({ configuration: { widgets: nextWidgets } })
+  }
+
+  const busy = isSaving || isResetting
+
+  return (
+    <div className="flex flex-col gap-y-2">
+      <div className="flex items-center justify-between px-1">
+        <Text size="xsmall" weight="plus" className="text-ui-fg-subtle">
+          {t("app.nav.customize.title")}
+        </Text>
+        <button
+          type="button"
+          onClick={() => resetLayout()}
+          disabled={busy}
+          className="text-ui-fg-muted hover:text-ui-fg-subtle text-xs disabled:opacity-50"
+        >
+          {t("app.nav.customize.resetAction")}
+        </button>
+      </div>
+
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext items={orderedIds} strategy={verticalListSortingStrategy}>
+          <div className="flex flex-col gap-y-1">
+            {orderedIds.map((id) => {
+              const item = itemById.get(id)
+              if (!item) return null
+              return (
+                <SortableCustomizerRow
+                  key={id}
+                  id={id}
+                  icon={item.icon}
+                  label={item.label}
+                  hidden={hiddenSet.has(id)}
+                  onToggleHidden={() => toggleHidden(id)}
+                />
+              )
+            })}
+          </div>
+        </SortableContext>
+      </DndContext>
+
+      <div className="flex items-center justify-end gap-x-2 px-1 pt-1">
+        <Button size="small" variant="secondary" onClick={onClose} disabled={busy}>
+          {t("app.nav.customize.cancel")}
+        </Button>
+        <Button size="small" variant="primary" onClick={handleSave} isLoading={isSaving} disabled={busy}>
+          <Check className="mr-1" />
+          {t("app.nav.customize.save")}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+type SortableCustomizerRowProps = {
+  id: string
+  icon?: React.ReactNode
+  label: string
+  hidden: boolean
+  onToggleHidden: () => void
+}
+
+const SortableCustomizerRow = ({
+  id,
+  icon,
+  label,
+  hidden,
+  onToggleHidden,
+}: SortableCustomizerRowProps) => {
+  const { t } = useTranslation()
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id })
+
+  const style = {
+    transform: CSS.Translate.toString(transform),
+    transition,
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={clx(
+        "bg-ui-bg-base ring-ui-border-base flex items-center gap-x-2 rounded-md px-2 py-1.5 ring-1 transition-opacity",
+        hidden && "opacity-40",
+        isDragging && "shadow-elevation-card-rest z-10"
+      )}
+    >
+      <button
+        type="button"
+        className="text-ui-fg-muted cursor-grab touch-none rounded focus:outline-none"
+        {...attributes}
+        {...listeners}
+        aria-label={t("app.nav.customize.dragToReorder")}
+      >
+        <DotsSix />
+      </button>
+      {icon && <span className="text-ui-fg-subtle [&>svg]:h-4 [&>svg]:w-4">{icon}</span>}
+      <Text size="small" leading="compact" className="flex-1 truncate">
+        {label}
+      </Text>
+      <IconButton
+        size="2xsmall"
+        variant="transparent"
+        onClick={onToggleHidden}
+        aria-label={hidden ? t("app.nav.customize.show") : t("app.nav.customize.hide")}
+      >
+        {hidden ? <EyeSlash /> : <Eye />}
+      </IconButton>
+    </div>
+  )
+}

--- a/apps/partner-ui/src/components/layout/main-layout/main-layout.tsx
+++ b/apps/partner-ui/src/components/layout/main-layout/main-layout.tsx
@@ -1,9 +1,12 @@
 import {
+  Adjustments,
   BuildingStorefront,
   CogSixTooth,
   CurrencyDollar,
   DocumentSeries,
   EllipsisHorizontal,
+  EyeMini,
+  EyeSlashMini,
   FolderOpen,
   House,
   MagnifyingGlass,
@@ -15,7 +18,19 @@ import {
   Users,
 } from "@medusajs/icons"
 import { Avatar, Divider, DropdownMenu, Kbd, Text, clx } from "@medusajs/ui"
+import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
+
+import {
+  SIDEBAR_ZONE,
+  DESIGNER_COMMERCE_ROUTE_IDS,
+  getSidebarPreset,
+  usePartnerLayoutConfiguration,
+  useSetPartnerLayoutConfiguration,
+  type LayoutPreference,
+  type SidebarPreset,
+} from "../../../hooks/api/layout-preferences"
+import { LayoutCustomizer } from "./layout-customizer"
 
 import { usePartnerStores } from "../../../hooks/api/partner-stores"
 import { useMe } from "../../../hooks/api/users"
@@ -180,12 +195,62 @@ const Header = () => {
   )
 }
 
-type WorkspaceType = "seller" | "manufacturer" | "individual"
+type WorkspaceType = "seller" | "manufacturer" | "individual" | "designer"
 
 const useCoreRoutes = (
   workspaceType?: WorkspaceType
 ): Omit<INavItem, "pathname">[] => {
   const { t } = useTranslation()
+
+  // #338/#958 — Designer persona. A lean, design-first sidebar: the authoring
+  // + production loop up top, with the full commerce surface present but
+  // hidden by default (see DESIGNER_COMMERCE_ROUTE_IDS) and revealed on demand.
+  if (workspaceType === "designer") {
+    return [
+      { icon: <House />, label: t("app.nav.main.home"), to: "/" },
+      {
+        icon: <PencilSquare />,
+        label: t("app.nav.main.designs"),
+        to: "/designs",
+        items: [{ label: t("app.nav.main.tasks"), to: "/tasks" }],
+      },
+      {
+        icon: <ShoppingCart />,
+        label: t("app.nav.main.orders"),
+        to: "/orders",
+        items: [
+          { label: "All", to: "/orders/all" },
+          { label: "Design", to: "/orders/design" },
+          { label: "Inventory", to: "/orders/inventory" },
+        ],
+      },
+      { icon: <CurrencyDollar />, label: t("app.nav.main.paymentSubmissions"), to: "/payment-submissions" },
+      { icon: <FolderOpen />, label: t("app.nav.main.sharedFolders"), to: "/shared-folders" },
+      // Commerce group — hidden by default for designers (DESIGNER_COMMERCE_ROUTE_IDS).
+      {
+        icon: <Tag />,
+        label: t("app.nav.main.products"),
+        to: "/products",
+        items: [
+          { label: t("app.nav.main.categories"), to: "/categories" },
+          { label: t("app.nav.main.collections"), to: "/collections" },
+          { label: t("app.nav.main.productTypes"), to: "/product-types" },
+          { label: t("app.nav.main.stock"), to: "/products/inventory" },
+        ],
+      },
+      { icon: <Users />, label: t("app.nav.main.customers"), to: "/customers" },
+      {
+        icon: <DocumentSeries />,
+        label: t("app.nav.main.webStore"),
+        to: "/content",
+        items: [
+          { label: t("app.nav.main.content"), to: "/content" },
+          { label: t("app.nav.main.theme"), to: "/webstore/theme" },
+          { label: t("app.nav.main.analytics"), to: "/webstore/analytics" },
+        ],
+      },
+    ]
+  }
 
   if (workspaceType === "seller") {
     return [
@@ -317,7 +382,9 @@ const Searchbar = () => {
   )
 }
 
+
 const CoreRouteSection = () => {
+  const { t } = useTranslation()
   const { user } = useMe()
   // Read workspace_type from the proper field, falling back to metadata.use_type for legacy partners
   const workspaceType = (
@@ -326,12 +393,108 @@ const CoreRouteSection = () => {
   ) as WorkspaceType | undefined
   const coreRoutes = useCoreRoutes(workspaceType)
 
+  // #338 — the partner's saved sidebar personalization (hide/reorder). Errors
+  // are non-fatal: the sidebar renders from persona defaults if the fetch fails.
+  const { personal_configuration } = usePartnerLayoutConfiguration(SIDEBAR_ZONE)
+  const { mutate: saveLayout, isPending: isSavingLayout } =
+    useSetPartnerLayoutConfiguration(SIDEBAR_ZONE)
+
+  const widgets = personal_configuration?.configuration?.widgets ?? {}
+
+  // The persona's pre-saved layout preset — the bootstrap default before any
+  // personal config. Apply precedence: personal override → persona preset →
+  // natural (source) order/visible.
+  const preset = useMemo<SidebarPreset>(
+    () => getSidebarPreset(workspaceType),
+    [workspaceType]
+  )
+
+  // Visible routes with saved ordering applied.
+  const visibleRoutes = useMemo(() => {
+    const hidden = (to: string) =>
+      widgets[to]?.hidden ?? preset[to]?.hidden ?? false
+    return coreRoutes
+      .map((route, index) => ({ route, index }))
+      .filter(({ route }) => !hidden(route.to))
+      .sort((a, b) => {
+        const oa = widgets[a.route.to]?.order ?? preset[a.route.to]?.order ?? a.index
+        const ob = widgets[b.route.to]?.order ?? preset[b.route.to]?.order ?? b.index
+        return oa - ob
+      })
+      .map(({ route }) => route)
+  }, [coreRoutes, widgets, preset])
+
+  // Commerce toggle (designer persona only): reveal or collapse the commerce
+  // group, persisting the choice as explicit overrides on the current widgets.
+  const anyCommerceHidden = DESIGNER_COMMERCE_ROUTE_IDS.some(
+    (id) => widgets[id]?.hidden ?? preset[id]?.hidden ?? false
+  )
+  const toggleCommerce = () => {
+    const nextHidden = !anyCommerceHidden
+    const nextWidgets: LayoutPreference["widgets"] = { ...widgets }
+    for (const id of DESIGNER_COMMERCE_ROUTE_IDS) {
+      nextWidgets[id] = { ...(nextWidgets[id] ?? {}), hidden: nextHidden }
+    }
+    saveLayout({ configuration: { widgets: nextWidgets } })
+  }
+
+  // #338 — full sidebar edit mode (drag-reorder + hide/show any item).
+  const [editMode, setEditMode] = useState(false)
+  if (editMode) {
+    return (
+      <div className="px-3 py-3">
+        <LayoutCustomizer
+          zone={SIDEBAR_ZONE}
+          items={coreRoutes.map((r) => ({
+            id: r.to,
+            label: r.label,
+            icon: r.icon,
+          }))}
+          widgets={widgets}
+          preset={preset}
+          onClose={() => setEditMode(false)}
+        />
+      </div>
+    )
+  }
+
   return (
     <nav className="flex flex-col gap-y-1 py-3">
       <Searchbar />
-      {coreRoutes.map((route) => {
+      {visibleRoutes.map((route) => {
         return <NavItem key={route.to} {...route} />
       })}
+      {workspaceType === "designer" && (
+        <button
+          type="button"
+          onClick={toggleCommerce}
+          disabled={isSavingLayout}
+          className={clx(
+            "text-ui-fg-muted transition-fg hover:bg-ui-bg-subtle-hover mx-3 mt-1 flex items-center gap-x-2 rounded-md px-2 py-1.5 outline-none",
+            "focus-visible:shadow-borders-focus disabled:opacity-60"
+          )}
+        >
+          {anyCommerceHidden ? <EyeMini /> : <EyeSlashMini />}
+          <Text size="small" leading="compact" className="text-ui-fg-subtle">
+            {anyCommerceHidden
+              ? t("app.nav.main.showCommerce")
+              : t("app.nav.main.hideCommerce")}
+          </Text>
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={() => setEditMode(true)}
+        className={clx(
+          "text-ui-fg-muted transition-fg hover:bg-ui-bg-subtle-hover mx-3 mt-1 flex items-center gap-x-2 rounded-md px-2 py-1.5 outline-none",
+          "focus-visible:shadow-borders-focus"
+        )}
+      >
+        <Adjustments />
+        <Text size="small" leading="compact" className="text-ui-fg-subtle">
+          {t("app.nav.customize.trigger")}
+        </Text>
+      </button>
     </nav>
   )
 }

--- a/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
+++ b/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
@@ -47,7 +47,14 @@ export function getPartnerRouteMap(): RouteObject[] {
               lazy: () => import("../../routes/home"),
               children: [
                 {
+                  // #338/#958 — the minimal, expressive gate (name + persona).
+                  // The full step-by-step wizard now lives at onboarding/full.
                   path: "onboarding",
+                  lazy: () =>
+                    import("../../routes/home/home-onboarding-quick"),
+                },
+                {
+                  path: "onboarding/full",
                   lazy: () =>
                     import("../../routes/home/home-onboarding"),
                 },

--- a/apps/partner-ui/src/hooks/api/layout-preferences.tsx
+++ b/apps/partner-ui/src/hooks/api/layout-preferences.tsx
@@ -1,0 +1,184 @@
+import { FetchError } from "@medusajs/js-sdk"
+import {
+  QueryKey,
+  UseMutationOptions,
+  UseQueryOptions,
+  useMutation,
+  useQuery,
+} from "@tanstack/react-query"
+
+import { sdk } from "../../lib/client"
+import { queryClient } from "../../lib/query-client"
+import { queryKeysFactory } from "../../lib/query-key-factory"
+
+/**
+ * Partner LayoutComposer persistence (#338).
+ *
+ * The real client for the partner-scoped layout-configuration API
+ * (`/partners/layouts/:zone/configuration`). This is the partner-ui counterpart
+ * of the composer's `use-layout-preference` hook — but where investor-ui stubbed
+ * persistence to a no-op, here it actually reads/writes the backend so a
+ * partner's sidebar/page customizations survive reloads.
+ *
+ * Data contract mirrors the composer's `LayoutPreference`.
+ */
+
+// Per-widget placement/visibility override (matches WidgetPreference).
+export type WidgetPreference = {
+  hidden?: boolean
+  section?: string
+  order?: number
+}
+
+export type LayoutPreference = {
+  widgets: Record<string, WidgetPreference>
+}
+
+type LayoutConfigurationRow = {
+  id: string
+  partner_id: string
+  zone: string
+  is_default: boolean
+  configuration: LayoutPreference
+} | null
+
+export type LayoutConfigurationResponse = {
+  personal_configuration: LayoutConfigurationRow
+  default_configuration: LayoutConfigurationRow
+  active_scope: "personal" | "default"
+}
+
+const LAYOUTS_QUERY_KEY = "partner-layouts" as const
+export const layoutsQueryKeys = queryKeysFactory(LAYOUTS_QUERY_KEY)
+
+/** The main sidebar's layout zone. Widget ids in this zone are nav `to` paths. */
+export const SIDEBAR_ZONE = "sidebar.main"
+
+/** The home dashboard's layout zone. Widget ids are stable section keys. */
+export const HOME_ZONE = "home"
+
+/**
+ * Top-level nav routes tagged as "commerce" — hidden by default for the
+ * designer persona so their workspace opens on design/production, not the full
+ * store surface. Revealed on demand via the sidebar "Show commerce tools"
+ * toggle (which writes an explicit `hidden:false` override that wins over this
+ * persona default). Widget ids are the routes' `to` paths.
+ */
+export const DESIGNER_COMMERCE_ROUTE_IDS = [
+  "/products",
+  "/customers",
+  "/content",
+] as const
+
+/**
+ * Persona layout presets — the "pre-saved layout" each workspace type bootstraps
+ * from before the partner has any personal config. Same `{widgets}` shape as a
+ * saved LayoutPreference, so the apply order is uniform:
+ *   personal override  →  persona preset  →  natural (source) order/visible.
+ *
+ * These are the client-side seed today; because they share the composer's data
+ * contract they can be promoted to server `is_default` rows per persona later
+ * (bootstrapping without a code change). Keep ids as nav `to` paths.
+ */
+export type SidebarPreset = LayoutPreference["widgets"]
+
+export const SIDEBAR_PERSONA_PRESETS: Record<string, SidebarPreset> = {
+  // Designer opens design-first with the commerce surface collapsed.
+  designer: {
+    "/designs": { order: 0 },
+    "/orders": { order: 1 },
+    "/payment-submissions": { order: 2 },
+    "/products": { hidden: true },
+    "/customers": { hidden: true },
+    "/content": { hidden: true },
+  },
+  // Seller / manufacturer / individual already get a curated route SET from
+  // useCoreRoutes, so their presets are empty (natural order, nothing hidden).
+  seller: {},
+  manufacturer: {},
+  individual: {},
+}
+
+/** The preset for a workspace type (empty when unknown/legacy). */
+export const getSidebarPreset = (workspaceType?: string): SidebarPreset =>
+  (workspaceType && SIDEBAR_PERSONA_PRESETS[workspaceType]) || {}
+
+export const usePartnerLayoutConfiguration = (
+  zone: string,
+  options?: Omit<
+    UseQueryOptions<
+      LayoutConfigurationResponse,
+      FetchError,
+      LayoutConfigurationResponse,
+      QueryKey
+    >,
+    "queryFn" | "queryKey"
+  >
+) => {
+  const { data, ...rest } = useQuery({
+    queryKey: layoutsQueryKeys.detail(zone),
+    queryFn: () =>
+      sdk.client.fetch<LayoutConfigurationResponse>(
+        `/partners/layouts/${encodeURIComponent(zone)}/configuration`,
+        { method: "GET" }
+      ),
+    ...options,
+  })
+
+  return { ...data, ...rest }
+}
+
+type SetLayoutConfigurationBody = {
+  is_default?: boolean
+  configuration: LayoutPreference
+}
+
+export const useSetPartnerLayoutConfiguration = (
+  zone: string,
+  options?: UseMutationOptions<
+    { layout_configuration: LayoutConfigurationRow },
+    FetchError,
+    SetLayoutConfigurationBody
+  >
+) => {
+  return useMutation({
+    // Spread caller options FIRST so our wrapped onSuccess below always wins —
+    // otherwise a caller-supplied onSuccess (e.g. the customizer's toast+close)
+    // would clobber the cache invalidation and the sidebar would keep rendering
+    // the stale config (looked like "saves don't persist").
+    ...options,
+    mutationFn: (body: SetLayoutConfigurationBody) =>
+      sdk.client.fetch<{ layout_configuration: LayoutConfigurationRow }>(
+        `/partners/layouts/${encodeURIComponent(zone)}/configuration`,
+        { method: "POST", body }
+      ),
+    onSuccess: async (data, variables, context) => {
+      await queryClient.invalidateQueries({
+        queryKey: layoutsQueryKeys.detail(zone),
+      })
+      await options?.onSuccess?.(data, variables, context)
+    },
+  })
+}
+
+export const useResetPartnerLayoutConfiguration = (
+  zone: string,
+  options?: UseMutationOptions<{ deleted: boolean }, FetchError, void>
+) => {
+  return useMutation({
+    // See useSetPartnerLayoutConfiguration: caller options first so the
+    // invalidation in our onSuccess isn't clobbered by a caller onSuccess.
+    ...options,
+    mutationFn: () =>
+      sdk.client.fetch<{ deleted: boolean }>(
+        `/partners/layouts/${encodeURIComponent(zone)}/configuration`,
+        { method: "DELETE" }
+      ),
+    onSuccess: async (data, variables, context) => {
+      await queryClient.invalidateQueries({
+        queryKey: layoutsQueryKeys.detail(zone),
+      })
+      await options?.onSuccess?.(data, variables, context)
+    },
+  })
+}

--- a/apps/partner-ui/src/i18n/translations/en.json
+++ b/apps/partner-ui/src/i18n/translations/en.json
@@ -273,13 +273,27 @@
         "webStore": "WebStore",
         "content": "Content",
         "theme": "Theme",
-        "analytics": "Analytics"
+        "analytics": "Analytics",
+        "showCommerce": "Show commerce tools",
+        "hideCommerce": "Hide commerce tools"
       },
       "settings": {
         "header": "Settings",
         "general": "General",
         "developer": "Developer",
         "myAccount": "My Account"
+      },
+      "customize": {
+        "trigger": "Customize menu",
+        "title": "Customize your menu",
+        "save": "Save",
+        "cancel": "Cancel",
+        "resetAction": "Reset to default",
+        "saved": "Menu updated",
+        "reset": "Menu reset to default",
+        "dragToReorder": "Drag to reorder",
+        "show": "Show",
+        "hide": "Hide"
       }
     }
   },
@@ -3277,6 +3291,7 @@
     "home": {
       "dashboard": "Dashboard",
       "welcome": "Welcome",
+      "customizeDashboard": "Customize",
       "gettingStarted": {
         "heading": "Getting Started",
         "description": "Complete these steps to set up your workspace.",
@@ -3288,6 +3303,7 @@
         "seller": "Seller",
         "manufacturer": "Manufacturer",
         "individual": "Individual",
+        "designer": "Designer",
         "verifyLabel": "Get verified",
         "verifyDescription": "Upload verification documents.",
         "upload": "Upload",
@@ -3517,6 +3533,19 @@
           "pending": "Pending"
         }
       }
+    },
+    "quickOnboarding": {
+      "heading": "Welcome — let's get you started",
+      "description": "Just two things to begin. You can fill in the rest whenever you like — we'll remind you.",
+      "nameLabel": "What should we call your workspace?",
+      "namePlaceholder": "e.g. Meera Handlooms",
+      "personaLabel": "What best describes you?",
+      "progressiveHint": "You can complete the rest later from your dashboard.",
+      "fullSetupLink": "Prefer to set everything up now?",
+      "continue": "Continue",
+      "toastSaved": "You're all set — welcome aboard!",
+      "errorMissing": "Add a name and pick what describes you to continue.",
+      "errorUnknown": "Something went wrong. Please try again."
     },
     "onboardingModal": {
       "title": "Welcome! Let's set up your workspace",
@@ -3853,6 +3882,10 @@
         "individual": {
           "title": "Individual",
           "description": "Work on assigned tasks. See Tasks, Shared Folders, and Payment Submissions."
+        },
+        "designer": {
+          "title": "Designer",
+          "description": "Author designs and route them to a producing partner. A lean, design-first sidebar; commerce tools stay hidden until you ask for them."
         }
       },
       "status": {

--- a/apps/partner-ui/src/routes/home/home-onboarding-quick/home-onboarding-quick.tsx
+++ b/apps/partner-ui/src/routes/home/home-onboarding-quick/home-onboarding-quick.tsx
@@ -1,0 +1,285 @@
+import { useMemo, useState } from "react"
+import {
+  Alert,
+  Button,
+  Heading,
+  Input,
+  Text,
+  clx,
+  toast,
+} from "@medusajs/ui"
+import {
+  BuildingStorefront,
+  PencilSquare,
+  Sparkles,
+  Users,
+} from "@medusajs/icons"
+import { useTranslation } from "react-i18next"
+import { Link } from "react-router-dom"
+
+import { RouteFocusModal, useRouteModal } from "../../../components/modals"
+import { KeyboundForm } from "../../../components/utilities/keybound-form"
+import { useMe } from "../../../hooks/api/users"
+import { sdk } from "../../../lib/client"
+import { queryClient } from "../../../lib/query-client"
+
+/**
+ * Minimal onboarding gate (#338/#958 — expressive, not linear).
+ *
+ * The ONLY blocking step for a new partner: their name + persona. Persona sets
+ * `workspace_type` immediately so the correct (e.g. lean designer) sidebar loads
+ * from the first screen. Everything else — logo, team, selling mode, plan — is
+ * filled progressively later from the home checklist, nudged by email/
+ * notifications. The full step-by-step wizard stays available at
+ * `/onboarding/full` for partners who'd rather complete it all at once.
+ */
+
+type Persona = "seller" | "manufacturer" | "designer" | "individual"
+
+const mapWorkspaceTypeToBusinessType = (workspaceType?: string): string => {
+  if (workspaceType === "seller") return "seller"
+  if (workspaceType === "individual") return "individual"
+  if (workspaceType === "designer") return "designer"
+  if (workspaceType === "manufacturer") return "manufacturer"
+  return ""
+}
+
+const getOnboardingStorageKey = (partnerId: string) =>
+  `partner_onboarding_${partnerId}`
+
+export const HomeOnboardingQuick = () => {
+  return (
+    <RouteFocusModal>
+      <QuickOnboardingForm />
+    </RouteFocusModal>
+  )
+}
+
+const QuickOnboardingForm = () => {
+  const { t } = useTranslation()
+  const { user } = useMe()
+  const partner = user?.partner
+  const partnerId = user?.partner_id
+  const { handleSuccess } = useRouteModal()
+
+  const metadata = (partner?.metadata || {}) as Record<string, any>
+  const workspaceType = (partner as any)?.workspace_type as string | undefined
+
+  const PERSONA_OPTIONS = useMemo<
+    { value: Persona; title: string; description: string; icon: React.ReactNode }[]
+  >(
+    () => [
+      {
+        value: "seller",
+        title: t("partner.onboardingSettings.businessType.seller.title"),
+        description: t("partner.onboardingSettings.businessType.seller.description"),
+        icon: <BuildingStorefront className="h-6 w-6" />,
+      },
+      {
+        value: "manufacturer",
+        title: t("partner.onboardingSettings.businessType.manufacturer.title"),
+        description: t("partner.onboardingSettings.businessType.manufacturer.description"),
+        icon: <PencilSquare className="h-6 w-6" />,
+      },
+      {
+        value: "designer",
+        title: t("partner.onboardingSettings.businessType.designer.title"),
+        description: t("partner.onboardingSettings.businessType.designer.description"),
+        icon: <Sparkles className="h-6 w-6" />,
+      },
+      {
+        value: "individual",
+        title: t("partner.onboardingSettings.businessType.individual.title"),
+        description: t("partner.onboardingSettings.businessType.individual.description"),
+        icon: <Users className="h-6 w-6" />,
+      },
+    ],
+    [t]
+  )
+
+  const [businessName, setBusinessName] = useState<string>(
+    () => metadata.business_name || partner?.name || ""
+  )
+  const [persona, setPersona] = useState<Persona | "">(() => {
+    const mapped = mapWorkspaceTypeToBusinessType(workspaceType || metadata.use_type)
+    return (mapped as Persona) || ""
+  })
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const canContinue = businessName.trim().length > 0 && persona !== ""
+
+  const handleSubmit = async () => {
+    if (!canContinue) {
+      setError(t("partner.quickOnboarding.errorMissing"))
+      return
+    }
+    setError(null)
+    setIsSubmitting(true)
+    try {
+      // Persona → workspace_type (drives the sidebar), name + an essentials flag
+      // so home stops routing the partner back here. The rest is progressive.
+      await sdk.client.fetch("/partners/update", {
+        method: "PUT",
+        body: {
+          workspace_type: persona,
+          // Merge — the update workflow REPLACES the metadata column wholesale,
+          // so spread existing keys to avoid clobbering country_code/use_type/etc.
+          metadata: {
+            ...metadata,
+            business_name: businessName.trim(),
+            onboarding_essentials_done: true,
+          },
+        },
+      })
+      queryClient.invalidateQueries({ queryKey: ["users", "me"] })
+
+      // Record the persona in the onboarding profile too (non-blocking).
+      try {
+        await sdk.client.fetch("/partners/onboarding-profile", {
+          method: "PUT",
+          body: { person_type: personaToProfileType(persona) },
+        })
+      } catch {
+        // profile is best-effort; the essentials flag above is the source of truth
+      }
+
+      if (partnerId) {
+        try {
+          localStorage.setItem(
+            getOnboardingStorageKey(partnerId),
+            JSON.stringify({
+              completed: false,
+              skipped: false,
+              essentials_done: true,
+              about: { business_name: businessName.trim() },
+              essentials_at: new Date().toISOString(),
+            })
+          )
+        } catch {
+          // localStorage is a cache; the server flag is authoritative
+        }
+      }
+
+      toast.success(t("partner.quickOnboarding.toastSaved"))
+      handleSuccess("/")
+    } catch (e) {
+      setError(
+        e instanceof Error ? e.message : t("partner.quickOnboarding.errorUnknown")
+      )
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <KeyboundForm
+      onSubmit={(e) => {
+        e.preventDefault()
+        handleSubmit()
+      }}
+      className="flex h-full flex-col overflow-hidden"
+    >
+      <RouteFocusModal.Body className="overflow-auto">
+        <div className="mx-auto flex w-full max-w-[720px] flex-col gap-y-6 px-6 py-10">
+          <div>
+            <Heading>{t("partner.quickOnboarding.heading")}</Heading>
+            <Text size="small" className="text-ui-fg-subtle mt-1">
+              {t("partner.quickOnboarding.description")}
+            </Text>
+          </div>
+
+          {error && <Alert variant="error">{error}</Alert>}
+
+          <div>
+            <Text size="small" className="mb-1 block font-medium">
+              {t("partner.quickOnboarding.nameLabel")}
+            </Text>
+            <Input
+              value={businessName}
+              onChange={(e) => setBusinessName(e.target.value)}
+              placeholder={t("partner.quickOnboarding.namePlaceholder")}
+              autoFocus
+            />
+          </div>
+
+          <div>
+            <Text size="small" className="mb-2 block font-medium">
+              {t("partner.quickOnboarding.personaLabel")}
+            </Text>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {PERSONA_OPTIONS.map((opt) => {
+                const selected = persona === opt.value
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    onClick={() => setPersona(opt.value)}
+                    className={clx(
+                      "bg-ui-bg-base rounded-lg border p-4 text-left transition-all outline-none",
+                      "hover:shadow-elevation-card-hover focus-visible:shadow-borders-focus",
+                      selected
+                        ? "border-ui-border-interactive shadow-elevation-card-rest"
+                        : "border-ui-border-base"
+                    )}
+                  >
+                    <div className="mb-2 flex items-center gap-x-3">
+                      <div className="text-ui-fg-subtle">{opt.icon}</div>
+                      <Text size="small" weight="plus">
+                        {opt.title}
+                      </Text>
+                    </div>
+                    <Text size="small" className="text-ui-fg-subtle">
+                      {opt.description}
+                    </Text>
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+
+          <Text size="xsmall" className="text-ui-fg-muted">
+            {t("partner.quickOnboarding.progressiveHint")}{" "}
+            <Link
+              to="/onboarding/full"
+              className="text-ui-fg-interactive"
+            >
+              {t("partner.quickOnboarding.fullSetupLink")}
+            </Link>
+          </Text>
+        </div>
+      </RouteFocusModal.Body>
+
+      <RouteFocusModal.Footer>
+        <div className="flex items-center justify-end gap-x-2">
+          <Button
+            size="small"
+            variant="primary"
+            type="submit"
+            isLoading={isSubmitting}
+            disabled={!canContinue || isSubmitting}
+          >
+            {t("partner.quickOnboarding.continue")}
+          </Button>
+        </div>
+      </RouteFocusModal.Footer>
+    </KeyboundForm>
+  )
+}
+
+/** Map the persona (workspace_type) to the closest onboarding_profile person_type. */
+function personaToProfileType(
+  persona: Persona
+): "individual" | "business" | "manufacturer" | "artisan" {
+  switch (persona) {
+    case "individual":
+      return "individual"
+    case "manufacturer":
+      return "manufacturer"
+    case "designer":
+      return "artisan"
+    case "seller":
+    default:
+      return "business"
+  }
+}

--- a/apps/partner-ui/src/routes/home/home-onboarding-quick/index.ts
+++ b/apps/partner-ui/src/routes/home/home-onboarding-quick/index.ts
@@ -1,0 +1,1 @@
+export { HomeOnboardingQuick as Component } from "./home-onboarding-quick"

--- a/apps/partner-ui/src/routes/home/home-onboarding/home-onboarding.tsx
+++ b/apps/partner-ui/src/routes/home/home-onboarding/home-onboarding.tsx
@@ -143,9 +143,14 @@ const BUSINESS_TYPE_KEYS = [
   "other",
 ] as const
 
-const mapBusinessTypeToWorkspaceType = (businessType: string): "seller" | "manufacturer" | "individual" => {
+const mapBusinessTypeToWorkspaceType = (
+  businessType: string
+): "seller" | "manufacturer" | "individual" | "designer" => {
   if (businessType === "seller") return "seller"
   if (businessType === "individual") return "individual"
+  // #338/#958 — designer is now a first-class persona (was collapsed to
+  // manufacturer), driving the lean designer sidebar + layout default.
+  if (businessType === "designer") return "designer"
   return "manufacturer"
 }
 
@@ -222,6 +227,7 @@ const mapWorkspaceTypeToBusinessType = (workspaceType?: string): string => {
   if (workspaceType === "seller") return "seller"
   if (workspaceType === "individual") return "individual"
   if (workspaceType === "manufacturer") return "manufacturer"
+  if (workspaceType === "designer") return "designer"
   return ""
 }
 

--- a/apps/partner-ui/src/routes/home/home.tsx
+++ b/apps/partner-ui/src/routes/home/home.tsx
@@ -1,6 +1,7 @@
 import { Badge, Button, Checkbox, Container, FocusModal, Heading, Text, clx, toast } from "@medusajs/ui"
 import { Outlet, useNavigate } from "react-router-dom"
 import {
+  Adjustments,
   ArrowPath,
   BuildingStorefront,
   CogSixTooth,
@@ -9,6 +10,7 @@ import {
   PencilSquare,
   Plus,
   ShoppingBag,
+  Sparkles,
   TruckFast,
   Users,
 } from "@medusajs/icons"
@@ -22,6 +24,11 @@ import { WhatsNewCarousel } from "./whats-new/whats-new-carousel"
 import { useDiscoverProducts, useCopyProduct, DiscoverProduct } from "../../hooks/api/discover"
 import { sdk } from "../../lib/client"
 import { queryClient } from "../../lib/query-client"
+import {
+  HOME_ZONE,
+  usePartnerLayoutConfiguration,
+} from "../../hooks/api/layout-preferences"
+import { LayoutCustomizer } from "../../components/layout/main-layout/layout-customizer"
 
 // ─── Main ────────────────────────────────────────────────────────────────────
 
@@ -44,24 +51,36 @@ export const Home = () => {
   // Track a render key so onboardingStatus re-evaluates after modal closes
   const [statusKey, setStatusKey] = useState(0)
 
+  // #338/#958 — the durable "essentials captured" signal (name + persona from
+  // the minimal gate), written to partner metadata so it survives across devices.
+  const essentialsDone = Boolean(
+    (partner?.metadata as any)?.onboarding_essentials_done
+  )
+
   const onboardingStatus = useMemo(() => {
-    if (!partnerId || !storageKey) return { completed: false, skipped: false }
+    if (!partnerId || !storageKey)
+      return { completed: false, skipped: false, essentials_done: false }
     try {
       const raw = localStorage.getItem(storageKey)
-      if (!raw) return { completed: false, skipped: false }
+      if (!raw)
+        return { completed: false, skipped: false, essentials_done: false }
       const parsed = JSON.parse(raw)
       return {
         completed: Boolean(parsed?.completed),
         skipped: Boolean(parsed?.skipped),
+        essentials_done: Boolean(parsed?.essentials_done),
       }
     } catch {
-      return { completed: false, skipped: false }
+      return { completed: false, skipped: false, essentials_done: false }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [partnerId, storageKey, statusKey])
 
   useEffect(() => {
     if (!partnerId || !storageKey || partner?.is_verified) return
+    // Minimal gate already satisfied (durable server flag) — don't re-trap;
+    // the rest of onboarding is progressive via the home checklist.
+    if (essentialsDone) return
     try {
       const raw = localStorage.getItem(storageKey)
       if (!raw) {
@@ -69,20 +88,95 @@ export const Home = () => {
         return
       }
       const parsed = JSON.parse(raw)
-      if (!parsed?.completed && !parsed?.skipped) {
+      if (!parsed?.completed && !parsed?.skipped && !parsed?.essentials_done) {
         navigate("/onboarding", { replace: true })
       }
     } catch {
       navigate("/onboarding", { replace: true })
     }
-  }, [partner?.is_verified, partnerId, storageKey, navigate])
+  }, [partner?.is_verified, essentialsDone, partnerId, storageKey, navigate])
 
   const verified = Boolean(partner?.is_verified)
-  const onboardingDone = Boolean(onboardingStatus.completed || onboardingStatus.skipped)
+  const onboardingDone = Boolean(
+    onboardingStatus.completed ||
+      onboardingStatus.skipped ||
+      onboardingStatus.essentials_done ||
+      essentialsDone
+  )
   const currentWorkspaceType = (
     (partner as any)?.workspace_type ||
     (partner?.metadata as any)?.use_type
   ) as string | undefined
+
+  // #338 — composable dashboard sections. Each card is a widget in the "home"
+  // zone; the partner can hide/reorder them via the LayoutCustomizer. `span: 2`
+  // makes a section full-width in the 2-col grid; the grid reflows on reorder.
+  const { personal_configuration } = usePartnerLayoutConfiguration(HOME_ZONE)
+  const homeWidgets = personal_configuration?.configuration?.widgets ?? {}
+  const [editLayout, setEditLayout] = useState(false)
+
+  const sections = useMemo(
+    () => [
+      {
+        id: "getting-started",
+        label: t("partner.home.gettingStarted.heading"),
+        span: 1,
+        node: (
+          <GettingStartedCard
+            partnerId={partnerId}
+            partner={partner}
+            verified={verified}
+            onboardingDone={onboardingDone}
+            hasStore={hasStore}
+            storesPending={storesPending}
+            currentWorkspaceType={currentWorkspaceType}
+            onOpenOnboarding={() => navigate("/onboarding")}
+          />
+        ),
+      },
+      {
+        id: "quick-settings",
+        label: t("partner.home.quickSettings.heading"),
+        span: 1,
+        node: <QuickSettingsCard hasStore={hasStore} storeId={store?.id} />,
+      },
+      // Discover only has content once the partner has a store.
+      ...(hasStore
+        ? [
+            {
+              id: "discover",
+              label: t("partner.home.discover.title"),
+              span: 2,
+              node: <DiscoverSection />,
+            },
+          ]
+        : []),
+    ],
+    [
+      partnerId,
+      partner,
+      verified,
+      onboardingDone,
+      hasStore,
+      storesPending,
+      currentWorkspaceType,
+      store?.id,
+      navigate,
+      t,
+    ]
+  )
+
+  const visibleSections = useMemo(() => {
+    return sections
+      .map((s, index) => ({ s, index }))
+      .filter(({ s }) => !(homeWidgets[s.id]?.hidden ?? false))
+      .sort((a, b) => {
+        const oa = homeWidgets[a.s.id]?.order ?? a.index
+        const ob = homeWidgets[b.s.id]?.order ?? b.index
+        return oa - ob
+      })
+      .map(({ s }) => s)
+  }, [sections, homeWidgets])
 
   return (
     <div className="flex flex-col gap-y-3">
@@ -98,28 +192,38 @@ export const Home = () => {
                 : t("partner.home.welcome")}
           </Text>
         </div>
+        <Button
+          size="small"
+          variant="secondary"
+          onClick={() => setEditLayout((v) => !v)}
+        >
+          <Adjustments className="mr-1" />
+          {t("partner.home.customizeDashboard")}
+        </Button>
       </div>
 
       {/* What's new — dashboard changelog carousel (#342) */}
       <WhatsNewCarousel />
 
-      {/* Top row: Getting Started + Quick Settings */}
-      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-        <GettingStartedCard
-          partnerId={partnerId}
-          partner={partner}
-          verified={verified}
-          onboardingDone={onboardingDone}
-          hasStore={hasStore}
-          storesPending={storesPending}
-          currentWorkspaceType={currentWorkspaceType}
-          onOpenOnboarding={() => navigate("/onboarding")}
-        />
-        <QuickSettingsCard hasStore={hasStore} storeId={store?.id} />
-      </div>
-
-      {/* Bottom row: Discover Products (full width) */}
-      {hasStore && <DiscoverSection />}
+      {editLayout ? (
+        <Container className="p-4">
+          <LayoutCustomizer
+            zone={HOME_ZONE}
+            items={sections.map((s) => ({ id: s.id, label: s.label }))}
+            widgets={homeWidgets}
+            preset={{}}
+            onClose={() => setEditLayout(false)}
+          />
+        </Container>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+          {visibleSections.map((s) => (
+            <div key={s.id} className={clx(s.span === 2 && "lg:col-span-2")}>
+              {s.node}
+            </div>
+          ))}
+        </div>
+      )}
 
       <Outlet context={{ onOnboardingClose: () => setStatusKey((k) => k + 1) }} />
     </div>
@@ -226,7 +330,9 @@ const GettingStartedCard = ({
                     ? t("partner.home.gettingStarted.seller")
                     : currentWorkspaceType === "individual"
                       ? t("partner.home.gettingStarted.individual")
-                      : t("partner.home.gettingStarted.manufacturer")}
+                      : currentWorkspaceType === "designer"
+                        ? t("partner.home.gettingStarted.designer")
+                        : t("partner.home.gettingStarted.manufacturer")}
                 </Text>
                 <Link to="/settings/onboarding" className="text-ui-fg-interactive">
                   <Text size="xsmall">{t("partner.home.gettingStarted.change")}</Text>
@@ -251,6 +357,15 @@ const GettingStartedCard = ({
                 >
                   <PencilSquare className="h-3.5 w-3.5 text-ui-fg-subtle" />
                   {t("partner.home.gettingStarted.manufacturer")}
+                </button>
+                <button
+                  type="button"
+                  disabled={savingWorkspaceType}
+                  onClick={() => handleWorkspaceTypeChange("designer")}
+                  className="flex items-center gap-1.5 rounded-md border border-ui-border-base px-2.5 py-1.5 text-xs hover:shadow-elevation-card-hover outline-none focus-visible:shadow-borders-focus"
+                >
+                  <Sparkles className="h-3.5 w-3.5 text-ui-fg-subtle" />
+                  {t("partner.home.gettingStarted.designer")}
                 </button>
                 <button
                   type="button"

--- a/apps/partner-ui/src/routes/settings/onboarding/onboarding.tsx
+++ b/apps/partner-ui/src/routes/settings/onboarding/onboarding.tsx
@@ -1,4 +1,4 @@
-import { BuildingStorefront, PencilSquare, Users } from "@medusajs/icons"
+import { BuildingStorefront, PencilSquare, Sparkles, Users } from "@medusajs/icons"
 import { Badge, Button, Container, Heading, Text, clx } from "@medusajs/ui"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -9,7 +9,7 @@ import { useMe } from "../../../hooks/api/users"
 import { sdk } from "../../../lib/client"
 import { queryClient } from "../../../lib/query-client"
 
-type WorkspaceType = "seller" | "manufacturer" | "individual"
+type WorkspaceType = "seller" | "manufacturer" | "individual" | "designer"
 
 export const SettingsOnboarding = () => {
   const { t } = useTranslation()
@@ -39,6 +39,12 @@ export const SettingsOnboarding = () => {
         title: t("partner.onboardingSettings.businessType.individual.title"),
         description: t("partner.onboardingSettings.businessType.individual.description"),
         icon: <Users className="h-6 w-6" />,
+      },
+      {
+        value: "designer",
+        title: t("partner.onboardingSettings.businessType.designer.title"),
+        description: t("partner.onboardingSettings.businessType.designer.description"),
+        icon: <Sparkles className="h-6 w-6" />,
       },
     ],
     [t]
@@ -98,7 +104,7 @@ export const SettingsOnboarding = () => {
           </Text>
         </div>
 
-        <div className="grid grid-cols-1 gap-4 px-6 py-4 sm:grid-cols-3">
+        <div className="grid grid-cols-1 gap-4 px-6 py-4 sm:grid-cols-2 lg:grid-cols-4">
           {WORKSPACE_TYPE_OPTIONS.map((opt) => (
             <button
               key={opt.value}


### PR DESCRIPTION
## What

Introduces the **designer partner persona** end-to-end and a **partner-scoped LayoutComposer** so partners can customize (reorder / hide) their sidebar and dashboard, with the layout persisted per-partner per-zone. Also ships **progressive onboarding** (ask only name + persona up front). Folds into #338 (menu/submenu personalization) and #958 (designer authoring → produce).

## Backend
- `partner.workspace_type` enum widened to include **`designer`** (4th value), threaded through partner + admin validators/routes/forms and the web marketing route. Migration `Migration20260715120000` re-adds the check constraint.
- New **`partner_ui_prefs`** module: `partner_ui_layout_configuration` model (`partner_id, zone, is_default, configuration jsonb`) with a compound partial-unique index; service upsert/get/delete helpers; migration; registered in both `medusa-config.ts` and `.prod.ts`.
- New routes `/partners/layouts/:zone/configuration` (GET/POST/DELETE) + `/partners/layouts/configurations` (list), strict validators, middleware wiring (static `configurations` matcher above dynamic `:zone`).
- Integration test `partner-layouts-api.spec.ts` — **8/8 green**.

## partner-ui
- `layout-preferences.tsx` — real client for the layout API, `LayoutPreference` contract, per-persona `SIDEBAR_PERSONA_PRESETS` (designer = design-first, commerce hidden). Mutation hooks spread caller options **first** so the wrapped cache-invalidation always wins (fixes a "saves don't persist" bug).
- Generic **`LayoutCustomizer`** (@dnd-kit flat sortable: drag-reorder + per-item hide/show), reused by **both** the sidebar and the home dashboard.
- Designer sidebar branch (commerce collapsed by default + show/hide-commerce toggle), composable home dashboard, and a minimal progressive onboarding gate (`/onboarding`), with the full 7-step wizard demoted to `/onboarding/full`.

## Scope / follow-ups
- Auth: `actor_id` **is** the partner id → configs scope per-partner; `is_default` distinguishes persona-default vs personal edit.
- Deliberately did **not** port the full investor-ui composer framework — the focused customizer delivers the #338 outcome on the same `{widgets}` contract, so a fuller composer can reuse this persistence later.
- Deferred: nudge/notification backend (**#1054**); page tab-strip composition; chat onboarding (mirror #339).

## Verify
- `pnpm test:integration:http:shared ./integration-tests/http/partner-layouts-api.spec.ts`
- In partner-ui, set a partner `workspace_type='designer'` (admin edit supports it) → lean sidebar, commerce hidden, Customize menu drag/hide/save/reset persists across reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)