### PR TITLE
feat(mcp): consolidate MCP on mcp-core — store migration, admin Tier 2, V4 deprecation, #844 ledger [#1092]

### DIFF
--- a/apps/backend/integration-tests/http/admin-mcp/admin-mcp.spec.ts
+++ b/apps/backend/integration-tests/http/admin-mcp/admin-mcp.spec.ts
@@ -1,0 +1,153 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "../shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../../helpers/create-admin-user"
+import { AI_USAGE_MODULE } from "../../../src/modules/ai_usage"
+import type AiUsageService from "../../../src/modules/ai_usage/service"
+
+jest.setTimeout(120000)
+
+// Streamable HTTP requires the client to accept BOTH json and the SSE stream;
+// our transport runs with enableJsonResponse so the body comes back as JSON.
+const MCP_HEADERS = {
+  "Content-Type": "application/json",
+  Accept: "application/json, text/event-stream",
+}
+
+const rpc = (method: string, params: Record<string, unknown>, id = 1) => ({
+  jsonrpc: "2.0",
+  id,
+  method,
+  params,
+})
+
+setupSharedTestSuite(() => {
+  describe("Admin MCP (Tier 1 reads + Tier 2 writes + #844 ledger + V4 deprecation)", () => {
+    const { api, getContainer } = getSharedTestEnv()
+
+    let auth: { headers: Record<string, string> }
+
+    beforeEach(async () => {
+      await createAdminUser(getContainer())
+      auth = await getAuthHeaders(api) // { headers: { Authorization } }
+    })
+
+    const mcp = (body: any) =>
+      api.post("/admin/mcp", body, {
+        headers: { ...MCP_HEADERS, ...auth.headers },
+      })
+
+    const parse = (res: any) => JSON.parse(res.data.result.content[0].text)
+
+    it("tools/list exposes reads + Tier 2 writes, and hides the dangerous tool by default", async () => {
+      const res = await mcp(rpc("tools/list", {}))
+      expect(res.status).toBe(200)
+      const names = (res.data?.result?.tools ?? []).map((t: any) => t.name)
+      // Tier 1 reads
+      expect(names).toContain("get_admin_stats")
+      expect(names).toContain("list_orders")
+      // #844 + carried-over resolver
+      expect(names).toContain("get_mcp_usage")
+      expect(names).toContain("resolve_admin_query")
+      // Tier 2 writes (ADMIN_MCP_ENABLE_WRITE defaults on)
+      expect(names).toContain("create_product")
+      expect(names).toContain("update_product")
+      expect(names).toContain("update_customer")
+      // Dangerous: hidden unless ADMIN_MCP_ENABLE_DANGEROUS is enabled
+      expect(names).not.toContain("delete_product")
+    })
+
+    it("a read tool returns the {ok,tool,data} envelope", async () => {
+      const res = await mcp(
+        rpc("tools/call", { name: "get_admin_stats", arguments: {} })
+      )
+      expect(res.status).toBe(200)
+      const payload = parse(res)
+      expect(payload.ok).toBe(true)
+      expect(payload.tool).toBe("get_admin_stats")
+      expect(payload.data).toBeDefined()
+    })
+
+    it("a Tier 2 write returns requires_confirmation and does NOT execute without confirm", async () => {
+      const res = await mcp(
+        rpc("tools/call", {
+          name: "update_product",
+          arguments: { id: "prod_missing", title: "Nope" },
+        })
+      )
+      const payload = parse(res)
+      expect(payload.requires_confirmation).toBe(true)
+      expect(payload.plan?.method).toBe("POST")
+      expect(payload.plan?.path).toBe("/admin/products/prod_missing")
+    })
+
+    it("dry_run on a write previews the plan without executing", async () => {
+      const res = await mcp(
+        rpc("tools/call", {
+          name: "update_product",
+          arguments: { id: "prod_x", title: "X", dry_run: true },
+        })
+      )
+      const payload = parse(res)
+      expect(payload.dry_run).toBe(true)
+      expect(payload.plan?.path).toBe("/admin/products/prod_x")
+    })
+
+    it("the dangerous tool (delete_product) is refused while ADMIN_MCP_ENABLE_DANGEROUS is off", async () => {
+      const res = await mcp(
+        rpc("tools/call", {
+          name: "delete_product",
+          arguments: { id: "prod_x", confirm: true, reason: "test" },
+        })
+      )
+      const payload = parse(res)
+      expect(payload.ok).toBe(false)
+      expect(payload.error).toMatch(/dangerous/i)
+    })
+
+    it("persists every dispatch to the ai_usage ledger and get_mcp_usage reads it back (#844)", async () => {
+      await mcp(rpc("tools/call", { name: "get_admin_stats", arguments: {} }))
+      await mcp(rpc("tools/call", { name: "list_orders", arguments: { limit: 1 } }))
+      // The ledger sink is fire-and-forget — give the async write a tick.
+      await new Promise((r) => setTimeout(r, 750))
+
+      const aiUsage = getContainer().resolve(AI_USAGE_MODULE) as AiUsageService
+      const { events, count } = await aiUsage.listMcpUsage({ surface: "admin" })
+      expect(count).toBeGreaterThan(0)
+      expect(events.some((e: any) => e.operation === "mcp:get_admin_stats")).toBe(
+        true
+      )
+
+      const usage = await mcp(
+        rpc("tools/call", {
+          name: "get_mcp_usage",
+          arguments: { surface: "admin" },
+        })
+      )
+      const payload = parse(usage)
+      expect(payload.ok).toBe(true)
+      expect(payload.data.usage.by_surface.admin).toBeGreaterThan(0)
+    })
+
+    it("V4 admin chat resolve 410s when ADMIN_V4_CHAT_DEPRECATED is set, and the MCP resolver survives", async () => {
+      process.env.ADMIN_V4_CHAT_DEPRECATED = "true"
+      try {
+        const res = await api
+          .post(
+            "/admin/ai/chat/resolve",
+            { query: "list designs" },
+            { ...auth, validateStatus: () => true }
+          )
+          .catch((e: any) => e.response)
+        expect(res.status).toBe(410)
+        expect(res.data.deprecated).toBe(true)
+        expect(res.data.replacement?.resolve_tool).toBe("resolve_admin_query")
+
+        // The capability itself is not gated — the tool still lists.
+        const list = await mcp(rpc("tools/list", {}))
+        const names = (list.data?.result?.tools ?? []).map((t: any) => t.name)
+        expect(names).toContain("resolve_admin_query")
+      } finally {
+        delete process.env.ADMIN_V4_CHAT_DEPRECATED
+      }
+    })
+  })
+})

--- a/apps/backend/src/api/admin/ai/chat/chat/route.ts
+++ b/apps/backend/src/api/admin/ai/chat/chat/route.ts
@@ -15,6 +15,7 @@ import { MedusaError } from "@medusajs/framework/utils"
 import { v4 as uuidv4 } from "uuid"
 import { mastra, mastraStorageInit } from "../../../../../mastra"
 import { AdminAiChatReq, AdminAiChatReqType } from "./validators"
+import { isV4ChatDeprecated, respondV4Deprecated } from "../deprecation"
 
 /**
  * POST /admin/ai/chat/chat
@@ -66,6 +67,11 @@ import { AdminAiChatReq, AdminAiChatReqType } from "./validators"
  * }
  */
 export const POST = async (req: MedusaRequest<AdminAiChatReqType>, res: MedusaResponse) => {
+  // Retired in favor of the MCP-backed Admin Assistant when the flag is on.
+  if (isV4ChatDeprecated()) {
+    return respondV4Deprecated(res)
+  }
+
   const runId = uuidv4()
 
   try {
@@ -196,6 +202,11 @@ export const GET = async (_req: MedusaRequest, res: MedusaResponse) => {
     return res.json({
       status: "ok",
       version: "v4",
+      // Signals the UI to steer users to the new Admin Assistant. When true the
+      // POST handler returns 410; the status stays reachable so the UI can show
+      // a deprecation banner rather than silently failing.
+      deprecated: isV4ChatDeprecated(),
+      replacement: "/app/assistant",
       workflow: {
         available: workflowAvailable,
         name: "aiChatWorkflow",

--- a/apps/backend/src/api/admin/ai/chat/deprecation.ts
+++ b/apps/backend/src/api/admin/ai/chat/deprecation.ts
@@ -1,0 +1,40 @@
+/**
+ * V4 admin-chat deprecation gate (#1092).
+ *
+ * The legacy "V4" admin chat (`/admin/ai/chat/chat` + `/admin/ai/chat/resolve`,
+ * the Mastra `aiChatWorkflow` hybrid resolver) is superseded by the MCP-backed
+ * Admin Assistant (`/admin/assistant/chat`). This flag retires it WITHOUT
+ * deleting the code, so the cutover is reversible from config alone:
+ *
+ *   ADMIN_V4_CHAT_DEPRECATED=true   → the V4 routes return 410 and point callers
+ *                                     at the new assistant.
+ *   (unset / false, the default)    → V4 stays live; zero behavior change.
+ *
+ * No capability regresses: the V4 query-resolution is preserved as the admin
+ * MCP `resolve_admin_query` tool (POST /admin/mcp/resolve-query), which the new
+ * assistant can call.
+ */
+import { MedusaResponse } from "@medusajs/framework/http"
+
+export function isV4ChatDeprecated(): boolean {
+  const v = (process.env.ADMIN_V4_CHAT_DEPRECATED || "").trim().toLowerCase()
+  return v === "true" || v === "1" || v === "yes"
+}
+
+export function respondV4Deprecated(res: MedusaResponse): void {
+  res.status(410).json({
+    deprecated: true,
+    code: "admin_v4_chat_deprecated",
+    message:
+      "The V4 admin chat has been retired. Use the MCP-backed Admin Assistant " +
+      "at /app/assistant (POST /admin/assistant/chat). The query-resolution " +
+      "capability lives on as the admin MCP `resolve_admin_query` tool " +
+      "(POST /admin/mcp/resolve-query), so nothing is lost.",
+    replacement: {
+      ui: "/app/assistant",
+      chat: "/admin/assistant/chat",
+      resolve: "/admin/mcp/resolve-query",
+      resolve_tool: "resolve_admin_query",
+    },
+  })
+}

--- a/apps/backend/src/api/admin/ai/chat/resolve/route.ts
+++ b/apps/backend/src/api/admin/ai/chat/resolve/route.ts
@@ -28,6 +28,7 @@
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { HybridQueryResolverService } from "../../../../../mastra/services/hybrid-query-resolver"
+import { isV4ChatDeprecated, respondV4Deprecated } from "../deprecation"
 
 // Singleton instance
 let resolverInstance: HybridQueryResolverService | null = null
@@ -49,6 +50,12 @@ function getResolver(): HybridQueryResolverService {
  * Resolve a natural language query into an execution plan
  */
 export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  // Superseded by POST /admin/mcp/resolve-query (the resolve_admin_query MCP
+  // tool). When the V4 chat is retired, this legacy alias 410s and points there.
+  if (isV4ChatDeprecated()) {
+    return respondV4Deprecated(res)
+  }
+
   try {
     const body = (req as any).validatedBody || req.body
     const { query, options } = body as {

--- a/apps/backend/src/api/admin/assistant/chat/route.ts
+++ b/apps/backend/src/api/admin/assistant/chat/route.ts
@@ -43,6 +43,7 @@ import {
   isAdminDangerousEnabled,
   resolveAdminBaseUrl,
 } from "../../mcp/lib/handler"
+import { makeMcpLedgerSink } from "../../../../lib/mcp-ledger"
 import type { AdminAssistantChatReq } from "./validators"
 
 const FEATURE = "admin/assistant/chat"
@@ -90,6 +91,10 @@ export const POST = async (
     enableWrite: isAdminWriteEnabled(),
     enableDangerous: isAdminDangerousEnabled(),
     surface: "admin",
+    observe: makeMcpLedgerSink(req.scope, {
+      id: (req as any).auth_context?.actor_id ?? null,
+      type: "admin",
+    }),
   }
   const writeEnabled = ctx.enableWrite !== false
   const dangerousEnabled = ctx.enableDangerous === true

--- a/apps/backend/src/api/admin/mcp/lib/__tests__/dispatch.unit.spec.ts
+++ b/apps/backend/src/api/admin/mcp/lib/__tests__/dispatch.unit.spec.ts
@@ -12,7 +12,7 @@ import {
 } from "../../../../../lib/mcp-core"
 
 describe("admin-mcp registry + dispatch", () => {
-  describe("Tier 1 shape", () => {
+  describe("registry shape (Tier 1 reads + Tier 2 writes)", () => {
     it("registers get_admin_stats as the read-only grounding tool", () => {
       const def = ADMIN_MCP_TOOLS.find((t) => t.name === "get_admin_stats")
       expect(def).toBeTruthy()
@@ -21,13 +21,43 @@ describe("admin-mcp registry + dispatch", () => {
       expect(isSensitive(def!)).toBe(false)
     })
 
-    it("is entirely read-only (no write/sensitive/dangerous tools in Tier 1)", () => {
+    it("GET tools carry no write/sensitive/dangerous flags", () => {
       for (const def of ADMIN_MCP_TOOLS) {
+        if ((def.method ?? "GET") !== "GET") continue
         expect(def.write).toBeFalsy()
         expect(isSensitive(def)).toBe(false)
         expect(isDangerous(def)).toBe(false)
-        expect(def.method ?? "GET").toBe("GET")
       }
+    })
+
+    it("every write tool is guarded (sensitive or dangerous) and non-GET", () => {
+      const writeTools = ADMIN_MCP_TOOLS.filter((t) => t.write)
+      // Tier 2 introduced writes — there must be some now.
+      expect(writeTools.length).toBeGreaterThan(0)
+      for (const def of writeTools) {
+        expect(def.method ?? "GET").not.toBe("GET")
+        expect(isSensitive(def)).toBe(true) // sensitive OR dangerous OR DELETE
+      }
+    })
+
+    it("exposes delete_product as the first dangerous action (confirm + reason)", () => {
+      const def = ADMIN_MCP_TOOLS.find((t) => t.name === "delete_product")
+      expect(def).toBeTruthy()
+      expect(def!.write).toBe(true)
+      expect(def!.method).toBe("DELETE")
+      expect(isDangerous(def!)).toBe(true)
+      // buildToolInputSchema must inject BOTH reason and confirm.
+      const schema = buildToolInputSchema(def!)
+      expect(schema.properties.reason).toBeDefined()
+      expect(schema.properties.confirm).toBeDefined()
+    })
+
+    it("resolve_admin_query is a read-only planner (POST, not a write)", () => {
+      const def = ADMIN_MCP_TOOLS.find((t) => t.name === "resolve_admin_query")
+      expect(def).toBeTruthy()
+      expect(def!.method).toBe("POST")
+      expect(def!.write).toBeFalsy()
+      expect(isSensitive(def!)).toBe(false)
     })
 
     it("has unique tool names", () => {

--- a/apps/backend/src/api/admin/mcp/lib/handler.ts
+++ b/apps/backend/src/api/admin/mcp/lib/handler.ts
@@ -22,6 +22,7 @@ import {
   envFlagDefaultTrue,
   envFlagDefaultFalse,
 } from "../../../../lib/mcp-core"
+import { makeMcpLedgerSink } from "../../../../lib/mcp-ledger"
 import { ADMIN_MCP_TOOLS } from "./registry"
 
 const SERVER_INFO = { name: "jyt-admin", version: "0.1.0" } as const
@@ -54,6 +55,7 @@ export function resolveAdminBaseUrl(req: MedusaRequest): string {
 }
 
 export function buildAdminMcpServer(req: MedusaRequest): Server {
+  const actorId = (req as any).auth_context?.actor_id as string | undefined
   return buildMcpServer(
     {
       baseUrl: resolveAdminBaseUrl(req),
@@ -62,6 +64,10 @@ export function buildAdminMcpServer(req: MedusaRequest): Server {
       enableWrite: isAdminWriteEnabled(),
       enableDangerous: isAdminDangerousEnabled(),
       surface: "admin",
+      observe: makeMcpLedgerSink(req.scope, {
+        id: actorId ?? null,
+        type: "admin",
+      }),
     },
     ADMIN_MCP_TOOLS,
     { serverInfo: SERVER_INFO, instructions: INSTRUCTIONS }

--- a/apps/backend/src/api/admin/mcp/lib/registry.ts
+++ b/apps/backend/src/api/admin/mcp/lib/registry.ts
@@ -14,8 +14,12 @@
  *  - `dangerous` (platform-destructive): additionally require a human `reason`;
  *    hidden + refused unless ADMIN_MCP_ENABLE_DANGEROUS is on.
  *
- * This is Tier 1 — read-only breadth. Later tiers add partner/storefront,
- * production, money, CRM/investor, and marketing tools (see epic #1092).
+ * Tier 1 is read-only breadth. Tier 2 (below) adds the first writes — catalog
+ * updates (sensitive: require confirm) and the first `dangerous` action
+ * (delete_product: confirm + reason, gated by ADMIN_MCP_ENABLE_DANGEROUS) —
+ * plus the MCP-observability read (`get_mcp_usage`) and the resolver capability
+ * carried over from the deprecated V4 chat (`resolve_admin_query`). Later tiers
+ * add production, money, CRM/investor and marketing tools (see epic #1092).
  */
 import type { McpToolDef } from "../../../../lib/mcp-core"
 
@@ -212,5 +216,128 @@ export const ADMIN_MCP_TOOLS: AdminMcpToolDef[] = [
     path: "/admin/notifications",
     queryParams: ["limit", "offset"],
     inputSchema: obj({ ...PAGINATION }),
+  },
+
+  // ===== Observability (#844) =============================================
+  {
+    name: "get_mcp_usage",
+    description:
+      "Read the MCP observability ledger: totals plus per-surface and per-tool counts, error count, and the most recent tool calls across the store/partner/admin MCP surfaces. Use to answer 'how is the MCP being used' or 'what's failing'.",
+    method: "GET",
+    path: "/admin/mcp/usage",
+    queryParams: ["surface", "limit"],
+    inputSchema: obj({
+      surface: STR("Optional surface filter: 'store' | 'partner' | 'admin'."),
+      limit: { type: "integer", description: "Max rows to scan (default 50, max 200)." },
+    }),
+  },
+
+  // ===== Assistant capability (carried over from the deprecated V4 chat) ===
+  {
+    name: "resolve_admin_query",
+    description:
+      "Resolve a natural-language question about the platform's data/code into an execution plan (hybrid BM25 code search + LLM). This is the query-resolution capability from the retired V4 admin chat. Read-only: it plans, it does not mutate anything.",
+    method: "POST",
+    path: "/admin/mcp/resolve-query",
+    bodyParams: ["query"],
+    inputSchema: obj(
+      { query: STR("The natural-language query to resolve into an execution plan.") },
+      ["query"]
+    ),
+  },
+
+  // ===== Tier 2: catalog writes ==========================================
+  // Writes are gated by ADMIN_MCP_ENABLE_WRITE (default on) and flagged
+  // `sensitive` so the dispatcher requires the admin's explicit confirm:true.
+  // Each declares a previewPath so dry_run / the confirmation card can show the
+  // current object before the change. They wrap Medusa's built-in admin routes.
+  {
+    name: "create_product",
+    description:
+      "Create a new product. Sensitive: requires confirm:true. Prefer dry_run first to review the payload.",
+    method: "POST",
+    path: "/admin/products",
+    write: true,
+    sensitive: true,
+    bodyParams: ["title", "status", "description", "subtitle", "handle", "metadata"],
+    inputSchema: obj(
+      {
+        title: STR("Product title (required)."),
+        status: STR("Product status: 'draft' | 'proposed' | 'published' | 'rejected'."),
+        description: STR("Product description."),
+        subtitle: STR("Optional subtitle."),
+        handle: STR("Optional URL handle (auto-derived from title if omitted)."),
+        metadata: { type: "object", description: "Optional key/value metadata." },
+      },
+      ["title"]
+    ),
+    sideEffects: "Creates a new product in 'draft' status unless status is set.",
+    nextSteps: ["get_product", "update_product"],
+  },
+  {
+    name: "update_product",
+    description:
+      "Update an existing product (title, status, description, handle, metadata). Sensitive: requires confirm:true. Use dry_run to see the current product first.",
+    method: "POST",
+    path: "/admin/products/:id",
+    pathParams: ["id"],
+    previewPath: "/admin/products/:id",
+    write: true,
+    sensitive: true,
+    bodyParams: ["title", "status", "description", "subtitle", "handle", "metadata"],
+    inputSchema: obj(
+      {
+        id: STR("Product id, e.g. 'prod_...'."),
+        title: STR("New title."),
+        status: STR("New status: 'draft' | 'proposed' | 'published' | 'rejected'."),
+        description: STR("New description."),
+        subtitle: STR("New subtitle."),
+        handle: STR("New URL handle."),
+        metadata: { type: "object", description: "Metadata to merge." },
+      },
+      ["id"]
+    ),
+    sideEffects: "Publishing a product makes it live on the storefront.",
+  },
+  {
+    name: "update_customer",
+    description:
+      "Update a customer's profile (name, email, phone, company, metadata). Sensitive: requires confirm:true. Use dry_run to see the current customer first.",
+    method: "POST",
+    path: "/admin/customers/:id",
+    pathParams: ["id"],
+    previewPath: "/admin/customers/:id",
+    write: true,
+    sensitive: true,
+    bodyParams: ["first_name", "last_name", "email", "phone", "company_name", "metadata"],
+    inputSchema: obj(
+      {
+        id: STR("Customer id, e.g. 'cus_...'."),
+        first_name: STR("First name."),
+        last_name: STR("Last name."),
+        email: STR("Email address."),
+        phone: STR("Phone number."),
+        company_name: STR("Company name."),
+        metadata: { type: "object", description: "Metadata to merge." },
+      },
+      ["id"]
+    ),
+  },
+
+  // ===== Tier 2: the first dangerous action ==============================
+  // Platform-destructive: hidden + refused unless ADMIN_MCP_ENABLE_DANGEROUS is
+  // on, and even then requires BOTH confirm:true AND a human-supplied reason.
+  {
+    name: "delete_product",
+    description:
+      "Permanently delete a product. PLATFORM-DESTRUCTIVE: requires confirm:true AND a human reason, and is only available when ADMIN_MCP_ENABLE_DANGEROUS is enabled. Always dry_run first.",
+    method: "DELETE",
+    path: "/admin/products/:id",
+    pathParams: ["id"],
+    previewPath: "/admin/products/:id",
+    write: true,
+    dangerous: true,
+    inputSchema: obj({ id: STR("Product id to delete, e.g. 'prod_...'.") }, ["id"]),
+    sideEffects: "Irreversibly removes the product and its variants from the catalog.",
   },
 ]

--- a/apps/backend/src/api/admin/mcp/resolve-query/route.ts
+++ b/apps/backend/src/api/admin/mcp/resolve-query/route.ts
@@ -1,0 +1,55 @@
+/**
+ * POST /admin/mcp/resolve-query — natural-language → execution-plan resolver.
+ *
+ * The canonical home of the former V4 admin-chat "resolve" capability (hybrid
+ * BM25 code search + LLM analysis via `HybridQueryResolverService`). It is
+ * exposed as the admin MCP `resolve_admin_query` tool so the MCP-backed Admin
+ * Assistant retains this capability after the V4 chat is deprecated
+ * (`ADMIN_V4_CHAT_DEPRECATED`). Independent of the legacy routes on purpose:
+ * this one is never gated, so no capability regresses.
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { HybridQueryResolverService } from "../../../../mastra/services/hybrid-query-resolver"
+
+// Singleton — the resolver builds an in-process BM25 index; keep one per process.
+let resolverInstance: HybridQueryResolverService | null = null
+
+function getResolver(): HybridQueryResolverService {
+  if (!resolverInstance) {
+    resolverInstance = new HybridQueryResolverService({
+      llmApiKey: process.env.OPENROUTER_API_KEY,
+      projectRoot: process.cwd(),
+      useIndexedFirst: true,
+      maxSearchResults: 5,
+    })
+  }
+  return resolverInstance
+}
+
+export const POST = async (req: MedusaRequest, res: MedusaResponse) => {
+  try {
+    const body = (req as any).validatedBody || req.body || {}
+    const query = body.query as string | undefined
+
+    if (!query || typeof query !== "string") {
+      return res.status(400).json({ error: "Missing required field: query" })
+    }
+
+    const resolver = getResolver()
+    const indexedStatus = resolver.hasIndexedDocs()
+
+    const startTime = Date.now()
+    const resolved = await resolver.resolve(query)
+    const duration = Date.now() - startTime
+
+    res.json({
+      resolved,
+      meta: { duration_ms: duration, indexed_docs: indexedStatus },
+    })
+  } catch (error: any) {
+    const logger: any = req.scope.resolve(ContainerRegistrationKeys.LOGGER)
+    logger.error(`[admin/mcp/resolve-query] ${error}`)
+    res.status(500).json({ error: error?.message || "Failed to resolve query" })
+  }
+}

--- a/apps/backend/src/api/admin/mcp/usage/route.ts
+++ b/apps/backend/src/api/admin/mcp/usage/route.ts
@@ -1,0 +1,55 @@
+/**
+ * GET /admin/mcp/usage — the MCP observability ledger view (#844).
+ *
+ * Reads the `ai_usage_event` rows written by every MCP tool dispatch (across
+ * the store / partner / admin surfaces) and returns an aggregated snapshot:
+ * totals, per-surface and per-tool counts, error count, and the most recent
+ * calls. Backs the `get_mcp_usage` admin MCP tool so the assistant can answer
+ * "how is the MCP being used / what's failing".
+ *
+ * Query params: `surface` (optional filter), `limit` (default 50, max 200).
+ */
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { AI_USAGE_MODULE } from "../../../../modules/ai_usage"
+import type AiUsageService from "../../../../modules/ai_usage/service"
+
+export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
+  const aiUsage = req.scope.resolve(AI_USAGE_MODULE) as AiUsageService
+
+  const surface =
+    typeof req.query.surface === "string" ? req.query.surface : undefined
+  const limit = Math.min(Number(req.query.limit) || 50, 200)
+
+  const { events, count } = await aiUsage.listMcpUsage({ surface, limit })
+
+  const bySurface: Record<string, number> = {}
+  const byTool: Record<string, number> = {}
+  let errors = 0
+
+  for (const e of events as any[]) {
+    const s = e.surface ?? "unknown"
+    bySurface[s] = (bySurface[s] ?? 0) + 1
+    const tool = String(e.operation ?? "").replace(/^mcp:/, "")
+    byTool[tool] = (byTool[tool] ?? 0) + 1
+    if (e.metadata?.ok === false) errors++
+  }
+
+  res.json({
+    usage: {
+      total: count,
+      returned: events.length,
+      errors,
+      by_surface: bySurface,
+      by_tool: byTool,
+      recent: (events as any[]).slice(0, 20).map((e) => ({
+        tool: String(e.operation ?? "").replace(/^mcp:/, ""),
+        surface: e.surface,
+        actor_type: e.actor_type,
+        outcome: e.metadata?.outcome ?? null,
+        ok: e.metadata?.ok ?? null,
+        ms: e.metadata?.ms ?? null,
+        at: e.created_at,
+      })),
+    },
+  })
+}

--- a/apps/backend/src/api/mcp/lib/handler.ts
+++ b/apps/backend/src/api/mcp/lib/handler.ts
@@ -1,14 +1,24 @@
 /**
- * Shared request handler for the MCP transport, mounted at two paths:
+ * Shared request handler for the Store MCP transport, mounted at two paths:
  *   - /mcp        (open: zero-config, server injects the default key)
  *   - /store/mcp  (gated: Medusa's publishable-key middleware requires a key)
  *
  * Stateless Streamable HTTP: each POST is a self-contained JSON-RPC request, so
  * there is no session to track — ideal for a read-only catalog server. GET and
  * DELETE are not supported in stateless mode and return 405.
+ *
+ * Transport wiring (build server → hand parsed body to the stateless
+ * Streamable-HTTP transport) is delegated to the shared mcp-core helpers; this
+ * file owns only the store-specific bits: publishable-key resolution, the
+ * STORE_MCP_ENABLE_WRITE gate and the dual-mount write-enable decision.
  */
 import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js"
+import {
+  handleMcpJsonRpc,
+  mcpMethodNotAllowed as coreMcpMethodNotAllowed,
+  resolveLoopbackBaseUrl,
+} from "../../../lib/mcp-core"
+import { makeMcpLedgerSink } from "../../../lib/mcp-ledger"
 import { buildStoreMcpServer } from "./server"
 
 const PUBLISHABLE_HEADER = "x-publishable-api-key"
@@ -20,28 +30,6 @@ const PUBLISHABLE_HEADER = "x-publishable-api-key"
 function isWriteEnabled(): boolean {
   const v = (process.env.STORE_MCP_ENABLE_WRITE || "").trim().toLowerCase()
   return v === "true" || v === "1" || v === "yes"
-}
-
-/**
- * Loopback origin for proxying to /store/* on this same process.
- *
- * Derived from the incoming request by default (`proto://host`), which is
- * correct everywhere: the integration test runner binds a random port, local
- * dev uses :9000, and prod uses the public host. Set STORE_MCP_LOOPBACK_URL to
- * force an internal address (e.g. http://localhost:9000) and skip a hop.
- */
-function resolveBaseUrl(req: MedusaRequest): string {
-  const override = process.env.STORE_MCP_LOOPBACK_URL
-  if (override) {
-    return override.replace(/\/$/, "")
-  }
-  const proto = (req.protocol || "http").split(",")[0].trim()
-  const host = req.get("host")
-  if (host) {
-    return `${proto}://${host}`
-  }
-  const port = process.env.PORT || "9000"
-  return `http://localhost:${port}`
 }
 
 export async function handleMcpRequest(
@@ -70,7 +58,7 @@ export async function handleMcpRequest(
   const enableWrite = writesEnabledGlobally && hasValidatedKey
 
   const server = buildStoreMcpServer({
-    baseUrl: resolveBaseUrl(req),
+    baseUrl: resolveLoopbackBaseUrl(req, "STORE_MCP_LOOPBACK_URL"),
     publishableKey,
     bearer,
     container: req.scope,
@@ -78,34 +66,15 @@ export async function handleMcpRequest(
     // True on the open /mcp mount when writes exist but aren't reachable here —
     // lets the server tell agents to use the keyed /store/mcp mount instead.
     writesEnabledGlobally,
+    observe: makeMcpLedgerSink(req.scope, { type: "storefront" }),
   })
 
-  const transport = new StreamableHTTPServerTransport({
-    sessionIdGenerator: undefined, // stateless: each POST is self-contained
-    enableJsonResponse: true, // return a plain JSON-RPC body, not an SSE stream
-  })
-
-  res.on("close", () => {
-    transport.close()
-    server.close()
-  })
-
-  await server.connect(transport)
-  // Medusa's body parser has already consumed the stream, so hand the parsed
-  // body to the transport explicitly.
-  await transport.handleRequest(req as any, res as any, (req as any).body)
+  await handleMcpJsonRpc(req, res, server)
 }
 
 export function mcpMethodNotAllowed(
-  _req: MedusaRequest,
+  req: MedusaRequest,
   res: MedusaResponse
 ): void {
-  res.status(405).json({
-    jsonrpc: "2.0",
-    error: {
-      code: -32000,
-      message: "Method not allowed. This MCP endpoint is stateless; use POST.",
-    },
-    id: null,
-  })
+  coreMcpMethodNotAllowed(req, res)
 }

--- a/apps/backend/src/api/mcp/lib/server.ts
+++ b/apps/backend/src/api/mcp/lib/server.ts
@@ -1,27 +1,37 @@
 /**
- * Builds the read-only Store MCP server.
+ * Builds the Store MCP server on the shared mcp-core (#1092).
  *
- * Uses the low-level `Server` + `setRequestHandler` API (rather than the
- * high-level `McpServer.registerTool`) so tool input schemas stay as plain
- * JSON Schema and we avoid coupling to a specific zod version.
+ * The store surface is the multi-tenant MCP: it keeps a thin surface-specific
+ * server (rather than the core `buildMcpServer`) for two reasons unique to it:
+ *  - It preserves the raw-JSON wire contract — clients parse the wrapped
+ *    Store-route payload directly, not a `{ok,tool,data}` envelope.
+ *  - Its DELETE (`remove_line_item`) is a normal cart op, so it opts out of the
+ *    confirm/reason rails via `disableSensitiveRails`.
+ * Everything else — path substitution, publishable-key scoping, the loopback
+ * proxy, the write gate and observability — is delegated to the shared
+ * `dispatchMcpTool`. The store-specific bits (per-call `store` → key resolution,
+ * native store-discovery tools, dual-mount write copy) are supplied as
+ * `McpContext` hooks:
+ *  - `tenant`             — resolve a `store` arg to a publishable key.
+ *  - `runNative`          — list_stores / get_storefront_key (container-backed).
+ *  - `writeDisabledMessage` — the keyed-mount vs STORE_MCP_ENABLE_WRITE guidance.
  *
- * Two kinds of tools (see registry.ts):
- *  - proxy tools forward to a live /store/* route (loopback) with a resolved
- *    publishable key, inheriting pricing/tax/scoping/validators.
- *  - native tools run in-process against the container for store discovery and
- *    publishable-key resolution (list_stores, get_storefront_key).
- *
- * Proxy tools accept an optional `store` arg (handle/domain) that is resolved
- * server-side to that storefront's default publishable key — so agents work in
- * terms of store names, not raw pk_ tokens, across a multi-tenant deployment.
+ * Tool input schemas stay plain JSON Schema (returned verbatim in tools/list),
+ * so we avoid coupling to a specific zod version.
  */
 import { Server } from "@modelcontextprotocol/sdk/server/index.js"
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js"
+import {
+  dispatchMcpTool,
+  type McpContext,
+  type McpToolDef,
+  type McpToolEvent,
+  type McpToolResult,
+} from "../../../lib/mcp-core"
 import { STORE_MCP_TOOLS } from "./registry"
-import { callStoreRoute, type ProxyError } from "./proxy"
 import { listStorefronts, resolveStorefront } from "./store-resolver"
 
 export type StoreMcpContext = {
@@ -44,6 +54,8 @@ export type StoreMcpContext = {
    * point agents on the open /mcp mount at the keyed /store/mcp write mount.
    */
   writesEnabledGlobally?: boolean
+  /** Optional observability sink (#844) — one event per tool call. */
+  observe?: (evt: McpToolEvent) => void
 }
 
 const SERVER_INFO = { name: "jyt-store", version: "0.1.0" } as const
@@ -93,15 +105,71 @@ export function buildStoreMcpServer(ctx: StoreMcpContext): Server {
     (writesRequireKey ? WRITE_MOUNT_HINT : "") +
     (ctx.enableWrite ? WRITE_FLOW_GUIDE : "")
 
+  // Native (container-backed) tools: store discovery + key resolution. Returns
+  // the store's raw payload shape; the CallTool handler unwraps `data`.
+  const runNative = async (
+    native: string,
+    args: Record<string, unknown>
+  ): Promise<McpToolResult> => {
+    if (!ctx.container) {
+      return {
+        ok: false,
+        tool: native,
+        error: "Store resolution unavailable (no container).",
+      }
+    }
+    if (native === "list_stores") {
+      const stores = await listStorefronts(ctx.container)
+      return { ok: true, tool: native, data: { stores, count: stores.length } }
+    }
+    if (native === "get_storefront_key") {
+      const store = String(args.store ?? "").trim()
+      if (!store) {
+        return { ok: false, tool: native, error: "Missing required parameter: store" }
+      }
+      const info = await resolveStorefront(ctx.container, store)
+      if (!info) {
+        return { ok: false, tool: native, error: `No storefront found for '${store}'.` }
+      }
+      return { ok: true, tool: native, data: info }
+    }
+    return { ok: false, tool: native, error: `Unhandled native tool: ${native}` }
+  }
+
+  const coreCtx: McpContext = {
+    baseUrl: ctx.baseUrl,
+    bearer: ctx.bearer,
+    enableWrite: ctx.enableWrite,
+    // The store's DELETE (remove_line_item) is a normal cart op — no rails.
+    disableSensitiveRails: true,
+    surface: "store",
+    observe: ctx.observe,
+    runNative,
+    tenant: {
+      defaultKey: ctx.publishableKey,
+      resolveKey: async (storeArg: string) => {
+        if (!ctx.container) return null
+        const info = await resolveStorefront(ctx.container, storeArg)
+        return info?.publishable_key ?? null
+      },
+      missingKeyMessage:
+        "No publishable key. Pass a `store` argument (see list_stores), send an " +
+        "'x-publishable-api-key' header, or configure STORE_MCP_DEFAULT_PUBLISHABLE_KEY " +
+        "on the server.",
+    },
+    writeDisabledMessage: (name: string) =>
+      writesRequireKey
+        ? `Tool '${name}' is a write/checkout tool, available only on the keyed write mount. Reconnect to POST /store/mcp with an 'x-publishable-api-key' header.`
+        : `Tool '${name}' is a write/checkout tool and is disabled on this server. Set STORE_MCP_ENABLE_WRITE=true to enable cart & payment tools.`,
+  }
+
   const server = new Server(SERVER_INFO, {
     capabilities: { tools: {} },
     instructions,
   })
 
   // Write (cart/checkout) tools are only visible/callable when writes are on.
-  const visibleTools = STORE_MCP_TOOLS.filter(
-    (t) => ctx.enableWrite || !t.write
-  )
+  const visibleTools = STORE_MCP_TOOLS.filter((t) => ctx.enableWrite || !t.write)
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: visibleTools.map((t) => ({
@@ -112,119 +180,20 @@ export function buildStoreMcpServer(ctx: StoreMcpContext): Server {
   }))
 
   server.setRequestHandler(CallToolRequestSchema, async (req) => {
-    const def = STORE_MCP_TOOLS.find((t) => t.name === req.params.name)
-    if (!def) {
-      return textResult(`Unknown tool: ${req.params.name}`, true)
-    }
-    // Refuse mutating tools unless writes are enabled AND a key was presented.
-    if (def.write && !ctx.enableWrite) {
-      const msg = writesRequireKey
-        ? `Tool '${def.name}' is a write/checkout tool, available only on the keyed write mount. Reconnect to POST /store/mcp with an 'x-publishable-api-key' header.`
-        : `Tool '${def.name}' is a write/checkout tool and is disabled on this server. Set STORE_MCP_ENABLE_WRITE=true to enable cart & payment tools.`
-      return textResult(msg, true)
-    }
     const args = (req.params.arguments ?? {}) as Record<string, unknown>
-
-    // --- Native tools: store discovery / key resolution -------------------
-    if (def.native) {
-      if (!ctx.container) {
-        return textResult("Store resolution unavailable (no container).", true)
-      }
-      try {
-        if (def.native === "list_stores") {
-          const stores = await listStorefronts(ctx.container)
-          return textResult(
-            JSON.stringify({ stores, count: stores.length }, null, 2)
-          )
-        }
-        if (def.native === "get_storefront_key") {
-          const store = String(args.store ?? "").trim()
-          if (!store) {
-            return textResult("Missing required parameter: store", true)
-          }
-          const info = await resolveStorefront(ctx.container, store)
-          if (!info) {
-            return textResult(`No storefront found for '${store}'.`, true)
-          }
-          return textResult(JSON.stringify(info, null, 2))
-        }
-      } catch (e) {
-        return textResult(`Error in ${def.name}: ${(e as Error).message}`, true)
-      }
-      return textResult(`Unhandled native tool: ${def.native}`, true)
+    const result = await dispatchMcpTool(
+      coreCtx,
+      STORE_MCP_TOOLS as unknown as McpToolDef[],
+      req.params.name,
+      args
+    )
+    if (!result.ok) {
+      return textResult(result.error ?? JSON.stringify(result, null, 2), true)
     }
-
-    // --- Proxy tools: resolve the effective publishable key ---------------
-    // A `store` arg (handle/domain) wins; otherwise the caller/default key.
-    let publishableKey = ctx.publishableKey
-    const storeArg = typeof args.store === "string" ? args.store.trim() : ""
-    if (storeArg) {
-      if (!ctx.container) {
-        return textResult("Cannot resolve `store` (no container).", true)
-      }
-      const info = await resolveStorefront(ctx.container, storeArg)
-      if (!info?.publishable_key) {
-        return textResult(
-          `No storefront / publishable key found for '${storeArg}'. Use list_stores to discover valid stores.`,
-          true
-        )
-      }
-      publishableKey = info.publishable_key
-    }
-    if (!publishableKey) {
-      return textResult(
-        "No publishable key. Pass a `store` argument (see list_stores), send an 'x-publishable-api-key' header, or configure STORE_MCP_DEFAULT_PUBLISHABLE_KEY on the server.",
-        true
-      )
-    }
-
-    // Substitute path params (e.g. :id -> prod_123).
-    let path = def.path as string
-    for (const p of def.pathParams ?? []) {
-      const value = args[p]
-      if (value === undefined || value === null || value === "") {
-        return textResult(`Missing required parameter: ${p}`, true)
-      }
-      path = path.replace(`:${p}`, encodeURIComponent(String(value)))
-    }
-
-    // Forward only the whitelisted query params (`store` is consumed above,
-    // never forwarded to the store route).
-    const query: Record<string, unknown> = {}
-    for (const k of def.queryParams ?? []) {
-      if (args[k] !== undefined && args[k] !== null) {
-        query[k] = args[k]
-      }
-    }
-
-    // Assemble the JSON body for write tools from the whitelisted body params.
-    const body: Record<string, unknown> = {}
-    for (const k of def.bodyParams ?? []) {
-      if (args[k] !== undefined && args[k] !== null) {
-        body[k] = args[k]
-      }
-    }
-
-    try {
-      const data = await callStoreRoute({
-        baseUrl: ctx.baseUrl,
-        method: def.method ?? "GET",
-        path,
-        query,
-        body,
-        publishableKey,
-        bearer: ctx.bearer,
-      })
-      // Optional provider-specific normalization (e.g. payment next_action).
-      const out = def.transform ? def.transform(data, args) : data
-      return textResult(JSON.stringify(out, null, 2))
-    } catch (e) {
-      const err = e as ProxyError
-      return textResult(
-        `Error calling ${def.name} (${path}): ${err.message}`,
-        true
-      )
-    }
+    // Preserve the store's raw-JSON wire contract: clients parse the wrapped
+    // route payload directly, not the {ok,tool,data} envelope.
+    const payload = result.data !== undefined ? result.data : result
+    return textResult(JSON.stringify(payload, null, 2))
   })
 
   return server

--- a/apps/backend/src/api/partners/assistant/chat/route.ts
+++ b/apps/backend/src/api/partners/assistant/chat/route.ts
@@ -40,6 +40,7 @@ import {
   isPartnerWriteEnabled,
   resolvePartnerBaseUrl,
 } from "../../mcp/lib/handler"
+import { makeMcpLedgerSink } from "../../../../lib/mcp-ledger"
 import type { PartnerAssistantChatReq } from "./validators"
 
 const FEATURE = "partners/assistant/chat"
@@ -85,6 +86,10 @@ export const POST = async (
     bearer: req.get("authorization") || undefined,
     cookie: req.get("cookie") || undefined,
     enableWrite: isPartnerWriteEnabled(),
+    observe: makeMcpLedgerSink(req.scope, {
+      id: (req as any).auth_context?.actor_id ?? null,
+      type: "partner",
+    }),
   }
   const writeEnabled = ctx.enableWrite !== false
 

--- a/apps/backend/src/api/partners/mcp/lib/handler.ts
+++ b/apps/backend/src/api/partners/mcp/lib/handler.ts
@@ -13,6 +13,7 @@ import {
   resolveLoopbackBaseUrl,
   envFlagDefaultTrue,
 } from "../../../../lib/mcp-core"
+import { makeMcpLedgerSink } from "../../../../lib/mcp-ledger"
 import { buildPartnerMcpServer } from "./server"
 
 /** Writes are on by default; a deployment can force read-only. */
@@ -32,11 +33,16 @@ export async function handlePartnerMcpRequest(
   req: MedusaRequest,
   res: MedusaResponse
 ): Promise<void> {
+  const actorId = (req as any).auth_context?.actor_id as string | undefined
   const server = buildPartnerMcpServer({
     baseUrl: resolvePartnerBaseUrl(req),
     bearer: req.get("authorization") || undefined,
     cookie: req.get("cookie") || undefined,
     enableWrite: isPartnerWriteEnabled(),
+    observe: makeMcpLedgerSink(req.scope, {
+      id: actorId ?? null,
+      type: "partner",
+    }),
   })
   await handleMcpJsonRpc(req, res, server)
 }

--- a/apps/backend/src/lib/mcp-core/dispatch.ts
+++ b/apps/backend/src/lib/mcp-core/dispatch.ts
@@ -76,6 +76,31 @@ export async function dispatchMcpTool(
   }
 
   const args = rawArgs || {}
+
+  // --- Native tools: run in-process via the surface handler -------------------
+  // Store discovery / key resolution etc. — no route, no write/rail gating
+  // (natives are read-only). The surface owns execution and error shaping.
+  if (def.native) {
+    if (!ctx.runNative) {
+      return fail(`Native tool '${name}' is not supported on this surface.`)
+    }
+    try {
+      const result = await ctx.runNative(def.native, args)
+      emit({
+        method: "native",
+        executed: true,
+        ok: result.ok,
+        outcome: "run",
+        context: typeof args.context === "string" ? args.context : undefined,
+      })
+      return result
+    } catch (e) {
+      const error = `Error in native tool ${name}: ${(e as Error).message}`
+      emit({ method: "native", executed: true, ok: false, outcome: "run", error })
+      return { ok: false, tool: name, error }
+    }
+  }
+
   const dryRun = args.dry_run === true
   const confirmed = args.confirm === true
   const context = typeof args.context === "string" ? args.context : undefined
@@ -84,12 +109,16 @@ export async function dispatchMcpTool(
       ? args.reason.trim()
       : undefined
   const write = !!def.write
-  const sensitive = isSensitive(def)
-  const dangerous = isDangerous(def)
+  // The store surface opts out of the confirm/reason rails (its DELETE is a
+  // normal cart op). Partner/admin keep them.
+  const railsOn = !ctx.disableSensitiveRails
+  const sensitive = railsOn && isSensitive(def)
+  const dangerous = railsOn && isDangerous(def)
 
   if (write && ctx.enableWrite === false) {
     return fail(
-      `Tool '${name}' is a write tool and writes are disabled on this server.`
+      ctx.writeDisabledMessage?.(name) ??
+        `Tool '${name}' is a write tool and writes are disabled on this server.`
     )
   }
   // Dangerous tools are hidden + refused when the surface hasn't opted in.
@@ -97,6 +126,33 @@ export async function dispatchMcpTool(
     return fail(
       `Tool '${name}' is a platform-destructive action and dangerous tools are disabled on this server.`
     )
+  }
+
+  // Resolve the tenant publishable key for multi-tenant (store) surfaces. A
+  // `store` argument (handle/domain) wins and is resolved per-call; otherwise
+  // the surface's default key applies. `store` is consumed here and never
+  // forwarded to the route (it isn't in any registry's queryParams either).
+  let publishableKey: string | undefined
+  if (ctx.tenant) {
+    publishableKey = ctx.tenant.defaultKey
+    const storeArg = typeof args.store === "string" ? args.store.trim() : ""
+    if (storeArg) {
+      const resolved = ctx.tenant.resolveKey
+        ? await ctx.tenant.resolveKey(storeArg)
+        : null
+      if (!resolved) {
+        return fail(
+          `No storefront / publishable key found for '${storeArg}'. Use list_stores to discover valid stores.`
+        )
+      }
+      publishableKey = resolved
+    }
+    if (!publishableKey) {
+      return fail(
+        ctx.tenant.missingKeyMessage ??
+          "No publishable key. Pass a `store` argument (see list_stores) or configure a default key on the server."
+      )
+    }
   }
 
   // Substitute path params for the target route.
@@ -131,6 +187,7 @@ export async function dispatchMcpTool(
         path: psub.path as string,
         bearer: ctx.bearer,
         cookie: ctx.cookie,
+        publishableKey,
       })
     } catch {
       return undefined
@@ -195,6 +252,7 @@ export async function dispatchMcpTool(
       body,
       bearer: ctx.bearer,
       cookie: ctx.cookie,
+      publishableKey,
       context,
       reason,
     })

--- a/apps/backend/src/lib/mcp-core/proxy.ts
+++ b/apps/backend/src/lib/mcp-core/proxy.ts
@@ -31,6 +31,12 @@ export type McpProxyArgs = {
   /** Optional session cookie to forward when the caller authed via cookie. */
   cookie?: string
   /**
+   * Publishable key for sales-channel scoping (store surface). Forwarded as the
+   * `x-publishable-api-key` header so `/store/*` routes resolve the right
+   * storefront. Ignored by single-tenant (partner/admin) surfaces.
+   */
+  publishableKey?: string
+  /**
    * Optional agent intent ("what am I trying to accomplish") forwarded as the
    * `x-mcp-context` header. Purely informational — routes/telemetry can log it
    * to understand multi-step tool sequences; it never affects route logic.
@@ -54,6 +60,7 @@ export async function callMcpRoute({
   body,
   bearer,
   cookie,
+  publishableKey,
   context,
   reason,
 }: McpProxyArgs): Promise<unknown> {
@@ -71,6 +78,9 @@ export async function callMcpRoute({
   }
   if (cookie) {
     headers["cookie"] = cookie
+  }
+  if (publishableKey) {
+    headers["x-publishable-api-key"] = publishableKey
   }
   if (context) {
     // Truncate defensively — this is a header, not a payload.

--- a/apps/backend/src/lib/mcp-core/types.ts
+++ b/apps/backend/src/lib/mcp-core/types.ts
@@ -22,6 +22,14 @@ export type McpToolDef = {
   description: string
   /** JSON Schema for the domain arguments (framework args are injected). */
   inputSchema: Record<string, any>
+  /**
+   * Native (non-proxy) tool marker. When set, the tool is NOT dispatched to a
+   * loopback route; instead the surface's `ctx.runNative(native, args)` handler
+   * runs it in-process (e.g. the store surface's `list_stores` /
+   * `get_storefront_key` container-backed tenant discovery). Native tools are
+   * read-only and bypass path/method/query/body. Leave unset for proxy tools.
+   */
+  native?: string
   /** HTTP method of the wrapped route. Defaults to GET. */
   method?: McpMethod
   /** Route path, with `:param` placeholders, e.g. `/admin/orders/:id`. */
@@ -105,10 +113,49 @@ export type McpContext = {
    * dangerous tools can leave this undefined.
    */
   enableDangerous?: boolean
+  /**
+   * When true, the confirm/reason safety rails are skipped entirely and every
+   * tool is either a read or a plain write (write-gated only). The store
+   * surface sets this: there a DELETE (`remove_line_item`) is an ordinary cart
+   * operation, not a platform-destructive action, so the admin surface's
+   * "DELETE is implicitly sensitive" rule must not apply. Defaults to false —
+   * partner/admin keep the full rails.
+   */
+  disableSensitiveRails?: boolean
   /** Which surface this context serves — labels observability + server name. */
   surface?: string
   /** Optional sink for per-call observability events (#844). */
   observe?: (evt: McpToolEvent) => void
+  /**
+   * Multi-tenant proxy scoping (store surface only). When set, every proxy tool
+   * is scoped to a storefront's publishable key rather than a user JWT: a
+   * `store` argument (handle/domain) is resolved per-call via `resolveKey`,
+   * falling back to `defaultKey`. Single-tenant surfaces (partner/admin) leave
+   * this undefined and authenticate via `bearer`/`cookie` instead.
+   */
+  tenant?: {
+    /** Publishable key used when no `store` argument is supplied. */
+    defaultKey?: string
+    /** Resolve a `store` argument (handle/domain/id) to a publishable key. */
+    resolveKey?: (storeArg: string) => Promise<string | null>
+    /** Message returned when no key can be resolved and one is required. */
+    missingKeyMessage?: string
+  }
+  /**
+   * Handler for `native` tools — run in-process instead of proxied to a route
+   * (store surface: `list_stores` / `get_storefront_key`). Required if any tool
+   * in the registry sets `native`.
+   */
+  runNative?: (
+    native: string,
+    args: Record<string, unknown>
+  ) => Promise<McpToolResult>
+  /**
+   * Surface-specific copy for the write-disabled refusal. Lets the store
+   * surface keep its dual-mount guidance ("use the keyed /store/mcp mount" vs
+   * "set STORE_MCP_ENABLE_WRITE"). Falls back to a generic message when unset.
+   */
+  writeDisabledMessage?: (toolName: string) => string
 }
 
 /** Structured tool result. `ok:false` is a soft error (returned, not thrown). */

--- a/apps/backend/src/lib/mcp-ledger.ts
+++ b/apps/backend/src/lib/mcp-ledger.ts
@@ -1,0 +1,60 @@
+/**
+ * MCP → ai_usage ledger bridge (#844).
+ *
+ * `makeMcpLedgerSink(container, actor)` returns an `observe` sink for the shared
+ * mcp-core dispatcher that BOTH logs a structured line (via the core log sink)
+ * AND persists one `ai_usage_event` row per tool dispatch. It lives here — not
+ * in mcp-core — so the core stays module-agnostic while every surface (store,
+ * partner, admin) gets cross-surface observability by passing this as
+ * `ctx.observe`.
+ *
+ * Persistence is best-effort and fire-and-forget: a ledger write must never
+ * break or slow the actual tool call, so failures are logged and swallowed.
+ */
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { makeMcpLogSink, type McpToolEvent } from "./mcp-core"
+import { AI_USAGE_MODULE } from "../modules/ai_usage"
+import type AiUsageService from "../modules/ai_usage/service"
+
+export type McpActor = {
+  id?: string | null
+  type?: string | null
+  partner_id?: string | null
+}
+
+/** Ops kill-switch: set MCP_LEDGER_DISABLED=true to log-only (no DB writes). */
+function isLedgerDisabled(): boolean {
+  const v = (process.env.MCP_LEDGER_DISABLED || "").trim().toLowerCase()
+  return v === "true" || v === "1" || v === "yes"
+}
+
+export function makeMcpLedgerSink(
+  container: any,
+  actor?: McpActor
+): (evt: McpToolEvent) => void {
+  let logger: any
+  let aiUsage: AiUsageService | undefined
+  try {
+    logger = container?.resolve?.(ContainerRegistrationKeys.LOGGER)
+  } catch {
+    // logger optional
+  }
+  try {
+    aiUsage = container?.resolve?.(AI_USAGE_MODULE)
+  } catch {
+    // module optional — degrade to log-only
+  }
+
+  const log = makeMcpLogSink(logger)
+  const persist = !!aiUsage && !isLedgerDisabled()
+
+  return (evt: McpToolEvent): void => {
+    log(evt)
+    if (!persist) return
+    Promise.resolve(aiUsage!.recordMcpEvent(evt, actor)).catch((e) => {
+      logger?.warn?.(
+        `[mcp:${evt.surface}] ledger write failed: ${(e as Error).message}`
+      )
+    })
+  }
+}

--- a/apps/backend/src/modules/ai_usage/migrations/Migration20260720190000.ts
+++ b/apps/backend/src/modules/ai_usage/migrations/Migration20260720190000.ts
@@ -1,0 +1,52 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations"
+
+/**
+ * Extend ai_usage_event into the cross-surface MCP observability ledger (#844).
+ *
+ * - `partner_id` becomes nullable — admin/store MCP calls have no partner actor.
+ * - Add `surface` / `actor_id` / `actor_type` to identify the MCP surface and
+ *   the actor behind each tool dispatch. All nullable + additive, so legacy
+ *   partner-image quota rows are untouched.
+ */
+export class Migration20260720190000 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(
+      `alter table if exists "ai_usage_event" alter column "partner_id" drop not null;`
+    )
+    this.addSql(
+      `alter table if exists "ai_usage_event" add column if not exists "surface" text null;`
+    )
+    this.addSql(
+      `alter table if exists "ai_usage_event" add column if not exists "actor_id" text null;`
+    )
+    this.addSql(
+      `alter table if exists "ai_usage_event" add column if not exists "actor_type" text null;`
+    )
+    this.addSql(
+      `CREATE INDEX IF NOT EXISTS "IDX_ai_usage_event_surface" ON "ai_usage_event" ("surface") WHERE deleted_at IS NULL;`
+    )
+    this.addSql(
+      `CREATE INDEX IF NOT EXISTS "IDX_ai_usage_event_actor_id" ON "ai_usage_event" ("actor_id") WHERE deleted_at IS NULL;`
+    )
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(
+      `DROP INDEX IF EXISTS "IDX_ai_usage_event_actor_id";`
+    )
+    this.addSql(
+      `DROP INDEX IF EXISTS "IDX_ai_usage_event_surface";`
+    )
+    this.addSql(
+      `alter table if exists "ai_usage_event" drop column if exists "actor_type";`
+    )
+    this.addSql(
+      `alter table if exists "ai_usage_event" drop column if exists "actor_id";`
+    )
+    this.addSql(
+      `alter table if exists "ai_usage_event" drop column if exists "surface";`
+    )
+    // Note: partner_id is left nullable on down — re-adding NOT NULL could fail
+    // against ledger rows written while this migration was live.
+  }
+}

--- a/apps/backend/src/modules/ai_usage/models/ai-usage-event.ts
+++ b/apps/backend/src/modules/ai_usage/models/ai-usage-event.ts
@@ -3,16 +3,28 @@ import { model } from "@medusajs/framework/utils"
 /**
  * AI Usage Event
  *
- * Append-only record of each AI operation a partner runs. Used to enforce
- * per-partner monthly quotas and drive the upgrade prompt. Not a metering
- * ledger — if you need billing precision later, replace this with something
- * heavier. For now it's the smallest thing that answers "how many times has
- * this partner hit the describe endpoint this month?"
+ * Append-only record of each AI operation. Originally per-partner image quota
+ * enforcement (`partner_id` + `operation` = an image_describe/segment/depth
+ * call). Extended for the MCP observability ledger (#844): every MCP tool
+ * dispatch across the store/partner/admin surfaces lands here too, so
+ * `partner_id` is now nullable (admin actors aren't partners) and the actor is
+ * captured via `surface` + `actor_id` + `actor_type`. Quota reads still filter
+ * on `partner_id` + `operation`; ledger reads filter on `surface`.
+ *
+ * Still not a billing-grade meter — if you need precision later, replace this
+ * with something heavier.
  */
 const AiUsageEvent = model.define("ai_usage_event", {
   id: model.id().primaryKey(),
-  partner_id: model.text().index(),
+  // Nullable for MCP ledger rows (admin/store actors aren't partners). DB
+  // indexes are maintained by the migrations, so no model-level `.index()`.
+  partner_id: model.text().nullable(),
   operation: model.text().index(),
+  // MCP ledger (#844): the surface that handled the call and the actor behind
+  // it. Null for the legacy partner-image quota rows.
+  surface: model.text().nullable(),
+  actor_id: model.text().nullable(),
+  actor_type: model.text().nullable(),
   metadata: model.json().nullable(),
 })
 

--- a/apps/backend/src/modules/ai_usage/service.ts
+++ b/apps/backend/src/modules/ai_usage/service.ts
@@ -1,5 +1,6 @@
 import { MedusaService } from "@medusajs/framework/utils"
 import AiUsageEvent from "./models/ai-usage-event"
+import type { McpToolEvent } from "../../lib/mcp-core"
 
 export const MONTHLY_QUOTA = {
   image_describe: 10,
@@ -68,6 +69,54 @@ class AiUsageService extends MedusaService({ AiUsageEvent }) {
       operation,
       metadata: metadata ?? null,
     })
+  }
+
+  /**
+   * MCP observability ledger (#844). Persists one row per MCP tool dispatch
+   * across the store/partner/admin surfaces. Best-effort: callers fire this
+   * from the dispatcher's observe sink and must not let a ledger failure break
+   * the tool call. `operation` is namespaced `mcp:<tool>` so it never collides
+   * with the image-quota operations and ledger reads can filter it out.
+   */
+  async recordMcpEvent(
+    evt: McpToolEvent,
+    actor?: { id?: string | null; type?: string | null; partner_id?: string | null }
+  ) {
+    await this.createAiUsageEvents({
+      partner_id: actor?.partner_id ?? null,
+      operation: `mcp:${evt.tool}`,
+      surface: evt.surface,
+      actor_id: actor?.id ?? null,
+      actor_type: actor?.type ?? null,
+      metadata: {
+        method: evt.method,
+        path: evt.path ?? null,
+        outcome: evt.outcome,
+        executed: evt.executed,
+        ok: evt.ok,
+        ms: evt.ms ?? null,
+        error: evt.error ?? null,
+        context: evt.context ?? null,
+      },
+    })
+  }
+
+  /**
+   * Read recent MCP ledger rows (optionally scoped to one surface), newest
+   * first. Backs the /admin/mcp/usage endpoint / get_mcp_usage tool.
+   */
+  async listMcpUsage(
+    opts: { surface?: string; limit?: number } = {}
+  ): Promise<{ events: any[]; count: number }> {
+    const filters: Record<string, any> = { operation: { $like: "mcp:%" } }
+    if (opts.surface) {
+      filters.surface = opts.surface
+    }
+    const [events, count] = await this.listAndCountAiUsageEvents(filters, {
+      take: opts.limit ?? 50,
+      order: { created_at: "DESC" },
+    } as any)
+    return { events, count }
   }
 }
 


### PR DESCRIPTION
Completes the four #1092 follow-ups after the Tier 0/1 merge (#1098), all on the shared **`src/lib/mcp-core`**.

## (a) Store MCP → mcp-core
The multi-tenant store surface now runs on the same dispatcher as partner/admin. Core was extended **additively** (partner/admin set none of these, so zero behavior change):
- `McpContext.tenant` — per-call `store`→publishable-key resolution + default key
- `McpContext.runNative` — native container-backed tools (`list_stores`, `get_storefront_key`)
- `McpContext.writeDisabledMessage` — surface-specific write-gate copy (keeps the dual-mount guidance)
- `McpContext.disableSensitiveRails` — store `DELETE` (`remove_line_item`) is a normal cart op, not a sensitive action
- `McpToolDef.native` + `publishableKey` proxy passthrough

Store keeps a thin server that unwraps the `{ok,data}` envelope to preserve its **raw-JSON wire contract**. `callStoreRoute` (used by UCP) is untouched. ✅ all 24 store MCP integration tests green.

## (b) Admin Tier 2 writes
`create_product` / `update_product` / `update_customer` (**sensitive** → require `confirm:true`) + `delete_product`, the **first `dangerous` action** (confirm **and** a human `reason`, gated by `ADMIN_MCP_ENABLE_DANGEROUS`). One registry row each — they wrap Medusa's built-in admin routes.

## (c) V4 admin chat deprecation
Behind `ADMIN_V4_CHAT_DEPRECATED` (**default OFF → fully reversible from config**). When on, `/admin/ai/chat/chat` + `/resolve` return `410` pointing at the MCP assistant. **No capability regresses** — the resolver lives on as the `resolve_admin_query` tool (`POST /admin/mcp/resolve-query`).

## (d) #844 MCP observability ledger
`ai_usage_event` extended (`partner_id` nullable + `surface`/`actor_id`/`actor_type`, additive migration). Every MCP dispatch across **all three surfaces** persists via the documented `makeMcpLogSink` seam (`makeMcpLedgerSink`, fire-and-forget). New `GET /admin/mcp/usage` + `get_mcp_usage` tool. `MCP_LEDGER_DISABLED` ops kill-switch (store is a public catalog server — avoids row bloat if needed).

## Verification
- **57** MCP unit tests + **24** store integration + **7** new `admin-mcp` integration — all green
- Prod-parity build (`check:prod-build`) passes

## Ops (post-merge, optional — all default to no-op)
- `ADMIN_MCP_ENABLE_DANGEROUS=true` to expose `delete_product`
- `ADMIN_V4_CHAT_DEPRECATED=true` to retire the old chat
- `MCP_LEDGER_DISABLED=true` to log-only (no ledger writes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
