### PR TITLE
chore(storefront-provision): default new storefronts to Vercel; defer the CF tier

### DIFF
--- a/apps/backend/src/workflows/stores/provision-storefront.ts
+++ b/apps/backend/src/workflows/stores/provision-storefront.ts
@@ -36,9 +36,16 @@ export type ProvisionStorefrontInput = {
   s3_pathname: string
   /**
    * Preferred hosting provider for this NEW storefront. Defaults to
-   * DEFAULT_HOSTING_PROVIDER env (or "cloudflare"). The selector rotates across
+   * DEFAULT_HOSTING_PROVIDER env (or "vercel"). The selector rotates across
    * that provider's accounts, spills to other providers, then falls back to the
    * legacy env-single-account path.
+   *
+   * Default is "vercel" (not "cloudflare"): Vercel handles custom domains —
+   * including bare apex — natively (A @ → 76.76.21.21) on any DNS provider,
+   * with auto TLS, so it "just works" for every partner. The Cloudflare Workers
+   * tier is deferred (its SaaS custom-hostname path can't serve a bare apex
+   * without Enterprise apex-proxying); re-enable it later by setting
+   * DEFAULT_HOSTING_PROVIDER=cloudflare and reactivating the CF account.
    */
   preferred_provider?: DeploymentProvider
 }
@@ -81,7 +88,9 @@ const selectHostingTargetStep = createStep(
     const preferred =
       input.preferredProvider ||
       (process.env.DEFAULT_HOSTING_PROVIDER as DeploymentProvider | undefined) ||
-      "cloudflare"
+      // Default to Vercel: native apex + auto-TLS on any DNS provider. The CF
+      // Workers tier is deferred (bare apex needs Enterprise apex-proxying).
+      "vercel"
 
     const target = decideProvisionTarget(accounts || [], {
       preferredProvider: preferred,


### PR DESCRIPTION
New-storefront provisioning defaulted to **Cloudflare Workers**, whose SaaS custom-hostname path can't serve a **bare apex** without Enterprise apex-proxying. Vercel handles custom domains — including apex (`A @ → 76.76.21.21`) — natively on any DNS provider with auto TLS. With few customers today, consolidate on the path that just works.

- Flip the default preferred provider `cloudflare` → `vercel` (still overridable via `DEFAULT_HOSTING_PROVIDER`).
- Paired with **deactivating the Cloudflare deployment account** (done via admin API), neither the preferred pick nor the cross-provider spillover lands a new storefront on CF.
- **Reversible:** set `DEFAULT_HOSTING_PROVIDER=cloudflare` + reactivate the CF account to bring the Workers tier back.
- Existing CF storefronts (hr-handloom pilot) untouched — repointing to the Vercel shared tier is a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)