### PR TITLE
feat(partner-mcp): discovery + AI reads (Tier 5)

### DIFF
--- a/apps/backend/src/api/partners/mcp/lib/__tests__/dispatch.unit.spec.ts
+++ b/apps/backend/src/api/partners/mcp/lib/__tests__/dispatch.unit.spec.ts
@@ -215,6 +215,25 @@ describe("partner-mcp registry + dispatch", () => {
       expect(isSensitive(byName("request_order_edit"))).toBe(false)
       expect(isSensitive(byName("finish_task"))).toBe(false)
     })
+
+    it("covers discovery + AI (Tier 5)", () => {
+      const names = new Set(PARTNER_MCP_TOOLS.map((t) => t.name))
+      for (const n of [
+        "discover_products", "copy_discover_product",
+        "get_ai_usage", "describe_image",
+      ]) {
+        expect(names.has(n)).toBe(true)
+      }
+      const byName = (n: string) => PARTNER_MCP_TOOLS.find((t) => t.name === n)!
+      // Copying a discovered product into the partner's catalog is a
+      // destructive create → require confirmation.
+      expect(isSensitive(byName("copy_discover_product"))).toBe(true)
+      // Discovery + usage are reads; describe_image is a write (not sensitive).
+      expect(byName("discover_products").method).toBe("GET")
+      expect(byName("get_ai_usage").method).toBe("GET")
+      expect(byName("describe_image").write).toBe(true)
+      expect(isSensitive(byName("describe_image"))).toBe(false)
+    })
   })
 
   it("returns a soft error for an unknown tool", async () => {

--- a/apps/backend/src/api/partners/mcp/lib/registry.ts
+++ b/apps/backend/src/api/partners/mcp/lib/registry.ts
@@ -1690,4 +1690,59 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
     write: true,
     inputSchema: obj({ taskId: STR("Task id to finish.") }, ["taskId"]),
   },
+
+  // ===== Platform discovery + AI (Tier 5) ====================================
+  // Discovery = browsing products across OTHER partners' sales channels so a
+  // partner can copy a product template into their own store. AI = read-only
+  // usage stats + a vision describe tool.
+  {
+    name: "discover_products",
+    description:
+      "Browse products across OTHER partners' sales channels (platform discovery). Use to find product templates the partner can copy into their own store. Paginated, free-text search via q.",
+    method: "GET",
+    path: "/partners/discover/products",
+    queryParams: ["q", "limit", "offset"],
+    inputSchema: obj({ ...PAGINATION }),
+  },
+  {
+    name: "copy_discover_product",
+    description:
+      "Deep-copy a discovered product into the partner's own store/sales channel. Sensitive — creates products in the partner's catalog from a source product. Pass the source product id from discover_products.",
+    method: "POST",
+    path: "/partners/discover/products/:id/copy",
+    pathParams: ["id"],
+    write: true,
+    sensitive: true,
+    inputSchema: obj(
+      { id: STR("Source product id to copy (from discover_products).") },
+      ["id"]
+    ),
+  },
+  {
+    name: "get_ai_usage",
+    description: "Get the partner's AI feature usage stats (tokens, calls, cost) for the billing period.",
+    method: "GET",
+    path: "/partners/ai/usage",
+    queryParams: ["start", "end"],
+    inputSchema: obj({
+      start: STR("Optional ISO start date."),
+      end: STR("Optional ISO end date."),
+    }),
+  },
+  {
+    name: "describe_image",
+    description:
+      "Run vision AI on an image URL to get a structured description (garment/material attributes) — useful before creating a design or product from a photo. Body: { imageUrl, hint? }.",
+    method: "POST",
+    path: "/partners/ai/describe-image",
+    write: true,
+    bodyParams: ["imageUrl", "hint"],
+    inputSchema: obj(
+      {
+        imageUrl: STR("Public URL of the image to describe."),
+        hint: STR("Optional hint, e.g. 'describe the weave and color'."),
+      },
+      ["imageUrl"]
+    ),
+  },
 ]


### PR DESCRIPTION
## Summary

Final pillar of the partner MCP catalog — **4 tools** for platform discovery and AI reads.

## Added tools
```
discover_products        copy_discover_product
get_ai_usage             describe_image
```

## Safety
- **Sensitive (`confirm: true`):** `copy_discover_product` — deep-copies a discovered product into the partner's catalog; destructive create, so it surfaces an approval card.
- **Write (routine):** `describe_image` — vision call (no confirmation friction).
- **Reads:** `discover_products` (browse other partners' products), `get_ai_usage` (token/call/cost stats).

## Tests
`dispatch.unit.spec.ts` +1 assertion for discovery/AI coverage + sensitivity flags. 16 pass.  clean on the MCP files.

## Stack
**Base: `feat/partner-mcp-tier4-sensitive-mutations`** — merge Tier 4 (#1066) first, then this.

## Catalog complete
With all five tiers merged, the Partner MCP catalog grows from 43 → **~100 tools**, covering: profile/onboarding, UI layout, the full production workflow, storefront management, store config, order/payment/task lifecycle, and discovery/AI. Every tool inherits the dispatcher's `dry_run` + `context` + sensitive-confirmation rails.