### PR TITLE
feat(crm): Hyperbee CRM → Autobase multi-writer → prod (Topology A) [#1082]

### DIFF
--- a/apps/backend/medusa-config.dev.ts
+++ b/apps/backend/medusa-config.dev.ts
@@ -77,7 +77,10 @@ module.exports = defineConfig({
       resolve: "./src/modules/person",
     },
     {
-      resolve: "./src/modules/persontype",
+      resolve: "./src/modules/personproperty",
+    },
+    {
+      resolve: "./src/modules/crm",
     },
     {
       resolve: "./src/modules/inventory_orders",

--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -105,6 +105,9 @@ module.exports = defineConfig({
       resolve: "./src/modules/personproperty",
     },
     {
+      resolve: "./src/modules/crm",
+    },
+    {
       resolve: "./src/modules/inventory_orders",
     },
     {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -127,6 +127,9 @@ module.exports = defineConfig({
       resolve: "./src/modules/personproperty",
     },
     {
+      resolve: "./src/modules/crm",
+    },
+    {
       resolve: "./src/modules/inventory_orders",
     },
     {

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -135,6 +135,7 @@
     "@xyflow/react": "^12.4.4",
     "ai": "^5.0.52",
     "ajv": "^8.18.0",
+    "autobase": "^7.28.1",
     "awilix": "^8.0.1",
     "bwip-js": "^4.8.0",
     "class-variance-authority": "^0.7.1",

--- a/apps/backend/src/api/admin/crm/companies/[id]/route.ts
+++ b/apps/backend/src/api/admin/crm/companies/[id]/route.ts
@@ -1,0 +1,24 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+import { CRM_MODULE } from "../../../../../modules/crm";
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const crm_company = await service.retrieveCrmCompany(req.params.id);
+  res.json({ crm_company });
+};
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const crm_company = await service.updateCrmCompanies({
+    id: req.params.id,
+    ...(req.validatedBody as Record<string, unknown>),
+  });
+  res.json({ crm_company });
+};
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  await service.deleteCrmCompanies(req.params.id);
+  res.json({ id: req.params.id, object: "crm_company", deleted: true });
+};

--- a/apps/backend/src/api/admin/crm/companies/route.ts
+++ b/apps/backend/src/api/admin/crm/companies/route.ts
@@ -1,0 +1,26 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+import { CRM_MODULE } from "../../../../modules/crm";
+import { COMPANY_LIST_FILTER_FIELDS } from "./validators";
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const created = await service.createCrmCompanies(req.validatedBody);
+  res.status(201).json({ crm_company: created });
+};
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const q = req.query as Record<string, string | undefined>;
+  const filters: Record<string, string> = {};
+  for (const f of COMPANY_LIST_FILTER_FIELDS) {
+    if (q[f] !== undefined && q[f] !== "") filters[f] = q[f] as string;
+  }
+  const limit = Math.min(Math.max(Number(q.limit) || 20, 1), 100);
+  const offset = Math.max(Number(q.offset) || 0, 0);
+  const [crm_companies, count] = await service.listAndCountCrmCompanies(
+    filters,
+    { take: limit, skip: offset }
+  );
+  res.json({ crm_companies, count, limit, offset });
+};

--- a/apps/backend/src/api/admin/crm/companies/validators.ts
+++ b/apps/backend/src/api/admin/crm/companies/validators.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+export const CreateCrmCompanySchema = z.object({
+  name: z.string().min(1),
+  website: z.string().nullish(),
+  industry: z.string().nullish(),
+  size: z.string().nullish(),
+  region: z.string().nullish(),
+  metadata: z.record(z.string(), z.unknown()).nullish(),
+});
+
+export const UpdateCrmCompanySchema = CreateCrmCompanySchema.partial();
+
+export type CreateCrmCompanyInput = z.infer<typeof CreateCrmCompanySchema>;
+export type UpdateCrmCompanyInput = z.infer<typeof UpdateCrmCompanySchema>;
+
+export const COMPANY_LIST_FILTER_FIELDS = [
+  "name",
+  "industry",
+  "region",
+] as const;

--- a/apps/backend/src/api/admin/crm/notes/[id]/route.ts
+++ b/apps/backend/src/api/admin/crm/notes/[id]/route.ts
@@ -1,0 +1,24 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+import { CRM_MODULE } from "../../../../../modules/crm";
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const crm_note = await service.retrieveCrmNote(req.params.id);
+  res.json({ crm_note });
+};
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const crm_note = await service.updateCrmNotes({
+    id: req.params.id,
+    ...(req.validatedBody as Record<string, unknown>),
+  });
+  res.json({ crm_note });
+};
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  await service.deleteCrmNotes(req.params.id);
+  res.json({ id: req.params.id, object: "crm_note", deleted: true });
+};

--- a/apps/backend/src/api/admin/crm/notes/route.ts
+++ b/apps/backend/src/api/admin/crm/notes/route.ts
@@ -1,0 +1,26 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+import { CRM_MODULE } from "../../../../modules/crm";
+import { NOTE_LIST_FILTER_FIELDS } from "./validators";
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const created = await service.createCrmNotes(req.validatedBody);
+  res.status(201).json({ crm_note: created });
+};
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const q = req.query as Record<string, string | undefined>;
+  const filters: Record<string, string> = {};
+  for (const f of NOTE_LIST_FILTER_FIELDS) {
+    if (q[f] !== undefined && q[f] !== "") filters[f] = q[f] as string;
+  }
+  const limit = Math.min(Math.max(Number(q.limit) || 20, 1), 100);
+  const offset = Math.max(Number(q.offset) || 0, 0);
+  const [crm_notes, count] = await service.listAndCountCrmNotes(filters, {
+    take: limit,
+    skip: offset,
+  });
+  res.json({ crm_notes, count, limit, offset });
+};

--- a/apps/backend/src/api/admin/crm/notes/validators.ts
+++ b/apps/backend/src/api/admin/crm/notes/validators.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+const RELATED_TYPES = ["person", "company", "opportunity", "task"] as const;
+
+export const CreateCrmNoteSchema = z.object({
+  body: z.string().min(1),
+  author: z.string().nullish(),
+  related_type: z.enum(RELATED_TYPES).nullish(),
+  related_id: z.string().nullish(),
+  metadata: z.record(z.string(), z.unknown()).nullish(),
+});
+
+export const UpdateCrmNoteSchema = CreateCrmNoteSchema.partial();
+
+export type CreateCrmNoteInput = z.infer<typeof CreateCrmNoteSchema>;
+export type UpdateCrmNoteInput = z.infer<typeof UpdateCrmNoteSchema>;
+
+export const NOTE_LIST_FILTER_FIELDS = [
+  "related_type",
+  "related_id",
+] as const;

--- a/apps/backend/src/api/admin/crm/opportunities/[id]/route.ts
+++ b/apps/backend/src/api/admin/crm/opportunities/[id]/route.ts
@@ -1,0 +1,24 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+import { CRM_MODULE } from "../../../../../modules/crm";
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const crm_opportunity = await service.retrieveCrmOpportunity(req.params.id);
+  res.json({ crm_opportunity });
+};
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const crm_opportunity = await service.updateCrmOpportunities({
+    id: req.params.id,
+    ...(req.validatedBody as Record<string, unknown>),
+  });
+  res.json({ crm_opportunity });
+};
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  await service.deleteCrmOpportunities(req.params.id);
+  res.json({ id: req.params.id, object: "crm_opportunity", deleted: true });
+};

--- a/apps/backend/src/api/admin/crm/opportunities/route.ts
+++ b/apps/backend/src/api/admin/crm/opportunities/route.ts
@@ -1,0 +1,26 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+import { CRM_MODULE } from "../../../../modules/crm";
+import { OPPORTUNITY_LIST_FILTER_FIELDS } from "./validators";
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const created = await service.createCrmOpportunities(req.validatedBody);
+  res.status(201).json({ crm_opportunity: created });
+};
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const q = req.query as Record<string, string | undefined>;
+  const filters: Record<string, string> = {};
+  for (const f of OPPORTUNITY_LIST_FILTER_FIELDS) {
+    if (q[f] !== undefined && q[f] !== "") filters[f] = q[f] as string;
+  }
+  const limit = Math.min(Math.max(Number(q.limit) || 20, 1), 100);
+  const offset = Math.max(Number(q.offset) || 0, 0);
+  const [crm_opportunities, count] = await service.listAndCountCrmOpportunities(
+    filters,
+    { take: limit, skip: offset }
+  );
+  res.json({ crm_opportunities, count, limit, offset });
+};

--- a/apps/backend/src/api/admin/crm/opportunities/validators.ts
+++ b/apps/backend/src/api/admin/crm/opportunities/validators.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+const STAGES = [
+  "prospecting",
+  "qualification",
+  "proposal",
+  "negotiation",
+  "won",
+  "lost",
+] as const;
+
+export const CreateCrmOpportunitySchema = z.object({
+  title: z.string().min(1),
+  stage: z.enum(STAGES).optional().default("prospecting"),
+  amount: z.number().nonnegative().nullish(),
+  currency: z.string().optional().default("INR"),
+  expected_close_date: z.string().datetime().nullish(),
+  company_id: z.string().nullish(),
+  owner_person_id: z.string().nullish(),
+  metadata: z.record(z.string(), z.unknown()).nullish(),
+});
+
+export const UpdateCrmOpportunitySchema = CreateCrmOpportunitySchema.partial();
+
+export type CreateCrmOpportunityInput = z.infer<typeof CreateCrmOpportunitySchema>;
+export type UpdateCrmOpportunityInput = z.infer<typeof UpdateCrmOpportunitySchema>;
+
+export const OPPORTUNITY_LIST_FILTER_FIELDS = [
+  "company_id",
+  "stage",
+  "owner_person_id",
+] as const;

--- a/apps/backend/src/api/admin/crm/people/[id]/route.ts
+++ b/apps/backend/src/api/admin/crm/people/[id]/route.ts
@@ -1,0 +1,24 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+import { CRM_MODULE } from "../../../../../modules/crm";
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const crm_person = await service.retrieveCrmPerson(req.params.id);
+  res.json({ crm_person });
+};
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const crm_person = await service.updateCrmPeople({
+    id: req.params.id,
+    ...(req.validatedBody as Record<string, unknown>),
+  });
+  res.json({ crm_person });
+};
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  await service.deleteCrmPeople(req.params.id);
+  res.json({ id: req.params.id, object: "crm_person", deleted: true });
+};

--- a/apps/backend/src/api/admin/crm/people/route.ts
+++ b/apps/backend/src/api/admin/crm/people/route.ts
@@ -1,0 +1,26 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+import { CRM_MODULE } from "../../../../modules/crm";
+import { PERSON_LIST_FILTER_FIELDS } from "./validators";
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const created = await service.createCrmPeople(req.validatedBody);
+  res.status(201).json({ crm_person: created });
+};
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const q = req.query as Record<string, string | undefined>;
+  const filters: Record<string, string> = {};
+  for (const f of PERSON_LIST_FILTER_FIELDS) {
+    if (q[f] !== undefined && q[f] !== "") filters[f] = q[f] as string;
+  }
+  const limit = Math.min(Math.max(Number(q.limit) || 20, 1), 100);
+  const offset = Math.max(Number(q.offset) || 0, 0);
+  const [crm_people, count] = await service.listAndCountCrmPeople(filters, {
+    take: limit,
+    skip: offset,
+  });
+  res.json({ crm_people, count, limit, offset });
+};

--- a/apps/backend/src/api/admin/crm/people/validators.ts
+++ b/apps/backend/src/api/admin/crm/people/validators.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+export const CreateCrmPersonSchema = z.object({
+  first_name: z.string().min(1),
+  last_name: z.string().min(1),
+  email: z.string().email().nullish(),
+  phone: z.string().nullish(),
+  title: z.string().nullish(),
+  company_id: z.string().nullish(),
+  metadata: z.record(z.string(), z.unknown()).nullish(),
+});
+
+export const UpdateCrmPersonSchema = CreateCrmPersonSchema.partial();
+
+export type CreateCrmPersonInput = z.infer<typeof CreateCrmPersonSchema>;
+export type UpdateCrmPersonInput = z.infer<typeof UpdateCrmPersonSchema>;
+
+export const PERSON_LIST_FILTER_FIELDS = [
+  "email",
+  "last_name",
+  "company_id",
+] as const;

--- a/apps/backend/src/api/admin/crm/tasks/[id]/route.ts
+++ b/apps/backend/src/api/admin/crm/tasks/[id]/route.ts
@@ -1,0 +1,24 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+import { CRM_MODULE } from "../../../../../modules/crm";
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const crm_task = await service.retrieveCrmTask(req.params.id);
+  res.json({ crm_task });
+};
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const crm_task = await service.updateCrmTasks({
+    id: req.params.id,
+    ...(req.validatedBody as Record<string, unknown>),
+  });
+  res.json({ crm_task });
+};
+
+export const DELETE = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  await service.deleteCrmTasks(req.params.id);
+  res.json({ id: req.params.id, object: "crm_task", deleted: true });
+};

--- a/apps/backend/src/api/admin/crm/tasks/route.ts
+++ b/apps/backend/src/api/admin/crm/tasks/route.ts
@@ -1,0 +1,26 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http";
+
+import { CRM_MODULE } from "../../../../modules/crm";
+import { TASK_LIST_FILTER_FIELDS } from "./validators";
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const created = await service.createCrmTasks(req.validatedBody);
+  res.status(201).json({ crm_task: created });
+};
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const service: any = req.scope.resolve(CRM_MODULE);
+  const q = req.query as Record<string, string | undefined>;
+  const filters: Record<string, string> = {};
+  for (const f of TASK_LIST_FILTER_FIELDS) {
+    if (q[f] !== undefined && q[f] !== "") filters[f] = q[f] as string;
+  }
+  const limit = Math.min(Math.max(Number(q.limit) || 20, 1), 100);
+  const offset = Math.max(Number(q.offset) || 0, 0);
+  const [crm_tasks, count] = await service.listAndCountCrmTasks(filters, {
+    take: limit,
+    skip: offset,
+  });
+  res.json({ crm_tasks, count, limit, offset });
+};

--- a/apps/backend/src/api/admin/crm/tasks/validators.ts
+++ b/apps/backend/src/api/admin/crm/tasks/validators.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+const STATUS = ["pending", "in_progress", "completed", "cancelled"] as const;
+const PRIORITY = ["low", "medium", "high"] as const;
+const RELATED_TYPES = ["person", "company", "opportunity"] as const;
+
+export const CreateCrmTaskSchema = z.object({
+  title: z.string().min(1),
+  description: z.string().nullish(),
+  due_date: z.string().datetime().nullish(),
+  status: z.enum(STATUS).optional().default("pending"),
+  priority: z.enum(PRIORITY).optional().default("medium"),
+  assignee_person_id: z.string().nullish(),
+  related_type: z.enum(RELATED_TYPES).nullish(),
+  related_id: z.string().nullish(),
+  metadata: z.record(z.string(), z.unknown()).nullish(),
+});
+
+export const UpdateCrmTaskSchema = CreateCrmTaskSchema.partial();
+
+export type CreateCrmTaskInput = z.infer<typeof CreateCrmTaskSchema>;
+export type UpdateCrmTaskInput = z.infer<typeof UpdateCrmTaskSchema>;
+
+export const TASK_LIST_FILTER_FIELDS = [
+  "assignee_person_id",
+  "status",
+  "due_date",
+] as const;

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -282,6 +282,26 @@ import {
   CreatePersonPropertySchema,
   UpdatePersonPropertySchema,
 } from "./admin/person-properties/validators";
+import {
+  CreateCrmCompanySchema,
+  UpdateCrmCompanySchema,
+} from "./admin/crm/companies/validators";
+import {
+  CreateCrmPersonSchema,
+  UpdateCrmPersonSchema,
+} from "./admin/crm/people/validators";
+import {
+  CreateCrmOpportunitySchema,
+  UpdateCrmOpportunitySchema,
+} from "./admin/crm/opportunities/validators";
+import {
+  CreateCrmNoteSchema,
+  UpdateCrmNoteSchema,
+} from "./admin/crm/notes/validators";
+import {
+  CreateCrmTaskSchema,
+  UpdateCrmTaskSchema,
+} from "./admin/crm/tasks/validators";
 import { VerifyWeaverSchema } from "./web/census/verify/validators";
 
 /**
@@ -3075,6 +3095,57 @@ export default defineMiddlewares({
       matcher: "/admin/person-properties/:id",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(UpdatePersonPropertySchema))],
+    },
+    // crm CRUD (Hyperbee-only module-service backed)
+    {
+      matcher: "/admin/crm/companies",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(CreateCrmCompanySchema))],
+    },
+    {
+      matcher: "/admin/crm/companies/:id",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(UpdateCrmCompanySchema))],
+    },
+    {
+      matcher: "/admin/crm/people",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(CreateCrmPersonSchema))],
+    },
+    {
+      matcher: "/admin/crm/people/:id",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(UpdateCrmPersonSchema))],
+    },
+    {
+      matcher: "/admin/crm/opportunities",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(CreateCrmOpportunitySchema))],
+    },
+    {
+      matcher: "/admin/crm/opportunities/:id",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(UpdateCrmOpportunitySchema))],
+    },
+    {
+      matcher: "/admin/crm/notes",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(CreateCrmNoteSchema))],
+    },
+    {
+      matcher: "/admin/crm/notes/:id",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(UpdateCrmNoteSchema))],
+    },
+    {
+      matcher: "/admin/crm/tasks",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(CreateCrmTaskSchema))],
+    },
+    {
+      matcher: "/admin/crm/tasks/:id",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(UpdateCrmTaskSchema))],
     },
     // #1038 weaver verify against the census public core
     {

--- a/apps/backend/src/modules/crm/__tests__/hyperbee-crm.e2e.ts
+++ b/apps/backend/src/modules/crm/__tests__/hyperbee-crm.e2e.ts
@@ -1,0 +1,258 @@
+/**
+ * REAL end-to-end proof: the module's actual CrmService driven over the
+ * module's Hyperbee DAL from @jytextiles/mikrohyperbee — no Postgres, no MikroORM.
+ *
+ * Exercises the SERVICE seam (CrmService methods → injected per-entity
+ * repositories), which is exactly what the always-on loader
+ * (loaders/hyperbee-dal.ts) wires at boot. Covers all 5 entities plus the
+ * cross-entity exists() resolver (opportunity → company/person) and the
+ * ContractError → MedusaError boundary.
+ *
+ * Run:  node_modules/.bin/tsx apps/backend/src/modules/crm/__tests__/hyperbee-crm.e2e.ts
+ */
+import assert from "node:assert";
+import { rmSync } from "node:fs";
+
+import Corestore from "corestore";
+import Hyperbee from "hyperbee";
+import { MedusaError } from "@medusajs/framework/utils";
+
+import { createCrmRepositories } from "../dal/hyperbee-crm-service";
+import CrmServiceDefault from "../service";
+
+const CrmService: any =
+  (CrmServiceDefault as any)?.default ?? CrmServiceDefault;
+
+let PASS = 0;
+let FAIL = 0;
+const ok = (label: string, cond: boolean) => {
+  if (cond) {
+    console.log(`  ✓ ${label}`);
+    PASS++;
+  } else {
+    console.error(`  ✗ ${label}`);
+    FAIL++;
+  }
+};
+async function throwsMedusa(
+  fn: () => Promise<any>,
+  type: string,
+  label: string
+) {
+  try {
+    await fn();
+    ok(`${label} (expected throw, none)`, false);
+  } catch (e: any) {
+    const got = e instanceof MedusaError ? e.type : e?.name;
+    ok(`${label} (threw ${got})`, e instanceof MedusaError && got === type);
+  }
+}
+
+const DIR = "./_crm_hb_e2e";
+
+async function main() {
+  rmSync(DIR, { recursive: true, force: true });
+  const store = new Corestore(DIR);
+  const bee = new Hyperbee(store.get({ name: "crm" }), {
+    keyEncoding: "utf-8",
+    valueEncoding: "binary",
+  });
+  await bee.ready();
+  const repos = createCrmRepositories(bee as any);
+
+  const container: any = {
+    resolve(name: string) {
+      return this[name];
+    },
+    crmCompanyService: repos.crmCompanyService,
+    crmPersonService: repos.crmPersonService,
+    crmOpportunityService: repos.crmOpportunityService,
+    crmNoteService: repos.crmNoteService,
+    crmTaskService: repos.crmTaskService,
+    baseRepository: {
+      serialize: async (d: any) => JSON.parse(JSON.stringify(d)),
+      getFreshManager: () => repos,
+      getActiveManager: () => repos,
+      transaction: async (task: any) => task(repos),
+    },
+  };
+
+  const svc: any = new CrmService(container);
+  console.log("Instantiated the REAL CrmService over the module's Hyperbee DAL.\n");
+
+  // ── companies ────────────────────────────────────────────────────────────────
+  const co = await svc.createCrmCompanies({
+    name: "Jaal Yantra Textiles",
+    website: "https://jyt.in",
+    industry: "textiles",
+    region: "HARYANA",
+  });
+  ok(`company created -> id ${co.id} (prefix crmco)`, /^crmco_\d{6}$/.test(co.id));
+  ok("company stamps ISO timestamps", !!co.created_at && !!co.updated_at);
+
+  await throwsMedusa(
+    () => svc.createCrmCompanies({ name: "Jaal Yantra Textiles" }),
+    MedusaError.Types.INVALID_DATA,
+    "duplicate company name rejected (not_unique → INVALID_DATA)"
+  );
+
+  const co2 = await svc.createCrmCompanies({ name: "Anokhi", industry: "textiles", region: "RAJASTHAN" });
+  const [cos, coCount] = await svc.listAndCountCrmCompanies(
+    { industry: "textiles" },
+    { take: 10 }
+  );
+  ok(`list companies industry=textiles -> count 2 (got ${coCount})`, coCount === 2 && cos.length === 2);
+  ok("company filter returns only matching rows", cos.every((c: any) => c.industry === "textiles"));
+
+  // ── people ───────────────────────────────────────────────────────────────────
+  const person = await svc.createCrmPeople({
+    first_name: "Saransh",
+    last_name: "Sharma",
+    email: "s@jyt.in",
+    title: "Founder",
+    company_id: co.id,
+  });
+  ok(`person created -> id ${person.id} (prefix crmp)`, /^crmp_\d{6}$/.test(person.id));
+  ok("person carries company_id", person.company_id === co.id);
+
+  await throwsMedusa(
+    () => svc.createCrmPeople({ first_name: "Dup", last_name: "Email", email: "s@jyt.in" }),
+    MedusaError.Types.INVALID_DATA,
+    "duplicate person email rejected"
+  );
+
+  const [people, pCount] = await svc.listAndCountCrmPeople(
+    { company_id: co.id },
+    { take: 10 }
+  );
+  ok(`list people by company_id -> count 1 (got ${pCount})`, pCount === 1 && people[0].id === person.id);
+
+  // ── opportunities (cross-entity exists) ───────────────────────────────────────
+  const opp = await svc.createCrmOpportunities({
+    title: "Handloom wholesale order",
+    stage: "prospecting",
+    amount: 250000,
+    currency: "INR",
+    company_id: co.id,
+    owner_person_id: person.id,
+  });
+  ok(`opportunity created -> id ${opp.id} (prefix crmo)`, /^crmo_\d{6}$/.test(opp.id));
+  ok("opportunity default stage=prospecting", opp.stage === "prospecting");
+  ok("opportunity default currency=INR", opp.currency === "INR");
+
+  // invariant: amount >= 0
+  await throwsMedusa(
+    () => svc.createCrmOpportunities({ title: "Bad deal", amount: -5, company_id: co.id }),
+    MedusaError.Types.INVALID_DATA,
+    "opportunity amount<0 rejected by invariant"
+  );
+
+  // enum: bad stage
+  await throwsMedusa(
+    () => svc.createCrmOpportunities({ title: "Bad stage", stage: "ghost", company_id: co.id }),
+    MedusaError.Types.INVALID_DATA,
+    "opportunity bad stage enum rejected"
+  );
+
+  // cross-entity exists(): flip the opportunity→company relation to strict by
+  // creating one with a dangling company_id. Soft mode tolerates it; the soft
+  // relation still stores + indexes the field.
+  const dangling = await svc.createCrmOpportunities({
+    title: "Dangling company",
+    company_id: "crmco_999999",
+  });
+  ok("soft relation tolerates dangling company_id", dangling.company_id === "crmco_999999");
+
+  const [oppsByCompany] = await svc.listAndCountCrmOpportunities({ company_id: co.id });
+  ok(`list opportunities by company -> ${oppsByCompany.length}`, oppsByCompany.length === 1 && oppsByCompany[0].id === opp.id);
+
+  // stage progression + reindex
+  const moved = await svc.updateCrmOpportunities({ id: opp.id, stage: "negotiation" });
+  ok("opportunity stage updated", moved.stage === "negotiation");
+  ok("opportunity created_at preserved on update", moved.created_at === opp.created_at);
+  ok("opportunity updated_at bumped", moved.updated_at >= opp.updated_at);
+  const [neg] = await svc.listAndCountCrmOpportunities({ stage: "negotiation" });
+  ok("reindexed: stage=negotiation -> 1", neg.length === 1);
+  const [pros] = await svc.listAndCountCrmOpportunities({ stage: "prospecting" });
+  ok("reindexed: stage=prospecting -> 1 (the dangling one)", pros.length === 1);
+
+  // ── notes (related_type/related_id) ────────────────────────────────────────────
+  const note = await svc.createCrmNotes({
+    body: "Followed up on the handloom order.",
+    author: "s@jyt.in",
+    related_type: "opportunity",
+    related_id: opp.id,
+  });
+  ok(`note created -> id ${note.id} (prefix crmn)`, /^crmn_\d{6}$/.test(note.id));
+
+  await throwsMedusa(
+    () => svc.createCrmNotes({ body: "x", related_type: "ghost" as any }),
+    MedusaError.Types.INVALID_DATA,
+    "note bad related_type enum rejected"
+  );
+
+  const [notesForOpp] = await svc.listAndCountCrmNotes(
+    { related_type: "opportunity", related_id: opp.id },
+    { take: 10 }
+  );
+  ok(`list notes by related opportunity -> ${notesForOpp.length}`, notesForOpp.length === 1 && notesForOpp[0].id === note.id);
+
+  // ── tasks (assignee + status) ──────────────────────────────────────────────────
+  const task = await svc.createCrmTasks({
+    title: "Send samples",
+    status: "pending",
+    priority: "high",
+    assignee_person_id: person.id,
+    related_type: "opportunity",
+    related_id: opp.id,
+  });
+  ok(`task created -> id ${task.id} (prefix crmt)`, /^crmt_\d{6}$/.test(task.id));
+  ok("task default status=pending", task.status === "pending");
+  ok("task default priority=medium… overridden to high", task.priority === "high");
+
+  const [tasksForPerson] = await svc.listAndCountCrmTasks(
+    { assignee_person_id: person.id },
+    { take: 10 }
+  );
+  ok(`list tasks by assignee -> ${tasksForPerson.length}`, tasksForPerson.length === 1 && tasksForPerson[0].id === task.id);
+
+  // mark complete
+  const done = await svc.updateCrmTasks({ id: task.id, status: "completed" });
+  ok("task status updated", done.status === "completed");
+  const [pendingTasks] = await svc.listAndCountCrmTasks({ status: "pending" });
+  ok("reindexed: status=pending -> 0", pendingTasks.length === 0);
+  const [doneTasks] = await svc.listAndCountCrmTasks({ status: "completed" });
+  ok("reindexed: status=completed -> 1", doneTasks.length === 1);
+
+  // ── retrieve missing → MedusaError NOT_FOUND ──────────────────────────────────
+  await throwsMedusa(
+    () => svc.retrieveCrmCompany("crmco_000000"),
+    MedusaError.Types.NOT_FOUND,
+    "retrieve missing company -> NOT_FOUND"
+  );
+
+  // ── delete + unique release ────────────────────────────────────────────────────
+  await svc.deleteCrmPeople(person.id);
+  ok("delete person removed row", (await svc.listAndCountCrmPeople({ company_id: co.id }))[1] === 0);
+  // email freed on delete → reusable
+  const reused = await svc.createCrmPeople({ first_name: "S", last_name: "S", email: "s@jyt.in" });
+  ok("person email unique key released on delete (reusable)", !!reused.id);
+
+  // ── bare-array IN filter (the shape query.graph uses for linked records) ───────
+  const byIds = await svc.listCrmCompanies({ id: [co.id, co2.id] });
+  ok(`bare-array id IN -> ${byIds.length}`, byIds.length === 2);
+
+  // ── take: null means "no limit" ────────────────────────────────────────────────
+  const allOpps = await svc.listCrmOpportunities({}, { take: null } as any);
+  ok(`take:null returns all (got ${allOpps.length})`, allOpps.length >= 2);
+
+  await store.close?.();
+  rmSync(DIR, { recursive: true, force: true });
+  console.log(`\n${FAIL === 0 ? "✅ PASS" : "❌ FAIL"} — ${PASS} passed, ${FAIL} failed — the REAL CrmService runs end-to-end over the module's Hyperbee DAL.`);
+  process.exit(FAIL === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error("TEST THREW:", e);
+  process.exit(1);
+});

--- a/apps/backend/src/modules/crm/dal/crm-contracts.ts
+++ b/apps/backend/src/modules/crm/dal/crm-contracts.ts
@@ -1,0 +1,121 @@
+/**
+ * CRM write-contracts — Medusa-free. Imported by BOTH the Medusa module DAL
+ * (dal/hyperbee-crm-service.ts) and the standalone CRM node (node/server.ts), so
+ * the record shape, indexes, uniqueness and relations are one source of truth
+ * regardless of where the store is hosted.
+ */
+import { defineContract, type Contract } from "@jytextiles/mikrohyperbee";
+
+export const crmCompanyContract = defineContract("crm_company", {
+  id: { prefix: "crmco" },
+  mode: "strict",
+  fields: {
+    name: { type: "string", required: true },
+    website: { type: "string", nullable: true },
+    industry: { type: "string", nullable: true },
+    size: { type: "string", nullable: true },
+    region: { type: "string", nullable: true },
+    metadata: { type: "json", nullable: true },
+  },
+  indexes: ["name", "industry", "region"],
+  unique: ["name"],
+});
+
+export const crmPersonContract = defineContract("crm_person", {
+  id: { prefix: "crmp" },
+  mode: "strict",
+  fields: {
+    first_name: { type: "string", required: true },
+    last_name: { type: "string", required: true },
+    email: { type: "string", nullable: true },
+    phone: { type: "string", nullable: true },
+    title: { type: "string", nullable: true },
+    company_id: { type: "string", nullable: true },
+    metadata: { type: "json", nullable: true },
+  },
+  indexes: ["email", "last_name", "company_id"],
+  unique: ["email"],
+  relations: {
+    company: {
+      kind: "belongsTo",
+      key: "company_id",
+      target: "crm_company",
+      integrity: "soft",
+    },
+  },
+});
+
+export const crmOpportunityContract = defineContract("crm_opportunity", {
+  id: { prefix: "crmo" },
+  mode: "strict",
+  fields: {
+    title: { type: "string", required: true },
+    stage: {
+      type: "string",
+      default: "prospecting",
+      enum: ["prospecting", "qualification", "proposal", "negotiation", "won", "lost"],
+    },
+    amount: { type: "number", nullable: true },
+    currency: { type: "string", default: "INR" },
+    expected_close_date: { type: "string", nullable: true },
+    company_id: { type: "string", nullable: true },
+    owner_person_id: { type: "string", nullable: true },
+    metadata: { type: "json", nullable: true },
+  },
+  indexes: ["company_id", "stage", "owner_person_id"],
+  relations: {
+    company: { kind: "belongsTo", key: "company_id", target: "crm_company", integrity: "soft" },
+    owner: { kind: "belongsTo", key: "owner_person_id", target: "crm_person", integrity: "soft" },
+  },
+  invariants: [(r) => r.amount == null || r.amount >= 0 || "amount must be >= 0"],
+});
+
+export const crmNoteContract = defineContract("crm_note", {
+  id: { prefix: "crmn" },
+  mode: "strict",
+  fields: {
+    body: { type: "string", required: true },
+    author: { type: "string", nullable: true },
+    related_type: { type: "string", nullable: true, enum: ["person", "company", "opportunity", "task"] },
+    related_id: { type: "string", nullable: true },
+    metadata: { type: "json", nullable: true },
+  },
+  indexes: ["related_type", "related_id"],
+});
+
+export const crmTaskContract = defineContract("crm_task", {
+  id: { prefix: "crmt" },
+  mode: "strict",
+  fields: {
+    title: { type: "string", required: true },
+    description: { type: "string", nullable: true },
+    due_date: { type: "string", nullable: true },
+    status: { type: "string", default: "pending", enum: ["pending", "in_progress", "completed", "cancelled"] },
+    priority: { type: "string", default: "medium", enum: ["low", "medium", "high"] },
+    assignee_person_id: { type: "string", nullable: true },
+    related_type: { type: "string", nullable: true, enum: ["person", "company", "opportunity"] },
+    related_id: { type: "string", nullable: true },
+    metadata: { type: "json", nullable: true },
+  },
+  indexes: ["assignee_person_id", "status", "due_date", "related_type", "related_id"],
+  relations: {
+    assignee: { kind: "belongsTo", key: "assignee_person_id", target: "crm_person", integrity: "soft" },
+  },
+});
+
+export const crmContracts: Record<string, Contract> = {
+  crm_company: crmCompanyContract,
+  crm_person: crmPersonContract,
+  crm_opportunity: crmOpportunityContract,
+  crm_note: crmNoteContract,
+  crm_task: crmTaskContract,
+};
+
+/** URL path segment ↔ model name, for the node's REST surface + the proxy. */
+export const CRM_MODEL_BY_SEGMENT: Record<string, string> = {
+  companies: "crm_company",
+  people: "crm_person",
+  opportunities: "crm_opportunity",
+  notes: "crm_note",
+  tasks: "crm_task",
+};

--- a/apps/backend/src/modules/crm/dal/crm-proxy.ts
+++ b/apps/backend/src/modules/crm/dal/crm-proxy.ts
@@ -1,0 +1,145 @@
+/**
+ * Proxy-mode CRM repositories — the Medusa side of Topology A. Instead of holding
+ * a Hyperbee in-process, each per-model repository forwards create/list/retrieve/
+ * update/delete to the always-on CRM node (node/server.ts) over HTTP, exactly the
+ * way the census reader proxies to its standalone reader. Medusa stays stateless
+ * (no native hypercore stack in the API tasks); the node is the durable Autobase
+ * writer.
+ *
+ * The node returns `{ type, message }` on contract errors; we re-raise them as the
+ * MedusaError the routes already expect, so the surface is identical to the
+ * embedded DAL.
+ */
+import { MedusaError } from "@medusajs/framework/utils";
+
+import type { ModelRepository } from "@jytextiles/mikrohyperbee";
+
+const SEGMENT_BY_MODEL: Record<string, string> = {
+  crm_company: "companies",
+  crm_person: "people",
+  crm_opportunity: "opportunities",
+  crm_note: "notes",
+  crm_task: "tasks",
+};
+
+const ERROR_TYPE: Record<string, string> = {
+  not_found: MedusaError.Types.NOT_FOUND,
+  invalid_data: MedusaError.Types.INVALID_DATA,
+  not_unique: MedusaError.Types.INVALID_DATA,
+  not_allowed: MedusaError.Types.NOT_ALLOWED,
+};
+
+class CrmProxyRepository implements ModelRepository {
+  constructor(
+    private baseUrl: string,
+    private segment: string,
+    private token?: string
+  ) {}
+
+  private async call(method: string, path: string, body?: unknown): Promise<any> {
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      method,
+      headers: {
+        accept: "application/json",
+        ...(body !== undefined ? { "content-type": "application/json" } : {}),
+        ...(this.token ? { authorization: `Bearer ${this.token}` } : {}),
+      },
+      ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      throw new MedusaError(
+        ERROR_TYPE[data?.type] ?? MedusaError.Types.UNEXPECTED_STATE,
+        data?.message || `crm node ${method} ${path} → HTTP ${res.status}`
+      );
+    }
+    return data;
+  }
+
+  private qs(filters?: Record<string, any>, config?: { take?: number | null; skip?: number }): string {
+    const p = new URLSearchParams();
+    for (const [k, v] of Object.entries(filters ?? {})) {
+      if (v === undefined || v === null || typeof v === "object") continue; // node handles equality filters
+      p.set(k, String(v));
+    }
+    if (config?.take != null) p.set("limit", String(config.take));
+    if (config?.skip) p.set("offset", String(config.skip));
+    const s = p.toString();
+    return s ? `?${s}` : "";
+  }
+
+  async create(data: any): Promise<any> {
+    const { record } = await this.call("POST", `/crm/${this.segment}`, data);
+    return record;
+  }
+  async retrieve(id: string): Promise<any> {
+    const { record } = await this.call("GET", `/crm/${this.segment}/${encodeURIComponent(id)}`);
+    return record;
+  }
+  async list(filters: any = {}, config: any = {}): Promise<any[]> {
+    const { rows } = await this.call("GET", `/crm/${this.segment}${this.qs(filters, config)}`);
+    return rows ?? [];
+  }
+  async listAndCount(filters: any = {}, config: any = {}): Promise<[any[], number]> {
+    const { rows, count } = await this.call("GET", `/crm/${this.segment}${this.qs(filters, config)}`);
+    return [rows ?? [], count ?? 0];
+  }
+  async update(data: any): Promise<any> {
+    const { id, ...rest } = data;
+    const { record } = await this.call("POST", `/crm/${this.segment}/${encodeURIComponent(id)}`, rest);
+    return record;
+  }
+  async upsert(data: any): Promise<any> {
+    // The node has no upsert route; emulate create-or-update by id.
+    if (data?.id) {
+      try {
+        return await this.update(data);
+      } catch (e: any) {
+        if (e?.type !== MedusaError.Types.NOT_FOUND) throw e;
+      }
+    }
+    return this.create(data);
+  }
+  async delete(selector: string | string[] | Record<string, any> | Record<string, any>[]): Promise<void> {
+    const ids: string[] = [];
+    const targets = Array.isArray(selector) ? selector : [selector];
+    for (const t of targets) {
+      if (typeof t === "string") ids.push(t);
+      else if (t && typeof t === "object") {
+        // filter-object delete → resolve to ids via the node, then delete each.
+        const rows = await this.list(t, { take: null });
+        for (const r of rows) ids.push(String(r.id));
+      }
+    }
+    for (const id of ids) {
+      await this.call("DELETE", `/crm/${this.segment}/${encodeURIComponent(id)}`);
+    }
+  }
+  async softDelete(): Promise<[any[], Record<string, unknown>]> {
+    return [[], {}];
+  }
+  async restore(): Promise<[any[], Record<string, unknown>]> {
+    return [[], {}];
+  }
+}
+
+export interface CrmRepositories {
+  crmCompanyService: ModelRepository;
+  crmPersonService: ModelRepository;
+  crmOpportunityService: ModelRepository;
+  crmNoteService: ModelRepository;
+  crmTaskService: ModelRepository;
+}
+
+/** Build proxy repositories that forward to the CRM node at `baseUrl`. */
+export function createCrmProxyRepositories(baseUrl: string, token?: string): CrmRepositories {
+  const url = baseUrl.replace(/\/$/, "");
+  const repo = (model: string) => new CrmProxyRepository(url, SEGMENT_BY_MODEL[model], token);
+  return {
+    crmCompanyService: repo("crm_company"),
+    crmPersonService: repo("crm_person"),
+    crmOpportunityService: repo("crm_opportunity"),
+    crmNoteService: repo("crm_note"),
+    crmTaskService: repo("crm_task"),
+  };
+}

--- a/apps/backend/src/modules/crm/dal/hyperbee-crm-service.ts
+++ b/apps/backend/src/modules/crm/dal/hyperbee-crm-service.ts
@@ -12,7 +12,7 @@ import {
 
 export const crmCompanyContract = defineContract("crm_company", {
   id: { prefix: "crmco" },
-  mode: "lax",
+  mode: "strict",
   fields: {
     name: { type: "string", required: true },
     website: { type: "string", nullable: true },
@@ -27,7 +27,7 @@ export const crmCompanyContract = defineContract("crm_company", {
 
 export const crmPersonContract = defineContract("crm_person", {
   id: { prefix: "crmp" },
-  mode: "lax",
+  mode: "strict",
   fields: {
     first_name: { type: "string", required: true },
     last_name: { type: "string", required: true },
@@ -51,7 +51,7 @@ export const crmPersonContract = defineContract("crm_person", {
 
 export const crmOpportunityContract = defineContract("crm_opportunity", {
   id: { prefix: "crmo" },
-  mode: "lax",
+  mode: "strict",
   fields: {
     title: { type: "string", required: true },
     stage: {
@@ -96,7 +96,7 @@ export const crmOpportunityContract = defineContract("crm_opportunity", {
 
 export const crmNoteContract = defineContract("crm_note", {
   id: { prefix: "crmn" },
-  mode: "lax",
+  mode: "strict",
   fields: {
     body: { type: "string", required: true },
     author: { type: "string", nullable: true },
@@ -113,7 +113,7 @@ export const crmNoteContract = defineContract("crm_note", {
 
 export const crmTaskContract = defineContract("crm_task", {
   id: { prefix: "crmt" },
-  mode: "lax",
+  mode: "strict",
   fields: {
     title: { type: "string", required: true },
     description: { type: "string", nullable: true },
@@ -208,9 +208,13 @@ export interface CrmRepositories {
 }
 
 export function createCrmRepositories(bee: BeeLike): CrmRepositories {
+  // Each entity gets its own sub-bee so the rec/idx/uniq/idemp/meta sub-dbs (and
+  // the persisted seq counter) are isolated per model. Sharing one bee would
+  // merge all records into one `rec` namespace, cross-link indexes, and share
+  // one id sequence across entities.
   const raw: Record<string, ModelRepository> = {};
   for (const [model, contract] of Object.entries(crmContracts)) {
-    raw[model] = hyperbeeRepositoryFor(contract, bee);
+    raw[model] = hyperbeeRepositoryFor(contract, bee.sub(model) as BeeLike);
   }
 
   const ctx: RepositoryContext = {
@@ -226,8 +230,10 @@ export function createCrmRepositories(bee: BeeLike): CrmRepositories {
     },
   };
 
+  // Re-bind with the cross-entity exists() resolver (soft relations ignore it,
+  // but flipping any relation to "strict" enforces across the shared store).
   for (const [model, contract] of Object.entries(crmContracts)) {
-    raw[model] = hyperbeeRepositoryFor(contract, bee, ctx);
+    raw[model] = hyperbeeRepositoryFor(contract, bee.sub(model) as BeeLike, ctx);
   }
 
   const wrapped: Record<string, ModelRepository> = {};

--- a/apps/backend/src/modules/crm/dal/hyperbee-crm-service.ts
+++ b/apps/backend/src/modules/crm/dal/hyperbee-crm-service.ts
@@ -2,159 +2,23 @@ import { MedusaError } from "@medusajs/framework/utils";
 
 import {
   ContractError,
-  defineContract,
   hyperbeeRepositoryFor,
   type BeeLike,
-  type Contract,
   type ModelRepository,
   type RepositoryContext,
 } from "@jytextiles/mikrohyperbee";
 
-export const crmCompanyContract = defineContract("crm_company", {
-  id: { prefix: "crmco" },
-  mode: "strict",
-  fields: {
-    name: { type: "string", required: true },
-    website: { type: "string", nullable: true },
-    industry: { type: "string", nullable: true },
-    size: { type: "string", nullable: true },
-    region: { type: "string", nullable: true },
-    metadata: { type: "json", nullable: true },
-  },
-  indexes: ["name", "industry", "region"],
-  unique: ["name"],
-});
+// One source of truth for the CRM record shapes (shared with the standalone node).
+export {
+  crmContracts,
+  crmCompanyContract,
+  crmPersonContract,
+  crmOpportunityContract,
+  crmNoteContract,
+  crmTaskContract,
+} from "./crm-contracts";
+import { crmContracts } from "./crm-contracts";
 
-export const crmPersonContract = defineContract("crm_person", {
-  id: { prefix: "crmp" },
-  mode: "strict",
-  fields: {
-    first_name: { type: "string", required: true },
-    last_name: { type: "string", required: true },
-    email: { type: "string", nullable: true },
-    phone: { type: "string", nullable: true },
-    title: { type: "string", nullable: true },
-    company_id: { type: "string", nullable: true },
-    metadata: { type: "json", nullable: true },
-  },
-  indexes: ["email", "last_name", "company_id"],
-  unique: ["email"],
-  relations: {
-    company: {
-      kind: "belongsTo",
-      key: "company_id",
-      target: "crm_company",
-      integrity: "soft",
-    },
-  },
-});
-
-export const crmOpportunityContract = defineContract("crm_opportunity", {
-  id: { prefix: "crmo" },
-  mode: "strict",
-  fields: {
-    title: { type: "string", required: true },
-    stage: {
-      type: "string",
-      default: "prospecting",
-      enum: [
-        "prospecting",
-        "qualification",
-        "proposal",
-        "negotiation",
-        "won",
-        "lost",
-      ],
-    },
-    amount: { type: "number", nullable: true },
-    currency: { type: "string", default: "INR" },
-    expected_close_date: { type: "string", nullable: true },
-    company_id: { type: "string", nullable: true },
-    owner_person_id: { type: "string", nullable: true },
-    metadata: { type: "json", nullable: true },
-  },
-  indexes: ["company_id", "stage", "owner_person_id"],
-  relations: {
-    company: {
-      kind: "belongsTo",
-      key: "company_id",
-      target: "crm_company",
-      integrity: "soft",
-    },
-    owner: {
-      kind: "belongsTo",
-      key: "owner_person_id",
-      target: "crm_person",
-      integrity: "soft",
-    },
-  },
-  invariants: [
-    (r) =>
-      r.amount == null || r.amount >= 0 || "amount must be >= 0",
-  ],
-});
-
-export const crmNoteContract = defineContract("crm_note", {
-  id: { prefix: "crmn" },
-  mode: "strict",
-  fields: {
-    body: { type: "string", required: true },
-    author: { type: "string", nullable: true },
-    related_type: {
-      type: "string",
-      nullable: true,
-      enum: ["person", "company", "opportunity", "task"],
-    },
-    related_id: { type: "string", nullable: true },
-    metadata: { type: "json", nullable: true },
-  },
-  indexes: ["related_type", "related_id"],
-});
-
-export const crmTaskContract = defineContract("crm_task", {
-  id: { prefix: "crmt" },
-  mode: "strict",
-  fields: {
-    title: { type: "string", required: true },
-    description: { type: "string", nullable: true },
-    due_date: { type: "string", nullable: true },
-    status: {
-      type: "string",
-      default: "pending",
-      enum: ["pending", "in_progress", "completed", "cancelled"],
-    },
-    priority: {
-      type: "string",
-      default: "medium",
-      enum: ["low", "medium", "high"],
-    },
-    assignee_person_id: { type: "string", nullable: true },
-    related_type: {
-      type: "string",
-      nullable: true,
-      enum: ["person", "company", "opportunity"],
-    },
-    related_id: { type: "string", nullable: true },
-    metadata: { type: "json", nullable: true },
-  },
-  indexes: ["assignee_person_id", "status", "due_date", "related_type", "related_id"],
-  relations: {
-    assignee: {
-      kind: "belongsTo",
-      key: "assignee_person_id",
-      target: "crm_person",
-      integrity: "soft",
-    },
-  },
-});
-
-export const crmContracts: Record<string, Contract> = {
-  crm_company: crmCompanyContract,
-  crm_person: crmPersonContract,
-  crm_opportunity: crmOpportunityContract,
-  crm_note: crmNoteContract,
-  crm_task: crmTaskContract,
-};
 
 const ERROR_MAP: Record<ContractError["type"], string> = {
   not_found: MedusaError.Types.NOT_FOUND,

--- a/apps/backend/src/modules/crm/dal/hyperbee-crm-service.ts
+++ b/apps/backend/src/modules/crm/dal/hyperbee-crm-service.ts
@@ -1,0 +1,245 @@
+import { MedusaError } from "@medusajs/framework/utils";
+
+import {
+  ContractError,
+  defineContract,
+  hyperbeeRepositoryFor,
+  type BeeLike,
+  type Contract,
+  type ModelRepository,
+  type RepositoryContext,
+} from "@jytextiles/mikrohyperbee";
+
+export const crmCompanyContract = defineContract("crm_company", {
+  id: { prefix: "crmco" },
+  mode: "lax",
+  fields: {
+    name: { type: "string", required: true },
+    website: { type: "string", nullable: true },
+    industry: { type: "string", nullable: true },
+    size: { type: "string", nullable: true },
+    region: { type: "string", nullable: true },
+    metadata: { type: "json", nullable: true },
+  },
+  indexes: ["name", "industry", "region"],
+  unique: ["name"],
+});
+
+export const crmPersonContract = defineContract("crm_person", {
+  id: { prefix: "crmp" },
+  mode: "lax",
+  fields: {
+    first_name: { type: "string", required: true },
+    last_name: { type: "string", required: true },
+    email: { type: "string", nullable: true },
+    phone: { type: "string", nullable: true },
+    title: { type: "string", nullable: true },
+    company_id: { type: "string", nullable: true },
+    metadata: { type: "json", nullable: true },
+  },
+  indexes: ["email", "last_name", "company_id"],
+  unique: ["email"],
+  relations: {
+    company: {
+      kind: "belongsTo",
+      key: "company_id",
+      target: "crm_company",
+      integrity: "soft",
+    },
+  },
+});
+
+export const crmOpportunityContract = defineContract("crm_opportunity", {
+  id: { prefix: "crmo" },
+  mode: "lax",
+  fields: {
+    title: { type: "string", required: true },
+    stage: {
+      type: "string",
+      default: "prospecting",
+      enum: [
+        "prospecting",
+        "qualification",
+        "proposal",
+        "negotiation",
+        "won",
+        "lost",
+      ],
+    },
+    amount: { type: "number", nullable: true },
+    currency: { type: "string", default: "INR" },
+    expected_close_date: { type: "string", nullable: true },
+    company_id: { type: "string", nullable: true },
+    owner_person_id: { type: "string", nullable: true },
+    metadata: { type: "json", nullable: true },
+  },
+  indexes: ["company_id", "stage", "owner_person_id"],
+  relations: {
+    company: {
+      kind: "belongsTo",
+      key: "company_id",
+      target: "crm_company",
+      integrity: "soft",
+    },
+    owner: {
+      kind: "belongsTo",
+      key: "owner_person_id",
+      target: "crm_person",
+      integrity: "soft",
+    },
+  },
+  invariants: [
+    (r) =>
+      r.amount == null || r.amount >= 0 || "amount must be >= 0",
+  ],
+});
+
+export const crmNoteContract = defineContract("crm_note", {
+  id: { prefix: "crmn" },
+  mode: "lax",
+  fields: {
+    body: { type: "string", required: true },
+    author: { type: "string", nullable: true },
+    related_type: {
+      type: "string",
+      nullable: true,
+      enum: ["person", "company", "opportunity", "task"],
+    },
+    related_id: { type: "string", nullable: true },
+    metadata: { type: "json", nullable: true },
+  },
+  indexes: ["related_type", "related_id"],
+});
+
+export const crmTaskContract = defineContract("crm_task", {
+  id: { prefix: "crmt" },
+  mode: "lax",
+  fields: {
+    title: { type: "string", required: true },
+    description: { type: "string", nullable: true },
+    due_date: { type: "string", nullable: true },
+    status: {
+      type: "string",
+      default: "pending",
+      enum: ["pending", "in_progress", "completed", "cancelled"],
+    },
+    priority: {
+      type: "string",
+      default: "medium",
+      enum: ["low", "medium", "high"],
+    },
+    assignee_person_id: { type: "string", nullable: true },
+    related_type: {
+      type: "string",
+      nullable: true,
+      enum: ["person", "company", "opportunity"],
+    },
+    related_id: { type: "string", nullable: true },
+    metadata: { type: "json", nullable: true },
+  },
+  indexes: ["assignee_person_id", "status", "due_date", "related_type", "related_id"],
+  relations: {
+    assignee: {
+      kind: "belongsTo",
+      key: "assignee_person_id",
+      target: "crm_person",
+      integrity: "soft",
+    },
+  },
+});
+
+export const crmContracts: Record<string, Contract> = {
+  crm_company: crmCompanyContract,
+  crm_person: crmPersonContract,
+  crm_opportunity: crmOpportunityContract,
+  crm_note: crmNoteContract,
+  crm_task: crmTaskContract,
+};
+
+const ERROR_MAP: Record<ContractError["type"], string> = {
+  not_found: MedusaError.Types.NOT_FOUND,
+  invalid_data: MedusaError.Types.INVALID_DATA,
+  not_unique: MedusaError.Types.INVALID_DATA,
+  not_allowed: MedusaError.Types.NOT_ALLOWED,
+};
+
+const WRAPPED = new Set([
+  "create",
+  "retrieve",
+  "list",
+  "listAndCount",
+  "update",
+  "upsert",
+  "delete",
+  "softDelete",
+  "restore",
+]);
+
+function toMedusaRepository(repo: ModelRepository): ModelRepository {
+  return new Proxy(repo, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value === "function" && WRAPPED.has(prop as string)) {
+        return async (...args: any[]) => {
+          try {
+            return await (value as (...a: any[]) => any).apply(target, args);
+          } catch (e) {
+            if (e instanceof ContractError) {
+              throw new MedusaError(
+                ERROR_MAP[e.type] ?? MedusaError.Types.UNEXPECTED_STATE,
+                e.message
+              );
+            }
+            throw e;
+          }
+        };
+      }
+      return value;
+    },
+  }) as ModelRepository;
+}
+
+export interface CrmRepositories {
+  crmCompanyService: ModelRepository;
+  crmPersonService: ModelRepository;
+  crmOpportunityService: ModelRepository;
+  crmNoteService: ModelRepository;
+  crmTaskService: ModelRepository;
+}
+
+export function createCrmRepositories(bee: BeeLike): CrmRepositories {
+  const raw: Record<string, ModelRepository> = {};
+  for (const [model, contract] of Object.entries(crmContracts)) {
+    raw[model] = hyperbeeRepositoryFor(contract, bee);
+  }
+
+  const ctx: RepositoryContext = {
+    exists: async (model: string, id: string): Promise<boolean> => {
+      const repo = raw[model];
+      if (!repo) return false;
+      try {
+        await repo.retrieve(id);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  };
+
+  for (const [model, contract] of Object.entries(crmContracts)) {
+    raw[model] = hyperbeeRepositoryFor(contract, bee, ctx);
+  }
+
+  const wrapped: Record<string, ModelRepository> = {};
+  for (const [model, repo] of Object.entries(raw)) {
+    wrapped[model] = toMedusaRepository(repo);
+  }
+
+  return {
+    crmCompanyService: wrapped.crm_company,
+    crmPersonService: wrapped.crm_person,
+    crmOpportunityService: wrapped.crm_opportunity,
+    crmNoteService: wrapped.crm_note,
+    crmTaskService: wrapped.crm_task,
+  };
+}

--- a/apps/backend/src/modules/crm/index.ts
+++ b/apps/backend/src/modules/crm/index.ts
@@ -1,0 +1,12 @@
+import { Module } from "@medusajs/framework/utils";
+import hyperbeeDalLoader from "./loaders/hyperbee-dal";
+import CrmService from "./service";
+
+export const CRM_MODULE = "crm";
+
+export default Module(CRM_MODULE, {
+  service: CrmService,
+  // Hyperbee-only DAL — no Postgres tables for CRM. The loader always runs and
+  // overrides the module container's per-model services + baseRepository.
+  loaders: [hyperbeeDalLoader],
+});

--- a/apps/backend/src/modules/crm/loaders/hyperbee-dal.ts
+++ b/apps/backend/src/modules/crm/loaders/hyperbee-dal.ts
@@ -1,0 +1,71 @@
+import { asValue } from "awilix";
+
+import type { LoaderOptions } from "@medusajs/framework/types";
+
+import { createCrmRepositories } from "../dal/hyperbee-crm-service";
+
+/**
+ * MikroHyperbee DAL for the `crm` module — the ONLY backend for CRM records.
+ * No Postgres tables, no MikroORM. All CRM entities (companies, people,
+ * opportunities, notes, tasks) are served from a local Hyperbee store.
+ *
+ * On boot this opens a Corestore/Hyperbee and overrides the module container's
+ * per-model internal services + baseRepository with Hyperbee-backed equivalents,
+ * so the REAL generated create/list/listAndCount/retrieve/update/delete run over
+ * Hyperbee. The DML models in ../models/* stay (they drive the generated method
+ * names + query.graph projection) but are never persisted to Postgres — no
+ * migration is shipped for this module.
+ *
+ * CRM_HYPERBEE_STORE overrides the on-disk store location (default
+ * ./.crm-store). On failure there is no fallback, so the error is logged and
+ * re-thrown so boot fails loudly rather than silently serving nothing.
+ */
+export default async function hyperbeeDalLoader({ container }: LoaderOptions) {
+  const logger = container.resolve("logger", { allowUnregistered: true }) as
+    | { info: (m: string) => void; error: (m: string) => void }
+    | undefined;
+
+  const storeDir = process.env.CRM_HYPERBEE_STORE || "./.crm-store";
+
+  try {
+    const [{ default: Corestore }, { default: Hyperbee }] = await Promise.all([
+      import("corestore"),
+      import("hyperbee"),
+    ]);
+
+    const store = new Corestore(storeDir);
+    await store.ready();
+
+    const repos = createCrmRepositories(
+      new Hyperbee(store.get({ name: "crm" }), {
+        keyEncoding: "utf-8",
+        valueEncoding: "binary",
+      }) as any
+    );
+
+    const baseRepository = {
+      serialize: async (d: any) => JSON.parse(JSON.stringify(d)),
+      getFreshManager: () => repos,
+      getActiveManager: () => repos,
+      transaction: async (task: (m: any) => any) => task(repos),
+    };
+
+    container.register({
+      crmCompanyService: asValue(repos.crmCompanyService),
+      crmPersonService: asValue(repos.crmPersonService),
+      crmOpportunityService: asValue(repos.crmOpportunityService),
+      crmNoteService: asValue(repos.crmNoteService),
+      crmTaskService: asValue(repos.crmTaskService),
+      baseRepository: asValue(baseRepository),
+    });
+
+    logger?.info(
+      "[crm] MikroHyperbee DAL active — all CRM records served from Hyperbee"
+    );
+  } catch (e: any) {
+    logger?.error(
+      `[crm] Hyperbee DAL failed to start: ${e?.message || e}`
+    );
+    throw e;
+  }
+}

--- a/apps/backend/src/modules/crm/loaders/hyperbee-dal.ts
+++ b/apps/backend/src/modules/crm/loaders/hyperbee-dal.ts
@@ -2,70 +2,85 @@ import { asValue } from "awilix";
 
 import type { LoaderOptions } from "@medusajs/framework/types";
 
+import { createCrmProxyRepositories, type CrmRepositories } from "../dal/crm-proxy";
 import { createCrmRepositories } from "../dal/hyperbee-crm-service";
 
 /**
- * MikroHyperbee DAL for the `crm` module — the ONLY backend for CRM records.
- * No Postgres tables, no MikroORM. All CRM entities (companies, people,
- * opportunities, notes, tasks) are served from a local Hyperbee store.
+ * CRM DAL loader. Two modes, and it is FLAG-GATED + NON-FATAL — a CRM backend
+ * problem must never take down Medusa boot (it's an opt-in module, not core).
  *
- * On boot this opens a Corestore/Hyperbee and overrides the module container's
- * per-model internal services + baseRepository with Hyperbee-backed equivalents,
- * so the REAL generated create/list/listAndCount/retrieve/update/delete run over
- * Hyperbee. The DML models in ../models/* stay (they drive the generated method
- * names + query.graph projection) but are never persisted to Postgres — no
- * migration is shipped for this module.
+ *  1. PROXY (recommended for prod) — CRM_NODE_URL set → forward every
+ *     create/list/retrieve/update/delete to the always-on CRM node
+ *     (modules/crm/node/server.ts), which holds the durable Autobase writer.
+ *     Medusa stays stateless: no native hypercore stack in the API tasks. This is
+ *     the multi-writer-ready path — offline/edge writers join the node's Autobase
+ *     later with zero Medusa changes.
  *
- * CRM_HYPERBEE_STORE overrides the on-disk store location (default
- * ./.crm-store). On failure there is no fallback, so the error is logged and
- * re-thrown so boot fails loudly rather than silently serving nothing.
+ *  2. EMBEDDED (dev/experimental) — CRM_HYPERBEE=true → open a LOCAL Hyperbee in
+ *     this process (single-writer, ephemeral on Fargate). Handy for local dev;
+ *     not durable in prod.
+ *
+ * With neither env set the loader no-ops (module simply serves nothing until
+ * configured) rather than throwing — so a missing config or a native-stack hiccup
+ * degrades CRM alone instead of crashing the whole backend.
+ *
+ * Env: CRM_NODE_URL, CRM_NODE_TOKEN (proxy) · CRM_HYPERBEE, CRM_HYPERBEE_STORE
+ * (embedded).
  */
+function registerCrm(container: LoaderOptions["container"], repos: CrmRepositories) {
+  const baseRepository = {
+    serialize: async (d: any) => JSON.parse(JSON.stringify(d)),
+    getFreshManager: () => repos,
+    getActiveManager: () => repos,
+    transaction: async (task: (m: any) => any) => task(repos),
+  };
+  container.register({
+    crmCompanyService: asValue(repos.crmCompanyService),
+    crmPersonService: asValue(repos.crmPersonService),
+    crmOpportunityService: asValue(repos.crmOpportunityService),
+    crmNoteService: asValue(repos.crmNoteService),
+    crmTaskService: asValue(repos.crmTaskService),
+    baseRepository: asValue(baseRepository),
+  });
+}
+
 export default async function hyperbeeDalLoader({ container }: LoaderOptions) {
   const logger = container.resolve("logger", { allowUnregistered: true }) as
     | { info: (m: string) => void; error: (m: string) => void }
     | undefined;
 
-  const storeDir = process.env.CRM_HYPERBEE_STORE || "./.crm-store";
+  // ── Proxy mode (prod) ──────────────────────────────────────────────────────
+  if (process.env.CRM_NODE_URL) {
+    registerCrm(container, createCrmProxyRepositories(process.env.CRM_NODE_URL, process.env.CRM_NODE_TOKEN));
+    logger?.info(`[crm] proxy mode → ${process.env.CRM_NODE_URL} (durable Autobase node)`);
+    return;
+  }
 
+  // ── Embedded mode (dev/experimental), gated + non-fatal ────────────────────
+  if (process.env.CRM_HYPERBEE !== "true") {
+    logger?.info(
+      "[crm] disabled — set CRM_NODE_URL for proxy mode, or CRM_HYPERBEE=true to embed a local store"
+    );
+    return;
+  }
+  const storeDir = process.env.CRM_HYPERBEE_STORE || "./.crm-store";
   try {
     const [{ default: Corestore }, { default: Hyperbee }] = await Promise.all([
       import("corestore"),
       import("hyperbee"),
     ]);
-
     const store = new Corestore(storeDir);
     await store.ready();
-
     const repos = createCrmRepositories(
       new Hyperbee(store.get({ name: "crm" }), {
         keyEncoding: "utf-8",
         valueEncoding: "binary",
       }) as any
     );
-
-    const baseRepository = {
-      serialize: async (d: any) => JSON.parse(JSON.stringify(d)),
-      getFreshManager: () => repos,
-      getActiveManager: () => repos,
-      transaction: async (task: (m: any) => any) => task(repos),
-    };
-
-    container.register({
-      crmCompanyService: asValue(repos.crmCompanyService),
-      crmPersonService: asValue(repos.crmPersonService),
-      crmOpportunityService: asValue(repos.crmOpportunityService),
-      crmNoteService: asValue(repos.crmNoteService),
-      crmTaskService: asValue(repos.crmTaskService),
-      baseRepository: asValue(baseRepository),
-    });
-
-    logger?.info(
-      "[crm] MikroHyperbee DAL active — all CRM records served from Hyperbee"
-    );
+    registerCrm(container, repos);
+    logger?.info(`[crm] embedded Hyperbee DAL active (store=${storeDir}) — single-writer, dev only`);
   } catch (e: any) {
-    logger?.error(
-      `[crm] Hyperbee DAL failed to start: ${e?.message || e}`
-    );
-    throw e;
+    // NON-FATAL: log and leave CRM unconfigured; never break boot.
+    logger?.error(`[crm] embedded Hyperbee DAL failed to start (module stays offline): ${e?.message || e}`);
   }
 }

--- a/apps/backend/src/modules/crm/node/crm-node.e2e.ts
+++ b/apps/backend/src/modules/crm/node/crm-node.e2e.ts
@@ -1,0 +1,118 @@
+/**
+ * Proxy-path proof: the REAL CrmService driven through the proxy repositories →
+ * HTTP → the standalone CRM node → its Autobase writer → back. This is exactly the
+ * prod Topology-A write path (`POST /admin/crm/*` → service → proxy → node), minus
+ * the Medusa HTTP shell. No Postgres.
+ *
+ * Run: tsx apps/backend/src/modules/crm/node/crm-node.e2e.ts
+ */
+import assert from "node:assert";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AddressInfo } from "node:net";
+
+import { MedusaError } from "@medusajs/framework/utils";
+
+import { openCrmNode, createCrmNodeServer } from "./server";
+import { createCrmProxyRepositories } from "../dal/crm-proxy";
+import CrmServiceDefault from "../service";
+
+const CrmService: any = (CrmServiceDefault as any)?.default ?? CrmServiceDefault;
+
+let PASS = 0;
+let FAIL = 0;
+const ok = (label: string, cond: boolean) => {
+  if (cond) { PASS++; console.log(`  ✓ ${label}`); }
+  else { FAIL++; console.error(`  ✗ ${label}`); }
+};
+async function throwsMedusa(fn: () => Promise<any>, type: string, label: string) {
+  try {
+    await fn();
+    ok(`${label} (expected throw, none)`, false);
+  } catch (e: any) {
+    const got = e instanceof MedusaError ? e.type : e?.name;
+    ok(`${label} (threw ${got})`, e instanceof MedusaError && got === type);
+  }
+}
+
+const DIR = join(tmpdir(), `crm-node-e2e-${process.pid}`);
+
+async function main() {
+  rmSync(DIR, { recursive: true, force: true });
+
+  const node = await openCrmNode(DIR);
+  const server = createCrmNodeServer(node);
+  await new Promise<void>((r) => server.listen(0, r));
+  const port = (server.address() as AddressInfo).port;
+  const url = `http://127.0.0.1:${port}`;
+  console.log(`CRM node up on ${url} (base writable=${node.base.writable})\n`);
+
+  // The loader would register exactly these as crmCompanyService, etc.
+  const repos = createCrmProxyRepositories(url);
+  const container: any = {
+    resolve(name: string) { return this[name]; },
+    crmCompanyService: repos.crmCompanyService,
+    crmPersonService: repos.crmPersonService,
+    crmOpportunityService: repos.crmOpportunityService,
+    crmNoteService: repos.crmNoteService,
+    crmTaskService: repos.crmTaskService,
+  };
+  const svc: any = new CrmService(container);
+
+  // ── create → the write leaves Medusa, lands in the node's Autobase ────────────
+  const co = await svc.createCrmCompanies({ name: "Bhujodi Weaves", industry: "textiles", region: "GUJARAT" });
+  ok(`company created via proxy → node (id ${co.id})`, /^crmco_/.test(co.id));
+  ok("node stamped timestamps", !!co.created_at && !!co.updated_at);
+
+  await throwsMedusa(
+    () => svc.createCrmCompanies({ name: "Bhujodi Weaves" }),
+    MedusaError.Types.INVALID_DATA,
+    "duplicate company name rejected across the wire (not_unique → INVALID_DATA)"
+  );
+
+  // ── read-back + filtered index read over HTTP ─────────────────────────────────
+  const fetched = await svc.retrieveCrmCompany(co.id);
+  ok("retrieve by id round-trips through the node", fetched.id === co.id && fetched.name === "Bhujodi Weaves");
+
+  const person = await svc.createCrmPeople({
+    first_name: "Champa", last_name: "Ben", email: "champa@bhujodi.in", company_id: co.id,
+  });
+  const [people, pCount] = await svc.listAndCountCrmPeople({ company_id: co.id }, { take: 20 });
+  ok(`list people by company_id → 1 (got ${pCount})`, pCount === 1 && people[0].id === person.id);
+
+  // ── update stage/field, then a reindexed filter read ──────────────────────────
+  const opp = await svc.createCrmOpportunities({ title: "Wholesale AW26", amount: 500000, company_id: co.id, owner_person_id: person.id });
+  ok("opportunity defaults applied by the node (stage/currency)", opp.stage === "prospecting" && opp.currency === "INR");
+  const moved = await svc.updateCrmOpportunities({ id: opp.id, stage: "negotiation" });
+  ok("update persisted through the node", moved.stage === "negotiation" && moved.created_at === opp.created_at);
+  const [neg] = await svc.listAndCountCrmOpportunities({ stage: "negotiation" });
+  ok("reindexed filter read (stage=negotiation) → 1 across the wire", neg.length === 1 && neg[0].id === opp.id);
+
+  // ── not_found + delete + unique release ───────────────────────────────────────
+  await throwsMedusa(
+    () => svc.retrieveCrmCompany("crmco_missing"),
+    MedusaError.Types.NOT_FOUND,
+    "retrieve missing → NOT_FOUND propagated from the node"
+  );
+  await svc.deleteCrmPeople(person.id);
+  ok("delete removed the person", (await svc.listAndCountCrmPeople({ company_id: co.id }))[1] === 0);
+  const reused = await svc.createCrmPeople({ first_name: "New", last_name: "Owner", email: "champa@bhujodi.in" });
+  ok("unique email freed on delete (reusable through the node)", !!reused.id);
+
+  // ── cleanup ───────────────────────────────────────────────────────────────────
+  await new Promise<void>((r) => server.close(() => r()));
+  await node.close();
+  rmSync(DIR, { recursive: true, force: true });
+
+  console.log(
+    `\n${FAIL === 0 ? "✅ PASS" : "❌ FAIL"} — ${PASS} passed, ${FAIL} failed — ` +
+    `the real CrmService drives CRUD through the proxy → CRM node → Autobase.`
+  );
+  process.exit(FAIL === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error("TEST THREW:", e);
+  process.exit(1);
+});

--- a/apps/backend/src/modules/crm/node/deploy/README.md
+++ b/apps/backend/src/modules/crm/node/deploy/README.md
@@ -1,0 +1,66 @@
+# CRM Autobase node — deploy (Topology-A anchor)
+
+The always-on Autobase writer/indexer behind the CRM module's proxy mode
+(`../server.ts`). Runs as a standalone Node process on a durable, always-on host
+(the OCI free-tier **handloom-mirror** VM in prod) and is reached by Medusa over
+a Cloudflare Tunnel — Medusa itself stays stateless (no native hypercore stack in
+the API tasks).
+
+No secrets live in this directory. The bearer token and the cloudflared connector
+token are generated at deploy time and kept only in SSM / on the box.
+
+## 1. Build the bundle (from repo root)
+
+A single self-contained CJS file — `server.ts` + `../dal/crm-contracts.ts` +
+`@jytextiles/mikrohyperbee` bundled; the native P2P deps stay external and are
+`npm install`ed on the box (they ship prebuilds for linux-x64).
+
+```bash
+pnpm --filter @jytextiles/mikrohyperbee build   # refresh dist (incl. view.sub isolation)
+node_modules/.bin/esbuild apps/backend/src/modules/crm/node/server.ts \
+  --bundle --platform=node --format=cjs --target=node20 \
+  --external:corestore --external:hyperbee --external:autobase \
+  --outfile=/tmp/crm-node/crm-node.cjs
+cp apps/backend/src/modules/crm/node/deploy/package.json /tmp/crm-node/
+```
+
+## 2. Ship to the host
+
+```bash
+HOST=ubuntu@<vm-ip>
+ssh $HOST 'sudo mkdir -p /opt/crm /etc/crm && sudo chown ubuntu:ubuntu /opt/crm'
+scp /tmp/crm-node/{crm-node.cjs,package.json} $HOST:/opt/crm/
+ssh $HOST 'cd /opt/crm && npm install --omit=dev'
+```
+
+## 3. Env + service
+
+```bash
+# /etc/crm/node.env  (root:600) — generate a strong CRM_NODE_TOKEN
+#   CRM_STORE=/opt/crm/store
+#   CRM_NODE_PORT=8790
+#   CRM_NODE_TOKEN=<openssl rand -hex 32>
+scp crm-node.service $HOST:/tmp/ && ssh $HOST '
+  sudo mv /tmp/crm-node.service /etc/systemd/system/crm-node.service
+  sudo systemctl daemon-reload && sudo systemctl enable --now crm-node.service'
+curl -s http://127.0.0.1:8790/health   # {"ok":true,"writable":true}
+```
+
+## 4. Cloudflare Tunnel (ingress — no inbound VM ports)
+
+Remotely-managed tunnel → public hostname → `http://localhost:8790`. Create the
+tunnel + ingress config + a **proxied** `CNAME <host> → <tunnel-id>.cfargotunnel.com`
+via the CF API (needs a token with account `Cloudflare Tunnel:Edit` + zone
+`DNS:Edit`), then on the box:
+
+```bash
+sudo cloudflared service install <connector-token>
+```
+
+## 5. Wire Medusa (prod)
+
+- SSM SecureString `/jyt/prod/CRM_NODE_TOKEN` = the bearer (write BEFORE deploy).
+- `CRM_NODE_URL` (variables) + `CRM_NODE_TOKEN` (secrets) are in
+  `deploy/aws/copilot/medusa-server/manifest.yml`.
+- Deploy the server → loader logs `[crm] proxy mode → https://…` → `/admin/crm/*`
+  is live end-to-end.

--- a/apps/backend/src/modules/crm/node/deploy/crm-node.service
+++ b/apps/backend/src/modules/crm/node/deploy/crm-node.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=JYT CRM Autobase node (Topology-A durable anchor)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=ubuntu
+WorkingDirectory=/opt/crm
+EnvironmentFile=/etc/crm/node.env
+ExecStart=/usr/bin/node /opt/crm/crm-node.cjs
+Restart=on-failure
+RestartSec=3
+# Hardening
+NoNewPrivileges=true
+ProtectSystem=full
+ReadWritePaths=/opt/crm
+# Keep footprint bounded on the 1 GB box
+MemoryMax=280M
+MemoryHigh=220M
+
+[Install]
+WantedBy=multi-user.target

--- a/apps/backend/src/modules/crm/node/deploy/package.json
+++ b/apps/backend/src/modules/crm/node/deploy/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "crm-node",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Standalone always-on CRM Autobase node (Topology A anchor) for the JYT Medusa CRM module.",
+  "main": "crm-node.cjs",
+  "scripts": {
+    "start": "node crm-node.cjs"
+  },
+  "dependencies": {
+    "autobase": "7.28.1",
+    "corestore": "7.11.0",
+    "hyperbee": "2.27.3"
+  }
+}

--- a/apps/backend/src/modules/crm/node/server.ts
+++ b/apps/backend/src/modules/crm/node/server.ts
@@ -1,0 +1,183 @@
+/**
+ * Standalone CRM node — the always-on Autobase writer/indexer behind the Medusa
+ * CRM module's proxy mode. Holds the CRM Autobase over a local Corestore and
+ * serves a tiny REST surface that the proxy repository (dal/crm-proxy.ts) calls.
+ *
+ * Host-agnostic: the SAME process runs on an always-on VM (OCI free-tier — the
+ * durable anchor) or a Cloudflare Container / Fargate task. Only durability
+ * differs by host: on a VM the CRM_STORE dir is a real persistent disk; on an
+ * ephemeral host you must either replicate to a durable peer (the multi-writer
+ * story — other writers hold the data) or snapshot CRM_STORE to R2 and restore
+ * on boot. This process itself just opens the store at CRM_STORE.
+ *
+ * Multi-writer ready: it's an Autobase indexer (bootstrap = null → its key IS the
+ * base id). Additional writers join with bootstrap=<this base key> and are
+ * authorized via the /admin/writers endpoint (owner-adds-writer).
+ *
+ *   Env: CRM_STORE (store dir, default ./.crm-node-store), CRM_NODE_PORT (8790),
+ *        CRM_NODE_TOKEN (optional bearer required on all routes).
+ *   Run: tsx apps/backend/src/modules/crm/node/server.ts
+ */
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+
+// @ts-ignore — native deps resolved at runtime (not part of the Medusa build)
+import Corestore from "corestore";
+// @ts-ignore
+import Hyperbee from "hyperbee";
+// @ts-ignore
+import Autobase from "autobase";
+
+import {
+  autobeeRepositoryFor,
+  makeApply,
+  authorizeWriter,
+  type ModelRepository,
+} from "@jytextiles/mikrohyperbee";
+
+import { crmContracts, CRM_MODEL_BY_SEGMENT } from "../dal/crm-contracts";
+
+export type CrmNode = {
+  base: any;
+  repos: Record<string, ModelRepository>;
+  close: () => Promise<void>;
+};
+
+/** Open the Autobase + per-model repositories over a store directory. */
+export async function openCrmNode(storeDir: string): Promise<CrmNode> {
+  const store = new Corestore(storeDir);
+  const base = new Autobase(store, null, {
+    valueEncoding: "json",
+    open(viewStore: any) {
+      return new Hyperbee(viewStore.get("view"), {
+        keyEncoding: "utf-8",
+        valueEncoding: "binary",
+      });
+    },
+    apply: makeApply(crmContracts),
+  });
+  await base.ready();
+
+  const repos: Record<string, ModelRepository> = {};
+  for (const [model, contract] of Object.entries(crmContracts)) {
+    repos[model] = autobeeRepositoryFor(contract, base);
+  }
+  return {
+    base,
+    repos,
+    close: async () => {
+      await base.close?.();
+      await store.close?.();
+    },
+  };
+}
+
+// ── HTTP surface ───────────────────────────────────────────────────────────────
+const send = (res: ServerResponse, code: number, body: unknown) => {
+  const s = JSON.stringify(body);
+  res.writeHead(code, { "content-type": "application/json", "content-length": Buffer.byteLength(s) });
+  res.end(s);
+};
+
+const readJson = (req: IncomingMessage): Promise<any> =>
+  new Promise((resolve, reject) => {
+    let raw = "";
+    req.on("data", (c) => (raw += c));
+    req.on("end", () => {
+      if (!raw) return resolve({});
+      try { resolve(JSON.parse(raw)); } catch (e) { reject(e); }
+    });
+    req.on("error", reject);
+  });
+
+/** Map a ContractError-shaped message to an HTTP status. */
+const statusForError = (e: any): number => {
+  const t = e?.type;
+  if (t === "not_found") return 404;
+  if (t === "invalid_data" || t === "not_unique") return 422;
+  if (t === "not_allowed") return 403;
+  return 500;
+};
+
+export function createCrmNodeServer(node: CrmNode, opts: { token?: string } = {}) {
+  return createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url || "/", "http://localhost");
+      const parts = url.pathname.split("/").filter(Boolean); // ["crm","people",":id"]
+
+      if (parts[0] === "health") return send(res, 200, { ok: true, writable: node.base.writable });
+
+      if (opts.token) {
+        const auth = req.headers["authorization"];
+        if (auth !== `Bearer ${opts.token}`) return send(res, 401, { message: "unauthorized" });
+      }
+
+      // Membership: authorize another writer (owner-adds-writer). Body: { key: hex }.
+      if (parts[0] === "admin" && parts[1] === "writers" && req.method === "POST") {
+        const { key } = await readJson(req);
+        if (!key) return send(res, 422, { message: "key (hex) required" });
+        await authorizeWriter(node.base, Buffer.from(String(key), "hex"));
+        return send(res, 200, { authorized: key });
+      }
+
+      if (parts[0] !== "crm") return send(res, 404, { message: "not found" });
+      const model = CRM_MODEL_BY_SEGMENT[parts[1]];
+      const repo = model && node.repos[model];
+      if (!repo) return send(res, 404, { message: `unknown crm collection '${parts[1]}'` });
+
+      const id = parts[2];
+
+      if (!id && req.method === "GET") {
+        const filters: Record<string, string> = {};
+        for (const [k, v] of url.searchParams) if (k !== "limit" && k !== "offset") filters[k] = v;
+        const take = url.searchParams.has("limit") ? Number(url.searchParams.get("limit")) : undefined;
+        const skip = url.searchParams.has("offset") ? Number(url.searchParams.get("offset")) : 0;
+        const [rows, count] = await repo.listAndCount(filters, { take, skip });
+        return send(res, 200, { rows, count });
+      }
+      if (!id && req.method === "POST") {
+        const created = await repo.create(await readJson(req));
+        return send(res, 201, { record: created });
+      }
+      if (id && req.method === "GET") {
+        return send(res, 200, { record: await repo.retrieve(id) });
+      }
+      if (id && req.method === "POST") {
+        const updated = await repo.update({ id, ...(await readJson(req)) });
+        return send(res, 200, { record: updated });
+      }
+      if (id && req.method === "DELETE") {
+        await repo.delete(id);
+        return send(res, 200, { id, deleted: true });
+      }
+      return send(res, 405, { message: "method not allowed" });
+    } catch (e: any) {
+      send(res, statusForError(e), { type: e?.type, message: e?.message || "error" });
+    }
+  });
+}
+
+// ── entrypoint (only when run directly) ─────────────────────────────────────────
+const isMain = (() => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return require.main === module;
+  } catch {
+    return false;
+  }
+})();
+
+if (isMain) {
+  const storeDir = process.env.CRM_STORE || "./.crm-node-store";
+  const port = Number(process.env.CRM_NODE_PORT || 8790);
+  openCrmNode(storeDir).then((node) => {
+    const server = createCrmNodeServer(node, { token: process.env.CRM_NODE_TOKEN });
+    server.listen(port, () => {
+      // eslint-disable-next-line no-console
+      console.log(
+        `[crm-node] listening on :${port} store=${storeDir} base=${Buffer.from(node.base.key)
+          .toString("hex")
+          .slice(0, 12)}… (writable=${node.base.writable})`
+      );
+    });
+  });
+}

--- a/apps/backend/src/modules/crm/service.ts
+++ b/apps/backend/src/modules/crm/service.ts
@@ -1,0 +1,126 @@
+import type { ModelRepository } from "@jytextiles/mikrohyperbee";
+
+/**
+ * CrmService — the module service for the Hyperbee-only CRM module.
+ *
+ * No DML models, no MedusaService({ ... }) generated layer, no Postgres. The
+ * data structure lives in the Hyperbee contracts (dal/hyperbee-crm-service.ts),
+ * and the loader registers per-entity ModelRepository instances
+ * (crmCompanyService, crmPersonService, ...) into the module container. This
+ * class lazily resolves them and exposes the conventional generated-style
+ * method names (createCrmCompanies, listAndCountCrmPeople, ...) so routes and
+ * workflows call the same surface regardless of backend.
+ */
+class CrmService {
+  protected readonly __container__: any;
+
+  constructor(container: any) {
+    this.__container__ = container;
+  }
+
+  private repo(name: string): ModelRepository {
+    return this.__container__.resolve(name);
+  }
+
+  // ── companies ────────────────────────────────────────────────────────────────
+  async createCrmCompanies(data: any) {
+    return this.repo("crmCompanyService").create(data);
+  }
+  async retrieveCrmCompany(id: string) {
+    return this.repo("crmCompanyService").retrieve(id);
+  }
+  async listCrmCompanies(filters?: any, config?: any) {
+    return this.repo("crmCompanyService").list(filters, config);
+  }
+  async listAndCountCrmCompanies(filters?: any, config?: any) {
+    return this.repo("crmCompanyService").listAndCount(filters, config);
+  }
+  async updateCrmCompanies(data: any) {
+    return this.repo("crmCompanyService").update(data);
+  }
+  async deleteCrmCompanies(selector: any) {
+    return this.repo("crmCompanyService").delete(selector);
+  }
+
+  // ── people ───────────────────────────────────────────────────────────────────
+  async createCrmPeople(data: any) {
+    return this.repo("crmPersonService").create(data);
+  }
+  async retrieveCrmPerson(id: string) {
+    return this.repo("crmPersonService").retrieve(id);
+  }
+  async listCrmPeople(filters?: any, config?: any) {
+    return this.repo("crmPersonService").list(filters, config);
+  }
+  async listAndCountCrmPeople(filters?: any, config?: any) {
+    return this.repo("crmPersonService").listAndCount(filters, config);
+  }
+  async updateCrmPeople(data: any) {
+    return this.repo("crmPersonService").update(data);
+  }
+  async deleteCrmPeople(selector: any) {
+    return this.repo("crmPersonService").delete(selector);
+  }
+
+  // ── opportunities ─────────────────────────────────────────────────────────────
+  async createCrmOpportunities(data: any) {
+    return this.repo("crmOpportunityService").create(data);
+  }
+  async retrieveCrmOpportunity(id: string) {
+    return this.repo("crmOpportunityService").retrieve(id);
+  }
+  async listCrmOpportunities(filters?: any, config?: any) {
+    return this.repo("crmOpportunityService").list(filters, config);
+  }
+  async listAndCountCrmOpportunities(filters?: any, config?: any) {
+    return this.repo("crmOpportunityService").listAndCount(filters, config);
+  }
+  async updateCrmOpportunities(data: any) {
+    return this.repo("crmOpportunityService").update(data);
+  }
+  async deleteCrmOpportunities(selector: any) {
+    return this.repo("crmOpportunityService").delete(selector);
+  }
+
+  // ── notes ─────────────────────────────────────────────────────────────────────
+  async createCrmNotes(data: any) {
+    return this.repo("crmNoteService").create(data);
+  }
+  async retrieveCrmNote(id: string) {
+    return this.repo("crmNoteService").retrieve(id);
+  }
+  async listCrmNotes(filters?: any, config?: any) {
+    return this.repo("crmNoteService").list(filters, config);
+  }
+  async listAndCountCrmNotes(filters?: any, config?: any) {
+    return this.repo("crmNoteService").listAndCount(filters, config);
+  }
+  async updateCrmNotes(data: any) {
+    return this.repo("crmNoteService").update(data);
+  }
+  async deleteCrmNotes(selector: any) {
+    return this.repo("crmNoteService").delete(selector);
+  }
+
+  // ── tasks ─────────────────────────────────────────────────────────────────────
+  async createCrmTasks(data: any) {
+    return this.repo("crmTaskService").create(data);
+  }
+  async retrieveCrmTask(id: string) {
+    return this.repo("crmTaskService").retrieve(id);
+  }
+  async listCrmTasks(filters?: any, config?: any) {
+    return this.repo("crmTaskService").list(filters, config);
+  }
+  async listAndCountCrmTasks(filters?: any, config?: any) {
+    return this.repo("crmTaskService").listAndCount(filters, config);
+  }
+  async updateCrmTasks(data: any) {
+    return this.repo("crmTaskService").update(data);
+  }
+  async deleteCrmTasks(selector: any) {
+    return this.repo("crmTaskService").delete(selector);
+  }
+}
+
+export default CrmService;

--- a/apps/backend/src/workflows/crm/create-opportunity.ts
+++ b/apps/backend/src/workflows/crm/create-opportunity.ts
@@ -1,0 +1,44 @@
+import {
+  createWorkflow,
+  createStep,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk";
+
+import { CRM_MODULE } from "../../modules/crm";
+
+type CreateOpportunityStepInput = {
+  title: string;
+  stage?: string;
+  amount?: number | null;
+  currency?: string;
+  expected_close_date?: string | null;
+  company_id?: string | null;
+  owner_person_id?: string | null;
+  metadata?: Record<string, any>;
+};
+
+export const createOpportunityStep = createStep(
+  "create-crm-opportunity-step",
+  async (input: CreateOpportunityStepInput, { container }) => {
+    const service: any = container.resolve(CRM_MODULE);
+    const opportunity = await service.createCrmOpportunities(input);
+    return new StepResponse(opportunity, opportunity.id);
+  },
+  async (opportunityId, { container }) => {
+    const service: any = container.resolve(CRM_MODULE);
+    await service.deleteCrmOpportunities(opportunityId!);
+  },
+);
+
+export type CreateOpportunityWorkflowInput = CreateOpportunityStepInput;
+
+export const createOpportunityWorkflow = createWorkflow(
+  "create-crm-opportunity",
+  (input: CreateOpportunityWorkflowInput) => {
+    const opportunity = createOpportunityStep(input);
+    return new WorkflowResponse(opportunity);
+  },
+);
+
+export default createOpportunityWorkflow;

--- a/apps/backend/src/workflows/crm/create-task.ts
+++ b/apps/backend/src/workflows/crm/create-task.ts
@@ -1,0 +1,45 @@
+import {
+  createWorkflow,
+  createStep,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk";
+
+import { CRM_MODULE } from "../../modules/crm";
+
+type CreateTaskStepInput = {
+  title: string;
+  description?: string | null;
+  due_date?: string | null;
+  status?: string;
+  priority?: string;
+  assignee_person_id?: string | null;
+  related_type?: string | null;
+  related_id?: string | null;
+  metadata?: Record<string, any>;
+};
+
+export const createTaskStep = createStep(
+  "create-crm-task-step",
+  async (input: CreateTaskStepInput, { container }) => {
+    const service: any = container.resolve(CRM_MODULE);
+    const task = await service.createCrmTasks(input);
+    return new StepResponse(task, task.id);
+  },
+  async (taskId, { container }) => {
+    const service: any = container.resolve(CRM_MODULE);
+    await service.deleteCrmTasks(taskId!);
+  },
+);
+
+export type CreateTaskWorkflowInput = CreateTaskStepInput;
+
+export const createTaskWorkflow = createWorkflow(
+  "create-crm-task",
+  (input: CreateTaskWorkflowInput) => {
+    const task = createTaskStep(input);
+    return new WorkflowResponse(task);
+  },
+);
+
+export default createTaskWorkflow;

--- a/apps/backend/src/workflows/crm/log-note.ts
+++ b/apps/backend/src/workflows/crm/log-note.ts
@@ -1,0 +1,41 @@
+import {
+  createWorkflow,
+  createStep,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk";
+
+import { CRM_MODULE } from "../../modules/crm";
+
+type LogNoteStepInput = {
+  body: string;
+  author?: string | null;
+  related_type?: string | null;
+  related_id?: string | null;
+  metadata?: Record<string, any>;
+};
+
+export const logNoteStep = createStep(
+  "log-crm-note-step",
+  async (input: LogNoteStepInput, { container }) => {
+    const service: any = container.resolve(CRM_MODULE);
+    const note = await service.createCrmNotes(input);
+    return new StepResponse(note, note.id);
+  },
+  async (noteId, { container }) => {
+    const service: any = container.resolve(CRM_MODULE);
+    await service.deleteCrmNotes(noteId!);
+  },
+);
+
+export type LogNoteWorkflowInput = LogNoteStepInput;
+
+export const logNoteWorkflow = createWorkflow(
+  "log-crm-note",
+  (input: LogNoteWorkflowInput) => {
+    const note = logNoteStep(input);
+    return new WorkflowResponse(note);
+  },
+);
+
+export default logNoteWorkflow;

--- a/apps/docs/notes/OFFLINE_FIRST_TO_FREE_VM_NODE.md
+++ b/apps/docs/notes/OFFLINE_FIRST_TO_FREE_VM_NODE.md
@@ -1,0 +1,146 @@
+# Offline-first → always-on node on a free VM — a deployment pattern
+
+> **Status (2026-07-18):** proven end-to-end by the CRM module (#1082). The CRM
+> Autobase node runs on an OCI free-tier VM behind a Cloudflare Tunnel; Medusa
+> proxies to it. This doc is the reusable **operational** guide. For the *design*
+> of the underlying DAL/seams, see
+> [`MIKROHYPERBEE_FRAMEWORK.md`](./MIKROHYPERBEE_FRAMEWORK.md). Related:
+> `#938 product-as-spine`, `#940 free-hosting migration`, and the tracking issue
+> for porting this to a full Medusa-free API on a free VM.
+
+## 1. What this is (and when to reach for it)
+
+A recipe for taking a module off Postgres and onto an **append-log + P2P**
+foundation, then running the durable writer on **free, always-on infrastructure**
+without opening the box to the internet — while Medusa stays a **stateless
+proxy**.
+
+Use it when a domain is:
+
+- **offline-first / edge-friendly** — writers may be disconnected and reconcile
+  later (contacts, notes, pipeline, field data, provenance);
+- **soft-integrity-tolerant** — eventual consistency + last-writer-wins is
+  acceptable (uniqueness resolved at *merge*, not at *append*);
+- **cost-sensitive** — you'd rather run it on a $0 always-free VM than pay for
+  managed Postgres + compute.
+
+Do **not** use it for money, inventory, or anything needing hard
+single-writer/ACID guarantees. Those stay on Postgres (**polyglot by design**).
+
+## 2. The layered pattern
+
+Six layers, each swappable, each already validated in the CRM build:
+
+```
+  ┌─ L6  Medusa (stateless) ──────────────────────────────────────────┐
+  │      MedusaService → ${model}Service → baseRepository (Seam A)     │
+  │      loader picks a repo impl by env; no native stack in the API   │
+  └───────────────────────────┬───────────────────────────────────────┘
+                              │  HTTP + bearer  (proxy repo)
+  ┌───────────────────────────▼─────── Cloudflare Tunnel (TLS@edge) ───┐
+  │  no inbound VM ports — cloudflared dials OUT to the CF edge        │
+  └───────────────────────────┬───────────────────────────────────────┘
+  ┌───────────────────────────▼──────── always-on node (free VM) ─────┐
+  │  L5  tiny HTTP surface  (/crm/:seg[/:id], /health, /admin/writers) │
+  │  L4  Autobase multi-writer  → deterministic apply() → ONE view     │
+  │  L3  repository contract  (shape · uniqueness · referential integ) │
+  │  L2  Hyperbee  (append-log KV, per-model sub-db isolation)         │
+  │  L1  Corestore on a PERSISTENT DISK  (the durability anchor)       │
+  └───────────────────────────────────────────────────────────────────┘
+```
+
+- **L1 Corestore / persistent disk** — the whole point of the VM. On an ephemeral
+  host (Fargate, CF Containers) the store is lost on restart; on a free VM the
+  `CRM_STORE` dir is a real disk. This is *the* reason the node lives on a VM.
+- **L2 Hyperbee** — append-only KV; reads are just Hyperbee reads. Per-entity
+  `view.sub(model)` isolation (a shared index once cross-linked two models — the
+  isolation fix is load-bearing).
+- **L3 repository contract** — Medusa-free (`dal/crm-contracts.ts`): shape,
+  uniqueness, referential integrity. The same contracts drive embedded *and* node
+  modes.
+- **L4 Autobase (multi-writer)** — each writer appends ops to its **own** input
+  core; a deterministic, **never-throwing LWW** `apply()` folds them into one
+  Hyperbee view. Ops carry fully-materialized rows (writer mints id + stamps
+  timestamps *before* append, so `apply()` is pure). Uniqueness clashes / stale
+  updates are *dropped* at merge; the loser learns by reading its id back.
+- **L5 tiny HTTP node** (`node/server.ts`) — host-agnostic. Opens the Autobase
+  over `CRM_STORE`, serves REST, gates on a bearer token, and can authorize new
+  writers (`POST /admin/writers`, owner-adds-writer).
+- **L6 Medusa proxy** — the DAL loader is **flag-gated + non-fatal**: `CRM_NODE_URL`
+  → proxy mode; `CRM_HYPERBEE=true` → embedded (dev); neither → no-op. A backend
+  hiccup degrades that module alone, never boot.
+
+## 3. Topologies
+
+| | Store lives | Medusa holds | Durability | Use |
+|---|---|---|---|---|
+| **Embedded** | in the API process | a local Hyperbee | ephemeral on Fargate | local dev / experiments (`CRM_HYPERBEE=true`) |
+| **Proxy (A)** ✅ | on the free VM | nothing (stateless) | persistent disk | **prod today** (`CRM_NODE_URL=…`) |
+| **Full API on VM** | on the free VM | — (Medusa-free API runs *on* the VM) | persistent disk | endgame — see §7 |
+
+Topology A is the current prod shape: durability + native P2P stack live on the
+VM; the API tasks stay light and stateless. Multi-writer-ready — offline/edge
+writers join the node's Autobase later with **zero Medusa changes**.
+
+## 4. Deploy recipe (the worked example: the CRM node)
+
+Reproducible steps live next to the code:
+[`apps/backend/src/modules/crm/node/deploy/`](../../backend/src/modules/crm/node/deploy/)
+(README + systemd unit + standalone `package.json`). In short:
+
+1. **Bundle** — one self-contained CJS file via esbuild; native P2P deps
+   (`corestore`/`hyperbee`/`autobase`) stay **external** and are `npm install`ed on
+   the box (they ship linux-x64 prebuilds). No `tsx` on the box.
+2. **Ship** — `scp` to `/opt/<svc>`, `npm install --omit=dev`.
+3. **Run** — systemd unit as an unprivileged user, `EnvironmentFile` (root:600),
+   persistent `*_STORE` dir, and a **`MemoryMax`** cap to stay inside the 1 GB box.
+4. **Ingress** — a Cloudflare **remotely-managed** tunnel: create tunnel + ingress
+   config + a **proxied** `CNAME <host> → <tunnel-id>.cfargotunnel.com`, then
+   `cloudflared service install <connector-token>` on the box. No inbound ports.
+5. **Wire the app** — `<SVC>_NODE_URL` (non-secret, in the copilot manifest
+   `variables:`) + `<SVC>_NODE_TOKEN` (SSM SecureString, in `secrets:`). Deploy →
+   loader logs proxy mode → the module is live.
+
+## 5. Footprint & host selection (why a *free* VM works)
+
+The node is tiny: Node baseline + Hyperbee/Autobase over a small dataset ≈ **35 MB
+RSS**. That comfortably co-locates on an **Oracle Always-Free `VM.Standard.E2.1.Micro`**
+(1 GB / 2 vCPU) alongside an existing idle service.
+
+Selection rule when co-locating: pick the box by **`available` RAM + 5-min load**,
+not by role. For CRM we chose the **P2P mirror** box (idle durability replica,
+~360 MB free) over the **crawler** box (saturated, ~195 MB free, load 3.5). Cap
+the service with systemd `MemoryMax` so it can never starve the host.
+
+> **Whole-Medusa-on-a-VM does _not_ fit these micros.** The prod build alone OOMs
+> at 2 GB (needs a 6 GB heap); runtime needs server + worker + Redis + Postgres.
+> That is the **Ampere A1** free allocation (up to 4 OCPU / 24 GB) — see #940 — a
+> different, deliberate move. This pattern is for a *single durable node*, not the
+> whole app.
+
+## 6. Security model
+
+- **No inbound ports.** The VM firewall opens only `:22`; the node binds locally
+  and is reachable **only** through the tunnel. `cloudflared` dials *out*.
+- **TLS at the CF edge**, so no cert management on the box.
+- **Bearer token** on every route (`/health` excepted); unauthenticated → 401. The
+  token is an SSM SecureString on the Medusa side and a root:600 env file on the
+  box. Rotate by regenerating both.
+- Defense-in-depth to add later: Cloudflare Access (service token / mTLS) in front
+  of the hostname; a `conflicts` sub-db so LWW losers are surfaced, not silently
+  dropped.
+
+## 7. The path forward — port to a full Medusa-free API on a free VM
+
+Topology A keeps Medusa in front. The endgame (strangler-fig, per the framework
+doc) is to let the **node itself grow into the API** — the same repository code +
+a `query.graph`-style joiner + a thin HTTP layer — so a whole domain runs
+Medusa-free **on the free VM**, and Medusa either proxies to it or is removed from
+that path entirely. That is what makes "moving off Medusa" a matter of *deleting an
+import*, not un-forking a fork.
+
+**Tracked as [#1084](https://github.com/Jaal-Yantra-Textiles/v2/issues/1084)** — the concrete port:
+generalize `node/server.ts` into a reusable service host (module registry, the
+joiner, auth, writer membership, snapshot/restore), so any offline-first module
+gets this deployment for free and the free-VM API becomes first-class rather than
+CRM-specific.

--- a/deploy/aws/copilot/medusa-server/manifest.yml
+++ b/deploy/aws/copilot/medusa-server/manifest.yml
@@ -80,6 +80,15 @@ variables:
   # non-fatal: if peering ever fails it just 503s /web/census/*, never breaks boot.
   # To revert to proxy: unset CENSUS_P2P_ENABLED and set CENSUS_READER_URL back.
   CENSUS_P2P_ENABLED: "true"
+  # #1082 — CRM on Hyperbee/Autobase (Topology-A). Points the CRM module's DAL
+  # loader (src/modules/crm/loaders/hyperbee-dal.ts) at the always-on Autobase
+  # node co-located on the OCI handloom-mirror VM, reached over a Cloudflare
+  # Tunnel (no inbound VM ports; TLS at the CF edge). Setting this flips the
+  # loader into PROXY mode — Medusa stays stateless (no native hypercore stack in
+  # the API tasks) and forwards CRM CRUD to the node. Unset → module no-ops
+  # (non-fatal). The bearer is CRM_NODE_TOKEN (secret, below). Non-secret URL, so
+  # it lives here.
+  CRM_NODE_URL: https://crm-node.jaalyantra.com
 
 # Secrets: rotating values come from Secrets Manager.
 # Non-rotating config (CORS, URLs, etc.) comes from SSM Parameter Store — listed
@@ -103,6 +112,10 @@ secrets:
   CLOUDFLARE_API_TOKEN: /jyt/prod/CLOUDFLARE_API_TOKEN
   CLOUDFLARE_ZONE_ID: /jyt/prod/CLOUDFLARE_ZONE_ID
   COOKIE_SECRET: /jyt/prod/COOKIE_SECRET
+  # #1082 — bearer for the CRM Autobase node (crm-node.jaalyantra.com). Pairs with
+  # CRM_NODE_URL (variables, above). Store the SSM SecureString BEFORE the first
+  # deploy that carries CRM_NODE_URL, else task start fails resolving this secret.
+  CRM_NODE_TOKEN: /jyt/prod/CRM_NODE_TOKEN
   DATABASE_URL: /jyt/prod/DATABASE_URL
   DELHIVERY_API_TOKEN: /jyt/prod/DELHIVERY_API_TOKEN
   ENCRYPTION_KEY: /jyt/prod/ENCRYPTION_KEY

--- a/packages/mikrohyperbee/package.json
+++ b/packages/mikrohyperbee/package.json
@@ -20,13 +20,14 @@
     "dist"
   ],
   "scripts": {
-    "test": "tsx test/repository.e2e.ts && tsx test/workflow-store.e2e.ts",
+    "test": "tsx test/repository.e2e.ts && tsx test/workflow-store.e2e.ts && tsx test/autobee-multiwriter.e2e.ts",
     "typecheck": "tsc --noEmit",
     "build": "tsc",
     "prepare": "tsc"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
+    "autobase": "^7.28.1",
     "corestore": "^7.4.6",
     "hyperbee": "^2.24.2",
     "tsx": "^4.19.2",

--- a/packages/mikrohyperbee/src/autobee.ts
+++ b/packages/mikrohyperbee/src/autobee.ts
@@ -1,0 +1,255 @@
+/**
+ * Autobee — multi-writer MikroHyperbee over Autobase.
+ *
+ * Single-writer is a property of a *hypercore*, not of this DAL. Autobase gives
+ * multi-writer by event-sourcing: each writer appends ops to its OWN input core,
+ * and a deterministic `apply()` linearizes every writer's ops into one Hyperbee
+ * view. The read surface is unchanged — the view IS a Hyperbee, so the same
+ * HyperbeeBaseRepository queries it.
+ *
+ * The adaptation that makes this correct:
+ *   - Ops carry FULLY-MATERIALIZED rows. The writer generates the id and stamps
+ *     created_at/updated_at *before* appending — because `apply()` must be a pure
+ *     function of the ops (running `nextId()` or `new Date()` inside apply would
+ *     make every node compute a different view → divergence).
+ *   - `apply()` is a pure LWW fold (repository.foldPut/foldDel) that NEVER throws:
+ *     a uniqueness clash or a stale (older updated_at) write is dropped, not
+ *     raised, so the linearizer keeps converging. The "loser" simply isn't in the
+ *     view — the writer learns it lost by reading its id back and not finding it.
+ *
+ * Consistency is eventual (this is the trade for P2P + offline + multi-writer):
+ * uniqueness is resolved deterministically at merge, not synchronously at append.
+ * Keep invariant-critical domains (money, inventory) on a strong store.
+ *
+ * The package stays storage-agnostic: the caller constructs the Autobase (wiring
+ * `makeApply(contracts)` as its apply fn) and passes it in, exactly as
+ * hyperbeeRepositoryFor takes a ready Hyperbee.
+ */
+import { applyShape } from "./contract";
+import { HyperbeeBaseRepository } from "./repository";
+import {
+  BeeLike,
+  Contract,
+  ContractError,
+  ListConfig,
+  ModelRepository,
+  RepositoryContext,
+  Where,
+} from "./types";
+
+/** The minimal Autobase surface Autobee needs (structurally typed, no dep). */
+export interface AutobaseLike {
+  /** The linearized view — a Hyperbee (opened by the caller's `open`). */
+  view: BeeLike;
+  /** Append an op to THIS writer's input core. */
+  append(value: any): Promise<void>;
+  /** Run the linearizer so `view` reflects all known ops. */
+  update(): Promise<void>;
+  /** This writer's input core (its `key` authorizes it as a writer). */
+  local?: { key: Buffer | Uint8Array };
+}
+
+/** Op envelope appended to a writer's input core (base `valueEncoding: "json"`). */
+export type AutobeeOp =
+  | { t: "put"; model: string; row: Record<string, any> }
+  | { t: "del"; model: string; key: string }
+  | { t: "addWriter"; key: string };
+
+const isPlainObject = (v: unknown): v is Record<string, any> =>
+  !!v && typeof v === "object" && !Array.isArray(v);
+
+/**
+ * Build the Autobase `apply(nodes, view, host)` handler for a set of contracts.
+ * Deterministic: it only ever touches `view` (the sole data structure Autobase
+ * can undo/reapply). Per-model repositories are cached against the view instance.
+ */
+export function makeApply(
+  contracts: Record<string, Contract>,
+  ctx: RepositoryContext = {}
+) {
+  let repos: Record<string, HyperbeeBaseRepository> | null = null;
+  let boundView: unknown = null;
+
+  return async function apply(nodes: any[], view: BeeLike, host: any): Promise<void> {
+    if (boundView !== view) {
+      boundView = view;
+      repos = {};
+      for (const [model, contract] of Object.entries(contracts)) {
+        repos[model] = new HyperbeeBaseRepository(view, contract, ctx);
+      }
+    }
+    for (const node of nodes) {
+      const op = node?.value as AutobeeOp | undefined;
+      if (!op || typeof op !== "object") continue;
+      if (op.t === "addWriter") {
+        await host.addWriter(Buffer.from(op.key, "hex"), { indexer: true });
+        continue;
+      }
+      const repo = repos![op.model];
+      if (!repo) continue;
+      if (op.t === "put") await repo.foldPut(op.row);
+      else if (op.t === "del") await repo.foldDel(op.key);
+    }
+  };
+}
+
+/**
+ * A ModelRepository whose writes go through Autobase (append → deterministic
+ * apply) and whose reads hit the linearized Hyperbee view. Same public surface as
+ * HyperbeeBaseRepository, so routes/workflows can't tell which backend they're on.
+ */
+export class AutobeeRepository implements ModelRepository {
+  private reader: HyperbeeBaseRepository | null = null;
+  private tag: string | null = null;
+  private counter = 0;
+
+  constructor(
+    private base: AutobaseLike,
+    private contract: Contract,
+    private ctx: RepositoryContext = {}
+  ) {}
+
+  /** Read path: the same contract-driven repository, bound to the linearized view. */
+  private read(): HyperbeeBaseRepository {
+    if (!this.reader) {
+      this.reader = new HyperbeeBaseRepository(this.base.view, this.contract, this.ctx);
+    }
+    return this.reader;
+  }
+
+  /** Writer-unique id: `<prefix>_<writerTag><base36 counter>` — collision-free
+   *  across writers without coordination (each writer's core key is unique). */
+  private writerTag(): string {
+    if (this.tag === null) {
+      const k = this.base.local?.key;
+      this.tag = k ? Buffer.from(k).toString("hex").slice(0, 8) : "local";
+    }
+    return this.tag;
+  }
+  private genId(explicit?: string): string {
+    if (explicit) return explicit;
+    const prefix = this.contract.id?.prefix ?? this.contract.model;
+    this.counter += 1;
+    return `${prefix}_${this.writerTag()}${this.counter.toString(36).padStart(4, "0")}`;
+  }
+
+  /** Fully materialize a row at the writer (id + timestamps), so `apply()` stays
+   *  a pure function of the op. */
+  private materialize(input: any, existing: any | null): Record<string, any> {
+    const merged = existing ? { ...existing, ...input } : input;
+    const { row: shaped } = applyShape(this.contract, merged);
+    const row: Record<string, any> = { ...shaped };
+    row.id = existing ? existing.id : this.genId(input.id);
+    if (this.contract.timestamps !== false) {
+      const now = new Date().toISOString();
+      row.created_at = existing ? existing.created_at : input.created_at ?? now;
+      row.updated_at = now;
+      if (row.deleted_at === undefined) row.deleted_at = null;
+    }
+    return row;
+  }
+
+  private async commit(row: Record<string, any>): Promise<void> {
+    await this.base.append({ t: "put", model: this.contract.model, row });
+    await this.base.update();
+  }
+
+  async create(data: any): Promise<any> {
+    const arr = Array.isArray(data) ? data : [data];
+    const out: any[] = [];
+    for (const input of arr) {
+      const row = this.materialize(input, null);
+      await this.commit(row);
+      // Read our id back from the linearized view: present → we won; absent → our
+      // write lost a uniqueness race (deterministic loser). Surfaced as not_unique.
+      try {
+        out.push(await this.read().retrieve(row.id));
+      } catch {
+        throw new ContractError(
+          "not_unique",
+          `${this.contract.model} create rejected — a conflicting record won linearization`
+        );
+      }
+    }
+    return Array.isArray(data) ? out : out[0];
+  }
+
+  async update(data: any): Promise<any> {
+    const arr = Array.isArray(data) ? data : [data];
+    const out: any[] = [];
+    for (const d of arr) {
+      const existing = await this.read().retrieve(String(d.id)); // throws not_found
+      const row = this.materialize(d, existing);
+      await this.commit(row);
+      out.push(await this.read().retrieve(row.id));
+    }
+    return Array.isArray(data) ? out : out[0];
+  }
+
+  async upsert(data: any): Promise<any> {
+    const arr = Array.isArray(data) ? data : [data];
+    const out: any[] = [];
+    for (const input of arr) {
+      const existing = input.id
+        ? await this.read().retrieve(String(input.id)).catch(() => null)
+        : null;
+      const row = this.materialize(input, existing);
+      await this.commit(row);
+      out.push(await this.read().retrieve(row.id));
+    }
+    return Array.isArray(data) ? out : out[0];
+  }
+
+  async delete(selector: string | string[] | Where | Where[]): Promise<void> {
+    const targets: Array<string | Where> = Array.isArray(selector)
+      ? (selector as Array<string | Where>)
+      : [selector as string | Where];
+    const keys = new Set<string>();
+    for (const t of targets) {
+      if (typeof t === "string") keys.add(t);
+      else if (isPlainObject(t)) {
+        for (const row of await this.read().list(t, { take: null })) keys.add(String(row.id));
+      }
+    }
+    for (const key of keys) {
+      await this.base.append({ t: "del", model: this.contract.model, key });
+    }
+    if (keys.size) await this.base.update();
+  }
+
+  // ── reads delegate to the view-bound repository ──────────────────────────────
+  retrieve(id: string): Promise<any> {
+    return this.read().retrieve(id);
+  }
+  list(filters?: Where, config?: ListConfig): Promise<any[]> {
+    return this.read().list(filters, config);
+  }
+  listAndCount(filters?: Where, config?: ListConfig): Promise<[any[], number]> {
+    return this.read().listAndCount(filters, config);
+  }
+  softDelete(): Promise<[any[], Record<string, unknown>]> {
+    return this.read().softDelete();
+  }
+  restore(): Promise<[any[], Record<string, unknown>]> {
+    return this.read().restore();
+  }
+}
+
+/** Factory: a multi-writer repository for a contract over a ready Autobase. */
+export function autobeeRepositoryFor(
+  contract: Contract,
+  base: AutobaseLike,
+  ctx?: RepositoryContext
+): AutobeeRepository {
+  return new AutobeeRepository(base, contract, ctx);
+}
+
+/** Membership: append an `addWriter` op authorizing `writerKey` (from another
+ *  base's `local.key`). Only an existing writer/indexer may do this. */
+export async function authorizeWriter(
+  base: AutobaseLike,
+  writerKey: Buffer | Uint8Array
+): Promise<void> {
+  await base.append({ t: "addWriter", key: Buffer.from(writerKey).toString("hex") });
+  await base.update();
+}

--- a/packages/mikrohyperbee/src/autobee.ts
+++ b/packages/mikrohyperbee/src/autobee.ts
@@ -75,7 +75,10 @@ export function makeApply(
       boundView = view;
       repos = {};
       for (const [model, contract] of Object.entries(contracts)) {
-        repos[model] = new HyperbeeBaseRepository(view, contract, ctx);
+        // Each model gets its OWN sub-bee on the view so rec/idx/uniq are isolated
+        // per entity — else a shared index (e.g. company_id) cross-links models and
+        // a list of one model returns another's rows. MUST match the read side.
+        repos[model] = new HyperbeeBaseRepository(view.sub(model), contract, ctx);
       }
     }
     for (const node of nodes) {
@@ -112,7 +115,13 @@ export class AutobeeRepository implements ModelRepository {
   /** Read path: the same contract-driven repository, bound to the linearized view. */
   private read(): HyperbeeBaseRepository {
     if (!this.reader) {
-      this.reader = new HyperbeeBaseRepository(this.base.view, this.contract, this.ctx);
+      // Same per-model sub-bee the apply-fold writes into (view.sub(model)), so
+      // reads see this entity's rec/idx/uniq only — never another model's.
+      this.reader = new HyperbeeBaseRepository(
+        this.base.view.sub(this.contract.model),
+        this.contract,
+        this.ctx
+      );
     }
     return this.reader;
   }

--- a/packages/mikrohyperbee/src/index.ts
+++ b/packages/mikrohyperbee/src/index.ts
@@ -6,6 +6,13 @@
 export { defineContract, applyShape, checkInvariants } from "./contract";
 export { HyperbeeBaseRepository, hyperbeeRepositoryFor } from "./repository";
 export {
+  AutobeeRepository,
+  autobeeRepositoryFor,
+  makeApply,
+  authorizeWriter,
+} from "./autobee";
+export type { AutobaseLike, AutobeeOp } from "./autobee";
+export {
   ContractError,
 } from "./types";
 export type {

--- a/packages/mikrohyperbee/src/repository.ts
+++ b/packages/mikrohyperbee/src/repository.ts
@@ -422,6 +422,61 @@ export class HyperbeeBaseRepository implements ModelRepository {
   async restore(): Promise<[any[], Record<string, unknown>]> {
     return [[], {}];
   }
+
+  // ── multi-writer fold (Autobase apply) ──────────────────────────────────────
+  // Deterministic persistence of a FULLY-MATERIALIZED row (id + timestamps already
+  // set by the writer). Unlike write(), it never generates an id, never re-stamps,
+  // and NEVER throws — it returns an outcome so the Autobase `apply()` can record a
+  // conflict and keep linearizing instead of halting. Referential integrity is NOT
+  // enforced here (soft-by-default across writers, per the framework doc); flip a
+  // relation to strict only inside a single-writer domain.
+  //
+  // Conflict policy = last-writer-wins by `updated_at` (ties → last in linear order,
+  // which is deterministic because apply replays a fixed order). A uniqueness clash
+  // with a *different* key, or an invariant violation, rejects the row (loser).
+  async foldPut(
+    row: Record<string, any>
+  ): Promise<"applied" | "stale" | "rejected"> {
+    const key = this.keyOf(row);
+    const existing = await this.get(key);
+    if (
+      existing &&
+      row.updated_at != null &&
+      existing.updated_at != null &&
+      String(row.updated_at) < String(existing.updated_at)
+    ) {
+      return "stale"; // an older write loses
+    }
+    // uniqueness: a reservation held by a DIFFERENT key means this row loses.
+    for (const f of this.uniques) {
+      const v = row[f];
+      if (v === undefined || v === null) continue;
+      const node = await this.uniq.get(this.uniqKey(f, v));
+      if (node && node.value !== key) return "rejected";
+    }
+    try {
+      checkInvariants(this.contract, row);
+    } catch {
+      return "rejected";
+    }
+    if (existing) {
+      await this.deindex(existing, key);
+      await this.releaseUnique(existing);
+    }
+    await this.recs.put(key, this.enc(row));
+    await this.index(row, key);
+    await this.reserveUnique(row, key);
+    return "applied";
+  }
+
+  /** Deterministic delete of a materialized key (Autobase apply). Idempotent. */
+  async foldDel(key: string): Promise<void> {
+    const cur = await this.get(key);
+    if (!cur) return;
+    await this.deindex(cur, key);
+    await this.releaseUnique(cur);
+    await this.recs.del(key);
+  }
 }
 
 /** Factory: build a repository for a contract over a ready Hyperbee. */

--- a/packages/mikrohyperbee/test/autobee-multiwriter.e2e.ts
+++ b/packages/mikrohyperbee/test/autobee-multiwriter.e2e.ts
@@ -1,0 +1,188 @@
+/**
+ * Multi-writer proof: two independent Autobase writers, replicated in-process,
+ * both driving the SAME CRM contracts through the AutobeeRepository. Proves:
+ *   1. cross-writer merge — each writer's records appear on the other,
+ *   2. deterministic uniqueness resolution across writers (email clash),
+ *   3. last-writer-wins by updated_at (a stale write is dropped on both views).
+ *
+ * No Medusa, no Postgres, no network. Run:
+ *   pnpm --filter @jytextiles/mikrohyperbee exec tsx test/autobee-multiwriter.e2e.ts
+ */
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// @ts-ignore - devDependencies, resolved at test time
+import Corestore from "corestore";
+// @ts-ignore
+import Hyperbee from "hyperbee";
+// @ts-ignore
+import Autobase from "autobase";
+
+import {
+  defineContract,
+  autobeeRepositoryFor,
+  makeApply,
+  authorizeWriter,
+  ContractError,
+} from "../src";
+
+let pass = 0;
+let fail = 0;
+const ok = (cond: boolean, msg: string) => {
+  if (cond) { pass++; console.log(`  ✓ ${msg}`); }
+  else { fail++; console.error(`  ✗ ${msg}`); }
+};
+
+// ── the CRM-shaped contracts (company + person, with unique constraints) ────────
+const company = defineContract("crm_company", {
+  id: { prefix: "crmco" },
+  mode: "strict",
+  fields: {
+    name: { type: "string", required: true },
+    industry: { type: "string", nullable: true },
+  },
+  indexes: ["industry"],
+  unique: ["name"],
+});
+const person = defineContract("crm_person", {
+  id: { prefix: "crmp" },
+  mode: "strict",
+  fields: {
+    first_name: { type: "string", required: true },
+    last_name: { type: "string", required: true },
+    email: { type: "string", nullable: true },
+    company_id: { type: "string", nullable: true },
+  },
+  indexes: ["email", "company_id"],
+  unique: ["email"],
+});
+const contracts = { crm_company: company, crm_person: person };
+
+const ROOT = join(tmpdir(), `autobee-mw-${process.pid}`);
+
+function makeBase(dir: string, bootstrap: Buffer | null) {
+  const store = new Corestore(dir);
+  const base = new Autobase(store, bootstrap, {
+    valueEncoding: "json",
+    open(viewStore: any) {
+      return new Hyperbee(viewStore.get("view"), {
+        keyEncoding: "utf-8",
+        valueEncoding: "binary",
+      });
+    },
+    apply: makeApply(contracts),
+  });
+  return { store, base };
+}
+
+function pipe(a: any, b: any) {
+  const s1 = a.replicate(true);
+  const s2 = b.replicate(false);
+  s1.pipe(s2).pipe(s1);
+  return () => { try { s1.destroy(); s2.destroy(); } catch {} };
+}
+
+/** Drive the linearizer on both bases until the view stops changing. */
+async function settle(...bases: any[]) {
+  for (let i = 0; i < 8; i++) {
+    for (const b of bases) await b.update();
+    await new Promise((r) => setImmediate(r));
+  }
+}
+
+async function main() {
+  rmSync(ROOT, { recursive: true, force: true });
+
+  const A = makeBase(join(ROOT, "a"), null);
+  await A.base.ready();
+  const B = makeBase(join(ROOT, "b"), A.base.key);
+  await B.base.ready();
+
+  const stop = pipe(A.store, B.store);
+
+  // A (the bootstrap/indexer) authorizes B as a writer.
+  await authorizeWriter(A.base, B.base.local.key);
+  await settle(A.base, B.base);
+  ok(A.base.writable === true, "writer A is writable (bootstrap)");
+  ok(B.base.writable === true, "writer B authorized + writable after addWriter");
+
+  const personA = autobeeRepositoryFor(person, A.base);
+  const companyA = autobeeRepositoryFor(company, A.base);
+  const personB = autobeeRepositoryFor(person, B.base);
+  const companyB = autobeeRepositoryFor(company, B.base);
+
+  // ── 1. cross-writer merge ─────────────────────────────────────────────────────
+  const acme = await companyA.create({ name: "Acme", industry: "tech" });
+  const sam = await personB.create({ first_name: "Sam", last_name: "Rao", email: "sam@x.io" });
+  ok(/^crmco_/.test(acme.id) && acme.id !== "crmco_000001", `A minted a writer-scoped id (${acme.id})`);
+  ok(/^crmp_/.test(sam.id), `B minted a writer-scoped id (${sam.id})`);
+  await settle(A.base, B.base);
+
+  const acmeSeenByB = await companyB.list({ name: "Acme" });
+  const samSeenByA = await personA.list({ email: "sam@x.io" });
+  ok(acmeSeenByB.length === 1 && acmeSeenByB[0].id === acme.id, "A's company is visible on writer B");
+  ok(samSeenByA.length === 1 && samSeenByA[0].id === sam.id, "B's person is visible on writer A");
+
+  // filtered index read across writers
+  const techByB = await companyB.list({ industry: "tech" });
+  ok(techByB.length === 1 && techByB[0].id === acme.id, "secondary index (industry) resolves across writers");
+
+  // ── 2. deterministic uniqueness resolution across writers ─────────────────────
+  const dupA = await personA.create({ first_name: "Dup", last_name: "A", email: "dup@x.io" });
+  await settle(A.base, B.base);
+  let bRejected = false;
+  try {
+    await personB.create({ first_name: "Dup", last_name: "B", email: "dup@x.io" });
+  } catch (e: any) {
+    bRejected = e instanceof ContractError && e.type === "not_unique";
+  }
+  ok(bRejected, "writer B's duplicate email is rejected (loser sees the winner's reservation)");
+  await settle(A.base, B.base);
+  const dupOnA = await personA.list({ email: "dup@x.io" });
+  const dupOnB = await personB.list({ email: "dup@x.io" });
+  ok(dupOnA.length === 1 && dupOnB.length === 1, "exactly one 'dup@x.io' record on BOTH views");
+  ok(
+    dupOnA[0].id === dupA.id && dupOnB[0].id === dupA.id,
+    "both writers agree on the SAME uniqueness winner (deterministic)"
+  );
+
+  // ── 3. last-writer-wins by updated_at ─────────────────────────────────────────
+  const beta = await companyA.create({ name: "Beta", industry: "old" });
+  await settle(A.base, B.base);
+  // B updates Beta → newer updated_at; both should converge to B's value.
+  const betaB = await companyB.update({ id: beta.id, industry: "new-from-B" });
+  await settle(A.base, B.base);
+  const betaSeenByA = await companyA.retrieve(beta.id);
+  ok(betaSeenByA.industry === "new-from-B", "cross-writer update converges (B's value on A)");
+
+  // Now craft a STALE write from A: same id, an OLDER updated_at → must be dropped.
+  const staleTs = new Date(Date.parse(betaB.updated_at) - 60_000).toISOString();
+  await A.base.append({
+    t: "put",
+    model: "crm_company",
+    row: { ...betaSeenByA, industry: "stale-from-A", updated_at: staleTs },
+  });
+  await settle(A.base, B.base);
+  const betaFinalA = await companyA.retrieve(beta.id);
+  const betaFinalB = await companyB.retrieve(beta.id);
+  ok(betaFinalA.industry === "new-from-B", "stale write (older updated_at) dropped on A — LWW");
+  ok(betaFinalB.industry === "new-from-B", "stale write dropped on B too — deterministic LWW");
+
+  // ── cleanup ───────────────────────────────────────────────────────────────────
+  stop();
+  await A.store.close?.();
+  await B.store.close?.();
+  rmSync(ROOT, { recursive: true, force: true });
+
+  console.log(
+    `\n${fail === 0 ? "✅ PASS" : "❌ FAIL"} — ${pass} passed, ${fail} failed — ` +
+    `two Autobase writers ran the CRM contracts multi-writer (merge + uniqueness + LWW).`
+  );
+  process.exit(fail === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error("TEST THREW:", e);
+  process.exit(1);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -733,13 +733,13 @@ importers:
         version: 2.17.2
       '@medusajs/ui':
         specifier: 4.1.19
-        version: 4.1.19(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+        version: 4.1.19(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@radix-ui/react-dialog':
         specifier: 1.1.4
-        version: 1.1.4(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.1.4(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dismissable-layer':
         specifier: 1.1.4
-        version: 1.1.4(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.1.4(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-query':
         specifier: ^5.90.20
         version: 5.90.21(react@18.3.1)
@@ -754,7 +754,7 @@ importers:
         version: 2.0.0-alpha.41(@babel/runtime@7.29.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       cmdk:
         specifier: ^0.2.0
-        version: 0.2.1(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 0.2.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       copy-to-clipboard:
         specifier: ^3.3.3
         version: 3.3.3
@@ -787,7 +787,7 @@ importers:
         version: 6.15.0
       radix-ui:
         specifier: 1.1.2
-        version: 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1216,7 +1216,7 @@ importers:
         version: 4.1.4(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(typescript@5.9.3)
       '@opennextjs/cloudflare':
         specifier: ^1.20.1
-        version: 1.20.1(next@15.3.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.97.3))(wrangler@4.111.0)
+        version: 1.20.1(next@15.5.20(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.97.3))(wrangler@4.111.0)
       '@radix-ui/react-accordion':
         specifier: ^1.2.1
         version: 1.2.2(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
@@ -1230,8 +1230,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.23
       next:
-        specifier: 15.3.9
-        version: 15.3.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.97.3)
+        specifier: ^15.5.18
+        version: 15.5.20(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.97.3)
       pg:
         specifier: ^8.11.3
         version: 8.19.0
@@ -1463,6 +1463,9 @@ importers:
       '@types/node':
         specifier: ^20.12.11
         version: 20.19.34
+      autobase:
+        specifier: ^7.28.1
+        version: 7.28.1(bare-url@2.4.5)
       corestore:
         specifier: ^7.4.6
         version: 7.11.0(bare-url@2.4.5)
@@ -5742,8 +5745,8 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@next/env@15.3.9':
-    resolution: {integrity: sha512-I7wMCjlHc85EvAebNYJCRBZ+shdrGhcIXBviWmDzGYXwTQ+WrYpfg1LBOnTK1Bn3b+ud5apesNObXKEGqi/C3g==}
+  '@next/env@15.5.20':
+    resolution: {integrity: sha512-dXh51Wvddf8daEyBXryZZEe1FdVxEWx9lgaTseLZUtC1XP/W8Wri+Z+VPOElHlByk23CyqHdc2oVByX7wsTWsw==}
 
   '@next/env@16.2.9':
     resolution: {integrity: sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==}
@@ -5754,8 +5757,8 @@ packages:
   '@next/eslint-plugin-next@16.2.9':
     resolution: {integrity: sha512-UZi8+YT/MLgTC9nrrn2Xd4lBYv1B7lVmtWHfPcthAI5Tt/C1LuDe6DfmtCtJ+WQod3ksY4VrKSvk3oMVAnL7qw==}
 
-  '@next/swc-darwin-arm64@15.3.5':
-    resolution: {integrity: sha512-lM/8tilIsqBq+2nq9kbTW19vfwFve0NR7MxfkuSUbRSgXlMQoJYg+31+++XwKVSXk4uT23G2eF/7BRIKdn8t8w==}
+  '@next/swc-darwin-arm64@15.5.20':
+    resolution: {integrity: sha512-in0yXG7/pRBVjWeEl7f7ZZETpletSMFKXVS4GJgHENTPVrJFNJKPrYewa9rpZcvdjwFece5fZP0CK34G4PxowA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -5766,8 +5769,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.3.5':
-    resolution: {integrity: sha512-WhwegPQJ5IfoUNZUVsI9TRAlKpjGVK0tpJTL6KeiC4cux9774NYE9Wu/iCfIkL/5J8rPAkqZpG7n+EfiAfidXA==}
+  '@next/swc-darwin-x64@15.5.20':
+    resolution: {integrity: sha512-0hsFshdPnTzGJdDTHeHJ+XPUShOpnyp9pUFDwDhqctsA0Cd8NcIVGRPtptYhgYY9DjkKgCDRkXxmgRc+CgT5Wg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -5778,8 +5781,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.3.5':
-    resolution: {integrity: sha512-LVD6uMOZ7XePg3KWYdGuzuvVboxujGjbcuP2jsPAN3MnLdLoZUXKRc6ixxfs03RH7qBdEHCZjyLP/jBdCJVRJQ==}
+  '@next/swc-linux-arm64-gnu@15.5.20':
+    resolution: {integrity: sha512-DMvkoBtAABOzE6pMZRW/xNm7sKqql3wzzzZJ1R/d/rp4BCxv6LykouD3tHjGY8WdQqGpZs11t+R9AtjPxvvljw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -5792,8 +5795,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@15.3.5':
-    resolution: {integrity: sha512-k8aVScYZ++BnS2P69ClK7v4nOu702jcF9AIHKu6llhHEtBSmM2zkPGl9yoqbSU/657IIIb0QHpdxEr0iW9z53A==}
+  '@next/swc-linux-arm64-musl@15.5.20':
+    resolution: {integrity: sha512-RQmDfeYBtXV2FSId7dfA1hE6M/T6+g7wdbYnFQ47tw/gUBwV+CccLVejNmCGa9yLDitk83foeg8hl/3DjfYQ5g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -5806,8 +5809,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@15.3.5':
-    resolution: {integrity: sha512-2xYU0DI9DGN/bAHzVwADid22ba5d/xrbrQlr2U+/Q5WkFUzeL0TDR963BdrtLS/4bMmKZGptLeg6282H/S2i8A==}
+  '@next/swc-linux-x64-gnu@15.5.20':
+    resolution: {integrity: sha512-DkWLEdKajJwdGt27M3i1VEO2kelTvZrK6Pcb7JvW2BY+nofWm7FBsBNDj7g7Pr1NuQ5PLJvqEqYa20GTsBDnKQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -5820,8 +5823,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@15.3.5':
-    resolution: {integrity: sha512-TRYIqAGf1KCbuAB0gjhdn5Ytd8fV+wJSM2Nh2is/xEqR8PZHxfQuaiNhoF50XfY90sNpaRMaGhF6E+qjV1b9Tg==}
+  '@next/swc-linux-x64-musl@15.5.20':
+    resolution: {integrity: sha512-rAO5b7pKHvX+ExdmJskusDXTNbiNZfptifIPZItbUx+AOXxxTydVBsPt7Oz84DRd5mY8e0DcE8kvLj3AIfjE6w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -5834,8 +5837,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@15.3.5':
-    resolution: {integrity: sha512-h04/7iMEUSMY6fDGCvdanKqlO1qYvzNxntZlCzfE8i5P0uqzVQWQquU1TIhlz0VqGQGXLrFDuTJVONpqGqjGKQ==}
+  '@next/swc-win32-arm64-msvc@15.5.20':
+    resolution: {integrity: sha512-Hp3zFsN8N8Kj9+vY6L4vnZ9EtA9eXyATu0q4EfGbZTiocgPUNSfz8NWhym6xvaOmHpJ8EuoypuU1WejCPsTFtg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -5846,8 +5849,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.3.5':
-    resolution: {integrity: sha512-5fhH6fccXxnX2KhllnGhkYMndhOiLOLEiVGYjP2nizqeGWkN10sA9taATlXwake2E2XMvYZjjz0Uj7T0y+z1yw==}
+  '@next/swc-win32-x64-msvc@15.5.20':
+    resolution: {integrity: sha512-T/L7CXpR1M0wij/xbF3rT1+7KvSkfOLr7C+ToHHWZTG2eKmb52C5WvsyGCBNtkVvDEUESWkRUbbqSH4rSbOCYQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -10994,6 +10997,9 @@ packages:
     resolution: {integrity: sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==}
     engines: {node: '>=8'}
 
+  autobase@7.28.1:
+    resolution: {integrity: sha512-I8SHcJE/ru5Nun6NpqwRjenB8aK01b9z1qNeyx4XuG+BxeFUpXk0ZT2u3/nG+GZnObUTFMCKOo2fbAv7ipcaLw==}
+
   autoprefixer@10.4.27:
     resolution: {integrity: sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==}
     engines: {node: ^10 || ^12 || >=14}
@@ -11190,23 +11196,9 @@ packages:
       bare-events:
         optional: true
 
-  bare-stream@2.8.0:
-    resolution: {integrity: sha512-reUN0M2sHRqCdG4lUK3Fw8w98eeUIZHL5c3H7Mbhk2yVBL+oofgaIp0ieLfD5QXwPCypBpmEEKU2WZKzbAk8GA==}
-    peerDependencies:
-      bare-buffer: '*'
-      bare-events: '*'
-    peerDependenciesMeta:
-      bare-buffer:
-        optional: true
-      bare-events:
-        optional: true
-
   bare-type@1.1.0:
     resolution: {integrity: sha512-LdtnnEEYldOc87Dr4GpsKnStStZk3zfgoEMXy8yvEZkXrcCv9RtYDrUYWFsBQHtaB0s1EUWmcvS6XmEZYIj3Bw==}
     engines: {bare: '>=1.2.0'}
-
-  bare-url@2.3.2:
-    resolution: {integrity: sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==}
 
   bare-url@2.4.5:
     resolution: {integrity: sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==}
@@ -12011,6 +12003,9 @@ packages:
     peerDependencies:
       webpack: ^5.1.0
 
+  core-coupler@2.0.0:
+    resolution: {integrity: sha512-FJuEvsdCMwx0Wu+gFQ49rGCi8LCXh8kizHsCQwkdgPZFEFiF0z2HDvyIs+fPt5wMIfU2UVFDuN+dtpfbIxJE6g==}
+
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
 
@@ -12812,6 +12807,9 @@ packages:
 
   encoding-sniffer@0.2.1:
     resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
+  encryption-encoding@1.0.3:
+    resolution: {integrity: sha512-+SlKCeULnNnwBF2rGrJlSLYjwITwfjO8PLSHzue4yt+2DsVJUU8GakRkH4+mTaa3FzpxVjpTy1kKR2gYGctNWg==}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -16213,13 +16211,13 @@ packages:
   nerf-dart@1.0.0:
     resolution: {integrity: sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==}
 
-  next@15.3.9:
-    resolution: {integrity: sha512-bat50ogkh2esjfkbqmVocL5QunR9RGCSO2oQKFjKeDcEylIgw3JY6CMfGnzoVfXJ9SDLHI546sHmsk90D2ivwQ==}
+  next@15.5.20:
+    resolution: {integrity: sha512-cvyS3/geydan1xLtE3FA8VCgdoQ/Gg/dlOldFkFCbB5VcVYJV7090hQLBnvTW2PwT76Z/dHdzDZCsVhZpoOlUA==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
-      '@playwright/test': ^1.41.2
+      '@playwright/test': ^1.51.1
       babel-plugin-react-compiler: '*'
       react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
       react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
@@ -17750,6 +17748,9 @@ packages:
 
   protocol-buffers-encodings@1.2.0:
     resolution: {integrity: sha512-daeNPuKh1NlLD1uDfbLpD+xyUTc07nEtfHwmBZmt/vH0B7VOM+JOCOpDcx9ZRpqHjAiIkGqyTDi+wfGSl17R9w==}
+
+  protomux-wakeup@2.9.0:
+    resolution: {integrity: sha512-K93WhS9qIRL8WAQPU2V3PxdpQ1oRlQCFyCyIYInoq/iRkcuO1BegRERWo7SS1Tcme14VKGWOr/IivjjYnHan3Q==}
 
   protomux@3.11.0:
     resolution: {integrity: sha512-Ze43XaNHbL6zQ/zJwVYvue7Aj8pDB1HNnISsrFhAur3291Y+Iu2fMhOpySD73J/32BoBIUYrhl07lJsBR/fUVA==}
@@ -19433,6 +19434,9 @@ packages:
   stylis@4.3.6:
     resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
 
+  sub-encoder@2.1.3:
+    resolution: {integrity: sha512-Xxx04ygZo/1J3yHvaSA6VhDmiSaBQkw/PmO3YnnYFXle+tfOGToC6FcDpIfMztWZXJzuKG14b/57HMkiL58C6A==}
+
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -19670,6 +19674,9 @@ packages:
 
   timeout-refresh@2.0.1:
     resolution: {integrity: sha512-SVqEcMZBsZF9mA78rjzCrYrUs37LMJk3ShZ851ygZYW1cMeIjs9mL57KO6Iv5mmjSQnOe/29/VAfGXo+oRCiVw==}
+
+  tiny-buffer-map@1.1.1:
+    resolution: {integrity: sha512-C1eDw6ks9CmkDbWVCPHobuixPTkxGa7IDERlaVk98dv4tOUdz42o3haHBr0uhNxbj0gczBTVIyS2uQsu+1vc2Q==}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -27812,14 +27819,14 @@ snapshots:
       - '@types/react-dom'
       - typescript
 
-  '@medusajs/ui@4.1.19(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
+  '@medusajs/ui@4.1.19(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
       '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@dnd-kit/sortable': 8.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@dnd-kit/utilities': 3.2.2(react@18.3.1)
       '@medusajs/icons': 2.17.2(react@18.3.1)
-      '@radix-ui/react-dialog': 1.1.4(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-dismissable-layer': 1.1.4(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dialog': 1.1.4(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.4(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-table': 8.20.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
       copy-to-clipboard: 3.3.3
@@ -27827,7 +27834,7 @@ snapshots:
       lodash.isequal: 4.5.0
       prism-react-renderer: 2.4.1(react@18.3.1)
       prismjs: 1.30.0
-      radix-ui: 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      radix-ui: 1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-aria: 3.46.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-currency-input-field: 3.10.0(react@18.3.1)
@@ -28230,7 +28237,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@15.3.9': {}
+  '@next/env@15.5.20': {}
 
   '@next/env@16.2.9': {}
 
@@ -28242,49 +28249,49 @@ snapshots:
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@15.3.5':
+  '@next/swc-darwin-arm64@15.5.20':
     optional: true
 
   '@next/swc-darwin-arm64@16.2.9':
     optional: true
 
-  '@next/swc-darwin-x64@15.3.5':
+  '@next/swc-darwin-x64@15.5.20':
     optional: true
 
   '@next/swc-darwin-x64@16.2.9':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.3.5':
+  '@next/swc-linux-arm64-gnu@15.5.20':
     optional: true
 
   '@next/swc-linux-arm64-gnu@16.2.9':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.3.5':
+  '@next/swc-linux-arm64-musl@15.5.20':
     optional: true
 
   '@next/swc-linux-arm64-musl@16.2.9':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.3.5':
+  '@next/swc-linux-x64-gnu@15.5.20':
     optional: true
 
   '@next/swc-linux-x64-gnu@16.2.9':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.3.5':
+  '@next/swc-linux-x64-musl@15.5.20':
     optional: true
 
   '@next/swc-linux-x64-musl@16.2.9':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.3.5':
+  '@next/swc-win32-arm64-msvc@15.5.20':
     optional: true
 
   '@next/swc-win32-arm64-msvc@16.2.9':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.3.5':
+  '@next/swc-win32-x64-msvc@15.5.20':
     optional: true
 
   '@next/swc-win32-x64-msvc@16.2.9':
@@ -28577,7 +28584,7 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 25.1.0
 
-  '@opennextjs/aws@4.0.2(next@15.3.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.97.3))':
+  '@opennextjs/aws@4.0.2(next@15.5.20(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.97.3))':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@aws-sdk/client-cloudfront': 3.984.0
@@ -28593,7 +28600,7 @@ snapshots:
       cookie: 1.1.1
       esbuild: 0.25.4
       express: 5.2.1
-      next: 15.3.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.97.3)
+      next: 15.5.20(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.97.3)
       path-to-regexp: 6.3.0
       urlpattern-polyfill: 10.1.0
       yaml: 2.9.0
@@ -28601,17 +28608,17 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@opennextjs/cloudflare@1.20.1(next@15.3.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.97.3))(wrangler@4.111.0)':
+  '@opennextjs/cloudflare@1.20.1(next@15.5.20(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.97.3))(wrangler@4.111.0)':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@dotenvx/dotenvx': 1.31.0
-      '@opennextjs/aws': 4.0.2(next@15.3.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.97.3))
+      '@opennextjs/aws': 4.0.2(next@15.5.20(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.97.3))
       ci-info: 4.4.0
       cloudflare: 4.5.0
       comment-json: 4.6.2
       enquirer: 2.4.1
       glob: 12.0.0
-      next: 15.3.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.97.3)
+      next: 15.5.20(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.97.3)
       ts-tqdm: 0.8.6
       wrangler: 4.111.0
       yargs: 18.0.0
@@ -29684,6 +29691,15 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-accessible-icon@1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-visually-hidden': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
+
   '@radix-ui/react-accessible-icon@1.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-visually-hidden': 1.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -29718,6 +29734,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-accordion@1.2.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-collapsible': 1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-collection': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
 
   '@radix-ui/react-accordion@1.2.2(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -29767,6 +29800,20 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-alert-dialog@1.1.5(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dialog': 1.1.5(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
+
   '@radix-ui/react-alert-dialog@1.1.5(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.1
@@ -29804,6 +29851,15 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-arrow@1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
+
   '@radix-ui/react-arrow@1.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -29840,6 +29896,15 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-aspect-ratio@1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
+
   '@radix-ui/react-aspect-ratio@1.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -29869,6 +29934,18 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-avatar@1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
 
   '@radix-ui/react-avatar@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -29909,6 +29986,22 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-checkbox@1.1.3(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
 
   '@radix-ui/react-checkbox@1.1.3(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -29957,6 +30050,22 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-collapsible@1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
 
   '@radix-ui/react-collapsible@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -30011,6 +30120,18 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-collection@1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
 
   '@radix-ui/react-collection@1.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -30072,6 +30193,20 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-context-menu@2.2.5(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-menu': 2.1.5(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
 
   '@radix-ui/react-context-menu@2.2.5(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -30146,28 +30281,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@radix-ui/react-dialog@1.0.0(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@radix-ui/primitive': 1.0.0
-      '@radix-ui/react-compose-refs': 1.0.0(react@18.3.1)
-      '@radix-ui/react-context': 1.0.0(react@18.3.1)
-      '@radix-ui/react-dismissable-layer': 1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-focus-guards': 1.0.0(react@18.3.1)
-      '@radix-ui/react-focus-scope': 1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-id': 1.0.0(react@18.3.1)
-      '@radix-ui/react-portal': 1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-presence': 1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-primitive': 1.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-slot': 1.0.0(react@18.3.1)
-      '@radix-ui/react-use-controllable-state': 1.0.0(react@18.3.1)
-      aria-hidden: 1.2.6
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-remove-scroll: 2.5.4(@types/react@19.0.3)(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
-
   '@radix-ui/react-dialog@1.1.4(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.1
@@ -30189,6 +30302,28 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-dialog@1.1.4(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.3(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.3(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@18.3.28)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
 
   '@radix-ui/react-dialog@1.1.4(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -30255,6 +30390,28 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-dialog@1.1.5(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.4(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.3(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@18.3.28)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
 
   '@radix-ui/react-dialog@1.1.5(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -30347,6 +30504,19 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-dismissable-layer@1.1.3(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
+
   '@radix-ui/react-dismissable-layer@1.1.3(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.1
@@ -30385,6 +30555,19 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-dismissable-layer@1.1.4(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
 
   '@radix-ui/react-dismissable-layer@1.1.4(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -30439,6 +30622,21 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-dropdown-menu@2.1.5(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-menu': 2.1.5(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
 
   '@radix-ui/react-dropdown-menu@2.1.5(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -30513,6 +30711,17 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-focus-scope@1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
+
   '@radix-ui/react-focus-scope@1.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.3)(react@18.3.1)
@@ -30560,6 +30769,20 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-form@0.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-label': 2.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
+
   '@radix-ui/react-form@0.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.1
@@ -30604,6 +30827,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-hover-card@1.1.5(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.4(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.3(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
 
   '@radix-ui/react-hover-card@1.1.5(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -30675,6 +30915,15 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-label@2.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
+
   '@radix-ui/react-label@2.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -30718,6 +30967,32 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-menu@2.1.5(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-collection': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.4(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.3(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@18.3.28)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
 
   '@radix-ui/react-menu@2.1.5(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -30789,6 +31064,24 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-menubar@1.1.5(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-collection': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-menu': 2.1.5(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
+
   '@radix-ui/react-menubar@1.1.5(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.1
@@ -30846,6 +31139,28 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-navigation-menu@1.2.4(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-collection': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.4(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
 
   '@radix-ui/react-navigation-menu@1.2.4(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -30913,6 +31228,29 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-popover@1.1.5(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.4(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.3(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@18.3.28)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
 
   '@radix-ui/react-popover@1.1.5(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -31001,6 +31339,24 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-popper@1.2.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-arrow': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-rect': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/rect': 1.1.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
+
   '@radix-ui/react-popper@1.2.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/react-dom': 2.1.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -31072,6 +31428,16 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-portal@1.1.3(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
+
   '@radix-ui/react-portal@1.1.3(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -31120,6 +31486,16 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-presence@1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
+
   '@radix-ui/react-presence@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.3)(react@18.3.1)
@@ -31163,6 +31539,15 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-primitive@2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
+
   '@radix-ui/react-primitive@2.0.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-slot': 1.1.1(@types/react@19.0.3)(react@18.3.1)
@@ -31199,6 +31584,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-progress@1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
 
   '@radix-ui/react-progress@1.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -31237,6 +31632,24 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-radio-group@1.2.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
 
   '@radix-ui/react-radio-group@1.2.2(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -31306,6 +31719,23 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-roving-focus@1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-collection': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
+
   '@radix-ui/react-roving-focus@1.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.1
@@ -31356,6 +31786,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-scroll-area@1.2.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/number': 1.1.0
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
 
   '@radix-ui/react-scroll-area@1.2.2(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -31419,6 +31866,35 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-select@2.1.5(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/number': 1.1.0
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-collection': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.4(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.3(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@18.3.28)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
 
   '@radix-ui/react-select@2.1.5(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -31487,6 +31963,15 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-separator@1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
+
   '@radix-ui/react-separator@1.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -31523,6 +32008,25 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-slider@1.2.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/number': 1.1.0
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-collection': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
 
   '@radix-ui/react-slider@1.2.2(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -31617,6 +32121,21 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-switch@1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
+
   '@radix-ui/react-switch@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.1
@@ -31677,6 +32196,22 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-tabs@1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
+
   '@radix-ui/react-tabs@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.1
@@ -31728,6 +32263,26 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-toast@1.2.5(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-collection': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.4(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.3(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
 
   '@radix-ui/react-toast@1.2.5(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -31784,6 +32339,21 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-toggle-group@1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
+
   '@radix-ui/react-toggle-group@1.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.1
@@ -31825,6 +32395,17 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-toggle@1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
+
   '@radix-ui/react-toggle@1.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.1
@@ -31861,6 +32442,21 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-toolbar@1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-separator': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle-group': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
 
   '@radix-ui/react-toolbar@1.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -31911,6 +32507,26 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-tooltip@1.1.7(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.4(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.3(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
 
   '@radix-ui/react-tooltip@1.1.7(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -32120,6 +32736,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-visually-hidden@1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
 
   '@radix-ui/react-visually-hidden@1.1.1(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -36036,6 +36661,11 @@ snapshots:
     dependencies:
       '@types/react': 18.3.28
 
+  '@types/react-dom@19.0.3(@types/react@18.3.28)':
+    dependencies:
+      '@types/react': 18.3.28
+    optional: true
+
   '@types/react-dom@19.0.3(@types/react@19.0.3)':
     dependencies:
       '@types/react': 19.0.3
@@ -37145,6 +37775,37 @@ snapshots:
 
   auto-bind@4.0.0: {}
 
+  autobase@7.28.1(bare-url@2.4.5):
+    dependencies:
+      b4a: 1.8.1
+      bare-events: 2.9.1
+      compact-encoding: 3.3.0
+      core-coupler: 2.0.0
+      debounceify: 1.1.0
+      encryption-encoding: 1.0.3
+      hyperbee: 2.27.3
+      hypercore: 11.34.0(bare-url@2.4.5)
+      hypercore-crypto: 3.7.0(bare-events@2.9.1)(bare-url@2.4.5)
+      hypercore-id-encoding: 1.3.0
+      hyperschema: 1.21.0
+      index-encoder: 3.5.0
+      nanoassert: 2.0.0
+      protomux-wakeup: 2.9.0(bare-events@2.9.1)(bare-url@2.4.5)
+      ready-resource: 1.2.0
+      resolve-reject-promise: 1.1.0
+      safety-catch: 1.0.3
+      scope-lock: 1.2.4
+      signal-promise: 1.0.3
+      sodium-universal: 5.0.1(bare-events@2.9.1)(bare-url@2.4.5)
+      sub-encoder: 2.1.3
+      tiny-buffer-map: 1.1.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bare-url
+      - react-native-b4a
+      - sodium-javascript
+
   autoprefixer@10.4.27(postcss@8.5.6):
     dependencies:
       browserslist: 4.28.1
@@ -37350,9 +38011,9 @@ snapshots:
   bare-fs@4.5.5:
     dependencies:
       bare-events: 2.9.1
-      bare-path: 3.0.0
-      bare-stream: 2.8.0(bare-events@2.9.1)
-      bare-url: 2.3.2
+      bare-path: 3.1.1
+      bare-stream: 2.13.3(bare-events@2.9.1)
+      bare-url: 2.4.5
       fast-fifo: 1.3.2
     transitivePeerDependencies:
       - bare-abort-controller
@@ -37408,23 +38069,7 @@ snapshots:
     transitivePeerDependencies:
       - react-native-b4a
 
-  bare-stream@2.8.0(bare-events@2.9.1):
-    dependencies:
-      streamx: 2.28.0
-      teex: 1.0.1
-    optionalDependencies:
-      bare-events: 2.9.1
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-    optional: true
-
   bare-type@1.1.0: {}
-
-  bare-url@2.3.2:
-    dependencies:
-      bare-path: 3.1.1
-    optional: true
 
   bare-url@2.4.5:
     dependencies:
@@ -38084,14 +38729,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  cmdk@0.2.1(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@radix-ui/react-dialog': 1.0.0(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
-
   co@4.6.0: {}
 
   codecs@3.1.0:
@@ -38373,6 +39010,10 @@ snapshots:
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       webpack: 5.105.4
+
+  core-coupler@2.0.0:
+    dependencies:
+      safety-catch: 1.0.3
 
   core-js-compat@3.49.0:
     dependencies:
@@ -39226,6 +39867,14 @@ snapshots:
     dependencies:
       iconv-lite: 0.6.3
       whatwg-encoding: 3.1.1
+
+  encryption-encoding@1.0.3:
+    dependencies:
+      hyperschema: 1.21.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
 
   end-of-stream@1.4.5:
     dependencies:
@@ -43997,26 +44646,24 @@ snapshots:
 
   nerf-dart@1.0.0: {}
 
-  next@15.3.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.97.3):
+  next@15.5.20(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.97.3):
     dependencies:
-      '@next/env': 15.3.9
-      '@swc/counter': 0.1.3
+      '@next/env': 15.5.20
       '@swc/helpers': 0.5.15
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001774
+      caniuse-lite: 1.0.30001805
       postcss: 8.4.31
       react: 19.0.4
       react-dom: 19.0.4(react@19.0.4)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.0.4)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.3.5
-      '@next/swc-darwin-x64': 15.3.5
-      '@next/swc-linux-arm64-gnu': 15.3.5
-      '@next/swc-linux-arm64-musl': 15.3.5
-      '@next/swc-linux-x64-gnu': 15.3.5
-      '@next/swc-linux-x64-musl': 15.3.5
-      '@next/swc-win32-arm64-msvc': 15.3.5
-      '@next/swc-win32-x64-msvc': 15.3.5
+      '@next/swc-darwin-arm64': 15.5.20
+      '@next/swc-darwin-x64': 15.5.20
+      '@next/swc-linux-arm64-gnu': 15.5.20
+      '@next/swc-linux-arm64-musl': 15.5.20
+      '@next/swc-linux-x64-gnu': 15.5.20
+      '@next/swc-linux-x64-musl': 15.5.20
+      '@next/swc-win32-arm64-msvc': 15.5.20
+      '@next/swc-win32-x64-msvc': 15.5.20
       '@opentelemetry/api': 1.9.0
       '@playwright/test': 1.61.1
       sass: 1.97.3
@@ -45672,6 +46319,20 @@ snapshots:
     transitivePeerDependencies:
       - react-native-b4a
 
+  protomux-wakeup@2.9.0(bare-events@2.9.1)(bare-url@2.4.5):
+    dependencies:
+      b4a: 1.8.1
+      hypercore-crypto: 3.7.0(bare-events@2.9.1)(bare-url@2.4.5)
+      hyperschema: 1.21.0
+      protomux: 3.11.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bare-events
+      - bare-url
+      - react-native-b4a
+      - sodium-javascript
+
   protomux@3.11.0:
     dependencies:
       b4a: 1.8.1
@@ -45820,6 +46481,64 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  radix-ui@1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-accessible-icon': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-accordion': 1.2.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-alert-dialog': 1.1.5(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-aspect-ratio': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-avatar': 1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-checkbox': 1.1.3(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-collapsible': 1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-collection': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context-menu': 2.2.5(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dialog': 1.1.5(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.4(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dropdown-menu': 2.1.5(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-form': 0.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-hover-card': 1.1.5(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-label': 2.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-menu': 2.1.5(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-menubar': 1.1.5(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-navigation-menu': 1.2.4(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popover': 1.1.5(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.3(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-progress': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-radio-group': 1.2.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-scroll-area': 1.2.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-select': 2.1.5(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-separator': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slider': 1.2.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-switch': 1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tabs': 1.1.2(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toast': 1.2.5(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toggle-group': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toolbar': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tooltip': 1.1.7(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.1.1(@types/react-dom@19.0.3(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.0.3(@types/react@18.3.28)
 
   radix-ui@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.3))(@types/react@19.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -46298,17 +47017,6 @@ snapshots:
       use-sidecar: 1.1.3(@types/react@18.3.28)(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.28
-
-  react-remove-scroll@2.5.4(@types/react@19.0.3)(react@18.3.1):
-    dependencies:
-      react: 18.3.1
-      react-remove-scroll-bar: 2.3.8(@types/react@19.0.3)(react@18.3.1)
-      react-style-singleton: 2.2.3(@types/react@19.0.3)(react@18.3.1)
-      tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@19.0.3)(react@18.3.1)
-      use-sidecar: 1.1.3(@types/react@19.0.3)(react@18.3.1)
-    optionalDependencies:
-      '@types/react': 19.0.3
 
   react-remove-scroll@2.7.2(@types/react@18.3.28)(react@18.3.1):
     dependencies:
@@ -48156,6 +48864,13 @@ snapshots:
 
   stylis@4.3.6: {}
 
+  sub-encoder@2.1.3:
+    dependencies:
+      b4a: 1.8.1
+      codecs: 3.1.0
+    transitivePeerDependencies:
+      - react-native-b4a
+
   sucrase@3.35.1:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -48469,6 +49184,12 @@ snapshots:
       convert-hrtime: 5.0.0
 
   timeout-refresh@2.0.1: {}
+
+  tiny-buffer-map@1.1.1:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   tiny-invariant@1.3.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,6 +347,9 @@ importers:
       ajv:
         specifier: ^8.18.0
         version: 8.18.0
+      autobase:
+        specifier: ^7.28.1
+        version: 7.28.1(bare-url@2.4.5)
       awilix:
         specifier: ^8.0.1
         version: 8.0.1
@@ -821,7 +824,7 @@ importers:
     devDependencies:
       '@medusajs/admin-vite-plugin':
         specifier: 2.17.2
-        version: 2.17.2(picomatch@4.0.5)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
+        version: 2.17.2(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
       '@medusajs/types':
         specifier: 2.17.2
         version: 2.17.2(ioredis@5.9.3)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
@@ -1389,7 +1392,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
+        version: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3))
       typescript:
         specifier: 5.6.3
         version: 5.6.3
@@ -1453,7 +1456,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
+        version: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3))
       typescript:
         specifier: 5.6.3
         version: 5.6.3
@@ -26055,41 +26058,6 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 20.19.34
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 29.7.0
@@ -26722,7 +26690,7 @@ snapshots:
   '@medusajs/admin-bundler@2.17.2(@emotion/is-prop-valid@1.4.0)(@types/node@20.19.34)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)(typescript@5.6.3)':
     dependencies:
       '@medusajs/admin-shared': 2.17.2
-      '@medusajs/admin-vite-plugin': 2.17.2(picomatch@4.0.5)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
+      '@medusajs/admin-vite-plugin': 2.17.2(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
       '@medusajs/dashboard': 2.17.2(@emotion/is-prop-valid@1.4.0)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(typescript@5.6.3)
       '@vitejs/plugin-react': 4.7.0(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
       autoprefixer: 10.4.27(postcss@8.5.6)
@@ -26786,6 +26754,22 @@ snapshots:
       '@medusajs/admin-shared': 2.17.2
       chokidar: 3.6.0
       fdir: 6.1.1(picomatch@4.0.5)
+      magic-string: 0.30.5
+      outdent: 0.8.0
+      picocolors: 1.1.1
+      vite: 5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
+    transitivePeerDependencies:
+      - picomatch
+      - supports-color
+
+  '@medusajs/admin-vite-plugin@2.17.2(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))':
+    dependencies:
+      '@babel/parser': 7.25.6
+      '@babel/traverse': 7.25.6
+      '@babel/types': 7.25.6
+      '@medusajs/admin-shared': 2.17.2
+      chokidar: 3.6.0
+      fdir: 6.1.1(picomatch@4.0.4)
       magic-string: 0.30.5
       outdent: 0.8.0
       picocolors: 1.1.1
@@ -27715,7 +27699,7 @@ snapshots:
       ulid: 2.4.0
     optionalDependencies:
       '@medusajs/core-flows': 2.17.2(@medusajs/framework@2.17.2(@medusajs/cli@2.17.2(@types/node@20.19.34))(@types/node@20.19.34)(ioredis@5.9.3)(vite@5.4.21(@types/node@20.19.34)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))(zod@4.2.0))
-      '@medusajs/medusa': 2.17.2(04dd21e010c91d2df8fbdd842a48400b)
+      '@medusajs/medusa': 2.17.2(e6c1958cb3b70ace10968fdc195a23ab)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -28335,17 +28319,6 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
-
-  '@oclif/command@1.8.36(@oclif/config@1.18.17)':
-    dependencies:
-      '@oclif/config': 1.18.17
-      '@oclif/errors': 1.3.6
-      '@oclif/help': 1.0.15(supports-color@8.1.1)
-      '@oclif/parser': 3.8.17
-      debug: 4.4.3(supports-color@8.1.1)
-      semver: 7.7.4
-    transitivePeerDependencies:
-      - supports-color
 
   '@oclif/command@1.8.36(@oclif/config@1.18.17)(supports-color@8.1.1)':
     dependencies:
@@ -39085,21 +39058,6 @@ snapshots:
       crc-32: 1.2.2
       readable-stream: 4.7.0
 
-  create-jest@29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   create-jest@29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
@@ -42671,25 +42629,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-cli@29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3))
@@ -42708,37 +42647,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
-
-  jest-config@29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.19.34
-      ts-node: 10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
 
   jest-config@29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3)):
     dependencies:
@@ -43007,18 +42915,6 @@ snapshots:
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
-
-  jest@29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
 
   jest@29.7.0(@types/node@20.19.34)(ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3)):
     dependencies:
@@ -45374,7 +45270,7 @@ snapshots:
 
   pg-god@1.0.12:
     dependencies:
-      '@oclif/command': 1.8.36(@oclif/config@1.18.17)
+      '@oclif/command': 1.8.36(@oclif/config@1.18.17)(supports-color@8.1.1)
       '@oclif/config': 1.18.17
       '@oclif/plugin-help': 3.3.1
       cli-ux: 5.6.7(@oclif/config@1.18.17)
@@ -49293,27 +49189,6 @@ snapshots:
   ts-dedent@2.2.0: {}
 
   ts-interface-checker@0.1.13: {}
-
-  ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.6.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.34
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 5.6.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.5.7(@swc/helpers@0.5.19)
-    optional: true
 
   ts-node@10.9.2(@swc/core@1.7.28(@swc/helpers@0.5.19))(@types/node@20.19.34)(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
Closes the build-out for **#1082** — CRM on a Hyperbee/Autobase multi-writer, deployed to prod as **Topology A** (Medusa proxies over HTTP to an always-on Autobase node).

## What's here
- **CRM module** (`src/modules/crm`) — 5 entities (company/person/opportunity/note/task), `/admin/crm/*` routes, validators, workflows, embedded Hyperbee DAL. `36/36` e2e.
- **Autobee multi-writer** (`packages/mikrohyperbee`) — Autobase-backed repository: each writer appends to its own input core, deterministic `apply()` linearizes into one Hyperbee view; LWW fold that never throws; writer-scoped ids; per-model `view.sub(model)` isolation. `13/13` multiwriter + `26/26` repository.
- **Prod Topology-A** — `node/server.ts` (standalone Autobase node), `dal/crm-proxy.ts` (Medusa→node proxy), Medusa-free `dal/crm-contracts.ts`, and a **flag-gated + non-fatal** loader (`CRM_NODE_URL` → proxy / `CRM_HYPERBEE=true` → embedded / neither → no-op, never breaks boot). `11/11` node e2e.

## Live infra (already up, independently verified)
- Node deployed on the OCI **handloom-mirror** VM (systemd `crm-node.service`, persistent store, `MemoryMax=280M`, ~35 MB RSS).
- Reached over a **Cloudflare Tunnel** at `https://crm-node.jaalyantra.com` — no inbound VM ports, TLS at the CF edge. Health + authed CRUD + 401 all verified end-to-end.
- This PR adds the Medusa wiring: `CRM_NODE_URL` + `CRM_NODE_TOKEN` in the server copilot manifest, plus a secret-free deploy scaffold.

## Prod cutover (post-merge, gated)
1. Write SSM SecureString `/jyt/prod/CRM_NODE_TOKEN` (the node bearer).
2. Merge → GHCR image build → **manual** ECS deploy (`Deploy to ECS Fargate`, medusa-server).
3. Loader logs `[crm] proxy mode → https://crm-node.jaalyantra.com` → `/admin/crm/*` live.

## Caveat (by design)
Eventual consistency — uniqueness resolved at merge (LWW drops the losing write). Fine for CRM contacts/notes/pipeline; money/inventory stay on Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)