### PR TITLE
feat(shipping): admin + partner shipment tracking UI, e2e in CI [#1118]

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,133 @@
+name: E2E (admin UI)
+
+# Browser-level verification of admin UI extensions (Playwright, headless
+# Chromium). Boots a real `medusa develop` server against a fresh Postgres,
+# seeds demo commerce infra + a fixture admin/order, then drives the admin.
+# Kept as its own workflow (separate from Test and Release) so the heavier
+# browser run can be gated to the paths that actually affect admin UI.
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'apps/backend/src/admin/**'
+      - 'apps/backend/src/scripts/seed.ts'
+      - 'e2e/**'
+      - '.github/workflows/e2e.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'apps/backend/src/admin/**'
+      - 'apps/backend/src/scripts/seed.ts'
+      - 'e2e/**'
+      - '.github/workflows/e2e.yml'
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      NODE_ENV: test
+      # No REDIS_URL → the backend falls back to an in-memory (fake) redis, the
+      # same path the seed uses locally. A single-worker e2e needs no real bus.
+      DATABASE_URL: postgresql://runner@localhost:5432/postgres
+      POSTGRES_USER: runner
+      POSTGRES_PASSWORD: runner
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Workspace plugins ship built output under .medusa/; the backend can't
+      # boot until they're built (mirrors the Test and Release workflow).
+      - name: Build workspace plugins
+        run: pnpm --filter "@jytextiles/medusa-plugin-etsy-sync" build
+
+      - name: Setup database user
+        run: |
+          psql -h localhost -U postgres -d postgres -c "CREATE USER runner SUPERUSER CREATEDB CREATEROLE;"
+          psql -h localhost -U postgres -d postgres -c "GRANT ALL PRIVILEGES ON DATABASE postgres TO runner;"
+
+      - name: Create backend env file
+        run: |
+          # Written to BOTH .env and .env.test so every entrypoint finds config
+          # whether it resolves NODE_ENV=test (medusa exec / integration) or
+          # development (medusa develop).
+          cat << 'EOF' > apps/backend/.env.test
+          DATABASE_TYPE=postgres
+          DATABASE_URL=postgresql://runner@localhost:5432/postgres
+          JWT_SECRET=secret
+          COOKIE_SECRET=secret
+          ADMIN_CORS=http://localhost:9000
+          STORE_CORS=http://localhost:9000
+          AUTH_CORS=http://localhost:9000
+          NODE_ENV=test
+          ENCRYPTION_KEY=bPH59JuZDRQULLeDD62+NiwqwcChpOLN/j7aqu3A+Hw=
+          EOF
+          cp apps/backend/.env.test apps/backend/.env
+
+      - name: Run migrations
+        working-directory: apps/backend
+        run: pnpm exec medusa db:migrate --execute-safe-links
+
+      # Demo commerce infra (region / sales channel / manual shipping option /
+      # products) the e2e order fixture depends on. e2e:seed throws a clear
+      # error if this hasn't run first.
+      - name: Seed demo commerce data
+        working-directory: apps/backend
+        run: pnpm run seed
+
+      - name: Install Playwright browser
+        working-directory: apps/backend
+        run: pnpm exec playwright install --with-deps chromium
+
+      # e2e:seed (fixture admin + order) then e2e:test (Playwright boots
+      # `medusa develop` on :9000 and drives the admin headlessly).
+      - name: Run e2e
+        working-directory: apps/backend
+        run: pnpm run e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            test-results/
+            playwright-report/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/apps/backend/src/admin/components/websites/analytics-search-discovery-card.tsx
+++ b/apps/backend/src/admin/components/websites/analytics-search-discovery-card.tsx
@@ -3,7 +3,7 @@ import { MagnifyingGlass } from "@medusajs/icons"
 import type { ConsoleStatus } from "../../hooks/api/search-console"
 import { useWebsiteConsoleStatus, useWebsiteConsoleSync } from "../../hooks/api/search-console"
 import { useWebsiteSearchConsoleRollup, type SearchConsoleRollupResponse } from "../../hooks/api/analytics"
-import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
+import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip as RechartsTooltip, ResponsiveContainer } from 'recharts'
 
 function formatPercent(v: number | null | undefined): string {
   if (v === null || v === undefined) return "—"
@@ -240,7 +240,7 @@ export const AnalyticsSearchDiscoveryCard = ({ websiteId, days }: Props) => {
                 <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
                 <XAxis dataKey="date" tick={{ fontSize: 11 }} stroke="#9ca3af" />
                 <YAxis tick={{ fontSize: 11 }} stroke="#9ca3af" />
-                <Tooltip
+                <RechartsTooltip
                   contentStyle={{
                     backgroundColor: '#fff',
                     border: '1px solid #e5e7eb',

--- a/apps/backend/src/admin/widgets/order-shipment-tracking.tsx
+++ b/apps/backend/src/admin/widgets/order-shipment-tracking.tsx
@@ -1,0 +1,316 @@
+import { defineWidgetConfig } from "@medusajs/admin-sdk"
+import { DetailWidgetProps } from "@medusajs/framework/types"
+import {
+  Badge,
+  Button,
+  Container,
+  Copy,
+  Heading,
+  Skeleton,
+  StatusBadge,
+  Text,
+} from "@medusajs/ui"
+import {
+  ArrowUpRightOnBox,
+  DocumentText,
+  TriangleRightMini,
+  TruckFast,
+} from "@medusajs/icons"
+import { useQuery } from "@tanstack/react-query"
+import { useState } from "react"
+import { sdk } from "../lib/config"
+
+// #1118 — surface the Shiprocket shipment on the admin ORDER detail: the
+// auto-selected courier + its quoted rate (`data.provider_refs.courier_rate`,
+// stamped for international orders in #1116 S3) and the tracking timeline
+// (`data.tracking_events`, appended by the #1117 core-order webhook sync).
+// Mirrors the inventory-order shipments section, but reads core-order
+// fulfillments and uses Medusa UI primitives throughout. Orders with no
+// carrier shipment (plain retail with no AWB) render nothing — no empty card.
+
+type FulfillmentLabel = {
+  tracking_number?: string | null
+  tracking_url?: string | null
+  label_url?: string | null
+}
+
+type ProviderRefs = {
+  courier_name?: string | null
+  courier_rate?: number | null
+  courier_rate_currency?: string | null
+  international?: boolean | null
+}
+
+type TrackingEvent = {
+  at?: string | null
+  received_at?: string | null
+  status?: string | null
+  status_code?: number | string | null
+  location?: string | null
+}
+
+type FulfillmentData = {
+  carrier?: string | null
+  waybill?: string | null
+  tracking_number?: string | null
+  tracking_url?: string | null
+  label_url?: string | null
+  current_status?: string | null
+  provider_refs?: ProviderRefs | null
+  tracking_events?: TrackingEvent[] | null
+}
+
+type Fulfillment = {
+  id: string
+  shipped_at?: string | null
+  delivered_at?: string | null
+  canceled_at?: string | null
+  data?: FulfillmentData | null
+  labels?: FulfillmentLabel[] | null
+}
+
+type AdminOrder = { id: string }
+
+type OrderResponse = { order: { id: string; fulfillments?: Fulfillment[] } }
+
+const FIELDS = [
+  "id",
+  "fulfillments.id",
+  "fulfillments.shipped_at",
+  "fulfillments.delivered_at",
+  "fulfillments.canceled_at",
+  "fulfillments.data",
+  "fulfillments.labels.tracking_number",
+  "fulfillments.labels.tracking_url",
+  "fulfillments.labels.label_url",
+].join(",")
+
+/** A fulfillment counts as a carrier shipment only once it carries carrier refs. */
+function isCarrierShipment(f: Fulfillment): boolean {
+  const d = f.data || {}
+  return Boolean(
+    d.carrier || d.waybill || d.tracking_number || d.provider_refs
+  )
+}
+
+/** Derive a human status + StatusBadge color from timestamps and the carrier status. */
+function deriveStatus(f: Fulfillment): {
+  label: string
+  color: "green" | "orange" | "blue" | "red" | "grey"
+} {
+  if (f.canceled_at) return { label: "Cancelled", color: "red" }
+  if (f.delivered_at) return { label: "Delivered", color: "green" }
+
+  const raw = (f.data?.current_status || "").toLowerCase()
+  if (raw) {
+    if (raw.includes("deliver")) return { label: f.data!.current_status!, color: "green" }
+    if (raw.includes("rto") || raw.includes("return") || raw.includes("cancel"))
+      return { label: f.data!.current_status!, color: "red" }
+    if (raw.includes("out for delivery"))
+      return { label: f.data!.current_status!, color: "orange" }
+    return { label: f.data!.current_status!, color: "blue" }
+  }
+
+  if (f.shipped_at) return { label: "In transit", color: "blue" }
+  return { label: "Awaiting pickup", color: "orange" }
+}
+
+function formatMoney(amount: number, currency?: string | null): string {
+  const cur = (currency || "INR").toUpperCase()
+  const safe = Number.isFinite(amount) ? amount : 0
+  try {
+    return new Intl.NumberFormat("en-IN", {
+      style: "currency",
+      currency: cur,
+      maximumFractionDigits: 2,
+    }).format(safe)
+  } catch {
+    return `${safe.toFixed(2)} ${cur}`
+  }
+}
+
+const linkOf = (f: Fulfillment) => {
+  const d = f.data || {}
+  const label = (f.labels || [])[0] || {}
+  const awb = d.tracking_number || d.waybill || label.tracking_number || undefined
+  const trackingUrl = d.tracking_url || label.tracking_url || undefined
+  const labelUrl = d.label_url || label.label_url || undefined
+  return { awb, trackingUrl, labelUrl }
+}
+
+const TrackingTimeline = ({ events }: { events: TrackingEvent[] }) => {
+  const [open, setOpen] = useState(false)
+  if (events.length === 0) return null
+  return (
+    <div className="pl-1">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-x-1 text-ui-fg-subtle transition-colors hover:text-ui-fg-base"
+      >
+        <TriangleRightMini
+          className={`text-ui-fg-muted transition-transform ${open ? "rotate-90" : ""}`}
+        />
+        <Text size="xsmall" leading="compact">
+          Tracking history ({events.length})
+        </Text>
+      </button>
+      {open && (
+        <div className="mt-2 flex flex-col gap-y-1 border-l border-ui-border-base pl-3">
+          {[...events].reverse().map((ev, idx) => {
+            const when = ev.at || ev.received_at
+            return (
+              <div key={idx} className="flex flex-col">
+                <Text size="xsmall" leading="compact" className="text-ui-fg-base">
+                  {ev.status || "—"}
+                  {ev.status_code != null && ev.status_code !== ""
+                    ? ` (${ev.status_code})`
+                    : ""}
+                </Text>
+                <Text size="xsmall" leading="compact" className="text-ui-fg-muted">
+                  {when ? new Date(when).toLocaleString() : ""}
+                  {ev.location ? ` · ${ev.location}` : ""}
+                </Text>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+const ShipmentRow = ({ f }: { f: Fulfillment }) => {
+  const status = deriveStatus(f)
+  const { awb, trackingUrl, labelUrl } = linkOf(f)
+  const refs = f.data?.provider_refs || {}
+  const events = Array.isArray(f.data?.tracking_events)
+    ? (f.data!.tracking_events as TrackingEvent[])
+    : []
+  const carrierName = f.data?.carrier || "Shiprocket"
+  const hasRate = refs.courier_rate != null && Number.isFinite(Number(refs.courier_rate))
+
+  return (
+    <div className="flex flex-col gap-y-2 py-4">
+      <div className="flex items-center justify-between gap-x-2">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <StatusBadge color={status.color} className="text-nowrap capitalize">
+            {status.label}
+          </StatusBadge>
+          <Text size="small" leading="compact" className="text-ui-fg-base capitalize">
+            {carrierName}
+          </Text>
+          {refs.international ? (
+            <Badge size="2xsmall" color="purple">
+              International
+            </Badge>
+          ) : null}
+        </div>
+        {labelUrl ? (
+          <Button size="small" variant="secondary" asChild>
+            <a href={labelUrl} target="_blank" rel="noreferrer">
+              <DocumentText />
+              Label
+            </a>
+          </Button>
+        ) : null}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 pl-1">
+        {refs.courier_name ? (
+          <Text size="xsmall" leading="compact" className="text-ui-fg-subtle">
+            Courier: {refs.courier_name}
+          </Text>
+        ) : null}
+        {hasRate ? (
+          <Text size="xsmall" leading="compact" className="text-ui-fg-subtle">
+            Rate: {formatMoney(Number(refs.courier_rate), refs.courier_rate_currency)}
+          </Text>
+        ) : null}
+      </div>
+
+      {awb ? (
+        <div className="flex items-center gap-x-2 pl-1">
+          <Text size="xsmall" leading="compact" className="text-ui-fg-muted">
+            AWB
+          </Text>
+          {trackingUrl ? (
+            <a
+              href={trackingUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-x-1 text-ui-fg-interactive transition-colors hover:text-ui-fg-interactive-hover"
+            >
+              <Text size="xsmall" leading="compact">
+                {awb}
+              </Text>
+              <ArrowUpRightOnBox />
+            </a>
+          ) : (
+            <Text size="xsmall" leading="compact" className="text-ui-fg-base">
+              {awb}
+            </Text>
+          )}
+          <Copy content={awb} variant="mini" />
+        </div>
+      ) : null}
+
+      <TrackingTimeline events={events} />
+    </div>
+  )
+}
+
+const OrderShipmentTrackingWidget = ({
+  data: order,
+}: DetailWidgetProps<AdminOrder>) => {
+  const { data, isLoading } = useQuery({
+    queryFn: () =>
+      sdk.client.fetch<OrderResponse>(`/admin/orders/${order.id}`, {
+        method: "GET",
+        query: { fields: FIELDS },
+      }),
+    queryKey: ["order-shipment-tracking", order.id],
+  })
+
+  const shipments = (data?.order?.fulfillments || []).filter(isCarrierShipment)
+
+  // No carrier shipment → plain retail order with no AWB → render nothing.
+  // (Match the widget-convention: no empty card on unrelated orders.)
+  if (!isLoading && shipments.length === 0) return null
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <div className="flex items-center gap-x-2">
+          <TruckFast className="text-ui-fg-subtle" />
+          <Heading level="h2">Shipping &amp; Tracking</Heading>
+          {shipments.length > 0 ? (
+            <Badge size="2xsmall" className="ml-1">
+              {shipments.length}
+            </Badge>
+          ) : null}
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="flex flex-col gap-y-3 px-6 py-4">
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-4 w-64" />
+          <Skeleton className="h-4 w-52" />
+        </div>
+      ) : (
+        <div className="flex flex-col divide-y px-6 py-2">
+          {shipments.map((f) => (
+            <ShipmentRow key={f.id} f={f} />
+          ))}
+        </div>
+      )}
+    </Container>
+  )
+}
+
+export const config = defineWidgetConfig({
+  zone: "order.details.after",
+})
+
+export default OrderShipmentTrackingWidget

--- a/apps/partner-ui/src/routes/orders/order-detail/components/order-fulfillment-section/order-fulfillment-section.tsx
+++ b/apps/partner-ui/src/routes/orders/order-detail/components/order-fulfillment-section/order-fulfillment-section.tsx
@@ -7,6 +7,7 @@ import {
   OrderLineItemDTO,
 } from "@medusajs/types"
 import {
+  Badge,
   Button,
   Container,
   Copy,
@@ -558,6 +559,48 @@ const Fulfillment = ({
           {formatProvider(fulfillment.provider_id)}
         </Text>
       </div>
+      {/* Auto-selected carrier courier + quoted rate (#1116 / #1118 partner
+          parity) — sourced from the fulfillment's stamped provider_refs, so no
+          extra fetch. Only shown once the carrier flow has resolved a courier. */}
+      {(() => {
+        const refs = (fulfillment as any).data?.provider_refs
+        const courierName: string | undefined = refs?.courier_name
+        const rate = refs?.courier_rate
+        const hasRate = rate != null && Number.isFinite(Number(rate))
+        const isInternational = !!refs?.international
+        if (!courierName && !hasRate && !isInternational) return null
+        return (
+          <div className="text-ui-fg-subtle grid grid-cols-2 items-center px-6 py-4">
+            <Text size="small" leading="compact" weight="plus">
+              Courier
+            </Text>
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+              {courierName && (
+                <Text size="small" leading="compact">
+                  {courierName}
+                </Text>
+              )}
+              {isInternational && (
+                <Badge size="2xsmall" color="purple">
+                  International
+                </Badge>
+              )}
+              {hasRate && (
+                <Text
+                  size="small"
+                  leading="compact"
+                  className="text-ui-fg-muted"
+                >
+                  {getLocaleAmount(
+                    Number(rate),
+                    refs?.courier_rate_currency || order.currency_code
+                  )}
+                </Text>
+              )}
+            </div>
+          </div>
+        )
+      })()}
       <div className="text-ui-fg-subtle grid grid-cols-2 items-start px-6 py-4">
         <Text size="small" leading="compact" weight="plus">
           {t("orders.fulfillment.trackingLabel")}

--- a/e2e/helpers/e2e-seed.ts
+++ b/e2e/helpers/e2e-seed.ts
@@ -1,9 +1,6 @@
 import { ExecArgs } from "@medusajs/framework/types"
 import { Modules, ContainerRegistrationKeys } from "@medusajs/framework/utils"
-import {
-  createOrderWorkflow,
-  createOrderFulfillmentWorkflow,
-} from "@medusajs/medusa/core-flows"
+import { createOrderFulfillmentWorkflow } from "@medusajs/medusa/core-flows"
 import Scrypt from "scrypt-kdf"
 import * as fs from "fs"
 import * as path from "path"
@@ -40,28 +37,43 @@ async function seedShipmentTrackingOrder(container: any): Promise<string> {
   }
   const countryCode = region.countries?.[0]?.iso_2 || "gb"
 
-  const { result: order }: any = await createOrderWorkflow(container).run({
-    input: {
-      status: "pending",
-      region_id: region.id,
-      currency_code: region.currency_code,
-      sales_channel_id: salesChannelId,
-      email: "e2e-buyer@jyt.test",
-      shipping_address: {
-        first_name: "Elena",
-        last_name: "Doe",
-        address_1: "9 Buyer Rd",
-        city: "London",
-        postal_code: "EC1A 1BB",
-        country_code: countryCode,
-        phone: "8887776665",
-      },
-      // Title-only line item (no variant) — same shape as design-order converts,
-      // which avoids inventory lookups and still fulfills via the manual path.
-      items: [{ title: "Tangaliya Stole (e2e)", quantity: 1, unit_price: 1500 }],
-      metadata: { source: "e2e-shipment-tracking" },
-    } as any,
+  // Create the order via the order module directly rather than
+  // createOrderWorkflow: the workflow runs an update-order-tax-lines step that
+  // resolves a tax provider for the region, which is unconfigured on a fresh CI
+  // DB ("tax provider with id: null"). A fixture order needs no tax lines, and
+  // the fulfillment still goes through the proper workflow below.
+  const orderModule: any = container.resolve(Modules.ORDER)
+  const created: any = await orderModule.createOrders({
+    status: "pending",
+    region_id: region.id,
+    currency_code: region.currency_code,
+    sales_channel_id: salesChannelId,
+    email: "e2e-buyer@jyt.test",
+    shipping_address: {
+      first_name: "Elena",
+      last_name: "Doe",
+      address_1: "9 Buyer Rd",
+      city: "London",
+      postal_code: "EC1A 1BB",
+      country_code: countryCode,
+      phone: "8887776665",
+    },
+    // Title-only line item (no variant) — same shape as design-order converts,
+    // which avoids inventory lookups and still fulfills via the manual path.
+    items: [{ title: "Tangaliya Stole (e2e)", quantity: 1, unit_price: 1500 }],
+    metadata: { source: "e2e-shipment-tracking" },
   })
+  const order = Array.isArray(created) ? created[0] : created
+
+  // Line-item ids for the fulfillment (read back — createOrders' return shape
+  // for nested items isn't relied upon).
+  const { data: withItems } = await query.graph({
+    entity: "order",
+    fields: ["id", "items.id"],
+    filters: { id: order.id },
+  })
+  const itemId = withItems?.[0]?.items?.[0]?.id
+  if (!itemId) throw new Error("E2E seed: order line item not created")
 
   // Resolve a manual shipping option (with a stock location) for the plain
   // fulfillment — identical selection to resolvePlainFulfillmentContext.
@@ -84,7 +96,7 @@ async function seedShipmentTrackingOrder(container: any): Promise<string> {
   await createOrderFulfillmentWorkflow(container).run({
     input: {
       order_id: order.id,
-      items: [{ id: order.items[0].id, quantity: 1 }],
+      items: [{ id: itemId, quantity: 1 }],
       shipping_option_id: manual.id,
       location_id: manual.service_zone?.fulfillment_set?.location?.id,
       no_notification: true,

--- a/e2e/helpers/e2e-seed.ts
+++ b/e2e/helpers/e2e-seed.ts
@@ -1,8 +1,142 @@
 import { ExecArgs } from "@medusajs/framework/types"
 import { Modules, ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import {
+  createOrderWorkflow,
+  createOrderFulfillmentWorkflow,
+} from "@medusajs/medusa/core-flows"
 import Scrypt from "scrypt-kdf"
 import * as fs from "fs"
 import * as path from "path"
+
+const E2E_AWB = "E2EAWB1234567"
+
+/**
+ * #1118 — seed a retail order whose fulfillment carries a Shiprocket shipment
+ * blob, so the order-detail "Shipping & Tracking" widget can be exercised in
+ * CI (the browser heavy-lifting Playwright does headlessly). Reuses the demo
+ * commerce infra (region / sales channel / manual shipping option / product)
+ * created by `src/scripts/seed.ts`, which the e2e:seed step runs first. Mirrors
+ * the plain-fulfillment path in `workflows/orders/fulfillment-context.ts`, then
+ * stamps the carrier refs the real Shiprocket flow persists onto
+ * `fulfillment.data` (#1116 courier_rate, #1117 tracking_events).
+ */
+async function seedShipmentTrackingOrder(container: any): Promise<string> {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+
+  const { data: regions } = await query.graph({
+    entity: "region",
+    fields: ["id", "currency_code", "countries.iso_2"],
+  })
+  const region = regions?.[0]
+  const { data: channels } = await query.graph({
+    entity: "sales_channel",
+    fields: ["id"],
+  })
+  const salesChannelId = channels?.[0]?.id
+  if (!region || !salesChannelId) {
+    throw new Error(
+      "E2E seed: no region/sales channel found. Run the demo seed first: `medusa exec ./src/scripts/seed.ts`."
+    )
+  }
+  const countryCode = region.countries?.[0]?.iso_2 || "gb"
+
+  const { result: order }: any = await createOrderWorkflow(container).run({
+    input: {
+      status: "pending",
+      region_id: region.id,
+      currency_code: region.currency_code,
+      sales_channel_id: salesChannelId,
+      email: "e2e-buyer@jyt.test",
+      shipping_address: {
+        first_name: "Elena",
+        last_name: "Doe",
+        address_1: "9 Buyer Rd",
+        city: "London",
+        postal_code: "EC1A 1BB",
+        country_code: countryCode,
+        phone: "8887776665",
+      },
+      // Title-only line item (no variant) — same shape as design-order converts,
+      // which avoids inventory lookups and still fulfills via the manual path.
+      items: [{ title: "Tangaliya Stole (e2e)", quantity: 1, unit_price: 1500 }],
+      metadata: { source: "e2e-shipment-tracking" },
+    } as any,
+  })
+
+  // Resolve a manual shipping option (with a stock location) for the plain
+  // fulfillment — identical selection to resolvePlainFulfillmentContext.
+  const { data: opts } = await query.graph({
+    entity: "shipping_option",
+    fields: ["id", "provider_id", "service_zone.fulfillment_set.location.id"],
+  })
+  const isManual = (o: any) =>
+    typeof o?.provider_id === "string" && o.provider_id.startsWith("manual")
+  const manual =
+    (opts || []).find(
+      (o: any) => isManual(o) && o.service_zone?.fulfillment_set?.location?.id
+    ) || (opts || []).find(isManual)
+  if (!manual) {
+    throw new Error(
+      "E2E seed: no manual shipping option found. Run the demo seed first."
+    )
+  }
+
+  await createOrderFulfillmentWorkflow(container).run({
+    input: {
+      order_id: order.id,
+      items: [{ id: order.items[0].id, quantity: 1 }],
+      shipping_option_id: manual.id,
+      location_id: manual.service_zone?.fulfillment_set?.location?.id,
+      no_notification: true,
+    } as any,
+  })
+
+  const { data: refetched } = await query.graph({
+    entity: "order",
+    fields: ["fulfillments.id"],
+    filters: { id: order.id },
+  })
+  const fulfillmentId = refetched?.[0]?.fulfillments?.[0]?.id
+  if (!fulfillmentId) throw new Error("E2E seed: fulfillment not created")
+
+  const now = new Date().toISOString()
+  const fulfillmentModule = container.resolve(Modules.FULFILLMENT)
+  await fulfillmentModule.updateFulfillment(fulfillmentId, {
+    data: {
+      carrier: "shiprocket",
+      waybill: E2E_AWB,
+      tracking_number: E2E_AWB,
+      tracking_url: `https://shiprocket.co/tracking/${E2E_AWB}`,
+      label_url: "https://sr-core-cdn.shiprocket.in/label/e2e.pdf",
+      current_status: "In Transit",
+      shipment_id: 999001,
+      sr_order_id: 999002,
+      provider_refs: {
+        shipment_id: 999001,
+        sr_order_id: 999002,
+        courier_name: "Xpressbees Surface",
+        // #1116 S3 — auto-selected international courier's quoted rate.
+        courier_rate: 845.5,
+        courier_rate_currency: "INR",
+        international: true,
+      },
+      // #1117 — carrier webhook scan history (oldest first).
+      tracking_events: [
+        { at: null, received_at: now, status: "Pickup Scheduled", status_code: 42, location: "Surendranagar" },
+        { at: null, received_at: now, status: "In Transit", status_code: 18, location: "Ahmedabad Hub" },
+      ],
+    },
+    labels: [
+      {
+        tracking_number: E2E_AWB,
+        tracking_url: `https://shiprocket.co/tracking/${E2E_AWB}`,
+        label_url: "https://sr-core-cdn.shiprocket.in/label/e2e.pdf",
+      },
+    ],
+  })
+
+  return order.id
+}
 
 const SEED_PASSWORD = "e2etest123!"
 const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
@@ -102,11 +236,15 @@ export default async function e2eSeed({ container }: ExecArgs) {
   }
   await socials.createGoogleSearchConsoleInsights(rows)
 
+  logger.info("E2E seed: creating retail order with Shiprocket shipment (#1118)...")
+  const shipmentOrderId = await seedShipmentTrackingOrder(container)
+
   const seedData = {
     email,
     password: SEED_PASSWORD,
     websiteId: website.id,
     domain,
+    shipmentOrderId,
   }
 
   fs.writeFileSync(SEED_FILE, JSON.stringify(seedData, null, 2))

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -10,6 +10,11 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   workers: 1,
   reporter: process.env.CI ? "github" : "list",
+  // On CI the admin bundle is compiled lazily by `medusa develop` on the first
+  // request to /app, so the first navigation can take far longer than a warm
+  // local dev server. Give tests (and assertions) generous headroom there.
+  timeout: process.env.CI ? 120_000 : 30_000,
+  expect: { timeout: process.env.CI ? 15_000 : 5_000 },
 
   webServer: {
     command: `pnpm exec medusa develop`,

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -15,6 +15,10 @@ export default defineConfig({
   // local dev server. Give tests (and assertions) generous headroom there.
   timeout: process.env.CI ? 120_000 : 30_000,
   expect: { timeout: process.env.CI ? 15_000 : 5_000 },
+  // This config only boots the admin (`medusa develop` on :9000). Specs that
+  // need the partner-ui (:5173) or a live LLM are tagged `@partnerui` and run
+  // only locally — skip them on CI so a shared admin e2e stays deterministic.
+  grepInvert: process.env.CI ? /@partnerui/ : undefined,
 
   webServer: {
     command: `pnpm exec medusa develop`,

--- a/e2e/specs/order-shipment-tracking.spec.ts
+++ b/e2e/specs/order-shipment-tracking.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "@playwright/test"
+import * as fs from "fs"
+import * as path from "path"
+
+const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
+
+// #1118 — the admin order-detail "Shipping & Tracking" widget surfaces the
+// Shiprocket shipment: auto-selected courier + quoted rate (#1116) and the
+// tracking timeline (#1117). Drives it headlessly against the seeded retail
+// order so CI does the browser verification.
+test.describe("Order shipment tracking widget (#1118)", () => {
+  let seed: { email: string; password: string; shipmentOrderId: string }
+
+  test.beforeAll(() => {
+    if (!fs.existsSync(SEED_FILE)) {
+      throw new Error(
+        `E2E seed file not found at ${SEED_FILE}. Run "pnpm e2e:seed" first.`
+      )
+    }
+    seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
+    if (!seed.shipmentOrderId) {
+      throw new Error("E2E seed missing shipmentOrderId — re-run the seed.")
+    }
+  })
+
+  test("renders the Shipping & Tracking panel with courier, rate and timeline", async ({
+    page,
+  }) => {
+    // Log in via the admin UI.
+    await page.goto("/app/login")
+    await page.waitForLoadState("networkidle")
+    await page.locator('input[name="email"]').fill(seed.email)
+    await page.locator('input[name="password"]').fill(seed.password)
+    await page.locator('button[type="submit"]').click()
+    await page.waitForURL(/\/app\/(?!login)/, { timeout: 15000 })
+
+    // Open the seeded order's detail page.
+    await page.goto(`/app/orders/${seed.shipmentOrderId}`)
+    await page.waitForLoadState("networkidle")
+
+    // The widget heading is present.
+    await expect(
+      page.getByText("Shipping & Tracking", { exact: true }).first()
+    ).toBeVisible({ timeout: 15000 })
+
+    // Auto-selected courier + the international badge.
+    await expect(page.getByText("Xpressbees Surface").first()).toBeVisible()
+    await expect(page.getByText("International", { exact: true }).first()).toBeVisible()
+
+    // Quoted courier rate (#1116). Assert on the amount to stay locale-tolerant.
+    await expect(page.getByText(/Rate:/).first()).toBeVisible()
+    await expect(page.getByText(/845\.5/).first()).toBeVisible()
+
+    // AWB is shown.
+    await expect(page.getByText("E2EAWB1234567").first()).toBeVisible()
+
+    // Tracking timeline (#1117): collapsed toggle shows the event count; expand it.
+    const toggle = page.getByText(/Tracking history \(2\)/).first()
+    await expect(toggle).toBeVisible()
+    await toggle.click()
+    await expect(page.getByText(/Pickup Scheduled/).first()).toBeVisible()
+    await expect(page.getByText(/In Transit/).first()).toBeVisible()
+  })
+})

--- a/e2e/specs/theme-editor-chat.spec.ts
+++ b/e2e/specs/theme-editor-chat.spec.ts
@@ -17,7 +17,9 @@ import { test, expect } from "@playwright/test"
 const PARTNER_EMAIL = "theme-test-1783505047@medusa-test.com"
 const PARTNER_PASSWORD = "supersecret"
 
-test.describe("Theme Editor LLM Chat (#339)", () => {
+// @partnerui — needs the partner-ui dev server (:5173) + a live LLM; runs
+// locally only, excluded from the admin e2e CI job (see playwright.config.ts).
+test.describe("Theme Editor LLM Chat (#339) @partnerui", () => {
   test.beforeEach(async ({ page }) => {
     // Login via the partner-ui
     await page.goto("http://localhost:5173/login")


### PR DESCRIPTION
Closes the #1118 UI/ops tail: surface the international-Shiprocket shipment (courier + quoted rate from #1116, tracking timeline from #1117) in both the **admin** and **partner** order views, and move the browser verification into the Playwright e2e harness so **CI does the heavy lifting headlessly**.

## What's in
- **Admin widget** (`order-shipment-tracking.tsx`, `order.details.after`) — StatusBadge, auto-selected courier + rate, International badge, AWB + `Copy`, Label button, collapsible tracking timeline. Pure Medusa UI primitives. Verified live locally (headless Chromium) against a seeded order.
- **Partner parity** — a Courier row (name + International badge + quoted rate) on the partner order fulfillment section, from the already-fetched `provider_refs`. No extra fetch.
- **e2e in CI** — new `e2e.yml` boots a real `medusa develop` server on fresh Postgres (migrate → demo seed → fixture admin+order), then a new spec drives `/app` and asserts the widget. Seed extended to build a retail order with a Shiprocket-shipped fulfillment (intl + rate + 2 tracking scans).
- **Pre-existing build fix** — `analytics-search-discovery-card.tsx` imported `Tooltip` from both `@medusajs/ui` and `recharts` (duplicate declaration → **broke the whole admin bundle**). Aliased the recharts one.

## Verify
- Local: `pnpm --filter @jyt/backend e2e:test order-shipment-tracking` → passes (screenshot in PR thread).
- CI: the new **E2E (admin UI)** workflow runs this end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)