### PR TITLE
feat(partner-assistant): stop/retry controls, context compaction, richer tool data

### DIFF
--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -120,6 +120,7 @@ import { subscriptionSchema } from "./web/website/[domain]/validators";
 import { websiteThemeSchema } from "./partners/storefront/website/theme/validators";
 import { ThemeChatSchema } from "./partners/storefront/website/theme/chat/validators";
 import { PartnerAssistantChatSchema } from "./partners/assistant/chat/validators";
+import { PartnerAssistantSummarizeSchema } from "./partners/assistant/summarize/validators";
 import { CreateConversationSchema as PartnerCreateConversationSchema, UpdateConversationSchema as PartnerUpdateConversationSchema } from "./partners/assistant/conversations/validators";
 import { createPlanSchema, updatePlanSchema, createSubscriptionSchema } from "./admin/partner-plans/validators";
 import { subscribeSchema as partnerSubscribeSchema } from "./partners/subscription/validators";
@@ -2178,6 +2179,18 @@ export default defineMiddlewares({
         createCorsPartnerMiddleware(),
         authenticate("partner", ["session", "bearer"]),
         validateAndTransformBody(wrapSchema(PartnerAssistantChatSchema)),
+      ],
+    },
+    // Partner assistant context compaction — the client calls this when the
+    // chat approaches the model's context window; the route returns a short
+    // summary the client stores in place of the older turns.
+    {
+      matcher: "/partners/assistant/summarize",
+      method: "POST",
+      middlewares: [
+        createCorsPartnerMiddleware(),
+        authenticate("partner", ["session", "bearer"]),
+        validateAndTransformBody(wrapSchema(PartnerAssistantSummarizeSchema)),
       ],
     },
     // Partner MCP — JSON-RPC endpoint exposing the Partner API as tools. Body is

--- a/apps/backend/src/api/partners/assistant/chat/route.ts
+++ b/apps/backend/src/api/partners/assistant/chat/route.ts
@@ -141,40 +141,55 @@ export const POST = async (
   } as const
 
   let result
-  try {
-    result = streamText({
-      model: chatModel,
-      ...(folded.system ? { system: folded.system } : {}),
-      messages: convertToModelMessages(folded.messages as any),
-      tools,
-      stopWhen: stepCountIs(8),
-      temperature: 0.3,
-      onFinish: ({ usage: u }: any) => {
-        logAiUsage(logger, {
-          ...usageBase,
-          ok: true,
-          ms: Date.now() - startedAt,
-          tokens: u?.totalTokens,
-        })
-      },
-      onError: (err: any) => {
-        logAiUsage(logger, {
-          ...usageBase,
-          ok: false,
-          ms: Date.now() - startedAt,
-          error: err?.error ?? err,
-        })
-      },
-    })
-  } catch (e: any) {
-    logAiUsage(logger, {
-      ...usageBase,
-      ok: false,
-      ms: Date.now() - startedAt,
-      error: e,
-    })
-    res.status(502).json({ error: "partner assistant provider failed" })
-    return
+  const MAX_CONSTRUCTION_ATTEMPTS = 2
+  for (let attempt = 1; attempt <= MAX_CONSTRUCTION_ATTEMPTS; attempt++) {
+    try {
+      result = streamText({
+        model: chatModel,
+        ...(folded.system ? { system: folded.system } : {}),
+        messages: convertToModelMessages(folded.messages as any),
+        tools,
+        stopWhen: stepCountIs(8),
+        temperature: 0.3,
+        // Let the AI SDK retry transient network/5xx failures at the model
+        // layer. The free rotator separately self-heals free-tier expiry
+        // (dynamic-text-model.ts), so this covers non-free providers and
+        // generic upstream hiccups.
+        maxRetries: 3,
+        onFinish: ({ usage: u }: any) => {
+          logAiUsage(logger, {
+            ...usageBase,
+            ok: true,
+            ms: Date.now() - startedAt,
+            tokens: u?.totalTokens,
+          })
+        },
+        onError: (err: any) => {
+          logAiUsage(logger, {
+            ...usageBase,
+            ok: false,
+            ms: Date.now() - startedAt,
+            error: err?.error ?? err,
+          })
+        },
+      })
+      break
+    } catch (e: any) {
+      logAiUsage(logger, {
+        ...usageBase,
+        ok: false,
+        ms: Date.now() - startedAt,
+        error: e,
+      })
+      if (attempt < MAX_CONSTRUCTION_ATTEMPTS) {
+        // Back off briefly and retry construction once — transient provider
+        // resolution / connection errors often clear on a second attempt.
+        await new Promise((r) => setTimeout(r, 400 * attempt))
+        continue
+      }
+      res.status(502).json({ error: "partner assistant provider failed" })
+      return
+    }
   }
 
   result.pipeUIMessageStreamToResponse(res as any)

--- a/apps/backend/src/api/partners/assistant/summarize/route.ts
+++ b/apps/backend/src/api/partners/assistant/summarize/route.ts
@@ -1,0 +1,104 @@
+/**
+ * POST /partners/assistant/summarize
+ *
+ * Context-compaction for the partner assistant. As a conversation grows it
+ * approaches the model's context window; rather than silently truncating
+ * (which the partner experiences as the assistant "forgetting"), the client
+ * asks this endpoint to roll the older turns into a short summary. The
+ * client then persists the trimmed thread (summary + recent turns) and the
+ * next request to /chat stays within budget.
+ *
+ * Non-streaming `generateText` is fine here — the result is short and the
+ * call is infrequent (only when the client's token estimate crosses the
+ * threshold). Retries once on failure so a transient model error does not
+ * block compaction.
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { convertToModelMessages, generateText } from "ai"
+import { resolveRoleTextModel, logAiUsage } from "../../../../mastra/services/ai-platforms"
+import { foldSystemForProvider } from "../../../store/ai/chat/system-fold-lib"
+import type { PartnerAssistantSummarizeReq } from "./validators"
+
+const FEATURE = "partners/assistant/summarize"
+const ROLE = "ai_partner_assistant"
+
+const SUMMARIZE_SYSTEM = `You are condensing a partner-portal assistant conversation so it can continue within a limited context window. Write a tight "Summary so far" the assistant can read instead of the earlier messages.
+
+Rules:
+- Capture decisions made, facts learned about the partner (name, persona, onboarding state), actions already taken (tool calls + their outcome), and any open follow-ups.
+- Do NOT restate the whole conversation. Aim for 4–8 short bullet lines.
+- Do NOT invent details. If something is uncertain, say "unclear".
+- Write in the second person to the assistant ("The partner …", "You already …"). End with a one-line "Continue by:" hint.`
+
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  const body = (req as any).validatedBody as PartnerAssistantSummarizeReq
+
+  const resolved = await resolveRoleTextModel(req.scope as any, ROLE)
+  if (resolved.source === "free" && !process.env.OPENROUTER_API_KEY) {
+    res.status(503).json({
+      error:
+        "The partner assistant is not configured. Add a platform with role ai_partner_assistant in Settings → External Platforms, or set OPENROUTER_API_KEY.",
+    })
+    return
+  }
+
+  // Keep only text parts — tool/reasoning parts are not useful for a summary
+  // and would inflate the input tokens for nothing.
+  const messages = body.messages.map((m: any) => {
+    const parts = Array.isArray(m.parts) ? m.parts : null
+    const textParts = parts
+      ? parts
+          .filter(
+            (p: any) =>
+              p?.type === "text" && typeof p.text === "string" && p.text.length > 0
+          )
+          .map((p: any) => ({ type: "text", text: p.text }))
+      : [{ type: "text", text: String(m.content ?? "") }]
+    return { role: m.role, parts: textParts.length ? textParts : [{ type: "text", text: "" }] }
+  })
+
+  const folded = foldSystemForProvider(resolved.providerType, SUMMARIZE_SYSTEM, messages)
+  const startedAt = Date.now()
+  const usageBase = {
+    feature: FEATURE,
+    role: ROLE,
+    provider: resolved.providerType,
+    source: resolved.source,
+    platformId: resolved.platformId,
+    model: resolved.modelId,
+  } as const
+
+  const MAX_ATTEMPTS = 2
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const { text } = await generateText({
+        model: resolved.model,
+        ...(folded.system ? { system: folded.system } : {}),
+        messages: convertToModelMessages(folded.messages as any),
+        temperature: 0.2,
+        maxRetries: 3,
+      })
+      logAiUsage(logger, { ...usageBase, ok: true, ms: Date.now() - startedAt })
+      res.status(200).json({ summary: text.trim() })
+      return
+    } catch (e: any) {
+      logAiUsage(logger, {
+        ...usageBase,
+        ok: false,
+        ms: Date.now() - startedAt,
+        error: e,
+      })
+      if (attempt < MAX_ATTEMPTS) {
+        await new Promise((r) => setTimeout(r, 400 * attempt))
+        continue
+      }
+      res.status(502).json({ error: "Could not summarize the conversation. Please try again or start a new chat." })
+      return
+    }
+  }
+}

--- a/apps/backend/src/api/partners/assistant/summarize/validators.ts
+++ b/apps/backend/src/api/partners/assistant/summarize/validators.ts
@@ -1,0 +1,28 @@
+/**
+ * POST /partners/assistant/summarize
+ *
+ * Validator for the context-compaction endpoint. The client sends the
+ * current message history when the chat approaches the context-window
+ * threshold; the route returns a short summary that the client stores in
+ * place of the older turns so the conversation can continue without
+ * exceeding the model's context limit.
+ */
+import { z } from "zod"
+
+const UiMessageSchema = z
+  .object({
+    role: z.enum(["system", "user", "assistant"]),
+    content: z.string().optional(),
+    parts: z
+      .array(z.object({ type: z.string(), text: z.string().optional() }).passthrough())
+      .optional(),
+  })
+  .passthrough()
+
+export const PartnerAssistantSummarizeSchema = z.object({
+  messages: z.array(UiMessageSchema).min(2).max(200),
+})
+
+export type PartnerAssistantSummarizeReq = z.infer<
+  typeof PartnerAssistantSummarizeSchema
+>

--- a/apps/backend/src/api/partners/mcp/lib/registry.ts
+++ b/apps/backend/src/api/partners/mcp/lib/registry.ts
@@ -1750,10 +1750,15 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
   // The partner's own purchase orders for raw materials / inventory. Lifecycle:
   //   list → get → start → (submit-payment) → shiprocket-rates / ready-for-delivery
   //   → shipment → complete
+  //
+  // `transform` flattens the most useful nested fields (partner_info, totals,
+  // order_lines_count) onto the row itself so the chat's ToolData table can
+  // surface them as columns — the table renderer skips nested objects. The
+  // original nested objects are preserved for the raw-JSON disclosure.
   {
     name: "list_inventory_orders",
     description:
-      "List the partner's inventory (purchase) orders — raw-material purchases from suppliers. Paginated, free-text search via q, optional status filter.",
+      "List the partner's inventory (purchase) orders — raw-material purchases from suppliers. Paginated, free-text search via q, optional status filter. Returns each order with status, quantity, total_price, expected delivery date, supplier (partner) status, and order-lines count.",
     method: "GET",
     path: "/partners/inventory-orders",
     queryParams: ["limit", "offset", "q", "status"],
@@ -1761,14 +1766,48 @@ export const PARTNER_MCP_TOOLS: PartnerMcpToolDef[] = [
       ...PAGINATION,
       status: STR("Optional status filter."),
     }),
+    transform: (data: any) => {
+      const orders = Array.isArray(data?.inventory_orders) ? data.inventory_orders : []
+      const flattened = orders.map((o: any) => ({
+        ...o,
+        partner_status: o?.partner_info?.partner_status,
+        supplier_name: o?.partner_info?.partner_name,
+        order_lines_count: o?.order_lines_count ?? o?.orderlines?.length ?? 0,
+        stock_location: o?.stock_location ?? o?.stock_locations?.[0]?.name,
+      }))
+      return { ...data, inventory_orders: flattened }
+    },
   },
   {
     name: "get_inventory_order",
-    description: "Get a single inventory (purchase) order by id, with its lines and supplier.",
+    description:
+      "Get a single inventory (purchase) order by id, with its lines, supplier (partner) info, payments, and shipments. Flattens partner/supplier info and line totals to the top level for easy reading.",
     method: "GET",
     path: "/partners/inventory-orders/:orderId",
     pathParams: ["orderId"],
     inputSchema: obj({ orderId: STR("Inventory order id.") }, ["orderId"]),
+    transform: (data: any) => {
+      const o = data?.inventoryOrder
+      if (!o) return data
+      const lines = Array.isArray(o.order_lines) ? o.order_lines : []
+      const lineTotal = lines.reduce(
+        (sum: number, l: any) => sum + (Number(l?.price) || 0) * (Number(l?.quantity) || 0),
+        0
+      )
+      return {
+        ...data,
+        inventoryOrder: {
+          ...o,
+          partner_status: o?.partner_info?.partner_status,
+          supplier_name: o?.partner_info?.partner_name,
+          supplier_handle: o?.partner_info?.partner_handle,
+          line_items_count: lines.length,
+          line_total: lineTotal,
+          payments_count: Array.isArray(o.payments) ? o.payments.length : 0,
+          shipments_count: Array.isArray(o.shipments) ? o.shipments.length : 0,
+        },
+      }
+    },
   },
   {
     name: "start_inventory_order",

--- a/apps/partner-ui/src/routes/assistant/assistant.tsx
+++ b/apps/partner-ui/src/routes/assistant/assistant.tsx
@@ -4,10 +4,18 @@
  * Two-pane: a conversation-history sidebar (server-persisted) beside the live
  * chat thread. History survives reloads and follows the partner across devices;
  * the thread itself is stateless and driven by the Partner API via MCP tools.
+ *
+ * Responsive behaviour:
+ *   - Desktop: the 260px history sidebar is collapsible (toggle in the
+ *     header). When collapsed the chat thread takes the full width — handy
+ *     for a fresh "New chat" where history isn't needed.
+ *   - Mobile: the history sidebar is hidden behind a slide-over panel
+ *     toggled by a menu button in the header, so the chat thread always has
+ *     the full viewport width on small screens.
  */
-import { useCallback, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { Container, Heading, Text, Button, IconButton, toast } from "@medusajs/ui"
-import { Sparkles, Plus, Trash, Spinner } from "@medusajs/icons"
+import { Sparkles, Plus, Trash, Spinner, SidebarLeft, BarsThree, XMark } from "@medusajs/icons"
 
 import { sdk } from "../../lib/client"
 import {
@@ -23,16 +31,25 @@ export const Assistant = () => {
   const [threadKey, setThreadKey] = useState(0)
   const [initialMessages, setInitialMessages] = useState<StoredMessage[]>([])
   const [opening, setOpening] = useState(false)
+  // Desktop: history sidebar visible by default, collapsible to give the chat
+  // thread the full width (e.g. when starting a fresh "New chat").
+  const [sidebarOpen, setSidebarOpen] = useState(true)
+  // Mobile: history is a slide-over, closed by default.
+  const [mobileOpen, setMobileOpen] = useState(false)
 
   const startNew = useCallback(() => {
     setActiveId(null)
     setInitialMessages([])
     setThreadKey((k) => k + 1)
+    setMobileOpen(false)
   }, [])
 
   const openConversation = useCallback(
     async (id: string) => {
-      if (id === activeId) return
+      if (id === activeId) {
+        setMobileOpen(false)
+        return
+      }
       setOpening(true)
       try {
         const { conversation } = await sdk.client.fetch<{
@@ -41,6 +58,7 @@ export const Assistant = () => {
         setActiveId(id)
         setInitialMessages(conversation.messages || [])
         setThreadKey((k) => k + 1)
+        setMobileOpen(false)
       } catch {
         toast.error("Could not open that conversation")
       } finally {
@@ -53,6 +71,11 @@ export const Assistant = () => {
   // A fresh chat was just saved — highlight it without remounting the thread.
   const onCreated = useCallback((id: string) => {
     setActiveId(id)
+  }, [])
+
+  const onCompacted = useCallback(() => {
+    // Refresh the history list so the title/stale state reflects compaction.
+    setThreadKey((k) => k)
   }, [])
 
   const { mutate: deleteConversation } = useDeleteConversation()
@@ -69,71 +92,93 @@ export const Assistant = () => {
     [deleteConversation, activeId, startNew]
   )
 
+  // Close the mobile slide-over on Escape for a native-feeling dismiss.
+  useEffect(() => {
+    if (!mobileOpen) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setMobileOpen(false)
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [mobileOpen])
+
+  const historyPanel = (
+    <HistoryPanel
+      conversations={conversations}
+      isPending={isPending}
+      activeId={activeId}
+      isMobile={false}
+      onNew={startNew}
+      onOpen={openConversation}
+      onDelete={onDelete}
+    />
+  )
+
   return (
     <Container className="p-0 overflow-hidden h-[calc(100vh-90px)] flex flex-col">
       <div className="flex items-center justify-between px-4 py-3 border-b border-ui-border-base shrink-0">
         <div className="flex items-center gap-x-2">
+          {/* Mobile: open history slide-over */}
+          <IconButton
+            variant="transparent"
+            size="small"
+            className="lg:hidden"
+            onClick={() => setMobileOpen(true)}
+            aria-label="Show conversations"
+          >
+            <BarsThree />
+          </IconButton>
           <Sparkles className="text-ui-fg-subtle" />
           <Heading level="h2">Assistant</Heading>
         </div>
+        {/* Desktop: collapse / expand the history sidebar */}
+        <IconButton
+          variant="transparent"
+          size="small"
+          className={`hidden lg:inline-flex ${sidebarOpen ? "rotate-180" : ""}`}
+          onClick={() => setSidebarOpen((v) => !v)}
+          aria-label={sidebarOpen ? "Hide conversations" : "Show conversations"}
+          title={sidebarOpen ? "Hide conversations" : "Show conversations"}
+        >
+          <SidebarLeft />
+        </IconButton>
       </div>
 
       <div className="flex flex-1 min-h-0">
-        {/* History sidebar */}
-        <div className="w-[260px] border-r border-ui-border-base flex flex-col shrink-0 min-h-0">
-          <div className="p-2 shrink-0">
-            <Button
-              variant="secondary"
-              size="small"
-              className="w-full justify-center"
-              onClick={startNew}
-            >
-              <Plus />
-              New chat
-            </Button>
-          </div>
-          <div className="flex-1 overflow-y-auto min-h-0 px-2 pb-2 space-y-0.5">
-            {isPending ? (
-              <div className="flex justify-center py-6">
-                <Spinner className="animate-spin text-ui-fg-muted" />
-              </div>
-            ) : !conversations?.length ? (
-              <Text
-                size="xsmall"
-                className="text-ui-fg-muted text-center py-6 px-2"
-              >
-                No conversations yet. Start a new chat to begin.
-              </Text>
-            ) : (
-              conversations.map((c) => (
-                <button
-                  key={c.id}
-                  onClick={() => openConversation(c.id)}
-                  className={`group w-full text-left rounded-md px-2.5 py-2 flex items-center gap-x-2 transition-colors ${
-                    c.id === activeId
-                      ? "bg-ui-bg-base-pressed"
-                      : "hover:bg-ui-bg-base-hover"
-                  }`}
+        {/* History sidebar — desktop collapsible column */}
+        {sidebarOpen && <div className="hidden lg:flex">{historyPanel}</div>}
+
+        {/* Mobile history slide-over */}
+        {mobileOpen && (
+          <div className="lg:hidden">
+            <div
+              className="fixed inset-0 z-40 bg-ui-bg-overlay"
+              onClick={() => setMobileOpen(false)}
+            />
+            <div className="fixed left-0 top-0 bottom-0 z-50 w-[280px] max-w-[85vw] bg-ui-bg-base shadow-elevation-elevated flex flex-col">
+              <div className="flex items-center justify-between px-3 py-2 border-b border-ui-border-base shrink-0">
+                <Text size="small" weight="plus">Conversations</Text>
+                <IconButton
+                  variant="transparent"
+                  size="small"
+                  onClick={() => setMobileOpen(false)}
+                  aria-label="Close conversations"
                 >
-                  <Text
-                    size="xsmall"
-                    className="flex-1 truncate text-ui-fg-subtle"
-                  >
-                    {c.title}
-                  </Text>
-                  <IconButton
-                    size="2xsmall"
-                    variant="transparent"
-                    className="opacity-0 group-hover:opacity-100 shrink-0"
-                    onClick={(e) => onDelete(c.id, e)}
-                  >
-                    <Trash className="text-ui-fg-muted" />
-                  </IconButton>
-                </button>
-              ))
-            )}
+                  <XMark />
+                </IconButton>
+              </div>
+              <HistoryPanel
+                conversations={conversations}
+                isPending={isPending}
+                activeId={activeId}
+                isMobile
+                onNew={startNew}
+                onOpen={openConversation}
+                onDelete={onDelete}
+              />
+            </div>
           </div>
-        </div>
+        )}
 
         {/* Chat thread */}
         <div className="flex-1 flex flex-col min-h-0 min-w-0 relative">
@@ -147,9 +192,89 @@ export const Assistant = () => {
             conversationId={activeId}
             initialMessages={initialMessages}
             onCreated={onCreated}
+            onCompacted={onCompacted}
           />
         </div>
       </div>
     </Container>
+  )
+}
+
+function HistoryPanel({
+  conversations,
+  isPending,
+  activeId,
+  isMobile,
+  onNew,
+  onOpen,
+  onDelete,
+}: {
+  conversations: any[]
+  isPending: boolean
+  activeId: string | null
+  isMobile: boolean
+  onNew: () => void
+  onOpen: (id: string) => void
+  onDelete: (id: string, e: React.MouseEvent) => void
+}) {
+  return (
+    <div
+      className={`${
+        isMobile ? "flex-1 min-h-0" : "w-[260px]"
+      } border-r border-ui-border-base flex flex-col shrink-0 min-h-0`}
+    >
+      <div className="p-2 shrink-0">
+        <Button
+          variant="secondary"
+          size="small"
+          className="w-full justify-center"
+          onClick={onNew}
+        >
+          <Plus />
+          New chat
+        </Button>
+      </div>
+      <div className="flex-1 overflow-y-auto min-h-0 px-2 pb-2 space-y-0.5">
+        {isPending ? (
+          <div className="flex justify-center py-6">
+            <Spinner className="animate-spin text-ui-fg-muted" />
+          </div>
+        ) : !conversations?.length ? (
+          <Text
+            size="xsmall"
+            className="text-ui-fg-muted text-center py-6 px-2"
+          >
+            No conversations yet. Start a new chat to begin.
+          </Text>
+        ) : (
+          conversations.map((c) => (
+            <button
+              key={c.id}
+              onClick={() => onOpen(c.id)}
+              className={`group w-full text-left rounded-md px-2.5 py-2 flex items-center gap-x-2 transition-colors ${
+                c.id === activeId
+                  ? "bg-ui-bg-base-pressed"
+                  : "hover:bg-ui-bg-base-hover"
+              }`}
+            >
+              <Text
+                size="xsmall"
+                className="flex-1 truncate text-ui-fg-subtle"
+              >
+                {c.title}
+              </Text>
+              <IconButton
+                size="2xsmall"
+                variant="transparent"
+                className="opacity-0 group-hover:opacity-100 shrink-0"
+                onClick={(e) => onDelete(c.id, e)}
+              >
+                <Trash className="text-ui-fg-muted" />
+              </IconButton>
+            </button>
+          ))
+        )}
+      </div>
+    </div>
   )
 }

--- a/apps/partner-ui/src/routes/assistant/components/chat-thread.tsx
+++ b/apps/partner-ui/src/routes/assistant/components/chat-thread.tsx
@@ -9,12 +9,24 @@
  *   - generic tool rendering: any registry tool result is summarised;
  *   - a sensitive-tool confirmation card that executes via POST /partners/mcp
  *     on the user's explicit approval (the model never self-confirms).
+ *
+ * UX additions:
+ *   - Stop: a stop button replaces the send button while the model is working
+ *     (streaming or reasoning) so the partner can interrupt a long turn.
+ *   - Retry: an inline "Retry" button appears when a turn errors, calling
+ *     `regenerate()`. The backend also retries construction once.
+ *   - Media upload: not supported in chat — a disabled attachment button with a
+ *     tooltip tells the partner so, instead of silently failing.
+ *   - Context window: a rough token estimate is tracked across the thread;
+ *     near the limit a banner offers "Compact summary" (POST .../summarize),
+ *     which replaces the older turns with a short summary so the chat keeps
+ *     going without exceeding the model's context budget.
  */
-import { useEffect, useRef, useState, useCallback } from "react"
+import { useEffect, useRef, useState, useCallback, useMemo } from "react"
 import { useChat } from "@ai-sdk/react"
 import { DefaultChatTransport } from "ai"
-import { Button, Text, IconButton, toast } from "@medusajs/ui"
-import { Sparkles, ArrowUpMini, Check, ExclamationCircle } from "@medusajs/icons"
+import { Button, Text, IconButton, toast, Tooltip, Label, Kbd } from "@medusajs/ui"
+import { Sparkles, ArrowUpMini, Check, ExclamationCircle, XMarkMini, PaperClip, ArrowPathMini, TrianglesMini } from "@medusajs/icons"
 
 import { sdk, backendUrl } from "../../../lib/client"
 import { queryClient } from "../../../lib/query-client"
@@ -35,6 +47,8 @@ type ChatThreadProps = {
   initialMessages: StoredMessage[]
   /** Fired once, when a fresh chat is first persisted (gets its server id). */
   onCreated: (id: string, title: string) => void
+  /** Fired after a context compaction replaces the stored history. */
+  onCompacted?: () => void
 }
 
 const SUGGESTIONS = [
@@ -43,6 +57,14 @@ const SUGGESTIONS = [
   "Hide the customers menu from my sidebar",
   "What products am I selling?",
 ]
+
+/**
+ * Rough context budget the chat tries to stay under. The free-model rotator
+ * ranks by context length and most free providers land in the 32k–128k range;
+ * we warn early at 20k estimated tokens so there is headroom for tool output.
+ * Conservative on purpose: this is an estimate, not a precise token count.
+ */
+const CONTEXT_WARN_TOKENS = 20000
 
 function getText(parts: any[] | undefined): string {
   return (
@@ -66,12 +88,37 @@ function toStored(messages: any[]): StoredMessage[] {
   return messages.map((m) => ({ id: m.id, role: m.role, parts: m.parts }))
 }
 
+/** Rough token estimate (~4 chars/token) across all text in a thread. */
+function estimateTokens(messages: any[]): number {
+  let chars = 0
+  for (const m of messages) {
+    const parts = m.parts ?? []
+    for (const p of parts) {
+      if (p?.type === "text" && typeof p.text === "string") chars += p.text.length
+      else if (p?.type === "reasoning" && typeof p.text === "string") chars += p.text.length
+      else if (p?.toolName) {
+        // Tool calls carry input + output; count their JSON size.
+        try {
+          if (p.input) chars += JSON.stringify(p.input).length
+          if (p.output) chars += JSON.stringify(p.output).length
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+  }
+  return Math.ceil(chars / 4)
+}
+
 export const ChatThread = ({
   conversationId,
   initialMessages,
   onCreated,
+  onCompacted,
 }: ChatThreadProps) => {
   const [input, setInput] = useState("")
+  const [compacting, setCompacting] = useState(false)
+  const [showContextBanner, setShowContextBanner] = useState(false)
   const scrollRef = useRef<HTMLDivElement>(null)
   const idRef = useRef<string | null>(conversationId)
   // Seed with the loaded thread's snapshot so opening a saved conversation
@@ -94,16 +141,24 @@ export const ChatThread = ({
     },
   })
 
-  const { messages, sendMessage, status, error } = useChat({
+  const { messages, sendMessage, setMessages, status, error, stop, regenerate, clearError } = useChat({
     transport,
     messages: initialMessages as any,
   })
+
+  const streaming = status === "submitted" || status === "streaming"
+  const tokenEstimate = useMemo(() => estimateTokens(messages as any[]), [messages])
 
   useEffect(() => {
     if (scrollRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight
     }
   }, [messages, status])
+
+  // Surface the context banner once the estimate crosses the threshold.
+  useEffect(() => {
+    setShowContextBanner(tokenEstimate >= CONTEXT_WARN_TOKENS)
+  }, [tokenEstimate])
 
   // Persist the thread after each completed turn. Create-on-first-turn, then
   // patch. A ref-guarded snapshot avoids redundant writes and re-entrancy.
@@ -148,9 +203,98 @@ export const ChatThread = ({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     if (!input.trim() || status !== "ready") return
+    clearError?.()
     sendMessage({ text: input.trim() })
     setInput("")
   }
+
+  const handleStop = () => {
+    try {
+      stop()
+    } catch {
+      /* stop is best-effort */
+    }
+  }
+
+  const handleRetry = () => {
+    clearError?.()
+    try {
+      regenerate()
+    } catch {
+      toast.error("Could not retry. Please send the message again.")
+    }
+  }
+
+  /**
+   * Context compaction: ask the backend to roll the older turns into a short
+   * summary, then replace the whole thread with [summary]. The recent turn
+   * the partner just made is included in the summary inputs so continuity is
+   * preserved; the client persists the trimmed conversation afterwards.
+   */
+  const handleCompact = useCallback(async () => {
+    if (compacting || messages.length < 2) return
+    setCompacting(true)
+    try {
+      const token =
+        (sdk as any).client?.token ||
+        (typeof window !== "undefined"
+          ? localStorage.getItem(jwtTokenStorageKey)
+          : null)
+      const { summary } = await fetch(
+        `${backendUrl.replace(/\/$/, "")}/partners/assistant/summarize`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: {
+            "content-type": "application/json",
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          body: JSON.stringify({ messages: toStored(messages as any[]) }),
+        }
+      ).then(async (r) => {
+        if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || "Summarize failed")
+        return r.json()
+      })
+      if (!summary) throw new Error("No summary returned")
+
+      // Replace the thread with a single assistant summary message. The
+      // persist effect will write it back on the next ready tick.
+      const summaryMessage = {
+        id: `summary-${Date.now()}`,
+        role: "assistant",
+        parts: [
+          {
+            type: "text",
+            text: `**Summary so far**\n\n${summary}`,
+          },
+        ],
+      }
+      setMessages?.([summaryMessage] as any)
+      try {
+        if (idRef.current) {
+          await sdk.client.fetch(
+            `/partners/assistant/conversations/${idRef.current}`,
+            { method: "PATCH", body: { messages: toStored([summaryMessage]) } }
+          )
+          lastPersistedRef.current = JSON.stringify([
+            [summaryMessage.id, summaryMessage.parts.length],
+          ])
+          queryClient.invalidateQueries({
+            queryKey: conversationsQueryKeys.lists(),
+          })
+          onCompacted?.()
+          toast.success("Chat compacted — older messages were summarized.")
+        }
+      } catch {
+        // Non-fatal: the in-memory thread is already compacted.
+      }
+      setShowContextBanner(false)
+    } catch (e: any) {
+      toast.error(e?.message || "Could not compact the chat. Try starting a new chat instead.")
+    } finally {
+      setCompacting(false)
+    }
+  }, [compacting, messages, setMessages, onCompacted])
 
   return (
     <div className="flex flex-col h-full min-h-0 flex-1">
@@ -158,7 +302,7 @@ export const ChatThread = ({
         ref={scrollRef}
         className="flex-1 overflow-y-auto px-4 py-4 space-y-4 min-h-0"
       >
-        {messages.length === 0 && (
+        {messages.length === 0 && !error && (
           <div className="flex flex-col items-center justify-center h-full text-center gap-y-3">
             <Sparkles className="text-ui-fg-subtle" />
             <Text size="small" className="text-ui-fg-subtle max-w-sm">
@@ -183,7 +327,7 @@ export const ChatThread = ({
           <MessageRow key={m.id} message={m} />
         ))}
 
-        {status === "submitted" && (
+        {streaming && (
           <div className="flex items-center gap-x-1 px-2">
             <span className="h-2 w-2 bg-ui-fg-muted rounded-full animate-pulse" />
             <span className="h-2 w-2 bg-ui-fg-muted rounded-full animate-pulse [animation-delay:0.2s]" />
@@ -192,9 +336,45 @@ export const ChatThread = ({
         )}
 
         {error && (
-          <Text size="small" className="text-ui-tag-red-text">
-            Something went wrong. Please try again.
-          </Text>
+          <div className="flex items-center gap-x-2 px-2">
+            <Text size="small" className="text-ui-tag-red-text">
+              Something went wrong.
+            </Text>
+            <Button
+              size="small"
+              variant="secondary"
+              onClick={handleRetry}
+              className="!py-1 !px-2"
+            >
+              <ArrowPathMini />
+              Retry
+            </Button>
+          </div>
+        )}
+
+        {showContextBanner && !compacting && (
+          <div className="flex items-start gap-x-2 rounded-lg border border-ui-tag-orange-border bg-ui-tag-orange-bg px-3 py-2">
+            <TrianglesMini className="text-ui-tag-orange-icon mt-0.5 shrink-0" />
+            <div className="space-y-1.5">
+              <Text size="xsmall" className="text-ui-tag-orange-text block">
+                This chat is getting long and may exceed the model's context
+                window — the assistant can start to "forget" earlier messages.
+              </Text>
+              <div className="flex items-center gap-x-2">
+                <Button
+                  size="small"
+                  variant="secondary"
+                  onClick={handleCompact}
+                >
+                  <ArrowPathMini />
+                  Compact summary
+                </Button>
+                <Text size="xsmall" className="text-ui-fg-muted">
+                  Or start a new chat to keep responses fast.
+                </Text>
+              </div>
+            </div>
+          </div>
         )}
       </div>
 
@@ -215,14 +395,43 @@ export const ChatThread = ({
           placeholder="Ask the assistant…"
           className="flex-1 resize-none rounded-lg border border-ui-border-base bg-ui-bg-field px-3 py-2 text-sm focus:outline-none focus:border-ui-border-interactive max-h-32"
         />
-        <IconButton
-          type="submit"
-          size="large"
-          disabled={!input.trim() || status !== "ready"}
-        >
-          <ArrowUpMini />
-        </IconButton>
+        {/* Media upload is intentionally not supported in chat. The attachment
+            tool exists in the registry (initiate/complete_media_upload) for the
+            model to call, but a partner cannot attach a file in the composer. */}
+        <Tooltip content="Media upload isn't supported in chat — start a new chat if you need to share a file." side="top">
+          <IconButton type="button" size="large" disabled aria-label="Attach media">
+            <PaperClip />
+          </IconButton>
+        </Tooltip>
+        {streaming ? (
+          <IconButton
+            type="button"
+            size="large"
+            onClick={handleStop}
+            aria-label="Stop generating"
+            className="text-ui-tag-red-icon"
+          >
+            <XMarkMini />
+          </IconButton>
+        ) : (
+          <IconButton
+            type="submit"
+            size="large"
+            disabled={!input.trim() || status !== "ready"}
+            aria-label="Send message"
+          >
+            <ArrowUpMini />
+          </IconButton>
+        )}
       </form>
+      <div className="px-3 pb-2 flex items-center justify-between">
+        <Text size="xsmall" className="text-ui-fg-muted">
+          <Kbd>Enter</Kbd> to send · <Kbd>Shift</Kbd>+<Kbd>Enter</Kbd> for a new line
+        </Text>
+        <Label size="xsmall" className="text-ui-fg-muted">
+          ~{tokenEstimate.toLocaleString()} tokens
+        </Label>
+      </div>
     </div>
   )
 }

--- a/apps/partner-ui/src/routes/assistant/components/tool-data.tsx
+++ b/apps/partner-ui/src/routes/assistant/components/tool-data.tsx
@@ -21,14 +21,27 @@ const PREFERRED_COLUMNS = [
   "handle",
   "email",
   "status",
+  "partner_status",
   "fulfillment_status",
   "payment_status",
   "quantity",
   "sku",
   "total",
+  "total_price",
+  "line_total",
   "amount",
   "currency_code",
+  "supplier_name",
+  "stock_location",
+  "order_lines_count",
+  "line_items_count",
+  "payments_count",
+  "shipments_count",
+  "is_sample",
+  "expected_delivery_date",
+  "order_date",
   "created_at",
+  "updated_at",
 ]
 
 const HIDDEN_KEYS = new Set(["id", "metadata", "raw_amount", "raw_total"])
@@ -183,29 +196,37 @@ export function ToolData({ data }: { data: unknown }) {
     }
   }
 
-  // ---- Single record: key/value grid -------------------------------------
+  // ---- Single record: key/value grid, with nested objects as sub-sections ---
   if (isRecord(data)) {
-    const entries = Object.entries(data).filter(
+    const scalarEntries = Object.entries(data).filter(
       ([k, v]) => !HIDDEN_KEYS.has(k) && (v === null || typeof v !== "object")
     )
-    if (entries.length) {
+    const nestedEntries = Object.entries(data).filter(
+      ([k, v]) => !HIDDEN_KEYS.has(k) && v !== null && typeof v === "object"
+    )
+    if (scalarEntries.length || nestedEntries.length) {
       return (
         <div className="space-y-1.5">
-          <div className="rounded-lg border border-ui-border-base divide-y divide-ui-border-base">
-            {entries.slice(0, 14).map(([k, v]) => (
-              <div key={k} className="flex gap-x-3 px-3 py-1.5">
-                <Text
-                  size="xsmall"
-                  className="w-32 shrink-0 capitalize text-ui-fg-muted"
-                >
-                  {HEADER_LABEL(k)}
-                </Text>
-                <div className="text-sm text-ui-fg-base break-words min-w-0">
-                  {formatValue(k, v)}
+          {scalarEntries.length > 0 && (
+            <div className="rounded-lg border border-ui-border-base divide-y divide-ui-border-base">
+              {scalarEntries.slice(0, 16).map(([k, v]) => (
+                <div key={k} className="flex gap-x-3 px-3 py-1.5">
+                  <Text
+                    size="xsmall"
+                    className="w-40 shrink-0 capitalize text-ui-fg-muted"
+                  >
+                    {HEADER_LABEL(k)}
+                  </Text>
+                  <div className="text-sm text-ui-fg-base break-words min-w-0">
+                    {formatValue(k, v)}
+                  </div>
                 </div>
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          )}
+          {nestedEntries.slice(0, 4).map(([k, v]) => (
+            <NestedSection key={k} label={k} value={v} />
+          ))}
           <RawJsonDisclosure data={data} />
         </div>
       )
@@ -234,4 +255,90 @@ function RawJsonDisclosure({
       </pre>
     </details>
   )
+}
+
+/**
+ * Render a nested object/array from a single-record tool result as a labelled
+ * sub-section — arrays of records become a 3-column mini table (capped), other
+ * objects become an indented key/value list. Keeps the raw JSON disclosure as
+ * the escape hatch so nothing is lost.
+ */
+function NestedSection({ label, value }: { label: string; value: unknown }) {
+  const rows = Array.isArray(value)
+    ? value.every(isRecord)
+      ? (value as Record<string, unknown>[])
+      : null
+    : null
+
+  if (rows && rows.length) {
+    const columns = pickColumns(rows).slice(0, 4)
+    const shown = rows.slice(0, 6)
+    return (
+      <div className="space-y-1">
+        <Text size="xsmall" weight="plus" className="text-ui-fg-muted capitalize">
+          {HEADER_LABEL(label)}{" "}
+          <span className="text-ui-fg-subtle font-normal">
+            · {rows.length} {rows.length === 1 ? "item" : "items"}
+          </span>
+        </Text>
+        <div className="overflow-x-auto rounded-lg border border-ui-border-base">
+          <Table className="min-w-full">
+            <Table.Header>
+              <Table.Row>
+                {columns.map((c) => (
+                  <Table.HeaderCell key={c} className="whitespace-nowrap capitalize">
+                    {HEADER_LABEL(c)}
+                  </Table.HeaderCell>
+                ))}
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {shown.map((row, i) => (
+                <Table.Row key={(row.id as string) || i}>
+                  {columns.map((c) => (
+                    <Table.Cell key={c}>
+                      <div className="text-sm text-ui-fg-base whitespace-nowrap">
+                        {formatValue(c, row[c])}
+                      </div>
+                    </Table.Cell>
+                  ))}
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table>
+        </div>
+      </div>
+    )
+  }
+
+  if (isRecord(value)) {
+    const entries = Object.entries(value).filter(
+      ([k, v]) => !HIDDEN_KEYS.has(k) && (v === null || typeof v !== "object")
+    )
+    if (!entries.length) return null
+    return (
+      <div className="space-y-1">
+        <Text size="xsmall" weight="plus" className="text-ui-fg-muted capitalize">
+          {HEADER_LABEL(label)}
+        </Text>
+        <div className="rounded-lg border border-ui-border-base divide-y divide-ui-border-base ml-2">
+          {entries.slice(0, 10).map(([k, v]) => (
+            <div key={k} className="flex gap-x-3 px-3 py-1.5">
+              <Text
+                size="xsmall"
+                className="w-36 shrink-0 capitalize text-ui-fg-muted"
+              >
+                {HEADER_LABEL(k)}
+              </Text>
+              <div className="text-sm text-ui-fg-base break-words min-w-0">
+                {formatValue(k, v)}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  return null
 }


### PR DESCRIPTION
## Summary

Partner-assistant chat UX and tool-data improvements addressing context handling, controls, and the information tools expose to the partner.

### Chat controls
- **Stop**: the Send button swaps to a red Stop button while the model is `submitted`/`streaming` (incl. reasoning) so a partner can interrupt a long turn.
- **Retry**: on a turn error, an inline **Retry** button calls `regenerate()`. The backend also retries `streamText` construction once (backoff) and sets `maxRetries: 3` for transient upstream failures.
- **Media upload**: not supported in chat — a disabled attach button with a tooltip explains it, instead of silently failing.

### Context window + compaction
- Client estimates tokens (~chars/4 across text/reasoning/tool IO) and shows a live \`~N tokens\` readout.
- At ~20k tokens an orange banner offers **Compact summary**: \`POST /partners/assistant/summarize\` (non-streaming \`generateText\`, retries once) rolls the older turns into a short summary the client stores in place of history — the chat "forgets" older turns but keeps a small summary, repeatable at each interval.

### Sidebar / responsive
- Desktop chat-history sidebar is now collapsible (toggle in the header); mobile gets a slide-over panel (overlay + Esc-to-close) so the chat thread keeps full width on small screens.

### Tools expose more information
- \`list_inventory_orders\` and \`get_inventory_order\` \`transform\` their payload to flatten \`partner_info\` → \`partner_status\`/\`supplier_name\`, plus \`line_total\`, \`line_items_count\`, \`payments_count\`, \`shipments_count\` to the top level (nested originals preserved for raw JSON).
- \`ToolData\` renders nested objects/arrays as labelled sub-grids/mini-tables instead of dropping them; adds inventory-order preferred columns — a systematic improvement benefiting all read tools.

## Files
- \`apps/backend/src/api/partners/assistant/chat/route.ts\` — retry + \`maxRetries\`
- \`apps/backend/src/api/partners/assistant/summarize/{route,validators}.ts\` — new compaction endpoint
- \`apps/backend/src/api/middlewares.ts\` — register summarize route
- \`apps/backend/src/api/partners/mcp/lib/registry.ts\` — inventory-order transforms
- \`apps/partner-ui/src/routes/assistant/assistant.tsx\` — collapsible + mobile sidebar
- \`apps/partner-ui/src/routes/assistant/components/chat-thread.tsx\` — stop/retry/media/context
- \`apps/partner-ui/src/routes/assistant/components/tool-data.tsx\` — nested rendering

## Verification
- \`dispatch.unit.spec.ts\` — 17/17 pass (registry integrity incl. new transforms)
- \`tsc --noEmit\` — clean for all changed files (partner-ui + backend)
- Conversations integration test can't bootstrap in this environment (pre-existing \`medusa-plugin-etsy-sync/.medusa\` not generated) — unrelated to these changes.

## Checklist
- [x] No new env vars required (summarize reuses the existing \`ai_partner_assistant\` role resolution)
- [x] No breaking changes to existing API contracts