### PR TITLE
feat(production-runs): backfill job for historical fulfilled retail orders [#1122]

### DIFF
--- a/apps/backend/integration-tests/http/backfill-fulfilled-retail-runs.spec.ts
+++ b/apps/backend/integration-tests/http/backfill-fulfilled-retail-runs.spec.ts
@@ -1,0 +1,285 @@
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import type { IOrderModuleService, IRegionModuleService } from "@medusajs/types"
+
+import { setupSharedTestSuite, getSharedTestEnv } from "./shared-test-setup"
+import { createAdminUser, getAuthHeaders } from "../helpers/create-admin-user"
+import { seedCommonEmailTemplates } from "../helpers/seed-email-templates"
+import { setupCheckoutInfrastructure } from "../helpers/setup-checkout-infrastructure"
+import { ensureOrderFulfillment } from "../../src/workflows/orders/fulfillment-context"
+import orderPlacedHandler from "../../src/subscribers/order-placed"
+import { PRODUCTION_RUNS_MODULE } from "../../src/modules/production_runs"
+
+jest.setTimeout(90 * 1000)
+
+// #1122 — the ops backfill job re-mints the #1112 fulfillment provenance runs
+// for orders that were fulfilled BEFORE the live path existed (empty product
+// design trail). Reuses the live subscriber's shared planner, so it never
+// double-creates and completes stuck design-backed runs (#1126).
+setupSharedTestSuite(() => {
+  describe("backfill-fulfilled-retail-production-runs maintenance job", () => {
+    let adminHeaders: { headers: Record<string, string> }
+    let regionId: string
+    const RUN =
+      "/admin/ops/maintenance-jobs/backfill-fulfilled-retail-production-runs/run"
+
+    beforeAll(async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      const container = getContainer()
+      await createAdminUser(container)
+      adminHeaders = await getAuthHeaders(api)
+      await seedCommonEmailTemplates(api, adminHeaders)
+
+      const regionsRes = await api.get("/admin/regions", adminHeaders)
+      if (regionsRes.data.regions?.length > 0) {
+        regionId = regionsRes.data.regions[0].id
+      } else {
+        const regionService = container.resolve(
+          Modules.REGION
+        ) as IRegionModuleService
+        const region = await regionService.createRegions({
+          name: "Backfill Runs Region",
+          currency_code: "usd",
+          countries: ["us"],
+        })
+        regionId = region.id
+      }
+      await setupCheckoutInfrastructure(container, regionId)
+    })
+
+    const createProduct = async (
+      api: any,
+      unique: string | number,
+      suffix: string,
+      designId?: string
+    ) => {
+      const res = await api.post(
+        "/admin/products",
+        {
+          title: `Backfill Product ${suffix} ${unique}`,
+          status: "published",
+          handle: `backfill-prod-${suffix}-${unique}`,
+          options: [{ title: "Default", values: ["Default"] }],
+        },
+        adminHeaders
+      )
+      expect(res.status).toBe(200)
+      const productId = res.data.product.id
+      if (designId) {
+        const linkRes = await api.post(
+          `/admin/products/${productId}/linkDesign`,
+          { designId },
+          adminHeaders
+        )
+        expect(linkRes.status).toBe(200)
+      }
+      return productId
+    }
+
+    const createOrder = async (
+      container: any,
+      unique: number,
+      productIds: string[]
+    ) => {
+      const orderService = container.resolve(
+        Modules.ORDER
+      ) as IOrderModuleService
+      const createdOrder: any = await orderService.createOrders({
+        region_id: regionId,
+        currency_code: "usd",
+        email: `backfill-${unique}@jyt.test`,
+        items: productIds.map((pid, i) => ({
+          title: `Line ${i}`,
+          quantity: i + 1,
+          unit_price: 1000,
+          product_id: pid,
+        })),
+      } as any)
+      return createdOrder.id as string
+    }
+
+    const runsForOrder = async (query: any, orderId: string, fields: string[]) => {
+      const { data } = await query.graph({
+        entity: "production_runs",
+        fields,
+        filters: { order_id: orderId },
+      })
+      return (data || []) as any[]
+    }
+
+    const waitForRuns = async (query: any, orderId: string, expected: number) => {
+      let runs: any[] = []
+      for (let i = 0; i < 40; i++) {
+        runs = await runsForOrder(query, orderId, ["id", "status"])
+        if (runs.length >= expected) break
+        await new Promise((r) => setTimeout(r, 150))
+      }
+      return runs
+    }
+
+    it("re-mints missing provenance runs for a historically-fulfilled order and is idempotent", async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      const container = getContainer()
+      const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+      const runService: any = container.resolve(PRODUCTION_RUNS_MODULE)
+      const unique = Date.now()
+
+      // A design-backed line + a design-less line.
+      const designRes = await api.post(
+        "/admin/designs",
+        {
+          name: `Backfill Design ${unique}`,
+          description: "backfill test",
+          design_type: "Original",
+          status: "Commerce_Ready",
+          priority: "Medium",
+        },
+        adminHeaders
+      )
+      expect(designRes.status).toBe(201)
+      const designId = designRes.data.design.id
+
+      const linkedProductId = await createProduct(api, unique, "linked", designId)
+      const bareProductId = await createProduct(api, unique, "bare")
+
+      const orderId = await createOrder(container, unique, [
+        linkedProductId,
+        bareProductId,
+      ])
+
+      // Real lifecycle: payment then fulfillment (the live path mints/completes
+      // runs). We then DELETE them to reconstruct the pre-#1112 historical state
+      // (fulfilled order, empty design trail).
+      await orderPlacedHandler({
+        event: { data: { id: orderId } },
+        container,
+      } as any)
+      await ensureOrderFulfillment(container, orderId)
+      const liveRuns = await waitForRuns(query, orderId, 2)
+      expect(liveRuns.length).toBe(2)
+      await runService.deleteProductionRuns(liveRuns.map((r) => r.id))
+      expect((await runsForOrder(query, orderId, ["id"])).length).toBe(0)
+
+      // ── Dry-run: previews 2 creates, writes nothing ──────────────────────
+      const dry = await api.post(
+        RUN,
+        { dry_run: true, params: { order_ids: orderId } },
+        adminHeaders
+      )
+      expect(dry.status).toBe(200)
+      expect(dry.data.result.dry_run).toBe(true)
+      expect(dry.data.result.applied).toBe(false)
+      expect(dry.data.result.changes.length).toBe(2)
+      expect((await runsForOrder(query, orderId, ["id"])).length).toBe(0)
+
+      // ── Apply: mints 2 completed runs (product-only + design-backed) ─────
+      const applied = await api.post(
+        RUN,
+        { dry_run: false, params: { order_ids: orderId } },
+        adminHeaders
+      )
+      expect(applied.status).toBe(200)
+      expect(applied.data.result.applied).toBe(true)
+
+      const runs = await runsForOrder(query, orderId, [
+        "id",
+        "status",
+        "design_id",
+        "product_id",
+        "produced_quantity",
+      ])
+      expect(runs.length).toBe(2)
+      for (const r of runs) {
+        expect(r.status).toBe("completed")
+      }
+      const linkedRun = runs.find((r) => r.product_id === linkedProductId)
+      const bareRun = runs.find((r) => r.product_id === bareProductId)
+      expect(linkedRun.design_id).toBe(designId)
+      expect(bareRun.design_id).toBeNull()
+      // Quantities mirror the fulfilled line qty (Line 0 = 1, Line 1 = 2).
+      expect(linkedRun.produced_quantity).toBe(1)
+      expect(bareRun.produced_quantity).toBe(2)
+
+      // ── Re-apply: idempotent no-op (runs exist + completed → skip) ────────
+      const reapply = await api.post(
+        RUN,
+        { dry_run: false, params: { order_ids: orderId } },
+        adminHeaders
+      )
+      expect(reapply.status).toBe(200)
+      expect(reapply.data.result.applied).toBe(false)
+      expect(reapply.data.result.changes.length).toBe(0)
+      expect((await runsForOrder(query, orderId, ["id"])).length).toBe(2)
+    })
+
+    it("completes a design-backed run left stuck in pending_review", async () => {
+      const { api, getContainer } = getSharedTestEnv()
+      const container = getContainer()
+      const query = container.resolve(ContainerRegistrationKeys.QUERY) as any
+      const runService: any = container.resolve(PRODUCTION_RUNS_MODULE)
+      const unique = Date.now() + 1
+
+      const designRes = await api.post(
+        "/admin/designs",
+        {
+          name: `Backfill Stuck Design ${unique}`,
+          description: "stuck run test",
+          design_type: "Original",
+          status: "Commerce_Ready",
+          priority: "Medium",
+        },
+        adminHeaders
+      )
+      expect(designRes.status).toBe(201)
+      const designId = designRes.data.design.id
+      const linkedProductId = await createProduct(api, unique, "stuck", designId)
+
+      const orderId = await createOrder(container, unique, [linkedProductId])
+
+      // order.placed mints the design-backed run (pending_review).
+      await orderPlacedHandler({
+        event: { data: { id: orderId } },
+        container,
+      } as any)
+      await ensureOrderFulfillment(container, orderId)
+
+      // Wait for the live fulfillment subscriber to SETTLE (it completes the
+      // run async) before forcing it back — otherwise its completion races past
+      // our manual downgrade. Then force pending_review to reconstruct the
+      // pre-#1126 "stuck" historical state (order fulfilled, run never completed).
+      let runId = ""
+      for (let i = 0; i < 40; i++) {
+        const rs = await runsForOrder(query, orderId, ["id", "status"])
+        if (rs.length === 1 && rs[0].status === "completed") {
+          runId = rs[0].id
+          break
+        }
+        await new Promise((r) => setTimeout(r, 150))
+      }
+      expect(runId).not.toBe("")
+      await runService.updateProductionRuns({
+        id: runId,
+        status: "pending_review",
+        produced_quantity: null,
+      })
+
+      const applied = await api.post(
+        RUN,
+        { dry_run: false, params: { order_ids: orderId } },
+        adminHeaders
+      )
+      expect(applied.status).toBe(200)
+      expect(applied.data.result.applied).toBe(true)
+
+      const after = await runsForOrder(query, orderId, [
+        "id",
+        "status",
+        "produced_quantity",
+      ])
+      // Same run (no double-create), now completed with the shipped qty.
+      expect(after.length).toBe(1)
+      expect(after[0].id).toBe(runId)
+      expect(after[0].status).toBe("completed")
+      expect(after[0].produced_quantity).toBe(1)
+    })
+  })
+})

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-fulfilled-retail-runs-job.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/backfill-fulfilled-retail-runs-job.ts
@@ -1,0 +1,232 @@
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import { z } from "@medusajs/framework/zod"
+
+import { createProductionRunWorkflow } from "../../../../workflows/production-runs/create-production-run"
+import { completeProvenanceRunWorkflow } from "../../../../workflows/production-runs/complete-provenance-run"
+import { planLineItemRunAction } from "../../../../lib/plan-fulfillment-production-runs"
+import type { MaintenanceChange, MaintenanceJob, MaintenanceJobResult } from "./registry"
+
+const MAX_FULFILLED_RUN_BACKFILL_SCAN = 5000
+
+const paramsSchema = z.object({
+  order_ids: z
+    .union([z.string(), z.array(z.string())])
+    .optional()
+    .transform((v) =>
+      (Array.isArray(v) ? v : String(v ?? "").split(","))
+        .map((s) => s.trim())
+        .filter(Boolean)
+    ),
+  limit: z.coerce
+    .number()
+    .int()
+    .positive()
+    .max(MAX_FULFILLED_RUN_BACKFILL_SCAN)
+    .optional()
+    .default(1000),
+})
+
+const ORDER_FIELDS = [
+  "id",
+  "items.id",
+  "items.product_id",
+  "items.variant_id",
+  "fulfillments.id",
+  "fulfillments.canceled_at",
+  "fulfillments.items.line_item_id",
+  "fulfillments.items.quantity",
+]
+
+/**
+ * #1122 — historical backfill of the #1112 fulfillment-triggered provenance
+ * runs. The live path only fires on NEW `order.fulfillment_created` events, so
+ * every already-fulfilled order predating #1112 has an empty product "design
+ * trail". This walks existing (non-canceled) fulfillments and, per fulfilled
+ * line item, applies the exact same decision as the live subscriber via the
+ * shared `planLineItemRunAction`:
+ *   - no run yet            → mint a COMPLETED provenance run (design-backed or
+ *                             product-only).
+ *   - run still pre-prod    → complete it + stamp the shipped quantity (the
+ *     (draft/pending_review)  #1126 stuck design-backed case).
+ *   - run already producing → skip.
+ *
+ * Because it reuses the same guard + planner as the live path, it never
+ * double-creates against it and is safe to re-run (idempotent). Provide
+ * `order_ids` to target specific orders, or omit for a bounded scan.
+ *
+ * Out of scope (matches the #1126 decision): it does NOT retract the #342
+ * unified-order projection that order.placed already wrote for historical
+ * design-backed runs — completing the run makes the product trail trustworthy;
+ * projection retraction is a separate concern.
+ */
+export const backfillFulfilledRetailRunsJob: MaintenanceJob = {
+  id: "backfill-fulfilled-retail-production-runs",
+  label: "Backfill production runs for fulfilled retail orders",
+  description:
+    `Mint the completed provenance production run for each fulfilled line item of orders that predate the #1112 fulfillment path (product-only or design-backed), and complete any design-backed run left in pending_review from order.placed (#1126). Reuses the live subscriber's guard + planner, so it never double-creates and is safe to re-run. Provide order_ids to target specific orders, or omit for a bounded scan (default 1000, max ${MAX_FULFILLED_RUN_BACKFILL_SCAN}). Canceled fulfillments are skipped. Dry-run previews; apply writes.`,
+  params: [
+    {
+      name: "order_ids",
+      type: "string",
+      required: false,
+      description: "Comma-separated order ids to target (default: scan fulfilled orders)",
+    },
+    {
+      name: "limit",
+      type: "number",
+      required: false,
+      description: `Max runs to create/complete in one call (default 1000, max ${MAX_FULFILLED_RUN_BACKFILL_SCAN})`,
+    },
+  ],
+  run: async (container, { dry_run, params }): Promise<MaintenanceJobResult> => {
+    const { order_ids, limit } = paramsSchema.parse(params)
+
+    const query: any = container.resolve(ContainerRegistrationKeys.QUERY)
+
+    const changes: MaintenanceChange[] = []
+    const errors: Array<{ id: string; message: string }> = []
+    let created = 0
+    let completed = 0
+    let scanned = 0
+
+    const considerOrder = async (order: any) => {
+      const fulfillments: any[] = order?.fulfillments || []
+      if (!fulfillments.length) {
+        return
+      }
+      scanned++
+
+      const itemById = new Map<string, any>(
+        (order?.items || []).map((it: any) => [it.id, it])
+      )
+
+      for (const f of fulfillments) {
+        // Canceled fulfillments never shipped → no provenance to mint.
+        if (f?.canceled_at) {
+          continue
+        }
+        for (const fi of f?.items || []) {
+          if (changes.length >= limit) {
+            return
+          }
+          const lineItemId = fi?.line_item_id
+          if (!lineItemId) {
+            continue
+          }
+          const orderItem = itemById.get(lineItemId)
+          const quantity = Number(fi?.quantity) || 1
+
+          const plan = await planLineItemRunAction(query, {
+            lineItemId,
+            productId: orderItem?.product_id,
+            variantId: orderItem?.variant_id,
+            quantity,
+          })
+          if (!plan) {
+            continue
+          }
+
+          if (plan.action === "complete") {
+            completed++
+            changes.push({
+              entity: "production_run",
+              id: plan.production_run_id,
+              field: "status",
+              before: plan.from_status,
+              after: "completed",
+            })
+            if (!dry_run) {
+              await completeProvenanceRunWorkflow(container).run({
+                input: {
+                  production_run_id: plan.production_run_id,
+                  produced_quantity: quantity,
+                },
+              })
+            }
+          } else {
+            created++
+            changes.push({
+              entity: "production_run",
+              id: lineItemId,
+              field: "create_run",
+              before: null,
+              after: {
+                order_id: order.id,
+                product_id: plan.product_id,
+                design_id: plan.design_id,
+                design_backed: Boolean(plan.design_id),
+                status: "completed",
+                produced_quantity: quantity,
+              },
+            })
+            if (!dry_run) {
+              await createProductionRunWorkflow(container).run({
+                input: {
+                  design_id: plan.design_id ?? undefined,
+                  quantity,
+                  produced_quantity: quantity,
+                  product_id: plan.product_id,
+                  variant_id: plan.variant_id,
+                  order_id: order.id,
+                  order_line_item_id: lineItemId,
+                  status: "completed",
+                  skip_unified_projection: true,
+                  metadata: {
+                    source: "backfill-fulfilled-retail-production-runs",
+                    is_custom_design: plan.is_custom_design,
+                    design_backed: Boolean(plan.design_id),
+                  },
+                },
+              })
+            }
+          }
+        }
+      }
+    }
+
+    if (order_ids.length) {
+      const { data: orders } = await query.graph({
+        entity: "order",
+        fields: ORDER_FIELDS,
+        filters: { id: order_ids },
+      })
+      for (const o of orders || []) {
+        if (changes.length >= limit) break
+        try {
+          await considerOrder(o)
+        } catch (e: any) {
+          errors.push({ id: o?.id, message: e?.message ?? String(e) })
+        }
+      }
+    } else {
+      const page = 200
+      for (let skip = 0; changes.length < limit; skip += page) {
+        const { data: orders } = await query.graph({
+          entity: "order",
+          fields: ORDER_FIELDS,
+          pagination: { skip, take: page },
+        })
+        if (!orders || orders.length === 0) break
+        for (const o of orders) {
+          if (changes.length >= limit) break
+          try {
+            await considerOrder(o)
+          } catch (e: any) {
+            errors.push({ id: o?.id, message: e?.message ?? String(e) })
+          }
+        }
+        if (orders.length < page) break
+      }
+    }
+
+    const verb = dry_run ? "Would create" : "Created"
+    return {
+      job_id: backfillFulfilledRetailRunsJob.id,
+      dry_run,
+      applied: !dry_run && changes.length > 0,
+      summary: `${verb} ${created} provenance run(s) and ${dry_run ? "complete" : "completed"} ${completed} stuck run(s) across ${scanned} fulfilled order(s), ${errors.length} error(s)`,
+      changes,
+      errors,
+    }
+  },
+}

--- a/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
+++ b/apps/backend/src/api/admin/ops/maintenance-jobs/registry.ts
@@ -92,6 +92,7 @@ import { backfillPartnerShippingOptionsJob } from "./backfill-partner-shipping-o
 import { repairShippingOptionStoreVisibilityJob } from "./repair-shipping-option-store-visibility-job"
 import { normalizeArtisanProductsJob } from "./normalize-artisan-products-job"
 import { linkArtisanDetailRowsJob } from "./link-artisan-detail-rows-job"
+import { backfillFulfilledRetailRunsJob } from "./backfill-fulfilled-retail-runs-job"
 import {
   sweepAiPlatformsByCategory,
   AI_ROLES,
@@ -5504,6 +5505,7 @@ export const MAINTENANCE_JOBS: MaintenanceJob[] = [
   repairShippingOptionStoreVisibilityJob,
   normalizeArtisanProductsJob,
   linkArtisanDetailRowsJob,
+  backfillFulfilledRetailRunsJob,
   seedInvestorPanelsJob,
 ]
 

--- a/apps/backend/src/lib/plan-fulfillment-production-runs.ts
+++ b/apps/backend/src/lib/plan-fulfillment-production-runs.ts
@@ -1,0 +1,94 @@
+// #1112 / #1126 / #1122 — the single decision for "what should happen to a
+// fulfilled retail line item's production run", shared by the live fulfillment
+// subscriber (order.fulfillment_created) and the historical backfill job so the
+// two can never drift or double-create against each other.
+//
+// Per fulfilled line item:
+//   - no run yet            → CREATE a completed provenance run (design-backed
+//                             or product-only), born terminal (goods shipped).
+//   - run still pre-prod    → COMPLETE it (the order.placed run for a
+//     (draft/pending_review)  design-backed line never went through production;
+//                             the goods shipped from stock — #1126).
+//   - run already producing → SKIP (real production; leave it alone).
+
+import {
+  getProductionRunForLineItem,
+  resolveLineItemDesignId,
+} from "./resolve-line-item-production"
+
+// A run in one of these states means no production actually happened yet — on
+// fulfillment that can only mean the goods shipped from stock.
+export const PRE_PRODUCTION_STATUSES = new Set(["draft", "pending_review"])
+
+export type PlannedRunAction =
+  | {
+      action: "create"
+      line_item_id: string
+      product_id: string
+      variant_id?: string
+      design_id: string | null
+      is_custom_design: boolean
+      quantity: number
+    }
+  | {
+      action: "complete"
+      line_item_id: string
+      product_id: string
+      production_run_id: string
+      from_status: string
+      quantity: number
+    }
+
+/**
+ * Decide the provenance action for ONE fulfilled line item. Read-only (no
+ * writes) — callers apply the returned action (create/complete workflow).
+ * Returns null when there's nothing to do (no product, or a run already in
+ * production/completed).
+ */
+export async function planLineItemRunAction(
+  query: any,
+  input: {
+    lineItemId: string
+    productId?: string | null
+    variantId?: string | null
+    quantity: number
+  }
+): Promise<PlannedRunAction | null> {
+  const { lineItemId, productId, variantId, quantity } = input
+
+  // No product to hang the run off → nothing to provenance.
+  if (!productId) {
+    return null
+  }
+
+  const existing = await getProductionRunForLineItem(query, lineItemId)
+  if (existing) {
+    if (PRE_PRODUCTION_STATUSES.has(existing.status)) {
+      return {
+        action: "complete",
+        line_item_id: lineItemId,
+        product_id: productId,
+        production_run_id: existing.id,
+        from_status: existing.status,
+        quantity,
+      }
+    }
+    // Already in production or completed — leave it untouched.
+    return null
+  }
+
+  const { designId, isCustomDesign } = await resolveLineItemDesignId(query, {
+    productId,
+    variantId,
+  })
+
+  return {
+    action: "create",
+    line_item_id: lineItemId,
+    product_id: productId,
+    variant_id: variantId ?? undefined,
+    design_id: designId ?? null,
+    is_custom_design: isCustomDesign,
+    quantity,
+  }
+}

--- a/apps/backend/src/subscribers/order-fullfilled.ts
+++ b/apps/backend/src/subscribers/order-fullfilled.ts
@@ -5,25 +5,14 @@ import { sendOrderFulfillmentEmail } from "../workflows/email/send-notification-
 import { sendPartnerOrderFulfilledWorkflow } from "../workflows/email/workflows/send-partner-order-email"
 import { createProductionRunWorkflow } from "../workflows/production-runs/create-production-run"
 import { completeProvenanceRunWorkflow } from "../workflows/production-runs/complete-provenance-run"
-import {
-  getProductionRunForLineItem,
-  resolveLineItemDesignId,
-} from "../lib/resolve-line-item-production"
-
-// #1126 — a run created at order.placed that is still in one of these
-// pre-production states means no production actually happened: the goods
-// shipped from stock. On fulfillment we transition it to `completed` (rather
-// than skipping) so design-backed retail provenance doesn't stay
-// `pending_review` forever. Runs already past this point (real production
-// underway) are left untouched.
-const PRE_PRODUCTION_STATUSES = new Set(["draft", "pending_review"])
+import { planLineItemRunAction } from "../lib/plan-fulfillment-production-runs"
 
 // #1112 — "fulfilled from produced stock" ⇒ retroactively mint a COMPLETED
 // production run per fulfilled line item, hung off the Product spine, carrying
 // order/partner provenance. Runs on `order.fulfillment_created` (the intent
-// signal). Idempotent with the payment path (`order.placed`) via the shared
-// `order_line_item_id` guard, so design-backed products (whose run was already
-// created at payment) are skipped here and never double-created.
+// signal). The per-line decision (create / complete an existing pre-production
+// run / skip) lives in the shared `planLineItemRunAction` so this path and the
+// historical backfill job (#1122) can never drift or double-create.
 async function createFulfillmentProductionRuns(
   container: SubscriberArgs<any>["container"],
   data: { order_id: string; fulfillment_id: string },
@@ -65,50 +54,41 @@ async function createFulfillmentProductionRuns(
     for (const fi of fulfilledItems) {
       const lineItemId = fi.line_item_id as string
       const orderItem = itemById.get(lineItemId)
-      const productId = orderItem?.product_id as string | undefined
-      const variantId = orderItem?.variant_id as string | undefined
       const quantity = Number(fi.quantity) || 1
 
-      // No product to hang the run off → nothing to provenance.
-      if (!productId) {
-        continue
-      }
-
-      // Shared idempotency with order.placed. If a run already exists it was
-      // minted at payment for a design-backed line. When it's still
-      // pre-production the goods shipped from stock, so complete it here (#1126)
-      // — otherwise it would stay `pending_review` forever. A run already in
-      // production is left alone.
-      const existingRun = await getProductionRunForLineItem(query, lineItemId)
-      if (existingRun) {
-        if (PRE_PRODUCTION_STATUSES.has(existingRun.status)) {
-          await completeProvenanceRunWorkflow(container).run({
-            input: {
-              production_run_id: existingRun.id,
-              produced_quantity: quantity,
-            },
-          })
-          logger.info(
-            `[order.fulfillment_created] Completed design-backed provenance run ${existingRun.id} for line item ${lineItemId} (shipped from stock)`
-          )
-        }
-        continue
-      }
-
-      // Reuse the design-resolution traversal; falls through to the product-only
-      // path (design_id null) when the product has no backing design.
-      const { designId, isCustomDesign } = await resolveLineItemDesignId(query, {
-        productId,
-        variantId,
+      const plan = await planLineItemRunAction(query, {
+        lineItemId,
+        productId: orderItem?.product_id,
+        variantId: orderItem?.variant_id,
+        quantity,
       })
+      if (!plan) {
+        continue
+      }
+
+      // A design-backed run from order.placed that never went through
+      // production → the goods shipped from stock, so complete it (#1126)
+      // instead of leaving it `pending_review` forever.
+      if (plan.action === "complete") {
+        await completeProvenanceRunWorkflow(container).run({
+          input: {
+            production_run_id: plan.production_run_id,
+            produced_quantity: plan.quantity,
+          },
+        })
+        logger.info(
+          `[order.fulfillment_created] Completed design-backed provenance run ${plan.production_run_id} for line item ${lineItemId} (shipped from stock)`
+        )
+        continue
+      }
 
       await createProductionRunWorkflow(container).run({
         input: {
-          design_id: designId ?? undefined,
-          quantity,
-          produced_quantity: quantity,
-          product_id: productId,
-          variant_id: variantId,
+          design_id: plan.design_id ?? undefined,
+          quantity: plan.quantity,
+          produced_quantity: plan.quantity,
+          product_id: plan.product_id,
+          variant_id: plan.variant_id,
           order_id: data.order_id,
           order_line_item_id: lineItemId,
           // Born terminal — the goods are already produced & shipping.
@@ -120,16 +100,16 @@ async function createFulfillmentProductionRuns(
           metadata: {
             source: "order.fulfillment_created",
             fulfillment_id: data.fulfillment_id,
-            is_custom_design: isCustomDesign,
-            design_backed: Boolean(designId),
+            is_custom_design: plan.is_custom_design,
+            design_backed: Boolean(plan.design_id),
           },
         },
       })
 
       logger.info(
         `[order.fulfillment_created] Minted ${
-          designId ? "design-backed" : "product-only"
-        } production run for line item ${lineItemId} (product ${productId})`
+          plan.design_id ? "design-backed" : "product-only"
+        } production run for line item ${lineItemId} (product ${plan.product_id})`
       )
     }
   } catch (e: any) {


### PR DESCRIPTION
Closes #1122 — follow-up to #1112 / #1126.

## Problem
The #1112 fulfillment-triggered provenance run creation only fires on **new** `order.fulfillment_created` events, so every already-fulfilled retail order predating #1112 has an empty product "design trail".

## What this adds
- **New `#457` Data Plumbing maintenance job** `backfill-fulfilled-retail-production-runs` (guarded dry-run→apply, `ops_audit` history, per-row `errors[]`, capped batch, targeted `order_ids` or bounded scan). Runnable from Settings → Data Plumbing or the Admin API.
- Walks existing **non-canceled** fulfillments and, per fulfilled line item, applies the exact same decision as the live subscriber:
  - no run yet → mint a **completed** provenance run (product-only or design-backed)
  - run still pre-production (`draft`/`pending_review`) → **complete** it + stamp shipped qty (the #1126 stuck case)
  - run already producing → skip
- **Extracted the per-line decision into a shared `planLineItemRunAction` lib** so the live subscriber and the backfill can never drift or double-create. Refactored `order-fullfilled.ts` onto it (behavior-preserving).

## Out of scope
Matches the #1126 decision: does **not** retract the #342 unified projection `order.placed` already wrote for historical design-backed runs — completing the run makes the product trail trustworthy; projection retraction is separate.

## Tests
New spec reconstructs the pre-#1112 historical state (fulfill → delete runs) and asserts the job re-mints completed runs + is idempotent, plus the stuck-`pending_review` completion path. Ran with the two subscriber specs — **5 passed**. `tsc` clean.

## Ops tail
After deploy, run against prod (v3.jaalyantra.com): **dry-run first** (`{ dry_run: true }`), review the change set, then apply (`{ dry_run: false }`), chunking via `limit` / `order_ids`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)