### PR TITLE
fix(storefront-hosting): guard shared multi-tenant project from per-partner destructive ops

### DIFF
--- a/apps/backend/src/api/admin/partners/[id]/storefront/redeploy/route.ts
+++ b/apps/backend/src/api/admin/partners/[id]/storefront/redeploy/route.ts
@@ -3,6 +3,7 @@ import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/util
 import { DEPLOYMENT_MODULE } from "../../../../../../modules/deployment"
 import type DeploymentService from "../../../../../../modules/deployment/service"
 import PartnerService from "../../../../../../modules/partner/service"
+import { partnerIsOnSharedProject } from "../../../../../../modules/deployment/providers/resolve-partner-provider"
 
 const STOREFRONT_REPO_ENV = process.env.VERCEL_STOREFRONT_REPO || ""
 const STOREFRONT_BRANCH_ENV = process.env.VERCEL_STOREFRONT_BRANCH || "main"
@@ -25,6 +26,18 @@ export const POST = async (
   }
 
   const partner = partners[0] as any
+
+  // Shared multi-tenant deployment: never redeploy it or overwrite its env on
+  // behalf of a single partner (it serves every tenant; the store is resolved
+  // per-request from the Host header). See partners redeploy route.
+  if (await partnerIsOnSharedProject(partner, req.scope)) {
+    return res.json({
+      message:
+        "This storefront runs on a shared, centrally-managed deployment — no per-partner redeploy is performed.",
+      deployment: { id: "shared", url: "", status: "shared" },
+    })
+  }
+
   const vercelProjectId =
     partner.vercel_project_id || partner.metadata?.vercel_project_id
   const vercelProjectName =

--- a/apps/backend/src/api/partners/storefront/domain/route.ts
+++ b/apps/backend/src/api/partners/storefront/domain/route.ts
@@ -63,6 +63,7 @@ export const GET = async (
       verified: partner.metadata?.custom_domain_verified === true,
       misconfigured: primary.misconfigured,
       configured_by: primary.configuredBy ?? null,
+      verification: primary.verification ?? null,
       dns_records: records,
     })
   } catch {

--- a/apps/backend/src/api/partners/storefront/redeploy/route.ts
+++ b/apps/backend/src/api/partners/storefront/redeploy/route.ts
@@ -4,6 +4,7 @@ import {
 } from "@medusajs/framework/http"
 import { MedusaError } from "@medusajs/framework/utils"
 import { getPartnerFromAuthContext } from "../../helpers"
+import { partnerIsOnSharedProject } from "../../../../modules/deployment/providers/resolve-partner-provider"
 import { redeployStorefrontWorkflow } from "../../../../workflows/stores/redeploy-storefront"
 
 const STOREFRONT_REPO_ENV = process.env.VERCEL_STOREFRONT_REPO || ""
@@ -19,6 +20,18 @@ export const POST = async (
       MedusaError.Types.UNAUTHORIZED,
       "No partner associated with this account"
     )
+  }
+
+  // Shared multi-tenant deployment: it's owned + deployed by us and serves every
+  // tenant, resolving the store per-request from the Host header. A per-partner
+  // redeploy would (with update_env) pin THIS partner's publishable key onto the
+  // shared project for all tenants, then redeploy it platform-wide. No-op it.
+  if (await partnerIsOnSharedProject(partner, req.scope)) {
+    return res.json({
+      message:
+        "Your storefront runs on a shared, centrally-managed deployment — content updates are live automatically, so no redeploy is needed.",
+      deployment: { id: "shared", url: "", status: "shared" },
+    })
   }
 
   const vercelProjectId =

--- a/apps/backend/src/api/partners/storefront/route.ts
+++ b/apps/backend/src/api/partners/storefront/route.ts
@@ -6,7 +6,10 @@ import { MedusaError } from "@medusajs/framework/utils"
 import { getPartnerFromAuthContext } from "../helpers"
 import { DEPLOYMENT_MODULE } from "../../../modules/deployment"
 import type DeploymentService from "../../../modules/deployment/service"
-import { resolveHostingProviderForPartner } from "../../../modules/deployment/providers/resolve-partner-provider"
+import {
+  partnerIsOnSharedProject,
+  resolveHostingProviderForPartner,
+} from "../../../modules/deployment/providers/resolve-partner-provider"
 import updatePartnerWorkflow from "../../../workflows/partners/update-partner"
 import { getStorefrontRefs } from "./helpers"
 
@@ -202,6 +205,12 @@ export const DELETE = async (
 
   const results: Record<string, any> = {}
 
+  // A SHARED, multi-tenant project (e.g. the Cloudflare shared worker) is owned
+  // by us and serves EVERY tenant — removing one partner must only detach that
+  // partner's domain, NEVER tear down the shared project. Deleting it here is
+  // what wiped the shared worker for all tenants; guard it.
+  const isShared = await partnerIsOnSharedProject(partner, req.scope)
+
   // Remove the project on whatever provider the partner is on.
   try {
     const { provider } = await resolveHostingProviderForPartner(partner, req.scope)
@@ -213,11 +222,17 @@ export const DELETE = async (
         results.domain = { action: "failed", error: e.message }
       }
     }
-    // deleteProject is an optional HostingProvider method (#345); every current
-    // adapter (Vercel/Cloudflare Pages/Netlify/Render) implements it, so this
-    // path fully tears down the project via the resolved account's creds. The
-    // legacy branch stays as a fallback for env-only Vercel setups.
-    if (typeof provider.deleteProject === "function") {
+    if (isShared) {
+      // Shared project: detached the domain above; leave the project standing.
+      results.project = {
+        action: "skipped",
+        reason: "shared multi-tenant project — only the partner's domain is detached",
+      }
+    } else if (typeof provider.deleteProject === "function") {
+      // deleteProject is an optional HostingProvider method (#345); every current
+      // adapter (Vercel/Cloudflare Pages/Netlify/Render) implements it, so this
+      // path fully tears down the project via the resolved account's creds. The
+      // legacy branch stays as a fallback for env-only Vercel setups.
       await provider.deleteProject(projectRef)
       results.project = { action: "deleted" }
     } else if (refs.providerName === "vercel" && deployment.isVercelConfigured()) {
@@ -243,7 +258,7 @@ export const DELETE = async (
   // Decrement the account's project_count (best-effort) so freed capacity is
   // reflected in future rotation.
   const accountId = partner?.deployment_account_id
-  if (accountId) {
+  if (accountId && !isShared) {
     try {
       const acct = await deployment.retrieveDeploymentAccount(accountId)
       const next = Math.max(0, ((acct as any)?.project_count ?? 1) - 1)

--- a/apps/backend/src/modules/deployment/providers/resolve-partner-provider.ts
+++ b/apps/backend/src/modules/deployment/providers/resolve-partner-provider.ts
@@ -26,6 +26,10 @@ import { DEPLOYMENT_MODULE } from ".."
 import type DeploymentService from "../service"
 import { ENCRYPTION_MODULE } from "../../encryption"
 import type EncryptionService from "../../encryption/service"
+import {
+  resolveProvisioningMode,
+  type DeploymentProvider,
+} from "../account-selector"
 import { createHostingProvider, resolveAccountCredentials } from "./registry"
 import type { HostingCredentials, HostingProvider, HostingProviderName } from "./types"
 
@@ -133,6 +137,52 @@ export async function buildHostingProvider(
     creds = envCredentials(providerName)
   }
   return createHostingProvider(providerName, creds)
+}
+
+/**
+ * Is this partner's storefront served by a SHARED, pre-deployed multi-tenant
+ * project (attach-domain-only) rather than its own dedicated deploy?
+ *
+ * Shared projects (e.g. the Cloudflare shared worker `nextjs-starter-medusa`)
+ * are owned by us and serve EVERY tenant, resolving the active store per-request
+ * from the Host header (NEXT_PUBLIC_MULTI_TENANT + /web/storefront/resolve). Any
+ * per-partner mutation of the project — above all `setEnvVars` — must be a no-op:
+ * on Cloudflare, `setEnvVars` re-uploads the worker script, replacing the live
+ * storefront with a placeholder and wiping the shared runtime bindings (see
+ * CloudflareWorkersProvider.uploadWorker), which takes ALL tenants down.
+ */
+export async function partnerIsOnSharedProject(
+  partner: any,
+  container: MedusaContainer
+): Promise<boolean> {
+  const providerName = partnerHostingProviderName(partner)
+  const projectRef = partnerProjectRef(partner, providerName)
+  if (!projectRef) return false
+
+  const accountId = (partner?.deployment_account_id ??
+    partner?.metadata?.deployment_account_id ??
+    null) as string | null
+
+  let apiConfig: Record<string, any> | null = null
+  if (accountId) {
+    try {
+      const deployment = container.resolve(DEPLOYMENT_MODULE) as DeploymentService
+      const account = await deployment.retrieveDeploymentAccount(accountId)
+      apiConfig = (account as any)?.api_config ?? null
+    } catch {
+      apiConfig = null
+    }
+  }
+
+  const { mode, sharedProjectId, sharedProjectName } = resolveProvisioningMode(
+    providerName as DeploymentProvider,
+    { apiConfig, env: process.env }
+  )
+
+  return (
+    mode === "shared" &&
+    (projectRef === sharedProjectId || projectRef === sharedProjectName)
+  )
 }
 
 export async function resolveHostingProviderForPartner(

--- a/apps/backend/src/scripts/backfill-storefront-deployments.ts
+++ b/apps/backend/src/scripts/backfill-storefront-deployments.ts
@@ -5,6 +5,7 @@ import type DeploymentService from "../modules/deployment/service"
 import { WEBSITE_MODULE } from "../modules/website"
 import type WebsiteService from "../modules/website/service"
 import type PartnerService from "../modules/partner/service"
+import { partnerIsOnSharedProject } from "../modules/deployment/providers/resolve-partner-provider"
 
 /**
  * Backfill existing partner storefronts onto the new deployment model:
@@ -119,6 +120,13 @@ export default async function backfillStorefrontDeployments({
 
       if (!domain || !projectId) {
         logger.warn(`[skip] ${label} — missing domain or project id`)
+        continue
+      }
+
+      // Never relink/redeploy a shared multi-tenant project on behalf of one
+      // partner — it serves every tenant and is deployed centrally.
+      if (await partnerIsOnSharedProject(partner, container)) {
+        logger.warn(`[skip] ${label} — shared multi-tenant project`)
         continue
       }
 

--- a/apps/backend/src/scripts/set-storefront-base-url.ts
+++ b/apps/backend/src/scripts/set-storefront-base-url.ts
@@ -3,6 +3,7 @@ import { ExecArgs } from "@medusajs/framework/types"
 import { DEPLOYMENT_MODULE } from "../modules/deployment"
 import type DeploymentService from "../modules/deployment/service"
 import { getStorefrontRefs } from "../api/partners/storefront/helpers"
+import { partnerIsOnSharedProject } from "../modules/deployment/providers/resolve-partner-provider"
 
 /**
  * One-off: pin NEXT_PUBLIC_BASE_URL on every provisioned partner
@@ -73,6 +74,16 @@ export default async function setStorefrontBaseUrl({ container }: ExecArgs) {
     if (!projectId) continue
 
     const label = `${partner.name} (${partner.handle || partner.id})`
+
+    // Never pin a per-partner base URL on a shared multi-tenant project — it
+    // serves every tenant and resolves the host per-request. Doing so would
+    // clobber the shared canonical (last-writer-wins) and redeploy it for all.
+    if (await partnerIsOnSharedProject(partner, container)) {
+      logger.warn(`[set-base-url] SKIP ${label}: shared multi-tenant project`)
+      skipped++
+      continue
+    }
+
     try {
       const res = await fetch(
         `https://api.vercel.com/v9/projects/${projectId}/domains${teamQuery}`,

--- a/apps/backend/src/workflows/partners/attach-storefront-domain.ts
+++ b/apps/backend/src/workflows/partners/attach-storefront-domain.ts
@@ -10,7 +10,10 @@ import {
 import { WEBSITE_MODULE } from "../../modules/website"
 import type WebsiteService from "../../modules/website/service"
 import { PARTNER_MODULE } from "../../modules/partner"
-import { resolveHostingProviderForPartner } from "../../modules/deployment/providers/resolve-partner-provider"
+import {
+  partnerIsOnSharedProject,
+  resolveHostingProviderForPartner,
+} from "../../modules/deployment/providers/resolve-partner-provider"
 
 /**
  * Roadmap #17 (issue #346) — a partner's custom domain should work in both
@@ -151,6 +154,17 @@ const setBaseUrlEnvStep = createStep(
   ) => {
     const partnerService: any = container.resolve(PARTNER_MODULE)
     const partner = await partnerService.retrievePartner(input.partner_id)
+
+    // Shared multi-tenant project: the base URL is resolved per-request from the
+    // Host header, never pinned to one tenant. And on Cloudflare, setEnvVars
+    // re-uploads the shared worker as a placeholder + wipes its bindings — which
+    // takes every tenant down. Never touch the shared project's env. (This is the
+    // bug that set NEXT_PUBLIC_BASE_URL=https://<partner-domain> on the shared
+    // worker and broke hr-handloom + all tenants.)
+    if (await partnerIsOnSharedProject(partner, container)) {
+      return new StepResponse({ set: false, skipped: "shared" as const })
+    }
+
     const { provider, projectRef } = await resolveHostingProviderForPartner(
       partner,
       container

--- a/apps/partner-ui/src/hooks/api/storefront.ts
+++ b/apps/partner-ui/src/hooks/api/storefront.ts
@@ -123,6 +123,7 @@ export interface DomainStatus {
   verified?: boolean
   misconfigured?: boolean
   configured_by?: string | null
+  verification?: Array<{ type: string; domain: string; value: string }> | null
   dns_records?: DnsRecord[]
 }
 

--- a/apps/partner-ui/src/routes/settings/stores/stores.tsx
+++ b/apps/partner-ui/src/routes/settings/stores/stores.tsx
@@ -46,7 +46,7 @@ function hostingProviderLabel(provider: string | undefined): string {
     case "vercel":
       return "Vercel"
     case "cloudflare":
-      return "Cloudflare Pages"
+      return "Cloudflare Workers"
     case "netlify":
       return "Netlify"
     case "render":
@@ -185,6 +185,11 @@ const StorefrontSection = () => {
             size="small"
             onClick={handleProvision}
             disabled={isProvisioning}
+            className={
+              isProvisioning
+                ? undefined
+                : "!bg-ui-tag-green-icon hover:!bg-ui-tag-green-icon/90 !text-white !border-transparent !shadow-none"
+            }
           >
             {isProvisioning ? "Enabling..." : "Enable Storefront"}
           </Button>
@@ -360,6 +365,39 @@ const StorefrontSection = () => {
   )
 }
 
+type DnsRow = { type: string; host: string; value: string }
+
+const DnsTable = ({ rows }: { rows: DnsRow[] }) => (
+  <div className="rounded-lg border border-ui-border-base overflow-hidden">
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="bg-ui-bg-subtle border-b border-ui-border-base">
+          <th className="px-3 py-2 text-left text-ui-fg-subtle font-normal">
+            Type
+          </th>
+          <th className="px-3 py-2 text-left text-ui-fg-subtle font-normal">
+            Host
+          </th>
+          <th className="px-3 py-2 text-left text-ui-fg-subtle font-normal">
+            Value
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((rec, i) => (
+          <tr key={i}>
+            <td className="px-3 py-2 font-mono text-xs">{rec.type}</td>
+            <td className="px-3 py-2 font-mono text-xs">{rec.host}</td>
+            <td className="px-3 py-2 font-mono text-xs break-all">
+              {rec.value}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+)
+
 const CustomDomainSection = () => {
   const { data: domainStatus, isPending } = useStorefrontDomain()
   const { mutateAsync: addDomain, isPending: isAdding } =
@@ -453,7 +491,12 @@ const CustomDomainSection = () => {
     domainStatus?.verified ?? addResult?.verified ?? false
   const isMisconfigured =
     domainStatus?.misconfigured ?? addResult?.misconfigured ?? true
-  const verification = addResult?.verification
+  const isActive = isVerified && !isMisconfigured
+  // Ownership (TXT) records come from the add/verify calls; the persistent
+  // "point your domain here" records come from the GET status. Prefer the
+  // freshest source but fall back so instructions survive a page reload.
+  const verification =
+    addResult?.verification || domainStatus?.verification || []
   const dnsRecords =
     domainStatus?.dns_records || addResult?.dns_records || []
 
@@ -524,97 +567,48 @@ const CustomDomainSection = () => {
             </Button>
           </div>
 
-          {!isVerified && verification && verification.length > 0 && (
+          {isActive ? (
+            <InlineTip variant="success" label="Domain Active">
+              Your custom domain is configured and serving your storefront.
+            </InlineTip>
+          ) : (
             <div className="space-y-3">
-              <InlineTip variant="warning" label="Domain Verification Required">
-                Add the following TXT record at your DNS provider to verify
-                ownership of this domain.
-              </InlineTip>
+              {verification.length > 0 && (
+                <>
+                  <InlineTip
+                    variant="warning"
+                    label="Verify Domain Ownership"
+                  >
+                    Add the following TXT record at your DNS provider to verify
+                    you own this domain.
+                  </InlineTip>
+                  <DnsTable
+                    rows={verification.map((v) => ({
+                      type: v.type,
+                      host: v.domain,
+                      value: v.value,
+                    }))}
+                  />
+                </>
+              )}
 
-              <div className="rounded-lg border border-ui-border-base overflow-hidden">
-                <table className="w-full text-sm">
-                  <thead>
-                    <tr className="bg-ui-bg-subtle border-b border-ui-border-base">
-                      <th className="px-3 py-2 text-left text-ui-fg-subtle font-normal">
-                        Type
-                      </th>
-                      <th className="px-3 py-2 text-left text-ui-fg-subtle font-normal">
-                        Host
-                      </th>
-                      <th className="px-3 py-2 text-left text-ui-fg-subtle font-normal">
-                        Value
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {verification.map((v, i) => (
-                      <tr key={i}>
-                        <td className="px-3 py-2 font-mono text-xs">
-                          {v.type}
-                        </td>
-                        <td className="px-3 py-2 font-mono text-xs">
-                          {v.domain}
-                        </td>
-                        <td className="px-3 py-2 font-mono text-xs break-all">
-                          {v.value}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
+              {dnsRecords.length > 0 && (
+                <>
+                  <InlineTip variant="info" label="Point Your Domain">
+                    Add the DNS record{dnsRecords.length > 1 ? "s" : ""} below at
+                    your domain provider so it resolves to your storefront. DNS
+                    changes can take up to 48 hours to propagate.
+                  </InlineTip>
+                  <DnsTable rows={dnsRecords} />
+                </>
+              )}
 
-              <Button
-                size="small"
-                variant="secondary"
-                onClick={handleVerify}
-                disabled={isVerifying}
-              >
-                {isVerifying ? "Verifying..." : "Verify Domain"}
-              </Button>
-            </div>
-          )}
-
-          {isVerified && isMisconfigured && (
-            <div className="space-y-3">
-              <InlineTip variant="info" label="DNS Configuration Required">
-                Point your domain to Vercel by adding the DNS record{dnsRecords.length > 1 ? "s" : ""} below at
-                your domain provider. DNS changes can take up to 48 hours to
-                propagate.
-              </InlineTip>
-
-              <div className="rounded-lg border border-ui-border-base overflow-hidden">
-                <table className="w-full text-sm">
-                  <thead>
-                    <tr className="bg-ui-bg-subtle border-b border-ui-border-base">
-                      <th className="px-3 py-2 text-left text-ui-fg-subtle font-normal">
-                        Type
-                      </th>
-                      <th className="px-3 py-2 text-left text-ui-fg-subtle font-normal">
-                        Host
-                      </th>
-                      <th className="px-3 py-2 text-left text-ui-fg-subtle font-normal">
-                        Value
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {dnsRecords.map((rec, i) => (
-                      <tr key={i}>
-                        <td className="px-3 py-2 font-mono text-xs">
-                          {rec.type}
-                        </td>
-                        <td className="px-3 py-2 font-mono text-xs">
-                          {rec.host}
-                        </td>
-                        <td className="px-3 py-2 font-mono text-xs break-all">
-                          {rec.value}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
+              {verification.length === 0 && dnsRecords.length === 0 && (
+                <InlineTip variant="info" label="Setting Up Domain">
+                  We're attaching your domain to your storefront. This can take a
+                  few minutes — click Check Status to refresh.
+                </InlineTip>
+              )}
 
               <Button
                 size="small"
@@ -625,12 +619,6 @@ const CustomDomainSection = () => {
                 {isVerifying ? "Checking..." : "Check Status"}
               </Button>
             </div>
-          )}
-
-          {isVerified && !isMisconfigured && (
-            <InlineTip variant="success" label="Domain Active">
-              Your custom domain is configured and serving your storefront.
-            </InlineTip>
           )}
         </div>
       )}


### PR DESCRIPTION
## Why
The shared multi-tenant project (the Cloudflare shared worker `nextjs-starter-medusa`) serves **every** tenant. Three per-partner lifecycle paths mutated it directly and took it down in prod:

| Step | Bug | Impact |
|---|---|---|
| attach-domain `setBaseUrlEnvStep` | `setEnvVars` on shared worker | CF re-uploads placeholder script + wipes all bindings |
| remove `DELETE /partners/storefront` | `deleteProject` on shared worker | **deletes the worker for all tenants** |

Confirmed live: the shared worker was reduced to a placeholder (bindings = `['NEXT_PUBLIC_BASE_URL']`), then deleted entirely.

## What
- New `partnerIsOnSharedProject(partner, container)` (`resolveProvisioningMode` + projectRef match).
- **attach-domain**: `setBaseUrlEnvStep` no-ops in shared mode (base URL is resolved per-request from Host header in multi-tenant).
- **remove**: shared mode only detaches the partner's own domain; skips `deleteProject` and the account `project_count` decrement.
- **Custom-domain UI**: always renders DNS records (TXT ownership + CNAME/A pointing) when a domain isn't Active — no more dead-end "Unverified" badge. GET `/partners/storefront/domain` now returns `verification`.
- Green **Enable Storefront** button.

## Notes
- `provision → setEnvVarsStep` was already shared-guarded; this brings attach + remove to parity.
- Ops tail (not in this PR): re-deploy the shared worker, re-attach tenant `*.cicilabel.com` domains, Cloudflare-for-SaaS Custom Hostnames for partner-owned domains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)