### PR TITLE
feat(storefront-hosting): Cloudflare for SaaS Custom Hostnames for partner-owned domains

### DIFF
--- a/apps/backend/src/api/admin/deployment-accounts/validators.ts
+++ b/apps/backend/src/api/admin/deployment-accounts/validators.ts
@@ -36,6 +36,11 @@ const providerConfigFields = {
   shared_project_id: z.string().optional(),
   shared_project_name: z.string().optional(),
   shared_worker_name: z.string().optional(),
+  // Cloudflare for SaaS: the proxied in-zone hostname partner-OWNED domains
+  // CNAME to (routes to the shared worker). Enables Custom Hostnames for domains
+  // outside our zone. `zone_name` lets the provider skip a zone lookup.
+  saas_fallback_origin: z.string().optional(),
+  zone_name: z.string().optional(),
 }
 
 export const CreateDeploymentAccountSchema = z
@@ -92,4 +97,6 @@ export const API_CONFIG_KEYS = [
   "shared_project_id",
   "shared_project_name",
   "shared_worker_name",
+  "saas_fallback_origin",
+  "zone_name",
 ] as const

--- a/apps/backend/src/modules/deployment/providers/cloudflare-workers-provider.ts
+++ b/apps/backend/src/modules/deployment/providers/cloudflare-workers-provider.ts
@@ -301,6 +301,63 @@ export class CloudflareWorkersProvider implements HostingProvider {
     return [cnameInstruction(hostname, this.saasFallbackOrigin)]
   }
 
+  /**
+   * SaaS custom hostnames are served via a **Worker Route**, not a Workers
+   * Custom Domain — the custom hostname proxies to the (originless) fallback
+   * origin and the route is what actually invokes the worker. Create a SCOPED
+   * `<hostname>/*` route (never `*/*`, which would hijack other in-zone hosts
+   * such as the `*.cicilabel.com` subdomains served by Vercel). Best-effort: the
+   * hostname still validates without it, so a failure here must not fail attach.
+   */
+  private async ensureWorkerRoute(
+    hostname: string,
+    script: string
+  ): Promise<void> {
+    const pattern = `${hostname}/*`
+    try {
+      const routes = await this.cf<Array<{ id: string; pattern: string }>>(
+        `${this.zoneBase()}/workers/routes`,
+        { method: "GET", headers: this.jsonHeaders() },
+        "listWorkerRoutes"
+      )
+      if ((routes || []).some((r) => r.pattern === pattern)) return
+      await this.cf(
+        `${this.zoneBase()}/workers/routes`,
+        {
+          method: "POST",
+          headers: this.jsonHeaders(),
+          body: JSON.stringify({ pattern, script }),
+        },
+        "createWorkerRoute"
+      )
+    } catch (e: any) {
+      console.warn(
+        `[CloudflareWorkersProvider] worker route ${pattern} not created:`,
+        e?.message
+      )
+    }
+  }
+
+  /** Delete the scoped `<hostname>/*` Worker Route (best-effort). */
+  private async removeWorkerRoute(hostname: string): Promise<void> {
+    const pattern = `${hostname}/*`
+    try {
+      const routes = await this.cf<Array<{ id: string; pattern: string }>>(
+        `${this.zoneBase()}/workers/routes`,
+        { method: "GET", headers: this.jsonHeaders() },
+        "listWorkerRoutes"
+      )
+      const match = (routes || []).find((r) => r.pattern === pattern)
+      if (!match) return
+      await fetch(`${this.zoneBase()}/workers/routes/${match.id}`, {
+        method: "DELETE",
+        headers: this.jsonHeaders(),
+      })
+    } catch {
+      // best-effort
+    }
+  }
+
   private async cf<T>(
     url: string,
     init: RequestInit,
@@ -444,6 +501,8 @@ export class CloudflareWorkersProvider implements HostingProvider {
       try {
         const existing = await this.findCustomHostname(domain)
         const ch = existing ?? (await this.createCustomHostname(domain))
+        // Route the custom hostname's traffic to the shared worker (scoped route).
+        await this.ensureWorkerRoute(domain, projectName)
         return {
           name: ch.hostname,
           verified: this.customHostnameActive(ch),
@@ -487,8 +546,9 @@ export class CloudflareWorkersProvider implements HostingProvider {
     projectName: string,
     domain: string
   ): Promise<void> {
-    // Partner-owned domain → delete its SaaS Custom Hostname.
+    // Partner-owned domain → delete its SaaS Custom Hostname + Worker Route.
     if (await this.shouldUseSaas(domain)) {
+      await this.removeWorkerRoute(domain)
       const ch = await this.findCustomHostname(domain)
       if (!ch) return
       const res = await fetch(`${this.zoneBase()}/custom_hostnames/${ch.id}`, {

--- a/apps/backend/src/modules/deployment/providers/cloudflare-workers-provider.ts
+++ b/apps/backend/src/modules/deployment/providers/cloudflare-workers-provider.ts
@@ -21,10 +21,12 @@
 import type {
   AddDomainOptions,
   CreateProjectInput,
+  DnsRecordInstruction,
   HostingCredentials,
   HostingDeployment,
   HostingDomain,
   HostingDomainStatus,
+  HostingDomainVerification,
   HostingEnvVar,
   HostingProject,
   HostingProvider,
@@ -59,6 +61,26 @@ type CfWorkerDomain = {
 
 type CfSubdomain = {
   subdomain: string
+}
+
+type CfCustomHostname = {
+  id: string
+  hostname: string
+  /** "pending" | "pending_validation" | "active" | "moved" | "deleted" | ... */
+  status: string
+  ssl?: {
+    status?: string
+    validation_records?: Array<{
+      txt_name?: string
+      txt_value?: string
+      http_url?: string
+      http_body?: string
+    }>
+    validation_errors?: Array<{ message: string }>
+  }
+  ownership_verification?: { type?: string; name?: string; value?: string }
+  ownership_verification_http?: { http_url?: string; http_body?: string }
+  verification_errors?: string[]
 }
 
 type CfWorkersBuild = {
@@ -109,8 +131,17 @@ export class CloudflareWorkersProvider implements HostingProvider {
   private readonly token: string
   private readonly accountId: string
   private readonly zoneId?: string
+  /**
+   * Cloudflare-for-SaaS fallback origin — a proxied hostname in OUR zone that
+   * routes to the shared worker (e.g. "mt.cicilabel.com"). Partner-OWNED domains
+   * (not in our zone) can't be Workers Custom Domains; they're attached as SaaS
+   * Custom Hostnames and the partner CNAMEs their domain to THIS origin.
+   */
+  private readonly saasFallbackOrigin?: string
   /** Cached workers.dev subdomain (lazily resolved). */
   private _subdomain: string | null = null
+  /** Cached SaaS zone name (e.g. "cicilabel.com") — lazily resolved from zoneId. */
+  private _zoneName: string | null = null
 
   constructor(creds: HostingCredentials) {
     if (!creds?.token)
@@ -120,6 +151,8 @@ export class CloudflareWorkersProvider implements HostingProvider {
     this.token = creds.token
     this.accountId = creds.accountId
     this.zoneId = creds.extra?.zone_id
+    this.saasFallbackOrigin = creds.extra?.saas_fallback_origin
+    this._zoneName = creds.extra?.zone_name || null
   }
 
   // ── Helpers ───────────────────────────────────────────────────────
@@ -156,6 +189,116 @@ export class CloudflareWorkersProvider implements HostingProvider {
     )
     this._subdomain = result.subdomain
     return result.subdomain
+  }
+
+  private zoneBase(): string {
+    if (!this.zoneId)
+      throw new Error("Cloudflare zone_id is required for custom hostnames")
+    return `${CF_API_BASE}/zones/${this.zoneId}`
+  }
+
+  /** Fetch + cache the SaaS zone name (e.g. "cicilabel.com"). */
+  private async getZoneName(): Promise<string | null> {
+    if (this._zoneName) return this._zoneName
+    if (!this.zoneId) return null
+    try {
+      const zone = await this.cf<{ name: string }>(
+        `${CF_API_BASE}/zones/${this.zoneId}`,
+        { method: "GET", headers: this.jsonHeaders() },
+        "getZoneName"
+      )
+      this._zoneName = zone.name
+      return zone.name
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * True when `hostname` is OWNED by the partner (outside our SaaS zone) — those
+   * route via Cloudflare-for-SaaS Custom Hostnames. In-zone hosts (subdomains of
+   * our zone, e.g. *.cicilabel.com) route via Workers Custom Domains. Only ever
+   * returns true when a fallback origin is configured (SaaS actually set up).
+   */
+  private async shouldUseSaas(hostname: string): Promise<boolean> {
+    if (!this.saasFallbackOrigin || !this.zoneId) return false
+    const zone = await this.getZoneName()
+    if (!zone) return false
+    const h = hostname.toLowerCase()
+    return h !== zone && !h.endsWith(`.${zone}`)
+  }
+
+  // ── Cloudflare for SaaS: Custom Hostnames (partner-owned domains) ──────────
+
+  private async findCustomHostname(
+    hostname: string
+  ): Promise<CfCustomHostname | null> {
+    try {
+      const res = await this.cf<CfCustomHostname[]>(
+        `${this.zoneBase()}/custom_hostnames?hostname=${encodeURIComponent(hostname)}`,
+        { method: "GET", headers: this.jsonHeaders() },
+        "findCustomHostname"
+      )
+      return (res || [])[0] || null
+    } catch {
+      return null
+    }
+  }
+
+  private async createCustomHostname(
+    hostname: string
+  ): Promise<CfCustomHostname> {
+    return this.cf<CfCustomHostname>(
+      `${this.zoneBase()}/custom_hostnames`,
+      {
+        method: "POST",
+        headers: this.jsonHeaders(),
+        body: JSON.stringify({
+          hostname,
+          ssl: {
+            method: "http",
+            type: "dv",
+            bundle_method: "ubiquitous",
+            wildcard: false,
+            settings: { min_tls_version: "1.2" },
+          },
+        }),
+      },
+      "createCustomHostname"
+    )
+  }
+
+  /** true once the custom hostname AND its cert are active. */
+  private customHostnameActive(ch: CfCustomHostname | null): boolean {
+    return ch?.status === "active" && ch?.ssl?.status === "active"
+  }
+
+  /** Ownership + SSL-validation records the partner must publish (for the UI). */
+  private customHostnameVerification(
+    ch: CfCustomHostname | null
+  ): HostingDomainVerification[] {
+    if (!ch) return []
+    const out: HostingDomainVerification[] = []
+    const ov = ch.ownership_verification
+    if (ov?.name && ov?.value) {
+      out.push({
+        type: (ov.type || "TXT").toUpperCase(),
+        domain: ov.name,
+        value: ov.value,
+      })
+    }
+    for (const r of ch.ssl?.validation_records || []) {
+      if (r.txt_name && r.txt_value) {
+        out.push({ type: "TXT", domain: r.txt_name, value: r.txt_value })
+      }
+    }
+    return out
+  }
+
+  /** The CNAME the partner points their domain at (→ our SaaS fallback origin). */
+  private customHostnameDns(hostname: string): DnsRecordInstruction[] {
+    if (!this.saasFallbackOrigin) return []
+    return [cnameInstruction(hostname, this.saasFallbackOrigin)]
   }
 
   private async cf<T>(
@@ -295,6 +438,22 @@ export class CloudflareWorkersProvider implements HostingProvider {
       }
     }
 
+    // Partner-OWNED domain (outside our zone) → Cloudflare for SaaS Custom
+    // Hostname. Workers Custom Domains only accept hosts inside our own zone.
+    if (await this.shouldUseSaas(domain)) {
+      try {
+        const existing = await this.findCustomHostname(domain)
+        const ch = existing ?? (await this.createCustomHostname(domain))
+        return {
+          name: ch.hostname,
+          verified: this.customHostnameActive(ch),
+          verification: this.customHostnameVerification(ch),
+        }
+      } catch (e: any) {
+        return { name: domain, verified: false, verification: [], error: e.message }
+      }
+    }
+
     try {
       const result = await this.cf<CfWorkerDomain>(
         `${this.domainsBase()}`,
@@ -328,6 +487,22 @@ export class CloudflareWorkersProvider implements HostingProvider {
     projectName: string,
     domain: string
   ): Promise<void> {
+    // Partner-owned domain → delete its SaaS Custom Hostname.
+    if (await this.shouldUseSaas(domain)) {
+      const ch = await this.findCustomHostname(domain)
+      if (!ch) return
+      const res = await fetch(`${this.zoneBase()}/custom_hostnames/${ch.id}`, {
+        method: "DELETE",
+        headers: this.jsonHeaders(),
+      })
+      if (!res.ok && res.status !== 404) {
+        throw new Error(
+          `Cloudflare removeDomain (custom hostname) failed (${res.status}): ${await res.text()}`
+        )
+      }
+      return
+    }
+
     // List domains scoped to this service, find the matching one, delete by id.
     const domains = await this.listServiceDomains(projectName)
     const match = domains.find((d) => d.hostname === domain)
@@ -363,6 +538,14 @@ export class CloudflareWorkersProvider implements HostingProvider {
     projectName: string,
     domain: string
   ): Promise<HostingDomain> {
+    if (await this.shouldUseSaas(domain)) {
+      const ch = await this.findCustomHostname(domain)
+      return {
+        name: domain,
+        verified: this.customHostnameActive(ch),
+        verification: this.customHostnameVerification(ch),
+      }
+    }
     const domains = await this.listServiceDomains(projectName)
     const match = domains.find((d) => d.hostname === domain)
     const active = match?.status === "active"
@@ -373,6 +556,20 @@ export class CloudflareWorkersProvider implements HostingProvider {
     projectName: string,
     domain: string
   ): Promise<HostingDomainStatus> {
+    // Partner-owned domain → SaaS Custom Hostname status + partner CNAME target.
+    if (await this.shouldUseSaas(domain)) {
+      const ch = await this.findCustomHostname(domain)
+      const active = this.customHostnameActive(ch)
+      return {
+        name: domain,
+        verified: active,
+        misconfigured: !active,
+        configuredBy: active ? "CNAME" : null,
+        verification: this.customHostnameVerification(ch),
+        dnsRecords: this.customHostnameDns(domain),
+      }
+    }
+
     const domains = await this.listServiceDomains(projectName)
     const match = domains.find((d) => d.hostname === domain)
     const active = match?.status === "active"

--- a/apps/backend/src/modules/deployment/providers/resolve-partner-provider.ts
+++ b/apps/backend/src/modules/deployment/providers/resolve-partner-provider.ts
@@ -99,10 +99,15 @@ function envCredentials(providerName: HostingProviderName): HostingCredentials {
       // bails ("zone_id is required") and the only routing left is a
       // workers.dev CNAME → Error 1014 (CNAME Cross-User Banned).
       const zoneId = process.env.CLOUDFLARE_ZONE_ID
+      // Cloudflare-for-SaaS fallback origin for partner-owned custom domains.
+      const saasFallback = process.env.CLOUDFLARE_SAAS_FALLBACK_ORIGIN
+      const extra: Record<string, string> = {}
+      if (zoneId) extra.zone_id = zoneId
+      if (saasFallback) extra.saas_fallback_origin = saasFallback
       return {
         token,
         accountId,
-        ...(zoneId ? { extra: { zone_id: zoneId } } : {}),
+        ...(Object.keys(extra).length ? { extra } : {}),
       }
     }
     default:

--- a/apps/docs/notes/STOREFRONT_SHARED_WORKER_AND_SAAS_2026_07.md
+++ b/apps/docs/notes/STOREFRONT_SHARED_WORKER_AND_SAAS_2026_07.md
@@ -1,0 +1,158 @@
+# Shared Multi-Tenant Storefront Worker + Cloudflare for SaaS
+
+_Last updated: 2026-07-17 — supersedes nothing; complements
+[`MULTI_ACCOUNT_HOSTING_PROVISIONING.md`](./MULTI_ACCOUNT_HOSTING_PROVISIONING.md)
+and epic #1060._
+
+## 1. Architecture
+
+One **shared Cloudflare Worker** (`nextjs-starter-medusa`) serves **every** tenant.
+There is no per-partner deploy in shared mode — the worker resolves the active
+store **per request from the `Host` header** (`NEXT_PUBLIC_MULTI_TENANT=true` +
+backend `/web/storefront/resolve`). "Provisioning" a partner in shared mode is
+therefore just **attaching their domain**, never creating/deploying a project.
+
+| Thing | Value |
+|-------|-------|
+| Cloudflare account | `c9b8b538ae53cd197539e3d1228e6dbe` (Saranshis@pm.me) |
+| Zone | `cicilabel.com` → `ac80552084461805e37b7cb1313863cd` (Free plan) |
+| Shared worker | `nextjs-starter-medusa` (workers.dev subdomain `saranshis`) |
+| Vercel shared project | `storefront-shared` = `prj_0ilDYOzSHLhviU9OLnnvJl0b0BbJ` |
+| Storefront repo | `Jaal-Yantra-Textiles/nextjs-starter-medusa` (submodule `apps/storefront-starter`) |
+| Deployment account row | `dep_acct_01KXBSTJXS32PZ7CVCF3TA1DW3` (`cf-worker-ciciclabel`) |
+
+Two domain classes attach differently:
+- **In-zone** (`*.cicilabel.com`) → **Workers Custom Domains** (Workers Domains API).
+- **Partner-owned** (`hrhandloom.in`) → **Cloudflare for SaaS Custom Hostnames**
+  (they can't be Workers Custom Domains — the hostname isn't in our zone).
+
+## 2. The "do no harm" rule (why the incident happened)
+
+A shared project must **never** be mutated by a per-partner lifecycle operation.
+Three paths violated this and each took the shared worker down for all tenants:
+
+| Lifecycle step | Bug | Blast radius |
+|---|---|---|
+| provision → `setEnvVars` | (already guarded) | — |
+| attach domain → `setBaseUrlEnvStep` | `setEnvVars` on the shared worker | CF `setEnvVars` re-uploads a **placeholder** script + wipes all bindings |
+| remove → `deleteProject` | deleted the shared worker | **worker gone for every tenant** |
+
+**Guard:** `partnerIsOnSharedProject(partner, container)`
+(`apps/backend/src/modules/deployment/providers/resolve-partner-provider.ts`) —
+true when `resolveProvisioningMode` says `shared` **and** the partner's
+`projectRef` equals the configured shared id/name. All destructive per-partner
+paths now early-return on it. Shipped in **PR #1068**.
+
+### Do-no-harm sweep (also #1068)
+Four more per-partner paths were unguarded — all on the **shared Vercel** project
+(`storefront-shared`, shared by 8 partners) via the legacy Vercel-only
+`DeploymentService` (addressed by `vercel_project_id`):
+- partner + admin **redeploy** routes (with `update_env` they pin ONE partner's
+  publishable key onto the shared project, then redeploy it platform-wide),
+- `set-storefront-base-url.ts` + `backfill-storefront-deployments.ts` scripts.
+
+All now gated on `partnerIsOnSharedProject()`.
+
+## 3. Restoring the shared worker (runbook)
+
+The worker builds **only in its own checkout**, not nested in the jyt pnpm
+workspace (OpenNext resolves Next against the hoisted root `node_modules` → 54
+esbuild "Could not resolve" errors). Recipe:
+
+```bash
+# 1. copy the submodule OUT of the workspace
+rsync -a --exclude node_modules --exclude .next --exclude .open-next --exclude .git \
+  apps/storefront-starter/ /tmp/sf-build/
+cd /tmp/sf-build
+
+# 2. build env (NEXT_PUBLIC_* are inlined at BUILD time)
+export CLOUDFLARE_API_TOKEN=<workers-scripts-edit token>
+export CLOUDFLARE_ACCOUNT_ID=c9b8b538ae53cd197539e3d1228e6dbe
+export NEXT_PUBLIC_MULTI_TENANT=true
+export NEXT_PUBLIC_MEDUSA_BACKEND_URL=https://v3.jaalyantra.com
+export NEXT_PUBLIC_STRIPE_KEY=$(aws ssm get-parameter --name /jyt/prod/STRIPE_PUBLISHABLE_KEY --with-decryption --query Parameter.Value --output text)
+export NODE_OPTIONS="--max-old-space-size=6144"
+
+# 3. standalone install + build + deploy
+pnpm install --ignore-workspace --no-frozen-lockfile
+pnpm exec opennextjs-cloudflare build
+pnpm exec opennextjs-cloudflare deploy
+```
+
+Notes:
+- `wrangler.jsonc` `vars` carries only `MEDUSA_BACKEND_URL`; `wrangler deploy`
+  overwrites the worker config with that file, so **server-read runtime secrets**
+  (e.g. `STOREFRONT_REVALIDATE_SECRET`) must be set with
+  `wrangler secret put STOREFRONT_REVALIDATE_SECRET --name nextjs-starter-medusa`.
+- Success check: `curl https://nextjs-starter-medusa.saranshis.workers.dev/`
+  returns the "No storefront here" fallback (not the placeholder); unknown-tenant
+  Host → 403 (correct until a tenant's domain + alias exist).
+
+## 4. Cloudflare for SaaS — partner-owned domains (PR #1069)
+
+`CloudflareWorkersProvider` branches on `shouldUseSaas(host)` (partner-owned host
+**and** `saas_fallback_origin` configured): `addDomain`/`removeDomain`/
+`verifyDomain`/`describeDomain` use `/zones/{zone}/custom_hostnames` instead of
+Workers Custom Domains. `describeDomain` returns the partner's CNAME target (→
+fallback origin) + ownership + SSL-validation TXT records for the partner-ui card.
+
+`addDomain` also creates a **scoped `<domain>/*` Worker Route** → the shared
+worker (custom hostnames are served via a route, not a Custom Domain), and
+`removeDomain` deletes it. Never `*/*` (would hijack in-zone Vercel-served
+subdomains). Route creation is best-effort — a failure doesn't fail the attach.
+
+Config: `deployment_account.api_config.saas_fallback_origin` / `zone_name`, or
+`CLOUDFLARE_SAAS_FALLBACK_ORIGIN` env. Off entirely when no fallback origin is
+set (backward-compatible). **The account token must carry `SSL and
+Certificates: Edit` + `Workers Routes: Edit` + `DNS: Edit` (zone) on top of
+`Workers Scripts: Edit` (account)** for the full flow — the mid-session `cfat_`
+account token has only Workers Scripts + Zone:Read, so it must be re-scoped or
+replaced before the partner-ui SaaS path works end-to-end.
+
+### One-time zone setup (done / to-do)
+1. **Fallback origin DNS** — `mt.cicilabel.com  AAAA 100::` (proxied, originless). ✅ done
+2. **Zone fallback origin** — set to `mt.cicilabel.com` (SSL/TLS → Custom Hostnames). ✅ done (status `active`)
+3. **Worker Route** — `hrhandloom.in/*` → `nextjs-starter-medusa`. ✅ done (id `66e3a649…`)
+   - Use a **scoped** `<domain>/*` route per partner, NOT `*/*` — a wildcard
+     route would hijack the `*.cicilabel.com` subdomains that Vercel serves.
+4. Per partner: create the **custom hostname**, partner CNAMEs their domain →
+   `mt.cicilabel.com` and adds the ownership/SSL TXT records.
+
+The custom hostname routes to the **originless fallback origin**; the **Worker
+Route** is what actually invokes the worker (which reads `Host` and resolves the
+tenant). Apex partner domains need CNAME-flattening/ALIAS or DNS on Cloudflare.
+
+## 5. Required Cloudflare API token scopes
+
+| Scope | Level | Needed for | Status |
+|---|---|---|---|
+| Workers Scripts → **Edit** | Account | deploy/manage the worker | ✅ (cfat_) |
+| DNS → **Edit** | Zone (cicilabel.com) | fallback-origin + subdomain records | ✅ (prod token) |
+| SSL and Certificates → **Edit** | Zone | custom hostnames + fallback origin | ✅ (prod token) |
+| **Workers Routes → Edit** | Zone | route custom hostnames → worker | ✅ (prod token) |
+| Zone → **Read** | Zone | metadata / zone-name lookup | ✅ |
+
+The **prod token** (`/jyt/prod/CLOUDFLARE_API_TOKEN`) now carries **DNS:Edit +
+SSL and Certificates:Edit + Workers Routes:Edit + Zone:Read** — it is the single
+automation token for the whole SaaS flow. (The mid-session `cfat_` = Workers
+Scripts + Zone:Read; `cfut_` = read-only — both superseded.)
+
+## 6. Current live state & remaining tails
+
+- ✅ Shared worker rebuilt + live (real multi-tenant app).
+- ✅ Vercel `storefront-shared`: empty `NEXT_PUBLIC_STRIPE_KEY` fixed to the live
+  SSM key + `STOREFRONT_REVALIDATE_SECRET` added, redeployed.
+- ✅ SaaS wired: fallback-origin DNS + zone fallback origin (`active`) + Worker
+  Route `hrhandloom.in/*` → worker. Ready to add the custom hostname (dashboard
+  or partner-ui once #1069 ships). Prod token has all edit scopes.
+- ✅ PR #1068 merged (guards). PR #1069 open (SaaS custom-hostname provider path
+  **+ per-partner scoped Worker Route create/delete**).
+- ⏳ After #1069 deploys: set `saas_fallback_origin=mt.cicilabel.com` +
+  `zone_name=cicilabel.com` on the CF deployment account (the admin validator
+  ships with #1069 — prod rejects the fields until then), and re-scope the
+  account token (add SSL:Edit + Workers Routes:Edit + DNS:Edit).
+- ⏳ `wrangler secret put STOREFRONT_REVALIDATE_SECRET` on the worker.
+- ⏳ Set `saas_fallback_origin=mt.cicilabel.com` on the deployment account so the
+  partner-ui "Add custom domain" flow drives SaaS once #1069 ships.
+- ⏳ Re-enable hr-handloom's storefront after #1068 backend deploys (re-attaches
+  its domain in shared mode).

--- a/apps/partner-ui/src/routes/settings/stores/stores.tsx
+++ b/apps/partner-ui/src/routes/settings/stores/stores.tsx
@@ -597,7 +597,10 @@ const CustomDomainSection = () => {
                   <InlineTip variant="info" label="Point Your Domain">
                     Add the DNS record{dnsRecords.length > 1 ? "s" : ""} below at
                     your domain provider so it resolves to your storefront. DNS
-                    changes can take up to 48 hours to propagate.
+                    changes can take up to 48 hours to propagate. For a root
+                    domain (e.g. example.com), use your provider's CNAME
+                    flattening / ALIAS / ANAME record — a plain CNAME isn't
+                    allowed at the root.
                   </InlineTip>
                   <DnsTable rows={dnsRecords} />
                 </>


### PR DESCRIPTION
## Why
Workers **Custom Domains** only accept hostnames inside *our* Cloudflare zone, so a partner's own apex (e.g. `hrhandloom.in`) could never attach to the shared worker — it stayed "Unverified" forever. Partner-owned domains need **Cloudflare for SaaS Custom Hostnames**.

## What
`CloudflareWorkersProvider` now branches on `shouldUseSaas(host)` (true only when a `saas_fallback_origin` is configured **and** the host is outside our zone):
- **addDomain** → `POST /zones/{zone}/custom_hostnames` (DV cert, HTTP validation); idempotent (reuses an existing hostname).
- **removeDomain** → deletes the custom hostname.
- **verifyDomain / describeDomain** → report status (`active` + cert `active`) and return the partner's **CNAME target** (→ `saas_fallback_origin`) plus ownership + SSL-validation records, so the partner-ui custom-domain card shows exactly what to add.
- In-zone hosts (`*.cicilabel.com`) keep using Workers Custom Domains — **unchanged** (34 provider unit tests still green).

Config: `api_config.saas_fallback_origin` / `zone_name` (admin validators) or `CLOUDFLARE_SAAS_FALLBACK_ORIGIN` env; the registry already passes non-secret keys through to `creds.extra`. **Backward-compatible** — no fallback origin ⇒ SaaS path is off.

## ⚠️ Ops prerequisites to go live (not code)
1. Enable **Cloudflare for SaaS** on the `cicilabel.com` zone (add-on).
2. Create the **fallback origin** — a proxied in-zone hostname (e.g. `mt.cicilabel.com`) routed to the shared worker — and set it as the zone's SaaS fallback origin; put its value in `saas_fallback_origin`.
3. Provision a CF token with **SSL and Certificates: Edit** + custom-hostname scope (the current `cfat_` token is Workers + Zone:Read only — every `custom_hostnames` call 403s).

Could not be validated against the live API for that reason; the request/response shapes follow the documented CF-for-SaaS custom_hostnames contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)