### PR TITLE
fix(ops): surface partner-order-* templates under the partner seed set

### DIFF
--- a/apps/backend/src/api/admin/ops/maintenance-jobs/seed-jobs.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/seed-jobs.ts
@@ -41,6 +41,19 @@ export type EmailTemplateSpec = {
   [key: string]: unknown
 }
 
+// The partner order-lifecycle templates (partner-order-placed / -fulfilled /
+// -cancelled) physically live in the core `emailTemplatesData`, but they are
+// logically partner/admin templates. Surface them under the `partner` set too so
+// `set=partner` (UI + API) can seed / overwrite them — e.g.
+// `{ set: "partner", only: "partner-order-placed", overwrite: true }`. They stay
+// in `core` as well; `resolveEmailTemplateSpecs` dedupes by `template_key`
+// (first occurrence wins), so the overlap is harmless.
+const partnerOrderTemplates = (emailTemplatesData as EmailTemplateSpec[]).filter(
+  (t) =>
+    typeof t.template_key === "string" &&
+    t.template_key.startsWith("partner-order-")
+)
+
 /** Selectable email-template sets, each wrapping one seed script's data. */
 export const EMAIL_TEMPLATE_SETS: Array<{
   key: string
@@ -65,7 +78,10 @@ export const EMAIL_TEMPLATE_SETS: Array<{
   {
     key: "partner",
     label: "partner/admin templates",
-    specs: partnerEmailTemplates as EmailTemplateSpec[],
+    specs: [
+      ...(partnerEmailTemplates as EmailTemplateSpec[]),
+      ...partnerOrderTemplates,
+    ],
   },
   {
     key: "investor",


### PR DESCRIPTION
`partner-order-placed` / `-fulfilled` / `-cancelled` live in the **core** `emailTemplatesData`, not the `partner` set. So `seedEmailTemplatesJob` scoped to `set=partner, only=partner-order-placed` planned nothing → reads as **"partner-order-placed is not there"**.

They're partner/admin templates, so include them in the `partner` set too (pulled from core by `partner-order-` key prefix). They stay in `core` as well; `resolveEmailTemplateSpecs` dedupes by `template_key` (first-wins), so the overlap is harmless.

**Runnable after deploy:**
```
POST /admin/ops/maintenance-jobs/seed-email-templates/run
{ "dry_run": false, "params": { "set": "partner", "only": "partner-order-placed", "overwrite": true } }
```
(Already works today with the default set / `set=core` — the template resolves there. Verified it exists + is active in prod.)

Note: an unrelated pre-existing test failure in `seed-additional-email-templates.unit.spec.ts` (duplicate key in the *additional* set) is not touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)