### PR TITLE
fix(storefront-resolve): match custom_domain column so attached domains serve

### DIFF
--- a/apps/backend/integration-tests/http/storefront-api.spec.ts
+++ b/apps/backend/integration-tests/http/storefront-api.spec.ts
@@ -271,6 +271,35 @@ setupSharedTestSuite(({ api, getContainer }) => {
       expect(res.data.publishable_key).toBe(publishableKey)
     })
 
+    test("GET /web/storefront/resolve?host=<custom_domain> resolves apex AND www via the custom_domain column", async () => {
+      const { partner, publishableKey } = await fullSetup(api, getContainer)
+
+      // Connect a custom domain via the typed column (no website_domain alias,
+      // no website_id) — the path that left www reaching the worker but showing
+      // "no shop found".
+      const container = await getContainer()
+      const partnerService: any = container.resolve("partner")
+      const apex = `brand-${Date.now()}.example.com`
+      await partnerService.updatePartners({
+        id: partner.partnerId,
+        custom_domain: apex,
+      })
+
+      // Apex resolves.
+      const apexRes = await api.get("/web/storefront/resolve", {
+        params: { host: apex },
+      })
+      expect(apexRes.status).toBe(200)
+      expect(apexRes.data.publishable_key).toBe(publishableKey)
+
+      // Its www twin resolves too (host is www-stripped to the apex).
+      const wwwRes = await api.get("/web/storefront/resolve", {
+        params: { host: `www.${apex}` },
+      })
+      expect(wwwRes.status).toBe(200)
+      expect(wwwRes.data.publishable_key).toBe(publishableKey)
+    })
+
     test("GET /web/storefront/resolve?host=<alias> resolves via website_domain", async () => {
       const { partner, publishableKey } = await fullSetup(api, getContainer)
 

--- a/apps/backend/src/api/web/storefront/resolve/route.ts
+++ b/apps/backend/src/api/web/storefront/resolve/route.ts
@@ -9,8 +9,10 @@ import { hostToCandidates, resolveStorefrontForPartner } from "../resolve-key"
  * storefront running as a single shared Worker. The edge middleware calls this
  * with the incoming `Host` and gets back the publishable key it must send to
  * the Store API for that tenant. Two lookup paths, in order:
- *   1. Custom domain  — `partner.storefront_domain === host`
- *   2. Handle subdomain — first label of the host === `partner.handle`
+ *   1. Provisioned subdomain — `partner.storefront_domain === host`
+ *   2. Connected custom domain — `partner.custom_domain === host` (apex or www)
+ *   3. Website-domain alias — a `website_domain` row for the host
+ *   4. Handle subdomain — first label of the host === `partner.handle`
  *
  * Single-tenant (per-partner Vercel) deploys never call this: they carry their
  * own `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` and short-circuit before resolution.
@@ -25,6 +27,9 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   }
 
   const { host, subdomain } = hostToCandidates(rawHost)
+  // The raw host, lowercased + port-stripped but NOT www-stripped — so a
+  // www-primary custom domain (stored as `www.foo.com`) still matches.
+  const rawHostLower = rawHost.toLowerCase().split(":")[0].trim()
   const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
 
   const partnerFields = [
@@ -32,18 +37,37 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     "name",
     "handle",
     "storefront_domain",
+    "custom_domain",
     "metadata",
     "stores.*",
   ]
 
-  // 1. Custom domain match (partner's primary storefront_domain column).
+  // 1. Provisioned-subdomain match (partner.storefront_domain column).
   let { data: partners } = await query.graph({
     entity: "partners",
     fields: partnerFields,
     filters: { storefront_domain: host },
   })
 
-  // 2. Alias/custom domain a partner attached later. These are registered as
+  // 2. Connected custom domain (partner.custom_domain column). hostToCandidates
+  //    already stripped a leading `www.`, so the apex form stored here matches
+  //    both `foo.com` and `www.foo.com`; we also try the raw host so a
+  //    www-primary domain resolves. This does NOT depend on website_domain
+  //    alias rows (which require a website_id the partner may not have) — the
+  //    gap that left an attached custom domain reaching the worker but showing
+  //    "no shop found".
+  if (!partners?.length) {
+    const customCandidates = Array.from(
+      new Set([host, rawHostLower].filter(Boolean))
+    )
+    ;({ data: partners } = await query.graph({
+      entity: "partners",
+      fields: partnerFields,
+      filters: { custom_domain: customCandidates },
+    }))
+  }
+
+  // 3. Alias/custom domain a partner attached later. These are registered as
   //    `website_domain` rows (primary + www/apex twin) on the partner's
   //    website, so resolve host -> website_domain -> website_id -> the partner
   //    whose website_id matches. Soft-deleted aliases are excluded by default.
@@ -63,7 +87,7 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
     }
   }
 
-  // 3. Fall back to handle-subdomain match.
+  // 4. Fall back to handle-subdomain match.
   if (!partners?.length && subdomain) {
     ;({ data: partners } = await query.graph({
       entity: "partners",

--- a/apps/partner-ui/src/routes/settings/stores/stores.tsx
+++ b/apps/partner-ui/src/routes/settings/stores/stores.tsx
@@ -632,10 +632,18 @@ const CustomDomainSection = () => {
                   <InlineTip variant="info" label="Point Your Domain">
                     Add the DNS record{dnsRecords.length > 1 ? "s" : ""} below at
                     your domain provider so it resolves to your storefront. DNS
-                    changes can take up to 48 hours to propagate. For a root
-                    domain (e.g. example.com), use your provider's CNAME
-                    flattening / ALIAS / ANAME record — a plain CNAME isn't
-                    allowed at the root.
+                    changes can take up to 48 hours to propagate.
+                    <br />
+                    <br />
+                    <strong>Root domain (e.g. example.com):</strong> a plain
+                    CNAME isn't allowed at the root. Your DNS provider must
+                    support CNAME flattening / ALIAS / ANAME (Cloudflare,
+                    DNSimple). Providers that don't — including{" "}
+                    <strong>AWS Route 53</strong>, whose ALIAS only targets AWS
+                    resources — can't point the root at an external host. On
+                    those, either move your domain's nameservers to Cloudflare,
+                    or point only <code>www</code> and set up a root&nbsp;→&nbsp;www
+                    redirect at your registrar.
                   </InlineTip>
                   <DnsTable rows={dnsRecords} />
                 </>


### PR DESCRIPTION
## The bug
`www.hrhandloom.in` correctly CNAME'd to `mt.cicilabel.com`, reached the shared worker over HTTPS — but rendered **"no shop found at this address."**

Root cause: `/web/storefront/resolve` never matched the partner's connected custom domain. It only checked:
1. `storefront_domain` (the *provisioned* subdomain — not the custom domain), and
2. `website_domain` alias rows — which are only created when the partner has a `website_id` (hr-handloom doesn't).

So the domain resolved DNS-wise but the resolver 404'd → storefront error page. The `custom_domain` column added in #1075 was going unused by the resolver.

## Fix
Add a **`custom_domain` match** between the subdomain and alias steps. `hostToCandidates` already strips a leading `www.`, so the apex form stored in the column matches both `foo.com` and `www.foo.com`; the raw host is also tried so a www-primary domain resolves. No dependency on `website_domain` aliases or `website_id`.

New resolution order: provisioned subdomain → **custom_domain column** → website_domain alias → handle subdomain.

## Also
Clarify the partner-ui "Point Your Domain" tip for **root domains**: a plain CNAME isn't allowed at the apex, and **AWS Route 53's ALIAS only targets AWS resources** — so it can't point the root at `mt.cicilabel.com`. Guidance: move the domain's nameservers to Cloudflare (CNAME flattening at apex), or point only `www` and set a root→www redirect. (This is the DNS-provider limitation the operator hit — not a code bug; the apex genuinely can't be served from Route 53 pointing at an external host.)

## Test
`resolve?host=<custom_domain>` now covered for both the apex and its www twin.

## Deploy note
Depends on #1075's `custom_domain` column + migration (already merged; its deploy runs the migration first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)