### PR TITLE
fix(production-runs): render the product-only runs section [#1112]

### DIFF
--- a/apps/backend/src/admin/widgets/product-designs.tsx
+++ b/apps/backend/src/admin/widgets/product-designs.tsx
@@ -409,6 +409,10 @@ const ProductDesignsWidget = ({ data }: DetailWidgetProps<AdminProduct>) => {
           </div>
         )}
       </div>
+
+      {/* #1112 — product-level provenance runs (design-less, from retail
+          fulfillment). Renders regardless of linked designs. */}
+      <ProductProvenanceRunsSection productId={data.id!} />
     </Container>
   )
 }


### PR DESCRIPTION
Fix-forward for #1112 / PR #1120.

`ProductProvenanceRunsSection` was defined but never placed in the Linked Designs widget's JSX, so the retail provenance runs were invisible in admin (dead code). The **e2e spec correctly caught this** — the `e2e` job on PR #1120 went red (section never rendered). This wires the section into the Container so it renders regardless of linked designs.

Verified: `test` + `prod-build` were already green; this only fixes the missing render that the e2e asserts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)