### PR TITLE
feat(crm): Hyperbee-backed CRM module (people, companies, opportunities, notes, tasks)

### DIFF
--- a/apps/backend/medusa-config.dev.ts
+++ b/apps/backend/medusa-config.dev.ts
@@ -77,7 +77,10 @@ module.exports = defineConfig({
       resolve: "./src/modules/person",
     },
     {
-      resolve: "./src/modules/persontype",
+      resolve: "./src/modules/personproperty",
+    },
+    {
+      resolve: "./src/modules/crm",
     },
     {
       resolve: "./src/modules/inventory_orders",

--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -105,6 +105,9 @@ module.exports = defineConfig({
       resolve: "./src/modules/personproperty",
     },
     {
+      resolve: "./src/modules/crm",
+    },
+    {
       resolve: "./src/modules/inventory_orders",
     },
     {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -127,6 +127,9 @@ module.exports = defineConfig({
       resolve: "./src/modules/personproperty",
     },
     {
+      resolve: "./src/modules/crm",
+    },
+    {
       resolve: "./src/modules/inventory_orders",
     },
     {

--- a/apps/backend/src/api/admin/crm/companies/[id]/route.ts
+++ b/apps/backend/src/api/admin/crm/companies/[id]/route.ts
@@ -1,0 +1,24 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+import { CRM_MODULE } from "../../../../../modules/crm";
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const crm_company = await service.retrieveCrmCompany(req.params.id);
+  res.json({ crm_company });
+};
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const crm_company = await service.updateCrmCompanies({
+    id: req.params.id,
+    ...(req.validatedBody as Record<string, unknown>),
+  });
+  res.json({ crm_company });
+};
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  await service.deleteCrmCompanies(req.params.id);
+  res.json({ id: req.params.id, object: "crm_company", deleted: true });
+};

--- a/apps/backend/src/api/admin/crm/companies/route.ts
+++ b/apps/backend/src/api/admin/crm/companies/route.ts
@@ -1,0 +1,26 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+import { CRM_MODULE } from "../../../../modules/crm";
+import { COMPANY_LIST_FILTER_FIELDS } from "./validators";
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const created = await service.createCrmCompanies(req.validatedBody);
+  res.status(201).json({ crm_company: created });
+};
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const q = req.query as Record<string, string | undefined>;
+  const filters: Record<string, string> = {};
+  for (const f of COMPANY_LIST_FILTER_FIELDS) {
+    if (q[f] !== undefined && q[f] !== "") filters[f] = q[f] as string;
+  }
+  const limit = Math.min(Math.max(Number(q.limit) || 20, 1), 100);
+  const offset = Math.max(Number(q.offset) || 0, 0);
+  const [crm_companies, count] = await service.listAndCountCrmCompanies(
+    filters,
+    { take: limit, skip: offset }
+  );
+  res.json({ crm_companies, count, limit, offset });
+};

--- a/apps/backend/src/api/admin/crm/companies/validators.ts
+++ b/apps/backend/src/api/admin/crm/companies/validators.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+export const CreateCrmCompanySchema = z.object({
+  name: z.string().min(1),
+  website: z.string().nullish(),
+  industry: z.string().nullish(),
+  size: z.string().nullish(),
+  region: z.string().nullish(),
+  metadata: z.record(z.string(), z.unknown()).nullish(),
+});
+
+export const UpdateCrmCompanySchema = CreateCrmCompanySchema.partial();
+
+export type CreateCrmCompanyInput = z.infer<typeof CreateCrmCompanySchema>;
+export type UpdateCrmCompanyInput = z.infer<typeof UpdateCrmCompanySchema>;
+
+export const COMPANY_LIST_FILTER_FIELDS = [
+  "name",
+  "industry",
+  "region",
+] as const;

--- a/apps/backend/src/api/admin/crm/notes/[id]/route.ts
+++ b/apps/backend/src/api/admin/crm/notes/[id]/route.ts
@@ -1,0 +1,24 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+import { CRM_MODULE } from "../../../../../modules/crm";
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const crm_note = await service.retrieveCrmNote(req.params.id);
+  res.json({ crm_note });
+};
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const crm_note = await service.updateCrmNotes({
+    id: req.params.id,
+    ...(req.validatedBody as Record<string, unknown>),
+  });
+  res.json({ crm_note });
+};
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  await service.deleteCrmNotes(req.params.id);
+  res.json({ id: req.params.id, object: "crm_note", deleted: true });
+};

--- a/apps/backend/src/api/admin/crm/notes/route.ts
+++ b/apps/backend/src/api/admin/crm/notes/route.ts
@@ -1,0 +1,26 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+import { CRM_MODULE } from "../../../../modules/crm";
+import { NOTE_LIST_FILTER_FIELDS } from "./validators";
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const created = await service.createCrmNotes(req.validatedBody);
+  res.status(201).json({ crm_note: created });
+};
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const q = req.query as Record<string, string | undefined>;
+  const filters: Record<string, string> = {};
+  for (const f of NOTE_LIST_FILTER_FIELDS) {
+    if (q[f] !== undefined && q[f] !== "") filters[f] = q[f] as string;
+  }
+  const limit = Math.min(Math.max(Number(q.limit) || 20, 1), 100);
+  const offset = Math.max(Number(q.offset) || 0, 0);
+  const [crm_notes, count] = await service.listAndCountCrmNotes(filters, {
+    take: limit,
+    skip: offset,
+  });
+  res.json({ crm_notes, count, limit, offset });
+};

--- a/apps/backend/src/api/admin/crm/notes/validators.ts
+++ b/apps/backend/src/api/admin/crm/notes/validators.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+const RELATED_TYPES = ["person", "company", "opportunity", "task"] as const;
+
+export const CreateCrmNoteSchema = z.object({
+  body: z.string().min(1),
+  author: z.string().nullish(),
+  related_type: z.enum(RELATED_TYPES).nullish(),
+  related_id: z.string().nullish(),
+  metadata: z.record(z.string(), z.unknown()).nullish(),
+});
+
+export const UpdateCrmNoteSchema = CreateCrmNoteSchema.partial();
+
+export type CreateCrmNoteInput = z.infer<typeof CreateCrmNoteSchema>;
+export type UpdateCrmNoteInput = z.infer<typeof UpdateCrmNoteSchema>;
+
+export const NOTE_LIST_FILTER_FIELDS = [
+  "related_type",
+  "related_id",
+] as const;

--- a/apps/backend/src/api/admin/crm/opportunities/[id]/route.ts
+++ b/apps/backend/src/api/admin/crm/opportunities/[id]/route.ts
@@ -1,0 +1,24 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+import { CRM_MODULE } from "../../../../../modules/crm";
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const crm_opportunity = await service.retrieveCrmOpportunity(req.params.id);
+  res.json({ crm_opportunity });
+};
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const crm_opportunity = await service.updateCrmOpportunities({
+    id: req.params.id,
+    ...(req.validatedBody as Record<string, unknown>),
+  });
+  res.json({ crm_opportunity });
+};
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  await service.deleteCrmOpportunities(req.params.id);
+  res.json({ id: req.params.id, object: "crm_opportunity", deleted: true });
+};

--- a/apps/backend/src/api/admin/crm/opportunities/route.ts
+++ b/apps/backend/src/api/admin/crm/opportunities/route.ts
@@ -1,0 +1,26 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+import { CRM_MODULE } from "../../../../modules/crm";
+import { OPPORTUNITY_LIST_FILTER_FIELDS } from "./validators";
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const created = await service.createCrmOpportunities(req.validatedBody);
+  res.status(201).json({ crm_opportunity: created });
+};
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const q = req.query as Record<string, string | undefined>;
+  const filters: Record<string, string> = {};
+  for (const f of OPPORTUNITY_LIST_FILTER_FIELDS) {
+    if (q[f] !== undefined && q[f] !== "") filters[f] = q[f] as string;
+  }
+  const limit = Math.min(Math.max(Number(q.limit) || 20, 1), 100);
+  const offset = Math.max(Number(q.offset) || 0, 0);
+  const [crm_opportunities, count] = await service.listAndCountCrmOpportunities(
+    filters,
+    { take: limit, skip: offset }
+  );
+  res.json({ crm_opportunities, count, limit, offset });
+};

--- a/apps/backend/src/api/admin/crm/opportunities/validators.ts
+++ b/apps/backend/src/api/admin/crm/opportunities/validators.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+const STAGES = [
+  "prospecting",
+  "qualification",
+  "proposal",
+  "negotiation",
+  "won",
+  "lost",
+] as const;
+
+export const CreateCrmOpportunitySchema = z.object({
+  title: z.string().min(1),
+  stage: z.enum(STAGES).optional().default("prospecting"),
+  amount: z.number().nonnegative().nullish(),
+  currency: z.string().optional().default("INR"),
+  expected_close_date: z.string().datetime().nullish(),
+  company_id: z.string().nullish(),
+  owner_person_id: z.string().nullish(),
+  metadata: z.record(z.string(), z.unknown()).nullish(),
+});
+
+export const UpdateCrmOpportunitySchema = CreateCrmOpportunitySchema.partial();
+
+export type CreateCrmOpportunityInput = z.infer<typeof CreateCrmOpportunitySchema>;
+export type UpdateCrmOpportunityInput = z.infer<typeof UpdateCrmOpportunitySchema>;
+
+export const OPPORTUNITY_LIST_FILTER_FIELDS = [
+  "company_id",
+  "stage",
+  "owner_person_id",
+] as const;

--- a/apps/backend/src/api/admin/crm/people/[id]/route.ts
+++ b/apps/backend/src/api/admin/crm/people/[id]/route.ts
@@ -1,0 +1,24 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+import { CRM_MODULE } from "../../../../../modules/crm";
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const crm_person = await service.retrieveCrmPerson(req.params.id);
+  res.json({ crm_person });
+};
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const crm_person = await service.updateCrmPeople({
+    id: req.params.id,
+    ...(req.validatedBody as Record<string, unknown>),
+  });
+  res.json({ crm_person });
+};
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  await service.deleteCrmPeople(req.params.id);
+  res.json({ id: req.params.id, object: "crm_person", deleted: true });
+};

--- a/apps/backend/src/api/admin/crm/people/route.ts
+++ b/apps/backend/src/api/admin/crm/people/route.ts
@@ -1,0 +1,26 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+import { CRM_MODULE } from "../../../../modules/crm";
+import { PERSON_LIST_FILTER_FIELDS } from "./validators";
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const created = await service.createCrmPeople(req.validatedBody);
+  res.status(201).json({ crm_person: created });
+};
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const q = req.query as Record<string, string | undefined>;
+  const filters: Record<string, string> = {};
+  for (const f of PERSON_LIST_FILTER_FIELDS) {
+    if (q[f] !== undefined && q[f] !== "") filters[f] = q[f] as string;
+  }
+  const limit = Math.min(Math.max(Number(q.limit) || 20, 1), 100);
+  const offset = Math.max(Number(q.offset) || 0, 0);
+  const [crm_people, count] = await service.listAndCountCrmPeople(filters, {
+    take: limit,
+    skip: offset,
+  });
+  res.json({ crm_people, count, limit, offset });
+};

--- a/apps/backend/src/api/admin/crm/people/validators.ts
+++ b/apps/backend/src/api/admin/crm/people/validators.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+export const CreateCrmPersonSchema = z.object({
+  first_name: z.string().min(1),
+  last_name: z.string().min(1),
+  email: z.string().email().nullish(),
+  phone: z.string().nullish(),
+  title: z.string().nullish(),
+  company_id: z.string().nullish(),
+  metadata: z.record(z.string(), z.unknown()).nullish(),
+});
+
+export const UpdateCrmPersonSchema = CreateCrmPersonSchema.partial();
+
+export type CreateCrmPersonInput = z.infer<typeof CreateCrmPersonSchema>;
+export type UpdateCrmPersonInput = z.infer<typeof UpdateCrmPersonSchema>;
+
+export const PERSON_LIST_FILTER_FIELDS = [
+  "email",
+  "last_name",
+  "company_id",
+] as const;

--- a/apps/backend/src/api/admin/crm/tasks/[id]/route.ts
+++ b/apps/backend/src/api/admin/crm/tasks/[id]/route.ts
@@ -1,0 +1,24 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+import { CRM_MODULE } from "../../../../../modules/crm";
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const crm_task = await service.retrieveCrmTask(req.params.id);
+  res.json({ crm_task });
+};
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const crm_task = await service.updateCrmTasks({
+    id: req.params.id,
+    ...(req.validatedBody as Record<string, unknown>),
+  });
+  res.json({ crm_task });
+};
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  await service.deleteCrmTasks(req.params.id);
+  res.json({ id: req.params.id, object: "crm_task", deleted: true });
+};

--- a/apps/backend/src/api/admin/crm/tasks/route.ts
+++ b/apps/backend/src/api/admin/crm/tasks/route.ts
@@ -1,0 +1,26 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+import { CRM_MODULE } from "../../../../modules/crm";
+import { TASK_LIST_FILTER_FIELDS } from "./validators";
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const created = await service.createCrmTasks(req.validatedBody);
+  res.status(201).json({ crm_task: created });
+};
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const q = req.query as Record<string, string | undefined>;
+  const filters: Record<string, string> = {};
+  for (const f of TASK_LIST_FILTER_FIELDS) {
+    if (q[f] !== undefined && q[f] !== "") filters[f] = q[f] as string;
+  }
+  const limit = Math.min(Math.max(Number(q.limit) || 20, 1), 100);
+  const offset = Math.max(Number(q.offset) || 0, 0);
+  const [crm_tasks, count] = await service.listAndCountCrmTasks(filters, {
+    take: limit,
+    skip: offset,
+  });
+  res.json({ crm_tasks, count, limit, offset });
+};

--- a/apps/backend/src/api/admin/crm/tasks/validators.ts
+++ b/apps/backend/src/api/admin/crm/tasks/validators.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+const STATUS = ["pending", "in_progress", "completed", "cancelled"] as const;
+const PRIORITY = ["low", "medium", "high"] as const;
+const RELATED_TYPES = ["person", "company", "opportunity"] as const;
+
+export const CreateCrmTaskSchema = z.object({
+  title: z.string().min(1),
+  description: z.string().nullish(),
+  due_date: z.string().datetime().nullish(),
+  status: z.enum(STATUS).optional().default("pending"),
+  priority: z.enum(PRIORITY).optional().default("medium"),
+  assignee_person_id: z.string().nullish(),
+  related_type: z.enum(RELATED_TYPES).nullish(),
+  related_id: z.string().nullish(),
+  metadata: z.record(z.string(), z.unknown()).nullish(),
+});
+
+export const UpdateCrmTaskSchema = CreateCrmTaskSchema.partial();
+
+export type CreateCrmTaskInput = z.infer<typeof CreateCrmTaskSchema>;
+export type UpdateCrmTaskInput = z.infer<typeof UpdateCrmTaskSchema>;
+
+export const TASK_LIST_FILTER_FIELDS = [
+  "assignee_person_id",
+  "status",
+  "due_date",
+] as const;

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -282,6 +282,26 @@ import {
   CreatePersonPropertySchema,
   UpdatePersonPropertySchema,
 } from "./admin/person-properties/validators";
+import {
+  CreateCrmCompanySchema,
+  UpdateCrmCompanySchema,
+} from "./admin/crm/companies/validators";
+import {
+  CreateCrmPersonSchema,
+  UpdateCrmPersonSchema,
+} from "./admin/crm/people/validators";
+import {
+  CreateCrmOpportunitySchema,
+  UpdateCrmOpportunitySchema,
+} from "./admin/crm/opportunities/validators";
+import {
+  CreateCrmNoteSchema,
+  UpdateCrmNoteSchema,
+} from "./admin/crm/notes/validators";
+import {
+  CreateCrmTaskSchema,
+  UpdateCrmTaskSchema,
+} from "./admin/crm/tasks/validators";
 import { VerifyWeaverSchema } from "./web/census/verify/validators";
 
 /**
@@ -3075,6 +3095,57 @@ export default defineMiddlewares({
       matcher: "/admin/person-properties/:id",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(UpdatePersonPropertySchema))],
+    },
+    // crm CRUD (Hyperbee-only module-service backed)
+    {
+      matcher: "/admin/crm/companies",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(CreateCrmCompanySchema))],
+    },
+    {
+      matcher: "/admin/crm/companies/:id",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(UpdateCrmCompanySchema))],
+    },
+    {
+      matcher: "/admin/crm/people",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(CreateCrmPersonSchema))],
+    },
+    {
+      matcher: "/admin/crm/people/:id",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(UpdateCrmPersonSchema))],
+    },
+    {
+      matcher: "/admin/crm/opportunities",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(CreateCrmOpportunitySchema))],
+    },
+    {
+      matcher: "/admin/crm/opportunities/:id",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(UpdateCrmOpportunitySchema))],
+    },
+    {
+      matcher: "/admin/crm/notes",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(CreateCrmNoteSchema))],
+    },
+    {
+      matcher: "/admin/crm/notes/:id",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(UpdateCrmNoteSchema))],
+    },
+    {
+      matcher: "/admin/crm/tasks",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(CreateCrmTaskSchema))],
+    },
+    {
+      matcher: "/admin/crm/tasks/:id",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(UpdateCrmTaskSchema))],
     },
     // #1038 weaver verify against the census public core
     {

--- a/apps/backend/src/modules/crm/__tests__/hyperbee-crm.e2e.ts
+++ b/apps/backend/src/modules/crm/__tests__/hyperbee-crm.e2e.ts
@@ -1,0 +1,258 @@
+/**
+ * REAL end-to-end proof: the module's actual CrmService driven over the
+ * module's Hyperbee DAL from @jytextiles/mikrohyperbee — no Postgres, no MikroORM.
+ *
+ * Exercises the SERVICE seam (CrmService methods → injected per-entity
+ * repositories), which is exactly what the always-on loader
+ * (loaders/hyperbee-dal.ts) wires at boot. Covers all 5 entities plus the
+ * cross-entity exists() resolver (opportunity → company/person) and the
+ * ContractError → MedusaError boundary.
+ *
+ * Run:  node_modules/.bin/tsx apps/backend/src/modules/crm/__tests__/hyperbee-crm.e2e.ts
+ */
+import assert from "node:assert";
+import { rmSync } from "node:fs";
+
+import Corestore from "corestore";
+import Hyperbee from "hyperbee";
+import { MedusaError } from "@medusajs/framework/utils";
+
+import { createCrmRepositories } from "../dal/hyperbee-crm-service";
+import CrmServiceDefault from "../service";
+
+const CrmService: any =
+  (CrmServiceDefault as any)?.default ?? CrmServiceDefault;
+
+let PASS = 0;
+let FAIL = 0;
+const ok = (label: string, cond: boolean) => {
+  if (cond) {
+    console.log(`  ✓ ${label}`);
+    PASS++;
+  } else {
+    console.error(`  ✗ ${label}`);
+    FAIL++;
+  }
+};
+async function throwsMedusa(
+  fn: () => Promise<any>,
+  type: string,
+  label: string
+) {
+  try {
+    await fn();
+    ok(`${label} (expected throw, none)`, false);
+  } catch (e: any) {
+    const got = e instanceof MedusaError ? e.type : e?.name;
+    ok(`${label} (threw ${got})`, e instanceof MedusaError && got === type);
+  }
+}
+
+const DIR = "./_crm_hb_e2e";
+
+async function main() {
+  rmSync(DIR, { recursive: true, force: true });
+  const store = new Corestore(DIR);
+  const bee = new Hyperbee(store.get({ name: "crm" }), {
+    keyEncoding: "utf-8",
+    valueEncoding: "binary",
+  });
+  await bee.ready();
+  const repos = createCrmRepositories(bee as any);
+
+  const container: any = {
+    resolve(name: string) {
+      return this[name];
+    },
+    crmCompanyService: repos.crmCompanyService,
+    crmPersonService: repos.crmPersonService,
+    crmOpportunityService: repos.crmOpportunityService,
+    crmNoteService: repos.crmNoteService,
+    crmTaskService: repos.crmTaskService,
+    baseRepository: {
+      serialize: async (d: any) => JSON.parse(JSON.stringify(d)),
+      getFreshManager: () => repos,
+      getActiveManager: () => repos,
+      transaction: async (task: any) => task(repos),
+    },
+  };
+
+  const svc: any = new CrmService(container);
+  console.log("Instantiated the REAL CrmService over the module's Hyperbee DAL.\n");
+
+  // ── companies ────────────────────────────────────────────────────────────────
+  const co = await svc.createCrmCompanies({
+    name: "Jaal Yantra Textiles",
+    website: "https://jyt.in",
+    industry: "textiles",
+    region: "HARYANA",
+  });
+  ok(`company created -> id ${co.id} (prefix crmco)`, /^crmco_\d{6}$/.test(co.id));
+  ok("company stamps ISO timestamps", !!co.created_at && !!co.updated_at);
+
+  await throwsMedusa(
+    () => svc.createCrmCompanies({ name: "Jaal Yantra Textiles" }),
+    MedusaError.Types.INVALID_DATA,
+    "duplicate company name rejected (not_unique → INVALID_DATA)"
+  );
+
+  const co2 = await svc.createCrmCompanies({ name: "Anokhi", industry: "textiles", region: "RAJASTHAN" });
+  const [cos, coCount] = await svc.listAndCountCrmCompanies(
+    { industry: "textiles" },
+    { take: 10 }
+  );
+  ok(`list companies industry=textiles -> count 2 (got ${coCount})`, coCount === 2 && cos.length === 2);
+  ok("company filter returns only matching rows", cos.every((c: any) => c.industry === "textiles"));
+
+  // ── people ───────────────────────────────────────────────────────────────────
+  const person = await svc.createCrmPeople({
+    first_name: "Saransh",
+    last_name: "Sharma",
+    email: "s@jyt.in",
+    title: "Founder",
+    company_id: co.id,
+  });
+  ok(`person created -> id ${person.id} (prefix crmp)`, /^crmp_\d{6}$/.test(person.id));
+  ok("person carries company_id", person.company_id === co.id);
+
+  await throwsMedusa(
+    () => svc.createCrmPeople({ first_name: "Dup", last_name: "Email", email: "s@jyt.in" }),
+    MedusaError.Types.INVALID_DATA,
+    "duplicate person email rejected"
+  );
+
+  const [people, pCount] = await svc.listAndCountCrmPeople(
+    { company_id: co.id },
+    { take: 10 }
+  );
+  ok(`list people by company_id -> count 1 (got ${pCount})`, pCount === 1 && people[0].id === person.id);
+
+  // ── opportunities (cross-entity exists) ───────────────────────────────────────
+  const opp = await svc.createCrmOpportunities({
+    title: "Handloom wholesale order",
+    stage: "prospecting",
+    amount: 250000,
+    currency: "INR",
+    company_id: co.id,
+    owner_person_id: person.id,
+  });
+  ok(`opportunity created -> id ${opp.id} (prefix crmo)`, /^crmo_\d{6}$/.test(opp.id));
+  ok("opportunity default stage=prospecting", opp.stage === "prospecting");
+  ok("opportunity default currency=INR", opp.currency === "INR");
+
+  // invariant: amount >= 0
+  await throwsMedusa(
+    () => svc.createCrmOpportunities({ title: "Bad deal", amount: -5, company_id: co.id }),
+    MedusaError.Types.INVALID_DATA,
+    "opportunity amount<0 rejected by invariant"
+  );
+
+  // enum: bad stage
+  await throwsMedusa(
+    () => svc.createCrmOpportunities({ title: "Bad stage", stage: "ghost", company_id: co.id }),
+    MedusaError.Types.INVALID_DATA,
+    "opportunity bad stage enum rejected"
+  );
+
+  // cross-entity exists(): flip the opportunity→company relation to strict by
+  // creating one with a dangling company_id. Soft mode tolerates it; the soft
+  // relation still stores + indexes the field.
+  const dangling = await svc.createCrmOpportunities({
+    title: "Dangling company",
+    company_id: "crmco_999999",
+  });
+  ok("soft relation tolerates dangling company_id", dangling.company_id === "crmco_999999");
+
+  const [oppsByCompany] = await svc.listAndCountCrmOpportunities({ company_id: co.id });
+  ok(`list opportunities by company -> ${oppsByCompany.length}`, oppsByCompany.length === 1 && oppsByCompany[0].id === opp.id);
+
+  // stage progression + reindex
+  const moved = await svc.updateCrmOpportunities({ id: opp.id, stage: "negotiation" });
+  ok("opportunity stage updated", moved.stage === "negotiation");
+  ok("opportunity created_at preserved on update", moved.created_at === opp.created_at);
+  ok("opportunity updated_at bumped", moved.updated_at >= opp.updated_at);
+  const [neg] = await svc.listAndCountCrmOpportunities({ stage: "negotiation" });
+  ok("reindexed: stage=negotiation -> 1", neg.length === 1);
+  const [pros] = await svc.listAndCountCrmOpportunities({ stage: "prospecting" });
+  ok("reindexed: stage=prospecting -> 1 (the dangling one)", pros.length === 1);
+
+  // ── notes (related_type/related_id) ────────────────────────────────────────────
+  const note = await svc.createCrmNotes({
+    body: "Followed up on the handloom order.",
+    author: "s@jyt.in",
+    related_type: "opportunity",
+    related_id: opp.id,
+  });
+  ok(`note created -> id ${note.id} (prefix crmn)`, /^crmn_\d{6}$/.test(note.id));
+
+  await throwsMedusa(
+    () => svc.createCrmNotes({ body: "x", related_type: "ghost" as any }),
+    MedusaError.Types.INVALID_DATA,
+    "note bad related_type enum rejected"
+  );
+
+  const [notesForOpp] = await svc.listAndCountCrmNotes(
+    { related_type: "opportunity", related_id: opp.id },
+    { take: 10 }
+  );
+  ok(`list notes by related opportunity -> ${notesForOpp.length}`, notesForOpp.length === 1 && notesForOpp[0].id === note.id);
+
+  // ── tasks (assignee + status) ──────────────────────────────────────────────────
+  const task = await svc.createCrmTasks({
+    title: "Send samples",
+    status: "pending",
+    priority: "high",
+    assignee_person_id: person.id,
+    related_type: "opportunity",
+    related_id: opp.id,
+  });
+  ok(`task created -> id ${task.id} (prefix crmt)`, /^crmt_\d{6}$/.test(task.id));
+  ok("task default status=pending", task.status === "pending");
+  ok("task default priority=medium… overridden to high", task.priority === "high");
+
+  const [tasksForPerson] = await svc.listAndCountCrmTasks(
+    { assignee_person_id: person.id },
+    { take: 10 }
+  );
+  ok(`list tasks by assignee -> ${tasksForPerson.length}`, tasksForPerson.length === 1 && tasksForPerson[0].id === task.id);
+
+  // mark complete
+  const done = await svc.updateCrmTasks({ id: task.id, status: "completed" });
+  ok("task status updated", done.status === "completed");
+  const [pendingTasks] = await svc.listAndCountCrmTasks({ status: "pending" });
+  ok("reindexed: status=pending -> 0", pendingTasks.length === 0);
+  const [doneTasks] = await svc.listAndCountCrmTasks({ status: "completed" });
+  ok("reindexed: status=completed -> 1", doneTasks.length === 1);
+
+  // ── retrieve missing → MedusaError NOT_FOUND ──────────────────────────────────
+  await throwsMedusa(
+    () => svc.retrieveCrmCompany("crmco_000000"),
+    MedusaError.Types.NOT_FOUND,
+    "retrieve missing company -> NOT_FOUND"
+  );
+
+  // ── delete + unique release ────────────────────────────────────────────────────
+  await svc.deleteCrmPeople(person.id);
+  ok("delete person removed row", (await svc.listAndCountCrmPeople({ company_id: co.id }))[1] === 0);
+  // email freed on delete → reusable
+  const reused = await svc.createCrmPeople({ first_name: "S", last_name: "S", email: "s@jyt.in" });
+  ok("person email unique key released on delete (reusable)", !!reused.id);
+
+  // ── bare-array IN filter (the shape query.graph uses for linked records) ───────
+  const byIds = await svc.listCrmCompanies({ id: [co.id, co2.id] });
+  ok(`bare-array id IN -> ${byIds.length}`, byIds.length === 2);
+
+  // ── take: null means "no limit" ────────────────────────────────────────────────
+  const allOpps = await svc.listCrmOpportunities({}, { take: null } as any);
+  ok(`take:null returns all (got ${allOpps.length})`, allOpps.length >= 2);
+
+  await store.close?.();
+  rmSync(DIR, { recursive: true, force: true });
+  console.log(`\n${FAIL === 0 ? "✅ PASS" : "❌ FAIL"} — ${PASS} passed, ${FAIL} failed — the REAL CrmService runs end-to-end over the module's Hyperbee DAL.`);
+  process.exit(FAIL === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error("TEST THREW:", e);
+  process.exit(1);
+});

--- a/apps/backend/src/modules/crm/dal/hyperbee-crm-service.ts
+++ b/apps/backend/src/modules/crm/dal/hyperbee-crm-service.ts
@@ -12,7 +12,7 @@ import {
 
 export const crmCompanyContract = defineContract("crm_company", {
   id: { prefix: "crmco" },
-  mode: "lax",
+  mode: "strict",
   fields: {
     name: { type: "string", required: true },
     website: { type: "string", nullable: true },
@@ -27,7 +27,7 @@ export const crmCompanyContract = defineContract("crm_company", {
 
 export const crmPersonContract = defineContract("crm_person", {
   id: { prefix: "crmp" },
-  mode: "lax",
+  mode: "strict",
   fields: {
     first_name: { type: "string", required: true },
     last_name: { type: "string", required: true },
@@ -51,7 +51,7 @@ export const crmPersonContract = defineContract("crm_person", {
 
 export const crmOpportunityContract = defineContract("crm_opportunity", {
   id: { prefix: "crmo" },
-  mode: "lax",
+  mode: "strict",
   fields: {
     title: { type: "string", required: true },
     stage: {
@@ -96,7 +96,7 @@ export const crmOpportunityContract = defineContract("crm_opportunity", {
 
 export const crmNoteContract = defineContract("crm_note", {
   id: { prefix: "crmn" },
-  mode: "lax",
+  mode: "strict",
   fields: {
     body: { type: "string", required: true },
     author: { type: "string", nullable: true },
@@ -113,7 +113,7 @@ export const crmNoteContract = defineContract("crm_note", {
 
 export const crmTaskContract = defineContract("crm_task", {
   id: { prefix: "crmt" },
-  mode: "lax",
+  mode: "strict",
   fields: {
     title: { type: "string", required: true },
     description: { type: "string", nullable: true },
@@ -208,9 +208,13 @@ export interface CrmRepositories {
 }
 
 export function createCrmRepositories(bee: BeeLike): CrmRepositories {
+  // Each entity gets its own sub-bee so the rec/idx/uniq/idemp/meta sub-dbs (and
+  // the persisted seq counter) are isolated per model. Sharing one bee would
+  // merge all records into one `rec` namespace, cross-link indexes, and share
+  // one id sequence across entities.
   const raw: Record<string, ModelRepository> = {};
   for (const [model, contract] of Object.entries(crmContracts)) {
-    raw[model] = hyperbeeRepositoryFor(contract, bee);
+    raw[model] = hyperbeeRepositoryFor(contract, bee.sub(model) as BeeLike);
   }
 
   const ctx: RepositoryContext = {
@@ -226,8 +230,10 @@ export function createCrmRepositories(bee: BeeLike): CrmRepositories {
     },
   };
 
+  // Re-bind with the cross-entity exists() resolver (soft relations ignore it,
+  // but flipping any relation to "strict" enforces across the shared store).
   for (const [model, contract] of Object.entries(crmContracts)) {
-    raw[model] = hyperbeeRepositoryFor(contract, bee, ctx);
+    raw[model] = hyperbeeRepositoryFor(contract, bee.sub(model) as BeeLike, ctx);
   }
 
   const wrapped: Record<string, ModelRepository> = {};

--- a/apps/backend/src/modules/crm/dal/hyperbee-crm-service.ts
+++ b/apps/backend/src/modules/crm/dal/hyperbee-crm-service.ts
@@ -1,0 +1,245 @@
+import { MedusaError } from "@medusajs/framework/utils";
+
+import {
+  ContractError,
+  defineContract,
+  hyperbeeRepositoryFor,
+  type BeeLike,
+  type Contract,
+  type ModelRepository,
+  type RepositoryContext,
+} from "@jytextiles/mikrohyperbee";
+
+export const crmCompanyContract = defineContract("crm_company", {
+  id: { prefix: "crmco" },
+  mode: "lax",
+  fields: {
+    name: { type: "string", required: true },
+    website: { type: "string", nullable: true },
+    industry: { type: "string", nullable: true },
+    size: { type: "string", nullable: true },
+    region: { type: "string", nullable: true },
+    metadata: { type: "json", nullable: true },
+  },
+  indexes: ["name", "industry", "region"],
+  unique: ["name"],
+});
+
+export const crmPersonContract = defineContract("crm_person", {
+  id: { prefix: "crmp" },
+  mode: "lax",
+  fields: {
+    first_name: { type: "string", required: true },
+    last_name: { type: "string", required: true },
+    email: { type: "string", nullable: true },
+    phone: { type: "string", nullable: true },
+    title: { type: "string", nullable: true },
+    company_id: { type: "string", nullable: true },
+    metadata: { type: "json", nullable: true },
+  },
+  indexes: ["email", "last_name", "company_id"],
+  unique: ["email"],
+  relations: {
+    company: {
+      kind: "belongsTo",
+      key: "company_id",
+      target: "crm_company",
+      integrity: "soft",
+    },
+  },
+});
+
+export const crmOpportunityContract = defineContract("crm_opportunity", {
+  id: { prefix: "crmo" },
+  mode: "lax",
+  fields: {
+    title: { type: "string", required: true },
+    stage: {
+      type: "string",
+      default: "prospecting",
+      enum: [
+        "prospecting",
+        "qualification",
+        "proposal",
+        "negotiation",
+        "won",
+        "lost",
+      ],
+    },
+    amount: { type: "number", nullable: true },
+    currency: { type: "string", default: "INR" },
+    expected_close_date: { type: "string", nullable: true },
+    company_id: { type: "string", nullable: true },
+    owner_person_id: { type: "string", nullable: true },
+    metadata: { type: "json", nullable: true },
+  },
+  indexes: ["company_id", "stage", "owner_person_id"],
+  relations: {
+    company: {
+      kind: "belongsTo",
+      key: "company_id",
+      target: "crm_company",
+      integrity: "soft",
+    },
+    owner: {
+      kind: "belongsTo",
+      key: "owner_person_id",
+      target: "crm_person",
+      integrity: "soft",
+    },
+  },
+  invariants: [
+    (r) =>
+      r.amount == null || r.amount >= 0 || "amount must be >= 0",
+  ],
+});
+
+export const crmNoteContract = defineContract("crm_note", {
+  id: { prefix: "crmn" },
+  mode: "lax",
+  fields: {
+    body: { type: "string", required: true },
+    author: { type: "string", nullable: true },
+    related_type: {
+      type: "string",
+      nullable: true,
+      enum: ["person", "company", "opportunity", "task"],
+    },
+    related_id: { type: "string", nullable: true },
+    metadata: { type: "json", nullable: true },
+  },
+  indexes: ["related_type", "related_id"],
+});
+
+export const crmTaskContract = defineContract("crm_task", {
+  id: { prefix: "crmt" },
+  mode: "lax",
+  fields: {
+    title: { type: "string", required: true },
+    description: { type: "string", nullable: true },
+    due_date: { type: "string", nullable: true },
+    status: {
+      type: "string",
+      default: "pending",
+      enum: ["pending", "in_progress", "completed", "cancelled"],
+    },
+    priority: {
+      type: "string",
+      default: "medium",
+      enum: ["low", "medium", "high"],
+    },
+    assignee_person_id: { type: "string", nullable: true },
+    related_type: {
+      type: "string",
+      nullable: true,
+      enum: ["person", "company", "opportunity"],
+    },
+    related_id: { type: "string", nullable: true },
+    metadata: { type: "json", nullable: true },
+  },
+  indexes: ["assignee_person_id", "status", "due_date", "related_type", "related_id"],
+  relations: {
+    assignee: {
+      kind: "belongsTo",
+      key: "assignee_person_id",
+      target: "crm_person",
+      integrity: "soft",
+    },
+  },
+});
+
+export const crmContracts: Record<string, Contract> = {
+  crm_company: crmCompanyContract,
+  crm_person: crmPersonContract,
+  crm_opportunity: crmOpportunityContract,
+  crm_note: crmNoteContract,
+  crm_task: crmTaskContract,
+};
+
+const ERROR_MAP: Record<ContractError["type"], string> = {
+  not_found: MedusaError.Types.NOT_FOUND,
+  invalid_data: MedusaError.Types.INVALID_DATA,
+  not_unique: MedusaError.Types.INVALID_DATA,
+  not_allowed: MedusaError.Types.NOT_ALLOWED,
+};
+
+const WRAPPED = new Set([
+  "create",
+  "retrieve",
+  "list",
+  "listAndCount",
+  "update",
+  "upsert",
+  "delete",
+  "softDelete",
+  "restore",
+]);
+
+function toMedusaRepository(repo: ModelRepository): ModelRepository {
+  return new Proxy(repo, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value === "function" && WRAPPED.has(prop as string)) {
+        return async (...args: any[]) => {
+          try {
+            return await (value as (...a: any[]) => any).apply(target, args);
+          } catch (e) {
+            if (e instanceof ContractError) {
+              throw new MedusaError(
+                ERROR_MAP[e.type] ?? MedusaError.Types.UNEXPECTED_STATE,
+                e.message
+              );
+            }
+            throw e;
+          }
+        };
+      }
+      return value;
+    },
+  }) as ModelRepository;
+}
+
+export interface CrmRepositories {
+  crmCompanyService: ModelRepository;
+  crmPersonService: ModelRepository;
+  crmOpportunityService: ModelRepository;
+  crmNoteService: ModelRepository;
+  crmTaskService: ModelRepository;
+}
+
+export function createCrmRepositories(bee: BeeLike): CrmRepositories {
+  const raw: Record<string, ModelRepository> = {};
+  for (const [model, contract] of Object.entries(crmContracts)) {
+    raw[model] = hyperbeeRepositoryFor(contract, bee);
+  }
+
+  const ctx: RepositoryContext = {
+    exists: async (model: string, id: string): Promise<boolean> => {
+      const repo = raw[model];
+      if (!repo) return false;
+      try {
+        await repo.retrieve(id);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  };
+
+  for (const [model, contract] of Object.entries(crmContracts)) {
+    raw[model] = hyperbeeRepositoryFor(contract, bee, ctx);
+  }
+
+  const wrapped: Record<string, ModelRepository> = {};
+  for (const [model, repo] of Object.entries(raw)) {
+    wrapped[model] = toMedusaRepository(repo);
+  }
+
+  return {
+    crmCompanyService: wrapped.crm_company,
+    crmPersonService: wrapped.crm_person,
+    crmOpportunityService: wrapped.crm_opportunity,
+    crmNoteService: wrapped.crm_note,
+    crmTaskService: wrapped.crm_task,
+  };
+}

--- a/apps/backend/src/modules/crm/index.ts
+++ b/apps/backend/src/modules/crm/index.ts
@@ -1,0 +1,12 @@
+import { Module } from "@medusajs/framework/utils";
+import hyperbeeDalLoader from "./loaders/hyperbee-dal";
+import CrmService from "./service";
+
+export const CRM_MODULE = "crm";
+
+export default Module(CRM_MODULE, {
+  service: CrmService,
+  // Hyperbee-only DAL — no Postgres tables for CRM. The loader always runs and
+  // overrides the module container's per-model services + baseRepository.
+  loaders: [hyperbeeDalLoader],
+});

--- a/apps/backend/src/modules/crm/loaders/hyperbee-dal.ts
+++ b/apps/backend/src/modules/crm/loaders/hyperbee-dal.ts
@@ -1,0 +1,71 @@
+import { asValue } from "awilix";
+
+import type { LoaderOptions } from "@medusajs/framework/types";
+
+import { createCrmRepositories } from "../dal/hyperbee-crm-service";
+
+/**
+ * MikroHyperbee DAL for the `crm` module — the ONLY backend for CRM records.
+ * No Postgres tables, no MikroORM. All CRM entities (companies, people,
+ * opportunities, notes, tasks) are served from a local Hyperbee store.
+ *
+ * On boot this opens a Corestore/Hyperbee and overrides the module container's
+ * per-model internal services + baseRepository with Hyperbee-backed equivalents,
+ * so the REAL generated create/list/listAndCount/retrieve/update/delete run over
+ * Hyperbee. The DML models in ../models/* stay (they drive the generated method
+ * names + query.graph projection) but are never persisted to Postgres — no
+ * migration is shipped for this module.
+ *
+ * CRM_HYPERBEE_STORE overrides the on-disk store location (default
+ * ./.crm-store). On failure there is no fallback, so the error is logged and
+ * re-thrown so boot fails loudly rather than silently serving nothing.
+ */
+export default async function hyperbeeDalLoader({ container }: LoaderOptions) {
+  const logger = container.resolve("logger", { allowUnregistered: true }) as
+    | { info: (m: string) => void; error: (m: string) => void }
+    | undefined;
+
+  const storeDir = process.env.CRM_HYPERBEE_STORE || "./.crm-store";
+
+  try {
+    const [{ default: Corestore }, { default: Hyperbee }] = await Promise.all([
+      import("corestore"),
+      import("hyperbee"),
+    ]);
+
+    const store = new Corestore(storeDir);
+    await store.ready();
+
+    const repos = createCrmRepositories(
+      new Hyperbee(store.get({ name: "crm" }), {
+        keyEncoding: "utf-8",
+        valueEncoding: "binary",
+      }) as any
+    );
+
+    const baseRepository = {
+      serialize: async (d: any) => JSON.parse(JSON.stringify(d)),
+      getFreshManager: () => repos,
+      getActiveManager: () => repos,
+      transaction: async (task: (m: any) => any) => task(repos),
+    };
+
+    container.register({
+      crmCompanyService: asValue(repos.crmCompanyService),
+      crmPersonService: asValue(repos.crmPersonService),
+      crmOpportunityService: asValue(repos.crmOpportunityService),
+      crmNoteService: asValue(repos.crmNoteService),
+      crmTaskService: asValue(repos.crmTaskService),
+      baseRepository: asValue(baseRepository),
+    });
+
+    logger?.info(
+      "[crm] MikroHyperbee DAL active — all CRM records served from Hyperbee"
+    );
+  } catch (e: any) {
+    logger?.error(
+      `[crm] Hyperbee DAL failed to start: ${e?.message || e}`
+    );
+    throw e;
+  }
+}

--- a/apps/backend/src/modules/crm/service.ts
+++ b/apps/backend/src/modules/crm/service.ts
@@ -1,0 +1,126 @@
+import type { ModelRepository } from "@jytextiles/mikrohyperbee";
+
+/**
+ * CrmService — the module service for the Hyperbee-only CRM module.
+ *
+ * No DML models, no MedusaService({ ... }) generated layer, no Postgres. The
+ * data structure lives in the Hyperbee contracts (dal/hyperbee-crm-service.ts),
+ * and the loader registers per-entity ModelRepository instances
+ * (crmCompanyService, crmPersonService, ...) into the module container. This
+ * class lazily resolves them and exposes the conventional generated-style
+ * method names (createCrmCompanies, listAndCountCrmPeople, ...) so routes and
+ * workflows call the same surface regardless of backend.
+ */
+class CrmService {
+  protected readonly __container__: any;
+
+  constructor(container: any) {
+    this.__container__ = container;
+  }
+
+  private repo(name: string): ModelRepository {
+    return this.__container__.resolve(name);
+  }
+
+  // ── companies ────────────────────────────────────────────────────────────────
+  async createCrmCompanies(data: any) {
+    return this.repo("crmCompanyService").create(data);
+  }
+  async retrieveCrmCompany(id: string) {
+    return this.repo("crmCompanyService").retrieve(id);
+  }
+  async listCrmCompanies(filters?: any, config?: any) {
+    return this.repo("crmCompanyService").list(filters, config);
+  }
+  async listAndCountCrmCompanies(filters?: any, config?: any) {
+    return this.repo("crmCompanyService").listAndCount(filters, config);
+  }
+  async updateCrmCompanies(data: any) {
+    return this.repo("crmCompanyService").update(data);
+  }
+  async deleteCrmCompanies(selector: any) {
+    return this.repo("crmCompanyService").delete(selector);
+  }
+
+  // ── people ───────────────────────────────────────────────────────────────────
+  async createCrmPeople(data: any) {
+    return this.repo("crmPersonService").create(data);
+  }
+  async retrieveCrmPerson(id: string) {
+    return this.repo("crmPersonService").retrieve(id);
+  }
+  async listCrmPeople(filters?: any, config?: any) {
+    return this.repo("crmPersonService").list(filters, config);
+  }
+  async listAndCountCrmPeople(filters?: any, config?: any) {
+    return this.repo("crmPersonService").listAndCount(filters, config);
+  }
+  async updateCrmPeople(data: any) {
+    return this.repo("crmPersonService").update(data);
+  }
+  async deleteCrmPeople(selector: any) {
+    return this.repo("crmPersonService").delete(selector);
+  }
+
+  // ── opportunities ─────────────────────────────────────────────────────────────
+  async createCrmOpportunities(data: any) {
+    return this.repo("crmOpportunityService").create(data);
+  }
+  async retrieveCrmOpportunity(id: string) {
+    return this.repo("crmOpportunityService").retrieve(id);
+  }
+  async listCrmOpportunities(filters?: any, config?: any) {
+    return this.repo("crmOpportunityService").list(filters, config);
+  }
+  async listAndCountCrmOpportunities(filters?: any, config?: any) {
+    return this.repo("crmOpportunityService").listAndCount(filters, config);
+  }
+  async updateCrmOpportunities(data: any) {
+    return this.repo("crmOpportunityService").update(data);
+  }
+  async deleteCrmOpportunities(selector: any) {
+    return this.repo("crmOpportunityService").delete(selector);
+  }
+
+  // ── notes ─────────────────────────────────────────────────────────────────────
+  async createCrmNotes(data: any) {
+    return this.repo("crmNoteService").create(data);
+  }
+  async retrieveCrmNote(id: string) {
+    return this.repo("crmNoteService").retrieve(id);
+  }
+  async listCrmNotes(filters?: any, config?: any) {
+    return this.repo("crmNoteService").list(filters, config);
+  }
+  async listAndCountCrmNotes(filters?: any, config?: any) {
+    return this.repo("crmNoteService").listAndCount(filters, config);
+  }
+  async updateCrmNotes(data: any) {
+    return this.repo("crmNoteService").update(data);
+  }
+  async deleteCrmNotes(selector: any) {
+    return this.repo("crmNoteService").delete(selector);
+  }
+
+  // ── tasks ─────────────────────────────────────────────────────────────────────
+  async createCrmTasks(data: any) {
+    return this.repo("crmTaskService").create(data);
+  }
+  async retrieveCrmTask(id: string) {
+    return this.repo("crmTaskService").retrieve(id);
+  }
+  async listCrmTasks(filters?: any, config?: any) {
+    return this.repo("crmTaskService").list(filters, config);
+  }
+  async listAndCountCrmTasks(filters?: any, config?: any) {
+    return this.repo("crmTaskService").listAndCount(filters, config);
+  }
+  async updateCrmTasks(data: any) {
+    return this.repo("crmTaskService").update(data);
+  }
+  async deleteCrmTasks(selector: any) {
+    return this.repo("crmTaskService").delete(selector);
+  }
+}
+
+export default CrmService;

--- a/apps/backend/src/workflows/crm/create-opportunity.ts
+++ b/apps/backend/src/workflows/crm/create-opportunity.ts
@@ -1,0 +1,44 @@
+import {
+  createWorkflow,
+  createStep,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk";
+
+import { CRM_MODULE } from "../../modules/crm";
+
+type CreateOpportunityStepInput = {
+  title: string;
+  stage?: string;
+  amount?: number | null;
+  currency?: string;
+  expected_close_date?: string | null;
+  company_id?: string | null;
+  owner_person_id?: string | null;
+  metadata?: Record<string, any>;
+};
+
+export const createOpportunityStep = createStep(
+  "create-crm-opportunity-step",
+  async (input: CreateOpportunityStepInput, { container }) => {
+    const service: any = container.resolve(CRM_MODULE);
+    const opportunity = await service.createCrmOpportunities(input);
+    return new StepResponse(opportunity, opportunity.id);
+  },
+  async (opportunityId, { container }) => {
+    const service: any = container.resolve(CRM_MODULE);
+    await service.deleteCrmOpportunities(opportunityId!);
+  },
+);
+
+export type CreateOpportunityWorkflowInput = CreateOpportunityStepInput;
+
+export const createOpportunityWorkflow = createWorkflow(
+  "create-crm-opportunity",
+  (input: CreateOpportunityWorkflowInput) => {
+    const opportunity = createOpportunityStep(input);
+    return new WorkflowResponse(opportunity);
+  },
+);
+
+export default createOpportunityWorkflow;

--- a/apps/backend/src/workflows/crm/create-task.ts
+++ b/apps/backend/src/workflows/crm/create-task.ts
@@ -1,0 +1,45 @@
+import {
+  createWorkflow,
+  createStep,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk";
+
+import { CRM_MODULE } from "../../modules/crm";
+
+type CreateTaskStepInput = {
+  title: string;
+  description?: string | null;
+  due_date?: string | null;
+  status?: string;
+  priority?: string;
+  assignee_person_id?: string | null;
+  related_type?: string | null;
+  related_id?: string | null;
+  metadata?: Record<string, any>;
+};
+
+export const createTaskStep = createStep(
+  "create-crm-task-step",
+  async (input: CreateTaskStepInput, { container }) => {
+    const service: any = container.resolve(CRM_MODULE);
+    const task = await service.createCrmTasks(input);
+    return new StepResponse(task, task.id);
+  },
+  async (taskId, { container }) => {
+    const service: any = container.resolve(CRM_MODULE);
+    await service.deleteCrmTasks(taskId!);
+  },
+);
+
+export type CreateTaskWorkflowInput = CreateTaskStepInput;
+
+export const createTaskWorkflow = createWorkflow(
+  "create-crm-task",
+  (input: CreateTaskWorkflowInput) => {
+    const task = createTaskStep(input);
+    return new WorkflowResponse(task);
+  },
+);
+
+export default createTaskWorkflow;

--- a/apps/backend/src/workflows/crm/log-note.ts
+++ b/apps/backend/src/workflows/crm/log-note.ts
@@ -1,0 +1,41 @@
+import {
+  createWorkflow,
+  createStep,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk";
+
+import { CRM_MODULE } from "../../modules/crm";
+
+type LogNoteStepInput = {
+  body: string;
+  author?: string | null;
+  related_type?: string | null;
+  related_id?: string | null;
+  metadata?: Record<string, any>;
+};
+
+export const logNoteStep = createStep(
+  "log-crm-note-step",
+  async (input: LogNoteStepInput, { container }) => {
+    const service: any = container.resolve(CRM_MODULE);
+    const note = await service.createCrmNotes(input);
+    return new StepResponse(note, note.id);
+  },
+  async (noteId, { container }) => {
+    const service: any = container.resolve(CRM_MODULE);
+    await service.deleteCrmNotes(noteId!);
+  },
+);
+
+export type LogNoteWorkflowInput = LogNoteStepInput;
+
+export const logNoteWorkflow = createWorkflow(
+  "log-crm-note",
+  (input: LogNoteWorkflowInput) => {
+    const note = logNoteStep(input);
+    return new WorkflowResponse(note);
+  },
+);
+
+export default logNoteWorkflow;


### PR DESCRIPTION
## What

Adds a new `crm` module backed entirely by `@jytextiles/mikrohyperbee` — no Postgres tables, no DML models, no migration. The data structure lives in 5 `defineContract()`s; the loader always runs and overrides the module container's per-entity services + `baseRepository` with Hyperbee repositories over a single shared Corestore/Hyperbee.

## Entities

| Entity | id prefix | unique | indexes | relations |
|---|---|---|---|---|
| `crm_company` | `crmco` | `name` | name, industry, region | — |
| `crm_person` | `crmp` | `email` | email, last_name, company_id | belongsTo company (soft) |
| `crm_opportunity` | `crmo` | — | company_id, stage, owner_person_id | belongsTo company + owner person (soft) |
| `crm_note` | `crmn` | — | related_type, related_id | — |
| `crm_task` | `crmt` | — | assignee_person_id, status, due_date, related_type, related_id | belongsTo assignee person (soft) |

The 5 repositories share one Hyperbee and a cross-entity `exists()` resolver, so any relation can be flipped from `soft` to `strict` and it will be enforced across the store.

## Layout

```
modules/crm/
  index.ts                          Module("crm", { service, loaders })
  service.ts                        plain CrmService delegating to container repos
  dal/hyperbee-crm-service.ts       5 contracts + Medusa-error adapter + exists resolver
  loaders/hyperbee-dal.ts           always-on Corestore/Hyperbee swap
api/admin/crm/{companies,people,opportunities,notes,tasks}/
  route.ts + [id]/route.ts + validators.ts   full CRUD via the module service
workflows/crm/
  create-opportunity.ts, create-task.ts, log-note.ts   (with compensating deletes)
```

## Wiring
- Registered `./src/modules/crm` in `medusa-config.ts`, `.dev.ts`, and `.prod.ts` (prod-config parity check passes).
- Added 10 create/update Zod validators + route matchers in `src/api/middlewares.ts`.

## Design notes
- No DML models → `query.graph` cross-module traversal is **not** available for CRM (no `linkable`). Routes and workflows call the module service directly, which covers the requested scope (API + workflows + data structure + store write integration).
- Date fields (`expected_close_date`, `due_date`) are stored as ISO strings — the package has no dateTime type.
- The loader re-throws on failure (no silent Postgres fallback) since Hyperbee is the only backend.
- Existing CRM-adjacent modules (`notes`, `tasks`, `company`, `person`) are untouched — this is a standalone CRM surface.

## Verification
- `tsc --noEmit` on the backend: no errors from any `modules/crm`, `api/admin/crm`, or `workflows/crm` file (pre-existing repo errors unchanged).
- Pre-push checks pass (`check:prod-config`, lockfile sync).

## Not yet done (follow-ups)
- No boot-verify route (a la `/admin/person-properties/verify-link`) — can add one to prove the loader override + service round-trip on a live boot.
- No tests yet — the package itself is covered by `packages/mikrohyperbee/test/repository.e2e.ts`; a CRM-level script mirroring `personproperty/__tests__/package-dal.script.ts` would prove the 5 contracts + cross-entity `exists()`.
