### PR TITLE
feat(partner-mcp): inventory orders (Tier 6)

### DIFF
--- a/apps/backend/src/api/partners/mcp/lib/__tests__/dispatch.unit.spec.ts
+++ b/apps/backend/src/api/partners/mcp/lib/__tests__/dispatch.unit.spec.ts
@@ -234,6 +234,33 @@ describe("partner-mcp registry + dispatch", () => {
       expect(byName("describe_image").write).toBe(true)
       expect(isSensitive(byName("describe_image"))).toBe(false)
     })
+
+    it("covers inventory orders (Tier 6) — raw-material purchase-order lifecycle", () => {
+      const names = new Set(PARTNER_MCP_TOOLS.map((t) => t.name))
+      for (const n of [
+        "list_inventory_orders", "get_inventory_order",
+        "start_inventory_order", "submit_inventory_order_payment",
+        "get_inventory_order_shiprocket_rates",
+        "get_inventory_order_fulfillment_rates",
+        "ready_inventory_order_for_delivery",
+        "create_inventory_order_shipment",
+        "complete_inventory_order",
+      ]) {
+        expect(names.has(n)).toBe(true)
+      }
+      const byName = (n: string) => PARTNER_MCP_TOOLS.find((t) => t.name === n)!
+      // Money/reversal/state-changing ops require confirmation.
+      expect(isSensitive(byName("submit_inventory_order_payment"))).toBe(true)
+      expect(isSensitive(byName("ready_inventory_order_for_delivery"))).toBe(true)
+      expect(isSensitive(byName("create_inventory_order_shipment"))).toBe(true)
+      expect(isSensitive(byName("complete_inventory_order"))).toBe(true)
+      // Start is a routine state advance (no money).
+      expect(isSensitive(byName("start_inventory_order"))).toBe(false)
+      expect(byName("start_inventory_order").write).toBe(true)
+      // Rates are reads.
+      expect(byName("get_inventory_order_shiprocket_rates").method).toBe("GET")
+      expect(byName("get_inventory_order_fulfillment_rates").method).toBe("GET")
+    })
   })
 
   it("returns a soft error for an unknown tool", async () => {

--- a/apps/backend/src/api/partners/mcp/lib/registry.ts
+++ b/apps/backend/src/api/partners/mcp/lib/registry.ts
@@ -1745,4 +1745,167 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
       ["imageUrl"]
     ),
   },
+
+  // ===== Inventory orders (Tier 6) — raw-material purchase orders ============
+  // The partner's own purchase orders for raw materials / inventory. Lifecycle:
+  //   list → get → start → (submit-payment) → shiprocket-rates / ready-for-delivery
+  //   → shipment → complete
+  {
+    name: "list_inventory_orders",
+    description:
+      "List the partner's inventory (purchase) orders — raw-material purchases from suppliers. Paginated, free-text search via q, optional status filter.",
+    method: "GET",
+    path: "/partners/inventory-orders",
+    queryParams: ["limit", "offset", "q", "status"],
+    inputSchema: obj({
+      ...PAGINATION,
+      status: STR("Optional status filter."),
+    }),
+  },
+  {
+    name: "get_inventory_order",
+    description: "Get a single inventory (purchase) order by id, with its lines and supplier.",
+    method: "GET",
+    path: "/partners/inventory-orders/:orderId",
+    pathParams: ["orderId"],
+    inputSchema: obj({ orderId: STR("Inventory order id.") }, ["orderId"]),
+  },
+  {
+    name: "start_inventory_order",
+    description:
+      "Start an inventory (purchase) order — moves it from draft/placed into in-progress (supplier is making/shipping). Body follows the route validator.",
+    method: "POST",
+    path: "/partners/inventory-orders/:orderId/start",
+    pathParams: ["orderId"],
+    write: true,
+    previewPath: "/partners/inventory-orders/:orderId",
+    bodyParams: ["metadata"],
+    inputSchema: obj(
+      {
+        orderId: STR("Inventory order id to start."),
+        metadata: { type: "object", additionalProperties: true },
+      },
+      ["orderId"]
+    ),
+  },
+  {
+    name: "submit_inventory_order_payment",
+    description:
+      "Record a payment made to a supplier for an inventory order (Bank/Cash/Digital_Wallet), with optional receipts. Sensitive — moves/reconciles money. Supports an idempotency_key for safe retries.",
+    method: "POST",
+    path: "/partners/inventory-orders/:orderId/submit-payment",
+    pathParams: ["orderId"],
+    write: true,
+    sensitive: true,
+    previewPath: "/partners/inventory-orders/:orderId",
+    bodyParams: [
+      "amount", "payment_type", "payment_date", "note",
+      "paid_to_id", "attachments", "idempotency_key",
+    ],
+    inputSchema: obj(
+      {
+        orderId: STR("Inventory order id."),
+        amount: { type: "number", description: "Amount paid (> 0). Required." },
+        payment_type: {
+          type: "string",
+          enum: ["Bank", "Cash", "Digital_Wallet"],
+          description: "How the supplier was paid.",
+        },
+        payment_date: STR("ISO date the payment was made."),
+        note: STR("Optional note."),
+        paid_to_id: STR("Optional recipient id."),
+        attachments: { type: "array", description: "Receipt/invoice file attachments.", items: { type: "object", additionalProperties: true } },
+        idempotency_key: STR("Optional idempotency key to dedupe retries."),
+      },
+      ["orderId", "amount"]
+    ),
+  },
+  {
+    name: "get_inventory_order_shiprocket_rates",
+    description:
+      "Get live Shiprocket shipping rates/quotes for an inventory order (carrier options + cost). Read.",
+    method: "GET",
+    path: "/partners/inventory-orders/:orderId/shiprocket-rates",
+    pathParams: ["orderId"],
+    inputSchema: obj({ orderId: STR("Inventory order id.") }, ["orderId"]),
+  },
+  {
+    name: "get_inventory_order_fulfillment_rates",
+    description:
+      "Alias for get_inventory_order_shiprocket_rates (fulfillment-rate quotes). Read.",
+    method: "GET",
+    path: "/partners/inventory-orders/:orderId/fulfillment-rates",
+    pathParams: ["orderId"],
+    inputSchema: obj({ orderId: STR("Inventory order id.") }, ["orderId"]),
+  },
+  {
+    name: "ready_inventory_order_for_delivery",
+    description:
+      "Mark an inventory order ready for delivery / pickup. Sensitive — changes the order's fulfillment state. Body follows the route validator.",
+    method: "POST",
+    path: "/partners/inventory-orders/:orderId/ready-for-delivery",
+    pathParams: ["orderId"],
+    write: true,
+    sensitive: true,
+    previewPath: "/partners/inventory-orders/:orderId",
+    bodyParams: ["metadata"],
+    inputSchema: obj(
+      {
+        orderId: STR("Inventory order id."),
+        metadata: { type: "object", additionalProperties: true },
+      },
+      ["orderId"]
+    ),
+  },
+  {
+    name: "create_inventory_order_shipment",
+    description:
+      "Create a shipment for an inventory order (book the carrier, optionally set pickup location/weight/dimensions/delivered quantities). Body follows the shipment route. Sensitive — books shipping and changes fulfillment state.",
+    method: "POST",
+    path: "/partners/inventory-orders/:orderId/shipment",
+    pathParams: ["orderId"],
+    write: true,
+    sensitive: true,
+    previewPath: "/partners/inventory-orders/:orderId",
+    bodyParams: [
+      "carrier", "pickup_stock_location_id", "weight_grams",
+      "dimensions_cm", "preferred_courier_id", "delivered_quantities", "pickup_date",
+    ],
+    inputSchema: obj(
+      {
+        orderId: STR("Inventory order id to ship."),
+        carrier: STR("Optional carrier override."),
+        pickup_stock_location_id: STR("Stock location to pick up from."),
+        weight_grams: { type: "number", description: "Shipment weight in grams." },
+        dimensions_cm: {
+          type: "object",
+          description: "Optional { length, breadth, height } in cm.",
+          additionalProperties: true,
+        },
+        preferred_courier_id: STR("Optional preferred courier id."),
+        delivered_quantities: { type: "object", description: "Map of line id -> delivered qty.", additionalProperties: true },
+        pickup_date: STR("Requested pickup date (YYYY-MM-DD)."),
+      },
+      ["orderId"]
+    ),
+  },
+  {
+    name: "complete_inventory_order",
+    description:
+      "Complete an inventory (purchase) order — final state, goods received. Sensitive — closes out the order. Body follows the route validator.",
+    method: "POST",
+    path: "/partners/inventory-orders/:orderId/complete",
+    pathParams: ["orderId"],
+    write: true,
+    sensitive: true,
+    previewPath: "/partners/inventory-orders/:orderId",
+    bodyParams: ["metadata"],
+    inputSchema: obj(
+      {
+        orderId: STR("Inventory order id to complete."),
+        metadata: { type: "object", additionalProperties: true },
+      },
+      ["orderId"]
+    ),
+  },
 ]


### PR DESCRIPTION
## Summary

You flagged a gap: the partner's **raw-material purchase-order (inventory orders) surface** was missing from the catalog entirely. This tier adds it on top of the now-merged Tiers 1–5.

## Added tools (9)
```
list_inventory_orders          get_inventory_order
start_inventory_order
submit_inventory_order_payment   (sensitive — records supplier payment)
get_inventory_order_shiprocket_rates      (read)
get_inventory_order_fulfillment_rates    (read alias)
ready_inventory_order_for_delivery        (sensitive — state)
create_inventory_order_shipment           (sensitive — books shipping)
complete_inventory_order                  (sensitive — closes the order)
```

## Lifecycle
`list → get → start → (submit-payment) → shiprocket-rates / ready-for-delivery → shipment → complete`

## Safety
- **Sensitive (`confirm: true`):** `submit_inventory_order_payment` (money + `idempotency_key`), `ready_inventory_order_for_delivery`, `create_inventory_order_shipment`, `complete_inventory_order`.
- **Routine write:** `start_inventory_order` (state advance, no money).
- **Reads:** the two rates endpoints.

Sensitive writes carry a `previewPath` so `dry_run` shows the current order before approval. Body schemas stay permissive (route validator is source of truth).

## Tests
`dispatch.unit.spec.ts` +1 assertion for the inventory-order lifecycle + sensitivity flags. 17 pass.

## Note
Tiers 1–5 (#1063–#1067) are merged; this rebases cleanly onto `main` (one commit) and targets `main` directly.