### PR TITLE
feat(shipping): international retail shipping via Shiprocket [#1111]

### DIFF
--- a/apps/backend/integration-tests/http/partner-order-shiprocket-label.spec.ts
+++ b/apps/backend/integration-tests/http/partner-order-shiprocket-label.spec.ts
@@ -184,14 +184,18 @@ setupSharedTestSuite(() => {
           region_id: regionId,
           sales_channel_id: salesChannelId,
           currency_code: "usd",
+          // Destination is incidental to this suite (it tests pickup ship-from);
+          // keep it an India address so it stays on the DOMESTIC Shiprocket path.
+          // International (non-IN) routing is covered in
+          // retail-order-international-shiprocket.spec.ts (#1111).
           shipping_address: {
             first_name: "Cust",
             last_name: "Omer",
             address_1: "9 Buyer Rd",
-            city: "New York",
-            province: "NY",
-            postal_code: "10001",
-            country_code: "us",
+            city: "Mumbai",
+            province: "MH",
+            postal_code: "400001",
+            country_code: "in",
             phone: "8887776665",
           },
           items: [{ title: "Tangaliya Stole", quantity: 1, unit_price: 1500 }],

--- a/apps/backend/integration-tests/http/retail-order-international-shiprocket.spec.ts
+++ b/apps/backend/integration-tests/http/retail-order-international-shiprocket.spec.ts
@@ -238,6 +238,70 @@ setupSharedTestSuite(() => {
       expect(body.pickup_location).toBe(nickname)
     })
 
+    it("sources HSN from the product variant's hs_code (production path)", async () => {
+      // A real product whose variant carries the customs hs_code — no line
+      // metadata. Proves the mapper resolves HSN via items.variant.hs_code.
+      const prod = await api.post(
+        "/admin/products",
+        {
+          title: "Handloom Silk Stole",
+          status: "published",
+          options: [{ title: "Size", values: ["OS"] }],
+          variants: [
+            {
+              title: "OS",
+              sku: `STOLE-${Date.now()}`,
+              hs_code: "621410",
+              manage_inventory: false, // no stock-location association needed
+              options: { Size: "OS" },
+              prices: [{ currency_code: "usd", amount: 1500 }],
+            },
+          ],
+          sales_channels: [{ id: salesChannelId }],
+        },
+        adminHeaders
+      )
+      const variantId = prod.data.product?.variants?.[0]?.id
+      expect(variantId).toBeTruthy()
+
+      const draft = await api.post(
+        "/admin/draft-orders",
+        {
+          email: "buyer3@t.com",
+          region_id: regionId,
+          sales_channel_id: salesChannelId,
+          currency_code: "usd",
+          shipping_address: {
+            first_name: "Prod",
+            last_name: "Buyer",
+            address_1: "9 Buyer Rd",
+            city: "Dallas",
+            province: "TX",
+            postal_code: "75201",
+            country_code: "us",
+            phone: "8887776665",
+          },
+          items: [{ variant_id: variantId, quantity: 1, unit_price: 1500 }],
+        },
+        adminHeaders
+      )
+      const converted = await api.post(
+        `/admin/draft-orders/${draft.data.draft_order.id}/convert-to-order`,
+        {},
+        adminHeaders
+      )
+      const prodOrderId = converted.data.order?.id
+
+      const res = await api.post(
+        `/partners/orders/${prodOrderId}/shiprocket-label`,
+        {},
+        { headers: partnerHeaders }
+      )
+      expect(res.status).toBe(200)
+      // HSN reached the customs body from the variant's hs_code.
+      expect(shiprocketStubState.lastIntlAdhocBody.order_items[0].hsn).toBe("621410")
+    })
+
     it("rejects the international shipment when a line has no HSN code", async () => {
       // Create a second order whose item carries NO hsn.
       const draft = await api.post(

--- a/apps/backend/integration-tests/http/retail-order-international-shiprocket.spec.ts
+++ b/apps/backend/integration-tests/http/retail-order-international-shiprocket.spec.ts
@@ -1,0 +1,282 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { shiprocketStubState } from "../../src/modules/shipping-providers/shiprocket/stub-fetch"
+
+const PARTNER_PASSWORD = "supersecret"
+
+jest.setTimeout(120 * 1000)
+
+/**
+ * #1111 S1 — a retail/core order shipping to a NON-India destination generates a
+ * real Shiprocket shipment via the international API namespace
+ * (`/international/orders/create/adhoc` → serviceability → assign/awb), with a
+ * customs-declaration body (country NAME, currency, export reason, HSN).
+ *
+ * Mirrors partner-order-shiprocket-label.spec.ts (#772) but with a US buyer, so
+ * the client's destination-country routing kicks in. HSN rides on the line-item
+ * metadata (the interim source until product hs_code is wired in S2).
+ *
+ * `SHIPROCKET_STUB=1` injects the deterministic transport; its international
+ * branch captures the create body into `shiprocketStubState.lastIntlAdhocBody`.
+ */
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("POST /partners/orders/:id/shiprocket-label — international (#1111)", () => {
+    let adminHeaders: any
+    let partnerHeaders: any
+    let locationId: string
+    let salesChannelId: string
+    let regionId: string
+    let orderId: string
+
+    let prevEmail: string | undefined
+    let prevPassword: string | undefined
+    let prevStub: string | undefined
+
+    beforeAll(() => {
+      prevEmail = process.env.SHIPROCKET_EMAIL
+      prevPassword = process.env.SHIPROCKET_PASSWORD
+      prevStub = process.env.SHIPROCKET_STUB
+      process.env.SHIPROCKET_EMAIL = "test@shiprocket.example"
+      process.env.SHIPROCKET_PASSWORD = "secret"
+      process.env.SHIPROCKET_STUB = "1"
+    })
+
+    afterAll(() => {
+      if (prevEmail === undefined) delete process.env.SHIPROCKET_EMAIL
+      else process.env.SHIPROCKET_EMAIL = prevEmail
+      if (prevPassword === undefined) delete process.env.SHIPROCKET_PASSWORD
+      else process.env.SHIPROCKET_PASSWORD = prevPassword
+      if (prevStub === undefined) delete process.env.SHIPROCKET_STUB
+      else process.env.SHIPROCKET_STUB = prevStub
+    })
+
+    beforeEach(async () => {
+      shiprocketStubState.lastAdhocBody = undefined
+      shiprocketStubState.lastIntlAdhocBody = undefined
+      shiprocketStubState.lastAddPickupBody = undefined
+
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+
+      const unique = `${Date.now()}${Math.random().toString(36).slice(2, 6)}`
+      const email = `intl-${unique}@t.com`
+      await api.post("/auth/partner/emailpass/register", {
+        email,
+        password: PARTNER_PASSWORD,
+      })
+      const login1 = await api.post("/auth/partner/emailpass", {
+        email,
+        password: PARTNER_PASSWORD,
+      })
+      let headers: any = { Authorization: `Bearer ${login1.data.token}` }
+      await api.post(
+        "/partners",
+        {
+          name: `Intl ${unique}`,
+          handle: `intl-${unique}`,
+          admin: { email, first_name: "I", last_name: unique },
+        },
+        { headers }
+      )
+      const login2 = await api.post("/auth/partner/emailpass", {
+        email,
+        password: PARTNER_PASSWORD,
+      })
+      partnerHeaders = { Authorization: `Bearer ${login2.data.token}` }
+
+      await api
+        .post(
+          "/admin/shipping-profiles",
+          { name: `default-${unique}`, type: "default" },
+          adminHeaders
+        )
+        .catch(() => {})
+
+      const storeRes = await api.post(
+        "/partners/stores",
+        {
+          store: {
+            name: `IStore ${unique}`,
+            supported_currencies: [{ currency_code: "usd", is_default: true }],
+          },
+          sales_channel: { name: `IChannel ${unique}`, description: "Default" },
+          region: {
+            name: `I Region ${unique}`,
+            currency_code: "usd",
+            countries: ["us"],
+          },
+          // Ship-FROM is an India address (export origin). Phone is added below
+          // via admin (the /partners/stores location schema rejects `phone`).
+          location: {
+            name: "I Warehouse",
+            address: {
+              address_1: "1 Loom St",
+              city: "Surendranagar",
+              province: "GJ",
+              postal_code: "363035",
+              country_code: "IN",
+            },
+          },
+        },
+        { headers: partnerHeaders }
+      )
+      locationId = storeRes.data.location?.id
+      salesChannelId = storeRes.data.sales_channel?.id
+      regionId = storeRes.data.region?.id
+      expect(locationId).toBeTruthy()
+
+      // Give the ship-from a phone so it is registerable as a Shiprocket pickup.
+      await api.post(
+        `/admin/stock-locations/${locationId}`,
+        {
+          address: {
+            address_1: "1 Loom St",
+            city: "Surendranagar",
+            province: "GJ",
+            postal_code: "363035",
+            country_code: "IN",
+            phone: "9990001112",
+          },
+        },
+        adminHeaders
+      )
+
+      const locDetail = await api.get(
+        `/admin/stock-locations/${locationId}?fields=id,*fulfillment_sets.service_zones`,
+        adminHeaders
+      )
+      const zoneId = (locDetail.data.stock_location?.fulfillment_sets || [])
+        .flatMap((f: any) => f.service_zones || [])
+        .map((z: any) => z.id)
+        .find(Boolean)
+      expect(zoneId).toBeTruthy()
+      const profiles = await api.get("/admin/shipping-profiles?limit=1", adminHeaders)
+      const profileId = profiles.data.shipping_profiles?.[0]?.id
+      expect(profileId).toBeTruthy()
+      await api.post(
+        "/admin/shipping-options",
+        {
+          name: "Standard Shipping",
+          service_zone_id: zoneId,
+          shipping_profile_id: profileId,
+          provider_id: "manual_manual",
+          price_type: "flat",
+          type: { label: "Standard", description: "Std", code: "standard" },
+          prices: [{ currency_code: "usd", amount: 10 }],
+        },
+        adminHeaders
+      )
+
+      // US buyer → international. HSN carried on the line-item metadata.
+      const draft = await api.post(
+        "/admin/draft-orders",
+        {
+          email: "buyer@t.com",
+          region_id: regionId,
+          sales_channel_id: salesChannelId,
+          currency_code: "usd",
+          shipping_address: {
+            first_name: "Elena",
+            last_name: "Doe",
+            address_1: "9 Buyer Rd",
+            city: "Dallas",
+            province: "TX",
+            postal_code: "75201",
+            country_code: "us",
+            phone: "8887776665",
+          },
+          items: [
+            {
+              title: "Tangaliya Stole",
+              quantity: 1,
+              unit_price: 1500,
+              metadata: { hsn: "621410" },
+            },
+          ],
+        },
+        adminHeaders
+      )
+      const draftId = draft.data.draft_order?.id
+      const converted = await api.post(
+        `/admin/draft-orders/${draftId}/convert-to-order`,
+        {},
+        adminHeaders
+      )
+      orderId = converted.data.order?.id ?? draftId
+    })
+
+    it("ships a US order via the international API with a customs body", async () => {
+      const res = await api.post(
+        `/partners/orders/${orderId}/shiprocket-label`,
+        {},
+        { headers: partnerHeaders }
+      )
+      expect(res.status).toBe(200)
+      expect(res.data.shiprocket_label.awb).toBe("STUBAWB123")
+      // provider_refs flag the international path.
+      expect(res.data.shiprocket_label.provider_refs?.international).toBe(true)
+
+      // The international create/adhoc endpoint was hit (captured separately).
+      const body = shiprocketStubState.lastIntlAdhocBody
+      expect(body).toBeTruthy()
+      // Country as a NAME (not ISO), amounts in the order currency, commercial export.
+      expect(body.billing_country).toBe("United States")
+      expect(body.currency).toBe("USD")
+      expect(body.payment_method).toBe("Prepaid")
+      expect(body.reasonOfExport).toBe(3)
+      expect(body.purpose_of_shipment).toBe(2)
+      expect(body.Terms_Of_Invoice).toBe("FOB")
+      expect(body.igstPaymentStatus).toBe("A")
+      expect(body.commodity).toBe(true)
+      // HSN reached the line item.
+      expect(body.order_items[0].hsn).toBe("621410")
+      // Ships from the partner's registered India pickup.
+      const nickname = `warehouse-${locationId.slice(-8)}`
+      expect(body.pickup_location).toBe(nickname)
+    })
+
+    it("rejects the international shipment when a line has no HSN code", async () => {
+      // Create a second order whose item carries NO hsn.
+      const draft = await api.post(
+        "/admin/draft-orders",
+        {
+          email: "buyer2@t.com",
+          region_id: regionId,
+          sales_channel_id: salesChannelId,
+          currency_code: "usd",
+          shipping_address: {
+            first_name: "No",
+            last_name: "Hsn",
+            address_1: "9 Buyer Rd",
+            city: "Dallas",
+            province: "TX",
+            postal_code: "75201",
+            country_code: "us",
+            phone: "8887776665",
+          },
+          items: [{ title: "Mystery Item", quantity: 1, unit_price: 1500 }],
+        },
+        adminHeaders
+      )
+      const converted = await api.post(
+        `/admin/draft-orders/${draft.data.draft_order.id}/convert-to-order`,
+        {},
+        adminHeaders
+      )
+      const noHsnOrderId = converted.data.order?.id
+
+      const res = await api
+        .post(
+          `/partners/orders/${noHsnOrderId}/shiprocket-label`,
+          {},
+          { headers: partnerHeaders }
+        )
+        .catch((e: any) => e.response)
+      expect(res.status).toBe(400)
+      expect(res.data.message).toMatch(/HSN code is required/i)
+    })
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/__tests__/order-partner-origin.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/__tests__/order-partner-origin.unit.spec.ts
@@ -1,0 +1,114 @@
+import {
+  resolveOrderPartnerId,
+  resolveOrderShipFromLocation,
+} from "../order-partner-origin"
+import partnerOrderLink from "../../../links/partner-order"
+
+const LINK = partnerOrderLink.entryPoint
+
+/**
+ * #1111 S4 — resolve a retail/core order's OWNING partner + ship-from location
+ * FROM THE ORDER (no partner auth context). Work link first, then retail
+ * sales-channel scoping; ship-from always taken from the partner's own store
+ * default sales channel. Exercised with a stubbed query.graph — no DB.
+ */
+
+// A query stub keyed by entity. The partner↔order LINK entity has a generated
+// entryPoint name, so callers put its rows under the "__link__" key and we map
+// the real entryPoint onto it.
+const makeQuery = (responses: Record<string, any[]>) => ({
+  graph: jest.fn(async ({ entity }: any) => {
+    if (entity === LINK) return { data: responses["__link__"] ?? [] }
+    return { data: responses[entity] ?? [] }
+  }),
+})
+const containerFor = (query: any) => ({ resolve: () => query }) as any
+
+describe("resolveOrderPartnerId", () => {
+  it("prefers the work link (source=work) over retail scoping", async () => {
+    const query = makeQuery({
+      __link__: [{ partner_id: "par_work" }],
+      orders: [{ id: "o1", sales_channel_id: "sc_store" }],
+      stores: [{ id: "st1", default_sales_channel_id: "sc_store" }],
+      partners: [{ id: "par_retail", stores: [{ id: "st1" }] }],
+    })
+    const res = await resolveOrderPartnerId(containerFor(query), "o1")
+    expect(res).toEqual({ partnerId: "par_work", source: "work" })
+  })
+
+  it("resolves retail ownership via order channel → store → partner", async () => {
+    const query = makeQuery({
+      __link__: [], // no work link
+      orders: [{ id: "o1", sales_channel_id: "sc_store" }],
+      stores: [{ id: "st1", default_sales_channel_id: "sc_store" }],
+      partners: [
+        { id: "par_other", stores: [{ id: "st9" }] },
+        { id: "par_retail", stores: [{ id: "st1" }] },
+      ],
+    })
+    const res = await resolveOrderPartnerId(containerFor(query), "o1")
+    expect(res).toEqual({ partnerId: "par_retail", source: "retail" })
+  })
+
+  it("returns nulls when neither rule matches", async () => {
+    const query = makeQuery({
+      __link__: [],
+      orders: [{ id: "o1", sales_channel_id: "sc_unknown" }],
+      stores: [],
+      partners: [],
+    })
+    const res = await resolveOrderPartnerId(containerFor(query), "o1")
+    expect(res).toEqual({ partnerId: null, source: null })
+  })
+
+  it("degrades to nulls (never throws) on a query error", async () => {
+    const query = { graph: jest.fn(async () => { throw new Error("boom") }) }
+    const res = await resolveOrderPartnerId(containerFor(query), "o1")
+    expect(res).toEqual({ partnerId: null, source: null })
+  })
+})
+
+describe("resolveOrderShipFromLocation", () => {
+  it("ships from the partner's OWN store channel location (registered nickname wins)", async () => {
+    const query = makeQuery({
+      __link__: [{ partner_id: "par_work" }],
+      // Loaded twice: partner id lookup for resolveOrderPartnerId isn't hit here
+      // (work link short-circuits), then the ship-from partner fetch:
+      partners: [
+        {
+          id: "par_work",
+          admins: [{ email: "ops@partner.test" }],
+          stores: [{ default_sales_channel_id: "sc_partner" }],
+        },
+      ],
+      sales_channels: [
+        {
+          stock_locations: [
+            { id: "loc_plain", metadata: {}, address: { phone: "", postal_code: "" } },
+            {
+              id: "loc_reg",
+              metadata: { shiprocket_pickup_location: "warehouse-x" },
+              address: { phone: "9999", postal_code: "560001" },
+            },
+          ],
+        },
+      ],
+    })
+    const res = await resolveOrderShipFromLocation(containerFor(query), "o1")
+    expect(res.partnerId).toBe("par_work")
+    expect(res.source).toBe("work")
+    expect(res.locationId).toBe("loc_reg")
+    expect(res.actingEmail).toBe("ops@partner.test")
+  })
+
+  it("returns nulls when the order has no resolvable partner", async () => {
+    const query = makeQuery({
+      __link__: [],
+      orders: [{ id: "o1", sales_channel_id: "sc_unknown" }],
+      stores: [],
+      partners: [],
+    })
+    const res = await resolveOrderShipFromLocation(containerFor(query), "o1")
+    expect(res).toEqual({ partnerId: null, source: null, locationId: null, actingEmail: null })
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/order-partner-origin.ts
+++ b/apps/backend/src/modules/shipping-providers/order-partner-origin.ts
@@ -1,0 +1,176 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+import partnerOrderLink from "../../links/partner-order"
+import { pickPartnerShipFromLocation } from "../../api/partners/lib/ship-from-location"
+import { SHIPROCKET_PICKUP_METADATA_KEY } from "./pickup-locations"
+
+/**
+ * Resolve the partner that OWNS a core/retail order — and their ship-from stock
+ * location — FROM THE ORDER ALONE (#1111 S4). This is the retail/admin
+ * counterpart to `resolvePartnerShipFromLocation` (api/partners/helpers), which
+ * needs the authenticated partner: retail orders arrive through the storefront
+ * with no partner in the auth context, so origin must be derived from the order.
+ *
+ * Ownership mirrors `validatePartnerOrderOwnership` exactly — the two scoping
+ * rules the partner order list uses:
+ *   - work (design / inventory): the D3 `partner ↔ order` link.
+ *   - retail: `order.sales_channel_id` === a partner store's
+ *     `default_sales_channel_id`.
+ *
+ * The ship-from location is always taken from the PARTNER'S store default sales
+ * channel (not the order's channel): retail's order channel IS that channel, but
+ * a work order lives in the shared work-orders channel, so using the order
+ * channel there would find no partner location. Same location the partner-auth
+ * label flow ships from.
+ *
+ * Everything here is BEST-EFFORT — every path degrades to nulls (never throws)
+ * so label generation falls back to the existing admin behaviour rather than
+ * blocking on a partner that can't be resolved.
+ */
+
+export type OrderPartnerId = {
+  partnerId: string | null
+  /** How the partner was resolved — for logging / callers that branch on it. */
+  source: "work" | "retail" | null
+}
+
+export type OrderShipFromOrigin = OrderPartnerId & {
+  /** The owning partner's ship-from stock location for this order, if any. */
+  locationId: string | null
+  /** Acting/notification email for a freshly-registered pickup (#427). */
+  actingEmail: string | null
+}
+
+/** Read a single order's `sales_channel_id` (null on any error). */
+async function orderSalesChannelId(
+  query: any,
+  orderId: string
+): Promise<string | null> {
+  const { data: orders } = await query.graph({
+    entity: "orders",
+    fields: ["id", "sales_channel_id"],
+    filters: { id: orderId },
+  })
+  return (orders?.[0]?.sales_channel_id as string) ?? null
+}
+
+/**
+ * Resolve the owning partner id for an order (work link first, then retail
+ * sales-channel scoping). Best-effort → `{ partnerId: null, source: null }`.
+ */
+export async function resolveOrderPartnerId(
+  container: MedusaContainer,
+  orderId: string
+): Promise<OrderPartnerId> {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  try {
+    // 1. Work ownership — the D3 partner↔order link (same source of truth as
+    //    validatePartnerOrderOwnership / resolveSellerTaxIdForOrder).
+    const { data: links } = await query.graph({
+      entity: partnerOrderLink.entryPoint,
+      fields: ["partner_id"],
+      filters: { order_id: orderId },
+    })
+    const workPartnerId = (links?.[0]?.partner_id as string) ?? null
+    if (workPartnerId) return { partnerId: workPartnerId, source: "work" }
+
+    // 2. Retail ownership — the order's channel is a partner store's default
+    //    channel. `default_sales_channel_id` is a plain column (sales_channel ↔
+    //    store is not a Medusa link), and filters don't auto-join the
+    //    partner_stores dot-path, so match the owner in JS — mirrors
+    //    resolvePartnerStorefrontForSalesChannel (google_merchant).
+    const salesChannelId = await orderSalesChannelId(query, orderId)
+    if (!salesChannelId) return { partnerId: null, source: null }
+
+    const { data: stores } = await query.graph({
+      entity: "stores",
+      fields: ["id", "default_sales_channel_id"],
+      filters: { default_sales_channel_id: [salesChannelId] },
+    })
+    const storeIds = new Set(
+      (stores ?? []).map((s: any) => s?.id).filter(Boolean)
+    )
+    if (!storeIds.size) return { partnerId: null, source: null }
+
+    const { data: partners } = await query.graph({
+      entity: "partners",
+      fields: ["id", "stores.id"],
+    })
+    const owner = (partners ?? []).find((p: any) =>
+      (p?.stores ?? []).some((st: any) => storeIds.has(st?.id))
+    )
+    return owner?.id
+      ? { partnerId: owner.id, source: "retail" }
+      : { partnerId: null, source: null }
+  } catch {
+    return { partnerId: null, source: null }
+  }
+}
+
+/** Pick the ship-from location among a sales channel's stock locations. */
+async function locationForSalesChannel(
+  query: any,
+  salesChannelId: string | null
+): Promise<string | null> {
+  if (!salesChannelId) return null
+  const { data: channels } = await query.graph({
+    entity: "sales_channels",
+    fields: [
+      "stock_locations.id",
+      "stock_locations.metadata",
+      "stock_locations.address.phone",
+      "stock_locations.address.postal_code",
+    ],
+    filters: { id: salesChannelId },
+  })
+  const candidates = ((channels?.[0]?.stock_locations || []) as any[]).map(
+    (loc) => ({
+      id: loc?.id,
+      pickup_nickname:
+        (loc?.metadata as any)?.[SHIPROCKET_PICKUP_METADATA_KEY] ?? null,
+      phone: loc?.address?.phone ?? null,
+      postal_code: loc?.address?.postal_code ?? null,
+    })
+  )
+  return pickPartnerShipFromLocation(candidates)?.id ?? null
+}
+
+/**
+ * Resolve the owning partner AND their ship-from stock location for an order.
+ * The location comes from the partner's own store default sales channel (works
+ * for both retail and work orders). Best-effort → nulls on any miss.
+ */
+export async function resolveOrderShipFromLocation(
+  container: MedusaContainer,
+  orderId: string
+): Promise<OrderShipFromOrigin> {
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  try {
+    const { partnerId, source } = await resolveOrderPartnerId(container, orderId)
+    if (!partnerId) {
+      return { partnerId: null, source: null, locationId: null, actingEmail: null }
+    }
+
+    const { data: partners } = await query.graph({
+      entity: "partners",
+      fields: [
+        "id",
+        "admins.email",
+        "stores.default_sales_channel_id",
+      ],
+      filters: { id: partnerId },
+    })
+    const partner = partners?.[0]
+    const partnerChannelId =
+      (partner?.stores?.[0]?.default_sales_channel_id as string) ?? null
+    const locationId = await locationForSalesChannel(query, partnerChannelId)
+    return {
+      partnerId,
+      source,
+      locationId,
+      actingEmail: (partner?.admins?.[0]?.email as string) ?? null,
+    }
+  } catch {
+    return { partnerId: null, source: null, locationId: null, actingEmail: null }
+  }
+}

--- a/apps/backend/src/modules/shipping-providers/provider-interface.ts
+++ b/apps/backend/src/modules/shipping-providers/provider-interface.ts
@@ -56,6 +56,26 @@ export type Dimensions = {
   height: number
 }
 
+/**
+ * Customs declaration for an INTERNATIONAL shipment (#1111). Only consulted when
+ * the destination is outside the origin country. All fields optional — the
+ * carrier client applies sensible retail-sale defaults (a commercial export,
+ * FOB terms) when omitted. Values mirror Shiprocket's international
+ * `create/adhoc` contract (see apps/docs/notes/SHIPROCKET_INTERNATIONAL_API.md).
+ */
+export type CustomsDeclaration = {
+  /** 0 BONAFIDE_SAMPLE · 1 SAMPLE · 2 GIFT · 3 COMMERCIAL. Default 3 (a sale). */
+  reason_of_export?: 0 | 1 | 2 | 3
+  /** 0 gift · 1 sample · 2 commercial. Default 2. */
+  purpose_of_shipment?: 0 | 1 | 2
+  /** Incoterms on the commercial invoice. Default "FOB". */
+  terms_of_invoice?: "FOB" | "CIF"
+  /** IGST: A not-applicable · B LUT/Export-under-Bond · C against IGST payment. Default "A". */
+  igst_payment_status?: "A" | "B" | "C"
+  /** Whether the order is a commodity. Default true. */
+  commodity?: boolean
+}
+
 export type CreateShipmentInput = {
   /** Our order / fulfillment id — the external reference the carrier echoes back. */
   reference_id: string
@@ -74,6 +94,18 @@ export type CreateShipmentInput = {
   dimensions_cm?: Dimensions
   /** Order sub-total (major units). Shiprocket requires it; also the COD amount. */
   sub_total?: number
+  /**
+   * ISO-4217 currency of the order amounts (#1111). Required by Shiprocket's
+   * international create flow — the declared value / line prices are read in THIS
+   * currency (not forced to INR). Ignored on domestic shipments. Shiprocket
+   * supports INR, USD, GBP, EUR, AUD, CAD, SAR, AED, SGD.
+   */
+  currency?: string
+  /**
+   * Customs declaration for international destinations (#1111). Optional — the
+   * carrier client fills retail-sale defaults. Ignored on domestic shipments.
+   */
+  customs?: CustomsDeclaration
   /** Aggregator courier choice (Shiprocket `courier_company_id`). Ignored by
    *  single-carrier providers. When omitted, the provider auto-selects. */
   preferred_courier_id?: string | number

--- a/apps/backend/src/modules/shipping-providers/seller-tax-id.ts
+++ b/apps/backend/src/modules/shipping-providers/seller-tax-id.ts
@@ -1,6 +1,6 @@
 import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import type { MedusaContainer } from "@medusajs/framework/types"
-import partnerOrderLink from "../../links/partner-order"
+import { resolveOrderPartnerId } from "./order-partner-origin"
 import { PLATFORM_TAX_IDENTITY_MODULE } from "../platform-tax-identity"
 import {
   resolvePlatformTaxIdString,
@@ -63,8 +63,16 @@ async function loadActiveIdentities(
   }
 }
 
-/** The order's partner's own tax ID, or null (best-effort, never throws). */
+/**
+ * The order's partner's own tax ID, or null (best-effort, never throws).
+ *
+ * Resolves the owning partner via BOTH scoping rules (#1111 S4): the D3
+ * partner↔order work link AND retail sales-channel scoping — so a retail order's
+ * partner GSTIN is stamped on its label instead of always falling through to the
+ * platform GSTIN.
+ */
 async function resolvePartnerOwnTaxId(
+  container: MedusaContainer,
   query: any,
   orderId: string | null | undefined
 ): Promise<string | null> {
@@ -72,12 +80,7 @@ async function resolvePartnerOwnTaxId(
     return null
   }
   try {
-    const { data: links } = await query.graph({
-      entity: partnerOrderLink.entryPoint,
-      fields: ["partner_id"],
-      filters: { order_id: orderId },
-    })
-    const partnerId = links?.[0]?.partner_id
+    const { partnerId } = await resolveOrderPartnerId(container, orderId)
     if (!partnerId) {
       return null
     }
@@ -88,8 +91,8 @@ async function resolvePartnerOwnTaxId(
     })
     return clean(partners?.[0]?.tax_id)
   } catch {
-    // Best-effort: degrade to the platform fallback (no link, un-migrated column,
-    // query error). Never block the label.
+    // Best-effort: degrade to the platform fallback (no partner, un-migrated
+    // column, query error). Never block the label.
     return null
   }
 }
@@ -105,7 +108,7 @@ export async function resolveSellerTaxIdForOrder(
 ): Promise<string | undefined> {
   const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
 
-  const own = await resolvePartnerOwnTaxId(query, orderId)
+  const own = await resolvePartnerOwnTaxId(container, query, orderId)
   if (own) {
     return own
   }

--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/create-international-shipment.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/create-international-shipment.unit.spec.ts
@@ -177,6 +177,60 @@ describe("ShiprocketClient.createShipment — international routing", () => {
     expect(hits.some((h) => h === "/orders/create/adhoc")).toBe(false)
   })
 
+  it("resolves the recommended courier via order_id serviceability (post-create) and passes it to assign", async () => {
+    // Live-verified (#1111): intl serviceability only answers in the `order_id`
+    // mode, so the lookup must run AFTER create with the returned SR order id,
+    // and the recommended courier must be forwarded to assign/awb.
+    const hits: { url: string; body?: any }[] = []
+    const real = global.fetch?.bind(globalThis)
+    fetchSpy = jest
+      .spyOn(global, "fetch" as any)
+      .mockImplementation(async (input: any, init: any = {}) => {
+        const url = String(input)
+        if (!url.includes("shiprocket.in")) return real?.(input, init)
+        const path = url.replace("https://apiv2.shiprocket.in/v1/external", "")
+        hits.push({ url: path, body: init.body ? JSON.parse(init.body) : undefined })
+        if (path.includes("/international/orders/create/adhoc"))
+          return make({ shipment_id: 700, order_id: 800 })
+        if (path.includes("/international/courier/serviceability"))
+          return make({
+            data: {
+              recommended_courier_company_id: 140,
+              available_courier_companies: [
+                { courier_company_id: 326, courier_name: "India Post", rate: 900, currency: "USD" },
+                { courier_company_id: 140, courier_name: "SRX Premium Pro", rate: 1500, currency: "USD" },
+              ],
+            },
+          })
+        if (path.includes("/international/courier/assign/awb"))
+          return make({ response: { data: { awb_code: "INTLAWB2", courier_company_id: 140 } } })
+        if (path.endsWith("/courier/generate/label")) return make({ label_url: "x.pdf" })
+        return make({}, 404)
+      })
+
+    const client = new ShiprocketClient({
+      email: "x@y.com",
+      password: "p",
+      token: "injected-token",
+      pickup_location: "warehouse-abc",
+    })
+
+    const result = await client.createShipment(usInput())
+    expect(result.awb).toBe("INTLAWB2")
+
+    // serviceability was queried by the created SR order_id (not country/weight).
+    const svc = hits.find((h) => h.url.includes("/international/courier/serviceability"))
+    expect(svc?.url).toContain("order_id=800")
+    expect(svc?.url).not.toContain("delivery_country")
+    // ...and its recommended courier (140) rode along on the assign body.
+    const assign = hits.find((h) => h.url.includes("/international/courier/assign/awb"))
+    expect(assign?.body?.courier_id).toBe(140)
+    // Serviceability ran AFTER create (order_id only exists post-create).
+    const createIdx = hits.findIndex((h) => h.url.includes("/international/orders/create/adhoc"))
+    const svcIdx = hits.findIndex((h) => h.url.includes("/international/courier/serviceability"))
+    expect(svcIdx).toBeGreaterThan(createIdx)
+  })
+
   it("keeps a domestic (India) destination on the domestic endpoints", async () => {
     const hits: string[] = []
     const real = global.fetch?.bind(globalThis)

--- a/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/create-international-shipment.unit.spec.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/__tests__/create-international-shipment.unit.spec.ts
@@ -1,0 +1,211 @@
+import {
+  ShiprocketClient,
+  buildInternationalCreateBody,
+  toShiprocketCountryName,
+  isInternationalDestination,
+  resolveCustomsDefaults,
+} from "../client"
+import type { CreateShipmentInput } from "../../provider-interface"
+
+/**
+ * #1111 S1 — International Shiprocket shipping. The client detects a non-India
+ * destination and routes to Shiprocket's separate `/international/*` namespace
+ * with a customs-declaration body. See apps/docs/notes/SHIPROCKET_INTERNATIONAL_API.md.
+ */
+
+const usInput = (over: Partial<CreateShipmentInput> = {}): CreateShipmentInput => ({
+  reference_id: "order_us_1",
+  payment_mode: "prepaid",
+  pickup_location_name: "warehouse-abc",
+  to: {
+    name: "Elena Doe",
+    phone: "+19762343722",
+    address_1: "12 Main St",
+    city: "Dallas",
+    state: "Texas",
+    pincode: "75201",
+    country: "US",
+  },
+  items: [{ name: "Silk Scarf", sku: "SCARF-1", quantity: 2, unit_price: 40, hsn: "6214" }],
+  weight_grams: 600,
+  sub_total: 80,
+  currency: "USD",
+  ...over,
+})
+
+describe("isInternationalDestination", () => {
+  it("is false for India / IN / empty, true for foreign", () => {
+    expect(isInternationalDestination("IN")).toBe(false)
+    expect(isInternationalDestination("India")).toBe(false)
+    expect(isInternationalDestination("")).toBe(false)
+    expect(isInternationalDestination(undefined)).toBe(false)
+    expect(isInternationalDestination("US")).toBe(true)
+    expect(isInternationalDestination("United States")).toBe(true)
+  })
+})
+
+describe("toShiprocketCountryName", () => {
+  it("maps ISO-2 to the full name Shiprocket's create body expects", () => {
+    expect(toShiprocketCountryName("US")).toBe("United States")
+    expect(toShiprocketCountryName("GB")).toBe("United Kingdom")
+    expect(toShiprocketCountryName("AE")).toBe("United Arab Emirates")
+    expect(toShiprocketCountryName("IN")).toBe("India")
+  })
+  it("passes a full name through and defaults empty to India", () => {
+    expect(toShiprocketCountryName("Australia")).toBe("Australia")
+    expect(toShiprocketCountryName("")).toBe("India")
+  })
+})
+
+describe("resolveCustomsDefaults", () => {
+  it("defaults to a commercial FOB export", () => {
+    expect(resolveCustomsDefaults()).toEqual({
+      reasonOfExport: 3,
+      purpose_of_shipment: 2,
+      Terms_Of_Invoice: "FOB",
+      igstPaymentStatus: "A",
+      commodity: true,
+    })
+  })
+  it("honours caller overrides", () => {
+    expect(
+      resolveCustomsDefaults({ reason_of_export: 2, terms_of_invoice: "CIF" })
+    ).toMatchObject({ reasonOfExport: 2, Terms_Of_Invoice: "CIF" })
+  })
+})
+
+describe("buildInternationalCreateBody", () => {
+  it("builds a customs-bearing body with country NAME + currency", () => {
+    const body = buildInternationalCreateBody(usInput(), "warehouse-abc")
+    expect(body).toMatchObject({
+      pickup_location: "warehouse-abc",
+      billing_country: "United States",
+      isd_code: "+1",
+      payment_method: "Prepaid",
+      currency: "USD",
+      reasonOfExport: 3,
+      purpose_of_shipment: 2,
+      Terms_Of_Invoice: "FOB",
+      igstPaymentStatus: "A",
+      commodity: true,
+      sub_total: 80,
+    })
+    expect(body.order_items[0]).toMatchObject({ sku: "SCARF-1", hsn: "6214", units: 2 })
+  })
+
+  it("throws when any line is missing an HSN code (mandatory internationally)", () => {
+    const input = usInput({
+      items: [{ name: "Mystery Item", sku: "M-1", quantity: 1, unit_price: 10 }],
+    })
+    expect(() => buildInternationalCreateBody(input, "wh")).toThrow(/HSN code is required/i)
+  })
+
+  it("throws when the caller asks for COD (unavailable internationally)", () => {
+    expect(() =>
+      buildInternationalCreateBody(usInput({ payment_mode: "cod" }), "wh")
+    ).toThrow(/COD/i)
+  })
+
+  it("defaults currency to INR when none supplied", () => {
+    const body = buildInternationalCreateBody(usInput({ currency: undefined }), "wh")
+    expect(body.currency).toBe("INR")
+  })
+})
+
+describe("ShiprocketClient.createShipment — international routing", () => {
+  let fetchSpy: jest.SpyInstance
+  afterEach(() => fetchSpy?.mockRestore())
+
+  const make = (body: any, status = 200) =>
+    ({
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    }) as any
+
+  it("routes a non-India destination through /international/* and returns an AWB", async () => {
+    const hits: string[] = []
+    const real = global.fetch?.bind(globalThis)
+    fetchSpy = jest
+      .spyOn(global, "fetch" as any)
+      .mockImplementation(async (input: any, init: any = {}) => {
+        const url = String(input)
+        if (!url.includes("shiprocket.in")) return real?.(input, init)
+        hits.push(url.replace("https://apiv2.shiprocket.in/v1/external", ""))
+        if (url.includes("/international/orders/create/adhoc"))
+          return make({ shipment_id: 700, order_id: 800 })
+        if (url.includes("/international/courier/serviceability"))
+          return make({
+            data: {
+              recommended_courier_company_id: 91,
+              available_courier_companies: [
+                { courier_company_id: 91, courier_name: "DHL Express", rate: 1200, currency: "INR" },
+              ],
+            },
+          })
+        if (url.includes("/international/courier/assign/awb"))
+          return make({
+            response: { data: { awb_code: "INTLAWB1", courier_company_id: 91, courier_name: "DHL Express" } },
+          })
+        if (url.endsWith("/courier/generate/label"))
+          return make({ label_url: "https://shiprocket/intl-label.pdf" })
+        return make({}, 404)
+      })
+
+    const client = new ShiprocketClient({
+      email: "x@y.com",
+      password: "p",
+      token: "injected-token",
+      pickup_location: "warehouse-abc",
+    })
+
+    const result = await client.createShipment(usInput())
+
+    expect(result.awb).toBe("INTLAWB1")
+    expect(result.label_url).toBe("https://shiprocket/intl-label.pdf")
+    expect(result.provider_refs).toMatchObject({
+      shipment_id: 700,
+      sr_order_id: 800,
+      international: true,
+    })
+    // It hit the international create + serviceability + assign endpoints.
+    expect(hits.some((h) => h.includes("/international/orders/create/adhoc"))).toBe(true)
+    expect(hits.some((h) => h.includes("/international/courier/serviceability"))).toBe(true)
+    expect(hits.some((h) => h.includes("/international/courier/assign/awb"))).toBe(true)
+    // ...and NOT the domestic create.
+    expect(hits.some((h) => h === "/orders/create/adhoc")).toBe(false)
+  })
+
+  it("keeps a domestic (India) destination on the domestic endpoints", async () => {
+    const hits: string[] = []
+    const real = global.fetch?.bind(globalThis)
+    fetchSpy = jest
+      .spyOn(global, "fetch" as any)
+      .mockImplementation(async (input: any, init: any = {}) => {
+        const url = String(input)
+        if (!url.includes("shiprocket.in")) return real?.(input, init)
+        hits.push(url.replace("https://apiv2.shiprocket.in/v1/external", ""))
+        if (url.endsWith("/orders/create/adhoc")) return make({ shipment_id: 1, order_id: 2 })
+        if (url.endsWith("/courier/assign/awb"))
+          return make({ response: { data: { awb_code: "DOM1", courier_company_id: 5 } } })
+        if (url.endsWith("/courier/generate/label")) return make({ label_url: "d.pdf" })
+        return make({}, 404)
+      })
+
+    const client = new ShiprocketClient({
+      email: "x@y.com",
+      password: "p",
+      token: "injected-token",
+      pickup_location: "warehouse-abc",
+    })
+
+    const result = await client.createShipment(
+      usInput({ to: { ...usInput().to, country: "IN", city: "Jaipur", state: "RJ", pincode: "302001" } })
+    )
+
+    expect(result.awb).toBe("DOM1")
+    expect(hits.some((h) => h.includes("/international/"))).toBe(false)
+    expect(hits).toContain("/orders/create/adhoc")
+  })
+})

--- a/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
@@ -652,17 +652,24 @@ export class ShiprocketClient implements ShippingProviderClient {
    * normalized RateOption shape.
    */
   async getInternationalRates(query: {
-    destination_country: string
-    weight_grams: number
+    destination_country?: string
+    weight_grams?: number
     order_id?: string | number
     origin_pincode?: string
   }): Promise<RateOption[]> {
-    const qs = new URLSearchParams({
-      weight: String(Math.max(0.01, query.weight_grams / 1000)),
-      cod: "0",
-      delivery_country: (query.destination_country || "").toUpperCase(),
-    })
-    if (query.order_id != null) qs.set("order_id", String(query.order_id))
+    // Live-verified (#1111): the `order_id` mode is the ONLY one this account
+    // answers — passing an existing Shiprocket order id returns the available
+    // international couriers (+ the recommended one) priced in the order
+    // currency. The documented country+weight mode (below) 400s on the live
+    // account, so `order_id` takes precedence and we omit weight/country when
+    // it's present (they're ignored anyway per the docs).
+    const qs = new URLSearchParams({ cod: "0" })
+    if (query.order_id != null) {
+      qs.set("order_id", String(query.order_id))
+    } else {
+      qs.set("weight", String(Math.max(0.01, (query.weight_grams || 500) / 1000)))
+      qs.set("delivery_country", (query.destination_country || "").toUpperCase())
+    }
     if (query.origin_pincode) qs.set("pickup_postcode", query.origin_pincode)
     const json = await this.request<any>(
       `/international/courier/serviceability?${qs}`,
@@ -709,23 +716,28 @@ export class ShiprocketClient implements ShippingProviderClient {
     }
 
     // Pick a courier: caller's explicit choice wins; otherwise ask international
-    // serviceability for the recommended one. Best-effort — if serviceability
-    // fails we still assign and let Shiprocket default.
-    let courierId = input.preferred_courier_id
-    if (!courierId) {
+    // serviceability for the recommended one. Live-verified (#1111): intl
+    // serviceability only answers in the `order_id` mode, so the lookup must
+    // happen AFTER the order is created (the domestic flow auto-selects on
+    // assign, but international assign needs an explicit courier). Best-effort —
+    // if serviceability fails we still assign and let Shiprocket default.
+    const resolveCourierId = async (
+      srOrderIdForRates: any
+    ): Promise<string | number | undefined> => {
+      if (input.preferred_courier_id) return input.preferred_courier_id
       try {
         const rates = await this.getInternationalRates({
-          destination_country: input.to.country || "",
-          weight_grams: input.weight_grams,
+          order_id: srOrderIdForRates,
         })
-        courierId =
+        return (
           rates.find((r) => r.is_recommended)?.courier_id || rates[0]?.courier_id
+        )
       } catch {
-        // serviceability best-effort; assign below can still auto-select.
+        return undefined
       }
     }
 
-    const assignAwb = async (shipmentIdToAssign: any) => {
+    const assignAwb = async (shipmentIdToAssign: any, courierId?: string | number) => {
       const assignBody: Record<string, any> = { shipment_id: [shipmentIdToAssign] }
       if (courierId) assignBody.courier_id = courierId
       return this.request<any>(`/international/courier/assign/awb`, {
@@ -737,7 +749,10 @@ export class ShiprocketClient implements ShippingProviderClient {
     let created = await createAdhoc(String(createBody.order_id))
     let assigned: any
     try {
-      assigned = await assignAwb(created.shipment_id)
+      assigned = await assignAwb(
+        created.shipment_id,
+        await resolveCourierId(created.order_id)
+      )
     } catch (e: any) {
       const cancelled =
         e instanceof ShiprocketApiError && /cancell?ed state/i.test(e.message)
@@ -745,7 +760,10 @@ export class ShiprocketClient implements ShippingProviderClient {
       created = await createAdhoc(
         `${input.reference_id}-R${Date.now().toString(36)}`
       )
-      assigned = await assignAwb(created.shipment_id)
+      assigned = await assignAwb(
+        created.shipment_id,
+        await resolveCourierId(created.order_id)
+      )
     }
 
     const srOrderId = created?.order_id

--- a/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/client.ts
@@ -214,6 +214,144 @@ export function buildShiprocketOrderItems(
   return Array.from(bySku.values())
 }
 
+/**
+ * International shipping (#1111). Shiprocket exposes a SEPARATE
+ * `/v1/external/international/*` namespace (create/serviceability/assign/track);
+ * a shipment is international when its destination is outside India. See
+ * apps/docs/notes/SHIPROCKET_INTERNATIONAL_API.md for the full contract.
+ */
+
+/** Destination ISD dial codes for the countries we ship to (best-effort; omitted when unknown). */
+const ISD_BY_ISO2: Record<string, string> = {
+  US: "+1", CA: "+1", GB: "+44", AU: "+61", NZ: "+64", AE: "+971", SA: "+966",
+  SG: "+65", MY: "+60", DE: "+49", FR: "+33", IT: "+39", ES: "+34", NL: "+31",
+  IE: "+353", SE: "+46", CH: "+41", JP: "+81", HK: "+852", ZA: "+27",
+}
+
+/**
+ * Full country NAME for Shiprocket's create body. The international create/adhoc
+ * expects a name ("United States"), NOT the ISO code (the serviceability call is
+ * the one that wants ISO-2). Our order addresses store ISO-2 `country_code`, so
+ * map it via `Intl.DisplayNames` with a couple of overrides where Shiprocket's
+ * expected spelling differs. Pure & exported for unit testing.
+ */
+const COUNTRY_NAME_OVERRIDES: Record<string, string> = {
+  US: "United States",
+  GB: "United Kingdom",
+  AE: "United Arab Emirates",
+  KR: "South Korea",
+}
+export function toShiprocketCountryName(country?: string): string {
+  const raw = (country || "").trim()
+  if (!raw) return "India"
+  if (/^(in|india)$/i.test(raw)) return "India"
+  // Already a full name (not a 2-letter code) — pass through.
+  if (raw.length > 2) return raw
+  const code = raw.toUpperCase()
+  if (COUNTRY_NAME_OVERRIDES[code]) return COUNTRY_NAME_OVERRIDES[code]
+  try {
+    return new Intl.DisplayNames(["en"], { type: "region" }).of(code) || raw
+  } catch {
+    return raw
+  }
+}
+
+/** True when a shipment's destination country is outside India. */
+export function isInternationalDestination(country?: string): boolean {
+  const raw = (country || "").trim()
+  if (!raw) return false
+  return !/^(in|india)$/i.test(raw)
+}
+
+/** Shiprocket international customs fields, with retail-sale defaults applied. */
+export type ResolvedCustoms = {
+  reasonOfExport: number
+  purpose_of_shipment: number
+  Terms_Of_Invoice: string
+  igstPaymentStatus: string
+  commodity: boolean
+}
+export function resolveCustomsDefaults(
+  customs?: import("../provider-interface").CustomsDeclaration
+): ResolvedCustoms {
+  return {
+    // A retail order is a commercial sale, shipped FOB, IGST not-applicable
+    // (LUT/bond is an account-level export scheme, not per-shipment here).
+    reasonOfExport: customs?.reason_of_export ?? 3, // COMMERCIAL
+    purpose_of_shipment: customs?.purpose_of_shipment ?? 2, // commercial
+    Terms_Of_Invoice: customs?.terms_of_invoice ?? "FOB",
+    igstPaymentStatus: customs?.igst_payment_status ?? "A",
+    commodity: customs?.commodity ?? true,
+  }
+}
+
+/**
+ * Build the Shiprocket INTERNATIONAL `create/adhoc` body from a shipment input.
+ * Pure & exported so the exact customs payload (country name, currency, HSN,
+ * export reason) is unit-testable without a live API. Throws if HSN is missing
+ * on any line (Shiprocket makes HSN mandatory for every international shipment)
+ * or if the caller asked for COD (unavailable internationally).
+ */
+export function buildInternationalCreateBody(
+  input: CreateShipmentInput,
+  pickup: string
+): Record<string, any> {
+  if (input.payment_mode === "cod") {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "Shiprocket does not support COD for international shipments"
+    )
+  }
+  const items = buildShiprocketOrderItems(input.items)
+  const missingHsn = items.filter((i) => !i.hsn).map((i) => i.name)
+  if (missingHsn.length) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `HSN code is required for international shipments; missing on: ${missingHsn.join(", ")}`
+    )
+  }
+  const [firstName, ...rest] = (input.to.name || "Customer").split(" ")
+  const lastName = rest.join(" ")
+  const subTotal =
+    input.sub_total ??
+    input.items.reduce((s, i) => s + i.unit_price * i.quantity, 0)
+  const iso2 = (input.to.country || "").trim().toUpperCase()
+  const customs = resolveCustomsDefaults(input.customs)
+
+  return {
+    order_id: input.reference_id,
+    order_date: new Date().toISOString().slice(0, 16).replace("T", " "),
+    pickup_location: pickup,
+    // The customer is abroad — billing + shipping are the same foreign address.
+    billing_customer_name: firstName,
+    billing_last_name: lastName,
+    billing_address: input.to.address_1,
+    billing_address_2: input.to.address_2 || "",
+    billing_city: input.to.city,
+    billing_pincode: input.to.pincode,
+    billing_state: input.to.state,
+    billing_country: toShiprocketCountryName(input.to.country),
+    billing_email: input.to.email || "",
+    billing_phone: input.to.phone,
+    ...(ISD_BY_ISO2[iso2] ? { isd_code: ISD_BY_ISO2[iso2] } : {}),
+    shipping_is_billing: true,
+    order_items: items,
+    payment_method: "Prepaid",
+    sub_total: subTotal,
+    length: input.dimensions_cm?.length || 10,
+    breadth: input.dimensions_cm?.width || 10,
+    height: input.dimensions_cm?.height || 10,
+    weight: Math.max(0.01, input.weight_grams / 1000),
+    // Customs / commercial-invoice fields (amounts are in `currency`, not INR).
+    currency: (input.currency || "INR").toUpperCase(),
+    reasonOfExport: customs.reasonOfExport,
+    purpose_of_shipment: customs.purpose_of_shipment,
+    Terms_Of_Invoice: customs.Terms_Of_Invoice,
+    igstPaymentStatus: customs.igstPaymentStatus,
+    commodity: customs.commodity,
+  }
+}
+
 /** Shiprocket numeric shipment_status_id → coarse scan_type. */
 export function scanTypeForStatus(id?: number): string {
   switch (id) {
@@ -387,6 +525,13 @@ export class ShiprocketClient implements ShippingProviderClient {
       )
     }
 
+    // International destinations use a separate Shiprocket API namespace with a
+    // customs-declaration payload (#1111). Domestic (India) stays on the path
+    // below unchanged.
+    if (isInternationalDestination(input.to.country)) {
+      return this.createInternationalShipment(input, pickup)
+    }
+
     const [firstName, ...rest] = (input.to.name || "Customer").split(" ")
     const lastName = rest.join(" ")
     const subTotal =
@@ -495,6 +640,143 @@ export class ShiprocketClient implements ShippingProviderClient {
         shipment_id: shipmentId,
         courier_company_id: awbData.courier_company_id,
         courier_name: awbData.courier_name,
+      },
+      raw: { created, assigned },
+    }
+  }
+
+  /**
+   * International courier serviceability (#1111). Distinct endpoint from the
+   * domestic `getRates` — takes a destination COUNTRY (ISO Alpha-2), not a
+   * pincode, and `cod` must be 0 (no international COD). Returns the same
+   * normalized RateOption shape.
+   */
+  async getInternationalRates(query: {
+    destination_country: string
+    weight_grams: number
+    order_id?: string | number
+    origin_pincode?: string
+  }): Promise<RateOption[]> {
+    const qs = new URLSearchParams({
+      weight: String(Math.max(0.01, query.weight_grams / 1000)),
+      cod: "0",
+      delivery_country: (query.destination_country || "").toUpperCase(),
+    })
+    if (query.order_id != null) qs.set("order_id", String(query.order_id))
+    if (query.origin_pincode) qs.set("pickup_postcode", query.origin_pincode)
+    const json = await this.request<any>(
+      `/international/courier/serviceability?${qs}`,
+      { method: "GET" }
+    )
+    const couriers = json?.data?.available_courier_companies || []
+    const recommended = json?.data?.recommended_courier_company_id
+    return couriers.map((c: any) => ({
+      courier_id: c.courier_company_id,
+      courier_name: c.courier_name,
+      amount: Number(c.rate) || 0,
+      currency_code: (c.currency || "inr").toString().toLowerCase(),
+      estimated_days: c.estimated_delivery_days
+        ? Number(c.estimated_delivery_days)
+        : undefined,
+      is_recommended: c.courier_company_id === recommended,
+    }))
+  }
+
+  /**
+   * Create an INTERNATIONAL shipment: create order → resolve an international
+   * courier (caller's choice, else the recommended one from serviceability) →
+   * assign AWB → generate label. Mirrors the domestic sequence (incl. the
+   * cancelled-order suffixed retry) but against `/international/*` endpoints and
+   * with a customs-declaration body. (#1111)
+   */
+  private async createInternationalShipment(
+    input: CreateShipmentInput,
+    pickup: string
+  ): Promise<ShipmentResult> {
+    const createBody = buildInternationalCreateBody(input, pickup)
+
+    const createAdhoc = async (channelOrderId: string) => {
+      const res = await this.request<any>(
+        `/international/orders/create/adhoc`,
+        { method: "POST", body: JSON.stringify({ ...createBody, order_id: channelOrderId }) }
+      )
+      if (!res?.shipment_id) {
+        throw new Error(
+          `Shiprocket international order created but returned no shipment_id: ${JSON.stringify(res)}`
+        )
+      }
+      return res
+    }
+
+    // Pick a courier: caller's explicit choice wins; otherwise ask international
+    // serviceability for the recommended one. Best-effort — if serviceability
+    // fails we still assign and let Shiprocket default.
+    let courierId = input.preferred_courier_id
+    if (!courierId) {
+      try {
+        const rates = await this.getInternationalRates({
+          destination_country: input.to.country || "",
+          weight_grams: input.weight_grams,
+        })
+        courierId =
+          rates.find((r) => r.is_recommended)?.courier_id || rates[0]?.courier_id
+      } catch {
+        // serviceability best-effort; assign below can still auto-select.
+      }
+    }
+
+    const assignAwb = async (shipmentIdToAssign: any) => {
+      const assignBody: Record<string, any> = { shipment_id: [shipmentIdToAssign] }
+      if (courierId) assignBody.courier_id = courierId
+      return this.request<any>(`/international/courier/assign/awb`, {
+        method: "POST",
+        body: JSON.stringify(assignBody),
+      })
+    }
+
+    let created = await createAdhoc(String(createBody.order_id))
+    let assigned: any
+    try {
+      assigned = await assignAwb(created.shipment_id)
+    } catch (e: any) {
+      const cancelled =
+        e instanceof ShiprocketApiError && /cancell?ed state/i.test(e.message)
+      if (!cancelled) throw e
+      created = await createAdhoc(
+        `${input.reference_id}-R${Date.now().toString(36)}`
+      )
+      assigned = await assignAwb(created.shipment_id)
+    }
+
+    const srOrderId = created?.order_id
+    const shipmentId = created?.shipment_id
+    const awbData = assigned?.response?.data || {}
+    const awb = awbData.awb_code || ""
+
+    // Label (shared endpoint; best-effort — may not be ready instantly).
+    let labelUrl = ""
+    try {
+      const label = await this.request<any>(`/courier/generate/label`, {
+        method: "POST",
+        body: JSON.stringify({ shipment_id: [shipmentId] }),
+      })
+      labelUrl = label?.label_url || ""
+    } catch {
+      // Fetch later via getLabel(); don't fail the shipment.
+    }
+
+    return {
+      carrier: this.carrier,
+      awb,
+      tracking_number: awb,
+      tracking_url: awb ? `https://shiprocket.co/tracking/${awb}` : undefined,
+      label_url: labelUrl || undefined,
+      provider_refs: {
+        sr_order_id: srOrderId,
+        shipment_id: shipmentId,
+        courier_company_id: awbData.courier_company_id,
+        courier_name: awbData.courier_name,
+        international: true,
       },
       raw: { created, assigned },
     }

--- a/apps/backend/src/modules/shipping-providers/shiprocket/stub-fetch.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/stub-fetch.ts
@@ -30,6 +30,8 @@ export const shiprocketStubState: {
   lastAdhocBody?: any
   lastPickupBody?: any
   lastAddPickupBody?: any
+  /** International create/adhoc body (#1111). Also mirrored onto lastAdhocBody. */
+  lastIntlAdhocBody?: any
 } = {}
 
 const parseBody = (init: any): any => {
@@ -46,6 +48,46 @@ export function createShiprocketStubFetch(): FetchLike {
 
     if (url.endsWith("/auth/login")) {
       return json({ token: "stub-token" })
+    }
+
+    // International create/adhoc (#1111) — must precede the generic
+    // "/orders/create/adhoc" match below. Capture into lastIntlAdhocBody AND
+    // mirror onto lastAdhocBody so existing pickup assertions keep working.
+    if (url.endsWith("/international/orders/create/adhoc")) {
+      const body = parseBody(init)
+      shiprocketStubState.lastIntlAdhocBody = body
+      shiprocketStubState.lastAdhocBody = body
+      return json({ order_id: 9101, shipment_id: 8101 })
+    }
+
+    // International courier serviceability (#1111) — recommend an intl courier.
+    if (url.includes("/international/courier/serviceability")) {
+      return json({
+        data: {
+          recommended_courier_company_id: 301,
+          available_courier_companies: [
+            {
+              courier_company_id: 301,
+              courier_name: "DHL Express Intl",
+              rate: 1450,
+              currency: "INR",
+              estimated_delivery_days: "6",
+            },
+          ],
+        },
+      })
+    }
+
+    if (url.endsWith("/international/courier/assign/awb")) {
+      return json({
+        response: {
+          data: {
+            awb_code: "STUBAWB123",
+            courier_company_id: 301,
+            courier_name: "DHL Express Intl",
+          },
+        },
+      })
     }
 
     // Adhoc order create — capture the body (the whole point of the #864/#866/#869

--- a/apps/backend/src/workflows/orders/__tests__/build-create-shipment-input.unit.spec.ts
+++ b/apps/backend/src/workflows/orders/__tests__/build-create-shipment-input.unit.spec.ts
@@ -66,4 +66,70 @@ describe("buildCreateShipmentInput (#404 PR-B)", () => {
     expect(input.sub_total).toBe(200) // 2 * 100
     expect(input.weight_grams).toBe(1200)
   })
+
+  describe("international customs fields (#1111)", () => {
+    it("passes the order currency through (declared value for intl customs)", () => {
+      const input = buildCreateShipmentInput(
+        { ...baseOrder, currency_code: "usd" },
+        { pickupLocationName: "wh" }
+      )
+      expect(input.currency).toBe("USD")
+    })
+
+    it("undefined currency when the order has none", () => {
+      const input = buildCreateShipmentInput(baseOrder, { pickupLocationName: "wh" })
+      expect(input.currency).toBeUndefined()
+    })
+
+    it("sources HSN from the variant's hs_code", () => {
+      const input = buildCreateShipmentInput(
+        {
+          ...baseOrder,
+          items: [
+            {
+              title: "Silk Scarf",
+              quantity: 1,
+              unit_price: 100,
+              sku: "S-1",
+              variant: { hs_code: "6214" },
+            },
+          ],
+        },
+        { pickupLocationName: "wh" }
+      )
+      expect(input.items[0].hsn).toBe("6214")
+    })
+
+    it("falls back to line metadata HSN for ad-hoc (variant-less) lines", () => {
+      const input = buildCreateShipmentInput(
+        {
+          ...baseOrder,
+          items: [
+            { title: "Ad-hoc", quantity: 1, unit_price: 100, metadata: { hsn: "9999" } },
+          ],
+        },
+        { pickupLocationName: "wh" }
+      )
+      expect(input.items[0].hsn).toBe("9999")
+    })
+
+    it("prefers the variant hs_code over line metadata when both exist", () => {
+      const input = buildCreateShipmentInput(
+        {
+          ...baseOrder,
+          items: [
+            {
+              title: "Both",
+              quantity: 1,
+              unit_price: 100,
+              variant: { hs_code: "6214" },
+              metadata: { hsn: "0000" },
+            },
+          ],
+        },
+        { pickupLocationName: "wh" }
+      )
+      expect(input.items[0].hsn).toBe("6214")
+    })
+  })
 })

--- a/apps/backend/src/workflows/orders/shiprocket-shipment.ts
+++ b/apps/backend/src/workflows/orders/shiprocket-shipment.ts
@@ -45,8 +45,9 @@ export type OrderForShipment = {
     quantity?: number | null
     unit_price?: number | null
     sku?: string | null
-    /** HSN/HS code (customs). Sourced from the product; carried in line metadata for now (#1111). */
-    hs_code?: string | null
+    /** Product variant behind the line — carries the customs `hs_code` (#1111). */
+    variant?: { hs_code?: string | null } | null
+    /** HSN/HS-code fallback for ad-hoc (variant-less) lines. */
     metadata?: Record<string, any> | null
   }> | null
 }
@@ -78,10 +79,10 @@ export function buildCreateShipmentInput(
     sku: li.sku || undefined,
     quantity: Number(li.quantity) || 1,
     unit_price: Number(li.unit_price) || 0,
-    // HSN for international customs (#1111): prefer the product's hs_code, then
-    // line metadata. Domestic shipments ignore it; the client requires it only
-    // when the destination is international.
-    hsn: (li.hs_code || li.metadata?.hsn || undefined) as string | undefined,
+    // HSN for international customs (#1111): prefer the variant's hs_code, then
+    // line metadata (for ad-hoc, variant-less lines). Domestic shipments ignore
+    // it; the client requires it only when the destination is international.
+    hsn: (li.variant?.hs_code || li.metadata?.hsn || undefined) as string | undefined,
   }))
   const subTotal =
     order.subtotal != null
@@ -163,6 +164,7 @@ export async function createShiprocketShipmentForFulfillment(
       "items.quantity",
       "items.unit_price",
       "items.metadata",
+      "items.variant.hs_code",
       "fulfillments.id",
       "fulfillments.location_id",
       "fulfillments.data",

--- a/apps/backend/src/workflows/orders/shiprocket-shipment.ts
+++ b/apps/backend/src/workflows/orders/shiprocket-shipment.ts
@@ -17,6 +17,7 @@ import {
   registerShiprocketPickup,
 } from "../../modules/shipping-providers/pickup-locations"
 import { resolveSellerTaxIdForOrder } from "../../modules/shipping-providers/seller-tax-id"
+import { resolveOrderShipFromLocation } from "../../modules/shipping-providers/order-partner-origin"
 
 /**
  * #404 (#31) PR-B — generate a Shiprocket shipment (forward order → AWB → label)
@@ -214,6 +215,29 @@ export async function createShiprocketShipmentForFulfillment(
     pickupLocationName = (locs?.[0]?.metadata as any)?.[
       SHIPROCKET_PICKUP_METADATA_KEY
     ]
+  }
+
+  // Retail / admin partner-origin (#1111 S4). Retail orders arrive with no
+  // partner in the auth context, so the label flow can't derive the owning
+  // partner's pickup from the caller — resolve it FROM THE ORDER (retail →
+  // sales-channel; work → link) and ship from THAT partner's location,
+  // registered on the fly. Best-effort: only when no explicit ship-from was
+  // given and we still have no pickup; a miss falls through to the #638
+  // any-registered fallback below, so existing admin design-order labels are
+  // unaffected. This stops a retail label from silently shipping from another
+  // party's warehouse on the shared Shiprocket account.
+  if (!pickupLocationName && !input.pickupStockLocationId) {
+    const origin = await resolveOrderShipFromLocation(container, input.orderId)
+    if (origin.locationId) {
+      try {
+        const reg = await registerShiprocketPickup(container, origin.locationId, {
+          email: input.actingEmail || origin.actingEmail || undefined,
+        })
+        pickupLocationName = reg.name
+      } catch {
+        // Best-effort — the #638 fallback (or the guard) handles it cleanly.
+      }
+    }
   }
 
   const carrier = input.carrier || "shiprocket"

--- a/apps/backend/src/workflows/orders/shiprocket-shipment.ts
+++ b/apps/backend/src/workflows/orders/shiprocket-shipment.ts
@@ -36,6 +36,8 @@ export type OrderForShipment = {
   email?: string | null
   total?: number | null
   subtotal?: number | null
+  /** ISO-4217 currency the order was placed in — declared value for intl customs (#1111). */
+  currency_code?: string | null
   metadata?: Record<string, any> | null
   shipping_address?: Record<string, any> | null
   items?: Array<{
@@ -43,6 +45,9 @@ export type OrderForShipment = {
     quantity?: number | null
     unit_price?: number | null
     sku?: string | null
+    /** HSN/HS code (customs). Sourced from the product; carried in line metadata for now (#1111). */
+    hs_code?: string | null
+    metadata?: Record<string, any> | null
   }> | null
 }
 
@@ -73,6 +78,10 @@ export function buildCreateShipmentInput(
     sku: li.sku || undefined,
     quantity: Number(li.quantity) || 1,
     unit_price: Number(li.unit_price) || 0,
+    // HSN for international customs (#1111): prefer the product's hs_code, then
+    // line metadata. Domestic shipments ignore it; the client requires it only
+    // when the destination is international.
+    hsn: (li.hs_code || li.metadata?.hsn || undefined) as string | undefined,
   }))
   const subTotal =
     order.subtotal != null
@@ -104,6 +113,9 @@ export function buildCreateShipmentInput(
     weight_grams: opts.weightGrams || DEFAULT_WEIGHT_GRAMS,
     dimensions_cm: opts.dimensionsCm,
     sub_total: subTotal,
+    // Declared-value currency for international customs (#1111). Shiprocket reads
+    // intl amounts in this currency; domestic ignores it.
+    currency: order.currency_code ? String(order.currency_code).toUpperCase() : undefined,
     preferred_courier_id: opts.preferredCourierId,
     tax_id: opts.taxId,
   }
@@ -144,11 +156,13 @@ export async function createShiprocketShipmentForFulfillment(
       "email",
       "total",
       "subtotal",
+      "currency_code",
       "metadata",
       "shipping_address.*",
       "items.title",
       "items.quantity",
       "items.unit_price",
+      "items.metadata",
       "fulfillments.id",
       "fulfillments.location_id",
       "fulfillments.data",

--- a/apps/docs/notes/SHIPROCKET_INTERNATIONAL_API.md
+++ b/apps/docs/notes/SHIPROCKET_INTERNATIONAL_API.md
@@ -1,0 +1,73 @@
+# Shiprocket International API — spec (for #1111)
+
+Source: Shiprocket's **official public Postman collection** (`shiprocketdev/shiprocket-dev-s-public-workspace`,
+collection `qu05zax`), read verbatim 2026-07-21 via the browser. This corrects an
+earlier web-research inference that "international reuses the domestic endpoint with
+HSN" — **it does not**. There is a full separate `/v1/external/international/*`
+namespace.
+
+Base URL is unchanged: `https://apiv2.shiprocket.in/v1/external`.
+
+## Endpoints (international namespace)
+
+| Purpose | Method | Path |
+|---|---|---|
+| Create order | POST | `/international/orders/create/adhoc` |
+| Courier serviceability | GET | `/international/courier/serviceability` |
+| AWB assignment | POST | `/international/courier/assign/awb` |
+| Tracking | GET | `/international/orders/track` |
+| Manifest generation | POST | `/international/manifests/generate` |
+| All-in-one wrapper (create+ship+pickup+label+manifest) | POST | `/international/shipments/create/forward-shipment` |
+| International KYC (prerequisite) | POST | `/international/settings/international_kyc` |
+| Add bank details (prerequisite) | POST | `/international/settings/add-bank-details` |
+
+Domestic label endpoint `/courier/generate/label` is shared (no international-specific
+label path in the collection). AWB assign shape mirrors domestic
+(`shipment_id` yes, `courier_id` no, `status: "reassign"` no).
+
+## Create order body — international-specific fields (beyond the domestic shape)
+
+Verbatim example body used `shipping_country: "United States"` (**full country NAME**,
+not ISO) and these extra top-level fields:
+
+| Field | Req | Type | Values / notes | Retail default |
+|---|---|---|---|---|
+| `currency` | **YES** | string | `INR,USD,GBP,EUR,AUD,CAD,SAR,AED,SGD`. **Amounts (`selling_price`, `sub_total`) are in THIS currency** — not forced to INR. | order currency |
+| `reasonOfExport` | **YES** | int | `0`=BONAFIDE_SAMPLE, `1`=SAMPLE, `2`=GIFT, `3`=COMMERCIAL | `3` (commercial sale) |
+| `Terms_Of_Invoice` | **YES** | string | `FOB` or `CIF` | `FOB` |
+| `purpose_of_shipment` | no | int | `0`=gift, `1`=sample, `2`=commercial | `2` |
+| `igstPaymentStatus` | no | char | `A`=not applicable, `B`=LUT/Export under Bond, `C`=Export against IGST payment | `A` |
+| `commodity` | no | bool | is the order a commodity | `true` |
+| `mies` | no | — | (undocumented) | omit |
+| `isd_code` | no | string | destination ISD dial code, e.g. `+1` | derive from country |
+| `shipping_country` | cond | string | **full country NAME** e.g. `"United States"` | ISO2→name map |
+| `order_items[].hsn` | no* | int | HSN code. *Shiprocket made HSN **mandatory for all international shipments** (product-update May 2025) → treat as required. | from product/variant |
+| `order_items[].category_name` / `category_id` / `caetgroy_code` (sic) | no | | optional catalogue hints | omit |
+| `pickup_location` (name) or `pickup_location_id` (int) | yes | | registered pickup | name (as domestic) |
+
+`payment_method` must be **Prepaid** — COD is not available internationally.
+
+## Serviceability — `GET /international/courier/serviceability`
+
+| Param | Req | Type | Notes |
+|---|---|---|---|
+| `weight` | **YES** | int | shipment weight |
+| `cod` | **YES** | int | **must be `0`** (no international COD) |
+| `delivery_country` | **YES** | string | **destination country ISO Alpha-2 code**, e.g. `US` (NB: create uses full name, serviceability uses ISO2) |
+| `order_id` | no | int | Shiprocket order id (skips weight/cod if given) |
+| `pickup_postcode` | no | int | non-primary pickup |
+
+## Country-format gotcha (load-bearing)
+
+- **create/adhoc** `shipping_country` → **full country NAME** ("United States").
+- **serviceability** `delivery_country` → **ISO Alpha-2** ("US").
+Our order addresses store ISO-2 `country_code`, so we need an ISO2→name map for the
+create body and pass ISO2 straight through to serviceability.
+
+## Ops prerequisites (not code — surface clean errors)
+
+International shipping requires, on the Shiprocket account: **International KYC**
+approved, **bank details** added, and an **international-capable pickup** registered.
+These fail the create/assign with actionable messages; the client should pass those
+through as `ShiprocketApiError` (already does), and the workflow should not silently
+fall back to a domestic label.


### PR DESCRIPTION
Closes part of #1111 (S1 + S2). Retail/core orders bound for a **non-India destination** now generate a real Shiprocket shipment (AWB + label + tracking) via Shiprocket's separate international API, with a proper customs declaration.

## Why
Today the retail→Shiprocket label path is functionally complete for domestic India only. International orders would have gone through the **domestic** `create/adhoc` endpoint, which cannot ship abroad — i.e. international retail labelling was effectively broken. This wires it correctly.

## Grounding
The contract was read verbatim from **Shiprocket's official Postman collection** (the docs SPA blocks automated fetch), captured in `apps/docs/notes/SHIPROCKET_INTERNATIONAL_API.md`. This corrected an earlier web-research inference: there is a **full separate `/v1/external/international/*` namespace**, not "domestic endpoint + HSN". Key facts:
- create body uses the **full country NAME** (`"United States"`); serviceability uses the **ISO-2 code** (`"US"`)
- amounts stay in the **order currency** (`currency` field: INR/USD/GBP/EUR/AUD/CAD/SAR/AED/SGD) — not forced to INR
- customs: `reasonOfExport` (3=commercial), `Terms_Of_Invoice` (FOB), `purpose_of_shipment` (2), `igstPaymentStatus` (A), `commodity`
- **HSN mandatory per line**; **COD unavailable** internationally

## Changes
**S1 (`e6caf9ad4`)**
- `provider-interface.ts` — `currency` + `CustomsDeclaration` on `CreateShipmentInput`
- `shiprocket/client.ts` — destination-country routing; pure exported `buildInternationalCreateBody` (country-name map via `Intl.DisplayNames`, retail customs defaults, HSN + COD guards); `getInternationalRates`; cancelled-order retry parity; `provider_refs.international=true`
- `stub-fetch.ts` — international endpoints for integration coverage

**S2 (`8284c2cf9`)**
- mapper resolves HSN from the line's **product variant `hs_code`** → line `metadata.hsn` fallback; order graph widened with `items.variant.hs_code`; currency passthrough

## Tests
- **15 unit** (11 client + 4 mapper): country-name mapping, customs defaults, HSN + COD guards, international-vs-domestic routing, variant-hs_code priority + metadata fallback, currency passthrough
- **3 integration** (`retail-order-international-shiprocket.spec.ts`): US order → international customs body · product-variant `hs_code` production path · missing-HSN → 400
- Existing #772 `partner-order-shiprocket-label` spec still green (its US destination was incidental → moved to an IN address to stay domestic)

```
cd apps/backend
NODE_OPTIONS=--experimental-vm-modules npx jest --testPathPattern="build-create-shipment-input|shiprocket/__tests__" --testPathIgnorePatterns=integration-tests
PARTNER_EMAIL_VERIFICATION=false pnpm test:integration:http:shared ./integration-tests/http/retail-order-international-shiprocket
```

## Behaviour change (intended)
Any **non-India** retail destination now auto-routes to the international API and **requires** a variant `hs_code` (or `metadata.hsn`), otherwise the label 400s with `"HSN code is required for international shipments"`. International shipping also needs Shiprocket account prerequisites (International KYC + bank details + intl-capable pickup); the client surfaces those as `ShiprocketApiError` (no friendly UI gate yet).

## Not in this PR (tracked on #1111)
- **S4** — partner-origin resolution for retail (retail is sales-channel-scoped, so the ship-from can't yet derive the owning partner's pickup)
- **S3** — international serviceability at checkout via `getInternationalRates` + FX for currencies outside Shiprocket's supported set

🤖 Generated with [Claude Code](https://claude.com/claude-code)
