### PR TITLE
Backlog clear: block PUT merge (#1016), email engagement view (#1017), collapse order lines (#887), Faire inventory-on-consume (#1018), main-only storefront builds (#1027)

### DIFF
--- a/apps/backend/scripts/limit-storefront-builds-to-main.mjs
+++ b/apps/backend/scripts/limit-storefront-builds-to-main.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * #1027 — Limit storefront Vercel builds to the production branch only.
+ *
+ * The storefront projects are linked to the shared monorepo, so every push to
+ * any feature branch fans out a preview build to EVERY storefront project. This
+ * sets each project's "Ignored Build Step" so it only builds its production
+ * branch. Provisioning bakes the same command into new projects
+ * (provision-storefront.ts); this backfills the existing ones.
+ *
+ * Vercel ignore-step semantics: exit code 1 => build, exit code 0 => skip.
+ *
+ * Usage (token/team read from apps/backend/.env, or the process env):
+ *   node scripts/limit-storefront-builds-to-main.mjs            # DRY RUN (default)
+ *   APPLY=1 node scripts/limit-storefront-builds-to-main.mjs    # actually patch
+ *   PREFIX=storefront- node scripts/...                         # name filter (default: storefront-)
+ */
+
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { dirname, join } from "node:path"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const API = "https://api.vercel.com"
+
+// ── Load token/team from apps/backend/.env if not already in the environment ──
+function loadEnvFallback() {
+  if (process.env.VERCEL_TOKEN) return
+  try {
+    const raw = readFileSync(join(__dirname, "..", ".env"), "utf8")
+    for (const line of raw.split("\n")) {
+      const m = line.match(/^(VERCEL_TOKEN|VERCEL_TEAM_ID)=(.*)$/)
+      if (m && !process.env[m[1]]) process.env[m[1]] = m[2].trim().replace(/^["']|["']$/g, "")
+    }
+  } catch {
+    // no .env — rely on process env
+  }
+}
+loadEnvFallback()
+
+const TOKEN = process.env.VERCEL_TOKEN
+const TEAM_ID = process.env.VERCEL_TEAM_ID
+const PREFIX = process.env.PREFIX ?? "storefront-"
+const APPLY = process.env.APPLY === "1"
+
+if (!TOKEN) {
+  console.error("VERCEL_TOKEN not set (and not found in apps/backend/.env) — aborting")
+  process.exit(1)
+}
+
+const teamQ = TEAM_ID ? `?teamId=${TEAM_ID}` : ""
+const teamQAmp = TEAM_ID ? `&teamId=${TEAM_ID}` : ""
+const headers = { Authorization: `Bearer ${TOKEN}`, "Content-Type": "application/json" }
+
+const ignoreCommandFor = (branch) =>
+  `if [ "$VERCEL_GIT_COMMIT_REF" = "${branch}" ]; then exit 1; else exit 0; fi`
+
+async function listAllProjects() {
+  const out = []
+  let until
+  while (true) {
+    const url = new URL(`${API}/v9/projects`)
+    if (TEAM_ID) url.searchParams.set("teamId", TEAM_ID)
+    url.searchParams.set("limit", "100")
+    if (until) url.searchParams.set("until", String(until))
+    const res = await fetch(url, { headers })
+    if (!res.ok) throw new Error(`listProjects ${res.status}: ${await res.text()}`)
+    const data = await res.json()
+    out.push(...(data.projects || []))
+    const next = data.pagination?.next
+    if (!next) break
+    until = next
+  }
+  return out
+}
+
+async function patchIgnoreCommand(project, cmd) {
+  const res = await fetch(`${API}/v9/projects/${project.id}${teamQ}`, {
+    method: "PATCH",
+    headers,
+    body: JSON.stringify({ commandForIgnoringBuildStep: cmd }),
+  })
+  if (!res.ok) throw new Error(`patch ${project.name} ${res.status}: ${await res.text()}`)
+}
+
+const projects = await listAllProjects()
+const storefronts = projects.filter((p) => p.name.startsWith(PREFIX))
+
+console.log(
+  `Found ${projects.length} projects; ${storefronts.length} match prefix "${PREFIX}".`
+)
+console.log(APPLY ? "MODE: APPLY (patching)\n" : "MODE: DRY RUN (no changes)\n")
+
+let changed = 0
+let alreadyOk = 0
+for (const p of storefronts) {
+  const branch = p.link?.productionBranch || "main"
+  const want = ignoreCommandFor(branch)
+  const current = p.commandForIgnoringBuildStep || null
+  const repo = p.link ? `${p.link.org || p.link.owner || "?"}/${p.link.repo || "?"}` : "(no git link)"
+
+  if (current === want) {
+    alreadyOk++
+    console.log(`  ✓ ${p.name}  [${repo}@${branch}]  already limited`)
+    continue
+  }
+
+  changed++
+  console.log(`  ${APPLY ? "→" : "•"} ${p.name}  [${repo}@${branch}]`)
+  console.log(`      current: ${current ?? "(none)"}`)
+  console.log(`      set to : ${want}`)
+  if (APPLY) {
+    try {
+      await patchIgnoreCommand(p, want)
+      console.log("      patched ✓")
+    } catch (e) {
+      console.error(`      FAILED: ${e.message}`)
+    }
+  }
+}
+
+console.log(
+  `\nSummary: ${alreadyOk} already limited, ${changed} ${APPLY ? "patched" : "would change"}.`
+)
+if (!APPLY && changed > 0) {
+  console.log("Re-run with APPLY=1 to apply.")
+}

--- a/apps/backend/src/admin/components/inventory-orders/inventory-order-lines-section.tsx
+++ b/apps/backend/src/admin/components/inventory-orders/inventory-order-lines-section.tsx
@@ -1,8 +1,12 @@
-import { Container, Heading, Text, Badge } from "@medusajs/ui";
+import { Container, Heading, Text, Badge, Button } from "@medusajs/ui";
 import { TriangleRightMini, PencilSquare } from "@medusajs/icons";
+import { useState } from "react";
 import { AdminInventoryOrder, OrderLine } from "../../hooks/api/inventory-orders";
 import { Link } from "react-router-dom";
 import { ActionMenu } from "../common/action-menu";
+
+// Collapse long order-line lists to keep the detail page scannable (#887).
+const COLLAPSED_LINE_COUNT = 6;
 
 export const InventoryOrderLinesSection = ({ inventoryOrder }: { inventoryOrder: AdminInventoryOrder }) => {
   // Define extended line type with inventory_item relation. The denormalized
@@ -17,6 +21,13 @@ export const InventoryOrderLinesSection = ({ inventoryOrder }: { inventoryOrder:
 
   // Handle both orderlines (from API) and order_lines (from type)
   const orderLines = (inventoryOrder as any).orderlines || inventoryOrder.order_lines || [];
+
+  const [expanded, setExpanded] = useState(false);
+  const isCollapsible = orderLines.length > COLLAPSED_LINE_COUNT;
+  const visibleLines =
+    isCollapsible && !expanded ? orderLines.slice(0, COLLAPSED_LINE_COUNT) : orderLines;
+  const hiddenCount = orderLines.length - COLLAPSED_LINE_COUNT;
+
   return (
     <Container className="p-0">
       <div className="flex items-center justify-between px-6 py-4">
@@ -46,7 +57,7 @@ export const InventoryOrderLinesSection = ({ inventoryOrder }: { inventoryOrder:
             <Text>No order lines found</Text>
           </div>
         ) : (
-          orderLines.map((line: InventoryOrderLine, idx: number) => {
+          visibleLines.map((line: InventoryOrderLine, idx: number) => {
             const inventoryItem = line.inventory_items?.[0];
             
             // Skip lines without inventory item data
@@ -88,6 +99,19 @@ export const InventoryOrderLinesSection = ({ inventoryOrder }: { inventoryOrder:
               </Link>
             );
           })
+        )}
+
+        {isCollapsible && (
+          <div className="px-2 pt-1">
+            <Button
+              variant="transparent"
+              size="small"
+              className="text-ui-fg-subtle w-full justify-center"
+              onClick={() => setExpanded((prev) => !prev)}
+            >
+              {expanded ? "Show less" : `Show ${hiddenCount} more`}
+            </Button>
+          </div>
         )}
       </div>
     </Container>

--- a/apps/backend/src/admin/routes/marketing/engagement/page.tsx
+++ b/apps/backend/src/admin/routes/marketing/engagement/page.tsx
@@ -1,0 +1,300 @@
+import { defineRouteConfig } from "@medusajs/admin-sdk"
+import {
+  Button,
+  Container,
+  DataTable,
+  type DataTablePaginationState,
+  Heading,
+  Input,
+  StatusBadge,
+  Text,
+  clx,
+  useDataTable,
+} from "@medusajs/ui"
+import { createColumnHelper } from "@tanstack/react-table"
+import { useQuery } from "@tanstack/react-query"
+import { useCallback, useEffect, useState } from "react"
+import { useSearchParams } from "react-router-dom"
+import { sdk } from "../../../lib/config"
+
+const PAGE_SIZE = 20
+
+type EngagementStatus =
+  | "engaged"
+  | "cooling"
+  | "dormant"
+  | "never_opened"
+  | "unknown"
+
+type EmailEngagement = {
+  id: string
+  email: string
+  delivered_count: number
+  opens_count: number
+  clicks_count: number
+  delivered_since_last_open: number
+  first_delivered_at: string | null
+  last_delivered_at: string | null
+  last_open_at: string | null
+  last_click_at: string | null
+  last_event_at: string | null
+  engagement_status: EngagementStatus
+  status_computed_at: string | null
+}
+
+type EngagementResponse = {
+  engagement: EmailEngagement[]
+  count: number
+  offset: number
+  limit: number
+  summary: Record<EngagementStatus | "total", number>
+}
+
+const columnHelper = createColumnHelper<EmailEngagement>()
+
+const statusToTone = (
+  status: EngagementStatus
+): "green" | "orange" | "red" | "grey" => {
+  switch (status) {
+    case "engaged":
+      return "green"
+    case "cooling":
+      return "orange"
+    case "dormant":
+      return "red"
+    default:
+      return "grey"
+  }
+}
+
+const STATUS_LABEL: Record<EngagementStatus, string> = {
+  engaged: "Engaged",
+  cooling: "Cooling",
+  dormant: "Dormant",
+  never_opened: "Never opened",
+  unknown: "Unknown",
+}
+
+const FILTERS = [
+  { value: "all", label: "All" },
+  { value: "engaged", label: "Engaged" },
+  { value: "cooling", label: "Cooling" },
+  { value: "dormant", label: "Dormant" },
+  { value: "never_opened", label: "Never opened" },
+  { value: "unknown", label: "Unknown" },
+] as const
+
+const formatDateTime = (iso: string | null): string => {
+  if (!iso) return "—"
+  try {
+    return new Date(iso).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    })
+  } catch {
+    return "—"
+  }
+}
+
+const EngagementView = () => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const pageFromUrl = parseInt(searchParams.get("e_page") || "1", 10)
+  const statusParam = searchParams.get("e_status") || "all"
+  const status = FILTERS.some((f) => f.value === statusParam)
+    ? statusParam
+    : "all"
+  const qParam = searchParams.get("e_q") || ""
+
+  // Local search box, debounced into the URL so typing doesn't refetch per key.
+  const [search, setSearch] = useState(qParam)
+  useEffect(() => setSearch(qParam), [qParam])
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      if (search === qParam) return
+      const params = new URLSearchParams(searchParams)
+      if (search.trim()) params.set("e_q", search.trim())
+      else params.delete("e_q")
+      params.delete("e_page")
+      setSearchParams(params, { replace: true })
+    }, 350)
+    return () => clearTimeout(handle)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search])
+
+  const pagination: DataTablePaginationState = {
+    pageIndex: Math.max(0, pageFromUrl - 1),
+    pageSize: PAGE_SIZE,
+  }
+  const offset = pagination.pageIndex * pagination.pageSize
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ["marketing", "engagement", status, qParam, pagination],
+    queryFn: async () => {
+      return await sdk.client.fetch<EngagementResponse>(
+        "/admin/marketing/engagement",
+        {
+          query: {
+            ...(status !== "all" ? { status } : {}),
+            ...(qParam ? { q: qParam } : {}),
+            limit: pagination.pageSize,
+            offset,
+          },
+        }
+      )
+    },
+    placeholderData: (prev) => prev,
+  })
+
+  const handleStatusChange = useCallback(
+    (next: string) => {
+      const params = new URLSearchParams(searchParams)
+      if (next !== "all") params.set("e_status", next)
+      else params.delete("e_status")
+      params.delete("e_page")
+      setSearchParams(params, { replace: true })
+    },
+    [searchParams, setSearchParams]
+  )
+
+  const handlePaginationChange = useCallback(
+    (newPagination: DataTablePaginationState) => {
+      const params = new URLSearchParams(searchParams)
+      if (newPagination.pageIndex > 0)
+        params.set("e_page", String(newPagination.pageIndex + 1))
+      else params.delete("e_page")
+      setSearchParams(params, { replace: true })
+    },
+    [searchParams, setSearchParams]
+  )
+
+  const columns = [
+    columnHelper.accessor("email", {
+      header: "Email",
+      cell: (info) => info.getValue(),
+    }),
+    columnHelper.accessor("engagement_status", {
+      header: "Status",
+      cell: (info) => (
+        <StatusBadge color={statusToTone(info.getValue())}>
+          {STATUS_LABEL[info.getValue()] ?? info.getValue()}
+        </StatusBadge>
+      ),
+    }),
+    columnHelper.accessor("delivered_count", {
+      header: "Delivered",
+      cell: (info) => info.getValue() ?? 0,
+    }),
+    columnHelper.accessor("opens_count", {
+      header: "Opens",
+      cell: (info) => info.getValue() ?? 0,
+    }),
+    columnHelper.accessor("clicks_count", {
+      header: "Clicks",
+      cell: (info) => info.getValue() ?? 0,
+    }),
+    columnHelper.accessor("delivered_since_last_open", {
+      header: "Cold streak",
+      cell: (info) => info.getValue() ?? 0,
+    }),
+    columnHelper.accessor("last_open_at", {
+      header: "Last open",
+      cell: (info) => formatDateTime(info.getValue()),
+    }),
+    columnHelper.accessor("last_event_at", {
+      header: "Last event",
+      cell: (info) => formatDateTime(info.getValue()),
+    }),
+  ]
+
+  const table = useDataTable({
+    data: data?.engagement || [],
+    columns,
+    rowCount: data?.count || 0,
+    getRowId: (row) => row.id,
+    isLoading,
+    pagination: {
+      state: pagination,
+      onPaginationChange: handlePaginationChange,
+    },
+  })
+
+  if (isError) throw error
+
+  const summary = data?.summary
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex flex-col gap-y-4 px-6 py-4">
+        <div>
+          <Heading>Engagement</Heading>
+          <Text className="text-ui-fg-subtle" size="small">
+            Per-recipient email engagement — deliveries, opens and clicks folded
+            into a status the bulk-send gate uses to soft-exclude dormant
+            contacts.
+          </Text>
+        </div>
+        {summary && (
+          <div className="flex flex-wrap gap-x-6 gap-y-2">
+            {(
+              [
+                ["total", "Total"],
+                ["engaged", "Engaged"],
+                ["cooling", "Cooling"],
+                ["dormant", "Dormant"],
+                ["never_opened", "Never opened"],
+                ["unknown", "Unknown"],
+              ] as const
+            ).map(([key, label]) => (
+              <div key={key} className="flex flex-col">
+                <Text size="xsmall" className="text-ui-fg-muted">
+                  {label}
+                </Text>
+                <Text size="large" weight="plus" className="tabular-nums">
+                  {summary[key] ?? 0}
+                </Text>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <DataTable instance={table}>
+        <DataTable.Toolbar className="flex flex-col md:flex-row md:items-center justify-between gap-y-4 w-full px-6 py-4">
+          <div className="flex items-center gap-x-1 rounded-lg bg-ui-bg-subtle p-1 overflow-x-auto">
+            {FILTERS.map((f) => (
+              <Button
+                key={f.value}
+                size="small"
+                variant="transparent"
+                onClick={() => handleStatusChange(f.value)}
+                className={clx(
+                  "whitespace-nowrap",
+                  status === f.value && "bg-ui-bg-base shadow-borders-base"
+                )}
+              >
+                {f.label}
+              </Button>
+            ))}
+          </div>
+          <Input
+            size="small"
+            placeholder="Search email…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="md:w-64"
+          />
+        </DataTable.Toolbar>
+        <DataTable.Table />
+        <DataTable.Pagination />
+      </DataTable>
+    </Container>
+  )
+}
+
+export const config = defineRouteConfig({
+  label: "Engagement",
+})
+
+export default EngagementView

--- a/apps/backend/src/api/admin/marketing/engagement/route.ts
+++ b/apps/backend/src/api/admin/marketing/engagement/route.ts
@@ -1,0 +1,87 @@
+/**
+ * GET /admin/marketing/engagement — read the email-engagement ledger for the
+ * admin Marketing → Engagement view (#1017).
+ *
+ * The engagement counters + `engagement_status` are computed (webhook ingestion
+ * + the recompute job) but nothing ever exposed them to the UI. This read route
+ * closes that gap: it lists rows filtered by status / email search, paginated at
+ * the DB, plus a global per-status summary for the KPI strip.
+ *
+ * No middleware: the query is parsed manually with a local schema so the
+ * `/admin/marketing` matcher stays off the shared middlewares list and undeclared
+ * query params never 400 (mirrors the sibling outreach read route, #508).
+ */
+
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { z } from "zod"
+
+import { EMAIL_ENGAGEMENT_MODULE } from "../../../../modules/email_engagement"
+
+const ENGAGEMENT_STATUSES = [
+  "engaged",
+  "cooling",
+  "dormant",
+  "never_opened",
+  "unknown",
+] as const
+
+const listEngagementQuerySchema = z.object({
+  status: z.enum(ENGAGEMENT_STATUSES).optional(),
+  q: z.string().trim().min(1).optional(),
+  limit: z.coerce.number().int().min(1).max(200).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+})
+
+export async function GET(
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+): Promise<void> {
+  const parsed = listEngagementQuerySchema.safeParse(req.query ?? {})
+  if (!parsed.success) {
+    res
+      .status(400)
+      .json({ message: parsed.error.issues[0]?.message ?? "Invalid query" })
+    return
+  }
+  const { status, q, limit, offset } = parsed.data
+
+  const service = req.scope.resolve(EMAIL_ENGAGEMENT_MODULE) as any
+
+  const filters: Record<string, unknown> = {}
+  if (status) filters.engagement_status = status
+  if (q) filters.q = q // `email` is a searchable field on the model
+
+  const [engagement, count] = await service.listAndCountEmailEngagements(
+    filters,
+    {
+      take: limit,
+      skip: offset,
+      // Most-recently-active first; nulls sink to the bottom.
+      order: { last_event_at: "DESC" },
+    }
+  )
+
+  // Global per-status distribution for the KPI strip (ignores the current
+  // status/q filter so the totals stay stable as the user drills in).
+  const summary: Record<string, number> = {}
+  let total = 0
+  for (const s of ENGAGEMENT_STATUSES) {
+    const [, c] = await service.listAndCountEmailEngagements(
+      { engagement_status: s },
+      { take: 1 }
+    )
+    summary[s] = c
+    total += c
+  }
+
+  res.status(200).json({
+    engagement,
+    count,
+    offset,
+    limit,
+    summary: { ...summary, total },
+  })
+}

--- a/apps/backend/src/api/partners/storefront/pages/[pageId]/blocks/[blockId]/route.ts
+++ b/apps/backend/src/api/partners/storefront/pages/[pageId]/blocks/[blockId]/route.ts
@@ -42,7 +42,7 @@ export const PUT = async (
   const { result } = await updateBlockWorkflow(req.scope).run({
     input: {
       ...(req.validatedBody as any),
-      id: req.params.blockId,
+      block_id: req.params.blockId,
       page_id: req.params.pageId,
     },
   })

--- a/apps/backend/src/workflows/blogs/send-blog-subscribers/utils/build-email-data.ts
+++ b/apps/backend/src/workflows/blogs/send-blog-subscribers/utils/build-email-data.ts
@@ -45,7 +45,9 @@ export interface BlogEmailConfig {
  * test email renders exactly what subscribers will receive.
  *
  * - UTM-tags every outbound link (utm_source=newsletter, utm_medium=email,
- *   utm_campaign=<post slug>) so newsletter/blog traffic is attributable.
+ *   utm_campaign=<post slug>, utm_content=<subscriber id>) so newsletter/blog
+ *   traffic is attributable down to the individual recipient — per-recipient
+ *   click feedback in analytics on top of the ESP-webhook engagement ledger.
  * - Carries the email alongside the person id on the unsubscribe URL so the
  *   unsubscribe endpoint can suppress by email even when the id can't resolve.
  * - Passes the two-doors CTAs: shop_url (cicilabel.com) + create_url (jaalyantra.com).
@@ -59,7 +61,11 @@ export function buildEmailData(
 ): Record<string, any> {
   const frontend = process.env.FRONTEND_URL || "https://jaalyantra.com"
   const campaign = (blogData?.slug || "blog_broadcast").toString()
-  const UTM = `utm_source=newsletter&utm_medium=email&utm_campaign=${encodeURIComponent(campaign)}`
+  // utm_content carries the subscriber id so a click is attributable to the
+  // individual recipient (per-recipient feedback), not just the campaign.
+  const UTM =
+    `utm_source=newsletter&utm_medium=email&utm_campaign=${encodeURIComponent(campaign)}` +
+    (subscriber?.id ? `&utm_content=${encodeURIComponent(subscriber.id)}` : "")
   const withUtm = (u: string) => (u ? `${u}${u.includes("?") ? "&" : "?"}${UTM}` : u)
 
   return {

--- a/apps/backend/src/workflows/stores/provision-storefront.ts
+++ b/apps/backend/src/workflows/stores/provision-storefront.ts
@@ -118,13 +118,20 @@ const createProjectStep = createStep(
       container
     )
     const projectName = `storefront-${input.handle}`
+    const branch = input.branch || "main"
     const project = await provider.createProject({
       name: projectName,
       gitRepo: input.storefrontRepo,
       framework: "nextjs",
       rootDirectory: input.rootDirectory,
-      productionBranch: input.branch || "main",
+      productionBranch: branch,
       installCommand: "pnpm install --no-frozen-lockfile",
+      // Build ONLY the production branch. The storefront repo is the shared
+      // monorepo, so without this every push to any feature branch fans out a
+      // preview build to every storefront project (#1027). Vercel ignore-step
+      // semantics: exit 1 => build, exit 0 => skip. (No-op on providers that
+      // don't consume ignoreCommand.)
+      ignoreCommand: `if [ "$VERCEL_GIT_COMMIT_REF" = "${branch}" ]; then exit 1; else exit 0; fi`,
     })
 
     return new StepResponse(

--- a/apps/backend/src/workflows/website/page-blocks/update-block.ts
+++ b/apps/backend/src/workflows/website/page-blocks/update-block.ts
@@ -22,6 +22,29 @@ export type UpdateBlockStepInput = {
   metadata?: Record<string, unknown> ;
 };
 
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === "object" && v !== null && !Array.isArray(v);
+
+/**
+ * Deep-merge `patch` onto `base`, recursing into plain objects and replacing
+ * arrays/primitives wholesale. Used so a partial `content`/`settings` payload
+ * updates only the keys it names instead of replacing the whole JSON column
+ * (Medusa writes model.json() columns as a full replace) — see #1016.
+ */
+const deepMerge = (
+  base: unknown,
+  patch: Record<string, unknown>
+): Record<string, unknown> => {
+  const out: Record<string, unknown> = isPlainObject(base) ? { ...base } : {};
+  for (const [key, value] of Object.entries(patch)) {
+    out[key] =
+      isPlainObject(value) && isPlainObject(out[key])
+        ? deepMerge(out[key], value)
+        : value;
+  }
+  return out;
+};
+
 export const updateBlockStep = createStep(
   "update-block-step",
   async (input: UpdateBlockStepInput, { container }) => {
@@ -60,13 +83,23 @@ export const updateBlockStep = createStep(
     // the PUT route's refetchBlock(result.id, ...) fell through to
     // `{ id: undefined }` and returned an arbitrary first block row
     // (same shape as the page PUT bug fixed in #285).
+    // Preserve sibling keys in the JSON columns: deep-merge any partial
+    // `content`/`settings` payload onto the existing block instead of letting
+    // Medusa full-replace the column and drop keys the caller didn't send (#1016).
+    const { content: inputContent, settings: inputSettings, ...rest } = input;
+    const data: Record<string, unknown> = { ...rest };
+    if (inputContent !== undefined) {
+      data.content = deepMerge(existingBlock.content, inputContent);
+    }
+    if (inputSettings !== undefined) {
+      data.settings = deepMerge(existingBlock.settings, inputSettings);
+    }
+
     const updatedRaw = await websiteService.updateBlocks({
       selector: {
         id: input.block_id
       },
-      data:{
-        ...input,
-      }
+      data,
     }) as unknown;
     const updatedBlock = (Array.isArray(updatedRaw) ? updatedRaw[0] : updatedRaw) as Block;
 

--- a/apps/partner-ui/src/components/work-orders/inventory-order-lines.tsx
+++ b/apps/partner-ui/src/components/work-orders/inventory-order-lines.tsx
@@ -1,6 +1,9 @@
-import { Badge, Container, Heading, Text } from "@medusajs/ui"
-import { useMemo } from "react"
+import { Badge, Button, Container, Heading, Text } from "@medusajs/ui"
+import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
+
+// Collapse long line lists so the work-order detail stays scannable (#887).
+const COLLAPSED_LINE_COUNT = 6
 
 import { getLocaleAmount, getStylizedAmount } from "../../lib/money-amount-helpers"
 import { Thumbnail } from "../common/thumbnail"
@@ -39,6 +42,7 @@ export const InventoryOrderLines = ({
   totalPrice?: number | null
 }) => {
   const { t } = useTranslation()
+  const [expanded, setExpanded] = useState(false)
 
   // Deterministic order: by creation time, then id — so rows don't jump around.
   const lines = useMemo(
@@ -72,6 +76,11 @@ export const InventoryOrderLines = ({
   const totalMoney = (amount: number) => (cc ? getStylizedAmount(amount, cc) : fmt(amount))
   const totalRequested = lines.reduce((sum, l) => sum + (Number(l?.quantity) || 0), 0)
 
+  const isCollapsible = lines.length > COLLAPSED_LINE_COUNT
+  const visibleLines =
+    isCollapsible && !expanded ? lines.slice(0, COLLAPSED_LINE_COUNT) : lines
+  const hiddenCount = lines.length - COLLAPSED_LINE_COUNT
+
   return (
     <Container className="divide-y divide-dashed p-0">
       <div className="px-6 py-4">
@@ -81,7 +90,7 @@ export const InventoryOrderLines = ({
         </Text>
       </div>
 
-      {lines.map((line) => {
+      {visibleLines.map((line) => {
         // #817 S2 — color identity is denormalized onto the line, so this reads
         // correctly even without the inventory_item relation loaded.
         const title =
@@ -157,6 +166,21 @@ export const InventoryOrderLines = ({
           </div>
         )
       })}
+
+      {isCollapsible && (
+        <div className="px-6 py-3">
+          <Button
+            variant="transparent"
+            size="small"
+            className="text-ui-fg-subtle w-full justify-center"
+            onClick={() => setExpanded((prev) => !prev)}
+          >
+            {expanded
+              ? t("actions.showLess")
+              : `${t("actions.showMore")} (${hiddenCount})`}
+          </Button>
+        </div>
+      )}
 
       {/* Total footer — the retail order-summary money block */}
       <div className="flex flex-col gap-y-2 px-6 py-4">

--- a/apps/partner-ui/src/i18n/translations/en.json
+++ b/apps/partner-ui/src/i18n/translations/en.json
@@ -119,6 +119,7 @@
     "back": "Back",
     "close": "Close",
     "showMore": "Show more",
+    "showLess": "Show less",
     "continue": "Continue",
     "continueWithEmail": "Continue with Email",
     "idCopiedToClipboard": "ID copied to clipboard",

--- a/packages/medusa-plugin-faire-store-sync/src/subscribers/faire-inventory-sync.ts
+++ b/packages/medusa-plugin-faire-store-sync/src/subscribers/faire-inventory-sync.ts
@@ -1,0 +1,108 @@
+import { SubscriberArgs, type SubscriberConfig } from "@medusajs/framework"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { Link } from "@medusajs/modules-sdk"
+import { FAIRE_SYNC_MODULE } from "../modules/faire-sync"
+import FaireSyncService from "../modules/faire-sync/service"
+import { syncProductToFaireWorkflow } from "../workflows/sync-product-to-faire"
+
+/**
+ * Push inventory to Faire when Medusa stock is CONSUMED, so a sale on any other
+ * channel decrements Faire's `on_hand_quantity` and Faire buyers can't oversell
+ * stock that's already gone (#1018). Without this the plugin only pushed
+ * inventory on product create/update, leaving Faire stale after every sale.
+ *
+ * `inventory.inventory-level.updated` fires on every stock movement. The
+ * generated event payload carries the changed level's `id` (and, on some paths,
+ * `inventory_item_id`); we resolve either back to the owning inventory item →
+ * its product(s), and re-sync ONLY products already linked to Faire. The vast
+ * majority of inventory events touch non-Faire products and drop out at the link
+ * guard, so this stays well inside Faire's rate budget.
+ *
+ * Re-uses `syncProductToFaireWorkflow` — the single source of truth for the
+ * available-quantity computation (stocked − reserved) and the by-SKU push — so
+ * the number Faire receives here is identical to a normal product sync.
+ */
+export default async function faireInventorySyncHandler({
+  event: { data },
+  container,
+}: SubscriberArgs<{ id?: string; inventory_item_id?: string }>) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER) as any
+  const service: FaireSyncService = container.resolve(FAIRE_SYNC_MODULE)
+
+  const account = await service.getActiveAccount()
+  if (!account) return
+
+  const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+
+  // 1) Resolve the affected inventory item id. Prefer an explicit
+  //    inventory_item_id; otherwise treat `id` as the level id and look it up.
+  let inventoryItemId = data?.inventory_item_id
+  if (!inventoryItemId && data?.id) {
+    try {
+      const { data: levels } = await query.graph({
+        entity: "inventory_level",
+        fields: ["inventory_item_id"],
+        filters: { id: data.id },
+      })
+      inventoryItemId = levels?.[0]?.inventory_item_id
+    } catch {
+      // Fall through — nothing to map.
+    }
+  }
+  if (!inventoryItemId) return
+
+  // 2) Map inventory item → product(s) via the variant↔inventory link pivot.
+  let productIds: string[] = []
+  try {
+    const { data: products } = await query.graph({
+      entity: "product",
+      fields: ["id"],
+      filters: {
+        variants: { inventory_items: { inventory_item_id: inventoryItemId } },
+      },
+    })
+    productIds = Array.from(
+      new Set((products ?? []).map((p: any) => p?.id).filter(Boolean))
+    )
+  } catch (err: any) {
+    logger?.warn?.(
+      `[faire] could not resolve product for inventory item ${inventoryItemId}: ${err?.message || err}`
+    )
+    return
+  }
+  if (!productIds.length) return
+
+  // 3) Re-sync only products already linked to Faire.
+  const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+
+  for (const productId of productIds) {
+    let linked = false
+    try {
+      const rows = await remoteLink.list({
+        [Modules.PRODUCT]: { product_id: productId },
+        [FAIRE_SYNC_MODULE]: { faire_sync_account_id: account.id },
+      })
+      linked = Boolean((rows as any[])?.[0]?.faire_product_token)
+    } catch {
+      continue
+    }
+    if (!linked) continue
+
+    try {
+      logger?.info?.(
+        `[faire] inventory changed for item ${inventoryItemId} → re-syncing linked product ${productId}`
+      )
+      await syncProductToFaireWorkflow(container).run({
+        input: { product_id: productId },
+      })
+    } catch (err: any) {
+      logger?.warn?.(
+        `[faire] inventory re-sync failed for product ${productId}: ${err?.message || err}`
+      )
+    }
+  }
+}
+
+export const config: SubscriberConfig = {
+  event: "inventory.inventory-level.updated",
+}


### PR DESCRIPTION
Clears five backlog issues. Each is an isolated commit.

- **#1016** `fix(website)` — partial `content`/`settings` PUTs replaced the whole JSON column, dropping sibling keys → now deep-merged onto the existing block. Partner block route passed `id` where the workflow reads `block_id` (updates silently no-op'd) → fixed.
- **#1017** `feat(marketing)` — `GET /admin/marketing/engagement` over the `email_engagement` ledger + a **Marketing → Engagement** DataTable (status tabs, email search, KPI strip). The ledger was computed but nothing rendered it. Newsletter links now carry `utm_content=<subscriber_id>` for per-recipient click attribution.
- **#887** `feat(inventory-orders)` — admin + partner-ui inventory-order detail collapse to the first 6 lines with a Show more/less toggle.
- **#1018** `feat(faire)` — new subscriber on `inventory.inventory-level.updated` re-syncs only Faire-linked products so a sale on another channel decrements Faire's `on_hand_quantity` (no oversell). *(Plugin — needs a republish to the local store to take effect.)*
- **#1027** `fix(hosting)` — provisioning sets a main-only ignore-build-step so feature-branch pushes to the shared storefront repo don't fan out preview builds; backfill script included and **already run against the 9 live storefront projects**.

## Verify
- `tsc --noEmit` clean for all changed files (only the known admin-JSX `TS2786` false-positives, which the real `medusa build` handles, remain).
- #1017: open Admin → Marketing → Engagement; expect the KPI strip + rows once the recompute job has populated statuses.
- #887: open an inventory order with >6 lines in admin and partner-ui.

## Notes
- #1018 is in the `medusa-plugin-faire-store-sync` package — republish to the local pnpm store for it to load.
- The event payload for `inventory.inventory-level.updated` is handled defensively (accepts `inventory_item_id` or resolves from a level `id`); confirm the shape on first deploy via the logged warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
