### PR TITLE
fix(production-runs): design-backed retail runs complete on fulfillment, not stuck pending_review [#1126]

### DIFF
--- a/apps/backend/integration-tests/http/order-fulfillment-production-runs.spec.ts
+++ b/apps/backend/integration-tests/http/order-fulfillment-production-runs.spec.ts
@@ -202,7 +202,7 @@ setupSharedTestSuite(() => {
       expect((runs2 || []).length).toBe(1)
     })
 
-    it("does not double-create when order.placed already minted a run for a design-backed line", async () => {
+    it("completes (not double-creates) the design-backed run order.placed minted, and mints the bare product's run", async () => {
       const { api, getContainer } = getSharedTestEnv()
       const container = getContainer()
       const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
@@ -254,23 +254,48 @@ setupSharedTestSuite(() => {
       // (already has a run) and mint only the bare product's completed run.
       await fulfillOrder(container, orderId)
 
-      const runs = await waitForRuns(query, orderId, 2, [
-        "id",
-        "product_id",
-        "status",
-        "design_id",
-      ])
+      // Poll until the design-backed run has been completed by the fulfillment
+      // subscriber (it starts pending_review, so a length check alone races).
+      let runs: any[] = []
+      for (let i = 0; i < 40; i++) {
+        runs = await waitForRuns(query, orderId, 2, [
+          "id",
+          "product_id",
+          "status",
+          "design_id",
+          "produced_quantity",
+        ])
+        const linked = runs.find((r: any) => r.product_id === linkedProductId)
+        if (runs.length >= 2 && linked?.status === "completed") {
+          break
+        }
+        await new Promise((r) => setTimeout(r, 150))
+      }
       expect(runs.length).toBe(2)
 
-      // The design-backed run is untouched (same id, still pending_review).
+      // #1126 — the same design-backed run (no double-create) is transitioned
+      // to completed from stock, with the shipped quantity stamped.
       const linkedRun = runs.find((r: any) => r.product_id === linkedProductId)
       expect(linkedRun.id).toBe(linkedRunId)
-      expect(linkedRun.status).toBe("pending_review")
+      expect(linkedRun.status).toBe("completed")
+      expect(linkedRun.produced_quantity).toBe(1)
 
       // The bare product got a completed product-only run.
       const bareRun = runs.find((r: any) => r.product_id === bareProductId)
       expect(bareRun.design_id).toBeNull()
       expect(bareRun.status).toBe("completed")
+
+      // #1126 — neither retail run is projected onto the #342 unified view: the
+      // order↔production_run link (`production_runs.order`) must be absent so
+      // the retail order isn't mis-discriminated as a design work-order.
+      const { data: projections } = await query.graph({
+        entity: "production_runs",
+        fields: ["id", "order.id"],
+        filters: { id: [linkedRun.id, bareRun.id] },
+      })
+      for (const p of projections || []) {
+        expect(p.order ?? null).toBeNull()
+      }
     })
   })
 })

--- a/apps/backend/src/lib/resolve-line-item-production.ts
+++ b/apps/backend/src/lib/resolve-line-item-production.ts
@@ -55,11 +55,25 @@ export async function hasProductionRunForLineItem(
   query: any,
   lineItemId: string
 ): Promise<boolean> {
+  return (await getProductionRunForLineItem(query, lineItemId)) !== null
+}
+
+/**
+ * Like {@link hasProductionRunForLineItem} but returns the existing run's id +
+ * status so the fulfillment path can decide whether to complete it (still
+ * pre-production, i.e. shipped from stock) vs leave it (production already
+ * underway). #1126.
+ */
+export async function getProductionRunForLineItem(
+  query: any,
+  lineItemId: string
+): Promise<{ id: string; status: string } | null> {
   const { data: existing } = await query.graph({
     entity: "production_runs",
-    fields: ["id"],
+    fields: ["id", "status"],
     filters: { order_line_item_id: lineItemId },
     pagination: { skip: 0, take: 1 },
   })
-  return (existing || []).length > 0
+  const run = (existing || [])[0]
+  return run ? { id: run.id, status: run.status } : null
 }

--- a/apps/backend/src/subscribers/order-fullfilled.ts
+++ b/apps/backend/src/subscribers/order-fullfilled.ts
@@ -4,10 +4,19 @@ import type { Logger } from "@medusajs/types"
 import { sendOrderFulfillmentEmail } from "../workflows/email/send-notification-email"
 import { sendPartnerOrderFulfilledWorkflow } from "../workflows/email/workflows/send-partner-order-email"
 import { createProductionRunWorkflow } from "../workflows/production-runs/create-production-run"
+import { completeProvenanceRunWorkflow } from "../workflows/production-runs/complete-provenance-run"
 import {
-  hasProductionRunForLineItem,
+  getProductionRunForLineItem,
   resolveLineItemDesignId,
 } from "../lib/resolve-line-item-production"
+
+// #1126 — a run created at order.placed that is still in one of these
+// pre-production states means no production actually happened: the goods
+// shipped from stock. On fulfillment we transition it to `completed` (rather
+// than skipping) so design-backed retail provenance doesn't stay
+// `pending_review` forever. Runs already past this point (real production
+// underway) are left untouched.
+const PRE_PRODUCTION_STATUSES = new Set(["draft", "pending_review"])
 
 // #1112 — "fulfilled from produced stock" ⇒ retroactively mint a COMPLETED
 // production run per fulfilled line item, hung off the Product spine, carrying
@@ -65,8 +74,24 @@ async function createFulfillmentProductionRuns(
         continue
       }
 
-      // Shared idempotency with order.placed — skip if a run already exists.
-      if (await hasProductionRunForLineItem(query, lineItemId)) {
+      // Shared idempotency with order.placed. If a run already exists it was
+      // minted at payment for a design-backed line. When it's still
+      // pre-production the goods shipped from stock, so complete it here (#1126)
+      // — otherwise it would stay `pending_review` forever. A run already in
+      // production is left alone.
+      const existingRun = await getProductionRunForLineItem(query, lineItemId)
+      if (existingRun) {
+        if (PRE_PRODUCTION_STATUSES.has(existingRun.status)) {
+          await completeProvenanceRunWorkflow(container).run({
+            input: {
+              production_run_id: existingRun.id,
+              produced_quantity: quantity,
+            },
+          })
+          logger.info(
+            `[order.fulfillment_created] Completed design-backed provenance run ${existingRun.id} for line item ${lineItemId} (shipped from stock)`
+          )
+        }
         continue
       }
 

--- a/apps/backend/src/subscribers/order-placed.ts
+++ b/apps/backend/src/subscribers/order-placed.ts
@@ -90,6 +90,12 @@ export default async function orderPlacedHandler({
           variant_id: variantId,
           order_id: order?.id,
           order_line_item_id: lineItemId,
+          // #1126 — a design-backed RETAIL run is provenance, not a partner
+          // work-order: don't project it onto the #342 unified view (it would
+          // be mis-discriminated as a design work-order). The run is born
+          // `pending_review` ("sold, not yet shipped") and is transitioned to
+          // `completed` by the fulfillment path once the goods ship from stock.
+          skip_unified_projection: true,
           metadata: {
             source: "order.placed",
             is_custom_design: isCustomDesign,

--- a/apps/backend/src/workflows/production-runs/complete-provenance-run.ts
+++ b/apps/backend/src/workflows/production-runs/complete-provenance-run.ts
@@ -1,0 +1,68 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+
+import { PRODUCTION_RUNS_MODULE } from "../../modules/production_runs"
+import type ProductionRunService from "../../modules/production_runs/service"
+
+// #1126 — lightweight completion for a RETAIL provenance run. When a
+// design-backed retail order is fulfilled from stock, the run minted at
+// order.placed (status `pending_review`) never went through production, so we
+// simply stamp it `completed` + record the produced/shipped yield. This is NOT
+// the partner completion flow (complete-production-run) — no consumptions, no
+// finished-goods stocking, no lifecycle signalling; the goods already exist.
+
+export type CompleteProvenanceRunInput = {
+  production_run_id: string
+  produced_quantity?: number
+}
+
+const completeProvenanceRunStep = createStep(
+  "complete-provenance-run",
+  async (input: CompleteProvenanceRunInput, { container }) => {
+    const service: ProductionRunService = container.resolve(
+      PRODUCTION_RUNS_MODULE
+    )
+
+    const previous = await service.retrieveProductionRun(input.production_run_id)
+
+    await service.updateProductionRuns({
+      id: input.production_run_id,
+      status: "completed",
+      ...(input.produced_quantity !== undefined
+        ? { produced_quantity: input.produced_quantity }
+        : {}),
+    } as any)
+
+    return new StepResponse(
+      { production_run_id: input.production_run_id },
+      {
+        production_run_id: input.production_run_id,
+        previous_status: previous.status,
+        previous_produced_quantity: (previous as any).produced_quantity ?? null,
+      }
+    )
+  },
+  async (rollback, { container }) => {
+    if (!rollback) return
+    const service: ProductionRunService = container.resolve(
+      PRODUCTION_RUNS_MODULE
+    )
+    await service.updateProductionRuns({
+      id: rollback.production_run_id,
+      status: rollback.previous_status as any,
+      produced_quantity: rollback.previous_produced_quantity,
+    } as any)
+  }
+)
+
+export const completeProvenanceRunWorkflow = createWorkflow(
+  "complete-provenance-run",
+  (input: CompleteProvenanceRunInput) => {
+    const result = completeProvenanceRunStep(input)
+    return new WorkflowResponse(result)
+  }
+)


### PR DESCRIPTION
Closes #1126 — follow-up from the #1112 gap review.

## Problem
For a product **with a linked design sold at retail**:
- `order.placed` minted a `pending_review` run **and** projected it onto the #342 unified view.
- `order.fulfillment_created`'s idempotency guard then **skipped** it, so the completed-from-stock intent never applied.

Consequences:
1. The run stayed `pending_review` forever despite the goods shipping.
2. It was mis-discriminated as a `kind=design` **work-order** in the #342 unified view.

## Approach — founder decision: retail runs are never work-orders
- `order.placed` now sets `skip_unified_projection: true` for design-backed retail runs (provenance, not a partner work-order).
- `order.fulfillment_created` **completes** an existing pre-production run (`draft`/`pending_review`) instead of skipping, stamping the shipped quantity. Runs already in production are untouched.
- New lightweight `complete-provenance-run` workflow (status→`completed` + `produced_quantity`; no consumptions/stocking/lifecycle — goods already exist; has compensation).
- Shared helper gains `getProductionRunForLineItem` (id + status).

## Tests
Updated `order-fulfillment-production-runs.spec.ts`:
- the design-backed run transitions to `completed` (same id, `produced_quantity` stamped) — no double-create.
- neither retail run is projected onto the #342 unified view (`production_runs.order` link absent).

Ran both affected specs against the shared DB — **3 passed**, driving the real fulfillment subscriber. `tsc` clean on touched files.

## Scope
Fixes new runs going forward. Historical `pending_review` retail runs already projected in prod = **#1122 (backfill)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)