### PR TITLE
fix(email): populate empty customer order-confirmation + partner branding

### DIFF
--- a/apps/backend/src/scripts/resend-order-confirmation.ts
+++ b/apps/backend/src/scripts/resend-order-confirmation.ts
@@ -1,0 +1,68 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { ExecArgs } from "@medusajs/framework/types"
+import { sendOrderConfirmationWorkflow } from "../workflows/email/workflows/send-order-confirmation-email"
+
+/**
+ * One-off ops job: re-send the customer order-confirmation email for one or
+ * more orders by re-running `sendOrderConfirmationWorkflow`.
+ *
+ * Why this and not the /admin/notifications/:id/retry endpoint: the maileroo
+ * provider sends `data._template_html_content` VERBATIM (it does not re-render
+ * from the DB template), so a bare retry with flat vars would send
+ * "No content available". Re-running the workflow rebuilds the flat vars +
+ * partner context from the order and renders the current DB template — so once
+ * `update-email-templates.ts` has refreshed the `order-placed` template, this
+ * produces the correct, partner-branded email.
+ *
+ * Usage (prod ships transpiled JS — .js via ECS run-task):
+ *   ORDER_IDS=order_01KXWHFP132AM0H940WFD2P0XW \
+ *     npx medusa exec ./src/scripts/resend-order-confirmation.ts
+ *   ORDER_IDS=order_a,order_b DRY_RUN=1 \
+ *     npx medusa exec ./src/scripts/resend-order-confirmation.ts
+ */
+export default async function resendOrderConfirmation({ container }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+
+  const dryRun = process.env.DRY_RUN === "1"
+  const orderIds = (process.env.ORDER_IDS || process.env.ORDER_ID || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+
+  if (!orderIds.length) {
+    logger.error(
+      "[resend-order-confirmation] ORDER_IDS (comma-separated) is required"
+    )
+    return
+  }
+
+  logger.info(
+    `[resend-order-confirmation] ${orderIds.length} order(s)${dryRun ? " (dry run)" : ""}`
+  )
+
+  let sent = 0
+  let errors = 0
+  for (const orderId of orderIds) {
+    if (dryRun) {
+      logger.info(`[resend-order-confirmation] would resend for ${orderId}`)
+      sent++
+      continue
+    }
+    try {
+      await sendOrderConfirmationWorkflow(container).run({
+        input: { orderId },
+      })
+      logger.info(`[resend-order-confirmation] resent for ${orderId}`)
+      sent++
+    } catch (e: any) {
+      errors++
+      logger.error(
+        `[resend-order-confirmation] failed for ${orderId}: ${e?.message ?? e}`
+      )
+    }
+  }
+
+  logger.info(
+    `[resend-order-confirmation] done — ${sent} ${dryRun ? "would be " : ""}sent, ${errors} error(s)`
+  )
+}

--- a/apps/backend/src/scripts/seed-email-templates.ts
+++ b/apps/backend/src/scripts/seed-email-templates.ts
@@ -6,33 +6,53 @@ export const emailTemplatesData = [
     name: "Order Confirmation",
     template_key: "order-placed",
     from: "orders@jyt.com",
-    subject: "Order Confirmation - Order #{{order_display_id}}",
+    subject: "Order Confirmation - Order {{order_display_id}}{{#if partner_name}} · {{partner_name}}{{/if}}",
     html_content: `
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; background-color: #f9f9f9;">
         <div style="background-color: #ffffff; padding: 30px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+          {{#if partner_name}}
+          <p style="color: #999999; font-size: 13px; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 8px;">{{partner_name}}</p>
+          {{/if}}
           <h1 style="color: #28a745; font-size: 24px; margin-bottom: 20px;">Order Confirmation</h1>
           <p style="color: #333333; font-size: 16px; margin-bottom: 15px;">
             Hi {{customer_first_name}},
           </p>
           <p style="color: #666666; font-size: 16px; line-height: 1.5; margin-bottom: 20px;">
-            Thank you for your order! We have received your order and will process it shortly.
+            Thank you for your order{{#if partner_name}} with {{partner_name}}{{/if}}! We have received it and will process it shortly.
           </p>
           <div style="margin-top: 20px; padding: 15px; background-color: #f8f9fa; border-radius: 4px;">
-            <h3 style="color: #333333; font-size: 18px; margin-bottom: 10px;">Order #{{order_display_id}}</h3>
-            <p style="color: #666666; font-size: 14px;">Total: {{order_total}}</p>
-            <p style="color: #666666; font-size: 14px;">Email: {{order_email}}</p>
+            <h3 style="color: #333333; font-size: 18px; margin-bottom: 10px;">Order {{order_display_id}}</h3>
+            <p style="color: #666666; font-size: 14px; margin: 4px 0;">Items: {{item_count}}</p>
+            <p style="color: #666666; font-size: 14px; margin: 4px 0;">Total: {{order_total}}</p>
+            <p style="color: #666666; font-size: 14px; margin: 4px 0;">Email: {{order_email}}</p>
           </div>
+          {{#if store_url}}
+          <div style="margin: 28px 0; text-align: center;">
+            <a href="{{store_url}}" style="background-color: #28a745; color: #ffffff; padding: 12px 24px; text-decoration: none; border-radius: 4px; display: inline-block; font-weight: bold;">
+              {{#if partner_name}}Visit {{partner_name}}{{else}}Visit our store{{/if}}
+            </a>
+          </div>
+          {{/if}}
           <p style="color: #999999; font-size: 14px; margin-top: 20px;">
             We'll send you another email when your order ships.
           </p>
+          {{#if partner_name}}
+          <p style="color: #cccccc; font-size: 12px; margin-top: 24px; border-top: 1px solid #eeeeee; padding-top: 16px;">
+            &copy; {{current_year}} {{partner_name}}
+          </p>
+          {{/if}}
         </div>
       </div>
     `,
     variables: {
       customer_first_name: "Customer's first name",
-      order_display_id: "Order display ID",
-      order_total: "Order total amount",
-      order_email: "Customer email"
+      order_display_id: "Order display ID (already prefixed with #)",
+      order_total: "Order total amount (formatted)",
+      order_email: "Customer email",
+      item_count: "Number of line items",
+      partner_name: "Partner / store name (optional)",
+      store_url: "Partner storefront URL (optional)",
+      current_year: "Current year"
     },
     template_type: "order_confirmation",
     is_active: true

--- a/apps/backend/src/scripts/update-email-templates.ts
+++ b/apps/backend/src/scripts/update-email-templates.ts
@@ -1,0 +1,97 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { ExecArgs } from "@medusajs/framework/types"
+import { EMAIL_TEMPLATES_MODULE } from "../modules/email_templates"
+import { emailTemplatesData } from "./seed-email-templates"
+
+/**
+ * One-off ops job: UPDATE existing DB email templates in place from the
+ * canonical definitions in `seed-email-templates.ts`.
+ *
+ * Why this exists: `seed-email-templates.ts` intentionally SKIPS templates that
+ * already exist (so it never clobbers admin edits). That means edits to a seed
+ * template never reach an environment that was already seeded. This job pushes
+ * the seed's subject / html_content / from / variables onto the live rows for a
+ * chosen set of keys — scoped by TEMPLATE_KEYS so we never touch templates we
+ * didn't mean to.
+ *
+ * Motivating case: the `order-placed` customer confirmation shipped as a stub
+ * whose payload never matched its variables (empty "Hi ," / "Order #"). The
+ * sending workflow now passes the correct flat vars + partner context
+ * (partner_name, store_url); this job upgrades the template body to use them.
+ *
+ * Idempotent — re-running writes the same content.
+ *
+ * Usage (prod ships transpiled JS — .js via ECS run-task):
+ *   TEMPLATE_KEYS=order-placed DRY_RUN=1 \
+ *     npx medusa exec ./src/scripts/update-email-templates.ts
+ *   TEMPLATE_KEYS=order-placed \
+ *     npx medusa exec ./src/scripts/update-email-templates.ts
+ */
+export default async function updateEmailTemplates({ container }: ExecArgs) {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const service: any = container.resolve(EMAIL_TEMPLATES_MODULE)
+
+  const dryRun = process.env.DRY_RUN === "1"
+  const keys = (process.env.TEMPLATE_KEYS || "order-placed")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+
+  logger.info(
+    `[update-email-templates] keys=[${keys.join(", ")}]${dryRun ? " (dry run)" : ""}`
+  )
+
+  let updated = 0
+  let missing = 0
+
+  for (const key of keys) {
+    const def = (emailTemplatesData as any[]).find(
+      (t) => t.template_key === key
+    )
+    if (!def) {
+      logger.warn(
+        `[update-email-templates] '${key}' not found in seed data — skip`
+      )
+      missing++
+      continue
+    }
+
+    // There can be one row per locale for a key; update them all.
+    const [rows] = await service.listAndCountEmailTemplates({
+      template_key: key,
+    })
+    if (!rows || rows.length === 0) {
+      logger.warn(
+        `[update-email-templates] no DB row for '${key}' — run the seed first; skip`
+      )
+      missing++
+      continue
+    }
+
+    for (const row of rows) {
+      if (dryRun) {
+        logger.info(
+          `[update-email-templates] would update '${key}' (${row.id}, locale=${row.locale ?? "-"})`
+        )
+        updated++
+        continue
+      }
+      await service.updateEmailTemplates({
+        id: row.id,
+        subject: def.subject,
+        html_content: def.html_content,
+        from: def.from,
+        variables: def.variables,
+        template_type: def.template_type,
+      })
+      logger.info(
+        `[update-email-templates] updated '${key}' (${row.id}, locale=${row.locale ?? "-"})`
+      )
+      updated++
+    }
+  }
+
+  logger.info(
+    `[update-email-templates] done — ${updated} ${dryRun ? "would be " : ""}updated, ${missing} missing`
+  )
+}

--- a/apps/backend/src/workflows/email/workflows/send-order-confirmation-email.ts
+++ b/apps/backend/src/workflows/email/workflows/send-order-confirmation-email.ts
@@ -1,17 +1,137 @@
 import { createWorkflow, createStep, StepResponse, transform } from "@medusajs/framework/workflows-sdk"
-import { Modules } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import type { IOrderModuleService } from "@medusajs/types"
 import { sendNotificationEmailStep } from "../steps/send-notification-email"
 import { fetchEmailTemplateStep } from "../steps/fetch-email-template"
+import { PARTNER_MODULE } from "../../../modules/partner"
+import PartnerService from "../../../modules/partner/service"
 
+/**
+ * Retrieve the order with the relations we need to render the confirmation.
+ * Addresses give us the customer name (line items don't), items give us the
+ * total and item count.
+ */
 const retrieveOrderStep = createStep(
   { name: "retrieve-order", store: true },
   async ({ orderId }: { orderId: string }, { container }) => {
     const orderService = container.resolve(Modules.ORDER) as IOrderModuleService
     const order = await orderService.retrieveOrder(orderId, {
-      relations: ["items"],
+      relations: ["items", "shipping_address", "billing_address"],
     })
     return new StepResponse(order)
+  }
+)
+
+/**
+ * Build the FLAT template variables the `order-placed` template declares
+ * (customer_first_name, order_display_id, order_total, order_email) plus the
+ * partner context (partner_name, store_url) so the customer email can carry the
+ * partner's branding + storefront link.
+ *
+ * Previously the workflow passed a nested `{ order, customer: { first_name } }`
+ * payload whose keys never matched the template's flat `{{customer_first_name}}`
+ * / `{{order_display_id}}` / `{{order_total}}` / `{{order_email}}` variables, so
+ * Handlebars rendered every field as an empty string ("Hi ,", "Order #",
+ * "Total: "). This step resolves the partner via
+ * order → sales_channel → store → partner_store link and formats the money.
+ */
+const buildOrderConfirmationVarsStep = createStep(
+  { name: "build-order-confirmation-vars", store: true },
+  async ({ order }: { order: any }, { container }) => {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+
+    // --- Order-level flat vars -------------------------------------------
+    const items = (order?.items || []) as any[]
+    // Prefer the order's computed grand total (includes shipping + tax); fall
+    // back to the line-item subtotal only if the total isn't populated.
+    const itemsSubtotal = items.reduce(
+      (sum: number, item: any) =>
+        sum + (Number(item.unit_price) || 0) * (Number(item.quantity) || 0),
+      0
+    )
+    const orderTotal =
+      Number(order?.total) > 0 ? Number(order.total) : itemsSubtotal || 0
+
+    const firstName =
+      order?.shipping_address?.first_name ||
+      order?.billing_address?.first_name ||
+      (order?.email ? String(order.email).split("@")[0] : "") ||
+      "there"
+
+    const customerName =
+      `${order?.shipping_address?.first_name || ""} ${order?.shipping_address?.last_name || ""}`.trim() ||
+      order?.email ||
+      "Customer"
+
+    // --- Partner context: order → sales_channel → store → partner --------
+    let partnerName = ""
+    let storeUrl = process.env.FRONTEND_URL || ""
+
+    try {
+      let storeId: string | null = null
+      if (order?.sales_channel_id) {
+        const { data: scLinks } = await query.graph({
+          entity: "sales_channel",
+          fields: ["id", "store.id"],
+          filters: { id: order.sales_channel_id },
+        })
+        storeId = scLinks?.[0]?.store?.id || null
+      }
+
+      if (storeId) {
+        const { data: partnerStoreLinks } = await query.graph({
+          entity: "partner_partner_store_store",
+          fields: ["partner_id"],
+          filters: { store_id: storeId },
+          pagination: { skip: 0, take: 1 },
+        })
+        const partnerId = partnerStoreLinks?.[0]?.partner_id || null
+
+        if (partnerId) {
+          const partnerService: PartnerService =
+            container.resolve(PARTNER_MODULE)
+          const partners = await partnerService.listPartners(
+            { id: partnerId },
+            { select: ["id", "name", "handle", "storefront_domain", "metadata"] }
+          )
+          const partner = (partners as any[])?.[0]
+          if (partner) {
+            partnerName = partner.name || ""
+            const domain =
+              partner.storefront_domain ||
+              partner.metadata?.storefront_domain ||
+              ""
+            if (domain) {
+              storeUrl = /^https?:\/\//i.test(domain)
+                ? domain
+                : `https://${domain}`
+            }
+          }
+        }
+      }
+    } catch (err) {
+      console.warn(
+        `[order-confirmation] partner context lookup failed for order ${order?.id}: ${(err as Error).message}`
+      )
+    }
+
+    const vars = {
+      customer_first_name: firstName,
+      customer_name: customerName,
+      order_display_id: order?.display_id ? `#${order.display_id}` : order?.id || "",
+      order_id: order?.id || "",
+      order_email: order?.email || "",
+      order_total: new Intl.NumberFormat("en-IN", {
+        style: "currency",
+        currency: order?.currency_code?.toUpperCase() || "INR",
+      }).format(orderTotal),
+      item_count: String(items.length),
+      partner_name: partnerName,
+      store_url: storeUrl,
+      current_year: String(new Date().getFullYear()),
+    }
+
+    return new StepResponse(vars)
   }
 )
 
@@ -20,22 +140,22 @@ export const sendOrderConfirmationWorkflow = createWorkflow(
   (input: { orderId: string }) => {
     const order = retrieveOrderStep(input)
 
-    const emailData = {
-      order,
-      customer: order.customer_id ? { first_name: "Customer" } : null,
-    }
+    const emailData = buildOrderConfirmationVarsStep({ order })
 
     const templateData = fetchEmailTemplateStep({
       templateKey: "order-placed",
       data: emailData as unknown as Record<string, any>,
     })
 
-    const emailWithTemplate = transform({ order, emailData, templateData }, (d) => ({
-      to: d.order.email || "customer@example.com",
-      template: "order-placed",
-      data: d.emailData,
-      templateData: d.templateData,
-    }))
+    const emailWithTemplate = transform(
+      { order, emailData, templateData },
+      (d) => ({
+        to: d.order.email || "customer@example.com",
+        template: "order-placed",
+        data: d.emailData,
+        templateData: d.templateData,
+      })
+    )
 
     sendNotificationEmailStep(emailWithTemplate as any)
   }

--- a/deploy/aws/scripts/run-backfill.sh
+++ b/deploy/aws/scripts/run-backfill.sh
@@ -167,6 +167,10 @@ add_env DRY_RUN                  "${DRY_RUN:-}"
 # backfill-order-address-country: which order + the corrected ISO-2 country.
 add_env ORDER_ID                 "${ORDER_ID:-}"
 add_env TARGET_COUNTRY           "${TARGET_COUNTRY:-}"
+# update-email-templates: which template keys to push from seed to the DB.
+add_env TEMPLATE_KEYS            "${TEMPLATE_KEYS:-}"
+# resend-order-confirmation: which order(s) to re-send the confirmation for.
+add_env ORDER_IDS               "${ORDER_IDS:-}"
 # repair-stuck-parent-production-runs: force-complete specific (incl.
 # already-cancelled) parents the default stuck-status scan skips.
 add_env FORCE_RUN_IDS            "${FORCE_RUN_IDS:-}"


### PR DESCRIPTION
**Stacked on #1099** (shares `run-backfill.sh`). Merge after #1099, then this retargets to `main`.

### Problem
The `order-placed` customer confirmation rendered completely empty for **every** order — `Hi ,` / `Order #` / `Total: `. Root cause: the sending workflow passed a nested stub `{ order, customer: { first_name: "Customer" } }`, but the template declares **flat** vars (`{{customer_first_name}}`, `{{order_display_id}}`, `{{order_total}}`, `{{order_email}}`), so Handlebars resolved every one to an empty string.

### Fix
- **`send-order-confirmation-email.ts`** — build the real flat vars from the order + partner context (`partner_name`, `store_url` from `partner.storefront_domain`) resolved via order → sales_channel → store → partner.
- **`seed-email-templates.ts`** — richer `order-placed` template: greet by name, items/total/email, partner header + "Visit {{partner_name}}" button + branded footer (all conditional).
- **`update-email-templates.ts`** (ops) — push seed content onto existing DB rows (seed *skips* existing templates). Scoped by `TEMPLATE_KEYS`.
- **`resend-order-confirmation.ts`** (ops) — re-run the fixed workflow per `ORDER_IDS`. Needed because the maileroo provider sends `data._template_html_content` **verbatim** (no re-render), so a bare notifications retry can't fix an old empty send.
- **`run-backfill.sh`** — forward `TEMPLATE_KEYS` / `ORDER_IDS`.

### Ops run order
```
TEMPLATE_KEYS=order-placed ./deploy/aws/scripts/run-backfill.sh update-email-templates
ORDER_IDS=order_01KXWHFP132AM0H940WFD2P0XW ./deploy/aws/scripts/run-backfill.sh resend-order-confirmation
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)