### PR TITLE
feat(crm): admin UI — People list + detail (#1082)

### DIFF
--- a/apps/backend/src/admin/routes/crm/[id]/page.tsx
+++ b/apps/backend/src/admin/routes/crm/[id]/page.tsx
@@ -1,0 +1,119 @@
+import { ArrowLeft, Spinner } from "@medusajs/icons";
+import { Container, Heading, Text, Badge, Button } from "@medusajs/ui";
+import { useQuery } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import { sdk } from "../../../lib/config";
+
+type CrmPerson = {
+  id: string;
+  first_name: string;
+  last_name: string;
+  email?: string | null;
+  phone?: string | null;
+  title?: string | null;
+  company_id?: string | null;
+  created_at?: string;
+  updated_at?: string;
+};
+
+const Row = ({ label, children }: { label: string; children: ReactNode }) => (
+  <div className="grid grid-cols-2 gap-4 px-6 py-4">
+    <Text size="small" leading="compact" weight="plus" className="text-ui-fg-subtle">
+      {label}
+    </Text>
+    <div className="text-right md:text-left">{children}</div>
+  </div>
+);
+
+const val = (v?: string | null) =>
+  v ? (
+    <Text size="small">{v}</Text>
+  ) : (
+    <Text size="small" className="text-ui-fg-muted">
+      —
+    </Text>
+  );
+
+const CrmPersonDetailPage = () => {
+  const { id } = useParams();
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["crm-person", id],
+    queryFn: () =>
+      sdk.client.fetch<{ crm_person: CrmPerson }>(`/admin/crm/people/${id}`),
+    enabled: !!id,
+  });
+
+  const person = data?.crm_person;
+  const fullName = person
+    ? [person.first_name, person.last_name].filter(Boolean).join(" ")
+    : "";
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex flex-col">
+          <Heading>{isLoading ? "Loading…" : fullName || "Person"}</Heading>
+          {person?.title && (
+            <Text size="small" className="text-ui-fg-subtle">
+              {person.title}
+            </Text>
+          )}
+        </div>
+        <Link to="/crm">
+          <Button variant="secondary" size="small">
+            <ArrowLeft />
+            Back
+          </Button>
+        </Link>
+      </div>
+
+      {isLoading && (
+        <div className="flex items-center justify-center px-6 py-16">
+          <Spinner className="text-ui-fg-subtle animate-spin" />
+        </div>
+      )}
+
+      {isError && (
+        <div className="px-6 py-16">
+          <Text size="small" className="text-ui-fg-error">
+            Could not load this person.
+          </Text>
+        </div>
+      )}
+
+      {person && (
+        <div className="divide-y">
+          <Row label="First name">{val(person.first_name)}</Row>
+          <Row label="Last name">{val(person.last_name)}</Row>
+          <Row label="Email">{val(person.email)}</Row>
+          <Row label="Phone">{val(person.phone)}</Row>
+          <Row label="Title">{val(person.title)}</Row>
+          <Row label="Company">
+            {person.company_id ? (
+              <Badge size="2xsmall">{person.company_id}</Badge>
+            ) : (
+              val(null)
+            )}
+          </Row>
+          <Row label="ID">
+            <Text size="small" className="font-mono text-ui-fg-subtle">
+              {person.id}
+            </Text>
+          </Row>
+          <Row label="Created">
+            {val(
+              person.created_at
+                ? new Date(person.created_at).toLocaleString()
+                : null
+            )}
+          </Row>
+        </div>
+      )}
+    </Container>
+  );
+};
+
+export default CrmPersonDetailPage;

--- a/apps/backend/src/admin/routes/crm/page.tsx
+++ b/apps/backend/src/admin/routes/crm/page.tsx
@@ -1,0 +1,186 @@
+import { defineRouteConfig } from "@medusajs/admin-sdk";
+import { Users } from "@medusajs/icons";
+import {
+  Container,
+  Heading,
+  Text,
+  Badge,
+  DataTable,
+  useDataTable,
+  createDataTableColumnHelper,
+  createDataTableFilterHelper,
+  DataTablePaginationState,
+  DataTableFilteringState,
+} from "@medusajs/ui";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { sdk } from "../../lib/config";
+
+// Mirrors the CRM People contract served by GET /admin/crm/people. CRM lives on a
+// Hyperbee/Autobase node (#1082), not Postgres — so there is no query.graph here;
+// we hit the module's REST surface directly, exactly like the census/reader UIs.
+type CrmPerson = {
+  id: string;
+  first_name: string;
+  last_name: string;
+  email?: string | null;
+  phone?: string | null;
+  title?: string | null;
+  company_id?: string | null;
+  created_at?: string;
+  updated_at?: string;
+};
+
+type ListResponse = {
+  crm_people: CrmPerson[];
+  count: number;
+  limit: number;
+  offset: number;
+};
+
+// The backend filters on exact matches for these fields (see people/validators.ts).
+const FILTER_FIELDS = ["email", "last_name", "company_id"] as const;
+
+const columnHelper = createDataTableColumnHelper<CrmPerson>();
+const filterHelper = createDataTableFilterHelper<CrmPerson>();
+
+const CrmPeoplePage = () => {
+  const navigate = useNavigate();
+
+  const [pagination, setPagination] = useState<DataTablePaginationState>({
+    pageSize: 20,
+    pageIndex: 0,
+  });
+  const [filtering, setFiltering] = useState<DataTableFilteringState>({});
+
+  const offset = pagination.pageIndex * pagination.pageSize;
+
+  // Collapse the DataTable filter state (values can arrive as arrays) into the
+  // flat exact-match query params the CRM API understands.
+  const filterParams = useMemo(() => {
+    const out: Record<string, string> = {};
+    for (const field of FILTER_FIELDS) {
+      const v = filtering[field];
+      const value = Array.isArray(v) ? v[0] : v;
+      if (typeof value === "string" && value !== "") out[field] = value;
+    }
+    return out;
+  }, [filtering]);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["crm-people", pagination.pageSize, offset, filterParams],
+    queryFn: () =>
+      sdk.client.fetch<ListResponse>("/admin/crm/people", {
+        query: { limit: pagination.pageSize, offset, ...filterParams },
+      }),
+    staleTime: 30_000,
+  });
+
+  const people = data?.crm_people ?? [];
+
+  const columns = useMemo(
+    () => [
+      columnHelper.accessor("last_name", {
+        header: "Name",
+        cell: ({ row }) => {
+          const p = row.original;
+          const name = [p.first_name, p.last_name].filter(Boolean).join(" ");
+          return <Text size="small">{name || "—"}</Text>;
+        },
+      }),
+      columnHelper.accessor("email", {
+        header: "Email",
+        cell: ({ getValue }) => (
+          <Text size="small" className="text-ui-fg-subtle">
+            {getValue() || "—"}
+          </Text>
+        ),
+      }),
+      columnHelper.accessor("title", {
+        header: "Title",
+        cell: ({ getValue }) => <Text size="small">{getValue() || "—"}</Text>,
+      }),
+      columnHelper.accessor("company_id", {
+        header: "Company",
+        cell: ({ getValue }) => {
+          const v = getValue();
+          return v ? (
+            <Badge size="2xsmall">{v}</Badge>
+          ) : (
+            <Text size="small" className="text-ui-fg-muted">
+              —
+            </Text>
+          );
+        },
+      }),
+    ],
+    []
+  );
+
+  // Select filters populated from the loaded page — mirrors the persons route.
+  const filters = useMemo(
+    () => [
+      filterHelper.accessor("email", {
+        type: "select",
+        label: "Email",
+        options: [...new Set(people.map((p) => p.email).filter(Boolean))].map(
+          (email) => ({ label: email as string, value: email as string })
+        ),
+      }),
+      filterHelper.accessor("last_name", {
+        type: "select",
+        label: "Last name",
+        options: [
+          ...new Set(people.map((p) => p.last_name).filter(Boolean)),
+        ].map((n) => ({ label: n, value: n })),
+      }),
+      filterHelper.accessor("company_id", {
+        type: "select",
+        label: "Company",
+        options: [
+          ...new Set(people.map((p) => p.company_id).filter(Boolean)),
+        ].map((c) => ({ label: c as string, value: c as string })),
+      }),
+    ],
+    [people]
+  );
+
+  const table = useDataTable({
+    columns,
+    data: people,
+    getRowId: (row) => row.id,
+    rowCount: data?.count ?? 0,
+    isLoading,
+    filters,
+    onRowClick: (_, row) => navigate(`/crm/${row.id}`),
+    pagination: { state: pagination, onPaginationChange: setPagination },
+    filtering: { state: filtering, onFilteringChange: setFiltering },
+  });
+
+  return (
+    <Container className="divide-y p-0">
+      <DataTable instance={table}>
+        <DataTable.Toolbar className="flex flex-col items-start justify-between gap-2 px-6 py-4 md:flex-row md:items-center">
+          <div>
+            <Heading>CRM · People</Heading>
+            <Text size="small" className="text-ui-fg-subtle">
+              Contacts on the multi-writer CRM node.
+            </Text>
+          </div>
+          <DataTable.FilterMenu tooltip="Filter people" />
+        </DataTable.Toolbar>
+        <DataTable.Table />
+        <DataTable.Pagination />
+      </DataTable>
+    </Container>
+  );
+};
+
+export const config = defineRouteConfig({
+  label: "CRM",
+  icon: Users,
+});
+
+export default CrmPeoplePage;


### PR DESCRIPTION
Simple, read-focused admin UI for the CRM module (#1082), mirroring the
persons/companies routes. Backed by the Hyperbee/Autobase CRM node via
`GET /admin/crm/people[/:id]` — CRM isn't on Postgres, so no query.graph; it hits
the module REST surface directly (same shape as the census reader UIs).

- **`routes/crm/page.tsx`** — DataTable list: Name / Email / Title / Company
  columns, select filters (email, last_name, company_id), pagination, row click →
  detail. Sidebar entry **"CRM"** (Users icon).
- **`routes/crm/[id]/page.tsx`** — person detail: key/value rows, loading/error
  states, back link.

Intentionally minimal (list + detail, read-only for now) — create/edit modals and
companies/opportunities/notes/tasks tabs can follow.

**Verify:** `yarn dev` → http://localhost:9000/app/crm (CRM must be configured —
`CRM_HYPERBEE=true` for a local embedded store, or `CRM_NODE_URL` to point at the
prod node). Typechecks clean (`tsc --noEmit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)