### PR TITLE
fix(storefront-hosting): Workers Custom Domain attach must be PUT not POST

### DIFF
--- a/apps/backend/src/modules/deployment/providers/cloudflare-workers-provider.ts
+++ b/apps/backend/src/modules/deployment/providers/cloudflare-workers-provider.ts
@@ -515,10 +515,13 @@ export class CloudflareWorkersProvider implements HostingProvider {
     }
 
     try {
+      // Cloudflare's Workers Custom Domains API attaches via PUT (idempotent
+      // upsert), NOT POST — POST returns 405 "Method not allowed for this
+      // authentication scheme" and the subdomain silently never attaches.
       const result = await this.cf<CfWorkerDomain>(
         `${this.domainsBase()}`,
         {
-          method: "POST",
+          method: "PUT",
           headers: this.jsonHeaders(),
           body: JSON.stringify({
             hostname: domain,


### PR DESCRIPTION
## Bug
Backend logs on a partner storefront provision showed:
```
Cloudflare Workers addDomain failed (405): Method not allowed for this authentication scheme
```
`CloudflareWorkersProvider.addDomain` attaches in-zone subdomains via **POST** `/accounts/{acct}/workers/domains`, but Cloudflare's Workers-Custom-Domain attach endpoint is **PUT**. POST → 405. And `addDomain` **catches** the error and returns it inside the response (never throws), so provision/attach still returned `201` — the subdomain (`hr-handloom.cicilabel.com`) silently never attached (no Workers Custom Domain → no DNS → doesn't resolve).

## Fix
`POST` → `PUT`. Verified with `medusa build`. (`cfat_` can reach `workers/domains` — a GET succeeds — so only the method was wrong; no token change needed for the subdomain path.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)