### PR TITLE
fix(partner-billing): resolve retail partner via store.default_sales_channel_id

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-retail-partner-fees-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-retail-partner-fees-job.ts
@@ -4,6 +4,7 @@ import { z } from "@medusajs/framework/zod"
 import { PARTNER_BILLING_MODULE } from "../../../../modules/partner_billing"
 import { computeRetailSplitFee } from "../../../../modules/partner_billing/compute-fee"
 import { resolveRetailFeeRates } from "../../../../modules/partner_billing/resolve-fee-rate"
+import { buildRetailPartnerBySalesChannel } from "../../../../modules/partner_billing/resolve-retail-partner"
 import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
 
 const MAX_RETAIL_FEE_BACKFILL_SCAN = 5000
@@ -64,27 +65,9 @@ export const backfillRetailPartnerFeesJob: MaintenanceJob = {
     const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
     const billing: any = container.resolve(PARTNER_BILLING_MODULE)
 
-    // Build sales_channel_id → partner_id (partners/stores are few).
-    const { data: partnerStoreLinks } = await query.graph({
-      entity: "partner_partner_store_store",
-      fields: ["partner_id", "store_id"],
-      pagination: { skip: 0, take: 1000 },
-    })
-    const partnerByStore = new Map<string, string>()
-    for (const l of partnerStoreLinks || []) {
-      if (l?.store_id && l?.partner_id) partnerByStore.set(l.store_id, l.partner_id)
-    }
-
-    const { data: salesChannels } = await query.graph({
-      entity: "sales_channel",
-      fields: ["id", "store.id"],
-      pagination: { skip: 0, take: 1000 },
-    })
-    const partnerBySc = new Map<string, string>()
-    for (const sc of salesChannels || []) {
-      const pid = sc?.store?.id ? partnerByStore.get(sc.store.id) : undefined
-      if (pid) partnerBySc.set(sc.id, pid)
-    }
+    // Map partner store default sales channel → partner_id (the retail
+    // ownership rule; partners are few).
+    const partnerBySc = await buildRetailPartnerBySalesChannel(container)
 
     const ratesByPartner = new Map<string, { gateway_bps: number; commission_bps: number }>()
     const ratesFor = async (pid: string) => {

--- a/apps/backend/src/modules/partner_billing/resolve-retail-partner.ts
+++ b/apps/backend/src/modules/partner_billing/resolve-retail-partner.ts
@@ -1,37 +1,55 @@
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
 /**
- * Resolve the owning partner for a RETAIL order by traversing
- *   order.sales_channel_id → sales_channel ↔ store → partner_store link → partner
+ * Resolve the owning partner for a RETAIL order from its sales channel.
  *
- * This is the retail counterpart to the work-order `partner↔order` D3 link:
- * storefront (retail) orders have no work-order link, so their partner is found
- * through the sales channel's store. Returns null for the platform's own
- * (non-partner) stores and on any lookup failure — accrual must never throw.
+ * Retail (storefront) orders have no partner↔order work-order link. Ownership is
+ * defined exactly as `validatePartnerOrderOwnership` does it:
+ *   order.sales_channel_id === partner.store.default_sales_channel_id
+ * i.e. the order sits in the partner store's default sales channel. We read
+ * every partner's `stores.default_sales_channel_id` (partners are few) and match.
+ *
+ * (The earlier `sales_channel → store → partner_partner_store_store` traversal
+ * was wrong: `sales_channel.store` isn't exposed and the link alias doesn't
+ * resolve — it always returned null.)
+ *
+ * Returns null for the platform's own (non-partner) channels and on any lookup
+ * failure — accrual must never throw.
  */
 export async function resolveRetailPartnerId(
   container: any,
   salesChannelId: string | null | undefined
 ): Promise<string | null> {
   if (!salesChannelId) return null
-  const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
-  try {
-    const { data: scLinks } = await query.graph({
-      entity: "sales_channel",
-      fields: ["id", "store.id"],
-      filters: { id: salesChannelId },
-    })
-    const storeId = scLinks?.[0]?.store?.id || null
-    if (!storeId) return null
+  const map = await buildRetailPartnerBySalesChannel(container)
+  return map.get(salesChannelId) || null
+}
 
-    const { data: partnerStoreLinks } = await query.graph({
-      entity: "partner_partner_store_store",
-      fields: ["partner_id"],
-      filters: { store_id: storeId },
-      pagination: { skip: 0, take: 1 },
+/**
+ * Build a `default_sales_channel_id → partner_id` map for all partners in one
+ * query — shared by the single-order resolver and the backfill job (which
+ * resolves many orders and shouldn't re-scan partners per order). Never throws.
+ */
+export async function buildRetailPartnerBySalesChannel(
+  container: any
+): Promise<Map<string, string>> {
+  const map = new Map<string, string>()
+  try {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+    const { data: partners } = await query.graph({
+      entity: "partners",
+      fields: ["id", "stores.default_sales_channel_id"],
+      pagination: { skip: 0, take: 1000 },
     })
-    return partnerStoreLinks?.[0]?.partner_id || null
+    for (const p of partners || []) {
+      for (const st of p?.stores || []) {
+        if (st?.default_sales_channel_id && p?.id) {
+          map.set(st.default_sales_channel_id, p.id)
+        }
+      }
+    }
   } catch {
-    return null
+    // best-effort — empty map means no retail partner resolves (accrual skipped)
   }
+  return map
 }

--- a/apps/backend/src/workflows/email/workflows/send-order-confirmation-email.ts
+++ b/apps/backend/src/workflows/email/workflows/send-order-confirmation-email.ts
@@ -1,10 +1,11 @@
 import { createWorkflow, createStep, StepResponse, transform } from "@medusajs/framework/workflows-sdk"
-import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { Modules } from "@medusajs/framework/utils"
 import type { IOrderModuleService } from "@medusajs/types"
 import { sendNotificationEmailStep } from "../steps/send-notification-email"
 import { fetchEmailTemplateStep } from "../steps/fetch-email-template"
 import { PARTNER_MODULE } from "../../../modules/partner"
 import PartnerService from "../../../modules/partner/service"
+import { resolveRetailPartnerId } from "../../../modules/partner_billing/resolve-retail-partner"
 
 /**
  * Retrieve the order with the relations we need to render the confirmation.
@@ -32,14 +33,12 @@ const retrieveOrderStep = createStep(
  * payload whose keys never matched the template's flat `{{customer_first_name}}`
  * / `{{order_display_id}}` / `{{order_total}}` / `{{order_email}}` variables, so
  * Handlebars rendered every field as an empty string ("Hi ,", "Order #",
- * "Total: "). This step resolves the partner via
- * order → sales_channel → store → partner_store link and formats the money.
+ * "Total: "). This step resolves the partner via the retail ownership rule
+ * (order.sales_channel_id === store.default_sales_channel_id) and formats money.
  */
 const buildOrderConfirmationVarsStep = createStep(
   { name: "build-order-confirmation-vars", store: true },
   async ({ order }: { order: any }, { container }) => {
-    const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
-
     // --- Order-level flat vars -------------------------------------------
     const items = (order?.items || []) as any[]
     // Prefer the order's computed grand total (includes shipping + tax); fall
@@ -63,49 +62,32 @@ const buildOrderConfirmationVarsStep = createStep(
       order?.email ||
       "Customer"
 
-    // --- Partner context: order → sales_channel → store → partner --------
+    // --- Partner context: order → (store default sales channel) → partner --
+    // Retail ownership rule: order.sales_channel_id === store.default_sales_channel_id
+    // (same as validatePartnerOrderOwnership / the fee subscriber).
     let partnerName = ""
     let storeUrl = process.env.FRONTEND_URL || ""
 
     try {
-      let storeId: string | null = null
-      if (order?.sales_channel_id) {
-        const { data: scLinks } = await query.graph({
-          entity: "sales_channel",
-          fields: ["id", "store.id"],
-          filters: { id: order.sales_channel_id },
-        })
-        storeId = scLinks?.[0]?.store?.id || null
-      }
-
-      if (storeId) {
-        const { data: partnerStoreLinks } = await query.graph({
-          entity: "partner_partner_store_store",
-          fields: ["partner_id"],
-          filters: { store_id: storeId },
-          pagination: { skip: 0, take: 1 },
-        })
-        const partnerId = partnerStoreLinks?.[0]?.partner_id || null
-
-        if (partnerId) {
-          const partnerService: PartnerService =
-            container.resolve(PARTNER_MODULE)
-          const partners = await partnerService.listPartners(
-            { id: partnerId },
-            { select: ["id", "name", "handle", "storefront_domain", "metadata"] }
-          )
-          const partner = (partners as any[])?.[0]
-          if (partner) {
-            partnerName = partner.name || ""
-            const domain =
-              partner.storefront_domain ||
-              partner.metadata?.storefront_domain ||
-              ""
-            if (domain) {
-              storeUrl = /^https?:\/\//i.test(domain)
-                ? domain
-                : `https://${domain}`
-            }
+      const partnerId = await resolveRetailPartnerId(
+        container,
+        order?.sales_channel_id
+      )
+      if (partnerId) {
+        const partnerService: PartnerService = container.resolve(PARTNER_MODULE)
+        const partners = await partnerService.listPartners(
+          { id: partnerId },
+          { select: ["id", "name", "handle", "storefront_domain", "metadata"] }
+        )
+        const partner = (partners as any[])?.[0]
+        if (partner) {
+          partnerName = partner.name || ""
+          const domain =
+            partner.storefront_domain ||
+            partner.metadata?.storefront_domain ||
+            ""
+          if (domain) {
+            storeUrl = /^https?:\/\//i.test(domain) ? domain : `https://${domain}`
           }
         }
       }


### PR DESCRIPTION
Follow-up to #1100 / #1101. The retail partner resolver used a broken traversal (`order → sales_channel → store → partner_partner_store_store`): `sales_channel.store` isn't exposed by the graph and the link alias `partner_partner_store_store` doesn't resolve (`Service with alias … was not found`). So **retail fee accrual** and the **order-confirmation partner branding** always fell through to null.

Fix: use the authoritative retail-ownership rule (same as `validatePartnerOrderOwnership`) — `order.sales_channel_id === partner.store.default_sales_channel_id`. Verified against prod: Sharlho's `store.default_sales_channel_id` matches order #79's sales channel.

- `resolve-retail-partner.ts` — rewrite; add `buildRetailPartnerBySalesChannel`.
- `backfill-retail-partner-fees-job.ts` — use the shared map builder.
- `send-order-confirmation-email.ts` — use `resolveRetailPartnerId` for partner name + storefront URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)