### PR TITLE
fix(partner-emails): fix partner resolution + branded templates with item thumbnails

### DIFF
--- a/apps/backend/src/scripts/seed-email-templates.ts
+++ b/apps/backend/src/scripts/seed-email-templates.ts
@@ -1043,43 +1043,67 @@ export const emailTemplatesData = [
     from: "partner@partner.jaalyantra.com",
     subject: "New order received: #{{order_display_id}}",
     html_content: `
-      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; background-color: #f9f9f9;">
-        <div style="background-color: #ffffff; padding: 30px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
-          <h1 style="color: #16a34a; font-size: 24px; margin-bottom: 20px;">New Order Received!</h1>
-          <p style="color: #333333; font-size: 16px; margin-bottom: 15px;">Hi {{partner_name}},</p>
-          <p style="color: #666666; font-size: 16px; line-height: 1.5; margin-bottom: 20px;">
-            You have received a new order on your store <strong>{{store_name}}</strong>.
-          </p>
-          <div style="margin: 20px 0; padding: 20px; background-color: #f0fdf4; border-radius: 6px; border-left: 4px solid #16a34a;">
-            <h3 style="color: #15803d; font-size: 18px; margin: 0 0 12px 0;">Order #{{order_display_id}}</h3>
-            <table style="width: 100%; border-collapse: collapse;">
-              <tr><td style="padding: 4px 0; color: #666; font-size: 14px;"><strong>Customer:</strong></td><td style="padding: 4px 0; font-size: 14px;">{{customer_name}} ({{customer_email}})</td></tr>
-              <tr><td style="padding: 4px 0; color: #666; font-size: 14px;"><strong>Total:</strong></td><td style="padding: 4px 0; font-size: 14px; font-weight: 600;">{{order_total}}</td></tr>
-              <tr><td style="padding: 4px 0; color: #666; font-size: 14px;"><strong>Items:</strong></td><td style="padding: 4px 0; font-size: 14px;">{{item_count}} item(s)</td></tr>
-              <tr><td style="padding: 4px 0; color: #666; font-size: 14px;"><strong>Payment:</strong></td><td style="padding: 4px 0; font-size: 14px;">{{payment_status}}</td></tr>
-            </table>
+      <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 24px; background-color: #f4f4f5;">
+        <div style="background-color: #ffffff; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.08);">
+          <div style="background-color: #16a34a; padding: 24px 32px;">
+            <p style="color: rgba(255,255,255,0.85); font-size: 12px; text-transform: uppercase; letter-spacing: 1px; margin: 0 0 4px 0;">{{store_name}}</p>
+            <h1 style="color: #ffffff; font-size: 22px; margin: 0; font-weight: 600;">New order received</h1>
           </div>
-          {{#if items}}
-          <div style="margin: 20px 0;">
-            <h4 style="color: #333; font-size: 14px; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 12px;">Order Items</h4>
-            {{#each items}}
-            <div style="display: flex; justify-content: space-between; padding: 10px 0; border-bottom: 1px solid #f0f0f0;">
-              <span style="color: #333; font-size: 14px;">{{title}} × {{quantity}}</span>
-              <span style="color: #666; font-size: 14px;">{{price}}</span>
+          <div style="padding: 28px 32px;">
+            <p style="color: #18181b; font-size: 15px; margin: 0 0 8px 0;">Hi {{partner_name}},</p>
+            <p style="color: #52525b; font-size: 15px; line-height: 1.6; margin: 0 0 24px 0;">
+              You have received a new order on your store <strong>{{store_name}}</strong>. Here are the details.
+            </p>
+            <div style="border: 1px solid #e4e4e7; border-radius: 10px; padding: 20px; margin-bottom: 24px;">
+              <div style="display: flex; justify-content: space-between; margin-bottom: 12px;">
+                <span style="color: #71717a; font-size: 13px;">Order</span>
+                <span style="color: #18181b; font-size: 14px; font-weight: 600;">#{{order_display_id}}</span>
+              </div>
+              <table role="presentation" width="100%" style="border-collapse: collapse; font-size: 14px;">
+                <tr><td style="padding: 4px 0; color: #71717a;">Customer</td><td align="right" style="padding: 4px 0; color: #18181b;">{{customer_name}}</td></tr>
+                <tr><td style="padding: 4px 0; color: #71717a;">Email</td><td align="right" style="padding: 4px 0; color: #18181b;">{{customer_email}}</td></tr>
+                <tr><td style="padding: 4px 0; color: #71717a;">Items</td><td align="right" style="padding: 4px 0; color: #18181b;">{{item_count}}</td></tr>
+                <tr><td style="padding: 4px 0; color: #71717a;">Payment</td><td align="right" style="padding: 4px 0; color: #18181b; text-transform: capitalize;">{{payment_status}}</td></tr>
+              </table>
             </div>
-            {{/each}}
+            {{#if items}}
+            <h4 style="color: #71717a; font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; margin: 0 0 12px 0;">Order items</h4>
+            <table role="presentation" width="100%" style="border-collapse: collapse; margin-bottom: 20px;">
+              {{#each items}}
+              <tr>
+                <td width="60" valign="top" style="padding: 12px 0; border-bottom: 1px solid #f4f4f5;">
+                  {{#if thumbnail}}
+                  <img src="{{thumbnail}}" width="48" height="48" alt="" style="width: 48px; height: 48px; border-radius: 8px; object-fit: cover; display: block; border: 1px solid #e4e4e7;" />
+                  {{else}}
+                  <div style="width: 48px; height: 48px; border-radius: 8px; background-color: #f4f4f5; border: 1px solid #e4e4e7;"></div>
+                  {{/if}}
+                </td>
+                <td valign="top" style="padding: 12px 0 12px 12px; border-bottom: 1px solid #f4f4f5;">
+                  <div style="color: #18181b; font-size: 14px; font-weight: 600; line-height: 1.3;">{{title}}</div>
+                  {{#if variant_title}}<div style="color: #a1a1aa; font-size: 12px; margin-top: 2px;">{{variant_title}}</div>{{/if}}
+                  <div style="color: #a1a1aa; font-size: 12px; margin-top: 2px;">Qty {{quantity}}</div>
+                </td>
+                <td valign="top" align="right" style="padding: 12px 0; border-bottom: 1px solid #f4f4f5; color: #18181b; font-size: 14px; font-weight: 600; white-space: nowrap;">{{price}}</td>
+              </tr>
+              {{/each}}
+              <tr>
+                <td colspan="2" style="padding: 14px 0 0 0; color: #18181b; font-size: 15px; font-weight: 700;">Total</td>
+                <td align="right" style="padding: 14px 0 0 0; color: #16a34a; font-size: 15px; font-weight: 700; white-space: nowrap;">{{order_total}}</td>
+              </tr>
+            </table>
+            {{/if}}
+            {{#if order_url}}
+            <div style="margin: 28px 0; text-align: center;">
+              <a href="{{order_url}}" style="background-color: #16a34a; color: #ffffff; padding: 13px 28px; text-decoration: none; border-radius: 8px; display: inline-block; font-weight: 600; font-size: 14px;">
+                View order details
+              </a>
+            </div>
+            {{/if}}
+            <p style="color: #a1a1aa; font-size: 13px; line-height: 1.6; margin: 24px 0 0 0; border-top: 1px solid #f4f4f5; padding-top: 16px;">
+              Please process this order as soon as possible from your partner dashboard.<br/>
+              &copy; {{current_year}} {{store_name}}
+            </p>
           </div>
-          {{/if}}
-          {{#if order_url}}
-          <div style="margin: 30px 0; text-align: center;">
-            <a href="{{order_url}}" style="background-color: #16a34a; color: white; padding: 14px 28px; text-decoration: none; border-radius: 6px; display: inline-block; font-weight: bold;">
-              View Order Details
-            </a>
-          </div>
-          {{/if}}
-          <p style="color: #999999; font-size: 14px; margin-top: 20px;">
-            Please process this order as soon as possible. You can manage it from your partner dashboard.
-          </p>
         </div>
       </div>
     `,
@@ -1092,8 +1116,9 @@ export const emailTemplatesData = [
       order_total: "Formatted total amount",
       item_count: "Number of items",
       payment_status: "Payment status (paid, pending, etc.)",
-      items: "Array of { title, quantity, price }",
+      items: "Array of { title, variant_title, quantity, price, thumbnail }",
       order_url: "URL to order in partner dashboard (optional)",
+      current_year: "Current year",
     },
     template_type: "partner_order_placed",
     is_active: true
@@ -1104,41 +1129,71 @@ export const emailTemplatesData = [
     from: "partner@partner.jaalyantra.com",
     subject: "Order #{{order_display_id}} has been fulfilled",
     html_content: `
-      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; background-color: #f9f9f9;">
-        <div style="background-color: #ffffff; padding: 30px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
-          <h1 style="color: #0369a1; font-size: 24px; margin-bottom: 20px;">Order Fulfilled</h1>
-          <p style="color: #333333; font-size: 16px; margin-bottom: 15px;">Hi {{admin_first_name}},</p>
-          <p style="color: #666666; font-size: 16px; line-height: 1.5; margin-bottom: 20px;">
-            Order <strong>#{{order_display_id}}</strong> for <strong>{{customer_name}}</strong> has been fulfilled and is on its way.
-          </p>
-          {{#if tracking_number}}
-          <div style="margin: 20px 0; padding: 20px; background-color: #f0f9ff; border-radius: 6px; border-left: 4px solid #0369a1;">
-            <p style="color: #333; font-size: 14px; margin: 0 0 8px 0;"><strong>Tracking Number:</strong> {{tracking_number}}</p>
-            <p style="color: #333; font-size: 14px; margin: 0 0 8px 0;"><strong>Carrier:</strong> {{carrier_name}}</p>
-            {{#if tracking_url}}
-            <a href="{{tracking_url}}" style="color: #0369a1; font-size: 14px; font-weight: 600; text-decoration: underline;">Track your shipment →</a>
-            {{/if}}
+      <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 24px; background-color: #f4f4f5;">
+        <div style="background-color: #ffffff; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.08);">
+          <div style="background-color: #0369a1; padding: 24px 32px;">
+            <p style="color: rgba(255,255,255,0.85); font-size: 12px; text-transform: uppercase; letter-spacing: 1px; margin: 0 0 4px 0;">{{store_name}}</p>
+            <h1 style="color: #ffffff; font-size: 22px; margin: 0; font-weight: 600;">Order fulfilled</h1>
           </div>
-          {{/if}}
-          <div style="margin: 20px 0; padding: 20px; background-color: #f8f9fa; border-radius: 6px;">
-            <h4 style="color: #333; margin: 0 0 12px 0; font-size: 14px; text-transform: uppercase; letter-spacing: 0.05em;">Shipping Address</h4>
-            <p style="color: #666; font-size: 14px; line-height: 1.6; margin: 0;">
-              {{shipping_address_line1}}<br/>
-              {{#if shipping_address_line2}}{{shipping_address_line2}}<br/>{{/if}}
-              {{shipping_city}}, {{shipping_postal_code}}<br/>
-              {{shipping_country}}
+          <div style="padding: 28px 32px;">
+            <p style="color: #18181b; font-size: 15px; margin: 0 0 8px 0;">Hi {{admin_first_name}},</p>
+            <p style="color: #52525b; font-size: 15px; line-height: 1.6; margin: 0 0 24px 0;">
+              Order <strong>#{{order_display_id}}</strong> for <strong>{{customer_name}}</strong> has been fulfilled and is on its way.
+            </p>
+            {{#if tracking_number}}
+            <div style="margin: 0 0 24px 0; padding: 18px 20px; background-color: #f0f9ff; border-radius: 10px; border: 1px solid #bae6fd;">
+              <p style="color: #0c4a6e; font-size: 14px; margin: 0 0 6px 0;"><strong>Tracking:</strong> {{tracking_number}}</p>
+              <p style="color: #0c4a6e; font-size: 14px; margin: 0 0 6px 0;"><strong>Carrier:</strong> {{carrier_name}}</p>
+              {{#if tracking_url}}
+              <a href="{{tracking_url}}" style="color: #0369a1; font-size: 14px; font-weight: 600; text-decoration: underline;">Track your shipment →</a>
+              {{/if}}
+            </div>
+            {{/if}}
+            {{#if items}}
+            <h4 style="color: #71717a; font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; margin: 0 0 12px 0;">Items shipped</h4>
+            <table role="presentation" width="100%" style="border-collapse: collapse; margin-bottom: 20px;">
+              {{#each items}}
+              <tr>
+                <td width="60" valign="top" style="padding: 12px 0; border-bottom: 1px solid #f4f4f5;">
+                  {{#if thumbnail}}
+                  <img src="{{thumbnail}}" width="48" height="48" alt="" style="width: 48px; height: 48px; border-radius: 8px; object-fit: cover; display: block; border: 1px solid #e4e4e7;" />
+                  {{else}}
+                  <div style="width: 48px; height: 48px; border-radius: 8px; background-color: #f4f4f5; border: 1px solid #e4e4e7;"></div>
+                  {{/if}}
+                </td>
+                <td valign="top" style="padding: 12px 0 12px 12px; border-bottom: 1px solid #f4f4f5;">
+                  <div style="color: #18181b; font-size: 14px; font-weight: 600; line-height: 1.3;">{{title}}</div>
+                  {{#if variant_title}}<div style="color: #a1a1aa; font-size: 12px; margin-top: 2px;">{{variant_title}}</div>{{/if}}
+                  <div style="color: #a1a1aa; font-size: 12px; margin-top: 2px;">Qty {{quantity}}</div>
+                </td>
+                <td valign="top" align="right" style="padding: 12px 0; border-bottom: 1px solid #f4f4f5; color: #18181b; font-size: 14px; font-weight: 600; white-space: nowrap;">{{price}}</td>
+              </tr>
+              {{/each}}
+            </table>
+            {{/if}}
+            <div style="margin: 0 0 24px 0; padding: 18px 20px; background-color: #fafafa; border-radius: 10px; border: 1px solid #e4e4e7;">
+              <h4 style="color: #71717a; margin: 0 0 8px 0; font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em;">Shipping address</h4>
+              <p style="color: #3f3f46; font-size: 14px; line-height: 1.6; margin: 0;">
+                {{shipping_address_line1}}<br/>
+                {{#if shipping_address_line2}}{{shipping_address_line2}}<br/>{{/if}}
+                {{shipping_city}}, {{shipping_postal_code}}<br/>
+                {{shipping_country}}
+              </p>
+            </div>
+            <p style="color: #a1a1aa; font-size: 13px; line-height: 1.6; margin: 0; border-top: 1px solid #f4f4f5; padding-top: 16px;">
+              If you have questions about this order, reach {{store_name}} by replying to this email.<br/>
+              &copy; {{current_year}} {{store_name}}
             </p>
           </div>
-          <p style="color: #999999; font-size: 14px; margin-top: 24px;">
-            If you have questions about your order, you can reach {{store_name}} by replying to this email.
-          </p>
         </div>
       </div>
     `,
     variables: {
+      admin_first_name: "Partner admin first name",
       customer_name: "Customer's name",
       order_display_id: "Order display ID",
       store_name: "Partner store name",
+      items: "Array of { title, variant_title, quantity, price, thumbnail }",
       tracking_number: "Shipment tracking number (optional)",
       carrier_name: "Shipping carrier name (optional)",
       tracking_url: "Tracking URL (optional)",
@@ -1147,6 +1202,7 @@ export const emailTemplatesData = [
       shipping_city: "City",
       shipping_postal_code: "Postal code",
       shipping_country: "Country",
+      current_year: "Current year",
     },
     template_type: "partner_order_fulfilled",
     is_active: true
@@ -1157,35 +1213,43 @@ export const emailTemplatesData = [
     from: "partner@partner.jaalyantra.com",
     subject: "Order #{{order_display_id}} has been cancelled",
     html_content: `
-      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; background-color: #f9f9f9;">
-        <div style="background-color: #ffffff; padding: 30px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
-          <h1 style="color: #dc2626; font-size: 24px; margin-bottom: 20px;">Order Cancelled</h1>
-          <p style="color: #333333; font-size: 16px; margin-bottom: 15px;">Hi {{admin_first_name}},</p>
-          <p style="color: #666666; font-size: 16px; line-height: 1.5; margin-bottom: 20px;">
-            Order <strong>#{{order_display_id}}</strong> for <strong>{{customer_name}}</strong> has been cancelled.
-          </p>
-          {{#if cancellation_reason}}
-          <div style="margin: 20px 0; padding: 16px; background-color: #fef2f2; border-radius: 6px; border-left: 4px solid #dc2626;">
-            <p style="color: #991b1b; font-size: 14px; margin: 0;"><strong>Reason:</strong> {{cancellation_reason}}</p>
+      <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 24px; background-color: #f4f4f5;">
+        <div style="background-color: #ffffff; border-radius: 12px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.08);">
+          <div style="background-color: #dc2626; padding: 24px 32px;">
+            <p style="color: rgba(255,255,255,0.85); font-size: 12px; text-transform: uppercase; letter-spacing: 1px; margin: 0 0 4px 0;">{{store_name}}</p>
+            <h1 style="color: #ffffff; font-size: 22px; margin: 0; font-weight: 600;">Order cancelled</h1>
           </div>
-          {{/if}}
-          <div style="margin: 20px 0; padding: 16px; background-color: #f0fdf4; border-radius: 6px;">
-            <p style="color: #15803d; font-size: 14px; margin: 0;">
-              {{#if refund_amount}}<strong>Refund:</strong> {{refund_amount}} will be returned to your original payment method within 5-10 business days.{{else}}If you were charged, a refund will be processed automatically.{{/if}}
+          <div style="padding: 28px 32px;">
+            <p style="color: #18181b; font-size: 15px; margin: 0 0 8px 0;">Hi {{admin_first_name}},</p>
+            <p style="color: #52525b; font-size: 15px; line-height: 1.6; margin: 0 0 24px 0;">
+              Order <strong>#{{order_display_id}}</strong> for <strong>{{customer_name}}</strong> has been cancelled.
+            </p>
+            {{#if cancellation_reason}}
+            <div style="margin: 0 0 20px 0; padding: 16px 20px; background-color: #fef2f2; border-radius: 10px; border: 1px solid #fecaca;">
+              <p style="color: #991b1b; font-size: 14px; margin: 0;"><strong>Reason:</strong> {{cancellation_reason}}</p>
+            </div>
+            {{/if}}
+            <div style="margin: 0 0 20px 0; padding: 16px 20px; background-color: #f0fdf4; border-radius: 10px; border: 1px solid #bbf7d0;">
+              <p style="color: #15803d; font-size: 14px; margin: 0;">
+                {{#if refund_amount}}<strong>Refund:</strong> {{refund_amount}} will be returned to the original payment method within 5-10 business days.{{else}}If the customer was charged, a refund will be processed automatically.{{/if}}
+              </p>
+            </div>
+            <p style="color: #a1a1aa; font-size: 13px; line-height: 1.6; margin: 0; border-top: 1px solid #f4f4f5; padding-top: 16px;">
+              If you have questions, reply to this email or contact our support team.<br/>
+              &copy; {{current_year}} {{store_name}}
             </p>
           </div>
-          <p style="color: #999999; font-size: 14px; margin-top: 24px;">
-            If you have questions, reply to this email or contact our support team.
-          </p>
         </div>
       </div>
     `,
     variables: {
+      admin_first_name: "Partner admin first name",
       customer_name: "Customer's name",
       order_display_id: "Order display ID",
       store_name: "Partner store name",
       cancellation_reason: "Reason for cancellation (optional)",
       refund_amount: "Formatted refund amount (optional)",
+      current_year: "Current year",
     },
     template_type: "partner_order_cancelled",
     is_active: true

--- a/apps/backend/src/workflows/email/steps/resolve-partner-from-order.ts
+++ b/apps/backend/src/workflows/email/steps/resolve-partner-from-order.ts
@@ -3,6 +3,8 @@ import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
 import type { IOrderModuleService } from "@medusajs/types"
 import { PARTNER_MODULE } from "../../../modules/partner"
 import PartnerService from "../../../modules/partner/service"
+import { resolveRetailPartnerId } from "../../../modules/partner_billing/resolve-retail-partner"
+import partnerOrderLink from "../../../links/partner-order"
 
 export type PartnerOrderContext = {
   order: any
@@ -21,13 +23,77 @@ export type PartnerOrderContext = {
   /** The from address for partner emails: partner+handle@partner.jaalyantra.com */
   partnerFromEmail: string
   partnerFromName: string
+  /** The partner store name (falls back to partner name). */
+  storeName: string
+  /** The partner storefront URL (from storefront_domain / metadata / FRONTEND_URL). */
+  storeUrl: string
+}
+
+const EMPTY = (order: any): PartnerOrderContext => ({
+  order,
+  partner: null,
+  partnerAdmins: [],
+  partnerFromEmail: "",
+  partnerFromName: "",
+  storeName: "",
+  storeUrl: process.env.FRONTEND_URL || "",
+})
+
+/**
+ * Backfill each line item's `thumbnail` from the live product — root thumbnail
+ * first, then the first image by rank. Medusa only ever snapshots the product
+ * ROOT thumbnail onto the line item at cart time, so a product that gained its
+ * image after the order was placed leaves `item.thumbnail` null forever. Same
+ * fallback the partner order API uses (api/partners/orders/[id]/route.ts).
+ */
+async function fillItemThumbnails(container: any, items: any[]): Promise<void> {
+  try {
+    const productIdOf = (it: any): string | undefined =>
+      it?.product_id || it?.variant?.product?.id || it?.variant?.product_id
+    const missing = items.filter((it) => !it?.thumbnail && productIdOf(it))
+    const productIds = Array.from(
+      new Set(missing.map((it) => productIdOf(it)).filter(Boolean))
+    ) as string[]
+    if (!productIds.length) return
+
+    const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+    const { data: products } = await query.graph({
+      entity: "product",
+      fields: ["id", "thumbnail", "images.url", "images.rank"],
+      filters: { id: productIds },
+    })
+    const thumbById = new Map<string, string | null | undefined>(
+      (products ?? []).map((p: any) => {
+        const firstImage = (p.images ?? [])
+          .slice()
+          .sort((a: any, b: any) => (a?.rank ?? 0) - (b?.rank ?? 0))[0]?.url
+        return [p.id, p.thumbnail || firstImage]
+      })
+    )
+    for (const it of missing) {
+      const pid = productIdOf(it)
+      const thumb = pid ? thumbById.get(pid) : undefined
+      if (thumb) it.thumbnail = thumb
+    }
+  } catch {
+    // best-effort: leave snapshot thumbnails as-is
+  }
 }
 
 /**
- * Resolves the partner associated with an order by traversing:
- *   order → sales_channel → store → partner_store link → partner → admins
+ * Resolve the partner that owns an order — the SAME two-rule ownership the
+ * partner API enforces (validatePartnerOrderOwnership):
+ *   1. Work order: the D3 partner↔order link (partner_partner_order_order).
+ *   2. Retail order: order.sales_channel_id === partner.store.default_sales_channel_id.
  *
- * Returns null partner and empty admins if the order has no partner association.
+ * The previous implementation traversed
+ * `sales_channel → store → partner_partner_store_store`, which always returned
+ * null (`sales_channel.store` isn't exposed and the link alias doesn't resolve),
+ * so partner order emails silently skipped — the templates existed and were
+ * active, but the partner never resolved. See #1102 / resolveRetailPartnerId.
+ *
+ * Also enriches the order with the relations the templates render (items with
+ * thumbnails, shipping/billing address) and the partner's store name + URL.
  */
 export const resolvePartnerFromOrderStep = createStep(
   "resolve-partner-from-order",
@@ -38,95 +104,55 @@ export const resolvePartnerFromOrderStep = createStep(
     const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
     const partnerService: PartnerService = container.resolve(PARTNER_MODULE)
 
-    // 1) Retrieve the order
+    // 1) Retrieve the order with the relations the templates need.
     const order: any = await orderService.retrieveOrder(input.orderId, {
-      relations: ["items"],
+      relations: ["items", "shipping_address", "billing_address"],
     })
 
     if (!order) {
-      return new StepResponse({
-        order: null,
-        partner: null,
-        partnerAdmins: [],
-        partnerFromEmail: "",
-        partnerFromName: "",
-      } as PartnerOrderContext)
+      return new StepResponse(EMPTY(null))
     }
 
-    // 2) Find the store for this order via sales_channel
-    //    Medusa links: sales_channel ↔ store, order has sales_channel_id
-    let storeId: string | null = null
-
-    if (order.sales_channel_id) {
-      try {
-        // Query the sales_channel → store link
-        const { data: scStoreLinks } = await query.graph({
-          entity: "sales_channel",
-          fields: ["id", "store.id"],
-          filters: { id: order.sales_channel_id },
-        })
-        storeId = scStoreLinks?.[0]?.store?.id || null
-      } catch {
-        // Fallback: query stores directly to find one
-      }
-    }
-
-    // If no store found via sales channel, try to find the default store
-    if (!storeId) {
-      try {
-        const { data: stores } = await query.graph({
-          entity: "store",
-          fields: ["id"],
-          pagination: { skip: 0, take: 1 },
-        })
-        storeId = stores?.[0]?.id || null
-      } catch {
-        // No store at all
-      }
-    }
-
-    if (!storeId) {
-      return new StepResponse({
-        order,
-        partner: null,
-        partnerAdmins: [],
-        partnerFromEmail: "",
-        partnerFromName: "",
-      } as PartnerOrderContext)
-    }
-
-    // 3) Find the partner linked to this store via the partner_partner_store_store link
+    // 2) Resolve the owning partner.
+    //    a) Work order: explicit D3 partner↔order link (source of truth).
     let partnerId: string | null = null
     try {
-      const { data: partnerStoreLinks } = await query.graph({
-        entity: "partner_partner_store_store",
+      const { data: links } = await query.graph({
+        entity: partnerOrderLink.entryPoint,
         fields: ["partner_id"],
-        filters: { store_id: storeId },
+        filters: { order_id: input.orderId },
         pagination: { skip: 0, take: 1 },
       })
-      partnerId = partnerStoreLinks?.[0]?.partner_id || null
+      partnerId = (links?.[0] as any)?.partner_id || null
     } catch {
-      // Link table might not exist or be empty
+      // link table absent / empty — fall through to retail
+    }
+
+    //    b) Retail order: sales-channel ownership rule (#1102).
+    if (!partnerId) {
+      partnerId = await resolveRetailPartnerId(container, order.sales_channel_id)
     }
 
     if (!partnerId) {
-      return new StepResponse({
-        order,
-        partner: null,
-        partnerAdmins: [],
-        partnerFromEmail: "",
-        partnerFromName: "",
-      } as PartnerOrderContext)
+      return new StepResponse(EMPTY(order))
     }
 
-    // 4) Fetch partner details + active admins
+    // 3) Fetch partner details + active admins + storefront info.
     let partner: any = null
     let admins: any[] = []
-
     try {
       const partners = await partnerService.listPartners(
         { id: partnerId },
-        { relations: ["admins"], select: ["id", "name", "handle"] }
+        {
+          relations: ["admins"],
+          select: [
+            "id",
+            "name",
+            "handle",
+            "storefront_domain",
+            "metadata",
+          ],
+        }
       )
       partner = (partners as any[])?.[0] || null
       admins = (partner?.admins || []).filter((a: any) => a.is_active)
@@ -137,16 +163,33 @@ export const resolvePartnerFromOrderStep = createStep(
       )
     }
 
-    const handle = partner?.handle || partner?.name?.toLowerCase().replace(/\s+/g, "-") || "partner"
-    const fromDomain = process.env.MAILEROO_FROM_DOMAIN || "partner.jaalyantra.com"
+    if (!partner) {
+      return new StepResponse(EMPTY(order))
+    }
+
+    // 4) Fill missing line-item thumbnails from the live products.
+    await fillItemThumbnails(container, (order?.items || []) as any[])
+
+    const handle =
+      partner.handle ||
+      partner.name?.toLowerCase().replace(/\s+/g, "-") ||
+      "partner"
+    const fromDomain =
+      process.env.MAILEROO_FROM_DOMAIN || "partner.jaalyantra.com"
     const partnerFromEmail = `partner+${handle}@${fromDomain}`
-    const partnerFromName = partner?.name || "Jaal Yantra Textiles Partner"
+    const partnerFromName = partner.name || "Jaal Yantra Textiles Partner"
+
+    const domain =
+      partner.storefront_domain || partner.metadata?.storefront_domain || ""
+    const storeUrl = domain
+      ? /^https?:\/\//i.test(domain)
+        ? domain
+        : `https://${domain}`
+      : process.env.FRONTEND_URL || ""
 
     const result: PartnerOrderContext = {
       order,
-      partner: partner
-        ? { id: partner.id, name: partner.name, handle }
-        : null,
+      partner: { id: partner.id, name: partner.name, handle },
       partnerAdmins: admins.map((a: any) => ({
         id: a.id,
         email: a.email,
@@ -156,6 +199,8 @@ export const resolvePartnerFromOrderStep = createStep(
       })),
       partnerFromEmail,
       partnerFromName,
+      storeName: partner.name || "",
+      storeUrl,
     }
 
     return new StepResponse(result)

--- a/apps/backend/src/workflows/email/workflows/send-partner-order-email.ts
+++ b/apps/backend/src/workflows/email/workflows/send-partner-order-email.ts
@@ -31,8 +31,15 @@ const sendPartnerOrderNotificationStep = createStep(
     { container }
   ) => {
     const { context, templateKey, extraData } = input
-    const { order, partner, partnerAdmins, partnerFromEmail, partnerFromName } =
-      context
+    const {
+      order,
+      partner,
+      partnerAdmins,
+      partnerFromEmail,
+      partnerFromName,
+      storeName,
+      storeUrl,
+    } = context
 
     if (!partner || partnerAdmins.length === 0) {
       console.log(
@@ -57,38 +64,83 @@ const sendPartnerOrderNotificationStep = createStep(
 
     // Compute order-level template data once
     const orderItems = (order?.items || []) as any[]
+    const currency = order?.currency_code?.toUpperCase() || "INR"
+    const money = (amount: number) =>
+      new Intl.NumberFormat("en-IN", {
+        style: "currency",
+        currency,
+      }).format(Number(amount) || 0)
+
+    // Prefer the order's computed grand total (shipping + tax); fall back to the
+    // line-item subtotal only when the total isn't populated.
+    const itemsSubtotal = orderItems.reduce(
+      (sum: number, item: any) =>
+        sum + (Number(item.unit_price) || 0) * (Number(item.quantity) || 0),
+      0
+    )
     const orderTotal =
-      orderItems.reduce(
-        (sum: number, item: any) =>
-          sum + (Number(item.unit_price) || 0) * (Number(item.quantity) || 0),
-        0
-      ) || 0
+      Number(order?.total) > 0 ? Number(order.total) : itemsSubtotal || 0
+
+    // Line items for the template — with thumbnails (backfilled in the resolve
+    // step), variant title, quantity and line total.
+    const lineItems = orderItems.map((item: any) => {
+      const quantity = Number(item?.quantity) || 0
+      const lineTotal = (Number(item?.unit_price) || 0) * quantity
+      return {
+        title: item?.product_title || item?.title || "Item",
+        variant_title: item?.variant_title || item?.subtitle || "",
+        quantity: String(quantity),
+        price: money(lineTotal),
+        unit_price: money(Number(item?.unit_price) || 0),
+        thumbnail: item?.thumbnail || "",
+      }
+    })
+
+    // Partner-facing order link (admin dashboard partner order view).
+    const backendUrl =
+      process.env.MEDUSA_ADMIN_BACKEND_URL || process.env.BACKEND_URL || ""
+    const orderUrl =
+      storeUrl && order?.id
+        ? `${storeUrl.replace(/\/$/, "")}/orders/${order.id}`
+        : backendUrl && order?.id
+          ? `${backendUrl.replace(/\/$/, "")}/app/orders/${order.id}`
+          : ""
+
+    const ship = order?.shipping_address || {}
 
     for (const admin of partnerAdmins) {
       const templateData = {
-        // Partner info
+        // Partner / store info
         partner_name: partner.name,
         partner_handle: partner.handle,
+        store_name: storeName || partner.name,
 
         // Admin info
         admin_name: `${admin.first_name} ${admin.last_name}`.trim(),
-        admin_first_name: admin.first_name,
+        admin_first_name: admin.first_name || partner.name,
 
         // Order info
         order_display_id: order?.display_id || order?.id || "",
         order_id: order?.id || "",
         order_email: order?.email || "",
-        order_total: new Intl.NumberFormat("en-IN", {
-          style: "currency",
-          currency: order?.currency_code?.toUpperCase() || "INR",
-        }).format(orderTotal),
+        order_total: money(orderTotal),
         item_count: String(orderItems.length),
-        customer_name: `${order?.shipping_address?.first_name || ""} ${order?.shipping_address?.last_name || ""}`.trim() || order?.email || "Customer",
+        items: lineItems,
+        payment_status: order?.payment_status || "pending",
+        customer_name: `${ship.first_name || ""} ${ship.last_name || ""}`.trim() || order?.email || "Customer",
         customer_email: order?.email || "",
 
-        // Metadata
+        // Shipping address
+        shipping_address_line1: ship.address_1 || "",
+        shipping_address_line2: ship.address_2 || "",
+        shipping_city: ship.city || "",
+        shipping_postal_code: ship.postal_code || "",
+        shipping_country: (ship.country_code || "").toUpperCase(),
+
+        // Links / metadata
+        order_url: orderUrl,
+        store_url: storeUrl || "",
         current_year: String(new Date().getFullYear()),
-        store_url: process.env.FRONTEND_URL || "",
 
         // Extra data (e.g., tracking, cancellation reason)
         ...extraData,


### PR DESCRIPTION
## Summary
Partner order emails (`partner-order-placed` / `-fulfilled` / `-cancelled`) were silently skipping because `resolve-partner-from-order` used the broken `sales_channel → store → partner_partner_store_store` traversal (always returned `null` — `sales_channel.store` isn't exposed and the link alias doesn't resolve). The templates existed and were active; the **resolution** was the bug. Follow-up to #1103.

## Changes
- **`resolve-partner-from-order.ts`** — resolve the owning partner with the same two-rule ownership the partner API enforces (`validatePartnerOrderOwnership`):
  1. Work orders → the D3 `partner↔order` link (`partnerOrderLink.entryPoint`)
  2. Retail orders → `resolveRetailPartnerId()` (`order.sales_channel_id === store.default_sales_channel_id`, per #1102)
  Also enriches the order (items + shipping/billing address), **backfills missing line-item thumbnails** from the live product (root thumbnail → first image by rank — same fallback as `api/partners/orders/[id]`), and resolves store name + storefront URL.
- **`send-partner-order-email.ts`** — populate the vars the templates always declared but never received: `items[]` (title, variant, qty, price, **thumbnail**), `store_name`, `payment_status`, `order_url`, `order_total` (order grand total → subtotal fallback), and shipping-address fields.
- **`seed-email-templates.ts`** — restyle all three templates into a shared branded, email-safe (table-based, not flexbox) layout with **line-item rows showing 48×48 thumbnails** (placeholder block when no image).

## Post-merge (re-seed prod templates)
```
POST /admin/ops/maintenance-jobs/seed-email-templates/run
{ params: { set: "partner", only: "partner-order-placed", overwrite: true } }
```
(repeat for `partner-order-fulfilled` / `partner-order-cancelled`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)