### PR TITLE
test(e2e): designer invite → brief moodboard end-to-end [#1113]

### DIFF
--- a/e2e/helpers/e2e-seed.ts
+++ b/e2e/helpers/e2e-seed.ts
@@ -224,6 +224,36 @@ async function seedProvenanceProductRun(container: any): Promise<string> {
   return product.id
 }
 
+/**
+ * #1113 — seed a design carrying a full brief (concept + aesthetic anchor +
+ * persona + competitors + price point + milestones + design budget), so the
+ * designer-invite → brief-moodboard flow (S1 invite/accept + S2 generate) can be
+ * driven end-to-end against the live server in CI. Returns the design id.
+ */
+async function seedDesignerInviteDesign(container: any): Promise<string> {
+  const designService: any = container.resolve("design")
+  const design = await designService.createDesigns({
+    name: `Designer Invite Brief (e2e)`,
+    description: "e2e designer-onboarding brief",
+    design_type: "Original",
+    status: "Conceptual",
+    priority: "Medium",
+    // Brief columns (#604 / #1113 S2) → the moodboard's anchor cards.
+    concept_theme: "90s Tokyo Streetwear",
+    aesthetic_keywords: ["utilitarian", "sleek", "nostalgic"],
+    persona: { age_range: "25-34", lifestyle: "urban minimalist", values: ["sustainability"] },
+    competitors: [{ name: "Acme Knits", differentiator: "hand-loomed" }],
+    price_point: "mid_market",
+    design_budget: 250000,
+    cost_currency: "inr",
+    milestones: [
+      { label: "Initial sketches", date: "2026-08-01" },
+      { label: "Production-ready samples", date: null },
+    ],
+  })
+  return design.id
+}
+
 const SEED_PASSWORD = "e2etest123!"
 const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
 
@@ -328,6 +358,9 @@ export default async function e2eSeed({ container }: ExecArgs) {
   logger.info("E2E seed: creating design-less product + fulfilled order → product-only run (#1112)...")
   const provenanceProductId = await seedProvenanceProductRun(container)
 
+  logger.info("E2E seed: creating design with a full brief for the designer-invite flow (#1113)...")
+  const inviteDesignId = await seedDesignerInviteDesign(container)
+
   const seedData = {
     email,
     password: SEED_PASSWORD,
@@ -335,6 +368,7 @@ export default async function e2eSeed({ container }: ExecArgs) {
     domain,
     shipmentOrderId,
     provenanceProductId,
+    inviteDesignId,
   }
 
   fs.writeFileSync(SEED_FILE, JSON.stringify(seedData, null, 2))

--- a/e2e/specs/designer-invite-moodboard.spec.ts
+++ b/e2e/specs/designer-invite-moodboard.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect, request as pwRequest } from "@playwright/test"
+import * as fs from "fs"
+import * as path from "path"
+
+const SEED_FILE = path.resolve(__dirname, "../../apps/backend/.e2e-seed.json")
+
+/**
+ * #1113 S1+S2 — designer onboarding, end-to-end against the live server.
+ *
+ * Exercises the real HTTP flow the founder asked for: a brand assembles a brief,
+ * mints a scoped invite, a stranger accepts (becoming an assigned `designer`
+ * partner without a portal login), and that partner generates the moodboard —
+ * getting the brief rendered as the three anchor "cards" frames. Uses the API
+ * request context (no browser UI needed) so it runs headless + on CI.
+ */
+test.describe("Designer invite → brief moodboard (#1113)", () => {
+  let seed: { email: string; password: string; inviteDesignId: string }
+  let adminToken: string
+
+  test.beforeAll(async ({ baseURL }) => {
+    if (!fs.existsSync(SEED_FILE)) {
+      throw new Error(`E2E seed file not found at ${SEED_FILE}. Run "pnpm e2e:seed" first.`)
+    }
+    seed = JSON.parse(fs.readFileSync(SEED_FILE, "utf-8"))
+    if (!seed.inviteDesignId) {
+      throw new Error("E2E seed missing inviteDesignId — re-run the seed.")
+    }
+
+    // Admin bearer via the emailpass auth route (same creds the seed wrote).
+    const api = await pwRequest.newContext({ baseURL })
+    const res = await api.post("/auth/user/emailpass", {
+      data: { email: seed.email, password: seed.password },
+    })
+    expect(res.ok()).toBeTruthy()
+    adminToken = (await res.json()).token
+    await api.dispose()
+  })
+
+  test("mint invite → stranger accepts → assigned designer generates the brief moodboard", async ({
+    baseURL,
+  }) => {
+    const admin = await pwRequest.newContext({
+      baseURL,
+      extraHTTPHeaders: { authorization: `Bearer ${adminToken}` },
+    })
+    const pub = await pwRequest.newContext({ baseURL })
+
+    // 1. Brand mints a scoped invite for the briefed design.
+    const mintRes = await admin.post(
+      `/admin/designs/${seed.inviteDesignId}/designer-invites`,
+      { data: { inviter_name: "Studio JYT" } }
+    )
+    expect(mintRes.status()).toBe(201)
+    const mint = await mintRes.json()
+    expect(mint.token).toBeTruthy()
+
+    // 2. Recipient lands on the read-only brief (token-as-auth, no session).
+    const infoRes = await pub.get(`/partners/designer-invites/${mint.token}`)
+    expect(infoRes.status()).toBe(200)
+    const info = await infoRes.json()
+    expect(info.invite.usable).toBe(true)
+    expect(info.design.id).toBe(seed.inviteDesignId)
+    expect(info.design.name).toContain("Designer Invite Brief")
+
+    // 3. Stranger accepts → becomes a `designer` partner + gets a session bearer.
+    const email = `e2e-designer-${Date.now()}@jyt.test`
+    const acceptRes = await pub.post(
+      `/partners/designer-invites/${mint.token}/accept`,
+      { data: { name: "Ada Weaver", email, password: "supersecret123" } }
+    )
+    expect(acceptRes.status()).toBe(201)
+    const accept = await acceptRes.json()
+    expect(accept.token).toBeTruthy()
+    expect(accept.redirect).toBe(`/designs/${seed.inviteDesignId}/moodboard`)
+
+    // 4. The assigned designer generates the moodboard — no measurements needed.
+    const partner = await pwRequest.newContext({
+      baseURL,
+      extraHTTPHeaders: { authorization: `Bearer ${accept.token}` },
+    })
+    const genRes = await partner.post(
+      `/partners/designs/${seed.inviteDesignId}/moodboard/generate`,
+      { data: {} }
+    )
+    expect(genRes.status()).toBe(200)
+    const gen = await genRes.json()
+
+    const frameNames = gen.moodboard.elements
+      .filter((e: any) => e.type === "frame")
+      .map((f: any) => f.name)
+    expect(frameNames).toEqual(
+      expect.arrayContaining([
+        "Brief · Concept & Identity",
+        "Brief · Audience & Positioning",
+        "Brief · Timeline & Budget",
+      ])
+    )
+
+    const texts = gen.moodboard.elements
+      .filter((e: any) => e.type === "text")
+      .map((e: any) => e.text)
+      .join("\n")
+    expect(texts).toContain("90s Tokyo Streetwear")
+    expect(texts).toContain("INR 250,000")
+    expect(texts).toContain("Initial sketches")
+
+    await admin.dispose()
+    await pub.dispose()
+    await partner.dispose()
+  })
+})


### PR DESCRIPTION
## What

Headless, CI-run end-to-end coverage for the merged **#1113 S1+S2** flow (invites #1129 + brief-moodboard #1131). Drives the real HTTP endpoints against a live `medusa develop` server:

1. Seed a design carrying a **full brief** (concept + aesthetic anchor + persona + competitors + price point + milestones + design budget).
2. **Admin mints** a scoped designer invite for it.
3. **Public accept-info** renders the brief read-only (token-as-auth).
4. A **stranger accepts** → becomes an assigned `designer` partner with a session bearer (no portal login).
5. That partner **generates the moodboard** → asserts the three brief anchor frames (`Brief · Concept & Identity`, `· Audience & Positioning`, `· Timeline & Budget`) + brief text (`90s Tokyo Streetwear`, `INR 250,000`, `Initial sketches`).

Uses Playwright's API request context (no browser UI needed), so it's deterministic and fast, and runs on CI via the existing `e2e.yml` (`e2e/**` path trigger — no `@partnerui` tag, so it runs in the shared admin e2e).

## Local result

```
✓ mint invite → stranger accepts → assigned designer generates the brief moodboard
1 passed
```

Verify locally:
```
pnpm --dir apps/backend e2e:seed
pnpm --dir apps/backend exec playwright test --config=../../e2e/playwright.config.ts designer-invite-moodboard
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)