### PR TITLE
feat(census): cut prod /web/census/* over to the durable reader node [#1087]

### DIFF
--- a/deploy/aws/copilot/medusa-server/manifest.yml
+++ b/deploy/aws/copilot/medusa-server/manifest.yml
@@ -70,16 +70,22 @@ variables:
   # (the cross-list subscriber runs on the WORKER — set there too). Non-secret.
   # Unset → falls back to the nondeterministic is_default storefront pick.
   CORE_SALES_CHANNEL_ID: sc_01JNQG1YX5549246DFCKKFTE0W
-  # #1031 — serve /web/census/* by peering the P2P PUBLIC core IN-PROCESS (no
-  # Render proxy). Verified end-to-end 2026-07-14: (1) the native hypercore stack
-  # loads in this image now that libatomic1 is installed (see apps/backend/
-  # Dockerfile); (2) a Fargate task in THIS exact placement (public subnets,
-  # assignPublicIp) hole-punched the OCI seeder and replicated 29,214 blocks in
-  # ~5s. So proxy mode is no longer needed — retire the Render reader
-  # (srv-d9b6t7nlk1mc73ciprv0) once this deploy is green. The loader is
-  # non-fatal: if peering ever fails it just 503s /web/census/*, never breaks boot.
-  # To revert to proxy: unset CENSUS_P2P_ENABLED and set CENSUS_READER_URL back.
-  CENSUS_P2P_ENABLED: "true"
+  # #1031/#1087 — serve /web/census/* via PROXY to the always-on durable reader
+  # node (census-node.service on the OCI handloom-mirror VM, :8791), reached over
+  # the same Cloudflare Tunnel as the CRM node below. PII-free public core → NO
+  # bearer token.
+  #
+  # Why not embedded (CENSUS_P2P_ENABLED): the in-process Hyperswarm peer holds no
+  # persistent store, so every Fargate task roll re-downloads the ~10M-block core
+  # from scratch. Post-deploy, /web/census/weavers range-scans a half-replicated
+  # core and hangs until the peer converges (observed: /weavers timing out while
+  # /stats — front-of-tree agg keys — still served). The durable node keeps a
+  # fully-converged store across deploys → O(page) reads immediately, no cold start.
+  #
+  # Loader is non-fatal: an unreachable URL just 503s /web/census/*, never breaks
+  # boot. To revert to embedded: unset CENSUS_READER_URL, set CENSUS_P2P_ENABLED=
+  # "true" (proxy wins if both set — see p2p-reader.ts:26).
+  CENSUS_READER_URL: https://census-node.jaalyantra.com
   # #1082 — CRM on Hyperbee/Autobase (Topology-A). Points the CRM module's DAL
   # loader (src/modules/crm/loaders/hyperbee-dal.ts) at the always-on Autobase
   # node co-located on the OCI handloom-mirror VM, reached over a Cloudflare

--- a/scripts/handloom-scrape/hyperbee-slice/census_reader_node.mjs
+++ b/scripts/handloom-scrape/hyperbee-slice/census_reader_node.mjs
@@ -73,16 +73,41 @@ for (const core of cores) {
 // reconnects after the seeder already grew (e.g. an index re-backfill jumped the
 // core from 3.26M→10M) can sit frozen at its old contiguous frontier. Re-learn the
 // length and explicitly re-request any missing tail on an interval until closed.
+//
+// download({start,end}) proved unreliable for this: it waits for the peer to
+// ADVERTISE the range in its bitfield, and after a big re-backfill the seeder can
+// under-advertise the tail → the range request never completes and the frontier
+// stays frozen (observed 2026-07-18: stuck at 3,510,134 while the seeder had 10.2M;
+// only a get()-driven mop-up filled it). get(i, {wait:true}) forces an explicit
+// per-block request that doesn't depend on the bitfield advertisement, so it can't
+// stall the same way. Fill the missing tail in bounded-concurrency batches (blocks
+// we already have return instantly from disk; we only pay for the true gap).
+const CATCHUP_CONCURRENCY = Number(process.env.CATCHUP_CONCURRENCY || 128);
+let catchUpRunning = false;
 const catchUp = async () => {
-  for (const core of cores) {
-    try {
-      await core.update();
-      if (core.contiguousLength < core.length) {
-        core.download({ start: core.contiguousLength, end: core.length });
+  if (catchUpRunning) return; // don't stack sweeps while a big tail is still filling
+  catchUpRunning = true;
+  try {
+    for (const core of cores) {
+      try {
+        await core.update();
+        let i = core.contiguousLength;
+        const target = core.length;
+        if (i >= target) continue;
+        console.log(`[${new Date().toISOString()}] catch-up: ${core.key.toString("hex").slice(0, 12)}… filling ${i}→${target} (${target - i} blocks)`);
+        while (i < target) {
+          const end = Math.min(i + CATCHUP_CONCURRENCY, target);
+          const batch = [];
+          for (let j = i; j < end; j++) batch.push(core.get(j, { wait: true }).catch(() => {}));
+          await Promise.all(batch);
+          i = end;
+        }
+      } catch (e) {
+        console.log(`[${new Date().toISOString()}] catch-up error: ${e?.message || e}`);
       }
-    } catch (e) {
-      console.log(`[${new Date().toISOString()}] catch-up error: ${e?.message || e}`);
     }
+  } finally {
+    catchUpRunning = false;
   }
 };
 catchUp();


### PR DESCRIPTION
## Why
Prod served `/web/census/*` via `CENSUS_P2P_ENABLED` — an in-process Hyperswarm peer with **no persistent store**, so every Fargate task roll re-downloads the ~10M-block public core from scratch. Post-deploy the peer sits half-replicated and `/web/census/weavers` (a range-scan over the core) **hangs until it converges**.

Observed live at handoff: `/weavers` timing out (`HTTP 000 @ 25s`) while `/stats` (front-of-tree agg keys) still served.

## What
- **Manifest cutover** → `CENSUS_READER_URL: https://census-node.jaalyantra.com`, drop `CENSUS_P2P_ENABLED`. Proxy against the always-on durable node (`census-node.service` on the OCI handloom-mirror VM `:8791`) over the same Cloudflare Tunnel as the CRM node. Fully-converged store across deploys → O(page) reads, no cold start. PII-free public core → no bearer. Loader non-fatal.
- **Catch-up hardening** (`census_reader_node.mjs`) → `download({start,end})` waits on the peer's bitfield advertisement, which under-advertises the tail after a big re-backfill and freezes the frontier (2026-07-18: stuck at 3.51M vs 10.2M; only a `get()` mop-up cleared it). Replace with bounded-concurrency `get(i,{wait:true})` + in-flight guard so 15s sweeps don't stack.

## Infra done (out of band)
- Cloudflare Tunnel `crm-node` ingress extended: `census-node.jaalyantra.com → localhost:8791` (CRM route preserved).
- Proxied CNAME `census-node.jaalyantra.com → 17188a98-….cfargotunnel.com`.

## Verified against census-node.jaalyantra.com
- `/health` → `have==known` (~10.46M blocks)
- `/stats` → total 2,070,203 weavers
- `/weavers` unfiltered → `indexed:true`, 0.2s; `state=UTTAR PRADESH` → 0.1s, count 126,872

## Known limitation (not a regression)
Composite filters (e.g. `state+gender`) still do residual in-memory hydration → slow/timeout-prone on the CPU-throttled 1-vCPU micro. Pre-existing `reader.ts` behavior; embedded prod is equally/worse affected. Follow-up: composite index.

## Deploy
Merging fires `deploy-to-aws` (`deploy/aws/**` path) → `svc deploy` applies the env change → server rolls into PROXY mode. Boot log: `[census] reader in PROXY mode → https://census-node.jaalyantra.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)