### PR TITLE
feat(production-runs): retail fulfillment → product-only run + design trail [#1112]

### DIFF
--- a/apps/backend/integration-tests/http/order-fulfillment-production-runs.spec.ts
+++ b/apps/backend/integration-tests/http/order-fulfillment-production-runs.spec.ts
@@ -1,0 +1,276 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { IOrderModuleService, IRegionModuleService } from "@medusajs/types"
+
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { seedCommonEmailTemplates } from "../helpers/seed-email-templates"
+import { setupCheckoutInfrastructure } from "../helpers/setup-checkout-infrastructure"
+import { ensureOrderFulfillment } from "../../src/workflows/orders/fulfillment-context"
+import orderPlacedHandler from "../../src/subscribers/order-placed"
+import orderFulfilledHandler from "../../src/subscribers/order-fullfilled"
+
+jest.setTimeout(60 * 1000)
+
+// #1112 — fulfillment-triggered provenance runs. A product sold and fulfilled
+// from produced stock retroactively mints a COMPLETED production run hung off
+// the Product spine, EVEN WHEN the product has no backing design (product-only
+// path). Shares idempotency with the payment (order.placed) path.
+setupSharedTestSuite(() => {
+  describe("order.fulfillment_created subscriber → production runs", () => {
+    let adminHeaders: { headers: Record<string, string> }
+    let regionId: string
+
+    beforeAll(async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+      await seedCommonEmailTemplates(api, adminHeaders)
+
+      // Fulfillment needs a shipping option + stock location, absent on the
+      // fresh shared DB. Reuse the same infra the checkout/shiprocket tests do.
+      const regionsRes = await api.get("/admin/regions", adminHeaders)
+      if (regionsRes.data.regions?.length > 0) {
+        regionId = regionsRes.data.regions[0].id
+      } else {
+        const regionService = container.resolve(
+          Modules.REGION
+        ) as IRegionModuleService
+        const region = await regionService.createRegions({
+          name: "Fulfillment Runs Region",
+          currency_code: "usd",
+          countries: ["us"],
+        })
+        regionId = region.id
+      }
+      await setupCheckoutInfrastructure(container, regionId)
+    })
+
+    // Create a product; optionally link a design. Returns the product id.
+    const createProduct = async (
+      api: any,
+      unique: string | number,
+      suffix: string,
+      designId?: string
+    ) => {
+      const res = await api.post(
+        "/admin/products",
+        {
+          title: `Fulfill Product ${suffix} ${unique}`,
+          status: "published",
+          handle: `fulfill-prod-${suffix}-${unique}`,
+          options: [{ title: "Default", values: ["Default"] }],
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      const productId = res.data.product.id
+      if (designId) {
+        const linkRes = await api.post(
+          `/admin/products/${productId}/linkDesign`,
+          { designId },
+          adminHeaders
+        )
+        expect(linkRes.status).toBe(200)
+      }
+      return productId
+    }
+
+    // Create an order (not yet fulfilled) with the given product line items.
+    const createOrder = async (
+      container: any,
+      unique: number,
+      productIds: string[]
+    ) => {
+      const orderService = container.resolve(
+        Modules.ORDER
+      ) as IOrderModuleService
+      const createdOrder: any = await orderService.createOrders({
+        region_id: regionId,
+        currency_code: "usd",
+        email: `fulfill-${unique}@jyt.test`,
+        // Title-only line items carrying product_id (no variant → no inventory
+        // reservation, so the manual fulfillment path just works — same shape
+        // the order-placed subscriber test uses).
+        items: productIds.map((pid, i) => ({
+          title: `Line ${i}`,
+          quantity: i + 1,
+          unit_price: 1000,
+          product_id: pid,
+        })),
+      } as any)
+      return createdOrder.id as string
+    }
+
+    // Fulfill the whole order via the shared helper (resolves shipping option +
+    // location). This emits `order.fulfillment_created`, firing the real
+    // subscriber. Returns the fulfillment id.
+    const fulfillOrder = async (container: any, orderId: string) => {
+      const fulfillmentId = await ensureOrderFulfillment(container, orderId)
+      if (!fulfillmentId) throw new Error("fulfillment not created")
+      return fulfillmentId
+    }
+
+    const createAndFulfillOrder = async (
+      container: any,
+      unique: number,
+      productIds: string[]
+    ) => {
+      const orderId = await createOrder(container, unique, productIds)
+      const fulfillmentId = await fulfillOrder(container, orderId)
+      return { orderId, fulfillmentId }
+    }
+
+    // The real `order.fulfillment_created` subscriber fires (async) when
+    // ensureOrderFulfillment emits the event — poll until the runs settle.
+    const waitForRuns = async (
+      query: any,
+      orderId: string,
+      expected: number,
+      fields: string[] = ["id"]
+    ) => {
+      let runs: any[] = []
+      for (let i = 0; i < 40; i++) {
+        const { data } = await query.graph({
+          entity: "production_runs",
+          fields,
+          filters: { order_id: orderId },
+        })
+        runs = data || []
+        if (runs.length >= expected) {
+          break
+        }
+        await new Promise((r) => setTimeout(r, 150))
+      }
+      return runs
+    }
+
+    it("mints a COMPLETED product-only run (design_id null) linked to the product for a design-less product", async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      const container = getContainer()
+      const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+      const unique = Date.now()
+
+      const productId = await createProduct(api, unique, "solo")
+      const { orderId, fulfillmentId } = await createAndFulfillOrder(
+        container,
+        unique,
+        [productId]
+      )
+
+      // The real subscriber (fired by the fulfillment event) mints the run.
+      const runs = await waitForRuns(query, orderId, 1, [
+        "id",
+        "design_id",
+        "order_id",
+        "order_line_item_id",
+        "product_id",
+        "quantity",
+        "produced_quantity",
+        "status",
+      ])
+      expect(runs.length).toBe(1)
+      const run = runs[0]
+      expect(run.design_id).toBeNull()
+      expect(run.product_id).toBe(productId)
+      expect(run.order_id).toBe(orderId)
+      expect(run.status).toBe("completed")
+      expect(run.produced_quantity).toBe(1)
+
+      // Provenance trail is queryable FROM the product spine via the new link.
+      const { data: prods } = await query.graph({
+        entity: "product",
+        fields: ["id", "production_runs.id", "production_runs.status"],
+        filters: { id: productId },
+      })
+      const linkedRuns = prods?.[0]?.production_runs || []
+      expect(linkedRuns.map((r: any) => r.id)).toContain(run.id)
+
+      // Idempotency: re-firing the handler directly must not double-create
+      // (the run already exists → shared line-item guard skips it).
+      await orderFulfilledHandler({
+        event: {
+          data: { order_id: orderId, fulfillment_id: fulfillmentId, no_notification: true },
+        },
+        container,
+      } as any)
+      const { data: runs2 } = await query.graph({
+        entity: "production_runs",
+        fields: ["id"],
+        filters: { order_id: orderId },
+      })
+      expect((runs2 || []).length).toBe(1)
+    })
+
+    it("does not double-create when order.placed already minted a run for a design-backed line", async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      const container = getContainer()
+      const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+      const unique = Date.now() + 1
+
+      // A design-backed product (order.placed will mint its run at payment) and
+      // a design-less product (only the fulfillment path can mint its run).
+      const designRes = await api.post(
+        "/admin/designs",
+        {
+          name: `Fulfill Design ${unique}`,
+          description: "fulfillment idempotency test",
+          design_type: "Original",
+          status: "Commerce_Ready",
+          priority: "Medium",
+        },
+        adminHeaders
+      )
+      expect(designRes.status).toBe(201)
+      const designId = designRes.data.design.id
+
+      const linkedProductId = await createProduct(api, unique, "linked", designId)
+      const bareProductId = await createProduct(api, unique, "bare")
+
+      // Real-world order: payment (order.placed) BEFORE fulfillment. Create the
+      // order, then run the payment path — it mints a pending_review run for the
+      // design-backed line only.
+      const orderId = await createOrder(container, unique, [
+        linkedProductId,
+        bareProductId,
+      ])
+      await orderPlacedHandler({
+        event: { data: { id: orderId } },
+        container,
+      } as any)
+
+      const { data: afterPlaced } = await query.graph({
+        entity: "production_runs",
+        fields: ["id", "product_id", "status", "design_id"],
+        filters: { order_id: orderId },
+      })
+      const placedRuns = afterPlaced || []
+      expect(placedRuns.length).toBe(1)
+      expect(placedRuns[0].product_id).toBe(linkedProductId)
+      expect(placedRuns[0].status).toBe("pending_review")
+      const linkedRunId = placedRuns[0].id
+
+      // Now fulfill — the real fulfillment subscriber must SKIP the linked line
+      // (already has a run) and mint only the bare product's completed run.
+      await fulfillOrder(container, orderId)
+
+      const runs = await waitForRuns(query, orderId, 2, [
+        "id",
+        "product_id",
+        "status",
+        "design_id",
+      ])
+      expect(runs.length).toBe(2)
+
+      // The design-backed run is untouched (same id, still pending_review).
+      const linkedRun = runs.find((r: any) => r.product_id === linkedProductId)
+      expect(linkedRun.id).toBe(linkedRunId)
+      expect(linkedRun.status).toBe("pending_review")
+
+      // The bare product got a completed product-only run.
+      const bareRun = runs.find((r: any) => r.product_id === bareProductId)
+      expect(bareRun.design_id).toBeNull()
+      expect(bareRun.status).toBe("completed")
+    })
+  })
+})

--- a/apps/backend/src/admin/widgets/product-designs.tsx
+++ b/apps/backend/src/admin/widgets/product-designs.tsx
@@ -178,6 +178,66 @@ function DesignAdminProductionRunsSection({ designId }: { designId: string }) {
   )
 }
 
+// #1112 — product-only production runs (design_id null) minted retroactively on
+// retail fulfillment. They hang off the PRODUCT spine (product↔production_run
+// link), not a design, so they'd otherwise be invisible on this page. Shown as
+// the product's "design trail" — the runs that produced sold-and-fulfilled
+// stock. Design-backed runs are excluded here (they already appear under their
+// design above), so there's no double-listing.
+function ProductProvenanceRunsSection({ productId }: { productId: string }) {
+  const navigate = useNavigate()
+  const { production_runs: runs = [], isLoading } = useProductionRuns({
+    product_id: productId,
+    limit: 50,
+  })
+
+  if (isLoading) return null
+
+  const productOnly = (runs as AdminProductionRun[]).filter((r) => !r.design_id)
+  if (!productOnly.length) return null
+
+  return (
+    <div className="flex flex-col gap-y-3 px-6 py-4">
+      <div className="flex items-center gap-x-2">
+        <Text size="small" weight="plus">Production Runs</Text>
+        <Badge size="2xsmall" color="grey">{productOnly.length}</Badge>
+        <Text size="xsmall" className="text-ui-fg-muted">from fulfilled orders</Text>
+      </div>
+
+      <div className="flex flex-col divide-y divide-ui-border-base rounded-lg border border-ui-border-base overflow-hidden">
+        <div className="grid grid-cols-3 px-3 py-1.5 bg-ui-bg-subtle">
+          <Text size="xsmall" weight="plus" className="text-ui-fg-subtle">Status</Text>
+          <Text size="xsmall" weight="plus" className="text-ui-fg-subtle">Order</Text>
+          <Text size="xsmall" weight="plus" className="text-ui-fg-subtle text-right">Produced</Text>
+        </div>
+        {productOnly.map((run) => (
+          <div key={run.id} className="grid grid-cols-3 px-3 py-2 items-center">
+            <StatusBadge color={RUN_STATUS_COLOR[run.status ?? ""] ?? "grey"}>
+              {runStatusLabel(run.status ?? "")}
+            </StatusBadge>
+            {run.order_id ? (
+              <button
+                type="button"
+                onClick={() => navigate(`/orders/${run.order_id}`)}
+                className="text-left"
+              >
+                <Text size="xsmall" className="text-ui-fg-interactive truncate">
+                  {run.order_id.slice(0, 14)}…
+                </Text>
+              </button>
+            ) : (
+              <Text size="xsmall" className="text-ui-fg-muted">—</Text>
+            )}
+            <Text size="xsmall" className="text-right">
+              {(run.produced_quantity ?? run.quantity ?? 0).toLocaleString()}
+            </Text>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 const ProductDesignsWidget = ({ data }: DetailWidgetProps<AdminProduct>) => {
   const navigate = useNavigate()
   const prompt = usePrompt()

--- a/apps/backend/src/api/admin/production-runs/route.ts
+++ b/apps/backend/src/api/admin/production-runs/route.ts
@@ -172,6 +172,12 @@ export const GET = async (req: MedusaRequest, res: MedusaResponse) => {
   if (q.design_id) {
     filters.design_id = q.design_id
   }
+  // #1112 — filter by product so the product-detail widget can render the
+  // full production-run "design trail" hung off the product spine, INCLUDING
+  // product-only runs (design_id null) minted on retail fulfillment.
+  if (q.product_id) {
+    filters.product_id = q.product_id
+  }
   // #826 — filter by the commissioning order so the admin design-order detail
   // can list all the per-design runs a produce fanned out for that one order.
   if (q.order_id) {

--- a/apps/backend/src/lib/resolve-line-item-production.ts
+++ b/apps/backend/src/lib/resolve-line-item-production.ts
@@ -1,0 +1,65 @@
+// #1112 — shared traversal for resolving a retail order line item to its
+// backing design (if any) and the idempotency guard both the payment
+// (`order.placed`) and fulfillment (`order.fulfillment_created`) run-creation
+// paths use. Keeping it in one place guarantees the two paths agree so they
+// never double-create a run for the same line item.
+
+export type ResolvedLineItemDesign = {
+  designId: string | null
+  isCustomDesign: boolean
+}
+
+/**
+ * Resolve the design linked to a line item — variant-level link (custom designs
+ * from the design editor) takes priority over the product-level link.
+ */
+export async function resolveLineItemDesignId(
+  query: any,
+  { productId, variantId }: { productId?: string | null; variantId?: string | null }
+): Promise<ResolvedLineItemDesign> {
+  let designId: string | null = null
+  let isCustomDesign = false
+
+  if (variantId) {
+    const { data: variantDesignLinks } = await query.graph({
+      entity: "design_product_variant",
+      fields: ["design_id"],
+      filters: { product_variant_id: variantId },
+      pagination: { skip: 0, take: 1 },
+    })
+    const variantLink = (variantDesignLinks || [])[0]
+    if (variantLink?.design_id) {
+      designId = variantLink.design_id
+      isCustomDesign = true
+    }
+  }
+
+  if (!designId && productId) {
+    const { data: productDesignLinks } = await query.graph({
+      entity: "product_design",
+      fields: ["design.*"],
+      filters: { product_id: productId },
+      pagination: { skip: 0, take: 1 },
+    })
+    designId = (productDesignLinks || [])[0]?.design?.id || null
+  }
+
+  return { designId, isCustomDesign }
+}
+
+/**
+ * Idempotency guard shared by both run-creation paths: true when a production
+ * run already exists for this line item (regardless of which path created it).
+ */
+export async function hasProductionRunForLineItem(
+  query: any,
+  lineItemId: string
+): Promise<boolean> {
+  const { data: existing } = await query.graph({
+    entity: "production_runs",
+    fields: ["id"],
+    filters: { order_line_item_id: lineItemId },
+    pagination: { skip: 0, take: 1 },
+  })
+  return (existing || []).length > 0
+}

--- a/apps/backend/src/links/product-production-run.ts
+++ b/apps/backend/src/links/product-production-run.ts
@@ -1,0 +1,24 @@
+import { defineLink } from "@medusajs/framework/utils"
+import ProductModule from "@medusajs/medusa/product"
+import ProductionRunsModule from "../modules/production_runs"
+
+// #1112 — the Product spine ↔ its production_run(s). This is the provenance /
+// "design trail" pointer queryable FROM the product: a product sold and
+// fulfilled from produced stock carries the (completed) run that made it.
+//
+// One product → many runs (isList on the run side); a run belongs to at most
+// one product (the run's `product_id` column). Complements the existing
+// `order ↔ production_run` link (order-production-run.ts) — that one
+// discriminates design work-orders; THIS one hangs runs off the product so
+// admin/partner UIs can render the trail without a bespoke design.
+//
+// MANAGED (pivot-table) link → bidirectional in query.graph:
+//   forward: `product.production_runs`   (plural, auto-derived)
+//   reverse: `production_runs.product`
+export default defineLink(
+  ProductModule.linkable.product,
+  {
+    linkable: ProductionRunsModule.linkable.productionRuns,
+    isList: true,
+  }
+)

--- a/apps/backend/src/modules/production_runs/migrations/Migration20260721160000.ts
+++ b/apps/backend/src/modules/production_runs/migrations/Migration20260721160000.ts
@@ -1,0 +1,28 @@
+import { Migration } from "@medusajs/framework/mikro-orm/migrations";
+
+/**
+ * #1112 — retail-order → production run (product-as-spine provenance).
+ *
+ * Relaxes `production_runs.design_id` to nullable so a retail-fulfillment run
+ * can be minted for a product with NO backing design (the product-only path).
+ * Design work-orders continue to set it; `createProductionRunWorkflow` branches
+ * on presence.
+ *
+ * Hand-written incremental ALTER (the generator emits a full snapshot, a no-op
+ * on the existing prod table). See memory
+ * `reference_medusa_migration_create_if_not_exists_hazard`.
+ */
+export class Migration20260721160000 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(
+      `alter table if exists "production_runs" alter column "design_id" drop not null;`
+    );
+  }
+
+  override async down(): Promise<void> {
+    // Best-effort restore: only valid when no product-only rows exist.
+    this.addSql(
+      `alter table if exists "production_runs" alter column "design_id" set not null;`
+    );
+  }
+}

--- a/apps/backend/src/modules/production_runs/models/production-run.ts
+++ b/apps/backend/src/modules/production_runs/models/production-run.ts
@@ -19,7 +19,10 @@ const ProductionRun = model.define("production_runs", {
   parent_run_id: model.text().nullable(),
   role: model.text().nullable(),
 
-  design_id: model.text(),
+  // #1112 — nullable so a retail-fulfillment provenance run can be minted for a
+  // product with NO backing design (product-only path). Design work-orders still
+  // set it; the create workflow branches on its presence.
+  design_id: model.text().nullable(),
   partner_id: model.text().nullable(),
 
   // Roadmap #6 Phase 4 — how the run is executed:

--- a/apps/backend/src/subscribers/order-fullfilled.ts
+++ b/apps/backend/src/subscribers/order-fullfilled.ts
@@ -3,6 +3,116 @@ import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import type { Logger } from "@medusajs/types"
 import { sendOrderFulfillmentEmail } from "../workflows/email/send-notification-email"
 import { sendPartnerOrderFulfilledWorkflow } from "../workflows/email/workflows/send-partner-order-email"
+import { createProductionRunWorkflow } from "../workflows/production-runs/create-production-run"
+import {
+  hasProductionRunForLineItem,
+  resolveLineItemDesignId,
+} from "../lib/resolve-line-item-production"
+
+// #1112 — "fulfilled from produced stock" ⇒ retroactively mint a COMPLETED
+// production run per fulfilled line item, hung off the Product spine, carrying
+// order/partner provenance. Runs on `order.fulfillment_created` (the intent
+// signal). Idempotent with the payment path (`order.placed`) via the shared
+// `order_line_item_id` guard, so design-backed products (whose run was already
+// created at payment) are skipped here and never double-created.
+async function createFulfillmentProductionRuns(
+  container: SubscriberArgs<any>["container"],
+  data: { order_id: string; fulfillment_id: string },
+  logger: Logger
+): Promise<void> {
+  try {
+    const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+
+    // Which line items (and how many) did THIS fulfillment cover.
+    const { data: fulfillments } = await query.graph({
+      entity: "fulfillment",
+      fields: ["id", "items.line_item_id", "items.quantity"],
+      filters: { id: data.fulfillment_id },
+    })
+    const fulfillment = (fulfillments || [])[0]
+    const fulfilledItems: any[] = (fulfillment?.items || []).filter(
+      (fi: any) => fi?.line_item_id
+    )
+    if (!fulfilledItems.length) {
+      return
+    }
+
+    // Resolve line_item_id → { product_id, variant_id } from the order.
+    const { data: orders } = await query.graph({
+      entity: "order",
+      fields: [
+        "id",
+        "items.id",
+        "items.product_id",
+        "items.variant_id",
+      ],
+      filters: { id: data.order_id },
+    })
+    const order = (orders || [])[0]
+    const itemById = new Map<string, any>(
+      (order?.items || []).map((it: any) => [it.id, it])
+    )
+
+    for (const fi of fulfilledItems) {
+      const lineItemId = fi.line_item_id as string
+      const orderItem = itemById.get(lineItemId)
+      const productId = orderItem?.product_id as string | undefined
+      const variantId = orderItem?.variant_id as string | undefined
+      const quantity = Number(fi.quantity) || 1
+
+      // No product to hang the run off → nothing to provenance.
+      if (!productId) {
+        continue
+      }
+
+      // Shared idempotency with order.placed — skip if a run already exists.
+      if (await hasProductionRunForLineItem(query, lineItemId)) {
+        continue
+      }
+
+      // Reuse the design-resolution traversal; falls through to the product-only
+      // path (design_id null) when the product has no backing design.
+      const { designId, isCustomDesign } = await resolveLineItemDesignId(query, {
+        productId,
+        variantId,
+      })
+
+      await createProductionRunWorkflow(container).run({
+        input: {
+          design_id: designId ?? undefined,
+          quantity,
+          produced_quantity: quantity,
+          product_id: productId,
+          variant_id: variantId,
+          order_id: data.order_id,
+          order_line_item_id: lineItemId,
+          // Born terminal — the goods are already produced & shipping.
+          status: "completed",
+          // Provenance runs are not partner work-orders; don't project them
+          // onto the unified #342 order (would mis-discriminate the retail
+          // order as a design work-order).
+          skip_unified_projection: true,
+          metadata: {
+            source: "order.fulfillment_created",
+            fulfillment_id: data.fulfillment_id,
+            is_custom_design: isCustomDesign,
+            design_backed: Boolean(designId),
+          },
+        },
+      })
+
+      logger.info(
+        `[order.fulfillment_created] Minted ${
+          designId ? "design-backed" : "product-only"
+        } production run for line item ${lineItemId} (product ${productId})`
+      )
+    }
+  } catch (e: any) {
+    logger.warn(
+      `[order.fulfillment_created] Failed to create production runs for order ${data.order_id}: ${e?.message || e}`
+    )
+  }
+}
 
 export default async function orderFulfillment_createdHandler({
   event: { data },
@@ -13,6 +123,9 @@ export default async function orderFulfillment_createdHandler({
   no_notification: boolean
 }>) {
   const logger = container.resolve(ContainerRegistrationKeys.LOGGER) as Logger
+
+  // #1112 — provenance run creation runs regardless of notification suppression.
+  await createFulfillmentProductionRuns(container, data, logger)
 
   // Skip notification if explicitly disabled
   if (data.no_notification) {

--- a/apps/backend/src/subscribers/order-placed.ts
+++ b/apps/backend/src/subscribers/order-placed.ts
@@ -5,6 +5,10 @@ import { sendOrderConfirmationWorkflow } from "../workflows/email/send-notificat
 import { sendPartnerOrderPlacedWorkflow } from "../workflows/email/workflows/send-partner-order-email"
 import { createProductionRunWorkflow } from "../workflows/production-runs/create-production-run"
 import { linkDesignsToOrder } from "../workflows/designs/link-designs-to-order"
+import {
+  hasProductionRunForLineItem,
+  resolveLineItemDesignId,
+} from "../lib/resolve-line-item-production"
 
 export default async function orderPlacedHandler({
   event: { data },
@@ -54,52 +58,21 @@ export default async function orderPlacedHandler({
       }
 
       // Idempotency: if we already created a production run for this line item, skip
-      const { data: existing } = await query.graph({
-        entity: "production_runs",
-        fields: ["id"],
-        filters: { order_line_item_id: lineItemId },
-        pagination: { skip: 0, take: 1 },
-      })
-      const existingRuns = existing || []
-      if (existingRuns.length) {
+      if (await hasProductionRunForLineItem(query, lineItemId)) {
         continue
       }
 
-      let designId: string | null = null
-      let isCustomDesign = false
+      // Resolve the design (variant-level custom design takes priority over the
+      // product-level association). Shared with the fulfillment path (#1112).
+      const { designId, isCustomDesign } = await resolveLineItemDesignId(query, {
+        productId,
+        variantId,
+      })
 
-      // First, check for design-variant link (custom designs created via design editor)
-      // This takes priority as it's a direct link to the specific design
-      if (variantId) {
-        const { data: variantDesignLinks } = await query.graph({
-          entity: "design_product_variant",
-          fields: ["design_id", "customer_id", "estimated_cost"],
-          filters: { product_variant_id: variantId },
-          pagination: { skip: 0, take: 1 },
-        })
-
-        const variantLink = (variantDesignLinks || [])[0]
-        if (variantLink?.design_id) {
-          designId = variantLink.design_id
-          isCustomDesign = true
-          logger.info(
-            `[order.placed] Found custom design ${designId} for variant ${variantId}`
-          )
-        }
-      }
-
-      // If no variant-level link, check product-level link (standard product-design association)
-      if (!designId) {
-        const { data: productDesignLinks } = await query.graph({
-          entity: "product_design",
-          fields: ["design.*"],
-          filters: { product_id: productId },
-          pagination: { skip: 0, take: 1 },
-        })
-
-        const link = (productDesignLinks || [])[0]
-        const design = link?.design
-        designId = design?.id || null
+      if (isCustomDesign) {
+        logger.info(
+          `[order.placed] Found custom design ${designId} for variant ${variantId}`
+        )
       }
 
       if (!designId) {

--- a/apps/backend/src/workflows/production-runs/create-production-run.ts
+++ b/apps/backend/src/workflows/production-runs/create-production-run.ts
@@ -1,4 +1,4 @@
-import { ContainerRegistrationKeys, MedusaError } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, MedusaError, Modules } from "@medusajs/framework/utils"
 import {
   createStep,
   createWorkflow,
@@ -37,9 +37,15 @@ const sanitizeBigInt = (value: any): any => {
 }
 
 export type CreateProductionRunInput = {
-  design_id: string
+  // #1112 — optional so a retail-fulfillment run can be minted from a product
+  // with NO backing design (product-only path). When absent, product_id is
+  // required and the snapshot is built from the product instead of a design.
+  design_id?: string | null
   partner_id?: string | null
   quantity?: number
+  // #1112 — for runs born already-`completed` (retail fulfillment), stamp the
+  // produced yield up front instead of leaving it for the lifecycle to fill.
+  produced_quantity?: number
   run_type?: "production" | "sample"
   product_id?: string
   variant_id?: string
@@ -130,13 +136,90 @@ const fetchDesignInventorySnapshotStep = createStep(
   }
 )
 
+// #1112 — product-only provenance path. When a retail line item resolves to a
+// product with no backing design, snapshot the product spine instead of a
+// design so a run can still be minted (design_id stays null).
+const fetchProductSnapshotStep = createStep(
+  "fetch-product-snapshot",
+  async (input: { product_id?: string }, { container }) => {
+    if (!input.product_id) {
+      return new StepResponse(null)
+    }
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+    const { data } = await query.graph({
+      entity: "product",
+      fields: [
+        "id",
+        "title",
+        "handle",
+        "status",
+        "thumbnail",
+        "subtitle",
+        "metadata",
+      ],
+      filters: { id: input.product_id },
+    })
+
+    const products = data || []
+    if (!products.length) {
+      throw new MedusaError(
+        MedusaError.Types.NOT_FOUND,
+        `Product ${input.product_id} not found`
+      )
+    }
+
+    return new StepResponse(products[0])
+  }
+)
+
+// #1112 — hang the run off the Product spine so the provenance trail is
+// queryable via `product.production_runs`. Idempotent-safe: only fires when a
+// product_id is present.
+const linkProductionRunToProductStep = createStep(
+  "link-production-run-to-product",
+  async (
+    input: { production_run_id: string; product_id?: string },
+    { container }
+  ) => {
+    if (!input.product_id) {
+      return new StepResponse<LinkDefinition | null, LinkDefinition | null>(
+        null,
+        null
+      )
+    }
+
+    const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+    const link: LinkDefinition = {
+      [Modules.PRODUCT]: { product_id: input.product_id },
+      [PRODUCTION_RUNS_MODULE]: {
+        production_runs_id: input.production_run_id,
+      },
+    }
+
+    await remoteLink.create([link])
+    return new StepResponse<LinkDefinition | null, LinkDefinition | null>(
+      link,
+      link
+    )
+  },
+  async (link: LinkDefinition | null, { container }) => {
+    if (!link) {
+      return
+    }
+    const remoteLink = container.resolve(ContainerRegistrationKeys.LINK) as Link
+    await remoteLink.dismiss([link])
+  }
+)
+
 const createProductionRunStep = createStep(
   "create-production-run",
   async (
     input: {
       payload: CreateProductionRunInput
-      design: any
-      inventory: { inventory_links: any[] }
+      design?: any
+      inventory?: { inventory_links: any[] } | null
       captured_at: Date
       snapshot: Record<string, any>
     },
@@ -147,7 +230,7 @@ const createProductionRunStep = createStep(
     )
 
     const created = await productionRunService.createProductionRuns({
-      design_id: input.payload.design_id,
+      design_id: input.payload.design_id ?? null,
       partner_id: input.payload.partner_id ?? null,
       quantity: input.payload.quantity ?? 1,
       run_type: input.payload.run_type ?? "production",
@@ -162,6 +245,9 @@ const createProductionRunStep = createStep(
       // paths keep the model defaults (status=pending_review,
       // execution_mode=in_house).
       ...(input.payload.status ? { status: input.payload.status } : {}),
+      ...(input.payload.produced_quantity !== undefined
+        ? { produced_quantity: input.payload.produced_quantity }
+        : {}),
       ...(input.payload.execution_mode
         ? { execution_mode: input.payload.execution_mode }
         : {}),
@@ -223,34 +309,61 @@ const linkProductionRunToTasksStep = createStep(
 export const createProductionRunWorkflow = createWorkflow(
   "create-production-run",
   (input: CreateProductionRunInput) => {
-    const design = fetchDesignSnapshotStep({ design_id: input.design_id })
-    const inventory = fetchDesignInventorySnapshotStep({ design_id: input.design_id })
+    // #1112 — branch on design presence. Design work-orders snapshot the design
+    // (+ its inventory links); a retail product-only run snapshots the product
+    // spine instead. Both feed the same provenance block.
+    const design = when({ input }, (data) => Boolean(data.input.design_id)).then(
+      () => fetchDesignSnapshotStep({ design_id: input.design_id })
+    )
+    const inventory = when({ input }, (data) =>
+      Boolean(data.input.design_id)
+    ).then(() => fetchDesignInventorySnapshotStep({ design_id: input.design_id }))
+    const product = when({ input }, (data) => !data.input.design_id).then(() =>
+      fetchProductSnapshotStep({ product_id: input.product_id })
+    )
 
     const captured_at = transform({}, () => new Date())
 
     const snapshot = transform(
-      { input, design, inventory, captured_at },
+      { input, design, inventory, product, captured_at },
       (data) => {
         const capturedAtDate =
           data.captured_at instanceof Date
             ? data.captured_at
             : new Date(data.captured_at as any)
 
+        const designData: any = data.design || null
+        const productData: any = data.product || null
+
         return {
           captured_at: capturedAtDate.toISOString(),
-          design: {
-            id: data.design.id,
-            name: data.design.name,
-            description: data.design.description,
-            status: data.design.status,
-            priority: data.design.priority,
-            metadata: data.design.metadata || {},
-            moodboard: data.design.moodboard ?? null,
-          },
-          specifications: data.design.specifications || [],
-          colors: data.design.colors || [],
-          size_sets: data.design.size_sets || [],
-          inventory_links: data.inventory.inventory_links || [],
+          design: designData
+            ? {
+                id: designData.id,
+                name: designData.name,
+                description: designData.description,
+                status: designData.status,
+                priority: designData.priority,
+                metadata: designData.metadata || {},
+                moodboard: designData.moodboard ?? null,
+              }
+            : null,
+          // #1112 — product spine snapshot for the design-less provenance path.
+          product: productData
+            ? {
+                id: productData.id,
+                title: productData.title,
+                handle: productData.handle,
+                status: productData.status,
+                thumbnail: productData.thumbnail ?? null,
+                subtitle: productData.subtitle ?? null,
+                metadata: productData.metadata || {},
+              }
+            : null,
+          specifications: designData?.specifications || [],
+          colors: designData?.colors || [],
+          size_sets: designData?.size_sets || [],
+          inventory_links: data.inventory?.inventory_links || [],
           provenance: {
             order_id: data.input.order_id,
             order_line_item_id: data.input.order_line_item_id,
@@ -272,6 +385,16 @@ export const createProductionRunWorkflow = createWorkflow(
     })
 
     const productionRunId = transform({ run }, (data) => (data.run as any).id as string)
+
+    // #1112 — link the run to the Product spine (provenance queryable via
+    // product.production_runs). Fires whenever a product_id is present, for
+    // both the design and product-only paths.
+    when({ input }, (data) => Boolean(data.input.product_id)).then(() => {
+      linkProductionRunToProductStep({
+        production_run_id: productionRunId,
+        product_id: input.product_id,
+      })
+    })
 
     when({ input }, (data) => Boolean(data.input.task_ids?.length)).then(() => {
       linkProductionRunToTasksStep({

--- a/e2e/helpers/e2e-seed.ts
+++ b/e2e/helpers/e2e-seed.ts
@@ -1,6 +1,7 @@
 import { ExecArgs } from "@medusajs/framework/types"
 import { Modules, ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { createOrderFulfillmentWorkflow } from "@medusajs/medusa/core-flows"
+import { ensureOrderFulfillment } from "../../apps/backend/src/workflows/orders/fulfillment-context"
 import Scrypt from "scrypt-kdf"
 import * as fs from "fs"
 import * as path from "path"
@@ -150,6 +151,79 @@ async function seedShipmentTrackingOrder(container: any): Promise<string> {
   return order.id
 }
 
+/**
+ * #1112 — seed a design-LESS product that has been sold and fulfilled, so the
+ * admin product-detail "Production Runs" section (in the Linked Designs widget)
+ * can be eyeballed in CI. Fulfilling emits `order.fulfillment_created`, whose
+ * subscriber retroactively mints a COMPLETED product-only run (design_id null)
+ * hung off the product spine. Returns the product id.
+ */
+async function seedProvenanceProductRun(container: any): Promise<string> {
+  const query = container.resolve(ContainerRegistrationKeys.QUERY)
+  const productModule: any = container.resolve(Modules.PRODUCT)
+  const orderModule: any = container.resolve(Modules.ORDER)
+
+  const { data: regions } = await query.graph({
+    entity: "region",
+    fields: ["id", "currency_code"],
+  })
+  const region = regions?.[0]
+  if (!region) {
+    throw new Error(
+      "E2E seed: no region found. Run the demo seed first: `medusa exec ./src/scripts/seed.ts`."
+    )
+  }
+
+  const product = await productModule.createProducts({
+    title: "Retail Provenance Stole (e2e)",
+    status: "published",
+    handle: `e2e-provenance-${Date.now()}`,
+    options: [{ title: "Default", values: ["Default"] }],
+  })
+
+  const created: any = await orderModule.createOrders({
+    status: "pending",
+    region_id: region.id,
+    currency_code: region.currency_code || "usd",
+    email: "e2e-provenance@jyt.test",
+    // Title-only line item carrying product_id (no variant → no inventory), so
+    // the manual fulfillment path works and the run is hung off the product.
+    items: [
+      {
+        title: "Retail Provenance Stole (e2e)",
+        quantity: 3,
+        unit_price: 2500,
+        product_id: product.id,
+      },
+    ],
+    metadata: { source: "e2e-provenance" },
+  })
+  const order = Array.isArray(created) ? created[0] : created
+
+  await ensureOrderFulfillment(container, order.id)
+
+  // The subscriber mints the run async on the emitted event — poll for it so
+  // the seed file only advertises the product once its run exists.
+  let minted = false
+  for (let i = 0; i < 40; i++) {
+    const { data: runs } = await query.graph({
+      entity: "production_runs",
+      fields: ["id", "design_id", "status"],
+      filters: { product_id: product.id },
+    })
+    if ((runs || []).length) {
+      minted = true
+      break
+    }
+    await new Promise((r) => setTimeout(r, 250))
+  }
+  if (!minted) {
+    throw new Error("E2E seed: product-only production run was not minted")
+  }
+
+  return product.id
+}
+
 const SEED_PASSWORD = "e2etest123!"
 const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
 
@@ -251,12 +325,16 @@ export default async function e2eSeed({ container }: ExecArgs) {
   logger.info("E2E seed: creating retail order with Shiprocket shipment (#1118)...")
   const shipmentOrderId = await seedShipmentTrackingOrder(container)
 
+  logger.info("E2E seed: creating design-less product + fulfilled order → product-only run (#1112)...")
+  const provenanceProductId = await seedProvenanceProductRun(container)
+
   const seedData = {
     email,
     password: SEED_PASSWORD,
     websiteId: website.id,
     domain,
     shipmentOrderId,
+    provenanceProductId,
   }
 
   fs.writeFileSync(SEED_FILE, JSON.stringify(seedData, null, 2))

--- a/e2e/specs/product-production-runs.spec.ts
+++ b/e2e/specs/product-production-runs.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from "@playwright/test"
+import * as fs from "fs"
+import * as path from "path"
+
+const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
+
+// #1112 — a product sold and fulfilled from produced stock retroactively mints a
+// COMPLETED product-only production run (design_id null) hung off the product
+// spine. This run surfaces in the existing "Linked Designs" widget's
+// product-level "Production Runs" section — even though the product has NO
+// linked design. Drives it headlessly against the seeded product so CI does the
+// browser verification.
+test.describe("Product production-runs provenance section (#1112)", () => {
+  let seed: { email: string; password: string; provenanceProductId: string }
+
+  test.beforeAll(() => {
+    if (!fs.existsSync(SEED_FILE)) {
+      throw new Error(
+        `E2E seed file not found at ${SEED_FILE}. Run "pnpm e2e:seed" first.`
+      )
+    }
+    seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
+    if (!seed.provenanceProductId) {
+      throw new Error("E2E seed missing provenanceProductId — re-run the seed.")
+    }
+  })
+
+  test("shows the completed retail run in the product's Production Runs section", async ({
+    page,
+  }) => {
+    // Log in via the admin UI.
+    await page.goto("/app/login")
+    await page.waitForLoadState("networkidle")
+    await page.locator('input[name="email"]').fill(seed.email)
+    await page.locator('input[name="password"]').fill(seed.password)
+    await page.locator('button[type="submit"]').click()
+    await page.waitForURL(/\/app\/(?!login)/, { timeout: 15000 })
+
+    // Open the seeded (design-less) product's detail page.
+    await page.goto(`/app/products/${seed.provenanceProductId}`)
+    await page.waitForLoadState("networkidle")
+
+    // The product-level Production Runs section (from the Linked Designs widget).
+    await expect(
+      page.getByText("Production Runs", { exact: true }).first()
+    ).toBeVisible({ timeout: 15000 })
+
+    // The provenance subtitle that distinguishes retail runs.
+    await expect(
+      page.getByText("from fulfilled orders").first()
+    ).toBeVisible()
+
+    // The run is born completed (status badge) with a produced quantity.
+    await expect(page.getByText("Completed").first()).toBeVisible()
+  })
+})


### PR DESCRIPTION
Closes part of #1112 (S1–S3 admin + e2e). Retail-order → production-run design trail (product-as-spine provenance).

## Vision
A product sold on a partner store and **fulfilled from produced stock** retroactively mints a `production_run` hung off the **Product spine**, so every sold-and-fulfilled product carries a provenance / design trail — even when it has no formal design.

## Slices

**S1 — product-only creation path**
- `production_runs.design_id` → **nullable** (+ `Migration20260721160000`).
- New **`product ↔ production_run` link** — provenance queryable via `product.production_runs`.
- `createProductionRunWorkflow` branches on design presence: design path unchanged (`when`-guarded); **product-only path** snapshots the product spine (`fetchProductSnapshotStep`) + links the run to the product. `produced_quantity` stampable for born-`completed` runs.

**S2 — fulfillment-triggered run**
- `order.fulfillment_created` mints a **`completed`** run per fulfilled line item (born terminal, `produced_quantity = qty`), design-backed when the product has a design else product-only. Runs before the `no_notification` early-return.
- New shared `lib/resolve-line-item-production.ts` (design resolution + `order_line_item_id` idempotency) drives **both** `order.placed` and `order.fulfillment_created` → never double-create. `order-placed.ts` refactored onto it.
- `skip_unified_projection` so retail provenance runs don't mint #342 partner work-orders (which would mis-discriminate the retail order as `kind=design`).

**S3 (admin) — provenance surface**
- Extended the **existing "Linked Designs" widget** (`product-designs.tsx`) with a product-level "Production Runs" section listing the design-less retail runs (status · order link · produced qty) via `useProductionRuns({ product_id })`. Filters `design_id == null` (no dup with per-design tables); renders even with zero linked designs.
- `GET /admin/production-runs` now accepts a `product_id` filter.

## Decisions (founder, 2026-07-21)
- Trigger = **fulfillment**, **product-only** path (ships independent of #938/#939).
- **Provenance-only** (no inventory adjustment).
- **Mint for all** fulfilled lines; dropship/resale distinction deferred.
- Partner UI mirror **deferred** to a follow-up.

## Tests
- `integration-tests/http/order-fulfillment-production-runs.spec.ts` (2): product-only completed run + product link + idempotency; no double-create when `order.placed` already minted the design-backed run.
- `order-placed-production-runs.spec.ts` refactored onto the shared helper, stays green.
- **e2e** (`e2e/specs/product-production-runs.spec.ts` + seed fixture): asserts the section renders on the product page in CI's fresh admin build.

## Acceptance
Buyer buys a product → partner fulfills it → a `completed` `production_run` linked to that **product** (no pre-existing design required) exists with order provenance, and no duplicate if `order.placed` also fired. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)