### PR TITLE
fix(census): redact raw survey PII from public read surface [#1087]

### DIFF
--- a/apps/backend/integration-tests/http/census-weavers-api.spec.ts
+++ b/apps/backend/integration-tests/http/census-weavers-api.spec.ts
@@ -333,4 +333,84 @@ setupSharedTestSuite(() => {
       expect(w22.fat).toBe("FROM_REC_SHOULD_NOT_APPEAR") // came from rec/* fallback
     })
   })
+
+  describe("GET /web/census/weavers — PII masking", () => {
+    // A record shaped like the real corpus: a fat raw `survey` bag (real name,
+    // EXACT coords, PIN/income re-dump under numbered keys) plus — to prove the
+    // defensive strip — raw contact/identity values that a future re-seed might
+    // carry. The masked-public fields (mobile_masked + the *_available presence
+    // flags) must survive as the "verified" signal.
+    const PII_RECORDS = [
+      {
+        census_id: 30,
+        state: "UTTAR PRADESH",
+        district: "SITAPUR",
+        village: "MAHMOODPUR",
+        gender: "Male",
+        mobile_masked: "91XXXXXXXXXX",
+        aadhaar_card_available: true,
+        voter_id_available: true,
+        // raw values that must never ship
+        mobile: "9812345678",
+        aadhaar_number: "123412341234",
+        pan: "ABCDE1234F",
+        bank_account: "00112233445566",
+        ifsc: "SBIN0001234",
+        father_husband_name: "SOMEONE ELSE",
+        survey: {
+          Name: "MOHD SHAHID",
+          Latitude: "27.2823364",
+          Longitude: "81.1697055",
+          "2.6": "261203", // PIN
+          "3.9.1": "Less than 5000", // income band
+          "1.9": "91XXXXXXXXXX",
+        },
+      },
+    ]
+
+    beforeAll(() => useBee(makeBee(buildSubs(PII_RECORDS, { indexed: false }))))
+
+    it("strips the raw survey bag but promotes name + coords to typed public fields", async () => {
+      const res = await api.get("/web/census/weavers?census_id=30", {
+        validateStatus: () => true,
+      })
+      expect(res.status).toBe(200)
+      const w = res.data.weaver
+      // survey bag (exact coords / PIN / income re-dump) is gone…
+      expect(w.survey).toBeUndefined()
+      // …but the public display fields are promoted to typed keys.
+      expect(w.name).toBe("MOHD SHAHID")
+      expect(w.latitude).toBe(27.2823364)
+      expect(w.longitude).toBe(81.1697055)
+    })
+
+    it("drops raw contact/identity values, keeps the masked + verified signals", async () => {
+      const res = await api.get("/web/census/weavers?census_id=30", {
+        validateStatus: () => true,
+      })
+      const w = res.data.weaver
+      for (const k of [
+        "mobile", "aadhaar_number", "pan", "bank_account", "ifsc", "father_husband_name",
+      ]) {
+        expect(w[k]).toBeUndefined()
+      }
+      // the "verified" signals the UI renders are intentionally preserved
+      expect(w.mobile_masked).toBe("91XXXXXXXXXX")
+      expect(w.aadhaar_card_available).toBe(true)
+      expect(w.voter_id_available).toBe(true)
+    })
+
+    it("masks every row in a browse list too (no survey leaks through the scan)", async () => {
+      const res = await api.get("/web/census/weavers?state=UTTAR PRADESH", {
+        validateStatus: () => true,
+      })
+      expect(res.status).toBe(200)
+      expect(res.data.weavers.length).toBeGreaterThan(0)
+      for (const w of res.data.weavers) {
+        expect(w.survey).toBeUndefined()
+        expect(w.mobile).toBeUndefined()
+        expect(w.aadhaar_number).toBeUndefined()
+      }
+    })
+  })
 })

--- a/apps/backend/src/modules/census/reader.ts
+++ b/apps/backend/src/modules/census/reader.ts
@@ -89,6 +89,64 @@ export type WeaverFilters = Record<string, string | number | boolean>
 export type ListOptions = { limit?: number; offset?: number; after?: string | number }
 export type Stats = Record<string, Record<string, number | null>>
 
+// Raw contact / identity-document VALUE keys that must never leave the public
+// read surface. Weaver demographics are public by design, but a phone number or
+// an Aadhaar/PAN number is not. The current corpus already carries none of these
+// as raw values (phone is pre-masked to `mobile_masked`; no Aadhaar/PAN numbers
+// are stored — only the boolean `aadhaar_card_available` / `voter_id_available`
+// presence flags, which ARE the "verified" signal the UI renders). This list is
+// the defensive backstop so a future re-seed can't leak them through here either.
+const RAW_CONTACT_ID_KEYS = [
+  "mobile", "phone", "aadhaar", "aadhaar_number", "aadhaar_no",
+  "pan", "pan_number", "pan_no", "bank_account", "account_number",
+  "ifsc", "aadhaar_photo_url", "profile_photo_url", "father_husband_name",
+] as const
+
+/**
+ * Project a decoded census record to the public read shape. Two things must never
+ * ship as raw values regardless of what the core physically stores:
+ *
+ *   1. The fat raw `survey` bag. It re-dumps every survey answer under opaque
+ *      numbered keys and — critically — carries the weaver's EXACT home
+ *      coordinates, PIN code, locality and income. The atlas legitimately needs
+ *      name + coordinates (it plots and labels weavers, and weaver names are
+ *      public), so we promote just `survey.{Name,Latitude,Longitude}` to typed
+ *      top-level fields (the same promotion census_index.geoPayload does) and then
+ *      drop the whole bag — dropping the PIN/locality/income re-dump with it.
+ *   2. Raw contact / identity-document values (see RAW_CONTACT_ID_KEYS). The
+ *      already-masked `mobile_masked` and the boolean `*_available` presence flags
+ *      are kept — they are the "verified" signal — the raw values are stripped.
+ *
+ * Pure + idempotent (a record with no `survey`/raw keys passes through unchanged),
+ * so it is safe to apply at every decode site, including the already-lean inline
+ * index payload.
+ */
+export function maskWeaver<T extends Record<string, any> | null | undefined>(rec: T): T {
+  if (!rec || typeof rec !== "object") return rec
+  const out: Record<string, any> = { ...rec }
+
+  const sv = out.survey && typeof out.survey === "object" ? out.survey : null
+  if (sv) {
+    if (out.name == null || out.name === "") {
+      const n = sv.Name ?? sv.name
+      if (typeof n === "string" && n.trim()) out.name = n.trim()
+    }
+    if (out.latitude == null) {
+      const lat = Number(sv.Latitude ?? sv.latitude)
+      if (Number.isFinite(lat)) out.latitude = lat
+    }
+    if (out.longitude == null) {
+      const lng = Number(sv.Longitude ?? sv.longitude)
+      if (Number.isFinite(lng)) out.longitude = lng
+    }
+  }
+  delete out.survey
+
+  for (const k of RAW_CONTACT_ID_KEYS) delete out[k]
+
+  return out as T
+}
+
 // Zero-pad census ids so the secondary index sorts lexicographically = numerically
 // (ids are < 10^10). MUST match the seeder/backfill's padding width.
 const ID_PAD = 10
@@ -150,7 +208,7 @@ export class CensusReader {
     if (cached) return cached
     const node = await rec.get(id)
     if (!node) return null
-    const r = await this.decode(node.value)
+    const r = maskWeaver(await this.decode(node.value))
     this.recCache.set(id, r)
     return r
   }
@@ -173,7 +231,7 @@ export class CensusReader {
       const cached = this.recCache.get("g:" + id)
       if (cached) return cached
       try {
-        const r = await this.decode(buf)
+        const r = maskWeaver(await this.decode(buf))
         this.recCache.set("g:" + id, r)
         return r
       } catch {
@@ -358,7 +416,7 @@ export class CensusReader {
         break
       }
       if (scanned % YIELD_EVERY === 0) await new Promise((r) => setImmediate(r))
-      const r = await this.decode(value)
+      const r = maskWeaver(await this.decode(value))
       if (!match(r)) continue
       if (count >= offset && weavers.length < limit) weavers.push(r)
       count++

--- a/scripts/handloom-scrape/hyperbee-slice/census_index.mjs
+++ b/scripts/handloom-scrape/hyperbee-slice/census_index.mjs
@@ -74,6 +74,11 @@ export function geoPayload(r) {
     if (v != null && v !== "") out[k] = v
   }
   const sv = r.survey && typeof r.survey === "object" ? r.survey : null
+  // Weaver names are public — promote to a typed field so the atlas can label
+  // pins (the map already reads w.name). The fat survey bag is NOT carried in the
+  // payload, so this is the only place the name survives into the fast browse path.
+  const nm = r.name ?? sv?.Name ?? sv?.name
+  if (typeof nm === "string" && nm.trim()) out.name = nm.trim()
   const lat = r.latitude ?? sv?.Latitude ?? sv?.latitude
   const lng = r.longitude ?? sv?.Longitude ?? sv?.longitude
   if (lat != null && lat !== "" && Number.isFinite(Number(lat))) out.latitude = Number(lat)
@@ -205,7 +210,7 @@ if (_isMain && process.argv.includes("--test")) {
   const records = [
     // id 10 carries coords in the raw survey bag (as the fast parser leaves them)
     // → the payload must promote them to typed lat/long.
-    { census_id: 10, state: "KARNATAKA", district: "BAGALKOT", gender: "Male", village: "ILKAL", survey: { Latitude: "16.1329", Longitude: "75.9587" } },
+    { census_id: 10, state: "KARNATAKA", district: "BAGALKOT", gender: "Male", village: "ILKAL", survey: { Name: "SHANTAVVA", Latitude: "16.1329", Longitude: "75.9587" } },
     { census_id: 11, state: "KARNATAKA", district: "BAGALKOT", gender: "Female" },
     { census_id: 12, state: "KARNATAKA", district: "BELGAUM", gender: "Male" },
     { census_id: 13, state: "PUNJAB", district: "AMRITSAR", gender: "Female" },
@@ -238,6 +243,7 @@ if (_isMain && process.argv.includes("--test")) {
   ok("all index returns every id, sorted", JSON.stringify(all) === JSON.stringify([10, 11, 12, 13, 14]))
   ok("inline payload carries the lean fields", payload10 && payload10.state === "KARNATAKA" && payload10.village === "ILKAL")
   ok("payload promotes survey coords to typed lat/long", payload10 && payload10.latitude === 16.1329 && payload10.longitude === 75.9587)
+  ok("payload promotes survey Name to a public typed field", payload10 && payload10.name === "SHANTAVVA")
   ok("payload omits the fat survey bag", payload10 && payload10.survey === undefined)
 
   // range-scan the KARNATAKA state facet → ids in ascending order.


### PR DESCRIPTION
## Problem

The public, no-auth `/web/census/*` read surface (serving ~2M weaver records) dumped the fat raw **`survey` bag verbatim** on every record. That re-exposed:

- the weaver's **exact home coordinates** (`survey.Latitude/Longitude`)
- **PIN code** (`survey["2.6"]`), **income band** (`survey["3.9.x"]`), locality
- a real-name field plus every survey answer under opaque numbered keys

Ground-truth check of prod (`census-node.jaalyantra.com/census/weavers/7`) confirmed the good news: phone is **already masked** (`mobile_masked`), and **no Aadhaar/PAN numbers exist** in the corpus — the `aadhaar_card_available` / `voter_id_available` booleans already serve as the "verified" presence flags. The `survey` bag was the only real leak.

## Policy (owner decision)

Weaver demographics **including name are public**. Contact + identity-document **values** (phone, Aadhaar/PAN, bank) must never ship as raw values — they surface only as "verified" flags.

## Fix

`maskWeaver()` in `reader.ts`, applied at **every decode site** — keyed get, inline geo-payload, and the **scan fallback** (which decoded straight off `rec/*` and bypassed masking — caught by a new test). It:

- lifts `survey.{Name,Latitude,Longitude}` → typed public fields (name public; the atlas needs coordinates), then **drops the whole survey bag** — discarding the PIN/income/raw-key re-dump;
- defensively strips raw contact/identity **values** (`mobile`, `aadhaar*`, `pan*`, `bank_account`, `account_number`, `ifsc`, …) as a backstop for any future re-seed;
- **keeps** `mobile_masked` + the `*_available` booleans (the verified signal the UI renders).

`census_index.geoPayload()` also promotes `survey.Name`, so the fast browse path stays name-bearing (and survey-free) once the geo payload is activated.

Net coordinate exposure is **unchanged** (the map already read `survey.Latitude`); this strictly removes the PIN/income/raw-key over-exposure while keeping names public and the map working.

## Tests

- census HTTP **18/18** (new "PII masking" block: strips survey, promotes name/coords, drops raw id values, masks every browse row)
- census_index **16/16** (name-promotion assertion added)
- esbuild bundle verified — exports `{ CensusReader, censusReader, maskWeaver }`

## ⚠️ Deploy note

Prod serves census in **proxy mode** → the hot path is the **bundled `census-reader.mjs`** on the OCI mirror box (esbuild of this `reader.ts`), not `reader.ts` directly. This fix takes effect in prod only after the node's bundle is rebuilt + redeployed — the **same box step** as the pending geo-payload activation, so both can ride one SSH visit.

## Scope note

This closes the public **HTTP API** exposure (the actual no-auth surface). The raw survey data still physically resides in the P2P public core, so a true scrub requires a re-seed — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)