### PR TITLE
fix(storefront-hosting): unbreak prod build — `*/*` in JSDoc closed the comment

### DIFF
--- a/apps/backend/src/modules/deployment/providers/cloudflare-workers-provider.ts
+++ b/apps/backend/src/modules/deployment/providers/cloudflare-workers-provider.ts
@@ -305,9 +305,10 @@ export class CloudflareWorkersProvider implements HostingProvider {
    * SaaS custom hostnames are served via a **Worker Route**, not a Workers
    * Custom Domain — the custom hostname proxies to the (originless) fallback
    * origin and the route is what actually invokes the worker. Create a SCOPED
-   * `<hostname>/*` route (never `*/*`, which would hijack other in-zone hosts
-   * such as the `*.cicilabel.com` subdomains served by Vercel). Best-effort: the
-   * hostname still validates without it, so a failure here must not fail attach.
+   * per-hostname route, never a zone-wide wildcard route — a wildcard would
+   * hijack other in-zone hosts such as the cicilabel.com subdomains served by
+   * Vercel. Best-effort: the hostname still validates without it, so a failure
+   * here must not fail the attach.
    */
   private async ensureWorkerRoute(
     hostname: string,


### PR DESCRIPTION
## Hotfix — main is build-broken

#1069 merged with a literal `` `*/*` `` inside the `ensureWorkerRoute` JSDoc. The `*/` sequence **terminated the `/** … */` block comment early**, so the rest parsed as code and the class closed prematurely:
- `TS2420: CloudflareWorkersProvider incorrectly implements interface 'HostingProvider'` (missing createProject, setEnvVars, …)
- `TS1128: Declaration or statement expected`

`medusa build` fails → **Deploy to AWS ECS failed** for #1069, so prod is still on the pre-#1069 image (the SaaS code + `saas_fallback_origin` validator aren't live).

## Fix
Reword the comment to avoid the `*/` sequence. No logic change. Verified locally with `medusa build` — backend compiles clean.

(Root cause note: a project-level `tsc -p tsconfig.json` missed it due to incremental cache; the `check:prod-build` / `medusa build` gate catches it — that's the gate to trust.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)