### PR TITLE
fix(ci): migrate-gate exits 1 under bash -e when no @medusajs dep change

### DIFF
--- a/.github/workflows/deploy-to-aws.yml
+++ b/.github/workflows/deploy-to-aws.yml
@@ -249,8 +249,13 @@ jobs:
           if [ -n "$NEED" ] || [ -n "$DEP" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
             echo "→ schema-affecting changes — running migrations:"
-            [ -n "$NEED" ] && echo "$NEED"
-            [ -n "$DEP" ] && echo "$DEP"
+            # NB: plain `[ -n "$X" ] && echo` as the LAST line makes the step exit
+            # non-zero under `bash -e` whenever $X is empty (the failing test is the
+            # step's final exit code) — which silently failed the whole migrate gate
+            # for any schema/config change without an @medusajs lockfile bump. Use
+            # if-blocks so the step always ends 0.
+            if [ -n "$NEED" ]; then echo "$NEED"; fi
+            if [ -n "$DEP" ]; then echo "$DEP"; fi
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
             echo "→ no migration/model/link/config/@medusajs changes — skipping migration boot, jumping to deploy"


### PR DESCRIPTION
The migrate-gate "Decide whether migrations are needed" step ended with
`[ -n "$DEP" ] && echo "$DEP"`. Under `bash -e`, when `$DEP` is empty (a
schema/config change with no `@medusajs` lockfile bump — e.g. registering a module
that has no DML models), that test returns 1 and, as the step's LAST command, sets
the step exit code to 1. That **fails the migrate job and SKIPS the server/worker
deploy** — before any migration runs.

This silently blocked the CRM prod deploy (#1082): its `medusa-config` change hit
the NEED branch, `$DEP` was empty → step exited 1 → deploy skipped.

Fix: use `if`-blocks so the step always ends 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)