### PR TITLE
fix(partner-storefront): repair custom-domain lifecycle + move domain out of metadata

### DIFF
--- a/apps/backend/src/api/partners/storefront/domain/route.ts
+++ b/apps/backend/src/api/partners/storefront/domain/route.ts
@@ -12,6 +12,8 @@ import updatePartnerWorkflow from "../../../../workflows/partners/update-partner
 import {
   attachStorefrontDomainWorkflow,
   deriveDomainPair,
+  partnerCustomDomain,
+  partnerCustomDomainVerified,
 } from "../../../../workflows/partners/attach-storefront-domain"
 
 /**
@@ -42,28 +44,33 @@ export const GET = async (
     )
   }
 
-  const customDomain = partner.metadata?.custom_domain as string | undefined
+  const customDomain = partnerCustomDomain(partner)
   if (!customDomain) {
     return res.json({ configured: false })
   }
 
   const pair = deriveDomainPair(customDomain)
+  const verified = partnerCustomDomainVerified(partner)
 
   try {
     const primary = await provider.describeDomain(projectRef, pair.primary)
     const records = [...primary.dnsRecords]
+    let verification = primary.verification ?? null
     if (pair.counterpart) {
       const twin = await provider.describeDomain(projectRef, pair.counterpart)
       records.push(...twin.dnsRecords)
+      if ((!verification || !verification.length) && twin.verification?.length) {
+        verification = twin.verification
+      }
     }
     return res.json({
       configured: true,
       domain: customDomain,
       redirect_from: pair.counterpart,
-      verified: partner.metadata?.custom_domain_verified === true,
+      verified,
       misconfigured: primary.misconfigured,
       configured_by: primary.configuredBy ?? null,
-      verification: primary.verification ?? null,
+      verification,
       dns_records: records,
     })
   } catch {
@@ -71,7 +78,7 @@ export const GET = async (
       configured: true,
       domain: customDomain,
       redirect_from: pair.counterpart,
-      verified: partner.metadata?.custom_domain_verified === true,
+      verified,
       misconfigured: true,
       configured_by: null,
       dns_records: [],
@@ -130,7 +137,6 @@ export const POST = async (
       partner_id: partner.id,
       website_id: websiteId,
       domain: cleaned,
-      prev_metadata: (partner.metadata || {}) as Record<string, any>,
     },
   })
 
@@ -159,6 +165,7 @@ export const POST = async (
     misconfigured,
     configured_by: configuredBy,
     dns_records: dnsRecords,
+    error: result.error || null,
   })
 }
 
@@ -182,7 +189,7 @@ export const DELETE = async (
     partner,
     req.scope
   )
-  const customDomain = partner.metadata?.custom_domain as string | undefined
+  const customDomain = partnerCustomDomain(partner)
 
   if (!projectRef || !customDomain) {
     throw new MedusaError(
@@ -191,20 +198,23 @@ export const DELETE = async (
     )
   }
 
-  // Remove BOTH hosts (primary + its www/apex twin — see deriveDomainPair)
+  // Remove BOTH hosts (primary + its www/apex twin — see deriveDomainPair).
+  // Collect failures instead of swallowing them: a silently-failed provider
+  // removal is exactly what leaves a "removed" domain still resolving.
   const pair = deriveDomainPair(customDomain)
   const hosts = [pair.primary, pair.counterpart].filter(
     (h): h is string => !!h
   )
+  const warnings: string[] = []
   for (const host of hosts) {
     try {
       await provider.removeDomain(projectRef, host)
-    } catch {
-      // best-effort removal
+    } catch (e: any) {
+      warnings.push(`${host}: ${e?.message || e}`)
     }
   }
 
-  // Clear from metadata
+  // Clear the typed columns (and strip any legacy metadata copy).
   const meta = { ...(partner.metadata || {}) }
   delete meta.custom_domain
   delete meta.custom_domain_verified
@@ -212,7 +222,11 @@ export const DELETE = async (
   await updatePartnerWorkflow(req.scope).run({
     input: {
       id: partner.id,
-      data: { metadata: meta },
+      data: {
+        custom_domain: null,
+        custom_domain_verified: false,
+        metadata: meta,
+      },
     },
   })
 
@@ -233,5 +247,8 @@ export const DELETE = async (
     // best-effort
   }
 
-  res.json({ message: "Custom domain removed" })
+  res.json({
+    message: "Custom domain removed",
+    ...(warnings.length ? { warnings } : {}),
+  })
 }

--- a/apps/backend/src/api/partners/storefront/domain/verify/route.ts
+++ b/apps/backend/src/api/partners/storefront/domain/verify/route.ts
@@ -8,6 +8,10 @@ import { DEPLOYMENT_MODULE } from "../../../../../modules/deployment"
 import type DeploymentService from "../../../../../modules/deployment/service"
 import { resolveHostingProviderForPartner } from "../../../../../modules/deployment/providers/resolve-partner-provider"
 import updatePartnerWorkflow from "../../../../../workflows/partners/update-partner"
+import {
+  deriveDomainPair,
+  partnerCustomDomain,
+} from "../../../../../workflows/partners/attach-storefront-domain"
 
 /**
  * POST /partners/storefront/domain/verify
@@ -39,7 +43,7 @@ export const POST = async (
 
   const { providerName, provider, projectRef } =
     await resolveHostingProviderForPartner(partner, req.scope)
-  const customDomain = partner.metadata?.custom_domain as string | undefined
+  const customDomain = partnerCustomDomain(partner)
 
   if (!projectRef || !customDomain) {
     throw new MedusaError(
@@ -48,43 +52,80 @@ export const POST = async (
     )
   }
 
-  // Vercel-only: apply Vercel's recommended DNS via Cloudflare. No-op for
-  // domains outside our zone; skipped entirely for non-Vercel providers.
+  const pair = deriveDomainPair(customDomain)
+  const healErrors: string[] = []
   let applied: any = null
+
   if (providerName === "vercel") {
+    // Vercel-only: apply Vercel's recommended DNS via Cloudflare. No-op for
+    // domains outside our zone.
     const deployment: DeploymentService = req.scope.resolve(DEPLOYMENT_MODULE)
     applied = await deployment.applyRecommendedDns(customDomain)
+  } else {
+    // Self-heal: idempotently (re)attach each host. `addDomain` reuses an
+    // existing provider hostname or creates a missing one — so a domain that
+    // was saved before its custom hostname existed (the classic "added during a
+    // broken window, then Check Status only ever *verified*, never *created*")
+    // gets recreated here instead of sitting unverifiable forever.
+    const hosts = [pair.primary, pair.counterpart].filter(
+      (h): h is string => !!h
+    )
+    for (const host of hosts) {
+      try {
+        const r = await provider.addDomain(
+          projectRef,
+          host,
+          host === pair.primary
+            ? undefined
+            : { redirect: pair.primary, redirectStatusCode: 308 }
+        )
+        if (r?.error) healErrors.push(`${host}: ${r.error}`)
+      } catch (e: any) {
+        healErrors.push(`${host}: ${e?.message || e}`)
+      }
+    }
   }
 
-  // Verify after applying so a successful CF write can flip verified=true in
-  // the same call (subject to the provider's propagation window).
-  const result = await provider.verifyDomain(projectRef, customDomain)
+  // Verify after (re)attaching so a freshly-created/validated hostname can flip
+  // verified=true in the same call (subject to the propagation window).
+  const result = await provider.verifyDomain(projectRef, pair.primary)
 
   if (result.verified) {
     await updatePartnerWorkflow(req.scope).run({
       input: {
         id: partner.id,
-        data: {
-          metadata: {
-            ...(partner.metadata || {}),
-            custom_domain_verified: true,
-          },
-        },
+        data: { custom_domain_verified: true },
       },
     })
   }
 
-  const status = await provider
-    .describeDomain(projectRef, customDomain)
+  // Aggregate status + DNS/verification records across the apex/www pair.
+  const primaryStatus = await provider
+    .describeDomain(projectRef, pair.primary)
     .catch(() => null)
+  const records = [...(primaryStatus?.dnsRecords ?? [])]
+  let verification =
+    result.verification || primaryStatus?.verification || []
+  if (pair.counterpart) {
+    const twin = await provider
+      .describeDomain(projectRef, pair.counterpart)
+      .catch(() => null)
+    if (twin) {
+      records.push(...twin.dnsRecords)
+      if (!verification.length && twin.verification?.length) {
+        verification = twin.verification
+      }
+    }
+  }
 
   res.json({
     domain: customDomain,
     verified: result.verified,
-    verification: result.verification || null,
-    misconfigured: status?.misconfigured ?? true,
-    configured_by: status?.configuredBy ?? null,
+    verification,
+    misconfigured: primaryStatus?.misconfigured ?? true,
+    configured_by: primaryStatus?.configuredBy ?? null,
     applied,
-    dns_records: status?.dnsRecords ?? [],
+    dns_records: records,
+    ...(healErrors.length ? { error: healErrors.join("; ") } : {}),
   })
 }

--- a/apps/backend/src/api/web/website/[domain]/marketing/partners/route.ts
+++ b/apps/backend/src/api/web/website/[domain]/marketing/partners/route.ts
@@ -8,6 +8,8 @@ type RawPartner = {
   logo: string | null
   workspace_type: "seller" | "manufacturer" | "individual" | "designer"
   storefront_domain: string | null
+  custom_domain: string | null
+  custom_domain_verified: boolean
   vercel_linked: boolean
   metadata: Record<string, unknown> | null
 }
@@ -52,6 +54,8 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
       "logo",
       "workspace_type",
       "storefront_domain",
+      "custom_domain",
+      "custom_domain_verified",
       "vercel_linked",
       "metadata",
     ],
@@ -89,9 +93,14 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
         // optional verified alias. Prefer the verified custom domain as
         // storefront_url when present so links in marketing UI point at
         // the partner's branded host.
+        // Prefer the typed columns; fall back to legacy metadata for any
+        // not-yet-migrated row.
         const customDomain =
-          typeof meta.custom_domain === "string" ? meta.custom_domain : null
-        const customVerified = meta.custom_domain_verified === true
+          (typeof p.custom_domain === "string" && p.custom_domain) ||
+          (typeof meta.custom_domain === "string" ? meta.custom_domain : null)
+        const customVerified =
+          p.custom_domain_verified === true ||
+          (!p.custom_domain && meta.custom_domain_verified === true)
         const primaryHost =
           customDomain && customVerified ? customDomain : p.storefront_domain!
 

--- a/apps/backend/src/modules/deployment/providers/cloudflare-workers-provider.ts
+++ b/apps/backend/src/modules/deployment/providers/cloudflare-workers-provider.ts
@@ -550,36 +550,60 @@ export class CloudflareWorkersProvider implements HostingProvider {
     projectName: string,
     domain: string
   ): Promise<void> {
-    // Partner-owned domain → delete its SaaS Custom Hostname + Worker Route.
-    if (await this.shouldUseSaas(domain)) {
+    // A host can have been attached via EITHER path — a SaaS Custom Hostname
+    // (partner-owned domains) or a Workers Custom Domain (in-zone subdomains) —
+    // and which one was used may differ from what `shouldUseSaas` reports now
+    // (config changed, or the attach happened under an older code path). So we
+    // tear down BOTH, idempotently: this is what keeps a "removed" domain from
+    // lingering in Cloudflare and still resolving.
+    const errors: string[] = []
+
+    // 1. SaaS Custom Hostname + its scoped `<host>/*` Worker Route.
+    if (this.zoneId) {
       await this.removeWorkerRoute(domain)
-      const ch = await this.findCustomHostname(domain)
-      if (!ch) return
-      const res = await fetch(`${this.zoneBase()}/custom_hostnames/${ch.id}`, {
-        method: "DELETE",
-        headers: this.jsonHeaders(),
-      })
-      if (!res.ok && res.status !== 404) {
-        throw new Error(
-          `Cloudflare removeDomain (custom hostname) failed (${res.status}): ${await res.text()}`
-        )
+      try {
+        const ch = await this.findCustomHostname(domain)
+        if (ch) {
+          const res = await fetch(
+            `${this.zoneBase()}/custom_hostnames/${ch.id}`,
+            { method: "DELETE", headers: this.jsonHeaders() }
+          )
+          if (!res.ok && res.status !== 404) {
+            errors.push(
+              `custom hostname (${res.status}): ${await res
+                .text()
+                .catch(() => res.statusText)}`
+            )
+          }
+        }
+      } catch (e: any) {
+        errors.push(`custom hostname: ${e?.message || e}`)
       }
-      return
     }
 
-    // List domains scoped to this service, find the matching one, delete by id.
-    const domains = await this.listServiceDomains(projectName)
-    const match = domains.find((d) => d.hostname === domain)
-    if (!match) return // already gone
+    // 2. Workers Custom Domain entry scoped to this service.
+    try {
+      const domains = await this.listServiceDomains(projectName)
+      const match = domains.find((d) => d.hostname === domain)
+      if (match) {
+        const res = await fetch(`${this.domainsBase()}/${match.id}`, {
+          method: "DELETE",
+          headers: this.jsonHeaders(),
+        })
+        if (!res.ok && res.status !== 404) {
+          errors.push(
+            `workers domain (${res.status}): ${await res
+              .text()
+              .catch(() => res.statusText)}`
+          )
+        }
+      }
+    } catch (e: any) {
+      errors.push(`workers domain: ${e?.message || e}`)
+    }
 
-    const res = await fetch(`${this.domainsBase()}/${match.id}`, {
-      method: "DELETE",
-      headers: this.jsonHeaders(),
-    })
-    if (!res.ok && res.status !== 404) {
-      throw new Error(
-        `Cloudflare Workers removeDomain failed (${res.status}): ${await res.text()}`
-      )
+    if (errors.length) {
+      throw new Error(`Cloudflare removeDomain failed: ${errors.join("; ")}`)
     }
   }
 

--- a/apps/backend/src/modules/partner/migrations/Migration20260718120000.ts
+++ b/apps/backend/src/modules/partner/migrations/Migration20260718120000.ts
@@ -1,0 +1,76 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Promote the partner's custom domain out of `metadata` into typed columns
+ * (`custom_domain`, `custom_domain_verified`).
+ *
+ * Hand-written (Claude-owned) migration. The custom domain is load-bearing —
+ * it drives the storefront domain-status API, host resolution and the
+ * marketing-base derivation — so it belongs in typed columns, not the JSON
+ * `metadata` blob (mirrors the `tax_id` / `country_code` convention on this
+ * model). Uses `add column if not exists` per the repo "migration
+ * create-if-not-exists hazard".
+ *
+ * Data move: copy `metadata.custom_domain` / `metadata.custom_domain_verified`
+ * into the new columns for existing partners, then strip those two keys from
+ * metadata so the domain lives in exactly one place. Migrations run (gated)
+ * ahead of the new code rolling, so the columns are populated before any
+ * reader depends on them.
+ */
+export class Migration20260718120000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(
+      `alter table if exists "partner" add column if not exists "custom_domain" text null;`
+    );
+    this.addSql(
+      `alter table if exists "partner" add column if not exists "custom_domain_verified" boolean not null default false;`
+    );
+
+    // Backfill from metadata (JSONB) for existing partners. Uses the
+    // `jsonb_exists()` function rather than the `?` operator, which collides
+    // with SQL bind-placeholder handling in the migration driver.
+    this.addSql(
+      `update "partner"
+         set "custom_domain" = "metadata"->>'custom_domain'
+       where "custom_domain" is null
+         and "metadata" is not null
+         and coalesce("metadata"->>'custom_domain', '') <> '';`
+    );
+    this.addSql(
+      `update "partner"
+         set "custom_domain_verified" = true
+       where "metadata" is not null
+         and ("metadata"->>'custom_domain_verified') = 'true';`
+    );
+
+    // Strip the migrated keys so the domain lives only in the typed columns.
+    this.addSql(
+      `update "partner"
+         set "metadata" = ("metadata" - 'custom_domain' - 'custom_domain_verified')
+       where "metadata" is not null
+         and (jsonb_exists("metadata", 'custom_domain')
+              or jsonb_exists("metadata", 'custom_domain_verified'));`
+    );
+  }
+
+  override async down(): Promise<void> {
+    // Restore the keys into metadata before dropping the columns (best-effort).
+    this.addSql(
+      `update "partner"
+         set "metadata" = coalesce("metadata", '{}'::jsonb)
+           || jsonb_build_object(
+                'custom_domain', "custom_domain",
+                'custom_domain_verified', "custom_domain_verified"
+              )
+       where "custom_domain" is not null;`
+    );
+    this.addSql(
+      `alter table if exists "partner" drop column if exists "custom_domain_verified";`
+    );
+    this.addSql(
+      `alter table if exists "partner" drop column if exists "custom_domain";`
+    );
+  }
+
+}

--- a/apps/backend/src/modules/partner/models/partner.ts
+++ b/apps/backend/src/modules/partner/models/partner.ts
@@ -42,6 +42,14 @@ const Partner = model.define("partner", {
 
     // Storefront
     storefront_domain: model.text().nullable(),
+    // The partner's own connected custom domain (apex/primary form, e.g.
+    // "hrhandloom.in"), distinct from `storefront_domain` (the provisioned
+    // platform subdomain). Typed columns NOT metadata — load-bearing for the
+    // domain status API, host resolution, and marketing-base derivation. The
+    // www/apex twin is derived (see deriveDomainPair) and registered as a
+    // `website_domain` alias; only the canonical host is stored here.
+    custom_domain: model.text().nullable(),
+    custom_domain_verified: model.boolean().default(false),
     website_id: model.text().nullable(),
     vercel_project_id: model.text().nullable(),
     vercel_project_name: model.text().nullable(),

--- a/apps/backend/src/scripts/set-storefront-base-url.ts
+++ b/apps/backend/src/scripts/set-storefront-base-url.ts
@@ -102,7 +102,9 @@ export default async function setStorefrontBaseUrl({ container }: ExecArgs) {
         .filter((n) => !n.endsWith(".cicilabel.com") && !n.endsWith(".vercel.app"))
 
       const customDomain = String(
-        (partner as any).metadata?.custom_domain || ""
+        (partner as any).custom_domain ||
+          (partner as any).metadata?.custom_domain ||
+          ""
       ).toLowerCase()
       const preferred = candidates.find(
         (c) => c === customDomain || c === twin(customDomain)

--- a/apps/backend/src/workflows/google_merchant/steps/resolve-partner-landing-base.ts
+++ b/apps/backend/src/workflows/google_merchant/steps/resolve-partner-landing-base.ts
@@ -47,13 +47,16 @@ export function normalizeLandingBase(value?: string | null): string | null {
 export function partnerBaseFromRecord(
   partner: {
     storefront_domain?: string | null
+    custom_domain?: string | null
     metadata?: Record<string, any> | null
   } | null | undefined
 ): string | null {
   if (!partner) return null
   const meta = partner.metadata || {}
+  // Prefer the typed `custom_domain` column; fall back to the legacy
+  // metadata copy for any row not yet migrated.
   return (
-    normalizeLandingBase(meta.custom_domain) ||
+    normalizeLandingBase(partner.custom_domain || meta.custom_domain) ||
     normalizeLandingBase(meta.website_domain) ||
     normalizeLandingBase(partner.storefront_domain)
   )
@@ -96,7 +99,7 @@ export async function resolvePartnerStorefrontForSalesChannel(
     //    dot-paths, so match owner in JS (mirrors resolvePartnerLandingBase).
     const { data: partners } = await query.graph({
       entity: "partners",
-      fields: ["id", "name", "handle", "storefront_domain", "metadata", "stores.id"],
+      fields: ["id", "name", "handle", "storefront_domain", "custom_domain", "metadata", "stores.id"],
     } as any)
     const owner = (partners ?? []).find((p: any) =>
       (p?.stores ?? []).some((st: any) => storeIds.has(st?.id))
@@ -149,7 +152,7 @@ export async function resolvePartnerLandingBase(
     //    and match in JS (mirrors propagate-region-to-partners).
     const { data: partners } = await query.graph({
       entity: "partners",
-      fields: ["id", "storefront_domain", "metadata", "stores.id"],
+      fields: ["id", "storefront_domain", "custom_domain", "metadata", "stores.id"],
     } as any)
     const owner = (partners ?? []).find((p: any) =>
       (p?.stores ?? []).some((st: any) => storeIds.has(st?.id))

--- a/apps/backend/src/workflows/partners/attach-storefront-domain.ts
+++ b/apps/backend/src/workflows/partners/attach-storefront-domain.ts
@@ -46,13 +46,31 @@ export function deriveDomainPair(domain: string): DomainPair {
   return { primary: domain, counterpart: null }
 }
 
+/**
+ * Read a partner's connected custom domain. Prefers the typed `custom_domain`
+ * column; falls back to the legacy `metadata.custom_domain` so a reader that
+ * runs during the deploy window (migration done, old rows) still resolves.
+ */
+export function partnerCustomDomain(partner: any): string | undefined {
+  const col = partner?.custom_domain
+  if (typeof col === "string" && col) return col
+  const meta = partner?.metadata?.custom_domain
+  return typeof meta === "string" && meta ? meta : undefined
+}
+
+export function partnerCustomDomainVerified(partner: any): boolean {
+  if (partner?.custom_domain_verified === true) return true
+  // Only trust the legacy metadata flag when the column hasn't taken over yet.
+  if (partner?.custom_domain) return partner.custom_domain_verified === true
+  return partner?.metadata?.custom_domain_verified === true
+}
+
 export type AttachStorefrontDomainInput = {
   partner_id: string
   /** @deprecated kept for callers; the provider + project ref are now resolved from the partner. */
   vercel_project_id?: string
   website_id: string | null
   domain: string
-  prev_metadata: Record<string, any>
 }
 
 /** Is this provider error just "the domain is already on this project"? */
@@ -83,11 +101,17 @@ const addProviderDomainPairStep = createStep(
     const created: string[] = []
     let verified = false
     let verification: any = null
+    // The Cloudflare provider swallows attach failures (returns `{error}`
+    // instead of throwing) so one bad host can't abort the whole attach. Carry
+    // that reason up to the caller so the partner sees *why* nothing attached
+    // rather than a domain stuck silently unverified with no DNS records.
+    let error: string | null = null
 
     try {
       const res = await provider.addDomain(projectRef, input.pair.primary)
       verified = !!res.verified
       verification = res.verification || null
+      error = res.error || null
       created.push(input.pair.primary)
     } catch (e: any) {
       if (!isAlreadyAttached(String(e?.message || ""))) throw e
@@ -116,10 +140,10 @@ const addProviderDomainPairStep = createStep(
     }
 
     return new StepResponse<
-      { verified: boolean; verification: any; created: string[] },
+      { verified: boolean; verification: any; created: string[]; error: string | null },
       ProviderPairComp
     >(
-      { verified, verification, created },
+      { verified, verification, created, error },
       { partner_id: input.partner_id, created }
     )
   },
@@ -187,38 +211,48 @@ const setBaseUrlEnvStep = createStep(
   }
 )
 
-type MetadataComp = { partner_id: string; prev_metadata: Record<string, any> }
-const updatePartnerDomainMetadataStep = createStep(
-  "asd-update-partner-metadata",
+type DomainColumnComp = {
+  partner_id: string
+  prev_domain: string | null
+  prev_verified: boolean
+}
+const updatePartnerDomainStep = createStep(
+  "asd-update-partner-domain",
   async (
     input: {
       partner_id: string
-      prev_metadata: Record<string, any>
       domain: string
       verified: boolean
     },
     { container }
   ) => {
+    // Typed columns, NOT metadata (#no-critical-data-in-metadata) — the custom
+    // domain is load-bearing for the status API + host resolution.
     const partnerService: any = container.resolve(PARTNER_MODULE)
+    const prev = await partnerService
+      .retrievePartner(input.partner_id)
+      .catch(() => null)
     await partnerService.updatePartners({
       id: input.partner_id,
-      metadata: {
-        ...(input.prev_metadata || {}),
-        custom_domain: input.domain,
-        custom_domain_verified: input.verified,
-      },
+      custom_domain: input.domain,
+      custom_domain_verified: input.verified,
     })
-    return new StepResponse<{ ok: boolean }, MetadataComp>(
+    return new StepResponse<{ ok: boolean }, DomainColumnComp>(
       { ok: true },
-      { partner_id: input.partner_id, prev_metadata: input.prev_metadata }
+      {
+        partner_id: input.partner_id,
+        prev_domain: prev?.custom_domain ?? null,
+        prev_verified: prev?.custom_domain_verified ?? false,
+      }
     )
   },
-  async (comp: MetadataComp | undefined, { container }) => {
+  async (comp: DomainColumnComp | undefined, { container }) => {
     if (!comp) return
     const partnerService: any = container.resolve(PARTNER_MODULE)
     await partnerService.updatePartners({
       id: comp.partner_id,
-      metadata: comp.prev_metadata,
+      custom_domain: comp.prev_domain,
+      custom_domain_verified: comp.prev_verified,
     })
   }
 )
@@ -286,13 +320,12 @@ export const attachStorefrontDomainWorkflow = createWorkflow(
     }))
     setBaseUrlEnvStep(envInput)
 
-    const metaInput = transform({ input, pair, attached }, (d) => ({
+    const domainInput = transform({ input, pair, attached }, (d) => ({
       partner_id: d.input.partner_id,
-      prev_metadata: d.input.prev_metadata,
       domain: d.pair.primary,
       verified: d.attached.verified,
     }))
-    updatePartnerDomainMetadataStep(metaInput)
+    updatePartnerDomainStep(domainInput)
 
     const aliasInput = transform({ input, pair }, (d) => ({
       website_id: d.input.website_id,
@@ -305,6 +338,7 @@ export const attachStorefrontDomainWorkflow = createWorkflow(
       counterpart: d.pair.counterpart,
       verified: d.attached.verified,
       verification: d.attached.verification,
+      error: d.attached.error,
       created_aliases: d.aliases.created,
     }))
 

--- a/apps/backend/src/workflows/partners/update-partner.ts
+++ b/apps/backend/src/workflows/partners/update-partner.ts
@@ -20,6 +20,8 @@ export type UpdatePartnerInput = {
     metadata: Record<string, any> | null
     website_id: string | null
     storefront_domain: string | null
+    custom_domain: string | null
+    custom_domain_verified: boolean
     vercel_project_id: string | null
     vercel_project_name: string | null
     vercel_last_deployment_id: string | null

--- a/apps/partner-ui/src/hooks/api/storefront.ts
+++ b/apps/partner-ui/src/hooks/api/storefront.ts
@@ -134,6 +134,14 @@ export interface AddDomainResponse {
   misconfigured: boolean
   configured_by: string | null
   dns_records?: DnsRecord[]
+  /** Provider attach/heal error (e.g. Cloudflare rejected the hostname). */
+  error?: string | null
+}
+
+export interface RemoveDomainResponse {
+  message: string
+  /** Provider hosts that couldn't be fully torn down (still resolving). */
+  warnings?: string[]
 }
 
 export const useStorefrontDomain = (
@@ -182,7 +190,7 @@ export const useVerifyStorefrontDomain = () => {
 export const useRemoveStorefrontDomain = () => {
   return useMutation({
     mutationFn: () =>
-      sdk.client.fetch<{ message: string }>("/partners/storefront/domain", {
+      sdk.client.fetch<RemoveDomainResponse>("/partners/storefront/domain", {
         method: "DELETE",
       }),
     onSuccess: () => {

--- a/apps/partner-ui/src/routes/settings/stores/stores.tsx
+++ b/apps/partner-ui/src/routes/settings/stores/stores.tsx
@@ -438,11 +438,19 @@ const CustomDomainSection = () => {
       const result = await addDomain({ domain: value })
       setAddResult(result)
       setDomainInput("")
-      toast.success("Domain added", {
-        description: result.verified
-          ? "Domain verified. Configure your DNS to point it to your storefront."
-          : "Domain added. Follow the verification steps below.",
-      })
+      if (result.error) {
+        // The domain was saved but the provider rejected the attach — surface
+        // why instead of a green "added" that never goes live.
+        toast.error("Domain saved, but attach failed", {
+          description: result.error,
+        })
+      } else {
+        toast.success("Domain added", {
+          description: result.verified
+            ? "Domain verified. Configure your DNS to point it to your storefront."
+            : "Domain added. Follow the verification steps below.",
+        })
+      }
     } catch (e: any) {
       toast.error("Could not add domain", {
         description: e?.message || "Something went wrong",
@@ -456,9 +464,20 @@ const CustomDomainSection = () => {
       setAddResult(result)
       if (result.verified) {
         toast.success("Domain verified")
+      } else if (result.error) {
+        toast.error("Couldn't attach domain", { description: result.error })
       } else {
+        // Guide by what the partner actually needs to publish: a TXT ownership
+        // record vs. a CNAME. The old copy always said "TXT" even when none
+        // existed yet — misleading when the hostname was just (re)created.
+        const hasTxt = (result.verification?.length ?? 0) > 0
+        const hasDns = (result.dns_records?.length ?? 0) > 0
         toast.warning("Domain not yet verified", {
-          description: "Make sure the TXT record is set and try again.",
+          description: hasTxt
+            ? "Add the TXT record(s) shown below to verify ownership, then check again."
+            : hasDns
+            ? "Add the DNS record(s) shown below at your domain provider, then check again in a few minutes."
+            : "We're still attaching your domain — give it a minute, then check again.",
         })
       }
     } catch (e: any) {
@@ -479,9 +498,17 @@ const CustomDomainSection = () => {
     if (!confirmed) return
 
     try {
-      await removeDomain()
+      const result = await removeDomain()
       setAddResult(null)
-      toast.success("Custom domain removed")
+      if (result?.warnings?.length) {
+        toast.warning("Custom domain removed", {
+          description:
+            "Some records may still be clearing at the host: " +
+            result.warnings.join("; "),
+        })
+      } else {
+        toast.success("Custom domain removed")
+      }
     } catch (e: any) {
       toast.error("Could not remove domain", {
         description: e?.message || "Something went wrong",


### PR DESCRIPTION
Fixes the partner storefront custom-domain flow, centred on the apex-domain path that could be **added but never went live** and couldn't be **cleanly removed** (#1060 tail).

## What was broken
- **Remove left the domain resolving.** `removeDomain` only cleaned *one* of the two Cloudflare attachment paths, chosen by the *current* `shouldUseSaas`. A domain attached under a different path/config (the apex's history) survived.
- **Apex never went live + misleading toast.** `addDomain` swallows Cloudflare errors, and Check Status only ever *verified* — it never *created* a missing SaaS custom hostname. So an apex added during a broken window sat unverifiable while the UI told the partner to "set the TXT record" that didn't exist.
- **Domain lived in `metadata`.** Load-bearing data in the JSON blob.

## Changes
- **`removeDomain`** tears down **both** paths (SaaS custom hostname + scoped worker route **and** the Workers Custom Domain entry), idempotently; collects failures. DELETE surfaces them as `warnings` instead of swallowing.
- **Check Status (`verify` route)** self-heals: for Cloudflare it idempotently re-attaches the apex/www pair (recreating a missing custom hostname + route) before verifying, then aggregates DNS/verification across both hosts.
- **Attach error surfaced** through the workflow → POST response; **partner-ui toasts** are context-aware (TXT vs CNAME vs still-attaching, + attach errors + remove warnings).
- **Domain moved to typed columns** `custom_domain` / `custom_domain_verified` (mirrors the `tax_id`/`country_code` convention). Migration adds columns, backfills from metadata, strips the old keys. All readers/writers updated with a metadata fallback for the deploy window.

Host resolution for custom domains still flows through `website_domain` aliases (unchanged); the new column drives status/marketing only.

## Verification
- `tsc --noEmit` clean on all touched backend + partner-ui files.
- 26 unit tests pass (`resolve-partner-landing-base`, `resolve-cart-recovery-urls`).

## Watch-outs
- Migration runs (gated) before code rolls and strips the metadata keys — brief read-only window where old code sees no custom domain on status/marketing endpoints; self-heals once new code is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)