### PR TITLE
fix(partner-orders): line-item thumbnails, wire edit actions, country backfill

### DIFF
--- a/apps/backend/src/api/partners/orders/[id]/line-items/route.ts
+++ b/apps/backend/src/api/partners/orders/[id]/line-items/route.ts
@@ -13,11 +13,35 @@ export const GET = async (
     entity: "order",
     // `relation.*` not `*relation` — the asterisk-prefix form has tripped
     // MikroORM on several entities. Admin uses the suffix form.
-    fields: ["items.*", "items.variant.*", "items.variant.product.*"],
+    fields: [
+      "items.*",
+      "items.variant.*",
+      "items.variant.product.*",
+      "items.variant.product.images.url",
+      "items.variant.product.images.rank",
+    ],
     filters: { id: req.params.id },
   })
 
   const items = (data?.[0] as any)?.items || []
+
+  // Backfill the order-time snapshot `thumbnail` when it's missing so
+  // `item.thumbnail` is always populated for the UI. Medusa only ever copies the
+  // product ROOT thumbnail onto the line item at cart time, so a product with
+  // only `images` (no root thumbnail) leaves the snapshot null — fall back to the
+  // first image. The product is already fetched, so no extra query.
+  for (const it of items) {
+    if (!it?.thumbnail) {
+      const product = it?.variant?.product
+      const firstImage = (product?.images ?? [])
+        .slice()
+        .sort((a: any, b: any) => (a?.rank ?? 0) - (b?.rank ?? 0))[0]?.url
+      const fallback = product?.thumbnail || firstImage
+      if (fallback) {
+        it.thumbnail = fallback
+      }
+    }
+  }
 
   res.json({ order_items: items })
 }

--- a/apps/backend/src/api/partners/orders/[id]/route.ts
+++ b/apps/backend/src/api/partners/orders/[id]/route.ts
@@ -83,6 +83,51 @@ export const GET = async (
     // leave the order as-is; the UI falls back to retail rendering
   }
 
+  // Line-item thumbnails: the order-time snapshot `item.thumbnail` can be null.
+  // Medusa copies it at add-to-cart time via
+  //   thumbnail: item.thumbnail ?? variant.thumbnail ?? variant.product.thumbnail
+  // (see @medusajs/core-flows prepare-line-item-data) — i.e. ONLY from the
+  // product's ROOT `thumbnail`, and only if that was already set then. A product
+  // that gained its thumbnail (or only ever had `images`, never a root thumbnail)
+  // after the order was placed leaves the snapshot null forever. The partner UI
+  // reads `item.thumbnail` directly, so backfill it here from the live product —
+  // root thumbnail first, then the first product image — keeping the response
+  // self-describing instead of pushing the fallback into every client.
+  try {
+    const items = (result as any)?.items as Array<any> | undefined
+    if (Array.isArray(items) && items.length) {
+      const productIdOf = (it: any): string | undefined =>
+        it?.product_id || it?.variant?.product?.id || it?.variant?.product_id
+      const missing = items.filter((it) => !it?.thumbnail && productIdOf(it))
+      const productIds = Array.from(
+        new Set(missing.map((it) => productIdOf(it)).filter(Boolean))
+      ) as string[]
+      if (productIds.length) {
+        const query = req.scope.resolve(ContainerRegistrationKeys.QUERY)
+        const { data: products } = await query.graph({
+          entity: "product",
+          fields: ["id", "thumbnail", "images.url", "images.rank"],
+          filters: { id: productIds },
+        })
+        const thumbById = new Map<string, string | null | undefined>(
+          (products ?? []).map((p: any) => {
+            const firstImage = (p.images ?? [])
+              .slice()
+              .sort((a: any, b: any) => (a?.rank ?? 0) - (b?.rank ?? 0))[0]?.url
+            return [p.id, p.thumbnail || firstImage]
+          })
+        )
+        for (const it of missing) {
+          const pid = productIdOf(it)
+          const thumb = pid ? thumbById.get(pid) : undefined
+          if (thumb) it.thumbnail = thumb
+        }
+      }
+    }
+  } catch {
+    // best-effort: leave snapshot thumbnails as-is
+  }
+
   res.json({ order: result })
 }
 

--- a/apps/backend/src/scripts/backfill-order-address-country.ts
+++ b/apps/backend/src/scripts/backfill-order-address-country.ts
@@ -1,0 +1,120 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { ExecArgs } from "@medusajs/framework/types"
+
+/**
+ * One-off: correct the country_code on a specific order's shipping/billing
+ * addresses.
+ *
+ * Why a script (and not the API): Medusa's order-update flow guards the address
+ * country — `POST /admin|partners/orders/:id` returns
+ * `400 "Country code cannot be changed"` because an order address's country is
+ * treated as locked to the order's region. We therefore write straight to the
+ * `order_address` rows via the raw PG connection, bypassing that flow guard.
+ *
+ * Concrete case (#79, order_01KXWHFP132AM0H940WFD2P0XW): the customer is in
+ * Jerusalem, Israel but checked out before an Israel region existed, so the
+ * storefront fell back to `um` (US Minor Outlying Islands, a member of the
+ * America/USD region). The order is captured in USD and not yet fulfilled — we
+ * fix ONLY the address country so the shipping label is correct, and
+ * deliberately leave the region/currency alone (moving a paid order to the
+ * ILS Israel region would break payment reconciliation).
+ *
+ * The address country will then no longer be a member of the order's region.
+ * That mismatch is cosmetic (admin shows Israel + America) and is exactly what
+ * the API guard prevents — acceptable here for a manual correction.
+ *
+ * Idempotent: addresses already on the target country are skipped.
+ *
+ * Usage (prod ships transpiled JS — use the .js extension via ECS run-task,
+ * see reference_prod_ecs_run_task_scripts):
+ *   ORDER_ID=order_01KXWHFP132AM0H940WFD2P0XW TARGET_COUNTRY=il DRY_RUN=1 \
+ *     npx medusa exec ./src/scripts/backfill-order-address-country.ts
+ *   ORDER_ID=order_01KXWHFP132AM0H940WFD2P0XW TARGET_COUNTRY=il \
+ *     npx medusa exec ./src/scripts/backfill-order-address-country.ts
+ */
+export default async function backfillOrderAddressCountry({
+  container,
+}: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const pg = container.resolve(ContainerRegistrationKeys.PG_CONNECTION) as any
+
+  const orderId = (process.env.ORDER_ID || "").trim()
+  const target = (process.env.TARGET_COUNTRY || "").trim().toLowerCase()
+  const dryRun = process.env.DRY_RUN === "1"
+
+  if (!orderId || !target) {
+    logger.error(
+      "[backfill-order-address-country] ORDER_ID and TARGET_COUNTRY are required"
+    )
+    return
+  }
+  if (!/^[a-z]{2}$/.test(target)) {
+    logger.error(
+      `[backfill-order-address-country] TARGET_COUNTRY must be a 2-letter ISO code, got '${target}'`
+    )
+    return
+  }
+
+  const { data: orders } = await query.graph({
+    entity: "order",
+    fields: [
+      "id",
+      "display_id",
+      "region_id",
+      "currency_code",
+      "shipping_address.id",
+      "shipping_address.country_code",
+      "shipping_address.city",
+      "billing_address.id",
+      "billing_address.country_code",
+    ],
+    filters: { id: orderId },
+  })
+
+  const order = orders?.[0] as any
+  if (!order) {
+    logger.error(`[backfill-order-address-country] order ${orderId} not found`)
+    return
+  }
+
+  const targets = [
+    { label: "shipping", addr: order.shipping_address },
+    { label: "billing", addr: order.billing_address },
+  ].filter((t) => t.addr?.id)
+
+  logger.info(
+    `[backfill-order-address-country] order #${order.display_id} (${order.id}) region=${order.region_id} ${order.currency_code} — ${targets.length} address(es), target='${target}'${dryRun ? " (dry run)" : ""}`
+  )
+
+  let changed = 0
+  for (const { label, addr } of targets) {
+    const current = (addr.country_code || "").toLowerCase()
+    if (current === target) {
+      logger.info(
+        `[backfill] ${label} (${addr.id}) already '${target}' — skip`
+      )
+      continue
+    }
+    if (dryRun) {
+      logger.info(
+        `[backfill] would set ${label} (${addr.id}) country_code '${current}' -> '${target}'`
+      )
+      changed++
+      continue
+    }
+    const res = await pg.raw(
+      `UPDATE "order_address" SET "country_code" = ?, "updated_at" = now() WHERE "id" = ?`,
+      [target, addr.id]
+    )
+    const rows = res?.rowCount ?? res?.rows?.length ?? 0
+    logger.info(
+      `[backfill] ${label} (${addr.id}) country_code '${current}' -> '${target}' (${rows} row)`
+    )
+    changed++
+  }
+
+  logger.info(
+    `[backfill-order-address-country] done — ${changed} address(es) ${dryRun ? "would be " : ""}updated`
+  )
+}

--- a/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
+++ b/apps/partner-ui/src/dashboard-app/routes/get-partner-route.map.tsx
@@ -647,6 +647,11 @@ export function getPartnerRouteMap(): RouteObject[] {
                         import("../../routes/orders/order-edit-email"),
                     },
                     {
+                      path: "transfer",
+                      lazy: () =>
+                        import("../../routes/orders/order-request-transfer"),
+                    },
+                    {
                       path: "edit-shipping-address",
                       lazy: () =>
                         import(

--- a/apps/partner-ui/src/routes/orders/order-detail/components/order-customer-section/order-customer-section.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/components/order-customer-section/order-customer-section.tsx
@@ -42,12 +42,12 @@ const Header = () => {
             actions: [
               {
                 label: t("addresses.shippingAddress.editLabel"),
-                to: "shipping-address",
+                to: "edit-shipping-address",
                 icon: <FlyingBox />,
               },
               {
                 label: t("addresses.billingAddress.editLabel"),
-                to: "billing-address",
+                to: "edit-billing-address",
                 icon: <CurrencyDollar />,
               },
             ],
@@ -56,7 +56,7 @@ const Header = () => {
             actions: [
               {
                 label: t("email.editLabel"),
-                to: `email`,
+                to: `edit-email`,
                 icon: <Envelope />,
               },
             ],

--- a/deploy/aws/scripts/run-backfill.sh
+++ b/deploy/aws/scripts/run-backfill.sh
@@ -164,6 +164,9 @@ add_env() {
 }
 add_env BATCH                    "${BATCH:-}"
 add_env DRY_RUN                  "${DRY_RUN:-}"
+# backfill-order-address-country: which order + the corrected ISO-2 country.
+add_env ORDER_ID                 "${ORDER_ID:-}"
+add_env TARGET_COUNTRY           "${TARGET_COUNTRY:-}"
 # repair-stuck-parent-production-runs: force-complete specific (incl.
 # already-cancelled) parents the default stuck-status scan skips.
 add_env FORCE_RUN_IDS            "${FORCE_RUN_IDS:-}"


### PR DESCRIPTION
Fixes three partner-order bugs.

### 1. Line-item thumbnails not visible
An order line item snapshots its thumbnail **once** at add-to-cart time — core-flows `prepare-line-item-data`: `item.thumbnail ?? variant.thumbnail ?? variant.product.thumbnail` — and never refreshes. Products that gained a thumbnail *after* the order (or that only ever had `images`, never a root `thumbnail`) leave `item.thumbnail` null forever, so the partner UI renders blanks even though the product has an image.

Verified on order #79 via the live admin API: all 7 line-item snapshots `null`, product **root** thumbnails **set**, variants carry no thumbnail field.

**Fix (API layer):** backfill `item.thumbnail` in the partner order `GET` and `line-items` routes from the live product — root thumbnail first, then first product image.

### 2. Order edit / shipping-address / email actions were dead links
The edit forms (email / shipping / billing / transfer) already exist and are API-wired via `useUpdateOrder` → `POST /partners/orders/:id`, but the customer-section ActionMenu pointed at `shipping-address` / `billing-address` / `email` / `transfer` while the partner route map registers `edit-shipping-address` / `edit-billing-address` / `edit-email` and never registered `transfer`.

**Fix:** correct the `to:` paths and register the `transfer` route.

### 3. Wrong country backfill (order #79)
Customer is in Jerusalem, Israel but checked out as `um` (US Minor Outlying Islands — an America/USD region fallback) before an Israel region existed. Medusa's order-update flow locks an address's country to its region (`400 "Country code cannot be changed"`), so a script writes `order_address.country_code` directly via the PG connection.

- `backfill-order-address-country.ts` — idempotent, `DRY_RUN`, `ORDER_ID` + `TARGET_COUNTRY` params.
- `run-backfill.sh` forwards `ORDER_ID` / `TARGET_COUNTRY`.

Country-only — region/currency deliberately left intact (the order is captured in USD).

```
ORDER_ID=order_01KXWHFP132AM0H940WFD2P0XW TARGET_COUNTRY=il DRY_RUN=1 FOLLOW=1 \
  ./deploy/aws/scripts/run-backfill.sh backfill-order-address-country
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)