### PR TITLE
feat(admin): Admin MCP + agentic assistant (Tier 0/1) on shared mcp-core [#1092]

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -130,6 +130,7 @@
     "@types/qrcode": "^1.5.5",
     "@types/react-color": "^3.0.13",
     "@types/react-json-editor-ajrm": "^2.5.6",
+    "@ai-sdk/react": "^2.0.194",
     "@uploadthing/react": "7.1.0",
     "@xenova/transformers": "^2.17.2",
     "@xyflow/react": "^12.4.4",

--- a/apps/backend/src/admin/lib/assistant-mcp.ts
+++ b/apps/backend/src/admin/lib/assistant-mcp.ts
@@ -1,0 +1,94 @@
+/**
+ * Admin MCP confirm bridge (#1092).
+ *
+ * The admin assistant's sensitive/dangerous tools never auto-execute — the chat
+ * endpoint returns `requires_confirmation` (and `requires_reason` for dangerous
+ * tools) and the UI shows an approval card. On approve we call the Admin MCP
+ * JSON-RPC endpoint DIRECTLY (bypassing the model) with `confirm: true` (and the
+ * operator's `reason`), re-issuing the exact tool + arguments the model
+ * proposed. This is the single sanctioned path for running a guarded tool.
+ *
+ * The endpoint runs stateless Streamable HTTP with `enableJsonResponse`, so a
+ * single POST returns a plain JSON-RPC body (it may also arrive as an SSE
+ * `data:` frame — we parse both). Admin auth is the session cookie, so the
+ * request is sent with credentials.
+ */
+import { API_BASE_URL } from "./config"
+
+/** Mirrors the backend AdminToolResult (mcp-core). */
+export type AdminToolResult = {
+  ok: boolean
+  tool: string
+  data?: unknown
+  error?: string
+  dry_run?: boolean
+  requires_confirmation?: boolean
+  requires_reason?: boolean
+  plan?: Record<string, unknown>
+  current?: unknown
+  warning?: string
+}
+
+/** Extract the JSON-RPC envelope from a plain-JSON or SSE-framed response body. */
+function parseRpcBody(text: string): any {
+  const trimmed = text.trim()
+  if (trimmed.startsWith("{")) return JSON.parse(trimmed)
+  // SSE frame: pull the last `data:` line and parse it.
+  const dataLine = trimmed
+    .split("\n")
+    .reverse()
+    .find((l) => l.startsWith("data:"))
+  if (dataLine) return JSON.parse(dataLine.slice(5).trim())
+  throw new Error("Unrecognized MCP response body")
+}
+
+/**
+ * Execute an admin tool via the MCP endpoint. `args` are the arguments the
+ * model proposed; `confirm: true` (and any `reason`) are added here for the
+ * sensitive/dangerous gates.
+ */
+export async function runAdminMcpTool(
+  name: string,
+  args: Record<string, unknown>,
+  opts: { reason?: string } = {}
+): Promise<AdminToolResult> {
+  const body = {
+    jsonrpc: "2.0",
+    id: Date.now(),
+    method: "tools/call",
+    params: {
+      name,
+      arguments: {
+        ...args,
+        confirm: true,
+        ...(opts.reason ? { reason: opts.reason } : {}),
+      },
+    },
+  }
+
+  const resp = await fetch(`${API_BASE_URL.replace(/\/$/, "")}/admin/mcp`, {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify(body),
+  })
+
+  const text = await resp.text()
+  const rpc = parseRpcBody(text)
+  if (rpc?.error) {
+    return { ok: false, tool: name, error: rpc.error?.message || "MCP error" }
+  }
+  // tools/call result: { content: [{ type: "text", text: "<AdminToolResult JSON>" }] }
+  const inner = rpc?.result?.content?.[0]?.text
+  if (typeof inner === "string") {
+    try {
+      return JSON.parse(inner) as AdminToolResult
+    } catch {
+      return { ok: false, tool: name, error: "Could not parse tool result" }
+    }
+  }
+  return { ok: false, tool: name, error: "Empty MCP response" }
+}

--- a/apps/backend/src/admin/routes/assistant/page.tsx
+++ b/apps/backend/src/admin/routes/assistant/page.tsx
@@ -1,0 +1,354 @@
+/**
+ * Admin Assistant (#1092) — an agentic chat that drives the Admin API through
+ * the shared MCP tool registry.
+ *
+ * Streaming chat wired to POST /admin/assistant/chat (admin session auth). The
+ * model grounds with get_admin_stats and answers operational questions using
+ * the Tier-1 read tools; write/dangerous tiers (later) surface an approval card
+ * that executes via POST /admin/mcp with confirm:true (+ reason) on the
+ * operator's explicit approval — the model never self-confirms.
+ *
+ * This lives alongside the legacy V4 hybrid-resolver chat (routes/chats) rather
+ * than replacing it, per the epic's one-release deprecation window.
+ */
+import { useEffect, useMemo, useRef, useState } from "react"
+import { defineRouteConfig } from "@medusajs/admin-sdk"
+import { ChatBubbleLeftRight, Sparkles, ArrowUpMini, Spinner, Check, ExclamationCircle } from "@medusajs/icons"
+import { Container, Heading, Text, Button, Textarea, IconButton, Badge, Table, toast } from "@medusajs/ui"
+import { useChat } from "@ai-sdk/react"
+import { DefaultChatTransport } from "ai"
+import { API_BASE_URL } from "../../lib/config"
+import { runAdminMcpTool, type AdminToolResult } from "../../lib/assistant-mcp"
+
+const SUGGESTIONS = [
+  "Give me a snapshot of the platform",
+  "How many orders came in recently?",
+  "List the most recent partners",
+  "What production runs are open?",
+]
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+  !!v && typeof v === "object" && !Array.isArray(v)
+
+/** Find the array a list tool returned (top-level or one level in). */
+function findRows(data: unknown): Record<string, unknown>[] | null {
+  if (Array.isArray(data) && data.every(isRecord)) return data as Record<string, unknown>[]
+  if (isRecord(data)) {
+    for (const v of Object.values(data)) {
+      if (Array.isArray(v) && v.every(isRecord)) return v as Record<string, unknown>[]
+    }
+  }
+  return null
+}
+
+const PREFERRED = ["display_id", "title", "name", "handle", "email", "status", "created_at"]
+
+/** Compact table for a list tool's rows; falls back to key/value or raw JSON. */
+const ToolData = ({ data }: { data: unknown }) => {
+  const rows = findRows(data)
+  if (rows && rows.length) {
+    const keys = Array.from(
+      new Set([
+        ...PREFERRED.filter((k) => k in rows[0]),
+        ...Object.keys(rows[0]).filter((k) => k !== "id" && k !== "metadata"),
+      ])
+    ).slice(0, 6)
+    return (
+      <div className="overflow-x-auto">
+        <Table>
+          <Table.Header>
+            <Table.Row>
+              {keys.map((k) => (
+                <Table.HeaderCell key={k}>{k}</Table.HeaderCell>
+              ))}
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {rows.slice(0, 10).map((r, i) => (
+              <Table.Row key={i}>
+                {keys.map((k) => (
+                  <Table.Cell key={k}>{formatCell(r[k])}</Table.Cell>
+                ))}
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+        {rows.length > 10 ? (
+          <Text size="xsmall" className="text-ui-fg-muted mt-1">
+            +{rows.length - 10} more
+          </Text>
+        ) : null}
+      </div>
+    )
+  }
+  if (isRecord(data)) {
+    return (
+      <div className="grid grid-cols-2 gap-x-3 gap-y-1">
+        {Object.entries(data)
+          .slice(0, 12)
+          .map(([k, v]) => (
+            <div key={k} className="contents">
+              <Text size="xsmall" className="text-ui-fg-muted">
+                {k}
+              </Text>
+              <Text size="xsmall">{formatCell(v)}</Text>
+            </div>
+          ))}
+      </div>
+    )
+  }
+  return (
+    <pre className="text-ui-fg-subtle whitespace-pre-wrap text-xs">
+      {JSON.stringify(data, null, 2)}
+    </pre>
+  )
+}
+
+function formatCell(v: unknown): string {
+  if (v == null) return "—"
+  if (typeof v === "object") return Array.isArray(v) ? `[${v.length}]` : "{…}"
+  return String(v)
+}
+
+/** One tool part: activity line + rendered result or approval card. */
+const ToolPart = ({ part }: { part: any }) => {
+  const toolName: string =
+    part.type === "dynamic-tool"
+      ? part.toolName
+      : String(part.type || "").replace(/^tool-/, "")
+  const output: AdminToolResult | undefined = part.output
+  const running = part.state === "input-available" || part.state === "input-streaming"
+
+  const [approving, setApproving] = useState(false)
+  const [reason, setReason] = useState("")
+  const [approved, setApproved] = useState<AdminToolResult | null>(null)
+
+  const guarded = !!output && (output.requires_confirmation || output.requires_reason)
+  const result = approved ?? output
+
+  const approve = async () => {
+    if (output?.requires_reason && !reason.trim()) {
+      toast.error("A reason is required for this action.")
+      return
+    }
+    setApproving(true)
+    try {
+      const args = (output?.plan as any)?.body || {}
+      const res = await runAdminMcpTool(
+        toolName,
+        { ...args, ...pathArgsFrom(output?.plan) },
+        { reason: reason.trim() || undefined }
+      )
+      setApproved(res)
+      if (res.ok) toast.success(`${toolName} completed.`)
+      else toast.error(res.error || `${toolName} failed.`)
+    } finally {
+      setApproving(false)
+    }
+  }
+
+  return (
+    <div className="border-ui-border-base bg-ui-bg-subtle mt-2 rounded-lg border p-3">
+      <div className="mb-1 flex items-center gap-2">
+        {running ? <Spinner className="animate-spin" /> : <Sparkles />}
+        <Text size="small" weight="plus">
+          {toolName}
+        </Text>
+        {result?.dry_run ? <Badge size="2xsmall" color="blue">preview</Badge> : null}
+        {result && !result.dry_run && result.ok && !guarded ? (
+          <Badge size="2xsmall" color="green">done</Badge>
+        ) : null}
+        {result && !result.ok ? <Badge size="2xsmall" color="red">error</Badge> : null}
+      </div>
+
+      {guarded && !approved ? (
+        <div className="mt-1">
+          <div className="mb-2 flex items-start gap-2">
+            <ExclamationCircle className="text-ui-tag-orange-icon mt-0.5" />
+            <Text size="small">
+              {output?.warning || "This action needs your approval before it runs."}
+            </Text>
+          </div>
+          {output?.plan ? (
+            <pre className="text-ui-fg-subtle bg-ui-bg-base mb-2 overflow-x-auto rounded p-2 text-xs">
+              {JSON.stringify(output.plan, null, 2)}
+            </pre>
+          ) : null}
+          {output?.requires_reason ? (
+            <Textarea
+              placeholder="Reason (why are you doing this?) — audited"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              className="mb-2"
+            />
+          ) : null}
+          <Button size="small" variant="danger" isLoading={approving} onClick={approve}>
+            <Check /> Approve &amp; run
+          </Button>
+        </div>
+      ) : result?.data !== undefined ? (
+        <ToolData data={result.data} />
+      ) : result?.error ? (
+        <Text size="small" className="text-ui-fg-error">
+          {result.error}
+        </Text>
+      ) : null}
+    </div>
+  )
+}
+
+/** Re-derive :param path args from a dry-run/confirmation plan's path. */
+function pathArgsFrom(_plan: unknown): Record<string, unknown> {
+  // Tier 1 has no guarded tools; later tiers with path params will thread the
+  // original args through the tool part. Kept as a no-op seam for now.
+  return {}
+}
+
+const getText = (parts: any[] | undefined): string =>
+  (parts || [])
+    .filter((p) => p?.type === "text" && typeof p.text === "string")
+    .map((p) => p.text)
+    .join("")
+
+const AssistantChat = () => {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const [input, setInput] = useState("")
+
+  const transport = useMemo(
+    () =>
+      new DefaultChatTransport({
+        api: `${API_BASE_URL.replace(/\/$/, "")}/admin/assistant/chat`,
+        credentials: "include",
+      }),
+    []
+  )
+
+  const { messages, sendMessage, status, error, stop } = useChat({ transport })
+  const streaming = status === "submitted" || status === "streaming"
+
+  useEffect(() => {
+    if (scrollRef.current) scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+  }, [messages, status])
+
+  const submit = (text: string) => {
+    const t = text.trim()
+    if (!t || streaming) return
+    setInput("")
+    sendMessage({ text: t })
+  }
+
+  return (
+    <Container className="flex h-[calc(100vh-140px)] flex-col overflow-hidden p-0">
+      <div className="border-ui-border-base flex items-center gap-2 border-b px-6 py-4">
+        <Sparkles className="text-ui-fg-interactive" />
+        <div>
+          <Heading level="h2">Admin Assistant</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            Ask about orders, partners, production and more — it reads the Admin API for you.
+          </Text>
+        </div>
+      </div>
+
+      <div ref={scrollRef} className="flex-1 space-y-4 overflow-y-auto px-6 py-4">
+        {messages.length === 0 ? (
+          <div className="flex flex-col gap-2">
+            <Text size="small" className="text-ui-fg-muted">
+              Try one of these:
+            </Text>
+            {SUGGESTIONS.map((s) => (
+              <Button
+                key={s}
+                variant="secondary"
+                size="small"
+                className="w-fit"
+                onClick={() => submit(s)}
+              >
+                {s}
+              </Button>
+            ))}
+          </div>
+        ) : null}
+
+        {messages.map((m: any) => {
+          const text = getText(m.parts)
+          const toolParts = (m.parts || []).filter(
+            (p: any) =>
+              p?.type === "dynamic-tool" || String(p?.type || "").startsWith("tool-")
+          )
+          return (
+            <div key={m.id} className={m.role === "user" ? "flex justify-end" : ""}>
+              <div
+                className={
+                  m.role === "user"
+                    ? "bg-ui-bg-interactive text-ui-fg-on-color max-w-[80%] rounded-lg px-3 py-2"
+                    : "max-w-[92%]"
+                }
+              >
+                {text ? (
+                  <Text size="small" className="whitespace-pre-wrap">
+                    {text}
+                  </Text>
+                ) : null}
+                {toolParts.map((p: any, i: number) => (
+                  <ToolPart key={p.toolCallId || i} part={p} />
+                ))}
+              </div>
+            </div>
+          )
+        })}
+
+        {streaming ? (
+          <div className="text-ui-fg-muted flex items-center gap-2">
+            <Spinner className="animate-spin" />
+            <Text size="small">Thinking…</Text>
+          </div>
+        ) : null}
+
+        {error ? (
+          <div className="text-ui-fg-error flex items-center gap-2">
+            <ExclamationCircle />
+            <Text size="small">The assistant hit an error. Try again.</Text>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="border-ui-border-base border-t px-6 py-4">
+        <div className="flex items-end gap-2">
+          <Textarea
+            placeholder="Ask the admin assistant…"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault()
+                submit(input)
+              }
+            }}
+            rows={1}
+            className="resize-none"
+          />
+          {streaming ? (
+            <Button variant="secondary" onClick={() => stop()}>
+              Stop
+            </Button>
+          ) : (
+            <IconButton
+              variant="primary"
+              disabled={!input.trim()}
+              onClick={() => submit(input)}
+            >
+              <ArrowUpMini />
+            </IconButton>
+          )}
+        </div>
+      </div>
+    </Container>
+  )
+}
+
+export const config = defineRouteConfig({
+  label: "Assistant",
+  icon: ChatBubbleLeftRight,
+})
+
+export default AssistantChat

--- a/apps/backend/src/api/admin/assistant/chat/route.ts
+++ b/apps/backend/src/api/admin/assistant/chat/route.ts
@@ -1,0 +1,205 @@
+/**
+ * POST /admin/assistant/chat
+ *
+ * Streaming chat endpoint for the admin assistant. The model drives the Admin
+ * API through the shared MCP tool registry (see ../../mcp/lib/registry) with
+ * three safety rails from the shared dispatcher:
+ *
+ *   - `dry_run` on any tool previews the request (and current object for writes)
+ *     without executing, so the model can inspect live data first.
+ *   - sensitive/destructive tools return `requires_confirmation` instead of
+ *     running; the UI surfaces an approval card and, on confirm, calls
+ *     POST /admin/mcp directly with `confirm: true`.
+ *   - dangerous (platform-destructive) tools additionally return
+ *     `requires_reason`; the admin must supply a reason (audited).
+ *
+ * Pipeline mirrors the partner assistant: resolve the chat model for the
+ * `ai_admin_assistant` role (DB-configured platform → OpenRouter free
+ * fallback), bind tools, `streamText(...)`, and pipe the UI message stream into
+ * the response. All /admin/* routes are admin-user authenticated by Medusa.
+ */
+import { AuthenticatedMedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import {
+  convertToModelMessages,
+  streamText,
+  stepCountIs,
+  tool,
+  jsonSchema,
+} from "ai"
+import { resolveRoleTextModel, logAiUsage } from "../../../../mastra/services/ai-platforms"
+import { dynamicFreeToolTextModel } from "../../../../mastra/providers/dynamic-text-model"
+import { foldSystemForProvider } from "../../../store/ai/chat/system-fold-lib"
+import { ADMIN_MCP_TOOLS, renderToolGuidance } from "../../mcp/lib/registry"
+import {
+  dispatchAdminTool,
+  buildToolInputSchema,
+  isSensitive,
+  isDangerous,
+  type AdminMcpContext,
+} from "../../mcp/lib/dispatch"
+import {
+  isAdminWriteEnabled,
+  isAdminDangerousEnabled,
+  resolveAdminBaseUrl,
+} from "../../mcp/lib/handler"
+import type { AdminAssistantChatReq } from "./validators"
+
+const FEATURE = "admin/assistant/chat"
+const ROLE = "ai_admin_assistant"
+
+const SYSTEM_PROMPT = `You are the JYT admin assistant. You help platform operators run the business by calling Admin API tools on their behalf — reading orders, products, customers, partners, stores, designs, production runs, inventory, payments and campaigns, and (in later tiers) acting on them.
+
+## How to work
+- ALWAYS call \`get_admin_stats\` first to ground yourself in the platform's current shape before answering operational questions.
+- Use the read tools (list_orders, list_products, list_customers, list_partners, list_designs, list_production_runs, list_inventory_items, list_payments, ...) to answer "what's happening" questions. Fetch a single record with the get_* tools when you have an id.
+- Prefer doing (calling a tool) over describing. Chain tools to complete a goal, and set each tool's \`context\` to what you're ultimately trying to accomplish.
+
+## Safety rails (important)
+- Every tool accepts \`dry_run: true\`. Use it to PREVIEW a change and inspect the current object before you actually write.
+- Sensitive/destructive tools refuse to run unless the user confirms. Never set \`confirm: true\` yourself. If a tool returns \`requires_confirmation\`, tell the user plainly what it will do and ask them to approve — the UI gives them a button.
+- Platform-destructive ("dangerous") tools additionally require a \`reason\`. If a tool returns \`requires_reason\`, ask the operator WHY they want to do it and pass their answer as the reason. Never invent a reason.
+
+## Style
+- Be concise and operator-focused. After a successful change, confirm what you did in one short sentence.
+- Never invent ids, values, or fields outside the tool schemas.`
+
+export const POST = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+  const body = (req as any).validatedBody as AdminAssistantChatReq
+
+  const resolved = await resolveRoleTextModel(req.scope as any, ROLE)
+  if (resolved.source === "free" && !process.env.OPENROUTER_API_KEY) {
+    res.status(503).json({
+      error:
+        "The admin assistant is not configured. Add a platform with role ai_admin_assistant in Settings → External Platforms, or set OPENROUTER_API_KEY.",
+    })
+    return
+  }
+
+  // Loopback context — forward the admin's auth so wrapped routes authenticate
+  // as the admin user. Writes/dangerous still require confirmation (+ reason)
+  // via the shared dispatcher; the write/dangerous flags gate visibility.
+  const ctx: AdminMcpContext = {
+    baseUrl: resolveAdminBaseUrl(req),
+    bearer: req.get("authorization") || undefined,
+    cookie: req.get("cookie") || undefined,
+    enableWrite: isAdminWriteEnabled(),
+    enableDangerous: isAdminDangerousEnabled(),
+    surface: "admin",
+  }
+  const writeEnabled = ctx.enableWrite !== false
+  const dangerousEnabled = ctx.enableDangerous === true
+
+  // Bind the registry as AI-SDK tools. One source of truth (JSON Schema) feeds
+  // both this binding and the MCP endpoint's tools/list. Disabled tiers are
+  // hidden from the model entirely (and refused at dispatch as a backstop).
+  const tools = Object.fromEntries(
+    ADMIN_MCP_TOOLS.filter(
+      (def) =>
+        (writeEnabled || !def.write) &&
+        (dangerousEnabled || !isDangerous(def))
+    ).map((def) => [
+      def.name,
+      tool({
+        description:
+          def.description +
+          (isDangerous(def)
+            ? " [dangerous: requires user confirmation AND a reason]"
+            : isSensitive(def)
+            ? " [sensitive: requires user confirmation]"
+            : "") +
+          renderToolGuidance(def),
+        inputSchema: jsonSchema(buildToolInputSchema(def)),
+        execute: async (input: any) => dispatchAdminTool(ctx, def.name, input),
+      }),
+    ])
+  )
+
+  // Normalise inbound UI messages — strip tool parts from history.
+  const messages = body.messages.map((m: any) => {
+    const parts = Array.isArray(m.parts) ? m.parts : null
+    const textParts = parts
+      ? parts
+          .filter(
+            (p: any) =>
+              p?.type === "text" && typeof p.text === "string" && p.text.length > 0
+          )
+          .map((p: any) => ({ type: "text", text: p.text }))
+      : [{ type: "text", text: String(m.content ?? "") }]
+
+    return {
+      role: m.role,
+      parts: textParts.length ? textParts : [{ type: "text", text: "" }],
+    }
+  })
+
+  // This assistant REQUIRES tool calling. The free rotator ranks by context
+  // length and can land on a text-only model, so on the free path use the
+  // tool-capable variant. A DB-configured platform for this role overrides this.
+  const chatModel =
+    resolved.source === "free" ? dynamicFreeToolTextModel : resolved.model
+
+  const folded = foldSystemForProvider(resolved.providerType, SYSTEM_PROMPT, messages)
+  const startedAt = Date.now()
+
+  const usageBase = {
+    feature: FEATURE,
+    role: ROLE,
+    provider: resolved.providerType,
+    source: resolved.source,
+    platformId: resolved.platformId,
+    model: resolved.modelId,
+  } as const
+
+  let result
+  const MAX_CONSTRUCTION_ATTEMPTS = 2
+  for (let attempt = 1; attempt <= MAX_CONSTRUCTION_ATTEMPTS; attempt++) {
+    try {
+      result = streamText({
+        model: chatModel,
+        ...(folded.system ? { system: folded.system } : {}),
+        messages: convertToModelMessages(folded.messages as any),
+        tools,
+        stopWhen: stepCountIs(8),
+        temperature: 0.3,
+        maxRetries: 3,
+        onFinish: ({ usage: u }: any) => {
+          logAiUsage(logger, {
+            ...usageBase,
+            ok: true,
+            ms: Date.now() - startedAt,
+            tokens: u?.totalTokens,
+          })
+        },
+        onError: (err: any) => {
+          logAiUsage(logger, {
+            ...usageBase,
+            ok: false,
+            ms: Date.now() - startedAt,
+            error: err?.error ?? err,
+          })
+        },
+      })
+      break
+    } catch (e: any) {
+      logAiUsage(logger, {
+        ...usageBase,
+        ok: false,
+        ms: Date.now() - startedAt,
+        error: e,
+      })
+      if (attempt < MAX_CONSTRUCTION_ATTEMPTS) {
+        await new Promise((r) => setTimeout(r, 400 * attempt))
+        continue
+      }
+      res.status(502).json({ error: "admin assistant provider failed" })
+      return
+    }
+  }
+
+  result.pipeUIMessageStreamToResponse(res as any)
+}

--- a/apps/backend/src/api/admin/assistant/chat/validators.ts
+++ b/apps/backend/src/api/admin/assistant/chat/validators.ts
@@ -1,0 +1,32 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * UI message shape sent by the AI-SDK `useChat` transport. Kept permissive
+ * (passthrough) — we normalise to text parts server-side before modelling.
+ * Mirrors the partner assistant validator.
+ */
+const UiMessageSchema = z
+  .object({
+    id: z.string().optional(),
+    role: z.enum(["system", "user", "assistant"]),
+    content: z.string().optional(),
+    parts: z
+      .array(
+        z
+          .object({
+            type: z.string(),
+            text: z.string().optional(),
+          })
+          .passthrough()
+      )
+      .optional(),
+  })
+  .passthrough()
+
+export const AdminAssistantChatSchema = z.object({
+  messages: z.array(UiMessageSchema).min(1).max(60),
+  id: z.string().optional(),
+  trigger: z.string().optional(),
+})
+
+export type AdminAssistantChatReq = z.infer<typeof AdminAssistantChatSchema>

--- a/apps/backend/src/api/admin/mcp/lib/__tests__/dispatch.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/dispatch.unit.spec.ts
@@ -1,0 +1,138 @@
+import {
+  dispatchAdminTool,
+  buildToolInputSchema,
+  isSensitive,
+  isDangerous,
+} from "../dispatch"
+import { ADMIN_MCP_TOOLS } from "../registry"
+import {
+  dispatchMcpTool,
+  type McpContext,
+  type McpToolDef,
+} from "../../../../../lib/mcp-core"
+
+describe("admin-mcp registry + dispatch", () => {
+  describe("Tier 1 shape", () => {
+    it("registers get_admin_stats as the read-only grounding tool", () => {
+      const def = ADMIN_MCP_TOOLS.find((t) => t.name === "get_admin_stats")
+      expect(def).toBeTruthy()
+      expect(def!.method ?? "GET").toBe("GET")
+      expect(def!.path).toBe("/admin/mcp/stats")
+      expect(isSensitive(def!)).toBe(false)
+    })
+
+    it("is entirely read-only (no write/sensitive/dangerous tools in Tier 1)", () => {
+      for (const def of ADMIN_MCP_TOOLS) {
+        expect(def.write).toBeFalsy()
+        expect(isSensitive(def)).toBe(false)
+        expect(isDangerous(def)).toBe(false)
+        expect(def.method ?? "GET").toBe("GET")
+      }
+    })
+
+    it("has unique tool names", () => {
+      const names = ADMIN_MCP_TOOLS.map((t) => t.name)
+      expect(new Set(names).size).toBe(names.length)
+    })
+  })
+
+  describe("framework args — parity with the partner dispatcher", () => {
+    it("injects context + dry_run onto EVERY tool's input schema", () => {
+      for (const def of ADMIN_MCP_TOOLS) {
+        const schema = buildToolInputSchema(def)
+        expect(schema.properties.context).toBeDefined()
+        expect(schema.properties.context.type).toBe("string")
+        expect(schema.properties.dry_run).toBeDefined()
+      }
+    })
+
+    it("adds neither confirm nor reason to a read tool", () => {
+      const schema = buildToolInputSchema(
+        ADMIN_MCP_TOOLS.find((t) => t.name === "list_orders")!
+      )
+      expect(schema.properties.confirm).toBeUndefined()
+      expect(schema.properties.reason).toBeUndefined()
+    })
+
+    it("echoes context on a read tool's dry-run plan (no network)", async () => {
+      const res = await dispatchAdminTool(
+        { baseUrl: "http://localhost:9999", bearer: "t" },
+        "list_orders",
+        { dry_run: true, context: "reviewing recent orders" }
+      )
+      expect(res.ok).toBe(true)
+      expect(res.dry_run).toBe(true)
+      expect(res.plan?.context).toBe("reviewing recent orders")
+      expect(res.plan?.method).toBe("GET")
+      expect(res.plan?.path).toBe("/admin/orders")
+    })
+
+    it("returns a soft error for an unknown tool", async () => {
+      const res = await dispatchAdminTool(
+        { baseUrl: "http://localhost:9999" },
+        "does_not_exist",
+        {}
+      )
+      expect(res.ok).toBe(false)
+      expect(res.error).toMatch(/unknown tool/i)
+    })
+  })
+
+  // The `dangerous` rail is the admin surface's third rail. Tier 1 has no
+  // dangerous tool yet, so exercise the shared dispatcher directly with a
+  // synthetic dangerous def — the exact contract later admin tiers rely on.
+  describe("dangerous rail (shared core)", () => {
+    const DANGEROUS: McpToolDef[] = [
+      {
+        name: "settle_reconciliation",
+        description: "Settle a payout reconciliation.",
+        method: "POST",
+        path: "/admin/reconciliations/:id/settle",
+        pathParams: ["id"],
+        write: true,
+        dangerous: true,
+        inputSchema: { type: "object", properties: {} },
+      },
+    ]
+    const ctx: McpContext = {
+      baseUrl: "http://localhost:9999",
+      enableWrite: true,
+      enableDangerous: true,
+      surface: "admin",
+    }
+
+    it("injects BOTH reason and confirm onto a dangerous tool's schema", () => {
+      const schema = buildToolInputSchema(DANGEROUS[0])
+      expect(schema.properties.reason).toBeDefined()
+      expect(schema.properties.confirm).toBeDefined()
+    })
+
+    it("refuses to run without a reason (even with confirm=true)", async () => {
+      const res = await dispatchMcpTool(ctx, DANGEROUS, "settle_reconciliation", {
+        id: "recon_1",
+        confirm: true,
+      })
+      expect(res.ok).toBe(true)
+      expect(res.requires_reason).toBe(true)
+    })
+
+    it("still requires confirmation when a reason is given", async () => {
+      const res = await dispatchMcpTool(ctx, DANGEROUS, "settle_reconciliation", {
+        id: "recon_1",
+        reason: "month-end close",
+      })
+      expect(res.requires_confirmation).toBe(true)
+    })
+
+    it("is hidden/refused when the surface disables dangerous tools", async () => {
+      const res = await dispatchMcpTool(
+        { ...ctx, enableDangerous: false },
+        DANGEROUS,
+        "settle_reconciliation",
+        { id: "recon_1", reason: "x", confirm: true }
+      )
+      expect(res.ok).toBe(false)
+      expect(res.error).toMatch(/dangerous/i)
+    })
+  })
+})

--- a/apps/backend/src/api/admin/mcp/lib/dispatch.ts
+++ b/apps/backend/src/api/admin/mcp/lib/dispatch.ts
@@ -1,0 +1,39 @@
+/**
+ * Admin-MCP tool dispatcher — thin wrapper over the shared mcp-core.
+ *
+ * Binds the core dispatcher to the Admin registry and stamps the "admin"
+ * surface. The three safety rails (dry_run preview, sensitive/DELETE confirm,
+ * dangerous/reason) live in the shared dispatcher, so the JSON-RPC MCP endpoint
+ * and the in-app admin assistant behave identically. Re-exports the schema
+ * helpers so the chat route and tests share one source of truth.
+ */
+import {
+  dispatchMcpTool,
+  type McpContext,
+  type McpToolResult,
+} from "../../../../lib/mcp-core"
+import { ADMIN_MCP_TOOLS } from "./registry"
+
+export {
+  buildToolInputSchema,
+  isSensitive,
+  isDangerous,
+} from "../../../../lib/mcp-core"
+
+/** Admin dispatch context (auth + write/dangerous flags). Alias of core context. */
+export type AdminMcpContext = McpContext
+/** Structured tool result. Alias of the core result. */
+export type AdminToolResult = McpToolResult
+
+export async function dispatchAdminTool(
+  ctx: AdminMcpContext,
+  name: string,
+  rawArgs: Record<string, unknown> = {}
+): Promise<AdminToolResult> {
+  return dispatchMcpTool(
+    { ...ctx, surface: "admin" },
+    ADMIN_MCP_TOOLS,
+    name,
+    rawArgs
+  )
+}

--- a/apps/backend/src/api/admin/mcp/lib/handler.ts
+++ b/apps/backend/src/api/admin/mcp/lib/handler.ts
@@ -1,0 +1,83 @@
+/**
+ * Shared request handler for the Admin MCP transport, mounted at
+ * POST /admin/mcp (admin-user-authenticated — all /admin/* routes are).
+ *
+ * Thin wrapper over the shared mcp-core transport helpers: build an
+ * admin-scoped server (auth captured from the request) and hand Medusa's
+ * already-parsed JSON-RPC body to the stateless Streamable-HTTP transport.
+ *
+ * Two env flags gate the write surface:
+ *   - ADMIN_MCP_ENABLE_WRITE      (default true)  — write tools (non-GET).
+ *   - ADMIN_MCP_ENABLE_DANGEROUS  (default false) — platform-destructive tools.
+ * Tier 1 is read-only, so neither flag affects it yet; they are wired now so
+ * later tiers land safe-by-default.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { Server } from "@modelcontextprotocol/sdk/server/index.js"
+import {
+  buildMcpServer,
+  handleMcpJsonRpc,
+  mcpMethodNotAllowed,
+  resolveLoopbackBaseUrl,
+  envFlagDefaultTrue,
+  envFlagDefaultFalse,
+} from "../../../../lib/mcp-core"
+import { ADMIN_MCP_TOOLS } from "./registry"
+
+const SERVER_INFO = { name: "jyt-admin", version: "0.1.0" } as const
+
+const INSTRUCTIONS =
+  "JYT Admin MCP — drive the platform via the Admin API. Tools currently cover " +
+  "read-only breadth: orders, products, customers, partners, stores, designs, " +
+  "production runs, inventory, payments, campaigns and notifications. Every tool " +
+  "accepts a `dry_run` flag. Sensitive/destructive tools require `confirm: true`, " +
+  "and platform-destructive ('dangerous') tools additionally require a human " +
+  "`reason` — never confirm or invent a reason on the admin's behalf. Start by " +
+  "calling get_admin_stats to ground yourself."
+
+/** Write tools are on by default; a deployment can force read-only. */
+export function isAdminWriteEnabled(): boolean {
+  return envFlagDefaultTrue("ADMIN_MCP_ENABLE_WRITE")
+}
+
+/** Dangerous (platform-destructive) tools are OFF unless explicitly enabled. */
+export function isAdminDangerousEnabled(): boolean {
+  return envFlagDefaultFalse("ADMIN_MCP_ENABLE_DANGEROUS")
+}
+
+/**
+ * Loopback origin for proxying to /admin/* on this same process. Derived from
+ * the incoming request by default; override with ADMIN_MCP_LOOPBACK_URL.
+ */
+export function resolveAdminBaseUrl(req: MedusaRequest): string {
+  return resolveLoopbackBaseUrl(req, "ADMIN_MCP_LOOPBACK_URL")
+}
+
+export function buildAdminMcpServer(req: MedusaRequest): Server {
+  return buildMcpServer(
+    {
+      baseUrl: resolveAdminBaseUrl(req),
+      bearer: req.get("authorization") || undefined,
+      cookie: req.get("cookie") || undefined,
+      enableWrite: isAdminWriteEnabled(),
+      enableDangerous: isAdminDangerousEnabled(),
+      surface: "admin",
+    },
+    ADMIN_MCP_TOOLS,
+    { serverInfo: SERVER_INFO, instructions: INSTRUCTIONS }
+  )
+}
+
+export async function handleAdminMcpRequest(
+  req: MedusaRequest,
+  res: MedusaResponse
+): Promise<void> {
+  await handleMcpJsonRpc(req, res, buildAdminMcpServer(req))
+}
+
+export function adminMcpMethodNotAllowed(
+  req: MedusaRequest,
+  res: MedusaResponse
+): void {
+  mcpMethodNotAllowed(req, res)
+}

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -1,0 +1,216 @@
+/**
+ * Declarative registry of Admin API endpoints exposed as MCP / chat tools.
+ *
+ * Each entry maps one tool -> one `/admin/*` route. The shared mcp-core
+ * dispatcher (see lib/mcp-core) is a thin loopback proxy: it forwards the tool
+ * arguments to the real admin route, so every tool inherits the route's admin
+ * authentication, `validateAndTransformBody` validators, and workflow logic —
+ * for free. Wrapping a new endpoint is one row.
+ *
+ * Three safety rails the dispatcher enforces from these flags:
+ *  - `dry_run` (every tool): preview the planned request — and, for writes with
+ *    a `previewPath`, the current object — WITHOUT executing.
+ *  - `sensitive` (+ every DELETE): require `confirm: true`.
+ *  - `dangerous` (platform-destructive): additionally require a human `reason`;
+ *    hidden + refused unless ADMIN_MCP_ENABLE_DANGEROUS is on.
+ *
+ * This is Tier 1 — read-only breadth. Later tiers add partner/storefront,
+ * production, money, CRM/investor, and marketing tools (see epic #1092).
+ */
+import type { McpToolDef } from "../../../../lib/mcp-core"
+
+/** Admin tool definition. Alias of the shared core tool model. */
+export type AdminMcpToolDef = McpToolDef
+
+export { renderToolGuidance } from "../../../../lib/mcp-core"
+
+// ---- Reusable JSON-Schema fragments ---------------------------------------
+
+const STR = (description: string) => ({ type: "string", description })
+
+const obj = (
+  properties: Record<string, any>,
+  required: string[] = []
+): Record<string, any> => ({
+  type: "object",
+  properties,
+  ...(required.length ? { required } : {}),
+  additionalProperties: false,
+})
+
+/** Pagination props shared by list tools. */
+const PAGINATION = {
+  limit: { type: "integer", description: "Max results (default 20)." },
+  offset: { type: "integer", description: "Pagination offset." },
+  q: { type: "string", description: "Free-text search filter." },
+} as const
+
+export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
+  // ===== Grounding =========================================================
+  {
+    name: "get_admin_stats",
+    description:
+      "Get a high-level snapshot of the platform: counts of orders, products, partners, designs, production runs and stores. Call this FIRST to ground yourself before answering operational questions.",
+    method: "GET",
+    path: "/admin/mcp/stats",
+    inputSchema: obj({}),
+  },
+
+  // ===== Orders ============================================================
+  {
+    name: "list_orders",
+    description:
+      "List orders (paginated). Supports free-text search via q. Use to answer 'what orders came in', revenue/volume, and to find an order id.",
+    method: "GET",
+    path: "/admin/orders",
+    queryParams: ["limit", "offset", "q", "status"],
+    inputSchema: obj({
+      ...PAGINATION,
+      status: STR("Optional order status filter."),
+    }),
+  },
+  {
+    name: "get_order",
+    description: "Get a single order by id (line items, totals, fulfillment, payment status).",
+    method: "GET",
+    path: "/admin/orders/:id",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Order id, e.g. 'order_...'.") }, ["id"]),
+  },
+
+  // ===== Catalog ===========================================================
+  {
+    name: "list_products",
+    description: "List products (paginated). Supports free-text search via q.",
+    method: "GET",
+    path: "/admin/products",
+    queryParams: ["limit", "offset", "q"],
+    inputSchema: obj({ ...PAGINATION }),
+  },
+  {
+    name: "get_product",
+    description: "Get a single product by id (variants, options, status).",
+    method: "GET",
+    path: "/admin/products/:id",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Product id, e.g. 'prod_...'.") }, ["id"]),
+  },
+
+  // ===== Customers =========================================================
+  {
+    name: "list_customers",
+    description: "List customers (paginated). Supports free-text search via q.",
+    method: "GET",
+    path: "/admin/customers",
+    queryParams: ["limit", "offset", "q"],
+    inputSchema: obj({ ...PAGINATION }),
+  },
+
+  // ===== Partners & stores =================================================
+  {
+    name: "list_partners",
+    description:
+      "List partners (sellers, manufacturers, makers, designers). Supports free-text search via q. Use to find a partner id or review onboarding status.",
+    method: "GET",
+    path: "/admin/partners",
+    queryParams: ["limit", "offset", "q"],
+    inputSchema: obj({ ...PAGINATION }),
+  },
+  {
+    name: "get_partner",
+    description: "Get a single partner by id (profile, handle, workspace_type, status, metadata).",
+    method: "GET",
+    path: "/admin/partners/:id",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Partner id, e.g. 'partner_...'.") }, ["id"]),
+  },
+  {
+    name: "list_stores",
+    description: "List storefronts / stores configured on the platform.",
+    method: "GET",
+    path: "/admin/stores",
+    queryParams: ["limit", "offset"],
+    inputSchema: obj({ ...PAGINATION }),
+  },
+
+  // ===== Designs & production ==============================================
+  {
+    name: "list_designs",
+    description: "List designs (paginated). Supports free-text search via q.",
+    method: "GET",
+    path: "/admin/designs",
+    queryParams: ["limit", "offset", "q"],
+    inputSchema: obj({ ...PAGINATION }),
+  },
+  {
+    name: "get_design",
+    description: "Get a single design by id (status, sizes, linked product, metadata).",
+    method: "GET",
+    path: "/admin/designs/:id",
+    pathParams: ["id"],
+    inputSchema: obj({ id: STR("Design id, e.g. 'design_...'.") }, ["id"]),
+  },
+  {
+    name: "list_production_runs",
+    description:
+      "List production runs / work orders (paginated). Use to see open runs, their stage and assigned partner.",
+    method: "GET",
+    path: "/admin/production-runs",
+    queryParams: ["limit", "offset", "q", "status"],
+    inputSchema: obj({
+      ...PAGINATION,
+      status: STR("Optional run status filter."),
+    }),
+  },
+
+  // ===== Inventory =========================================================
+  {
+    name: "list_inventory_items",
+    description: "List inventory items (paginated). Supports free-text search via q.",
+    method: "GET",
+    path: "/admin/inventory-items",
+    queryParams: ["limit", "offset", "q"],
+    inputSchema: obj({ ...PAGINATION }),
+  },
+  {
+    name: "list_inventory_orders",
+    description:
+      "List inventory orders (raw-material purchase orders / stock movements), paginated.",
+    method: "GET",
+    path: "/admin/inventory-orders",
+    queryParams: ["limit", "offset", "q", "status"],
+    inputSchema: obj({
+      ...PAGINATION,
+      status: STR("Optional status filter."),
+    }),
+  },
+
+  // ===== Money =============================================================
+  {
+    name: "list_payments",
+    description:
+      "List payments / payout records (paginated). Read-only view of money movement; settling is a later, dangerous tier.",
+    method: "GET",
+    path: "/admin/payments",
+    queryParams: ["limit", "offset", "q"],
+    inputSchema: obj({ ...PAGINATION }),
+  },
+
+  // ===== Marketing & analytics ============================================
+  {
+    name: "list_publishing_campaigns",
+    description: "List publishing / newsletter campaigns (paginated).",
+    method: "GET",
+    path: "/admin/publishing-campaigns",
+    queryParams: ["limit", "offset", "q"],
+    inputSchema: obj({ ...PAGINATION }),
+  },
+  {
+    name: "list_notifications",
+    description: "List platform notifications (paginated). Use to review recent system events.",
+    method: "GET",
+    path: "/admin/notifications",
+    queryParams: ["limit", "offset"],
+    inputSchema: obj({ ...PAGINATION }),
+  },
+]

--- a/apps/backend/src/api/admin/mcp/route.ts
+++ b/apps/backend/src/api/admin/mcp/route.ts
@@ -1,0 +1,19 @@
+/**
+ * POST /admin/mcp — the Admin MCP JSON-RPC endpoint.
+ *
+ * Admin-user authenticated (all /admin/* routes are, via Medusa). Lets MCP
+ * clients — and the in-app admin assistant's confirmation step — drive the
+ * Admin API as tools. Stateless Streamable HTTP: POST only; GET/DELETE → 405.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import {
+  handleAdminMcpRequest,
+  adminMcpMethodNotAllowed,
+} from "./lib/handler"
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  await handleAdminMcpRequest(req, res)
+}
+
+export const GET = adminMcpMethodNotAllowed
+export const DELETE = adminMcpMethodNotAllowed

--- a/apps/backend/src/api/admin/mcp/stats/route.ts
+++ b/apps/backend/src/api/admin/mcp/stats/route.ts
@@ -1,0 +1,45 @@
+/**
+ * GET /admin/mcp/stats — high-level platform snapshot for the Admin MCP's
+ * `get_admin_stats` grounding tool.
+ *
+ * Returns entity counts (orders, products, customers, partners, designs,
+ * production runs, stores) so the assistant can orient before answering
+ * operational questions. Each count is resolved independently and tolerates a
+ * failure (unknown entity, module not loaded) by returning null for that key —
+ * a partial snapshot is more useful to the agent than a 500.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+
+/** query.graph entity names to count, keyed by the label surfaced to the model. */
+const COUNTS: Record<string, string> = {
+  orders: "order",
+  products: "product",
+  customers: "customer",
+  partners: "partner",
+  designs: "design",
+  production_runs: "production_run",
+  stores: "store",
+}
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+
+  const entries = await Promise.all(
+    Object.entries(COUNTS).map(async ([label, entity]) => {
+      try {
+        const { metadata } = await query.graph({
+          entity,
+          fields: ["id"],
+          pagination: { take: 1, skip: 0 },
+        })
+        return [label, (metadata as any)?.count ?? null] as const
+      } catch {
+        // Unknown entity name or module not registered — omit gracefully.
+        return [label, null] as const
+      }
+    })
+  )
+
+  res.json({ stats: Object.fromEntries(entries) })
+}

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -186,6 +186,7 @@ import { AdminRagSearchQuery } from "./admin/ai/rag/search/validators";
 import { AdminAiChatResolveReq, AdminAiChatResolveQuery } from "./admin/ai/chat/resolve/validators";
 import { ListConversationsQuerySchema, ListMessagesQuerySchema, SendMessageSchema, CreateConversationSchema } from "./admin/messaging/validators";
 import { AdminAiChatReq } from "./admin/ai/chat/chat/validators";
+import { AdminAssistantChatSchema } from "./admin/assistant/chat/validators";
 import { AdminPostDesignTaskAssignReq } from "./admin/designs/[id]/tasks/[taskId]/assign/validators";
 import { AdminPostPartnerTaskAssignReq } from "./admin/partners/[id]/tasks/[taskId]/assign/validators";
 import { AdminCreatePartnerTaskReq } from "./admin/partners/[id]/tasks/validators";
@@ -3249,6 +3250,21 @@ export default defineMiddlewares({
       matcher: "/admin/ai/chat/chat",
       method: "POST",
       middlewares: [validateAndTransformBody(wrapSchema(AdminAiChatReq))],
+    },
+
+    // Admin MCP — JSON-RPC endpoint exposing the Admin API as tools (#1092).
+    // Body is JSON-RPC (validated by the MCP transport), so no body validator
+    // here. All /admin/* routes are admin-user authenticated by Medusa.
+    {
+      matcher: "/admin/mcp",
+      method: "POST",
+      middlewares: [],
+    },
+    // Admin agentic assistant — streaming tool-caller over the Admin MCP registry.
+    {
+      matcher: "/admin/assistant/chat",
+      method: "POST",
+      middlewares: [validateAndTransformBody(wrapSchema(AdminAssistantChatSchema))],
     },
 
     {

--- a/apps/backend/src/api/partners/mcp/lib/dispatch.ts
+++ b/apps/backend/src/api/partners/mcp/lib/dispatch.ts
@@ -1,244 +1,36 @@
 /**
- * Shared Partner-MCP tool dispatcher.
+ * Partner-MCP tool dispatcher — thin wrapper over the shared mcp-core.
  *
- * One function, `dispatchPartnerTool`, runs a registry tool against the real
- * partner route via the loopback proxy. It is the single execution path for
- * BOTH consumers:
- *   - the JSON-RPC MCP endpoint (POST /partners/mcp), and
- *   - the in-app streaming assistant (POST /partners/assistant/chat), whose
- *     AI-SDK tools' `execute` delegate straight here.
- *
- * It enforces the two safety rails declared in the registry:
- *   - dry_run  → return the planned request (+ current object for writes with a
- *                previewPath) without executing.
- *   - sensitive/DELETE → require `confirm: true`; otherwise return a
- *                `requires_confirmation` plan for the UI to approve.
+ * The dispatch logic and the two safety rails (dry_run preview, sensitive/DELETE
+ * confirmation) now live in `lib/mcp-core`. This module binds the core
+ * dispatcher to the Partner registry and stamps the "partner" surface, and
+ * re-exports the schema helpers so existing imports (chat route, tests) keep
+ * working. It is the single execution path for both the JSON-RPC MCP endpoint
+ * and the in-app assistant.
  */
-import { PARTNER_MCP_TOOLS, type PartnerMcpToolDef } from "./registry"
-import { callPartnerRoute, type PartnerProxyError } from "./proxy"
+import {
+  dispatchMcpTool,
+  type McpContext,
+  type McpToolResult,
+} from "../../../../lib/mcp-core"
+import { PARTNER_MCP_TOOLS } from "./registry"
 
-export type PartnerMcpContext = {
-  /** Backend origin for loopback calls, e.g. http://localhost:9000. */
-  baseUrl: string
-  /** Partner JWT to forward so the wrapped route authenticates. */
-  bearer?: string
-  /** Session cookie to forward when the caller authed via cookie. */
-  cookie?: string
-  /**
-   * When false, write tools (non-GET) are refused. Defaults to true for the
-   * partner assistant — the partner acts on their own tenant — but a deployment
-   * can force read-only via PARTNER_MCP_ENABLE_WRITE=false.
-   */
-  enableWrite?: boolean
-}
+export { buildToolInputSchema, isSensitive } from "../../../../lib/mcp-core"
 
-/** Structured tool result. `ok:false` is a soft error (returned, not thrown). */
-export type PartnerToolResult = {
-  ok: boolean
-  tool: string
-  /** Successful response payload. */
-  data?: unknown
-  /** Soft error message. */
-  error?: string
-  /** Set when dry_run echoed the plan instead of executing. */
-  dry_run?: boolean
-  /** Set when a sensitive tool needs `confirm: true` before it will run. */
-  requires_confirmation?: boolean
-  /** The request that would be / was sent — { method, path, query, body }. */
-  plan?: Record<string, unknown>
-  /** Current object (writes with a previewPath, during dry_run/confirmation). */
-  current?: unknown
-  /** Human-readable warning for sensitive actions. */
-  warning?: string
-}
-
-/** A tool is sensitive if flagged, or if it is a DELETE (implicitly). */
-export const isSensitive = (def: PartnerMcpToolDef): boolean =>
-  !!def.sensitive || def.method === "DELETE"
-
-/**
- * Build the full JSON Schema for a tool, injecting the framework args
- * (`dry_run`, and `confirm` for sensitive tools) onto the domain schema. Used
- * by both `tools/list` and the chat route's tool binding so the model/clients
- * know these switches exist.
- */
-export const buildToolInputSchema = (
-  def: PartnerMcpToolDef
-): Record<string, any> => {
-  const base = def.inputSchema || { type: "object", properties: {} }
-  const properties = { ...(base.properties || {}) }
-
-  // Injected on EVERY tool. Lets the model state what it is trying to
-  // accomplish — most valuable for multi-step goals where several tools are
-  // called in sequence (e.g. creating a store, then a product, then pricing).
-  // Forwarded to the route as the `x-mcp-context` header for telemetry and
-  // echoed on dry_run/confirmation plans so approval cards show intent.
-  properties.context = {
-    type: "string",
-    description:
-      "One sentence on what you are ultimately trying to accomplish with this call (and the broader goal if this is one step of several). Always set it — it improves results and helps diagnose multi-step flows.",
-  }
-
-  properties.dry_run = {
-    type: "boolean",
-    description:
-      "Preview only: return the planned request (and, for writes, the current object) WITHOUT executing. Use this to inspect data before making a change.",
-  }
-  if (isSensitive(def)) {
-    properties.confirm = {
-      type: "boolean",
-      description:
-        "This is a sensitive/destructive action. It will NOT run unless confirm=true. Do not set this yourself — the user must approve it.",
-    }
-  }
-
-  return { ...base, properties }
-}
-
-const substitutePath = (
-  template: string,
-  params: string[],
-  args: Record<string, unknown>
-): { path?: string; missing?: string } => {
-  let path = template
-  for (const p of params) {
-    const value = args[p]
-    if (value === undefined || value === null || value === "") {
-      return { missing: p }
-    }
-    path = path.replace(`:${p}`, encodeURIComponent(String(value)))
-  }
-  return { path }
-}
-
-const pick = (
-  keys: string[] | undefined,
-  args: Record<string, unknown>
-): Record<string, unknown> => {
-  const out: Record<string, unknown> = {}
-  for (const k of keys ?? []) {
-    if (args[k] !== undefined && args[k] !== null) {
-      out[k] = args[k]
-    }
-  }
-  return out
-}
-
-const fail = (tool: string, error: string): PartnerToolResult => ({
-  ok: false,
-  tool,
-  error,
-})
+/** Partner dispatch context (auth + write flag). Alias of the core context. */
+export type PartnerMcpContext = McpContext
+/** Structured tool result. Alias of the core result. */
+export type PartnerToolResult = McpToolResult
 
 export async function dispatchPartnerTool(
   ctx: PartnerMcpContext,
   name: string,
   rawArgs: Record<string, unknown> = {}
 ): Promise<PartnerToolResult> {
-  const def = PARTNER_MCP_TOOLS.find((t) => t.name === name)
-  if (!def) {
-    return fail(name, `Unknown tool: ${name}`)
-  }
-
-  const args = rawArgs || {}
-  const dryRun = args.dry_run === true
-  const confirmed = args.confirm === true
-  const context = typeof args.context === "string" ? args.context : undefined
-  const write = !!def.write
-  const sensitive = isSensitive(def)
-
-  if (write && ctx.enableWrite === false) {
-    return fail(
-      name,
-      `Tool '${name}' is a write tool and writes are disabled on this server (PARTNER_MCP_ENABLE_WRITE=false).`
-    )
-  }
-
-  // Substitute path params for the target route.
-  const sub = substitutePath(def.path as string, def.pathParams ?? [], args)
-  if (sub.missing) {
-    return fail(name, `Missing required parameter: ${sub.missing}`)
-  }
-  const path = sub.path as string
-  const query = pick(def.queryParams, args)
-  const body = pick(def.bodyParams, args)
-  const method = def.method ?? "GET"
-
-  const plan = {
-    method,
-    path,
-    ...(Object.keys(query).length ? { query } : {}),
-    ...(Object.keys(body).length ? { body } : {}),
-    ...(context ? { context } : {}),
-  }
-
-  // Fetch the current object for writes that declare a previewPath — so the
-  // model (or the confirmation card) can show what is about to change.
-  const fetchCurrent = async (): Promise<unknown> => {
-    if (!def.previewPath) return undefined
-    const psub = substitutePath(def.previewPath, def.pathParams ?? [], args)
-    if (psub.missing) return undefined
-    try {
-      return await callPartnerRoute({
-        baseUrl: ctx.baseUrl,
-        method: "GET",
-        path: psub.path as string,
-        bearer: ctx.bearer,
-        cookie: ctx.cookie,
-      })
-    } catch {
-      return undefined
-    }
-  }
-
-  // --- Dry run: never execute -------------------------------------------------
-  if (dryRun) {
-    const current = write ? await fetchCurrent() : undefined
-    return {
-      ok: true,
-      tool: name,
-      dry_run: true,
-      plan,
-      ...(current !== undefined ? { current } : {}),
-      warning: sensitive
-        ? "This is a sensitive action; when you run it for real it will require the user's confirmation."
-        : undefined,
-    }
-  }
-
-  // --- Sensitive gate: require explicit confirm -------------------------------
-  if (sensitive && !confirmed) {
-    const current = await fetchCurrent()
-    return {
-      ok: true,
-      tool: name,
-      requires_confirmation: true,
-      plan,
-      ...(current !== undefined ? { current } : {}),
-      warning: `'${name}' is a sensitive action and needs explicit confirmation before it runs.`,
-    }
-  }
-
-  // --- Execute for real -------------------------------------------------------
-  try {
-    const data = await callPartnerRoute({
-      baseUrl: ctx.baseUrl,
-      method,
-      path,
-      query,
-      body,
-      bearer: ctx.bearer,
-      cookie: ctx.cookie,
-      context,
-    })
-    const out = def.transform ? def.transform(data, args) : data
-    return { ok: true, tool: name, data: out }
-  } catch (e) {
-    const err = e as PartnerProxyError
-    return {
-      ok: false,
-      tool: name,
-      error: `Error calling ${name} (${path}): ${err.message}`,
-    }
-  }
+  return dispatchMcpTool(
+    { ...ctx, surface: "partner" },
+    PARTNER_MCP_TOOLS,
+    name,
+    rawArgs
+  )
 }

--- a/apps/backend/src/api/partners/mcp/lib/handler.ts
+++ b/apps/backend/src/api/partners/mcp/lib/handler.ts
@@ -2,35 +2,30 @@
  * Shared request handler for the Partner MCP transport, mounted at
  * POST /partners/mcp (partner-authenticated via middlewares.ts).
  *
- * Stateless Streamable HTTP: each POST is a self-contained JSON-RPC request.
- * The calling partner's auth (JWT bearer and/or session cookie) is captured
- * here and forwarded on every loopback proxy call, so the wrapped `/partners/*`
- * routes authenticate and scope to that partner.
+ * Thin wrapper over the shared mcp-core transport helpers: build a
+ * partner-scoped server (auth captured from the request) and hand Medusa's
+ * already-parsed JSON-RPC body to the stateless Streamable-HTTP transport.
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js"
+import {
+  handleMcpJsonRpc,
+  mcpMethodNotAllowed,
+  resolveLoopbackBaseUrl,
+  envFlagDefaultTrue,
+} from "../../../../lib/mcp-core"
 import { buildPartnerMcpServer } from "./server"
 
 /** Writes are on by default; a deployment can force read-only. */
 export function isPartnerWriteEnabled(): boolean {
-  const v = (process.env.PARTNER_MCP_ENABLE_WRITE || "").trim().toLowerCase()
-  if (v === "false" || v === "0" || v === "no") return false
-  return true
+  return envFlagDefaultTrue("PARTNER_MCP_ENABLE_WRITE")
 }
 
 /**
  * Loopback origin for proxying to /partners/* on this same process. Derived
- * from the incoming request by default (`proto://host`); override with
- * PARTNER_MCP_LOOPBACK_URL (e.g. http://localhost:9000) to skip a hop.
+ * from the incoming request by default; override with PARTNER_MCP_LOOPBACK_URL.
  */
 export function resolvePartnerBaseUrl(req: MedusaRequest): string {
-  const override = process.env.PARTNER_MCP_LOOPBACK_URL
-  if (override) return override.replace(/\/$/, "")
-  const proto = (req.protocol || "http").split(",")[0].trim()
-  const host = req.get("host")
-  if (host) return `${proto}://${host}`
-  const port = process.env.PORT || "9000"
-  return `http://localhost:${port}`
+  return resolveLoopbackBaseUrl(req, "PARTNER_MCP_LOOPBACK_URL")
 }
 
 export async function handlePartnerMcpRequest(
@@ -43,33 +38,12 @@ export async function handlePartnerMcpRequest(
     cookie: req.get("cookie") || undefined,
     enableWrite: isPartnerWriteEnabled(),
   })
-
-  const transport = new StreamableHTTPServerTransport({
-    sessionIdGenerator: undefined, // stateless: each POST is self-contained
-    enableJsonResponse: true, // return a plain JSON-RPC body, not an SSE stream
-  })
-
-  res.on("close", () => {
-    transport.close()
-    server.close()
-  })
-
-  await server.connect(transport)
-  // Medusa's body parser has already consumed the stream, so hand the parsed
-  // body to the transport explicitly.
-  await transport.handleRequest(req as any, res as any, (req as any).body)
+  await handleMcpJsonRpc(req, res, server)
 }
 
 export function partnerMcpMethodNotAllowed(
-  _req: MedusaRequest,
+  req: MedusaRequest,
   res: MedusaResponse
 ): void {
-  res.status(405).json({
-    jsonrpc: "2.0",
-    error: {
-      code: -32000,
-      message: "Method not allowed. This MCP endpoint is stateless; use POST.",
-    },
-    id: null,
-  })
+  mcpMethodNotAllowed(req, res)
 }

--- a/apps/backend/src/api/partners/mcp/lib/proxy.ts
+++ b/apps/backend/src/api/partners/mcp/lib/proxy.ts
@@ -1,101 +1,10 @@
 /**
- * Loopback proxy to the Partner API.
- *
- * Partner MCP tools call this to forward their arguments to a real
- * `/partners/*` route over HTTP on the same process, attaching the calling
- * partner's auth (JWT bearer and/or session cookie). Going through HTTP — vs
- * re-implementing the logic here — means every tool inherits the exact
- * middleware the partner route already runs: `authenticate("partner", …)`
- * ownership scoping, `validateAndTransformBody` validators, and any custom
- * route logic. Wrapping a new partner endpoint becomes a single registry row.
+ * Loopback proxy to the Partner API — thin re-export of the shared mcp-core
+ * proxy. Kept as a surface-local module so existing `callPartnerRoute` imports
+ * keep working; the implementation is now the generic `callMcpRoute`.
  */
-import qs from "qs"
-
-export type PartnerProxyArgs = {
-  /** Base origin of this backend, e.g. http://localhost:9000 (no trailing slash). */
-  baseUrl: string
-  /** HTTP method. Defaults to GET (read tools). */
-  method?: "GET" | "POST" | "PUT" | "DELETE"
-  /** Partner route path with params already substituted, e.g. /partners/products/prod_1. */
-  path: string
-  /** Query params to forward. Arrays are serialized as key[]=a&key[]=b. */
-  query?: Record<string, unknown>
-  /**
-   * JSON request body for write tools. Sent as application/json. The partner
-   * route's own `validateAndTransformBody` validator runs on it, so the
-   * MCP-side schema stays permissive and Medusa remains the source of truth.
-   */
-  body?: Record<string, unknown>
-  /** Partner auth header to forward (JWT). Required for authenticated routes. */
-  bearer?: string
-  /** Optional session cookie to forward when the caller authed via cookie. */
-  cookie?: string
-  /**
-   * Optional agent intent ("what am I trying to accomplish") forwarded as the
-   * `x-mcp-context` header. Purely informational — routes/telemetry can log it
-   * to understand multi-step tool sequences; it never affects route logic.
-   */
-  context?: string
-}
-
-export type PartnerProxyError = Error & { status?: number; body?: unknown }
-
-export async function callPartnerRoute({
-  baseUrl,
-  method = "GET",
-  path,
-  query,
-  body,
-  bearer,
-  cookie,
-  context,
-}: PartnerProxyArgs): Promise<unknown> {
-  const qstr =
-    query && Object.keys(query).length
-      ? `?${qs.stringify(query, { arrayFormat: "brackets", skipNulls: true })}`
-      : ""
-  const url = `${baseUrl}${path}${qstr}`
-
-  const headers: Record<string, string> = { accept: "application/json" }
-  if (bearer) {
-    headers["authorization"] = bearer.toLowerCase().startsWith("bearer ")
-      ? bearer
-      : `Bearer ${bearer}`
-  }
-  if (cookie) {
-    headers["cookie"] = cookie
-  }
-  if (context) {
-    // Truncate defensively — this is a header, not a payload.
-    headers["x-mcp-context"] = context.slice(0, 1024)
-  }
-
-  const init: RequestInit = { method, headers }
-  // Attach a JSON body for writes. GET never carries a body.
-  if (method !== "GET" && body && Object.keys(body).length) {
-    headers["content-type"] = "application/json"
-    init.body = JSON.stringify(body)
-  }
-
-  const resp = await fetch(url, init)
-  const text = await resp.text()
-
-  let json: any = null
-  try {
-    json = text ? JSON.parse(text) : null
-  } catch {
-    json = { raw: text }
-  }
-
-  if (!resp.ok) {
-    const message = json?.message || json?.type || `HTTP ${resp.status}`
-    const err: PartnerProxyError = new Error(
-      `Partner route ${path} responded ${resp.status}: ${message}`
-    )
-    err.status = resp.status
-    err.body = json
-    throw err
-  }
-
-  return json
-}
+export {
+  callMcpRoute as callPartnerRoute,
+  type McpProxyArgs as PartnerProxyArgs,
+  type McpProxyError as PartnerProxyError,
+} from "../../../../lib/mcp-core"

--- a/apps/backend/src/api/partners/mcp/lib/registry.ts
+++ b/apps/backend/src/api/partners/mcp/lib/registry.ts
@@ -21,68 +21,21 @@
  *    the UI can surface an approval card. Everything else executes directly.
  */
 
-export type PartnerMcpToolDef = {
-  /** Tool name surfaced to the agent (snake_case). */
-  name: string
-  /** One-line description shown in `tools/list` and to the model. */
-  description: string
-  /** JSON Schema for the domain arguments (dry_run/confirm are injected). */
-  inputSchema: Record<string, any>
-  /** HTTP method of the wrapped partner route. GET = read (always exposed). */
-  method?: "GET" | "POST" | "PUT" | "DELETE"
-  /** Partner route path, with `:param` placeholders, e.g. `/partners/products/:id`. */
-  path?: string
-  /** Names of `:param` placeholders that must be supplied as arguments. */
-  pathParams?: string[]
-  /** Argument keys forwarded to the route as query-string params. */
-  queryParams?: string[]
-  /** Argument keys assembled into the JSON request body (write tools only). */
-  bodyParams?: string[]
-  /** Non-GET tool: gated behind the write flag on the server. */
-  write?: boolean
-  /**
-   * High-stakes mutation: requires `confirm: true` to execute. Called without
-   * it, the dispatcher returns a `requires_confirmation` plan. Every DELETE is
-   * treated as sensitive implicitly; set this to flag sensitive POST/PUTs too.
-   */
-  sensitive?: boolean
-  /**
-   * Companion GET path (same `:param` substitution) used during `dry_run` to
-   * fetch the current object so the model can see what it is about to change.
-   */
-  previewPath?: string
-  /** Optional pure post-processor applied to a successful response. */
-  transform?: (data: any, args: Record<string, unknown>) => any
-  /**
-   * One-line note about non-obvious effects of running this tool (state it
-   * leaves behind, what it does NOT do). Rendered into the model-facing
-   * description so the agent reasons about the tool's real footprint — e.g.
-   * "creates the product in draft with variants + inventory items; does not
-   * publish or set stock quantities."
-   */
-  sideEffects?: string
-  /**
-   * Tool names the agent typically calls after this one to complete the task.
-   * Rendered into the description as a hint (not enforced). Keep these to real
-   * follow-ups a partner would expect — publishing, pricing, stock — not an
-   * exhaustive graph. HARD invariants (a managed variant MUST have a stock
-   * level) belong in the route, not here.
-   */
-  nextSteps?: string[]
-}
+import type { McpToolDef } from "../../../../lib/mcp-core"
+
+/**
+ * Partner tool definition. The declarative model now lives in the shared
+ * mcp-core (one type reused by store/partner/admin); `PartnerMcpToolDef` stays
+ * as the surface-local alias so existing imports keep working.
+ */
+export type PartnerMcpToolDef = McpToolDef
 
 /**
  * Fold the declarative guidance fields (`sideEffects`, `nextSteps`) into a
- * short suffix appended to the model-facing description. Single source of truth
- * so the chat route AND the MCP server render identical guidance. Returns "" when
- * a tool declares neither, so untouched tools are unaffected.
+ * short suffix appended to the model-facing description. Re-exported from the
+ * shared core so the chat route AND the MCP server render identical guidance.
  */
-export const renderToolGuidance = (def: PartnerMcpToolDef): string => {
-  const parts: string[] = []
-  if (def.sideEffects) parts.push(`Side effects: ${def.sideEffects}`)
-  if (def.nextSteps?.length) parts.push(`Usually followed by: ${def.nextSteps.join(", ")}.`)
-  return parts.length ? `\n${parts.join(" ")}` : ""
-}
+export { renderToolGuidance } from "../../../../lib/mcp-core"
 
 // ---- Reusable JSON-Schema fragments ---------------------------------------
 

--- a/apps/backend/src/api/partners/mcp/lib/server.ts
+++ b/apps/backend/src/api/partners/mcp/lib/server.ts
@@ -1,29 +1,15 @@
 /**
- * Builds the Partner MCP server.
+ * Builds the Partner MCP server — thin wrapper over the shared mcp-core.
  *
- * Uses the low-level `Server` + `setRequestHandler` API (not the high-level
- * `McpServer.registerTool`) so tool input schemas stay as plain JSON Schema and
- * we avoid coupling to a specific zod version.
- *
- * Every tool is a loopback proxy to a live `/partners/*` route (see
- * dispatch.ts / proxy.ts), authenticated with the forwarded partner JWT — so it
- * inherits the route's ownership scoping, validators and workflow logic. The
- * two safety rails (dry_run preview, sensitive/DELETE confirmation) live in the
- * shared dispatcher, so the JSON-RPC endpoint and the in-app assistant behave
- * identically.
+ * The generic JSON-RPC server (tools/list + tools/call over a registry, with
+ * the dry_run/confirm rails in the shared dispatcher) lives in `lib/mcp-core`.
+ * This module supplies the Partner registry, server identity and instructions,
+ * and stamps the "partner" surface.
  */
 import { Server } from "@modelcontextprotocol/sdk/server/index.js"
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js"
-import { PARTNER_MCP_TOOLS, renderToolGuidance } from "./registry"
-import {
-  dispatchPartnerTool,
-  buildToolInputSchema,
-  isSensitive,
-  type PartnerMcpContext,
-} from "./dispatch"
+import { buildMcpServer } from "../../../../lib/mcp-core"
+import { PARTNER_MCP_TOOLS } from "./registry"
+import type { PartnerMcpContext } from "./dispatch"
 
 const SERVER_INFO = { name: "jyt-partner", version: "0.1.0" } as const
 
@@ -36,38 +22,9 @@ const INSTRUCTIONS =
   "explicit `confirm: true` — surface them to the user for approval rather than " +
   "confirming on their behalf. Start by calling get_partner_profile."
 
-const textResult = (text: string, isError = false) => ({
-  content: [{ type: "text" as const, text }],
-  ...(isError ? { isError: true } : {}),
-})
-
 export function buildPartnerMcpServer(ctx: PartnerMcpContext): Server {
-  const server = new Server(SERVER_INFO, {
-    capabilities: { tools: {} },
+  return buildMcpServer({ ...ctx, surface: "partner" }, PARTNER_MCP_TOOLS, {
+    serverInfo: SERVER_INFO,
     instructions: INSTRUCTIONS,
   })
-
-  const writeEnabled = ctx.enableWrite !== false
-  const visibleTools = PARTNER_MCP_TOOLS.filter(
-    (t) => writeEnabled || !t.write
-  )
-
-  server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: visibleTools.map((t) => ({
-      name: t.name,
-      description:
-        t.description +
-        (isSensitive(t) ? " [sensitive: requires confirm:true]" : "") +
-        renderToolGuidance(t),
-      inputSchema: buildToolInputSchema(t),
-    })),
-  }))
-
-  server.setRequestHandler(CallToolRequestSchema, async (req) => {
-    const args = (req.params.arguments ?? {}) as Record<string, unknown>
-    const result = await dispatchPartnerTool(ctx, req.params.name, args)
-    return textResult(JSON.stringify(result, null, 2), !result.ok)
-  })
-
-  return server
 }

--- a/apps/backend/src/lib/mcp-core/dispatch.ts
+++ b/apps/backend/src/lib/mcp-core/dispatch.ts
@@ -1,0 +1,227 @@
+/**
+ * Shared MCP core — tool dispatcher.
+ *
+ * `dispatchMcpTool(ctx, tools, name, args)` runs one registry tool against its
+ * real route via the loopback proxy. It is the single execution path for BOTH
+ * consumers of every surface:
+ *   - the JSON-RPC MCP endpoint (POST /{surface}/mcp), and
+ *   - the in-app streaming assistant, whose AI-SDK tools' `execute` delegate
+ *     straight here.
+ *
+ * It enforces three safety rails declared in the registry:
+ *   - dry_run   → return the planned request (+ current object for writes with
+ *                 a previewPath) without executing.
+ *   - confirm   → sensitive/DELETE tools require `confirm: true`; otherwise a
+ *                 `requires_confirmation` plan is returned for UI approval.
+ *   - reason    → dangerous tools additionally refuse without a `reason` string
+ *                 (forwarded as x-mcp-reason and audited); also require confirm.
+ *
+ * Each call emits one observability event through `ctx.observe` (#844).
+ */
+import type {
+  McpContext,
+  McpToolDef,
+  McpToolEvent,
+  McpToolResult,
+} from "./types"
+import { isDangerous, isSensitive } from "./schema"
+import { callMcpRoute, type McpProxyError } from "./proxy"
+
+const substitutePath = (
+  template: string,
+  params: string[],
+  args: Record<string, unknown>
+): { path?: string; missing?: string } => {
+  let path = template
+  for (const p of params) {
+    const value = args[p]
+    if (value === undefined || value === null || value === "") {
+      return { missing: p }
+    }
+    path = path.replace(`:${p}`, encodeURIComponent(String(value)))
+  }
+  return { path }
+}
+
+const pick = (
+  keys: string[] | undefined,
+  args: Record<string, unknown>
+): Record<string, unknown> => {
+  const out: Record<string, unknown> = {}
+  for (const k of keys ?? []) {
+    if (args[k] !== undefined && args[k] !== null) {
+      out[k] = args[k]
+    }
+  }
+  return out
+}
+
+export async function dispatchMcpTool(
+  ctx: McpContext,
+  tools: McpToolDef[],
+  name: string,
+  rawArgs: Record<string, unknown> = {}
+): Promise<McpToolResult> {
+  const surface = ctx.surface ?? "mcp"
+  const emit = (evt: Omit<McpToolEvent, "surface" | "tool">) =>
+    ctx.observe?.({ surface, tool: name, ...evt })
+  const fail = (error: string, outcome = "refused"): McpToolResult => {
+    emit({ method: "", executed: false, ok: false, outcome, error })
+    return { ok: false, tool: name, error }
+  }
+
+  const def = tools.find((t) => t.name === name)
+  if (!def) {
+    return fail(`Unknown tool: ${name}`)
+  }
+
+  const args = rawArgs || {}
+  const dryRun = args.dry_run === true
+  const confirmed = args.confirm === true
+  const context = typeof args.context === "string" ? args.context : undefined
+  const reason =
+    typeof args.reason === "string" && args.reason.trim()
+      ? args.reason.trim()
+      : undefined
+  const write = !!def.write
+  const sensitive = isSensitive(def)
+  const dangerous = isDangerous(def)
+
+  if (write && ctx.enableWrite === false) {
+    return fail(
+      `Tool '${name}' is a write tool and writes are disabled on this server.`
+    )
+  }
+  // Dangerous tools are hidden + refused when the surface hasn't opted in.
+  if (dangerous && ctx.enableDangerous === false) {
+    return fail(
+      `Tool '${name}' is a platform-destructive action and dangerous tools are disabled on this server.`
+    )
+  }
+
+  // Substitute path params for the target route.
+  const sub = substitutePath(def.path as string, def.pathParams ?? [], args)
+  if (sub.missing) {
+    return fail(`Missing required parameter: ${sub.missing}`)
+  }
+  const path = sub.path as string
+  const query = pick(def.queryParams, args)
+  const body = pick(def.bodyParams, args)
+  const method = def.method ?? "GET"
+
+  const plan = {
+    method,
+    path,
+    ...(Object.keys(query).length ? { query } : {}),
+    ...(Object.keys(body).length ? { body } : {}),
+    ...(context ? { context } : {}),
+    ...(reason ? { reason } : {}),
+  }
+
+  // Fetch the current object for writes that declare a previewPath — so the
+  // model (or the confirmation card) can show what is about to change.
+  const fetchCurrent = async (): Promise<unknown> => {
+    if (!def.previewPath) return undefined
+    const psub = substitutePath(def.previewPath, def.pathParams ?? [], args)
+    if (psub.missing) return undefined
+    try {
+      return await callMcpRoute({
+        baseUrl: ctx.baseUrl,
+        method: "GET",
+        path: psub.path as string,
+        bearer: ctx.bearer,
+        cookie: ctx.cookie,
+      })
+    } catch {
+      return undefined
+    }
+  }
+
+  // --- Dry run: never execute -------------------------------------------------
+  if (dryRun) {
+    const current = write ? await fetchCurrent() : undefined
+    emit({ method, path, executed: false, ok: true, outcome: "dry_run", context })
+    return {
+      ok: true,
+      tool: name,
+      dry_run: true,
+      plan,
+      ...(current !== undefined ? { current } : {}),
+      warning: dangerous
+        ? "This is a platform-destructive action; running it will require the user's confirmation AND a reason."
+        : sensitive
+        ? "This is a sensitive action; when you run it for real it will require the user's confirmation."
+        : undefined,
+    }
+  }
+
+  // --- Dangerous gate: require a human reason ---------------------------------
+  if (dangerous && !reason) {
+    const current = await fetchCurrent()
+    emit({ method, path, executed: false, ok: true, outcome: "reason", context })
+    return {
+      ok: true,
+      tool: name,
+      requires_reason: true,
+      requires_confirmation: true,
+      plan,
+      ...(current !== undefined ? { current } : {}),
+      warning: `'${name}' is a platform-destructive action. It needs an explicit reason (why this is being done) and the user's confirmation before it runs.`,
+    }
+  }
+
+  // --- Sensitive gate: require explicit confirm -------------------------------
+  if (sensitive && !confirmed) {
+    const current = await fetchCurrent()
+    emit({ method, path, executed: false, ok: true, outcome: "confirm", context })
+    return {
+      ok: true,
+      tool: name,
+      requires_confirmation: true,
+      plan,
+      ...(current !== undefined ? { current } : {}),
+      warning: `'${name}' is a sensitive action and needs explicit confirmation before it runs.`,
+    }
+  }
+
+  // --- Execute for real -------------------------------------------------------
+  const startedAt = Date.now()
+  try {
+    const data = await callMcpRoute({
+      baseUrl: ctx.baseUrl,
+      method,
+      path,
+      query,
+      body,
+      bearer: ctx.bearer,
+      cookie: ctx.cookie,
+      context,
+      reason,
+    })
+    const out = def.transform ? def.transform(data, args) : data
+    emit({
+      method,
+      path,
+      executed: true,
+      ok: true,
+      outcome: "run",
+      ms: Date.now() - startedAt,
+      context,
+    })
+    return { ok: true, tool: name, data: out }
+  } catch (e) {
+    const err = e as McpProxyError
+    const error = `Error calling ${name} (${path}): ${err.message}`
+    emit({
+      method,
+      path,
+      executed: true,
+      ok: false,
+      outcome: "run",
+      ms: Date.now() - startedAt,
+      error: err.message,
+      context,
+    })
+    return { ok: false, tool: name, error }
+  }
+}

--- a/apps/backend/src/lib/mcp-core/handler.ts
+++ b/apps/backend/src/lib/mcp-core/handler.ts
@@ -1,0 +1,79 @@
+/**
+ * Shared MCP core — HTTP transport helpers.
+ *
+ * Each surface's `POST /{surface}/mcp` route is stateless Streamable HTTP: one
+ * self-contained JSON-RPC request per POST. `handleMcpJsonRpc` wires a freshly
+ * built server (with the caller's auth captured in its context) to the
+ * transport and hands Medusa's already-parsed body to it. `resolveLoopbackBaseUrl`
+ * and `mcpMethodNotAllowed` are the shared bits every surface's handler reuses.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js"
+import { Server } from "@modelcontextprotocol/sdk/server/index.js"
+
+/** Parse a boolean env flag; defaults to `true` unless explicitly falsey. */
+export function envFlagDefaultTrue(name: string): boolean {
+  const v = (process.env[name] || "").trim().toLowerCase()
+  if (v === "false" || v === "0" || v === "no") return false
+  return true
+}
+
+/** Parse a boolean env flag; defaults to `false` unless explicitly truthy. */
+export function envFlagDefaultFalse(name: string): boolean {
+  const v = (process.env[name] || "").trim().toLowerCase()
+  return v === "true" || v === "1" || v === "yes"
+}
+
+/**
+ * Loopback origin for proxying to routes on this same process. Derived from the
+ * incoming request by default (`proto://host`); override with the given env var
+ * (e.g. http://localhost:9000) to skip a hop.
+ */
+export function resolveLoopbackBaseUrl(
+  req: MedusaRequest,
+  overrideEnvVar?: string
+): string {
+  const override = overrideEnvVar ? process.env[overrideEnvVar] : undefined
+  if (override) return override.replace(/\/$/, "")
+  const proto = (req.protocol || "http").split(",")[0].trim()
+  const host = req.get("host")
+  if (host) return `${proto}://${host}`
+  const port = process.env.PORT || "9000"
+  return `http://localhost:${port}`
+}
+
+/** Wire a built MCP server to a stateless Streamable-HTTP transport. */
+export async function handleMcpJsonRpc(
+  req: MedusaRequest,
+  res: MedusaResponse,
+  server: Server
+): Promise<void> {
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: undefined, // stateless: each POST is self-contained
+    enableJsonResponse: true, // return a plain JSON-RPC body, not an SSE stream
+  })
+
+  res.on("close", () => {
+    transport.close()
+    server.close()
+  })
+
+  await server.connect(transport)
+  // Medusa's body parser has already consumed the stream, so hand the parsed
+  // body to the transport explicitly.
+  await transport.handleRequest(req as any, res as any, (req as any).body)
+}
+
+export function mcpMethodNotAllowed(
+  _req: MedusaRequest,
+  res: MedusaResponse
+): void {
+  res.status(405).json({
+    jsonrpc: "2.0",
+    error: {
+      code: -32000,
+      message: "Method not allowed. This MCP endpoint is stateless; use POST.",
+    },
+    id: null,
+  })
+}

--- a/apps/backend/src/lib/mcp-core/index.ts
+++ b/apps/backend/src/lib/mcp-core/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared MCP core — barrel.
+ *
+ * One declarative tool model + dispatch/proxy/schema/server/observability,
+ * reused by every MCP surface (store, partner, admin). A surface supplies its
+ * own `McpToolDef[]` registry and an auth-scoped `McpContext`; the core owns
+ * execution and the safety rails (dry_run / confirm / reason).
+ */
+export type {
+  McpMethod,
+  McpToolDef,
+  McpContext,
+  McpToolResult,
+  McpToolEvent,
+} from "./types"
+export {
+  isSensitive,
+  isDangerous,
+  renderToolGuidance,
+  buildToolInputSchema,
+} from "./schema"
+export { dispatchMcpTool } from "./dispatch"
+export { callMcpRoute, type McpProxyArgs, type McpProxyError } from "./proxy"
+export { buildMcpServer, type BuildMcpServerOptions } from "./server"
+export {
+  handleMcpJsonRpc,
+  mcpMethodNotAllowed,
+  resolveLoopbackBaseUrl,
+  envFlagDefaultTrue,
+  envFlagDefaultFalse,
+} from "./handler"
+export { makeMcpLogSink } from "./observability"

--- a/apps/backend/src/lib/mcp-core/observability.ts
+++ b/apps/backend/src/lib/mcp-core/observability.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared MCP core — observability seam (#844).
+ *
+ * The dispatcher emits one `McpToolEvent` per call through `ctx.observe`. This
+ * module gives surfaces a ready-made sink that logs a structured line via the
+ * Medusa logger — usage, latency, outcome, per-surface. It is intentionally
+ * thin: the fuller work of #844 (persisting to the `ai_usage` ledger for
+ * cross-surface reporting) plugs in here by swapping/extending `makeMcpLogSink`
+ * without touching the dispatcher or any registry.
+ */
+import type { McpToolEvent } from "./types"
+
+type MinimalLogger = {
+  info?: (msg: string) => void
+  warn?: (msg: string) => void
+  error?: (msg: string) => void
+}
+
+/**
+ * Build an observe() sink that logs each tool call as a single structured line.
+ * `warn` for soft errors, `info` otherwise. Safe to pass a partial logger.
+ */
+export const makeMcpLogSink =
+  (logger: MinimalLogger | undefined) =>
+  (evt: McpToolEvent): void => {
+    if (!logger) return
+    const line =
+      `[mcp:${evt.surface}] ${evt.tool} ${evt.method} ${evt.path ?? ""}` +
+      ` outcome=${evt.outcome} executed=${evt.executed} ok=${evt.ok}` +
+      (evt.ms !== undefined ? ` ms=${evt.ms}` : "") +
+      (evt.error ? ` error=${JSON.stringify(evt.error)}` : "") +
+      (evt.context ? ` context=${JSON.stringify(evt.context.slice(0, 200))}` : "")
+    if (!evt.ok && evt.executed) logger.warn?.(line)
+    else logger.info?.(line)
+  }

--- a/apps/backend/src/lib/mcp-core/proxy.ts
+++ b/apps/backend/src/lib/mcp-core/proxy.ts
@@ -1,0 +1,111 @@
+/**
+ * Shared MCP core — loopback proxy.
+ *
+ * MCP tools call `callMcpRoute` to forward their arguments to a real route
+ * (`/store/*`, `/partners/*`, `/admin/*`) over HTTP on the same process,
+ * attaching the caller's auth (JWT bearer and/or session cookie). Going through
+ * HTTP — vs re-implementing route logic here — means every tool inherits the
+ * exact middleware the route already runs: `authenticate(...)` scoping,
+ * `validateAndTransformBody` validators, and any custom route logic. Wrapping a
+ * new endpoint becomes a single registry row.
+ */
+import qs from "qs"
+
+export type McpProxyArgs = {
+  /** Base origin of this backend, e.g. http://localhost:9000 (no trailing slash). */
+  baseUrl: string
+  /** HTTP method. Defaults to GET (read tools). */
+  method?: "GET" | "POST" | "PUT" | "DELETE"
+  /** Route path with params already substituted, e.g. /admin/orders/order_1. */
+  path: string
+  /** Query params to forward. Arrays are serialized as key[]=a&key[]=b. */
+  query?: Record<string, unknown>
+  /**
+   * JSON request body for write tools. Sent as application/json. The wrapped
+   * route's own `validateAndTransformBody` validator runs on it, so the
+   * MCP-side schema stays permissive and Medusa remains the source of truth.
+   */
+  body?: Record<string, unknown>
+  /** Auth header to forward (JWT). Required for authenticated routes. */
+  bearer?: string
+  /** Optional session cookie to forward when the caller authed via cookie. */
+  cookie?: string
+  /**
+   * Optional agent intent ("what am I trying to accomplish") forwarded as the
+   * `x-mcp-context` header. Purely informational — routes/telemetry can log it
+   * to understand multi-step tool sequences; it never affects route logic.
+   */
+  context?: string
+  /**
+   * Optional human-supplied reason for a `dangerous` action, forwarded as the
+   * `x-mcp-reason` header so the wrapped route (and the audit log) can record
+   * why a platform-destructive mutation was performed.
+   */
+  reason?: string
+}
+
+export type McpProxyError = Error & { status?: number; body?: unknown }
+
+export async function callMcpRoute({
+  baseUrl,
+  method = "GET",
+  path,
+  query,
+  body,
+  bearer,
+  cookie,
+  context,
+  reason,
+}: McpProxyArgs): Promise<unknown> {
+  const qstr =
+    query && Object.keys(query).length
+      ? `?${qs.stringify(query, { arrayFormat: "brackets", skipNulls: true })}`
+      : ""
+  const url = `${baseUrl}${path}${qstr}`
+
+  const headers: Record<string, string> = { accept: "application/json" }
+  if (bearer) {
+    headers["authorization"] = bearer.toLowerCase().startsWith("bearer ")
+      ? bearer
+      : `Bearer ${bearer}`
+  }
+  if (cookie) {
+    headers["cookie"] = cookie
+  }
+  if (context) {
+    // Truncate defensively — this is a header, not a payload.
+    headers["x-mcp-context"] = context.slice(0, 1024)
+  }
+  if (reason) {
+    headers["x-mcp-reason"] = reason.slice(0, 1024)
+  }
+
+  const init: RequestInit = { method, headers }
+  // Attach a JSON body for writes. GET never carries a body.
+  if (method !== "GET" && body && Object.keys(body).length) {
+    headers["content-type"] = "application/json"
+    init.body = JSON.stringify(body)
+  }
+
+  const resp = await fetch(url, init)
+  const text = await resp.text()
+
+  let json: any = null
+  try {
+    json = text ? JSON.parse(text) : null
+  } catch {
+    json = { raw: text }
+  }
+
+  if (!resp.ok) {
+    const message = json?.message || json?.type || `HTTP ${resp.status}`
+    const err: McpProxyError = new Error(
+      `Route ${path} responded ${resp.status}: ${message}`
+    )
+    err.status = resp.status
+    err.body = json
+    throw err
+  }
+
+  return json
+}

--- a/apps/backend/src/lib/mcp-core/schema.ts
+++ b/apps/backend/src/lib/mcp-core/schema.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared MCP core — tool classification + input-schema shaping.
+ *
+ * Single source of truth for the framework args injected onto every tool
+ * (`context`, `dry_run`, and `confirm`/`reason` for guarded tools) and for the
+ * sensitivity classification the dispatcher enforces. Both consumers — the
+ * JSON-RPC `tools/list` and the in-app assistant's AI-SDK tool binding — call
+ * these so they present identical schemas and guidance.
+ */
+import type { McpToolDef } from "./types"
+
+/** A tool is sensitive if flagged, dangerous, or a DELETE (implicitly). */
+export const isSensitive = (def: McpToolDef): boolean =>
+  !!def.sensitive || !!def.dangerous || def.method === "DELETE"
+
+/** A tool is dangerous (platform-destructive) only when explicitly flagged. */
+export const isDangerous = (def: McpToolDef): boolean => !!def.dangerous
+
+/**
+ * Fold the declarative guidance fields (`sideEffects`, `nextSteps`) into a
+ * short suffix appended to the model-facing description. Returns "" when a tool
+ * declares neither, so untouched tools are unaffected.
+ */
+export const renderToolGuidance = (def: McpToolDef): string => {
+  const parts: string[] = []
+  if (def.sideEffects) parts.push(`Side effects: ${def.sideEffects}`)
+  if (def.nextSteps?.length)
+    parts.push(`Usually followed by: ${def.nextSteps.join(", ")}.`)
+  return parts.length ? `\n${parts.join(" ")}` : ""
+}
+
+/**
+ * Build the full JSON Schema for a tool, injecting the framework args
+ * (`context`, `dry_run`, and `confirm`/`reason` for guarded tools) onto the
+ * domain schema. Used by both `tools/list` and the chat route's tool binding so
+ * the model/clients know these switches exist.
+ */
+export const buildToolInputSchema = (
+  def: McpToolDef
+): Record<string, any> => {
+  const base = def.inputSchema || { type: "object", properties: {} }
+  const properties = { ...(base.properties || {}) }
+
+  // Injected on EVERY tool. Lets the model state what it is trying to
+  // accomplish — most valuable for multi-step goals. Forwarded to the route as
+  // the `x-mcp-context` header for telemetry and echoed on dry_run/confirmation
+  // plans so approval cards show intent.
+  properties.context = {
+    type: "string",
+    description:
+      "One sentence on what you are ultimately trying to accomplish with this call (and the broader goal if this is one step of several). Always set it — it improves results and helps diagnose multi-step flows.",
+  }
+
+  properties.dry_run = {
+    type: "boolean",
+    description:
+      "Preview only: return the planned request (and, for writes, the current object) WITHOUT executing. Use this to inspect data before making a change.",
+  }
+  if (isSensitive(def)) {
+    properties.confirm = {
+      type: "boolean",
+      description:
+        "This is a sensitive/destructive action. It will NOT run unless confirm=true. Do not set this yourself — the user must approve it.",
+    }
+  }
+  if (isDangerous(def)) {
+    properties.reason = {
+      type: "string",
+      description:
+        "This is a PLATFORM-DESTRUCTIVE action. It will NOT run without a human-supplied reason explaining why (audited). Ask the user for the reason; do not invent one.",
+    }
+  }
+
+  return { ...base, properties }
+}

--- a/apps/backend/src/lib/mcp-core/server.ts
+++ b/apps/backend/src/lib/mcp-core/server.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared MCP core — JSON-RPC server builder.
+ *
+ * Uses the low-level `Server` + `setRequestHandler` API (not the high-level
+ * `McpServer.registerTool`) so tool input schemas stay as plain JSON Schema and
+ * we avoid coupling to a specific zod version. Every tool is a loopback proxy
+ * to a live route (see dispatch.ts / proxy.ts). The safety rails live in the
+ * shared dispatcher, so the JSON-RPC endpoint and the in-app assistant behave
+ * identically.
+ */
+import { Server } from "@modelcontextprotocol/sdk/server/index.js"
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js"
+import type { McpContext, McpToolDef } from "./types"
+import { dispatchMcpTool } from "./dispatch"
+import {
+  buildToolInputSchema,
+  isDangerous,
+  isSensitive,
+  renderToolGuidance,
+} from "./schema"
+
+export type BuildMcpServerOptions = {
+  /** MCP server identity, e.g. { name: "jyt-admin", version: "0.1.0" }. */
+  serverInfo: { name: string; version: string }
+  /** High-level usage instructions surfaced to MCP clients. */
+  instructions: string
+}
+
+const textResult = (text: string, isError = false) => ({
+  content: [{ type: "text" as const, text }],
+  ...(isError ? { isError: true } : {}),
+})
+
+/**
+ * Build an MCP `Server` over a registry + context. Tools are filtered by the
+ * context's write/dangerous flags so disabled tools never appear in
+ * `tools/list` (and are refused at dispatch as a backstop).
+ */
+export function buildMcpServer(
+  ctx: McpContext,
+  tools: McpToolDef[],
+  opts: BuildMcpServerOptions
+): Server {
+  const server = new Server(opts.serverInfo, {
+    capabilities: { tools: {} },
+    instructions: opts.instructions,
+  })
+
+  const writeEnabled = ctx.enableWrite !== false
+  const dangerousEnabled = ctx.enableDangerous === true
+  const visibleTools = tools.filter(
+    (t) =>
+      (writeEnabled || !t.write) && (dangerousEnabled || !isDangerous(t))
+  )
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: visibleTools.map((t) => ({
+      name: t.name,
+      description:
+        t.description +
+        (isDangerous(t)
+          ? " [dangerous: requires confirm:true AND a reason]"
+          : isSensitive(t)
+          ? " [sensitive: requires confirm:true]"
+          : "") +
+        renderToolGuidance(t),
+      inputSchema: buildToolInputSchema(t),
+    })),
+  }))
+
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const args = (req.params.arguments ?? {}) as Record<string, unknown>
+    const result = await dispatchMcpTool(ctx, tools, req.params.name, args)
+    return textResult(JSON.stringify(result, null, 2), !result.ok)
+  })
+
+  return server
+}

--- a/apps/backend/src/lib/mcp-core/types.ts
+++ b/apps/backend/src/lib/mcp-core/types.ts
@@ -1,0 +1,134 @@
+/**
+ * Shared MCP core — types.
+ *
+ * One declarative tool model + one execution context, reused by every MCP
+ * surface (store, partner, admin). Each surface supplies its own registry of
+ * `McpToolDef[]` (a data array) and an auth-scoped `McpContext`; the core owns
+ * the dispatch, proxy, schema-shaping, observability and JSON-RPC server logic.
+ *
+ * A tool maps 1:1 to a real HTTP route on this backend. The dispatcher is a
+ * thin loopback proxy, so every tool inherits the wrapped route's auth,
+ * `validateAndTransformBody` validators and workflow logic — for free. Wrapping
+ * a new endpoint is a single registry row.
+ */
+
+/** HTTP verb of the wrapped route. GET = read (always exposed). */
+export type McpMethod = "GET" | "POST" | "PUT" | "DELETE"
+
+export type McpToolDef = {
+  /** Tool name surfaced to the agent (snake_case). */
+  name: string
+  /** One-line description shown in `tools/list` and to the model. */
+  description: string
+  /** JSON Schema for the domain arguments (framework args are injected). */
+  inputSchema: Record<string, any>
+  /** HTTP method of the wrapped route. Defaults to GET. */
+  method?: McpMethod
+  /** Route path, with `:param` placeholders, e.g. `/admin/orders/:id`. */
+  path?: string
+  /** Names of `:param` placeholders that must be supplied as arguments. */
+  pathParams?: string[]
+  /** Argument keys forwarded to the route as query-string params. */
+  queryParams?: string[]
+  /** Argument keys assembled into the JSON request body (write tools only). */
+  bodyParams?: string[]
+  /** Non-GET tool: gated behind the write flag on the server. */
+  write?: boolean
+  /**
+   * High-stakes mutation: requires `confirm: true` to execute. Called without
+   * it, the dispatcher returns a `requires_confirmation` plan. Every DELETE is
+   * treated as sensitive implicitly; set this to flag sensitive POST/PUTs too.
+   */
+  sensitive?: boolean
+  /**
+   * Platform-destructive action (admin surface): on top of `confirm: true`, it
+   * refuses to run without a human-supplied `reason` string (forwarded as the
+   * `x-mcp-reason` header and audited). Hidden from `tools/list` and refused at
+   * dispatch when the surface's dangerous flag is off. Implies `sensitive`.
+   */
+  dangerous?: boolean
+  /**
+   * Companion GET path (same `:param` substitution) used during `dry_run` to
+   * fetch the current object so the model can see what it is about to change.
+   */
+  previewPath?: string
+  /** Optional pure post-processor applied to a successful response. */
+  transform?: (data: any, args: Record<string, unknown>) => any
+  /**
+   * One-line note about non-obvious effects of running this tool (state it
+   * leaves behind, what it does NOT do). Rendered into the model-facing
+   * description so the agent reasons about the tool's real footprint.
+   */
+  sideEffects?: string
+  /**
+   * Tool names the agent typically calls after this one. Rendered into the
+   * description as a hint (not enforced).
+   */
+  nextSteps?: string[]
+}
+
+/** A single observability event emitted by the dispatcher (#844). */
+export type McpToolEvent = {
+  /** Which MCP surface handled the call: "store" | "partner" | "admin". */
+  surface: string
+  /** Tool name. */
+  tool: string
+  /** Wrapped route method + path actually planned/executed. */
+  method: string
+  path?: string
+  /** True when the tool executed for real (not dry_run / requires_confirmation). */
+  executed: boolean
+  /** Outcome of an executed call. */
+  ok: boolean
+  /** Rail the call resolved on: "dry_run" | "confirm" | "reason" | "run" | "refused". */
+  outcome: string
+  /** Wall-clock milliseconds for the loopback call (executed calls only). */
+  ms?: number
+  /** Soft error message when ok=false. */
+  error?: string
+  /** The agent's stated intent (`context` arg), truncated. */
+  context?: string
+}
+
+export type McpContext = {
+  /** Backend origin for loopback calls, e.g. http://localhost:9000. */
+  baseUrl: string
+  /** Auth header to forward so the wrapped route authenticates (JWT). */
+  bearer?: string
+  /** Session cookie to forward when the caller authed via cookie. */
+  cookie?: string
+  /** When false, write tools (non-GET) are refused. Defaults to true. */
+  enableWrite?: boolean
+  /**
+   * When false (default on the admin surface in dev/preview), `dangerous` tools
+   * are hidden from `tools/list` and refused at dispatch. Surfaces without any
+   * dangerous tools can leave this undefined.
+   */
+  enableDangerous?: boolean
+  /** Which surface this context serves — labels observability + server name. */
+  surface?: string
+  /** Optional sink for per-call observability events (#844). */
+  observe?: (evt: McpToolEvent) => void
+}
+
+/** Structured tool result. `ok:false` is a soft error (returned, not thrown). */
+export type McpToolResult = {
+  ok: boolean
+  tool: string
+  /** Successful response payload. */
+  data?: unknown
+  /** Soft error message. */
+  error?: string
+  /** Set when dry_run echoed the plan instead of executing. */
+  dry_run?: boolean
+  /** Set when a sensitive tool needs `confirm: true` before it will run. */
+  requires_confirmation?: boolean
+  /** Set when a dangerous tool needs a `reason` string before it will run. */
+  requires_reason?: boolean
+  /** The request that would be / was sent — { method, path, query, body }. */
+  plan?: Record<string, unknown>
+  /** Current object (writes with a previewPath, during dry_run/confirmation). */
+  current?: unknown
+  /** Human-readable warning for sensitive/dangerous actions. */
+  warning?: string
+}

--- a/apps/backend/src/mastra/services/ai-platforms.ts
+++ b/apps/backend/src/mastra/services/ai-platforms.ts
@@ -79,6 +79,11 @@ export type AiRole =
   // auto-rotating OpenRouter free models. The model drives the Partner API via
   // a tool registry — see api/partners/mcp/lib/registry.ts.
   | "ai_partner_assistant"
+  // Admin agentic assistant chat (#1092). Resolves the assistant provider from
+  // the admin-configured External Platform; falls back to the auto-rotating
+  // OpenRouter free models. The model drives the Admin API via the shared MCP
+  // tool registry — see api/admin/mcp/lib/registry.ts.
+  | "ai_admin_assistant"
   // String escape hatch so callers can use ad-hoc roles without
   // bumping this union every time.
   | (string & {})
@@ -720,4 +725,5 @@ export const AI_ROLES: AiRole[] = [
   "ai_image_extraction",
   "ai_redesign",
   "ai_partner_assistant",
+  "ai_admin_assistant",
 ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^2.0.15
         version: 2.0.94(zod@4.2.0)
+      '@ai-sdk/react':
+        specifier: ^2.0.194
+        version: 2.0.194(react@18.3.1)(zod@4.2.0)
       '@ariakit/react':
         specifier: ^0.4.17
         version: 0.4.21(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
## Summary
Consolidates the MCP surfaces onto one shared core and adds the **Admin MCP + agentic assistant** (epic #1092, Tier 0 + Tier 1). Also lays the shared foundation for MCP observability (#844) and future MCP work (#845/#1026).

## What's in it
**`src/lib/mcp-core/`** — one declarative tool model + `dispatch`/`proxy`/`schema`/`server`/`handler`/`observability`, reused by every MCP surface. Three safety rails in one dispatcher:
- `dry_run` (every tool) — preview the planned request (+ current object for writes)
- `confirm` (sensitive/DELETE) — `requires_confirmation` until `confirm:true`
- **`dangerous`** (new) — platform-destructive tools additionally require an audited `reason` (`x-mcp-reason`), gated by `ADMIN_MCP_ENABLE_DANGEROUS` (default off)

**Partner MCP refactored onto the core** — `dispatch/proxy/server/handler` are now thin wrappers; all public exports preserved. Partner dispatch tests stay green.

**Admin MCP — Tier 0 + Tier 1** (`api/admin/mcp/`) — JSON-RPC route (POST; GET/DELETE→405) + **17 read-only tools** (`get_admin_stats`, orders, products, customers, partners, stores, designs, production runs, inventory items/orders, payments, campaigns, notifications) + a grounding `/admin/mcp/stats` snapshot. `ADMIN_MCP_ENABLE_WRITE`/`ADMIN_MCP_ENABLE_DANGEROUS` flags wired.

**Admin assistant** — `api/admin/assistant/chat` streaming tool-caller + `ai_admin_assistant` role (DB platform → OpenRouter-free fallback) + middleware. **Admin UI** `routes/assistant` chat page (AI-SDK `useChat`) alongside the legacy V4 chat.

## Testing
- **40/40** MCP dispatch unit tests (29 partner + 11 admin, incl. the dangerous rail)
- **Full prod-build gate passes** (backend + admin frontend + schemas)
- **Live local run**: `tools/list` → 17 tools; `get_admin_stats` dry-run + real (real counts via `/admin/mcp/stats`); `list_orders` proxies live data; `/admin/assistant/chat` streams a tool-calling turn on the OpenRouter-free model that grounds with `get_admin_stats` and answers accurately (35 orders, 8 partners, …).

## Deliberately deferred (follow-ups)
- Store MCP migration onto the core (it's structurally divergent — multi-tenant resolver + key-gated writes)
- Admin write/dangerous Tiers 2–6; V4-chat deprecation flag + `resolve_admin_query` fallback
- Full #844 `ai_usage` ledger persistence (the observability seam exists)

Refs #1092, #844.

🤖 Generated with [Claude Code](https://claude.com/claude-code)