### PR TITLE
feat(census): inline geo payload on the index — fast map browse + coords [#1087]

### DIFF
--- a/apps/backend/integration-tests/http/census-weavers-api.spec.ts
+++ b/apps/backend/integration-tests/http/census-weavers-api.spec.ts
@@ -45,10 +45,28 @@ function makeBee(subs: Record<string, Array<[string, any]>>) {
   }
 }
 
+// The lean display projection the seeder stores inline on each index value
+// (mirrors census_index.geoPayload): the map's fields + coords promoted from the
+// raw survey bag. Deliberately EXCLUDES the `fat` sentinel below, so a browse
+// that returns it proves the reader decoded the payload, not the rec/* record.
+const geoProj = (r: Record<string, any>) => {
+  const sv = r.survey || {}
+  return {
+    census_id: r.census_id,
+    state: r.state,
+    district: r.district,
+    gender: r.gender,
+    education: r.education,
+    village: r.village,
+    latitude: Number(sv.Latitude),
+    longitude: Number(sv.Longitude),
+  }
+}
+
 /** Build rec + agg + (optionally) idx/meta subs from a record set. */
 function buildSubs(
   records: Array<Record<string, any>>,
-  { indexed }: { indexed: boolean }
+  { indexed, geo = false }: { indexed: boolean; geo?: boolean }
 ) {
   const rec: Array<[string, any]> = records.map((r) => [String(r.census_id), enc(r)])
 
@@ -69,13 +87,17 @@ function buildSubs(
     const idx: Array<[string, any]> = []
     for (const r of records) {
       const p = padId(r.census_id)
-      idx.push([`all/${p}`, Buffer.from("")])
-      idx.push([`state/${r.state}/${p}`, Buffer.from("")])
-      idx.push([`gender/${r.gender}/${p}`, Buffer.from("")])
-      idx.push([`sd/${r.state}|${r.district}/${p}`, Buffer.from("")])
+      // geo mode carries the inline payload on the value; legacy mode is keys-only.
+      const val = geo ? enc(geoProj(r)) : Buffer.from("")
+      idx.push([`all/${p}`, val])
+      idx.push([`state/${r.state}/${p}`, val])
+      idx.push([`gender/${r.gender}/${p}`, val])
+      idx.push([`sd/${r.state}|${r.district}/${p}`, val])
     }
     subs.idx = idx
-    subs.meta = [["idx-version", "idx-v1"], ["idx-all-version", "idxall-v1"]]
+    subs.meta = geo
+      ? [["idx-version", "idx-v1"], ["idx-all-version", "idxall-v1"], ["idx-geo-version", "geo-v1"]]
+      : [["idx-version", "idx-v1"], ["idx-all-version", "idxall-v1"]]
   }
 
   return subs
@@ -241,6 +263,74 @@ setupSharedTestSuite(() => {
       expect(res.data.indexed).toBe(true)
       expect(res.data.estimated).toBe(true) // residual → count is scanned matches
       expect(res.data.weavers.map((w: any) => w.census_id).sort()).toEqual([11, 14])
+    })
+  })
+
+  describe("GET /web/census/weavers — inline geo-payload fast path", () => {
+    // rec/* carries a fat `survey` bag + a `fat` sentinel; the index payload is the
+    // lean projection WITHOUT `fat`. So a browse that returns coords but no `fat`
+    // proves the reader decoded the inline payload and never touched rec/*.
+    // distinct ids (+10) so the reader's per-id LRU can't hand us a record cached
+    // by the earlier RECORDS-based suites (which lack the `fat` sentinel).
+    const GEO_RECORDS = RECORDS.map((r, i) => ({
+      ...r,
+      census_id: r.census_id + 10,
+      village: `V${r.census_id + 10}`,
+      fat: "FROM_REC_SHOULD_NOT_APPEAR",
+      survey: { Latitude: `${16 + i / 100}`, Longitude: `${75 + i / 100}`, blob: "x".repeat(80) },
+    }))
+
+    beforeAll(() => useBee(makeBee(buildSubs(GEO_RECORDS, { indexed: true, geo: true }))))
+
+    it("browses a state facet from the inline payload (coords present, rec/* untouched)", async () => {
+      const res = await api.get("/web/census/weavers?state=KARNATAKA", {
+        validateStatus: () => true,
+      })
+      expect(res.status).toBe(200)
+      expect(res.data.indexed).toBe(true)
+      expect(res.data.count).toBe(4)
+      for (const w of res.data.weavers) {
+        expect(typeof w.latitude).toBe("number") // promoted from survey.Latitude
+        expect(w.longitude).toBeGreaterThan(74)
+        expect(w.fat).toBeUndefined() // payload, not the fat rec/* record
+        expect(w.survey).toBeUndefined()
+      }
+    })
+
+    it("browses the whole corpus from the inline payload with an O(1) total", async () => {
+      const res = await api.get("/web/census/weavers?limit=2", {
+        validateStatus: () => true,
+      })
+      expect(res.status).toBe(200)
+      expect(res.data.count).toBe(5)
+      expect(res.data.weavers.map((w: any) => w.census_id)).toEqual([20, 21])
+      expect(res.data.weavers.every((w: any) => w.fat === undefined)).toBe(true)
+      expect(res.data.weavers.every((w: any) => typeof w.latitude === "number")).toBe(true)
+    })
+
+    it("applies a residual filter on the payload fields", async () => {
+      const res = await api.get("/web/census/weavers?state=KARNATAKA&education=Middle", {
+        validateStatus: () => true,
+      })
+      expect(res.status).toBe(200)
+      expect(res.data.weavers.map((w: any) => w.census_id).sort()).toEqual([20, 22])
+    })
+
+    it("falls back to rec/* for a row whose inline payload is empty", async () => {
+      // Simulate a record seeded before the geo backfill (blank idx value): the
+      // reader must still return it, hydrated from the authoritative rec/* record.
+      const subs = buildSubs(GEO_RECORDS, { indexed: true, geo: true })
+      subs.idx = subs.idx!.map(([k, v]) =>
+        k === `state/KARNATAKA/${padId(22)}` ? [k, Buffer.from("")] : [k, v]
+      )
+      useBee(makeBee(subs))
+      const res = await api.get("/web/census/weavers?state=KARNATAKA", {
+        validateStatus: () => true,
+      })
+      expect(res.status).toBe(200)
+      const w22 = res.data.weavers.find((w: any) => w.census_id === 22)
+      expect(w22).toBeDefined()
+      expect(w22.fat).toBe("FROM_REC_SHOULD_NOT_APPEAR") // came from rec/* fallback
     })
   })
 })

--- a/apps/backend/src/modules/census/reader.ts
+++ b/apps/backend/src/modules/census/reader.ts
@@ -68,6 +68,13 @@ class TtlLru<V> {
 // an empty `idx/all/*` family and return nothing).
 const FACET_IDX_META = "idx-version"
 const ALL_IDX_META = "idx-all-version"
+// Set once the backfill has written the inline DISPLAY PAYLOAD into every index
+// family value (see census_index.mjs geoPayload). When present, browse decodes
+// that small payload straight off the ordered index scan instead of doing a
+// random rec/* seek + 125-field brotli inflate per row — the whole point of the
+// speedup. Absent → we fall back to hydrating the fat rec/* record. MUST match
+// census_index.mjs IDX_GEO_VERSION's meta key.
+const GEO_IDX_META = "idx-geo-version"
 
 // Minimal shape of the Hyperbee handle we depend on. The real instance is created
 // in the P2P loader (dynamic native import) and injected via setBee — this file
@@ -146,6 +153,34 @@ export class CensusReader {
     const r = await this.decode(node.value)
     this.recCache.set(id, r)
     return r
+  }
+
+  /**
+   * Geo-index path: decode the inline display payload carried on an index row's
+   * value. Falls back to the fat rec/* record only when the value is empty — a
+   * row written before the geo backfill, or by the seeder's forward path pre-
+   * upgrade. Payloads are cached under a "g:" prefix so they never collide with
+   * full records cached by getDecoded (retrieveWeaver still returns the full bag).
+   */
+  private async decodeIndexRow(
+    rec: Sub,
+    id: string,
+    value: any
+  ): Promise<Record<string, any> | null> {
+    const buf: Buffer | undefined =
+      value != null && typeof value.length === "number" ? value : undefined
+    if (buf && buf.length > 0) {
+      const cached = this.recCache.get("g:" + id)
+      if (cached) return cached
+      try {
+        const r = await this.decode(buf)
+        this.recCache.set("g:" + id, r)
+        return r
+      } catch {
+        // torn/corrupt payload — fall through to the authoritative rec/* record
+      }
+    }
+    return this.getDecoded(rec, id)
   }
 
   /** Bounded-concurrency, order-preserving hydration of a list of census ids. */
@@ -297,11 +332,13 @@ export class CensusReader {
     // -scan it; until then we take the bounded fallback below. resolveIndexDriver
     // always returns a driver now (the `all` family covers the no-facet case), so
     // this gate is the only thing that keeps us off an un-backfilled family.
-    const indexReady =
-      (await bee.sub("meta", { valueEncoding: "utf-8" }).get(driver.metaKey)) != null
+    const metaSub = bee.sub("meta", { valueEncoding: "utf-8" })
+    const indexReady = (await metaSub.get(driver.metaKey)) != null
 
     if (indexReady) {
-      return this.listViaIndex(bee, rec, driver, { limit, offset, after })
+      // Whether the inline display payload has been backfilled onto index values.
+      const geoReady = (await metaSub.get(GEO_IDX_META)) != null
+      return this.listViaIndex(bee, rec, driver, { limit, offset, after }, geoReady)
     }
 
     // Fallback: bounded in-memory scan over rec/* (only when the driver's index
@@ -352,13 +389,25 @@ export class CensusReader {
     bee: Bee,
     rec: Sub,
     driver: { prefix: string; aggKey: string; residual: WeaverFilters },
-    { limit, offset, after }: { limit: number; offset: number; after?: string | number }
+    { limit, offset, after }: { limit: number; offset: number; after?: string | number },
+    geoReady = false
   ) {
     const idx = bee.sub("idx", { valueEncoding: "binary" })
     const residualEntries = Object.entries(driver.residual)
     const hasResidual = residualEntries.length > 0
     const residualMatch = (r: Record<string, any>) =>
       residualEntries.every(([k, v]) => String(r[k]) === String(v))
+
+    // Hydrate a page of index rows. With the geo payload backfilled, decode the
+    // inline value carried on each row — no random rec/* seek, no fat-record
+    // inflate (falls back to rec/* only for a row whose value is still empty).
+    // Otherwise (pre-backfill) hydrate the authoritative rec/* record by id.
+    const hydratePage = (
+      rows: { id: string; value: any }[]
+    ): Promise<(Record<string, any> | null)[]> =>
+      geoReady
+        ? Promise.all(rows.map((r) => this.decodeIndexRow(rec, r.id, r.value)))
+        : this.hydrateInOrder(rec, rows.map((r) => r.id))
 
     // sub-relative range over `<prefix><paddedId>`. ":" (0x3a) is the first byte
     // above "9" (0x39), so it upper-bounds the all-digit id suffix.
@@ -374,53 +423,54 @@ export class CensusReader {
     let next: string | null = null
 
     if (!hasResidual) {
-      // Purely index-paged: walk the ordered index (keys only — no decode) to the
-      // page window, collect its ids, then hydrate that page in PARALLEL. Total
-      // comes from agg (O(1)) below, so counting past the page is unnecessary.
-      const pageIds: string[] = []
-      for await (const { key } of idx.createReadStream(range)) {
+      // Purely index-paged: walk the ordered index to the page window, collect its
+      // rows, then hydrate that page in PARALLEL (inline payload when geoReady, else
+      // rec/*). Total comes from agg (O(1)) below, so counting past the page is
+      // unnecessary. `value` rides along so the geo path needs no second read.
+      const pageRows: { id: string; value: any }[] = []
+      for await (const { key, value } of idx.createReadStream(range)) {
         if (++scanned > MAX_SCAN) {
           capped = true
           break
         }
-        if (count >= offset && pageIds.length < limit) {
-          pageIds.push(String(Number(key.slice(driver.prefix.length))))
+        if (count >= offset && pageRows.length < limit) {
+          pageRows.push({ id: String(Number(key.slice(driver.prefix.length))), value })
         }
         count++
-        if (pageIds.length >= limit) break
+        if (pageRows.length >= limit) break
       }
-      const hydrated = await this.hydrateInOrder(rec, pageIds)
+      const hydrated = await hydratePage(pageRows)
       for (let j = 0; j < hydrated.length; j++) {
         const r = hydrated[j]
         if (r) {
           weavers.push(r)
-          next = pageIds[j]
+          next = pageRows[j].id
         }
       }
     } else {
       // Residual predicate needs the decoded record, so every id in the family
       // must be hydrated (up to MAX_SCAN) to count exact matches. Do it in ordered,
       // bounded-concurrency batches instead of one blocking seek at a time.
-      let batch: string[] = []
+      let batch: { id: string; value: any }[] = []
       const drain = async () => {
-        const hydrated = await this.hydrateInOrder(rec, batch)
+        const hydrated = await hydratePage(batch)
         for (let j = 0; j < hydrated.length; j++) {
           const r = hydrated[j]
           if (!r || !residualMatch(r)) continue
           if (count >= offset && weavers.length < limit) {
             weavers.push(r)
-            next = batch[j]
+            next = batch[j].id
           }
           count++
         }
         batch = []
       }
-      for await (const { key } of idx.createReadStream(range)) {
+      for await (const { key, value } of idx.createReadStream(range)) {
         if (++scanned > MAX_SCAN) {
           capped = true
           break
         }
-        batch.push(String(Number(key.slice(driver.prefix.length))))
+        batch.push({ id: String(Number(key.slice(driver.prefix.length))), value })
         if (batch.length >= HYDRATE_BATCH) await drain()
       }
       if (batch.length) await drain()

--- a/scripts/handloom-scrape/hyperbee-slice/apply_repairs.mjs
+++ b/scripts/handloom-scrape/hyperbee-slice/apply_repairs.mjs
@@ -29,7 +29,7 @@ import { readFileSync } from "node:fs"
 
 import { fileURLToPath } from "node:url"
 
-import { idxRelKeys } from "./census_index.mjs"
+import { idxRelKeys, geoPayload } from "./census_index.mjs"
 
 // True only when this file is the entry point (not when imported).
 const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]
@@ -103,10 +103,13 @@ export async function applyRepairs(bee, records, { dryRun = true } = {}) {
       if (d !== 0) aggDelta.set(k, (aggDelta.get(k) || 0) + d)
     }
 
-    // idx delta
+    // idx delta. Re-put the inline geo payload on EVERY current family (not just
+    // newly-added keys) so a repair that changed a display field refreshes the
+    // value the reader browses; delete only families the record left.
+    const idxVal = brotliCompressSync(Buffer.from(JSON.stringify(geoPayload(newPub))))
     const newIdx = new Set(idxRelKeys(newPub))
     const oldIdx = new Set(oldPub ? idxRelKeys(oldPub) : [])
-    for (const k of newIdx) if (!oldIdx.has(k)) idxAdd.push(k)
+    for (const k of newIdx) idxAdd.push([k, idxVal])
     for (const k of oldIdx) if (!newIdx.has(k)) idxDel.push(k)
 
     recPuts.push([id, enc(newPub)])
@@ -115,7 +118,7 @@ export async function applyRepairs(bee, records, { dryRun = true } = {}) {
   if (!dryRun) {
     const batch = bee.batch({ keyEncoding: "binary", valueEncoding: "binary" })
     for (const [id, val] of recPuts) await batch.put(subKey("rec", id), val)
-    for (const k of idxAdd) await batch.put(subKey("idx", k), EMPTY)
+    for (const [k, val] of idxAdd) await batch.put(subKey("idx", k), val)
     for (const k of idxDel) await batch.del(subKey("idx", k))
     for (const [k, d] of aggDelta) {
       const cur = await agg.get(k)

--- a/scripts/handloom-scrape/hyperbee-slice/backfill_index.mjs
+++ b/scripts/handloom-scrape/hyperbee-slice/backfill_index.mjs
@@ -19,7 +19,7 @@
 
 import Corestore from "corestore"
 import Hyperbee from "hyperbee"
-import { brotliDecompressSync } from "node:zlib"
+import { brotliDecompressSync, brotliCompressSync } from "node:zlib"
 
 import { backfillIndex } from "./census_index.mjs"
 
@@ -29,6 +29,9 @@ const CORE_NAME = process.env.PUBLIC_CORE_NAME || "handloom-public-v1"
 const SEP = Buffer.from([0])
 const subKey = (name, k) => Buffer.concat([Buffer.from(name), SEP, Buffer.from(String(k))])
 const decode = (buf) => JSON.parse(brotliDecompressSync(buf).toString())
+// Encodes the lean inline display payload written onto every index value (the
+// geo generation). Passing this flips backfillIndex into payload mode.
+const encodePayload = (obj) => brotliCompressSync(Buffer.from(JSON.stringify(obj)))
 
 const store = new Corestore(STORE_DIR)
 const core = store.get({ name: CORE_NAME })
@@ -51,6 +54,7 @@ const t0 = Date.now()
 const { indexed, alreadyDone } = await backfillIndex(bee, {
   subKey,
   decode,
+  encodePayload,
   batchSize: Number(process.env.IDX_BATCH || 5000),
   log: (m) => console.log(m),
 })

--- a/scripts/handloom-scrape/hyperbee-slice/census_index.mjs
+++ b/scripts/handloom-scrape/hyperbee-slice/census_index.mjs
@@ -37,9 +37,49 @@ export const ID_PAD = 10
 // range-scan an empty family). MUST match reader.ts FACET_IDX_META/ALL_IDX_META.
 export const IDX_VERSION = "idx-v1"
 export const IDX_ALL_VERSION = "idxall-v1"
+// Bumped when the index VALUE format changes. v1 stored empty values (keys only,
+// so browse range-scanned the index for ids then hydrated each fat rec/* record);
+// "geo-v1" stores an inline display payload in every family value so browse reads
+// the small payload straight off the ordered scan — no random rec/* seek, no
+// 125-field brotli inflate per row. The reader flips to the inline path only when
+// meta/idx-geo-version is set. MUST match reader.ts GEO_IDX_META.
+export const IDX_GEO_VERSION = "geo-v1"
 export const padId = (id) => String(id).padStart(ID_PAD, "0")
 
 const EMPTY = Buffer.from("")
+
+// The lean projection stored in each index value — exactly the fields the atlas
+// map plots + shows in its side panel, and the equality-filterable facets. Chosen
+// to exclude the fat `survey`/`products`/`schemes` bags (the reason a full-record
+// hydrate is slow). Keep in sync with the map's WEAVER_META_KEYS.
+const GEO_FIELDS = [
+  "census_id", "village", "block", "district", "state", "gender", "age",
+  "religion", "social_group", "education", "rural_urban", "household_type",
+  "dwelling_type", "ownership_type", "electricity", "own_looms",
+  "total_looms_owned", "pit_loom_count", "frame_loom_count", "natural_dye_used",
+  "monthly_income", "handloom_income", "avg_production_meters", "intricacy_level",
+]
+
+/**
+ * Build the inline display payload for a PUBLIC record: the lean typed fields
+ * plus latitude/longitude. The scraper captures the source portal's coordinates
+ * but the fast parser leaves them in the raw `survey` bag rather than promoting
+ * them — so lift survey.{Latitude,Longitude} to typed lat/long here (this is what
+ * finally puts weavers on the map). Only non-empty scalars are kept.
+ */
+export function geoPayload(r) {
+  const out = {}
+  for (const k of GEO_FIELDS) {
+    const v = r[k]
+    if (v != null && v !== "") out[k] = v
+  }
+  const sv = r.survey && typeof r.survey === "object" ? r.survey : null
+  const lat = r.latitude ?? sv?.Latitude ?? sv?.latitude
+  const lng = r.longitude ?? sv?.Longitude ?? sv?.longitude
+  if (lat != null && lat !== "" && Number.isFinite(Number(lat))) out.latitude = Number(lat)
+  if (lng != null && lng !== "" && Number.isFinite(Number(lng))) out.longitude = Number(lng)
+  return out
+}
 
 /** Sub-relative idx keys for one PUBLIC record (skips families whose value is
  * null/empty so we never index a bogus "undefined" bucket). */
@@ -67,20 +107,27 @@ export function idxRelKeys(r) {
  * deps: { subKey(name, key)->Buffer, decode(buf)->record, batchSize?, log? }
  * Returns { indexed, alreadyDone }.
  */
-export async function backfillIndex(bee, { subKey, decode, batchSize = 5000, log = () => {} }) {
+export async function backfillIndex(bee, { subKey, decode, encodePayload, batchSize = 5000, log = () => {} }) {
   const meta = bee.sub("meta", { valueEncoding: "utf-8" })
   const facetsDone = (await meta.get("idx-version"))?.value === IDX_VERSION
   const allDone = (await meta.get("idx-all-version"))?.value === IDX_ALL_VERSION
-  if (facetsDone && allDone) {
+  // Only emit inline payloads when the caller wired an encoder; without it we
+  // preserve the legacy keys-only behaviour (empty values) for old callers.
+  const emitGeo = typeof encodePayload === "function"
+  const geoDone = (await meta.get("idx-geo-version"))?.value === IDX_GEO_VERSION
+  if (facetsDone && allDone && (!emitGeo || geoDone)) {
     return { indexed: 0, alreadyDone: true }
   }
 
-  // A prior run may have completed the facet families (idx-version set) before
-  // the `all` family existed — its completion cursor is parked at the corpus
-  // end, so resuming from it would emit nothing. Reset to a full re-walk in that
-  // case; the idx puts are idempotent (EMPTY-value overwrites), so re-emitting
-  // the facet keys alongside the new `all` keys is harmless.
-  const cursorNode = facetsDone && !allDone ? null : await meta.get("idx-backfill-cursor")
+  // The geo generation rewrites EVERY family value (payload, not empty), so it
+  // must re-walk the whole corpus — a legacy cursor is parked at the end and
+  // would emit nothing. Track the geo pass under its OWN cursor so a crash mid-
+  // backfill resumes instead of restarting. Legacy (no-geo) runs keep using the
+  // old cursor and its facet/all-only reset rule. Puts are idempotent overwrites,
+  // so re-emitting keys is always harmless.
+  const CURSOR = emitGeo ? "idx-geo-cursor" : "idx-backfill-cursor"
+  const cursorNode =
+    !emitGeo && facetsDone && !allDone ? null : await meta.get(CURSOR)
   let resumeAfter = cursorNode ? cursorNode.value : null
 
   const rec = bee.sub("rec", { valueEncoding: "binary" })
@@ -89,15 +136,15 @@ export async function backfillIndex(bee, { subKey, decode, batchSize = 5000, log
   const range = resumeAfter != null ? { gt: resumeAfter } : {}
 
   let indexed = 0
-  let pending = []
+  let pending = [] // [relKey, valueBuffer]
   let lastKey = resumeAfter
 
   const flush = async () => {
     if (pending.length === 0) return
     const batch = bee.batch({ keyEncoding: "binary", valueEncoding: "binary" })
-    for (const relKey of pending) await batch.put(subKey("idx", relKey), EMPTY)
+    for (const [relKey, val] of pending) await batch.put(subKey("idx", relKey), val)
     // checkpoint the cursor in the SAME batch → backfill is itself crash-exact.
-    if (lastKey != null) await batch.put(subKey("meta", "idx-backfill-cursor"), Buffer.from(String(lastKey)))
+    if (lastKey != null) await batch.put(subKey("meta", CURSOR), Buffer.from(String(lastKey)))
     await batch.flush()
     pending = []
   }
@@ -111,7 +158,8 @@ export async function backfillIndex(bee, { subKey, decode, batchSize = 5000, log
     } catch {
       continue // torn/corrupt row — skip, don't abort the whole backfill
     }
-    for (const rk of idxRelKeys(record)) pending.push(rk)
+    const val = emitGeo ? encodePayload(geoPayload(record)) : EMPTY
+    for (const rk of idxRelKeys(record)) pending.push([rk, val])
     indexed++
     if (++sinceFlush >= batchSize) {
       await flush()
@@ -123,7 +171,8 @@ export async function backfillIndex(bee, { subKey, decode, batchSize = 5000, log
 
   await meta.put("idx-version", IDX_VERSION)
   await meta.put("idx-all-version", IDX_ALL_VERSION)
-  log(`[idx-backfill] DONE — ${indexed} records indexed, idx-version=${IDX_VERSION}, idx-all-version=${IDX_ALL_VERSION}`)
+  if (emitGeo) await meta.put("idx-geo-version", IDX_GEO_VERSION)
+  log(`[idx-backfill] DONE — ${indexed} records indexed, idx-version=${IDX_VERSION}, idx-all-version=${IDX_ALL_VERSION}${emitGeo ? `, idx-geo-version=${IDX_GEO_VERSION}` : ""}`)
   return { indexed, alreadyDone: false }
 }
 
@@ -151,9 +200,12 @@ if (_isMain && process.argv.includes("--test")) {
   const subKey = (name, k) => Buffer.concat([Buffer.from(name), SEP, Buffer.from(String(k))])
   const decode = (buf) => JSON.parse(brotliDecompressSync(buf).toString())
   const enc = (r) => brotliCompressSync(Buffer.from(JSON.stringify(r)))
+  const encodePayload = (obj) => brotliCompressSync(Buffer.from(JSON.stringify(obj)))
 
   const records = [
-    { census_id: 10, state: "KARNATAKA", district: "BAGALKOT", gender: "Male" },
+    // id 10 carries coords in the raw survey bag (as the fast parser leaves them)
+    // → the payload must promote them to typed lat/long.
+    { census_id: 10, state: "KARNATAKA", district: "BAGALKOT", gender: "Male", village: "ILKAL", survey: { Latitude: "16.1329", Longitude: "75.9587" } },
     { census_id: 11, state: "KARNATAKA", district: "BAGALKOT", gender: "Female" },
     { census_id: 12, state: "KARNATAKA", district: "BELGAUM", gender: "Male" },
     { census_id: 13, state: "PUNJAB", district: "AMRITSAR", gender: "Female" },
@@ -168,18 +220,25 @@ if (_isMain && process.argv.includes("--test")) {
   let pass = 0
   const ok = (l, c) => { assert(c, `FAIL: ${l}`); console.log(`  ✓ ${l}`); pass++ }
 
-  const res = await backfillIndex(bee, { subKey, decode, batchSize: 2 })
+  const res = await backfillIndex(bee, { subKey, decode, encodePayload, batchSize: 2 })
   ok("backfill reports all records indexed", res.indexed === 5)
   ok("idx-version flag set", (await bee.sub("meta", { valueEncoding: "utf-8" }).get("idx-version"))?.value === "idx-v1")
   ok("idx-all-version flag set", (await bee.sub("meta", { valueEncoding: "utf-8" }).get("idx-all-version"))?.value === "idxall-v1")
+  ok("idx-geo-version flag set", (await bee.sub("meta", { valueEncoding: "utf-8" }).get("idx-geo-version"))?.value === "geo-v1")
 
   // whole-corpus `all` family → every id, ascending (powers the unfiltered browse).
   const idxAll = bee.sub("idx", { valueEncoding: "binary" })
   const all = []
-  for await (const { key } of idxAll.createReadStream({ gte: "all/", lt: "all/:" })) {
-    all.push(Number(key.slice("all/".length)))
+  let payload10 = null
+  for await (const { key, value } of idxAll.createReadStream({ gte: "all/", lt: "all/:" })) {
+    const id = Number(key.slice("all/".length))
+    all.push(id)
+    if (id === 10) payload10 = decode(value) // inline payload rides the value now
   }
   ok("all index returns every id, sorted", JSON.stringify(all) === JSON.stringify([10, 11, 12, 13, 14]))
+  ok("inline payload carries the lean fields", payload10 && payload10.state === "KARNATAKA" && payload10.village === "ILKAL")
+  ok("payload promotes survey coords to typed lat/long", payload10 && payload10.latitude === 16.1329 && payload10.longitude === 75.9587)
+  ok("payload omits the fat survey bag", payload10 && payload10.survey === undefined)
 
   // range-scan the KARNATAKA state facet → ids in ascending order.
   const idx = bee.sub("idx", { valueEncoding: "binary" })

--- a/scripts/handloom-scrape/hyperbee-slice/seed_p2p.mjs
+++ b/scripts/handloom-scrape/hyperbee-slice/seed_p2p.mjs
@@ -26,7 +26,7 @@ import { readdirSync, writeFileSync, existsSync, createReadStream, openSync, fst
 import { createInterface } from "node:readline";
 import { join } from "node:path";
 import assert from "node:assert";
-import { idxRelKeys } from "./census_index.mjs";
+import { idxRelKeys, geoPayload } from "./census_index.mjs";
 
 const DATA_DIR = "../data/live";
 const STORE_DIR = process.env.P2P_STORE || "./p2p-store";
@@ -203,14 +203,20 @@ async function ingestCore(bee, file, sens) {
   }
 
   const recPuts = [];              // [census_id, brotli(row)]
-  const idxPuts = [];              // sub-relative secondary-index keys (public core)
+  const idxPuts = [];              // [idxRelKey, brotli(geoPayload)] (public core)
   const delta = new Map();         // agg key -> increment
   for (const r of records) {
     if (sens && r.profile_photo_url == null && photos.has(String(r.census_id)))
       r.profile_photo_url = photos.get(String(r.census_id));
     const { pub: pubRow, sensitive } = splitRecord(r);
     recPuts.push([String(r.census_id), brotliCompressSync(Buffer.from(JSON.stringify(sens ? sensitive : pubRow)))]);
-    if (!sens) for (const rk of idxRelKeys(pubRow)) idxPuts.push(rk);
+    // Carry the lean display payload inline on every index family value so the
+    // reader browses without a fat rec/* seek (see census_index.geoPayload). The
+    // payload is identical across a record's families → encode once.
+    if (!sens) {
+      const idxVal = brotliCompressSync(Buffer.from(JSON.stringify(geoPayload(pubRow))));
+      for (const rk of idxRelKeys(pubRow)) idxPuts.push([rk, idxVal]);
+    }
     bumpInto(delta, r, sens);
   }
 
@@ -224,7 +230,7 @@ async function ingestCore(bee, file, sens) {
   }
   const batch = bee.batch({ keyEncoding: "binary", valueEncoding: "binary" });
   for (const [id, val] of recPuts) await batch.put(subKey("rec", id), val);
-  for (const rk of idxPuts) await batch.put(subKey("idx", rk), Buffer.from(""));
+  for (const [rk, val] of idxPuts) await batch.put(subKey("idx", rk), val);
   for (const [k, v] of newAgg) await batch.put(subKey("agg", k), Buffer.from(String(v)));
   await batch.put(subKey("meta", "off/" + file), Buffer.from(String(endOffset)));
   await batch.flush();


### PR DESCRIPTION
## Problem
The atlas map was broken two ways:
1. **No coords** — the scraper captures the portal's `Latitude`/`Longitude`, but the fast parser leaves them in the raw `survey` bag un-promoted. The map read `w.latitude` → `NaN` → dropped **every** weaver.
2. **Slow** — even when it did query, browse hydrated the full `rec/*` record (125-field survey) per row just for a few display fields, so a filtered page of 50 took **10–30s** on the free reader node (random seek + big brotli inflate × 50) → the 8s fetch aborted → 504/empty.

## Fix — denormalize a lean payload onto the index
Store the map's display fields + promoted `lat/long` **inline on every secondary-index value**. Browse decodes that small payload straight off the ordered index scan — no `rec/*` seek, no survey inflate — and coords are present.

- **`census_index.mjs`** — `geoPayload(record)` projection (promotes `survey.{Latitude,Longitude}`); `backfillIndex` writes it onto every family value under a geo-generation cursor and sets `meta/idx-geo-version`. Self-test **15/15**.
- **`seed_p2p.mjs` / `apply_repairs.mjs`** — forward + repair paths emit the same payload so new/repaired rows aren't blank.
- **`reader.ts`** — when `meta/idx-geo-version` is set, decode the inline payload (cached under a `g:` key) instead of hydrating `rec/*`; **falls back to `rec/*`** for any row still empty (pre-backfill). `retrieveWeaver` still returns the full record. HTTP test **15/15** (+4: coords-present, `rec/*`-untouched, residual-on-payload, empty→fallback).

## Activation (box, out of band)
Prod is **proxy mode**, so the node's bundled `census-reader.mjs` (built from `reader.ts`) is the hot path. Safe to merge before activating (reader auto-flips only when the meta flag is set). To activate:
1. Rebuild `census-reader.mjs`: `esbuild reader.ts --bundle --platform=node --format=esm` → scp to box, restart `census-node`.
2. scp updated `census_index.mjs` + `backfill_index.mjs` + `seed_p2p.mjs`; run the payload backfill (stop seeder → `node backfill_index.mjs` → start seeder). Sets `idx-geo-version`; reader flips to the fast path.

## Notes
- Storage: payload (~150B brotli) on all 4 families ≈ ~1GB core growth, intra-OCI (prod is proxy, doesn't replicate).
- `retrieveWeaver` / census_id lookup unchanged (full record).

🤖 Generated with [Claude Code](https://claude.com/claude-code)