### PR TITLE
feat(shipping): core-order webhook tracking sync [#1111]

### DIFF
--- a/apps/backend/integration-tests/http/retail-order-tracking-webhook.spec.ts
+++ b/apps/backend/integration-tests/http/retail-order-tracking-webhook.spec.ts
@@ -1,0 +1,221 @@
+import { getSharedTestEnv, setupSharedTestSuite } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { shiprocketStubState } from "../../src/modules/shipping-providers/shiprocket/stub-fetch"
+
+const PARTNER_PASSWORD = "supersecret"
+const WEBHOOK_SECRET = "test-core-webhook-secret"
+
+jest.setTimeout(120 * 1000)
+
+/**
+ * #1111 — the carrier tracking webhook advances RETAIL/CORE-order fulfillments,
+ * not just inventory shipments. A core order's Shiprocket label stamps the AWB
+ * onto a `fulfillment_label`; a delivered push then routes AWB → fulfillment and
+ * marks it shipped + delivered (forward-only). Works for domestic + intl; this
+ * exercises a US (international) order end-to-end.
+ */
+setupSharedTestSuite(() => {
+  const { api, getContainer } = getSharedTestEnv()
+
+  describe("POST /webhooks/shipping/track — core-order fulfillment (#1111)", () => {
+    let adminHeaders: any
+    let partnerHeaders: any
+    let locationId: string
+    let salesChannelId: string
+    let regionId: string
+    let orderId: string
+    let awb: string
+
+    let prevEmail: string | undefined
+    let prevPassword: string | undefined
+    let prevStub: string | undefined
+    let prevSecret: string | undefined
+
+    beforeAll(() => {
+      prevEmail = process.env.SHIPROCKET_EMAIL
+      prevPassword = process.env.SHIPROCKET_PASSWORD
+      prevStub = process.env.SHIPROCKET_STUB
+      prevSecret = process.env.SHIPPING_WEBHOOK_SECRET
+      process.env.SHIPROCKET_EMAIL = "test@shiprocket.example"
+      process.env.SHIPROCKET_PASSWORD = "secret"
+      process.env.SHIPROCKET_STUB = "1"
+      process.env.SHIPPING_WEBHOOK_SECRET = WEBHOOK_SECRET
+    })
+
+    afterAll(() => {
+      if (prevEmail === undefined) delete process.env.SHIPROCKET_EMAIL
+      else process.env.SHIPROCKET_EMAIL = prevEmail
+      if (prevPassword === undefined) delete process.env.SHIPROCKET_PASSWORD
+      else process.env.SHIPROCKET_PASSWORD = prevPassword
+      if (prevStub === undefined) delete process.env.SHIPROCKET_STUB
+      else process.env.SHIPROCKET_STUB = prevStub
+      if (prevSecret === undefined) delete process.env.SHIPPING_WEBHOOK_SECRET
+      else process.env.SHIPPING_WEBHOOK_SECRET = prevSecret
+      shiprocketStubState.awbOverride = undefined
+    })
+
+    beforeEach(async () => {
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+
+      const unique = `${Date.now()}${Math.random().toString(36).slice(2, 6)}`
+      // Unique AWB so this shipment's webhook can't collide with another spec's
+      // STUBAWB123 in the shared DB (the inventory path would otherwise match).
+      awb = `COREAWB${unique}`
+      shiprocketStubState.awbOverride = awb
+
+      const email = `trk-${unique}@t.com`
+      await api.post("/auth/partner/emailpass/register", { email, password: PARTNER_PASSWORD })
+      const login1 = await api.post("/auth/partner/emailpass", { email, password: PARTNER_PASSWORD })
+      let headers: any = { Authorization: `Bearer ${login1.data.token}` }
+      await api.post(
+        "/partners",
+        { name: `Trk ${unique}`, handle: `trk-${unique}`, admin: { email, first_name: "T", last_name: unique } },
+        { headers }
+      )
+      const login2 = await api.post("/auth/partner/emailpass", { email, password: PARTNER_PASSWORD })
+      partnerHeaders = { Authorization: `Bearer ${login2.data.token}` }
+
+      await api
+        .post("/admin/shipping-profiles", { name: `default-${unique}`, type: "default" }, adminHeaders)
+        .catch(() => {})
+
+      const storeRes = await api.post(
+        "/partners/stores",
+        {
+          store: { name: `TStore ${unique}`, supported_currencies: [{ currency_code: "usd", is_default: true }] },
+          sales_channel: { name: `TChannel ${unique}`, description: "Default" },
+          region: { name: `T Region ${unique}`, currency_code: "usd", countries: ["us"] },
+          location: {
+            name: "T Warehouse",
+            address: { address_1: "1 Loom St", city: "Surendranagar", province: "GJ", postal_code: "363035", country_code: "IN" },
+          },
+        },
+        { headers: partnerHeaders }
+      )
+      locationId = storeRes.data.location?.id
+      salesChannelId = storeRes.data.sales_channel?.id
+      regionId = storeRes.data.region?.id
+
+      await api.post(
+        `/admin/stock-locations/${locationId}`,
+        { address: { address_1: "1 Loom St", city: "Surendranagar", province: "GJ", postal_code: "363035", country_code: "IN", phone: "9990001112" } },
+        adminHeaders
+      )
+
+      const locDetail = await api.get(
+        `/admin/stock-locations/${locationId}?fields=id,*fulfillment_sets.service_zones`,
+        adminHeaders
+      )
+      const zoneId = (locDetail.data.stock_location?.fulfillment_sets || [])
+        .flatMap((f: any) => f.service_zones || [])
+        .map((z: any) => z.id)
+        .find(Boolean)
+      const profiles = await api.get("/admin/shipping-profiles?limit=1", adminHeaders)
+      const profileId = profiles.data.shipping_profiles?.[0]?.id
+      await api.post(
+        "/admin/shipping-options",
+        {
+          name: "Standard Shipping",
+          service_zone_id: zoneId,
+          shipping_profile_id: profileId,
+          provider_id: "manual_manual",
+          price_type: "flat",
+          type: { label: "Standard", description: "Std", code: "standard" },
+          prices: [{ currency_code: "usd", amount: 10 }],
+        },
+        adminHeaders
+      )
+
+      const draft = await api.post(
+        "/admin/draft-orders",
+        {
+          email: "buyer@t.com",
+          region_id: regionId,
+          sales_channel_id: salesChannelId,
+          currency_code: "usd",
+          shipping_address: {
+            first_name: "Elena", last_name: "Doe", address_1: "9 Buyer Rd",
+            city: "Dallas", province: "TX", postal_code: "75201", country_code: "us", phone: "8887776665",
+          },
+          items: [{ title: "Tangaliya Stole", quantity: 1, unit_price: 1500, metadata: { hsn: "621410" } }],
+        },
+        adminHeaders
+      )
+      const draftId = draft.data.draft_order?.id
+      const converted = await api.post(`/admin/draft-orders/${draftId}/convert-to-order`, {}, adminHeaders)
+      orderId = converted.data.order?.id ?? draftId
+
+      // Generate the label → creates the fulfillment + the AWB fulfillment_label.
+      const label = await api.post(`/partners/orders/${orderId}/shiprocket-label`, {}, { headers: partnerHeaders })
+      expect(label.status).toBe(200)
+      expect(label.data.shiprocket_label.awb).toBe(awb)
+    })
+
+    const fetchOrder = async (): Promise<any> => {
+      const res = await api.get(
+        `/admin/orders/${orderId}?fields=id,fulfillment_status,fulfillments.id,fulfillments.shipped_at,fulfillments.delivered_at,fulfillments.data`,
+        adminHeaders
+      )
+      return res.data.order
+    }
+
+    const waitFor = async (predicate: () => Promise<boolean>, timeoutMs = 25000): Promise<boolean> => {
+      const start = Date.now()
+      while (Date.now() - start < timeoutMs) {
+        if (await predicate()) return true
+        await new Promise((r) => setTimeout(r, 400))
+      }
+      return false
+    }
+
+    const push = async (payload: any, token: string | null = WEBHOOK_SECRET) => {
+      const qs = token ? `?token=${token}` : ""
+      return api.post(`/webhooks/shipping/track${qs}`, payload).catch((e: any) => e.response)
+    }
+
+    const deliveredPayload = () => ({
+      awb,
+      current_status: "DELIVERED",
+      current_status_id: 7,
+      shipment_status: "DELIVERED",
+      shipment_status_id: 7,
+      scans: [{ date: "2026-07-06 14:00", status: "Delivered", location: "Dallas" }],
+    })
+
+    it("a delivered push marks the core fulfillment shipped + delivered", async () => {
+      const res = await push(deliveredPayload())
+      expect(res.status).toBe(200)
+
+      const landed = await waitFor(async () => (await fetchOrder()).fulfillment_status === "delivered")
+      expect(landed).toBe(true)
+
+      const order = await fetchOrder()
+      const f = order.fulfillments?.[0]
+      expect(f?.shipped_at).toBeTruthy()
+      expect(f?.delivered_at).toBeTruthy()
+      // The scan history is recorded on the fulfillment data blob.
+      expect(Array.isArray(f?.data?.tracking_events)).toBe(true)
+      expect(f.data.tracking_events.length).toBeGreaterThan(0)
+    })
+
+    it("a later pre-delivery push never regresses a delivered fulfillment", async () => {
+      await push(deliveredPayload())
+      await waitFor(async () => (await fetchOrder()).fulfillment_status === "delivered")
+
+      const late = await push({
+        awb,
+        current_status: "IN TRANSIT",
+        current_status_id: 20,
+        shipment_status_id: 18,
+        scans: [{ date: "2026-07-05 09:00", status: "In transit", location: "Mumbai" }],
+      })
+      expect(late.status).toBe(200)
+      await new Promise((r) => setTimeout(r, 1500))
+      const order = await fetchOrder()
+      expect(order.fulfillment_status).toBe("delivered")
+      expect(order.fulfillments?.[0]?.delivered_at).toBeTruthy()
+    })
+  })
+})

--- a/apps/backend/src/api/webhooks/shipping/track/route.ts
+++ b/apps/backend/src/api/webhooks/shipping/track/route.ts
@@ -3,6 +3,7 @@ import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 
 import { normalizeShiprocketWebhook } from "../../../../modules/shipping-providers/shiprocket/client"
 import { syncInventoryShipmentTrackingWorkflow } from "../../../../workflows/inventory_orders/sync-inventory-shipment-tracking"
+import { syncOrderShipmentTrackingWorkflow } from "../../../../workflows/orders/sync-order-shipment-tracking"
 
 /**
  * POST /webhooks/shipping/track (#888)
@@ -73,18 +74,34 @@ async function processTrackingPush(scope: any, carrier: string, body: any): Prom
     input: { tracking: { ...tracking, raw: body } },
   })
 
-  if (!result.matched) {
+  if (result.matched) {
     logger.info(
-      `[Shipping Webhook] AWB ${tracking.awb} matched no inventory shipment (status "${tracking.current_status}") — ignored`
+      `[Shipping Webhook] AWB ${tracking.awb}: shipment ${result.shipment_id} ` +
+        `${result.previous_shipment_status}→${result.shipment_status}` +
+        (result.shipment_status_changed ? "" : " (no change)") +
+        (result.order_status_changed
+          ? ` · order ${result.order_id} ${result.previous_order_status}→${result.order_status}`
+          : "")
+    )
+    return
+  }
+
+  // Not an inventory shipment — try the retail/core-order path (#1111). The
+  // account-level webhook carries both; core shipments store the AWB on a
+  // fulfillment_label (domestic + international alike).
+  const { result: orderResult } = await syncOrderShipmentTrackingWorkflow(scope).run({
+    input: { tracking: { ...tracking, raw: body } },
+  })
+
+  if (!orderResult.matched) {
+    logger.info(
+      `[Shipping Webhook] AWB ${tracking.awb} matched no inventory or core-order shipment (status "${tracking.current_status}") — ignored`
     )
     return
   }
   logger.info(
-    `[Shipping Webhook] AWB ${tracking.awb}: shipment ${result.shipment_id} ` +
-      `${result.previous_shipment_status}→${result.shipment_status}` +
-      (result.shipment_status_changed ? "" : " (no change)") +
-      (result.order_status_changed
-        ? ` · order ${result.order_id} ${result.previous_order_status}→${result.order_status}`
-        : "")
+    `[Shipping Webhook] AWB ${tracking.awb}: core fulfillment ${orderResult.fulfillment_id} ` +
+      `(order ${orderResult.order_id}) → ${orderResult.synced_state}` +
+      (orderResult.status_changed ? "" : " (no change)")
   )
 }

--- a/apps/backend/src/modules/shipping-providers/shiprocket/stub-fetch.ts
+++ b/apps/backend/src/modules/shipping-providers/shiprocket/stub-fetch.ts
@@ -32,6 +32,13 @@ export const shiprocketStubState: {
   lastAddPickupBody?: any
   /** International create/adhoc body (#1111). Also mirrored onto lastAdhocBody. */
   lastIntlAdhocBody?: any
+  /**
+   * Override the AWB the assign endpoints return (default STUBAWB123). Lets a
+   * spec generate a shipment with a UNIQUE waybill so its webhook push can't
+   * collide with another spec's shipment in the shared test DB (#1111 core-order
+   * tracking). Reset to undefined in the spec's cleanup.
+   */
+  awbOverride?: string
 } = {}
 
 const parseBody = (init: any): any => {
@@ -82,7 +89,7 @@ export function createShiprocketStubFetch(): FetchLike {
       return json({
         response: {
           data: {
-            awb_code: "STUBAWB123",
+            awb_code: shiprocketStubState.awbOverride || "STUBAWB123",
             courier_company_id: 301,
             courier_name: "DHL Express Intl",
           },
@@ -101,7 +108,7 @@ export function createShiprocketStubFetch(): FetchLike {
       return json({
         response: {
           data: {
-            awb_code: "STUBAWB123",
+            awb_code: shiprocketStubState.awbOverride || "STUBAWB123",
             courier_company_id: 51,
             courier_name: "Xpressbees Surface",
           },

--- a/apps/backend/src/workflows/orders/__tests__/sync-order-shipment-tracking.unit.spec.ts
+++ b/apps/backend/src/workflows/orders/__tests__/sync-order-shipment-tracking.unit.spec.ts
@@ -1,0 +1,44 @@
+import { resolveFulfillmentSyncAction } from "../sync-order-shipment-tracking"
+
+/**
+ * #1111 — core-order tracking webhook forward-only guard. Pure decision: given
+ * the carrier-derived coarse state and the fulfillment's shipped/delivered/
+ * canceled timestamps, what should the webhook do? Idempotent + never regresses.
+ */
+describe("resolveFulfillmentSyncAction", () => {
+  const T = "2026-07-21T00:00:00.000Z"
+
+  it("ships a fresh fulfillment on a shipped signal", () => {
+    expect(resolveFulfillmentSyncAction("shipped", {})).toBe("ship")
+    expect(resolveFulfillmentSyncAction("shipped", { shipped_at: null })).toBe("ship")
+  })
+
+  it("ships+delivers a fresh fulfillment on a delivered signal (skips the intermediate)", () => {
+    expect(resolveFulfillmentSyncAction("delivered", {})).toBe("ship_and_deliver")
+  })
+
+  it("only delivers when already shipped", () => {
+    expect(resolveFulfillmentSyncAction("delivered", { shipped_at: T })).toBe("deliver")
+  })
+
+  it("is idempotent — no-ops when already in the target state", () => {
+    expect(resolveFulfillmentSyncAction("shipped", { shipped_at: T })).toBe("none")
+    expect(resolveFulfillmentSyncAction("delivered", { shipped_at: T, delivered_at: T })).toBe("none")
+  })
+
+  it("never regresses a delivered fulfillment on a later shipped/pending push", () => {
+    expect(resolveFulfillmentSyncAction("shipped", { shipped_at: T, delivered_at: T })).toBe("none")
+    expect(resolveFulfillmentSyncAction("pending", { shipped_at: T, delivered_at: T })).toBe("none")
+  })
+
+  it("never touches a canceled fulfillment", () => {
+    expect(resolveFulfillmentSyncAction("shipped", { canceled_at: T })).toBe("none")
+    expect(resolveFulfillmentSyncAction("delivered", { canceled_at: T })).toBe("none")
+    expect(resolveFulfillmentSyncAction("delivered", { shipped_at: T, canceled_at: T })).toBe("none")
+  })
+
+  it("does nothing on a pre-pickup / unknown (pending) push", () => {
+    expect(resolveFulfillmentSyncAction("pending", {})).toBe("none")
+    expect(resolveFulfillmentSyncAction("pending", { shipped_at: T })).toBe("none")
+  })
+})

--- a/apps/backend/src/workflows/orders/shiprocket-shipment.ts
+++ b/apps/backend/src/workflows/orders/shiprocket-shipment.ts
@@ -333,7 +333,10 @@ export async function createShiprocketShipmentForFulfillment(
 
   const result = await provider.createShipment(shipmentInput)
 
-  // Persist the carrier refs onto fulfillment.data (what label/tracking read).
+  // Persist the carrier refs onto fulfillment.data (what label/tracking read),
+  // AND stamp the AWB as a fulfillment_label tracking number — the queryable
+  // key the tracking webhook matches core-order pushes on (data.waybill is
+  // JSONB and can't be filtered). Only when an AWB actually came back.
   await fulfillmentModule.updateFulfillment(input.fulfillmentId, {
     data: {
       ...(fulfillment.data || {}),
@@ -346,6 +349,17 @@ export async function createShiprocketShipmentForFulfillment(
       sr_order_id: result.provider_refs?.sr_order_id,
       provider_refs: result.provider_refs,
     },
+    ...(result.awb
+      ? {
+          labels: [
+            {
+              tracking_number: result.awb,
+              tracking_url: result.tracking_url || "",
+              label_url: result.label_url || "",
+            },
+          ],
+        }
+      : {}),
   })
 
   return { ...result, fulfillment_id: input.fulfillmentId }

--- a/apps/backend/src/workflows/orders/sync-order-shipment-tracking.ts
+++ b/apps/backend/src/workflows/orders/sync-order-shipment-tracking.ts
@@ -1,0 +1,218 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { MedusaContainer } from "@medusajs/framework/types"
+import {
+  createOrderShipmentWorkflow,
+  markOrderFulfillmentAsDeliveredWorkflow,
+} from "@medusajs/medusa/core-flows"
+import type { TrackingResult } from "../../modules/shipping-providers/provider-interface"
+import { deriveFulfillmentState } from "./shiprocket-attach-awb"
+import { appendTrackingEvent } from "../inventory_orders/lib/shipment-tracking"
+
+/**
+ * Core-order counterpart of `syncInventoryShipmentTracking` (#888 → #1111).
+ *
+ * The account-level Shiprocket webhook carries BOTH inventory-order shipments
+ * (matched on the `inventory_shipment.awb` column) AND retail/core-order
+ * shipments — the latter store their AWB only on `fulfillment.data`, so they
+ * were previously logged-and-swallowed. This routes a core-order push to its
+ * fulfillment and advances the order's fulfillment status (shipped → delivered)
+ * from the carrier's real state, the same way `attachExistingShiprocketAwb`
+ * does on demand. Works identically for domestic and international shipments —
+ * both persist a `fulfillment_label` with the AWB as its tracking number.
+ *
+ * Forward-only + idempotent: a fulfillment already shipped/delivered isn't
+ * re-shipped/re-delivered, so webhook retries and out-of-order pushes are safe.
+ */
+
+export type SyncOrderShipmentTrackingInput = {
+  tracking: Pick<
+    TrackingResult,
+    "carrier" | "awb" | "current_status" | "current_status_code" | "estimated_delivery"
+  > & { raw?: any }
+}
+
+export type SyncOrderShipmentTrackingResult = {
+  matched: boolean
+  fulfillment_id?: string
+  order_id?: string
+  /** What we advanced the fulfillment to (or left it at). */
+  synced_state?: "shipped" | "delivered" | "pending"
+  status_changed?: boolean
+}
+
+export type FulfillmentTimestamps = {
+  shipped_at?: unknown
+  delivered_at?: unknown
+  canceled_at?: unknown
+}
+
+export type FulfillmentSyncAction = "none" | "ship" | "deliver" | "ship_and_deliver"
+
+/**
+ * Pure forward-only decision: given the carrier-derived coarse state and the
+ * fulfillment's current shipped/delivered/canceled timestamps, what should the
+ * webhook do? Never regresses (a delivered fulfillment stays delivered), never
+ * touches a canceled one, and idempotently no-ops when already in the target
+ * state. Exported for unit testing.
+ */
+export function resolveFulfillmentSyncAction(
+  derived: "delivered" | "shipped" | "pending",
+  f: FulfillmentTimestamps | null | undefined
+): FulfillmentSyncAction {
+  if (f?.canceled_at) return "none"
+  const shipped = !!f?.shipped_at
+  const delivered = !!f?.delivered_at
+  if (derived === "delivered") {
+    if (delivered) return "none"
+    return shipped ? "deliver" : "ship_and_deliver"
+  }
+  if (derived === "shipped") {
+    return shipped ? "none" : "ship"
+  }
+  return "none"
+}
+
+export async function syncOrderShipmentTracking(
+  container: MedusaContainer,
+  input: SyncOrderShipmentTrackingInput
+): Promise<SyncOrderShipmentTrackingResult> {
+  const logger: any = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+  const fulfillmentModule: any = container.resolve(Modules.FULFILLMENT)
+  const tracking = input.tracking
+
+  const awb = String(tracking.awb || "").trim()
+  if (!awb) return { matched: false }
+
+  // AWB → core fulfillment, via the queryable label tracking number the
+  // shipment flow stamps on generation (data.waybill is JSONB and can't be
+  // filtered). Filter fulfillments by the nested `labels.tracking_number`, then
+  // confirm the match in JS (defensive against a filter that over-returns).
+  const { data: fulfillments } = await query.graph({
+    entity: "fulfillment",
+    fields: [
+      "id",
+      "data",
+      "shipped_at",
+      "delivered_at",
+      "canceled_at",
+      "labels.tracking_number",
+      "order.id",
+      "order.items.id",
+      "order.items.detail.quantity",
+      "order.items.quantity",
+    ],
+    filters: { labels: { tracking_number: awb } },
+  })
+  const fulfillment = (fulfillments || []).find((f: any) =>
+    (f?.labels || []).some((l: any) => l?.tracking_number === awb)
+  )
+  if (!fulfillment) {
+    // Not a core-order shipment we know (or the inventory path already handled
+    // it) — 200-and-log is the webhook contract.
+    return { matched: false }
+  }
+  const fulfillmentId = fulfillment.id
+  const order = fulfillment.order
+  const orderId = order?.id
+
+  // Always record the scan (even when the status doesn't move) — the history is
+  // how Shiprocket's under-documented status ids get confirmed empirically.
+  const data = appendTrackingEvent(
+    fulfillment.data,
+    {
+      at: null,
+      received_at: new Date().toISOString(),
+      status: String(tracking.current_status || ""),
+      status_code: tracking.current_status_code ?? null,
+    },
+    tracking.raw
+  )
+  await fulfillmentModule.updateFulfillment(fulfillmentId, { data })
+
+  const derived = deriveFulfillmentState(
+    tracking.current_status_code != null
+      ? Number(tracking.current_status_code)
+      : undefined,
+    tracking.current_status
+  )
+  const action = resolveFulfillmentSyncAction(derived, fulfillment)
+
+  const result: SyncOrderShipmentTrackingResult = {
+    matched: true,
+    fulfillment_id: fulfillmentId,
+    order_id: orderId,
+    synced_state: derived,
+    status_changed: false,
+  }
+
+  if (action === "none" || !orderId) {
+    return result
+  }
+
+  const items = (order.items || []).map((i: any) => ({
+    id: i.id,
+    quantity: Number(i.detail?.quantity ?? i.quantity) || 1,
+  }))
+
+  // Mark shipped (labels already exist from generation — pass none to avoid dupes).
+  if (action === "ship" || action === "ship_and_deliver") {
+    try {
+      await createOrderShipmentWorkflow(container).run({
+        input: {
+          order_id: orderId,
+          fulfillment_id: fulfillmentId,
+          items,
+          labels: [],
+          no_notification: true,
+        },
+      })
+      result.status_changed = true
+    } catch (e: any) {
+      logger.warn(
+        `[Shipping Webhook] mark-shipped skipped for fulfillment ${fulfillmentId} (AWB ${awb}): ${e?.message}`
+      )
+    }
+  }
+
+  if (action === "deliver" || action === "ship_and_deliver") {
+    try {
+      await markOrderFulfillmentAsDeliveredWorkflow(container).run({
+        input: {
+          orderId: orderId,
+          fulfillmentId: fulfillmentId,
+          no_notification: true,
+        } as any,
+      })
+      result.status_changed = true
+    } catch (e: any) {
+      logger.warn(
+        `[Shipping Webhook] mark-delivered skipped for fulfillment ${fulfillmentId} (AWB ${awb}): ${e?.message}`
+      )
+    }
+  }
+
+  return result
+}
+
+const syncOrderShipmentTrackingStep = createStep(
+  "sync-order-shipment-tracking",
+  async (input: SyncOrderShipmentTrackingInput, { container }) => {
+    const result = await syncOrderShipmentTracking(container, input)
+    return new StepResponse(result)
+  }
+)
+
+export const syncOrderShipmentTrackingWorkflow = createWorkflow(
+  "sync-order-shipment-tracking",
+  (input: SyncOrderShipmentTrackingInput) => {
+    const result = syncOrderShipmentTrackingStep(input)
+    return new WorkflowResponse(result)
+  }
+)


### PR DESCRIPTION
## #1111 — core-order tracking webhook (parity with domestic)

Follow-up that missed the #1116 squash (auto-merge fired early). Brings retail/core-order shipments to tracking parity with inventory shipments.

The account-level Shiprocket webhook previously advanced only **inventory-order** shipments (matched on the `inventory_shipment.awb` column); retail/core orders — **domestic AND international** — stored their AWB only on `fulfillment.data` (JSONB, unqueryable) and were logged-and-swallowed.

- **Shipment generation** now stamps the AWB as a `fulfillment_label.tracking_number` (alongside `data.waybill`) — the queryable key.
- **New `sync-order-shipment-tracking` workflow**: AWB → core fulfillment (filter by `labels.tracking_number`), record the scan on `fulfillment.data`, advance shipped→delivered via core-flows (`createOrderShipment` / `markOrderFulfillmentAsDelivered`), behind a pure forward-only guard (`resolveFulfillmentSyncAction` — idempotent, never regresses, never touches a canceled fulfillment).
- **Webhook route**: routes pushes unmatched by the inventory sync through the core-order sync.
- **stub-fetch**: optional `awbOverride` so a spec can generate a unique-AWB shipment (avoids shared-DB collisions).

### Tests
- 7 unit (forward-only guard) + 2 integration (`retail-order-tracking-webhook`: US order label → delivered webhook → fulfillment shipped+delivered; late push doesn't regress). Inventory webhook (5) + intl (3) still green.

Completes the tracking/webhook tail of #1111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)