### PR TITLE
fix(crm): resolve repos via cradle property (fixes 500 on all /admin/crm/*)

### DIFF
--- a/apps/backend/src/modules/crm/service.ts
+++ b/apps/backend/src/modules/crm/service.ts
@@ -19,7 +19,14 @@ class CrmService {
   }
 
   private repo(name: string): ModelRepository {
-    return this.__container__.resolve(name);
+    // In the Medusa runtime the module service is constructed with the Awilix
+    // *cradle* (a proxy), not a container — it has no `.resolve()` method, and
+    // even reading `.resolve` makes Awilix look up a registration named
+    // "resolve" ("Could not resolve 'resolve'"), which 500-ed every
+    // /admin/crm/* route. Registrations are read as PROPERTIES on the cradle,
+    // so index into it. The e2e mock container exposes the same properties, so
+    // this works there too.
+    return (this.__container__ as any)[name];
   }
 
   // ── companies ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Symptom
Every `/admin/crm/*` request 500s in prod (both the People **list** and the new **create**):

```
AwilixResolutionError: Could not resolve 'resolve'.
```

(Confirmed in the medusa-server container logs — `GET` and `POST /admin/crm/people` both 500 with this error.)

## Root cause
`CrmService.repo()` did `this.__container__.resolve(name)`. In the Medusa runtime the module service is constructed with the Awilix **cradle** (a proxy), not a container — it has no `.resolve()` method, and merely *reading* `.resolve` on a cradle makes Awilix look up a registration named `"resolve"`, which doesn't exist → throws on every call.

The loader (`loaders/hyperbee-dal.ts`) registers the per-entity repos by name (`crmPersonService`, `crmCompanyService`, …). On a cradle those are read as **properties**, not via `.resolve()`.

## Fix
Index into the cradle: `this.__container__[name]`. The e2e mock container exposes the same properties, so this works there too.

## Verification
- Embedded e2e (`src/modules/crm/__tests__/hyperbee-crm.e2e.ts`): **36/36 pass** with the change.
- The admin CRM create UI (#1091) was already correctly wired to `POST /admin/crm/people`; it was 500-ing solely because of this backend bug — this unblocks both list and create.

Note: unrelated to this PR, the `deploy-to-aws` server job has been circuit-breaking on slow Medusa boot (the ECS service still reaches steady state on the rolled-forward revision) — worth a separate look at the health-check grace period.

🤖 Generated with [Claude Code](https://claude.com/claude-code)