### PR TITLE
feat(admin): conversation history + persistence for admin assistant [#1092]

### DIFF
--- a/apps/backend/integration-tests/http/admin-assistant-conversations-api.spec.ts
+++ b/apps/backend/integration-tests/http/admin-assistant-conversations-api.spec.ts
@@ -1,0 +1,189 @@
+import { Modules } from "@medusajs/utils"
+import Scrypt from "scrypt-kdf"
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+
+jest.setTimeout(90 * 1000)
+
+const SECOND_PASSWORD = "somepassword"
+
+/**
+ * Provision a second admin user directly through the container (mirroring the
+ * createAdminUser helper, but with a distinct email that doesn't clobber the
+ * shared testUserCredentials) and return its bearer headers — to prove
+ * cross-user isolation.
+ */
+async function createSecondAdmin(container: any, api: any) {
+  const unique = Math.random().toString(36).slice(2, 10)
+  const email = `admin-asst2-${unique}@jyt.test`
+
+  const userModule = container.resolve(Modules.USER)
+  const authModule = container.resolve(Modules.AUTH)
+  const user = await userModule.createUsers({
+    first_name: "Asst",
+    last_name: "Two",
+    email,
+  })
+  const passwordHash = await Scrypt.kdf(SECOND_PASSWORD, { logN: 15, r: 8, p: 1 })
+  await authModule.createAuthIdentities({
+    provider_identities: [
+      {
+        provider: "emailpass",
+        entity_id: email,
+        provider_metadata: { password: passwordHash.toString("base64") },
+      },
+    ],
+    app_metadata: { user_id: user.id },
+  })
+
+  const login = await api.post("/auth/user/emailpass", {
+    email,
+    password: SECOND_PASSWORD,
+  })
+  return { headers: { Authorization: `Bearer ${login.data.token}` } }
+}
+
+const SAMPLE_MESSAGES = [
+  { id: "m1", role: "user", parts: [{ type: "text", text: "Hi" }] },
+  { id: "m2", role: "assistant", parts: [{ type: "text", text: "Hello!" }] },
+]
+
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("Admin assistant conversation history API (#1092)", () => {
+    let headers: Record<string, string>
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      headers = (await getAuthHeaders(api)).headers
+    })
+
+    it("creates a conversation and reads it back with messages", async () => {
+      const post = await api.post(
+        "/admin/assistant/conversations",
+        { title: "Ops question", messages: SAMPLE_MESSAGES },
+        { headers }
+      )
+      expect(post.status).toBe(201)
+      expect(post.data.conversation.user_id).toBeTruthy()
+      expect(post.data.conversation.title).toBe("Ops question")
+      const id = post.data.conversation.id
+
+      const get = await api.get(`/admin/assistant/conversations/${id}`, {
+        headers,
+      })
+      expect(get.status).toBe(200)
+      expect(get.data.conversation.messages).toHaveLength(2)
+      expect(get.data.conversation.messages[0].parts[0].text).toBe("Hi")
+    })
+
+    it("defaults the title when omitted", async () => {
+      const post = await api.post(
+        "/admin/assistant/conversations",
+        {},
+        { headers }
+      )
+      expect(post.status).toBe(201)
+      expect(post.data.conversation.title).toBe("New chat")
+      expect(post.data.conversation.messages).toEqual([])
+    })
+
+    it("lists the user's conversations newest first (no message bodies)", async () => {
+      await api.post(
+        "/admin/assistant/conversations",
+        { title: "First" },
+        { headers }
+      )
+      await api.post(
+        "/admin/assistant/conversations",
+        { title: "Second" },
+        { headers }
+      )
+
+      const list = await api.get("/admin/assistant/conversations", { headers })
+      expect(list.status).toBe(200)
+      expect(list.data.count).toBe(2)
+      expect(list.data.conversations[0].title).toBe("Second")
+      expect(list.data.conversations[0].messages).toBeUndefined()
+    })
+
+    it("PATCH renames and persists messages", async () => {
+      const post = await api.post(
+        "/admin/assistant/conversations",
+        { title: "Untitled" },
+        { headers }
+      )
+      const id = post.data.conversation.id
+
+      const res = await api.patch(
+        `/admin/assistant/conversations/${id}`,
+        { title: "Renamed", messages: SAMPLE_MESSAGES },
+        { headers }
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.conversation.title).toBe("Renamed")
+      expect(res.data.conversation.messages).toHaveLength(2)
+    })
+
+    it("DELETE removes the conversation", async () => {
+      const post = await api.post(
+        "/admin/assistant/conversations",
+        { title: "Doomed" },
+        { headers }
+      )
+      const id = post.data.conversation.id
+
+      const del = await api.delete(`/admin/assistant/conversations/${id}`, {
+        headers,
+      })
+      expect(del.status).toBe(200)
+      expect(del.data.deleted).toBe(true)
+
+      const get = await api
+        .get(`/admin/assistant/conversations/${id}`, { headers })
+        .catch((e: any) => e.response)
+      expect(get.status).toBe(404)
+    })
+
+    it("does not leak another user's conversation", async () => {
+      const other = await createSecondAdmin(getContainer(), api)
+      const post = await api.post(
+        "/admin/assistant/conversations",
+        { title: "Private" },
+        { headers: other.headers }
+      )
+      const id = post.data.conversation.id
+
+      const get = await api
+        .get(`/admin/assistant/conversations/${id}`, { headers })
+        .catch((e: any) => e.response)
+      expect(get.status).toBe(404)
+
+      const list = await api.get("/admin/assistant/conversations", { headers })
+      expect(list.data.conversations.some((c: any) => c.id === id)).toBe(false)
+    })
+
+    it("PATCH with an empty body is rejected (400)", async () => {
+      const post = await api.post(
+        "/admin/assistant/conversations",
+        { title: "X" },
+        { headers }
+      )
+      const id = post.data.conversation.id
+
+      const res = await api
+        .patch(`/admin/assistant/conversations/${id}`, {}, { headers })
+        .catch((e: any) => e.response)
+      expect(res.status).toBe(400)
+    })
+
+    it("requires admin authentication", async () => {
+      const res = await api
+        .get("/admin/assistant/conversations")
+        .catch((e: any) => e.response)
+      expect([401, 403]).toContain(res.status)
+    })
+  })
+})

--- a/apps/backend/medusa-config.prod.ts
+++ b/apps/backend/medusa-config.prod.ts
@@ -519,6 +519,9 @@ module.exports = defineConfig({
       resolve: "./src/modules/partner-assistant",
     },
     {
+      resolve: "./src/modules/admin-assistant",
+    },
+    {
       resolve: "./src/modules/artisan-product-detail",
     },
     {

--- a/apps/backend/medusa-config.ts
+++ b/apps/backend/medusa-config.ts
@@ -187,6 +187,9 @@ module.exports = defineConfig({
       resolve: "./src/modules/partner-assistant",
     },
     {
+      resolve: "./src/modules/admin-assistant",
+    },
+    {
       resolve: "./src/modules/artisan-product-detail",
     },
     {

--- a/apps/backend/src/admin/routes/assistant/page.tsx
+++ b/apps/backend/src/admin/routes/assistant/page.tsx
@@ -11,9 +11,9 @@
  * This lives alongside the legacy V4 hybrid-resolver chat (routes/chats) rather
  * than replacing it, per the epic's one-release deprecation window.
  */
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { defineRouteConfig } from "@medusajs/admin-sdk"
-import { ChatBubbleLeftRight, Sparkles, ArrowUpMini, Spinner, Check, ExclamationCircle, ArrowPathMini, SquareTwoStack } from "@medusajs/icons"
+import { ChatBubbleLeftRight, Sparkles, ArrowUpMini, Spinner, Check, ExclamationCircle, ArrowPathMini, SquareTwoStack, Plus, Trash } from "@medusajs/icons"
 import { Container, Heading, Text, Button, Textarea, IconButton, Badge, Table, toast } from "@medusajs/ui"
 import { useChat } from "@ai-sdk/react"
 import { DefaultChatTransport } from "ai"
@@ -298,9 +298,59 @@ const CopyButton = ({ text }: { text: string }) => {
   )
 }
 
-const AssistantChat = () => {
+// ─── Conversation persistence (history) ──────────────────────────────────────
+
+type ConversationSummary = {
+  id: string
+  title: string
+  created_at?: string
+  updated_at?: string
+}
+
+type StoredMessage = { id: string; role: string; parts: any[] }
+
+const CONVERSATIONS_URL = `${API_BASE_URL.replace(/\/$/, "")}/admin/assistant/conversations`
+
+/** Admin session cookie authenticates; small typed fetch wrapper. */
+async function apiFetch<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    credentials: "include",
+    headers: { "content-type": "application/json" },
+    ...init,
+  })
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`)
+  return (await res.json()) as T
+}
+
+/** First user message → conversation title (trimmed to a sane length). */
+function deriveTitle(messages: any[]): string {
+  const firstUser = messages.find((m) => m.role === "user")
+  const text = getText(firstUser?.parts).trim()
+  if (!text) return "New chat"
+  return text.length > 60 ? `${text.slice(0, 57)}…` : text
+}
+
+/** Reduce UI messages to the storable shape (id/role/parts). */
+function toStored(messages: any[]): StoredMessage[] {
+  return messages.map((m) => ({ id: m.id, role: m.role, parts: m.parts }))
+}
+
+const AssistantChat = ({
+  conversationId,
+  initialMessages,
+  onCreated,
+}: {
+  conversationId: string | null
+  initialMessages: StoredMessage[]
+  onCreated: (id: string, title: string) => void
+}) => {
   const scrollRef = useRef<HTMLDivElement>(null)
   const [input, setInput] = useState("")
+  const idRef = useRef<string | null>(conversationId)
+  const persistingRef = useRef(false)
+  const lastPersistedRef = useRef<string>(
+    JSON.stringify(initialMessages.map((m) => [m.id, m.parts?.length]))
+  )
 
   const transport = useMemo(
     () =>
@@ -312,7 +362,7 @@ const AssistantChat = () => {
   )
 
   const { messages, sendMessage, status, error, stop, regenerate, clearError } =
-    useChat({ transport })
+    useChat({ transport, messages: initialMessages as any })
   const streaming = status === "submitted" || status === "streaming"
 
   const retry = () => {
@@ -328,6 +378,43 @@ const AssistantChat = () => {
     if (scrollRef.current) scrollRef.current.scrollTop = scrollRef.current.scrollHeight
   }, [messages, status])
 
+  // Persist the thread after each completed turn: create-on-first-turn, then
+  // patch. A ref-guarded snapshot avoids redundant writes and re-entrancy.
+  useEffect(() => {
+    if (status !== "ready" || messages.length === 0) return
+    const snapshot = JSON.stringify(messages.map((m: any) => [m.id, m.parts?.length]))
+    if (snapshot === lastPersistedRef.current || persistingRef.current) return
+
+    persistingRef.current = true
+    const stored = toStored(messages as any[])
+    const run = async () => {
+      try {
+        if (idRef.current) {
+          await apiFetch(`${CONVERSATIONS_URL}/${idRef.current}`, {
+            method: "PATCH",
+            body: JSON.stringify({ messages: stored }),
+          })
+        } else {
+          const title = deriveTitle(messages as any[])
+          const { conversation } = await apiFetch<{
+            conversation: { id: string; title: string }
+          }>(CONVERSATIONS_URL, {
+            method: "POST",
+            body: JSON.stringify({ title, messages: stored }),
+          })
+          idRef.current = conversation.id
+          onCreated(conversation.id, conversation.title)
+        }
+        lastPersistedRef.current = snapshot
+      } catch {
+        // Non-fatal: the chat still works, history just didn't save this turn.
+      } finally {
+        persistingRef.current = false
+      }
+    }
+    void run()
+  }, [status, messages, onCreated])
+
   const submit = (text: string) => {
     const t = text.trim()
     if (!t || streaming) return
@@ -336,17 +423,7 @@ const AssistantChat = () => {
   }
 
   return (
-    <Container className="flex h-[calc(100vh-140px)] flex-col overflow-hidden p-0">
-      <div className="border-ui-border-base flex items-center gap-2 border-b px-6 py-4">
-        <Sparkles className="text-ui-fg-interactive" />
-        <div>
-          <Heading level="h2">Admin Assistant</Heading>
-          <Text size="small" className="text-ui-fg-subtle">
-            Ask about orders, partners, production and more — it reads the Admin API for you.
-          </Text>
-        </div>
-      </div>
-
+    <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
       <div ref={scrollRef} className="flex-1 space-y-4 overflow-y-auto px-6 py-4">
         {messages.length === 0 ? (
           <div className="flex flex-col gap-2">
@@ -450,6 +527,171 @@ const AssistantChat = () => {
           )}
         </div>
       </div>
+    </div>
+  )
+}
+
+// ─── History sidebar ─────────────────────────────────────────────────────────
+
+const HistorySidebar = ({
+  conversations,
+  activeId,
+  loading,
+  onNew,
+  onSelect,
+  onDelete,
+}: {
+  conversations: ConversationSummary[]
+  activeId: string | null
+  loading: boolean
+  onNew: () => void
+  onSelect: (id: string) => void
+  onDelete: (id: string) => void
+}) => (
+  <div className="border-ui-border-base flex w-64 shrink-0 flex-col border-r">
+    <div className="border-ui-border-base border-b p-3">
+      <Button variant="secondary" size="small" className="w-full" onClick={onNew}>
+        <Plus /> New chat
+      </Button>
+    </div>
+    <div className="min-h-0 flex-1 overflow-y-auto p-2">
+      {loading ? (
+        <Text size="xsmall" className="text-ui-fg-muted px-2 py-1">
+          Loading…
+        </Text>
+      ) : conversations.length === 0 ? (
+        <Text size="xsmall" className="text-ui-fg-muted px-2 py-1">
+          No conversations yet.
+        </Text>
+      ) : (
+        conversations.map((c) => (
+          <div
+            key={c.id}
+            className={`group flex items-center gap-1 rounded-md px-2 py-1.5 ${
+              c.id === activeId ? "bg-ui-bg-base-pressed" : "hover:bg-ui-bg-base-hover"
+            }`}
+          >
+            <button
+              type="button"
+              onClick={() => onSelect(c.id)}
+              className="text-ui-fg-subtle hover:text-ui-fg-base flex-1 truncate text-left text-sm"
+              title={c.title}
+            >
+              {c.title}
+            </button>
+            <button
+              type="button"
+              onClick={() => onDelete(c.id)}
+              className="text-ui-fg-muted hover:text-ui-fg-error opacity-0 transition-opacity group-hover:opacity-100"
+              aria-label="Delete conversation"
+            >
+              <Trash className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        ))
+      )}
+    </div>
+  </div>
+)
+
+// ─── Page (two-pane: history + chat) ─────────────────────────────────────────
+
+const AssistantPage = () => {
+  const [conversations, setConversations] = useState<ConversationSummary[]>([])
+  const [loading, setLoading] = useState(true)
+  const [activeId, setActiveId] = useState<string | null>(null)
+  const [initialMessages, setInitialMessages] = useState<StoredMessage[]>([])
+  // Bumping this remounts <AssistantChat>, resetting useChat for a fresh thread
+  // or a freshly-loaded conversation.
+  const [threadKey, setThreadKey] = useState(0)
+
+  const refreshList = useCallback(async () => {
+    try {
+      const { conversations } = await apiFetch<{
+        conversations: ConversationSummary[]
+      }>(CONVERSATIONS_URL)
+      setConversations(conversations)
+    } catch {
+      // Non-fatal: the chat still works without the history list.
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void refreshList()
+  }, [refreshList])
+
+  const startNew = useCallback(() => {
+    setActiveId(null)
+    setInitialMessages([])
+    setThreadKey((k) => k + 1)
+  }, [])
+
+  const openConversation = useCallback(async (id: string) => {
+    try {
+      const { conversation } = await apiFetch<{
+        conversation: { id: string; messages: StoredMessage[] }
+      }>(`${CONVERSATIONS_URL}/${id}`)
+      setActiveId(id)
+      setInitialMessages(conversation.messages || [])
+      setThreadKey((k) => k + 1)
+    } catch {
+      toast.error("Could not open that conversation.")
+    }
+  }, [])
+
+  const deleteConversation = useCallback(
+    async (id: string) => {
+      try {
+        await apiFetch(`${CONVERSATIONS_URL}/${id}`, { method: "DELETE" })
+        setConversations((prev) => prev.filter((c) => c.id !== id))
+        if (id === activeId) startNew()
+      } catch {
+        toast.error("Could not delete that conversation.")
+      }
+    },
+    [activeId, startNew]
+  )
+
+  const onCreated = useCallback(
+    (id: string, title: string) => {
+      setActiveId(id)
+      setConversations((prev) => [
+        { id, title },
+        ...prev.filter((c) => c.id !== id),
+      ])
+    },
+    []
+  )
+
+  return (
+    <Container className="flex h-[calc(100vh-140px)] flex-col overflow-hidden p-0">
+      <div className="border-ui-border-base flex items-center gap-2 border-b px-6 py-4">
+        <Sparkles className="text-ui-fg-interactive" />
+        <div>
+          <Heading level="h2">Admin Assistant</Heading>
+          <Text size="small" className="text-ui-fg-subtle">
+            Ask about orders, partners, production and more — it reads the Admin API for you.
+          </Text>
+        </div>
+      </div>
+      <div className="flex min-h-0 flex-1">
+        <HistorySidebar
+          conversations={conversations}
+          activeId={activeId}
+          loading={loading}
+          onNew={startNew}
+          onSelect={openConversation}
+          onDelete={deleteConversation}
+        />
+        <AssistantChat
+          key={threadKey}
+          conversationId={activeId}
+          initialMessages={initialMessages}
+          onCreated={onCreated}
+        />
+      </div>
     </Container>
   )
 }
@@ -459,4 +701,4 @@ export const config = defineRouteConfig({
   icon: ChatBubbleLeftRight,
 })
 
-export default AssistantChat
+export default AssistantPage

--- a/apps/backend/src/api/admin/assistant/conversations/[id]/route.ts
+++ b/apps/backend/src/api/admin/assistant/conversations/[id]/route.ts
@@ -1,0 +1,68 @@
+/**
+ * Admin assistant conversation — single-resource ops (#1092).
+ *
+ *   GET    /admin/assistant/conversations/:id  → full conversation (messages)
+ *   PATCH  /admin/assistant/conversations/:id  → rename / persist messages
+ *   DELETE /admin/assistant/conversations/:id  → delete
+ *
+ * All user-scoped: the service 404s a conversation that isn't the authenticated
+ * user's, so ids aren't cross-user readable.
+ */
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { ADMIN_ASSISTANT_MODULE } from "../../../../../modules/admin-assistant"
+import type { UpdateConversationInput } from "../validators"
+
+function requireUserId(req: AuthenticatedMedusaRequest): string {
+  const userId = req.auth_context?.actor_id
+  if (!userId) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "Admin authentication required"
+    )
+  }
+  return userId
+}
+
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const userId = requireUserId(req)
+  const service: any = req.scope.resolve(ADMIN_ASSISTANT_MODULE)
+  const conversation = await service.getConversationForUser(
+    userId,
+    req.params.id
+  )
+  return res.status(200).json({ conversation })
+}
+
+export const PATCH = async (
+  req: AuthenticatedMedusaRequest<UpdateConversationInput>,
+  res: MedusaResponse
+) => {
+  const userId = requireUserId(req)
+  const body = req.validatedBody as UpdateConversationInput
+  const service: any = req.scope.resolve(ADMIN_ASSISTANT_MODULE)
+  const conversation = await service.updateConversationForUser(
+    userId,
+    req.params.id,
+    body
+  )
+  return res.status(200).json({ conversation })
+}
+
+export const DELETE = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const userId = requireUserId(req)
+  const service: any = req.scope.resolve(ADMIN_ASSISTANT_MODULE)
+  await service.deleteConversationForUser(userId, req.params.id)
+  return res
+    .status(200)
+    .json({ id: req.params.id, object: "conversation", deleted: true })
+}

--- a/apps/backend/src/api/admin/assistant/conversations/route.ts
+++ b/apps/backend/src/api/admin/assistant/conversations/route.ts
@@ -1,0 +1,56 @@
+/**
+ * Admin assistant conversation history (#1092).
+ *
+ *   GET  /admin/assistant/conversations   → list this user's saved chats
+ *                                           (light: no message bodies)
+ *   POST /admin/assistant/conversations   → create a new conversation
+ *
+ * Server-persisted so history follows the operator across devices. The chat
+ * endpoint itself stays stateless; the client writes the message array back to
+ * a conversation here after each completed turn. Scoped to the authenticated
+ * admin user throughout. Mirrors /partners/assistant/conversations.
+ */
+import {
+  AuthenticatedMedusaRequest,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { MedusaError } from "@medusajs/framework/utils"
+import { ADMIN_ASSISTANT_MODULE } from "../../../../modules/admin-assistant"
+import type { CreateConversationInput } from "./validators"
+
+function requireUserId(req: AuthenticatedMedusaRequest): string {
+  const userId = req.auth_context?.actor_id
+  if (!userId) {
+    throw new MedusaError(
+      MedusaError.Types.UNAUTHORIZED,
+      "Admin authentication required"
+    )
+  }
+  return userId
+}
+
+export const GET = async (
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse
+) => {
+  const userId = requireUserId(req)
+  const service: any = req.scope.resolve(ADMIN_ASSISTANT_MODULE)
+  const conversations = await service.listConversationsForUser(userId)
+
+  return res.status(200).json({
+    conversations,
+    count: conversations.length,
+  })
+}
+
+export const POST = async (
+  req: AuthenticatedMedusaRequest<CreateConversationInput>,
+  res: MedusaResponse
+) => {
+  const userId = requireUserId(req)
+  const body = req.validatedBody as CreateConversationInput
+  const service: any = req.scope.resolve(ADMIN_ASSISTANT_MODULE)
+  const conversation = await service.createConversationForUser(userId, body)
+
+  return res.status(201).json({ conversation })
+}

--- a/apps/backend/src/api/admin/assistant/conversations/validators.ts
+++ b/apps/backend/src/api/admin/assistant/conversations/validators.ts
@@ -1,0 +1,32 @@
+import { z } from "@medusajs/framework/zod"
+
+/**
+ * A persisted UI message (AI-SDK shape). Kept permissive (passthrough) — the
+ * chat endpoint owns the canonical normalisation; here we only store what the
+ * client sends so a conversation replays exactly.
+ */
+const StoredMessageSchema = z
+  .object({
+    id: z.string().optional(),
+    role: z.enum(["system", "user", "assistant"]),
+    content: z.string().optional(),
+    parts: z.array(z.object({ type: z.string() }).passthrough()).optional(),
+  })
+  .passthrough()
+
+export const CreateConversationSchema = z.object({
+  title: z.string().trim().min(1).max(200).optional(),
+  messages: z.array(StoredMessageSchema).max(200).optional(),
+})
+
+export const UpdateConversationSchema = z
+  .object({
+    title: z.string().trim().min(1).max(200).optional(),
+    messages: z.array(StoredMessageSchema).max(200).optional(),
+  })
+  .refine((v) => v.title !== undefined || v.messages !== undefined, {
+    message: "Provide at least one of title or messages",
+  })
+
+export type CreateConversationInput = z.infer<typeof CreateConversationSchema>
+export type UpdateConversationInput = z.infer<typeof UpdateConversationSchema>

--- a/apps/backend/src/api/middlewares.ts
+++ b/apps/backend/src/api/middlewares.ts
@@ -122,6 +122,7 @@ import { ThemeChatSchema } from "./partners/storefront/website/theme/chat/valida
 import { PartnerAssistantChatSchema } from "./partners/assistant/chat/validators";
 import { PartnerAssistantSummarizeSchema } from "./partners/assistant/summarize/validators";
 import { CreateConversationSchema as PartnerCreateConversationSchema, UpdateConversationSchema as PartnerUpdateConversationSchema } from "./partners/assistant/conversations/validators";
+import { CreateConversationSchema as AdminAssistantCreateConversationSchema, UpdateConversationSchema as AdminAssistantUpdateConversationSchema } from "./admin/assistant/conversations/validators";
 import { createPlanSchema, updatePlanSchema, createSubscriptionSchema } from "./admin/partner-plans/validators";
 import { subscribeSchema as partnerSubscribeSchema } from "./partners/subscription/validators";
 import { AdminPostInventoryOrderTasksReq } from "./admin/inventory-orders/[id]/tasks/validators";
@@ -2266,6 +2267,23 @@ export default defineMiddlewares({
       middlewares: [
         createCorsPartnerMiddleware(),
         authenticate("partner", ["session", "bearer"]),
+      ],
+    },
+    // Admin assistant conversation history (#1092) — server-persisted chat
+    // threads, user-scoped. /admin/* is admin-authenticated globally, so only
+    // the write bodies need validation.
+    {
+      matcher: "/admin/assistant/conversations",
+      method: "POST",
+      middlewares: [
+        validateAndTransformBody(wrapSchema(AdminAssistantCreateConversationSchema)),
+      ],
+    },
+    {
+      matcher: "/admin/assistant/conversations/:id",
+      method: "PATCH",
+      middlewares: [
+        validateAndTransformBody(wrapSchema(AdminAssistantUpdateConversationSchema)),
       ],
     },
     // Partner Subscription

--- a/apps/backend/src/modules/admin-assistant/index.ts
+++ b/apps/backend/src/modules/admin-assistant/index.ts
@@ -1,0 +1,8 @@
+import { Module } from "@medusajs/framework/utils"
+import AdminAssistantService from "./service"
+
+export const ADMIN_ASSISTANT_MODULE = "admin_assistant"
+
+export default Module(ADMIN_ASSISTANT_MODULE, {
+  service: AdminAssistantService,
+})

--- a/apps/backend/src/modules/admin-assistant/migrations/Migration20260721181500.ts
+++ b/apps/backend/src/modules/admin-assistant/migrations/Migration20260721181500.ts
@@ -1,0 +1,25 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * Creates the admin_assistant_conversation table (#1092 — admin assistant chat
+ * history). Mirrors partner_assistant_conversation (partner_id → user_id).
+ *
+ * Hand-written (Claude-owned) create migration mirroring what DML would
+ * generate for the model: jsonb `messages` (default '[]') + nullable jsonb
+ * `metadata`, a lookup index on user_id, and the standard deleted_at index.
+ * Distinct class name + timestamp to avoid the Medusa migration-name-collision
+ * hazard.
+ */
+export class Migration20260721181500 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`create table if not exists "admin_assistant_conversation" ("id" text not null, "user_id" text not null, "title" text not null default 'New chat', "messages" jsonb not null default '[]', "metadata" jsonb null, "created_at" timestamptz not null default now(), "updated_at" timestamptz not null default now(), "deleted_at" timestamptz null, constraint "admin_assistant_conversation_pkey" primary key ("id"));`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_admin_assistant_conversation_user_id" ON "admin_assistant_conversation" ("user_id") WHERE deleted_at IS NULL;`);
+    this.addSql(`CREATE INDEX IF NOT EXISTS "IDX_admin_assistant_conversation_deleted_at" ON "admin_assistant_conversation" ("deleted_at") WHERE deleted_at IS NULL;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "admin_assistant_conversation" cascade;`);
+  }
+
+}

--- a/apps/backend/src/modules/admin-assistant/models/admin-assistant-conversation.ts
+++ b/apps/backend/src/modules/admin-assistant/models/admin-assistant-conversation.ts
@@ -1,0 +1,45 @@
+import { model } from "@medusajs/framework/utils"
+
+/**
+ * A saved admin-assistant conversation (#1092 — chat history).
+ *
+ * The `/admin/assistant/chat` endpoint is stateless (the client sends the full
+ * message array each turn), so history lives here: one row per saved
+ * conversation, the whole AI-SDK UIMessage array persisted as `messages`. The
+ * admin user IS the auth actor (auth_context.actor_id = user_id), so scoping is
+ * per-user — every route filters by the authenticated user's id.
+ *
+ * `messages` mirrors the shape the chat transport sends/receives:
+ *   [{ id, role: 'user'|'assistant'|'system', parts: [{ type, text, ... }] }]
+ * Persisted verbatim (client-driven) after each completed stream, so reopening a
+ * conversation replays it exactly and continues the thread.
+ *
+ * Mirrors the partner-assistant conversation model so both assistants share one
+ * persistence shape.
+ */
+const AdminAssistantConversation = model
+  .define("admin_assistant_conversation", {
+    id: model.id().primaryKey(),
+
+    // The admin user this conversation belongs to (auth actor id).
+    user_id: model.text().searchable(),
+
+    // Human-readable label shown in the history sidebar. Seeded from the first
+    // user message client-side; editable.
+    title: model.text().default("New chat"),
+
+    // The AI-SDK UIMessage array (see doc-comment). Empty for a fresh chat.
+    // `model.json()` types as an object; the array is stored/read at runtime and
+    // the service always writes a value (defaulting to []), with the DB-level
+    // default '[]' from the migration as the backstop.
+    messages: model.json(),
+
+    metadata: model.json().nullable(),
+  })
+  .indexes([
+    {
+      on: ["user_id"],
+    },
+  ])
+
+export default AdminAssistantConversation

--- a/apps/backend/src/modules/admin-assistant/service.ts
+++ b/apps/backend/src/modules/admin-assistant/service.ts
@@ -1,0 +1,88 @@
+import { MedusaError, MedusaService } from "@medusajs/framework/utils"
+import AdminAssistantConversation from "./models/admin-assistant-conversation"
+
+/**
+ * Admin assistant conversation store — thin CRUD over saved chat threads,
+ * always scoped to the authenticated admin user. The generated MedusaService
+ * methods do the heavy lifting; the helpers below enforce user ownership so a
+ * route can never read or mutate another user's conversation.
+ *
+ * Mirrors PartnerAssistantService (partner_id → user_id).
+ */
+class AdminAssistantService extends MedusaService({
+  AdminAssistantConversation,
+}) {
+  /** The user's conversations, newest first. Excludes the heavy `messages`
+   * blob by default so the history list stays light. */
+  async listConversationsForUser(
+    userId: string,
+    { withMessages = false }: { withMessages?: boolean } = {}
+  ) {
+    return this.listAdminAssistantConversations(
+      { user_id: userId },
+      {
+        order: { updated_at: "DESC" },
+        ...(withMessages
+          ? {}
+          : { select: ["id", "title", "created_at", "updated_at"] as any }),
+      }
+    )
+  }
+
+  /** Fetch one conversation, 404-ing if it doesn't exist OR isn't the user's —
+   * the same response either way so ids aren't probeable. */
+  async getConversationForUser(userId: string, id: string) {
+    const [row] = await this.listAdminAssistantConversations({
+      id,
+      user_id: userId,
+    })
+    if (!row) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Conversation ${id} not found`
+      )
+    }
+    return row
+  }
+
+  createConversationForUser(
+    userId: string,
+    input: { title?: string; messages?: unknown[] }
+  ) {
+    // `messages` is an array stored in a json column, which the generated
+    // create typing narrows to an object — cast at the boundary.
+    return this.createAdminAssistantConversations({
+      user_id: userId,
+      ...(input.title !== undefined ? { title: input.title } : {}),
+      messages: (input.messages ?? []) as any,
+    })
+  }
+
+  /** Update title and/or messages, first asserting the row is the user's. */
+  async updateConversationForUser(
+    userId: string,
+    id: string,
+    input: { title?: string; messages?: unknown[] }
+  ) {
+    await this.getConversationForUser(userId, id)
+    const [updated] = await this.updateAdminAssistantConversations([
+      {
+        id,
+        ...(input.title !== undefined ? { title: input.title } : {}),
+        // json column holds an array; cast past the object-narrowed typing.
+        ...(input.messages !== undefined
+          ? { messages: input.messages as any }
+          : {}),
+      },
+    ])
+    return updated
+  }
+
+  async deleteConversationForUser(userId: string, id: string) {
+    await this.getConversationForUser(userId, id)
+    await this.deleteAdminAssistantConversations(id)
+    return true
+  }
+}
+
+export default AdminAssistantService


### PR DESCRIPTION
Third and final chat-improvement PR (after markdown #1107 and approval/UX #1108). The admin assistant was in-memory only — a refresh wiped the thread and there was no way to revisit past conversations. This adds server-persisted history with per-user isolation, mirroring the proven partner assistant.

## Backend — new `admin_assistant` module
- **Model** `admin_assistant_conversation` — `user_id`-scoped, whole AI-SDK UIMessage array in a jsonb `messages` column. Hand-written create migration with a distinct class name/timestamp (migration-name-collision hazard).
- **Service** — user-scoped CRUD: list is light (no message bodies); get/update/delete 404 anything that isn't the caller's, so ids aren't cross-user probeable. json array cast at the boundary (the `model.json()` prod-build typing hazard).
- **Routes** — `GET`/`POST` `/admin/assistant/conversations`, `GET`/`PATCH`/`DELETE` `.../:id`. `/admin/*` is admin-authenticated globally; the user id is `auth_context.actor_id`. Write bodies validated in `middlewares.ts`.
- Registered the module in **both** `medusa-config.ts` and `medusa-config.prod.ts`.

## Admin UI (`routes/assistant/page.tsx`)
- **Two-pane**: a history sidebar (New chat / select / delete) beside the chat thread.
- Thread **persists after each completed turn** (create-on-first, then PATCH), ref-guarded against redundant writes; opening a saved conversation replays it and continues. A key-based remount gives a clean `useChat` reset on new/open.

## Tests
8 HTTP integration tests — CRUD, newest-first light list, default title, empty-PATCH 400, auth-required, and **cross-user 404 isolation** — all green against the shared test DB (which also exercises the new migration).

## Verification
- `medusa build` (backend + admin bundles) passes
- prod-build gate passes
- integration suite: 8/8 green

## Notes
- New table only + additive routes — the migrate job creates `admin_assistant_conversation` before services roll; no impact on existing tables.
- `workflow-schemas.json` build churn intentionally excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)