### PR TITLE
feat(census): reader-node + reader perf (LRU/parallel/stats-cache) [#1087]

### DIFF
--- a/apps/backend/src/api/web/census/stats/route.ts
+++ b/apps/backend/src/api/web/census/stats/route.ts
@@ -19,5 +19,9 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   }
 
   const stats = await census.getStats()
+  // Aggregates only change on re-seed → let the CDN/edge hold them. s-maxage caches
+  // at the edge for 10min; stale-while-revalidate serves stale up to 1h while a
+  // fresh copy is fetched in the background. Pairs with the reader's in-process memo.
+  res.setHeader("Cache-Control", "public, s-maxage=600, stale-while-revalidate=3600")
   res.json({ stats })
 }

--- a/apps/backend/src/modules/census/reader.ts
+++ b/apps/backend/src/modules/census/reader.ts
@@ -19,6 +19,48 @@ const MAX_SCAN = 50_000
 // each decode is already off-thread.
 const YIELD_EVERY = 256
 
+// Hydration concurrency: each rec.get is an INDEPENDENT seek, so draining the
+// index with a bounded worker pool turns N sequential seeks into ~N/POOL. Over a
+// remote P2P peer each seek is an RTT; even against a local replica it overlaps
+// disk + brotli. Bounded so we never open thousands of concurrent seeks at once.
+const HYDRATE_CONCURRENCY = Number(process.env.CENSUS_HYDRATE_CONCURRENCY || 12)
+const HYDRATE_BATCH = HYDRATE_CONCURRENCY * 4
+
+// Decoded-record LRU: the seek+brotli is the cost, so cache the decoded records.
+// Helps repeated reads, the /verify path, and residual re-scans. A short TTL
+// bounds staleness if the underlying core replicates a newer version.
+const REC_CACHE_MAX = Number(process.env.CENSUS_REC_CACHE_MAX || 5000)
+const REC_CACHE_TTL_MS = Number(process.env.CENSUS_REC_CACHE_TTL_MS || 300_000)
+// Stats memo: the agg stream is cheap but there's no reason to re-walk it on
+// every request — aggregates only change on re-seed.
+const STATS_MEMO_TTL_MS = Number(process.env.CENSUS_STATS_MEMO_TTL_MS || 60_000)
+
+/** Tiny insertion-ordered LRU with per-entry TTL — no external dependency. */
+class TtlLru<V> {
+  private map = new Map<string, { v: V; exp: number }>()
+  constructor(private max: number, private ttlMs: number) {}
+  get(k: string): V | undefined {
+    const e = this.map.get(k)
+    if (!e) return undefined
+    if (e.exp <= Date.now()) {
+      this.map.delete(k)
+      return undefined
+    }
+    // bump recency: re-insert so it moves to the tail
+    this.map.delete(k)
+    this.map.set(k, e)
+    return e.v
+  }
+  set(k: string, v: V): void {
+    if (this.map.has(k)) this.map.delete(k)
+    this.map.set(k, { v, exp: Date.now() + this.ttlMs })
+    if (this.map.size > this.max) {
+      const oldest = this.map.keys().next().value
+      if (oldest !== undefined) this.map.delete(oldest)
+    }
+  }
+}
+
 // meta flags the seeder sets once an index family has been backfilled. The facet
 // families (state/gender/sd) gate on FACET_IDX_META; the whole-corpus ordered
 // `all` family gates on ALL_IDX_META — decoupled so the unfiltered browse only
@@ -54,6 +96,8 @@ const padId = (id: string | number) => String(id).padStart(ID_PAD, "0")
 export class CensusReader {
   private bee: Bee | null = null
   private proxyUrl: string | null = null
+  private recCache = new TtlLru<Record<string, any>>(REC_CACHE_MAX, REC_CACHE_TTL_MS)
+  private statsMemo: { at: number; minCell: number; value: Stats } | null = null
 
   /** Embedded mode: the loader replicated the core and hands us the live Hyperbee. */
   setBee(bee: Bee) {
@@ -93,6 +137,36 @@ export class CensusReader {
     return JSON.parse((await brotliDecompressAsync(buf)).toString())
   }
 
+  /** rec.get + decode, memoized in the LRU (keyed by census_id). */
+  private async getDecoded(rec: Sub, id: string): Promise<Record<string, any> | null> {
+    const cached = this.recCache.get(id)
+    if (cached) return cached
+    const node = await rec.get(id)
+    if (!node) return null
+    const r = await this.decode(node.value)
+    this.recCache.set(id, r)
+    return r
+  }
+
+  /** Bounded-concurrency, order-preserving hydration of a list of census ids. */
+  private async hydrateInOrder(
+    rec: Sub,
+    ids: string[]
+  ): Promise<(Record<string, any> | null)[]> {
+    const out: (Record<string, any> | null)[] = new Array(ids.length)
+    let cursor = 0
+    const worker = async () => {
+      while (true) {
+        const i = cursor++
+        if (i >= ids.length) return
+        out[i] = await this.getDecoded(rec, ids[i])
+      }
+    }
+    const n = Math.min(HYDRATE_CONCURRENCY, ids.length)
+    await Promise.all(Array.from({ length: n }, () => worker()))
+    return out
+  }
+
   /** Resolve one masked weaver record by census_id, or null if unknown. */
   async retrieveWeaver(id: string | number): Promise<Record<string, any> | null> {
     if (this.proxyUrl) {
@@ -102,8 +176,7 @@ export class CensusReader {
       return weaver ?? null
     }
     const rec = this.requireBee().sub("rec", { valueEncoding: "binary" })
-    const node = await rec.get(String(id))
-    return node ? await this.decode(node.value) : null
+    return await this.getDecoded(rec, String(id))
   }
 
   /**
@@ -116,6 +189,10 @@ export class CensusReader {
       const { stats } = await this.proxyGet<{ stats: Stats }>(`/census/stats?minCell=${minCell}`)
       return stats
     }
+    const memo = this.statsMemo
+    if (memo && memo.minCell === minCell && Date.now() - memo.at < STATS_MEMO_TTL_MS) {
+      return memo.value
+    }
     const agg = this.requireBee().sub("agg", { valueEncoding: "utf-8" })
     const dims: Stats = {}
     for await (const { key, value } of agg.createReadStream()) {
@@ -127,6 +204,7 @@ export class CensusReader {
       ;(dims[dim] ??= {})[label] =
         dim === "total" || dim === "loom_type" ? count : count < minCell ? null : count
     }
+    this.statsMemo = { at: Date.now(), minCell, value: dims }
     return dims
   }
 
@@ -295,35 +373,57 @@ export class CensusReader {
     let capped = false
     let next: string | null = null
 
-    for await (const { key } of idx.createReadStream(range)) {
-      if (++scanned > MAX_SCAN) {
-        capped = true
-        break
-      }
-      const id = String(Number(key.slice(driver.prefix.length)))
-
-      if (!hasResidual) {
-        // Purely index-paged: fetch only the page window; total comes from agg.
-        if (count >= offset && weavers.length < limit) {
-          const node = await rec.get(id)
-          if (node) {
-            weavers.push(await this.decode(node.value))
-            next = id
-          }
+    if (!hasResidual) {
+      // Purely index-paged: walk the ordered index (keys only — no decode) to the
+      // page window, collect its ids, then hydrate that page in PARALLEL. Total
+      // comes from agg (O(1)) below, so counting past the page is unnecessary.
+      const pageIds: string[] = []
+      for await (const { key } of idx.createReadStream(range)) {
+        if (++scanned > MAX_SCAN) {
+          capped = true
+          break
+        }
+        if (count >= offset && pageIds.length < limit) {
+          pageIds.push(String(Number(key.slice(driver.prefix.length))))
         }
         count++
-        if (weavers.length >= limit) break
-      } else {
-        const node = await rec.get(id)
-        if (!node) continue
-        const r = await this.decode(node.value)
-        if (!residualMatch(r)) continue
-        if (count >= offset && weavers.length < limit) {
+        if (pageIds.length >= limit) break
+      }
+      const hydrated = await this.hydrateInOrder(rec, pageIds)
+      for (let j = 0; j < hydrated.length; j++) {
+        const r = hydrated[j]
+        if (r) {
           weavers.push(r)
-          next = id
+          next = pageIds[j]
         }
-        count++
       }
+    } else {
+      // Residual predicate needs the decoded record, so every id in the family
+      // must be hydrated (up to MAX_SCAN) to count exact matches. Do it in ordered,
+      // bounded-concurrency batches instead of one blocking seek at a time.
+      let batch: string[] = []
+      const drain = async () => {
+        const hydrated = await this.hydrateInOrder(rec, batch)
+        for (let j = 0; j < hydrated.length; j++) {
+          const r = hydrated[j]
+          if (!r || !residualMatch(r)) continue
+          if (count >= offset && weavers.length < limit) {
+            weavers.push(r)
+            next = batch[j]
+          }
+          count++
+        }
+        batch = []
+      }
+      for await (const { key } of idx.createReadStream(range)) {
+        if (++scanned > MAX_SCAN) {
+          capped = true
+          break
+        }
+        batch.push(String(Number(key.slice(driver.prefix.length))))
+        if (batch.length >= HYDRATE_BATCH) await drain()
+      }
+      if (batch.length) await drain()
     }
 
     // Exact O(1) total from the aggregate cell when the index alone answered the

--- a/scripts/handloom-scrape/hyperbee-slice/census_reader_node.mjs
+++ b/scripts/handloom-scrape/hyperbee-slice/census_reader_node.mjs
@@ -1,0 +1,175 @@
+// Census reader NODE — durability replica + fast read surface, in ONE process.
+//
+// A superset of replicate_peer.mjs: it still joins the Hyperswarm and persists
+// every block of the public + sensitive cores to disk (the blind-mirror
+// durability role), and ADDITIONALLY opens a Hyperbee over the PUBLIC core and
+// serves the census read API over localhost HTTP. Fronted by a Cloudflare Tunnel,
+// prod Medusa reads census via CENSUS_READER_URL → this node — so the API tasks
+// hold NO P2P store and never re-download the core on deploy (#1031/#1087 #2).
+//
+// One process owns the store: no second replica in RAM, no concurrent-corestore
+// corruption. Reads are LOCAL disk seeks (the whole core is on disk here), so the
+// remote-RTT N+1 that made the embedded reader slow is gone; the bundled reader
+// still parallelizes hydration + LRU-caches decodes.
+//
+//   PUBLIC_CORE_KEY=<hex> SENSITIVE_CORE_KEY=<hex> [P2P_STORE=./replica-store] \
+//   [CENSUS_NODE_PORT=8791] [SEED_HOST=<ip> SEED_PORT=49737] node census_reader_node.mjs
+//
+// Read surface (matches the CENSUS_READER_URL proxy contract in reader.ts):
+//   GET /health
+//   GET /census/stats?minCell=N        → { stats }
+//   GET /census/weavers?<filters>&limit&offset&after → { weavers, count, ... }
+//   GET /census/weavers/:id            → { weaver }
+// Public, PII-free data → no auth (the proxy sends none).
+
+import { createServer } from "node:http";
+
+import Corestore from "corestore";
+import Hyperswarm from "hyperswarm";
+import Hyperbee from "hyperbee";
+import b4a from "b4a";
+
+import { CensusReader } from "./census-reader.mjs";
+
+const STORE_DIR = process.env.P2P_STORE || "./replica-store";
+const PORT = Number(process.env.CENSUS_NODE_PORT || 8791);
+const keys = [process.env.PUBLIC_CORE_KEY, process.env.SENSITIVE_CORE_KEY,
+  ...(process.env.EXTRA_CORE_KEYS ? process.env.EXTRA_CORE_KEYS.split(",") : [])]
+  .map((k) => (k || "").trim()).filter(Boolean);
+
+if (!keys.length) {
+  console.error("set PUBLIC_CORE_KEY (64-hex) — SENSITIVE_CORE_KEY optional for durability parity");
+  process.exit(2);
+}
+
+const store = new Corestore(STORE_DIR);
+await store.ready();
+
+// read-only replicas of each core (no encryptionKey → sensitive stays opaque)
+const cores = keys.map((hex) => store.get({ key: b4a.from(hex, "hex") }));
+await Promise.all(cores.map((c) => c.ready()));
+const publicCore = cores[0];
+
+const swarm = new Hyperswarm();
+swarm.on("connection", (conn) => {
+  store.replicate(conn);
+  console.log(`[${new Date().toISOString()}] peer connected — ${swarm.connections.size} active`);
+  conn.on("close", () => console.log(`[${new Date().toISOString()}] peer disconnected — ${swarm.connections.size} active`));
+});
+
+for (const core of cores) {
+  const done = core.findingPeers();
+  swarm.join(core.discoveryKey, { server: false, client: true });
+  swarm.flush().then(done, done);
+  core.download({ start: 0, end: -1 });
+  core.on("append", () => {
+    core.download({ start: 0, end: core.length });
+    console.log(`[${new Date().toISOString()}] mirror: ${core.key.toString("hex").slice(0, 12)}… grew → ${core.length} blocks`);
+  });
+}
+
+// Catch-up: the initial download({start:0,end:-1}) only covers the length known
+// at call time, and `append` fires only for FUTURE growth — so a peer that
+// reconnects after the seeder already grew (e.g. an index re-backfill jumped the
+// core from 3.26M→10M) can sit frozen at its old contiguous frontier. Re-learn the
+// length and explicitly re-request any missing tail on an interval until closed.
+const catchUp = async () => {
+  for (const core of cores) {
+    try {
+      await core.update();
+      if (core.contiguousLength < core.length) {
+        core.download({ start: core.contiguousLength, end: core.length });
+      }
+    } catch (e) {
+      console.log(`[${new Date().toISOString()}] catch-up error: ${e?.message || e}`);
+    }
+  }
+};
+catchUp();
+setInterval(catchUp, 15000);
+
+// Direct-socket path for same-VCN peers (deterministic; avoids NAT hole-punch).
+if (process.env.SEED_HOST) {
+  const net = await import("node:net");
+  const port = Number(process.env.SEED_PORT || 49737);
+  const dial = () => {
+    const socket = net.connect(port, process.env.SEED_HOST);
+    socket.on("connect", () => {
+      console.log(`[${new Date().toISOString()}] direct connect → ${process.env.SEED_HOST}:${port}`);
+      const s = store.replicate(true);
+      s.pipe(socket).pipe(s);
+    });
+    socket.on("error", (e) => console.log(`[${new Date().toISOString()}] direct dial error: ${e.message}`));
+    socket.on("close", () => setTimeout(dial, 5000));
+  };
+  dial();
+}
+
+// ── Read surface over the PUBLIC core ────────────────────────────────────────
+const bee = new Hyperbee(publicCore, { keyEncoding: "utf-8", valueEncoding: "binary" });
+await bee.ready();
+const reader = new CensusReader();
+reader.setBee(bee);
+
+const send = (res, code, body) => {
+  const s = JSON.stringify(body);
+  res.writeHead(code, { "content-type": "application/json", "content-length": Buffer.byteLength(s) });
+  res.end(s);
+};
+
+const server = createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url || "/", "http://localhost");
+    const parts = url.pathname.split("/").filter(Boolean);
+
+    if (parts[0] === "health") {
+      return send(res, 200, {
+        ok: true,
+        ready: reader.ready,
+        blocks: { have: publicCore.contiguousLength, known: publicCore.length },
+      });
+    }
+
+    if (parts[0] === "census" && parts[1] === "stats") {
+      const minCell = url.searchParams.has("minCell") ? Number(url.searchParams.get("minCell")) : undefined;
+      return send(res, 200, { stats: await reader.getStats(minCell != null ? { minCell } : {}) });
+    }
+
+    if (parts[0] === "census" && parts[1] === "weavers") {
+      if (parts[2]) {
+        return send(res, 200, { weaver: await reader.retrieveWeaver(decodeURIComponent(parts[2])) });
+      }
+      const filters = {};
+      let limit, offset, after;
+      for (const [k, v] of url.searchParams) {
+        if (k === "limit") limit = Number(v);
+        else if (k === "offset") offset = Number(v);
+        else if (k === "after") after = v;
+        else filters[k] = v;
+      }
+      const opts = {};
+      if (limit != null) opts.limit = limit;
+      if (offset != null) opts.offset = offset;
+      if (after != null) opts.after = after;
+      return send(res, 200, await reader.listAndCountWeavers(filters, opts));
+    }
+
+    return send(res, 404, { message: "not found" });
+  } catch (e) {
+    send(res, 500, { message: e?.message || "error" });
+  }
+});
+
+server.listen(PORT, "127.0.0.1", () => {
+  console.log(`[census-node] read surface on 127.0.0.1:${PORT} store=${STORE_DIR} public=${publicCore.key.toString("hex").slice(0, 12)}…`);
+});
+
+const report = () => {
+  const parts = cores.map((c, i) =>
+    `${["public", "sensitive", "extra"][i] || "core" + i}=${c.contiguousLength}/${c.length}`);
+  console.log(`[${new Date().toISOString()}] peers=${swarm.connections.size}  mirror blocks (have/known): ${parts.join("  ")}`);
+};
+setInterval(report, 5 * 60 * 1000);
+await new Promise((r) => setTimeout(r, 3000));
+report();
+console.log("census reader node: replicating + persisting all cores; serving public read API (sensitive stays opaque)");


### PR DESCRIPTION
Foundation for #1087 (#2 + #1/#3/#5). Serves `/web/census/*` from a durable reader
**node on the OCI VM** instead of an ephemeral in-Fargate P2P peer that
re-downloads the whole core on every deploy.

## What's here (all safe — prod path unchanged)
- **`census_reader_node.mjs`** — durability replica + census read API in ONE
  process (owns the existing persistent store; no 2nd replica in RAM, no
  concurrent-corestore corruption). Serves the `CENSUS_READER_URL` proxy contract
  (`/health`, `/census/stats`, `/census/weavers[/:id]`) from the bundled reader.
  Adds a catch-up loop (re-learn length + re-request missing tail).
- **`reader.ts`** — #1 bounded-concurrency ordered hydration, #3 TTL-LRU on decoded
  records, 60s stats memo. On the node these are local-disk reads, so N sequential
  seeks → ~N/concurrency, decodes cached.
- **`web/census/stats/route.ts`** — #5 `Cache-Control: public, s-maxage=600, stale-while-revalidate=3600`.

## Deployed / verified
Node is live on **handloom-mirror** (`census-node.service`, replaces the old blind
replica, reuses the 4.1 GB store). `/health`, `/census/stats`, `/census/weavers`
all respond. tsc clean; `node --check` clean.

## NOT in this PR (gated)
Manifest is untouched → **prod still uses embedded P2P**. The cutover
(`CENSUS_READER_URL` + drop `CENSUS_P2P_ENABLED`) waits until the VM replica is
fully caught up — currently blocked by a **pre-existing census replication stall**:
the public core is frozen at block 3,258,684 after the 17:14 re-backfill while the
seeder is healthy at 10.18M (same freeze affected the old replica). Diagnosis +
fix (likely a clean re-clone of the public core) tracked in #1087.

🤖 Generated with [Claude Code](https://claude.com/claude-code)