### PR TITLE
fix(hosting): Cloudflare storefront provisioning — domain removal + real Workers Builds deploy

### DIFF
--- a/apps/backend/src/api/partners/storefront/domain/route.ts
+++ b/apps/backend/src/api/partners/storefront/domain/route.ts
@@ -6,6 +6,8 @@ import { MedusaError } from "@medusajs/framework/utils"
 import { getPartnerFromAuthContext } from "../../helpers"
 import { resolveHostingProviderForPartner } from "../../../../modules/deployment/providers/resolve-partner-provider"
 import type { HostingDomainStatus } from "../../../../modules/deployment/providers/types"
+import { DEPLOYMENT_MODULE } from "../../../../modules/deployment"
+import type DeploymentService from "../../../../modules/deployment/service"
 import { WEBSITE_MODULE } from "../../../../modules/website"
 import type WebsiteService from "../../../../modules/website/service"
 import updatePartnerWorkflow from "../../../../workflows/partners/update-partner"
@@ -200,6 +202,19 @@ export const DELETE = async (
       await provider.removeDomain(projectRef, host)
     } catch {
       // best-effort removal
+    }
+  }
+
+  // Also delete the Cloudflare zone DNS record we created for each host. The
+  // provider.removeDomain call above only unbinds the domain from the hosting
+  // project; without this the CNAME/A record lingers in our zone and the domain
+  // keeps resolving after "removal" (mirrors the full-teardown route). #cf-domain
+  const deployment: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
+  for (const host of hosts) {
+    try {
+      await deployment.removeStorefrontDns(host)
+    } catch {
+      // best-effort — a missing record is fine
     }
   }
 

--- a/apps/backend/src/modules/deployment/providers/cloudflare-workers-provider.ts
+++ b/apps/backend/src/modules/deployment/providers/cloudflare-workers-provider.ts
@@ -61,19 +61,6 @@ type CfSubdomain = {
   subdomain: string
 }
 
-type CfWorkersBuild = {
-  id: string
-  status: string
-  started_on?: string
-  completed_on?: string
-}
-
-type CfDeployment = {
-  id: string
-  url?: string
-  latest_stage?: { name: string; status: string }
-}
-
 const PLACEHOLDER_SCRIPT = `export default {
   async fetch(request) {
     return new Response("storefront placeholder", { status: 200 })
@@ -204,6 +191,125 @@ export class CloudflareWorkersProvider implements HostingProvider {
     )
   }
 
+  // ── Workers Builds (git-connected auto-deploy) ────────────────────
+  //
+  // The storefront is an OpenNext app (`@opennextjs/cloudflare`), so the build
+  // pipeline is `opennextjs-cloudflare build && … deploy`, NOT `wrangler deploy`.
+  // Workers Builds runs this on the Cloudflare side whenever `main` is pushed.
+  //
+  // Two account-level values are provisioned once (dashboard) and read from env:
+  //   - CLOUDFLARE_GIT_CONNECTION_UUID — the repo connection (GitHub app auth)
+  //   - CLOUDFLARE_BUILD_TOKEN_UUID    — the API token builds deploy with
+  // A single repo connection covers every storefront (all build the same repo).
+
+  private buildsBase(): string {
+    return `${CF_API_BASE}/accounts/${this.accountId}/builds`
+  }
+
+  /** The build-trigger config that makes a storefront Worker deploy on push. */
+  private static readonly BUILD_COMMAND = "npx opennextjs-cloudflare build"
+
+  /**
+   * Deploy command for a partner's Worker. The storefront repo's `wrangler.jsonc`
+   * hardcodes `name: "storefront-starter"`, so every partner would otherwise
+   * deploy onto the SAME worker. Passing `-- --name <script>` forwards the
+   * per-partner worker name to `wrangler deploy` so each partner lands on its own
+   * `storefront-<handle>` worker.
+   */
+  private static deployCommand(scriptName: string): string {
+    return `npx opennextjs-cloudflare deploy -- --name ${scriptName}`
+  }
+
+  private gitConnectionUuid(): string | undefined {
+    return process.env.CLOUDFLARE_GIT_CONNECTION_UUID
+  }
+  private buildTokenUuid(): string | undefined {
+    return process.env.CLOUDFLARE_BUILD_TOKEN_UUID
+  }
+
+  /** Look up a Worker's build tag (external_script_id) by script name. */
+  private async getWorkerTag(scriptName: string): Promise<string | null> {
+    try {
+      const scripts = await this.cf<Array<{ id: string; tag?: string }>>(
+        `${this.scriptsBase()}`,
+        { method: "GET", headers: this.jsonHeaders() },
+        "getWorkerTag"
+      )
+      return scripts.find((s) => s.id === scriptName)?.tag ?? null
+    } catch {
+      return null
+    }
+  }
+
+  /** The production build trigger for a Worker (the one that includes `main`). */
+  private async findProductionTrigger(
+    workerTag: string
+  ): Promise<{ trigger_uuid: string; branch_includes?: string[] } | null> {
+    try {
+      const triggers = await this.cf<
+        Array<{ trigger_uuid: string; branch_includes?: string[] }>
+      >(
+        `${this.buildsBase()}/workers/${workerTag}/triggers`,
+        { method: "GET", headers: this.jsonHeaders() },
+        "listTriggers"
+      )
+      return (
+        triggers.find((t) => (t.branch_includes ?? []).includes("main")) ??
+        triggers[0] ??
+        null
+      )
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * Ensure a production Workers Builds trigger exists for the Worker, creating
+   * it if the git-connection + build-token env vars are configured. Returns the
+   * worker tag + trigger uuid, or null if builds can't be wired (env missing or
+   * the worker has no tag yet) — caller logs and continues.
+   */
+  private async ensureBuildTrigger(
+    scriptName: string,
+    branch: string,
+    rootDir: string
+  ): Promise<{ workerTag: string; triggerUuid: string } | null> {
+    const repoConnectionUuid = this.gitConnectionUuid()
+    const buildTokenUuid = this.buildTokenUuid()
+    if (!repoConnectionUuid || !buildTokenUuid) return null
+
+    const workerTag = await this.getWorkerTag(scriptName)
+    if (!workerTag) return null
+
+    const existing = await this.findProductionTrigger(workerTag)
+    if (existing) return { workerTag, triggerUuid: existing.trigger_uuid }
+
+    const trigger = await this.cf<{ trigger_uuid: string }>(
+      `${this.buildsBase()}/triggers`,
+      {
+        method: "POST",
+        headers: this.jsonHeaders(),
+        body: JSON.stringify({
+          external_script_id: workerTag,
+          repo_connection_uuid: repoConnectionUuid,
+          build_token_uuid: buildTokenUuid,
+          trigger_name: "Deploy production",
+          build_command: CloudflareWorkersProvider.BUILD_COMMAND,
+          deploy_command: CloudflareWorkersProvider.deployCommand(scriptName),
+          root_directory: rootDir || "/",
+          // Production only — this is also the #1027 fix for Workers: feature
+          // branches on the shared storefront repo never fan out a build.
+          branch_includes: [branch],
+          branch_excludes: [],
+          path_includes: ["*"],
+          path_excludes: [],
+        }),
+      },
+      "createTrigger"
+    )
+    return { workerTag, triggerUuid: trigger.trigger_uuid }
+  }
+
   // ── HostingProvider interface ─────────────────────────────────────
 
   dnsTarget(project: HostingProject): string {
@@ -222,38 +328,31 @@ export class CloudflareWorkersProvider implements HostingProvider {
       { key: "CLOUDFLARE_WORKER_NAME", value: name, type: "plain" },
     ]
 
-    // 1. Upload a placeholder Worker with initial env vars (as bindings).
+    // 1. Upload a placeholder Worker so the script exists (and gets a build
+    //    tag). Workers Builds replaces this with the real OpenNext bundle on the
+    //    first build.
     await this.uploadWorker(name, envVars)
 
-    // 2. Try to connect the GitHub repo via Workers Builds so that pushes
-    //    auto-build and deploy. This requires the Cloudflare account to have
-    //    a pre-established Git connection (set up once per account via the
-    //    dashboard or the Workers Builds API). If it fails, the operator
-    //    connects manually.
-    try {
-      const [owner, repo] = input.gitRepo.split("/")
-      await this.cf<any>(
-        `${this.scriptsBase()}/${name}/build-git-connection`,
-        {
-          method: "POST",
-          headers: this.jsonHeaders(),
-          body: JSON.stringify({
-            repo_owner: owner,
-            repo_name: repo,
-            production_branch: input.productionBranch || "main",
-            build_command:
-              input.buildCommand || "npm run build",
-            deploy_command: `npx wrangler deploy --name ${name}`,
-            root_directory: input.rootDirectory || "",
-          }),
-        },
-        "createProject"
-      )
-    } catch (e) {
+    // 2. Wire a production Workers Builds trigger so pushes to `main` auto-build
+    //    and deploy the OpenNext storefront. No-op (with a warning) when the
+    //    account-level git-connection / build-token env vars aren't configured —
+    //    the worker still exists, just without auto-deploy.
+    const branch = input.productionBranch || "main"
+    const built = await this.ensureBuildTrigger(
+      name,
+      branch,
+      input.rootDirectory || "/"
+    ).catch((e) => {
       console.warn(
-        `[CloudflareWorkersProvider] Workers Builds Git integration failed for ${name}:`,
-        (e as Error).message,
-        "— the operator should connect the repo via the Cloudflare dashboard."
+        `[CloudflareWorkersProvider] Workers Builds trigger setup failed for ${name}: ${(e as Error).message}`
+      )
+      return null
+    })
+    if (!built) {
+      console.warn(
+        `[CloudflareWorkersProvider] ${name}: no Workers Builds trigger created ` +
+          `(set CLOUDFLARE_GIT_CONNECTION_UUID + CLOUDFLARE_BUILD_TOKEN_UUID). ` +
+          `The storefront will serve the placeholder until a build is wired.`
       )
     }
 
@@ -270,13 +369,32 @@ export class CloudflareWorkersProvider implements HostingProvider {
     projectName: string,
     envVars: HostingEnvVar[]
   ): Promise<void> {
-    // Re-upload the placeholder Worker with updated bindings.
-    // Caution: if Workers Builds has already deployed the real storefront,
-    // this re-upload temporarily replaces it with the placeholder until the
-    // next Workers Builds run. For production use, consider a dedicated
-    // env-var API (e.g. PUT /accounts/…/secrets for secrets, and
-    // re-deploying with vars baked into the metadata).
-    await this.uploadWorker(projectName, envVars)
+    // Set env vars on the Workers Builds production trigger — NOT by re-uploading
+    // the script (which would clobber the deployed storefront back to the
+    // placeholder). The storefront's config is all NEXT_PUBLIC_* (build-time,
+    // baked into the OpenNext bundle), so trigger env vars are exactly the right
+    // place. If no trigger exists yet (builds not wired), skip — the vars will be
+    // set on the next createProject/build-trigger pass rather than clobbering.
+    const name = sanitizeProjectName(projectName)
+    const workerTag = await this.getWorkerTag(name)
+    const trigger = workerTag ? await this.findProductionTrigger(workerTag) : null
+    if (!trigger) {
+      console.warn(
+        `[CloudflareWorkersProvider] setEnvVars(${name}): no build trigger yet — ` +
+          `env vars not applied (wire Workers Builds first).`
+      )
+      return
+    }
+
+    const body: Record<string, { value: string; is_secret: boolean }> = {}
+    for (const v of envVars) {
+      body[v.key] = { value: v.value, is_secret: v.type === "sensitive" }
+    }
+    await this.cf<unknown>(
+      `${this.buildsBase()}/triggers/${trigger.trigger_uuid}/environment_variables`,
+      { method: "PATCH", headers: this.jsonHeaders(), body: JSON.stringify(body) },
+      "setEnvVars"
+    )
   }
 
   async addDomain(
@@ -397,57 +515,34 @@ export class CloudflareWorkersProvider implements HostingProvider {
     input: TriggerDeploymentInput
   ): Promise<HostingDeployment> {
     const projectName = sanitizeProjectName(input.projectName)
+    const branch = input.ref || "main"
+    const subdomain = await this.getSubdomain()
+    const url = `https://${projectName}.${subdomain}.workers.dev`
 
-    // Attempt to trigger Workers Builds from the Git repo.
-    // The Workers Builds API is still evolving — the endpoint path may differ.
-    // Fall back to reporting a queued deployment on failure.
-    try {
-      // Try Workers Builds trigger endpoint first.
-      const buildsResponse = await this.cf<any>(
-        `${CF_API_BASE}/accounts/${this.accountId}/workers/builds`,
-        {
-          method: "POST",
-          headers: this.jsonHeaders(),
-          body: JSON.stringify({
-            script_name: projectName,
-            deployment_trigger: {
-              type: "git_push",
-              ...(input.ref ? { ref: input.ref } : {}),
-            },
-          }),
-        },
-        "triggerDeployment"
-      )
-      const subdomain = await this.getSubdomain()
-      return {
-        id: buildsResponse.id ?? projectName,
-        url: `https://${projectName}.${subdomain}.workers.dev`,
-        status: buildsResponse.status ?? "queued",
-      }
-    } catch {
-      // If Workers Builds trigger fails, try the Deployments API.
-      try {
-        const dp = await this.cf<CfDeployment>(
-          `${this.scriptsBase()}/${projectName}/deployments`,
-          { method: "POST", headers: this.jsonHeaders() },
-          "triggerDeployment"
-        )
-        const subdomain = await this.getSubdomain()
-        return {
-          id: dp.id,
-          url:
-            dp.url ??
-            `https://${projectName}.${subdomain}.workers.dev`,
-          status: dp.latest_stage?.status ?? "queued",
-        }
-      } catch {
-        const subdomain = await this.getSubdomain()
-        return {
-          id: projectName,
-          url: `https://${projectName}.${subdomain}.workers.dev`,
-          status: "queued",
-        }
-      }
+    // Ensure the build trigger exists (creates it if createProject couldn't —
+    // e.g. env creds were added after provisioning), then fire a real build via
+    // the Workers Builds API. No fabricated "queued" success: if builds aren't
+    // wired we report "skipped" so the caller sees the storefront isn't live.
+    const built = await this.ensureBuildTrigger(projectName, branch, "/").catch(
+      () => null
+    )
+    if (!built) {
+      return { id: projectName, url, status: "skipped" }
+    }
+
+    const build = await this.cf<{ build_uuid?: string; id?: string; status?: string }>(
+      `${this.buildsBase()}/triggers/${built.triggerUuid}/builds`,
+      {
+        method: "POST",
+        headers: this.jsonHeaders(),
+        body: JSON.stringify({ branch }),
+      },
+      "triggerDeployment"
+    )
+    return {
+      id: build.build_uuid ?? build.id ?? built.triggerUuid,
+      url,
+      status: build.status ?? "queued",
     }
   }
 

--- a/apps/backend/src/modules/deployment/providers/registry.ts
+++ b/apps/backend/src/modules/deployment/providers/registry.ts
@@ -98,6 +98,9 @@ export function createHostingProvider(
     case "vercel":
       return new VercelHostingProvider(creds)
     case "cloudflare":
+      // Cloudflare Workers (via Workers Builds + OpenNext) — NOT Pages: Pages'
+      // next-on-pages only runs edge-runtime Next.js, so full SSR storefronts
+      // must deploy to Workers.
       return new CloudflareWorkersProvider(creds)
     case "netlify":
       return new NetlifyProvider(creds)

--- a/apps/backend/src/modules/deployment/service.ts
+++ b/apps/backend/src/modules/deployment/service.ts
@@ -747,12 +747,21 @@ class DeploymentService extends MedusaService({ DeploymentAccount }) {
     }
 
     try {
-      const records = await this.listDnsRecords({ name: domain, type: "CNAME" })
-      if (records.length > 0) {
-        await this.deleteDnsRecord(records[0].id)
-        return { action: "deleted" }
+      // Match by name across record types: a storefront domain is a CNAME for a
+      // subdomain but an apex custom domain is an A record — querying CNAME-only
+      // left apex records (and any duplicates) behind. Delete every record we
+      // hold for this name.
+      const records = await this.listDnsRecords({ name: domain })
+      const removable = records.filter(
+        (r) => r.type === "CNAME" || r.type === "A" || r.type === "AAAA"
+      )
+      if (removable.length === 0) {
+        return { action: "not_found" }
       }
-      return { action: "not_found" }
+      for (const record of removable) {
+        await this.deleteDnsRecord(record.id)
+      }
+      return { action: "deleted" }
     } catch (e: any) {
       return { action: "failed", error: e.message }
     }


### PR DESCRIPTION
> **Draft** — code complete + typechecked, but **not verified with a live deploy yet** (pending a Workers build token + a test provision). See #1060 for the broader hosting direction.

Two Cloudflare storefront-provisioning bugs.

## Bug 1 — custom-domain removal never deleted the DNS record
`DELETE /partners/storefront/domain` unbound the domain from the hosting project but never removed the Cloudflare **zone** DNS record, so the domain kept resolving after "removal". Now deletes the record per host (mirrors the full-teardown route), and `removeStorefrontDns` clears apex `A`/`AAAA` records too — it previously deleted only the first `CNAME`.

## Bug 2 — Cloudflare Workers storefronts never actually deployed
The Workers provider only uploaded a **placeholder** `worker.js`, POSTed to a non-existent `build-git-connection` endpoint (swallowed on failure), and `triggerDeployment` **fabricated** a `queued` status — so a Cloudflare-routed partner "provisioned" but served the placeholder. `setEnvVars` re-uploaded the placeholder, clobbering any real deploy.

Rewritten against the **real Workers Builds API** (verified against current CF docs):
- `createProject` uploads the placeholder (to get a worker tag) then wires a **production build trigger** (`opennextjs-cloudflare build` / `... deploy -- --name storefront-<handle>`, `branch_includes: [main]`).
- `setEnvVars` sets the **trigger's** env vars (`PATCH …/environment_variables`) — never re-uploads the script. The storefront's tenant config is all `NEXT_PUBLIC_*` (build-time), so trigger env is the right place.
- `triggerDeployment` fires a real build via the trigger; returns `status: "skipped"` (not fake success) when builds aren't wired.
- Per-partner `--name` avoids every partner colliding on the repo's hardcoded `storefront-starter` worker.

Reads `CLOUDFLARE_GIT_CONNECTION_UUID` + `CLOUDFLARE_BUILD_TOKEN_UUID` from env; no-ops gracefully (with a warning) when absent.

## Before this can go live (ops)
- Set `CLOUDFLARE_GIT_CONNECTION_UUID` (repo connection — already created: `06a6cd8b-4766-4e8e-b1e2-96f5c9f6d33d`) + `CLOUDFLARE_BUILD_TOKEN_UUID` on the deployment account / prod env.
- The **runtime** deploy uses the deployment-account CF creds (`api_config`), which need **Workers Scripts:Edit + Workers CI:Edit** scope.
- **Storefront repo (`nextjs-starter-medusa`) build is currently broken**: `pnpm-lock.yaml` is stale vs `package.json` (frozen-install fails), and `@opennextjs/cloudflare@1.20.1` needs `next >= 15.5.18` (repo pins `15.3.9`). Lockfile regenerated locally (uncommitted in the submodule); Next bump still needed.

## Follow-up (see #1060)
Per-repo connection resolution (instead of a single env UUID) for BYO-repo partners; and the longer-term move to a config-driven multi-tenant Tier-1 that removes per-partner builds entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
